### PR TITLE
Recover chat messages the incremental cursor skipped past

### DIFF
--- a/src/plugins/builtin/chat/controller.test.ts
+++ b/src/plugins/builtin/chat/controller.test.ts
@@ -501,19 +501,76 @@ describe("ChatController", () => {
     const calls: Array<{ channelId: string; opts?: { after?: string; before?: string; limit?: number } }> = [];
     apiClient.getMessages = async (channelId, opts) => {
       calls.push({ channelId, opts });
-      return opts?.after === "m1" ? [next] : [];
+      if (!opts?.after) return [initial, next];
+      return opts.after === "m1" ? [next] : [];
     };
 
     await controller.refreshMessages();
 
-    expect(calls).toEqual([{
-      channelId: "everyone",
-      opts: { limit: 50, after: "m1" },
-    }]);
+    expect(calls[0]?.opts?.after).toBeUndefined();
     expect(controller.getSnapshot().messages.map((entry) => entry.id)).toEqual(["m1", "m2"]);
     expect(persistence.getState<{ lastCursor: string }>("channel:everyone", { schemaVersion: 1 })).toMatchObject({
       lastCursor: "m2",
     });
+
+    await controller.refreshMessages();
+
+    expect(calls[1]?.opts?.after).toBe("m2");
+  });
+
+  test("recovers a message the cursor already moved past", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const asked: ChatMessage = {
+      id: "m1",
+      channelId: "everyone",
+      content: "why is the chart glitching",
+      replyToId: null,
+      createdAt: "2026-03-28T00:00:00.000Z",
+      user: { id: "u1", username: "vince", displayName: "Vince" },
+    };
+    const missed: ChatMessage = {
+      id: "m2",
+      channelId: "everyone",
+      content: "charts open with GP",
+      replyToId: "m1",
+      createdAt: "2026-03-28T00:01:00.000Z",
+      user: { id: "u2", username: "gloombot", displayName: "Gloombot" },
+    };
+    const acknowledged: ChatMessage = {
+      id: "m3",
+      channelId: "everyone",
+      content: "got it",
+      replyToId: null,
+      createdAt: "2026-03-28T00:02:00.000Z",
+      user: { id: "u1", username: "vince", displayName: "Vince" },
+    };
+
+    // The cursor already sits on m3, so an incremental fetch can never ask for
+    // m2 again even though the server still has it.
+    persistence.setState("channel:everyone", {
+      draft: "",
+      replyToId: null,
+      lastCursor: "m3",
+      lastViewedMessageId: "m3",
+    }, { schemaVersion: 1 });
+    persistence.setResource(TRANSCRIPT_KIND, TRANSCRIPT_KEY, {
+      messages: [asked, acknowledged],
+    }, {
+      sourceKey: TRANSCRIPT_SOURCE,
+      schemaVersion: TRANSCRIPT_SCHEMA_VERSION,
+      cachePolicy: { staleMs: 1_000, expireMs: 2_000 },
+    });
+
+    controller.attachPersistence(persistence);
+
+    apiClient.getMessages = async (_channelId, opts) => (
+      opts?.after ? [] : [asked, missed, acknowledged]
+    );
+
+    await controller.refreshMessages();
+
+    expect(controller.getSnapshot().messages.map((entry) => entry.id)).toEqual(["m1", "m2", "m3"]);
   });
 
   test("hydrates missing transcript cache without marking history unread", async () => {
@@ -603,19 +660,21 @@ describe("ChatController", () => {
     const calls: Array<{ channelId: string; opts?: { after?: string; before?: string; limit?: number } }> = [];
     apiClient.getMessages = async (channelId, opts) => {
       calls.push({ channelId, opts });
-      return opts?.after === "m1" ? [fresh] : [];
+      return opts?.after ? [] : [cached, fresh];
     };
 
     await controller.refreshMessages();
 
-    expect(calls).toEqual([{
-      channelId: "everyone",
-      opts: { limit: 50, after: "m1" },
-    }]);
+    expect(calls[0]?.opts?.after).toBeUndefined();
     expect(controller.getSnapshot().messages.map((entry) => entry.id)).toEqual(["m1", "m2"]);
     expect(persistence.getState<{ lastCursor: string }>("channel:everyone", { schemaVersion: 1 })).toMatchObject({
       lastCursor: "m2",
     });
+
+    await controller.refreshMessages();
+
+    // The stale m99 cursor never reaches the server.
+    expect(calls[1]?.opts?.after).toBe("m2");
   });
 
   test("shows a pending message immediately and replaces it when the send succeeds", async () => {
@@ -1398,16 +1457,10 @@ describe("ChatController", () => {
 
     await controller.refreshMessages();
 
-    expect(calls).toEqual([
-      {
-        channelId: "everyone",
-        opts: { limit: 50, after: "2026-03-28T00:00:00.000Z" },
-      },
-      {
-        channelId: "everyone",
-        opts: { limit: 50 },
-      },
-    ]);
+    // The session backfill already ignores the cursor, so the legacy timestamp
+    // is never sent and the old wasted round trip is gone.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.opts?.after).toBeUndefined();
     expect(controller.getSnapshot().messages.map((entry) => entry.id)).toEqual(["m1", "m2"]);
     expect(persistence.getState<{ lastCursor: string }>("channel:everyone", { schemaVersion: 1 })).toMatchObject({
       lastCursor: "m2",

--- a/src/plugins/builtin/chat/controller/fetch.ts
+++ b/src/plugins/builtin/chat/controller/fetch.ts
@@ -23,13 +23,18 @@ export async function fetchLatestChannelMessages(
   const hasIncrementalCursor = !!channel.lastCursor;
   const hadMessages = channel.messages.length > 0;
   const countIncrementalUnread = hadMessages && hasIncrementalCursor && !legacyTimestampCursor;
+  // The first fetch of a session drops the cursor so anything missed while the
+  // socket was connected comes back. Merging is keyed by message id, so
+  // re-reading known messages changes nothing and counts no unread.
+  const backfillGaps = !channel.backfilled;
 
   try {
     const messages = await apiClient.getMessages(channelId, {
       limit: MESSAGE_PAGE_SIZE,
-      after: channel.lastCursor ?? undefined,
+      after: backfillGaps ? undefined : channel.lastCursor ?? undefined,
     });
-    if (!hasIncrementalCursor && messages.length < MESSAGE_PAGE_SIZE) {
+    channel.backfilled = true;
+    if ((!hasIncrementalCursor || backfillGaps) && messages.length < MESSAGE_PAGE_SIZE) {
       channel.reachedOldestMessage = true;
     }
     if (messages.length > 0) {
@@ -51,6 +56,7 @@ export async function fetchLatestChannelMessages(
     return;
   } catch {
     const messages = await apiClient.getMessages(channelId, { limit: MESSAGE_PAGE_SIZE });
+    channel.backfilled = true;
     if (messages.length < MESSAGE_PAGE_SIZE) {
       channel.reachedOldestMessage = true;
     }

--- a/src/plugins/builtin/chat/controller/state.ts
+++ b/src/plugins/builtin/chat/controller/state.ts
@@ -73,6 +73,12 @@ export interface ChannelRuntimeState {
   refreshMessagesPromise: Promise<void> | null;
   loadOlderMessagesPromise: Promise<void> | null;
   reachedOldestMessage: boolean;
+  /**
+   * False until this session has fetched a full latest page. The incremental
+   * cursor only ever asks for newer messages, so a message missed live can
+   * never be requested again; one uncursored fetch per session repairs it.
+   */
+  backfilled: boolean;
   messages: ChatMessage[];
   pendingMessages: ChatMessage[];
   draft: string;
@@ -105,6 +111,7 @@ export function createEmptyChannelState(): ChannelRuntimeState {
     refreshMessagesPromise: null,
     loadOlderMessagesPromise: null,
     reachedOldestMessage: false,
+    backfilled: false,
     messages: [],
     pendingMessages: [],
     draft: "",


### PR DESCRIPTION
Messages that exist on the server can stay permanently invisible in a client.

## What happens

`fetchLatestChannelMessages` only ever asks for messages newer than `channel.lastCursor`, and that cursor is persisted across restarts:

```ts
const messages = await apiClient.getMessages(channelId, {
  limit: MESSAGE_PAGE_SIZE,
  after: channel.lastCursor ?? undefined,
});
```

If a message is never delivered live, the next message to arrive pushes the cursor past it and it can never be requested again. Paging backwards does not help either, since that path uses `before` from the oldest loaded message, so it steps over the hole rather than into it.

The 30s safety refresh could not help, because it carried the same cursor and so could only ever fetch what was already newest. It could not catch the thing it exists to catch.

Observed in `#everyone`: three replies were committed server side and are still returned by the API, but no client that had moved its cursor on could ask for them again. The result reads as one side of a conversation talking to nobody.

## Fix

Drop the cursor for the first fetch of each session, keep it for the rest.

This is safe because the existing merge is already keyed by message id, and unread counting only looks at ids that were not already present, so re-reading a page is inert: no duplicates, no unread inflation. That is why this is ten lines rather than gap-detection machinery.

`backfilled` is deliberately not part of `PersistedChannelState`, so every launch starts false and re-heals.

Cost is one extra 50-message page per channel per app start. The safety refresh stays incremental; making that uncursored would be ~50KB every 30s per open channel.

Also removes a wasted round trip: the legacy timestamp cursor path used to send a bad cursor, get nothing back, then refetch in full. The first fetch now sends no cursor at all.

## Limits

Repairs any gap inside the newest page at launch. A gap opened mid-session heals on the next start, not immediately. A gap older than one page is not recovered.

## Tests

New regression test `recovers a message the cursor already moved past`: cached m1 and m3 with the cursor on m3, m2 only on the server, asserts all three end up present. Two tests that asserted cursor-first behaviour were updated.

Full suite: 1657 pass, 0 fail. Typecheck error count is unchanged from main (187 pre-existing, none in the touched files).