### PR TITLE
Fix startup pane sync race

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -268,6 +268,7 @@ function AppInner({
 
   useCloudSyncRuntime({
     state,
+    getState: getRemoteState,
     dispatch,
     tickerRepository,
     pluginRegistry,

--- a/src/sync/controller.test.ts
+++ b/src/sync/controller.test.ts
@@ -1,8 +1,24 @@
 import { expect, test } from "bun:test";
-import type { AppState } from "../core/state/app/state";
+import {
+  appReducer,
+  createInitialState,
+  type AppAction,
+  type AppState,
+} from "../core/state/app/state";
 import type { TickerRepository } from "../data/ticker-repository";
+import { createDefaultConfig } from "../types/config";
+import {
+  __syncContributorInternalsForTests,
+  coreConfigSyncContributor,
+} from "./core-contributors";
 import { CloudSyncController } from "./controller";
-import type { SyncTransport } from "./types";
+import {
+  SYNC_SNAPSHOT_SCHEMA_VERSION,
+  type SyncContributor,
+  type SyncSnapshot,
+  type SyncSnapshotResponse,
+  type SyncTransport,
+} from "./types";
 
 test("does not push local state when the initial pull fails", async () => {
   let pushes = 0;
@@ -17,7 +33,7 @@ test("does not push local state when the initial pull fails", async () => {
   };
   const controller = new CloudSyncController();
   controller.setRuntime({
-    state: {} as AppState,
+    getState: () => ({} as AppState),
     dispatch: () => {},
     tickerRepository: {} as TickerRepository,
     getContributors: () => [],
@@ -28,4 +44,108 @@ test("does not push local state when the initial pull fails", async () => {
 
   expect(pushes).toBe(0);
   expect(controller.getStatus()).toMatchObject({ phase: "error", error: "pull failed" });
+});
+
+test("keeps startup layout changes while serializing pull and push", async () => {
+  let state = createInitialState(createDefaultConfig("/tmp/gloomberb-sync-controller-test"));
+  const dispatch = (action: AppAction) => {
+    state = appReducer(state, action);
+  };
+  let resolvePull!: (response: SyncSnapshotResponse) => void;
+  const deferredPull = new Promise<SyncSnapshotResponse>((resolve) => {
+    resolvePull = resolve;
+  });
+  let pulls = 0;
+  const pushes: Array<{
+    snapshot: SyncSnapshot;
+    options?: { baseRevision?: number | null };
+  }> = [];
+  const transport: SyncTransport = {
+    id: "deferred-pull",
+    isAvailable: () => true,
+    pullSnapshot: () => {
+      pulls += 1;
+      return deferredPull;
+    },
+    pushSnapshot: async (snapshot, options) => {
+      pushes.push({ snapshot, options });
+      return { revision: 8, updatedAt: "2026-07-13T10:00:08.000Z" };
+    },
+  };
+  const contributor: SyncContributor = {
+    ...coreConfigSyncContributor,
+    apply: (payload, context) => {
+      const config = __syncContributorInternalsForTests.mergeConfigPayload(
+        context.state.config,
+        payload,
+        context.baselineState.config,
+      );
+      if (config) context.dispatch({ type: "SET_CONFIG", config });
+    },
+  };
+  const controller = new CloudSyncController();
+  controller.setRuntime({
+    getState: () => state,
+    dispatch,
+    tickerRepository: {} as TickerRepository,
+    getContributors: () => [{ pluginId: "test", contributor }],
+    getTransport: () => ({ pluginId: "test", transport }),
+  });
+
+  const startupSync = controller.requestSync({ reason: "startup" });
+  const startupPane = {
+    instanceId: "help:startup",
+    paneId: "help",
+    binding: { kind: "none" as const },
+  };
+  const localLayout = {
+    ...state.config.layout,
+    instances: [...state.config.layout.instances, startupPane],
+    floating: [
+      ...state.config.layout.floating,
+      { instanceId: startupPane.instanceId, x: 4, y: 3, width: 60, height: 20 },
+    ],
+  };
+  dispatch({
+    type: "SET_CONFIG",
+    config: {
+      ...state.config,
+      layout: localLayout,
+      layouts: state.config.layouts.map((saved, index) => (
+        index === state.config.activeLayoutIndex ? { ...saved, layout: localLayout } : saved
+      )),
+    },
+  });
+  const queuedPush = controller.requestSync({ reason: "state-change" });
+
+  const remoteConfig = createDefaultConfig("/remote/path-is-not-synced");
+  remoteConfig.theme = "green";
+  resolvePull({
+    snapshot: {
+      schemaVersion: SYNC_SNAPSHOT_SCHEMA_VERSION,
+      appId: "gloomberb",
+      clientId: "remote-client",
+      createdAt: "2026-07-13T10:00:07.000Z",
+      contributors: {
+        "core.config": {
+          schemaVersion: 1,
+          updatedAt: "2026-07-13T10:00:07.000Z",
+          payload: __syncContributorInternalsForTests.collectCoreConfigPayload(remoteConfig),
+        },
+      },
+    },
+    revision: 7,
+    updatedAt: "2026-07-13T10:00:07.000Z",
+  });
+  await Promise.all([startupSync, queuedPush]);
+
+  const pushedConfig = pushes[0]?.snapshot.contributors["core.config"]?.payload as {
+    layout: AppState["config"]["layout"];
+  };
+  expect(pulls).toBe(1);
+  expect(pushes).toHaveLength(1);
+  expect(pushes[0]?.options).toEqual({ baseRevision: 7 });
+  expect(state.config.theme).toBe("green");
+  expect(state.config.layout.instances).toContainEqual(startupPane);
+  expect(pushedConfig.layout.instances).toContainEqual(startupPane);
 });

--- a/src/sync/controller.ts
+++ b/src/sync/controller.ts
@@ -23,7 +23,7 @@ export interface CloudSyncStatus {
 }
 
 interface SyncRuntime {
-  state: AppState;
+  getState: () => AppState;
   dispatch: Dispatch<AppAction>;
   tickerRepository: TickerRepository;
   getContributors: () => RegisteredSyncContributor[];
@@ -32,7 +32,6 @@ interface SyncRuntime {
 
 const CLIENT_ID_STORAGE_KEY = "gloomberb.sync.clientId";
 const PUSH_DEBOUNCE_MS = 2500;
-const PULL_MIN_INTERVAL_MS = 60_000;
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -47,6 +46,15 @@ function resolveClientId(): string {
   return id;
 }
 
+function snapshotContentSignature(snapshot: SyncSnapshot): string {
+  return stableStringify(Object.fromEntries(
+    Object.entries(snapshot.contributors).map(([id, contributor]) => [
+      id,
+      { schemaVersion: contributor.schemaVersion, payload: contributor.payload },
+    ]),
+  ));
+}
+
 export class CloudSyncController {
   private runtime: SyncRuntime | null = null;
   private contributors = new Map<string, RegisteredSyncContributor>();
@@ -57,7 +65,6 @@ export class CloudSyncController {
   private syncQueued = false;
   private clientId: string | null = null;
   private lastSignature: string | null = null;
-  private lastPulledAtMs = 0;
   private hasPulledForTransport = new Set<string>();
   private status: CloudSyncStatus = {
     phase: "idle",
@@ -100,16 +107,20 @@ export class CloudSyncController {
     return [...this.transports.values()];
   }
 
-  setRuntime(runtime: SyncRuntime): void {
-    this.runtime = runtime;
-    this.updateAvailability();
+  setRuntime(runtime: SyncRuntime): () => void {
+    if (this.runtime !== runtime) {
+      this.resetOperations();
+      this.runtime = runtime;
+      this.updateAvailability();
+    }
+    return () => this.clearRuntime(runtime);
   }
 
-  clearRuntime(): void {
+  clearRuntime(runtime?: SyncRuntime): void {
+    if (runtime && this.runtime !== runtime) return;
     this.runtime = null;
-    if (this.pushTimer) clearTimeout(this.pushTimer);
-    this.pushTimer = null;
-    this.syncQueued = false;
+    this.resetOperations();
+    this.setStatus({ phase: "disabled", transportId: null, error: null });
   }
 
   subscribe(listener: () => void): () => void {
@@ -124,11 +135,11 @@ export class CloudSyncController {
   schedulePush(reason: string): void {
     const runtime = this.runtime;
     if (!runtime) return;
-    const transport = runtime.getTransport();
-    if (!transport?.transport.isAvailable()) {
+    const registration = runtime.getTransport();
+    if (!registration?.transport.isAvailable()) {
       this.setStatus({
         phase: "disabled",
-        transportId: transport?.transport.id ?? null,
+        transportId: registration?.transport.id ?? null,
         error: null,
       });
       return;
@@ -146,6 +157,7 @@ export class CloudSyncController {
       return this.inFlight;
     }
     const run = this.syncOnce(options).finally(async () => {
+      if (this.inFlight !== run) return;
       this.inFlight = null;
       if (!this.syncQueued) return;
       this.syncQueued = false;
@@ -155,42 +167,36 @@ export class CloudSyncController {
     return run;
   }
 
-  async pullLatest(options: { force?: boolean } = {}): Promise<void> {
-    const runtime = this.runtime;
-    if (!runtime) return;
-    const transport = runtime.getTransport();
-    if (!transport?.transport.isAvailable()) {
-      this.setStatus({ phase: "disabled", transportId: transport?.transport.id ?? null, error: null });
-      return;
-    }
-    const currentMs = Date.now();
-    if (!options.force && currentMs - this.lastPulledAtMs < PULL_MIN_INTERVAL_MS) return;
-    if (await this.runPull(runtime, transport.transport)) {
-      this.lastPulledAtMs = currentMs;
-    }
-  }
-
   private async syncOnce(options: { reason?: string; force?: boolean }): Promise<void> {
     const runtime = this.runtime;
     if (!runtime) return;
-    const transportRegistration = runtime.getTransport();
-    if (!transportRegistration?.transport.isAvailable()) {
-      this.setStatus({ phase: "disabled", transportId: transportRegistration?.transport.id ?? null, error: null });
+    const registration = runtime.getTransport();
+    if (!registration?.transport.isAvailable()) {
+      this.setStatus({
+        phase: "disabled",
+        transportId: registration?.transport.id ?? null,
+        error: null,
+      });
       return;
     }
-    const transport = transportRegistration.transport;
+    const transport = registration.transport;
+
     if (!this.hasPulledForTransport.has(transport.id)) {
+      this.lastSignature = null;
       if (!await this.runPull(runtime, transport)) return;
+      if (!this.isCurrent(runtime, transport)) return;
       this.hasPulledForTransport.add(transport.id);
     }
 
     const snapshot = await this.assembleSnapshot(runtime);
-    const signature = stableStringify(snapshot.contributors);
+    if (!this.isCurrent(runtime, transport)) return;
+    const signature = snapshotContentSignature(snapshot);
     if (!options.force && signature === this.lastSignature) return;
 
     this.setStatus({ phase: "syncing", transportId: transport.id, error: null });
     try {
       const result = await transport.pushSnapshot(snapshot, { baseRevision: this.status.revision });
+      if (!this.isCurrent(runtime, transport)) return;
       this.lastSignature = signature;
       this.setStatus({
         phase: "synced",
@@ -200,6 +206,7 @@ export class CloudSyncController {
         error: null,
       });
     } catch (error) {
+      if (!this.isCurrent(runtime, transport)) return;
       this.setStatus({
         phase: "error",
         transportId: transport.id,
@@ -209,9 +216,30 @@ export class CloudSyncController {
   }
 
   private async runPull(runtime: SyncRuntime, transport: SyncTransport): Promise<boolean> {
+    const baselineState = runtime.getState();
     this.setStatus({ phase: "syncing", transportId: transport.id, error: null });
     try {
       const response = await transport.pullSnapshot();
+      if (!this.isCurrent(runtime, transport)) return false;
+
+      if (response.snapshot) {
+        for (const entry of runtime.getContributors()) {
+          if (!this.isCurrent(runtime, transport)) return false;
+          const payload = response.snapshot.contributors[entry.contributor.id]?.payload;
+          if (payload === undefined || !entry.contributor.apply) continue;
+          await entry.contributor.apply(payload, {
+            snapshot: response.snapshot,
+            baselineState,
+            state: runtime.getState(),
+            getState: runtime.getState,
+            isCurrent: () => this.isCurrent(runtime, transport),
+            dispatch: runtime.dispatch,
+            tickerRepository: runtime.tickerRepository,
+          });
+        }
+      }
+
+      if (!this.isCurrent(runtime, transport)) return false;
       this.setStatus({
         phase: response.snapshot ? "synced" : "idle",
         transportId: transport.id,
@@ -220,19 +248,9 @@ export class CloudSyncController {
         lastSyncAt: response.updatedAt,
         error: null,
       });
-      if (!response.snapshot) return true;
-      for (const entry of runtime.getContributors()) {
-        const payload = response.snapshot.contributors[entry.contributor.id]?.payload;
-        if (payload === undefined || !entry.contributor.apply) continue;
-        await entry.contributor.apply(payload, {
-          snapshot: response.snapshot,
-          state: runtime.state,
-          dispatch: runtime.dispatch,
-          tickerRepository: runtime.tickerRepository,
-        });
-      }
       return true;
     } catch (error) {
+      if (!this.isCurrent(runtime, transport)) return false;
       this.setStatus({
         phase: "error",
         transportId: transport.id,
@@ -247,7 +265,7 @@ export class CloudSyncController {
     const createdAt = nowIso();
     const payloads: SyncSnapshot["contributors"] = {};
     for (const entry of contributors) {
-      const payload = await entry.contributor.collect({ state: runtime.state });
+      const payload = await entry.contributor.collect({ state: runtime.getState() });
       payloads[entry.contributor.id] = {
         schemaVersion: entry.contributor.schemaVersion,
         updatedAt: createdAt,
@@ -261,6 +279,19 @@ export class CloudSyncController {
       createdAt,
       contributors: payloads,
     };
+  }
+
+  private isCurrent(runtime: SyncRuntime, transport: SyncTransport): boolean {
+    return this.runtime === runtime && runtime.getTransport()?.transport === transport;
+  }
+
+  private resetOperations(): void {
+    if (this.pushTimer) clearTimeout(this.pushTimer);
+    this.pushTimer = null;
+    this.inFlight = null;
+    this.syncQueued = false;
+    this.hasPulledForTransport.clear();
+    this.lastSignature = null;
   }
 
   private updateAvailability(): void {

--- a/src/sync/core-contributors.ts
+++ b/src/sync/core-contributors.ts
@@ -1,4 +1,5 @@
 import { scheduleConfigSave } from "../state/config-save-scheduler";
+import { stableStringify } from "../remote/revision";
 import type { AppConfig, BrokerInstanceConfig } from "../types/config";
 import type { PricePoint, TickerFinancials } from "../types/financials";
 import type { Portfolio, TickerMetadata, TickerPosition, TickerRecord, Watchlist } from "../types/ticker";
@@ -295,20 +296,30 @@ function collectCoreCollectionsPayload(
   };
 }
 
-function mergeConfigPayload(config: AppConfig, payload: unknown): AppConfig | null {
+function valuesEqual(left: unknown, right: unknown): boolean {
+  return stableStringify(left) === stableStringify(right);
+}
+
+function mergeConfigPayload(
+  config: AppConfig,
+  payload: unknown,
+  baselineConfig: AppConfig = config,
+): AppConfig | null {
   if (!isPlainObject(payload)) return null;
   const next: AppConfig = { ...config };
+  const canApply = <K extends keyof AppConfig>(key: K) => (
+    valuesEqual(config[key], baselineConfig[key])
+  );
   const assign = <K extends keyof AppConfig>(key: K) => {
-    if (key in payload) {
+    if (key in payload && canApply(key)) {
       next[key] = payload[key as string] as AppConfig[K];
     }
   };
 
   assign("baseCurrency");
   assign("refreshIntervalMinutes");
-  assign("layout");
-  assign("layouts");
-  assign("activeLayoutIndex");
+  assign("portfolios");
+  assign("watchlists");
   assign("disabledPlugins");
   assign("disabledSources");
   assign("pluginConfig");
@@ -318,9 +329,21 @@ function mergeConfigPayload(config: AppConfig, payload: unknown): AppConfig | nu
   assign("recentTickers");
   assign("onboardingComplete");
 
-  if (Array.isArray(payload.portfolios)) next.portfolios = payload.portfolios as Portfolio[];
-  if (Array.isArray(payload.watchlists)) next.watchlists = payload.watchlists as Watchlist[];
-  if (Array.isArray(payload.brokerInstances)) {
+  if (
+    ["layout", "layouts", "activeLayoutIndex"].every((key) => (
+      key in payload &&
+      valuesEqual(
+        config[key as keyof AppConfig],
+        baselineConfig[key as keyof AppConfig],
+      )
+    ))
+  ) {
+    next.layout = payload.layout as unknown as AppConfig["layout"];
+    next.layouts = payload.layouts as AppConfig["layouts"];
+    next.activeLayoutIndex = payload.activeLayoutIndex as number;
+  }
+
+  if (Array.isArray(payload.brokerInstances) && canApply("brokerInstances")) {
     const incoming = payload.brokerInstances as Array<Partial<BrokerInstanceConfig>>;
     const existingById = new Map(config.brokerInstances.map((instance) => [instance.id, instance]));
     next.brokerInstances = incoming.map((instance) => {
@@ -343,9 +366,9 @@ export const coreConfigSyncContributor: SyncContributor = {
   id: "core.config",
   schemaVersion: 1,
   collect: ({ state }) => collectCoreConfigPayload(state.config),
-  apply: (payload, { state, dispatch }) => {
-    const nextConfig = mergeConfigPayload(state.config, payload);
-    if (!nextConfig) return;
+  apply: (payload, { baselineState, state, dispatch }) => {
+    const nextConfig = mergeConfigPayload(state.config, payload, baselineState.config);
+    if (!nextConfig || valuesEqual(nextConfig, state.config)) return;
     dispatch({ type: "SET_CONFIG", config: nextConfig });
     scheduleConfigSave(nextConfig);
   },
@@ -360,18 +383,15 @@ export const coreCollectionsSyncContributor: SyncContributor = {
     state.financials,
     state.exchangeRates,
   ),
-  apply: async (payload, { state, dispatch, tickerRepository }) => {
+  apply: async (payload, { getState, isCurrent, dispatch, tickerRepository }) => {
     if (!isPlainObject(payload)) return;
-    const nextConfig = { ...state.config };
-    if (Array.isArray(payload.portfolios)) nextConfig.portfolios = payload.portfolios as Portfolio[];
-    if (Array.isArray(payload.watchlists)) nextConfig.watchlists = payload.watchlists as Watchlist[];
-
-    const nextTickers = new Map(state.tickers);
+    const incomingRecords: TickerRecord[] = [];
     const rawTickers = Array.isArray(payload.tickers) ? payload.tickers : [];
     for (const rawTicker of rawTickers) {
+      if (!isCurrent()) return;
       if (!isPlainObject(rawTicker)) continue;
       const current = typeof rawTicker.ticker === "string"
-        ? nextTickers.get(rawTicker.ticker)
+        ? getState().tickers.get(rawTicker.ticker)
         : null;
       const metadata = hydrateTickerMetadata({
         ...current?.metadata,
@@ -380,12 +400,15 @@ export const coreCollectionsSyncContributor: SyncContributor = {
       });
       const record: TickerRecord = { metadata };
       await tickerRepository.saveTicker(record);
-      nextTickers.set(metadata.ticker, record);
+      incomingRecords.push(record);
     }
 
-    dispatch({ type: "SET_CONFIG", config: nextConfig });
+    if (!isCurrent() || incomingRecords.length === 0) return;
+    const nextTickers = new Map(getState().tickers);
+    for (const record of incomingRecords) {
+      nextTickers.set(record.metadata.ticker, record);
+    }
     dispatch({ type: "SET_TICKERS", tickers: nextTickers });
-    scheduleConfigSave(nextConfig);
   },
 };
 
@@ -397,4 +420,5 @@ export const __syncContributorInternalsForTests = {
   sanitizeUnknown,
   collectCoreConfigPayload,
   collectCoreCollectionsPayload,
+  mergeConfigPayload,
 };

--- a/src/sync/react.ts
+++ b/src/sync/react.ts
@@ -6,6 +6,7 @@ import { cloudSyncController } from "./controller";
 
 interface CloudSyncRuntimeOptions {
   state: AppState;
+  getState: () => AppState;
   dispatch: Dispatch<AppAction>;
   tickerRepository: TickerRepository;
   pluginRegistry: PluginRegistry;
@@ -14,28 +15,25 @@ interface CloudSyncRuntimeOptions {
 
 export function useCloudSyncRuntime({
   state,
+  getState,
   dispatch,
   tickerRepository,
   pluginRegistry,
   initialized,
 }: CloudSyncRuntimeOptions): void {
   useEffect(() => {
-    cloudSyncController.setRuntime({
-      state,
+    return cloudSyncController.setRuntime({
+      getState,
       dispatch,
       tickerRepository,
       getContributors: () => pluginRegistry.getEnabledSyncContributors(),
       getTransport: () => pluginRegistry.getActiveSyncTransport(),
     });
-  }, [dispatch, pluginRegistry, state, tickerRepository]);
-
-  useEffect(() => () => {
-    cloudSyncController.clearRuntime();
-  }, []);
+  }, [dispatch, getState, pluginRegistry, tickerRepository]);
 
   useEffect(() => {
     if (!initialized) return;
-    void cloudSyncController.pullLatest();
+    void cloudSyncController.requestSync({ reason: "startup" });
   }, [initialized, pluginRegistry]);
 
   useEffect(() => {

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -25,7 +25,10 @@ export interface SyncCollectContext {
 
 export interface SyncApplyContext {
   snapshot: SyncSnapshot;
+  baselineState: AppState;
   state: AppState;
+  getState: () => AppState;
+  isCurrent: () => boolean;
   dispatch: Dispatch<AppAction>;
   tickerRepository: TickerRepository;
 }


### PR DESCRIPTION
## What changed

- serialize startup cloud sync as one pull, apply, and push transaction
- merge remote configuration against the pull baseline so panes opened during startup win locally
- treat the active layout fields atomically and keep collection sync from writing duplicate config
- add a delayed-pull regression test covering a pane opened before startup sync completes

## Root cause

The startup pull and the state-triggered push could run independently. The pull applied a configuration snapshot captured before the user opened a pane, so the stale remote layout could replace the live layout several seconds after launch.

## Verification

- `bun test` — 1430 tests passed
- `bun run build`
- delayed 8-second sync through the real TUI path: Help pane remained open and persisted, with one snapshot pull and one push
