### PR TITLE
Fix earnings calendar provider routing

### DIFF
--- a/src/cli/commands/market.ts
+++ b/src/cli/commands/market.ts
@@ -466,20 +466,7 @@ async function runEarnings(rawArgs: string[], ctx: Parameters<CliCommandDef["exe
   if (symbols.length === 0) ctx.fail("Usage: gloomberb earnings <symbol...>");
   const services = await ctx.initServices();
   try {
-    let events: EarningsEvent[] = [];
-    for (const { capability } of services.services.pluginRegistry.capabilities.list("asset-data")) {
-      if (!capability.operations.getEarningsCalendar?.handler) continue;
-      try {
-        events = await services.services.pluginRegistry.capabilities.invoke<EarningsEvent[]>(
-          capability.id,
-          "getEarningsCalendar",
-          { symbols },
-        );
-      } catch {
-        continue;
-      }
-      if (events.length > 0) break;
-    }
+    const events = await services.dataProvider.getEarningsCalendar(symbols);
     ctx.printResult({ data: events }, {
       rows: earningsRows,
       columns: [

--- a/src/sources/provider-router/index.test.ts
+++ b/src/sources/provider-router/index.test.ts
@@ -209,6 +209,49 @@ describe("AssetDataRouter", () => {
     expect(holders.holders[0]?.name).toBe("Vanguard Group Inc");
   });
 
+  test("routes earnings calendars through providers and fills missing symbols from fallback", async () => {
+    const cloudCalls: string[][] = [];
+    const yahooCalls: string[][] = [];
+    const event = (symbol: string, date: string) => ({
+      symbol,
+      name: symbol,
+      earningsDate: new Date(date),
+      epsEstimate: null,
+      epsActual: null,
+      revenueEstimate: null,
+      revenueActual: null,
+      surprise: null,
+      timing: "" as const,
+    });
+    const cloudProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "cloud",
+      name: "Cloud",
+      priority: 100,
+      async getEarningsCalendar(symbols) {
+        cloudCalls.push(symbols);
+        return [event("AAPL", "2026-07-30T20:00:00Z")];
+      },
+    };
+    const yahooProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      priority: 1000,
+      async getEarningsCalendar(symbols) {
+        yahooCalls.push(symbols);
+        return [event("MSFT", "2026-07-29T20:00:00Z")];
+      },
+    };
+
+    const router = new AssetDataRouter(yahooProvider, [cloudProvider]);
+    const events = await router.getEarningsCalendar(["msft", " AAPL ", "aapl"]);
+
+    expect(cloudCalls).toEqual([["MSFT", "AAPL"]]);
+    expect(yahooCalls).toEqual([["MSFT"]]);
+    expect(events.map((entry) => entry.symbol)).toEqual(["MSFT", "AAPL"]);
+  });
+
   test("falls back to later analyst providers when rating targets are missing", async () => {
     const cloudProvider: DataProvider = {
       ...fallbackProvider,

--- a/src/sources/provider-router/index.ts
+++ b/src/sources/provider-router/index.ts
@@ -215,6 +215,10 @@ export class AssetDataRouter implements DataProvider {
     return this.supplementalRoutes.getCorporateActions(ticker, exchange, context);
   }
 
+  async getEarningsCalendar(symbols: string[], context?: MarketDataRequestContext) {
+    return this.supplementalRoutes.getEarningsCalendar(symbols, context);
+  }
+
   async getSecFilings(ticker: string, count = 15, exchange?: string, context?: MarketDataRequestContext): Promise<SecFilingItem[]> {
     return this.documentRoutes.getSecFilings(ticker, count, exchange, context);
   }

--- a/src/sources/provider-router/supplemental.ts
+++ b/src/sources/provider-router/supplemental.ts
@@ -1,5 +1,6 @@
 import type {
   DataProvider,
+  EarningsEvent,
   MarketDataRequestContext,
 } from "../../types/data-provider";
 import type {
@@ -118,6 +119,51 @@ export class ProviderRouterSupplementalRoutes {
     if (result) return result.value;
     if (cached) return cached.value;
     throw new Error(`No corporate actions provider available for ${ticker}`);
+  }
+
+  async getEarningsCalendar(
+    symbols: string[],
+    context?: MarketDataRequestContext,
+  ): Promise<EarningsEvent[]> {
+    const remaining = new Set(
+      symbols
+        .map((symbol) => symbol.trim().toUpperCase())
+        .filter(Boolean),
+    );
+    if (remaining.size === 0) return [];
+
+    const eventsBySymbol = new Map<string, EarningsEvent>();
+    let supported = false;
+    let succeeded = false;
+    let lastError: unknown = null;
+
+    for (const provider of this.deps.providersInPriorityOrder()) {
+      if (!provider.getEarningsCalendar || remaining.size === 0) continue;
+      supported = true;
+      try {
+        const events = await provider.getEarningsCalendar([...remaining], context);
+        succeeded = true;
+        for (const event of events) {
+          const symbol = event.symbol.trim().toUpperCase();
+          if (!remaining.has(symbol)) continue;
+          eventsBySymbol.set(symbol, event);
+          remaining.delete(symbol);
+        }
+      } catch (error) {
+        lastError = error;
+        if (shouldLogProviderError(error)) {
+          this.deps.logProviderError(`${provider.id} failed: ${error}`);
+        }
+      }
+    }
+
+    if (eventsBySymbol.size > 0 || succeeded) {
+      return [...eventsBySymbol.values()]
+        .sort((a, b) => a.earningsDate.getTime() - b.earningsDate.getTime());
+    }
+    if (lastError) throw lastError;
+    if (!supported) throw new Error("No earnings calendar provider available");
+    return [];
   }
 
   async getOptionsChain(ticker: string, exchange?: string, expirationDate?: number, context?: MarketDataRequestContext): Promise<OptionsChain> {


### PR DESCRIPTION
## Summary

- expose earnings calendar requests through the composite asset-data router
- fill missing symbols from later providers while deduplicating and date-sorting results
- route the earnings CLI through the same provider path as the calendar and monitor panes
- add regression coverage for partial preferred-provider results and Yahoo fallback

## Root cause

The Earnings Calendar and Earnings Monitor panes receive the composite `AssetDataRouter`, but the router did not implement `getEarningsCalendar`. Their shared cache therefore returned an empty list before either cloud or Yahoo was called. Yahoo had valid upcoming earnings data; the fallback route was simply unreachable from the panes.

## Validation

- `bun test src/sources/provider-router/index.test.ts src/plugins/builtin/earnings/data/cache.test.ts src/sources/yahoo-finance.test.ts src/cli.test.ts` — 58 passed
- `bun test` — 1,513 passed
- live router-backed CLI returned upcoming MSFT, AAPL, and NVDA earnings
- isolated tmux TUI showed all three rows in Earnings Monitor with no runtime warnings
- `git diff --check`

Repository-wide `tsc --noEmit` remains baseline-red with existing errors outside the changed files; no changed file was reported.