### PR TITLE
Show external brokers as top-level choices

### DIFF
--- a/src/components/command-bar/workflow/broker.test.ts
+++ b/src/components/command-bar/workflow/broker.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import type { BrokerAdapter } from "../../../types/broker";
+import { buildBrokerChoices } from "./broker";
+
+function createBroker(id: string, name: string): BrokerAdapter {
+  return {
+    id,
+    name,
+    configSchema: [{ key: "apiKey", label: "API key", type: "password", required: true }],
+    validate: async () => true,
+    importPositions: async () => [],
+  };
+}
+
+test("shows external brokers as sorted top-level choices", () => {
+  const choices = buildBrokerChoices(new Map([
+    ["ibkr", createBroker("ibkr", "Interactive Brokers")],
+    ["newbroker", createBroker("newbroker", "newbroker")],
+  ]));
+
+  expect(choices.map((choice) => choice.id)).toEqual(["ibkr", "newbroker"]);
+});

--- a/src/components/command-bar/workflow/broker.ts
+++ b/src/components/command-bar/workflow/broker.ts
@@ -23,6 +23,7 @@ export interface CommandBarBrokerChoice {
 export function buildBrokerChoices(brokers: ReadonlyMap<string, BrokerAdapter>): CommandBarBrokerChoice[] {
   return [...brokers.values()]
     .filter((adapter) => adapter.configSchema.length > 0)
+    .sort((a, b) => a.name.localeCompare(b.name))
     .map((adapter) => ({
       id: adapter.id,
       label: adapter.name,


### PR DESCRIPTION
## Summary

Fixes #526.

- Sort connectable broker choices by adapter name.
- Keep externally registered brokers as peer, top-level choices alongside Interactive Brokers.
- Add a regression test covering `newbroker` and Interactive Brokers in the shared broker registry.

## Validation

- `bun install --frozen-lockfile` ✅
- `bun test src/components/command-bar/workflow/broker.test.ts` ✅
- `bun run typecheck:opentui` ✅
- `git diff --check` ✅
- tmux TUI smoke ✅ (app started successfully; session cleaned up)