### PR TITLE
Add live quote pane controls

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -490,6 +490,42 @@ function MyPane() {
 }
 ```
 
+### Pane quick settings
+
+A pane can surface important toggle settings next to its title. Each quick setting references a `toggle` field from the pane's normal settings definition, so the header control and settings dialog share the same persisted value and update behavior.
+
+```typescript
+ctx.registerPane({
+  id: "live-prices",
+  name: "Live Prices",
+  component: LivePricesPane,
+  defaultPosition: "right",
+  quickSettings: [
+    { type: "toggle", key: "liveStreaming", icon: "zap" },
+  ],
+  settings: (context) => ({
+    values: {
+      liveStreaming: context.settings.liveStreaming !== false,
+    },
+    fields: [
+      {
+        key: "liveStreaming",
+        label: "Live streaming",
+        description: "Stream updates continuously when enabled.",
+        type: "toggle",
+      },
+    ],
+  }),
+});
+
+function LivePricesPane() {
+  const [liveStreaming] = usePaneSettingValue("liveStreaming", true);
+  // Use liveStreaming to select continuous updates or a slower polling path.
+}
+```
+
+Quick settings currently support toggle fields with the `zap` icon. Unknown keys and non-toggle fields are ignored.
+
 ### Events
 
 Subscribe to and emit app events:

--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, useRendererHost, useUiCapabilities } from "../../ui";
+import { Box, Span, Text, useRendererHost, useUiCapabilities } from "../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { t } from "../../i18n";
 import { useShortcut, useViewport } from "../../react/input";
@@ -49,6 +49,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
   const instance = useAppSelector((state) => findPaneInstance(state.config.layout, desktopWindowBridge.paneId) ?? null);
   const paneDef = instance ? pluginRegistry.panes.get(instance.paneId) ?? null : null;
   const hasPaneSettings = !!instance && pluginRegistry.hasPaneSettings(instance.instanceId);
+  const quickSettings = instance ? pluginRegistry.resolvePaneQuickSettings(instance.instanceId) : [];
   const titleState = useMemo(
     () => ({ config, paneState }) as Parameters<typeof getPaneDisplayTitle>[0],
     [config, paneState],
@@ -118,6 +119,16 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
     stopMouse(event);
     pluginRegistry.openPaneSettingsFn(desktopWindowBridge.paneId);
   }, [desktopWindowBridge.paneId, pluginRegistry]);
+  const toggleQuickSetting = useCallback((key: string, event?: { stopPropagation?: () => void; preventDefault?: () => void }) => {
+    stopMouse(event);
+    focusPane();
+    void pluginRegistry.togglePaneQuickSetting(desktopWindowBridge.paneId, key).catch((error) => {
+      pluginRegistry.notify({
+        body: error instanceof Error ? error.message : "Could not update pane setting.",
+        type: "error",
+      });
+    });
+  }, [desktopWindowBridge.paneId, focusPane, pluginRegistry]);
 
   if (!instance || !paneDef) {
     return (
@@ -183,9 +194,36 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
                 paddingRight={showWindowControls ? 0 : 1}
                 style={{ position: "relative" }}
               >
-                <Box flexGrow={1} minWidth={0} overflow="hidden">
+                <Box minWidth={0} flexShrink={1} overflow="hidden">
                   <Text fg={paneTitleText(focused, true, colors)} selectable={false} data-gloom-role="pane-title">{title}</Text>
                 </Box>
+                {quickSettings.map((setting) => (
+                  <Box
+                    key={setting.key}
+                    height={1}
+                    minWidth={20}
+                    paddingLeft={1}
+                    paddingRight={1}
+                    alignItems="center"
+                    justifyContent="center"
+                    className="electrobun-webkit-app-region-no-drag"
+                    data-gloom-role="pane-quick-setting"
+                    data-setting-key={setting.key}
+                    data-gloom-interactive="true"
+                    aria-label={`${setting.label}: ${setting.value ? "on" : "off"}`}
+                    aria-pressed={setting.value}
+                    title={`${setting.label}: ${setting.value ? "on" : "off"}`}
+                    style={{ cursor: "pointer" }}
+                    onMouseDown={(event: any) => toggleQuickSetting(setting.key, event)}
+                  >
+                    <Span style={{ display: "inline-flex", width: 12, height: 12, color: setting.value ? colors.warning : colors.textDim }}>
+                      <svg viewBox="0 0 12 12" width="12" height="12" fill="none" aria-hidden="true">
+                        <path d="M7.1 1.2 2.7 6.5h3.1l-.7 4.3 4.4-5.5H6.4l.7-4.1Z" fill="currentColor" />
+                      </svg>
+                    </Span>
+                  </Box>
+                ))}
+                <Box flexGrow={1} minWidth={0} />
                 {hasPaneSettings && (
                   <Text
                     fg={paneTitleText(focused, true, colors)}

--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -2,7 +2,7 @@ import { Box, Text, useUiCapabilities } from "../../ui";
 import type { ReactNode } from "react";
 import { colors, floatingPaneBg } from "../../theme/colors";
 import { PaneBodyFrame, getPaneWindowAttributes } from "./pane/frame";
-import { PaneHeader } from "./pane/header";
+import { PaneHeader, type PaneHeaderQuickSetting } from "./pane/header";
 import { hasPaneFooterContent, PaneFooterBar, type CombinedPaneFooter } from "./pane/footer";
 import { resolvePaneBodyFrame, shouldReservePaneFooter } from "./pane/sizing";
 
@@ -17,6 +17,7 @@ interface FloatingPaneWrapperProps {
   focused: boolean;
   windowModeSelected?: boolean;
   showActions?: boolean;
+  quickSettings?: PaneHeaderQuickSetting[];
   onMouseDown?: (event: any) => void;
   onMouseDownCapture?: (event: any) => void;
   onHeaderMouseMove?: (event: any) => void;
@@ -63,6 +64,7 @@ export function FloatingPaneWrapper({
   focused,
   windowModeSelected = false,
   showActions = false,
+  quickSettings,
   onMouseDown,
   onMouseDownCapture,
   onHeaderMouseMove,
@@ -115,6 +117,7 @@ export function FloatingPaneWrapper({
         windowModeSelected={windowModeSelected}
         floating
         showActions={showActions}
+        quickSettings={quickSettings}
         onHeaderMouseMove={onHeaderMouseMove}
         onHeaderMouseDown={onHeaderMouseDown}
         onHeaderMouseDrag={onHeaderMouseDrag}

--- a/src/components/layout/pane/header.tsx
+++ b/src/components/layout/pane/header.tsx
@@ -15,6 +15,7 @@ interface PaneHeaderProps {
   windowModeSelected?: boolean;
   floating?: boolean;
   showActions?: boolean;
+  quickSettings?: PaneHeaderQuickSetting[];
   onHeaderMouseMove?: (event: any) => void;
   onHeaderMouseDown?: (event: any) => void;
   onHeaderMouseDrag?: (event: any) => void;
@@ -22,6 +23,15 @@ interface PaneHeaderProps {
   onHeaderContextMenu?: (event: any) => void;
   onActionMouseDown?: (event: any) => void;
   onCloseMouseDown?: (event: any) => void;
+}
+
+export interface PaneHeaderQuickSetting {
+  key: string;
+  icon: "zap";
+  label: string;
+  description?: string;
+  active: boolean;
+  onMouseDown?: (event: any) => void;
 }
 
 function truncateTitle(title: string, maxWidth: number): string {
@@ -43,9 +53,15 @@ function captureTerminalPointerDrag(renderer: unknown, renderable: unknown): voi
 function DesktopPaneButton({
   icon,
   onMouseDown,
+  color = colors.textDim,
+  label,
+  pressed,
 }: {
   icon: ReactNode;
   onMouseDown?: (event: any) => void;
+  color?: string;
+  label?: string;
+  pressed?: boolean;
 }) {
   return (
     <Box
@@ -54,6 +70,9 @@ function DesktopPaneButton({
       justifyContent="center"
       onMouseDown={onMouseDown}
       data-gloom-interactive={onMouseDown ? "true" : undefined}
+      aria-label={label}
+      aria-pressed={pressed}
+      title={label}
       style={{
         borderRadius: 4,
         minWidth: 20,
@@ -69,7 +88,7 @@ function DesktopPaneButton({
           justifyContent: "center",
           width: 12,
           height: 12,
-          color: colors.textDim,
+          color,
         }}
       >
         {icon}
@@ -92,7 +111,7 @@ function TerminalPaneButton({
   return (
     <Box
       height={1}
-      width={text.length}
+      width={displayWidth(text)}
       flexDirection="row"
       data-gloom-role={role}
       data-gloom-interactive={onMouseDown ? "true" : undefined}
@@ -110,6 +129,7 @@ export function PaneHeader({
   windowModeSelected = false,
   floating = false,
   showActions = false,
+  quickSettings = [],
   onHeaderMouseMove,
   onHeaderMouseDown,
   onHeaderMouseDrag,
@@ -125,6 +145,7 @@ export function PaneHeader({
   const backgroundColor = floating ? floatingPaneTitleBg(visuallyFocused) : paneTitleBg(visuallyFocused);
   const actionText = showActions ? PANE_HEADER_ACTION : "     ";
   const closeText = floating ? PANE_HEADER_CLOSE : "";
+  const terminalQuickSettingsWidth = quickSettings.reduce((total) => total + displayWidth(" ⚡ "), 0);
   const textColor = paneTitleText(visuallyFocused, floating);
   const handleTerminalHeaderMouseDown = useCallback((event: any) => {
     captureTerminalPointerDrag(nativeRenderer, terminalHeaderRef.current);
@@ -158,7 +179,7 @@ export function PaneHeader({
         <Text fg={visuallyFocused ? colors.borderFocused : colors.textMuted} selectable={false} data-gloom-role="pane-grip">
           {PANE_HEADER_GRIP}
         </Text>
-        <Box flexGrow={1} minWidth={0} overflow="hidden">
+        <Box minWidth={0} flexShrink={1} overflow="hidden">
           <Text
             fg={textColor}
             selectable={false}
@@ -173,6 +194,25 @@ export function PaneHeader({
             {title}
           </Text>
         </Box>
+        {quickSettings.map((setting) => (
+          <Box key={setting.key} data-gloom-role="pane-quick-setting" data-setting-key={setting.key}>
+            <DesktopPaneButton
+              onMouseDown={setting.onMouseDown}
+              color={setting.active ? colors.warning : colors.textDim}
+              label={`${setting.label}: ${setting.active ? "on" : "off"}`}
+              pressed={setting.active}
+              icon={(
+                <svg viewBox="0 0 12 12" width="12" height="12" fill="none" aria-hidden="true">
+                  <path
+                    d="M7.1 1.2 2.7 6.5h3.1l-.7 4.3 4.4-5.5H6.4l.7-4.1Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              )}
+            />
+          </Box>
+        ))}
+        <Box flexGrow={1} minWidth={0} />
         <Box data-gloom-role="pane-action">
           {showActions ? (
             <DesktopPaneButton
@@ -213,10 +253,10 @@ export function PaneHeader({
     // Reserve 2 for corners, 1 for ─ after ┌, 1 for ─ before ┐
     const borderColor = visuallyFocused ? colors.borderFocused : colors.border;
     const innerWidth = Math.max(0, width - 4);
-    const contentWidth = PANE_HEADER_GRIP.length + closeText.length + actionText.length;
+    const contentWidth = PANE_HEADER_GRIP.length + terminalQuickSettingsWidth + closeText.length + actionText.length;
     const titleWidth = Math.max(0, innerWidth - contentWidth);
     const clippedTitle = truncateTitle(title, titleWidth);
-    const fillLen = Math.max(0, innerWidth - PANE_HEADER_GRIP.length - displayWidth(clippedTitle) - actionText.length - closeText.length);
+    const fillLen = Math.max(0, innerWidth - PANE_HEADER_GRIP.length - displayWidth(clippedTitle) - terminalQuickSettingsWidth - actionText.length - closeText.length);
     const fill = "─".repeat(fillLen);
 
     return (
@@ -233,6 +273,15 @@ export function PaneHeader({
       >
         <Text fg={borderColor} selectable={false}>{"┌─"}</Text>
         <Text fg={textColor} selectable={false}>{`${PANE_HEADER_GRIP}${clippedTitle}`}</Text>
+        {quickSettings.map((setting) => (
+          <TerminalPaneButton
+            key={setting.key}
+            text=" ⚡ "
+            fg={setting.active ? colors.warning : colors.textDim}
+            role="pane-quick-setting"
+            onMouseDown={setting.onMouseDown}
+          />
+        ))}
         <Text fg={borderColor} selectable={false}>{fill}</Text>
         <TerminalPaneButton
           text={actionText}
@@ -253,7 +302,7 @@ export function PaneHeader({
     );
   }
 
-  const titleWidth = Math.max(0, width - PANE_HEADER_GRIP.length - actionText.length - closeText.length);
+  const titleWidth = Math.max(0, width - PANE_HEADER_GRIP.length - terminalQuickSettingsWidth - actionText.length - closeText.length);
   const clippedTitle = truncateTitle(title, titleWidth);
   const padding = " ".repeat(Math.max(0, titleWidth - displayWidth(clippedTitle)));
 
@@ -272,6 +321,15 @@ export function PaneHeader({
       <Text fg={textColor} selectable={false}>
         {`${PANE_HEADER_GRIP}${clippedTitle}${padding}`}
       </Text>
+      {quickSettings.map((setting) => (
+        <TerminalPaneButton
+          key={setting.key}
+          text=" ⚡ "
+          fg={setting.active ? colors.warning : colors.textDim}
+          role="pane-quick-setting"
+          onMouseDown={setting.onMouseDown}
+        />
+      ))}
       <TerminalPaneButton
         text={actionText}
         fg={textColor}

--- a/src/components/layout/pane/index.tsx
+++ b/src/components/layout/pane/index.tsx
@@ -2,7 +2,7 @@ import { Box, useUiCapabilities } from "../../../ui";
 import type { ReactNode } from "react";
 import { paneBg } from "../../../theme/colors";
 import { PaneBodyFrame, getPaneWindowAttributes } from "./frame";
-import { PaneHeader } from "./header";
+import { PaneHeader, type PaneHeaderQuickSetting } from "./header";
 import { hasPaneFooterContent, PaneFooterBar, type CombinedPaneFooter } from "./footer";
 import { resolvePaneBodyFrame, shouldReservePaneFooter } from "./sizing";
 
@@ -15,6 +15,7 @@ interface PaneWrapperProps {
   height?: number | `${number}%` | "auto";
   flexGrow?: number;
   showActions?: boolean;
+  quickSettings?: PaneHeaderQuickSetting[];
   onMouseDown?: (event: any) => void;
   onMouseDownCapture?: (event: any) => void;
   onHeaderMouseMove?: (event: any) => void;
@@ -36,6 +37,7 @@ export function PaneWrapper({
   height,
   flexGrow,
   showActions = false,
+  quickSettings,
   onMouseDown,
   onMouseDownCapture,
   onHeaderMouseMove,
@@ -87,6 +89,7 @@ export function PaneWrapper({
           focused={focused}
           windowModeSelected={windowModeSelected}
           showActions={showActions}
+          quickSettings={quickSettings}
           onHeaderMouseMove={onHeaderMouseMove}
           onHeaderMouseDown={onHeaderMouseDown}
           onHeaderMouseDrag={onHeaderMouseDrag}

--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -30,6 +30,7 @@ import {
 } from "../../../state/selectors-ui";
 import { useThemeColors } from "../../../theme/theme-context";
 import { getPaneDisplayTitle } from "../pane/title";
+import type { PaneHeaderQuickSetting } from "../pane/header";
 import { getShortcutDisplayMode } from "../../../utils/shortcut-labels";
 import {
   actionMenuWidth,
@@ -423,6 +424,27 @@ export function Shell({
     (pane: ResolvedPane): string => getPaneDisplayTitle(titleState, pane.instance, pane.def),
     [titleState],
   );
+  const handlePaneQuickSetting = useCallback((paneId: string, key: string, event: any) => {
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
+    focusPane(paneId);
+    void pluginRegistry.togglePaneQuickSetting(paneId, key).catch((error) => {
+      pluginRegistry.notify({
+        body: error instanceof Error ? error.message : "Could not update pane setting.",
+        type: "error",
+      });
+    });
+  }, [focusPane, pluginRegistry]);
+  const getPaneQuickSettings = useCallback((paneId: string): PaneHeaderQuickSetting[] => (
+    (pluginRegistry.resolvePaneQuickSettings?.(paneId) ?? []).map((setting) => ({
+      key: setting.key,
+      icon: setting.icon,
+      label: setting.label,
+      description: setting.description,
+      active: setting.value,
+      onMouseDown: (event) => handlePaneQuickSetting(paneId, setting.key, event),
+    }))
+  ), [config, handlePaneQuickSetting, pluginRegistry]);
 
   const openPaneMenu = useCallback((paneId: string, rect: LayoutBounds, event?: { preventDefault?: () => void; stopPropagation?: () => void }) => {
     const pane = paneMap.get(paneId);
@@ -561,6 +583,7 @@ export function Shell({
         dragFloatingRect={dragFloatingRect}
         focusedPaneId={focusedPaneId}
         getPaneTitle={getPaneTitle}
+        getPaneQuickSettings={getPaneQuickSettings}
         handleFloatingClose={handleFloatingClose}
         handleFloatingCloseMouseDown={handleFloatingCloseMouseDown}
         handleNativeDrag={handleNativeDrag}

--- a/src/components/layout/shell/pane/layers.tsx
+++ b/src/components/layout/shell/pane/layers.tsx
@@ -12,6 +12,7 @@ import { pathKey } from "../../window-edit/mode";
 import { FloatingPaneWrapper } from "../../floating-pane";
 import { PaneContent } from "../../pane/content";
 import { PaneWrapper } from "../../pane";
+import type { PaneHeaderQuickSetting } from "../../pane/header";
 import { hasPaneFooterContent, PaneFooterProvider } from "../../pane/footer";
 import { resolvePaneBodyFrame, shouldReservePaneFooter } from "../../pane/sizing";
 import type { DividerPreviewState } from "../native/window-state";
@@ -31,6 +32,7 @@ interface ShellPaneLayersProps {
   dragFloatingRect: { paneId: string; rect: FloatingRect } | null;
   focusedPaneId: string | null;
   getPaneTitle: (pane: ResolvedPane) => string;
+  getPaneQuickSettings: (paneId: string) => PaneHeaderQuickSetting[];
   handleFloatingClose: (paneId: string) => void;
   handleFloatingCloseMouseDown: (paneId: string, event: any) => void;
   handleNativeDrag: ShellMouseHandler;
@@ -64,6 +66,7 @@ export function ShellPaneLayers({
   dragFloatingRect,
   focusedPaneId,
   getPaneTitle,
+  getPaneQuickSettings,
   handleFloatingClose,
   handleFloatingCloseMouseDown,
   handleNativeDrag,
@@ -129,6 +132,7 @@ export function ShellPaneLayers({
                     width={rect.width}
                     height={rect.height}
                     showActions={showActions}
+                    quickSettings={getPaneQuickSettings(leaf.instanceId)}
                     windowModeSelected={windowModeSelected}
                     footer={footer}
                     onMouseDownCapture={nativePaneChrome ? (event) => handleNativePaneMouseDown(leaf.instanceId, event) : undefined}
@@ -190,6 +194,7 @@ export function ShellPaneLayers({
                   focused={focused}
                   windowModeSelected={windowModeSelected}
                   showActions={showActions}
+                  quickSettings={getPaneQuickSettings(pane.instance.instanceId)}
                   footer={footer}
                   onMouseDownCapture={nativePaneChrome ? (event) => handleNativePaneMouseDown(pane.instance.instanceId, event) : undefined}
                   onHeaderMouseMove={() => setHoveredPaneIfChanged(pane.instance.instanceId)}

--- a/src/plugins/builtin/ai/index.tsx
+++ b/src/plugins/builtin/ai/index.tsx
@@ -46,6 +46,10 @@ import {
   normalizeTabs,
   type PersistedAiScreenerPaneState,
 } from "./screener/model";
+import {
+  LIVE_STREAMING_QUICK_SETTING,
+  withLiveStreamingSetting,
+} from "../shared/live-streaming";
 
 function settingOrFallback(
   settings: Record<string, unknown>,
@@ -331,6 +335,7 @@ export const aiPlugin: GloomPlugin = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 76, height: 24 },
+      quickSettings: [LIVE_STREAMING_QUICK_SETTING],
       settings: (context) => {
         const providers = detectProviders();
         const screenerProviders = providers.filter((provider) => (
@@ -351,7 +356,7 @@ export const aiPlugin: GloomPlugin = {
           ? context.paneState.activeTabId
           : null;
         const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? tabs[0] ?? null;
-        return buildAiPaneSettingsDef({
+        return withLiveStreamingSetting(buildAiPaneSettingsDef({
           title: "AI Screener Settings",
           providers: settingsProviders(screenerProviders),
           models: settingsModels(providerIds),
@@ -369,7 +374,7 @@ export const aiPlugin: GloomPlugin = {
           additional: buildAiScreenerPaneSettingsDef(
             getAiScreenerPaneSettings(context.settings),
           ),
-        });
+        }), context.settings);
       },
     });
 

--- a/src/plugins/builtin/ai/screener/market-runtime.ts
+++ b/src/plugins/builtin/ai/screener/market-runtime.ts
@@ -5,7 +5,7 @@ import { useAppSelector } from "../../../../state/app/context";
 import { useFxRatesMap, useTickerFinancialsMap } from "../../../../market-data/hooks";
 import { getSharedMarketDataCoordinator } from "../../../../market-data/coordinator";
 import { instrumentFromTicker, quoteSubscriptionTargetFromTicker } from "../../../../market-data/request-types";
-import { useQuoteStreaming } from "../../../../state/hooks/quote-streaming";
+import { useQuoteUpdates } from "../../../../state/hooks/quote-streaming";
 import type { ColumnContext } from "../../portfolio-list/metrics";
 import type { ColumnConfig } from "../../../../types/config";
 import type { ValidatedScreenerResult } from "./contract";
@@ -21,6 +21,7 @@ interface UseAiScreenerMarketRuntimeOptions {
   resultMap: Map<string, ValidatedScreenerResult>;
   setCursorSymbol: (symbol: string | null) => void;
   tickers: Map<string, TickerRecord>;
+  liveStreaming: boolean;
 }
 
 export function useAiScreenerMarketRuntime({
@@ -32,6 +33,7 @@ export function useAiScreenerMarketRuntime({
   resultMap,
   setCursorSymbol,
   tickers,
+  liveStreaming,
 }: UseAiScreenerMarketRuntimeOptions) {
   const baseCurrency = useAppSelector((state) => state.config.baseCurrency);
   const cachedExchangeRates = useAppSelector((state) => state.exchangeRates);
@@ -68,7 +70,7 @@ export function useAiScreenerMarketRuntime({
     })
   ), [sortedTickers]);
 
-  useQuoteStreaming(quoteTargets);
+  useQuoteUpdates(quoteTargets, { liveStreaming });
 
   useEffect(() => {
     const coordinator = getSharedMarketDataCoordinator();

--- a/src/plugins/builtin/ai/screener/pane.tsx
+++ b/src/plugins/builtin/ai/screener/pane.tsx
@@ -52,12 +52,14 @@ import {
   AI_DEFAULT_PROVIDER_SETTING_KEY,
   resolveAiPaneSelection,
 } from "../pane-settings";
+import { useLiveStreamingSetting } from "../../shared/live-streaming";
 
 export function AiScreenerPane({ focused, width, height }: PaneProps) {
   const dataProvider = useAssetData();
   const { pinTicker } = usePluginTickerActions();
   const paneId = usePaneInstanceId();
   const paneInstance = usePaneInstance();
+  const liveStreaming = useLiveStreamingSetting();
   const dispatch = useAppDispatch();
   const tickers = useAppSelector((state) => state.tickers);
   const providers = useAiRuntimeProviders();
@@ -169,6 +171,7 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
     resultMap,
     setCursorSymbol,
     tickers,
+    liveStreaming,
   });
 
   const updateTabs = useCallback((updater: (tabs: AiScreenerTab[]) => AiScreenerTab[]) => {

--- a/src/plugins/builtin/chart-composer/index.tsx
+++ b/src/plugins/builtin/chart-composer/index.tsx
@@ -20,6 +20,10 @@ import {
 } from "./presets";
 import { buildChartComposerPaneSettingsDef } from "./settings";
 import type { PluginModule } from "../plugin-module";
+import {
+  LIVE_STREAMING_QUICK_SETTING,
+  withLiveStreamingSetting,
+} from "../shared/live-streaming";
 
 const CHART_COMPOSER_TEMPLATE_ID = "chart-composer-pane";
 
@@ -199,9 +203,13 @@ export const chartComposerModule: PluginModule = {
     defaultPosition: "right",
     defaultMode: "floating",
     defaultFloatingSize: { width: 100, height: 32 },
-    settings: (context) => buildChartComposerPaneSettingsDef(
+    quickSettings: [LIVE_STREAMING_QUICK_SETTING],
+    settings: (context) => withLiveStreamingSetting(
+      buildChartComposerPaneSettingsDef(
+        context.settings,
+        context.activeTicker,
+      ),
       context.settings,
-      context.activeTicker,
     ),
   }],
   paneTemplates: chartComposerTemplates,

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -61,6 +61,7 @@ import {
 } from "./settings";
 import { resolveChartComposerShortcut } from "./shortcuts";
 import { ChartSeriesQuickAdd } from "./quick-add";
+import { useLiveStreamingSetting } from "../shared/live-streaming";
 
 const RANGE_TABS = RANGES.map((range, index) => ({ label: `${index + 1}:${range}`, value: range }));
 const AUTO_VIEWPORT_DEBOUNCE_MS = 350;
@@ -107,6 +108,7 @@ function ChartComposerSurface({
   const dialog = useDialog();
   const dispatch = useAppDispatch();
   const paneId = usePaneInstanceId();
+  const liveStreaming = useLiveStreamingSetting();
   const dialogOpen = useDialogState((state) => state.isOpen);
   const authoredViewportKey = useMemo(() => JSON.stringify({
     range: spec.viewport.range,
@@ -145,6 +147,7 @@ function ChartComposerSurface({
       : null,
     requestViewport: activeRuntimeViewport?.requestViewport,
     targetPointCount,
+    liveStreaming,
   });
   const availableResolutions = useMemo<ChartResolution[]>(() => {
     if (!resolution.resolutionSupport) {

--- a/src/plugins/builtin/options/index.tsx
+++ b/src/plugins/builtin/options/index.tsx
@@ -1,6 +1,10 @@
 import type { PluginModule } from "../plugin-module";
 import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
 import { OptionsView } from "./view";
+import {
+  LIVE_STREAMING_QUICK_SETTING,
+  withLiveStreamingSetting,
+} from "../shared/live-streaming";
 
 export const optionsModule: PluginModule = {
   panes: [
@@ -12,6 +16,8 @@ export const optionsModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 112, height: 28 },
+      quickSettings: [LIVE_STREAMING_QUICK_SETTING],
+      settings: (context) => withLiveStreamingSetting({ fields: [] }, context.settings),
     },
   ],
 

--- a/src/plugins/builtin/options/view.tsx
+++ b/src/plugins/builtin/options/view.tsx
@@ -30,9 +30,11 @@ import {
   resolveOptionQuoteCoverage,
 } from "./live-quotes";
 import { useOptionsAccessFooter } from "./footer";
+import { useLiveStreamingSetting } from "../shared/live-streaming";
 
 export function OptionsView({ width, height, focused, onCapture = () => {} }: OptionsViewProps) {
   const { ticker, financials } = usePaneTicker();
+  const liveStreaming = useLiveStreamingSetting();
   const [expIdx, setExpIdx] = useState(0);
   const [strikeIdx, setStrikeIdx] = useState(0);
   const [autoScrollVersion, setAutoScrollVersion] = useState(0);
@@ -168,6 +170,7 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     subscriptionStartedAt,
   } = useLiveQuoteEntries(optionQuoteTargets, {
     freshnessScopeKey: viewportKey,
+    liveStreaming,
   });
   const optionQuoteFreshness = useMemo(
     () => ({

--- a/src/plugins/builtin/portfolio-list/index.tsx
+++ b/src/plugins/builtin/portfolio-list/index.tsx
@@ -9,6 +9,10 @@ import {
 } from "./settings";
 import { portfolioCliCommand } from "./cli/portfolio-command";
 import { watchlistCliCommand } from "./cli/watchlist-command";
+import {
+  LIVE_STREAMING_QUICK_SETTING,
+  withLiveStreamingSetting,
+} from "../shared/live-streaming";
 
 export { shouldToggleCashMarginDrawer };
 
@@ -43,10 +47,14 @@ export const portfolioListModule: PluginModule = {
       defaultPosition: "left",
       defaultMode: "floating",
       defaultWidth: "40%",
-      settings: (context) => buildPortfolioPaneSettingsDef(
-        context.config,
-        getPortfolioPaneSettings(context.settings),
-        context.activeCollectionId,
+      quickSettings: [LIVE_STREAMING_QUICK_SETTING],
+      settings: (context) => withLiveStreamingSetting(
+        buildPortfolioPaneSettingsDef(
+          context.config,
+          getPortfolioPaneSettings(context.settings),
+          context.activeCollectionId,
+        ),
+        context.settings,
       ),
     },
   ],

--- a/src/plugins/builtin/portfolio-list/pane/index.tsx
+++ b/src/plugins/builtin/portfolio-list/pane/index.tsx
@@ -51,6 +51,8 @@ import {
 } from "./data";
 import { usePortfolioPaneStreaming } from "./streaming";
 import { usePortfolioSupplementalData } from "./supplemental";
+import { useLiveStreamingSetting } from "../../shared/live-streaming";
+import { useThrottledTickerOrder } from "../use-throttled-ticker-order";
 
 export function PortfolioListPane({ focused, width, height }: PaneProps) {
   const { pinTicker } = usePluginTickerActions();
@@ -63,6 +65,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
   const brokerAccounts = useAppSelector((state) => state.brokerAccounts);
   const refreshingSize = useAppSelector((state) => state.refreshing.size);
   const paneCollection = usePaneCollection();
+  const liveStreaming = useLiveStreamingSetting();
 
   const [currentCollectionId, setCurrentCollectionId] = usePaneStateValue<string>("collectionId", paneCollection.collectionId ?? "");
   const [committedCursorSymbol, setCommittedCursorSymbol] = usePaneStateValue<string | null>("cursorSymbol", null);
@@ -169,9 +172,26 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
   ]);
 
   const activeSort = resolveCollectionSortPreference(activeCollectionId, isPortfolioTab, collectionSorts);
-  const sortedTickers = useMemo(
+  const candidateSortedTickers = useMemo(
     () => sortTickers(tickers, financialsMap, activeSort, columnContext, columns),
     [tickers, financialsMap, activeSort, columnContext, columns],
+  );
+  const candidateSymbols = useMemo(
+    () => candidateSortedTickers.map((ticker) => ticker.metadata.ticker),
+    [candidateSortedTickers],
+  );
+  const orderResetKey = `${activeCollectionId}|${activeSort.columnId ?? ""}|${activeSort.direction}`;
+  const orderedSymbols = useThrottledTickerOrder(candidateSymbols, orderResetKey);
+  const tickerBySymbol = useMemo(
+    () => new Map(candidateSortedTickers.map((ticker) => [ticker.metadata.ticker, ticker])),
+    [candidateSortedTickers],
+  );
+  const sortedTickers = useMemo(
+    () => orderedSymbols.flatMap((symbol) => {
+      const ticker = tickerBySymbol.get(symbol);
+      return ticker ? [ticker] : [];
+    }),
+    [orderedSymbols, tickerBySymbol],
   );
 
   const selectedIdx = sortedTickers.findIndex((ticker) => ticker.metadata.ticker === cursorSymbol);
@@ -322,6 +342,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     activeSort,
     financialsMap,
     visibleWarmupRequirements,
+    liveStreaming,
   });
 
   const summaryFooterInfo = useMemo(() => buildPortfolioFooterSegments({

--- a/src/plugins/builtin/portfolio-list/pane/streaming.ts
+++ b/src/plugins/builtin/portfolio-list/pane/streaming.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import { getSharedMarketDataCoordinator } from "../../../../market-data/coordinator";
 import { instrumentFromTicker, quoteSubscriptionTargetFromTicker } from "../../../../market-data/request-types";
-import { useQuoteStreaming } from "../../../../state/hooks/quote-streaming";
+import { useQuoteUpdates } from "../../../../state/hooks/quote-streaming";
 import type { TickerFinancials } from "../../../../types/financials";
 import type { TickerRecord } from "../../../../types/ticker";
 import type { CollectionSortPreference } from "../../../../state/app/context";
@@ -32,6 +32,7 @@ export function usePortfolioPaneStreaming({
   activeSort,
   financialsMap,
   visibleWarmupRequirements,
+  liveStreaming,
 }: {
   appActive: boolean;
   activeCollectionId?: string;
@@ -42,6 +43,7 @@ export function usePortfolioPaneStreaming({
   activeSort: CollectionSortPreference;
   financialsMap: Map<string, TickerFinancials>;
   visibleWarmupRequirements: VisibleWarmupRequirements;
+  liveStreaming: boolean;
 }) {
   const sharedCoordinator = getSharedMarketDataCoordinator();
   const mountedRef = useRef(true);
@@ -213,7 +215,7 @@ export function usePortfolioPaneStreaming({
   }, [activeSort, appActive, financialsMap, instrumentOptions, sharedCoordinator, sortedTickers, streamWindow, visibleFinancialTickers, visibleWarmupRequirements]);
 
   useEffect(() => {
-    if (!appActive) return;
+    if (!liveStreaming || !appActive) return;
     if (!sharedCoordinator) return;
 
     let cancelled = false;
@@ -262,7 +264,7 @@ export function usePortfolioPaneStreaming({
       cancelled = true;
       clearInterval(intervalId);
     };
-  }, [appActive, sharedCoordinator]);
+  }, [appActive, liveStreaming, sharedCoordinator]);
 
-  useQuoteStreaming(streamTargets);
+  useQuoteUpdates(streamTargets, { liveStreaming });
 }

--- a/src/plugins/builtin/portfolio-list/use-throttled-ticker-order.test.tsx
+++ b/src/plugins/builtin/portfolio-list/use-throttled-ticker-order.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useState } from "react";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { useThrottledTickerOrder } from "./use-throttled-ticker-order";
+
+const TEST_THROTTLE_MS = 80;
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+let updateCandidates: ((symbols: string[]) => void) | null = null;
+let updateResetKey: ((key: string) => void) | null = null;
+let latestOrder: string[] = [];
+
+function ThrottledOrderHarness() {
+  const [candidates, setCandidates] = useState(["AAPL", "MSFT", "NVDA"]);
+  const [resetKey, setResetKey] = useState("price:desc");
+  latestOrder = useThrottledTickerOrder(candidates, resetKey, TEST_THROTTLE_MS);
+  updateCandidates = setCandidates;
+  updateResetKey = setResetKey;
+  return <text>{latestOrder.join(",")}</text>;
+}
+
+afterEach(async () => {
+  if (testSetup) {
+    await act(async () => testSetup!.renderer.destroy());
+    testSetup = undefined;
+  }
+  updateCandidates = null;
+  updateResetKey = null;
+  latestOrder = [];
+});
+
+describe("useThrottledTickerOrder", () => {
+  test("coalesces rapid market-driven reorders into the latest trailing order", async () => {
+    testSetup = await testRender(<ThrottledOrderHarness />, { width: 32, height: 1 });
+    await act(async () => testSetup!.renderOnce());
+
+    await act(async () => {
+      updateCandidates?.(["MSFT", "AAPL", "NVDA"]);
+      await Promise.resolve();
+    });
+    await act(async () => testSetup!.renderOnce());
+    expect(latestOrder).toEqual(["MSFT", "AAPL", "NVDA"]);
+
+    await act(async () => {
+      updateCandidates?.(["NVDA", "MSFT", "AAPL"]);
+      await Promise.resolve();
+    });
+    await act(async () => testSetup!.renderOnce());
+    expect(latestOrder).toEqual(["MSFT", "AAPL", "NVDA"]);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, TEST_THROTTLE_MS + 20));
+    });
+    await act(async () => testSetup!.renderOnce());
+    expect(latestOrder).toEqual(["NVDA", "MSFT", "AAPL"]);
+  });
+
+  test("applies user sort changes and ticker membership changes immediately", async () => {
+    testSetup = await testRender(<ThrottledOrderHarness />, { width: 32, height: 1 });
+    await act(async () => testSetup!.renderOnce());
+
+    await act(async () => {
+      updateCandidates?.(["NVDA", "MSFT", "AAPL"]);
+      updateResetKey?.("price:asc");
+      await Promise.resolve();
+    });
+    await act(async () => testSetup!.renderOnce());
+    expect(latestOrder).toEqual(["NVDA", "MSFT", "AAPL"]);
+
+    await act(async () => {
+      updateCandidates?.(["AMD", "NVDA", "MSFT", "AAPL"]);
+      await Promise.resolve();
+    });
+    await act(async () => testSetup!.renderOnce());
+    expect(latestOrder).toEqual(["AMD", "NVDA", "MSFT", "AAPL"]);
+  });
+});

--- a/src/plugins/builtin/portfolio-list/use-throttled-ticker-order.ts
+++ b/src/plugins/builtin/portfolio-list/use-throttled-ticker-order.ts
@@ -1,0 +1,78 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+export const PORTFOLIO_REORDER_THROTTLE_MS = 5_000;
+
+function hasSameOrder(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((symbol, index) => symbol === right[index]);
+}
+
+function hasSameMembership(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  const symbols = new Set(left);
+  return right.every((symbol) => symbols.has(symbol));
+}
+
+export function useThrottledTickerOrder(
+  candidateSymbols: string[],
+  resetKey: string,
+  throttleMs = PORTFOLIO_REORDER_THROTTLE_MS,
+): string[] {
+  const [committedSymbols, setCommittedSymbols] = useState(candidateSymbols);
+  const committedRef = useRef(candidateSymbols);
+  const latestCandidateRef = useRef(candidateSymbols);
+  const resetKeyRef = useRef(resetKey);
+  const lastCommitAtRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const candidateKey = JSON.stringify(candidateSymbols);
+
+  useEffect(() => {
+    latestCandidateRef.current = candidateSymbols;
+    const current = committedRef.current;
+    const resetChanged = resetKeyRef.current !== resetKey;
+    const membershipChanged = !hasSameMembership(current, candidateSymbols);
+    resetKeyRef.current = resetKey;
+
+    const commit = (nextSymbols: string[]) => {
+      committedRef.current = nextSymbols;
+      lastCommitAtRef.current = Date.now();
+      setCommittedSymbols(nextSymbols);
+    };
+
+    if (resetChanged || membershipChanged) {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = null;
+      if (!hasSameOrder(current, candidateSymbols)) commit(candidateSymbols);
+      return;
+    }
+    if (hasSameOrder(current, candidateSymbols)) return;
+
+    const elapsed = Date.now() - lastCommitAtRef.current;
+    const remaining = Math.max(0, throttleMs - elapsed);
+    if (remaining === 0) {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = null;
+      commit(candidateSymbols);
+      return;
+    }
+    if (timerRef.current) return;
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      const latest = latestCandidateRef.current;
+      if (!hasSameOrder(committedRef.current, latest)) commit(latest);
+    }, remaining);
+  }, [candidateKey, resetKey, throttleMs]);
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  return useMemo(() => {
+    const currentSymbols = new Set(candidateSymbols);
+    const ordered = committedSymbols.filter((symbol) => currentSymbols.has(symbol));
+    const orderedSet = new Set(ordered);
+    for (const symbol of candidateSymbols) {
+      if (!orderedSet.has(symbol)) ordered.push(symbol);
+    }
+    return ordered;
+  }, [candidateKey, committedSymbols]);
+}

--- a/src/plugins/builtin/shared/live-streaming.ts
+++ b/src/plugins/builtin/shared/live-streaming.ts
@@ -1,0 +1,43 @@
+import { usePaneSettingValue } from "../../../state/app/context";
+import type {
+  PaneQuickSettingDef,
+  PaneSettingField,
+  PaneSettingsDef,
+} from "../../../types/plugin";
+
+export const LIVE_STREAMING_SETTING_KEY = "liveStreaming";
+
+export const LIVE_STREAMING_QUICK_SETTING: PaneQuickSettingDef = {
+  type: "toggle",
+  key: LIVE_STREAMING_SETTING_KEY,
+  icon: "zap",
+};
+
+export const LIVE_STREAMING_SETTING_FIELD: PaneSettingField = {
+  type: "toggle",
+  key: LIVE_STREAMING_SETTING_KEY,
+  label: "Live streaming",
+  description: "Stream quote updates continuously. Turn off to refresh quotes once per minute.",
+};
+
+export function withLiveStreamingSetting(
+  settingsDef: PaneSettingsDef,
+  settings: Record<string, unknown> | undefined,
+): PaneSettingsDef {
+  return {
+    ...settingsDef,
+    values: {
+      ...settingsDef.values,
+      [LIVE_STREAMING_SETTING_KEY]: settings?.[LIVE_STREAMING_SETTING_KEY] !== false,
+    },
+    fields: [
+      ...settingsDef.fields.filter((field) => field.key !== LIVE_STREAMING_SETTING_KEY),
+      LIVE_STREAMING_SETTING_FIELD,
+    ],
+  };
+}
+
+export function useLiveStreamingSetting(): boolean {
+  const [enabled] = usePaneSettingValue(LIVE_STREAMING_SETTING_KEY, true);
+  return enabled;
+}

--- a/src/plugins/builtin/ticker-detail/index.tsx
+++ b/src/plugins/builtin/ticker-detail/index.tsx
@@ -19,6 +19,10 @@ import {
   getTickerResearchPaneSettings,
 } from "./settings";
 import { formatTickerListInput } from "../../../tickers/list";
+import {
+  LIVE_STREAMING_QUICK_SETTING,
+  withLiveStreamingSetting,
+} from "../shared/live-streaming";
 
 function hasStatementFinancials(financials: TickerFinancials | null | undefined): boolean {
   return (financials?.annualStatements.length ?? 0) > 0 || (financials?.quarterlyStatements.length ?? 0) > 0;
@@ -50,7 +54,11 @@ export const tickerDetailModule: PluginModule = {
       component: TickerResearchPane,
       defaultPosition: "right",
       defaultMode: "floating",
-      settings: (context) => buildTickerResearchSettingsDef(getTickerResearchPaneSettings(context.settings)),
+      quickSettings: [LIVE_STREAMING_QUICK_SETTING],
+      settings: (context) => withLiveStreamingSetting(
+        buildTickerResearchSettingsDef(getTickerResearchPaneSettings(context.settings)),
+        context.settings,
+      ),
     },
     {
       id: "financial-analysis",
@@ -69,7 +77,8 @@ export const tickerDetailModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 72, height: 10 },
-      settings: buildQuoteMonitorSettingsDef(),
+      quickSettings: [LIVE_STREAMING_QUICK_SETTING],
+      settings: (context) => withLiveStreamingSetting(buildQuoteMonitorSettingsDef(), context.settings),
     },
     {
       id: "historical-prices",

--- a/src/plugins/builtin/ticker-detail/pane.tsx
+++ b/src/plugins/builtin/ticker-detail/pane.tsx
@@ -11,7 +11,7 @@ import {
   usePaneStateValue,
   usePaneTicker,
 } from "../../../state/app/context";
-import { useQuoteStreaming } from "../../../state/hooks/quote-streaming";
+import { useQuoteUpdates } from "../../../state/hooks/quote-streaming";
 import { getCollectionName, getCollectionTickerCount } from "../../../state/selectors";
 import { getSharedRegistry } from "../../registry";
 import { EmptyState, PaneFooterScope, Tabs } from "../../../components";
@@ -22,6 +22,7 @@ import {
   getTickerResearchPaneSettings,
   resolveLockedTabId,
 } from "./settings";
+import { useLiveStreamingSetting } from "../shared/live-streaming";
 
 const TICKER_RESEARCH_TAB_COMMIT_DELAY_MS = 120;
 
@@ -61,6 +62,7 @@ export function TickerResearchPane({ focused, width, height }: PaneProps) {
   const config = useAppSelector((state) => state.config);
   const paneInstance = usePaneInstance();
   const { ticker, financials } = usePaneTicker();
+  const liveStreaming = useLiveStreamingSetting();
   const streamingTarget = quoteSubscriptionTargetFromTicker(ticker, ticker?.metadata.ticker, "provider");
   const streamingTargets = useMemo(() => (
     streamingTarget
@@ -80,7 +82,7 @@ export function TickerResearchPane({ focused, width, height }: PaneProps) {
     streamingTarget?.context?.brokerInstanceId,
     streamingTarget?.context?.instrument,
   ]);
-  useQuoteStreaming(streamingTargets);
+  useQuoteUpdates(streamingTargets, { liveStreaming });
 
   const { collectionId } = usePaneCollection();
   const [committedActiveTabId, setCommittedActiveTabId] = usePaneStateValue<string>("activeTabId", "overview");

--- a/src/plugins/builtin/ticker-detail/quote-monitor/index.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor/index.tsx
@@ -5,13 +5,14 @@ import { TICKER_RESEARCH_PANE_ID } from "../../../../types/config";
 import type { QuoteSubscriptionTarget } from "../../../../types/data-provider";
 import { quoteSubscriptionTargetFromTicker } from "../../../../market-data/request-types";
 import { useAppSelector, usePaneInstance, usePaneTicker } from "../../../../state/app/context";
-import { useQuoteStreaming } from "../../../../state/hooks/quote-streaming";
+import { useQuoteUpdates } from "../../../../state/hooks/quote-streaming";
 import { usePluginAppActions, usePluginTickerActions } from "../../../runtime";
 import { colors } from "../../../../theme/colors";
 import { EmptyState } from "../../../../components";
 import { getQuoteMonitorPaneSettings } from "../settings";
 import { useShortcut } from "../../../../react/input";
 import { QuoteMonitorCard } from "./card";
+import { useLiveStreamingSetting } from "../../shared/live-streaming";
 
 function chunkSymbols(symbols: string[], columns: number): string[][] {
   const rows: string[][] = [];
@@ -58,6 +59,7 @@ function resolveGridColumnCount(symbolCount: number, width: number, height: numb
 export function QuoteMonitorPane({ paneId, focused, width, height }: PaneProps) {
   const pane = usePaneInstance();
   const { symbol: fallbackSymbol, ticker: fallbackTicker } = usePaneTicker();
+  const liveStreaming = useLiveStreamingSetting();
   const settings = useMemo(
     () => getQuoteMonitorPaneSettings(pane?.settings, fallbackSymbol),
     [fallbackSymbol, pane?.settings],
@@ -77,7 +79,7 @@ export function QuoteMonitorPane({ paneId, focused, width, height }: PaneProps) 
     }
     return targets;
   }, [fallbackSymbol, fallbackTicker, symbols, tickersBySymbol]);
-  useQuoteStreaming(streamingTargets);
+  useQuoteUpdates(streamingTargets, { liveStreaming });
   const { pinTicker } = usePluginTickerActions();
   const { openPaneSettings } = usePluginAppActions();
   const { nativePaneChrome } = useUiCapabilities();

--- a/src/plugins/registry/index.test.ts
+++ b/src/plugins/registry/index.test.ts
@@ -414,6 +414,57 @@ describe("PluginRegistry pane settings", () => {
     expect(descriptor?.pluginId).toBe("news");
     expect(descriptor?.context.settings.breakingNewsNotificationsEnabled).toBe(true);
   });
+
+  test("resolves and applies toggle-backed pane quick settings", async () => {
+    const registry = createRegistry();
+    const config = createDefaultConfig("/tmp/gloomberb-pane-quick-settings-test");
+    config.layout = {
+      dockRoot: { kind: "pane", instanceId: "test-pane:main" },
+      instances: [{
+        instanceId: "test-pane:main",
+        paneId: "test-pane",
+        binding: { kind: "none" },
+        settings: {},
+      }],
+      floating: [],
+      detached: [],
+    };
+    registry.getConfigFn = () => config;
+    registry.getLayoutFn = () => config.layout;
+
+    await registry.register(plugin("quotes", (ctx) => {
+      ctx.registerPane({
+        id: "test-pane",
+        name: "Test Pane",
+        defaultPosition: "right",
+        component: () => null,
+        quickSettings: [{ type: "toggle", key: "liveStreaming", icon: "zap" }],
+        settings: {
+          values: { liveStreaming: true },
+          fields: [{
+            key: "liveStreaming",
+            label: "Live streaming",
+            type: "toggle",
+          }],
+        },
+      });
+    }));
+
+    const applied: Array<{ key: string; value: unknown }> = [];
+    registry.applyPaneSettingValueFn = async (_paneId, field, value) => {
+      applied.push({ key: field.key, value });
+    };
+
+    expect(registry.resolvePaneQuickSettings("test-pane:main")).toMatchObject([{
+      key: "liveStreaming",
+      icon: "zap",
+      label: "Live streaming",
+      value: true,
+    }]);
+
+    await registry.togglePaneQuickSetting("test-pane:main", "liveStreaming");
+    expect(applied).toEqual([{ key: "liveStreaming", value: false }]);
+  });
 });
 
 describe("PluginRegistry broker runtime", () => {

--- a/src/plugins/registry/index.ts
+++ b/src/plugins/registry/index.ts
@@ -42,7 +42,9 @@ import {
 } from "../runtime";
 import type { PaneRuntimeState } from "../../core/state/app/state";
 import {
+  resolveRegistryPaneQuickSettings,
   resolveRegistryPaneSettings,
+  type ResolvedRegistryPaneQuickSetting,
   type ResolvedRegistryPaneSettings,
 } from "./pane-settings";
 import { RegistrySlots } from "./slots";
@@ -361,6 +363,16 @@ export class PluginRegistry implements PluginRuntimeAccess {
 
   hasPaneSettings(paneId: string): boolean {
     return this.resolvePaneSettings(paneId) !== null;
+  }
+
+  resolvePaneQuickSettings(paneId: string): ResolvedRegistryPaneQuickSetting[] {
+    return resolveRegistryPaneQuickSettings(this.resolvePaneSettings(paneId));
+  }
+
+  async togglePaneQuickSetting(paneId: string, key: string): Promise<void> {
+    const quickSetting = this.resolvePaneQuickSettings(paneId).find((setting) => setting.key === key);
+    if (!quickSetting) return;
+    await this.applyPaneSettingValueFn(paneId, quickSetting.field, !quickSetting.value);
   }
 
   getCommandPluginId(commandId: string): string | undefined {

--- a/src/plugins/registry/pane-settings.ts
+++ b/src/plugins/registry/pane-settings.ts
@@ -7,6 +7,8 @@ import { getPaneSettings } from "../../pane-settings";
 import type { AppConfig, LayoutConfig, PaneInstanceConfig } from "../../types/config";
 import type {
   PaneDef,
+  PaneQuickSettingDef,
+  PaneSettingField,
   PaneSettingsContext,
   PaneSettingsDef,
 } from "../../types/plugin";
@@ -19,6 +21,33 @@ export interface ResolvedRegistryPaneSettings {
   settingsDef: PaneSettingsDef;
   rawSettings: Record<string, unknown>;
   context: PaneSettingsContext;
+}
+
+export interface ResolvedRegistryPaneQuickSetting extends PaneQuickSettingDef {
+  label: string;
+  description?: string;
+  value: boolean;
+  field: PaneSettingField & { type: "toggle" };
+}
+
+export function resolveRegistryPaneQuickSettings(
+  resolved: ResolvedRegistryPaneSettings | null,
+): ResolvedRegistryPaneQuickSetting[] {
+  if (!resolved?.paneDef.quickSettings?.length) return [];
+
+  return resolved.paneDef.quickSettings.flatMap((quickSetting) => {
+    const field = resolved.settingsDef.fields.find((candidate) => (
+      candidate.key === quickSetting.key && candidate.type === "toggle"
+    ));
+    if (!field || field.type !== "toggle") return [];
+    return [{
+      ...quickSetting,
+      label: quickSetting.label ?? field.label,
+      description: field.description,
+      value: resolved.context.settings[quickSetting.key] === true,
+      field,
+    }];
+  });
 }
 
 export function resolveRegistryPaneSettings({

--- a/src/state/hooks/quote-streaming.test.tsx
+++ b/src/state/hooks/quote-streaming.test.tsx
@@ -3,10 +3,11 @@ import { act, useState } from "react";
 import { testRender } from "../../renderers/opentui/test-utils";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../market-data/coordinator";
 import { createTestDataProvider } from "../../test-support/data-provider";
-import { useLiveQuoteEntries, useQuoteStreaming } from "./quote-streaming";
+import { useLiveQuoteEntries, useQuoteStreaming, useQuoteUpdates } from "./quote-streaming";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let bumpHarness: (() => void) | null = null;
+let togglePollingPriority: (() => void) | null = null;
 let updateLiveTargets: ((symbol: string) => void) | null = null;
 let updateFreshnessScope: ((scope: string) => void) | null = null;
 let observedSubscriptionStartedAt = 0;
@@ -21,6 +22,32 @@ function QuoteStreamingHarness() {
   }]);
 
   return <text>{String(tick)}</text>;
+}
+
+function QuotePollingHarness() {
+  useQuoteUpdates([{
+    symbol: "AAPL",
+    exchange: "NASDAQ",
+  }], {
+    liveStreaming: false,
+    pollIntervalMs: 30,
+  });
+  return <text>polling</text>;
+}
+
+function QuotePollingPriorityHarness() {
+  const [selected, setSelected] = useState(false);
+  togglePollingPriority = () => setSelected((current) => !current);
+  useQuoteUpdates([{
+    symbol: "AAPL",
+    exchange: "NASDAQ",
+    selected,
+    weight: selected ? 100 : 10,
+  }], {
+    liveStreaming: false,
+    pollIntervalMs: 1_000,
+  });
+  return <text>{selected ? "selected" : "idle"}</text>;
 }
 
 function LiveQuoteFreshnessHarness() {
@@ -43,6 +70,7 @@ afterEach(async () => {
     testSetup = undefined;
   }
   bumpHarness = null;
+  togglePollingPriority = null;
   updateLiveTargets = null;
   updateFreshnessScope = null;
   observedSubscriptionStartedAt = 0;
@@ -85,6 +113,56 @@ describe("useQuoteStreaming", () => {
 
     expect(subscribeCalls).toBe(1);
     expect(unsubscribeCalls).toBe(0);
+  });
+
+  test("uses forced polling instead of a subscription when live streaming is disabled", async () => {
+    let subscribeCalls = 0;
+    let loadCalls = 0;
+    const coordinator = {
+      subscribeQuotes: () => {
+        subscribeCalls += 1;
+        return () => {};
+      },
+      loadQuotesBatch: async (_instruments: unknown[], options: { forceRefresh?: boolean }) => {
+        expect(options.forceRefresh).toBe(true);
+        loadCalls += 1;
+        return [];
+      },
+    };
+    setSharedMarketDataCoordinator(coordinator as unknown as MarketDataCoordinator);
+
+    testSetup = await testRender(<QuotePollingHarness />, { width: 20, height: 1 });
+    await act(async () => testSetup!.renderOnce());
+    expect(subscribeCalls).toBe(0);
+    expect(loadCalls).toBe(1);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 45));
+    });
+    expect(loadCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  test("does not restart polling when only subscription priority changes", async () => {
+    let loadCalls = 0;
+    const coordinator = {
+      subscribeQuotes: () => () => {},
+      loadQuotesBatch: async () => {
+        loadCalls += 1;
+        return [];
+      },
+    };
+    setSharedMarketDataCoordinator(coordinator as unknown as MarketDataCoordinator);
+
+    testSetup = await testRender(<QuotePollingPriorityHarness />, { width: 20, height: 1 });
+    await act(async () => testSetup!.renderOnce());
+    expect(loadCalls).toBe(1);
+
+    await act(async () => {
+      togglePollingPriority?.();
+      await Promise.resolve();
+    });
+    await act(async () => testSetup!.renderOnce());
+    expect(loadCalls).toBe(1);
   });
 
   test("keeps quote freshness stable while targets move within one surface", async () => {

--- a/src/state/hooks/quote-streaming.ts
+++ b/src/state/hooks/quote-streaming.ts
@@ -11,6 +11,17 @@ import type { QueryEntry } from "../../market-data/result-types";
 import { buildQuoteKey } from "../../market-data/selectors";
 
 const quoteStreamLog = debugLog.createLogger("quote-stream");
+export const DEFAULT_QUOTE_POLL_INTERVAL_MS = 60_000;
+
+export interface QuoteStreamingOptions {
+  enabled?: boolean;
+}
+
+export interface QuoteUpdateOptions {
+  liveStreaming?: boolean;
+  pollIntervalMs?: number;
+  freshnessScopeKey?: string;
+}
 
 export function normalizeQuoteStreamSubscriptionTarget(target: QuoteSubscriptionTarget): QuoteSubscriptionTarget | null {
   const symbol = normalizeSymbol(target.symbol);
@@ -42,7 +53,10 @@ export function buildQuoteStreamSubscriptionKey(target: QuoteSubscriptionTarget)
   ].join("|");
 }
 
-export function useQuoteStreaming(targets: QuoteSubscriptionTarget[]): void {
+export function useQuoteStreaming(
+  targets: QuoteSubscriptionTarget[],
+  { enabled = true }: QuoteStreamingOptions = {},
+): void {
   const appActive = useAppActive();
   const coordinator = getSharedMarketDataCoordinator();
 
@@ -58,9 +72,12 @@ export function useQuoteStreaming(targets: QuoteSubscriptionTarget[]): void {
   const subscriptionKey = sortedEntries.map(([key]) => key).join("|");
 
   useEffect(() => {
-    if (!appActive) {
+    if (!enabled || !appActive) {
       if (normalizedTargets.length > 0) {
-        quoteStreamLog.info("skipping subscription while inactive", { targets: subscriptionKey });
+        quoteStreamLog.info("skipping subscription", {
+          reason: enabled ? "inactive" : "disabled",
+          targets: subscriptionKey,
+        });
       }
       return;
     }
@@ -94,7 +111,71 @@ export function useQuoteStreaming(targets: QuoteSubscriptionTarget[]): void {
       });
       unsubscribe?.();
     };
-  }, [appActive, coordinator, subscriptionKey]);
+  }, [appActive, coordinator, enabled, subscriptionKey]);
+}
+
+export function useQuoteUpdates(
+  targets: QuoteSubscriptionTarget[],
+  {
+    liveStreaming = true,
+    pollIntervalMs = DEFAULT_QUOTE_POLL_INTERVAL_MS,
+  }: QuoteUpdateOptions = {},
+): void {
+  const appActive = useAppActive();
+  const coordinator = getSharedMarketDataCoordinator();
+  const normalizedTargets = targets.flatMap((target) => {
+    const normalized = normalizeQuoteStreamSubscriptionTarget(target);
+    return normalized ? [normalized] : [];
+  });
+  const instrumentKey = normalizedTargets
+    .map((target) => buildQuoteKey({
+      symbol: target.symbol,
+      exchange: target.exchange,
+      brokerId: target.context?.brokerId,
+      brokerInstanceId: target.context?.brokerInstanceId,
+      instrument: target.context?.instrument ?? null,
+    }))
+    .sort()
+    .join("\u001f");
+  const instruments = useMemo(() => {
+    const unique = new Map<string, InstrumentRef>();
+    for (const target of normalizedTargets) {
+      const instrument: InstrumentRef = {
+        symbol: target.symbol,
+        exchange: target.exchange,
+        brokerId: target.context?.brokerId,
+        brokerInstanceId: target.context?.brokerInstanceId,
+        instrument: target.context?.instrument ?? null,
+      };
+      unique.set(buildQuoteKey(instrument), instrument);
+    }
+    return [...unique.values()];
+  }, [instrumentKey]);
+
+  useQuoteStreaming(targets, { enabled: liveStreaming });
+
+  useEffect(() => {
+    if (liveStreaming || !appActive || !coordinator || instruments.length === 0) return;
+    let cancelled = false;
+    let inFlight = false;
+    const refresh = async () => {
+      if (cancelled || inFlight) return;
+      inFlight = true;
+      try {
+        await coordinator.loadQuotesBatch(instruments, { forceRefresh: true });
+      } catch {
+        // Polling is best effort and the coordinator retains the last good quote.
+      } finally {
+        inFlight = false;
+      }
+    };
+    void refresh();
+    const intervalId = setInterval(() => void refresh(), pollIntervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [appActive, coordinator, instrumentKey, instruments, liveStreaming, pollIntervalMs]);
 }
 
 /**
@@ -103,7 +184,7 @@ export function useQuoteStreaming(targets: QuoteSubscriptionTarget[]): void {
  */
 export function useLiveQuoteEntries(
   targets: QuoteSubscriptionTarget[],
-  options: { freshnessScopeKey?: string } = {},
+  options: QuoteUpdateOptions = {},
 ): {
   entries: Map<string, QueryEntry<Quote>>;
   freshnessNow: number;
@@ -118,7 +199,9 @@ export function useLiveQuoteEntries(
     .map((target) => buildQuoteStreamSubscriptionKey(target))
     .sort()
     .join("\u001f");
-  const subscriptionKey = `${appActive ? "active" : "inactive"}\u001f${options.freshnessScopeKey ?? targetKey}`;
+  const liveStreaming = options.liveStreaming !== false;
+  const freshnessKey = options.freshnessScopeKey ?? targetKey;
+  const subscriptionKey = `${appActive ? "active" : "inactive"}\u001f${liveStreaming ? "live" : "poll"}\u001f${freshnessKey}`;
   const subscriptionRef = useRef({
     key: subscriptionKey,
     startedAt: Date.now(),
@@ -152,7 +235,7 @@ export function useLiveQuoteEntries(
     return () => clearInterval(interval);
   }, [appActive, targetKey]);
 
-  useQuoteStreaming(targets);
+  useQuoteUpdates(targets, options);
   return {
     entries: useQuoteEntries(instruments),
     freshnessNow,

--- a/src/time-series/use-chart-resolution.test.tsx
+++ b/src/time-series/use-chart-resolution.test.tsx
@@ -103,6 +103,14 @@ function ResolutionHarness({
   return <text>{`${latestResult.loading ? "loading" : "settled"}:${pointCount}`}</text>;
 }
 
+function PollingResolutionHarness({ sources }: { sources: ChartResolveSources }) {
+  latestResult = useChartResolution(SPEC, sources, {
+    liveStreaming: false,
+    quotePollingIntervalMs: 30,
+  });
+  return <text>{latestResult.loading ? "loading" : "settled"}</text>;
+}
+
 async function flushEffects(iterations = 1): Promise<void> {
   for (let iteration = 0; iteration < iterations; iteration += 1) {
     await act(async () => {
@@ -134,6 +142,35 @@ afterEach(async () => {
 });
 
 describe("useChartResolution", () => {
+  test("polls chart data without opening a quote subscription when live streaming is disabled", async () => {
+    let historyCalls = 0;
+    let subscribeCalls = 0;
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => EMPTY_FINANCIALS,
+      getPriceHistoryForResolution: async () => {
+        historyCalls += 1;
+        return INITIAL_HISTORY;
+      },
+      subscribeQuotes: () => {
+        subscribeCalls += 1;
+        return () => {};
+      },
+    });
+    testSetup = await testRender(<PollingResolutionHarness sources={sourcesFor(provider)} />, {
+      width: 24,
+      height: 1,
+    });
+
+    await waitFor(() => historyCalls >= 2 && latestResult?.loading === false);
+    expect(subscribeCalls).toBe(0);
+
+    const callsAfterImmediatePoll = historyCalls;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 45));
+    });
+    await waitFor(() => historyCalls > callsAfterImmediatePoll);
+  });
+
   test("keeps renderable data settled through empty adaptive and live refreshes", async () => {
     const adaptiveHistory = deferred<PricePoint[]>();
     let detailedCalls = 0;

--- a/src/time-series/use-chart-resolution.ts
+++ b/src/time-series/use-chart-resolution.ts
@@ -19,10 +19,14 @@ export interface UseChartResolutionResult extends ChartResolutionResult {
 
 export interface UseChartResolutionOptions {
   liveRefreshIntervalMs?: number;
+  liveStreaming?: boolean;
+  quotePollingIntervalMs?: number;
   autoViewport?: ChartResolveOptions["autoViewport"];
   requestViewport?: ChartResolveOptions["requestViewport"];
   targetPointCount?: number;
 }
+
+const DEFAULT_QUOTE_POLL_INTERVAL_MS = 60_000;
 
 const EMPTY_RESULT: ChartResolutionResult = {
   series: [],
@@ -150,9 +154,11 @@ export function useChartResolution(
 
   const liveTargetSignature = liveChartQuoteTargetSignature(spec);
   const liveRefreshIntervalMs = options.liveRefreshIntervalMs ?? LIVE_CHART_REFRESH_INTERVAL_MS;
+  const liveStreaming = options.liveStreaming !== false;
   useEffect(() => {
     const subscriptionGeneration = ++liveSubscriptionGenerationRef.current;
     liveQuoteOverridesRef.current = new Map();
+    if (!liveStreaming) return;
     const dispose = subscribeToLiveChartQuotes({
       spec,
       dataProvider: sources.dataProvider,
@@ -202,7 +208,17 @@ export function useChartResolution(
         liveQuoteOverridesRef.current = new Map();
       }
     };
-  }, [liveRefreshIntervalMs, liveTargetSignature, sources.dataProvider]);
+  }, [liveRefreshIntervalMs, liveStreaming, liveTargetSignature, sources.dataProvider]);
+
+  const quotePollingIntervalMs = options.quotePollingIntervalMs ?? DEFAULT_QUOTE_POLL_INTERVAL_MS;
+  useEffect(() => {
+    if (liveStreaming || !liveTargetSignature) return;
+    setRevision((current) => current + 1);
+    const intervalId = setInterval(() => {
+      setRevision((current) => current + 1);
+    }, quotePollingIntervalMs);
+    return () => clearInterval(intervalId);
+  }, [liveStreaming, liveTargetSignature, quotePollingIntervalMs]);
 
   return { ...result, reload };
 }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -53,6 +53,15 @@ export interface PaneDef {
   defaultFloatingSize?: { width: number; height: number };
   defaultMode?: "docked" | "floating";
   settings?: PaneSettingsDef | ((context: PaneSettingsContext) => PaneSettingsDef | null);
+  /** Compact controls surfaced next to the pane title. Toggle keys reference toggle fields in settings. */
+  quickSettings?: readonly PaneQuickSettingDef[];
+}
+
+export interface PaneQuickSettingDef {
+  type: "toggle";
+  key: string;
+  icon: "zap";
+  label?: string;
 }
 
 export interface PaneSettingsContext {


### PR DESCRIPTION
## Summary

- throttle quote-driven portfolio and watchlist reordering to at most once every five seconds
- add reusable toggle-backed pane quick settings with a zap control in pane titles
- switch live-data panes between websocket streaming and one-minute quote polling
- document the plugin quick settings API and cover the async behavior with focused tests

## Validation

- focused Bun tests: 93 passed, 0 failed across 11 files
- `bun run typecheck`
- `bun run build`
- `bun run desktop:view:build`
- real OpenTUI tmux verification of the live toggle, with a clean runtime warning scan
