### PR TITLE
Fix exchange hydration for chart history

### DIFF
--- a/src/time-series/hooks.test.ts
+++ b/src/time-series/hooks.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { buildComparisonChartPreset } from "../plugins/builtin/chart-composer/presets";
+import type { TickerRecord } from "../types/ticker";
+import { hydrateChartSpecInstruments } from "./hooks";
+
+function ticker(symbol: string, exchange: string): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange,
+      currency: "USD",
+      name: symbol,
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+describe("hydrateChartSpecInstruments", () => {
+  test("fills missing exchanges without replacing explicit chart identities", () => {
+    const initial = buildComparisonChartPreset(["SNDK", "SAP:XETR"]);
+    const spec = {
+      ...initial,
+      series: initial.series.map((entry, index) => (
+        index === 0 && entry.source.kind === "security"
+          ? {
+            ...entry,
+            source: {
+              ...entry.source,
+              instrument: { ...entry.source.instrument, exchange: "" },
+            },
+          }
+          : entry
+      )),
+    };
+
+    const hydrated = hydrateChartSpecInstruments(spec, new Map([
+      ["SNDK", ticker("SNDK", "NASDAQ")],
+      ["SAP", ticker("SAP", "JSE")],
+    ]));
+
+    expect(hydrated.series[0]?.source).toMatchObject({
+      kind: "security",
+      instrument: { symbol: "SNDK", exchange: "NASDAQ" },
+    });
+    expect(hydrated.series[1]?.source).toMatchObject({
+      kind: "security",
+      instrument: { symbol: "SAP", exchange: "XETRA" },
+    });
+    expect(spec.series[0]?.source).toMatchObject({
+      kind: "security",
+      instrument: { symbol: "SNDK", exchange: "" },
+    });
+    expect(hydrateChartSpecInstruments(hydrated, new Map())).toBe(hydrated);
+  });
+});

--- a/src/time-series/hooks.ts
+++ b/src/time-series/hooks.ts
@@ -5,6 +5,7 @@ import { instrumentFromTicker } from "../market-data/request-types";
 import { useAssetData } from "../plugins/runtime";
 import { useAppSelector } from "../state/app/context";
 import type { FredSeriesRequest } from "../data/fred-series";
+import type { TickerRecord } from "../types/ticker";
 import type { ChartSpec } from "./types";
 import {
   useChartResolution,
@@ -22,24 +23,44 @@ async function loadFred(request: FredSeriesRequest) {
   );
 }
 
+export function hydrateChartSpecInstruments(
+  spec: ChartSpec,
+  tickers: ReadonlyMap<string, TickerRecord>,
+): ChartSpec {
+  let changed = false;
+  const series = spec.series.map((entry) => {
+    if (entry.source.kind !== "security" || entry.source.instrument.exchange?.trim()) {
+      return entry;
+    }
+    const symbol = entry.source.instrument.symbol.trim().toUpperCase();
+    const instrument = instrumentFromTicker(tickers.get(symbol), symbol);
+    if (!instrument?.exchange) return entry;
+    changed = true;
+    return {
+      ...entry,
+      source: {
+        ...entry.source,
+        instrument: {
+          ...instrument,
+          ...entry.source.instrument,
+          exchange: instrument.exchange,
+        },
+      },
+    };
+  });
+  return changed ? { ...spec, series } : spec;
+}
+
 export function useResolvedChartSpec(
   spec: ChartSpec,
   options: UseChartResolutionOptions = {},
 ): UseChartResolutionResult {
   const dataProvider = useAssetData();
   const tickers = useAppSelector((state) => state.tickers);
-  const hydratedSpec = useMemo<ChartSpec>(() => ({
-    ...spec,
-    series: spec.series.map((entry) => {
-      if (entry.source.kind !== "security" || entry.source.instrument.exchange) return entry;
-      const symbol = entry.source.instrument.symbol.trim().toUpperCase();
-      const ticker = tickers.get(symbol);
-      const instrument = instrumentFromTicker(ticker, symbol);
-      return instrument
-        ? { ...entry, source: { ...entry.source, instrument: { ...instrument, ...entry.source.instrument } } }
-        : entry;
-    }),
-  }), [spec, tickers]);
+  const hydratedSpec = useMemo(
+    () => hydrateChartSpecInstruments(spec, tickers),
+    [spec, tickers],
+  );
   const sources = useMemo(() => ({ dataProvider, loadFredSeries: loadFred }), [dataProvider]);
   return useChartResolution(hydratedSpec, sources, options);
 }


### PR DESCRIPTION
## Summary
- preserve the resolved ticker exchange when hydrating chart sources that omit it
- keep explicitly authored exchange identities unchanged
- prevent intraday history from using an unqualified cache and provider path

## Verification
- `bun test` (1,728 passing)
- `bun run typecheck`
- rendered 5-minute GIP charts for SNDK, AAPL, IBM, SPY, and BMW
- refreshed the saved GIP SNDK pane and matched its $1,245.155 chart value to the live quote value