### PR TITLE
Play terminal TV inside the pane

### DIFF
--- a/src/components/chart/native/kitty/manager.ts
+++ b/src/components/chart/native/kitty/manager.ts
@@ -127,6 +127,10 @@ export class KittyImageManager {
       this.renderer,
       `${encodeKittyDeleteImage(this.imageIds[0])}${encodeKittyDeleteImage(this.imageIds[1])}`,
     );
+    this.forgetPlacedImages();
+  }
+
+  forgetPlacedImages() {
     this.activeSlot = null;
     this.lastBitmapKey = null;
     this.lastPlacementKeys = [];

--- a/src/components/chart/native/surface/manager.ts
+++ b/src/components/chart/native/surface/manager.ts
@@ -210,6 +210,13 @@ export class NativeSurfaceManager {
     this.localOccluders.clear();
   }
 
+  retransmitAll() {
+    for (const entry of this.surfaces.values()) {
+      entry.imageManager.forgetPlacedImages();
+      this.syncSurface(entry);
+    }
+  }
+
   private syncAll() {
     for (const entry of this.surfaces.values()) {
       this.syncSurface(entry);

--- a/src/plugins/builtin/tv/pane.tsx
+++ b/src/plugins/builtin/tv/pane.tsx
@@ -11,7 +11,7 @@ import {
 import { scheduleConfigSave } from "../../../state/config-save-scheduler";
 import { colors } from "../../../theme/colors";
 import type { PaneProps } from "../../../types/plugin";
-import { Box, ImageSurface, MediaSurface, Text, useRendererHost, useUiHost, type MediaSurfaceHandle } from "../../../ui";
+import { Box, MediaSurface, Text, useRendererHost, type MediaSurfaceHandle } from "../../../ui";
 import { getTvChannel, TV_CHANNELS, type TvChannelId } from "./channels";
 import type { ResolvedLiveStream } from "../../../types/media";
 import { resolveTvStream } from "./youtube-stream";
@@ -19,7 +19,6 @@ import { resolveTvStream } from "./youtube-stream";
 type PlaybackState = "idle" | "loading" | "playing" | "paused" | "error";
 
 export function TvPane({ paneId, focused, width, height }: PaneProps) {
-  const isDesktop = useUiHost().kind === "desktop-web";
   const renderer = useRendererHost();
   const dispatch = useAppDispatch();
   const stateRef = useAppStateRef();
@@ -35,7 +34,6 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
   const [playbackState, setPlaybackState] = useState<PlaybackState>("idle");
   const [muted, setMuted] = useState(true);
   const mediaRef = useRef<MediaSurfaceHandle | null>(null);
-  const terminalAutoPlayedRef = useRef<string | null>(null);
   const generationRef = useRef(0);
   const channel = getTvChannel(channelId);
 
@@ -105,49 +103,20 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
     }
   }, []);
 
-  const playInTerminal = useCallback(async () => {
-    if (!stream || !renderer.playTerminalMedia) return;
-    setPlaybackError(null);
-    setPlaybackState("playing");
-    try {
-      await renderer.playTerminalMedia(stream.manifestUrl, stream.title, { muted });
-      setPlaybackState("paused");
-    } catch (cause) {
-      setPlaybackState("error");
-      setPlaybackError(cause instanceof Error ? cause.message : String(cause));
-    }
-  }, [muted, renderer, stream]);
-
-  useEffect(() => {
-    if (isDesktop || loading || !stream || stream.sourceId !== channel.id) return;
-    const streamKey = `${stream.sourceId}:${stream.videoId}`;
-    if (terminalAutoPlayedRef.current === streamKey) return;
-    terminalAutoPlayedRef.current = streamKey;
-    void playInTerminal();
-  }, [channel.id, isDesktop, loading, playInTerminal, stream]);
-
   const togglePlayback = useCallback(async () => {
     setPlaybackError(null);
     try {
-      if (isDesktop) {
-        await mediaRef.current?.toggle();
-      } else {
-        await playInTerminal();
-      }
+      await mediaRef.current?.toggle();
     } catch (cause) {
       setPlaybackState("error");
       setPlaybackError(cause instanceof Error ? cause.message : String(cause));
     }
-  }, [isDesktop, playInTerminal]);
+  }, []);
 
   const toggleMute = useCallback(() => {
-    if (isDesktop) {
-      const nextMuted = mediaRef.current?.toggleMuted();
-      if (typeof nextMuted === "boolean") setMuted(nextMuted);
-      return;
-    }
-    setMuted((current) => !current);
-  }, [isDesktop]);
+    const nextMuted = mediaRef.current?.toggleMuted();
+    if (typeof nextMuted === "boolean") setMuted(nextMuted);
+  }, []);
 
   useShortcut((event) => {
     if (!focused) return;
@@ -175,15 +144,17 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
 
   const status = loading
     ? `resolving ${channel.name}`
-    : error || playbackError
+    : error
       ? "stream error"
-      : playbackState === "playing"
-        ? "playing live"
-        : playbackState === "loading"
-          ? "buffering live"
-          : stream
-            ? "live"
-            : "offline";
+      : playbackError
+        ? /required|install|not found/i.test(playbackError) ? "player missing" : "playback error"
+        : playbackState === "playing"
+          ? "playing live"
+          : playbackState === "loading"
+            ? "buffering live"
+            : stream
+              ? "live"
+              : "offline";
 
   usePaneFooter(paneId, () => ({
     info: [{
@@ -240,7 +211,7 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
           <Text fg={colors.warning}>{error ?? `${channel.name} is offline.`}</Text>
           <Button label="Try again" variant="primary" onPress={refresh} />
         </Box>
-      ) : isDesktop ? (
+      ) : (
         <MediaSurface
           src={stream.manifestUrl}
           title={stream.title}
@@ -255,31 +226,9 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
           onError={setPlaybackError}
         >
           <Box flexGrow={1} justifyContent="center" alignItems="center">
-            <Text fg={colors.warning}>{playbackError ?? "Live video unavailable."}</Text>
+            <Text fg={colors.warning}>{playbackError ?? stream.title}</Text>
           </Box>
         </MediaSurface>
-      ) : (
-        <Box flexGrow={1} flexDirection="column" alignItems="center" justifyContent="center" gap={1}>
-          <ImageSurface
-            src={stream.posterUrl}
-            alt={stream.title}
-            objectFit="contain"
-            width="100%"
-            height={Math.max(5, mediaHeight - 2)}
-          >
-            <Box flexGrow={1} justifyContent="center" alignItems="center">
-              <Text fg={colors.text}>{stream.title}</Text>
-            </Box>
-          </ImageSurface>
-          <Button
-            label="Play in Kitty"
-            shortcut="p"
-            variant="primary"
-            disabled={!renderer.playTerminalMedia}
-            onPress={() => void togglePlayback()}
-          />
-          {playbackError ? <Text fg={colors.warning}>{playbackError}</Text> : null}
-        </Box>
       )}
     </Box>
   );

--- a/src/renderers/opentui/host.tsx
+++ b/src/renderers/opentui/host.tsx
@@ -55,6 +55,11 @@ export function toKeyEventLike(event: {
   };
 }
 
+function clearKittyGraphics(): void {
+  if (!process.stdout.isTTY) return;
+  process.stdout.write("\x1b_Ga=d,d=A\x1b\\");
+}
+
 function samePixelResolution(left: PixelResolution | null, right: PixelResolution | null): boolean {
   if (left === right) return true;
   if (!left || !right) return false;
@@ -81,6 +86,7 @@ function installResolutionEventBridge(renderer: CliRenderer): void {
 
 export async function createOpenTuiHost(): Promise<OpenTuiHost> {
   resetTerminalInputState();
+  clearKittyGraphics();
 
   // Mouse motion is reported per pixel; our @opentui/core patch coalesces moves
   // to one per fastest frame (~16ms) so pointer-tracked UI like the chart
@@ -130,45 +136,6 @@ export async function createOpenTuiHost(): Promise<OpenTuiHost> {
     },
     notify() {
       // The app-level notifier still owns toast/desktop notification behavior.
-    },
-    async playTerminalMedia(url, title, options) {
-      const mpv = Bun.which("mpv");
-      if (!mpv) {
-        throw new Error("mpv is required for terminal TV playback. Install mpv and try again.");
-      }
-
-      renderer.suspend();
-      try {
-        const proc = Bun.spawn([
-          mpv,
-          "--no-config",
-          "--profile=sw-fast",
-          "--vo=kitty",
-          "--vo-kitty-auto-multiplexer-passthrough=yes",
-          "--demuxer-lavf-probe-info=yes",
-          "--demuxer-lavf-analyzeduration=10",
-          "--demuxer-lavf-probesize=25000000",
-          "--ytdl=no",
-          `--mute=${options?.muted === false ? "no" : "yes"}`,
-          ...(title ? [`--title=${title}`] : []),
-          "--",
-          url,
-        ], {
-          stdin: "inherit",
-          stdout: "inherit",
-          stderr: "pipe",
-        });
-        const stderrPromise = new Response(proc.stderr).text();
-        const exitCode = await proc.exited;
-        const stderr = await stderrPromise;
-        if (exitCode !== 0) {
-          const detail = stderr.trim().split("\n").slice(-3).join(" ");
-          throw new Error(detail || `mpv exited with status ${exitCode}`);
-        }
-      } finally {
-        renderer.resume();
-        renderer.requestRender();
-      }
     },
   };
 

--- a/src/renderers/opentui/media-decoder.ts
+++ b/src/renderers/opentui/media-decoder.ts
@@ -1,0 +1,161 @@
+import { writeRendererRaw } from "../../components/chart/native/kitty/adapter";
+import { getNativeSurfaceManager } from "../../components/chart/native/surface/manager";
+import type { NativeRendererHost } from "../../ui";
+
+const ESC = 0x1b;
+const ST_SLASH = 0x5c;
+
+export interface TerminalMpvPlaybackOptions {
+  url: string;
+  cols: number;
+  rows: number;
+  left: number;
+  top: number;
+  pixelWidth: number;
+  pixelHeight: number;
+  muted?: boolean;
+  renderer: NativeRendererHost;
+  onPlaying?: () => void;
+  onError?: (message: string) => void;
+}
+
+function findCsiEnd(buffer: Uint8Array, start: number): number {
+  for (let index = start; index < buffer.length; index += 1) {
+    const byte = buffer[index]!;
+    if (byte >= 0x40 && byte <= 0x7e) return index;
+  }
+  return -1;
+}
+
+function findKittyEnd(buffer: Uint8Array, start: number): number {
+  for (let index = start; index + 1 < buffer.length; index += 1) {
+    if (buffer[index] === ESC && buffer[index + 1] === ST_SLASH) return index + 2;
+  }
+  return -1;
+}
+
+export function startTerminalMpvPlayback(options: TerminalMpvPlaybackOptions): () => void {
+  const mpv = Bun.which("mpv");
+  if (!mpv) {
+    options.onError?.("mpv is required for terminal TV playback. Install mpv and try again.");
+    return () => {};
+  }
+
+  const cols = Math.max(1, options.cols);
+  const rows = Math.max(1, options.rows);
+  const left = Math.max(1, options.left);
+  const top = Math.max(1, options.top);
+  const pixelWidth = Math.max(1, options.pixelWidth);
+  const pixelHeight = Math.max(1, options.pixelHeight);
+
+  const proc = Bun.spawn([
+    mpv,
+    "--no-config",
+    "--profile=sw-fast",
+    "--vo=kitty",
+    "--vo-kitty-alt-screen=no",
+    "--vo-kitty-config-clear=no",
+    "--vo-kitty-auto-multiplexer-passthrough=no",
+    "--vo-kitty-use-shm=no",
+    "--really-quiet",
+    "--osd-level=0",
+    "--no-osc",
+    "--no-terminal",
+    "--input-terminal=no",
+    "--input-vo-keyboard=no",
+    "--keepaspect=no",
+    `--vo-kitty-cols=${cols}`,
+    `--vo-kitty-rows=${rows}`,
+    `--vo-kitty-left=${left}`,
+    `--vo-kitty-top=${top}`,
+    `--vo-kitty-width=${pixelWidth}`,
+    `--vo-kitty-height=${pixelHeight}`,
+    "--cache=yes",
+    "--demuxer-max-bytes=67108864",
+    "--demuxer-readahead-secs=5",
+    "--ytdl=no",
+    `--mute=${options.muted === false ? "no" : "yes"}`,
+    "--",
+    options.url,
+  ], {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      TERM: "xterm-kitty",
+    },
+  });
+
+  let stopped = false;
+  let pending = Buffer.alloc(0);
+  let lastCup: Uint8Array | null = null;
+  let sequences = 0;
+  const saveRestorePrefix = Buffer.from("\x1b[s");
+  const saveRestoreSuffix = Buffer.from("\x1b[u");
+
+  const abort = () => {
+    if (stopped) return;
+    stopped = true;
+    proc.kill();
+  };
+
+  const forwardKitty = (kitty: Uint8Array) => {
+    sequences += 1;
+    const parts = lastCup
+      ? [saveRestorePrefix, lastCup, kitty, saveRestoreSuffix]
+      : [saveRestorePrefix, kitty, saveRestoreSuffix];
+    writeRendererRaw(options.renderer, Buffer.concat(parts));
+    if (sequences === 1) options.onPlaying?.();
+  };
+
+  void (async () => {
+    try {
+      for await (const chunk of proc.stdout) {
+        if (stopped) break;
+        pending = Buffer.concat([pending, chunk]);
+        let offset = 0;
+        while (offset < pending.length) {
+          if (pending[offset] !== ESC) {
+            offset += 1;
+            continue;
+          }
+          if (offset + 1 >= pending.length) break;
+          const next = pending[offset + 1]!;
+          if (next === 0x5b) {
+            const end = findCsiEnd(pending, offset + 2);
+            if (end < 0) break;
+            const finalByte = pending[end]!;
+            if (finalByte === 0x48 || finalByte === 0x66) {
+              lastCup = Uint8Array.from(pending.subarray(offset, end + 1));
+            }
+            offset = end + 1;
+            continue;
+          }
+          if (next === 0x5f && offset + 2 < pending.length && pending[offset + 2] === 0x47) {
+            const end = findKittyEnd(pending, offset + 3);
+            if (end < 0) break;
+            forwardKitty(pending.subarray(offset, end));
+            offset = end;
+            continue;
+          }
+          offset += 1;
+        }
+        pending = pending.subarray(offset);
+      }
+      const stderr = await new Response(proc.stderr).text();
+      const exitCode = await proc.exited;
+      if (!stopped && (exitCode !== 0 || sequences === 0)) {
+        options.onError?.(stderr.trim().split("\n").slice(-3).join(" ") || `mpv exited with status ${exitCode}`);
+      }
+    } catch (cause) {
+      if (!stopped) options.onError?.(cause instanceof Error ? cause.message : String(cause));
+    }
+  })();
+
+  return () => {
+    abort();
+    writeRendererRaw(options.renderer, "\x1b_Ga=d,d=A\x1b\\");
+    getNativeSurfaceManager(options.renderer).retransmitAll();
+  };
+}

--- a/src/renderers/opentui/media-surface.tsx
+++ b/src/renderers/opentui/media-surface.tsx
@@ -1,0 +1,283 @@
+import { createElement, forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState, type ForwardedRef, type ReactNode } from "react";
+import {
+  computeBitmapSize,
+  intersectCellRects,
+  type CellRect,
+  type NativeChartBitmap,
+} from "../../components/chart/native/chart-rasterizer";
+import { getCachedKittySupport, ensureKittySupport } from "../../components/chart/native/kitty/support";
+import { getNativeSurfaceManager } from "../../components/chart/native/surface/manager";
+import {
+  getRenderableCellRect,
+  resolveNativeSurfaceVisibleRect,
+  type NativeSurfaceRenderableNode,
+} from "../../components/chart/native/surface/visibility";
+import { useOptionalPaneInstanceId } from "../../state/app/context";
+import { useNativeRenderer, type BoxRenderable, type MediaSurfaceHandle, type MediaSurfaceProps } from "../../ui";
+import { loadOpenTuiImageBitmap } from "./image/loader";
+import { startTerminalMpvPlayback } from "./media-decoder";
+
+interface NativeRenderableNode extends BoxRenderable, NativeSurfaceRenderableNode {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  parent: NativeRenderableNode | null;
+  onLifecyclePass: (() => void) | null;
+}
+
+interface SurfaceTarget {
+  rect: CellRect;
+  visibleRect: CellRect | null;
+  pixelWidth: number;
+  pixelHeight: number;
+  sizeKey: string;
+}
+
+let nextMediaSurfaceId = 1;
+
+function assignRef(ref: ForwardedRef<unknown>, value: unknown) {
+  if (typeof ref === "function") {
+    ref(value);
+    return;
+  }
+  if (ref) {
+    (ref as { current: unknown }).current = value;
+  }
+}
+
+function sameRect(left: CellRect | null, right: CellRect | null): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return left.x === right.x
+    && left.y === right.y
+    && left.width === right.width
+    && left.height === right.height;
+}
+
+function sameTarget(left: SurfaceTarget | null, right: SurfaceTarget | null): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return left.sizeKey === right.sizeKey
+    && left.pixelWidth === right.pixelWidth
+    && left.pixelHeight === right.pixelHeight
+    && sameRect(left.rect, right.rect)
+    && sameRect(left.visibleRect, right.visibleRect);
+}
+
+export const OpenTuiMediaSurface = forwardRef<unknown, MediaSurfaceProps>(function OpenTuiMediaSurface(
+  rawProps,
+  forwardedRef,
+) {
+  const {
+    children,
+    src,
+    title: _title,
+    poster,
+    autoPlay = false,
+    muted: mutedProp = true,
+    mediaHandleRef,
+    onPlaybackStateChange,
+    onMutedChange,
+    onError,
+    ...props
+  } = rawProps as MediaSurfaceProps & {
+    children?: ReactNode;
+    src?: string;
+    poster?: string;
+    autoPlay?: boolean;
+    muted?: boolean;
+    mediaHandleRef?: MediaSurfaceProps["mediaHandleRef"];
+    onPlaybackStateChange?: MediaSurfaceProps["onPlaybackStateChange"];
+    onMutedChange?: MediaSurfaceProps["onMutedChange"];
+    onError?: MediaSurfaceProps["onError"];
+  };
+  const renderer = useNativeRenderer();
+  const paneId = useOptionalPaneInstanceId();
+  const nativeSurfaceManager = useMemo(() => getNativeSurfaceManager(renderer), [renderer]);
+  const surfaceId = useRef(`opentui-media:${nextMediaSurfaceId++}`).current;
+  const renderableRef = useRef<NativeRenderableNode | null>(null);
+  const [kittySupport, setKittySupport] = useState<boolean | null>(() => getCachedKittySupport(renderer));
+  const [target, setTarget] = useState<SurfaceTarget | null>(null);
+  const [bitmapState, setBitmapState] = useState<{ key: string; bitmap: NativeChartBitmap } | null>(null);
+  const [hasLiveFrame, setHasLiveFrame] = useState(false);
+  const [active, setActive] = useState(autoPlay);
+  const [muted, setMuted] = useState(mutedProp);
+  const mediaSrc = typeof src === "string" ? src.trim() : "";
+  const posterSrc = typeof poster === "string" ? poster.trim() : "";
+
+  const setRenderableRef = useCallback((node: unknown) => {
+    renderableRef.current = node as NativeRenderableNode | null;
+    assignRef(forwardedRef, node);
+  }, [forwardedRef]);
+
+  useImperativeHandle(mediaHandleRef, (): MediaSurfaceHandle => ({
+    async play() {
+      setActive(true);
+    },
+    pause() {
+      setActive(false);
+      onPlaybackStateChange?.("paused");
+    },
+    async toggle() {
+      setActive((current) => !current);
+    },
+    toggleMuted() {
+      const next = !muted;
+      setMuted(next);
+      onMutedChange?.(next);
+      return next;
+    },
+  }), [muted, onMutedChange, onPlaybackStateChange]);
+
+  useEffect(() => {
+    onMutedChange?.(muted);
+  }, [muted, onMutedChange]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setKittySupport(getCachedKittySupport(renderer));
+    ensureKittySupport(renderer).then((supported) => {
+      if (!cancelled) setKittySupport(supported);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [renderer]);
+
+  useEffect(() => {
+    const renderable = renderableRef.current;
+    if (!renderable || kittySupport !== true) {
+      setTarget(null);
+      return;
+    }
+
+    let mountTimer: Timer | null = null;
+    const previousLifecyclePass = renderable.onLifecyclePass;
+    const syncTarget = () => {
+      const rect = getRenderableCellRect(renderable);
+      if (!rect.width || !rect.height || !renderer.resolution || renderer.terminalWidth <= 0 || renderer.terminalHeight <= 0) {
+        setTarget((current) => (current === null ? current : null));
+        return;
+      }
+
+      const visibleRect = resolveNativeSurfaceVisibleRect(renderable, renderer.terminalWidth, renderer.terminalHeight);
+      const clipped = visibleRect ? intersectCellRects(rect, visibleRect) : null;
+      const bitmapSize = computeBitmapSize(rect, renderer.resolution, renderer.terminalWidth, renderer.terminalHeight);
+      const nextTarget: SurfaceTarget = {
+        rect,
+        visibleRect: clipped,
+        pixelWidth: bitmapSize.pixelWidth,
+        pixelHeight: bitmapSize.pixelHeight,
+        sizeKey: `${bitmapSize.pixelWidth}x${bitmapSize.pixelHeight}`,
+      };
+      setTarget((current) => (sameTarget(current, nextTarget) ? current : nextTarget));
+    };
+    const lifecyclePass = () => {
+      previousLifecyclePass?.();
+      syncTarget();
+    };
+
+    renderable.onLifecyclePass = lifecyclePass;
+    renderer.registerLifecyclePass(renderable);
+    syncTarget();
+    mountTimer = setTimeout(() => {
+      syncTarget();
+      renderer.requestRender();
+    }, 0);
+
+    return () => {
+      if (mountTimer) clearTimeout(mountTimer);
+      if (renderable.onLifecyclePass === lifecyclePass) {
+        renderable.onLifecyclePass = previousLifecyclePass;
+      }
+      renderer.unregisterLifecyclePass(renderable);
+      setTarget(null);
+    };
+  }, [kittySupport, renderer]);
+
+  useEffect(() => {
+    if (!target || !posterSrc || kittySupport !== true || active) return;
+
+    let cancelled = false;
+    loadOpenTuiImageBitmap(posterSrc, {
+      width: target.pixelWidth,
+      height: target.pixelHeight,
+      objectFit: "contain",
+    }).then((bitmap) => {
+      if (!cancelled) setBitmapState({ key: `poster:${posterSrc}:${target.sizeKey}`, bitmap });
+    }).catch(() => {
+      if (!cancelled) setBitmapState(null);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [active, kittySupport, posterSrc, target]);
+
+  useEffect(() => {
+    if (!active || !mediaSrc || !target || kittySupport !== true) {
+      if (!active) onPlaybackStateChange?.("paused");
+      return;
+    }
+
+    let cancelled = false;
+    onPlaybackStateChange?.("loading");
+    nativeSurfaceManager.removeSurface(surfaceId);
+    const stop = startTerminalMpvPlayback({
+      url: mediaSrc,
+      cols: target.rect.width,
+      rows: target.rect.height,
+      left: target.rect.x + 1,
+      top: target.rect.y + 1,
+      pixelWidth: target.pixelWidth,
+      pixelHeight: target.pixelHeight,
+      muted,
+      renderer,
+      onPlaying: () => {
+        if (cancelled) return;
+        setHasLiveFrame(true);
+        onPlaybackStateChange?.("playing");
+      },
+      onError: (message) => {
+        if (cancelled) return;
+        setActive(false);
+        onPlaybackStateChange?.("error");
+        onError?.(message);
+      },
+    });
+
+    return () => {
+      cancelled = true;
+      stop();
+    };
+  }, [active, kittySupport, mediaSrc, muted, nativeSurfaceManager, onError, onPlaybackStateChange, renderer, surfaceId, target]);
+
+  useEffect(() => {
+    return () => {
+      nativeSurfaceManager.removeSurface(surfaceId);
+    };
+  }, [nativeSurfaceManager, surfaceId]);
+
+  useEffect(() => {
+    if (active) return;
+    if (kittySupport !== true || !target?.visibleRect || !bitmapState) {
+      nativeSurfaceManager.removeSurface(surfaceId);
+      return;
+    }
+
+    nativeSurfaceManager.upsertSurface({
+      id: surfaceId,
+      paneId: paneId ?? "__global__",
+      rect: target.rect,
+      visibleRect: target.visibleRect,
+      bitmap: bitmapState.bitmap,
+      bitmapKey: bitmapState.key,
+    });
+    renderer.requestRender();
+  }, [active, bitmapState, kittySupport, nativeSurfaceManager, paneId, renderer, surfaceId, target]);
+
+  const showFallback = kittySupport !== true || (!hasLiveFrame && !bitmapState);
+
+  return (createElement as any)("box", { ...props, ref: setRenderableRef }, showFallback ? children : null);
+});

--- a/src/renderers/opentui/ui-host.tsx
+++ b/src/renderers/opentui/ui-host.tsx
@@ -4,6 +4,7 @@ import { TextAttributes, type UiHost, type TextProps } from "../../ui/host";
 import { renderAsciiText } from "../../ui/ascii-font";
 import { OpenTuiImageSurface } from "./image/surface";
 import { OpenTuiChartSurface } from "./chart-surface";
+import { OpenTuiMediaSurface } from "./media-surface";
 
 interface OpenTuiPrimitiveProps {
   children?: ReactNode;
@@ -59,7 +60,6 @@ const OpenTuiBox = createOpenTuiPrimitive("box");
 const OpenTuiScrollBox = createOpenTuiPrimitive("scrollbox");
 const OpenTuiInput = createOpenTuiPrimitive("input");
 const OpenTuiTextarea = createOpenTuiPrimitive("textarea");
-const OpenTuiMediaSurface = createOpenTuiPrimitive("box");
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -120,7 +120,7 @@ export const openTuiUiHost: UiHost = {
   Textarea: OpenTuiTextarea as UiHost["Textarea"],
   ChartSurface: OpenTuiChartSurface,
   ImageSurface: OpenTuiImageSurface,
-  MediaSurface: OpenTuiMediaSurface as UiHost["MediaSurface"],
+  MediaSurface: OpenTuiMediaSurface,
   SpinnerMark: OpenTuiSpinnerMark as UiHost["SpinnerMark"],
   AsciiText: ({ text, font = "tiny", color, fg, bg, backgroundColor, selectable = false, ...props }) => {
     const resolvedColor = color ?? fg;

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -383,7 +383,6 @@ export interface RendererHost {
   supportsNativeDesktopNotifications?: boolean;
   notify(notification: AppNotificationRequest): void;
   showContextMenu?(items: ContextMenuItem[]): Promise<boolean>;
-  playTerminalMedia?(url: string, title?: string, options?: { muted?: boolean }): Promise<void>;
   resolveLiveStream?(request: LiveStreamResolveRequest): Promise<ResolvedLiveStream>;
 }
 


### PR DESCRIPTION
## Summary
- Forward mpv Kitty graphics through a pipe into the TV pane so live video plays in-app instead of taking over the TTY.
- Use the same `MediaSurface` path on terminal and desktop; restore chart Kitty images when playback stops.
- Surface a real missing-player error instead of a generic stream failure.

## Test plan
- [ ] `brew install mpv` (or confirm `which mpv` is on PATH)
- [ ] `bun run start` in Ghostty, open the TV pane, wait for a channel to resolve
- [ ] Confirm video plays **inside** the pane with the rest of the TUI still visible
- [ ] Toggle `[p]`lay / `[m]`ute / `[r]`efresh and switch Bloomberg / CNBC / Yahoo
- [ ] Confirm charts still render after stopping or leaving the TV pane
- [ ] Desktop: open TV and confirm hls.js playback is unchanged


Made with [Cursor](https://cursor.com)