### PR TITLE
Fix fundamental graph bar rendering

### DIFF
--- a/.agents/skills/tui-testing/SKILL.md
+++ b/.agents/skills/tui-testing/SKILL.md
@@ -196,12 +196,15 @@ bun test --update-snapshots           # Update snapshot files
 
 Run the actual app in a tmux session, send keystrokes, and capture the rendered screen. **Use this as a last resort** — for verifying full-app behavior that can't be tested with the harness or CLI.
 
+When tmux is used for React/OpenTUI changes, always treat runtime health as part of the smoke. Do not stop at "it rendered"; scan for React hook/update-depth failures, listener leak warnings, and obvious memory runaway.
+
 ### When to use tmux
 
 - Verifying layout and pane arrangement with real data
 - Testing keyboard navigation flows across multiple views
 - Smoke-testing after major refactors
 - Debugging rendering issues that only appear with the full app
+- Checking for real-app React warnings, listener leaks, update loops, or memory growth after layout/pane/chart/subscription changes
 
 ### Setup
 
@@ -214,6 +217,12 @@ tmux new-session -d -s test -x 120 -y 40 'bun run dev 2>&1'
 
 # Wait for the app to render (2-3 seconds for initial load)
 sleep 3
+```
+
+For warning/error scans, pipe the pane output to a log before interacting:
+
+```bash
+tmux pipe-pane -o -t test 'cat > /tmp/gloomberb-test.log'
 ```
 
 If you need to run the app without `tmux`, keep the process handle so you can shut it down:
@@ -283,6 +292,60 @@ tmux capture-pane -t test -p
 # 5. Always clean up
 tmux kill-session -t test
 ```
+
+### Runtime health checks
+
+For real-app smokes, especially after touching React hooks, subscriptions, chart rendering, pane settings, market-data events, layout switching, or plugin runtime code, perform these checks before finishing:
+
+1. Capture a log and final screen.
+2. Scan both for React/runtime warnings.
+3. Sample RSS before and after interactions if the test runs long enough to compare.
+4. Explicitly report any remaining uncertainty, such as a short smoke not proving long-horizon leak absence.
+
+Suggested scan:
+
+```bash
+LOG=/tmp/gloomberb-test.log
+CAP=/tmp/gloomberb-test.capture
+tmux capture-pane -t test -p > "$CAP"
+
+rg -n \
+  "Possible EventTarget|MaxListeners|Maximum update depth|Invalid hook|Rendered more hooks|Rendered fewer hooks|React has detected|\\[ERROR\\]|Error:" \
+  "$LOG" "$CAP" || true
+```
+
+Suggested RSS sampling:
+
+```bash
+pane_pid=$(tmux display-message -p -t test '#{pane_pid}')
+child_pids=$(pgrep -P "$pane_pid" || true)
+grandchild_pids=""
+for pid in $child_pids; do
+  grandchild_pids="$grandchild_pids $(pgrep -P "$pid" || true)"
+done
+app_pids=$(printf '%s\n' $child_pids $grandchild_pids | awk 'NF' | sort -u)
+
+for pid in $app_pids; do
+  ps -o pid=,rss=,command= -p "$pid" || true
+done
+```
+
+Interpret memory samples conservatively:
+
+- A short smoke can catch obvious runaway growth, but it cannot prove there is no long-horizon leak.
+- Startup, first data load, chart bitmap allocation, and layout switching can legitimately increase RSS.
+- Suspicious signs are repeated warning logs, unbounded growth across repeated identical interactions, or jumps paired with update-depth/listener warnings.
+
+### Layout and pane smoke coverage
+
+When a bug mentions a specific saved layout, pane type, or focus path, launch directly into that layout or use the remote-control endpoint to switch layouts rather than relying only on keyboard shortcuts. Keyboard encoding in tmux can be terminal-dependent.
+
+Recommended coverage for layout/pane regressions:
+
+- Launch the affected layout directly from an isolated temp config or copied app config.
+- Exercise the affected pane's own interactions, such as chart period changes, refresh, tab changes, pane settings, or legend toggles.
+- Switch between the affected layout and another layout at least a few times when the bug involved layout activation or pane unmount/remount behavior.
+- Re-run the warning scan after interactions and after layout switches.
 
 ### Common command bar actions (Ctrl+P)
 

--- a/src/components/chart/bar-chart-renderer.test.ts
+++ b/src/components/chart/bar-chart-renderer.test.ts
@@ -7,6 +7,7 @@ import {
   renderNativeBarChart,
   resolveNativeBarPixelBounds,
   resolveBarChartHover,
+  resolveNativeBarChartHover,
 } from "./bar-chart-renderer";
 
 const series = [
@@ -122,16 +123,14 @@ describe("bar chart renderer", () => {
       colors: { bgColor: "#000000", gridColor: "#333333", axisColor: "#666666", negativeColor: "#ff5555" },
     })!;
 
-    const lastBar = scene.bars.at(-1)!;
-    expect(lastBar.x + lastBar.width).toBe(scene.width);
-    expect(renderBarChart(scene)[scene.zeroRow]).not.toContain("─");
+    const zeroRow = renderBarChart(scene)[scene.zeroRow]!;
+    expect([...zeroRow].filter((char) => char === "█").length).toBeGreaterThan(0);
+    expect([...zeroRow].filter((char) => char === "─").length).toBeGreaterThanOrEqual(scene.categories.length - 1);
 
     const bitmapWidth = 470;
     const pixelBounds = scene.bars.map((bar) => resolveNativeBarPixelBounds(scene, bar, bitmapWidth));
     const pixelWidths = pixelBounds.map((bounds) => bounds.rightExclusive - bounds.left);
     expect(Math.max(...pixelWidths) - Math.min(...pixelWidths)).toBeLessThanOrEqual(1);
-    expect(pixelBounds[0]!.left).toBe(0);
-    expect(pixelBounds.at(-1)!.rightExclusive).toBe(bitmapWidth);
     const pixelGaps: number[] = [];
     for (let index = 1; index < pixelBounds.length; index++) {
       pixelGaps.push(pixelBounds[index]!.left - pixelBounds[index - 1]!.rightExclusive);
@@ -139,13 +138,7 @@ describe("bar chart renderer", () => {
     expect(new Set(pixelGaps)).toEqual(new Set([1]));
 
     const bitmap = renderNativeBarChart(scene, bitmapWidth, 80);
-    const zeroY = Math.round((scene.zeroRow / Math.max(scene.height - 1, 1)) * (bitmap.height - 1));
-    let separatorColumns = 0;
-    for (let x = 0; x < bitmap.width; x++) {
-      const index = (zeroY * bitmap.width + x) * 4;
-      if (bitmap.pixels[index + 1]! <= 120) separatorColumns++;
-    }
-    expect(separatorColumns).toBe(scene.categories.length - 1);
+    expect(bitmap.pixels.some((value) => value > 0)).toBe(true);
 
     const axis = renderBarChartAxis(scene, 1);
     expect(axis).toHaveLength(1);
@@ -154,5 +147,87 @@ describe("bar chart renderer", () => {
     expect(axis.join("\n")).not.toContain("Q1");
     expect(axis.join("\n")).not.toContain("20 20");
     expect(axis[0]!.endsWith("  ")).toBe(true);
+  });
+
+  test("drops null-only categories while keeping fixed ticker slots", () => {
+    const sparseSeries = [
+      {
+        id: "AMD",
+        label: "AMD",
+        color: "#00ff66",
+        points: [
+          { category: "2025 Q1", value: 10 },
+          { category: "2025 Q2", value: 11 },
+          { category: "2025 Q3", value: 12 },
+          { category: "2025 Q4", value: null },
+        ],
+      },
+      {
+        id: "NVDA",
+        label: "NVDA",
+        color: "#4dabf7",
+        points: [
+          { category: "2025 Q1", value: 20 },
+          { category: "2025 Q3", value: 30 },
+          { category: "2025 Q4", value: null },
+        ],
+      },
+    ];
+    const scene = buildBarChartScene(sparseSeries, {
+      width: 36,
+      height: 8,
+      colors: { bgColor: "#000000", gridColor: "#333333", axisColor: "#666666", negativeColor: "#ff5555" },
+    })!;
+
+    expect(scene.categories).toEqual(["2025 Q1", "2025 Q2", "2025 Q3"]);
+    const middleCategoryBars = scene.bars.filter((bar) => bar.category === "2025 Q2");
+    expect(middleCategoryBars).toHaveLength(1);
+    expect(middleCategoryBars[0]!.seriesCount).toBe(2);
+
+    const bitmapWidth = 360;
+    const firstAmd = resolveNativeBarPixelBounds(scene, scene.bars.find((bar) => bar.category === "2025 Q1" && bar.seriesId === "AMD")!, bitmapWidth);
+    const middleAmd = resolveNativeBarPixelBounds(scene, middleCategoryBars[0]!, bitmapWidth);
+    expect(middleAmd.rightExclusive - middleAmd.left).toBe(firstAmd.rightExclusive - firstAmd.left);
+  });
+
+  test("spreads saturated text slots and resolves native hover by pixel slot", () => {
+    const denseMultiSeries = Array.from({ length: 3 }, (_unused, seriesIndex) => ({
+      id: `S${seriesIndex}`,
+      label: `S${seriesIndex}`,
+      color: "#00ff66",
+      points: Array.from({ length: 80 }, (_point, categoryIndex) => ({
+        category: `${2020 + Math.floor(categoryIndex / 4)} Q${categoryIndex % 4 + 1}`,
+        value: seriesIndex + categoryIndex + 1,
+      })),
+    }));
+    const scene = buildBarChartScene(denseMultiSeries, {
+      width: 80,
+      height: 8,
+      colors: { bgColor: "#000000", gridColor: "#333333", axisColor: "#666666", negativeColor: "#ff5555" },
+    })!;
+
+    const xPositions = scene.bars.map((bar) => bar.x);
+    expect(Math.min(...xPositions)).toBe(0);
+    expect(Math.max(...xPositions)).toBe(scene.width - 1);
+    expect(new Set(xPositions).size).toBe(scene.width);
+    expect(xPositions.filter((x) => x === scene.width - 1).length).toBeLessThanOrEqual(denseMultiSeries.length);
+
+    const target = scene.bars.find((bar, index) => (
+      scene.bars.findIndex((candidate) => candidate.x === bar.x) < index
+    ))!;
+    const bitmapWidth = 1200;
+    const bounds = resolveNativeBarPixelBounds(scene, target, bitmapWidth);
+    const pixelCenter = Math.floor((bounds.left + bounds.rightExclusive - 1) / 2);
+
+    expect(scene.bars.filter((bar) => bar.x === target.x).length).toBeGreaterThan(1);
+    expect(resolveBarChartHover(scene, target.x)).not.toMatchObject({
+      seriesId: target.seriesId,
+      category: target.category,
+    });
+    expect(resolveNativeBarChartHover(scene, pixelCenter, bitmapWidth)).toMatchObject({
+      seriesId: target.seriesId,
+      category: target.category,
+      value: target.value,
+    });
   });
 });

--- a/src/components/chart/bar-chart-renderer.ts
+++ b/src/components/chart/bar-chart-renderer.ts
@@ -34,6 +34,9 @@ export interface BarChartBar {
   category: string;
   value: number;
   color: string;
+  categoryIndex: number;
+  seriesIndex: number;
+  seriesCount: number;
   x: number;
   width: number;
   row: number;
@@ -69,17 +72,6 @@ export interface NativeBarChartPixelBounds {
 
 const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
 
-function categorySlotBounds(width: number, categoryCount: number, index: number): { left: number; width: number } {
-  const left = Math.floor((index * width) / categoryCount);
-  const right = index === categoryCount - 1
-    ? width
-    : Math.floor(((index + 1) * width) / categoryCount);
-  return {
-    left,
-    width: Math.max(1, right - left),
-  };
-}
-
 function collectCategories(series: BarChartSeries[]): string[] {
   const categories: string[] = [];
   const seen = new Set<string>();
@@ -90,7 +82,10 @@ function collectCategories(series: BarChartSeries[]): string[] {
       categories.push(point.category);
     }
   }
-  return categories;
+  return categories.filter((category) => series.some((item) => {
+    const value = item.points.find((point) => point.category === category)?.value;
+    return typeof value === "number" && Number.isFinite(value);
+  }));
 }
 
 function normalizeRange(values: number[]): { min: number; max: number } {
@@ -133,32 +128,28 @@ export function buildBarChartScene(series: BarChartSeries[], options: BarChartSc
 
   const { min, max } = normalizeRange(values);
   const zeroRow = valueToRow(0, min, max, height);
-  const seriesCount = Math.max(series.length, 1);
-  const categorySlots = categories.map((_, index) => categorySlotBounds(width, categories.length, index));
-  const minSlotWidth = Math.max(1, Math.min(...categorySlots.map((slot) => slot.width)));
-  const groupedInnerWidth = Math.max(seriesCount, minSlotWidth - (minSlotWidth > seriesCount * 2 ? 1 : 0));
-  const groupedBarWidth = Math.max(1, Math.floor(groupedInnerWidth / seriesCount));
+  const seriesSlotCount = Math.max(series.length, 1);
   const bars: BarChartBar[] = [];
 
   categories.forEach((category, categoryIndex) => {
-    const group = categorySlots[categoryIndex]!;
-    const barWidth = seriesCount === 1 ? group.width : groupedBarWidth;
-    const barGroupWidth = barWidth * seriesCount;
-    const groupOffset = Math.max(0, Math.floor((group.width - barGroupWidth) / 2));
     series.forEach((item, seriesIndex) => {
       const value = item.points.find((point) => point.category === category)?.value;
       if (typeof value !== "number" || !Number.isFinite(value)) return;
       const color = value < 0 && options.colors.negativeColor
         ? options.colors.negativeColor
         : item.color;
+      const barBounds = chartSlotBounds(width, categories.length * seriesSlotCount, categoryIndex * seriesSlotCount + seriesIndex);
       bars.push({
         seriesId: item.id,
         seriesLabel: item.label,
         category,
         value,
         color,
-        x: clamp(group.left + groupOffset + seriesIndex * barWidth, 0, width - 1),
-        width: Math.min(barWidth, Math.max(width - (group.left + groupOffset + seriesIndex * barWidth), 1)),
+        categoryIndex,
+        seriesIndex,
+        seriesCount: seriesSlotCount,
+        x: barBounds.x,
+        width: barBounds.width,
         row: valueToRow(value, min, max, height),
       });
     });
@@ -174,6 +165,47 @@ export function buildBarChartScene(series: BarChartSeries[], options: BarChartSc
     max,
     zeroRow,
     colors: options.colors,
+  };
+}
+
+function chartSlotBounds(
+  width: number,
+  slotCount: number,
+  slotIndex: number,
+): { x: number; width: number } {
+  const slots = Math.max(1, slotCount);
+  if (slots > width) {
+    const x = clamp(Math.floor(slotIndex * width / slots), 0, width - 1);
+    const right = clamp(Math.floor((slotIndex + 1) * width / slots), x + 1, width);
+    return {
+      x,
+      width: Math.max(1, right - x),
+    };
+  }
+  const gap = slots > 1 && width >= slots * 2 - 1 ? 1 : 0;
+  const usableWidth = Math.max(slots, width - gap * (slots - 1));
+  const slotWidth = Math.max(1, Math.floor(usableWidth / slots));
+  const usedWidth = slotWidth * slots + gap * (slots - 1);
+  const offset = Math.max(0, Math.floor((width - usedWidth) / 2));
+  const x = clamp(offset + slotIndex * (slotWidth + gap), 0, width - 1);
+  return {
+    x,
+    width: Math.max(1, Math.min(slotWidth, width - x)),
+  };
+}
+
+function categoryCellBounds(
+  width: number,
+  categoryCount: number,
+  seriesCount: number,
+  categoryIndex: number,
+): { left: number; width: number } {
+  const first = chartSlotBounds(width, categoryCount * seriesCount, categoryIndex * seriesCount);
+  const last = chartSlotBounds(width, categoryCount * seriesCount, categoryIndex * seriesCount + seriesCount - 1);
+  const right = last.x + last.width;
+  return {
+    left: first.x,
+    width: Math.max(1, right - first.x),
   };
 }
 
@@ -227,6 +259,10 @@ export function resolveBarChartHover(scene: BarChartScene, cellX: number): BarCh
     return Math.abs(currentCenter - x) < Math.abs(closestCenter - x) ? current : closest;
   }, scene.bars[0]!);
 
+  return barToHover(bar);
+}
+
+function barToHover(bar: BarChartBar): BarChartHover {
   return {
     seriesId: bar.seriesId,
     seriesLabel: bar.seriesLabel,
@@ -237,6 +273,29 @@ export function resolveBarChartHover(scene: BarChartScene, cellX: number): BarCh
     width: bar.width,
     row: bar.row,
   };
+}
+
+export function resolveNativeBarChartHover(
+  scene: BarChartScene,
+  pixelX: number,
+  pixelWidth: number,
+): BarChartHover | null {
+  if (!Number.isFinite(pixelX) || scene.bars.length === 0) return null;
+  const width = Math.max(1, Math.floor(pixelWidth));
+  const x = clamp(Math.floor(pixelX), 0, width - 1);
+  const direct = scene.bars.find((bar) => {
+    const bounds = resolveNativeBarPixelBounds(scene, bar, width);
+    return x >= bounds.left && x < bounds.rightExclusive;
+  });
+  const bar = direct ?? scene.bars.reduce((closest, current) => {
+    const closestBounds = resolveNativeBarPixelBounds(scene, closest, width);
+    const currentBounds = resolveNativeBarPixelBounds(scene, current, width);
+    const closestCenter = (closestBounds.left + closestBounds.rightExclusive - 1) / 2;
+    const currentCenter = (currentBounds.left + currentBounds.rightExclusive - 1) / 2;
+    return Math.abs(currentCenter - x) < Math.abs(closestCenter - x) ? current : closest;
+  }, scene.bars[0]!);
+
+  return barToHover(bar);
 }
 
 export function renderBarChart(scene: BarChartScene, hover: BarChartHover | null = null): string[] {
@@ -288,7 +347,7 @@ export function renderBarChartAxis(scene: BarChartScene, rowCount = 1): string[]
   scene.categories.forEach((category, index) => {
     const label = compactCategoryLabel(category, scene.categories[index - 1], scene.categories.length);
     if (!label) return;
-    const group = categorySlotBounds(scene.width, scene.categories.length, index);
+    const group = categoryCellBounds(scene.width, scene.categories.length, Math.max(scene.series.length, 1), index);
     const start = centeredLabelStart(group.left + group.width / 2, label, scene.width, rightInset);
     const row = rows.find((candidate) => canPlaceLabel(candidate, start, label, minGap));
     if (!row) return;
@@ -305,40 +364,37 @@ export function resolveNativeBarPixelBounds(
   pixelWidth: number,
 ): NativeBarChartPixelBounds {
   const width = Math.max(1, Math.floor(pixelWidth));
-
-  if (scene.series.length === 1) {
-    const categoryIndex = scene.categories.indexOf(bar.category);
-    if (categoryIndex >= 0) {
-      const separatorWidth = scene.categories.length > 1 && width >= scene.categories.length * 3 ? 1 : 0;
-      const usableWidth = Math.max(
-        scene.categories.length,
-        width - separatorWidth * (scene.categories.length - 1),
-      );
-      const left = Math.floor((categoryIndex * usableWidth) / scene.categories.length)
-        + categoryIndex * separatorWidth;
-      const rightExclusive = categoryIndex === scene.categories.length - 1
-        ? width
-        : Math.floor(((categoryIndex + 1) * usableWidth) / scene.categories.length)
-          + categoryIndex * separatorWidth;
-      return {
-        left,
-        rightExclusive: Math.max(left + 1, rightExclusive),
-      };
-    }
-  }
-
-  const horizontalInset = 1;
-  const left = clamp(
-    Math.floor((bar.x / scene.width) * width + horizontalInset),
-    0,
-    width - 1,
-  );
-  const rightExclusive = clamp(
-    Math.ceil(((bar.x + bar.width) / scene.width) * width - horizontalInset),
-    left + 1,
+  const bounds = nativeSlotBounds(
     width,
+    scene.categories.length * bar.seriesCount,
+    bar.categoryIndex * bar.seriesCount + bar.seriesIndex,
   );
+  const left = clamp(bounds.left, 0, width - 1);
+  const rightExclusive = clamp(bounds.rightExclusive, left + 1, width);
   return { left, rightExclusive };
+}
+
+function nativeSlotBounds(
+  width: number,
+  slotCount: number,
+  slotIndex: number,
+): NativeBarChartPixelBounds {
+  const slots = Math.max(1, slotCount);
+  if (slots > width) {
+    const left = clamp(Math.floor(slotIndex * width / slots), 0, width - 1);
+    const rightExclusive = clamp(Math.floor((slotIndex + 1) * width / slots), left + 1, width);
+    return { left, rightExclusive };
+  }
+  const gap = slots > 1 && width >= slots * 2 - 1 ? 1 : 0;
+  const usableWidth = Math.max(slots, width - gap * (slots - 1));
+  const slotWidth = Math.max(1, Math.floor(usableWidth / slots));
+  const usedWidth = slotWidth * slots + gap * (slots - 1);
+  const offset = Math.max(0, Math.floor((width - usedWidth) / 2));
+  const left = offset + slotIndex * (slotWidth + gap);
+  return {
+    left,
+    rightExclusive: Math.max(left + 1, left + slotWidth),
+  };
 }
 
 export function renderNativeBarChart(

--- a/src/components/chart/static/bar-chart-surface.tsx
+++ b/src/components/chart/static/bar-chart-surface.tsx
@@ -1,7 +1,14 @@
-import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
-import { Box, ChartSurface, Span, Text, useNativeRenderer, type BoxRenderable } from "../../../ui";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Box, ChartSurface, Text, TextAttributes, useNativeRenderer, type BoxRenderable } from "../../../ui";
 import { colors } from "../../../theme/colors";
-import { consumeChartMouseEvent, getLocalPlotPointer, type ChartMouseEvent } from "../core/pointer";
+import {
+  consumeChartMouseEvent,
+  getLocalPlotPointer,
+  getRenderablePixelSize,
+  scaleLocalPixelCoordinate,
+  type ChartMouseEvent,
+  type LocalPlotPointer,
+} from "../core/pointer";
 import type { NativeChartBitmap } from "../native/chart-rasterizer";
 import { truncateWithEllipsis } from "../../../utils/text-wrap";
 import { useStaticChartBitmapSize } from "./chart/bitmap";
@@ -12,10 +19,35 @@ import {
   renderBarChartYAxis,
   renderNativeBarChart,
   resolveBarChartHover,
+  resolveNativeBarChartHover,
   type BarChartColors,
   type BarChartHover,
+  type BarChartScene,
   type BarChartSeries,
 } from "../bar-chart-renderer";
+
+export interface BarChartSurfaceHoverGeometry {
+  bitmapPixelWidth: number;
+  renderablePixelWidth?: number | null;
+}
+
+export function resolveBarChartSurfaceHover(
+  scene: BarChartScene,
+  pointer: Pick<LocalPlotPointer, "cellX" | "pixelX">,
+  geometry?: BarChartSurfaceHoverGeometry | null,
+): BarChartHover | null {
+  if (geometry && pointer.pixelX !== null) {
+    const pixelX = scaleLocalPixelCoordinate(
+      pointer.pixelX,
+      geometry.renderablePixelWidth ?? geometry.bitmapPixelWidth,
+      geometry.bitmapPixelWidth,
+    );
+    if (pixelX !== null) {
+      return resolveNativeBarChartHover(scene, pixelX, geometry.bitmapPixelWidth);
+    }
+  }
+  return resolveBarChartHover(scene, pointer.cellX);
+}
 
 export interface StaticBarChartSurfaceProps {
   series: BarChartSeries[];
@@ -25,6 +57,8 @@ export interface StaticBarChartSurfaceProps {
   title?: string;
   header?: ReactNode;
   formatValue?: (value: number) => string;
+  hiddenSeriesIds?: readonly string[] | ReadonlySet<string>;
+  onToggleSeries?: (seriesId: string) => void;
   onHoverChange?: (hover: BarChartHover | null) => void;
   onMouseDown?: (event: ChartMouseEvent) => void;
 }
@@ -36,6 +70,8 @@ export function StaticBarChartSurface({
   title,
   header,
   formatValue,
+  hiddenSeriesIds,
+  onToggleSeries,
   onHoverChange,
   onMouseDown,
   colors: chartColors,
@@ -59,11 +95,18 @@ export function StaticBarChartSurface({
     negativeColor: chartColors?.negativeColor ?? colors.negative,
     hoverColor: chartColors?.hoverColor ?? colors.textBright,
   }), [chartColors]);
-  const scene = useMemo(() => buildBarChartScene(series, {
+  const hiddenSeriesIdSet = useMemo(() => (
+    hiddenSeriesIds instanceof Set ? hiddenSeriesIds : new Set(hiddenSeriesIds ?? [])
+  ), [hiddenSeriesIds]);
+  const visibleSeries = useMemo(
+    () => series.filter((item) => !hiddenSeriesIdSet.has(item.id)),
+    [hiddenSeriesIdSet, series],
+  );
+  const scene = useMemo(() => buildBarChartScene(visibleSeries, {
     width: plotWidth,
     height: plotHeight,
     colors: resolvedChartColors,
-  }), [plotHeight, plotWidth, resolvedChartColors, series]);
+  }), [plotHeight, plotWidth, resolvedChartColors, visibleSeries]);
 
   const bitmapSize = useStaticChartBitmapSize(plotWidth, plotHeight);
 
@@ -78,8 +121,8 @@ export function StaticBarChartSurface({
   const hoverLabel = useMemo(() => {
     if (!hover) return null;
     const value = formatValue ? formatValue(hover.value) : String(hover.value);
-    return series.length > 1 ? `${hover.category} ${hover.seriesLabel}: ${value}` : `${hover.category}: ${value}`;
-  }, [formatValue, hover, series.length]);
+    return visibleSeries.length > 1 ? `${hover.category} ${hover.seriesLabel}: ${value}` : `${hover.category}: ${value}`;
+  }, [formatValue, hover, visibleSeries.length]);
   const readout = useMemo(() => {
     if (!hoverLabel) return title ?? "";
     return title ? `${title}  ${hoverLabel}` : hoverLabel;
@@ -98,6 +141,17 @@ export function StaticBarChartSurface({
     return { labelLeft, labelTop, labelWidth, text };
   }, [hover, hoverLabel, plotHeight, plotWidth]);
 
+  const resolvePointerHover = useCallback((pointer: LocalPlotPointer): BarChartHover | null => {
+    if (!scene) return null;
+    const renderablePixelSize = bitmapSize ? getRenderablePixelSize(plotRef.current, renderer) : null;
+    return resolveBarChartSurfaceHover(scene, pointer, bitmapSize
+      ? {
+        bitmapPixelWidth: bitmapSize.pixelWidth,
+        renderablePixelWidth: renderablePixelSize?.pixelWidth ?? bitmapSize.pixelWidth,
+      }
+      : null);
+  }, [bitmapSize, renderer, scene]);
+
   const handleMouseMove = useCallback((event: ChartMouseEvent) => {
     if (!scene) return;
     const pointer = getLocalPlotPointer(event, plotRef.current, renderer);
@@ -106,11 +160,11 @@ export function StaticBarChartSurface({
       onHoverChange?.(null);
       return;
     }
-    const nextHover = resolveBarChartHover(scene, pointer.cellX);
+    const nextHover = resolvePointerHover(pointer);
     setHover(nextHover);
     onHoverChange?.(nextHover);
     consumeChartMouseEvent(event);
-  }, [onHoverChange, renderer, scene]);
+  }, [onHoverChange, renderer, resolvePointerHover, scene]);
 
   const handleMouseOut = useCallback(() => {
     setHover(null);
@@ -122,16 +176,54 @@ export function StaticBarChartSurface({
     if (!scene) return;
     const pointer = getLocalPlotPointer(event, plotRef.current, renderer);
     if (!pointer) return;
-    const nextHover = resolveBarChartHover(scene, pointer.cellX);
+    const nextHover = resolvePointerHover(pointer);
     setHover(nextHover);
     onHoverChange?.(nextHover);
     consumeChartMouseEvent(event);
-  }, [onHoverChange, onMouseDown, renderer, scene]);
+  }, [onHoverChange, onMouseDown, renderer, resolvePointerHover, scene]);
+
+  useEffect(() => {
+    if (hover && hiddenSeriesIdSet.has(hover.seriesId)) {
+      setHover(null);
+      onHoverChange?.(null);
+    }
+  }, [hiddenSeriesIdSet, hover, onHoverChange]);
+
+  const legend = legendRows ? (
+    <Box flexDirection="row" height={1}>
+      {series.map((item, index) => {
+        const hidden = hiddenSeriesIdSet.has(item.id);
+        const legendColor = hidden ? colors.textDim : item.color;
+        const legendAttributes = hidden ? TextAttributes.STRIKETHROUGH | TextAttributes.DIM : TextAttributes.NONE;
+        const handleLegendMouseDown = onToggleSeries
+          ? (event: any) => {
+            event.stopPropagation?.();
+            onToggleSeries(item.id);
+          }
+          : undefined;
+        return (
+          <Box
+            key={item.id}
+            flexDirection="row"
+            height={1}
+            onMouseDown={handleLegendMouseDown}
+            cursor={onToggleSeries ? "pointer" : undefined}
+            data-gloom-interactive={onToggleSeries ? "true" : undefined}
+          >
+            <Text>{index > 0 ? "  " : " "}</Text>
+            <Text fg={legendColor} bg={legendColor} attributes={legendAttributes}> </Text>
+            <Text fg={legendColor} attributes={legendAttributes}>{` ${item.label}`}</Text>
+          </Box>
+        );
+      })}
+    </Box>
+  ) : null;
 
   if (!scene) {
     return (
       <Box flexDirection="column" width={totalWidth} height={totalHeight} onMouseDown={onMouseDown}>
         {header ?? (title ? <Text fg={colors.textBright} bold>{truncateWithEllipsis(title, totalWidth)}</Text> : null)}
+        {legend}
         <Text fg={colors.textDim}>No chart data</Text>
       </Box>
     );
@@ -146,15 +238,7 @@ export function StaticBarChartSurface({
           </Text>
         )
       ) : null}
-      {legendRows ? (
-        <Text>
-          {series.map((item, index) => (
-            <Span key={item.id} fg={item.color}>
-              {index > 0 ? "  " : ""}{"■ "}{item.label}
-            </Span>
-          ))}
-        </Text>
-      ) : null}
+      {legend}
       <Box flexDirection="row" width={totalWidth} height={plotHeight}>
         {yAxisWidth ? (
           <Box flexDirection="column" width={yAxisWidth} height={plotHeight}>

--- a/src/components/command-bar/workflow/ops.ts
+++ b/src/components/command-bar/workflow/ops.ts
@@ -7,10 +7,21 @@ import { updatePaneInstance, setPaneSettings } from "../../../pane-settings";
 import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
 import { cleanPortfolioPaneSettings, resolvePortfolioPaneCollectionId } from "../../../plugins/builtin/portfolio-list/settings";
 import {
+  DEFAULT_RELATIONSHIP_SECOND_SYMBOL,
+  RELATIONSHIP_GRAPH_PANE_ID,
+  buildRelationshipGraphPaneTitle,
+} from "../../../plugins/builtin/correlation/relationship/model";
+import {
   buildComparisonChartPaneTitle,
   COMPARISON_CHART_PANE_ID,
   MIN_COMPARISON_CHART_SYMBOLS,
 } from "../../../plugins/builtin/comparison-chart";
+import {
+  FUNDAMENTAL_GRAPH_PANE_ID,
+  graphKindFromSettings,
+  graphShortcutForKind,
+  graphTemplateTitle,
+} from "../../../plugins/builtin/ticker-detail/data-panes/fundamental-graph/settings";
 import { buildQuoteMonitorPaneTitle } from "../../../plugins/builtin/ticker-detail/settings";
 import { getPaneTemplateDisplayLabel } from "../pane-templates/items";
 import {
@@ -52,6 +63,30 @@ interface CreatePaneTemplateDeps extends SharedWorkflowDeps {
 
 interface ApplyPaneSettingDeps extends SharedWorkflowDeps {
   persistLayout: (layout: LayoutConfig, options?: { pushHistory?: boolean }) => void;
+}
+
+function updateTickerListPane(
+  layout: LayoutConfig,
+  targetId: string,
+  options: {
+    title: string;
+    symbols: readonly string[];
+    primarySymbol?: string;
+    settings?: Record<string, unknown>;
+  },
+): LayoutConfig {
+  const symbols = [...options.symbols];
+  return updatePaneInstance(layout, targetId, (instance) => ({
+    ...instance,
+    title: options.title,
+    ...(options.primarySymbol ? { binding: { kind: "fixed", symbol: options.primarySymbol } as PaneBinding } : {}),
+    settings: {
+      ...(instance.settings ?? {}),
+      symbols,
+      symbolsText: formatTickerListInput(symbols),
+      ...(options.settings ?? {}),
+    },
+  }));
 }
 
 async function resolvePaneTemplateOptions(
@@ -180,19 +215,50 @@ export async function applyPaneSettingFieldValue(
     const rawQuery = typeof value === "string" ? value.trim() : "";
     const symbols = await resolveTickerListInput(rawQuery, null, deps);
     const primarySymbol = symbols[0]!;
-    const symbolsText = formatTickerListInput(symbols);
-
-    const nextLayout = updatePaneInstance(state.config.layout, targetId, (instance) => ({
-      ...instance,
+    const nextLayout = updateTickerListPane(state.config.layout, targetId, {
       title: buildQuoteMonitorPaneTitle(symbols),
-      binding: { kind: "fixed", symbol: primarySymbol },
-      settings: {
-        ...(instance.settings ?? {}),
-        symbol: primarySymbol,
-        symbols,
-        symbolsText,
-      },
-    }));
+      symbols,
+      primarySymbol,
+      settings: { symbol: primarySymbol },
+    });
+    deps.persistLayout(nextLayout, { pushHistory: shouldPushHistory });
+    return;
+  }
+
+  if (descriptor.pane.paneId === FUNDAMENTAL_GRAPH_PANE_ID && field.key === "symbolsText") {
+    const rawInput = typeof value === "string" ? value : "";
+    const symbols = await resolveTickerListInput(
+      rawInput,
+      descriptor.context.activeCollectionId,
+      deps,
+    );
+    const primarySymbol = symbols[0]!;
+    const chartKind = graphKindFromSettings(descriptor.context.settings, "fundamental");
+    const nextLayout = updateTickerListPane(state.config.layout, targetId, {
+      title: graphTemplateTitle(graphShortcutForKind(chartKind), symbols),
+      symbols,
+      primarySymbol,
+    });
+    deps.persistLayout(nextLayout, { pushHistory: shouldPushHistory });
+    return;
+  }
+
+  if (descriptor.pane.paneId === RELATIONSHIP_GRAPH_PANE_ID && field.key === "symbolsText") {
+    const rawInput = typeof value === "string" ? value : "";
+    const symbols = await resolveTickerListInput(
+      rawInput,
+      descriptor.context.activeCollectionId,
+      deps,
+    );
+    if (symbols.length > 2) {
+      throw new Error("Enter one or two tickers.");
+    }
+    const pair: [string, string] = [symbols[0]!, symbols[1] ?? DEFAULT_RELATIONSHIP_SECOND_SYMBOL];
+    const nextLayout = updateTickerListPane(state.config.layout, targetId, {
+      title: buildRelationshipGraphPaneTitle(pair),
+      symbols: pair,
+      primarySymbol: pair[0],
+    });
     deps.persistLayout(nextLayout, { pushHistory: shouldPushHistory });
     return;
   }
@@ -207,15 +273,10 @@ export async function applyPaneSettingFieldValue(
     if (symbols.length < MIN_COMPARISON_CHART_SYMBOLS) {
       throw new Error(`Enter at least ${MIN_COMPARISON_CHART_SYMBOLS} tickers.`);
     }
-    const nextLayout = updatePaneInstance(state.config.layout, targetId, (instance) => ({
-      ...instance,
+    const nextLayout = updateTickerListPane(state.config.layout, targetId, {
       title: buildComparisonChartPaneTitle(symbols),
-      settings: {
-        ...(instance.settings ?? {}),
-        symbols,
-        symbolsText: formatTickerListInput(symbols),
-      },
-    }));
+      symbols,
+    });
     deps.persistLayout(nextLayout, { pushHistory: shouldPushHistory });
     return;
   }

--- a/src/market-data/coordinator/events.test.ts
+++ b/src/market-data/coordinator/events.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { MarketDataCoordinatorEvents } from "./events";
+
+const waitMicrotask = () => Promise.resolve();
+const waitTimer = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("MarketDataCoordinatorEvents", () => {
+  test("coalesces version bumps before notifying external-store listeners", async () => {
+    const events = new MarketDataCoordinatorEvents();
+    const calls: number[] = [];
+    events.subscribeKeys(["quote:AMD"], () => {
+      calls.push(events.getKeysVersion(["quote:AMD"]));
+    });
+
+    events.bump("quote:AMD");
+    events.bump("quote:AMD");
+
+    expect(events.getKeysVersion(["quote:AMD"])).toBe(0);
+    expect(calls).toEqual([]);
+
+    await waitMicrotask();
+    expect(events.getKeysVersion(["quote:AMD"])).toBe(1);
+    expect(calls).toEqual([]);
+
+    await waitTimer();
+    expect(calls).toEqual([1]);
+  });
+
+  test("delivers bumps scheduled during notification in a later notification pass", async () => {
+    const events = new MarketDataCoordinatorEvents();
+    const order: string[] = [];
+    events.subscribeKeys(["quote:AMD"], () => {
+      order.push("AMD");
+      events.bump("quote:NVDA");
+    });
+    events.subscribeKeys(["quote:NVDA"], () => {
+      order.push("NVDA");
+    });
+
+    events.bump("quote:AMD");
+    await waitMicrotask();
+    await waitTimer();
+    expect(order).toEqual(["AMD"]);
+
+    await waitMicrotask();
+    await waitTimer();
+    expect(order).toEqual(["AMD", "NVDA"]);
+  });
+});

--- a/src/market-data/coordinator/events.ts
+++ b/src/market-data/coordinator/events.ts
@@ -4,6 +4,8 @@ export class MarketDataCoordinatorEvents {
   private version = 0;
   private pendingVersionBump = false;
   private pendingChangedKeys = new Set<string>();
+  private pendingNotify = false;
+  private pendingListeners = new Set<() => void>();
   private readonly listeners = new Set<() => void>();
   private readonly keyListeners = new Map<string, Set<() => void>>();
   private readonly keyVersions = new Map<string, number>();
@@ -60,15 +62,34 @@ export class MarketDataCoordinatorEvents {
       for (const key of changedKeys) {
         this.keyVersions.set(key, (this.keyVersions.get(key) ?? 0) + 1);
       }
-      const keyListeners = new Set<() => void>();
+      for (const listener of this.listeners) {
+        this.pendingListeners.add(listener);
+      }
       for (const key of changedKeys) {
         for (const listener of this.keyListeners.get(key) ?? []) {
-          keyListeners.add(listener);
+          this.pendingListeners.add(listener);
         }
       }
 
-      for (const listener of this.listeners) listener();
-      for (const listener of keyListeners) listener();
+      this.scheduleNotify();
     }, { changedKeyCount: changedKeys.size });
+  }
+
+  private scheduleNotify(): void {
+    if (this.pendingNotify) return;
+    this.pendingNotify = true;
+    setTimeout(() => this.flushNotify(), 0);
+  }
+
+  private flushNotify(): void {
+    this.pendingNotify = false;
+    const listeners = [...this.pendingListeners];
+    this.pendingListeners.clear();
+    for (const listener of listeners) {
+      listener();
+    }
+    if (this.pendingListeners.size > 0) {
+      this.scheduleNotify();
+    }
   }
 }

--- a/src/plugins/builtin/correlation/index.tsx
+++ b/src/plugins/builtin/correlation/index.tsx
@@ -18,7 +18,9 @@ import {
 } from "./settings";
 import { resolveCorrelationHeatmapCellColors } from "./colors";
 import {
+  buildRelationshipGraphSettingsDef,
   createRelationshipPaneTemplate,
+  RELATIONSHIP_GRAPH_PANE_ID,
   RelationshipGraphPane,
 } from "./relationship/pane";
 import {
@@ -234,13 +236,14 @@ export const correlationPlugin: GloomPlugin = {
       settings: buildCorrelationSettingsDef(),
     },
     {
-      id: "relationship-graph",
+      id: RELATIONSHIP_GRAPH_PANE_ID,
       name: "Relationship Graph",
       icon: "R",
       component: RelationshipGraphPane,
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 100, height: 30 },
+      settings: buildRelationshipGraphSettingsDef(),
     },
   ],
 

--- a/src/plugins/builtin/correlation/relationship/model.ts
+++ b/src/plugins/builtin/correlation/relationship/model.ts
@@ -1,12 +1,13 @@
 import type { ProjectedChartPoint } from "../../../../components/chart/core/data";
 import type { TimeRange } from "../../../../components/chart/core/types";
 import type { ScatterChartPoint } from "../../../../components/chart/scatter-chart-renderer";
-import type { PaneTemplateCreateOptions } from "../../../../types/plugin";
+import type { PaneSettingsDef, PaneTemplateCreateOptions } from "../../../../types/plugin";
 import type { PricePoint } from "../../../../types/financials";
-import { parseTickerListInput } from "../../../../tickers/list";
+import { formatTickerListInput, parseTickerListInput } from "../../../../tickers/list";
 
 export type RelationshipRange = Extract<TimeRange, "1M" | "3M" | "6M" | "1Y" | "5Y" | "ALL">;
 
+export const RELATIONSHIP_GRAPH_PANE_ID = "relationship-graph";
 const RELATIONSHIP_RANGES: RelationshipRange[] = ["1M", "3M", "6M", "1Y", "5Y", "ALL"];
 export const DEFAULT_RELATIONSHIP_SECOND_SYMBOL = "SPY";
 const RELATIONSHIP_CORRELATION_WINDOWS = [30, 60, 120, 252] as const;
@@ -276,4 +277,23 @@ export function relationshipTemplateSymbols(
   } catch {
     return null;
   }
+}
+
+export function buildRelationshipGraphPaneTitle(pair: readonly [string, string]): string {
+  return `GR ${pair[0]}/${pair[1]}`;
+}
+
+export function buildRelationshipGraphSettingsDef(): PaneSettingsDef {
+  return {
+    title: "Relationship Graph Settings",
+    fields: [
+      {
+        key: "symbolsText",
+        label: "Tickers",
+        description: `Enter one or two tickers. One ticker compares against ${DEFAULT_RELATIONSHIP_SECOND_SYMBOL}.`,
+        type: "text",
+        placeholder: formatTickerListInput(["AMD", "NVDA"]),
+      },
+    ],
+  };
 }

--- a/src/plugins/builtin/correlation/relationship/pane.tsx
+++ b/src/plugins/builtin/correlation/relationship/pane.tsx
@@ -17,7 +17,9 @@ import { useRelationshipHistories } from "./history";
 import {
   DEFAULT_RELATIONSHIP_CORRELATION_WINDOW,
   DEFAULT_RELATIONSHIP_SECOND_SYMBOL,
+  RELATIONSHIP_GRAPH_PANE_ID,
   buildRelationshipAnalysis,
+  buildRelationshipGraphPaneTitle,
   nextRelationshipRange,
   nextRelationshipWindow,
   relationshipSymbolsFromPaneSettings,
@@ -35,7 +37,11 @@ import {
   formatNullableNumber,
 } from "./view-model";
 
-export { buildRelationshipAnalysis } from "./model";
+export {
+  buildRelationshipAnalysis,
+  buildRelationshipGraphSettingsDef,
+  RELATIONSHIP_GRAPH_PANE_ID,
+} from "./model";
 
 type RelationshipGraphShortcut = "range" | "window" | "correlation" | "regression";
 
@@ -326,7 +332,7 @@ export function RelationshipGraphPane({ focused, width, height }: PaneProps) {
 export function createRelationshipPaneTemplate(): PaneTemplateDef {
   return {
     id: "relationship-graph-pane",
-    paneId: "relationship-graph",
+    paneId: RELATIONSHIP_GRAPH_PANE_ID,
     label: "Relationship Graph",
     description: "Graph ratio, rolling correlation, and regression between two tickers.",
     keywords: ["relationship", "ratio", "graph", "correlation", "regression", "gr"],
@@ -345,7 +351,7 @@ export function createRelationshipPaneTemplate(): PaneTemplateDef {
       const pair = relationshipTemplateSymbols(context.activeTicker, options);
       return pair
         ? {
-          title: `GR ${pair[0]}/${pair[1]}`,
+          title: buildRelationshipGraphPaneTitle(pair),
           binding: { kind: "fixed" as const, symbol: pair[0] },
           placement: "floating" as const,
           settings: {

--- a/src/plugins/builtin/ticker-detail/data-panes.test.ts
+++ b/src/plugins/builtin/ticker-detail/data-panes.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { buildRelationshipAnalysis, createRelationshipPaneTemplate } from "../correlation/relationship/pane";
 import { buildFundamentalGraphRows, buildValuationGraphRows } from "./data-panes/fundamental-graph";
+import { allMetricDefs, buildGraphBarSeries, graphRowsForFinancials } from "./data-panes/fundamental-graph/model";
 import { buildHistoricalPriceRows } from "./data-panes/historical-prices";
 import { createDefaultConfig } from "../../../types/config";
-import type { FinancialStatement, PricePoint } from "../../../types/financials";
+import type { FinancialStatement, PricePoint, TickerFinancials } from "../../../types/financials";
 
 describe("ticker data panes", () => {
   test("builds historical price rows with close-to-close changes", () => {
@@ -65,6 +66,55 @@ describe("ticker data panes", () => {
     ]);
   });
 
+  test("orders multi-symbol chart categories by statement date", () => {
+    const series = buildGraphBarSeries([
+      { key: "NVDA:2025-01-31", symbol: "NVDA", date: "2025-01-31", category: "2025 Q1", value: 1, growth: null, barWidth: 1 },
+      { key: "NVDA:2026-04-30", symbol: "NVDA", date: "2026-04-30", category: "2026 Q2", value: 2, growth: null, barWidth: 1 },
+      { key: "AMD:2024-12-31", symbol: "AMD", date: "2024-12-31", category: "2024 Q4", value: 3, growth: null, barWidth: 1 },
+    ]);
+
+    expect(series[0]?.points.map((point) => point.category)).toEqual(["2024 Q4", "2025 Q1", "2026 Q2"]);
+    expect(series[1]?.points.map((point) => point.category)).toEqual(["2024 Q4", "2025 Q1", "2026 Q2"]);
+  });
+
+  test("derives free cash flow and margins for graph metrics", () => {
+    const fcfRows = buildFundamentalGraphRows([
+      { date: "2025-03-31", operatingCashFlow: 100, capitalExpenditure: -25 },
+      { date: "2025-06-30", freeCashFlow: 90, operatingCashFlow: 120, capitalExpenditure: -30 },
+    ] satisfies FinancialStatement[], "freeCashFlow", "NVDA", "quarterly");
+    const marginRows = buildFundamentalGraphRows([
+      { date: "2025-03-31", totalRevenue: 200, grossProfit: 100 },
+    ] satisfies FinancialStatement[], "grossMargin", "AMD", "quarterly");
+
+    expect(fcfRows.map((row) => row.value)).toEqual([75, 90]);
+    expect(marginRows[0]?.value).toBe(0.5);
+    expect(allMetricDefs().map(({ definition }) => definition.key)).toContain("freeCashFlowMargin");
+  });
+
+  test("fills missing Q4 margin rows from annual totals and preceding quarters", () => {
+    const financials = {
+      annualStatements: [
+        { date: "2025-12-31", totalRevenue: 1_000, grossProfit: 500 },
+      ],
+      quarterlyStatements: [
+        { date: "2025-03-31", totalRevenue: 100, grossProfit: 40 },
+        { date: "2025-06-30", totalRevenue: 200, grossProfit: 90 },
+        { date: "2025-09-30", totalRevenue: 300, grossProfit: 150 },
+        { date: "2025-12-31" },
+      ],
+      priceHistory: [],
+    } satisfies TickerFinancials;
+
+    const rows = graphRowsForFinancials(financials, "fundamental", "grossMargin", "quarterly", "AMD");
+
+    expect(rows.map((row) => [row.category, row.value])).toEqual([
+      ["2025 Q1", 0.4],
+      ["2025 Q2", 0.45],
+      ["2025 Q3", 0.5],
+      ["2025 Q4", 220 / 400],
+    ]);
+  });
+
   test("builds valuation graph rows from available multiples", () => {
     const rows = buildValuationGraphRows({
       quote: { symbol: "AMD", price: 100, currency: "USD", change: 0, changePercent: 0, lastUpdated: 1, marketCap: 1_000 },
@@ -80,6 +130,50 @@ describe("ticker data panes", () => {
     expect(rows.map((row) => [row.symbol, row.category, row.value])).toEqual([
       ["AMD", "FY2024", 10],
       ["AMD", "FY2025", 5],
+    ]);
+  });
+
+  test("builds historical trailing and forward P/E rows from prices and EPS", () => {
+    const financials = {
+      quote: { symbol: "META", price: 320, currency: "USD", change: 0, changePercent: 0, lastUpdated: 1 },
+      fundamentals: { forwardPE: 16 },
+      annualStatements: [
+        { date: "2024-12-31", eps: 5 },
+        { date: "2025-12-31", eps: 10 },
+        { date: "2026-12-31", eps: 20 },
+      ],
+      quarterlyStatements: [
+        { date: "2025-03-31", eps: 1 },
+        { date: "2025-06-30", eps: 2 },
+        { date: "2025-09-30", eps: 3 },
+        { date: "2025-12-31", eps: 4 },
+        { date: "2026-03-31", eps: 5 },
+      ],
+      priceHistory: [
+        { date: new Date("2024-12-31T00:00:00Z"), close: 100 },
+        { date: new Date("2025-12-31T00:00:00Z"), close: 150 },
+        { date: new Date("2026-03-31T00:00:00Z"), close: 180 },
+        { date: new Date("2026-12-31T00:00:00Z"), close: 300 },
+      ],
+    } satisfies TickerFinancials;
+
+    const trailingAnnual = buildValuationGraphRows(financials, "trailingPE", "META", "annual");
+    const forwardAnnual = buildValuationGraphRows(financials, "forwardPE", "META", "annual");
+    const trailingQuarterly = buildValuationGraphRows(financials, "trailingPE", "META", "quarterly");
+
+    expect(trailingAnnual.map((row) => [row.category, row.value])).toEqual([
+      ["FY2024", 20],
+      ["FY2025", 15],
+      ["FY2026", 15],
+    ]);
+    expect(forwardAnnual.map((row) => [row.category, row.value])).toEqual([
+      ["FY2024", 10],
+      ["FY2025", 7.5],
+      ["Current", 16],
+    ]);
+    expect(trailingQuarterly.map((row) => [row.category, row.value])).toEqual([
+      ["2025 Q4", 15],
+      ["2026 Q1", 180 / 14],
     ]);
   });
 

--- a/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph.tsx
+++ b/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph.tsx
@@ -12,6 +12,7 @@ import {
   isMetricForKind,
 } from "./fundamental-graph/model";
 import {
+  FUNDAMENTAL_GRAPH_PANE_ID,
   graphKindFromSettings,
   graphTemplateSymbols,
   graphTemplateTitle,
@@ -20,6 +21,7 @@ import {
 import type { FundamentalPeriod, GraphKind, GraphMetricKey } from "./fundamental-graph/types";
 
 export { buildFundamentalGraphRows, buildValuationGraphRows } from "./fundamental-graph/model";
+export { buildGraphPaneSettingsDef, FUNDAMENTAL_GRAPH_PANE_ID } from "./fundamental-graph/settings";
 
 export function FundamentalGraphPane({ focused, width, height }: PaneProps) {
   const pane = usePaneInstance();
@@ -99,7 +101,7 @@ export function createGraphPaneTemplate({
 }): PaneTemplateDef {
   return {
     id,
-    paneId: "fundamental-graph",
+    paneId: FUNDAMENTAL_GRAPH_PANE_ID,
     label,
     description,
     keywords: chartKind === "valuation"

--- a/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph/content.tsx
+++ b/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph/content.tsx
@@ -9,7 +9,9 @@ import {
 } from "../../../../../components";
 import { useShortcut } from "../../../../../react/input";
 import type { BarChartHover } from "../../../../../components/chart/bar-chart-renderer";
+import type { MouseInteractionEvent } from "../../../../../components/chart/core/pointer";
 import { StaticBarChartSurface } from "../../../../../components/chart/static/bar-chart-surface";
+import { useAppDispatch, usePaneInstanceId } from "../../../../../state/app/context";
 import { colors, priceColor } from "../../../../../theme/colors";
 import { usePluginPaneState } from "../../../../runtime";
 import { loadingErrorFooterInfo, refreshFooterHint, useClampSelectedIndex } from "../../../shared/table-pane";
@@ -60,7 +62,10 @@ export function FundamentalGraphContent({
   setChartKind: (updater: (current: GraphKind) => GraphKind) => void;
   onCapture?: (capturing: boolean) => void;
 }) {
+  const dispatch = useAppDispatch();
+  const paneId = usePaneInstanceId();
   const [selectedIdx, setSelectedIdx] = usePluginPaneState<number>("selectedIdx", 0);
+  const [hiddenSeriesIds, setHiddenSeriesIds] = usePluginPaneState<string[]>("hiddenSeriesIds", []);
   const [hoveredBar, setHoveredBar] = useState<BarChartHover | null>(null);
   const [metricTabsFocused, setMetricTabsFocused] = useState(false);
   const definition = metricDef(chartKind, metric);
@@ -69,17 +74,23 @@ export function FundamentalGraphContent({
     label: definition.label,
     value: definition.key,
   })), [metricOptions]);
-  const multiSymbol = new Set(rows.map((row) => row.symbol)).size > 1;
+  const chartSeries = useMemo(() => buildGraphBarSeries(rows), [rows]);
+  const chartSeriesIds = useMemo(() => new Set(chartSeries.map((series) => series.id)), [chartSeries]);
+  const hiddenSeriesIdSet = useMemo(() => new Set(hiddenSeriesIds), [hiddenSeriesIds]);
+  const visibleRows = useMemo(() => rows.filter((row) => {
+    const seriesId = row.symbol || "value";
+    return !hiddenSeriesIdSet.has(seriesId);
+  }), [hiddenSeriesIdSet, rows]);
+  const multiSymbol = new Set(visibleRows.map((row) => row.symbol)).size > 1;
   const columns = useMemo(() => buildFundamentalColumns(width, multiSymbol), [multiSymbol, width]);
-  const tableRows = useMemo(() => [...rows].sort((left, right) => (
+  const tableRows = useMemo(() => [...visibleRows].sort((left, right) => (
     right.date.localeCompare(left.date) || left.symbol.localeCompare(right.symbol)
-  )), [rows]);
+  )), [visibleRows]);
   const boundedSelectedIdx = tableRows.length > 0 ? Math.min(selectedIdx, tableRows.length - 1) : -1;
   const minTableHeight = tableRows.length > 0 ? 4 : 3;
   const desiredChartHeight = height >= 14 ? Math.min(16, Math.max(9, Math.floor(height * 0.58))) : Math.max(4, Math.floor(height / 2));
   const chartHeight = Math.max(1, Math.min(desiredChartHeight, Math.max(1, height - minTableHeight)));
   const tableHeight = Math.max(0, height - chartHeight);
-  const chartSeries = useMemo(() => buildGraphBarSeries(rows), [rows]);
   const selectMetric = useCallback((value: string) => {
     const nextMetric = value as GraphMetricKey;
     const nextKind = metricKind(nextMetric);
@@ -88,11 +99,19 @@ export function FundamentalGraphContent({
     setChartKind(() => nextKind);
     setMetric(() => nextMetric);
   }, [setChartKind, setMetric]);
-  const focusMetricTabs = useCallback(() => {
+  const focusPaneForMouseInteraction = useCallback((event: MouseInteractionEvent | null | undefined) => {
+    event?.stopPropagation?.();
+    event?.preventDefault?.();
+    if (!focused) {
+      dispatch({ type: "FOCUS_PANE", paneId });
+    }
+  }, [dispatch, focused, paneId]);
+  const focusMetricTabs = useCallback((event?: MouseInteractionEvent | null) => {
+    focusPaneForMouseInteraction(event);
     if (metricTabsFocused) return;
     setMetricTabsFocused(true);
     onCapture?.(true);
-  }, [metricTabsFocused, onCapture]);
+  }, [focusPaneForMouseInteraction, metricTabsFocused, onCapture]);
   const releaseMetricTabs = useCallback(() => {
     if (!metricTabsFocused) return;
     setMetricTabsFocused(false);
@@ -103,6 +122,14 @@ export function FundamentalGraphContent({
     selectMetric(value);
   }, [focusMetricTabs, selectMetric]);
   const togglePeriod = useCallback(() => setPeriod((current) => current === "annual" ? "quarterly" : "annual"), [setPeriod]);
+  const toggleSeries = useCallback((seriesId: string) => {
+    setHiddenSeriesIds((current) => {
+      const hidden = new Set(current);
+      if (hidden.has(seriesId)) hidden.delete(seriesId);
+      else hidden.add(seriesId);
+      return [...hidden].filter((id) => chartSeriesIds.has(id));
+    });
+  }, [chartSeriesIds, setHiddenSeriesIds]);
   const hoveredValue = useMemo(() => {
     if (!hoveredBar) return null;
     const label = chartSeries.length > 1 ? `${hoveredBar.category} ${hoveredBar.seriesLabel}` : hoveredBar.category;
@@ -110,6 +137,13 @@ export function FundamentalGraphContent({
   }, [chartSeries.length, definition, hoveredBar]);
 
   useClampSelectedIndex(tableRows.length, selectedIdx, setSelectedIdx);
+
+  useEffect(() => {
+    setHiddenSeriesIds((current) => {
+      const next = current.filter((id) => chartSeriesIds.has(id));
+      return next.length === current.length ? current : next;
+    });
+  }, [chartSeriesIds, setHiddenSeriesIds]);
 
   useEffect(() => {
     if (!focused && metricTabsFocused) {
@@ -228,10 +262,12 @@ export function FundamentalGraphContent({
         width={width}
         height={chartHeight}
         series={chartSeries}
+        hiddenSeriesIds={hiddenSeriesIds}
+        onToggleSeries={toggleSeries}
         header={metricHeader}
         formatValue={definition.format}
         onHoverChange={setHoveredBar}
-        onMouseDown={focusMetricTabs}
+        onMouseDown={focusPaneForMouseInteraction}
       />
       {tableHeight > 0 ? (
         <DataTableView<FundamentalGraphRow, FundamentalColumn>

--- a/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph/model.ts
+++ b/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph/model.ts
@@ -1,6 +1,6 @@
 import type { BarChartSeries } from "../../../../../components/chart/bar-chart-renderer";
 import { colors } from "../../../../../theme/colors";
-import type { FinancialStatement, TickerFinancials } from "../../../../../types/financials";
+import type { FinancialStatement, PricePoint, TickerFinancials } from "../../../../../types/financials";
 import { formatCompact, formatNumber, formatPercent } from "../../../../../utils/format";
 import type {
   FundamentalColumn,
@@ -13,13 +13,62 @@ import type {
   ValuationMetricKey,
 } from "./types";
 
+function finiteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function financialRatio(
+  numerator: number | null | undefined,
+  denominator: number | null | undefined,
+): number | null {
+  return finiteNumber(numerator) && finiteNumber(denominator) && denominator !== 0
+    ? numerator / denominator
+    : null;
+}
+
+function freeCashFlowValue(statement: FinancialStatement): number | null {
+  if (finiteNumber(statement.freeCashFlow)) return statement.freeCashFlow;
+  if (finiteNumber(statement.operatingCashFlow) && finiteNumber(statement.capitalExpenditure)) {
+    return statement.operatingCashFlow + statement.capitalExpenditure;
+  }
+  return null;
+}
+
+function formatMargin(value: number): string {
+  return `${formatNumber(value * 100, 1)}%`;
+}
+
 const FUNDAMENTAL_METRICS: ReadonlyArray<MetricDefinition<FundamentalMetricKey>> = [
   { key: "totalRevenue", label: "Revenue", format: formatCompact },
   { key: "grossProfit", label: "Gross Profit", format: formatCompact },
+  {
+    key: "grossMargin",
+    label: "Gross Margin",
+    format: formatMargin,
+    value: (statement) => financialRatio(statement.grossProfit, statement.totalRevenue),
+  },
   { key: "operatingIncome", label: "Operating Income", format: formatCompact },
+  {
+    key: "operatingMargin",
+    label: "Operating Margin",
+    format: formatMargin,
+    value: (statement) => financialRatio(statement.operatingIncome, statement.totalRevenue),
+  },
   { key: "netIncome", label: "Net Income", format: formatCompact },
+  {
+    key: "netMargin",
+    label: "Net Margin",
+    format: formatMargin,
+    value: (statement) => financialRatio(statement.netIncome, statement.totalRevenue),
+  },
   { key: "operatingCashFlow", label: "Operating Cash Flow", format: formatCompact },
-  { key: "freeCashFlow", label: "Free Cash Flow", format: formatCompact },
+  { key: "freeCashFlow", label: "Free Cash Flow", format: formatCompact, value: freeCashFlowValue },
+  {
+    key: "freeCashFlowMargin",
+    label: "FCF Margin",
+    format: formatMargin,
+    value: (statement) => financialRatio(freeCashFlowValue(statement), statement.totalRevenue),
+  },
   { key: "totalAssets", label: "Total Assets", format: formatCompact },
   { key: "totalDebt", label: "Total Debt", format: formatCompact },
   { key: "totalEquity", label: "Equity", format: formatCompact },
@@ -52,17 +101,204 @@ export function formatMaybePercent(value: number | null): string {
 }
 
 function selectedStatements(financials: TickerFinancials | null, period: FundamentalPeriod): FinancialStatement[] {
-  return period === "annual"
-    ? financials?.annualStatements ?? []
-    : financials?.quarterlyStatements ?? [];
+  if (period === "annual") return financials?.annualStatements ?? [];
+  return deriveQuarterlyStatements(financials?.quarterlyStatements ?? [], financials?.annualStatements ?? []);
 }
 
 function periodCategory(date: string, period: FundamentalPeriod): string {
-  const year = date.slice(0, 4);
-  if (period === "annual") return `FY${year}`;
-  const month = Number(date.slice(5, 7));
+  const parsedYear = Number(date.slice(0, 4));
+  let year = Number.isFinite(parsedYear) ? parsedYear : 0;
+  if (period === "annual") return year > 0 ? `FY${year}` : date;
+  let month = Number(date.slice(5, 7));
+  const day = Number(date.slice(8, 10));
+  if (Number.isFinite(month) && Number.isFinite(day) && day <= 7 && (month - 1) % 3 === 0) {
+    month -= 1;
+    if (month === 0) {
+      month = 12;
+      year -= 1;
+    }
+  }
   const quarter = Number.isFinite(month) && month > 0 ? Math.ceil(month / 3) : 0;
-  return quarter > 0 ? `${year} Q${quarter}` : date;
+  return quarter > 0 && year > 0 ? `${year} Q${quarter}` : date;
+}
+
+type NumericStatementField = Exclude<keyof FinancialStatement, "date">;
+
+const QUARTERLY_FLOW_FIELDS: NumericStatementField[] = [
+  "totalRevenue",
+  "grossProfit",
+  "operatingIncome",
+  "netIncome",
+  "ebitda",
+  "operatingCashFlow",
+  "capitalExpenditure",
+  "freeCashFlow",
+  "eps",
+];
+
+const QUARTERLY_SNAPSHOT_FIELDS: NumericStatementField[] = [
+  "totalAssets",
+  "cashAndCashEquivalents",
+  "cashCashEquivalentsAndShortTermInvestments",
+  "totalDebt",
+  "totalEquity",
+  "basicShares",
+  "dilutedShares",
+  "shareIssued",
+  "ordinarySharesNumber",
+];
+
+function statementNumber(statement: FinancialStatement, field: NumericStatementField): number | null {
+  const value = statement[field];
+  return finiteNumber(value) ? value : null;
+}
+
+function setStatementNumber(statement: FinancialStatement, field: NumericStatementField, value: number): void {
+  (statement as Record<NumericStatementField, number | undefined>)[field] = value;
+}
+
+function statementTime(statement: FinancialStatement): number {
+  const time = Date.parse(statement.date);
+  return Number.isFinite(time) ? time : Number.NaN;
+}
+
+function precedingQuarterValues(
+  quarterlyStatements: FinancialStatement[],
+  annualStatement: FinancialStatement,
+  field: NumericStatementField,
+): number[] {
+  const annualTime = statementTime(annualStatement);
+  if (!Number.isFinite(annualTime)) return [];
+
+  const annualCategory = periodCategory(annualStatement.date, "quarterly");
+  const byCategory = new Map<string, { date: string; time: number; value: number }>();
+  for (const statement of quarterlyStatements) {
+    const time = statementTime(statement);
+    if (!Number.isFinite(time) || time >= annualTime || annualTime - time > 370 * 24 * 60 * 60 * 1000) {
+      continue;
+    }
+    const category = periodCategory(statement.date, "quarterly");
+    if (category === annualCategory) continue;
+    const value = statementNumber(statement, field);
+    if (value === null) continue;
+    const previous = byCategory.get(category);
+    if (!previous || statement.date.localeCompare(previous.date) > 0) {
+      byCategory.set(category, { date: statement.date, time, value });
+    }
+  }
+
+  return [...byCategory.values()]
+    .sort((left, right) => right.time - left.time)
+    .slice(0, 3)
+    .sort((left, right) => left.time - right.time)
+    .map((entry) => entry.value);
+}
+
+function mergeStatementsByDate(statements: FinancialStatement[]): FinancialStatement[] {
+  const byDate = new Map<string, FinancialStatement>();
+  for (const statement of statements) {
+    const existing = byDate.get(statement.date);
+    if (!existing) {
+      byDate.set(statement.date, { ...statement });
+      continue;
+    }
+    for (const [key, value] of Object.entries(statement) as Array<[keyof FinancialStatement, unknown]>) {
+      if (key === "date") continue;
+      if (value !== undefined && existing[key] === undefined) {
+        (existing as unknown as Record<string, unknown>)[key] = value;
+      }
+    }
+  }
+  return [...byDate.values()];
+}
+
+function deriveQuarterlyStatements(
+  quarterlyStatements: FinancialStatement[],
+  annualStatements: FinancialStatement[],
+): FinancialStatement[] {
+  const mergedQuarterly = mergeStatementsByDate(quarterlyStatements);
+  const byDate = new Map(mergedQuarterly.map((statement) => [statement.date, { ...statement }]));
+
+  for (const annualStatement of annualStatements) {
+    let target = byDate.get(annualStatement.date);
+    let changed = false;
+    if (!target) {
+      target = { date: annualStatement.date };
+    }
+
+    for (const field of QUARTERLY_FLOW_FIELDS) {
+      if (statementNumber(target, field) !== null) continue;
+      const annualValue = statementNumber(annualStatement, field);
+      if (annualValue === null) continue;
+      const previousValues = precedingQuarterValues(mergedQuarterly, annualStatement, field);
+      if (previousValues.length !== 3) continue;
+      const derived = annualValue - previousValues.reduce((sum, value) => sum + value, 0);
+      if (!Number.isFinite(derived)) continue;
+      setStatementNumber(target, field, derived);
+      changed = true;
+    }
+
+    for (const field of QUARTERLY_SNAPSHOT_FIELDS) {
+      if (statementNumber(target, field) !== null) continue;
+      const annualValue = statementNumber(annualStatement, field);
+      if (annualValue === null) continue;
+      setStatementNumber(target, field, annualValue);
+      changed = true;
+    }
+
+    if (changed) byDate.set(target.date, target);
+  }
+
+  return [...byDate.values()].sort((left, right) => left.date.localeCompare(right.date));
+}
+
+function fundamentalMetricDef(metric: FundamentalMetricKey): MetricDefinition<FundamentalMetricKey> {
+  return FUNDAMENTAL_METRICS.find((definition) => definition.key === metric) ?? FUNDAMENTAL_METRICS[0]!;
+}
+
+function fundamentalMetricValue(statement: FinancialStatement, metric: FundamentalMetricKey): number | null {
+  const definition = fundamentalMetricDef(metric);
+  const value = definition.value
+    ? definition.value(statement)
+    : statement[metric as keyof FinancialStatement];
+  return finiteNumber(value) ? value : null;
+}
+
+interface GraphRowEntry {
+  date: string;
+  category: string;
+  value: number;
+}
+
+function buildRowsFromEntries(
+  entries: GraphRowEntry[],
+  metric: GraphMetricKey,
+  symbol: string,
+): FundamentalGraphRow[] {
+  const byCategory = new Map<string, GraphRowEntry>();
+  for (const entry of [...entries].sort((left, right) => left.date.localeCompare(right.date))) {
+    const previous = byCategory.get(entry.category);
+    if (!previous || entry.date.localeCompare(previous.date) >= 0) {
+      byCategory.set(entry.category, entry);
+    }
+  }
+  const sorted = [...byCategory.values()].sort((left, right) => left.date.localeCompare(right.date));
+  const maxAbs = Math.max(1, ...sorted.map((entry) => Math.abs(entry.value)));
+
+  return sorted.map((entry, index) => {
+    const previous = sorted[index - 1]?.value;
+    return {
+      key: [symbol, entry.date, metric].filter(Boolean).join(":"),
+      symbol,
+      date: entry.date,
+      category: entry.category,
+      value: entry.value,
+      growth: typeof previous === "number" && previous !== 0
+        ? (entry.value - previous) / Math.abs(previous)
+        : null,
+      barWidth: Math.max(1, Math.round((Math.abs(entry.value) / maxAbs) * 24)),
+    };
+  });
 }
 
 export function buildFundamentalGraphRows(
@@ -71,33 +307,15 @@ export function buildFundamentalGraphRows(
   symbol = "",
   period: FundamentalPeriod = "annual",
 ): FundamentalGraphRow[] {
-  const sortedStatements = [...statements]
-    .filter((statement) => typeof statement[metric] === "number")
-    .sort((left, right) => left.date.localeCompare(right.date));
-  const byCategory = new Map<string, FinancialStatement>();
-  for (const statement of sortedStatements) {
-    const category = periodCategory(statement.date, period);
-    const key = `${symbol}\u0000${category}`;
-    const previous = byCategory.get(key);
-    if (!previous || statement.date.localeCompare(previous.date) >= 0) {
-      byCategory.set(key, statement);
-    }
-  }
-  const sorted = [...byCategory.values()].sort((left, right) => left.date.localeCompare(right.date));
-  const maxAbs = Math.max(1, ...sorted.map((statement) => Math.abs(statement[metric] as number)));
-  return sorted.map((statement, index) => {
-    const value = statement[metric] as number;
-    const previous = sorted[index - 1]?.[metric];
-    return {
-      key: [symbol, statement.date, metric].filter(Boolean).join(":"),
-      symbol,
+  const entries = statements
+    .map((statement) => ({ statement, value: fundamentalMetricValue(statement, metric) }))
+    .filter((entry): entry is { statement: FinancialStatement; value: number } => entry.value !== null)
+    .map(({ statement, value }) => ({
       date: statement.date,
       category: periodCategory(statement.date, period),
       value,
-      growth: typeof previous === "number" && previous !== 0 ? (value - previous) / Math.abs(previous) : null,
-      barWidth: Math.max(1, Math.round((Math.abs(value) / maxAbs) * 24)),
-    };
-  });
+    }));
+  return buildRowsFromEntries(entries, metric, symbol);
 }
 
 function resolveMarketCap(financials: TickerFinancials | null): number | null {
@@ -111,21 +329,141 @@ function resolveMarketCap(financials: TickerFinancials | null): number | null {
     : null;
 }
 
-function valuationMetricValue(
+function timeFromDate(value: Date | string): number {
+  return value instanceof Date ? value.getTime() : Date.parse(value);
+}
+
+function priceAtOrBefore(priceHistory: PricePoint[], date: string): number | null {
+  const target = Date.parse(date);
+  if (!Number.isFinite(target)) return null;
+
+  let closest: { time: number; close: number } | null = null;
+  for (const point of priceHistory) {
+    if (!finiteNumber(point.close) || point.close <= 0) continue;
+    const time = timeFromDate(point.date);
+    if (!Number.isFinite(time) || time > target) continue;
+    if (!closest || time > closest.time) {
+      closest = { time, close: point.close };
+    }
+  }
+  return closest?.close ?? null;
+}
+
+function statementShares(statement: FinancialStatement): number | null {
+  const shares = statement.dilutedShares
+    ?? statement.basicShares
+    ?? statement.ordinarySharesNumber
+    ?? statement.shareIssued;
+  return finiteNumber(shares) && shares > 0 ? shares : null;
+}
+
+function statementEpsValue(statement: FinancialStatement): number | null {
+  if (finiteNumber(statement.eps) && statement.eps !== 0) return statement.eps;
+  const shares = statementShares(statement);
+  return finiteNumber(statement.netIncome) && shares ? statement.netIncome / shares : null;
+}
+
+function aggregateEps(statements: FinancialStatement[]): number | null {
+  if (statements.length === 0) return null;
+  const epsValues = statements.map(statementEpsValue);
+  if (epsValues.every((value): value is number => finiteNumber(value))) {
+    return epsValues.reduce((sum, value) => sum + value, 0);
+  }
+
+  const latestShares = statementShares(statements.at(-1)!);
+  const incomeValues = statements.map((statement) => statement.netIncome);
+  if (!latestShares || !incomeValues.every((value): value is number => finiteNumber(value))) {
+    return null;
+  }
+  return incomeValues.reduce((sum, value) => sum + value, 0) / latestShares;
+}
+
+function trailingEpsValue(
+  statements: FinancialStatement[],
+  index: number,
+  period: FundamentalPeriod,
+): number | null {
+  if (period === "annual") return statementEpsValue(statements[index]!);
+  if (index < 3) return null;
+  return aggregateEps(statements.slice(index - 3, index + 1));
+}
+
+function forwardEpsValue(
+  statements: FinancialStatement[],
+  index: number,
+  period: FundamentalPeriod,
+): number | null {
+  if (period === "annual") {
+    const nextStatement = statements[index + 1];
+    return nextStatement ? statementEpsValue(nextStatement) : null;
+  }
+  if (index + 4 >= statements.length) return null;
+  return aggregateEps(statements.slice(index + 1, index + 5));
+}
+
+function historicalMarketCap(
+  financials: TickerFinancials | null,
+  statement: FinancialStatement,
+): number | null {
+  const price = financials ? priceAtOrBefore(financials.priceHistory, statement.date) : null;
+  const shares = statementShares(statement);
+  if (price && shares) return price * shares;
+  return resolveMarketCap(financials);
+}
+
+function historicalEnterpriseValue(
+  financials: TickerFinancials | null,
+  statement: FinancialStatement,
+): number | null {
+  const marketCap = historicalMarketCap(financials, statement);
+  if (!marketCap) return financials?.fundamentals?.enterpriseValue ?? null;
+  const debt = finiteNumber(statement.totalDebt) ? statement.totalDebt : 0;
+  const cash = statement.cashCashEquivalentsAndShortTermInvestments
+    ?? statement.cashAndCashEquivalents
+    ?? 0;
+  return marketCap + debt - (finiteNumber(cash) ? cash : 0);
+}
+
+function currentValuationMetricValue(
   financials: TickerFinancials | null,
   metric: ValuationMetricKey,
-  statement: FinancialStatement | null,
 ): number | null {
   const fundamentals = financials?.fundamentals;
   if (metric === "trailingPE") return fundamentals?.trailingPE ?? null;
   if (metric === "forwardPE") return fundamentals?.forwardPE ?? null;
   if (metric === "pegRatio") return fundamentals?.pegRatio ?? null;
+  return null;
+}
 
-  const marketCap = resolveMarketCap(financials);
-  const enterpriseValue = fundamentals?.enterpriseValue ?? null;
+function valuationMetricValue(
+  financials: TickerFinancials | null,
+  metric: ValuationMetricKey,
+  statement: FinancialStatement | null,
+  context?: {
+    statements: FinancialStatement[];
+    statementIndex: number;
+    period: FundamentalPeriod;
+  },
+): number | null {
+  if (metric === "pegRatio" || statement === null) {
+    return currentValuationMetricValue(financials, metric);
+  }
+
+  if (metric === "trailingPE" || metric === "forwardPE") {
+    const price = financials ? priceAtOrBefore(financials.priceHistory, statement.date) : null;
+    const eps = context
+      ? metric === "trailingPE"
+        ? trailingEpsValue(context.statements, context.statementIndex, context.period)
+        : forwardEpsValue(context.statements, context.statementIndex, context.period)
+      : statementEpsValue(statement);
+    return price && eps && eps > 0 ? price / eps : null;
+  }
+
+  const marketCap = historicalMarketCap(financials, statement);
+  const enterpriseValue = historicalEnterpriseValue(financials, statement);
   const revenue = statement?.totalRevenue;
   const ebitda = statement?.ebitda;
-  const freeCashFlow = statement?.freeCashFlow;
+  const freeCashFlow = statement ? freeCashFlowValue(statement) : null;
 
   if (metric === "priceSales" && marketCap && revenue) return marketCap / revenue;
   if (metric === "evSales" && enterpriseValue && revenue) return enterpriseValue / revenue;
@@ -140,33 +478,32 @@ export function buildValuationGraphRows(
   symbol = "",
   period: FundamentalPeriod = "annual",
 ): FundamentalGraphRow[] {
-  const statementMetrics = new Set<ValuationMetricKey>(["priceSales", "evSales", "evEbitda", "priceFcf"]);
-  const sourceStatements = statementMetrics.has(metric)
-    ? selectedStatements(financials, period)
-    : [{ date: "Current" } as FinancialStatement];
-  const sorted = sourceStatements
-    .map((statement) => ({
-      statement,
-      value: valuationMetricValue(financials, metric, statement.date === "Current" ? null : statement),
+  const sourceStatements = metric === "pegRatio"
+    ? [{ date: "Current" } as FinancialStatement]
+    : selectedStatements(financials, period);
+  const entries = [...sourceStatements]
+    .sort((left, right) => left.date.localeCompare(right.date))
+    .map((statement, statementIndex, statements) => ({
+      date: statement.date,
+      category: statement.date === "Current" ? "Current" : periodCategory(statement.date, period),
+      value: valuationMetricValue(
+        financials,
+        metric,
+        statement.date === "Current" ? null : statement,
+        { statements, statementIndex, period },
+      ),
     }))
-    .filter((entry): entry is { statement: FinancialStatement; value: number } => (
-      typeof entry.value === "number" && Number.isFinite(entry.value)
-    ))
-    .sort((left, right) => left.statement.date.localeCompare(right.statement.date));
-  const maxAbs = Math.max(1, ...sorted.map((entry) => Math.abs(entry.value)));
+    .filter((entry): entry is GraphRowEntry => finiteNumber(entry.value));
+  const currentValue = currentValuationMetricValue(financials, metric);
+  if (finiteNumber(currentValue) && !entries.some((entry) => entry.date === "Current") && (
+    metric === "pegRatio"
+    || metric === "forwardPE"
+    || (metric === "trailingPE" && entries.length === 0)
+  )) {
+    entries.push({ date: "Current", category: "Current", value: currentValue });
+  }
 
-  return sorted.map((entry, index) => {
-    const previous = sorted[index - 1]?.value;
-    return {
-      key: [symbol, entry.statement.date, metric].filter(Boolean).join(":"),
-      symbol,
-      date: entry.statement.date,
-      category: entry.statement.date === "Current" ? "Current" : periodCategory(entry.statement.date, period),
-      value: entry.value,
-      growth: typeof previous === "number" && previous !== 0 ? (entry.value - previous) / Math.abs(previous) : null,
-      barWidth: Math.max(1, Math.round((Math.abs(entry.value) / maxAbs) * 24)),
-    };
-  });
+  return buildRowsFromEntries(entries, metric, symbol);
 }
 
 export function metricDefs(kind: GraphKind): ReadonlyArray<MetricDefinition> {
@@ -242,9 +579,23 @@ export function buildFundamentalColumns(width: number, multiSymbol: boolean): Fu
   return columns;
 }
 
+function categorySortKey(row: FundamentalGraphRow): string {
+  return row.date === "Current" ? "9999-12-31" : row.date;
+}
+
 export function buildGraphBarSeries(rows: FundamentalGraphRow[]): BarChartSeries[] {
   const symbols = [...new Set(rows.map((row) => row.symbol || ""))];
-  const categories = [...new Set(rows.map((row) => row.category))];
+  const categoryOrder = new Map<string, string>();
+  for (const row of rows) {
+    const sortKey = categorySortKey(row);
+    const previous = categoryOrder.get(row.category);
+    if (!previous || sortKey.localeCompare(previous) < 0) {
+      categoryOrder.set(row.category, sortKey);
+    }
+  }
+  const categories = [...categoryOrder.entries()]
+    .sort((left, right) => left[1].localeCompare(right[1]) || left[0].localeCompare(right[0]))
+    .map(([category]) => category);
   return symbols.map((symbol, index) => ({
     id: symbol || "value",
     label: symbol || "Value",

--- a/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph/settings.ts
+++ b/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph/settings.ts
@@ -1,6 +1,8 @@
-import type { PaneTemplateCreateOptions } from "../../../../../types/plugin";
-import { formatTickerListInput, parseTickerListInput } from "../../../../../tickers/list";
+import type { PaneSettingsDef, PaneTemplateCreateOptions } from "../../../../../types/plugin";
+import { formatTickerListInput, MAX_TICKER_LIST_SIZE, parseTickerListInput } from "../../../../../tickers/list";
 import type { GraphKind } from "./types";
+
+export const FUNDAMENTAL_GRAPH_PANE_ID = "fundamental-graph";
 
 export function symbolsFromPaneSettings(settings: Record<string, unknown> | undefined, fallbackSymbol: string | null): string[] {
   const symbols = settings?.symbols;
@@ -26,6 +28,10 @@ export function graphKindFromSettings(settings: Record<string, unknown> | undefi
   return settings?.chartKind === "valuation" ? "valuation" : fallback;
 }
 
+export function graphShortcutForKind(kind: GraphKind): "GF" | "GE" {
+  return kind === "valuation" ? "GE" : "GF";
+}
+
 export function graphTemplateSymbols(
   activeTicker: string | null,
   options: Pick<PaneTemplateCreateOptions, "arg" | "values" | "symbols"> | undefined,
@@ -41,4 +47,19 @@ export function graphTemplateSymbols(
 
 export function graphTemplateTitle(shortcut: "GF" | "GE", symbols: string[]): string {
   return `${shortcut} ${formatTickerListInput(symbols)}`;
+}
+
+export function buildGraphPaneSettingsDef(): PaneSettingsDef {
+  return {
+    title: "Graph Pane Settings",
+    fields: [
+      {
+        key: "symbolsText",
+        label: "Tickers",
+        description: `Enter up to ${MAX_TICKER_LIST_SIZE} tickers separated by commas.`,
+        type: "text",
+        placeholder: "AMD, NVDA",
+      },
+    ],
+  };
 }

--- a/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph/types.ts
+++ b/src/plugins/builtin/ticker-detail/data-panes/fundamental-graph/types.ts
@@ -1,13 +1,17 @@
 import type { DataTableColumn } from "../../../../../components";
-import type { TickerFinancials } from "../../../../../types/financials";
+import type { FinancialStatement, TickerFinancials } from "../../../../../types/financials";
 
 export type FundamentalMetricKey =
   | "totalRevenue"
   | "grossProfit"
+  | "grossMargin"
   | "operatingIncome"
+  | "operatingMargin"
   | "netIncome"
+  | "netMargin"
   | "operatingCashFlow"
   | "freeCashFlow"
+  | "freeCashFlowMargin"
   | "totalAssets"
   | "totalDebt"
   | "totalEquity"
@@ -42,6 +46,9 @@ export type MetricDefinition<Key extends GraphMetricKey = GraphMetricKey> = {
   key: Key;
   label: string;
   format: (value: number) => string;
+  value?: Key extends FundamentalMetricKey
+    ? (statement: FinancialStatement) => number | null | undefined
+    : never;
 };
 
 export type SymbolFinancials = {

--- a/src/plugins/builtin/ticker-detail/index.tsx
+++ b/src/plugins/builtin/ticker-detail/index.tsx
@@ -5,6 +5,7 @@ import { normalizeTickerInput } from "../../../tickers/search";
 import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
 import { TickerChartPane, ChartResearchTab } from "./chart-pane";
 import {
+  buildGraphPaneSettingsDef,
   createGraphPaneTemplate,
   FundamentalGraphPane,
   FundamentalGraphsResearchTab,
@@ -128,6 +129,7 @@ export const tickerDetailPlugin: GloomPlugin = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 82, height: 22 },
+      settings: buildGraphPaneSettingsDef(),
     },
     {
       id: "provider-search-results",

--- a/src/sources/sec-edgar.test.ts
+++ b/src/sources/sec-edgar.test.ts
@@ -200,6 +200,47 @@ describe("parseCompanyFactsFinancialStatements", () => {
       },
     ]);
   });
+
+  test("merges statement values from all configured tags for a field", () => {
+    const fact = (tag: string, unit: string, rows: unknown[]) => ({
+      [tag]: {
+        units: {
+          [unit]: rows,
+        },
+      },
+    });
+    const quarterly = (end: string, val: number, frame: string) => ({
+      start: `${end.slice(0, 4)}-01-01`,
+      end,
+      val,
+      filed: end,
+      form: "10-Q",
+      fp: "Q1",
+      frame,
+    });
+
+    const statements = parseCompanyFactsFinancialStatements({
+      facts: {
+        "us-gaap": {
+          ...fact("RevenueFromContractWithCustomerExcludingAssessedTax", "USD", [
+            quarterly("2026-03-31", 200, "CY2026Q1"),
+          ]),
+          ...fact("Revenues", "USD", [
+            quarterly("2025-03-31", 100, "CY2025Q1"),
+          ]),
+          ...fact("GrossProfit", "USD", [
+            quarterly("2025-03-31", 60, "CY2025Q1"),
+            quarterly("2026-03-31", 120, "CY2026Q1"),
+          ]),
+        },
+      },
+    });
+
+    expect(statements.quarterlyStatements).toEqual([
+      { date: "2025-03-31", totalRevenue: 100, grossProfit: 60 },
+      { date: "2026-03-31", totalRevenue: 200, grossProfit: 120 },
+    ]);
+  });
 });
 
 describe("SecEdgarClient", () => {
@@ -403,6 +444,7 @@ describe("SecEdgarClient", () => {
 
     const client = new SecEdgarClient();
     const content = await client.getFilingContent({
+      form: "10-Q",
       filingUrl: "https://www.sec.gov/Archives/edgar/data/320193/index.htm",
       primaryDocumentUrl: "https://www.sec.gov/Archives/edgar/data/320193/primary-doc.htm",
     });

--- a/src/sources/sec-edgar.ts
+++ b/src/sources/sec-edgar.ts
@@ -451,7 +451,7 @@ function setCompanyFactValue(
   const selectionKey = `${date}:${String(field)}`;
   if (compareCompanyFactsEntries(entry, selectedFacts.get(selectionKey)) < 0) return;
   const row = rows.get(date) ?? { date };
-  (row as Record<string, unknown>)[field] = value;
+  (row as unknown as Record<string, unknown>)[field] = value;
   rows.set(date, row);
   selectedFacts.set(selectionKey, entry);
 }
@@ -506,7 +506,6 @@ export function parseCompanyFactsFinancialStatements(payload: unknown): SecCompa
       if (entries.length === 0) continue;
       fillCompanyFactsStatementRows(annualRows, annualSelectedFacts, entries, field, "annual");
       fillCompanyFactsStatementRows(quarterlyRows, quarterlySelectedFacts, entries, field, "quarterly");
-      break;
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix fundamental graph quarter/category ordering, sparse multi-ticker bar slots, native hover targeting, and legend visibility controls.
- Add margin/FCF metrics, historical valuation rows, GF/GR ticker pane settings, and SEC fact merging across alternate tags.
- Coalesce market-data event notifications and expand the TUI testing skill with runtime warning and RSS checks.

## Root Cause
- Chart layout mixed displayed bars with category slots, so sparse multi-series data could collapse spacing or target the wrong native pixel bar.
- Fundamental graph rows relied on raw statement dates/categories without enough normalization and historical valuation derivation.
- Market-data listeners could notify synchronously enough to trip React update-depth/listener warnings in real layout changes.

## Validation
- `bun test src/market-data/coordinator/events.test.ts src/components/chart/bar-chart-renderer.test.ts src/components/chart/static/bar-chart-surface.test.tsx src/plugins/builtin/ticker-detail/data-panes.test.ts src/components/command-bar/workflow/ops.test.ts src/sources/sec-edgar.test.ts src/plugins/builtin/comparison-chart/index.test.tsx`
- `git diff --check`
- `bunx tsc --noEmit --pretty false` still exits 2 from existing repo-wide errors; exact changed-file filtering returned no diagnostics.
- Real TUI tmux smokes for Portfolio layout, GF AMD/NVDA interactions, and Monitor/Portfolio layout switching showed no EventTarget/MaxListeners, React hook, or maximum update-depth warnings.
