### PR TITLE
Hide option contracts from command bar ticker quick look

### DIFF
--- a/src/components/command-bar/command-bar.tsx
+++ b/src/components/command-bar/command-bar.tsx
@@ -180,6 +180,7 @@ const COMMAND_BAR_OVERLAY_Z_INDEX = 2_147_483_646;
 const COMMAND_BAR_PANEL_Z_INDEX = 2_147_483_647;
 const NATIVE_COMMAND_BAR_PADDING_X_PX = 14;
 const NATIVE_COMMAND_BAR_PADDING_Y_PX = 14;
+const QUICK_LOOK_TICKER_SEARCH_OPTIONS = { includeOptionContracts: false } as const;
 
 function getDefaultConfigBackupPath(): string {
   const home = typeof process !== "undefined" ? process.env.HOME : undefined;
@@ -2379,20 +2380,24 @@ export function CommandBar({
     tickerSearchCacheRef.current.clear();
   }, [state.tickers]);
 
+  const createQuickLookLocalTickerCandidates = useCallback((tickers: Iterable<TickerRecord>) => (
+    createLocalTickerSearchCandidates(tickers, new Map(), QUICK_LOOK_TICKER_SEARCH_OPTIONS)
+  ), []);
+
   const localTickerSearchResultItems = useCallback((query?: string, options?: {
     category?: string;
     limit?: number;
   }): ResultItem[] => {
     const items = query
-      ? rankTickerSearchItems(createLocalTickerSearchCandidates(state.tickers.values()), query)
-      : createLocalTickerSearchCandidates(state.tickers.values());
+      ? rankTickerSearchItems(createQuickLookLocalTickerCandidates(state.tickers.values()), query)
+      : createQuickLookLocalTickerCandidates(state.tickers.values());
     return items
       .slice(0, options?.limit)
       .map((candidate) => ({
         ...mapTickerSearchCandidateToResultItem(candidate),
         category: options?.category ?? candidate.category,
       }));
-  }, [mapTickerSearchCandidateToResultItem, state.tickers]);
+  }, [createQuickLookLocalTickerCandidates, mapTickerSearchCandidateToResultItem, state.tickers]);
 
   const adaptTickerSearchRouteResult = useCallback((
     item: ResultItem,
@@ -2957,6 +2962,7 @@ export function CommandBar({
             brokerId: activePortfolio?.brokerId,
             brokerInstanceId: activePortfolio?.brokerInstanceId,
           },
+          ...QUICK_LOOK_TICKER_SEARCH_OPTIONS,
         });
         if (requestId !== searchRequestIdRef.current) return;
         writeTickerSearchCache(
@@ -3281,18 +3287,26 @@ export function CommandBar({
       const recentSymbols = state.recentTickers.slice(0, maxDefaultTickers);
       const recentTickers = recentSymbols
         .map((symbol) => state.tickers.get(symbol))
-        .filter((ticker): ticker is NonNullable<typeof ticker> => ticker != null);
+        .filter((ticker): ticker is NonNullable<typeof ticker> => (
+          ticker != null && createQuickLookLocalTickerCandidates([ticker]).length > 0
+        ));
       if (recentTickers.length < maxDefaultTickers) {
         const seen = new Set(recentSymbols);
         for (const ticker of state.tickers.values()) {
           if (recentTickers.length >= maxDefaultTickers) break;
+          if (createQuickLookLocalTickerCandidates([ticker]).length === 0) continue;
           if (!seen.has(ticker.metadata.ticker)) recentTickers.push(ticker);
         }
       }
-      items.push(...recentTickers.map((ticker) => ({
-        ...mapTickerSearchCandidateToResultItem(createLocalTickerSearchCandidates([ticker])[0]!),
-        category: "Tickers",
-      })));
+      items.push(...recentTickers.flatMap((ticker) => {
+        const candidate = createQuickLookLocalTickerCandidates([ticker])[0];
+        return candidate
+          ? [{
+            ...mapTickerSearchCandidateToResultItem(candidate),
+            category: "Tickers",
+          }]
+          : [];
+      }));
       items.push(...paneShortcutItems());
       for (const command of availableCommands) {
         const item = commandToItem(command);
@@ -3325,6 +3339,7 @@ export function CommandBar({
     buildLayoutItems,
     buildPluginItems,
     buildThemeItems,
+    createQuickLookLocalTickerCandidates,
     createPluginCommandItem,
     currentRoute,
     executeCollectionCommand,
@@ -3412,6 +3427,7 @@ export function CommandBar({
             brokerId: activeSearchPortfolio?.brokerId,
             brokerInstanceId: activeSearchPortfolio?.brokerInstanceId,
           },
+          ...QUICK_LOOK_TICKER_SEARCH_OPTIONS,
         });
         if (requestId !== rootSearchRequestIdRef.current) return;
         writeTickerSearchCache(

--- a/src/utils/ticker-search.ts
+++ b/src/utils/ticker-search.ts
@@ -3,12 +3,14 @@ import type { InstrumentSearchResult } from "../types/instrument";
 import type { TickerRecord } from "../types/ticker";
 import type { TickerMetadata } from "../types/ticker";
 import type { TickerRepository } from "../data/ticker-repository";
+import { parseOptionSymbol } from "./options";
 
 export type TickerSearchInstrumentClass = "equity" | "fund" | "derivative" | "other";
 export type TickerSearchCategory = "Saved" | "Primary Listing" | "Other Listings" | "Funds & Derivatives";
 
 const FUND_TYPES = new Set(["ETF", "ETN", "ETP", "FUND", "MUTUALFUND", "CEF", "CLOSEDEND"]);
 const DERIVATIVE_TYPES = new Set(["OPT", "OPTION", "OPTIONS", "FUT", "FUTURE", "FUTURES", "WARRANT", "WARRANTS", "RIGHT", "RIGHTS"]);
+const OPTION_TYPES = new Set(["OPT", "OPTION", "OPTIONS"]);
 const EQUITY_TYPES = new Set(["STK", "STOCK", "EQUITY", "COMMONSTOCK", "COMMON STOCK", "ADR", "ORDINARYSHARES", "ORDINARY SHARES"]);
 
 const EXCHANGE_HINT_ALIASES: Record<string, string[]> = {
@@ -90,6 +92,10 @@ interface SearchQueryIntent {
   assetPreference: TickerSearchInstrumentClass | null;
 }
 
+interface TickerSearchCandidateOptions {
+  includeOptionContracts?: boolean;
+}
+
 export function normalizeTickerInput(activeTicker: string | null, arg?: string): string | null {
   const explicitTicker = arg?.trim().toUpperCase();
   if (explicitTicker) return explicitTicker;
@@ -99,11 +105,13 @@ export function normalizeTickerInput(activeTicker: string | null, arg?: string):
 export function createLocalTickerSearchCandidates(
   tickers: Iterable<TickerRecord>,
   providerHints: ReadonlyMap<string, InstrumentSearchResult> = new Map(),
+  options: TickerSearchCandidateOptions = {},
 ): TickerSearchCandidate[] {
-  return Array.from(tickers).map((ticker) => {
+  return Array.from(tickers).flatMap((ticker) => {
+    if (options.includeOptionContracts === false && isOptionTickerRecord(ticker)) return [];
     const symbol = normalizeTickerSymbol(ticker.metadata.ticker);
     const hint = providerHints.get(symbol);
-    return {
+    return [{
       id: `goto:${ticker.metadata.ticker}`,
       label: ticker.metadata.ticker,
       symbol,
@@ -118,18 +126,20 @@ export function createLocalTickerSearchCandidates(
       searchAliases: buildSymbolAliases(symbol),
       ticker,
       result: hint,
-    };
+    }];
   });
 }
 
 export function createProviderTickerSearchCandidates(
   searchResults: InstrumentSearchResult[],
   localTickers: ReadonlyMap<string, TickerRecord>,
+  options: TickerSearchCandidateOptions = {},
 ): TickerSearchCandidate[] {
-  return searchResults.map((result) => {
+  return searchResults.flatMap((result) => {
+    if (options.includeOptionContracts === false && isOptionSearchResult(result)) return [];
     const symbol = getSearchResultSymbol(result);
     const saved = localTickers.has(symbol);
-    return {
+    return [{
       id: `search:${result.symbol}`,
       label: symbol,
       symbol,
@@ -143,7 +153,7 @@ export function createProviderTickerSearchCandidates(
       instrumentClass: classifyInstrumentKind(result.brokerContract?.secType || result.type),
       searchAliases: buildSearchResultAliases(result),
       result,
-    };
+    }];
   });
 }
 
@@ -154,6 +164,7 @@ export async function searchTickerCandidates({
   searchContext,
   localLimit = 6,
   totalLimit = 8,
+  includeOptionContracts = true,
 }: {
   query: string;
   tickers: ReadonlyMap<string, TickerRecord>;
@@ -161,6 +172,7 @@ export async function searchTickerCandidates({
   searchContext?: SearchRequestContext;
   localLimit?: number;
   totalLimit?: number;
+  includeOptionContracts?: boolean;
 }): Promise<TickerSearchCandidate[]> {
   return buildTickerSearchCandidates({
     query,
@@ -168,6 +180,7 @@ export async function searchTickerCandidates({
     providerResults: await searchProviderResults(dataProvider, query, searchContext),
     localLimit,
     totalLimit,
+    includeOptionContracts,
   });
 }
 
@@ -177,19 +190,25 @@ export function buildTickerSearchCandidates({
   providerResults,
   localLimit = 6,
   totalLimit = 8,
+  includeOptionContracts = true,
 }: {
   query: string;
   tickers: ReadonlyMap<string, TickerRecord>;
   providerResults: InstrumentSearchResult[];
   localLimit?: number;
   totalLimit?: number;
+  includeOptionContracts?: boolean;
 }): TickerSearchCandidate[] {
-  const providerHints = buildProviderHintMap(providerResults);
+  const candidateOptions = { includeOptionContracts };
+  const filteredProviderResults = includeOptionContracts
+    ? providerResults
+    : providerResults.filter((result) => !isOptionSearchResult(result));
+  const providerHints = buildProviderHintMap(filteredProviderResults);
   const localItems = rankTickerSearchItems(
-    createLocalTickerSearchCandidates(tickers.values(), providerHints),
+    createLocalTickerSearchCandidates(tickers.values(), providerHints, candidateOptions),
     query,
   );
-  const providerItems = createProviderTickerSearchCandidates(providerResults, tickers);
+  const providerItems = createProviderTickerSearchCandidates(filteredProviderResults, tickers, candidateOptions);
   const ranked = rankTickerSearchItems([...localItems, ...providerItems], query);
   return limitTickerSearchCandidates(assignTickerSearchCategories(ranked), totalLimit, localLimit);
 }
@@ -549,6 +568,31 @@ function shouldReplaceAssetCategory(currentCategory: string | undefined, nextCat
   const currentClass = classifyInstrumentKind(currentCategory);
   const nextClass = classifyInstrumentKind(nextCategory);
   return currentClass === "equity" && nextClass !== "equity";
+}
+
+function isOptionTickerRecord(ticker: TickerRecord): boolean {
+  return isOptionType(ticker.metadata.assetCategory)
+    || parseOptionSymbol(ticker.metadata.ticker) != null
+    || (ticker.metadata.broker_contracts ?? []).some(isOptionBrokerContract);
+}
+
+function isOptionSearchResult(result: InstrumentSearchResult): boolean {
+  return isOptionType(result.type)
+    || parseOptionSymbol(result.symbol) != null
+    || isOptionBrokerContract(result.brokerContract);
+}
+
+function isOptionBrokerContract(contract: InstrumentSearchResult["brokerContract"]): boolean {
+  if (!contract) return false;
+  return isOptionType(contract.secType)
+    || parseOptionSymbol(contract.localSymbol || "") != null
+    || contract.right === "C"
+    || contract.right === "P"
+    || contract.strike != null;
+}
+
+function isOptionType(rawType?: string): boolean {
+  return OPTION_TYPES.has(normalizeSearchText(rawType || ""));
 }
 
 function analyzeSearchQuery(query: string): SearchQueryIntent {


### PR DESCRIPTION
Follow-up on the hiring dataset after the first review of real data.

## What was wrong

- **Unclassified everywhere.** Classification capped at 2,000 rows per company per pass, so AMZN sat at 20.6k of 22.6k unclassified and JPM at 5.4k of 7.4k even though the titles are plain. The classifier now works the whole backlog: rules are unbounded, the model rung is budgeted (1,500 postings per company per pass, top 20 backlogs first) and anything it cannot place stays unclassified for the next pass instead of being dumped in "other".
- **"Roles posted per week" was survivorship.** It counted still-open roles by posting date, so a year ago always looked quiet. Gone, along with `postingVelocity`, which had the same flaw. In their place: open roles by posting age (7 days, 8 to 30, 1 to 3 months, 3 to 6, over 6, plus an undated bucket), which is the one thing a first read can say honestly about time. The open-roles history chart takes over after seven daily reads.
- **Countries had no trend.** Country rows now carry the count from 30 days ago (from `job_daily.by_country`), so a location spike shows as a delta in the Locations tab and in `company.hiring`.
- **amazon.jobs and a few HTML boards use alpha-3 codes** (`Bengaluru, Karnataka, IND`), which we did not read; 7.4k Amazon roles had no country. Alpha-3 is mapped now, explicit or trailing the location, and the country-name list is longer.
- Seniority rules matched `partner` inside "HR Business Partner" and "Associate Partner" as executive; now only `managing partner`, `general partner`, `equity partner`. "Vendor Manager" is supply chain.

## Movers

`market.hiring_movers` and `/cloud/jobs` drop `postingVelocity` and gain `posted30d` and `topCountry` (code and share of located roles, only once at least half the board has a known country, so a sitemap board waiting on its detail pass says nothing rather than "US 2.5%").

## Pipeline

- Main pass: discovery, collection, classification. Details run in their own loop (1s between ticks while there is a backlog, 60s idle) at 400 pages per source, so big Workday and sitemap boards fill in within hours instead of days.
- `runClassifyPass` rolls up the day after classifying so `job_daily.by_function` reflects the new labels.

## Site

One function now: `JOBS` alone is the coverage table, `JOBS NVDA` the company. HIRE removed from the functions list, homepage copy, shots and docs. `hiring-data.md` measures table updated.

## Screenshots

Coverage table (`JOBS`):

![jobs home](https://github.com/vincelwt/gloomberb-platform/blob/feat/jobs-accuracy/docs/screenshots/jobs/jobs-home.png?raw=true)

`JOBS AMZN` before the new classify pass runs in prod (the unclassified bar is what this PR fixes):

![jobs amzn](https://github.com/vincelwt/gloomberb-platform/blob/feat/jobs-accuracy/docs/screenshots/jobs/jobs-amzn.png?raw=true)

Narrow pane:

![jobs jpm narrow](https://github.com/vincelwt/gloomberb-platform/blob/feat/jobs-accuracy/docs/screenshots/jobs/jobs-jpm-narrow.png?raw=true)

## After merge

- Backfill `country` on open rows with a location but no country (alpha-3 boards).
- Watch the first classify pass on prod: AMZN and JPM should drop under 10% unclassified after one pass with the model rung.

Terminal side: gloom-sh/gloomberb PR (JOBS pane v2).

## CALLS absorbs ECT

Functions list and data-coverage table: `ECT` folded into `CALLS [ticker]`, matching the terminal.

## ERN absorbs EM, BI absorbs SP

Functions list and docs (`macro-market-commands.md`, `workflows.md`) drop `EM` and `SP` in favor of `ERN [tickers]` and `BI`, matching the terminal.
