### PR TITLE
Reorder Overview tab to render Positions above Description

### DIFF
--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -191,32 +191,6 @@ export function OverviewTab({
           />
         </box>
 
-        {description && (
-          <box flexDirection="column" paddingTop={1}>
-            <box height={1}>
-              <text attributes={TextAttributes.BOLD} fg={colors.textBright}>Description</text>
-            </box>
-            <text fg={colors.text}>{description}</text>
-          </box>
-        )}
-
-        {(sector || industry || ticker.metadata.assetCategory || ticker.metadata.isin) && (
-          <box flexDirection="column">
-            {ticker.metadata.assetCategory && (
-              <FieldRow label="Type" value={ticker.metadata.assetCategory} />
-            )}
-            {sector && (
-              <FieldRow label="Sector" value={sector} />
-            )}
-            {industry && (
-              <FieldRow label="Industry" value={industry} />
-            )}
-            {ticker.metadata.isin && (
-              <FieldRow label="ISIN" value={ticker.metadata.isin} />
-            )}
-          </box>
-        )}
-
         {ticker.metadata.positions.length > 0 && (
           <box flexDirection="column">
             <box height={1}>
@@ -269,6 +243,32 @@ export function OverviewTab({
                 </box>
               );
             })}
+          </box>
+        )}
+
+        {description && (
+          <box flexDirection="column" paddingTop={1}>
+            <box height={1}>
+              <text attributes={TextAttributes.BOLD} fg={colors.textBright}>Description</text>
+            </box>
+            <text fg={colors.text}>{description}</text>
+          </box>
+        )}
+
+        {(sector || industry || ticker.metadata.assetCategory || ticker.metadata.isin) && (
+          <box flexDirection="column">
+            {ticker.metadata.assetCategory && (
+              <FieldRow label="Type" value={ticker.metadata.assetCategory} />
+            )}
+            {sector && (
+              <FieldRow label="Sector" value={sector} />
+            )}
+            {industry && (
+              <FieldRow label="Industry" value={industry} />
+            )}
+            {ticker.metadata.isin && (
+              <FieldRow label="ISIN" value={ticker.metadata.isin} />
+            )}
           </box>
         )}
       </box>


### PR DESCRIPTION
### Motivation
- Improve the ticker detail Overview layout by showing portfolio `Positions` before the textual `Description`, which makes position-related info more prominent in the overview. 
- Preserve all existing position calculation and metadata rendering logic while only changing visual order.

### Description
- Reordered the JSX in `src/plugins/builtin/ticker-detail/overview-tab.tsx` so the `Positions` block is rendered before the `Description` and metadata rows.
- No changes to the underlying position calculations, currency conversions, or displayed fields were made; only the render order was modified.
- Only the file `src/plugins/builtin/ticker-detail/overview-tab.tsx` was updated.