### PR TITLE
feat(layout): add direct pane grid construction

### DIFF
--- a/src/components/command-bar/keyboard-shortcuts.ts
+++ b/src/components/command-bar/keyboard-shortcuts.ts
@@ -200,5 +200,9 @@ export function useCommandBarKeyboardShortcuts({
       }
       activateListSelection();
     }
-  }, { phase: "before", allowEditable: true });
+  }, {
+    phase: "before",
+    allowEditable: true,
+    interceptNative: (event) => event.targetEditable === true,
+  });
 }

--- a/src/components/command-bar/layout-items/current-layout.test.ts
+++ b/src/components/command-bar/layout-items/current-layout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createInitialState, type AppAction, type AppState } from "../../../state/app/context";
 import { cloneLayout, createDefaultConfig, type LayoutConfig } from "../../../types/config";
+import { getDockedPaneIds } from "../../../plugins/pane-manager";
 import type { PluginRegistry } from "../../../plugins/registry";
 import type { CommandBarRoute } from "../workflow/types";
 import type { LayoutItemsContext } from "./types";
@@ -67,6 +68,25 @@ function createLayoutItemsContext(
 }
 
 describe("buildCurrentLayoutItems", () => {
+  test("exposes one-action presets that tile every visible pane", () => {
+    const layouts: LayoutConfig[] = [];
+    const confirmations: InlineConfirmOptions[] = [];
+    const items = buildCurrentLayoutItems(createLayoutItemsContext({ layouts, confirmations }));
+
+    expect(items.filter((entry) => entry.category === "Layout Presets").map((entry) => entry.label)).toEqual([
+      "Single Column",
+      "2x2 Grid",
+      "3x3 Grid",
+      "Left Main + Right Stack",
+    ]);
+
+    items.find((entry) => entry.id === "layout-preset:2x2")?.action();
+
+    expect(layouts).toHaveLength(1);
+    expect(layouts[0]?.floating).toEqual([]);
+    expect(getDockedPaneIds(layouts[0]!)).toHaveLength(3);
+  });
+
   test("closes all floating panes from the current layout", () => {
     const layouts: LayoutConfig[] = [];
     const confirmations: InlineConfirmOptions[] = [];

--- a/src/components/command-bar/layout-items/current-layout.ts
+++ b/src/components/command-bar/layout-items/current-layout.ts
@@ -1,6 +1,8 @@
 import {
+  applyLayoutPreset,
   gridlockAllPanes,
   removeFloatingPanes,
+  type LayoutPresetId,
 } from "../../../plugins/pane-manager";
 import {
   DEFAULT_LAYOUT,
@@ -24,8 +26,31 @@ export function buildCurrentLayoutItems({
   const layoutHistory = state.layoutHistory[state.config.activeLayoutIndex];
   const floatingPaneCount = currentLayout.floating.length;
   const floatingPaneLabel = floatingPaneCount === 1 ? "floating pane" : "floating panes";
+  const presetItems = ([
+    ["single", "Single Column", "Stack all visible panes in one column"],
+    ["2x2", "2x2 Grid", "Arrange visible panes in a two-column grid"],
+    ["3x3", "3x3 Grid", "Arrange visible panes in a three-column grid"],
+    ["left-main", "Left Main + Right Stack", "Make the first pane primary and stack the rest on the right"],
+  ] satisfies Array<[LayoutPresetId, string, string]>).map(([preset, label, detail]) => ({
+    id: `layout-preset:${preset}`,
+    label,
+    detail,
+    category: "Layout Presets",
+    kind: "action" as const,
+    action: () => {
+      const { width, height } = pluginRegistry.getTermSizeFn();
+      persistLayoutChange(applyLayoutPreset(
+        currentLayout,
+        preset,
+        { x: 0, y: 0, width, height },
+        pluginRegistry.panes,
+      ));
+      closeAll({ revertThemePreview: false });
+    },
+  }));
 
   return [
+    ...presetItems,
     {
       id: "layout-undo",
       label: "Undo Layout Change",

--- a/src/components/command-bar/layout-items/focused-pane.ts
+++ b/src/components/command-bar/layout-items/focused-pane.ts
@@ -1,7 +1,8 @@
 import {
-  dockPane,
-  floatPane,
+  dockFloatingPaneAtCurrentRect,
+  floatAtRect,
   getDockedPaneIds,
+  getLeafRect,
   removePane,
 } from "../../../plugins/pane-manager";
 import { findPaneInstance } from "../../../types/config";
@@ -46,9 +47,15 @@ export function buildFocusedPaneLayoutItems({
       kind: "action",
       action: () => {
         const { width, height } = pluginRegistry.getTermSizeFn();
+        const bounds = { x: 0, y: 0, width, height };
+        const tiledRect = focusedFloating
+          ? null
+          : getLeafRect(currentLayout, focusedPane.instanceId, bounds);
         const nextLayout = focusedFloating
-          ? dockPane(currentLayout, focusedPane.instanceId)
-          : floatPane(currentLayout, focusedPane.instanceId, width, height, focusedPaneDef);
+          ? dockFloatingPaneAtCurrentRect(currentLayout, focusedPane.instanceId, bounds)
+          : tiledRect
+            ? floatAtRect(currentLayout, focusedPane.instanceId, tiledRect)
+            : currentLayout;
         persistLayoutChange(nextLayout);
         closeAll({ revertThemePreview: false });
       },

--- a/src/components/layout/floating-pane.test.tsx
+++ b/src/components/layout/floating-pane.test.tsx
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { ReactNode } from "react";
+import { UiHostProvider } from "../../ui";
+import type { RendererHost, UiHost } from "../../ui/host";
+import { shouldDispatchWebAppKeyDown } from "../../renderers/electrobun/view/key-event";
+import { FloatingPaneWrapper } from "./floating-pane";
+import { DesktopPaneButton } from "./pane/header";
+
+const rendererHost: RendererHost = {
+  requestExit() {},
+  async openExternal() {},
+  async copyText() {},
+  async readText() { return ""; },
+  notify() {},
+};
+
+describe("FloatingPaneWrapper", () => {
+  test("leaves the native header interior move-owned and exposes all eight resize handles", () => {
+    const resizeHandles: Array<Record<string, unknown>> = [];
+    const headerHitTargets: Array<Record<string, unknown>> = [];
+    const Box = ({ children, ...props }: Record<string, unknown> & { children?: ReactNode }) => {
+      if (props["data-gloom-role"] === "resize-handle") resizeHandles.push(props);
+      if (props["data-gloom-role"] === "pane-header-actions" || props["data-gloom-role"] === "pane-close") {
+        headerHitTargets.push(props);
+      }
+      return <div>{children}</div>;
+    };
+    const Inline = ({ children }: { children?: ReactNode }) => <span>{children}</span>;
+    const ui = {
+      capabilities: { nativePaneChrome: true },
+      Box,
+      Text: Inline,
+      Span: Inline,
+      Strong: Inline,
+      Underline: Inline,
+      ScrollBox: Box,
+      Input: Box,
+      Textarea: Box,
+      ChartSurface: Box,
+      ImageSurface: Box,
+      SpinnerMark: Inline,
+      AsciiText: Inline,
+    } as unknown as UiHost;
+
+    const markup = renderToStaticMarkup(
+      <UiHostProvider ui={ui} renderer={rendererHost}>
+        <FloatingPaneWrapper
+          paneId="floating:main"
+          title="Floating"
+          x={8}
+          y={2}
+          width={32}
+          height={10}
+          zIndex={75}
+          focused
+          showActions
+          onFloatToggleMouseDown={() => {}}
+          onActionMouseDown={() => {}}
+          onCloseMouseDown={() => {}}
+        >
+          <span>body</span>
+        </FloatingPaneWrapper>
+      </UiHostProvider>,
+    );
+
+    expect(resizeHandles.map((handle) => handle["data-corner"])).toEqual([
+      "top-left",
+      "top-right",
+      "top",
+      "left",
+      "right",
+      "bottom-left",
+      "bottom",
+      "bottom-right",
+    ]);
+    expect(resizeHandles.filter((handle) => String(handle["data-corner"]).startsWith("top")))
+      .toEqual([
+        expect.objectContaining({ top: 0, left: 0, width: 2, height: 1 }),
+        expect.objectContaining({ top: 0, right: 0, width: 2, height: 1 }),
+        expect.objectContaining({ top: 0, left: 14, width: 4, height: 1, zIndex: 1 }),
+      ]);
+    expect(headerHitTargets).toEqual([
+      expect.objectContaining({ "data-gloom-role": "pane-header-actions", position: "relative", zIndex: 2 }),
+      expect.objectContaining({ "data-gloom-role": "pane-close", position: "relative", zIndex: 2 }),
+    ]);
+    expect(resizeHandles.find((handle) => handle["data-corner"] === "top")?.width)
+      .toBeLessThan(32 - 4);
+    expect(resizeHandles.find((handle) => handle["data-corner"] === "top-right")?.zIndex).toBeUndefined();
+    expect(markup).toContain('<button type="button"');
+    expect(markup.match(/<button type="button"/g)).toHaveLength(3);
+    expect(markup.indexOf('data-gloom-role="pane-float-toggle"'))
+      .toBeLessThan(markup.indexOf('data-gloom-role="pane-action"'));
+    expect(markup.indexOf('data-gloom-role="pane-action"'))
+      .toBeLessThan(markup.indexOf('data-gloom-role="pane-close"'));
+    expect(markup).not.toContain("tabindex=");
+    expect(markup).toContain('aria-label="Pane is floating — tile pane"');
+  });
+
+  test("lets native pane-header buttons focus and activate without pane shortcuts or dragging", () => {
+    let activations = 0;
+    let focusedPaneShortcuts = 0;
+    let headerDrags = 0;
+    let activeElement: { tagName: string } | null = null;
+    const button = DesktopPaneButton({
+      label: "Tile pane",
+      icon: null,
+      role: "pane-float-toggle",
+      onActivate: () => { activations += 1; },
+    });
+    const props = button.props as {
+      onClick?: (event: unknown) => void;
+      onKeyDown?: (event: unknown) => void;
+      onMouseDown?: (event: { stopPropagation(): void; preventDefault(): void }) => void;
+      tabIndex?: number;
+    };
+    const buttonElement = { tagName: "BUTTON" };
+
+    const pressKey = (key: string) => {
+      const event = {
+        key,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        target: activeElement,
+      } as never;
+      if (shouldDispatchWebAppKeyDown(event)) focusedPaneShortcuts += 1;
+      if (activeElement === buttonElement && (key === "Enter" || key === " ")) {
+        props.onClick?.(event);
+      }
+    };
+
+    expect(shouldDispatchWebAppKeyDown({
+      key: "Tab",
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      target: null,
+    } as never)).toBe(false);
+    activeElement = buttonElement;
+
+    pressKey("Enter");
+    expect(activations).toBe(1);
+    expect(focusedPaneShortcuts).toBe(0);
+    expect(headerDrags).toBe(0);
+
+    pressKey(" ");
+    expect(activations).toBe(2);
+    expect(focusedPaneShortcuts).toBe(0);
+    expect(headerDrags).toBe(0);
+
+    let stopped = false;
+    let prevented = false;
+    props.onMouseDown?.({
+      stopPropagation() { stopped = true; },
+      preventDefault() { prevented = true; },
+    });
+    if (!stopped) headerDrags += 1;
+
+    expect(stopped).toBe(true);
+    expect(prevented).toBe(false);
+    expect(activations).toBe(2);
+    expect(props.tabIndex).toBeUndefined();
+    expect(props.onKeyDown).toBeUndefined();
+    expect(headerDrags).toBe(0);
+
+    props.onClick?.({});
+    expect(activations).toBe(3);
+    expect(focusedPaneShortcuts).toBe(0);
+    expect(headerDrags).toBe(0);
+  });
+});

--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, useUiCapabilities } from "../../ui";
 import type { ReactNode } from "react";
 import { colors, floatingPaneBg } from "../../theme/colors";
+import type { FloatingResizeCorner } from "../../plugins/pane-manager";
 import { PaneBodyFrame, getPaneWindowAttributes } from "./pane/frame";
 import { PaneHeader } from "./pane/header";
 import { hasPaneFooterContent, PaneFooterBar, type CombinedPaneFooter } from "./pane/footer";
@@ -24,8 +25,9 @@ interface FloatingPaneWrapperProps {
   onHeaderMouseDragEnd?: (event: any) => void;
   onHeaderContextMenu?: (event: any) => void;
   onActionMouseDown?: (event: any) => void;
+  onFloatToggleMouseDown?: (event: any) => void;
   onCloseMouseDown?: (event: any) => void;
-  onResizeMouseDown?: (event: any) => void;
+  onResizeMouseDown?: (corner: FloatingResizeCorner, event: any) => void;
   onResizeMouseDrag?: (event: any) => void;
   onResizeMouseDragEnd?: (event: any) => void;
   footer?: CombinedPaneFooter | null;
@@ -69,6 +71,7 @@ export function FloatingPaneWrapper({
   onHeaderMouseDragEnd,
   onHeaderContextMenu,
   onActionMouseDown,
+  onFloatToggleMouseDown,
   onCloseMouseDown,
   onResizeMouseDown,
   onResizeMouseDrag,
@@ -82,9 +85,12 @@ export function FloatingPaneWrapper({
   const reserveFooter = shouldReservePaneFooter(nativePaneChrome, showFooter);
   const renderFooter = reserveFooter || showFooter;
   const bodyFrame = resolvePaneBodyFrame({ height, nativePaneChrome, footerVisible: renderFooter, reserveFooter });
+  const topResizeWidth = Math.min(4, Math.max(0, width - 4));
+  const topResizeLeft = Math.max(2, Math.floor((width - topResizeWidth) / 2));
 
   return (
     <Box
+      id={`floating-pane:${paneId}`}
       position="absolute"
       top={y}
       left={x}
@@ -118,6 +124,7 @@ export function FloatingPaneWrapper({
         onHeaderMouseDragEnd={onHeaderMouseDragEnd}
         onHeaderContextMenu={onHeaderContextMenu}
         onActionMouseDown={onActionMouseDown}
+        onFloatToggleMouseDown={onFloatToggleMouseDown}
         onCloseMouseDown={onCloseMouseDown}
       />
 
@@ -138,17 +145,105 @@ export function FloatingPaneWrapper({
       {!nativePaneChrome && !focused && <TerminalFloatingPaneBorder width={width} height={height} />}
 
       {nativePaneChrome ? (
-        <Box
-          position="absolute"
-          bottom={0}
-          right={0}
-          width={2}
-          height={1}
-          data-gloom-role="resize-handle"
-          onMouseDown={onResizeMouseDown}
-          onMouseDrag={onResizeMouseDrag}
-          onMouseDragEnd={onResizeMouseDragEnd}
-        />
+        <>
+          <Box
+            position="absolute"
+            top={0}
+            left={0}
+            width={2}
+            height={1}
+            data-gloom-role="resize-handle"
+            data-corner="top-left"
+            onMouseDown={(event: any) => onResizeMouseDown?.("top-left", event)}
+            onMouseDrag={onResizeMouseDrag}
+            onMouseDragEnd={onResizeMouseDragEnd}
+          />
+          <Box
+            position="absolute"
+            top={0}
+            right={0}
+            width={2}
+            height={1}
+            data-gloom-role="resize-handle"
+            data-corner="top-right"
+            onMouseDown={(event: any) => onResizeMouseDown?.("top-right", event)}
+            onMouseDrag={onResizeMouseDrag}
+            onMouseDragEnd={onResizeMouseDragEnd}
+          />
+          <Box
+            position="absolute"
+            top={0}
+            left={topResizeLeft}
+            width={topResizeWidth}
+            height={1}
+            zIndex={1}
+            data-gloom-role="resize-handle"
+            data-corner="top"
+            onMouseDown={(event: any) => onResizeMouseDown?.("top", event)}
+            onMouseDrag={onResizeMouseDrag}
+            onMouseDragEnd={onResizeMouseDragEnd}
+          />
+          <Box
+            position="absolute"
+            top={1}
+            left={0}
+            width={1}
+            height={Math.max(0, height - 2)}
+            data-gloom-role="resize-handle"
+            data-corner="left"
+            onMouseDown={(event: any) => onResizeMouseDown?.("left", event)}
+            onMouseDrag={onResizeMouseDrag}
+            onMouseDragEnd={onResizeMouseDragEnd}
+          />
+          <Box
+            position="absolute"
+            top={1}
+            right={0}
+            width={1}
+            height={Math.max(0, height - 2)}
+            data-gloom-role="resize-handle"
+            data-corner="right"
+            onMouseDown={(event: any) => onResizeMouseDown?.("right", event)}
+            onMouseDrag={onResizeMouseDrag}
+            onMouseDragEnd={onResizeMouseDragEnd}
+          />
+          <Box
+            position="absolute"
+            bottom={0}
+            left={0}
+            width={2}
+            height={1}
+            data-gloom-role="resize-handle"
+            data-corner="bottom-left"
+            onMouseDown={(event: any) => onResizeMouseDown?.("bottom-left", event)}
+            onMouseDrag={onResizeMouseDrag}
+            onMouseDragEnd={onResizeMouseDragEnd}
+          />
+          <Box
+            position="absolute"
+            bottom={0}
+            left={2}
+            width={Math.max(0, width - 4)}
+            height={1}
+            data-gloom-role="resize-handle"
+            data-corner="bottom"
+            onMouseDown={(event: any) => onResizeMouseDown?.("bottom", event)}
+            onMouseDrag={onResizeMouseDrag}
+            onMouseDragEnd={onResizeMouseDragEnd}
+          />
+          <Box
+            position="absolute"
+            bottom={0}
+            right={0}
+            width={2}
+            height={1}
+            data-gloom-role="resize-handle"
+            data-corner="bottom-right"
+            onMouseDown={(event: any) => onResizeMouseDown?.("bottom-right", event)}
+            onMouseDrag={onResizeMouseDrag}
+            onMouseDragEnd={onResizeMouseDragEnd}
+          />
+        </>
       ) : (
         <Box position="absolute" bottom={0} right={0} width={2} height={1}>
           <Text fg={focused ? colors.borderFocused : colors.border} selectable={false}>{"─◢"}</Text>

--- a/src/components/layout/pane/header.tsx
+++ b/src/components/layout/pane/header.tsx
@@ -1,4 +1,4 @@
-import { Box, Span, Text, useNativeRenderer, useUiCapabilities } from "../../../ui";
+import { Box, Span, Text, useNativeRenderer, useUiCapabilities, useUiHost } from "../../../ui";
 import { useCallback, useRef, type ReactNode } from "react";
 import { blendHex, colors, floatingPaneTitleBg, paneTitleBg, paneTitleText } from "../../../theme/colors";
 
@@ -6,6 +6,8 @@ const PANE_HEADER_HEIGHT = 1;
 const PANE_HEADER_GRIP = ":: ";
 export const PANE_HEADER_ACTION = " ... ";
 export const PANE_HEADER_CLOSE = " x ";
+export const PANE_HEADER_TILED = "T▦";
+export const PANE_HEADER_FLOATING = "F◇";
 
 interface PaneHeaderProps {
   title: string;
@@ -20,6 +22,7 @@ interface PaneHeaderProps {
   onHeaderMouseDragEnd?: (event: any) => void;
   onHeaderContextMenu?: (event: any) => void;
   onActionMouseDown?: (event: any) => void;
+  onFloatToggleMouseDown?: (event: any) => void;
   onCloseMouseDown?: (event: any) => void;
 }
 
@@ -42,26 +45,38 @@ function captureTerminalPointerDrag(renderer: unknown, renderable: unknown): voi
   capture.call(renderer, renderable);
 }
 
-function DesktopPaneButton({
+export function DesktopPaneButton({
+  label,
   icon,
-  onMouseDown,
+  onActivate,
+  role,
 }: {
+  label: string;
   icon: ReactNode;
-  onMouseDown?: (event: any) => void;
+  onActivate?: (event: any) => void;
+  role: string;
 }) {
   return (
-    <Box
-      height={1}
-      alignItems="center"
-      justifyContent="center"
-      onMouseDown={onMouseDown}
-      data-gloom-interactive={onMouseDown ? "true" : undefined}
+    <button
+      type="button"
+      onMouseDown={(event) => event.stopPropagation()}
+      onClick={onActivate}
+      data-gloom-role={role}
+      data-gloom-interactive={onActivate ? "true" : undefined}
+      aria-label={label}
+      title={label}
       style={{
+        appearance: "none",
+        border: 0,
         borderRadius: 4,
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        height: "100%",
         minWidth: 20,
         paddingInline: 4,
         backgroundColor: "transparent",
-        cursor: onMouseDown ? "pointer" : "default",
+        cursor: onActivate ? "pointer" : "default",
       }}
     >
       <Span
@@ -76,7 +91,7 @@ function DesktopPaneButton({
       >
         {icon}
       </Span>
-    </Box>
+    </button>
   );
 }
 
@@ -118,15 +133,21 @@ export function PaneHeader({
   onHeaderMouseDragEnd,
   onHeaderContextMenu,
   onActionMouseDown,
+  onFloatToggleMouseDown,
   onCloseMouseDown,
 }: PaneHeaderProps) {
   const { nativePaneChrome } = useUiCapabilities();
+  const uiKind = useUiHost().kind;
   const nativeRenderer = useNativeRenderer();
   const terminalHeaderRef = useRef<unknown>(null);
   const visuallyFocused = focused || windowModeSelected;
   const backgroundColor = floating ? floatingPaneTitleBg(visuallyFocused) : paneTitleBg(visuallyFocused);
   const actionText = showActions ? PANE_HEADER_ACTION : "     ";
   const closeText = floating ? PANE_HEADER_CLOSE : "";
+  const floatToggleText = floating ? PANE_HEADER_FLOATING : PANE_HEADER_TILED;
+  const floatToggleLabel = floating
+    ? "Pane is floating — tile pane"
+    : "Pane is tiled — float pane";
   const textColor = paneTitleText(visuallyFocused, floating);
   const handleTerminalHeaderMouseDown = useCallback((event: any) => {
     captureTerminalPointerDrag(nativeRenderer, terminalHeaderRef.current);
@@ -175,35 +196,72 @@ export function PaneHeader({
             {title}
           </Text>
         </Box>
-        <Box data-gloom-role="pane-action">
-          {showActions ? (
+        <Box data-gloom-role="pane-header-actions" position="relative" zIndex={2}>
+          {uiKind === "opentui" ? (
+            <TerminalPaneButton
+              text={floatToggleText}
+              fg={colors.textDim}
+              role="pane-float-toggle"
+              onMouseDown={onFloatToggleMouseDown}
+            />
+          ) : (
             <DesktopPaneButton
-              onMouseDown={onActionMouseDown}
-              icon={(
+              label={floatToggleLabel}
+              onActivate={onFloatToggleMouseDown}
+              role="pane-float-toggle"
+              icon={floating ? (
                 <svg viewBox="0 0 12 12" width="12" height="12" fill="none" aria-hidden="true">
-                  <circle cx="2" cy="6" r="1.1" fill="currentColor" />
-                  <circle cx="6" cy="6" r="1.1" fill="currentColor" />
-                  <circle cx="10" cy="6" r="1.1" fill="currentColor" />
+                  <rect x="1.5" y="1.5" width="7" height="7" rx="1" stroke="currentColor" strokeWidth="1.2" />
+                  <rect x="4.5" y="4.5" width="6" height="6" rx="1" fill={backgroundColor} stroke="currentColor" strokeWidth="1.2" />
+                </svg>
+              ) : (
+                <svg viewBox="0 0 12 12" width="12" height="12" fill="none" aria-hidden="true">
+                  <rect x="1" y="1" width="10" height="10" rx="1" stroke="currentColor" strokeWidth="1.2" />
+                  <path d="M6 1V11M1 6H11" stroke="currentColor" strokeWidth="1" />
                 </svg>
               )}
             />
+          )}
+          {showActions ? (
+            uiKind === "opentui" ? (
+              <TerminalPaneButton text={PANE_HEADER_ACTION} fg={colors.textDim} role="pane-action" onMouseDown={onActionMouseDown} />
+            ) : (
+              <DesktopPaneButton
+                label="Pane actions"
+                onActivate={onActionMouseDown}
+                role="pane-action"
+                icon={(
+                  <svg viewBox="0 0 12 12" width="12" height="12" fill="none" aria-hidden="true">
+                    <circle cx="2" cy="6" r="1.1" fill="currentColor" />
+                    <circle cx="6" cy="6" r="1.1" fill="currentColor" />
+                    <circle cx="10" cy="6" r="1.1" fill="currentColor" />
+                  </svg>
+                )}
+              />
+            )
           ) : <Box width={2} />}
         </Box>
         {floating && (
-          <Box data-gloom-role="pane-close" marginLeft={1}>
-            <DesktopPaneButton
-              onMouseDown={onCloseMouseDown}
-              icon={(
-                <svg viewBox="0 0 12 12" width="12" height="12" fill="none" aria-hidden="true">
-                  <path
-                    d="M3 3L9 9M9 3L3 9"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              )}
-            />
+          <Box data-gloom-role="pane-close" marginLeft={1} position="relative" zIndex={2}>
+            {uiKind === "opentui" ? (
+              <TerminalPaneButton text={PANE_HEADER_CLOSE} fg={colors.textDim} role="pane-close" onMouseDown={onCloseMouseDown} />
+            ) : (
+              <DesktopPaneButton
+                label="Close pane"
+                onActivate={onCloseMouseDown}
+                role="pane-close"
+                icon={(
+                  <svg viewBox="0 0 12 12" width="12" height="12" fill="none" aria-hidden="true">
+                    <path
+                      d="M3 3L9 9M9 3L3 9"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                )}
+              />
+            )}
           </Box>
         )}
       </Box>
@@ -215,10 +273,10 @@ export function PaneHeader({
     // Reserve 2 for corners, 1 for ─ after ┌, 1 for ─ before ┐
     const borderColor = visuallyFocused ? colors.borderFocused : colors.border;
     const innerWidth = Math.max(0, width - 4);
-    const contentWidth = PANE_HEADER_GRIP.length + closeText.length + actionText.length;
+    const contentWidth = PANE_HEADER_GRIP.length + floatToggleText.length + closeText.length + actionText.length;
     const titleWidth = Math.max(0, innerWidth - contentWidth);
     const clippedTitle = truncateTitle(title, titleWidth);
-    const fillLen = Math.max(0, innerWidth - PANE_HEADER_GRIP.length - clippedTitle.length - actionText.length - closeText.length);
+    const fillLen = Math.max(0, innerWidth - PANE_HEADER_GRIP.length - clippedTitle.length - floatToggleText.length - actionText.length - closeText.length);
     const fill = "─".repeat(fillLen);
 
     return (
@@ -236,6 +294,12 @@ export function PaneHeader({
         <Text fg={borderColor} selectable={false}>{"┌─"}</Text>
         <Text fg={textColor} selectable={false}>{`${PANE_HEADER_GRIP}${clippedTitle}`}</Text>
         <Text fg={borderColor} selectable={false}>{fill}</Text>
+        <TerminalPaneButton
+          text={floatToggleText}
+          fg={visuallyFocused ? colors.borderFocused : textColor}
+          role="pane-float-toggle"
+          onMouseDown={onFloatToggleMouseDown}
+        />
         <TerminalPaneButton
           text={actionText}
           fg={textColor}
@@ -255,7 +319,7 @@ export function PaneHeader({
     );
   }
 
-  const titleWidth = Math.max(0, width - PANE_HEADER_GRIP.length - actionText.length - closeText.length);
+  const titleWidth = Math.max(0, width - PANE_HEADER_GRIP.length - floatToggleText.length - actionText.length - closeText.length);
   const clippedTitle = truncateTitle(title, titleWidth);
   const padding = " ".repeat(Math.max(0, titleWidth - clippedTitle.length));
 
@@ -274,6 +338,12 @@ export function PaneHeader({
       <Text fg={textColor} selectable={false}>
         {`${PANE_HEADER_GRIP}${clippedTitle}${padding}`}
       </Text>
+      <TerminalPaneButton
+        text={floatToggleText}
+        fg={textColor}
+        role="pane-float-toggle"
+        onMouseDown={onFloatToggleMouseDown}
+      />
       <TerminalPaneButton
         text={actionText}
         fg={textColor}

--- a/src/components/layout/pane/index.tsx
+++ b/src/components/layout/pane/index.tsx
@@ -22,6 +22,7 @@ interface PaneWrapperProps {
   onHeaderMouseDragEnd?: (event: any) => void;
   onHeaderContextMenu?: (event: any) => void;
   onActionMouseDown?: (event: any) => void;
+  onFloatToggleMouseDown?: (event: any) => void;
   footer?: CombinedPaneFooter | null;
   children: ReactNode;
 }
@@ -42,6 +43,7 @@ export function PaneWrapper({
   onHeaderMouseDragEnd,
   onHeaderContextMenu,
   onActionMouseDown,
+  onFloatToggleMouseDown,
   footer,
   children,
 }: PaneWrapperProps) {
@@ -90,6 +92,7 @@ export function PaneWrapper({
           onHeaderMouseDragEnd={onHeaderMouseDragEnd}
           onHeaderContextMenu={onHeaderContextMenu}
           onActionMouseDown={onActionMouseDown}
+          onFloatToggleMouseDown={onFloatToggleMouseDown}
         />
       )}
       <PaneBodyFrame layoutProps={bodyFrame.layoutProps} backgroundColor={bg}>

--- a/src/components/layout/shell/active-drag.ts
+++ b/src/components/layout/shell/active-drag.ts
@@ -3,7 +3,6 @@ import {
   floatAtRect,
   getRememberedFloatingRect,
   resizeSplitAtPath,
-  simulateDrop,
   type DockGeometryOptions,
   type DockLeafLayout,
   type DropTarget,
@@ -13,6 +12,9 @@ import {
 import type { AppAction } from "../../../state/app/context";
 import type { LayoutConfig } from "../../../types/config";
 import {
+  createCompactedDropPreview,
+  createLeafDropPreview,
+  createSnapDropPreview,
   finalizePaneDragRelease,
   isMeaningfulPaneDrag,
   makeSnapGuides,
@@ -115,23 +117,43 @@ export function useShellActiveDrag({
         updateDragFloatingRect({ paneId: drag.paneId, rect: nextRect });
         setDragCursor({ x: hitX, y: hitShellY });
 
+        const occupiedDockLeaf = dockLeafLayouts.find((leaf) => (
+          leaf.instanceId !== drag.paneId && pointInRect(leaf.rect, hitX, hitShellY)
+        ));
         const hoveredOverlay = resolveHoverOverlay(hitX, hitShellY, dockLeafLayouts, drag.paneId);
-        if (hoveredOverlay) {
-          const hoveredCell = hoveredOverlay.cells.find((cell) => pointInRect(cell.rect, hitX, hitShellY));
-          if (hoveredCell) {
-            const target: DropTarget = { kind: "leaf", targetId: hoveredOverlay.targetId, position: hoveredCell.position };
-            const simulation = simulateDrop(baseLayout, drag.paneId, target, bounds, dockGeometryOptions);
-            if (simulation.previewRect) {
-              updateDockPreview({ kind: "dock", target, rect: simulation.previewRect });
-            } else {
-              updateDockPreview(null);
-            }
-          } else {
-            updateDockPreview(null);
-          }
+        const hoveredCell = hoveredOverlay?.cells.find((cell) => pointInRect(cell.rect, hitX, hitShellY));
+        if (hoveredOverlay && hoveredCell) {
+          const target: DropTarget = { kind: "leaf", targetId: hoveredOverlay.targetId, position: hoveredCell.position };
+          updateDockPreview(createLeafDropPreview(baseLayout, drag.paneId, target, bounds, dockGeometryOptions));
+        } else if (drag.mode === "docked" && occupiedDockLeaf) {
+          updateDockPreview(createCompactedDropPreview(
+            baseLayout,
+            drag.paneId,
+            occupiedDockLeaf,
+            hitX,
+            hitShellY,
+            bounds,
+            dockGeometryOptions,
+          ));
         } else {
-          const snapGuide = resolveSnapGuide(hitX, hitShellY, snapGuides);
-          updateDockPreview(snapGuide ? { kind: "snap", position: snapGuide.position, rect: snapGuide.previewRect } : null);
+          if (drag.mode === "floating") {
+            // Floating panes are the free-placement escape hatch. Only an explicit
+            // dock hover above may tile one; the dashboard-wide grid must not make
+            // every otherwise-free pointer position an implicit dock target.
+            updateDockPreview(null);
+          } else {
+            const snapGuide = resolveSnapGuide(hitX, hitShellY, snapGuides);
+            updateDockPreview(snapGuide
+              ? createSnapDropPreview(
+                baseLayout,
+                drag.paneId,
+                snapGuide.position,
+                snapGuide.previewRect,
+                bounds,
+                dockGeometryOptions,
+              )
+              : null);
+          }
         }
       } else if (drag.type === "float-resize") {
         updateDragFloatingRect({

--- a/src/components/layout/shell/drag/index.test.ts
+++ b/src/components/layout/shell/drag/index.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, test } from "bun:test";
+import { createPaneInstance, type LayoutConfig } from "../../../../types/config";
+import { getDockLeafLayouts } from "../../../../plugins/pane-manager";
+import {
+  createCompactedDropPreview,
+  createLeafDropPreview,
+  createSnapDropPreview,
+  constrainFloatingRectToBounds,
+  finalizePaneDragRelease,
+  LAYOUT_GRID_COLUMNS,
+  LAYOUT_GRID_ROWS,
+  makeLayoutGridCells,
+  makeSnapGuides,
+  resolveFloatResizeRect,
+  resolveSnapGuide,
+} from "./index";
+
+const BOUNDS = { x: 0, y: 0, width: 120, height: 60 };
+
+function threePaneLayout(): LayoutConfig {
+  return {
+    dockRoot: {
+      kind: "split",
+      axis: "horizontal",
+      ratio: 0.5,
+      first: { kind: "pane", instanceId: "a:main" },
+      second: {
+        kind: "split",
+        axis: "vertical",
+        ratio: 0.5,
+        first: { kind: "pane", instanceId: "b:main" },
+        second: { kind: "pane", instanceId: "c:main" },
+      },
+    },
+    instances: [
+      createPaneInstance("a", { instanceId: "a:main" }),
+      createPaneInstance("b", { instanceId: "b:main" }),
+      createPaneInstance("c", { instanceId: "c:main" }),
+    ],
+    floating: [],
+    detached: [],
+  };
+}
+
+describe("layout construction grid", () => {
+  test("builds a visible 6x6 grid whose cells cover odd dashboard bounds", () => {
+    const cells = makeLayoutGridCells(121, 41);
+
+    expect(cells).toHaveLength(LAYOUT_GRID_COLUMNS * LAYOUT_GRID_ROWS);
+    expect(cells[0]?.rect).toEqual({ x: 0, y: 0, width: 20, height: 6 });
+    expect(cells.at(-1)?.rect).toEqual({ x: 100, y: 34, width: 21, height: 7 });
+    expect(Math.max(...cells.map((cell) => cell.rect.x + cell.rect.width))).toBe(121);
+    expect(Math.max(...cells.map((cell) => cell.rect.y + cell.rect.height))).toBe(41);
+  });
+
+  test("resolves every pointer position to the matching highlighted cell", () => {
+    const guides = makeSnapGuides(120, 42);
+
+    expect(guides).toHaveLength(36);
+    expect(resolveSnapGuide(0, 0, guides)).toMatchObject({
+      position: "cell-1-1",
+      previewRect: { x: 0, y: 0, width: 20, height: 7 },
+    });
+    expect(resolveSnapGuide(119, 41, guides)).toMatchObject({
+      position: "cell-6-6",
+      previewRect: { x: 100, y: 35, width: 20, height: 7 },
+    });
+    expect(resolveSnapGuide(120, 41, guides)).toBeNull();
+  });
+
+  test("coarsens the grid safely when the content area is smaller than 6x6", () => {
+    const guides = makeSnapGuides(3, 2);
+    expect(guides).toHaveLength(6);
+    expect(guides.every((guide) => guide.previewRect.width === 1 && guide.previewRect.height === 1)).toBe(true);
+  });
+
+  test("builds a deterministic compact preview outside the explicit target overlay", () => {
+    const layout = threePaneLayout();
+    const targetLeaf = getDockLeafLayouts(layout, BOUNDS, { reserveDividerGutters: true })
+      .find((leaf) => leaf.instanceId === "b:main")!;
+    const preview = createCompactedDropPreview(
+      layout,
+      "a:main",
+      targetLeaf,
+      targetLeaf.rect.x + targetLeaf.rect.width - 1,
+      targetLeaf.rect.y + Math.floor(targetLeaf.rect.height / 2),
+      BOUNDS,
+      { reserveDividerGutters: true },
+    );
+
+    expect(preview).not.toBeNull();
+    expect(preview!.kind).toBe("compact");
+    expect(preview!.layout.dockRoot).toMatchObject({
+      kind: "split",
+      axis: "vertical",
+      first: {
+        kind: "split",
+        axis: "horizontal",
+        first: { kind: "pane", instanceId: "b:main" },
+        second: { kind: "pane", instanceId: "a:main" },
+      },
+      second: { kind: "pane", instanceId: "c:main" },
+    });
+    expect(finalizePaneDragRelease(
+      layout,
+      "a:main",
+      { x: 9, y: 8, width: 20, height: 10 },
+      preview,
+    ).nextLayout).toEqual(preview!.layout);
+  });
+
+  for (const directionalCase of [
+    {
+      position: "top" as const,
+      axis: "vertical" as const,
+      order: ["a:main", "b:main"],
+      previewRects: [
+        { instanceId: "a:main", rect: { x: 0, y: 0, width: 120, height: 15 } },
+        { instanceId: "b:main", rect: { x: 0, y: 16, width: 120, height: 14 } },
+        { instanceId: "c:main", rect: { x: 0, y: 31, width: 120, height: 29 } },
+      ],
+      committedRects: [
+        { instanceId: "a:main", rect: { x: 0, y: 0, width: 120, height: 15 } },
+        { instanceId: "b:main", rect: { x: 0, y: 16, width: 120, height: 14 } },
+        { instanceId: "c:main", rect: { x: 0, y: 31, width: 120, height: 29 } },
+      ],
+    },
+    {
+      position: "left" as const,
+      axis: "horizontal" as const,
+      order: ["a:main", "b:main"],
+      previewRects: [
+        { instanceId: "a:main", rect: { x: 0, y: 0, width: 60, height: 30 } },
+        { instanceId: "c:main", rect: { x: 0, y: 31, width: 120, height: 29 } },
+      ],
+      committedRects: [
+        { instanceId: "a:main", rect: { x: 0, y: 0, width: 60, height: 30 } },
+        { instanceId: "b:main", rect: { x: 61, y: 0, width: 59, height: 30 } },
+        { instanceId: "c:main", rect: { x: 0, y: 31, width: 120, height: 29 } },
+      ],
+    },
+    {
+      position: "right" as const,
+      axis: "horizontal" as const,
+      order: ["b:main", "a:main"],
+      previewRects: [
+        { instanceId: "b:main", rect: { x: 0, y: 0, width: 60, height: 30 } },
+        { instanceId: "a:main", rect: { x: 61, y: 0, width: 59, height: 30 } },
+        { instanceId: "c:main", rect: { x: 0, y: 31, width: 120, height: 29 } },
+      ],
+      committedRects: [
+        { instanceId: "b:main", rect: { x: 0, y: 0, width: 60, height: 30 } },
+        { instanceId: "a:main", rect: { x: 61, y: 0, width: 59, height: 30 } },
+        { instanceId: "c:main", rect: { x: 0, y: 31, width: 120, height: 29 } },
+      ],
+    },
+    {
+      position: "bottom" as const,
+      axis: "vertical" as const,
+      order: ["b:main", "a:main"],
+      previewRects: [
+        { instanceId: "b:main", rect: { x: 0, y: 0, width: 120, height: 15 } },
+        { instanceId: "a:main", rect: { x: 0, y: 16, width: 120, height: 14 } },
+        { instanceId: "c:main", rect: { x: 0, y: 31, width: 120, height: 29 } },
+      ],
+      committedRects: [
+        { instanceId: "b:main", rect: { x: 0, y: 0, width: 120, height: 15 } },
+        { instanceId: "a:main", rect: { x: 0, y: 16, width: 120, height: 14 } },
+        { instanceId: "c:main", rect: { x: 0, y: 31, width: 120, height: 29 } },
+      ],
+    },
+  ]) {
+    test(`routes the ${directionalCase.position} cell to an exact target-relative preview and commit`, () => {
+      const layout = threePaneLayout();
+      const preview = createLeafDropPreview(
+        layout,
+        "a:main",
+        { kind: "leaf", targetId: "b:main", position: directionalCase.position },
+        BOUNDS,
+        { reserveDividerGutters: true },
+      );
+
+      expect(preview).not.toBeNull();
+      expect(preview!.layout.dockRoot).toMatchObject({
+        kind: "split",
+        axis: "vertical",
+        first: {
+          kind: "split",
+          axis: directionalCase.axis,
+          first: { kind: "pane", instanceId: directionalCase.order[0] },
+          second: { kind: "pane", instanceId: directionalCase.order[1] },
+        },
+        second: { kind: "pane", instanceId: "c:main" },
+      });
+      expect(preview!.rects).toEqual(directionalCase.previewRects);
+
+      const committed = finalizePaneDragRelease(
+        layout,
+        "a:main",
+        { x: 9, y: 8, width: 20, height: 10 },
+        preview,
+      ).nextLayout;
+      expect(committed).toEqual(preview!.layout);
+      expect(getDockLeafLayouts(committed, BOUNDS, { reserveDividerGutters: true })
+        .map(({ instanceId, rect }) => ({ instanceId, rect })))
+        .toEqual(directionalCase.committedRects);
+    });
+  }
+
+  test("commits the selected grid cell exactly for one-pane and empty-grid layouts", () => {
+    const target = { x: 80, y: 40, width: 20, height: 10 };
+    const dockedOnly: LayoutConfig = {
+      dockRoot: { kind: "pane", instanceId: "a:main" },
+      instances: [createPaneInstance("a", { instanceId: "a:main" })],
+      floating: [],
+      detached: [],
+    };
+    const floatingOnly: LayoutConfig = {
+      ...dockedOnly,
+      dockRoot: null,
+      floating: [{ instanceId: "a:main", x: 5, y: 5, width: 40, height: 20, zIndex: 70 }],
+    };
+
+    for (const layout of [dockedOnly, floatingOnly]) {
+      const preview = createSnapDropPreview(layout, "a:main", "cell-5-5", target, BOUNDS);
+      expect(preview.rect).toEqual(target);
+      expect(preview.layout.dockRoot).toBeNull();
+      expect(preview.layout.floating.find((entry) => entry.instanceId === "a:main"))
+        .toEqual(expect.objectContaining({ ...target, fixedGeometry: true }));
+      expect(preview.rects).toEqual([{ instanceId: "a:main", rect: target }]);
+    }
+  });
+
+  test("preserves fixed cells without weakening ordinary floating minimums", () => {
+    const selectedCell = { x: 50, y: 30, width: 10, height: 3 };
+
+    expect(constrainFloatingRectToBounds({ ...selectedCell, fixedGeometry: true }, 60, 36))
+      .toEqual({ ...selectedCell, fixedGeometry: true });
+    expect(constrainFloatingRectToBounds(selectedCell, 60, 36))
+      .toEqual({ x: 45, y: 30, width: 15, height: 6 });
+  });
+
+  test("resizes a snapped grid cell without expanding it or losing fixed geometry", () => {
+    const rect = resolveFloatResizeRect({
+      corner: "bottom-right",
+      startX: 56,
+      startY: 33,
+      origRect: { x: 50, y: 30, width: 6, height: 3, zIndex: 75, fixedGeometry: true },
+    }, 58, 34, 120, 60);
+
+    expect(rect).toEqual({
+      x: 50,
+      y: 30,
+      width: 8,
+      height: 4,
+      zIndex: 75,
+      fixedGeometry: true,
+    });
+  });
+});

--- a/src/components/layout/shell/drag/index.ts
+++ b/src/components/layout/shell/drag/index.ts
@@ -1,16 +1,23 @@
 import {
   MIN_FLOAT_HEIGHT,
   MIN_FLOAT_WIDTH,
-  applyDrop,
   floatAtRect,
+  getDockLeafLayouts,
+  simulateDrop,
+  snapPaneToGridRect,
   type DockLeafLayout,
   type DropTarget,
   type FloatingRect,
+  type FloatingResizeCorner,
   type LayoutBounds,
 } from "../../../../plugins/pane-manager";
 import type { DesktopDockPreviewState } from "../../../../types/desktop-window";
 import type { LayoutConfig } from "../../../../types/config";
-import { PANE_HEADER_ACTION, PANE_HEADER_CLOSE } from "../../pane/header";
+import {
+  PANE_HEADER_ACTION,
+  PANE_HEADER_CLOSE,
+  PANE_HEADER_TILED,
+} from "../../pane/header";
 
 export interface HoverOverlay {
   targetId: string;
@@ -18,32 +25,41 @@ export interface HoverOverlay {
   cells: Array<{ position: "top" | "left" | "center" | "right" | "bottom"; rect: LayoutBounds }>;
 }
 
-type SnapGuidePosition =
-  | "left"
-  | "right"
-  | "top"
-  | "bottom"
-  | "top-left"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-right";
+type SnapGuidePosition = `cell-${number}-${number}`;
 
 export interface SnapGuide {
   position: SnapGuidePosition;
+  column: number;
+  row: number;
   triggerRect: LayoutBounds;
   previewRect: FloatingRect;
 }
 
+export interface DragPreviewRect {
+  instanceId: string;
+  rect: LayoutBounds;
+}
+
 export type DragPreview =
+  | {
+    kind: "compact";
+    layout: LayoutConfig;
+    rect: LayoutBounds;
+    rects: DragPreviewRect[];
+  }
   | {
     kind: "dock";
     target: DropTarget;
+    layout: LayoutConfig;
     rect: LayoutBounds;
+    rects: DragPreviewRect[];
   }
   | {
     kind: "snap";
     position: SnapGuidePosition;
+    layout: LayoutConfig;
     rect: FloatingRect;
+    rects: DragPreviewRect[];
   };
 
 export interface PaneDragReleaseResult {
@@ -59,6 +75,7 @@ export interface PaneDragRectState {
 }
 
 export interface FloatResizeDragState {
+  corner: FloatingResizeCorner;
   startX: number;
   startY: number;
   origRect: FloatingRect;
@@ -67,6 +84,48 @@ export interface FloatResizeDragState {
 const DOCK_DIVIDER_SIZE = 1;
 export const PANE_DRAG_THRESHOLD = 2;
 export const PRECISE_PANE_DRAG_THRESHOLD = 0.15;
+export const LAYOUT_GRID_COLUMNS = 6;
+export const LAYOUT_GRID_ROWS = 6;
+
+export interface LayoutGridCell {
+  column: number;
+  row: number;
+  rect: LayoutBounds;
+}
+
+export function makeLayoutGridCells(
+  width: number,
+  height: number,
+  columns = LAYOUT_GRID_COLUMNS,
+  rows = LAYOUT_GRID_ROWS,
+): LayoutGridCell[] {
+  const safeWidth = Math.max(1, Math.floor(width));
+  const safeHeight = Math.max(1, Math.floor(height));
+  const columnCount = Math.max(1, Math.min(Math.floor(columns), safeWidth));
+  const rowCount = Math.max(1, Math.min(Math.floor(rows), safeHeight));
+  const cells: LayoutGridCell[] = [];
+
+  for (let row = 0; row < rowCount; row += 1) {
+    const y = Math.floor((safeHeight * row) / rowCount);
+    const bottom = Math.floor((safeHeight * (row + 1)) / rowCount);
+    for (let column = 0; column < columnCount; column += 1) {
+      const x = Math.floor((safeWidth * column) / columnCount);
+      const right = Math.floor((safeWidth * (column + 1)) / columnCount);
+      cells.push({
+        column,
+        row,
+        rect: {
+          x,
+          y,
+          width: Math.max(1, right - x),
+          height: Math.max(1, bottom - y),
+        },
+      });
+    }
+  }
+
+  return cells;
+}
 
 export function pointInRect(rect: LayoutBounds, x: number, y: number): boolean {
   return x >= rect.x && x < rect.x + rect.width && y >= rect.y && y < rect.y + rect.height;
@@ -94,8 +153,8 @@ export function constrainFloatingRectToBounds(
 ): FloatingRect {
   const boundsWidth = Math.max(1, Number.isFinite(totalWidth) ? totalWidth : 1);
   const boundsHeight = Math.max(1, Number.isFinite(totalHeight) ? totalHeight : 1);
-  const width = fitFloatingDimension(rect.width, MIN_FLOAT_WIDTH, boundsWidth);
-  const height = fitFloatingDimension(rect.height, MIN_FLOAT_HEIGHT, boundsHeight);
+  const width = fitFloatingDimension(rect.width, rect.fixedGeometry ? 1 : MIN_FLOAT_WIDTH, boundsWidth);
+  const height = fitFloatingDimension(rect.height, rect.fixedGeometry ? 1 : MIN_FLOAT_HEIGHT, boundsHeight);
   const maxX = Math.max(0, boundsWidth - width);
   const maxY = Math.max(0, boundsHeight - height);
 
@@ -139,6 +198,7 @@ export function resolvePaneDragFloatingRect(
   }
 
   return constrainFloatingRectToBounds({
+    ...drag.origRect,
     x: drag.origRect.x + (pointerX - drag.startX),
     y: drag.origRect.y + (pointerY - drag.startY),
     width: drag.origRect.width,
@@ -153,12 +213,38 @@ export function resolveFloatResizeRect(
   totalWidth: number,
   totalHeight: number,
 ): FloatingRect {
+  const dx = pointerX - drag.startX;
+  const dy = pointerY - drag.startY;
+  const minWidth = drag.origRect.fixedGeometry ? 1 : MIN_FLOAT_WIDTH;
+  const minHeight = drag.origRect.fixedGeometry ? 1 : MIN_FLOAT_HEIGHT;
+  let left = drag.origRect.x;
+  let top = drag.origRect.y;
+  let right = drag.origRect.x + drag.origRect.width;
+  let bottom = drag.origRect.y + drag.origRect.height;
+  const affectsLeft = drag.corner === "top-left" || drag.corner === "bottom-left" || drag.corner === "left";
+  const affectsRight = drag.corner === "top-right" || drag.corner === "bottom-right" || drag.corner === "right";
+  const affectsTop = drag.corner === "top-left" || drag.corner === "top-right" || drag.corner === "top";
+  const affectsBottom = drag.corner === "bottom-left" || drag.corner === "bottom-right" || drag.corner === "bottom";
+
+  if (affectsLeft) {
+    left = Math.max(0, Math.min(left + dx, right - minWidth));
+  } else if (affectsRight) {
+    right = Math.min(totalWidth, Math.max(right + dx, left + minWidth));
+  }
+
+  if (affectsTop) {
+    top = Math.max(0, Math.min(top + dy, bottom - minHeight));
+  } else if (affectsBottom) {
+    bottom = Math.min(totalHeight, Math.max(bottom + dy, top + minHeight));
+  }
+
   return constrainFloatingRectToBounds({
-    x: drag.origRect.x,
-    y: drag.origRect.y,
-    width: Math.max(MIN_FLOAT_WIDTH, Math.min(totalWidth - drag.origRect.x, drag.origRect.width + (pointerX - drag.startX))),
-    height: Math.max(MIN_FLOAT_HEIGHT, Math.min(totalHeight - drag.origRect.y, drag.origRect.height + (pointerY - drag.startY))),
+    x: left,
+    y: top,
+    width: right - left,
+    height: bottom - top,
     zIndex: drag.origRect.zIndex,
+    fixedGeometry: drag.origRect.fixedGeometry,
   }, totalWidth, totalHeight);
 }
 
@@ -234,6 +320,113 @@ export function resolveHoverOverlay(
   };
 }
 
+function sameRect(left: LayoutBounds, right: LayoutBounds): boolean {
+  return left.x === right.x
+    && left.y === right.y
+    && left.width === right.width
+    && left.height === right.height;
+}
+
+export function changedDockPreviewRects(
+  layout: LayoutConfig,
+  nextLayout: LayoutConfig,
+  bounds: LayoutBounds,
+  options?: Parameters<typeof getDockLeafLayouts>[2],
+): DragPreviewRect[] {
+  const currentRects = new Map(
+    getDockLeafLayouts(layout, bounds, options).map((leaf) => [leaf.instanceId, leaf.rect]),
+  );
+  return getDockLeafLayouts(nextLayout, bounds, options)
+    .filter((leaf) => {
+      const currentRect = currentRects.get(leaf.instanceId);
+      return !currentRect || !sameRect(currentRect, leaf.rect);
+    })
+    .map(({ instanceId, rect }) => ({ instanceId, rect }));
+}
+
+export function createLeafDropPreview(
+  layout: LayoutConfig,
+  paneId: string,
+  target: DropTarget,
+  bounds: LayoutBounds,
+  options?: Parameters<typeof getDockLeafLayouts>[2],
+): Extract<DragPreview, { kind: "dock" }> | null {
+  const simulation = simulateDrop(layout, paneId, target, bounds, options);
+  if (!simulation.previewRect) return null;
+  return {
+    kind: "dock",
+    target,
+    layout: simulation.layout,
+    rect: simulation.previewRect,
+    rects: changedDockPreviewRects(layout, simulation.layout, bounds, options),
+  };
+}
+
+function resolveCompactedDropPosition(
+  targetRect: LayoutBounds,
+  pointerX: number,
+  pointerY: number,
+): "top" | "left" | "right" | "bottom" {
+  const horizontal = (pointerX - (targetRect.x + (targetRect.width / 2))) / Math.max(1, targetRect.width);
+  const vertical = (pointerY - (targetRect.y + (targetRect.height / 2))) / Math.max(1, targetRect.height);
+  if (Math.abs(horizontal) >= Math.abs(vertical)) {
+    return horizontal < 0 ? "left" : "right";
+  }
+  return vertical < 0 ? "top" : "bottom";
+}
+
+export function createCompactedDropPreview(
+  layout: LayoutConfig,
+  paneId: string,
+  targetLeaf: DockLeafLayout,
+  pointerX: number,
+  pointerY: number,
+  bounds: LayoutBounds,
+  options?: Parameters<typeof getDockLeafLayouts>[2],
+): Extract<DragPreview, { kind: "compact" }> | null {
+  const preview = createLeafDropPreview(
+    layout,
+    paneId,
+    {
+      kind: "leaf",
+      targetId: targetLeaf.instanceId,
+      position: resolveCompactedDropPosition(targetLeaf.rect, pointerX, pointerY),
+    },
+    bounds,
+    options,
+  );
+  return preview
+    ? {
+      kind: "compact",
+      layout: preview.layout,
+      rect: preview.rect,
+      rects: preview.rects,
+    }
+    : null;
+}
+
+export function createSnapDropPreview(
+  layout: LayoutConfig,
+  paneId: string,
+  position: SnapGuidePosition,
+  targetRect: LayoutBounds,
+  bounds: LayoutBounds,
+  options?: Parameters<typeof getDockLeafLayouts>[2],
+): Extract<DragPreview, { kind: "snap" }> {
+  const nextLayout = snapPaneToGridRect(layout, paneId, targetRect, bounds);
+  return {
+    kind: "snap",
+    position,
+    layout: nextLayout,
+    rect: targetRect,
+    rects: [
+      { instanceId: paneId, rect: targetRect },
+      ...changedDockPreviewRects(layout, nextLayout, bounds, options)
+        .filter((entry) => entry.instanceId !== paneId),
+    ],
+  };
+}
+
 export function resolveDividerPreviewRect(
   axis: "horizontal" | "vertical",
   bounds: LayoutBounds,
@@ -273,17 +466,24 @@ export function finalizePaneDragRelease(
   previewRect: FloatingRect,
   dockPreview: DragPreview | null,
 ): PaneDragReleaseResult {
+  if (dockPreview?.kind === "compact") {
+    return {
+      nextLayout: dockPreview.layout,
+      shouldShowGridlockTip: false,
+    };
+  }
+
   if (dockPreview?.kind === "dock") {
     return {
-      nextLayout: applyDrop(layout, paneId, dockPreview.target),
+      nextLayout: dockPreview.layout,
       shouldShowGridlockTip: false,
     };
   }
 
   if (dockPreview?.kind === "snap") {
     return {
-      nextLayout: floatAtRect(layout, paneId, dockPreview.rect),
-      shouldShowGridlockTip: true,
+      nextLayout: dockPreview.layout,
+      shouldShowGridlockTip: false,
     };
   }
 
@@ -294,75 +494,13 @@ export function finalizePaneDragRelease(
 }
 
 export function makeSnapGuides(width: number, height: number): SnapGuide[] {
-  const halfWidth = Math.max(1, Math.floor(width / 2));
-  const halfHeight = Math.max(1, Math.floor(height / 2));
-  const cornerWidth = Math.max(8, Math.min(16, Math.floor(width * 0.2)));
-  const cornerHeight = Math.max(4, Math.min(8, Math.floor(height * 0.22)));
-  const edgeWidth = Math.max(6, Math.min(10, Math.floor(width * 0.1)));
-  const topBottomEdgeHeight = Math.max(2, Math.min(4, Math.floor(height * 0.1)));
-
-  return [
-    {
-      position: "top-left",
-      triggerRect: { x: 0, y: 0, width: cornerWidth, height: cornerHeight },
-      previewRect: { x: 0, y: 0, width: halfWidth, height: halfHeight },
-    },
-    {
-      position: "top-right",
-      triggerRect: { x: Math.max(0, width - cornerWidth), y: 0, width: cornerWidth, height: cornerHeight },
-      previewRect: { x: Math.max(0, width - halfWidth), y: 0, width: halfWidth, height: halfHeight },
-    },
-    {
-      position: "bottom-left",
-      triggerRect: { x: 0, y: Math.max(0, height - cornerHeight), width: cornerWidth, height: cornerHeight },
-      previewRect: { x: 0, y: Math.max(0, height - halfHeight), width: halfWidth, height: halfHeight },
-    },
-    {
-      position: "bottom-right",
-      triggerRect: {
-        x: Math.max(0, width - cornerWidth),
-        y: Math.max(0, height - cornerHeight),
-        width: cornerWidth,
-        height: cornerHeight,
-      },
-      previewRect: {
-        x: Math.max(0, width - halfWidth),
-        y: Math.max(0, height - halfHeight),
-        width: halfWidth,
-        height: halfHeight,
-      },
-    },
-    {
-      position: "left",
-      triggerRect: { x: 0, y: cornerHeight, width: edgeWidth, height: Math.max(1, height - (cornerHeight * 2)) },
-      previewRect: { x: 0, y: 0, width: halfWidth, height },
-    },
-    {
-      position: "right",
-      triggerRect: {
-        x: Math.max(0, width - edgeWidth),
-        y: cornerHeight,
-        width: edgeWidth,
-        height: Math.max(1, height - (cornerHeight * 2)),
-      },
-      previewRect: { x: Math.max(0, width - halfWidth), y: 0, width: halfWidth, height },
-    },
-    {
-      position: "top",
-      triggerRect: { x: cornerWidth, y: 0, width: Math.max(1, width - (cornerWidth * 2)), height: topBottomEdgeHeight },
-      previewRect: { x: 0, y: 0, width, height: halfHeight },
-    },
-    {
-      position: "bottom",
-      triggerRect: {
-        x: cornerWidth,
-        y: Math.max(0, height - topBottomEdgeHeight),
-        width: Math.max(1, width - (cornerWidth * 2)),
-        height: topBottomEdgeHeight,
-      },
-      previewRect: { x: 0, y: Math.max(0, height - halfHeight), width, height: halfHeight },
-    },
-  ];
+  return makeLayoutGridCells(width, height).map((cell) => ({
+    position: `cell-${cell.column + 1}-${cell.row + 1}`,
+    column: cell.column,
+    row: cell.row,
+    triggerRect: cell.rect,
+    previewRect: cell.rect,
+  }));
 }
 
 export function resolveSnapGuide(x: number, y: number, guides: SnapGuide[]): SnapGuide | null {
@@ -374,55 +512,67 @@ export function resolveHeaderHitAreas(
   options: { floating: boolean; focused: boolean },
 ): {
   actionStart: number | null;
+  actionEnd: number | null;
   closeStart: number | null;
+  closeEnd: number | null;
+  toggleStart: number;
+  toggleEnd: number;
 } {
   // Focused panes and all floating panes render corner chrome around the header.
   let rightEdge = options.focused || options.floating ? width - 2 : width;
   let closeStart: number | null = null;
+  let closeEnd: number | null = null;
   let actionStart: number | null = null;
+  let actionEnd: number | null = null;
 
   if (options.floating) {
+    closeEnd = rightEdge;
     closeStart = Math.max(0, rightEdge - PANE_HEADER_CLOSE.length);
     rightEdge = closeStart;
   }
 
+  actionEnd = rightEdge;
   actionStart = Math.max(0, rightEdge - PANE_HEADER_ACTION.length);
+  rightEdge = actionStart;
+  const toggleEnd = rightEdge;
+  const toggleStart = Math.max(0, rightEdge - PANE_HEADER_TILED.length);
 
-  return { actionStart, closeStart };
+  return { actionStart, actionEnd, closeStart, closeEnd, toggleStart, toggleEnd };
 }
 
 export function resolveExternalDockPreview(
   preview: DesktopDockPreviewState | null | undefined,
   bounds: LayoutBounds,
+  layout: LayoutConfig,
+  options?: Parameters<typeof getDockLeafLayouts>[2],
 ): DragPreview | null {
   if (!preview?.paneId || !preview.edge) return null;
+  const target: DropTarget = { kind: "frame", edge: preview.edge };
+  const resolved = createLeafDropPreview(layout, preview.paneId, target, bounds, options);
+  if (!resolved) return null;
 
   switch (preview.edge) {
     case "left":
       return {
-        kind: "dock",
-        target: { kind: "frame", edge: "left" },
+        ...resolved,
         rect: { x: bounds.x, y: bounds.y, width: Math.max(1, Math.floor(bounds.width / 2)), height: bounds.height },
       };
     case "right": {
       const width = Math.max(1, Math.floor(bounds.width / 2));
       return {
-        kind: "dock",
-        target: { kind: "frame", edge: "right" },
+        ...resolved,
         rect: { x: bounds.x + Math.max(0, bounds.width - width), y: bounds.y, width, height: bounds.height },
       };
     }
     case "top":
       return {
-        kind: "dock",
-        target: { kind: "frame", edge: "top" },
+        ...resolved,
         rect: { x: bounds.x, y: bounds.y, width: bounds.width, height: Math.max(1, Math.floor(bounds.height / 2)) },
       };
     case "bottom": {
       const height = Math.max(1, Math.floor(bounds.height / 2));
       return {
-        kind: "dock",
-        target: { kind: "frame", edge: "bottom" },
+        ...resolved,
         rect: { x: bounds.x, y: bounds.y + Math.max(0, bounds.height - height), width: bounds.width, height },
       };
     }

--- a/src/components/layout/shell/drag/overlays.tsx
+++ b/src/components/layout/shell/drag/overlays.tsx
@@ -1,7 +1,88 @@
-import { Box } from "../../../../ui";
-import { colors } from "../../../../theme/colors";
+import { Box, Text, useUiCapabilities } from "../../../../ui";
+import { blendHex, colors } from "../../../../theme/colors";
 import type { FloatingRect } from "../../../../plugins/pane-manager";
-import type { DragPreview, HoverOverlay } from "./index";
+import {
+  LAYOUT_GRID_COLUMNS,
+  LAYOUT_GRID_ROWS,
+  makeLayoutGridCells,
+  type DragPreview,
+  type HoverOverlay,
+} from "./index";
+
+export function ShellLayoutGridOverlay({
+  excludedRows = [],
+  height,
+  width,
+}: {
+  excludedRows?: number[];
+  height: number;
+  width: number;
+}) {
+  const { nativePaneChrome } = useUiCapabilities();
+  const cells = makeLayoutGridCells(width, height);
+
+  if (nativePaneChrome) {
+    return (
+      <Box
+        position="absolute"
+        left={0}
+        top={0}
+        width={width}
+        height={height}
+        zIndex={90}
+        data-gloom-role="layout-grid-overlay"
+        data-columns={LAYOUT_GRID_COLUMNS}
+        data-rows={LAYOUT_GRID_ROWS}
+        style={{
+          pointerEvents: "none",
+          opacity: 0.38,
+          backgroundImage: [
+            `linear-gradient(to right, ${blendHex(colors.bg, colors.borderFocused, 0.42)} 1px, transparent 1px)`,
+            `linear-gradient(to bottom, ${blendHex(colors.bg, colors.borderFocused, 0.34)} 1px, transparent 1px)`,
+          ].join(", "),
+          backgroundSize: `${100 / LAYOUT_GRID_COLUMNS}% ${100 / LAYOUT_GRID_ROWS}%`,
+        }}
+      />
+    );
+  }
+
+  const lineColor = blendHex(colors.bg, colors.borderFocused, 0.42);
+  const excluded = new Set(excludedRows.flatMap((row) => {
+    const headerRow = Math.floor(row);
+    return [headerRow - 1, headerRow, headerRow + 1];
+  }));
+  const verticalLines = [...new Set(cells.map((cell) => cell.rect.x))].filter((x) => x > 0);
+  const horizontalLines = [...new Set(cells.map((cell) => cell.rect.y))]
+    .filter((y) => y > 0 && !excluded.has(y));
+  return (
+    <Box
+      position="absolute"
+      left={0}
+      top={0}
+      width={width}
+      height={height}
+      zIndex={90}
+      data-gloom-role="layout-grid-overlay"
+      data-columns={LAYOUT_GRID_COLUMNS}
+      data-rows={LAYOUT_GRID_ROWS}
+    >
+      {verticalLines.map((x) => (
+        Array.from({ length: Math.max(1, Math.floor(height)) }, (_, y) => (
+          excluded.has(y) ? null : (
+            <Box key={`grid-v:${x}:${y}`} position="absolute" left={x} top={y} width={1} height={1}>
+              <Text fg={lineColor} selectable={false}>┊</Text>
+            </Box>
+          )
+        ))
+      ))}
+      {horizontalLines.map((y) => (
+        <Box key={`grid-h:${y}`} position="absolute" left={0} top={y} width={width} height={1}>
+          <Text fg={lineColor} selectable={false}>{"┄".repeat(Math.max(1, Math.floor(width)))}</Text>
+        </Box>
+      ))}
+    </Box>
+  );
+}
 
 export function ShellDragOverlays({
   activeHoverOverlay,
@@ -9,15 +90,26 @@ export function ShellDragOverlays({
   dockPreview,
   dragFloatingRect,
   effectiveDockPreview,
+  gridHeight,
+  gridWidth,
+  gridExcludedRows,
+  showGrid,
 }: {
   activeHoverOverlay: HoverOverlay | null;
   activePaneDrag: { paneId: string; mode: "docked" | "floating" } | null;
   dockPreview: DragPreview | null;
   dragFloatingRect: { paneId: string; rect: FloatingRect } | null;
   effectiveDockPreview: DragPreview | null;
+  gridHeight: number;
+  gridWidth: number;
+  gridExcludedRows?: number[];
+  showGrid: boolean;
 }) {
+  const { nativePaneChrome } = useUiCapabilities();
   return (
     <>
+      {showGrid && <ShellLayoutGridOverlay width={gridWidth} height={gridHeight} excludedRows={gridExcludedRows} />}
+
       {activeHoverOverlay && activeHoverOverlay.cells.map((cell) => {
         const active = dockPreview?.kind === "dock"
           && dockPreview.target.kind === "leaf"
@@ -59,20 +151,31 @@ export function ShellDragOverlays({
           />
         )}
 
-      {effectiveDockPreview && (
+      {effectiveDockPreview && effectiveDockPreview.rects.map((preview, index) => (
         <Box
+          key={`drag-preview:${preview.instanceId}`}
+          id={`drag-preview:${preview.instanceId}`}
           position="absolute"
-          left={effectiveDockPreview.rect.x}
-          top={effectiveDockPreview.rect.y}
-          width={effectiveDockPreview.rect.width}
-          height={effectiveDockPreview.rect.height}
+          left={preview.rect.x}
+          top={preview.rect.y}
+          width={preview.rect.width}
+          height={preview.rect.height}
           border
           borderStyle="single"
           borderColor={colors.borderFocused}
-          backgroundColor={colors.panel}
+          backgroundColor={effectiveDockPreview.kind === "snap" && index === 0 ? colors.header : colors.panel}
           zIndex={96}
+          data-gloom-role={effectiveDockPreview.kind === "snap" && index === 0 ? "grid-snap-placeholder" : "dock-preview"}
+          data-preview-pane-id={preview.instanceId}
+          data-snap-position={effectiveDockPreview.kind === "snap" && index === 0 ? effectiveDockPreview.position : undefined}
+          style={nativePaneChrome && effectiveDockPreview.kind === "snap" && index === 0 ? {
+            pointerEvents: "none",
+            backgroundColor: blendHex(colors.panel, colors.borderFocused, 0.24),
+            border: `2px solid ${colors.borderFocused}`,
+            boxShadow: `inset 0 0 0 1px ${blendHex(colors.borderFocused, colors.textBright, 0.35)}`,
+          } : undefined}
         />
-      )}
+      ))}
     </>
   );
 }

--- a/src/components/layout/shell/drag/runtime.ts
+++ b/src/components/layout/shell/drag/runtime.ts
@@ -12,6 +12,7 @@ import {
   type DockGeometryOptions,
   type DockLeafLayout,
   type FloatingRect,
+  type FloatingResizeCorner,
   type LayoutBounds,
   type ResolvedPane,
 } from "../../../../plugins/pane-manager";
@@ -47,6 +48,7 @@ type DragMode =
   | {
     type: "float-resize";
     paneId: string;
+    corner: FloatingResizeCorner;
     startX: number;
     startY: number;
     origRect: FloatingRect;
@@ -186,6 +188,7 @@ interface UseShellPointerRuntimeOptions {
   setMenuState: Dispatch<SetStateAction<ActionMenuState | null>>;
   snapGuides: ReturnType<typeof makeSnapGuides>;
   transientFocusActive: boolean;
+  togglePaneFloating: (paneId: string) => boolean;
   updateWindowModePreviewLayout: (nextLayout: LayoutConfig, paneId?: string) => void;
   visibleFloatingPanes: VisibleFloatingPane[];
   visibleLayout: LayoutConfig;
@@ -217,6 +220,7 @@ export function useShellPointerRuntime({
   setMenuState,
   snapGuides,
   transientFocusActive,
+  togglePaneFloating,
   updateWindowModePreviewLayout,
   visibleFloatingPanes,
   visibleLayout,
@@ -261,6 +265,7 @@ export function useShellPointerRuntime({
     setHoveredMenuItemId,
     setMenuState,
     transientFocusActive,
+    togglePaneFloating,
     visibleFloatingPanes,
     width,
     windowMode,
@@ -279,6 +284,7 @@ export function useShellPointerRuntime({
     setHoveredMenuItemId,
     setMenuState,
     transientFocusActive,
+    togglePaneFloating,
     windowMode,
   });
 

--- a/src/components/layout/shell/index.test.tsx
+++ b/src/components/layout/shell/index.test.tsx
@@ -13,21 +13,25 @@ import {
 import { cloneLayout, createDefaultConfig, TICKER_RESEARCH_PANE_ID, type LayoutConfig } from "../../../types/config";
 import type { PluginRegistry } from "../../../plugins/registry";
 import type { PaneProps } from "../../../types/plugin";
-import { Textarea } from "../../../ui";
+import { Textarea, type BoxRenderable } from "../../../ui";
 import {
   buildNativeWindowState,
   resolvePaneManagementShortcut,
   resolveAppHeaderHeightCells,
   Shell,
 } from "./index";
+import { buildNativeTransientOccluders } from "./native/window-state";
 import { resolvePaneFocusSourceLayout } from "./fullscreen";
 import { TransientLayoutProvider, useTransientLayout, type TransientLayoutState } from "../transient-layout";
+import { getDockLeafLayouts } from "../../../plugins/pane-manager";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 
-afterEach(() => {
+afterEach(async () => {
   if (testSetup) {
-    testSetup.renderer.destroy();
+    await act(async () => {
+      testSetup!.renderer.destroy();
+    });
     testSetup = undefined;
   }
 });
@@ -215,6 +219,33 @@ describe("Shell", () => {
     expect(state.occluders.some((occluder) => occluder.id === "overlay:global")).toBe(false);
   });
 
+  test("occludes every changed pane in a native multi-pane drag preview", () => {
+    const rects = [
+      { instanceId: "left:main", rect: { x: 0, y: 0, width: 40, height: 20 } },
+      { instanceId: "right:main", rect: { x: 40, y: 0, width: 40, height: 20 } },
+    ];
+    const occluders = buildNativeTransientOccluders({
+      activeHoverOverlay: null,
+      activePaneDrag: null,
+      commandBarNativeOccluder: null,
+      dragFloatingRect: null,
+      dockPreview: {
+        kind: "compact",
+        layout: { dockRoot: null, instances: [], floating: [], detached: [] },
+        rect: rects[0]!.rect,
+        rects,
+      },
+      menu: null,
+      nativeWindowModePanelRect: null,
+      windowModeDockMovePreview: null,
+    });
+
+    expect(occluders).toEqual([
+      { id: "dock-preview:compact:left:main", rect: rects[0]!.rect, zIndex: 96 },
+      { id: "dock-preview:compact:right:main", rect: rects[1]!.rect, zIndex: 96 },
+    ]);
+  });
+
   test("opens the pane menu when clicking the docked header action area", async () => {
     const config = createDefaultConfig("/tmp/gloomberb-shell-test");
     const mainPane = config.layout.instances.find((instance) => instance.instanceId === "portfolio-list:main");
@@ -255,6 +286,36 @@ describe("Shell", () => {
     expect(frame).toContain("Ctrl+,");
     expect(frame).not.toContain("Layout Actions");
     expect(frame).not.toContain("CmdOrCtrl");
+  });
+
+  test("toggles a pane from the visible tiled header control", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-header-toggle-test");
+    const mainPane = requireLayoutInstance(config, "portfolio-list:main");
+    const layout: LayoutConfig = {
+      dockRoot: { kind: "pane", instanceId: mainPane.instanceId },
+      instances: [{ ...mainPane }],
+      floating: [],
+      detached: [],
+    };
+    const actions: ShellTestAction[] = [];
+    await renderShellForWindowModeTest(
+      createShellStateWithLayout(config, layout, mainPane.instanceId),
+      { width: 50, height: 12, dispatch: (action) => actions.push(action) },
+    );
+
+    const frame = testSetup!.captureCharFrame();
+    const toggleX = frame.split("\n")[0]?.indexOf("T▦") ?? -1;
+    expect(toggleX).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(toggleX, 1);
+      await testSetup!.renderOnce();
+    });
+
+    const update = actions.find((action) => action.type === "UPDATE_LAYOUT");
+    expect(update?.layout.floating).toEqual([
+      expect.objectContaining({ instanceId: mainPane.instanceId }),
+    ]);
   });
 
   test("shows a Pop Out action in the pane menu when a desktop bridge is available", async () => {
@@ -478,6 +539,8 @@ describe("Shell", () => {
 
     const frame = testSetup!.captureCharFrame();
     const rows = frame.split("\n");
+    expect(frame).toContain("┊");
+    expect(frame).toContain("┄");
     expect(rows[2]?.indexOf("┌─:: Main Portfolio") ?? -1).toBeLessThan(0);
     expect(rows[5]?.indexOf("┌─:: Main Portfolio")).toBeGreaterThanOrEqual(14);
 
@@ -485,6 +548,360 @@ describe("Shell", () => {
       await testSetup!.mockMouse.release(16, 6);
       await testSetup!.renderOnce();
     });
+  });
+
+  test("keeps a freely moved floating pane floating when no dock target is present", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-free-floating-drag-test");
+    const mainPane = requireLayoutInstance(config, "portfolio-list:main");
+    const layout: LayoutConfig = {
+      dockRoot: null,
+      instances: [{ ...mainPane }],
+      floating: [{ instanceId: mainPane.instanceId, x: 8, y: 2, width: 32, height: 10, zIndex: 75 }],
+      detached: [],
+    };
+    const { actions } = await renderShellForWindowModeTest(
+      createShellStateWithLayout(config, layout, mainPane.instanceId),
+      { width: 80, height: 18 },
+    );
+
+    await act(async () => {
+      await testSetup!.mockMouse.drag(10, 3, 28, 8);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const nextLayout = actions.filter((action) => action.type === "UPDATE_LAYOUT").at(-1)?.layout as LayoutConfig | undefined;
+    expect(nextLayout?.dockRoot).toBeNull();
+    expect(nextLayout?.floating).toEqual([
+      expect.objectContaining({
+        instanceId: mainPane.instanceId,
+        x: 26,
+        y: 6,
+        width: 32,
+        height: 10,
+      }),
+    ]);
+  });
+
+  test("previews and commits compact reflow outside the explicit dock overlay", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-live-compact-drag-test");
+    const mainPane = requireLayoutInstance(config, "portfolio-list:main");
+    const detailPane = requireLayoutInstance(config, "ticker-detail:main");
+    const lowerDetailPane = { ...detailPane, instanceId: "ticker-detail:lower" };
+    const layout: LayoutConfig = {
+      dockRoot: {
+        kind: "split",
+        axis: "horizontal",
+        ratio: 0.5,
+        first: { kind: "pane", instanceId: mainPane.instanceId },
+        second: {
+          kind: "split",
+          axis: "vertical",
+          ratio: 0.5,
+          first: { kind: "pane", instanceId: detailPane.instanceId },
+          second: { kind: "pane", instanceId: lowerDetailPane.instanceId },
+        },
+      },
+      instances: [{ ...mainPane }, { ...detailPane }, lowerDetailPane],
+      floating: [],
+      detached: [],
+    };
+    const { actions } = await renderShellForWindowModeTest(
+      createShellStateWithLayout(config, layout, mainPane.instanceId),
+      { width: 120, height: 61 },
+    );
+
+    await act(async () => {
+      await testSetup!.mockMouse.pressDown(5, 1);
+      await testSetup!.renderOnce();
+      await testSetup!.mockMouse.moveTo(115, 5);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
+    expect(testSetup!.renderer.root.findDescendantById(`drag-preview:${mainPane.instanceId}`)).toBeDefined();
+
+    await act(async () => {
+      await testSetup!.mockMouse.release(115, 5);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const updates = actions.filter((action) => action.type === "UPDATE_LAYOUT");
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.layout.dockRoot).toMatchObject({
+      kind: "split",
+      axis: "vertical",
+      first: {
+        kind: "split",
+        axis: "horizontal",
+        first: { kind: "pane", instanceId: detailPane.instanceId },
+        second: { kind: "pane", instanceId: mainPane.instanceId },
+      },
+      second: { kind: "pane", instanceId: lowerDetailPane.instanceId },
+    });
+  });
+
+  for (const directionalCase of [
+    {
+      position: "top",
+      pointer: { x: 88, y: 12 },
+      axis: "vertical",
+      order: ["portfolio-list:main", "ticker-detail:main"],
+      previewRects: [
+        { instanceId: "portfolio-list:main", rect: { x: 0, y: 0, width: 120, height: 14 } },
+        { instanceId: "ticker-detail:main", rect: { x: 0, y: 15, width: 120, height: 14 } },
+        { instanceId: "ticker-detail:lower", rect: { x: 0, y: 30, width: 120, height: 29 } },
+      ],
+      committedRects: [
+        { instanceId: "portfolio-list:main", rect: { x: 0, y: 0, width: 120, height: 14 } },
+        { instanceId: "ticker-detail:main", rect: { x: 0, y: 15, width: 120, height: 14 } },
+        { instanceId: "ticker-detail:lower", rect: { x: 0, y: 30, width: 120, height: 29 } },
+      ],
+    },
+    {
+      position: "left",
+      pointer: { x: 82, y: 15 },
+      axis: "horizontal",
+      order: ["portfolio-list:main", "ticker-detail:main"],
+      previewRects: [
+        { instanceId: "portfolio-list:main", rect: { x: 0, y: 0, width: 60, height: 29 } },
+        { instanceId: "ticker-detail:lower", rect: { x: 0, y: 30, width: 120, height: 29 } },
+      ],
+      committedRects: [
+        { instanceId: "portfolio-list:main", rect: { x: 0, y: 0, width: 60, height: 29 } },
+        { instanceId: "ticker-detail:main", rect: { x: 61, y: 0, width: 59, height: 29 } },
+        { instanceId: "ticker-detail:lower", rect: { x: 0, y: 30, width: 120, height: 29 } },
+      ],
+    },
+    {
+      position: "right",
+      pointer: { x: 95, y: 15 },
+      axis: "horizontal",
+      order: ["ticker-detail:main", "portfolio-list:main"],
+      previewRects: [
+        { instanceId: "ticker-detail:main", rect: { x: 0, y: 0, width: 60, height: 29 } },
+        { instanceId: "portfolio-list:main", rect: { x: 61, y: 0, width: 59, height: 29 } },
+        { instanceId: "ticker-detail:lower", rect: { x: 0, y: 30, width: 120, height: 29 } },
+      ],
+      committedRects: [
+        { instanceId: "ticker-detail:main", rect: { x: 0, y: 0, width: 60, height: 29 } },
+        { instanceId: "portfolio-list:main", rect: { x: 61, y: 0, width: 59, height: 29 } },
+        { instanceId: "ticker-detail:lower", rect: { x: 0, y: 30, width: 120, height: 29 } },
+      ],
+    },
+    {
+      position: "bottom",
+      pointer: { x: 88, y: 18 },
+      axis: "vertical",
+      order: ["ticker-detail:main", "portfolio-list:main"],
+      previewRects: [
+        { instanceId: "ticker-detail:main", rect: { x: 0, y: 0, width: 120, height: 14 } },
+        { instanceId: "portfolio-list:main", rect: { x: 0, y: 15, width: 120, height: 14 } },
+        { instanceId: "ticker-detail:lower", rect: { x: 0, y: 30, width: 120, height: 29 } },
+      ],
+      committedRects: [
+        { instanceId: "ticker-detail:main", rect: { x: 0, y: 0, width: 120, height: 14 } },
+        { instanceId: "portfolio-list:main", rect: { x: 0, y: 15, width: 120, height: 14 } },
+        { instanceId: "ticker-detail:lower", rect: { x: 0, y: 30, width: 120, height: 29 } },
+      ],
+    },
+  ] as const) {
+    test(`routes the ${directionalCase.position} overlay cell through pointer preview and release`, async () => {
+      const config = createDefaultConfig(`/tmp/gloomberb-shell-directional-${directionalCase.position}-test`);
+      const mainPane = requireLayoutInstance(config, "portfolio-list:main");
+      const detailPane = requireLayoutInstance(config, "ticker-detail:main");
+      const lowerDetailPane = { ...detailPane, instanceId: "ticker-detail:lower" };
+      const layout: LayoutConfig = {
+        dockRoot: {
+          kind: "split",
+          axis: "horizontal",
+          ratio: 0.5,
+          first: { kind: "pane", instanceId: mainPane.instanceId },
+          second: {
+            kind: "split",
+            axis: "vertical",
+            ratio: 0.5,
+            first: { kind: "pane", instanceId: detailPane.instanceId },
+            second: { kind: "pane", instanceId: lowerDetailPane.instanceId },
+          },
+        },
+        instances: [{ ...mainPane }, { ...detailPane }, lowerDetailPane],
+        floating: [],
+        detached: [],
+      };
+      const { actions } = await renderShellForWindowModeTest(
+        createShellStateWithLayout(config, layout, mainPane.instanceId),
+        { width: 120, height: 61 },
+      );
+
+      await act(async () => {
+        await testSetup!.mockMouse.pressDown(5, 1);
+        await testSetup!.renderOnce();
+        await testSetup!.mockMouse.moveTo(directionalCase.pointer.x, directionalCase.pointer.y);
+        await testSetup!.renderOnce();
+        await testSetup!.renderOnce();
+      });
+
+      expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
+      for (const instanceId of [mainPane.instanceId, detailPane.instanceId, lowerDetailPane.instanceId]) {
+        const expectedPreview = directionalCase.previewRects.find((entry) => entry.instanceId === instanceId);
+        const renderable = testSetup!.renderer.root.findDescendantById(`drag-preview:${instanceId}`) as BoxRenderable | undefined;
+        if (!expectedPreview) {
+          expect(renderable).toBeUndefined();
+          continue;
+        }
+        expect(renderable).toBeDefined();
+        expect({ x: renderable!.x, y: renderable!.y, width: renderable!.width, height: renderable!.height })
+          .toEqual(expectedPreview.rect);
+      }
+
+      await act(async () => {
+        await testSetup!.mockMouse.release(directionalCase.pointer.x, directionalCase.pointer.y);
+        await testSetup!.renderOnce();
+        await testSetup!.renderOnce();
+      });
+
+      const updates = actions.filter((action) => action.type === "UPDATE_LAYOUT");
+      expect(updates).toHaveLength(1);
+      expect(updates[0]!.layout.dockRoot).toMatchObject({
+        kind: "split",
+        axis: "vertical",
+        first: {
+          kind: "split",
+          axis: directionalCase.axis,
+          first: { kind: "pane", instanceId: directionalCase.order[0] },
+          second: { kind: "pane", instanceId: directionalCase.order[1] },
+        },
+        second: { kind: "pane", instanceId: lowerDetailPane.instanceId },
+      });
+      expect(JSON.stringify(getDockLeafLayouts(
+        updates[0]!.layout,
+        { x: 0, y: 0, width: 120, height: 59 },
+        { reserveDividerGutters: true },
+      ).map(({ instanceId, rect }) => ({ instanceId, rect }))))
+        .toBe(JSON.stringify(directionalCase.committedRects));
+    });
+  }
+
+  test("renders and commits the exact selected 6x6 cell when the only dock leaf becomes floating", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-cell-snap-test");
+    const mainPane = requireLayoutInstance(config, "portfolio-list:main");
+    const layout: LayoutConfig = {
+      dockRoot: { kind: "pane", instanceId: mainPane.instanceId },
+      instances: [{ ...mainPane }],
+      floating: [],
+      detached: [],
+    };
+    const controls: {
+      state?: ReturnType<typeof createInitialState>;
+      transientLayout: TransientLayoutState | null;
+    } = { transientLayout: null };
+    testSetup = await testRender(
+      <ShellTransientHarness
+        initialState={createShellStateWithLayout(config, layout, mainPane.instanceId)}
+        registry={createShellPluginRegistry()}
+        controls={controls}
+      />,
+      { width: 60, height: 37 },
+    );
+    await testSetup.renderOnce();
+    const expected = { x: 50, y: 29, width: 10, height: 6 };
+
+    await act(async () => {
+      await testSetup!.mockMouse.pressDown(5, 1);
+      await testSetup!.renderOnce();
+      await testSetup!.mockMouse.moveTo(55, 34);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const livePreview = testSetup.renderer.root.findDescendantById(`drag-preview:${mainPane.instanceId}`) as BoxRenderable | undefined;
+    expect(livePreview).toBeDefined();
+    expect({ x: livePreview!.x, y: livePreview!.y, width: livePreview!.width, height: livePreview!.height }).toEqual(expected);
+
+    await act(async () => {
+      await testSetup!.mockMouse.release(55, 34);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(controls.state?.config.layout.dockRoot).toBeNull();
+    expect(controls.state?.config.layout.floating).toEqual([
+      expect.objectContaining({ instanceId: mainPane.instanceId, ...expected, fixedGeometry: true }),
+    ]);
+    const committedPane = testSetup.renderer.root.findDescendantById(`floating-pane:${mainPane.instanceId}`) as BoxRenderable | undefined;
+    expect({ x: committedPane!.x, y: committedPane!.y, width: committedPane!.width, height: committedPane!.height }).toEqual(expected);
+  });
+
+  test("center-swaps a snapped floating pane through pointer preview, release, and rendered geometry", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-snapped-center-drop-test");
+    const dockedPane = requireLayoutInstance(config, "portfolio-list:main");
+    const floatingPane = requireLayoutInstance(config, "ticker-detail:main");
+    const snappedRect = {
+      instanceId: floatingPane.instanceId,
+      x: 80,
+      y: 4,
+      width: 20,
+      height: 10,
+      zIndex: 75,
+      fixedGeometry: true,
+    };
+    const layout: LayoutConfig = {
+      dockRoot: { kind: "pane", instanceId: dockedPane.instanceId },
+      instances: [{ ...dockedPane }, { ...floatingPane }],
+      floating: [snappedRect],
+      detached: [],
+    };
+    const controls: {
+      state?: ReturnType<typeof createInitialState>;
+      transientLayout: TransientLayoutState | null;
+    } = { transientLayout: null };
+    testSetup = await testRender(
+      <ShellTransientHarness
+        initialState={createShellStateWithLayout(config, layout, floatingPane.instanceId)}
+        registry={createShellPluginRegistry()}
+        controls={controls}
+      />,
+      { width: 120, height: 61 },
+    );
+    await testSetup.renderOnce();
+
+    await act(async () => {
+      await testSetup!.mockMouse.pressDown(82, 5);
+      await testSetup!.renderOnce();
+      await testSetup!.mockMouse.moveTo(59, 30);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const dockPreview = testSetup.renderer.root.findDescendantById(`drag-preview:${floatingPane.instanceId}`) as BoxRenderable | undefined;
+    expect(dockPreview).toBeDefined();
+    expect({ x: dockPreview!.x, y: dockPreview!.y, width: dockPreview!.width, height: dockPreview!.height })
+      .toEqual({ x: 0, y: 0, width: 120, height: 59 });
+    const floatingPreview = testSetup.renderer.root.findDescendantById(`floating-pane:${dockedPane.instanceId}`) as BoxRenderable | undefined;
+    expect(floatingPreview).toBeDefined();
+    expect({ x: floatingPreview!.x, y: floatingPreview!.y, width: floatingPreview!.width, height: floatingPreview!.height })
+      .toEqual({ x: 80, y: 4, width: 20, height: 10 });
+
+    await act(async () => {
+      await testSetup!.mockMouse.release(59, 30);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(controls.state?.config.layout.dockRoot).toEqual({
+      kind: "pane",
+      instanceId: floatingPane.instanceId,
+    });
+    expect(controls.state?.config.layout.floating).toEqual([
+      { ...snappedRect, instanceId: dockedPane.instanceId },
+    ]);
+    const committedPane = testSetup.renderer.root.findDescendantById(`floating-pane:${dockedPane.instanceId}`) as BoxRenderable | undefined;
+    expect(committedPane).toBeDefined();
+    expect({ x: committedPane!.x, y: committedPane!.y, width: committedPane!.width, height: committedPane!.height })
+      .toEqual({ x: 80, y: 4, width: 20, height: 10 });
   });
 
   test("keeps the focused textarea cursor visible when it is not covered", async () => {

--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -193,15 +193,19 @@ export function Shell({
     focusedPaneId,
     hasActiveDrag,
     nativePaneChrome,
+    overlayOpen,
     persistLayout,
     pluginRegistry,
     visibleLayout,
     width,
   });
   const transientFocusActive = !windowMode && transientFocusLayoutState?.active === true;
-  const activeLayout = transientFocusActive && transientFocusLayoutState
+  const interactionLayout = transientFocusActive && transientFocusLayoutState
     ? transientFocusLayoutState.layout
     : windowModeLayout;
+  const activeLayout = !windowMode && dockPreview
+    ? dockPreview.layout
+    : interactionLayout;
   const transientFocusPaneId = transientFocusActive ? transientFocusLayoutState?.paneId ?? null : null;
 
   useEffect(() => {
@@ -255,6 +259,7 @@ export function Shell({
     openPaneSettings,
     popOutFocusedPane,
     toggleFocusedPaneFloating,
+    togglePaneFloating,
   } = useShellPaneActions({
     closePaneMenu,
     contentHeight,
@@ -385,16 +390,20 @@ export function Shell({
     toggleFocusedPaneFloating,
   });
 
+  const interactionDockLeafLayouts = useMemo(
+    () => getDockLeafLayouts(interactionLayout, bounds, dockGeometryOptions),
+    [bounds, dockGeometryOptions, interactionLayout],
+  );
   const dockLeafLayouts = useMemo(() => getDockLeafLayouts(activeLayout, bounds, dockGeometryOptions), [activeLayout, bounds, dockGeometryOptions]);
   const dockDividerLayouts = useMemo(() => getDockDividerLayouts(activeLayout, bounds, dockGeometryOptions), [activeLayout, bounds, dockGeometryOptions]);
   const snapGuides = useMemo(() => makeSnapGuides(width, contentHeight), [contentHeight, width]);
   const externalDockPreview = useMemo(
-    () => resolveExternalDockPreview(desktopDockPreview, bounds),
-    [bounds, desktopDockPreview],
+    () => resolveExternalDockPreview(desktopDockPreview, bounds, visibleLayout, dockGeometryOptions),
+    [bounds, desktopDockPreview, dockGeometryOptions, visibleLayout],
   );
   const activePaneDrag = dragRef.current?.type === "pane-drag" ? dragRef.current : null;
-  const activeHoverOverlay = activePaneDrag && dragCursor
-    ? resolveHoverOverlay(dragCursor.x, dragCursor.y, dockLeafLayouts, activePaneDrag.paneId)
+  const activeHoverOverlay = activePaneDrag && dragCursor && dockPreview?.kind !== "compact"
+    ? resolveHoverOverlay(dragCursor.x, dragCursor.y, interactionDockLeafLayouts, activePaneDrag.paneId)
     : null;
   const effectiveDockPreview = dockPreview ?? externalDockPreview;
   useShellNativeSurfaceWindowState({
@@ -438,6 +447,7 @@ export function Shell({
     };
     const items = menuForPane(
       pane,
+      rect,
       visibleLayout,
       width,
       contentHeight,
@@ -479,6 +489,7 @@ export function Shell({
     handleNativePaneContextMenu,
     handleNativePaneMouseDown,
     handlePaneAction,
+    handlePaneFloatToggle,
     startNativeDividerDrag,
     startNativeDockedDrag,
     startNativeFloatingDrag,
@@ -491,7 +502,7 @@ export function Shell({
     dispatch,
     dockGeometryOptions,
     dockDividerLayouts,
-    dockLeafLayouts,
+    dockLeafLayouts: interactionDockLeafLayouts,
     dragRuntime,
     focusPane,
     focusedPaneId,
@@ -507,6 +518,7 @@ export function Shell({
     setMenuState,
     snapGuides,
     transientFocusActive,
+    togglePaneFloating,
     updateWindowModePreviewLayout,
     visibleFloatingPanes,
     visibleLayout,
@@ -568,6 +580,7 @@ export function Shell({
         handleNativePaneContextMenu={handleNativePaneContextMenu}
         handleNativePaneMouseDown={handleNativePaneMouseDown}
         handlePaneAction={handlePaneAction}
+        handlePaneFloatToggle={handlePaneFloatToggle}
         hoveredPaneId={hoveredPaneId}
         menuPaneId={menuState?.paneId ?? null}
         nativeContextMenu={nativeContextMenu}
@@ -612,6 +625,15 @@ export function Shell({
         dockPreview={dockPreview}
         dragFloatingRect={dragFloatingRect}
         effectiveDockPreview={effectiveDockPreview}
+        gridHeight={contentHeight}
+        gridWidth={width}
+        gridExcludedRows={[
+          ...dockLeafLayouts.map((leaf) => leaf.rect.y),
+          ...visibleFloatingPanes.map(({ pane, rect }) => (
+            dragFloatingRect?.paneId === pane.instance.instanceId ? dragFloatingRect.rect.y : rect.y
+          )),
+        ]}
+        showGrid={!!dragRef.current && !windowMode}
       />
 
       <ShellActionMenuOverlay

--- a/src/components/layout/shell/menu.ts
+++ b/src/components/layout/shell/menu.ts
@@ -1,8 +1,9 @@
 import type { DesktopWindowBridge } from "../../../types/desktop-window";
 import {
-  applyDrop,
-  floatPane,
+  dockFloatingPaneAtCurrentRect,
+  floatAtRect,
   removePane,
+  type LayoutBounds,
   type ResolvedPane,
 } from "../../../plugins/pane-manager";
 import type { PluginRegistry } from "../../../plugins/registry";
@@ -21,6 +22,7 @@ export const MENU_Z_INDEX = 10_000;
 
 export function menuForPane(
   pane: ResolvedPane,
+  rect: LayoutBounds,
   layout: LayoutConfig,
   width: number,
   contentHeight: number,
@@ -55,7 +57,11 @@ export function menuForPane(
       label: "Dock Pane",
       accelerator: PANE_MANAGEMENT_ACCELERATORS.toggleFloating,
       onSelect: () => {
-        persistLayout(applyDrop(layout, pane.instance.instanceId, { kind: "frame", edge: "right" }));
+        persistLayout(dockFloatingPaneAtCurrentRect(
+          layout,
+          pane.instance.instanceId,
+          { x: 0, y: 0, width, height: contentHeight },
+        ));
         focusPane(pane.instance.instanceId);
       },
     });
@@ -65,7 +71,7 @@ export function menuForPane(
       label: "Float Pane",
       accelerator: PANE_MANAGEMENT_ACCELERATORS.toggleFloating,
       onSelect: () => {
-        persistLayout(floatPane(layout, pane.instance.instanceId, width, contentHeight, pane.def));
+        persistLayout(floatAtRect(layout, pane.instance.instanceId, rect));
         focusPane(pane.instance.instanceId);
       },
     });

--- a/src/components/layout/shell/native/pointer-runtime.test.tsx
+++ b/src/components/layout/shell/native/pointer-runtime.test.tsx
@@ -1,0 +1,465 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  getDockLeafLayouts,
+  type LayoutBounds,
+  type ResolvedPane,
+} from "../../../../plugins/pane-manager";
+import { createPaneInstance, type LayoutConfig } from "../../../../types/config";
+import { useShellActiveDrag } from "../active-drag";
+import {
+  constrainFloatingRectToBounds,
+  makeSnapGuides,
+  resolveHoverOverlay,
+} from "../drag";
+import type { ShellDragRuntimeState, ShellMouseEvent } from "../drag/runtime";
+import { useShellNativePointerRuntime } from "./pointer-runtime";
+
+type NativePointerRuntime = ReturnType<typeof useShellNativePointerRuntime>;
+
+function createMouseDown(): ShellMouseEvent & { defaultPrevented: boolean; propagationStopped: boolean } {
+  return {
+    type: "down",
+    x: 20,
+    y: 5,
+    button: 0,
+    preciseX: 20,
+    preciseY: 5,
+    defaultPrevented: false,
+    propagationStopped: false,
+    preventDefault() { this.defaultPrevented = true; },
+    stopPropagation() { this.propagationStopped = true; },
+  };
+}
+
+function createPointerEvent(
+  type: "down" | "drag" | "drag-end",
+  x: number,
+  preciseY: number,
+): ShellMouseEvent & { defaultPrevented: boolean; propagationStopped: boolean } {
+  return {
+    type,
+    x,
+    y: preciseY,
+    button: 0,
+    preciseX: x,
+    preciseY,
+    defaultPrevented: false,
+    propagationStopped: false,
+    preventDefault() { this.defaultPrevented = true; },
+    stopPropagation() { this.propagationStopped = true; },
+  };
+}
+
+function createDragRuntime(): ShellDragRuntimeState {
+  const dragRef = { current: null } as ShellDragRuntimeState["dragRef"];
+  const dividerPreviewRef = { current: null } as ShellDragRuntimeState["dividerPreviewRef"];
+  const dockPreviewRef = { current: null } as ShellDragRuntimeState["dockPreviewRef"];
+  const dragRuntime: ShellDragRuntimeState = {
+    cancelActiveDrag() {
+      dragRef.current = null;
+      dividerPreviewRef.current = null;
+      dockPreviewRef.current = null;
+    },
+    dividerPreview: null,
+    dividerPreviewRef,
+    dockPreview: null,
+    dockPreviewRef,
+    dragCursor: null,
+    dragFloatingRect: null,
+    dragRef,
+    hasActiveDrag: () => dragRef.current != null,
+    setDragCursor() {},
+    updateDividerPreview(next) { dividerPreviewRef.current = next; },
+    updateDockPreview(next) { dockPreviewRef.current = next; },
+    updateDragFloatingRect(next) { dragRuntime.dragFloatingRect = next; },
+  };
+  return dragRuntime;
+}
+
+const NATIVE_BOUNDS: LayoutBounds = { x: 0, y: 0, width: 120, height: 60 };
+const NATIVE_APP_HEADER_HEIGHT = 28 / 18;
+
+function paneMapFor(layout: LayoutConfig): Map<string, ResolvedPane> {
+  return new Map(layout.instances.map((instance): [string, ResolvedPane] => {
+    const floating = layout.floating.find((entry) => entry.instanceId === instance.instanceId);
+    return [instance.instanceId, {
+      instance,
+      def: {
+        id: instance.paneId,
+        name: instance.paneId,
+        component: () => null,
+        defaultPosition: "left",
+      },
+      ...(floating ? { floating } : {}),
+    }];
+  }));
+}
+
+function renderIntegratedPointerRuntime(layout: LayoutConfig) {
+  const dragRuntime = createDragRuntime();
+  const persistedLayouts: LayoutConfig[] = [];
+  const focusedPaneIds: string[] = [];
+  let runtime: NativePointerRuntime | undefined;
+  const dockLeafLayouts = getDockLeafLayouts(layout, NATIVE_BOUNDS, { precise: true });
+
+  function Harness() {
+    const handleActiveDrag = useShellActiveDrag({
+      appHeaderHeight: NATIVE_APP_HEADER_HEIGHT,
+      bounds: NATIVE_BOUNDS,
+      contentHeight: NATIVE_BOUNDS.height,
+      dispatch() {},
+      dockGeometryOptions: { precise: true },
+      dockLeafLayouts,
+      dragRuntime,
+      focusPane(paneId) { focusedPaneIds.push(paneId); },
+      nativePaneChrome: true,
+      paneMap: paneMapFor(layout),
+      persistLayout(nextLayout) { persistedLayouts.push(nextLayout); },
+      precisePointer: true,
+      snapGuides: makeSnapGuides(NATIVE_BOUNDS.width, NATIVE_BOUNDS.height),
+      updateWindowModePreviewLayout() {},
+      visibleLayout: layout,
+      width: NATIVE_BOUNDS.width,
+      windowMode: null,
+    });
+    runtime = useShellNativePointerRuntime({
+      appHeaderHeight: NATIVE_APP_HEADER_HEIGHT,
+      dragRuntime,
+      focusPane(paneId) { focusedPaneIds.push(paneId); },
+      handleActiveDrag,
+      handleFloatingClose() {},
+      menuState: null,
+      nativePaneChrome: true,
+      openPaneMenu() {},
+      selectWindowModePane() {},
+      setHoveredMenuItemId() {},
+      setMenuState() {},
+      transientFocusActive: false,
+      togglePaneFloating: () => true,
+      windowMode: null,
+    });
+    return null;
+  }
+
+  renderToStaticMarkup(<Harness />);
+  if (!runtime) throw new Error("integrated native pointer runtime was not captured");
+  return { dockLeafLayouts, dragRuntime, focusedPaneIds, persistedLayouts, runtime };
+}
+
+function overlayCellCenter(
+  layout: LayoutConfig,
+  draggedPaneId: string,
+  targetPaneId: string,
+  position: "top" | "left" | "center" | "right" | "bottom",
+) {
+  const leaves = getDockLeafLayouts(layout, NATIVE_BOUNDS, { precise: true });
+  const target = leaves.find((leaf) => leaf.instanceId === targetPaneId);
+  if (!target) throw new Error(`missing target pane ${targetPaneId}`);
+  const overlay = resolveHoverOverlay(
+    target.rect.x + (target.rect.width / 2),
+    target.rect.y + (target.rect.height / 2),
+    leaves,
+    draggedPaneId,
+  );
+  const cell = overlay?.cells.find((entry) => entry.position === position);
+  if (!cell) throw new Error(`missing ${position} overlay cell`);
+  return {
+    x: cell.rect.x + (cell.rect.width / 2),
+    shellY: cell.rect.y + (cell.rect.height / 2),
+  };
+}
+
+function renderPointerRuntime(): {
+  dragRef: ShellDragRuntimeState["dragRef"];
+  runtime: NativePointerRuntime;
+  toggledPaneIds: string[];
+} {
+  const dragRef = { current: null } as ShellDragRuntimeState["dragRef"];
+  const dragRuntime = {
+    dragRef,
+    updateDividerPreview() {},
+    updateDockPreview() {},
+    updateDragFloatingRect() {},
+  } as unknown as ShellDragRuntimeState;
+  let runtime: NativePointerRuntime | undefined;
+  const toggledPaneIds: string[] = [];
+
+  function Harness() {
+    runtime = useShellNativePointerRuntime({
+      appHeaderHeight: 1,
+      dragRuntime,
+      focusPane() {},
+      handleActiveDrag() {},
+      handleFloatingClose() {},
+      menuState: null,
+      nativePaneChrome: true,
+      openPaneMenu() {},
+      selectWindowModePane() {},
+      setHoveredMenuItemId() {},
+      setMenuState() {},
+      transientFocusActive: false,
+      togglePaneFloating(paneId) {
+        toggledPaneIds.push(paneId);
+        return true;
+      },
+      windowMode: null,
+    });
+    return null;
+  }
+
+  renderToStaticMarkup(<Harness />);
+  if (!runtime) throw new Error("native pointer runtime was not captured");
+  return { dragRef, runtime, toggledPaneIds };
+}
+
+describe("useShellNativePointerRuntime", () => {
+  test("routes floating and docked header mousedown to move, and border mousedown to resize", () => {
+    const { dragRef, runtime } = renderPointerRuntime();
+    const floatingRect = { x: 8, y: 2, width: 32, height: 10 };
+    const dockedRect = { x: 0, y: 0, width: 40, height: 17 };
+
+    const floatingHeaderDown = createMouseDown();
+    runtime.startNativeFloatingDrag("floating:main", floatingRect, floatingHeaderDown);
+    expect(dragRef.current).toEqual(expect.objectContaining({
+      type: "pane-drag",
+      paneId: "floating:main",
+      mode: "floating",
+    }));
+    expect(floatingHeaderDown.defaultPrevented).toBe(true);
+    expect(floatingHeaderDown.propagationStopped).toBe(false);
+
+    const dockedHeaderDown = createMouseDown();
+    runtime.startNativeDockedDrag("docked:main", dockedRect, dockedHeaderDown);
+    expect(dragRef.current).toEqual(expect.objectContaining({
+      type: "pane-drag",
+      paneId: "docked:main",
+      mode: "docked",
+    }));
+    expect(dockedHeaderDown.defaultPrevented).toBe(true);
+    expect(dockedHeaderDown.propagationStopped).toBe(false);
+
+    for (const corner of [
+      "top-left",
+      "top",
+      "top-right",
+      "left",
+      "right",
+      "bottom-left",
+      "bottom",
+      "bottom-right",
+    ] as const) {
+      const resizeDown = createMouseDown();
+      runtime.startNativeFloatResize("floating:main", floatingRect, corner, resizeDown);
+      expect(dragRef.current).toEqual(expect.objectContaining({
+        type: "float-resize",
+        paneId: "floating:main",
+        corner,
+      }));
+      expect(resizeDown.defaultPrevented).toBe(true);
+      expect(resizeDown.propagationStopped).toBe(true);
+    }
+  });
+
+  test("previews and commits a native top-edge resize without changing x or width", () => {
+    const floatingRect = {
+      instanceId: "floating:main",
+      x: 20,
+      y: 10,
+      width: 40,
+      height: 20,
+      zIndex: 75,
+    };
+    const layout: LayoutConfig = {
+      dockRoot: null,
+      instances: [createPaneInstance("floating", { instanceId: floatingRect.instanceId })],
+      floating: [floatingRect],
+      detached: [],
+    };
+    const { dragRuntime, persistedLayouts, runtime } = renderIntegratedPointerRuntime(layout);
+    const pointerX = floatingRect.x + (floatingRect.width / 2);
+    const resizedTop = floatingRect.y - 3;
+    const down = createPointerEvent(
+      "down",
+      pointerX,
+      floatingRect.y + NATIVE_APP_HEADER_HEIGHT,
+    );
+
+    runtime.startNativeFloatResize(floatingRect.instanceId, floatingRect, "top", down);
+    expect(dragRuntime.dragRef.current).toEqual(expect.objectContaining({
+      type: "float-resize",
+      paneId: floatingRect.instanceId,
+      corner: "top",
+    }));
+
+    const move = createPointerEvent("drag", pointerX, resizedTop + NATIVE_APP_HEADER_HEIGHT);
+    runtime.handleNativeDrag(move);
+    expect(dragRuntime.dragFloatingRect).toEqual({
+      paneId: floatingRect.instanceId,
+      rect: {
+        x: floatingRect.x,
+        y: resizedTop,
+        width: floatingRect.width,
+        height: floatingRect.height + 3,
+        zIndex: floatingRect.zIndex,
+        fixedGeometry: undefined,
+      },
+    });
+
+    const release = createPointerEvent("drag-end", pointerX, resizedTop + NATIVE_APP_HEADER_HEIGHT);
+    runtime.handleNativeDrag(release);
+
+    expect(persistedLayouts).toHaveLength(1);
+    expect(persistedLayouts[0]!.floating[0]).toMatchObject({
+      instanceId: floatingRect.instanceId,
+      x: floatingRect.x,
+      y: resizedTop,
+      width: floatingRect.width,
+      height: floatingRect.height + 3,
+    });
+    expect(dragRuntime.dragFloatingRect).toBeNull();
+    expect(dragRuntime.dragRef.current).toBeNull();
+    expect(release.defaultPrevented).toBe(true);
+    expect(release.propagationStopped).toBe(true);
+  });
+
+  test("keeps the small float toggle isolated from the header move grab", () => {
+    const { dragRef, runtime, toggledPaneIds } = renderPointerRuntime();
+    const toggleDown = createMouseDown();
+
+    runtime.handlePaneFloatToggle("docked:main", toggleDown);
+
+    expect(toggledPaneIds).toEqual(["docked:main"]);
+    expect(toggleDown.defaultPrevented).toBe(true);
+    expect(toggleDown.propagationStopped).toBe(true);
+    expect(dragRef.current).toBeNull();
+  });
+
+  for (const operation of [
+    { position: "top" as const, axis: "vertical" as const, order: ["source:main", "target:main"] },
+    { position: "left" as const, axis: "horizontal" as const, order: ["source:main", "target:main"] },
+    { position: "right" as const, axis: "horizontal" as const, order: ["target:main", "source:main"] },
+    { position: "bottom" as const, axis: "vertical" as const, order: ["target:main", "source:main"] },
+  ]) {
+    test(`runs native header move, ${operation.position} hover, and release through the shared operator`, () => {
+      const layout: LayoutConfig = {
+        dockRoot: {
+          kind: "split",
+          axis: "horizontal",
+          ratio: 0.5,
+          first: { kind: "pane", instanceId: "source:main" },
+          second: { kind: "pane", instanceId: "target:main" },
+        },
+        instances: [
+          createPaneInstance("source", { instanceId: "source:main" }),
+          createPaneInstance("target", { instanceId: "target:main" }),
+        ],
+        floating: [],
+        detached: [],
+      };
+      const { dockLeafLayouts, dragRuntime, focusedPaneIds, persistedLayouts, runtime } = renderIntegratedPointerRuntime(layout);
+      const sourceRect = dockLeafLayouts.find((leaf) => leaf.instanceId === "source:main")!.rect;
+      const pointer = overlayCellCenter(layout, "source:main", "target:main", operation.position);
+      const down = createPointerEvent("down", sourceRect.x + 2, sourceRect.y + NATIVE_APP_HEADER_HEIGHT + 1);
+
+      runtime.startNativeDockedDrag("source:main", sourceRect, down);
+      expect(dragRuntime.dragRef.current).toEqual(expect.objectContaining({
+        type: "pane-drag",
+        mode: "docked",
+      }));
+      expect(dragRuntime.dragRef.current?.startY).toBeCloseTo(sourceRect.y + 1);
+
+      const move = createPointerEvent("drag", pointer.x, pointer.shellY + NATIVE_APP_HEADER_HEIGHT);
+      runtime.handleNativeDrag(move);
+      const preview = dragRuntime.dockPreviewRef.current;
+      expect(preview).toMatchObject({
+        kind: "dock",
+        target: { kind: "leaf", targetId: "target:main", position: operation.position },
+      });
+      expect(move.defaultPrevented).toBe(true);
+      expect(move.propagationStopped).toBe(true);
+
+      const release = createPointerEvent("drag-end", pointer.x, pointer.shellY + NATIVE_APP_HEADER_HEIGHT);
+      runtime.handleNativeDrag(release);
+
+      expect(persistedLayouts).toHaveLength(1);
+      expect(persistedLayouts[0]).toEqual(preview!.layout);
+      expect(persistedLayouts[0]!.dockRoot).toMatchObject({
+        kind: "split",
+        axis: operation.axis,
+        first: { kind: "pane", instanceId: operation.order[0] },
+        second: { kind: "pane", instanceId: operation.order[1] },
+      });
+      expect(focusedPaneIds.at(-1)).toBe("source:main");
+      expect(dragRuntime.dragRef.current).toBeNull();
+      expect(release.defaultPrevented).toBe(true);
+      expect(release.propagationStopped).toBe(true);
+    });
+  }
+
+  test("center-drops a snapped floating pane onto a docked pane through native preview and release", () => {
+    const snappedRect = {
+      instanceId: "source:main",
+      x: 80,
+      y: 4,
+      width: 6,
+      height: 6,
+      zIndex: 75,
+      fixedGeometry: true,
+    };
+    const layout: LayoutConfig = {
+      dockRoot: { kind: "pane", instanceId: "target:main" },
+      instances: [
+        createPaneInstance("source", { instanceId: "source:main" }),
+        createPaneInstance("target", { instanceId: "target:main" }),
+      ],
+      floating: [snappedRect],
+      detached: [],
+    };
+    const { dragRuntime, persistedLayouts, runtime } = renderIntegratedPointerRuntime(layout);
+    const pointer = overlayCellCenter(layout, "source:main", "target:main", "center");
+    const down = createPointerEvent(
+      "down",
+      snappedRect.x + 1,
+      snappedRect.y + NATIVE_APP_HEADER_HEIGHT + 1,
+    );
+
+    runtime.startNativeFloatingDrag("source:main", snappedRect, down);
+    const move = createPointerEvent("drag", pointer.x, pointer.shellY + NATIVE_APP_HEADER_HEIGHT);
+    runtime.handleNativeDrag(move);
+
+    const preview = dragRuntime.dockPreviewRef.current;
+    expect(preview).toMatchObject({
+      kind: "dock",
+      target: { kind: "leaf", targetId: "target:main", position: "center" },
+      rect: NATIVE_BOUNDS,
+    });
+    expect(preview!.layout.floating).toEqual([
+      { ...snappedRect, instanceId: "target:main" },
+    ]);
+
+    const release = createPointerEvent("drag-end", pointer.x, pointer.shellY + NATIVE_APP_HEADER_HEIGHT);
+    runtime.handleNativeDrag(release);
+
+    expect(persistedLayouts).toHaveLength(1);
+    expect(persistedLayouts[0]).toEqual(preview!.layout);
+    expect(getDockLeafLayouts(persistedLayouts[0]!, NATIVE_BOUNDS, { precise: true })).toEqual([
+      { instanceId: "source:main", path: [], rect: NATIVE_BOUNDS },
+    ]);
+    const { instanceId: renderedInstanceId, ...renderedTarget } = constrainFloatingRectToBounds(
+      persistedLayouts[0]!.floating[0]!,
+      NATIVE_BOUNDS.width,
+      NATIVE_BOUNDS.height,
+    ) as typeof snappedRect;
+    expect(renderedInstanceId).toBe("target:main");
+    expect(renderedTarget).toEqual({
+      x: snappedRect.x,
+      y: snappedRect.y,
+      width: snappedRect.width,
+      height: snappedRect.height,
+      zIndex: snappedRect.zIndex,
+      fixedGeometry: true,
+    });
+    expect(dragRuntime.dragRef.current).toBeNull();
+  });
+});

--- a/src/components/layout/shell/native/pointer-runtime.ts
+++ b/src/components/layout/shell/native/pointer-runtime.ts
@@ -1,5 +1,10 @@
 import { useCallback, type Dispatch, type SetStateAction } from "react";
-import type { DockDividerLayout, FloatingRect, LayoutBounds } from "../../../../plugins/pane-manager";
+import type {
+  DockDividerLayout,
+  FloatingRect,
+  FloatingResizeCorner,
+  LayoutBounds,
+} from "../../../../plugins/pane-manager";
 import type { ActionMenuState } from "../action-menu-overlay";
 import type { ShellDragRuntimeState, ShellMouseEvent } from "../drag/runtime";
 import type { WindowEditState } from "../../window-edit/mode";
@@ -21,6 +26,7 @@ interface UseShellNativePointerRuntimeOptions {
   setHoveredMenuItemId: Dispatch<SetStateAction<string | null>>;
   setMenuState: Dispatch<SetStateAction<ActionMenuState | null>>;
   transientFocusActive: boolean;
+  togglePaneFloating: (paneId: string) => boolean;
   windowMode: WindowEditState | null;
 }
 
@@ -37,11 +43,13 @@ export function useShellNativePointerRuntime({
   setHoveredMenuItemId,
   setMenuState,
   transientFocusActive,
+  togglePaneFloating,
   windowMode,
 }: UseShellNativePointerRuntimeOptions) {
   const {
     dragRef,
     updateDividerPreview,
+    updateDockPreview,
     updateDragFloatingRect,
   } = dragRuntime;
 
@@ -76,17 +84,18 @@ export function useShellNativePointerRuntime({
 
     const pointer = getShellPointer(event);
     focusNativePane(paneId);
+    updateDockPreview(null);
     dragRef.current = {
       type: "pane-drag",
       paneId,
       mode: "floating",
       startX: pointer.x,
       startY: pointer.y,
-      origRect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+      origRect: { ...rect },
     };
-    updateDragFloatingRect({ paneId, rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height } });
+    updateDragFloatingRect({ paneId, rect: { ...rect } });
     event.preventDefault();
-  }, [dragRef, focusNativePane, getShellPointer, nativePaneChrome, transientFocusActive, updateDragFloatingRect, windowMode]);
+  }, [dragRef, focusNativePane, getShellPointer, nativePaneChrome, transientFocusActive, updateDockPreview, updateDragFloatingRect, windowMode]);
 
   const startNativeDockedDrag = useCallback((paneId: string, rect: LayoutBounds, event: ShellMouseEvent) => {
     if (!nativePaneChrome) return;
@@ -96,6 +105,7 @@ export function useShellNativePointerRuntime({
 
     const pointer = getShellPointer(event);
     focusNativePane(paneId);
+    updateDockPreview(null);
     dragRef.current = {
       type: "pane-drag",
       paneId,
@@ -105,9 +115,14 @@ export function useShellNativePointerRuntime({
       origRect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
     };
     event.preventDefault();
-  }, [dragRef, focusNativePane, getShellPointer, nativePaneChrome, transientFocusActive, windowMode]);
+  }, [dragRef, focusNativePane, getShellPointer, nativePaneChrome, transientFocusActive, updateDockPreview, windowMode]);
 
-  const startNativeFloatResize = useCallback((paneId: string, rect: FloatingRect, event: ShellMouseEvent) => {
+  const startNativeFloatResize = useCallback((
+    paneId: string,
+    rect: FloatingRect,
+    corner: FloatingResizeCorner,
+    event: ShellMouseEvent,
+  ) => {
     if (!nativePaneChrome) return;
     if (transientFocusActive) return;
 
@@ -120,11 +135,12 @@ export function useShellNativePointerRuntime({
     dragRef.current = {
       type: "float-resize",
       paneId,
+      corner,
       startX: pointer.x,
       startY: pointer.y,
-      origRect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+      origRect: { ...rect },
     };
-    updateDragFloatingRect({ paneId, rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height } });
+    updateDragFloatingRect({ paneId, rect: { ...rect } });
     event.stopPropagation();
     event.preventDefault();
   }, [dragRef, focusNativePane, getShellPointer, nativePaneChrome, selectWindowModePane, transientFocusActive, updateDragFloatingRect, windowMode]);
@@ -176,12 +192,20 @@ export function useShellNativePointerRuntime({
     handleFloatingClose(paneId);
   }, [handleFloatingClose, windowMode]);
 
+  const handlePaneFloatToggle = useCallback((paneId: string, event: ShellMouseEvent) => {
+    event.stopPropagation();
+    event.preventDefault();
+    if (windowMode || event.button === 2) return;
+    togglePaneFloating(paneId);
+  }, [togglePaneFloating, windowMode]);
+
   return {
     handleFloatingCloseMouseDown,
     handleNativeDrag: handleActiveDrag,
     handleNativePaneContextMenu,
     handleNativePaneMouseDown,
     handlePaneAction,
+    handlePaneFloatToggle,
     startNativeDividerDrag,
     startNativeDockedDrag,
     startNativeFloatingDrag,

--- a/src/components/layout/shell/native/surfaces.ts
+++ b/src/components/layout/shell/native/surfaces.ts
@@ -14,7 +14,7 @@ import {
   resolveNativeDockDividers,
   type DividerPreviewState,
 } from "./window-state";
-import type { WindowEditDockMovePreview } from "../../window-edit/mode";
+import type { WindowEditDockMovePreview } from "../../window-edit/presentation";
 
 interface ShellNativeSurfaceMenuState {
   paneId: string;

--- a/src/components/layout/shell/native/window-state.ts
+++ b/src/components/layout/shell/native/window-state.ts
@@ -3,7 +3,7 @@ import type { NativeOccluder, NativePaneLayer } from "../../../chart/native/surf
 import { DEFAULT_HEADER_HEIGHT } from "../chrome";
 import type { DragPreview, HoverOverlay } from "../drag";
 import { MENU_Z_INDEX } from "../menu";
-import type { WindowEditDockMovePreview } from "../../window-edit/mode";
+import type { WindowEditDockMovePreview } from "../../window-edit/presentation";
 
 export interface FloatingPreviewRect {
   paneId: string;
@@ -71,11 +71,13 @@ export function buildNativeTransientOccluders({
   }
 
   if (dockPreview) {
-    occluders.push({
-      id: `dock-preview:${dockPreview.kind}`,
-      rect: dockPreview.rect,
-      zIndex: 96,
-    });
+    for (const preview of dockPreview.rects) {
+      occluders.push({
+        id: `dock-preview:${dockPreview.kind}:${preview.instanceId}`,
+        rect: preview.rect,
+        zIndex: 96,
+      });
+    }
   }
 
   if (windowModeDockMovePreview) {

--- a/src/components/layout/shell/pane/actions.ts
+++ b/src/components/layout/shell/pane/actions.ts
@@ -1,8 +1,9 @@
 import { useCallback } from "react";
 import type { DesktopWindowBridge } from "../../../../types/desktop-window";
 import {
-  applyDrop,
-  floatPane,
+  dockFloatingPaneAtCurrentRect,
+  floatAtRect,
+  getDockLeafLayouts,
   gridlockAllPanes,
   isPaneInLayout,
   removeFloatingPanes,
@@ -106,17 +107,29 @@ export function useShellPaneActions({
     return true;
   }, [focusedPaneId, openPaneSettings, pluginRegistry]);
 
-  const toggleFocusedPaneFloating = useCallback(() => {
-    if (!focusedPaneId) return false;
-    const pane = paneMap.get(focusedPaneId);
+  const togglePaneFloating = useCallback((paneId: string) => {
+    const pane = paneMap.get(paneId);
     if (!pane) return false;
+    const bounds = { x: 0, y: 0, width, height: contentHeight };
+    const tiledRect = pane.floating
+      ? null
+      : getDockLeafLayouts(
+          visibleLayout,
+          bounds,
+          nativePaneChrome ? { precise: true } : { reserveDividerGutters: true },
+        ).find((leaf) => leaf.instanceId === pane.instance.instanceId)?.rect;
+    if (!pane.floating && !tiledRect) return false;
     const nextLayout = pane.floating
-      ? applyDrop(visibleLayout, pane.instance.instanceId, { kind: "frame", edge: "right" })
-      : floatPane(visibleLayout, pane.instance.instanceId, width, contentHeight, pane.def);
+      ? dockFloatingPaneAtCurrentRect(visibleLayout, pane.instance.instanceId, bounds)
+      : floatAtRect(visibleLayout, pane.instance.instanceId, tiledRect!);
     persistLayout(nextLayout);
     focusPane(pane.instance.instanceId);
     return true;
-  }, [contentHeight, focusPane, focusedPaneId, paneMap, persistLayout, visibleLayout, width]);
+  }, [contentHeight, focusPane, nativePaneChrome, paneMap, persistLayout, visibleLayout, width]);
+
+  const toggleFocusedPaneFloating = useCallback(() => (
+    focusedPaneId ? togglePaneFloating(focusedPaneId) : false
+  ), [focusedPaneId, togglePaneFloating]);
 
   const popOutFocusedPane = useCallback(() => {
     if (!focusedPaneId || desktopWindowBridge?.kind !== "main" || !desktopWindowBridge.popOutPane) return false;
@@ -147,5 +160,6 @@ export function useShellPaneActions({
     openPaneSettings,
     popOutFocusedPane,
     toggleFocusedPaneFloating,
+    togglePaneFloating,
   };
 }

--- a/src/components/layout/shell/pane/layers.tsx
+++ b/src/components/layout/shell/pane/layers.tsx
@@ -3,6 +3,7 @@ import type {
   DockDividerLayout,
   DockLeafLayout,
   FloatingRect,
+  FloatingResizeCorner,
   LayoutBounds,
   ResolvedPane,
 } from "../../../../plugins/pane-manager";
@@ -37,6 +38,7 @@ interface ShellPaneLayersProps {
   handleNativePaneContextMenu: (paneId: string, rect: LayoutBounds, event: any) => void;
   handleNativePaneMouseDown: (paneId: string, event: any) => void;
   handlePaneAction: (paneId: string, rect: LayoutBounds, event: any) => void;
+  handlePaneFloatToggle: (paneId: string, event: any) => void;
   hoveredPaneId: string | null;
   menuPaneId: string | null;
   nativeContextMenu?: boolean;
@@ -47,7 +49,7 @@ interface ShellPaneLayersProps {
   startNativeDividerDrag: (divider: DockDividerLayout, event: any) => void;
   startNativeDockedDrag: (paneId: string, rect: LayoutBounds, event: any) => void;
   startNativeFloatingDrag: (paneId: string, rect: FloatingRect, event: any) => void;
-  startNativeFloatResize: (paneId: string, rect: FloatingRect, event: any) => void;
+  startNativeFloatResize: (paneId: string, rect: FloatingRect, corner: FloatingResizeCorner, event: any) => void;
   transientFocusActive: boolean;
   transientFocusPaneId: string | null;
   visibleFloatingPanes: VisibleFloatingPane[];
@@ -70,6 +72,7 @@ export function ShellPaneLayers({
   handleNativePaneContextMenu,
   handleNativePaneMouseDown,
   handlePaneAction,
+  handlePaneFloatToggle,
   hoveredPaneId,
   menuPaneId,
   nativeContextMenu,
@@ -138,6 +141,7 @@ export function ShellPaneLayers({
                     onHeaderMouseDragEnd={nativePaneChrome && !transientFocusActive ? handleNativeDrag : undefined}
                     onHeaderContextMenu={nativePaneChrome && nativeContextMenu === true ? (event) => handleNativePaneContextMenu(leaf.instanceId, rect, event) : undefined}
                     onActionMouseDown={(event) => handlePaneAction(leaf.instanceId, rect, event)}
+                    onFloatToggleMouseDown={nativePaneChrome ? (event) => handlePaneFloatToggle(leaf.instanceId, event) : undefined}
                   >
                     <PaneContent
                       component={pane.def.component}
@@ -198,8 +202,11 @@ export function ShellPaneLayers({
                   onHeaderMouseDragEnd={nativePaneChrome ? handleNativeDrag : undefined}
                   onHeaderContextMenu={nativePaneChrome && nativeContextMenu === true ? (event) => handleNativePaneContextMenu(pane.instance.instanceId, preview, event) : undefined}
                   onActionMouseDown={(event) => handlePaneAction(pane.instance.instanceId, preview, event)}
+                  onFloatToggleMouseDown={nativePaneChrome ? (event) => handlePaneFloatToggle(pane.instance.instanceId, event) : undefined}
                   onCloseMouseDown={(event) => handleFloatingCloseMouseDown(pane.instance.instanceId, event)}
-                  onResizeMouseDown={nativePaneChrome ? (event) => startNativeFloatResize(pane.instance.instanceId, preview, event) : undefined}
+                  onResizeMouseDown={nativePaneChrome
+                    ? (corner, event) => startNativeFloatResize(pane.instance.instanceId, preview, corner, event)
+                    : undefined}
                   onResizeMouseDrag={nativePaneChrome ? handleNativeDrag : undefined}
                   onResizeMouseDragEnd={nativePaneChrome ? handleNativeDrag : undefined}
                 >

--- a/src/components/layout/shell/terminal-pointer-runtime.ts
+++ b/src/components/layout/shell/terminal-pointer-runtime.ts
@@ -3,6 +3,7 @@ import type {
   DockDividerLayout,
   DockLeafLayout,
   FloatingRect,
+  FloatingResizeCorner,
   LayoutBounds,
   ResolvedPane,
 } from "../../../plugins/pane-manager";
@@ -41,6 +42,7 @@ interface UseShellTerminalPointerRuntimeOptions {
   setHoveredMenuItemId: Dispatch<SetStateAction<string | null>>;
   setMenuState: Dispatch<SetStateAction<ActionMenuState | null>>;
   transientFocusActive: boolean;
+  togglePaneFloating: (paneId: string) => boolean;
   visibleFloatingPanes: VisibleFloatingPane[];
   width: number;
   windowMode: WindowEditState | null;
@@ -62,6 +64,27 @@ function sortedFloatingPanes(visibleFloatingPanes: VisibleFloatingPane[]): Visib
   return [...visibleFloatingPanes].sort((a, b) => (b.pane.floating?.zIndex ?? 50) - (a.pane.floating?.zIndex ?? 50));
 }
 
+function resolveTerminalResizeHandle(
+  relativeX: number,
+  relativeY: number,
+  rect: { width: number; height: number },
+): FloatingResizeCorner | null {
+  const nearLeft = relativeX <= 1;
+  const nearRight = relativeX >= rect.width - 2;
+  const nearTop = relativeY <= 0;
+  const nearBottom = relativeY >= rect.height - 1;
+
+  if (nearBottom && nearRight) return "bottom-right";
+  if (nearBottom && nearLeft) return "bottom-left";
+  if (nearTop && nearRight) return "top-right";
+  if (nearTop && nearLeft) return "top-left";
+  if (nearBottom) return "bottom";
+  if (nearLeft) return "left";
+  if (nearRight) return "right";
+  // The TUI header owns the interior top row for dragging and header actions.
+  return null;
+}
+
 export function useShellTerminalPointerRuntime({
   appHeaderHeight,
   closePaneMenu,
@@ -80,6 +103,7 @@ export function useShellTerminalPointerRuntime({
   setHoveredMenuItemId,
   setMenuState,
   transientFocusActive,
+  togglePaneFloating,
   visibleFloatingPanes,
   width,
   windowMode,
@@ -88,6 +112,7 @@ export function useShellTerminalPointerRuntime({
     dragFloatingRect,
     dragRef,
     updateDividerPreview,
+    updateDockPreview,
     updateDragFloatingRect,
   } = dragRuntime;
 
@@ -117,15 +142,17 @@ export function useShellTerminalPointerRuntime({
         const relativeY = shellY - rect.y;
         selectWindowModePane(paneId);
 
-        if (relativeX >= rect.width - 2 && relativeY >= rect.height - 1) {
+        const resizeHandle = resolveTerminalResizeHandle(relativeX, relativeY, rect);
+        if (resizeHandle) {
           dragRef.current = {
             type: "float-resize",
             paneId,
+            corner: resizeHandle,
             startX: preciseX,
             startY: preciseShellY,
-            origRect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+            origRect: { ...rect },
           };
-          updateDragFloatingRect({ paneId, rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height } });
+          updateDragFloatingRect({ paneId, rect: { ...rect } });
         }
 
         event.stopPropagation();
@@ -191,7 +218,11 @@ export function useShellTerminalPointerRuntime({
           openPaneMenu(paneId, rect, event);
           return;
         }
-        if (relativeY === 0 && headerAreas.closeStart != null && relativeX >= headerAreas.closeStart && relativeX < rect.width) {
+        if (relativeY === 0
+          && headerAreas.closeStart != null
+          && headerAreas.closeEnd != null
+          && relativeX >= headerAreas.closeStart
+          && relativeX < headerAreas.closeEnd) {
           handleFloatingClose(paneId);
           event.stopPropagation();
           event.preventDefault();
@@ -199,37 +230,48 @@ export function useShellTerminalPointerRuntime({
         }
         if (relativeY === 0
           && headerAreas.actionStart != null
-          && headerAreas.closeStart != null
+          && headerAreas.actionEnd != null
           && relativeX >= headerAreas.actionStart
-          && relativeX < headerAreas.closeStart) {
+          && relativeX < headerAreas.actionEnd) {
           openPaneMenu(paneId, rect, event);
           event.stopPropagation();
           event.preventDefault();
           return;
         }
-        if (relativeX >= rect.width - 2 && relativeY >= rect.height - 1) {
+        if (relativeY === 0
+          && relativeX >= headerAreas.toggleStart
+          && relativeX < headerAreas.toggleEnd) {
+          togglePaneFloating(paneId);
+          event.stopPropagation();
+          event.preventDefault();
+          return;
+        }
+        const resizeHandle = resolveTerminalResizeHandle(relativeX, relativeY, rect);
+        if (resizeHandle) {
           dragRef.current = {
             type: "float-resize",
             paneId,
+            corner: resizeHandle,
             startX: preciseX,
             startY: preciseShellY,
-            origRect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+            origRect: { ...rect },
           };
-          updateDragFloatingRect({ paneId, rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height } });
+          updateDragFloatingRect({ paneId, rect: { ...rect } });
           event.stopPropagation();
           event.preventDefault();
           return;
         }
         if (relativeY === 0) {
+          updateDockPreview(null);
           dragRef.current = {
             type: "pane-drag",
             paneId,
             mode: "floating",
             startX: preciseX,
             startY: preciseShellY,
-            origRect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+            origRect: { ...rect },
           };
-          updateDragFloatingRect({ paneId, rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height } });
+          updateDragFloatingRect({ paneId, rect: { ...rect } });
           event.stopPropagation();
           event.preventDefault();
           return;
@@ -276,8 +318,18 @@ export function useShellTerminalPointerRuntime({
         }
         if (relativeY === 0
           && headerAreas.actionStart != null
-          && relativeX >= headerAreas.actionStart) {
+          && headerAreas.actionEnd != null
+          && relativeX >= headerAreas.actionStart
+          && relativeX < headerAreas.actionEnd) {
           openPaneMenu(leaf.instanceId, leaf.rect, event);
+          event.stopPropagation();
+          event.preventDefault();
+          return;
+        }
+        if (relativeY === 0
+          && relativeX >= headerAreas.toggleStart
+          && relativeX < headerAreas.toggleEnd) {
+          togglePaneFloating(leaf.instanceId);
           event.stopPropagation();
           event.preventDefault();
           return;
@@ -288,6 +340,7 @@ export function useShellTerminalPointerRuntime({
           return;
         }
         if (relativeY === 0) {
+          updateDockPreview(null);
           dragRef.current = {
             type: "pane-drag",
             paneId: leaf.instanceId,
@@ -326,7 +379,9 @@ export function useShellTerminalPointerRuntime({
     setHoveredMenuItemId,
     setMenuState,
     transientFocusActive,
+    togglePaneFloating,
     updateDividerPreview,
+    updateDockPreview,
     updateDragFloatingRect,
     visibleFloatingPanes,
     windowMode,

--- a/src/components/layout/shell/window-mode/index.ts
+++ b/src/components/layout/shell/window-mode/index.ts
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { useShortcut } from "../../../../react/input";
 import {
-  dockPane,
-  floatPane,
+  dockFloatingPaneAtCurrentRect,
+  floatAtRect,
+  getDockLeafLayouts,
   isPaneInLayout,
   type DockGeometryOptions,
   type LayoutBounds,
@@ -37,6 +38,7 @@ interface UseShellWindowModeOptions {
   focusedPaneId: string | null;
   hasActiveDrag: () => boolean;
   nativePaneChrome: boolean;
+  overlayOpen: boolean;
   persistLayout: (nextLayout: LayoutConfig, options?: { pushHistory?: boolean }) => void;
   pluginRegistry: PluginRegistry;
   visibleLayout: LayoutConfig;
@@ -53,6 +55,7 @@ export function useShellWindowMode({
   focusedPaneId,
   hasActiveDrag,
   nativePaneChrome,
+  overlayOpen,
   persistLayout,
   pluginRegistry,
   visibleLayout,
@@ -128,6 +131,10 @@ export function useShellWindowMode({
     setWindowMode(null);
   }, []);
 
+  useLayoutEffect(() => {
+    if (overlayOpen && windowMode) cancelWindowMode();
+  }, [cancelWindowMode, overlayOpen, windowMode]);
+
   const commitWindowMode = useCallback(() => {
     if (!windowMode) return;
     const committedLayout = resolveWindowEditCommitLayout(windowMode, bounds, dockGeometryOptions);
@@ -200,9 +207,15 @@ export function useShellWindowMode({
           const paneDef = paneInstance ? pluginRegistry.panes.get(paneInstance.paneId) : undefined;
           if (!paneDef) return current;
           const isFloating = current.previewLayout.floating.some((entry) => entry.instanceId === current.paneId);
+          const tiledRect = isFloating
+            ? null
+            : getDockLeafLayouts(current.previewLayout, bounds, dockGeometryOptions)
+              .find((leaf) => leaf.instanceId === current.paneId)?.rect;
           const nextLayout = isFloating
-            ? dockPane(current.previewLayout, current.paneId)
-            : floatPane(current.previewLayout, current.paneId, width, contentHeight, paneDef);
+            ? dockFloatingPaneAtCurrentRect(current.previewLayout, current.paneId, bounds)
+            : tiledRect
+              ? floatAtRect(current.previewLayout, current.paneId, tiledRect)
+              : current.previewLayout;
           return {
             ...current,
             previewLayout: nextLayout,
@@ -252,7 +265,12 @@ export function useShellWindowMode({
       event.preventDefault();
       event.stopPropagation();
     }
-  }, { phase: "before", enabled: !!windowMode });
+  }, {
+    phase: "before",
+    enabled: !!windowMode,
+    allowEditable: true,
+    interceptNative: true,
+  });
 
   return {
     activeLayout,

--- a/src/components/layout/shell/window-mode/overlays.tsx
+++ b/src/components/layout/shell/window-mode/overlays.tsx
@@ -20,6 +20,7 @@ import {
   resolveNativeFloatingResizeCornerRect,
 } from "../../window-edit/status";
 import { MENU_Z_INDEX, truncateMenuText } from "../menu";
+import { ShellLayoutGridOverlay } from "../drag/overlays";
 
 interface ShellWindowModeOverlaysProps {
   bounds: LayoutBounds;
@@ -91,9 +92,19 @@ export function ShellWindowModeOverlays({
   const highlightedZIndex = highlightedFloatingPane
     ? (highlightedFloatingPane.pane.floating?.zIndex ?? 50) + 1
     : 3;
+  const gridExcludedRows = [
+    ...dockLeafLayouts.map((leaf) => leaf.rect.y),
+    ...visibleFloatingPanes.map(({ pane, rect }) => (
+      dragFloatingRect?.paneId === pane.instance.instanceId ? dragFloatingRect.rect.y : rect.y
+    )),
+  ];
 
   return (
     <>
+      {windowMode && (
+        <ShellLayoutGridOverlay width={width} height={contentHeight} excludedRows={gridExcludedRows} />
+      )}
+
       {windowModeDockMovePreview && (
         <Box
           position="absolute"

--- a/src/components/layout/status-bar.test.tsx
+++ b/src/components/layout/status-bar.test.tsx
@@ -78,6 +78,29 @@ describe("StatusBar", () => {
     expect(actions).toContainEqual({ type: "SET_COMMAND_BAR", open: true, query: "" });
   });
 
+  test("opens the discoverable layout preset menu", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-layout-menu-test");
+    config.layouts = [{ name: "Home", layout: cloneLayout(config.layout) }];
+    const state = { ...createInitialState(config), statusBarVisible: true };
+    const actions: Array<{ type: string; open?: boolean; query?: string }> = [];
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: (action) => actions.push(action as { type: string; open?: boolean; query?: string }) }}>
+        <StatusBar />
+      </AppContext>,
+      { width: 120, height: 1 },
+    );
+    await testSetup.renderOnce();
+
+    const frame = testSetup.captureCharFrame();
+    const layoutsX = frame.split("\n")[0]?.indexOf("Layouts") ?? -1;
+    expect(layoutsX).toBeGreaterThanOrEqual(0);
+    await testSetup.mockMouse.click(layoutsX + 1, 0);
+    await testSetup.renderOnce();
+
+    expect(actions).toContainEqual({ type: "SET_COMMAND_BAR", open: true, query: "LAY " });
+  });
+
   test("shows a transient focus layout tab without replacing saved layouts", async () => {
     const config = createDefaultConfig("/tmp/gloomberb-transient-layout-test");
     config.layouts = [

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -41,6 +41,7 @@ type StatusBarViewProps = {
   layoutTabItems: LayoutTabItem[];
   layoutTabsWidth: number;
   openCommandBar: (event?: StatusBarEvent) => void;
+  openLayouts: (event?: StatusBarEvent) => void;
   openLayoutContextMenu: (index: number, event: any) => void | Promise<unknown>;
   setHoveredControl: SetHoveredControl;
   showGridlockTip: boolean;
@@ -135,6 +136,12 @@ export function StatusBar() {
     event?.preventDefault?.();
     event?.stopPropagation?.();
     dispatch({ type: "SET_COMMAND_BAR", open: true, query: "" });
+  };
+
+  const openLayouts = (event?: StatusBarEvent) => {
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
+    dispatch({ type: "SET_COMMAND_BAR", open: true, query: "LAY " });
   };
 
   const layoutContextMenuItems = useCallback((index: number): ContextMenuItem[] => {
@@ -236,6 +243,7 @@ export function StatusBar() {
     layoutTabItems,
     layoutTabsWidth,
     openCommandBar,
+    openLayouts,
     openLayoutContextMenu,
     setHoveredControl,
     showGridlockTip,
@@ -250,9 +258,19 @@ export function StatusBar() {
 
 function NativeStatusBar({
   activeLayoutIdx,
+  activeLayoutValue,
+  dismissGridlockTip,
+  handleGridlockTip,
+  handleLayoutSelect,
+  hasMultipleLayouts,
+  hoveredControl,
+  layoutTabItems,
+  layoutTabsWidth,
+  openCommandBar,
+  openLayouts,
   openLayoutContextMenu,
+  setHoveredControl,
   showGridlockTip,
-  ...props
 }: StatusBarViewProps) {
   return (
     <Box
@@ -270,18 +288,46 @@ function NativeStatusBar({
         paddingInline: 8,
       }}
     >
-      <StatusBarLayoutControl activeLayoutIdx={activeLayoutIdx} nativePaneChrome {...props} />
-      {showGridlockTip && <NativeGridlockTip {...props} />}
-      <StatusBarWidgets {...props} />
+      <StatusBarLayoutControl
+        activeLayoutValue={activeLayoutValue}
+        handleLayoutSelect={handleLayoutSelect}
+        hasMultipleLayouts={hasMultipleLayouts}
+        hoveredControl={hoveredControl}
+        layoutTabItems={layoutTabItems}
+        layoutTabsWidth={layoutTabsWidth}
+        nativePaneChrome
+        openCommandBar={openCommandBar}
+        openLayouts={openLayouts}
+        setHoveredControl={setHoveredControl}
+      />
+      {showGridlockTip && (
+        <NativeGridlockTip
+          dismissGridlockTip={dismissGridlockTip}
+          handleGridlockTip={handleGridlockTip}
+          hoveredControl={hoveredControl}
+          setHoveredControl={setHoveredControl}
+        />
+      )}
+      <StatusBarWidgets />
     </Box>
   );
 }
 
 function TerminalStatusBar({
   activeLayoutIdx,
+  activeLayoutValue,
+  dismissGridlockTip,
+  handleGridlockTip,
+  handleLayoutSelect,
+  hasMultipleLayouts,
+  hoveredControl,
+  layoutTabItems,
+  layoutTabsWidth,
+  openCommandBar,
+  openLayouts,
   openLayoutContextMenu,
+  setHoveredControl,
   showGridlockTip,
-  ...props
 }: StatusBarViewProps) {
   return (
     <Box
@@ -294,9 +340,27 @@ function TerminalStatusBar({
         void openLayoutContextMenu(activeLayoutIdx, event);
       }}
     >
-      <StatusBarLayoutControl activeLayoutIdx={activeLayoutIdx} nativePaneChrome={false} {...props} />
-      {showGridlockTip && <TerminalGridlockTip {...props} />}
-      <StatusBarWidgets {...props} />
+      <StatusBarLayoutControl
+        activeLayoutValue={activeLayoutValue}
+        handleLayoutSelect={handleLayoutSelect}
+        hasMultipleLayouts={hasMultipleLayouts}
+        hoveredControl={hoveredControl}
+        layoutTabItems={layoutTabItems}
+        layoutTabsWidth={layoutTabsWidth}
+        nativePaneChrome={false}
+        openCommandBar={openCommandBar}
+        openLayouts={openLayouts}
+        setHoveredControl={setHoveredControl}
+      />
+      {showGridlockTip && (
+        <TerminalGridlockTip
+          dismissGridlockTip={dismissGridlockTip}
+          handleGridlockTip={handleGridlockTip}
+          hoveredControl={hoveredControl}
+          setHoveredControl={setHoveredControl}
+        />
+      )}
+      <StatusBarWidgets />
     </Box>
   );
 }
@@ -310,6 +374,7 @@ function StatusBarLayoutControl({
   layoutTabsWidth,
   nativePaneChrome,
   openCommandBar,
+  openLayouts,
   setHoveredControl,
 }: Pick<
   StatusBarViewProps,
@@ -320,6 +385,7 @@ function StatusBarLayoutControl({
   | "layoutTabItems"
   | "layoutTabsWidth"
   | "openCommandBar"
+  | "openLayouts"
   | "setHoveredControl"
 > & { nativePaneChrome: boolean }) {
   return (
@@ -347,6 +413,50 @@ function StatusBarLayoutControl({
           setHoveredControl={setHoveredControl}
         />
       )}
+      <LayoutsButton
+        hoveredControl={hoveredControl}
+        nativePaneChrome={nativePaneChrome}
+        openLayouts={openLayouts}
+        setHoveredControl={setHoveredControl}
+      />
+    </Box>
+  );
+}
+
+function LayoutsButton({
+  hoveredControl,
+  nativePaneChrome,
+  openLayouts,
+  setHoveredControl,
+}: Pick<StatusBarViewProps, "hoveredControl" | "openLayouts" | "setHoveredControl"> & {
+  nativePaneChrome: boolean;
+}) {
+  const hovered = hoveredControl === "layouts";
+  return (
+    <Box
+      marginLeft={1}
+      height={1}
+      alignItems="center"
+      onMouseOver={() => setHoveredControl((current) => (current === "layouts" ? current : "layouts"))}
+      onMouseDown={openLayouts}
+      data-gloom-role="layout-presets-button"
+      data-gloom-interactive="true"
+      aria-label="Open layout presets"
+      title="Layouts and presets"
+      {...(nativePaneChrome ? {
+        style: {
+          cursor: "pointer",
+          borderRadius: 4,
+          paddingInline: 6,
+          backgroundColor: hovered ? hoverBg() : blendHex(colors.panel, colors.header, 0.18),
+        },
+      } : {
+        backgroundColor: hovered ? hoverBg() : colors.header,
+      })}
+    >
+      <Text fg={nativePaneChrome ? (hovered ? colors.textBright : colors.text) : colors.headerText}>
+        {nativePaneChrome ? "Layouts" : " Layouts "}
+      </Text>
     </Box>
   );
 }

--- a/src/components/layout/window-edit/mode.test.ts
+++ b/src/components/layout/window-edit/mode.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { LayoutConfig } from "../../../types/config";
 import {
+  applyWindowEditDirection,
+  cycleWindowEditFocus,
   cycleWindowEditPane,
   cycleWindowEditTarget,
   getWindowEditPaneIds,
@@ -122,5 +124,111 @@ describe("window edit mode", () => {
 
     expect(resolveWindowEditDockMovePreview(state, bounds, { reserveDividerGutters: true })?.rect)
       .toEqual({ x: 61, y: 0, width: 59, height: 40 });
+  });
+
+  test("resizes floating panes from an edge and a corner", () => {
+    const layout: LayoutConfig = {
+      dockRoot: null,
+      instances: [pane("float-a")],
+      floating: [{ instanceId: "float-a", x: 20, y: 8, width: 40, height: 14, zIndex: 50 }],
+      detached: [],
+    };
+    const edgeState: WindowEditState = {
+      paneId: "float-a",
+      previewLayout: layout,
+      mode: "resize",
+      focus: { kind: "floating-resize", corner: "right" },
+      dirty: false,
+    };
+
+    const edgeNext = applyWindowEditDirection(edgeState, "right", false, bounds, {});
+    expect(edgeNext.previewLayout.floating[0]).toEqual(expect.objectContaining({
+      x: 20,
+      y: 8,
+      width: 42,
+      height: 14,
+    }));
+    expect(edgeNext.dirty).toBe(true);
+
+    let cornerNext = applyWindowEditDirection({
+      ...edgeState,
+      focus: { kind: "floating-resize", corner: "bottom-left" },
+    }, "left", false, bounds, {});
+    cornerNext = applyWindowEditDirection(cornerNext, "down", false, bounds, {});
+    expect(cornerNext.previewLayout.floating[0]).toEqual(expect.objectContaining({
+      x: 18,
+      y: 8,
+      width: 42,
+      height: 15,
+    }));
+    expect(cornerNext.dirty).toBe(true);
+  });
+
+  test("resizes a small snapped pane without applying ordinary float minimums", () => {
+    const layout: LayoutConfig = {
+      dockRoot: null,
+      instances: [pane("float-a")],
+      floating: [{
+        instanceId: "float-a",
+        x: 20,
+        y: 8,
+        width: 6,
+        height: 3,
+        zIndex: 50,
+        fixedGeometry: true,
+      }],
+      detached: [],
+    };
+    const state: WindowEditState = {
+      paneId: "float-a",
+      previewLayout: layout,
+      mode: "resize",
+      focus: { kind: "floating-resize", corner: "bottom-right" },
+      dirty: false,
+    };
+
+    const next = applyWindowEditDirection(state, "right", false, bounds, {});
+
+    expect(next.previewLayout.floating[0]).toEqual({
+      instanceId: "float-a",
+      x: 20,
+      y: 8,
+      width: 8,
+      height: 3,
+      zIndex: 50,
+      fixedGeometry: true,
+    });
+    expect(next.dirty).toBe(true);
+  });
+
+  test("cycles through all eight floating resize handles", () => {
+    const layout: LayoutConfig = {
+      dockRoot: null,
+      instances: [pane("float-a")],
+      floating: [{ instanceId: "float-a", x: 20, y: 8, width: 40, height: 14, zIndex: 50 }],
+      detached: [],
+    };
+    const expectedCorners = [
+      "top-left",
+      "top",
+      "top-right",
+      "right",
+      "bottom-right",
+      "bottom",
+      "bottom-left",
+      "left",
+    ] as const;
+    let focus: WindowEditState["focus"] = { kind: "floating-resize", corner: "top-left" };
+    const visited = [focus.corner];
+
+    for (let index = 1; index < expectedCorners.length; index += 1) {
+      focus = cycleWindowEditFocus(focus, layout, "float-a", "resize", bounds, {}, 1);
+      expect(focus.kind).toBe("floating-resize");
+      if (focus.kind === "floating-resize") visited.push(focus.corner);
+    }
+
+    expect(visited).toEqual([...expectedCorners]);
+    expect(cycleWindowEditFocus(focus, layout, "float-a", "resize", bounds, {}, 1))
+      .toEqual({ kind: "floating-resize", corner: "top-left" });
   });
 });

--- a/src/components/layout/window-edit/mode.ts
+++ b/src/components/layout/window-edit/mode.ts
@@ -35,7 +35,16 @@ export interface WindowEditState {
 
 export type WindowEditDirection = "left" | "right" | "up" | "down";
 
-const FLOATING_RESIZE_CORNERS: FloatingResizeCorner[] = ["top-left", "bottom-right"];
+const FLOATING_RESIZE_CORNERS: FloatingResizeCorner[] = [
+  "top-left",
+  "top",
+  "top-right",
+  "right",
+  "bottom-right",
+  "bottom",
+  "bottom-left",
+  "left",
+];
 const WINDOW_EDIT_MOVE_STEP = { x: 2, y: 1 };
 const WINDOW_EDIT_FAST_STEP = { x: 10, y: 5 };
 

--- a/src/components/layout/window-edit/presentation.ts
+++ b/src/components/layout/window-edit/presentation.ts
@@ -114,11 +114,19 @@ export function getFloatingResizeCornerPosition(rect: FloatingRect, corner: Floa
   switch (corner) {
     case "top-left":
       return { x: rect.x, y: rect.y, marker: "◤" };
+    case "top":
+      return { x: rect.x + Math.floor(rect.width / 2), y: rect.y, marker: "┬" };
     case "top-right":
       return { x: rect.x + rect.width - 1, y: rect.y, marker: "◥" };
+    case "right":
+      return { x: rect.x + rect.width - 1, y: rect.y + Math.floor(rect.height / 2), marker: "┤" };
+    case "bottom":
+      return { x: rect.x + Math.floor(rect.width / 2), y: rect.y + rect.height - 1, marker: "┴" };
     case "bottom-left":
       return { x: rect.x, y: rect.y + rect.height - 1, marker: "◣" };
     case "bottom-right":
       return { x: rect.x + rect.width - 1, y: rect.y + rect.height - 1, marker: "◢" };
+    case "left":
+      return { x: rect.x, y: rect.y + Math.floor(rect.height / 2), marker: "├" };
   }
 }

--- a/src/components/layout/window-edit/status.tsx
+++ b/src/components/layout/window-edit/status.tsx
@@ -32,12 +32,24 @@ export function resolveNativeWindowEditPanelRect(width: number, contentHeight: n
 
 export function resolveNativeFloatingResizeCornerRect(rect: FloatingRect, corner: FloatingResizeCorner): LayoutBounds {
   const size = Math.max(1, Math.min(NATIVE_WINDOW_EDIT_CORNER_SIZE, rect.width, rect.height));
-  const x = corner === "top-left" || corner === "bottom-left"
+  const x = corner === "left"
     ? rect.x
-    : Math.max(rect.x, rect.x + rect.width - size);
-  const y = corner === "top-left" || corner === "top-right"
+    : corner === "right"
+      ? Math.max(rect.x, rect.x + rect.width - size)
+      : corner === "top" || corner === "bottom"
+        ? rect.x + Math.floor((rect.width - size) / 2)
+        : corner === "top-left" || corner === "bottom-left"
+          ? rect.x
+          : Math.max(rect.x, rect.x + rect.width - size);
+  const y = corner === "top"
     ? rect.y
-    : Math.max(rect.y, rect.y + rect.height - size);
+    : corner === "bottom"
+      ? Math.max(rect.y, rect.y + rect.height - size)
+      : corner === "left" || corner === "right"
+        ? rect.y + Math.floor((rect.height - size) / 2)
+        : corner === "top-left" || corner === "top-right"
+          ? rect.y
+          : Math.max(rect.y, rect.y + rect.height - size);
   return { x, y, width: size, height: size };
 }
 

--- a/src/data/config/layout.ts
+++ b/src/data/config/layout.ts
@@ -41,7 +41,13 @@ function sanitizeFloatingPlacementMemory(value: unknown): FloatingPlacementMemor
   const width = typeof (value as FloatingPlacementMemory).width === "number" ? Math.max(1, Math.round((value as FloatingPlacementMemory).width)) : null;
   const height = typeof (value as FloatingPlacementMemory).height === "number" ? Math.max(1, Math.round((value as FloatingPlacementMemory).height)) : null;
   if (x === null || y === null || width === null || height === null) return undefined;
-  return { x, y, width, height };
+  return {
+    x,
+    y,
+    width,
+    height,
+    fixedGeometry: (value as FloatingPlacementMemory).fixedGeometry === true ? true : undefined,
+  };
 }
 
 function sanitizeDetachedPlacementMemory(value: unknown): DetachedPlacementMemory | undefined {
@@ -171,6 +177,7 @@ function sanitizeFloatingEntries(value: unknown, validInstanceIds: Set<string>):
       width: Math.max(1, Math.round(entry.width)),
       height: Math.max(1, Math.round(entry.height)),
       zIndex: typeof entry.zIndex === "number" ? Math.round(entry.zIndex) : entry.zIndex,
+      fixedGeometry: entry.fixedGeometry === true ? true : undefined,
     }));
 }
 

--- a/src/data/config/store/index.test.ts
+++ b/src/data/config/store/index.test.ts
@@ -138,6 +138,7 @@ describe("sanitizeLayout", () => {
               y: 4,
               width: 0,
               height: 7,
+              fixedGeometry: true,
             },
           },
         },
@@ -155,8 +156,39 @@ describe("sanitizeLayout", () => {
         y: 4,
         width: 1,
         height: 7,
+        fixedGeometry: true,
       },
     });
+  });
+
+  test("preserves explicit fixed floating geometry through layout sanitization", () => {
+    const layout = sanitizeLayout({
+      dockRoot: null,
+      instances: [{
+        instanceId: "portfolio-list:main",
+        paneId: "portfolio-list",
+        binding: { kind: "none" },
+      }],
+      floating: [{
+        instanceId: "portfolio-list:main",
+        x: 50,
+        y: 30,
+        width: 10,
+        height: 3,
+        fixedGeometry: true,
+      }],
+      detached: [],
+    }, DEFAULT_LAYOUT);
+
+    expect(layout.floating).toEqual([{
+      instanceId: "portfolio-list:main",
+      x: 50,
+      y: 30,
+      width: 10,
+      height: 3,
+      fixedGeometry: true,
+      zIndex: undefined,
+    }]);
   });
 
   test("falls back to the default layout when given an obsolete column layout", () => {

--- a/src/plugins/builtin/layout-manager/index.tsx
+++ b/src/plugins/builtin/layout-manager/index.tsx
@@ -3,9 +3,10 @@ import type { AppNotificationRequest, GloomPlugin, GloomPluginContext } from "..
 import type { AppAction } from "../../../state/app/context";
 import { notifyGridlockComplete } from "../../gridlock-notification";
 import {
-  dockPane,
-  floatPane,
+  dockFloatingPaneAtCurrentRect,
+  floatAtRect,
   getDockedPaneIds,
+  getLeafRect,
   gridlockAllPanes,
   isPaneInLayout,
   isPaneDocked,
@@ -66,8 +67,13 @@ export const layoutManagerPlugin: GloomPlugin = {
           return;
         }
 
-        const def = ctx.getPaneDef(focusedPane.paneId);
-        const nextLayout = floatPane(layout, focusedPane.instanceId, termWidth, termHeight, def);
+        const rect = getLeafRect(
+          layout,
+          focusedPane.instanceId,
+          { x: 0, y: 0, width: termWidth, height: termHeight },
+        );
+        if (!rect) return;
+        const nextLayout = floatAtRect(layout, focusedPane.instanceId, rect);
         persistLayout(ctx, nextLayout);
         dispatchRef?.({ type: "FOCUS_PANE", paneId: focusedPane.instanceId });
       },
@@ -82,14 +88,18 @@ export const layoutManagerPlugin: GloomPlugin = {
       execute: async () => {
         if (!getStateRef) return;
 
-        const { layout, focusedPaneId } = getStateRef();
+        const { layout, termWidth, termHeight, focusedPaneId } = getStateRef();
         const focusedPane = getFocusedPane(layout, focusedPaneId);
         if (!focusedPane || !layout.floating.some((entry) => entry.instanceId === focusedPane.instanceId)) {
           notify("Focus a floating pane to dock it", { type: "info" });
           return;
         }
 
-        const nextLayout = dockPane(layout, focusedPane.instanceId);
+        const nextLayout = dockFloatingPaneAtCurrentRect(
+          layout,
+          focusedPane.instanceId,
+          { x: 0, y: 0, width: termWidth, height: termHeight },
+        );
         persistLayout(ctx, nextLayout);
         dispatchRef?.({ type: "FOCUS_PANE", paneId: focusedPane.instanceId });
       },

--- a/src/plugins/pane-manager.test.ts
+++ b/src/plugins/pane-manager.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { cloneLayout, createDefaultConfig, createPaneInstance, type LayoutConfig } from "../types/config";
 import {
   addPaneFloating,
+  applyLayoutPreset,
   applyDrop,
+  compactDockedPaneAtRect,
+  dockFloatingPaneAtCurrentRect,
   floatAtRect,
   getDockResizeTargets,
   gridlockAllPanes,
@@ -13,9 +16,20 @@ import {
   moveFloatingPane,
   resizeFloatingPaneFromCorner,
   simulateDrop,
+  snapPaneToGridRect,
 } from "./pane-manager";
 
 const BOUNDS = { x: 0, y: 0, width: 120, height: 40 };
+
+function rectsOverlap(
+  first: { x: number; y: number; width: number; height: number },
+  second: { x: number; y: number; width: number; height: number },
+): boolean {
+  return first.x < second.x + second.width
+    && first.x + first.width > second.x
+    && first.y < second.y + second.height
+    && first.y + first.height > second.y;
+}
 
 describe("pane-manager split-tree drops", () => {
   test("docks the first floating pane into an empty dock root", () => {
@@ -170,6 +184,155 @@ describe("pane-manager split-tree drops", () => {
     expect(getLeafRect(next, bottomRightPane.instanceId, BOUNDS)).toEqual({ x: 60, y: 20, width: 60, height: 20 });
   });
 
+  test("builds grid and left-main presets from every visible pane without changing the schema", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-preset-test");
+    let layout = cloneLayout(config.layout);
+    layout = addPaneFloating(layout, createPaneInstance("chat"), 120, 40);
+    const visibleIds = new Set([
+      ...getDockedPaneIds(layout),
+      ...layout.floating.map((entry) => entry.instanceId),
+    ]);
+
+    for (const preset of ["single", "2x2", "3x3", "left-main"] as const) {
+      const next = applyLayoutPreset(layout, preset, BOUNDS);
+      expect(new Set(getDockedPaneIds(next))).toEqual(visibleIds);
+      expect(next.floating).toEqual([]);
+      expect(next.instances).toHaveLength(layout.instances.length);
+      expect(next.detached).toEqual(layout.detached);
+    }
+
+    const leftMain = applyLayoutPreset(layout, "left-main", BOUNDS);
+    const leaves = getDockLeafLayouts(leftMain, BOUNDS, { precise: true });
+    const main = leaves.find((leaf) => leaf.instanceId === getDockedPaneIds(layout)[0]);
+    const stack = leaves.filter((leaf) => leaf.instanceId !== main?.instanceId);
+    expect(main?.rect).toEqual({ x: 0, y: 0, width: 60, height: 40 });
+    expect(stack.every((leaf) => leaf.rect.x === 60 && leaf.rect.width === 60)).toBe(true);
+  });
+
+  test("keeps a snapped grid cell as exact committed floating geometry", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-cell-snap-test");
+    const floatingPane = createPaneInstance("chat", { instanceId: "chat:floating" });
+    const layout = addPaneFloating(cloneLayout(config.layout), floatingPane, 120, 40);
+
+    const next = snapPaneToGridRect(
+      layout,
+      floatingPane.instanceId,
+      { x: 80, y: 0, width: 20, height: 10 },
+      BOUNDS,
+    );
+
+    expect(getDockedPaneIds(next)).not.toContain(floatingPane.instanceId);
+    expect(next.floating.find((entry) => entry.instanceId === floatingPane.instanceId)).toEqual(expect.objectContaining({
+      x: 80,
+      y: 0,
+      width: 20,
+      height: 10,
+      fixedGeometry: true,
+    }));
+  });
+
+  test("keeps snapped cell geometry when center-swapping with a docked pane", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-cell-swap-test");
+    const floatingPane = createPaneInstance("chat", { instanceId: "chat:floating" });
+    const dockedPaneId = "ticker-detail:main";
+    const snapped = snapPaneToGridRect(
+      addPaneFloating(cloneLayout(config.layout), floatingPane, 120, 40),
+      floatingPane.instanceId,
+      { x: 80, y: 4, width: 6, height: 6 },
+      BOUNDS,
+    );
+    const snappedEntry = snapped.floating.find((entry) => entry.instanceId === floatingPane.instanceId)!;
+
+    const swapped = applyDrop(snapped, floatingPane.instanceId, {
+      kind: "leaf",
+      targetId: dockedPaneId,
+      position: "center",
+    });
+    const replacement = swapped.floating.find((entry) => entry.instanceId === dockedPaneId);
+
+    expect(replacement).toEqual({ ...snappedEntry, instanceId: dockedPaneId });
+    expect(replacement).toEqual(expect.objectContaining({
+      x: 80,
+      y: 4,
+      width: 6,
+      height: 6,
+      fixedGeometry: true,
+    }));
+    expect(getDockedPaneIds(swapped)).toContain(floatingPane.instanceId);
+    expect(getDockedPaneIds(swapped)).not.toContain(dockedPaneId);
+
+    const clamped = moveFloatingPane(swapped, dockedPaneId, 0, 0, BOUNDS);
+    expect(clamped.floating.find((entry) => entry.instanceId === dockedPaneId)).toEqual(replacement);
+  });
+
+  test("rejects an overlapping auto-compact candidate without rebuilding the dock tree", () => {
+    const layout: LayoutConfig = {
+      dockRoot: {
+        kind: "split",
+        axis: "horizontal",
+        ratio: 0.5,
+        first: { kind: "pane", instanceId: "left:main" },
+        second: {
+          kind: "split",
+          axis: "vertical",
+          ratio: 0.5,
+          first: { kind: "pane", instanceId: "top-right:main" },
+          second: { kind: "pane", instanceId: "bottom-right:main" },
+        },
+      },
+      instances: [
+        createPaneInstance("left", { instanceId: "left:main" }),
+        createPaneInstance("top-right", { instanceId: "top-right:main" }),
+        createPaneInstance("bottom-right", { instanceId: "bottom-right:main" }),
+        createPaneInstance("floating", { instanceId: "floating:main" }),
+        createPaneInstance("detached", { instanceId: "detached:main" }),
+      ],
+      floating: [{ instanceId: "floating:main", x: 45, y: 10, width: 30, height: 12, zIndex: 77 }],
+      detached: [{ instanceId: "detached:main", x: 10, y: 10, width: 50, height: 20 }],
+    };
+    const next = compactDockedPaneAtRect(
+      layout,
+      "left:main",
+      { x: 60, y: 20, width: 60, height: 20 },
+      BOUNDS,
+    );
+    expect(next).toBe(layout);
+    expect(next.dockRoot).toEqual(layout.dockRoot);
+    expect(getDockLeafLayouts(next, BOUNDS)).toEqual(getDockLeafLayouts(layout, BOUNDS));
+  });
+
+  test("restores a floated tile to its target-relative dock placement", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    const unrelated = createPaneInstance("chat");
+    let layout = addPaneFloating(cloneLayout(config.layout), unrelated, 120, 40);
+    layout = floatAtRect(layout, unrelated.instanceId, { x: 5, y: 5, width: 25, height: 10, zIndex: 80 });
+    const paneId = "ticker-detail:main";
+    const tiledRect = getLeafRect(layout, paneId, BOUNDS)!;
+
+    const floated = floatAtRect(layout, paneId, tiledRect);
+
+    expect(getDockedPaneIds(floated)).not.toContain(paneId);
+    expect(floated.floating.find((entry) => entry.instanceId === paneId)).toEqual(expect.objectContaining(tiledRect));
+    expect(floated.floating.find((entry) => entry.instanceId === unrelated.instanceId)).toEqual(
+      layout.floating.find((entry) => entry.instanceId === unrelated.instanceId),
+    );
+
+    const docked = dockFloatingPaneAtCurrentRect(floated, paneId, BOUNDS);
+    const leaves = getDockLeafLayouts(docked, BOUNDS);
+
+    expect(getDockedPaneIds(docked)).toContain(paneId);
+    expect(getDockedPaneIds(docked)).toEqual(getDockedPaneIds(layout));
+    expect(docked.floating.some((entry) => entry.instanceId === paneId)).toBe(false);
+    expect(docked.floating.find((entry) => entry.instanceId === unrelated.instanceId)).toEqual(
+      layout.floating.find((entry) => entry.instanceId === unrelated.instanceId),
+    );
+    for (let firstIndex = 0; firstIndex < leaves.length; firstIndex += 1) {
+      for (let secondIndex = firstIndex + 1; secondIndex < leaves.length; secondIndex += 1) {
+        expect(rectsOverlap(leaves[firstIndex]!.rect, leaves[secondIndex]!.rect)).toBe(false);
+      }
+    }
+  });
+
   test("moves floating panes repeatedly within the terminal bounds", () => {
     const config = createDefaultConfig("/tmp/gloomberb-test");
     const pane = createPaneInstance("chat");
@@ -208,6 +371,26 @@ describe("pane-manager split-tree drops", () => {
       width: 105,
       height: 34,
     }));
+  });
+
+  test("resizes floating panes from each edge without changing the orthogonal axis", () => {
+    const cases = [
+      { corner: "right", deltaX: 10, deltaY: 99, expected: { x: 20, y: 8, width: 50, height: 14 } },
+      { corner: "left", deltaX: -5, deltaY: 99, expected: { x: 15, y: 8, width: 45, height: 14 } },
+      { corner: "bottom", deltaX: 99, deltaY: 6, expected: { x: 20, y: 8, width: 40, height: 20 } },
+      { corner: "top", deltaX: 99, deltaY: -3, expected: { x: 20, y: 5, width: 40, height: 17 } },
+    ] as const;
+
+    for (const { corner, deltaX, deltaY, expected } of cases) {
+      const config = createDefaultConfig("/tmp/gloomberb-test");
+      const pane = createPaneInstance("chat");
+      let layout = addPaneFloating(cloneLayout(config.layout), pane, 120, 40);
+      layout = floatAtRect(layout, pane.instanceId, { x: 20, y: 8, width: 40, height: 14 });
+
+      layout = resizeFloatingPaneFromCorner(layout, pane.instanceId, corner, deltaX, deltaY, BOUNDS);
+
+      expect(layout.floating.find((entry) => entry.instanceId === pane.instanceId)).toEqual(expect.objectContaining(expected));
+    }
   });
 
   test("finds dock resize targets from the focused pane ancestors", () => {

--- a/src/plugins/pane-manager.ts
+++ b/src/plugins/pane-manager.ts
@@ -32,6 +32,7 @@ export {
   addPaneFloating,
   bringToFront,
   detachPaneToFrame,
+  dockFloatingPaneAtCurrentRect,
   floatAtRect,
   floatPane,
   getRememberedFloatingRect,
@@ -55,7 +56,15 @@ export {
   removeUnavailablePaneTypes,
   type PaneTypeAvailability,
 } from "./pane-manager/layout-state";
-export { gridlockAllPanes } from "./pane-manager/gridlock";
+export {
+  applyLayoutPreset,
+  compactDockedPaneAtRect,
+  gridlockAllPanes,
+  LAYOUT_PRESET_IDS,
+  snapPaneToGridRect,
+  type LayoutPresetId,
+} from "./pane-manager/gridlock";
+export { inferCompactedDockTree } from "./pane-manager/gridlock-inference";
 export type {
   DropTarget,
   FloatingResizeCorner,

--- a/src/plugins/pane-manager/docking.ts
+++ b/src/plugins/pane-manager/docking.ts
@@ -180,6 +180,7 @@ export function swapPanes(layout: LayoutConfig, firstId: string, secondId: strin
         width: floatingEntry.width,
         height: floatingEntry.height,
         zIndex: floatingEntry.zIndex,
+        fixedGeometry: floatingEntry.fixedGeometry,
       },
     ],
   });

--- a/src/plugins/pane-manager/floating-actions.ts
+++ b/src/plugins/pane-manager/floating-actions.ts
@@ -16,6 +16,8 @@ import {
   type FloatingRect,
 } from "./floating";
 import type { LayoutBounds } from "./dock-tree";
+import { inferCompactedDockTree } from "./gridlock-inference";
+import { dockPane } from "./docking";
 import type { FloatingResizeCorner } from "./types";
 import { detachPane, ensurePaneInstance, finalizeLayout } from "./layout-state";
 
@@ -53,8 +55,25 @@ export function floatAtRect(layout: LayoutConfig, instanceId: string, rect: Floa
         width: rect.width,
         height: rect.height,
         zIndex: rect.zIndex ?? maxFloatingZ(layout) + 1,
+        fixedGeometry: rect.fixedGeometry,
       },
     ],
+  });
+}
+
+export function dockFloatingPaneAtCurrentRect(
+  layout: LayoutConfig,
+  instanceId: string,
+  bounds: LayoutBounds,
+): LayoutConfig {
+  const floating = layout.floating.find((entry) => entry.instanceId === instanceId);
+  if (!floating) return layout;
+  const dockRoot = inferCompactedDockTree(layout, instanceId, floating, bounds);
+  if (!dockRoot) return dockPane(layout, instanceId);
+  return finalizeLayout({
+    ...layout,
+    dockRoot,
+    floating: layout.floating.filter((entry) => entry.instanceId !== instanceId),
   });
 }
 
@@ -85,22 +104,29 @@ export function resizeFloatingPaneFromCorner(
 ): LayoutConfig {
   const floating = layout.floating.find((entry) => entry.instanceId === instanceId);
   if (!floating) return layout;
+  const minWidth = floating.fixedGeometry ? 1 : MIN_FLOAT_WIDTH;
+  const minHeight = floating.fixedGeometry ? 1 : MIN_FLOAT_HEIGHT;
 
   let left = floating.x;
   let top = floating.y;
   let right = floating.x + floating.width;
   let bottom = floating.y + floating.height;
 
-  if (corner === "top-left" || corner === "bottom-left") {
-    left = Math.max(bounds.x, Math.min(left + deltaX, right - MIN_FLOAT_WIDTH));
-  } else {
-    right = Math.min(bounds.x + bounds.width, Math.max(right + deltaX, left + MIN_FLOAT_WIDTH));
+  const affectsLeft = corner === "top-left" || corner === "bottom-left" || corner === "left";
+  const affectsRight = corner === "top-right" || corner === "bottom-right" || corner === "right";
+  const affectsTop = corner === "top-left" || corner === "top-right" || corner === "top";
+  const affectsBottom = corner === "bottom-left" || corner === "bottom-right" || corner === "bottom";
+
+  if (affectsLeft) {
+    left = Math.max(bounds.x, Math.min(left + deltaX, right - minWidth));
+  } else if (affectsRight) {
+    right = Math.min(bounds.x + bounds.width, Math.max(right + deltaX, left + minWidth));
   }
 
-  if (corner === "top-left" || corner === "top-right") {
-    top = Math.max(bounds.y, Math.min(top + deltaY, bottom - MIN_FLOAT_HEIGHT));
-  } else {
-    bottom = Math.min(bounds.y + bounds.height, Math.max(bottom + deltaY, top + MIN_FLOAT_HEIGHT));
+  if (affectsTop) {
+    top = Math.max(bounds.y, Math.min(top + deltaY, bottom - minHeight));
+  } else if (affectsBottom) {
+    bottom = Math.min(bounds.y + bounds.height, Math.max(bottom + deltaY, top + minHeight));
   }
 
   return finalizeLayout(updateFloatingPane(layout, instanceId, {

--- a/src/plugins/pane-manager/floating.ts
+++ b/src/plugins/pane-manager/floating.ts
@@ -10,6 +10,7 @@ export interface FloatingRect {
   width: number;
   height: number;
   zIndex?: number;
+  fixedGeometry?: boolean;
 }
 
 interface LayoutBoundsLike {
@@ -20,8 +21,8 @@ interface LayoutBoundsLike {
 }
 
 export function clampFloatingRect(rect: FloatingRect, termWidth?: number, termHeight?: number): FloatingRect {
-  const width = Math.max(MIN_FLOAT_WIDTH, Math.round(rect.width));
-  const height = Math.max(MIN_FLOAT_HEIGHT, Math.round(rect.height));
+  const width = Math.max(rect.fixedGeometry ? 1 : MIN_FLOAT_WIDTH, Math.round(rect.width));
+  const height = Math.max(rect.fixedGeometry ? 1 : MIN_FLOAT_HEIGHT, Math.round(rect.height));
   const maxX = typeof termWidth === "number" ? Math.max(0, termWidth - width) : Number.POSITIVE_INFINITY;
   const maxY = typeof termHeight === "number" ? Math.max(0, termHeight - height) : Number.POSITIVE_INFINITY;
   return {
@@ -30,12 +31,13 @@ export function clampFloatingRect(rect: FloatingRect, termWidth?: number, termHe
     width,
     height,
     zIndex: rect.zIndex,
+    fixedGeometry: rect.fixedGeometry,
   };
 }
 
 export function clampFloatingRectWithinBounds(rect: FloatingRect, bounds: LayoutBoundsLike): FloatingRect {
-  const width = Math.min(Math.max(MIN_FLOAT_WIDTH, Math.round(rect.width)), Math.max(1, bounds.width));
-  const height = Math.min(Math.max(MIN_FLOAT_HEIGHT, Math.round(rect.height)), Math.max(1, bounds.height));
+  const width = Math.min(Math.max(rect.fixedGeometry ? 1 : MIN_FLOAT_WIDTH, Math.round(rect.width)), Math.max(1, bounds.width));
+  const height = Math.min(Math.max(rect.fixedGeometry ? 1 : MIN_FLOAT_HEIGHT, Math.round(rect.height)), Math.max(1, bounds.height));
   const maxX = bounds.x + Math.max(0, bounds.width - width);
   const maxY = bounds.y + Math.max(0, bounds.height - height);
   return {
@@ -44,6 +46,7 @@ export function clampFloatingRectWithinBounds(rect: FloatingRect, bounds: Layout
     width,
     height,
     zIndex: rect.zIndex,
+    fixedGeometry: rect.fixedGeometry,
   };
 }
 

--- a/src/plugins/pane-manager/gridlock-inference.ts
+++ b/src/plugins/pane-manager/gridlock-inference.ts
@@ -1,5 +1,5 @@
-import type { DockLayoutNode } from "../../types/config";
-import type { LayoutBounds } from "./dock-tree";
+import type { DockLayoutNode, LayoutConfig } from "../../types/config";
+import { getDockLeafLayouts, type LayoutBounds } from "./dock-tree";
 
 export interface GridlockRect {
   instanceId: string;
@@ -7,6 +7,13 @@ export interface GridlockRect {
   y: number;
   width: number;
   height: number;
+}
+
+function rectsOverlap(left: LayoutBounds, right: LayoutBounds): boolean {
+  return left.x < right.x + right.width
+    && left.x + left.width > right.x
+    && left.y < right.y + right.height
+    && left.y + left.height > right.y;
 }
 
 export function boundsForRects(rects: GridlockRect[]): LayoutBounds {
@@ -123,4 +130,32 @@ export function inferDockTreeFromRects(rects: GridlockRect[], bounds?: LayoutBou
     first: inferDockTreeFromRects(chosen.first, boundsForRects(chosen.first))!,
     second: inferDockTreeFromRects(chosen.second, boundsForRects(chosen.second))!,
   };
+}
+
+export function inferCompactedDockTree(
+  layout: LayoutConfig,
+  draggedInstanceId: string,
+  targetRect: LayoutBounds,
+  bounds: LayoutBounds,
+): DockLayoutNode | null {
+  const siblingLeaves = getDockLeafLayouts(layout, bounds)
+    .filter((leaf) => leaf.instanceId !== draggedInstanceId);
+  if (siblingLeaves.some((leaf) => rectsOverlap(targetRect, leaf.rect))) {
+    return null;
+  }
+
+  let replacedDraggedPane = false;
+  const rects: GridlockRect[] = getDockLeafLayouts(layout, bounds).map((leaf) => {
+    if (leaf.instanceId !== draggedInstanceId) {
+      return { instanceId: leaf.instanceId, ...leaf.rect };
+    }
+    replacedDraggedPane = true;
+    return { instanceId: draggedInstanceId, ...targetRect };
+  });
+
+  if (!replacedDraggedPane) {
+    rects.push({ instanceId: draggedInstanceId, ...targetRect });
+  }
+
+  return inferDockTreeFromRects(rects, bounds);
 }

--- a/src/plugins/pane-manager/gridlock.ts
+++ b/src/plugins/pane-manager/gridlock.ts
@@ -1,10 +1,13 @@
 import type { LayoutConfig } from "../../types/config";
 import {
   boundsForRects,
+  inferCompactedDockTree,
   inferDockTreeFromRects,
   type GridlockRect,
 } from "./gridlock-inference";
 import {
+  findDockLeaf,
+  getDockedPaneIds,
   getDockLeafLayouts,
   type LayoutBounds,
 } from "./dock-tree";
@@ -13,6 +16,124 @@ import {
   removeUnavailablePaneTypes,
   type PaneTypeAvailability,
 } from "./layout-state";
+import { floatAtRect } from "./floating-actions";
+
+export const LAYOUT_PRESET_IDS = ["single", "2x2", "3x3", "left-main"] as const;
+export type LayoutPresetId = typeof LAYOUT_PRESET_IDS[number];
+
+function splitDimension(total: number, parts: number, index: number): { start: number; size: number } {
+  const start = Math.floor((total * index) / parts);
+  const end = Math.floor((total * (index + 1)) / parts);
+  return { start, size: Math.max(1, end - start) };
+}
+
+function visiblePaneIds(layout: LayoutConfig): string[] {
+  return [
+    ...getDockedPaneIds(layout),
+    ...layout.floating.map((entry) => entry.instanceId),
+  ];
+}
+
+function makeGridPresetRects(
+  instanceIds: string[],
+  bounds: LayoutBounds,
+  columns: number,
+): GridlockRect[] {
+  const columnCount = Math.max(1, Math.min(columns, instanceIds.length));
+  const rowCount = Math.max(1, Math.ceil(instanceIds.length / columnCount));
+  return instanceIds.map((instanceId, index) => {
+    const column = index % columnCount;
+    const row = Math.floor(index / columnCount);
+    const horizontal = splitDimension(bounds.width, columnCount, column);
+    const vertical = splitDimension(bounds.height, rowCount, row);
+    return {
+      instanceId,
+      x: bounds.x + horizontal.start,
+      y: bounds.y + vertical.start,
+      width: horizontal.size,
+      height: vertical.size,
+    };
+  });
+}
+
+function makeLeftMainPresetRects(instanceIds: string[], bounds: LayoutBounds): GridlockRect[] {
+  if (instanceIds.length <= 1) {
+    return instanceIds.map((instanceId) => ({ instanceId, ...bounds }));
+  }
+
+  const left = splitDimension(bounds.width, 2, 0);
+  const right = splitDimension(bounds.width, 2, 1);
+  const stackedIds = instanceIds.slice(1);
+  return [
+    {
+      instanceId: instanceIds[0]!,
+      x: bounds.x + left.start,
+      y: bounds.y,
+      width: left.size,
+      height: bounds.height,
+    },
+    ...stackedIds.map((instanceId, index) => {
+      const vertical = splitDimension(bounds.height, stackedIds.length, index);
+      return {
+        instanceId,
+        x: bounds.x + right.start,
+        y: bounds.y + vertical.start,
+        width: right.size,
+        height: vertical.size,
+      };
+    }),
+  ];
+}
+
+export function applyLayoutPreset(
+  layout: LayoutConfig,
+  preset: LayoutPresetId,
+  bounds: LayoutBounds = { x: 0, y: 0, width: 120, height: 40 },
+  paneTypes?: PaneTypeAvailability,
+): LayoutConfig {
+  const visibleLayout = paneTypes
+    ? removeUnavailablePaneTypes(layout, paneTypes)
+    : layout;
+  const instanceIds = visiblePaneIds(visibleLayout);
+  if (instanceIds.length === 0) return visibleLayout;
+
+  const rects = preset === "left-main"
+    ? makeLeftMainPresetRects(instanceIds, bounds)
+    : makeGridPresetRects(instanceIds, bounds, preset === "single" ? 1 : preset === "2x2" ? 2 : 3);
+
+  return finalizeLayout({
+    ...visibleLayout,
+    dockRoot: inferDockTreeFromRects(rects, bounds),
+    floating: visibleLayout.floating.filter((entry) => !instanceIds.includes(entry.instanceId)),
+  });
+}
+
+export function snapPaneToGridRect(
+  layout: LayoutConfig,
+  instanceId: string,
+  targetRect: LayoutBounds,
+  _bounds: LayoutBounds,
+): LayoutConfig {
+  const visibleIds = new Set(visiblePaneIds(layout));
+  if (!visibleIds.has(instanceId)) return layout;
+  return floatAtRect(layout, instanceId, { ...targetRect, fixedGeometry: true });
+}
+
+export function compactDockedPaneAtRect(
+  layout: LayoutConfig,
+  draggedInstanceId: string,
+  targetRect: LayoutBounds,
+  bounds: LayoutBounds,
+): LayoutConfig {
+  if (!findDockLeaf(layout, draggedInstanceId)) return layout;
+  const dockRoot = inferCompactedDockTree(layout, draggedInstanceId, targetRect, bounds);
+  if (!dockRoot) return layout;
+  return finalizeLayout({
+    ...layout,
+    dockRoot,
+    floating: layout.floating,
+  });
+}
 
 export function gridlockAllPanes(
   layout: LayoutConfig,

--- a/src/plugins/pane-manager/layout-state.ts
+++ b/src/plugins/pane-manager/layout-state.ts
@@ -100,6 +100,7 @@ function capturePlacementMemory(layout: LayoutConfig): LayoutConfig {
         y: floating.y,
         width: floating.width,
         height: floating.height,
+        fixedGeometry: floating.fixedGeometry,
       } : previous.floating;
       const detached = detachedById.get(instance.instanceId);
       const nextDetached = detached ? {

--- a/src/plugins/pane-manager/types.ts
+++ b/src/plugins/pane-manager/types.ts
@@ -16,7 +16,15 @@ export type DropTarget =
   | { kind: "frame"; edge: "left" | "right" | "top" | "bottom" }
   | { kind: "leaf"; targetId: string; position: LeafDropPosition };
 
-export type FloatingResizeCorner = "top-left" | "top-right" | "bottom-left" | "bottom-right";
+export type FloatingResizeCorner =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right"
+  | "top"
+  | "bottom"
+  | "left"
+  | "right";
 
 export interface LayoutSimulation {
   layout: LayoutConfig;

--- a/src/react/input.ts
+++ b/src/react/input.ts
@@ -21,6 +21,7 @@ export interface ShortcutOptions {
   scope?: string;
   phase?: "before" | "normal" | "after";
   allowEditable?: boolean;
+  interceptNative?: boolean | ((event: KeyEventLike) => boolean);
 }
 
 export interface InputHost {

--- a/src/renderers/electrobun/view/input-host.test.ts
+++ b/src/renderers/electrobun/view/input-host.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from "bun:test";
+import type { KeyEventLike } from "../../../react/input";
+import { dispatchWebAppKeyDown, dispatchWebNativeInterceptors } from "./input-host";
+
+function keyboardEvent(overrides: Record<string, unknown> = {}) {
+  let defaultPrevented = false;
+  let propagationStopped = false;
+  const event = {
+    key: "x",
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+    target: { tagName: "DIV" },
+    get defaultPrevented() { return defaultPrevented; },
+    get cancelBubble() { return propagationStopped; },
+    isComposing: false,
+    preventDefault() { defaultPrevented = true; },
+    stopPropagation() { propagationStopped = true; },
+    ...overrides,
+  };
+  return event as unknown as KeyboardEvent;
+}
+
+function shortcut(
+  handler: (event: KeyEventLike) => void,
+  options: {
+    allowEditable?: boolean;
+    enabled?: boolean;
+    interceptNative?: boolean | ((event: KeyEventLike) => boolean);
+    order?: number;
+    phase?: "before" | "normal" | "after";
+  } = {},
+) {
+  return {
+    handlerRef: { current: handler },
+    enabledRef: { current: options.enabled !== false },
+    allowEditableRef: { current: options.allowEditable === true },
+    interceptNativeRef: { current: options.interceptNative ?? false },
+    phase: options.phase ?? "normal",
+    order: options.order ?? 1,
+  };
+}
+
+function runNativeDefault(event: KeyboardEvent, action: () => void): void {
+  if (!event.defaultPrevented) action();
+}
+
+describe("dispatchWebAppKeyDown", () => {
+  test("runs only native before-phase interceptors during capture and does not repeat them in bubble", () => {
+    const calls: string[] = [];
+    const event = keyboardEvent({ key: "x", target: { tagName: "DIV" } });
+    const entries = [
+      shortcut(() => { calls.push("generic-before"); }, { phase: "before", order: 1 }),
+      shortcut(() => { calls.push("native-before"); }, { phase: "before", order: 2, interceptNative: true }),
+      shortcut(() => { calls.push("generic-normal"); }, { phase: "normal", order: 3 }),
+    ];
+
+    dispatchWebNativeInterceptors(event, entries);
+    expect(calls).toEqual(["native-before"]);
+
+    dispatchWebAppKeyDown(event, entries, true);
+    expect(calls).toEqual(["native-before", "generic-before", "generic-normal"]);
+  });
+
+  test("leaves Tab and Shift+Tab to native focus traversal when no modal handler accepts them", () => {
+    let paneTabs = 0;
+    const focusMoves: string[] = [];
+    const paneShortcut = shortcut(() => { paneTabs += 1; }, { phase: "before" });
+
+    for (const shiftKey of [false, true]) {
+      const event = keyboardEvent({ key: "Tab", shiftKey });
+      dispatchWebAppKeyDown(event, [paneShortcut]);
+      runNativeDefault(event, () => { focusMoves.push(shiftKey ? "backward" : "forward"); });
+      expect(event.defaultPrevented).toBe(false);
+    }
+
+    expect(paneTabs).toBe(0);
+    expect(focusMoves).toEqual(["forward", "backward"]);
+  });
+
+  test("lets an active before-phase modal intercept Tab ahead of native focus and pane shortcuts", () => {
+    let modalTabs = 0;
+    let paneTabs = 0;
+    let focusMoves = 0;
+    const event = keyboardEvent({ key: "Tab", target: { tagName: "INPUT" } });
+
+    dispatchWebAppKeyDown(event, [
+      shortcut(() => { paneTabs += 1; }, { phase: "before", order: 1 }),
+      shortcut((key) => {
+        if (key.name !== "tab") return;
+        modalTabs += 1;
+        key.preventDefault();
+        key.stopPropagation();
+      }, { phase: "before", order: 2, allowEditable: true, interceptNative: true }),
+    ]);
+    runNativeDefault(event, () => { focusMoves += 1; });
+
+    expect({ modalTabs, paneTabs, focusMoves }).toEqual({ modalTabs: 1, paneTabs: 0, focusMoves: 0 });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("limits target-aware native interception to matching editable controls", () => {
+    let commandBarTabs = 0;
+    let nativeFocusMoves = 0;
+    const commandBarShortcut = shortcut((key) => {
+      if (key.name !== "tab") return;
+      commandBarTabs += 1;
+      key.preventDefault();
+      key.stopPropagation();
+    }, {
+      phase: "before",
+      allowEditable: true,
+      interceptNative: (key) => key.targetEditable === true,
+    });
+
+    const editableTargets = [
+      { tagName: "INPUT" },
+      { tagName: "TEXTAREA" },
+      { tagName: "SELECT" },
+      { tagName: "DIV", isContentEditable: true },
+      { tagName: "SPAN", closest: (selector: string) => selector.includes("contenteditable") ? {} : null },
+    ];
+    const nativeTargets = [
+      { tagName: "BUTTON" },
+      { tagName: "A", getAttribute: (name: string) => name === "href" ? "/back" : null },
+      { tagName: "SUMMARY" },
+    ];
+
+    for (const target of [...editableTargets, ...nativeTargets]) {
+      const event = keyboardEvent({ key: "Tab", target });
+      dispatchWebAppKeyDown(event, [commandBarShortcut]);
+      runNativeDefault(event, () => { nativeFocusMoves += 1; });
+    }
+
+    expect({ commandBarTabs, nativeFocusMoves }).toEqual({ commandBarTabs: 5, nativeFocusMoves: 3 });
+  });
+
+  test("leaves button, link, and summary activation outside target-aware interception", () => {
+    const cases = [
+      { target: { tagName: "BUTTON" }, keys: ["Enter", " "] },
+      { target: { tagName: "A", getAttribute: (name: string) => name === "href" ? "/back" : null }, keys: ["Enter"] },
+      { target: { tagName: "SUMMARY" }, keys: ["Enter", " "] },
+    ];
+    let commandBarActivations = 0;
+    let nativeActivations = 0;
+    const commandBarShortcut = shortcut(() => {
+      commandBarActivations += 1;
+    }, {
+      phase: "before",
+      allowEditable: true,
+      interceptNative: (key) => key.targetEditable === true,
+    });
+
+    for (const { target, keys } of cases) {
+      for (const key of keys) {
+        const event = keyboardEvent({ key, target });
+        dispatchWebAppKeyDown(event, [commandBarShortcut]);
+        runNativeDefault(event, () => { nativeActivations += 1; });
+      }
+    }
+
+    expect({ commandBarActivations, nativeActivations }).toEqual({
+      commandBarActivations: 0,
+      nativeActivations: 5,
+    });
+  });
+
+  test("keeps native control defaults ahead of focused-pane shortcuts", () => {
+    const cases = [
+      { target: { tagName: "BUTTON" }, keys: ["Enter", "Return", " "] },
+      { target: { tagName: "A", getAttribute: (name: string) => name === "href" ? "/news" : null }, keys: ["Enter"] },
+      { target: { tagName: "SUMMARY" }, keys: ["Enter", " "] },
+    ];
+    let paneActivations = 0;
+    let nativeDefaults = 0;
+    const paneShortcut = shortcut(() => { paneActivations += 1; });
+
+    for (const { target, keys } of cases) {
+      for (const key of keys) {
+        const event = keyboardEvent({ key, target });
+        dispatchWebAppKeyDown(event, [paneShortcut]);
+        runNativeDefault(event, () => { nativeDefaults += 1; });
+        expect(event.defaultPrevented).toBe(false);
+      }
+    }
+
+    expect(paneActivations).toBe(0);
+    expect(nativeDefaults).toBe(6);
+  });
+
+  test("lets Window Edit commit with Enter even when a native header button retains focus", () => {
+    let commits = 0;
+    let paneActivations = 0;
+    let buttonClicks = 0;
+    const event = keyboardEvent({ key: "Enter", target: { tagName: "BUTTON" } });
+
+    dispatchWebAppKeyDown(event, [
+      shortcut(() => { paneActivations += 1; }, { phase: "normal", order: 1 }),
+      shortcut((key) => {
+        if (key.name !== "return") return;
+        commits += 1;
+        key.preventDefault();
+        key.stopPropagation();
+      }, { phase: "before", order: 2, allowEditable: true, interceptNative: true }),
+    ]);
+    runNativeDefault(event, () => { buttonClicks += 1; });
+
+    expect({ commits, paneActivations, buttonClicks }).toEqual({ commits: 1, paneActivations: 0, buttonClicks: 0 });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("does not leak native editing targets into generic shortcuts", () => {
+    const targets = [
+      { tagName: "INPUT" },
+      { tagName: "TEXTAREA" },
+      { tagName: "SELECT" },
+      { tagName: "DIV", isContentEditable: true },
+      { tagName: "SPAN", closest: (selector: string) => selector.includes("contenteditable") ? {} : null },
+    ];
+    let genericCalls = 0;
+    const genericShortcut = shortcut(() => { genericCalls += 1; });
+
+    for (const target of targets) {
+      for (const key of ["x", "Enter", " "]) {
+        const event = keyboardEvent({ key, target });
+        dispatchWebAppKeyDown(event, [genericShortcut]);
+        expect(event.defaultPrevented).toBe(false);
+      }
+    }
+
+    expect(genericCalls).toBe(0);
+  });
+
+  test("returns unhandled modal-native keys to the browser", () => {
+    let buttonClicks = 0;
+    const event = keyboardEvent({ key: " ", target: { tagName: "BUTTON" } });
+
+    dispatchWebAppKeyDown(event, [
+      shortcut(() => {}, { phase: "before", interceptNative: true }),
+    ]);
+    runNativeDefault(event, () => { buttonClicks += 1; });
+
+    expect(buttonClicks).toBe(1);
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/src/renderers/electrobun/view/input-host.tsx
+++ b/src/renderers/electrobun/view/input-host.tsx
@@ -17,6 +17,7 @@ import {
   isEditableKeyboardTarget,
   normalizeWebKeyName,
   shouldConsumeWebAppKeyDown,
+  shouldDispatchWebAppKeyDown,
   webKeySequence,
 } from "./key-event";
 
@@ -80,11 +81,17 @@ interface ShortcutEntry {
   handlerRef: { current: (event: KeyEventLike) => void };
   enabledRef: { current: boolean };
   allowEditableRef: { current: boolean };
+  interceptNativeRef: { current: NonNullable<ShortcutOptions["interceptNative"]> | false };
   phase: NonNullable<ShortcutOptions["phase"]>;
   order: number;
 }
 
 let nextShortcutOrder = 1;
+
+function shouldInterceptNative(entry: ShortcutEntry, event: KeyEventLike): boolean {
+  const interceptor = entry.interceptNativeRef.current;
+  return typeof interceptor === "function" ? interceptor(event) : interceptor;
+}
 
 function subscribeViewport(listener: () => void): () => void {
   window.addEventListener("resize", listener);
@@ -102,30 +109,71 @@ function getViewport() {
   return viewportSnapshot;
 }
 
+function dispatchShortcutEntries(
+  shortcutEvent: KeyEventLike,
+  entries: readonly ShortcutEntry[],
+  nativeInterceptionOnly = false,
+  skipNativeInterceptors = false,
+): void {
+  for (const phase of ["before", "normal", "after"] as const) {
+    if (phase === "after" && (shortcutEvent.defaultPrevented || shortcutEvent.propagationStopped)) break;
+    const phaseEntries = entries
+      .filter((entry) => entry.phase === phase)
+      .map((entry) => ({
+        entry,
+        interceptsNative: shouldInterceptNative(entry, shortcutEvent),
+      }))
+      .sort((left, right) => (
+        phase === "before" && left.interceptsNative !== right.interceptsNative
+          ? Number(right.interceptsNative) - Number(left.interceptsNative)
+          : left.entry.order - right.entry.order
+      ));
+    for (const { entry, interceptsNative } of phaseEntries) {
+      if (!entry.enabledRef.current) continue;
+      if (nativeInterceptionOnly && (phase !== "before" || !interceptsNative)) continue;
+      if (skipNativeInterceptors && phase === "before" && interceptsNative) continue;
+      if (!shouldDeliverShortcut(shortcutEvent, entry.allowEditableRef.current)) continue;
+      entry.handlerRef.current(shortcutEvent);
+      if (shortcutEvent.propagationStopped) break;
+    }
+    if (shortcutEvent.propagationStopped) break;
+  }
+}
+
+export function dispatchWebNativeInterceptors(event: KeyboardEvent, entries: readonly ShortcutEntry[]): void {
+  if (event.defaultPrevented || event.isComposing) return;
+  dispatchShortcutEntries(toKeyEventLike(event), entries, true);
+}
+
+export function dispatchWebAppKeyDown(
+  event: KeyboardEvent,
+  entries: readonly ShortcutEntry[],
+  nativeInterceptorsDispatched = false,
+): void {
+  if (event.defaultPrevented || event.isComposing) return;
+  const shortcutEvent = toKeyEventLike(event);
+  const nativeInterceptionOnly = !shouldDispatchWebAppKeyDown(event);
+
+  dispatchShortcutEntries(shortcutEvent, entries, nativeInterceptionOnly, nativeInterceptorsDispatched);
+  if (!nativeInterceptionOnly && shouldConsumeWebAppKeyDown(event)) event.preventDefault();
+}
+
 export function WebInputHostProvider({ children }: { children: ReactNode }) {
   const shortcutsRef = useRef<ShortcutEntry[]>([]);
 
-  const dispatchShortcut = (shortcutEvent: KeyEventLike) => {
-    for (const phase of ["before", "normal", "after"] as const) {
-      if (phase === "after" && (shortcutEvent.defaultPrevented || shortcutEvent.propagationStopped)) break;
-      for (const entry of shortcutsRef.current) {
-        if (entry.phase !== phase || !entry.enabledRef.current) continue;
-        if (!shouldDeliverShortcut(shortcutEvent, entry.allowEditableRef.current)) continue;
-        entry.handlerRef.current(shortcutEvent);
-        if (shortcutEvent.propagationStopped) break;
-      }
-      if (shortcutEvent.propagationStopped) break;
-    }
-  };
-
   useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      const shortcutEvent = toKeyEventLike(event);
-      dispatchShortcut(shortcutEvent);
-      if (shouldConsumeWebAppKeyDown(event)) event.preventDefault();
+    const onKeyDownCapture = (event: KeyboardEvent) => {
+      dispatchWebNativeInterceptors(event, shortcutsRef.current);
     };
+    const onKeyDown = (event: KeyboardEvent) => {
+      dispatchWebAppKeyDown(event, shortcutsRef.current, true);
+    };
+    window.addEventListener("keydown", onKeyDownCapture, true);
     window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDownCapture, true);
+      window.removeEventListener("keydown", onKeyDown);
+    };
   }, []);
 
   useEffect(() => {
@@ -138,7 +186,7 @@ export function WebInputHostProvider({ children }: { children: ReactNode }) {
       if (!isMouseBackNavigationButton(event.button)) return;
       event.preventDefault();
       event.stopPropagation();
-      dispatchShortcut(toMouseBackKeyEventLike(event));
+      dispatchShortcutEntries(toMouseBackKeyEventLike(event), shortcutsRef.current);
     };
 
     window.addEventListener("mousedown", preventBrowserBack, true);
@@ -156,15 +204,18 @@ export function WebInputHostProvider({ children }: { children: ReactNode }) {
       const handlerRef = useRef(handler);
       const enabledRef = useRef(options?.enabled !== false);
       const allowEditableRef = useRef(options?.allowEditable === true);
+      const interceptNativeRef = useRef<NonNullable<ShortcutOptions["interceptNative"]> | false>(options?.interceptNative ?? false);
       handlerRef.current = handler;
       enabledRef.current = options?.enabled !== false;
       allowEditableRef.current = options?.allowEditable === true;
+      interceptNativeRef.current = options?.interceptNative ?? false;
 
       useLayoutEffect(() => {
         const entry: ShortcutEntry = {
           handlerRef,
           enabledRef,
           allowEditableRef,
+          interceptNativeRef,
           phase: options?.phase ?? "normal",
           order: nextShortcutOrder++,
         };

--- a/src/renderers/electrobun/view/key-event.test.ts
+++ b/src/renderers/electrobun/view/key-event.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { shouldConsumeWebAppKeyDown } from "./key-event";
+import {
+  shouldConsumeWebAppKeyDown,
+  shouldDispatchWebAppKeyDown,
+  shouldDispatchWebNativeKeyDown,
+} from "./key-event";
 
 function keyEvent(overrides: Record<string, unknown>) {
   return {
@@ -30,5 +34,50 @@ describe("shouldConsumeWebAppKeyDown", () => {
     expect(shouldConsumeWebAppKeyDown(keyEvent({ key: "c", ctrlKey: true }))).toBe(false);
     expect(shouldConsumeWebAppKeyDown(keyEvent({ key: "c", metaKey: true }))).toBe(false);
     expect(shouldConsumeWebAppKeyDown(keyEvent({ key: "c", ctrlKey: true, shiftKey: true }))).toBe(true);
+  });
+
+  test("leaves native Tab focus traversal available from the app root and its controls", () => {
+    const root = { tagName: "DIV", getAttribute: (name: string) => name === "id" ? "root" : null };
+    const button = { tagName: "BUTTON" };
+
+    for (const target of [root, button]) {
+      const event = keyEvent({ key: "Tab", target });
+      expect(shouldDispatchWebAppKeyDown(event)).toBe(false);
+      expect(shouldConsumeWebAppKeyDown(event)).toBe(false);
+    }
+    expect(shouldDispatchWebAppKeyDown(keyEvent({ key: "Tab", shiftKey: true, target: button }))).toBe(false);
+  });
+
+  test("bypasses app shortcut dispatch for native control activation keys", () => {
+    const button = { tagName: "BUTTON" };
+    const link = { tagName: "A", getAttribute: (name: string) => name === "href" ? "/details" : null };
+    const buttonChild = {
+      tagName: "SVG",
+      closest: (selector: string) => selector.includes("button") ? button : null,
+    };
+
+    for (const key of ["Enter", "Return", " "]) {
+      for (const target of [button, buttonChild, link, { tagName: "SUMMARY" }]) {
+        expect(shouldDispatchWebAppKeyDown(keyEvent({ key, target }))).toBe(false);
+      }
+    }
+
+    expect(shouldDispatchWebAppKeyDown(keyEvent({ key: "+", target: button }))).toBe(true);
+    expect(shouldDispatchWebAppKeyDown(keyEvent({ key: "Enter", target: { tagName: "A", getAttribute: () => null } }))).toBe(true);
+  });
+
+  test("keeps native renderer keypresses out of editable DOM controls", () => {
+    const editableTargets = [
+      { tagName: "INPUT" },
+      { tagName: "TEXTAREA" },
+      { tagName: "SELECT" },
+      { tagName: "DIV", isContentEditable: true },
+      { tagName: "SPAN", closest: (selector: string) => selector.includes("contenteditable") ? {} : null },
+    ];
+
+    for (const target of editableTargets) {
+      expect(shouldDispatchWebNativeKeyDown(keyEvent({ key: "x", target }))).toBe(false);
+      expect(shouldDispatchWebNativeKeyDown(keyEvent({ key: "Enter", target }))).toBe(false);
+    }
   });
 });

--- a/src/renderers/electrobun/view/key-event.ts
+++ b/src/renderers/electrobun/view/key-event.ts
@@ -9,6 +9,7 @@ type KeyboardTargetLike = EventTarget & {
 };
 
 type WebKeyDefaultEvent = Pick<KeyboardEvent, "key" | "ctrlKey" | "metaKey" | "shiftKey" | "target"> & {
+  altKey?: boolean;
   defaultPrevented?: boolean;
   isComposing?: boolean;
 };
@@ -58,7 +59,8 @@ function isNativeKeyboardControlTarget(target: EventTarget | null): boolean {
   if (!element) return false;
 
   const tagName = getTargetTagName(element);
-  if (tagName === "BUTTON" || tagName === "A" || tagName === "SUMMARY") return true;
+  if (tagName === "BUTTON" || tagName === "SUMMARY") return true;
+  if (tagName === "A" && element.getAttribute?.("href") != null) return true;
 
   return targetHasClosest(element, "button, a[href], summary");
 }
@@ -76,8 +78,21 @@ function isNativeControlActivationKey(event: WebKeyDefaultEvent): boolean {
   return key === "return" || key === "enter" || key === "space";
 }
 
+export function shouldDispatchWebAppKeyDown(event: WebKeyDefaultEvent): boolean {
+  if (isNativeKeyboardControlTarget(event.target) && isNativeControlActivationKey(event)) return false;
+  return normalizeWebKeyName(event.key) !== "tab"
+    || !!event.ctrlKey
+    || !!event.metaKey
+    || !!event.altKey;
+}
+
+export function shouldDispatchWebNativeKeyDown(event: WebKeyDefaultEvent): boolean {
+  return !isEditableKeyboardTarget(event.target) && shouldDispatchWebAppKeyDown(event);
+}
+
 export function shouldConsumeWebAppKeyDown(event: WebKeyDefaultEvent): boolean {
   if (event.defaultPrevented || event.isComposing) return false;
+  if (!shouldDispatchWebAppKeyDown(event)) return false;
   if (isEditableKeyboardTarget(event.target)) return false;
   if (isBrowserModifierShortcut(event)) return false;
   if (isNativeKeyboardControlTarget(event.target) && isNativeControlActivationKey(event)) return false;

--- a/src/renderers/electrobun/view/native-renderer.ts
+++ b/src/renderers/electrobun/view/native-renderer.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
 import type { NativeRendererHost } from "../../../ui";
 import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "./input-host";
-import { hasWebCtrlModifier, normalizeWebKeyName, shouldConsumeWebAppKeyDown, webKeySequence } from "./key-event";
+import { hasWebCtrlModifier, normalizeWebKeyName, shouldConsumeWebAppKeyDown, shouldDispatchWebNativeKeyDown, webKeySequence } from "./key-event";
 
 type Listener = (...args: unknown[]) => void;
 type KeypressListener = (event: {
@@ -42,6 +42,7 @@ class WebKeyInput {
   }
 
   emitKeyPress(event: KeyboardEvent): void {
+    if (!shouldDispatchWebNativeKeyDown(event)) return;
     const payload = {
       name: normalizeWebKeyName(event.key),
       sequence: webKeySequence(event),

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -139,6 +139,7 @@ button, [data-gloom-interactive="true"] { cursor: pointer; }
 [data-gloom-role="pane-header"][data-window-mode-selected="true"] {
   background: color-mix(in srgb, var(--gloom-border-focused) 24%, var(--gloom-panel)) !important;
 }
+[data-gloom-role="pane-float-toggle"],
 [data-gloom-role="pane-action"],
 [data-gloom-role="pane-close"] {
   cursor: pointer;
@@ -212,17 +213,35 @@ body.gloom-dragging {
 [data-gloom-role="pane-hint"]:hover {
   background: color-mix(in srgb, var(--gloom-text-bright) 8%, transparent);
 }
+[data-gloom-role="pane-float-toggle"],
 [data-gloom-role="pane-action"],
 [data-gloom-role="pane-close"] {
   border-radius: 4px;
   padding-inline: 2px;
 }
+[data-gloom-role="pane-float-toggle"]:hover,
 [data-gloom-role="pane-action"]:hover,
 [data-gloom-role="pane-close"]:hover {
   background: color-mix(in srgb, var(--gloom-text-bright) 8%, transparent);
 }
 [data-gloom-role="resize-handle"] {
+  cursor: default;
+}
+[data-gloom-role="resize-handle"][data-corner="top-left"],
+[data-gloom-role="resize-handle"][data-corner="bottom-right"] {
   cursor: nwse-resize;
+}
+[data-gloom-role="resize-handle"][data-corner="top-right"],
+[data-gloom-role="resize-handle"][data-corner="bottom-left"] {
+  cursor: nesw-resize;
+}
+[data-gloom-role="resize-handle"][data-corner="left"],
+[data-gloom-role="resize-handle"][data-corner="right"] {
+  cursor: ew-resize;
+}
+[data-gloom-role="resize-handle"][data-corner="top"],
+[data-gloom-role="resize-handle"][data-corner="bottom"] {
+  cursor: ns-resize;
 }
 [data-gloom-role="window-mode-status"] {
   border: 1px solid color-mix(in srgb, var(--gloom-border-focused) 76%, transparent);
@@ -328,7 +347,7 @@ body.gloom-dragging [data-gloom-role="chart-surface"] {
   width: 0;
   display: none;
 }
-[data-gloom-role="resize-handle"]::after {
+[data-gloom-role="resize-handle"][data-corner="bottom-right"]::after {
   content: "";
   position: absolute;
   right: 4px;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -44,6 +44,7 @@ export interface FloatingPlacementMemory {
   y: number;
   width: number;
   height: number;
+  fixedGeometry?: boolean;
 }
 
 export interface DetachedPlacementMemory {
@@ -91,6 +92,7 @@ export interface FloatingPaneEntry {
   width: number;
   height: number;
   zIndex?: number;
+  fixedGeometry?: boolean;
 }
 
 interface DetachedPaneEntry {

--- a/src/ui/context-menu.tsx
+++ b/src/ui/context-menu.tsx
@@ -37,6 +37,7 @@ const EDITABLE_SELECTOR = "input, textarea, [contenteditable='true']";
 const MENU_SURFACE_SELECTOR = [
   "[data-gloom-context-menu-surface='true']",
   "[data-gloom-role='pane-header']",
+  "[data-gloom-role='pane-float-toggle']",
   "[data-gloom-role='pane-action']",
   "[data-gloom-role='pane-close']",
   "[data-gloom-role='status-bar']",


### PR DESCRIPTION
## Summary
- makes desktop pane construction visible with a 6×6 placement grid, header control, and layout presets
- supports target-relative left/right/top/bottom insertion with truthful live previews and exact committed geometry
- restores header drag-to-move, adds compact tiled reflow with a per-pane float escape, and completes all-edge floating resize behavior
- preserves native control/header action precedence and adds focused regression coverage for geometry and pointer interactions

## Verification
- focused layout/native tests: 10 passed, 125 assertions
- `bun run build`
- `bun run desktop:view:build`
- `git diff --check upstream/main...HEAD`

## TypeScript note
`bunx tsc --noEmit` reports 254 existing repository-wide diagnostics on current upstream `main`; the count is unchanged from baseline and none reference changed files.