### PR TITLE
Fix market time fallback for buffered charts

### DIFF
--- a/src/components/chart/composite/scene.test.ts
+++ b/src/components/chart/composite/scene.test.ts
@@ -397,6 +397,42 @@ describe("composite chart scene", () => {
     expect(layout.groupByPoint.get(second)).toMatchObject({ index: 1, count: 2 });
   });
 
+  test("uses plotted market data when the legend timeline is empty", () => {
+    const timestamps = [
+      "2025-01-03T15:00:00.000Z",
+      "2025-01-03T16:00:00.000Z",
+      "2025-01-06T14:00:00.000Z",
+    ];
+    const price = series({
+      id: "price",
+      timeBasis: {
+        kind: "market",
+        timeZone: "America/New_York",
+        cadenceMs: 60 * 60 * 1_000,
+      },
+      points: timestamps.map((timestamp, index) => {
+        const date = new Date(timestamp);
+        return { date, observedAt: date, value: 100 + index };
+      }),
+    });
+    const scene = buildCompositeChartScene(
+      [price],
+      [{ id: "main" }],
+      {
+        width: 80,
+        height: 10,
+        viewport: {
+          start: new Date(timestamps[0]!),
+          end: new Date(timestamps.at(-1)!),
+        },
+        timelineSeries: [],
+      },
+    );
+
+    expect(scene?.timeScale).toMatchObject({ kind: "market", anchorSeriesId: "price" });
+    expect(scene?.panels[0]?.series[0]?.points.map(({ xRatio }) => xRatio)).toEqual([0, 0.5, 1]);
+  });
+
   test("retains the authored primary market scale when its plotted series is hidden", () => {
     const anchor = series({
       id: "primary-price",

--- a/src/components/chart/composite/scene.ts
+++ b/src/components/chart/composite/scene.ts
@@ -423,8 +423,11 @@ export function buildCompositeChartScene(
   const viewport = explicitViewport(options);
   const startTime = viewport?.startTime ?? (firstTime === lastTime ? firstTime - DAY_MS / 2 : firstTime);
   const endTime = viewport?.endTime ?? (firstTime === lastTime ? lastTime + DAY_MS / 2 : lastTime);
+  const timelineSeries = options.timelineSeries?.some((entry) => (
+    entry.timeBasis?.kind === "market" && entry.points.length > 0
+  )) ? options.timelineSeries : dataSeries;
   const timeScale = buildCompositeTimeScale(
-    options.timelineSeries ?? dataSeries,
+    timelineSeries,
     startTime,
     endTime,
   );


### PR DESCRIPTION
## Summary
- fall back to plotted market data when the legend timeline has no usable market anchor
- keep overnight and weekend closures compressed after historical chart panning
- add a regression for an empty legend timeline with buffered price data

## Verification
- `bun test` (1,657 passed)
- `bun run build`
- tmux TUI smoke test with no runtime warnings