### PR TITLE
Fix chat notification delivery across focus states

### DIFF
--- a/src/notifications/app-notifier.test.ts
+++ b/src/notifications/app-notifier.test.ts
@@ -93,7 +93,7 @@ describe("app notifier", () => {
       },
     });
 
-    notifier.notify({
+    const inactiveDelivery = notifier.notify({
       title: "Chat mention",
       body: "@bob mentioned you",
       type: "info",
@@ -103,9 +103,10 @@ describe("app notifier", () => {
 
     expect(toasts).toEqual([{ message: "@bob mentioned you", type: "info", duration: 5000 }]);
     expect(desktops).toEqual(["@bob mentioned you"]);
+    expect(inactiveDelivery).toEqual({ toastVisible: false, desktopRequested: true });
 
     active = true;
-    notifier.notify({
+    const activeDelivery = notifier.notify({
       body: "Visible toast only",
       type: "success",
       desktop: "when-inactive",
@@ -116,6 +117,7 @@ describe("app notifier", () => {
       { message: "Visible toast only", type: "success", duration: undefined },
     ]);
     expect(desktops).toEqual(["@bob mentioned you"]);
+    expect(activeDelivery).toEqual({ toastVisible: true, desktopRequested: false });
   });
 
   test("toast-disabled notifications skip toast delivery", () => {
@@ -133,10 +135,27 @@ describe("app notifier", () => {
       },
     });
 
-    notifier.notify({ body: "Saved", type: "success", toast: false, desktop: "when-inactive" });
+    const delivery = notifier.notify({ body: "Saved", type: "success", toast: false, desktop: "when-inactive" });
 
     expect(toasts).toEqual([]);
     expect(desktops).toEqual(["Saved"]);
+    expect(delivery).toEqual({ toastVisible: false, desktopRequested: true });
+  });
+
+  test("does not report an inactive toast as visible delivery without a desktop sink", () => {
+    const toasts: string[] = [];
+    const notifier = createAppNotifier({
+      isAppActive: () => false,
+      renderToast: (notification) => {
+        toasts.push(notification.body);
+      },
+      desktop: null,
+    });
+
+    const delivery = notifier.notify({ body: "Pending reply", desktop: "when-inactive" });
+
+    expect(toasts).toEqual(["Pending reply"]);
+    expect(delivery).toEqual({ toastVisible: false, desktopRequested: false });
   });
 });
 
@@ -153,10 +172,12 @@ describe("desktop notifier", () => {
       },
     });
 
-    notifier.notify({ body: "first" });
-    notifier.notify({ body: "second" });
+    const firstDelivery = notifier.notify({ body: "first" });
+    const secondDelivery = notifier.notify({ body: "second" });
 
     expect(calls).toEqual(["notify-send"]);
+    expect(firstDelivery).toBe(false);
+    expect(secondDelivery).toBe(false);
   });
 
   test("plays requested sounds alongside desktop notifications", () => {
@@ -170,8 +191,9 @@ describe("desktop notifier", () => {
       },
     });
 
-    notifier.notify({ body: "AAPL triggered", sound: "Glass" });
+    const delivery = notifier.notify({ body: "AAPL triggered", sound: "Glass" });
 
     expect(calls).toEqual(["notify-send", "paplay"]);
+    expect(delivery).toBe(true);
   });
 });

--- a/src/notifications/app-notifier.ts
+++ b/src/notifications/app-notifier.ts
@@ -1,4 +1,8 @@
-import type { AppNotificationRequest, AppNotificationType } from "../types/plugin";
+import type {
+  AppNotificationDelivery,
+  AppNotificationRequest,
+  AppNotificationType,
+} from "../types/plugin";
 import { debugLog } from "../utils/debug-log";
 
 const DEFAULT_NOTIFICATION_TITLE = "Gloomberb";
@@ -22,11 +26,11 @@ export interface DesktopNotificationRunner {
 }
 
 export interface DesktopNotificationSink {
-  notify(notification: AppNotificationRequest): void;
+  notify(notification: AppNotificationRequest): boolean | void;
 }
 
 export interface AppNotifier {
-  notify(notification: AppNotificationRequest): void;
+  notify(notification: AppNotificationRequest): AppNotificationDelivery;
 }
 
 interface CreateAppNotifierOptions {
@@ -194,9 +198,12 @@ export function createDesktopNotifier(
   return {
     notify(notification) {
       const desktopCommand = buildDesktopNotificationCommand(notification, platform);
+      let desktopRequested = false;
       if (desktopCommand && disabledCommand !== desktopCommand.command) {
+        let requestFailed = false;
         runner.run(desktopCommand.command, desktopCommand.args, {
           onError: (error) => {
+            requestFailed = true;
             if (error.code === "ENOENT") {
               disabledCommand = desktopCommand.command;
             }
@@ -207,6 +214,7 @@ export function createDesktopNotifier(
             });
           },
         });
+        desktopRequested = !requestFailed;
       }
 
       if (notification.sound) {
@@ -223,6 +231,8 @@ export function createDesktopNotifier(
           });
         }
       }
+
+      return desktopRequested;
     },
   };
 }
@@ -234,19 +244,28 @@ export function createAppNotifier({
 }: CreateAppNotifierOptions): AppNotifier {
   return {
     notify(notification) {
+      const appActive = isAppActive();
       const toastEnabled = notification.toast !== false;
       const desktopMode = notification.desktop ?? "never";
+      let toastRendered = false;
+      let desktopRequested = false;
 
       if (toastEnabled) {
         renderToast(notification);
+        toastRendered = true;
       }
 
       if (
         desktopMode === "always" ||
-        (desktopMode === "when-inactive" && !isAppActive())
+        (desktopMode === "when-inactive" && !appActive)
       ) {
-        desktop?.notify(notification);
+        desktopRequested = desktop ? desktop.notify(notification) !== false : false;
       }
+
+      return {
+        toastVisible: appActive && toastRendered,
+        desktopRequested,
+      };
     },
   };
 }

--- a/src/plugins/builtin/chat/content/index.tsx
+++ b/src/plugins/builtin/chat/content/index.tsx
@@ -133,6 +133,7 @@ export function ChatContent({
     applyingExternalDraftRef,
     channelId,
     controller,
+    focused,
     initialSnapshot,
     inputRef,
     inputValueRef,

--- a/src/plugins/builtin/chat/content/snapshot.ts
+++ b/src/plugins/builtin/chat/content/snapshot.ts
@@ -14,6 +14,7 @@ interface ChatSnapshotStateArgs {
   applyingExternalDraftRef: MutableRef<boolean>;
   channelId: string;
   controller: ChatContentController;
+  focused: boolean;
   initialSnapshot: ChatSnapshot;
   inputRef: MutableRef<TextareaRenderable | null>;
   inputValueRef: MutableRef<string>;
@@ -63,6 +64,7 @@ export function useChatSnapshotState({
   applyingExternalDraftRef,
   channelId,
   controller,
+  focused,
   initialSnapshot,
   inputRef,
   inputValueRef,
@@ -86,8 +88,10 @@ export function useChatSnapshotState({
   const [replyTo, setReplyTo] = useState<ChatMessage | null>(() => resolveReplyTo(initialSnapshot));
 
   useEffect(() => {
-    return useDefaultControllerChannel ? controller.attachView() : controller.attachChannelView(channelId);
-  }, [channelId, controller, useDefaultControllerChannel]);
+    return useDefaultControllerChannel
+      ? controller.attachView(focused)
+      : controller.attachChannelView(channelId, focused);
+  }, [channelId, controller, focused, useDefaultControllerChannel]);
 
   useEffect(() => {
     void controller.refreshChannels().catch(() => {});

--- a/src/plugins/builtin/chat/controller.test.ts
+++ b/src/plugins/builtin/chat/controller.test.ts
@@ -36,6 +36,27 @@ function recentChatTimestamp(offsetMs = 60_000) {
   return new Date(Date.now() - offsetMs).toISOString();
 }
 
+function mentionNotification(overrides: Partial<ChatNotification> = {}): ChatNotification {
+  const channelId = overrides.channelId ?? "everyone";
+  const messageId = overrides.messageId ?? "m1";
+  const createdAt = overrides.createdAt ?? "2026-03-28T00:00:00.000Z";
+  return {
+    id: overrides.id ?? "n1",
+    type: overrides.type ?? "mention",
+    channelId,
+    messageId,
+    createdAt,
+    message: overrides.message ?? {
+      id: messageId,
+      channelId,
+      content: "hey @vince",
+      replyToId: null,
+      createdAt,
+      user: { id: "u2", username: "bob", displayName: "Bob" },
+    },
+  };
+}
+
 class TrackingPersistence extends MemoryPersistence {
   stateWrites = 0;
 
@@ -974,18 +995,11 @@ describe("ChatController", () => {
     });
   });
 
-  test("displays server-issued mention notifications while the app is backgrounded", () => {
+  test("delivers background notifications while the focused chat stays unread", async () => {
     const persistence = new MemoryPersistence();
     const controller = new ChatController();
     const notifications: AppNotificationRequest[] = [];
-    const message: ChatMessage = {
-      id: "m1",
-      channelId: "everyone",
-      content: "hey @vince",
-      replyToId: null,
-      createdAt: "2026-03-28T00:00:00.000Z",
-      user: { id: "u2", username: "bob", displayName: "Bob" },
-    };
+    const deliveredIds: string[][] = [];
 
     persistence.setState("session", {
       sessionToken: "token-123",
@@ -994,18 +1008,17 @@ describe("ChatController", () => {
 
     controller.setNotifier((notification) => {
       notifications.push(notification);
+      return { toastVisible: false, desktopRequested: true };
     });
+    apiClient.markChatNotificationsDelivered = async (ids) => {
+      deliveredIds.push(ids);
+      return { delivered: ids.length };
+    };
     controller.attachPersistence(persistence);
+    const detachView = controller.attachView(true);
     controller.setAppActive(false);
 
-    (controller as any).handleChatNotification({
-      id: "n1",
-      type: "mention",
-      channelId: "everyone",
-      messageId: "m1",
-      createdAt: "2026-03-28T00:00:00.000Z",
-      message,
-    } satisfies ChatNotification);
+    (controller as any).handleChatNotification(mentionNotification());
 
     expect(notifications).toEqual([{
       title: "Gloomberb chat",
@@ -1014,6 +1027,49 @@ describe("ChatController", () => {
       type: "info",
       desktop: "when-inactive",
     }]);
+    expect(controller.getSnapshot().unreadMentionCount).toBe(1);
+    expect(deliveredIds).toEqual([["n1"]]);
+
+    controller.setAppActive(true);
+    await flushMicrotasks();
+    await flushMicrotasks();
+    expect(controller.getSnapshot().unreadMentionCount).toBe(0);
+    detachView();
+  });
+
+  test("keeps undeliverable background notifications pending for email fallback", () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const deliveredIds: string[][] = [];
+    let desktopAvailable = false;
+    let presentationCount = 0;
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+    controller.setNotifier(() => {
+      presentationCount += 1;
+      return { toastVisible: false, desktopRequested: desktopAvailable };
+    });
+    apiClient.markChatNotificationsDelivered = async (ids) => {
+      deliveredIds.push(ids);
+      return { delivered: ids.length };
+    };
+    controller.attachPersistence(persistence);
+    controller.setAppActive(false);
+
+    const notification = mentionNotification({ type: "reply" });
+    (controller as any).handleChatNotification(notification);
+
+    expect(presentationCount).toBe(1);
+    expect(deliveredIds).toEqual([]);
+
+    desktopAvailable = true;
+    (controller as any).handleChatNotification({ ...notification, id: "n2" });
+
+    expect(presentationCount).toBe(2);
+    expect(deliveredIds).toEqual([["n2"]]);
   });
 
   test("marks mentions viewed when a chat view opens", () => {
@@ -1053,18 +1109,11 @@ describe("ChatController", () => {
     detachView();
   });
 
-  test("does not keep mentions unread while a chat view is already open", () => {
+  test("keeps focused foreground notifications read without presenting an alert", () => {
     const persistence = new MemoryPersistence();
     const controller = new ChatController();
     const notifications: AppNotificationRequest[] = [];
-    const message: ChatMessage = {
-      id: "m1",
-      channelId: "everyone",
-      content: "hey @vince",
-      replyToId: null,
-      createdAt: "2026-03-28T00:00:00.000Z",
-      user: { id: "u2", username: "bob", displayName: "Bob" },
-    };
+    const deliveredIds: string[][] = [];
 
     persistence.setState("session", {
       sessionToken: "token-123",
@@ -1074,18 +1123,56 @@ describe("ChatController", () => {
     controller.setNotifier((notification) => {
       notifications.push(notification);
     });
+    apiClient.markChatNotificationsDelivered = async (ids) => {
+      deliveredIds.push(ids);
+      return { delivered: ids.length };
+    };
     controller.attachPersistence(persistence);
-    const detachView = controller.attachView();
+    const detachView = controller.attachView(true);
 
-    (controller as any).mergeMessages([message]);
+    (controller as any).handleChatNotification(mentionNotification());
 
     expect(controller.getSnapshot().unreadMentionCount).toBe(0);
     expect(notifications).toEqual([]);
+    expect(deliveredIds).toEqual([["n1"]]);
     expect(persistence.getState<{ lastViewedMessageId: string | null }>("channel:everyone", { schemaVersion: 1 })).toMatchObject({
       lastViewedMessageId: "m1",
     });
 
     detachView();
+  });
+
+  test("keeps an unfocused foreground chat unread while presenting an in-app alert", () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    const notifications: AppNotificationRequest[] = [];
+    const deliveredIds: string[][] = [];
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+    controller.setNotifier((notification) => {
+      notifications.push(notification);
+      return { toastVisible: true, desktopRequested: false };
+    });
+    apiClient.markChatNotificationsDelivered = async (ids) => {
+      deliveredIds.push(ids);
+      return { delivered: ids.length };
+    };
+    controller.attachPersistence(persistence);
+    const detachUnfocusedView = controller.attachView(false);
+
+    (controller as any).handleChatNotification(mentionNotification());
+
+    expect(notifications).toHaveLength(1);
+    expect(controller.getSnapshot().unreadMentionCount).toBe(1);
+    expect(deliveredIds).toEqual([["n1"]]);
+
+    detachUnfocusedView();
+    const detachFocusedView = controller.attachView(true);
+    expect(controller.getSnapshot().unreadMentionCount).toBe(0);
+    detachFocusedView();
   });
 
   test("loads server chat state, pending reply notifications, and acks delivery", async () => {
@@ -1147,6 +1234,7 @@ describe("ChatController", () => {
 
     controller.setNotifier((notification) => {
       notifications.push(notification);
+      return { toastVisible: true, desktopRequested: false };
     });
     controller.attachPersistence(persistence);
 
@@ -1229,6 +1317,7 @@ describe("ChatController", () => {
     }, { schemaVersion: 1 });
     controller.setNotifier((entry) => {
       notifications.push(entry);
+      return { toastVisible: true, desktopRequested: false };
     });
     controller.attachPersistence(persistence);
 

--- a/src/plugins/builtin/chat/controller/channel-actions.ts
+++ b/src/plugins/builtin/chat/controller/channel-actions.ts
@@ -68,20 +68,30 @@ export function attachChatChannelView({
   channelId,
   emit,
   flushDraftSync,
+  focused,
+  appActive,
   markViewedThroughLatestMessage,
 }: {
   channel: ChannelRuntimeState;
   channelId: string;
   emit: (channelId: string) => void;
   flushDraftSync: (channelId: string) => void;
+  focused: boolean;
+  appActive: boolean;
   markViewedThroughLatestMessage: (channelId: string) => boolean;
 }): () => void {
   channel.openViewCount += 1;
-  if (markViewedThroughLatestMessage(channelId)) {
+  if (focused) {
+    channel.focusedViewCount += 1;
+  }
+  if (focused && appActive && markViewedThroughLatestMessage(channelId)) {
     emit(channelId);
   }
   return () => {
     channel.openViewCount = Math.max(0, channel.openViewCount - 1);
+    if (focused) {
+      channel.focusedViewCount = Math.max(0, channel.focusedViewCount - 1);
+    }
     flushDraftSync(channelId);
   };
 }

--- a/src/plugins/builtin/chat/controller/index.ts
+++ b/src/plugins/builtin/chat/controller/index.ts
@@ -1,4 +1,9 @@
-import type { AppNotificationRequest, PluginPersistence, PluginResumeState } from "../../../../types/plugin";
+import type {
+  AppNotificationDelivery,
+  AppNotificationRequest,
+  PluginPersistence,
+  PluginResumeState,
+} from "../../../../types/plugin";
 import {
   apiClient,
   type ChatChannel,
@@ -65,7 +70,7 @@ export class ChatController {
   private appActive = true;
   private readonly session = createChatControllerSessionState();
   private pendingMessageSeq = 0;
-  private notifyFn: (notification: AppNotificationRequest) => void = () => {};
+  private notifyFn: (notification: AppNotificationRequest) => AppNotificationDelivery | void = () => {};
   private notifiedMessageIds = new Set<string>();
 
   private readonly storage = new ChatControllerStorage({
@@ -119,7 +124,7 @@ export class ChatController {
     this.hydrate();
   }
 
-  setNotifier(notify: (notification: AppNotificationRequest) => void): void {
+  setNotifier(notify: (notification: AppNotificationRequest) => AppNotificationDelivery | void): void {
     this.notifyFn = notify;
   }
 
@@ -258,11 +263,11 @@ export class ChatController {
     });
   }
 
-  attachView(): () => void {
-    return this.attachChannelView(DEFAULT_CHAT_CHANNEL_ID);
+  attachView(focused = true): () => void {
+    return this.attachChannelView(DEFAULT_CHAT_CHANNEL_ID, focused);
   }
 
-  attachChannelView(channelId: string): () => void {
+  attachChannelView(channelId: string, focused = true): () => void {
     const normalizedChannelId = normalizeChannelId(channelId);
     const channel = this.ensureChannelState(normalizedChannelId);
     return attachChatChannelView({
@@ -270,6 +275,8 @@ export class ChatController {
       channelId: normalizedChannelId,
       emit: (nextChannelId) => this.emit(nextChannelId),
       flushDraftSync: (nextChannelId) => this.storage.flushDraftSync(nextChannelId),
+      focused,
+      appActive: this.appActive,
       markViewedThroughLatestMessage: (nextChannelId) => this.markViewedThroughLatestMessage(nextChannelId),
     });
   }
@@ -295,8 +302,11 @@ export class ChatController {
       this.realtime.stopVerificationPolling();
       return;
     }
+    this.markFocusedViewsViewed();
     this.realtime.syncVerificationPolling();
-    void this.refreshChatState().catch(() => {});
+    void this.refreshChatState()
+      .then(() => this.markFocusedViewsViewed())
+      .catch(() => {});
   }
 
   reset(clearSession = false): void {
@@ -466,6 +476,7 @@ export class ChatController {
       currentUserId: this.session.user?.id,
       messages,
       options,
+      viewActive: this.appActive && channel.focusedViewCount > 0,
       markViewed: (persist) => this.markViewedThroughLatestMessage(channelId, persist),
     });
     this.storage.persistTranscript(channelId);
@@ -479,6 +490,7 @@ export class ChatController {
     handleChatNotificationEvent({
       notification,
       options,
+      appActive: this.appActive,
       ensureChannelState: (channelId) => this.ensureChannelState(channelId),
       mergeMessages: (channelId, messages, mergeOptions) => this.mergeMessages(channelId, messages, mergeOptions),
       getChannel: (channelId) => this.channelCatalog.getChannels().find((channel) => channel.id === channelId),
@@ -490,6 +502,15 @@ export class ChatController {
   private getUnreadMentionCount(channelId: string): number {
     const channel = this.ensureChannelState(channelId);
     return getUnreadMentionMessages(channel, this.session.user).length;
+  }
+
+  private markFocusedViewsViewed(): void {
+    for (const [channelId, channel] of this.storage.channelStates) {
+      if (channel.focusedViewCount === 0) continue;
+      if (this.markViewedThroughLatestMessage(channelId)) {
+        this.emit(channelId);
+      }
+    }
   }
 
   private markViewedThroughLatestMessage(channelId: string, persist = true): boolean {

--- a/src/plugins/builtin/chat/controller/lifecycle.ts
+++ b/src/plugins/builtin/chat/controller/lifecycle.ts
@@ -27,6 +27,7 @@ function resetChannelRuntimeState(channel: ChannelRuntimeState): void {
   channel.notificationsEnabled = false;
   channel.reachedOldestMessage = false;
   channel.openViewCount = 0;
+  channel.focusedViewCount = 0;
 }
 
 function disposeChannelRuntimeState(channel: ChannelRuntimeState): void {
@@ -35,6 +36,7 @@ function disposeChannelRuntimeState(channel: ChannelRuntimeState): void {
   channel.refreshMessagesPromise = null;
   channel.loadOlderMessagesPromise = null;
   channel.openViewCount = 0;
+  channel.focusedViewCount = 0;
 }
 
 interface ClearChatControllerSessionOptions {

--- a/src/plugins/builtin/chat/controller/messages.ts
+++ b/src/plugins/builtin/chat/controller/messages.ts
@@ -139,6 +139,7 @@ interface MergeChatMessagesOptions {
   currentUserId?: string | null;
   messages: ChatMessage[];
   options?: MergeMessagesOptions;
+  viewActive: boolean;
   markViewed: (persist?: boolean) => void;
 }
 
@@ -147,12 +148,13 @@ export function mergeChatMessages({
   currentUserId,
   messages,
   options,
+  viewActive,
   markViewed,
 }: MergeChatMessagesOptions): void {
   reconcilePendingMessages(channel, messages);
   const freshIncoming = mergeStoredMessages(channel, messages)
     .filter((message) => message.user.id !== currentUserId);
-  if (channel.openViewCount > 0) {
+  if (viewActive) {
     markViewed(false);
   } else if (freshIncoming.length > 0 && options?.countUnread !== false) {
     channel.unreadCount += freshIncoming.length;

--- a/src/plugins/builtin/chat/controller/notifications.ts
+++ b/src/plugins/builtin/chat/controller/notifications.ts
@@ -1,4 +1,7 @@
-import type { AppNotificationRequest } from "../../../../types/plugin";
+import type {
+  AppNotificationDelivery,
+  AppNotificationRequest,
+} from "../../../../types/plugin";
 import { apiClient, type ChatChannel, type ChatMessage, type ChatNotification } from "../../../../api-client";
 import type { ChannelRuntimeState, MergeMessagesOptions } from "./state";
 import { formatChatPaneTitle } from "../channel-labels";
@@ -7,6 +10,10 @@ import {
   formatMentionToast,
   formatReplyToast,
 } from "./utils";
+
+function wasNotificationDelivered(delivery: AppNotificationDelivery | void): boolean {
+  return !!delivery && (delivery.toastVisible || delivery.desktopRequested);
+}
 
 function notifyChatServerMessage({
   notification,
@@ -17,23 +24,26 @@ function notifyChatServerMessage({
   notification: ChatNotification;
   channel: ChatChannel | undefined;
   notifiedMessageIds: Set<string>;
-  notify: (notification: AppNotificationRequest) => void;
-}): void {
-  if (notifiedMessageIds.has(notification.messageId)) return;
-  notifiedMessageIds.add(notification.messageId);
+  notify: (notification: AppNotificationRequest) => AppNotificationDelivery | void;
+}): boolean {
+  if (notifiedMessageIds.has(notification.messageId)) return true;
   const channelTitle = formatChatPaneTitle(channel, notification.channelId);
   const body = notification.type === "reply"
     ? formatReplyToast(notification.message)
     : notification.type === "mention"
       ? formatMentionToast(notification.message)
       : formatChannelToast(channelTitle, notification.message, channel?.kind);
-  notify({
+  const delivered = wasNotificationDelivered(notify({
     title: "Gloomberb chat",
     subtitle: channelTitle,
     body,
     type: "info",
     desktop: "when-inactive",
-  });
+  }));
+  if (delivered) {
+    notifiedMessageIds.add(notification.messageId);
+  }
+  return delivered;
 }
 
 export function handleChatNotification({
@@ -41,6 +51,7 @@ export function handleChatNotification({
   options = {},
   ensureChannelState,
   mergeMessages,
+  appActive,
   getChannel,
   notifiedMessageIds,
   notify,
@@ -49,14 +60,24 @@ export function handleChatNotification({
   options?: { countUnread?: boolean };
   ensureChannelState: (channelId: string) => ChannelRuntimeState;
   mergeMessages: (channelId: string, messages: ChatMessage[], options?: MergeMessagesOptions) => void;
+  appActive: boolean;
   getChannel: (channelId: string) => ChatChannel | undefined;
   notifiedMessageIds: Set<string>;
-  notify: (notification: AppNotificationRequest) => void;
+  notify: (notification: AppNotificationRequest) => AppNotificationDelivery | void;
 }): void {
   mergeMessages(notification.channelId, [notification.message], { countUnread: options.countUnread });
   const channel = ensureChannelState(notification.channelId);
-  if (channel.openViewCount === 0) {
-    notifyChatServerMessage({ notification, channel: getChannel(notification.channelId), notifiedMessageIds, notify });
+  const activelyViewed = appActive && channel.focusedViewCount > 0;
+  const delivered = activelyViewed || notifyChatServerMessage({
+    notification,
+    channel: getChannel(notification.channelId),
+    notifiedMessageIds,
+    notify,
+  });
+  if (activelyViewed) {
+    notifiedMessageIds.add(notification.messageId);
   }
-  void apiClient.markChatNotificationsDelivered([notification.id]).catch(() => {});
+  if (delivered) {
+    void apiClient.markChatNotificationsDelivered([notification.id]).catch(() => {});
+  }
 }

--- a/src/plugins/builtin/chat/controller/state.ts
+++ b/src/plugins/builtin/chat/controller/state.ts
@@ -92,6 +92,7 @@ export interface ChannelRuntimeState {
   wsConnected: boolean;
   draftSyncTimer: ReturnType<typeof setTimeout> | null;
   openViewCount: number;
+  focusedViewCount: number;
 }
 
 export function channelStateKey(channelId: string): string {
@@ -125,6 +126,7 @@ export function createEmptyChannelState(): ChannelRuntimeState {
     wsConnected: false,
     draftSyncTimer: null,
     openViewCount: 0,
+    focusedViewCount: 0,
   };
 }
 

--- a/src/plugins/registry/context.ts
+++ b/src/plugins/registry/context.ts
@@ -5,6 +5,7 @@ import type { TickerFinancials } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
 import type { PluginCapability } from "../../capabilities";
 import type {
+  AppNotificationDelivery,
   AppNotificationRequest,
   BrokerInstanceUpdateOptions,
   GloomPluginContext,
@@ -69,7 +70,7 @@ export interface RegistryPluginContextOptions {
     on: <K extends keyof PluginEvents>(event: K, handler: (payload: PluginEvents[K]) => void) => () => void;
     emit: <K extends keyof PluginEvents>(event: K, payload: PluginEvents[K]) => void;
   };
-  notify: (notification: AppNotificationRequest) => void;
+  notify: (notification: AppNotificationRequest) => AppNotificationDelivery | void;
 }
 
 export function createRegistryPluginContext({

--- a/src/plugins/registry/index.ts
+++ b/src/plugins/registry/index.ts
@@ -10,6 +10,7 @@ import type { BrokerInstanceConfig, LayoutConfig } from "../../types/config";
 import type { DataProvider } from "../../types/data-provider";
 import type { TickerFinancials } from "../../types/financials";
 import type {
+  AppNotificationDelivery,
   AppNotificationRequest,
   BrokerInstanceUpdateOptions,
   CommandDef,
@@ -170,7 +171,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
     listener: (state: import("../../types/news-source").NewsQueryState) => void,
   ) => () => void) = () => () => {};
 
-  notifyFn: ((notification: AppNotificationRequest) => void) = () => {};
+  notifyFn: ((notification: AppNotificationRequest) => AppNotificationDelivery | void) = () => {};
   getPaneRuntimeStateFn: ((paneId: string) => PaneRuntimeState | null) = () => null;
   updatePaneRuntimeStateFn: ((paneId: string, patch: Partial<PaneRuntimeState>) => void) = () => {};
   applyPaneSettingValueFn: ((paneId: string, field: import("../../types/plugin").PaneSettingField, value: unknown) => Promise<void>) = async () => {};
@@ -278,8 +279,8 @@ export class PluginRegistry implements PluginRuntimeAccess {
     return this.contributions.pluginItems.get(pluginId)?.paneTemplates ?? [];
   }
 
-  notify(notification: AppNotificationRequest): void {
-    this.notifyFn(notification);
+  notify(notification: AppNotificationRequest): AppNotificationDelivery | void {
+    return this.notifyFn(notification);
   }
 
   renderSlot<K extends keyof GloomSlots>(name: K, props: GloomSlots[K]): ReactNode {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -467,6 +467,11 @@ export interface PluginPaneSettingsState {
 export type AppNotificationType = "info" | "success" | "error";
 type AppDesktopNotificationMode = "never" | "when-inactive" | "always";
 
+export interface AppNotificationDelivery {
+  toastVisible: boolean;
+  desktopRequested: boolean;
+}
+
 export interface AppNotificationRequest {
   title?: string;
   body: string;
@@ -548,7 +553,7 @@ export interface GloomPluginContext {
   on<K extends keyof PluginEvents>(event: K, handler: (payload: PluginEvents[K]) => void): () => void;
   emit<K extends keyof PluginEvents>(event: K, payload: PluginEvents[K]): void;
 
-  notify(notification: AppNotificationRequest): void;
+  notify(notification: AppNotificationRequest): AppNotificationDelivery | void;
 }
 
 export interface GloomPlugin {


### PR DESCRIPTION
## What changed

- Track focused chat views separately from mounted views so backgrounded or unfocused conversations remain unread.
- Send desktop notifications when the app is inactive, including when the same chat pane was last focused.
- Acknowledge chat delivery only after an actively viewed conversation, a visible in-app toast, or a desktop notification request.
- Leave failed or unavailable background delivery unacknowledged so the existing delayed email fallback can run.

## Why

Mounted chat panes were treated as visible even after the app lost focus. That suppressed desktop alerts, marked background messages as read, and still acknowledged them to the server, which could also suppress the offline email fallback.

## Validation

- `bun run typecheck`
- `bun test` (1,875 passing)
- `bun run desktop:view:build`
- `bun run build`
- Full TUI smoke in tmux with command-bar interaction and runtime-warning scan
