### PR TITLE
GBX doesn't work properly for P&L%. Fixed

### DIFF
--- a/src/plugins/ibkr/gateway/account-loaders.ts
+++ b/src/plugins/ibkr/gateway/account-loaders.ts
@@ -135,7 +135,7 @@ export async function loadIbkrPositions({
         ticker: position.contract.localSymbol || position.contract.symbol,
         exchange: position.contract.primaryExch || position.contract.exchange || "",
         shares: Math.abs(position.pos),
-        avgCost: normalizeIbkrPriceValue(portfolioSnapshot?.avgCost ?? position.avgCost, priceDivisor),
+        avgCost: portfolioSnapshot?.avgCost ?? position.avgCost,
         currency: position.contract.currency || "USD",
         accountId,
         name: position.contract.description || position.contract.localSymbol || position.contract.symbol,


### PR DESCRIPTION
## Bug

IBKR reports `avgCost` for sub-unit-quoted contracts (e.g. GBX/pence LSE stocks) already in the contract's major currency unit, unlike `marketPrice`, which is reported in the sub-unit. `loadIbkrPositions` was applying the same pence→pounds `priceDivisor` to `avgCost` too, deflating it by ~100x and producing wildly inflated P&L% for those positions.

## Fix

Stop normalizing `avgCost` with `priceDivisor` in `src/plugins/ibkr/gateway/account-loaders.ts` — pass it through as-is. USD-quoted positions are unaffected (divisor is always 1 there).

## Verified against a real portfolio (Gateway mode)

| Ticker | avgCost before → after | P&L% before → after |
|---|---|---|
| STAN | 0.09 → 9.47 | +23,371% → +134.72% |
| ATYM | 0.08 → 7.73 | +11,824% → +19.25% |

`bun run typecheck:opentui` clean, `bun test src/plugins/ibkr` 61/61 pass, no regressions.
