### PR TITLE
Fix portfolio quote sort warmup

### DIFF
--- a/src/market-data/coordinator/index.test.ts
+++ b/src/market-data/coordinator/index.test.ts
@@ -449,6 +449,93 @@ describe("MarketDataCoordinator", () => {
     expect(quote?.provenance?.fields?.previousClose?.providerId).toBe("yahoo");
   });
 
+  it("reconciles batch quote loads with cached provider day references before a snapshot loads", async () => {
+    const provider = createProvider({
+      getCachedFinancialsForTargets: () => new Map([[
+        "VICR",
+        {
+          quote: {
+            symbol: "VICR",
+            providerId: "gloomberb-cloud",
+            price: 292.83,
+            currency: "USD",
+            previousClose: 282.95,
+            change: 9.88,
+            changePercent: 3.49,
+            lastUpdated: Date.parse("2026-07-06T16:54:30Z"),
+            marketState: "REGULAR",
+            dataSource: "live",
+          },
+          quoteContributions: {
+            "gloomberb-cloud": {
+              symbol: "VICR",
+              providerId: "gloomberb-cloud",
+              price: 292.83,
+              currency: "USD",
+              previousClose: 380.07,
+              change: -87.24,
+              changePercent: -22.95,
+              lastUpdated: Date.parse("2026-07-06T16:54:30Z"),
+              marketState: "REGULAR",
+              dataSource: "live",
+            },
+            yahoo: {
+              symbol: "VICR",
+              providerId: "yahoo",
+              price: 294.39,
+              currency: "USD",
+              previousClose: 282.95,
+              change: 11.44,
+              changePercent: 4.04,
+              lastUpdated: Date.parse("2026-07-06T16:45:37Z"),
+              marketState: "REGULAR",
+              dataSource: "delayed",
+            },
+          },
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+        },
+      ]]),
+      getQuotesBatch: async (targets) => targets.map((target) => ({
+        target,
+        quote: {
+          symbol: target.symbol,
+          providerId: "gloomberb-cloud",
+          price: 293.07,
+          currency: "USD",
+          previousClose: 380.07,
+          change: -87,
+          changePercent: -22.89,
+          lastUpdated: Date.parse("2026-07-06T17:17:00Z"),
+          marketState: "REGULAR",
+          dataSource: "live",
+        },
+      })),
+    });
+    const coordinator = new MarketDataCoordinator(provider);
+    const instrument = {
+      symbol: "VICR",
+      exchange: "NASDAQ",
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-work",
+      instrument: {
+        brokerId: "ibkr",
+        brokerInstanceId: "ibkr-work",
+        conId: 275759,
+        symbol: "VICR",
+      },
+    };
+
+    await coordinator.loadQuotesBatch([instrument], { forceRefresh: true });
+
+    const quote = coordinator.getQuoteEntry(instrument).data;
+    expect(quote?.price).toBe(293.07);
+    expect(quote?.previousClose).toBe(282.95);
+    expect(quote?.changePercent).toBeCloseTo(((293.07 - 282.95) / 282.95) * 100, 10);
+    expect(quote?.provenance?.fields?.previousClose?.providerId).toBe("yahoo");
+  });
+
   it("preserves requested quote stream routes", () => {
     let subscribedTargets: QuoteSubscriptionTarget[] = [];
     const provider = createProvider({

--- a/src/market-data/coordinator/index.ts
+++ b/src/market-data/coordinator/index.ts
@@ -20,6 +20,7 @@ import {
   toMarketDataContext,
 } from "../selectors";
 import { resolveTickerFinancialsQuoteState } from "../quotes/resolution";
+import { hasLikelyQuoteUnitMismatch } from "../../utils/currency-units";
 import { normalizePriceHistory } from "../../utils/price-history";
 import {
   createBaselineChartRequest,
@@ -219,6 +220,7 @@ export class MarketDataCoordinator {
       options,
       quoteStore: this.quoteStore,
       runSingleFlight: (key, task) => this.runSingleFlight(key, task),
+      resolveQuote: (targetInstrument, quote) => this.resolveIncomingQuote(targetInstrument, quote),
     });
   }
 
@@ -232,6 +234,7 @@ export class MarketDataCoordinator {
       options,
       quoteStore: this.quoteStore,
       runSingleFlight: (key, task) => this.runSingleFlight(key, task),
+      resolveQuote: (targetInstrument, quote) => this.resolveIncomingQuote(targetInstrument, quote),
     });
   }
 
@@ -387,9 +390,17 @@ export class MarketDataCoordinator {
 
   private resolveIncomingQuote(instrument: InstrumentRef, quote: Quote): Quote {
     const snapshot = resolveEntryData(this.snapshotStore.get(buildSnapshotKey(instrument)));
-    if (snapshot) return quote;
-
-    const cachedFinancials = this.readCachedFinancialsForInstrument(instrument);
+    if (snapshot?.quote) {
+      if (hasLikelyQuoteUnitMismatch(snapshot.quote, quote)) return quote;
+      if (
+        typeof snapshot.quote.lastUpdated === "number"
+        && typeof quote.lastUpdated === "number"
+        && quote.lastUpdated < snapshot.quote.lastUpdated
+      ) {
+        return quote;
+      }
+    }
+    const cachedFinancials = snapshot ?? this.readCachedFinancialsForInstrument(instrument);
     return resolveTickerFinancialsQuoteState(cachedFinancials, quote)?.quote ?? quote;
   }
 

--- a/src/market-data/coordinator/quotes.ts
+++ b/src/market-data/coordinator/quotes.ts
@@ -123,6 +123,7 @@ interface LoadQuoteEntryOptions {
   options?: CoordinatorLoadOptions;
   quoteStore: QueryStore<Quote>;
   runSingleFlight: CoordinatorSingleFlight;
+  resolveQuote?: (instrument: InstrumentRef, quote: Quote) => Quote;
 }
 
 export async function loadQuoteEntry({
@@ -131,6 +132,7 @@ export async function loadQuoteEntry({
   options = {},
   quoteStore,
   runSingleFlight,
+  resolveQuote,
 }: LoadQuoteEntryOptions): Promise<QueryEntry<Quote>> {
   const key = buildQuoteKey(instrument);
   const flightKey = options.forceRefresh ? `${key}|refresh` : key;
@@ -146,9 +148,10 @@ export async function loadQuoteEntry({
           cacheMode: options.forceRefresh ? "refresh" : "default",
         },
       );
-      const source = quote.providerId ?? dataProvider.id;
+      const resolvedQuote = resolveQuote?.(instrument, quote) ?? quote;
+      const source = resolvedQuote.providerId ?? dataProvider.id;
       const attempts = [createAttempt(source, startedAt, "success")];
-      return quoteStore.update(key, (current) => readyQuoteEntry(current, quote, source, attempts));
+      return quoteStore.update(key, (current) => readyQuoteEntry(current, resolvedQuote, source, attempts));
     } catch (error) {
       const classified = classifyError(error);
       const attempt = createAttempt(dataProvider.id, startedAt, EXPECTED_EMPTY.test(classified.message) ? "empty" : "fatal_error", classified.reasonCode, classified.message);
@@ -163,6 +166,7 @@ interface LoadQuoteBatchEntriesOptions {
   options?: CoordinatorLoadOptions;
   quoteStore: QueryStore<Quote>;
   runSingleFlight: CoordinatorSingleFlight;
+  resolveQuote?: (instrument: InstrumentRef, quote: Quote) => Quote;
 }
 
 export async function loadQuoteBatchEntries({
@@ -171,6 +175,7 @@ export async function loadQuoteBatchEntries({
   options = {},
   quoteStore,
   runSingleFlight,
+  resolveQuote,
 }: LoadQuoteBatchEntriesOptions): Promise<QueryEntry<Quote>[]> {
   const uniqueInstruments = [...new Map(instruments.map((instrument) => [buildQuoteKey(instrument), instrument] as const)).values()];
   const results = new Map<string, QueryEntry<Quote>>();
@@ -195,9 +200,10 @@ export async function loadQuoteBatchEntries({
       const instrument = misses[index];
       if (!instrument || !item.quote) return;
       const key = buildQuoteKey(instrument);
-      const source = item.quote.providerId ?? dataProvider.id;
+      const quote = resolveQuote?.(instrument, item.quote) ?? item.quote;
+      const source = quote.providerId ?? dataProvider.id;
       const attempts = [createAttempt(source, Date.now(), "success")];
-      results.set(key, quoteStore.update(key, (current) => readyQuoteEntry(current, item.quote!, source, attempts)));
+      results.set(key, quoteStore.update(key, (current) => readyQuoteEntry(current, quote, source, attempts)));
     });
   }
 
@@ -210,6 +216,7 @@ export async function loadQuoteBatchEntries({
       options,
       quoteStore,
       runSingleFlight,
+      resolveQuote,
     }));
   }));
 

--- a/src/plugins/builtin/portfolio-list/index.test.ts
+++ b/src/plugins/builtin/portfolio-list/index.test.ts
@@ -6,7 +6,7 @@ import type { TickerRecord } from "../../../types/ticker";
 import type { PortfolioSummaryTotals } from "./metrics";
 import { buildPortfolioSummarySegments } from "./summary";
 import { portfolioListPlugin, shouldToggleCashMarginDrawer } from ".";
-import { needsVisibleQuoteWatchdogRefresh, selectStreamTickers } from "./pane/data";
+import { needsVisibleQuoteWatchdogRefresh, selectQuoteWarmupTickers, selectStreamTickers } from "./pane/data";
 import { buildPortfolioPaneSettingsDef, getPortfolioPaneSettings } from "./settings";
 
 function ticker(symbol: string): TickerRecord {
@@ -131,6 +131,56 @@ describe("selectStreamTickers", () => {
   test("includes selected ticker outside the visible streaming window", () => {
     const tickers = Array.from({ length: 20 }, (_, index) => ticker(`T${index}`));
     expect(selectStreamTickers(tickers, { start: 3, end: 7 }, "T19").map((entry) => entry.metadata.ticker)).toContain("T19");
+  });
+});
+
+describe("selectQuoteWarmupTickers", () => {
+  function financials(quoteValue: Quote | undefined): TickerFinancials {
+    return {
+      annualStatements: [],
+      quarterlyStatements: [],
+      priceHistory: [],
+      quote: quoteValue,
+    };
+  }
+
+  test("includes hidden quote-missing rows when sorting by quote-dependent columns", () => {
+    const tickers = Array.from({ length: 30 }, (_, index) => ticker(`T${index}`));
+    const financialsMap = new Map<string, TickerFinancials>(
+      tickers.slice(0, 29).map((entry, index) => [
+        entry.metadata.ticker,
+        financials({
+          symbol: entry.metadata.ticker,
+          price: index + 1,
+          currency: "USD",
+          change: index,
+          changePercent: index,
+          lastUpdated: 1_700_000_000_000,
+        }),
+      ]),
+    );
+
+    const selected = selectQuoteWarmupTickers(
+      tickers,
+      { start: 0, end: 24 },
+      financialsMap,
+      { columnId: "change_pct", direction: "asc" },
+      1_700_000_010_000,
+    ).map((entry) => entry.metadata.ticker);
+
+    expect(selected).toContain("T29");
+  });
+
+  test("does not add hidden rows for ticker-only sorting", () => {
+    const tickers = Array.from({ length: 30 }, (_, index) => ticker(`T${index}`));
+    expect(selectQuoteWarmupTickers(
+      tickers,
+      { start: 0, end: 24 },
+      new Map(),
+      { columnId: "ticker", direction: "asc" },
+    ).map((entry) => entry.metadata.ticker)).toEqual(
+      tickers.slice(0, 24).map((entry) => entry.metadata.ticker),
+    );
   });
 });
 

--- a/src/plugins/builtin/portfolio-list/pane/data.ts
+++ b/src/plugins/builtin/portfolio-list/pane/data.ts
@@ -16,8 +16,26 @@ export const VISIBLE_QUOTE_STREAM_WATCHDOG_MS = 30_000;
 export const VISIBLE_SNAPSHOT_REFRESH_COOLDOWN_MS = 5 * 60_000;
 export const VISIBLE_FINANCIAL_WARMUP_DELAY_MS = 350;
 export const VISIBLE_SNAPSHOT_WARMUP_BATCH_LIMIT = 3;
+export const SORT_QUOTE_WARMUP_BATCH_LIMIT = 64;
 
 const STREAM_OVERSCAN_ROWS = 6;
+const QUOTE_SORT_COLUMN_IDS = new Set([
+  "price",
+  "change",
+  "change_pct",
+  "volume",
+  "dollar_volume",
+  "range_52w",
+  "market_cap",
+  "latency",
+  "ext_hours",
+  "mkt_value",
+  "weight",
+  "day_pnl",
+  "pnl",
+  "pnl_pct",
+  "mark_delta",
+]);
 const FUNDAMENTAL_COLUMN_IDS = new Set(["pe", "forward_pe", "dividend_yield"]);
 const PROFILE_COLUMN_IDS = new Set(["sector", "industry"]);
 const sortValueCache = createRowValueCache<string, ReturnType<typeof getSortValue>>(5000);
@@ -79,6 +97,35 @@ export function selectStreamTickers(
   }
   const selectedTicker = tickers.find((ticker) => ticker.metadata.ticker === selectedSymbol);
   return selectedTicker ? [...visible, selectedTicker] : visible;
+}
+
+export function sortPreferenceUsesQuote(sortPreference: CollectionSortPreference): boolean {
+  return !!sortPreference.columnId && QUOTE_SORT_COLUMN_IDS.has(sortPreference.columnId);
+}
+
+export function selectQuoteWarmupTickers(
+  sortedTickers: TickerRecord[],
+  visibleRange: { start: number; end: number },
+  financialsMap: Map<string, TickerFinancials>,
+  sortPreference: CollectionSortPreference,
+  now = Date.now(),
+  hiddenLimit = SORT_QUOTE_WARMUP_BATCH_LIMIT,
+): TickerRecord[] {
+  const visible = sortedTickers.slice(visibleRange.start, visibleRange.end);
+  if (!sortPreferenceUsesQuote(sortPreference)) {
+    return visible;
+  }
+
+  const seen = new Set(visible.map((ticker) => ticker.metadata.ticker));
+  const hidden: TickerRecord[] = [];
+  for (const ticker of sortedTickers) {
+    if (seen.has(ticker.metadata.ticker)) continue;
+    if (!needsVisibleQuoteWarmup(financialsMap.get(ticker.metadata.ticker), now)) continue;
+    hidden.push(ticker);
+    seen.add(ticker.metadata.ticker);
+    if (hidden.length >= hiddenLimit) break;
+  }
+  return [...visible, ...hidden];
 }
 
 export function buildTrackedCurrencies(

--- a/src/plugins/builtin/portfolio-list/pane/index.test.tsx
+++ b/src/plugins/builtin/portfolio-list/pane/index.test.tsx
@@ -1060,6 +1060,14 @@ describe("PortfolioListPane cash and margin UI", () => {
         config={config}
         collectionId="broker:ibkr-flex:DU12345"
         quote={staleQuote}
+        stateMutator={(state) => {
+          state.paneState[TEST_PANE_ID] = {
+            ...(state.paneState[TEST_PANE_ID] ?? {}),
+            collectionSorts: {
+              "broker:ibkr-flex:DU12345": { columnId: "ticker", direction: "asc" },
+            },
+          };
+        }}
       />,
       { width: 100, height: 12 },
     );
@@ -1525,6 +1533,149 @@ describe("PortfolioListPane cash and margin UI", () => {
     const vicrTarget = subscribedTargets.find((target) => target.symbol === "VICR");
     expect(vicrTarget?.context?.brokerInstanceId).toBe("ibkr-live");
     expect(vicrTarget?.context?.instrument).toEqual(liveContract);
+  });
+
+  test("warms hidden quote-missing rows when sorting by change percent", async () => {
+    const portfolioId = "broker:ibkr-live:DU12345";
+    const config = createPortfolioConfigWithColumns(
+      portfolioId,
+      ["ticker", "price", "change_pct", "latency"],
+      [createBrokerInstance("gateway", "ibkr-live")],
+    );
+    const requestedSnapshots: string[] = [];
+    const provider: DataProvider = {
+      id: "test-provider",
+      name: "Test Provider",
+      async getTickerFinancials(symbol) {
+        requestedSnapshots.push(symbol);
+        return {
+          annualStatements: [],
+          quarterlyStatements: [],
+          priceHistory: [],
+          quote: makeQuote({
+            symbol,
+            price: symbol === "SIVE" ? 46.7 : 100,
+            change: symbol === "SIVE" ? -9.6 : 0,
+            changePercent: symbol === "SIVE" ? -17.05 : 0,
+            previousClose: symbol === "SIVE" ? 56.3 : 100,
+          }),
+        };
+      },
+      async getQuote(symbol) {
+        return makeQuote({
+          symbol,
+          price: symbol === "SIVE" ? 46.7 : 100,
+          change: symbol === "SIVE" ? -9.6 : 0,
+          changePercent: symbol === "SIVE" ? -17.05 : 0,
+          previousClose: symbol === "SIVE" ? 56.3 : 100,
+        });
+      },
+      async getQuotesBatch(targets) {
+        return targets.map((target) => ({
+          target,
+          quote: makeQuote({
+            symbol: target.symbol,
+            price: target.symbol === "SIVE" ? 46.7 : 100,
+            change: target.symbol === "SIVE" ? -9.6 : 0,
+            changePercent: target.symbol === "SIVE" ? -17.05 : 0,
+            previousClose: target.symbol === "SIVE" ? 56.3 : 100,
+          }),
+        }));
+      },
+      async getExchangeRate() {
+        return 1;
+      },
+      async search() {
+        return [];
+      },
+      async getArticleSummary() {
+        return null;
+      },
+      async getPriceHistory() {
+        return [];
+      },
+      subscribeQuotes() {
+        return () => {};
+      },
+    };
+    sharedCoordinator = new MarketDataCoordinator(provider);
+    setSharedMarketDataCoordinator(sharedCoordinator);
+
+    const makeBrokerTicker = (symbol: string, index: number): TickerRecord => makeTicker({
+      ticker: symbol,
+      name: symbol,
+      portfolios: [portfolioId],
+      positions: [{
+        portfolio: portfolioId,
+        shares: 10,
+        avgCost: 100,
+        currency: "USD",
+        broker: "ibkr",
+        brokerInstanceId: "ibkr-live",
+        brokerAccountId: "DU12345",
+        brokerContractId: 10_000 + index,
+        markPrice: symbol === "SIVE" ? 56.3 : 100,
+      }],
+      broker_contracts: [{
+        brokerId: "ibkr",
+        brokerInstanceId: "ibkr-live",
+        symbol,
+        localSymbol: symbol,
+        exchange: "SMART",
+        primaryExchange: "NASDAQ",
+        conId: 10_000 + index,
+      }],
+    });
+    const tickers = Array.from({ length: 29 }, (_, index) => makeBrokerTicker(`T${String(index).padStart(2, "0")}`, index));
+    const sive = makeBrokerTicker("SIVE", 29);
+
+    testSetup = await testRender(
+      <PortfolioHarness
+        config={config}
+        collectionId={portfolioId}
+        stateMutator={(state) => {
+          state.tickers = new Map([...tickers, sive].map((entry) => [entry.metadata.ticker, entry]));
+          state.financials = new Map(tickers.map((entry, index) => [
+            entry.metadata.ticker,
+            {
+              annualStatements: [],
+              quarterlyStatements: [],
+              priceHistory: [],
+              quote: makeQuote({
+                symbol: entry.metadata.ticker,
+                price: 100 + index,
+                change: index,
+                changePercent: index,
+              }),
+            },
+          ]));
+          state.paneState[TEST_PANE_ID] = {
+            collectionId: portfolioId,
+            cursorSymbol: "T00",
+            cashDrawerExpanded: false,
+            collectionSorts: {
+              [portfolioId]: { columnId: "change_pct", direction: "asc" },
+            },
+          };
+        }}
+        paneHeight={12}
+      />,
+      { width: 100, height: 12 },
+    );
+
+    await flushFrame();
+    expect(testSetup.captureCharFrame()).not.toContain("SIVE");
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    });
+    await flushFrame();
+
+    expect(requestedSnapshots).toContain("SIVE");
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("SIVE");
+    expect(frame).toContain("-17.05%");
+    expect(frame).toContain("46.7");
   });
 
 });

--- a/src/plugins/builtin/portfolio-list/pane/index.tsx
+++ b/src/plugins/builtin/portfolio-list/pane/index.tsx
@@ -317,6 +317,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     cursorSymbol,
     streamWindow: effectiveStreamWindow,
     isPortfolioTab,
+    activeSort,
     financialsMap,
     visibleWarmupRequirements,
   });

--- a/src/plugins/builtin/portfolio-list/pane/streaming.ts
+++ b/src/plugins/builtin/portfolio-list/pane/streaming.ts
@@ -4,16 +4,20 @@ import { instrumentFromTicker, quoteSubscriptionTargetFromTicker } from "../../.
 import { useQuoteStreaming } from "../../../../state/hooks/quote-streaming";
 import type { TickerFinancials } from "../../../../types/financials";
 import type { TickerRecord } from "../../../../types/ticker";
+import type { CollectionSortPreference } from "../../../../state/app/context";
 import {
   VISIBLE_FINANCIAL_WARMUP_DELAY_MS,
   VISIBLE_QUOTE_REFRESH_COOLDOWN_MS,
   VISIBLE_QUOTE_STREAM_WATCHDOG_MS,
   VISIBLE_SNAPSHOT_WARMUP_BATCH_LIMIT,
   VISIBLE_SNAPSHOT_REFRESH_COOLDOWN_MS,
+  SORT_QUOTE_WARMUP_BATCH_LIMIT,
   needsVisibleQuoteWarmup,
   needsVisibleQuoteWatchdogRefresh,
   needsVisibleSnapshotWarmup,
+  selectQuoteWarmupTickers,
   selectStreamTickers,
+  sortPreferenceUsesQuote,
   visibleWarmupKey,
   type VisibleWarmupRequirements,
 } from "./data";
@@ -26,6 +30,7 @@ export function usePortfolioPaneStreaming({
   cursorSymbol,
   streamWindow,
   isPortfolioTab,
+  activeSort,
   financialsMap,
   visibleWarmupRequirements,
 }: {
@@ -36,6 +41,7 @@ export function usePortfolioPaneStreaming({
   cursorSymbol: string | null;
   streamWindow: { start: number; end: number };
   isPortfolioTab: boolean;
+  activeSort: CollectionSortPreference;
   financialsMap: Map<string, TickerFinancials>;
   visibleWarmupRequirements: VisibleWarmupRequirements;
 }) {
@@ -91,19 +97,39 @@ export function usePortfolioPaneStreaming({
 
     const nowTimestamp = Date.now();
     const quoteQueue: TickerRecord[] = [];
+    const quoteSnapshotQueue: TickerRecord[] = [];
     const snapshotQueue: TickerRecord[] = [];
-    for (const ticker of visibleFinancialTickers) {
+    const snapshotQueueSymbols = new Set<string>();
+    const useSnapshotForQuoteWarmup = sortPreferenceUsesQuote(activeSort);
+    const quoteWarmupTickers = selectQuoteWarmupTickers(
+      sortedTickers,
+      streamWindow,
+      financialsMap,
+      activeSort,
+      nowTimestamp,
+    );
+    for (const ticker of quoteWarmupTickers) {
       const financials = financialsMap.get(ticker.metadata.ticker);
       const quoteKey = visibleWarmupKey("quote", ticker);
+      const warmupWithSnapshot = useSnapshotForQuoteWarmup && ticker.metadata.assetCategory !== "OPT";
+      const warmupKey = warmupWithSnapshot ? visibleWarmupKey("snapshot", ticker) : quoteKey;
       if (
         needsVisibleQuoteWarmup(financials, nowTimestamp)
-        && !warmupInFlightRef.current.has(quoteKey)
-        && nowTimestamp - (warmupAttemptRef.current.get(quoteKey) ?? 0) >= VISIBLE_QUOTE_REFRESH_COOLDOWN_MS
+        && !warmupInFlightRef.current.has(warmupKey)
+        && nowTimestamp - (warmupAttemptRef.current.get(warmupKey) ?? 0) >= VISIBLE_QUOTE_REFRESH_COOLDOWN_MS
       ) {
-        quoteQueue.push(ticker);
-        continue;
+        if (warmupWithSnapshot) {
+          quoteSnapshotQueue.push(ticker);
+          snapshotQueueSymbols.add(ticker.metadata.ticker);
+        } else {
+          quoteQueue.push(ticker);
+        }
       }
+    }
 
+    for (const ticker of visibleFinancialTickers) {
+      const financials = financialsMap.get(ticker.metadata.ticker);
+      if (snapshotQueueSymbols.has(ticker.metadata.ticker)) continue;
       const snapshotKey = visibleWarmupKey("snapshot", ticker);
       if (
         needsVisibleSnapshotWarmup(ticker, financials, visibleWarmupRequirements)
@@ -111,9 +137,13 @@ export function usePortfolioPaneStreaming({
         && nowTimestamp - (warmupAttemptRef.current.get(snapshotKey) ?? 0) >= VISIBLE_SNAPSHOT_REFRESH_COOLDOWN_MS
       ) {
         snapshotQueue.push(ticker);
+        snapshotQueueSymbols.add(ticker.metadata.ticker);
       }
     }
-    const limitedSnapshotQueue = snapshotQueue.slice(0, VISIBLE_SNAPSHOT_WARMUP_BATCH_LIMIT);
+    const limitedSnapshotQueue = [
+      ...quoteSnapshotQueue.slice(0, SORT_QUOTE_WARMUP_BATCH_LIMIT),
+      ...snapshotQueue.slice(0, VISIBLE_SNAPSHOT_WARMUP_BATCH_LIMIT),
+    ];
     if (quoteQueue.length === 0 && limitedSnapshotQueue.length === 0) return;
 
     let cancelled = false;
@@ -161,7 +191,7 @@ export function usePortfolioPaneStreaming({
       cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [appActive, financialsMap, focused, instrumentOptions, sharedCoordinator, visibleFinancialTickers, visibleWarmupRequirements]);
+  }, [activeSort, appActive, financialsMap, focused, instrumentOptions, sharedCoordinator, sortedTickers, streamWindow, visibleFinancialTickers, visibleWarmupRequirements]);
 
   useEffect(() => {
     if (!appActive) return;


### PR DESCRIPTION
## Summary
- warm hidden quote-missing portfolio rows when sorting by quote-derived columns
- use snapshot warmups for stock quote-sort gaps so stale broker marks do not drive CHG% order
- reconcile single and batch quote loads with cached provider day references before writing quote state

## Tests
- bun test src/market-data/quotes/resolution.test.ts src/sources/provider-router/index.test.ts src/sources/provider-router/cached-financials.test.ts src/market-data/coordinator/index.test.ts src/plugins/ibkr/gateway/service/index.test.ts src/market-data/request-types.test.ts src/market-data/hooks.test.tsx src/plugins/builtin/portfolio-list/index.test.ts src/plugins/builtin/portfolio-list/pane/index.test.tsx
- git diff --check