### PR TITLE
Fix AI CLI discovery and readiness checks

### DIFF
--- a/src/cli/commands/automation.ts
+++ b/src/cli/commands/automation.ts
@@ -1,4 +1,5 @@
-import { detectProviders, getAiProvider } from "../../plugins/builtin/ai/providers";
+import { discoverAiCliProviders } from "../../plugins/builtin/ai/cli-readiness";
+import { getAiProviderUnavailableReason } from "../../plugins/builtin/ai/providers";
 import { runAiPrompt } from "../../plugins/builtin/ai/runner";
 import { createRssNewsCapability } from "../../plugins/builtin/news/wire/rss/source";
 import type { CliCommandDef } from "../../types/plugin";
@@ -91,24 +92,35 @@ export const aiCliCommand: CliCommandDef = {
   execute: async (args, ctx) => {
     const action = args[0] ?? "providers";
     if (action === "providers") {
-      ctx.printResult({ data: detectProviders().map((provider) => ({
+      const providers = await discoverAiCliProviders({ cwd: process.cwd() });
+      ctx.printResult({ data: providers.map(({ provider }) => ({
         id: provider.id,
         name: provider.name,
         command: provider.command,
         available: provider.available,
+        status: provider.status,
+        unavailableReason: provider.unavailableReason,
       })) });
       return;
     }
     if (action === "ask") {
       const rawArgs = args.slice(1);
-      const providerId = takeOption(rawArgs, "--provider") ?? detectProviders().find((provider) => provider.available)?.id;
-      const selectedProvider = getAiProvider(providerId) ?? ctx.fail("Unknown AI provider.");
-      if (!selectedProvider.available) ctx.fail(`${selectedProvider.name} is not installed or not available in PATH.`);
+      const providers = await discoverAiCliProviders({ cwd: process.cwd() });
+      const providerId = takeOption(rawArgs, "--provider")
+        ?? providers.find(({ provider }) => provider.available)?.provider.id;
+      const selected = providers.find(({ provider }) => provider.id === providerId)
+        ?? ctx.fail("Unknown AI provider.");
+      if (!selected.provider.available) ctx.fail(getAiProviderUnavailableReason(selected.provider));
       const prompt = rawArgs.join(" ").trim();
       if (!prompt) ctx.fail("Usage: gloomberb ai ask [--provider id] <prompt>");
-      const controller = runAiPrompt({ provider: selectedProvider, prompt, cwd: process.cwd() });
+      const controller = runAiPrompt({
+        provider: selected.provider,
+        prompt,
+        cwd: process.cwd(),
+        environment: selected.environment,
+      });
       const text = await controller.done;
-      ctx.printResult({ data: { provider: selectedProvider.id, text } });
+      ctx.printResult({ data: { provider: selected.provider.id, text } });
       return;
     }
     if (action === "screen") {

--- a/src/plugins/builtin/ai/ask-ai-detail-tab.tsx
+++ b/src/plugins/builtin/ai/ask-ai-detail-tab.tsx
@@ -12,7 +12,14 @@ import { MarkdownText } from "../../../components/markdown-text";
 import { getMessageComposerBlockHeight, MessageComposer, Spinner, usePaneFooter } from "../../../components";
 import { colors } from "../../../theme/colors";
 import { buildTickerAiContext } from "./ticker-context";
-import { detectProviders, getAvailableProviders, resolveDefaultAiProviderId, __setDetectedProvidersForTests, type AiProvider } from "./providers";
+import {
+  detectProviders,
+  getAiProviderUnavailableLabel,
+  getAvailableProviders,
+  resolveDefaultAiProviderId,
+  __setDetectedProvidersForTests,
+  type AiProvider,
+} from "./providers";
 import { runAiPrompt } from "./runner";
 
 interface ChatMessage {
@@ -283,11 +290,19 @@ export function AskAiResearchTab({ width, height, focused, onCapture }: TickerRe
   if (availableProviders.length === 0) {
     return (
       <Box flexDirection="column" paddingX={1} flexGrow={1}>
-        <Text fg={colors.textDim}>No AI CLI tools detected. Install one of:</Text>
+        <Text fg={colors.textDim}>No AI CLI tools are ready:</Text>
         <Box height={1} />
-        <Text fg={colors.text}>  claude  - Claude Code (claude.ai/claude-code)</Text>
-        <Text fg={colors.text}>  gemini  - Gemini CLI (github.com/google-gemini/gemini-cli)</Text>
-        <Text fg={colors.text}>  codex   - OpenAI Codex (github.com/openai/codex)</Text>
+        {providers.length > 0 ? providers.map((provider) => (
+          <Text key={provider.id} fg={colors.text}>
+            {`  ${provider.command.padEnd(7)} - ${provider.name}: ${getAiProviderUnavailableLabel(provider)}`}
+          </Text>
+        )) : (
+          <>
+            <Text fg={colors.text}>  claude  - Claude: missing</Text>
+            <Text fg={colors.text}>  gemini  - Gemini: missing</Text>
+            <Text fg={colors.text}>  codex   - Codex: missing</Text>
+          </>
+        )}
       </Box>
     );
   }

--- a/src/plugins/builtin/ai/ask-ai.test.tsx
+++ b/src/plugins/builtin/ai/ask-ai.test.tsx
@@ -120,7 +120,7 @@ describe("AskAiTab", () => {
     await flushFrame();
 
     const frame = testSetup.captureCharFrame();
-    expect(frame).toContain("No AI CLI tools detected.");
+    expect(frame).toContain("No AI CLI tools are ready:");
     expect(frame).toContain("claude");
     expect(frame).toContain("gemini");
     expect(frame).toContain("codex");

--- a/src/plugins/builtin/ai/cli-readiness.test.ts
+++ b/src/plugins/builtin/ai/cli-readiness.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { delimiter } from "path";
+import { discoverAiCliProviders, resolveAiCliSearchPath } from "./cli-readiness";
+
+describe("AI CLI readiness", () => {
+  test("recovers GUI paths and verifies every provider without sending prompts", async () => {
+    const userBin = "/Users/test/.local/bin";
+    const basePath = ["/usr/bin", "/bin"].join(delimiter);
+    const recoveredPath = [userBin, basePath].join(delimiter);
+    const commands: string[][] = [];
+
+    const providers = await discoverAiCliProviders({
+      env: { HOME: "/Users/test", PATH: basePath, SHELL: "/bin/zsh" },
+      homeDir: "/Users/test",
+      platform: "darwin",
+      recoverLoginShellPath: true,
+      loadLoginShellEnvironment: async () => ({
+        PATH: recoveredPath,
+        GEMINI_API_KEY: "configured-in-login-shell",
+      }),
+      which: (command, searchPath) => (
+        searchPath.includes(userBin) ? `${userBin}/${command}` : null
+      ),
+      runCommand: async (executable, args, options) => {
+        commands.push([executable, ...args]);
+        expect(options.env.PATH).toContain(userBin);
+        expect(options.env.GEMINI_API_KEY).toBe("configured-in-login-shell");
+        return executable.endsWith("/claude")
+          ? { exitCode: 0, stdout: '{"loggedIn":true}', stderr: "" }
+          : { exitCode: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    expect(providers.map(({ provider }) => ({
+      id: provider.id,
+      available: provider.available,
+      command: provider.command,
+    }))).toEqual([
+      { id: "claude", available: true, command: `${userBin}/claude` },
+      { id: "gemini", available: true, command: `${userBin}/gemini` },
+      { id: "codex", available: true, command: `${userBin}/codex` },
+    ]);
+    expect(commands).toEqual([
+      [`${userBin}/claude`, "auth", "status", "--json"],
+      [`${userBin}/gemini`, "--list-extensions"],
+      [`${userBin}/codex`, "login", "status"],
+    ]);
+  });
+
+  test("distinguishes missing commands from installed but logged-out commands", async () => {
+    const providers = await discoverAiCliProviders({
+      searchPath: "/tools",
+      platform: "darwin",
+      homeDir: "/Users/test",
+      which: (command) => command === "gemini" ? null : `/tools/${command}`,
+      runCommand: async (executable) => executable.endsWith("/claude")
+        ? { exitCode: 0, stdout: '{"loggedIn":false}', stderr: "" }
+        : { exitCode: 1, stdout: "", stderr: "Not logged in" },
+    });
+
+    expect(providers.map(({ provider }) => [provider.id, provider.status])).toEqual([
+      ["claude", "not_authenticated"],
+      ["gemini", "missing"],
+      ["codex", "not_authenticated"],
+    ]);
+    expect(providers.every(({ provider }) => !provider.available)).toBe(true);
+  });
+
+  test("falls back to common user install directories when shell startup fails", async () => {
+    const searchPath = await resolveAiCliSearchPath({
+      searchPath: ["/usr/bin", "/bin"].join(delimiter),
+      platform: "darwin",
+      homeDir: "/Users/test",
+      recoverLoginShellPath: true,
+      loadLoginShellEnvironment: async () => {
+        throw new Error("broken shell profile");
+      },
+    });
+
+    expect(searchPath.split(delimiter)).toEqual(expect.arrayContaining([
+      "/Users/test/.local/bin",
+      "/Users/test/.bun/bin",
+      "/Users/test/.claude/local",
+      "/opt/homebrew/bin",
+      "/usr/bin",
+      "/bin",
+    ]));
+    expect(searchPath.split(delimiter).filter((entry) => entry === "/usr/bin")).toHaveLength(1);
+  });
+});

--- a/src/plugins/builtin/ai/cli-readiness.ts
+++ b/src/plugins/builtin/ai/cli-readiness.ts
@@ -1,0 +1,279 @@
+import { homedir } from "os";
+import { delimiter, join } from "path";
+import { withDeadline } from "../../../utils/async-deadline";
+import {
+  getAiProviderDefinitions,
+  type AiProvider,
+  type AiProviderAvailability,
+  type AiProviderDefinition,
+} from "./providers";
+
+const LOGIN_SHELL_ENV_MARKER = "__GLOOMBERB_LOGIN_ENV__";
+const LOGIN_SHELL_TIMEOUT_MS = 3_000;
+const AUTH_PROBE_TIMEOUT_MS = 8_000;
+
+interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+interface RunCommandOptions {
+  cwd?: string;
+  env: NodeJS.ProcessEnv;
+  timeoutMs: number;
+}
+
+type CommandRunner = (
+  executable: string,
+  args: string[],
+  options: RunCommandOptions,
+) => Promise<CommandResult>;
+
+interface AuthProbe {
+  args: string[];
+  loginCommand: string;
+  isReady(result: CommandResult): boolean;
+}
+
+const AUTH_PROBES: Record<string, AuthProbe> = {
+  claude: {
+    args: ["auth", "status", "--json"],
+    loginCommand: "claude auth login",
+    isReady(result) {
+      if (result.exitCode !== 0) return false;
+      const start = result.stdout.indexOf("{");
+      const end = result.stdout.lastIndexOf("}");
+      if (start < 0 || end < start) return false;
+      try {
+        return JSON.parse(result.stdout.slice(start, end + 1)).loggedIn === true;
+      } catch {
+        return false;
+      }
+    },
+  },
+  gemini: {
+    // Gemini has no auth-status command. This command performs its normal
+    // non-interactive auth validation and OAuth refresh, then exits before a
+    // prompt is sent.
+    args: ["--list-extensions"],
+    loginCommand: "gemini",
+    isReady: (result) => result.exitCode === 0,
+  },
+  codex: {
+    args: ["login", "status"],
+    loginCommand: "codex login",
+    isReady: (result) => result.exitCode === 0,
+  },
+};
+
+export interface ResolvedAiProvider {
+  provider: AiProvider;
+  environment: NodeJS.ProcessEnv;
+}
+
+export interface DiscoverAiCliProvidersOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  platform?: NodeJS.Platform;
+  recoverLoginShellPath?: boolean;
+  searchPath?: string;
+  which?: (command: string, searchPath: string) => string | null;
+  runCommand?: CommandRunner;
+  loadLoginShellEnvironment?: (basePath: string) => Promise<NodeJS.ProcessEnv | null>;
+}
+
+function mergeSearchPaths(paths: Array<string | null | undefined>): string {
+  const entries: string[] = [];
+  const seen = new Set<string>();
+  for (const path of paths) {
+    for (const entry of path?.split(delimiter) ?? []) {
+      const trimmed = entry.trim();
+      if (!trimmed || seen.has(trimmed)) continue;
+      seen.add(trimmed);
+      entries.push(trimmed);
+    }
+  }
+  return entries.join(delimiter);
+}
+
+async function runCommand(
+  executable: string,
+  args: string[],
+  options: RunCommandOptions,
+): Promise<CommandResult> {
+  const child = Bun.spawn([executable, ...args], {
+    cwd: options.cwd,
+    env: options.env,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return withDeadline(
+    (async () => {
+      const [exitCode, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+      return { exitCode, stdout, stderr };
+    })(),
+    options.timeoutMs,
+    `${executable} readiness check timed out`,
+    () => {
+      try {
+        child.kill();
+      } catch {
+        // Process may already have exited.
+      }
+    },
+  );
+}
+
+async function readLoginShellEnvironment(
+  basePath: string,
+  env: NodeJS.ProcessEnv,
+  runner: CommandRunner,
+): Promise<NodeJS.ProcessEnv | null> {
+  const shell = env.SHELL || "/bin/zsh";
+  const result = await runner(
+    shell,
+    ["-ilc", `printf '\\0${LOGIN_SHELL_ENV_MARKER}\\0'; env -0`],
+    {
+      env: { ...env, PATH: basePath },
+      timeoutMs: LOGIN_SHELL_TIMEOUT_MS,
+    },
+  );
+  if (result.exitCode !== 0) return null;
+  const marker = `\0${LOGIN_SHELL_ENV_MARKER}\0`;
+  const markerIndex = result.stdout.lastIndexOf(marker);
+  if (markerIndex < 0) return null;
+
+  const loginEnvironment: NodeJS.ProcessEnv = {};
+  for (const entry of result.stdout.slice(markerIndex + marker.length).split("\0")) {
+    const separator = entry.indexOf("=");
+    if (separator <= 0) continue;
+    loginEnvironment[entry.slice(0, separator)] = entry.slice(separator + 1);
+  }
+  return loginEnvironment;
+}
+
+export async function resolveAiCliEnvironment(
+  options: DiscoverAiCliProvidersOptions = {},
+): Promise<NodeJS.ProcessEnv> {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const basePath = options.searchPath ?? env.PATH ?? "";
+  const home = options.homeDir ?? env.HOME ?? homedir();
+  const runner = options.runCommand ?? runCommand;
+  let loginEnvironment: NodeJS.ProcessEnv | null = null;
+
+  if (options.recoverLoginShellPath && platform !== "win32") {
+    try {
+      loginEnvironment = await (options.loadLoginShellEnvironment
+        ? options.loadLoginShellEnvironment(basePath)
+        : readLoginShellEnvironment(basePath, env, runner));
+    } catch {
+      loginEnvironment = null;
+    }
+  }
+
+  const commonUserPaths = options.recoverLoginShellPath && platform !== "win32"
+    ? [
+        join(home, ".local", "bin"),
+        join(home, ".bun", "bin"),
+        join(home, ".claude", "local"),
+        join(home, ".volta", "bin"),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+      ]
+    : [];
+
+  return {
+    ...env,
+    ...loginEnvironment,
+    PATH: mergeSearchPaths([loginEnvironment?.PATH, ...commonUserPaths, basePath]),
+  };
+}
+
+export async function resolveAiCliSearchPath(
+  options: DiscoverAiCliProvidersOptions = {},
+): Promise<string> {
+  return (await resolveAiCliEnvironment(options)).PATH ?? "";
+}
+
+function missingAvailability(provider: AiProviderDefinition): AiProviderAvailability {
+  return {
+    available: false,
+    status: "missing",
+    unavailableReason: `${provider.name} is not installed or was not found in PATH.`,
+  };
+}
+
+function unauthenticatedAvailability(
+  provider: AiProviderDefinition,
+  probe: AuthProbe,
+): AiProviderAvailability {
+  return {
+    available: false,
+    status: "not_authenticated",
+    unavailableReason: `${provider.name} is installed but is not authenticated. Run ${probe.loginCommand} in a terminal.`,
+  };
+}
+
+function failedCheckAvailability(provider: AiProviderDefinition): AiProviderAvailability {
+  return {
+    available: false,
+    status: "check_failed",
+    unavailableReason: `${provider.name} is installed, but Gloomberb could not verify that it is ready.`,
+  };
+}
+
+export async function discoverAiCliProviders(
+  options: DiscoverAiCliProvidersOptions = {},
+): Promise<ResolvedAiProvider[]> {
+  const environment = await resolveAiCliEnvironment(options);
+  const searchPath = environment.PATH ?? "";
+  const runner = options.runCommand ?? runCommand;
+  const which = options.which ?? ((command, path) => Bun.which(command, { PATH: path }));
+
+  return Promise.all(getAiProviderDefinitions().map(async (definition) => {
+    const executable = which(definition.command, searchPath);
+    if (!executable) {
+      return {
+        provider: { ...definition, ...missingAvailability(definition) },
+        environment,
+      };
+    }
+
+    const probe = AUTH_PROBES[definition.id];
+    if (!probe) {
+      return {
+        provider: { ...definition, command: executable, ...failedCheckAvailability(definition) },
+        environment,
+      };
+    }
+
+    try {
+      const result = await runner(executable, probe.args, {
+        cwd: options.cwd,
+        env: environment,
+        timeoutMs: AUTH_PROBE_TIMEOUT_MS,
+      });
+      const availability = probe.isReady(result)
+        ? { available: true, status: "ready" as const }
+        : unauthenticatedAvailability(definition, probe);
+      return {
+        provider: { ...definition, command: executable, ...availability },
+        environment,
+      };
+    } catch {
+      return {
+        provider: { ...definition, command: executable, ...failedCheckAvailability(definition) },
+        environment,
+      };
+    }
+  }));
+}

--- a/src/plugins/builtin/ai/providers.ts
+++ b/src/plugins/builtin/ai/providers.ts
@@ -3,10 +3,20 @@ export interface AiProvider {
   name: string;
   command: string;
   available: boolean;
+  status?: AiProviderStatus;
+  unavailableReason?: string;
   buildArgs: (prompt: string) => string[];
 }
 
-export interface AiProviderDefinition extends Omit<AiProvider, "available"> {}
+export type AiProviderStatus = "ready" | "missing" | "not_authenticated" | "check_failed";
+
+export interface AiProviderAvailability {
+  available: boolean;
+  status: AiProviderStatus;
+  unavailableReason?: string;
+}
+
+export interface AiProviderDefinition extends Omit<AiProvider, "available" | "status" | "unavailableReason"> {}
 
 const PROVIDER_DEFS: AiProviderDefinition[] = [
   {
@@ -47,9 +57,22 @@ export function detectProviders(): AiProvider[] {
 
   detectedProviders = PROVIDER_DEFS.map((definition) => ({
     ...definition,
-    available: commandExists(definition.command),
+    ...availabilityFromCommand(definition, commandExists(definition.command)),
   }));
   return detectedProviders;
+}
+
+function availabilityFromCommand(
+  provider: AiProviderDefinition,
+  available: boolean,
+): AiProviderAvailability {
+  return available
+    ? { available: true, status: "ready" }
+    : {
+        available: false,
+        status: "missing",
+        unavailableReason: `${provider.name} is not installed or was not found in PATH.`,
+      };
 }
 
 export function getAvailableProviders(providers = detectProviders()): AiProvider[] {
@@ -63,6 +86,17 @@ export function getAiProvider(providerId: string | null | undefined, providers =
 
 export function resolveDefaultAiProviderId(providers = detectProviders()): string {
   return getAvailableProviders(providers)[0]?.id ?? providers[0]?.id ?? "claude";
+}
+
+export function getAiProviderUnavailableReason(provider: AiProvider): string {
+  return provider.unavailableReason
+    ?? `${provider.name} is not installed, not authenticated, or not available in PATH.`;
+}
+
+export function getAiProviderUnavailableLabel(provider: AiProvider): string {
+  if (provider.status === "not_authenticated") return "sign in";
+  if (provider.status === "check_failed") return "unavailable";
+  return "missing";
 }
 
 export function __setDetectedProvidersForTests(providers: AiProvider[] | null): void {

--- a/src/plugins/builtin/ai/runner.test.ts
+++ b/src/plugins/builtin/ai/runner.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { delimiter, join } from "path";
+import type { AiProvider } from "./providers";
+import { runAiPrompt, setAiRunHost } from "./runner";
+
+afterEach(() => {
+  setAiRunHost(null);
+});
+
+describe("AI runner", () => {
+  test("passes the recovered PATH to executables that use env shebangs", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "gloomberb-ai-runner-"));
+    try {
+      const interpreter = join(directory, "gloomberb-test-interpreter");
+      const executable = join(directory, "fake-ai");
+      await writeFile(interpreter, "#!/bin/sh\nexec /bin/sh \"$@\"\n");
+      await writeFile(executable, "#!/usr/bin/env gloomberb-test-interpreter\nprintf ready\n");
+      await chmod(interpreter, 0o755);
+      await chmod(executable, 0o755);
+
+      const provider: AiProvider = {
+        id: "fake",
+        name: "Fake",
+        command: executable,
+        available: true,
+        status: "ready",
+        buildArgs: () => [],
+      };
+      const run = runAiPrompt({
+        provider,
+        prompt: "unused",
+        environment: {
+          ...process.env,
+          PATH: [directory, "/usr/bin", "/bin"].join(delimiter),
+        },
+      });
+
+      expect(await run.done).toBe("ready");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/plugins/builtin/ai/runner.ts
+++ b/src/plugins/builtin/ai/runner.ts
@@ -17,6 +17,7 @@ export interface AiRunHost {
     provider: AiProvider;
     prompt: string;
     cwd?: string;
+    environment?: NodeJS.ProcessEnv;
     onChunk?: (output: string) => void;
   }): AiRunController;
 }
@@ -35,11 +36,13 @@ function runWithBun({
   provider,
   prompt,
   cwd = typeof process !== "undefined" ? process.cwd() : ".",
+  environment,
   onChunk,
 }: {
   provider: AiProvider;
   prompt: string;
   cwd?: string;
+  environment?: NodeJS.ProcessEnv;
   onChunk?: (output: string) => void;
 }): AiRunController {
   type BunSubprocess = ReturnType<typeof Bun.spawn>;
@@ -56,6 +59,7 @@ function runWithBun({
   const done = (async () => {
     const proc = Bun.spawn([provider.command, ...provider.buildArgs(prompt)], {
       cwd,
+      env: environment,
       stdin: "ignore",
       stdout: "pipe",
       stderr: "pipe",
@@ -108,12 +112,14 @@ export function runAiPrompt({
   provider,
   prompt,
   cwd,
+  environment,
   onChunk,
 }: {
   provider: AiProvider;
   prompt: string;
   cwd?: string;
+  environment?: NodeJS.ProcessEnv;
   onChunk?: (output: string) => void;
 }): AiRunController {
-  return (configuredHost ?? { run: runWithBun }).run({ provider, prompt, cwd, onChunk });
+  return (configuredHost ?? { run: runWithBun }).run({ provider, prompt, cwd, environment, onChunk });
 }

--- a/src/plugins/builtin/ai/screener/editor.tsx
+++ b/src/plugins/builtin/ai/screener/editor.tsx
@@ -3,7 +3,11 @@ import { useEffect } from "react";
 import { Box, Text, Textarea, type TextareaRenderable } from "../../../../ui";
 import { Button, SegmentedControl } from "../../../../components";
 import { colors } from "../../../../theme/colors";
-import type { AiProvider } from "../providers";
+import {
+  getAiProviderUnavailableLabel,
+  getAiProviderUnavailableReason,
+  type AiProvider,
+} from "../providers";
 import type { ScreenerEditorState } from "./model";
 
 function ScreenerPromptEditor({
@@ -87,7 +91,9 @@ export function AiScreenerEditorView({
           value={editorState.providerId}
           options={selectableProviders.map((provider) => ({
             value: provider.id,
-            label: provider.available ? provider.name : `${provider.name} (missing)`,
+            label: provider.available
+              ? provider.name
+              : `${provider.name} (${getAiProviderUnavailableLabel(provider)})`,
           }))}
           onChange={onProviderChange}
         />
@@ -116,7 +122,7 @@ export function AiScreenerEditorView({
       <Box flexDirection="column" paddingX={1}>
         <Text fg={colors.textDim}>
           {editorProvider?.available === false
-            ? `${editorProvider.name} is not currently installed. Save and switch later.`
+            ? `${getAiProviderUnavailableReason(editorProvider)} Save and switch later.`
             : "Click a provider chip to switch. Save to keep the draft."}
         </Text>
       </Box>

--- a/src/plugins/builtin/ai/screener/runner.ts
+++ b/src/plugins/builtin/ai/screener/runner.ts
@@ -4,7 +4,7 @@ import type { TickerRecord } from "../../../../types/ticker";
 import type { AppAction } from "../../../../core/state/app/types";
 import { buildGloomberbCliInstructions, resolveGloomberbCliCommand } from "../gloomberb-cli";
 import type { AiProvider } from "../providers";
-import { getAiProvider } from "../providers";
+import { getAiProvider, getAiProviderUnavailableReason } from "../providers";
 import { isAiRunCancelled, runAiPrompt, type AiRunController } from "../runner";
 import {
   buildScreenerPrompt,
@@ -56,7 +56,7 @@ export function useAiScreenerRunner({
     if (!provider.available) {
       upsertTab(tab.id, (current) => ({
         ...current,
-        lastError: `${provider.name} is not installed or not available in PATH.`,
+        lastError: getAiProviderUnavailableReason(provider),
       }));
       return;
     }

--- a/src/renderers/electrobun/bun/core-capabilities.ts
+++ b/src/renderers/electrobun/bun/core-capabilities.ts
@@ -8,7 +8,8 @@ import {
   type PluginCapability,
 } from "../../../capabilities";
 import type { AppServices } from "../../../core/app-services";
-import { getAiProviderDefinitions } from "../../../plugins/builtin/ai/providers";
+import { discoverAiCliProviders } from "../../../plugins/builtin/ai/cli-readiness";
+import type { AiProviderAvailability } from "../../../plugins/builtin/ai/providers";
 import { isAiRunCancelled, runAiPrompt } from "../../../plugins/builtin/ai/runner";
 import type { BrokerAdapter } from "../../../types/broker";
 import type { AppConfig, BrokerInstanceConfig } from "../../../types/config";
@@ -265,41 +266,52 @@ function createNotesFilesCapability(): PluginCapability {
   };
 }
 
-function getAiProviderAvailability(): Record<string, boolean> {
-  const availability: Record<string, boolean> = {};
-  const hasBunWhich = typeof Bun !== "undefined" && typeof Bun.which === "function";
-  for (const definition of getAiProviderDefinitions()) {
-    availability[definition.id] = hasBunWhich ? !!Bun.which(definition.command) : false;
-  }
-  return availability;
-}
-
 function createAiRunnerCapability(options: CoreCapabilityOptions): PluginCapability {
+  let providersPromise: ReturnType<typeof discoverAiCliProviders> | null = null;
+  const getProviders = () => {
+    providersPromise ??= discoverAiCliProviders({
+      cwd: options.getConfig().dataDir,
+      recoverLoginShellPath: process.platform === "darwin",
+    });
+    return providersPromise;
+  };
+
   return {
     id: AI_RUNNER_CAPABILITY_ID,
     kind: "ai-runner",
     name: "AI Runner",
     operations: {
-      getProviderAvailability: op(() => getAiProviderAvailability()),
-      run: stream((input: any, emit) => {
+      getProviderAvailability: op(async () => {
+        const providers = await getProviders();
+        return Object.fromEntries(providers.map(({ provider }) => [
+          provider.id,
+          {
+            available: provider.available,
+            status: provider.status ?? (provider.available ? "ready" : "check_failed"),
+            unavailableReason: provider.unavailableReason,
+          } satisfies AiProviderAvailability,
+        ]));
+      }),
+      run: stream(async (input: any, emit) => {
         const providerId = requireString(input.providerId, "AI provider");
         const prompt = requireString(input.prompt, "AI prompt");
-        const providerDefinition = getAiProviderDefinitions().find((entry) => entry.id === providerId);
-        if (!providerDefinition) {
+        const resolvedProvider = (await getProviders()).find(({ provider }) => provider.id === providerId);
+        if (!resolvedProvider) {
           throw new Error(`Unknown AI provider: ${providerId}`);
         }
-        if (typeof Bun === "undefined" || typeof Bun.which !== "function" || !Bun.which(providerDefinition.command)) {
-          throw new Error(`${providerDefinition.name} is not installed on this system.`);
+        if (!resolvedProvider.provider.available) {
+          throw new Error(
+            resolvedProvider.provider.unavailableReason
+              ?? `${resolvedProvider.provider.name} is not ready.`,
+          );
         }
 
         let disposed = false;
         const controller = runAiPrompt({
-          provider: {
-            ...providerDefinition,
-            available: true,
-          },
+          provider: resolvedProvider.provider,
           prompt,
           cwd: optionalString(input.cwd) ?? options.getConfig().dataDir,
+          environment: resolvedProvider.environment,
           onChunk: (output) => {
             if (!disposed) emit({ kind: "chunk", output });
           },

--- a/src/renderers/electrobun/view/ai-host.ts
+++ b/src/renderers/electrobun/view/ai-host.ts
@@ -5,6 +5,7 @@ import {
 import {
   getAiProviderDefinitions,
   __setDetectedProvidersForTests,
+  type AiProviderAvailability,
 } from "../../../plugins/builtin/ai/providers";
 import { AiRunCancelledError, setAiRunHost } from "../../../plugins/builtin/ai/runner";
 import { backendRequest, onCapabilityEvent } from "./backend-rpc";
@@ -12,14 +13,18 @@ import { backendRequest, onCapabilityEvent } from "./backend-rpc";
 let nextRunId = 1;
 
 export async function installElectrobunAiHost(): Promise<void> {
-  const availability = await backendRequest<Record<string, boolean>>("capability.invoke", {
+  const availability = await backendRequest<Record<string, AiProviderAvailability>>("capability.invoke", {
     capabilityId: AI_RUNNER_CAPABILITY_ID,
     operationId: "getProviderAvailability",
     payload: {},
   });
   const providers = getAiProviderDefinitions().map((definition) => ({
     ...definition,
-    available: availability[definition.id] ?? false,
+    ...(availability[definition.id] ?? {
+      available: false,
+      status: "check_failed" as const,
+      unavailableReason: `${definition.name} readiness could not be checked.`,
+    }),
   }));
 
   __setDetectedProvidersForTests(providers);


### PR DESCRIPTION
## What changed

- Recover the macOS login-shell environment for desktop AI CLI discovery
- Resolve exact executables and pass the same environment when running them
- Validate Claude, Gemini, and the OpenAI CLI authentication before allowing selection
- Distinguish missing, signed-out, and failed-check states across chat, screeners, and direct CLI commands

## Why

Apps launched from Finder or the Dock inherit a minimal PATH, so tools installed in user-managed directories were reported as missing. Executable-only detection also treated signed-out tools as ready.

## Validation

- `bun test` — 1,434 passed
- `bun run desktop:view:build`
- `bun run build` — signed macOS binary smoke test passed
- `bun run desktop:build`
- Finder-style minimal-PATH smoke test with the packaged Bun runtime
