### PR TITLE
Fix chat profile guidance and analytics sync

### DIFF
--- a/src/plugins/builtin/chat/content/index.tsx
+++ b/src/plugins/builtin/chat/content/index.tsx
@@ -33,6 +33,8 @@ import { useChatComposerRuntime } from "./composer-runtime";
 import { useChatMessageSelection } from "./selection-runtime";
 import type { ChatMessage } from "../../../../api-client";
 import { NewDmDialog } from "./new-dm-dialog";
+import { usePluginAppActions } from "../../../runtime";
+import { requestAccountManagementTab } from "../../account-management/navigation";
 import {
   CHAT_MESSAGE_EDIT_WINDOW_MS,
   findLatestEditableChatMessage,
@@ -69,6 +71,7 @@ export function ChatContent({
   onTargetMessageHandled,
 }: ChatContentProps) {
   const dispatch = useAppDispatch();
+  const { showPane } = usePluginAppActions();
   const commandBarOpen = useAppSelector((state) => state.commandBarOpen);
   const channelId = normalizeChannelId(rawChannelId);
   const channelIdRef = useRef(channelId);
@@ -236,6 +239,16 @@ export function ChatContent({
     scheduleProfilePopoverClose,
     showProfilePopover,
   } = useChatProfilePopover();
+
+  const showUserProfilePopover = useCallback((targetUser: Parameters<typeof showProfilePopover>[0]) => {
+    showProfilePopover(targetUser, { ownProfile: targetUser.id === user?.id });
+  }, [showProfilePopover, user?.id]);
+
+  const openProfileSetup = useCallback(() => {
+    closeProfilePopover();
+    requestAccountManagementTab("profile");
+    showPane("account-management");
+  }, [closeProfilePopover, showPane]);
 
   const blurInput = useCallback(() => {
     setInputFocused(false);
@@ -571,10 +584,11 @@ export function ChatContent({
         scrollRef={scrollRef}
         selectedIdx={selectedIdx}
         setHoveredIdx={setHoveredIdx}
-        showProfilePopover={showProfilePopover}
+        showProfilePopover={showUserProfilePopover}
         stickyTranscript={stickyTranscript}
         user={user}
         userByUsername={userByUsername}
+        onSetUpProfile={openProfileSetup}
       />
 
       {newDmOpen ? (

--- a/src/plugins/builtin/chat/content/transcript.tsx
+++ b/src/plugins/builtin/chat/content/transcript.tsx
@@ -37,6 +37,7 @@ interface ChatTranscriptProps {
   selectedIdx: number;
   setHoveredIdx: Dispatch<SetStateAction<number | null>>;
   showProfilePopover: (user: ChatUserSummary) => void;
+  onSetUpProfile: () => void;
   stickyTranscript: boolean;
   user: { id: string; username: string; emailVerified: boolean } | null;
   userByUsername: Map<string, ChatUserSummary>;
@@ -69,7 +70,9 @@ export function ChatTranscript({
   setHoveredIdx,
   showProfilePopover,
   stickyTranscript,
+  user,
   userByUsername,
+  onSetUpProfile,
 }: ChatTranscriptProps) {
   return (
     <>
@@ -151,6 +154,8 @@ export function ChatTranscript({
           width={chatWidth}
           onClose={scheduleProfilePopoverClose}
           onKeepOpen={cancelProfilePopoverClose}
+          isOwnProfile={profilePopoverUser.id === user?.id}
+          onSetUpProfile={onSetUpProfile}
         />
       )}
     </>

--- a/src/plugins/builtin/chat/message/desktop.tsx
+++ b/src/plugins/builtin/chat/message/desktop.tsx
@@ -35,6 +35,7 @@ export const DesktopChatMessage = memo(function DesktopChatMessage({
   const showInlineEditAction = !state.grouped && canSend && canEditMessage;
   const showGroupedReplyAction = state.grouped && canSend;
   const showGroupedEditAction = state.grouped && canSend && canEditMessage;
+  const authorLabel = msg.user.username ?? "anon";
   const groupedActionWidth = MESSAGE_ACTION_WIDTH * Number(showGroupedReplyAction) + MESSAGE_ACTION_WIDTH * Number(showGroupedEditAction);
   const rowProps = {
     width: "100%",
@@ -94,15 +95,20 @@ export const DesktopChatMessage = memo(function DesktopChatMessage({
           height={1}
           paddingLeft={1}
         >
-          <Text
-            fg={state.authorColor}
-            attributes={state.authorAttributes}
+          <Box
+            height={1}
             onMouseOver={() => onUserHover(msg.user)}
+            onMouseMove={() => onUserHover(msg.user)}
             onMouseOut={onUserHoverEnd}
-            style={{ cursor: "default" }}
+            style={{ cursor: "pointer" }}
           >
-            {msg.user.username ?? "anon"}
-          </Text>
+            <Text
+              fg={state.authorColor}
+              attributes={state.authorAttributes}
+            >
+              {authorLabel}
+            </Text>
+          </Box>
           <Text fg={state.headerStatusColor}> {state.headerStatus}</Text>
           {(showInlineReplyAction || showInlineEditAction) && (
             <>

--- a/src/plugins/builtin/chat/message/profile-popover.test.tsx
+++ b/src/plugins/builtin/chat/message/profile-popover.test.tsx
@@ -1,6 +1,30 @@
-import { describe, expect, test } from "bun:test";
-import type { ChatUserSummary } from "../../../../api-client";
-import { hasPublicChatProfileInfo } from "./profile-popover";
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useEffect } from "react";
+import {
+  apiClient,
+  type AccountProfile,
+  type ChatUserSummary,
+} from "../../../../api-client";
+import { testRender } from "../../../../renderers/opentui/test-utils";
+import { Box, Text } from "../../../../ui";
+import { useChatProfilePopover } from "../profile-popover";
+import {
+  hasPublicChatProfileInfo,
+  shouldOfferChatProfileSetup,
+} from "./profile-popover";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+const originalGetAccountProfile = apiClient.getAccountProfile.bind(apiClient);
+
+afterEach(async () => {
+  apiClient.getAccountProfile = originalGetAccountProfile;
+  apiClient.setSessionToken(null);
+  if (!testSetup) return;
+  await act(async () => {
+    testSetup?.renderer.destroy();
+  });
+  testSetup = undefined;
+});
 
 function makeUser(overrides: Partial<ChatUserSummary>): ChatUserSummary {
   return {
@@ -10,6 +34,55 @@ function makeUser(overrides: Partial<ChatUserSummary>): ChatUserSummary {
     profilePublic: true,
     ...overrides,
   };
+}
+
+function makeAccountProfile(overrides: Partial<AccountProfile> = {}): AccountProfile {
+  return {
+    id: "u1",
+    email: "vince@example.com",
+    emailVerified: true,
+    plan: "pro",
+    username: "vince",
+    name: "Vince",
+    company: "Gloom",
+    title: null,
+    bio: "Made Gloomberb",
+    profilePublic: true,
+    publicEmail: null,
+    xAccount: null,
+    sharedPortfolioId: "broker:ibkr:coldstart",
+    acceptUnknownDms: false,
+    chatEmailNotificationsEnabled: true,
+    portfolioAnalytics: null,
+    syncEnabled: true,
+    weeklyRoundupEnabled: true,
+    positionAlertsEnabled: true,
+    lastSyncAt: null,
+    lastRoundupEmailAt: null,
+    updatedAt: "2026-07-21T22:03:59.832Z",
+    ...overrides,
+  };
+}
+
+function OwnProfileHarness({ user }: { user: ChatUserSummary }) {
+  const {
+    profilePopoverUser,
+    showProfilePopover,
+  } = useChatProfilePopover();
+
+  useEffect(() => {
+    showProfilePopover(user, { ownProfile: true });
+  }, [showProfilePopover, user]);
+
+  return (
+    <Box width={50} height={1}>
+      <Text>
+        {profilePopoverUser?.portfolioAnalytics
+          ? JSON.stringify(profilePopoverUser.portfolioAnalytics)
+          : "loading"}
+      </Text>
+    </Box>
+  );
 }
 
 describe("profile popover", () => {
@@ -32,5 +105,51 @@ describe("profile popover", () => {
         oneYearReturn: 0.14,
       },
     }))).toBe(false);
+  });
+
+  test("refreshes your cached chat identity from the current account profile", async () => {
+    apiClient.setSessionToken("token-123");
+    apiClient.getAccountProfile = async () => makeAccountProfile({
+      portfolioAnalytics: {
+        oneYearReturn: 0.14,
+        spyBeta: 1.05,
+      },
+    });
+
+    await act(async () => {
+      testSetup = await testRender(
+        <OwnProfileHarness user={makeUser({
+          company: "Gloom",
+          bio: "Made Gloomberb",
+          portfolioAnalytics: null,
+        })} />,
+        { width: 50, height: 8 },
+      );
+    });
+    const setup = testSetup;
+    expect(setup).toBeDefined();
+    if (!setup) return;
+    await act(async () => {
+      await setup.renderOnce();
+      await Promise.resolve();
+      await setup.renderOnce();
+      await setup.renderOnce();
+    });
+
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain('"oneYearReturn":0.14');
+    expect(frame).toContain('"spyBeta":1.05');
+  });
+
+  test("offers a quiet setup action on your own empty profile", () => {
+    const emptyProfile = makeUser({
+      bio: null,
+      company: null,
+      title: null,
+      profilePublic: false,
+    });
+    expect(shouldOfferChatProfileSetup(emptyProfile, true)).toBe(true);
+    expect(shouldOfferChatProfileSetup(emptyProfile, false)).toBe(false);
+    expect(shouldOfferChatProfileSetup(makeUser({ bio: "Already set up" }), true)).toBe(false);
   });
 });

--- a/src/plugins/builtin/chat/message/profile-popover.tsx
+++ b/src/plugins/builtin/chat/message/profile-popover.tsx
@@ -1,6 +1,7 @@
+import { useState } from "react";
 import { Box, Text } from "../../../../ui";
 import { TextAttributes } from "../../../../ui";
-import { colors } from "../../../../theme/colors";
+import { colors, hoverBg } from "../../../../theme/colors";
 import type { ChatUserSummary, PublicPortfolioAnalytics } from "../../../../api-client";
 import { formatNumber } from "../../../../utils/format";
 import { truncateChannelLabel } from "../channels";
@@ -20,6 +21,14 @@ function hasPortfolioAnalytics(analytics: PublicPortfolioAnalytics | null | unde
 export function hasPublicChatProfileInfo(user: ChatUserSummary): boolean {
   if (user.profilePublic === false) return false;
   return Boolean(user.bio?.trim() || user.title?.trim() || user.company?.trim() || hasPortfolioAnalytics(user.portfolioAnalytics));
+}
+
+export function hasChatProfileDetails(user: ChatUserSummary): boolean {
+  return Boolean(user.bio?.trim() || user.title?.trim() || user.company?.trim());
+}
+
+export function shouldOfferChatProfileSetup(user: ChatUserSummary, isOwnProfile: boolean): boolean {
+  return isOwnProfile && !hasChatProfileDetails(user);
 }
 
 function formatSignedPercent(value: number): string {
@@ -118,12 +127,17 @@ export function UserProfilePopover({
   width,
   onClose,
   onKeepOpen,
+  isOwnProfile = false,
+  onSetUpProfile,
 }: {
   user: ChatUserSummary;
   width: number;
   onClose: () => void;
   onKeepOpen: () => void;
+  isOwnProfile?: boolean;
+  onSetUpProfile?: () => void;
 }) {
+  const [setupHovered, setSetupHovered] = useState(false);
   const popoverWidth = Math.max(24, Math.min(38, width - 4));
   const meta = [user.title, user.company].filter(Boolean).join(" · ");
   const bio = user.bio?.trim();
@@ -135,6 +149,7 @@ export function UserProfilePopover({
     ? Math.min(headerMetricsNaturalWidth(metrics), maxStatsWidth)
     : 0;
   const usernameWidth = Math.max(1, headerWidth - (statsWidth > 0 ? statsWidth + 1 : 0));
+  const showSetupAction = shouldOfferChatProfileSetup(user, isOwnProfile) && !!onSetUpProfile;
 
   return (
     <Box
@@ -170,6 +185,28 @@ export function UserProfilePopover({
         <Text fg={colors.text} wrapText width={popoverWidth - 2}>
           {bio}
         </Text>
+      ) : null}
+      {showSetupAction ? (
+        <Box
+          height={1}
+          width={headerWidth}
+          backgroundColor={setupHovered ? hoverBg() : undefined}
+          onMouseOver={() => setSetupHovered(true)}
+          onMouseOut={() => setSetupHovered(false)}
+          onMouseDown={(event: { preventDefault?: () => void; stopPropagation?: () => void }) => {
+            event?.preventDefault?.();
+            event?.stopPropagation?.();
+            onSetUpProfile?.();
+          }}
+          style={{ cursor: "pointer" }}
+        >
+          <Text
+            fg={setupHovered ? colors.text : colors.textMuted}
+            attributes={setupHovered ? TextAttributes.BOLD : 0}
+          >
+            Set up profile
+          </Text>
+        </Box>
       ) : null}
     </Box>
   );

--- a/src/plugins/builtin/chat/message/terminal.tsx
+++ b/src/plugins/builtin/chat/message/terminal.tsx
@@ -38,6 +38,7 @@ export function TerminalChatMessage({
   const showInlineEditAction = !state.grouped && state.showReplyAction && canEditMessage;
   const showGroupedReplyAction = state.grouped && state.showReplyAction;
   const showGroupedEditAction = state.grouped && state.showReplyAction && canEditMessage;
+  const authorLabel = msg.user.username ?? "anon";
   const groupedActionWidth = MESSAGE_ACTION_WIDTH * Number(showGroupedReplyAction) + MESSAGE_ACTION_WIDTH * Number(showGroupedEditAction);
   const setHovered = () => setHoveredIdx((current) => (current === index ? current : index));
   const clearHovered = () => setHoveredIdx((current) => (current === index ? null : current));
@@ -77,14 +78,21 @@ export function TerminalChatMessage({
           height={1}
           paddingLeft={1}
         >
-          <Text
-            fg={state.authorColor}
-            attributes={state.authorAttributes}
+          <Box
+            width={authorLabel.length}
+            height={1}
             onMouseOver={() => onUserHover(msg.user)}
+            onMouseMove={() => onUserHover(msg.user)}
             onMouseOut={onUserHoverEnd}
+            style={{ cursor: "pointer" }}
           >
-            {msg.user.username ?? "anon"}
-          </Text>
+            <Text
+              fg={state.authorColor}
+              attributes={state.authorAttributes}
+            >
+              {authorLabel}
+            </Text>
+          </Box>
           <Text fg={state.headerStatusColor}> {state.headerStatus}</Text>
           {(showInlineReplyAction || showInlineEditAction) && (
             <>

--- a/src/plugins/builtin/chat/profile-popover.ts
+++ b/src/plugins/builtin/chat/profile-popover.ts
@@ -1,13 +1,35 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { ChatUserSummary } from "../../../api-client";
+import {
+  apiClient,
+  type AccountProfile,
+  type ChatUserSummary,
+} from "../../../api-client";
 import {
   PROFILE_POPOVER_CLOSE_DELAY_MS,
   hasPublicChatProfileInfo,
 } from "./message/profile-popover";
 
+function accountProfileToChatUser(profile: AccountProfile): ChatUserSummary {
+  return {
+    id: profile.id,
+    username: profile.username,
+    displayName: profile.name,
+    bio: profile.bio,
+    company: profile.company,
+    title: profile.title,
+    profilePublic: profile.profilePublic,
+    acceptUnknownDms: profile.acceptUnknownDms,
+    portfolioAnalytics: profile.portfolioAnalytics,
+  };
+}
+
 export function useChatProfilePopover() {
   const [profilePopoverUser, setProfilePopoverUser] = useState<ChatUserSummary | null>(null);
   const profilePopoverCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const ownProfileRef = useRef<ChatUserSummary | null>(null);
+  const ownProfileRequestRef = useRef<Promise<void> | null>(null);
+  const ownProfileLoadedAtRef = useRef(0);
+  const activeRef = useRef(true);
 
   const cancelProfilePopoverClose = useCallback(() => {
     if (profilePopoverCloseTimerRef.current == null) return;
@@ -28,16 +50,51 @@ export function useChatProfilePopover() {
     }, PROFILE_POPOVER_CLOSE_DELAY_MS);
   }, [cancelProfilePopoverClose]);
 
-  const showProfilePopover = useCallback((targetUser: ChatUserSummary) => {
-    if (!hasPublicChatProfileInfo(targetUser)) {
+  const showProfilePopover = useCallback((
+    targetUser: ChatUserSummary,
+    options?: { ownProfile?: boolean },
+  ) => {
+    const ownProfile = options?.ownProfile === true;
+    const cachedUser = ownProfile && ownProfileRef.current?.id === targetUser.id
+      ? ownProfileRef.current
+      : targetUser;
+    if (!ownProfile && !hasPublicChatProfileInfo(cachedUser)) {
       closeProfilePopover();
       return;
     }
     cancelProfilePopoverClose();
-    setProfilePopoverUser(targetUser);
+    setProfilePopoverUser(cachedUser);
+
+    if (
+      !ownProfile
+      || !apiClient.getSessionToken()
+      || ownProfileRequestRef.current
+      || (ownProfileRef.current?.id === targetUser.id && Date.now() - ownProfileLoadedAtRef.current < 10_000)
+    ) return;
+    const request = apiClient.getAccountProfile()
+      .then((profile) => {
+        if (!activeRef.current || profile.id !== targetUser.id) return;
+        const nextUser = accountProfileToChatUser(profile);
+        ownProfileRef.current = nextUser;
+        ownProfileLoadedAtRef.current = Date.now();
+        setProfilePopoverUser((current) => current?.id === targetUser.id ? nextUser : current);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (ownProfileRequestRef.current === request) {
+          ownProfileRequestRef.current = null;
+        }
+      });
+    ownProfileRequestRef.current = request;
   }, [cancelProfilePopoverClose, closeProfilePopover]);
 
-  useEffect(() => () => cancelProfilePopoverClose(), [cancelProfilePopoverClose]);
+  useEffect(() => {
+    activeRef.current = true;
+    return () => {
+      activeRef.current = false;
+      cancelProfilePopoverClose();
+    };
+  }, [cancelProfilePopoverClose]);
 
   return {
     cancelProfilePopoverClose,

--- a/src/sync/core-contributors.test.ts
+++ b/src/sync/core-contributors.test.ts
@@ -248,4 +248,39 @@ describe("core sync contributors", () => {
     });
     expect(payload.analyticsByPortfolio.preview).not.toHaveProperty("marketValue");
   });
+
+  test("preserves pulled profile analytics before local market data is ready", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-sync-test");
+    config.portfolios = [{ id: "main", name: "Main", currency: "USD" }];
+    const state = createInitialState(config);
+
+    await coreCollectionsSyncContributor.apply?.({
+      analyticsByPortfolio: {
+        main: { oneYearReturn: 0.27, spyBeta: 1.1 },
+      },
+      tickers: [],
+    }, {
+      snapshot: {
+        schemaVersion: 1,
+        appId: "gloomberb",
+        clientId: "test-client",
+        createdAt: "2026-07-21T22:03:59.832Z",
+        contributors: {},
+      },
+      baselineState: state,
+      state,
+      getState: () => state,
+      isCurrent: () => true,
+      dispatch: () => {},
+      tickerRepository: {} as never,
+    });
+
+    const payload = await coreCollectionsSyncContributor.collect({ state }) as any;
+    setSyncedProfileAnalytics("main", null);
+
+    expect(payload.analyticsByPortfolio.main).toEqual({
+      oneYearReturn: 0.27,
+      spyBeta: 1.1,
+    });
+  });
 });

--- a/src/sync/core-contributors.ts
+++ b/src/sync/core-contributors.ts
@@ -12,7 +12,10 @@ import {
   computeWeightedPortfolioReturns,
   type WeightedReturnSeries,
 } from "../plugins/builtin/analytics/metrics";
-import { getSyncedProfileAnalytics } from "./profile-analytics";
+import {
+  getSyncedProfileAnalytics,
+  setSyncedProfileAnalytics,
+} from "./profile-analytics";
 
 const SENSITIVE_KEY_PATTERN = /(token|secret|password|credential|private|api[_-]?key|access[_-]?key|refresh[_-]?key|session|cookie|dataDir|path|directory|localPath)/i;
 
@@ -296,6 +299,17 @@ function collectCoreCollectionsPayload(
   };
 }
 
+function hydrateProfileAnalytics(payload: Record<string, unknown>): void {
+  if (!isPlainObject(payload.analyticsByPortfolio)) return;
+  for (const [portfolioId, analytics] of Object.entries(payload.analyticsByPortfolio)) {
+    if (!isPlainObject(analytics)) continue;
+    setSyncedProfileAnalytics(portfolioId, {
+      oneYearReturn: typeof analytics.oneYearReturn === "number" ? analytics.oneYearReturn : null,
+      spyBeta: typeof analytics.spyBeta === "number" ? analytics.spyBeta : null,
+    });
+  }
+}
+
 function valuesEqual(left: unknown, right: unknown): boolean {
   return stableStringify(left) === stableStringify(right);
 }
@@ -383,6 +397,7 @@ export const coreCollectionsSyncContributor: SyncContributor = {
   ),
   apply: async (payload, { getState, isCurrent, dispatch, tickerRepository }) => {
     if (!isPlainObject(payload)) return;
+    hydrateProfileAnalytics(payload);
     const incomingRecords: TickerRecord[] = [];
     const rawTickers = Array.isArray(payload.tickers) ? payload.tickers : [];
     for (const rawTicker of rawTickers) {


### PR DESCRIPTION
## What changed

- add a quiet **Set up profile** action to an empty logged-in user's own chat hover card
- make chat author names consistently mouse-interactive in both terminal and desktop renderers
- refresh the current user's hover-card data from the canonical account profile
- preserve pulled public portfolio analytics while local market history is still loading

## Why

Chat transcripts can contain stale denormalized user metadata, so a user's own hover card could omit already-published return and beta metrics. Separately, the startup sync path could pull valid analytics and immediately overwrite them with null values before local analytics inputs were ready.

## Impact

Users without profile details get a subtle path into Profile settings. Users who share a portfolio keep seeing their published 1Y return and SPY beta after cold starts, without exposing positions.

## Validation

- `bun test src/sync/core-contributors.test.ts src/plugins/builtin/chat/message/profile-popover.test.tsx src/plugins/builtin/chat/chat.test.tsx` (44 passed)
- `bun run desktop:view:build`
- `bun run build`
- `git diff --check origin/main...HEAD`
- full TypeScript check remains baseline-red in unrelated files; changed chat/sync files report no errors
- real terminal and desktop hover-card verification against the logged-in production profile
- cold-start production read-back confirmed published analytics remain populated