### PR TITLE
Fix onboarding rendering and small-terminal layout

### DIFF
--- a/src/components/onboarding/onboarding-steps.tsx
+++ b/src/components/onboarding/onboarding-steps.tsx
@@ -1,8 +1,10 @@
+import { useMemo } from "react";
 import { AsciiText, Box, Span, Strong, Text, TextAttributes, useUiHost } from "../../ui";
 import { colors } from "../../theme/colors";
 import { t, tf } from "../../i18n";
 import { themes } from "../../theme/themes";
 import { detectShortcutPlatform, formatPrimaryShortcut, getShortcutDisplayMode } from "../../utils/shortcut-labels";
+import { ListView, type ListViewItem } from "../ui";
 export { PortfolioStep, type PortfolioSub } from "./portfolio-step";
 
 export interface BrokerSyncSummary {
@@ -30,12 +32,24 @@ export function WelcomeStep() {
   );
 }
 
-export function ThemeStep({ themeIds, selectedIdx, height }: { themeIds: string[]; selectedIdx: number; height: number }) {
-  const maxVisible = Math.min(themeIds.length, Math.max(6, height - 12));
-  const halfWindow = Math.floor(maxVisible / 2);
-  let windowStart = Math.max(0, Math.min(selectedIdx - halfWindow, themeIds.length - maxVisible));
-  if (windowStart < 0) windowStart = 0;
-  const windowEnd = Math.min(themeIds.length, windowStart + maxVisible);
+// Rows the theme step spends on everything that is not the theme list itself.
+const THEME_CHROME_ROWS = 8;
+
+export function ThemeStep({
+  themeIds,
+  selectedIdx,
+  onSelect,
+  height,
+}: {
+  themeIds: string[];
+  selectedIdx: number;
+  onSelect: (index: number) => void;
+  height: number;
+}) {
+  const items = useMemo<ListViewItem[]>(
+    () => themeIds.map((id) => ({ id, label: themes[id]!.name })),
+    [themeIds],
+  );
 
   return (
     <Box flexDirection="column" paddingX={2}>
@@ -48,7 +62,7 @@ export function ThemeStep({ themeIds, selectedIdx, height }: { themeIds: string[
         <Text fg={colors.text} attributes={TextAttributes.BOLD}>{"TH"}</Text>
       </Box>
       <Box height={1} />
-      <Box height={1}>
+      <Box height={1} flexDirection="row">
         <Text fg={colors.positive}>{" \u2588\u2588 "}</Text>
         <Text fg={colors.negative}>{" \u2588\u2588 "}</Text>
         <Text fg={colors.text}>{" \u2588\u2588 "}</Text>
@@ -58,33 +72,13 @@ export function ThemeStep({ themeIds, selectedIdx, height }: { themeIds: string[
       </Box>
       <Box height={1} />
 
-      {windowStart > 0 && (
-        <Box height={1}>
-          <Text fg={colors.textMuted}>{"\u2191 more"}</Text>
-        </Box>
-      )}
-
-      {themeIds.slice(windowStart, windowEnd).map((id, index) => {
-        const theme = themes[id]!;
-        const globalIdx = windowStart + index;
-        const isSelected = globalIdx === selectedIdx;
-        return (
-          <Box key={id} height={1} backgroundColor={isSelected ? colors.selected : colors.bg}>
-            <Text fg={isSelected ? colors.selectedText : colors.textDim}>
-              {isSelected ? "\u25b8 " : "  "}
-            </Text>
-            <Text fg={isSelected ? colors.text : colors.textDim} attributes={isSelected ? TextAttributes.BOLD : 0}>
-              {theme.name}
-            </Text>
-          </Box>
-        );
-      })}
-
-      {windowEnd < themeIds.length && (
-        <Box height={1}>
-          <Text fg={colors.textMuted}>{"\u2193 more"}</Text>
-        </Box>
-      )}
+      <ListView
+        items={items}
+        selectedIndex={selectedIdx}
+        onSelect={onSelect}
+        scrollable
+        height={Math.max(3, height - THEME_CHROME_ROWS)}
+      />
 
       <Box height={1} />
       <Box height={1}>
@@ -94,7 +88,7 @@ export function ThemeStep({ themeIds, selectedIdx, height }: { themeIds: string[
   );
 }
 
-export function ShortcutsStep() {
+export function ShortcutsStep({ height }: { height: number }) {
   const uiHost = useUiHost();
   const shortcutPlatform = detectShortcutPlatform();
   const shortcutDisplayMode = getShortcutDisplayMode(uiHost.kind);
@@ -117,6 +111,11 @@ export function ShortcutsStep() {
 
   const COL = 20;
 
+  // Shed the least useful rows first so the wizard footer stays on screen in an 80x24 terminal.
+  const gap = height < 21 ? 1 : 2;
+  const showTagline = height >= 19;
+  const showPrefixHint = height >= 17;
+
   return (
     <Box flexDirection="column" paddingX={2}>
       <Box height={1}>
@@ -131,15 +130,19 @@ export function ShortcutsStep() {
         </Box>
       ))}
 
-      <Box height={2} />
+      <Box height={gap} />
       <Box height={1}>
         <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{t("Basic command prefixes")}</Text>
       </Box>
       <Box height={1} />
-      <Box height={1}>
-        <Text fg={colors.textDim}>{t("Type these in the command bar (")}<Span fg={colors.text}><Strong>{"Ctrl+P"}</Strong></Span>{"):"}</Text>
-      </Box>
-      <Box height={1} />
+      {showPrefixHint && (
+        <>
+          <Box height={1}>
+            <Text fg={colors.textDim}>{t("Type these in the command bar (")}<Span fg={colors.text}><Strong>{"Ctrl+P"}</Strong></Span>{"):"}</Text>
+          </Box>
+          <Box height={1} />
+        </>
+      )}
 
       {commandPrefixes.map((shortcut) => (
         <Box key={shortcut.key} height={1} flexDirection="row">
@@ -148,10 +151,14 @@ export function ShortcutsStep() {
         </Box>
       ))}
 
-      <Box height={2} />
-      <Box height={1}>
-        <Text fg={colors.textDim}>{t("Everything is searchable, just type what you want.")}</Text>
-      </Box>
+      {showTagline && (
+        <>
+          <Box height={gap} />
+          <Box height={1}>
+            <Text fg={colors.textDim}>{t("Everything is searchable, just type what you want.")}</Text>
+          </Box>
+        </>
+      )}
     </Box>
   );
 }
@@ -179,21 +186,21 @@ export function ReadyStep({
         <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{t("You're all set")}</Text>
       </Box>
       <Box height={2} />
-      <Box height={1}>
-        <Text fg={colors.positive} attributes={TextAttributes.BOLD}>{"\u2713"}</Text>
-        <Text fg={colors.text}>{` ${t("Theme configured")}`}</Text>
+      <Box height={1} flexDirection="row">
+        <Text fg={colors.positive} attributes={TextAttributes.BOLD}>{"\u2713 "}</Text>
+        <Text fg={colors.text}>{t("Theme configured")}</Text>
       </Box>
-      <Box height={1}>
-        <Text fg={colors.positive} attributes={TextAttributes.BOLD}>{"\u2713"}</Text>
+      <Box height={1} flexDirection="row">
+        <Text fg={colors.positive} attributes={TextAttributes.BOLD}>{"\u2713 "}</Text>
         <Text fg={colors.text}>
           {brokerName
-            ? ` ${tf("{broker} connected. Imported {count} {label}", { broker: brokerName, count: positionsImported, label: t(positionLabel) })}`
-            : ` ${tf('Portfolio "{name}" created', { name: portfolioName })}`}
+            ? tf("{broker} connected. Imported {count} {label}", { broker: brokerName, count: positionsImported, label: t(positionLabel) })
+            : tf('Portfolio "{name}" created', { name: portfolioName })}
         </Text>
       </Box>
-      <Box height={1}>
-        <Text fg={colors.positive} attributes={TextAttributes.BOLD}>{"\u2713"}</Text>
-        <Text fg={colors.text}>{` ${t("Plugins enabled")}`}</Text>
+      <Box height={1} flexDirection="row">
+        <Text fg={colors.positive} attributes={TextAttributes.BOLD}>{"\u2713 "}</Text>
+        <Text fg={colors.text}>{t("Plugins enabled")}</Text>
       </Box>
       <Box height={2} />
       {brokerName ? (

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -26,6 +26,9 @@ import {
   type OnboardingStep,
 } from "./wizard-model";
 
+// Blank spacer + progress dots + hint line.
+const FOOTER_ROWS = 3;
+
 interface OnboardingWizardProps {
   config: AppConfig;
   pluginRegistry: PluginRegistry;
@@ -213,7 +216,9 @@ export function OnboardingWizard({ config, pluginRegistry, onComplete }: Onboard
 
   const contentWidth = Math.min(60, termWidth - 4);
   const contentLeft = Math.floor((termWidth - contentWidth) / 2);
-  const contentTop = Math.max(1, Math.floor((termHeight - 24) / 2));
+  // The footer is pinned to the last FOOTER_ROWS rows, so steps get whatever is left.
+  const contentTop = Math.max(0, Math.min(Math.floor((termHeight - 24) / 2), termHeight - FOOTER_ROWS - 1));
+  const contentHeight = Math.max(1, termHeight - contentTop - FOOTER_ROWS);
   const progressDots = ONBOARDING_STEPS.map((_, index) => {
     if (index < stepIdx) return "\u2501";
     if (index === stepIdx) return "\u25cf";
@@ -248,10 +253,18 @@ export function OnboardingWizard({ config, pluginRegistry, onComplete }: Onboard
         top={contentTop}
         left={contentLeft}
         width={contentWidth}
+        height={contentHeight}
         flexDirection="column"
       >
         {step === "welcome" && <WelcomeStep />}
-        {step === "theme" && <ThemeStep themeIds={themeIds} selectedIdx={themeIdx} height={termHeight - contentTop - 4} />}
+        {step === "theme" && (
+          <ThemeStep
+            themeIds={themeIds}
+            selectedIdx={themeIdx}
+            onSelect={setThemeIdx}
+            height={contentHeight}
+          />
+        )}
         {step === "portfolio" && (
           <PortfolioStep
             sub={portfolioSub}
@@ -271,7 +284,7 @@ export function OnboardingWizard({ config, pluginRegistry, onComplete }: Onboard
           />
         )}
         {step === "shortcuts" && (
-          <ShortcutsStep />
+          <ShortcutsStep height={contentHeight} />
         )}
         {step === "ready" && (
           <ReadyStep
@@ -282,7 +295,15 @@ export function OnboardingWizard({ config, pluginRegistry, onComplete }: Onboard
             error={finishError}
           />
         )}
+      </Box>
 
+      <Box
+        position="absolute"
+        top={termHeight - FOOTER_ROWS}
+        left={contentLeft}
+        width={contentWidth}
+        flexDirection="column"
+      >
         <Box height={1} />
         <Box height={1} flexDirection="row" width={contentWidth}>
           <Box flexGrow={1}>

--- a/src/components/onboarding/portfolio-step/broker-fields-panel.tsx
+++ b/src/components/onboarding/portfolio-step/broker-fields-panel.tsx
@@ -45,7 +45,7 @@ export function BrokerFieldsPanel({
 
         if (!isActive && value) {
           return (
-            <Box key={field.key} height={1}>
+            <Box key={field.key} height={1} flexDirection="row">
               <Text fg={colors.positive}>{"\u2713 "}</Text>
               <Text fg={colors.text}>{`${field.label}: ${formatBrokerFieldValue(field, value)}`}</Text>
             </Box>
@@ -58,7 +58,7 @@ export function BrokerFieldsPanel({
           return (
             <Box key={field.key} flexDirection="column">
               {index > 0 && <Box height={1} />}
-              <Box height={1}>
+              <Box height={1} flexDirection="row">
                 <Text fg={colors.text} attributes={TextAttributes.BOLD}>
                   {tf("Step {step}: ", { step: index + 1 })}
                 </Text>
@@ -97,7 +97,7 @@ export function BrokerFieldsPanel({
                     const selected = optionIdx === brokerSelectIdx;
                     return (
                       <Box key={option.value} flexDirection="column" backgroundColor={selected ? colors.selected : colors.bg}>
-                        <Box height={1}>
+                        <Box height={1} flexDirection="row">
                           <Text fg={selected ? colors.selectedText : colors.textDim}>{selected ? "\u25b8 " : "  "}</Text>
                           <Text
                             fg={selected ? colors.text : colors.textDim}


### PR DESCRIPTION
## Rendering bugs

Sibling `<Text>` children inside a `<Box>` without `flexDirection="row"` collapse. Three visible symptoms on the first-run wizard:

- The theme step's color swatch row rendered **one dim block** instead of six colors.
- The theme list's `▸` selection marker never rendered — background highlight was the only cue.
- The Ready screen rendered `✓Theme configured` / `✓Portfolio "Main Portfolio" created`, checkmark jammed against the label.

Fixed by setting row direction, plus three more instances of the same bug found in `broker-fields-panel.tsx` (completed-field `✓` rows, the `Step N:` label, and the connection-mode option markers).

## Theme step now uses the shared ListView

The theme step hand-rolled a windowed list — that's the one that was broken. Swapping in the shared `ListView` restores the selection marker, adds scrolling and a scrollbar, and makes the step clickable (it was the only step you couldn't use the mouse on). The manual `windowStart`/`windowEnd`/`↑ more`/`↓ more` logic is gone.

## 80x24 clipping

At a standard 80x24 terminal the shortcuts step pushed the `enter ->` hint off screen, hiding the only affordance telling you how to proceed. `contentTop` was computed against a hardcoded `24` while `ShortcutsStep` was a fixed ~22 rows.

- The footer is now its own absolutely-positioned box pinned to the last three rows, so content can never displace it.
- `contentTop` no longer forces a 1-row minimum and is capped so the footer always fits; steps receive a real `contentHeight` budget.
- `ShortcutsStep` sheds rows in priority order as height drops: spacers, then the tagline, then the "Type these in the command bar" line.

## Verification

Ran the wizard end-to-end in tmux with a fresh `$HOME`:

- **120x34** — six swatches render, `▸` marker back, list scrolls and follows selection, checkmarks spaced.
- **80x24** — all 21 rows *and* the hint line visible.
- **80x20** — degrades to 17 rows, footer intact.
- Confirmed a synthetic SGR mouse click on a theme row selects it.

Full suite: 1771 pass / 0 fail. `typecheck:opentui` clean.

## Not addressed

Separate issues found during review, left alone: the manual portfolio path creates an empty hardcoded portfolio despite promising "add tickers and positions by hand"; no skip/quit key in the wizard; `→` silently abandons an in-progress broker connection; no sign-in step; several untranslated strings; `applyTheme` called during render; the "Plugins enabled" checkmark for something the user is never asked about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)