### PR TITLE
Refresh persisted chart history

### DIFF
--- a/src/sources/gloomberb-cloud/index.test.ts
+++ b/src/sources/gloomberb-cloud/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createGloomberbCloudCapabilities, GloomberbCloudProvider } from "./index";
+import { getRangeStartDate, toHistoryRequest } from "./normalizers";
 import type { NewsCapability } from "../../capabilities";
 import { apiClient, type AuthUser, type CloudNewsPayload } from "../../api-client";
 
@@ -24,6 +25,17 @@ const originalGetCloudOptionsChain = apiClient.getCloudOptionsChain.bind(apiClie
 const originalGetCloudNews = apiClient.getCloudNews.bind(apiClient);
 const originalGetCloudNewsStory = apiClient.getCloudNewsStory.bind(apiClient);
 const originalSubscribeQuotes = apiClient.subscribeQuotes.bind(apiClient);
+
+test("requests fifty years of cloud history for the ALL range", () => {
+  const endDate = new Date("2026-07-30T20:00:00.000Z");
+
+  expect(getRangeStartDate("ALL", endDate).toISOString()).toBe("1976-07-30T20:00:00.000Z");
+  expect(toHistoryRequest("ALL")).toEqual({
+    interval: "1month",
+    outputsize: 600,
+    rangeKey: "ALL",
+  });
+});
 
 function makeCloudNewsPayload(overrides: Partial<CloudNewsPayload> = {}): CloudNewsPayload {
   return {

--- a/src/sources/gloomberb-cloud/normalizers.ts
+++ b/src/sources/gloomberb-cloud/normalizers.ts
@@ -326,7 +326,7 @@ export function getRangeStartDate(
       startDate.setFullYear(startDate.getFullYear() - 5);
       break;
     case "ALL":
-      startDate.setFullYear(startDate.getFullYear() - 20);
+      startDate.setFullYear(startDate.getFullYear() - 50);
       break;
   }
   return startDate;
@@ -353,7 +353,7 @@ export function toHistoryRequest(range: TimeRange): {
     case "5Y":
       return { interval: "1week", outputsize: 261, rangeKey: range };
     case "ALL":
-      return { interval: "1month", outputsize: 240, rangeKey: range };
+      return { interval: "1month", outputsize: 600, rangeKey: range };
     default:
       return { interval: "1day", outputsize: 366, rangeKey: range };
   }

--- a/src/sources/provider-router/history.test.ts
+++ b/src/sources/provider-router/history.test.ts
@@ -135,6 +135,59 @@ describe("AssetDataRouter chart history", () => {
     persistence.close();
   });
 
+  test("ignores the previous chart history cache generation", async () => {
+    const dbPath = createTempDbPath("previous-chart-cache-generation");
+    const persistence = new AppPersistence(dbPath);
+    const latestDate = new Date(Date.now() - 60_000);
+    const previousDate = new Date(latestDate.getTime() - 5 * 60_000);
+
+    persistence.resources.set(
+      {
+        namespace: "market",
+        kind: "price-history",
+        entityKey: "META",
+        variantKey: "exchange=NASDAQ;range=1M;resolution=5m;version=2",
+        sourceKey: "provider:gloomberb-cloud",
+      },
+      [
+        { date: previousDate, close: 620 },
+        { date: latestDate, close: 680 },
+      ],
+      {
+        cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
+      },
+    );
+
+    let providerCalls = 0;
+    const router = new AssetDataRouter({
+      ...fallbackProvider,
+      id: "gloomberb-cloud",
+      name: "Gloomberb Cloud",
+      async getPriceHistoryForResolution() {
+        providerCalls += 1;
+        return [
+          { date: previousDate, close: 620 },
+          { date: latestDate, close: 560 },
+        ];
+      },
+    }, [], persistence.resources);
+
+    const history = await router.getPriceHistoryForResolution("META", "NASDAQ", "1M", "5m");
+
+    expect(providerCalls).toBe(1);
+    expect(history.map((point) => point.close)).toEqual([620, 560]);
+
+    const cachedRows = persistence.database.connection
+      .query("SELECT variant_key FROM resource_cache WHERE namespace = ? AND kind = ? AND entity_key = ? ORDER BY variant_key")
+      .all("market", "price-history", "META") as Array<{ variant_key: string }>;
+    expect(cachedRows.map((row) => row.variant_key)).toEqual([
+      "exchange=NASDAQ;range=1M;resolution=5m;version=2",
+      "exchange=NASDAQ;range=1M;resolution=5m;version=3",
+    ]);
+
+    persistence.close();
+  });
+
   test("ignores legacy unversioned sub-unit chart history caches", async () => {
     const dbPath = createTempDbPath("subunit-chart-cache");
     const persistence = new AppPersistence(dbPath);
@@ -180,7 +233,7 @@ describe("AssetDataRouter chart history", () => {
       .all("market", "price-history", "FTC") as Array<{ variant_key: string }>;
     expect(cachedRows.map((row) => row.variant_key)).toEqual([
       "exchange=LSE;range=ALL;resolution=1wk",
-      "exchange=LSE;range=ALL;resolution=1wk;version=2;unit=GBP",
+      "exchange=LSE;range=ALL;resolution=1wk;version=3;unit=GBP",
     ]);
 
     persistence.close();

--- a/src/sources/provider-router/history.ts
+++ b/src/sources/provider-router/history.ts
@@ -29,7 +29,7 @@ type PriceHistoryCachePolicyKey = Extract<
   ProviderRouterCachePolicyKey,
   "priceHistoryIntraday" | "priceHistoryDaily"
 >;
-const PRICE_HISTORY_CACHE_VERSION = 2;
+const PRICE_HISTORY_CACHE_VERSION = 3;
 
 interface HistoryRequestDescriptor {
   identity: RouterRequestIdentity;


### PR DESCRIPTION
## Summary

- move chart history persistence to a new cache generation so installations refetch the corrected cloud bars instead of reopening previously downloaded malformed data
- request 50 years and 600 monthly bars for the ALL range instead of limiting history to 20 years
- cover the cache rollover and full-history request boundary with focused regression tests

## Verification

- `bun test`: 1,766 passed
- `bun run typecheck`: all four TypeScript targets passed
- real Electrobun desktop QA with a persisted pre-fix database: META, SNDK, and AAPL refetched clean current bars after relaunch
- AAPL ALL at 1-week resolution displayed history from 1980 through 2026
- desktop two-finger pan shifted a 1-day window by 40 minutes while preserving the exact 24-hour span and selected resolution