### PR TITLE
Fix chart axes, zoom resilience, and adaptive history loading

### DIFF
--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -4,6 +4,7 @@ import {
   createElement,
   forwardRef,
   useMemo,
+  useState,
   type ForwardedRef,
   type ReactNode,
 } from "react";
@@ -180,8 +181,8 @@ describe("CompositeChart", () => {
     expect(frame).toContain("ACME Price");
     expect(frame).toContain("OTHER Revenue");
     expect(frame).toContain("$103");
-    expect(frame.match(/2025-01-01/g)).toHaveLength(1);
-    expect(frame.match(/2025-01-03/g)).toHaveLength(1);
+    expect(frame.match(/Jan 1/g)).toHaveLength(1);
+    expect(frame.match(/Jan 3/g)).toHaveLength(1);
   });
 
   test("keeps legend items compact and anchors an accessory to the right edge", async () => {
@@ -464,11 +465,8 @@ describe("CompositeChart", () => {
     );
 
     await act(async () => testSetup!.renderOnce());
-    expect(testSetup.captureCharFrame()).toContain("2025-01-01");
-    expect(viewportChanges).toEqual([{
-      start: "2025-01-01T00:00:00.000Z",
-      end: "2025-01-09T00:00:00.000Z",
-    }]);
+    expect(testSetup.captureCharFrame()).toContain("Jan 1");
+    expect(viewportChanges).toEqual([]);
 
     const zoomIn = keyEvent("=");
     zoomIn.sequence = "+";
@@ -477,16 +475,76 @@ describe("CompositeChart", () => {
     await act(async () => testSetup!.renderOnce());
 
     expect(zoomIn.defaultPrevented).toBe(true);
-    expect(testSetup.captureCharFrame()).not.toContain("2025-01-01");
+    expect(testSetup.captureCharFrame()).not.toContain("Jan 1");
     expect(viewportChanges.at(-1)?.start).not.toBe("2025-01-01T00:00:00.000Z");
 
     await act(async () => chartShortcut?.(keyEvent("0")));
     await act(async () => testSetup!.renderOnce());
-    expect(testSetup.captureCharFrame()).toContain("2025-01-01");
-    expect(viewportChanges.at(-1)).toEqual({
-      start: "2025-01-01T00:00:00.000Z",
-      end: "2025-01-09T00:00:00.000Z",
+    expect(testSetup.captureCharFrame()).toContain("Jan 1");
+    expect(viewportChanges.at(-1)).toBeNull();
+  });
+
+  test("preserves a zoomed viewport when adaptive data refreshes its buffer", async () => {
+    const viewportChanges: Array<{ start: string; end: string } | null> = [];
+    let replacePoints: ((points: TimeSeriesPoint[]) => void) | null = null;
+    const initialPoints = series(
+      "price",
+      "main",
+      "left",
+      "USD",
+      [100, 101, 102, 103, 104, 105, 106, 107, 108],
+    ).points;
+    function Harness() {
+      const [points, setPoints] = useState(initialPoints);
+      replacePoints = setPoints;
+      return (
+        <InputHostProvider host={chartInputHost}>
+          <CompositeChart
+            width={60}
+            height={12}
+            focused
+            series={[{
+              ...series("price", "main", "left", "USD", []),
+              points,
+            }]}
+            panels={[{ id: "main" }]}
+            viewport={{
+              start: new Date("2025-01-01T00:00:00.000Z"),
+              end: new Date("2025-01-09T00:00:00.000Z"),
+            }}
+            onViewportChange={(next) => viewportChanges.push(next
+              ? { start: next.start.toISOString(), end: next.end.toISOString() }
+              : null)}
+          />
+        </InputHostProvider>
+      );
+    }
+
+    testSetup = await testRender(
+      <Harness />,
+      { width: 62, height: 14 },
+    );
+    await act(async () => testSetup!.renderOnce());
+
+    for (let index = 0; index < 2; index += 1) {
+      const zoomIn = keyEvent("=");
+      zoomIn.sequence = "+";
+      zoomIn.shift = true;
+      await act(async () => chartShortcut?.(zoomIn));
+      await act(async () => testSetup!.renderOnce());
+    }
+    const zoomedViewport = viewportChanges.at(-1);
+    expect(zoomedViewport?.start).not.toBe("2025-01-01T00:00:00.000Z");
+    const changeCount = viewportChanges.length;
+
+    await act(async () => replacePoints?.(initialPoints.slice(2)));
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
     });
+
+    expect(viewportChanges).toHaveLength(changeCount);
+    expect(viewportChanges.at(-1)).toEqual(zoomedViewport);
   });
 
   test("activates and navigates a buffered viewport from the first mouse gesture", async () => {
@@ -515,7 +573,7 @@ describe("CompositeChart", () => {
     );
 
     await act(async () => testSetup!.renderOnce());
-    expect(testSetup.captureCharFrame()).toContain("2025-01-05");
+    expect(testSetup.captureCharFrame()).toContain("Jan 5");
 
     await act(async () => {
       capturedSurfaceProps!.onMouseDown(pointerEvent(10, 3));
@@ -526,7 +584,7 @@ describe("CompositeChart", () => {
 
     expect(activations).toBe(1);
     expect(cursorChanges.length).toBeGreaterThan(0);
-    expect(testSetup.captureCharFrame()).toContain("2025-01-03");
+    expect(testSetup.captureCharFrame()).toContain("Jan 3");
   });
 
   test("maps the pointer crosshair level through both axes and labels its date", async () => {
@@ -584,7 +642,7 @@ describe("CompositeChart", () => {
     );
 
     await act(async () => testSetup!.renderOnce());
-    expect(testSetup.captureCharFrame()).toContain("2025-01-09");
+    expect(testSetup.captureCharFrame()).toContain("Jan 9");
 
     await act(async () => {
       capturedSurfaceProps!.onMouseScroll(pointerEvent(25, 3, {
@@ -594,7 +652,77 @@ describe("CompositeChart", () => {
     });
     await act(async () => testSetup!.renderOnce());
 
-    expect(testSetup.captureCharFrame()).not.toContain("2025-01-09");
+    expect(testSetup.captureCharFrame()).not.toContain("Jan 9");
+  });
+
+  test("keeps the date axis and mouse recovery when refreshed data misses the zoomed window", async () => {
+    let replacePoints: ((points: TimeSeriesPoint[]) => void) | null = null;
+    function Harness() {
+      const [points, setPoints] = useState(
+        series("price", "main", "left", "USD", [100, 101, 102, 103, 104, 105, 106, 107, 108]).points,
+      );
+      replacePoints = setPoints;
+      return (
+        <CompositeChart
+          width={60}
+          height={12}
+          interactive
+          series={[{
+            ...series("price", "main", "left", "USD", []),
+            points,
+          }]}
+          panels={[{ id: "main" }]}
+          viewport={{
+            start: new Date("2025-01-01T00:00:00.000Z"),
+            end: new Date("2025-01-09T00:00:00.000Z"),
+          }}
+        />
+      );
+    }
+
+    testSetup = await testRender(
+      <CaptureChartSurfaceProvider>
+        <Harness />
+      </CaptureChartSurfaceProvider>,
+      { width: 62, height: 14 },
+    );
+    await act(async () => testSetup!.renderOnce());
+
+    for (let index = 0; index < 8; index += 1) {
+      await act(async () => {
+        capturedSurfaceProps!.onMouseScroll(pointerEvent(25, 3, {
+          ctrl: true,
+          scroll: { direction: "up", delta: 8 },
+        }));
+      });
+      await act(async () => testSetup!.renderOnce());
+    }
+
+    await act(async () => {
+      replacePoints?.([
+        point("2025-01-01", 100),
+        point("2025-01-09", 108),
+      ]);
+    });
+    await act(async () => testSetup!.renderOnce());
+
+    const emptyFrame = testSetup.captureCharFrame();
+    expect(emptyFrame).toContain("No chart data");
+    expect(emptyFrame).toContain("Jan ");
+    expect(typeof capturedSurfaceProps!.onMouseScroll).toBe("function");
+
+    await act(async () => {
+      capturedSurfaceProps!.onMouseScroll(pointerEvent(25, 3, {
+        ctrl: true,
+        scroll: { direction: "down", delta: 4 },
+      }));
+    });
+    await act(async () => testSetup!.renderOnce());
+
+    const recoveredFrame = testSetup.captureCharFrame();
+    expect(recoveredFrame).not.toContain("No chart data");
+    expect(recoveredFrame).toContain("2025-01-01");
+    expect(recoveredFrame).toContain("Jan 9");
   });
 
   test("shows useful UTC times for an intraday shared cursor and time axis", async () => {

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -64,8 +64,11 @@ import {
 import {
   renderCompositeAxisText,
   renderCompositePanelText,
-  renderCompositeTimeAxis,
 } from "./text-renderer";
+import {
+  buildCompositeTimeAxisLayout,
+  buildCompositeViewportTimeAxisLayout,
+} from "./time-axis";
 import type {
   CompositeChartColors,
   CompositeChartProps,
@@ -788,79 +791,73 @@ export function CompositeChart({
         : navigationBounds
       : null
   ), [navigationBounds, viewport]);
-  const previousNavigationBoundsRef = useRef<CompositeViewportRange | null>(navigationBounds);
-  const previousInitialViewportRef = useRef<CompositeViewportRange | null>(initialViewport);
+  const previousAuthoredViewportRef = useRef<CompositeViewportRange | null>(viewport ?? null);
   const [interactionViewport, setInteractionViewport] = useState<CompositeViewportRange | null>(null);
-  const navigationBoundsChanged = shouldResetCompositeViewport(
-    previousNavigationBoundsRef.current,
-    navigationBounds,
+  const authoredViewportChanged = shouldResetCompositeViewport(
+    previousAuthoredViewportRef.current,
+    viewport ?? null,
   );
-  const initialViewportChanged = shouldResetCompositeViewport(
-    previousInitialViewportRef.current,
-    initialViewport,
-  );
-  const interactionViewportStillValid = !!interactionViewport
-    && !!navigationBounds
-    && sameCompositeViewport(
-      clampCompositeViewport(interactionViewport, navigationBounds),
-      interactionViewport,
-    );
-  const shouldResetInteractionViewport = initialViewportChanged
-    || (navigationBoundsChanged && !interactionViewportStillValid);
-  const currentInteractionViewport = shouldResetInteractionViewport ? null : interactionViewport;
+  const currentInteractionViewport = authoredViewportChanged
+    ? null
+    : interactionViewport && navigationBounds
+      ? clampCompositeViewport(interactionViewport, navigationBounds)
+      : interactionViewport;
   const effectiveViewport = navigationBounds
     ? currentInteractionViewport
       ? clampCompositeViewport(currentInteractionViewport, navigationBounds)
       : initialViewport
     : null;
-  const effectiveViewportStart = effectiveViewport?.start.getTime() ?? null;
-  const effectiveViewportEnd = effectiveViewport?.end.getTime() ?? null;
+  const interactionViewportStart = currentInteractionViewport?.start.getTime() ?? null;
+  const interactionViewportEnd = currentInteractionViewport?.end.getTime() ?? null;
   const viewportSeriesKey = visibleLegendSeries
     .map((entry) => `${entry.id}:${entry.label}`)
     .join("|");
   const lastReportedViewportRef = useRef<string | null>(null);
   useEffect(() => {
     if (!onViewportChange) return;
-    const viewportKey = effectiveViewportStart === null || effectiveViewportEnd === null
+    const viewportKey = interactionViewportStart === null || interactionViewportEnd === null
       ? "none"
-      : `${effectiveViewportStart}:${effectiveViewportEnd}`;
+      : `${interactionViewportStart}:${interactionViewportEnd}`;
     const key = `${viewportSeriesKey}|${viewportKey}`;
+    // The callback drives adaptive data loading. Seed it from the authored
+    // viewport without echoing that controlled value back into the loader.
+    if (lastReportedViewportRef.current === null) {
+      lastReportedViewportRef.current = key;
+      return;
+    }
     if (lastReportedViewportRef.current === key) return;
     lastReportedViewportRef.current = key;
     onViewportChange(
-      effectiveViewportStart === null || effectiveViewportEnd === null
+      interactionViewportStart === null || interactionViewportEnd === null
         ? null
         : {
-            start: new Date(effectiveViewportStart),
-            end: new Date(effectiveViewportEnd),
+            start: new Date(interactionViewportStart),
+            end: new Date(interactionViewportEnd),
           },
     );
-  }, [effectiveViewportEnd, effectiveViewportStart, onViewportChange, viewportSeriesKey]);
+  }, [interactionViewportEnd, interactionViewportStart, onViewportChange, viewportSeriesKey]);
   const minimumViewportSpanMs = useMemo(
     () => navigationBounds ? resolveCompositeMinimumSpanMs(visibleSeries, navigationBounds) : 1,
     [navigationBounds, visibleSeries],
   );
 
   useEffect(() => {
-    const previousBounds = previousNavigationBoundsRef.current;
-    const previousInitial = previousInitialViewportRef.current;
-    previousNavigationBoundsRef.current = navigationBounds;
-    previousInitialViewportRef.current = initialViewport;
-    if (
-      shouldResetCompositeViewport(previousInitial, initialViewport)
-      || (
-        shouldResetCompositeViewport(previousBounds, navigationBounds)
-        && interactionViewport
-        && navigationBounds
-        && !sameCompositeViewport(
-          clampCompositeViewport(interactionViewport, navigationBounds),
-          interactionViewport,
-        )
-      )
-    ) {
+    const authoredChanged = shouldResetCompositeViewport(
+      previousAuthoredViewportRef.current,
+      viewport ?? null,
+    );
+    previousAuthoredViewportRef.current = viewport ?? null;
+    if (authoredChanged || (interactionViewport && !navigationBounds)) {
       setInteractionViewport(null);
+      return;
     }
-  }, [initialViewport, interactionViewport, navigationBounds]);
+    if (interactionViewport && navigationBounds) {
+      const clamped = clampCompositeViewport(interactionViewport, navigationBounds);
+      if (!sameCompositeViewport(clamped, interactionViewport)) {
+        setInteractionViewport(clamped);
+      }
+    }
+  }, [interactionViewport, navigationBounds, viewport]);
 
   const zoomViewport = useCallback((zoomFactor: number, anchorRatio = 1) => {
     if (!navigationBounds || !initialViewport) return;
@@ -872,10 +869,11 @@ export function CompositeChart({
         zoomFactor,
         anchorRatio,
         minimumViewportSpanMs,
+        visibleSeries,
       );
       return sameCompositeViewport(next, initialViewport) ? null : next;
     });
-  }, [initialViewport, minimumViewportSpanMs, navigationBounds]);
+  }, [initialViewport, minimumViewportSpanMs, navigationBounds, visibleSeries]);
   const panViewport = useCallback((
     shiftRatio: number,
     fromViewport?: CompositeViewportRange,
@@ -883,10 +881,10 @@ export function CompositeChart({
     if (!navigationBounds || !initialViewport) return;
     setInteractionViewport((current) => {
       const base = fromViewport ?? current ?? initialViewport;
-      const next = panCompositeViewport(base, navigationBounds, shiftRatio);
+      const next = panCompositeViewport(base, navigationBounds, shiftRatio, visibleSeries);
       return sameCompositeViewport(next, initialViewport) ? null : next;
     });
-  }, [initialViewport, navigationBounds]);
+  }, [initialViewport, navigationBounds, visibleSeries]);
   const resetViewport = useCallback(() => {
     setInteractionViewport(null);
   }, []);
@@ -955,6 +953,30 @@ export function CompositeChart({
       )
       : null
   ), [baseScene, normalizedCursorTimestamp]);
+  const handleEmptyMouseScroll = useCallback((event: ChartMouseEvent) => {
+    const direction = event.scroll?.direction;
+    if (!interactive || !navigationBounds || !direction) return;
+    onActivate?.();
+    consumeChartMouseEvent(event);
+    if (event.modifiers.ctrl) {
+      const zoomIn = direction === "up" || direction === "left";
+      if (!zoomIn) {
+        resetViewport();
+        return;
+      }
+      const magnitude = Math.min(Math.max(Math.abs(event.scroll?.delta ?? 1), 1), 8);
+      zoomViewport(1 + magnitude * 0.04, 0.5);
+      return;
+    }
+    panViewport(resolveCompositeWheelPanRatio(direction, event.scroll?.delta));
+  }, [
+    interactive,
+    navigationBounds,
+    onActivate,
+    panViewport,
+    resetViewport,
+    zoomViewport,
+  ]);
   const keyboardCursorDateRef = useRef<Date | null>(scene?.cursorDate ?? null);
   keyboardCursorDateRef.current = scene?.cursorDate ?? null;
   const lastCursorTimestampRef = useRef<number | null>(normalizedCursorTimestamp);
@@ -1049,9 +1071,25 @@ export function CompositeChart({
     }
   }, { enabled: focused && interactive });
 
+  const leftPadding = leftAxisWidth + (leftAxisWidth ? axisGap : 0);
+  const rightPadding = rightAxisWidth + (rightAxisWidth ? axisGap : 0);
+  const timeAxisLayout = scene && showTimeAxis
+    ? buildCompositeTimeAxisLayout(scene, plotWidth)
+    : null;
+  const emptyTimeAxisLayout = !scene && showTimeAxis && effectiveViewport
+    ? buildCompositeViewportTimeAxisLayout(effectiveViewport, plotWidth)
+    : null;
+
   if (!scene) {
+    const emptyPlotHeight = Math.max(0, totalHeight - legendRows - timeAxisRows);
     return (
-      <Box flexDirection="column" width={totalWidth} height={totalHeight} overflow="hidden">
+      <Box
+        flexDirection="column"
+        width={totalWidth}
+        height={totalHeight}
+        overflow="hidden"
+        data-gloom-role="composite-chart"
+      >
         {legendRows > 0 && legendAccessory ? (
           <CompositeLegend
             scene={null}
@@ -1067,22 +1105,41 @@ export function CompositeChart({
             keyboardIndex={legendKeyboardIndex}
           />
         ) : null}
-        {totalHeight > legendRows ? (
-          <Box
-            width={totalWidth}
-            height={totalHeight - legendRows}
-            alignItems="center"
-            justifyContent="center"
-          >
-            <Text fg={resolvedColors.textDim}>{emptyMessage}</Text>
+        {emptyPlotHeight > 0 ? (
+          <Box flexDirection="row" width={totalWidth} height={emptyPlotHeight}>
+            {leftPadding > 0 ? <Box width={leftPadding} /> : null}
+            <ChartSurface
+              width={plotWidth}
+              height={emptyPlotHeight}
+              alignItems="center"
+              justifyContent="center"
+              onMouseScroll={interactive && navigationBounds ? handleEmptyMouseScroll : undefined}
+              cursor={interactive && navigationBounds ? "grab" : undefined}
+              data-gloom-interactive={interactive && navigationBounds ? "true" : undefined}
+              data-gloom-role="composite-chart-empty"
+              data-gloom-label={emptyMessage}
+            >
+              <Text fg={resolvedColors.textDim}>{emptyMessage}</Text>
+            </ChartSurface>
+            {rightPadding > 0 ? <Box width={rightPadding} /> : null}
+          </Box>
+        ) : null}
+        {emptyTimeAxisLayout ? (
+          <Box flexDirection="row" width={totalWidth} height={1}>
+            {leftPadding > 0 ? <Box width={leftPadding} /> : null}
+            <StaticXAxisLabels
+              labels={[emptyTimeAxisLayout.text]}
+              positionedLabels={emptyTimeAxisLayout.ticks}
+              width={plotWidth}
+              color={resolvedColors.textDim}
+            />
+            {rightPadding > 0 ? <Box width={rightPadding} /> : null}
           </Box>
         ) : null}
       </Box>
     );
   }
 
-  const leftPadding = leftAxisWidth + (leftAxisWidth ? axisGap : 0);
-  const rightPadding = rightAxisWidth + (rightAxisWidth ? axisGap : 0);
   const timeAxisCursorColumn = scene.cursorXRatio === null
     ? null
     : scene.cursorXRatio * Math.max(plotWidth - 1, 0);
@@ -1127,11 +1184,12 @@ export function CompositeChart({
           onZoomViewport={zoomViewport}
         />
       ))}
-      {showTimeAxis ? (
+      {timeAxisLayout ? (
         <Box flexDirection="row" width={totalWidth} height={1}>
           {leftPadding > 0 ? <Box width={leftPadding} /> : null}
           <StaticXAxisLabels
-            labels={[renderCompositeTimeAxis(scene, plotWidth)]}
+            labels={[timeAxisLayout.text]}
+            positionedLabels={timeAxisLayout.ticks}
             width={plotWidth}
             color={resolvedColors.textDim}
             cursorColumn={timeAxisCursorColumn}

--- a/src/components/chart/composite/format.test.ts
+++ b/src/components/chart/composite/format.test.ts
@@ -8,7 +8,10 @@ import {
   formatCompositeTimeAxisDate,
 } from "./format";
 import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
-import { renderCompositeTimeAxis } from "./text-renderer";
+import {
+  renderCompositeTimeAxis,
+  renderCompositeViewportTimeAxis,
+} from "./text-renderer";
 
 function scene(start: string, end: string): CompositeChartScene {
   const startTime = Date.parse(start);
@@ -38,7 +41,7 @@ describe("composite chart timestamp formatting", () => {
     expect(formatCompositeTimeAxisDate(cursor, intraday.startTime, intraday.endTime))
       .toBe("12:05 UTC");
     expect(renderCompositeTimeAxis(intraday, 60)).toContain("09:30 UTC");
-    expect(renderCompositeTimeAxis(intraday, 60)).toContain("12:45 UTC");
+    expect(renderCompositeTimeAxis(intraday, 60)).toContain("12:00");
     expect(renderCompositeTimeAxis(intraday, 60)).toContain("16:00 UTC");
   });
 
@@ -51,9 +54,9 @@ describe("composite chart timestamp formatting", () => {
       overnight.endTime,
     )).toBe("01-02 00:15 UTC");
     const axis = renderCompositeTimeAxis(overnight, 80);
-    expect(axis).toContain("01-01 23:30 UTC");
-    expect(axis).toContain("01-02 00:00 UTC");
-    expect(axis).toContain("01-02 00:30 UTC");
+    expect(axis).toContain("Jan 1 23:30 UTC");
+    expect(axis).toContain("Jan 2 00:00");
+    expect(axis).toContain("Jan 2 00:30 UTC");
   });
 
   test("keeps longer chart spans as concise UTC calendar dates", () => {
@@ -62,8 +65,18 @@ describe("composite chart timestamp formatting", () => {
 
     expect(formatCompositeCursorDate(cursor, weekly.startTime, weekly.endTime)).toBe("2025-01-04");
     expect(formatCompositeTimeAxisDate(cursor, weekly.startTime, weekly.endTime)).toBe("2025-01-04");
-    expect(renderCompositeTimeAxis(weekly, 60)).toContain("2025-01-01");
-    expect(renderCompositeTimeAxis(weekly, 60)).toContain("2025-01-08");
+    expect(renderCompositeTimeAxis(weekly, 60)).toContain("Jan 1");
+    expect(renderCompositeTimeAxis(weekly, 60)).toContain("Jan 8");
+  });
+
+  test("renders recovery-shell dates directly from a viewport", () => {
+    const axis = renderCompositeViewportTimeAxis({
+      start: new Date("2025-01-01T00:00:00.000Z"),
+      end: new Date("2025-01-08T00:00:00.000Z"),
+    }, 60);
+
+    expect(axis).toContain("Jan 1");
+    expect(axis).toContain("Jan 8");
   });
 });
 

--- a/src/components/chart/composite/interactions.test.ts
+++ b/src/components/chart/composite/interactions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
 import {
+  compositeViewportHasObservations,
   panCompositeViewport,
   resolveCompositeChartInteraction,
   resolveCompositeMinimumSpanMs,
@@ -65,16 +66,54 @@ describe("composite chart interactions", () => {
     expect(clampedNewer).toEqual(viewport(7, 11));
   });
 
-  test("uses the finest real observation step as the zoom floor", () => {
-    const data = series([1, 2, 5, 11]);
+  test("uses representative cadence instead of a stray fine gap as the zoom floor", () => {
+    const data = series([1, 2, 5, 8, 11]);
     const bounds = resolveCompositeNavigationBounds([data]);
     expect(bounds).toEqual(viewport(1, 11));
-    expect(resolveCompositeMinimumSpanMs([data], bounds!)).toBe(DAY_MS);
+    expect(resolveCompositeMinimumSpanMs([data], bounds!)).toBe(3 * DAY_MS);
   });
 
   test("keeps the selected window separate from wider loaded navigation bounds", () => {
     const data = series([1, 2, 3, 4, 5, 6, 7, 8, 9]);
     expect(resolveCompositeNavigationBounds([data], viewport(5, 9))).toEqual(viewport(1, 9));
+  });
+
+  test("clamps overlapping requested bounds to real data but preserves disjoint requests", () => {
+    const data = series([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+    expect(resolveCompositeNavigationBounds([data], viewport(5, 12))).toEqual(viewport(1, 9));
+    expect(resolveCompositeNavigationBounds([data], viewport(20, 30))).toEqual(viewport(20, 30));
+  });
+
+  test("requires distinct renderable observations inside a viewport", () => {
+    const data = series([1, 2, 3]);
+    const emptyPoint = point(4);
+    emptyPoint.value = null;
+    data.points.push(emptyPoint);
+
+    expect(compositeViewportHasObservations([data], viewport(1, 2))).toBe(true);
+    expect(compositeViewportHasObservations([data], viewport(2, 2))).toBe(false);
+    expect(compositeViewportHasObservations([data], viewport(3, 4))).toBe(false);
+  });
+
+  test("does not zoom or pan a populated viewport into fewer than two observations", () => {
+    const data = series([1, 5, 10, 11]);
+    const bounds = viewport(1, 11);
+    const populated = viewport(1, 5);
+
+    expect(zoomCompositeViewport(populated, bounds, 2, 0.5, 1, [data])).toEqual(populated);
+    expect(panCompositeViewport(populated, bounds, -1, [data])).toEqual(populated);
+    expect(panCompositeViewport(populated, bounds, -1.5, [data])).toEqual(viewport(7, 11));
+  });
+
+  test("allows zoom-out to recover when refreshed data has already emptied the viewport", () => {
+    const data = series([1, 2, 10, 11]);
+    const bounds = viewport(1, 11);
+    const empty = viewport(5, 6);
+    const expanded = zoomCompositeViewport(empty, bounds, 0.5, 0.5, 1, [data]);
+
+    expect(expanded.end.getTime() - expanded.start.getTime()).toBe(2 * DAY_MS);
+    expect(compositeViewportHasObservations([data], expanded)).toBe(false);
   });
 
   test("keeps live viewport drift but resets deliberate range/window changes", () => {

--- a/src/components/chart/composite/interactions.ts
+++ b/src/components/chart/composite/interactions.ts
@@ -44,10 +44,18 @@ function normalizeViewport(
   };
 }
 
+function hasRenderableValue(point: ResolvedSeries["points"][number]): boolean {
+  return (
+    (typeof point.value === "number" && Number.isFinite(point.value))
+    || (typeof point.close === "number" && Number.isFinite(point.close))
+  );
+}
+
 function pointTimestamps(series: ResolvedSeries[]): number[] {
   const timestamps = new Set<number>();
   for (const entry of series) {
     for (const point of entry.points) {
+      if (!hasRenderableValue(point)) continue;
       const timestamp = point.date instanceof Date
         ? point.date.getTime()
         : new Date(point.date).getTime();
@@ -55,6 +63,33 @@ function pointTimestamps(series: ResolvedSeries[]): number[] {
     }
   }
   return [...timestamps].sort((left, right) => left - right);
+}
+
+function viewportHasTimestamps(
+  timestamps: readonly number[],
+  viewport: CompositeViewportRange,
+  minimumCount: number,
+): boolean {
+  const start = finiteTime(viewport.start);
+  const end = finiteTime(viewport.end);
+  if (start === null || end === null || start > end) return false;
+  const required = Math.max(1, Math.floor(minimumCount));
+  let count = 0;
+  for (const timestamp of timestamps) {
+    if (timestamp < start) continue;
+    if (timestamp > end) break;
+    count += 1;
+    if (count >= required) return true;
+  }
+  return false;
+}
+
+export function compositeViewportHasObservations(
+  series: ResolvedSeries[],
+  viewport: CompositeViewportRange,
+  minimumCount = 2,
+): boolean {
+  return viewportHasTimestamps(pointTimestamps(series), viewport, minimumCount);
 }
 
 export function resolveCompositeNavigationBounds(
@@ -70,10 +105,12 @@ export function resolveCompositeNavigationBounds(
   });
   if (!requested) return data;
   if (!data) return requested;
-  return normalizeViewport({
-    start: new Date(Math.min(requested.start.getTime(), data.start.getTime())),
-    end: new Date(Math.max(requested.end.getTime(), data.end.getTime())),
-  });
+  const overlapsData = requested.end.getTime() >= data.start.getTime()
+    && requested.start.getTime() <= data.end.getTime();
+  // Loaded series can include a buffer outside the authored viewport. Use the
+  // complete real-data extent when the two ranges overlap, but do not clamp a
+  // newly authored, disjoint request to stale observations.
+  return overlapsData ? data : requested;
 }
 
 export function resolveCompositeMinimumSpanMs(
@@ -83,14 +120,18 @@ export function resolveCompositeMinimumSpanMs(
   const start = bounds.start.getTime();
   const end = bounds.end.getTime();
   const timestamps = pointTimestamps(series).filter((timestamp) => timestamp >= start && timestamp <= end);
-  let minimumStep = Number.POSITIVE_INFINITY;
+  const steps: number[] = [];
   for (let index = 1; index < timestamps.length; index += 1) {
     const step = timestamps[index]! - timestamps[index - 1]!;
-    if (step > 0) minimumStep = Math.min(minimumStep, step);
+    if (step > 0) steps.push(step);
   }
   const boundsSpan = Math.max(end - start, 1);
-  return Number.isFinite(minimumStep)
-    ? Math.min(Math.max(minimumStep, 1), boundsSpan)
+  steps.sort((left, right) => left - right);
+  // Use an observed upper median rather than the absolute minimum. This keeps
+  // one near-duplicate live observation from lowering a daily chart's floor.
+  const representativeStep = steps[Math.floor(steps.length / 2)];
+  return representativeStep !== undefined
+    ? Math.min(Math.max(representativeStep, 1), boundsSpan)
     : Math.max(Math.min(boundsSpan, FALLBACK_SINGLE_POINT_SPAN_MS), 1);
 }
 
@@ -136,6 +177,7 @@ export function zoomCompositeViewport(
   zoomFactor: number,
   anchorRatio: number,
   minimumSpanMs: number,
+  series?: ResolvedSeries[],
 ): CompositeViewportRange {
   const current = clampCompositeViewport(viewport, bounds);
   if (!Number.isFinite(zoomFactor) || zoomFactor <= 0) return current;
@@ -151,10 +193,24 @@ export function zoomCompositeViewport(
   );
   const ratio = clamp(anchorRatio, 0, 1);
   const anchor = start + currentSpan * ratio;
-  return clampCompositeViewport({
+  const candidate = clampCompositeViewport({
     start: new Date(anchor - nextSpan * ratio),
     end: new Date(anchor + nextSpan * (1 - ratio)),
   }, bounds);
+  if (!series) return candidate;
+
+  const timestamps = pointTimestamps(series)
+    .filter((timestamp) => timestamp >= bounds.start.getTime() && timestamp <= bounds.end.getTime());
+  if (timestamps.length < 2 || viewportHasTimestamps(timestamps, candidate, 2)) {
+    return candidate;
+  }
+
+  const currentHasObservations = viewportHasTimestamps(timestamps, current, 2);
+  const candidateSpan = candidate.end.getTime() - candidate.start.getTime();
+  // An adaptive response can invalidate an existing viewport. Let zoom-out
+  // keep expanding from that state until observations re-enter the window.
+  if (!currentHasObservations && candidateSpan > currentSpan) return candidate;
+  return current;
 }
 
 /**
@@ -165,15 +221,23 @@ export function panCompositeViewport(
   viewport: CompositeViewportRange,
   bounds: CompositeViewportRange,
   shiftRatio: number,
+  series?: ResolvedSeries[],
 ): CompositeViewportRange {
   const current = clampCompositeViewport(viewport, bounds);
   if (!Number.isFinite(shiftRatio) || shiftRatio === 0) return current;
   const span = Math.max(current.end.getTime() - current.start.getTime(), 1);
   const shift = span * shiftRatio;
-  return clampCompositeViewport({
+  const candidate = clampCompositeViewport({
     start: new Date(current.start.getTime() - shift),
     end: new Date(current.end.getTime() - shift),
   }, bounds);
+  if (!series) return candidate;
+
+  const timestamps = pointTimestamps(series)
+    .filter((timestamp) => timestamp >= bounds.start.getTime() && timestamp <= bounds.end.getTime());
+  return timestamps.length < 2 || viewportHasTimestamps(timestamps, candidate, 2)
+    ? candidate
+    : current;
 }
 
 export function resolveCompositeWheelPanRatio(

--- a/src/components/chart/composite/rasterizer.ts
+++ b/src/components/chart/composite/rasterizer.ts
@@ -97,10 +97,6 @@ function median(values: number[]): number | null {
     : sorted[middle]!;
 }
 
-function observationGaps(points: CompositeProjectedPoint[], pixelWidth: number): number[] {
-  return ratioGaps(points.map((point) => point.xRatio), pixelWidth);
-}
-
 function ratioGaps(ratios: readonly number[], pixelWidth: number): number[] {
   const xs = ratios.map((ratio) => ratio * Math.max(pixelWidth - 1, 0)).sort((left, right) => left - right);
   const positiveGaps: number[] = [];
@@ -111,9 +107,14 @@ function ratioGaps(ratios: readonly number[], pixelWidth: number): number[] {
   return positiveGaps;
 }
 
-function observationWidth(points: CompositeProjectedPoint[], pixelWidth: number, maximum: number): number {
-  const minimumGap = Math.min(...observationGaps(points, pixelWidth));
-  return clamp(Number.isFinite(minimumGap) ? minimumGap * 0.58 : maximum, 2, maximum);
+export function resolveCompositeObservationWidth(
+  points: CompositeProjectedPoint[],
+  extent: number,
+  minimum: number,
+  maximum: number,
+): number {
+  const typicalGap = median(ratioGaps(points.map((point) => point.xRatio), extent));
+  return clamp(typicalGap === null ? maximum : typicalGap * 0.58, minimum, maximum);
 }
 
 function columnObservationWidth(
@@ -171,7 +172,8 @@ export function resolveCompositeOhlcWidth(
   points: CompositeProjectedPoint[],
   pixelWidth: number,
 ): number {
-  return observationWidth(points, pixelWidth, 9);
+  const maximum = clamp(pixelWidth * 0.03, 12, 36);
+  return resolveCompositeObservationWidth(points, pixelWidth, 2, maximum);
 }
 
 function columnPixelGeometry(

--- a/src/components/chart/composite/renderers.test.ts
+++ b/src/components/chart/composite/renderers.test.ts
@@ -7,7 +7,10 @@ import {
 } from "./rasterizer";
 import { buildCompositeColumnLayout } from "./column-layout";
 import { buildCompositeChartScene } from "./scene";
-import { renderCompositePanelText } from "./text-renderer";
+import {
+  renderCompositePanelText,
+  resolveCompositeTextOhlcWidth,
+} from "./text-renderer";
 
 function point(date: string, value: number): TimeSeriesPoint {
   const observedAt = new Date(`${date}T00:00:00.000Z`);
@@ -569,7 +572,51 @@ describe("composite chart renderers", () => {
     expect(resolveCompositeOhlcWidth(
       scene.panels[0]!.series[0]!.points,
       2_000,
-    )).toBeLessThan(4);
+    )).toBe(36);
+  });
+
+  test("widens candle bodies as the visible observation spacing grows", () => {
+    const candles = series("price", "candles", [], "left");
+    candles.points = Array.from({ length: 100 }, (_, index) => {
+      const observedAt = new Date(Date.UTC(2025, 0, index + 1));
+      return {
+        date: observedAt,
+        observedAt,
+        value: 10,
+        open: 8,
+        high: 11,
+        low: 7,
+        close: 10,
+      };
+    });
+    const fullScene = buildCompositeChartScene(
+      [candles],
+      [{ id: "main" }],
+      { width: 81, height: 9 },
+    )!;
+    const zoomedScene = buildCompositeChartScene(
+      [candles],
+      [{ id: "main" }],
+      {
+        width: 81,
+        height: 9,
+        viewport: {
+          start: new Date(Date.UTC(2025, 0, 98)),
+          end: new Date(Date.UTC(2025, 0, 100)),
+        },
+      },
+    )!;
+    const fullPoints = fullScene.panels[0]!.series[0]!.points;
+    const zoomedPoints = zoomedScene.panels[0]!.series[0]!.points;
+
+    expect(resolveCompositeOhlcWidth(fullPoints, 800)).toBeLessThan(
+      resolveCompositeOhlcWidth(zoomedPoints, 800),
+    );
+    expect(resolveCompositeTextOhlcWidth(fullPoints, 81)).toBe(1);
+    expect(resolveCompositeTextOhlcWidth(zoomedPoints, 81)).toBe(5);
+
+    const zoomedText = renderCompositePanelText(zoomedScene.panels[0]!, 81, null, null).join("\n");
+    expect(zoomedText).toContain("█████");
   });
 
   test("marks a standalone line observation without extending it through time", () => {

--- a/src/components/chart/composite/text-renderer.ts
+++ b/src/components/chart/composite/text-renderer.ts
@@ -1,7 +1,12 @@
-import { compositeAxisTicks, formatCompositeTimeAxisDate } from "./format";
-import { resolveCompositeTimeAxisDate } from "./scene";
+import { compositeAxisTicks } from "./format";
+import type { CompositeViewportRange } from "./interactions";
+import { resolveCompositeObservationWidth } from "./rasterizer";
 import { buildCompositeColumnLayout, type CompositeColumnLayout } from "./column-layout";
 import { projectCompositeValue } from "./scene";
+import {
+  buildCompositeTimeAxisLayout,
+  buildCompositeViewportTimeAxisLayout,
+} from "./time-axis";
 import type {
   CompositeAxisDomain,
   CompositeChartScene,
@@ -159,6 +164,8 @@ function renderOhlc(
   width: number,
   height: number,
 ): void {
+  const candleWidth = resolveCompositeTextOhlcWidth(series.points, width);
+  const halfCandleWidth = Math.floor(candleWidth / 2);
   for (const projected of series.points) {
     const source = projected.point;
     const x = cellPoint(projected, width, height).x;
@@ -173,12 +180,31 @@ function renderOhlc(
     if (closeRow === null || highRow === null || lowRow === null) continue;
     drawLine(rows, x, highRow, x, lowRow, "│");
     if (series.source.style === "candles" && openRow !== null) {
-      drawLine(rows, x, openRow, x, closeRow, "█");
+      for (let row = Math.min(openRow, closeRow); row <= Math.max(openRow, closeRow); row += 1) {
+        for (let offset = -halfCandleWidth; offset <= halfCandleWidth; offset += 1) {
+          setCell(rows, x + offset, row, "█");
+        }
+      }
       continue;
     }
-    if (series.source.style === "ohlc" && openRow !== null) setCell(rows, Math.max(0, x - 1), openRow, "─");
-    setCell(rows, Math.min(width - 1, x + 1), closeRow, "─");
+    const tickWidth = Math.max(1, halfCandleWidth);
+    if (series.source.style === "ohlc" && openRow !== null) {
+      drawLine(rows, Math.max(0, x - tickWidth), openRow, x, openRow, "─");
+    }
+    drawLine(rows, x, closeRow, Math.min(width - 1, x + tickWidth), closeRow, "─");
   }
+}
+
+export function resolveCompositeTextOhlcWidth(
+  points: CompositeProjectedPoint[],
+  width: number,
+): number {
+  const maximum = clamp(Math.floor(width / 16), 3, 7);
+  const resolved = Math.max(
+    1,
+    Math.floor(resolveCompositeObservationWidth(points, width, 1, maximum)),
+  );
+  return resolved % 2 === 0 ? Math.max(1, resolved - 1) : resolved;
 }
 
 export function renderCompositePanelText(
@@ -259,27 +285,13 @@ export function renderCompositeAxisText(
   return rows;
 }
 
-function placeLabel(chars: string[], label: string, center: number): void {
-  const start = clamp(Math.round(center - label.length / 2), 0, Math.max(chars.length - label.length, 0));
-  for (let index = 0; index < label.length && start + index < chars.length; index += 1) {
-    chars[start + index] = label[index]!;
-  }
+export function renderCompositeViewportTimeAxis(
+  viewport: CompositeViewportRange,
+  width: number,
+): string {
+  return buildCompositeViewportTimeAxisLayout(viewport, width).text;
 }
 
 export function renderCompositeTimeAxis(scene: CompositeChartScene, width: number): string {
-  const chars = Array(Math.max(1, width)).fill(" ");
-  const formatDate = (ratio: number) => formatCompositeTimeAxisDate(
-    resolveCompositeTimeAxisDate(scene, ratio),
-    scene.startTime,
-    scene.endTime,
-  );
-  const startLabel = formatDate(0);
-  const midpointLabel = formatDate(0.5);
-  const endLabel = formatDate(1);
-  placeLabel(chars, startLabel, 0);
-  if (chars.length >= startLabel.length + midpointLabel.length + endLabel.length + 4) {
-    placeLabel(chars, midpointLabel, (chars.length - 1) / 2);
-  }
-  placeLabel(chars, endLabel, chars.length - 1);
-  return chars.join("");
+  return buildCompositeTimeAxisLayout(scene, width).text;
 }

--- a/src/components/chart/composite/time-axis.test.ts
+++ b/src/components/chart/composite/time-axis.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test } from "bun:test";
+import type { CompositeChartScene } from "./types";
+import {
+  buildCompositeTimeAxisLayout,
+  buildCompositeViewportTimeAxisLayout,
+  type CompositeTimeAxisLayout,
+} from "./time-axis";
+
+function viewport(start: string, end: string, width: number): CompositeTimeAxisLayout {
+  return buildCompositeViewportTimeAxisLayout({
+    start: new Date(start),
+    end: new Date(end),
+  }, width);
+}
+
+function expectValidLayout(layout: CompositeTimeAxisLayout, width: number): void {
+  expect(layout.text).toHaveLength(width);
+  layout.ticks.forEach((tick, index) => {
+    expect(tick.start).toBeGreaterThanOrEqual(0);
+    expect(tick.end).toBeLessThan(width);
+    expect(tick.end).toBeGreaterThanOrEqual(tick.start);
+    expect(layout.text.slice(tick.start, tick.end + 1)).toBe(tick.label);
+    if (index > 0) {
+      expect(tick.start).toBeGreaterThan(layout.ticks[index - 1]!.end);
+    }
+  });
+}
+
+function marketScene(
+  dates: string[],
+  dateRatios: number[],
+): CompositeChartScene {
+  const timestamps = dates.map((date) => Date.parse(date));
+  const startTime = timestamps[0]!;
+  const endTime = timestamps.at(-1)!;
+  return {
+    width: 80,
+    height: 10,
+    startTime,
+    endTime,
+    timeScale: {
+      kind: "market",
+      startTime,
+      endTime,
+      anchorSeriesId: "price",
+      cadenceMs: 24 * 60 * 60 * 1_000,
+      anchors: timestamps.map((timestamp, index) => ({
+        timestamp,
+        position: index,
+      })),
+      startPosition: 0,
+      endPosition: Math.max(timestamps.length - 1, 1),
+    },
+    dates: timestamps.map((timestamp) => new Date(timestamp)),
+    dateRatios,
+    panels: [],
+    cursorDate: null,
+    cursorXRatio: null,
+    cursorValues: [],
+  };
+}
+
+describe("adaptive composite time axis", () => {
+  test("increases intraday density with width while keeping concise UTC clock labels", () => {
+    const narrow = viewport(
+      "2026-07-29T09:30:00.000Z",
+      "2026-07-29T16:00:00.000Z",
+      40,
+    );
+    const medium = viewport(
+      "2026-07-29T09:30:00.000Z",
+      "2026-07-29T16:00:00.000Z",
+      80,
+    );
+    const wide = viewport(
+      "2026-07-29T09:30:00.000Z",
+      "2026-07-29T16:00:00.000Z",
+      165,
+    );
+
+    expect(narrow.text).toContain("09:30 UTC");
+    expect(narrow.text).toContain("16:00 UTC");
+    expect(narrow.text).not.toContain("2026-07-29");
+    expect(medium.ticks.length).toBeGreaterThan(narrow.ticks.length);
+    expect(wide.ticks.length).toBeGreaterThan(medium.ticks.length);
+    expectValidLayout(narrow, 40);
+    expectValidLayout(medium, 80);
+    expectValidLayout(wide, 165);
+  });
+
+  test("uses day, month, and year context appropriate to the visible span", () => {
+    const month = viewport(
+      "2026-06-29T00:00:00.000Z",
+      "2026-07-29T00:00:00.000Z",
+      80,
+    );
+    const year = viewport(
+      "2025-07-29T00:00:00.000Z",
+      "2026-07-29T00:00:00.000Z",
+      80,
+    );
+    const multiyear = viewport(
+      "2021-07-29T00:00:00.000Z",
+      "2026-07-29T00:00:00.000Z",
+      40,
+    );
+
+    expect(month.text).toContain("Jun 29");
+    expect(month.text).toContain("Jul 29");
+    expect(month.text).not.toContain("2026-06-29");
+    expect(month.ticks.length).toBeGreaterThan(3);
+    expect(year.text).toContain("Jul 29 2025");
+    expect(year.text).toContain("Jan 2026");
+    expect(year.text).toContain("Jul 29 2026");
+    expect(year.ticks.length).toBeGreaterThan(3);
+    expect(multiyear.text).toContain("2021");
+    expect(multiyear.text).toContain("2026");
+    expect(multiyear.text).not.toContain("Jul 29");
+    expectValidLayout(month, 80);
+    expectValidLayout(year, 80);
+    expectValidLayout(multiyear, 40);
+  });
+
+  test("gives a wide NBIS-length chart useful bimonthly density", () => {
+    const narrow = viewport(
+      "2024-10-21T00:00:00.000Z",
+      "2026-07-29T00:00:00.000Z",
+      40,
+    );
+    const wide = viewport(
+      "2024-10-21T00:00:00.000Z",
+      "2026-07-29T00:00:00.000Z",
+      165,
+    );
+
+    expect(narrow.ticks.length).toBeGreaterThanOrEqual(2);
+    expect(wide.ticks.length).toBeGreaterThanOrEqual(8);
+    expect(wide.ticks.length).toBeGreaterThan(narrow.ticks.length);
+    expect(wide.text).toContain("Oct 21 2024");
+    expect(wide.text).toContain("Jan 2025");
+    expect(wide.text).toContain("Jan 2026");
+    expect(wide.text).toContain("Jul 29 2026");
+    expectValidLayout(narrow, 40);
+    expectValidLayout(wide, 165);
+  });
+
+  test("keeps very narrow layouts in bounds without overlapping labels", () => {
+    for (const width of [18, 24]) {
+      const layout = viewport(
+        "2024-10-21T00:00:00.000Z",
+        "2026-07-29T00:00:00.000Z",
+        width,
+      );
+      expect(layout.ticks.length).toBeGreaterThanOrEqual(2);
+      expectValidLayout(layout, width);
+    }
+  });
+
+  test("snaps calendar boundaries to supplied market ratios instead of inventing weekend ticks", () => {
+    const scene = marketScene([
+      "2025-01-03T00:00:00.000Z",
+      "2025-01-06T00:00:00.000Z",
+      "2025-01-07T00:00:00.000Z",
+    ], [0, 0.25, 1]);
+    const layout = buildCompositeTimeAxisLayout(scene, 80);
+    const monday = layout.ticks.find((tick) => (
+      tick.timestamp === Date.parse("2025-01-06T00:00:00.000Z")
+    ));
+
+    expect(monday?.ratio).toBe(0.25);
+    expect(monday?.start).toBeLessThan(30);
+    expect(layout.ticks.some((tick) => tick.label.includes("4"))).toBe(false);
+    expect(layout.ticks.some((tick) => tick.label.includes("5"))).toBe(false);
+    expectValidLayout(layout, 80);
+  });
+
+  test("keeps the final month tick and an exact viewport endpoint distinct", () => {
+    const layout = viewport(
+      "2025-11-03T00:00:00.000Z",
+      "2026-07-29T00:00:00.000Z",
+      217,
+    );
+    const july = layout.ticks.find((tick) => (
+      tick.timestamp === Date.parse("2026-07-01T00:00:00.000Z")
+    ));
+    const endpoint = layout.ticks.at(-1);
+
+    expect(july?.label).toBe("Jul");
+    expect(july?.ratio).toBeCloseTo(240 / 268);
+    expect(endpoint).toMatchObject({
+      timestamp: Date.parse("2026-07-29T00:00:00.000Z"),
+      ratio: 1,
+      label: "Jul 29 2026",
+    });
+    expectValidLayout(layout, 217);
+  });
+
+  test("keeps viewport edges distinct from market observations between those edges", () => {
+    const scene = marketScene([
+      "2025-01-03T10:00:00.000Z",
+      "2025-01-03T16:00:00.000Z",
+    ], [0.25, 0.9]);
+    scene.startTime = Date.parse("2025-01-03T09:30:00.000Z");
+    scene.endTime = Date.parse("2025-01-03T16:30:00.000Z");
+    const layout = buildCompositeTimeAxisLayout(scene, 80);
+    const tenOClock = layout.ticks.find((tick) => (
+      tick.timestamp === Date.parse("2025-01-03T10:00:00.000Z")
+    ));
+
+    expect(layout.ticks[0]?.timestamp).toBe(scene.startTime);
+    expect(layout.ticks[0]?.ratio).toBe(0);
+    expect(tenOClock?.ratio).toBe(0.25);
+    expect(layout.ticks.at(-1)?.timestamp).toBe(scene.endTime);
+    expect(layout.ticks.at(-1)?.ratio).toBe(1);
+    expectValidLayout(layout, 80);
+  });
+
+  test("compacts cross-year endpoints before dropping either side", () => {
+    const layout = viewport(
+      "2025-12-31T23:30:00.000Z",
+      "2026-01-01T00:30:00.000Z",
+      30,
+    );
+
+    expect(layout.text).toContain("Dec 31 23:30");
+    expect(layout.text).toContain("Jan 1 00:30");
+    expect(layout.ticks).toHaveLength(2);
+    expectValidLayout(layout, 30);
+  });
+
+  test("keeps fixed UTC progression across a local daylight-saving transition", () => {
+    const layout = viewport(
+      "2025-03-30T00:30:00.000Z",
+      "2025-03-30T04:30:00.000Z",
+      165,
+    );
+
+    expect(layout.text).toContain("01:00");
+    expect(layout.text).toContain("02:00");
+    expect(layout.text).toContain("03:00");
+    expectValidLayout(layout, 165);
+  });
+});

--- a/src/components/chart/composite/time-axis.ts
+++ b/src/components/chart/composite/time-axis.ts
@@ -1,0 +1,608 @@
+import type { CompositeViewportRange } from "./interactions";
+import type { CompositeChartScene } from "./types";
+
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+
+const SECOND_MS = 1_000;
+const MINUTE_MS = 60 * SECOND_MS;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+const MONTH_MS = 30.4375 * DAY_MS;
+const YEAR_MS = 365.25 * DAY_MS;
+const MONDAY_ANCHOR_MS = Date.UTC(1970, 0, 5);
+
+type CompositeTimeAxisUnit =
+  | "millisecond"
+  | "second"
+  | "minute"
+  | "hour"
+  | "day"
+  | "week"
+  | "month"
+  | "year";
+
+interface CompositeTimeAxisInterval {
+  unit: CompositeTimeAxisUnit;
+  step: number;
+  approximateMs: number;
+}
+
+interface CompositeTimeAxisSample {
+  timestamp: number;
+  ratio: number;
+}
+
+interface CompositeTimeAxisCandidate extends CompositeTimeAxisSample {
+  boundary: boolean;
+}
+
+export interface CompositeTimeAxisTick extends CompositeTimeAxisSample {
+  label: string;
+  start: number;
+  end: number;
+}
+
+export interface CompositeTimeAxisLayout {
+  text: string;
+  ticks: CompositeTimeAxisTick[];
+}
+
+const TIME_AXIS_INTERVALS: readonly CompositeTimeAxisInterval[] = [
+  { unit: "millisecond", step: 1, approximateMs: 1 },
+  { unit: "millisecond", step: 5, approximateMs: 5 },
+  { unit: "millisecond", step: 10, approximateMs: 10 },
+  { unit: "millisecond", step: 50, approximateMs: 50 },
+  { unit: "millisecond", step: 100, approximateMs: 100 },
+  { unit: "millisecond", step: 250, approximateMs: 250 },
+  { unit: "millisecond", step: 500, approximateMs: 500 },
+  { unit: "second", step: 1, approximateMs: SECOND_MS },
+  { unit: "second", step: 5, approximateMs: 5 * SECOND_MS },
+  { unit: "second", step: 15, approximateMs: 15 * SECOND_MS },
+  { unit: "second", step: 30, approximateMs: 30 * SECOND_MS },
+  { unit: "minute", step: 1, approximateMs: MINUTE_MS },
+  { unit: "minute", step: 5, approximateMs: 5 * MINUTE_MS },
+  { unit: "minute", step: 15, approximateMs: 15 * MINUTE_MS },
+  { unit: "minute", step: 30, approximateMs: 30 * MINUTE_MS },
+  { unit: "hour", step: 1, approximateMs: HOUR_MS },
+  { unit: "hour", step: 2, approximateMs: 2 * HOUR_MS },
+  { unit: "hour", step: 4, approximateMs: 4 * HOUR_MS },
+  { unit: "hour", step: 6, approximateMs: 6 * HOUR_MS },
+  { unit: "hour", step: 12, approximateMs: 12 * HOUR_MS },
+  { unit: "day", step: 1, approximateMs: DAY_MS },
+  { unit: "day", step: 2, approximateMs: 2 * DAY_MS },
+  { unit: "week", step: 1, approximateMs: WEEK_MS },
+  { unit: "week", step: 2, approximateMs: 2 * WEEK_MS },
+  { unit: "month", step: 1, approximateMs: MONTH_MS },
+  { unit: "month", step: 2, approximateMs: 2 * MONTH_MS },
+  { unit: "month", step: 3, approximateMs: 3 * MONTH_MS },
+  { unit: "month", step: 6, approximateMs: 6 * MONTH_MS },
+  { unit: "year", step: 1, approximateMs: YEAR_MS },
+  { unit: "year", step: 2, approximateMs: 2 * YEAR_MS },
+  { unit: "year", step: 5, approximateMs: 5 * YEAR_MS },
+  { unit: "year", step: 10, approximateMs: 10 * YEAR_MS },
+  { unit: "year", step: 20, approximateMs: 20 * YEAR_MS },
+  { unit: "year", step: 50, approximateMs: 50 * YEAR_MS },
+] as const;
+
+const clamp = (value: number, min: number, max: number) => (
+  Math.max(min, Math.min(max, value))
+);
+
+function validTimestamp(value: number): boolean {
+  return Number.isFinite(value);
+}
+
+function axisLabelWidth(interval: CompositeTimeAxisInterval, startTime: number, endTime: number): number {
+  const start = new Date(startTime);
+  const end = new Date(endTime);
+  const spansDays = start.getUTCFullYear() !== end.getUTCFullYear()
+    || start.getUTCMonth() !== end.getUTCMonth()
+    || start.getUTCDate() !== end.getUTCDate();
+  const spansYears = start.getUTCFullYear() !== end.getUTCFullYear();
+
+  switch (interval.unit) {
+    case "millisecond":
+      return spansDays ? 20 : 12;
+    case "second":
+      return spansDays ? 16 : 8;
+    case "minute":
+    case "hour":
+      return spansDays ? 13 : 5;
+    case "day":
+    case "week":
+      return spansYears ? 11 : 6;
+    case "month":
+      return 8;
+    case "year":
+      return 4;
+  }
+}
+
+function resolveTimeAxisInterval(
+  startTime: number,
+  endTime: number,
+  width: number,
+): CompositeTimeAxisInterval {
+  const span = Math.max(endTime - startTime, 1);
+  for (const interval of TIME_AXIS_INTERVALS) {
+    const labelWidth = axisLabelWidth(interval, startTime, endTime);
+    const maximumLabels = Math.max(2, Math.floor(width / (labelWidth + 2)));
+    const estimatedLabels = Math.floor(span / interval.approximateMs) + 1;
+    if (estimatedLabels <= maximumLabels) return interval;
+  }
+  return TIME_AXIS_INTERVALS.at(-1)!;
+}
+
+function nextFixedBoundary(
+  startTime: number,
+  intervalMs: number,
+  anchorTime = 0,
+): number {
+  const steps = Math.floor((startTime - anchorTime) / intervalMs) + 1;
+  return anchorTime + steps * intervalMs;
+}
+
+function nextMonthBoundary(startTime: number, step: number): number {
+  const start = new Date(startTime);
+  const monthIndex = start.getUTCFullYear() * 12 + start.getUTCMonth();
+  let alignedIndex = Math.floor(monthIndex / step) * step;
+  let boundary = Date.UTC(
+    Math.floor(alignedIndex / 12),
+    alignedIndex % 12,
+    1,
+  );
+  if (boundary <= startTime) {
+    alignedIndex += step;
+    boundary = Date.UTC(
+      Math.floor(alignedIndex / 12),
+      alignedIndex % 12,
+      1,
+    );
+  }
+  return boundary;
+}
+
+function nextYearBoundary(startTime: number, step: number): number {
+  const startYear = new Date(startTime).getUTCFullYear();
+  let year = Math.floor(startYear / step) * step;
+  let boundary = Date.UTC(year, 0, 1);
+  if (boundary <= startTime) {
+    year += step;
+    boundary = Date.UTC(year, 0, 1);
+  }
+  return boundary;
+}
+
+function calendarBoundaries(
+  startTime: number,
+  endTime: number,
+  interval: CompositeTimeAxisInterval,
+): number[] {
+  let boundary: number;
+  let advance: (timestamp: number) => number;
+
+  switch (interval.unit) {
+    case "millisecond":
+      boundary = nextFixedBoundary(startTime, interval.step);
+      advance = (timestamp) => timestamp + interval.step;
+      break;
+    case "second":
+      boundary = nextFixedBoundary(startTime, interval.step * SECOND_MS);
+      advance = (timestamp) => timestamp + interval.step * SECOND_MS;
+      break;
+    case "minute":
+      boundary = nextFixedBoundary(startTime, interval.step * MINUTE_MS);
+      advance = (timestamp) => timestamp + interval.step * MINUTE_MS;
+      break;
+    case "hour":
+      boundary = nextFixedBoundary(startTime, interval.step * HOUR_MS);
+      advance = (timestamp) => timestamp + interval.step * HOUR_MS;
+      break;
+    case "day":
+      boundary = nextFixedBoundary(startTime, interval.step * DAY_MS);
+      advance = (timestamp) => timestamp + interval.step * DAY_MS;
+      break;
+    case "week":
+      boundary = nextFixedBoundary(
+        startTime,
+        interval.step * WEEK_MS,
+        MONDAY_ANCHOR_MS,
+      );
+      advance = (timestamp) => timestamp + interval.step * WEEK_MS;
+      break;
+    case "month":
+      boundary = nextMonthBoundary(startTime, interval.step);
+      advance = (timestamp) => {
+        const date = new Date(timestamp);
+        return Date.UTC(
+          date.getUTCFullYear(),
+          date.getUTCMonth() + interval.step,
+          1,
+        );
+      };
+      break;
+    case "year":
+      boundary = nextYearBoundary(startTime, interval.step);
+      advance = (timestamp) => (
+        Date.UTC(new Date(timestamp).getUTCFullYear() + interval.step, 0, 1)
+      );
+      break;
+  }
+
+  const boundaries: number[] = [];
+  while (boundary < endTime && boundaries.length < 1_000) {
+    boundaries.push(boundary);
+    const next = advance(boundary);
+    if (!validTimestamp(next) || next <= boundary) break;
+    boundary = next;
+  }
+  return boundaries;
+}
+
+function intervalBucketKey(
+  timestamp: number,
+  interval: CompositeTimeAxisInterval,
+): number {
+  switch (interval.unit) {
+    case "millisecond":
+      return Math.floor(timestamp / interval.step);
+    case "second":
+      return Math.floor(timestamp / (interval.step * SECOND_MS));
+    case "minute":
+      return Math.floor(timestamp / (interval.step * MINUTE_MS));
+    case "hour":
+      return Math.floor(timestamp / (interval.step * HOUR_MS));
+    case "day":
+      return Math.floor(timestamp / (interval.step * DAY_MS));
+    case "week":
+      return Math.floor((timestamp - MONDAY_ANCHOR_MS) / (interval.step * WEEK_MS));
+    case "month": {
+      const date = new Date(timestamp);
+      const monthIndex = date.getUTCFullYear() * 12 + date.getUTCMonth();
+      return Math.floor(monthIndex / interval.step);
+    }
+    case "year":
+      return Math.floor(new Date(timestamp).getUTCFullYear() / interval.step);
+  }
+}
+
+function lowerBoundSample(samples: readonly CompositeTimeAxisSample[], timestamp: number): number {
+  let low = 0;
+  let high = samples.length;
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2);
+    if (samples[middle]!.timestamp < timestamp) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+function normalizeMarketSamples(scene: CompositeChartScene): CompositeTimeAxisSample[] {
+  const samples = scene.dates.flatMap((date, index) => {
+    const timestamp = date.getTime();
+    const ratio = scene.dateRatios[index];
+    return validTimestamp(timestamp) && typeof ratio === "number" && Number.isFinite(ratio)
+      ? [{ timestamp, ratio: clamp(ratio, 0, 1) }]
+      : [];
+  }).sort((left, right) => left.timestamp - right.timestamp || left.ratio - right.ratio);
+
+  return samples.filter((sample, index) => (
+    index === 0
+    || sample.timestamp !== samples[index - 1]!.timestamp
+    || sample.ratio !== samples[index - 1]!.ratio
+  ));
+}
+
+function sameUtcDay(left: number, right: number): boolean {
+  const leftDate = new Date(left);
+  const rightDate = new Date(right);
+  return leftDate.getUTCFullYear() === rightDate.getUTCFullYear()
+    && leftDate.getUTCMonth() === rightDate.getUTCMonth()
+    && leftDate.getUTCDate() === rightDate.getUTCDate();
+}
+
+function sameUtcMonth(left: number, right: number): boolean {
+  const leftDate = new Date(left);
+  const rightDate = new Date(right);
+  return leftDate.getUTCFullYear() === rightDate.getUTCFullYear()
+    && leftDate.getUTCMonth() === rightDate.getUTCMonth();
+}
+
+function clockLabel(timestamp: number, unit: CompositeTimeAxisUnit): string {
+  const date = new Date(timestamp);
+  const hours = String(date.getUTCHours()).padStart(2, "0");
+  const minutes = String(date.getUTCMinutes()).padStart(2, "0");
+  const seconds = String(date.getUTCSeconds()).padStart(2, "0");
+  const milliseconds = String(date.getUTCMilliseconds()).padStart(3, "0");
+  if (unit === "millisecond") return `${hours}:${minutes}:${seconds}.${milliseconds}`;
+  if (unit === "second") return `${hours}:${minutes}:${seconds}`;
+  return `${hours}:${minutes}`;
+}
+
+function calendarLabel(timestamp: number, includeYear: boolean): string {
+  const date = new Date(timestamp);
+  const base = `${MONTHS[date.getUTCMonth()]} ${date.getUTCDate()}`;
+  return includeYear ? `${base} ${date.getUTCFullYear()}` : base;
+}
+
+function formatBoundaryLabel(
+  timestamp: number,
+  counterpart: number,
+  interval: CompositeTimeAxisInterval,
+  includeTimeZone = true,
+  includeBoundaryYear = true,
+): string {
+  const date = new Date(timestamp);
+  switch (interval.unit) {
+    case "millisecond":
+    case "second":
+    case "minute":
+    case "hour": {
+      const clock = clockLabel(timestamp, interval.unit);
+      const suffix = includeTimeZone ? " UTC" : "";
+      if (sameUtcDay(timestamp, counterpart)) return `${clock}${suffix}`;
+      const includeYear = includeBoundaryYear
+        && date.getUTCFullYear() !== new Date(counterpart).getUTCFullYear();
+      return `${calendarLabel(timestamp, includeYear)} ${clock}${suffix}`;
+    }
+    case "day":
+    case "week":
+      return calendarLabel(
+        timestamp,
+        includeBoundaryYear
+          && date.getUTCFullYear() !== new Date(counterpart).getUTCFullYear(),
+      );
+    case "month":
+      return calendarLabel(timestamp, includeBoundaryYear);
+    case "year":
+      return `${date.getUTCFullYear()}`;
+  }
+}
+
+function formatInteriorLabel(
+  timestamp: number,
+  previousTimestamp: number,
+  interval: CompositeTimeAxisInterval,
+): string {
+  const date = new Date(timestamp);
+  const previous = new Date(previousTimestamp);
+  switch (interval.unit) {
+    case "millisecond":
+    case "second":
+    case "minute":
+    case "hour": {
+      const clock = clockLabel(timestamp, interval.unit);
+      if (sameUtcDay(timestamp, previousTimestamp)) return clock;
+      return `${calendarLabel(
+        timestamp,
+        date.getUTCFullYear() !== previous.getUTCFullYear(),
+      )} ${clock}`;
+    }
+    case "day":
+    case "week":
+      if (sameUtcMonth(timestamp, previousTimestamp)) return `${date.getUTCDate()}`;
+      return calendarLabel(
+        timestamp,
+        date.getUTCFullYear() !== previous.getUTCFullYear(),
+      );
+    case "month":
+      return date.getUTCFullYear() === previous.getUTCFullYear()
+        ? MONTHS[date.getUTCMonth()]!
+        : `${MONTHS[date.getUTCMonth()]} ${date.getUTCFullYear()}`;
+    case "year":
+      return `${date.getUTCFullYear()}`;
+  }
+}
+
+function resolveLabelStart(center: number, label: string, width: number): number {
+  return clamp(
+    Math.round(center - label.length / 2),
+    0,
+    Math.max(width - label.length, 0),
+  );
+}
+
+function writeLabel(axis: string[], start: number, label: string): void {
+  for (let index = 0; index < label.length && start + index < axis.length; index += 1) {
+    axis[start + index] = label[index]!;
+  }
+}
+
+function addCandidate(
+  candidates: CompositeTimeAxisCandidate[],
+  candidate: CompositeTimeAxisCandidate,
+): void {
+  const duplicate = candidates.some((existing) => (
+    Math.abs(existing.ratio - candidate.ratio) < 1e-9
+    || existing.timestamp === candidate.timestamp
+  ));
+  if (!duplicate) candidates.push(candidate);
+}
+
+function layoutTimeAxis({
+  startTime,
+  endTime,
+  width,
+  samples,
+}: {
+  startTime: number;
+  endTime: number;
+  width: number;
+  samples?: readonly CompositeTimeAxisSample[];
+}): CompositeTimeAxisLayout {
+  const axisWidth = Math.max(1, Math.floor(width));
+  const axis = Array(axisWidth).fill(" ");
+  if (!validTimestamp(startTime) || !validTimestamp(endTime) || endTime < startTime) {
+    return { text: axis.join(""), ticks: [] };
+  }
+
+  const interval = resolveTimeAxisInterval(startTime, endTime, axisWidth);
+  const marketSamples = samples?.length ? [...samples] : null;
+  const firstTimestamp = startTime;
+  const lastTimestamp = endTime;
+  const candidates: CompositeTimeAxisCandidate[] = [{
+    timestamp: firstTimestamp,
+    ratio: 0,
+    boundary: true,
+  }];
+  const firstBucket = intervalBucketKey(firstTimestamp, interval);
+
+  for (const boundary of calendarBoundaries(startTime, endTime, interval)) {
+    if (marketSamples) {
+      const sample = marketSamples[lowerBoundSample(marketSamples, boundary)];
+      if (
+        sample
+        && intervalBucketKey(sample.timestamp, interval) !== firstBucket
+        && sample.timestamp < lastTimestamp
+        && sample.ratio < 1
+      ) {
+        addCandidate(candidates, { ...sample, boundary: false });
+      }
+      continue;
+    }
+    const bucket = intervalBucketKey(boundary, interval);
+    if (bucket === firstBucket) continue;
+    const span = Math.max(endTime - startTime, 1);
+    addCandidate(candidates, {
+      timestamp: boundary,
+      ratio: clamp((boundary - startTime) / span, 0, 1),
+      boundary: false,
+    });
+  }
+
+  addCandidate(candidates, {
+    timestamp: lastTimestamp,
+    ratio: 1,
+    boundary: true,
+  });
+  candidates.sort((left, right) => left.ratio - right.ratio || left.timestamp - right.timestamp);
+
+  if (candidates.length === 1 || firstTimestamp === lastTimestamp) {
+    const label = formatBoundaryLabel(firstTimestamp, lastTimestamp, interval);
+    const visibleLabel = label.slice(0, axisWidth);
+    const start = Math.max(Math.floor((axisWidth - visibleLabel.length) / 2), 0);
+    writeLabel(axis, start, visibleLabel);
+    return {
+      text: axis.join(""),
+      ticks: [{
+        timestamp: firstTimestamp,
+        ratio: 0.5,
+        label: visibleLabel,
+        start,
+        end: start + visibleLabel.length - 1,
+      }],
+    };
+  }
+
+  let startLabel = formatBoundaryLabel(firstTimestamp, lastTimestamp, interval);
+  let endLabel = formatBoundaryLabel(lastTimestamp, firstTimestamp, interval);
+  if (startLabel.length + endLabel.length + 1 > axisWidth) {
+    startLabel = formatBoundaryLabel(firstTimestamp, lastTimestamp, interval, false);
+    endLabel = formatBoundaryLabel(lastTimestamp, firstTimestamp, interval, false);
+  }
+  if (startLabel.length + endLabel.length + 1 > axisWidth) {
+    startLabel = formatBoundaryLabel(firstTimestamp, lastTimestamp, interval, false, false);
+    endLabel = formatBoundaryLabel(lastTimestamp, firstTimestamp, interval, false, false);
+  }
+  if (startLabel.length + endLabel.length + 1 > axisWidth) {
+    const visibleLabel = startLabel.slice(0, axisWidth);
+    writeLabel(axis, 0, visibleLabel);
+    return {
+      text: axis.join(""),
+      ticks: [{
+        timestamp: firstTimestamp,
+        ratio: 0,
+        label: visibleLabel,
+        start: 0,
+        end: visibleLabel.length - 1,
+      }],
+    };
+  }
+
+  const placed: CompositeTimeAxisTick[] = [];
+  writeLabel(axis, 0, startLabel);
+  placed.push({
+    timestamp: firstTimestamp,
+    ratio: 0,
+    label: startLabel,
+    start: 0,
+    end: startLabel.length - 1,
+  });
+
+  const endPadding = axisWidth > startLabel.length + endLabel.length + 2 ? 1 : 0;
+  const endStart = axisWidth - endLabel.length - endPadding;
+  const minimumGap = interval.unit === "month" || interval.unit === "year" ? 2 : 1;
+  let previousTimestamp = firstTimestamp;
+  let previousEnd = startLabel.length - 1;
+  for (const candidate of candidates.filter((entry) => !entry.boundary)) {
+    const label = formatInteriorLabel(candidate.timestamp, previousTimestamp, interval);
+    const center = candidate.ratio * Math.max(axisWidth - 1, 0);
+    const start = resolveLabelStart(center, label, axisWidth);
+    const end = start + label.length - 1;
+    if (start <= previousEnd + minimumGap) continue;
+    if (end >= endStart - minimumGap) continue;
+    writeLabel(axis, start, label);
+    placed.push({
+      timestamp: candidate.timestamp,
+      ratio: candidate.ratio,
+      label,
+      start,
+      end,
+    });
+    previousTimestamp = candidate.timestamp;
+    previousEnd = end;
+  }
+
+  writeLabel(axis, endStart, endLabel);
+  placed.push({
+    timestamp: lastTimestamp,
+    ratio: 1,
+    label: endLabel,
+    start: endStart,
+    end: endStart + endLabel.length - 1,
+  });
+
+  return {
+    text: axis.join(""),
+    ticks: placed,
+  };
+}
+
+export function buildCompositeTimeAxisLayout(
+  scene: CompositeChartScene,
+  width: number,
+): CompositeTimeAxisLayout {
+  return layoutTimeAxis({
+    startTime: scene.startTime,
+    endTime: scene.endTime,
+    width,
+    samples: scene.timeScale.kind === "market"
+      ? normalizeMarketSamples(scene)
+      : undefined,
+  });
+}
+
+export function buildCompositeViewportTimeAxisLayout(
+  viewport: CompositeViewportRange,
+  width: number,
+): CompositeTimeAxisLayout {
+  return layoutTimeAxis({
+    startTime: viewport.start.getTime(),
+    endTime: viewport.end.getTime(),
+    width,
+  });
+}

--- a/src/components/chart/composite/types.ts
+++ b/src/components/chart/composite/types.ts
@@ -134,6 +134,7 @@ export interface CompositeChartProps {
   emptyMessage?: string;
   formatValue?: (value: number, series: ResolvedSeries) => string;
   onCursorDateChange?: (date: Date | null) => void;
+  /** Reports a user-created viewport, or null when the user resets to the authored viewport. */
   onViewportChange?: (viewport: { start: Date; end: Date } | null) => void;
   onActivate?: () => void;
   onToggleSeries?: (seriesId: string) => void;

--- a/src/components/chart/static/chart/axis-overlays.test.tsx
+++ b/src/components/chart/static/chart/axis-overlays.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  UiHostProvider,
+  type RendererHost,
+  type UiHost,
+} from "../../../../ui";
+import { WebBox } from "../../../../renderers/electrobun/view/host/box";
+import { WebText } from "../../../../renderers/electrobun/view/host/text";
+import { StaticXAxisLabels } from "./axis-overlays";
+
+const renderer: RendererHost = {
+  requestExit() {},
+  async openExternal() {},
+  async copyText() {},
+  async readText() {
+    return "";
+  },
+  notify() {},
+};
+
+function renderAxis(kind: "opentui" | "desktop-web"): string {
+  const ui = {
+    kind,
+    capabilities: {
+      cellWidthPx: 8,
+      fractionalViewport: kind === "desktop-web",
+    },
+    Box: WebBox,
+    Text: WebText,
+  } as unknown as UiHost;
+  const fallback = "Nov 3 2025                    Mar                    Jul 29 2026";
+  return renderToStaticMarkup(
+    <UiHostProvider ui={ui} renderer={renderer}>
+      <StaticXAxisLabels
+        labels={[fallback]}
+        positionedLabels={[
+          { label: "Nov 3 2025", ratio: 0 },
+          { label: "Mar", ratio: 0.5 },
+          { label: "Jul 29 2026", ratio: 1 },
+        ]}
+        width={80}
+      />
+    </UiHostProvider>,
+  );
+}
+
+describe("StaticXAxisLabels", () => {
+  test("positions desktop labels by chart ratio instead of font-space advances", () => {
+    const html = renderAxis("desktop-web");
+
+    expect(html).toContain("left:50%");
+    expect(html).toContain("transform:translateX(-50%)");
+    expect(html).toContain("right:0");
+    expect(html).not.toContain("Nov 3 2025                    Mar");
+  });
+
+  test("keeps the fixed-width axis string for terminal cells", () => {
+    const html = renderAxis("opentui");
+
+    expect(html).toContain("Nov 3 2025                    Mar");
+    expect(html).not.toContain("left:50%");
+  });
+});

--- a/src/components/chart/static/chart/axis-overlays.tsx
+++ b/src/components/chart/static/chart/axis-overlays.tsx
@@ -8,6 +8,11 @@ export interface StaticChartXMarker {
   lineChar?: string;
 }
 
+export interface StaticChartXAxisLabel {
+  label: string;
+  ratio: number;
+}
+
 export function clampRatio(value: number): number {
   if (!Number.isFinite(value)) return 0;
   return Math.max(0, Math.min(1, value));
@@ -28,6 +33,7 @@ function alignAxisLabel(label: string, width: number, index: number, count: numb
 
 export function StaticXAxisLabels({
   labels,
+  positionedLabels,
   width,
   color,
   cursorColumn,
@@ -37,6 +43,7 @@ export function StaticXAxisLabels({
   cursorBackgroundColor,
 }: {
   labels: string[];
+  positionedLabels?: readonly StaticChartXAxisLabel[];
   width: number;
   color?: string;
   cursorColumn?: number | null;
@@ -45,11 +52,17 @@ export function StaticXAxisLabels({
   cursorColor?: string;
   cursorBackgroundColor?: string;
 }) {
+  const uiHost = useUiHost();
   const { cellWidthPx = 8, fractionalViewport = false } = useUiCapabilities();
   const visibleLabels = labels.filter(Boolean);
-  if (visibleLabels.length === 0 || width <= 0) return null;
-  const baseWidth = Math.floor(width / visibleLabels.length);
-  let remainder = width - baseWidth * visibleLabels.length;
+  const visiblePositionedLabels = positionedLabels?.filter((entry) => (
+    entry.label.length > 0 && Number.isFinite(entry.ratio)
+  )) ?? [];
+  if (visibleLabels.length === 0 && visiblePositionedLabels.length === 0) return null;
+  if (width <= 0) return null;
+  const segmentCount = Math.max(visibleLabels.length, 1);
+  const baseWidth = Math.floor(width / segmentCount);
+  let remainder = width - baseWidth * segmentCount;
   const clippedCursorLabel = cursorLabel ? cursorLabel.slice(0, width) : null;
   const cursorLabelWidth = clippedCursorLabel?.length ?? 0;
   const usePixelOverlay = fractionalViewport
@@ -83,17 +96,49 @@ export function StaticXAxisLabels({
       position="relative"
       overflow="hidden"
     >
-      <Box width={width} height={1} flexDirection="row">
-        {visibleLabels.map((label, index) => {
-          const cellWidth = baseWidth + (remainder > 0 ? 1 : 0);
-          remainder -= remainder > 0 ? 1 : 0;
-          return (
-            <Box key={`${label}:${index}`} width={cellWidth} overflow="hidden">
-              <Text fg={color}>{alignAxisLabel(label, cellWidth, index, visibleLabels.length)}</Text>
-            </Box>
-          );
-        })}
-      </Box>
+      {uiHost.kind === "desktop-web" && visiblePositionedLabels.length > 0 ? (
+        <Box position="absolute" left={0} top={0} width={width} height={1}>
+          {visiblePositionedLabels.map((entry, index) => {
+            const ratio = clampRatio(entry.ratio);
+            const edgeStyle = ratio <= 0
+              ? { left: 0 }
+              : ratio >= 1
+                ? { right: 0 }
+                : {
+                  left: `${ratio * 100}%`,
+                  transform: "translateX(-50%)",
+                };
+            return (
+              <Text
+                key={`${entry.label}:${entry.ratio}:${index}`}
+                fg={color}
+                selectable={false}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  whiteSpace: "pre",
+                  pointerEvents: "none",
+                  ...edgeStyle,
+                }}
+              >
+                {entry.label}
+              </Text>
+            );
+          })}
+        </Box>
+      ) : (
+        <Box width={width} height={1} flexDirection="row">
+          {visibleLabels.map((label, index) => {
+            const cellWidth = baseWidth + (remainder > 0 ? 1 : 0);
+            remainder -= remainder > 0 ? 1 : 0;
+            return (
+              <Box key={`${label}:${index}`} width={cellWidth} overflow="hidden">
+                <Text fg={color}>{alignAxisLabel(label, cellWidth, index, visibleLabels.length)}</Text>
+              </Box>
+            );
+          })}
+        </Box>
+      )}
       {clippedCursorLabel && (cursorLeftPercent !== null || cursorLeft !== null) ? (
         <Text
           fg={cursorColor}

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -66,7 +66,7 @@ const RESOLUTION_TABS_WIDTH = RESOLUTION_TABS.reduce(
   (width, tab) => width + [...tab.label].length + 1,
   0,
 );
-const AUTO_VIEWPORT_DEBOUNCE_MS = 120;
+const AUTO_VIEWPORT_DEBOUNCE_MS = 350;
 
 function footerAnchorPoint(event?: PaneFooterPressEvent): { x: number; y: number } | undefined {
   const x = event?.pixelX;

--- a/src/sources/provider-router/history.test.ts
+++ b/src/sources/provider-router/history.test.ts
@@ -349,6 +349,39 @@ describe("AssetDataRouter chart history", () => {
     expect(await router.getChartResolutionCapabilities("AAPL", "NASDAQ")).toEqual(["1d", "1wk"]);
   });
 
+  test("skips unavailable providers when resolving chart resolution support", async () => {
+    let cloudSupportCalls = 0;
+    const cloudProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "cloud",
+      name: "Cloud",
+      priority: 100,
+      async canProvide() {
+        return false;
+      },
+      getChartResolutionSupport() {
+        cloudSupportCalls += 1;
+        return [{ resolution: "1m", maxRange: "1W" }];
+      },
+    };
+    const yahooProvider: DataProvider = {
+      ...fallbackProvider,
+      id: "yahoo",
+      name: "Yahoo",
+      priority: 1000,
+      getChartResolutionSupport() {
+        return [{ resolution: "1d", maxRange: "5Y" }];
+      },
+    };
+
+    const router = new AssetDataRouter(yahooProvider, [cloudProvider]);
+
+    expect(await router.getChartResolutionSupport("AAPL", "NASDAQ")).toEqual([
+      { resolution: "1d", maxRange: "5Y" },
+    ]);
+    expect(cloudSupportCalls).toBe(0);
+  });
+
   test("refreshes each history request type before falling back to its cached value", async () => {
     const dbPath = createTempDbPath("forced-history-refresh");
     const persistence = new AppPersistence(dbPath);

--- a/src/sources/provider-router/history.ts
+++ b/src/sources/provider-router/history.ts
@@ -186,6 +186,9 @@ export class ProviderRouterHistoryRoutes {
     if (brokerSupport) return brokerSupport.value;
 
     const providerSupport = await this.firstProviderArrayResult(async (provider) => {
+      if (provider.canProvide && !await provider.canProvide(ticker, exchange, context)) {
+        return null;
+      }
       if (provider.getChartResolutionSupport) {
         return normalizeChartResolutionSupport(await provider.getChartResolutionSupport(ticker, exchange, context));
       }

--- a/src/time-series/spec-studies.test.ts
+++ b/src/time-series/spec-studies.test.ts
@@ -281,6 +281,21 @@ describe("study resolution", () => {
     expect(maxStudyWarmupPoints(specs)).toBe(33);
   });
 
+  test("omits empty-volume noise while preserving analytical history warnings", () => {
+    const input = resolved("a");
+    input.points = input.points.map(({ volume: _volume, ...point }) => point);
+
+    const result = resolveStudies([input], [
+      study("volume", "volume", ["a"]),
+      study("sma", "sma", ["a"], { period: 100 }),
+    ]);
+
+    expect(result.series.find(({ id }) => id === "volume")?.points).toEqual([]);
+    expect(result.warnings).toEqual([
+      "sma: not enough valid history to calculate sma.",
+    ]);
+  });
+
   test("aligns pair formulas to the latest available value even when display interpolation is off", () => {
     const point = (date: string, value: number): TimeSeriesPoint => {
       const availableAt = new Date(`${date}T00:00:00Z`);

--- a/src/time-series/studies.ts
+++ b/src/time-series/studies.ts
@@ -554,7 +554,10 @@ export function resolveStudies(
       }
       outputs = resolvePairStudy(spec, input, pairedInput, color);
     }
-    if (outputs.length === 0 || outputs.every((output) => output.points.length === 0)) {
+    if (
+      spec.kind !== "volume"
+      && (outputs.length === 0 || outputs.every((output) => output.points.length === 0))
+    ) {
       warnings.push(`${spec.id}: not enough valid history to calculate ${spec.kind}.`);
     }
     resolved.push(...outputs);

--- a/src/time-series/use-chart-resolution.test.tsx
+++ b/src/time-series/use-chart-resolution.test.tsx
@@ -1,0 +1,288 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useState } from "react";
+import { testRender } from "../renderers/opentui/test-utils";
+import { createTestDataProvider } from "../test-support/data-provider";
+import type { DataProvider } from "../types/data-provider";
+import type { PricePoint, TickerFinancials } from "../types/financials";
+import type { ChartResolveSources } from "./resolve";
+import { CHART_SPEC_VERSION, type ChartSpec } from "./types";
+import {
+  useChartResolution,
+  type UseChartResolutionResult,
+} from "./use-chart-resolution";
+
+type AutoViewport = NonNullable<Parameters<typeof useChartResolution>[2]["autoViewport"]>;
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+let setAutoViewport: ((viewport: AutoViewport | null) => void) | null = null;
+let latestResult: UseChartResolutionResult | null = null;
+
+const EMPTY_FINANCIALS: TickerFinancials = {
+  annualStatements: [],
+  quarterlyStatements: [],
+  priceHistory: [],
+};
+
+const INITIAL_HISTORY: PricePoint[] = [
+  {
+    date: new Date("2025-01-02T16:00:00.000Z"),
+    open: 100,
+    high: 103,
+    low: 99,
+    close: 102,
+    volume: 1_000,
+  },
+  {
+    date: new Date("2025-01-03T16:00:00.000Z"),
+    open: 102,
+    high: 105,
+    low: 101,
+    close: 104,
+    volume: 1_200,
+  },
+];
+
+const SPEC: ChartSpec = {
+  version: CHART_SPEC_VERSION,
+  viewport: { range: "1Y", resolution: "auto" },
+  panels: [{ id: "main" }],
+  series: [{
+    id: "price",
+    source: {
+      kind: "security",
+      instrument: { symbol: "TEST", exchange: "NASDAQ" },
+      fieldId: "market.ohlcv",
+    },
+    style: "candles",
+    transform: "raw",
+    axis: "left",
+    panelId: "main",
+    interpolation: "none",
+  }],
+  studies: [],
+};
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function sourcesFor(dataProvider: DataProvider): ChartResolveSources {
+  return {
+    dataProvider,
+    now: new Date("2025-01-10T00:00:00.000Z"),
+    loadFredSeries: async () => {
+      throw new Error("FRED is unused in this test.");
+    },
+  };
+}
+
+function ResolutionHarness({
+  sources,
+}: {
+  sources: ChartResolveSources;
+}) {
+  const [viewport, setViewport] = useState<AutoViewport | null>(null);
+  setAutoViewport = setViewport;
+  latestResult = useChartResolution(SPEC, sources, {
+    autoViewport: viewport,
+    targetPointCount: 100,
+    liveRefreshIntervalMs: 0,
+  });
+  const pointCount = (latestResult.bufferedSeries ?? latestResult.series)
+    .reduce((total, series) => total + series.points.length, 0);
+  return <text>{`${latestResult.loading ? "loading" : "settled"}:${pointCount}`}</text>;
+}
+
+async function flushEffects(iterations = 1): Promise<void> {
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    await act(async () => {
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+  }
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    await flushEffects();
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  throw new Error("Timed out waiting for chart resolution.");
+}
+
+afterEach(async () => {
+  if (testSetup) {
+    await act(async () => {
+      testSetup!.renderer.destroy();
+    });
+    testSetup = undefined;
+  }
+  setAutoViewport = null;
+  latestResult = null;
+});
+
+describe("useChartResolution", () => {
+  test("keeps renderable data settled through empty adaptive and live refreshes", async () => {
+    const adaptiveHistory = deferred<PricePoint[]>();
+    let detailedCalls = 0;
+    let quoteHandler: Parameters<NonNullable<DataProvider["subscribeQuotes"]>>[1] | null = null;
+    let quoteTarget: Parameters<NonNullable<DataProvider["subscribeQuotes"]>>[0][number] | null = null;
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => EMPTY_FINANCIALS,
+      getChartResolutionSupport: () => [
+        { resolution: "15m", maxRange: "1M" },
+        { resolution: "1d", maxRange: "ALL" },
+      ],
+      getPriceHistoryForResolution: async (_symbol, _exchange, _range, resolution) => (
+        resolution === "1d" ? INITIAL_HISTORY : []
+      ),
+      getDetailedPriceHistory: async () => {
+        detailedCalls += 1;
+        return adaptiveHistory.promise;
+      },
+      getPriceHistory: async () => [],
+      subscribeQuotes: (targets, onQuote) => {
+        quoteTarget = targets[0] ?? null;
+        quoteHandler = onQuote;
+        return () => {};
+      },
+    });
+    const sources = sourcesFor(provider);
+    testSetup = await testRender(<ResolutionHarness sources={sources} />, {
+      width: 24,
+      height: 1,
+    });
+
+    await waitFor(() => latestResult?.loading === false && latestResult.series[0]?.points.length === 2);
+    const lastGoodSeries = latestResult!.series;
+    const lastGoodBufferedSeries = latestResult!.bufferedSeries;
+
+    await act(async () => {
+      setAutoViewport?.({
+        start: new Date("2025-01-02T00:00:00.000Z"),
+        end: new Date("2025-01-04T00:00:00.000Z"),
+      });
+      await testSetup!.renderOnce();
+    });
+    await waitFor(() => detailedCalls === 1);
+
+    expect(latestResult?.loading).toBe(false);
+    expect(latestResult?.series).toBe(lastGoodSeries);
+    expect(latestResult?.bufferedSeries).toBe(lastGoodBufferedSeries);
+
+    adaptiveHistory.resolve([]);
+    await flushEffects(3);
+
+    expect(latestResult?.loading).toBe(false);
+    expect(latestResult?.series).toBe(lastGoodSeries);
+    expect(latestResult?.bufferedSeries).toBe(lastGoodBufferedSeries);
+    expect(latestResult?.errors).toEqual([]);
+
+    await act(async () => {
+      quoteHandler!(quoteTarget!, {
+        symbol: "TEST",
+        price: 105,
+        currency: "USD",
+        change: 1,
+        changePercent: 0.96,
+        lastUpdated: Date.parse("2025-01-03T20:00:00.000Z"),
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await testSetup!.renderOnce();
+    });
+    await flushEffects(3);
+
+    expect(latestResult?.loading).toBe(false);
+    expect(latestResult?.series).toBe(lastGoodSeries);
+    expect(latestResult?.bufferedSeries).toBe(lastGoodBufferedSeries);
+    expect(latestResult?.errors).toEqual([]);
+  });
+
+  test("keeps renderable data when an adaptive viewport request rejects", async () => {
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => EMPTY_FINANCIALS,
+      getPriceHistoryForResolution: async () => INITIAL_HISTORY,
+    });
+    const sources = sourcesFor(provider);
+    testSetup = await testRender(<ResolutionHarness sources={sources} />, {
+      width: 24,
+      height: 1,
+    });
+
+    await waitFor(() => latestResult?.loading === false && latestResult.series[0]?.points.length === 2);
+    const lastGoodSeries = latestResult!.series;
+    const lastGoodBufferedSeries = latestResult!.bufferedSeries;
+    provider.getChartResolutionSupport = () => {
+      throw new Error("adaptive history failed");
+    };
+
+    await act(async () => {
+      setAutoViewport?.({
+        start: new Date("2025-01-02T00:00:00.000Z"),
+        end: new Date("2025-01-04T00:00:00.000Z"),
+      });
+      await testSetup!.renderOnce();
+    });
+    await flushEffects(3);
+
+    expect(latestResult?.loading).toBe(false);
+    expect(latestResult?.series).toBe(lastGoodSeries);
+    expect(latestResult?.bufferedSeries).toBe(lastGoodBufferedSeries);
+    expect(latestResult?.errors).toEqual([]);
+  });
+
+  test("keeps initial and explicit reloads blocking", async () => {
+    const initialHistory = deferred<PricePoint[]>();
+    const reloadHistory = deferred<PricePoint[]>();
+    let historyCalls = 0;
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => EMPTY_FINANCIALS,
+      getPriceHistoryForResolution: async () => {
+        historyCalls += 1;
+        return historyCalls === 1 ? initialHistory.promise : reloadHistory.promise;
+      },
+      getPriceHistory: async () => [],
+    });
+    const sources = sourcesFor(provider);
+    testSetup = await testRender(<ResolutionHarness sources={sources} />, {
+      width: 24,
+      height: 1,
+    });
+
+    await waitFor(() => historyCalls === 1);
+    expect(latestResult?.loading).toBe(true);
+    expect(latestResult?.series).toEqual([]);
+
+    await act(async () => {
+      initialHistory.resolve(INITIAL_HISTORY);
+      await testSetup!.renderOnce();
+    });
+    await waitFor(() => latestResult?.loading === false && latestResult.series[0]?.points.length === 2);
+    await act(async () => {
+      latestResult!.reload();
+      await testSetup!.renderOnce();
+    });
+    await waitFor(() => historyCalls === 2);
+
+    expect(latestResult?.loading).toBe(true);
+
+    await act(async () => {
+      reloadHistory.resolve([]);
+      await testSetup!.renderOnce();
+    });
+    await waitFor(() => (
+      latestResult?.loading === false
+      && latestResult.series.every((series) => series.points.length === 0)
+    ));
+
+    expect(latestResult?.series.every((series) => series.points.length === 0)).toBe(true);
+    expect(latestResult?.errors).toEqual([]);
+  });
+});

--- a/src/time-series/use-chart-resolution.ts
+++ b/src/time-series/use-chart-resolution.ts
@@ -30,6 +30,10 @@ const EMPTY_RESULT: ChartResolutionResult = {
   warnings: [],
 };
 
+function hasRenderableData(result: ChartResolutionResult): boolean {
+  return (result.bufferedSeries ?? result.series).some((series) => series.points.length > 0);
+}
+
 function withQuoteOverrides(
   sources: ChartResolveSources,
   liveOverrides: ReadonlyMap<string, Quote>,
@@ -49,6 +53,8 @@ export function useChartResolution(
   options: UseChartResolutionOptions = {},
 ): UseChartResolutionResult {
   const [result, setResult] = useState<ChartResolutionResult>(EMPTY_RESULT);
+  const resultRef = useRef(result);
+  resultRef.current = result;
   const [revision, setRevision] = useState(0);
   const generationRef = useRef(0);
   const liveSubscriptionGenerationRef = useRef(0);
@@ -89,7 +95,13 @@ export function useChartResolution(
       cacheIdentityRef.current = { spec, sources, revision };
     }
     const cache = resolveCacheRef.current;
-    setResult((current) => ({ ...current, loading: true, errors: [] }));
+    const current = resultRef.current;
+    const backgroundRefresh = !resetCache
+      && !current.loading
+      && hasRenderableData(current);
+    if (!backgroundRefresh) {
+      setResult((currentResult) => ({ ...currentResult, loading: true, errors: [] }));
+    }
     resolveChartSpecData(
       spec,
       withQuoteOverrides(sources, liveQuoteOverridesRef.current),
@@ -97,10 +109,13 @@ export function useChartResolution(
       resolveOptions,
     )
       .then((next) => {
-        if (generationRef.current === generation) setResult(next);
+        if (generationRef.current !== generation) return;
+        if (backgroundRefresh && !hasRenderableData(next)) return;
+        setResult(next);
       })
       .catch((error) => {
         if (generationRef.current !== generation) return;
+        if (backgroundRefresh) return;
         setResult({
           series: [],
           loading: false,
@@ -138,7 +153,14 @@ export function useChartResolution(
             liveSubscriptionGenerationRef.current === subscriptionGeneration
             && generationRef.current === generation
           ) {
-            setResult(next);
+            setResult((current) => (
+              request.options.autoViewport
+              && !current.loading
+              && hasRenderableData(current)
+              && !hasRenderableData(next)
+                ? current
+                : next
+            ));
           }
         } catch (error) {
           if (


### PR DESCRIPTION
## Summary

- make the price-chart time axis adapt from multi-year ranges down to intraday views, with ratio-positioned desktop labels and fixed-cell terminal rendering
- keep zoom and pan inside usable observations, preserve the viewport across adaptive refreshes, and scale candle widths with visible density
- retain settled chart data during background empty/error refreshes, reduce loading-status churn, and debounce viewport requests
- skip unavailable history providers, improving NBIS history selection, and suppress non-actionable empty-volume warnings

## Root cause

The chart mixed terminal-cell text spacing with a pixel-rendered desktop plot, so date labels drifted horizontally. Zoom used the smallest timestamp gap and did not require two renderable observations, allowing navigation into empty ranges; refreshed buffers could also reset the interaction viewport. Adaptive requests repeatedly toggled loading and could replace usable data with transient empty results, while provider resolution support was queried without first checking whether that source could serve the ticker.

## Validation

- `bun test` — 1,726 tests passed
- `bun run typecheck`
- `bun run desktop:view:build`
- real NBIS desktop verification at 1Y
- real OpenTUI smoke at 175×44: 38 consecutive zoom-ins through monthly, daily, and UTC labels; successful zoom-out recovery; no empty state or runtime warnings
- `git diff --check`