### PR TITLE
feat(ai): local agent workspace with Claude Code / Codex / Pi runtimes

### DIFF
--- a/src/plugins/builtin/ai/command-resolution.test.ts
+++ b/src/plugins/builtin/ai/command-resolution.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { getAiCliSearchPath, resolveAiCliCommand } from "./command-resolution";
+import { __setDetectedProvidersForTests, detectProviders, getAiProvider } from "./providers";
+import { runAiPrompt, setAiRunHost } from "./runner";
+
+const originalHome = process.env.HOME;
+const originalPath = process.env.PATH;
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  process.env.HOME = originalHome;
+  process.env.PATH = originalPath;
+  __setDetectedProvidersForTests(null);
+  setAiRunHost(null);
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+describe("AI CLI command resolution", () => {
+  test("augments a macOS GUI PATH with user-level and Homebrew bin directories", () => {
+    const homeDir = "/Users/example";
+    const searchPath = getAiCliSearchPath({
+      env: { PATH: "/usr/bin:/bin" },
+      homeDir,
+      platform: "darwin",
+    });
+
+    expect(searchPath.split(":")).toEqual([
+      "/usr/bin",
+      "/bin",
+      `${homeDir}/.local/bin`,
+      `${homeDir}/.bun/bin`,
+      `${homeDir}/.npm-global/bin`,
+      "/opt/homebrew/bin",
+      "/usr/local/bin",
+    ]);
+  });
+
+  test("uses the augmented PATH for both detection and execution", async () => {
+    if (process.platform === "win32") return;
+
+    const homeDir = await mkdtemp(join(tmpdir(), "gloomberb-ai-path-"));
+    temporaryDirectories.push(homeDir);
+    const binDir = join(homeDir, ".local", "bin");
+    await mkdir(binDir, { recursive: true });
+    await writeFile(join(binDir, "claude"), "#!/usr/bin/env fake-ai-runtime\n");
+    await writeFile(
+      join(binDir, "fake-ai-runtime"),
+      "#!/bin/sh\nfor argument do prompt=\"$argument\"; done\nprintf 'resolved:%s' \"$prompt\"\n",
+    );
+    await chmod(join(binDir, "claude"), 0o755);
+    await chmod(join(binDir, "fake-ai-runtime"), 0o755);
+
+    process.env.HOME = homeDir;
+    process.env.PATH = "/usr/bin:/bin";
+    __setDetectedProvidersForTests(null);
+
+    const provider = getAiProvider("claude", detectProviders());
+    expect(provider?.available).toBe(true);
+    expect(resolveAiCliCommand("claude")?.executable).toBe(join(binDir, "claude"));
+
+    const run = runAiPrompt({ provider: provider!, prompt: "AAPL" });
+    expect(await run.done).toBe("resolved:AAPL");
+  });
+});

--- a/src/plugins/builtin/ai/command-resolution.ts
+++ b/src/plugins/builtin/ai/command-resolution.ts
@@ -1,0 +1,61 @@
+import { homedir } from "os";
+import { join } from "path";
+
+interface AiCliPathOptions {
+  env?: Record<string, string | undefined>;
+  homeDir?: string;
+  platform?: NodeJS.Platform;
+}
+
+interface AiCliResolutionOptions extends AiCliPathOptions {
+  which?: (command: string, options: { PATH: string }) => string | null;
+}
+
+export interface ResolvedAiCliCommand {
+  executable: string;
+  env: Record<string, string | undefined>;
+}
+
+export function getAiCliSearchPath({
+  env = process.env,
+  homeDir = env.HOME || homedir(),
+  platform = process.platform,
+}: AiCliPathOptions = {}): string {
+  const delimiter = platform === "win32" ? ";" : ":";
+  const entries = (env.PATH ?? "").split(delimiter).filter(Boolean);
+
+  if (platform === "win32") {
+    if (env.APPDATA) entries.push(join(env.APPDATA, "npm"));
+  } else {
+    entries.push(
+      join(homeDir, ".local", "bin"),
+      join(homeDir, ".bun", "bin"),
+      join(homeDir, ".npm-global", "bin"),
+    );
+
+    if (platform === "darwin") {
+      entries.push("/opt/homebrew/bin", "/usr/local/bin");
+    } else if (platform === "linux") {
+      entries.push("/home/linuxbrew/.linuxbrew/bin", "/usr/local/bin");
+    }
+  }
+
+  return [...new Set(entries)].join(delimiter);
+}
+
+export function resolveAiCliCommand(
+  command: string,
+  options: AiCliResolutionOptions = {},
+): ResolvedAiCliCommand | null {
+  if (typeof Bun === "undefined" || typeof Bun.which !== "function") return null;
+
+  const env = options.env ?? process.env;
+  const searchPath = getAiCliSearchPath({ ...options, env });
+  const executable = (options.which ?? Bun.which)(command, { PATH: searchPath });
+  if (!executable) return null;
+
+  return {
+    executable,
+    env: { ...env, PATH: searchPath },
+  };
+}

--- a/src/plugins/builtin/ai/index.tsx
+++ b/src/plugins/builtin/ai/index.tsx
@@ -64,7 +64,7 @@ export const aiPlugin: GloomPlugin = {
       }],
       createInstance: (_context, options) => {
         const providerId = options?.values?.providerId;
-        if (providerId !== "claude" && providerId !== "codex") return null;
+        if (providerId !== "claude" && providerId !== "codex" && providerId !== "pi") return null;
         return {
           title: "Local AI",
           placement: "floating",

--- a/src/plugins/builtin/ai/index.tsx
+++ b/src/plugins/builtin/ai/index.tsx
@@ -1,8 +1,9 @@
 import type { GloomPlugin } from "../../../types/plugin";
-import { detectProviders } from "./providers";
 import { AskAiResearchTab } from "./ask-ai-detail-tab";
+import { detectProviders, getLocalWorkspaceProviders } from "./providers";
 import { AiScreenerPane } from "./screener/pane";
 import { buildAiScreenerPaneSettingsDef, getAiScreenerPaneSettings } from "./settings";
+import { LocalAgentWorkspacePane } from "./workspace/pane";
 
 export const aiPlugin: GloomPlugin = {
   id: "ai",
@@ -20,12 +21,56 @@ export const aiPlugin: GloomPlugin = {
         value: provider.id,
       }));
     const defaultProviderId = providerOptions[0]?.value ?? "claude";
+    const localWorkspaceProviders = getLocalWorkspaceProviders(detectedProviders);
+    const localWorkspaceProviderOptions = localWorkspaceProviders.map((provider) => ({
+      label: provider.available ? provider.name : `${provider.name} (not detected)`,
+      value: provider.id,
+    }));
 
     ctx.registerTickerResearchTab({
       id: "ai-chat",
       name: "Ask AI",
       order: 60,
       component: AskAiResearchTab,
+    });
+
+    ctx.registerPane({
+      id: "local-agent-workspace",
+      name: "Local AI",
+      icon: "A",
+      component: LocalAgentWorkspacePane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 96, height: 32 },
+    });
+
+    ctx.registerPaneTemplate({
+      id: "new-local-agent-workspace",
+      paneId: "local-agent-workspace",
+      label: "Local AI Workspace",
+      description: "Create a persistent local Claude Code or Codex research thread.",
+      keywords: ["ai", "agent", "claude", "codex", "local", "research", "thread"],
+      shortcut: { prefix: "AGENT" },
+      wizard: [{
+        key: "providerId",
+        label: "Local Runtime",
+        type: "select",
+        defaultValue: localWorkspaceProviderOptions[0]?.value ?? "claude",
+        options: localWorkspaceProviderOptions,
+        body: [
+          "Choose the locally authenticated runtime for this thread.",
+          "The runtime cannot be changed after creation; choose New Thread to use another one.",
+        ],
+      }],
+      createInstance: (_context, options) => {
+        const providerId = options?.values?.providerId;
+        if (providerId !== "claude" && providerId !== "codex") return null;
+        return {
+          title: "Local AI",
+          placement: "floating",
+          params: { providerId, threadId: crypto.randomUUID() },
+        };
+      },
     });
 
     ctx.registerPane({

--- a/src/plugins/builtin/ai/providers.test.ts
+++ b/src/plugins/builtin/ai/providers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getAiProviderDefinitions } from "./providers";
+import { getAiProviderDefinitions, getLocalWorkspaceProviders } from "./providers";
 
 describe("local workspace provider contracts", () => {
   test("uses supported isolated structured modes for Claude and Codex", () => {
@@ -21,5 +21,25 @@ describe("local workspace provider contracts", () => {
     expect(codexArgs).toContain("--disable");
     expect(codexArgs).toContain("shell_tool");
     expect(codexArgs).toContain("--json");
+  });
+
+  test("defines Pi structured mode without an auth-status contract", () => {
+    const definitions = getAiProviderDefinitions();
+    const pi = definitions.find((provider) => provider.id === "pi");
+    if (!pi?.buildStructuredArgs) throw new Error("Expected a structured Pi definition");
+
+    const args = pi.buildStructuredArgs("PROMPT");
+    expect(pi.name).toBe("Pi");
+    expect(pi.command).toBe("pi");
+    expect(args).toContain("--mode");
+    expect(args).toContain("json");
+    expect(args.at(-1)).toBe("PROMPT");
+    expect(pi.authCheckArgs).toBeUndefined();
+  });
+
+  test("includes Pi in the local workspace runtimes", () => {
+    const providers = getAiProviderDefinitions().map((provider) => ({ ...provider, available: true }));
+
+    expect(getLocalWorkspaceProviders(providers).map((provider) => provider.id)).toEqual(["claude", "codex", "pi"]);
   });
 });

--- a/src/plugins/builtin/ai/providers.test.ts
+++ b/src/plugins/builtin/ai/providers.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { getAiProviderDefinitions } from "./providers";
+
+describe("local workspace provider contracts", () => {
+  test("uses supported isolated structured modes for Claude and Codex", () => {
+    const definitions = getAiProviderDefinitions();
+    const claude = definitions.find((provider) => provider.id === "claude");
+    const codex = definitions.find((provider) => provider.id === "codex");
+    if (!claude?.buildStructuredArgs || !codex?.buildStructuredArgs) {
+      throw new Error("Expected structured Claude and Codex definitions");
+    }
+    const claudeArgs = claude.buildStructuredArgs("PROMPT");
+    const codexArgs = codex.buildStructuredArgs("PROMPT");
+
+    expect(claudeArgs.slice(0, 2)).toEqual(["--print", "PROMPT"]);
+    expect(claudeArgs).toContain("--safe-mode");
+    expect(claudeArgs).toContain("--no-session-persistence");
+    expect(codexArgs).toContain("--ephemeral");
+    expect(codexArgs).toContain("--ignore-user-config");
+    expect(codexArgs).toContain("--ignore-rules");
+    expect(codexArgs).toContain("--disable");
+    expect(codexArgs).toContain("shell_tool");
+    expect(codexArgs).toContain("--json");
+  });
+});

--- a/src/plugins/builtin/ai/providers.ts
+++ b/src/plugins/builtin/ai/providers.ts
@@ -63,6 +63,15 @@ const PROVIDER_DEFS: AiProviderDefinition[] = [
     authCheckArgs: ["login", "status"],
     authLoginCommand: "codex login",
   },
+  {
+    id: "pi",
+    name: "Pi",
+    command: "pi",
+    buildArgs: (prompt) => ["-p", "--mode", "text", "--offline", "--no-tools", "--no-session", "-nc", "-ne", "-ns", prompt],
+    buildStructuredArgs: (prompt) => ["-p", "--mode", "json", "--offline", "--no-tools", "--no-session", "-nc", "-ne", "-ns", prompt],
+    // No authCheckArgs: pi authenticates via config/env (no auth-status subcommand);
+    // an inconclusive/unauthenticated state surfaces at run time.
+  },
 ];
 
 let detectedProviders: AiProvider[] | null = null;
@@ -90,7 +99,7 @@ export function getAvailableProviders(providers = detectProviders()): AiProvider
 }
 
 export function getLocalWorkspaceProviders(providers = detectProviders()): AiProvider[] {
-  return providers.filter((provider) => provider.id === "claude" || provider.id === "codex");
+  return providers.filter((provider) => provider.id === "claude" || provider.id === "codex" || provider.id === "pi");
 }
 
 export function getAiProvider(providerId: string | null | undefined, providers = detectProviders()): AiProvider | null {

--- a/src/plugins/builtin/ai/providers.ts
+++ b/src/plugins/builtin/ai/providers.ts
@@ -1,9 +1,14 @@
+import { resolveAiCliCommand } from "./command-resolution";
+
 export interface AiProvider {
   id: string;
   name: string;
   command: string;
   available: boolean;
   buildArgs: (prompt: string) => string[];
+  buildStructuredArgs?: (prompt: string) => string[];
+  authCheckArgs?: string[];
+  authLoginCommand?: string;
 }
 
 export interface AiProviderDefinition extends Omit<AiProvider, "available"> {}
@@ -14,6 +19,22 @@ const PROVIDER_DEFS: AiProviderDefinition[] = [
     name: "Claude",
     command: "claude",
     buildArgs: (prompt) => ["-p", prompt],
+    buildStructuredArgs: (prompt) => [
+      "--print",
+      prompt,
+      "--verbose",
+      "--output-format",
+      "stream-json",
+      "--include-partial-messages",
+      "--no-session-persistence",
+      "--safe-mode",
+      "--tools",
+      "",
+      "--permission-mode",
+      "manual",
+    ],
+    authCheckArgs: ["auth", "status"],
+    authLoginCommand: "claude auth login",
   },
   {
     id: "gemini",
@@ -26,6 +47,21 @@ const PROVIDER_DEFS: AiProviderDefinition[] = [
     name: "Codex",
     command: "codex",
     buildArgs: (prompt) => ["exec", "--skip-git-repo-check", prompt],
+    buildStructuredArgs: (prompt) => [
+      "exec",
+      "--skip-git-repo-check",
+      "--ephemeral",
+      "--ignore-user-config",
+      "--ignore-rules",
+      "--disable",
+      "shell_tool",
+      "--sandbox",
+      "read-only",
+      "--json",
+      prompt,
+    ],
+    authCheckArgs: ["login", "status"],
+    authLoginCommand: "codex login",
   },
 ];
 
@@ -33,13 +69,10 @@ let detectedProviders: AiProvider[] | null = null;
 
 function commandExists(command: string): boolean {
   try {
-    if (typeof Bun !== "undefined" && typeof Bun.which === "function") {
-      return !!Bun.which(command);
-    }
+    return resolveAiCliCommand(command) !== null;
   } catch {
     return false;
   }
-  return false;
 }
 
 export function detectProviders(): AiProvider[] {
@@ -54,6 +87,10 @@ export function detectProviders(): AiProvider[] {
 
 export function getAvailableProviders(providers = detectProviders()): AiProvider[] {
   return providers.filter((provider) => provider.available);
+}
+
+export function getLocalWorkspaceProviders(providers = detectProviders()): AiProvider[] {
+  return providers.filter((provider) => provider.id === "claude" || provider.id === "codex");
 }
 
 export function getAiProvider(providerId: string | null | undefined, providers = detectProviders()): AiProvider | null {

--- a/src/plugins/builtin/ai/runner.test.ts
+++ b/src/plugins/builtin/ai/runner.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { chmodSync, existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AiProvider } from "./providers";
+import { checkStatusWithBun, isAiRunCancelled, runAiPrompt, setAiRunHost } from "./runner";
+
+function shellProvider(script: string): AiProvider {
+  return {
+    id: "codex",
+    name: "Codex",
+    command: "sh",
+    available: true,
+    buildArgs: () => ["-c", script],
+    buildStructuredArgs: () => ["-c", script],
+  };
+}
+
+async function fakeAuthProvider(id: string, script: string): Promise<{ provider: AiProvider; tmpPath: string }> {
+  const tmpPath = await mkdtemp(join(tmpdir(), "gloomberb-auth-check-"));
+  const command = join(tmpPath, `${id}-auth`);
+  await Bun.write(command, `#!/bin/sh\n${script}\n`);
+  chmodSync(command, 0o755);
+  return {
+    tmpPath,
+    provider: {
+      id,
+      name: id === "claude" ? "Claude" : "Codex",
+      command,
+      available: true,
+      authCheckArgs: ["auth", "status"],
+      buildArgs: () => [],
+    },
+  };
+}
+
+describe("AI provider status checks", () => {
+  test("marks a timed-out auth check as inconclusive", async () => {
+    const { provider, tmpPath } = await fakeAuthProvider("codex", "exec sleep 1");
+    try {
+      const result = await checkStatusWithBun(provider, 50);
+      expect(result).toMatchObject({ available: true, authenticated: false, inconclusive: true });
+      expect(result.message).toBeTruthy();
+    } finally {
+      await rm(tmpPath, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps a confirmed unauthenticated check conclusive", async () => {
+    const { provider, tmpPath } = await fakeAuthProvider("codex", "exit 1");
+    try {
+      const result = await checkStatusWithBun(provider, 500);
+      expect(result.available).toBe(true);
+      expect(result.authenticated).toBe(false);
+      expect(result.inconclusive).toBeFalsy();
+    } finally {
+      await rm(tmpPath, { recursive: true, force: true });
+    }
+  });
+
+  test("accepts Claude's authenticated JSON status", async () => {
+    const { provider, tmpPath } = await fakeAuthProvider("claude", `printf '%s\\n' '{"loggedIn":true}'`);
+    try {
+      const result = await checkStatusWithBun(provider, 500);
+      expect(result.authenticated).toBe(true);
+      expect(result.inconclusive).toBeFalsy();
+    } finally {
+      await rm(tmpPath, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("AI runner structured mode", () => {
+  test("converts JSONL events into cumulative display transcript", async () => {
+    const chunks: string[] = [];
+    const provider = shellProvider(`
+      printf '%s\n' '{"type":"item.completed","item":{"id":"reason","type":"reasoning","text":"hidden"}}'
+      printf '%s\n' '{"type":"item.started","item":{"id":"answer","type":"agent_message","text":"Draft"}}'
+      printf '%s\n' '{"type":"item.completed","item":{"id":"answer","type":"agent_message","text":"Final answer"}}'
+    `);
+
+    const run = runAiPrompt({
+      provider,
+      prompt: "ignored",
+      outputMode: "structured",
+      onChunk: (output) => chunks.push(output),
+    });
+
+    expect(await run.done).toBe("Final answer");
+    expect(chunks.at(-1)).toBe("Final answer");
+    expect(chunks.join(" ")).not.toContain("hidden");
+  });
+
+  test("cancellation takes precedence over process exit errors", async () => {
+    const run = runAiPrompt({
+      provider: shellProvider("sleep 5; exit 7"),
+      prompt: "ignored",
+      outputMode: "structured",
+    });
+    run.cancel();
+
+    let caught: unknown;
+    try {
+      await run.done;
+    } catch (error) {
+      caught = error;
+    }
+    expect(isAiRunCancelled(caught)).toBe(true);
+  });
+
+  test("uses and removes an empty temporary cwd for isolated workspace runs", async () => {
+    const provider = shellProvider(`printf '{"type":"item.completed","item":{"id":"answer","type":"agent_message","text":"%s"}}\\n' "$PWD"`);
+    const run = runAiPrompt({
+      provider,
+      prompt: "ignored",
+      outputMode: "structured",
+      isolatedWorkspace: true,
+    });
+
+    const isolatedPath = await run.done;
+    expect(isolatedPath).toContain("gloomberb-local-agent-");
+    expect(existsSync(isolatedPath)).toBe(false);
+  });
+
+  test("forwards structured isolation and cancellation through a configured host", async () => {
+    let received: Parameters<NonNullable<import("./runner").AiRunHost["run"]>>[0] | null = null;
+    let cancelled = false;
+    setAiRunHost({
+      run(options) {
+        received = options;
+        return {
+          done: Promise.resolve("host output"),
+          cancel: () => { cancelled = true; },
+        };
+      },
+    });
+
+    try {
+      const run = runAiPrompt({
+        provider: shellProvider("unused"),
+        prompt: "selected context only",
+        outputMode: "structured",
+        isolatedWorkspace: true,
+      });
+      run.cancel();
+      expect(await run.done).toBe("host output");
+      expect(received?.prompt).toBe("selected context only");
+      expect(received?.outputMode).toBe("structured");
+      expect(received?.isolatedWorkspace).toBe(true);
+      expect(cancelled).toBe(true);
+    } finally {
+      setAiRunHost(null);
+    }
+  });
+});

--- a/src/plugins/builtin/ai/runner.ts
+++ b/src/plugins/builtin/ai/runner.ts
@@ -1,4 +1,11 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveAiCliCommand } from "./command-resolution";
 import type { AiProvider } from "./providers";
+import { AiStructuredStreamParser } from "./stream-events";
+
+const AUTH_CHECK_TIMEOUT_MS = 15_000;
 
 export class AiRunCancelledError extends Error {
   constructor() {
@@ -18,7 +25,18 @@ export interface AiRunHost {
     prompt: string;
     cwd?: string;
     onChunk?: (output: string) => void;
+    outputMode?: "plain" | "structured";
+    isolatedWorkspace?: boolean;
   }): AiRunController;
+  checkStatus?(provider: AiProvider): Promise<AiProviderStatus>;
+}
+
+export interface AiProviderStatus {
+  available: boolean;
+  authenticated: boolean;
+  /** True when the check could not determine auth state, such as a timeout or spawn failure. */
+  inconclusive?: boolean;
+  message: string | null;
 }
 
 let configuredHost: AiRunHost | null = null;
@@ -31,16 +49,103 @@ export function isAiRunCancelled(error: unknown): boolean {
   return error instanceof AiRunCancelledError;
 }
 
+function remediationFor(provider: AiProvider, reason: "unavailable" | "unauthenticated"): string {
+  if (reason === "unavailable") {
+    return `${provider.name} is not installed or not available in PATH.`;
+  }
+  const loginCommand = provider.authLoginCommand ?? provider.command;
+  return `${provider.name} is installed but not authenticated. Run \`${loginCommand}\` in your terminal.`;
+}
+
+function sanitizeRuntimeError(value: string): string {
+  return value
+    .replace(/(bearer\s+)[^\s]+/gi, "$1[redacted]")
+    .replace(/((?:access[_ -]?token|auth[_ -]?token|oauth[_ -]?token|claude_code_oauth_token|api[_ -]?key|authorization)["']?\s*[:=]\s*["']?)[^\s"']+/gi, "$1[redacted]")
+    .trim()
+    .slice(0, 2_000);
+}
+
+export async function checkStatusWithBun(
+  provider: AiProvider,
+  timeoutMs: number = AUTH_CHECK_TIMEOUT_MS,
+): Promise<AiProviderStatus> {
+  if (typeof Bun === "undefined" || typeof Bun.spawn !== "function") {
+    return { available: false, authenticated: false, message: "Local AI status checks require a native Bun host." };
+  }
+  const resolvedCommand = resolveAiCliCommand(provider.command);
+  if (!resolvedCommand) {
+    return { available: false, authenticated: false, message: remediationFor(provider, "unavailable") };
+  }
+  if (!provider.authCheckArgs) {
+    return { available: true, authenticated: true, message: null };
+  }
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    const proc = Bun.spawn([resolvedCommand.executable, ...provider.authCheckArgs], {
+      env: resolvedCommand.env,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        try { proc.kill(); } catch { /* ignore cleanup failures */ }
+        reject(new Error(`${provider.name} authentication check timed out.`));
+      }, timeoutMs);
+    });
+    const exitCode = await Promise.race([proc.exited, timeout]);
+    const statusText = await new Response(proc.stdout).text();
+    const errorText = await new Response(proc.stderr).text();
+    let authenticated = exitCode === 0;
+    if (provider.id === "claude" && exitCode === 0) {
+      try {
+        // Claude's JSON includes account metadata. Read only this boolean and discard the payload.
+        authenticated = JSON.parse(statusText)?.loggedIn === true;
+      } catch {
+        authenticated = false;
+      }
+    }
+    if (authenticated) {
+      return { available: true, authenticated: true, message: null };
+    }
+    const stderrSuffix = errorText.trim() ? ` (${sanitizeRuntimeError(errorText)})` : "";
+    return {
+      available: true,
+      authenticated: false,
+      message: `${remediationFor(provider, "unauthenticated")}${stderrSuffix}`,
+    };
+  } catch (error) {
+    const fallbackMessage = `${provider.name} authentication check failed.`;
+    return {
+      available: true,
+      authenticated: false,
+      inconclusive: true,
+      message: sanitizeRuntimeError(error instanceof Error ? error.message : fallbackMessage),
+    };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export function checkAiProviderStatus(provider: AiProvider): Promise<AiProviderStatus> {
+  return configuredHost?.checkStatus?.(provider) ?? checkStatusWithBun(provider);
+}
+
 function runWithBun({
   provider,
   prompt,
   cwd = typeof process !== "undefined" ? process.cwd() : ".",
   onChunk,
+  outputMode = "plain",
+  isolatedWorkspace = false,
 }: {
   provider: AiProvider;
   prompt: string;
   cwd?: string;
   onChunk?: (output: string) => void;
+  outputMode?: "plain" | "structured";
+  isolatedWorkspace?: boolean;
 }): AiRunController {
   type BunSubprocess = ReturnType<typeof Bun.spawn>;
   if (typeof Bun === "undefined" || typeof Bun.spawn !== "function") {
@@ -54,41 +159,94 @@ function runWithBun({
   let processRef: BunSubprocess | null = null;
 
   const done = (async () => {
-    const proc = Bun.spawn([provider.command, ...provider.buildArgs(prompt)], {
-      cwd,
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    processRef = proc;
-
-    const stderrPromise = new Response(proc.stderr).text().catch(() => "");
-    const stdoutReader = proc.stdout.getReader();
-    const decoder = new TextDecoder();
-    let fullOutput = "";
-
-    while (true) {
-      const { done: streamDone, value } = await stdoutReader.read();
-      if (streamDone) break;
-      if (cancelled) throw new AiRunCancelledError();
-      fullOutput += decoder.decode(value, { stream: true });
-      onChunk?.(fullOutput);
-    }
-
-    const exitCode = await proc.exited;
-    const stderr = (await stderrPromise).trim();
-
     if (cancelled) throw new AiRunCancelledError();
-    if (exitCode !== 0) {
-      throw new Error(stderr || fullOutput.trim() || `${provider.name} exited with status ${exitCode}.`);
+    const resolvedCommand = resolveAiCliCommand(provider.command);
+    if (!resolvedCommand) {
+      throw new Error(`${provider.name} is not installed or not available in PATH.`);
     }
 
-    const finalOutput = fullOutput.trim();
-    if (!finalOutput) {
-      throw new Error(stderr || `${provider.name} returned an empty response.`);
+    const args = outputMode === "structured"
+      ? provider.buildStructuredArgs?.(prompt)
+      : provider.buildArgs(prompt);
+    if (!args) {
+      throw new Error(`${provider.name} does not support structured non-interactive output.`);
     }
 
-    return finalOutput;
+    const isolatedCwd = isolatedWorkspace
+      ? await mkdtemp(join(tmpdir(), "gloomberb-local-agent-"))
+      : null;
+    let proc: BunSubprocess | null = null;
+    try {
+      if (cancelled) throw new AiRunCancelledError();
+      proc = Bun.spawn([resolvedCommand.executable, ...args], {
+        cwd: isolatedCwd ?? cwd,
+        env: resolvedCommand.env,
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      processRef = proc;
+
+      const stderrPromise = new Response(proc.stderr).text().catch(() => "");
+      const stdoutReader = proc.stdout.getReader();
+      const decoder = new TextDecoder();
+      let fullOutput = "";
+      const structuredParser = outputMode === "structured"
+        ? new AiStructuredStreamParser(provider.id)
+        : null;
+
+      while (true) {
+        const { done: streamDone, value } = await stdoutReader.read();
+        if (streamDone) break;
+        if (cancelled) throw new AiRunCancelledError();
+        const decoded = decoder.decode(value, { stream: true });
+        if (structuredParser) {
+          const nextOutput = structuredParser.push(decoded).transcript;
+          if (nextOutput !== fullOutput) {
+            fullOutput = nextOutput;
+            onChunk?.(fullOutput);
+          }
+        } else {
+          fullOutput += decoded;
+          onChunk?.(fullOutput);
+        }
+      }
+
+      const tail = decoder.decode();
+      if (structuredParser && tail) structuredParser.push(tail);
+      const structuredResult = structuredParser?.finish();
+      if (structuredResult && structuredResult.transcript !== fullOutput) {
+        fullOutput = structuredResult.transcript;
+        onChunk?.(fullOutput);
+      }
+
+      const exitCode = await proc.exited;
+      const stderr = sanitizeRuntimeError(await stderrPromise);
+
+      if (cancelled) throw new AiRunCancelledError();
+      if (exitCode !== 0 || structuredResult?.terminalError) {
+        const errorText = sanitizeRuntimeError(structuredResult?.terminalError || stderr || fullOutput);
+        if (/not authenticated|authentication required|not logged in|login required|credential(?:s)? (?:expired|required)|refresh token/i.test(errorText)) {
+          throw new Error(remediationFor(provider, "unauthenticated"));
+        }
+        throw new Error(errorText || `${provider.name} exited with status ${exitCode}.`);
+      }
+
+      const finalOutput = fullOutput.trim();
+      if (!finalOutput) {
+        throw new Error(stderr || `${provider.name} returned an empty response.`);
+      }
+
+      return finalOutput;
+    } catch (error) {
+      try { proc?.kill(); } catch { /* ignore cleanup failures */ }
+      await proc?.exited.catch(() => {});
+      if (cancelled) throw new AiRunCancelledError();
+      throw error;
+    } finally {
+      processRef = null;
+      if (isolatedCwd) await rm(isolatedCwd, { recursive: true, force: true }).catch(() => {});
+    }
   })();
 
   return {
@@ -109,11 +267,15 @@ export function runAiPrompt({
   prompt,
   cwd,
   onChunk,
+  outputMode,
+  isolatedWorkspace,
 }: {
   provider: AiProvider;
   prompt: string;
   cwd?: string;
   onChunk?: (output: string) => void;
+  outputMode?: "plain" | "structured";
+  isolatedWorkspace?: boolean;
 }): AiRunController {
-  return (configuredHost ?? { run: runWithBun }).run({ provider, prompt, cwd, onChunk });
+  return (configuredHost ?? { run: runWithBun }).run({ provider, prompt, cwd, onChunk, outputMode, isolatedWorkspace });
 }

--- a/src/plugins/builtin/ai/stream-events.test.ts
+++ b/src/plugins/builtin/ai/stream-events.test.ts
@@ -32,4 +32,32 @@ describe("AI structured stream parser", () => {
     const malformed = new AiStructuredStreamParser("claude");
     expect(() => malformed.push("not-json\n")).toThrow("Claude returned malformed structured output");
   });
+
+  test("renders Pi text deltas while ignoring envelope events", () => {
+    const parser = new AiStructuredStreamParser("pi");
+    parser.push([
+      JSON.stringify({ type: "session", id: "session-1" }),
+      JSON.stringify({ type: "agent_start" }),
+      JSON.stringify({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "ok" } }),
+      JSON.stringify({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "ok" }] } }),
+      JSON.stringify({ type: "turn_end" }),
+      JSON.stringify({ type: "agent_settled" }),
+      "",
+    ].join("\n"));
+
+    expect(parser.finish()).toEqual({ transcript: "ok", terminalError: null });
+  });
+
+  test("reports Pi terminal errors", () => {
+    const parser = new AiStructuredStreamParser("pi");
+    parser.push('{"type":"error","message":"boom"}\n');
+
+    expect(parser.finish().terminalError).toBe("boom");
+  });
+
+  test("labels malformed Pi output", () => {
+    const parser = new AiStructuredStreamParser("pi");
+
+    expect(() => parser.push("not-json\n")).toThrow("Pi returned malformed structured output");
+  });
 });

--- a/src/plugins/builtin/ai/stream-events.test.ts
+++ b/src/plugins/builtin/ai/stream-events.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { AiStructuredStreamParser } from "./stream-events";
+
+describe("AI structured stream parser", () => {
+  test("renders only Claude text deltas across arbitrary chunks", () => {
+    const parser = new AiStructuredStreamParser("claude");
+    parser.push('{"type":"system","subtype":"init"}\n{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"Hel');
+    const current = parser.push('lo"}}}\n{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":" world"}}}\n');
+    const final = parser.finish();
+
+    expect(current.transcript).toBe("Hello world");
+    expect(final.terminalError).toBeNull();
+  });
+
+  test("replaces Codex in-progress agent messages and ignores reasoning events", () => {
+    const parser = new AiStructuredStreamParser("codex");
+    parser.push([
+      JSON.stringify({ type: "item.completed", item: { id: "r1", type: "reasoning", text: "private" } }),
+      JSON.stringify({ type: "item.started", item: { id: "a1", type: "agent_message", text: "Draft" } }),
+      JSON.stringify({ type: "item.updated", item: { id: "a1", type: "agent_message", text: "Final answer" } }),
+      "",
+    ].join("\n"));
+
+    expect(parser.finish().transcript).toBe("Final answer");
+  });
+
+  test("reports terminal and malformed structured errors without displaying metadata", () => {
+    const failed = new AiStructuredStreamParser("codex");
+    failed.push('{"type":"turn.failed","error":{"message":"Authentication required"}}\n');
+    expect(failed.finish()).toEqual({ transcript: "", terminalError: "Authentication required" });
+
+    const malformed = new AiStructuredStreamParser("claude");
+    expect(() => malformed.push("not-json\n")).toThrow("Claude returned malformed structured output");
+  });
+});

--- a/src/plugins/builtin/ai/stream-events.ts
+++ b/src/plugins/builtin/ai/stream-events.ts
@@ -23,6 +23,8 @@ export class AiStructuredStreamParser {
   private buffer = "";
   private claudeTranscript = "";
   private claudeSawDeltas = false;
+  private piTranscript = "";
+  private piSawDeltas = false;
   private readonly codexItems = new Map<string, string>();
   private readonly codexItemOrder: string[] = [];
   private terminalError: string | null = null;
@@ -49,12 +51,20 @@ export class AiStructuredStreamParser {
     try {
       parsed = JSON.parse(line);
     } catch {
-      throw new Error(`${this.providerId === "claude" ? "Claude" : "Codex"} returned malformed structured output.`);
+      const label = this.providerId === "claude"
+        ? "Claude"
+        : this.providerId === "codex"
+          ? "Codex"
+          : this.providerId === "pi"
+            ? "Pi"
+            : this.providerId;
+      throw new Error(`${label} returned malformed structured output.`);
     }
     const event = objectValue(parsed);
     if (!event) return;
     if (this.providerId === "claude") this.parseClaude(event);
     if (this.providerId === "codex") this.parseCodex(event);
+    if (this.providerId === "pi") this.parsePi(event);
   }
 
   private parseClaude(event: Record<string, unknown>): void {
@@ -98,10 +108,37 @@ export class AiStructuredStreamParser {
     this.codexItems.set(id, stringValue(item.text) ?? "");
   }
 
+  private parsePi(event: Record<string, unknown>): void {
+    if (event.type === "message_update") {
+      const assistantMessageEvent = objectValue(event.assistantMessageEvent);
+      if (assistantMessageEvent?.type === "text_delta") {
+        this.piSawDeltas = true;
+        this.piTranscript += stringValue(assistantMessageEvent.delta) ?? "";
+      }
+      return;
+    }
+    if (event.type === "message_end" && !this.piSawDeltas) {
+      const message = objectValue(event.message);
+      if (message?.role === "assistant") {
+        const snapshot = contentText(message.content);
+        if (snapshot) this.piTranscript = snapshot;
+      }
+      return;
+    }
+    if (event.type === "error") {
+      this.terminalError = stringValue(event.message) ?? "Pi failed to complete the request.";
+    }
+  }
+
   private result(): StructuredEventResult {
-    const transcript = this.providerId === "codex"
-      ? this.codexItemOrder.map((id) => this.codexItems.get(id) ?? "").filter(Boolean).join("\n\n")
-      : this.claudeTranscript;
+    let transcript: string;
+    if (this.providerId === "codex") {
+      transcript = this.codexItemOrder.map((id) => this.codexItems.get(id) ?? "").filter(Boolean).join("\n\n");
+    } else if (this.providerId === "pi") {
+      transcript = this.piTranscript;
+    } else {
+      transcript = this.claudeTranscript;
+    }
     return { transcript, terminalError: this.terminalError };
   }
 }

--- a/src/plugins/builtin/ai/stream-events.ts
+++ b/src/plugins/builtin/ai/stream-events.ts
@@ -1,0 +1,107 @@
+interface StructuredEventResult {
+  transcript: string;
+  terminalError: string | null;
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? value as Record<string, unknown> : null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function contentText(value: unknown): string {
+  if (!Array.isArray(value)) return "";
+  return value
+    .map((entry) => stringValue(objectValue(entry)?.text) ?? "")
+    .filter(Boolean)
+    .join("");
+}
+
+export class AiStructuredStreamParser {
+  private buffer = "";
+  private claudeTranscript = "";
+  private claudeSawDeltas = false;
+  private readonly codexItems = new Map<string, string>();
+  private readonly codexItemOrder: string[] = [];
+  private terminalError: string | null = null;
+
+  constructor(private readonly providerId: string) {}
+
+  push(chunk: string): StructuredEventResult {
+    this.buffer += chunk;
+    const lines = this.buffer.split("\n");
+    this.buffer = lines.pop() ?? "";
+    for (const line of lines) this.parseLine(line);
+    return this.result();
+  }
+
+  finish(): StructuredEventResult {
+    if (this.buffer.trim()) this.parseLine(this.buffer);
+    this.buffer = "";
+    return this.result();
+  }
+
+  private parseLine(line: string): void {
+    if (!line.trim()) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      throw new Error(`${this.providerId === "claude" ? "Claude" : "Codex"} returned malformed structured output.`);
+    }
+    const event = objectValue(parsed);
+    if (!event) return;
+    if (this.providerId === "claude") this.parseClaude(event);
+    if (this.providerId === "codex") this.parseCodex(event);
+  }
+
+  private parseClaude(event: Record<string, unknown>): void {
+    const nestedEvent = event.type === "stream_event" ? objectValue(event.event) : event;
+    const delta = nestedEvent?.type === "content_block_delta" ? objectValue(nestedEvent.delta) : null;
+    if (delta?.type === "text_delta") {
+      this.claudeSawDeltas = true;
+      this.claudeTranscript += stringValue(delta.text) ?? "";
+      return;
+    }
+
+    if (event.type === "assistant" && !this.claudeSawDeltas) {
+      const snapshot = contentText(objectValue(event.message)?.content);
+      if (snapshot) this.claudeTranscript = snapshot;
+      return;
+    }
+
+    if (event.type === "result") {
+      const result = stringValue(event.result);
+      if (event.is_error === true || event.subtype !== "success") {
+        this.terminalError = result ?? "Claude failed to complete the request.";
+      } else if (!this.claudeTranscript && result) {
+        this.claudeTranscript = result;
+      }
+    }
+  }
+
+  private parseCodex(event: Record<string, unknown>): void {
+    if (event.type === "error" || event.type === "turn.failed") {
+      const error = objectValue(event.error);
+      this.terminalError = stringValue(event.message)
+        ?? stringValue(error?.message)
+        ?? "Codex failed to complete the request.";
+      return;
+    }
+    if (event.type !== "item.started" && event.type !== "item.updated" && event.type !== "item.completed") return;
+    const item = objectValue(event.item);
+    if (item?.type !== "agent_message") return;
+    const id = stringValue(item.id) ?? `agent-message-${this.codexItemOrder.length}`;
+    if (!this.codexItems.has(id)) this.codexItemOrder.push(id);
+    this.codexItems.set(id, stringValue(item.text) ?? "");
+  }
+
+  private result(): StructuredEventResult {
+    const transcript = this.providerId === "codex"
+      ? this.codexItemOrder.map((id) => this.codexItems.get(id) ?? "").filter(Boolean).join("\n\n")
+      : this.claudeTranscript;
+    return { transcript, terminalError: this.terminalError };
+  }
+}

--- a/src/plugins/builtin/ai/workspace/model.test.ts
+++ b/src/plugins/builtin/ai/workspace/model.test.ts
@@ -37,6 +37,25 @@ describe("local agent workspace model", () => {
     expect(codex.threads.find((thread) => thread.id === "claude-1")?.messages[0]?.content).toBe("Original answer");
   });
 
+  test("normalizes and creates Pi threads with the Pi title", () => {
+    const normalized = normalizeLocalAgentWorkspace({
+      activeThreadId: "pi-1",
+      threads: [{
+        id: "pi-1",
+        providerId: "pi",
+        title: "Pi research",
+        createdAt: 1,
+        updatedAt: 1,
+        messages: [],
+      }],
+    });
+    const created = createLocalAgentThread(EMPTY_LOCAL_AGENT_WORKSPACE, "pi", { id: "pi-2", now: 2 });
+
+    expect(normalized.threads[0]?.providerId).toBe("pi");
+    expect(created.threads[0]?.providerId).toBe("pi");
+    expect(created.threads[0]?.title).toContain("Pi");
+  });
+
   test("sends no financial context unless the user selected an attachment", () => {
     const state = createLocalAgentThread(EMPTY_LOCAL_AGENT_WORKSPACE, "codex", { id: "thread-1", now: 10 });
     const thread = state.threads[0];

--- a/src/plugins/builtin/ai/workspace/model.test.ts
+++ b/src/plugins/builtin/ai/workspace/model.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import {
+  appendLocalAgentMessages,
+  buildLocalAgentPrompt,
+  createLocalAgentThread,
+  EMPTY_LOCAL_AGENT_WORKSPACE,
+  normalizeLocalAgentWorkspace,
+  updateLocalAgentThread,
+} from "./model";
+
+describe("local agent workspace model", () => {
+  test("binds a provider at creation and refuses later provider mutation", () => {
+    const created = createLocalAgentThread(EMPTY_LOCAL_AGENT_WORKSPACE, "claude", {
+      id: "thread-1",
+      now: 10,
+    });
+    const attemptedMutation = updateLocalAgentThread(created, "thread-1", (thread) => ({
+      ...thread,
+      providerId: "codex",
+    }));
+
+    expect(attemptedMutation.threads[0]?.providerId).toBe("claude");
+  });
+
+  test("creates a second provider thread without changing the first transcript", () => {
+    const claude = createLocalAgentThread(EMPTY_LOCAL_AGENT_WORKSPACE, "claude", { id: "claude-1", now: 10 });
+    const withMessage = appendLocalAgentMessages(claude, "claude-1", [{
+      id: "message-1",
+      role: "assistant",
+      content: "Original answer",
+      createdAt: 11,
+      status: "complete",
+    }]);
+    const codex = createLocalAgentThread(withMessage, "codex", { id: "codex-1", now: 12 });
+
+    expect(codex.activeThreadId).toBe("codex-1");
+    expect(codex.threads.find((thread) => thread.id === "claude-1")?.messages[0]?.content).toBe("Original answer");
+  });
+
+  test("sends no financial context unless the user selected an attachment", () => {
+    const state = createLocalAgentThread(EMPTY_LOCAL_AGENT_WORKSPACE, "codex", { id: "thread-1", now: 10 });
+    const thread = state.threads[0];
+    if (!thread) throw new Error("Expected a created thread");
+    const withoutContext = buildLocalAgentPrompt(thread, "Compare the risks", []);
+    const withContext = buildLocalAgentPrompt(thread, "Compare the risks", [{
+      id: "ticker:AAPL:10",
+      kind: "ticker",
+      label: "Ticker AAPL",
+      preview: "Apple Inc. (AAPL)",
+      content: "Company: Apple Inc. (AAPL)\nCurrent Price: $210.00",
+    }]);
+
+    expect(withoutContext).not.toContain("Apple Inc.");
+    expect(withoutContext).not.toContain("$210.00");
+    expect(withContext).toContain("Context explicitly attached by the user");
+    expect(withContext).toContain("Company: Apple Inc. (AAPL)");
+  });
+
+  test("drops malformed persisted threads and preserves ordered messages", () => {
+    const normalized = normalizeLocalAgentWorkspace({
+      activeThreadId: "thread-1",
+      threads: [{
+        id: "thread-1",
+        providerId: "claude",
+        title: "Research",
+        createdAt: 1,
+        updatedAt: 3,
+        messages: [
+          { id: "m1", role: "user", content: "First", createdAt: 2 },
+          { id: "m2", role: "assistant", content: "Second", createdAt: 3, status: "complete" },
+        ],
+      }, { id: "bad", providerId: "gemini", messages: [] }],
+    });
+
+    expect(normalized.threads).toHaveLength(1);
+    expect(normalized.threads[0]?.messages.map((message) => message.content)).toEqual(["First", "Second"]);
+  });
+});

--- a/src/plugins/builtin/ai/workspace/model.ts
+++ b/src/plugins/builtin/ai/workspace/model.ts
@@ -1,4 +1,4 @@
-export type LocalAgentProviderId = "claude" | "codex";
+export type LocalAgentProviderId = "claude" | "codex" | "pi";
 
 export interface LocalAgentAttachmentMetadata {
   id: string;
@@ -41,9 +41,14 @@ export const EMPTY_LOCAL_AGENT_WORKSPACE: LocalAgentWorkspaceState = {
 
 const MAX_THREADS = 50;
 const MAX_MESSAGES_PER_THREAD = 100;
+const PROVIDER_TITLES: Record<LocalAgentProviderId, string> = {
+  claude: "Claude",
+  codex: "Codex",
+  pi: "Pi",
+};
 
 function isProviderId(value: unknown): value is LocalAgentProviderId {
-  return value === "claude" || value === "codex";
+  return value === "claude" || value === "codex" || value === "pi";
 }
 
 function normalizeMessage(value: unknown): LocalAgentMessage | null {
@@ -121,7 +126,7 @@ export function createLocalAgentThread(
   const thread: LocalAgentThread = {
     id,
     providerId,
-    title: `New ${providerId === "claude" ? "Claude" : "Codex"} thread`,
+    title: `New ${PROVIDER_TITLES[providerId]} thread`,
     createdAt: now,
     updatedAt: now,
     messages: [],

--- a/src/plugins/builtin/ai/workspace/model.ts
+++ b/src/plugins/builtin/ai/workspace/model.ts
@@ -1,0 +1,231 @@
+export type LocalAgentProviderId = "claude" | "codex";
+
+export interface LocalAgentAttachmentMetadata {
+  id: string;
+  kind: "ticker";
+  label: string;
+  preview: string;
+}
+
+export interface LocalAgentAttachmentPayload extends LocalAgentAttachmentMetadata {
+  content: string;
+}
+
+export interface LocalAgentMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  createdAt: number;
+  status?: "complete" | "cancelled" | "error";
+  attachments?: LocalAgentAttachmentMetadata[];
+}
+
+export interface LocalAgentThread {
+  id: string;
+  providerId: LocalAgentProviderId;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  messages: LocalAgentMessage[];
+}
+
+export interface LocalAgentWorkspaceState {
+  activeThreadId: string | null;
+  threads: LocalAgentThread[];
+}
+
+export const EMPTY_LOCAL_AGENT_WORKSPACE: LocalAgentWorkspaceState = {
+  activeThreadId: null,
+  threads: [],
+};
+
+const MAX_THREADS = 50;
+const MAX_MESSAGES_PER_THREAD = 100;
+
+function isProviderId(value: unknown): value is LocalAgentProviderId {
+  return value === "claude" || value === "codex";
+}
+
+function normalizeMessage(value: unknown): LocalAgentMessage | null {
+  if (!value || typeof value !== "object") return null;
+  const message = value as Partial<LocalAgentMessage>;
+  if (
+    typeof message.id !== "string"
+    || (message.role !== "user" && message.role !== "assistant")
+    || typeof message.content !== "string"
+    || typeof message.createdAt !== "number"
+  ) return null;
+  const attachments = Array.isArray(message.attachments)
+    ? message.attachments.filter((attachment): attachment is LocalAgentAttachmentMetadata => (
+      !!attachment
+      && typeof attachment === "object"
+      && typeof attachment.id === "string"
+      && attachment.kind === "ticker"
+      && typeof attachment.label === "string"
+      && typeof attachment.preview === "string"
+    ))
+    : undefined;
+  const status = message.status === "complete" || message.status === "cancelled" || message.status === "error"
+    ? message.status
+    : undefined;
+  return {
+    id: message.id,
+    role: message.role,
+    content: message.content,
+    createdAt: message.createdAt,
+    ...(status ? { status } : {}),
+    ...(attachments?.length ? { attachments } : {}),
+  };
+}
+
+function isThread(value: unknown): value is LocalAgentThread {
+  if (!value || typeof value !== "object") return false;
+  const thread = value as Partial<LocalAgentThread>;
+  return typeof thread.id === "string"
+    && isProviderId(thread.providerId)
+    && typeof thread.title === "string"
+    && typeof thread.createdAt === "number"
+    && typeof thread.updatedAt === "number"
+    && Array.isArray(thread.messages);
+}
+
+export function normalizeLocalAgentWorkspace(value: unknown): LocalAgentWorkspaceState {
+  if (!value || typeof value !== "object") return EMPTY_LOCAL_AGENT_WORKSPACE;
+  const candidate = value as Partial<LocalAgentWorkspaceState>;
+  const threads = Array.isArray(candidate.threads)
+    ? candidate.threads
+      .filter(isThread)
+      .map((thread) => ({
+        ...thread,
+        messages: thread.messages
+          .map(normalizeMessage)
+          .filter((message): message is LocalAgentMessage => message !== null)
+          .slice(-MAX_MESSAGES_PER_THREAD),
+      }))
+      .slice(0, MAX_THREADS)
+    : [];
+  const activeThreadId = typeof candidate.activeThreadId === "string"
+    && threads.some((thread) => thread.id === candidate.activeThreadId)
+    ? candidate.activeThreadId
+    : threads[0]?.id ?? null;
+  return { activeThreadId, threads };
+}
+
+export function createLocalAgentThread(
+  state: LocalAgentWorkspaceState,
+  providerId: LocalAgentProviderId,
+  options: { id?: string; now?: number } = {},
+): LocalAgentWorkspaceState {
+  const now = options.now ?? Date.now();
+  const id = options.id ?? crypto.randomUUID();
+  const thread: LocalAgentThread = {
+    id,
+    providerId,
+    title: `New ${providerId === "claude" ? "Claude" : "Codex"} thread`,
+    createdAt: now,
+    updatedAt: now,
+    messages: [],
+  };
+  return {
+    activeThreadId: id,
+    threads: [thread, ...state.threads].slice(0, MAX_THREADS),
+  };
+}
+
+export function selectLocalAgentThread(
+  state: LocalAgentWorkspaceState,
+  threadId: string,
+): LocalAgentWorkspaceState {
+  return state.threads.some((thread) => thread.id === threadId)
+    ? { ...state, activeThreadId: threadId }
+    : state;
+}
+
+export function updateLocalAgentThread(
+  state: LocalAgentWorkspaceState,
+  threadId: string,
+  updater: (thread: LocalAgentThread) => LocalAgentThread,
+): LocalAgentWorkspaceState {
+  let changed = false;
+  const threads = state.threads.map((thread) => {
+    if (thread.id !== threadId) return thread;
+    const updated = updater(thread);
+    changed = updated !== thread;
+    // Provider identity is a creation-time property. Ignore accidental mutation.
+    return updated.providerId === thread.providerId
+      ? updated
+      : { ...updated, providerId: thread.providerId };
+  });
+  return changed ? { ...state, threads } : state;
+}
+
+export function appendLocalAgentMessages(
+  state: LocalAgentWorkspaceState,
+  threadId: string,
+  messages: LocalAgentMessage[],
+): LocalAgentWorkspaceState {
+  if (messages.length === 0) return state;
+  return updateLocalAgentThread(state, threadId, (thread) => {
+    const nextMessages = [...thread.messages, ...messages].slice(-MAX_MESSAGES_PER_THREAD);
+    const firstUserMessage = nextMessages.find((message) => message.role === "user")?.content.trim();
+    return {
+      ...thread,
+      title: firstUserMessage
+        ? firstUserMessage.replace(/\s+/g, " ").slice(0, 42)
+        : thread.title,
+      updatedAt: Math.max(thread.updatedAt, ...messages.map((message) => message.createdAt)),
+      messages: nextMessages,
+    };
+  });
+}
+
+export function replaceLocalAgentMessage(
+  state: LocalAgentWorkspaceState,
+  threadId: string,
+  messageId: string,
+  update: Pick<LocalAgentMessage, "content"> & Pick<Partial<LocalAgentMessage>, "status">,
+  now = Date.now(),
+): LocalAgentWorkspaceState {
+  return updateLocalAgentThread(state, threadId, (thread) => ({
+    ...thread,
+    updatedAt: now,
+    messages: thread.messages.map((message) => (
+      message.id === messageId ? { ...message, ...update } : message
+    )),
+  }));
+}
+
+export function removeLocalAgentMessages(
+  state: LocalAgentWorkspaceState,
+  threadId: string,
+  messageIds: readonly string[],
+): LocalAgentWorkspaceState {
+  const removed = new Set(messageIds);
+  return updateLocalAgentThread(state, threadId, (thread) => ({
+    ...thread,
+    messages: thread.messages.filter((message) => !removed.has(message.id)),
+  }));
+}
+
+export function buildLocalAgentPrompt(
+  thread: LocalAgentThread,
+  userText: string,
+  attachments: LocalAgentAttachmentPayload[],
+): string {
+  const transcript = thread.messages
+    .filter((message) => message.role === "user" || message.status === "complete")
+    .map((message) => `${message.role === "user" ? "User" : "Assistant"}: ${message.content}`)
+    .join("\n\n");
+  const sections = [
+    "Continue this local research conversation. Answer the current user request directly.",
+  ];
+  if (transcript) sections.push(`Conversation so far:\n${transcript}`);
+  if (attachments.length > 0) {
+    sections.push([
+      "Context explicitly attached by the user for this request:",
+      ...attachments.map((attachment) => `\n[${attachment.label}]\n${attachment.content}`),
+    ].join("\n"));
+  }
+  sections.push(`Current user request:\n${userText.trim()}`);
+  return sections.join("\n\n");
+}

--- a/src/plugins/builtin/ai/workspace/pane.tsx
+++ b/src/plugins/builtin/ai/workspace/pane.tsx
@@ -1,0 +1,579 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, ScrollBox, Text, TextAttributes, useUiCapabilities } from "../../../../ui";
+import type { ScrollBoxRenderable, TextareaRenderable } from "../../../../ui";
+import { MarkdownText } from "../../../../components/markdown-text";
+import { MessageComposer, Spinner, usePaneFooter } from "../../../../components";
+import { useShortcut } from "../../../../react/input";
+import { resolveTickerForPane, useAppDispatch, useAppSelector, usePaneInstance } from "../../../../state/app/context";
+import { useInlineTickers } from "../../../../state/hooks/inline-tickers";
+import type { PaneProps } from "../../../../types/plugin";
+import { colors, hoverBg } from "../../../../theme/colors";
+import { usePluginState } from "../../../runtime";
+import { buildTickerAiContext } from "../ticker-context";
+import { detectProviders, getLocalWorkspaceProviders, type AiProvider } from "../providers";
+import { checkAiProviderStatus, isAiRunCancelled, runAiPrompt, type AiRunController } from "../runner";
+import {
+  EMPTY_LOCAL_AGENT_WORKSPACE,
+  appendLocalAgentMessages,
+  buildLocalAgentPrompt,
+  createLocalAgentThread,
+  normalizeLocalAgentWorkspace,
+  removeLocalAgentMessages,
+  selectLocalAgentThread,
+  type LocalAgentAttachmentPayload,
+  type LocalAgentProviderId,
+  type LocalAgentWorkspaceState,
+} from "./model";
+
+export const LOCAL_AGENT_WORKSPACE_STATE_KEY = "local-agent-workspace";
+export const LOCAL_AGENT_WORKSPACE_SCHEMA_VERSION = 1;
+
+function providerLabel(providerId: LocalAgentProviderId): string {
+  return providerId === "claude" ? "Claude Code" : "Codex";
+}
+
+function providerPrerequisite(provider: AiProvider): string {
+  if (provider.available) return `Uses your existing local ${provider.name} sign-in.`;
+  return `${provider.name} is not installed or not available in PATH.`;
+}
+
+function WorkspaceProviderChooser({
+  providers,
+  selectedIndex,
+  checkingProviderId,
+  statusMessage,
+  onSelectIndex,
+  onCreate,
+}: {
+  providers: AiProvider[];
+  selectedIndex: number;
+  checkingProviderId: string | null;
+  statusMessage: string | null;
+  onSelectIndex: (index: number) => void;
+  onCreate: (provider: AiProvider) => void;
+}) {
+  return (
+    <Box flexDirection="column" paddingX={1} paddingTop={1} flexGrow={1}>
+      <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>Choose a local runtime</Text>
+      <Text fg={colors.textDim}>The selection is permanent for this thread. A different runtime creates a new thread.</Text>
+      <Box height={1} />
+      {statusMessage && <Text fg={colors.warning}>{statusMessage}</Text>}
+      {providers.map((provider, index) => {
+        const selected = index === selectedIndex;
+        return (
+          <Box
+            key={provider.id}
+            flexDirection="column"
+            paddingX={1}
+            marginBottom={1}
+            backgroundColor={selected ? colors.selected : colors.panel}
+            onMouseDown={() => {
+              onSelectIndex(index);
+              onCreate(provider);
+            }}
+            style={{ cursor: "pointer" }}
+          >
+            <Text
+              fg={selected ? colors.selectedText : colors.text}
+              attributes={TextAttributes.BOLD}
+            >
+              {selected ? "› " : "  "}{providerLabel(provider.id as LocalAgentProviderId)}
+              {checkingProviderId === provider.id ? " · checking local sign-in…" : ""}
+            </Text>
+            <Text fg={provider.available ? colors.textDim : colors.warning}>
+              {providerPrerequisite(provider)}
+            </Text>
+          </Box>
+        );
+      })}
+      <Text fg={colors.textMuted}>↑/↓ choose · Enter create · Esc return to threads</Text>
+    </Box>
+  );
+}
+
+export function LocalAgentWorkspacePane({ focused, width, height }: PaneProps) {
+  const { nativePaneChrome } = useUiCapabilities();
+  const dispatch = useAppDispatch();
+  const paneInstance = usePaneInstance();
+  const [providers] = useState(() => getLocalWorkspaceProviders(detectProviders()));
+  const [persistedWorkspace, setPersistedWorkspace] = usePluginState<LocalAgentWorkspaceState>(
+    LOCAL_AGENT_WORKSPACE_STATE_KEY,
+    EMPTY_LOCAL_AGENT_WORKSPACE,
+    { schemaVersion: LOCAL_AGENT_WORKSPACE_SCHEMA_VERSION },
+  );
+  const workspace = useMemo(() => normalizeLocalAgentWorkspace(persistedWorkspace), [persistedWorkspace]);
+  const activeThread = workspace.threads.find((thread) => thread.id === workspace.activeThreadId) ?? null;
+  const [creating, setCreating] = useState(() => workspace.threads.length === 0);
+  const [selectedProviderIndex, setSelectedProviderIndex] = useState(0);
+  const [checkingProviderId, setCheckingProviderId] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [inputFocused, setInputFocused] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const [attachments, setAttachments] = useState<LocalAgentAttachmentPayload[]>([]);
+  const [runningMessageId, setRunningMessageId] = useState<string | null>(null);
+  const [streamingOutput, setStreamingOutput] = useState("");
+  const [hoveredThreadId, setHoveredThreadId] = useState<string | null>(null);
+  const inputRef = useRef<TextareaRenderable | null>(null);
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null);
+  const runRef = useRef<{ controller: AiRunController; threadId: string; assistantMessageId: string } | null>(null);
+  const busyRef = useRef(false);
+  const seededRef = useRef(false);
+
+  const previousSymbol = useAppSelector((state) => {
+    const previous = state.previousFocusedPaneId
+      ? resolveTickerForPane(state, state.previousFocusedPaneId)
+      : null;
+    return previous ?? state.recentTickers[0] ?? null;
+  });
+  const selectedTicker = useAppSelector((state) => previousSymbol ? state.tickers.get(previousSymbol) ?? null : null);
+  const selectedFinancials = useAppSelector((state) => previousSymbol ? state.financials.get(previousSymbol) ?? null : null);
+  const baseCurrency = useAppSelector((state) => state.config.baseCurrency);
+  const exchangeRates = useAppSelector((state) => state.exchangeRates);
+
+  const updateWorkspace = useCallback((updater: (current: LocalAgentWorkspaceState) => LocalAgentWorkspaceState) => {
+    setPersistedWorkspace((current) => updater(normalizeLocalAgentWorkspace(current)));
+  }, [setPersistedWorkspace]);
+
+  const clearDraft = useCallback(() => {
+    setInputValue("");
+    inputRef.current?.editBuffer.setText?.("");
+    setAttachments([]);
+  }, []);
+
+  const createThread = useCallback(async (provider: AiProvider, threadId?: string) => {
+    if (busyRef.current || runRef.current) return;
+    busyRef.current = true;
+    setCheckingProviderId(provider.id);
+    setStatusMessage(null);
+    try {
+      const status = await checkAiProviderStatus(provider);
+      if (!status.available || (!status.authenticated && !status.inconclusive)) {
+        setStatusMessage(status.message ?? `${provider.name} is not ready.`);
+        return;
+      }
+      if (status.inconclusive) {
+        setStatusMessage(status.message ?? `Couldn't verify ${provider.name} sign-in; attempting anyway.`);
+      }
+      updateWorkspace((current) => createLocalAgentThread(
+        current,
+        provider.id as LocalAgentProviderId,
+        threadId ? { id: threadId } : {},
+      ));
+      clearDraft();
+      setCreating(false);
+    } catch (error) {
+      setStatusMessage(error instanceof Error ? error.message : `${provider.name} status check failed.`);
+    } finally {
+      busyRef.current = false;
+      setCheckingProviderId(null);
+    }
+  }, [clearDraft, updateWorkspace]);
+
+  useEffect(() => {
+    if (seededRef.current) return;
+    seededRef.current = true;
+    const providerId = paneInstance?.params?.providerId;
+    const threadId = paneInstance?.params?.threadId;
+    const providerIndex = providers.findIndex((provider) => provider.id === providerId);
+    const provider = providers[providerIndex];
+    if (provider && typeof threadId === "string") {
+      setSelectedProviderIndex(providerIndex);
+      if (workspace.threads.some((thread) => thread.id === threadId)) {
+        updateWorkspace((current) => selectLocalAgentThread(current, threadId));
+        setCreating(false);
+      } else {
+        void createThread(provider, threadId);
+      }
+    }
+  }, [createThread, paneInstance?.params?.providerId, paneInstance?.params?.threadId, providers, updateWorkspace, workspace.threads]);
+
+  useEffect(() => {
+    if (!focused) return;
+    const scroll = scrollRef.current;
+    if (!scroll || !activeThread?.messages.length) return;
+    scroll.scrollTo({ x: 0, y: Math.max(0, scroll.scrollHeight - scroll.viewport.height) });
+  }, [activeThread?.messages, focused]);
+
+  const focusInput = useCallback(() => {
+    setInputFocused(true);
+    dispatch({ type: "SET_INPUT_CAPTURED", captured: true });
+    inputRef.current?.focus();
+  }, [dispatch]);
+
+  const blurInput = useCallback(() => {
+    setInputFocused(false);
+    dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (!focused && inputFocused) blurInput();
+  }, [blurInput, focused, inputFocused]);
+
+  const cycleThread = useCallback((direction: -1 | 1) => {
+    if (!activeThread || busyRef.current || workspace.threads.length < 2) return;
+    const currentIndex = workspace.threads.findIndex((thread) => thread.id === activeThread.id);
+    const nextIndex = (currentIndex + direction + workspace.threads.length) % workspace.threads.length;
+    const nextThread = workspace.threads[nextIndex];
+    if (!nextThread) return;
+    updateWorkspace((current) => selectLocalAgentThread(current, nextThread.id));
+    clearDraft();
+    setStatusMessage(null);
+  }, [activeThread, clearDraft, updateWorkspace, workspace.threads]);
+
+  const attachSelectedTicker = useCallback(() => {
+    if (!selectedTicker || !previousSymbol) {
+      setStatusMessage("Select a ticker in another pane before attaching context.");
+      return;
+    }
+    const content = buildTickerAiContext(selectedTicker, selectedFinancials, baseCurrency, exchangeRates);
+    const attachment: LocalAgentAttachmentPayload = {
+      id: `ticker:${previousSymbol}:${Date.now()}`,
+      kind: "ticker",
+      label: `Ticker ${previousSymbol}`,
+      preview: content.split("\n").slice(0, 4).join(" · "),
+      content,
+    };
+    setAttachments([attachment]);
+    setStatusMessage(null);
+  }, [baseCurrency, exchangeRates, previousSymbol, selectedFinancials, selectedTicker]);
+
+  const removeAttachments = useCallback(() => {
+    setAttachments([]);
+  }, []);
+
+  const cancelRun = useCallback(() => {
+    runRef.current?.controller.cancel();
+  }, []);
+
+  const sendMessage = useCallback(async (text: string) => {
+    if (!activeThread || runRef.current || busyRef.current) return;
+    const provider = providers.find((entry) => entry.id === activeThread.providerId);
+    if (!provider) {
+      setStatusMessage("This thread's local runtime is no longer configured.");
+      return;
+    }
+
+    busyRef.current = true;
+    setCheckingProviderId(provider.id);
+    try {
+      const providerStatus = await checkAiProviderStatus(provider);
+      if (!providerStatus.available || (!providerStatus.authenticated && !providerStatus.inconclusive)) {
+        setStatusMessage(providerStatus.message ?? `${provider.name} is not ready.`);
+        busyRef.current = false;
+        return;
+      }
+    } catch (error) {
+      setStatusMessage(error instanceof Error ? error.message : `${provider.name} status check failed.`);
+      busyRef.current = false;
+      return;
+    } finally {
+      setCheckingProviderId(null);
+    }
+
+    const now = Date.now();
+    const userMessageId = crypto.randomUUID();
+    const assistantMessageId = crypto.randomUUID();
+    const attachmentMetadata = attachments.map(({ content: _content, ...metadata }) => metadata);
+    const prompt = buildLocalAgentPrompt(activeThread, text, attachments);
+    updateWorkspace((current) => appendLocalAgentMessages(current, activeThread.id, [{
+      id: userMessageId,
+      role: "user",
+      content: text,
+      createdAt: now,
+      attachments: attachmentMetadata,
+    }]));
+    setInputValue("");
+    inputRef.current?.editBuffer.setText?.("");
+    setAttachments([]);
+    setStatusMessage(null);
+    setRunningMessageId(assistantMessageId);
+    setStreamingOutput("");
+
+    let streamedOutput = "";
+    try {
+      const controller = runAiPrompt({
+        provider,
+        prompt,
+        outputMode: "structured",
+        isolatedWorkspace: true,
+        onChunk: (output) => {
+          streamedOutput = output;
+          setStreamingOutput(output);
+        },
+      });
+      runRef.current = { controller, threadId: activeThread.id, assistantMessageId };
+      const output = await controller.done;
+      updateWorkspace((current) => appendLocalAgentMessages(current, activeThread.id, [{
+        id: assistantMessageId,
+        role: "assistant",
+        content: output,
+        createdAt: Date.now(),
+        status: "complete",
+      }]));
+    } catch (error) {
+      if (isAiRunCancelled(error)) {
+        updateWorkspace((current) => appendLocalAgentMessages(current, activeThread.id, [{
+          id: assistantMessageId,
+          role: "assistant",
+          content: streamedOutput || "Cancelled before a response was received.",
+          createdAt: Date.now(),
+          status: "cancelled",
+        }]));
+      } else if (!streamedOutput) {
+        updateWorkspace((current) => removeLocalAgentMessages(
+          current,
+          activeThread.id,
+          [userMessageId],
+        ));
+        setInputValue(text);
+        inputRef.current?.editBuffer.setText?.(text);
+        setAttachments(attachments);
+        setStatusMessage(error instanceof Error ? error.message : `${provider.name} failed to start.`);
+      } else {
+        const message = error instanceof Error ? error.message : `${provider.name} failed.`;
+        updateWorkspace((current) => appendLocalAgentMessages(current, activeThread.id, [{
+          id: assistantMessageId,
+          role: "assistant",
+          content: `${streamedOutput}\n\nError: ${message}`,
+          createdAt: Date.now(),
+          status: "error",
+        }]));
+        setStatusMessage(message);
+      }
+    } finally {
+      runRef.current = null;
+      busyRef.current = false;
+      setRunningMessageId(null);
+      setStreamingOutput("");
+    }
+  }, [activeThread, attachments, providers, updateWorkspace]);
+
+  const submitInput = useCallback(() => {
+    const value = inputRef.current?.editBuffer.getText() ?? inputValue;
+    const trimmed = value.trim();
+    if (trimmed) void sendMessage(trimmed);
+  }, [inputValue, sendMessage]);
+
+  useShortcut((event) => {
+    if (!focused) return;
+    const isEnter = event.name === "enter" || event.name === "return";
+    if (inputFocused) {
+      if (event.name === "escape") blurInput();
+      return;
+    }
+    if (creating) {
+      if (event.name === "escape" && workspace.threads.length > 0) setCreating(false);
+      if (event.name === "up") setSelectedProviderIndex((current) => (current - 1 + providers.length) % providers.length);
+      if (event.name === "down") setSelectedProviderIndex((current) => (current + 1) % providers.length);
+      const selectedProvider = providers[selectedProviderIndex];
+      if (isEnter && selectedProvider) void createThread(selectedProvider);
+      return;
+    }
+    if (isEnter) focusInput();
+    if (event.name === "n" && !busyRef.current) setCreating(true);
+    if (event.name === "a") attachSelectedTicker();
+    if (event.name === "x") removeAttachments();
+    if (event.name === "c" && runRef.current) cancelRun();
+    if (event.name === "[") cycleThread(-1);
+    if (event.name === "]") cycleThread(1);
+  }, { allowEditable: true });
+
+  useEffect(() => () => {
+    runRef.current?.controller.cancel();
+    dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
+  }, [dispatch]);
+
+  usePaneFooter("local-agent-workspace", () => ({
+    info: runningMessageId
+      ? [{ id: "running", parts: [{ text: "Streaming local reply", tone: "positive" as const, bold: true }] }]
+      : checkingProviderId
+        ? [{ id: "checking", parts: [{ text: "Checking local sign-in", tone: "muted" as const }] }]
+        : statusMessage
+          ? [{ id: "error", parts: [{ text: statusMessage, tone: "warning" as const }] }]
+          : [],
+    hints: [],
+  }), [checkingProviderId, runningMessageId, statusMessage]);
+
+  const messageText = activeThread?.messages.map((message) => message.content) ?? [];
+  const { catalog, openTicker } = useInlineTickers(messageText);
+
+  if (providers.length === 0) {
+    return (
+      <Box flexDirection="column" paddingX={1} paddingTop={1}>
+        <Text fg={colors.warning}>No supported local AI runtime was detected.</Text>
+        <Text fg={colors.textDim}>Install and authenticate Claude Code or Codex locally. Gloomberb never requests provider credentials.</Text>
+      </Box>
+    );
+  }
+
+  if (creating || !activeThread) {
+    return (
+      <WorkspaceProviderChooser
+        providers={providers}
+        selectedIndex={selectedProviderIndex}
+        checkingProviderId={checkingProviderId}
+        statusMessage={statusMessage}
+        onSelectIndex={setSelectedProviderIndex}
+        onCreate={(provider) => { void createThread(provider); }}
+      />
+    );
+  }
+
+  const showSidebar = width >= 72;
+  const sidebarWidth = showSidebar ? Math.min(24, Math.max(18, Math.floor(width * 0.24))) : 0;
+  const contentWidth = Math.max(20, width - sidebarWidth - (nativePaneChrome ? 0 : 2));
+  const composerHeight = nativePaneChrome ? 3 : 2;
+
+  return (
+    <Box flexDirection="row" width={nativePaneChrome ? "100%" : width} height={nativePaneChrome ? "100%" : height} overflow="hidden">
+      {showSidebar && (
+        <Box width={sidebarWidth} flexDirection="column" backgroundColor={colors.panel}>
+          <Box height={1} paddingX={1} flexDirection="row">
+            <Text fg={colors.textDim}>Threads</Text>
+            <Box flexGrow={1} />
+            <Text fg={colors.textBright} onMouseDown={() => { if (!busyRef.current) setCreating(true); }} style={{ cursor: "pointer" }}>+ New</Text>
+          </Box>
+          <ScrollBox flexGrow={1} scrollY focusable={false}>
+            {workspace.threads.map((thread) => {
+              const selected = thread.id === activeThread.id;
+              const backgroundColor = selected ? colors.selected : hoveredThreadId === thread.id ? hoverBg() : colors.panel;
+              return (
+                <Box
+                  key={thread.id}
+                  flexDirection="column"
+                  paddingX={1}
+                  backgroundColor={backgroundColor}
+                  onMouseOver={() => setHoveredThreadId(thread.id)}
+                  onMouseOut={() => setHoveredThreadId((current) => current === thread.id ? null : current)}
+                  onMouseDown={() => {
+                    if (busyRef.current) return;
+                    updateWorkspace((current) => selectLocalAgentThread(current, thread.id));
+                    clearDraft();
+                    setStatusMessage(null);
+                  }}
+                  style={{ cursor: "pointer" }}
+                >
+                  <Text fg={selected ? colors.selectedText : colors.text} attributes={selected ? TextAttributes.BOLD : 0}>
+                    {thread.title}
+                  </Text>
+                  <Text fg={selected ? colors.selectedText : colors.textMuted}>{providerLabel(thread.providerId)}</Text>
+                </Box>
+              );
+            })}
+          </ScrollBox>
+        </Box>
+      )}
+
+      <Box flexDirection="column" flexGrow={1} minWidth={0} overflow="hidden">
+        <Box height={1} paddingX={1} flexDirection="row">
+          <Text fg={colors.positive} attributes={TextAttributes.BOLD}>{providerLabel(activeThread.providerId)}</Text>
+          <Text fg={colors.textDim}> · local thread</Text>
+          {!showSidebar && (
+            <>
+              <Text fg={colors.textDim}> · </Text>
+              <Text fg={colors.textBright} onMouseDown={() => cycleThread(-1)} style={{ cursor: "pointer" }}>‹ </Text>
+              <Text fg={colors.text}>{activeThread.title}</Text>
+              <Text fg={colors.textBright} onMouseDown={() => cycleThread(1)} style={{ cursor: "pointer" }}> ›</Text>
+              <Text fg={colors.textBright} onMouseDown={() => { if (!busyRef.current) setCreating(true); }} style={{ cursor: "pointer" }}>  + New</Text>
+            </>
+          )}
+        </Box>
+
+        <ScrollBox ref={scrollRef} flexGrow={1} minHeight={0} scrollY focusable={false} paddingX={1}>
+          {activeThread.messages.length === 0 ? (
+            <Box flexDirection="column" paddingTop={1}>
+              <Text fg={colors.textDim}>Start a local research conversation. No financial context is attached automatically.</Text>
+              <Text fg={colors.textMuted}>Press a to attach the selected ticker, then review the preview before sending.</Text>
+            </Box>
+          ) : activeThread.messages.map((message) => (
+            <Box key={message.id} flexDirection="column" paddingTop={1}>
+              <Text
+                fg={message.role === "user" ? colors.textBright : colors.positive}
+                attributes={TextAttributes.BOLD}
+              >
+                {message.role === "user" ? "You" : providerLabel(activeThread.providerId)}
+                {message.id === runningMessageId ? " · streaming" : message.status === "cancelled" ? " · cancelled" : ""}
+              </Text>
+              {message.attachments?.map((attachment) => (
+                <Text key={attachment.id} fg={colors.warning}>Attached: {attachment.label}</Text>
+              ))}
+              {message.content ? (
+                <MarkdownText
+                  text={message.content}
+                  lineWidth={contentWidth}
+                  catalog={catalog}
+                  textColor={colors.text}
+                  openTicker={openTicker}
+                />
+              ) : message.id === runningMessageId ? (
+                <Spinner label="Waiting for local runtime…" />
+              ) : null}
+            </Box>
+          ))}
+          {runningMessageId && (
+            <Box flexDirection="column" paddingTop={1}>
+              <Text fg={colors.positive} attributes={TextAttributes.BOLD}>
+                {providerLabel(activeThread.providerId)} · streaming
+              </Text>
+              {streamingOutput ? (
+                <MarkdownText
+                  text={streamingOutput}
+                  lineWidth={contentWidth}
+                  catalog={catalog}
+                  textColor={colors.text}
+                  openTicker={openTicker}
+                />
+              ) : (
+                <Spinner label="Waiting for local runtime…" />
+              )}
+            </Box>
+          )}
+        </ScrollBox>
+
+        {statusMessage && (
+          <Box paddingX={1}><Text fg={colors.warning}>{statusMessage}</Text></Box>
+        )}
+        <Box flexDirection="column" paddingX={1}>
+          {attachments.map((attachment) => (
+            <Box key={attachment.id} flexDirection="column" backgroundColor={colors.panel} paddingX={1}>
+              <Box flexDirection="row">
+                <Text fg={colors.warning} attributes={TextAttributes.BOLD}>Attached: {attachment.label}</Text>
+                <Box flexGrow={1} />
+                <Text fg={colors.textBright} onMouseDown={removeAttachments} style={{ cursor: "pointer" }}>Remove</Text>
+              </Box>
+              <ScrollBox height={Math.min(8, Math.max(3, height - 12))} scrollY focusable={false}>
+                <Text fg={colors.textDim}>{attachment.content}</Text>
+              </ScrollBox>
+            </Box>
+          ))}
+          <Box height={1} flexDirection="row">
+            <Text fg={colors.textBright} onMouseDown={attachSelectedTicker} style={{ cursor: "pointer" }}>
+              {attachments.length > 0 ? "Replace context" : `Attach ${previousSymbol ? previousSymbol : "selected ticker"}`}
+            </Text>
+            {runningMessageId && (
+              <Text fg={colors.warning} onMouseDown={cancelRun} style={{ cursor: "pointer" }}>  Cancel</Text>
+            )}
+          </Box>
+        </Box>
+        <MessageComposer
+          inputRef={inputRef}
+          initialValue={inputValue}
+          focused={inputFocused && focused}
+          placeholder={`Message ${providerLabel(activeThread.providerId)}…`}
+          width="100%"
+          height={composerHeight}
+          terminalPrefix=" > "
+          terminalBottomInset={nativePaneChrome ? 0 : 1}
+          onFocusRequest={focusInput}
+          onInput={setInputValue}
+          keyBindings={[
+            { name: "return", action: "submit" },
+            { name: "linefeed", action: "submit" },
+          ]}
+          onSubmit={submitInput}
+          wrapText
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/renderers/electrobun/bun/core-capabilities.ts
+++ b/src/renderers/electrobun/bun/core-capabilities.ts
@@ -8,8 +8,9 @@ import {
   type PluginCapability,
 } from "../../../capabilities";
 import type { AppServices } from "../../../core/app-services";
+import { resolveAiCliCommand } from "../../../plugins/builtin/ai/command-resolution";
 import { getAiProviderDefinitions } from "../../../plugins/builtin/ai/providers";
-import { isAiRunCancelled, runAiPrompt } from "../../../plugins/builtin/ai/runner";
+import { checkAiProviderStatus, isAiRunCancelled, runAiPrompt } from "../../../plugins/builtin/ai/runner";
 import type { BrokerAdapter } from "../../../types/broker";
 import type { AppConfig, BrokerInstanceConfig } from "../../../types/config";
 
@@ -267,9 +268,8 @@ function createNotesFilesCapability(): PluginCapability {
 
 function getAiProviderAvailability(): Record<string, boolean> {
   const availability: Record<string, boolean> = {};
-  const hasBunWhich = typeof Bun !== "undefined" && typeof Bun.which === "function";
   for (const definition of getAiProviderDefinitions()) {
-    availability[definition.id] = hasBunWhich ? !!Bun.which(definition.command) : false;
+    availability[definition.id] = resolveAiCliCommand(definition.command) !== null;
   }
   return availability;
 }
@@ -281,6 +281,15 @@ function createAiRunnerCapability(options: CoreCapabilityOptions): PluginCapabil
     name: "AI Runner",
     operations: {
       getProviderAvailability: op(() => getAiProviderAvailability()),
+      checkProviderStatus: op(async (input: any) => {
+        const providerId = requireString(input.providerId, "AI provider");
+        const providerDefinition = getAiProviderDefinitions().find((entry) => entry.id === providerId);
+        if (!providerDefinition) throw new Error(`Unknown AI provider: ${providerId}`);
+        return checkAiProviderStatus({
+          ...providerDefinition,
+          available: resolveAiCliCommand(providerDefinition.command) !== null,
+        });
+      }),
       run: stream((input: any, emit) => {
         const providerId = requireString(input.providerId, "AI provider");
         const prompt = requireString(input.prompt, "AI prompt");
@@ -288,7 +297,7 @@ function createAiRunnerCapability(options: CoreCapabilityOptions): PluginCapabil
         if (!providerDefinition) {
           throw new Error(`Unknown AI provider: ${providerId}`);
         }
-        if (typeof Bun === "undefined" || typeof Bun.which !== "function" || !Bun.which(providerDefinition.command)) {
+        if (!resolveAiCliCommand(providerDefinition.command)) {
           throw new Error(`${providerDefinition.name} is not installed on this system.`);
         }
 
@@ -300,6 +309,8 @@ function createAiRunnerCapability(options: CoreCapabilityOptions): PluginCapabil
           },
           prompt,
           cwd: optionalString(input.cwd) ?? options.getConfig().dataDir,
+          outputMode: input.outputMode === "structured" ? "structured" : "plain",
+          isolatedWorkspace: input.isolatedWorkspace === true,
           onChunk: (output) => {
             if (!disposed) emit({ kind: "chunk", output });
           },

--- a/src/renderers/electrobun/view/ai-host.ts
+++ b/src/renderers/electrobun/view/ai-host.ts
@@ -3,8 +3,8 @@ import {
   type AiRunnerEvent,
 } from "../../../capabilities";
 import {
-  getAiProviderDefinitions,
   __setDetectedProvidersForTests,
+  getAiProviderDefinitions,
 } from "../../../plugins/builtin/ai/providers";
 import { AiRunCancelledError, setAiRunHost } from "../../../plugins/builtin/ai/runner";
 import { backendRequest, onCapabilityEvent } from "./backend-rpc";
@@ -24,7 +24,14 @@ export async function installElectrobunAiHost(): Promise<void> {
 
   __setDetectedProvidersForTests(providers);
   setAiRunHost({
-    run({ provider, prompt, cwd, onChunk }) {
+    checkStatus(provider) {
+      return backendRequest("capability.invoke", {
+        capabilityId: AI_RUNNER_CAPABILITY_ID,
+        operationId: "checkProviderStatus",
+        payload: { providerId: provider.id },
+      });
+    },
+    run({ provider, prompt, cwd, onChunk, outputMode, isolatedWorkspace }) {
       const subscriptionId = `ai-run:${nextRunId++}`;
       let disposed = false;
       let settled = false;
@@ -69,7 +76,7 @@ export async function installElectrobunAiHost(): Promise<void> {
         }
       });
 
-      void backendRequest("capability.subscribe", {
+      const subscribePromise = backendRequest("capability.subscribe", {
         subscriptionId,
         capabilityId: AI_RUNNER_CAPABILITY_ID,
         operationId: "run",
@@ -77,10 +84,19 @@ export async function installElectrobunAiHost(): Promise<void> {
           providerId: provider.id,
           prompt,
           cwd,
+          outputMode,
+          isolatedWorkspace,
         },
       }).catch((error) => {
         settle(() => rejectDone(error));
+      }).finally(() => {
+        // Cancellation can race the async subscribe. Unsubscribe again after it
+        // settles so a late backend subscription cannot outlive this run.
+        if (disposed) {
+          void backendRequest("capability.unsubscribe", { subscriptionId }).catch(() => {});
+        }
       });
+      void subscribePromise;
 
       return {
         done,


### PR DESCRIPTION
## Summary
Adds a local, privacy-first **AI agent workspace** under the existing AI plugin — separate from the Gloom Cloud human chat, which is untouched. It lets you run research/analysis threads against a **locally authenticated agent CLI** (Claude Code, Codex, or Pi), with deliberate ticker context and no cloud credential proxying.

## What's included
- **"Local AI" pane** (command: `AGENT`). Each persisted thread binds **immutably at creation** to a chosen local runtime — **Claude Code**, **Codex**, or **Pi**; switching runtime creates a new thread.
- **Deliberate context** — you explicitly attach the active ticker/rows; nothing auto-injects portfolio or market data into prompts.
- **Structured, sandboxed runs** — provider-native non-interactive structured output (`claude --print` stream-json / `codex exec --json` / `pi -p --mode json`) parsed into the transcript; per-turn isolated temp cwd with tools/shell disabled and ephemeral sessions; cancellation preserved; transcripts stay on-device.
- **Cross-platform CLI resolution** — packaged/desktop (GUI-launched) builds augment `PATH` via a shared resolver so they find user/Homebrew-installed `claude`/`codex`/`pi`. No hardcoded paths.
- **Resilient auth checks** — 15s timeout (Node CLIs cold-start slowly), and an *inconclusive* probe (timeout/spawn failure) no longer fails closed; the run surfaces any real auth error instead. stderr is sanitized into remediation messages. Pi authenticates via its own config/env (no auth-status subcommand), so it has no pre-check and surfaces auth errors at run time.

## Testing
- Full `bun test`: **1470 pass / 0 fail**.
- Focused behavioral coverage: provider resolution, structured stream parsing (Claude / Codex / Pi), workspace thread model, and auth-probe outcomes (authenticated / confirmed-unauthenticated / inconclusive).
- Verified end-to-end on macOS (Apple Silicon): all three runtimes create threads and stream results in the pane; the Pi parser was validated against live `pi --mode json` output.

## Out of scope (deliberately deferred)
Provider OAuth, gateway proxying, remote-agent bridge, cross-device sync, automatic provider routing/fallback.

## Notes
Contribution from the Raava Solutions fork. No versioning/release changes are included — that's left to the maintainer.
