### PR TITLE
Shorten on-screen help text in chart components

### DIFF
--- a/src/components/chart/comparison-stock-chart.tsx
+++ b/src/components/chart/comparison-stock-chart.tsx
@@ -1721,7 +1721,7 @@ function ComparisonStockChartView({
 
       <box height={1}>
         <text fg={colors.textMuted}>
-          mouse hover inspect  drag pan  wheel zoom  ⇧wheel pan  h/l cursor  arrows legend  Enter open  1-7 presets  r res  m mode  0 reset
+          h/l cursor  arrows legend  Enter open  r res  m mode  0 reset
         </text>
       </box>
     </box>

--- a/src/components/chart/stock-chart.tsx
+++ b/src/components/chart/stock-chart.tsx
@@ -1919,8 +1919,8 @@ export const ResolvedStockChart = memo(function ResolvedStockChart({
       <box height={1}>
         <text fg={colors.textMuted}>
           {interactive
-            ? "mouse hover inspect  drag pan  wheel zoom  ⇧wheel pan  ←→ cursor  ⇧←→ pan  m mode  r res  1-7 presets  v vol  0 reset  Esc exit"
-            : "Enter crosshair  click chart to focus  a/d pan  +/- zoom  m mode  r res  1-7 presets  v volume  0 reset"}
+            ? "←→ cursor  ⇧←→ pan  m mode  r res  v vol  0 reset  Esc exit"
+            : "m mode  r res  v volume  0 reset"}
         </text>
       </box>
     </box>


### PR DESCRIPTION
### Motivation
- Reduce visual clutter in the chart UI by replacing verbose interaction hints with more concise help text so the footer lines remain compact and readable.

### Description
- Shorten the on-screen help strings in `src/components/chart/comparison-stock-chart.tsx` (`ComparisonStockChartView`) and `src/components/chart/stock-chart.tsx` (`ResolvedStockChart`) by removing several verbose instructions and trimming non-essential words to more compact phrases.

### Testing
- Ran project type-check and lint (`npm run build` / `npm run lint`) and executed the automated test suite (`npm test`), and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d745833dd88327999ade125f9c3bec)