### PR TITLE
Mute closed market portfolio changes

### DIFF
--- a/src/market-data/market/status.ts
+++ b/src/market-data/market/status.ts
@@ -1,5 +1,7 @@
 import type { MarketState, Quote, QuoteFieldProvenance } from "../../types/financials";
-import { colors } from "../../theme/colors";
+import { blendHex, colors, priceColor } from "../../theme/colors";
+
+const CLOSED_CHANGE_MUTING_RATIO = 0.55;
 
 export interface ActiveQuoteDisplay {
   price: number;
@@ -43,6 +45,22 @@ export function marketStateDot(state?: MarketState): string {
     default:
       return "\u25CC";
   }
+}
+
+export function isClosedMarketState(state?: MarketState): boolean {
+  return state === "CLOSED" || state === "PREPRE" || state === "POSTPOST";
+}
+
+/** Closed prices are final snapshots, so they should not look live or directional. */
+export function marketPriceColor(change: number, state?: MarketState): string {
+  return isClosedMarketState(state) ? colors.textDim : priceColor(change);
+}
+
+/** Preserve a closed session's direction while visually distinguishing it from a live move. */
+export function marketChangeColor(change: number, state?: MarketState): string {
+  const directionalColor = priceColor(change);
+  if (!isClosedMarketState(state) || change === 0) return directionalColor;
+  return blendHex(directionalColor, colors.textDim, CLOSED_CHANGE_MUTING_RATIO);
 }
 
 /** Short exchange display name */

--- a/src/plugins/builtin/portfolio-list/column-values.ts
+++ b/src/plugins/builtin/portfolio-list/column-values.ts
@@ -1,5 +1,5 @@
 import type { ColumnConfig } from "../../../types/config";
-import type { AnalystResearchData, CorporateActionsData, TickerFinancials } from "../../../types/financials";
+import type { AnalystResearchData, CorporateActionsData, MarketState, TickerFinancials } from "../../../types/financials";
 import type { EarningsEvent } from "../../../types/data-provider";
 import type { TickerRecord } from "../../../types/ticker";
 import { priceColor } from "../../../theme/colors";
@@ -13,7 +13,13 @@ import {
   formatSignedMarketPrice,
   type MarketFormatOptions,
 } from "../../../market-data/market/format";
-import { getActiveQuoteDisplay, marketStateDot, type ActiveQuoteDisplay } from "../../../market-data/market/status";
+import {
+  getActiveQuoteDisplay,
+  marketChangeColor,
+  marketPriceColor,
+  marketStateDot,
+  type ActiveQuoteDisplay,
+} from "../../../market-data/market/status";
 import { formatOptionTicker } from "../../../utils/options";
 import { PRICE_SPARKLINE_COLUMN_ID } from "../../../components/price-sparkline/view";
 import {
@@ -159,13 +165,14 @@ function getActiveMarketValue(
 export function resolvePortfolioPriceValue(
   activeQuote: ActiveQuoteDisplay | null,
   brokerMarkPrice: number | undefined,
-  formatOptions: MarketFormatOptions,
+  formatOptions: MarketFormatOptions = {},
   maxWidth?: number,
+  marketState?: MarketState,
 ): { text: string; color?: string } {
   if (activeQuote) {
     return {
       text: formatMarketPrice(activeQuote.price, { ...formatOptions, maxWidth }),
-      color: priceColor(activeQuote.change),
+      color: marketPriceColor(activeQuote.change, marketState),
     };
   }
   if (brokerMarkPrice != null) {
@@ -229,12 +236,12 @@ export function getColumnValue(
     case "tags":
       return { text: ticker.metadata.tags.length > 0 ? ticker.metadata.tags.join(",") : "—" };
     case "price":
-      return resolvePortfolioPriceValue(activeQuote, brokerMarkPrice, formatOptions, col.width);
+      return resolvePortfolioPriceValue(activeQuote, brokerMarkPrice, formatOptions, col.width, quote?.marketState);
     case "change":
       if (!activeQuote) return { text: "—" };
       return {
         text: formatSignedMarketPrice(activeQuote.change, { ...formatOptions, maxWidth: col.width }),
-        color: priceColor(activeQuote.change),
+        color: marketChangeColor(activeQuote.change, quote?.marketState),
       };
     case "bid":
       return { text: quote?.bid != null ? formatMarketPrice(quote.bid, { ...formatOptions, maxWidth: col.width }) : "—" };
@@ -258,8 +265,8 @@ export function getColumnValue(
     }
     case "change_pct":
       return activeQuote
-        ? { text: formatPercentRaw(activeQuote.changePercent), color: priceColor(activeQuote.changePercent) }
-        : { text: quote ? formatPercentRaw(quote.changePercent) : "—", color: quote ? priceColor(quote.changePercent) : undefined };
+        ? { text: formatPercentRaw(activeQuote.changePercent), color: marketChangeColor(activeQuote.changePercent, quote?.marketState) }
+        : { text: quote ? formatPercentRaw(quote.changePercent) : "—", color: quote ? marketChangeColor(quote.changePercent, quote.marketState) : undefined };
     case "volume":
       return { text: finiteNumber(quote?.volume) ? formatCompact(quote.volume) : "—" };
     case "dollar_volume": {

--- a/src/plugins/builtin/portfolio-list/metrics.test.ts
+++ b/src/plugins/builtin/portfolio-list/metrics.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { CollectionSortPreference } from "../../../state/app/context";
 import type { ColumnConfig } from "../../../types/config";
-import type { TickerFinancials } from "../../../types/financials";
+import type { Quote, TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
+import { blendHex, colors } from "../../../theme/colors";
 import {
   calculatePortfolioSummaryTotals,
   getColumnValue,
@@ -29,8 +30,15 @@ function createTicker(overrides: Partial<TickerRecord["metadata"]> = {}): Ticker
   };
 }
 
-function createFinancials(overrides: Partial<TickerFinancials> = {}): TickerFinancials {
+function createFinancials(
+  overrides: Omit<Partial<TickerFinancials>, "quote"> & { quote?: Partial<Quote> } = {},
+): TickerFinancials {
+  const { quote: quoteOverrides, ...financialOverrides } = overrides;
   return {
+    annualStatements: [],
+    quarterlyStatements: [],
+    priceHistory: [],
+    ...financialOverrides,
     quote: {
       symbol: "AAPL",
       price: 120,
@@ -39,12 +47,8 @@ function createFinancials(overrides: Partial<TickerFinancials> = {}): TickerFina
       changePercent: 4.35,
       previousClose: 115,
       lastUpdated: 1_700_000_000_000,
-      ...overrides.quote,
+      ...quoteOverrides,
     },
-    annualStatements: [],
-    quarterlyStatements: [],
-    priceHistory: [],
-    ...overrides,
   };
 }
 
@@ -80,6 +84,39 @@ describe("portfolio-metrics", () => {
     expect(resolvePortfolioPriceValue(null, 382.5)).toEqual({
       text: "382.5",
     });
+  });
+
+  test("mutes completed-session prices and changes without discarding their direction", () => {
+    const ticker = createTicker({
+      positions: [{ portfolio: "main", shares: 10, avgCost: 100, broker: "manual" }],
+    });
+    const priceColumn: ColumnConfig = { id: "price", label: "LAST", width: 10, align: "right" };
+    const changeColumn: ColumnConfig = { id: "change", label: "CHG", width: 8, align: "right" };
+    const changePctColumn: ColumnConfig = { id: "change_pct", label: "CHG%", width: 8, align: "right" };
+    const financials = createFinancials({ quote: { marketState: "CLOSED" } });
+    const mutedPositive = blendHex(colors.positive, colors.textDim, 0.55);
+
+    expect(getColumnValue(priceColumn, ticker, financials, defaultColumnContext)).toEqual({
+      text: "120",
+      color: colors.textDim,
+    });
+    expect(getColumnValue(changeColumn, ticker, financials, defaultColumnContext)).toEqual({
+      text: "+5",
+      color: mutedPositive,
+    });
+    expect(getColumnValue(changePctColumn, ticker, financials, defaultColumnContext)).toEqual({
+      text: "+4.35%",
+      color: mutedPositive,
+    });
+    const unchanged = createFinancials({ quote: { change: 0, changePercent: 0, previousClose: 120, marketState: "CLOSED" } });
+    expect(getColumnValue(changePctColumn, ticker, unchanged, defaultColumnContext)).toEqual({
+      text: "0.00%",
+      color: colors.neutral,
+    });
+
+    const open = createFinancials({ quote: { marketState: "REGULAR" } });
+    expect(getColumnValue(priceColumn, ticker, open, defaultColumnContext).color).toBe(colors.positive);
+    expect(getColumnValue(changePctColumn, ticker, open, defaultColumnContext).color).toBe(colors.positive);
   });
 
   test("calculates portfolio totals from live quotes", () => {

--- a/src/sources/provider-router/financial-routes.ts
+++ b/src/sources/provider-router/financial-routes.ts
@@ -43,6 +43,19 @@ export interface ProviderRouterFinancialRouteDeps extends Pick<
   primaryRoutes: ProviderRouterPrimaryRoutes;
 }
 
+function withoutSessionState(quote: Quote): Quote {
+  const fallback = { ...quote };
+  delete fallback.marketState;
+  delete fallback.sessionConfidence;
+  delete fallback.preMarketPrice;
+  delete fallback.preMarketChange;
+  delete fallback.preMarketChangePercent;
+  delete fallback.postMarketPrice;
+  delete fallback.postMarketChange;
+  delete fallback.postMarketChangePercent;
+  return fallback;
+}
+
 export class ProviderRouterFinancialRoutes {
   constructor(private readonly deps: ProviderRouterFinancialRouteDeps) {}
 
@@ -169,16 +182,21 @@ export class ProviderRouterFinancialRoutes {
     exchange?: string,
     context?: MarketDataRequestContext,
   ): Promise<Quote | null> {
-    const cached = this.readCachedProviderQuote(ticker, exchange, context);
+    const cached = context?.cacheMode === "refresh"
+      ? null
+      : this.readCachedProviderQuote(ticker, exchange, context);
     if (cached) return cached;
+    const staleFallback = this.readCachedProviderQuote(ticker, exchange, context, true);
     const providerQuote = await this.deps.primaryRoutes.fetchProviderQuote(ticker, exchange, context);
-    return providerQuote?.value ?? null;
+    if (providerQuote) return providerQuote.value;
+    return staleFallback ? withoutSessionState(staleFallback) : null;
   }
 
   private readCachedProviderQuote(
     ticker: string,
     exchange?: string,
     context?: MarketDataRequestContext,
+    includeStale = false,
   ): Quote | null {
     const entityKey = this.deps.getEntityKey(ticker, context?.instrument);
     const entityKeys = [...new Set([entityKey, normalizeTicker(ticker)])];
@@ -186,7 +204,11 @@ export class ProviderRouterFinancialRoutes {
     const sourceKeys = this.deps.getProviderSourceKeys();
     for (const candidateEntityKey of entityKeys) {
       const record = selectCachedResource<Quote>(this.deps.resources, "quote", candidateEntityKey, variantKeys, sourceKeys, false);
-      if (record && !isQuoteStaleForCurrentSession(quoteWithFreshnessExchange(record.value, exchange))) {
+      if (
+        record
+        && (includeStale || !record.stale)
+        && !isQuoteStaleForCurrentSession(quoteWithFreshnessExchange(record.value, exchange))
+      ) {
         return record.value;
       }
     }

--- a/src/sources/provider-router/index.test.ts
+++ b/src/sources/provider-router/index.test.ts
@@ -367,6 +367,119 @@ describe("AssetDataRouter", () => {
     expect(quote.provenance?.fields?.previousClose?.providerId).toBe("yahoo");
   });
 
+  test("refreshes broker option session references across the market close", async () => {
+    const dbPath = createTempDbPath("option-session-transition");
+    const persistence = new AppPersistence(dbPath);
+    const optionSymbol = "IBIT  281215C00030000";
+    const entityKey = `contract:${optionSymbol}`;
+    const providerSourceKey = "provider:yahoo";
+    const cacheKey = {
+      namespace: "market",
+      kind: "quote",
+      entityKey,
+      variantKey: "",
+      sourceKey: providerSourceKey,
+    };
+    const regularReference = makeQuote({
+      symbol: optionSymbol,
+      providerId: "yahoo",
+      price: 15.775,
+      change: 0.29,
+      changePercent: 1.87,
+      previousClose: 15.485,
+      listingExchangeName: "OPTIONS",
+      marketState: "REGULAR",
+      sessionConfidence: "derived",
+    });
+    let providerCalls = 0;
+    let providerAvailable = true;
+    const provider: DataProvider = {
+      ...fallbackProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      async getQuote() {
+        providerCalls += 1;
+        if (!providerAvailable) throw new Error("temporary provider outage");
+        return {
+          ...regularReference,
+          marketState: "CLOSED",
+          lastUpdated: Date.now(),
+        };
+      },
+    };
+    const broker: BrokerAdapter = {
+      id: "ibkr",
+      name: "IBKR",
+      configSchema: [],
+      async validate() {
+        return true;
+      },
+      async importPositions() {
+        return [];
+      },
+      async getQuote() {
+        return {
+          ...regularReference,
+          providerId: "ibkr",
+          previousClose: 99,
+          marketState: undefined,
+          sessionConfidence: "unknown",
+          dataSource: "live",
+          lastUpdated: Date.now(),
+        };
+      },
+    };
+
+    try {
+      persistence.resources.set(cacheKey, regularReference, {
+        cachePolicy: { staleMs: 60_000, expireMs: 24 * 60 * 60_000 },
+        fetchedAt: Date.now() - 2 * 60_000,
+      });
+      const router = new AssetDataRouter(provider, [], persistence.resources);
+      attachTestRegistry(router, { brokers: [["ibkr", broker]] });
+      setBrokerInstances(router, [brokerInstance()]);
+      const context = {
+        brokerId: "ibkr",
+        brokerInstanceId: "ibkr-work",
+        instrument: {
+          brokerId: "ibkr",
+          brokerInstanceId: "ibkr-work",
+          symbol: "IBIT",
+          localSymbol: optionSymbol,
+          secType: "OPT",
+        },
+      } as const;
+
+      const staleTransition = await router.getQuote(optionSymbol, "", context);
+      expect(staleTransition.marketState).toBe("CLOSED");
+      expect(providerCalls).toBe(1);
+
+      persistence.resources.set(cacheKey, regularReference, {
+        cachePolicy: { staleMs: 60_000, expireMs: 24 * 60 * 60_000 },
+        fetchedAt: Date.now(),
+      });
+      const forcedTransition = await router.getQuote(optionSymbol, "", {
+        ...context,
+        cacheMode: "refresh",
+      });
+      expect(forcedTransition.marketState).toBe("CLOSED");
+      expect(providerCalls).toBe(2);
+
+      providerAvailable = false;
+      persistence.resources.set(cacheKey, regularReference, {
+        cachePolicy: { staleMs: 60_000, expireMs: 24 * 60 * 60_000 },
+        fetchedAt: Date.now() - 2 * 60_000,
+      });
+      const outageFallback = await router.getQuote(optionSymbol, "", context);
+      expect(outageFallback.previousClose).toBe(15.485);
+      expect(outageFallback.provenance?.fields?.previousClose?.providerId).toBe("yahoo");
+      expect(outageFallback.marketState).toBeUndefined();
+      expect(providerCalls).toBe(3);
+    } finally {
+      persistence.close();
+    }
+  });
+
   test("prefers broker options chains for broker-context targets", async () => {
     const chain = {
       underlyingSymbol: "AAPL",

--- a/src/sources/yahoo-finance.test.ts
+++ b/src/sources/yahoo-finance.test.ts
@@ -135,28 +135,38 @@ describe("YahooFinanceClient exchange aliases", () => {
 
   test("maps IBKR option symbols to Yahoo option quote marks", async () => {
     const provider = new YahooFinanceClient() as any;
-    provider.getOptionsChain = async (ticker: string, _exchange: string, expirationDate: number) => ({
-      underlyingSymbol: ticker,
-      expirationDates: [expirationDate],
-      calls: [{
-        contractSymbol: "AMD270917C00230000",
-        strike: 230,
-        currency: "USD",
-        lastPrice: 251,
-        change: 1.5,
-        percentChange: 0.6,
-        volume: 10,
-        openInterest: 20,
-        bid: 250.25,
-        ask: 254.5,
-        impliedVolatility: 0.4,
-        inTheMoney: false,
-        expiration: expirationDate,
-        lastTradeDate: 1_800_000_000,
-      }],
-      puts: [],
+    const expiration = 1_821_139_200;
+    let underlyingMarketState = "POST";
+    provider.http.fetchJsonWithCrumb = async () => ({
+      optionChain: {
+        result: [{
+          underlyingSymbol: "AMD",
+          expirationDates: [expiration],
+          quote: { marketState: underlyingMarketState },
+          options: [{
+            calls: [{
+              contractSymbol: "AMD270917C00230000",
+              strike: 230,
+              currency: "USD",
+              lastPrice: 251,
+              change: 1.5,
+              percentChange: 0.6,
+              volume: 10,
+              openInterest: 20,
+              bid: 250.25,
+              ask: 254.5,
+              impliedVolatility: 0.4,
+              inTheMoney: false,
+              expiration,
+              lastTradeDate: 1_800_000_000,
+            }],
+            puts: [],
+          }],
+        }],
+      },
     });
 
+    const requestedAt = Date.now();
     const quote = await provider.getQuote("AMD   270917C00230000");
 
     expect(quote).toMatchObject({
@@ -166,8 +176,17 @@ describe("YahooFinanceClient exchange aliases", () => {
       bid: 250.25,
       ask: 254.5,
       providerId: "yahoo",
+      marketState: "CLOSED",
+      sessionConfidence: "derived",
     });
-    expect(quote.lastUpdated).toBe(1_800_000_000_000);
+    expect(quote.lastUpdated).toBeGreaterThanOrEqual(requestedAt);
+
+    underlyingMarketState = "REGULAR";
+    const regularQuote = await provider.getQuote("AMD   270917C00230000");
+    expect(regularQuote).toMatchObject({
+      marketState: "REGULAR",
+      sessionConfidence: "derived",
+    });
   });
 
   test("preserves analyst rating price targets from upgrade history", async () => {

--- a/src/sources/yahoo-finance.ts
+++ b/src/sources/yahoo-finance.ts
@@ -31,6 +31,7 @@ import {
 import {
   getYahooOptionQuote,
   loadYahooOptionsChain,
+  loadYahooOptionsChainResult,
 } from "./yahoo-finance/options";
 import {
   loadYahooAnalystResearch,
@@ -155,8 +156,13 @@ export class YahooFinanceClient implements DataProvider {
     if (parseOptionSymbol(ticker)) {
       return getYahooOptionQuote({
         context,
-        getOptionsChain: (underlying, requestExchange, expirationDate, requestContext) => (
-          this.getOptionsChain(underlying, requestExchange, expirationDate, requestContext)
+        getOptionsChainResult: (underlying, requestExchange, expirationDate) => (
+          loadYahooOptionsChainResult({
+            exchange: requestExchange ?? "",
+            expirationDate,
+            fetchJsonWithCrumb: (url) => this.http.fetchJsonWithCrumb(url),
+            ticker: underlying,
+          })
         ),
         providerId: this.id,
         ticker,

--- a/src/sources/yahoo-finance/options.ts
+++ b/src/sources/yahoo-finance/options.ts
@@ -1,5 +1,5 @@
 import type { MarketDataRequestContext } from "../../types/data-provider";
-import type { OptionContract, OptionsChain, Quote } from "../../types/financials";
+import type { MarketState, OptionContract, OptionsChain, Quote } from "../../types/financials";
 import { parseOptionSymbol } from "../../utils/options";
 import { getYahooSymbolsToTry } from "./symbols";
 
@@ -14,14 +14,38 @@ interface LoadYahooOptionsChainOptions {
 
 interface GetYahooOptionQuoteOptions {
   context?: MarketDataRequestContext;
-  getOptionsChain: (
+  getOptionsChainResult: (
     ticker: string,
     exchange?: string,
     expirationDate?: number,
     context?: MarketDataRequestContext,
-  ) => Promise<OptionsChain>;
+  ) => Promise<YahooOptionsChainResult>;
   providerId: string;
   ticker: string;
+}
+
+export interface YahooOptionsChainResult {
+  chain: OptionsChain;
+  underlyingMarketState?: MarketState;
+}
+
+const MARKET_STATES = new Set<MarketState>([
+  "PRE",
+  "REGULAR",
+  "POST",
+  "PREPRE",
+  "POSTPOST",
+  "CLOSED",
+]);
+
+function normalizeYahooMarketState(value: unknown): MarketState | undefined {
+  const normalized = typeof value === "string" ? value.toUpperCase() as MarketState : undefined;
+  return normalized && MARKET_STATES.has(normalized) ? normalized : undefined;
+}
+
+function deriveOptionMarketState(underlyingMarketState?: MarketState): MarketState | undefined {
+  if (!underlyingMarketState) return undefined;
+  return underlyingMarketState === "REGULAR" ? "REGULAR" : "CLOSED";
 }
 
 function mapYahooOptionContract(raw: Record<string, any>): OptionContract {
@@ -43,12 +67,12 @@ function mapYahooOptionContract(raw: Record<string, any>): OptionContract {
   };
 }
 
-export async function loadYahooOptionsChain({
+export async function loadYahooOptionsChainResult({
   exchange,
   expirationDate,
   fetchJsonWithCrumb,
   ticker,
-}: LoadYahooOptionsChainOptions): Promise<OptionsChain> {
+}: LoadYahooOptionsChainOptions): Promise<YahooOptionsChainResult> {
   const symbolsToTry = getYahooSymbolsToTry(ticker, exchange);
   let lastError: any;
 
@@ -62,6 +86,7 @@ export async function loadYahooOptionsChain({
           result?: Array<{
             underlyingSymbol?: string;
             expirationDates?: number[];
+            quote?: { marketState?: unknown };
             options?: Array<{
               calls?: Array<Record<string, any>>;
               puts?: Array<Record<string, any>>;
@@ -75,10 +100,13 @@ export async function loadYahooOptionsChain({
 
       const opts = result.options?.[0];
       return {
-        underlyingSymbol: result.underlyingSymbol ?? symbol,
-        expirationDates: result.expirationDates ?? [],
-        calls: (opts?.calls ?? []).map((contract) => mapYahooOptionContract(contract)),
-        puts: (opts?.puts ?? []).map((contract) => mapYahooOptionContract(contract)),
+        chain: {
+          underlyingSymbol: result.underlyingSymbol ?? symbol,
+          expirationDates: result.expirationDates ?? [],
+          calls: (opts?.calls ?? []).map((contract) => mapYahooOptionContract(contract)),
+          puts: (opts?.puts ?? []).map((contract) => mapYahooOptionContract(contract)),
+        },
+        underlyingMarketState: normalizeYahooMarketState(result.quote?.marketState),
       };
     } catch (err) {
       lastError = err;
@@ -87,15 +115,26 @@ export async function loadYahooOptionsChain({
   throw lastError || new Error(`No options chain for ${ticker}`);
 }
 
+export async function loadYahooOptionsChain(
+  options: LoadYahooOptionsChainOptions,
+): Promise<OptionsChain> {
+  return (await loadYahooOptionsChainResult(options)).chain;
+}
+
 export async function getYahooOptionQuote({
   context,
-  getOptionsChain,
+  getOptionsChainResult,
   providerId,
   ticker,
 }: GetYahooOptionQuoteOptions): Promise<Quote> {
   const parsed = parseOptionSymbol(ticker);
   if (!parsed) throw new Error(`Unsupported option symbol ${ticker}`);
-  const chain = await getOptionsChain(parsed.underlying, "", parsed.expTs, context);
+  const { chain, underlyingMarketState } = await getOptionsChainResult(
+    parsed.underlying,
+    "",
+    parsed.expTs,
+    context,
+  );
   const contracts = parsed.side === "C" ? chain.calls : chain.puts;
   const contract = contracts.find((candidate) =>
     Math.abs(candidate.strike - parsed.strike) < 0.001 &&
@@ -110,6 +149,12 @@ export async function getYahooOptionQuote({
       : contract.ask > 0
         ? contract.ask
         : undefined;
+  const marketState = deriveOptionMarketState(underlyingMarketState);
+  const lastUpdated = mark != null
+    ? Date.now()
+    : contract.lastTradeDate > 0
+      ? contract.lastTradeDate * 1000
+      : Date.now();
   return {
     symbol: ticker,
     providerId,
@@ -122,13 +167,13 @@ export async function getYahooOptionQuote({
     ask: contract.ask,
     mark,
     name: contract.contractSymbol,
-    lastUpdated: contract.lastTradeDate > 0
-      ? contract.lastTradeDate * 1000
-      : Date.now(),
+    lastUpdated,
     exchangeName: "OPTIONS",
     fullExchangeName: "OPTIONS",
     listingExchangeName: "OPTIONS",
     listingExchangeFullName: "OPTIONS",
+    marketState,
+    sessionConfidence: marketState ? "derived" : "unknown",
     dataSource: "delayed",
   };
 }


### PR DESCRIPTION
## Summary

- mute portfolio last prices after the market closes while keeping percentage direction softly visible
- propagate Yahoo option session state without another upstream request
- refresh stale broker option session references and preserve non-session fallback fields during provider outages
- cover regular-to-closed transitions, quiet option marks, and closed-session colors

## Root cause

Option-chain responses included the underlying market state, but option quote mappers discarded it. Broker-backed rows therefore had no session metadata, and cached regular-session references could survive a forced refresh.

## Validation

- `bun test src/sources/yahoo-finance.test.ts src/sources/provider-router/financials.test.ts src/sources/provider-router/index.test.ts src/plugins/builtin/portfolio-list/metrics.test.ts` (58 passed)
- `bun run build` including packaged binary smoke test
- live Yahoo option quote returned `CLOSED` with derived confidence
- broad suite reached 1,465 passes; 11 unrelated renderer timing failures reproduce on the unchanged base branch