### PR TITLE
Fix intraday chart panning and empty ranges

### DIFF
--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -1175,8 +1175,14 @@ describe("CompositeChart", () => {
     });
     await act(async () => testSetup!.renderOnce());
 
+    // An observation-free window keeps the chart frame and its axes; only the
+    // plotted points go away.
+    // An observation-free window keeps the chart frame and its axes; only the
+    // plotted points go away.
     const emptyFrame = testSetup.captureCharFrame();
-    expect(emptyFrame).toContain("No chart data");
+    expect(emptyFrame).not.toContain("No chart data");
+    expect(emptyFrame).not.toContain("•");
+    expect(emptyFrame).toContain("$108");
     expect(emptyFrame).toContain("Jan ");
     expect(typeof capturedSurfaceProps!.onMouseScroll).toBe("function");
 
@@ -1189,9 +1195,8 @@ describe("CompositeChart", () => {
     await act(async () => testSetup!.renderOnce());
 
     const recoveredFrame = testSetup.captureCharFrame();
-    expect(recoveredFrame).not.toContain("No chart data");
-    expect(recoveredFrame).toContain("2025-01-01");
-    expect(recoveredFrame).toContain("Jan 9");
+    expect(recoveredFrame).toContain("•");
+    expect(recoveredFrame).toContain("Jan 1");
   });
 
   test("shows useful UTC times for an intraday shared cursor and time axis", async () => {

--- a/src/components/chart/composite/interactions.test.ts
+++ b/src/components/chart/composite/interactions.test.ts
@@ -11,6 +11,7 @@ import {
   zoomCompositeViewport,
   type CompositeViewportRange,
 } from "./interactions";
+import { buildCompositeTimeScale, projectCompositeTimestamp } from "./time-scale";
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 function point(day: number): TimeSeriesPoint {
@@ -64,6 +65,18 @@ function intradayMarketSeries(): ResolvedSeries {
   };
 }
 
+function marketSlotSpan(
+  data: ResolvedSeries,
+  bounds: CompositeViewportRange,
+  view: CompositeViewportRange,
+): number {
+  const scale = buildCompositeTimeScale([data], bounds.start.getTime(), bounds.end.getTime());
+  const start = projectCompositeTimestamp(scale, view.start.getTime())!.ratio;
+  const end = projectCompositeTimestamp(scale, view.end.getTime())!.ratio;
+  const positions = scale.kind === "market" ? scale.endPosition - scale.startPosition : 1;
+  return (end - start) * positions;
+}
+
 describe("composite chart interactions", () => {
   test("zooms around the right edge and clamps zoom-out to loaded bounds", () => {
     const bounds = viewport(1, 11);
@@ -86,17 +99,21 @@ describe("composite chart interactions", () => {
     expect(clampedNewer).toEqual(viewport(7, 11));
   });
 
-  test("never changes the viewport span while panning across a closed session", () => {
+  test("never changes the visible slot count while panning across a closed session", () => {
     const data = intradayMarketSeries();
     const bounds = resolveCompositeNavigationBounds([data])!;
-    const visible = {
+    let visible: CompositeViewportRange = {
       start: new Date("2025-01-03T13:30:00.000Z"),
       end: new Date("2025-01-03T17:00:00.000Z"),
     };
-    const panned = panCompositeViewport(visible, bounds, 0.5, [data]);
+    const slots = marketSlotSpan(data, bounds, visible);
 
-    expect(panned.end.getTime() - panned.start.getTime())
-      .toBe(visible.end.getTime() - visible.start.getTime());
+    // A wall-clock shift changes how many market slots stay in view, which
+    // renders as the plot squeezing shut instead of scrolling sideways.
+    for (let step = 0; step < 4; step += 1) {
+      visible = panCompositeViewport(visible, bounds, 0.5, [data]);
+      expect(marketSlotSpan(data, bounds, visible)).toBeCloseTo(slots, 6);
+    }
   });
 
   test("uses representative cadence instead of a stray fine gap as the zoom floor", () => {
@@ -142,16 +159,18 @@ describe("composite chart interactions", () => {
     const older = panCompositeViewport(requested, bounds, 1, [data], true);
     expect(older).not.toEqual(requested);
     expect(older.end.getTime()).toBe(requested.start.getTime());
-    expect(older.end.getTime() - older.start.getTime())
-      .toBe(requested.end.getTime() - requested.start.getTime());
+    expect(marketSlotSpan(data, bounds, older))
+      .toBeCloseTo(marketSlotSpan(data, bounds, requested), 6);
     expect(panCompositeViewport(older, bounds, -1, [data], true)).toEqual(requested);
   });
 
-  test("clamps overlapping requested bounds to real data but preserves disjoint requests", () => {
+  test("clamps overlapping requested bounds to real data and keeps disjoint ones reachable", () => {
     const data = series([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
     expect(resolveCompositeNavigationBounds([data], viewport(5, 12))).toEqual(viewport(1, 9));
-    expect(resolveCompositeNavigationBounds([data], viewport(20, 30))).toEqual(viewport(20, 30));
+    // Bounds equal to an observation-free window would strand pan and zoom
+    // inside it, so a disjoint request stays unioned with the loaded data.
+    expect(resolveCompositeNavigationBounds([data], viewport(20, 30))).toEqual(viewport(1, 30));
   });
 
   test("requires distinct renderable observations inside a viewport", () => {

--- a/src/components/chart/composite/interactions.ts
+++ b/src/components/chart/composite/interactions.ts
@@ -114,9 +114,15 @@ export function resolveCompositeNavigationBounds(
   const overlapsData = requested.end.getTime() >= data.start.getTime()
     && requested.start.getTime() <= data.end.getTime();
   // Loaded series can include a buffer outside the authored viewport. Use the
-  // complete real-data extent when the two ranges overlap, but do not clamp a
-  // newly authored, disjoint request to stale observations.
-  if (!overlapsData) return requested;
+  // complete real-data extent when the two ranges overlap. A disjoint request
+  // keeps its own window, unioned with the data so navigation can always get
+  // back: bounds equal to an observation-free window strand pan and zoom.
+  if (!overlapsData) {
+    return {
+      start: new Date(Math.min(data.start.getTime(), requested.start.getTime())),
+      end: new Date(Math.max(data.end.getTime(), requested.end.getTime())),
+    };
+  }
   const paddingRatio = Math.max(options.historicalPaddingRatio ?? 0, 0);
   if (paddingRatio === 0) return data;
   const requestedSpan = Math.max(requested.end.getTime() - requested.start.getTime(), 1);
@@ -317,12 +323,27 @@ export function panCompositeViewport(
 ): CompositeViewportRange {
   const current = clampCompositeViewport(viewport, bounds);
   if (!Number.isFinite(shiftRatio) || shiftRatio === 0) return current;
-  const span = Math.max(current.end.getTime() - current.start.getTime(), 1);
-  const shift = span * shiftRatio;
-  const candidate = clampCompositeViewport({
-    start: new Date(current.start.getTime() - shift),
-    end: new Date(current.end.getTime() - shift),
-  }, bounds);
+  const marketProjection = marketViewportProjection(current, bounds, series);
+  // Market scales collapse overnight and weekend gaps, so a wall-clock shift
+  // changes how many slots stay visible and the plot accordions instead of
+  // translating. Shift in slot space so the visible span is preserved.
+  const candidate = marketProjection
+    ? (() => {
+        const { scale, startRatio, endRatio } = marketProjection;
+        const marketSpan = endRatio - startRatio;
+        const nextStart = clamp(startRatio - marketSpan * shiftRatio, 0, 1 - marketSpan);
+        return clampCompositeViewport(
+          viewportFromMarketRatios(scale, nextStart, nextStart + marketSpan),
+          bounds,
+        );
+      })()
+    : (() => {
+        const shift = Math.max(current.end.getTime() - current.start.getTime(), 1) * shiftRatio;
+        return clampCompositeViewport({
+          start: new Date(current.start.getTime() - shift),
+          end: new Date(current.end.getTime() - shift),
+        }, bounds);
+      })();
   if (!series || allowEmpty) return candidate;
 
   const timestamps = pointTimestamps(series)

--- a/src/components/chart/composite/scene.ts
+++ b/src/components/chart/composite/scene.ts
@@ -431,10 +431,15 @@ export function buildCompositeChartScene(
     startTime,
     endTime,
   );
-  const usableSeries = viewport
+  const scopedSeries = viewport
     ? dataSeries.flatMap((entry) => scopeSeriesToViewport(entry, startTime, endTime, timeScale) ?? [])
     : dataSeries;
-  if (usableSeries.length === 0) return null;
+  // A range without observations still has a chart: keep the panels, axes and
+  // grid and simply draw no points, instead of blanking the whole surface.
+  const emptyRange = scopedSeries.length === 0;
+  const usableSeries = emptyRange
+    ? dataSeries.map((entry) => ({ ...entry, points: [] }))
+    : scopedSeries;
   const visibleTimes = uniqueTimes.filter((time) => time >= startTime && time <= endTime);
   const marketTimes = timeScale.kind === "market"
     ? timeScale.anchors
@@ -463,8 +468,13 @@ export function buildCompositeChartScene(
     const panelSeries = usableSeries.filter((entry) => entry.panelId === panel.id);
     if (panelSeries.length === 0) return [];
     const scale = panel.scale ?? "linear";
-    const left = buildAxisDomain("left", panelSeries, scale);
-    const right = buildAxisDomain("right", panelSeries, scale);
+    // An empty range has no in-view values, so scale its axes to the loaded
+    // history rather than the meaningless 0..1 fallback.
+    const domainSeries = emptyRange
+      ? dataSeries.filter((entry) => entry.panelId === panel.id)
+      : panelSeries;
+    const left = buildAxisDomain("left", domainSeries, scale);
+    const right = buildAxisDomain("right", domainSeries, scale);
     const axes: Partial<Record<CompositeAxisSide, CompositeAxisDomain>> = { left, right };
     return [{
       id: panel.id,


### PR DESCRIPTION
## Problem

Two reported chart bugs, one shared root cause.

1. **Two-finger panning on GIP accordions instead of moving.** GIP renders on a market time scale where overnight and weekend gaps collapse to a single slot, but `panCompositeViewport` shifted the viewport in wall-clock milliseconds. Both edges moved by the same number of ms, so the number of visible market slots changed on every step and the plot squeezed and stretched instead of scrolling. GP is mostly daily bars, where the gaps are small relative to the window, so the same code looked fine there.

   Measured on a 5-minute series before the fix, panning 0.15 per step:

   ```
   start slots 78.00
   pan 0 slots 66.36
   pan 1 slots 54.71
   ...
   pan 6 slots  0.37
   ```

2. **"No observations in this range" blanks the pane.** Once the squeezed window landed inside a closed session, the scene builder returned `null` and the whole plot was replaced by a centered message. `resolveCompositeNavigationBounds` then returned that observation-free window as the navigation bounds whenever it was disjoint from the data, so pan and zoom were clamped inside it and could not get back out.

## Fix

- `panCompositeViewport` shifts in market slot space when a market timeline is present, mirroring what `zoomCompositeViewport` already did. The visible slot count is now constant across pans, and panning past Friday's close lands on Monday's open instead of stranding the view in the weekend.
- `buildCompositeChartScene` keeps the panels, axes, grid and time axis when a range holds no observations, and simply plots no points. Axes scale to the loaded history instead of the 0..1 fallback. No data means no candle, not a blank pane.
- `resolveCompositeNavigationBounds` unions a disjoint request with the data extent instead of returning it alone, so navigation always has a route back to the observations.

## Verification

- Updated `interactions.test.ts` to assert the visible slot count is preserved while panning across a closed session, replacing assertions that encoded the wall-clock span behaviour.
- `composite-chart.test.tsx` now asserts an observation-free window keeps its axes and draws no points.
- Full suite: 1788 pass, 0 fail. Typecheck clean.
- tmux smoke on `GIP AAPL` against both branches. On main, panning left reached `Jul 31 20:57 UTC -> Aug 1 20:57 UTC` and rendered a fully blank pane with "No observations in this range". On the branch the same walk keeps every window populated, holds the span constant, and steps over the weekend gap.