### PR TITLE
Drop darwin-x64 build, use Rosetta

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,20 +14,10 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            arch: arm64
-            target: bun-darwin-arm64
             asset: gloomberb-darwin-arm64
-          - os: macos-15
-            arch: x64
-            target: bun-darwin-x64
-            asset: gloomberb-darwin-x64
           - os: ubuntu-latest
-            arch: x64
-            target: bun-linux-x64
             asset: gloomberb-linux-x64
           - os: ubuntu-24.04-arm
-            arch: arm64
-            target: bun-linux-arm64
             asset: gloomberb-linux-arm64
     runs-on: ${{ matrix.os }}
     steps:

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,11 @@ case "$ARCH" in
     ;;
 esac
 
+# macOS x64 uses arm64 binary (runs via Rosetta 2)
+if [ "$os" = "darwin" ] && [ "$arch" = "x64" ]; then
+  arch="arm64"
+fi
+
 ASSET="gloomberb-${os}-${arch}"
 
 # Get latest release download URL

--- a/npm/install.mjs
+++ b/npm/install.mjs
@@ -14,11 +14,16 @@ const osMap = { darwin: "darwin", linux: "linux" };
 const archMap = { arm64: "arm64", x64: "x64" };
 
 const os = osMap[platform];
-const cpu = archMap[arch];
+let cpu = archMap[arch];
 
 if (!os || !cpu) {
   console.error(`Unsupported platform: ${platform}-${arch}`);
   process.exit(1);
+}
+
+// macOS x64 uses arm64 binary (runs via Rosetta 2)
+if (os === "darwin" && cpu === "x64") {
+  cpu = "arm64";
 }
 
 const asset = `gloomberb-${os}-${cpu}`;

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -19,7 +19,6 @@ writeFileSync(npmPkgPath, JSON.stringify(npmPkg, null, 2) + "\n");
 
 const targets = [
   { os: "darwin", arch: "arm64" },
-  { os: "darwin", arch: "x64" },
   { os: "linux", arch: "x64" },
   { os: "linux", arch: "arm64" },
 ];

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -28,7 +28,8 @@ function compareSemver(a: string, b: string): number {
 
 function getAssetName(): string {
   const os = process.platform === "darwin" ? "darwin" : "linux";
-  const arch = process.arch === "arm64" ? "arm64" : "x64";
+  // macOS x64 uses arm64 binary (runs via Rosetta 2)
+  const arch = os === "darwin" || process.arch === "arm64" ? "arm64" : "x64";
   return `gloomberb-${os}-${arch}`;
 }
 


### PR DESCRIPTION
No x64 macOS CI runners. ARM64 binary runs on Intel via Rosetta 2.