### PR TITLE
Fix ticker search ranking

### DIFF
--- a/src/components/command-bar/routes/root/provider-search.ts
+++ b/src/components/command-bar/routes/root/provider-search.ts
@@ -98,7 +98,7 @@ export function useRootProviderSearch(options: {
     );
     const localItems = localTickerSearchResultItems(searchQuery, { limit: 6 });
     setRootProviderResults(cachedCandidates
-      ? mergeTickerSearchResultItems(searchQuery, localItems, buildTickerSearchResultItems(cachedCandidates, searchQuery))
+      ? mergeTickerSearchResultItems(searchQuery, buildTickerSearchResultItems(cachedCandidates, searchQuery), localItems)
       : null);
     setRootProviderResultsQuery(cachedCandidates ? searchQuery : null);
 
@@ -125,8 +125,8 @@ export function useRootProviderSearch(options: {
         );
         setRootProviderResults(mergeTickerSearchResultItems(
           searchQuery,
-          localTickerSearchResultItems(searchQuery, { limit: 6 }),
           buildTickerSearchResultItems(combined, searchQuery),
+          localTickerSearchResultItems(searchQuery, { limit: 6 }),
         ));
         setRootProviderResultsQuery(searchQuery);
       } catch {
@@ -178,7 +178,11 @@ export function useRootProviderSearch(options: {
     rootResultItems,
     rootTickerSearchArg,
   ]);
-  const rootSectionOrder: CommandBarSectionOrder = rootPlainTickerSearchArg ? "app-first" : "default";
+  const rootSectionOrder: CommandBarSectionOrder = rootPlainTickerSearchArg
+    ? "app-first"
+    : rootTickerSearchArg
+      ? "ranked"
+      : "default";
   const orderedRootResults = useMemo(
     () => orderListResults(rootResults, { sectionOrder: rootSectionOrder }),
     [rootResults, rootSectionOrder],

--- a/src/components/command-bar/routes/ticker-search/results.test.ts
+++ b/src/components/command-bar/routes/ticker-search/results.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import type { ResultItem } from "../../list/model";
+import { mergeTickerSearchResultItems } from "./results";
+
+function resultItem(id: string, label: string, right: string, kind: ResultItem["kind"] = "ticker"): ResultItem {
+  return {
+    id,
+    label,
+    detail: "Apple Inc.",
+    category: kind === "info" ? "Search" : "Saved",
+    kind,
+    right,
+    action: () => {},
+  };
+}
+
+test("keeps completed ticker-search results authoritative over provisional rows", () => {
+  const authoritative = [
+    resultItem("ranked:AAPL", "AAPL", "Equity NASDAQ"),
+    resultItem("ranked:APC", "APC", "Equity XETRA"),
+  ];
+  const provisional = [
+    resultItem("local:APC", "APC", "Equity XETRA"),
+    resultItem("local:AAPL", "AAPL", "Equity NASDAQ"),
+  ];
+
+  expect(mergeTickerSearchResultItems("Apple", authoritative, provisional).map((item) => item.id)).toEqual([
+    "ranked:AAPL",
+    "ranked:APC",
+  ]);
+
+  const noResults = resultItem("no-results", "No matches for Apple", "", "info");
+  expect(mergeTickerSearchResultItems("Apple", [noResults], [])).toEqual([noResults]);
+});

--- a/src/components/command-bar/routes/ticker-search/results.ts
+++ b/src/components/command-bar/routes/ticker-search/results.ts
@@ -1,7 +1,6 @@
 import type { TickerRecord } from "../../../../types/ticker";
 import {
   createLocalTickerSearchCandidates,
-  rankTickerSearchItems,
   type TickerSearchCandidate,
 } from "../../../../tickers/search";
 import type { ResultItem } from "../../list/model";
@@ -33,7 +32,7 @@ function isExactTickerResultMatch(item: ResultItem, query: string): boolean {
 
 export function mergeTickerSearchResultItems(
   query: string,
-  preferredItems: ResultItem[],
+  rankedItems: ResultItem[],
   fallbackItems: ResultItem[],
 ): ResultItem[] {
   const merged: ResultItem[] = [];
@@ -45,12 +44,11 @@ export function mergeTickerSearchResultItems(
     seen.add(key);
     merged.push(item);
   };
-  preferredItems.forEach(addItem);
+  rankedItems.forEach(addItem);
   fallbackItems.forEach(addItem);
-  if (merged.length === 0) return fallbackItems;
+  if (merged.length === 0) return rankedItems.length > 0 ? rankedItems : fallbackItems;
 
-  return rankTickerSearchItems(merged, query)
-    .map((item) => isExactTickerResultMatch(item, query) && item.category !== "Saved"
+  return merged.map((item) => isExactTickerResultMatch(item, query) && item.category !== "Saved"
       ? { ...item, category: "Exact Match" }
       : item);
 }

--- a/src/components/command-bar/routes/ticker-search/route.ts
+++ b/src/components/command-bar/routes/ticker-search/route.ts
@@ -80,7 +80,7 @@ export function useTickerSearchRouteResults(options: {
       brokerInstanceId,
     );
     setTickerSearchResults(cachedCandidates
-      ? mergeTickerSearchResultItems(searchQuery, localItems, buildTickerSearchResultItems(cachedCandidates, searchQuery))
+      ? mergeTickerSearchResultItems(searchQuery, buildTickerSearchResultItems(cachedCandidates, searchQuery), localItems)
       : localItems);
     const requestId = ++searchRequestIdRef.current;
     const searchDelay = skipTickerSearchDebounceRef.current ? 0 : 200;
@@ -109,8 +109,8 @@ export function useTickerSearchRouteResults(options: {
         );
         setTickerSearchResults(mergeTickerSearchResultItems(
           searchQuery,
-          localTickerSearchResultItems(searchQuery, { limit: 6 }),
           buildTickerSearchResultItems(combined, searchQuery),
+          localTickerSearchResultItems(searchQuery, { limit: 6 }),
         ));
       } catch {
         if (requestId !== searchRequestIdRef.current) return;

--- a/src/components/command-bar/routing/list-state.ts
+++ b/src/components/command-bar/routing/list-state.ts
@@ -135,12 +135,13 @@ function buildRouteListState(options: BuildRouteListStateOptions): ListScreenSta
           query: currentRoute.query,
           selectedIdx: currentRoute.selectedIdx,
           hoveredIdx: currentRoute.hoveredIdx,
-          results: orderListResults(results),
+          results: orderListResults(results, { sectionOrder: "ranked" }),
           searching: tickerSearchPending,
           emptyLabel: emptyState.label,
           emptyDetail: emptyState.detail,
           footerLeft: getScreenFooterLeft(currentRoute),
           footerRight: getScreenFooterRight(currentRoute),
+          sectionOrder: "ranked",
         };
       }
       default:

--- a/src/components/command-bar/surface/index.test.tsx
+++ b/src/components/command-bar/surface/index.test.tsx
@@ -926,6 +926,71 @@ describe("CommandBar", () => {
     expect(aaplRow).toBeLessThan(appRow);
   });
 
+  test("keeps the provider-ranked canonical listing ahead of provisional saved order", async () => {
+    testSetup = await testRender(
+      <CommandBarHarness
+        query=""
+        extraTickers={[makeTicker("APC", "Apple Inc.", {
+          exchange: "XETRA",
+          currency: "EUR",
+          assetCategory: "STK",
+        })]}
+        configureState={(state) => ({
+          ...state,
+          commandBarLaunchRequest: {
+            kind: "ticker-search",
+            query: "Apple",
+            sequence: 1,
+          },
+          tickers: new Map([
+            ["APC", state.tickers.get("APC")!],
+            ["AAPL", state.tickers.get("AAPL")!],
+            ["MSFT", state.tickers.get("MSFT")!],
+          ]),
+        })}
+        dataProvider={makeDataProvider(async () => [
+          {
+            providerId: "yahoo",
+            symbol: "AAPL",
+            name: "Apple Inc.",
+            exchange: "NASDAQ",
+            primaryExchange: "NASDAQ",
+            type: "EQUITY",
+            currency: "USD",
+          },
+          {
+            providerId: "broker",
+            symbol: "APC",
+            name: "Apple Inc.",
+            exchange: "XETRA",
+            primaryExchange: "XETRA",
+            type: "EQUITY",
+            currency: "EUR",
+          },
+          {
+            providerId: "yahoo",
+            symbol: "APLY",
+            name: "Apple Yield Shares ETF",
+            exchange: "NYSE Arca",
+            type: "ETF",
+            currency: "USD",
+          },
+        ])}
+      />,
+      { width: 100, height: 24 },
+    );
+
+    await testSetup.renderOnce();
+    const frame = await waitForFrameToContain("APLY");
+    const rows = frame.split("\n");
+    const aaplRow = rows.findIndex((line) => line.trimStart().startsWith("AAPL"));
+    const apcRow = rows.findIndex((line) => line.trimStart().startsWith("APC"));
+
+    expect(aaplRow).toBeGreaterThanOrEqual(0);
+    expect(apcRow).toBeGreaterThanOrEqual(0);
+    expect(aaplRow).toBeLessThan(apcRow);
+  });
+
   test("renders form-layout wizard fields together on one screen", async () => {
     testSetup = await testRender(
       <CommandBarHarness

--- a/src/components/command-bar/view-model.test.ts
+++ b/src/components/command-bar/view-model.test.ts
@@ -67,6 +67,30 @@ describe("command bar view model helpers", () => {
     ]);
   });
 
+  test("orders ticker sections by their best-ranked candidate", () => {
+    const sections = buildSections([
+      { id: "primary", category: "Primary Listing" },
+      { id: "saved-alternate", category: "Saved" },
+      { id: "other", category: "Other Listings" },
+      { id: "saved-fallback", category: "Saved" },
+      { id: "fund", category: "Funds & Derivatives" },
+    ], { sectionOrder: "ranked" });
+
+    expect(sections.map((section) => section.category)).toEqual([
+      "Primary Listing",
+      "Saved",
+      "Other Listings",
+      "Funds & Derivatives",
+    ]);
+    expect(sections.flatMap((section) => section.items.map((item) => item.id))).toEqual([
+      "primary",
+      "saved-alternate",
+      "saved-fallback",
+      "other",
+      "fund",
+    ]);
+  });
+
   test("derives row presentation for toggles and current rows", () => {
     expect(getRowPresentation({
       id: "plugin:news",

--- a/src/components/command-bar/view-model.ts
+++ b/src/components/command-bar/view-model.ts
@@ -17,7 +17,7 @@ export interface CommandBarSection<T> {
   items: T[];
 }
 
-export type CommandBarSectionOrder = "default" | "app-first";
+export type CommandBarSectionOrder = "default" | "app-first" | "ranked";
 
 export interface CommandBarItemView {
   id: string;
@@ -138,6 +138,7 @@ export function truncateText(text: string, width: number): string {
 
 function getCategoryPriority(category: string, sectionOrder: CommandBarSectionOrder = "default"): number {
   const normalized = category.trim().toLowerCase();
+  if (sectionOrder === "ranked") return 0;
   // The AI answers the question the user actually typed, so it leads the list.
   if (normalized === "ask ai") return -100;
   if (normalized === "exact match") return -50;

--- a/src/tickers/search/index.test.ts
+++ b/src/tickers/search/index.test.ts
@@ -8,12 +8,17 @@ import {
   createLocalTickerSearchCandidates,
   findExactTickerSearchMatch,
   normalizeTickerInput,
+  rankTickerSearchItems,
   resolveTickerSearch,
   searchTickerCandidates,
   upsertTickerFromSearchResult,
 } from "./index";
 
-function makeTicker(symbol: string, name = symbol): TickerRecord {
+function makeTicker(
+  symbol: string,
+  name = symbol,
+  overrides: Partial<TickerRecord["metadata"]> = {},
+): TickerRecord {
   return {
     metadata: {
       ticker: symbol,
@@ -25,17 +30,23 @@ function makeTicker(symbol: string, name = symbol): TickerRecord {
       positions: [],
       custom: {},
       tags: [],
+      ...overrides,
     },
   };
 }
 
-function makeSearchResult(symbol: string, name = symbol): InstrumentSearchResult {
+function makeSearchResult(
+  symbol: string,
+  name = symbol,
+  overrides: Partial<InstrumentSearchResult> = {},
+): InstrumentSearchResult {
   return {
     providerId: "test",
     symbol,
     name,
     exchange: "NASDAQ",
     type: "EQUITY",
+    ...overrides,
   };
 }
 
@@ -104,6 +115,277 @@ describe("ticker-search utilities", () => {
       category: "Saved",
     });
     expect(findExactTickerSearchMatch(results, "AAPL")?.id).toBe("goto:AAPL");
+  });
+
+  test("enriches duplicate provider symbols from the saved listing's exchange", () => {
+    const results = buildTickerSearchCandidates({
+      query: "Apple NASDAQ",
+      tickers: new Map<string, TickerRecord>([
+        ["APC", makeTicker("APC", "Apple Inc.", { exchange: "XETRA", assetCategory: "STK" })],
+        ["AAPL", makeTicker("AAPL", "Apple Inc.", { exchange: "NASDAQ", assetCategory: "STK" })],
+      ]),
+      providerResults: [
+        makeSearchResult("APC", "Apple Inc.", { exchange: "XETRA" }),
+        makeSearchResult("AAPL", "Apple Inc. CEDEAR", {
+          exchange: "BYMA",
+          primaryExchange: "BYMA",
+          currency: "ARS",
+        }),
+        makeSearchResult("AAPL", "Apple Inc.", {
+          exchange: "SMART",
+          brokerContract: {
+            brokerId: "test",
+            symbol: "AAPL",
+            exchange: "NASDAQ",
+          },
+        }),
+      ],
+    });
+
+    expect(results[0]).toMatchObject({
+      id: "goto:AAPL",
+      right: "NASDAQ",
+      exchangeLabel: "NASDAQ",
+    });
+  });
+
+  test("does not apply a conflicting provider primary exchange to a saved listing", () => {
+    const results = buildTickerSearchCandidates({
+      query: "Apple BUE",
+      tickers: new Map<string, TickerRecord>([[
+        "AAPL",
+        makeTicker("AAPL", "Apple Inc.", { exchange: "NASDAQ", assetCategory: "STK" }),
+      ]]),
+      providerResults: [
+        makeSearchResult("AAPL", "Apple Inc.", {
+          exchange: "SMART",
+          primaryExchange: "BUE",
+        }),
+        makeSearchResult("AAPLC.BA", "Apple Inc.", { exchange: "BUE" }),
+      ],
+    });
+
+    expect(results[0]?.symbol).toBe("AAPLC.BA");
+    expect(results.find((item) => item.symbol === "AAPL")?.primaryExchangeLabel).toBeUndefined();
+  });
+
+  test("uses provider ordering to prefer the canonical saved listing for company-name queries", () => {
+    const tickers = new Map<string, TickerRecord>([
+      ["APC", makeTicker("APC", "Apple Inc.", {
+        exchange: "XETRA",
+        currency: "EUR",
+        assetCategory: "STK",
+      })],
+      ["AAPL", makeTicker("AAPL", "Apple Inc.", {
+        exchange: "NASDAQ",
+        currency: "USD",
+        assetCategory: "STK",
+      })],
+    ]);
+
+    const results = buildTickerSearchCandidates({
+      query: "Apple",
+      tickers,
+      providerResults: [
+        makeSearchResult("AAPL", "Apple Inc.", {
+          exchange: "NASDAQ",
+          primaryExchange: "NASDAQ",
+          currency: "USD",
+        }),
+        makeSearchResult("APC", "Apple Inc.", {
+          exchange: "XETRA",
+          primaryExchange: "XETRA",
+          currency: "EUR",
+        }),
+      ],
+    });
+
+    expect(results.slice(0, 2).map((item) => item.id)).toEqual([
+      "goto:AAPL",
+      "goto:APC",
+    ]);
+    expect(results.slice(0, 2).map((item) => item.category)).toEqual([
+      "Saved",
+      "Saved",
+    ]);
+  });
+
+  test("keeps explicit symbol, exchange, and asset-class intent ahead of provider ordering", () => {
+    const tickers = new Map<string, TickerRecord>([
+      ["APC", makeTicker("APC", "Apple Inc.", {
+        exchange: "XETRA",
+        currency: "EUR",
+        assetCategory: "STK",
+      })],
+      ["AAPL", makeTicker("AAPL", "Apple Inc.", {
+        exchange: "NASDAQ",
+        currency: "USD",
+        assetCategory: "STK",
+      })],
+    ]);
+    const providerResults = [
+      makeSearchResult("AAPL", "Apple Inc.", { exchange: "NASDAQ" }),
+      makeSearchResult("APC", "Apple Inc.", { exchange: "XETRA", currency: "EUR" }),
+      makeSearchResult("APLY", "Yield Strategy Linked to Apple ETF", { exchange: "NYSE Arca", type: "ETF" }),
+      makeSearchResult("APP", "AppLovin Corporation", { exchange: "NASDAQ" }),
+    ];
+    const firstSymbolFor = (query: string) => buildTickerSearchCandidates({
+      query,
+      tickers,
+      providerResults,
+    })[0]?.symbol;
+
+    expect(firstSymbolFor("APC")).toBe("APC");
+    expect(firstSymbolFor("APP")).toBe("APP");
+    expect(firstSymbolFor("Apple XETRA")).toBe("APC");
+    expect(firstSymbolFor("Apple NASDAQ")).toBe("AAPL");
+    expect(firstSymbolFor("Apple ETF")).toBe("APLY");
+  });
+
+  test("uses provider ordering without assuming the canonical listing is on a US exchange", () => {
+    const results = buildTickerSearchCandidates({
+      query: "Toyota",
+      tickers: new Map<string, TickerRecord>([[
+        "TM",
+        makeTicker("TM", "Toyota Motor Corporation", {
+          exchange: "NYSE",
+          currency: "USD",
+          assetCategory: "STK",
+        }),
+      ]]),
+      providerResults: [
+        makeSearchResult("7203", "Toyota Motor Corp", {
+          exchange: "Tokyo Stock Exchange",
+          primaryExchange: "Tokyo Stock Exchange",
+          currency: "JPY",
+        }),
+        makeSearchResult("TM", "Toyota Motor Corporation", {
+          exchange: "NYSE",
+          primaryExchange: "NYSE",
+          currency: "USD",
+        }),
+        makeSearchResult("TOYOTA80.BK", "TOYOTA80 DR", {
+          exchange: "SET",
+          currency: "THB",
+        }),
+      ],
+    });
+
+    expect(results.slice(0, 2).map((item) => [item.symbol, item.category])).toEqual([
+      ["7203", "Primary Listing"],
+      ["TM", "Saved"],
+    ]);
+  });
+
+  test("does not let provider order or an accidental symbol prefix overwhelm a closer company match", () => {
+    const results = buildTickerSearchCandidates({
+      query: "Apple",
+      tickers: new Map<string, TickerRecord>(),
+      providerResults: [
+        makeSearchResult("APLE", "Apple Hospitality REIT, Inc.", { exchange: "NYSE" }),
+        makeSearchResult("AAPL", "Apple Inc.", { exchange: "NASDAQ" }),
+        makeSearchResult("APPLE80.BK", "APPLE80 DR", { exchange: "SET", currency: "THB" }),
+      ],
+    });
+
+    expect(results[0]?.symbol).toBe("AAPL");
+    expect(results.some((item) => item.symbol === "APPLE80.BK")).toBe(true);
+  });
+
+  test("normalizes legal suffixes in literal company-name queries", () => {
+    const cases = [
+      {
+        query: "Apple Inc",
+        canonical: makeSearchResult("AAPL", "Apple Inc.", { exchange: "NASDAQ" }),
+        alternate: makeSearchResult("AAPL-ADR", "Apple Inc. ADR", { exchange: "OTC" }),
+      },
+      {
+        query: "Toyota Motor Corporation",
+        canonical: makeSearchResult("TM", "Toyota Motor Corporation", { exchange: "NYSE" }),
+        alternate: makeSearchResult("TM-ADR", "Toyota Motor Corporation ADR", { exchange: "OTC" }),
+      },
+    ];
+
+    for (const { query, canonical, alternate } of cases) {
+      const results = buildTickerSearchCandidates({
+        query,
+        tickers: new Map<string, TickerRecord>(),
+        providerResults: [alternate, canonical],
+      });
+
+      expect(results[0]?.symbol).toBe(canonical.symbol);
+    }
+  });
+
+  test("keeps same-issuer provider ordering transitive across ambiguous company matches", () => {
+    const candidates = [
+      {
+        id: "big-apple-primary",
+        label: "ZZZ",
+        symbol: "ZZZ",
+        detail: "Big Apple",
+        right: "NYSE",
+        category: "Other Listings",
+        kind: "search" as const,
+        instrumentClass: "equity" as const,
+        providerRank: 1,
+      },
+      {
+        id: "big-apple-alternate",
+        label: "APPLEB",
+        symbol: "APPLEB",
+        detail: "Big Apple",
+        right: "NASDAQ",
+        category: "Other Listings",
+        kind: "search" as const,
+        instrumentClass: "equity" as const,
+        providerRank: 2,
+      },
+      {
+        id: "unrelated-apple",
+        label: "XAPL",
+        symbol: "XAPL",
+        detail: "X Apple",
+        right: "NYSE",
+        category: "Other Listings",
+        kind: "search" as const,
+        instrumentClass: "equity" as const,
+        providerRank: 0,
+      },
+    ];
+
+    const expected = ["ZZZ", "APPLEB", "XAPL"];
+    expect(rankTickerSearchItems(candidates, "Apple").map((item) => item.symbol)).toEqual(expected);
+    expect(rankTickerSearchItems([...candidates].reverse(), "Apple").map((item) => item.symbol)).toEqual(expected);
+  });
+
+  test("normalizes punctuated legal suffixes before applying same-issuer provider order", () => {
+    const results = buildTickerSearchCandidates({
+      query: "Acme",
+      tickers: new Map<string, TickerRecord>(),
+      providerResults: [
+        makeSearchResult("AMS.MC", "Acme S.A.", { exchange: "BME" }),
+        makeSearchResult("ACM", "Acme SA", { exchange: "NYSE" }),
+      ],
+    });
+
+    expect(results.slice(0, 2).map((item) => item.symbol)).toEqual(["AMS.MC", "ACM"]);
+  });
+
+  test("keeps saved funds in the saved category", () => {
+    const results = buildTickerSearchCandidates({
+      query: "Vanguard",
+      tickers: new Map<string, TickerRecord>([[
+        "VTI",
+        makeTicker("VTI", "Vanguard Total Stock Market ETF", {
+          exchange: "NYSE Arca",
+          assetCategory: "ETF",
+        }),
+      ]]),
+      providerResults: [],
+    });
+
+    expect(results[0]).toMatchObject({ symbol: "VTI", category: "Saved" });
   });
 
   test("preserves exchange-qualified symbols and groups provider listings intuitively", () => {

--- a/src/tickers/search/index.ts
+++ b/src/tickers/search/index.ts
@@ -1,6 +1,7 @@
 import type { SearchRequestContext, DataProvider } from "../../types/data-provider";
 import type { InstrumentSearchResult } from "../../types/instrument";
 import type { TickerRecord } from "../../types/ticker";
+import { canonicalExchange } from "../../utils/exchanges";
 import { parseOptionSymbol } from "../../utils/options";
 import {
   buildSymbolAliases,
@@ -36,6 +37,7 @@ const SHARE_CLASS_SUFFIXES = new Set(["A", "B", "C", "D", "K"]);
 
 interface TickerSearchCandidateOptions {
   includeOptionContracts?: boolean;
+  providerRanks?: ReadonlyMap<string, number>;
 }
 
 export function normalizeTickerInput(activeTicker: string | null, arg?: string): string | null {
@@ -53,14 +55,21 @@ export function createLocalTickerSearchCandidates(
     if (options.includeOptionContracts === false && isOptionTickerRecord(ticker)) return [];
     const symbol = normalizeTickerSymbol(ticker.metadata.ticker);
     const hint = providerHints.get(symbol);
+    const exchangeLabel = ticker.metadata.exchange || hint?.exchange || hint?.primaryExchange;
+    const savedExchange = canonicalExchange(ticker.metadata.exchange);
+    const hintPrimaryExchange = canonicalExchange(hint?.primaryExchange);
+    const primaryExchangeLabel = !savedExchange || !hintPrimaryExchange || savedExchange === hintPrimaryExchange
+      ? hint?.primaryExchange
+      : undefined;
     return [{
       id: `goto:${ticker.metadata.ticker}`,
       label: ticker.metadata.ticker,
       symbol,
       detail: resolveLocalSearchName(ticker, hint),
-      right: hint?.exchange || ticker.metadata.exchange,
-      exchangeLabel: hint?.exchange || ticker.metadata.exchange,
-      primaryExchangeLabel: hint?.primaryExchange,
+      right: exchangeLabel,
+      exchangeLabel,
+      primaryExchangeLabel,
+      providerRank: options.providerRanks?.get(symbol),
       category: "Saved",
       kind: "ticker",
       saved: true,
@@ -77,7 +86,7 @@ function createProviderTickerSearchCandidates(
   localTickers: ReadonlyMap<string, TickerRecord>,
   options: TickerSearchCandidateOptions = {},
 ): TickerSearchCandidate[] {
-  return searchResults.flatMap((result) => {
+  return searchResults.flatMap((result, providerRank) => {
     if (options.includeOptionContracts === false && isOptionSearchResult(result)) return [];
     const symbol = getSearchResultSymbol(result);
     const saved = localTickers.has(symbol);
@@ -89,6 +98,7 @@ function createProviderTickerSearchCandidates(
       right: result.exchange || result.primaryExchange || result.type || undefined,
       exchangeLabel: result.exchange,
       primaryExchangeLabel: result.primaryExchange,
+      providerRank,
       category: saved ? "Saved" : "Other Listings",
       kind: "search",
       saved,
@@ -141,13 +151,16 @@ export function buildTickerSearchCandidates({
   totalLimit?: number;
   includeOptionContracts?: boolean;
 }): TickerSearchCandidate[] {
-  const candidateOptions = { includeOptionContracts };
   const filteredProviderResults = includeOptionContracts
     ? providerResults
     : providerResults.filter((result) => !isOptionSearchResult(result));
-  const providerHints = buildProviderHintMap(filteredProviderResults);
+  const providerHints = buildProviderHints(filteredProviderResults, tickers);
+  const candidateOptions = {
+    includeOptionContracts,
+    providerRanks: providerHints.ranks,
+  };
   const localItems = rankTickerSearchItems(
-    createLocalTickerSearchCandidates(tickers.values(), providerHints, candidateOptions),
+    createLocalTickerSearchCandidates(tickers.values(), providerHints.results, candidateOptions),
     query,
   );
   const providerItems = createProviderTickerSearchCandidates(filteredProviderResults, tickers, candidateOptions);
@@ -192,16 +205,28 @@ export async function resolveTickerSearch({
   };
 }
 
-function buildProviderHintMap(searchResults: InstrumentSearchResult[]): Map<string, InstrumentSearchResult> {
-  const hints = new Map<string, InstrumentSearchResult>();
-  for (const result of searchResults) {
+function buildProviderHints(
+  searchResults: InstrumentSearchResult[],
+  localTickers: ReadonlyMap<string, TickerRecord>,
+): {
+  results: Map<string, InstrumentSearchResult>;
+  ranks: Map<string, number>;
+} {
+  const results = new Map<string, InstrumentSearchResult>();
+  const ranks = new Map<string, number>();
+  for (const [rank, result] of searchResults.entries()) {
     const symbol = getSearchResultSymbol(result);
-    const existing = hints.get(symbol);
-    if (!existing || getProviderHintRichness(result) > getProviderHintRichness(existing)) {
-      hints.set(symbol, result);
+    if (!ranks.has(symbol)) ranks.set(symbol, rank);
+    const existing = results.get(symbol);
+    const preferredExchange = localTickers.get(symbol)?.metadata.exchange;
+    if (
+      !existing
+      || getProviderHintScore(result, preferredExchange) > getProviderHintScore(existing, preferredExchange)
+    ) {
+      results.set(symbol, result);
     }
   }
-  return hints;
+  return { results, ranks };
 }
 
 async function searchProviderResults(
@@ -284,14 +309,26 @@ function getProviderHintRichness(result: InstrumentSearchResult): number {
   return score;
 }
 
+function getProviderHintScore(result: InstrumentSearchResult, preferredExchange?: string): number {
+  const canonicalPreferredExchange = canonicalExchange(preferredExchange);
+  const matchesPreferredExchange = canonicalPreferredExchange
+    && [
+      result.exchange,
+      result.primaryExchange,
+      result.brokerContract?.exchange,
+      result.brokerContract?.primaryExchange,
+    ].some((exchange) => canonicalExchange(exchange) === canonicalPreferredExchange);
+  return getProviderHintRichness(result) + (matchesPreferredExchange ? 10_000 : 0);
+}
+
 function assignTickerSearchCategories<T extends TickerSearchCandidate>(items: T[]): T[] {
-  const hasSavedListing = items.some((item) =>
-    item.saved && item.instrumentClass !== "fund" && item.instrumentClass !== "derivative"
-  );
-  let assignedPrimaryListing = hasSavedListing;
+  let assignedPrimaryListing = false;
 
   return items.map((item) => {
     if (item.saved || item.kind === "ticker") {
+      if (item.instrumentClass !== "fund" && item.instrumentClass !== "derivative") {
+        assignedPrimaryListing = true;
+      }
       return { ...item, category: "Saved" };
     }
     if (item.instrumentClass === "fund" || item.instrumentClass === "derivative") {

--- a/src/tickers/search/ranking.ts
+++ b/src/tickers/search/ranking.ts
@@ -6,6 +6,23 @@ import type {
 const FUND_TYPES = new Set(["ETF", "ETN", "ETP", "FUND", "MUTUALFUND", "CEF", "CLOSEDEND"]);
 const DERIVATIVE_TYPES = new Set(["OPT", "OPTION", "OPTIONS", "FUT", "FUTURE", "FUTURES", "WARRANT", "WARRANTS", "RIGHT", "RIGHTS"]);
 const EQUITY_TYPES = new Set(["STK", "STOCK", "EQUITY", "COMMONSTOCK", "COMMON STOCK", "ADR", "ORDINARYSHARES", "ORDINARY SHARES"]);
+const COMPANY_NAME_SUFFIXES = new Set([
+  "AG",
+  "CO",
+  "COMPANY",
+  "CORP",
+  "CORPORATION",
+  "INC",
+  "INCORPORATED",
+  "LTD",
+  "LIMITED",
+  "NV",
+  "PLC",
+  "R",
+  "REGISTERED",
+  "SA",
+  "SE",
+]);
 
 const EXCHANGE_HINT_ALIASES: Record<string, string[]> = {
   NASDAQ: ["NASDAQ", "NMS"],
@@ -46,10 +63,13 @@ const ASSET_HINT_MAP: Record<string, TickerSearchInstrumentClass> = {
   FUTURES: "derivative",
 };
 
+const SAVED_MATCH_BONUS = 900;
+
 interface SearchQueryIntent {
   normalizedQuery: string;
   compactQuery: string;
   companyQuery: string;
+  companyQueryKey: string;
   exchangeHints: string[];
   assetPreference: TickerSearchInstrumentClass | null;
 }
@@ -82,6 +102,7 @@ export function rankTickerSearchItems<T extends Pick<TickerSearchRankableItem, "
       const normalizedLabel = normalizeSearchText(item.label);
       const normalizedDetail = normalizeSearchText(item.detail);
       const normalizedRight = normalizeSearchText(item.right || "");
+      const companyNameKey = getCompanyNameKey(item.detail);
       const textQueries = [intent.normalizedQuery, intent.companyQuery].filter(Boolean);
       const labelScore = maxScoreForQueries(textQueries, normalizedLabel, {
         exact: 24_000,
@@ -107,16 +128,23 @@ export function rankTickerSearchItems<T extends Pick<TickerSearchRankableItem, "
         .reduce((best, alias) => Math.max(best, scoreSearchAlias(intent, alias)), 0);
       const textScore = labelScore + detailScore + aliasScore;
       const saved = isSavedSearchItem(item);
-      const priorityScore = scoreAssetPreference(intent, item.instrumentClass)
-        + scoreExchangePreference(intent, item)
-        + scoreListingPriority(item);
+      const explicitIntentScore = scoreAssetPreference(intent, item.instrumentClass)
+        + scoreExchangePreference(intent, item);
+      const priorityScore = explicitIntentScore + scoreListingPriority(item);
+      const companyMatchRank = scoreCompanyNameMatch(intent, companyNameKey);
       return {
         item,
         index,
+        companyMatchRank,
+        companyNameKey,
+        issuerGroupKey: companyMatchRank > 0 && item.instrumentClass === "equity"
+          ? companyNameKey
+          : null,
+        explicitIntentScore,
         normalizedSymbol: normalizeSearchText(item.symbol || item.label),
         symbolMatchRank: scoreSymbolMatchRank(intent, item),
         textScore,
-        score: textScore + priorityScore + (textScore > 0 && saved ? 900 : 0),
+        score: textScore + priorityScore + (textScore > 0 && saved ? SAVED_MATCH_BONUS : 0),
       };
     });
 
@@ -126,21 +154,83 @@ export function rankTickerSearchItems<T extends Pick<TickerSearchRankableItem, "
       .map(({ normalizedSymbol }) => normalizedSymbol),
   );
 
-  const filtered = ranked
-    .filter(({ item, normalizedSymbol, textScore }) => {
-      if (textScore <= 0) return false;
-      if (item.kind !== "search") return true;
-      return !matchedLocalSymbols.has(normalizedSymbol);
-    })
-    .sort((a, b) => {
-      if (b.symbolMatchRank !== a.symbolMatchRank) return b.symbolMatchRank - a.symbolMatchRank;
-      if (b.score !== a.score) return b.score - a.score;
-      const aSaved = isSavedSearchItem(a.item);
-      const bSaved = isSavedSearchItem(b.item);
-      if (aSaved !== bSaved) return aSaved ? -1 : 1;
-      if (a.item.label.length !== b.item.label.length) return a.item.label.length - b.item.label.length;
-      return a.index - b.index;
+  const filtered = ranked.filter(({ item, normalizedSymbol, textScore }) => {
+    if (textScore <= 0) return false;
+    if (item.kind !== "search") return true;
+    return !matchedLocalSymbols.has(normalizedSymbol);
+  });
+
+  type RankedEntry = (typeof ranked)[number];
+  const compareFallbackEntries = (a: RankedEntry, b: RankedEntry): number => {
+    if (b.symbolMatchRank !== a.symbolMatchRank) return b.symbolMatchRank - a.symbolMatchRank;
+    if (b.score !== a.score) return b.score - a.score;
+    const aSaved = isSavedSearchItem(a.item);
+    const bSaved = isSavedSearchItem(b.item);
+    if (aSaved !== bSaved) return aSaved ? -1 : 1;
+    if (a.item.label.length !== b.item.label.length) return a.item.label.length - b.item.label.length;
+    return a.index - b.index;
+  };
+
+  const hasExplicitHint = intent.exchangeHints.length > 0 || intent.assetPreference != null;
+  const bucketGroups = new Map<string, Map<string, RankedEntry[]>>();
+  for (const entry of filtered) {
+    const exactSymbolRank = entry.symbolMatchRank >= 2 ? entry.symbolMatchRank : 0;
+    const bucketKey = [
+      exactSymbolRank,
+      hasExplicitHint ? entry.explicitIntentScore : 0,
+      entry.companyMatchRank,
+    ].join(":");
+    const groupKey = entry.issuerGroupKey
+      ? `issuer:${entry.issuerGroupKey}`
+      : `item:${entry.index}`;
+    const groups = bucketGroups.get(bucketKey) ?? new Map<string, RankedEntry[]>();
+    const group = groups.get(groupKey) ?? [];
+    group.push(entry);
+    groups.set(groupKey, group);
+    bucketGroups.set(bucketKey, groups);
+  }
+
+  const groupOrderByIndex = new Map<number, number>();
+  for (const groups of bucketGroups.values()) {
+    const orderedGroups = [...groups.values()]
+      .map((entries) => ({
+        entries,
+        representative: entries.reduce((best, entry) =>
+          compareFallbackEntries(entry, best) < 0 ? entry : best
+        ),
+      }))
+      .sort((a, b) => compareFallbackEntries(a.representative, b.representative));
+    orderedGroups.forEach(({ entries }, order) => {
+      entries.forEach((entry) => groupOrderByIndex.set(entry.index, order));
     });
+  }
+
+  filtered.sort((a, b) => {
+    // Precedence is exact symbol, explicit query hints, whole-word company
+    // relevance, issuer relevance, provider order within that issuer, partial
+    // symbol, saved relevance, then stable source order.
+    const aExactSymbolRank = a.symbolMatchRank >= 2 ? a.symbolMatchRank : 0;
+    const bExactSymbolRank = b.symbolMatchRank >= 2 ? b.symbolMatchRank : 0;
+    if (bExactSymbolRank !== aExactSymbolRank) return bExactSymbolRank - aExactSymbolRank;
+    if (hasExplicitHint && b.explicitIntentScore !== a.explicitIntentScore) {
+      return b.explicitIntentScore - a.explicitIntentScore;
+    }
+    if (b.companyMatchRank !== a.companyMatchRank) {
+      return b.companyMatchRank - a.companyMatchRank;
+    }
+    const aGroupOrder = groupOrderByIndex.get(a.index) ?? a.index;
+    const bGroupOrder = groupOrderByIndex.get(b.index) ?? b.index;
+    if (aGroupOrder !== bGroupOrder) return aGroupOrder - bGroupOrder;
+    if (
+      a.issuerGroupKey
+      && a.issuerGroupKey === b.issuerGroupKey
+    ) {
+      const aProviderRank = a.item.providerRank ?? Number.POSITIVE_INFINITY;
+      const bProviderRank = b.item.providerRank ?? Number.POSITIVE_INFINITY;
+      if (aProviderRank !== bProviderRank) return aProviderRank - bProviderRank;
+    }
+    return compareFallbackEntries(a, b);
+  });
 
   const deduped: T[] = [];
   const seen = new Set<string>();
@@ -216,6 +306,7 @@ function analyzeSearchQuery(query: string): SearchQueryIntent {
     normalizedQuery,
     compactQuery,
     companyQuery,
+    companyQueryKey: normalizeCompanyName(companyQuery),
     exchangeHints,
     assetPreference,
   };
@@ -354,6 +445,40 @@ function scoreListingPriority(item: Pick<TickerSearchRankableItem, "label"> & Pa
   if (item.label.includes(".")) score -= 140;
   if (item.label.length <= 5) score += 120;
   return score;
+}
+
+function getCompanyNameKey(detail: string): string {
+  return normalizeCompanyName(detail.split("|")[0] || "");
+}
+
+function normalizeCompanyName(name: string): string {
+  const tokens = normalizeSearchText(name).split(" ").filter(Boolean);
+  while (tokens.length > 1) {
+    if (COMPANY_NAME_SUFFIXES.has(tokens.at(-1)!)) {
+      tokens.pop();
+      continue;
+    }
+
+    const punctuatedSuffix = [...COMPANY_NAME_SUFFIXES].find((suffix) =>
+      suffix.length > 1
+      && tokens.length > suffix.length
+      && tokens.slice(-suffix.length).every((token, index) =>
+        token.length === 1 && token === suffix[index]
+      )
+    );
+    if (!punctuatedSuffix) break;
+    tokens.splice(-punctuatedSuffix.length);
+  }
+  return tokens.join(" ");
+}
+
+function scoreCompanyNameMatch(intent: SearchQueryIntent, companyName: string): number {
+  const query = intent.companyQueryKey;
+  if (!query || !companyName) return 0;
+  if (companyName === query) return 3;
+  if (companyName.startsWith(`${query} `)) return 2;
+  if (companyName.includes(` ${query} `) || companyName.endsWith(` ${query}`)) return 1;
+  return 0;
 }
 
 function isSavedSearchItem(item: Pick<TickerSearchRankableItem, "kind" | "category"> & Partial<TickerSearchRankableItem>): boolean {

--- a/src/tickers/search/types.ts
+++ b/src/tickers/search/types.ts
@@ -16,6 +16,7 @@ export interface TickerSearchRankableItem {
   instrumentClass?: TickerSearchInstrumentClass;
   exchangeLabel?: string;
   primaryExchangeLabel?: string;
+  providerRank?: number;
   searchAliases?: string[];
 }
 


### PR DESCRIPTION
## Summary

- preserve provider result ordering during saved ticker candidate enrichment
- rank exact symbols and explicit exchange or asset hints before normalized company and issuer matches
- apply provider order only within the same normalized issuer group
- keep completed and cached results authoritative over provisional local rows
- keep saved-listing exchange metadata authoritative when provider duplicates disagree

## Root cause

Provider ordering was discarded while enriching saved candidates, leaving equivalent company-name matches tied on local insertion order. The command bar could then merge provisional local rows ahead of completed results and restore the incorrect order. Duplicate provider metadata could also attach the wrong exchange to a saved listing.

## Impact

Company-name searches now prefer the provider's canonical listing signal without hardcoded issuer, symbol, or exchange rules. Exact symbols, explicit exchange hints, asset-class hints, saved instruments, funds, and alternate listings retain their intended behavior.

## Validation

- `bun test`: 1,868 passed, 0 failed
- `bun run typecheck:opentui`
- focused ticker-ranking and command-bar regression suites
- tmux OpenTUI verification for `Apple` and `Apple XETRA`
