### PR TITLE
Prevent layout state races

### DIFF
--- a/src/renderers/electrobun/bun/desktop/workspace/index.test.ts
+++ b/src/renderers/electrobun/bun/desktop/workspace/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createDefaultConfig } from "../../../../../types/config";
+import { cloneLayout, createDefaultConfig } from "../../../../../types/config";
 import { createDesktopWorkspace } from "./index";
 
 describe("desktop workspace", () => {
@@ -59,5 +59,36 @@ describe("desktop workspace", () => {
     expect(snapshot.config.layout.detached).toEqual([
       { instanceId: "chat:main", x: 220, y: 260, width: 640, height: 480 },
     ]);
+  });
+
+  test("ignores main-window state that arrives behind a newer layout revision", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-desktop-layout-revision");
+    const workspace = createDesktopWorkspace(config, null);
+    const initialSnapshot = workspace.getSnapshot();
+    const monitorLayout = config.layouts[1]!;
+
+    const newerSnapshot = {
+      ...initialSnapshot,
+      config: {
+        ...initialSnapshot.config,
+        layout: cloneLayout(monitorLayout.layout),
+        activeLayoutIndex: 1,
+      },
+      paneState: monitorLayout.paneState ?? {},
+      focusedPaneId: monitorLayout.focusedPaneId ?? null,
+      activePanel: monitorLayout.activePanel ?? "left" as const,
+      mainStateRevision: 2,
+    };
+    const staleSnapshot = {
+      ...initialSnapshot,
+      mainStateRevision: 1,
+    };
+
+    workspace.syncMainState(newerSnapshot);
+    const result = workspace.syncMainState(staleSnapshot);
+
+    expect(result.mainStateRevision).toBe(2);
+    expect(result.config.activeLayoutIndex).toBe(1);
+    expect(result.config.layout).toEqual(monitorLayout.layout);
   });
 });

--- a/src/renderers/electrobun/bun/desktop/workspace/index.ts
+++ b/src/renderers/electrobun/bun/desktop/workspace/index.ts
@@ -62,6 +62,7 @@ export function createDesktopWorkspace(
     focusedPaneId: initialFocusedPaneId,
     activePanel: initialActivePanel,
     statusBarVisible: sessionSnapshot?.statusBarVisible !== false,
+    mainStateRevision: 0,
   };
 
   const updateConfig = (nextConfig: AppConfig, options?: { layoutChanged?: boolean }) => {
@@ -94,12 +95,20 @@ export function createDesktopWorkspace(
     focusedPaneId: sharedState.focusedPaneId,
     activePanel: sharedState.activePanel,
     statusBarVisible: sharedState.statusBarVisible,
+    mainStateRevision: sharedState.mainStateRevision,
     layoutChanged: sharedState.layoutChanged,
   });
 
   return {
     getSnapshot,
     syncMainState(snapshot) {
+      const currentRevision = sharedState.mainStateRevision ?? 0;
+      if (
+        typeof snapshot.mainStateRevision === "number"
+        && snapshot.mainStateRevision <= currentRevision
+      ) {
+        return getSnapshot();
+      }
       const syncedConfig = syncConfigActiveLayoutState(
         snapshot.config,
         snapshot.paneState,
@@ -116,6 +125,7 @@ export function createDesktopWorkspace(
         focusedPaneId: snapshot.focusedPaneId,
         activePanel: snapshot.activePanel,
         statusBarVisible: snapshot.statusBarVisible,
+        mainStateRevision: snapshot.mainStateRevision ?? currentRevision,
         layoutChanged: snapshot.layoutChanged,
       };
       return getSnapshot();

--- a/src/state/app/context/index.tsx
+++ b/src/state/app/context/index.tsx
@@ -369,6 +369,7 @@ export function AppProvider({
   const listenersRef = useRef(new Set<() => void>());
   const storeRef = useRef<AppContextStoreValue | null>(null);
   const lastMainSyncRef = useRef<string | null>(null);
+  const latestMainStateRevisionRef = useRef(desktopSnapshot?.mainStateRevision ?? 0);
   const lastDetachedPaneSyncRef = useRef<string | null>(null);
   const lastThemePreviewSyncRef = useRef<string | null | undefined>(undefined);
 
@@ -437,6 +438,13 @@ export function AppProvider({
   useEffect(() => {
     if (!desktopBridge) return;
     return desktopBridge.subscribeState((snapshot) => {
+      if (desktopBridge.kind === "main" && typeof snapshot.mainStateRevision === "number") {
+        if (snapshot.mainStateRevision < latestMainStateRevisionRef.current) return;
+        latestMainStateRevisionRef.current = Math.max(
+          latestMainStateRevisionRef.current,
+          snapshot.mainStateRevision,
+        );
+      }
       const currentSignature = serializeDesktopSnapshot(buildDesktopSnapshot(stateRef.current));
       const nextSignature = serializeDesktopSnapshot(snapshot);
       if (currentSignature === nextSignature) return;
@@ -455,7 +463,11 @@ export function AppProvider({
     const signature = serializeDesktopSnapshot(snapshot);
     if (signature === lastMainSyncRef.current) return;
     lastMainSyncRef.current = signature;
-    void desktopBridge.syncMainState(snapshot);
+    latestMainStateRevisionRef.current += 1;
+    void desktopBridge.syncMainState({
+      ...snapshot,
+      mainStateRevision: latestMainStateRevisionRef.current,
+    });
   }, [
     buildDesktopSnapshot,
     desktopBridge,

--- a/src/state/app/context/selector.test.tsx
+++ b/src/state/app/context/selector.test.tsx
@@ -50,11 +50,17 @@ function ThemeSelectorHarness() {
   return <text>{`${focusedPaneId ?? "none"}:${themeId}`}</text>;
 }
 
+function ActiveLayoutHarness() {
+  const activeLayoutIndex = useAppSelector((state) => state.config.activeLayoutIndex);
+  return <text>{`layout:${activeLayoutIndex}`}</text>;
+}
+
 function createDesktopBridge(
   kind: "main" | "detached",
   calls: {
     mainSnapshots?: DesktopSharedStateSnapshot[];
     themePreviews?: DesktopThemePreviewState[];
+    onStateSubscribe?: (listener: (snapshot: DesktopSharedStateSnapshot) => void) => void;
     onThemePreviewSubscribe?: (listener: (preview: DesktopThemePreviewState) => void) => void;
   } = {},
 ): DesktopWindowBridge {
@@ -71,7 +77,10 @@ function createDesktopBridge(
         calls.themePreviews?.push(preview);
       }
       : undefined,
-    subscribeState: () => () => {},
+    subscribeState: (listener) => {
+      calls.onStateSubscribe?.(listener);
+      return () => {};
+    },
     subscribeThemePreview: kind === "detached"
       ? (listener) => {
         calls.onThemePreviewSubscribe?.(listener);
@@ -263,6 +272,58 @@ describe("pane selectors", () => {
     expect(mainSnapshots).toHaveLength(1);
     expect(mainSnapshots[0]?.config.theme).toBe("green");
     expect(themePreviews).toHaveLength(0);
+  });
+
+  test("does not hydrate a stale desktop echo after a newer layout switch", async () => {
+    const mainSnapshots: DesktopSharedStateSnapshot[] = [];
+    let stateListener: ((snapshot: DesktopSharedStateSnapshot) => void) | null = null;
+    const bridge = createDesktopBridge("main", {
+      mainSnapshots,
+      onStateSubscribe: (listener) => {
+        stateListener = listener;
+      },
+    });
+
+    testSetup = await testRender(
+      <AppProvider config={createDefaultConfig("/tmp/gloomberb-layout-race")} desktopBridge={bridge}>
+        <DispatchCapture />
+        <ActiveLayoutHarness />
+      </AppProvider>,
+      { width: 24, height: 4 },
+    );
+
+    await testSetup.renderOnce();
+    const matchingNewerSnapshot = {
+      ...mainSnapshots.at(-1)!,
+      mainStateRevision: 10,
+    };
+    await act(() => {
+      stateListener?.(matchingNewerSnapshot);
+    });
+    await act(() => {
+      capturedDispatch?.({ type: "SWITCH_LAYOUT", index: 1 });
+    });
+    await testSetup.renderOnce();
+    await testSetup.renderOnce();
+    const staleSnapshot = mainSnapshots.at(-1)!;
+    expect(staleSnapshot.config.activeLayoutIndex).toBe(1);
+    expect(staleSnapshot.mainStateRevision).toBe(11);
+
+    await act(() => {
+      capturedDispatch?.({ type: "SWITCH_LAYOUT", index: 0 });
+    });
+    await testSetup.renderOnce();
+    await testSetup.renderOnce();
+    expect(mainSnapshots.at(-1)?.config.activeLayoutIndex).toBe(0);
+    expect(mainSnapshots.at(-1)!.mainStateRevision).toBeGreaterThan(staleSnapshot.mainStateRevision!);
+
+    await act(() => {
+      stateListener?.(staleSnapshot);
+    });
+    await testSetup.renderOnce();
+    await testSetup.renderOnce();
+
+    expect(testSetup.captureCharFrame()).toContain("layout:0");
   });
 
   test("desktop detached windows apply theme preview messages locally", async () => {

--- a/src/sync/controller.test.ts
+++ b/src/sync/controller.test.ts
@@ -149,3 +149,70 @@ test("keeps startup layout changes while serializing pull and push", async () =>
   expect(state.config.layout.instances).toContainEqual(startupPane);
   expect(pushedConfig.layout.instances).toContainEqual(startupPane);
 });
+
+test("keeps the latest layout when switching away and back during a pull", async () => {
+  let state = createInitialState(createDefaultConfig("/tmp/gloomberb-sync-layout-roundtrip-test"));
+  const dispatch = (action: AppAction) => {
+    state = appReducer(state, action);
+  };
+  dispatch({ type: "SWITCH_LAYOUT", index: 1 });
+  dispatch({ type: "SWITCH_LAYOUT", index: 0 });
+
+  let resolvePull!: (response: SyncSnapshotResponse) => void;
+  const deferredPull = new Promise<SyncSnapshotResponse>((resolve) => {
+    resolvePull = resolve;
+  });
+  const pushes: SyncSnapshot[] = [];
+  const transport: SyncTransport = {
+    id: "deferred-layout-pull",
+    isAvailable: () => true,
+    pullSnapshot: () => deferredPull,
+    pushSnapshot: async (snapshot) => {
+      pushes.push(snapshot);
+      return { revision: 12, updatedAt: "2026-07-21T10:00:12.000Z" };
+    },
+  };
+  const controller = new CloudSyncController();
+  controller.setRuntime({
+    getState: () => state,
+    dispatch,
+    tickerRepository: {} as TickerRepository,
+    getContributors: () => [{ pluginId: "test", contributor: coreConfigSyncContributor }],
+    getTransport: () => ({ pluginId: "test", transport }),
+  });
+
+  const startupSync = controller.requestSync({ reason: "startup" });
+  dispatch({ type: "SWITCH_LAYOUT", index: 1 });
+  dispatch({ type: "SWITCH_LAYOUT", index: 0 });
+  const queuedPush = controller.requestSync({ reason: "state-change" });
+
+  const remoteConfig = createDefaultConfig("/remote/path-is-not-synced");
+  remoteConfig.theme = "green";
+  remoteConfig.layout = remoteConfig.layouts[1]!.layout;
+  remoteConfig.activeLayoutIndex = 1;
+  resolvePull({
+    snapshot: {
+      schemaVersion: SYNC_SNAPSHOT_SCHEMA_VERSION,
+      appId: "gloomberb",
+      clientId: "remote-client",
+      createdAt: "2026-07-21T10:00:11.000Z",
+      contributors: {
+        "core.config": {
+          schemaVersion: 1,
+          updatedAt: "2026-07-21T10:00:11.000Z",
+          payload: __syncContributorInternalsForTests.collectCoreConfigPayload(remoteConfig),
+        },
+      },
+    },
+    revision: 11,
+    updatedAt: "2026-07-21T10:00:11.000Z",
+  });
+  await Promise.all([startupSync, queuedPush]);
+
+  const pushedConfig = pushes[0]?.contributors["core.config"]?.payload as {
+    activeLayoutIndex: number;
+  };
+  expect(state.config.theme).toBe("green");
+  expect(state.config.activeLayoutIndex).toBe(0);
+  expect(pushedConfig.activeLayoutIndex).toBe(0);
+});

--- a/src/sync/core-contributors.ts
+++ b/src/sync/core-contributors.ts
@@ -329,14 +329,12 @@ function mergeConfigPayload(
   assign("recentTickers");
   assign("onboardingComplete");
 
+  const layoutStateUntouched = config.layout === baselineConfig.layout
+    && config.layouts === baselineConfig.layouts
+    && config.activeLayoutIndex === baselineConfig.activeLayoutIndex;
   if (
-    ["layout", "layouts", "activeLayoutIndex"].every((key) => (
-      key in payload &&
-      valuesEqual(
-        config[key as keyof AppConfig],
-        baselineConfig[key as keyof AppConfig],
-      )
-    ))
+    layoutStateUntouched
+    && ["layout", "layouts", "activeLayoutIndex"].every((key) => key in payload)
   ) {
     next.layout = payload.layout as unknown as AppConfig["layout"];
     next.layouts = payload.layouts as AppConfig["layouts"];

--- a/src/types/desktop-window.ts
+++ b/src/types/desktop-window.ts
@@ -7,6 +7,7 @@ export interface DesktopSharedStateSnapshot {
   focusedPaneId: string | null;
   activePanel: "left" | "right";
   statusBarVisible: boolean;
+  mainStateRevision?: number;
   layoutChanged?: boolean;
 }
 


### PR DESCRIPTION
## Summary

- preserve local layout changes made while a cloud pull is in flight, including switch-away-and-back sequences
- add monotonic revisions to main-window desktop state synchronization so delayed IPC echoes cannot restore an older layout
- cover both async ordering boundaries with regression tests

## Root cause

The cloud merge used deep equality against the pull baseline, so a rapid round trip back to the same layout looked untouched and allowed stale remote layout state to win. Desktop main-state snapshots also had no ordering signal, allowing a delayed older response to overwrite newer renderer state.

## Validation

- `bun test` — 1,450 passed, 0 failed
- focused sync, app context, and desktop workspace tests — 17 passed, 0 failed
- `bun run desktop:view:build`
- rapid real TUI layout switching remained on the final selected layout after delayed cloud sync

## Note

The repository-wide TypeScript check has existing unrelated errors; changed-area tests and the desktop build are clean.