### PR TITLE
Keep latest chart candles visible

### DIFF
--- a/scripts/verify-windows-arm64.ps1
+++ b/scripts/verify-windows-arm64.ps1
@@ -10,7 +10,9 @@ $InstallLog = Join-Path $env:TEMP "gloomberb-arm64-install-$PID.log"
 $UninstallLog = Join-Path $env:TEMP "gloomberb-arm64-uninstall-$PID.log"
 $GuiStdoutLog = Join-Path $env:TEMP "gloomberb-arm64-gui-stdout-$PID.log"
 $GuiStderrLog = Join-Path $env:TEMP "gloomberb-arm64-gui-stderr-$PID.log"
-$DesktopProfileDir = Join-Path $env:LOCALAPPDATA "com.vincelwt.gloomberb"
+$OriginalLocalAppData = $env:LOCALAPPDATA
+$IsolatedLocalAppData = Join-Path $env:TEMP "GloomberbArm64LocalAppData-$PID"
+$DesktopProfileDir = Join-Path $IsolatedLocalAppData "com.vincelwt.gloomberb"
 
 function Assert-CommandSucceeds {
   param(
@@ -79,6 +81,9 @@ try {
   Assert-CommandSucceeds $InstalledCli @("__gloomberb-smoke-opentui-native")
   Assert-CommandSucceeds $InstalledCli @("help")
 
+  Remove-Item -Path $IsolatedLocalAppData -Recurse -Force -ErrorAction SilentlyContinue
+  New-Item -ItemType Directory -Path $IsolatedLocalAppData -Force | Out-Null
+  $env:LOCALAPPDATA = $IsolatedLocalAppData
   Remove-Item -Path $DesktopProfileDir -Recurse -Force -ErrorAction SilentlyContinue
 
   $env:ELECTROBUN_CONSOLE = "1"
@@ -115,6 +120,7 @@ try {
   if ($GuiProcess -and -not $GuiProcess.HasExited) {
     Stop-Process -Id $GuiProcess.Id -Force -ErrorAction SilentlyContinue
   }
+  $env:LOCALAPPDATA = $OriginalLocalAppData
 
   $Uninstaller = Get-ChildItem -Path $InstallDir -Filter "unins*.exe" -File -ErrorAction SilentlyContinue | Select-Object -First 1
   if ($Uninstaller) {
@@ -130,6 +136,6 @@ try {
   }
 
   Remove-Item -Path $InstallDir -Recurse -Force -ErrorAction SilentlyContinue
-  Remove-Item -Path $DesktopProfileDir -Recurse -Force -ErrorAction SilentlyContinue
+  Remove-Item -Path $IsolatedLocalAppData -Recurse -Force -ErrorAction SilentlyContinue
   Remove-Item -Path $GuiStdoutLog, $GuiStderrLog -Force -ErrorAction SilentlyContinue
 }

--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -196,6 +196,26 @@ function twoSessionCandles(): ResolvedSeries {
 }
 
 describe("CompositeChart", () => {
+  test("shows the regular-session move beside the latest intraday value", async () => {
+    testSetup = await testRender(
+      <CompositeChart
+        width={60}
+        height={12}
+        series={[{
+          ...series("price", "main", "left", "USD", [100, 110]),
+          latestChangePercent: 10.65,
+        }]}
+        panels={[{ id: "main" }]}
+        showLatestChangePercent
+      />,
+      { width: 62, height: 14 },
+    );
+
+    await act(async () => testSetup!.renderOnce());
+
+    expect(testSetup.captureCharFrame()).toContain("ACME Price $110 +10.65%");
+  });
+
   test("lays out mixed panels with one shared legend and time axis", async () => {
     testSetup = await testRender(
       <CompositeChart

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../../ui";
 import { useShortcut } from "../../../react/input";
 import { colors as themeColors, hoverBg } from "../../../theme/colors";
+import { formatPercentRaw } from "../../../utils/format";
 import { isPlainKey } from "../../../utils/keyboard";
 import { truncateWithEllipsis } from "../../../utils/text-wrap";
 import type { ResolvedSeries } from "../../../time-series/types";
@@ -504,6 +505,7 @@ function CompositeLegend({
   accessory,
   accessoryWidth,
   formatValue,
+  showLatestChangePercent,
   onActivate,
   onToggleSeries,
   isSeriesToggleable,
@@ -516,6 +518,7 @@ function CompositeLegend({
   accessory: CompositeChartProps["legendAccessory"];
   accessoryWidth: CompositeChartProps["legendAccessoryWidth"];
   formatValue: CompositeChartProps["formatValue"];
+  showLatestChangePercent: CompositeChartProps["showLatestChangePercent"];
   onActivate: CompositeChartProps["onActivate"];
   onToggleSeries: CompositeChartProps["onToggleSeries"];
   isSeriesToggleable: CompositeChartProps["isSeriesToggleable"];
@@ -534,11 +537,17 @@ function CompositeLegend({
   const entries = series.map((entry) => {
     const toggleable = !!onToggleSeries && (isSeriesToggleable?.(entry) ?? true);
     const cursorValue = cursorValueById.get(entry.id);
+    const changeText = showLatestChangePercent
+        && !scene?.cursorDate
+        && typeof entry.latestChangePercent === "number"
+        && Number.isFinite(entry.latestChangePercent)
+      ? ` ${formatPercentRaw(entry.latestChangePercent)}`
+      : "";
     const fullText = `${entry.label} ${legendValue(
       entry,
       cursorValue?.value ?? null,
       formatValue,
-    )}`;
+    )}${changeText}`;
     const details = formatCompositePointDetails(cursorValue?.point);
     const tooltip = details ? `${fullText} · ${details}` : fullText;
     const textWidth = Math.max(1, Math.min(30, [...fullText].length));
@@ -748,6 +757,7 @@ export function CompositeChart({
   allowHistoricalBackfill = false,
   axisWidth = 9,
   showLegend = true,
+  showLatestChangePercent = false,
   legendAccessory,
   legendAccessoryWidth,
   showTimeAxis = true,
@@ -1152,6 +1162,7 @@ export function CompositeChart({
             accessory={legendAccessory}
             accessoryWidth={legendAccessoryWidth}
             formatValue={formatValue}
+            showLatestChangePercent={showLatestChangePercent}
             onActivate={onActivate}
             onToggleSeries={onToggleSeries}
             isSeriesToggleable={isSeriesToggleable}
@@ -1213,6 +1224,7 @@ export function CompositeChart({
           accessory={legendAccessory}
           accessoryWidth={legendAccessoryWidth}
           formatValue={formatValue}
+          showLatestChangePercent={showLatestChangePercent}
           onActivate={onActivate}
           onToggleSeries={onToggleSeries}
           isSeriesToggleable={isSeriesToggleable}

--- a/src/components/chart/composite/types.ts
+++ b/src/components/chart/composite/types.ts
@@ -137,6 +137,8 @@ export interface CompositeChartProps {
   colors?: Partial<CompositeChartColors>;
   axisWidth?: number;
   showLegend?: boolean;
+  /** Show the regular-session percentage beside latest eligible legend values. */
+  showLatestChangePercent?: boolean;
   legendAccessory?: ReactNode;
   legendAccessoryWidth?: number;
   showTimeAxis?: boolean;

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -650,6 +650,7 @@ function ChartComposerSurface({
           focused={focused}
           interactive={surfaceInteractive}
           allowHistoricalBackfill
+          showLatestChangePercent={!spec.viewport.dateWindow && spec.viewport.range === "1D"}
           onViewportChange={handleChartViewportChange}
           onActivate={activatePane}
           onToggleSeries={toggleSeries}

--- a/src/plugins/builtin/chart-composer/semantic.ts
+++ b/src/plugins/builtin/chart-composer/semantic.ts
@@ -64,6 +64,7 @@ export function chartComposerSemanticMetadata(
       panelId: series.panelId,
       visible: series.visible !== false,
       pointCount: resolved?.points.length ?? 0,
+      latestChangePercent: resolved?.latestChangePercent ?? null,
       first: pointEvidence(resolved?.points[0]),
       last: pointEvidence(resolved?.points.at(-1)),
     };

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -1165,6 +1165,74 @@ describe("resolveChartSpecData", () => {
     expect(sma.points.at(-1)?.value).toBeCloseTo(15.5);
   });
 
+  test("keeps a quote received after resolution starts inside the latest viewport", async () => {
+    const now = Date.parse("2026-08-05T14:00:00Z");
+    const quoteTime = now + 60_000;
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => ({
+        ...emptyFinancials(),
+        quote: {
+          symbol: "FRESH",
+          price: 130,
+          currency: "USD",
+          change: 30,
+          changePercent: 30,
+          lastUpdated: quoteTime,
+          listingExchangeName: "XNAS",
+          marketState: "POST",
+          postMarketPrice: 129,
+          postMarketChange: -1,
+          postMarketChangePercent: -0.77,
+        },
+      }),
+      getPriceHistoryForResolution: async () => [
+        { date: new Date(now - 2 * 86_400_000), open: 99, high: 102, low: 98, close: 100 },
+        { date: new Date(now - 86_400_000), open: 100, high: 101, low: 99, close: 100 },
+      ],
+    });
+    const spec: ChartSpec = {
+      version: CHART_SPEC_VERSION,
+      viewport: { range: "6M", resolution: "1d" },
+      panels: [{ id: "main" }],
+      series: [{
+        id: "price",
+        source: {
+          kind: "security",
+          instrument: { symbol: "FRESH", exchange: "XNAS" },
+          fieldId: "market.ohlcv",
+        },
+        style: "candles",
+        transform: "raw",
+        axis: "left",
+        panelId: "main",
+        interpolation: "none",
+      }],
+      studies: [{
+        id: "sma",
+        kind: "sma",
+        inputSeriesIds: ["price"],
+        parameters: { period: 2 },
+        panelId: "main",
+        axis: "left",
+      }],
+    };
+
+    const result = await resolveChartSpecData(spec, {
+      dataProvider: provider,
+      now: new Date(now),
+      loadFredSeries: async () => fredLoad(),
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.viewport?.end.getTime()).toBe(quoteTime);
+    const price = result.series.find((entry) => entry.id === "price");
+    const sma = result.series.find((entry) => entry.id === "sma");
+    expect(price?.points.at(-1)?.date.getTime()).toBe(quoteTime);
+    expect(price?.points.at(-1)?.close).toBe(129);
+    expect(price?.latestChangePercent).toBe(30);
+    expect(sma?.points.at(-1)?.date.getTime()).toBe(quoteTime);
+  });
+
   test("reuses raw source loads while live quotes recompute the chart tail", async () => {
     const now = Date.parse("2026-05-15T20:30:00Z");
     const source = {

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -298,6 +298,27 @@ function filterPoints(points: readonly TimeSeriesPoint[], bounds: DateBounds): T
   });
 }
 
+function followLatestMarketObservation(
+  bounds: DateBounds,
+  series: readonly ResolvedSeries[],
+): DateBounds {
+  if (bounds.end === null) return bounds;
+  let latest = bounds.end;
+  for (const entry of series) {
+    if (entry.timeBasis?.kind !== "market") continue;
+    for (const point of entry.points) {
+      const timestamp = point.date.getTime();
+      if (Number.isFinite(timestamp) && timestamp > latest) latest = timestamp;
+    }
+  }
+  if (latest === bounds.end) return bounds;
+  const shift = latest - bounds.end;
+  return {
+    start: bounds.start === null ? null : bounds.start + shift,
+    end: latest,
+  };
+}
+
 function emptyFinancials(priceHistory: TickerFinancials["priceHistory"] = []): TickerFinancials {
   return { annualStatements: [], quarterlyStatements: [], priceHistory };
 }
@@ -454,10 +475,14 @@ function baseSecuritySeries(
   const marketExchange = spec.source.instrument.exchange
     || financials.quote?.listingExchangeName
     || financials.quote?.exchangeName;
-  const marketTimeZone = isMarketFieldId(spec.source.fieldId)
+  const marketField = isMarketFieldId(spec.source.fieldId);
+  const marketTimeZone = marketField
     && canonicalExchange(marketExchange) !== "CCC"
     ? resolveExchangeTimeZone(marketExchange)
     : null;
+  const latestChangePercent = marketField && field.unit.startsWith("currency")
+    ? financials.quote?.changePercent
+    : undefined;
   return {
     id: spec.id,
     label: spec.label?.trim() || `${symbol} ${field.shortLabel}`,
@@ -482,6 +507,9 @@ function baseSecuritySeries(
             ? CHART_RESOLUTION_STEP_MS[marketResolution]
             : undefined,
         }
+      : undefined,
+    latestChangePercent: typeof latestChangePercent === "number" && Number.isFinite(latestChangePercent)
+      ? latestChangePercent
       : undefined,
     points,
   };
@@ -879,13 +907,19 @@ export async function resolveChartSpecData(
   const marketTimelineSeries = primaryMarketSeries?.visible === false
     ? rawSeries.filter((entry) => entry.id === primaryMarketSeries.id)
     : [];
-  // Preset ranges describe a window ending at the requested reference time,
-  // even when the newest filing or economic observation lags that endpoint.
-  // Re-anchoring to the latest observation both mislabels the range and asks
-  // providers for a different window than the one ultimately rendered.
-  const bounds = initialVisibleBounds;
+  // Preset ranges normally end at the requested reference time. A quote fetched
+  // asynchronously can be timestamped just after that reference, so advance an
+  // untouched market viewport by the same amount instead of clipping its tail.
+  // Explicit and user-created windows stay fixed through hasExplicitWindow.
+  const bounds = hasExplicitWindow
+    ? initialVisibleBounds
+    : followLatestMarketObservation(initialVisibleBounds, rawSeries);
   const resolution = initialResolution;
-  const studyBounds = initialCalculationBounds;
+  const studyBounds = bounds.end !== null
+      && initialCalculationBounds.end !== null
+      && bounds.end > initialCalculationBounds.end
+    ? { ...initialCalculationBounds, end: bounds.end }
+    : initialCalculationBounds;
   const baseSeries = rawSeries
     .filter((entry) => visibleSeriesIds.has(entry.id))
     .map((entry) => prepareBaseSeriesForStudies(entry, bounds, false, requestVisibleBounds));

--- a/src/time-series/types.ts
+++ b/src/time-series/types.ts
@@ -130,6 +130,8 @@ export interface ResolvedSeries {
   interpolation: SeriesInterpolation;
   /** Present only for exchange-traded market observations. */
   timeBasis?: ResolvedSeriesMarketTimeBasis;
+  /** Regular-session move supplied with the latest market quote. */
+  latestChangePercent?: number;
   points: TimeSeriesPoint[];
   warning?: string;
 }


### PR DESCRIPTION
## Summary

- keep untouched preset chart ranges aligned with the newest market observation returned by asynchronous quote loading
- preserve explicit and user-panned windows while extending studies through the newest quote
- show the regular-session percentage move beside the latest value on intraday charts

## Root cause

The chart resolver captured its viewport end before the asynchronous quote request completed. A valid quote timestamped just after that frozen boundary was appended to the series but clipped from the initial viewport until the user zoomed or panned right.

## Validation

- \`bun test\` (1,790 passing)
- \`bun run typecheck\`
- \`bun run build\`
- \`bun run desktop:view:build\`
- live TUI and desktop verification using TSM and AVGO
