### PR TITLE
Fix portfolio live quote cadence

### DIFF
--- a/src/market-data/coordinator/quotes.ts
+++ b/src/market-data/coordinator/quotes.ts
@@ -1,6 +1,7 @@
 import type { DataProvider, QuoteSubscriptionTarget } from "../../types/data-provider";
 import type { Quote } from "../../types/financials";
 import type { InstrumentRef } from "../request-types";
+import { QUOTE_STREAM_UPDATE_THROTTLE_MS } from "../quotes/cadence";
 import { mergeQuoteSubscriptionTargets } from "../quote-subscription-target";
 import { QueryStore } from "../query-store";
 import type { QueryEntry } from "../result-types";
@@ -22,6 +23,11 @@ export interface QuoteSubscriptionEntry {
   target: QuoteSubscriptionTarget;
   targets: Map<number, QuoteSubscriptionTarget>;
   removeTimer: ReturnType<typeof setTimeout> | null;
+}
+
+interface PendingStreamQuote {
+  instrument: InstrumentRef;
+  quote: Quote;
 }
 
 const QUOTE_SUBSCRIPTION_REMOVE_GRACE_MS = 250;
@@ -189,6 +195,9 @@ export async function loadQuoteBatchEntries({
 
 export class QuoteSubscriptionManager {
   private readonly quoteSubscriptions = new Map<string, QuoteSubscriptionEntry>();
+  private readonly pendingStreamQuotes = new Map<string, PendingStreamQuote>();
+  private lastStreamQuoteBatchAppliedAt: number | null = null;
+  private pendingStreamQuoteTimer: ReturnType<typeof setTimeout> | null = null;
   private nextQuoteSubscriptionId = 1;
   private quoteSubscriptionDispose: (() => void) | null = null;
   private quoteSubscriptionSignature = "";
@@ -239,10 +248,12 @@ export class QuoteSubscriptionManager {
           continue;
         }
         if (existing.removeTimer) continue;
+        this.clearPendingStreamQuote(key);
         existing.removeTimer = setTimeout(() => {
           const current = this.quoteSubscriptions.get(key);
           if (!current || current.targets.size > 0) return;
           this.quoteSubscriptions.delete(key);
+          this.clearPendingStreamQuote(key);
           this.flush();
         }, QUOTE_SUBSCRIPTION_REMOVE_GRACE_MS);
       }
@@ -280,8 +291,59 @@ export class QuoteSubscriptionManager {
         brokerInstanceId: target.context?.brokerInstanceId,
         instrument: target.context?.instrument ?? null,
       };
-      this.applyQuote(instrument, quote);
+      this.enqueueStreamQuote(instrument, quote);
     });
+  }
+
+  private enqueueStreamQuote(instrument: InstrumentRef, quote: Quote): void {
+    const key = buildQuoteKey(instrument);
+    const subscription = this.quoteSubscriptions.get(key);
+    if (!subscription || subscription.targets.size === 0) return;
+
+    this.pendingStreamQuotes.set(key, { instrument, quote });
+    const elapsed = this.lastStreamQuoteBatchAppliedAt == null
+      ? Number.POSITIVE_INFINITY
+      : Date.now() - this.lastStreamQuoteBatchAppliedAt;
+    if (elapsed >= QUOTE_STREAM_UPDATE_THROTTLE_MS) {
+      this.flushPendingStreamQuotes();
+      return;
+    }
+    this.schedulePendingStreamQuoteFlush(QUOTE_STREAM_UPDATE_THROTTLE_MS - elapsed);
+  }
+
+  private schedulePendingStreamQuoteFlush(delayMs: number): void {
+    if (this.pendingStreamQuoteTimer !== null) return;
+    this.pendingStreamQuoteTimer = setTimeout(() => {
+      this.pendingStreamQuoteTimer = null;
+      this.flushPendingStreamQuotes();
+    }, Math.max(0, delayMs));
+  }
+
+  private flushPendingStreamQuotes(): void {
+    const pendingQuotes = [...this.pendingStreamQuotes.entries()];
+    this.pendingStreamQuotes.clear();
+    if (this.pendingStreamQuoteTimer !== null) clearTimeout(this.pendingStreamQuoteTimer);
+    this.pendingStreamQuoteTimer = null;
+    if (pendingQuotes.length === 0) return;
+
+    this.lastStreamQuoteBatchAppliedAt = Date.now();
+    for (const [key, pending] of pendingQuotes) {
+      const subscription = this.quoteSubscriptions.get(key);
+      if (subscription?.targets.size) {
+        this.applyQuote(pending.instrument, pending.quote);
+      }
+    }
+  }
+
+  private clearPendingStreamQuote(key: string): void {
+    this.pendingStreamQuotes.delete(key);
+    if (this.pendingStreamQuotes.size === 0 && this.pendingStreamQuoteTimer !== null) {
+      clearTimeout(this.pendingStreamQuoteTimer);
+      this.pendingStreamQuoteTimer = null;
+    }
+    if (![...this.quoteSubscriptions.values()].some((entry) => entry.targets.size > 0)) {
+      this.lastStreamQuoteBatchAppliedAt = null;
+    }
   }
 }
 

--- a/src/market-data/coordinator/subscriptions.test.ts
+++ b/src/market-data/coordinator/subscriptions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, jest, test } from "bun:test";
 import { MarketDataCoordinator } from "./index";
 import { buildQuoteKey } from "../selectors";
+import { QUOTE_STREAM_UPDATE_THROTTLE_MS } from "../quotes/cadence";
 import { createTestDataProvider } from "../../test-support/data-provider";
 import type { Quote } from "../../types/financials";
 import type { DataProvider, QuoteSubscriptionTarget } from "../../types/data-provider";
@@ -206,6 +207,38 @@ describe("MarketDataCoordinator key subscriptions", () => {
 
     expect(calls).toBe(1);
     expect(coordinator.getVersion()).toBe(1);
+  });
+
+  test("coalesces bursty stream quotes into one readable update cadence", () => {
+    jest.useFakeTimers();
+    const originalDateNow = Date.now;
+    let now = 1_700_000_000_000;
+    Date.now = () => now;
+
+    try {
+      const { provider, emitQuote } = createProvider();
+      const coordinator = new MarketDataCoordinator(provider);
+      const amd = { symbol: "AMD", exchange: "NASDAQ" };
+      const msft = { symbol: "MSFT", exchange: "NASDAQ" };
+      coordinator.subscribeQuotes([{ instrument: amd }, { instrument: msft }]);
+
+      emitQuote(amd, quote("AMD", 100));
+      expect(coordinator.getQuoteEntry(amd).data?.price).toBe(100);
+
+      now += 100;
+      emitQuote(msft, quote("MSFT", 200));
+      emitQuote(amd, quote("AMD", 101));
+      expect(coordinator.getQuoteEntry(amd).data?.price).toBe(100);
+      expect(coordinator.getQuoteEntry(msft).data).toBeNull();
+
+      now += QUOTE_STREAM_UPDATE_THROTTLE_MS - 100;
+      jest.advanceTimersByTime(QUOTE_STREAM_UPDATE_THROTTLE_MS - 100);
+      expect(coordinator.getQuoteEntry(amd).data?.price).toBe(101);
+      expect(coordinator.getQuoteEntry(msft).data?.price).toBe(200);
+    } finally {
+      Date.now = originalDateNow;
+      jest.useRealTimers();
+    }
   });
 
   test("applies repeated stream quotes that refresh quote freshness", async () => {

--- a/src/market-data/quotes/cadence.ts
+++ b/src/market-data/quotes/cadence.ts
@@ -1,0 +1,2 @@
+// Keep a completed 450 ms value flash readable before the next streamed update.
+export const QUOTE_STREAM_UPDATE_THROTTLE_MS = 750;

--- a/src/market-data/quotes/cadence.ts
+++ b/src/market-data/quotes/cadence.ts
@@ -1,2 +1,2 @@
-// Keep a completed 450 ms value flash readable before the next streamed update.
-export const QUOTE_STREAM_UPDATE_THROTTLE_MS = 750;
+// Leave a short gap after the 450 ms value flash before the next streamed update.
+export const QUOTE_STREAM_UPDATE_THROTTLE_MS = 500;

--- a/src/plugins/builtin/portfolio-list/pane/streaming.ts
+++ b/src/plugins/builtin/portfolio-list/pane/streaming.ts
@@ -112,14 +112,16 @@ export function usePortfolioPaneStreaming({
     const quoteSnapshotQueue: TickerRecord[] = [];
     const snapshotQueue: TickerRecord[] = [];
     const snapshotQueueSymbols = new Set<string>();
-    const useSnapshotForQuoteWarmup = sortPreferenceUsesQuote(activeSort);
-    const quoteWarmupTickers = selectQuoteWarmupTickers(
-      sortedTickers,
-      streamWindow,
-      financialsMap,
-      activeSort,
-      nowTimestamp,
-    );
+    const useSnapshotForQuoteWarmup = liveStreaming && sortPreferenceUsesQuote(activeSort);
+    const quoteWarmupTickers = liveStreaming
+      ? selectQuoteWarmupTickers(
+        sortedTickers,
+        streamWindow,
+        financialsMap,
+        activeSort,
+        nowTimestamp,
+      )
+      : [];
     for (const ticker of quoteWarmupTickers) {
       const financials = financialsMap.get(ticker.metadata.ticker);
       const quoteKey = visibleWarmupKey("quote", ticker);
@@ -212,7 +214,7 @@ export function usePortfolioPaneStreaming({
       cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [activeSort, appActive, financialsMap, instrumentOptions, sharedCoordinator, sortedTickers, streamWindow, visibleFinancialTickers, visibleWarmupRequirements]);
+  }, [activeSort, appActive, financialsMap, instrumentOptions, liveStreaming, sharedCoordinator, sortedTickers, streamWindow, visibleFinancialTickers, visibleWarmupRequirements]);
 
   useEffect(() => {
     if (!liveStreaming || !appActive) return;

--- a/src/plugins/builtin/shared/live-streaming.ts
+++ b/src/plugins/builtin/shared/live-streaming.ts
@@ -1,4 +1,5 @@
-import { usePaneSettingValue } from "../../../state/app/context";
+import { useAppSelector, usePaneInstanceId } from "../../../state/app/context";
+import { findPaneInstance, type LayoutConfig } from "../../../types/config";
 import type {
   PaneQuickSettingDef,
   PaneSettingField,
@@ -17,7 +18,7 @@ export const LIVE_STREAMING_SETTING_FIELD: PaneSettingField = {
   type: "toggle",
   key: LIVE_STREAMING_SETTING_KEY,
   label: "Live streaming",
-  description: "Stream quote updates continuously. Turn off to refresh quotes once per minute.",
+  description: "Stream quote updates continuously. Turn off to refresh quotes once per minute. Follow panes inherit their source pane's setting.",
 };
 
 export function withLiveStreamingSetting(
@@ -37,7 +38,23 @@ export function withLiveStreamingSetting(
   };
 }
 
+export function resolveLiveStreamingSetting(
+  layout: LayoutConfig,
+  paneId: string,
+  seen = new Set<string>(),
+): boolean {
+  if (seen.has(paneId)) return false;
+
+  const pane = findPaneInstance(layout, paneId);
+  if (!pane) return true;
+  if (pane.settings?.[LIVE_STREAMING_SETTING_KEY] === false) return false;
+  if (pane.binding?.kind !== "follow") return true;
+
+  seen.add(paneId);
+  return resolveLiveStreamingSetting(layout, pane.binding.sourceInstanceId, seen);
+}
+
 export function useLiveStreamingSetting(): boolean {
-  const [enabled] = usePaneSettingValue(LIVE_STREAMING_SETTING_KEY, true);
-  return enabled;
+  const paneId = usePaneInstanceId();
+  return useAppSelector((state) => resolveLiveStreamingSetting(state.config.layout, paneId));
 }

--- a/src/state/hooks/quote-streaming.test.tsx
+++ b/src/state/hooks/quote-streaming.test.tsx
@@ -3,6 +3,9 @@ import { act, useState } from "react";
 import { testRender } from "../../renderers/opentui/test-utils";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../market-data/coordinator";
 import { createTestDataProvider } from "../../test-support/data-provider";
+import { AppProvider, PaneInstanceProvider } from "../../state/app/context";
+import { createDefaultConfig } from "../../types/config";
+import { useLiveStreamingSetting } from "../../plugins/builtin/shared/live-streaming";
 import { useLiveQuoteEntries, useQuoteStreaming, useQuoteUpdates } from "./quote-streaming";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
@@ -48,6 +51,15 @@ function QuotePollingPriorityHarness() {
     pollIntervalMs: 1_000,
   });
   return <text>{selected ? "selected" : "idle"}</text>;
+}
+
+function FollowedQuoteStreamingHarness() {
+  const liveStreaming = useLiveStreamingSetting();
+  useQuoteUpdates([{
+    symbol: "AMD",
+    exchange: "NASDAQ",
+  }], { liveStreaming });
+  return <text>{liveStreaming ? "live" : "polling"}</text>;
 }
 
 function LiveQuoteFreshnessHarness() {
@@ -140,6 +152,39 @@ describe("useQuoteStreaming", () => {
       await new Promise((resolve) => setTimeout(resolve, 45));
     });
     expect(loadCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  test("inherits disabled streaming from a followed portfolio pane", async () => {
+    let subscribeCalls = 0;
+    let loadCalls = 0;
+    const config = createDefaultConfig("/tmp/gloomberb-live-streaming-test");
+    const portfolioPane = config.layout.instances.find((pane) => pane.instanceId === "portfolio-list:main");
+    if (!portfolioPane) throw new Error("expected default portfolio pane");
+    portfolioPane.settings = { ...portfolioPane.settings, liveStreaming: false };
+    setSharedMarketDataCoordinator({
+      subscribeQuotes: () => {
+        subscribeCalls += 1;
+        return () => {};
+      },
+      loadQuotesBatch: async () => {
+        loadCalls += 1;
+        return [];
+      },
+    } as unknown as MarketDataCoordinator);
+
+    testSetup = await testRender(
+      <AppProvider config={config}>
+        <PaneInstanceProvider paneId="ticker-detail:main">
+          <FollowedQuoteStreamingHarness />
+        </PaneInstanceProvider>
+      </AppProvider>,
+      { width: 20, height: 1 },
+    );
+    await act(async () => testSetup!.renderOnce());
+
+    expect(testSetup.captureCharFrame()).toContain("polling");
+    expect(subscribeCalls).toBe(0);
+    expect(loadCalls).toBe(1);
   });
 
   test("does not restart polling when only subscription priority changes", async () => {


### PR DESCRIPTION
## Summary

- Make panes following a portfolio inherit its live-streaming state.
- Prevent disabled portfolio streaming from running fast quote warmups.
- Batch websocket quote updates at a maximum of one visible refresh every 500 ms.

## Validation

- Focused Bun tests
- bun run typecheck
- bun run build
- bun run i18n:audit
- tmux terminal UI smoke