### PR TITLE
Stream all visible option quotes

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -41,7 +41,7 @@ export { Checkbox } from "./ui/checkbox";
 export { ConfirmDialog } from "./ui/confirm-dialog";
 export { ChoiceDialog } from "./ui/choice-dialog";
 export type { ChoiceDialogChoice } from "./ui/choice-dialog";
-export type { DataTableCell, DataTableColumn } from "./ui/data-table";
+export type { DataTableCell, DataTableColumn, DataTableVisibleRange } from "./ui/data-table";
 export { EmptyState } from "./ui/status";
 export { getMessageComposerBlockHeight, MessageComposer } from "./ui/message-composer";
 export { NumberField, TextField } from "./ui/fields";

--- a/src/components/ui/data-table/index.tsx
+++ b/src/components/ui/data-table/index.tsx
@@ -13,6 +13,7 @@ export type {
   DataTableColumn,
   DataTableProps,
   DataTableSectionHeader,
+  DataTableVisibleRange,
 } from "./types";
 
 export function DataTable<T, C extends DataTableColumn = DataTableColumn>(

--- a/src/components/ui/data-table/opentui/index.tsx
+++ b/src/components/ui/data-table/opentui/index.tsx
@@ -19,7 +19,9 @@ import {
 import type {
   DataTableColumn,
   DataTableProps,
+  DataTableVisibleRange,
 } from "../types";
+import { resolveDataTableVisibleRange } from "../visible-range";
 import {
   resolveDataTableScrollTop,
   resolveDataTableVisibleWindow,
@@ -47,6 +49,8 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
   onSelect,
   onActivate,
   onTableMouseDown,
+  visibleRangeKey,
+  onVisibleRangeChange,
   onRowMouseDown,
   onRowContextMenu,
   rowContextMenuSurface = false,
@@ -74,6 +78,10 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
   const nativeRenderer = useNativeRenderer();
   const [scrollVersion, setScrollVersion] = useState(0);
   const lastAppliedScrollRequestRef = useRef<string | null>(null);
+  const lastVisibleRangeRef = useRef<{
+    key: string | number | undefined;
+    range: DataTableVisibleRange;
+  } | null>(null);
   const scrollTop = virtualize ? (scrollRef.current?.scrollTop ?? 0) : 0;
   const measuredViewportHeight = scrollRef.current?.viewport?.height;
   const tableWindow = useMemo(
@@ -123,6 +131,25 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
     () => expandTableColumns(columns, contentWidth, columnGap, horizontalPadding),
     [columnGap, columns, contentWidth, horizontalPadding],
   );
+  const emitVisibleRange = useCallback(() => {
+    if (!onVisibleRangeChange) return;
+    const scrollBox = scrollRef.current;
+    const range = resolveDataTableVisibleRange({
+      itemCount: items.length,
+      rowSize: 1,
+      scrollOffset: scrollBox?.scrollTop ?? scrollTop,
+      viewportSize: scrollBox?.viewport?.height ?? viewportHeight,
+    });
+    const previous = lastVisibleRangeRef.current;
+    if (
+      previous !== null
+      && previous.key === visibleRangeKey
+      && previous.range.start === range.start
+      && previous.range.end === range.end
+    ) return;
+    lastVisibleRangeRef.current = { key: visibleRangeKey, range };
+    onVisibleRangeChange(range);
+  }, [items.length, onVisibleRangeChange, scrollRef, scrollTop, viewportHeight, visibleRangeKey]);
   const handleRowMouseDown =
     useDoubleClickActivation<DataTableRowPointerTarget<T>>({
       onSelect: ({ item, index }) => {
@@ -140,13 +167,26 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
       setScrollVersion((current) => current + 1);
     }
     onBodyScrollActivity();
+    emitVisibleRange();
     nativeRenderer.requestRender();
-  }, [nativeRenderer, onBodyScrollActivity, virtualize]);
+  }, [emitVisibleRange, nativeRenderer, onBodyScrollActivity, virtualize]);
   useScrollBoxScrollActivity({
     scrollRef,
     onVerticalScroll: handleBodyScrollActivity,
     onHorizontalScroll: syncHeaderScroll,
   });
+  const handleBodySizeChange = useCallback(() => {
+    measureContentWidth();
+    if (virtualize) {
+      setScrollVersion((current) => current + 1);
+    }
+    queueMicrotask(emitVisibleRange);
+  }, [emitVisibleRange, measureContentWidth, virtualize]);
+
+  useEffect(() => {
+    emitVisibleRange();
+    queueMicrotask(emitVisibleRange);
+  }, [emitVisibleRange]);
   const focusPane = useCallback(() => {
     if (!paneInstanceId) return;
     dispatch({ type: "FOCUS_PANE", paneId: paneInstanceId });
@@ -178,6 +218,7 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
       setScrollVersion((current) => current + 1);
     }
     syncHeaderScroll();
+    queueMicrotask(emitVisibleRange);
     return true;
   }, [
     appViewport.height,
@@ -185,6 +226,7 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
     scrollRef,
     scrollToIndex,
     scrollToIndexAlign,
+    emitVisibleRange,
     syncHeaderScroll,
     virtualize,
   ]);
@@ -324,7 +366,7 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
           focusPane();
           onTableMouseDown?.({});
         }}
-        onSizeChange={measureContentWidth}
+        onSizeChange={handleBodySizeChange}
       >
         {items.length === 0 ? (
           emptyContent ?? (

--- a/src/components/ui/data-table/types.ts
+++ b/src/components/ui/data-table/types.ts
@@ -33,6 +33,13 @@ export interface DataTableRowState {
   selected: boolean;
 }
 
+export interface DataTableVisibleRange {
+  /** First visible row index. */
+  start: number;
+  /** Exclusive end of the visible row range. */
+  end: number;
+}
+
 export interface DataTableProps<
   T,
   C extends DataTableColumn = DataTableColumn,
@@ -53,6 +60,9 @@ export interface DataTableProps<
   onSelect: (item: T, index: number) => void;
   onActivate?: (item: T, index: number) => void;
   onTableMouseDown?: (event: any) => void;
+  /** Changes when the meaning of row indexes changes without changing table geometry. */
+  visibleRangeKey?: string | number;
+  onVisibleRangeChange?: (range: DataTableVisibleRange) => void;
   onRowMouseDown?: (item: T, index: number, event: any) => boolean | void;
   onRowContextMenu?: (item: T, index: number, event: any) => void;
   rowContextMenuSurface?: boolean;

--- a/src/components/ui/data-table/visible-range.test.ts
+++ b/src/components/ui/data-table/visible-range.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { resolveDataTableVisibleRange } from "./visible-range";
+
+describe("data table visible range", () => {
+  test("includes partially visible desktop rows without counting the sticky header", () => {
+    expect(resolveDataTableVisibleRange({
+      itemCount: 100,
+      rowSize: 20,
+      scrollOffset: 10,
+      viewportSize: 180,
+    })).toEqual({ start: 0, end: 10 });
+
+    expect(resolveDataTableVisibleRange({
+      itemCount: 100,
+      rowSize: 20,
+      scrollOffset: 30,
+      viewportSize: 180,
+    })).toEqual({ start: 1, end: 11 });
+  });
+
+  test("clamps a terminal range to the available rows", () => {
+    expect(resolveDataTableVisibleRange({
+      itemCount: 8,
+      rowSize: 1,
+      scrollOffset: 6,
+      viewportSize: 5,
+    })).toEqual({ start: 6, end: 8 });
+  });
+});

--- a/src/components/ui/data-table/visible-range.ts
+++ b/src/components/ui/data-table/visible-range.ts
@@ -1,0 +1,21 @@
+import type { DataTableVisibleRange } from "./types";
+
+export function resolveDataTableVisibleRange({
+  itemCount,
+  rowSize,
+  scrollOffset,
+  viewportSize,
+}: {
+  itemCount: number;
+  rowSize: number;
+  scrollOffset: number;
+  viewportSize: number;
+}): DataTableVisibleRange {
+  const count = Math.max(0, Math.floor(itemCount));
+  const size = Number.isFinite(rowSize) && rowSize > 0 ? rowSize : 1;
+  const offset = Number.isFinite(scrollOffset) ? Math.max(0, scrollOffset) : 0;
+  const viewport = Number.isFinite(viewportSize) ? Math.max(0, viewportSize) : 0;
+  const start = Math.min(count, Math.floor(offset / size));
+  const end = Math.min(count, Math.max(start, Math.ceil((offset + viewport) / size)));
+  return { start, end };
+}

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -3,7 +3,7 @@ import { act, createRef, useEffect, useRef, useState } from "react";
 import { TestDialogProvider, testRender } from "../../renderers/opentui/test-utils";
 import type { BoxRenderable, ScrollBoxRenderable } from "@opentui/core";
 import { ChoiceDialog } from "./choice-dialog";
-import { DataTable, type DataTableColumn } from "./data-table";
+import { DataTable, type DataTableColumn, type DataTableVisibleRange } from "./data-table";
 import { TextField } from "./fields";
 import { ListView } from "./list-view";
 import { MultiSelectDialogButton, type MultiSelectDialogButtonHandle } from "./multi-select/dialog";
@@ -26,6 +26,8 @@ let setListSelection: ((index: number) => void) | null = null;
 let selectedTableRow: string | null = null;
 let activatedTableRow: string | null = null;
 let tableScrollBoxForTest: ScrollBoxRenderable | null = null;
+let tableVisibleRanges: DataTableVisibleRange[] = [];
+let setTableVisibleRangeKey: ((key: string) => void) | null = null;
 let closedTab: string | null = null;
 let addedTab = false;
 let resolvedChoice: string | null = null;
@@ -176,6 +178,7 @@ function DataTableHorizontalScrollHarness({
 function DataTableVirtualizationHarness() {
   const headerScrollRef = useRef<ScrollBoxRenderable>(null);
   const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const [visibleRangeKey, setVisibleRangeKey] = useState("first");
   const rows = Array.from({ length: 100 }, (_, index) => ({
     id: `row-${index}`,
     name: `Row ${index}`,
@@ -183,6 +186,7 @@ function DataTableVirtualizationHarness() {
 
   useEffect(() => {
     tableScrollBoxForTest = scrollRef.current;
+    setTableVisibleRangeKey = setVisibleRangeKey;
     return () => {
       if (tableScrollBoxForTest === scrollRef.current) {
         tableScrollBoxForTest = null;
@@ -201,6 +205,8 @@ function DataTableVirtualizationHarness() {
       scrollRef={scrollRef}
       syncHeaderScroll={() => {}}
       onBodyScrollActivity={() => {}}
+      visibleRangeKey={visibleRangeKey}
+      onVisibleRangeChange={(range) => tableVisibleRanges.push(range)}
       getItemKey={(row) => row.id}
       isSelected={() => false}
       onSelect={() => {}}
@@ -287,6 +293,8 @@ afterEach(async () => {
   selectedTableRow = null;
   activatedTableRow = null;
   tableScrollBoxForTest = null;
+  tableVisibleRanges = [];
+  setTableVisibleRangeKey = null;
   closedTab = null;
   addedTab = false;
   resolvedChoice = null;
@@ -906,6 +914,16 @@ describe("shared UI kit", () => {
     expect(frame).toContain("Row 0");
     expect(frame).not.toContain("Row 99");
     expect(tableScrollBoxForTest?.scrollTop).toBe(0);
+    expect(tableVisibleRanges.at(-1)).toEqual({ start: 0, end: 5 });
+
+    const initialRangeCount = tableVisibleRanges.length;
+    await act(async () => {
+      setTableVisibleRangeKey!("second");
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+    expect(tableVisibleRanges.length).toBeGreaterThan(initialRangeCount);
+    expect(tableVisibleRanges.at(-1)).toEqual({ start: 0, end: 5 });
 
     await act(async () => {
       for (let index = 0; index < 12; index++) {
@@ -919,6 +937,10 @@ describe("shared UI kit", () => {
 
     const scrollTop = tableScrollBoxForTest?.scrollTop ?? 0;
     expect(scrollTop).toBeGreaterThan(0);
+    expect(tableVisibleRanges.at(-1)).toEqual({
+      start: scrollTop,
+      end: Math.min(100, scrollTop + 5),
+    });
 
     const scrolledFrame = testSetup.captureCharFrame();
     expect(scrolledFrame).toContain(`Row ${scrollTop}`);

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -645,6 +645,8 @@ export const ja: Record<string, string> = {
   "{count}-minute delayed options, upgrade for real-time":
     "オプションは {count} 分遅延、リアルタイムにはアップグレード",
   "real-time options": "リアルタイムオプション",
+  "mixed real-time and delayed options": "リアルタイムと遅延の混在オプション",
+  "connecting real-time options": "リアルタイムオプションに接続中",
   "options delayed fallback": "オプション遅延フォールバック",
   "News": "ニュース",
   "12h delay": "12 時間遅延",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -643,6 +643,8 @@ export const ko: Record<string, string> = {
   "{count}-minute delayed options, upgrade for real-time":
     "옵션 데이터 {count}분 지연, 실시간으로 업그레이드",
   "real-time options": "실시간 옵션",
+  "mixed real-time and delayed options": "실시간 및 지연 옵션 혼합",
+  "connecting real-time options": "실시간 옵션 연결 중",
   "options delayed fallback": "옵션 지연 대체 데이터",
   "News": "뉴스",
   "12h delay": "12시간 지연",

--- a/src/i18n/zh-cn.ts
+++ b/src/i18n/zh-cn.ts
@@ -645,6 +645,8 @@ export const zhCN: Record<string, string> = {
   "{count}-minute delayed options, upgrade for real-time":
     "期权行情延迟 {count} 分钟，升级以获取实时数据",
   "real-time options": "实时期权",
+  "mixed real-time and delayed options": "实时与延迟期权混合",
+  "connecting real-time options": "正在连接实时期权",
   "options delayed fallback": "期权延迟备用数据",
   "News": "新闻",
   "12h delay": "延迟 12 小时",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -645,6 +645,8 @@ export const zhTW: Record<string, string> = {
   "{count}-minute delayed options, upgrade for real-time":
     "選擇權行情延遲 {count} 分鐘，升級以取得即時資料",
   "real-time options": "即時選擇權",
+  "mixed real-time and delayed options": "即時與延遲選擇權混合",
+  "connecting real-time options": "正在連線即時選擇權",
   "options delayed fallback": "選擇權延遲備援資料",
   "News": "新聞",
   "12h delay": "延遲 12 小時",

--- a/src/market-data/coordinator/index.ts
+++ b/src/market-data/coordinator/index.ts
@@ -369,10 +369,10 @@ export class MarketDataCoordinator {
     const key = buildQuoteKey(instrument);
     const current = this.quoteStore.get(key);
     const resolvedQuote = quote.stale === true ? quote : this.resolveIncomingQuote(instrument, quote);
-    if (areStreamQuotesEquivalent(current.data ?? current.lastGoodData, resolvedQuote)) return;
     const startedAt = Date.now();
     const receivedAt = resolvedQuote.stale === true ? resolvedQuote.receivedAt : startedAt;
     const storedQuote = receivedAt == null ? resolvedQuote : { ...resolvedQuote, receivedAt };
+    if (areStreamQuotesEquivalent(current.data ?? current.lastGoodData, storedQuote)) return;
     const attempts = [createAttempt(resolvedQuote.providerId ?? this.dataProvider.id, startedAt, "success")];
     this.quoteStore.set(key, readyQuoteEntry(current, storedQuote, resolvedQuote.providerId ?? this.dataProvider.id, attempts));
   }

--- a/src/market-data/coordinator/quotes.ts
+++ b/src/market-data/coordinator/quotes.ts
@@ -291,5 +291,6 @@ export function areStreamQuotesEquivalent(current: Quote | null | undefined, nex
     if (current[field] !== next[field]) return false;
   }
   return current.lastUpdated === next.lastUpdated
+    && current.receivedAt === next.receivedAt
     && JSON.stringify(current.provenance ?? null) === JSON.stringify(next.provenance ?? null);
 }

--- a/src/market-data/coordinator/subscriptions.test.ts
+++ b/src/market-data/coordinator/subscriptions.test.ts
@@ -245,6 +245,45 @@ describe("MarketDataCoordinator key subscriptions", () => {
     }
   });
 
+  test("advances receipt freshness for an identical live stream heartbeat", async () => {
+    const realDateNow = Date.now;
+    const { provider, emitQuote } = createProvider();
+    const coordinator = new MarketDataCoordinator(provider);
+    const option = { symbol: "AAPL260731C00110000", exchange: "OPTIONS" };
+    const firstTimestamp = 1_800_000_000_000;
+    let calls = 0;
+
+    try {
+      coordinator.subscribeKeys([buildQuoteKey(option)], () => { calls += 1; });
+      coordinator.subscribeQuotes([{ instrument: option }]);
+
+      Date.now = () => firstTimestamp;
+      const heartbeat = quote(option.symbol, 2.5, {
+        lastUpdated: firstTimestamp,
+        bid: 2.4,
+        ask: 2.6,
+        mark: 2.5,
+        dataSource: "live",
+        delivery: "stream",
+        stale: false,
+      });
+      emitQuote(option, heartbeat);
+      await flushCoordinator();
+
+      Date.now = () => firstTimestamp + 60_000;
+      emitQuote(option, heartbeat);
+      await flushCoordinator();
+
+      expect(calls).toBe(2);
+      expect(coordinator.getQuoteEntry(option).data).toMatchObject({
+        lastUpdated: firstTimestamp,
+        receivedAt: firstTimestamp + 60_000,
+      });
+    } finally {
+      Date.now = realDateNow;
+    }
+  });
+
   test("does not refresh receipt time from an explicitly stale polled quote", async () => {
     const realDateNow = Date.now;
     const { provider, emitQuote } = createProvider();

--- a/src/plugins/builtin/options/footer.test.ts
+++ b/src/plugins/builtin/options/footer.test.ts
@@ -21,7 +21,7 @@ describe("options access footer", () => {
         realtimeEligible: false,
       }),
       clientPlan: "free",
-      hasLiveQuote: false,
+      quoteCoverage: { status: "delayed" },
     });
     let upgrades = 0;
     const segment = buildOptionsAccessFooterSegment(state, () => {
@@ -37,7 +37,7 @@ describe("options access footer", () => {
     expect(upgrades).toBe(1);
   });
 
-  test("claims real-time only for a Pro user with a fresh live stream", () => {
+  test("reports complete, mixed, connecting, and delayed Pro coverage", () => {
     expect(
       resolveOptionsAccessFooterState({
         chain: chain({
@@ -46,7 +46,7 @@ describe("options access footer", () => {
           realtimeEligible: true,
         }),
         clientPlan: "pro",
-        hasLiveQuote: false,
+        quoteCoverage: { status: "delayed" },
       }),
     ).toMatchObject({
       canUpgrade: false,
@@ -62,21 +62,33 @@ describe("options access footer", () => {
           realtimeEligible: true,
         }),
         clientPlan: "pro",
-        hasLiveQuote: false,
+        quoteCoverage: { status: "connecting" },
       }),
     ).toMatchObject({
       canUpgrade: false,
-      text: "options delayed fallback",
-      tone: "warning",
+      text: "connecting real-time options",
+      tone: "muted",
     });
 
     expect(
       resolveOptionsAccessFooterState({
         chain: chain({ realtimeEligible: false }),
         clientPlan: "pro",
-        hasLiveQuote: true,
+        quoteCoverage: { status: "live" },
       }).text,
     ).toBe("real-time options");
+
+    expect(
+      resolveOptionsAccessFooterState({
+        chain: chain({ realtimeEligible: true }),
+        clientPlan: "pro",
+        quoteCoverage: { status: "mixed" },
+      }),
+    ).toMatchObject({
+      canUpgrade: false,
+      text: "mixed real-time and delayed options",
+      tone: "warning",
+    });
   });
 
   test("makes the current plan authoritative over cached chain metadata", () => {
@@ -88,7 +100,7 @@ describe("options access footer", () => {
           realtimeEligible: true,
         }),
         clientPlan: "free",
-        hasLiveQuote: true,
+        quoteCoverage: { status: "live" },
       }),
     ).toMatchObject({
       canUpgrade: true,
@@ -104,7 +116,7 @@ describe("options access footer", () => {
           realtimeEligible: false,
         }),
         clientPlan: "pro",
-        hasLiveQuote: true,
+        quoteCoverage: { status: "live" },
       }),
     ).toMatchObject({
       canUpgrade: false,

--- a/src/plugins/builtin/options/footer.ts
+++ b/src/plugins/builtin/options/footer.ts
@@ -7,21 +7,22 @@ import type { OptionsChain } from "../../../types/financials";
 import { useRendererHost } from "../../../ui";
 import { CLOUD_UPGRADE_URL } from "../shared/cloud-upgrade";
 import { usePaneStatusFooter } from "../shared/pane-footer";
+import type { OptionQuoteCoverage } from "./live-quotes";
 
 export interface OptionsAccessFooterState {
   canUpgrade: boolean;
   text: string;
-  tone: "positive" | "warning";
+  tone: "muted" | "positive" | "warning";
 }
 
 export function resolveOptionsAccessFooterState({
   chain,
   clientPlan,
-  hasLiveQuote,
+  quoteCoverage,
 }: {
   chain: OptionsChain | null | undefined;
   clientPlan: "free" | "pro" | null;
-  hasLiveQuote: boolean;
+  quoteCoverage: Pick<OptionQuoteCoverage, "status">;
 }): OptionsAccessFooterState {
   if (clientPlan !== "pro") {
     const delayMinutes = chain?.delayMinutes && chain.delayMinutes > 0 ? chain.delayMinutes : 15;
@@ -34,11 +35,25 @@ export function resolveOptionsAccessFooterState({
     };
   }
 
-  if (hasLiveQuote) {
+  if (quoteCoverage.status === "live") {
     return {
       canUpgrade: false,
       text: t("real-time options"),
       tone: "positive",
+    };
+  }
+  if (quoteCoverage.status === "mixed") {
+    return {
+      canUpgrade: false,
+      text: t("mixed real-time and delayed options"),
+      tone: "warning",
+    };
+  }
+  if (quoteCoverage.status === "connecting") {
+    return {
+      canUpgrade: false,
+      text: t("connecting real-time options"),
+      tone: "muted",
     };
   }
 
@@ -64,14 +79,14 @@ export function useOptionsAccessFooter({
   chain,
   error,
   focused,
-  hasLiveQuote,
   loading,
+  quoteCoverage,
 }: {
   chain: OptionsChain | null | undefined;
   error?: string | null;
   focused: boolean;
-  hasLiveQuote: boolean;
   loading?: boolean;
+  quoteCoverage: Pick<OptionQuoteCoverage, "status">;
 }): OptionsAccessFooterState {
   const rendererHost = useRendererHost();
   const user = apiClient.getCurrentUser();
@@ -79,7 +94,7 @@ export function useOptionsAccessFooter({
   const state = resolveOptionsAccessFooterState({
     chain,
     clientPlan,
-    hasLiveQuote,
+    quoteCoverage,
   });
   const openUpgrade = useCallback(() => {
     void rendererHost.openExternal(CLOUD_UPGRADE_URL);

--- a/src/plugins/builtin/options/live-quotes.test.ts
+++ b/src/plugins/builtin/options/live-quotes.test.ts
@@ -5,8 +5,8 @@ import type { OptionTableRow } from "./types";
 import {
   buildOptionQuoteKey,
   buildOptionQuoteTargets,
-  hasLiveOptionQuote,
   overlayOptionRowQuotes,
+  resolveOptionQuoteCoverage,
 } from "./live-quotes";
 
 function contract(strike: number, side: "C" | "P"): OptionContract {
@@ -51,20 +51,90 @@ function readyQuote(quote: Quote): QueryEntry<Quote> {
 }
 
 describe("options live quotes", () => {
-  test("bounds selected-expiry subscriptions around the current strike", () => {
+  test("subscribes every visible contract plus non-visible overscan", () => {
     const rows = Array.from({ length: 100 }, (_, index) => row(50 + index));
-    const targets = buildOptionQuoteTargets(rows, 50, 14);
+    const targets = buildOptionQuoteTargets(rows, {
+      fallbackHeight: 14,
+      selectedIndex: 50,
+      visibleRange: { start: 40, end: 64 },
+    });
+    const visibleTargets = targets.filter((target) => target.visible === true);
 
-    expect(targets).toHaveLength(16);
+    expect(targets).toHaveLength(64);
+    expect(visibleTargets).toHaveLength(48);
     expect(
       targets.every(
-        (target) => target.exchange === "OPTIONS" && target.surface === "options" && target.visible === true,
+        (target) => target.exchange === "OPTIONS" && target.surface === "options",
       ),
     ).toBe(true);
     expect(targets.filter((target) => target.selected)).toHaveLength(2);
     expect(targets.some((target) => target.symbol === rows[50]!.call!.contractSymbol)).toBe(true);
+    expect(visibleTargets.some((target) => target.symbol === rows[40]!.call!.contractSymbol)).toBe(true);
+    expect(visibleTargets.some((target) => target.symbol === rows[63]!.put!.contractSymbol)).toBe(true);
+    expect(targets.find((target) => target.symbol === rows[36]!.call!.contractSymbol)?.visible).toBe(false);
     expect(targets.some((target) => target.symbol === rows[0]!.call!.contractSymbol)).toBe(false);
     expect(targets.some((target) => target.symbol === rows.at(-1)!.put!.contractSymbol)).toBe(false);
+  });
+
+  test("requires fresh live stream metadata for every visible contract", () => {
+    const rows = [row(100), row(105), row(110)];
+    const targets = buildOptionQuoteTargets(rows, {
+      fallbackHeight: 14,
+      selectedIndex: 1,
+      visibleRange: { start: 1, end: 2 },
+    });
+    const freshness = {
+      chainAsOf: new Date(1_799_999_000_000).toISOString(),
+      chainDataSource: "live" as const,
+      now: 1_800_000_030_000,
+      subscriptionStartedAt: 1_799_999_500_000,
+    };
+    const visibleRow = rows[1]!;
+    const quote = (symbol: string): Quote => ({
+      symbol,
+      providerId: "gloomberb-cloud",
+      price: 2.4,
+      mark: 2.5,
+      bid: 2.45,
+      ask: 2.55,
+      currency: "USD",
+      change: 0,
+      changePercent: 0,
+      lastUpdated: 1_800_000_000_000,
+      receivedAt: 1_800_000_010_000,
+      dataSource: "live",
+      delivery: "stream",
+      stale: false,
+    });
+    const entries = new Map([
+      [buildOptionQuoteKey(visibleRow.call!.contractSymbol), readyQuote(quote(visibleRow.call!.contractSymbol))],
+      [buildOptionQuoteKey(visibleRow.put!.contractSymbol), readyQuote(quote(visibleRow.put!.contractSymbol))],
+      [buildOptionQuoteKey(rows[0]!.call!.contractSymbol), readyQuote(quote(rows[0]!.call!.contractSymbol))],
+    ]);
+
+    expect(resolveOptionQuoteCoverage(targets, entries, freshness)).toEqual({
+      fallbackCount: 0,
+      liveCount: 2,
+      status: "live",
+      totalCount: 2,
+    });
+
+    entries.delete(buildOptionQuoteKey(visibleRow.put!.contractSymbol));
+    expect(resolveOptionQuoteCoverage(targets, entries, freshness)).toMatchObject({
+      liveCount: 1,
+      status: "mixed",
+      totalCount: 2,
+    });
+
+    entries.clear();
+    entries.set(
+      buildOptionQuoteKey(rows[0]!.call!.contractSymbol),
+      readyQuote(quote(rows[0]!.call!.contractSymbol)),
+    );
+    expect(resolveOptionQuoteCoverage(targets, entries, {
+      ...freshness,
+      now: freshness.subscriptionStartedAt + 1_000,
+    })).toMatchObject({ liveCount: 0, status: "connecting", totalCount: 2 });
   });
 
   test("overlays streamed quote fields while preserving chain-only Greeks and open interest", () => {
@@ -103,10 +173,9 @@ describe("options live quotes", () => {
       impliedVolatility: 0.25,
       openInterest: 20,
     });
-    expect(hasLiveOptionQuote(entries, freshness)).toBe(true);
   });
 
-  test("rejects cached quotes from before this subscription or the current chain", () => {
+  test("rejects quotes from before this subscription without comparing contracts to a global chain timestamp", () => {
     const original = row(100);
     const symbol = original.call!.contractSymbol;
     const quote: Quote = {
@@ -122,6 +191,8 @@ describe("options live quotes", () => {
       lastUpdated: 1_800_000_000_000,
       receivedAt: 1_800_000_010_000,
       dataSource: "live",
+      delivery: "stream",
+      stale: false,
     };
     const entries = new Map([[buildOptionQuoteKey(symbol), readyQuote(quote)]]);
 
@@ -131,16 +202,33 @@ describe("options live quotes", () => {
       subscriptionStartedAt: 1_800_000_020_000,
     };
     expect(overlayOptionRowQuotes([original], entries, beforeSubscription)[0]!.call!.lastPrice).toBe(1);
-    expect(hasLiveOptionQuote(entries, beforeSubscription)).toBe(false);
+    const targets = buildOptionQuoteTargets([original], {
+      fallbackHeight: 14,
+      selectedIndex: 0,
+      visibleRange: { start: 0, end: 1 },
+    });
+    expect(resolveOptionQuoteCoverage(targets, entries, beforeSubscription).status).not.toBe("live");
 
-    const olderThanChain = {
+    const heterogeneousChainSnapshot = {
       chainAsOf: new Date(1_800_000_005_000).toISOString(),
       chainDataSource: "live" as const,
       now: 1_800_000_030_000,
       subscriptionStartedAt: 1_800_000_000_000,
     };
-    expect(overlayOptionRowQuotes([original], entries, olderThanChain)[0]!.call!.lastPrice).toBe(1);
-    expect(hasLiveOptionQuote(entries, olderThanChain)).toBe(false);
+    expect(overlayOptionRowQuotes([original], entries, heterogeneousChainSnapshot)[0]!.call!.lastPrice).toBe(9);
+    expect(resolveOptionQuoteCoverage(targets, entries, heterogeneousChainSnapshot)).toMatchObject({
+      liveCount: 1,
+      status: "mixed",
+    });
+
+    const newerContract = row(100);
+    newerContract.call = {
+      ...newerContract.call!,
+      lastUpdated: 1_800_000_005_000,
+    };
+    expect(
+      overlayOptionRowQuotes([newerContract], entries, heterogeneousChainSnapshot)[0]!.call!.lastPrice,
+    ).toBe(1);
   });
 
   test("accepts a freshly delivered delayed quote older than the delayed chain fetch", () => {
@@ -171,7 +259,12 @@ describe("options live quotes", () => {
     };
 
     expect(overlayOptionRowQuotes([original], entries, freshness)[0]!.call!.lastPrice).toBe(2.25);
-    expect(hasLiveOptionQuote(entries, freshness)).toBe(false);
+    const targets = buildOptionQuoteTargets([original], {
+      fallbackHeight: 14,
+      selectedIndex: 0,
+      visibleRange: { start: 0, end: 1 },
+    });
+    expect(resolveOptionQuoteCoverage(targets, entries, freshness).status).toBe("delayed");
   });
 
   test("overlays a valid polled quote without reporting a live stream", () => {
@@ -202,7 +295,12 @@ describe("options live quotes", () => {
     };
 
     expect(overlayOptionRowQuotes([original], entries, freshness)[0]!.call!.lastPrice).toBe(2.5);
-    expect(hasLiveOptionQuote(entries, freshness)).toBe(false);
+    const targets = buildOptionQuoteTargets([original], {
+      fallbackHeight: 14,
+      selectedIndex: 0,
+      visibleRange: { start: 0, end: 1 },
+    });
+    expect(resolveOptionQuoteCoverage(targets, entries, freshness).status).toBe("delayed");
   });
 
   test("rejects a freshly received quote marked stale by the server", () => {
@@ -233,6 +331,11 @@ describe("options live quotes", () => {
     };
 
     expect(overlayOptionRowQuotes([original], entries, freshness)[0]!.call!.lastPrice).toBe(1);
-    expect(hasLiveOptionQuote(entries, freshness)).toBe(false);
+    const targets = buildOptionQuoteTargets([original], {
+      fallbackHeight: 14,
+      selectedIndex: 0,
+      visibleRange: { start: 0, end: 1 },
+    });
+    expect(resolveOptionQuoteCoverage(targets, entries, freshness).status).toBe("delayed");
   });
 });

--- a/src/plugins/builtin/options/live-quotes.ts
+++ b/src/plugins/builtin/options/live-quotes.ts
@@ -7,14 +7,11 @@ import type { OptionTableRow } from "./types";
 export const OPTIONS_QUOTE_EXCHANGE = "OPTIONS";
 export const OPTIONS_CHAIN_REFRESH_INTERVAL_MS = 10 * 60_000;
 export const OPTIONS_STREAM_FRESHNESS_MS = 2 * 60_000;
+export const OPTIONS_STREAM_CONNECTING_GRACE_MS = 15_000;
 
-const OPTIONS_STREAM_MAX_TARGETS = 16;
-const OPTIONS_STREAM_MAX_ROWS = OPTIONS_STREAM_MAX_TARGETS / 2;
 const OPTIONS_STREAM_OVERSCAN_ROWS = 4;
 
 export interface OptionsQuoteFreshness {
-  chainAsOf?: string;
-  chainDataSource?: "live" | "delayed";
   now: number;
   subscriptionStartedAt: number;
 }
@@ -23,35 +20,64 @@ function isFiniteNumber(value: number | undefined): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
-function optionStreamRowCount(height: number): number {
-  const visibleRows = Math.max(1, Math.floor(height) - 3);
-  return Math.min(
-    OPTIONS_STREAM_MAX_ROWS,
-    visibleRows + OPTIONS_STREAM_OVERSCAN_ROWS,
-  );
+export interface OptionQuoteTargetWindow {
+  fallbackHeight: number;
+  selectedIndex: number;
+  visibleRange: { start: number; end: number } | null;
 }
 
-function optionStreamWindow(totalRows: number, selectedIndex: number, height: number): [number, number] {
-  const count = Math.min(totalRows, optionStreamRowCount(height));
+export type OptionQuoteCoverageStatus = "live" | "mixed" | "connecting" | "delayed";
+
+export interface OptionQuoteCoverage {
+  fallbackCount: number;
+  liveCount: number;
+  status: OptionQuoteCoverageStatus;
+  totalCount: number;
+}
+
+function fallbackVisibleRange(
+  totalRows: number,
+  selectedIndex: number,
+  height: number,
+): { start: number; end: number } {
+  const count = Math.min(totalRows, Math.max(1, Math.floor(height) - 3));
   const clampedIndex = Math.max(0, Math.min(selectedIndex, Math.max(0, totalRows - 1)));
   const start = Math.max(0, Math.min(clampedIndex - Math.floor(count / 2), totalRows - count));
-  return [start, start + count];
+  return { start, end: start + count };
+}
+
+function normalizeVisibleRange(
+  totalRows: number,
+  window: OptionQuoteTargetWindow,
+): { start: number; end: number } {
+  if (!window.visibleRange) {
+    return fallbackVisibleRange(totalRows, window.selectedIndex, window.fallbackHeight);
+  }
+  const start = Math.max(0, Math.min(totalRows, Math.floor(window.visibleRange.start)));
+  const end = Math.max(start, Math.min(totalRows, Math.ceil(window.visibleRange.end)));
+  return { start, end };
 }
 
 export function buildOptionQuoteTargets(
   rows: readonly OptionTableRow[],
-  selectedIndex: number,
-  height: number,
+  window: OptionQuoteTargetWindow,
 ): QuoteSubscriptionTarget[] {
   if (rows.length === 0) return [];
-  const [start, end] = optionStreamWindow(rows.length, selectedIndex, height);
+  const visibleRange = normalizeVisibleRange(rows.length, window);
+  const start = Math.max(0, visibleRange.start - OPTIONS_STREAM_OVERSCAN_ROWS);
+  const end = Math.min(rows.length, visibleRange.end + OPTIONS_STREAM_OVERSCAN_ROWS);
   const targets = new Map<string, QuoteSubscriptionTarget>();
 
-  for (let index = start; index < end; index += 1) {
+  const addRow = (index: number) => {
     const row = rows[index];
-    if (!row) continue;
-    const selected = index === selectedIndex;
-    const distance = Math.abs(index - selectedIndex);
+    if (!row) return;
+    const selected = index === window.selectedIndex;
+    const visible = index >= visibleRange.start && index < visibleRange.end;
+    const distance = visible
+      ? 0
+      : index < visibleRange.start
+        ? visibleRange.start - index
+        : index - visibleRange.end + 1;
     for (const contract of [row.call, row.put]) {
       const symbol = contract?.contractSymbol.trim().toUpperCase();
       if (!symbol) continue;
@@ -59,11 +85,18 @@ export function buildOptionQuoteTargets(
         symbol,
         exchange: OPTIONS_QUOTE_EXCHANGE,
         surface: "options",
-        visible: true,
+        visible,
         selected,
-        weight: Math.max(50, 100 - distance),
+        weight: selected ? 100 : visible ? 80 : Math.max(50, 70 - distance),
       });
     }
+  };
+
+  for (let index = start; index < end; index += 1) {
+    addRow(index);
+  }
+  if (window.selectedIndex < start || window.selectedIndex >= end) {
+    addRow(window.selectedIndex);
   }
 
   return [...targets.values()];
@@ -99,18 +132,8 @@ function freshOptionQuote(entry: QueryEntry<Quote> | undefined, freshness: Optio
   const receivedAt = quote.receivedAt ?? 0;
   if (
     !Number.isFinite(receivedAt) ||
-    receivedAt <= freshness.subscriptionStartedAt ||
+    receivedAt < freshness.subscriptionStartedAt ||
     freshness.now - receivedAt > OPTIONS_STREAM_FRESHNESS_MS
-  ) {
-    return null;
-  }
-  const chainAsOf = freshness.chainAsOf ? Date.parse(freshness.chainAsOf) : Number.NaN;
-  if (
-    freshness.chainDataSource === "live" &&
-    quote.dataSource === "live" &&
-    Number.isFinite(chainAsOf) &&
-    Number.isFinite(quote.lastUpdated) &&
-    quote.lastUpdated < chainAsOf
   ) {
     return null;
   }
@@ -135,13 +158,44 @@ export function overlayOptionRowQuotes(
   }));
 }
 
-export function hasLiveOptionQuote(
+export function resolveOptionQuoteCoverage(
+  targets: readonly QuoteSubscriptionTarget[],
   quoteEntries: ReadonlyMap<string, QueryEntry<Quote>>,
   freshness: OptionsQuoteFreshness,
-): boolean {
-  for (const entry of quoteEntries.values()) {
-    const quote = freshOptionQuote(entry, freshness);
-    if (quote?.dataSource === "live" && quote.delivery === "stream") return true;
+): OptionQuoteCoverage {
+  const visibleSymbols = new Set(
+    targets
+      .filter((target) => target.visible === true)
+      .map((target) => target.symbol.trim().toUpperCase())
+      .filter(Boolean),
+  );
+  let liveCount = 0;
+  let fallbackCount = 0;
+  for (const symbol of visibleSymbols) {
+    const quote = freshOptionQuote(
+      quoteEntries.get(buildOptionQuoteKey(symbol)),
+      freshness,
+    );
+    if (
+      quote?.dataSource === "live"
+      && quote.delivery === "stream"
+      && quote.stale === false
+    ) {
+      liveCount += 1;
+    } else if (quote) {
+      fallbackCount += 1;
+    }
   }
-  return false;
+
+  const totalCount = visibleSymbols.size;
+  const status: OptionQuoteCoverageStatus = totalCount > 0 && liveCount === totalCount
+    ? "live"
+    : liveCount > 0
+      ? "mixed"
+      : fallbackCount === 0
+        && totalCount > 0
+        && freshness.now - freshness.subscriptionStartedAt < OPTIONS_STREAM_CONNECTING_GRACE_MS
+        ? "connecting"
+        : "delayed";
+  return { fallbackCount, liveCount, status, totalCount };
 }

--- a/src/plugins/builtin/options/view.test.tsx
+++ b/src/plugins/builtin/options/view.test.tsx
@@ -164,7 +164,7 @@ test("defaults the table around the nearest strike to the current quote", async 
   expect(frame).not.toContain(" 50 ");
 });
 
-test("streams a bounded options window and overlays live contract quotes", async () => {
+test("streams every visible option row and overlays live contract quotes", async () => {
   const strikes = Array.from({ length: 100 }, (_, index) => 50 + index);
   const subscriptions: QuoteSubscriptionTarget[][] = [];
   let emitQuote:
@@ -193,8 +193,9 @@ test("streams a bounded options window and overlays live contract quotes", async
   await renderSettled();
 
   const targets = subscriptions.at(-1) ?? [];
-  expect(targets.length).toBeGreaterThan(0);
+  expect(targets.length).toBeGreaterThan(16);
   expect(targets.length).toBeLessThanOrEqual(80);
+  expect(targets.filter((target) => target.visible === true).length).toBeGreaterThan(16);
   expect(
     targets.every(
       (target) => target.exchange === "OPTIONS" && target.surface === "options",
@@ -218,6 +219,8 @@ test("streams a bounded options window and overlays live contract quotes", async
       changePercent: 0,
       lastUpdated: Date.now(),
       dataSource: "live",
+      delivery: "stream",
+      stale: false,
     });
     await Promise.resolve();
     await testSetup!.renderOnce();

--- a/src/plugins/builtin/options/view.tsx
+++ b/src/plugins/builtin/options/view.tsx
@@ -5,7 +5,13 @@ import { colors } from "../../../theme/colors";
 import { isPlainKey } from "../../../utils/keyboard";
 import { formatExpDate, resolveOptionsTarget } from "../../../utils/options";
 import { useOptionsQuery, useResolvedEntryValue } from "../../../market-data/hooks";
-import { DataTableView, Spinner, Tabs, type DataTableKeyEvent } from "../../../components";
+import {
+  DataTableView,
+  Spinner,
+  Tabs,
+  type DataTableKeyEvent,
+  type DataTableVisibleRange,
+} from "../../../components";
 import { useShortcut } from "../../../react/input";
 import { useLiveQuoteEntries } from "../../../state/hooks/quote-streaming";
 import {
@@ -19,9 +25,9 @@ import {
 import type { OptionColumn, OptionTableRow, OptionsViewProps } from "./types";
 import {
   buildOptionQuoteTargets,
-  hasLiveOptionQuote,
   OPTIONS_CHAIN_REFRESH_INTERVAL_MS,
   overlayOptionRowQuotes,
+  resolveOptionQuoteCoverage,
 } from "./live-quotes";
 import { useOptionsAccessFooter } from "./footer";
 
@@ -31,6 +37,10 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
   const [strikeIdx, setStrikeIdx] = useState(0);
   const [autoScrollVersion, setAutoScrollVersion] = useState(0);
   const [scrollToIndexAlign, setScrollToIndexAlign] = useState<"nearest" | "center">("nearest");
+  const [visibleStrikeViewport, setVisibleStrikeViewport] = useState<{
+    key: string;
+    range: DataTableVisibleRange;
+  } | null>(null);
   const [interactive, setInteractive] = useState(false);
   const userSelectedStrikeRef = useRef(false);
   const onCaptureRef = useRef(onCapture);
@@ -54,6 +64,7 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
   const initialChainEntry = useOptionsQuery(baseRequest);
   const initialChain = useResolvedEntryValue(initialChainEntry);
   const selectedExpiration = initialChain?.expirationDates[expIdx];
+  const viewportKey = `${effectiveTicker}:${selectedExpiration ?? "initial"}`;
   const expirationChainEntry = useOptionsQuery(
     baseRequest && selectedExpiration != null
       ? { ...baseRequest, expirationDate: selectedExpiration }
@@ -131,27 +142,51 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     put: putsByStrike.get(strike),
     isPositionStrike: !!parsed && Math.abs(strike - parsed.strike) < 0.01,
   })), [callsByStrike, parsed, putsByStrike, strikes]);
+  const visibleStrikeRange = visibleStrikeViewport?.key === viewportKey
+    ? visibleStrikeViewport.range
+    : null;
+  const handleVisibleStrikeRangeChange = useCallback((range: DataTableVisibleRange) => {
+    setVisibleStrikeViewport((current) => (
+      current?.key === viewportKey
+      && current.range.start === range.start
+      && current.range.end === range.end
+        ? current
+        : { key: viewportKey, range }
+    ));
+  }, [viewportKey]);
   const optionQuoteTargets = useMemo(
-    () => buildOptionQuoteTargets(snapshotRows, strikeIdx, height),
-    [height, snapshotRows, strikeIdx],
+    () => buildOptionQuoteTargets(snapshotRows, {
+      fallbackHeight: height,
+      selectedIndex: strikeIdx,
+      visibleRange: visibleStrikeRange,
+    }),
+    [height, snapshotRows, strikeIdx, visibleStrikeRange],
   );
   const {
     entries: optionQuoteEntries,
     freshnessNow,
     subscriptionStartedAt,
-  } = useLiveQuoteEntries(optionQuoteTargets);
+  } = useLiveQuoteEntries(optionQuoteTargets, {
+    freshnessScopeKey: viewportKey,
+  });
   const optionQuoteFreshness = useMemo(
     () => ({
-      chainAsOf: chain?.asOf,
-      chainDataSource: chain?.dataSource,
       now: freshnessNow,
       subscriptionStartedAt,
     }),
-    [chain?.asOf, chain?.dataSource, freshnessNow, subscriptionStartedAt],
+    [freshnessNow, subscriptionStartedAt],
   );
   const rows = useMemo(
     () => overlayOptionRowQuotes(snapshotRows, optionQuoteEntries, optionQuoteFreshness),
     [optionQuoteEntries, optionQuoteFreshness, snapshotRows],
+  );
+  const optionQuoteCoverage = useMemo(
+    () => resolveOptionQuoteCoverage(
+      optionQuoteTargets,
+      optionQuoteEntries,
+      optionQuoteFreshness,
+    ),
+    [optionQuoteEntries, optionQuoteFreshness, optionQuoteTargets],
   );
   const optionColumns: OptionColumn[] = OPTION_COLUMNS.map((column) => ({
     ...column,
@@ -162,8 +197,8 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     chain,
     error,
     focused,
-    hasLiveQuote: hasLiveOptionQuote(optionQuoteEntries, optionQuoteFreshness),
     loading,
+    quoteCoverage: optionQuoteCoverage,
   });
 
   useEffect(() => {
@@ -333,6 +368,8 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
         sortDirection="asc"
         onHeaderClick={() => {}}
         onTableMouseDown={enterInteractive}
+        visibleRangeKey={viewportKey}
+        onVisibleRangeChange={handleVisibleStrikeRangeChange}
         getItemKey={(row) => String(row.strike)}
         renderCell={renderOptionCell}
         emptyStateTitle="No strikes available."

--- a/src/renderers/electrobun/view/data-table/index.tsx
+++ b/src/renderers/electrobun/view/data-table/index.tsx
@@ -15,7 +15,9 @@ import { measurePerf } from "../../../../utils/perf-marks";
 import type {
   DataTableColumn,
   DataTableProps,
+  DataTableVisibleRange,
 } from "../../../../components/ui/data-table";
+import { resolveDataTableVisibleRange } from "../../../../components/ui/data-table/visible-range";
 import {
   buildTableGridTemplateColumns,
   getTableWidth,
@@ -57,6 +59,8 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   onSelect,
   onActivate,
   onTableMouseDown,
+  visibleRangeKey,
+  onVisibleRangeChange,
   onRowMouseDown,
   onRowContextMenu,
   rowContextMenuSurface = false,
@@ -80,6 +84,10 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   const dispatch = useAppDispatch();
   const paneInstanceId = usePaneInstance()?.instanceId ?? null;
   const bodyElementRef = useRef<HTMLDivElement | null>(null);
+  const lastVisibleRangeRef = useRef<{
+    key: string | number | undefined;
+    range: DataTableVisibleRange;
+  } | null>(null);
   const headerHorizontal = useScrollbarState(false);
   const headerVertical = useScrollbarState(false);
   const bodyHorizontal = useScrollbarState(showHorizontalScrollbar);
@@ -106,10 +114,32 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
     dispatch({ type: "FOCUS_PANE", paneId: paneInstanceId });
   }, [dispatch, paneInstanceId]);
 
+  const emitVisibleRange = useCallback(() => {
+    if (!onVisibleRangeChange) return;
+    const element = bodyElementRef.current;
+    if (!element) return;
+    const range = resolveDataTableVisibleRange({
+      itemCount: items.length,
+      rowSize: WEB_CELL_HEIGHT,
+      scrollOffset: element.scrollTop,
+      viewportSize: Math.max(0, element.clientHeight - WEB_CELL_HEIGHT),
+    });
+    const previous = lastVisibleRangeRef.current;
+    if (
+      previous !== null
+      && previous.key === visibleRangeKey
+      && previous.range.start === range.start
+      && previous.range.end === range.end
+    ) return;
+    lastVisibleRangeRef.current = { key: visibleRangeKey, range };
+    onVisibleRangeChange(range);
+  }, [items.length, onVisibleRangeChange, visibleRangeKey]);
   const handleBodyScrollActivity = useCallback(() => {
     onBodyScrollActivity();
-  }, [onBodyScrollActivity]);
+    emitVisibleRange();
+  }, [emitVisibleRange, onBodyScrollActivity]);
   const scheduleBodyScrollActivity = useRafCallback(handleBodyScrollActivity);
+  const scheduleVisibleRangeMeasure = useRafCallback(emitVisibleRange);
 
   const rowVirtualizer = useVirtualizer({
     count: items.length,
@@ -154,12 +184,20 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
 
   useEffect(() => {
     measureViewportWidth();
+    scheduleVisibleRangeMeasure();
     const element = bodyElementRef.current;
     if (!element || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(scheduleViewportWidthMeasure);
+    const observer = new ResizeObserver(() => {
+      scheduleViewportWidthMeasure();
+      scheduleVisibleRangeMeasure();
+    });
     observer.observe(element);
     return () => observer.disconnect();
-  }, [measureViewportWidth, scheduleViewportWidthMeasure]);
+  }, [measureViewportWidth, scheduleViewportWidthMeasure, scheduleVisibleRangeMeasure]);
+
+  useEffect(() => {
+    scheduleVisibleRangeMeasure();
+  }, [items.length, scheduleVisibleRangeMeasure, visibleRangeKey]);
 
   useEffect(() => {
     if (scrollToIndex == null || items.length === 0) return;
@@ -168,6 +206,7 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
       rowVirtualizer.scrollToIndex(targetIndex, {
         align: scrollToIndexAlign === "center" ? "center" : "auto",
       });
+      scheduleVisibleRangeMeasure();
       return;
     }
     const element = bodyElementRef.current;
@@ -185,12 +224,14 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
     if (nextTop !== currentTop) {
       element.scrollTop = nextTop * WEB_CELL_HEIGHT;
     }
+    scheduleVisibleRangeMeasure();
   }, [
     items.length,
     rowVirtualizer,
     scrollToIndex,
     scrollToIndexAlign,
     scrollToIndexVersion,
+    scheduleVisibleRangeMeasure,
     virtualize,
   ]);
 

--- a/src/state/hooks/quote-streaming.test.tsx
+++ b/src/state/hooks/quote-streaming.test.tsx
@@ -2,10 +2,14 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { act, useState } from "react";
 import { testRender } from "../../renderers/opentui/test-utils";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../market-data/coordinator";
-import { useQuoteStreaming } from "./quote-streaming";
+import { createTestDataProvider } from "../../test-support/data-provider";
+import { useLiveQuoteEntries, useQuoteStreaming } from "./quote-streaming";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let bumpHarness: (() => void) | null = null;
+let updateLiveTargets: ((symbol: string) => void) | null = null;
+let updateFreshnessScope: ((scope: string) => void) | null = null;
+let observedSubscriptionStartedAt = 0;
 
 function QuoteStreamingHarness() {
   const [tick, setTick] = useState(0);
@@ -19,6 +23,18 @@ function QuoteStreamingHarness() {
   return <text>{String(tick)}</text>;
 }
 
+function LiveQuoteFreshnessHarness() {
+  const [symbol, setSymbol] = useState("AAPL");
+  const [freshnessScopeKey, setFreshnessScopeKey] = useState("expiration-1");
+  updateLiveTargets = setSymbol;
+  updateFreshnessScope = setFreshnessScopeKey;
+  observedSubscriptionStartedAt = useLiveQuoteEntries(
+    [{ symbol, exchange: "OPTIONS" }],
+    { freshnessScopeKey },
+  ).subscriptionStartedAt;
+  return <text>{symbol}</text>;
+}
+
 afterEach(async () => {
   if (testSetup) {
     await act(async () => {
@@ -27,6 +43,9 @@ afterEach(async () => {
     testSetup = undefined;
   }
   bumpHarness = null;
+  updateLiveTargets = null;
+  updateFreshnessScope = null;
+  observedSubscriptionStartedAt = 0;
   setSharedMarketDataCoordinator(null);
 });
 
@@ -66,5 +85,43 @@ describe("useQuoteStreaming", () => {
 
     expect(subscribeCalls).toBe(1);
     expect(unsubscribeCalls).toBe(0);
+  });
+
+  test("keeps quote freshness stable while targets move within one surface", async () => {
+    const originalDateNow = Date.now;
+    let now = 100;
+    Date.now = () => now;
+    setSharedMarketDataCoordinator(new MarketDataCoordinator(createTestDataProvider({
+      subscribeQuotes: () => () => {},
+    })));
+
+    try {
+      testSetup = await testRender(<LiveQuoteFreshnessHarness />, {
+        width: 20,
+        height: 1,
+      });
+      await act(async () => {
+        await testSetup!.renderOnce();
+      });
+      expect(observedSubscriptionStartedAt).toBe(100);
+
+      now = 200;
+      await act(async () => {
+        updateLiveTargets?.("MSFT");
+        await Promise.resolve();
+        await testSetup!.renderOnce();
+      });
+      expect(observedSubscriptionStartedAt).toBe(100);
+
+      now = 300;
+      await act(async () => {
+        updateFreshnessScope?.("expiration-2");
+        await Promise.resolve();
+        await testSetup!.renderOnce();
+      });
+      expect(observedSubscriptionStartedAt).toBe(300);
+    } finally {
+      Date.now = originalDateNow;
+    }
   });
 });

--- a/src/state/hooks/quote-streaming.ts
+++ b/src/state/hooks/quote-streaming.ts
@@ -101,7 +101,10 @@ export function useQuoteStreaming(targets: QuoteSubscriptionTarget[]): void {
  * Subscribe to a bounded target set and observe the coordinator entries filled
  * by that stream. This intentionally avoids per-symbol HTTP quote loads.
  */
-export function useLiveQuoteEntries(targets: QuoteSubscriptionTarget[]): {
+export function useLiveQuoteEntries(
+  targets: QuoteSubscriptionTarget[],
+  options: { freshnessScopeKey?: string } = {},
+): {
   entries: Map<string, QueryEntry<Quote>>;
   freshnessNow: number;
   subscriptionStartedAt: number;
@@ -115,7 +118,7 @@ export function useLiveQuoteEntries(targets: QuoteSubscriptionTarget[]): {
     .map((target) => buildQuoteStreamSubscriptionKey(target))
     .sort()
     .join("\u001f");
-  const subscriptionKey = `${appActive ? "active" : "inactive"}\u001f${targetKey}`;
+  const subscriptionKey = `${appActive ? "active" : "inactive"}\u001f${options.freshnessScopeKey ?? targetKey}`;
   const subscriptionRef = useRef({
     key: subscriptionKey,
     startedAt: Date.now(),


### PR DESCRIPTION
## What

- Subscribe the Cloud quote stream to every call and put in the visible TUI or desktop viewport, with bounded overscan and the selected row retained.
- Derive live, mixed, connecting, and delayed footer states from per-contract stream metadata.
- Keep unchanged live heartbeat frames fresh locally while preserving upstream exchange timestamps.
- Add translated option stream status copy.

## Why

The options pane previously subscribed a fixed window around the selected strike. Scrolling far from the current price could therefore leave visible contracts on chain snapshots. Quiet heartbeat frames were also deduplicated before refreshing their local receipt time.

## Impact

All visible option rows now stay subscribed without making the client aware of the Cloud data provider implementation. Free-plan delayed behavior and existing international market-data routes are unchanged. No pricing-page copy is changed.

## Validation

- 54 focused option, viewport, hook, and coordinator tests passed.
- 29 coordinator and live-chart regression tests passed.
- All four TypeScript projects passed.
- i18n audit and desktop view build passed.
- Production AAPL July 31 streaming was exercised in the actual terminal TUI and Electrobun desktop, including far visible calls and puts. Sampled downstream quotes reported dataSource=live, delivery=stream, stale=false.
- Runtime error scans were clean.