### PR TITLE
Show idle chart OHLC summary

### DIFF
--- a/src/components/chart/stock-chart/footer.test.ts
+++ b/src/components/chart/stock-chart/footer.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import type { ProjectedChartPoint } from "../core/data";
+import { resolveStockChartFooterOhlcReadout } from "./footer";
+
+function point(
+  close: number,
+  overrides: Partial<ProjectedChartPoint> = {},
+): ProjectedChartPoint {
+  return {
+    date: new Date("2026-07-03T10:00:00Z"),
+    open: close,
+    high: close,
+    low: close,
+    close,
+    volume: 100,
+    ...overrides,
+  };
+}
+
+describe("stock chart footer OHLC readout", () => {
+  test("summarizes the visible OHLC window for idle chart readouts", () => {
+    const readout = resolveStockChartFooterOhlcReadout({
+      activePoint: null,
+      hasDisplayCursor: false,
+      points: [
+        point(100, { open: 99, high: 101, low: 98, volume: 10 }),
+        point(104, { open: 100, high: 108, low: 99, volume: 20 }),
+        point(106, { open: 104, high: 107, low: 103, volume: 30 }),
+      ],
+    });
+
+    expect(readout).toMatchObject({
+      open: 99,
+      high: 108,
+      low: 98,
+      close: 106,
+      volume: 60,
+    });
+    expect(readout?.changePercent).toBeCloseTo(((106 - 99) / 99) * 100);
+  });
+
+  test("uses the summary only when there is no chart cursor", () => {
+    const activePoint = point(104, { open: 103, high: 105, low: 102 });
+    const points = [
+      point(100, { open: 99, high: 101, low: 98 }),
+      point(106, { open: 104, high: 107, low: 103 }),
+    ];
+
+    const idleReadout = resolveStockChartFooterOhlcReadout({
+      activePoint,
+      hasDisplayCursor: false,
+      points,
+    });
+    const cursorReadout = resolveStockChartFooterOhlcReadout({
+      activePoint,
+      hasDisplayCursor: true,
+      points,
+    });
+
+    expect(idleReadout?.close).toBe(106);
+    expect(idleReadout?.changePercent).not.toBeNull();
+    expect(cursorReadout).toMatchObject(activePoint);
+    expect(cursorReadout?.changePercent).toBeNull();
+  });
+});

--- a/src/components/chart/stock-chart/footer.ts
+++ b/src/components/chart/stock-chart/footer.ts
@@ -1,7 +1,8 @@
 import { useMemo, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
-import { formatCompact } from "../../../utils/format";
+import { formatCompact, formatPercentRaw } from "../../../utils/format";
 import { formatMarketPriceWithCurrency } from "../../../market-data/market/format";
 import { usePaneFooter, type PaneFooterSegment, type PaneHint } from "../../layout/pane/footer";
+import { priceColor } from "../../../theme/colors";
 import type { PricePoint } from "../../../types/financials";
 import type { ProjectedChartPoint } from "../core/data";
 import type { DateWindowRange } from "../core/controller";
@@ -24,8 +25,53 @@ import {
   type StockChartViewportState,
 } from "./viewport";
 
-interface StockChartFooterOptions {
+interface StockChartOhlcReadout extends ProjectedChartPoint {
+  changePercent: number | null;
+}
+
+function summarizeOhlcWindow(points: readonly ProjectedChartPoint[]): StockChartOhlcReadout | null {
+  const first = points[0];
+  const last = points.at(-1);
+  if (!first || !last) return null;
+
+  let high = first.high;
+  let low = first.low;
+  let volume = 0;
+  for (const point of points) {
+    high = Math.max(high, point.high);
+    low = Math.min(low, point.low);
+    volume += point.volume;
+  }
+
+  return {
+    date: last.date,
+    open: first.open,
+    high,
+    low,
+    close: last.close,
+    volume,
+    changePercent: Number.isFinite(first.open) && first.open !== 0
+      ? ((last.close - first.open) / first.open) * 100
+      : null,
+  };
+}
+
+export function resolveStockChartFooterOhlcReadout({
+  activePoint,
+  hasDisplayCursor,
+  points,
+}: {
   activePoint: ProjectedChartPoint | null;
+  hasDisplayCursor: boolean;
+  points: readonly ProjectedChartPoint[];
+}): StockChartOhlcReadout | null {
+  if (hasDisplayCursor) {
+    return activePoint ? { ...activePoint, changePercent: null } : null;
+  }
+  return summarizeOhlcWindow(points);
+}
+
+interface StockChartFooterOptions {
   activePreset: TimeRange | null;
   baseDateBounds: DateWindowRange | null;
   boundsHistoryDates: Date[];
@@ -37,6 +83,7 @@ interface StockChartFooterOptions {
   history: PricePoint[];
   manualMinimumSpanMs: number | null;
   navigableDateWindow: DateWindowRange | null;
+  ohlcReadout: StockChartOhlcReadout | null;
   pendingAutoWindowRef: MutableRefObject<DateWindowRange | null>;
   pendingCanonicalResetRef: MutableRefObject<number>;
   persistRenderMode: (mode: ChartRenderMode) => void;
@@ -50,7 +97,6 @@ interface StockChartFooterOptions {
   setRenderedAutoView: Dispatch<SetStateAction<AutoRenderedView | null>>;
   setResolution: (resolution: ChartResolution) => void;
   setViewState: Dispatch<SetStateAction<StockChartViewportState>>;
-  showOhlcSummary: boolean;
   updateDisplayCursorTarget: (next: DisplayCursorState, motionKind: ChartCursorMotionKind) => void;
   visibleDateWindow: DateWindowRange | null;
   visiblePriceRange: number | undefined;
@@ -58,7 +104,6 @@ interface StockChartFooterOptions {
 }
 
 export function useStockChartFooter({
-  activePoint,
   activePreset,
   baseDateBounds,
   boundsHistoryDates,
@@ -70,6 +115,7 @@ export function useStockChartFooter({
   history,
   manualMinimumSpanMs,
   navigableDateWindow,
+  ohlcReadout,
   pendingAutoWindowRef,
   pendingCanonicalResetRef,
   persistRenderMode,
@@ -83,7 +129,6 @@ export function useStockChartFooter({
   setRenderedAutoView,
   setResolution,
   setViewState,
-  showOhlcSummary,
   updateDisplayCursorTarget,
   visibleDateWindow,
   visiblePriceRange,
@@ -196,7 +241,7 @@ export function useStockChartFooter({
   ]);
 
   const chartFooterInfo = useMemo<PaneFooterSegment[]>(() => {
-    if (compact || !showOhlcSummary || !activePoint) return [];
+    if (compact || !ohlcReadout) return [];
 
     const formatPrice = (value: number) => formatMarketPriceWithCurrency(value, chartCurrency, {
       assetCategory: chartAssetCategory,
@@ -210,16 +255,27 @@ export function useStockChartFooter({
         ? []
         : [
             { text: "O", tone: "label" as const },
-            { text: formatPrice(activePoint.open), tone: "value" as const },
+            { text: formatPrice(ohlcReadout.open), tone: "value" as const },
           ]),
       { text: "H", tone: "label" },
-      { text: formatPrice(activePoint.high), tone: "value" },
+      { text: formatPrice(ohlcReadout.high), tone: "value" },
       { text: "L", tone: "label" },
-      { text: formatPrice(activePoint.low), tone: "value" },
+      { text: formatPrice(ohlcReadout.low), tone: "value" },
       { text: "C", tone: "label" },
-      { text: formatPrice(activePoint.close), tone: "value" },
+      { text: formatPrice(ohlcReadout.close), tone: "value" },
+      ...(ohlcReadout.changePercent === null
+        ? []
+        : [
+            { text: "%", tone: "label" as const },
+            {
+              text: formatPercentRaw(ohlcReadout.changePercent),
+              tone: "value" as const,
+              color: priceColor(ohlcReadout.changePercent),
+              bold: true,
+            },
+          ]),
       { text: "V", tone: "label" },
-      { text: formatCompact(activePoint.volume), tone: "value" },
+      { text: formatCompact(ohlcReadout.volume), tone: "value" },
     ];
 
     return [{
@@ -227,12 +283,11 @@ export function useStockChartFooter({
       parts,
     }];
   }, [
-    activePoint,
     chartAssetCategory,
     chartCurrency,
     compact,
+    ohlcReadout,
     projectionMode,
-    showOhlcSummary,
     visiblePriceRange,
   ]);
 

--- a/src/components/chart/stock-chart/resolved.tsx
+++ b/src/components/chart/stock-chart/resolved.tsx
@@ -1,5 +1,5 @@
-import { memo, type ComponentProps } from "react";
-import { useStockChartFooter } from "./footer";
+import { memo, useMemo, type ComponentProps } from "react";
+import { resolveStockChartFooterOhlcReadout, useStockChartFooter } from "./footer";
 import { useStockChartKeyboardShortcuts } from "./keyboard";
 import { useStockChartControlRenderInvalidation } from "./rendering/invalidation";
 import { useStockChartRenderOutput } from "./rendering/output";
@@ -139,9 +139,23 @@ function useResolvedStockChartControls(
   } = runtime;
   const { output, status } = render;
   const manualMinimumSpanMs = getChartResolutionStepMs(dataRuntime.renderedResolution);
+  const ohlcReadout = useMemo(
+    () => output.showOhlcSummary
+      ? resolveStockChartFooterOhlcReadout({
+        activePoint: output.activePoint,
+        hasDisplayCursor: output.hasDisplayCursor,
+        points: projectionModel.projection.points,
+      })
+      : null,
+    [
+      output.activePoint,
+      output.hasDisplayCursor,
+      output.showOhlcSummary,
+      projectionModel.projection.points,
+    ],
+  );
 
   useStockChartFooter({
-    activePoint: output.activePoint,
     activePreset: viewportRuntime.activePreset,
     baseDateBounds: dataRuntime.baseDateBounds,
     boundsHistoryDates: dataRuntime.boundsHistoryDates,
@@ -153,6 +167,7 @@ function useResolvedStockChartControls(
     history: dataRuntime.history,
     manualMinimumSpanMs,
     navigableDateWindow: dataRuntime.navigableDateWindow,
+    ohlcReadout,
     pendingAutoWindowRef: interactionRuntime.pendingAutoWindowRef,
     pendingCanonicalResetRef: interactionRuntime.pendingCanonicalResetRef,
     persistRenderMode: viewportRuntime.persistRenderMode,
@@ -166,7 +181,6 @@ function useResolvedStockChartControls(
     setRenderedAutoView: dataRuntime.setRenderedAutoView,
     setResolution: viewportRuntime.setResolution,
     setViewState: settings.setViewState,
-    showOhlcSummary: output.showOhlcSummary,
     updateDisplayCursorTarget: interactionRuntime.updateDisplayCursorTarget,
     visibleDateWindow: dataRuntime.visibleDateWindow,
     visiblePriceRange: output.visiblePriceRange,


### PR DESCRIPTION
## Summary
- show the idle stock-chart footer as a visible-window OHLC summary instead of the last candle
- add signed open-to-close percent change to the idle OHLC readout
- keep cursor and crosshair readouts on the selected candle

## Validation
- bun test src/components/chart/stock-chart/footer.test.ts src/components/chart/stock-chart/index.test.ts src/components/chart/stock-chart/rendering/state.test.ts src/components/chart/stock-chart/rendering/projection.test.tsx src/components/chart/stock-chart/renderer-switch.test.tsx
- git diff --check
- tmux smoke: opened GIP ALAB in an isolated profile; first smoke confirmed `O $431.80 H $465.93 L $390.01 C $409.60 % -5.14% V 6.13M`; later cleanup smoke loaded without runtime warnings but isolated provider data returned no intraday history