### PR TITLE
Fix chart composition, mixed-series timelines, and earnings loading

### DIFF
--- a/src/app/pane-runtime/pane-settings-runtime.tsx
+++ b/src/app/pane-runtime/pane-settings-runtime.tsx
@@ -52,6 +52,7 @@ export function useAppPaneSettingsRuntime({
     };
 
     await dialog.alert({
+      closeOnClickOutside: true,
       content: (ctx: AlertContext) => (
         <PaneSettingsDialogContent
           {...ctx}

--- a/src/components/chart/composite/column-layout.ts
+++ b/src/components/chart/composite/column-layout.ts
@@ -1,48 +1,215 @@
 import type {
-  CompositeAxisSide,
   CompositePanelScene,
   CompositeProjectedPoint,
+  CompositeProjectedSeries,
 } from "./types";
 
 export interface CompositeColumnGroupSlot {
   index: number;
   count: number;
+  xRatio: number;
+  familyKey: string;
+}
+
+export interface CompositeColumnGroupCenter {
+  xRatio: number;
+  ordinal: number | null;
 }
 
 export interface CompositeColumnLayout {
   groupByPoint: ReadonlyMap<CompositeProjectedPoint, CompositeColumnGroupSlot>;
-  pointsByAxis: Record<CompositeAxisSide, CompositeProjectedPoint[]>;
+  centersByFamily: ReadonlyMap<string, readonly CompositeColumnGroupCenter[]>;
+  seriesCountByFamily: ReadonlyMap<string, number>;
+}
+
+interface ColumnEntry {
+  point: CompositeProjectedPoint;
+  series: CompositeProjectedSeries;
+  familyKey: string;
+  ordinal: number | null;
+}
+
+interface FinancialPeriodBucket {
+  key: string;
+  ordinal: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const MAX_QUARTER_END_DISTANCE_MS = 45 * DAY_MS;
+
+function familyKey(series: CompositeProjectedSeries): string {
+  return [
+    series.source.axis,
+    series.source.nativeFrequency,
+    series.source.unitGroup,
+  ].join(":");
+}
+
+function observedTimestamp(point: CompositeProjectedPoint): number | null {
+  const timestamp = point.point.observedAt.getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function annualBucket(point: CompositeProjectedPoint): FinancialPeriodBucket | null {
+  const periodLabel = point.point.periodLabel?.trim();
+  const timestamp = observedTimestamp(point);
+  if (!periodLabel || !/^FY\d{4}$/.test(periodLabel) || timestamp === null) return null;
+  const observedAt = new Date(timestamp);
+  const observedYear = observedAt.getUTCFullYear();
+  const cohortYear = observedAt.getUTCMonth() <= 1 ? observedYear - 1 : observedYear;
+  return { key: `annual:${cohortYear}`, ordinal: cohortYear };
+}
+
+function quarterlyBucket(point: CompositeProjectedPoint): FinancialPeriodBucket | null {
+  const periodLabel = point.point.periodLabel?.trim();
+  const timestamp = observedTimestamp(point);
+  if (!periodLabel || !/^\d{4} Q[1-4]$/.test(periodLabel) || timestamp === null) return null;
+
+  const observedYear = new Date(timestamp).getUTCFullYear();
+  let nearest: { year: number; quarter: number; distance: number } | null = null;
+  for (let year = observedYear - 1; year <= observedYear + 1; year += 1) {
+    for (let quarter = 1; quarter <= 4; quarter += 1) {
+      const quarterEnd = Date.UTC(year, quarter * 3, 0);
+      const distance = Math.abs(timestamp - quarterEnd);
+      if (!nearest || distance < nearest.distance) {
+        nearest = { year, quarter, distance };
+      }
+    }
+  }
+  if (!nearest || nearest.distance > MAX_QUARTER_END_DISTANCE_MS) return null;
+  return {
+    key: `quarterly:${nearest.year}:Q${nearest.quarter}`,
+    ordinal: nearest.year * 4 + nearest.quarter - 1,
+  };
+}
+
+function financialPeriodBucket(
+  series: CompositeProjectedSeries,
+  point: CompositeProjectedPoint,
+): FinancialPeriodBucket | null {
+  // A market-anchored mixed chart places publications by their first eligible
+  // trading slot, so fiscal-period cohorting must not move them elsewhere.
+  if (point.xSlot !== undefined) return null;
+  // Availability-timed data must stay on its actual plotted date. Cohort
+  // alignment is only valid for period-end observations.
+  if (series.source.timestampMode === "available-at") return null;
+  if (series.source.nativeFrequency === "annual") return annualBucket(point);
+  if (series.source.nativeFrequency === "quarterly") return quarterlyBucket(point);
+  return null;
 }
 
 /**
- * Assigns every column observation a stable slot among columns that share its
- * panel, axis, and timestamp. The panel is implicit in the input, while axis
- * separation prevents independently scaled columns from being presented as a
- * comparable group.
+ * Assigns each column series a stable slot on its axis, then gathers matching
+ * financial periods around their latest member date. Stable cohort slots keep
+ * bar width and order unchanged when one series lacks an observation, while
+ * financial-period normalization accounts for offset issuer fiscal calendars.
  */
 export function buildCompositeColumnLayout(panel: CompositePanelScene): CompositeColumnLayout {
-  const groups = new Map<string, CompositeProjectedPoint[]>();
-  const pointsByAxis: Record<CompositeAxisSide, CompositeProjectedPoint[]> = {
-    left: [],
-    right: [],
-  };
-
+  const columnSeriesByFamily = new Map<string, CompositeProjectedSeries[]>();
   for (const series of panel.series) {
     if (series.source.style !== "columns") continue;
-    const axis = series.source.axis;
-    for (const point of series.points) {
-      pointsByAxis[axis].push(point);
-      const key = `${axis}:${point.timestamp}`;
-      const group = groups.get(key);
-      if (group) group.push(point);
-      else groups.set(key, [point]);
+    const family = familyKey(series);
+    const cohort = columnSeriesByFamily.get(family);
+    if (cohort) cohort.push(series);
+    else columnSeriesByFamily.set(family, [series]);
+  }
+
+  const seriesSlots = new Map<CompositeProjectedSeries, { index: number; count: number }>();
+  for (const seriesGroup of columnSeriesByFamily.values()) {
+    seriesGroup.forEach((series, index) => {
+      seriesSlots.set(series, { index, count: seriesGroup.length });
+    });
+  }
+
+  const groups = new Map<string, ColumnEntry[]>();
+  const semanticBucketsBySeries = new Map<
+    CompositeProjectedSeries,
+    Array<FinancialPeriodBucket | null>
+  >();
+  const duplicateSemanticBucketKeys = new Set<string>();
+  for (const series of panel.series) {
+    if (series.source.style !== "columns") continue;
+    const family = familyKey(series);
+    const semanticBuckets = series.points.map((point) => financialPeriodBucket(series, point));
+    semanticBucketsBySeries.set(series, semanticBuckets);
+    const bucketCounts = new Map<string, number>();
+    for (const bucket of semanticBuckets) {
+      if (bucket) bucketCounts.set(bucket.key, (bucketCounts.get(bucket.key) ?? 0) + 1);
+    }
+    for (const [key, count] of bucketCounts) {
+      if (count > 1) duplicateSemanticBucketKeys.add(`${family}:${key}`);
     }
   }
 
-  const groupByPoint = new Map<CompositeProjectedPoint, CompositeColumnGroupSlot>();
-  for (const group of groups.values()) {
-    group.forEach((point, index) => groupByPoint.set(point, { index, count: group.length }));
+  for (const series of panel.series) {
+    if (series.source.style !== "columns") continue;
+    const family = familyKey(series);
+    const semanticBuckets = semanticBucketsBySeries.get(series) ?? [];
+    series.points.forEach((point, index) => {
+      const semanticBucket = semanticBuckets[index];
+      const uniqueSemanticBucket = semanticBucket
+        && !duplicateSemanticBucketKeys.has(`${family}:${semanticBucket.key}`)
+        ? semanticBucket
+        : null;
+      const key = uniqueSemanticBucket
+        ? `${family}:${uniqueSemanticBucket.key}`
+        : point.xSlot !== undefined
+          ? `${family}:market-slot:${point.xSlot}`
+          : `${family}:timestamp:${point.timestamp}`;
+      const entry = {
+        point,
+        series,
+        familyKey: family,
+        ordinal: uniqueSemanticBucket?.ordinal ?? null,
+      };
+      const group = groups.get(key);
+      if (group) group.push(entry);
+      else groups.set(key, [entry]);
+    });
   }
 
-  return { groupByPoint, pointsByAxis };
+  const groupByPoint = new Map<CompositeProjectedPoint, CompositeColumnGroupSlot>();
+  const centersByFamily = new Map<string, CompositeColumnGroupCenter[]>();
+  for (const group of groups.values()) {
+    const centerRatio = Math.max(...group.map(({ point }) => point.xRatio));
+    const family = group[0]!.familyKey;
+    const ordinal = group[0]!.ordinal;
+    const center = { xRatio: centerRatio, ordinal };
+    const centers = centersByFamily.get(family);
+    if (centers) centers.push(center);
+    else centersByFamily.set(family, [center]);
+
+    const localSeries = ordinal === null
+      // Groups are populated in panel-series order, so Set insertion order is
+      // already the stable authored order and avoids sorting per observation.
+      ? [...new Set(group.map(({ series }) => series))]
+      : [];
+    const localSlots = new Map(localSeries.map((series, index) => [
+      series,
+      { index, count: localSeries.length },
+    ]));
+    for (const { point, series } of group) {
+      // Semantic fiscal cohorts retain stable empty lanes. Exact timestamp
+      // groups only reserve lanes for series that actually share that date.
+      const slot = ordinal === null
+        ? localSlots.get(series) ?? { index: 0, count: 1 }
+        : seriesSlots.get(series) ?? { index: 0, count: 1 };
+      groupByPoint.set(point, {
+        ...slot,
+        xRatio: centerRatio,
+        familyKey: family,
+      });
+    }
+  }
+
+  for (const centers of centersByFamily.values()) {
+    centers.sort((left, right) => left.xRatio - right.xRatio);
+  }
+
+  const seriesCountByFamily = new Map<string, number>();
+  for (const [family, seriesGroup] of columnSeriesByFamily) {
+    seriesCountByFamily.set(family, seriesGroup.length);
+  }
+
+  return { groupByPoint, centersByFamily, seriesCountByFamily };
 }

--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -244,6 +244,112 @@ describe("CompositeChart", () => {
     expect(testSetup.captureCharFrame()).toContain("OTHER Revenue");
   });
 
+  test("shows an explicit legend toggle action on hover", async () => {
+    const toggled: string[] = [];
+    testSetup = await testRender(
+      <CompositeChart
+        width={58}
+        height={10}
+        series={[
+          series("price", "main", "left", "USD", [100, 103, 101]),
+          series("revenue", "main", "right", "%", [4, 6, 8]),
+        ]}
+        panels={[{ id: "main" }]}
+        onToggleSeries={(seriesId) => toggled.push(seriesId)}
+      />,
+      { width: 60, height: 12 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+    const firstLegendLine = testSetup.captureCharFrame().split("\n")[0]!;
+    const priceColumn = firstLegendLine.indexOf("ACME Price");
+    expect(priceColumn).toBeGreaterThan(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.moveTo(2, 5);
+      await testSetup!.mockMouse.moveTo(priceColumn, 0);
+      await testSetup!.renderOnce();
+    });
+    expect(testSetup.captureCharFrame().split("\n")[0]).toContain("Hide");
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(priceColumn, 0);
+      await testSetup!.renderOnce();
+    });
+    expect(toggled).toEqual(["price"]);
+  });
+
+  test("scrolls an overflowing legend horizontally", async () => {
+    const labels = ["FIRST LONG SERIES", "SECOND LONG SERIES", "THIRD LONG SERIES", "LAST LONG SERIES"];
+    const overflowingSeries = labels.map((label, index) => ({
+      ...series(`series-${index}`, "main", "left", "USD", [index + 1, index + 2]),
+      label,
+    }));
+    testSetup = await testRender(
+      <CompositeChart
+        width={38}
+        height={10}
+        series={overflowingSeries}
+        panels={[{ id: "main" }]}
+      />,
+      { width: 40, height: 12 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+    expect(testSetup.captureCharFrame().split("\n")[0]).toContain("FIRST LONG SERIES");
+    expect(testSetup.captureCharFrame().split("\n")[0]).not.toContain("LAST LONG SERIES");
+
+    await act(async () => {
+      for (let index = 0; index < 120; index += 1) {
+        await testSetup!.mockMouse.scroll(20, 0, "down");
+      }
+      await testSetup!.renderOnce();
+    });
+    expect(testSetup.captureCharFrame().split("\n")[0]).toContain("LAST LONG SERIES");
+  });
+
+  test("reaches and toggles overflowing legend series from the keyboard", async () => {
+    const toggled: string[] = [];
+    const labels = ["FIRST LONG SERIES", "SECOND LONG SERIES", "THIRD LONG SERIES", "LAST LONG SERIES"];
+    const overflowingSeries = labels.map((label, index) => ({
+      ...series(`series-${index}`, "main", "left", "USD", [index + 1, index + 2]),
+      label,
+    }));
+    testSetup = await testRender(
+      <InputHostProvider host={chartInputHost}>
+        <CompositeChart
+          width={38}
+          height={10}
+          focused
+          series={overflowingSeries}
+          panels={[{ id: "main" }]}
+          onToggleSeries={(seriesId) => toggled.push(seriesId)}
+        />
+      </InputHostProvider>,
+      { width: 40, height: 12 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      for (let index = 0; index < overflowingSeries.length; index += 1) {
+        chartShortcut?.(keyEvent("]"));
+      }
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+    expect(testSetup.captureCharFrame().split("\n")[0]).toContain("LAST LONG SERIES");
+
+    await act(async () => {
+      chartShortcut?.(keyEvent("space"));
+      await testSetup!.renderOnce();
+    });
+    expect(toggled).toEqual(["series-3"]);
+  });
+
   test("keeps the legend accessory visible when the pane is narrower than its legend", async () => {
     testSetup = await testRender(
       <CompositeChart
@@ -336,6 +442,7 @@ describe("CompositeChart", () => {
   });
 
   test("zooms with plus and resets the interaction viewport with zero", async () => {
+    const viewportChanges: Array<{ start: string; end: string } | null> = [];
     testSetup = await testRender(
       <InputHostProvider host={chartInputHost}>
         <CompositeChart
@@ -348,6 +455,9 @@ describe("CompositeChart", () => {
             start: new Date("2025-01-01T00:00:00.000Z"),
             end: new Date("2025-01-09T00:00:00.000Z"),
           }}
+          onViewportChange={(next) => viewportChanges.push(next
+            ? { start: next.start.toISOString(), end: next.end.toISOString() }
+            : null)}
         />
       </InputHostProvider>,
       { width: 62, height: 14 },
@@ -355,6 +465,10 @@ describe("CompositeChart", () => {
 
     await act(async () => testSetup!.renderOnce());
     expect(testSetup.captureCharFrame()).toContain("2025-01-01");
+    expect(viewportChanges).toEqual([{
+      start: "2025-01-01T00:00:00.000Z",
+      end: "2025-01-09T00:00:00.000Z",
+    }]);
 
     const zoomIn = keyEvent("=");
     zoomIn.sequence = "+";
@@ -364,10 +478,15 @@ describe("CompositeChart", () => {
 
     expect(zoomIn.defaultPrevented).toBe(true);
     expect(testSetup.captureCharFrame()).not.toContain("2025-01-01");
+    expect(viewportChanges.at(-1)?.start).not.toBe("2025-01-01T00:00:00.000Z");
 
     await act(async () => chartShortcut?.(keyEvent("0")));
     await act(async () => testSetup!.renderOnce());
     expect(testSetup.captureCharFrame()).toContain("2025-01-01");
+    expect(viewportChanges.at(-1)).toEqual({
+      start: "2025-01-01T00:00:00.000Z",
+      end: "2025-01-09T00:00:00.000Z",
+    });
   });
 
   test("activates and navigates a buffered viewport from the first mouse gesture", async () => {

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -2,15 +2,18 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Box,
   ChartSurface,
+  ScrollBox,
   Text,
   useNativeRenderer,
   useUiCapabilities,
   useUiHost,
   type BoxRenderable,
   type ChartSurfaceProps,
+  type ScrollBoxRenderable,
 } from "../../../ui";
 import { useShortcut } from "../../../react/input";
-import { colors as themeColors } from "../../../theme/colors";
+import { colors as themeColors, hoverBg } from "../../../theme/colors";
+import { isPlainKey } from "../../../utils/keyboard";
 import { truncateWithEllipsis } from "../../../utils/text-wrap";
 import type { ResolvedSeries } from "../../../time-series/types";
 import {
@@ -29,6 +32,7 @@ import { PriceAxisLabels } from "../price-axis-labels";
 import {
   formatCompositeAxisValue,
   formatCompositeCursorDate,
+  formatCompositePointDetails,
   formatCompositeSeriesValue,
   formatCompositeTimeAxisDate,
 } from "./format";
@@ -46,6 +50,7 @@ import {
   zoomCompositeViewport,
   type CompositeViewportRange,
 } from "./interactions";
+import { buildCompositeColumnLayout, type CompositeColumnLayout } from "./column-layout";
 import { renderCompositePanelBitmap } from "./rasterizer";
 import {
   allocateCompositePanelHeights,
@@ -71,6 +76,7 @@ import type {
 // A short resize-only delay coalesces geometry churn without delaying
 // live-data paints or depending on a foreground animation frame.
 const DESKTOP_BITMAP_RESIZE_DEBOUNCE_MS = 32;
+const LEGEND_WHEEL_DELTA_PER_CELL = 8;
 
 function renderPanelBitmap(
   panel: CompositePanelScene,
@@ -202,6 +208,7 @@ function useCompositePanelBitmap({
 
 function resolvePanelCrosshair(
   panel: CompositePanelScene,
+  columnLayout: CompositeColumnLayout,
   bitmap: NativeChartBitmap | null,
   cursorXRatio: number | null,
   cursorYRatio: number | null,
@@ -209,7 +216,14 @@ function resolvePanelCrosshair(
 ): ChartSurfaceProps["crosshair"] {
   if (!bitmap || cursorXRatio === null || cursorYRatio === null) return null;
   const markers = panel.series.flatMap((series) => {
-    const cursorPoint = series.points.find((point) => Math.abs(point.xRatio - cursorXRatio) < 1e-9);
+    // Column cohorts are drawn at their group center, not each observation's
+    // own timestamp, so match the position the bar actually occupies.
+    const cursorPoint = series.points.find((point) => {
+      const xRatio = series.source.style === "columns"
+        ? columnLayout.groupByPoint.get(point)?.xRatio ?? point.xRatio
+        : point.xRatio;
+      return Math.abs(xRatio - cursorXRatio) < 1e-9;
+    });
     return cursorPoint
       ? [{
         pixelY: cursorPoint.yRatio * Math.max(bitmap.height - 1, 0),
@@ -308,9 +322,10 @@ function CompositePanelSurface({
   } | null>(null);
   const bitmapSize = useStaticChartBitmapSize(plotWidth, panel.height);
   const bitmap = useCompositePanelBitmap({ panel, bitmapSize, colors, isDesktopWeb });
+  const columnLayout = useMemo(() => buildCompositeColumnLayout(panel), [panel]);
   const crosshair = useMemo(
-    () => resolvePanelCrosshair(panel, bitmap, scene.cursorXRatio, activeCursorYRatio, colors.crosshair),
-    [activeCursorYRatio, bitmap, colors.crosshair, panel, scene.cursorXRatio],
+    () => resolvePanelCrosshair(panel, columnLayout, bitmap, scene.cursorXRatio, activeCursorYRatio, colors.crosshair),
+    [activeCursorYRatio, bitmap, colors.crosshair, columnLayout, panel, scene.cursorXRatio],
   );
   const bitmapLayers = useMemo(() => bitmap ? [bitmap] : null, [bitmap]);
   const textLines = useMemo(
@@ -388,9 +403,18 @@ function CompositePanelSurface({
     if (event.modifiers.ctrl && pointer) {
       const zoomIn = direction === "up" || direction === "left";
       const magnitude = Math.min(Math.max(Math.abs(event.scroll?.delta ?? 1), 1), 8);
+      const pointerRatio = pointer.cellX / Math.max(plotWidth - 1, 1);
+      const anchorDate = resolveCompositeCursorDate(scene, pointer.cellX);
+      const viewportSpan = Math.max(viewport.end.getTime() - viewport.start.getTime(), 1);
+      const viewportAnchorRatio = anchorDate
+        ? Math.max(0, Math.min(
+            1,
+            (anchorDate.getTime() - viewport.start.getTime()) / viewportSpan,
+          ))
+        : pointerRatio;
       onZoomViewport(
         zoomIn ? 1 + magnitude * 0.04 : 1 / (1 + magnitude * 0.04),
-        pointer.cellX / Math.max(plotWidth - 1, 1),
+        viewportAnchorRatio,
       );
       updateCursor(event);
       return;
@@ -474,6 +498,7 @@ function legendValue(
 function CompositeLegend({
   scene,
   series,
+  visibleSeriesIds,
   width,
   accessory,
   accessoryWidth,
@@ -481,9 +506,11 @@ function CompositeLegend({
   onActivate,
   onToggleSeries,
   isSeriesToggleable,
+  keyboardIndex,
 }: {
   scene: CompositeChartScene | null;
   series: ResolvedSeries[];
+  visibleSeriesIds: ReadonlySet<string>;
   width: number;
   accessory: CompositeChartProps["legendAccessory"];
   accessoryWidth: CompositeChartProps["legendAccessoryWidth"];
@@ -491,26 +518,35 @@ function CompositeLegend({
   onActivate: CompositeChartProps["onActivate"];
   onToggleSeries: CompositeChartProps["onToggleSeries"];
   isSeriesToggleable: CompositeChartProps["isSeriesToggleable"];
+  keyboardIndex?: number | null;
 }) {
+  const isDesktopWeb = useUiHost().kind === "desktop-web";
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null);
   const dateLabel = scene
     ? scene.cursorDate
       ? formatCompositeCursorDate(scene.cursorDate, scene.startTime, scene.endTime)
       : "Latest"
     : "";
-  const valueById = new Map(
-    scene?.cursorValues.map((entry) => [entry.seriesId, entry.value] as const) ?? [],
+  const cursorValueById = new Map(
+    scene?.cursorValues.map((entry) => [entry.seriesId, entry] as const) ?? [],
   );
   const entries = series.map((entry) => {
+    const toggleable = !!onToggleSeries && (isSeriesToggleable?.(entry) ?? true);
+    const cursorValue = cursorValueById.get(entry.id);
     const fullText = `${entry.label} ${legendValue(
       entry,
-      valueById.get(entry.id) ?? null,
+      cursorValue?.value ?? null,
       formatValue,
     )}`;
+    const details = formatCompositePointDetails(cursorValue?.point);
+    const tooltip = details ? `${fullText} · ${details}` : fullText;
     const textWidth = Math.max(1, Math.min(30, [...fullText].length));
     return {
       entry,
       text: truncateWithEllipsis(fullText, textWidth),
-      width: textWidth + 2,
+      width: textWidth + 2 + (toggleable ? 5 : 0),
+      toggleable,
+      tooltip,
     };
   });
   const desiredSeriesWidth = entries.reduce(
@@ -541,6 +577,57 @@ function CompositeLegend({
       width - dateWidth - dateSeriesGap - seriesWidth - resolvedAccessoryWidth,
     )
     : 0;
+  const keyboardEntryStart = keyboardIndex === null || keyboardIndex === undefined
+    ? null
+    : entries.slice(0, keyboardIndex).reduce(
+      (total, entry, index) => total + entry.width + (index > 0 ? 1 : 0),
+      0,
+    ) + (keyboardIndex > 0 ? 1 : 0);
+  const keyboardEntryEnd = keyboardEntryStart === null
+    ? null
+    : keyboardEntryStart + (entries[keyboardIndex!]?.width ?? 0);
+
+  useEffect(() => {
+    if (keyboardEntryStart === null || keyboardEntryEnd === null) return;
+    const scrollBox = scrollRef.current;
+    const viewportWidth = scrollBox?.viewport?.width || scrollBox?.width || seriesWidth;
+    if (!scrollBox || viewportWidth <= 0) return;
+    const currentLeft = scrollBox.scrollLeft ?? 0;
+    const nextLeft = keyboardEntryStart < currentLeft
+      ? keyboardEntryStart
+      : keyboardEntryEnd > currentLeft + viewportWidth
+        ? keyboardEntryEnd - viewportWidth
+        : currentLeft;
+    if (nextLeft === currentLeft) return;
+    scrollBox.scrollLeft = nextLeft;
+    scrollBox.scrollTo({ x: nextLeft, y: scrollBox.scrollTop });
+  }, [keyboardEntryEnd, keyboardEntryStart, seriesWidth]);
+  const handleMouseScroll = (event?: {
+    preventDefault?: () => void;
+    stopPropagation?: () => void;
+    scroll?: { direction?: string; delta?: number };
+  }) => {
+    const direction = event?.scroll?.direction;
+    const scrollBox = scrollRef.current;
+    const viewportWidth = scrollBox?.viewport?.width || scrollBox?.width || 0;
+    const contentWidth = Math.max(desiredSeriesWidth, scrollBox?.scrollWidth ?? 0);
+    if (!direction || !scrollBox || viewportWidth <= 0 || contentWidth <= viewportWidth) return;
+
+    event.preventDefault?.();
+    event.stopPropagation?.();
+    const rawDelta = Math.abs(event.scroll?.delta ?? 1);
+    const deltaCells = Math.max(1, Math.round(rawDelta / LEGEND_WHEEL_DELTA_PER_CELL));
+    const directionSign = direction === "right" || direction === "down" ? 1 : -1;
+    const nextLeft = Math.max(
+      0,
+      Math.min(
+        contentWidth - viewportWidth,
+        (scrollBox.scrollLeft ?? 0) + directionSign * deltaCells,
+      ),
+    );
+    scrollBox.scrollLeft = nextLeft;
+    scrollBox.scrollTo({ x: nextLeft, y: scrollBox.scrollTop });
+  };
   return (
     <Box
       flexDirection="row"
@@ -558,24 +645,31 @@ function CompositeLegend({
       ) : null}
       {dateSeriesGap > 0 ? <Box width={dateSeriesGap} flexShrink={0} /> : null}
       {seriesWidth > 0 ? (
-        <Box
-          flexDirection="row"
+        <ScrollBox
+          ref={scrollRef}
           width={seriesWidth}
           height={1}
           flexShrink={0}
-          gap={1}
-          overflow="hidden"
+          scrollX
+          focusable={false}
+          horizontalScrollbarOptions={{ visible: false }}
+          onMouseScroll={handleMouseScroll}
+          data-gloom-role="composite-chart-legend-scroll"
         >
-          {entries.map(({ entry, text, width: entryWidth }) => {
-            const toggleable = !!onToggleSeries && (isSeriesToggleable?.(entry) ?? true);
-            return (
+          <Box flexDirection="row" width={desiredSeriesWidth} height={1} gap={1}>
+            {entries.map(({ entry, text, toggleable, tooltip, width: entryWidth }, index) => {
+              const entryVisible = visibleSeriesIds.has(entry.id);
+              return (
               <Box
                 key={entry.id}
                 flexDirection="row"
+                alignItems="center"
                 width={entryWidth}
                 height={1}
                 flexShrink={0}
                 overflow="hidden"
+                backgroundColor={keyboardIndex === index ? themeColors.selected : undefined}
+                hoverBackgroundColor={toggleable ? hoverBg() : undefined}
                 onMouseDown={toggleable ? (event: ChartMouseEvent) => {
                   onActivate?.();
                   consumeChartMouseEvent(event);
@@ -583,14 +677,40 @@ function CompositeLegend({
                 } : undefined}
                 cursor={toggleable ? "pointer" : undefined}
                 data-gloom-interactive={toggleable ? "true" : undefined}
-                data-gloom-label={entry.label}
+                data-gloom-role="composite-chart-legend-series"
+                data-gloom-label={`${toggleable
+                  ? `${entryVisible ? "Hide" : "Show"} `
+                  : ""}${tooltip}`}
+                data-visible={entryVisible ? "true" : "false"}
+                title={isDesktopWeb ? tooltip : undefined}
               >
-                <Text fg={entry.color}>● </Text>
-                <Text fg={themeColors.text}>{text}</Text>
+                {isDesktopWeb ? (
+                  <Box
+                    flexShrink={0}
+                    style={{
+                      width: 8,
+                      height: 8,
+                      marginInlineEnd: 6,
+                      borderRadius: 999,
+                      border: `1px solid ${entry.color}`,
+                      backgroundColor: entryVisible ? entry.color : "transparent",
+                    }}
+                    data-gloom-role="composite-chart-legend-marker"
+                  />
+                ) : (
+                  <Text fg={entryVisible ? entry.color : themeColors.textMuted}>● </Text>
+                )}
+                <Text fg={entryVisible ? themeColors.text : themeColors.textDim}>{text}</Text>
+                {toggleable ? (
+                  <Text fg={themeColors.textMuted}>
+                    {entryVisible ? " Hide" : " Show"}
+                  </Text>
+                ) : null}
               </Box>
-            );
-          })}
-        </Box>
+              );
+            })}
+          </Box>
+        </ScrollBox>
       ) : null}
       {accessorySpacerWidth > 0 ? (
         <Box width={accessorySpacerWidth} flexShrink={0} />
@@ -630,12 +750,14 @@ export function CompositeChart({
   emptyMessage = "No chart data",
   formatValue,
   onCursorDateChange,
+  onViewportChange,
   onActivate,
   onToggleSeries,
   isSeriesToggleable,
 }: CompositeChartProps) {
   const { cellWidthPx = 8 } = useUiCapabilities();
   const [internalCursorDate, setInternalCursorDate] = useState<Date | null>(null);
+  const [legendKeyboardIndex, setLegendKeyboardIndex] = useState<number | null>(null);
   const resolvedCursorDate = cursorDate === undefined ? internalCursorDate : cursorDate;
   const totalWidth = Math.max(1, Math.floor(width));
   const totalHeight = Math.max(1, Math.floor(height));
@@ -644,6 +766,17 @@ export function CompositeChart({
     () => (legendSeries ?? visibleSeries).filter((entry) => entry.points.length > 0),
     [legendSeries, visibleSeries],
   );
+  const visibleSeriesIds = useMemo(
+    () => new Set(visibleSeries.map((entry) => entry.id)),
+    [visibleSeries],
+  );
+  useEffect(() => {
+    setLegendKeyboardIndex((current) => (
+      current === null || visibleLegendSeries.length === 0
+        ? null
+        : Math.min(current, visibleLegendSeries.length - 1)
+    ));
+  }, [visibleLegendSeries.length]);
   const navigationBounds = useMemo(
     () => resolveCompositeNavigationBounds(visibleSeries, viewport),
     [viewport, visibleSeries],
@@ -666,12 +799,43 @@ export function CompositeChart({
     previousInitialViewportRef.current,
     initialViewport,
   );
-  const currentInteractionViewport = navigationBoundsChanged || initialViewportChanged ? null : interactionViewport;
+  const interactionViewportStillValid = !!interactionViewport
+    && !!navigationBounds
+    && sameCompositeViewport(
+      clampCompositeViewport(interactionViewport, navigationBounds),
+      interactionViewport,
+    );
+  const shouldResetInteractionViewport = initialViewportChanged
+    || (navigationBoundsChanged && !interactionViewportStillValid);
+  const currentInteractionViewport = shouldResetInteractionViewport ? null : interactionViewport;
   const effectiveViewport = navigationBounds
     ? currentInteractionViewport
       ? clampCompositeViewport(currentInteractionViewport, navigationBounds)
       : initialViewport
     : null;
+  const effectiveViewportStart = effectiveViewport?.start.getTime() ?? null;
+  const effectiveViewportEnd = effectiveViewport?.end.getTime() ?? null;
+  const viewportSeriesKey = visibleLegendSeries
+    .map((entry) => `${entry.id}:${entry.label}`)
+    .join("|");
+  const lastReportedViewportRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!onViewportChange) return;
+    const viewportKey = effectiveViewportStart === null || effectiveViewportEnd === null
+      ? "none"
+      : `${effectiveViewportStart}:${effectiveViewportEnd}`;
+    const key = `${viewportSeriesKey}|${viewportKey}`;
+    if (lastReportedViewportRef.current === key) return;
+    lastReportedViewportRef.current = key;
+    onViewportChange(
+      effectiveViewportStart === null || effectiveViewportEnd === null
+        ? null
+        : {
+            start: new Date(effectiveViewportStart),
+            end: new Date(effectiveViewportEnd),
+          },
+    );
+  }, [effectiveViewportEnd, effectiveViewportStart, onViewportChange, viewportSeriesKey]);
   const minimumViewportSpanMs = useMemo(
     () => navigationBounds ? resolveCompositeMinimumSpanMs(visibleSeries, navigationBounds) : 1,
     [navigationBounds, visibleSeries],
@@ -683,12 +847,20 @@ export function CompositeChart({
     previousNavigationBoundsRef.current = navigationBounds;
     previousInitialViewportRef.current = initialViewport;
     if (
-      shouldResetCompositeViewport(previousBounds, navigationBounds)
-      || shouldResetCompositeViewport(previousInitial, initialViewport)
+      shouldResetCompositeViewport(previousInitial, initialViewport)
+      || (
+        shouldResetCompositeViewport(previousBounds, navigationBounds)
+        && interactionViewport
+        && navigationBounds
+        && !sameCompositeViewport(
+          clampCompositeViewport(interactionViewport, navigationBounds),
+          interactionViewport,
+        )
+      )
     ) {
       setInteractionViewport(null);
     }
-  }, [initialViewport, navigationBounds]);
+  }, [initialViewport, interactionViewport, navigationBounds]);
 
   const zoomViewport = useCallback((zoomFactor: number, anchorRatio = 1) => {
     if (!navigationBounds || !initialViewport) return;
@@ -745,7 +917,8 @@ export function CompositeChart({
     width: 1,
     height: Math.max(panelCount, 1),
     viewport: effectiveViewport ?? undefined,
-  }), [effectiveViewport, panelCount, panels, visibleSeries]);
+    timelineSeries: visibleLegendSeries,
+  }), [effectiveViewport, panelCount, panels, visibleLegendSeries, visibleSeries]);
   const layoutPanels = useMemo<CompositePanelScene[] | null>(() => {
     if (!projectedScene) return null;
     const panelSpecById = new Map(panels.map((panel) => [panel.id, panel] as const));
@@ -802,6 +975,33 @@ export function CompositeChart({
 
   useShortcut((event) => {
     if (!focused || !interactive) return;
+    if (isPlainKey(event, "[", "]") && visibleLegendSeries.length > 0) {
+      event.preventDefault();
+      event.stopPropagation();
+      const direction = event.name === "[" ? -1 : 1;
+      setLegendKeyboardIndex((current) => (
+        current === null
+          ? direction > 0 ? 0 : visibleLegendSeries.length - 1
+          : (current + direction + visibleLegendSeries.length) % visibleLegendSeries.length
+      ));
+      onActivate?.();
+      return;
+    }
+    if (isPlainKey(event, "space") && legendKeyboardIndex !== null) {
+      const entry = visibleLegendSeries[legendKeyboardIndex];
+      if (!entry || !onToggleSeries || !(isSeriesToggleable?.(entry) ?? true)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      onActivate?.();
+      onToggleSeries(entry.id);
+      return;
+    }
+    if (isPlainKey(event, "escape") && legendKeyboardIndex !== null && !scene?.cursorDate) {
+      event.preventDefault();
+      event.stopPropagation();
+      setLegendKeyboardIndex(null);
+      return;
+    }
     const interaction = resolveCompositeChartInteraction(event);
     if (!interaction) return;
     if (
@@ -856,6 +1056,7 @@ export function CompositeChart({
           <CompositeLegend
             scene={null}
             series={[]}
+            visibleSeriesIds={new Set()}
             width={totalWidth}
             accessory={legendAccessory}
             accessoryWidth={legendAccessoryWidth}
@@ -863,6 +1064,7 @@ export function CompositeChart({
             onActivate={onActivate}
             onToggleSeries={onToggleSeries}
             isSeriesToggleable={isSeriesToggleable}
+            keyboardIndex={legendKeyboardIndex}
           />
         ) : null}
         {totalHeight > legendRows ? (
@@ -896,6 +1098,7 @@ export function CompositeChart({
         <CompositeLegend
           scene={scene}
           series={visibleLegendSeries}
+          visibleSeriesIds={visibleSeriesIds}
           width={totalWidth}
           accessory={legendAccessory}
           accessoryWidth={legendAccessoryWidth}
@@ -903,6 +1106,7 @@ export function CompositeChart({
           onActivate={onActivate}
           onToggleSeries={onToggleSeries}
           isSeriesToggleable={isSeriesToggleable}
+          keyboardIndex={legendKeyboardIndex}
         />
       ) : null}
       {scene.panels.map((panel) => (

--- a/src/components/chart/composite/format.test.ts
+++ b/src/components/chart/composite/format.test.ts
@@ -3,19 +3,24 @@ import type { CompositeChartScene } from "./types";
 import {
   formatCompositeAxisValue,
   formatCompositeCursorDate,
+  formatCompositePointDetails,
   formatCompositeSeriesValue,
   formatCompositeTimeAxisDate,
 } from "./format";
-import type { ResolvedSeries } from "../../../time-series/types";
+import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
 import { renderCompositeTimeAxis } from "./text-renderer";
 
 function scene(start: string, end: string): CompositeChartScene {
+  const startTime = Date.parse(start);
+  const endTime = Date.parse(end);
   return {
     width: 80,
     height: 10,
-    startTime: Date.parse(start),
-    endTime: Date.parse(end),
+    startTime,
+    endTime,
+    timeScale: { kind: "calendar", startTime, endTime },
     dates: [],
+    dateRatios: [],
     panels: [],
     cursorDate: null,
     cursorXRatio: null,
@@ -59,6 +64,45 @@ describe("composite chart timestamp formatting", () => {
     expect(formatCompositeTimeAxisDate(cursor, weekly.startTime, weekly.endTime)).toBe("2025-01-04");
     expect(renderCompositeTimeAxis(weekly, 60)).toContain("2025-01-01");
     expect(renderCompositeTimeAxis(weekly, 60)).toContain("2025-01-08");
+  });
+});
+
+describe("composite chart point details", () => {
+  test("disambiguates fiscal period, availability, and provenance", () => {
+    const point: TimeSeriesPoint = {
+      date: new Date("2025-03-14T00:00:00.000Z"),
+      observedAt: new Date("2025-01-26T00:00:00.000Z"),
+      availableAt: new Date("2025-03-14T00:00:00.000Z"),
+      value: 42,
+      periodLabel: "FY2025",
+      provenance: {
+        providerId: "sec-filings",
+        quality: "reported",
+      },
+    };
+
+    expect(formatCompositePointDetails(point)).toBe(
+      "FY2025 · Period ended 2025-01-26 · Available 2025-03-14 · Reported · Source sec-filings",
+    );
+  });
+
+  test("omits a duplicate availability date for ordinary observations", () => {
+    const observedAt = new Date("2025-01-02T00:00:00.000Z");
+    expect(formatCompositePointDetails({
+      date: observedAt,
+      observedAt,
+      availableAt: observedAt,
+      value: 10,
+    })).toBe("Observed 2025-01-02");
+  });
+
+  test("retains non-midnight observation and availability times", () => {
+    expect(formatCompositePointDetails({
+      date: new Date("2025-01-02T12:05:00.000Z"),
+      observedAt: new Date("2025-01-02T09:30:00.000Z"),
+      availableAt: new Date("2025-01-02T12:05:00.000Z"),
+      value: 10,
+    })).toBe("Observed 2025-01-02 09:30 UTC · Available 2025-01-02 12:05 UTC");
   });
 });
 

--- a/src/components/chart/composite/format.ts
+++ b/src/components/chart/composite/format.ts
@@ -1,4 +1,4 @@
-import type { ResolvedSeries } from "../../../time-series/types";
+import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
 import type { CompositeAxisDomain } from "./types";
 
 const CURRENCY_SYMBOLS: Record<string, string> = {
@@ -85,6 +85,43 @@ export function formatCompositeCursorDate(date: Date, startTime: number, endTime
   return isIntradaySpan(startTime, endTime)
     ? `${utcDate(date)} ${utcTime(date)} UTC`
     : utcDate(date);
+}
+
+function validUtcTimestamp(date: Date | undefined): string | null {
+  if (!date || !Number.isFinite(date.getTime())) return null;
+  return date.getUTCHours() === 0
+      && date.getUTCMinutes() === 0
+      && date.getUTCSeconds() === 0
+      && date.getUTCMilliseconds() === 0
+    ? utcDate(date)
+    : `${utcDate(date)} ${utcTime(date)} UTC`;
+}
+
+/**
+ * Concise, audit-friendly context for an observation. Kept separate from the
+ * visible legend so fiscal-period and availability metadata is available on
+ * demand without reducing chart density.
+ */
+export function formatCompositePointDetails(point: TimeSeriesPoint | null | undefined): string {
+  if (!point) return "";
+  const details: string[] = [];
+  const periodLabel = point.periodLabel?.trim();
+  const observedAt = validUtcTimestamp(point.observedAt);
+  const availableAt = validUtcTimestamp(point.availableAt);
+
+  if (periodLabel) details.push(periodLabel);
+  if (observedAt) {
+    const isFiscalPeriod = periodLabel && periodLabel.toLowerCase() !== "current";
+    details.push(`${isFiscalPeriod ? "Period ended" : "Observed"} ${observedAt}`);
+  }
+  if (availableAt && availableAt !== observedAt) details.push(`Available ${availableAt}`);
+
+  const quality = point.provenance?.quality;
+  if (quality) details.push(`${quality[0]!.toUpperCase()}${quality.slice(1)}`);
+  const providerId = point.provenance?.providerId?.trim();
+  if (providerId) details.push(`Source ${providerId}`);
+
+  return details.join(" · ");
 }
 
 /** Compact UTC tick label selected from the full visible chart span. */

--- a/src/components/chart/composite/price-series.ts
+++ b/src/components/chart/composite/price-series.ts
@@ -1,4 +1,11 @@
-import type { ResolvedSeries, SeriesPeriod, SeriesStyle, SeriesTransform, TimeSeriesPoint } from "../../../time-series/types";
+import type {
+  ResolvedSeries,
+  ResolvedSeriesMarketTimeBasis,
+  SeriesPeriod,
+  SeriesStyle,
+  SeriesTransform,
+  TimeSeriesPoint,
+} from "../../../time-series/types";
 import type { PricePoint } from "../../../types/financials";
 
 export interface PricePointsToResolvedSeriesOptions {
@@ -14,6 +21,7 @@ export interface PricePointsToResolvedSeriesOptions {
   panelId?: string;
   providerId?: string;
   warning?: string;
+  timeBasis?: ResolvedSeriesMarketTimeBasis;
 }
 
 function finiteOrNull(value: number | null | undefined): number | null {
@@ -61,6 +69,7 @@ export function pricePointsToResolvedSeries(
     axis: options.axis ?? "left",
     panelId: options.panelId ?? "main",
     interpolation: "none",
+    timeBasis: options.timeBasis,
     points: [...byTimestamp.values()].sort((left, right) => left.date.getTime() - right.date.getTime()),
     warning: options.warning,
   };

--- a/src/components/chart/composite/rasterizer.ts
+++ b/src/components/chart/composite/rasterizer.ts
@@ -6,7 +6,11 @@ import {
   parseHex,
   type RgbaColor,
 } from "../native/raster/primitives";
-import { buildCompositeColumnLayout, type CompositeColumnLayout } from "./column-layout";
+import {
+  buildCompositeColumnLayout,
+  type CompositeColumnGroupCenter,
+  type CompositeColumnLayout,
+} from "./column-layout";
 import { projectCompositeValue } from "./scene";
 import type {
   CompositeAxisDomain,
@@ -94,7 +98,11 @@ function median(values: number[]): number | null {
 }
 
 function observationGaps(points: CompositeProjectedPoint[], pixelWidth: number): number[] {
-  const xs = points.map((point) => point.xRatio * Math.max(pixelWidth - 1, 0)).sort((left, right) => left - right);
+  return ratioGaps(points.map((point) => point.xRatio), pixelWidth);
+}
+
+function ratioGaps(ratios: readonly number[], pixelWidth: number): number[] {
+  const xs = ratios.map((ratio) => ratio * Math.max(pixelWidth - 1, 0)).sort((left, right) => left - right);
   const positiveGaps: number[] = [];
   for (let index = 1; index < xs.length; index += 1) {
     const gap = xs[index]! - xs[index - 1]!;
@@ -109,12 +117,46 @@ function observationWidth(points: CompositeProjectedPoint[], pixelWidth: number,
 }
 
 function columnObservationWidth(
-  points: CompositeProjectedPoint[],
+  ratios: readonly number[],
   pixelWidth: number,
   maximum: number,
 ): number {
-  const typicalGap = median(observationGaps(points, pixelWidth));
+  const typicalGap = median(ratioGaps(ratios, pixelWidth));
   return clamp(typicalGap === null ? maximum : typicalGap * 0.58, 2, maximum);
+}
+
+function columnCenterGaps(
+  centers: readonly CompositeColumnGroupCenter[],
+  pixelWidth: number,
+): number[] {
+  const scale = Math.max(pixelWidth - 1, 0);
+  const positiveGaps: number[] = [];
+  for (let index = 1; index < centers.length; index += 1) {
+    const previous = centers[index - 1]!;
+    const current = centers[index]!;
+    const ordinalGap = previous.ordinal !== null
+      && current.ordinal !== null
+      && current.ordinal > previous.ordinal
+      ? current.ordinal - previous.ordinal
+      : 1;
+    const gap = (current.xRatio - previous.xRatio) * scale / ordinalGap;
+    if (gap > 0) positiveGaps.push(gap);
+  }
+  return positiveGaps;
+}
+
+function columnWidthFromCenters(
+  centers: readonly CompositeColumnGroupCenter[],
+  pixelWidth: number,
+  maximum: number,
+): number {
+  const typicalGap = median(columnCenterGaps(centers, pixelWidth));
+  return clamp(typicalGap === null ? maximum : typicalGap * 0.58, 2, maximum);
+}
+
+function maximumColumnClusterWidth(pixelWidth: number, seriesCount: number): number {
+  const maximumSlotWidth = clamp(pixelWidth * 0.04, 18, 72);
+  return maximumSlotWidth * Math.max(1, seriesCount);
 }
 
 export function resolveCompositeColumnWidth(
@@ -122,7 +164,7 @@ export function resolveCompositeColumnWidth(
   pixelWidth: number,
 ): number {
   const maximum = clamp(pixelWidth * 0.04, 18, 72);
-  return columnObservationWidth(points, pixelWidth, maximum);
+  return columnObservationWidth(points.map((point) => point.xRatio), pixelWidth, maximum);
 }
 
 export function resolveCompositeOhlcWidth(
@@ -130,6 +172,39 @@ export function resolveCompositeOhlcWidth(
   pixelWidth: number,
 ): number {
   return observationWidth(points, pixelWidth, 9);
+}
+
+function columnPixelGeometry(
+  projected: CompositeProjectedPoint,
+  width: number,
+  layout: CompositeColumnLayout,
+  widthByFamily: ReadonlyMap<string, number>,
+): { x: number; width: number } {
+  const group = layout.groupByPoint.get(projected) ?? {
+    index: 0,
+    count: 1,
+    xRatio: projected.xRatio,
+    familyKey: "",
+  };
+  const maximum = maximumColumnClusterWidth(width, group.count);
+  const clusterWidth = widthByFamily.get(group.familyKey) ?? maximum;
+  const drawableWidth = Math.min(clusterWidth, Math.max(width - 1, 1));
+  const slotWidth = drawableWidth / group.count;
+  const columnWidth = group.count === 1 ? slotWidth : slotWidth * 0.78;
+  const groupCenter = clamp(
+    group.xRatio * Math.max(width - 1, 0),
+    0,
+    Math.max(width - 1, 0),
+  );
+  const clusterLeft = clamp(
+    groupCenter - drawableWidth / 2,
+    0,
+    Math.max(width - 1 - drawableWidth, 0),
+  );
+  return {
+    x: clusterLeft + slotWidth * (group.index + 0.5),
+    width: columnWidth,
+  };
 }
 
 function drawColumns(
@@ -140,51 +215,20 @@ function drawColumns(
   domain: CompositeAxisDomain,
   color: RgbaColor,
   layout: CompositeColumnLayout,
+  widthByFamily: ReadonlyMap<string, number>,
   opacity: number,
 ): void {
   const baseline = pixelY(0, domain, height) ?? height - 1;
-  const singleSeriesWidth = resolveCompositeColumnWidth(series.points, width);
-  const hasGroupedObservations = series.points.some((point) => (
-    (layout.groupByPoint.get(point)?.count ?? 1) > 1
-  ));
-  const groupedSeriesWidth = hasGroupedObservations
-    ? resolveCompositeColumnWidth(layout.pointsByAxis[series.source.axis], width)
-    : singleSeriesWidth;
   for (const projected of series.points) {
     const point = pixelPoint(projected, width, height);
-    const group = layout.groupByPoint.get(projected) ?? { index: 0, count: 1 };
-    const clusterWidth = group.count > 1 ? groupedSeriesWidth : singleSeriesWidth;
-    if (group.count === 1) {
-      fillRect(
-        data,
-        width,
-        height,
-        point.x - clusterWidth / 2,
-        Math.min(point.y, baseline),
-        point.x + clusterWidth / 2,
-        Math.max(point.y, baseline),
-        color,
-        opacity,
-      );
-      continue;
-    }
-
-    const drawableWidth = Math.min(clusterWidth, Math.max(width - 1, 1));
-    const slotWidth = drawableWidth / group.count;
-    const columnWidth = slotWidth * 0.78;
-    const clusterLeft = clamp(
-      point.x - drawableWidth / 2,
-      0,
-      Math.max(width - 1 - drawableWidth, 0),
-    );
-    const columnCenter = clusterLeft + slotWidth * (group.index + 0.5);
+    const geometry = columnPixelGeometry(projected, width, layout, widthByFamily);
     fillRect(
       data,
       width,
       height,
-      columnCenter - columnWidth / 2,
+      geometry.x - geometry.width / 2,
       Math.min(point.y, baseline),
-      columnCenter + columnWidth / 2,
+      geometry.x + geometry.width / 2,
       Math.max(point.y, baseline),
       color,
       opacity,
@@ -259,6 +303,17 @@ export function renderCompositePanelBitmap(
     return rank(left.source.style) - rank(right.source.style);
   });
   const columnLayout = buildCompositeColumnLayout(panel);
+  const columnWidthByFamily = new Map<string, number>();
+  for (const [family, centers] of columnLayout.centersByFamily) {
+    const maximumColumnWidth = maximumColumnClusterWidth(
+      width,
+      columnLayout.seriesCountByFamily.get(family) ?? 1,
+    );
+    columnWidthByFamily.set(
+      family,
+      columnWidthFromCenters(centers, width, maximumColumnWidth),
+    );
+  }
   const mixesColumnsWithOtherMarks = panel.series.some((series) => series.source.style === "columns")
     && panel.series.some((series) => series.source.style !== "columns");
   for (const series of ordered) {
@@ -275,6 +330,7 @@ export function renderCompositePanelBitmap(
           domain,
           color,
           columnLayout,
+          columnWidthByFamily,
           mixesColumnsWithOtherMarks ? 0.48 : 0.72,
         );
         break;

--- a/src/components/chart/composite/renderers.test.ts
+++ b/src/components/chart/composite/renderers.test.ts
@@ -5,6 +5,7 @@ import {
   resolveCompositeColumnWidth,
   resolveCompositeOhlcWidth,
 } from "./rasterizer";
+import { buildCompositeColumnLayout } from "./column-layout";
 import { buildCompositeChartScene } from "./scene";
 import { renderCompositePanelText } from "./text-renderer";
 
@@ -34,6 +35,22 @@ function series(
     panelId: "main",
     interpolation: style === "step" ? "step-after" : "none",
     points: values.map((value, index) => point(`2025-01-0${index + 1}`, value)),
+  };
+}
+
+function periodSeries(
+  id: string,
+  nativeFrequency: "annual" | "quarterly",
+  observations: Array<{ date: string; periodLabel: string; value?: number }>,
+  color = "#00ff66",
+): ResolvedSeries {
+  return {
+    ...series(id, "columns", [], "left", color),
+    nativeFrequency,
+    points: observations.map(({ date, periodLabel, value = 5 }) => ({
+      ...point(date, value),
+      periodLabel,
+    })),
   };
 }
 
@@ -94,6 +111,282 @@ describe("composite chart renderers", () => {
     expect(Math.max(...greenXs)).toBeLessThan(Math.min(...orangeXs));
   });
 
+  test("groups offset annual and quarterly fiscal closes into stable cohort lanes", () => {
+    const cases = [
+      {
+        frequency: "annual" as const,
+        first: [
+          { date: "2024-01-28", periodLabel: "FY2024" },
+          { date: "2025-01-26", periodLabel: "FY2025" },
+        ],
+        second: [
+          { date: "2023-12-31", periodLabel: "FY2023" },
+          { date: "2024-12-31", periodLabel: "FY2024" },
+        ],
+      },
+      {
+        frequency: "quarterly" as const,
+        first: [
+          { date: "2024-01-28", periodLabel: "2024 Q1" },
+          { date: "2024-04-28", periodLabel: "2024 Q2" },
+        ],
+        second: [
+          { date: "2023-12-31", periodLabel: "2023 Q4" },
+          { date: "2024-03-31", periodLabel: "2024 Q1" },
+        ],
+      },
+    ];
+
+    for (const fixture of cases) {
+      const scene = buildCompositeChartScene(
+        [
+          periodSeries("offset-calendar", fixture.frequency, fixture.first),
+          periodSeries("calendar", fixture.frequency, fixture.second),
+        ],
+        [{ id: "main" }],
+        {
+          width: 61,
+          height: 9,
+          viewport: {
+            start: new Date("2023-10-01T00:00:00.000Z"),
+            end: new Date("2025-03-01T00:00:00.000Z"),
+          },
+        },
+      )!;
+      const panel = scene.panels[0]!;
+      const layout = buildCompositeColumnLayout(panel);
+      const firstPoints = panel.series[0]!.points;
+      const secondPoints = panel.series[1]!.points;
+
+      for (let index = 0; index < firstPoints.length; index += 1) {
+        const firstSlot = layout.groupByPoint.get(firstPoints[index]!)!;
+        const secondSlot = layout.groupByPoint.get(secondPoints[index]!)!;
+        expect(firstSlot.xRatio).toBe(secondSlot.xRatio);
+        expect([firstSlot.index, secondSlot.index]).toEqual([0, 1]);
+        expect([firstSlot.count, secondSlot.count]).toEqual([2, 2]);
+      }
+    }
+  });
+
+  test("keeps absent observations as empty lanes instead of widening nearby bars", () => {
+    const scene = buildCompositeChartScene(
+      [
+        periodSeries("partial", "annual", [
+          { date: "2024-01-28", periodLabel: "FY2024" },
+          { date: "2026-01-25", periodLabel: "FY2026" },
+        ]),
+        periodSeries("complete", "annual", [
+          { date: "2023-12-31", periodLabel: "FY2023" },
+          { date: "2024-12-31", periodLabel: "FY2024" },
+          { date: "2025-12-31", periodLabel: "FY2025" },
+        ]),
+      ],
+      [{ id: "main" }],
+      { width: 81, height: 9 },
+    )!;
+    const panel = scene.panels[0]!;
+    const layout = buildCompositeColumnLayout(panel);
+    const completeSlots = panel.series[1]!.points.map((point) => layout.groupByPoint.get(point)!);
+
+    expect(completeSlots.map(({ index }) => index)).toEqual([1, 1, 1]);
+    expect(completeSlots.map(({ count }) => count)).toEqual([2, 2, 2]);
+  });
+
+  test("keeps availability-timed financial columns on their actual dates", () => {
+    const observedAt = new Date("2024-03-31T00:00:00.000Z");
+    const firstAvailableAt = new Date("2024-04-15T00:00:00.000Z");
+    const secondAvailableAt = new Date("2024-05-01T00:00:00.000Z");
+    const first = periodSeries("first-filing", "quarterly", []);
+    const second = periodSeries("second-filing", "quarterly", []);
+    first.timestampMode = "available-at";
+    second.timestampMode = "available-at";
+    first.points = [{
+      date: firstAvailableAt,
+      observedAt,
+      availableAt: firstAvailableAt,
+      periodLabel: "2024 Q1",
+      value: 5,
+    }];
+    second.points = [{
+      date: secondAvailableAt,
+      observedAt,
+      availableAt: secondAvailableAt,
+      periodLabel: "2024 Q1",
+      value: 6,
+    }];
+
+    const scene = buildCompositeChartScene(
+      [first, second],
+      [{ id: "main" }],
+      {
+        width: 61,
+        height: 9,
+        viewport: {
+          start: new Date("2024-03-01T00:00:00.000Z"),
+          end: new Date("2024-06-01T00:00:00.000Z"),
+        },
+      },
+    )!;
+    const panel = scene.panels[0]!;
+    const firstPoint = panel.series[0]!.points[0]!;
+    const secondPoint = panel.series[1]!.points[0]!;
+    const layout = buildCompositeColumnLayout(panel);
+    const firstSlot = layout.groupByPoint.get(firstPoint)!;
+    const secondSlot = layout.groupByPoint.get(secondPoint)!;
+
+    expect(firstSlot.xRatio).toBe(firstPoint.xRatio);
+    expect(secondSlot.xRatio).toBe(secondPoint.xRatio);
+    expect(firstSlot.xRatio).not.toBe(secondSlot.xRatio);
+    expect([firstSlot.count, secondSlot.count]).toEqual([1, 1]);
+  });
+
+  test("rasterizes offset annual cohorts as non-overlapping equal-width bars", () => {
+    const scene = buildCompositeChartScene(
+      [
+        periodSeries("january-close", "annual", [
+          { date: "2024-01-28", periodLabel: "FY2024" },
+          { date: "2025-01-26", periodLabel: "FY2025" },
+          { date: "2026-01-25", periodLabel: "FY2026" },
+        ], "#00ff00"),
+        periodSeries("june-close", "annual", [
+          { date: "2023-06-30", periodLabel: "FY2023" },
+          { date: "2024-06-30", periodLabel: "FY2024" },
+          { date: "2025-06-30", periodLabel: "FY2025" },
+        ], "#ff0000"),
+        periodSeries("december-close", "annual", [
+          { date: "2023-12-31", periodLabel: "FY2023" },
+          { date: "2024-12-31", periodLabel: "FY2024" },
+          { date: "2025-12-31", periodLabel: "FY2025" },
+        ], "#0000ff"),
+      ],
+      [{ id: "main" }],
+      {
+        width: 101,
+        height: 12,
+        viewport: {
+          start: new Date("2023-01-01T00:00:00.000Z"),
+          end: new Date("2026-03-01T00:00:00.000Z"),
+        },
+      },
+    )!;
+    const bitmap = renderCompositePanelBitmap(scene.panels[0]!, {
+      pixelWidth: 401,
+      pixelHeight: 80,
+      colors: {
+        background: "#000000",
+        grid: "#000000",
+        crosshair: "#ffffff",
+        text: "#eeeeee",
+        textDim: "#999999",
+        negative: "#ff0000",
+      },
+    });
+    const runsForChannel = (channel: 0 | 1 | 2): Array<{ start: number; end: number }> => {
+      const occupied: number[] = [];
+      const y = 40;
+      for (let x = 0; x < bitmap.width; x += 1) {
+        const offset = (y * bitmap.width + x) * 4;
+        const value = bitmap.pixels[offset + channel]!;
+        const otherChannels = [0, 1, 2].filter((candidate) => candidate !== channel);
+        if (otherChannels.every((candidate) => value > bitmap.pixels[offset + candidate]! * 2)) {
+          occupied.push(x);
+        }
+      }
+      return occupied.reduce<Array<{ start: number; end: number }>>((runs, x) => {
+        const current = runs.at(-1);
+        if (current && x === current.end + 1) current.end = x;
+        else runs.push({ start: x, end: x });
+        return runs;
+      }, []);
+    };
+    const greenRuns = runsForChannel(1);
+    const redRuns = runsForChannel(0);
+    const blueRuns = runsForChannel(2);
+
+    expect([greenRuns.length, redRuns.length, blueRuns.length]).toEqual([3, 3, 3]);
+    for (let index = 0; index < 3; index += 1) {
+      const runs = [greenRuns[index]!, redRuns[index]!, blueRuns[index]!];
+      expect(runs[0]!.end).toBeLessThan(runs[1]!.start);
+      expect(runs[1]!.end).toBeLessThan(runs[2]!.start);
+      const widths = runs.map(({ start, end }) => end - start + 1);
+      expect(Math.max(...widths) - Math.min(...widths)).toBeLessThanOrEqual(1);
+      expect(Math.min(...widths)).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  test("keeps six-series annual bars visibly wide without merging their lanes", () => {
+    const colors = ["#ff0000", "#00ff00", "#0000ff", "#ffff00", "#ff00ff", "#00ffff"];
+    const fiscalCloses = [
+      ["2024-01-28", "2025-01-26", "2026-01-25"],
+      ["2023-06-30", "2024-06-30", "2025-06-30"],
+      ["2023-09-30", "2024-09-28", "2025-09-27"],
+      ["2023-12-15", "2024-12-15", "2025-12-15"],
+      ["2023-12-28", "2024-12-28", "2025-12-27"],
+      ["2023-12-31", "2024-12-31", "2025-12-31"],
+    ];
+    const scene = buildCompositeChartScene(
+      fiscalCloses.map((dates, seriesIndex) => periodSeries(
+        `series-${seriesIndex}`,
+        "annual",
+        dates.map((date, periodIndex) => ({
+          date,
+          periodLabel: `FY${2023 + periodIndex + (seriesIndex === 0 ? 1 : 0)}`,
+        })),
+        colors[seriesIndex],
+      )),
+      [{ id: "main" }],
+      {
+        width: 180,
+        height: 12,
+        viewport: {
+          start: new Date("2023-01-01T00:00:00.000Z"),
+          end: new Date("2026-03-01T00:00:00.000Z"),
+        },
+      },
+    )!;
+    const bitmap = renderCompositePanelBitmap(scene.panels[0]!, {
+      pixelWidth: 2_880,
+      pixelHeight: 80,
+      colors: {
+        background: "#000000",
+        grid: "#000000",
+        crosshair: "#ffffff",
+        text: "#eeeeee",
+        textDim: "#999999",
+        negative: "#ff0000",
+      },
+    });
+    const y = 40;
+    const xsByMask = new Map<number, number[]>();
+    for (let x = 0; x < bitmap.width; x += 1) {
+      const offset = (y * bitmap.width + x) * 4;
+      const mask = [0, 1, 2].reduce((value, channel) => (
+        bitmap.pixels[offset + channel]! > 20 ? value | (1 << channel) : value
+      ), 0);
+      if (mask > 0) {
+        const xs = xsByMask.get(mask);
+        if (xs) xs.push(x);
+        else xsByMask.set(mask, [x]);
+      }
+    }
+    const widths = [1, 2, 4, 3, 5, 6].flatMap((mask) => {
+      const runs = (xsByMask.get(mask) ?? []).reduce<Array<{ start: number; end: number }>>(
+        (result, x) => {
+          const current = result.at(-1);
+          if (current && x === current.end + 1) current.end = x;
+          else result.push({ start: x, end: x });
+          return result;
+        },
+        [],
+      );
+      expect(runs).toHaveLength(3);
+      return runs.map(({ start, end }) => end - start + 1);
+    });
+
+    expect(Math.min(...widths)).toBeGreaterThanOrEqual(16);
+    expect(Math.max(...widths) - Math.min(...widths)).toBeLessThanOrEqual(1);
+  });
+
   test("keeps a lone column series centered on its observation dates", () => {
     const scene = buildCompositeChartScene(
       [series("only", "columns", [5, 6, 5], "left")],
@@ -144,6 +437,42 @@ describe("composite chart renderers", () => {
     expect(output).toContain("█");
     expect(output).toContain("•");
     expect(output).toMatch(/[│┼]/);
+  });
+
+  test("draws columns beneath line marks in the text fallback regardless of authored order", () => {
+    const scene = buildCompositeChartScene(
+      [
+        series("price", "line", [5, 6, 5], "left"),
+        series("revenue", "columns", [5, 6, 5], "left"),
+      ],
+      [{ id: "main" }],
+      { width: 31, height: 9 },
+    )!;
+    const panel = scene.panels[0]!;
+    const linePoint = panel.series[0]!.points[1]!;
+    const x = Math.round(linePoint.xRatio * (scene.width - 1));
+    const y = Math.round(linePoint.yRatio * (panel.height - 1));
+
+    const rows = renderCompositePanelText(panel, scene.width, null, null);
+
+    expect(rows[y]![x]).toBe("•");
+  });
+
+  test("renders point series without connecting their observations", () => {
+    const scene = buildCompositeChartScene(
+      [series("events", "points", [2, 8, 3], "left")],
+      [{ id: "main" }],
+      { width: 31, height: 9 },
+    )!;
+
+    const output = renderCompositePanelText(
+      scene.panels[0]!,
+      scene.width,
+      null,
+      null,
+    ).join("\n");
+    expect(output).toContain("●");
+    expect(output).not.toContain("•");
   });
 
   test("rasterizes a fully opaque native bitmap of the plotted series", () => {

--- a/src/components/chart/composite/scene.test.ts
+++ b/src/components/chart/composite/scene.test.ts
@@ -8,6 +8,7 @@ import {
   resolveCompositeCursorDate,
   unprojectCompositeValue,
 } from "./scene";
+import { buildCompositeColumnLayout } from "./column-layout";
 
 function point(date: string, value: number): TimeSeriesPoint {
   const observedAt = new Date(`${date}T00:00:00.000Z`);
@@ -28,6 +29,8 @@ function series(overrides: Partial<ResolvedSeries> & Pick<ResolvedSeries, "id" |
     axis: overrides.axis ?? "left",
     panelId: overrides.panelId ?? "main",
     interpolation: overrides.interpolation ?? "none",
+    timestampMode: overrides.timestampMode,
+    timeBasis: overrides.timeBasis,
     points: overrides.points,
     warning: overrides.warning,
   };
@@ -149,6 +152,26 @@ describe("composite chart scene", () => {
       [{ id: "one", height: 3 }, { id: "two", height: 1 }, { id: "three", height: 1 }],
       4,
     )).toEqual(new Map([["one", 2], ["two", 1], ["three", 1]]));
+    expect(allocateCompositePanelHeights(
+      [{ id: "primary", height: 2 }, { id: "secondary", height: 1 }],
+      4,
+    )).toEqual(new Map([["primary", 3], ["secondary", 1]]));
+  });
+
+  test("uses one last-write-wins policy for duplicate timestamps", () => {
+    const duplicate = series({
+      id: "duplicate",
+      points: [
+        point("2025-01-01", 10),
+        { ...point("2025-01-01", 10), value: null, close: null },
+      ],
+    });
+
+    expect(buildCompositeChartScene(
+      [duplicate],
+      [{ id: "main" }],
+      { width: 40, height: 8 },
+    )).toBeNull();
   });
 
   test("preserves explicit viewport bounds when observations are sparse", () => {
@@ -243,6 +266,177 @@ describe("composite chart scene", () => {
     expect(betweenDaily?.cursorDate?.toISOString()).toBe("2025-01-02T00:00:00.000Z");
     expect(betweenDaily?.cursorValues.find((entry) => entry.seriesId === "daily")?.value).toBe(20);
     expect(betweenDaily?.cursorValues.find((entry) => entry.seriesId === "quarterly")?.value).toBe(100);
+  });
+
+  test("places a filing on its first eligible market slot without changing source timestamps", () => {
+    const price = series({
+      id: "price",
+      dataShape: "ohlcv",
+      timeBasis: {
+        kind: "market",
+        timeZone: "America/New_York",
+        cadenceMs: 60 * 60 * 1_000,
+      },
+      points: [
+        point("2025-01-03", 100),
+        { ...point("2025-01-03", 101), date: new Date("2025-01-03T16:00:00.000Z"), observedAt: new Date("2025-01-03T16:00:00.000Z") },
+        { ...point("2025-01-06", 102), date: new Date("2025-01-06T14:00:00.000Z"), observedAt: new Date("2025-01-06T14:00:00.000Z") },
+        { ...point("2025-01-06", 103), date: new Date("2025-01-06T15:00:00.000Z"), observedAt: new Date("2025-01-06T15:00:00.000Z") },
+      ],
+    });
+    const observedAt = new Date("2024-12-31T00:00:00.000Z");
+    const availableAt = new Date("2025-01-04T12:05:00.000Z");
+    const filingPoint: TimeSeriesPoint = {
+      date: observedAt,
+      observedAt,
+      availableAt,
+      value: 500,
+      periodLabel: "2024 Q4",
+    };
+    const filing = series({
+      id: "filing",
+      style: "columns",
+      nativeFrequency: "quarterly",
+      timestampMode: "period-end",
+      points: [filingPoint],
+    });
+    const viewport = {
+      start: new Date("2025-01-03T00:00:00.000Z"),
+      end: new Date("2025-01-06T15:00:00.000Z"),
+    };
+    const friday = buildCompositeChartScene(
+      [price, filing],
+      [{ id: "main" }],
+      { width: 101, height: 10, viewport, cursorDate: new Date("2025-01-03T16:00:00.000Z") },
+    )!;
+
+    const pricePoints = friday.panels[0]!.series.find((entry) => entry.source.id === "price")!.points;
+    const filingProjected = friday.panels[0]!.series.find((entry) => entry.source.id === "filing")!.points[0]!;
+    const mondayPrice = pricePoints.find((entry) => entry.timestamp === Date.parse("2025-01-06T14:00:00.000Z"))!;
+    expect(filingProjected.xRatio).toBe(mondayPrice.xRatio);
+    expect(filingProjected.xSlot).toBe(mondayPrice.xSlot);
+    expect(filingProjected.point.date).toBe(observedAt);
+    expect(filingProjected.point.observedAt).toBe(observedAt);
+    expect(filingProjected.point.availableAt).toBe(availableAt);
+    expect(friday.cursorValues.find((entry) => entry.seriesId === "filing")?.value).toBeNull();
+
+    const monday = applyCompositeChartCursor(friday, new Date("2025-01-06T14:00:00.000Z"));
+    expect(monday.cursorValues.find((entry) => entry.seriesId === "filing")?.value).toBe(500);
+    expect(monday.dates.map((date) => date.getUTCDay())).not.toContain(6);
+  });
+
+  test("does not expose a filing whose availability is after the market viewport", () => {
+    const price = series({
+      id: "price",
+      timeBasis: {
+        kind: "market",
+        timeZone: "America/New_York",
+        cadenceMs: 24 * 60 * 60 * 1_000,
+      },
+      points: [point("2025-01-03", 100), point("2025-01-06", 102)],
+    });
+    const filing = series({
+      id: "filing",
+      style: "columns",
+      points: [{
+        ...point("2025-01-03", 500),
+        availableAt: new Date("2025-01-07T12:00:00.000Z"),
+      }],
+    });
+    const scene = buildCompositeChartScene(
+      [price, filing],
+      [{ id: "main" }],
+      {
+        width: 80,
+        height: 10,
+        viewport: {
+          start: new Date("2025-01-03T00:00:00.000Z"),
+          end: new Date("2025-01-06T23:59:59.999Z"),
+        },
+      },
+    );
+
+    expect(scene?.panels[0]?.series.some((entry) => entry.source.id === "filing")).toBe(false);
+  });
+
+  test("groups publications that snap to the same market slot into adjacent lanes", () => {
+    const price = series({
+      id: "price",
+      timeBasis: {
+        kind: "market",
+        timeZone: "America/New_York",
+        cadenceMs: 24 * 60 * 60 * 1_000,
+      },
+      points: [point("2025-01-03", 100), point("2025-01-06", 102), point("2025-01-07", 104)],
+    });
+    const filing = (id: string, availableAt: string) => series({
+      id,
+      style: "columns",
+      nativeFrequency: "quarterly",
+      timestampMode: "period-end",
+      unitGroup: "currency-total",
+      points: [{
+        ...point("2024-12-31", id === "revenue" ? 500 : 100),
+        availableAt: new Date(availableAt),
+        periodLabel: "2024 Q4",
+      }],
+    });
+    const scene = buildCompositeChartScene(
+      [price, filing("revenue", "2025-01-04T12:00:00.000Z"), filing("income", "2025-01-05T12:00:00.000Z")],
+      [{ id: "main" }],
+      { width: 80, height: 10 },
+    )!;
+    const panel = scene.panels[0]!;
+    const columns = panel.series.filter((entry) => entry.source.style === "columns");
+    const first = columns[0]!.points[0]!;
+    const second = columns[1]!.points[0]!;
+    const layout = buildCompositeColumnLayout(panel);
+
+    expect(first.xSlot).toBe(second.xSlot);
+    expect(layout.groupByPoint.get(first)).toMatchObject({ index: 0, count: 2 });
+    expect(layout.groupByPoint.get(second)).toMatchObject({ index: 1, count: 2 });
+  });
+
+  test("retains the authored primary market scale when its plotted series is hidden", () => {
+    const anchor = series({
+      id: "primary-price",
+      timeBasis: {
+        kind: "market",
+        timeZone: "America/New_York",
+        cadenceMs: 60 * 60 * 1_000,
+      },
+      points: [
+        { ...point("2025-01-03", 100), date: new Date("2025-01-03T16:00:00.000Z") },
+        { ...point("2025-01-06", 101), date: new Date("2025-01-06T14:00:00.000Z") },
+      ],
+    });
+    const filing = series({
+      id: "filing",
+      style: "columns",
+      points: [{
+        ...point("2024-12-31", 500),
+        availableAt: new Date("2025-01-04T12:00:00.000Z"),
+      }],
+    });
+    const scene = buildCompositeChartScene(
+      [filing],
+      [{ id: "main" }],
+      {
+        width: 80,
+        height: 10,
+        viewport: {
+          start: new Date("2025-01-03T00:00:00.000Z"),
+          end: new Date("2025-01-06T23:59:59.999Z"),
+        },
+        timelineSeries: [anchor, filing],
+      },
+    );
+
+    expect(scene?.timeScale).toMatchObject({
+      kind: "market",
+      anchorSeriesId: "primary-price",
+    });
+    expect(scene?.panels[0]?.series[0]?.points[0]?.xSlot).toBe(1);
   });
 
   test("hydrates cursor values without rebuilding projected panels", () => {

--- a/src/components/chart/composite/scene.ts
+++ b/src/components/chart/composite/scene.ts
@@ -4,6 +4,7 @@ import type {
   ResolvedSeries,
   TimeSeriesPoint,
 } from "../../../time-series/types";
+import { effectiveTimeSeriesPointTime } from "../../../time-series/alignment";
 import type {
   BuildCompositeChartSceneOptions,
   CompositeAxisDomain,
@@ -13,6 +14,12 @@ import type {
   CompositePanelScene,
   CompositeProjectedPoint,
 } from "./types";
+import {
+  buildCompositeTimeScale,
+  projectCompositeTimestamp,
+  unprojectCompositeTimestamp,
+} from "./time-scale";
+import type { CompositeTimeScale } from "./types";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -31,29 +38,50 @@ function pointTime(point: TimeSeriesPoint): number | null {
   return Number.isFinite(time) ? time : null;
 }
 
-function normalizedPoints(series: ResolvedSeries): Array<{ point: TimeSeriesPoint; timestamp: number; value: number }> {
-  const byTimestamp = new Map<number, { point: TimeSeriesPoint; timestamp: number; value: number }>();
-  for (const point of series.points) {
-    const timestamp = pointTime(point);
-    const value = resolveTimeSeriesPointValue(point);
-    if (timestamp === null || value === null) continue;
-    byTimestamp.set(timestamp, { point, timestamp, value });
-  }
-  return [...byTimestamp.values()].sort((left, right) => left.timestamp - right.timestamp);
+function pointTimestampForScale(
+  series: ResolvedSeries,
+  point: TimeSeriesPoint,
+  timeScale?: CompositeTimeScale,
+): number | null {
+  const timestamp = pointTime(point);
+  if (timestamp === null) return null;
+  return timeScale?.kind === "market" && !series.timeBasis
+    ? effectiveTimeSeriesPointTime(point)
+    : timestamp;
 }
 
-function normalizedSourcePoints(series: ResolvedSeries): Array<{
+function normalizedSourcePoints(series: ResolvedSeries, timeScale?: CompositeTimeScale): Array<{
   point: TimeSeriesPoint;
   timestamp: number;
   value: number | null;
 }> {
-  const byTimestamp = new Map<number, { point: TimeSeriesPoint; timestamp: number; value: number | null }>();
+  const bySourceTimestamp = new Map<number, { point: TimeSeriesPoint; timestamp: number; value: number | null }>();
   for (const point of series.points) {
-    const timestamp = pointTime(point);
-    if (timestamp === null) continue;
-    byTimestamp.set(timestamp, { point, timestamp, value: resolveTimeSeriesPointValue(point) });
+    const sourceTimestamp = pointTime(point);
+    const timestamp = pointTimestampForScale(series, point, timeScale);
+    if (sourceTimestamp === null || timestamp === null || !Number.isFinite(timestamp)) continue;
+    bySourceTimestamp.set(sourceTimestamp, {
+      point,
+      timestamp,
+      value: resolveTimeSeriesPointValue(point),
+    });
   }
-  return [...byTimestamp.values()].sort((left, right) => left.timestamp - right.timestamp);
+  return [...bySourceTimestamp.values()].sort((left, right) => (
+    left.timestamp - right.timestamp
+    || left.point.date.getTime() - right.point.date.getTime()
+  ));
+}
+
+function normalizedPoints(series: ResolvedSeries): Array<{
+  point: TimeSeriesPoint;
+  timestamp: number;
+  value: number;
+}> {
+  return normalizedSourcePoints(series).flatMap((entry) => (
+    entry.value === null
+      ? []
+      : [{ ...entry, value: entry.value }]
+  ));
 }
 
 function explicitViewport(
@@ -70,12 +98,20 @@ function scopeSeriesToViewport(
   series: ResolvedSeries,
   startTime: number,
   endTime: number,
+  timeScale: CompositeTimeScale,
 ): ResolvedSeries | null {
-  const points = normalizedSourcePoints(series);
-  const visible = points.filter(({ timestamp }) => timestamp >= startTime && timestamp <= endTime);
+  const points = normalizedSourcePoints(series, timeScale);
+  const placement = timeScale.kind === "market" && !series.timeBasis
+    ? "next-market-slot" as const
+    : "timestamp" as const;
+  const visible = points.filter(({ timestamp }) => {
+    if (timestamp >= startTime && timestamp <= endTime) return true;
+    const projected = projectCompositeTimestamp(timeScale, timestamp, placement);
+    return !!projected && projected.ratio >= 0 && projected.ratio <= 1;
+  });
   if (series.interpolation === "step-after" || series.style === "step") {
     const anchor = [...points].reverse().find(({ timestamp, value }) => timestamp < startTime && value !== null);
-    if (anchor) visible.unshift(anchor);
+    if (anchor && !visible.includes(anchor)) visible.unshift(anchor);
   }
   return visible.some(({ value }) => value !== null)
     ? { ...series, points: visible.map(({ point }) => point) }
@@ -106,16 +142,30 @@ export function allocateCompositePanelHeights(
     finiteNumber(panel.height) && panel.height > 0 ? panel.height : 1
   ));
   const totalWeight = weights.reduce((sum, weight) => sum + weight, 0) || panels.length;
-  const allocations = weights.map((weight) => Math.max(1, Math.floor((weight / totalWeight) * totalHeight)));
+  const quotas = weights.map((weight) => (weight / totalWeight) * totalHeight);
+  const allocations = quotas.map((quota) => Math.max(1, Math.floor(quota)));
   let allocated = allocations.reduce((sum, value) => sum + value, 0);
 
   while (allocated < totalHeight) {
-    const index = allocated % allocations.length;
+    let index = 0;
+    for (let candidate = 1; candidate < allocations.length; candidate += 1) {
+      if (quotas[candidate]! - allocations[candidate]!
+        > quotas[index]! - allocations[index]!) {
+        index = candidate;
+      }
+    }
     allocations[index] = (allocations[index] ?? 0) + 1;
     allocated += 1;
   }
   while (allocated > totalHeight) {
-    const index = allocations.findLastIndex((value) => value > 1);
+    let index = -1;
+    for (let candidate = 0; candidate < allocations.length; candidate += 1) {
+      if (allocations[candidate]! <= 1) continue;
+      if (index < 0 || allocations[candidate]! - quotas[candidate]!
+        > allocations[index]! - quotas[index]!) {
+        index = candidate;
+      }
+    }
     if (index < 0) break;
     allocations[index] = allocations[index]! - 1;
     allocated -= 1;
@@ -229,11 +279,15 @@ function projectSeries(
   domain: CompositeAxisDomain,
   startTime: number,
   endTime: number,
+  timeScale: CompositeTimeScale,
 ): CompositeProjectedPoint[] {
-  const span = Math.max(endTime - startTime, 1);
   const projected: CompositeProjectedPoint[] = [];
   let breakBefore = true;
-  for (const { point, timestamp, value } of normalizedSourcePoints(series)) {
+  const placement = timeScale.kind === "market" && !series.timeBasis
+    ? "next-market-slot" as const
+    : "timestamp" as const;
+  const stepSeries = series.interpolation === "step-after" || series.style === "step";
+  for (const { point, timestamp, value } of normalizedSourcePoints(series, timeScale)) {
     if (value === null) {
       breakBefore = true;
       continue;
@@ -243,23 +297,28 @@ function projectSeries(
       breakBefore = true;
       continue;
     }
+    const projectedTime = projectCompositeTimestamp(timeScale, timestamp, placement);
+    if (!projectedTime) continue;
+    const beforeViewportStepAnchor = stepSeries
+      && timestamp < startTime
+      && projectedTime.ratio < 0;
+    if (!beforeViewportStepAnchor && (projectedTime.ratio < 0 || projectedTime.ratio > 1)) {
+      continue;
+    }
     projected.push({
       point,
-      timestamp,
+      timestamp: beforeViewportStepAnchor ? startTime : timestamp,
       value,
-      xRatio: (timestamp - startTime) / span,
+      xRatio: beforeViewportStepAnchor ? 0 : projectedTime.ratio,
+      xSlot: beforeViewportStepAnchor ? undefined : projectedTime.xSlot,
       yRatio,
       breakBefore,
     });
     breakBefore = false;
   }
-  if ((series.interpolation === "step-after" || series.style === "step") && projected.length > 0) {
-    const first = projected[0]!;
-    if (first.timestamp < startTime) {
-      projected[0] = { ...first, timestamp: startTime, xRatio: 0, breakBefore: true };
-    }
+  if (stepSeries && projected.length > 0) {
     const last = projected.at(-1)!;
-    const trailingGap = normalizedSourcePoints(series).some(({ timestamp, value }) => (
+    const trailingGap = normalizedSourcePoints(series, timeScale).some(({ timestamp, value }) => (
       timestamp > last.timestamp && timestamp <= endTime
       && (value === null || projectCompositeValue(value, domain) === null)
     ));
@@ -338,7 +397,7 @@ export function applyCompositeChartCursor(
   if (currentTimestamp === nextTimestamp) return scene;
 
   const cursorXRatio = cursorDate
-    ? (cursorDate.getTime() - scene.startTime) / Math.max(scene.endTime - scene.startTime, 1)
+    ? projectCompositeTimestamp(scene.timeScale, cursorDate.getTime())?.ratio ?? null
     : null;
   return {
     ...scene,
@@ -364,21 +423,35 @@ export function buildCompositeChartScene(
   const viewport = explicitViewport(options);
   const startTime = viewport?.startTime ?? (firstTime === lastTime ? firstTime - DAY_MS / 2 : firstTime);
   const endTime = viewport?.endTime ?? (firstTime === lastTime ? lastTime + DAY_MS / 2 : lastTime);
+  const timeScale = buildCompositeTimeScale(
+    options.timelineSeries ?? dataSeries,
+    startTime,
+    endTime,
+  );
   const usableSeries = viewport
-    ? dataSeries.flatMap((entry) => scopeSeriesToViewport(entry, startTime, endTime) ?? [])
+    ? dataSeries.flatMap((entry) => scopeSeriesToViewport(entry, startTime, endTime, timeScale) ?? [])
     : dataSeries;
   if (usableSeries.length === 0) return null;
   const visibleTimes = uniqueTimes.filter((time) => time >= startTime && time <= endTime);
-  const dates = (visibleTimes.length > 0
-    ? visibleTimes
+  const marketTimes = timeScale.kind === "market"
+    ? timeScale.anchors
+      .map(({ timestamp }) => timestamp)
+      .filter((time) => time >= startTime && time <= endTime)
+    : [];
+  const cursorTimes = timeScale.kind === "market" ? marketTimes : visibleTimes;
+  const dates = (cursorTimes.length > 0
+    ? cursorTimes
     : viewport
       ? [...new Set([startTime, endTime])]
       : uniqueTimes
   ).map((time) => new Date(time));
+  const dateRatios = dates.map((date) => (
+    projectCompositeTimestamp(timeScale, date.getTime())?.ratio ?? 0
+  ));
   const requestedCursor = options.cursorDate ?? null;
   const cursorDate = requestedCursor ? nearestDate(dates, requestedCursor) : null;
   const cursorXRatio = cursorDate
-    ? (cursorDate.getTime() - startTime) / Math.max(endTime - startTime, 1)
+    ? projectCompositeTimestamp(timeScale, cursorDate.getTime())?.ratio ?? null
     : null;
   const orderedPanels = panelSpecsForSeries(usableSeries, panels);
   const panelHeights = allocateCompositePanelHeights(orderedPanels, options.height);
@@ -398,7 +471,9 @@ export function buildCompositeChartScene(
       axes,
       series: panelSeries.flatMap((entry) => {
         const domain = axes[entry.axis];
-        return domain ? [{ source: entry, points: projectSeries(entry, domain, startTime, endTime) }] : [];
+        return domain
+          ? [{ source: entry, points: projectSeries(entry, domain, startTime, endTime, timeScale) }]
+          : [];
       }),
     }];
   });
@@ -408,7 +483,9 @@ export function buildCompositeChartScene(
     height: panelScenes.reduce((sum, panel) => sum + panel.height, 0),
     startTime,
     endTime,
+    timeScale,
     dates,
+    dateRatios,
     panels: panelScenes,
     cursorDate,
     cursorXRatio,
@@ -421,8 +498,36 @@ export function resolveCompositeCursorDate(scene: CompositeChartScene, localX: n
   const ratio = scene.width <= 1
     ? 0
     : Math.max(0, Math.min(1, localX / Math.max(scene.width - 1, 1)));
-  const target = scene.startTime + ratio * (scene.endTime - scene.startTime);
-  return nearestDate(scene.dates, new Date(target));
+  let nearestIndex = 0;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+  scene.dateRatios.forEach((candidate, index) => {
+    const distance = Math.abs(candidate - ratio);
+    if (distance < nearestDistance) {
+      nearestIndex = index;
+      nearestDistance = distance;
+    }
+  });
+  return scene.dates[nearestIndex] ?? null;
+}
+
+export function resolveCompositeTimeAxisDate(
+  scene: CompositeChartScene,
+  ratio: number,
+): Date {
+  const safeRatio = Math.max(0, Math.min(1, ratio));
+  if (scene.timeScale.kind === "market" && scene.dates.length > 0) {
+    let nearestIndex = 0;
+    let nearestDistance = Number.POSITIVE_INFINITY;
+    scene.dateRatios.forEach((candidate, index) => {
+      const distance = Math.abs(candidate - safeRatio);
+      if (distance < nearestDistance) {
+        nearestIndex = index;
+        nearestDistance = distance;
+      }
+    });
+    return scene.dates[nearestIndex] ?? new Date(scene.startTime);
+  }
+  return new Date(unprojectCompositeTimestamp(scene.timeScale, safeRatio));
 }
 
 export function resolveAdjacentCompositeCursorDate(

--- a/src/components/chart/composite/text-renderer.ts
+++ b/src/components/chart/composite/text-renderer.ts
@@ -1,4 +1,5 @@
 import { compositeAxisTicks, formatCompositeTimeAxisDate } from "./format";
+import { resolveCompositeTimeAxisDate } from "./scene";
 import { buildCompositeColumnLayout, type CompositeColumnLayout } from "./column-layout";
 import { projectCompositeValue } from "./scene";
 import type {
@@ -72,7 +73,26 @@ function renderLineLike(
       drawLine(rows, previous.x, previous.y, current.x, current.y, "•");
     }
   }
-  for (const point of points) setCell(rows, point.x, point.y, series.source.style === "points" ? "●" : "◆");
+  for (let index = 0; index < points.length; index += 1) {
+    const connectedToPrevious = index > 0 && points[index]!.point.breakBefore === false;
+    const connectedToNext = index + 1 < points.length && points[index + 1]!.point.breakBefore === false;
+    if (!connectedToPrevious && !connectedToNext) {
+      const point = points[index]!;
+      setCell(rows, point.x, point.y, "◆");
+    }
+  }
+}
+
+function renderPoints(
+  rows: string[][],
+  series: CompositeProjectedSeries,
+  width: number,
+  height: number,
+): void {
+  for (const point of series.points) {
+    const cell = cellPoint(point, width, height);
+    setCell(rows, cell.x, cell.y, "●");
+  }
 }
 
 function renderArea(
@@ -103,7 +123,17 @@ function renderColumns(
   const baseline = valueRow(0, domain, height) ?? height - 1;
   for (const point of series.points) {
     const cell = cellPoint(point, width, height);
-    const group = layout.groupByPoint.get(point) ?? { index: 0, count: 1 };
+    const group = layout.groupByPoint.get(point) ?? {
+      index: 0,
+      count: 1,
+      xRatio: point.xRatio,
+      familyKey: "",
+    };
+    cell.x = clamp(
+      Math.round(group.xRatio * Math.max(width - 1, 0)),
+      0,
+      Math.max(width - 1, 0),
+    );
     if (group.count > 1) {
       const groupWidth = Math.min(group.count, width);
       const groupStart = clamp(
@@ -166,7 +196,11 @@ export function renderCompositePanelText(
   }
 
   const columnLayout = buildCompositeColumnLayout(panel);
-  for (const series of panel.series) {
+  const orderedSeries = [...panel.series].sort((left, right) => {
+    const layerRank = (style: string) => style === "area" || style === "columns" ? 0 : 1;
+    return layerRank(left.source.style) - layerRank(right.source.style);
+  });
+  for (const series of orderedSeries) {
     const domain = panel.axes[series.source.axis];
     if (!domain) continue;
     switch (series.source.style) {
@@ -183,8 +217,10 @@ export function renderCompositePanelText(
         break;
       case "line":
       case "step":
-      case "points":
         renderLineLike(rows, series, plotWidth, height);
+        break;
+      case "points":
+        renderPoints(rows, series, plotWidth, height);
         break;
     }
   }
@@ -232,14 +268,14 @@ function placeLabel(chars: string[], label: string, center: number): void {
 
 export function renderCompositeTimeAxis(scene: CompositeChartScene, width: number): string {
   const chars = Array(Math.max(1, width)).fill(" ");
-  const formatDate = (time: number) => formatCompositeTimeAxisDate(
-    new Date(time),
+  const formatDate = (ratio: number) => formatCompositeTimeAxisDate(
+    resolveCompositeTimeAxisDate(scene, ratio),
     scene.startTime,
     scene.endTime,
   );
-  const startLabel = formatDate(scene.startTime);
-  const midpointLabel = formatDate((scene.startTime + scene.endTime) / 2);
-  const endLabel = formatDate(scene.endTime);
+  const startLabel = formatDate(0);
+  const midpointLabel = formatDate(0.5);
+  const endLabel = formatDate(1);
   placeLabel(chars, startLabel, 0);
   if (chars.length >= startLabel.length + midpointLabel.length + endLabel.length + 4) {
     placeLabel(chars, midpointLabel, (chars.length - 1) / 2);

--- a/src/components/chart/composite/time-scale.test.ts
+++ b/src/components/chart/composite/time-scale.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
+import {
+  buildCompositeTimeScale,
+  projectCompositeTimestamp,
+} from "./time-scale";
+
+const HOUR_MS = 60 * 60 * 1_000;
+
+function point(timestamp: string): TimeSeriesPoint {
+  const date = new Date(timestamp);
+  return { date, observedAt: date, value: 1 };
+}
+
+function series(timestamps: string[], market = false): ResolvedSeries {
+  return {
+    id: "primary",
+    label: "Primary",
+    color: "#fff",
+    unit: "USD",
+    unitGroup: "price",
+    nativeFrequency: "daily",
+    dataShape: "ohlcv",
+    style: "candles",
+    transform: "raw",
+    axis: "left",
+    panelId: "main",
+    interpolation: "none",
+    timeBasis: market
+      ? { kind: "market", timeZone: "America/New_York", cadenceMs: HOUR_MS }
+      : undefined,
+    points: timestamps.map(point),
+  };
+}
+
+describe("composite time scale", () => {
+  test("compresses closed sessions while retaining an in-session missing-bar gap", () => {
+    const timestamps = [
+      "2025-01-03T14:00:00.000Z",
+      "2025-01-03T15:00:00.000Z",
+      "2025-01-03T16:00:00.000Z",
+      "2025-01-06T14:00:00.000Z",
+      "2025-01-06T16:00:00.000Z",
+    ];
+    const scale = buildCompositeTimeScale(
+      [series(timestamps, true)],
+      Date.parse(timestamps[0]!),
+      Date.parse(timestamps.at(-1)!),
+    );
+
+    expect(scale.kind).toBe("market");
+    if (scale.kind !== "market") return;
+    expect(scale.anchors.map(({ position }) => position)).toEqual([0, 1, 2, 3, 5]);
+    expect(projectCompositeTimestamp(scale, Date.parse(timestamps[2]!))?.ratio).toBeCloseTo(0.4);
+    expect(projectCompositeTimestamp(scale, Date.parse(timestamps[3]!))?.ratio).toBeCloseTo(0.6);
+  });
+
+  test("snaps weekend availability forward and leaves calendar-only charts linear", () => {
+    const marketTimestamps = [
+      "2025-01-03T16:00:00.000Z",
+      "2025-01-06T14:00:00.000Z",
+      "2025-01-06T15:00:00.000Z",
+    ];
+    const marketScale = buildCompositeTimeScale(
+      [series(marketTimestamps, true)],
+      Date.parse(marketTimestamps[0]!),
+      Date.parse(marketTimestamps.at(-1)!),
+    );
+    const weekend = projectCompositeTimestamp(
+      marketScale,
+      Date.parse("2025-01-04T12:00:00.000Z"),
+      "next-market-slot",
+    );
+    expect(weekend?.xSlot).toBe(1);
+    expect(weekend?.ratio).toBeCloseTo(0.5);
+
+    const calendarScale = buildCompositeTimeScale(
+      [series([], false)],
+      Date.parse("2025-01-04T00:00:00.000Z"),
+      Date.parse("2025-01-06T00:00:00.000Z"),
+    );
+    expect(calendarScale.kind).toBe("calendar");
+    expect(projectCompositeTimestamp(
+      calendarScale,
+      Date.parse("2025-01-05T00:00:00.000Z"),
+    )?.ratio).toBe(0.5);
+  });
+});

--- a/src/components/chart/composite/time-scale.ts
+++ b/src/components/chart/composite/time-scale.ts
@@ -1,0 +1,217 @@
+import type { ResolvedSeries } from "../../../time-series/types";
+import type { CompositeTimeScale } from "./types";
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const MINIMUM_SLOT_FRACTION = 0.25;
+const dateFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function finiteTimestamp(value: Date): number | null {
+  const timestamp = value.getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function uniqueSeriesTimestamps(series: ResolvedSeries): number[] {
+  return [...new Set(series.points.flatMap((point) => {
+    const timestamp = finiteTimestamp(point.date);
+    return timestamp === null ? [] : [timestamp];
+  }))].sort((left, right) => left - right);
+}
+
+function formatterFor(timeZone: string): Intl.DateTimeFormat {
+  let formatter = dateFormatters.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    dateFormatters.set(timeZone, formatter);
+  }
+  return formatter;
+}
+
+function sessionDate(timestamp: number, timeZone: string): string {
+  try {
+    const parts = formatterFor(timeZone).formatToParts(new Date(timestamp));
+    const year = parts.find((part) => part.type === "year")?.value;
+    const month = parts.find((part) => part.type === "month")?.value;
+    const day = parts.find((part) => part.type === "day")?.value;
+    if (year && month && day) return `${year}-${month}-${day}`;
+  } catch {
+    // Invalid or unsupported IANA zones fall back to UTC below.
+  }
+  return new Date(timestamp).toISOString().slice(0, 10);
+}
+
+function median(values: readonly number[]): number | null {
+  const sorted = values.filter((value) => Number.isFinite(value) && value > 0)
+    .sort((left, right) => left - right);
+  if (sorted.length === 0) return null;
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1
+    ? sorted[middle]!
+    : (sorted[middle - 1]! + sorted[middle]!) / 2;
+}
+
+function lowerBoundAnchor(
+  anchors: Extract<CompositeTimeScale, { kind: "market" }>["anchors"],
+  timestamp: number,
+): number {
+  let low = 0;
+  let high = anchors.length;
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2);
+    if (anchors[middle]!.timestamp < timestamp) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+function positionForTimestamp(
+  scale: Extract<CompositeTimeScale, { kind: "market" }>,
+  timestamp: number,
+): number {
+  const { anchors, cadenceMs } = scale;
+  const index = lowerBoundAnchor(anchors, timestamp);
+  const next = anchors[index];
+  if (next?.timestamp === timestamp) return next.position;
+  const previous = anchors[index - 1];
+  if (!previous) {
+    return anchors[0]!.position + (timestamp - anchors[0]!.timestamp) / cadenceMs;
+  }
+  if (!next) {
+    const last = anchors.at(-1)!;
+    return last.position + (timestamp - last.timestamp) / cadenceMs;
+  }
+  const elapsed = next.timestamp - previous.timestamp;
+  if (elapsed <= 0) return previous.position;
+  return previous.position
+    + (next.position - previous.position) * ((timestamp - previous.timestamp) / elapsed);
+}
+
+export function buildCompositeTimeScale(
+  timelineSeries: readonly ResolvedSeries[],
+  startTime: number,
+  endTime: number,
+): CompositeTimeScale {
+  const anchorSeries = timelineSeries.find((series) => series.timeBasis?.kind === "market");
+  const anchorTimestamps = anchorSeries ? uniqueSeriesTimestamps(anchorSeries) : [];
+  if (!anchorSeries?.timeBasis || anchorTimestamps.length === 0) {
+    return { kind: "calendar", startTime, endTime };
+  }
+
+  const { timeZone } = anchorSeries.timeBasis;
+  const sameSessionGaps: number[] = [];
+  const allGaps: number[] = [];
+  for (let index = 1; index < anchorTimestamps.length; index += 1) {
+    const previous = anchorTimestamps[index - 1]!;
+    const next = anchorTimestamps[index]!;
+    const gap = next - previous;
+    if (gap <= 0) continue;
+    allGaps.push(gap);
+    if (sessionDate(previous, timeZone) === sessionDate(next, timeZone)) {
+      sameSessionGaps.push(gap);
+    }
+  }
+  const configuredCadence = anchorSeries.timeBasis.cadenceMs;
+  const cadenceMs = typeof configuredCadence === "number"
+    && Number.isFinite(configuredCadence)
+    && configuredCadence > 0
+    ? configuredCadence
+    : median(sameSessionGaps) ?? median(allGaps) ?? DAY_MS;
+
+  const anchors: Extract<CompositeTimeScale, { kind: "market" }>["anchors"] = [];
+  let position = 0;
+  anchorTimestamps.forEach((timestamp, index) => {
+    if (index > 0) {
+      const previous = anchorTimestamps[index - 1]!;
+      const sameSession = sessionDate(previous, timeZone) === sessionDate(timestamp, timeZone);
+      position += sameSession
+        ? Math.max((timestamp - previous) / cadenceMs, MINIMUM_SLOT_FRACTION)
+        : 1;
+    }
+    anchors.push({ timestamp, position });
+  });
+
+  const provisional: Extract<CompositeTimeScale, { kind: "market" }> = {
+    kind: "market",
+    startTime,
+    endTime,
+    anchorSeriesId: anchorSeries.id,
+    cadenceMs,
+    anchors,
+    startPosition: 0,
+    endPosition: 1,
+  };
+  const startPosition = positionForTimestamp(provisional, startTime);
+  const endPosition = positionForTimestamp(provisional, endTime);
+  return {
+    ...provisional,
+    startPosition,
+    endPosition: endPosition > startPosition ? endPosition : startPosition + 1,
+  };
+}
+
+export function projectCompositeTimestamp(
+  scale: CompositeTimeScale,
+  timestamp: number,
+  placement: "timestamp" | "next-market-slot" = "timestamp",
+): { ratio: number; xSlot?: number } | null {
+  if (!Number.isFinite(timestamp)) return null;
+  if (scale.kind === "calendar") {
+    const span = Math.max(scale.endTime - scale.startTime, 1);
+    return { ratio: (timestamp - scale.startTime) / span };
+  }
+
+  let position: number;
+  let xSlot: number | undefined;
+  if (placement === "next-market-slot") {
+    const index = lowerBoundAnchor(scale.anchors, timestamp);
+    const anchor = scale.anchors[index];
+    if (!anchor) return null;
+    position = anchor.position;
+    xSlot = index;
+  } else {
+    const index = lowerBoundAnchor(scale.anchors, timestamp);
+    const exact = scale.anchors[index];
+    position = positionForTimestamp(scale, timestamp);
+    if (exact?.timestamp === timestamp) xSlot = index;
+  }
+  const span = Math.max(scale.endPosition - scale.startPosition, Number.EPSILON);
+  return { ratio: (position - scale.startPosition) / span, xSlot };
+}
+
+export function unprojectCompositeTimestamp(
+  scale: CompositeTimeScale,
+  ratio: number,
+): number {
+  const safeRatio = Math.max(0, Math.min(1, ratio));
+  if (scale.kind === "calendar") {
+    return scale.startTime + (scale.endTime - scale.startTime) * safeRatio;
+  }
+  const targetPosition = scale.startPosition
+    + (scale.endPosition - scale.startPosition) * safeRatio;
+  const anchors = scale.anchors;
+  let low = 0;
+  let high = anchors.length;
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2);
+    if (anchors[middle]!.position < targetPosition) low = middle + 1;
+    else high = middle;
+  }
+  const next = anchors[low];
+  const previous = anchors[low - 1];
+  if (!previous) {
+    return anchors[0]!.timestamp + (targetPosition - anchors[0]!.position) * scale.cadenceMs;
+  }
+  if (!next) {
+    const last = anchors.at(-1)!;
+    return last.timestamp + (targetPosition - last.position) * scale.cadenceMs;
+  }
+  const positionSpan = next.position - previous.position;
+  if (positionSpan <= 0) return previous.timestamp;
+  return previous.timestamp
+    + (next.timestamp - previous.timestamp)
+      * ((targetPosition - previous.position) / positionSpan);
+}

--- a/src/components/chart/composite/types.ts
+++ b/src/components/chart/composite/types.ts
@@ -32,10 +32,34 @@ export interface CompositeProjectedPoint {
   timestamp: number;
   value: number;
   xRatio: number;
+  /** Primary-market anchor slot when projection snapped to a trading observation. */
+  xSlot?: number;
   yRatio: number;
   /** True when this point starts after a null, invalid, or log-hidden gap. */
   breakBefore: boolean;
 }
+
+export interface CompositeCalendarTimeScale {
+  kind: "calendar";
+  startTime: number;
+  endTime: number;
+}
+
+export interface CompositeMarketTimeScale {
+  kind: "market";
+  startTime: number;
+  endTime: number;
+  anchorSeriesId: string;
+  cadenceMs: number;
+  anchors: Array<{
+    timestamp: number;
+    position: number;
+  }>;
+  startPosition: number;
+  endPosition: number;
+}
+
+export type CompositeTimeScale = CompositeCalendarTimeScale | CompositeMarketTimeScale;
 
 export interface CompositeProjectedSeries {
   source: ResolvedSeries;
@@ -65,7 +89,10 @@ export interface CompositeChartScene {
   height: number;
   startTime: number;
   endTime: number;
+  timeScale: CompositeTimeScale;
   dates: Date[];
+  /** Projected positions aligned with `dates`, used for pointer snapping. */
+  dateRatios: number[];
   panels: CompositePanelScene[];
   cursorDate: Date | null;
   cursorXRatio: number | null;
@@ -80,6 +107,8 @@ export interface BuildCompositeChartSceneOptions {
     start: Date;
     end: Date;
   };
+  /** Authored series order retained even when the primary anchor is hidden. */
+  timelineSeries?: ResolvedSeries[];
 }
 
 export interface CompositeChartProps {
@@ -105,6 +134,7 @@ export interface CompositeChartProps {
   emptyMessage?: string;
   formatValue?: (value: number, series: ResolvedSeries) => string;
   onCursorDateChange?: (date: Date | null) => void;
+  onViewportChange?: (viewport: { start: Date; end: Date } | null) => void;
   onActivate?: () => void;
   onToggleSeries?: (seriesId: string) => void;
   isSeriesToggleable?: (series: ResolvedSeries) => boolean;

--- a/src/components/chart/native/kitty/index.test.ts
+++ b/src/components/chart/native/kitty/index.test.ts
@@ -474,6 +474,26 @@ describe("computeSurfaceVisibleFragments", () => {
       { x: 10, y: 6, width: 12, height: 8 },
     ]);
   });
+
+  test("subtracts an explicitly local overlay from its own pane", () => {
+    expect(computeSurfaceVisibleFragments(
+      { x: 10, y: 6, width: 12, height: 8 },
+      { x: 10, y: 6, width: 12, height: 8 },
+      120,
+      "chart:float",
+      [{
+        id: "chart:float:quick-add",
+        paneId: "chart:float",
+        rect: { x: 14, y: 6, width: 4, height: 3 },
+        zIndex: 120,
+        occludesOwnPane: true,
+      }],
+    )).toEqual([
+      { x: 10, y: 6, width: 4, height: 3 },
+      { x: 18, y: 6, width: 4, height: 3 },
+      { x: 10, y: 9, width: 12, height: 5 },
+    ]);
+  });
 });
 
 describe("KittyImageManager", () => {
@@ -635,6 +655,51 @@ describe("NativeSurfaceManager", () => {
     });
 
     expect(writes.length).toBe(1);
+  });
+
+  test("clips and restores a surface as a local overlay opens and closes", () => {
+    const renderer = {
+      resolution: { width: 1200, height: 800 },
+      terminalWidth: 120,
+      terminalHeight: 40,
+      write() { return true; },
+    } as unknown as CliRenderer;
+    const manager = new NativeSurfaceManager(renderer);
+    const originalRender = KittyImageManager.prototype.render;
+    const renderedRowCounts: number[][] = [];
+    KittyImageManager.prototype.render = function(
+      _bitmap,
+      placement,
+    ) {
+      const placements = Array.isArray(placement) ? placement : [placement];
+      renderedRowCounts.push(placements.map((entry) => entry.rows));
+    };
+
+    try {
+      manager.setWindowState({
+        paneLayers: [{ paneId: "pane", zIndex: 120 }],
+        occluders: [],
+      });
+      manager.upsertSurface({
+        id: "chart",
+        paneId: "pane",
+        rect: { x: 2, y: 3, width: 20, height: 8 },
+        visibleRect: { x: 2, y: 3, width: 20, height: 8 },
+        bitmap: { width: 200, height: 80, pixels: new Uint8Array(200 * 80 * 4) },
+        bitmapKey: "frame-1",
+      });
+      manager.upsertLocalOccluder({
+        id: "quick-add",
+        paneId: "pane",
+        rect: { x: 2, y: 3, width: 20, height: 2 },
+      });
+      manager.removeLocalOccluder("quick-add");
+
+      expect(renderedRowCounts).toEqual([[8], [6], [8]]);
+    } finally {
+      KittyImageManager.prototype.render = originalRender;
+      manager.destroy();
+    }
   });
 
   test("skips rerendering when an identical surface snapshot is upserted", () => {

--- a/src/components/chart/native/surface/manager.ts
+++ b/src/components/chart/native/surface/manager.ts
@@ -18,6 +18,14 @@ export interface NativeOccluder {
   paneId?: string | null;
   rect: CellRect;
   zIndex: number;
+  /** Explicit overlays may cover a native surface inside their own pane. */
+  occludesOwnPane?: boolean;
+}
+
+export interface NativeLocalOccluder {
+  id: string;
+  paneId: string;
+  rect: CellRect;
 }
 
 export interface NativeSurfaceSnapshot {
@@ -62,6 +70,7 @@ function sameOccluder(a: NativeOccluder, b: NativeOccluder): boolean {
   return a.id === b.id
     && (a.paneId ?? null) === (b.paneId ?? null)
     && a.zIndex === b.zIndex
+    && a.occludesOwnPane === b.occludesOwnPane
     && sameRect(a.rect, b.rect);
 }
 
@@ -106,7 +115,11 @@ export function computeSurfaceVisibleFragments(
   if (!clipped) return [];
 
   const relevantCuts = occluders
-    .filter((occluder) => occluder.paneId !== paneId && occluder.zIndex >= surfaceZIndex)
+    .filter((occluder) => (
+      occluder.paneId === paneId
+        ? occluder.occludesOwnPane === true
+        : occluder.zIndex >= surfaceZIndex
+    ))
     .sort((left, right) => right.zIndex - left.zIndex)
     .map((occluder) => occluder.rect);
 
@@ -116,6 +129,7 @@ export function computeSurfaceVisibleFragments(
 export class NativeSurfaceManager {
   private windowState: NativeWindowState = { paneLayers: [], occluders: [] };
   private readonly surfaces = new Map<string, SurfaceEntry>();
+  private readonly localOccluders = new Map<string, NativeLocalOccluder>();
 
   constructor(private readonly renderer: CliRenderer) {}
 
@@ -171,10 +185,29 @@ export class NativeSurfaceManager {
     this.surfaces.delete(id);
   }
 
+  upsertLocalOccluder(occluder: NativeLocalOccluder) {
+    const existing = this.localOccluders.get(occluder.id);
+    if (
+      existing
+      && existing.paneId === occluder.paneId
+      && sameRect(existing.rect, occluder.rect)
+    ) {
+      return;
+    }
+    this.localOccluders.set(occluder.id, occluder);
+    this.syncAll();
+  }
+
+  removeLocalOccluder(id: string) {
+    if (!this.localOccluders.delete(id)) return;
+    this.syncAll();
+  }
+
   destroy() {
     for (const id of [...this.surfaces.keys()]) {
       this.removeSurface(id);
     }
+    this.localOccluders.clear();
   }
 
   private syncAll() {
@@ -191,12 +224,17 @@ export class NativeSurfaceManager {
     }
 
     const surfaceZIndex = this.windowState.paneLayers.find((layer) => layer.paneId === entry.snapshot.paneId)?.zIndex ?? 0;
+    const localOccluders: NativeOccluder[] = [...this.localOccluders.values()].map((occluder) => ({
+      ...occluder,
+      zIndex: this.windowState.paneLayers.find((layer) => layer.paneId === occluder.paneId)?.zIndex ?? 0,
+      occludesOwnPane: true,
+    }));
     const fragments = computeSurfaceVisibleFragments(
       entry.snapshot.rect,
       entry.snapshot.visibleRect,
       surfaceZIndex,
       entry.snapshot.paneId,
-      this.windowState.occluders,
+      [...this.windowState.occluders, ...localOccluders],
     );
 
     const placements = computeNativePlacements(

--- a/src/components/command-bar/list/view.tsx
+++ b/src/components/command-bar/list/view.tsx
@@ -1,10 +1,11 @@
-import { memo, useMemo, type RefObject } from "react";
+import { memo, useLayoutEffect, useMemo, useRef, type RefObject } from "react";
 import {
   Box,
   Input,
   ScrollBox,
   Text,
   TextAttributes,
+  type InputRenderable,
   type ScrollBoxRenderable,
 } from "../../../ui";
 import { Spinner } from "../../ui";
@@ -54,6 +55,15 @@ export const CommandBarListHeader = memo(function CommandBarListHeader({
   rootShortcutFeedback,
   onQueryChange,
 }: CommandBarListHeaderProps) {
+  const inputRef = useRef<InputRenderable | null>(null);
+
+  useLayoutEffect(() => {
+    const input = inputRef.current;
+    if (!input || input.editBuffer.getText() === query) return;
+    input.editBuffer.setText?.(query);
+    input.setCursorOffset?.(query.length);
+  }, [kind, query, title]);
+
   return (
     <>
       <Box height={1} paddingX={contentPadding}>
@@ -67,9 +77,10 @@ export const CommandBarListHeader = memo(function CommandBarListHeader({
           }}
         >
           <Input
+            key={`${kind}:${title}`}
+            ref={inputRef}
             value={query}
             onInput={onQueryChange}
-            onChange={onQueryChange}
             placeholder={kind === "root" ? t("Search commands") : title === "Security Description" ? t("Search tickers") : t("Filter")}
             focused
             data-gloom-remote-scope="command-bar"

--- a/src/components/command-bar/surface/pane.test.tsx
+++ b/src/components/command-bar/surface/pane.test.tsx
@@ -704,6 +704,53 @@ describe("CommandBar pane and layout routes", () => {
     }]);
   });
 
+  test("clears the root shortcut query when opening pane settings and nested pickers", async () => {
+    testSetup = await testRender(<CommandBarHarness
+      query="PS"
+      configureState={(state) => ({
+        ...state,
+        focusedPaneId: "quote-monitor:main",
+      })}
+      hasPaneSettings={(paneId) => paneId === "quote-monitor:main"}
+      configurePluginRegistry={(pluginRegistry) => {
+        pluginRegistry.resolvePaneSettings = () => makeQuoteMonitorPaneSettingsDescriptor(pluginRegistry, [{
+          key: "range",
+          label: "Range",
+          type: "select",
+          options: [
+            { label: "1M", value: "1M" },
+            { label: "1Y", value: "1Y" },
+          ],
+        }]);
+      }}
+    />, {
+      width: 100,
+      height: 20,
+    });
+
+    await testSetup.renderOnce();
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await testSetup!.renderOnce();
+    });
+    await renderFrames();
+    let frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Quote Monitor Settings");
+    expect(frame).not.toContain("PS");
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await testSetup!.renderOnce();
+    });
+    await renderFrames();
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("1M");
+    expect(frame).toContain("1Y");
+    expect(frame).not.toContain("No matches");
+    expect(frame).not.toContain("PS");
+  });
+
   test("opens focused pane settings directly from root search", async () => {
     const appliedValues: Array<{ paneId: string; key: string; value: unknown }> = [];
 

--- a/src/components/layout/pane/footer/index.test.tsx
+++ b/src/components/layout/pane/footer/index.test.tsx
@@ -20,8 +20,10 @@ afterEach(() => {
 
 function Registration({
   onRefresh,
+  refreshDisabled = false,
 }: {
   onRefresh?: () => void;
+  refreshDisabled?: boolean;
 }) {
   usePaneFooter("test", () => {
     return {
@@ -35,10 +37,10 @@ function Registration({
         },
       ],
       hints: [
-        { id: "refresh", key: "r", label: "efresh", onPress: onRefresh },
+        { id: "refresh", key: "r", label: "efresh", onPress: onRefresh, disabled: refreshDisabled },
       ],
     };
-  }, [onRefresh]);
+  }, [onRefresh, refreshDisabled]);
   return null;
 }
 
@@ -55,15 +57,17 @@ function ExternalLinkRegistration() {
 function FooterHarness({
   focused = false,
   onRefresh,
+  refreshDisabled = false,
 }: {
   focused?: boolean;
   onRefresh?: () => void;
+  refreshDisabled?: boolean;
 }) {
   return (
     <PaneFooterProvider>
       {(footer) => (
         <Box width={64} height={1}>
-          <Registration onRefresh={onRefresh} />
+          <Registration onRefresh={onRefresh} refreshDisabled={refreshDisabled} />
           <PaneFooterBar footer={footer} focused={focused} width={64} />
         </Box>
       )}
@@ -108,6 +112,21 @@ describe("PaneFooterBar", () => {
     expect(frame).toContain("source Reuters");
     expect(frame).toContain("[o]pen");
     expect(frame).not.toContain("https://example.com");
+  });
+
+  test("omits disabled controls instead of rendering muted hints", async () => {
+    testSetup = await testRender(
+      <FooterHarness focused refreshDisabled onRefresh={() => {}} />,
+      { width: 64, height: 1 },
+    );
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Rows 12");
+    expect(frame).not.toContain("[r]efresh");
   });
 
   test("calls hint onPress from mouse interaction", async () => {

--- a/src/components/layout/pane/footer/index.tsx
+++ b/src/components/layout/pane/footer/index.tsx
@@ -142,7 +142,7 @@ function FooterContent({
   showBackground?: boolean;
 }) {
   const hasInfo = footer.info.length > 0;
-  const visibleHints = focused ? footer.hints : [];
+  const visibleHints = focused ? footer.hints.filter((hint) => !hint.disabled) : [];
   const hasHints = visibleHints.length > 0;
   const dividerColor = focused ? colors.borderFocused : colors.border;
   const backgroundColor = showBackground ? blendHex(colors.bg, dividerColor, focused ? 0.12 : 0.06) : undefined;

--- a/src/components/layout/pane/footer/model.ts
+++ b/src/components/layout/pane/footer/model.ts
@@ -42,7 +42,7 @@ export const EMPTY_FOOTER: CombinedPaneFooter = { info: [], hints: [] };
 
 export function hasPaneFooterContent(footer?: CombinedPaneFooter | null): boolean {
   if (!footer) return false;
-  return footer.info.length > 0 || footer.hints.length > 0;
+  return footer.info.length > 0 || footer.hints.some((hint) => !hint.disabled);
 }
 
 export function combinePaneFooterRegistrations(registrations: Map<string, PaneFooterRegistration>): CombinedPaneFooter {

--- a/src/components/pane-settings-dialog.test.tsx
+++ b/src/components/pane-settings-dialog.test.tsx
@@ -4,16 +4,22 @@ import type { PluginRegistry } from "../plugins/registry";
 import type {
   PaneSettingActionContext,
   PaneSettingActionField,
+  PaneSettingField,
   PaneSettingsContext,
 } from "../types/plugin";
 import { TestDialogProvider, testRender } from "../renderers/opentui/test-utils";
+import { useDialog } from "../ui/dialog";
 import { PaneSettingsDialogContent } from "./pane-settings-dialog";
 import { TuiPaneSettingsDialogBody } from "./pane-settings-dialog/tui";
+import { Button } from "./ui";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 
-afterEach(() => {
-  testSetup?.renderer.destroy();
+afterEach(async () => {
+  if (!testSetup) return;
+  await act(async () => {
+    testSetup!.renderer.destroy();
+  });
   testSetup = undefined;
 });
 
@@ -50,6 +56,44 @@ function makeRegistry(
     openCommandBar: options.openCommandBar ?? (() => {}),
     notify: () => {},
   } as unknown as PluginRegistry;
+}
+
+function NestedSettingsHarness({
+  field,
+  applyFieldValue,
+}: {
+  field: PaneSettingField;
+  applyFieldValue: (paneId: string, field: PaneSettingField, value: unknown) => Promise<void>;
+}) {
+  const dialog = useDialog();
+  const registry = {
+    resolvePaneSettings: () => ({
+      paneId: context.paneId,
+      pane: { title: "Chart", paneId: "chart-composer" },
+      paneDef: { name: "Chart" },
+      settingsDef: { title: "Chart Settings", fields: [field] },
+      context,
+    }),
+    openCommandBar: () => {},
+    notify: () => {},
+  } as unknown as PluginRegistry;
+  return (
+    <Button
+      label="Open settings"
+      onPress={() => {
+        void dialog.alert({
+          content: (ctx: { dismiss: () => void }) => (
+            <PaneSettingsDialogContent
+              {...ctx}
+              paneId={context.paneId}
+              pluginRegistry={registry}
+              applyFieldValue={applyFieldValue}
+            />
+          ),
+        });
+      }}
+    />
+  );
 }
 
 describe("pane settings action rows", () => {
@@ -132,5 +176,60 @@ describe("pane settings action rows", () => {
     });
 
     expect(activated).toEqual([enabled.key]);
+  });
+
+  test("routes keyboard input to a nested select instead of the parent settings list", async () => {
+    const applied: unknown[] = [];
+    const field: PaneSettingField = {
+      key: "range",
+      label: "Range",
+      type: "select",
+      options: [
+        { value: "1M", label: "1M" },
+        { value: "1Y", label: "1Y" },
+      ],
+    };
+    testSetup = await testRender(
+      <NestedSettingsHarness
+        field={field}
+        applyFieldValue={async (_paneId, _field, value) => {
+          applied.push(value);
+        }}
+      />,
+      { width: 72, height: 16 },
+    );
+    await testSetup.renderOnce();
+    const openRow = testSetup.captureCharFrame().split("\n")
+      .findIndex((line) => line.includes("Open settings"));
+    expect(openRow).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(2, openRow);
+      await testSetup!.renderOnce();
+    });
+    expect(testSetup.captureCharFrame()).toContain("Chart Settings");
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Promise.resolve();
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+    expect(testSetup.captureCharFrame()).toContain("1Y");
+
+    await act(async () => {
+      testSetup!.mockInput.pressArrow("down");
+      await Bun.sleep(10);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Promise.resolve();
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+
+    expect(applied).toEqual(["1Y"]);
   });
 });

--- a/src/components/pane-settings-dialog.tsx
+++ b/src/components/pane-settings-dialog.tsx
@@ -96,6 +96,7 @@ export function PaneSettingsDialogContent({
         return;
       }
       await dialog.alert({
+        closeOnClickOutside: true,
         content: (ctx: AlertContext) => (
           <TuiSelectFieldDialog
             {...ctx}
@@ -110,6 +111,7 @@ export function PaneSettingsDialogContent({
 
     if (field.type === "text") {
       await dialog.alert({
+        closeOnClickOutside: true,
         content: (ctx: AlertContext) => (
           <TextFieldDialog
             {...ctx}
@@ -123,6 +125,7 @@ export function PaneSettingsDialogContent({
     }
 
     await dialog.alert({
+      closeOnClickOutside: true,
       content: (ctx: AlertContext) => (
         <MultiSelectFieldDialog
           {...ctx}

--- a/src/components/ui/fields.tsx
+++ b/src/components/ui/fields.tsx
@@ -22,6 +22,13 @@ export interface TextFieldProps {
   textColor?: string;
   placeholderColor?: string;
   onMouseDown?: () => void;
+  onKeyDown?: (event: {
+    name?: string;
+    shift?: boolean;
+    defaultPrevented?: boolean;
+    preventDefault(): void;
+    stopPropagation(): void;
+  }) => void;
 }
 
 const PASSWORD_MASK_CHAR = "*";
@@ -47,6 +54,7 @@ export function TextField({
   textColor = colors.text,
   placeholderColor = colors.textDim,
   onMouseDown,
+  onKeyDown,
 }: TextFieldProps) {
   useRemoteUiNode({
     role: "text-field",
@@ -138,6 +146,7 @@ export function TextField({
           selectionBg={isPassword ? backgroundColor : undefined}
           selectionFg={isPassword ? backgroundColor : undefined}
           showCursor={!isPassword}
+          onKeyDown={onKeyDown}
           onCursorChange={() => syncCursorOffset()}
           onInput={(nextValue: string) => {
             currentValueRef.current = nextValue;

--- a/src/components/ui/inline-quick-add.tsx
+++ b/src/components/ui/inline-quick-add.tsx
@@ -31,7 +31,7 @@ export function InlineQuickAddRow({
   placeholder,
   inputRef,
   preview,
-  minInputWidth = 6,
+  minInputWidth,
   maxInputWidth = 18,
   onFocusRequest,
   onChange,
@@ -43,9 +43,10 @@ export function InlineQuickAddRow({
   const inputWidth = useMemo(() => {
     const queryWidth = [...value.trim()].length;
     if (queryWidth > 0) {
-      return Math.max(4, Math.min(maxInputWidth, queryWidth + 1));
+      // A typed query hugs its preview unless the caller asked for a wider field.
+      return Math.max(minInputWidth ?? 4, Math.min(maxInputWidth, queryWidth + 1));
     }
-    return Math.max(minInputWidth, Math.min(10, Math.floor(width * 0.18)));
+    return Math.max(minInputWidth ?? 6, Math.min(10, Math.floor(width * 0.18)));
   }, [maxInputWidth, minInputWidth, value, width]);
   const hasPreview = preview !== undefined && preview !== null;
   const previewWidth = Math.max(4, width - inputWidth - 5);

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -27,6 +27,7 @@ export interface TabsProps {
   activeValue: string | null;
   onSelect: (value: string) => void;
   compact?: boolean;
+  dense?: boolean;
   variant?: "underline" | "pill" | "bare";
   closeMode?: "active" | "always";
   addLabel?: string;
@@ -44,6 +45,7 @@ export function Tabs({
   activeValue,
   onSelect,
   compact = false,
+  dense = false,
   variant = "underline",
   closeMode = "always",
   addLabel = "+",
@@ -152,6 +154,7 @@ export function Tabs({
         activeValue={activeValue}
         onSelect={handleSelect}
         compact={compact}
+        dense={dense}
         variant={variant}
         closeMode={closeMode}
         addLabel={addLabel}
@@ -168,6 +171,7 @@ export function Tabs({
       activeValue={activeValue}
       onSelect={handleSelect}
       compact={compact}
+      dense={dense}
       variant={variant}
       closeMode={closeMode}
       addLabel={addLabel}
@@ -198,9 +202,10 @@ function tabWidth(
   tab: TabItem,
   active: boolean,
   closeMode: TabsProps["closeMode"],
+  dense = false,
 ): number {
   const showClose = !!tab.onClose && (closeMode === "always" || active);
-  return displayWidth(tab.label) + 2 + (showClose ? 2 : 0);
+  return displayWidth(tab.label) + (dense ? 1 : 2) + (showClose ? 2 : 0);
 }
 
 function OpenTuiTabs({
@@ -208,6 +213,7 @@ function OpenTuiTabs({
   activeValue,
   onSelect,
   compact = false,
+  dense = false,
   variant = "underline",
   closeMode = "always",
   addLabel = "+",
@@ -235,10 +241,10 @@ function OpenTuiTabs({
   const [hoveredValue, setHoveredValue] = useState<string | null>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const tabWidths = useMemo(
-    () => tabs.map((tab) => tabWidth(tab, tab.value === activeValue, closeMode)),
-    [activeValue, closeMode, tabs],
+    () => tabs.map((tab) => tabWidth(tab, tab.value === activeValue, closeMode, dense)),
+    [activeValue, closeMode, dense, tabs],
   );
-  const addWidth = onAdd ? addLabel.length + 2 : 0;
+  const addWidth = onAdd ? addLabel.length + (dense ? 1 : 2) : 0;
   const totalWidth = tabWidths.reduce((sum, width) => sum + width, 0) + addWidth;
 
   useEffect(() => {
@@ -346,7 +352,7 @@ function OpenTuiTabs({
               attributes={attributes}
               onMouseDown={selectTab}
             >
-              {` ${tab.label} `}
+              {dense ? `${tab.label} ` : ` ${tab.label} `}
             </Text>
             {showClose && (
               <Text
@@ -376,7 +382,7 @@ function OpenTuiTabs({
           }}
         >
           <Text fg={hoveredValue === "__add__" ? palette.hoverFg : palette.addFg}>
-            {` ${addLabel} `}
+            {dense ? `${addLabel} ` : ` ${addLabel} `}
           </Text>
         </Box>
       )}

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,6 +1,8 @@
 import { Box, Text, TextAttributes, useUiHost } from "../../ui";
 import { type ComponentType } from "react";
 import { colors } from "../../theme/colors";
+import { useShortcut } from "../../react/input";
+import { isPlainKey } from "../../utils/keyboard";
 
 interface SegmentedControlOption {
   label: string;
@@ -12,14 +14,47 @@ export interface SegmentedControlProps {
   options: SegmentedControlOption[];
   value: string;
   onChange?: (value: string) => void;
+  focused?: boolean;
+  shortcutScope?: string;
+  width?: number | "100%";
+  wrap?: boolean;
 }
 
 export function SegmentedControl({
   options,
   value,
   onChange,
+  focused = false,
+  shortcutScope,
+  width,
+  wrap = false,
 }: SegmentedControlProps) {
-  const HostSegmentedControl = useUiHost().SegmentedControl as ComponentType<SegmentedControlProps> | undefined;
+  const ui = useUiHost();
+  const HostSegmentedControl = ui.SegmentedControl as ComponentType<SegmentedControlProps> | undefined;
+  useShortcut((event) => {
+    const direction = isPlainKey(event, "left")
+      ? -1
+      : isPlainKey(event, "right")
+        ? 1
+        : 0;
+    if (!direction) return;
+    event.preventDefault();
+    event.stopPropagation();
+
+    const enabled = options.filter((option) => !option.disabled);
+    if (enabled.length === 0) return;
+    const index = enabled.findIndex((option) => option.value === value);
+    const nextIndex = index < 0
+      ? 0
+      : (index + direction + enabled.length) % enabled.length;
+    const next = enabled[nextIndex];
+    if (next && next.value !== value) onChange?.(next.value);
+  }, {
+    enabled: ui.kind !== "desktop-web" && focused && !!onChange,
+    phase: "before",
+    scope: shortcutScope,
+  });
+
   if (HostSegmentedControl) {
     return (
       <HostSegmentedControl
@@ -31,16 +66,22 @@ export function SegmentedControl({
   }
 
   return (
-    <Box flexDirection="row">
+    <Box
+      flexDirection="row"
+      flexWrap={wrap ? "wrap" : "nowrap"}
+      width={width}
+      overflow="hidden"
+    >
       {options.map((option) => {
         const active = option.value === value;
         return (
           <Box
             key={option.value}
-            backgroundColor={active ? colors.selected : colors.panel}
+            backgroundColor={active ? (focused ? colors.borderFocused : colors.selected) : colors.panel}
             onMouseDown={() => {
               if (!option.disabled) onChange?.(option.value);
             }}
+            cursor={option.disabled ? undefined : "pointer"}
           >
             <Text
               fg={option.disabled ? colors.textMuted : active ? colors.selectedText : colors.textDim}

--- a/src/plugins/builtin/chart-composer/chart-spec.ts
+++ b/src/plugins/builtin/chart-composer/chart-spec.ts
@@ -1,4 +1,4 @@
-import type { ChartSpec } from "../../../time-series/types";
+import type { ChartSpec, ResolvedSeries } from "../../../time-series/types";
 import { CHART_SPEC_VERSION } from "../../../time-series/types";
 import {
   DEFAULT_CHART_SPEC,
@@ -9,6 +9,47 @@ import {
 
 export const CHART_SPEC_SETTING_KEY = "chartSpec";
 export const MAX_CHART_COMPOSER_SERIES = MAX_CHART_SERIES;
+
+export function canToggleChartSeries(spec: ChartSpec, seriesId: string): boolean {
+  const target = spec.series.find((series) => series.id === seriesId);
+  if (!target) return false;
+  if (target.visible === false) return true;
+  return spec.series.filter((series) => series.visible !== false).length > 1;
+}
+
+export function toggleChartSeries(spec: ChartSpec, seriesId: string): ChartSpec {
+  if (!canToggleChartSeries(spec, seriesId)) return spec;
+  return {
+    ...spec,
+    series: spec.series.map((series) => series.id === seriesId
+      ? { ...series, visible: series.visible === false }
+      : series),
+  };
+}
+
+/**
+ * Project the latest resolved data through the authored visibility immediately.
+ * Resolution continues in the background, but hiding/restoring a loaded base
+ * series should not wait for another provider round trip.
+ */
+export function projectVisibleChartSeries(
+  spec: ChartSpec,
+  resolvedSeries: readonly ResolvedSeries[],
+  legendSeries: readonly ResolvedSeries[] = [],
+): ResolvedSeries[] {
+  const baseIds = new Set(spec.series.map((series) => series.id));
+  const resolvedById = new Map([
+    ...legendSeries.map((series) => [series.id, series] as const),
+    ...resolvedSeries.map((series) => [series.id, series] as const),
+  ]);
+  return [
+    ...spec.series.flatMap((series) => {
+      const resolved = series.visible === false ? undefined : resolvedById.get(series.id);
+      return resolved ? [resolved] : [];
+    }),
+    ...resolvedSeries.filter((series) => !baseIds.has(series.id)),
+  ];
+}
 
 function decodeSpec(value: unknown): unknown {
   if (typeof value !== "string") return value;

--- a/src/plugins/builtin/chart-composer/cli-options.ts
+++ b/src/plugins/builtin/chart-composer/cli-options.ts
@@ -79,7 +79,6 @@ export function applyChartComposerCapabilityOptions(
           ...entry.source,
           fieldId: `${graphKind}.${options.metric}`,
           ...(period ? { period } : {}),
-          timestampMode: entry.style === "columns" ? "period-end" : "available-at",
         } : entry.source,
       })),
     };

--- a/src/plugins/builtin/chart-composer/editor.test.tsx
+++ b/src/plugins/builtin/chart-composer/editor.test.tsx
@@ -2,11 +2,20 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { act } from "react";
 import { testRender } from "../../../renderers/opentui/test-utils";
 import { SeriesEditorDialog } from "./editor";
-import { buildPriceChartPreset } from "./presets";
+import {
+  appendChartSeries,
+  buildFundamentalChartPreset,
+  buildPriceChartPreset,
+  parseSeriesExpression,
+} from "./presets";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 
-async function emitKey(name: string, sequence: string) {
+async function emitKey(
+  name: string,
+  sequence: string,
+  overrides: Partial<{ shift: boolean }> = {},
+) {
   await act(async () => {
     (testSetup!.renderer as any).keyInput.emit("keypress", {
       name,
@@ -15,7 +24,7 @@ async function emitKey(name: string, sequence: string) {
       meta: false,
       super: false,
       option: false,
-      shift: false,
+      shift: overrides.shift ?? false,
       eventType: "press",
       repeated: false,
       defaultPrevented: false,
@@ -90,5 +99,234 @@ describe("chart composer series editor", () => {
     expect(secondAddFrame).toContain("AAPL free cash flow");
     expect(secondAddFrame).toContain("AAPL · Free Cash Flow");
     expect(secondAddFrame).not.toContain("MSFT revenueAAPL");
+  });
+
+  test("keeps the final series when removal is requested", async () => {
+    let resolved = undefined as ReturnType<typeof buildPriceChartPreset> | null | undefined;
+    testSetup = await testRender(
+      <SeriesEditorDialog
+        dialogId="series-editor-last-series-test"
+        initialSpec={buildPriceChartPreset("AAPL")}
+        dismiss={() => {}}
+        resolve={(next) => {
+          resolved = next;
+        }}
+      />,
+      { width: 92, height: 42 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+    const frame = testSetup.captureCharFrame();
+    const rows = frame.split("\n");
+    const actionRow = rows.findIndex((line) => line.includes("Remove") && line.includes("Save"));
+    expect(actionRow).toBeGreaterThan(0);
+    const removeColumn = rows[actionRow]!.indexOf("Remove");
+    const saveColumn = rows[actionRow]!.indexOf("Save");
+    expect(removeColumn).toBeGreaterThan(0);
+    expect(saveColumn).toBeGreaterThan(removeColumn);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(removeColumn, actionRow);
+      await testSetup!.mockMouse.click(saveColumn, actionRow);
+      await testSetup!.renderOnce();
+    });
+
+    expect(resolved?.series).toHaveLength(1);
+    expect(resolved?.series[0]?.source).toMatchObject({
+      kind: "security",
+      instrument: { symbol: "AAPL" },
+    });
+  });
+
+  test("edits financial timing independently from style", async () => {
+    let resolved: ReturnType<typeof buildFundamentalChartPreset> | null | undefined;
+    testSetup = await testRender(
+      <SeriesEditorDialog
+        dialogId="series-editor-timing-test"
+        initialSpec={buildFundamentalChartPreset(["AAPL"])}
+        dismiss={() => {}}
+        resolve={(next) => {
+          resolved = next;
+        }}
+      />,
+      { width: 92, height: 48 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+    const rows = testSetup.captureCharFrame().split("\n");
+    const timingLabelRow = rows.findIndex((line) => line.includes("Timing"));
+    const timingRow = timingLabelRow + 1;
+    const availableColumn = rows[timingRow]?.indexOf("Available Date") ?? -1;
+    const styleLabelRow = rows.findIndex((line) => line.trim() === "Style");
+    const styleRow = styleLabelRow + 1;
+    const lineColumn = rows[styleRow]?.indexOf("Line") ?? -1;
+    const actionRow = rows.findIndex((line) => line.includes("Remove") && line.includes("Save"));
+    const saveColumn = rows[actionRow]?.indexOf("Save") ?? -1;
+    expect(timingLabelRow).toBeGreaterThan(0);
+    expect(availableColumn).toBeGreaterThan(0);
+    expect(styleLabelRow).toBeGreaterThan(0);
+    expect(lineColumn).toBeGreaterThan(0);
+    expect(saveColumn).toBeGreaterThan(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(availableColumn + 1, timingRow);
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      await testSetup!.mockMouse.click(lineColumn + 1, styleRow);
+      await testSetup!.renderOnce();
+    });
+    await act(async () => {
+      await testSetup!.mockMouse.click(saveColumn + 1, actionRow);
+      await testSetup!.renderOnce();
+    });
+
+    expect(resolved?.series[0]).toMatchObject({
+      style: "line",
+      source: { kind: "security", timestampMode: "available-at" },
+    });
+  });
+
+  test("dismisses the editor from the initially focused quick-add with Escape", async () => {
+    let resolved: ReturnType<typeof buildPriceChartPreset> | null | undefined;
+    testSetup = await testRender(
+      <SeriesEditorDialog
+        dialogId="series-editor-escape-test"
+        initialSpec={buildPriceChartPreset("AAPL")}
+        dismiss={() => {}}
+        resolve={(next) => {
+          resolved = next;
+        }}
+      />,
+      { width: 92, height: 42 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+    await emitKey("escape", "\u001b");
+    expect(resolved).toBeNull();
+  });
+
+  test("tabs through add, series, and exact source without clearing the add query", async () => {
+    const initialSpec = appendChartSeries(
+      buildPriceChartPreset("AAPL"),
+      parseSeriesExpression("MSFT")!,
+    ).spec;
+    testSetup = await testRender(
+      <SeriesEditorDialog
+        dialogId="series-editor-focus-order-test"
+        initialSpec={initialSpec}
+        dismiss={() => {}}
+        resolve={() => {}}
+      />,
+      { width: 92, height: 42 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.mockInput.typeText("revenue");
+      await testSetup!.renderOnce();
+    });
+    expect(testSetup.captureCharFrame()).toContain("› Add a series");
+
+    await emitKey("tab", "\t");
+    await emitKey("down", "\u001b[B");
+    await emitKey("tab", "\t");
+    let frame = await waitForFrameToContain("› Exact source (advanced)");
+    expect(frame).toContain("revenue");
+    expect(frame).toContain("› Exact source (advanced)");
+    expect(frame).toContain("MSFT:market.ohlcv");
+
+    await emitKey("tab", "\t", { shift: true });
+    await emitKey("tab", "\t", { shift: true });
+    await act(async () => {
+      await testSetup!.mockInput.typeText("x");
+      await testSetup!.renderOnce();
+    });
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("› Add a series");
+    expect(frame).toContain("revenuex");
+  });
+
+  test("contains editor fields within a narrow terminal", async () => {
+    testSetup = await testRender(
+      <SeriesEditorDialog
+        dialogId="series-editor-narrow-test"
+        initialSpec={buildPriceChartPreset("AAPL")}
+        dismiss={() => {}}
+        resolve={() => {}}
+      />,
+      { width: 60, height: 42 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    const contentWidth = 60 - 8;
+    const overflowRows = testSetup.captureCharFrame()
+      .split("\n")
+      .map((row) => row.trimEnd())
+      .filter((row) => row.length > contentWidth);
+    expect(overflowRows).toEqual([]);
+  });
+
+  test("edits every segmented series setting with Tab and arrow keys", async () => {
+    let resolved: ReturnType<typeof buildFundamentalChartPreset> | null | undefined;
+    testSetup = await testRender(
+      <SeriesEditorDialog
+        dialogId="series-editor-keyboard-settings-test"
+        initialSpec={buildFundamentalChartPreset(["AAPL"])}
+        dismiss={() => {}}
+        resolve={(next) => {
+          resolved = next;
+        }}
+      />,
+      { width: 92, height: 48 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    await emitKey("tab", "\t");
+    await emitKey("tab", "\t");
+    await emitKey("tab", "\t");
+
+    await emitKey("right", "\u001b[C");
+    await emitKey("tab", "\t");
+    await emitKey("right", "\u001b[C");
+    await emitKey("tab", "\t");
+    await emitKey("right", "\u001b[C");
+    await emitKey("tab", "\t");
+    await emitKey("right", "\u001b[C");
+    await emitKey("tab", "\t");
+    await emitKey("right", "\u001b[C");
+    await emitKey("tab", "\t");
+    await emitKey("right", "\u001b[C");
+    await emitKey("tab", "\t");
+    await emitKey("right", "\u001b[C");
+    await emitKey("tab", "\t");
+    await emitKey("right", "\u001b[C");
+    await emitKey("enter", "\r");
+
+    expect(resolved?.series[0]).toMatchObject({
+      style: "line",
+      transform: "percent",
+      axis: "right",
+      panelId: "main",
+      source: {
+        kind: "security",
+        period: "annual",
+        timestampMode: "available-at",
+      },
+    });
+    expect(resolved?.series[0]?.visible).not.toBe(false);
+    expect(resolved?.panels.find((panel) => panel.id === "main")?.scale).toBe("log");
   });
 });

--- a/src/plugins/builtin/chart-composer/editor.tsx
+++ b/src/plugins/builtin/chart-composer/editor.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
-import { Box, Text, type InputRenderable, useUiHost } from "../../../ui";
+import { Box, Text, type InputRenderable, useNativeRenderer, useUiHost } from "../../../ui";
 import { SegmentedControl } from "../../../components";
 import {
   Button,
@@ -19,18 +19,26 @@ import type {
   PanelScale,
   SeriesPeriod,
   SeriesStyle,
+  SeriesTimestampMode,
   SeriesTransform,
 } from "../../../time-series/types";
+import { isFundamentalFieldId } from "../../../time-series/field-catalog";
 import { validateChartSpec } from "../../../time-series/spec";
 import { isPlainKey } from "../../../utils/keyboard";
-import { publicTickerKey } from "../../../utils/exchanges";
 import { getSharedRegistry } from "../../registry";
-import { MAX_CHART_COMPOSER_SERIES, parseChartSpecOr } from "./chart-spec";
+import {
+  canToggleChartSeries,
+  MAX_CHART_COMPOSER_SERIES,
+  parseChartSpecOr,
+} from "./chart-spec";
 import {
   appendChartSeries,
   buildEmptyChartPreset,
   applySeriesStyle,
+  applySeriesTimestampMode,
   buildSeriesSpec,
+  chartSeriesLabel,
+  defaultFinancialTimestampMode,
   formatSeriesExpression,
   getCompatibleSeriesStyles,
   getCompatibleSeriesTransforms,
@@ -46,6 +54,20 @@ import { useSeriesCatalogSuggestions } from "./use-series-catalog";
 const AXES: SeriesAxis[] = ["auto", "left", "right"];
 const MARKET_PERIODS: SeriesPeriod[] = ["auto", "daily", "weekly", "monthly", "quarterly", "annual"];
 const FINANCIAL_PERIODS: SeriesPeriod[] = ["auto", "quarterly", "annual", "ttm"];
+const TIMING_OPTIONS: Array<{ value: SeriesTimestampMode; label: string }> = [
+  { value: "available-at", label: "Available Date" },
+  { value: "period-end", label: "Period End" },
+];
+type SeriesEditorField =
+  | "style"
+  | "transform"
+  | "axis"
+  | "visibility"
+  | "panel"
+  | "scale"
+  | "period"
+  | "timing";
+type SeriesEditorFocus = "add" | "series" | "source" | SeriesEditorField;
 
 function titleCase(value: string): string {
   return value
@@ -62,15 +84,28 @@ function seriesFieldId(series: ChartSeriesSpec): string {
   return series.source.kind === "security" ? series.source.fieldId : series.source.seriesId;
 }
 
-function seriesLabel(series: ChartSeriesSpec): string {
-  if (series.label) return series.label;
-  if (series.source.kind === "economic") return `FRED · ${series.source.seriesId}`;
-  return `${publicTickerKey(series.source.instrument.symbol, series.source.instrument.exchange)} · ${series.source.fieldId.split(".").at(-1)}`;
-}
-
 function compatiblePeriods(series: ChartSeriesSpec | null): SeriesPeriod[] {
   if (!series || series.source.kind !== "security") return [];
   return series.source.fieldId.startsWith("market.") ? MARKET_PERIODS : FINANCIAL_PERIODS;
+}
+
+function supportsTimestampMode(series: ChartSeriesSpec | null): boolean {
+  return !!series
+    && series.source.kind === "security"
+    && isFundamentalFieldId(series.source.fieldId);
+}
+
+function seriesTimestampMode(series: ChartSeriesSpec): SeriesTimestampMode {
+  return series.source.kind === "security"
+    ? series.source.timestampMode
+      ?? defaultFinancialTimestampMode(series.source.fieldId)
+      ?? "available-at"
+    : "available-at";
+}
+
+function timingDescription(series: ChartSeriesSpec): string | null {
+  if (!supportsTimestampMode(series)) return null;
+  return seriesTimestampMode(series) === "available-at" ? "Available date" : "Period end";
 }
 
 function DesktopEditorField({
@@ -90,6 +125,32 @@ function DesktopEditorField({
   );
 }
 
+function TuiEditorField({
+  label,
+  focused,
+  onFocus,
+  children,
+}: {
+  label: string;
+  focused: boolean;
+  onFocus: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Box
+      flexDirection="column"
+      width="100%"
+      overflow="hidden"
+      onMouseDown={onFocus}
+    >
+      <Text fg={focused ? colors.textBright : colors.textDim}>
+        {focused ? `› ${label}` : label}
+      </Text>
+      {children}
+    </Box>
+  );
+}
+
 function pruneSpec(spec: ChartSpec): ChartSpec {
   const selectedBuiltinStudies = getSelectedBuiltinStudies(spec);
   const selectedPairStudies = getSelectedPairStudies(spec);
@@ -103,8 +164,7 @@ function pruneSpec(spec: ChartSpec): ChartSpec {
     return study.inputSeriesIds.length === requiredInputs
       && study.inputSeriesIds.every((id) => seriesIds.has(id));
   });
-  const usedPanels = new Set(["main", ...rebound.series.map((series) => series.panelId), ...studies.map((study) => study.panelId)]);
-  const panels = rebound.panels.filter((panel) => usedPanels.has(panel.id));
+  const panels = [...rebound.panels];
   if (!panels.some((panel) => panel.id === "main")) panels.unshift({ id: "main" });
   return { ...rebound, panels, studies };
 }
@@ -127,6 +187,7 @@ export interface SeriesEditorDialogProps extends PromptContext<ChartSpec | null>
 
 export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEditorDialogProps) {
   const isDesktop = useUiHost().kind === "desktop-web";
+  const nativeRenderer = useNativeRenderer();
   const [draft, setDraft] = useState(() => parseChartSpecOr(initialSpec, buildEmptyChartPreset()));
   const [selectedIndex, setSelectedIndex] = useState(() => clampIndex(0, initialSpec.series.length));
   const [expression, setExpression] = useState(() => initialSpec.series[0] ? formatSeriesExpression(initialSpec.series[0]) : "");
@@ -134,43 +195,72 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
   const [quickAddActive, setQuickAddActive] = useState(true);
   const [quickAddQuery, setQuickAddQuery] = useState("");
   const [quickAddSelection, setQuickAddSelection] = useState(0);
+  const [keyboardFocus, setKeyboardFocus] = useState<SeriesEditorFocus>("add");
   const [error, setError] = useState<string | null>(null);
   const expressionRef = useRef<InputRenderable | null>(null);
   const quickAddRef = useRef<InputRenderable | null>(null);
-  const quickAddActiveRef = useRef(true);
-  const quickAddAutoFocusUntilRef = useRef(0);
+  const keyboardFocusRef = useRef<SeriesEditorFocus>("add");
   const catalogCommitLockRef = useRef(false);
+  const expressionCommitLockRef = useRef(false);
   const selected = selectedIndex >= 0 ? draft.series[selectedIndex] ?? null : null;
-
-  useEffect(() => {
-    if (!quickAddActive) return;
-    quickAddAutoFocusUntilRef.current = Date.now() + 500;
-    const focusQuickAdd = () => quickAddRef.current?.focus?.();
-    let animationFrame: number | null = null;
-    const timeouts: ReturnType<typeof setTimeout>[] = [];
-    focusQuickAdd();
-    queueMicrotask(focusQuickAdd);
-    animationFrame = globalThis.requestAnimationFrame?.(focusQuickAdd) ?? null;
-    timeouts.push(
-      setTimeout(focusQuickAdd, 0),
-      setTimeout(focusQuickAdd, 32),
-      setTimeout(focusQuickAdd, 64),
-    );
-    return () => {
-      if (animationFrame !== null) globalThis.cancelAnimationFrame?.(animationFrame);
-      for (const timeout of timeouts) clearTimeout(timeout);
-    };
-  }, [quickAddActive]);
+  const keyboardFields = useMemo<SeriesEditorField[]>(() => {
+    if (!selected) return [];
+    return [
+      "style",
+      "transform",
+      "axis",
+      "visibility",
+      "panel",
+      "scale",
+      ...(selected.source.kind === "security" ? ["period" as const] : []),
+      ...(supportsTimestampMode(selected) ? ["timing" as const] : []),
+    ];
+  }, [selected]);
+  const keyboardTargets = useMemo<SeriesEditorFocus[]>(() => [
+    "add",
+    ...(selected ? ["series" as const, "source" as const, ...keyboardFields] : []),
+  ], [keyboardFields, selected]);
 
   const activateQuickAdd = () => {
-    quickAddActiveRef.current = true;
     setQuickAddActive(true);
   };
 
   const deactivateQuickAdd = () => {
-    quickAddActiveRef.current = false;
-    quickAddAutoFocusUntilRef.current = 0;
     setQuickAddActive(false);
+  };
+
+  const updateKeyboardFocus = (target: SeriesEditorFocus) => {
+    keyboardFocusRef.current = target;
+    setKeyboardFocus(target);
+  };
+
+  const focusKeyboardTarget = (target: SeriesEditorFocus) => {
+    if (!keyboardTargets.includes(target)) return;
+    updateKeyboardFocus(target);
+    if (target === "add") {
+      setEditingExpression(false);
+      expressionRef.current?.blur?.();
+      activateQuickAdd();
+      queueMicrotask(() => quickAddRef.current?.focus?.());
+      return;
+    }
+
+    deactivateQuickAdd();
+    quickAddRef.current?.blur?.();
+    if (target === "source") {
+      setEditingExpression(true);
+      queueMicrotask(() => expressionRef.current?.focus?.());
+    } else {
+      setEditingExpression(false);
+      expressionRef.current?.blur?.();
+    }
+  };
+
+  const moveKeyboardFocus = (direction: -1 | 1) => {
+    const currentIndex = Math.max(0, keyboardTargets.indexOf(keyboardFocusRef.current));
+    const nextIndex = (currentIndex + direction + keyboardTargets.length) % keyboardTargets.length;
+    const next = keyboardTargets[nextIndex];
+    if (next) focusKeyboardTarget(next);
   };
 
   useEffect(() => {
@@ -208,6 +298,10 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
     setQuickAddSelection(0);
   }, [quickAddQuery, quickAddSuggestions.length]);
 
+  useEffect(() => {
+    if (!keyboardTargets.includes(keyboardFocus)) updateKeyboardFocus("add");
+  }, [keyboardFocus, keyboardTargets]);
+
   const updateSelected = (update: (series: ChartSeriesSpec) => ChartSeriesSpec) => {
     if (!selected) return;
     setDraft((current) => ({
@@ -217,12 +311,17 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
   };
 
   const commitExpression = (): boolean => {
+    if (expressionCommitLockRef.current) return true;
     if (!selected) return false;
     const parsed = parseSeriesExpression(expression);
     if (!parsed) {
       setError("Use SYMBOL, SYMBOL:field, SYMBOL:EXCHANGE:field, or FRED:series.");
       return false;
     }
+    expressionCommitLockRef.current = true;
+    queueMicrotask(() => {
+      expressionCommitLockRef.current = false;
+    });
 
     const candidate = buildSeriesSpec(parsed, selectedIndex);
     const previousFieldId = seriesFieldId(selected);
@@ -233,7 +332,10 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
       ? {
         ...candidate.source,
         ...(previousFieldId === nextFieldId
-          ? { period: selected.source.period, timestampMode: selected.source.timestampMode }
+          ? { period: selected.source.period }
+          : {}),
+        ...(supportsTimestampMode(candidate) && supportsTimestampMode(selected)
+          ? { timestampMode: seriesTimestampMode(selected) }
           : {}),
         instrument: candidate.source.instrument.symbol === selected.source.instrument.symbol
           && (candidate.source.instrument.exchange ?? "") === (selected.source.instrument.exchange ?? "")
@@ -278,8 +380,8 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
       return;
     }
     if (reset) clearQuickAddInput();
+    updateKeyboardFocus("add");
     setEditingExpression(false);
-    quickAddAutoFocusUntilRef.current = Date.now() + 500;
     activateQuickAdd();
     setError(null);
     quickAddRef.current?.focus?.();
@@ -304,6 +406,7 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
     const appended = appendChartSeries(draft, suggestion.expression);
     setDraft(appended.spec);
     setSelectedIndex(appended.spec.series.length - 1);
+    updateKeyboardFocus("series");
     setExpression(formatSeriesExpression(appended.series));
     clearQuickAddInput();
     deactivateQuickAdd();
@@ -315,8 +418,14 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
     addCatalogSuggestion(quickAddSuggestions[clampIndex(quickAddSelection, quickAddSuggestions.length)]);
   };
 
+  const leaveQuickAdd = () => {
+    deactivateQuickAdd();
+    quickAddRef.current?.blur?.();
+    setError(null);
+  };
+
   const removeSeries = () => {
-    if (!selected) return;
+    if (!selected || draft.series.length <= 1) return;
     setDraft((current) => pruneSpec({
       ...current,
       series: current.series.filter((_, index) => index !== selectedIndex),
@@ -335,6 +444,7 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
 
   const beginExpressionEdit = () => {
     if (!selected) return;
+    updateKeyboardFocus("source");
     deactivateQuickAdd();
     setEditingExpression(true);
     queueMicrotask(() => expressionRef.current?.focus?.());
@@ -402,6 +512,22 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
     updateSelected((series) => applySeriesStyle(series, style));
   };
 
+  const setSelectedTimestampMode = (timestampMode: SeriesTimestampMode) => {
+    updateSelected((series) => applySeriesTimestampMode(series, timestampMode));
+  };
+
+  const setSelectedVisibility = (visible: boolean) => {
+    if (!selected) return;
+    setDraft((current) => {
+      const target = current.series[selectedIndex];
+      if (!target || (!visible && !canToggleChartSeries(current, target.id))) return current;
+      return {
+        ...current,
+        series: replaceAt(current.series, selectedIndex, { ...target, visible }),
+      };
+    });
+  };
+
   const saveDraft = () => {
     const next = pruneSpec(draft);
     const validation = validateChartSpec(next);
@@ -418,7 +544,16 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
   };
 
   useDialogKeyboard((event) => {
-    if (quickAddActive) {
+    if (isDesktop && (event.targetEditable === true || event.name === "tab")) {
+      if (event.name === "escape") {
+        event.stopPropagation();
+        event.preventDefault();
+        resolve(null);
+      }
+      return;
+    }
+
+    if ((isDesktop && quickAddActive) || (!isDesktop && keyboardFocusRef.current === "add")) {
       const printableSequence = (
         !event.ctrl
         && !event.alt
@@ -443,9 +578,12 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
       } else if (event.name === "escape") {
         event.stopPropagation();
         event.preventDefault();
-        clearQuickAddInput();
-        deactivateQuickAdd();
-        quickAddRef.current?.blur?.();
+        resolve(null);
+      } else if (event.name === "tab") {
+        event.stopPropagation();
+        event.preventDefault();
+        leaveQuickAdd();
+        moveKeyboardFocus(event.shift ? -1 : 1);
       } else if (
         event.targetEditable !== true
         && printableSequence
@@ -456,32 +594,36 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
         quickAddRef.current?.editBuffer.setText?.(nextQuery);
         quickAddRef.current?.setCursorOffset?.(nextQuery.length);
         setQuickAddQuery(nextQuery);
-        quickAddAutoFocusUntilRef.current = 0;
         activateQuickAdd();
         quickAddRef.current?.focus?.();
       }
       return;
     }
 
-    if (editingExpression) {
+    if ((isDesktop && editingExpression) || (!isDesktop && keyboardFocusRef.current === "source")) {
       if (event.name === "escape") {
         event.stopPropagation();
-        setExpression(selected ? formatSeriesExpression(selected) : "");
-        setEditingExpression(false);
-        expressionRef.current?.blur?.();
-        setError(null);
+        event.preventDefault();
+        resolve(null);
       } else if (event.name === "enter" || event.name === "return") {
         event.stopPropagation();
-        commitExpression();
+        event.preventDefault();
+        if (commitExpression()) moveKeyboardFocus(1);
+      } else if (event.name === "tab") {
+        event.stopPropagation();
+        event.preventDefault();
+        if (commitExpression()) moveKeyboardFocus(event.shift ? -1 : 1);
       }
       return;
     }
 
     event.stopPropagation();
     event.preventDefault();
-    if (isPlainKey(event, "up", "k")) {
+    if (event.name === "tab") {
+      moveKeyboardFocus(event.shift ? -1 : 1);
+    } else if (keyboardFocusRef.current === "series" && isPlainKey(event, "up", "k")) {
       setSelectedIndex((current) => clampIndex(current - 1, draft.series.length));
-    } else if (isPlainKey(event, "down", "j")) {
+    } else if (keyboardFocusRef.current === "series" && isPlainKey(event, "down", "j")) {
       setSelectedIndex((current) => clampIndex(current + 1, draft.series.length));
     } else if (event.name === "[") {
       moveSeries(-1);
@@ -508,8 +650,14 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
 
   const items = useMemo<ListViewItem[]>(() => draft.series.map((series) => ({
     id: series.id,
-    label: seriesLabel(series),
-    description: `${titleCase(series.style)} · ${titleCase(series.transform)} · ${titleCase(series.axis)} axis · ${series.panelId}`,
+    label: chartSeriesLabel(series),
+    description: [
+      titleCase(series.style),
+      timingDescription(series),
+      titleCase(series.transform),
+      `${titleCase(series.axis)} axis`,
+      series.panelId,
+    ].filter(Boolean).join(" · "),
   })), [draft.series]);
   const quickAddItems = useMemo<ListViewItem[]>(() => quickAddSuggestions.map((suggestion) => ({
     id: suggestion.id,
@@ -526,51 +674,51 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
     : [];
   const selectedPanel = selected ? draft.panels.find((panel) => panel.id === selected.panelId) : null;
   const periodOptions = compatiblePeriods(selected);
-  const contentWidth = isDesktop ? "660px" : 76;
+  const availableTuiWidth = nativeRenderer.terminalWidth > 0
+    ? nativeRenderer.terminalWidth - 8
+    : 76;
+  const tuiContentWidth = Math.max(1, Math.min(76, availableTuiWidth));
+  const contentWidth = isDesktop ? "660px" : tuiContentWidth;
+  const fieldLabel = (field: SeriesEditorFocus, label: string) => (
+    keyboardFocus === field ? `› ${label}` : label
+  );
 
   return (
     <DialogFrame
       title="Chart Series"
       footer={isDesktop
         ? undefined
-        : "↑↓ select · E source · P panel · L scale · N new panel · A add · D remove · [ ] reorder · Enter save"}
+        : "Tab/Shift+Tab field · ←→ change · ↑↓ series"}
     >
       <Box
         flexDirection="column"
         width={contentWidth}
+        overflow="hidden"
         gap={1}
         style={isDesktop ? { gap: 10 } : undefined}
       >
         <TextField
-          label="Add a series"
+          label={isDesktop ? "Add a series" : fieldLabel("add", "Add a series")}
           value={quickAddQuery}
           placeholder={`Search ${defaultInstrument.symbol} metrics or type “MSFT revenue”`}
           hint={isDesktop ? "Search by ticker or company and metric. Exact FRED IDs also work." : undefined}
           focused={quickAddActive}
+          width={isDesktop ? undefined : tuiContentWidth}
           inputRef={quickAddRef}
           onMouseDown={() => beginQuickAdd()}
           onChange={(value) => {
             setQuickAddQuery(value);
             if (value.trim()) {
-              quickAddAutoFocusUntilRef.current = 0;
               activateQuickAdd();
             }
           }}
           onSubmit={submitQuickAdd}
-          onBlur={() => {
-            if (quickAddActiveRef.current && Date.now() < quickAddAutoFocusUntilRef.current) {
-              queueMicrotask(() => {
-                if (quickAddActiveRef.current) quickAddRef.current?.focus?.();
-              });
-              return;
-            }
-            deactivateQuickAdd();
-          }}
+          onBlur={deactivateQuickAdd}
         />
 
-        {quickAddQuery.trim() && (
+        {quickAddActive && quickAddQuery.trim() && (
           quickAddItems.length > 0 ? (
-            <Box overflow="hidden">
+            <Box width={contentWidth} overflow="hidden" onMouseDown={() => beginQuickAdd()}>
               <ListView
                 items={quickAddItems}
                 selectedIndex={quickAddSelection}
@@ -591,17 +739,26 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
         )}
 
         {items.length > 0 ? (
-          <Box overflow="hidden">
+          <Box
+            width={contentWidth}
+            overflow="hidden"
+            onMouseDown={() => {
+              if (!isDesktop) focusKeyboardTarget("series");
+            }}
+          >
             <ListView
               items={items}
               selectedIndex={selectedIndex}
               height={isDesktop
                 ? Math.min(5, items.length)
-                : Math.min(7, Math.max(3, items.length))}
+                : Math.min(7, Math.max(1, items.length))}
               surface={isDesktop ? "plain" : "framed"}
+              selectedBgColor={!isDesktop && keyboardFocus === "series"
+                ? colors.borderFocused
+                : undefined}
               scrollable={items.length > (isDesktop ? 5 : 7)}
               rowGap={isDesktop ? 0 : undefined}
-              selectOnHover
+              selectOnHover={isDesktop}
               onSelect={setSelectedIndex}
               onActivate={(_, index) => {
                 setSelectedIndex(index);
@@ -615,17 +772,47 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
         )}
 
         {selected && (
-          <Box flexDirection="column" gap={1}>
+          <Box flexDirection="column" width="100%" overflow="hidden" gap={1}>
             <TextField
-              label="Source expression"
+              label={isDesktop
+                ? "Exact source (advanced)"
+                : fieldLabel("source", "Exact source (advanced)")}
               value={expression}
               placeholder="AAPL:revenue or FRED:CPIAUCSL"
+              hint={isDesktop
+                ? "Changes this series in place; use an exact symbol, field, or FRED ID."
+                : undefined}
               focused={editingExpression}
+              width={isDesktop ? undefined : tuiContentWidth}
               inputRef={expressionRef}
               onMouseDown={beginExpressionEdit}
+              onKeyDown={(event) => {
+                if (event.defaultPrevented) return;
+                if (event.name === "escape") {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  resolve(null);
+                } else if (event.name === "enter" || event.name === "return") {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  if (commitExpression()) moveKeyboardFocus(1);
+                } else if (event.name === "tab") {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  if (commitExpression()) moveKeyboardFocus(event.shift ? -1 : 1);
+                }
+              }}
               onChange={setExpression}
               onSubmit={() => { commitExpression(); }}
-              onBlur={() => { if (editingExpression) commitExpression(); }}
+              onBlur={() => {
+                if (!editingExpression) return;
+                const committed = commitExpression();
+                if (!committed && !isDesktop) {
+                  updateKeyboardFocus("source");
+                  setEditingExpression(true);
+                  queueMicrotask(() => expressionRef.current?.focus?.());
+                }
+              }}
             />
 
             {isDesktop ? (
@@ -678,9 +865,19 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
                         label="Show series"
                         checked={selected.visible !== false}
                         variant="desktop"
-                        onChange={(visible) => updateSelected((series) => ({ ...series, visible }))}
+                        onChange={setSelectedVisibility}
                       />
                     </Box>
+                  </DesktopEditorField>
+                )}
+                {supportsTimestampMode(selected) && (
+                  <DesktopEditorField label="Timing">
+                    <NativeSelect
+                      value={seriesTimestampMode(selected)}
+                      options={TIMING_OPTIONS}
+                      width="100%"
+                      onChange={(value) => setSelectedTimestampMode(value as SeriesTimestampMode)}
+                    />
                   </DesktopEditorField>
                 )}
                 <DesktopEditorField label="Panel">
@@ -714,7 +911,7 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
                         label="Show series"
                         checked={selected.visible !== false}
                         variant="desktop"
-                        onChange={(visible) => updateSelected((series) => ({ ...series, visible }))}
+                        onChange={setSelectedVisibility}
                       />
                     </Box>
                   </DesktopEditorField>
@@ -722,59 +919,103 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
               </Box>
             ) : (
               <>
-                <Box flexDirection="column">
-                  <Text fg={colors.textDim}>Style</Text>
+                <TuiEditorField
+                  label="Style"
+                  focused={keyboardFocus === "style"}
+                  onFocus={() => focusKeyboardTarget("style")}
+                >
                   <SegmentedControl
                     options={styleOptions}
                     value={selected.style}
                     onChange={(value) => setSelectedStyle(value as SeriesStyle)}
+                    focused={keyboardFocus === "style"}
+                    shortcutScope={dialogId}
+                    width="100%"
+                    wrap
                   />
-                </Box>
+                </TuiEditorField>
 
-                <Box flexDirection="column">
-                  <Text fg={colors.textDim}>Transform</Text>
+                <TuiEditorField
+                  label="Transform"
+                  focused={keyboardFocus === "transform"}
+                  onFocus={() => focusKeyboardTarget("transform")}
+                >
                   <SegmentedControl
                     options={transformOptions}
                     value={selected.transform}
                     onChange={(value) => setSelectedTransform(value as SeriesTransform)}
+                    focused={keyboardFocus === "transform"}
+                    shortcutScope={dialogId}
+                    width="100%"
+                    wrap
                   />
-                </Box>
+                </TuiEditorField>
 
-                <Box flexDirection="column">
-                  <Text fg={colors.textDim}>Axis</Text>
+                <TuiEditorField
+                  label="Axis"
+                  focused={keyboardFocus === "axis"}
+                  onFocus={() => focusKeyboardTarget("axis")}
+                >
                   <SegmentedControl
                     options={AXES.map((value) => ({ value, label: titleCase(value) }))}
                     value={selected.axis}
                     onChange={(value) => updateSelected((series) => ({ ...series, axis: value as SeriesAxis }))}
+                    focused={keyboardFocus === "axis"}
+                    shortcutScope={dialogId}
+                    width="100%"
+                    wrap
                   />
-                </Box>
+                </TuiEditorField>
 
-                <Box flexDirection="column">
-                  <Text fg={colors.textDim}>Visibility</Text>
+                <TuiEditorField
+                  label="Visibility"
+                  focused={keyboardFocus === "visibility"}
+                  onFocus={() => focusKeyboardTarget("visibility")}
+                >
                   <SegmentedControl
                     options={[
                       { value: "shown", label: "Shown" },
-                      { value: "hidden", label: "Hidden" },
+                      {
+                        value: "hidden",
+                        label: "Hidden",
+                        disabled: selected.visible !== false && !canToggleChartSeries(draft, selected.id),
+                      },
                     ]}
                     value={selected.visible === false ? "hidden" : "shown"}
-                    onChange={(value) => updateSelected((series) => ({ ...series, visible: value !== "hidden" }))}
+                    onChange={(value) => setSelectedVisibility(value !== "hidden")}
+                    focused={keyboardFocus === "visibility"}
+                    shortcutScope={dialogId}
+                    width="100%"
+                    wrap
                   />
-                </Box>
+                </TuiEditorField>
 
-                <Box flexDirection="column">
-                  <Text fg={colors.textDim}>Panel</Text>
-                  <Box flexDirection="row" gap={1}>
-                    <SegmentedControl
-                      options={draft.panels.map((panel) => ({ value: panel.id, label: panel.label ?? titleCase(panel.id) }))}
-                      value={selected.panelId}
-                      onChange={setSelectedPanel}
-                    />
+                <TuiEditorField
+                  label="Panel"
+                  focused={keyboardFocus === "panel"}
+                  onFocus={() => focusKeyboardTarget("panel")}
+                >
+                  <Box flexDirection="row" width="100%" minWidth={0} gap={1} overflow="hidden">
+                    <Box flexGrow={1} minWidth={0} overflow="hidden">
+                      <SegmentedControl
+                        options={draft.panels.map((panel) => ({ value: panel.id, label: panel.label ?? titleCase(panel.id) }))}
+                        value={selected.panelId}
+                        onChange={setSelectedPanel}
+                        focused={keyboardFocus === "panel"}
+                        shortcutScope={dialogId}
+                        width="100%"
+                        wrap
+                      />
+                    </Box>
                     <Button label="New Panel" shortcut="N" onPress={addPanel} />
                   </Box>
-                </Box>
+                </TuiEditorField>
 
-                <Box flexDirection="column">
-                  <Text fg={colors.textDim}>{`Scale (${selectedPanel?.label ?? selected.panelId})`}</Text>
+                <TuiEditorField
+                  label={`Scale (${selectedPanel?.label ?? selected.panelId})`}
+                  focused={keyboardFocus === "scale"}
+                  onFocus={() => focusKeyboardTarget("scale")}
+                >
                   <SegmentedControl
                     options={[
                       { value: "linear", label: "Linear" },
@@ -782,12 +1023,19 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
                     ]}
                     value={selectedPanel?.scale ?? "linear"}
                     onChange={(value) => setSelectedPanelScale(value as PanelScale)}
+                    focused={keyboardFocus === "scale"}
+                    shortcutScope={dialogId}
+                    width="100%"
+                    wrap
                   />
-                </Box>
+                </TuiEditorField>
 
                 {selected.source.kind === "security" && (
-                  <Box flexDirection="column">
-                    <Text fg={colors.textDim}>Period</Text>
+                  <TuiEditorField
+                    label="Period"
+                    focused={keyboardFocus === "period"}
+                    onFocus={() => focusKeyboardTarget("period")}
+                  >
                     <SegmentedControl
                       options={periodOptions.map((value) => ({ value, label: value === "ttm" ? "TTM" : titleCase(value) }))}
                       value={selected.source.period ?? "auto"}
@@ -795,8 +1043,30 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
                         ...series,
                         source: { ...series.source, period: value as SeriesPeriod },
                       }) : series)}
+                      focused={keyboardFocus === "period"}
+                      shortcutScope={dialogId}
+                      width="100%"
+                      wrap
                     />
-                  </Box>
+                  </TuiEditorField>
+                )}
+
+                {supportsTimestampMode(selected) && (
+                  <TuiEditorField
+                    label="Timing"
+                    focused={keyboardFocus === "timing"}
+                    onFocus={() => focusKeyboardTarget("timing")}
+                  >
+                    <SegmentedControl
+                      options={TIMING_OPTIONS}
+                      value={seriesTimestampMode(selected)}
+                      onChange={(value) => setSelectedTimestampMode(value as SeriesTimestampMode)}
+                      focused={keyboardFocus === "timing"}
+                      shortcutScope={dialogId}
+                      width="100%"
+                      wrap
+                    />
+                  </TuiEditorField>
                 )}
               </>
             )}
@@ -810,7 +1080,7 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
             <>
               <Box flexDirection="row" style={{ gap: 6 }}>
                 <Button label="Add Series" onPress={() => beginQuickAdd(true)} disabled={draft.series.length >= MAX_CHART_COMPOSER_SERIES} />
-                <Button label="Remove" variant="danger" onPress={removeSeries} disabled={!selected} />
+                <Button label="Remove" variant="danger" onPress={removeSeries} disabled={!selected || draft.series.length <= 1} />
                 <Button label="Move Up" onPress={() => moveSeries(-1)} disabled={selectedIndex <= 0} />
                 <Button label="Move Down" onPress={() => moveSeries(1)} disabled={selectedIndex < 0 || selectedIndex >= draft.series.length - 1} />
               </Box>
@@ -823,7 +1093,7 @@ export function SeriesEditorDialog({ dialogId, resolve, initialSpec }: SeriesEdi
           ) : (
             <>
               <Button label="Add Series" shortcut="A" onPress={() => beginQuickAdd(true)} disabled={draft.series.length >= MAX_CHART_COMPOSER_SERIES} />
-              <Button label="Remove" shortcut="D" variant="danger" onPress={removeSeries} disabled={!selected} />
+              <Button label="Remove" shortcut="D" variant="danger" onPress={removeSeries} disabled={!selected || draft.series.length <= 1} />
               <Button label="Move Up" onPress={() => moveSeries(-1)} disabled={selectedIndex <= 0} />
               <Button label="Move Down" onPress={() => moveSeries(1)} disabled={selectedIndex < 0 || selectedIndex >= draft.series.length - 1} />
               <Button label="Cancel" variant="ghost" onPress={() => resolve(null)} />

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Box } from "../../../ui";
+import { Box, Text } from "../../../ui";
 import {
   ChoiceDialog,
   Tabs,
@@ -13,7 +13,7 @@ import {
 import { CompositeChart } from "../../../components/chart/composite";
 import type { PaneProps, TickerResearchTabProps } from "../../../types/plugin";
 import type { ChartResolution, TimeRange } from "../../../components/chart/core/types";
-import type { ChartSeriesSpec, ChartSpec, SeriesStyle } from "../../../time-series/types";
+import type { ChartSpec, SeriesStyle } from "../../../time-series/types";
 import { useResolvedChartSpec } from "../../../time-series/hooks";
 import { useShortcut } from "../../../react/input";
 import { useDialog, useDialogState, type PromptContext } from "../../../ui/dialog";
@@ -30,13 +30,17 @@ import { SeriesEditorDialog } from "./editor";
 import { DateWindowDialog, type DateWindowDialogResult } from "./date-window-dialog";
 import { chartComposerSemanticMetadata } from "./semantic";
 import {
+  canToggleChartSeries,
   CHART_SPEC_SETTING_KEY,
   parseChartSpecOr,
+  projectVisibleChartSeries,
+  toggleChartSeries,
 } from "./chart-spec";
 import {
   buildEmptyChartPreset,
   buildPriceChartPreset,
   applySeriesStyle,
+  chartSeriesLabel,
   getSelectedBuiltinStudies,
   getSelectedPairStudies,
   setBuiltinStudies,
@@ -50,13 +54,19 @@ import {
   CHART_RANGES as RANGES,
   CHART_RESOLUTIONS as RESOLUTIONS,
   CHART_STUDY_OPTIONS,
-  getChartPrimaryStyles,
+  getChartInlineStyles,
+  getChartInlineStyleTarget,
 } from "./settings";
 import { resolveChartComposerShortcut } from "./shortcuts";
 import { ChartSeriesQuickAdd } from "./quick-add";
 
 const RANGE_TABS = RANGES.map((range, index) => ({ label: `${index + 1}:${range}`, value: range }));
 const RESOLUTION_TABS = RESOLUTIONS.map((value) => ({ label: value.toUpperCase(), value }));
+const RESOLUTION_TABS_WIDTH = RESOLUTION_TABS.reduce(
+  (width, tab) => width + [...tab.label].length + 1,
+  0,
+);
+const AUTO_VIEWPORT_DEBOUNCE_MS = 120;
 
 function footerAnchorPoint(event?: PaneFooterPressEvent): { x: number; y: number } | undefined {
   const x = event?.pixelX;
@@ -74,10 +84,6 @@ export interface ChartComposerSurfaceProps {
   height: number;
   footerId: string;
   onCapture?: (capturing: boolean) => void;
-}
-
-function replacePrimarySeries(spec: ChartSpec, next: ChartSeriesSpec): ChartSpec {
-  return { ...spec, series: [next, ...spec.series.slice(1)] };
 }
 
 function isPriceStudyTarget(spec: ChartSpec): boolean {
@@ -100,17 +106,52 @@ export function ChartComposerSurface({
   const dispatch = useAppDispatch();
   const paneId = usePaneInstanceId();
   const dialogOpen = useDialogState((state) => state.isOpen);
-  const resolution = useResolvedChartSpec(spec);
+  const authoredViewportKey = useMemo(() => JSON.stringify({
+    range: spec.viewport.range,
+    resolution: spec.viewport.resolution,
+    dateWindow: spec.viewport.dateWindow ?? null,
+    sources: spec.series.map((entry) => entry.source.kind === "security"
+      ? [
+          entry.id,
+          entry.source.kind,
+          entry.source.instrument.symbol,
+          entry.source.instrument.exchange ?? "",
+          entry.source.fieldId,
+          entry.source.period ?? "auto",
+        ]
+      : [entry.id, entry.source.kind, entry.source.seriesId]),
+  }), [spec.series, spec.viewport.dateWindow, spec.viewport.range, spec.viewport.resolution]);
+  const [autoViewportState, setAutoViewportState] = useState<{
+    key: string;
+    viewport: { start: Date; end: Date };
+  } | null>(null);
+  const autoViewportTimerRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
+  const autoViewport = autoViewportState?.key === authoredViewportKey
+    && spec.viewport.resolution === "auto"
+    ? autoViewportState.viewport
+    : null;
+  const targetPointCount = Math.max(60, Math.floor(width * 1.25));
+  const resolution = useResolvedChartSpec(spec, { autoViewport, targetPointCount });
   const selectedStudies = getSelectedBuiltinStudies(spec);
   const selectedPairStudies = getSelectedPairStudies(spec);
-  const styles = useMemo(() => getChartPrimaryStyles(spec), [spec]);
+  const inlineStyleTarget = useMemo(() => getChartInlineStyleTarget(spec), [spec]);
+  const styles = useMemo(() => getChartInlineStyles(spec), [spec]);
   const styleTabs = useMemo(
     () => styles.map((value) => ({ label: value.toUpperCase(), value })),
     [styles],
   );
-  const primaryStyle = spec.series[0]?.style ?? "line";
+  const inlineStyle = inlineStyleTarget?.style ?? "line";
+  const inlineStyleLabel = inlineStyleTarget ? chartSeriesLabel(inlineStyleTarget) : "";
   const viewport = resolution.viewport;
   const baseSeriesIds = useMemo(() => new Set(spec.series.map((series) => series.id)), [spec.series]);
+  const plottedSeries = useMemo(
+    () => projectVisibleChartSeries(
+      spec,
+      resolution.bufferedSeries ?? resolution.series,
+      resolution.legendSeries,
+    ),
+    [resolution.bufferedSeries, resolution.legendSeries, resolution.series, spec],
+  );
   const [interactionCaptured, setInteractionCapturedState] = useState(false);
   const [quickAddWidth, setQuickAddWidth] = useState(14);
   const interactionCaptureRef = useRef(false);
@@ -142,6 +183,45 @@ export function ChartComposerSurface({
   const activatePane = useCallback(() => {
     if (!focused) dispatch({ type: "FOCUS_PANE", paneId });
   }, [dispatch, focused, paneId]);
+  useEffect(() => {
+    if (autoViewportTimerRef.current !== null) {
+      clearTimeout(autoViewportTimerRef.current);
+      autoViewportTimerRef.current = null;
+    }
+    setAutoViewportState((current) => current?.key === authoredViewportKey ? current : null);
+    return () => {
+      if (autoViewportTimerRef.current !== null) {
+        clearTimeout(autoViewportTimerRef.current);
+        autoViewportTimerRef.current = null;
+      }
+    };
+  }, [authoredViewportKey]);
+  const handleChartViewportChange = useCallback((next: { start: Date; end: Date } | null) => {
+    if (autoViewportTimerRef.current !== null) {
+      clearTimeout(autoViewportTimerRef.current);
+      autoViewportTimerRef.current = null;
+    }
+    if (spec.viewport.resolution !== "auto" || !next) {
+      setAutoViewportState(null);
+      return;
+    }
+    const start = next.start.getTime();
+    const end = next.end.getTime();
+    if (!Number.isFinite(start) || !Number.isFinite(end) || start > end) return;
+    autoViewportTimerRef.current = globalThis.setTimeout(() => {
+      autoViewportTimerRef.current = null;
+      setAutoViewportState((current) => (
+        current?.key === authoredViewportKey
+          && current.viewport.start.getTime() === start
+          && current.viewport.end.getTime() === end
+          ? current
+          : {
+              key: authoredViewportKey,
+              viewport: { start: new Date(start), end: new Date(end) },
+            }
+      ));
+    }, AUTO_VIEWPORT_DEBOUNCE_MS);
+  }, [authoredViewportKey, spec.viewport.resolution]);
 
   useRemoteUiNode({
     role: "chart-data",
@@ -153,7 +233,8 @@ export function ChartComposerSurface({
     setInteractionCaptured("prompt", true);
     try {
       const next = await dialog.prompt<ChartSpec | null>({
-        closeOnClickOutside: false,
+        closeOnClickOutside: true,
+        size: "large",
         content: (context: PromptContext<ChartSpec | null>) => (
           <SeriesEditorDialog {...context} initialSpec={spec} />
         ),
@@ -174,7 +255,7 @@ export function ChartComposerSurface({
     setInteractionCaptured("prompt", true);
     try {
       const result = await dialog.prompt<DateWindowDialogResult>({
-        closeOnClickOutside: false,
+        closeOnClickOutside: true,
         content: (context: PromptContext<DateWindowDialogResult>) => (
           <DateWindowDialog {...context} initial={spec.viewport.dateWindow} />
         ),
@@ -198,11 +279,15 @@ export function ChartComposerSurface({
   const setResolution = useCallback((next: ChartResolution) => {
     setSpec({ ...spec, viewport: { ...spec.viewport, resolution: next } });
   }, [setSpec, spec]);
-  const setPrimaryStyle = useCallback((style: SeriesStyle) => {
-    const primary = spec.series[0];
-    if (!primary || !styles.includes(style)) return;
-    setSpec(replacePrimarySeries(spec, applySeriesStyle(primary, style)));
-  }, [setSpec, spec, styles]);
+  const setInlineStyle = useCallback((style: SeriesStyle) => {
+    if (!inlineStyleTarget || !styles.includes(style)) return;
+    setSpec({
+      ...spec,
+      series: spec.series.map((series) => (
+        series.id === inlineStyleTarget.id ? applySeriesStyle(series, style) : series
+      )),
+    });
+  }, [inlineStyleTarget, setSpec, spec, styles]);
   const openRangePicker = useCallback(async () => {
     setInteractionCaptured("prompt", true);
     try {
@@ -260,29 +345,33 @@ export function ChartComposerSurface({
         content: (context: PromptContext<string>) => (
           <ChoiceDialog
             {...context}
-            title="Chart Mode"
-            selectedChoiceId={primaryStyle}
+            title={`${inlineStyleLabel} Style`}
+            selectedChoiceId={inlineStyle}
             choices={styles.map((value) => ({
               id: value,
               label: value.toUpperCase(),
-              description: `Draw the primary series as ${value}.`,
+              description: `Draw ${inlineStyleLabel} as ${value}.`,
             }))}
           />
         ),
       }).catch(() => "");
-      if (styles.includes(next as SeriesStyle)) setPrimaryStyle(next as SeriesStyle);
+      if (styles.includes(next as SeriesStyle)) setInlineStyle(next as SeriesStyle);
     } finally {
       setInteractionCaptured("prompt", false);
     }
-  }, [dialog, primaryStyle, setInteractionCaptured, setPrimaryStyle, styles]);
+  }, [dialog, inlineStyle, inlineStyleLabel, setInlineStyle, setInteractionCaptured, styles]);
   const toggleSeries = useCallback((seriesId: string) => {
-    setSpec({
-      ...spec,
-      series: spec.series.map((series) => series.id === seriesId
-        ? { ...series, visible: series.visible === false }
-        : series),
-    });
+    const next = toggleChartSeries(spec, seriesId);
+    if (next !== spec) setSpec(next);
   }, [setSpec, spec]);
+  const isSeriesToggleable = useCallback(
+    (series: { id: string }) => baseSeriesIds.has(series.id) && canToggleChartSeries(spec, series.id),
+    [baseSeriesIds, spec],
+  );
+  const handleQuickAddActiveChange = useCallback(
+    (active: boolean) => setInteractionCaptured("quick-add", active),
+    [setInteractionCaptured],
+  );
   const openIndicators = useCallback((event?: PaneFooterPressEvent) => {
     indicatorsDialogRef.current?.open(footerAnchorPoint(event));
   }, []);
@@ -384,40 +473,57 @@ export function ChartComposerSurface({
 
   return (
     <Box flexDirection="column" width={width} height={height} backgroundColor={colors.panel}>
-      <Box flexDirection="row" height={1} paddingX={1} gap={1} overflow="hidden">
+      <Box flexDirection="row" height={1} paddingX={1} gap={0} overflow="hidden">
         <Box flexShrink={0} height={1} maxWidth={52} overflow="hidden">
           <Tabs
             tabs={RANGE_TABS}
             activeValue={spec.viewport.dateWindow ? null : spec.viewport.range}
             onSelect={(value) => setRange(value as TimeRange)}
             compact
+            dense
             variant="bare"
             focused={focused}
             keyboardNavigation={false}
           />
         </Box>
 
-        <Box flexGrow={1} flexShrink={1} minWidth={0} maxWidth={82} height={1} overflow="hidden">
+        <Box flexGrow={1} minWidth={0} height={1} />
+        <Box
+          flexShrink={1}
+          minWidth={0}
+          width={RESOLUTION_TABS_WIDTH}
+          height={1}
+          overflow="hidden"
+          data-gloom-role="chart-resolution-control"
+        >
           <Tabs
             tabs={RESOLUTION_TABS}
             activeValue={spec.viewport.resolution}
             onSelect={(value) => setResolution(value as ChartResolution)}
             compact
+            dense
             variant="bare"
             focused={focused}
             keyboardNavigation={false}
           />
         </Box>
-        {width >= 132 && (
-          <Box flexGrow={1} />
-        )}
-        {width >= 132 && (
-          <Box flexShrink={0} maxWidth={48} height={1} overflow="hidden">
+        {width >= 132 && inlineStyleTarget && (
+          <Box
+            flexDirection="row"
+            flexShrink={0}
+            maxWidth={64}
+            height={1}
+            overflow="hidden"
+            data-gloom-role="chart-inline-style"
+            data-gloom-label={`${inlineStyleLabel} style`}
+          >
+            <Text fg={colors.textDim}>{`${inlineStyleLabel}: `}</Text>
             <Tabs
               tabs={styleTabs}
-              activeValue={primaryStyle}
-              onSelect={(value) => setPrimaryStyle(value as SeriesStyle)}
+              activeValue={inlineStyle}
+              onSelect={(value) => setInlineStyle(value as SeriesStyle)}
               compact
+              dense
               variant="bare"
               focused={focused}
               keyboardNavigation={false}
@@ -456,7 +562,7 @@ export function ChartComposerSurface({
 
       <Box flexGrow={1} minHeight={4}>
         <CompositeChart
-          series={resolution.bufferedSeries ?? resolution.series}
+          series={plottedSeries}
           legendSeries={resolution.legendSeries}
           panels={spec.panels}
           viewport={viewport}
@@ -464,9 +570,10 @@ export function ChartComposerSurface({
           height={Math.max(4, height - 1)}
           focused={focused}
           interactive={surfaceInteractive}
+          onViewportChange={handleChartViewportChange}
           onActivate={activatePane}
           onToggleSeries={toggleSeries}
-          isSeriesToggleable={(series) => baseSeriesIds.has(series.id)}
+          isSeriesToggleable={isSeriesToggleable}
           emptyMessage={emptyMessage}
           legendAccessory={(
             <ChartSeriesQuickAdd
@@ -478,7 +585,7 @@ export function ChartComposerSurface({
               shortcutEnabled={surfaceInteractive}
               shortcutBlocked={dialogOpen}
               onActivatePane={activatePane}
-              onActiveChange={(active) => setInteractionCaptured("quick-add", active)}
+              onActiveChange={handleQuickAddActiveChange}
               onWidthChange={setQuickAddWidth}
             />
           )}

--- a/src/plugins/builtin/chart-composer/presets.test.ts
+++ b/src/plugins/builtin/chart-composer/presets.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+  canToggleChartSeries,
   parseChartSpec,
+  projectVisibleChartSeries,
   serializeChartSpec,
+  toggleChartSeries,
 } from "./chart-spec";
 import {
   appendChartSeries,
@@ -12,6 +15,7 @@ import {
   buildPriceChartPreset,
   buildSeriesSpec,
   applySeriesStyle,
+  applySeriesTimestampMode,
   getSelectedBuiltinStudies,
   getSelectedPairStudies,
   parseChartExpression,
@@ -48,6 +52,64 @@ describe("chart composer expressions", () => {
       "aapl-market-ohlcv-3",
       "aapl-market-ohlcv-3-2",
     ]);
+  });
+
+  test("places appended financial data in a synchronized panel without rewriting authored state", () => {
+    const price = buildPriceChartPreset("AAPL");
+    const authored = {
+      ...price,
+      viewport: { ...price.viewport, range: "3M" as const },
+      panels: [...price.panels, { id: "notes", label: "Reserved", height: 0.4 }],
+    };
+    const appended = appendChartSeries(authored, {
+      kind: "security",
+      symbol: "MSFT",
+      fieldId: "fundamental.totalRevenue",
+    });
+
+    expect(appended.spec.viewport).toEqual(authored.viewport);
+    expect(appended.spec.studies).toEqual(authored.studies);
+    expect(appended.spec.series[0]).toEqual(authored.series[0]);
+    expect(appended.spec.panels.slice(0, authored.panels.length)).toEqual(authored.panels);
+    expect(appended.series).toMatchObject({
+      style: "columns",
+      panelId: "fundamentals",
+      source: { timestampMode: "available-at" },
+    });
+    expect(appended.spec.panels.find((panel) => panel.id === "fundamentals")).toMatchObject({
+      label: "Fundamentals",
+      height: 0.35,
+    });
+  });
+
+  test("places only the new candidate when incremental axes or panel scopes overflow", () => {
+    const fundamentals = buildFundamentalChartPreset(["AAPL"]);
+    const withPrice = appendChartSeries(fundamentals, {
+      kind: "security",
+      symbol: "AAPL",
+      fieldId: "market.ohlcv",
+    });
+    expect(withPrice.spec.series[0]).toEqual(fundamentals.series[0]);
+    expect(withPrice.series.panelId).toBe("panel-2");
+
+    const price = buildPriceChartPreset("AAPL");
+    const withCpi = appendChartSeries(price, {
+      kind: "economic",
+      provider: "fred",
+      seriesId: "CPIAUCSL",
+    }).spec;
+    const withRates = appendChartSeries(withCpi, {
+      kind: "economic",
+      provider: "fred",
+      seriesId: "UNRATE",
+    });
+    expect(withRates.spec.series.slice(0, 2).map((series) => series.panelId))
+      .toEqual(["main", "main"]);
+    expect(withRates.series.panelId).toBe("panel-2");
+    expect(withRates.spec.panels.find((panel) => panel.id === "panel-2")).toMatchObject({
+      label: "Panel 2",
+      height: 0.35,
+    });
   });
 
   test("renders an appended secondary OHLCV price as a valid comparison line", () => {
@@ -130,8 +192,9 @@ describe("chart composer expressions", () => {
     ]);
     expect(spec.series[0]).toMatchObject({ style: "candles", interpolation: "none" });
     expect(spec.series[1]).toMatchObject({
-      style: "step",
-      interpolation: "step-after",
+      style: "columns",
+      interpolation: "none",
+      panelId: "fundamentals",
       source: {
         kind: "security",
         fieldId: "fundamental.totalRevenue",
@@ -148,6 +211,24 @@ describe("chart composer expressions", () => {
     expect(spec.panels.find((panel) => panel.id === "panel-2")).toMatchObject({
       label: "Panel 2",
       height: 0.35,
+    });
+    expect(spec.panels.find((panel) => panel.id === "fundamentals")).toMatchObject({
+      label: "Fundamentals",
+      height: 0.35,
+    });
+
+    const reversed = buildCustomChartPreset("MSFT:revenue, AAPL:price");
+    const price = reversed.series.find((series) => (
+      series.source.kind === "security" && series.source.fieldId === "market.ohlcv"
+    ));
+    const revenue = reversed.series.find((series) => (
+      series.source.kind === "security" && series.source.fieldId === "fundamental.totalRevenue"
+    ));
+    expect(price?.panelId).toBe("main");
+    expect(revenue).toMatchObject({
+      panelId: "fundamentals",
+      style: "columns",
+      source: { timestampMode: "available-at" },
     });
 
     expect(buildCustomChartPreset("AAPL:revenue, MSFT:revenue").series.map((series) => series.axis))
@@ -190,10 +271,40 @@ describe("chart composer presets and formulas", () => {
 
     const fundamental = buildFundamentalChartPreset(["aapl"]);
     expect(fundamental.series[0]).toMatchObject({
-      style: "step",
-      interpolation: "step-after",
-      source: { fieldId: "fundamental.totalRevenue" },
+      style: "columns",
+      interpolation: "none",
+      source: { fieldId: "fundamental.totalRevenue", timestampMode: "period-end" },
     });
+  });
+
+  test("keeps one visible base series and projects visibility without waiting for data reload", () => {
+    const spec = buildComparisonChartPreset(["AAPL", "MSFT"]);
+    const resolved = spec.series.map((series, index) => ({
+      id: series.id,
+      label: series.id,
+      color: index === 0 ? "#fff" : "#aaa",
+      unit: "USD",
+      unitGroup: "price",
+      nativeFrequency: "daily" as const,
+      dataShape: "scalar" as const,
+      style: series.style,
+      transform: series.transform,
+      axis: "left" as const,
+      panelId: series.panelId,
+      interpolation: series.interpolation,
+      points: [],
+    }));
+
+    const withHiddenSecond = toggleChartSeries(spec, spec.series[1]!.id);
+    expect(withHiddenSecond.series[1]?.visible).toBe(false);
+    expect(projectVisibleChartSeries(withHiddenSecond, resolved).map((series) => series.id))
+      .toEqual([spec.series[0]!.id]);
+    expect(canToggleChartSeries(withHiddenSecond, spec.series[0]!.id)).toBe(false);
+    expect(toggleChartSeries(withHiddenSecond, spec.series[0]!.id)).toBe(withHiddenSecond);
+
+    const restored = toggleChartSeries(withHiddenSecond, spec.series[1]!.id);
+    expect(projectVisibleChartSeries(restored, [], resolved).map((series) => series.id))
+      .toEqual(spec.series.map((series) => series.id));
   });
 
   test("includes volume in fresh price and followed-ticker defaults", () => {
@@ -217,12 +328,16 @@ describe("chart composer presets and formulas", () => {
     });
   });
 
-  test("uses period-end timestamps when a financial series changes to columns", () => {
+  test("keeps financial timing independent from visual style", () => {
     const revenue = buildCustomChartPreset("AAPL:revenue").series[0]!;
-    const columns = applySeriesStyle(revenue, "columns");
+    const line = applySeriesStyle(revenue, "line");
+    const available = applySeriesTimestampMode(revenue, "available-at");
+    const columns = applySeriesStyle(available, "columns");
 
+    expect(line.interpolation).toBe("none");
+    expect(line.source).toMatchObject({ timestampMode: "period-end" });
     expect(columns.interpolation).toBe("none");
-    expect(columns.source).toMatchObject({ timestampMode: "period-end" });
+    expect(columns.source).toMatchObject({ timestampMode: "available-at" });
     expect(applySeriesStyle(columns, "line")).toMatchObject({
       interpolation: "none",
       source: {
@@ -279,7 +394,10 @@ describe("chart composer presets and formulas", () => {
     const comparison = buildComparisonChartPreset(["AAPL", "MSFT"]);
     const customized = {
       ...comparison,
-      panels: [{ id: "main", label: "Relative performance", height: 0.72, scale: "log" as const }],
+      panels: [
+        { id: "main", label: "Relative performance", height: 0.72, scale: "log" as const },
+        { id: "notes", label: "Reserved", height: 0.4 },
+      ],
     };
 
     const withIndicators = setBuiltinStudies(customized, ["rsi14"]);
@@ -293,6 +411,11 @@ describe("chart composer presets and formulas", () => {
     expect(withIndicators.panels.find((panel) => panel.id === "rsi")).toMatchObject({
       label: "RSI",
       height: 0.28,
+    });
+    expect(withIndicators.panels).toContainEqual({
+      id: "notes",
+      label: "Reserved",
+      height: 0.4,
     });
 
     const withFormula = setPairStudies(withIndicators, ["ratio"]);
@@ -314,6 +437,15 @@ describe("chart composer presets and formulas", () => {
       height: 0.41,
       scale: "log",
     });
+
+    const withoutManagedStudies = setPairStudies(setBuiltinStudies(rebound, []), []);
+    expect(withoutManagedStudies.panels.some((panel) => panel.id === "rsi")).toBe(false);
+    expect(withoutManagedStudies.panels.some((panel) => panel.id === "formula")).toBe(false);
+    expect(withoutManagedStudies.panels).toContainEqual({
+      id: "notes",
+      label: "Reserved",
+      height: 0.4,
+    });
   });
 });
 
@@ -331,7 +463,7 @@ describe("chart composer spec persistence", () => {
     });
 
     expect(parsed?.series[0]).toMatchObject({
-      style: "step",
+      style: "columns",
       source: { kind: "security", fieldId: "fundamental.totalRevenue" },
     });
     expect(parsed?.panels[0]?.scale).toBe("linear");
@@ -360,6 +492,29 @@ describe("chart composer spec persistence", () => {
     })).toBeNull();
   });
 
+  test("round-trips independent financial style and timing choices", () => {
+    const base = buildCustomChartPreset("AAPL:revenue, MSFT:revenue");
+    const authored = {
+      ...base,
+      series: [
+        applySeriesStyle(base.series[0]!, "line"),
+        applySeriesTimestampMode(
+          applySeriesStyle(base.series[1]!, "columns"),
+          "available-at",
+        ),
+      ],
+    };
+
+    const parsed = parseChartSpec(serializeChartSpec(authored));
+    expect(parsed?.series.map((series) => ({
+      style: series.style,
+      timestampMode: series.source.kind === "security" ? series.source.timestampMode : undefined,
+    }))).toEqual([
+      { style: "line", timestampMode: "period-end" },
+      { style: "columns", timestampMode: "available-at" },
+    ]);
+  });
+
   test("rejects chart specs authored by a newer unsupported version", () => {
     const current = buildPriceChartPreset("AAPL");
     expect(parseChartSpec({ ...current, version: current.version + 1 })).toBeNull();
@@ -384,8 +539,14 @@ describe("chart composer CLI options", () => {
     expect(comparison.viewport).toMatchObject({ range: "3M", resolution: "1h" });
     expect(comparison.series.every((series) => series.transform === "raw")).toBe(true);
 
+    const initialFinancial = buildCustomChartPreset("AAPL:revenue");
     const financial = applyChartComposerCapabilityOptions(
-      buildCustomChartPreset("AAPL:revenue"),
+      {
+        ...initialFinancial,
+        series: [
+          applySeriesTimestampMode(initialFinancial.series[0]!, "available-at"),
+        ],
+      },
       "fundamental-series",
       { metric: "freeCashFlow", period: "annual", periods: 6 },
     );

--- a/src/plugins/builtin/chart-composer/presets.ts
+++ b/src/plugins/builtin/chart-composer/presets.ts
@@ -8,12 +8,14 @@ import {
   type SeriesAxis,
   type SeriesPeriod,
   type SeriesStyle,
+  type SeriesTimestampMode,
   type SeriesTransform,
 } from "../../../time-series/types";
 import type { ChartResolution, TimeRange } from "../../../components/chart/core/types";
 import {
   canonicalTimeSeriesFieldId,
   getTimeSeriesField,
+  isFundamentalFieldId,
   listTimeSeriesFields,
 } from "../../../time-series/field-catalog";
 import {
@@ -146,6 +148,17 @@ export function formatSeriesExpression(series: ChartSeriesSpec): string {
   return `${publicTickerKey(series.source.instrument.symbol, series.source.instrument.exchange)}:${series.source.fieldId}`;
 }
 
+export function chartSeriesLabel(series: ChartSeriesSpec): string {
+  if (series.label?.trim()) return series.label.trim();
+  if (series.source.kind === "economic") return `FRED ${series.source.seriesId}`;
+  const instrument = publicTickerKey(
+    series.source.instrument.symbol,
+    series.source.instrument.exchange,
+  );
+  const field = getTimeSeriesField(series.source.fieldId);
+  return `${instrument} ${field?.shortLabel ?? series.source.fieldId.split(".").at(-1) ?? "Series"}`;
+}
+
 export function getCompatibleSeriesStyles(fieldId: string): SeriesStyle[] {
   return getTimeSeriesField(fieldId)?.styles ?? ["line", "area", "step", "columns", "points"];
 }
@@ -154,21 +167,30 @@ export function getCompatibleSeriesTransforms(fieldId: string): SeriesTransform[
   return getTimeSeriesField(fieldId)?.transforms ?? ["raw", "percent", "index100", "yoy", "qoq", "log"];
 }
 
-/** Apply style invariants shared by the series editor and toolbar mode cycle. */
-export function applySeriesStyle(series: ChartSeriesSpec, style: SeriesStyle): ChartSeriesSpec {
-  const source = series.source.kind === "security"
-    && (
-      series.source.fieldId.startsWith("fundamental.")
-      || series.source.fieldId.startsWith("valuation.")
-    )
-    ? {
-        ...series.source,
-        timestampMode: style === "columns" ? "period-end" as const : "available-at" as const,
-      }
-    : series.source;
+export function defaultFinancialTimestampMode(fieldId: string): SeriesTimestampMode | null {
+  const canonical = canonicalTimeSeriesFieldId(fieldId);
+  if (canonical.startsWith("fundamental.")) return "period-end";
+  if (canonical.startsWith("valuation.")) return "available-at";
+  return null;
+}
+
+export function applySeriesTimestampMode(
+  series: ChartSeriesSpec,
+  timestampMode: SeriesTimestampMode,
+): ChartSeriesSpec {
+  if (series.source.kind !== "security" || !isFundamentalFieldId(series.source.fieldId)) {
+    return series;
+  }
   return {
     ...series,
-    source,
+    source: { ...series.source, timestampMode },
+  };
+}
+
+/** Apply visual invariants without changing the series' authored time basis. */
+export function applySeriesStyle(series: ChartSeriesSpec, style: SeriesStyle): ChartSeriesSpec {
+  return {
+    ...series,
     style,
     transform: coerceSeriesTransformForStyle(style, series.transform),
     interpolation: coerceSeriesInterpolationForStyle(style),
@@ -217,8 +239,7 @@ export function buildSeriesSpec(
   }
   const presentation = defaultSeriesPresentation(expression.fieldId);
   const style = overrides.style ?? presentation.style;
-  const financialSource = expression.fieldId.startsWith("fundamental.")
-    || expression.fieldId.startsWith("valuation.");
+  const timestampMode = defaultFinancialTimestampMode(expression.fieldId);
   return {
     id: `${slug(expression.symbol)}-${slug(expression.fieldId)}-${index + 1}`,
     source: {
@@ -229,9 +250,7 @@ export function buildSeriesSpec(
       },
       fieldId: expression.fieldId,
       period: presentation.period,
-      timestampMode: financialSource
-        ? style === "columns" ? "period-end" : "available-at"
-        : undefined,
+      ...(timestampMode ? { timestampMode } : {}),
     },
     ...(expression.label ? { label: expression.label } : {}),
     transform: presentation.transform,
@@ -262,12 +281,144 @@ function coerceOhlcPanelCollision(
     : series;
 }
 
+function isFinancialSeries(series: ChartSeriesSpec): boolean {
+  return series.source.kind === "security" && isFundamentalFieldId(series.source.fieldId);
+}
+
+function isMarketPriceSeries(series: ChartSeriesSpec): boolean {
+  return series.source.kind === "security"
+    && getTimeSeriesField(series.source.fieldId)?.unitGroup === "price";
+}
+
+function effectiveSeriesUnitGroup(series: ChartSeriesSpec): string {
+  if (series.transform === "percent" || series.transform === "yoy" || series.transform === "qoq") {
+    return "percent";
+  }
+  if (series.transform === "index100") return "index";
+  return series.source.kind === "economic"
+    ? `economic:${series.source.seriesId}`
+    : getTimeSeriesField(series.source.fieldId)?.unitGroup ?? series.source.fieldId;
+}
+
+function nextGeneratedPanelId(
+  spec: Pick<ChartSpec, "panels" | "series" | "studies">,
+  prefix = "panel",
+): string {
+  const used = new Set([
+    ...spec.panels.map((panel) => panel.id),
+    ...spec.series.map((series) => series.panelId),
+    ...spec.studies.map((study) => study.panelId),
+  ]);
+  let index = 2;
+  while (used.has(`${prefix}-${index}`)) index += 1;
+  return `${prefix}-${index}`;
+}
+
+function availableGenericPanelId(
+  spec: ChartSpec,
+  candidate: ChartSeriesSpec,
+): string {
+  const candidateGroup = effectiveSeriesUnitGroup(candidate);
+  const canFit = (panelId: string) => {
+    if (spec.studies.some((study) => study.panelId === panelId && panelId !== "main")) {
+      return false;
+    }
+    const groups = new Set(
+      spec.series
+        .filter((series) => series.panelId === panelId)
+        .map(effectiveSeriesUnitGroup),
+    );
+    return groups.has(candidateGroup) || groups.size < 2;
+  };
+  if (canFit(candidate.panelId)) return candidate.panelId;
+  const generated = spec.panels
+    .map((panel) => panel.id)
+    .filter((panelId) => /^panel-\d+$/.test(panelId))
+    .find(canFit);
+  return generated ?? nextGeneratedPanelId(spec);
+}
+
+function availableFinancialPanelId(
+  spec: ChartSpec,
+  candidate: ChartSeriesSpec,
+): string {
+  const { series, studies } = spec;
+  const candidateGroup = effectiveSeriesUnitGroup(candidate);
+  const existingPanelIds = [
+    ...new Set(
+      series
+        .filter(isFinancialSeries)
+        .map((entry) => entry.panelId)
+        .filter((id) => id !== "main"),
+    ),
+  ];
+  for (const panelId of existingPanelIds) {
+    if (studies.some((study) => study.panelId === panelId)) continue;
+    const occupants = series.filter((entry) => entry.panelId === panelId);
+    const groups = new Set(occupants.filter(isFinancialSeries).map(effectiveSeriesUnitGroup));
+    if (occupants.every(isFinancialSeries) && (groups.has(candidateGroup) || groups.size < 2)) {
+      return panelId;
+    }
+  }
+
+  let suffix = 1;
+  while (true) {
+    const panelId = suffix === 1 ? "fundamentals" : `fundamentals-${suffix}`;
+    const occupants = series.filter((entry) => entry.panelId === panelId);
+    const usedByStudy = studies.some((study) => study.panelId === panelId);
+    if (occupants.length === 0 && !usedByStudy) return panelId;
+    if (!usedByStudy && occupants.every(isFinancialSeries)) {
+      const groups = new Set(occupants.map(effectiveSeriesUnitGroup));
+      if (groups.has(candidateGroup) || groups.size < 2) return panelId;
+    }
+    suffix += 1;
+  }
+}
+
+function placeAppendedSeriesByDefault(
+  series: ChartSeriesSpec,
+  spec: ChartSpec,
+): ChartSeriesSpec {
+  if (series.panelId !== "main") return series;
+  if (isFinancialSeries(series) && spec.series.some(isMarketPriceSeries)) {
+    return applySeriesTimestampMode({
+      ...series,
+      panelId: availableFinancialPanelId(spec, series),
+    }, "available-at");
+  }
+  const sharesPanelWithFinancial = isMarketPriceSeries(series)
+    && spec.series.some((entry) => (
+      entry.panelId === series.panelId && isFinancialSeries(entry)
+    ));
+  return {
+    ...series,
+    panelId: sharesPanelWithFinancial
+      ? nextGeneratedPanelId(spec)
+      : availableGenericPanelId(spec, series),
+  };
+}
+
+function ensureRequiredPanels(
+  existing: readonly ChartPanelSpec[],
+  series: readonly ChartSeriesSpec[],
+  studies: readonly ChartStudySpec[],
+): ChartPanelSpec[] {
+  const known = new Set(existing.map((panel) => panel.id));
+  return [
+    ...existing,
+    ...panelsForSeries(series, studies).filter((panel) => !known.has(panel.id)),
+  ];
+}
+
 export function appendChartSeries(
   spec: ChartSpec,
   expression: ParsedSeriesExpression,
 ): { spec: ChartSpec; series: ChartSeriesSpec } {
   const built = coerceOhlcPanelCollision(
-    buildSeriesSpec(expression, spec.series.length),
+    placeAppendedSeriesByDefault(
+      buildSeriesSpec(expression, spec.series.length),
+      spec,
+    ),
     spec.series,
   );
   const series = {
@@ -280,7 +431,7 @@ export function appendChartSeries(
     spec: {
       ...spec,
       series: nextSeries,
-      panels: reconcilePanels(spec.panels, nextSeries, spec.studies),
+      panels: ensureRequiredPanels(spec.panels, nextSeries, spec.studies),
     },
   };
 }
@@ -290,6 +441,9 @@ function panelsForSeries(series: readonly ChartSeriesSpec[], studies: readonly C
   return [...panelIds].map((id) => ({
     id,
     ...(id === "volume" ? { label: "Volume", height: 0.24 } : {}),
+    ...(id === "fundamentals" || /^fundamentals-\d+$/.test(id)
+      ? { label: id === "fundamentals" ? "Fundamentals" : `Fundamentals ${id.slice("fundamentals-".length)}`, height: 0.35 }
+      : {}),
     ...(id === "rsi" || id === "macd" ? { label: id.toUpperCase(), height: 0.28 } : {}),
     ...(id === "formula" ? { label: "Formula", height: 0.3 } : {}),
     ...(id === "correlation" ? { label: "Correlation", height: 0.3 } : {}),
@@ -297,30 +451,61 @@ function panelsForSeries(series: readonly ChartSeriesSpec[], studies: readonly C
   }));
 }
 
-function defaultExpressionUnitGroup(expression: ParsedSeriesExpression): string {
-  return expression.kind === "economic"
-    ? `economic:${expression.seriesId}`
-    : getTimeSeriesField(expression.fieldId)?.unitGroup ?? expression.fieldId;
-}
-
 /** Keep arbitrary sources legible when one panel would require more than two axes. */
 function buildCustomSeries(expressions: readonly ParsedSeriesExpression[]): ChartSeriesSpec[] {
-  const panelGroups: Array<{ id: string; groups: Set<string> }> = [{ id: "main", groups: new Set() }];
+  const parsedSeries = expressions.map((expression, index) => buildSeriesSpec(expression, index));
+  const mixedPriceAndFinancial = parsedSeries.some(isMarketPriceSeries)
+    && parsedSeries.some(isFinancialSeries);
+  const reservedPanelIds = new Set([
+    "main",
+    ...(mixedPriceAndFinancial ? ["fundamentals"] : []),
+    ...parsedSeries.filter((series) => series.panelId !== "main").map((series) => series.panelId),
+  ]);
+  const panelGroups: Array<{ id: string; scope: string; groups: Set<string> }> = [];
   const builtSeries: ChartSeriesSpec[] = [];
-  expressions.forEach((expression, index) => {
-    const built = buildSeriesSpec(expression, index);
+  const nextPanelId = (prefix: "panel" | "fundamentals") => {
+    let index = 2;
+    while (reservedPanelIds.has(`${prefix}-${index}`)) index += 1;
+    const id = `${prefix}-${index}`;
+    reservedPanelIds.add(id);
+    return id;
+  };
+  const allocatePanel = (scope: string, preferredId: string | null, unitGroup: string) => {
+    const candidates = panelGroups.filter((entry) => entry.scope === scope);
+    const panel = candidates.find((entry) => entry.groups.has(unitGroup))
+      ?? candidates.find((entry) => entry.groups.size < 2)
+      ?? (() => {
+        const id = candidates.length === 0 && preferredId
+          ? preferredId
+          : nextPanelId(scope === "financial" ? "fundamentals" : "panel");
+        const entry = { id, scope, groups: new Set<string>() };
+        panelGroups.push(entry);
+        reservedPanelIds.add(id);
+        return entry;
+      })();
+    panel.groups.add(unitGroup);
+    return panel.id;
+  };
+
+  parsedSeries.forEach((built) => {
     let candidate = built;
     if (built.panelId === "main") {
-      const unitGroup = defaultExpressionUnitGroup(expression);
-      const panel = panelGroups.find((entry) => entry.groups.has(unitGroup))
-        ?? panelGroups.find((entry) => entry.groups.size < 2)
-        ?? (() => {
-          const entry = { id: `panel-${panelGroups.length + 1}`, groups: new Set<string>() };
-          panelGroups.push(entry);
-          return entry;
-        })();
-      panel.groups.add(unitGroup);
-      if (panel.id !== "main") candidate = { ...built, panelId: panel.id };
+      const unitGroup = effectiveSeriesUnitGroup(built);
+      const scope = mixedPriceAndFinancial
+        ? isFinancialSeries(built)
+          ? "financial"
+          : isMarketPriceSeries(built) ? "price" : "other"
+        : "main";
+      const preferredId = scope === "financial"
+        ? "fundamentals"
+        : scope === "price" || scope === "main" ? "main" : null;
+      candidate = {
+        ...built,
+        panelId: allocatePanel(scope, preferredId, unitGroup),
+      };
+      if (scope === "financial") {
+        candidate = applySeriesTimestampMode(candidate, "available-at");
+      }
     }
     builtSeries.push(coerceOhlcPanelCollision(candidate, builtSeries));
   });
@@ -340,7 +525,10 @@ function reconcilePanels(
 ): ChartPanelSpec[] {
   const defaults = panelsForSeries(series, studies);
   const requiredIds = new Set(defaults.map((panel) => panel.id));
-  const retained = existing.filter((panel) => requiredIds.has(panel.id));
+  const managedStudyPanelIds = new Set(["volume", "rsi", "macd", "formula", "correlation"]);
+  const retained = existing.filter((panel) => (
+    requiredIds.has(panel.id) || !managedStudyPanelIds.has(panel.id)
+  ));
   const retainedIds = new Set(retained.map((panel) => panel.id));
   return [
     ...retained,
@@ -442,7 +630,7 @@ export function buildFundamentalChartPreset(
   return chartSpec(normalized.map((instrument, index) => buildSeriesSpec(
     { kind: "security", ...instrument, fieldId: resolvedField },
     index,
-    { style: "step", axis: "left", interpolation: "step-after" },
+    { axis: "left" },
   )), { range: "5Y", resolution: "auto" });
 }
 

--- a/src/plugins/builtin/chart-composer/quick-add.test.tsx
+++ b/src/plugins/builtin/chart-composer/quick-add.test.tsx
@@ -1,13 +1,48 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { act } from "react";
+import {
+  act,
+  createElement,
+  forwardRef,
+  useCallback,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { testRender } from "../../../renderers/opentui/test-utils";
+import {
+  UiHostProvider,
+  useNativeRenderer,
+  useRendererHost,
+  useUiHost,
+} from "../../../ui";
+import { useShortcut } from "../../../react/input";
 import { AppContext, createInitialState } from "../../../state/app/context";
 import { createDefaultConfig } from "../../../types/config";
 import type { ChartSpec } from "../../../time-series/types";
 import { buildPriceChartPreset } from "./presets";
-import { ChartSeriesQuickAdd } from "./quick-add";
+import { ChartSeriesQuickAdd, isChartQuickAddMouseTarget } from "./quick-add";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+let capturedInputProps: Record<string, any> | null = null;
+
+function CaptureInputProvider({ children }: { children: ReactNode }) {
+  const baseUi = useUiHost();
+  const renderer = useRendererHost();
+  const nativeRenderer = useNativeRenderer();
+  const CapturingInput = useMemo(() => {
+    const BaseInput = baseUi.Input;
+    return forwardRef<any, Record<string, any>>(function CapturingInput(props, ref) {
+      capturedInputProps = props;
+      return createElement(BaseInput as any, { ...props, ref });
+    });
+  }, [baseUi]);
+  const ui = useMemo(() => ({ ...baseUi, Input: CapturingInput }), [CapturingInput, baseUi]);
+  return (
+    <UiHostProvider ui={ui} renderer={renderer} nativeRenderer={nativeRenderer}>
+      {children}
+    </UiHostProvider>
+  );
+}
 
 async function emitKey(name: string, sequence: string) {
   await act(async () => {
@@ -66,9 +101,23 @@ afterEach(async () => {
     testSetup!.renderer.destroy();
   });
   testSetup = undefined;
+  capturedInputProps = null;
 });
 
 describe("chart series inline quick add", () => {
+  test("distinguishes its own drawer from outside desktop clicks", () => {
+    const ownRoot = {
+      getAttribute: (name: string) => name === "data-gloom-chart-quick-add" ? "chart-a" : null,
+    };
+    const otherRoot = {
+      getAttribute: (name: string) => name === "data-gloom-chart-quick-add" ? "chart-b" : null,
+    };
+
+    expect(isChartQuickAddMouseTarget({ closest: () => ownRoot }, "chart-a")).toBe(true);
+    expect(isChartQuickAddMouseTarget({ closest: () => otherRoot }, "chart-a")).toBe(false);
+    expect(isChartQuickAddMouseTarget({ closest: () => null }, "chart-a")).toBe(false);
+  });
+
   test("stays visible and adds a smart ticker-metric suggestion", async () => {
     const initial = createInitialState(createDefaultConfig("/tmp/gloomberb-chart-quick-add"));
     const startingSpec = buildPriceChartPreset("AAPL");
@@ -107,6 +156,7 @@ describe("chart series inline quick add", () => {
       await testSetup!.mockInput.typeText("MSFT revenue");
       await testSetup!.renderOnce();
     });
+    expect(testSetup.captureCharFrame()).toContain("MSFT revenue");
     expect(await waitForFrameToContain("MSFT · Revenue")).toContain("MSFT · Revenue");
     expect(renderedWidth).toBe(36);
 
@@ -119,11 +169,77 @@ describe("chart series inline quick add", () => {
       kind: "security",
       instrument: { symbol: "MSFT" },
       fieldId: "fundamental.totalRevenue",
+      timestampMode: "available-at",
+    });
+    expect(updatedSpec?.series[1]).toMatchObject({
+      style: "columns",
+      interpolation: "none",
+      panelId: "fundamentals",
+    });
+    expect(updatedSpec?.panels.find((panel) => panel.id === "fundamentals")).toMatchObject({
+      label: "Fundamentals",
+      height: 0.35,
     });
 
     const closedFrame = await waitForFrameToExclude("MSFT · Revenue");
     expect(closedFrame).toContain("add series");
     expect(closedFrame).not.toContain("MSFT · Revenue");
     expect(renderedWidth).toBe(14);
+  });
+
+  test("releases focus capture when the input blurs", async () => {
+    const initial = createInitialState(createDefaultConfig("/tmp/gloomberb-chart-quick-add-blur"));
+    const startingSpec = buildPriceChartPreset("AAPL");
+    const activeStates: boolean[] = [];
+    let seriesShortcutCount = 0;
+
+    function Harness() {
+      const [capturing, setCapturing] = useState(false);
+      const handleActiveChange = useCallback((active: boolean) => {
+        activeStates.push(active);
+        setCapturing(active);
+      }, []);
+      useShortcut((event) => {
+        if (event.name === "s") seriesShortcutCount += 1;
+      }, { enabled: !capturing });
+      return (
+        <ChartSeriesQuickAdd
+          spec={startingSpec}
+          setSpec={() => {}}
+          focused
+          width={92}
+          height={8}
+          shortcutEnabled
+          shortcutBlocked={false}
+          onActivatePane={() => {}}
+          onActiveChange={handleActiveChange}
+        />
+      );
+    }
+
+    testSetup = await testRender(
+      <AppContext.Provider value={{ state: initial, dispatch: () => {} }}>
+        <CaptureInputProvider>
+          <Harness />
+        </CaptureInputProvider>
+      </AppContext.Provider>,
+      { width: 92, height: 8 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+    await emitKey("n", "n");
+    expect(activeStates.at(-1)).toBe(true);
+
+    await act(async () => {
+      capturedInputProps?.onBlur?.();
+      await Bun.sleep(10);
+      await testSetup!.renderOnce();
+    });
+    expect(activeStates.at(-1)).toBe(false);
+
+    await emitKey("s", "s");
+    expect(seriesShortcutCount).toBe(1);
   });
 });

--- a/src/plugins/builtin/chart-composer/quick-add.tsx
+++ b/src/plugins/builtin/chart-composer/quick-add.tsx
@@ -1,8 +1,18 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Box, Text, type InputRenderable } from "../../../ui";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import {
+  Box,
+  Text,
+  useNativeRenderer,
+  useUiHost,
+  type BoxRenderable,
+  type InputRenderable,
+} from "../../../ui";
 import { InlineQuickAddRow, ListView, type ListViewItem } from "../../../components/ui";
+import { getNativeSurfaceManager } from "../../../components/chart/native/surface/manager";
+import { getRenderableCellRect } from "../../../components/chart/native/surface/visibility";
 import { useShortcut } from "../../../react/input";
 import { useAppInputCapture } from "../../../state/app/input-capture";
+import { useOptionalPaneInstanceId } from "../../../state/app/context";
 import { colors } from "../../../theme/colors";
 import type { ChartSpec } from "../../../time-series/types";
 import { getSharedRegistry } from "../../registry";
@@ -17,6 +27,23 @@ const MINIMUM_CHART_HEIGHT = 4;
 const QUICK_ADD_ROW_HEIGHT = 1;
 const IDLE_QUICK_ADD_WIDTH = 14;
 const ACTIVE_QUICK_ADD_WIDTH = 36;
+
+interface ClosestElementLike {
+  closest(selector: string): {
+    getAttribute(name: string): string | null;
+  } | null;
+}
+
+export function isChartQuickAddMouseTarget(target: unknown, quickAddId: string): boolean {
+  if (!target || typeof target !== "object") return false;
+  const candidate = target as Partial<ClosestElementLike> & {
+    parentElement?: Partial<ClosestElementLike> | null;
+  };
+  const element = typeof candidate.closest === "function" ? candidate : candidate.parentElement;
+  if (!element || typeof element.closest !== "function") return false;
+  const root = element.closest("[data-gloom-chart-quick-add]");
+  return root?.getAttribute("data-gloom-chart-quick-add") === quickAddId;
+}
 
 function clampSelection(index: number, length: number): number {
   if (length <= 0) return -1;
@@ -65,10 +92,16 @@ export function ChartSeriesQuickAdd({
   onActiveChange?: (active: boolean) => void;
   onWidthChange?: (width: number) => void;
 }) {
+  const ui = useUiHost();
+  const nativeRenderer = useNativeRenderer();
+  const paneId = useOptionalPaneInstanceId();
+  const quickAddId = useId();
   const inputRef = useRef<InputRenderable | null>(null);
+  const drawerRef = useRef<BoxRenderable | null>(null);
   const commitLockRef = useRef(false);
   const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [active, setActive] = useState(false);
+  const [inputFocused, setInputFocused] = useState(false);
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -97,11 +130,56 @@ export function ChartSeriesQuickAdd({
   const drawerHeight = active
     ? Math.min(maximumDrawerHeight, drawerStatus ? 1 : suggestions.length)
     : 0;
-  useAppInputCapture(active && focused);
+  const nativeSurfaceManager = useMemo(
+    () => getNativeSurfaceManager(nativeRenderer),
+    [nativeRenderer],
+  );
+  useAppInputCapture(inputFocused && focused);
 
   useEffect(() => {
-    onActiveChange?.(active && focused);
-  }, [active, focused, onActiveChange]);
+    const occluderId = `${quickAddId}:drawer`;
+    if (ui.kind === "desktop-web" || drawerHeight <= 0 || !paneId || !drawerRef.current) {
+      nativeSurfaceManager.removeLocalOccluder(occluderId);
+      return;
+    }
+
+    const drawer = drawerRef.current as BoxRenderable & { onLifecyclePass?: (() => void) | null };
+    const previousLifecyclePass = drawer.onLifecyclePass;
+    const syncOccluder = () => {
+      if (
+        typeof drawer.x !== "number"
+        || typeof drawer.y !== "number"
+        || typeof drawer.width !== "number"
+        || typeof drawer.height !== "number"
+      ) {
+        return;
+      }
+      nativeSurfaceManager.upsertLocalOccluder({
+        id: occluderId,
+        paneId,
+        rect: getRenderableCellRect(drawer as Parameters<typeof getRenderableCellRect>[0]),
+      });
+    };
+    const lifecyclePass = () => {
+      previousLifecyclePass?.();
+      syncOccluder();
+    };
+    drawer.onLifecyclePass = lifecyclePass;
+    nativeRenderer.registerLifecyclePass(drawer);
+    syncOccluder();
+    const mountTimer = setTimeout(syncOccluder, 0);
+
+    return () => {
+      clearTimeout(mountTimer);
+      nativeRenderer.unregisterLifecyclePass(drawer);
+      if (drawer.onLifecyclePass === lifecyclePass) drawer.onLifecyclePass = previousLifecyclePass;
+      nativeSurfaceManager.removeLocalOccluder(occluderId);
+    };
+  }, [drawerHeight, nativeRenderer, nativeSurfaceManager, paneId, quickAddId, ui.kind]);
+
+  useEffect(() => {
+    onActiveChange?.(inputFocused && focused);
+  }, [focused, inputFocused, onActiveChange]);
 
   useEffect(() => {
     onWidthChange?.(controlWidth);
@@ -114,8 +192,21 @@ export function ChartSeriesQuickAdd({
   useEffect(() => {
     if (focused || !active) return;
     setActive(false);
+    setInputFocused(false);
     inputRef.current?.blur?.();
   }, [active, focused]);
+
+  useEffect(() => {
+    if (ui.kind !== "desktop-web" || !inputFocused) return;
+
+    const handleOutsideMouseDown = (event: globalThis.MouseEvent) => {
+      if (isChartQuickAddMouseTarget(event.target, quickAddId)) return;
+      inputRef.current?.blur?.();
+    };
+
+    document.addEventListener("mousedown", handleOutsideMouseDown, true);
+    return () => document.removeEventListener("mousedown", handleOutsideMouseDown, true);
+  }, [inputFocused, quickAddId, ui.kind]);
 
   const cancelPendingBlur = useCallback(() => {
     if (blurTimerRef.current === null) return;
@@ -135,9 +226,11 @@ export function ChartSeriesQuickAdd({
     cancelPendingBlur();
     onActivatePane();
     setActive(true);
+    setInputFocused(true);
+    onActiveChange?.(true);
     setError(null);
     queueMicrotask(() => inputRef.current?.focus?.());
-  }, [cancelPendingBlur, onActivatePane]);
+  }, [cancelPendingBlur, onActivatePane, onActiveChange]);
 
   const commitSuggestion = useCallback((suggestion: SeriesCatalogSuggestion | undefined) => {
     if (!suggestion || commitLockRef.current) return;
@@ -155,8 +248,10 @@ export function ChartSeriesQuickAdd({
     setSelectedIndex(0);
     setError(null);
     setActive(false);
+    setInputFocused(false);
+    onActiveChange?.(false);
     queueMicrotask(() => inputRef.current?.blur?.());
-  }, [cancelPendingBlur, clearInput, setSpec, spec]);
+  }, [cancelPendingBlur, clearInput, onActiveChange, setSpec, spec]);
 
   const submit = useCallback(() => {
     commitSuggestion(suggestions[clampSelection(selectedIndex, suggestions.length)]);
@@ -166,8 +261,10 @@ export function ChartSeriesQuickAdd({
     inputRef.current?.blur?.();
     clearInput();
     setActive(false);
+    setInputFocused(false);
+    onActiveChange?.(false);
     setError(null);
-  }, [cancelPendingBlur, clearInput]);
+  }, [cancelPendingBlur, clearInput, onActiveChange]);
 
   useShortcut((event) => {
     if (!focused) return;
@@ -221,10 +318,12 @@ export function ChartSeriesQuickAdd({
       overflow="visible"
       backgroundColor={colors.panel}
       zIndex={30}
+      data-gloom-role="chart-series-quick-add"
+      data-gloom-chart-quick-add={quickAddId}
     >
       <InlineQuickAddRow
         value={query}
-        active={active}
+        active={inputFocused}
         paneFocused={focused}
         width={controlWidth}
         rowWidth={controlWidth}
@@ -237,10 +336,16 @@ export function ChartSeriesQuickAdd({
           setQuery(value);
           setError(null);
           if (!active) setActive(true);
+          if (!inputFocused) setInputFocused(true);
         }}
         onSubmit={submit}
-        onFocus={cancelPendingBlur}
+        onFocus={() => {
+          cancelPendingBlur();
+          setInputFocused(true);
+        }}
         onBlur={() => {
+          setInputFocused(false);
+          onActiveChange?.(false);
           cancelPendingBlur();
           blurTimerRef.current = setTimeout(() => {
             blurTimerRef.current = null;
@@ -254,6 +359,7 @@ export function ChartSeriesQuickAdd({
       />
       {drawerHeight > 0 ? (
         <Box
+          ref={drawerRef}
           position="absolute"
           left={0}
           top={1}

--- a/src/plugins/builtin/chart-composer/semantic.ts
+++ b/src/plugins/builtin/chart-composer/semantic.ts
@@ -23,6 +23,7 @@ function sourceEvidence(series: ChartSeriesSpec) {
       exchange: series.source.instrument.exchange ?? null,
       fieldId: series.source.fieldId,
       period: series.source.period ?? "auto",
+      timestampMode: series.source.timestampMode ?? null,
     }
     : {
       sourceKind: "economic",

--- a/src/plugins/builtin/chart-composer/settings.test.ts
+++ b/src/plugins/builtin/chart-composer/settings.test.ts
@@ -11,6 +11,7 @@ import {
   applyChartComposerPaneSetting,
   buildChartComposerPaneSettingsDef,
   CHART_SETTING_KEYS,
+  getChartInlineStyleTarget,
 } from "./settings";
 
 function field(key: string, type: PaneSettingField["type"] = "text"): PaneSettingField {
@@ -45,7 +46,29 @@ describe("chart composer pane settings", () => {
       [CHART_SETTING_KEYS.resolution]: "auto",
       [CHART_SETTING_KEYS.mode]: "candles",
     });
+    expect(definition.fields.at(-1)?.label).toBe("Style (AAPL Price)");
     expect(definition.applyValue).toBe(applyChartComposerPaneSetting);
+  });
+
+  test("routes multi-series styling through the series editor", () => {
+    const spec = buildComparisonChartPreset(["AAPL", "MSFT"]);
+    const definition = buildChartComposerPaneSettingsDef({
+      [CHART_SPEC_SETTING_KEY]: spec,
+    });
+
+    expect(definition.fields.map((entry) => entry.key)).not.toContain(CHART_SETTING_KEYS.mode);
+    expect(() => applyChartComposerPaneSetting(
+      { [CHART_SPEC_SETTING_KEY]: spec },
+      field(CHART_SETTING_KEYS.mode, "select"),
+      "area",
+    )).toThrow("Series editor");
+    expect(getChartInlineStyleTarget({
+      ...spec,
+      series: [
+        { ...spec.series[0]!, visible: false },
+        spec.series[1]!,
+      ],
+    })).toBeNull();
   });
 
   test("updates nested chart state without persisting duplicate derived keys", () => {
@@ -77,7 +100,7 @@ describe("chart composer pane settings", () => {
     expect(nextSettings).not.toHaveProperty("chartExpression");
   });
 
-  test("applies range, resolution, custom dates, indicators, formulas, and mode to the chart spec", () => {
+  test("applies range, resolution, custom dates, indicators, formulas, and single-series style", () => {
     let settings: Record<string, unknown> = {
       [CHART_SPEC_SETTING_KEY]: buildComparisonChartPreset(["AAPL", "MSFT"]),
     };
@@ -101,19 +124,12 @@ describe("chart composer pane settings", () => {
       field(CHART_SETTING_KEYS.resolution, "select"),
       "1wk",
     );
-    settings = applyChartComposerPaneSetting(
-      settings,
-      field(CHART_SETTING_KEYS.mode, "select"),
-      "area",
-    );
     let spec = settings[CHART_SPEC_SETTING_KEY] as ReturnType<typeof buildComparisonChartPreset>;
 
     expect(getSelectedBuiltinStudies(spec)).toEqual(["sma20"]);
     expect(getSelectedPairStudies(spec)).toEqual(["ratio", "correlation"]);
     expect(spec.viewport.dateWindow).toEqual({ start: "2025-01-01", end: "2025-06-30" });
     expect(spec.viewport.resolution).toBe("1wk");
-    expect(spec.series[0]?.style).toBe("area");
-
     settings = applyChartComposerPaneSetting(
       settings,
       field(CHART_SETTING_KEYS.range, "select"),
@@ -122,6 +138,13 @@ describe("chart composer pane settings", () => {
     spec = settings[CHART_SPEC_SETTING_KEY] as ReturnType<typeof buildComparisonChartPreset>;
     expect(spec.viewport.range).toBe("1Y");
     expect(spec.viewport.dateWindow).toBeUndefined();
+
+    const single = applyChartComposerPaneSetting(
+      { [CHART_SPEC_SETTING_KEY]: buildPriceChartPreset("AAPL") },
+      field(CHART_SETTING_KEYS.mode, "select"),
+      "area",
+    )[CHART_SPEC_SETTING_KEY] as ReturnType<typeof buildPriceChartPreset>;
+    expect(single.series[0]?.style).toBe("area");
   });
 
   test("rejects invalid date windows and incompatible modes", () => {

--- a/src/plugins/builtin/chart-composer/settings.ts
+++ b/src/plugins/builtin/chart-composer/settings.ts
@@ -18,6 +18,7 @@ import {
   buildCustomChartPreset,
   buildEmptyChartPreset,
   buildPriceChartPreset,
+  chartSeriesLabel,
   formatSeriesExpression,
   getCompatibleSeriesStyles,
   getSelectedBuiltinStudies,
@@ -81,12 +82,23 @@ function sourceKey(series: ChartSeriesSpec): string {
   return formatSeriesExpression(series).toLowerCase();
 }
 
-export function getChartPrimaryStyles(spec: ChartSpec): SeriesStyle[] {
-  const primary = spec.series[0];
-  if (!primary) return [];
-  const fieldId = primary.source.kind === "security" ? primary.source.fieldId : "";
-  const anotherOhlcSeriesSharesPanel = spec.series.slice(1).some((series) => (
-    series.panelId === primary.panelId && isOhlcSeriesStyle(series.style)
+/**
+ * The compact style picker is intentionally scoped to a chart with exactly one
+ * authored series. Multi-series styling belongs in the Series editor where the
+ * target is explicit, even when all but one series are currently hidden.
+ */
+export function getChartInlineStyleTarget(spec: ChartSpec): ChartSeriesSpec | null {
+  return spec.series.length === 1 ? spec.series[0] ?? null : null;
+}
+
+export function getChartInlineStyles(spec: ChartSpec): SeriesStyle[] {
+  const target = getChartInlineStyleTarget(spec);
+  if (!target) return [];
+  const fieldId = target.source.kind === "security" ? target.source.fieldId : "";
+  const anotherOhlcSeriesSharesPanel = spec.series.some((series) => (
+    series.id !== target.id
+    && series.panelId === target.panelId
+    && isOhlcSeriesStyle(series.style)
   ));
   return getCompatibleSeriesStyles(fieldId).filter((style) => (
     !anotherOhlcSeriesSharesPanel || !isOhlcSeriesStyle(style)
@@ -280,18 +292,21 @@ export function applyChartComposerPaneSetting(
       break;
     }
     case CHART_SETTING_KEYS.mode: {
-      const primary = spec.series[0];
+      const target = getChartInlineStyleTarget(spec);
       const mode = requireString(value, "Mode") as SeriesStyle;
-      if (!primary) throw new Error("Add a series before choosing a chart mode.");
-      if (!getChartPrimaryStyles(spec).includes(mode)) {
-        throw new Error("That chart mode is not compatible with the primary series.");
+      if (!target) {
+        throw new Error(spec.series.length === 0
+          ? "Add a series before choosing a chart style."
+          : "Use the Series editor to style a multi-series chart.");
+      }
+      if (!getChartInlineStyles(spec).includes(mode)) {
+        throw new Error(`That chart style is not compatible with ${chartSeriesLabel(target)}.`);
       }
       nextSpec = {
         ...spec,
-        series: [
-          applySeriesStyle(primary, mode),
-          ...spec.series.slice(1),
-        ],
+        series: spec.series.map((series) => (
+          series.id === target.id ? applySeriesStyle(series, mode) : series
+        )),
       };
       break;
     }
@@ -307,8 +322,8 @@ export function buildChartComposerPaneSettingsDef(
   activeTicker?: string | null,
 ): PaneSettingsDef {
   const spec = parseChartSpecOr(settings[CHART_SPEC_SETTING_KEY], fallbackSpec(activeTicker));
-  const primary = spec.series[0];
-  const modes = getChartPrimaryStyles(spec);
+  const inlineStyleTarget = getChartInlineStyleTarget(spec);
+  const modes = getChartInlineStyles(spec);
 
   return {
     title: "Chart Settings",
@@ -319,7 +334,7 @@ export function buildChartComposerPaneSettingsDef(
       [CHART_SETTING_KEYS.dateWindow]: formatDateWindow(spec),
       [CHART_SETTING_KEYS.range]: spec.viewport.range,
       [CHART_SETTING_KEYS.resolution]: spec.viewport.resolution,
-      [CHART_SETTING_KEYS.mode]: primary?.style ?? "",
+      [CHART_SETTING_KEYS.mode]: inlineStyleTarget?.style ?? "",
     },
     fields: [
       {
@@ -339,7 +354,7 @@ export function buildChartComposerPaneSettingsDef(
       {
         key: CHART_SETTING_KEYS.formulas,
         label: "Formulas",
-        description: "Compare the first two visible series with a derived formula.",
+        description: "Compare two chart series with a derived formula.",
         type: "multi-select",
         options: CHART_FORMULA_OPTIONS,
       },
@@ -367,11 +382,11 @@ export function buildChartComposerPaneSettingsDef(
           label: resolution.toUpperCase(),
         })),
       },
-      ...(primary
+      ...(inlineStyleTarget
         ? [{
           key: CHART_SETTING_KEYS.mode,
-          label: "Mode",
-          description: "Choose how the primary series is drawn.",
+          label: `Style (${chartSeriesLabel(inlineStyleTarget)})`,
+          description: `Choose how ${chartSeriesLabel(inlineStyleTarget)} is drawn.`,
           type: "select" as const,
           options: modes.map((mode) => ({ value: mode, label: mode.toUpperCase() })),
         }]

--- a/src/plugins/builtin/earnings/index.tsx
+++ b/src/plugins/builtin/earnings/index.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DataTableView, usePaneFooter, type DataTableKeyEvent } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import type { EarningsEvent } from "../../../types/data-provider";
-import { useAppSelector, getFocusedCollectionId, usePaneInstance } from "../../../state/app/context";
-import { getCollectionTickers } from "../../../state/selectors";
+import { useAppSelector, usePaneInstance } from "../../../state/app/context";
 import { parseTickerListInput, formatTickerListInput } from "../../../tickers/list";
 import { useAssetData, usePluginPaneState, usePluginTickerActions } from "../../runtime";
 import {
@@ -14,8 +13,10 @@ import {
 } from "./data/cache";
 import {
   groupEarningsByRelativeDate,
+  resolveEarningsCollectionId,
   resolveEarningsMonitorSymbols,
   scopedSymbolsFromSettings,
+  trackedEarningsSymbols,
   type EarningsDisplayRow,
   type EarningsEventDisplayRow,
 } from "./model";
@@ -34,16 +35,21 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedIdx, setSelectedIdx] = usePluginPaneState<number>("selectedIdx", 0);
+  const requestIdRef = useRef(0);
 
-  const state = useAppSelector((current) => current);
-  const collectionId = getFocusedCollectionId(state);
+  const tickers = useAppSelector((state) => state.tickers);
+  const legacyCollectionId = useAppSelector((state) => (
+    state.config.portfolios[0]?.id ?? state.config.watchlists[0]?.id ?? null
+  ));
   const scopedSymbols = useMemo(() => scopedSymbolsFromSettings(pane?.settings), [pane?.settings]);
-  const fallbackTickerSymbols = useMemo(() => {
-    if (collectionId) {
-      return getCollectionTickers(state, collectionId).map((ticker) => ticker.metadata.ticker);
-    }
-    return [...state.tickers.values()].map((ticker) => ticker.metadata.ticker);
-  }, [state.tickers, collectionId]);
+  const scopedCollectionId = useMemo(
+    () => resolveEarningsCollectionId(pane?.settings, legacyCollectionId),
+    [legacyCollectionId, pane?.settings],
+  );
+  const fallbackTickerSymbols = useMemo(
+    () => trackedEarningsSymbols(tickers.values(), scopedCollectionId),
+    [scopedCollectionId, tickers],
+  );
   const tickerSymbols = useMemo(
     () => resolveEarningsMonitorSymbols(scopedSymbols, fallbackTickerSymbols),
     [fallbackTickerSymbols, scopedSymbols],
@@ -60,6 +66,7 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
   const columns = useMemo(() => buildEarningsColumns(width), [width]);
 
   const reload = useCallback((force = false) => {
+    const requestId = ++requestIdRef.current;
     if (tickerSymbols.length === 0) {
       setEvents([]);
       setError(null);
@@ -71,12 +78,15 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
     setError(null);
     loadEarningsCalendar(dataProvider, tickerSymbols, { force })
       .then((data) => {
+        if (requestId !== requestIdRef.current) return;
         setEvents(data);
       })
       .catch((err) => {
+        if (requestId !== requestIdRef.current) return;
         setError(err instanceof Error ? err.message : String(err));
       })
       .finally(() => {
+        if (requestId !== requestIdRef.current) return;
         setLoading(false);
       });
   }, [dataProvider, tickerSymbols]);
@@ -84,6 +94,10 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
   useEffect(() => {
     reload(false);
   }, [reload]);
+
+  useEffect(() => () => {
+    requestIdRef.current += 1;
+  }, []);
 
   useEffect(() => {
     if (eventCount > 0 && selectedIdx >= eventCount) {
@@ -198,6 +212,11 @@ export const earningsModule: PluginModule = {
       description: "Upcoming earnings dates and estimates for your tickers.",
       keywords: ["earn", "earnings", "calendar", "eps", "revenue", "quarterly"],
       shortcut: { prefix: "ERN" },
+      createInstance: (context) => ({
+        settings: context.activeCollectionId
+          ? { collectionId: context.activeCollectionId }
+          : undefined,
+      }),
     },
     {
       id: "earnings-monitor-pane",
@@ -206,7 +225,7 @@ export const earningsModule: PluginModule = {
       description: "Upcoming earnings dates and estimates, optionally scoped to tickers.",
       keywords: ["earn", "earnings", "monitor", "em", "eps", "revenue"],
       canCreate: () => true,
-      createInstance: (_context, options) => {
+      createInstance: (context, options) => {
         const raw = options?.arg?.trim() ?? "";
         const symbols = raw ? parseTickerListInput(raw) : [];
         return {
@@ -217,7 +236,9 @@ export const earningsModule: PluginModule = {
               symbols,
               symbolsText: formatTickerListInput(symbols),
             }
-            : undefined,
+            : context.activeCollectionId
+              ? { collectionId: context.activeCollectionId }
+              : undefined,
         };
       },
     },

--- a/src/plugins/builtin/earnings/model.test.ts
+++ b/src/plugins/builtin/earnings/model.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import type { TickerRecord } from "../../../types/ticker";
+import { resolveEarningsCollectionId, trackedEarningsSymbols } from "./model";
+
+function ticker(
+  symbol: string,
+  portfolios: string[] = [],
+  watchlists: string[] = [],
+): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange: "",
+      currency: "USD",
+      name: symbol,
+      portfolios,
+      watchlists,
+      positions: [],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+describe("trackedEarningsSymbols", () => {
+  test("gives settings-less legacy panes one stable collection scope", () => {
+    expect(resolveEarningsCollectionId(undefined, "main")).toBe("main");
+    expect(resolveEarningsCollectionId({ collectionId: " watchlist " }, "main")).toBe("watchlist");
+    expect(resolveEarningsCollectionId({ collectionId: "" }, "main")).toBe("main");
+  });
+
+  test("excludes incidental cached tickers when no collection is focused", () => {
+    const tickers = [
+      ticker("CACHE"),
+      ticker("AAPL", ["main"]),
+      ticker("MSFT", [], ["watchlist"]),
+      ticker(" aapl ", ["main"], ["watchlist"]),
+    ];
+
+    expect(trackedEarningsSymbols(tickers, null)).toEqual(["AAPL", "MSFT"]);
+  });
+
+  test("limits symbols to the focused collection when available", () => {
+    const tickers = [
+      ticker("AAPL", ["main"]),
+      ticker("MSFT", ["broker"]),
+      ticker("NVDA", [], ["main"]),
+    ];
+
+    expect(trackedEarningsSymbols(tickers, "main")).toEqual(["AAPL", "NVDA"]);
+  });
+});

--- a/src/plugins/builtin/earnings/model.ts
+++ b/src/plugins/builtin/earnings/model.ts
@@ -1,4 +1,5 @@
 import type { EarningsEvent } from "../../../types/data-provider";
+import type { TickerRecord } from "../../../types/ticker";
 import { parseTickerListInput } from "../../../tickers/list";
 
 export type EarningsDisplayRow =
@@ -9,6 +10,37 @@ export type EarningsEventDisplayRow = EarningsDisplayRow & { kind: "event" };
 
 export function resolveEarningsMonitorSymbols(scopedSymbols: string[], fallbackSymbols: string[]): string[] {
   return scopedSymbols.length > 0 ? scopedSymbols : fallbackSymbols;
+}
+
+export function resolveEarningsCollectionId(
+  settings: Record<string, unknown> | undefined,
+  legacyFallbackId: string | null,
+): string | null {
+  const configuredId = settings?.collectionId;
+  if (typeof configuredId === "string" && configuredId.trim()) {
+    return configuredId.trim();
+  }
+  return legacyFallbackId;
+}
+
+export function trackedEarningsSymbols(
+  tickers: Iterable<TickerRecord>,
+  collectionId: string | null,
+): string[] {
+  const symbols = new Set<string>();
+
+  for (const ticker of tickers) {
+    const { metadata } = ticker;
+    const tracked = collectionId
+      ? metadata.portfolios.includes(collectionId) || metadata.watchlists.includes(collectionId)
+      : metadata.portfolios.length > 0 || metadata.watchlists.length > 0;
+    if (!tracked) continue;
+
+    const symbol = metadata.ticker.trim().toUpperCase();
+    if (symbol) symbols.add(symbol);
+  }
+
+  return [...symbols];
 }
 
 export function scopedSymbolsFromSettings(settings: Record<string, unknown> | undefined): string[] {

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -19,6 +19,7 @@ import {
   CompositeChart,
   pricePointsToResolvedSeries,
 } from "../../../components/chart/composite";
+import { resolveExchangeTimeZone } from "../../../utils/exchanges";
 import { appendLiveQuotePoint } from "../../../components/chart/core/data";
 import { PriceReturnStrip } from "../../../components/price-performance";
 import {
@@ -90,6 +91,9 @@ export function OverviewTab({
   const hasHistory = (financials?.priceHistory?.length ?? 0) > 2;
   const chartHistory = appendLiveQuotePoint(financials?.priceHistory ?? [], quote);
   const chartDelta = (chartHistory.at(-1)?.close ?? 0) - (chartHistory[0]?.close ?? 0);
+  const chartTimeZone = resolveExchangeTimeZone(
+    ticker.metadata.exchange || quote?.listingExchangeName || quote?.exchangeName,
+  );
   const priceSeries = pricePointsToResolvedSeries(chartHistory, {
     id: `${ticker.metadata.ticker}:price`,
     label: `${ticker.metadata.ticker} Price`,
@@ -99,6 +103,7 @@ export function OverviewTab({
     axis: "right",
     panelId: "price",
     providerId: quote?.provenance?.price?.providerId ?? quote?.providerId,
+    timeBasis: chartTimeZone ? { kind: "market", timeZone: chartTimeZone } : undefined,
   });
   const hasBidAsk = quote?.bid != null || quote?.ask != null;
   const quoteBookInline = hasBidAsk && contentWidth >= 68;

--- a/src/renderers/electrobun/view/dialog-host.test.ts
+++ b/src/renderers/electrobun/view/dialog-host.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { isDialogDismissKey, shouldFocusDialogContainer } from "./dialog-host";
+
+describe("desktop dialog focus and dismissal", () => {
+  test("dismisses on Escape, including legacy WebView key names", () => {
+    expect(isDialogDismissKey({ key: "Escape", isComposing: false })).toBe(true);
+    expect(isDialogDismissKey({ key: "Esc", isComposing: false })).toBe(true);
+    expect(isDialogDismissKey({ key: "Enter", isComposing: false })).toBe(false);
+    expect(isDialogDismissKey({ key: "Escape", isComposing: true })).toBe(false);
+  });
+
+  test("preserves focus already owned by dialog content", () => {
+    const child = {} as Element;
+    const outside = {} as Element;
+    const dialog = {
+      contains(element: Node | null) {
+        return element === child;
+      },
+    };
+
+    expect(shouldFocusDialogContainer(dialog, child)).toBe(false);
+    expect(shouldFocusDialogContainer(dialog, outside)).toBe(true);
+    expect(shouldFocusDialogContainer(dialog, null)).toBe(true);
+  });
+});

--- a/src/renderers/electrobun/view/dialog-host.tsx
+++ b/src/renderers/electrobun/view/dialog-host.tsx
@@ -15,6 +15,17 @@ interface DialogState {
 
 let nextDialogId = 1;
 
+export function isDialogDismissKey(event: Pick<KeyboardEvent, "key" | "isComposing">): boolean {
+  return !event.isComposing && (event.key === "Escape" || event.key === "Esc");
+}
+
+export function shouldFocusDialogContainer(
+  dialog: Pick<HTMLElement, "contains">,
+  activeElement: Element | null,
+): boolean {
+  return activeElement === null || !dialog.contains(activeElement);
+}
+
 export function WebDialogHostProvider({ children }: { children: ReactNode }) {
   useThemeColors();
   const [dialogState, setDialogState] = useState<DialogState | null>(null);
@@ -54,9 +65,29 @@ export function WebDialogHostProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (!dialogState) return;
-    const frame = requestAnimationFrame(() => dialogElementRef.current?.focus({ preventScroll: true }));
+    const frame = requestAnimationFrame(() => {
+      const dialogElement = dialogElementRef.current;
+      if (
+        dialogElement
+        && shouldFocusDialogContainer(dialogElement, document.activeElement)
+      ) {
+        dialogElement.focus({ preventScroll: true });
+      }
+    });
     return () => cancelAnimationFrame(frame);
   }, [dialogState?.id]);
+
+  useEffect(() => {
+    if (!dialogState) return;
+    const dismissOnEscape = (event: KeyboardEvent) => {
+      if (!isDialogDismissKey(event)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      close(undefined);
+    };
+    window.addEventListener("keydown", dismissOnEscape, true);
+    return () => window.removeEventListener("keydown", dismissOnEscape, true);
+  }, [close, dialogState?.id]);
 
   const api = useMemo<DialogApi>(() => ({
     alert: open,

--- a/src/renderers/electrobun/view/host/input.tsx
+++ b/src/renderers/electrobun/view/host/input.tsx
@@ -89,13 +89,11 @@ function useLatestRef<T>(value: T): RefObject<T> {
 
 function useSyncedEditableElement<T extends HTMLInputElement | HTMLTextAreaElement>({
   elementRef,
-  propsRef,
   valueRef,
   handleValueChange,
   active,
 }: {
   elementRef: RefObject<T | null>;
-  propsRef: RefObject<Record<string, unknown>>;
   valueRef: RefObject<string>;
   handleValueChange: (nextValue: string) => void;
   active: boolean;
@@ -121,21 +119,6 @@ function useSyncedEditableElement<T extends HTMLInputElement | HTMLTextAreaEleme
       if (animationFrame !== null) globalThis.cancelAnimationFrame?.(animationFrame);
     };
   }, [active, syncElementValue]);
-
-  useEffect(() => {
-    if (!active) return;
-    const commitBeforeOutsideMouseDown = (event: globalThis.MouseEvent) => {
-      const element = elementRef.current;
-      const target = event.target;
-      if (!element || (target instanceof Node && element.contains(target))) return;
-      const nextValue = syncElementValue();
-      callTextHandler(propsRef.current.onBlur, nextValue);
-    };
-    document.addEventListener("mousedown", commitBeforeOutsideMouseDown, true);
-    return () => {
-      document.removeEventListener("mousedown", commitBeforeOutsideMouseDown, true);
-    };
-  }, [active, elementRef, propsRef, syncElementValue]);
 
   return syncElementValue;
 }
@@ -250,7 +233,6 @@ export const WebInput = forwardRef<InputRenderable, Record<string, unknown>>(fun
   }, [propsRef, setValue]);
   const syncElementValue = useSyncedEditableElement({
     elementRef,
-    propsRef,
     valueRef,
     handleValueChange,
     active: props.focused === true || domFocused,
@@ -370,7 +352,6 @@ export const WebTextarea = forwardRef<TextareaRenderable, Record<string, unknown
   }, [propsRef, setValue]);
   const syncElementValue = useSyncedEditableElement({
     elementRef,
-    propsRef,
     valueRef,
     handleValueChange,
     active: props.focused === true || domFocused,

--- a/src/renderers/electrobun/view/host/tabs.tsx
+++ b/src/renderers/electrobun/view/host/tabs.tsx
@@ -17,6 +17,7 @@ export function WebTabs({
   activeValue,
   onSelect,
   compact = false,
+  dense = false,
   variant = "underline",
   closeMode = "always",
   addLabel = "+",
@@ -29,7 +30,7 @@ export function WebTabs({
   const showUnderline = variant === "underline" && !compact;
   const listHeight = showUnderline ? 28 : compact ? WEB_CELL_HEIGHT : "100%";
   const tabFontSize = compact || showUnderline ? 12 : 13;
-  const tabPaddingInline = showUnderline ? 10 : 8;
+  const tabPaddingInline = dense ? 5 : showUnderline ? 10 : 8;
   const tabPaddingBlock = variant === "bare" || variant === "pill" ? 2 : 0;
 
   useEffect(() => {
@@ -74,14 +75,14 @@ export function WebTabs({
         display: "flex",
         flexDirection: "row",
         alignItems: "stretch",
-        gap: 4,
+        gap: dense ? 2 : 4,
         width: "100%",
         height: listHeight,
         minInlineSize: 0,
         flexShrink: 0,
         overflowX: "auto",
         overflowY: "hidden",
-        paddingInline: variant === "underline" ? 0 : 4,
+        paddingInline: variant === "underline" || dense ? 0 : 4,
         paddingBlock: tabPaddingBlock,
         marginBottom: showUnderline ? 4 : 0,
         boxSizing: "border-box",

--- a/src/renderers/opentui/dialog-host.tsx
+++ b/src/renderers/opentui/dialog-host.tsx
@@ -13,17 +13,48 @@ function renderDialogContent(content: unknown, context: Record<string, unknown>)
     : content as ReactNode;
 }
 
+function normalizeDialogId(value: unknown): string | undefined {
+  return typeof value === "string" || typeof value === "number" ? String(value) : undefined;
+}
+
+function OpenTuiDialogContentBridge({
+  dialog,
+  dialogId,
+  children,
+}: {
+  dialog: DialogApi;
+  dialogId: string | undefined;
+  children: ReactNode;
+}) {
+  const isTopmost = useOpenTuiDialogState(
+    (state) => normalizeDialogId(state.topDialog?.id) === dialogId,
+  );
+  return (
+    <DialogHostProvider
+      dialog={dialog}
+      isOpen={true}
+      dialogId={dialogId}
+      keyboardEnabled={isTopmost}
+    >
+      {children}
+    </DialogHostProvider>
+  );
+}
+
 function OpenTuiDialogBridge({ children }: { children: ReactNode }) {
   const openTuiDialog = useOpenTuiDialog();
   const isOpen = useOpenTuiDialogState((state) => state.isOpen);
   const dialog = useMemo<DialogApi>(() => {
     const wrapOptions = (options: Record<string, unknown>) => ({
       ...options,
-      content: (context: Record<string, unknown>) => (
-        <DialogHostProvider dialog={dialog} isOpen={true}>
-          {renderDialogContent(options.content, context)}
-        </DialogHostProvider>
-      ),
+      content: (context: Record<string, unknown>) => {
+        const dialogId = normalizeDialogId(context.dialogId);
+        return (
+          <OpenTuiDialogContentBridge dialog={dialog} dialogId={dialogId}>
+            {renderDialogContent(options.content, { ...context, dialogId })}
+          </OpenTuiDialogContentBridge>
+        );
+      },
     });
 
     return {

--- a/src/time-series/alignment.ts
+++ b/src/time-series/alignment.ts
@@ -41,7 +41,7 @@ function sortedUniquePoints(points: readonly TimeSeriesPoint[]): TimeSeriesPoint
   return [...byTime.values()].sort((left, right) => left.date.getTime() - right.date.getTime());
 }
 
-function effectivePointTime(point: TimeSeriesPoint): number {
+export function effectiveTimeSeriesPointTime(point: TimeSeriesPoint): number {
   const pointTime = point.date.getTime();
   const availableTime = point.availableAt?.getTime();
   return finiteNumber(availableTime) ? Math.max(pointTime, availableTime) : pointTime;
@@ -69,7 +69,7 @@ export function alignTimeSeries(
       for (const point of entry.points) {
         const time = point.date.getTime();
         if (time >= start && time <= end) timeline.add(time);
-        const effectiveTime = effectivePointTime(point);
+        const effectiveTime = effectiveTimeSeriesPointTime(point);
         if (effectiveTime !== time && effectiveTime >= start && effectiveTime <= end) {
           timeline.add(effectiveTime);
         }
@@ -78,7 +78,7 @@ export function alignTimeSeries(
   }
 
   const exactMaps = series.map((entry) => (
-    new Map(entry.points.map((point) => [effectivePointTime(point), point]))
+    new Map(entry.points.map((point) => [effectiveTimeSeriesPointTime(point), point]))
   ));
   const sortedTimes = [...timeline].sort((left, right) => left - right);
   const rows: AlignedTimeSeriesRow[] = [];
@@ -99,7 +99,7 @@ export function alignTimeSeries(
       let previous: TimeSeriesPoint | null = null;
       let previousEligibleAt = Number.NEGATIVE_INFINITY;
       for (const point of entry.points) {
-        const eligibleAt = effectivePointTime(point);
+        const eligibleAt = effectiveTimeSeriesPointTime(point);
         if (eligibleAt <= time && eligibleAt >= previousEligibleAt) {
           previous = point;
           previousEligibleAt = eligibleAt;
@@ -150,7 +150,7 @@ export function clipSeriesToWindow(
   });
   if (includeStepAnchor && series.interpolation === "step-after") {
     const anchor = [...sorted].reverse().find((point) => (
-      effectivePointTime(point) <= startTime && point.date.getTime() < startTime
+      effectiveTimeSeriesPointTime(point) <= startTime && point.date.getTime() < startTime
     ));
     if (anchor) visible.unshift(anchor);
   }

--- a/src/time-series/field-catalog.ts
+++ b/src/time-series/field-catalog.ts
@@ -7,6 +7,10 @@ import type {
 const MARKET_TRANSFORMS: SeriesTransform[] = ["raw", "percent", "index100", "yoy", "qoq", "log"];
 const FUNDAMENTAL_TRANSFORMS: SeriesTransform[] = ["raw", "percent", "index100", "yoy", "qoq", "log"];
 const RATIO_TRANSFORMS: SeriesTransform[] = ["raw", "percent", "index100", "yoy", "qoq"];
+const FUNDAMENTAL_PRESENTATION = {
+  defaultStyle: "columns",
+  defaultInterpolation: "none",
+} as const;
 
 function field(
   definition: TimeSeriesFieldDefinition,
@@ -71,9 +75,8 @@ const FIELDS = [
     unitGroup: "currency-total",
     nativeFrequency: "quarterly",
     styles: ["step", "columns", "line", "points"],
-    defaultStyle: "step",
+    ...FUNDAMENTAL_PRESENTATION,
     transforms: FUNDAMENTAL_TRANSFORMS,
-    defaultInterpolation: "step-after",
   }),
   field({
     id: "fundamental.grossProfit",
@@ -85,9 +88,8 @@ const FIELDS = [
     unitGroup: "currency-total",
     nativeFrequency: "quarterly",
     styles: ["step", "columns", "line", "points"],
-    defaultStyle: "step",
+    ...FUNDAMENTAL_PRESENTATION,
     transforms: FUNDAMENTAL_TRANSFORMS,
-    defaultInterpolation: "step-after",
   }),
   field({
     id: "fundamental.grossMargin",
@@ -99,9 +101,8 @@ const FIELDS = [
     unitGroup: "percent",
     nativeFrequency: "quarterly",
     styles: ["step", "line", "columns", "points"],
-    defaultStyle: "step",
+    ...FUNDAMENTAL_PRESENTATION,
     transforms: RATIO_TRANSFORMS,
-    defaultInterpolation: "step-after",
   }),
   field({
     id: "fundamental.operatingIncome",
@@ -113,9 +114,8 @@ const FIELDS = [
     unitGroup: "currency-total",
     nativeFrequency: "quarterly",
     styles: ["step", "columns", "line", "points"],
-    defaultStyle: "step",
+    ...FUNDAMENTAL_PRESENTATION,
     transforms: FUNDAMENTAL_TRANSFORMS,
-    defaultInterpolation: "step-after",
   }),
   field({
     id: "fundamental.operatingMargin",
@@ -127,9 +127,8 @@ const FIELDS = [
     unitGroup: "percent",
     nativeFrequency: "quarterly",
     styles: ["step", "line", "columns", "points"],
-    defaultStyle: "step",
+    ...FUNDAMENTAL_PRESENTATION,
     transforms: RATIO_TRANSFORMS,
-    defaultInterpolation: "step-after",
   }),
   field({
     id: "fundamental.netIncome",
@@ -141,9 +140,8 @@ const FIELDS = [
     unitGroup: "currency-total",
     nativeFrequency: "quarterly",
     styles: ["step", "columns", "line", "points"],
-    defaultStyle: "step",
+    ...FUNDAMENTAL_PRESENTATION,
     transforms: FUNDAMENTAL_TRANSFORMS,
-    defaultInterpolation: "step-after",
   }),
   field({
     id: "fundamental.netMargin",
@@ -155,9 +153,8 @@ const FIELDS = [
     unitGroup: "percent",
     nativeFrequency: "quarterly",
     styles: ["step", "line", "columns", "points"],
-    defaultStyle: "step",
+    ...FUNDAMENTAL_PRESENTATION,
     transforms: RATIO_TRANSFORMS,
-    defaultInterpolation: "step-after",
   }),
   field({
     id: "fundamental.operatingCashFlow",
@@ -169,9 +166,8 @@ const FIELDS = [
     unitGroup: "currency-total",
     nativeFrequency: "quarterly",
     styles: ["step", "columns", "line", "points"],
-    defaultStyle: "step",
+    ...FUNDAMENTAL_PRESENTATION,
     transforms: FUNDAMENTAL_TRANSFORMS,
-    defaultInterpolation: "step-after",
   }),
   field({
     id: "fundamental.freeCashFlow",
@@ -183,9 +179,8 @@ const FIELDS = [
     unitGroup: "currency-total",
     nativeFrequency: "quarterly",
     styles: ["step", "columns", "line", "points"],
-    defaultStyle: "step",
+    ...FUNDAMENTAL_PRESENTATION,
     transforms: FUNDAMENTAL_TRANSFORMS,
-    defaultInterpolation: "step-after",
   }),
   field({
     id: "fundamental.freeCashFlowMargin",
@@ -197,9 +192,8 @@ const FIELDS = [
     unitGroup: "percent",
     nativeFrequency: "quarterly",
     styles: ["step", "line", "columns", "points"],
-    defaultStyle: "step",
+    ...FUNDAMENTAL_PRESENTATION,
     transforms: RATIO_TRANSFORMS,
-    defaultInterpolation: "step-after",
   }),
   ...([
     ["totalAssets", "Total Assets", "Assets"],
@@ -215,9 +209,8 @@ const FIELDS = [
     unitGroup: "currency-total",
     nativeFrequency: "quarterly" as const,
     styles: ["step", "columns", "line", "points"] as SeriesStyle[],
-    defaultStyle: "step" as const,
+    ...FUNDAMENTAL_PRESENTATION,
     transforms: FUNDAMENTAL_TRANSFORMS,
-    defaultInterpolation: "step-after" as const,
   })),
   field({
     id: "fundamental.eps",
@@ -229,9 +222,8 @@ const FIELDS = [
     unitGroup: "per-share",
     nativeFrequency: "quarterly",
     styles: ["step", "columns", "line", "points"],
-    defaultStyle: "step",
+    ...FUNDAMENTAL_PRESENTATION,
     transforms: FUNDAMENTAL_TRANSFORMS,
-    defaultInterpolation: "step-after",
   }),
   ...([
     ["trailingPE", "Trailing P/E", "P/E"],

--- a/src/time-series/hooks.ts
+++ b/src/time-series/hooks.ts
@@ -6,7 +6,11 @@ import { useAssetData } from "../plugins/runtime";
 import { useAppSelector } from "../state/app/context";
 import type { FredSeriesRequest } from "../data/fred-series";
 import type { ChartSpec } from "./types";
-import { useChartResolution, type UseChartResolutionResult } from "./use-chart-resolution";
+import {
+  useChartResolution,
+  type UseChartResolutionOptions,
+  type UseChartResolutionResult,
+} from "./use-chart-resolution";
 
 async function loadFred(request: FredSeriesRequest) {
   return loadCachedFredSeries(
@@ -18,7 +22,10 @@ async function loadFred(request: FredSeriesRequest) {
   );
 }
 
-export function useResolvedChartSpec(spec: ChartSpec): UseChartResolutionResult {
+export function useResolvedChartSpec(
+  spec: ChartSpec,
+  options: UseChartResolutionOptions = {},
+): UseChartResolutionResult {
   const dataProvider = useAssetData();
   const tickers = useAppSelector((state) => state.tickers);
   const hydratedSpec = useMemo<ChartSpec>(() => ({
@@ -34,5 +41,5 @@ export function useResolvedChartSpec(spec: ChartSpec): UseChartResolutionResult 
     }),
   }), [spec, tickers]);
   const sources = useMemo(() => ({ dataProvider, loadFredSeries: loadFred }), [dataProvider]);
-  return useChartResolution(hydratedSpec, sources);
+  return useChartResolution(hydratedSpec, sources, options);
 }

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -186,6 +186,78 @@ describe("resolveChartSpecData", () => {
     expect(requests).toEqual([{ range: "1W", resolution: "5m" }]);
   });
 
+  test("adapts Auto to a zoomed historical window without changing the authored viewport", async () => {
+    const detailedRequests: Array<{
+      start: string;
+      end: string;
+      resolution: string;
+    }> = [];
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => emptyFinancials(),
+      getChartResolutionSupport: () => [
+        { resolution: "15m", maxRange: "1M" },
+        { resolution: "1h", maxRange: "6M" },
+        { resolution: "1d", maxRange: "5Y" },
+      ],
+      getDetailedPriceHistory: async (_symbol, _exchange, start, end, resolution) => {
+        detailedRequests.push({
+          start: start.toISOString(),
+          end: end.toISOString(),
+          resolution,
+        });
+        return [{ date: new Date("2025-01-15T16:00:00.000Z"), close: 100 }];
+      },
+    });
+    const spec: ChartSpec = {
+      version: CHART_SPEC_VERSION,
+      viewport: { range: "3M", resolution: "auto" },
+      panels: [{ id: "main" }],
+      series: [{
+        id: "price",
+        source: {
+          kind: "security",
+          instrument: { symbol: "TEST", exchange: "NASDAQ" },
+          fieldId: "market.close",
+        },
+        style: "line",
+        transform: "raw",
+        axis: "left",
+        panelId: "main",
+        interpolation: "none",
+      }],
+      studies: [],
+    };
+
+    const result = await resolveChartSpecData(
+      spec,
+      {
+        dataProvider: provider,
+        now: new Date("2025-04-01T00:00:00.000Z"),
+        loadFredSeries: async () => fredLoad(),
+      },
+      new ChartResolveCache(),
+      {
+        autoViewport: {
+          start: new Date("2025-01-10T00:00:00.000Z"),
+          end: new Date("2025-01-17T00:00:00.000Z"),
+        },
+        targetPointCount: 100,
+      },
+    );
+
+    expect(spec.viewport.resolution).toBe("auto");
+    expect(detailedRequests).toHaveLength(1);
+    expect(detailedRequests[0]?.resolution).toBe("15m");
+    expect(detailedRequests[0]?.end).toBe("2025-01-17T00:00:00.001Z");
+    expect(result.viewport?.start.toISOString()).toBe("2025-01-01T00:00:00.000Z");
+    expect(result.viewport?.end.toISOString()).toBe("2025-04-01T00:00:00.000Z");
+    expect(result.series[0]?.timeBasis).toMatchObject({
+      kind: "market",
+      timeZone: "America/New_York",
+      cadenceMs: 15 * 60 * 1_000,
+    });
+  });
+
   test("resolves unrelated price, filed fundamental, and economic series on one chart", async () => {
     const provider = createTestDataProvider({
       getTickerFinancials: async (symbol) => symbol === "MSFT"
@@ -641,7 +713,11 @@ describe("resolveChartSpecData", () => {
       panels: [{ id: "main" }],
       series: [{
         id: "price",
-        source: { kind: "security", instrument: { symbol: "TEST" }, fieldId: "market.close" },
+        source: {
+          kind: "security",
+          instrument: { symbol: "TEST", exchange: "NASDAQ" },
+          fieldId: "market.close",
+        },
         style: "line",
         transform: "raw",
         axis: "left",
@@ -669,6 +745,10 @@ describe("resolveChartSpecData", () => {
     expect(result.series.map((series) => series.id)).toEqual(["sma"]);
     expect(result.legendSeries?.map((series) => series.id)).toEqual(["price", "sma"]);
     expect(result.series[0]?.points.map((point) => point.value)).toEqual([15, 25]);
+    expect(result.legendSeries?.find((series) => series.id === "price")?.timeBasis)
+      .toMatchObject({ kind: "market", timeZone: "America/New_York" });
+    expect(result.series[0]?.timeBasis)
+      .toMatchObject({ kind: "market", timeZone: "America/New_York" });
   });
 
   test("applies a streamed quote override before recomputing transforms and studies", async () => {

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -6,9 +6,11 @@ import {
 import {
   CHART_RESOLUTION_STEP_MS,
   clampTimeRangeToMaxRange,
+  getBestSupportedResolutionForVisibleWindow,
   getNextBufferRange,
   getPresetResolution,
   getSupportMaxRange,
+  intersectChartResolutionSupport,
   TIME_RANGE_ORDER,
   type ChartResolutionSupport,
   type ManualChartResolution,
@@ -38,7 +40,11 @@ import { applyResolvedSeriesTransform } from "./transforms";
 import { clipSeriesToWindow } from "./alignment";
 import { chartQuoteOverrideKeyForSource } from "./live-quotes";
 import { resolutionForExplicitMarketPeriods } from "./market-resolution";
-import { publicTickerKey } from "../utils/exchanges";
+import {
+  canonicalExchange,
+  publicTickerKey,
+  resolveExchangeTimeZone,
+} from "../utils/exchanges";
 import type {
   ChartResolutionResult,
   ChartSeriesSpec,
@@ -66,6 +72,13 @@ export interface ChartResolveSources {
   now?: Date;
   /** Latest streamed quote per security identity, layered over snapshot data. */
   quoteOverrides?: ReadonlyMap<string, Quote>;
+}
+
+export interface ChartResolveOptions {
+  /** Runtime interaction window used only while the authored resolution is Auto. */
+  autoViewport?: { start: Date; end: Date } | null;
+  /** Approximate number of horizontal observations the current surface can use. */
+  targetPointCount?: number;
 }
 
 /** Raw source data retained while live quotes recompute the chart tail. */
@@ -145,6 +158,22 @@ function requestedBounds(spec: ChartSpec, latestObservation: Date): DateBounds {
   };
 }
 
+function runtimeAutoBounds(options: ChartResolveOptions): DateBounds | null {
+  const start = options.autoViewport?.start.getTime();
+  const end = options.autoViewport?.end.getTime();
+  return typeof start === "number"
+      && Number.isFinite(start)
+      && typeof end === "number"
+      && Number.isFinite(end)
+      && start <= end
+    ? { start, end }
+    : null;
+}
+
+function sameBounds(left: DateBounds | null, right: DateBounds | null): boolean {
+  return left?.start === right?.start && left?.end === right?.end;
+}
+
 function boundsRange(bounds: DateBounds): TimeRange {
   if (bounds.start === null || bounds.end === null) return "ALL";
   return getTimeRangeForDateWindow({
@@ -157,9 +186,20 @@ function requestResolution(
   spec: ChartSpec,
   bounds: DateBounds,
   calculationSeriesIds: ReadonlySet<string>,
+  options: ChartResolveOptions,
+  sharedSupport: readonly ChartResolutionSupport[],
 ): ManualChartResolution {
   if (spec.viewport.resolution !== "auto") return spec.viewport.resolution;
-  const preferred = getPresetResolution(explicitBounds(spec) ? boundsRange(bounds) : spec.viewport.range);
+  const runtimeBounds = runtimeAutoBounds(options);
+  const adaptive = runtimeBounds && runtimeBounds.start !== null && runtimeBounds.end !== null
+    ? getBestSupportedResolutionForVisibleWindow(
+        { start: new Date(runtimeBounds.start), end: new Date(runtimeBounds.end) },
+        sharedSupport,
+        options.targetPointCount ?? 120,
+      )
+    : null;
+  const preferred = adaptive
+    ?? getPresetResolution(explicitBounds(spec) ? boundsRange(bounds) : spec.viewport.range);
   const activeSeries = spec.series.filter((entry) => calculationSeriesIds.has(entry.id));
   return resolutionForExplicitMarketPeriods(preferred, activeSeries);
 }
@@ -292,6 +332,7 @@ function baseSecuritySeries(
   spec: ChartSeriesSpec,
   financials: TickerFinancials,
   index: number,
+  marketResolution?: ManualChartResolution,
 ): ResolvedSeries | null {
   if (spec.source.kind !== "security") return null;
   const field = getTimeSeriesField(spec.source.fieldId);
@@ -305,6 +346,13 @@ function baseSecuritySeries(
   const currencyUnitGroup = field.unit.startsWith("currency") && currency
     ? `${field.unitGroup}:${currency}`
     : field.unitGroup;
+  const marketExchange = spec.source.instrument.exchange
+    || financials.quote?.listingExchangeName
+    || financials.quote?.exchangeName;
+  const marketTimeZone = isMarketFieldId(spec.source.fieldId)
+    && canonicalExchange(marketExchange) !== "CCC"
+    ? resolveExchangeTimeZone(marketExchange)
+    : null;
   return {
     id: spec.id,
     label: spec.label?.trim() || `${symbol} ${field.shortLabel}`,
@@ -314,12 +362,22 @@ function baseSecuritySeries(
     nativeFrequency: spec.source.period && spec.source.period !== "auto"
       ? spec.source.period
       : field.nativeFrequency,
+    timestampMode: spec.source.timestampMode,
     dataShape: field.dataShape,
     style: spec.style,
     transform: spec.transform,
     axis: spec.axis === "right" ? "right" : "left",
     panelId: spec.panelId,
     interpolation: spec.interpolation,
+    timeBasis: marketTimeZone
+      ? {
+          kind: "market",
+          timeZone: marketTimeZone,
+          cadenceMs: marketResolution
+            ? CHART_RESOLUTION_STEP_MS[marketResolution]
+            : undefined,
+        }
+      : undefined,
     points,
   };
 }
@@ -340,6 +398,7 @@ function baseEconomicSeries(
     unit: isPercent ? "%" : units,
     unitGroup: isPercent ? "percent" : `economic:${units.toLowerCase()}`,
     nativeFrequency: "auto",
+    timestampMode: "period-end",
     dataShape: "scalar",
     style: spec.style,
     transform: spec.transform,
@@ -460,6 +519,7 @@ export async function resolveChartSpecData(
   spec: ChartSpec,
   sources: ChartResolveSources,
   cache = new ChartResolveCache(),
+  options: ChartResolveOptions = {},
 ): Promise<ChartResolutionResult> {
   const errors: string[] = [];
   const warnings: string[] = [];
@@ -470,6 +530,12 @@ export async function resolveChartSpecData(
     .map((entry) => entry.id));
   const calculationSeriesIds = activeStudyInputSeriesIds(spec.studies);
   visibleSeriesIds.forEach((id) => calculationSeriesIds.add(id));
+  // Keep the first authored market series loaded as the deterministic shared
+  // session anchor even when the user temporarily hides its marks.
+  const primaryMarketSeries = spec.series.find((entry) => (
+    entry.source.kind === "security" && isMarketFieldId(entry.source.fieldId)
+  ));
+  if (primaryMarketSeries) calculationSeriesIds.add(primaryMarketSeries.id);
   if (!sources.dataProvider && spec.series.some((entry) => (
     calculationSeriesIds.has(entry.id) && entry.source.kind === "security"
   ))) {
@@ -478,9 +544,6 @@ export async function resolveChartSpecData(
 
   const referenceNow = sources.now ?? new Date();
   const initialVisibleBounds = requestedBounds(spec, referenceNow);
-  const initialResolution = requestResolution(spec, initialVisibleBounds, calculationSeriesIds);
-  const initialCalculationBounds = calculationBounds(spec, initialVisibleBounds, initialResolution);
-  const hasExplicitWindow = explicitBounds(spec) !== null;
 
   const loadFinancials = (source: Extract<ChartSeriesSpec["source"], { kind: "security" }>) => {
     const key = instrumentKey(source);
@@ -514,6 +577,38 @@ export async function resolveChartSpecData(
     }
     return pending;
   };
+
+  const runtimeBounds = spec.viewport.resolution === "auto"
+    ? runtimeAutoBounds(options)
+    : null;
+  const activeMarketSources = [...new Map(spec.series.flatMap((entry) => (
+    calculationSeriesIds.has(entry.id)
+      && entry.source.kind === "security"
+      && isMarketFieldId(entry.source.fieldId)
+      ? [[instrumentKey(entry.source), entry.source] as const]
+      : []
+  ))).values()];
+  const sharedSupport = runtimeBounds && activeMarketSources.length > 0
+    ? intersectChartResolutionSupport(await Promise.all(
+        activeMarketSources.map((source) => loadResolutionSupport(source)),
+      ))
+    : [];
+  const initialResolution = requestResolution(
+    spec,
+    initialVisibleBounds,
+    calculationSeriesIds,
+    options,
+    sharedSupport,
+  );
+  const requestVisibleBounds = runtimeBounds ?? initialVisibleBounds;
+  const initialCalculationBounds = calculationBounds(
+    spec,
+    requestVisibleBounds,
+    initialResolution,
+  );
+  const hasExplicitWindow = explicitBounds(spec) !== null
+    || (runtimeBounds !== null && !sameBounds(runtimeBounds, initialVisibleBounds));
+
   const loadHistory = async (
     source: Extract<ChartSeriesSpec["source"], { kind: "security" }>,
     all = false,
@@ -595,7 +690,7 @@ export async function resolveChartSpecData(
           ? { ...financials, quote: latestQuote(financials.quote, quoteOverride) }
           : financials;
       if (!merged) throw new Error(`No financial data is available for ${instrumentLabel(source)}.`);
-      const result = baseSecuritySeries(seriesSpec, merged, index);
+      const result = baseSecuritySeries(seriesSpec, merged, index, initialResolution);
       if (!result) throw new Error(`Unknown field ${source.fieldId}.`);
       if (isFundamentalFieldId(source.fieldId) && fundamentalSeriesUsesAvailabilityFallback(merged, source)) {
         result.warning = "Publication dates are unavailable for some observations; period-end dates are used as a fallback.";

--- a/src/time-series/spec-studies.test.ts
+++ b/src/time-series/spec-studies.test.ts
@@ -65,7 +65,7 @@ describe("chart spec normalization and validation", () => {
     if (normalized.series[0]?.source.kind !== "security") throw new Error("expected security source");
     expect(normalized.series[0].source.fieldId).toBe("fundamental.totalRevenue");
     expect(normalized.series[0].source.instrument.symbol).toBe("MSFT");
-    expect(normalized.series[0].style).toBe("step");
+    expect(normalized.series[0].style).toBe("columns");
     expect(validateChartSpec(normalized).valid).toBe(true);
   });
 
@@ -89,8 +89,8 @@ describe("chart spec normalization and validation", () => {
     expect(validateChartSpec(normalized).valid).toBe(true);
   });
 
-  test("normalizes persisted financial columns to period-end timestamps", () => {
-    const normalized = normalizeChartSpec({
+  test("preserves explicit financial timing and migrates legacy timing once", () => {
+    const authored = {
       viewport: { range: "1Y", resolution: "auto" },
       panels: [{ id: "main" }],
       series: [{
@@ -100,7 +100,6 @@ describe("chart spec normalization and validation", () => {
           instrument: { symbol: "AAPL" },
           fieldId: "fundamental.totalRevenue",
           period: "quarterly",
-          timestampMode: "available-at",
         },
         style: "columns",
         transform: "raw",
@@ -109,41 +108,44 @@ describe("chart spec normalization and validation", () => {
         interpolation: "none",
       }],
       studies: [],
-    });
+    } as const;
 
-    expect(normalized.series[0]?.source).toMatchObject({
-      kind: "security",
-      timestampMode: "period-end",
-    });
-
-    const line = normalizeChartSpec({
-      viewport: { range: "1Y", resolution: "auto" },
-      panels: [{ id: "main" }],
+    const explicitColumns = normalizeChartSpec({
+      ...authored,
       series: [{
-        id: "revenue",
-        source: {
-          kind: "security",
-          instrument: { symbol: "AAPL" },
-          fieldId: "fundamental.totalRevenue",
-          period: "quarterly",
-          timestampMode: "period-end",
-        },
+        ...authored.series[0],
+        source: { ...authored.series[0].source, timestampMode: "available-at" },
+      }],
+    });
+    expect(explicitColumns.series[0]?.source).toMatchObject({
+      kind: "security",
+      timestampMode: "available-at",
+    });
+
+    const explicitLine = normalizeChartSpec({
+      ...authored,
+      series: [{
+        ...authored.series[0],
+        source: { ...authored.series[0].source, timestampMode: "period-end" },
         style: "line",
-        transform: "raw",
-        axis: "right",
-        panelId: "main",
         interpolation: "step-after",
       }],
-      studies: [],
     });
-    expect(line.series[0]).toMatchObject({
+    expect(explicitLine.series[0]).toMatchObject({
       style: "line",
       interpolation: "none",
       source: {
         kind: "security",
-        timestampMode: "available-at",
+        timestampMode: "period-end",
       },
     });
+
+    expect(normalizeChartSpec(authored).series[0]?.source)
+      .toMatchObject({ timestampMode: "period-end" });
+    expect(normalizeChartSpec({
+      ...authored,
+      series: [{ ...authored.series[0], style: "line" }],
+    }).series[0]?.source).toMatchObject({ timestampMode: "available-at" });
   });
 
   test("rejects annual QoQ, duplicate OHLC series, and missing study inputs", () => {

--- a/src/time-series/spec.ts
+++ b/src/time-series/spec.ts
@@ -1,6 +1,10 @@
 import type { ChartResolution, TimeRange } from "../components/chart/core/types";
 import { getChartResolutionLabel } from "../components/chart/core/resolution";
-import { canonicalTimeSeriesFieldId, getTimeSeriesField } from "./field-catalog";
+import {
+  canonicalTimeSeriesFieldId,
+  getTimeSeriesField,
+  isFundamentalFieldId,
+} from "./field-catalog";
 import {
   isResolutionFineEnoughForMarketPeriod,
   maximumResolutionForMarketPeriod,
@@ -18,6 +22,7 @@ import {
   type SeriesInterpolation,
   type SeriesPeriod,
   type SeriesStyle,
+  type SeriesTimestampMode,
   type SeriesTransform,
   type SecuritySeriesSource,
 } from "./types";
@@ -136,7 +141,9 @@ function normalizeSource(value: unknown): ChartSeriesSource | null {
   const fieldId = nonEmptyString(source.fieldId);
   if (!instrument || !symbol || !fieldId) return null;
   const period = PERIODS.has(source.period as SeriesPeriod) ? source.period as SeriesPeriod : undefined;
-  const timestampMode = source.timestampMode === "period-end" ? "period-end" : "available-at";
+  const timestampMode = source.timestampMode === "period-end" || source.timestampMode === "available-at"
+    ? source.timestampMode as SeriesTimestampMode
+    : undefined;
   return {
     kind: "security",
     instrument: {
@@ -145,7 +152,7 @@ function normalizeSource(value: unknown): ChartSeriesSource | null {
     } as unknown as SecuritySeriesSource["instrument"],
     fieldId: canonicalTimeSeriesFieldId(fieldId),
     period,
-    timestampMode,
+    ...(timestampMode ? { timestampMode } : {}),
   };
 }
 
@@ -202,14 +209,14 @@ function normalizeSeries(
       ? requestedTransform
       : "raw"
     : requestedTransform ?? "raw";
-  const normalizedSource = source.kind === "security"
-    && (
-      source.fieldId.startsWith("fundamental.")
-      || source.fieldId.startsWith("valuation.")
-    )
+  const normalizedSource = source.kind === "security" && isFundamentalFieldId(source.fieldId)
     ? {
         ...source,
-        timestampMode: style === "columns" ? "period-end" as const : "available-at" as const,
+        // V1 specs created before timing became an independent control may not
+        // contain a timestamp mode. Preserve their legacy visual semantics once
+        // during normalization, then persist the explicit choice.
+        timestampMode: source.timestampMode
+          ?? (style === "columns" ? "period-end" as const : "available-at" as const),
       }
     : source;
   return {

--- a/src/time-series/studies.ts
+++ b/src/time-series/studies.ts
@@ -88,6 +88,7 @@ function outputSeries(
     axis: spec.axis === "auto" ? options.axis ?? input.axis : spec.axis,
     panelId: spec.panelId,
     interpolation: options.interpolation ?? "none",
+    timeBasis: input.timeBasis,
     points: options.points,
   };
 }

--- a/src/time-series/types.ts
+++ b/src/time-series/types.ts
@@ -8,6 +8,7 @@ export type SeriesStyle = "line" | "area" | "step" | "columns" | "points" | "can
 export type SeriesTransform = "raw" | "percent" | "index100" | "yoy" | "qoq" | "log";
 export type SeriesAxis = "auto" | "left" | "right";
 export type SeriesInterpolation = "none" | "step-after";
+export type SeriesTimestampMode = "available-at" | "period-end";
 export type PanelScale = "linear" | "log";
 
 export interface SecuritySeriesSource {
@@ -15,7 +16,7 @@ export interface SecuritySeriesSource {
   instrument: InstrumentRef;
   fieldId: string;
   period?: SeriesPeriod;
-  timestampMode?: "available-at" | "period-end";
+  timestampMode?: SeriesTimestampMode;
 }
 
 export interface EconomicSeriesSource {
@@ -103,6 +104,14 @@ export interface TimeSeriesPoint {
   };
 }
 
+export interface ResolvedSeriesMarketTimeBasis {
+  kind: "market";
+  /** IANA timezone used to recognize one exchange-local trading day. */
+  timeZone: string;
+  /** Requested bar cadence when known; otherwise the chart derives it. */
+  cadenceMs?: number;
+}
+
 export interface ResolvedSeries {
   id: string;
   label: string;
@@ -110,12 +119,16 @@ export interface ResolvedSeries {
   unit: string;
   unitGroup: string;
   nativeFrequency: SeriesPeriod;
+  /** Authored time basis retained for layout and cursor semantics. */
+  timestampMode?: SeriesTimestampMode;
   dataShape: SeriesDataShape;
   style: SeriesStyle;
   transform: SeriesTransform;
   axis: Exclude<SeriesAxis, "auto">;
   panelId: string;
   interpolation: SeriesInterpolation;
+  /** Present only for exchange-traded market observations. */
+  timeBasis?: ResolvedSeriesMarketTimeBasis;
   points: TimeSeriesPoint[];
   warning?: string;
 }

--- a/src/time-series/use-chart-resolution.ts
+++ b/src/time-series/use-chart-resolution.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ChartResolveCache,
   resolveChartSpecData,
+  type ChartResolveOptions,
   type ChartResolveSources,
 } from "./resolve";
 import type { ChartResolutionResult, ChartSpec } from "./types";
@@ -18,6 +19,8 @@ export interface UseChartResolutionResult extends ChartResolutionResult {
 
 export interface UseChartResolutionOptions {
   liveRefreshIntervalMs?: number;
+  autoViewport?: ChartResolveOptions["autoViewport"];
+  targetPointCount?: number;
 }
 
 const EMPTY_RESULT: ChartResolutionResult = {
@@ -51,20 +54,47 @@ export function useChartResolution(
   const liveSubscriptionGenerationRef = useRef(0);
   const liveQuoteOverridesRef = useRef<ReadonlyMap<string, Quote>>(new Map());
   const resolveCacheRef = useRef(new ChartResolveCache());
-  const latestRequestRef = useRef({ spec, sources });
-  latestRequestRef.current = { spec, sources };
+  const cacheIdentityRef = useRef<{
+    spec: ChartSpec | null;
+    sources: ChartResolveSources | null;
+    revision: number;
+  }>({ spec: null, sources: null, revision: -1 });
+  const autoViewportStart = options.autoViewport?.start.getTime();
+  const autoViewportEnd = options.autoViewport?.end.getTime();
+  const validAutoViewport = typeof autoViewportStart === "number"
+      && Number.isFinite(autoViewportStart)
+      && typeof autoViewportEnd === "number"
+      && Number.isFinite(autoViewportEnd)
+      && autoViewportStart <= autoViewportEnd
+    ? { start: new Date(autoViewportStart), end: new Date(autoViewportEnd) }
+    : null;
+  const adaptiveTargetPointCount = validAutoViewport ? options.targetPointCount : undefined;
+  const resolveOptions: ChartResolveOptions = {
+    autoViewport: validAutoViewport,
+    targetPointCount: adaptiveTargetPointCount,
+  };
+  const latestRequestRef = useRef({ spec, sources, options: resolveOptions });
+  latestRequestRef.current = { spec, sources, options: resolveOptions };
   const reload = useCallback(() => setRevision((current) => current + 1), []);
 
   useEffect(() => {
     generationRef.current += 1;
     const generation = generationRef.current;
-    const cache = new ChartResolveCache();
-    resolveCacheRef.current = cache;
+    const cacheIdentity = cacheIdentityRef.current;
+    const resetCache = cacheIdentity.spec !== spec
+      || cacheIdentity.sources !== sources
+      || cacheIdentity.revision !== revision;
+    if (resetCache) {
+      resolveCacheRef.current = new ChartResolveCache();
+      cacheIdentityRef.current = { spec, sources, revision };
+    }
+    const cache = resolveCacheRef.current;
     setResult((current) => ({ ...current, loading: true, errors: [] }));
     resolveChartSpecData(
       spec,
       withQuoteOverrides(sources, liveQuoteOverridesRef.current),
       cache,
+      resolveOptions,
     )
       .then((next) => {
         if (generationRef.current === generation) setResult(next);
@@ -81,7 +111,7 @@ export function useChartResolution(
     return () => {
       if (generationRef.current === generation) generationRef.current += 1;
     };
-  }, [revision, sources, spec]);
+  }, [adaptiveTargetPointCount, autoViewportEnd, autoViewportStart, revision, sources, spec]);
 
   const liveTargetSignature = liveChartQuoteTargetSignature(spec);
   const liveRefreshIntervalMs = options.liveRefreshIntervalMs ?? LIVE_CHART_REFRESH_INTERVAL_MS;
@@ -102,6 +132,7 @@ export function useChartResolution(
             request.spec,
             withQuoteOverrides(request.sources, quoteOverrides),
             resolveCacheRef.current,
+            request.options,
           );
           if (
             liveSubscriptionGenerationRef.current === subscriptionGeneration

--- a/src/ui/dialog.tsx
+++ b/src/ui/dialog.tsx
@@ -18,6 +18,8 @@ export interface DialogApi {
 interface DialogContextValue {
   dialog: DialogApi;
   isOpen: boolean;
+  dialogId?: string;
+  keyboardEnabled: boolean;
 }
 
 const DialogContext = createContext<DialogContextValue | null>(null);
@@ -25,14 +27,18 @@ const DialogContext = createContext<DialogContextValue | null>(null);
 export function DialogHostProvider({
   dialog,
   isOpen,
+  dialogId,
+  keyboardEnabled = true,
   children,
 }: {
   dialog: DialogApi;
   isOpen: boolean;
+  dialogId?: string;
+  keyboardEnabled?: boolean;
   children: ReactNode;
 }) {
   return (
-    <DialogContext value={{ dialog, isOpen }}>
+    <DialogContext value={{ dialog, isOpen, dialogId, keyboardEnabled }}>
       {children}
     </DialogContext>
   );
@@ -54,5 +60,11 @@ export function useDialogKeyboard(
   handler: (event: KeyEventLike) => void,
   options?: ShortcutOptions | string,
 ): void {
-  useShortcut(handler, typeof options === "string" ? { scope: options } : options);
+  const context = useContext(DialogContext);
+  const resolved = typeof options === "string" ? { scope: options } : options;
+  useShortcut(handler, {
+    ...resolved,
+    enabled: (resolved?.enabled ?? true) && (context?.keyboardEnabled ?? true),
+    scope: resolved?.scope ?? context?.dialogId,
+  });
 }

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -108,6 +108,7 @@ export interface ScrollBoxRenderable {
   scrollTop: number;
   scrollLeft?: number;
   scrollHeight: number;
+  scrollWidth?: number;
   scrollTopPx?: number;
   scrollLeftPx?: number;
   scrollHeightPx?: number;
@@ -278,6 +279,7 @@ export interface HostTabsProps {
   activeValue: string | null;
   onSelect: (value: string) => void;
   compact?: boolean;
+  dense?: boolean;
   variant?: "underline" | "pill" | "bare";
   closeMode?: "active" | "always";
   addLabel?: string;


### PR DESCRIPTION
## Summary

- Stabilize chart quick-add and series settings across desktop and OpenTUI, including focus, keyboard traversal, Escape/outside dismissal, and responsive field layout.
- Improve legend interaction with hover feedback, horizontal scrolling, keyboard controls, final-series protection, and hidden disabled footer actions.
- Render fundamental series as consistent grouped columns and align mixed price/fundamental data on an availability-safe trading-session timeline.
- Preserve exact observation metadata while adding zoom-aware Auto resolution and stable chart viewports.
- Fix earnings collection scoping and stale asynchronous requests that could leave panes loading indefinitely.

## Root causes

Chart state and input focus were controlled across overlapping render and dialog layers, while mixed-frequency data used literal calendar timestamps instead of a shared market-session projection. Earnings requests could also outlive their active selection and leave loading state unresolved.

## Validation

- `bun test src/components/chart src/plugins/builtin/chart-composer src/time-series` — 259 passed
- `bun run build`
- `bun run desktop:view:build`
- Real tmux keyboard smoke for mixed TSLA chart zoom, series modal traversal, and Escape dismissal
- Runtime warning scan
- `git diff --check`