### PR TITLE
Prevent stalled market data loading

### DIFF
--- a/src/api-client/request.test.ts
+++ b/src/api-client/request.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { CloudApiRequestTransport } from "./request";
+
+function responseWithBody(body: () => Promise<string>): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    text: body,
+  } as Response;
+}
+
+describe("CloudApiRequestTransport market deadlines", () => {
+  test("aborts when response headers never arrive", async () => {
+    let signal: AbortSignal | null | undefined;
+    const transport = new CloudApiRequestTransport({
+      marketRequestTimeoutMs: 10,
+      fetchTransport: async (_url, init) => {
+        signal = init?.signal;
+        return new Promise<Response>(() => {});
+      },
+    });
+
+    await expect(transport.request("/market/quote?symbol=AAPL")).rejects.toThrow(
+      "Cloud market request timed out after 10ms",
+    );
+    expect(signal?.aborted).toBe(true);
+  });
+
+  test("keeps the deadline active while reading the response body", async () => {
+    let signal: AbortSignal | null | undefined;
+    const transport = new CloudApiRequestTransport({
+      marketRequestTimeoutMs: 10,
+      fetchTransport: async (_url, init) => {
+        signal = init?.signal;
+        return responseWithBody(async () => new Promise<string>(() => {}));
+      },
+    });
+
+    await expect(transport.request("/market/history?symbol=AAPL")).rejects.toThrow(
+      "Cloud market request timed out after 10ms",
+    );
+    expect(signal?.aborted).toBe(true);
+  });
+
+  test("preserves a caller abort instead of replacing it with the market deadline", async () => {
+    let fetchCalls = 0;
+    const controller = new AbortController();
+    controller.abort(new Error("cancelled by caller"));
+    const transport = new CloudApiRequestTransport({
+      marketRequestTimeoutMs: 100,
+      fetchTransport: async () => {
+        fetchCalls += 1;
+        return responseWithBody(async () => "{}");
+      },
+    });
+
+    await expect(transport.request("/market/quote?symbol=AAPL", {
+      signal: controller.signal,
+    })).rejects.toThrow("cancelled by caller");
+    expect(fetchCalls).toBe(0);
+  });
+});

--- a/src/api-client/request.ts
+++ b/src/api-client/request.ts
@@ -1,7 +1,9 @@
 import { httpFetch } from "../utils/http-transport";
+import { withDeadline } from "../utils/async-deadline";
 import { ApiRequestError, parseApiErrorMessage } from "./errors";
 
 const DEFAULT_API_URL = "https://api.gloom.sh";
+const DEFAULT_MARKET_REQUEST_TIMEOUT_MS = 10_000;
 const SESSION_COOKIE_NAMES = ["__Secure-gloomberb.session_token", "gloomberb.session_token"] as const;
 
 type CloudApiResponse = Pick<Response, "ok" | "status" | "headers" | "text">;
@@ -21,12 +23,27 @@ function getCloudApiBaseUrl(): string {
   return process.env.GLOOMBERB_API_URL ?? DEFAULT_API_URL;
 }
 
+function throwIfRequestAborted(signal: AbortSignal | null | undefined): void {
+  if (!signal?.aborted) return;
+  throw signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+}
+
 export class CloudApiRequestTransport {
   private sessionToken: string | null = null;
   private sessionCookieName: SessionCookieName | null = null;
   private websocketToken: string | null = null;
+  private readonly fetchTransport: CloudApiFetchTransport | null;
+  private readonly marketRequestTimeoutMs: number;
 
   readonly baseUrl = getCloudApiBaseUrl();
+
+  constructor(options: {
+    fetchTransport?: CloudApiFetchTransport;
+    marketRequestTimeoutMs?: number;
+  } = {}) {
+    this.fetchTransport = options.fetchTransport ?? null;
+    this.marketRequestTimeoutMs = options.marketRequestTimeoutMs ?? DEFAULT_MARKET_REQUEST_TIMEOUT_MS;
+  }
 
   getSessionToken(): string | null {
     return this.sessionToken;
@@ -61,6 +78,37 @@ export class CloudApiRequestTransport {
   }
 
   async request<T>(path: string, options?: RequestInit): Promise<T> {
+    if (!path.startsWith("/market/")) {
+      return this.performRequest<T>(path, options);
+    }
+
+    const controller = new AbortController();
+    const callerSignal = options?.signal;
+    const abortFromCaller = () => controller.abort(callerSignal?.reason);
+    if (callerSignal?.aborted) {
+      abortFromCaller();
+    } else {
+      callerSignal?.addEventListener("abort", abortFromCaller, { once: true });
+    }
+
+    try {
+      const request = this.performRequest<T>(path, {
+        ...options,
+        signal: controller.signal,
+      });
+      return await withDeadline(
+        request,
+        this.marketRequestTimeoutMs,
+        `Cloud market request timed out after ${this.marketRequestTimeoutMs}ms: ${path}`,
+        (error) => controller.abort(error),
+      );
+    } finally {
+      callerSignal?.removeEventListener("abort", abortFromCaller);
+    }
+  }
+
+  private async performRequest<T>(path: string, options?: RequestInit): Promise<T> {
+    throwIfRequestAborted(options?.signal);
     const headers = new Headers(options?.headers);
     if (!headers.has("Content-Type") && options?.method && options.method !== "GET") {
       headers.set("Content-Type", "application/json");
@@ -68,21 +116,21 @@ export class CloudApiRequestTransport {
     this.setSessionCookieHeader(headers);
     headers.set("Origin", this.baseUrl);
 
-    const res = await cloudApiFetchTransport(`${this.baseUrl}${path}`, {
+    const res = await (this.fetchTransport ?? cloudApiFetchTransport)(`${this.baseUrl}${path}`, {
       ...options,
       headers,
       credentials: "include",
     });
-
+    throwIfRequestAborted(options?.signal);
     this.extractSessionCookie(res);
+    const text = await res.text();
+    throwIfRequestAborted(options?.signal);
 
     if (!res.ok) {
-      const body = await res.text();
-      const msg = parseApiErrorMessage(body);
+      const msg = parseApiErrorMessage(text);
       throw new ApiRequestError(msg, res.status);
     }
 
-    const text = await res.text();
     if (!text) return undefined as T;
     const parsed = JSON.parse(text) as T & { token?: string };
     if (typeof parsed?.token === "string" && parsed.token.length > 0) {

--- a/src/renderers/electrobun/bun/desktop/http-fetch.test.ts
+++ b/src/renderers/electrobun/bun/desktop/http-fetch.test.ts
@@ -39,4 +39,18 @@ describe("handleHttpFetch", () => {
     expect(response.headers.location).toBe("/reader");
     expect(response.setCookie).toEqual(["substack.sid=sid123; Path=/; HttpOnly"]);
   });
+
+  test("aborts the backend fetch at the requested deadline", async () => {
+    server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Promise<Response>(() => {});
+      },
+    });
+
+    await expect(handleHttpFetch({
+      url: server.url.toString(),
+      init: { timeoutMs: 10 },
+    })).rejects.toThrow();
+  });
 });

--- a/src/renderers/electrobun/bun/desktop/http-fetch.ts
+++ b/src/renderers/electrobun/bun/desktop/http-fetch.ts
@@ -34,12 +34,20 @@ export async function handleHttpFetch(payload: Record<string, unknown>) {
     typeof init.body === "string" && method !== "GET" && method !== "HEAD"
       ? init.body
       : undefined;
+  const timeoutMs =
+    typeof init.timeoutMs === "number"
+      && Number.isFinite(init.timeoutMs)
+      && init.timeoutMs > 0
+      && init.timeoutMs <= 120_000
+      ? init.timeoutMs
+      : undefined;
 
   const response = await fetch(url, {
     method,
     headers: normalizeHttpFetchHeaders(init.headers),
     body,
     redirect,
+    signal: timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined,
   });
   const responseHeaders: Record<string, string> = {};
   response.headers.forEach((value, key) => {

--- a/src/renderers/electrobun/view/http-fetch.ts
+++ b/src/renderers/electrobun/view/http-fetch.ts
@@ -11,6 +11,8 @@ interface ElectrobunHttpFetchResponse {
   body: string;
 }
 
+const CLOUD_MARKET_HTTP_TIMEOUT_MS = 10_000;
+
 function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {
   const normalized: Record<string, string> = {};
   if (!headers) return normalized;
@@ -75,7 +77,11 @@ async function electrobunHttpFetch(url: string, init?: RequestInit): Promise<Res
   return fetchResponse;
 }
 
-async function requestBackendHttpFetch(url: string, init?: RequestInit): Promise<ElectrobunHttpFetchResponse> {
+async function requestBackendHttpFetch(
+  url: string,
+  init?: RequestInit,
+  timeoutMs?: number,
+): Promise<ElectrobunHttpFetchResponse> {
   return backendRequest<ElectrobunHttpFetchResponse>("http.fetch", {
     url,
     init: {
@@ -83,6 +89,7 @@ async function requestBackendHttpFetch(url: string, init?: RequestInit): Promise
       headers: normalizeHeaders(init?.headers),
       body: await serializeBody(init?.body),
       redirect: init?.redirect,
+      timeoutMs,
     },
   });
 }
@@ -100,7 +107,13 @@ function createResponseHeaders(headers: Record<string, string>, setCookie: strin
 }
 
 async function electrobunCloudApiFetch(url: string, init?: RequestInit): Promise<Response> {
-  const response = await requestBackendHttpFetch(url, init);
+  if (init?.signal?.aborted) {
+    throw createAbortError();
+  }
+  const timeoutMs = new URL(url).pathname.startsWith("/market/")
+    ? CLOUD_MARKET_HTTP_TIMEOUT_MS
+    : undefined;
+  const response = await withAbort(requestBackendHttpFetch(url, init, timeoutMs), init?.signal);
 
   return {
     ok: response.status >= 200 && response.status < 300,

--- a/src/renderers/electrobun/view/remote/asset-data-client.ts
+++ b/src/renderers/electrobun/view/remote/asset-data-client.ts
@@ -3,9 +3,11 @@ import type { NewsArticle, NewsQuery } from "../../../../news/types";
 import type { DataProvider, QuoteSubscriptionTarget } from "../../../../types/data-provider";
 import type { Quote, TickerFinancials } from "../../../../types/financials";
 import { backendRequest, getElectrobunBackendInitSnapshot, onCapabilityEvent } from "../backend-rpc";
+import { createCapabilityInvoker } from "./capability-invoker";
 
 const ASSET_DATA_CAPABILITY_ID = "asset-data.asset-data-router";
 const NEWS_CAPABILITY_ID = "news.core";
+const ASSET_DATA_REQUEST_TIMEOUT_MS = 115_000;
 
 export type RemoteAssetDataClient = DataProvider & {
   getNews(query: NewsQuery): Promise<NewsArticle[]>;
@@ -64,23 +66,12 @@ function hasRendererOperation(operations: Set<string> | null, operationId: strin
   return operations === null || operations.has(operationId);
 }
 
-function createCapabilityInvoker() {
-  const inFlightRequests = new Map<string, Promise<unknown>>();
-  return function invoke<T>(capabilityId: string, operationId: string, payload: unknown): Promise<T> {
-    const requestPayload = { capabilityId, operationId, payload };
-    const key = JSON.stringify(requestPayload);
-    const inFlight = inFlightRequests.get(key);
-    if (inFlight) return inFlight as Promise<T>;
-    const promise = backendRequest<T>("capability.invoke", requestPayload).finally(() => {
-      inFlightRequests.delete(key);
-    });
-    inFlightRequests.set(key, promise);
-    return promise;
-  };
-}
-
 export function createRemoteAssetDataClient(): RemoteAssetDataClient {
-  const invoke = createCapabilityInvoker();
+  const invoke = createCapabilityInvoker({
+    request: backendRequest,
+    shouldApplyDeadline: (capabilityId) => capabilityId === ASSET_DATA_CAPABILITY_ID,
+    timeoutMs: ASSET_DATA_REQUEST_TIMEOUT_MS,
+  });
   const assetDataOperations = getRendererOperationIds(ASSET_DATA_CAPABILITY_ID);
   const newsOperations = getRendererOperationIds(NEWS_CAPABILITY_ID);
   let nextSubscriptionId = 1;

--- a/src/renderers/electrobun/view/remote/capability-invoker.test.ts
+++ b/src/renderers/electrobun/view/remote/capability-invoker.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { createCapabilityInvoker } from "./capability-invoker";
+
+describe("createCapabilityInvoker", () => {
+  test("keeps timed-out calls deduped until the raw backend request settles", async () => {
+    let requestCount = 0;
+    const rawResolvers: Array<(value: unknown) => void> = [];
+    const invoke = createCapabilityInvoker({
+      request: <T>() => {
+        requestCount += 1;
+        return new Promise<T>((resolve) => {
+          rawResolvers.push((value) => resolve(value as T));
+        });
+      },
+      shouldApplyDeadline: (capabilityId) => capabilityId.startsWith("asset-data."),
+      timeoutMs: 10,
+    });
+    const payload = { ticker: "AAPL", exchange: "NASDAQ" };
+
+    const first = invoke("asset-data.asset-data-router", "getQuote", payload);
+    const duplicate = invoke("asset-data.asset-data-router", "getQuote", payload);
+    expect(duplicate).toBe(first);
+    expect(requestCount).toBe(1);
+    await expect(first).rejects.toThrow("Asset data request timed out after 10ms");
+
+    const retryWhileRawPending = invoke(
+      "asset-data.asset-data-router",
+      "getQuote",
+      payload,
+    );
+    expect(retryWhileRawPending).toBe(first);
+    await expect(retryWhileRawPending).rejects.toThrow(
+      "Asset data request timed out after 10ms",
+    );
+    expect(requestCount).toBe(1);
+
+    rawResolvers[0]?.({ price: 100 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const retryAfterRawSettles = invoke(
+      "asset-data.asset-data-router",
+      "getQuote",
+      payload,
+    );
+    expect(requestCount).toBe(2);
+    rawResolvers[1]?.({ price: 101 });
+    await expect(retryAfterRawSettles).resolves.toEqual({ price: 101 });
+  });
+});

--- a/src/renderers/electrobun/view/remote/capability-invoker.ts
+++ b/src/renderers/electrobun/view/remote/capability-invoker.ts
@@ -1,0 +1,36 @@
+import { withDeadline } from "../../../../utils/async-deadline";
+
+type CapabilityRequest = <T>(method: string, payload: unknown) => Promise<T>;
+
+export function createCapabilityInvoker(options: {
+  request: CapabilityRequest;
+  shouldApplyDeadline(capabilityId: string): boolean;
+  timeoutMs: number;
+}) {
+  const inFlightRequests = new Map<string, Promise<unknown>>();
+
+  return function invoke<T>(capabilityId: string, operationId: string, payload: unknown): Promise<T> {
+    const requestPayload = { capabilityId, operationId, payload };
+    const key = JSON.stringify(requestPayload);
+    const inFlight = inFlightRequests.get(key);
+    if (inFlight) return inFlight as Promise<T>;
+
+    const request = options.request<T>("capability.invoke", requestPayload);
+    const boundedRequest = options.shouldApplyDeadline(capabilityId)
+      ? withDeadline(
+        request,
+        options.timeoutMs,
+        `Asset data request timed out after ${options.timeoutMs}ms: ${operationId}`,
+      )
+      : request;
+    inFlightRequests.set(key, boundedRequest);
+    void request.finally(() => {
+      if (inFlightRequests.get(key) === boundedRequest) {
+        inFlightRequests.delete(key);
+      }
+    }).catch(() => {
+      // The returned bounded request owns error delivery to the caller.
+    });
+    return boundedRequest;
+  };
+}

--- a/src/sources/provider-router/index.test.ts
+++ b/src/sources/provider-router/index.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { CloudApiRequestTransport } from "../../api-client/request";
 import { AppPersistence } from "../../data/app-persistence";
 import { AssetDataRouter } from "./index";
 import { assetDataProvider } from "../../capabilities";
@@ -26,6 +27,59 @@ afterEach(() => {
 });
 
 describe("AssetDataRouter", () => {
+  test("falls through to Yahoo quotes and history when Cloud market requests never settle", async () => {
+    const cloudCalls = { quote: 0, history: 0 };
+    const yahooCalls = { quote: 0, history: 0 };
+    const cloudTransport = new CloudApiRequestTransport({
+      marketRequestTimeoutMs: 10,
+      fetchTransport: async () => new Promise<Response>(() => {}),
+    });
+    const cloudProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "gloomberb-cloud",
+      name: "Cloud",
+      priority: 100,
+      async getQuote() {
+        cloudCalls.quote += 1;
+        await cloudTransport.request("/market/quote?symbol=AAPL");
+        throw new Error("unreachable");
+      },
+      async getPriceHistory() {
+        cloudCalls.history += 1;
+        await cloudTransport.request("/market/history?symbol=AAPL&range=1Y");
+        throw new Error("unreachable");
+      },
+    };
+    const yahooProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      priority: 1000,
+      async getQuote() {
+        yahooCalls.quote += 1;
+        return makeQuote({ providerId: "yahoo", price: 212.5 });
+      },
+      async getPriceHistory() {
+        yahooCalls.history += 1;
+        return [
+          { date: new Date("2026-07-10T00:00:00Z"), close: 210 },
+          { date: new Date("2026-07-11T00:00:00Z"), close: 212.5 },
+        ];
+      },
+    };
+    const router = new AssetDataRouter(yahooProvider, [cloudProvider]);
+    console.error = () => {};
+
+    const quote = await router.getQuote("AAPL", "NASDAQ");
+    const history = await router.getPriceHistory("AAPL", "NASDAQ", "1Y");
+
+    expect(quote.providerId).toBe("yahoo");
+    expect(quote.price).toBe(212.5);
+    expect(history.map((point) => point.close)).toEqual([210, 212.5]);
+    expect(cloudCalls).toEqual({ quote: 1, history: 1 });
+    expect(yahooCalls).toEqual({ quote: 1, history: 1 });
+  });
+
   test("serves USD exchange rate locally without provider revalidation", async () => {
     let providerCalls = 0;
     const router = new AssetDataRouter({

--- a/src/utils/async-deadline.ts
+++ b/src/utils/async-deadline.ts
@@ -1,0 +1,26 @@
+export class OperationTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TimeoutError";
+  }
+}
+
+export function withDeadline<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+  onTimeout?: (error: OperationTimeoutError) => void,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      const error = new OperationTimeoutError(message);
+      reject(error);
+      onTimeout?.(error);
+    }, timeoutMs);
+  });
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}


### PR DESCRIPTION
## What

- bound Cloud market REST requests across headers and response bodies
- abort desktop backend market fetches at the same deadline
- preserve Yahoo quote and chart-history fallback after Cloud stalls
- bound desktop asset-data RPCs without duplicating raw backend work

## Why

A Cloud market request could remain pending forever, which kept chart and quote single-flight entries in loading state and prevented the existing Yahoo fallback from running.

## Checks

- `bun test` (1,429 passed)
- `bun run desktop:view:build`
- `git diff --check`