### PR TITLE
Keep chart panning stable and backfill older history

### DIFF
--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -547,12 +547,17 @@ describe("CompositeChart", () => {
     expect(viewportChanges.at(-1)).toEqual(zoomedViewport);
   });
 
-  test("keeps a panned viewport when the parent echoes the adaptive window", async () => {
+  test("keeps the latest pan when an older adaptive viewport arrives first", async () => {
     const viewportChanges: Array<{ start: string; end: string } | null> = [];
+    let publishViewport: ((next: { start: string; end: string }) => void) | null = null;
     function Harness() {
       const [viewport, setViewport] = useState({
         start: new Date("2025-01-05T00:00:00.000Z"),
         end: new Date("2025-01-09T00:00:00.000Z"),
+      });
+      publishViewport = (next) => setViewport({
+        start: new Date(next.start),
+        end: new Date(next.end),
       });
       return (
         <CompositeChart
@@ -566,7 +571,6 @@ describe("CompositeChart", () => {
             viewportChanges.push(next
               ? { start: next.start.toISOString(), end: next.end.toISOString() }
               : null);
-            if (next) setViewport(next);
           }}
         />
       );
@@ -588,11 +592,39 @@ describe("CompositeChart", () => {
     await act(async () => {
       await testSetup!.renderOnce();
       await testSetup!.renderOnce();
+    });
+    const firstPan = viewportChanges[0]!;
+
+    await act(async () => {
+      capturedSurfaceProps!.onMouseScroll(pointerEvent(25, 3, {
+        scroll: { direction: "up", delta: 4 },
+      }));
+    });
+    await act(async () => {
+      await testSetup!.renderOnce();
       await testSetup!.renderOnce();
     });
+    const secondPan = viewportChanges[1]!;
 
-    expect(viewportChanges).toHaveLength(1);
-    expect(viewportChanges[0]).not.toBeNull();
+    expect(firstPan).not.toBeNull();
+    expect(secondPan).not.toBeNull();
+    expect(secondPan).not.toEqual(firstPan);
+
+    await act(async () => publishViewport!(firstPan));
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+    expect(viewportChanges).toEqual([firstPan, secondPan]);
+
+    await act(async () => publishViewport!(secondPan));
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+    expect(viewportChanges).toEqual([firstPan, secondPan]);
   });
 
   test("activates and navigates a buffered viewport from the first mouse gesture", async () => {

--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -625,6 +625,71 @@ describe("CompositeChart", () => {
     expect(viewportChanges.at(-1)).toEqual(zoomedViewport);
   });
 
+  test("keeps a panned viewport when backfill moves beyond the authored range", async () => {
+    const viewportChanges: Array<{ start: string; end: string } | null> = [];
+    let replacePoints: ((points: TimeSeriesPoint[]) => void) | null = null;
+    const initialPoints = series(
+      "price",
+      "main",
+      "left",
+      "USD",
+      [100, 101, 102, 103, 104, 105, 106, 107, 108],
+    ).points;
+    const olderPoints = Array.from({ length: 11 }, (_, index) => {
+      const date = new Date(Date.UTC(2024, 11, 25 + index));
+      return { date, observedAt: date, value: 90 + index };
+    });
+    function Harness() {
+      const [points, setPoints] = useState(initialPoints);
+      replacePoints = setPoints;
+      return (
+        <InputHostProvider host={chartInputHost}>
+          <CompositeChart
+            width={60}
+            height={12}
+            focused
+            series={[{
+              ...series("price", "main", "left", "USD", []),
+              points,
+            }]}
+            panels={[{ id: "main" }]}
+            viewport={{
+              start: new Date("2025-01-06T00:00:00.000Z"),
+              end: new Date("2025-01-09T00:00:00.000Z"),
+            }}
+            onViewportChange={(next) => viewportChanges.push(next
+              ? { start: next.start.toISOString(), end: next.end.toISOString() }
+              : null)}
+          />
+        </InputHostProvider>
+      );
+    }
+
+    testSetup = await testRender(<Harness />, { width: 62, height: 14 });
+    await act(async () => testSetup!.renderOnce());
+    for (let index = 0; index < 120; index += 1) {
+      const panOlder = keyEvent("left");
+      panOlder.shift = true;
+      await act(async () => chartShortcut?.(panOlder));
+      await act(async () => testSetup!.renderOnce());
+    }
+    const pannedViewport = viewportChanges.at(-1);
+    expect(pannedViewport).toEqual({
+      start: "2025-01-01T00:00:00.000Z",
+      end: "2025-01-04T00:00:00.000Z",
+    });
+
+    await act(async () => replacePoints?.(olderPoints));
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(viewportChanges.at(-1)).toEqual(pannedViewport);
+    expect(testSetup.captureCharFrame()).not.toContain("No chart data");
+    expect(testSetup.captureCharFrame()).not.toContain("Jan 9");
+  });
+
   test("keeps the latest pan through delayed adaptive viewport and series echoes", async () => {
     const viewportChanges: Array<{ start: string; end: string } | null> = [];
     let publishViewport: ((

--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -566,6 +566,42 @@ describe("CompositeChart", () => {
     expect(viewportInteractions.at(-1)).toBe("reset");
   });
 
+  test("clears the interaction when zoom returns to the authored viewport", async () => {
+    const viewportChanges: Array<{ start: string; end: string } | null> = [];
+    testSetup = await testRender(
+      <InputHostProvider host={chartInputHost}>
+        <CompositeChart
+          width={60}
+          height={12}
+          focused
+          series={[series("price", "main", "left", "USD", [100, 101, 102, 103, 104, 105, 106, 107, 108])]}
+          panels={[{ id: "main" }]}
+          viewport={{
+            start: new Date("2025-01-01T00:00:00.000Z"),
+            end: new Date("2025-01-09T00:00:00.000Z"),
+          }}
+          onViewportChange={(next) => viewportChanges.push(next
+            ? { start: next.start.toISOString(), end: next.end.toISOString() }
+            : null)}
+        />
+      </InputHostProvider>,
+      { width: 62, height: 14 },
+    );
+
+    await act(async () => testSetup!.renderOnce());
+    const zoomIn = keyEvent("=");
+    zoomIn.sequence = "+";
+    zoomIn.shift = true;
+    await act(async () => chartShortcut?.(zoomIn));
+    await act(async () => testSetup!.renderOnce());
+    expect(viewportChanges.at(-1)).not.toBeNull();
+
+    await act(async () => chartShortcut?.(keyEvent("-")));
+    await act(async () => testSetup!.renderOnce());
+
+    expect(viewportChanges.at(-1)).toBeNull();
+  });
+
   test("preserves a zoomed viewport when adaptive data refreshes its buffer", async () => {
     const viewportChanges: Array<{ start: string; end: string } | null> = [];
     let replacePoints: ((points: TimeSeriesPoint[]) => void) | null = null;

--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -547,6 +547,54 @@ describe("CompositeChart", () => {
     expect(viewportChanges.at(-1)).toEqual(zoomedViewport);
   });
 
+  test("keeps a panned viewport when the parent echoes the adaptive window", async () => {
+    const viewportChanges: Array<{ start: string; end: string } | null> = [];
+    function Harness() {
+      const [viewport, setViewport] = useState({
+        start: new Date("2025-01-05T00:00:00.000Z"),
+        end: new Date("2025-01-09T00:00:00.000Z"),
+      });
+      return (
+        <CompositeChart
+          width={60}
+          height={12}
+          interactive
+          series={[series("price", "main", "left", "USD", [100, 101, 102, 103, 104, 105, 106, 107, 108])]}
+          panels={[{ id: "main" }]}
+          viewport={viewport}
+          onViewportChange={(next) => {
+            viewportChanges.push(next
+              ? { start: next.start.toISOString(), end: next.end.toISOString() }
+              : null);
+            if (next) setViewport(next);
+          }}
+        />
+      );
+    }
+
+    testSetup = await testRender(
+      <CaptureChartSurfaceProvider>
+        <Harness />
+      </CaptureChartSurfaceProvider>,
+      { width: 62, height: 14 },
+    );
+    await act(async () => testSetup!.renderOnce());
+
+    await act(async () => {
+      capturedSurfaceProps!.onMouseScroll(pointerEvent(25, 3, {
+        scroll: { direction: "up", delta: 4 },
+      }));
+    });
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(viewportChanges).toHaveLength(1);
+    expect(viewportChanges[0]).not.toBeNull();
+  });
+
   test("activates and navigates a buffered viewport from the first mouse gesture", async () => {
     let activations = 0;
     const cursorChanges: string[] = [];

--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -547,26 +547,46 @@ describe("CompositeChart", () => {
     expect(viewportChanges.at(-1)).toEqual(zoomedViewport);
   });
 
-  test("keeps the latest pan when an older adaptive viewport arrives first", async () => {
+  test("keeps the latest pan through delayed adaptive viewport and series echoes", async () => {
     const viewportChanges: Array<{ start: string; end: string } | null> = [];
-    let publishViewport: ((next: { start: string; end: string }) => void) | null = null;
+    let publishViewport: ((
+      next: { start: string; end: string },
+      showSecondary?: boolean,
+    ) => void) | null = null;
+    let publishExternalViewport: (() => void) | null = null;
     function Harness() {
       const [viewport, setViewport] = useState({
         start: new Date("2025-01-05T00:00:00.000Z"),
         end: new Date("2025-01-09T00:00:00.000Z"),
       });
-      publishViewport = (next) => setViewport({
-        start: new Date(next.start),
-        end: new Date(next.end),
-      });
+      const [showSecondary, setShowSecondary] = useState(false);
+      const [viewportResetKey, setViewportResetKey] = useState("price:1D:auto");
+      publishViewport = (next, nextShowSecondary = showSecondary) => {
+        setViewport({
+          start: new Date(next.start),
+          end: new Date(next.end),
+        });
+        setShowSecondary(nextShowSecondary);
+      };
+      publishExternalViewport = () => {
+        setViewport({
+          start: new Date("2025-01-01T00:00:00.000Z"),
+          end: new Date("2025-01-09T00:00:00.000Z"),
+        });
+        setViewportResetKey("price:1W:auto");
+      };
       return (
         <CompositeChart
           width={60}
           height={12}
           interactive
-          series={[series("price", "main", "left", "USD", [100, 101, 102, 103, 104, 105, 106, 107, 108])]}
+          series={[
+            series("price", "main", "left", "USD", [100, 101, 102, 103, 104, 105, 106, 107, 108]),
+            series("secondary", "main", "left", "USD", showSecondary ? [90, 91, 92] : []),
+          ]}
           panels={[{ id: "main" }]}
           viewport={viewport}
+          viewportResetKey={viewportResetKey}
           onViewportChange={(next) => {
             viewportChanges.push(next
               ? { start: next.start.toISOString(), end: next.end.toISOString() }
@@ -584,47 +604,47 @@ describe("CompositeChart", () => {
     );
     await act(async () => testSetup!.renderOnce());
 
-    await act(async () => {
-      capturedSurfaceProps!.onMouseScroll(pointerEvent(25, 3, {
-        scroll: { direction: "up", delta: 4 },
-      }));
-    });
-    await act(async () => {
-      await testSetup!.renderOnce();
-      await testSetup!.renderOnce();
-    });
+    for (let index = 0; index < 10; index += 1) {
+      await act(async () => {
+        capturedSurfaceProps!.onMouseScroll(pointerEvent(25, 3, {
+          scroll: { direction: "up", delta: 1 },
+        }));
+      });
+      await act(async () => {
+        await testSetup!.renderOnce();
+        await testSetup!.renderOnce();
+      });
+    }
     const firstPan = viewportChanges[0]!;
-
-    await act(async () => {
-      capturedSurfaceProps!.onMouseScroll(pointerEvent(25, 3, {
-        scroll: { direction: "up", delta: 4 },
-      }));
-    });
-    await act(async () => {
-      await testSetup!.renderOnce();
-      await testSetup!.renderOnce();
-    });
-    const secondPan = viewportChanges[1]!;
-
+    const latestPan = viewportChanges.at(-1)!;
     expect(firstPan).not.toBeNull();
-    expect(secondPan).not.toBeNull();
-    expect(secondPan).not.toEqual(firstPan);
+    expect(latestPan).not.toBeNull();
+    expect(latestPan).not.toEqual(firstPan);
 
-    await act(async () => publishViewport!(firstPan));
+    await act(async () => publishViewport!(firstPan, true));
     await act(async () => {
       await testSetup!.renderOnce();
       await testSetup!.renderOnce();
       await testSetup!.renderOnce();
     });
-    expect(viewportChanges).toEqual([firstPan, secondPan]);
+    expect(viewportChanges).not.toContain(null);
+    expect(viewportChanges.at(-1)).toEqual(latestPan);
 
-    await act(async () => publishViewport!(secondPan));
+    await act(async () => publishViewport!(latestPan));
     await act(async () => {
       await testSetup!.renderOnce();
       await testSetup!.renderOnce();
       await testSetup!.renderOnce();
     });
-    expect(viewportChanges).toEqual([firstPan, secondPan]);
+    expect(viewportChanges).not.toContain(null);
+    expect(viewportChanges.at(-1)).toEqual(latestPan);
+
+    await act(async () => publishExternalViewport!());
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+    expect(viewportChanges.at(-1)).toBeNull();
   });
 
   test("activates and navigates a buffered viewport from the first mouse gesture", async () => {

--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -155,6 +155,42 @@ function series(id: string, panelId: string, axis: ResolvedSeries["axis"], unit:
   };
 }
 
+function twoSessionCandles(): ResolvedSeries {
+  const points = [
+    ...Array.from({ length: 7 }, (_, index) => (
+      Date.UTC(2025, 0, 2, 17, index * 30)
+    )),
+    ...Array.from({ length: 8 }, (_, index) => (
+      Date.UTC(2025, 0, 3, 13, 30 + index * 30)
+    )),
+  ].map((timestamp, index) => {
+    const date = new Date(timestamp);
+    const value = 100 + index * 0.1;
+    return {
+      date,
+      observedAt: date,
+      value,
+      open: value,
+      high: value + 1,
+      low: value - 1,
+      close: value,
+      volume: 100,
+    };
+  });
+  return {
+    ...series("price", "main", "left", "USD", []),
+    nativeFrequency: "intraday",
+    dataShape: "ohlc",
+    style: "candles",
+    timeBasis: {
+      kind: "market",
+      timeZone: "America/New_York",
+      cadenceMs: 30 * 60_000,
+    },
+    points,
+  };
+}
+
 describe("CompositeChart", () => {
   test("lays out mixed panels with one shared legend and time axis", async () => {
     testSetup = await testRender(
@@ -243,6 +279,42 @@ describe("CompositeChart", () => {
     });
 
     expect(testSetup.captureCharFrame()).toContain("OTHER Revenue");
+  });
+
+  test("uses buffered market anchors so closed sessions do not create chart holes", async () => {
+    const candles = twoSessionCandles();
+    const currentSession = {
+      ...candles,
+      points: candles.points.filter((point) => point.date.getUTCDate() === 3),
+    };
+    testSetup = await testRender(
+      <CompositeChart
+        width={72}
+        height={12}
+        series={[candles]}
+        legendSeries={[currentSession]}
+        panels={[{ id: "main" }]}
+        viewport={{
+          start: new Date("2025-01-02T17:00:00.000Z"),
+          end: new Date("2025-01-03T17:00:00.000Z"),
+        }}
+        showLegend={false}
+      />,
+      { width: 74, height: 14 },
+    );
+    await act(async () => testSetup!.renderOnce());
+
+    const bodyColumns = [...new Set(testSetup.captureCharFrame()
+      .split("\n")
+      .flatMap((line) => [...line].flatMap((cell, index) => cell === "█" ? [index] : [])))]
+      .sort((left, right) => left - right);
+    const largestGap = bodyColumns.slice(1).reduce(
+      (largest, column, index) => Math.max(largest, column - bodyColumns[index]!),
+      0,
+    );
+
+    expect(bodyColumns.length).toBeGreaterThan(10);
+    expect(largestGap).toBeLessThan(10);
   });
 
   test("shows an explicit legend toggle action on hover", async () => {
@@ -444,6 +516,7 @@ describe("CompositeChart", () => {
 
   test("zooms with plus and resets the interaction viewport with zero", async () => {
     const viewportChanges: Array<{ start: string; end: string } | null> = [];
+    const viewportInteractions: string[] = [];
     testSetup = await testRender(
       <InputHostProvider host={chartInputHost}>
         <CompositeChart
@@ -456,9 +529,12 @@ describe("CompositeChart", () => {
             start: new Date("2025-01-01T00:00:00.000Z"),
             end: new Date("2025-01-09T00:00:00.000Z"),
           }}
-          onViewportChange={(next) => viewportChanges.push(next
-            ? { start: next.start.toISOString(), end: next.end.toISOString() }
-            : null)}
+          onViewportChange={(next, interaction) => {
+            viewportInteractions.push(interaction);
+            viewportChanges.push(next
+              ? { start: next.start.toISOString(), end: next.end.toISOString() }
+              : null);
+          }}
         />
       </InputHostProvider>,
       { width: 62, height: 14 },
@@ -477,11 +553,13 @@ describe("CompositeChart", () => {
     expect(zoomIn.defaultPrevented).toBe(true);
     expect(testSetup.captureCharFrame()).not.toContain("Jan 1");
     expect(viewportChanges.at(-1)?.start).not.toBe("2025-01-01T00:00:00.000Z");
+    expect(viewportInteractions.at(-1)).toBe("zoom");
 
     await act(async () => chartShortcut?.(keyEvent("0")));
     await act(async () => testSetup!.renderOnce());
     expect(testSetup.captureCharFrame()).toContain("Jan 1");
     expect(viewportChanges.at(-1)).toBeNull();
+    expect(viewportInteractions.at(-1)).toBe("reset");
   });
 
   test("preserves a zoomed viewport when adaptive data refreshes its buffer", async () => {
@@ -786,6 +864,41 @@ describe("CompositeChart", () => {
     await act(async () => testSetup!.renderOnce());
 
     expect(testSetup.captureCharFrame()).not.toContain("Jan 9");
+  });
+
+  test("always treats horizontal control-wheel movement as a pan", async () => {
+    const interactions: string[] = [];
+    testSetup = await testRender(
+      <CaptureChartSurfaceProvider>
+        <CompositeChart
+          width={60}
+          height={12}
+          interactive
+          series={[twoSessionCandles()]}
+          panels={[{ id: "main" }]}
+          viewport={{
+            start: new Date("2025-01-03T13:30:00.000Z"),
+            end: new Date("2025-01-03T17:00:00.000Z"),
+          }}
+          onViewportChange={(_next, interaction) => interactions.push(interaction)}
+        />
+      </CaptureChartSurfaceProvider>,
+      { width: 62, height: 14 },
+    );
+
+    await act(async () => testSetup!.renderOnce());
+    await act(async () => {
+      capturedSurfaceProps!.onMouseScroll(pointerEvent(25, 3, {
+        ctrl: true,
+        scroll: { direction: "left", delta: 4 },
+      }));
+    });
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(interactions.at(-1)).toBe("pan");
   });
 
   test("keeps the date axis and mouse recovery when refreshed data misses the zoomed window", async () => {

--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -627,6 +627,7 @@ describe("CompositeChart", () => {
 
   test("keeps a panned viewport when backfill moves beyond the authored range", async () => {
     const viewportChanges: Array<{ start: string; end: string } | null> = [];
+    const viewportInteractions: string[] = [];
     let replacePoints: ((points: TimeSeriesPoint[]) => void) | null = null;
     const initialPoints = series(
       "price",
@@ -636,7 +637,9 @@ describe("CompositeChart", () => {
       [100, 101, 102, 103, 104, 105, 106, 107, 108],
     ).points;
     const olderPoints = Array.from({ length: 11 }, (_, index) => {
-      const date = new Date(Date.UTC(2024, 11, 25 + index));
+      const date = new Date(
+        Date.UTC(2024, 11, 25 + index) - (index === 10 ? 60_000 : 0),
+      );
       return { date, observedAt: date, value: 90 + index };
     });
     function Harness() {
@@ -657,9 +660,12 @@ describe("CompositeChart", () => {
               start: new Date("2025-01-06T00:00:00.000Z"),
               end: new Date("2025-01-09T00:00:00.000Z"),
             }}
-            onViewportChange={(next) => viewportChanges.push(next
-              ? { start: next.start.toISOString(), end: next.end.toISOString() }
-              : null)}
+            onViewportChange={(next, interaction) => {
+              viewportInteractions.push(interaction);
+              viewportChanges.push(next
+                ? { start: next.start.toISOString(), end: next.end.toISOString() }
+                : null);
+            }}
           />
         </InputHostProvider>
       );
@@ -685,7 +691,11 @@ describe("CompositeChart", () => {
       await testSetup!.renderOnce();
     });
 
-    expect(viewportChanges.at(-1)).toEqual(pannedViewport);
+    expect(viewportChanges.at(-1)).toEqual({
+      start: "2024-12-31T23:59:00.000Z",
+      end: "2025-01-03T23:59:00.000Z",
+    });
+    expect(viewportInteractions.at(-1)).toBe("sync");
     expect(testSetup.captureCharFrame()).not.toContain("No chart data");
     expect(testSetup.captureCharFrame()).not.toContain("Jan 9");
   });

--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -639,6 +639,39 @@ describe("CompositeChart", () => {
     expect(viewportChanges).not.toContain(null);
     expect(viewportChanges.at(-1)).toEqual(latestPan);
 
+    for (let index = 0; index < 32; index += 1) {
+      await act(async () => {
+        capturedSurfaceProps!.onMouseScroll(pointerEvent(25, 3, {
+          scroll: { direction: "up", delta: 100 },
+        }));
+      });
+      await act(async () => {
+        await testSetup!.renderOnce();
+        await testSetup!.renderOnce();
+      });
+    }
+    const boundaryViewport = viewportChanges.at(-1)!;
+    expect(boundaryViewport).not.toBeNull();
+
+    await act(async () => publishViewport!(boundaryViewport));
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+    const boundaryChangeCount = viewportChanges.length;
+
+    await act(async () => {
+      capturedSurfaceProps!.onMouseScroll(pointerEvent(25, 3, {
+        scroll: { direction: "up", delta: 100 },
+      }));
+    });
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+    expect(viewportChanges).toHaveLength(boundaryChangeCount);
+    expect(viewportChanges).not.toContain(null);
+
     await act(async () => publishExternalViewport!());
     await act(async () => {
       await testSetup!.renderOnce();

--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -25,6 +25,10 @@ import {
   type KeyEventLike,
 } from "../../../react/input";
 import { CompositeChart } from "./composite-chart";
+import {
+  resolveCompositeMinimumSpanMs,
+  zoomCompositeViewport,
+} from "./interactions";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let chartShortcut: ((event: KeyEventLike) => void) | null = null;
@@ -939,6 +943,114 @@ describe("CompositeChart", () => {
     await act(async () => testSetup!.renderOnce());
 
     expect(testSetup.captureCharFrame()).not.toContain("Jan 9");
+  });
+
+  test("uses a supplied market timeline to keep control-wheel zoom under the pointer", async () => {
+    const anchor = twoSessionCandles();
+    const display = {
+      ...anchor,
+      id: "secondary",
+      label: "Secondary",
+      timeBasis: undefined,
+    };
+    const viewport = {
+      start: new Date(anchor.points[0]!.date.getTime()),
+      end: new Date(anchor.points.at(-1)!.date.getTime()),
+    };
+    const viewportChanges: Array<{ start: string; end: string } | null> = [];
+    testSetup = await testRender(
+      <CaptureChartSurfaceProvider>
+        <CompositeChart
+          width={60}
+          height={12}
+          interactive
+          series={[display]}
+          timelineSeries={[anchor]}
+          panels={[{ id: "main" }]}
+          viewport={viewport}
+          onViewportChange={(next) => viewportChanges.push(next
+            ? { start: next.start.toISOString(), end: next.end.toISOString() }
+            : null)}
+        />
+      </CaptureChartSurfaceProvider>,
+      { width: 62, height: 14 },
+    );
+
+    await act(async () => testSetup!.renderOnce());
+    const pointerX = 35;
+    const plotWidth = capturedSurfaceNode!.width as number;
+    const minimumSpan = resolveCompositeMinimumSpanMs([display], viewport);
+    const expected = zoomCompositeViewport(
+      viewport,
+      viewport,
+      1 + 4 * 0.04,
+      pointerX / Math.max(plotWidth - 1, 1),
+      minimumSpan,
+      [anchor],
+    );
+
+    await act(async () => {
+      capturedSurfaceProps!.onMouseScroll(pointerEvent(pointerX, 3, {
+        ctrl: true,
+        scroll: { direction: "up", delta: 4 },
+      }));
+    });
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(viewportChanges.at(-1)).toEqual({
+      start: expected.start.toISOString(),
+      end: expected.end.toISOString(),
+    });
+  });
+
+  test("clears a drag interaction when the pointer returns to the authored viewport", async () => {
+    const viewportChanges: Array<{ start: string; end: string } | null> = [];
+    const interactions: string[] = [];
+    testSetup = await testRender(
+      <CaptureChartSurfaceProvider>
+        <CompositeChart
+          width={60}
+          height={12}
+          interactive
+          series={[series("price", "main", "left", "USD", [100, 101, 102, 103, 104, 105, 106, 107, 108])]}
+          panels={[{ id: "main" }]}
+          viewport={{
+            start: new Date("2025-01-05T00:00:00.000Z"),
+            end: new Date("2025-01-09T00:00:00.000Z"),
+          }}
+          onViewportChange={(next, interaction) => {
+            interactions.push(interaction);
+            viewportChanges.push(next
+              ? { start: next.start.toISOString(), end: next.end.toISOString() }
+              : null);
+          }}
+        />
+      </CaptureChartSurfaceProvider>,
+      { width: 62, height: 14 },
+    );
+
+    await act(async () => testSetup!.renderOnce());
+    await act(async () => {
+      capturedSurfaceProps!.onMouseDown(pointerEvent(20, 3));
+      capturedSurfaceProps!.onMouseDrag(pointerEvent(30, 3));
+    });
+    await act(async () => testSetup!.renderOnce());
+    expect(viewportChanges.at(-1)).not.toBeNull();
+
+    await act(async () => {
+      capturedSurfaceProps!.onMouseDrag(pointerEvent(20, 3));
+      capturedSurfaceProps!.onMouseUp(pointerEvent(20, 3));
+    });
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(viewportChanges.at(-1)).toBeNull();
+    expect(interactions.at(-1)).toBe("pan");
   });
 
   test("always treats horizontal control-wheel movement as a pan", async () => {

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -787,20 +787,6 @@ export function CompositeChart({
         : Math.min(current, visibleLegendSeries.length - 1)
     ));
   }, [visibleLegendSeries.length]);
-  const navigationBounds = useMemo(
-    () => resolveCompositeNavigationBounds(visibleSeries, viewport),
-    [viewport, visibleSeries],
-  );
-  const initialViewport = useMemo(() => (
-    navigationBounds
-      ? viewport
-        ? clampCompositeViewport(viewport, navigationBounds)
-        : navigationBounds
-      : null
-  ), [navigationBounds, viewport]);
-  const viewportSeriesKey = visibleLegendSeries
-    .map((entry) => `${entry.id}:${entry.label}`)
-    .join("|");
   const previousAuthoredViewportRef = useRef<CompositeViewportRange | null>(viewport ?? null);
   const previousViewportResetKeyRef = useRef(viewportResetKey);
   const [interactionViewport, setInteractionViewport] = useState<CompositeViewportRange | null>(null);
@@ -812,6 +798,23 @@ export function CompositeChart({
         previousAuthoredViewportRef.current,
         viewport ?? null,
       );
+  const navigationAnchorViewport = authoredViewportChanged
+    ? viewport
+    : interactionViewport ?? viewport;
+  const navigationBounds = useMemo(
+    () => resolveCompositeNavigationBounds(visibleSeries, navigationAnchorViewport),
+    [navigationAnchorViewport, visibleSeries],
+  );
+  const initialViewport = useMemo(() => (
+    navigationBounds
+      ? viewport
+        ? clampCompositeViewport(viewport, navigationBounds)
+        : navigationBounds
+      : null
+  ), [navigationBounds, viewport]);
+  const viewportSeriesKey = visibleLegendSeries
+    .map((entry) => `${entry.id}:${entry.label}`)
+    .join("|");
   const currentInteractionViewport = authoredViewportChanged
     ? null
     : interactionViewport && navigationBounds

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -81,6 +81,12 @@ import type {
 const DESKTOP_BITMAP_RESIZE_DEBOUNCE_MS = 32;
 const LEGEND_WHEEL_DELTA_PER_CELL = 8;
 
+function isVerticalWheelDirection(
+  direction: "up" | "down" | "left" | "right",
+): direction is "up" | "down" {
+  return direction === "up" || direction === "down";
+}
+
 function renderPanelBitmap(
   panel: CompositePanelScene,
   bitmapSize: StaticChartBitmapSize,
@@ -403,8 +409,8 @@ function CompositePanelSurface({
     consumeChartMouseEvent(event);
     const pointerTarget = plotRef.current as unknown as Parameters<typeof getLocalPlotPointer>[1];
     const pointer = getLocalPlotPointer(event, pointerTarget, renderer);
-    if (event.modifiers.ctrl && pointer) {
-      const zoomIn = direction === "up" || direction === "left";
+    if (event.modifiers.ctrl && pointer && isVerticalWheelDirection(direction)) {
+      const zoomIn = direction === "up";
       const magnitude = Math.min(Math.max(Math.abs(event.scroll?.delta ?? 1), 1), 8);
       const pointerRatio = pointer.cellX / Math.max(plotWidth - 1, 1);
       const anchorDate = resolveCompositeCursorDate(scene, pointer.cellX);
@@ -819,6 +825,7 @@ export function CompositeChart({
   const interactionViewportStart = currentInteractionViewport?.start.getTime() ?? null;
   const interactionViewportEnd = currentInteractionViewport?.end.getTime() ?? null;
   const lastReportedViewportRef = useRef<string | null>(null);
+  const viewportInteractionRef = useRef<"pan" | "reset" | "zoom">("reset");
   useEffect(() => {
     if (!onViewportChange) return;
     const interactionKey = interactionViewportStart === null || interactionViewportEnd === null
@@ -840,6 +847,7 @@ export function CompositeChart({
             start: new Date(interactionViewportStart),
             end: new Date(interactionViewportEnd),
           },
+      viewportInteractionRef.current,
     );
   }, [interactionViewportEnd, interactionViewportStart, onViewportChange, viewportSeriesKey]);
   const minimumViewportSpanMs = useMemo(
@@ -854,6 +862,7 @@ export function CompositeChart({
       authoredViewportChanged
       || (interactionViewport && !navigationBounds)
     ) {
+      viewportInteractionRef.current = "reset";
       setInteractionViewport(null);
       return;
     }
@@ -873,6 +882,7 @@ export function CompositeChart({
 
   const zoomViewport = useCallback((zoomFactor: number, anchorRatio = 1) => {
     if (!navigationBounds || !initialViewport) return;
+    viewportInteractionRef.current = "zoom";
     setInteractionViewport((current) => {
       const base = current ?? initialViewport;
       const next = zoomCompositeViewport(
@@ -892,6 +902,7 @@ export function CompositeChart({
     fromViewport?: CompositeViewportRange,
   ) => {
     if (!navigationBounds || !initialViewport) return;
+    viewportInteractionRef.current = "pan";
     setInteractionViewport((current) => {
       const base = fromViewport ?? current ?? initialViewport;
       const next = panCompositeViewport(base, navigationBounds, shiftRatio, visibleSeries);
@@ -900,6 +911,7 @@ export function CompositeChart({
     });
   }, [initialViewport, navigationBounds, visibleSeries]);
   const resetViewport = useCallback(() => {
+    viewportInteractionRef.current = "reset";
     setInteractionViewport(null);
   }, []);
   const hasLeftAxis = visibleSeries.some((entry) => entry.axis === "left");
@@ -929,8 +941,8 @@ export function CompositeChart({
     width: 1,
     height: Math.max(panelCount, 1),
     viewport: effectiveViewport ?? undefined,
-    timelineSeries: visibleLegendSeries,
-  }), [effectiveViewport, panelCount, panels, visibleLegendSeries, visibleSeries]);
+    timelineSeries: visibleSeries,
+  }), [effectiveViewport, panelCount, panels, visibleSeries]);
   const layoutPanels = useMemo<CompositePanelScene[] | null>(() => {
     if (!projectedScene) return null;
     const panelSpecById = new Map(panels.map((panel) => [panel.id, panel] as const));
@@ -972,8 +984,8 @@ export function CompositeChart({
     if (!interactive || !navigationBounds || !direction) return;
     onActivate?.();
     consumeChartMouseEvent(event);
-    if (event.modifiers.ctrl) {
-      const zoomIn = direction === "up" || direction === "left";
+    if (event.modifiers.ctrl && isVerticalWheelDirection(direction)) {
+      const zoomIn = direction === "up";
       if (!zoomIn) {
         resetViewport();
         return;

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -883,7 +883,8 @@ export function CompositeChart({
         minimumViewportSpanMs,
         visibleSeries,
       );
-      return sameCompositeViewport(next, initialViewport) ? null : next;
+      if (sameCompositeViewport(next, base)) return current;
+      return current === null && sameCompositeViewport(next, initialViewport) ? null : next;
     });
   }, [initialViewport, minimumViewportSpanMs, navigationBounds, visibleSeries]);
   const panViewport = useCallback((
@@ -894,7 +895,8 @@ export function CompositeChart({
     setInteractionViewport((current) => {
       const base = fromViewport ?? current ?? initialViewport;
       const next = panCompositeViewport(base, navigationBounds, shiftRatio, visibleSeries);
-      return sameCompositeViewport(next, initialViewport) ? null : next;
+      if (sameCompositeViewport(next, base)) return current;
+      return current === null && sameCompositeViewport(next, initialViewport) ? null : next;
     });
   }, [initialViewport, navigationBounds, visibleSeries]);
   const resetViewport = useCallback(() => {

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -80,6 +80,13 @@ import type {
 // live-data paints or depending on a foreground animation frame.
 const DESKTOP_BITMAP_RESIZE_DEBOUNCE_MS = 32;
 const LEGEND_WHEEL_DELTA_PER_CELL = 8;
+const MAX_PENDING_VIEWPORT_ECHOES = 8;
+
+function viewportRangeKey(viewport: CompositeViewportRange | null): string {
+  return viewport
+    ? `${viewport.start.getTime()}:${viewport.end.getTime()}`
+    : "none";
+}
 
 function renderPanelBitmap(
   panel: CompositePanelScene,
@@ -791,16 +798,19 @@ export function CompositeChart({
         : navigationBounds
       : null
   ), [navigationBounds, viewport]);
+  const viewportSeriesKey = visibleLegendSeries
+    .map((entry) => `${entry.id}:${entry.label}`)
+    .join("|");
   const previousAuthoredViewportRef = useRef<CompositeViewportRange | null>(viewport ?? null);
   const [interactionViewport, setInteractionViewport] = useState<CompositeViewportRange | null>(null);
+  const pendingViewportEchoesRef = useRef(new Set<string>());
   const authoredViewportChanged = shouldResetCompositeViewport(
     previousAuthoredViewportRef.current,
     viewport ?? null,
   );
-  const authoredViewportEchoesInteraction = interactionViewport !== null
-    && viewport !== null
-    && viewport !== undefined
-    && sameCompositeViewport(interactionViewport, viewport);
+  const authoredViewportKey = `${viewportSeriesKey}|${viewportRangeKey(viewport ?? null)}`;
+  const authoredViewportEchoesInteraction = authoredViewportChanged
+    && pendingViewportEchoesRef.current.has(authoredViewportKey);
   const resetInteractionForAuthoredViewport = authoredViewportChanged
     && !authoredViewportEchoesInteraction;
   const currentInteractionViewport = resetInteractionForAuthoredViewport
@@ -815,16 +825,13 @@ export function CompositeChart({
     : null;
   const interactionViewportStart = currentInteractionViewport?.start.getTime() ?? null;
   const interactionViewportEnd = currentInteractionViewport?.end.getTime() ?? null;
-  const viewportSeriesKey = visibleLegendSeries
-    .map((entry) => `${entry.id}:${entry.label}`)
-    .join("|");
   const lastReportedViewportRef = useRef<string | null>(null);
   useEffect(() => {
     if (!onViewportChange) return;
-    const viewportKey = interactionViewportStart === null || interactionViewportEnd === null
+    const interactionKey = interactionViewportStart === null || interactionViewportEnd === null
       ? "none"
       : `${interactionViewportStart}:${interactionViewportEnd}`;
-    const key = `${viewportSeriesKey}|${viewportKey}`;
+    const key = `${viewportSeriesKey}|${interactionKey}`;
     // The callback drives adaptive data loading. Seed it from the authored
     // viewport without echoing that controlled value back into the loader.
     if (lastReportedViewportRef.current === null) {
@@ -833,6 +840,16 @@ export function CompositeChart({
     }
     if (lastReportedViewportRef.current === key) return;
     lastReportedViewportRef.current = key;
+    if (interactionKey === "none") {
+      pendingViewportEchoesRef.current.clear();
+    } else {
+      pendingViewportEchoesRef.current.add(key);
+      while (pendingViewportEchoesRef.current.size > MAX_PENDING_VIEWPORT_ECHOES) {
+        const oldest = pendingViewportEchoesRef.current.values().next().value;
+        if (!oldest) break;
+        pendingViewportEchoesRef.current.delete(oldest);
+      }
+    }
     onViewportChange(
       interactionViewportStart === null || interactionViewportEnd === null
         ? null
@@ -849,6 +866,13 @@ export function CompositeChart({
 
   useEffect(() => {
     previousAuthoredViewportRef.current = viewport ?? null;
+    if (authoredViewportChanged) {
+      if (authoredViewportEchoesInteraction) {
+        pendingViewportEchoesRef.current.delete(authoredViewportKey);
+      } else {
+        pendingViewportEchoesRef.current.clear();
+      }
+    }
     if (
       resetInteractionForAuthoredViewport
       || (interactionViewport && !navigationBounds)
@@ -863,6 +887,9 @@ export function CompositeChart({
       }
     }
   }, [
+    authoredViewportChanged,
+    authoredViewportEchoesInteraction,
+    authoredViewportKey,
     interactionViewport,
     navigationBounds,
     resetInteractionForAuthoredViewport,

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -815,11 +815,15 @@ export function CompositeChart({
   const viewportSeriesKey = visibleLegendSeries
     .map((entry) => `${entry.id}:${entry.label}`)
     .join("|");
+  const clampedInteractionViewport = interactionViewport && navigationBounds
+    ? clampCompositeViewport(interactionViewport, navigationBounds)
+    : interactionViewport;
+  const interactionViewportNeedsSync = !!interactionViewport
+    && !!clampedInteractionViewport
+    && !sameCompositeViewport(interactionViewport, clampedInteractionViewport);
   const currentInteractionViewport = authoredViewportChanged
     ? null
-    : interactionViewport && navigationBounds
-      ? clampCompositeViewport(interactionViewport, navigationBounds)
-      : interactionViewport;
+    : clampedInteractionViewport;
   const effectiveViewport = navigationBounds
     ? currentInteractionViewport
       ? clampCompositeViewport(currentInteractionViewport, navigationBounds)
@@ -828,9 +832,10 @@ export function CompositeChart({
   const interactionViewportStart = currentInteractionViewport?.start.getTime() ?? null;
   const interactionViewportEnd = currentInteractionViewport?.end.getTime() ?? null;
   const lastReportedViewportRef = useRef<string | null>(null);
-  const viewportInteractionRef = useRef<"pan" | "reset" | "zoom">("reset");
+  const viewportInteractionRef = useRef<"pan" | "reset" | "sync" | "zoom">("reset");
   useEffect(() => {
     if (!onViewportChange) return;
+    if (interactionViewportNeedsSync) return;
     const interactionKey = interactionViewportStart === null || interactionViewportEnd === null
       ? "none"
       : `${interactionViewportStart}:${interactionViewportEnd}`;
@@ -852,7 +857,13 @@ export function CompositeChart({
           },
       viewportInteractionRef.current,
     );
-  }, [interactionViewportEnd, interactionViewportStart, onViewportChange, viewportSeriesKey]);
+  }, [
+    interactionViewportEnd,
+    interactionViewportNeedsSync,
+    interactionViewportStart,
+    onViewportChange,
+    viewportSeriesKey,
+  ]);
   const minimumViewportSpanMs = useMemo(
     () => navigationBounds ? resolveCompositeMinimumSpanMs(visibleSeries, navigationBounds) : 1,
     [navigationBounds, visibleSeries],
@@ -869,15 +880,15 @@ export function CompositeChart({
       setInteractionViewport(null);
       return;
     }
-    if (interactionViewport && navigationBounds) {
-      const clamped = clampCompositeViewport(interactionViewport, navigationBounds);
-      if (!sameCompositeViewport(clamped, interactionViewport)) {
-        setInteractionViewport(clamped);
-      }
+    if (interactionViewportNeedsSync && clampedInteractionViewport) {
+      viewportInteractionRef.current = "sync";
+      setInteractionViewport(clampedInteractionViewport);
     }
   }, [
     authoredViewportChanged,
+    clampedInteractionViewport,
     interactionViewport,
+    interactionViewportNeedsSync,
     navigationBounds,
     viewport,
     viewportResetKey,

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -907,7 +907,7 @@ export function CompositeChart({
         marketTimelineSeries,
       );
       if (sameCompositeViewport(next, base)) return current;
-      return current === null && sameCompositeViewport(next, initialViewport) ? null : next;
+      return sameCompositeViewport(next, initialViewport) ? null : next;
     });
   }, [initialViewport, marketTimelineSeries, minimumViewportSpanMs, navigationBounds]);
   const panViewport = useCallback((

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -80,13 +80,6 @@ import type {
 // live-data paints or depending on a foreground animation frame.
 const DESKTOP_BITMAP_RESIZE_DEBOUNCE_MS = 32;
 const LEGEND_WHEEL_DELTA_PER_CELL = 8;
-const MAX_PENDING_VIEWPORT_ECHOES = 8;
-
-function viewportRangeKey(viewport: CompositeViewportRange | null): string {
-  return viewport
-    ? `${viewport.start.getTime()}:${viewport.end.getTime()}`
-    : "none";
-}
 
 function renderPanelBitmap(
   panel: CompositePanelScene,
@@ -750,6 +743,7 @@ export function CompositeChart({
   focused = false,
   cursorDate,
   viewport,
+  viewportResetKey,
   colors,
   interactive = true,
   axisWidth = 9,
@@ -802,18 +796,17 @@ export function CompositeChart({
     .map((entry) => `${entry.id}:${entry.label}`)
     .join("|");
   const previousAuthoredViewportRef = useRef<CompositeViewportRange | null>(viewport ?? null);
+  const previousViewportResetKeyRef = useRef(viewportResetKey);
   const [interactionViewport, setInteractionViewport] = useState<CompositeViewportRange | null>(null);
-  const pendingViewportEchoesRef = useRef(new Set<string>());
-  const authoredViewportChanged = shouldResetCompositeViewport(
-    previousAuthoredViewportRef.current,
-    viewport ?? null,
-  );
-  const authoredViewportKey = `${viewportSeriesKey}|${viewportRangeKey(viewport ?? null)}`;
-  const authoredViewportEchoesInteraction = authoredViewportChanged
-    && pendingViewportEchoesRef.current.has(authoredViewportKey);
-  const resetInteractionForAuthoredViewport = authoredViewportChanged
-    && !authoredViewportEchoesInteraction;
-  const currentInteractionViewport = resetInteractionForAuthoredViewport
+  const hasViewportResetKey = viewportResetKey !== undefined
+    || previousViewportResetKeyRef.current !== undefined;
+  const authoredViewportChanged = hasViewportResetKey
+    ? previousViewportResetKeyRef.current !== viewportResetKey
+    : shouldResetCompositeViewport(
+        previousAuthoredViewportRef.current,
+        viewport ?? null,
+      );
+  const currentInteractionViewport = authoredViewportChanged
     ? null
     : interactionViewport && navigationBounds
       ? clampCompositeViewport(interactionViewport, navigationBounds)
@@ -840,16 +833,6 @@ export function CompositeChart({
     }
     if (lastReportedViewportRef.current === key) return;
     lastReportedViewportRef.current = key;
-    if (interactionKey === "none") {
-      pendingViewportEchoesRef.current.clear();
-    } else {
-      pendingViewportEchoesRef.current.add(key);
-      while (pendingViewportEchoesRef.current.size > MAX_PENDING_VIEWPORT_ECHOES) {
-        const oldest = pendingViewportEchoesRef.current.values().next().value;
-        if (!oldest) break;
-        pendingViewportEchoesRef.current.delete(oldest);
-      }
-    }
     onViewportChange(
       interactionViewportStart === null || interactionViewportEnd === null
         ? null
@@ -866,15 +849,9 @@ export function CompositeChart({
 
   useEffect(() => {
     previousAuthoredViewportRef.current = viewport ?? null;
-    if (authoredViewportChanged) {
-      if (authoredViewportEchoesInteraction) {
-        pendingViewportEchoesRef.current.delete(authoredViewportKey);
-      } else {
-        pendingViewportEchoesRef.current.clear();
-      }
-    }
+    previousViewportResetKeyRef.current = viewportResetKey;
     if (
-      resetInteractionForAuthoredViewport
+      authoredViewportChanged
       || (interactionViewport && !navigationBounds)
     ) {
       setInteractionViewport(null);
@@ -888,12 +865,10 @@ export function CompositeChart({
     }
   }, [
     authoredViewportChanged,
-    authoredViewportEchoesInteraction,
-    authoredViewportKey,
     interactionViewport,
     navigationBounds,
-    resetInteractionForAuthoredViewport,
     viewport,
+    viewportResetKey,
   ]);
 
   const zoomViewport = useCallback((zoomFactor: number, anchorRatio = 1) => {

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -413,17 +413,9 @@ function CompositePanelSurface({
       const zoomIn = direction === "up";
       const magnitude = Math.min(Math.max(Math.abs(event.scroll?.delta ?? 1), 1), 8);
       const pointerRatio = pointer.cellX / Math.max(plotWidth - 1, 1);
-      const anchorDate = resolveCompositeCursorDate(scene, pointer.cellX);
-      const viewportSpan = Math.max(viewport.end.getTime() - viewport.start.getTime(), 1);
-      const viewportAnchorRatio = anchorDate
-        ? Math.max(0, Math.min(
-            1,
-            (anchorDate.getTime() - viewport.start.getTime()) / viewportSpan,
-          ))
-        : pointerRatio;
       onZoomViewport(
         zoomIn ? 1 + magnitude * 0.04 : 1 / (1 + magnitude * 0.04),
-        viewportAnchorRatio,
+        pointerRatio,
       );
       updateCursor(event);
       return;
@@ -743,6 +735,7 @@ function CompositeLegend({
 export function CompositeChart({
   series,
   legendSeries,
+  timelineSeries,
   panels,
   width,
   height,
@@ -772,6 +765,12 @@ export function CompositeChart({
   const totalWidth = Math.max(1, Math.floor(width));
   const totalHeight = Math.max(1, Math.floor(height));
   const visibleSeries = useMemo(() => series.filter((entry) => entry.points.length > 0), [series]);
+  const marketTimelineSeries = useMemo(() => {
+    const supplied = timelineSeries?.filter((entry) => entry.points.length > 0) ?? [];
+    return supplied.some((entry) => entry.timeBasis?.kind === "market")
+      ? supplied
+      : visibleSeries;
+  }, [timelineSeries, visibleSeries]);
   const visibleLegendSeries = useMemo(
     () => (legendSeries ?? visibleSeries).filter((entry) => entry.points.length > 0),
     [legendSeries, visibleSeries],
@@ -905,12 +904,12 @@ export function CompositeChart({
         zoomFactor,
         anchorRatio,
         minimumViewportSpanMs,
-        visibleSeries,
+        marketTimelineSeries,
       );
       if (sameCompositeViewport(next, base)) return current;
       return current === null && sameCompositeViewport(next, initialViewport) ? null : next;
     });
-  }, [initialViewport, minimumViewportSpanMs, navigationBounds, visibleSeries]);
+  }, [initialViewport, marketTimelineSeries, minimumViewportSpanMs, navigationBounds]);
   const panViewport = useCallback((
     shiftRatio: number,
     fromViewport?: CompositeViewportRange,
@@ -919,11 +918,14 @@ export function CompositeChart({
     viewportInteractionRef.current = "pan";
     setInteractionViewport((current) => {
       const base = fromViewport ?? current ?? initialViewport;
-      const next = panCompositeViewport(base, navigationBounds, shiftRatio, visibleSeries);
-      if (sameCompositeViewport(next, base)) return current;
-      return current === null && sameCompositeViewport(next, initialViewport) ? null : next;
+      const next = panCompositeViewport(base, navigationBounds, shiftRatio, marketTimelineSeries);
+      if (sameCompositeViewport(next, base)) {
+        if (!fromViewport) return current;
+        return sameCompositeViewport(base, initialViewport) ? null : base;
+      }
+      return sameCompositeViewport(next, initialViewport) ? null : next;
     });
-  }, [initialViewport, navigationBounds, visibleSeries]);
+  }, [initialViewport, marketTimelineSeries, navigationBounds]);
   const resetViewport = useCallback(() => {
     viewportInteractionRef.current = "reset";
     setInteractionViewport(null);
@@ -955,8 +957,8 @@ export function CompositeChart({
     width: 1,
     height: Math.max(panelCount, 1),
     viewport: effectiveViewport ?? undefined,
-    timelineSeries: visibleSeries,
-  }), [effectiveViewport, panelCount, panels, visibleSeries]);
+    timelineSeries: marketTimelineSeries,
+  }), [effectiveViewport, marketTimelineSeries, panelCount, panels, visibleSeries]);
   const layoutPanels = useMemo<CompositePanelScene[] | null>(() => {
     if (!projectedScene) return null;
     const panelSpecById = new Map(panels.map((panel) => [panel.id, panel] as const));

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -797,7 +797,13 @@ export function CompositeChart({
     previousAuthoredViewportRef.current,
     viewport ?? null,
   );
-  const currentInteractionViewport = authoredViewportChanged
+  const authoredViewportEchoesInteraction = interactionViewport !== null
+    && viewport !== null
+    && viewport !== undefined
+    && sameCompositeViewport(interactionViewport, viewport);
+  const resetInteractionForAuthoredViewport = authoredViewportChanged
+    && !authoredViewportEchoesInteraction;
+  const currentInteractionViewport = resetInteractionForAuthoredViewport
     ? null
     : interactionViewport && navigationBounds
       ? clampCompositeViewport(interactionViewport, navigationBounds)
@@ -842,12 +848,11 @@ export function CompositeChart({
   );
 
   useEffect(() => {
-    const authoredChanged = shouldResetCompositeViewport(
-      previousAuthoredViewportRef.current,
-      viewport ?? null,
-    );
     previousAuthoredViewportRef.current = viewport ?? null;
-    if (authoredChanged || (interactionViewport && !navigationBounds)) {
+    if (
+      resetInteractionForAuthoredViewport
+      || (interactionViewport && !navigationBounds)
+    ) {
       setInteractionViewport(null);
       return;
     }
@@ -857,7 +862,12 @@ export function CompositeChart({
         setInteractionViewport(clamped);
       }
     }
-  }, [interactionViewport, navigationBounds, viewport]);
+  }, [
+    interactionViewport,
+    navigationBounds,
+    resetInteractionForAuthoredViewport,
+    viewport,
+  ]);
 
   const zoomViewport = useCallback((zoomFactor: number, anchorRatio = 1) => {
     if (!navigationBounds || !initialViewport) return;

--- a/src/components/chart/composite/interactions.test.ts
+++ b/src/components/chart/composite/interactions.test.ts
@@ -11,6 +11,10 @@ import {
   zoomCompositeViewport,
   type CompositeViewportRange,
 } from "./interactions";
+import {
+  buildCompositeTimeScale,
+  projectCompositeTimestamp,
+} from "./time-scale";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -44,6 +48,27 @@ function viewport(startDay: number, endDay: number): CompositeViewportRange {
   };
 }
 
+function intradayMarketSeries(): ResolvedSeries {
+  const points: TimeSeriesPoint[] = [];
+  for (const day of [2, 3]) {
+    const sessionStart = Date.UTC(2025, 0, day, 13, 30);
+    for (let index = 0; index < 78; index += 1) {
+      const date = new Date(sessionStart + index * 5 * 60_000);
+      points.push({ date, observedAt: date, value: 100 + points.length });
+    }
+  }
+  return {
+    ...series([]),
+    nativeFrequency: "intraday",
+    timeBasis: {
+      kind: "market",
+      timeZone: "America/New_York",
+      cadenceMs: 5 * 60_000,
+    },
+    points,
+  };
+}
+
 describe("composite chart interactions", () => {
   test("zooms around the right edge and clamps zoom-out to loaded bounds", () => {
     const bounds = viewport(1, 11);
@@ -64,6 +89,29 @@ describe("composite chart interactions", () => {
 
     const clampedNewer = panCompositeViewport(visible, bounds, -10);
     expect(clampedNewer).toEqual(viewport(7, 11));
+  });
+
+  test("keeps the same market-slot span while panning across a closed session", () => {
+    const data = intradayMarketSeries();
+    const bounds = resolveCompositeNavigationBounds([data])!;
+    const visible = {
+      start: new Date("2025-01-03T13:30:00.000Z"),
+      end: new Date("2025-01-03T17:00:00.000Z"),
+    };
+    const panned = panCompositeViewport(visible, bounds, 0.5, [data]);
+    const scale = buildCompositeTimeScale(
+      [data],
+      bounds.start.getTime(),
+      bounds.end.getTime(),
+    );
+    const projectedSpan = (window: CompositeViewportRange) => (
+      projectCompositeTimestamp(scale, window.end.getTime())!.ratio
+      - projectCompositeTimestamp(scale, window.start.getTime())!.ratio
+    );
+
+    expect(panned.end.getTime() - panned.start.getTime())
+      .not.toBe(visible.end.getTime() - visible.start.getTime());
+    expect(Math.abs(projectedSpan(panned) - projectedSpan(visible))).toBeLessThan(1e-12);
   });
 
   test("uses representative cadence instead of a stray fine gap as the zoom floor", () => {

--- a/src/components/chart/composite/interactions.ts
+++ b/src/components/chart/composite/interactions.ts
@@ -1,4 +1,9 @@
 import type { ResolvedSeries } from "../../../time-series/types";
+import {
+  buildCompositeTimeScale,
+  projectCompositeTimestamp,
+  unprojectCompositeTimestamp,
+} from "./time-scale";
 
 export interface CompositeViewportRange {
   start: Date;
@@ -139,6 +144,47 @@ function clamp(value: number, minimum: number, maximum: number): number {
   return Math.max(minimum, Math.min(maximum, value));
 }
 
+function marketViewportProjection(
+  viewport: CompositeViewportRange,
+  bounds: CompositeViewportRange,
+  series: ResolvedSeries[] | undefined,
+): {
+  scale: Extract<ReturnType<typeof buildCompositeTimeScale>, { kind: "market" }>;
+  startRatio: number;
+  endRatio: number;
+} | null {
+  if (!series?.some((entry) => entry.timeBasis?.kind === "market")) return null;
+  const scale = buildCompositeTimeScale(
+    series,
+    bounds.start.getTime(),
+    bounds.end.getTime(),
+  );
+  if (scale.kind !== "market") return null;
+  const startRatio = projectCompositeTimestamp(scale, viewport.start.getTime())?.ratio;
+  const endRatio = projectCompositeTimestamp(scale, viewport.end.getTime())?.ratio;
+  if (
+    typeof startRatio !== "number"
+    || !Number.isFinite(startRatio)
+    || typeof endRatio !== "number"
+    || !Number.isFinite(endRatio)
+    || startRatio >= endRatio
+  ) {
+    return null;
+  }
+  return { scale, startRatio, endRatio };
+}
+
+function viewportFromMarketRatios(
+  scale: Extract<ReturnType<typeof buildCompositeTimeScale>, { kind: "market" }>,
+  startRatio: number,
+  endRatio: number,
+): CompositeViewportRange {
+  return {
+    start: new Date(unprojectCompositeTimestamp(scale, startRatio)),
+    end: new Date(unprojectCompositeTimestamp(scale, endRatio)),
+  };
+}
+
 export function clampCompositeViewport(
   viewport: CompositeViewportRange,
   bounds: CompositeViewportRange,
@@ -186,17 +232,54 @@ export function zoomCompositeViewport(
   const end = current.end.getTime();
   const boundsSpan = Math.max(bounds.end.getTime() - bounds.start.getTime(), 1);
   const currentSpan = Math.max(end - start, 1);
-  const nextSpan = clamp(
-    currentSpan / zoomFactor,
-    Math.min(Math.max(minimumSpanMs, 1), boundsSpan),
-    boundsSpan,
-  );
   const ratio = clamp(anchorRatio, 0, 1);
-  const anchor = start + currentSpan * ratio;
-  const candidate = clampCompositeViewport({
-    start: new Date(anchor - nextSpan * ratio),
-    end: new Date(anchor + nextSpan * (1 - ratio)),
-  }, bounds);
+  const marketProjection = marketViewportProjection(current, bounds, series);
+  const candidate = marketProjection
+    ? (() => {
+        const {
+          scale,
+          startRatio,
+          endRatio,
+        } = marketProjection;
+        const currentMarketSpan = endRatio - startRatio;
+        const totalMarketPositions = Math.max(
+          scale.endPosition - scale.startPosition,
+          Number.EPSILON,
+        );
+        const minimumMarketSpan = clamp(
+          Math.max(minimumSpanMs, 1) / scale.cadenceMs / totalMarketPositions,
+          Number.EPSILON,
+          1,
+        );
+        const nextMarketSpan = clamp(
+          currentMarketSpan / zoomFactor,
+          minimumMarketSpan,
+          1,
+        );
+        const anchor = startRatio + currentMarketSpan * ratio;
+        const candidateStart = clamp(
+          anchor - nextMarketSpan * ratio,
+          0,
+          1 - nextMarketSpan,
+        );
+        return viewportFromMarketRatios(
+          scale,
+          candidateStart,
+          candidateStart + nextMarketSpan,
+        );
+      })()
+    : (() => {
+        const nextSpan = clamp(
+          currentSpan / zoomFactor,
+          Math.min(Math.max(minimumSpanMs, 1), boundsSpan),
+          boundsSpan,
+        );
+        const anchor = start + currentSpan * ratio;
+        return clampCompositeViewport({
+          start: new Date(anchor - nextSpan * ratio),
+          end: new Date(anchor + nextSpan * (1 - ratio)),
+        }, bounds);
+      })();
   if (!series) return candidate;
 
   const timestamps = pointTimestamps(series)
@@ -225,12 +308,30 @@ export function panCompositeViewport(
 ): CompositeViewportRange {
   const current = clampCompositeViewport(viewport, bounds);
   if (!Number.isFinite(shiftRatio) || shiftRatio === 0) return current;
-  const span = Math.max(current.end.getTime() - current.start.getTime(), 1);
-  const shift = span * shiftRatio;
-  const candidate = clampCompositeViewport({
-    start: new Date(current.start.getTime() - shift),
-    end: new Date(current.end.getTime() - shift),
-  }, bounds);
+  const marketProjection = marketViewportProjection(current, bounds, series);
+  const candidate = marketProjection
+    ? (() => {
+        const {
+          scale,
+          startRatio,
+          endRatio,
+        } = marketProjection;
+        const span = endRatio - startRatio;
+        const nextStart = clamp(
+          startRatio - span * shiftRatio,
+          0,
+          1 - span,
+        );
+        return viewportFromMarketRatios(scale, nextStart, nextStart + span);
+      })()
+    : (() => {
+        const span = Math.max(current.end.getTime() - current.start.getTime(), 1);
+        const shift = span * shiftRatio;
+        return clampCompositeViewport({
+          start: new Date(current.start.getTime() - shift),
+          end: new Date(current.end.getTime() - shift),
+        }, bounds);
+      })();
   if (!series) return candidate;
 
   const timestamps = pointTimestamps(series)

--- a/src/components/chart/composite/types.ts
+++ b/src/components/chart/composite/types.ts
@@ -115,6 +115,8 @@ export interface CompositeChartProps {
   series: ResolvedSeries[];
   /** Optional legend model; can include hidden series that are not plotted. */
   legendSeries?: ResolvedSeries[];
+  /** Optional hidden market series used to preserve session-time navigation. */
+  timelineSeries?: ResolvedSeries[];
   panels: ChartPanelSpec[];
   width: number;
   height: number;

--- a/src/components/chart/composite/types.ts
+++ b/src/components/chart/composite/types.ts
@@ -125,6 +125,11 @@ export interface CompositeChartProps {
     start: Date;
     end: Date;
   };
+  /**
+   * Stable identity for the authored viewport. Changing it resets user navigation;
+   * viewport updates under the same key are treated as adaptive data refreshes.
+   */
+  viewportResetKey?: string;
   colors?: Partial<CompositeChartColors>;
   axisWidth?: number;
   showLegend?: boolean;

--- a/src/components/chart/composite/types.ts
+++ b/src/components/chart/composite/types.ts
@@ -140,7 +140,10 @@ export interface CompositeChartProps {
   formatValue?: (value: number, series: ResolvedSeries) => string;
   onCursorDateChange?: (date: Date | null) => void;
   /** Reports a user-created viewport, or null when the user resets to the authored viewport. */
-  onViewportChange?: (viewport: { start: Date; end: Date } | null) => void;
+  onViewportChange?: (
+    viewport: { start: Date; end: Date } | null,
+    interaction: "pan" | "reset" | "zoom",
+  ) => void;
   onActivate?: () => void;
   onToggleSeries?: (seriesId: string) => void;
   isSeriesToggleable?: (series: ResolvedSeries) => boolean;

--- a/src/components/chart/composite/types.ts
+++ b/src/components/chart/composite/types.ts
@@ -142,7 +142,7 @@ export interface CompositeChartProps {
   /** Reports a user-created viewport, or null when the user resets to the authored viewport. */
   onViewportChange?: (
     viewport: { start: Date; end: Date } | null,
-    interaction: "pan" | "reset" | "zoom",
+    interaction: "pan" | "reset" | "sync" | "zoom",
   ) => void;
   onActivate?: () => void;
   onToggleSeries?: (seriesId: string) => void;

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -566,6 +566,7 @@ function ChartComposerSurface({
           legendSeries={resolution.legendSeries}
           panels={spec.panels}
           viewport={viewport}
+          viewportResetKey={authoredViewportKey}
           width={Math.max(1, width)}
           height={Math.max(4, height - 1)}
           focused={focused}

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -41,6 +41,7 @@ import {
   buildPriceChartPreset,
   applySeriesStyle,
   chartSeriesLabel,
+  defaultFinancialTimestampMode,
   getSelectedBuiltinStudies,
   getSelectedPairStudies,
   setBuiltinStudies,
@@ -118,6 +119,9 @@ function ChartComposerSurface({
           entry.source.instrument.exchange ?? "",
           entry.source.fieldId,
           entry.source.period ?? "auto",
+          entry.source.timestampMode
+            ?? defaultFinancialTimestampMode(entry.source.fieldId)
+            ?? "",
         ]
       : [entry.id, entry.source.kind, entry.source.seriesId]),
   }), [spec.series, spec.viewport.dateWindow, spec.viewport.range, spec.viewport.resolution]);

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -69,6 +69,11 @@ const RESOLUTION_TABS_WIDTH = RESOLUTION_TABS.reduce(
 );
 const AUTO_VIEWPORT_DEBOUNCE_MS = 350;
 
+interface RuntimeChartViewport {
+  start: Date;
+  end: Date;
+}
+
 function footerAnchorPoint(event?: PaneFooterPressEvent): { x: number; y: number } | undefined {
   const x = event?.pixelX;
   const y = event?.pixelY;
@@ -125,17 +130,25 @@ function ChartComposerSurface({
         ]
       : [entry.id, entry.source.kind, entry.source.seriesId]),
   }), [spec.series, spec.viewport.dateWindow, spec.viewport.range, spec.viewport.resolution]);
-  const [autoViewportState, setAutoViewportState] = useState<{
+  const [runtimeViewportState, setRuntimeViewportState] = useState<{
     key: string;
-    viewport: { start: Date; end: Date };
+    adaptiveViewport: RuntimeChartViewport | null;
+    requestViewport: RuntimeChartViewport;
   } | null>(null);
-  const autoViewportTimerRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
-  const autoViewport = autoViewportState?.key === authoredViewportKey
-    && spec.viewport.resolution === "auto"
-    ? autoViewportState.viewport
+  const runtimeViewportTimerRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
+  const adaptiveViewportRef = useRef<RuntimeChartViewport | null>(null);
+  const requestViewportRef = useRef<RuntimeChartViewport | null>(null);
+  const activeRuntimeViewport = runtimeViewportState?.key === authoredViewportKey
+    ? runtimeViewportState
     : null;
   const targetPointCount = Math.max(60, Math.floor(width * 1.25));
-  const resolution = useResolvedChartSpec(spec, { autoViewport, targetPointCount });
+  const resolution = useResolvedChartSpec(spec, {
+    autoViewport: spec.viewport.resolution === "auto"
+      ? activeRuntimeViewport?.adaptiveViewport
+      : null,
+    requestViewport: activeRuntimeViewport?.requestViewport,
+    targetPointCount,
+  });
   const selectedStudies = getSelectedBuiltinStudies(spec);
   const selectedPairStudies = getSelectedPairStudies(spec);
   const inlineStyleTarget = useMemo(() => getChartInlineStyleTarget(spec), [spec]);
@@ -188,15 +201,17 @@ function ChartComposerSurface({
     if (!focused) dispatch({ type: "FOCUS_PANE", paneId });
   }, [dispatch, focused, paneId]);
   useEffect(() => {
-    if (autoViewportTimerRef.current !== null) {
-      clearTimeout(autoViewportTimerRef.current);
-      autoViewportTimerRef.current = null;
+    if (runtimeViewportTimerRef.current !== null) {
+      clearTimeout(runtimeViewportTimerRef.current);
+      runtimeViewportTimerRef.current = null;
     }
-    setAutoViewportState((current) => current?.key === authoredViewportKey ? current : null);
+    adaptiveViewportRef.current = null;
+    requestViewportRef.current = null;
+    setRuntimeViewportState((current) => current?.key === authoredViewportKey ? current : null);
     return () => {
-      if (autoViewportTimerRef.current !== null) {
-        clearTimeout(autoViewportTimerRef.current);
-        autoViewportTimerRef.current = null;
+      if (runtimeViewportTimerRef.current !== null) {
+        clearTimeout(runtimeViewportTimerRef.current);
+        runtimeViewportTimerRef.current = null;
       }
     };
   }, [authoredViewportKey]);
@@ -204,30 +219,36 @@ function ChartComposerSurface({
     next: { start: Date; end: Date } | null,
     interaction: "pan" | "reset" | "zoom",
   ) => {
-    if (interaction === "pan") return;
-    if (autoViewportTimerRef.current !== null) {
-      clearTimeout(autoViewportTimerRef.current);
-      autoViewportTimerRef.current = null;
+    if (runtimeViewportTimerRef.current !== null) {
+      clearTimeout(runtimeViewportTimerRef.current);
+      runtimeViewportTimerRef.current = null;
     }
-    if (spec.viewport.resolution !== "auto" || !next) {
-      setAutoViewportState(null);
+    if (!next) {
+      adaptiveViewportRef.current = null;
+      requestViewportRef.current = null;
+      setRuntimeViewportState(null);
       return;
     }
     const start = next.start.getTime();
     const end = next.end.getTime();
     if (!Number.isFinite(start) || !Number.isFinite(end) || start > end) return;
-    autoViewportTimerRef.current = globalThis.setTimeout(() => {
-      autoViewportTimerRef.current = null;
-      setAutoViewportState((current) => (
-        current?.key === authoredViewportKey
-          && current.viewport.start.getTime() === start
-          && current.viewport.end.getTime() === end
-          ? current
-          : {
-              key: authoredViewportKey,
-              viewport: { start: new Date(start), end: new Date(end) },
-            }
-      ));
+    const viewport = { start: new Date(start), end: new Date(end) };
+    requestViewportRef.current = viewport;
+    if (interaction === "zoom" && spec.viewport.resolution === "auto") {
+      adaptiveViewportRef.current = viewport;
+    }
+    runtimeViewportTimerRef.current = globalThis.setTimeout(() => {
+      runtimeViewportTimerRef.current = null;
+      const requestViewport = requestViewportRef.current;
+      if (!requestViewport) return;
+      const adaptiveViewport = spec.viewport.resolution === "auto"
+        ? adaptiveViewportRef.current
+        : null;
+      setRuntimeViewportState({
+        key: authoredViewportKey,
+        adaptiveViewport,
+        requestViewport,
+      });
     }, AUTO_VIEWPORT_DEBOUNCE_MS);
   }, [authoredViewportKey, spec.viewport.resolution]);
 

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -116,6 +116,7 @@ function ChartComposerSurface({
     range: spec.viewport.range,
     resolution: spec.viewport.resolution,
     dateWindow: spec.viewport.dateWindow ?? null,
+    maxPoints: spec.viewport.maxPoints ?? null,
     sources: spec.series.map((entry) => entry.source.kind === "security"
       ? [
           entry.id,
@@ -129,7 +130,7 @@ function ChartComposerSurface({
             ?? "",
         ]
       : [entry.id, entry.source.kind, entry.source.seriesId]),
-  }), [spec.series, spec.viewport.dateWindow, spec.viewport.range, spec.viewport.resolution]);
+  }), [spec.series, spec.viewport.dateWindow, spec.viewport.maxPoints, spec.viewport.range, spec.viewport.resolution]);
   const [runtimeViewportState, setRuntimeViewportState] = useState<{
     key: string;
     adaptiveViewport: RuntimeChartViewport | null;
@@ -594,6 +595,7 @@ function ChartComposerSurface({
         <CompositeChart
           series={plottedSeries}
           legendSeries={resolution.legendSeries}
+          timelineSeries={resolution.timelineSeries}
           panels={spec.panels}
           viewport={viewport}
           viewportResetKey={authoredViewportKey}

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -217,8 +217,9 @@ function ChartComposerSurface({
   }, [authoredViewportKey]);
   const handleChartViewportChange = useCallback((
     next: { start: Date; end: Date } | null,
-    interaction: "pan" | "reset" | "zoom",
+    interaction: "pan" | "reset" | "sync" | "zoom",
   ) => {
+    if (interaction === "sync") return;
     if (runtimeViewportTimerRef.current !== null) {
       clearTimeout(runtimeViewportTimerRef.current);
       runtimeViewportTimerRef.current = null;

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -200,7 +200,11 @@ function ChartComposerSurface({
       }
     };
   }, [authoredViewportKey]);
-  const handleChartViewportChange = useCallback((next: { start: Date; end: Date } | null) => {
+  const handleChartViewportChange = useCallback((
+    next: { start: Date; end: Date } | null,
+    interaction: "pan" | "reset" | "zoom",
+  ) => {
+    if (interaction === "pan") return;
     if (autoViewportTimerRef.current !== null) {
       clearTimeout(autoViewportTimerRef.current);
       autoViewportTimerRef.current = null;

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -325,7 +325,7 @@ describe("resolveChartSpecData", () => {
     expect(requests).toEqual([{ range: "1W", resolution: "5m" }]);
   });
 
-  test("adapts Auto to a zoomed historical window without changing the authored viewport", async () => {
+  test("keeps Auto zoom selection while loading a separately panned history window", async () => {
     const detailedRequests: Array<{
       start: string;
       end: string;
@@ -377,6 +377,10 @@ describe("resolveChartSpecData", () => {
       new ChartResolveCache(),
       {
         autoViewport: {
+          start: new Date("2025-03-10T00:00:00.000Z"),
+          end: new Date("2025-03-17T00:00:00.000Z"),
+        },
+        requestViewport: {
           start: new Date("2025-01-10T00:00:00.000Z"),
           end: new Date("2025-01-17T00:00:00.000Z"),
         },

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -401,6 +401,64 @@ describe("resolveChartSpecData", () => {
     });
   });
 
+  test("keeps percent transforms and studies defined in a panned history window", async () => {
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => emptyFinancials(),
+      getDetailedPriceHistory: async () => [
+        { date: new Date("2024-10-15T16:00:00.000Z"), close: 100 },
+        { date: new Date("2024-10-16T16:00:00.000Z"), close: 110 },
+      ],
+    });
+    const spec: ChartSpec = {
+      version: CHART_SPEC_VERSION,
+      viewport: { range: "3M", resolution: "1d" },
+      panels: [{ id: "main" }],
+      series: [{
+        id: "price",
+        source: {
+          kind: "security",
+          instrument: { symbol: "TEST", exchange: "NASDAQ" },
+          fieldId: "market.close",
+        },
+        style: "line",
+        transform: "percent",
+        axis: "left",
+        panelId: "main",
+        interpolation: "none",
+      }],
+      studies: [{
+        id: "sma",
+        kind: "sma",
+        inputSeriesIds: ["price"],
+        parameters: { period: 2 },
+        panelId: "main",
+        axis: "left",
+      }],
+    };
+
+    const result = await resolveChartSpecData(
+      spec,
+      {
+        dataProvider: provider,
+        now: new Date("2025-04-01T00:00:00.000Z"),
+        loadFredSeries: async () => fredLoad(),
+      },
+      new ChartResolveCache(),
+      {
+        requestViewport: {
+          start: new Date("2024-10-10T00:00:00.000Z"),
+          end: new Date("2024-10-17T00:00:00.000Z"),
+        },
+      },
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.bufferedSeries?.find((series) => series.id === "price")?.points.map((point) => point.value))
+      .toEqual([0, 10]);
+    expect(result.bufferedSeries?.find((series) => series.id === "sma")?.points.map((point) => point.value))
+      .toEqual([5]);
+  });
+
   test("resolves unrelated price, filed fundamental, and economic series on one chart", async () => {
     const provider = createTestDataProvider({
       getTickerFinancials: async (symbol) => symbol === "MSFT"
@@ -890,6 +948,7 @@ describe("resolveChartSpecData", () => {
     expect(result.series[0]?.points.map((point) => point.value)).toEqual([15, 25]);
     expect(result.legendSeries?.find((series) => series.id === "price")?.timeBasis)
       .toMatchObject({ kind: "market", timeZone: "America/New_York" });
+    expect(result.timelineSeries?.map((series) => series.id)).toEqual(["price"]);
     expect(result.series[0]?.timeBasis)
       .toMatchObject({ kind: "market", timeZone: "America/New_York" });
   });

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -482,6 +482,7 @@ function prepareBaseSeriesForStudies(
   series: ResolvedSeries,
   bounds: DateBounds,
   clipToBounds = false,
+  fallbackBaselineBounds?: DateBounds,
 ): ResolvedSeries {
   const baselineTransform = series.transform === "percent" || series.transform === "index100";
   let source = series;
@@ -490,10 +491,14 @@ function prepareBaseSeriesForStudies(
   } else if (clipToBounds) {
     source = { ...series, points: filterPoints(series.points, bounds) };
   }
+  const baseline = baselineTransform
+    ? scalarBaseline(series, bounds)
+      ?? (fallbackBaselineBounds ? scalarBaseline(series, fallbackBaselineBounds) : null)
+    : null;
   return applyResolvedSeriesTransform(
     source,
     source.transform,
-    baselineTransform ? { baseline: scalarBaseline(series, bounds) } : undefined,
+    baselineTransform ? { baseline } : undefined,
   );
 }
 
@@ -531,6 +536,7 @@ function applyStudyPresentationTransforms(
   studies: readonly ChartSpec["studies"][number][],
   rawSeries: readonly ResolvedSeries[],
   visibleBounds: DateBounds,
+  fallbackBaselineBounds?: DateBounds,
 ): ResolvedSeries[] {
   const rawById = new Map(rawSeries.map((series) => [series.id, series] as const));
   return outputs.map((output) => {
@@ -542,6 +548,7 @@ function applyStudyPresentationTransforms(
     if (!input || input.transform === "raw") return output;
     const baseline = input.transform === "percent" || input.transform === "index100"
       ? scalarBaseline(input, visibleBounds)
+        ?? (fallbackBaselineBounds ? scalarBaseline(input, fallbackBaselineBounds) : null)
       : undefined;
     return applyResolvedSeriesTransform(output, input.transform, { baseline });
   });
@@ -764,6 +771,9 @@ export async function resolveChartSpecData(
   }));
 
   const rawSeries = loaded.filter((entry): entry is ResolvedSeries => !!entry);
+  const marketTimelineSeries = primaryMarketSeries?.visible === false
+    ? rawSeries.filter((entry) => entry.id === primaryMarketSeries.id)
+    : [];
   // Preset ranges describe a window ending at the requested reference time,
   // even when the newest filing or economic observation lags that endpoint.
   // Re-anchoring to the latest observation both mislabels the range and asks
@@ -773,7 +783,7 @@ export async function resolveChartSpecData(
   const studyBounds = initialCalculationBounds;
   const baseSeries = rawSeries
     .filter((entry) => visibleSeriesIds.has(entry.id))
-    .map((entry) => prepareBaseSeriesForStudies(entry, bounds));
+    .map((entry) => prepareBaseSeriesForStudies(entry, bounds, false, requestVisibleBounds));
   const calculationSeries = rawSeries.map((entry) => rawCalculationSeries(entry, studyBounds));
   let resolved = baseSeries;
 
@@ -782,7 +792,13 @@ export async function resolveChartSpecData(
     const studyResult = resolveStudies(calculationSeries, spec.studies);
     resolved = [
       ...resolved,
-      ...applyStudyPresentationTransforms(studyResult.series, spec.studies, rawSeries, bounds),
+      ...applyStudyPresentationTransforms(
+        studyResult.series,
+        spec.studies,
+        rawSeries,
+        bounds,
+        requestVisibleBounds,
+      ),
     ];
     warnings.push(...studyResult.warnings);
     errors.push(...studyResult.errors);
@@ -803,7 +819,7 @@ export async function resolveChartSpecData(
   const resolvedById = new Map(resolved.map((entry) => [entry.id, entry] as const));
   const hiddenBaseSeries = rawSeries
     .filter((entry) => !visibleSeriesIds.has(entry.id))
-    .map((entry) => prepareBaseSeriesForStudies(entry, bounds, true));
+    .map((entry) => prepareBaseSeriesForStudies(entry, bounds, true, requestVisibleBounds));
   const hiddenBaseById = new Map(hiddenBaseSeries.map((entry) => [entry.id, entry] as const));
   const legendSeries = [
     ...spec.series.flatMap((seriesSpec) => {
@@ -836,6 +852,7 @@ export async function resolveChartSpecData(
     series: resolved,
     legendSeries,
     ...(spec.viewport.maxPoints === undefined ? { bufferedSeries } : {}),
+    ...(marketTimelineSeries.length > 0 ? { timelineSeries: marketTimelineSeries } : {}),
     loading: false,
     errors,
     warnings: [...new Set([...priorityWarnings, ...warnings])],

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -75,8 +75,10 @@ export interface ChartResolveSources {
 }
 
 export interface ChartResolveOptions {
-  /** Runtime interaction window used only while the authored resolution is Auto. */
+  /** Runtime zoom window used only to choose an adaptive Auto resolution. */
   autoViewport?: { start: Date; end: Date } | null;
+  /** Runtime interaction window used to load history around the visible chart. */
+  requestViewport?: { start: Date; end: Date } | null;
   /** Approximate number of horizontal observations the current surface can use. */
   targetPointCount?: number;
 }
@@ -179,6 +181,18 @@ function requestedBounds(spec: ChartSpec, latestObservation: Date): DateBounds {
 function runtimeAutoBounds(options: ChartResolveOptions): DateBounds | null {
   const start = options.autoViewport?.start.getTime();
   const end = options.autoViewport?.end.getTime();
+  return typeof start === "number"
+      && Number.isFinite(start)
+      && typeof end === "number"
+      && Number.isFinite(end)
+      && start <= end
+    ? { start, end }
+    : null;
+}
+
+function runtimeRequestBounds(options: ChartResolveOptions): DateBounds | null {
+  const start = options.requestViewport?.start.getTime();
+  const end = options.requestViewport?.end.getTime();
   return typeof start === "number"
       && Number.isFinite(start)
       && typeof end === "number"
@@ -608,9 +622,10 @@ export async function resolveChartSpecData(
     );
   };
 
-  const runtimeBounds = spec.viewport.resolution === "auto"
+  const adaptiveBounds = spec.viewport.resolution === "auto"
     ? runtimeAutoBounds(options)
     : null;
+  const requestBounds = runtimeRequestBounds(options) ?? adaptiveBounds;
   const activeMarketSources = [...new Map(spec.series.flatMap((entry) => (
     calculationSeriesIds.has(entry.id)
       && entry.source.kind === "security"
@@ -618,14 +633,14 @@ export async function resolveChartSpecData(
       ? [[instrumentKey(entry.source), entry.source] as const]
       : []
   ))).values()];
-  const resolutionSupportSources = runtimeBounds
+  const resolutionSupportSources = adaptiveBounds
     ? await Promise.all(activeMarketSources.map(async (source) => (
         source.instrument.exchange?.trim()
           ? source
           : sourceWithResolvedExchange(source, await loadFinancials(source))
       )))
     : activeMarketSources;
-  const sharedSupport = runtimeBounds && activeMarketSources.length > 0
+  const sharedSupport = adaptiveBounds && activeMarketSources.length > 0
     ? intersectChartResolutionSupport(await Promise.all(
         resolutionSupportSources.map((source) => loadResolutionSupport(source)),
       ))
@@ -637,14 +652,14 @@ export async function resolveChartSpecData(
     options,
     sharedSupport,
   );
-  const requestVisibleBounds = runtimeBounds ?? initialVisibleBounds;
+  const requestVisibleBounds = requestBounds ?? initialVisibleBounds;
   const initialCalculationBounds = calculationBounds(
     spec,
     requestVisibleBounds,
     initialResolution,
   );
   const hasExplicitWindow = explicitBounds(spec) !== null
-    || (runtimeBounds !== null && !sameBounds(runtimeBounds, initialVisibleBounds));
+    || (requestBounds !== null && !sameBounds(requestBounds, initialVisibleBounds));
 
   const loadHistory = async (
     source: Extract<ChartSeriesSpec["source"], { kind: "security" }>,

--- a/src/time-series/types.ts
+++ b/src/time-series/types.ts
@@ -154,6 +154,8 @@ export interface ChartResolutionResult {
   legendSeries?: ResolvedSeries[];
   /** Loaded observations retained outside the visible window for interactive navigation. */
   bufferedSeries?: ResolvedSeries[];
+  /** Hidden market data retained as a deterministic session-time anchor. */
+  timelineSeries?: ResolvedSeries[];
   loading: boolean;
   errors: string[];
   warnings: string[];

--- a/src/time-series/use-chart-resolution.test.tsx
+++ b/src/time-series/use-chart-resolution.test.tsx
@@ -15,6 +15,7 @@ type AutoViewport = NonNullable<Parameters<typeof useChartResolution>[2]["autoVi
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let setAutoViewport: ((viewport: AutoViewport | null) => void) | null = null;
+let setRequestViewport: ((viewport: AutoViewport | null) => void) | null = null;
 let latestResult: UseChartResolutionResult | null = null;
 
 const EMPTY_FINANCIALS: TickerFinancials = {
@@ -87,10 +88,13 @@ function ResolutionHarness({
 }: {
   sources: ChartResolveSources;
 }) {
-  const [viewport, setViewport] = useState<AutoViewport | null>(null);
-  setAutoViewport = setViewport;
+  const [autoViewport, setAutoViewportState] = useState<AutoViewport | null>(null);
+  const [requestViewport, setRequestViewportState] = useState<AutoViewport | null>(null);
+  setAutoViewport = setAutoViewportState;
+  setRequestViewport = setRequestViewportState;
   latestResult = useChartResolution(SPEC, sources, {
-    autoViewport: viewport,
+    autoViewport,
+    requestViewport,
     targetPointCount: 100,
     liveRefreshIntervalMs: 0,
   });
@@ -125,6 +129,7 @@ afterEach(async () => {
     testSetup = undefined;
   }
   setAutoViewport = null;
+  setRequestViewport = null;
   latestResult = null;
 });
 
@@ -184,6 +189,71 @@ describe("useChartResolution", () => {
     expect(latestResult?.series).toBe(lastGoodSeries);
     expect(latestResult?.bufferedSeries).toBe(lastGoodBufferedSeries);
     expect(latestResult?.errors).toEqual([]);
+
+    await act(async () => {
+      quoteHandler!(quoteTarget!, {
+        symbol: "TEST",
+        price: 105,
+        currency: "USD",
+        change: 1,
+        changePercent: 0.96,
+        lastUpdated: Date.parse("2025-01-03T20:00:00.000Z"),
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await testSetup!.renderOnce();
+    });
+    await flushEffects(3);
+
+    expect(latestResult?.loading).toBe(false);
+    expect(latestResult?.series).toBe(lastGoodSeries);
+    expect(latestResult?.bufferedSeries).toBe(lastGoodBufferedSeries);
+    expect(latestResult?.errors).toEqual([]);
+  });
+
+  test("keeps renderable data through an empty panned-history live refresh", async () => {
+    let detailedCalls = 0;
+    let fixedHistoryCalls = 0;
+    let quoteHandler: Parameters<NonNullable<DataProvider["subscribeQuotes"]>>[1] | null = null;
+    let quoteTarget: Parameters<NonNullable<DataProvider["subscribeQuotes"]>>[0][number] | null = null;
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => EMPTY_FINANCIALS,
+      getPriceHistoryForResolution: async () => {
+        fixedHistoryCalls += 1;
+        return fixedHistoryCalls === 1 ? INITIAL_HISTORY : [];
+      },
+      getDetailedPriceHistory: async () => {
+        detailedCalls += 1;
+        return [];
+      },
+      getPriceHistory: async () => [],
+      subscribeQuotes: (targets, onQuote) => {
+        quoteTarget = targets[0] ?? null;
+        quoteHandler = onQuote;
+        return () => {};
+      },
+    });
+    const sources = sourcesFor(provider);
+    testSetup = await testRender(<ResolutionHarness sources={sources} />, {
+      width: 24,
+      height: 1,
+    });
+
+    await waitFor(() => latestResult?.loading === false && latestResult.series[0]?.points.length === 2);
+    const lastGoodSeries = latestResult!.series;
+    const lastGoodBufferedSeries = latestResult!.bufferedSeries;
+
+    await act(async () => {
+      setRequestViewport?.({
+        start: new Date("2024-12-20T00:00:00.000Z"),
+        end: new Date("2024-12-27T00:00:00.000Z"),
+      });
+      await testSetup!.renderOnce();
+    });
+    await waitFor(() => detailedCalls === 1);
+    await flushEffects(3);
+
+    expect(latestResult?.series).toBe(lastGoodSeries);
+    expect(latestResult?.bufferedSeries).toBe(lastGoodBufferedSeries);
 
     await act(async () => {
       quoteHandler!(quoteTarget!, {

--- a/src/time-series/use-chart-resolution.ts
+++ b/src/time-series/use-chart-resolution.ts
@@ -174,7 +174,7 @@ export function useChartResolution(
             && generationRef.current === generation
           ) {
             setResult((current) => (
-              request.options.autoViewport
+              (request.options.autoViewport || request.options.requestViewport)
               && !current.loading
               && hasRenderableData(current)
               && !hasRenderableData(next)

--- a/src/time-series/use-chart-resolution.ts
+++ b/src/time-series/use-chart-resolution.ts
@@ -20,6 +20,7 @@ export interface UseChartResolutionResult extends ChartResolutionResult {
 export interface UseChartResolutionOptions {
   liveRefreshIntervalMs?: number;
   autoViewport?: ChartResolveOptions["autoViewport"];
+  requestViewport?: ChartResolveOptions["requestViewport"];
   targetPointCount?: number;
 }
 
@@ -74,9 +75,19 @@ export function useChartResolution(
       && autoViewportStart <= autoViewportEnd
     ? { start: new Date(autoViewportStart), end: new Date(autoViewportEnd) }
     : null;
+  const requestViewportStart = options.requestViewport?.start.getTime();
+  const requestViewportEnd = options.requestViewport?.end.getTime();
+  const validRequestViewport = typeof requestViewportStart === "number"
+      && Number.isFinite(requestViewportStart)
+      && typeof requestViewportEnd === "number"
+      && Number.isFinite(requestViewportEnd)
+      && requestViewportStart <= requestViewportEnd
+    ? { start: new Date(requestViewportStart), end: new Date(requestViewportEnd) }
+    : null;
   const adaptiveTargetPointCount = validAutoViewport ? options.targetPointCount : undefined;
   const resolveOptions: ChartResolveOptions = {
     autoViewport: validAutoViewport,
+    requestViewport: validRequestViewport,
     targetPointCount: adaptiveTargetPointCount,
   };
   const latestRequestRef = useRef({ spec, sources, options: resolveOptions });
@@ -126,7 +137,16 @@ export function useChartResolution(
     return () => {
       if (generationRef.current === generation) generationRef.current += 1;
     };
-  }, [adaptiveTargetPointCount, autoViewportEnd, autoViewportStart, revision, sources, spec]);
+  }, [
+    adaptiveTargetPointCount,
+    autoViewportEnd,
+    autoViewportStart,
+    requestViewportEnd,
+    requestViewportStart,
+    revision,
+    sources,
+    spec,
+  ]);
 
   const liveTargetSignature = liveChartQuoteTargetSignature(spec);
   const liveRefreshIntervalMs = options.liveRefreshIntervalMs ?? LIVE_CHART_REFRESH_INTERVAL_MS;


### PR DESCRIPTION
## Summary

- preserve market-slot width while panning across closed sessions
- treat horizontal two-finger movement as pan only, without changing zoom or Auto resolution
- use buffered market anchors so closed sessions do not appear as chart holes
- backfill around the panned window without changing the active interval
- preserve pointer-anchored zoom on compressed market time scales
- retain the hidden primary market series as a deterministic session anchor
- retain rendered data through empty panned-history live refreshes
- reset navigation when the authored maximum-point limit or timestamp mode changes

## Root cause

The interaction path mixed calendar-time motion with a renderer that compresses closed market sessions. Delayed data responses could echo stale bounds back into the chart, while transformed history and live refreshes could become empty after a deep pan.

## Impact

Two-finger horizontal movement cannot zoom the chart. Pans stay at a constant market scale, pointer zoom stays on its original market slot, older history backfills at the selected resolution, and the X axis remains aligned through session gaps.

## Validation

- `bun run typecheck`
- `bun test --silent`
- targeted regression coverage for panned transforms, hidden timeline anchors, control-wheel pointer zoom, reversed zoom, drag reset, and live-refresh preservation
- OpenTUI tmux smoke with SNDK
- live Electrobun checks with SNDK, META, and AAPL, including a current SNDK 1-minute series and stable desktop pan