### PR TITLE
Fix desktop chart quick-add crash from stubbed surface manager

### DIFF
--- a/src/renderers/electrobun/view/native-stubs/chart/surface-manager.ts
+++ b/src/renderers/electrobun/view/native-stubs/chart/surface-manager.ts
@@ -10,11 +10,22 @@ export interface NativeOccluder {
   zIndex: number;
 }
 
+export interface NativeLocalOccluder {
+  id: string;
+  paneId: string;
+  rect: { x: number; y: number; width: number; height: number };
+}
+
+// Must expose every public method of the terminal manager: the desktop view
+// bundle swaps this module in, so a missing method is a runtime crash.
+// native-stubs.test.ts guards the drift.
 export class NativeSurfaceManager {
   setWindowState(): void {}
   upsertSurface(): void {}
   updateSurfaceGeometry(): void {}
   removeSurface(): void {}
+  upsertLocalOccluder(): void {}
+  removeLocalOccluder(): void {}
   destroy(): void {}
 }
 

--- a/src/renderers/electrobun/view/native-stubs/native-stubs.test.ts
+++ b/src/renderers/electrobun/view/native-stubs/native-stubs.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { Glob } from "bun";
+import * as realSurfaceSync from "../../../../components/chart/native/surface/sync";
+import * as realKittySupport from "../../../../components/chart/native/kitty/support";
+import { NativeSurfaceManager as StubNativeSurfaceManager } from "./chart/surface-manager";
+import * as stubSurfaceSync from "./chart/surface-sync";
+import * as stubKittySupport from "./chart/kitty-support";
+
+// The desktop view bundle aliases these modules to the stubs in this directory
+// (see build-assets.ts COMMON_ALIAS_RULES). A method the app calls but the stub
+// lacks is a desktop startup crash, not a type error, so check the shapes here.
+
+function exportedFunctions(module: Record<string, unknown>): string[] {
+  return Object.keys(module)
+    .filter((name) => typeof module[name] === "function")
+    .sort();
+}
+
+async function calledSurfaceManagerMethods(): Promise<string[]> {
+  const calls = new Set<string>();
+  const pattern = /\b\w*[sS]urfaceManager(?:\.current)?\.([a-zA-Z]\w*)\s*\(/g;
+  for await (const path of new Glob("src/**/*.{ts,tsx}").scan(".")) {
+    if (path.includes("native-stubs") || path.includes("native/surface/manager")) continue;
+    for (const match of (await Bun.file(path).text()).matchAll(pattern)) {
+      calls.add(match[1]!);
+    }
+  }
+  return [...calls].sort();
+}
+
+describe("desktop view native stubs", () => {
+  test("surface manager stub answers every method the app calls on it", async () => {
+    const called = await calledSurfaceManagerMethods();
+    expect(called.length).toBeGreaterThan(3);
+    const stub = StubNativeSurfaceManager.prototype as unknown as Record<string, unknown>;
+    expect(called.filter((name) => typeof stub[name] !== "function")).toEqual([]);
+  });
+
+  test("module stubs export every function of the modules they replace", () => {
+    expect(
+      exportedFunctions(realSurfaceSync).filter((name) => !exportedFunctions(stubSurfaceSync).includes(name)),
+    ).toEqual([]);
+    expect(
+      exportedFunctions(realKittySupport).filter((name) => !exportedFunctions(stubKittySupport).includes(name)),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Symptom

v0.10.0 crashed on startup on the macOS desktop app with `Gloomberb crashed` and a stack of react-dom frames. Mapping the shipped sourcemap put the throw at `src/plugins/builtin/chart-composer/quick-add.tsx:141`.

## Root cause

The desktop view bundle aliases `components/chart/native/surface/manager` to `view/native-stubs/chart/surface-manager.ts` (build-assets.ts `COMMON_ALIAS_RULES`). #505 added `upsertLocalOccluder`/`removeLocalOccluder` to the real manager and called them from the chart quick-add, but the stub was never updated — and the desktop-web branch of that effect calls `removeLocalOccluder` unconditionally:

```ts
if (ui.kind === "desktop-web" || drawerHeight <= 0 || !paneId || !drawerRef.current) {
  nativeSurfaceManager.removeLocalOccluder(occluderId);
```

So every desktop user with a chart pane hit `removeLocalOccluder is not a function` during the first render. Confirmed against the shipped bundle: `removeLocalOccluder` appears twice (both call sites, no definition). The terminal build was unaffected because it uses the real manager.

TypeScript could not catch it — the alias only exists at bundle time — and the Windows desktop GUI smoke launches with a fresh profile, so it never opened a chart pane.

## Fix

- Add the two occluder methods to the stub.
- Add `native-stubs.test.ts`, which greps the source for `*surfaceManager.<method>(` call sites and asserts the stub answers each, plus checks the other two stub modules re-export every function they replace. It fails on the pre-fix stub and passes after.

## Validation

- `bun test src/renderers src/plugins/builtin/chart-composer src/components/chart` — 238 passed
- Rebuilt the view bundle and confirmed `removeLocalOccluder(){}` is now defined in `dist/electrobun-view/main.js`