### PR TITLE
Add automatic cloud sync and profile analytics preview

### DIFF
--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -10,6 +10,7 @@ const config: ElectrobunConfig = {
     identifier: "com.vincelwt.gloomberb",
     version: pkg.version,
     description: pkg.description,
+    urlSchemes: ["gloomberb"],
   },
   build: {
     bun: {

--- a/src/api-client/auth.ts
+++ b/src/api-client/auth.ts
@@ -175,4 +175,13 @@ export class CloudAuthApi {
       }),
     });
   }
+
+  async deleteAccount(): Promise<void> {
+    await this.options.request("/account", {
+      method: "DELETE",
+      body: JSON.stringify({}),
+    });
+    this.options.setSessionToken(null);
+    this.options.setCurrentUser(null);
+  }
 }

--- a/src/api-client/auth.ts
+++ b/src/api-client/auth.ts
@@ -38,6 +38,11 @@ export class CloudAuthApi {
       username: typeof user.username === "string" ? user.username : null,
       emailVerified: user.emailVerified === true,
       image: typeof user.image === "string" ? user.image : null,
+      syncEnabled: user.syncEnabled === false ? false : true,
+      weeklyRoundupEnabled: user.weeklyRoundupEnabled === false ? false : true,
+      positionAlertsEnabled: user.positionAlertsEnabled === false ? false : true,
+      lastSyncAt: typeof user.lastSyncAt === "string" ? user.lastSyncAt : null,
+      lastRoundupEmailAt: typeof user.lastRoundupEmailAt === "string" ? user.lastRoundupEmailAt : null,
       createdAt: typeof user.createdAt === "string" ? user.createdAt : "",
       updatedAt: typeof user.updatedAt === "string" ? user.updatedAt : "",
     });
@@ -148,6 +153,12 @@ export class CloudAuthApi {
         xAccount: profile.xAccount,
         sharedPortfolioId: profile.sharedPortfolioId,
         acceptUnknownDms: profile.acceptUnknownDms,
+        portfolioAnalytics: profile.portfolioAnalytics,
+        syncEnabled: profile.syncEnabled,
+        weeklyRoundupEnabled: profile.weeklyRoundupEnabled,
+        positionAlertsEnabled: profile.positionAlertsEnabled,
+        lastSyncAt: profile.lastSyncAt,
+        lastRoundupEmailAt: profile.lastRoundupEmailAt,
         updatedAt: profile.updatedAt ?? currentUser.updatedAt,
       }));
     }

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -46,8 +46,12 @@ import type {
   CloudMarketBatchTarget,
   CloudMarketBatchPayload,
   CloudVerificationResponse,
+  CloudRoundupPreviewResponse,
+  CloudSyncPushResponse,
+  CloudSyncSnapshotResponse,
   QuoteStreamTarget,
 } from "./types";
+import type { SyncSettings, SyncSnapshot } from "../sync/types";
 
 export type * from "./types";
 export { setCloudApiFetchTransport } from "./request";
@@ -196,6 +200,46 @@ class GloomApiClient {
 
   async updateAccountProfile(update: AccountProfileUpdate): Promise<AccountProfile> {
     return this.auth.updateAccountProfile(update);
+  }
+
+  async getSyncSnapshot(): Promise<CloudSyncSnapshotResponse> {
+    return this.request<CloudSyncSnapshotResponse>("/sync/snapshot", { method: "GET" });
+  }
+
+  async putSyncSnapshot(snapshot: SyncSnapshot, options?: { baseRevision?: number | null }): Promise<CloudSyncPushResponse> {
+    return this.request<CloudSyncPushResponse>("/sync/snapshot", {
+      method: "PUT",
+      body: JSON.stringify({
+        snapshot,
+        baseRevision: options?.baseRevision ?? null,
+      }),
+    });
+  }
+
+  async updateSyncSettings(update: Partial<SyncSettings>): Promise<SyncSettings> {
+    const result = await this.request<{ settings: SyncSettings }>("/sync/settings", {
+      method: "PATCH",
+      body: JSON.stringify(update),
+    });
+    if (this.currentUser) {
+      this.currentUser = {
+        ...this.currentUser,
+        syncEnabled: result.settings.syncEnabled,
+        weeklyRoundupEnabled: result.settings.weeklyRoundupEnabled,
+        positionAlertsEnabled: result.settings.positionAlertsEnabled,
+        lastSyncAt: result.settings.lastSyncAt ?? this.currentUser.lastSyncAt,
+        lastRoundupEmailAt: result.settings.lastRoundupEmailAt ?? this.currentUser.lastRoundupEmailAt,
+      };
+    }
+    return result.settings;
+  }
+
+  async getRoundupPreview(): Promise<CloudRoundupPreviewResponse> {
+    return this.request<CloudRoundupPreviewResponse>("/sync/roundup/preview", { method: "POST", body: JSON.stringify({}) });
+  }
+
+  async sendRoundupTestEmail(): Promise<CloudRoundupPreviewResponse> {
+    return this.request<CloudRoundupPreviewResponse>("/sync/roundup/test-email", { method: "POST", body: JSON.stringify({}) });
   }
 
   async changePassword(currentPassword: string, newPassword: string): Promise<void> {

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -246,6 +246,10 @@ class GloomApiClient {
     return this.auth.changePassword(currentPassword, newPassword);
   }
 
+  async deleteAccount(): Promise<void> {
+    return this.auth.deleteAccount();
+  }
+
   async getChannels(): Promise<ChatChannel[]> {
     return this.chat.getChannels();
   }

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -10,6 +10,7 @@ import type {
   Quote,
   TickerFinancials,
 } from "../types/financials";
+import type { SyncSettings, SyncSnapshot } from "../sync/types";
 
 export interface ChatUserSummary {
   id: string;
@@ -20,6 +21,7 @@ export interface ChatUserSummary {
   title?: string | null;
   profilePublic?: boolean;
   acceptUnknownDms?: boolean;
+  portfolioAnalytics?: PublicPortfolioAnalytics | null;
 }
 
 export interface ChatMessage {
@@ -83,6 +85,12 @@ export interface AuthUser {
   xAccount?: string | null;
   sharedPortfolioId?: string | null;
   acceptUnknownDms?: boolean;
+  portfolioAnalytics?: PublicPortfolioAnalytics | null;
+  syncEnabled?: boolean;
+  weeklyRoundupEnabled?: boolean;
+  positionAlertsEnabled?: boolean;
+  lastSyncAt?: string | null;
+  lastRoundupEmailAt?: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -104,7 +112,24 @@ export interface AccountProfile {
   xAccount: string | null;
   sharedPortfolioId: string | null;
   acceptUnknownDms: boolean;
+  portfolioAnalytics?: PublicPortfolioAnalytics | null;
+  syncEnabled: boolean;
+  weeklyRoundupEnabled: boolean;
+  positionAlertsEnabled: boolean;
+  lastSyncAt: string | null;
+  lastRoundupEmailAt: string | null;
   updatedAt: string | null;
+}
+
+export interface PublicPortfolioAnalytics {
+  portfolioName?: string | null;
+  holdingsCount?: number | null;
+  oneYearReturn?: number | null;
+  spyBeta?: number | null;
+  marketValue?: number | null;
+  currency?: string | null;
+  sourceLabel?: string | null;
+  asOf?: string | null;
 }
 
 export interface BuildoutAccountResponse {
@@ -151,7 +176,33 @@ export type AccountProfileUpdate = Partial<{
   xAccount: string | null;
   sharedPortfolioId: string | null;
   acceptUnknownDms: boolean;
+  portfolioAnalytics: PublicPortfolioAnalytics | null;
+  syncEnabled: boolean;
+  weeklyRoundupEnabled: boolean;
+  positionAlertsEnabled: boolean;
 }>;
+
+export interface CloudSyncSnapshotResponse {
+  snapshot: SyncSnapshot | null;
+  revision: number | null;
+  updatedAt: string | null;
+  settings: SyncSettings;
+}
+
+export interface CloudSyncPushResponse {
+  revision: number;
+  updatedAt: string;
+  settings: SyncSettings;
+}
+
+export interface CloudRoundupPreviewResponse {
+  subject: string;
+  text: string;
+  html: string;
+  sender: string;
+  replyTo: string;
+  recipient: string;
+}
 
 export interface CloudQuotePayload extends Quote {
   providerId: "gloomberb-cloud";

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -122,14 +122,8 @@ export interface AccountProfile {
 }
 
 export interface PublicPortfolioAnalytics {
-  portfolioName?: string | null;
-  holdingsCount?: number | null;
   oneYearReturn?: number | null;
   spyBeta?: number | null;
-  marketValue?: number | null;
-  currency?: string | null;
-  sourceLabel?: string | null;
-  asOf?: string | null;
 }
 
 export interface BuildoutAccountResponse {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -232,7 +232,9 @@ function AppInner({
   useDesktopDeepLinkRuntime({
     desktopDeepLinkBridge,
     desktopWindowKind: desktopWindowBridge?.kind,
+    dispatch,
     pluginRegistry,
+    stateRef,
   });
 
   const focusedTickerSymbol = getFocusedTickerSymbol(state);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -22,6 +22,7 @@ import { PluginRegistry } from "./plugins/registry";
 import type { TickerRepository } from "./data/ticker-repository";
 import { ThemeProvider, useThemeColors } from "./theme/theme-context";
 import type { AppConfig } from "./types/config";
+import type { DesktopDeepLinkBridge } from "./types/desktop-deeplink";
 import type { CliLaunchRequest } from "./types/plugin";
 import type { DataProvider } from "./types/data-provider";
 import type { DesktopDockPreviewState, DesktopSharedStateSnapshot, DesktopThemePreviewState, DesktopWindowBridge } from "./types/desktop-window";
@@ -32,6 +33,7 @@ import type { MarketDataCoordinator } from "./market-data/coordinator";
 import { createAppNotifier } from "./notifications/app-notifier";
 import { createAppServices } from "./core/app-services";
 import { useBrokerImportRuntime } from "./app/runtime/broker-import";
+import { useDesktopDeepLinkRuntime } from "./app/runtime/desktop-deeplink";
 import { useDesktopApplicationMenuRuntime } from "./app/runtime/desktop-menu";
 import { useAppGlobalShortcuts } from "./app/global-shortcuts";
 import { useAppPaneRuntime } from "./app/pane-runtime";
@@ -59,6 +61,7 @@ interface AppInnerProps {
   sessionSnapshot?: AppSessionSnapshot | null;
   desktopWindowBridge?: DesktopWindowBridge;
   desktopApplicationMenuBridge?: DesktopApplicationMenuBridge;
+  desktopDeepLinkBridge?: DesktopDeepLinkBridge;
   remoteControlAdapter?: RemoteControlAdapter;
 }
 
@@ -88,6 +91,7 @@ function AppInner({
   sessionSnapshot = null,
   desktopWindowBridge,
   desktopApplicationMenuBridge,
+  desktopDeepLinkBridge,
   remoteControlAdapter,
 }: AppInnerProps) {
   const dispatch = useAppDispatch();
@@ -223,6 +227,12 @@ function AppInner({
     rendererHost,
     runUpdateCheck,
     stateRef,
+  });
+
+  useDesktopDeepLinkRuntime({
+    desktopDeepLinkBridge,
+    desktopWindowKind: desktopWindowBridge?.kind,
+    pluginRegistry,
   });
 
   const focusedTickerSymbol = getFocusedTickerSymbol(state);
@@ -372,6 +382,7 @@ interface AppProps {
   cliLaunchRequest?: CliLaunchRequest | null;
   desktopWindowBridge?: DesktopWindowBridge;
   desktopApplicationMenuBridge?: DesktopApplicationMenuBridge;
+  desktopDeepLinkBridge?: DesktopDeepLinkBridge;
   desktopSnapshot?: DesktopSharedStateSnapshot | null;
   desktopThemePreview?: DesktopThemePreviewState | null;
   remoteControlAdapter?: RemoteControlAdapter;
@@ -383,6 +394,7 @@ export function App({
   cliLaunchRequest = null,
   desktopWindowBridge,
   desktopApplicationMenuBridge,
+  desktopDeepLinkBridge,
   desktopSnapshot = null,
   desktopThemePreview = null,
   remoteControlAdapter,
@@ -470,6 +482,7 @@ export function App({
           sessionSnapshot={sessionSnapshot}
           desktopWindowBridge={desktopWindowBridge}
           desktopApplicationMenuBridge={desktopApplicationMenuBridge}
+          desktopDeepLinkBridge={desktopDeepLinkBridge}
           remoteControlAdapter={remoteControlAdapter}
         />
       </AppProvider>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -39,6 +39,8 @@ import { bindPluginRegistryRuntimeAccess } from "./app/runtime/plugin-bindings";
 import { useAppStartupRuntime } from "./app/runtime/startup";
 import { useTickerRefreshRuntime } from "./app/runtime/ticker-refresh";
 import { useAppUpdateRuntime } from "./app/runtime/update";
+import { createCoreSyncContributors } from "./sync/core-contributors";
+import { useCloudSyncRuntime } from "./sync/react";
 import { RemoteControlHost, type RemoteControlAdapter } from "./remote/app-host";
 import { RemoteUiRegistryProvider } from "./remote/semantic-tree";
 import {
@@ -173,6 +175,15 @@ function AppInner({
     });
   }, [desktopWindowBridge]);
 
+  useEffect(() => {
+    const disposers = createCoreSyncContributors().map((contributor) => (
+      pluginRegistry.registerSyncContributorForPlugin("core", contributor)
+    ));
+    return () => {
+      for (const dispose of disposers) dispose();
+    };
+  }, [pluginRegistry]);
+
   const {
     primeCachedFinancials,
     refreshQuote,
@@ -241,6 +252,14 @@ function AppInner({
     pluginRegistry,
     state,
     tickerRepository,
+  });
+
+  useCloudSyncRuntime({
+    state,
+    dispatch,
+    tickerRepository,
+    pluginRegistry,
+    initialized: state.initialized && desktopWindowBridge?.kind !== "detached",
   });
 
   useAppPaneRuntime({

--- a/src/app/runtime/desktop-deeplink.test.ts
+++ b/src/app/runtime/desktop-deeplink.test.ts
@@ -18,9 +18,70 @@ describe("desktop deeplinks", () => {
     });
   });
 
-  test("rejects non-cloud and malformed links", () => {
+  test("routes ticker links with arbitrary registered tab ids", () => {
+    expect(resolveDesktopDeepLinkAction("gloomberb://ticker/NVDA?tab=analyst-research")).toEqual({
+      type: "open-ticker",
+      symbol: "NVDA",
+      tabId: "analyst-research",
+      message: "Opened NVDA analyst-research tab.",
+    });
+  });
+
+  test("routes portfolio and watchlist links", () => {
+    expect(resolveDesktopDeepLinkAction("gloomberb://portfolio/main")).toEqual({
+      type: "open-collection",
+      kind: "portfolio",
+      collectionId: "main",
+      message: "Opened portfolio main.",
+    });
+    expect(resolveDesktopDeepLinkAction("gloomberb://watchlist/favorites")).toEqual({
+      type: "open-collection",
+      kind: "watchlist",
+      collectionId: "favorites",
+      message: "Opened watchlist favorites.",
+    });
+  });
+
+  test("routes alert links with structured values", () => {
+    expect(resolveDesktopDeepLinkAction("gloomberb://alert/new?symbol=nvda&side=above&price=$200")).toEqual({
+      type: "create-alert",
+      values: { symbol: "NVDA", condition: "above", price: "200" },
+      message: "Created NVDA above 200 alert.",
+    });
+  });
+
+  test("routes chat links", () => {
+    expect(resolveDesktopDeepLinkAction("gloomberb://chat/channel/everyone")).toEqual({
+      type: "open-chat-channel",
+      channelId: "everyone",
+      message: "Opened chat everyone.",
+    });
+    expect(resolveDesktopDeepLinkAction("gloomberb://chat/dm?users=@vince,@alex")).toEqual({
+      type: "open-chat-dm",
+      participants: "@vince,@alex",
+      message: "Opened DM.",
+    });
+  });
+
+  test("routes news links", () => {
+    expect(resolveDesktopDeepLinkAction("gloomberb://news?ticker=7203.T")).toEqual({
+      type: "open-news",
+      kind: "ticker",
+      symbol: "7203.T",
+      message: "Opened 7203.T news.",
+    });
+    expect(resolveDesktopDeepLinkAction("gloomberb://news/breaking")).toEqual({
+      type: "open-news",
+      kind: "breaking",
+      symbol: null,
+      message: "Opened breaking news.",
+    });
+  });
+
+  test("rejects command-bar, non-gloomberb, and malformed links", () => {
+    expect(resolveDesktopDeepLinkAction("gloomberb://command?query=profile").type).toBe("unsupported");
+    expect(resolveDesktopDeepLinkAction("gloomberb://search/NVDA").type).toBe("unsupported");
     expect(resolveDesktopDeepLinkAction("https://gloom.sh/cloud").type).toBe("unsupported");
-    expect(resolveDesktopDeepLinkAction("gloomberb://ticker/NVDA").type).toBe("unsupported");
     expect(resolveDesktopDeepLinkAction("not a url").type).toBe("unsupported");
   });
 });

--- a/src/app/runtime/desktop-deeplink.test.ts
+++ b/src/app/runtime/desktop-deeplink.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { resolveDesktopDeepLinkAction } from "./desktop-deeplink";
+
+describe("desktop deeplinks", () => {
+  test("routes cloud roundup links to account management", () => {
+    expect(resolveDesktopDeepLinkAction("gloomberb://cloud/roundup?week=2026-07-03")).toEqual({
+      type: "open-account-management",
+      route: { kind: "cloud-roundup", week: "2026-07-03" },
+      message: "Opened weekly roundup settings for 2026-07-03.",
+    });
+  });
+
+  test("routes cloud alert links to account management", () => {
+    expect(resolveDesktopDeepLinkAction("gloomberb://cloud/alerts")).toEqual({
+      type: "open-account-management",
+      route: { kind: "cloud-alerts", week: null },
+      message: "Opened portfolio alert settings.",
+    });
+  });
+
+  test("rejects non-cloud and malformed links", () => {
+    expect(resolveDesktopDeepLinkAction("https://gloom.sh/cloud").type).toBe("unsupported");
+    expect(resolveDesktopDeepLinkAction("gloomberb://ticker/NVDA").type).toBe("unsupported");
+    expect(resolveDesktopDeepLinkAction("not a url").type).toBe("unsupported");
+  });
+});

--- a/src/app/runtime/desktop-deeplink.ts
+++ b/src/app/runtime/desktop-deeplink.ts
@@ -1,5 +1,12 @@
-import { useEffect } from "react";
+import { useEffect, type Dispatch } from "react";
+import { getDockedPaneIds } from "../../plugins/pane-manager";
 import type { PluginRegistry } from "../../plugins/registry";
+import type { AppAction, AppState } from "../../state/app/context";
+import {
+  findPaneInstance,
+  resolveFollowBindingInstance,
+  TICKER_RESEARCH_PANE_ID,
+} from "../../types/config";
 import type { DesktopDeepLinkBridge } from "../../types/desktop-deeplink";
 import type { DesktopWindowBridge } from "../../types/desktop-window";
 
@@ -8,28 +15,128 @@ type CloudDeepLinkRoute = {
   week: string | null;
 };
 
+type CollectionDeepLinkKind = "collection" | "portfolio" | "watchlist";
+type AlertDeepLinkCondition = "above" | "below" | "crosses";
+type NewsDeepLinkKind = "breaking" | "feed" | "ticker" | "top";
+
 export type DesktopDeepLinkAction =
   | { type: "open-account-management"; route: CloudDeepLinkRoute; message: string }
+  | { type: "open-ticker"; symbol: string; tabId: string | null; message: string }
+  | { type: "open-collection"; kind: CollectionDeepLinkKind; collectionId: string; message: string }
+  | {
+      type: "create-alert";
+      values: { symbol: string; condition: AlertDeepLinkCondition; price: string };
+      message: string;
+    }
+  | { type: "open-chat-channel"; channelId: string; message: string }
+  | { type: "open-chat-dm"; participants: string; message: string }
+  | { type: "open-news"; kind: NewsDeepLinkKind; symbol: string | null; message: string }
   | { type: "unsupported"; message: string };
+
+interface ParsedGloomUrl {
+  url: URL;
+  host: string;
+  segments: string[];
+}
+
+interface DesktopDeepLinkHandlerOptions {
+  dispatch: Dispatch<AppAction>;
+  pluginRegistry: PluginRegistry;
+  stateRef: { current: AppState };
+}
 
 function weekSuffix(week: string | null): string {
   return week ? ` for ${week}` : "";
 }
 
-export function resolveDesktopDeepLinkAction(rawUrl: string): DesktopDeepLinkAction {
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function splitPathSegments(pathname: string): string[] {
+  return pathname
+    .split("/")
+    .map((segment) => safeDecode(segment).trim())
+    .filter(Boolean);
+}
+
+function parseGloomUrl(rawUrl: string): ParsedGloomUrl | null {
   let url: URL;
   try {
     url = new URL(rawUrl);
   } catch {
-    return { type: "unsupported", message: "Unsupported Gloomberb link." };
+    return null;
+  }
+  if (url.protocol !== "gloomberb:") return null;
+
+  const host = url.hostname.trim().toLowerCase();
+  if (host) {
+    return { url, host, segments: splitPathSegments(url.pathname) };
   }
 
-  if (url.protocol !== "gloomberb:" || url.hostname !== "cloud") {
-    return { type: "unsupported", message: "Unsupported Gloomberb link." };
-  }
+  const segments = splitPathSegments(url.pathname);
+  const opaqueHost = segments.shift()?.toLowerCase();
+  return opaqueHost ? { url, host: opaqueHost, segments } : null;
+}
 
-  const route = url.pathname.replace(/^\/+/, "");
-  const week = url.searchParams.get("week");
+function param(url: URL, ...names: string[]): string | null {
+  for (const name of names) {
+    const value = url.searchParams.get(name)?.trim();
+    if (value) return value;
+  }
+  return null;
+}
+
+function normalizeSymbol(value: string | null | undefined): string | null {
+  const trimmed = value?.trim().replace(/^\$/, "");
+  if (!trimmed) return null;
+  return trimmed.toUpperCase();
+}
+
+function normalizeAlertCondition(value: string | null): AlertDeepLinkCondition | null {
+  switch (value?.trim().toLowerCase()) {
+    case ">":
+    case "above":
+    case "over":
+    case "gt":
+      return "above";
+    case "<":
+    case "below":
+    case "under":
+    case "lt":
+      return "below";
+    case "x":
+    case "cross":
+    case "crosses":
+      return "crosses";
+    default:
+      return null;
+  }
+}
+
+function normalizePrice(value: string | null): string | null {
+  const trimmed = value?.trim().replace(/^\$/, "");
+  if (!trimmed) return null;
+  const price = Number.parseFloat(trimmed);
+  return Number.isFinite(price) && price > 0 ? String(price) : null;
+}
+
+function tickerMessage(symbol: string, tabId: string | null): string {
+  return tabId ? `Opened ${symbol} ${tabId} tab.` : `Opened ${symbol}.`;
+}
+
+function collectionMessage(kind: CollectionDeepLinkKind, collectionId: string): string {
+  const label = kind === "watchlist" ? "watchlist" : kind === "portfolio" ? "portfolio" : "collection";
+  return `Opened ${label} ${collectionId}.`;
+}
+
+function parseCloudDeepLink(parsed: ParsedGloomUrl): DesktopDeepLinkAction {
+  const route = parsed.segments[0] ?? "";
+  const week = parsed.url.searchParams.get("week");
   if (route === "roundup") {
     return {
       type: "open-account-management",
@@ -44,37 +151,346 @@ export function resolveDesktopDeepLinkAction(rawUrl: string): DesktopDeepLinkAct
       message: `Opened portfolio alert settings${weekSuffix(week)}.`,
     };
   }
-
   return { type: "unsupported", message: "Unsupported Gloomberb cloud link." };
 }
 
-export function handleDesktopDeepLink(rawUrl: string, pluginRegistry: PluginRegistry): void {
+function parseTickerDeepLink(parsed: ParsedGloomUrl): DesktopDeepLinkAction {
+  const symbol = normalizeSymbol(parsed.segments[0] ?? param(parsed.url, "symbol", "ticker"));
+  if (!symbol) return { type: "unsupported", message: "Ticker links need a symbol." };
+  const tabId = param(parsed.url, "tab");
+  return { type: "open-ticker", symbol, tabId, message: tickerMessage(symbol, tabId) };
+}
+
+function parseCollectionDeepLink(parsed: ParsedGloomUrl, kind: CollectionDeepLinkKind): DesktopDeepLinkAction {
+  const collectionId = parsed.segments[0] ?? param(parsed.url, "id", "collection");
+  if (!collectionId) return { type: "unsupported", message: "Collection links need an id." };
+  return {
+    type: "open-collection",
+    kind,
+    collectionId,
+    message: collectionMessage(kind, collectionId),
+  };
+}
+
+function parseAlertDeepLink(parsed: ParsedGloomUrl): DesktopDeepLinkAction {
+  if ((parsed.segments[0] ?? "new") !== "new") {
+    return { type: "unsupported", message: "Unsupported Gloomberb alert link." };
+  }
+  const symbol = normalizeSymbol(param(parsed.url, "symbol", "ticker"));
+  const condition = normalizeAlertCondition(param(parsed.url, "condition", "side", "trigger"));
+  const price = normalizePrice(param(parsed.url, "price", "target"));
+  if (!symbol || !condition || !price) {
+    return { type: "unsupported", message: "Alert links need symbol, condition, and price." };
+  }
+  return {
+    type: "create-alert",
+    values: { symbol, condition, price },
+    message: `Created ${symbol} ${condition} ${price} alert.`,
+  };
+}
+
+function parseChatDeepLink(parsed: ParsedGloomUrl): DesktopDeepLinkAction {
+  const route = parsed.segments[0] ?? "default";
+  if (route === "channel") {
+    const channelId = parsed.segments[1] ?? param(parsed.url, "id", "channel");
+    if (!channelId) return { type: "unsupported", message: "Chat channel links need a channel id." };
+    return { type: "open-chat-channel", channelId, message: `Opened chat ${channelId}.` };
+  }
+  if (route === "dm") {
+    const participants = param(parsed.url, "users", "participants", "user") ?? parsed.segments.slice(1).join(",");
+    if (!participants.trim()) return { type: "unsupported", message: "DM links need at least one username." };
+    return { type: "open-chat-dm", participants, message: "Opened DM." };
+  }
+  if (route === "default") {
+    return { type: "open-chat-channel", channelId: "", message: "Opened chat." };
+  }
+  return { type: "open-chat-channel", channelId: route, message: `Opened chat ${route}.` };
+}
+
+function parseNewsDeepLink(parsed: ParsedGloomUrl): DesktopDeepLinkAction {
+  const ticker = normalizeSymbol(param(parsed.url, "ticker", "symbol") ?? (parsed.segments[0] === "ticker" ? parsed.segments[1] : null));
+  if (ticker) return { type: "open-news", kind: "ticker", symbol: ticker, message: `Opened ${ticker} news.` };
+
+  const route = parsed.segments[0] ?? "top";
+  if (route === "breaking") {
+    return { type: "open-news", kind: "breaking", symbol: null, message: "Opened breaking news." };
+  }
+  if (route === "feed") {
+    return { type: "open-news", kind: "feed", symbol: null, message: "Opened news feed." };
+  }
+  if (route === "top") {
+    return { type: "open-news", kind: "top", symbol: null, message: "Opened top news." };
+  }
+  return { type: "unsupported", message: "Unsupported Gloomberb news link." };
+}
+
+export function resolveDesktopDeepLinkAction(rawUrl: string): DesktopDeepLinkAction {
+  const parsed = parseGloomUrl(rawUrl);
+  if (!parsed) return { type: "unsupported", message: "Unsupported Gloomberb link." };
+
+  switch (parsed.host) {
+    case "cloud":
+      return parseCloudDeepLink(parsed);
+    case "ticker":
+      return parseTickerDeepLink(parsed);
+    case "portfolio":
+      return parseCollectionDeepLink(parsed, "portfolio");
+    case "watchlist":
+      return parseCollectionDeepLink(parsed, "watchlist");
+    case "collection":
+      return parseCollectionDeepLink(parsed, "collection");
+    case "alert":
+      return parseAlertDeepLink(parsed);
+    case "chat":
+      return parseChatDeepLink(parsed);
+    case "news":
+      return parseNewsDeepLink(parsed);
+    default:
+      return { type: "unsupported", message: "Unsupported Gloomberb link." };
+  }
+}
+
+function notifyError(pluginRegistry: PluginRegistry, body: string): void {
+  pluginRegistry.notify({ body, type: "error" });
+}
+
+function notifySuccess(pluginRegistry: PluginRegistry, body: string): void {
+  pluginRegistry.notify({ body, type: "success" });
+}
+
+function requirePane(pluginRegistry: PluginRegistry, paneId: string, unavailableMessage: string): boolean {
+  if (pluginRegistry.panes.has(paneId)) return true;
+  notifyError(pluginRegistry, unavailableMessage);
+  return false;
+}
+
+function resolveCollectionRecord(
+  state: AppState,
+  action: Extract<DesktopDeepLinkAction, { type: "open-collection" }>,
+): { name?: string } | null {
+  const portfolio = state.config.portfolios.find((entry) => entry.id === action.collectionId);
+  const watchlist = state.config.watchlists.find((entry) => entry.id === action.collectionId);
+  if (action.kind === "portfolio") return portfolio ?? null;
+  if (action.kind === "watchlist") return watchlist ?? null;
+  return portfolio ?? watchlist ?? null;
+}
+
+function visiblePaneIds(state: AppState): Set<string> {
+  return new Set([
+    ...getDockedPaneIds(state.config.layout),
+    ...state.config.layout.floating.map((entry) => entry.instanceId),
+    ...state.config.layout.detached.map((entry) => entry.instanceId),
+  ]);
+}
+
+function isVisiblePane(state: AppState, paneId: string | null | undefined): paneId is string {
+  return !!paneId && visiblePaneIds(state).has(paneId);
+}
+
+function resolveVisibleCollectionPaneId(state: AppState): string | null {
+  const followedPaneId = resolveFollowBindingInstance(
+    state.config.layout,
+    state.focusedPaneId,
+    (instance) => instance.paneId === "portfolio-list",
+  )?.instanceId;
+  if (isVisiblePane(state, followedPaneId)) return followedPaneId;
+
+  const focusedPane = state.focusedPaneId ? findPaneInstance(state.config.layout, state.focusedPaneId) : null;
+  if (focusedPane?.paneId === "portfolio-list" && isVisiblePane(state, focusedPane.instanceId)) {
+    return focusedPane.instanceId;
+  }
+
+  const visibleIds = visiblePaneIds(state);
+  return state.config.layout.instances.find((instance) => (
+    instance.paneId === "portfolio-list" && visibleIds.has(instance.instanceId)
+  ))?.instanceId ?? null;
+}
+
+function applyCollectionSelection(
+  collectionId: string,
+  { dispatch, stateRef }: Pick<DesktopDeepLinkHandlerOptions, "dispatch" | "stateRef">,
+): boolean {
+  const targetPaneId = resolveVisibleCollectionPaneId(stateRef.current);
+  if (!targetPaneId) return false;
+  dispatch({ type: "UPDATE_PANE_STATE", paneId: targetPaneId, patch: { collectionId } });
+  dispatch({ type: "FOCUS_PANE", paneId: targetPaneId });
+  return true;
+}
+
+function retryCollectionSelection(
+  collectionId: string,
+  options: Pick<DesktopDeepLinkHandlerOptions, "dispatch" | "stateRef">,
+): void {
+  globalThis.setTimeout(() => {
+    applyCollectionSelection(collectionId, options);
+  }, 50);
+}
+
+function handleOpenTicker(
+  action: Extract<DesktopDeepLinkAction, { type: "open-ticker" }>,
+  pluginRegistry: PluginRegistry,
+): void {
+  if (!requirePane(pluginRegistry, TICKER_RESEARCH_PANE_ID, "Ticker research is unavailable.")) return;
+  if (action.tabId && !pluginRegistry.getTickerResearchTabPluginId(action.tabId)) {
+    notifyError(pluginRegistry, `Ticker tab "${action.tabId}" is unavailable.`);
+    return;
+  }
+
+  pluginRegistry.pinTicker(action.symbol, {
+    floating: true,
+    paneType: TICKER_RESEARCH_PANE_ID,
+  });
+
+  if (action.tabId) {
+    globalThis.setTimeout(() => {
+      pluginRegistry.switchTab(action.tabId!);
+    }, 80);
+  }
+  notifySuccess(pluginRegistry, action.message);
+}
+
+function handleOpenCollection(
+  action: Extract<DesktopDeepLinkAction, { type: "open-collection" }>,
+  options: DesktopDeepLinkHandlerOptions,
+): void {
+  const collection = resolveCollectionRecord(options.stateRef.current, action);
+  if (!collection) {
+    notifyError(options.pluginRegistry, `Collection "${action.collectionId}" is unavailable.`);
+    return;
+  }
+  if (!requirePane(options.pluginRegistry, "portfolio-list", "Collections are unavailable.")) return;
+
+  options.pluginRegistry.showPane("portfolio-list");
+  if (!applyCollectionSelection(action.collectionId, options)) {
+    retryCollectionSelection(action.collectionId, options);
+  }
+  notifySuccess(options.pluginRegistry, collection.name ? `Opened ${collection.name}.` : action.message);
+}
+
+function handleCreateAlert(
+  action: Extract<DesktopDeepLinkAction, { type: "create-alert" }>,
+  pluginRegistry: PluginRegistry,
+): void {
+  const command = pluginRegistry.commands.get("set-alert");
+  if (!command) {
+    notifyError(pluginRegistry, "Alerts are unavailable.");
+    return;
+  }
+  void Promise.resolve(command.execute(action.values)).catch((error) => {
+    notifyError(pluginRegistry, error instanceof Error ? error.message : "Failed to create alert.");
+  });
+}
+
+function handleOpenChatChannel(
+  action: Extract<DesktopDeepLinkAction, { type: "open-chat-channel" }>,
+  pluginRegistry: PluginRegistry,
+): void {
+  if (!pluginRegistry.paneTemplates.has("new-chat-pane")) {
+    notifyError(pluginRegistry, "Chat is unavailable.");
+    return;
+  }
+  const options = action.channelId ? { arg: action.channelId } : undefined;
+  void pluginRegistry.createPaneFromTemplateAsyncFn("new-chat-pane", options).then(() => {
+    notifySuccess(pluginRegistry, action.message);
+  }).catch((error) => {
+    notifyError(pluginRegistry, error instanceof Error ? error.message : "Failed to open chat.");
+  });
+}
+
+function handleOpenChatDm(
+  action: Extract<DesktopDeepLinkAction, { type: "open-chat-dm" }>,
+  pluginRegistry: PluginRegistry,
+): void {
+  const command = pluginRegistry.commands.get("direct-message");
+  if (!command) {
+    notifyError(pluginRegistry, "Direct messages are unavailable.");
+    return;
+  }
+  void Promise.resolve(command.execute({ participants: action.participants })).then(() => {
+    notifySuccess(pluginRegistry, action.message);
+  }).catch((error) => {
+    notifyError(pluginRegistry, error instanceof Error ? error.message : "Failed to open DM.");
+  });
+}
+
+function handleOpenNews(
+  action: Extract<DesktopDeepLinkAction, { type: "open-news" }>,
+  pluginRegistry: PluginRegistry,
+): void {
+  if (action.kind === "ticker") {
+    if (!action.symbol || !pluginRegistry.paneTemplates.has("ticker-news-pane")) {
+      notifyError(pluginRegistry, "Ticker news is unavailable.");
+      return;
+    }
+    void pluginRegistry.createPaneFromTemplateAsyncFn("ticker-news-pane", { symbol: action.symbol }).then(() => {
+      notifySuccess(pluginRegistry, action.message);
+    }).catch((error) => {
+      notifyError(pluginRegistry, error instanceof Error ? error.message : "Failed to open ticker news.");
+    });
+    return;
+  }
+
+  const paneId = action.kind === "breaking"
+    ? "news-breaking"
+    : action.kind === "feed"
+      ? "news-feed"
+      : "news-top";
+  if (!requirePane(pluginRegistry, paneId, "News is unavailable.")) return;
+  pluginRegistry.showPane(paneId);
+  notifySuccess(pluginRegistry, action.message);
+}
+
+export function handleDesktopDeepLink(rawUrl: string, options: DesktopDeepLinkHandlerOptions): void {
   const action = resolveDesktopDeepLinkAction(rawUrl);
   if (action.type === "unsupported") {
-    pluginRegistry.notify({ body: action.message, type: "error" });
+    notifyError(options.pluginRegistry, action.message);
     return;
   }
-  if (!pluginRegistry.panes.has("account-management")) {
-    pluginRegistry.notify({ body: "Account management is unavailable.", type: "error" });
-    return;
+
+  switch (action.type) {
+    case "open-account-management":
+      if (!requirePane(options.pluginRegistry, "account-management", "Account management is unavailable.")) return;
+      options.pluginRegistry.showPane("account-management");
+      notifySuccess(options.pluginRegistry, action.message);
+      return;
+    case "open-ticker":
+      handleOpenTicker(action, options.pluginRegistry);
+      return;
+    case "open-collection":
+      handleOpenCollection(action, options);
+      return;
+    case "create-alert":
+      handleCreateAlert(action, options.pluginRegistry);
+      return;
+    case "open-chat-channel":
+      handleOpenChatChannel(action, options.pluginRegistry);
+      return;
+    case "open-chat-dm":
+      handleOpenChatDm(action, options.pluginRegistry);
+      return;
+    case "open-news":
+      handleOpenNews(action, options.pluginRegistry);
+      return;
   }
-  pluginRegistry.showPane("account-management");
-  pluginRegistry.notify({ body: action.message, type: "success" });
 }
 
 export function useDesktopDeepLinkRuntime({
   desktopDeepLinkBridge,
   desktopWindowKind,
+  dispatch,
   pluginRegistry,
+  stateRef,
 }: {
   desktopDeepLinkBridge?: DesktopDeepLinkBridge;
   desktopWindowKind?: DesktopWindowBridge["kind"];
+  dispatch: Dispatch<AppAction>;
   pluginRegistry: PluginRegistry;
+  stateRef: { current: AppState };
 }) {
   useEffect(() => {
     if (desktopWindowKind !== "main" || !desktopDeepLinkBridge) return;
     return desktopDeepLinkBridge.subscribe((deeplink) => {
-      handleDesktopDeepLink(deeplink.url, pluginRegistry);
+      handleDesktopDeepLink(deeplink.url, { dispatch, pluginRegistry, stateRef });
     });
-  }, [desktopDeepLinkBridge, desktopWindowKind, pluginRegistry]);
+  }, [desktopDeepLinkBridge, desktopWindowKind, dispatch, pluginRegistry, stateRef]);
 }

--- a/src/app/runtime/desktop-deeplink.ts
+++ b/src/app/runtime/desktop-deeplink.ts
@@ -1,0 +1,80 @@
+import { useEffect } from "react";
+import type { PluginRegistry } from "../../plugins/registry";
+import type { DesktopDeepLinkBridge } from "../../types/desktop-deeplink";
+import type { DesktopWindowBridge } from "../../types/desktop-window";
+
+type CloudDeepLinkRoute = {
+  kind: "cloud-alerts" | "cloud-roundup";
+  week: string | null;
+};
+
+export type DesktopDeepLinkAction =
+  | { type: "open-account-management"; route: CloudDeepLinkRoute; message: string }
+  | { type: "unsupported"; message: string };
+
+function weekSuffix(week: string | null): string {
+  return week ? ` for ${week}` : "";
+}
+
+export function resolveDesktopDeepLinkAction(rawUrl: string): DesktopDeepLinkAction {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return { type: "unsupported", message: "Unsupported Gloomberb link." };
+  }
+
+  if (url.protocol !== "gloomberb:" || url.hostname !== "cloud") {
+    return { type: "unsupported", message: "Unsupported Gloomberb link." };
+  }
+
+  const route = url.pathname.replace(/^\/+/, "");
+  const week = url.searchParams.get("week");
+  if (route === "roundup") {
+    return {
+      type: "open-account-management",
+      route: { kind: "cloud-roundup", week },
+      message: `Opened weekly roundup settings${weekSuffix(week)}.`,
+    };
+  }
+  if (route === "alerts") {
+    return {
+      type: "open-account-management",
+      route: { kind: "cloud-alerts", week },
+      message: `Opened portfolio alert settings${weekSuffix(week)}.`,
+    };
+  }
+
+  return { type: "unsupported", message: "Unsupported Gloomberb cloud link." };
+}
+
+export function handleDesktopDeepLink(rawUrl: string, pluginRegistry: PluginRegistry): void {
+  const action = resolveDesktopDeepLinkAction(rawUrl);
+  if (action.type === "unsupported") {
+    pluginRegistry.notify({ body: action.message, type: "error" });
+    return;
+  }
+  if (!pluginRegistry.panes.has("account-management")) {
+    pluginRegistry.notify({ body: "Account management is unavailable.", type: "error" });
+    return;
+  }
+  pluginRegistry.showPane("account-management");
+  pluginRegistry.notify({ body: action.message, type: "success" });
+}
+
+export function useDesktopDeepLinkRuntime({
+  desktopDeepLinkBridge,
+  desktopWindowKind,
+  pluginRegistry,
+}: {
+  desktopDeepLinkBridge?: DesktopDeepLinkBridge;
+  desktopWindowKind?: DesktopWindowBridge["kind"];
+  pluginRegistry: PluginRegistry;
+}) {
+  useEffect(() => {
+    if (desktopWindowKind !== "main" || !desktopDeepLinkBridge) return;
+    return desktopDeepLinkBridge.subscribe((deeplink) => {
+      handleDesktopDeepLink(deeplink.url, pluginRegistry);
+    });
+  }, [desktopDeepLinkBridge, desktopWindowKind, pluginRegistry]);
+}

--- a/src/components/command-bar/commands/direct/index.ts
+++ b/src/components/command-bar/commands/direct/index.ts
@@ -80,6 +80,15 @@ export function runDirectCommandAction(options: {
       closeAll({ revertThemePreview: false });
       pluginRegistry.showPane("help");
       return;
+    case "account-profile":
+      if (!pluginRegistry.panes.has("account-management")) {
+        notify("Account management is unavailable.", { type: "error" });
+        closeAll({ revertThemePreview: false });
+        return;
+      }
+      closeAll({ revertThemePreview: false });
+      pluginRegistry.showPane("account-management");
+      return;
     case "pane-settings":
       if (state.focusedPaneId) openPaneSettingsRoute(state.focusedPaneId);
       return;

--- a/src/components/command-bar/commands/direct/index.ts
+++ b/src/components/command-bar/commands/direct/index.ts
@@ -80,15 +80,6 @@ export function runDirectCommandAction(options: {
       closeAll({ revertThemePreview: false });
       pluginRegistry.showPane("help");
       return;
-    case "account-profile":
-      if (!pluginRegistry.panes.has("account-management")) {
-        notify("Account management is unavailable.", { type: "error" });
-        closeAll({ revertThemePreview: false });
-        return;
-      }
-      closeAll({ revertThemePreview: false });
-      pluginRegistry.showPane("account-management");
-      return;
     case "pane-settings":
       if (state.focusedPaneId) openPaneSettingsRoute(state.focusedPaneId);
       return;

--- a/src/components/command-bar/commands/registry.ts
+++ b/src/components/command-bar/commands/registry.ts
@@ -40,6 +40,13 @@ export const commands: Command[] = [
     description: "Open the help window",
     category: "Navigation",
   },
+  {
+    id: "account-profile",
+    prefix: "",
+    label: "Profile",
+    description: "Open Account Management for your Gloom Cloud profile and portfolio analytics",
+    category: "Config",
+  },
 
   // Watchlist/Portfolio management
   {

--- a/src/components/command-bar/commands/registry.ts
+++ b/src/components/command-bar/commands/registry.ts
@@ -40,13 +40,6 @@ export const commands: Command[] = [
     description: "Open the help window",
     category: "Navigation",
   },
-  {
-    id: "account-profile",
-    prefix: "",
-    label: "Profile",
-    description: "Open Account Management for your Gloom Cloud profile and portfolio analytics",
-    category: "Config",
-  },
 
   // Watchlist/Portfolio management
   {

--- a/src/components/command-bar/pane-templates/items.ts
+++ b/src/components/command-bar/pane-templates/items.ts
@@ -139,6 +139,14 @@ export function buildPaneTemplateItem(options: {
       .join(" ")
     : null;
   const arg = options.createOptions?.arg;
+  const searchText = [
+    options.template.keywords?.join(" ") || "",
+    displayLabel,
+    options.template.label,
+    options.template.paneId,
+    shortcutLabel || "",
+    pluginName || "",
+  ].filter(Boolean).join(" ");
 
   const action = () => {
     if (
@@ -163,7 +171,7 @@ export function buildPaneTemplateItem(options: {
     kind: "action",
     right: options.showShortcut ? options.template.shortcut?.prefix : undefined,
     shortcutQuery: options.template.shortcut?.prefix,
-    searchText: `${displayLabel} ${options.template.label} ${options.template.paneId} ${options.template.keywords?.join(" ") || ""} ${shortcutLabel || ""} ${pluginName || ""}`,
+    searchText,
     action,
   };
 }
@@ -187,7 +195,7 @@ export function buildPaneShortcutItems(options: {
     }));
 
   return options.filterQuery
-    ? fuzzyFilter(items, options.filterQuery, (item) => `${item.label} ${item.detail} ${item.searchText || ""} ${item.right || ""}`)
+    ? fuzzyFilter(items, options.filterQuery, (item) => `${item.label} ${item.searchText || ""} ${item.detail} ${item.right || ""}`)
     : items;
 }
 
@@ -201,6 +209,6 @@ export function buildNonShortcutPaneTemplateItems(options: {
     .map((template) => options.createItem(template, { category: "Panes" }));
 
   return options.filterQuery
-    ? fuzzyFilter(items, options.filterQuery, (item) => `${item.label} ${item.detail} ${item.searchText || ""} ${item.right || ""}`)
+    ? fuzzyFilter(items, options.filterQuery, (item) => `${item.label} ${item.searchText || ""} ${item.detail} ${item.right || ""}`)
     : items;
 }

--- a/src/components/command-bar/routes/root/command-items.ts
+++ b/src/components/command-bar/routes/root/command-items.ts
@@ -59,6 +59,8 @@ export function createRootCommandItemBuilder({
         );
       case "set-portfolio-position":
         return manualPortfolios.length > 0;
+      case "account-profile":
+        return !state.config.disabledPlugins.includes("gloomberb-cloud");
       case "disconnect-broker-account":
         return state.config.brokerInstances.length > 0;
       case "delete-watchlist":
@@ -151,6 +153,8 @@ export function createRootCommandItemBuilder({
     switch (command.id) {
       case "set-portfolio-position":
         return "edit position update position modify position manual position portfolio position";
+      case "account-profile":
+        return "profile account management cloud public portfolio analytics password username settings";
       default:
         return "";
     }

--- a/src/components/command-bar/routes/root/command-items.ts
+++ b/src/components/command-bar/routes/root/command-items.ts
@@ -59,8 +59,6 @@ export function createRootCommandItemBuilder({
         );
       case "set-portfolio-position":
         return manualPortfolios.length > 0;
-      case "account-profile":
-        return !state.config.disabledPlugins.includes("gloomberb-cloud");
       case "disconnect-broker-account":
         return state.config.brokerInstances.length > 0;
       case "delete-watchlist":
@@ -153,8 +151,6 @@ export function createRootCommandItemBuilder({
     switch (command.id) {
       case "set-portfolio-position":
         return "edit position update position modify position manual position portfolio position";
-      case "account-profile":
-        return "profile account management cloud public portfolio analytics password username settings";
       default:
         return "";
     }

--- a/src/components/command-bar/routes/root/results.ts
+++ b/src/components/command-bar/routes/root/results.ts
@@ -196,7 +196,7 @@ export function buildRootResultModel(options: RootResultModelOptions): RootResul
       ...tickerActionItems(),
       ...pluginCommandItems(),
     ];
-    items.push(...fuzzyFilter(allItems, rootQuery, (item) => `${item.label} ${item.detail} ${item.searchText || ""} ${item.right || ""}`));
+    items.push(...fuzzyFilter(allItems, rootQuery, (item) => `${item.label} ${item.searchText || ""} ${item.detail} ${item.right || ""}`));
   }
 
   return { items, initialIdx };

--- a/src/components/command-bar/surface/index.test.tsx
+++ b/src/components/command-bar/surface/index.test.tsx
@@ -6,6 +6,7 @@ import type { CommandDef, CommandShortcutArgContext, PaneTemplateCreateOptions, 
 import {
   CommandBarHarness,
   createCommandBarTestControls,
+  emitKeypress,
   expectSingleBackControl,
   makeDataProvider,
   makeTicker,
@@ -24,6 +25,10 @@ const { waitForFrameToContain, clickFrameText } = createCommandBarTestControls((
 
 type MutableCommandRegistry = {
   commands: ReadonlyMap<string, CommandDef>;
+};
+
+type MutablePaneRegistry = {
+  panes: ReadonlyMap<string, unknown>;
 };
 
 const DEFAULT_ALERT_OPTIONS = [
@@ -68,6 +73,10 @@ function registerAlertCommand(
     execute: async () => {},
     ...overrides,
   });
+}
+
+function mutablePaneRegistryMap(map: ReadonlyMap<string, unknown>): Map<string, unknown> {
+  return map as Map<string, unknown>;
 }
 
 describe("CommandBar", () => {
@@ -127,6 +136,38 @@ describe("CommandBar", () => {
 
     expect(calls).toHaveLength(1);
     expect(testSetup.captureCharFrame()).not.toContain("Commands");
+  });
+
+  test("opens account management when searching profile", async () => {
+    const openedPanes: string[] = [];
+
+    testSetup = await testRender(<CommandBarHarness
+      query="profile"
+      live
+      configurePluginRegistry={(pluginRegistry) => {
+        mutablePaneRegistryMap((pluginRegistry as MutablePaneRegistry).panes).set("account-management", {
+          id: "account-management",
+          name: "Account Management",
+          component: () => null,
+          defaultPosition: "right",
+          defaultMode: "floating",
+        });
+        pluginRegistry.showPane = (paneId) => {
+          openedPanes.push(paneId);
+        };
+      }}
+    />, {
+      width: 80,
+      height: 24,
+    });
+
+    await testSetup.renderOnce();
+    const frame = await waitForFrameToContain("Profile");
+    expect(frame.indexOf("Profile")).toBeLessThan(frame.indexOf("Add Broker Account"));
+
+    await emitKeypress(testSetup, { name: "return", sequence: "\r" });
+
+    expect(openedPanes).toEqual(["account-management"]);
   });
 
   test("shows theme picker rows and commits a filtered light theme", async () => {

--- a/src/components/command-bar/surface/index.test.tsx
+++ b/src/components/command-bar/surface/index.test.tsx
@@ -29,6 +29,7 @@ type MutableCommandRegistry = {
 
 type MutablePaneRegistry = {
   panes: ReadonlyMap<string, unknown>;
+  paneTemplates: ReadonlyMap<string, unknown>;
 };
 
 const DEFAULT_ALERT_OPTIONS = [
@@ -138,22 +139,31 @@ describe("CommandBar", () => {
     expect(testSetup.captureCharFrame()).not.toContain("Commands");
   });
 
-  test("opens account management when searching profile", async () => {
-    const openedPanes: string[] = [];
+  test("shows one account management result when searching profile", async () => {
+    const created: Array<{ templateId: string; options?: PaneTemplateCreateOptions }> = [];
 
     testSetup = await testRender(<CommandBarHarness
       query="profile"
       live
       configurePluginRegistry={(pluginRegistry) => {
-        mutablePaneRegistryMap((pluginRegistry as MutablePaneRegistry).panes).set("account-management", {
+        const registry = pluginRegistry as MutablePaneRegistry;
+        mutablePaneRegistryMap(registry.panes).set("account-management", {
           id: "account-management",
           name: "Account Management",
           component: () => null,
           defaultPosition: "right",
           defaultMode: "floating",
         });
-        pluginRegistry.showPane = (paneId) => {
-          openedPanes.push(paneId);
+        mutablePaneRegistryMap(registry.paneTemplates).set("account-management-pane", {
+          id: "account-management-pane",
+          paneId: "account-management",
+          label: "Account Management",
+          description: "Edit your Gloom Cloud profile, password, and public portfolio sharing settings",
+          keywords: ["account", "profile", "cloud", "acm", "password", "settings"],
+          shortcut: { prefix: "ACM" },
+        });
+        pluginRegistry.createPaneFromTemplateAsyncFn = async (templateId, options) => {
+          created.push({ templateId, options });
         };
       }}
     />, {
@@ -162,12 +172,13 @@ describe("CommandBar", () => {
     });
 
     await testSetup.renderOnce();
-    const frame = await waitForFrameToContain("Profile");
-    expect(frame.indexOf("Profile")).toBeLessThan(frame.indexOf("Add Broker Account"));
+    const frame = await waitForFrameToContain("Account Management");
+    expect(frame).not.toMatch(/\n\s*Profile\s*(?:\n|$)/);
+    expect(frame.indexOf("Account Management")).toBeLessThan(frame.indexOf("Add Broker Account"));
 
     await emitKeypress(testSetup, { name: "return", sequence: "\r" });
 
-    expect(openedPanes).toEqual(["account-management"]);
+    expect(created).toEqual([{ templateId: "account-management-pane", options: undefined }]);
   });
 
   test("shows theme picker rows and commits a filtered light theme", async () => {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -25,6 +25,7 @@ export { PaneFooterScope, usePaneFooter } from "./layout/pane/footer";
 export type { PaneFooterSegment, PaneHint } from "./layout/pane/footer";
 export { useExternalLinkFooter } from "./use-external-link-footer";
 export { Button } from "./ui/button";
+export { Checkbox } from "./ui/checkbox";
 export { ConfirmDialog } from "./ui/confirm-dialog";
 export { ChoiceDialog } from "./ui/choice-dialog";
 export type { ChoiceDialogChoice } from "./ui/choice-dialog";

--- a/src/components/toggle-list.tsx
+++ b/src/components/toggle-list.tsx
@@ -1,6 +1,6 @@
-import { Box, Text, useUiHost } from "../ui";
-import { TextAttributes } from "../ui";
-import { blendHex, colors } from "../theme/colors";
+import { Box, useUiHost } from "../ui";
+import { colors } from "../theme/colors";
+import { Checkbox } from "./ui/checkbox";
 import { ListView, type ListRowState, type ListViewItem } from "./ui/list-view";
 
 interface ToggleListItem {
@@ -36,23 +36,14 @@ function DesktopToggleRow({
   state,
   rowIdPrefix,
   enabled,
+  onPress,
 }: {
   item: ListViewItem;
   state: ListRowState;
   rowIdPrefix?: string;
   enabled: boolean;
+  onPress: () => void;
 }) {
-  const checkboxBorder = enabled
-    ? colors.borderFocused
-    : state.selected
-    ? colors.textMuted
-    : colors.border;
-  const textColor = state.disabled
-    ? colors.textMuted
-    : state.selected
-    ? colors.text
-    : colors.textDim;
-
   return (
     <Box
       id={rowIdPrefix ? `${rowIdPrefix}:${item.id}` : undefined}
@@ -67,48 +58,15 @@ function DesktopToggleRow({
         opacity: state.disabled ? 0.55 : 1,
       }}
     >
-      <Box
-        alignItems="center"
-        justifyContent="center"
-        backgroundColor={enabled ? colors.borderFocused : "transparent"}
-        style={{
-          width: 16,
-          height: 16,
-          minWidth: 16,
-          alignSelf: "center",
-          border: `1px solid ${checkboxBorder}`,
-          borderRadius: 4,
-          boxShadow: enabled
-            ? `inset 0 1px 0 ${blendHex(colors.borderFocused, colors.textBright, 0.28)}`
-            : `inset 0 1px 0 ${blendHex(colors.bg, colors.textBright, 0.05)}`,
-        }}
-      >
-        {enabled && (
-          <Text
-            fg={colors.bg}
-            attributes={TextAttributes.BOLD}
-            style={{ fontSize: 12, lineHeight: "14px", fontWeight: 800 }}
-          >
-            {"✓"}
-          </Text>
-        )}
-      </Box>
-      <Box minWidth={0} flexShrink={1}>
-        <Text
-          fg={textColor}
-          attributes={state.selected ? TextAttributes.BOLD : 0}
-          style={{
-            display: "block",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            fontWeight: state.selected ? 700 : 500,
-            lineHeight: "16px",
-          }}
-        >
-          {item.label}
-        </Text>
-      </Box>
+      <Checkbox
+        label={item.label}
+        checked={enabled}
+        disabled={state.disabled}
+        active={state.selected}
+        width="100%"
+        variant="desktop"
+        onChange={onPress}
+      />
     </Box>
   );
 }
@@ -161,6 +119,13 @@ export function ToggleList({
       }}
       renderRow={(item, state, index) => {
         const toggleItem = items.find((entry) => entry.id === item.id);
+        const activate = (event?: { stopPropagation?: () => void; preventDefault?: () => void }) => {
+          event?.stopPropagation?.();
+          event?.preventDefault?.();
+          if (state.disabled) return;
+          onSelect?.(index);
+          onToggle?.(item.id);
+        };
         if (isDesktopWeb) {
           return (
             <DesktopToggleRow
@@ -168,33 +133,24 @@ export function ToggleList({
               state={state}
               rowIdPrefix={rowIdPrefix}
               enabled={toggleItem?.enabled === true}
+              onPress={() => activate()}
             />
           );
         }
 
-        const checked = toggleItem?.enabled ? "\u2713" : " ";
-        const activate = (event: any) => {
-          event.stopPropagation?.();
-          if (state.disabled) return;
-          onSelect?.(index);
-          onToggle?.(item.id);
-        };
         return (
           <Box
             id={rowIdPrefix ? `${rowIdPrefix}:${item.id}` : undefined}
             flexDirection="row"
             onMouseDown={activate}
           >
-            <Text fg={state.selected ? colors.selectedText : colors.textDim}>
-              {state.selected ? "\u25b8 " : "  "}
-            </Text>
-            <Text
-              fg={state.selected ? colors.text : colors.textDim}
-              attributes={state.selected ? TextAttributes.BOLD : 0}
-              onMouseDown={activate}
-            >
-              {`[${checked}] ${item.label}`}
-            </Text>
+            <Checkbox
+              label={item.label}
+              checked={toggleItem?.enabled === true}
+              disabled={state.disabled}
+              active={state.selected}
+              onChange={() => activate()}
+            />
           </Box>
         );
       }}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -14,6 +14,7 @@ export interface ButtonProps {
   active?: boolean;
   shortcut?: string;
   width?: number;
+  height?: number | string;
 }
 
 function resolveButtonColors(variant: ButtonVariant, active: boolean, disabled: boolean) {
@@ -45,6 +46,7 @@ export function Button({
   active = false,
   shortcut,
   width,
+  height,
 }: ButtonProps) {
   useRemoteUiNode({
     role: "button",
@@ -68,6 +70,7 @@ export function Button({
         active={active}
         shortcut={shortcut}
         width={width}
+        height={height}
       />
     );
   }
@@ -77,7 +80,7 @@ export function Button({
   return (
     <Box
       width={width}
-      height={1}
+      height={height ?? 1}
       flexDirection="row"
       backgroundColor={palette.bg}
       onMouseDown={() => {

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,73 @@
+import { type ComponentType } from "react";
+import { Box, Text, TextAttributes, useUiHost, type HostCheckboxProps } from "../../ui";
+import { colors, hoverBg } from "../../theme/colors";
+import { useRemoteUiNode } from "../../remote/semantic-tree";
+
+export type CheckboxProps = HostCheckboxProps;
+
+export function Checkbox({
+  label,
+  checked,
+  onChange,
+  disabled = false,
+  active = false,
+  description,
+  width,
+  variant = "default",
+}: CheckboxProps) {
+  useRemoteUiNode({
+    role: "checkbox",
+    label,
+    disabled,
+    actions: {
+      toggle: () => {
+        if (!disabled) onChange?.(!checked);
+      },
+      press: () => {
+        if (!disabled) onChange?.(!checked);
+      },
+    },
+    metadata: { checked, active, variant },
+  });
+
+  const HostCheckbox = useUiHost().Checkbox as ComponentType<CheckboxProps> | undefined;
+  if (HostCheckbox) {
+    return (
+      <HostCheckbox
+        label={label}
+        checked={checked}
+        onChange={onChange}
+        disabled={disabled}
+        active={active}
+        description={description}
+        width={width}
+        variant={variant}
+      />
+    );
+  }
+
+  const marker = checked ? "\u2713" : " ";
+  const fg = disabled ? colors.textMuted : active ? colors.textBright : colors.text;
+  const descriptionWidth = typeof width === "number" ? Math.max(20, width - 2) : 28;
+  return (
+    <Box
+      flexDirection="column"
+      width={width}
+      backgroundColor={active && !disabled ? hoverBg() : undefined}
+      onMouseDown={(event?: { preventDefault?: () => void; stopPropagation?: () => void }) => {
+        event?.preventDefault?.();
+        event?.stopPropagation?.();
+        if (!disabled) onChange?.(!checked);
+      }}
+    >
+      <Text fg={fg} attributes={active ? TextAttributes.BOLD : 0}>
+        {`${active ? "> " : "  "}[${marker}] ${label}`}
+      </Text>
+      {description ? (
+        <Text fg={colors.textMuted} wrapText width={descriptionWidth}>
+          {description}
+        </Text>
+      ) : null}
+    </Box>
+  );
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -7,6 +7,7 @@ export type CheckboxProps = HostCheckboxProps;
 
 export function Checkbox({
   label,
+  displayLabel,
   checked,
   onChange,
   disabled = false,
@@ -35,6 +36,7 @@ export function Checkbox({
     return (
       <HostCheckbox
         label={label}
+        displayLabel={displayLabel}
         checked={checked}
         onChange={onChange}
         disabled={disabled}
@@ -47,6 +49,7 @@ export function Checkbox({
   }
 
   const marker = checked ? "\u2713" : " ";
+  const visibleLabel = displayLabel ?? label;
   const fg = disabled ? colors.textMuted : active ? colors.textBright : colors.text;
   const descriptionWidth = typeof width === "number" ? Math.max(20, width - 2) : 28;
   return (
@@ -61,7 +64,7 @@ export function Checkbox({
       }}
     >
       <Text fg={fg} attributes={active ? TextAttributes.BOLD : 0}>
-        {`${active ? "> " : "  "}[${marker}] ${label}`}
+        {`${active ? "> " : "  "}[${marker}] ${visibleLabel}`}
       </Text>
       {description ? (
         <Text fg={colors.textMuted} wrapText width={descriptionWidth}>

--- a/src/components/ui/choice-dialog.tsx
+++ b/src/components/ui/choice-dialog.tsx
@@ -37,6 +37,15 @@ function getInitialChoiceIndex(choices: ChoiceDialogChoice[], selectedChoiceId: 
   return selectedIndex >= 0 ? selectedIndex : 0;
 }
 
+function choiceDialogWidth(title: string, choices: ChoiceDialogChoice[]): number {
+  const contentWidth = Math.max(
+    title.length,
+    ...choices.map((choice) => choice.label.length + (choice.detail ? choice.detail.length + 4 : 0)),
+    ...choices.map((choice) => getChoiceDescription(choice).length),
+  );
+  return Math.max(34, Math.min(76, contentWidth + 4));
+}
+
 export function ChoiceDialog({
   resolve,
   title,
@@ -57,6 +66,7 @@ export function ChoiceDialog({
     detail: choice.detail,
     disabled: choice.disabled,
   })), [choices]);
+  const width = useMemo(() => choiceDialogWidth(title, choices), [choices, title]);
 
   useEffect(() => {
     setIndex((current) => clampChoiceIndex(current, choices.length));
@@ -82,7 +92,7 @@ export function ChoiceDialog({
 
   return (
     <DialogFrame title={title} footer={footer} showTitleDivider={false}>
-      <Box flexDirection="column">
+      <Box flexDirection="column" width={width}>
         <ListView
           items={items}
           selectedIndex={selectedIndex}
@@ -95,7 +105,7 @@ export function ChoiceDialog({
           onActivate={(_, nextIndex) => activateChoice(choices[nextIndex])}
         />
         <Box height={1} />
-        <Text fg={colors.textDim}>{getChoiceDescription(selectedChoice)}</Text>
+        <Text fg={colors.textDim} wrapText width={width}>{getChoiceDescription(selectedChoice)}</Text>
       </Box>
     </DialogFrame>
   );

--- a/src/components/ui/choice-dialog.tsx
+++ b/src/components/ui/choice-dialog.tsx
@@ -81,13 +81,15 @@ export function ChoiceDialog({
   });
 
   return (
-    <DialogFrame title={title} footer={footer}>
+    <DialogFrame title={title} footer={footer} showTitleDivider={false}>
       <Box flexDirection="column">
         <ListView
           items={items}
           selectedIndex={selectedIndex}
           bgColor={bgColor}
           emptyMessage="No choices."
+          rowGap={0}
+          surface="framed"
           selectOnHover
           onSelect={setIndex}
           onActivate={(_, nextIndex) => activateChoice(choices[nextIndex])}

--- a/src/components/ui/frame.tsx
+++ b/src/components/ui/frame.tsx
@@ -11,7 +11,7 @@ export interface DialogFrameProps {
   showTitleDivider?: boolean;
 }
 
-export function DialogFrame({ title, children, footer, showTitleDivider = true }: DialogFrameProps) {
+export function DialogFrame({ title, children, footer, showTitleDivider = false }: DialogFrameProps) {
   useThemeColors();
   const HostDialogFrame = useUiHost().DialogFrame as ComponentType<DialogFrameProps> | undefined;
   if (HostDialogFrame) {

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -6,6 +6,8 @@ export { DataTable } from "./data-table";
 export type { DataTableCell, DataTableColumn, DataTableProps } from "./data-table";
 
 export { Button } from "./button";
+export { Checkbox } from "./checkbox";
+export type { CheckboxProps } from "./checkbox";
 export { ShortcutHint } from "./shortcut-hint";
 
 export { MultiSelectDialogButton, MultiSelectDialogContent } from "./multi-select/dialog";

--- a/src/components/ui/native-select.tsx
+++ b/src/components/ui/native-select.tsx
@@ -17,6 +17,7 @@ export interface NativeSelectProps {
   value: string;
   options: NativeSelectOption[];
   width?: number | string;
+  height?: number;
   includeUnsetOption?: boolean;
   selectRef?: (element: NativeSelectElement | null) => void;
   onFocus?: () => void;
@@ -41,6 +42,7 @@ export function NativeSelect({
   value,
   options,
   width = 184,
+  height = 28,
   includeUnsetOption = false,
   selectRef,
   onFocus,
@@ -49,7 +51,7 @@ export function NativeSelect({
   const hasCurrentValue = options.some((option) => option.value === value);
   const style: CSSProperties = {
     width,
-    height: 28,
+    height,
     color: colors.text,
     backgroundColor: blendHex(colors.panel, colors.textBright, 0.06),
     border: `1px solid ${colors.border}`,
@@ -66,7 +68,7 @@ export function NativeSelect({
 
   return (
     <Box
-      height="28px"
+      height={`${height}px`}
       flexDirection="row"
       alignItems="center"
       onMouseDown={(event: any) => {

--- a/src/plugins/builtin/account-management/footer.ts
+++ b/src/plugins/builtin/account-management/footer.ts
@@ -8,22 +8,19 @@ export function useAccountManagementFooter({
   draft,
   hasSession,
   message,
-  openPasswordDialog,
   profile,
   saveProfile,
 }: {
-  busy: "profile" | "password" | "alerts" | null;
+  busy: "profile" | "password" | "alerts" | "billing" | "delete" | null;
   draft: AccountDraft;
   hasSession: boolean;
   message: { tone: "info" | "success" | "error"; text: string } | null;
-  openPasswordDialog: () => void;
   profile: AccountProfile | null;
   saveProfile: () => Promise<void>;
 }) {
   const footerHints = useMemo<PaneHint[]>(() => [
     { id: "save", key: "Ctrl+S", label: "save", onPress: () => { void saveProfile(); }, disabled: !!busy || !hasSession },
-    { id: "password", key: "p", label: "assword", onPress: openPasswordDialog, disabled: !!busy || !hasSession },
-  ], [busy, hasSession, openPasswordDialog, saveProfile]);
+  ], [busy, hasSession, saveProfile]);
 
   usePaneFooter("account-management", () => ({
     info: [

--- a/src/plugins/builtin/account-management/footer.ts
+++ b/src/plugins/builtin/account-management/footer.ts
@@ -12,7 +12,7 @@ export function useAccountManagementFooter({
   profile,
   saveProfile,
 }: {
-  busy: "profile" | "password" | null;
+  busy: "profile" | "password" | "sync" | "alerts" | null;
   draft: AccountDraft;
   hasSession: boolean;
   message: { tone: "info" | "success" | "error"; text: string } | null;

--- a/src/plugins/builtin/account-management/footer.ts
+++ b/src/plugins/builtin/account-management/footer.ts
@@ -12,7 +12,7 @@ export function useAccountManagementFooter({
   profile,
   saveProfile,
 }: {
-  busy: "profile" | "password" | "sync" | "alerts" | null;
+  busy: "profile" | "password" | "alerts" | null;
   draft: AccountDraft;
   hasSession: boolean;
   message: { tone: "info" | "success" | "error"; text: string } | null;

--- a/src/plugins/builtin/account-management/form-components.tsx
+++ b/src/plugins/builtin/account-management/form-components.tsx
@@ -1,7 +1,8 @@
 import { type ReactNode } from "react";
-import { Button, Checkbox, TextField } from "../../../components";
-import { Box, Text, TextAttributes } from "../../../ui";
+import { Button, Checkbox, TextField, type ChoiceDialogChoice } from "../../../components";
+import { Box, Text, TextAttributes, useUiHost } from "../../../ui";
 import { colors } from "../../../theme/colors";
+import { NativeSelect, type NativeSelectElement } from "../../../components/ui/native-select";
 import type { AccountFieldKey, ProfileAnalyticsPreview } from "./model";
 import { truncate } from "./model";
 
@@ -148,9 +149,12 @@ export function CheckboxRow({
   onFocus: () => void;
   onChange: (checked: boolean) => void;
 }) {
-  const labelWidth = accountFieldLabelWidth(width);
-  const controlWidth = Math.max(8, width - labelWidth - 1);
   const labelText = `${active ? "> " : "  "}${label}`;
+  const labelWidth = Math.min(
+    width - 9,
+    Math.max(accountFieldLabelWidth(width), Math.min(labelText.length, 34)),
+  );
+  const controlWidth = Math.max(8, width - labelWidth - 1);
   return (
     <Box
       flexDirection="column"
@@ -277,28 +281,38 @@ export function AccountAnalyticsPreview({
 
 export function PublicAnalyticsGroup({
   preview,
+  choices,
+  value,
   label,
   detail,
   active,
   width,
   disclaimer,
+  selectRef,
   onFocus,
+  onSelect,
   onOpen,
 }: {
   preview: ProfileAnalyticsPreview;
+  choices: ChoiceDialogChoice[];
+  value: string;
   label: string;
   detail?: string;
   active: boolean;
   width: number;
   disclaimer?: string | null;
+  selectRef?: (element: NativeSelectElement | null) => void;
   onFocus: () => void;
+  onSelect: (value: string) => void;
   onOpen: () => void;
 }) {
+  const isDesktop = useUiHost().kind === "desktop-web";
   const contentWidth = Math.max(1, width - 2);
   const labelText = active ? "> Public Stats:" : "  Public Stats:";
   const labelWidth = Math.min(accountFieldLabelWidth(width), Math.max(1, contentWidth));
   const buttonWidth = Math.max(14, Math.min(24, Math.floor(contentWidth * 0.3)));
-  const selectLabel = `${label} v`;
+  const buttonLabel = truncate(label, Math.max(1, buttonWidth - 4));
+  const nativeSelectWidth = buttonWidth * 8;
   const normalizedDetail = (detail ?? "").replace(/\.+$/, "");
   const displayPreview = (
     preview.metrics.length === 0
@@ -315,20 +329,36 @@ export function PublicAnalyticsGroup({
       width={width}
       onMouseOver={onFocus}
     >
-      <Box height={1} flexDirection="row" gap={1}>
+      <Box height={isDesktop ? "24px" : 1} flexDirection="row" gap={1} alignItems="center">
         <Text fg={active ? colors.textBright : colors.textDim} attributes={active ? TextAttributes.BOLD : 0}>
           {truncate(labelText, labelWidth)}
         </Text>
-        <Button
-          label={truncate(selectLabel, Math.max(1, buttonWidth - 2))}
-          variant="secondary"
-          width={buttonWidth}
-          active={active}
-          onPress={() => {
-            onFocus();
-            onOpen();
-          }}
-        />
+        {isDesktop ? (
+          <NativeSelect
+            value={value}
+            options={choices.map((choice) => ({
+              value: choice.id,
+              label: choice.label,
+              disabled: choice.disabled,
+            }))}
+            width={nativeSelectWidth}
+            height={22}
+            selectRef={selectRef}
+            onFocus={onFocus}
+            onChange={onSelect}
+          />
+        ) : (
+          <Button
+            label={`${buttonLabel} v`}
+            variant="secondary"
+            width={buttonWidth}
+            active={active}
+            onPress={() => {
+              onFocus();
+              onOpen();
+            }}
+          />
+        )}
         {metrics.length > 0 ? metrics.map((metric) => {
           const labelTextWidth = Math.max(1, Math.min(metric.label.length, metricWidth - 2));
           const valueWidth = Math.max(1, metricWidth - labelTextWidth - 1);

--- a/src/plugins/builtin/account-management/form-components.tsx
+++ b/src/plugins/builtin/account-management/form-components.tsx
@@ -1,7 +1,7 @@
-import { useState, type ReactNode } from "react";
-import { TextField } from "../../../components";
+import { type ReactNode } from "react";
+import { Checkbox, TextField } from "../../../components";
 import { Box, Text, TextAttributes } from "../../../ui";
-import { colors, hoverBg } from "../../../theme/colors";
+import { colors } from "../../../theme/colors";
 import type { AccountFieldKey, ProfileAnalyticsPreview } from "./model";
 import { truncate } from "./model";
 
@@ -127,32 +127,20 @@ export function CheckboxRow({
   onFocus: () => void;
   onChange: (checked: boolean) => void;
 }) {
-  const [hovered, setHovered] = useState(false);
-  const marker = checked ? "x" : " ";
-  const fg = active ? colors.textBright : colors.text;
-
   return (
-    <Box
-      flexDirection="column"
-      backgroundColor={hovered ? hoverBg() : undefined}
-      onMouseOver={() => {
-        setHovered(true);
-        onFocus();
-      }}
-      onMouseOut={() => setHovered(false)}
-      onMouseDown={() => {
-        onFocus();
-        onChange(!checked);
-      }}
-    >
-      <Text fg={fg} attributes={active ? TextAttributes.BOLD : 0}>
-        {`${active ? "> " : "  "}[${marker}] ${label}`}
-      </Text>
-      {description ? (
-        <Text fg={colors.textMuted} wrapText width={Math.max(24, width - 2)}>
-          {description}
-        </Text>
-      ) : null}
+    <Box onMouseOver={onFocus}>
+      <Checkbox
+        label={label}
+        checked={checked}
+        active={active}
+        description={description}
+        width={width}
+        variant="desktop"
+        onChange={(nextChecked) => {
+          onFocus();
+          onChange(nextChecked);
+        }}
+      />
     </Box>
   );
 }
@@ -168,28 +156,39 @@ export function AccountAnalyticsPreview({
   preview,
   width,
   disclaimer,
+  surface = "panel",
 }: {
   preview: ProfileAnalyticsPreview;
   width: number;
   disclaimer?: string | null;
+  surface?: "panel" | "plain";
 }) {
-  const contentWidth = Math.max(1, width - 2);
+  const horizontalPadding = surface === "panel" ? 1 : 0;
+  const contentWidth = Math.max(1, width - horizontalPadding * 2);
   const metricWidth = Math.max(14, Math.min(28, Math.floor((contentWidth - 2) / 2)));
   const subtitleWidth = Math.max(1, contentWidth - preview.title.length - 2);
+  const showHeader = surface === "panel";
 
   return (
-    <Box flexDirection="column" width={width} backgroundColor={colors.panel} paddingX={1}>
-      <Box height={1} flexDirection="row">
-        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-          {truncate(preview.title, contentWidth)}
-        </Text>
-        {preview.subtitle ? (
-          <>
-            <Box flexGrow={1} />
-            <Text fg={colors.textMuted}>{truncate(preview.subtitle, subtitleWidth)}</Text>
-          </>
-        ) : null}
-      </Box>
+    <Box
+      flexDirection="column"
+      width={width}
+      backgroundColor={surface === "panel" ? colors.panel : undefined}
+      paddingX={horizontalPadding}
+    >
+      {showHeader ? (
+        <Box height={1} flexDirection="row">
+          <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+            {truncate(preview.title, contentWidth)}
+          </Text>
+          {preview.subtitle ? (
+            <>
+              <Box flexGrow={1} />
+              <Text fg={colors.textMuted}>{truncate(preview.subtitle, subtitleWidth)}</Text>
+            </>
+          ) : null}
+        </Box>
+      ) : null}
       {preview.metrics.length > 0 ? (
         <Box flexDirection="row" flexWrap="wrap" gap={2}>
           {preview.metrics.map((metric) => {
@@ -211,16 +210,86 @@ export function AccountAnalyticsPreview({
             );
           })}
         </Box>
-      ) : (
+      ) : preview.subtitle ? (
         <Text fg={colors.textMuted} wrapText width={contentWidth}>
           {preview.subtitle}
         </Text>
-      )}
+      ) : null}
       {disclaimer ? (
         <Text fg={colors.textMuted} wrapText width={contentWidth}>
           {disclaimer}
         </Text>
       ) : null}
+    </Box>
+  );
+}
+
+export function PublicAnalyticsGroup({
+  preview,
+  label,
+  detail,
+  active,
+  width,
+  disclaimer,
+  onFocus,
+  onOpen,
+}: {
+  preview: ProfileAnalyticsPreview;
+  label: string;
+  detail?: string;
+  active: boolean;
+  width: number;
+  disclaimer?: string | null;
+  onFocus: () => void;
+  onOpen: () => void;
+}) {
+  const contentWidth = Math.max(1, width - 2);
+  const buttonWidth = Math.max(12, Math.min(34, Math.floor(contentWidth * 0.44)));
+  const detailWidth = Math.max(0, contentWidth - buttonWidth - 12);
+  const normalizedDetail = (detail ?? "").replace(/\.+$/, "");
+  const displayPreview = (
+    preview.metrics.length === 0
+    && normalizedDetail
+    && preview.subtitle.replace(/\.+$/, "") === normalizedDetail
+  ) ? { ...preview, subtitle: "" } : preview;
+  return (
+    <Box
+      flexDirection="column"
+      width={width}
+      backgroundColor={colors.panel}
+      paddingX={1}
+      onMouseOver={onFocus}
+    >
+      <Box height={1} flexDirection="row" gap={1}>
+        <Text fg={active ? colors.textBright : colors.textDim} attributes={active ? TextAttributes.BOLD : 0}>
+          {active ? "> Analytics" : "  Analytics"}
+        </Text>
+        <Box
+          width={buttonWidth}
+          backgroundColor={active ? colors.selected : colors.bg}
+          onMouseDown={(event?: { preventDefault?: () => void; stopPropagation?: () => void }) => {
+            event?.preventDefault?.();
+            event?.stopPropagation?.();
+            onFocus();
+            onOpen();
+          }}
+        >
+          <Text fg={active ? colors.selectedText : colors.text}>
+            {` ${truncate(label, Math.max(1, buttonWidth - 2))} `}
+          </Text>
+        </Box>
+        {detail ? (
+          <Text fg={colors.textMuted}>
+            {truncate(detail, detailWidth)}
+          </Text>
+        ) : null}
+      </Box>
+      <AccountAnalyticsPreview
+        preview={displayPreview}
+        width={contentWidth}
+        disclaimer={disclaimer}
+        surface="plain"
+      />
     </Box>
   );
 }

--- a/src/plugins/builtin/account-management/form-components.tsx
+++ b/src/plugins/builtin/account-management/form-components.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactNode } from "react";
 import { TextField } from "../../../components";
 import { Box, Text, TextAttributes } from "../../../ui";
 import { colors, hoverBg } from "../../../theme/colors";
-import type { AccountFieldKey } from "./model";
+import type { AccountFieldKey, ProfileAnalyticsPreview } from "./model";
 import { truncate } from "./model";
 
 export function AccountTextField({
@@ -153,6 +153,66 @@ export function CheckboxRow({
           {description}
         </Text>
       ) : null}
+    </Box>
+  );
+}
+
+function metricColor(tone: ProfileAnalyticsPreview["metrics"][number]["tone"]): string {
+  if (tone === "positive") return colors.positive;
+  if (tone === "negative") return colors.negative;
+  if (tone === "muted") return colors.textMuted;
+  return colors.text;
+}
+
+export function AccountAnalyticsPreview({
+  preview,
+  width,
+}: {
+  preview: ProfileAnalyticsPreview;
+  width: number;
+}) {
+  const metricWidth = Math.max(14, Math.min(24, Math.floor((width - 2) / 2)));
+  const subtitleWidth = Math.max(1, width - preview.title.length - 4);
+
+  return (
+    <Box flexDirection="column" width={width} backgroundColor={colors.panel} paddingX={1}>
+      <Box height={1} flexDirection="row">
+        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+          {truncate(preview.title, Math.max(1, width - 2))}
+        </Text>
+        {preview.subtitle ? (
+          <>
+            <Box flexGrow={1} />
+            <Text fg={colors.textMuted}>{truncate(preview.subtitle, subtitleWidth)}</Text>
+          </>
+        ) : null}
+      </Box>
+      {preview.metrics.length > 0 ? (
+        <Box flexDirection="row" flexWrap="wrap" gap={1}>
+          {preview.metrics.map((metric) => (
+            <Box key={metric.id} width={metricWidth} flexDirection="column">
+              <Text fg={colors.textDim}>{truncate(metric.label, metricWidth)}</Text>
+              <Box height={1} flexDirection="row">
+                <Text fg={metricColor(metric.tone)} attributes={TextAttributes.BOLD}>
+                  {truncate(metric.value, metricWidth)}
+                </Text>
+                {metric.detail ? (
+                  <>
+                    <Text fg={colors.textDim}>{" "}</Text>
+                    <Text fg={colors.textMuted}>
+                      {truncate(metric.detail, Math.max(0, metricWidth - metric.value.length - 1))}
+                    </Text>
+                  </>
+                ) : null}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      ) : (
+        <Text fg={colors.textMuted} wrapText width={Math.max(1, width - 2)}>
+          {preview.subtitle}
+        </Text>
+      )}
     </Box>
   );
 }

--- a/src/plugins/builtin/account-management/form-components.tsx
+++ b/src/plugins/builtin/account-management/form-components.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react";
-import { Checkbox, TextField } from "../../../components";
+import { Button, Checkbox, TextField } from "../../../components";
 import { Box, Text, TextAttributes } from "../../../ui";
 import { colors } from "../../../theme/colors";
 import type { AccountFieldKey, ProfileAnalyticsPreview } from "./model";
@@ -244,8 +244,10 @@ export function PublicAnalyticsGroup({
   onOpen: () => void;
 }) {
   const contentWidth = Math.max(1, width - 2);
-  const buttonWidth = Math.max(12, Math.min(34, Math.floor(contentWidth * 0.44)));
-  const detailWidth = Math.max(0, contentWidth - buttonWidth - 12);
+  const labelText = active ? "> Shared Portfolio:" : "  Shared Portfolio:";
+  const labelWidth = Math.min(labelText.length, Math.max(1, contentWidth));
+  const buttonWidth = Math.max(12, Math.min(24, Math.floor(contentWidth * 0.3)));
+  const detailWidth = Math.max(0, contentWidth - labelWidth - buttonWidth - 2);
   const normalizedDetail = (detail ?? "").replace(/\.+$/, "");
   const displayPreview = (
     preview.metrics.length === 0
@@ -262,22 +264,18 @@ export function PublicAnalyticsGroup({
     >
       <Box height={1} flexDirection="row" gap={1}>
         <Text fg={active ? colors.textBright : colors.textDim} attributes={active ? TextAttributes.BOLD : 0}>
-          {active ? "> Analytics" : "  Analytics"}
+          {truncate(labelText, labelWidth)}
         </Text>
-        <Box
+        <Button
+          label={truncate(label, Math.max(1, buttonWidth - 2))}
+          variant="primary"
           width={buttonWidth}
-          backgroundColor={active ? colors.selected : colors.bg}
-          onMouseDown={(event?: { preventDefault?: () => void; stopPropagation?: () => void }) => {
-            event?.preventDefault?.();
-            event?.stopPropagation?.();
+          active={active}
+          onPress={() => {
             onFocus();
             onOpen();
           }}
-        >
-          <Text fg={active ? colors.selectedText : colors.text}>
-            {` ${truncate(label, Math.max(1, buttonWidth - 2))} `}
-          </Text>
-        </Box>
+        />
         {detail ? (
           <Text fg={colors.textMuted}>
             {truncate(detail, detailWidth)}

--- a/src/plugins/builtin/account-management/form-components.tsx
+++ b/src/plugins/builtin/account-management/form-components.tsx
@@ -31,14 +31,30 @@ export function AccountTextField({
   onSubmit?: () => void;
 }) {
   const active = activeField === fieldKey;
+  const labelWidth = accountFieldLabelWidth(width);
+  const inputWidth = Math.max(8, width - labelWidth - 1);
+  const labelText = `${active ? "> " : "  "}${label}`;
   return (
-    <Box onMouseDown={() => onFocus(fieldKey)}>
+    <Box
+      height={1}
+      width={width}
+      flexDirection="row"
+      alignItems="center"
+      gap={1}
+      onMouseDown={() => onFocus(fieldKey)}
+    >
+      <Text
+        width={labelWidth}
+        fg={active ? colors.textBright : colors.textDim}
+        attributes={active ? TextAttributes.BOLD : 0}
+      >
+        {truncate(labelText, labelWidth)}
+      </Text>
       <TextField
-        label={`${active ? "> " : "  "}${label}`}
         value={value}
         placeholder={placeholder}
         focused={focused && active}
-        width={width}
+        width={inputWidth}
         type={type}
         onChange={onChange}
         onSubmit={onSubmit}
@@ -46,6 +62,11 @@ export function AccountTextField({
       />
     </Box>
   );
+}
+
+export function accountFieldLabelWidth(width: number) {
+  const preferred = Math.min(16, Math.max(14, Math.floor(width * 0.42)));
+  return Math.max(8, Math.min(preferred, width - 9));
 }
 
 export function FieldRow({
@@ -244,22 +265,23 @@ export function PublicAnalyticsGroup({
   onOpen: () => void;
 }) {
   const contentWidth = Math.max(1, width - 2);
-  const labelText = active ? "> Shared Portfolio:" : "  Shared Portfolio:";
+  const labelText = active ? "> Public Stats:" : "  Public Stats:";
   const labelWidth = Math.min(labelText.length, Math.max(1, contentWidth));
-  const buttonWidth = Math.max(12, Math.min(24, Math.floor(contentWidth * 0.3)));
-  const detailWidth = Math.max(0, contentWidth - labelWidth - buttonWidth - 2);
+  const buttonWidth = Math.max(12, Math.min(22, Math.floor(contentWidth * 0.28)));
   const normalizedDetail = (detail ?? "").replace(/\.+$/, "");
   const displayPreview = (
     preview.metrics.length === 0
     && normalizedDetail
     && preview.subtitle.replace(/\.+$/, "") === normalizedDetail
   ) ? { ...preview, subtitle: "" } : preview;
+  const metrics = displayPreview.metrics.slice(0, 2);
+  const metricAreaWidth = Math.max(0, contentWidth - labelWidth - buttonWidth - 2);
+  const metricWidth = metrics.length > 0 ? Math.max(8, Math.floor((metricAreaWidth - (metrics.length - 1)) / metrics.length)) : 0;
+  const detailWidth = Math.max(0, metricAreaWidth);
   return (
     <Box
       flexDirection="column"
       width={width}
-      backgroundColor={colors.panel}
-      paddingX={1}
       onMouseOver={onFocus}
     >
       <Box height={1} flexDirection="row" gap={1}>
@@ -276,18 +298,33 @@ export function PublicAnalyticsGroup({
             onOpen();
           }}
         />
-        {detail ? (
+        {metrics.length > 0 ? metrics.map((metric) => {
+          const labelTextWidth = Math.max(1, Math.min(metric.label.length, metricWidth - 2));
+          const valueWidth = Math.max(1, metricWidth - labelTextWidth - 1);
+          return (
+            <Box key={metric.id} width={metricWidth} height={1} flexDirection="row" gap={1}>
+              <Text fg={colors.textDim}>{truncate(metric.label, labelTextWidth)}</Text>
+              <Text fg={metricColor(metric.tone)} attributes={TextAttributes.BOLD}>
+                {truncate(metric.value, valueWidth)}
+              </Text>
+            </Box>
+          );
+        }) : detail ? (
           <Text fg={colors.textMuted}>
             {truncate(detail, detailWidth)}
           </Text>
         ) : null}
       </Box>
-      <AccountAnalyticsPreview
-        preview={displayPreview}
-        width={contentWidth}
-        disclaimer={disclaimer}
-        surface="plain"
-      />
+      {metrics.length === 0 && displayPreview.subtitle ? (
+        <Text fg={colors.textMuted} wrapText width={contentWidth}>
+          {displayPreview.subtitle}
+        </Text>
+      ) : null}
+      {disclaimer ? (
+        <Text fg={colors.textMuted} wrapText width={contentWidth}>
+          {disclaimer}
+        </Text>
+      ) : null}
     </Box>
   );
 }

--- a/src/plugins/builtin/account-management/form-components.tsx
+++ b/src/plugins/builtin/account-management/form-components.tsx
@@ -310,9 +310,12 @@ export function PublicAnalyticsGroup({
   const contentWidth = Math.max(1, width - 2);
   const labelText = active ? "> Public Stats:" : "  Public Stats:";
   const labelWidth = Math.min(accountFieldLabelWidth(width), Math.max(1, contentWidth));
-  const buttonWidth = Math.max(14, Math.min(24, Math.floor(contentWidth * 0.3)));
-  const buttonLabel = truncate(label, Math.max(1, buttonWidth - 4));
-  const nativeSelectWidth = buttonWidth * 8;
+  const nativeButtonWidth = Math.max(14, Math.min(24, Math.floor(contentWidth * 0.3)));
+  const terminalMaxButtonWidth = Math.max(8, Math.min(24, contentWidth - labelWidth - 1));
+  const buttonLabel = truncate(label, Math.max(1, terminalMaxButtonWidth - 4));
+  const buttonWidth = buttonLabel.length + 4;
+  const layoutButtonWidth = isDesktop ? nativeButtonWidth : buttonWidth;
+  const nativeSelectWidth = nativeButtonWidth * 8;
   const normalizedDetail = (detail ?? "").replace(/\.+$/, "");
   const displayPreview = (
     preview.metrics.length === 0
@@ -320,7 +323,7 @@ export function PublicAnalyticsGroup({
     && preview.subtitle.replace(/\.+$/, "") === normalizedDetail
   ) ? { ...preview, subtitle: "" } : preview;
   const metrics = displayPreview.metrics.slice(0, 2);
-  const metricAreaWidth = Math.max(0, contentWidth - labelWidth - buttonWidth - 2);
+  const metricAreaWidth = Math.max(0, contentWidth - labelWidth - layoutButtonWidth - 2);
   const metricWidth = metrics.length > 0 ? Math.max(8, Math.floor((metricAreaWidth - (metrics.length - 1)) / metrics.length)) : 0;
   const detailWidth = Math.max(0, metricAreaWidth);
   return (

--- a/src/plugins/builtin/account-management/form-components.tsx
+++ b/src/plugins/builtin/account-management/form-components.tsx
@@ -65,7 +65,7 @@ export function AccountTextField({
 }
 
 export function accountFieldLabelWidth(width: number) {
-  const preferred = Math.min(16, Math.max(14, Math.floor(width * 0.42)));
+  const preferred = width >= 28 ? 16 : Math.max(10, Math.floor(width * 0.42));
   return Math.max(8, Math.min(preferred, width - 9));
 }
 
@@ -148,20 +148,50 @@ export function CheckboxRow({
   onFocus: () => void;
   onChange: (checked: boolean) => void;
 }) {
+  const labelWidth = accountFieldLabelWidth(width);
+  const controlWidth = Math.max(8, width - labelWidth - 1);
+  const labelText = `${active ? "> " : "  "}${label}`;
   return (
-    <Box onMouseOver={onFocus}>
-      <Checkbox
-        label={label}
-        checked={checked}
-        active={active}
-        description={description}
-        width={width}
-        variant="desktop"
-        onChange={(nextChecked) => {
-          onFocus();
-          onChange(nextChecked);
-        }}
-      />
+    <Box
+      flexDirection="column"
+      width={width}
+      onMouseOver={onFocus}
+      onMouseDown={(event?: { preventDefault?: () => void; stopPropagation?: () => void }) => {
+        event?.preventDefault?.();
+        event?.stopPropagation?.();
+        onFocus();
+        onChange(!checked);
+      }}
+    >
+      <Box height={1} flexDirection="row" alignItems="center" gap={1}>
+        <Text
+          width={labelWidth}
+          fg={active ? colors.textBright : colors.textDim}
+          attributes={active ? TextAttributes.BOLD : 0}
+        >
+          {truncate(labelText, labelWidth)}
+        </Text>
+        <Checkbox
+          label={label}
+          displayLabel={checked ? "On" : "Off"}
+          checked={checked}
+          active={false}
+          width={controlWidth}
+          variant="desktop"
+          onChange={(nextChecked) => {
+            onFocus();
+            onChange(nextChecked);
+          }}
+        />
+      </Box>
+      {description ? (
+        <Box height={1} flexDirection="row" gap={1}>
+          <Box width={labelWidth} />
+          <Text fg={colors.textMuted} wrapText width={controlWidth}>
+            {description}
+          </Text>
+        </Box>
+      ) : null}
     </Box>
   );
 }
@@ -266,8 +296,9 @@ export function PublicAnalyticsGroup({
 }) {
   const contentWidth = Math.max(1, width - 2);
   const labelText = active ? "> Public Stats:" : "  Public Stats:";
-  const labelWidth = Math.min(labelText.length, Math.max(1, contentWidth));
-  const buttonWidth = Math.max(12, Math.min(22, Math.floor(contentWidth * 0.28)));
+  const labelWidth = Math.min(accountFieldLabelWidth(width), Math.max(1, contentWidth));
+  const buttonWidth = Math.max(14, Math.min(24, Math.floor(contentWidth * 0.3)));
+  const selectLabel = `${label} v`;
   const normalizedDetail = (detail ?? "").replace(/\.+$/, "");
   const displayPreview = (
     preview.metrics.length === 0
@@ -289,8 +320,8 @@ export function PublicAnalyticsGroup({
           {truncate(labelText, labelWidth)}
         </Text>
         <Button
-          label={truncate(label, Math.max(1, buttonWidth - 2))}
-          variant="primary"
+          label={truncate(selectLabel, Math.max(1, buttonWidth - 2))}
+          variant="secondary"
           width={buttonWidth}
           active={active}
           onPress={() => {

--- a/src/plugins/builtin/account-management/form-components.tsx
+++ b/src/plugins/builtin/account-management/form-components.tsx
@@ -167,18 +167,21 @@ function metricColor(tone: ProfileAnalyticsPreview["metrics"][number]["tone"]): 
 export function AccountAnalyticsPreview({
   preview,
   width,
+  disclaimer,
 }: {
   preview: ProfileAnalyticsPreview;
   width: number;
+  disclaimer?: string | null;
 }) {
-  const metricWidth = Math.max(14, Math.min(24, Math.floor((width - 2) / 2)));
-  const subtitleWidth = Math.max(1, width - preview.title.length - 4);
+  const contentWidth = Math.max(1, width - 2);
+  const metricWidth = Math.max(14, Math.min(28, Math.floor((contentWidth - 2) / 2)));
+  const subtitleWidth = Math.max(1, contentWidth - preview.title.length - 2);
 
   return (
     <Box flexDirection="column" width={width} backgroundColor={colors.panel} paddingX={1}>
       <Box height={1} flexDirection="row">
         <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-          {truncate(preview.title, Math.max(1, width - 2))}
+          {truncate(preview.title, contentWidth)}
         </Text>
         {preview.subtitle ? (
           <>
@@ -188,31 +191,36 @@ export function AccountAnalyticsPreview({
         ) : null}
       </Box>
       {preview.metrics.length > 0 ? (
-        <Box flexDirection="row" flexWrap="wrap" gap={1}>
-          {preview.metrics.map((metric) => (
-            <Box key={metric.id} width={metricWidth} flexDirection="column">
-              <Text fg={colors.textDim}>{truncate(metric.label, metricWidth)}</Text>
-              <Box height={1} flexDirection="row">
+        <Box flexDirection="row" flexWrap="wrap" gap={2}>
+          {preview.metrics.map((metric) => {
+            const labelWidth = Math.max(1, Math.min(metric.label.length, metricWidth - 2));
+            const valueWidth = Math.max(1, metricWidth - labelWidth - 1);
+            const detailWidth = Math.max(0, metricWidth - labelWidth - metric.value.length - 2);
+            return (
+              <Box key={metric.id} width={metricWidth} height={1} flexDirection="row" gap={1}>
+                <Text fg={colors.textDim}>{truncate(metric.label, labelWidth)}</Text>
                 <Text fg={metricColor(metric.tone)} attributes={TextAttributes.BOLD}>
-                  {truncate(metric.value, metricWidth)}
+                  {truncate(metric.value, valueWidth)}
                 </Text>
                 {metric.detail ? (
-                  <>
-                    <Text fg={colors.textDim}>{" "}</Text>
-                    <Text fg={colors.textMuted}>
-                      {truncate(metric.detail, Math.max(0, metricWidth - metric.value.length - 1))}
-                    </Text>
-                  </>
+                  <Text fg={colors.textMuted}>
+                    {truncate(metric.detail, detailWidth)}
+                  </Text>
                 ) : null}
               </Box>
-            </Box>
-          ))}
+            );
+          })}
         </Box>
       ) : (
-        <Text fg={colors.textMuted} wrapText width={Math.max(1, width - 2)}>
+        <Text fg={colors.textMuted} wrapText width={contentWidth}>
           {preview.subtitle}
         </Text>
       )}
+      {disclaimer ? (
+        <Text fg={colors.textMuted} wrapText width={contentWidth}>
+          {disclaimer}
+        </Text>
+      ) : null}
     </Box>
   );
 }

--- a/src/plugins/builtin/account-management/keyboard.ts
+++ b/src/plugins/builtin/account-management/keyboard.ts
@@ -59,12 +59,6 @@ export function useAccountManagementKeyboard({
       setDraftValue("acceptUnknownDms", !draftRef.current.acceptUnknownDms);
       return;
     }
-    if (!event.targetEditable && activeField === "syncEnabled" && isPlainKey(event, "space", "enter", "return")) {
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      setDraftValue("syncEnabled", !draftRef.current.syncEnabled);
-      return;
-    }
     if (!event.targetEditable && activeField === "weeklyRoundupEnabled" && isPlainKey(event, "space", "enter", "return")) {
       event.preventDefault?.();
       event.stopPropagation?.();

--- a/src/plugins/builtin/account-management/keyboard.ts
+++ b/src/plugins/builtin/account-management/keyboard.ts
@@ -12,6 +12,7 @@ export function useAccountManagementKeyboard({
   openPortfolioDialog,
   saveProfile,
   setDraftValue,
+  turnOffEmailAlerts,
 }: {
   activeField: AccountFieldKey;
   cycleField: (delta: number) => void;
@@ -22,6 +23,7 @@ export function useAccountManagementKeyboard({
   openPortfolioDialog: () => Promise<void>;
   saveProfile: () => Promise<void>;
   setDraftValue: <K extends keyof AccountDraft>(key: K, value: AccountDraft[K]) => void;
+  turnOffEmailAlerts: () => Promise<void>;
 }) {
   useShortcut((event) => {
     if (!focused) return;
@@ -57,6 +59,24 @@ export function useAccountManagementKeyboard({
       setDraftValue("acceptUnknownDms", !draftRef.current.acceptUnknownDms);
       return;
     }
+    if (!event.targetEditable && activeField === "syncEnabled" && isPlainKey(event, "space", "enter", "return")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      setDraftValue("syncEnabled", !draftRef.current.syncEnabled);
+      return;
+    }
+    if (!event.targetEditable && activeField === "weeklyRoundupEnabled" && isPlainKey(event, "space", "enter", "return")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      setDraftValue("weeklyRoundupEnabled", !draftRef.current.weeklyRoundupEnabled);
+      return;
+    }
+    if (!event.targetEditable && activeField === "positionAlertsEnabled" && isPlainKey(event, "space", "enter", "return")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      setDraftValue("positionAlertsEnabled", !draftRef.current.positionAlertsEnabled);
+      return;
+    }
     if (!event.targetEditable && activeField === "sharedPortfolioId" && isPlainKey(event, "left", "h", "[")) {
       event.preventDefault?.();
       event.stopPropagation?.();
@@ -79,6 +99,12 @@ export function useAccountManagementKeyboard({
       event.preventDefault?.();
       event.stopPropagation?.();
       openPasswordDialog();
+      return;
+    }
+    if (!event.targetEditable && activeField === "emailAlertsOffAction" && isPlainKey(event, "space", "enter", "return")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      void turnOffEmailAlerts();
       return;
     }
     if (!event.targetEditable && event.name === "p") {

--- a/src/plugins/builtin/account-management/keyboard.ts
+++ b/src/plugins/builtin/account-management/keyboard.ts
@@ -10,8 +10,10 @@ export function useAccountManagementKeyboard({
   focused,
   openPasswordDialog,
   openPortfolioDialog,
+  openUpgrade,
   saveProfile,
   setDraftValue,
+  deleteAccount,
   turnOffEmailAlerts,
 }: {
   activeField: AccountFieldKey;
@@ -21,8 +23,10 @@ export function useAccountManagementKeyboard({
   focused: boolean;
   openPasswordDialog: () => void;
   openPortfolioDialog: () => Promise<void>;
+  openUpgrade: () => void;
   saveProfile: () => Promise<void>;
   setDraftValue: <K extends keyof AccountDraft>(key: K, value: AccountDraft[K]) => void;
+  deleteAccount: () => Promise<void>;
   turnOffEmailAlerts: () => Promise<void>;
 }) {
   useShortcut((event) => {
@@ -95,16 +99,22 @@ export function useAccountManagementKeyboard({
       openPasswordDialog();
       return;
     }
+    if (!event.targetEditable && activeField === "upgradeAction" && isPlainKey(event, "space", "enter", "return")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      openUpgrade();
+      return;
+    }
+    if (!event.targetEditable && activeField === "deleteAccountAction" && isPlainKey(event, "space", "enter", "return")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      void deleteAccount();
+      return;
+    }
     if (!event.targetEditable && activeField === "emailAlertsOffAction" && isPlainKey(event, "space", "enter", "return")) {
       event.preventDefault?.();
       event.stopPropagation?.();
       void turnOffEmailAlerts();
-      return;
-    }
-    if (!event.targetEditable && event.name === "p") {
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      openPasswordDialog();
     }
   }, { allowEditable: true });
 }

--- a/src/plugins/builtin/account-management/model.test.ts
+++ b/src/plugins/builtin/account-management/model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { Portfolio, TickerRecord } from "../../../types/ticker";
 import {
+  buildPublishedProfileAnalyticsPreview,
   buildPortfolioChoices,
   buildProfileAnalyticsPreview,
   computeCumulativeReturn,
@@ -103,5 +104,46 @@ describe("account management model", () => {
       oneYearReturn: 0.1,
       spyBeta: 1.1,
     });
+  });
+
+  test("builds the visible profile analytics card from published account data", () => {
+    const portfolio: Portfolio = { id: "main", name: "Main Portfolio", currency: "USD" };
+    const preview = buildPublishedProfileAnalyticsPreview({
+      analytics: { oneYearReturn: 0.15, spyBeta: 1.25 },
+      draftProfilePublic: true,
+      portfolio,
+      profileLoaded: true,
+      savedProfilePublic: true,
+      savedSharedPortfolioId: "main",
+      selectedPortfolioId: "main",
+      syncing: false,
+    });
+
+    expect(preview.status).toBe("ready");
+    expect(preview.title).toBe("Main Portfolio");
+    expect(preview.metrics).toEqual([
+      { id: "one-year", label: "1Y", value: "+15.00%", tone: "positive" },
+      { id: "beta", label: "SPY Beta", value: "1.25" },
+    ]);
+    expect(preview.publicAnalytics).toEqual({ oneYearReturn: 0.15, spyBeta: 1.25 });
+  });
+
+  test("does not show stale published analytics when the selected profile portfolio is unsaved", () => {
+    const portfolio: Portfolio = { id: "new", name: "New Portfolio", currency: "USD" };
+    const preview = buildPublishedProfileAnalyticsPreview({
+      analytics: { oneYearReturn: 0.15, spyBeta: 1.25 },
+      draftProfilePublic: true,
+      portfolio,
+      profileLoaded: true,
+      savedProfilePublic: true,
+      savedSharedPortfolioId: "old",
+      selectedPortfolioId: "new",
+      syncing: false,
+    });
+
+    expect(preview.status).toBe("pending");
+    expect(preview.metrics).toEqual([]);
+    expect(preview.subtitle).toBe("Save profile to update published metrics.");
+    expect(preview.publicAnalytics).toBeNull();
   });
 });

--- a/src/plugins/builtin/account-management/model.test.ts
+++ b/src/plugins/builtin/account-management/model.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, test } from "bun:test";
+import type { TickerFinancials } from "../../../types/financials";
+import type { AppConfig } from "../../../types/config";
 import type { Portfolio, TickerRecord } from "../../../types/ticker";
-import { buildPortfolioChoices, countPortfolioHoldings, NO_PORTFOLIO_VALUE } from "./model";
+import {
+  buildPortfolioChoices,
+  buildProfileAnalyticsPreview,
+  computeCumulativeReturn,
+  countPortfolioHoldings,
+  getPortfolioPositionTickers,
+  NO_PORTFOLIO_VALUE,
+} from "./model";
 
-function makeTicker(symbol: string, portfolios: string[]): TickerRecord {
+function makeTicker(symbol: string, portfolios: string[], positionedPortfolios: string[] = []): TickerRecord {
   return {
     metadata: {
       ticker: symbol,
@@ -11,10 +20,33 @@ function makeTicker(symbol: string, portfolios: string[]): TickerRecord {
       name: symbol,
       portfolios,
       watchlists: [],
-      positions: [],
+      positions: positionedPortfolios.map((portfolio) => ({
+        portfolio,
+        shares: 10,
+        avgCost: 90,
+        currency: "USD",
+        broker: "manual",
+      })),
       custom: {},
       tags: [],
     },
+  };
+}
+
+function makeFinancials(symbol: string): TickerFinancials {
+  return {
+    quote: {
+      symbol,
+      price: 100,
+      currency: "USD",
+      change: 2,
+      changePercent: 2,
+      previousClose: 98,
+      lastUpdated: Date.now(),
+    },
+    annualStatements: [],
+    quarterlyStatements: [],
+    priceHistory: [],
   };
 }
 
@@ -47,8 +79,56 @@ describe("account management model", () => {
         id: "main",
         label: "Main Portfolio",
         detail: "2 tickers",
-        description: "Shares this portfolio's YTD % and SPY Beta on your public profile.",
+        description: "Shares this portfolio's 1Y return and SPY Beta on your public profile.",
       },
     ]);
+  });
+
+  test("filters shared analytics tickers by actual portfolio positions", () => {
+    const tickers = new Map([
+      ["AAPL", makeTicker("AAPL", ["main"], ["main"])],
+      ["MSFT", makeTicker("MSFT", ["main"], [])],
+      ["NVDA", makeTicker("NVDA", ["other"], ["other"])],
+    ]);
+
+    expect(getPortfolioPositionTickers(tickers, "main").map((ticker) => ticker.metadata.ticker)).toEqual(["AAPL"]);
+  });
+
+  test("compounds the selected one-year return series", () => {
+    expect(computeCumulativeReturn([
+      { dateKey: "2025-06-01", value: 0.1 },
+      { dateKey: "2025-06-02", value: 0.05 },
+      { dateKey: "2025-06-03", value: -0.02 },
+    ])).toBeCloseTo(0.1319, 5);
+  });
+
+  test("builds a real public analytics preview snapshot", () => {
+    const portfolio: Portfolio = { id: "main", name: "Main Portfolio", currency: "USD" };
+    const ticker = makeTicker("AAPL", ["main"], ["main"]);
+    const preview = buildProfileAnalyticsPreview({
+      accountState: null,
+      baseCurrency: "USD",
+      beta: 1.1,
+      config: { baseCurrency: "USD" } as AppConfig,
+      exchangeRates: new Map(),
+      financials: new Map([["AAPL", makeFinancials("AAPL")]]),
+      portfolio,
+      portfolioTickers: [ticker],
+      selectedPortfolioId: "main",
+      oneYearReturn: 0.1,
+    });
+
+    expect(preview.status).toBe("ready");
+    expect(preview.metrics[0]).toMatchObject({ label: "1Y", value: "+10.00%", tone: "positive" });
+    expect(preview.metrics[1]).toMatchObject({ label: "SPY Beta", value: "1.10" });
+    expect(preview.metrics[2]).toMatchObject({ label: "Value", value: "1k USD" });
+    expect(preview.publicAnalytics).toMatchObject({
+      portfolioName: "Main Portfolio",
+      holdingsCount: 1,
+      oneYearReturn: 0.1,
+      spyBeta: 1.1,
+      marketValue: 1000,
+      currency: "USD",
+    });
   });
 });

--- a/src/plugins/builtin/account-management/model.test.ts
+++ b/src/plugins/builtin/account-management/model.test.ts
@@ -1,6 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import type { TickerFinancials } from "../../../types/financials";
-import type { AppConfig } from "../../../types/config";
 import type { Portfolio, TickerRecord } from "../../../types/ticker";
 import {
   buildPortfolioChoices,
@@ -30,23 +28,6 @@ function makeTicker(symbol: string, portfolios: string[], positionedPortfolios: 
       custom: {},
       tags: [],
     },
-  };
-}
-
-function makeFinancials(symbol: string): TickerFinancials {
-  return {
-    quote: {
-      symbol,
-      price: 100,
-      currency: "USD",
-      change: 2,
-      changePercent: 2,
-      previousClose: 98,
-      lastUpdated: Date.now(),
-    },
-    annualStatements: [],
-    quarterlyStatements: [],
-    priceHistory: [],
   };
 }
 
@@ -106,12 +87,7 @@ describe("account management model", () => {
     const portfolio: Portfolio = { id: "main", name: "Main Portfolio", currency: "USD" };
     const ticker = makeTicker("AAPL", ["main"], ["main"]);
     const preview = buildProfileAnalyticsPreview({
-      accountState: null,
-      baseCurrency: "USD",
       beta: 1.1,
-      config: { baseCurrency: "USD" } as AppConfig,
-      exchangeRates: new Map(),
-      financials: new Map([["AAPL", makeFinancials("AAPL")]]),
       portfolio,
       portfolioTickers: [ticker],
       selectedPortfolioId: "main",
@@ -119,16 +95,13 @@ describe("account management model", () => {
     });
 
     expect(preview.status).toBe("ready");
+    expect(preview.subtitle).toBe("");
+    expect(preview.metrics).toHaveLength(2);
     expect(preview.metrics[0]).toMatchObject({ label: "1Y", value: "+10.00%", tone: "positive" });
     expect(preview.metrics[1]).toMatchObject({ label: "SPY Beta", value: "1.10" });
-    expect(preview.metrics[2]).toMatchObject({ label: "Value", value: "1k USD" });
-    expect(preview.publicAnalytics).toMatchObject({
-      portfolioName: "Main Portfolio",
-      holdingsCount: 1,
+    expect(preview.publicAnalytics).toEqual({
       oneYearReturn: 0.1,
       spyBeta: 1.1,
-      marketValue: 1000,
-      currency: "USD",
     });
   });
 });

--- a/src/plugins/builtin/account-management/model.ts
+++ b/src/plugins/builtin/account-management/model.ts
@@ -14,7 +14,6 @@ export type AccountFieldKey =
   | "xAccount"
   | "acceptUnknownDms"
   | "sharedPortfolioId"
-  | "syncEnabled"
   | "weeklyRoundupEnabled"
   | "positionAlertsEnabled"
   | "emailAlertsOffAction"
@@ -31,7 +30,6 @@ export interface AccountDraft {
   xAccount: string;
   sharedPortfolioId: string;
   acceptUnknownDms: boolean;
-  syncEnabled: boolean;
   weeklyRoundupEnabled: boolean;
   positionAlertsEnabled: boolean;
 }
@@ -63,7 +61,6 @@ export const BASE_FIELD_ORDER: AccountFieldKey[] = [
   "xAccount",
   "acceptUnknownDms",
   "sharedPortfolioId",
-  "syncEnabled",
   "weeklyRoundupEnabled",
   "positionAlertsEnabled",
   "emailAlertsOffAction",
@@ -84,7 +81,6 @@ export function profileToDraft(profile: AccountProfile | null): AccountDraft {
     xAccount: profile?.xAccount ?? "",
     sharedPortfolioId: profile?.sharedPortfolioId ?? "",
     acceptUnknownDms: profile?.acceptUnknownDms === true,
-    syncEnabled: profile?.syncEnabled === false ? false : true,
     weeklyRoundupEnabled: profile?.weeklyRoundupEnabled === false ? false : true,
     positionAlertsEnabled: profile?.positionAlertsEnabled === false ? false : true,
   };

--- a/src/plugins/builtin/account-management/model.ts
+++ b/src/plugins/builtin/account-management/model.ts
@@ -45,7 +45,7 @@ export interface ProfileAnalyticsPreviewMetric {
 }
 
 export interface ProfileAnalyticsPreview {
-  status: "off" | "missing" | "empty" | "ready";
+  status: "off" | "missing" | "empty" | "pending" | "ready";
   title: string;
   subtitle: string;
   metrics: ProfileAnalyticsPreviewMetric[];
@@ -153,6 +153,34 @@ function finiteMetric(value: number | null | undefined): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+function normalizePublicAnalytics(analytics: PublicPortfolioAnalytics | null | undefined): PublicPortfolioAnalytics | null {
+  const normalized: PublicPortfolioAnalytics = {
+    oneYearReturn: finiteMetric(analytics?.oneYearReturn),
+    spyBeta: finiteMetric(analytics?.spyBeta),
+  };
+  return normalized.oneYearReturn != null || normalized.spyBeta != null ? normalized : null;
+}
+
+function buildPublicAnalyticsMetrics(analytics: PublicPortfolioAnalytics): ProfileAnalyticsPreviewMetric[] {
+  const metrics: ProfileAnalyticsPreviewMetric[] = [];
+  if (analytics.oneYearReturn != null) {
+    metrics.push({
+      id: "one-year",
+      label: "1Y",
+      value: signedReturn(analytics.oneYearReturn),
+      tone: signedTone(analytics.oneYearReturn),
+    });
+  }
+  if (analytics.spyBeta != null) {
+    metrics.push({
+      id: "beta",
+      label: "SPY Beta",
+      value: formatNumber(analytics.spyBeta, 2),
+    });
+  }
+  return metrics;
+}
+
 export function getPortfolioPositionTickers(
   tickers: ReadonlyMap<string, TickerRecord>,
   portfolioId: string,
@@ -246,5 +274,94 @@ export function buildProfileAnalyticsPreview({
         tone: beta == null ? "muted" : undefined,
       },
     ],
+  };
+}
+
+export function buildPublishedProfileAnalyticsPreview({
+  analytics,
+  draftProfilePublic,
+  portfolio,
+  profileLoaded,
+  savedProfilePublic,
+  savedSharedPortfolioId,
+  selectedPortfolioId,
+  syncing,
+}: {
+  analytics: PublicPortfolioAnalytics | null | undefined;
+  draftProfilePublic: boolean;
+  portfolio: Portfolio | null;
+  profileLoaded: boolean;
+  savedProfilePublic: boolean;
+  savedSharedPortfolioId: string;
+  selectedPortfolioId: string;
+  syncing: boolean;
+}): ProfileAnalyticsPreview {
+  if (!selectedPortfolioId) {
+    return {
+      status: "off",
+      title: "No public portfolio analytics",
+      subtitle: "Choose a portfolio to publish 1Y return and SPY Beta.",
+      metrics: [],
+      publicAnalytics: null,
+    };
+  }
+
+  if (!portfolio) {
+    return {
+      status: "missing",
+      title: "Portfolio not found",
+      subtitle: selectedPortfolioId,
+      metrics: [],
+      publicAnalytics: null,
+    };
+  }
+
+  if (!profileLoaded) {
+    return {
+      status: "pending",
+      title: portfolio.name,
+      subtitle: "Loading published metrics.",
+      metrics: [],
+      publicAnalytics: null,
+    };
+  }
+
+  if (draftProfilePublic !== savedProfilePublic || selectedPortfolioId !== savedSharedPortfolioId) {
+    return {
+      status: "pending",
+      title: portfolio.name,
+      subtitle: "Save profile to update published metrics.",
+      metrics: [],
+      publicAnalytics: null,
+    };
+  }
+
+  if (!savedProfilePublic) {
+    return {
+      status: "off",
+      title: "No public portfolio analytics",
+      subtitle: "Public profile is off.",
+      metrics: [],
+      publicAnalytics: null,
+    };
+  }
+
+  const publicAnalytics = normalizePublicAnalytics(analytics);
+  if (!publicAnalytics) {
+    return {
+      status: "pending",
+      title: portfolio.name,
+      subtitle: syncing ? "Syncing published metrics." : "Waiting for published metrics.",
+      metrics: [],
+      publicAnalytics: null,
+    };
+  }
+
+  return {
+    status: "ready",
+    title: portfolio.name,
+    subtitle: "",
+    metrics: buildPublicAnalyticsMetrics(publicAnalytics),
+    publicAnalytics,
   };
 }

--- a/src/plugins/builtin/account-management/model.ts
+++ b/src/plugins/builtin/account-management/model.ts
@@ -17,7 +17,9 @@ export type AccountFieldKey =
   | "weeklyRoundupEnabled"
   | "positionAlertsEnabled"
   | "emailAlertsOffAction"
-  | "passwordAction";
+  | "upgradeAction"
+  | "passwordAction"
+  | "deleteAccountAction";
 
 export interface AccountDraft {
   username: string;
@@ -64,7 +66,9 @@ export const BASE_FIELD_ORDER: AccountFieldKey[] = [
   "weeklyRoundupEnabled",
   "positionAlertsEnabled",
   "emailAlertsOffAction",
+  "upgradeAction",
   "passwordAction",
+  "deleteAccountAction",
 ];
 
 export const NO_PORTFOLIO_VALUE = "__none__";

--- a/src/plugins/builtin/account-management/model.ts
+++ b/src/plugins/builtin/account-management/model.ts
@@ -1,6 +1,12 @@
 import type { ChoiceDialogChoice } from "../../../components";
-import type { AccountProfile } from "../../../api-client";
+import type { AccountProfile, PublicPortfolioAnalytics } from "../../../api-client";
+import { calculatePortfolioSummaryTotals } from "../portfolio-list/metrics";
+import { resolvePortfolioAccountMetrics, resolvePortfolioMarketValue } from "../portfolio-list/account-metrics";
+import type { ResolvedPortfolioAccountState } from "../portfolio-list/summary";
+import type { AppConfig } from "../../../types/config";
+import type { TickerFinancials } from "../../../types/financials";
 import type { Portfolio, TickerRecord } from "../../../types/ticker";
+import { formatCompact, formatNumber, formatPercentRaw } from "../../../utils/format";
 
 export type AccountFieldKey =
   | "username"
@@ -13,6 +19,10 @@ export type AccountFieldKey =
   | "xAccount"
   | "acceptUnknownDms"
   | "sharedPortfolioId"
+  | "syncEnabled"
+  | "weeklyRoundupEnabled"
+  | "positionAlertsEnabled"
+  | "emailAlertsOffAction"
   | "passwordAction";
 
 export interface AccountDraft {
@@ -26,6 +36,25 @@ export interface AccountDraft {
   xAccount: string;
   sharedPortfolioId: string;
   acceptUnknownDms: boolean;
+  syncEnabled: boolean;
+  weeklyRoundupEnabled: boolean;
+  positionAlertsEnabled: boolean;
+}
+
+export interface ProfileAnalyticsPreviewMetric {
+  id: string;
+  label: string;
+  value: string;
+  detail?: string;
+  tone?: "positive" | "negative" | "muted";
+}
+
+export interface ProfileAnalyticsPreview {
+  status: "off" | "missing" | "empty" | "ready";
+  title: string;
+  subtitle: string;
+  metrics: ProfileAnalyticsPreviewMetric[];
+  publicAnalytics: PublicPortfolioAnalytics | null;
 }
 
 export const BASE_FIELD_ORDER: AccountFieldKey[] = [
@@ -39,6 +68,10 @@ export const BASE_FIELD_ORDER: AccountFieldKey[] = [
   "xAccount",
   "acceptUnknownDms",
   "sharedPortfolioId",
+  "syncEnabled",
+  "weeklyRoundupEnabled",
+  "positionAlertsEnabled",
+  "emailAlertsOffAction",
   "passwordAction",
 ];
 
@@ -56,6 +89,9 @@ export function profileToDraft(profile: AccountProfile | null): AccountDraft {
     xAccount: profile?.xAccount ?? "",
     sharedPortfolioId: profile?.sharedPortfolioId ?? "",
     acceptUnknownDms: profile?.acceptUnknownDms === true,
+    syncEnabled: profile?.syncEnabled === false ? false : true,
+    weeklyRoundupEnabled: profile?.weeklyRoundupEnabled === false ? false : true,
+    positionAlertsEnabled: profile?.positionAlertsEnabled === false ? false : true,
   };
 }
 
@@ -92,7 +128,7 @@ export function buildPortfolioChoices(portfolios: Portfolio[], holdingCounts: Re
       id: portfolio.id,
       label: portfolio.name,
       detail: `${holdingCounts[portfolio.id] ?? 0} tickers`,
-      description: "Shares this portfolio's YTD % and SPY Beta on your public profile.",
+      description: "Shares this portfolio's 1Y return and SPY Beta on your public profile.",
     })),
   ];
 }
@@ -104,4 +140,166 @@ export function portfolioOptionIds(portfolios: Portfolio[]): string[] {
 export function selectedPortfolioLabel(portfolios: Portfolio[], value: string): string {
   if (!value) return "None";
   return portfolios.find((portfolio) => portfolio.id === value)?.name ?? value;
+}
+
+function signedCompact(value: number): string {
+  return `${value >= 0 ? "+" : ""}${formatCompact(value)}`;
+}
+
+function signedReturn(value: number): string {
+  const percent = value * 100;
+  return `${percent >= 0 ? "+" : ""}${formatNumber(percent, 2)}%`;
+}
+
+function signedTone(value: number | null | undefined): ProfileAnalyticsPreviewMetric["tone"] {
+  if (value == null || !Number.isFinite(value)) return "muted";
+  if (value > 0) return "positive";
+  if (value < 0) return "negative";
+  return "muted";
+}
+
+function finiteMetric(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function getPortfolioPositionTickers(
+  tickers: ReadonlyMap<string, TickerRecord>,
+  portfolioId: string,
+): TickerRecord[] {
+  return [...tickers.values()].filter((ticker) => (
+    ticker.metadata.positions.some((position) => position.portfolio === portfolioId)
+  ));
+}
+
+export function computeCumulativeReturn(
+  returns: Array<{ dateKey: string; value: number }>,
+  options?: { sinceDateKey?: string },
+): number | null {
+  const filtered = options?.sinceDateKey
+    ? returns.filter((point) => point.dateKey >= options.sinceDateKey!)
+    : returns;
+  if (filtered.length === 0) return null;
+  const value = filtered.reduce((acc, point) => (
+    Number.isFinite(point.value) ? acc * (1 + point.value) : acc
+  ), 1) - 1;
+  return Number.isFinite(value) ? value : null;
+}
+
+export function buildProfileAnalyticsPreview({
+  accountState,
+  baseCurrency,
+  beta,
+  config,
+  exchangeRates,
+  financials,
+  portfolio,
+  portfolioTickers,
+  selectedPortfolioId,
+  oneYearReturn,
+}: {
+  accountState: ResolvedPortfolioAccountState | null;
+  baseCurrency: string;
+  beta: number | null;
+  config: AppConfig;
+  exchangeRates: Map<string, number>;
+  financials: Map<string, TickerFinancials>;
+  portfolio: Portfolio | null;
+  portfolioTickers: TickerRecord[];
+  selectedPortfolioId: string;
+  oneYearReturn: number | null;
+}): ProfileAnalyticsPreview {
+  if (!selectedPortfolioId) {
+    return {
+      status: "off",
+      title: "No public portfolio analytics",
+      subtitle: "Choose a portfolio to preview the public profile metrics.",
+      metrics: [],
+      publicAnalytics: null,
+    };
+  }
+
+  if (!portfolio) {
+    return {
+      status: "missing",
+      title: "Portfolio not found",
+      subtitle: selectedPortfolioId,
+      metrics: [],
+      publicAnalytics: null,
+    };
+  }
+
+  if (portfolioTickers.length === 0) {
+    return {
+      status: "empty",
+      title: portfolio.name,
+      subtitle: "No positions to preview yet.",
+      metrics: [],
+      publicAnalytics: null,
+    };
+  }
+
+  const totals = calculatePortfolioSummaryTotals(
+    portfolioTickers,
+    financials,
+    baseCurrency,
+    exchangeRates,
+    true,
+    portfolio.id,
+  );
+  const accountMetrics = resolvePortfolioAccountMetrics(totals, accountState?.account);
+  const marketValue = resolvePortfolioMarketValue(totals, accountState?.account);
+  const currency = portfolio.currency || config.baseCurrency;
+  const sourceLabel = accountState?.sourceLabel ?? null;
+  const publicAnalytics: PublicPortfolioAnalytics = {
+    portfolioName: portfolio.name,
+    holdingsCount: portfolioTickers.length,
+    oneYearReturn: finiteMetric(oneYearReturn),
+    spyBeta: finiteMetric(beta),
+    marketValue: finiteMetric(marketValue),
+    currency,
+    sourceLabel,
+    asOf: new Date().toISOString(),
+  };
+
+  return {
+    status: "ready",
+    title: portfolio.name,
+    subtitle: `${portfolioTickers.length} holdings${sourceLabel ? ` · ${sourceLabel}` : ""}`,
+    publicAnalytics,
+    metrics: [
+      {
+        id: "one-year",
+        label: "1Y",
+        value: oneYearReturn == null ? "Pending" : signedReturn(oneYearReturn),
+        detail: oneYearReturn == null ? "needs price history" : undefined,
+        tone: signedTone(oneYearReturn),
+      },
+      {
+        id: "beta",
+        label: "SPY Beta",
+        value: beta == null ? "Pending" : formatNumber(beta, 2),
+        detail: beta == null ? "needs SPY overlap" : undefined,
+        tone: beta == null ? "muted" : undefined,
+      },
+      {
+        id: "value",
+        label: "Value",
+        value: `${formatCompact(marketValue)} ${currency}`,
+      },
+      {
+        id: "day",
+        label: "Day",
+        value: signedCompact(accountMetrics.dailyPnl),
+        detail: formatPercentRaw(accountMetrics.dailyPnlPct),
+        tone: signedTone(accountMetrics.dailyPnl),
+      },
+      {
+        id: "pnl",
+        label: "P&L",
+        value: signedCompact(accountMetrics.unrealizedPnl),
+        detail: formatPercentRaw(accountMetrics.unrealizedPnlPct),
+        tone: signedTone(accountMetrics.unrealizedPnl),
+      },
+    ],
+  };
 }

--- a/src/plugins/builtin/account-management/model.ts
+++ b/src/plugins/builtin/account-management/model.ts
@@ -1,12 +1,7 @@
 import type { ChoiceDialogChoice } from "../../../components";
 import type { AccountProfile, PublicPortfolioAnalytics } from "../../../api-client";
-import { calculatePortfolioSummaryTotals } from "../portfolio-list/metrics";
-import { resolvePortfolioAccountMetrics, resolvePortfolioMarketValue } from "../portfolio-list/account-metrics";
-import type { ResolvedPortfolioAccountState } from "../portfolio-list/summary";
-import type { AppConfig } from "../../../types/config";
-import type { TickerFinancials } from "../../../types/financials";
 import type { Portfolio, TickerRecord } from "../../../types/ticker";
-import { formatCompact, formatNumber, formatPercentRaw } from "../../../utils/format";
+import { formatNumber } from "../../../utils/format";
 
 export type AccountFieldKey =
   | "username"
@@ -142,10 +137,6 @@ export function selectedPortfolioLabel(portfolios: Portfolio[], value: string): 
   return portfolios.find((portfolio) => portfolio.id === value)?.name ?? value;
 }
 
-function signedCompact(value: number): string {
-  return `${value >= 0 ? "+" : ""}${formatCompact(value)}`;
-}
-
 function signedReturn(value: number): string {
   const percent = value * 100;
   return `${percent >= 0 ? "+" : ""}${formatNumber(percent, 2)}%`;
@@ -186,23 +177,13 @@ export function computeCumulativeReturn(
 }
 
 export function buildProfileAnalyticsPreview({
-  accountState,
-  baseCurrency,
   beta,
-  config,
-  exchangeRates,
-  financials,
   portfolio,
   portfolioTickers,
   selectedPortfolioId,
   oneYearReturn,
 }: {
-  accountState: ResolvedPortfolioAccountState | null;
-  baseCurrency: string;
   beta: number | null;
-  config: AppConfig;
-  exchangeRates: Map<string, number>;
-  financials: Map<string, TickerFinancials>;
   portfolio: Portfolio | null;
   portfolioTickers: TickerRecord[];
   selectedPortfolioId: string;
@@ -238,34 +219,17 @@ export function buildProfileAnalyticsPreview({
     };
   }
 
-  const totals = calculatePortfolioSummaryTotals(
-    portfolioTickers,
-    financials,
-    baseCurrency,
-    exchangeRates,
-    true,
-    portfolio.id,
-  );
-  const accountMetrics = resolvePortfolioAccountMetrics(totals, accountState?.account);
-  const marketValue = resolvePortfolioMarketValue(totals, accountState?.account);
-  const currency = portfolio.currency || config.baseCurrency;
-  const sourceLabel = accountState?.sourceLabel ?? null;
   const publicAnalytics: PublicPortfolioAnalytics = {
-    portfolioName: portfolio.name,
-    holdingsCount: portfolioTickers.length,
     oneYearReturn: finiteMetric(oneYearReturn),
     spyBeta: finiteMetric(beta),
-    marketValue: finiteMetric(marketValue),
-    currency,
-    sourceLabel,
-    asOf: new Date().toISOString(),
   };
+  const hasSharedMetric = publicAnalytics.oneYearReturn != null || publicAnalytics.spyBeta != null;
 
   return {
     status: "ready",
     title: portfolio.name,
-    subtitle: `${portfolioTickers.length} holdings${sourceLabel ? ` · ${sourceLabel}` : ""}`,
-    publicAnalytics,
+    subtitle: "",
+    publicAnalytics: hasSharedMetric ? publicAnalytics : null,
     metrics: [
       {
         id: "one-year",
@@ -280,25 +244,6 @@ export function buildProfileAnalyticsPreview({
         value: beta == null ? "Pending" : formatNumber(beta, 2),
         detail: beta == null ? "needs SPY overlap" : undefined,
         tone: beta == null ? "muted" : undefined,
-      },
-      {
-        id: "value",
-        label: "Value",
-        value: `${formatCompact(marketValue)} ${currency}`,
-      },
-      {
-        id: "day",
-        label: "Day",
-        value: signedCompact(accountMetrics.dailyPnl),
-        detail: formatPercentRaw(accountMetrics.dailyPnlPct),
-        tone: signedTone(accountMetrics.dailyPnl),
-      },
-      {
-        id: "pnl",
-        label: "P&L",
-        value: signedCompact(accountMetrics.unrealizedPnl),
-        detail: formatPercentRaw(accountMetrics.unrealizedPnlPct),
-        tone: signedTone(accountMetrics.unrealizedPnl),
       },
     ],
   };

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -49,16 +49,6 @@ import { setSyncedProfileAnalytics } from "../../../sync/profile-analytics";
 
 type AccountBusy = "profile" | "password" | "alerts" | null;
 
-function formatSyncStatus(status: ReturnType<typeof useCloudSyncStatus>, profile: AccountProfile | null): string {
-  if (!profile?.syncEnabled) return "Off";
-  if (status.phase === "syncing") return "Syncing";
-  if (status.phase === "error") return status.error ? `Error: ${status.error}` : "Error";
-  if (status.lastSyncAt) return `Last sync ${new Date(status.lastSyncAt).toLocaleString()}`;
-  if (profile.lastSyncAt) return `Last sync ${new Date(profile.lastSyncAt).toLocaleString()}`;
-  if (status.phase === "disabled") return "Waiting for login";
-  return "Not synced yet";
-}
-
 export function AccountManagementPane({ focused, width, height }: PaneProps) {
   const dialog = useDialog();
   const config = useAppSelector((state) => state.config);
@@ -378,7 +368,6 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
         xAccount: emptyToNull(current.xAccount),
         sharedPortfolioId: emptyToNull(current.sharedPortfolioId),
         acceptUnknownDms: current.acceptUnknownDms,
-        syncEnabled: current.syncEnabled,
         weeklyRoundupEnabled: current.weeklyRoundupEnabled,
         positionAlertsEnabled: current.positionAlertsEnabled,
       });
@@ -593,21 +582,9 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
 
           <Box flexDirection="column" gap={1}>
             <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-              Automatic Sync
-            </Text>
-            <Text fg={colors.textMuted} wrapText width={Math.max(24, formWidth - 2)}>
-              {formatSyncStatus(syncStatus, profile)}
+              Email Alerts
             </Text>
             <FieldRow twoColumns={twoColumns}>
-              <CheckboxRow
-                label="Cloud Sync"
-                checked={draft.syncEnabled}
-                active={activeField === "syncEnabled"}
-                description="Sync config, portfolios, watchlists, and sanitized positions."
-                width={fieldWidth}
-                onFocus={() => setActiveField("syncEnabled")}
-                onChange={(checked) => setDraftValue("syncEnabled", checked)}
-              />
               <CheckboxRow
                 label="Weekly Roundup"
                 checked={draft.weeklyRoundupEnabled}
@@ -622,7 +599,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
               label="Position/Watchlist Alerts"
               checked={draft.positionAlertsEnabled}
               active={activeField === "positionAlertsEnabled"}
-              description="Email alerts for large synced position or watchlist jumps."
+              description="Email alerts for large position or watchlist jumps."
               width={formWidth}
               onFocus={() => setActiveField("positionAlertsEnabled")}
               onChange={(checked) => setDraftValue("positionAlertsEnabled", checked)}

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -7,6 +7,7 @@ import { blendHex, colors } from "../../../theme/colors";
 import type { PaneProps } from "../../../types/plugin";
 import { Box, ScrollBox, Text, Textarea, TextAttributes, type TextareaRenderable, useRendererHost } from "../../../ui";
 import { useDialog, type AlertContext, type PromptContext } from "../../../ui/dialog";
+import { openNativeSelect, type NativeSelectElement } from "../../../components/ui/native-select";
 import { apiClient, type AccountProfile } from "../../../api-client";
 import { chatController } from "../chat/controller";
 import { CloudAuthNotice } from "../cloud/auth-actions";
@@ -151,6 +152,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   const [activeTab, setActiveTab] = useState<AccountTab>("profile");
   const syncStatus = useCloudSyncStatus();
   const bioRef = useRef<TextareaRenderable | null>(null);
+  const portfolioNativeSelectRef = useRef<NativeSelectElement | null>(null);
   const refreshedSyncRevisionRef = useRef<number | null>(null);
   const draftRef = useRef(draft);
   draftRef.current = draft;
@@ -418,6 +420,15 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
     setDraftValue("sharedPortfolioId", selected === NO_PORTFOLIO_VALUE ? "" : selected);
   }, [dialog, portfolioChoices, setDraftValue]);
 
+  const openPortfolioPicker = useCallback(async () => {
+    setActiveField("sharedPortfolioId");
+    if (portfolioNativeSelectRef.current) {
+      openNativeSelect(portfolioNativeSelectRef.current);
+      return;
+    }
+    await openPortfolioDialog();
+  }, [openPortfolioDialog]);
+
   const cycleField = useCallback((delta: number) => {
     setActiveField((current) => {
       const index = fieldOrder.indexOf(current);
@@ -572,7 +583,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
     draftRef,
     focused,
     openPasswordDialog,
-    openPortfolioDialog,
+    openPortfolioDialog: openPortfolioPicker,
     openUpgrade,
     saveProfile,
     setDraftValue,
@@ -721,6 +732,10 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
                   border
                   borderColor={activeField === "bio" ? colors.borderFocused : colors.border}
                   backgroundColor={colors.panel}
+                  style={{
+                    borderRadius: 6,
+                    overflow: "hidden",
+                  }}
                 >
                   <Textarea
                     key={`bio:${profile?.updatedAt ?? "empty"}`}
@@ -740,13 +755,22 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
 
               <PublicAnalyticsGroup
                 preview={publicAnalyticsPreview}
+                choices={portfolioChoices}
+                value={draft.sharedPortfolioId || NO_PORTFOLIO_VALUE}
                 label={selectedPortfolioLabel(portfolios, draft.sharedPortfolioId)}
                 detail={profileAnalyticsDetail}
                 active={activeField === "sharedPortfolioId"}
                 width={formWidth}
                 disclaimer={draft.sharedPortfolioId ? "Only 1Y return and SPY Beta are shared. Positions are not shared." : null}
+                selectRef={(element) => {
+                  portfolioNativeSelectRef.current = element;
+                }}
                 onFocus={() => setActiveField("sharedPortfolioId")}
-                onOpen={() => { void openPortfolioDialog(); }}
+                onSelect={(selected) => {
+                  setActiveField("sharedPortfolioId");
+                  setDraftValue("sharedPortfolioId", selected === NO_PORTFOLIO_VALUE ? "" : selected);
+                }}
+                onOpen={() => { void openPortfolioPicker(); }}
               />
 
               <Box flexDirection="row" gap={1}>
@@ -767,15 +791,15 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
                 onChange={(checked) => setDraftValue("weeklyRoundupEnabled", checked)}
               />
               <CheckboxRow
-                label="Smart Position/Watchlist Alerts"
+                label="Smart Alerts"
                 checked={draft.positionAlertsEnabled}
                 active={activeField === "positionAlertsEnabled"}
-                description="Automatic alerts for unusual portfolio or watchlist moves."
+                description="Unusual portfolio or watchlist moves."
                 width={formWidth}
                 onFocus={() => setActiveField("positionAlertsEnabled")}
                 onChange={(checked) => setDraftValue("positionAlertsEnabled", checked)}
               />
-              <Box flexDirection="row" gap={1}>
+              <Box flexDirection="row" gap={1} style={{ marginTop: 8 }}>
                 <Button
                   label={busy === "alerts" ? "Turning Off..." : "Turn Off Both"}
                   active={activeField === "emailAlertsOffAction"}

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -1,24 +1,22 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Button, ChoiceDialog } from "../../../components";
+import { Button, ChoiceDialog, ConfirmDialog, Tabs } from "../../../components";
 import { useAppSelector } from "../../../state/app/context";
 import { useChartQueries, useFxRatesMap, useTickerFinancialsMap } from "../../../market-data/hooks";
 import { selectEffectiveExchangeRates } from "../../../utils/exchange-rate-map";
 import { colors } from "../../../theme/colors";
 import type { PaneProps } from "../../../types/plugin";
-import { Box, ScrollBox, Text, Textarea, TextAttributes, type TextareaRenderable } from "../../../ui";
+import { Box, ScrollBox, Text, Textarea, TextAttributes, type TextareaRenderable, useRendererHost } from "../../../ui";
 import { useDialog, type AlertContext, type PromptContext } from "../../../ui/dialog";
 import { apiClient, type AccountProfile } from "../../../api-client";
 import { chatController } from "../chat/controller";
 import { CloudAuthNotice } from "../cloud/auth-actions";
 import {
-  AccountAnalyticsPreview,
   AccountTextField,
   CheckboxRow,
   FieldRow,
-  PickerRow,
+  PublicAnalyticsGroup,
 } from "./form-components";
 import {
-  BASE_FIELD_ORDER,
   NO_PORTFOLIO_VALUE,
   buildPublishedProfileAnalyticsPreview,
   buildProfileAnalyticsPreview,
@@ -26,6 +24,7 @@ import {
   computeCumulativeReturn,
   countPortfolioHoldings,
   emptyToNull,
+  formatPlan,
   getPortfolioPositionTickers,
   portfolioOptionIds,
   profileToDraft,
@@ -47,10 +46,78 @@ import { useCloudSyncStatus } from "../../../sync/react";
 import { cloudSyncController } from "../../../sync/controller";
 import { setSyncedProfileAnalytics } from "../../../sync/profile-analytics";
 
-type AccountBusy = "profile" | "password" | "alerts" | null;
+type AccountBusy = "profile" | "password" | "alerts" | "billing" | "delete" | null;
+type AccountTab = "profile" | "emails" | "pro" | "advanced";
+
+const CLOUD_UPGRADE_URL = "https://gloom.sh/cloud?upgrade=pro";
+
+const ACCOUNT_TABS: Array<{ label: string; value: AccountTab }> = [
+  { label: "Profile", value: "profile" },
+  { label: "Emails", value: "emails" },
+  { label: "Pro", value: "pro" },
+  { label: "Advanced", value: "advanced" },
+];
+
+const ACCOUNT_TAB_FIELD_ORDER: Record<AccountTab, AccountFieldKey[]> = {
+  profile: [
+    "profilePublic",
+    "acceptUnknownDms",
+    "username",
+    "name",
+    "company",
+    "title",
+    "publicEmail",
+    "xAccount",
+    "bio",
+    "sharedPortfolioId",
+  ],
+  emails: ["weeklyRoundupEnabled", "positionAlertsEnabled", "emailAlertsOffAction"],
+  pro: ["upgradeAction"],
+  advanced: ["passwordAction", "deleteAccountAction"],
+};
+
+const FREE_BENEFITS = [
+  "Delayed market data",
+  "12h delayed news",
+  "Cloud sync",
+];
+
+const PRO_BENEFITS = [
+  "Real-time financial data",
+  "Real-time news wire",
+  "X data",
+  "Chat",
+  "AI Screener soon",
+];
+
+function BenefitList({
+  title,
+  benefits,
+  active,
+  width,
+}: {
+  title: string;
+  benefits: string[];
+  active: boolean;
+  width: number;
+}) {
+  return (
+    <Box flexDirection="column" width={width} backgroundColor={active ? colors.panel : undefined} paddingX={active ? 1 : 0}>
+      <Text fg={active ? colors.textBright : colors.textDim} attributes={active ? TextAttributes.BOLD : 0}>
+        {title}
+      </Text>
+      {benefits.map((benefit) => (
+        <Text key={benefit} fg={active ? colors.text : colors.textDim} wrapText width={Math.max(12, width - (active ? 2 : 0))}>
+          {`+ ${benefit}`}
+        </Text>
+      ))}
+    </Box>
+  );
+}
 
 export function AccountManagementPane({ focused, width, height }: PaneProps) {
   const dialog = useDialog();
+  const renderer = useRendererHost();
   const config = useAppSelector((state) => state.config);
   const portfolios = config.portfolios;
   const baseCurrency = config.baseCurrency;
@@ -67,6 +134,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   const [activeField, setActiveField] = useState<AccountFieldKey>("username");
   const [message, setMessage] = useState<{ tone: "info" | "success" | "error"; text: string } | null>(null);
   const [busy, setBusy] = useState<AccountBusy>(null);
+  const [activeTab, setActiveTab] = useState<AccountTab>("profile");
   const syncStatus = useCloudSyncStatus();
   const bioRef = useRef<TextareaRenderable | null>(null);
   const refreshedSyncRevisionRef = useRef<number | null>(null);
@@ -78,7 +146,8 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   const fieldWidth = twoColumns ? Math.max(22, Math.floor((formWidth - 3) / 2)) : Math.max(18, Math.min(46, formWidth - 2));
   const fullFieldWidth = Math.max(18, Math.min(54, formWidth - 2));
   const bodyHeight = Math.max(5, height);
-  const fieldOrder = BASE_FIELD_ORDER;
+  const benefitColumnWidth = twoColumns ? Math.max(22, Math.floor((formWidth - 3) / 2)) : formWidth;
+  const fieldOrder = ACCOUNT_TAB_FIELD_ORDER[activeTab];
 
   const portfolioHoldingCounts = useMemo(() => countPortfolioHoldings(tickers), [tickers]);
   const portfolioChoices = useMemo(
@@ -274,12 +343,18 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
 
   useEffect(() => {
     if (!fieldOrder.includes(activeField)) {
-      setActiveField("username");
+      setActiveField(fieldOrder[0] ?? "username");
     }
   }, [activeField, fieldOrder]);
 
   const setDraftValue = useCallback(<K extends keyof AccountDraft>(key: K, value: AccountDraft[K]) => {
     setDraft((current) => ({ ...current, [key]: value }));
+  }, []);
+
+  const selectTab = useCallback((tab: string) => {
+    const nextTab = tab as AccountTab;
+    setActiveTab(nextTab);
+    setActiveField(ACCOUNT_TAB_FIELD_ORDER[nextTab][0] ?? "username");
   }, []);
 
   const openPasswordDialog = useCallback(() => {
@@ -412,12 +487,65 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
     }
   }, []);
 
+  const openUpgrade = useCallback(() => {
+    setActiveField("upgradeAction");
+    setBusy("billing");
+    setMessage({ tone: "info", text: "Opening Pro upgrade..." });
+    void renderer.openExternal(CLOUD_UPGRADE_URL)
+      .then(() => setMessage(null))
+      .catch((error) => {
+        setMessage({
+          tone: "error",
+          text: error instanceof Error ? error.message : "Failed to open upgrade page.",
+        });
+      })
+      .finally(() => setBusy(null));
+  }, [renderer]);
+
+  const deleteAccount = useCallback(async () => {
+    setActiveField("deleteAccountAction");
+    if (busy) return;
+    const confirmed = await dialog.prompt<boolean>({
+      closeOnClickOutside: false,
+      content: (context: PromptContext<boolean>) => (
+        <ConfirmDialog
+          {...context}
+          title="Delete Account"
+          body={[
+            "Delete your Gloom Cloud account?",
+            "This removes cloud profile, chat, sync, and billing-linked account data.",
+          ]}
+          confirmLabel="Delete Account"
+          confirmVariant="danger"
+        />
+      ),
+    }).catch(() => false);
+    if (!confirmed) return;
+
+    setBusy("delete");
+    setMessage({ tone: "info", text: "Deleting account..." });
+    try {
+      await apiClient.deleteAccount();
+      setProfile(null);
+      setDraft(profileToDraft(null));
+      setHasSession(false);
+      await chatController.refreshSession().catch(() => {});
+      setMessage({ tone: "success", text: "Account deleted." });
+    } catch (error) {
+      setMessage({
+        tone: "error",
+        text: error instanceof Error ? error.message : "Failed to delete account.",
+      });
+    } finally {
+      setBusy(null);
+    }
+  }, [busy, dialog]);
+
   useAccountManagementFooter({
     busy,
     draft,
     hasSession,
     message,
-    openPasswordDialog,
     profile,
     saveProfile,
   });
@@ -426,10 +554,12 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
     activeField,
     cycleField,
     cyclePortfolio,
+    deleteAccount,
     draftRef,
     focused,
     openPasswordDialog,
     openPortfolioDialog,
+    openUpgrade,
     saveProfile,
     setDraftValue,
     turnOffEmailAlerts,
@@ -444,189 +574,244 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   }
 
   return (
-    <Box flexDirection="column" width={width} height={height} paddingX={1}>
-      <ScrollBox height={bodyHeight} scrollY focusable={false}>
+    <Box flexDirection="column" width={width} height={height} paddingX={1} gap={1}>
+      <Tabs
+        tabs={ACCOUNT_TABS}
+        activeValue={activeTab}
+        onSelect={selectTab}
+        focused={focused}
+        variant="pill"
+        compact
+        keyboardNavigation={false}
+      />
+      <ScrollBox height={Math.max(3, bodyHeight - 2)} scrollY focusable={false}>
         <Box flexDirection="column" width={formWidth} gap={1}>
-          <FieldRow twoColumns={twoColumns}>
-            <AccountTextField
-              fieldKey="username"
-              label="Username"
-              value={draft.username}
-              placeholder="username"
-              activeField={activeField}
-              focused={focused}
-              width={fieldWidth}
-              onFocus={setActiveField}
-              onChange={(value) => setDraftValue("username", value)}
-              onSubmit={() => { void saveProfile(); }}
-            />
-            <AccountTextField
-              fieldKey="name"
-              label="Full Name"
-              value={draft.name}
-              placeholder="Full name"
-              activeField={activeField}
-              focused={focused}
-              width={fieldWidth}
-              onFocus={setActiveField}
-              onChange={(value) => setDraftValue("name", value)}
-              onSubmit={() => { void saveProfile(); }}
-            />
-          </FieldRow>
+          {activeTab === "profile" ? (
+            <>
+              <FieldRow twoColumns={twoColumns}>
+                <CheckboxRow
+                  label="Public Profile"
+                  checked={draft.profilePublic}
+                  active={activeField === "profilePublic"}
+                  width={fieldWidth}
+                  onFocus={() => setActiveField("profilePublic")}
+                  onChange={(checked) => setDraftValue("profilePublic", checked)}
+                />
+                <CheckboxRow
+                  label="Incoming DMs"
+                  checked={draft.acceptUnknownDms}
+                  active={activeField === "acceptUnknownDms"}
+                  width={fieldWidth}
+                  onFocus={() => setActiveField("acceptUnknownDms")}
+                  onChange={(checked) => setDraftValue("acceptUnknownDms", checked)}
+                />
+              </FieldRow>
 
-          <FieldRow twoColumns={twoColumns}>
-            <AccountTextField
-              fieldKey="company"
-              label="Company"
-              value={draft.company}
-              placeholder="Company"
-              activeField={activeField}
-              focused={focused}
-              width={fieldWidth}
-              onFocus={setActiveField}
-              onChange={(value) => setDraftValue("company", value)}
-              onSubmit={() => { void saveProfile(); }}
-            />
-            <AccountTextField
-              fieldKey="title"
-              label="Title"
-              value={draft.title}
-              placeholder="Title"
-              activeField={activeField}
-              focused={focused}
-              width={fieldWidth}
-              onFocus={setActiveField}
-              onChange={(value) => setDraftValue("title", value)}
-              onSubmit={() => { void saveProfile(); }}
-            />
-          </FieldRow>
+              <FieldRow twoColumns={twoColumns}>
+                <AccountTextField
+                  fieldKey="username"
+                  label="Username"
+                  value={draft.username}
+                  placeholder="username"
+                  activeField={activeField}
+                  focused={focused}
+                  width={fieldWidth}
+                  onFocus={setActiveField}
+                  onChange={(value) => setDraftValue("username", value)}
+                  onSubmit={() => { void saveProfile(); }}
+                />
+                <AccountTextField
+                  fieldKey="name"
+                  label="Full Name"
+                  value={draft.name}
+                  placeholder="Full name"
+                  activeField={activeField}
+                  focused={focused}
+                  width={fieldWidth}
+                  onFocus={setActiveField}
+                  onChange={(value) => setDraftValue("name", value)}
+                  onSubmit={() => { void saveProfile(); }}
+                />
+              </FieldRow>
 
-          <FieldRow twoColumns={twoColumns}>
-            <AccountTextField
-              fieldKey="publicEmail"
-              label="Public Email"
-              value={draft.publicEmail}
-              placeholder="public@example.com"
-              activeField={activeField}
-              focused={focused}
-              width={fieldWidth}
-              onFocus={setActiveField}
-              onChange={(value) => setDraftValue("publicEmail", value)}
-              onSubmit={() => { void saveProfile(); }}
-            />
-            <AccountTextField
-              fieldKey="xAccount"
-              label="X Account"
-              value={draft.xAccount}
-              placeholder="handle"
-              activeField={activeField}
-              focused={focused}
-              width={fieldWidth}
-              onFocus={setActiveField}
-              onChange={(value) => setDraftValue("xAccount", value)}
-              onSubmit={() => { void saveProfile(); }}
-            />
-          </FieldRow>
+              <FieldRow twoColumns={twoColumns}>
+                <AccountTextField
+                  fieldKey="company"
+                  label="Company"
+                  value={draft.company}
+                  placeholder="Company"
+                  activeField={activeField}
+                  focused={focused}
+                  width={fieldWidth}
+                  onFocus={setActiveField}
+                  onChange={(value) => setDraftValue("company", value)}
+                  onSubmit={() => { void saveProfile(); }}
+                />
+                <AccountTextField
+                  fieldKey="title"
+                  label="Title"
+                  value={draft.title}
+                  placeholder="Title"
+                  activeField={activeField}
+                  focused={focused}
+                  width={fieldWidth}
+                  onFocus={setActiveField}
+                  onChange={(value) => setDraftValue("title", value)}
+                  onSubmit={() => { void saveProfile(); }}
+                />
+              </FieldRow>
 
-          <Box flexDirection="column" onMouseDown={() => setActiveField("bio")}>
-            <Text fg={activeField === "bio" ? colors.textBright : colors.textDim} attributes={activeField === "bio" ? TextAttributes.BOLD : 0}>
-              {activeField === "bio" ? "> Bio" : "  Bio"}
-            </Text>
-            <Box height={3} width={fullFieldWidth} border borderColor={activeField === "bio" ? colors.borderFocused : colors.border} backgroundColor={colors.panel}>
-              <Textarea
-                key={`bio:${profile?.updatedAt ?? "empty"}`}
-                ref={bioRef}
-                initialValue={draft.bio}
-                placeholder="Short profile bio"
-                focused={focused && activeField === "bio"}
-                textColor={colors.text}
-                placeholderColor={colors.textDim}
-                backgroundColor={colors.panel}
-                flexGrow={1}
-                wrapText
-                onInput={(value: string) => setDraftValue("bio", value)}
+              <FieldRow twoColumns={twoColumns}>
+                <AccountTextField
+                  fieldKey="publicEmail"
+                  label="Public Email"
+                  value={draft.publicEmail}
+                  placeholder="public@example.com"
+                  activeField={activeField}
+                  focused={focused}
+                  width={fieldWidth}
+                  onFocus={setActiveField}
+                  onChange={(value) => setDraftValue("publicEmail", value)}
+                  onSubmit={() => { void saveProfile(); }}
+                />
+                <AccountTextField
+                  fieldKey="xAccount"
+                  label="X Account"
+                  value={draft.xAccount}
+                  placeholder="handle"
+                  activeField={activeField}
+                  focused={focused}
+                  width={fieldWidth}
+                  onFocus={setActiveField}
+                  onChange={(value) => setDraftValue("xAccount", value)}
+                  onSubmit={() => { void saveProfile(); }}
+                />
+              </FieldRow>
+
+              <Box flexDirection="column" onMouseDown={() => setActiveField("bio")}>
+                <Text fg={activeField === "bio" ? colors.textBright : colors.textDim} attributes={activeField === "bio" ? TextAttributes.BOLD : 0}>
+                  {activeField === "bio" ? "> Bio" : "  Bio"}
+                </Text>
+                <Box height={3} width={fullFieldWidth} border borderColor={activeField === "bio" ? colors.borderFocused : colors.border} backgroundColor={colors.panel}>
+                  <Textarea
+                    key={`bio:${profile?.updatedAt ?? "empty"}`}
+                    ref={bioRef}
+                    initialValue={draft.bio}
+                    placeholder="Short profile bio"
+                    focused={focused && activeField === "bio"}
+                    textColor={colors.text}
+                    placeholderColor={colors.textDim}
+                    backgroundColor={colors.panel}
+                    flexGrow={1}
+                    wrapText
+                    onInput={(value: string) => setDraftValue("bio", value)}
+                  />
+                </Box>
+              </Box>
+
+              <PublicAnalyticsGroup
+                preview={publicAnalyticsPreview}
+                label={selectedPortfolioLabel(portfolios, draft.sharedPortfolioId)}
+                detail={profileAnalyticsDetail}
+                active={activeField === "sharedPortfolioId"}
+                width={formWidth}
+                disclaimer={draft.sharedPortfolioId ? "Only 1Y return and SPY Beta are shared. Positions are not shared." : null}
+                onFocus={() => setActiveField("sharedPortfolioId")}
+                onOpen={() => { void openPortfolioDialog(); }}
               />
-            </Box>
-          </Box>
 
-          <FieldRow twoColumns={twoColumns}>
-            <CheckboxRow
-              label="Public Profile"
-              checked={draft.profilePublic}
-              active={activeField === "profilePublic"}
-              width={fieldWidth}
-              onFocus={() => setActiveField("profilePublic")}
-              onChange={(checked) => setDraftValue("profilePublic", checked)}
-            />
-            <CheckboxRow
-              label="Incoming DMs"
-              checked={draft.acceptUnknownDms}
-              active={activeField === "acceptUnknownDms"}
-              width={fieldWidth}
-              onFocus={() => setActiveField("acceptUnknownDms")}
-              onChange={(checked) => setDraftValue("acceptUnknownDms", checked)}
-            />
-          </FieldRow>
+              <Box flexDirection="row" gap={1}>
+                <Button label={busy === "profile" ? "Saving..." : "Save Profile"} variant="primary" onPress={() => { void saveProfile(); }} disabled={!!busy} />
+              </Box>
+            </>
+          ) : null}
 
-          <PickerRow
-            label="Profile Analytics"
-            value={selectedPortfolioLabel(portfolios, draft.sharedPortfolioId)}
-            detail={profileAnalyticsDetail}
-            active={activeField === "sharedPortfolioId"}
-            width={formWidth}
-            onFocus={() => setActiveField("sharedPortfolioId")}
-            onOpen={() => { void openPortfolioDialog(); }}
-          />
-
-          <AccountAnalyticsPreview
-            preview={publicAnalyticsPreview}
-            width={formWidth}
-            disclaimer={draft.sharedPortfolioId ? "Only 1Y return and SPY Beta are shared. Positions are not shared." : null}
-          />
-
-          <Box flexDirection="column" gap={1}>
-            <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-              Email Alerts
-            </Text>
-            <FieldRow twoColumns={twoColumns}>
+          {activeTab === "emails" ? (
+            <>
               <CheckboxRow
                 label="Weekly Roundup"
                 checked={draft.weeklyRoundupEnabled}
                 active={activeField === "weeklyRoundupEnabled"}
-                description="Friday after market close portfolio and watchlist email."
-                width={fieldWidth}
+                description="Friday after market close."
+                width={formWidth}
                 onFocus={() => setActiveField("weeklyRoundupEnabled")}
                 onChange={(checked) => setDraftValue("weeklyRoundupEnabled", checked)}
               />
-            </FieldRow>
-            <CheckboxRow
-              label="Position/Watchlist Alerts"
-              checked={draft.positionAlertsEnabled}
-              active={activeField === "positionAlertsEnabled"}
-              description="Email alerts for large position or watchlist jumps."
-              width={formWidth}
-              onFocus={() => setActiveField("positionAlertsEnabled")}
-              onChange={(checked) => setDraftValue("positionAlertsEnabled", checked)}
-            />
-            <Box flexDirection="row" gap={1}>
-              <Button
-                label={busy === "alerts" ? "Turning Off..." : "Turn Off Email Alerts"}
-                active={activeField === "emailAlertsOffAction"}
-                onPress={() => { void turnOffEmailAlerts(); }}
-                disabled={!!busy || (!draft.weeklyRoundupEnabled && !draft.positionAlertsEnabled)}
+              <CheckboxRow
+                label="Position/Watchlist Alerts"
+                checked={draft.positionAlertsEnabled}
+                active={activeField === "positionAlertsEnabled"}
+                description="Large portfolio or watchlist jumps."
+                width={formWidth}
+                onFocus={() => setActiveField("positionAlertsEnabled")}
+                onChange={(checked) => setDraftValue("positionAlertsEnabled", checked)}
               />
-            </Box>
-          </Box>
+              <Box flexDirection="row" gap={1}>
+                <Button
+                  label={busy === "alerts" ? "Turning Off..." : "Turn Off Both"}
+                  active={activeField === "emailAlertsOffAction"}
+                  onPress={() => { void turnOffEmailAlerts(); }}
+                  disabled={!!busy || (!draft.weeklyRoundupEnabled && !draft.positionAlertsEnabled)}
+                />
+                <Button label={busy === "profile" ? "Saving..." : "Save"} variant="primary" onPress={() => { void saveProfile(); }} disabled={!!busy} />
+              </Box>
+            </>
+          ) : null}
 
-          <Box flexDirection="row" gap={1}>
-            <Button label={busy === "profile" ? "Saving..." : "Save Profile"} variant="primary" onPress={() => { void saveProfile(); }} disabled={!!busy} />
-            <Button
-              label="Change Password"
-              active={activeField === "passwordAction"}
-              onPress={openPasswordDialog}
-              disabled={!!busy}
-            />
-          </Box>
+          {activeTab === "pro" ? (
+            <>
+              <Box flexDirection="row" gap={1}>
+                <Text fg={colors.textDim}>Status</Text>
+                <Text fg={profile?.plan === "pro" ? colors.positive : colors.textBright} attributes={TextAttributes.BOLD}>
+                  {formatPlan(profile?.plan)}
+                </Text>
+                {profile?.email ? <Text fg={colors.textMuted}>{profile.email}</Text> : null}
+              </Box>
+              <FieldRow twoColumns={twoColumns}>
+                <BenefitList
+                  title="Free"
+                  benefits={FREE_BENEFITS}
+                  active={profile?.plan !== "pro"}
+                  width={benefitColumnWidth}
+                />
+                <BenefitList
+                  title="Pro $49/mo"
+                  benefits={PRO_BENEFITS}
+                  active={profile?.plan === "pro"}
+                  width={benefitColumnWidth}
+                />
+              </FieldRow>
+              <Box flexDirection="row" gap={1}>
+                <Button
+                  label={profile?.plan === "pro" ? "Manage Pro" : busy === "billing" ? "Opening..." : "Upgrade to Pro"}
+                  variant={profile?.plan === "pro" ? "secondary" : "primary"}
+                  active={activeField === "upgradeAction"}
+                  onPress={openUpgrade}
+                  disabled={!!busy}
+                />
+              </Box>
+            </>
+          ) : null}
+
+          {activeTab === "advanced" ? (
+            <>
+              <Box flexDirection="row" gap={1}>
+                <Button
+                  label="Change Password"
+                  active={activeField === "passwordAction"}
+                  onPress={openPasswordDialog}
+                  disabled={!!busy}
+                />
+                <Button
+                  label={busy === "delete" ? "Deleting..." : "Delete Account"}
+                  variant="danger"
+                  active={activeField === "deleteAccountAction"}
+                  onPress={() => { void deleteAccount(); }}
+                  disabled={!!busy}
+                />
+              </Box>
+            </>
+          ) : null}
           <Box height={1} />
         </Box>
       </ScrollBox>

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -20,6 +20,7 @@ import {
 import {
   BASE_FIELD_ORDER,
   NO_PORTFOLIO_VALUE,
+  buildPublishedProfileAnalyticsPreview,
   buildProfileAnalyticsPreview,
   buildPortfolioChoices,
   computeCumulativeReturn,
@@ -78,6 +79,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   const [busy, setBusy] = useState<AccountBusy>(null);
   const syncStatus = useCloudSyncStatus();
   const bioRef = useRef<TextareaRenderable | null>(null);
+  const refreshedSyncRevisionRef = useRef<number | null>(null);
   const draftRef = useRef(draft);
   draftRef.current = draft;
 
@@ -164,7 +166,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
     () => (portfolioReturnSeries && spyReturnSeries ? computeDatedBeta(portfolioReturnSeries, spyReturnSeries) : null),
     [portfolioReturnSeries, spyReturnSeries],
   );
-  const analyticsPreview = useMemo(
+  const localAnalyticsPreview = useMemo(
     () => buildProfileAnalyticsPreview({
       beta,
       portfolio: selectedAnalyticsPortfolio,
@@ -183,12 +185,50 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   useEffect(() => {
     const portfolioId = selectedAnalyticsPortfolio?.id;
     if (!portfolioId) return;
-    const changed = setSyncedProfileAnalytics(portfolioId, analyticsPreview.publicAnalytics);
+    const changed = setSyncedProfileAnalytics(portfolioId, localAnalyticsPreview.publicAnalytics);
     if (changed) cloudSyncController.schedulePush("profile-analytics");
   }, [
-    analyticsPreview.publicAnalytics?.oneYearReturn,
-    analyticsPreview.publicAnalytics?.spyBeta,
+    localAnalyticsPreview.publicAnalytics?.oneYearReturn,
+    localAnalyticsPreview.publicAnalytics?.spyBeta,
     selectedAnalyticsPortfolio?.id,
+  ]);
+  const publicAnalyticsPreview = useMemo(
+    () => buildPublishedProfileAnalyticsPreview({
+      analytics: profile?.portfolioAnalytics ?? null,
+      draftProfilePublic: draft.profilePublic,
+      portfolio: selectedAnalyticsPortfolio,
+      profileLoaded: !!profile,
+      savedProfilePublic: profile?.profilePublic === true,
+      savedSharedPortfolioId: profile?.sharedPortfolioId ?? "",
+      selectedPortfolioId: draft.sharedPortfolioId,
+      syncing: syncStatus.phase === "syncing",
+    }),
+    [
+      draft.profilePublic,
+      draft.sharedPortfolioId,
+      profile,
+      selectedAnalyticsPortfolio,
+      syncStatus.phase,
+    ],
+  );
+  const profileAnalyticsDetail = useMemo(() => {
+    if (!draft.sharedPortfolioId) return "No public portfolio analytics";
+    if (!profile) return "Loading published metrics";
+    if (
+      draft.profilePublic !== profile.profilePublic
+      || draft.sharedPortfolioId !== (profile.sharedPortfolioId ?? "")
+    ) {
+      return "Save profile to update published metrics";
+    }
+    if (profile.profilePublic !== true) return "Public profile is off";
+    if (syncStatus.phase === "syncing") return "Syncing published metrics";
+    if (!profile.portfolioAnalytics) return "Waiting for published metrics";
+    return "Published public metrics";
+  }, [
+    draft.profilePublic,
+    draft.sharedPortfolioId,
+    profile,
+    syncStatus.phase,
   ]);
 
   useEffect(() => {
@@ -224,6 +264,23 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   useEffect(() => {
     void loadProfile();
   }, [loadProfile, sessionMarker]);
+
+  useEffect(() => {
+    if (!hasSession || !apiClient.getSessionToken()) return;
+    if (syncStatus.phase !== "synced" || syncStatus.revision == null) return;
+    if (refreshedSyncRevisionRef.current === syncStatus.revision) return;
+    refreshedSyncRevisionRef.current = syncStatus.revision;
+    let cancelled = false;
+    void (async () => {
+      const nextProfile = await apiClient.getAccountProfile().catch(() => null);
+      if (cancelled || !nextProfile) return;
+      setProfile(nextProfile);
+      await chatController.refreshSession().catch(() => {});
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [hasSession, syncStatus.phase, syncStatus.revision]);
 
   useEffect(() => {
     if (!fieldOrder.includes(activeField)) {
@@ -525,14 +582,14 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
           <PickerRow
             label="Profile Analytics"
             value={selectedPortfolioLabel(portfolios, draft.sharedPortfolioId)}
-            detail={draft.sharedPortfolioId ? "Preview below uses current market data" : "No public portfolio analytics"}
+            detail={profileAnalyticsDetail}
             active={activeField === "sharedPortfolioId"}
             width={formWidth}
             onFocus={() => setActiveField("sharedPortfolioId")}
             onOpen={() => { void openPortfolioDialog(); }}
           />
 
-          <AccountAnalyticsPreview preview={analyticsPreview} width={formWidth} />
+          <AccountAnalyticsPreview preview={publicAnalyticsPreview} width={formWidth} />
 
           <Box flexDirection="column" gap={1}>
             <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -751,10 +751,10 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
                 onChange={(checked) => setDraftValue("weeklyRoundupEnabled", checked)}
               />
               <CheckboxRow
-                label="Position/Watchlist Alerts"
+                label="Smart Position/Watchlist Alerts"
                 checked={draft.positionAlertsEnabled}
                 active={activeField === "positionAlertsEnabled"}
-                description="Large portfolio or watchlist jumps."
+                description="Automatic alerts for unusual portfolio or watchlist moves."
                 width={formWidth}
                 onFocus={() => setActiveField("positionAlertsEnabled")}
                 onChange={(checked) => setDraftValue("positionAlertsEnabled", checked)}

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -579,6 +579,11 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
           />
 
           <AccountAnalyticsPreview preview={publicAnalyticsPreview} width={formWidth} />
+          {draft.sharedPortfolioId ? (
+            <Text fg={colors.textMuted} wrapText width={Math.max(24, formWidth - 2)}>
+              Only 1Y return and SPY Beta are shared. Positions are not shared.
+            </Text>
+          ) : null}
 
           <Box flexDirection="column" gap={1}>
             <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button, ChoiceDialog } from "../../../components";
 import { useAppSelector } from "../../../state/app/context";
+import { useChartQueries, useFxRatesMap, useTickerFinancialsMap } from "../../../market-data/hooks";
+import { selectEffectiveExchangeRates } from "../../../utils/exchange-rate-map";
 import { colors } from "../../../theme/colors";
 import type { PaneProps } from "../../../types/plugin";
 import { Box, ScrollBox, Text, Textarea, TextAttributes, type TextareaRenderable } from "../../../ui";
@@ -8,13 +10,22 @@ import { useDialog, type AlertContext, type PromptContext } from "../../../ui/di
 import { apiClient, type AccountProfile } from "../../../api-client";
 import { chatController } from "../chat/controller";
 import { CloudAuthNotice } from "../cloud/auth-actions";
-import { AccountTextField, CheckboxRow, FieldRow, PickerRow } from "./form-components";
+import {
+  AccountAnalyticsPreview,
+  AccountTextField,
+  CheckboxRow,
+  FieldRow,
+  PickerRow,
+} from "./form-components";
 import {
   BASE_FIELD_ORDER,
   NO_PORTFOLIO_VALUE,
+  buildProfileAnalyticsPreview,
   buildPortfolioChoices,
+  computeCumulativeReturn,
   countPortfolioHoldings,
   emptyToNull,
+  getPortfolioPositionTickers,
   portfolioOptionIds,
   profileToDraft,
   selectedPortfolioLabel,
@@ -24,11 +35,37 @@ import {
 import { PasswordChangeDialog } from "./password-dialog";
 import { useAccountManagementFooter } from "./footer";
 import { useAccountManagementKeyboard } from "./keyboard";
+import { usePortfolioAccountState } from "../portfolio-list/header";
+import { buildTrackedCurrencies } from "../analytics/sector-model";
+import {
+  buildBenchmarkReturnSeries,
+  buildPortfolioChartTargets,
+  buildPortfolioReturnSeries,
+} from "../analytics/pane-model";
+import { computeDatedBeta } from "../analytics/metrics";
+import { useCloudSyncStatus } from "../../../sync/react";
+
+type AccountBusy = "profile" | "password" | "alerts" | null;
+
+function formatSyncStatus(status: ReturnType<typeof useCloudSyncStatus>, profile: AccountProfile | null): string {
+  if (!profile?.syncEnabled) return "Off";
+  if (status.phase === "syncing") return "Syncing";
+  if (status.phase === "error") return status.error ? `Error: ${status.error}` : "Error";
+  if (status.lastSyncAt) return `Last sync ${new Date(status.lastSyncAt).toLocaleString()}`;
+  if (profile.lastSyncAt) return `Last sync ${new Date(profile.lastSyncAt).toLocaleString()}`;
+  if (status.phase === "disabled") return "Waiting for login";
+  return "Not synced yet";
+}
 
 export function AccountManagementPane({ focused, width, height }: PaneProps) {
   const dialog = useDialog();
-  const portfolios = useAppSelector((state) => state.config.portfolios);
+  const config = useAppSelector((state) => state.config);
+  const portfolios = config.portfolios;
+  const baseCurrency = config.baseCurrency;
   const tickers = useAppSelector((state) => state.tickers);
+  const cachedFinancials = useAppSelector((state) => state.financials);
+  const cachedExchangeRates = useAppSelector((state) => state.exchangeRates);
+  const brokerAccounts = useAppSelector((state) => state.brokerAccounts);
   const [sessionMarker, setSessionMarker] = useState(() => {
     const snapshot = chatController.getSnapshot();
     return `${apiClient.getSessionToken() ?? ""}:${snapshot.user?.id ?? ""}:${snapshot.user?.username ?? ""}`;
@@ -38,7 +75,8 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   const [draft, setDraft] = useState<AccountDraft>(() => profileToDraft(null));
   const [activeField, setActiveField] = useState<AccountFieldKey>("username");
   const [message, setMessage] = useState<{ tone: "info" | "success" | "error"; text: string } | null>(null);
-  const [busy, setBusy] = useState<"profile" | "password" | null>(null);
+  const [busy, setBusy] = useState<AccountBusy>(null);
+  const syncStatus = useCloudSyncStatus();
   const bioRef = useRef<TextareaRenderable | null>(null);
   const draftRef = useRef(draft);
   draftRef.current = draft;
@@ -54,6 +92,105 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   const portfolioChoices = useMemo(
     () => buildPortfolioChoices(portfolios, portfolioHoldingCounts),
     [portfolioHoldingCounts, portfolios],
+  );
+  const selectedAnalyticsPortfolio = useMemo(
+    () => portfolios.find((portfolio) => portfolio.id === draft.sharedPortfolioId) ?? null,
+    [draft.sharedPortfolioId, portfolios],
+  );
+  const portfolioTickers = useMemo(
+    () => draft.sharedPortfolioId ? getPortfolioPositionTickers(tickers, draft.sharedPortfolioId) : [],
+    [draft.sharedPortfolioId, tickers],
+  );
+  const marketFinancials = useTickerFinancialsMap(portfolioTickers);
+  const financials = useMemo(() => {
+    const merged = new Map(cachedFinancials);
+    for (const [symbol, data] of marketFinancials) {
+      merged.set(symbol, data);
+    }
+    return merged;
+  }, [cachedFinancials, marketFinancials]);
+  const trackedCurrencies = useMemo(
+    () => buildTrackedCurrencies(portfolioTickers, financials, baseCurrency),
+    [baseCurrency, financials, portfolioTickers],
+  );
+  const fetchedExchangeRates = useFxRatesMap(trackedCurrencies);
+  const effectiveExchangeRates = selectEffectiveExchangeRates(fetchedExchangeRates, cachedExchangeRates);
+  const accountStateInput = useMemo(() => ({ brokerAccounts, config }), [brokerAccounts, config]);
+  const accountState = usePortfolioAccountState(selectedAnalyticsPortfolio, accountStateInput);
+  const chartTargets = useMemo(
+    () => buildPortfolioChartTargets(portfolioTickers),
+    [portfolioTickers],
+  );
+  const chartRequests = useMemo(
+    () => chartTargets.map((target) => target.request),
+    [chartTargets],
+  );
+  const chartEntries = useChartQueries(chartRequests);
+  const spyRequest = useMemo(
+    () => ({
+      instrument: { symbol: "SPY", exchange: "" },
+      bufferRange: "1Y" as const,
+      granularity: "range" as const,
+    }),
+    [],
+  );
+  const spyChartRequests = useMemo(
+    () => portfolioTickers.length > 0 ? [spyRequest] : [],
+    [portfolioTickers.length, spyRequest],
+  );
+  const spyChartEntries = useChartQueries(spyChartRequests);
+  const columnContext = useMemo(() => ({
+    activeTab: draft.sharedPortfolioId || undefined,
+    baseCurrency,
+    exchangeRates: effectiveExchangeRates,
+    now: Date.now(),
+  }), [baseCurrency, draft.sharedPortfolioId, effectiveExchangeRates]);
+  const portfolioReturnSeries = useMemo(
+    () => buildPortfolioReturnSeries({
+      chartTargets,
+      chartEntries,
+      financials,
+      columnContext,
+    }),
+    [chartEntries, chartTargets, columnContext, financials],
+  );
+  const spyReturnSeries = useMemo(
+    () => buildBenchmarkReturnSeries(spyRequest, spyChartEntries),
+    [spyChartEntries, spyRequest],
+  );
+  const oneYearReturn = useMemo(
+    () => portfolioReturnSeries ? computeCumulativeReturn(portfolioReturnSeries) : null,
+    [portfolioReturnSeries],
+  );
+  const beta = useMemo(
+    () => (portfolioReturnSeries && spyReturnSeries ? computeDatedBeta(portfolioReturnSeries, spyReturnSeries) : null),
+    [portfolioReturnSeries, spyReturnSeries],
+  );
+  const analyticsPreview = useMemo(
+    () => buildProfileAnalyticsPreview({
+      accountState,
+      baseCurrency,
+      beta,
+      config,
+      exchangeRates: effectiveExchangeRates,
+      financials,
+      portfolio: selectedAnalyticsPortfolio,
+      portfolioTickers,
+      selectedPortfolioId: draft.sharedPortfolioId,
+      oneYearReturn,
+    }),
+    [
+      accountState,
+      baseCurrency,
+      beta,
+      config,
+      draft.sharedPortfolioId,
+      effectiveExchangeRates,
+      financials,
+      portfolioTickers,
+      selectedAnalyticsPortfolio,
+      oneYearReturn,
+    ],
   );
 
   useEffect(() => {
@@ -186,6 +323,9 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
         xAccount: emptyToNull(current.xAccount),
         sharedPortfolioId: emptyToNull(current.sharedPortfolioId),
         acceptUnknownDms: current.acceptUnknownDms,
+        syncEnabled: current.syncEnabled,
+        weeklyRoundupEnabled: current.weeklyRoundupEnabled,
+        positionAlertsEnabled: current.positionAlertsEnabled,
       });
       setProfile(nextProfile);
       setDraft(profileToDraft(nextProfile));
@@ -195,6 +335,33 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
       setMessage({
         tone: "error",
         text: error instanceof Error ? error.message : "Failed to save account profile.",
+      });
+    } finally {
+      setBusy(null);
+    }
+  }, []);
+
+  const turnOffEmailAlerts = useCallback(async () => {
+    setActiveField("emailAlertsOffAction");
+    setBusy("alerts");
+    setMessage({ tone: "info", text: "Turning off email alerts..." });
+    try {
+      const settings = await apiClient.updateSyncSettings({
+        weeklyRoundupEnabled: false,
+        positionAlertsEnabled: false,
+      });
+      setDraft((current) => ({
+        ...current,
+        weeklyRoundupEnabled: settings.weeklyRoundupEnabled,
+        positionAlertsEnabled: settings.positionAlertsEnabled,
+      }));
+      const nextProfile = await apiClient.getAccountProfile().catch(() => null);
+      if (nextProfile) setProfile(nextProfile);
+      setMessage({ tone: "success", text: "Email alerts are off." });
+    } catch (error) {
+      setMessage({
+        tone: "error",
+        text: error instanceof Error ? error.message : "Failed to update alert settings.",
       });
     } finally {
       setBusy(null);
@@ -221,6 +388,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
     openPortfolioDialog,
     saveProfile,
     setDraftValue,
+    turnOffEmailAlerts,
   });
 
   if (!hasSession && !apiClient.getSessionToken()) {
@@ -359,12 +527,60 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
           <PickerRow
             label="Profile Analytics"
             value={selectedPortfolioLabel(portfolios, draft.sharedPortfolioId)}
-            detail={draft.sharedPortfolioId ? "Shares portfolio YTD % + SPY Beta" : "No public portfolio analytics"}
+            detail={draft.sharedPortfolioId ? "Preview below uses current market data" : "No public portfolio analytics"}
             active={activeField === "sharedPortfolioId"}
             width={formWidth}
             onFocus={() => setActiveField("sharedPortfolioId")}
             onOpen={() => { void openPortfolioDialog(); }}
           />
+
+          <AccountAnalyticsPreview preview={analyticsPreview} width={formWidth} />
+
+          <Box flexDirection="column" gap={1}>
+            <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+              Automatic Sync
+            </Text>
+            <Text fg={colors.textMuted} wrapText width={Math.max(24, formWidth - 2)}>
+              {formatSyncStatus(syncStatus, profile)}
+            </Text>
+            <FieldRow twoColumns={twoColumns}>
+              <CheckboxRow
+                label="Cloud Sync"
+                checked={draft.syncEnabled}
+                active={activeField === "syncEnabled"}
+                description="Sync config, portfolios, watchlists, and sanitized positions."
+                width={fieldWidth}
+                onFocus={() => setActiveField("syncEnabled")}
+                onChange={(checked) => setDraftValue("syncEnabled", checked)}
+              />
+              <CheckboxRow
+                label="Weekly Roundup"
+                checked={draft.weeklyRoundupEnabled}
+                active={activeField === "weeklyRoundupEnabled"}
+                description="Friday after market close portfolio and watchlist email."
+                width={fieldWidth}
+                onFocus={() => setActiveField("weeklyRoundupEnabled")}
+                onChange={(checked) => setDraftValue("weeklyRoundupEnabled", checked)}
+              />
+            </FieldRow>
+            <CheckboxRow
+              label="Position/Watchlist Alerts"
+              checked={draft.positionAlertsEnabled}
+              active={activeField === "positionAlertsEnabled"}
+              description="Email alerts for large synced position or watchlist jumps."
+              width={formWidth}
+              onFocus={() => setActiveField("positionAlertsEnabled")}
+              onChange={(checked) => setDraftValue("positionAlertsEnabled", checked)}
+            />
+            <Box flexDirection="row" gap={1}>
+              <Button
+                label={busy === "alerts" ? "Turning Off..." : "Turn Off Email Alerts"}
+                active={activeField === "emailAlertsOffAction"}
+                onPress={() => { void turnOffEmailAlerts(); }}
+                disabled={!!busy || (!draft.weeklyRoundupEnabled && !draft.positionAlertsEnabled)}
+              />
+            </Box>
+          </Box>
 
           <Box flexDirection="row" gap={1}>
             <Button label={busy === "profile" ? "Saving..." : "Save Profile"} variant="primary" onPress={() => { void saveProfile(); }} disabled={!!busy} />

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -15,6 +15,7 @@ import {
   CheckboxRow,
   FieldRow,
   PublicAnalyticsGroup,
+  accountFieldLabelWidth,
 } from "./form-components";
 import {
   NO_PORTFOLIO_VALUE,
@@ -157,7 +158,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   const formWidth = Math.max(24, Math.min(70, width - 2));
   const twoColumns = formWidth >= 60;
   const fieldWidth = twoColumns ? Math.max(22, Math.floor((formWidth - 3) / 2)) : Math.max(18, Math.min(46, formWidth - 2));
-  const fullFieldWidth = Math.max(18, Math.min(54, formWidth - 2));
+  const formLabelWidth = accountFieldLabelWidth(formWidth);
   const bodyHeight = Math.max(5, height);
   const benefitColumnWidth = twoColumns ? Math.max(22, Math.floor((formWidth - 3) / 2)) : formWidth;
   const fieldOrder = ACCOUNT_TAB_FIELD_ORDER[activeTab];
@@ -407,7 +408,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
       content: (context: PromptContext<string>) => (
         <ChoiceDialog
           {...context}
-          title="Shared Portfolio"
+          title="Public Stats"
           choices={portfolioChoices}
           selectedChoiceId={currentPortfolioChoiceId}
         />
@@ -701,11 +702,26 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
                 />
               </FieldRow>
 
-              <Box flexDirection="column" onMouseDown={() => setActiveField("bio")}>
-                <Text fg={activeField === "bio" ? colors.textBright : colors.textDim} attributes={activeField === "bio" ? TextAttributes.BOLD : 0}>
+              <Box
+                flexDirection="row"
+                width={formWidth}
+                gap={1}
+                onMouseDown={() => setActiveField("bio")}
+              >
+                <Text
+                  width={formLabelWidth}
+                  fg={activeField === "bio" ? colors.textBright : colors.textDim}
+                  attributes={activeField === "bio" ? TextAttributes.BOLD : 0}
+                >
                   {activeField === "bio" ? "> Bio" : "  Bio"}
                 </Text>
-                <Box height={3} width={fullFieldWidth} border borderColor={activeField === "bio" ? colors.borderFocused : colors.border} backgroundColor={colors.panel}>
+                <Box
+                  height={3}
+                  width={Math.max(18, formWidth - formLabelWidth - 1)}
+                  border
+                  borderColor={activeField === "bio" ? colors.borderFocused : colors.border}
+                  backgroundColor={colors.panel}
+                >
                   <Textarea
                     key={`bio:${profile?.updatedAt ?? "empty"}`}
                     ref={bioRef}

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -1,11 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { Button, ChoiceDialog, ConfirmDialog, Tabs } from "../../../components";
 import { useAppSelector } from "../../../state/app/context";
 import { useChartQueries, useFxRatesMap, useTickerFinancialsMap } from "../../../market-data/hooks";
 import { selectEffectiveExchangeRates } from "../../../utils/exchange-rate-map";
 import { blendHex, colors } from "../../../theme/colors";
 import type { PaneProps } from "../../../types/plugin";
-import { Box, ScrollBox, Text, Textarea, TextAttributes, type TextareaRenderable, useRendererHost } from "../../../ui";
+import { Box, ScrollBox, Text, Textarea, TextAttributes, type TextareaRenderable, useRendererHost, useUiHost } from "../../../ui";
 import { useDialog, type AlertContext, type PromptContext } from "../../../ui/dialog";
 import { openNativeSelect, type NativeSelectElement } from "../../../components/ui/native-select";
 import { apiClient, type AccountProfile } from "../../../api-client";
@@ -95,6 +95,7 @@ function PlanComparison({
   activePlan: "free" | "pro";
   upgradeButton: ReactNode;
 }) {
+  const isDesktop = useUiHost().kind === "desktop-web";
   const comparisonWidth = Math.min(width, 58);
   const capabilityWidth = Math.max(13, Math.min(16, Math.floor(comparisonWidth * 0.32)));
   const valueWidth = Math.max(10, Math.floor((comparisonWidth - capabilityWidth - 2) / 2));
@@ -107,6 +108,138 @@ function PlanComparison({
     if (tone === "muted") return colors.textMuted;
     return colors.text;
   };
+
+  if (isDesktop) {
+    const gridStyle: CSSProperties = {
+      display: "grid",
+      gridTemplateColumns: width >= 86
+        ? "minmax(220px, 1fr) minmax(120px, 0.42fr) minmax(300px, 1.05fr)"
+        : "minmax(150px, 0.95fr) minmax(86px, 0.42fr) minmax(180px, 1fr)",
+      columnGap: width >= 86 ? "clamp(30px, 5vw, 72px)" : "22px",
+      alignItems: "center",
+      width: "100%",
+    };
+    const desktopProBg = blendHex(colors.panel, colors.selected, activePlan === "pro" ? 0.34 : 0.24);
+    const desktopProAltBg = blendHex(colors.panel, colors.selected, activePlan === "pro" ? 0.39 : 0.28);
+    const desktopText = {
+      lineHeight: "22px",
+      fontSize: "15px",
+    } satisfies CSSProperties;
+    return (
+      <Box
+        flexDirection="column"
+        width="100%"
+        maxWidth={width >= 86 ? "980px" : "100%"}
+        style={{
+          marginTop: 18,
+          paddingLeft: width >= 86 ? 12 : 4,
+          paddingRight: width >= 86 ? 10 : 4,
+        }}
+      >
+        <Box
+          style={{
+            ...gridStyle,
+            marginBottom: 12,
+          }}
+        >
+          <Text fg={colors.textDim} style={{ ...desktopText, fontWeight: 650 }}>
+            Capability
+          </Text>
+          <Text
+            fg={activePlan === "free" ? colors.textBright : colors.textDim}
+            attributes={activePlan === "free" ? TextAttributes.BOLD : 0}
+            style={{ ...desktopText, fontWeight: activePlan === "free" ? 700 : 650 }}
+          >
+            Free
+          </Text>
+          <Box flexDirection="row" alignItems="baseline" gap={1}>
+            <Text
+              fg={colors.borderFocused}
+              attributes={TextAttributes.BOLD}
+              style={{ ...desktopText, fontWeight: 750 }}
+            >
+              Pro
+            </Text>
+            <Text fg={colors.textBright} style={desktopText}>
+              $49/mo
+            </Text>
+          </Box>
+        </Box>
+        {PLAN_COMPARISON_ROWS.map((row, index) => {
+          const first = index === 0;
+          const last = index === PLAN_COMPARISON_ROWS.length - 1;
+          return (
+            <Box
+              key={row.capability}
+              style={{
+                ...gridStyle,
+                minHeight: 48,
+              }}
+            >
+              <Box flexDirection="row" alignItems="center" style={{ minWidth: 0 }}>
+                <Box
+                  aria-hidden="true"
+                  style={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: 999,
+                    marginRight: 18,
+                    flexShrink: 0,
+                    backgroundColor: colors.borderFocused,
+                    boxShadow: `0 0 0 2px ${blendHex(colors.bg, colors.borderFocused, 0.14)}`,
+                  }}
+                />
+                <Text fg={colors.textBright} style={{ ...desktopText, fontWeight: 520 }}>
+                  {row.capability}
+                </Text>
+              </Box>
+              <Text fg={freeFg} style={desktopText}>
+                {row.free}
+              </Text>
+              <Box
+                flexDirection="row"
+                alignItems="center"
+                backgroundColor={index % 2 === 0 ? desktopProBg : desktopProAltBg}
+                style={{
+                  minHeight: 48,
+                  paddingLeft: width >= 86 ? 24 : 16,
+                  paddingRight: width >= 86 ? 24 : 14,
+                  borderTopLeftRadius: first ? 2 : 0,
+                  borderTopRightRadius: first ? 2 : 0,
+                  borderBottomLeftRadius: last ? 2 : 0,
+                  borderBottomRightRadius: last ? 2 : 0,
+                  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.025)",
+                }}
+              >
+                <Text
+                  fg={proValueColor(row.proTone)}
+                  attributes={row.proTone === "positive" ? TextAttributes.BOLD : 0}
+                  style={{
+                    ...desktopText,
+                    fontWeight: row.proTone === "positive" ? 720 : 560,
+                  }}
+                >
+                  {row.pro}
+                </Text>
+              </Box>
+            </Box>
+          );
+        })}
+        <Box
+          style={{
+            ...gridStyle,
+            marginTop: 14,
+          }}
+        >
+          <Box />
+          <Box />
+          <Box flexDirection="row" justifyContent="center">
+            {upgradeButton}
+          </Box>
+        </Box>
+      </Box>
+    );
+  }
 
   return (
     <Box flexDirection="column" width={rowWidth}>
@@ -146,6 +279,7 @@ function PlanComparison({
 export function AccountManagementPane({ focused, width, height }: PaneProps) {
   const dialog = useDialog();
   const renderer = useRendererHost();
+  const isDesktop = useUiHost().kind === "desktop-web";
   const config = useAppSelector((state) => state.config);
   const portfolios = config.portfolios;
   const baseCurrency = config.baseCurrency;
@@ -171,6 +305,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   draftRef.current = draft;
 
   const formWidth = Math.max(24, Math.min(70, width - 2));
+  const contentWidth = activeTab === "pro" && isDesktop ? Math.max(formWidth, width - 2) : formWidth;
   const twoColumns = formWidth >= 60;
   const fieldWidth = twoColumns ? Math.max(22, Math.floor((formWidth - 3) / 2)) : Math.max(18, Math.min(46, formWidth - 2));
   const formLabelWidth = accountFieldLabelWidth(formWidth);
@@ -622,7 +757,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
         keyboardNavigation={false}
       />
       <ScrollBox height={Math.max(3, bodyHeight - 2)} scrollY focusable={false}>
-        <Box flexDirection="column" width={formWidth} gap={1}>
+        <Box flexDirection="column" width={contentWidth} gap={1}>
           {activeTab === "profile" ? (
             <>
               <FieldRow twoColumns={twoColumns}>
@@ -833,12 +968,14 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
                 {profile?.email ? <Text fg={colors.textMuted}>{profile.email}</Text> : null}
               </Box>
               <PlanComparison
-                width={formWidth}
+                width={contentWidth}
                 activePlan={profile?.plan === "pro" ? "pro" : "free"}
                 upgradeButton={(
                   <Button
                     label={profile?.plan === "pro" ? "Manage Pro" : busy === "billing" ? "Opening..." : "Upgrade to Pro"}
                     variant={profile?.plan === "pro" ? "secondary" : "primary"}
+                    width={isDesktop ? 28 : profile?.plan === "pro" ? 18 : 24}
+                    height={isDesktop ? "28px" : undefined}
                     active={activeField === "upgradeAction"}
                     onPress={openUpgrade}
                     disabled={!!busy}

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Button, ChoiceDialog, ConfirmDialog, Tabs } from "../../../components";
 import { useAppSelector } from "../../../state/app/context";
 import { useChartQueries, useFxRatesMap, useTickerFinancialsMap } from "../../../market-data/hooks";
@@ -78,54 +78,67 @@ const ACCOUNT_TAB_FIELD_ORDER: Record<AccountTab, AccountFieldKey[]> = {
   advanced: ["passwordAction", "deleteAccountAction"],
 };
 
-const FREE_BENEFITS = [
-  "Delayed market data",
-  "12h delayed news",
-  "Cloud sync",
-];
+const PLAN_COMPARISON_ROWS = [
+  { capability: "Market data", free: "Delayed", pro: "Real-time", proTone: "positive" },
+  { capability: "News", free: "12h delay", pro: "Real-time wire", proTone: "positive" },
+  { capability: "Cloud sync", free: "Included", pro: "Included", proTone: "neutral" },
+  { capability: "X data", free: "No", pro: "Included", proTone: "positive" },
+  { capability: "AI Screener", free: "No", pro: "Soon", proTone: "muted" },
+] as const;
 
-const PRO_BENEFITS = [
-  "Real-time financial data",
-  "Real-time news wire",
-  "X data",
-  "AI Screener soon",
-];
-
-function BenefitList({
-  title,
-  benefits,
-  active,
-  featured = false,
+function PlanComparison({
   width,
+  activePlan,
+  upgradeButton,
 }: {
-  title: string;
-  benefits: string[];
-  active: boolean;
-  featured?: boolean;
   width: number;
+  activePlan: "free" | "pro";
+  upgradeButton: ReactNode;
 }) {
-  const contentWidth = Math.max(12, width - 2);
-  const backgroundColor = featured
-    ? blendHex(colors.panel, colors.selected, active ? 0.48 : 0.34)
-    : active
-    ? colors.panel
-    : blendHex(colors.bg, colors.panel, 0.42);
-  const titleFg = featured ? colors.textBright : active ? colors.textBright : colors.textDim;
-  const benefitFg = featured || active ? colors.text : colors.textDim;
-  const markerFg = featured ? colors.positive : colors.textDim;
+  const comparisonWidth = Math.min(width, 58);
+  const capabilityWidth = Math.max(13, Math.min(16, Math.floor(comparisonWidth * 0.32)));
+  const valueWidth = Math.max(10, Math.floor((comparisonWidth - capabilityWidth - 2) / 2));
+  const rowWidth = capabilityWidth + valueWidth * 2 + 2;
+  const proCellBg = blendHex(colors.panel, colors.selected, activePlan === "pro" ? 0.42 : 0.26);
+  const freeFg = activePlan === "free" ? colors.text : colors.textDim;
+  const proHeadingFg = activePlan === "pro" ? colors.textBright : colors.text;
+  const proValueColor = (tone: typeof PLAN_COMPARISON_ROWS[number]["proTone"]) => {
+    if (tone === "positive") return colors.positive;
+    if (tone === "muted") return colors.textMuted;
+    return colors.text;
+  };
+
   return (
-    <Box flexDirection="column" width={width} backgroundColor={backgroundColor} paddingX={1}>
-      <Text fg={titleFg} attributes={featured || active ? TextAttributes.BOLD : 0}>
-        {title}
-      </Text>
-      {benefits.map((benefit) => (
-        <Box key={benefit} height={1} flexDirection="row" gap={1}>
-          <Text fg={markerFg} attributes={featured ? TextAttributes.BOLD : 0}>+</Text>
-          <Text fg={benefitFg} wrapText width={contentWidth - 2}>
-            {benefit}
+    <Box flexDirection="column" width={rowWidth}>
+      <Box height={1} flexDirection="row" gap={1}>
+        <Text width={capabilityWidth} fg={colors.textDim}>Capability</Text>
+        <Text width={valueWidth} fg={activePlan === "free" ? colors.textBright : colors.textDim} attributes={activePlan === "free" ? TextAttributes.BOLD : 0}>
+          Free
+        </Text>
+        <Box width={valueWidth} backgroundColor={proCellBg} paddingX={1}>
+          <Text fg={proHeadingFg} attributes={TextAttributes.BOLD}>
+            Pro $49/mo
           </Text>
         </Box>
+      </Box>
+      {PLAN_COMPARISON_ROWS.map((row) => (
+        <Box key={row.capability} height={1} flexDirection="row" gap={1}>
+          <Text width={capabilityWidth} fg={colors.textDim}>{row.capability}</Text>
+          <Text width={valueWidth} fg={freeFg}>{row.free}</Text>
+          <Box width={valueWidth} backgroundColor={proCellBg} paddingX={1}>
+            <Text fg={proValueColor(row.proTone)} attributes={row.proTone === "positive" ? TextAttributes.BOLD : 0}>
+              {row.pro}
+            </Text>
+          </Box>
+        </Box>
       ))}
+      <Box height={1} flexDirection="row" gap={1}>
+        <Box width={capabilityWidth} />
+        <Box width={valueWidth} />
+        <Box width={valueWidth} flexDirection="row">
+          {upgradeButton}
+        </Box>
+      </Box>
     </Box>
   );
 }
@@ -162,7 +175,6 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   const fieldWidth = twoColumns ? Math.max(22, Math.floor((formWidth - 3) / 2)) : Math.max(18, Math.min(46, formWidth - 2));
   const formLabelWidth = accountFieldLabelWidth(formWidth);
   const bodyHeight = Math.max(5, height);
-  const benefitColumnWidth = twoColumns ? Math.max(22, Math.floor((formWidth - 3) / 2)) : formWidth;
   const fieldOrder = ACCOUNT_TAB_FIELD_ORDER[activeTab];
 
   const portfolioHoldingCounts = useMemo(() => countPortfolioHoldings(tickers), [tickers]);
@@ -820,30 +832,19 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
                 </Text>
                 {profile?.email ? <Text fg={colors.textMuted}>{profile.email}</Text> : null}
               </Box>
-              <FieldRow twoColumns={twoColumns}>
-                <BenefitList
-                  title="Free"
-                  benefits={FREE_BENEFITS}
-                  active={profile?.plan !== "pro"}
-                  width={benefitColumnWidth}
-                />
-                <BenefitList
-                  title="Pro $49/mo"
-                  benefits={PRO_BENEFITS}
-                  active={profile?.plan === "pro"}
-                  featured
-                  width={benefitColumnWidth}
-                />
-              </FieldRow>
-              <Box flexDirection="row" gap={1}>
-                <Button
-                  label={profile?.plan === "pro" ? "Manage Pro" : busy === "billing" ? "Opening..." : "Upgrade to Pro"}
-                  variant={profile?.plan === "pro" ? "secondary" : "primary"}
-                  active={activeField === "upgradeAction"}
-                  onPress={openUpgrade}
-                  disabled={!!busy}
-                />
-              </Box>
+              <PlanComparison
+                width={formWidth}
+                activePlan={profile?.plan === "pro" ? "pro" : "free"}
+                upgradeButton={(
+                  <Button
+                    label={profile?.plan === "pro" ? "Manage Pro" : busy === "billing" ? "Opening..." : "Upgrade to Pro"}
+                    variant={profile?.plan === "pro" ? "secondary" : "primary"}
+                    active={activeField === "upgradeAction"}
+                    onPress={openUpgrade}
+                    disabled={!!busy}
+                  />
+                )}
+              />
             </>
           ) : null}
 

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -578,12 +578,11 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
             onOpen={() => { void openPortfolioDialog(); }}
           />
 
-          <AccountAnalyticsPreview preview={publicAnalyticsPreview} width={formWidth} />
-          {draft.sharedPortfolioId ? (
-            <Text fg={colors.textMuted} wrapText width={Math.max(24, formWidth - 2)}>
-              Only 1Y return and SPY Beta are shared. Positions are not shared.
-            </Text>
-          ) : null}
+          <AccountAnalyticsPreview
+            preview={publicAnalyticsPreview}
+            width={formWidth}
+            disclaimer={draft.sharedPortfolioId ? "Only 1Y return and SPY Beta are shared. Positions are not shared." : null}
+          />
 
           <Box flexDirection="column" gap={1}>
             <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -86,7 +86,6 @@ const PRO_BENEFITS = [
   "Real-time financial data",
   "Real-time news wire",
   "X data",
-  "Chat",
   "AI Screener soon",
 ];
 

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -3,7 +3,7 @@ import { Button, ChoiceDialog, ConfirmDialog, Tabs } from "../../../components";
 import { useAppSelector } from "../../../state/app/context";
 import { useChartQueries, useFxRatesMap, useTickerFinancialsMap } from "../../../market-data/hooks";
 import { selectEffectiveExchangeRates } from "../../../utils/exchange-rate-map";
-import { colors } from "../../../theme/colors";
+import { blendHex, colors } from "../../../theme/colors";
 import type { PaneProps } from "../../../types/plugin";
 import { Box, ScrollBox, Text, Textarea, TextAttributes, type TextareaRenderable, useRendererHost } from "../../../ui";
 import { useDialog, type AlertContext, type PromptContext } from "../../../ui/dialog";
@@ -93,22 +93,36 @@ function BenefitList({
   title,
   benefits,
   active,
+  featured = false,
   width,
 }: {
   title: string;
   benefits: string[];
   active: boolean;
+  featured?: boolean;
   width: number;
 }) {
+  const contentWidth = Math.max(12, width - 2);
+  const backgroundColor = featured
+    ? blendHex(colors.panel, colors.selected, active ? 0.48 : 0.34)
+    : active
+    ? colors.panel
+    : blendHex(colors.bg, colors.panel, 0.42);
+  const titleFg = featured ? colors.textBright : active ? colors.textBright : colors.textDim;
+  const benefitFg = featured || active ? colors.text : colors.textDim;
+  const markerFg = featured ? colors.positive : colors.textDim;
   return (
-    <Box flexDirection="column" width={width} backgroundColor={active ? colors.panel : undefined} paddingX={active ? 1 : 0}>
-      <Text fg={active ? colors.textBright : colors.textDim} attributes={active ? TextAttributes.BOLD : 0}>
+    <Box flexDirection="column" width={width} backgroundColor={backgroundColor} paddingX={1}>
+      <Text fg={titleFg} attributes={featured || active ? TextAttributes.BOLD : 0}>
         {title}
       </Text>
       {benefits.map((benefit) => (
-        <Text key={benefit} fg={active ? colors.text : colors.textDim} wrapText width={Math.max(12, width - (active ? 2 : 0))}>
-          {`+ ${benefit}`}
-        </Text>
+        <Box key={benefit} height={1} flexDirection="row" gap={1}>
+          <Text fg={markerFg} attributes={featured ? TextAttributes.BOLD : 0}>+</Text>
+          <Text fg={benefitFg} wrapText width={contentWidth - 2}>
+            {benefit}
+          </Text>
+        </Box>
       ))}
     </Box>
   );
@@ -777,6 +791,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
                   title="Pro $49/mo"
                   benefits={PRO_BENEFITS}
                   active={profile?.plan === "pro"}
+                  featured
                   width={benefitColumnWidth}
                 />
               </FieldRow>

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -35,7 +35,6 @@ import {
 import { PasswordChangeDialog } from "./password-dialog";
 import { useAccountManagementFooter } from "./footer";
 import { useAccountManagementKeyboard } from "./keyboard";
-import { usePortfolioAccountState } from "../portfolio-list/header";
 import { buildTrackedCurrencies } from "../analytics/sector-model";
 import {
   buildBenchmarkReturnSeries,
@@ -44,6 +43,8 @@ import {
 } from "../analytics/pane-model";
 import { computeDatedBeta } from "../analytics/metrics";
 import { useCloudSyncStatus } from "../../../sync/react";
+import { cloudSyncController } from "../../../sync/controller";
+import { setSyncedProfileAnalytics } from "../../../sync/profile-analytics";
 
 type AccountBusy = "profile" | "password" | "alerts" | null;
 
@@ -65,7 +66,6 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   const tickers = useAppSelector((state) => state.tickers);
   const cachedFinancials = useAppSelector((state) => state.financials);
   const cachedExchangeRates = useAppSelector((state) => state.exchangeRates);
-  const brokerAccounts = useAppSelector((state) => state.brokerAccounts);
   const [sessionMarker, setSessionMarker] = useState(() => {
     const snapshot = chatController.getSnapshot();
     return `${apiClient.getSessionToken() ?? ""}:${snapshot.user?.id ?? ""}:${snapshot.user?.username ?? ""}`;
@@ -115,8 +115,6 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   );
   const fetchedExchangeRates = useFxRatesMap(trackedCurrencies);
   const effectiveExchangeRates = selectEffectiveExchangeRates(fetchedExchangeRates, cachedExchangeRates);
-  const accountStateInput = useMemo(() => ({ brokerAccounts, config }), [brokerAccounts, config]);
-  const accountState = usePortfolioAccountState(selectedAnalyticsPortfolio, accountStateInput);
   const chartTargets = useMemo(
     () => buildPortfolioChartTargets(portfolioTickers),
     [portfolioTickers],
@@ -168,30 +166,30 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   );
   const analyticsPreview = useMemo(
     () => buildProfileAnalyticsPreview({
-      accountState,
-      baseCurrency,
       beta,
-      config,
-      exchangeRates: effectiveExchangeRates,
-      financials,
       portfolio: selectedAnalyticsPortfolio,
       portfolioTickers,
       selectedPortfolioId: draft.sharedPortfolioId,
       oneYearReturn,
     }),
     [
-      accountState,
-      baseCurrency,
       beta,
-      config,
       draft.sharedPortfolioId,
-      effectiveExchangeRates,
-      financials,
       portfolioTickers,
       selectedAnalyticsPortfolio,
       oneYearReturn,
     ],
   );
+  useEffect(() => {
+    const portfolioId = selectedAnalyticsPortfolio?.id;
+    if (!portfolioId) return;
+    const changed = setSyncedProfileAnalytics(portfolioId, analyticsPreview.publicAnalytics);
+    if (changed) cloudSyncController.schedulePush("profile-analytics");
+  }, [
+    analyticsPreview.publicAnalytics?.oneYearReturn,
+    analyticsPreview.publicAnalytics?.spyBeta,
+    selectedAnalyticsPortfolio?.id,
+  ]);
 
   useEffect(() => {
     const unsubscribe = chatController.subscribe((snapshot) => {

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -268,7 +268,7 @@ function PlanComparison({
       <Box height={1} flexDirection="row" gap={1}>
         <Box width={capabilityWidth} />
         <Box width={valueWidth} />
-        <Box width={valueWidth} flexDirection="row">
+        <Box width={valueWidth} flexDirection="row" paddingLeft={1}>
           {upgradeButton}
         </Box>
       </Box>
@@ -974,7 +974,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
                   <Button
                     label={profile?.plan === "pro" ? "Manage Pro" : busy === "billing" ? "Opening..." : "Upgrade to Pro"}
                     variant={profile?.plan === "pro" ? "secondary" : "primary"}
-                    width={isDesktop ? 28 : profile?.plan === "pro" ? 18 : 24}
+                    width={isDesktop ? 28 : undefined}
                     height={isDesktop ? "28px" : undefined}
                     active={activeField === "upgradeAction"}
                     onPress={openUpgrade}

--- a/src/plugins/builtin/chat/content/channel-navigation.ts
+++ b/src/plugins/builtin/chat/content/channel-navigation.ts
@@ -1,12 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
-import type { ChatChannel, ChatUserSummary } from "../../../../api-client";
+import type { ChatChannel } from "../../../../api-client";
 import { useThrottledCommitValue } from "../../../../react/use-throttled-commit-value";
 import {
   DEFAULT_CHAT_CHANNEL_ID,
   normalizeChannelId,
 } from "../channels";
-import type { ChatContentController } from "./types";
 
 const CHANNEL_NAVIGATION_COMMIT_DELAY_MS = 150;
 
@@ -20,8 +19,6 @@ export function useChatChannelNavigation({
   channelIdRef,
   channels,
   channelsLoading,
-  closeProfilePopover,
-  controller,
   focused,
   inputFocused,
   onChannelChange,
@@ -33,8 +30,6 @@ export function useChatChannelNavigation({
   channelIdRef: MutableRefObject<string>;
   channels: ChatChannel[];
   channelsLoading: boolean;
-  closeProfilePopover: () => void;
-  controller: ChatContentController;
   focused: boolean;
   inputFocused: boolean;
   onChannelChange?: (channelId: string) => void;
@@ -46,7 +41,6 @@ export function useChatChannelNavigation({
   focusChannelSidebar: () => boolean;
   focusChatContent: () => boolean;
   moveSidebarChannelSelection: (direction: "up" | "down") => boolean;
-  openDirectMessage: (target: ChatUserSummary) => Promise<void>;
   selectSidebarChannel: (channelId: string) => void;
   setDirectExpanded: Dispatch<SetStateAction<boolean>>;
   setSidebarFocused: (nextFocused: boolean) => void;
@@ -81,19 +75,6 @@ export function useChatChannelNavigation({
     flushValue: flushSidebarCursorChannelId,
     replaceValue: replaceSidebarCursorChannelId,
   } = useThrottledCommitValue(channelId, changeChannel, CHANNEL_NAVIGATION_COMMIT_DELAY_MS);
-
-  const openDirectMessage = useCallback(async (target: ChatUserSummary) => {
-    if (!target.id && !target.username) return;
-    try {
-      const channel = await controller.openDirectChannel({
-        userId: target.id,
-        username: target.username ?? undefined,
-      });
-      setDirectExpanded(true);
-      setSidebarCursorChannelId(channel.id, { immediate: true });
-      closeProfilePopover();
-    } catch {}
-  }, [closeProfilePopover, controller, setSidebarCursorChannelId]);
 
   useEffect(() => {
     if (!onChannelChange || channelsLoading || channels.length === 0) return;
@@ -185,7 +166,6 @@ export function useChatChannelNavigation({
     focusChannelSidebar,
     focusChatContent,
     moveSidebarChannelSelection,
-    openDirectMessage,
     selectSidebarChannel,
     setDirectExpanded,
     setSidebarFocused,

--- a/src/plugins/builtin/chat/content/index.tsx
+++ b/src/plugins/builtin/chat/content/index.tsx
@@ -32,6 +32,7 @@ import { buildChatUserByUsername } from "./user-map";
 import { useChatComposerRuntime } from "./composer-runtime";
 import { useChatMessageSelection } from "./selection-runtime";
 import type { ChatMessage } from "../../../../api-client";
+import { NewDmDialog } from "./new-dm-dialog";
 import {
   CHAT_MESSAGE_EDIT_WINDOW_MS,
   findLatestEditableChatMessage,
@@ -67,6 +68,7 @@ export function ChatContent({
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
   const [editingMessage, setEditingMessage] = useState<ChatMessage | null>(null);
   const [followMessages, setFollowMessages] = useState(true);
+  const [newDmOpen, setNewDmOpen] = useState(false);
   const inputRef = useRef<TextareaRenderable>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const messageElementsRef = useRef(new Map<string, unknown>());
@@ -217,7 +219,6 @@ export function ChatContent({
     focusChannelSidebar,
     focusChatContent,
     moveSidebarChannelSelection,
-    openDirectMessage,
     selectSidebarChannel,
     setDirectExpanded,
     setSidebarFocused,
@@ -230,8 +231,6 @@ export function ChatContent({
     channelIdRef,
     channels,
     channelsLoading,
-    closeProfilePopover,
-    controller,
     focused,
     inputFocused,
     onChannelChange,
@@ -240,11 +239,42 @@ export function ChatContent({
   });
 
   const focusInput = useCallback(() => {
+    setNewDmOpen(false);
     setSidebarFocused(false);
     setInputFocused(true);
     dispatch({ type: "SET_INPUT_CAPTURED", captured: true });
     inputRef.current?.focus?.();
   }, [dispatch, setSidebarFocused]);
+
+  const closeNewDmDialog = useCallback(() => {
+    setNewDmOpen(false);
+    dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
+  }, [dispatch]);
+
+  const openNewDmDialog = useCallback(() => {
+    blurInput();
+    closeProfilePopover();
+    setSidebarFocused(false);
+    setNewDmOpen(true);
+    dispatch({ type: "SET_INPUT_CAPTURED", captured: true });
+  }, [blurInput, closeProfilePopover, dispatch, setSidebarFocused]);
+
+  const openConversationFromDialog = useCallback(async (usernames: string[]) => {
+    const channel = usernames.length === 1
+      ? await controller.openDirectChannel({ username: usernames[0] })
+      : await controller.openGroupChannel({ usernames });
+    setDirectExpanded(true);
+    channelIdRef.current = channel.id;
+    selectSidebarChannel(channel.id);
+    setSidebarFocused(false);
+    closeNewDmDialog();
+  }, [channelIdRef, closeNewDmDialog, controller, selectSidebarChannel, setDirectExpanded, setSidebarFocused]);
+
+  useEffect(() => {
+    if (!focused && newDmOpen) {
+      closeNewDmDialog();
+    }
+  }, [closeNewDmDialog, focused, newDmOpen]);
 
   const {
     beginEditLatestMessage,
@@ -327,7 +357,7 @@ export function ChatContent({
     focusChannelSidebar,
     focusChatContent,
     focusComposer,
-    focused,
+    focused: focused && !newDmOpen,
     hasOlderMessages,
     inputFocused,
     inputValueRef,
@@ -376,9 +406,11 @@ export function ChatContent({
           keyboardFocused={sidebarFocused}
           loading={channelsLoading}
           canManageNotifications={!!user?.emailVerified}
+          canCreateConversation={!!user?.emailVerified}
           directExpanded={directExpanded}
           onSelect={selectSidebarChannel}
           onFocusRequest={() => setSidebarFocused(true)}
+          onCreateConversation={openNewDmDialog}
           onToggleNotifications={(nextChannelId, enabled) => {
             controller.setChannelNotificationsEnabled(nextChannelId, enabled);
           }}
@@ -420,7 +452,6 @@ export function ChatContent({
         messages={messages}
         nativePaneChrome={nativePaneChrome}
         latestEditableMessageId={latestEditableMessageId}
-        openDirectMessage={openDirectMessage}
         openTicker={openTicker}
         profilePopoverUser={profilePopoverUser}
         registerMessageElement={registerMessageElement}
@@ -433,6 +464,17 @@ export function ChatContent({
         user={user}
         userByUsername={userByUsername}
       />
+
+      {newDmOpen ? (
+        <NewDmDialog
+          width={chatWidth}
+          height={height}
+          userByUsername={userByUsername}
+          currentUserId={user?.id}
+          onCancel={closeNewDmDialog}
+          onSubmit={openConversationFromDialog}
+        />
+      ) : null}
 
       {!nativePaneChrome && !canSend && (
         <Box height={1} width={contentWidth}>

--- a/src/plugins/builtin/chat/content/new-dm-dialog.tsx
+++ b/src/plugins/builtin/chat/content/new-dm-dialog.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ListView, TextField, type ListViewItem } from "../../../../components/ui";
+import { useShortcut } from "../../../../react/input";
+import { colors, hoverBg } from "../../../../theme/colors";
+import { Box, Text, TextAttributes, type InputRenderable } from "../../../../ui";
+import type { ChatUserSummary } from "../../../../api-client";
+import { isPlainKey } from "../../../../utils/keyboard";
+import {
+  hasOnlyDmUsernameArgs,
+  parseDmUsernames,
+  truncateChannelLabel,
+} from "../channels";
+
+const MAX_RECENT_USERS = 6;
+const MIN_DIALOG_WIDTH = 32;
+const MAX_DIALOG_WIDTH = 52;
+const DIALOG_HEIGHT = 10;
+
+interface DmUserCandidate {
+  username: string;
+  displayName: string;
+}
+
+function normalizeUsername(value: string | null | undefined): string {
+  return value?.trim().replace(/^@+/, "").toLowerCase() ?? "";
+}
+
+function currentTokenQuery(value: string): string {
+  const token = value.split(/[\s,]+/).at(-1) ?? "";
+  return normalizeUsername(token);
+}
+
+function candidateUsers(
+  userByUsername: Map<string, ChatUserSummary>,
+  currentUserId: string | null | undefined,
+): DmUserCandidate[] {
+  const candidates = new Map<string, DmUserCandidate>();
+  for (const [key, user] of userByUsername) {
+    if (currentUserId && user.id === currentUserId) continue;
+    const username = normalizeUsername(user.username ?? key);
+    if (!username) continue;
+    candidates.set(username, {
+      username,
+      displayName: user.displayName?.trim() || `@${username}`,
+    });
+  }
+  return [...candidates.values()].sort((left, right) => left.username.localeCompare(right.username));
+}
+
+function setUsernameSelected(value: string, username: string, selected: boolean): string {
+  const usernames = parseDmUsernames(value).filter((existing) => existing !== username);
+  if (selected) usernames.push(username);
+  return usernames.map((entry) => `@${entry}`).join(" ") + (usernames.length > 0 ? " " : "");
+}
+
+function usernamesLabel(usernames: string[], width: number): string {
+  return truncateChannelLabel(usernames.map((username) => `@${username}`).join(" "), width);
+}
+
+export function NewDmDialog({
+  width,
+  height,
+  userByUsername,
+  currentUserId,
+  onCancel,
+  onSubmit,
+}: {
+  width: number;
+  height: number;
+  userByUsername: Map<string, ChatUserSummary>;
+  currentUserId?: string | null;
+  onCancel: () => void;
+  onSubmit: (usernames: string[]) => Promise<void>;
+}) {
+  const inputRef = useRef<InputRenderable | null>(null);
+  const [value, setValue] = useState("");
+  const valueRef = useRef("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const dialogWidth = Math.max(MIN_DIALOG_WIDTH, Math.min(MAX_DIALOG_WIDTH, width - 4));
+  const dialogHeight = Math.min(DIALOG_HEIGHT, Math.max(7, height - 2));
+  const left = Math.max(0, Math.floor((width - dialogWidth) / 2));
+  const top = Math.max(0, Math.floor((height - dialogHeight) / 2));
+  const contentWidth = Math.max(1, dialogWidth - 4);
+  const selectedUsernames = useMemo(() => parseDmUsernames(value), [value]);
+  const selectedUsernameSet = useMemo(() => new Set(selectedUsernames), [selectedUsernames]);
+  const allCandidates = useMemo(() => candidateUsers(userByUsername, currentUserId), [currentUserId, userByUsername]);
+  const query = currentTokenQuery(value);
+  const visibleCandidates = useMemo(() => {
+    const filtered = query
+      ? allCandidates.filter((candidate) => candidate.username.includes(query))
+      : allCandidates;
+    return filtered.slice(0, MAX_RECENT_USERS);
+  }, [allCandidates, query]);
+  const items = useMemo<ListViewItem[]>(() => visibleCandidates.map((candidate) => ({
+    id: candidate.username,
+    label: `@${candidate.username}`,
+    detail: candidate.displayName,
+    checked: selectedUsernameSet.has(candidate.username),
+  })), [selectedUsernameSet, visibleCandidates]);
+  const canSubmit = hasOnlyDmUsernameArgs(value) && selectedUsernames.length > 0 && !submitting;
+
+  useEffect(() => {
+    inputRef.current?.focus?.();
+  }, []);
+
+  useEffect(() => {
+    setSelectedIndex((current) => Math.max(0, Math.min(current, Math.max(items.length - 1, 0))));
+  }, [items.length]);
+
+  const updateValue = (nextValue: string) => {
+    valueRef.current = nextValue;
+    setValue(nextValue);
+  };
+
+  const toggleCandidate = (username: string) => {
+    updateValue(setUsernameSelected(valueRef.current, username, !parseDmUsernames(valueRef.current).includes(username)));
+    setError(null);
+    queueMicrotask(() => inputRef.current?.focus?.());
+  };
+
+  const submit = async () => {
+    const submittedValue = valueRef.current;
+    const submittedUsernames = parseDmUsernames(submittedValue);
+    if (!hasOnlyDmUsernameArgs(submittedValue) || submittedUsernames.length === 0 || submitting) {
+      setError("Enter at least one @username.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(submittedUsernames);
+    } catch {
+      setError("Could not start conversation.");
+      setSubmitting(false);
+    }
+  };
+
+  useShortcut((event) => {
+    if (event.name === "escape") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      onCancel();
+      return;
+    }
+    if (isPlainKey(event, "up", "down")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      setSelectedIndex((current) => {
+        if (items.length === 0) return 0;
+        return event.name === "up"
+          ? Math.max(0, current - 1)
+          : Math.min(items.length - 1, current + 1);
+      });
+      return;
+    }
+    if (event.name === "tab" && items[selectedIndex]) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      toggleCandidate(items[selectedIndex]!.id);
+      return;
+    }
+    if (event.name === "enter" || event.name === "return") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      void submit();
+    }
+  }, { allowEditable: true, phase: "before" });
+
+  return (
+    <Box
+      position="absolute"
+      left={left}
+      top={top}
+      width={dialogWidth}
+      height={dialogHeight}
+      flexDirection="column"
+      border
+      borderColor={colors.borderFocused}
+      backgroundColor={colors.bg}
+      paddingX={1}
+      onMouseDown={(event: any) => {
+        event?.preventDefault?.();
+        event?.stopPropagation?.();
+      }}
+      style={{ zIndex: 8 }}
+    >
+      <Box height={1} flexDirection="row">
+        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>New DM</Text>
+        <Box flexGrow={1} />
+        <Box width={3} height={1} backgroundColor={colors.panel} onMouseDown={onCancel} style={{ cursor: "pointer" }}>
+          <Text fg={colors.text}> x </Text>
+        </Box>
+      </Box>
+      <TextField
+        inputRef={inputRef}
+        value={value}
+        placeholder="@username, @second"
+        focused
+        width={contentWidth}
+        backgroundColor={colors.panel}
+        onChange={(nextValue) => {
+          updateValue(nextValue);
+          setError(null);
+        }}
+        onSubmit={() => { void submit(); }}
+      />
+      <Box height={1}>
+        <Text fg={selectedUsernames.length > 0 ? colors.textMuted : colors.textDim}>
+          {selectedUsernames.length > 0 ? usernamesLabel(selectedUsernames, contentWidth) : "Recent users"}
+        </Text>
+      </Box>
+      <ListView
+        items={items}
+        selectedIndex={items.length > 0 ? selectedIndex : -1}
+        height={Math.max(1, dialogHeight - 6)}
+        bgColor={colors.bg}
+        selectedBgColor={colors.selected}
+        hoverBgColor={hoverBg()}
+        emptyMessage="No recent users"
+        selectOnHover
+        onSelect={setSelectedIndex}
+        onActivate={(item) => toggleCandidate(item.id)}
+        renderRow={(item, state) => (
+          <Box flexDirection="row" width={contentWidth}>
+            <Text fg={state.selected ? colors.selectedText : colors.textDim}>
+              {item.checked ? "x " : "+ "}
+            </Text>
+            <Text
+              fg={state.selected ? colors.text : colors.textMuted}
+              attributes={state.selected ? TextAttributes.BOLD : 0}
+            >
+              {truncateChannelLabel(item.label, Math.max(1, contentWidth - 12))}
+            </Text>
+            <Box flexGrow={1} />
+            {item.detail ? (
+              <Text fg={colors.textDim}>{truncateChannelLabel(item.detail, 10)}</Text>
+            ) : null}
+          </Box>
+        )}
+      />
+      <Box height={1} flexDirection="row">
+        {error ? (
+          <Text fg={colors.negative}>{truncateChannelLabel(error, contentWidth)}</Text>
+        ) : (
+          <Text fg={colors.textDim}>{selectedUsernames.length > 1 ? "Group chat" : "Direct message"}</Text>
+        )}
+        <Box flexGrow={1} />
+        <Box
+          width={submitting ? 10 : 7}
+          height={1}
+          backgroundColor={canSubmit ? colors.selected : colors.panel}
+          onMouseDown={() => { void submit(); }}
+          style={{ cursor: canSubmit ? "pointer" : "default" }}
+        >
+          <Text fg={canSubmit ? colors.selectedText : colors.textDim}>
+            {submitting ? " Starting " : " Start "}
+          </Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/plugins/builtin/chat/content/transcript.tsx
+++ b/src/plugins/builtin/chat/content/transcript.tsx
@@ -29,7 +29,6 @@ interface ChatTranscriptProps {
   messages: ChatMessage[];
   nativePaneChrome: boolean | undefined;
   latestEditableMessageId: string | null;
-  openDirectMessage: (target: ChatUserSummary) => void;
   openTicker: (symbol: string) => void;
   profilePopoverUser: ChatUserSummary | null;
   registerMessageElement: (messageId: string, node: unknown | null) => void;
@@ -61,7 +60,6 @@ export function ChatTranscript({
   messages,
   nativePaneChrome,
   latestEditableMessageId,
-  openDirectMessage,
   openTicker,
   profilePopoverUser,
   registerMessageElement,
@@ -152,8 +150,6 @@ export function ChatTranscript({
         <UserProfilePopover
           user={profilePopoverUser}
           width={chatWidth}
-          currentUserId={user?.id}
-          onDirectMessage={openDirectMessage}
           onClose={scheduleProfilePopoverClose}
           onKeepOpen={cancelProfilePopoverClose}
         />

--- a/src/plugins/builtin/chat/message/profile-popover.test.tsx
+++ b/src/plugins/builtin/chat/message/profile-popover.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import type { ChatUserSummary } from "../../../../api-client";
+import { hasPublicChatProfileInfo } from "./profile-popover";
+
+function makeUser(overrides: Partial<ChatUserSummary>): ChatUserSummary {
+  return {
+    id: "u1",
+    username: "vince",
+    displayName: "Vince",
+    profilePublic: true,
+    ...overrides,
+  };
+}
+
+describe("profile popover", () => {
+  test("treats public portfolio analytics as hover profile information", () => {
+    expect(hasPublicChatProfileInfo(makeUser({
+      bio: null,
+      company: null,
+      title: null,
+      portfolioAnalytics: {
+        portfolioName: "Main Portfolio",
+        holdingsCount: 12,
+        oneYearReturn: 0.14,
+        spyBeta: 1.05,
+        marketValue: 125000,
+        currency: "USD",
+      },
+    }))).toBe(true);
+  });
+
+  test("hides analytics when the chat profile is private", () => {
+    expect(hasPublicChatProfileInfo(makeUser({
+      profilePublic: false,
+      portfolioAnalytics: {
+        oneYearReturn: 0.14,
+      },
+    }))).toBe(false);
+  });
+});

--- a/src/plugins/builtin/chat/message/profile-popover.test.tsx
+++ b/src/plugins/builtin/chat/message/profile-popover.test.tsx
@@ -19,12 +19,8 @@ describe("profile popover", () => {
       company: null,
       title: null,
       portfolioAnalytics: {
-        portfolioName: "Main Portfolio",
-        holdingsCount: 12,
         oneYearReturn: 0.14,
         spyBeta: 1.05,
-        marketValue: 125000,
-        currency: "USD",
       },
     }))).toBe(true);
   });

--- a/src/plugins/builtin/chat/message/profile-popover.tsx
+++ b/src/plugins/builtin/chat/message/profile-popover.tsx
@@ -28,6 +28,13 @@ function formatSignedPercent(value: number): string {
   return `${percent >= 0 ? "+" : ""}${formatNumber(percent, 2)}%`;
 }
 
+type AnalyticsMetric = {
+  id: "one-year" | "beta";
+  label: string;
+  value: string;
+  rawValue: number;
+};
+
 function analyticsValueColor(id: string, value: number): string {
   if (id === "one-year") {
     if (value > 0) return colors.positive;
@@ -36,7 +43,7 @@ function analyticsValueColor(id: string, value: number): string {
   return colors.warning;
 }
 
-function analyticsMetrics(analytics: PublicPortfolioAnalytics) {
+function analyticsMetrics(analytics: PublicPortfolioAnalytics): AnalyticsMetric[] {
   return [
     analytics.oneYearReturn != null
       ? {
@@ -54,28 +61,49 @@ function analyticsMetrics(analytics: PublicPortfolioAnalytics) {
         rawValue: analytics.spyBeta,
       }
       : null,
-  ].filter((metric): metric is { id: string; label: string; value: string; rawValue: number } => !!metric);
+  ].filter((metric): metric is AnalyticsMetric => !!metric);
 }
 
-function PortfolioAnalyticsBand({
-  analytics,
+function headerMetricLabel(metric: AnalyticsMetric): string {
+  return metric.id === "beta" ? "Beta" : metric.label;
+}
+
+function headerMetricsNaturalWidth(metrics: AnalyticsMetric[]): number {
+  const metricWidth = metrics.reduce((sum, metric) => (
+    sum + headerMetricLabel(metric).length + 1 + metric.value.length
+  ), 0);
+  return metricWidth + Math.max(0, metrics.length - 1);
+}
+
+function HeaderAnalyticsStats({
+  metrics,
   width,
 }: {
-  analytics: PublicPortfolioAnalytics;
+  metrics: AnalyticsMetric[];
   width: number;
 }) {
-  const metrics = analyticsMetrics(analytics);
-  if (metrics.length === 0) return null;
-  const metricWidth = Math.max(11, Math.floor((width - 2) / metrics.length));
+  if (metrics.length === 0 || width < 8) return null;
+  const gapWidth = Math.max(0, metrics.length - 1);
+  const naturalWidths = metrics.map((metric) => headerMetricLabel(metric).length + 1 + metric.value.length);
+  const availableMetricWidth = Math.max(metrics.length * 4, width - gapWidth);
+  let overflow = Math.max(0, naturalWidths.reduce((sum, value) => sum + value, 0) - availableMetricWidth);
+  const metricWidths = naturalWidths.map((naturalWidth, index) => {
+    const shrinkable = Math.max(0, naturalWidth - 4);
+    const shrink = Math.min(shrinkable, Math.ceil(overflow / (naturalWidths.length - index)));
+    overflow -= shrink;
+    return naturalWidth - shrink;
+  });
 
   return (
-    <Box flexDirection="row" flexWrap="wrap" gap={2} width={width} backgroundColor={colors.commandBg}>
-      {metrics.map((metric) => {
-        const labelWidth = Math.max(1, Math.min(metric.label.length, metricWidth - 2));
+    <Box flexDirection="row" gap={1} width={width}>
+      {metrics.map((metric, index) => {
+        const label = headerMetricLabel(metric);
+        const metricWidth = metricWidths[index] ?? 4;
+        const labelWidth = Math.max(1, Math.min(label.length, metricWidth - 2));
         const valueWidth = Math.max(1, metricWidth - labelWidth - 1);
         return (
           <Box key={metric.id} width={metricWidth} height={1} flexDirection="row" gap={1}>
-            <Text fg={colors.textMuted}>{truncateChannelLabel(metric.label, labelWidth)}</Text>
+            <Text fg={colors.textMuted}>{truncateChannelLabel(label, labelWidth)}</Text>
             <Text fg={analyticsValueColor(metric.id, metric.rawValue)} attributes={TextAttributes.BOLD}>
               {truncateChannelLabel(metric.value, valueWidth)}
             </Text>
@@ -105,7 +133,15 @@ export function UserProfilePopover({
   const meta = [user.title, user.company].filter(Boolean).join(" · ");
   const bio = user.bio?.trim();
   const analytics = user.portfolioAnalytics;
+  const metrics = analytics ? analyticsMetrics(analytics) : [];
   const canDm = user.id === currentUserId || user.acceptUnknownDms !== false;
+  const headerWidth = Math.max(1, popoverWidth - 4);
+  const dmWidth = canDm ? 5 : 9;
+  const maxStatsWidth = Math.max(0, headerWidth - dmWidth - 8);
+  const statsWidth = metrics.length > 0 && maxStatsWidth >= 8
+    ? Math.min(headerMetricsNaturalWidth(metrics), maxStatsWidth)
+    : 0;
+  const usernameWidth = Math.max(1, headerWidth - dmWidth - (statsWidth > 0 ? statsWidth + 1 : 0));
 
   return (
     <Box
@@ -122,10 +158,18 @@ export function UserProfilePopover({
       onMouseOut={onClose}
       style={{ zIndex: 4 }}
     >
-      <Box height={1} flexDirection="row">
-        <Text fg={colors.positive} attributes={TextAttributes.BOLD}>
-          {truncateChannelLabel(user.username ? `@${user.username}` : user.displayName, Math.max(popoverWidth - 10, 1))}
-        </Text>
+      <Box height={1} width={headerWidth} flexDirection="row">
+        <Box width={usernameWidth}>
+          <Text fg={colors.positive} attributes={TextAttributes.BOLD}>
+            {truncateChannelLabel(user.username ? `@${user.username}` : user.displayName, usernameWidth)}
+          </Text>
+        </Box>
+        {statsWidth > 0 ? (
+          <>
+            <Box width={1} />
+            <HeaderAnalyticsStats metrics={metrics} width={statsWidth} />
+          </>
+        ) : null}
         <Box flexGrow={1} />
         <ChatActionChip
           label={canDm ? "DM" : "Closed"}
@@ -141,9 +185,6 @@ export function UserProfilePopover({
         <Text fg={colors.text} wrapText width={popoverWidth - 2}>
           {bio}
         </Text>
-      ) : null}
-      {analytics && hasPortfolioAnalytics(analytics) ? (
-        <PortfolioAnalyticsBand analytics={analytics} width={Math.max(1, popoverWidth - 4)} />
       ) : null}
     </Box>
   );

--- a/src/plugins/builtin/chat/message/profile-popover.tsx
+++ b/src/plugins/builtin/chat/message/profile-popover.tsx
@@ -1,15 +1,42 @@
 import { Box, Text } from "../../../../ui";
 import { TextAttributes } from "../../../../ui";
 import { colors } from "../../../../theme/colors";
-import type { ChatUserSummary } from "../../../../api-client";
+import type { ChatUserSummary, PublicPortfolioAnalytics } from "../../../../api-client";
+import { formatCompact, formatNumber } from "../../../../utils/format";
 import { truncateChannelLabel } from "../channels";
 import { ChatActionChip } from "./action-chip";
 
 export const PROFILE_POPOVER_CLOSE_DELAY_MS = 40;
 
+function hasPortfolioAnalytics(analytics: PublicPortfolioAnalytics | null | undefined): boolean {
+  return Boolean(
+    analytics
+    && (
+      analytics.portfolioName?.trim()
+      || analytics.oneYearReturn != null
+      || analytics.spyBeta != null
+      || analytics.marketValue != null
+    ),
+  );
+}
+
 export function hasPublicChatProfileInfo(user: ChatUserSummary): boolean {
   if (user.profilePublic === false) return false;
-  return Boolean(user.bio?.trim() || user.title?.trim() || user.company?.trim());
+  return Boolean(user.bio?.trim() || user.title?.trim() || user.company?.trim() || hasPortfolioAnalytics(user.portfolioAnalytics));
+}
+
+function formatSignedPercent(value: number): string {
+  const percent = value * 100;
+  return `${percent >= 0 ? "+" : ""}${formatNumber(percent, 2)}%`;
+}
+
+function analyticsLine(analytics: PublicPortfolioAnalytics): string | null {
+  const parts = [
+    analytics.oneYearReturn != null ? `1Y ${formatSignedPercent(analytics.oneYearReturn)}` : null,
+    analytics.spyBeta != null ? `Beta ${formatNumber(analytics.spyBeta, 2)}` : null,
+    analytics.marketValue != null ? `Value ${formatCompact(analytics.marketValue)}${analytics.currency ? ` ${analytics.currency}` : ""}` : null,
+  ].filter((part): part is string => !!part);
+  return parts.length > 0 ? parts.join(" · ") : null;
 }
 
 export function UserProfilePopover({
@@ -30,6 +57,9 @@ export function UserProfilePopover({
   const popoverWidth = Math.max(24, Math.min(38, width - 4));
   const meta = [user.title, user.company].filter(Boolean).join(" · ");
   const bio = user.bio?.trim();
+  const analytics = user.portfolioAnalytics;
+  const analyticsTitle = analytics?.portfolioName?.trim();
+  const analyticsDetail = analytics && hasPortfolioAnalytics(analytics) ? analyticsLine(analytics) : null;
   const canDm = user.id === currentUserId || user.acceptUnknownDms !== false;
 
   return (
@@ -66,6 +96,16 @@ export function UserProfilePopover({
         <Text fg={colors.text} wrapText width={popoverWidth - 2}>
           {bio}
         </Text>
+      ) : null}
+      {analytics && hasPortfolioAnalytics(analytics) ? (
+        <Box flexDirection="column">
+          {analyticsTitle ? (
+            <Text fg={colors.textDim}>{truncateChannelLabel(analyticsTitle, popoverWidth - 2)}</Text>
+          ) : null}
+          {analyticsDetail ? (
+            <Text fg={colors.text}>{truncateChannelLabel(analyticsDetail, popoverWidth - 2)}</Text>
+          ) : null}
+        </Box>
       ) : null}
     </Box>
   );

--- a/src/plugins/builtin/chat/message/profile-popover.tsx
+++ b/src/plugins/builtin/chat/message/profile-popover.tsx
@@ -4,7 +4,6 @@ import { colors } from "../../../../theme/colors";
 import type { ChatUserSummary, PublicPortfolioAnalytics } from "../../../../api-client";
 import { formatNumber } from "../../../../utils/format";
 import { truncateChannelLabel } from "../channels";
-import { ChatActionChip } from "./action-chip";
 
 export const PROFILE_POPOVER_CLOSE_DELAY_MS = 40;
 
@@ -117,15 +116,11 @@ function HeaderAnalyticsStats({
 export function UserProfilePopover({
   user,
   width,
-  currentUserId,
-  onDirectMessage,
   onClose,
   onKeepOpen,
 }: {
   user: ChatUserSummary;
   width: number;
-  currentUserId?: string | null;
-  onDirectMessage: (user: ChatUserSummary) => void;
   onClose: () => void;
   onKeepOpen: () => void;
 }) {
@@ -134,14 +129,12 @@ export function UserProfilePopover({
   const bio = user.bio?.trim();
   const analytics = user.portfolioAnalytics;
   const metrics = analytics ? analyticsMetrics(analytics) : [];
-  const canDm = user.id === currentUserId || user.acceptUnknownDms !== false;
-  const headerWidth = Math.max(1, popoverWidth - 4);
-  const dmWidth = canDm ? 5 : 9;
-  const maxStatsWidth = Math.max(0, headerWidth - dmWidth - 8);
+  const headerWidth = Math.max(1, popoverWidth - 2);
+  const maxStatsWidth = Math.max(0, headerWidth - 8);
   const statsWidth = metrics.length > 0 && maxStatsWidth >= 8
     ? Math.min(headerMetricsNaturalWidth(metrics), maxStatsWidth)
     : 0;
-  const usernameWidth = Math.max(1, headerWidth - dmWidth - (statsWidth > 0 ? statsWidth + 1 : 0));
+  const usernameWidth = Math.max(1, headerWidth - (statsWidth > 0 ? statsWidth + 1 : 0));
 
   return (
     <Box
@@ -171,14 +164,6 @@ export function UserProfilePopover({
           </>
         ) : null}
         <Box flexGrow={1} />
-        <ChatActionChip
-          label={canDm ? "DM" : "Closed"}
-          width={canDm ? 5 : 9}
-          emphasized
-          onPress={() => {
-            if (canDm) onDirectMessage(user);
-          }}
-        />
       </Box>
       {meta ? <Text fg={colors.textDim}>{truncateChannelLabel(meta, popoverWidth - 2)}</Text> : null}
       {bio ? (

--- a/src/plugins/builtin/chat/message/profile-popover.tsx
+++ b/src/plugins/builtin/chat/message/profile-popover.tsx
@@ -28,12 +28,61 @@ function formatSignedPercent(value: number): string {
   return `${percent >= 0 ? "+" : ""}${formatNumber(percent, 2)}%`;
 }
 
-function analyticsLine(analytics: PublicPortfolioAnalytics): string | null {
-  const parts = [
-    analytics.oneYearReturn != null ? `1Y ${formatSignedPercent(analytics.oneYearReturn)}` : null,
-    analytics.spyBeta != null ? `Beta ${formatNumber(analytics.spyBeta, 2)}` : null,
-  ].filter((part): part is string => !!part);
-  return parts.length > 0 ? parts.join(" · ") : null;
+function analyticsValueColor(id: string, value: number): string {
+  if (id === "one-year") {
+    if (value > 0) return colors.positive;
+    if (value < 0) return colors.negative;
+  }
+  return colors.warning;
+}
+
+function analyticsMetrics(analytics: PublicPortfolioAnalytics) {
+  return [
+    analytics.oneYearReturn != null
+      ? {
+        id: "one-year",
+        label: "1Y",
+        value: formatSignedPercent(analytics.oneYearReturn),
+        rawValue: analytics.oneYearReturn,
+      }
+      : null,
+    analytics.spyBeta != null
+      ? {
+        id: "beta",
+        label: "Beta",
+        value: formatNumber(analytics.spyBeta, 2),
+        rawValue: analytics.spyBeta,
+      }
+      : null,
+  ].filter((metric): metric is { id: string; label: string; value: string; rawValue: number } => !!metric);
+}
+
+function PortfolioAnalyticsBand({
+  analytics,
+  width,
+}: {
+  analytics: PublicPortfolioAnalytics;
+  width: number;
+}) {
+  const metrics = analyticsMetrics(analytics);
+  if (metrics.length === 0) return null;
+  const metricWidth = Math.max(9, Math.floor((width - 5) / metrics.length));
+
+  return (
+    <Box flexDirection="column" width={width} backgroundColor={colors.commandBg} paddingX={1}>
+      <Text fg={colors.textDim}>Portfolio Stats</Text>
+      <Box flexDirection="row" gap={1}>
+        {metrics.map((metric) => (
+          <Box key={metric.id} width={metricWidth} flexDirection="column">
+            <Text fg={colors.textMuted}>{truncateChannelLabel(metric.label, metricWidth)}</Text>
+            <Text fg={analyticsValueColor(metric.id, metric.rawValue)} attributes={TextAttributes.BOLD}>
+              {truncateChannelLabel(metric.value, metricWidth)}
+            </Text>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
 }
 
 export function UserProfilePopover({
@@ -55,7 +104,6 @@ export function UserProfilePopover({
   const meta = [user.title, user.company].filter(Boolean).join(" · ");
   const bio = user.bio?.trim();
   const analytics = user.portfolioAnalytics;
-  const analyticsDetail = analytics && hasPortfolioAnalytics(analytics) ? analyticsLine(analytics) : null;
   const canDm = user.id === currentUserId || user.acceptUnknownDms !== false;
 
   return (
@@ -94,11 +142,7 @@ export function UserProfilePopover({
         </Text>
       ) : null}
       {analytics && hasPortfolioAnalytics(analytics) ? (
-        <Box flexDirection="column">
-          {analyticsDetail ? (
-            <Text fg={colors.text}>{truncateChannelLabel(analyticsDetail, popoverWidth - 2)}</Text>
-          ) : null}
-        </Box>
+        <PortfolioAnalyticsBand analytics={analytics} width={popoverWidth - 2} />
       ) : null}
     </Box>
   );

--- a/src/plugins/builtin/chat/message/profile-popover.tsx
+++ b/src/plugins/builtin/chat/message/profile-popover.tsx
@@ -2,7 +2,7 @@ import { Box, Text } from "../../../../ui";
 import { TextAttributes } from "../../../../ui";
 import { colors } from "../../../../theme/colors";
 import type { ChatUserSummary, PublicPortfolioAnalytics } from "../../../../api-client";
-import { formatCompact, formatNumber } from "../../../../utils/format";
+import { formatNumber } from "../../../../utils/format";
 import { truncateChannelLabel } from "../channels";
 import { ChatActionChip } from "./action-chip";
 
@@ -12,10 +12,8 @@ function hasPortfolioAnalytics(analytics: PublicPortfolioAnalytics | null | unde
   return Boolean(
     analytics
     && (
-      analytics.portfolioName?.trim()
-      || analytics.oneYearReturn != null
+      analytics.oneYearReturn != null
       || analytics.spyBeta != null
-      || analytics.marketValue != null
     ),
   );
 }
@@ -34,7 +32,6 @@ function analyticsLine(analytics: PublicPortfolioAnalytics): string | null {
   const parts = [
     analytics.oneYearReturn != null ? `1Y ${formatSignedPercent(analytics.oneYearReturn)}` : null,
     analytics.spyBeta != null ? `Beta ${formatNumber(analytics.spyBeta, 2)}` : null,
-    analytics.marketValue != null ? `Value ${formatCompact(analytics.marketValue)}${analytics.currency ? ` ${analytics.currency}` : ""}` : null,
   ].filter((part): part is string => !!part);
   return parts.length > 0 ? parts.join(" · ") : null;
 }
@@ -58,7 +55,6 @@ export function UserProfilePopover({
   const meta = [user.title, user.company].filter(Boolean).join(" · ");
   const bio = user.bio?.trim();
   const analytics = user.portfolioAnalytics;
-  const analyticsTitle = analytics?.portfolioName?.trim();
   const analyticsDetail = analytics && hasPortfolioAnalytics(analytics) ? analyticsLine(analytics) : null;
   const canDm = user.id === currentUserId || user.acceptUnknownDms !== false;
 
@@ -99,9 +95,6 @@ export function UserProfilePopover({
       ) : null}
       {analytics && hasPortfolioAnalytics(analytics) ? (
         <Box flexDirection="column">
-          {analyticsTitle ? (
-            <Text fg={colors.textDim}>{truncateChannelLabel(analyticsTitle, popoverWidth - 2)}</Text>
-          ) : null}
           {analyticsDetail ? (
             <Text fg={colors.text}>{truncateChannelLabel(analyticsDetail, popoverWidth - 2)}</Text>
           ) : null}

--- a/src/plugins/builtin/chat/message/profile-popover.tsx
+++ b/src/plugins/builtin/chat/message/profile-popover.tsx
@@ -66,21 +66,22 @@ function PortfolioAnalyticsBand({
 }) {
   const metrics = analyticsMetrics(analytics);
   if (metrics.length === 0) return null;
-  const metricWidth = Math.max(9, Math.floor((width - 5) / metrics.length));
+  const metricWidth = Math.max(11, Math.floor((width - 2) / metrics.length));
 
   return (
-    <Box flexDirection="column" width={width} backgroundColor={colors.commandBg} paddingX={1}>
-      <Text fg={colors.textDim}>Portfolio Stats</Text>
-      <Box flexDirection="row" gap={1}>
-        {metrics.map((metric) => (
-          <Box key={metric.id} width={metricWidth} flexDirection="column">
-            <Text fg={colors.textMuted}>{truncateChannelLabel(metric.label, metricWidth)}</Text>
+    <Box flexDirection="row" flexWrap="wrap" gap={2} width={width} backgroundColor={colors.commandBg}>
+      {metrics.map((metric) => {
+        const labelWidth = Math.max(1, Math.min(metric.label.length, metricWidth - 2));
+        const valueWidth = Math.max(1, metricWidth - labelWidth - 1);
+        return (
+          <Box key={metric.id} width={metricWidth} height={1} flexDirection="row" gap={1}>
+            <Text fg={colors.textMuted}>{truncateChannelLabel(metric.label, labelWidth)}</Text>
             <Text fg={analyticsValueColor(metric.id, metric.rawValue)} attributes={TextAttributes.BOLD}>
-              {truncateChannelLabel(metric.value, metricWidth)}
+              {truncateChannelLabel(metric.value, valueWidth)}
             </Text>
           </Box>
-        ))}
-      </Box>
+        );
+      })}
     </Box>
   );
 }
@@ -142,7 +143,7 @@ export function UserProfilePopover({
         </Text>
       ) : null}
       {analytics && hasPortfolioAnalytics(analytics) ? (
-        <PortfolioAnalyticsBand analytics={analytics} width={popoverWidth - 2} />
+        <PortfolioAnalyticsBand analytics={analytics} width={Math.max(1, popoverWidth - 4)} />
       ) : null}
     </Box>
   );

--- a/src/plugins/builtin/chat/sidebar.test.tsx
+++ b/src/plugins/builtin/chat/sidebar.test.tsx
@@ -5,6 +5,7 @@ import { AppContext, appReducer, createInitialState, PaneInstanceProvider } from
 import { createConfigBackedTestPluginRuntime, createTestPluginRuntime } from "../../../test-support/plugin-runtime";
 import { createDefaultConfig, findPaneInstance, type PaneInstanceConfig } from "../../../types/config";
 import { TextAttributes } from "../../../ui";
+import { apiClient } from "../../../api-client";
 import { PluginRenderProvider } from "../../runtime";
 import { gloomberbCloudPlugin } from "../cloud";
 import { ChatContent } from "../chat";
@@ -18,6 +19,7 @@ import {
   installChatApiTestDefaults,
   installServerChannels,
   lineText,
+  makeMessage,
   MemoryPersistence,
   type ChatTestSetup,
 } from "./test-harness";
@@ -214,6 +216,72 @@ describe("ChatContent channel sidebar", () => {
     expect(setup().captureCharFrame()).not.toContain("#options");
   });
 
+  test("opens a new direct-message dialog from the DMs header", async () => {
+    const controller = createController({
+      messages: [{
+        ...makeMessage(1),
+        user: { id: "u2", username: "bob", displayName: "Bob" },
+      }],
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    });
+    installServerChannels(controller);
+    controller.refreshChannels = async () => {};
+    controller.refreshChannelMessages = async () => {};
+    const openedTargets: Array<{ username?: string }> = [];
+    const originalOpenDirectChannel = apiClient.openDirectChannel.bind(apiClient);
+    apiClient.openDirectChannel = async (target) => {
+      openedTargets.push(target);
+      return {
+        id: "dm:bob",
+        name: "@bob",
+        kind: "direct",
+        created_at: "2026-07-03T09:30:00.000Z",
+        dmUser: { id: "u2", username: "bob", displayName: "Bob" },
+      };
+    };
+    const ChannelPane = createChannelPane(controller, "everyone");
+
+    try {
+      await act(async () => {
+        testSetup = await testRender(<ChannelPane />, {
+          width: 90,
+          height: 14,
+        });
+      });
+
+      await flushFrame();
+      const lines = setup().captureCharFrame().split("\n");
+      const row = lines.findIndex((line) => line.includes("DMs"));
+      const col = lines[row]?.lastIndexOf("+") ?? -1;
+      expect(row).toBeGreaterThanOrEqual(0);
+      expect(col).toBeGreaterThanOrEqual(0);
+
+      await act(async () => {
+        await setup().mockMouse.click(col, row);
+        await setup().renderOnce();
+        await setup().renderOnce();
+      });
+      await flushFrame();
+
+      expect(setup().captureCharFrame()).toContain("New DM");
+
+      await act(async () => {
+        await setup().mockInput.typeText("@bob");
+        setup().mockInput.pressEnter();
+        await setup().renderOnce();
+        await setup().renderOnce();
+      });
+      await flushFrame();
+
+      expect(openedTargets).toEqual([{ username: "bob" }]);
+      expect(setup().captureCharFrame()).toContain("@bob");
+      expect(setup().captureCharFrame()).not.toContain("New DM");
+    } finally {
+      apiClient.openDirectChannel = originalOpenDirectChannel;
+    }
+  });
+
   test("shows the sidebar online count footer", async () => {
     const controller = createController({ sessionToken: "token-123" });
     installServerChannels(controller);
@@ -314,8 +382,6 @@ describe("ChatContent channel sidebar", () => {
         channelIdRef,
         channels,
         channelsLoading: false,
-        closeProfilePopover: () => {},
-        controller,
         focused: true,
         inputFocused: false,
         onChannelChange: handleChannelChange,
@@ -412,6 +478,7 @@ describe("ChatContent channel sidebar", () => {
       },
       registerPaneTemplate: () => {},
       registerTickerResearchTab: () => {},
+      registerSyncTransport: () => {},
       registerShortcut: () => {},
       registerCommand: () => {},
       showPane: () => {},

--- a/src/plugins/builtin/chat/sidebar.tsx
+++ b/src/plugins/builtin/chat/sidebar.tsx
@@ -109,9 +109,11 @@ export function ChannelSidebar({
   keyboardFocused,
   loading,
   canManageNotifications,
+  canCreateConversation,
   directExpanded,
   onSelect,
   onFocusRequest,
+  onCreateConversation,
   onToggleNotifications,
   onToggleDirectExpanded,
 }: {
@@ -125,9 +127,11 @@ export function ChannelSidebar({
   keyboardFocused: boolean;
   loading: boolean;
   canManageNotifications: boolean;
+  canCreateConversation: boolean;
   directExpanded: boolean;
   onSelect?: (channelId: string) => void;
   onFocusRequest?: () => void;
+  onCreateConversation?: () => void;
   onToggleNotifications?: (channelId: string, enabled: boolean) => void;
   onToggleDirectExpanded?: () => void;
 }) {
@@ -149,9 +153,9 @@ export function ChannelSidebar({
   const conversationUnread = conversationChannels.some((channel) => (channelStateById.get(channel.id)?.unreadCount ?? 0) > 0);
   const sidebarRows = useMemo(() => [
     ...publicChannels.map((channel) => ({ kind: "channel" as const, channel })),
-    ...(conversationChannels.length > 0 ? [{ kind: "direct-header" as const }] : []),
+    ...(conversationChannels.length > 0 || canCreateConversation ? [{ kind: "direct-header" as const }] : []),
     ...(directExpanded ? conversationChannels.map((channel) => ({ kind: "channel" as const, channel })) : []),
-  ], [conversationChannels, directExpanded, publicChannels]);
+  ], [canCreateConversation, conversationChannels, directExpanded, publicChannels]);
   const sidebarLayoutHeight = nativePaneChrome ? "100%" : height;
   const nativeFillStyle = nativePaneChrome ? { minHeight: 0 } : undefined;
   const sidebarBorder = borderWidth > 0
@@ -201,6 +205,26 @@ export function ChannelSidebar({
                 >
                   {` ${directExpanded ? "▾" : "▸"} DMs`}
                 </Text>
+                <Box flexGrow={1} />
+                {canCreateConversation ? (
+                  <Box
+                    width={3}
+                    height={1}
+                    alignItems="center"
+                    justifyContent="center"
+                    backgroundColor={hoveredChannelId === "direct-header:create" ? hoverBg() : sidebarBg}
+                    onMouseOver={() => setHoveredChannelId("direct-header:create")}
+                    onMouseOut={() => setHoveredChannelId((current) => (current === "direct-header:create" ? null : current))}
+                    onMouseDown={(event: any) => {
+                      event?.preventDefault?.();
+                      event?.stopPropagation?.();
+                      onCreateConversation?.();
+                    }}
+                    style={{ cursor: "pointer" }}
+                  >
+                    <Text fg={colors.text} attributes={TextAttributes.BOLD}>+</Text>
+                  </Box>
+                ) : null}
               </Box>
             );
           }

--- a/src/plugins/builtin/chat/sidebar.tsx
+++ b/src/plugins/builtin/chat/sidebar.tsx
@@ -222,7 +222,7 @@ export function ChannelSidebar({
                     }}
                     style={{ cursor: "pointer" }}
                   >
-                    <Text fg={colors.text} attributes={TextAttributes.BOLD}>+</Text>
+                    <Text fg={hoveredChannelId === "direct-header:create" ? colors.textMuted : colors.textDim}>+</Text>
                   </Box>
                 ) : null}
               </Box>

--- a/src/plugins/builtin/cloud/plugin.tsx
+++ b/src/plugins/builtin/cloud/plugin.tsx
@@ -103,6 +103,13 @@ export function createGloomberbCloudPlugin({
       chatController.attachPersistence(ctx.persistence, ctx.resume);
       chatController.setNotifier(ctx.notify);
 
+      ctx.registerSyncTransport({
+        id: "gloomberb-cloud",
+        isAvailable: () => apiClient.isVerified(),
+        pullSnapshot: () => apiClient.getSyncSnapshot(),
+        pushSnapshot: (snapshot, options) => apiClient.putSyncSnapshot(snapshot, options),
+      });
+
       ctx.registerPane({
         id: "chat",
         name: "Chat",

--- a/src/plugins/builtin/correlation/relationship/controls.tsx
+++ b/src/plugins/builtin/correlation/relationship/controls.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "../../../../ui";
 import { colors } from "../../../../theme/colors";
+import { Checkbox } from "../../../../components/ui/checkbox";
 
 export function RelationshipMetricsTable({
   rows,
@@ -39,7 +40,7 @@ export function RelationshipToggle({
 }) {
   return (
     <Box
-      width={label.length + 5}
+      width={label.length + 6}
       height={1}
       onMouseDown={(event: { preventDefault?: () => void; stopPropagation?: () => void }) => {
         event.preventDefault?.();
@@ -47,7 +48,12 @@ export function RelationshipToggle({
         onPress();
       }}
     >
-      <Text fg={checked ? colors.text : colors.textDim}>{checked ? "[x]" : "[ ]"} {label}</Text>
+      <Checkbox
+        label={label}
+        checked={checked}
+        width={label.length + 6}
+        onChange={onPress}
+      />
     </Box>
   );
 }

--- a/src/plugins/registry/context.ts
+++ b/src/plugins/registry/context.ts
@@ -14,6 +14,7 @@ import type {
 } from "../../types/plugin";
 import type { PaneRuntimeState } from "../../core/state/app/state";
 import type { NewsQuery, NewsQueryState } from "../../types/news-source";
+import type { SyncContributor, SyncTransport } from "../../sync/types";
 import { debugLog } from "../../utils/debug-log";
 import { createPluginPersistence } from "../plugin-persistence";
 import type { PluginEvents } from "../event-bus";
@@ -35,6 +36,8 @@ export interface RegistryPluginContextOptions {
   updateLayout: (layout: LayoutConfig) => void;
   resolvePaneTarget: (paneId: string) => string | undefined;
   registerCapabilityForPlugin: (pluginId: string, capability: PluginCapability, items: PluginItems) => void;
+  registerSyncContributorForPlugin: (pluginId: string, contributor: SyncContributor) => () => void;
+  registerSyncTransportForPlugin: (pluginId: string, transport: SyncTransport) => () => void;
   watchNewsQuery: (query: NewsQuery, listener: (state: NewsQueryState) => void) => () => void;
   getData: (ticker: string) => TickerFinancials | null;
   getTicker: (symbol: string) => TickerRecord | null;
@@ -82,6 +85,8 @@ export function createRegistryPluginContext({
   updateLayout,
   resolvePaneTarget,
   registerCapabilityForPlugin,
+  registerSyncContributorForPlugin,
+  registerSyncTransportForPlugin,
   watchNewsQuery,
   getData,
   getTicker,
@@ -143,6 +148,16 @@ export function createRegistryPluginContext({
     registerShortcut: (shortcut) => contributions.registerShortcut(pluginId, shortcut, items),
     registerTickerAction: (action) => contributions.registerTickerAction(pluginId, action, items),
     registerContextMenuProvider: (provider) => contributions.registerContextMenuProvider(pluginId, provider, items),
+    registerSyncContributor: (contributor) => {
+      const dispose = registerSyncContributorForPlugin(pluginId, contributor);
+      items.eventDisposers.push(dispose);
+      return dispose;
+    },
+    registerSyncTransport: (transport) => {
+      const dispose = registerSyncTransportForPlugin(pluginId, transport);
+      items.eventDisposers.push(dispose);
+      return dispose;
+    },
     watchNewsQuery: (query, listener) => {
       const dispose = watchNewsQuery(query, listener);
       items.newsQueryWatchDisposers.push(dispose);

--- a/src/plugins/registry/index.ts
+++ b/src/plugins/registry/index.ts
@@ -27,6 +27,12 @@ import type {
 } from "../../types/plugin";
 import type { ContextMenuContext, ContextMenuItem } from "../../types/context-menu";
 import type { TickerRecord } from "../../types/ticker";
+import type {
+  RegisteredSyncContributor,
+  RegisteredSyncTransport,
+  SyncContributor,
+  SyncTransport,
+} from "../../sync/types";
 import { EventBus } from "../event-bus";
 import { resolvePaneInstance } from "../../types/config";
 import { debugLog } from "../../utils/debug-log";
@@ -49,6 +55,7 @@ import {
   releaseSharedRegistry,
 } from "./shared";
 import { RegistryResumeStateListeners } from "./plugin-state";
+import { cloudSyncController } from "../../sync/controller";
 
 interface PluginRegistryOptions {
   enableCapabilityHandlers?: boolean;
@@ -215,6 +222,28 @@ export class PluginRegistry implements PluginRuntimeAccess {
   get tickerActions(): ReadonlyMap<string, TickerAction> { return this.contributions.tickerActionsMap; }
   get allPlugins(): ReadonlyMap<string, GloomPlugin> { return this.plugins; }
 
+  registerSyncContributorForPlugin(pluginId: string, contributor: SyncContributor): () => void {
+    return cloudSyncController.registerContributor(pluginId, contributor);
+  }
+
+  registerSyncTransportForPlugin(pluginId: string, transport: SyncTransport): () => void {
+    return cloudSyncController.registerTransport(pluginId, transport);
+  }
+
+  getEnabledSyncContributors(): RegisteredSyncContributor[] {
+    const disabledPlugins = new Set(this.getConfigFn().disabledPlugins ?? []);
+    return cloudSyncController
+      .getRegisteredContributors()
+      .filter((entry) => !disabledPlugins.has(entry.pluginId));
+  }
+
+  getActiveSyncTransport(): RegisteredSyncTransport | null {
+    const disabledPlugins = new Set(this.getConfigFn().disabledPlugins ?? []);
+    return cloudSyncController
+      .getRegisteredTransports()
+      .find((entry) => !disabledPlugins.has(entry.pluginId) && entry.transport.isAvailable()) ?? null;
+  }
+
   getContextMenuItems(context: ContextMenuContext): ContextMenuItem[] {
     return resolveRegistryContextMenuItems({
       context,
@@ -373,6 +402,8 @@ export class PluginRegistry implements PluginRuntimeAccess {
       updateLayout: (layout) => this.updateLayoutFn(layout),
       resolvePaneTarget: (paneId) => this.resolvePaneTarget(paneId),
       registerCapabilityForPlugin: (targetPluginId, capability, pluginItems) => this.registerCapabilityForPlugin(targetPluginId, capability, pluginItems),
+      registerSyncContributorForPlugin: (targetPluginId, contributor) => this.registerSyncContributorForPlugin(targetPluginId, contributor),
+      registerSyncTransportForPlugin: (targetPluginId, transport) => this.registerSyncTransportForPlugin(targetPluginId, transport),
       watchNewsQuery: (query, listener) => this.watchNewsQueryFn(query, listener),
       getData: (ticker) => this.getDataFn(ticker),
       getTicker: (symbol) => this.getTickerFn(symbol),

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -103,6 +103,41 @@ function requireDesktopWorkspace(): DesktopWorkspace {
   return desktopWorkspace;
 }
 
+const pendingDesktopDeepLinks: string[] = [];
+
+function isGloomberbDeepLink(rawUrl: string): boolean {
+  try {
+    return new URL(rawUrl).protocol === "gloomberb:";
+  } catch {
+    return false;
+  }
+}
+
+function readOpenUrlEvent(event: unknown): string | null {
+  const data = event && typeof event === "object" ? (event as { data?: unknown }).data : null;
+  if (!data || typeof data !== "object") return null;
+  const url = (data as { url?: unknown }).url;
+  return typeof url === "string" && url ? url : null;
+}
+
+function sendDesktopDeepLink(rawUrl: string): void {
+  if (!isGloomberbDeepLink(rawUrl)) return;
+  const rpc = getWindowRpc(MAIN_WINDOW_RPC_KEY);
+  if (!rpc || !isWindowRpcReady(MAIN_WINDOW_RPC_KEY)) {
+    pendingDesktopDeepLinks.push(rawUrl);
+    if (pendingDesktopDeepLinks.length > 20) pendingDesktopDeepLinks.shift();
+    return;
+  }
+  detachedWindowManager.focusWindowForRpcKey(MAIN_WINDOW_RPC_KEY);
+  rpc.send["desktop.deepLink"]({ url: rawUrl });
+}
+
+function flushPendingDesktopDeepLinks(): void {
+  if (pendingDesktopDeepLinks.length === 0) return;
+  const urls = pendingDesktopDeepLinks.splice(0);
+  for (const url of urls) sendDesktopDeepLink(url);
+}
+
 function remoteFailure(code: string, message: string): RemoteControlResponse {
   return { ok: false, error: { code, message } };
 }
@@ -377,6 +412,7 @@ async function initialize(
     syncConfigAccessors,
   });
   if (init.windowKind === "main") {
+    flushPendingDesktopDeepLinks();
     void ensureDesktopRemoteControlServer().catch((error) => {
       console.error("[remote] desktop control endpoint failed", summarizeError(error));
     });
@@ -500,6 +536,12 @@ Electrobun.events.on("context-menu-clicked", (event: unknown) => {
   forEachReadyWindowRpc((windowRpc) => {
     windowRpc.send["context-menu.select"](message);
   });
+});
+
+Electrobun.events.on("open-url", (event: unknown) => {
+  const url = readOpenUrlEvent(event);
+  if (!url) return;
+  sendDesktopDeepLink(url);
 });
 
 ApplicationMenu.on("application-menu-clicked", (event: unknown) => {

--- a/src/renderers/electrobun/shared/protocol.ts
+++ b/src/renderers/electrobun/shared/protocol.ts
@@ -60,6 +60,10 @@ export interface DesktopRestartMessage {
   source?: string;
 }
 
+export interface DesktopDeepLinkMessage {
+  url: string;
+}
+
 export interface RemoteControlRequestMessage {
   request: RemoteControlRequest;
 }
@@ -89,6 +93,7 @@ export interface ElectrobunDesktopRpcSchema {
       "desktop.state": DesktopStateMessage;
       "desktop.dockPreview": DesktopDockPreviewMessage;
       "desktop.themePreview": DesktopThemePreviewMessage;
+      "desktop.deepLink": DesktopDeepLinkMessage;
       "update.progress": UpdateProgressMessage;
       "capability.event": CapabilityEventMessage;
     };

--- a/src/renderers/electrobun/view/backend-rpc.ts
+++ b/src/renderers/electrobun/view/backend-rpc.ts
@@ -4,6 +4,7 @@ import {
   type ApplicationMenuSelectMessage,
   type CapabilityEventMessage,
   type ContextMenuSelectMessage,
+  type DesktopDeepLinkMessage,
   type DesktopDockPreviewMessage,
   type DesktopRestartMessage,
   type DesktopStateMessage,
@@ -18,6 +19,7 @@ import type { RemoteControlRequest, RemoteControlResponse } from "../../../remot
 
 type ContextMenuSelectListener = (message: ContextMenuSelectMessage) => void;
 type ApplicationMenuSelectListener = (message: ApplicationMenuSelectMessage) => void;
+type DesktopDeepLinkListener = (message: DesktopDeepLinkMessage) => void;
 type DesktopStateListener = (message: DesktopStateMessage) => void;
 type DesktopDockPreviewListener = (message: DesktopDockPreviewMessage) => void;
 type DesktopThemePreviewListener = (message: DesktopThemePreviewMessage) => void;
@@ -29,6 +31,8 @@ let initSnapshot: ElectrobunBackendInit | null = null;
 let remoteControlRequestHandler: RemoteControlRequestHandler | null = null;
 const contextMenuSelectListeners = new Map<string, Set<ContextMenuSelectListener>>();
 const applicationMenuSelectListeners = new Set<ApplicationMenuSelectListener>();
+const desktopDeepLinkListeners = new Set<DesktopDeepLinkListener>();
+const pendingDesktopDeepLinks: DesktopDeepLinkMessage[] = [];
 const desktopStateListeners = new Set<DesktopStateListener>();
 const desktopDockPreviewListeners = new Set<DesktopDockPreviewListener>();
 const desktopThemePreviewListeners = new Set<DesktopThemePreviewListener>();
@@ -64,6 +68,17 @@ function subscribe<T>(
   };
 }
 
+function dispatchDesktopDeepLink(message: DesktopDeepLinkMessage): void {
+  if (desktopDeepLinkListeners.size === 0) {
+    pendingDesktopDeepLinks.push(message);
+    if (pendingDesktopDeepLinks.length > 20) pendingDesktopDeepLinks.shift();
+    return;
+  }
+  for (const listener of desktopDeepLinkListeners) {
+    listener(message);
+  }
+}
+
 const rpc = Electroview.defineRPC<ElectrobunDesktopRpcSchema>({
   maxRequestTime: 120_000,
   handlers: {
@@ -91,6 +106,10 @@ const rpc = Electroview.defineRPC<ElectrobunDesktopRpcSchema>({
         for (const listener of applicationMenuSelectListeners) {
           listener(decoded);
         }
+      },
+      "desktop.deepLink": (message) => {
+        if (typeof message.url !== "string" || !message.url) return;
+        dispatchDesktopDeepLink({ url: message.url });
       },
       "desktop.state": (message) => {
         for (const listener of desktopStateListeners) {
@@ -185,6 +204,16 @@ export function onApplicationMenuSelect(listener: ApplicationMenuSelectListener)
   applicationMenuSelectListeners.add(listener);
   return () => {
     applicationMenuSelectListeners.delete(listener);
+  };
+}
+
+export function onDesktopDeepLink(listener: DesktopDeepLinkListener): () => void {
+  desktopDeepLinkListeners.add(listener);
+  for (const message of pendingDesktopDeepLinks.splice(0)) {
+    listener(message);
+  }
+  return () => {
+    desktopDeepLinkListeners.delete(listener);
   };
 }
 

--- a/src/renderers/electrobun/view/desktop-deeplink-bridge.ts
+++ b/src/renderers/electrobun/view/desktop-deeplink-bridge.ts
@@ -1,0 +1,10 @@
+import type { DesktopDeepLinkBridge } from "../../../types/desktop-deeplink";
+import { onDesktopDeepLink } from "./backend-rpc";
+
+export function createDesktopDeepLinkBridge(): DesktopDeepLinkBridge {
+  return {
+    subscribe(listener) {
+      return onDesktopDeepLink(listener);
+    },
+  };
+}

--- a/src/renderers/electrobun/view/desktop/controls.tsx
+++ b/src/renderers/electrobun/view/desktop/controls.tsx
@@ -4,7 +4,7 @@ import { Box, Input, Text, Textarea, editableTextContextMenuItems, useRendererHo
 import { TextAttributes, type InputRenderable } from "../../../../ui";
 import { useShortcut } from "../../../../react/input";
 import { blendHex, colors } from "../../../../theme/colors";
-import { blendForContrast, higherContrast } from "../../../../theme/color-utils";
+import { contrastRatio } from "../../../../theme/color-utils";
 import { useThemeColors } from "../../../../theme/theme-context";
 import { isDetailBackNavigationKey } from "../../../../utils/back-navigation";
 import type { ButtonProps } from "../../../../components/ui/button";
@@ -53,7 +53,8 @@ export function WebButton({
       style={{
         border: `1px solid ${palette.border}`,
         borderRadius: CONTROL_RADIUS,
-        paddingInline: 8,
+        paddingLeft: 8,
+        paddingRight: 8,
         boxShadow: controlShadow(active),
         cursor: disabled ? "default" : "pointer",
       }}
@@ -61,7 +62,9 @@ export function WebButton({
       <Text
         fg={palette.fg}
         attributes={active ? TextAttributes.BOLD : 0}
-        style={{ fontWeight: active || variant === "primary" ? 700 : 600 }}
+        style={{
+          fontWeight: active || variant === "primary" ? 700 : 600,
+        }}
       >
         {label}
       </Text>
@@ -75,6 +78,27 @@ export function WebButton({
       )}
     </Box>
   );
+}
+
+function checkboxAccentColor(): string {
+  const base = colors.borderFocused;
+  const nativeCheckmark = "#ffffff";
+  const candidates = [
+    blendHex(base, colors.selected, 0.55),
+    blendHex(base, colors.selected, 0.65),
+    blendHex(base, "#000000", 0.45),
+    blendHex(base, "#000000", 0.52),
+    base,
+  ];
+  return candidates.find((candidate) => (
+    contrastRatio(candidate, nativeCheckmark) >= 4.5
+    && contrastRatio(candidate, colors.panel) >= 2.2
+  )) ?? candidates[1]!;
+}
+
+function checkboxCheckImage(): string {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14"><path d="M3 7.3 5.8 10 11.2 3.7" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+  return `url("data:image/svg+xml,${encodeURIComponent(svg)}")`;
 }
 
 export function WebCheckbox({
@@ -94,20 +118,8 @@ export function WebCheckbox({
     ? colors.textBright
     : colors.text;
   const visibleLabel = displayLabel ?? label;
-  const accentColor = blendForContrast(
-    higherContrast(colors.borderFocused, colors.selected, colors.panel),
-    colors.panel,
-    colors.textBright,
-    3.8,
-  );
-  const outlineColor = checked
-    ? blendForContrast(
-      higherContrast(colors.textBright, colors.bg, accentColor),
-      accentColor,
-      colors.bg,
-      3.2,
-    )
-    : controlBorderColor(active, false);
+  const accentColor = checkboxAccentColor();
+  const borderColor = checked ? accentColor : controlBorderColor(active, false);
   return (
     <Box
       flexDirection="column"
@@ -137,6 +149,7 @@ export function WebCheckbox({
           fontWeight: active ? 700 : 500,
           lineHeight: "20px",
           userSelect: "none",
+          position: "relative",
         }}
       >
         <input
@@ -145,14 +158,25 @@ export function WebCheckbox({
           readOnly
           disabled={disabled}
           style={{
+            appearance: "none",
+            WebkitAppearance: "none",
             width: 14,
             height: 14,
             margin: 0,
-            accentColor,
+            backgroundColor: checked ? accentColor : panelFill(),
+            backgroundImage: checked ? checkboxCheckImage() : undefined,
+            backgroundPosition: "center",
+            backgroundRepeat: "no-repeat",
+            backgroundSize: "12px 12px",
+            border: `1px solid ${borderColor}`,
+            borderRadius: 4,
+            boxShadow: active
+              ? `0 0 0 2px ${blendHex(colors.bg, colors.borderFocused, 0.28)}, inset 0 1px 0 rgba(255,255,255,0.16)`
+              : "inset 0 1px 0 rgba(255,255,255,0.10)",
+            boxSizing: "border-box",
             flexShrink: 0,
             cursor: disabled ? "default" : "pointer",
-            outline: `1px solid ${outlineColor}`,
-            outlineOffset: 1,
+            verticalAlign: "middle",
           }}
         />
         <span

--- a/src/renderers/electrobun/view/desktop/controls.tsx
+++ b/src/renderers/electrobun/view/desktop/controls.tsx
@@ -7,6 +7,7 @@ import { blendHex, colors } from "../../../../theme/colors";
 import { useThemeColors } from "../../../../theme/theme-context";
 import { isDetailBackNavigationKey } from "../../../../utils/back-navigation";
 import type { ButtonProps } from "../../../../components/ui/button";
+import type { CheckboxProps } from "../../../../components/ui/checkbox";
 import type { TextFieldProps } from "../../../../components/ui/fields";
 import type { DialogFrameProps } from "../../../../components/ui/frame";
 import type { MessageComposerProps } from "../../../../components/ui/message-composer";
@@ -71,6 +72,90 @@ export function WebButton({
           {shortcut}
         </Text>
       )}
+    </Box>
+  );
+}
+
+export function WebCheckbox({
+  label,
+  checked,
+  onChange,
+  disabled = false,
+  active = false,
+  description,
+  width,
+}: CheckboxProps) {
+  useThemeColors();
+  const textColor = disabled
+    ? colors.textMuted
+    : active
+    ? colors.textBright
+    : colors.text;
+  return (
+    <Box
+      flexDirection="column"
+      width={width}
+      data-gloom-role="desktop-checkbox"
+      data-gloom-interactive={disabled ? undefined : "true"}
+      style={{ opacity: disabled ? 0.55 : 1 }}
+    >
+      <label
+        onMouseDown={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (!disabled) onChange?.(!checked);
+        }}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          width: "100%",
+          minWidth: 0,
+          cursor: disabled ? "default" : "pointer",
+          color: textColor,
+          fontWeight: active ? 700 : 500,
+          lineHeight: "20px",
+          userSelect: "none",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={checked}
+          readOnly
+          disabled={disabled}
+          style={{
+            width: 14,
+            height: 14,
+            margin: 0,
+            accentColor: colors.borderFocused,
+            flexShrink: 0,
+            cursor: disabled ? "default" : "pointer",
+          }}
+        />
+        <span
+          style={{
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {label}
+        </span>
+      </label>
+      {description ? (
+        <Text
+          fg={colors.textMuted}
+          wrapText
+          width={width}
+          style={{ paddingLeft: 22, lineHeight: "18px" }}
+        >
+          {description}
+        </Text>
+      ) : null}
     </Box>
   );
 }

--- a/src/renderers/electrobun/view/desktop/controls.tsx
+++ b/src/renderers/electrobun/view/desktop/controls.tsx
@@ -380,7 +380,7 @@ export function WebDialogFrame({
   title,
   children,
   footer,
-  showTitleDivider = true,
+  showTitleDivider = false,
 }: DialogFrameProps) {
   useThemeColors();
   return (

--- a/src/renderers/electrobun/view/desktop/controls.tsx
+++ b/src/renderers/electrobun/view/desktop/controls.tsx
@@ -33,6 +33,7 @@ export function WebButton({
   active = false,
   shortcut,
   width,
+  height,
 }: ButtonProps) {
   useThemeColors();
   const palette = buttonPalette({ variant, active, disabled });
@@ -40,7 +41,7 @@ export function WebButton({
   return (
     <Box
       width={width}
-      height={1}
+      height={height ?? 1}
       flexDirection="row"
       alignItems="center"
       justifyContent="center"

--- a/src/renderers/electrobun/view/desktop/controls.tsx
+++ b/src/renderers/electrobun/view/desktop/controls.tsx
@@ -4,6 +4,7 @@ import { Box, Input, Text, Textarea, editableTextContextMenuItems, useRendererHo
 import { TextAttributes, type InputRenderable } from "../../../../ui";
 import { useShortcut } from "../../../../react/input";
 import { blendHex, colors } from "../../../../theme/colors";
+import { blendForContrast, higherContrast } from "../../../../theme/color-utils";
 import { useThemeColors } from "../../../../theme/theme-context";
 import { isDetailBackNavigationKey } from "../../../../utils/back-navigation";
 import type { ButtonProps } from "../../../../components/ui/button";
@@ -78,6 +79,7 @@ export function WebButton({
 
 export function WebCheckbox({
   label,
+  displayLabel,
   checked,
   onChange,
   disabled = false,
@@ -91,6 +93,21 @@ export function WebCheckbox({
     : active
     ? colors.textBright
     : colors.text;
+  const visibleLabel = displayLabel ?? label;
+  const accentColor = blendForContrast(
+    higherContrast(colors.borderFocused, colors.selected, colors.panel),
+    colors.panel,
+    colors.textBright,
+    3.8,
+  );
+  const outlineColor = checked
+    ? blendForContrast(
+      higherContrast(colors.textBright, colors.bg, accentColor),
+      accentColor,
+      colors.bg,
+      3.2,
+    )
+    : controlBorderColor(active, false);
   return (
     <Box
       flexDirection="column"
@@ -131,9 +148,11 @@ export function WebCheckbox({
             width: 14,
             height: 14,
             margin: 0,
-            accentColor: colors.borderFocused,
+            accentColor,
             flexShrink: 0,
             cursor: disabled ? "default" : "pointer",
+            outline: `1px solid ${outlineColor}`,
+            outlineOffset: 1,
           }}
         />
         <span
@@ -143,7 +162,7 @@ export function WebCheckbox({
             whiteSpace: "nowrap",
           }}
         >
-          {label}
+          {visibleLabel}
         </span>
       </label>
       {description ? (

--- a/src/renderers/electrobun/view/desktop/list-view.tsx
+++ b/src/renderers/electrobun/view/desktop/list-view.tsx
@@ -20,17 +20,29 @@ function DefaultDesktopRow({
   selected: boolean;
 }) {
   return (
-    <Box flexDirection="row" justifyContent="space-between" width="100%" alignItems="center">
-      <Box flexDirection="row" alignItems="center" minWidth={0}>
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
+      width="100%"
+      minWidth={0}
+      alignItems="center"
+      style={{ boxSizing: "border-box" }}
+    >
+      <Box flexDirection="row" alignItems="center" minWidth={0} flexShrink={1}>
         <Text
           fg={selected ? colors.text : colors.textDim}
           attributes={selected ? TextAttributes.BOLD : 0}
+          style={{
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
         >
           {item.label}
         </Text>
       </Box>
       {item.detail && (
-        <Text fg={colors.textMuted}>
+        <Text fg={colors.textMuted} style={{ flexShrink: 0, marginLeft: 12 }}>
           {item.detail}
         </Text>
       )}
@@ -43,7 +55,10 @@ function listRowStyle(selected: boolean): CSSProperties {
     borderRadius: CONTROL_RADIUS,
     border: `1px solid ${selected ? colors.borderFocused : "transparent"}`,
     boxShadow: selected ? `inset 0 1px 0 ${blendHex(colors.bg, colors.textBright, 0.06)}` : undefined,
+    boxSizing: "border-box",
     cursor: "pointer",
+    maxWidth: "100%",
+    minWidth: 0,
     paddingInline: 10,
   };
 }

--- a/src/renderers/electrobun/view/desktop/list-view.tsx
+++ b/src/renderers/electrobun/view/desktop/list-view.tsx
@@ -22,13 +22,6 @@ function DefaultDesktopRow({
   return (
     <Box flexDirection="row" justifyContent="space-between" width="100%" alignItems="center">
       <Box flexDirection="row" alignItems="center" minWidth={0}>
-        <Box
-          width={1}
-          height={1}
-          marginRight={1}
-          backgroundColor={selected ? colors.borderFocused : "transparent"}
-          style={{ borderRadius: CONTROL_RADIUS }}
-        />
         <Text
           fg={selected ? colors.text : colors.textDim}
           attributes={selected ? TextAttributes.BOLD : 0}
@@ -51,6 +44,7 @@ function listRowStyle(selected: boolean): CSSProperties {
     border: `1px solid ${selected ? colors.borderFocused : "transparent"}`,
     boxShadow: selected ? `inset 0 1px 0 ${blendHex(colors.bg, colors.textBright, 0.06)}` : undefined,
     cursor: "pointer",
+    paddingInline: 10,
   };
 }
 
@@ -69,10 +63,11 @@ export function WebListView({
   hoverBgColor,
   rowGap = 1,
   rowHeight = 1,
-  surface = "framed",
+  surface,
   height,
   flexGrow,
   scrollable = false,
+  selectOnHover = false,
   autoScrollToIndex = true,
 }: ListViewProps) {
   useThemeColors();
@@ -83,6 +78,20 @@ export function WebListView({
   const rowHoverBg = hoverBgColor ?? hoverBg();
   const selectedItem = selectedIndex >= 0 ? items[selectedIndex] : undefined;
   const activeScrollIndex = scrollIndex ?? selectedIndex;
+  const effectiveSurface = surface ?? (scrollable ? "framed" : "plain");
+  const frameStyle = effectiveSurface === "plain"
+    ? {
+      border: "none",
+      borderRadius: 0,
+      padding: 0,
+      backgroundColor: "transparent",
+    }
+    : {
+      border: `1px solid ${panelBorder()}`,
+      borderRadius: CONTROL_RADIUS,
+      padding: 4,
+      backgroundColor: subtlePanelFill(),
+    };
 
   useEffect(() => {
     if (!scrollable || !autoScrollToIndex || activeScrollIndex < 0) return;
@@ -130,6 +139,7 @@ export function WebListView({
           onMouseMove={() => {
             if (!disabled) {
               setHoveredIndex((current) => (current === index ? current : index));
+              if (selectOnHover) onSelect?.(index);
             }
           }}
           onMouseDown={() => {
@@ -156,26 +166,14 @@ export function WebListView({
           flexGrow={flexGrow}
           scrollY
           focusable={false}
-          style={surface === "plain"
-            ? {
-              border: "none",
-              borderRadius: 0,
-              padding: 0,
-              backgroundColor: "transparent",
-            }
-            : {
-              border: `1px solid ${panelBorder()}`,
-              borderRadius: CONTROL_RADIUS,
-              padding: 4,
-              backgroundColor: subtlePanelFill(),
-            }}
+          style={frameStyle}
         >
           <Box flexDirection="column" gap={rowGap}>
             {rows}
           </Box>
         </ScrollBox>
       ) : (
-        <Box flexDirection="column" gap={rowGap}>
+        <Box flexDirection="column" gap={rowGap} style={frameStyle}>
           {rows}
         </Box>
       )}

--- a/src/renderers/electrobun/view/host/box.tsx
+++ b/src/renderers/electrobun/view/host/box.tsx
@@ -19,7 +19,6 @@ import {
   cancelWebFrame,
   cellBoundsForElement,
   cellMouseEvent,
-  hasDirectMouseHandler,
   requestWebFrame,
 } from "./mouse";
 import { cleanDomProps, commonStyle } from "./style";
@@ -148,7 +147,6 @@ export const WebBox = forwardRef<HTMLDivElement, Record<string, unknown> & { chi
       <div
         {...cleanDomProps(props)}
         data-gloom-hover-bg={hoverBackgroundColor ? "true" : undefined}
-        data-gloom-interactive={hasDirectMouseHandler(props) ? "true" : undefined}
         ref={elementRef}
         onMouseDown={handleMouseDown}
         onMouseOver={handleMouseOver}

--- a/src/renderers/electrobun/view/host/scroll-box.tsx
+++ b/src/renderers/electrobun/view/host/scroll-box.tsx
@@ -14,7 +14,7 @@ import {
 } from "react";
 import type { ScrollBoxRenderable } from "../../../../ui/host";
 import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "../input-host";
-import { callMouseHandler, hasDirectMouseHandler } from "./mouse";
+import { callMouseHandler } from "./mouse";
 import { cleanDomProps, commonStyle } from "./style";
 import { useScrollbarActivity } from "../scrollbar-activity";
 
@@ -254,7 +254,6 @@ export const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unkno
         data-gloom-scrollbar-x={props.scrollX === true ? (horizontalScrollBarVisible ? "visible" : "hidden") : undefined}
         data-gloom-scrollbar-y={props.scrollY === true ? (verticalScrollBarVisible ? "visible" : "hidden") : undefined}
         data-gloom-scrollbar-active={scrollbarActive ? "true" : undefined}
-        data-gloom-interactive={hasDirectMouseHandler(props) ? "true" : undefined}
         onMouseDown={(event) => callMouseHandler(props.onMouseDown, event, "down")}
         onMouseMove={(event) => callMouseHandler(props.onMouseMove, event, "move")}
         onMouseUp={(event) => callMouseHandler(props.onMouseUp, event, "up")}

--- a/src/renderers/electrobun/view/host/text.tsx
+++ b/src/renderers/electrobun/view/host/text.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../../../ui/host";
 import { WEB_CELL_WIDTH } from "../input-host";
 import { webAsciiTextLines, webAsciiTextWordmarkVariant } from "./ascii-text";
-import { hasDirectMouseHandler, mouseHandlers } from "./mouse";
+import { mouseHandlers } from "./mouse";
 import { cleanDomProps, commonStyle, textStyle } from "./style";
 
 const WEB_WORDMARK_CHAR_WIDTH_PX = Math.max(10, WEB_CELL_WIDTH);
@@ -56,7 +56,6 @@ export function WebText({ children, ...props }: TextProps) {
     <span
       {...cleanDomProps(props)}
       {...mouseHandlers(props)}
-      data-gloom-interactive={hasDirectMouseHandler(props) ? "true" : undefined}
       style={{ ...textStyle(props), ...(props.style as CSSProperties | undefined) }}
     >
       {renderTextContent(children, props.content, props)}

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -21,6 +21,7 @@ import { webNativeRenderer } from "./native-renderer";
 import { WebToastHostProvider } from "./toast-host";
 import { createWebUiHost, webRendererHost } from "./ui-host";
 import { createApplicationMenuBridge } from "./application-menu-bridge";
+import { createDesktopDeepLinkBridge } from "./desktop-deeplink-bridge";
 import { createDesktopWindowBridge } from "./desktop/window/bridge";
 import { prepareDetachedSnapshot } from "./desktop/window/snapshot";
 
@@ -88,6 +89,7 @@ async function boot() {
   const config = desktopSnapshot?.config ?? init.config;
   const desktopWindowBridge = createDesktopWindowBridge(init.windowKind, init.paneId);
   const desktopApplicationMenuBridge = createApplicationMenuBridge();
+  const desktopDeepLinkBridge = createDesktopDeepLinkBridge();
   const webUiHost = createWebUiHost(init.desktopPlatform);
   const remoteControlAdapter = init.windowKind === "main"
     ? { registerHandler: setElectrobunRemoteRequestHandler }
@@ -103,6 +105,7 @@ async function boot() {
                   config={config}
                   desktopWindowBridge={desktopWindowBridge}
                   desktopApplicationMenuBridge={desktopApplicationMenuBridge}
+                  desktopDeepLinkBridge={desktopDeepLinkBridge}
                   desktopSnapshot={desktopSnapshot}
                   desktopThemePreview={init.desktopThemePreview}
                   remoteControlAdapter={remoteControlAdapter}

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -7,6 +7,7 @@ import { backendRequest } from "./backend-rpc";
 import { WebDataTable } from "./data-table";
 import {
   WebButton,
+  WebCheckbox,
   WebDialogFrame,
   WebListView,
   WebMessageComposer,
@@ -82,6 +83,7 @@ export function createWebUiHost(desktopPlatform?: string): UiHost {
     Input: WebInput,
     Textarea: WebTextarea,
     Button: WebButton,
+    Checkbox: WebCheckbox,
     TextField: WebTextField,
     MessageComposer: WebMessageComposer,
     ListView: WebListView,

--- a/src/sync/controller.ts
+++ b/src/sync/controller.ts
@@ -1,0 +1,296 @@
+import type { Dispatch } from "react";
+import type { AppAction, AppState } from "../core/state/app/state";
+import type { TickerRepository } from "../data/ticker-repository";
+import {
+  SYNC_SNAPSHOT_SCHEMA_VERSION,
+  type RegisteredSyncContributor,
+  type RegisteredSyncTransport,
+  type SyncContributor,
+  type SyncSnapshot,
+  type SyncTransport,
+} from "./types";
+
+export type CloudSyncPhase = "idle" | "disabled" | "syncing" | "synced" | "error";
+
+export interface CloudSyncStatus {
+  phase: CloudSyncPhase;
+  transportId: string | null;
+  lastSyncAt: string | null;
+  lastPullAt: string | null;
+  revision: number | null;
+  error: string | null;
+}
+
+interface SyncRuntime {
+  state: AppState;
+  dispatch: Dispatch<AppAction>;
+  tickerRepository: TickerRepository;
+  getContributors: () => RegisteredSyncContributor[];
+  getTransport: () => RegisteredSyncTransport | null;
+}
+
+const CLIENT_ID_STORAGE_KEY = "gloomberb.sync.clientId";
+const PUSH_DEBOUNCE_MS = 2500;
+const PULL_MIN_INTERVAL_MS = 60_000;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function stableStringify(value: unknown): string {
+  if (value == null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, child]) => `${JSON.stringify(key)}:${stableStringify(child)}`);
+  return `{${entries.join(",")}}`;
+}
+
+function resolveClientId(): string {
+  const storage = globalThis.localStorage;
+  const existing = storage?.getItem(CLIENT_ID_STORAGE_KEY);
+  if (existing) return existing;
+  const id = `client_${crypto.randomUUID()}`;
+  storage?.setItem(CLIENT_ID_STORAGE_KEY, id);
+  return id;
+}
+
+class CloudSyncController {
+  private runtime: SyncRuntime | null = null;
+  private contributors = new Map<string, RegisteredSyncContributor>();
+  private transports = new Map<string, RegisteredSyncTransport>();
+  private listeners = new Set<() => void>();
+  private pushTimer: ReturnType<typeof setTimeout> | null = null;
+  private inFlight: Promise<void> | null = null;
+  private clientId: string | null = null;
+  private lastSignature: string | null = null;
+  private lastPulledAtMs = 0;
+  private hasPulledForTransport = new Set<string>();
+  private status: CloudSyncStatus = {
+    phase: "idle",
+    transportId: null,
+    lastSyncAt: null,
+    lastPullAt: null,
+    revision: null,
+    error: null,
+  };
+
+  registerContributor(pluginId: string, contributor: SyncContributor): () => void {
+    this.contributors.set(contributor.id, { pluginId, contributor });
+    this.emit();
+    return () => {
+      const current = this.contributors.get(contributor.id);
+      if (current?.contributor === contributor) {
+        this.contributors.delete(contributor.id);
+        this.emit();
+      }
+    };
+  }
+
+  registerTransport(pluginId: string, transport: SyncTransport): () => void {
+    this.transports.set(transport.id, { pluginId, transport });
+    this.emit();
+    return () => {
+      const current = this.transports.get(transport.id);
+      if (current?.transport === transport) {
+        this.transports.delete(transport.id);
+        this.emit();
+      }
+    };
+  }
+
+  getRegisteredContributors(): RegisteredSyncContributor[] {
+    return [...this.contributors.values()];
+  }
+
+  getRegisteredTransports(): RegisteredSyncTransport[] {
+    return [...this.transports.values()];
+  }
+
+  setRuntime(runtime: SyncRuntime): void {
+    this.runtime = runtime;
+    this.updateAvailability();
+  }
+
+  clearRuntime(): void {
+    this.runtime = null;
+    if (this.pushTimer) clearTimeout(this.pushTimer);
+    this.pushTimer = null;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  getStatus(): CloudSyncStatus {
+    return this.status;
+  }
+
+  schedulePush(reason: string): void {
+    const runtime = this.runtime;
+    if (!runtime) return;
+    const transport = runtime.getTransport();
+    if (!transport?.transport.isAvailable()) {
+      this.setStatus({
+        phase: "disabled",
+        transportId: transport?.transport.id ?? null,
+        error: null,
+      });
+      return;
+    }
+    if (this.pushTimer) clearTimeout(this.pushTimer);
+    this.pushTimer = setTimeout(() => {
+      void this.requestSync({ reason });
+    }, PUSH_DEBOUNCE_MS);
+  }
+
+  async requestSync(options: { reason?: string; force?: boolean } = {}): Promise<void> {
+    if (this.inFlight) return this.inFlight;
+    const run = this.syncOnce(options).finally(() => {
+      this.inFlight = null;
+    });
+    this.inFlight = run;
+    return run;
+  }
+
+  async pullLatest(options: { force?: boolean } = {}): Promise<void> {
+    const runtime = this.runtime;
+    if (!runtime) return;
+    const transport = runtime.getTransport();
+    if (!transport?.transport.isAvailable()) {
+      this.setStatus({ phase: "disabled", transportId: transport?.transport.id ?? null, error: null });
+      return;
+    }
+    const currentMs = Date.now();
+    if (!options.force && currentMs - this.lastPulledAtMs < PULL_MIN_INTERVAL_MS) return;
+    this.lastPulledAtMs = currentMs;
+    await this.runPull(runtime, transport.transport);
+  }
+
+  private async syncOnce(options: { reason?: string; force?: boolean }): Promise<void> {
+    const runtime = this.runtime;
+    if (!runtime) return;
+    const transportRegistration = runtime.getTransport();
+    if (!transportRegistration?.transport.isAvailable()) {
+      this.setStatus({ phase: "disabled", transportId: transportRegistration?.transport.id ?? null, error: null });
+      return;
+    }
+    const transport = transportRegistration.transport;
+    if (!this.hasPulledForTransport.has(transport.id)) {
+      await this.runPull(runtime, transport);
+      this.hasPulledForTransport.add(transport.id);
+    }
+
+    const snapshot = await this.assembleSnapshot(runtime);
+    const signature = stableStringify(snapshot.contributors);
+    if (!options.force && signature === this.lastSignature) return;
+
+    this.setStatus({ phase: "syncing", transportId: transport.id, error: null });
+    try {
+      const result = await transport.pushSnapshot(snapshot, { baseRevision: this.status.revision });
+      this.lastSignature = signature;
+      this.setStatus({
+        phase: "synced",
+        transportId: transport.id,
+        revision: result.revision,
+        lastSyncAt: result.updatedAt,
+        error: null,
+      });
+    } catch (error) {
+      this.setStatus({
+        phase: "error",
+        transportId: transport.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async runPull(runtime: SyncRuntime, transport: SyncTransport): Promise<void> {
+    this.setStatus({ phase: "syncing", transportId: transport.id, error: null });
+    try {
+      const response = await transport.pullSnapshot();
+      this.setStatus({
+        phase: response.snapshot ? "synced" : "idle",
+        transportId: transport.id,
+        revision: response.revision,
+        lastPullAt: response.updatedAt ?? nowIso(),
+        lastSyncAt: response.updatedAt,
+        error: null,
+      });
+      if (!response.snapshot) return;
+      for (const entry of runtime.getContributors()) {
+        const payload = response.snapshot.contributors[entry.contributor.id]?.payload;
+        if (payload === undefined || !entry.contributor.apply) continue;
+        await entry.contributor.apply(payload, {
+          snapshot: response.snapshot,
+          state: runtime.state,
+          dispatch: runtime.dispatch,
+          tickerRepository: runtime.tickerRepository,
+        });
+      }
+    } catch (error) {
+      this.setStatus({
+        phase: "error",
+        transportId: transport.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async assembleSnapshot(runtime: SyncRuntime): Promise<SyncSnapshot> {
+    const contributors = runtime.getContributors();
+    const createdAt = nowIso();
+    const payloads: SyncSnapshot["contributors"] = {};
+    for (const entry of contributors) {
+      const payload = await entry.contributor.collect({ state: runtime.state });
+      payloads[entry.contributor.id] = {
+        schemaVersion: entry.contributor.schemaVersion,
+        updatedAt: createdAt,
+        payload,
+      };
+    }
+    return {
+      schemaVersion: SYNC_SNAPSHOT_SCHEMA_VERSION,
+      appId: "gloomberb",
+      clientId: this.clientId ??= resolveClientId(),
+      createdAt,
+      contributors: payloads,
+    };
+  }
+
+  private updateAvailability(): void {
+    const transport = this.runtime?.getTransport() ?? null;
+    if (!transport) {
+      this.setStatus({ phase: "disabled", transportId: null, error: null });
+      return;
+    }
+    if (!transport.transport.isAvailable()) {
+      this.setStatus({ phase: "disabled", transportId: transport.transport.id, error: null });
+      return;
+    }
+    if (
+      this.status.transportId === transport.transport.id &&
+      this.status.phase !== "disabled" &&
+      this.status.phase !== "idle"
+    ) {
+      return;
+    }
+    this.setStatus({
+      phase: "idle",
+      transportId: transport.transport.id,
+      error: null,
+    });
+  }
+
+  private setStatus(patch: Partial<CloudSyncStatus>): void {
+    this.status = { ...this.status, ...patch };
+    this.emit();
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) listener();
+  }
+}
+
+export const cloudSyncController = new CloudSyncController();

--- a/src/sync/core-contributors.test.ts
+++ b/src/sync/core-contributors.test.ts
@@ -112,6 +112,84 @@ describe("core sync contributors", () => {
     expect((payload as any).analyticsByPortfolio.main.oneYearReturn).toBe(0.42);
   });
 
+  test("syncs portfolio analytics in base currency and uses broker account market value", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-sync-test");
+    config.baseCurrency = "USD";
+    config.portfolios = [
+      { id: "main", name: "Main", currency: "USD" },
+      {
+        id: "broker:ibkr:U123",
+        name: "U123",
+        currency: "USD",
+        brokerId: "ibkr",
+        brokerInstanceId: "ibkr",
+        brokerAccountId: "U123",
+      },
+    ];
+    config.brokerInstances = [{
+      id: "ibkr",
+      brokerType: "ibkr",
+      label: "IBKR",
+      config: {},
+      enabled: true,
+    }];
+    const ticker = (symbol: string, portfolio: string): TickerRecord => ({
+      metadata: {
+        ticker: symbol,
+        exchange: "TSE",
+        currency: "JPY",
+        name: symbol,
+        portfolios: [portfolio],
+        watchlists: [],
+        positions: [{
+          portfolio,
+          shares: 10,
+          avgCost: 900,
+          broker: "manual",
+          currency: "JPY",
+        }],
+        custom: {},
+        tags: [],
+      },
+    });
+    const state = createInitialState(config);
+    state.exchangeRates = new Map([["USD", 1], ["JPY", 0.0067]]);
+    state.tickers = new Map([
+      ["7203.T", ticker("7203.T", "main")],
+      ["6758.T", ticker("6758.T", "broker:ibkr:U123")],
+    ]);
+    state.financials = new Map([
+      ["7203.T", {
+        quote: { symbol: "7203.T", price: 1000, currency: "JPY", change: 0, changePercent: 0, lastUpdated: 1 },
+        fundamentals: { return1Y: 0.1 },
+        annualStatements: [],
+        quarterlyStatements: [],
+      }],
+      ["6758.T", {
+        quote: { symbol: "6758.T", price: 1000, currency: "JPY", change: 0, changePercent: 0, lastUpdated: 1 },
+        fundamentals: { return1Y: 0.2 },
+        annualStatements: [],
+        quarterlyStatements: [],
+      }],
+    ]);
+    state.brokerAccounts = {
+      ibkr: [{
+        accountId: "U123",
+        name: "U123",
+        currency: "USD",
+        source: "flex",
+        grossPositionValue: 1234,
+      }],
+    };
+
+    const payload = await coreCollectionsSyncContributor.collect({ state }) as any;
+
+    expect(payload.analyticsByPortfolio.main.marketValue).toBeCloseTo(67);
+    expect(payload.analyticsByPortfolio.main.oneYearReturn).toBe(0.1);
+    expect(payload.analyticsByPortfolio["broker:ibkr:U123"].marketValue).toBe(1234);
+    expect(payload.analyticsByPortfolio["broker:ibkr:U123"].sourceLabel).toBe("Flex");
+  });
+
   test("redaction removes nested credential-shaped fields", () => {
     const sanitized = __syncContributorInternalsForTests.sanitizeUnknown({
       nested: {

--- a/src/sync/core-contributors.test.ts
+++ b/src/sync/core-contributors.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import { createInitialState } from "../core/state/app/state";
+import { createDefaultConfig } from "../types/config";
+import type { TickerRecord } from "../types/ticker";
+import {
+  __syncContributorInternalsForTests,
+  coreCollectionsSyncContributor,
+  coreConfigSyncContributor,
+} from "./core-contributors";
+
+describe("core sync contributors", () => {
+  test("redacts local paths and credential-like config keys", async () => {
+    const config = createDefaultConfig("/Users/vince/private-data");
+    config.brokerInstances = [{
+      id: "broker-1",
+      brokerType: "demo",
+      label: "Demo Broker",
+      config: {
+        apiKey: "secret-api-key",
+        password: "secret-password",
+      },
+    }];
+    config.pluginConfig = {
+      "demo-plugin": {
+        theme: "dark",
+        token: "secret-token",
+        downloadPath: "/Users/vince/private-downloads",
+      },
+    };
+
+    const state = createInitialState(config);
+    const payload = await coreConfigSyncContributor.collect({ state });
+    const serialized = JSON.stringify(payload);
+
+    expect(serialized).not.toContain("/Users/vince/private-data");
+    expect(serialized).not.toContain("/Users/vince/private-downloads");
+    expect(serialized).not.toContain("secret-api-key");
+    expect(serialized).not.toContain("secret-password");
+    expect(serialized).not.toContain("secret-token");
+    expect(serialized).toContain("Demo Broker");
+  });
+
+  test("syncs collection memberships and sanitized positions", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-sync-test");
+    config.portfolios = [{
+      id: "main",
+      name: "Main",
+      currency: "USD",
+      brokerAccountId: "account-id",
+      brokerInstanceId: "broker-id",
+    }];
+    config.watchlists = [{ id: "ai", name: "AI" }];
+    const ticker: TickerRecord = {
+      metadata: {
+        ticker: "NVDA",
+        exchange: "NASDAQ",
+        currency: "USD",
+        name: "NVIDIA",
+        portfolios: ["main"],
+        watchlists: ["ai"],
+        positions: [{
+          portfolio: "main",
+          shares: 10,
+          avgCost: 100,
+          broker: "manual",
+          marketValue: 1500,
+          brokerAccountId: "account-id",
+          brokerInstanceId: "broker-id",
+          brokerContractId: 42,
+        }],
+        custom: { secretToken: "hidden", note: "keep" },
+        tags: ["semis"],
+      },
+    };
+    const state = createInitialState(config);
+    state.tickers = new Map([["NVDA", ticker]]);
+    state.financials = new Map([[
+      "NVDA",
+      {
+        quote: {
+          symbol: "NVDA",
+          price: 150,
+          currency: "USD",
+          change: 1,
+          changePercent: 2,
+          lastUpdated: 1,
+        },
+        fundamentals: { return1Y: 0.42 },
+        annualStatements: [],
+        quarterlyStatements: [],
+        priceHistory: [
+          { date: new Date("2026-06-23T20:00:00.000Z"), close: 125 },
+          { date: new Date("2026-06-30T20:00:00.000Z"), close: 149 },
+        ],
+      },
+    ]]);
+
+    const payload = await coreCollectionsSyncContributor.collect({ state });
+    const serialized = JSON.stringify(payload);
+
+    expect(serialized).toContain("NVDA");
+    expect(serialized).toContain("AI");
+    expect(serialized).toContain("Main");
+    expect(serialized).toContain("keep");
+    expect(serialized).not.toContain("account-id");
+    expect(serialized).not.toContain("broker-id");
+    expect(serialized).not.toContain("hidden");
+    expect(serialized).not.toContain("brokerContractId");
+    expect((payload as any).tickers[0].quote.price).toBe(150);
+    expect((payload as any).tickers[0].quote.weekReferencePrice).toBe(125);
+    expect((payload as any).tickers[0].quote.weekChangePercent).toBe(20);
+    expect((payload as any).analyticsByPortfolio.main.oneYearReturn).toBe(0.42);
+  });
+
+  test("redaction removes nested credential-shaped fields", () => {
+    const sanitized = __syncContributorInternalsForTests.sanitizeUnknown({
+      nested: {
+        refreshToken: "nope",
+        publicValue: "ok",
+      },
+    });
+
+    expect(sanitized).toEqual({ nested: { publicValue: "ok" } });
+  });
+});

--- a/src/sync/core-contributors.test.ts
+++ b/src/sync/core-contributors.test.ts
@@ -122,6 +122,8 @@ describe("core sync contributors", () => {
     expect(serialized).not.toContain("broker-id");
     expect(serialized).not.toContain("hidden");
     expect(serialized).not.toContain("brokerContractId");
+    expect((payload as any).baseCurrency).toBe("USD");
+    expect((payload as any).exchangeRates).toEqual({ USD: 1 });
     expect((payload as any).tickers[0].quote.price).toBe(150);
     expect((payload as any).tickers[0].quote.weekReferencePrice).toBe(125);
     expect((payload as any).tickers[0].quote.weekChangePercent).toBe(20);
@@ -208,6 +210,8 @@ describe("core sync contributors", () => {
 
     const payload = await coreCollectionsSyncContributor.collect({ state }) as any;
 
+    expect(payload.baseCurrency).toBe("USD");
+    expect(payload.exchangeRates).toEqual({ USD: 1, JPY: 0.0067 });
     expect(payload.analyticsByPortfolio.main.oneYearReturn).toBe(0.1);
     expect(payload.analyticsByPortfolio.main.spyBeta).toBeCloseTo(1.5, 5);
     expect(payload.analyticsByPortfolio["broker:ibkr:U123"].oneYearReturn).toBe(0.2);

--- a/src/sync/core-contributors.test.ts
+++ b/src/sync/core-contributors.test.ts
@@ -1,14 +1,30 @@
 import { describe, expect, test } from "bun:test";
 import { createInitialState } from "../core/state/app/state";
 import { createDefaultConfig } from "../types/config";
+import type { PricePoint } from "../types/financials";
 import type { TickerRecord } from "../types/ticker";
 import {
   __syncContributorInternalsForTests,
   coreCollectionsSyncContributor,
   coreConfigSyncContributor,
 } from "./core-contributors";
+import { setSyncedProfileAnalytics } from "./profile-analytics";
 
 describe("core sync contributors", () => {
+  function priceHistoryFromReturns(returns: number[]): PricePoint[] {
+    let close = 100;
+    return [
+      { date: new Date("2026-06-01T20:00:00.000Z"), close },
+      ...returns.map((value, index) => {
+        close *= 1 + value;
+        return {
+          date: new Date(Date.UTC(2026, 5, index + 2, 20)),
+          close,
+        };
+      }),
+    ];
+  }
+
   test("redacts local paths and credential-like config keys", async () => {
     const config = createDefaultConfig("/Users/vince/private-data");
     config.brokerInstances = [{
@@ -112,7 +128,7 @@ describe("core sync contributors", () => {
     expect((payload as any).analyticsByPortfolio.main.oneYearReturn).toBe(0.42);
   });
 
-  test("syncs portfolio analytics in base currency and uses broker account market value", async () => {
+  test("syncs only public return and beta analytics", async () => {
     const config = createDefaultConfig("/tmp/gloomberb-sync-test");
     config.baseCurrency = "USD";
     config.portfolios = [
@@ -162,12 +178,20 @@ describe("core sync contributors", () => {
       ["7203.T", {
         quote: { symbol: "7203.T", price: 1000, currency: "JPY", change: 0, changePercent: 0, lastUpdated: 1 },
         fundamentals: { return1Y: 0.1 },
+        priceHistory: priceHistoryFromReturns([0.015, -0.0045, 0.018, 0.009, -0.006, 0.012, 0.0045, -0.003, 0.0105, 0.006, -0.0015]),
         annualStatements: [],
         quarterlyStatements: [],
       }],
       ["6758.T", {
         quote: { symbol: "6758.T", price: 1000, currency: "JPY", change: 0, changePercent: 0, lastUpdated: 1 },
         fundamentals: { return1Y: 0.2 },
+        priceHistory: priceHistoryFromReturns([0.03, -0.009, 0.036, 0.018, -0.012, 0.024, 0.009, -0.006, 0.021, 0.012, -0.003]),
+        annualStatements: [],
+        quarterlyStatements: [],
+      }],
+      ["SPY", {
+        quote: { symbol: "SPY", price: 100, currency: "USD", change: 0, changePercent: 0, lastUpdated: 1 },
+        priceHistory: priceHistoryFromReturns([0.01, -0.003, 0.012, 0.006, -0.004, 0.008, 0.003, -0.002, 0.007, 0.004, -0.001]),
         annualStatements: [],
         quarterlyStatements: [],
       }],
@@ -184,10 +208,14 @@ describe("core sync contributors", () => {
 
     const payload = await coreCollectionsSyncContributor.collect({ state }) as any;
 
-    expect(payload.analyticsByPortfolio.main.marketValue).toBeCloseTo(67);
     expect(payload.analyticsByPortfolio.main.oneYearReturn).toBe(0.1);
-    expect(payload.analyticsByPortfolio["broker:ibkr:U123"].marketValue).toBe(1234);
-    expect(payload.analyticsByPortfolio["broker:ibkr:U123"].sourceLabel).toBe("Flex");
+    expect(payload.analyticsByPortfolio.main.spyBeta).toBeCloseTo(1.5, 5);
+    expect(payload.analyticsByPortfolio["broker:ibkr:U123"].oneYearReturn).toBe(0.2);
+    expect(payload.analyticsByPortfolio["broker:ibkr:U123"].spyBeta).toBeCloseTo(3, 5);
+    expect(payload.analyticsByPortfolio.main).not.toHaveProperty("marketValue");
+    expect(payload.analyticsByPortfolio.main).not.toHaveProperty("holdingsCount");
+    expect(payload.analyticsByPortfolio.main).not.toHaveProperty("currency");
+    expect(payload.analyticsByPortfolio.main).not.toHaveProperty("sourceLabel");
   });
 
   test("redaction removes nested credential-shaped fields", () => {
@@ -199,5 +227,21 @@ describe("core sync contributors", () => {
     });
 
     expect(sanitized).toEqual({ nested: { publicValue: "ok" } });
+  });
+
+  test("uses preview-computed profile analytics without exposing values", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-sync-test");
+    config.portfolios = [{ id: "preview", name: "Preview", currency: "USD" }];
+    const state = createInitialState(config);
+
+    setSyncedProfileAnalytics("preview", { oneYearReturn: 0.25, spyBeta: 1.4 });
+    const payload = await coreCollectionsSyncContributor.collect({ state }) as any;
+    setSyncedProfileAnalytics("preview", null);
+
+    expect(payload.analyticsByPortfolio.preview).toEqual({
+      oneYearReturn: 0.25,
+      spyBeta: 1.4,
+    });
+    expect(payload.analyticsByPortfolio.preview).not.toHaveProperty("marketValue");
   });
 });

--- a/src/sync/core-contributors.ts
+++ b/src/sync/core-contributors.ts
@@ -4,6 +4,11 @@ import type { TickerFinancials } from "../types/financials";
 import type { Portfolio, TickerMetadata, TickerPosition, TickerRecord, Watchlist } from "../types/ticker";
 import { hydrateTickerMetadata } from "../tickers/metadata";
 import type { SyncContributor } from "./types";
+import { calculatePortfolioSummaryTotals } from "../plugins/builtin/portfolio-list/metrics";
+import { resolvePortfolioMarketValue } from "../plugins/builtin/portfolio-list/account-metrics";
+import { resolvePortfolioAccountState } from "../plugins/builtin/portfolio-list/summary";
+import type { BrokerAccount } from "../types/trading";
+import { convertCurrency } from "../utils/format";
 
 const SENSITIVE_KEY_PATTERN = /(token|secret|password|credential|private|api[_-]?key|access[_-]?key|refresh[_-]?key|session|cookie|dataDir|path|directory|localPath)/i;
 
@@ -157,39 +162,51 @@ function collectCoreConfigPayload(config: AppConfig) {
   });
 }
 
-function positionValue(position: TickerPosition, financials: TickerFinancials | null | undefined): number | null {
+function positionValueBase(
+  position: TickerPosition,
+  financials: TickerFinancials | null | undefined,
+  baseCurrency: string,
+  exchangeRates: Map<string, number>,
+): number | null {
+  const quoteCurrency = financials?.quote?.currency || position.currency || baseCurrency;
+  const positionCurrency = position.currency || quoteCurrency;
   if (typeof position.marketValue === "number" && Number.isFinite(position.marketValue)) {
-    return Math.abs(position.marketValue);
+    return convertCurrency(Math.abs(position.marketValue), positionCurrency, baseCurrency, exchangeRates);
   }
-  const price = typeof position.markPrice === "number" && Number.isFinite(position.markPrice)
-    ? position.markPrice
-    : financials?.quote?.price ?? position.avgCost;
+  const hasMarkPrice = typeof position.markPrice === "number" && Number.isFinite(position.markPrice);
+  const hasQuotePrice = typeof financials?.quote?.price === "number" && Number.isFinite(financials.quote.price);
+  const price = hasMarkPrice ? position.markPrice : hasQuotePrice ? financials!.quote!.price : position.avgCost;
   if (!Number.isFinite(position.shares) || !Number.isFinite(price)) return null;
-  return Math.abs(position.shares * price * (position.multiplier ?? 1));
+  return convertCurrency(
+    Math.abs(position.shares * price * (position.multiplier ?? 1)),
+    hasQuotePrice && !hasMarkPrice ? quoteCurrency : positionCurrency,
+    baseCurrency,
+    exchangeRates,
+  );
 }
 
 function collectAnalyticsByPortfolio(
   config: AppConfig,
   tickers: Map<string, TickerRecord>,
   financials: Map<string, TickerFinancials>,
+  exchangeRates: Map<string, number>,
+  brokerAccounts: Record<string, BrokerAccount[]>,
 ) {
   const output: Record<string, Record<string, unknown>> = {};
   for (const portfolio of config.portfolios) {
     const symbols = new Set<string>();
-    let marketValue = 0;
-    let hasMarketValue = false;
     let returnWeight = 0;
     let weightedReturn = 0;
+    const portfolioTickers: TickerRecord[] = [];
     for (const ticker of tickers.values()) {
       const tickerFinancials = financials.get(ticker.metadata.ticker);
       const portfolioPositions = ticker.metadata.positions.filter((position) => position.portfolio === portfolio.id);
       if (portfolioPositions.length === 0 && !ticker.metadata.portfolios.includes(portfolio.id)) continue;
       symbols.add(ticker.metadata.ticker);
+      portfolioTickers.push(ticker);
       for (const position of portfolioPositions) {
-        const value = positionValue(position, tickerFinancials);
+        const value = positionValueBase(position, tickerFinancials, config.baseCurrency, exchangeRates);
         if (value != null) {
-          hasMarketValue = true;
-          marketValue += value;
           const return1Y = tickerFinancials?.fundamentals?.return1Y;
           if (typeof return1Y === "number" && Number.isFinite(return1Y)) {
             returnWeight += value;
@@ -198,21 +215,37 @@ function collectAnalyticsByPortfolio(
         }
       }
     }
+    const totals = calculatePortfolioSummaryTotals(
+      portfolioTickers,
+      financials,
+      config.baseCurrency,
+      exchangeRates,
+      true,
+      portfolio.id,
+    );
+    const accountState = resolvePortfolioAccountState(portfolio, { config, brokerAccounts }, { status: null, accounts: [] });
+    const marketValue = resolvePortfolioMarketValue(totals, accountState?.account);
     output[portfolio.id] = {
       portfolioName: portfolio.name,
       holdingsCount: symbols.size,
       oneYearReturn: returnWeight > 0 ? weightedReturn / returnWeight : null,
       spyBeta: null,
-      marketValue: hasMarketValue ? marketValue : null,
+      marketValue: totals.hasPositions || accountState ? marketValue : null,
       currency: portfolio.currency || config.baseCurrency,
-      sourceLabel: "Synced portfolio",
+      sourceLabel: accountState?.sourceLabel ?? "Synced portfolio",
       asOf: new Date().toISOString(),
     };
   }
   return output;
 }
 
-function collectCoreCollectionsPayload(config: AppConfig, tickers: Map<string, TickerRecord>, financials: Map<string, TickerFinancials>) {
+function collectCoreCollectionsPayload(
+  config: AppConfig,
+  tickers: Map<string, TickerRecord>,
+  financials: Map<string, TickerFinancials>,
+  exchangeRates: Map<string, number>,
+  brokerAccounts: Record<string, BrokerAccount[]>,
+) {
   const records = [...tickers.values()]
     .map((ticker) => sanitizeTickerMetadata(ticker.metadata, financials.get(ticker.metadata.ticker)))
     .filter((metadata) => (
@@ -224,7 +257,7 @@ function collectCoreCollectionsPayload(config: AppConfig, tickers: Map<string, T
   return {
     portfolios: config.portfolios.map(sanitizePortfolio),
     watchlists: config.watchlists.map(sanitizeWatchlist),
-    analyticsByPortfolio: collectAnalyticsByPortfolio(config, tickers, financials),
+    analyticsByPortfolio: collectAnalyticsByPortfolio(config, tickers, financials, exchangeRates, brokerAccounts),
     tickers: records,
   };
 }
@@ -288,7 +321,13 @@ export const coreConfigSyncContributor: SyncContributor = {
 export const coreCollectionsSyncContributor: SyncContributor = {
   id: "core.collections",
   schemaVersion: 1,
-  collect: ({ state }) => collectCoreCollectionsPayload(state.config, state.tickers, state.financials),
+  collect: ({ state }) => collectCoreCollectionsPayload(
+    state.config,
+    state.tickers,
+    state.financials,
+    state.exchangeRates,
+    state.brokerAccounts,
+  ),
   apply: async (payload, { state, dispatch, tickerRepository }) => {
     if (!isPlainObject(payload)) return;
     const nextConfig = { ...state.config };

--- a/src/sync/core-contributors.ts
+++ b/src/sync/core-contributors.ts
@@ -1,14 +1,17 @@
 import { scheduleConfigSave } from "../state/config-save-scheduler";
 import type { AppConfig, BrokerInstanceConfig } from "../types/config";
-import type { TickerFinancials } from "../types/financials";
+import type { PricePoint, TickerFinancials } from "../types/financials";
 import type { Portfolio, TickerMetadata, TickerPosition, TickerRecord, Watchlist } from "../types/ticker";
 import { hydrateTickerMetadata } from "../tickers/metadata";
 import type { SyncContributor } from "./types";
-import { calculatePortfolioSummaryTotals } from "../plugins/builtin/portfolio-list/metrics";
-import { resolvePortfolioMarketValue } from "../plugins/builtin/portfolio-list/account-metrics";
-import { resolvePortfolioAccountState } from "../plugins/builtin/portfolio-list/summary";
-import type { BrokerAccount } from "../types/trading";
 import { convertCurrency } from "../utils/format";
+import {
+  computeDatedBeta,
+  computeDatedReturns,
+  computeWeightedPortfolioReturns,
+  type WeightedReturnSeries,
+} from "../plugins/builtin/analytics/metrics";
+import { getSyncedProfileAnalytics } from "./profile-analytics";
 
 const SENSITIVE_KEY_PATTERN = /(token|secret|password|credential|private|api[_-]?key|access[_-]?key|refresh[_-]?key|session|cookie|dataDir|path|directory|localPath)/i;
 
@@ -176,7 +179,7 @@ function positionValueBase(
   const hasMarkPrice = typeof position.markPrice === "number" && Number.isFinite(position.markPrice);
   const hasQuotePrice = typeof financials?.quote?.price === "number" && Number.isFinite(financials.quote.price);
   const price = hasMarkPrice ? position.markPrice : hasQuotePrice ? financials!.quote!.price : position.avgCost;
-  if (!Number.isFinite(position.shares) || !Number.isFinite(price)) return null;
+  if (!Number.isFinite(position.shares) || typeof price !== "number" || !Number.isFinite(price)) return null;
   return convertCurrency(
     Math.abs(position.shares * price * (position.multiplier ?? 1)),
     hasQuotePrice && !hasMarkPrice ? quoteCurrency : positionCurrency,
@@ -185,25 +188,52 @@ function positionValueBase(
   );
 }
 
+function pricePointTimeOrNull(point: PricePoint): number | null {
+  const value = point.date;
+  if (value == null) return null;
+  const time = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return Number.isFinite(time) ? time : null;
+}
+
+function recentPriceHistory(history: PricePoint[], days: number): PricePoint[] {
+  let latestTime = 0;
+  for (const point of history) {
+    const time = pricePointTimeOrNull(point);
+    if (time != null && time > latestTime) latestTime = time;
+  }
+  if (latestTime <= 0) return [];
+  const cutoff = latestTime - days * 24 * 60 * 60 * 1000;
+  return history.filter((point) => {
+    const time = pricePointTimeOrNull(point);
+    return time != null && time >= cutoff;
+  });
+}
+
+function oneYearReturnFromSeries(series: WeightedReturnSeries[]): number | null {
+  const returns = computeWeightedPortfolioReturns(series);
+  if (returns.length === 0) return null;
+  const cumulative = returns.reduce((acc, point) => (
+    Number.isFinite(point.value) ? acc * (1 + point.value) : acc
+  ), 1) - 1;
+  return Number.isFinite(cumulative) ? cumulative : null;
+}
+
 function collectAnalyticsByPortfolio(
   config: AppConfig,
   tickers: Map<string, TickerRecord>,
   financials: Map<string, TickerFinancials>,
   exchangeRates: Map<string, number>,
-  brokerAccounts: Record<string, BrokerAccount[]>,
 ) {
   const output: Record<string, Record<string, unknown>> = {};
+  const spyReturns = computeDatedReturns(recentPriceHistory(financials.get("SPY")?.priceHistory ?? [], 366));
   for (const portfolio of config.portfolios) {
-    const symbols = new Set<string>();
     let returnWeight = 0;
     let weightedReturn = 0;
-    const portfolioTickers: TickerRecord[] = [];
+    const datedReturnSeries: WeightedReturnSeries[] = [];
     for (const ticker of tickers.values()) {
       const tickerFinancials = financials.get(ticker.metadata.ticker);
       const portfolioPositions = ticker.metadata.positions.filter((position) => position.portfolio === portfolio.id);
       if (portfolioPositions.length === 0 && !ticker.metadata.portfolios.includes(portfolio.id)) continue;
-      symbols.add(ticker.metadata.ticker);
-      portfolioTickers.push(ticker);
       for (const position of portfolioPositions) {
         const value = positionValueBase(position, tickerFinancials, config.baseCurrency, exchangeRates);
         if (value != null) {
@@ -212,28 +242,22 @@ function collectAnalyticsByPortfolio(
             returnWeight += value;
             weightedReturn += return1Y * value;
           }
+          const returns = computeDatedReturns(recentPriceHistory(tickerFinancials?.priceHistory ?? [], 366));
+          if (returns.length >= 10) datedReturnSeries.push({ weight: value, returns });
         }
       }
     }
-    const totals = calculatePortfolioSummaryTotals(
-      portfolioTickers,
-      financials,
-      config.baseCurrency,
-      exchangeRates,
-      true,
-      portfolio.id,
-    );
-    const accountState = resolvePortfolioAccountState(portfolio, { config, brokerAccounts }, { status: null, accounts: [] });
-    const marketValue = resolvePortfolioMarketValue(totals, accountState?.account);
+    const portfolioReturns = computeWeightedPortfolioReturns(datedReturnSeries);
+    const previewAnalytics = getSyncedProfileAnalytics(portfolio.id);
     output[portfolio.id] = {
-      portfolioName: portfolio.name,
-      holdingsCount: symbols.size,
-      oneYearReturn: returnWeight > 0 ? weightedReturn / returnWeight : null,
-      spyBeta: null,
-      marketValue: totals.hasPositions || accountState ? marketValue : null,
-      currency: portfolio.currency || config.baseCurrency,
-      sourceLabel: accountState?.sourceLabel ?? "Synced portfolio",
-      asOf: new Date().toISOString(),
+      oneYearReturn: previewAnalytics?.oneYearReturn
+        ?? (returnWeight > 0 ? weightedReturn / returnWeight : oneYearReturnFromSeries(datedReturnSeries)),
+      spyBeta: previewAnalytics?.spyBeta
+        ?? (
+          portfolioReturns.length > 0 && spyReturns.length > 0
+            ? computeDatedBeta(portfolioReturns, spyReturns)
+            : null
+        ),
     };
   }
   return output;
@@ -244,7 +268,6 @@ function collectCoreCollectionsPayload(
   tickers: Map<string, TickerRecord>,
   financials: Map<string, TickerFinancials>,
   exchangeRates: Map<string, number>,
-  brokerAccounts: Record<string, BrokerAccount[]>,
 ) {
   const records = [...tickers.values()]
     .map((ticker) => sanitizeTickerMetadata(ticker.metadata, financials.get(ticker.metadata.ticker)))
@@ -257,7 +280,7 @@ function collectCoreCollectionsPayload(
   return {
     portfolios: config.portfolios.map(sanitizePortfolio),
     watchlists: config.watchlists.map(sanitizeWatchlist),
-    analyticsByPortfolio: collectAnalyticsByPortfolio(config, tickers, financials, exchangeRates, brokerAccounts),
+    analyticsByPortfolio: collectAnalyticsByPortfolio(config, tickers, financials, exchangeRates),
     tickers: records,
   };
 }
@@ -326,7 +349,6 @@ export const coreCollectionsSyncContributor: SyncContributor = {
     state.tickers,
     state.financials,
     state.exchangeRates,
-    state.brokerAccounts,
   ),
   apply: async (payload, { state, dispatch, tickerRepository }) => {
     if (!isPlainObject(payload)) return;

--- a/src/sync/core-contributors.ts
+++ b/src/sync/core-contributors.ts
@@ -1,0 +1,329 @@
+import { scheduleConfigSave } from "../state/config-save-scheduler";
+import type { AppConfig, BrokerInstanceConfig } from "../types/config";
+import type { TickerFinancials } from "../types/financials";
+import type { Portfolio, TickerMetadata, TickerPosition, TickerRecord, Watchlist } from "../types/ticker";
+import { hydrateTickerMetadata } from "../tickers/metadata";
+import type { SyncContributor } from "./types";
+
+const SENSITIVE_KEY_PATTERN = /(token|secret|password|credential|private|api[_-]?key|access[_-]?key|refresh[_-]?key|session|cookie|dataDir|path|directory|localPath)/i;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function sanitizeUnknown(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeUnknown).filter((entry) => entry !== undefined);
+  }
+  if (!isPlainObject(value)) return value;
+
+  const output: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) continue;
+    const sanitized = sanitizeUnknown(child);
+    if (sanitized !== undefined) output[key] = sanitized;
+  }
+  return output;
+}
+
+function sanitizePortfolio(portfolio: Portfolio): Portfolio {
+  return {
+    id: portfolio.id,
+    name: portfolio.name,
+    description: portfolio.description,
+    currency: portfolio.currency,
+    brokerId: portfolio.brokerId,
+    lastSyncedAt: portfolio.lastSyncedAt,
+  };
+}
+
+function sanitizeWatchlist(watchlist: Watchlist): Watchlist {
+  return {
+    id: watchlist.id,
+    name: watchlist.name,
+    description: watchlist.description,
+  };
+}
+
+function sanitizeBrokerInstance(instance: BrokerInstanceConfig): Omit<BrokerInstanceConfig, "config"> {
+  return {
+    id: instance.id,
+    brokerType: instance.brokerType,
+    label: instance.label,
+    connectionMode: instance.connectionMode,
+    enabled: instance.enabled,
+    lastSyncedAt: instance.lastSyncedAt,
+  };
+}
+
+function sanitizePosition(position: TickerPosition): TickerPosition {
+  return {
+    portfolio: position.portfolio,
+    shares: position.shares,
+    avgCost: position.avgCost,
+    currency: position.currency,
+    dateAcquired: position.dateAcquired,
+    broker: position.broker,
+    side: position.side,
+    marketValue: position.marketValue,
+    unrealizedPnl: position.unrealizedPnl,
+    multiplier: position.multiplier,
+    markPrice: position.markPrice,
+  };
+}
+
+function pricePointTime(point: { date: Date | string | number }): number {
+  const value = point.date;
+  if (value instanceof Date) return value.getTime();
+  return new Date(value).getTime();
+}
+
+function weeklyQuoteMove(financials: TickerFinancials | null | undefined) {
+  const quote = financials?.quote;
+  if (!quote || !Number.isFinite(quote.price) || quote.price <= 0) return undefined;
+  const history = (financials?.priceHistory ?? [])
+    .filter((point) => Number.isFinite(point.close) && point.close > 0 && Number.isFinite(pricePointTime(point)))
+    .sort((left, right) => pricePointTime(left) - pricePointTime(right));
+  if (history.length === 0) return undefined;
+  const latestTime = Number.isFinite(quote.lastUpdated)
+    ? quote.lastUpdated
+    : pricePointTime(history[history.length - 1]!);
+  const cutoff = latestTime - 7 * 24 * 60 * 60 * 1000;
+  const reference = history.find((point) => pricePointTime(point) >= cutoff) ?? history[Math.max(0, history.length - 7)];
+  if (!reference || !Number.isFinite(reference.close) || reference.close <= 0) return undefined;
+  const weekChange = quote.price - reference.close;
+  return {
+    weekReferencePrice: reference.close,
+    weekChange,
+    weekChangePercent: (weekChange / reference.close) * 100,
+  };
+}
+
+function sanitizeQuote(financials: TickerFinancials | null | undefined) {
+  const quote = financials?.quote;
+  if (!quote) return undefined;
+  const week = weeklyQuoteMove(financials);
+  return {
+    price: Number.isFinite(quote.price) ? quote.price : undefined,
+    currency: quote.currency,
+    changePercent: Number.isFinite(quote.changePercent) ? quote.changePercent : undefined,
+    previousClose: Number.isFinite(quote.previousClose) ? quote.previousClose : undefined,
+    weekReferencePrice: week?.weekReferencePrice,
+    weekChange: week?.weekChange,
+    weekChangePercent: week?.weekChangePercent,
+    lastUpdated: quote.lastUpdated,
+  };
+}
+
+function sanitizeTickerMetadata(metadata: TickerMetadata, financials?: TickerFinancials | null): Omit<TickerMetadata, "broker_contracts"> & { quote?: ReturnType<typeof sanitizeQuote> } {
+  return {
+    ticker: metadata.ticker,
+    exchange: metadata.exchange,
+    currency: metadata.currency,
+    name: metadata.name,
+    sector: metadata.sector,
+    industry: metadata.industry,
+    assetCategory: metadata.assetCategory,
+    isin: metadata.isin,
+    cusip: metadata.cusip,
+    portfolios: [...metadata.portfolios],
+    watchlists: [...metadata.watchlists],
+    positions: metadata.positions.map(sanitizePosition),
+    custom: (sanitizeUnknown(metadata.custom) as Record<string, unknown>) ?? {},
+    tags: [...metadata.tags],
+    quote: sanitizeQuote(financials),
+  };
+}
+
+function collectCoreConfigPayload(config: AppConfig) {
+  return sanitizeUnknown({
+    configVersion: config.configVersion,
+    baseCurrency: config.baseCurrency,
+    refreshIntervalMinutes: config.refreshIntervalMinutes,
+    portfolios: config.portfolios.map(sanitizePortfolio),
+    watchlists: config.watchlists.map(sanitizeWatchlist),
+    layout: config.layout,
+    layouts: config.layouts,
+    activeLayoutIndex: config.activeLayoutIndex,
+    brokerInstances: config.brokerInstances.map(sanitizeBrokerInstance),
+    disabledPlugins: config.disabledPlugins,
+    disabledSources: config.disabledSources,
+    pluginConfig: config.pluginConfig,
+    theme: config.theme,
+    chartPreferences: config.chartPreferences,
+    valueFlashingEnabled: config.valueFlashingEnabled,
+    recentTickers: config.recentTickers,
+    onboardingComplete: config.onboardingComplete,
+  });
+}
+
+function positionValue(position: TickerPosition, financials: TickerFinancials | null | undefined): number | null {
+  if (typeof position.marketValue === "number" && Number.isFinite(position.marketValue)) {
+    return Math.abs(position.marketValue);
+  }
+  const price = typeof position.markPrice === "number" && Number.isFinite(position.markPrice)
+    ? position.markPrice
+    : financials?.quote?.price ?? position.avgCost;
+  if (!Number.isFinite(position.shares) || !Number.isFinite(price)) return null;
+  return Math.abs(position.shares * price * (position.multiplier ?? 1));
+}
+
+function collectAnalyticsByPortfolio(
+  config: AppConfig,
+  tickers: Map<string, TickerRecord>,
+  financials: Map<string, TickerFinancials>,
+) {
+  const output: Record<string, Record<string, unknown>> = {};
+  for (const portfolio of config.portfolios) {
+    const symbols = new Set<string>();
+    let marketValue = 0;
+    let hasMarketValue = false;
+    let returnWeight = 0;
+    let weightedReturn = 0;
+    for (const ticker of tickers.values()) {
+      const tickerFinancials = financials.get(ticker.metadata.ticker);
+      const portfolioPositions = ticker.metadata.positions.filter((position) => position.portfolio === portfolio.id);
+      if (portfolioPositions.length === 0 && !ticker.metadata.portfolios.includes(portfolio.id)) continue;
+      symbols.add(ticker.metadata.ticker);
+      for (const position of portfolioPositions) {
+        const value = positionValue(position, tickerFinancials);
+        if (value != null) {
+          hasMarketValue = true;
+          marketValue += value;
+          const return1Y = tickerFinancials?.fundamentals?.return1Y;
+          if (typeof return1Y === "number" && Number.isFinite(return1Y)) {
+            returnWeight += value;
+            weightedReturn += return1Y * value;
+          }
+        }
+      }
+    }
+    output[portfolio.id] = {
+      portfolioName: portfolio.name,
+      holdingsCount: symbols.size,
+      oneYearReturn: returnWeight > 0 ? weightedReturn / returnWeight : null,
+      spyBeta: null,
+      marketValue: hasMarketValue ? marketValue : null,
+      currency: portfolio.currency || config.baseCurrency,
+      sourceLabel: "Synced portfolio",
+      asOf: new Date().toISOString(),
+    };
+  }
+  return output;
+}
+
+function collectCoreCollectionsPayload(config: AppConfig, tickers: Map<string, TickerRecord>, financials: Map<string, TickerFinancials>) {
+  const records = [...tickers.values()]
+    .map((ticker) => sanitizeTickerMetadata(ticker.metadata, financials.get(ticker.metadata.ticker)))
+    .filter((metadata) => (
+      metadata.portfolios.length > 0 ||
+      metadata.watchlists.length > 0 ||
+      metadata.positions.length > 0
+    ));
+
+  return {
+    portfolios: config.portfolios.map(sanitizePortfolio),
+    watchlists: config.watchlists.map(sanitizeWatchlist),
+    analyticsByPortfolio: collectAnalyticsByPortfolio(config, tickers, financials),
+    tickers: records,
+  };
+}
+
+function mergeConfigPayload(config: AppConfig, payload: unknown): AppConfig | null {
+  if (!isPlainObject(payload)) return null;
+  const next: AppConfig = { ...config };
+  const assign = <K extends keyof AppConfig>(key: K) => {
+    if (key in payload) {
+      next[key] = payload[key as string] as AppConfig[K];
+    }
+  };
+
+  assign("baseCurrency");
+  assign("refreshIntervalMinutes");
+  assign("layout");
+  assign("layouts");
+  assign("activeLayoutIndex");
+  assign("disabledPlugins");
+  assign("disabledSources");
+  assign("pluginConfig");
+  assign("theme");
+  assign("chartPreferences");
+  assign("valueFlashingEnabled");
+  assign("recentTickers");
+  assign("onboardingComplete");
+
+  if (Array.isArray(payload.portfolios)) next.portfolios = payload.portfolios as Portfolio[];
+  if (Array.isArray(payload.watchlists)) next.watchlists = payload.watchlists as Watchlist[];
+  if (Array.isArray(payload.brokerInstances)) {
+    const incoming = payload.brokerInstances as Array<Partial<BrokerInstanceConfig>>;
+    const existingById = new Map(config.brokerInstances.map((instance) => [instance.id, instance]));
+    next.brokerInstances = incoming.map((instance) => {
+      const current = instance.id ? existingById.get(instance.id) : undefined;
+      return {
+        id: instance.id ?? current?.id ?? crypto.randomUUID(),
+        brokerType: instance.brokerType ?? current?.brokerType ?? "",
+        label: instance.label ?? current?.label ?? "",
+        connectionMode: instance.connectionMode ?? current?.connectionMode,
+        enabled: instance.enabled ?? current?.enabled,
+        lastSyncedAt: instance.lastSyncedAt ?? current?.lastSyncedAt,
+        config: current?.config ?? {},
+      };
+    });
+  }
+  return next;
+}
+
+export const coreConfigSyncContributor: SyncContributor = {
+  id: "core.config",
+  schemaVersion: 1,
+  collect: ({ state }) => collectCoreConfigPayload(state.config),
+  apply: (payload, { state, dispatch }) => {
+    const nextConfig = mergeConfigPayload(state.config, payload);
+    if (!nextConfig) return;
+    dispatch({ type: "SET_CONFIG", config: nextConfig });
+    scheduleConfigSave(nextConfig);
+  },
+};
+
+export const coreCollectionsSyncContributor: SyncContributor = {
+  id: "core.collections",
+  schemaVersion: 1,
+  collect: ({ state }) => collectCoreCollectionsPayload(state.config, state.tickers, state.financials),
+  apply: async (payload, { state, dispatch, tickerRepository }) => {
+    if (!isPlainObject(payload)) return;
+    const nextConfig = { ...state.config };
+    if (Array.isArray(payload.portfolios)) nextConfig.portfolios = payload.portfolios as Portfolio[];
+    if (Array.isArray(payload.watchlists)) nextConfig.watchlists = payload.watchlists as Watchlist[];
+
+    const nextTickers = new Map(state.tickers);
+    const rawTickers = Array.isArray(payload.tickers) ? payload.tickers : [];
+    for (const rawTicker of rawTickers) {
+      if (!isPlainObject(rawTicker)) continue;
+      const current = typeof rawTicker.ticker === "string"
+        ? nextTickers.get(rawTicker.ticker)
+        : null;
+      const metadata = hydrateTickerMetadata({
+        ...current?.metadata,
+        ...rawTicker,
+        broker_contracts: current?.metadata.broker_contracts ?? [],
+      });
+      const record: TickerRecord = { metadata };
+      await tickerRepository.saveTicker(record);
+      nextTickers.set(metadata.ticker, record);
+    }
+
+    dispatch({ type: "SET_CONFIG", config: nextConfig });
+    dispatch({ type: "SET_TICKERS", tickers: nextTickers });
+    scheduleConfigSave(nextConfig);
+  },
+};
+
+export function createCoreSyncContributors(): SyncContributor[] {
+  return [coreConfigSyncContributor, coreCollectionsSyncContributor];
+}
+
+export const __syncContributorInternalsForTests = {
+  sanitizeUnknown,
+  collectCoreConfigPayload,
+  collectCoreCollectionsPayload,
+};

--- a/src/sync/core-contributors.ts
+++ b/src/sync/core-contributors.ts
@@ -278,6 +278,16 @@ function collectCoreCollectionsPayload(
     ));
 
   return {
+    baseCurrency: config.baseCurrency,
+    exchangeRates: Object.fromEntries(
+      [...exchangeRates.entries()]
+        .filter(([currency, rate]) => (
+          typeof currency === "string" &&
+          Number.isFinite(rate) &&
+          rate > 0
+        ))
+        .map(([currency, rate]) => [currency.trim().toUpperCase(), rate]),
+    ),
     portfolios: config.portfolios.map(sanitizePortfolio),
     watchlists: config.watchlists.map(sanitizeWatchlist),
     analyticsByPortfolio: collectAnalyticsByPortfolio(config, tickers, financials, exchangeRates),

--- a/src/sync/profile-analytics.ts
+++ b/src/sync/profile-analytics.ts
@@ -1,0 +1,39 @@
+import type { PublicPortfolioAnalytics } from "../api-client";
+
+const analyticsByPortfolio = new Map<string, PublicPortfolioAnalytics>();
+
+function finiteMetric(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function normalizeAnalytics(analytics: PublicPortfolioAnalytics | null | undefined): PublicPortfolioAnalytics | null {
+  if (!analytics) return null;
+  const normalized = {
+    oneYearReturn: finiteMetric(analytics.oneYearReturn),
+    spyBeta: finiteMetric(analytics.spyBeta),
+  };
+  return normalized.oneYearReturn != null || normalized.spyBeta != null ? normalized : null;
+}
+
+function sameAnalytics(left: PublicPortfolioAnalytics | null, right: PublicPortfolioAnalytics | null): boolean {
+  return left?.oneYearReturn === right?.oneYearReturn && left?.spyBeta === right?.spyBeta;
+}
+
+export function setSyncedProfileAnalytics(
+  portfolioId: string,
+  analytics: PublicPortfolioAnalytics | null | undefined,
+): boolean {
+  const normalized = normalizeAnalytics(analytics);
+  const current = analyticsByPortfolio.get(portfolioId) ?? null;
+  if (sameAnalytics(current, normalized)) return false;
+  if (normalized) {
+    analyticsByPortfolio.set(portfolioId, normalized);
+  } else {
+    analyticsByPortfolio.delete(portfolioId);
+  }
+  return true;
+}
+
+export function getSyncedProfileAnalytics(portfolioId: string): PublicPortfolioAnalytics | null {
+  return analyticsByPortfolio.get(portfolioId) ?? null;
+}

--- a/src/sync/react.ts
+++ b/src/sync/react.ts
@@ -1,0 +1,53 @@
+import { useEffect, useSyncExternalStore, type Dispatch } from "react";
+import type { AppAction, AppState } from "../core/state/app/state";
+import type { TickerRepository } from "../data/ticker-repository";
+import type { PluginRegistry } from "../plugins/registry";
+import { cloudSyncController } from "./controller";
+
+interface CloudSyncRuntimeOptions {
+  state: AppState;
+  dispatch: Dispatch<AppAction>;
+  tickerRepository: TickerRepository;
+  pluginRegistry: PluginRegistry;
+  initialized: boolean;
+}
+
+export function useCloudSyncRuntime({
+  state,
+  dispatch,
+  tickerRepository,
+  pluginRegistry,
+  initialized,
+}: CloudSyncRuntimeOptions): void {
+  useEffect(() => {
+    cloudSyncController.setRuntime({
+      state,
+      dispatch,
+      tickerRepository,
+      getContributors: () => pluginRegistry.getEnabledSyncContributors(),
+      getTransport: () => pluginRegistry.getActiveSyncTransport(),
+    });
+  }, [dispatch, pluginRegistry, state, tickerRepository]);
+
+  useEffect(() => () => {
+    cloudSyncController.clearRuntime();
+  }, []);
+
+  useEffect(() => {
+    if (!initialized) return;
+    void cloudSyncController.pullLatest();
+  }, [initialized, pluginRegistry]);
+
+  useEffect(() => {
+    if (!initialized) return;
+    cloudSyncController.schedulePush("state-change");
+  }, [initialized, state.config, state.tickers]);
+}
+
+export function useCloudSyncStatus() {
+  return useSyncExternalStore(
+    (listener) => cloudSyncController.subscribe(listener),
+    () => cloudSyncController.getStatus(),
+    () => cloudSyncController.getStatus(),
+  );
+}

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -1,0 +1,77 @@
+import type { Dispatch } from "react";
+import type { AppAction, AppState } from "../core/state/app/state";
+import type { TickerRepository } from "../data/ticker-repository";
+
+export const SYNC_SNAPSHOT_SCHEMA_VERSION = 1;
+
+export interface SyncContributorPayload {
+  schemaVersion: number;
+  updatedAt: string;
+  payload: unknown;
+}
+
+export interface SyncSnapshot {
+  schemaVersion: typeof SYNC_SNAPSHOT_SCHEMA_VERSION;
+  appId: "gloomberb";
+  clientId: string;
+  createdAt: string;
+  appVersion?: string;
+  contributors: Record<string, SyncContributorPayload>;
+}
+
+export interface SyncCollectContext {
+  state: AppState;
+}
+
+export interface SyncApplyContext {
+  snapshot: SyncSnapshot;
+  state: AppState;
+  dispatch: Dispatch<AppAction>;
+  tickerRepository: TickerRepository;
+}
+
+export interface SyncContributor {
+  id: string;
+  schemaVersion: number;
+  collect(context: SyncCollectContext): unknown | Promise<unknown>;
+  apply?(payload: unknown, context: SyncApplyContext): void | Promise<void>;
+}
+
+export interface SyncSnapshotResponse {
+  snapshot: SyncSnapshot | null;
+  revision: number | null;
+  updatedAt: string | null;
+  settings?: SyncSettings;
+}
+
+export interface SyncPushResult {
+  revision: number;
+  updatedAt: string;
+  settings?: SyncSettings;
+}
+
+export interface SyncTransport {
+  id: string;
+  isAvailable(): boolean;
+  pullSnapshot(): Promise<SyncSnapshotResponse>;
+  pushSnapshot(snapshot: SyncSnapshot, options?: { baseRevision?: number | null }): Promise<SyncPushResult>;
+}
+
+export interface SyncSettings {
+  syncEnabled: boolean;
+  weeklyRoundupEnabled: boolean;
+  positionAlertsEnabled: boolean;
+  selectedSharedPortfolioId?: string | null;
+  lastSyncAt?: string | null;
+  lastRoundupEmailAt?: string | null;
+}
+
+export interface RegisteredSyncContributor {
+  pluginId: string;
+  contributor: SyncContributor;
+}
+
+export interface RegisteredSyncTransport {
+  pluginId: string;
+  transport: SyncTransport;
+}

--- a/src/types/desktop-deeplink.ts
+++ b/src/types/desktop-deeplink.ts
@@ -1,0 +1,7 @@
+export interface DesktopDeepLink {
+  url: string;
+}
+
+export interface DesktopDeepLinkBridge {
+  subscribe(listener: (deeplink: DesktopDeepLink) => void): () => void;
+}

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -20,6 +20,7 @@ import type { TickerFinancials } from "./financials";
 import type { CachePolicy, PersistedResourceValue } from "./persistence";
 import type { TickerRecord } from "./ticker";
 import type { InstrumentSearchResult } from "./instrument";
+import type { SyncContributor, SyncTransport } from "../sync/types";
 
 export interface GloomSlots {
   "ticker-research:tab": { ticker: TickerRecord; financials: TickerFinancials | null };
@@ -467,6 +468,8 @@ export interface GloomPluginContext {
   registerShortcut(shortcut: KeyboardShortcut): void;
   registerTickerAction(action: TickerAction): void;
   registerContextMenuProvider(provider: ContextMenuProviderDef): void;
+  registerSyncContributor(contributor: SyncContributor): () => void;
+  registerSyncTransport(transport: SyncTransport): () => void;
   watchNewsQuery?(
     query: import("./news-source").NewsQuery,
     listener: (state: import("./news-source").NewsQueryState) => void,

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -85,7 +85,7 @@ export interface SyntaxStyleLike {
 export interface BoxRenderable {
   x?: number;
   y?: number;
-  width?: number;
+  width?: number | string;
   height?: number;
   absoluteX?: number;
   absoluteY?: number;
@@ -264,6 +264,17 @@ export interface HostTabsProps {
   palette: HostTabsPalette;
 }
 
+export interface HostCheckboxProps {
+  label: string;
+  checked: boolean;
+  onChange?: (checked: boolean) => void;
+  disabled?: boolean;
+  active?: boolean;
+  description?: string;
+  width?: number;
+  variant?: "default" | "desktop";
+}
+
 export interface UiHost {
   kind?: "opentui" | "desktop-web";
   capabilities?: {
@@ -299,6 +310,7 @@ export interface UiHost {
   DialogFrame?: ComponentType<any>;
   PageStackView?: ComponentType<any>;
   Tabs?: ComponentType<HostTabsProps>;
+  Checkbox?: ComponentType<HostCheckboxProps>;
   DataTable?: ComponentType<any>;
   createSyntaxStyle?(): SyntaxStyleLike;
   colorFromHex?(hex: string): unknown;

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -266,6 +266,7 @@ export interface HostTabsProps {
 
 export interface HostCheckboxProps {
   label: string;
+  displayLabel?: string;
   checked: boolean;
   onChange?: (checked: boolean) => void;
   disabled?: boolean;

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -35,6 +35,7 @@ export { contextMenuDivider } from "../types/context-menu";
 export type {
   BoxRenderable,
   ChartSurfaceProps,
+  HostCheckboxProps,
   Highlight,
   ImageSurfaceProps,
   InputRenderable,


### PR DESCRIPTION
## Summary
- add plugin sync contributor and transport APIs with a core sync manager
- sync safe config, collections, sanitized positions, quote fields, and weekly quote movement metadata
- update Account Management with profile analytics preview, automatic sync status, roundup and jump alert preferences
- include public account analytics in chat hover profiles when enabled

## Validation
- `bun test src/sync/core-contributors.test.ts src/plugins/builtin/account-management/model.test.ts src/components/command-bar/surface/index.test.tsx`

## Notes
- Sync is automatic after startup/login and after config or ticker changes; there is no manual sync button.
- No email was sent.