### PR TITLE
Prevent intraday charts from bridging missing history

### DIFF
--- a/src/components/chart/core/data.ts
+++ b/src/components/chart/core/data.ts
@@ -16,6 +16,8 @@ export type {
 
 const MAX_LIVE_QUOTE_TAIL_AGE_MS = 7 * 24 * 60 * 60_000;
 const MAX_LIVE_QUOTE_CLOCK_SKEW_MS = 5 * 60_000;
+const MAX_INTRADAY_BAR_INTERVAL_MS = 6 * 60 * 60_000;
+const MIN_LIVE_QUOTE_TAIL_GAP_MS = 5 * 60_000;
 const MS_DAY = 86400_000;
 
 function coerceDate(value: Date | string | number): Date {
@@ -60,6 +62,16 @@ export function appendLiveQuotePoint(
 
   const latestTime = getPointTime(latest);
   if (!Number.isFinite(latestTime) || quoteTime <= latestTime) return points;
+
+  const previous = points.at(-2);
+  const latestInterval = previous ? latestTime - getPointTime(previous) : Number.NaN;
+  if (
+    latestInterval > 0
+    && latestInterval <= MAX_INTRADAY_BAR_INTERVAL_MS
+    && quoteTime - latestTime > Math.max(MIN_LIVE_QUOTE_TAIL_GAP_MS, latestInterval * 3)
+  ) {
+    return points;
+  }
 
   const latestClose = latest.close;
   if (hasLikelyQuoteUnitMismatch(

--- a/src/components/chart/core/index.test.ts
+++ b/src/components/chart/core/index.test.ts
@@ -226,6 +226,26 @@ describe("appendLiveQuotePoint", () => {
     expect(extended.at(-1)?.close).toBe(131);
   });
 
+  test("does not bridge a missing intraday history window with one synthetic candle", () => {
+    const history: PricePoint[] = [
+      { date: new Date("2026-07-22T14:49:00Z"), close: 347.73 },
+      { date: new Date("2026-07-22T14:50:00Z"), close: 347.76 },
+      { date: new Date("2026-07-22T14:51:00Z"), close: 347.68 },
+    ];
+
+    const extended = appendLiveQuotePoint(
+      history,
+      quoteFixture({
+        symbol: "GOOG",
+        price: 346.27,
+        lastUpdated: Date.parse("2026-07-22T18:52:00Z"),
+      }),
+      Date.parse("2026-07-22T18:53:00Z"),
+    );
+
+    expect(extended).toBe(history);
+  });
+
   test("does not append a live quote tail with a likely unit mismatch", () => {
     const history: PricePoint[] = [
       { date: new Date("2026-05-18T00:00:00Z"), close: 405 },


### PR DESCRIPTION
## Summary

- stop live quotes from creating a synthetic candle across a large intraday history gap
- infer the guard from the immediately preceding bar while preserving coarse chart histories
- cover the observed four-hour minute-chart gap with a focused regression test

## Why

When intraday history stopped hours before a fresh quote, the chart appended that quote as one OHLC point. Because chart positions are index-based, it appeared beside the stale history as a misleading giant candle.

## Validation

- `bun test` — 1,512 tests passed
- `bun run build` — packaged macOS binary built, signed, and smoke-tested
- real-data `GIP GOOG` terminal smoke completed without runtime warnings