### PR TITLE
Preserve genuine wide history bars

### DIFF
--- a/src/sources/gloomberb-cloud/history-quality.ts
+++ b/src/sources/gloomberb-cloud/history-quality.ts
@@ -2,7 +2,7 @@ import type { PricePoint } from "../../types/financials";
 import { getPricePointTimestamp } from "../../utils/price-history";
 
 const MAX_NEIGHBOR_GAP_MS = 60 * 60 * 1000;
-const STABLE_NEIGHBOR_CLOSE_RATIO = 0.02;
+const STABLE_NEIGHBOR_CLOSE_RATIO = 0.01;
 const ISOLATED_OHLC_OUTLIER_RATIO = 0.04;
 
 function relativeDifference(value: number, reference: number): number {

--- a/src/sources/gloomberb-cloud/index.test.ts
+++ b/src/sources/gloomberb-cloud/index.test.ts
@@ -202,6 +202,46 @@ describe("GloomberbCloudProvider", () => {
     ).rejects.toThrow("failed OHLC validation");
   });
 
+  test("preserves a wide cloud bar during a continuing price move", async () => {
+    apiClient.ensureVerifiedSession = async () => verifiedUser;
+    apiClient.getCloudHistory = async () => ({
+      status: "success",
+      data: [
+        {
+          date: "2026-07-29T20:10:00Z",
+          open: 561.1,
+          high: 561.3,
+          low: 560.7,
+          close: 560.8994,
+        },
+        {
+          date: "2026-07-29T20:15:00Z",
+          open: 560.11,
+          high: 585.61,
+          low: 553.41,
+          close: 555.4,
+        },
+        {
+          date: "2026-07-29T20:20:00Z",
+          open: 555.2,
+          high: 556,
+          low: 548.9,
+          close: 549.01,
+        },
+      ],
+    });
+
+    const provider = new GloomberbCloudProvider();
+    const history = await provider.getPriceHistoryForResolution(
+      "META",
+      "NASDAQ",
+      "1W",
+      "5m",
+    );
+
+    expect(history).toHaveLength(3);
+  });
+
   test("does not reject an explicitly Yahoo-backed cloud history response", async () => {
     apiClient.ensureVerifiedSession = async () => verifiedUser;
     apiClient.getCloudHistory = async () => ({


### PR DESCRIPTION
## What changed

- narrow the desktop Cloud-history safety check to match the backend’s conservative neighbor criterion
- preserve a genuine wide intraday candle when adjacent closes confirm an ongoing move

## Why

The Cloud producer now validates malformed upstream batches and falls back to clean Alpaca SIP history. The existing desktop guard used a broader 2% neighbor threshold and could reject one genuine earnings candle in that validated response, causing the router to fall through to a noisier source.

## Impact

Malformed isolated spikes are still rejected, while verified wide candles during real price moves remain visible.

## Validation

- `bun test src/sources/gloomberb-cloud/index.test.ts` (18 passed)
- `bun run typecheck`
- `bun test` (1,744 passed)