### PR TITLE
Fix stale portfolio quote change anchors

### DIFF
--- a/src/market-data/coordinator/index.test.ts
+++ b/src/market-data/coordinator/index.test.ts
@@ -347,6 +347,142 @@ describe("MarketDataCoordinator", () => {
     expect(coordinator.getQuoteEntry(instrument).data?.price).toBe(412.5);
   });
 
+  it("reconciles stream quotes with cached provider day references before a snapshot loads", () => {
+    let streamed: ((target: QuoteSubscriptionTarget, quote: Quote) => void) | null = null;
+    const provider = createProvider({
+      getCachedFinancialsForTargets: () => new Map([[
+        "VICR",
+        {
+          quote: {
+            symbol: "VICR",
+            providerId: "gloomberb-cloud",
+            price: 292.83,
+            currency: "USD",
+            previousClose: 282.95,
+            change: 9.88,
+            changePercent: 3.49,
+            lastUpdated: Date.parse("2026-07-06T16:54:30Z"),
+            marketState: "REGULAR",
+            dataSource: "live",
+          },
+          quoteContributions: {
+            "gloomberb-cloud": {
+              symbol: "VICR",
+              providerId: "gloomberb-cloud",
+              price: 292.83,
+              currency: "USD",
+              previousClose: 380.07,
+              change: -87.24,
+              changePercent: -22.95,
+              lastUpdated: Date.parse("2026-07-06T16:54:30Z"),
+              marketState: "REGULAR",
+              dataSource: "live",
+            },
+            yahoo: {
+              symbol: "VICR",
+              providerId: "yahoo",
+              price: 294.39,
+              currency: "USD",
+              previousClose: 282.95,
+              change: 11.44,
+              changePercent: 4.04,
+              lastUpdated: Date.parse("2026-07-06T16:45:37Z"),
+              marketState: "REGULAR",
+              dataSource: "delayed",
+            },
+          },
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+        },
+      ]]),
+      subscribeQuotes: (_targets, onQuote) => {
+        streamed = onQuote as typeof streamed;
+        return () => {};
+      },
+    });
+    const coordinator = new MarketDataCoordinator(provider);
+    const instrument = {
+      symbol: "VICR",
+      exchange: "NASDAQ",
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-work",
+      instrument: {
+        brokerId: "ibkr",
+        brokerInstanceId: "ibkr-work",
+        conId: 275759,
+        symbol: "VICR",
+      },
+    };
+
+    coordinator.subscribeQuotes([{ instrument }]);
+    const onStreamed = streamed as ((target: QuoteSubscriptionTarget, quote: Quote) => void) | null;
+    if (!onStreamed) throw new Error("expected streaming callback");
+    onStreamed(
+      {
+        symbol: "VICR",
+        exchange: "NASDAQ",
+        context: {
+          brokerId: "ibkr",
+          brokerInstanceId: "ibkr-work",
+          instrument: instrument.instrument,
+        },
+      },
+      {
+        symbol: "VICR",
+        providerId: "gloomberb-cloud",
+        price: 293.07,
+        currency: "USD",
+        previousClose: 380.07,
+        change: -87,
+        changePercent: -22.89,
+        lastUpdated: Date.parse("2026-07-06T17:17:00Z"),
+        marketState: "REGULAR",
+        dataSource: "live",
+      },
+    );
+
+    const quote = coordinator.getQuoteEntry(instrument).data;
+    expect(quote?.price).toBe(293.07);
+    expect(quote?.previousClose).toBe(282.95);
+    expect(quote?.changePercent).toBeCloseTo(((293.07 - 282.95) / 282.95) * 100, 10);
+    expect(quote?.provenance?.fields?.previousClose?.providerId).toBe("yahoo");
+  });
+
+  it("preserves requested quote stream routes", () => {
+    let subscribedTargets: QuoteSubscriptionTarget[] = [];
+    const provider = createProvider({
+      subscribeQuotes: (targets) => {
+        subscribedTargets = targets;
+        return () => {};
+      },
+    });
+    const coordinator = new MarketDataCoordinator(provider);
+
+    coordinator.subscribeQuotes([{
+      instrument: {
+        symbol: "AAPL",
+        exchange: "NASDAQ",
+        brokerId: "ibkr",
+        brokerInstanceId: "ibkr-work",
+      },
+      priority: { route: "provider", surface: "portfolio", visible: true },
+    }]);
+
+    expect(subscribedTargets).toEqual([{
+      symbol: "AAPL",
+      exchange: "NASDAQ",
+      route: "provider",
+      context: {
+        brokerId: "ibkr",
+        brokerInstanceId: "ibkr-work",
+        instrument: null,
+      },
+      surface: "portfolio",
+      visible: true,
+    }]);
+  });
+
   it("routes manual-resolution chart requests through the resolution-aware provider path", async () => {
     let requested: { range: string; resolution: string } | null = null;
     const provider = createProvider({

--- a/src/market-data/coordinator/index.ts
+++ b/src/market-data/coordinator/index.ts
@@ -19,6 +19,7 @@ import {
   resolveEntryData,
   toMarketDataContext,
 } from "../selectors";
+import { resolveTickerFinancialsQuoteState } from "../quotes/resolution";
 import { normalizePriceHistory } from "../../utils/price-history";
 import {
   createBaselineChartRequest,
@@ -377,10 +378,35 @@ export class MarketDataCoordinator {
   private applyStreamQuote(instrument: InstrumentRef, quote: Quote): void {
     const key = buildQuoteKey(instrument);
     const current = this.quoteStore.get(key);
-    if (areStreamQuotesEquivalent(current.data ?? current.lastGoodData, quote)) return;
+    const resolvedQuote = this.resolveIncomingQuote(instrument, quote);
+    if (areStreamQuotesEquivalent(current.data ?? current.lastGoodData, resolvedQuote)) return;
     const receivedAt = Date.now();
-    const attempts = [createAttempt(quote.providerId ?? this.dataProvider.id, receivedAt, "success")];
-    this.quoteStore.set(key, readyQuoteEntry(current, { ...quote, receivedAt }, quote.providerId ?? this.dataProvider.id, attempts));
+    const attempts = [createAttempt(resolvedQuote.providerId ?? this.dataProvider.id, receivedAt, "success")];
+    this.quoteStore.set(key, readyQuoteEntry(current, { ...resolvedQuote, receivedAt }, resolvedQuote.providerId ?? this.dataProvider.id, attempts));
+  }
+
+  private resolveIncomingQuote(instrument: InstrumentRef, quote: Quote): Quote {
+    const snapshot = resolveEntryData(this.snapshotStore.get(buildSnapshotKey(instrument)));
+    if (snapshot) return quote;
+
+    const cachedFinancials = this.readCachedFinancialsForInstrument(instrument);
+    return resolveTickerFinancialsQuoteState(cachedFinancials, quote)?.quote ?? quote;
+  }
+
+  private readCachedFinancialsForInstrument(instrument: InstrumentRef): TickerFinancials | null {
+    if (!this.dataProvider.getCachedFinancialsForTargets) return null;
+    const result = this.dataProvider.getCachedFinancialsForTargets([{
+      symbol: instrument.symbol,
+      exchange: instrument.exchange,
+      brokerId: instrument.brokerId,
+      brokerInstanceId: instrument.brokerInstanceId,
+      instrument: instrument.instrument ?? null,
+    }], {
+      allowExpired: true,
+      includeStaleQuotes: true,
+    });
+    if (result instanceof Promise) return null;
+    return result.get(instrument.symbol.trim().toUpperCase()) ?? null;
   }
 }
 

--- a/src/market-data/coordinator/quotes.ts
+++ b/src/market-data/coordinator/quotes.ts
@@ -15,7 +15,7 @@ import {
   readyQuoteEntry,
 } from "./entries";
 
-export type QuoteSubscriptionPriority = Pick<QuoteSubscriptionTarget, "surface" | "visible" | "selected" | "weight">;
+export type QuoteSubscriptionPriority = Pick<QuoteSubscriptionTarget, "route" | "surface" | "visible" | "selected" | "weight">;
 
 export interface QuoteSubscriptionEntry {
   target: QuoteSubscriptionTarget;
@@ -292,6 +292,7 @@ export class QuoteSubscriptionManager {
       .sort(([left], [right]) => left.localeCompare(right));
     const nextSignature = activeEntries.map(([key, entry]) => [
       key,
+      entry.target.route ?? "",
       entry.target.surface ?? "",
       entry.target.visible ? "visible" : "",
       entry.target.selected ? "selected" : "",

--- a/src/market-data/hooks.tsx
+++ b/src/market-data/hooks.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "r
 import type { SecFilingDocument, SecFilingItem } from "../types/data-provider";
 import type { OptionsChain, PricePoint, Quote, TickerFinancials } from "../types/financials";
 import type { TickerRecord } from "../types/ticker";
-import type { ChartRequest, InstrumentRef, OptionsRequest, SecFilingsRequest } from "./request-types";
+import type { ChartRequest, InstrumentRef, OptionsRequest, SecFilingsRequest, TickerInstrumentOptions } from "./request-types";
 import { instrumentFromTicker } from "./request-types";
 import { useAppActive } from "../state/app/activity";
 import {
@@ -74,17 +74,17 @@ function stableCurrencyList(currencies: Array<string | null | undefined>): strin
   )].sort((left, right) => left.localeCompare(right));
 }
 
-function buildTickerFinancialsMapKey(tickers: TickerRecord[]): string {
+function buildTickerFinancialsMapKey(tickers: TickerRecord[], options: TickerInstrumentOptions = {}): string {
   return tickers.map((ticker) => {
-    const instrument = ticker.metadata.broker_contracts?.[0];
+    const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker, options);
     return [
       ticker.metadata.ticker,
       ticker.metadata.exchange ?? "",
       instrument?.brokerId ?? "",
       instrument?.brokerInstanceId ?? "",
-      instrument?.conId ?? "",
-      instrument?.localSymbol ?? "",
-      instrument?.symbol ?? "",
+      instrument?.instrument?.conId ?? "",
+      instrument?.instrument?.localSymbol ?? "",
+      instrument?.instrument?.symbol ?? "",
     ].join("|");
   }).join("::");
 }
@@ -122,10 +122,10 @@ export function useTickerFinancials(symbol: string | null | undefined, ticker: T
   return financials;
 }
 
-function buildTickerFinancialsKeys(tickers: TickerRecord[]): string[] {
+function buildTickerFinancialsKeys(tickers: TickerRecord[], options: TickerInstrumentOptions = {}): string[] {
   const keys: string[] = [];
   for (const ticker of tickers) {
-    const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
+    const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker, options);
     if (!instrument) continue;
     keys.push(
       buildSnapshotKey(instrument),
@@ -136,17 +136,21 @@ function buildTickerFinancialsKeys(tickers: TickerRecord[]): string[] {
   return keys;
 }
 
-export function useTickerFinancialsMap(tickers: TickerRecord[]): Map<string, TickerFinancials> {
+export function useTickerFinancialsMap(
+  tickers: TickerRecord[],
+  options: TickerInstrumentOptions = {},
+): Map<string, TickerFinancials> {
   const coordinator = getSharedMarketDataCoordinator();
-  const tickerKey = buildTickerFinancialsMapKey(tickers);
-  const subscriptionKeys = useMemo(() => buildTickerFinancialsKeys(tickers), [tickerKey]);
+  const optionsKey = options.portfolioId ?? "";
+  const tickerKey = buildTickerFinancialsMapKey(tickers, options);
+  const subscriptionKeys = useMemo(() => buildTickerFinancialsKeys(tickers, options), [optionsKey, tickerKey]);
   const keysVersion = useCoordinatorKeysVersion(subscriptionKeys);
 
   return useMemo(() => {
     if (!coordinator) return new Map<string, TickerFinancials>();
     const result = new Map<string, TickerFinancials>();
     for (const ticker of tickers) {
-      const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
+      const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker, options);
       if (!instrument) continue;
       const financials = coordinator.getTickerFinancialsSync(instrument);
       if (financials) {
@@ -154,7 +158,7 @@ export function useTickerFinancialsMap(tickers: TickerRecord[]): Map<string, Tic
       }
     }
     return result;
-  }, [coordinator, keysVersion, tickerKey, subscriptionKeys]);
+  }, [coordinator, keysVersion, optionsKey, tickerKey, subscriptionKeys]);
 }
 
 export function useQuoteEntry(symbol: string | null | undefined, ticker: TickerRecord | null | undefined): QueryEntry<Quote> | null {

--- a/src/market-data/quotes/resolution.test.ts
+++ b/src/market-data/quotes/resolution.test.ts
@@ -68,6 +68,95 @@ describe("quote-resolution", () => {
     expect(quote?.provenance?.session?.providerId).toBe("yahoo");
   });
 
+  test("uses provider previous close with the live broker price for daily change", () => {
+    const now = Date.parse("2026-07-06T14:05:00Z");
+    const contributions: QuoteContributionMap = {
+      ibkr: {
+        symbol: "VICR",
+        providerId: "ibkr",
+        dataSource: "live",
+        price: 299.8,
+        currency: "USD",
+        change: -80.3,
+        changePercent: -21.12,
+        previousClose: 380.1,
+        lastUpdated: Date.parse("2026-07-06T14:04:58Z"),
+        receivedAt: Date.parse("2026-07-06T14:04:59Z"),
+        listingExchangeName: "NASDAQ",
+        routingExchangeName: "SMART",
+        sessionConfidence: "unknown",
+      },
+      yahoo: {
+        symbol: "VICR",
+        providerId: "yahoo",
+        dataSource: "delayed",
+        price: 299.74,
+        currency: "USD",
+        change: 16.79,
+        changePercent: 5.93,
+        previousClose: 282.95,
+        lastUpdated: Date.parse("2026-07-06T14:04:00Z"),
+        listingExchangeName: "NMS",
+        marketState: "REGULAR",
+        sessionConfidence: "derived",
+      },
+    };
+
+    const quote = resolveCanonicalQuote(contributions, now).quote;
+
+    expect(quote?.providerId).toBe("ibkr");
+    expect(quote?.price).toBe(299.8);
+    expect(quote?.previousClose).toBe(282.95);
+    expect(quote?.change).toBeCloseTo(16.85, 10);
+    expect(quote?.changePercent).toBeCloseTo((16.85 / 282.95) * 100, 10);
+    expect(quote?.provenance?.price?.providerId).toBe("ibkr");
+    expect(quote?.provenance?.fields?.previousClose?.providerId).toBe("yahoo");
+  });
+
+  test("prefers yahoo day reference fields over stale cloud previous close data", () => {
+    const now = Date.parse("2026-07-06T15:45:00Z");
+    const contributions: QuoteContributionMap = {
+      "gloomberb-cloud": {
+        symbol: "VICR",
+        providerId: "gloomberb-cloud",
+        dataSource: "delayed",
+        price: 299.8,
+        currency: "USD",
+        change: -80.27,
+        changePercent: -21.12,
+        previousClose: 380.07,
+        lastUpdated: Date.parse("2026-07-06T15:44:00Z"),
+        listingExchangeName: "NASDAQ",
+        marketState: "REGULAR",
+        sessionConfidence: "derived",
+      },
+      yahoo: {
+        symbol: "VICR",
+        providerId: "yahoo",
+        dataSource: "delayed",
+        price: 297.9,
+        currency: "USD",
+        change: 14.95,
+        changePercent: 5.28,
+        previousClose: 282.95,
+        lastUpdated: Date.parse("2026-07-06T15:41:00Z"),
+        listingExchangeName: "NMS",
+        marketState: "REGULAR",
+        sessionConfidence: "derived",
+      },
+    };
+
+    const quote = resolveCanonicalQuote(contributions, now).quote;
+
+    expect(quote?.providerId).toBe("gloomberb-cloud");
+    expect(quote?.price).toBe(299.8);
+    expect(quote?.previousClose).toBe(282.95);
+    expect(quote?.change).toBeCloseTo(16.85, 10);
+    expect(quote?.changePercent).toBeCloseTo((16.85 / 282.95) * 100, 10);
+    expect(quote?.provenance?.price?.providerId).toBe("gloomberb-cloud");
+    expect(quote?.provenance?.fields?.previousClose?.providerId).toBe("yahoo");
+  });
+
   test("prefers cloud session data over yahoo when confidence is tied", () => {
     const now = Date.parse("2026-04-08T11:00:00Z");
     const contributions: QuoteContributionMap = {

--- a/src/market-data/quotes/resolution.ts
+++ b/src/market-data/quotes/resolution.ts
@@ -31,9 +31,6 @@ const PRICE_FIELD_KEYS = [
   "symbol",
   "price",
   "currency",
-  "change",
-  "changePercent",
-  "previousClose",
   "bid",
   "ask",
   "bidSize",
@@ -80,6 +77,19 @@ function providerKindRank(providerId?: string): number {
     case "gloomberb-cloud":
       return 0;
     case "yahoo":
+      return 1;
+    case "ibkr":
+      return 2;
+    default:
+      return 3;
+  }
+}
+
+function dailyReferenceRank(providerId?: string): number {
+  switch (providerId) {
+    case "yahoo":
+      return 0;
+    case "gloomberb-cloud":
       return 1;
     case "ibkr":
       return 2;
@@ -142,6 +152,61 @@ function pickField(
     return candidate;
   }
   return undefined;
+}
+
+function finitePositiveNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function buildDailyReferenceCandidates(
+  candidates: QuoteContribution[],
+  priceProvider: QuoteContribution | undefined,
+): QuoteContribution[] {
+  return [...candidates]
+    .filter((quote) => finitePositiveNumber(quote.previousClose))
+    .sort((left, right) => {
+      if (priceProvider) {
+        const leftMismatch = hasLikelyQuoteUnitMismatch(priceProvider, left) ? 1 : 0;
+        const rightMismatch = hasLikelyQuoteUnitMismatch(priceProvider, right) ? 1 : 0;
+        if (leftMismatch !== rightMismatch) return leftMismatch - rightMismatch;
+      }
+      const providerDelta = dailyReferenceRank(left.providerId) - dailyReferenceRank(right.providerId);
+      if (providerDelta !== 0) return providerDelta;
+      return (right.lastUpdated ?? 0) - (left.lastUpdated ?? 0);
+    });
+}
+
+function assignDailyChangeFields(
+  target: Partial<Quote>,
+  provenance: QuoteProvenance,
+  priceProvider: QuoteContribution | undefined,
+  candidates: QuoteContribution[],
+): void {
+  const referenceProvider = buildDailyReferenceCandidates(candidates, priceProvider)[0];
+  if (!referenceProvider) {
+    pickField(target, provenance, "previousClose", candidates);
+    pickField(target, provenance, "change", candidates);
+    pickField(target, provenance, "changePercent", candidates);
+    return;
+  }
+
+  assignField(target, provenance, "previousClose", referenceProvider);
+  const price = target.price;
+  const previousClose = target.previousClose;
+  if (!finitePositiveNumber(price) || !finitePositiveNumber(previousClose)) {
+    pickField(target, provenance, "change", candidates);
+    pickField(target, provenance, "changePercent", candidates);
+    return;
+  }
+
+  target.change = price - previousClose;
+  target.changePercent = (target.change / previousClose) * 100;
+  provenance.fields ??= {};
+  const referenceProvenance = toProvenance(referenceProvider);
+  if (referenceProvenance) {
+    provenance.fields.change = referenceProvenance;
+    provenance.fields.changePercent = referenceProvenance;
+  }
 }
 
 function buildAcceptedPriceCandidates(contributions: QuoteContribution[]): {
@@ -290,6 +355,7 @@ export function resolveCanonicalQuote(
     if (field === "price") continue;
     pickField(resolved, provenance, field, acceptedPriceCandidates);
   }
+  assignDailyChangeFields(resolved, provenance, priceProvider, acceptedPriceCandidates);
   provenance.price = toProvenance(priceProvider);
 
   const sessionProvider = sessionCandidates[0];

--- a/src/market-data/request-types.test.ts
+++ b/src/market-data/request-types.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { TickerRecord } from "../types/ticker";
-import { quoteSubscriptionTargetFromTicker } from "./request-types";
+import { instrumentFromTicker, quoteSubscriptionTargetFromTicker } from "./request-types";
 
 function makeTicker(overrides: Partial<TickerRecord["metadata"]> = {}): TickerRecord {
   return {
@@ -21,6 +21,66 @@ function makeTicker(overrides: Partial<TickerRecord["metadata"]> = {}): TickerRe
 }
 
 describe("quoteSubscriptionTargetFromTicker", () => {
+  test("selects the broker contract that belongs to the active portfolio", () => {
+    const ticker = makeTicker({
+      ticker: "VICR",
+      name: "Vicor",
+      portfolios: [
+        "broker:ibkr-live:DU111",
+        "broker:ibkr-coldstart:DU222",
+      ],
+      positions: [
+        {
+          portfolio: "broker:ibkr-live:DU111",
+          shares: 170,
+          avgCost: 198,
+          currency: "USD",
+          broker: "ibkr",
+          brokerInstanceId: "ibkr-live",
+          brokerContractId: 275759,
+        },
+        {
+          portfolio: "broker:ibkr-coldstart:DU222",
+          shares: 350,
+          avgCost: 290,
+          currency: "USD",
+          broker: "ibkr",
+          brokerInstanceId: "ibkr-coldstart",
+          brokerContractId: 275759,
+        },
+      ],
+      broker_contracts: [
+        {
+          brokerId: "ibkr",
+          brokerInstanceId: "ibkr-live",
+          conId: 275759,
+          symbol: "VICR",
+          localSymbol: "VICR",
+          exchange: "NASDAQ",
+          currency: "USD",
+          secType: "STK",
+        },
+        {
+          brokerId: "ibkr",
+          brokerInstanceId: "ibkr-coldstart",
+          conId: 275759,
+          symbol: "VICR",
+          localSymbol: "VICR",
+          exchange: "NASDAQ",
+          currency: "USD",
+          secType: "STK",
+        },
+      ],
+    });
+
+    expect(instrumentFromTicker(ticker, "VICR", { portfolioId: "broker:ibkr-coldstart:DU222" })).toMatchObject({
+      symbol: "VICR",
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-coldstart",
+      instrument: ticker.metadata.broker_contracts?.[1],
+    });
+  });
+
   test("preserves broker contract context for streaming targets", () => {
     const ticker = makeTicker({
       broker_contracts: [{

--- a/src/market-data/request-types.ts
+++ b/src/market-data/request-types.ts
@@ -12,6 +12,10 @@ export interface InstrumentRef {
   instrument?: BrokerContractRef | null;
 }
 
+export interface TickerInstrumentOptions {
+  portfolioId?: string | null;
+}
+
 type ChartGranularity = "range" | "detail" | "resolution";
 
 export interface ChartRequest {
@@ -39,10 +43,44 @@ export interface SecFilingsRequest {
   count?: number;
 }
 
-export function instrumentFromTicker(ticker: TickerRecord | null | undefined, fallbackSymbol?: string | null): InstrumentRef | null {
+function brokerContractForTicker(
+  ticker: TickerRecord | null | undefined,
+  options: TickerInstrumentOptions = {},
+): BrokerContractRef | null {
+  const contracts = ticker?.metadata.broker_contracts ?? [];
+  if (contracts.length === 0) return null;
+
+  const portfolioId = options.portfolioId;
+  if (portfolioId) {
+    const positions = ticker?.metadata.positions.filter((position) => position.portfolio === portfolioId) ?? [];
+    for (const position of positions) {
+      const matchingContract = contracts.find((contract) => (
+        (position.brokerContractId == null || contract.conId === position.brokerContractId)
+        && (!position.brokerInstanceId || contract.brokerInstanceId === position.brokerInstanceId)
+        && (!position.broker || contract.brokerId === position.broker)
+      ));
+      if (matchingContract) return matchingContract;
+    }
+    for (const position of positions) {
+      const matchingContract = contracts.find((contract) => (
+        (!position.brokerInstanceId || contract.brokerInstanceId === position.brokerInstanceId)
+        && (!position.broker || contract.brokerId === position.broker)
+      ));
+      if (matchingContract) return matchingContract;
+    }
+  }
+
+  return contracts[0] ?? null;
+}
+
+export function instrumentFromTicker(
+  ticker: TickerRecord | null | undefined,
+  fallbackSymbol?: string | null,
+  options: TickerInstrumentOptions = {},
+): InstrumentRef | null {
   const symbol = ticker?.metadata.ticker ?? fallbackSymbol ?? null;
   if (!symbol) return null;
-  const instrument = ticker?.metadata.broker_contracts?.[0] ?? null;
+  const instrument = brokerContractForTicker(ticker, options);
   return {
     symbol,
     exchange: ticker?.metadata.exchange ?? "",
@@ -56,8 +94,9 @@ export function quoteSubscriptionTargetFromTicker(
   ticker: TickerRecord | null | undefined,
   fallbackSymbol?: string | null,
   route: QuoteSubscriptionTarget["route"] = "auto",
+  options: TickerInstrumentOptions = {},
 ): QuoteSubscriptionTarget | null {
-  const instrument = instrumentFromTicker(ticker, fallbackSymbol);
+  const instrument = instrumentFromTicker(ticker, fallbackSymbol, options);
   return quoteSubscriptionTargetFromInstrument(instrument, route);
 }
 

--- a/src/plugins/builtin/portfolio-list/pane/index.test.tsx
+++ b/src/plugins/builtin/portfolio-list/pane/index.test.tsx
@@ -323,6 +323,7 @@ async function flushFrame() {
   await act(async () => {
     await Promise.resolve();
     await testSetup!.renderOnce();
+    await new Promise((resolve) => setTimeout(resolve, 0));
     await Promise.resolve();
     await testSetup!.renderOnce();
   });
@@ -1411,6 +1412,119 @@ describe("PortfolioListPane cash and margin UI", () => {
     expect(frame).toContain("AAPL");
     expect(frame).toContain("126.5");
     expect(frame).toContain("+5.41%");
+  });
+
+  test("streams portfolio rows with the active collection broker contract", async () => {
+    const config = createPortfolioConfigWithColumns(
+      "broker:ibkr-live:DU12345",
+      ["ticker", "price", "change_pct", "latency"],
+      [createBrokerInstance("gateway", "ibkr-flex"), createBrokerInstance("gateway", "ibkr-live")],
+    );
+    let subscribedTargets: Array<{ symbol: string; context?: { brokerInstanceId?: string; instrument?: unknown } }> = [];
+    const provider: DataProvider = {
+      id: "test-provider",
+      name: "Test Provider",
+      async getTickerFinancials(symbol) {
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+          quote: makeQuote({ symbol }),
+        };
+      },
+      async getQuote(symbol) {
+        return makeQuote({ symbol });
+      },
+      async getExchangeRate() {
+        return 1;
+      },
+      async search() {
+        return [];
+      },
+      async getArticleSummary() {
+        return null;
+      },
+      async getPriceHistory() {
+        return [];
+      },
+      subscribeQuotes(targets) {
+        subscribedTargets = targets;
+        return () => {};
+      },
+    };
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+
+    const flexContract = {
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-flex",
+      symbol: "VICR",
+      localSymbol: "VICR",
+      exchange: "NASDAQ",
+      conId: 275759,
+    };
+    const liveContract = {
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-live",
+      symbol: "VICR",
+      localSymbol: "VICR",
+      exchange: "NASDAQ",
+      primaryExchange: "NASDAQ",
+      conId: 275759,
+    };
+
+    testSetup = await testRender(
+      <PortfolioHarness
+        config={config}
+        collectionId="broker:ibkr-live:DU12345"
+        stateMutator={(state) => {
+          state.tickers = new Map([["VICR", makeTicker({
+            ticker: "VICR",
+            name: "Vicor",
+            portfolios: ["broker:ibkr-flex:DU12345", "broker:ibkr-live:DU12345"],
+            positions: [
+              {
+                portfolio: "broker:ibkr-flex:DU12345",
+                shares: 170,
+                avgCost: 198,
+                currency: "USD",
+                broker: "ibkr",
+                brokerInstanceId: "ibkr-flex",
+                brokerAccountId: "DU12345",
+                brokerContractId: 275759,
+              },
+              {
+                portfolio: "broker:ibkr-live:DU12345",
+                shares: 350,
+                avgCost: 290,
+                currency: "USD",
+                broker: "ibkr",
+                brokerInstanceId: "ibkr-live",
+                brokerAccountId: "DU12345",
+                brokerContractId: 275759,
+              },
+            ],
+            broker_contracts: [flexContract, liveContract],
+          })]]);
+          state.financials = new Map();
+          state.paneState[TEST_PANE_ID] = {
+            collectionId: "broker:ibkr-live:DU12345",
+            cursorSymbol: "VICR",
+            cashDrawerExpanded: false,
+          };
+        }}
+      />,
+      { width: 100, height: 12 },
+    );
+
+    await flushFrame();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const vicrTarget = subscribedTargets.find((target) => target.symbol === "VICR");
+    expect(vicrTarget?.context?.brokerInstanceId).toBe("ibkr-live");
+    expect(vicrTarget?.context?.instrument).toEqual(liveContract);
   });
 
 });

--- a/src/plugins/builtin/portfolio-list/pane/index.tsx
+++ b/src/plugins/builtin/portfolio-list/pane/index.tsx
@@ -107,7 +107,10 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     () => getCollectionTickersFromConfig(config, tickersBySymbol, activeCollectionId),
     [activeCollectionId, config, tickersBySymbol],
   );
-  const marketFinancialsMap = useTickerFinancialsMap(tickers);
+  const financialsInstrumentOptions = useMemo(() => ({
+    portfolioId: isPortfolioTab ? activeCollectionId : undefined,
+  }), [activeCollectionId, isPortfolioTab]);
+  const marketFinancialsMap = useTickerFinancialsMap(tickers, financialsInstrumentOptions);
   const financialsMap = useMemo(() => {
     const merged = new Map(cachedFinancials);
     for (const [symbol, financials] of marketFinancialsMap) {
@@ -309,6 +312,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
   usePortfolioPaneStreaming({
     appActive,
     focused,
+    activeCollectionId: isPortfolioTab ? activeCollectionId : undefined,
     sortedTickers,
     cursorSymbol,
     streamWindow: effectiveStreamWindow,

--- a/src/plugins/builtin/portfolio-list/pane/streaming.ts
+++ b/src/plugins/builtin/portfolio-list/pane/streaming.ts
@@ -21,6 +21,7 @@ import {
 export function usePortfolioPaneStreaming({
   appActive,
   focused,
+  activeCollectionId,
   sortedTickers,
   cursorSymbol,
   streamWindow,
@@ -30,6 +31,7 @@ export function usePortfolioPaneStreaming({
 }: {
   appActive: boolean;
   focused: boolean;
+  activeCollectionId?: string;
   sortedTickers: TickerRecord[];
   cursorSymbol: string | null;
   streamWindow: { start: number; end: number };
@@ -57,10 +59,13 @@ export function usePortfolioPaneStreaming({
     [streamTickers],
   );
   const streamSurface: "portfolio" | "watchlist" = isPortfolioTab ? "portfolio" : "watchlist";
+  const instrumentOptions = useMemo(() => ({
+    portfolioId: isPortfolioTab ? activeCollectionId : undefined,
+  }), [activeCollectionId, isPortfolioTab]);
   const streamTargets = useMemo(() => (
     sortedTickers
       .map((ticker) => {
-        const target = quoteSubscriptionTargetFromTicker(ticker, ticker.metadata.ticker, "provider");
+        const target = quoteSubscriptionTargetFromTicker(ticker, ticker.metadata.ticker, "provider", instrumentOptions);
         if (!target) return null;
         const selected = ticker.metadata.ticker === cursorSymbol;
         const visible = priorityStreamSymbols.has(ticker.metadata.ticker);
@@ -73,7 +78,7 @@ export function usePortfolioPaneStreaming({
         };
       })
       .filter((target): target is NonNullable<typeof target> => target != null)
-  ), [cursorSymbol, priorityStreamSymbols, sortedTickers, streamSurface]);
+  ), [cursorSymbol, instrumentOptions, priorityStreamSymbols, sortedTickers, streamSurface]);
   const visibleFinancialTickers = useMemo(
     () => sortedTickers.slice(streamWindow.start, streamWindow.end),
     [sortedTickers, streamWindow.end, streamWindow.start],
@@ -114,7 +119,7 @@ export function usePortfolioPaneStreaming({
     let cancelled = false;
     const runBatch = async (): Promise<void> => {
       const quoteEntries = quoteQueue.flatMap((ticker) => {
-        const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
+        const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker, instrumentOptions);
         if (!instrument) return [];
         const key = visibleWarmupKey("quote", ticker);
         warmupInFlightRef.current.add(key);
@@ -122,7 +127,7 @@ export function usePortfolioPaneStreaming({
         return [{ key, instrument }];
       });
       const snapshotEntries = limitedSnapshotQueue.flatMap((ticker) => {
-        const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
+        const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker, instrumentOptions);
         if (!instrument) return [];
         const key = visibleWarmupKey("snapshot", ticker);
         warmupInFlightRef.current.add(key);
@@ -156,7 +161,7 @@ export function usePortfolioPaneStreaming({
       cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [appActive, financialsMap, focused, sharedCoordinator, visibleFinancialTickers, visibleWarmupRequirements]);
+  }, [appActive, financialsMap, focused, instrumentOptions, sharedCoordinator, visibleFinancialTickers, visibleWarmupRequirements]);
 
   useEffect(() => {
     if (!appActive) return;
@@ -176,7 +181,7 @@ export function usePortfolioPaneStreaming({
         ) {
           return [];
         }
-        const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker);
+        const instrument = instrumentFromTicker(ticker, ticker.metadata.ticker, instrumentOptions);
         if (!instrument) return [];
         warmupInFlightRef.current.add(key);
         warmupAttemptRef.current.set(key, nowTimestamp);
@@ -203,7 +208,7 @@ export function usePortfolioPaneStreaming({
       cancelled = true;
       clearInterval(intervalId);
     };
-  }, [appActive, financialsMap, focused, sharedCoordinator, visibleFinancialTickers]);
+  }, [appActive, financialsMap, focused, instrumentOptions, sharedCoordinator, visibleFinancialTickers]);
 
   useQuoteStreaming(streamTargets);
 }

--- a/src/plugins/ibkr/gateway/market-data.ts
+++ b/src/plugins/ibkr/gateway/market-data.ts
@@ -136,15 +136,22 @@ export function applyTickByTickAllLastToQuote(
   const nextPrice = normalizeIbkrPriceValue(tick.price, priceDivisor);
   if (nextPrice == null || nextPrice <= 0) return null;
 
-  const previousClose = current?.previousClose ?? current?.price ?? nextPrice;
-  const change = nextPrice - previousClose;
+  const canInferPreviousClose = current?.price != null
+    && current.change != null
+    && (current.change !== 0 || current.changePercent !== 0);
+  const inferredPreviousClose = current?.previousClose
+    ?? (canInferPreviousClose ? current.price - current.change : undefined);
+  const previousClose = inferredPreviousClose != null && Number.isFinite(inferredPreviousClose) && inferredPreviousClose > 0
+    ? inferredPreviousClose
+    : undefined;
+  const change = previousClose != null ? nextPrice - previousClose : current?.change ?? 0;
   return {
     symbol: current?.symbol ?? contract.localSymbol ?? contract.symbol ?? "",
     providerId: "ibkr",
     price: nextPrice,
     currency: current?.currency ?? contract.currency ?? "USD",
     change,
-    changePercent: previousClose ? (change / previousClose) * 100 : 0,
+    changePercent: previousClose ? (change / previousClose) * 100 : current?.changePercent ?? 0,
     previousClose,
     high52w: current?.high52w,
     low52w: current?.low52w,

--- a/src/plugins/ibkr/gateway/service/index.test.ts
+++ b/src/plugins/ibkr/gateway/service/index.test.ts
@@ -312,6 +312,37 @@ describe("tick-by-tick quote updates", () => {
     expect(next?.lastUpdated).toBe(1_700_000_000_000);
   });
 
+  test("does not use the previous tick as the daily close when no close is known", () => {
+    const current = {
+      symbol: "AAPL",
+      providerId: "ibkr" as const,
+      price: 249,
+      currency: "USD",
+      change: 0,
+      changePercent: 0,
+      name: "Apple Inc.",
+      lastUpdated: 1000,
+      dataSource: "live" as const,
+    };
+    const tick: TickByTickAllLast = {
+      time: 1_700_000_000,
+      price: 250.5,
+      size: 100,
+      tickType: 1,
+      tickAttribLast: {},
+      exchange: "NASDAQ",
+      specialConditions: "",
+      contract: contract as any,
+    };
+
+    const next = applyTickByTickAllLastToQuote(current, contract as any, details, tick, 1, "live");
+
+    expect(next?.price).toBe(250.5);
+    expect(next?.previousClose).toBeUndefined();
+    expect(next?.change).toBe(0);
+    expect(next?.changePercent).toBe(0);
+  });
+
   test("applies bid/ask ticks without disturbing the current trade price", () => {
     const current = {
       symbol: "AAPL",

--- a/src/sources/provider-router/batches.ts
+++ b/src/sources/provider-router/batches.ts
@@ -52,8 +52,9 @@ export class ProviderRouterBatchRoutes {
       const context = target.context;
       const entityKey = this.deps.getEntityKey(target.symbol, context?.instrument);
       const variantKeys = this.deps.getTickerVariantCandidates(target.exchange);
+      const brokerSourceKeys = this.deps.getBrokerCandidatesForContext(context, false).map((candidate) => this.deps.brokerSourceKey(candidate));
       const sourceKeys = [
-        ...this.deps.getBrokerCandidatesForContext(context, false).map((candidate) => this.deps.brokerSourceKey(candidate)),
+        ...brokerSourceKeys,
         ...this.deps.getProviderSourceKeys(),
       ];
       const rawCached = selectCachedResource<Quote>(this.deps.resources, "quote", entityKey, variantKeys, sourceKeys, false);
@@ -61,6 +62,10 @@ export class ProviderRouterBatchRoutes {
         ? rawCached
         : null;
       if (cached && !forceRefresh && !cached.stale) {
+        if (brokerSourceKeys.includes(cached.sourceKey)) {
+          misses.push({ index, target });
+          return;
+        }
         results[index] = { target, quote: cached.value };
         return;
       }

--- a/src/sources/provider-router/cached-financials.test.ts
+++ b/src/sources/provider-router/cached-financials.test.ts
@@ -405,6 +405,129 @@ describe("AssetDataRouter cached financials", () => {
     persistence.close();
   });
 
+  test("uses symbol provider quote reference for broker-linked snapshot reads", async () => {
+    const dbPath = createTempDbPath("cached-symbol-reference-for-contract-snapshot");
+    const persistence = new AppPersistence(dbPath);
+    const now = Date.parse("2026-07-06T16:54:30Z");
+
+    persistence.resources.set(
+      {
+        namespace: "market",
+        kind: "financials",
+        entityKey: "contract:275759",
+        variantKey: "exchange=NASDAQ",
+        sourceKey: "provider:gloomberb-cloud",
+      },
+      makeFinancials({
+        quote: makeQuote({
+          symbol: "VICR",
+          providerId: "gloomberb-cloud",
+          price: 292.83,
+          currency: "USD",
+          previousClose: 380.07,
+          change: -87.24,
+          changePercent: -22.95,
+          lastUpdated: now,
+          marketState: "REGULAR",
+          exchangeName: "NASDAQ",
+          listingExchangeName: "NASDAQ",
+          dataSource: "live",
+        }),
+        profile: {
+          description: "Cloud profile",
+        },
+        fundamentals: {
+          trailingPE: 94.3,
+        },
+      }),
+      {
+        cachePolicy: { staleMs: 60_000, expireMs: 7 * 24 * 60 * 60_000 },
+        fetchedAt: now,
+      },
+    );
+    persistence.resources.set(
+      {
+        namespace: "market",
+        kind: "financials",
+        entityKey: "contract:275759",
+        variantKey: "exchange=NASDAQ",
+        sourceKey: "provider:yahoo",
+      },
+      makeFinancials({
+        annualStatements: [{ date: "2025-12-31", totalRevenue: 100 }],
+      }),
+      {
+        cachePolicy: { staleMs: 60_000, expireMs: 7 * 24 * 60 * 60_000 },
+        fetchedAt: now + 1_000,
+      },
+    );
+    persistence.resources.set(
+      {
+        namespace: "market",
+        kind: "financials",
+        entityKey: "VICR",
+        variantKey: "exchange=NASDAQ",
+        sourceKey: "provider:yahoo",
+      },
+      makeFinancials({
+        quote: makeQuote({
+          symbol: "VICR",
+          providerId: "yahoo",
+          price: 294.39,
+          currency: "USD",
+          previousClose: 282.95,
+          change: 11.44,
+          changePercent: 4.04,
+          lastUpdated: now - 1_000,
+          marketState: "REGULAR",
+          exchangeName: "NASDAQ",
+          listingExchangeName: "NASDAQ",
+          dataSource: "delayed",
+        }),
+      }),
+      {
+        cachePolicy: { staleMs: 60_000, expireMs: 7 * 24 * 60 * 60_000 },
+        fetchedAt: now - 1_000,
+      },
+    );
+
+    const router = new AssetDataRouter({
+      ...fallbackProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      async getTickerFinancials() {
+        throw new Error("should not fetch financials");
+      },
+    }, [{
+      ...fallbackProvider,
+      id: "gloomberb-cloud",
+      name: "Cloud",
+      priority: 100,
+      async getTickerFinancials() {
+        throw new Error("should not fetch financials");
+      },
+    }], persistence.resources);
+
+    const financials = await router.getTickerFinancials("VICR", "NASDAQ", {
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-work",
+      instrument: {
+        brokerId: "ibkr",
+        brokerInstanceId: "ibkr-work",
+        conId: 275759,
+        symbol: "VICR",
+      },
+    });
+
+    expect(financials.quote?.providerId).toBe("gloomberb-cloud");
+    expect(financials.quote?.price).toBe(292.83);
+    expect(financials.quote?.previousClose).toBe(282.95);
+    expect(financials.quote?.changePercent).toBeCloseTo(((292.83 - 282.95) / 282.95) * 100, 10);
+    expect(financials.quote?.provenance?.fields?.previousClose?.providerId).toBe("yahoo");
+
+    persistence.close();
+  });
+
   test("overlays standalone quote cache on stale financial snapshots during startup priming", () => {
     const dbPath = createTempDbPath("cached-quote-over-financial-snapshot");
     const persistence = new AppPersistence(dbPath);

--- a/src/sources/provider-router/financial-routes.ts
+++ b/src/sources/provider-router/financial-routes.ts
@@ -81,7 +81,9 @@ export class ProviderRouterFinancialRoutes {
       quarterlyStatements: base?.quarterlyStatements ?? [],
       priceHistory: base?.priceHistory ?? [],
     });
-    const cached = this.readCachedMergedFinancialsSelection(ticker, exchange, context, false);
+    const cached = this.readCachedMergedFinancialsSelection(ticker, exchange, context, false, {
+      includeSymbolProviderFallback: true,
+    });
     const forceRefresh = context?.cacheMode === "refresh";
     if (cached.value && !forceRefresh) {
       if (isOptionTicker && !cached.value.quote) {
@@ -128,8 +130,9 @@ export class ProviderRouterFinancialRoutes {
   async getQuote(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<Quote> {
     const entityKey = this.deps.getEntityKey(ticker, context?.instrument);
     const variantKeys = this.deps.getTickerVariantCandidates(exchange);
+    const brokerSourceKeys = this.deps.getBrokerCandidatesForContext(context, false).map((candidate) => this.deps.brokerSourceKey(candidate));
     const sourceKeys = [
-      ...this.deps.getBrokerCandidatesForContext(context, false).map((candidate) => this.deps.brokerSourceKey(candidate)),
+      ...brokerSourceKeys,
       ...this.deps.getProviderSourceKeys(),
     ];
     const rawCached = selectCachedResource<Quote>(this.deps.resources, "quote", entityKey, variantKeys, sourceKeys, false);
@@ -138,12 +141,19 @@ export class ProviderRouterFinancialRoutes {
       : null;
     const forceRefresh = context?.cacheMode === "refresh";
     if (cached && !forceRefresh && !cached.stale) {
-      return cached.value;
+      if (!brokerSourceKeys.includes(cached.sourceKey)) return cached.value;
+      return this.mergeBrokerQuoteWithProviderReference(
+        cached.value,
+        await this.getProviderReferenceQuote(ticker, exchange, context),
+      );
     }
 
     const brokerQuote = await withBrokerTimeout(this.deps.primaryRoutes.fetchBrokerQuote(ticker, exchange, context));
     if (brokerQuote && !isQuoteStaleForCurrentSession(quoteWithFreshnessExchange(brokerQuote.value, exchange))) {
-      return brokerQuote.value;
+      return this.mergeBrokerQuoteWithProviderReference(
+        brokerQuote.value,
+        await this.getProviderReferenceQuote(ticker, exchange, context),
+      );
     }
 
     const providerQuote = await this.deps.primaryRoutes.fetchProviderQuote(ticker, exchange, context);
@@ -152,6 +162,45 @@ export class ProviderRouterFinancialRoutes {
     }
     if (cached) return cached.value;
     throw new Error(`No quote provider available for ${ticker}`);
+  }
+
+  private async getProviderReferenceQuote(
+    ticker: string,
+    exchange?: string,
+    context?: MarketDataRequestContext,
+  ): Promise<Quote | null> {
+    const cached = this.readCachedProviderQuote(ticker, exchange, context);
+    if (cached) return cached;
+    const providerQuote = await this.deps.primaryRoutes.fetchProviderQuote(ticker, exchange, context);
+    return providerQuote?.value ?? null;
+  }
+
+  private readCachedProviderQuote(
+    ticker: string,
+    exchange?: string,
+    context?: MarketDataRequestContext,
+  ): Quote | null {
+    const entityKey = this.deps.getEntityKey(ticker, context?.instrument);
+    const entityKeys = [...new Set([entityKey, normalizeTicker(ticker)])];
+    const variantKeys = this.deps.getTickerVariantCandidates(exchange);
+    const sourceKeys = this.deps.getProviderSourceKeys();
+    for (const candidateEntityKey of entityKeys) {
+      const record = selectCachedResource<Quote>(this.deps.resources, "quote", candidateEntityKey, variantKeys, sourceKeys, false);
+      if (record && !isQuoteStaleForCurrentSession(quoteWithFreshnessExchange(record.value, exchange))) {
+        return record.value;
+      }
+    }
+    return null;
+  }
+
+  private mergeBrokerQuoteWithProviderReference(brokerQuote: Quote, providerQuote: Quote | null): Quote {
+    if (!providerQuote) return brokerQuote;
+    return resolveTickerFinancialsQuoteState({
+      quote: providerQuote,
+      annualStatements: [],
+      quarterlyStatements: [],
+      priceHistory: [],
+    }, brokerQuote)?.quote ?? brokerQuote;
   }
 
   readCachedMergedFinancialsSelection(
@@ -171,7 +220,8 @@ export class ProviderRouterFinancialRoutes {
       ? { ...brokerRecord, value: sanitizeCachedFinancials(brokerRecord.value, options) }
       : null;
     const providerSourceKeys = this.deps.getProviderSourceKeys();
-    const providerEntityKeys = options.includeSymbolProviderFallback
+    const includeSymbolProviderFallback = options.includeSymbolProviderFallback !== false;
+    const providerEntityKeys = includeSymbolProviderFallback
       ? [...new Set([entityKey, normalizeTicker(ticker)])]
       : [entityKey];
     const providerRecords = sortCachedRecords(

--- a/src/sources/provider-router/financials.ts
+++ b/src/sources/provider-router/financials.ts
@@ -216,13 +216,10 @@ export function mergeCachedFinancialRecords(
   value: TickerFinancials | null;
   stale: boolean;
 } {
-  const seenSources = new Set<string>();
   let merged: TickerFinancials | null = null;
   let stale = false;
 
   for (const record of records) {
-    if (seenSources.has(record.sourceKey)) continue;
-    seenSources.add(record.sourceKey);
     merged = mergeFinancials(merged, sanitizeCachedFinancials(record.value, options));
     stale = stale || record.stale === true;
   }

--- a/src/sources/provider-router/index.test.ts
+++ b/src/sources/provider-router/index.test.ts
@@ -312,6 +312,61 @@ describe("AssetDataRouter", () => {
     expect(quote.price).toBe(123.45);
   });
 
+  test("reconciles broker quote price with provider day reference fields", async () => {
+    const router = new AssetDataRouter({
+      ...fallbackProvider,
+      id: "yahoo",
+      async getQuote() {
+        return {
+          symbol: "VICR",
+          providerId: "yahoo",
+          price: 299.74,
+          currency: "USD",
+          previousClose: 282.95,
+          change: 16.79,
+          changePercent: 5.93,
+          lastUpdated: Date.now(),
+        };
+      },
+    });
+    const broker: BrokerAdapter = {
+      id: "ibkr",
+      name: "IBKR",
+      configSchema: [],
+      async validate() {
+        return true;
+      },
+      async importPositions() {
+        return [];
+      },
+      async getQuote() {
+        return {
+          symbol: "VICR",
+          providerId: "ibkr",
+          price: 299.8,
+          currency: "USD",
+          previousClose: 380.1,
+          change: -80.3,
+          changePercent: -21.12,
+          lastUpdated: Date.now(),
+          dataSource: "live",
+        };
+      },
+    };
+
+    attachTestRegistry(router, { brokers: [["ibkr", broker]] });
+    setBrokerInstances(router, [brokerInstance()]);
+
+    const quote = await router.getQuote("VICR", "NASDAQ", { brokerId: "ibkr", brokerInstanceId: "ibkr-work" });
+    expect(quote.providerId).toBe("ibkr");
+    expect(quote.price).toBe(299.8);
+    expect(quote.previousClose).toBe(282.95);
+    expect(quote.change).toBeCloseTo(16.85, 5);
+    expect(quote.changePercent).toBeCloseTo(5.955, 3);
+    expect(quote.provenance?.price?.providerId).toBe("ibkr");
+    expect(quote.provenance?.fields?.previousClose?.providerId).toBe("yahoo");
+  });
+
   test("prefers broker options chains for broker-context targets", async () => {
     const chain = {
       underlyingSymbol: "AAPL",

--- a/src/state/hooks/quote-streaming.ts
+++ b/src/state/hooks/quote-streaming.ts
@@ -74,6 +74,7 @@ export function useQuoteStreaming(targets: QuoteSubscriptionTarget[]): void {
         instrument: target.context?.instrument ?? null,
       },
       priority: {
+        route: target.route,
         surface: target.surface,
         visible: target.visible,
         selected: target.selected,


### PR DESCRIPTION
## Summary
- recompute daily change from the selected live price and selected day reference instead of trusting stale embedded change fields
- merge broker quote prices with provider day-reference fields for broker-linked portfolio rows
- preserve quote stream routing so broker-linked rows can still prefer provider streams when requested
- stop tick-by-tick broker updates from using the previous tick as a synthetic daily close

## Verification
- bun test src/market-data/quotes/resolution.test.ts src/sources/provider-router/index.test.ts src/market-data/coordinator/index.test.ts src/plugins/ibkr/gateway/service/index.test.ts
- bun run start portfolio coldstart | rg "VICR|Ticker|Last|Chg|CHG|294|295|%"
- bun run start portfolio U13268153 | rg "VICR|Ticker|Last|Chg|CHG|294|295|%"
- git diff --check origin/main...HEAD