### PR TITLE
Fix layout deletion and reordering

### DIFF
--- a/src/components/layout/pane/header.tsx
+++ b/src/components/layout/pane/header.tsx
@@ -2,6 +2,7 @@ import { Box, Span, Text, useNativeRenderer, useUiCapabilities } from "../../../
 import { useCallback, useRef, type ReactNode } from "react";
 import { blendHex, colors, floatingPaneTitleBg, paneTitleBg, paneTitleText } from "../../../theme/colors";
 import { displayWidth, truncateToDisplayWidth } from "../../../utils/format";
+import { capturePointerDrag } from "../../../ui/pointer-drag";
 
 const PANE_HEADER_HEIGHT = 1;
 const PANE_HEADER_GRIP = ":: ";
@@ -36,18 +37,6 @@ export interface PaneHeaderQuickSetting {
 
 function truncateTitle(title: string, maxWidth: number): string {
   return truncateToDisplayWidth(title, maxWidth);
-}
-
-function captureTerminalPointerDrag(renderer: unknown, renderable: unknown): void {
-  if (!renderable) return;
-  const hostCapture = (renderer as { captureMouseRenderable?: (target: unknown) => void }).captureMouseRenderable;
-  if (typeof hostCapture === "function") {
-    hostCapture.call(renderer, renderable);
-    return;
-  }
-  const capture = (renderer as { setCapturedRenderable?: (target: unknown) => void }).setCapturedRenderable;
-  if (typeof capture !== "function") return;
-  capture.call(renderer, renderable);
 }
 
 function DesktopPaneButton({
@@ -148,7 +137,7 @@ export function PaneHeader({
   const terminalQuickSettingsWidth = quickSettings.reduce((total) => total + displayWidth(" ⚡ "), 0);
   const textColor = paneTitleText(visuallyFocused, floating);
   const handleTerminalHeaderMouseDown = useCallback((event: any) => {
-    captureTerminalPointerDrag(nativeRenderer, terminalHeaderRef.current);
+    capturePointerDrag(nativeRenderer, terminalHeaderRef.current);
     onHeaderMouseDown?.(event);
   }, [nativeRenderer, onHeaderMouseDown]);
 

--- a/src/components/layout/status-bar.test.tsx
+++ b/src/components/layout/status-bar.test.tsx
@@ -5,7 +5,7 @@ import { cloneLayout, createDefaultConfig, TICKER_RESEARCH_PANE_ID, type LayoutC
 import type { AppNotificationRequest } from "../../types/plugin";
 import { StatusBar } from "./status-bar";
 import { setSharedRegistryForTests } from "../../plugins/registry";
-import { useEffect, useState } from "react";
+import { act, useEffect, useState } from "react";
 import { TransientLayoutProvider, useTransientLayout } from "./transient-layout";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
@@ -148,6 +148,41 @@ describe("StatusBar", () => {
     await testSetup.renderOnce();
 
     expect(exitCount).toBe(1);
+  });
+
+  test("reorders saved layout tabs by dragging them left and right", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-layout-tab-reorder-test");
+    config.layouts = [
+      { name: "Home", layout: cloneLayout(config.layout) },
+      { name: "Research", layout: cloneLayout(config.layout) },
+      { name: "News", layout: cloneLayout(config.layout) },
+    ];
+    const state = {
+      ...createInitialState(config),
+      statusBarVisible: true,
+    };
+    const actions: Array<{ type: string; fromIndex?: number; toIndex?: number }> = [];
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: (action) => actions.push(action as { type: string; fromIndex?: number; toIndex?: number }) }}>
+        <StatusBar />
+      </AppContext>,
+      { width: 120, height: 3 },
+    );
+
+    await testSetup.renderOnce();
+    const frame = testSetup.captureCharFrame();
+    const homeX = frame.split("\n")[0]?.indexOf("^1 Home") ?? -1;
+    const newsX = frame.split("\n")[0]?.indexOf("^3 News") ?? -1;
+    expect(homeX).toBeGreaterThanOrEqual(0);
+    expect(newsX).toBeGreaterThan(homeX);
+
+    await act(async () => {
+      await testSetup!.mockMouse.drag(homeX + 1, 0, newsX + 1, 0);
+      await testSetup!.renderOnce();
+    });
+
+    expect(actions).toContainEqual({ type: "REORDER_LAYOUT", fromIndex: 0, toIndex: 2 });
   });
 
   test("shows a gridlock tip after a corner snap and runs gridlock on click", async () => {

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -1,4 +1,5 @@
 import { Box, Span, Text, TextAttributes, contextMenuDivider, useContextMenu, useUiCapabilities } from "../../ui";
+import { useDialog, type PromptContext } from "../../ui/dialog";
 import { useCallback, useEffect, useState } from "react";
 import { blendHex, hoverBg } from "../../theme/colors";
 import { t, tf } from "../../i18n";
@@ -17,6 +18,7 @@ import { notifyGridlockComplete } from "../../plugins/gridlock-notification";
 import { PluginSlot } from "../../react/plugins/plugin-slot";
 import type { ContextMenuItem } from "../../types/context-menu";
 import { Tabs } from "../ui/tabs";
+import { ConfirmDialog } from "../ui/confirm-dialog";
 import { useTransientLayout } from "./transient-layout";
 
 const GRIDLOCK_TIP_DURATION_MS = 60_000;
@@ -28,6 +30,7 @@ type SetHoveredControl = (updater: (current: HoveredControl) => HoveredControl) 
 type LayoutTabItem = {
   label: string;
   value: string;
+  reorderable?: boolean;
   onContextMenu: (value: string, event: any) => void;
 };
 
@@ -36,6 +39,7 @@ type StatusBarViewProps = {
   activeLayoutValue: string;
   dismissGridlockTip: (event?: StatusBarEvent) => void;
   handleGridlockTip: (event?: StatusBarEvent) => void;
+  handleLayoutReorder: (fromValue: string, toValue: string) => void;
   handleLayoutSelect: (value: string) => void;
   hasMultipleLayouts: boolean;
   hoveredControl: HoveredControl;
@@ -57,6 +61,7 @@ function truncate(text: string, width: number): string {
 export function StatusBar() {
   const { nativePaneChrome, nativeContextMenu } = useUiCapabilities();
   const { showContextMenu } = useContextMenu();
+  const dialog = useDialog();
   const registry = getSharedRegistry();
   const dispatch = useAppDispatch();
   const layouts = useAppSelector(selectSavedLayouts);
@@ -72,6 +77,7 @@ export function StatusBar() {
   const savedLayoutTabs = layouts.map((layout, index) => ({
     label: `^${index + 1} ${truncate(layout.name, 14)}`,
     value: String(index),
+    reorderable: true,
   }));
   const layoutTabs = transientLayout
     ? [
@@ -79,6 +85,7 @@ export function StatusBar() {
       {
         label: transientLayout.label,
         value: transientLayout.id,
+        reorderable: false,
       },
     ]
     : savedLayoutTabs;
@@ -99,6 +106,20 @@ export function StatusBar() {
       transientLayout.onDeactivate?.();
     }
     dispatch({ type: "SWITCH_LAYOUT", index });
+  };
+  const handleLayoutReorder = (fromValue: string, toValue: string) => {
+    const fromIndex = Number(fromValue);
+    const toIndex = Number(toValue);
+    if (
+      !Number.isInteger(fromIndex)
+      || !Number.isInteger(toIndex)
+      || fromIndex < 0
+      || toIndex < 0
+      || fromIndex >= layouts.length
+      || toIndex >= layouts.length
+      || fromIndex === toIndex
+    ) return;
+    dispatch({ type: "REORDER_LAYOUT", fromIndex, toIndex });
   };
 
   useEffect(() => {
@@ -136,6 +157,27 @@ export function StatusBar() {
     event?.stopPropagation?.();
     dispatch({ type: "SET_COMMAND_BAR", open: true, query: "" });
   };
+
+  const requestDeleteLayout = useCallback(async (index: number) => {
+    const layout = layouts[index];
+    if (!layout || layouts.length <= 1) return;
+    const confirmed = await dialog.prompt<boolean>({
+      closeOnClickOutside: true,
+      content: (context: PromptContext<boolean>) => (
+        <ConfirmDialog
+          {...context}
+          title={t("Delete Layout")}
+          body={[`Delete layout "${layout.name}"? This cannot be undone.`]}
+          confirmLabel={t("Delete Layout")}
+          cancelLabel={t("Cancel")}
+          width={48}
+        />
+      ),
+    }).catch(() => false);
+    if (confirmed !== true) return;
+    dispatch({ type: "DELETE_LAYOUT", index });
+    registry?.notify({ body: `Layout "${layout.name}" deleted`, type: "success" });
+  }, [dialog, dispatch, layouts, registry]);
 
   const layoutContextMenuItems = useCallback((index: number): ContextMenuItem[] => {
     const layout = layouts[index];
@@ -181,7 +223,7 @@ export function StatusBar() {
         id: "layout:delete",
         label: "Delete Layout...",
         enabled: layouts.length > 1,
-        onSelect: () => openWorkflowForLayout("delete-layout"),
+        onSelect: () => requestDeleteLayout(index),
       },
       contextMenuDivider("layout:actions-divider"),
       {
@@ -192,7 +234,7 @@ export function StatusBar() {
     );
 
     return items;
-  }, [activeLayoutIdx, dispatch, layouts, registry]);
+  }, [activeLayoutIdx, dispatch, layouts, registry, requestDeleteLayout]);
 
   const openLayoutContextMenu = useCallback((
     index: number,
@@ -230,6 +272,7 @@ export function StatusBar() {
     activeLayoutValue,
     dismissGridlockTip,
     handleGridlockTip,
+    handleLayoutReorder,
     handleLayoutSelect,
     hasMultipleLayouts,
     hoveredControl,
@@ -306,6 +349,7 @@ function TerminalStatusBar({
 function StatusBarLayoutControl({
   activeLayoutValue,
   handleLayoutSelect,
+  handleLayoutReorder,
   hasMultipleLayouts,
   hoveredControl,
   layoutTabItems,
@@ -317,6 +361,7 @@ function StatusBarLayoutControl({
   StatusBarViewProps,
   | "activeLayoutValue"
   | "handleLayoutSelect"
+  | "handleLayoutReorder"
   | "hasMultipleLayouts"
   | "hoveredControl"
   | "layoutTabItems"
@@ -337,6 +382,7 @@ function StatusBarLayoutControl({
             tabs={layoutTabItems}
             activeValue={activeLayoutValue}
             onSelect={handleLayoutSelect}
+            onReorder={handleLayoutReorder}
             compact
             variant="pill"
           />

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShortcut } from "../../react/input";
-import { Box, ScrollBox, Text, useUiHost } from "../../ui";
-import { TextAttributes, type ScrollBoxRenderable } from "../../ui";
+import { Box, ScrollBox, Text, useNativeRenderer, useUiHost } from "../../ui";
+import { TextAttributes, type BoxRenderable, type ScrollBoxRenderable } from "../../ui";
 import { hoverBg } from "../../theme/colors";
 import { useThemeColors } from "../../theme/theme-context";
 import { t } from "../../i18n";
 import { useAppLanguage } from "../../i18n/react";
 import { displayWidth } from "../../utils/format";
 import { useRemoteUiNode } from "../../remote/semantic-tree";
+import { capturePointerDrag } from "../../ui/pointer-drag";
 
 type TabPointerEvent = {
   button?: number;
@@ -19,6 +20,7 @@ interface TabItem {
   label: string;
   value: string;
   disabled?: boolean;
+  reorderable?: boolean;
   onClose?: (value: string) => void;
   onDoubleClick?: (value: string) => void;
   onContextMenu?: (value: string, event: TabPointerEvent) => void;
@@ -34,6 +36,7 @@ export interface TabsProps {
   closeMode?: "active" | "always";
   addLabel?: string;
   onAdd?: () => void;
+  onReorder?: (fromValue: string, toValue: string) => void;
   focused?: boolean;
   keyboardNavigation?: boolean;
   scrollable?: boolean;
@@ -52,6 +55,7 @@ export function Tabs({
   closeMode = "always",
   addLabel = "+",
   onAdd,
+  onReorder,
   focused = false,
   keyboardNavigation = true,
   scrollable = true,
@@ -163,6 +167,7 @@ export function Tabs({
         closeMode={closeMode}
         addLabel={addLabel}
         onAdd={onAdd}
+        onReorder={onReorder}
         focused={focused}
         palette={palette}
       />
@@ -180,6 +185,7 @@ export function Tabs({
       closeMode={closeMode}
       addLabel={addLabel}
       onAdd={onAdd}
+      onReorder={onReorder}
       focused={focused}
       scrollable={scrollable}
       scrollId={scrollId}
@@ -222,6 +228,7 @@ function OpenTuiTabs({
   closeMode = "always",
   addLabel = "+",
   onAdd,
+  onReorder,
   focused = false,
   scrollable = true,
   scrollId,
@@ -243,13 +250,72 @@ function OpenTuiTabs({
   };
 }) {
   const [hoveredValue, setHoveredValue] = useState<string | null>(null);
+  const [dragTargetValue, setDragTargetValue] = useState<string | null>(null);
+  const nativeRenderer = useNativeRenderer();
   const scrollRef = useRef<ScrollBoxRenderable>(null);
+  const tabRowRef = useRef<BoxRenderable>(null);
+  const tabRefs = useRef(new Map<string, BoxRenderable>());
+  const dragSourceValueRef = useRef<string | null>(null);
   const tabWidths = useMemo(
     () => tabs.map((tab) => tabWidth(tab, tab.value === activeValue, closeMode, dense)),
     [activeValue, closeMode, dense, tabs],
   );
   const addWidth = onAdd ? addLabel.length + (dense ? 1 : 2) : 0;
   const totalWidth = tabWidths.reduce((sum, width) => sum + width, 0) + addWidth;
+
+  const resolveDragTarget = useCallback((event?: { x?: number; preciseX?: number }) => {
+    const pointerX = event?.preciseX ?? event?.x;
+    if (typeof pointerX !== "number") return null;
+
+    let closestValue: string | null = null;
+    let closestDistance = Number.POSITIVE_INFINITY;
+    for (const tab of tabs) {
+      if (tab.disabled || tab.reorderable === false) continue;
+      const renderable = tabRefs.current.get(tab.value);
+      const bounds = renderable?.absoluteBounds;
+      const left = bounds?.x ?? renderable?.absoluteX ?? renderable?.x;
+      const width = bounds?.width ?? renderable?.width;
+      if (typeof left !== "number" || typeof width !== "number") continue;
+      const right = left + width;
+      const distance = pointerX < left ? left - pointerX : pointerX > right ? pointerX - right : 0;
+      if (distance < closestDistance) {
+        closestDistance = distance;
+        closestValue = tab.value;
+      }
+    }
+    return closestValue;
+  }, [tabs]);
+
+  const handleTabDrag = useCallback((event?: {
+    x?: number;
+    preciseX?: number;
+    preventDefault?: () => void;
+    stopPropagation?: () => void;
+  }) => {
+    if (!dragSourceValueRef.current) return;
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
+    const targetValue = resolveDragTarget(event);
+    setDragTargetValue((current) => (current === targetValue ? current : targetValue));
+  }, [resolveDragTarget]);
+
+  const finishTabDrag = useCallback((event?: {
+    x?: number;
+    preciseX?: number;
+    preventDefault?: () => void;
+    stopPropagation?: () => void;
+  }) => {
+    const sourceValue = dragSourceValueRef.current;
+    if (!sourceValue) return;
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
+    const targetValue = resolveDragTarget(event) ?? dragTargetValue;
+    dragSourceValueRef.current = null;
+    setDragTargetValue(null);
+    if (targetValue && targetValue !== sourceValue) {
+      onReorder?.(sourceValue, targetValue);
+    }
+  }, [dragTargetValue, onReorder, resolveDragTarget]);
 
   useEffect(() => {
     const scrollBox = scrollRef.current;
@@ -301,10 +367,17 @@ function OpenTuiTabs({
   };
 
   const tabRow = (
-    <Box flexDirection="row" width={totalWidth} height={1}>
+    <Box
+      ref={tabRowRef}
+      flexDirection="row"
+      width={totalWidth}
+      height={1}
+      onMouseDrag={onReorder ? handleTabDrag : undefined}
+      onMouseDragEnd={onReorder ? finishTabDrag : undefined}
+    >
       {tabs.map((tab, index) => {
         const active = tab.value === activeValue;
-        const hovered = hoveredValue === tab.value && !tab.disabled;
+        const hovered = (hoveredValue === tab.value || dragTargetValue === tab.value) && !tab.disabled;
         const focusedActive = focused && active;
         const tabWidth = tabWidths[index] ?? displayWidth(tab.label) + 2;
         const showClose = !!tab.onClose && (closeMode === "always" || active);
@@ -336,12 +409,20 @@ function OpenTuiTabs({
               }
               event.preventDefault();
               event.stopPropagation?.();
+              if (onReorder && tab.reorderable !== false) {
+                dragSourceValueRef.current = tab.value;
+                capturePointerDrag(nativeRenderer, tabRowRef.current);
+              }
               onSelect(tab.value);
             };
 
         return (
           <Box
             key={tab.value}
+            ref={(renderable: BoxRenderable | null) => {
+              if (renderable) tabRefs.current.set(tab.value, renderable);
+              else tabRefs.current.delete(tab.value);
+            }}
             width={tabWidth}
             height={1}
             flexDirection="row"
@@ -355,6 +436,7 @@ function OpenTuiTabs({
               fg={tab.disabled ? palette.disabledFg : active && variant === "pill" ? palette.activePillFg : active ? palette.activeFg : hovered ? palette.hoverFg : palette.inactiveFg}
               attributes={attributes}
               onMouseDown={selectTab}
+              selectable={onReorder ? false : undefined}
             >
               {dense ? `${tab.label} ` : ` ${tab.label} `}
             </Text>

--- a/src/core/state/app/layout-reducer.ts
+++ b/src/core/state/app/layout-reducer.ts
@@ -3,6 +3,8 @@ import {
   clonePaneStateMap,
   cloneSavedLayout,
   historyForIndex,
+  moveHistoryIndex,
+  movedIndex,
   removeHistoryIndex,
   setHistoryForIndex,
   syncConfigActiveLayoutState,
@@ -90,6 +92,38 @@ export function reduceLayoutAction(state: AppState, action: AppAction): AppState
         focusedPaneId: target.focusedPaneId ?? null,
         activePanel: target.activePanel ?? state.activePanel,
       });
+    }
+
+    case "REORDER_LAYOUT": {
+      const { fromIndex, toIndex } = action;
+      if (
+        fromIndex === toIndex
+        || fromIndex < 0
+        || toIndex < 0
+        || fromIndex >= state.config.layouts.length
+        || toIndex >= state.config.layouts.length
+      ) return state;
+
+      const currentConfig = syncConfigActiveLayoutState(
+        state.config,
+        state.paneState,
+        state.focusedPaneId,
+        state.activePanel,
+      );
+      const layouts = [...currentConfig.layouts];
+      const [movedLayout] = layouts.splice(fromIndex, 1);
+      if (!movedLayout) return state;
+      layouts.splice(toIndex, 0, movedLayout);
+
+      return {
+        ...state,
+        config: {
+          ...currentConfig,
+          layouts,
+          activeLayoutIndex: movedIndex(currentConfig.activeLayoutIndex, fromIndex, toIndex),
+        },
+        layoutHistory: moveHistoryIndex(state.layoutHistory, fromIndex, toIndex),
+      };
     }
 
     case "NEW_LAYOUT": {

--- a/src/core/state/app/layout.ts
+++ b/src/core/state/app/layout.ts
@@ -317,6 +317,27 @@ export function removeHistoryIndex(layoutHistory: Record<number, LayoutHistoryEn
   return next;
 }
 
+export function movedIndex(index: number, fromIndex: number, toIndex: number): number {
+  if (index === fromIndex) return toIndex;
+  if (fromIndex < toIndex && index > fromIndex && index <= toIndex) return index - 1;
+  if (fromIndex > toIndex && index >= toIndex && index < fromIndex) return index + 1;
+  return index;
+}
+
+export function moveHistoryIndex(
+  layoutHistory: Record<number, LayoutHistoryEntry>,
+  fromIndex: number,
+  toIndex: number,
+): Record<number, LayoutHistoryEntry> {
+  const next: Record<number, LayoutHistoryEntry> = {};
+  for (const [rawIndex, entry] of Object.entries(layoutHistory)) {
+    const index = Number.parseInt(rawIndex, 10);
+    if (Number.isNaN(index)) continue;
+    next[movedIndex(index, fromIndex, toIndex)] = cloneHistoryEntry(entry);
+  }
+  return next;
+}
+
 /** If paneId is a floating pane, bump its zIndex to the top. */
 export function bringFloatingToFront(layout: LayoutConfig, paneId: string): LayoutConfig {
   const entryIndex = layout.floating.findIndex((e) => e.instanceId === paneId);

--- a/src/core/state/app/types.ts
+++ b/src/core/state/app/types.ts
@@ -107,6 +107,7 @@ export type AppAction =
   | { type: "REDO_LAYOUT" }
   | { type: "UPDATE_LAYOUT"; layout: LayoutConfig; focusedPaneId?: string | null }
   | { type: "SWITCH_LAYOUT"; index: number }
+  | { type: "REORDER_LAYOUT"; fromIndex: number; toIndex: number }
   | { type: "NEW_LAYOUT"; name: string }
   | { type: "DELETE_LAYOUT"; index: number }
   | { type: "RENAME_LAYOUT"; index: number; name: string }

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -95,3 +95,51 @@ test("a tab bar occupies exactly the one row panes reserve for it", async () => 
   expect(list.style.marginBottom === "" || list.style.marginBottom === "0px").toBe(true);
   await act(async () => root.unmount());
 });
+
+test("desktop tabs reorder through native drag and drop", async () => {
+  const { WebTabs } = await import("./tabs");
+  const reordered: Array<[string, string]> = [];
+  const container = testWindow.document.createElement("div");
+  testWindow.document.body.appendChild(container);
+  const root = createRoot(container as unknown as HTMLElement);
+  await act(async () => {
+    root.render(
+      <WebTabs
+        tabs={[
+          { label: "Home", value: "home" },
+          { label: "Research", value: "research" },
+          { label: "News", value: "news" },
+        ]}
+        activeValue="home"
+        onSelect={() => {}}
+        onReorder={(fromValue, toValue) => reordered.push([fromValue, toValue])}
+        palette={{} as never}
+      />,
+    );
+  });
+
+  const buttons = [...container.querySelectorAll('[data-gloom-role="tab-button"]')] as unknown as HTMLElement[];
+  const values = new Map<string, string>();
+  const dataTransfer = {
+    effectAllowed: "none",
+    dropEffect: "none",
+    setData(type: string, value: string) { values.set(type, value); },
+    getData(type: string) { return values.get(type) ?? ""; },
+  };
+  const drag = (type: string, target: HTMLElement) => {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+    target.dispatchEvent(event);
+  };
+
+  expect(buttons).toHaveLength(3);
+  expect(buttons[0]?.getAttribute("draggable")).toBe("true");
+  await act(async () => {
+    drag("dragstart", buttons[0]!);
+    drag("dragover", buttons[2]!);
+    drag("drop", buttons[2]!);
+  });
+
+  expect(reordered).toEqual([["home", "news"]]);
+  await act(async () => root.unmount());
+});

--- a/src/renderers/electrobun/view/host/tabs.tsx
+++ b/src/renderers/electrobun/view/host/tabs.tsx
@@ -21,11 +21,14 @@ export function WebTabs({
   closeMode = "always",
   addLabel = "+",
   onAdd,
+  onReorder,
   focused = false,
   palette,
 }: HostTabsProps) {
   const activeTabRef = useRef<HTMLButtonElement | null>(null);
   const [hoveredValue, setHoveredValue] = useState<string | null>(null);
+  const [dragTargetValue, setDragTargetValue] = useState<string | null>(null);
+  const dragSourceValueRef = useRef<string | null>(null);
   const showUnderline = variant === "underline" && !compact;
   // A tab bar occupies exactly the one row every caller reserves for it. Any
   // extra pixels here are pixels the pane's children are told they own and the
@@ -94,6 +97,8 @@ export function WebTabs({
         const disabled = tab.disabled === true;
         const hovered = hoveredValue === tab.value && !disabled;
         const closeVisible = !!tab.onClose && (closeMode === "always" || active);
+        const reorderable = !!onReorder && !disabled && tab.reorderable !== false;
+        const dragTarget = dragTargetValue === tab.value && dragSourceValueRef.current !== tab.value;
         const tabStyle = {
           "--tab-fg": resolveTabColor(disabled, active, hovered),
           "--tab-hover-fg": palette.hoverFg,
@@ -117,7 +122,7 @@ export function WebTabs({
           margin: 0,
           border: "1px solid transparent",
           borderRadius: variant === "underline" ? 5 : 6,
-          background: resolveTabBackground(active, hovered),
+          background: resolveTabBackground(active, hovered || dragTarget),
           boxSizing: "border-box",
           font: "inherit",
           fontSize: tabFontSize,
@@ -129,7 +134,7 @@ export function WebTabs({
             ? `color-mix(in srgb, ${palette.activeUnderline} 35%, transparent)`
             : "transparent",
           transition: "background-color 110ms ease, border-color 110ms ease, color 110ms ease",
-          cursor: disabled ? "default" : "pointer",
+          cursor: disabled ? "default" : reorderable ? "grab" : "pointer",
         } satisfies CssVars;
 
         return (
@@ -143,6 +148,8 @@ export function WebTabs({
             aria-selected={active}
             aria-disabled={disabled || undefined}
             disabled={disabled}
+            draggable={reorderable}
+            aria-grabbed={reorderable && dragSourceValueRef.current === tab.value ? true : undefined}
             style={tabStyle}
             onMouseEnter={() => setHoveredValue(tab.value)}
             onMouseLeave={() => setHoveredValue((current) => (current === tab.value ? null : current))}
@@ -156,6 +163,32 @@ export function WebTabs({
               event.preventDefault();
               event.stopPropagation();
               tab.onContextMenu?.(tab.value, event);
+            } : undefined}
+            onDragStart={reorderable ? (event) => {
+              dragSourceValueRef.current = tab.value;
+              event.dataTransfer.effectAllowed = "move";
+              event.dataTransfer.setData("text/plain", tab.value);
+            } : undefined}
+            onDragOver={reorderable ? (event) => {
+              const sourceValue = dragSourceValueRef.current;
+              if (!sourceValue || sourceValue === tab.value) return;
+              event.preventDefault();
+              event.dataTransfer.dropEffect = "move";
+              setDragTargetValue(tab.value);
+            } : undefined}
+            onDragLeave={reorderable ? () => {
+              setDragTargetValue((current) => (current === tab.value ? null : current));
+            } : undefined}
+            onDrop={reorderable ? (event) => {
+              event.preventDefault();
+              const sourceValue = dragSourceValueRef.current ?? event.dataTransfer.getData("text/plain");
+              dragSourceValueRef.current = null;
+              setDragTargetValue(null);
+              if (sourceValue && sourceValue !== tab.value) onReorder(sourceValue, tab.value);
+            } : undefined}
+            onDragEnd={reorderable ? () => {
+              dragSourceValueRef.current = null;
+              setDragTargetValue(null);
             } : undefined}
           >
             <span

--- a/src/state/app/context/index.test.tsx
+++ b/src/state/app/context/index.test.tsx
@@ -94,6 +94,107 @@ describe("appReducer command bar state", () => {
     expect(secondUndone.config.layout).toEqual(createBlankLayout());
   });
 
+  test("reorders saved layouts without changing the active workspace", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-layout-reorder-test");
+    const baseLayout = cloneLayout(config.layout);
+    config.layouts = [
+      { name: "Home", layout: cloneLayout(baseLayout) },
+      { name: "Research", layout: cloneLayout(baseLayout) },
+      { name: "News", layout: cloneLayout(baseLayout) },
+    ];
+    config.activeLayoutIndex = 1;
+    config.layout = cloneLayout(config.layouts[1]!.layout);
+
+    const historyLayout = (ratio: number) => {
+      const layout = cloneLayout(baseLayout);
+      if (!layout.dockRoot || layout.dockRoot.kind !== "split") {
+        throw new Error("expected split dock root");
+      }
+      layout.dockRoot.ratio = ratio;
+      return layout;
+    };
+
+    const state = {
+      ...createInitialState(config),
+      paneState: {
+        "ticker-detail:main": { activeTabId: "financials" },
+      },
+      focusedPaneId: "ticker-detail:main",
+      layoutHistory: {
+        0: { past: [historyLayout(0.41)], future: [] },
+        1: { past: [historyLayout(0.52)], future: [] },
+        2: { past: [historyLayout(0.63)], future: [] },
+      },
+    };
+
+    const next = appReducer(state, { type: "REORDER_LAYOUT", fromIndex: 0, toIndex: 2 });
+
+    expect(next.config.layouts.map((layout) => layout.name)).toEqual(["Research", "News", "Home"]);
+    expect(next.config.activeLayoutIndex).toBe(0);
+    expect(next.config.layout).toEqual(state.config.layout);
+    expect(next.paneState).toEqual(state.paneState);
+    expect(next.config.layouts[0]?.paneState?.["ticker-detail:main"]?.activeTabId).toBe("financials");
+    expect(next.layoutHistory[0]?.past[0]?.dockRoot).toMatchObject({ kind: "split", ratio: 0.52 });
+    expect(next.layoutHistory[1]?.past[0]?.dockRoot).toMatchObject({ kind: "split", ratio: 0.63 });
+    expect(next.layoutHistory[2]?.past[0]?.dockRoot).toMatchObject({ kind: "split", ratio: 0.41 });
+  });
+
+  test("keeps saved layout operations coherent after a reorder", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-layout-operations-test");
+    const baseLayout = cloneLayout(config.layout);
+    config.layouts = [
+      { name: "Home", layout: cloneLayout(baseLayout) },
+      { name: "Research", layout: cloneLayout(baseLayout) },
+      { name: "News", layout: cloneLayout(baseLayout) },
+    ];
+    config.activeLayoutIndex = 1;
+    config.layout = cloneLayout(config.layouts[1]!.layout);
+
+    let state = createInitialState(config);
+    state = appReducer(state, { type: "REORDER_LAYOUT", fromIndex: 0, toIndex: 2 });
+    expect(state.config.layouts.map((layout) => layout.name)).toEqual(["Research", "News", "Home"]);
+    expect(state.config.activeLayoutIndex).toBe(0);
+
+    state = appReducer(state, { type: "RENAME_LAYOUT", index: 0, name: "Overview" });
+    expect(state.config.layouts.map((layout) => layout.name)).toEqual(["Overview", "News", "Home"]);
+
+    state = appReducer(state, { type: "DUPLICATE_LAYOUT", index: 0 });
+    expect(state.config.layouts.map((layout) => layout.name)).toEqual([
+      "Overview",
+      "News",
+      "Home",
+      "Overview Copy",
+    ]);
+    expect(state.config.activeLayoutIndex).toBe(3);
+
+    state = appReducer(state, { type: "SWITCH_LAYOUT", index: 1 });
+    expect(state.config.activeLayoutIndex).toBe(1);
+    expect(state.config.layouts[state.config.activeLayoutIndex]?.name).toBe("News");
+
+    state = appReducer(state, { type: "NEW_LAYOUT", name: "Scratch" });
+    expect(state.config.layouts.at(-1)?.name).toBe("Scratch");
+    expect(state.config.activeLayoutIndex).toBe(4);
+    expect(state.config.layout).toEqual(createBlankLayout());
+
+    state = appReducer(state, { type: "DELETE_LAYOUT", index: 4 });
+    expect(state.config.layouts.map((layout) => layout.name)).toEqual([
+      "Overview",
+      "News",
+      "Home",
+      "Overview Copy",
+    ]);
+    expect(state.config.activeLayoutIndex).toBe(3);
+
+    state = appReducer(state, { type: "DELETE_LAYOUT", index: 1 });
+    expect(state.config.layouts.map((layout) => layout.name)).toEqual([
+      "Overview",
+      "Home",
+      "Overview Copy",
+    ]);
+    expect(state.config.activeLayoutIndex).toBe(2);
+    expect(state.config.layouts[state.config.activeLayoutIndex]?.name).toBe("Overview Copy");
+  });
+
   test("restores an explicit focus target after a layout removes the focused pane", () => {
     const config = createDefaultConfig("/tmp/gloomberb-test-focus-restore");
     const nextLayout = removePane(config.layout, "ticker-detail:main");

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -271,6 +271,7 @@ interface HostTabItem {
   label: string;
   value: string;
   disabled?: boolean;
+  reorderable?: boolean;
   onClose?: (value: string) => void;
   onDoubleClick?: (value: string) => void;
   onContextMenu?: (value: string, event: any) => void;
@@ -301,6 +302,7 @@ export interface HostTabsProps {
   closeMode?: "active" | "always";
   addLabel?: string;
   onAdd?: () => void;
+  onReorder?: (fromValue: string, toValue: string) => void;
   focused?: boolean;
   palette: HostTabsPalette;
 }

--- a/src/ui/pointer-drag.ts
+++ b/src/ui/pointer-drag.ts
@@ -1,0 +1,12 @@
+export function capturePointerDrag(renderer: unknown, renderable: unknown): void {
+  if (!renderable) return;
+  const hostCapture = (renderer as { captureMouseRenderable?: (target: unknown) => void }).captureMouseRenderable;
+  if (typeof hostCapture === "function") {
+    hostCapture.call(renderer, renderable);
+    return;
+  }
+  const capture = (renderer as { setCapturedRenderable?: (target: unknown) => void }).setCapturedRenderable;
+  if (typeof capture === "function") {
+    capture.call(renderer, renderable);
+  }
+}


### PR DESCRIPTION
## What changed

- open a direct confirmation when deleting a saved layout from its context menu
- support dragging saved layout tabs left and right in both OpenTUI and the desktop app
- preserve the active layout, pane state, and per-layout undo history when tabs move
- share terminal pointer capture logic and add focused desktop, OpenTUI, and reducer coverage

## Why

The Delete Layout context-menu action routed through the command workflow, which opened the command bar instead of presenting the deletion confirmation. Saved layouts also had no direct way to change their tab order.

## Validation

- `bun test`: 1,872 passed, 0 failed
- `bun run typecheck`
- desktop interaction checks for switch, rename, new layout, delete confirmation, and Layout Actions
- OpenTUI tmux smoke with runtime warning scan
