### PR TITLE
Fix global OpenTUI upgrade crash

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -37,3 +37,6 @@ jobs:
 
       - name: Build core binary
         run: bun run build
+
+      - name: Test global upgrade from 0.5.0
+        run: bun run test:global-upgrade

--- a/bun.lock
+++ b/bun.lock
@@ -7,15 +7,12 @@
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.81.1",
         "@earendil-works/pi-ai": "0.81.1",
-        "@opentui-ui/dialog": "^0.1.2",
-        "@opentui-ui/toast": "^0.0.5",
         "@opentui/core": "^0.3.2",
         "@opentui/react": "^0.3.2",
         "@stoqey/ib": "^1.5.6",
         "@tanstack/react-virtual": "^3.14.2",
         "hls.js": "1.6.13",
         "jimp": "1.6.1",
-        "opentui-spinner": "^0.0.6",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "rxjs": "^7.8.2",
@@ -171,10 +168,6 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
-    "@opentui-ui/dialog": ["@opentui-ui/dialog@0.1.2", "", { "peerDependencies": { "@opentui/core": "^0.1.69", "@opentui/react": "^0.1.69", "@opentui/solid": "^0.1.69" }, "optionalPeers": ["@opentui/react", "@opentui/solid"] }, "sha512-EZ4FG5u5sxU75+6pcsJsLzsD5JqO05So/1ceZUKUu7nxZ9IF7gcZEi+MU4HnYC9cb2Q7w6hM9y3/iW+jE1C53w=="],
-
-    "@opentui-ui/toast": ["@opentui-ui/toast@0.0.5", "", { "peerDependencies": { "@opentui/core": "^0.1.63", "@opentui/react": "^0.1.63", "@opentui/solid": "^0.1.63" }, "optionalPeers": ["@opentui/react", "@opentui/solid"] }, "sha512-LOT5Bw0F5AEyhjSqpKgS7aSe7M7v+ahaAa4t3/K2dtWiT0CJ711UHXqM31KKN6yuHoUKRNs+g+643ety/a3lEw=="],
-
     "@opentui/core": ["@opentui/core@0.3.2", "", { "dependencies": { "bun-ffi-structs": "0.2.2", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.3.2", "@opentui/core-darwin-x64": "0.3.2", "@opentui/core-linux-arm64": "0.3.2", "@opentui/core-linux-arm64-musl": "0.3.2", "@opentui/core-linux-x64": "0.3.2", "@opentui/core-linux-x64-musl": "0.3.2", "@opentui/core-win32-arm64": "0.3.2", "@opentui/core-win32-x64": "0.3.2" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-5rCVS/3Obb3iLqg/egLCRArt7hAu3lX/9PWVHqUlnJylCT6b5NYDFljt0r3x8v3VG98LB71UzpnDv7DgmGKATw=="],
 
     "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rFnGfqqEOGiUTbxglpiDA500KeRqcI1ukemhNfDrEzx3imAArS8mFZSuUG7ib31P5EpX+PXuvg0G9/3YXfgWeQ=="],
@@ -292,8 +285,6 @@
     "bun-ffi-structs": ["bun-ffi-structs@0.2.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-N/ZWtyN0piZlrXQT7TO0V+q952orYqkfhXRXM1Hcbb+R3QSiBH4vLnib187Mrs1H7pWIYECAmPeapGYDOMCl+w=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
-
-    "cli-spinners": ["cli-spinners@3.4.0", "", {}, "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw=="],
 
     "colors": ["colors@1.4.0", "", {}, "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="],
 
@@ -420,8 +411,6 @@
     "omggif": ["omggif@1.0.10", "", {}, "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="],
 
     "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
-
-    "opentui-spinner": ["opentui-spinner@0.0.6", "", { "dependencies": { "cli-spinners": "^3.3.0" }, "peerDependencies": { "@opentui/core": "^0.1.49", "@opentui/react": "^0.1.49", "@opentui/solid": "^0.1.49", "typescript": "^5" }, "optionalPeers": ["@opentui/react", "@opentui/solid"] }, "sha512-xupLOeVQEAXEvVJCvHkfX6fChDWmJIPHe5jyUrVb8+n4XVTX8mBNhitFfB9v2ZbkC1H2UwPab/ElePHoW37NcA=="],
 
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "typecheck:electrobun-view": "tsc --project tsconfig.electrobun-view.json",
     "typecheck:scripts": "tsc --project tsconfig.scripts.json",
     "test": "bun test",
+    "test:global-upgrade": "bun run scripts/smoke-global-upgrade.ts",
     "release": "./scripts/release.sh"
   },
   "license": "MIT",
@@ -59,15 +60,12 @@
   "dependencies": {
     "@earendil-works/pi-agent-core": "0.81.1",
     "@earendil-works/pi-ai": "0.81.1",
-    "@opentui-ui/dialog": "^0.1.2",
-    "@opentui-ui/toast": "^0.0.5",
     "@opentui/core": "^0.3.2",
     "@opentui/react": "^0.3.2",
     "@stoqey/ib": "^1.5.6",
     "@tanstack/react-virtual": "^3.14.2",
     "hls.js": "1.6.13",
     "jimp": "1.6.1",
-    "opentui-spinner": "^0.0.6",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "rxjs": "^7.8.2",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -2,7 +2,10 @@ import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, 
 import { tmpdir } from "os";
 import { join } from "path";
 import { gzipSync } from "zlib";
-import { OPEN_TUI_NATIVE_SMOKE_COMMAND } from "../src/cli/native-smoke";
+import {
+  OPEN_TUI_NATIVE_SMOKE_COMMAND,
+  OPEN_TUI_RUNTIME_SMOKE_COMMAND,
+} from "../src/cli/native-smoke";
 
 const rootDir = join(import.meta.dir, "..");
 
@@ -95,6 +98,10 @@ async function smokeTestBinary(outfile: string, os: string, arch: string) {
     {
       args: [OPEN_TUI_NATIVE_SMOKE_COMMAND],
       failureMessage: `Packaged binary failed to load OpenTUI native package: ${outfile}`,
+    },
+    {
+      args: [OPEN_TUI_RUNTIME_SMOKE_COMMAND],
+      failureMessage: `Packaged binary failed to load the OpenTUI runtime graph: ${outfile}`,
     },
     {
       args: ["help"],

--- a/scripts/smoke-global-upgrade.ts
+++ b/scripts/smoke-global-upgrade.ts
@@ -1,0 +1,109 @@
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { OPEN_TUI_RUNTIME_SMOKE_COMMAND } from "../src/cli/native-smoke";
+
+const rootDir = join(import.meta.dir, "..");
+const smokeDir = mkdtempSync(join(tmpdir(), "gloomberb-global-upgrade-"));
+const installDir = join(smokeDir, "bun-install");
+const packageDir = join(smokeDir, "package");
+const archiveName = "gloomberb-current.tgz";
+const archivePath = join(smokeDir, archiveName);
+const smokeEnvironment = { ...process.env, BUN_INSTALL: installDir };
+
+async function run(command: string[], cwd = rootDir): Promise<void> {
+  const process = Bun.spawn(command, {
+    cwd,
+    env: smokeEnvironment,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ]);
+  if (exitCode === 0) return;
+  throw new Error([
+    `Command failed (${exitCode}): ${command.join(" ")}`,
+    stdout.trim(),
+    stderr.trim(),
+  ].filter(Boolean).join("\n"));
+}
+
+try {
+  mkdirSync(packageDir);
+  const packageJson = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8")) as {
+    patchedDependencies?: Record<string, string>;
+  };
+  delete packageJson.patchedDependencies;
+  writeFileSync(join(packageDir, "package.json"), `${JSON.stringify(packageJson, null, 2)}\n`);
+  for (const entry of ["bin", "src", "patches"]) {
+    cpSync(join(rootDir, entry), join(packageDir, entry), { recursive: true });
+  }
+
+  await run([
+    "bun",
+    "pm",
+    "pack",
+    "--filename",
+    archivePath,
+    "--ignore-scripts",
+    "--quiet",
+  ], packageDir);
+  await run(["bun", "install", "--global", "gloomberb@0.5.0"]);
+
+  const globalNodeModules = join(installDir, "install", "global", "node_modules");
+  const staleBackupDir = join(smokeDir, "stale-opentui");
+  const oldCoreDir = join(globalNodeModules, "@opentui", "core");
+  const oldReactDir = join(globalNodeModules, "@opentui", "react");
+  const addOnPaths: Array<readonly [string, string]> = [
+    [join(globalNodeModules, "@opentui-ui", "dialog"), join(staleBackupDir, "dialog")],
+    [join(globalNodeModules, "@opentui-ui", "toast"), join(staleBackupDir, "toast")],
+    [join(globalNodeModules, "opentui-spinner"), join(staleBackupDir, "spinner")],
+  ];
+  if (!existsSync(oldCoreDir) || !existsSync(oldReactDir) || addOnPaths.some(([source]) => !existsSync(source))) {
+    throw new Error("The 0.5.0 fixture did not install the expected OpenTUI dependency graph.");
+  }
+  cpSync(oldCoreDir, join(staleBackupDir, "core"), { recursive: true });
+  cpSync(oldReactDir, join(staleBackupDir, "react"), { recursive: true });
+  for (const [source, backup] of addOnPaths) cpSync(source, backup, { recursive: true });
+  // Bun treats a local tarball replacement for a recorded global registry package as a
+  // dependency loop. Forget only the manifest entry while preserving the 0.5.0 files
+  // and dependency residue that this regression needs to exercise.
+  const globalPackageJsonPath = join(installDir, "install", "global", "package.json");
+  const globalPackageJson = JSON.parse(readFileSync(globalPackageJsonPath, "utf8")) as {
+    dependencies?: Record<string, string>;
+  };
+  delete globalPackageJson.dependencies?.gloomberb;
+  writeFileSync(globalPackageJsonPath, `${JSON.stringify(globalPackageJson, null, 2)}\n`);
+
+  await run(["bun", "install", "--global", archivePath]);
+
+  // Recreate the exact stale peer layout from #510 deterministically. The fixed
+  // runtime must ignore these old nested OpenTUI copies even when they remain on disk.
+  for (const [destination, backup] of addOnPaths) {
+    mkdirSync(dirname(destination), { recursive: true });
+    cpSync(backup, destination, { recursive: true });
+    const nestedOpenTui = join(destination, "node_modules", "@opentui");
+    mkdirSync(nestedOpenTui, { recursive: true });
+    cpSync(join(staleBackupDir, "core"), join(nestedOpenTui, "core"), { recursive: true });
+    cpSync(join(staleBackupDir, "react"), join(nestedOpenTui, "react"), { recursive: true });
+  }
+
+  const installedPackage = JSON.parse(readFileSync(
+    join(installDir, "install", "global", "node_modules", "gloomberb", "package.json"),
+    "utf8",
+  )) as { dependencies?: Record<string, string> };
+  const incompatiblePackages = ["@opentui-ui/dialog", "@opentui-ui/toast", "opentui-spinner"];
+  const retained = incompatiblePackages.filter((name) => installedPackage.dependencies?.[name]);
+  if (retained.length > 0) {
+    throw new Error(`Current package still depends on incompatible OpenTUI add-ons: ${retained.join(", ")}`);
+  }
+
+  const executable = join(installDir, "bin", process.platform === "win32" ? "gloomberb.exe" : "gloomberb");
+  await run([executable, OPEN_TUI_RUNTIME_SMOKE_COMMAND], smokeDir);
+  console.log("Global upgrade smoke passed: gloomberb 0.5.0 to the current package loaded the OpenTUI runtime graph.");
+} finally {
+  rmSync(smokeDir, { recursive: true, force: true });
+}

--- a/src/cli/entry.ts
+++ b/src/cli/entry.ts
@@ -2,7 +2,12 @@ import { dispatchCli } from "./index";
 import { fail, inferCliErrorOptions, printCliError } from "./errors";
 import { loadExternalPlugins } from "../plugins/loader";
 import type { CliLaunchRequest } from "../types/plugin";
-import { OPEN_TUI_NATIVE_SMOKE_COMMAND, smokeOpenTuiNative } from "./native-smoke";
+import {
+  OPEN_TUI_NATIVE_SMOKE_COMMAND,
+  OPEN_TUI_RUNTIME_SMOKE_COMMAND,
+  smokeOpenTuiNative,
+  smokeOpenTuiRuntime,
+} from "./native-smoke";
 
 async function launchOpenTuiApp(options: {
   externalPlugins: Awaited<ReturnType<typeof loadExternalPlugins>>;
@@ -23,6 +28,11 @@ export async function runCliEntrypoint(rawArgs = process.argv.slice(2)): Promise
 
   if (command === OPEN_TUI_NATIVE_SMOKE_COMMAND) {
     await smokeOpenTuiNative();
+    process.exit(0);
+  }
+
+  if (command === OPEN_TUI_RUNTIME_SMOKE_COMMAND) {
+    await smokeOpenTuiRuntime();
     process.exit(0);
   }
 

--- a/src/cli/native-smoke.ts
+++ b/src/cli/native-smoke.ts
@@ -1,5 +1,10 @@
 export const OPEN_TUI_NATIVE_SMOKE_COMMAND = "__gloomberb-smoke-opentui-native";
+export const OPEN_TUI_RUNTIME_SMOKE_COMMAND = "__gloomberb-smoke-opentui-runtime";
 
 export async function smokeOpenTuiNative(): Promise<void> {
   await import("../renderers/opentui/native-smoke");
+}
+
+export async function smokeOpenTuiRuntime(): Promise<void> {
+  await import("../renderers/opentui/start");
 }

--- a/src/renderers/opentui/dialog-host.tsx
+++ b/src/renderers/opentui/dialog-host.tsx
@@ -1,103 +1,302 @@
-import type { ReactNode } from "react";
-import { useMemo } from "react";
+/** @jsxImportSource @opentui/react */
+import { RGBA, type Renderable } from "@opentui/core";
+import { flushSync, useKeyboard, useRenderer } from "@opentui/react";
 import {
-  DialogProvider as OpenTuiDialogProvider,
-  type AlertContext as OpenTuiAlertContext,
-  type AlertOptions as OpenTuiAlertOptions,
-  type PromptContext as OpenTuiPromptContext,
-  type PromptOptions as OpenTuiPromptOptions,
-  useDialog as useOpenTuiDialog,
-  useDialogState as useOpenTuiDialogState,
-} from "@opentui-ui/dialog/react";
-import { DialogHostProvider, type DialogApi } from "../../ui/dialog";
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { colors } from "../../theme/colors";
+import {
+  DialogHostProvider,
+  type AlertContext,
+  type DialogApi,
+  type PromptContext,
+} from "../../ui/dialog";
 
-function renderDialogContent(content: unknown, context: Record<string, unknown>): ReactNode {
+type DialogSize = "small" | "medium" | "large" | "full";
+
+interface DialogStyle {
+  width?: number;
+  maxWidth?: number;
+  maxHeight?: number;
+  [key: string]: unknown;
+}
+
+interface DialogRecord {
+  id: string;
+  content: unknown;
+  kind: "alert" | "prompt";
+  size?: DialogSize;
+  style?: DialogStyle;
+  closeOnEscape?: boolean;
+  closeOnClickOutside?: boolean;
+  settle(value: unknown): void;
+}
+
+export interface OpenTuiDialogHostProviderProps {
+  children: ReactNode;
+  size?: DialogSize;
+  sizePresets?: Partial<Record<DialogSize, number>>;
+  closeOnEscape?: boolean;
+  closeOnClickOutside?: boolean;
+  dialogOptions?: { style?: DialogStyle };
+  backdropColor?: string;
+  backdropOpacity?: number;
+}
+
+let nextDialogId = 1;
+
+function renderDialogContent(content: unknown, context: AlertContext | PromptContext<unknown>): ReactNode {
   return typeof content === "function"
-    ? (content as (context: Record<string, unknown>) => ReactNode)(context)
+    ? (content as (context: AlertContext | PromptContext<unknown>) => ReactNode)(context)
     : content as ReactNode;
 }
 
-function normalizeDialogId(value: unknown): string | undefined {
-  return typeof value === "string" || typeof value === "number" ? String(value) : undefined;
+function dialogWidth(
+  size: DialogSize,
+  terminalWidth: number,
+  sizePresets: OpenTuiDialogHostProviderProps["sizePresets"],
+): number {
+  const customWidth = sizePresets?.[size];
+  const requestedWidth = customWidth && customWidth > 0
+    ? customWidth
+    : size === "small"
+      ? 40
+      : size === "large"
+        ? 80
+        : size === "full"
+          ? terminalWidth - 4
+          : 60;
+  return Math.max(1, Math.min(requestedWidth, terminalWidth - 2));
 }
 
-function OpenTuiDialogContentBridge({
+function backdrop(color: string, opacity: number): RGBA {
+  const value = RGBA.fromHex(color);
+  value.a = Math.max(0, Math.min(opacity, 1));
+  return value;
+}
+
+function DialogLayer({
+  api,
+  close,
+  containerOptions,
   dialog,
-  dialogId,
-  children,
+  dimensions,
+  index,
+  isTopmost,
 }: {
-  dialog: DialogApi;
-  dialogId: string | undefined;
-  children: ReactNode;
+  api: DialogApi;
+  close(id: string, value?: unknown): void;
+  containerOptions: Omit<OpenTuiDialogHostProviderProps, "children">;
+  dialog: DialogRecord;
+  dimensions: { width: number; height: number };
+  index: number;
+  isTopmost: boolean;
 }) {
-  const isTopmost = useOpenTuiDialogState(
-    (state) => normalizeDialogId(state.topDialog?.id) === dialogId,
-  );
-  return (
-    <DialogHostProvider
-      dialog={dialog}
-      isOpen={true}
-      dialogId={dialogId}
-      keyboardEnabled={isTopmost}
-    >
-      {children}
-    </DialogHostProvider>
-  );
-}
+  const effectiveSize = dialog.size ?? containerOptions.size ?? "medium";
+  const providerStyle = containerOptions.dialogOptions?.style ?? {};
+  const style = { ...providerStyle, ...dialog.style };
+  const viewportWidth = Math.max(1, dimensions.width - 2);
+  const viewportHeight = Math.max(1, dimensions.height - 2);
+  const width = typeof style.width === "number"
+    ? Math.max(1, Math.min(style.width, viewportWidth))
+    : dialogWidth(effectiveSize, dimensions.width, containerOptions.sizePresets);
+  const maxWidth = typeof style.maxWidth === "number"
+    ? Math.max(1, Math.min(style.maxWidth, viewportWidth))
+    : viewportWidth;
+  const maxHeight = typeof style.maxHeight === "number"
+    ? Math.max(1, Math.min(style.maxHeight, viewportHeight))
+    : viewportHeight;
+  const closeOnEscape = dialog.closeOnEscape ?? containerOptions.closeOnEscape ?? true;
+  const closeOnClickOutside = dialog.closeOnClickOutside
+    ?? containerOptions.closeOnClickOutside
+    ?? false;
+  const zIndex = 9_998 + index * 2;
 
-function OpenTuiDialogBridge({ children }: { children: ReactNode }) {
-  const openTuiDialog = useOpenTuiDialog();
-  const isOpen = useOpenTuiDialogState((state) => state.isOpen);
-  const dialog = useMemo<DialogApi>(() => {
-    const wrapAlertOptions = (options: Record<string, unknown>): OpenTuiAlertOptions => ({
-      ...options,
-      content: (context: OpenTuiAlertContext) => {
-        const dialogId = normalizeDialogId(context.dialogId);
-        return (
-          <OpenTuiDialogContentBridge dialog={dialog} dialogId={dialogId}>
-            {renderDialogContent(options.content, { ...context, dialogId })}
-          </OpenTuiDialogContentBridge>
-        );
-      },
-    });
+  useKeyboard((event) => {
+    if (!isTopmost || !closeOnEscape || event.name !== "escape") return;
+    event.preventDefault?.();
+    event.stopPropagation?.();
+    close(dialog.id);
+  });
 
-    const wrapPromptOptions = <T,>(options: Record<string, unknown>): OpenTuiPromptOptions<T> => ({
-      ...options,
-      content: (context: OpenTuiPromptContext<T>) => {
-        const dialogId = normalizeDialogId(context.dialogId);
-        return (
-          <OpenTuiDialogContentBridge dialog={dialog} dialogId={dialogId}>
-            {renderDialogContent(options.content, { ...context, dialogId })}
-          </OpenTuiDialogContentBridge>
-        );
-      },
-    });
-
-    return {
-      alert: (options) => openTuiDialog.alert(wrapAlertOptions(options)),
-      prompt: <T,>(options: Record<string, unknown>) => openTuiDialog.prompt<T>(wrapPromptOptions<T>(options)),
+  const context = dialog.kind === "prompt"
+    ? {
+      dialogId: dialog.id,
+      dismiss: () => close(dialog.id),
+      resolve: (value: unknown) => close(dialog.id, value),
+    }
+    : {
+      dialogId: dialog.id,
+      dismiss: () => close(dialog.id),
     };
-  }, [openTuiDialog]);
 
   return (
-    <DialogHostProvider dialog={dialog} isOpen={isOpen}>
-      {children}
-    </DialogHostProvider>
+    <>
+      <box
+        position="absolute"
+        left={0}
+        top={0}
+        width={dimensions.width}
+        height={dimensions.height}
+        zIndex={zIndex}
+        backgroundColor={backdrop(
+          containerOptions.backdropColor ?? colors.bg,
+          containerOptions.backdropOpacity ?? 0.8,
+        )}
+      />
+      <box
+        position="absolute"
+        left={0}
+        top={0}
+        width={dimensions.width}
+        height={dimensions.height}
+        zIndex={zIndex + 1}
+        alignItems="center"
+        justifyContent="center"
+        onMouseDown={() => {
+          if (isTopmost && closeOnClickOutside) close(dialog.id);
+        }}
+      >
+        <box
+          {...style as any}
+          width={width}
+          maxWidth={maxWidth}
+          maxHeight={maxHeight}
+          border={style.border ?? true}
+          borderStyle={style.borderStyle ?? "single"}
+          borderColor={style.borderColor ?? colors.borderFocused}
+          backgroundColor={style.backgroundColor ?? colors.bg}
+          paddingX={style.paddingX ?? 2}
+          paddingY={style.paddingY ?? 1}
+          onMouseDown={(event: { stopPropagation(): void }) => event.stopPropagation()}
+        >
+          <DialogHostProvider
+            dialog={api}
+            isOpen={true}
+            dialogId={dialog.id}
+            keyboardEnabled={isTopmost}
+          >
+            {renderDialogContent(dialog.content, context)}
+          </DialogHostProvider>
+        </box>
+      </box>
+    </>
   );
 }
 
 export function OpenTuiDialogHostProvider({
   children,
-  ...props
-}: {
-  children: ReactNode;
-  [key: string]: unknown;
-}) {
+  ...containerOptions
+}: OpenTuiDialogHostProviderProps) {
+  const renderer = useRenderer();
+  const [dimensions, setDimensions] = useState(() => ({
+    width: renderer.width,
+    height: renderer.height,
+  }));
+  const [dialogs, setDialogs] = useState<DialogRecord[]>([]);
+  const dialogsRef = useRef<DialogRecord[]>([]);
+  const savedFocusRef = useRef<Renderable | null>(null);
+  const mountedRef = useRef(true);
+
+  const publish = useCallback((next: DialogRecord[]) => {
+    dialogsRef.current = next;
+    if (mountedRef.current) flushSync(() => setDialogs(next));
+  }, []);
+
+  const close = useCallback((id: string, value?: unknown) => {
+    const current = dialogsRef.current;
+    const target = current.find((dialog) => dialog.id === id);
+    if (!target) return;
+    const next = current.filter((dialog) => dialog.id !== id);
+    publish(next);
+    target.settle(value);
+    if (next.length === 0) {
+      const savedFocus = savedFocusRef.current;
+      savedFocusRef.current = null;
+      queueMicrotask(() => {
+        try {
+          savedFocus?.focus();
+        } catch {
+          // The previously focused renderable may have unmounted with the dialog.
+        }
+      });
+    }
+  }, [publish]);
+
+  const open = useCallback(<T,>(kind: DialogRecord["kind"], options: Record<string, unknown>) => (
+    new Promise<T | undefined>((resolve) => {
+      if (dialogsRef.current.length === 0) {
+        savedFocusRef.current = renderer.currentFocusedRenderable;
+        savedFocusRef.current?.blur();
+      }
+      let settled = false;
+      const record: DialogRecord = {
+        id: `gloom-dialog-${nextDialogId++}`,
+        kind,
+        content: options.content,
+        size: options.size as DialogSize | undefined,
+        style: options.style as DialogStyle | undefined,
+        closeOnEscape: options.closeOnEscape as boolean | undefined,
+        closeOnClickOutside: options.closeOnClickOutside as boolean | undefined,
+        settle(value) {
+          if (settled) return;
+          settled = true;
+          resolve(value as T | undefined);
+        },
+      };
+      publish([...dialogsRef.current, record]);
+    })
+  ), [publish, renderer]);
+
+  const api = useMemo<DialogApi>(() => ({
+    alert: async (options) => {
+      await open<void>("alert", options);
+    },
+    prompt: <T,>(options: Record<string, unknown>) => open<T>("prompt", options),
+  }), [open]);
+
+  useEffect(() => {
+    const updateDimensions = () => {
+      setDimensions({ width: renderer.width, height: renderer.height });
+    };
+    renderer.on("resize", updateDimensions);
+    return () => {
+      renderer.off("resize", updateDimensions);
+    };
+  }, [renderer]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      for (const dialog of dialogsRef.current) dialog.settle(undefined);
+      dialogsRef.current = [];
+      savedFocusRef.current = null;
+    };
+  }, []);
+
   return (
-    <OpenTuiDialogProvider {...props}>
-      <OpenTuiDialogBridge>
+    <DialogHostProvider dialog={api} isOpen={dialogs.length > 0}>
+      <box position="relative" width={dimensions.width} height={dimensions.height}>
         {children}
-      </OpenTuiDialogBridge>
-    </OpenTuiDialogProvider>
+        {dialogs.map((dialog, index) => (
+          <DialogLayer
+            key={dialog.id}
+            api={api}
+            close={close}
+            containerOptions={containerOptions}
+            dialog={dialog}
+            dimensions={dimensions}
+            index={index}
+            isTopmost={index === dialogs.length - 1}
+          />
+        ))}
+      </box>
+    </DialogHostProvider>
   );
 }

--- a/src/renderers/opentui/test-utils.tsx
+++ b/src/renderers/opentui/test-utils.tsx
@@ -1,5 +1,4 @@
 import { useMemo, type ReactNode } from "react";
-import { DialogProvider } from "@opentui-ui/dialog/react";
 import { testRender as openTuiTestRender } from "@opentui/react/test-utils";
 import { createRoot as openTuiCreateRoot, useRenderer } from "@opentui/react";
 import { UiHostProvider, type NativeRendererHost, type RendererHost } from "../../ui";
@@ -12,7 +11,7 @@ import { openTuiToastHost } from "./toast-host";
 
 export function TestDialogProvider({ children }: { children: ReactNode }) {
   return (
-    <DialogProvider
+    <OpenTuiDialogHostProvider
       dialogOptions={{
         style: {
           backgroundColor: colors.bg,
@@ -22,7 +21,7 @@ export function TestDialogProvider({ children }: { children: ReactNode }) {
       }}
     >
       {children}
-    </DialogProvider>
+    </OpenTuiDialogHostProvider>
   );
 }
 
@@ -55,9 +54,13 @@ function OpenTuiTestProviders({ children }: { children: ReactNode }) {
       <OpenTuiInputHostProvider>
         <ToastHostProvider host={openTuiToastHost}>
           <OpenTuiDialogHostProvider
-            backgroundColor={colors.bg}
-            containerBorderColor={colors.border}
-            focusedBorderColor={colors.borderFocused}
+            dialogOptions={{
+              style: {
+                backgroundColor: colors.bg,
+                borderColor: colors.borderFocused,
+                borderStyle: "single",
+              },
+            }}
           >
             {children}
           </OpenTuiDialogHostProvider>

--- a/src/renderers/opentui/toast-host.tsx
+++ b/src/renderers/opentui/toast-host.tsx
@@ -1,10 +1,139 @@
-import { Toaster, toast } from "@opentui-ui/toast/react";
-import type { ToastHost } from "../../ui/toast";
+/** @jsxImportSource @opentui/react */
+import { useTerminalDimensions } from "@opentui/react";
+import { useSyncExternalStore } from "react";
+import { colors } from "../../theme/colors";
+import type { ToastHost, ToastOptions } from "../../ui/toast";
+
+type ToastTone = "success" | "error" | "info";
+
+interface ToastRecord {
+  id: number;
+  body: string;
+  tone: ToastTone;
+  options?: ToastOptions;
+}
+
+let nextToastId = 1;
+let toasts: ToastRecord[] = [];
+const listeners = new Set<() => void>();
+const timers = new Map<number, ReturnType<typeof setTimeout>>();
+
+function publish(): void {
+  for (const listener of listeners) listener();
+}
+
+function dismissToast(id: string | number): void {
+  const numericId = typeof id === "number" ? id : Number(id);
+  if (!Number.isFinite(numericId)) return;
+  const timer = timers.get(numericId);
+  if (timer) clearTimeout(timer);
+  timers.delete(numericId);
+  const next = toasts.filter((toast) => toast.id !== numericId);
+  if (next.length === toasts.length) return;
+  toasts = next;
+  publish();
+}
+
+function addToast(tone: ToastTone, body: string, options?: ToastOptions): number {
+  const id = nextToastId++;
+  toasts = [...toasts, { id, body, tone, options }];
+  publish();
+  const duration = options?.duration ?? 4_000;
+  if (Number.isFinite(duration) && duration > 0) {
+    timers.set(id, setTimeout(() => dismissToast(id), duration));
+  }
+  return id;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot(): ToastRecord[] {
+  return toasts;
+}
+
+function toneColor(tone: ToastTone): string {
+  if (tone === "success") return colors.positive;
+  if (tone === "error") return colors.negative;
+  return colors.neutral;
+}
+
+function toneIcon(tone: ToastTone): string {
+  if (tone === "success") return "✓";
+  if (tone === "error") return "!";
+  return "i";
+}
+
+function ToastViewport({ position = "bottom-right" }: { position?: string }) {
+  const dimensions = useTerminalDimensions();
+  const visibleToasts = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const maxWidth = Math.max(1, Math.min(60, dimensions.width - 4));
+  const placement = position.startsWith("top") ? { top: 1 } : { bottom: 1 };
+  const horizontal = position.endsWith("left")
+    ? { left: 2 }
+    : position.endsWith("center")
+      ? { left: Math.max(0, Math.floor((dimensions.width - maxWidth) / 2)) }
+      : { right: 2 };
+
+  if (visibleToasts.length === 0) return null;
+
+  return (
+    <box
+      position="absolute"
+      {...placement}
+      {...horizontal}
+      width={maxWidth}
+      zIndex={9_900}
+      flexDirection="column"
+      gap={1}
+    >
+      {visibleToasts.slice(-4).map((toast) => (
+        <box
+          key={toast.id}
+          width="100%"
+          border
+          borderStyle="single"
+          borderColor={toneColor(toast.tone)}
+          backgroundColor={colors.panel}
+          paddingX={1}
+          flexDirection="row"
+          gap={1}
+        >
+          <text fg={toneColor(toast.tone)}>{toneIcon(toast.tone)}</text>
+          <text fg={colors.text} flexGrow={1} wrapMode="word">{toast.body}</text>
+          {toast.options?.action && (
+            <text
+              fg={colors.textBright}
+              attributes={1}
+              onMouseDown={(event) => {
+                event.stopPropagation();
+                toast.options?.action?.onClick();
+              }}
+            >
+              {`[${toast.options.action.label}]`}
+            </text>
+          )}
+          <text
+            fg={colors.textMuted}
+            onMouseDown={(event) => {
+              event.stopPropagation();
+              dismissToast(toast.id);
+            }}
+          >
+            ×
+          </text>
+        </box>
+      ))}
+    </box>
+  );
+}
 
 export const openTuiToastHost: ToastHost = {
-  Viewport: Toaster as ToastHost["Viewport"],
-  success: toast.success,
-  error: toast.error,
-  info: toast.info,
-  dismiss: toast.dismiss,
+  Viewport: ToastViewport,
+  success: (body, options) => addToast("success", body, options),
+  error: (body, options) => addToast("error", body, options),
+  info: (body, options) => addToast("info", body, options),
+  dismiss: dismissToast,
 };

--- a/src/renderers/opentui/ui-host.tsx
+++ b/src/renderers/opentui/ui-host.tsx
@@ -1,6 +1,5 @@
 import { RGBA, StyledText as OpenTuiStyledText, SyntaxStyle, TextAttributes as OpenTuiTextAttributes } from "@opentui/core";
-import { createElement, forwardRef, type ReactNode } from "react";
-import "opentui-spinner/react";
+import { createElement, forwardRef, useEffect, useState, type ReactNode } from "react";
 import { TextAttributes, type UiHost, type TextProps } from "../../ui/host";
 import { renderAsciiText } from "../../ui/ascii-font";
 import { OpenTuiImageSurface } from "./image/surface";
@@ -60,8 +59,25 @@ const OpenTuiBox = createOpenTuiPrimitive("box");
 const OpenTuiScrollBox = createOpenTuiPrimitive("scrollbox");
 const OpenTuiInput = createOpenTuiPrimitive("input");
 const OpenTuiTextarea = createOpenTuiPrimitive("textarea");
-const OpenTuiSpinnerMark = createOpenTuiPrimitive("spinner");
 const OpenTuiMediaSurface = createOpenTuiPrimitive("box");
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+const OpenTuiSpinnerMark = forwardRef<unknown, OpenTuiPrimitiveProps & { name?: string; color?: string }>(
+  function OpenTuiSpinnerMark({ name: _name, color, ...props }, ref) {
+    const [frame, setFrame] = useState(0);
+    useEffect(() => {
+      const timer = setInterval(() => setFrame((current) => (current + 1) % SPINNER_FRAMES.length), 80);
+      return () => clearInterval(timer);
+    }, []);
+    return createElement("text" as any, {
+      ...props,
+      ref,
+      fg: color,
+      content: SPINNER_FRAMES[frame],
+    });
+  },
+);
 
 const OpenTuiText = forwardRef<unknown, TextProps>(function OpenTuiText({ children, ...props }, ref) {
   const textProps = stripTextProps(props);


### PR DESCRIPTION
## What changed

- Remove the dialog, toast, and spinner packages that still peer-depend on OpenTUI 0.1.x.
- Preserve those UI behaviors with local implementations built against the current OpenTUI runtime.
- Add a full runtime-graph smoke to packaged builds.
- Add an isolated global-upgrade regression that installs 0.5.0, recreates the stale nested peer layout, upgrades to the current package, and starts the current OpenTUI graph.

## Root cause

An in-place Bun global upgrade could retain old nested `@opentui/core` and `@opentui/react` copies beneath the three incompatible add-ons. The old and current cores then registered the same environment variable with different definitions and aborted startup.

Closes #510.

## Verification

- `bun run typecheck`
- `bun test` with 1,855 passing tests
- `bun run build`, including packaged native, runtime-graph, and help smokes
- `bun run test:global-upgrade`
- tmux launch using the real TUI and command bar
