### PR TITLE
Use Cloud data in market panes

### DIFF
--- a/src/api-client/data.ts
+++ b/src/api-client/data.ts
@@ -32,6 +32,8 @@ import type {
   CloudMarketBatchPayload,
   CloudMarketBatchTarget,
   CloudMarketResponse,
+  CloudMarketScreenerCategory,
+  CloudMarketScreenerPayload,
   CloudNewsListResponse,
   CloudNewsPayload,
   CloudOptionsChainPayload,
@@ -75,6 +77,22 @@ export class CloudDataApi {
     mode: "cache-first" | "refresh" = "cache-first",
   ): Promise<CloudMarketResponse<CloudMarketBatchPayload<CloudQuotePayload>>> {
     return this.postMarketBatch("/market/quotes/batch", targets, mode);
+  }
+
+  async getCloudMarketScreener(
+    category: CloudMarketScreenerCategory,
+    count = 25,
+    mode: "cache-first" | "refresh" = "cache-first",
+  ): Promise<CloudMarketResponse<CloudMarketScreenerPayload>> {
+    const requestedCount = Number.isFinite(count) ? Math.round(count) : 25;
+    const params = new URLSearchParams({
+      category,
+      count: String(Math.max(1, Math.min(50, requestedCount))),
+      mode,
+    });
+    return this.request<CloudMarketResponse<CloudMarketScreenerPayload>>(
+      `/market/screener?${params.toString()}`,
+    );
   }
 
   async getCloudOptionsChain(

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -47,6 +47,8 @@ import type {
   CloudMarketResponse,
   CloudMarketBatchTarget,
   CloudMarketBatchPayload,
+  CloudMarketScreenerCategory,
+  CloudMarketScreenerPayload,
   CloudVerificationResponse,
   CloudRoundupPreviewResponse,
   CloudSyncPushResponse,
@@ -411,6 +413,14 @@ class GloomApiClient {
     mode: "cache-first" | "refresh" = "cache-first",
   ): Promise<CloudMarketResponse<CloudMarketBatchPayload<CloudQuotePayload>>> {
     return this.data.getCloudQuotesBatch(targets, mode);
+  }
+
+  async getCloudMarketScreener(
+    category: CloudMarketScreenerCategory,
+    count = 25,
+    mode: "cache-first" | "refresh" = "cache-first",
+  ): Promise<CloudMarketResponse<CloudMarketScreenerPayload>> {
+    return this.data.getCloudMarketScreener(category, count, mode);
   }
 
   async getCloudOptionsChain(

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -570,6 +570,35 @@ export interface CloudMarketBatchPayload<T> {
   items: Array<CloudMarketBatchItem<T>>;
 }
 
+export type CloudMarketScreenerCategory = "gainers" | "losers" | "most-active";
+
+export interface CloudMarketScreenerItem {
+  rank: number;
+  symbol: string;
+  name: string;
+  price: number;
+  change: number;
+  changePercent: number;
+  volume: number;
+  tradeCount?: number;
+  currency: string;
+  high52w?: number;
+  low52w?: number;
+  dayHigh?: number;
+  dayLow?: number;
+  exchange: string;
+  lastUpdated: number;
+  dataSource: "live";
+}
+
+export interface CloudMarketScreenerPayload {
+  providerId: "gloomberb-cloud";
+  category: CloudMarketScreenerCategory;
+  asOf: string;
+  stale?: boolean;
+  items: CloudMarketScreenerItem[];
+}
+
 export interface CloudVerificationResponse {
   sent: boolean;
   email?: string;

--- a/src/market-data/market/status.ts
+++ b/src/market-data/market/status.ts
@@ -1,4 +1,4 @@
-import type { MarketState, Quote, QuoteFieldProvenance } from "../../types/financials";
+import type { MarketState, Quote } from "../../types/financials";
 import { blendHex, colors, priceColor, type ThemeColors } from "../../theme/colors";
 
 const CLOSED_CHANGE_MUTING_RATIO = 0.55;
@@ -88,22 +88,6 @@ export function exchangeShortName(exchangeName?: string, fullExchangeName?: stri
     JPX: "TYO",
   };
   return map[name] || name;
-}
-
-export function quoteSourceLabel(
-  provenance?: QuoteFieldProvenance,
-  kind: "price" | "session" = "price",
-): string {
-  if (!provenance?.providerId) return "Unknown";
-  if (provenance.providerId === "ibkr") {
-    if (kind === "session") return "Broker";
-    if (provenance.dataSource === "live") return "IBKR live";
-    if (provenance.dataSource === "delayed") return "IBKR delayed";
-    return "IBKR";
-  }
-  if (provenance.providerId === "gloomberb-cloud") return "Cloud";
-  if (provenance.providerId === "yahoo") return "Yahoo";
-  return provenance.providerId;
 }
 
 export function getActiveQuoteDisplay(quote: Quote | null | undefined): ActiveQuoteDisplay | null {

--- a/src/plugins/builtin/market-heatmap/index.tsx
+++ b/src/plugins/builtin/market-heatmap/index.tsx
@@ -17,6 +17,7 @@ import { priceColor } from "../../../theme/colors";
 import { formatCompact, formatCurrency, formatPercentRaw } from "../../../utils/format";
 import { isPlainKey } from "../../../utils/keyboard";
 import { usePluginPaneState, usePluginTickerActions } from "../../runtime";
+import { useLiveQuoteEntries } from "../../../state/hooks/quote-streaming";
 import {
   MARKET_HEATMAP_UNIVERSES,
   fetchMarketHeatmap,
@@ -24,6 +25,16 @@ import {
   type MarketHeatmapAsset,
   type MarketHeatmapUniverseId,
 } from "./data";
+import {
+  LIVE_STREAMING_QUICK_SETTING,
+  useLiveStreamingSetting,
+  withLiveStreamingSetting,
+} from "../shared/live-streaming";
+import {
+  buildScreenerQuoteTargets,
+  overlayScreenerQuoteEntries,
+  resolveScreenerQuoteFeedStatus,
+} from "../shared/screener-live-quotes";
 
 function formatMoneyCompact(value: number | null | undefined, currency: string): string {
   if (value == null) return "—";
@@ -59,6 +70,7 @@ function buildItems(assets: MarketHeatmapAsset[]): Array<MetricTreemapItem<Marke
 
 function MarketHeatmapPane({ focused, width, height }: PaneProps) {
   const { pinTicker } = usePluginTickerActions();
+  const liveStreaming = useLiveStreamingSetting();
   const { cellWidthPx = 8, cellHeightPx = 18, nativePaneChrome } = useUiCapabilities();
   const [activeUniverse, setActiveUniverse] = usePluginPaneState<MarketHeatmapUniverseId>("universe", "us-equity");
   const [assets, setAssets] = useState<MarketHeatmapAsset[]>([]);
@@ -71,16 +83,39 @@ function MarketHeatmapPane({ focused, width, height }: PaneProps) {
   const chartHeight = Math.max(1, height - 1);
   const chartWidth = Math.max(1, width - 2);
   const cellAspect = Math.max(0.5, Math.min(4, cellHeightPx / Math.max(1, cellWidthPx)));
-  const items = useMemo(() => buildItems(assets), [assets]);
+  const quoteTargets = useMemo(
+    () => buildScreenerQuoteTargets(assets, selectedSymbol),
+    [assets, selectedSymbol],
+  );
+  const {
+    entries: liveQuoteEntries,
+    freshnessNow,
+    subscriptionStartedAt,
+  } = useLiveQuoteEntries(quoteTargets, {
+    freshnessScopeKey: `market-heatmap:${activeUniverse}`,
+    liveStreaming,
+  });
+  const resolvedAssets = useMemo(
+    () => overlayScreenerQuoteEntries(assets, liveQuoteEntries),
+    [assets, liveQuoteEntries],
+  );
+  const feedStatus = useMemo(
+    () => resolveScreenerQuoteFeedStatus(quoteTargets, liveQuoteEntries, {
+      now: freshnessNow,
+      subscriptionStartedAt,
+    }),
+    [freshnessNow, liveQuoteEntries, quoteTargets, subscriptionStartedAt],
+  );
+  const items = useMemo(() => buildItems(resolvedAssets), [resolvedAssets]);
   const navigationTiles = useMemo(
     () => buildMetricTreemapNavigationTiles(items, chartWidth, chartHeight, cellAspect, nativePaneChrome ? "float" : "integer"),
     [cellAspect, chartHeight, chartWidth, items, nativePaneChrome],
   );
   const selectedIdx = selectedSymbol
-    ? assets.findIndex((asset) => asset.symbol === selectedSymbol)
+    ? resolvedAssets.findIndex((asset) => asset.symbol === selectedSymbol)
     : -1;
-  const activeIdx = selectedIdx >= 0 ? selectedIdx : (assets.length > 0 ? 0 : -1);
-  const selectedAsset = activeIdx >= 0 ? assets[activeIdx] ?? null : null;
+  const activeIdx = selectedIdx >= 0 ? selectedIdx : (resolvedAssets.length > 0 ? 0 : -1);
+  const selectedAsset = activeIdx >= 0 ? resolvedAssets[activeIdx] ?? null : null;
 
   const loadUniverse = useCallback(async (universe: MarketHeatmapUniverseId, options?: { forceRefresh?: boolean }) => {
     fetchGenRef.current += 1;
@@ -97,12 +132,12 @@ function MarketHeatmapPane({ focused, width, height }: PaneProps) {
       setAssets(result.assets);
       setLastUpdated(result.fetchedAt);
       setSelectedSymbol(result.assets[0]?.symbol ?? null);
-    } catch (error) {
+    } catch {
       if (fetchGenRef.current !== gen) return;
       setAssets([]);
       setLastUpdated(null);
       setSelectedSymbol(null);
-      setLoadError(error instanceof Error ? error.message : "Market heatmap unavailable");
+      setLoadError("Market heatmap temporarily unavailable");
     } finally {
       if (fetchGenRef.current === gen) setLoading(false);
     }
@@ -247,9 +282,13 @@ function MarketHeatmapPane({ focused, width, height }: PaneProps) {
         }] : []),
         ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
         ...(loadError ? [{ id: "error", parts: [{ text: "error", tone: "muted" as const }] }] : []),
+        ...(feedStatus ? [{
+          id: "feed",
+          parts: [{ text: feedStatus, tone: feedStatus === "live" ? "value" as const : "muted" as const }],
+        }] : []),
       ],
     };
-  }, [lastUpdated, loadError, loading, selectedAsset]);
+  }, [feedStatus, lastUpdated, loadError, loading, selectedAsset]);
 
   const emptyStateTitle = loading
     ? "Loading market heatmap..."
@@ -299,6 +338,8 @@ export const marketHeatmapModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 110, height: 36 },
+      quickSettings: [LIVE_STREAMING_QUICK_SETTING],
+      settings: (context) => withLiveStreamingSetting({ fields: [] }, context.settings),
     },
   ],
 

--- a/src/plugins/builtin/market-movers/index.tsx
+++ b/src/plugins/builtin/market-movers/index.tsx
@@ -7,9 +7,10 @@ import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
 import { priceColor } from "../../../theme/colors";
 import { formatPercentRaw } from "../../../utils/format";
 import { useAssetData, usePluginTickerActions } from "../../runtime";
+import { useLiveQuoteEntries } from "../../../state/hooks/quote-streaming";
 import {
   attachMarketMoversPersistence,
-  fetchScreener,
+  fetchPreferredMarketMovers,
   fetchTrending,
   MARKET_SUMMARY_SYMBOLS,
   resetMarketMoversPersistence,
@@ -32,10 +33,21 @@ import {
   type TabId,
 } from "./model";
 import { buildMarketMoverColumns, renderMarketMoverCell } from "./table";
+import {
+  LIVE_STREAMING_QUICK_SETTING,
+  useLiveStreamingSetting,
+  withLiveStreamingSetting,
+} from "../shared/live-streaming";
+import {
+  buildScreenerQuoteTargets,
+  overlayScreenerQuoteEntries,
+  resolveScreenerQuoteFeedStatus,
+} from "../shared/screener-live-quotes";
 
 function MarketMoversPane({ focused, width, height }: PaneProps) {
   const dataProvider = useAssetData();
   const { pinTicker } = usePluginTickerActions();
+  const liveStreaming = useLiveStreamingSetting();
   const [activeTab, setActiveTab] = useState<TabId>("gainers");
   const [quotes, setQuotes] = useState<ScreenerQuote[]>([]);
   const [loading, setLoading] = useState(false);
@@ -43,11 +55,35 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
   const [selectedSymbol, setSelectedSymbol] = useState<string | null>(null);
   const [sortPreference, setSortPreference] = useState<MarketMoverSortPreference>(DEFAULT_SORT_PREFERENCE);
   const [summaryQuotes, setSummaryQuotes] = useState<MarketSummaryQuote[]>([]);
+  const [moversStale, setMoversStale] = useState(false);
 
   const fetchGenRef = useRef(0);
 
+  const quoteTargets = useMemo(
+    () => buildScreenerQuoteTargets(quotes, selectedSymbol),
+    [quotes, selectedSymbol],
+  );
+  const {
+    entries: liveQuoteEntries,
+    freshnessNow,
+    subscriptionStartedAt,
+  } = useLiveQuoteEntries(quoteTargets, {
+    freshnessScopeKey: `market-movers:${activeTab}`,
+    liveStreaming,
+  });
+  const resolvedQuotes = useMemo(
+    () => overlayScreenerQuoteEntries(quotes, liveQuoteEntries),
+    [liveQuoteEntries, quotes],
+  );
+  const feedStatus = useMemo(
+    () => resolveScreenerQuoteFeedStatus(quoteTargets, liveQuoteEntries, {
+      now: freshnessNow,
+      subscriptionStartedAt,
+    }),
+    [freshnessNow, liveQuoteEntries, quoteTargets, subscriptionStartedAt],
+  );
   const columns = useMemo(() => buildMarketMoverColumns(width), [width]);
-  const rankedRows = useMemo(() => createRows(quotes), [quotes]);
+  const rankedRows = useMemo(() => createRows(resolvedQuotes), [resolvedQuotes]);
   const rows = useMemo(() => sortRows(rankedRows, sortPreference), [rankedRows, sortPreference]);
   const selectedIdx = selectedSymbol
     ? rows.findIndex((row) => row.symbol === selectedSymbol)
@@ -101,11 +137,16 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
     return () => clearInterval(interval);
   }, [dataProvider]);
 
-  const loadTab = useCallback(async (tab: TabId, options?: { forceRefresh?: boolean }) => {
+  const loadTab = useCallback(async (
+    tab: TabId,
+    options?: { forceRefresh?: boolean; background?: boolean },
+  ) => {
     fetchGenRef.current += 1;
     const gen = fetchGenRef.current;
-    setLoading(true);
-    setLoadError(null);
+    if (!options?.background) {
+      setLoading(true);
+      setLoadError(null);
+    }
 
     try {
       let data: ScreenerQuote[];
@@ -145,27 +186,36 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
         data = trending
           .map((t) => resolved.find((r) => r.symbol === t.symbol))
           .filter((r): r is ScreenerQuote => r !== undefined);
+        setMoversStale(false);
       } else {
-        data = await fetchScreener(CATEGORY_MAP[tab], 25, undefined, {
+        const result = await fetchPreferredMarketMovers(CATEGORY_MAP[tab], 25, {
           forceRefresh: options?.forceRefresh,
         });
         if (fetchGenRef.current !== gen) return;
+        data = result.quotes;
+        setMoversStale(result.stale);
       }
 
       setQuotes(data);
-      setSelectedSymbol(null);
+      if (!options?.background) setSelectedSymbol(null);
       setLoadError(null);
-    } catch (error) {
-      if (fetchGenRef.current === gen) {
-        setLoadError(error instanceof Error ? error.message : "Market movers unavailable");
+    } catch {
+      if (fetchGenRef.current === gen && !options?.background) {
+        setLoadError("Market movers temporarily unavailable");
       }
     }
     finally {
-      if (fetchGenRef.current === gen) setLoading(false);
+      if (fetchGenRef.current === gen && !options?.background) setLoading(false);
     }
   }, [dataProvider]);
 
-  useEffect(() => { loadTab(activeTab); }, [activeTab, loadTab]);
+  useEffect(() => {
+    void loadTab(activeTab);
+    const interval = setInterval(() => {
+      void loadTab(activeTab, { background: true });
+    }, 60_000);
+    return () => clearInterval(interval);
+  }, [activeTab, loadTab]);
 
   const openSymbol = useCallback((symbol: string) => {
     pinTicker(symbol, { floating: true, paneType: TICKER_RESEARCH_PANE_ID });
@@ -204,9 +254,17 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
         };
       }),
       ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+      ...(feedStatus ? [{
+        id: "feed",
+        parts: [{ text: feedStatus, tone: feedStatus === "live" ? "value" as const : "muted" as const }],
+      }] : []),
+      ...(moversStale ? [{
+        id: "stale",
+        parts: [{ text: "stale", tone: "muted" as const }],
+      }] : []),
     ],
     hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refreshActiveTab }],
-  }), [loading, refreshActiveTab, summaryQuotes]);
+  }), [feedStatus, loading, moversStale, refreshActiveTab, summaryQuotes]);
 
   return (
     <Box flexDirection="column" width={width} height={height}>
@@ -243,7 +301,7 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
         onActivate={(row) => openSymbol(row.symbol)}
         renderCell={renderMarketMoverCell}
         emptyStateTitle={loading ? "Loading movers..." : loadError ?? "No data"}
-        emptyStateHint={loadError ? "Yahoo Finance did not return market movers." : undefined}
+        emptyStateHint={loadError ? "Try again in a moment." : undefined}
       />
     </Box>
   );
@@ -267,6 +325,8 @@ export const marketMoversModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 100, height: 36 },
+      quickSettings: [LIVE_STREAMING_QUICK_SETTING],
+      settings: (context) => withLiveStreamingSetting({ fields: [] }, context.settings),
     },
   ],
 

--- a/src/plugins/builtin/market-movers/model.ts
+++ b/src/plugins/builtin/market-movers/model.ts
@@ -125,7 +125,7 @@ export function summaryQuoteFromQuote(
   };
 }
 
-export function screenerQuoteFromQuote(symbol: string, quote: { name?: string; price?: number; change?: number; changePercent?: number; volume?: number; currency?: string }): ScreenerQuote {
+export function screenerQuoteFromQuote(symbol: string, quote: { name?: string; price?: number; change?: number; changePercent?: number; volume?: number; currency?: string; exchangeName?: string; listingExchangeName?: string; lastUpdated?: number }): ScreenerQuote {
   return {
     symbol,
     name: quote.name ?? symbol,
@@ -141,6 +141,7 @@ export function screenerQuoteFromQuote(symbol: string, quote: { name?: string; p
     fiftyTwoWeekLow: undefined,
     dayHigh: undefined,
     dayLow: undefined,
-    exchange: "",
+    exchange: quote.listingExchangeName ?? quote.exchangeName ?? "",
+    lastUpdated: quote.lastUpdated,
   };
 }

--- a/src/plugins/builtin/market-movers/screener.test.ts
+++ b/src/plugins/builtin/market-movers/screener.test.ts
@@ -3,11 +3,13 @@ import { MemoryPluginPersistence } from "../../../test-support/plugin-persistenc
 import {
   attachMarketMoversPersistence,
   createYahooScreenerApi,
+  fetchPreferredMarketMovers,
   fetchScreener,
   parseScreenerResponse,
   parseTrendingResponse,
   resetMarketMoversPersistence,
   type YahooScreenerApi,
+  type PreferredMarketMoverSources,
 } from "./screener";
 
 const SAMPLE_SCREENER_RESPONSE = {
@@ -138,6 +140,86 @@ describe("parseTrendingResponse", () => {
 });
 
 describe("fetchScreener", () => {
+  test("uses Cloud rankings and prices while retaining Yahoo metadata", async () => {
+    const calls: unknown[] = [];
+    const yahooQuotes = parseScreenerResponse(SAMPLE_SCREENER_RESPONSE);
+    const sources: PreferredMarketMoverSources = {
+      isCloudEligible: () => true,
+      fetchCloud: async (category, count, mode) => {
+        calls.push({ category, count, mode });
+        return {
+          status: "success",
+          data: {
+            providerId: "gloomberb-cloud",
+            category,
+            asOf: "2026-08-14T23:59:00.000Z",
+            items: [
+              {
+                rank: 1,
+                symbol: "AAPL",
+                name: "AAPL",
+                price: 190,
+                change: 7.75,
+                changePercent: 4.25,
+                volume: 60_000_000,
+                currency: "USD",
+                exchange: "NASDAQ",
+                lastUpdated: 1_700_000_000_000,
+                dataSource: "live",
+              },
+            ],
+          },
+        };
+      },
+      fetchYahoo: async () => yahooQuotes,
+    };
+
+    const result = await fetchPreferredMarketMovers(
+      "day_gainers",
+      25,
+      { forceRefresh: true },
+      sources,
+    );
+
+    expect(calls).toEqual([
+      { category: "gainers", count: 25, mode: "refresh" },
+    ]);
+    expect(result).toMatchObject({ source: "cloud", stale: false });
+    expect(result.quotes[0]).toMatchObject({
+      symbol: "AAPL",
+      name: "Apple Inc.",
+      price: 190,
+      changePercent: 4.25,
+      volume: 60_000_000,
+      avgVolume: 20_000_000,
+      marketCap: 2_900_000_000_000,
+      lastUpdated: 1_700_000_000_000,
+    });
+  });
+
+  test("keeps free accounts on Yahoo without calling the Pro screener", async () => {
+    let cloudCalls = 0;
+    const sources: PreferredMarketMoverSources = {
+      isCloudEligible: () => false,
+      fetchCloud: async () => {
+        cloudCalls += 1;
+        throw new Error("not expected");
+      },
+      fetchYahoo: async () => parseScreenerResponse(SAMPLE_SCREENER_RESPONSE),
+    };
+
+    const result = await fetchPreferredMarketMovers(
+      "most_actives",
+      25,
+      undefined,
+      sources,
+    );
+
+    expect(cloudCalls).toBe(0);
+    expect(result.source).toBe("yahoo");
+    expect(result.quotes.map((quote) => quote.symbol)).toEqual(["AAPL", "MSFT"]);
+  });
+
   test("falls back to the secondary Yahoo host when the primary host fails", async () => {
     const requestedHosts: string[] = [];
     const userAgents: string[] = [];

--- a/src/plugins/builtin/market-movers/screener.ts
+++ b/src/plugins/builtin/market-movers/screener.ts
@@ -1,5 +1,13 @@
 import { createThrottledFetch, type ThrottledFetchTransport } from "../../../utils/throttled-fetch";
 import type { PluginPersistence } from "../../../types/plugin";
+import { apiClient } from "../../../api-client";
+import type {
+  CloudMarketResponse,
+  CloudMarketScreenerCategory,
+  CloudMarketScreenerItem,
+  CloudMarketScreenerPayload,
+} from "../../../api-client/types";
+import { hasProAccess } from "../shared/plan-access";
 
 const YAHOO_FINANCE_HOSTS = [
   "query2.finance.yahoo.com",
@@ -12,6 +20,7 @@ const CACHE_POLICY = {
   staleMs: 5 * 60 * 1000,
   expireMs: 60 * 60 * 1000,
 } as const;
+const YAHOO_METADATA_WAIT_MS = 1_500;
 
 const YAHOO_FINANCE_HEADERS = {
   "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
@@ -152,6 +161,29 @@ export interface ScreenerQuote {
   dayHigh: number | undefined;
   dayLow: number | undefined;
   exchange: string;
+  lastUpdated?: number;
+}
+
+export type MarketMoversDataSource = "cloud" | "yahoo";
+
+export interface MarketMoversResult {
+  quotes: ScreenerQuote[];
+  source: MarketMoversDataSource;
+  stale: boolean;
+}
+
+export interface PreferredMarketMoverSources {
+  isCloudEligible(): boolean;
+  fetchCloud(
+    category: CloudMarketScreenerCategory,
+    count: number,
+    mode: "cache-first" | "refresh",
+  ): Promise<CloudMarketResponse<CloudMarketScreenerPayload>>;
+  fetchYahoo(
+    category: ScreenerCategory,
+    count: number,
+    options?: FetchCacheOptions,
+  ): Promise<ScreenerQuote[]>;
 }
 
 export interface TrendingSymbol {
@@ -217,6 +249,118 @@ export async function fetchScreener(
   };
   if (!shouldUseCache(api, options)) return load();
   return loadCached(`screener:${category}:count=${count}`, load, options);
+}
+
+function cloudScreenerCategory(category: ScreenerCategory): CloudMarketScreenerCategory {
+  if (category === "day_gainers") return "gainers";
+  if (category === "day_losers") return "losers";
+  return "most-active";
+}
+
+function isCloudScreenerEligible(): boolean {
+  const user = apiClient.getCurrentUser();
+  return apiClient.isVerified() && hasProAccess(user);
+}
+
+const defaultPreferredMarketMoverSources: PreferredMarketMoverSources = {
+  isCloudEligible: isCloudScreenerEligible,
+  fetchCloud: (category, count, mode) => apiClient.getCloudMarketScreener(category, count, mode),
+  fetchYahoo: (category, count, options) => fetchScreener(category, count, undefined, options),
+};
+
+function mergeCloudScreenerItem(
+  item: CloudMarketScreenerItem,
+  metadata?: ScreenerQuote,
+): ScreenerQuote {
+  return {
+    symbol: item.symbol,
+    name: item.name && item.name !== item.symbol
+      ? item.name
+      : metadata?.name ?? item.symbol,
+    price: item.price,
+    change: item.change,
+    changePercent: item.changePercent,
+    volume: item.volume,
+    avgVolume: metadata?.avgVolume ?? 0,
+    volumeRatio: metadata?.avgVolume
+      ? item.volume / metadata.avgVolume
+      : 0,
+    marketCap: metadata?.marketCap,
+    currency: item.currency || metadata?.currency || "USD",
+    fiftyTwoWeekHigh: item.high52w ?? metadata?.fiftyTwoWeekHigh,
+    fiftyTwoWeekLow: item.low52w ?? metadata?.fiftyTwoWeekLow,
+    dayHigh: item.dayHigh ?? metadata?.dayHigh,
+    dayLow: item.dayLow ?? metadata?.dayLow,
+    exchange: item.exchange || metadata?.exchange || "",
+    lastUpdated: item.lastUpdated,
+  };
+}
+
+async function bestEffortYahooMetadata(
+  request: Promise<ScreenerQuote[]>,
+): Promise<ScreenerQuote[]> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      request.catch(() => []),
+      new Promise<ScreenerQuote[]>((resolve) => {
+        timeout = setTimeout(() => resolve([]), YAHOO_METADATA_WAIT_MS);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+export async function fetchPreferredMarketMovers(
+  category: ScreenerCategory,
+  count = 25,
+  options?: FetchCacheOptions,
+  sources: PreferredMarketMoverSources = defaultPreferredMarketMoverSources,
+): Promise<MarketMoversResult> {
+  if (!sources.isCloudEligible()) {
+    return {
+      quotes: await sources.fetchYahoo(category, count, options),
+      source: "yahoo",
+      stale: false,
+    };
+  }
+
+  const yahooMetadata = sources.fetchYahoo(
+    category,
+    Math.max(count, 50),
+    options,
+  );
+  try {
+    const response = await sources.fetchCloud(
+      cloudScreenerCategory(category),
+      count,
+      options?.forceRefresh ? "refresh" : "cache-first",
+    );
+    if (
+      (response.status === "success" || response.status === "partial")
+      && response.data
+      && response.data.items.length > 0
+    ) {
+      const metadata = await bestEffortYahooMetadata(yahooMetadata);
+      const metadataBySymbol = new Map(metadata.map((quote) => [quote.symbol, quote]));
+      return {
+        quotes: response.data.items.map((item) => (
+          mergeCloudScreenerItem(item, metadataBySymbol.get(item.symbol))
+        )),
+        source: "cloud",
+        stale: response.stale === true || response.data.stale === true,
+      };
+    }
+  } catch {
+    // Yahoo remains the resilient fallback when Cloud is unavailable.
+  }
+
+  return {
+    quotes: await yahooMetadata,
+    source: "yahoo",
+    stale: false,
+  };
 }
 
 export function parseTrendingResponse(data: any): TrendingSymbol[] {

--- a/src/plugins/builtin/shared/screener-live-quotes.test.ts
+++ b/src/plugins/builtin/shared/screener-live-quotes.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import type { Quote } from "../../../types/financials";
+import { buildQuoteKey } from "../../../market-data/selectors";
+import type { QueryEntry } from "../../../market-data/result-types";
+import {
+  buildScreenerQuoteTargets,
+  overlayScreenerQuoteEntries,
+  resolveScreenerQuoteFeedStatus,
+} from "./screener-live-quotes";
+
+function readyEntry(quote: Quote): QueryEntry<Quote> {
+  return {
+    phase: "ready",
+    data: quote,
+    lastGoodData: quote,
+    source: "gloomberb-cloud",
+    fetchedAt: quote.receivedAt ?? null,
+    staleAt: null,
+    error: null,
+    attempts: [],
+  };
+}
+
+describe("screener live quotes", () => {
+  test("overlays dynamic quote fields without replacing screener metadata", () => {
+    const rows = [{
+      symbol: "AAPL",
+      name: "Apple Inc.",
+      price: 190,
+      change: 1,
+      changePercent: 0.5,
+      volume: 10,
+      currency: "USD",
+      exchange: "NASDAQ",
+      lastUpdated: 100,
+      size: 3_000_000_000_000,
+    }];
+    const quote: Quote = {
+      symbol: "AAPL",
+      price: 192,
+      change: 3,
+      changePercent: 1.59,
+      volume: 20,
+      currency: "USD",
+      lastUpdated: 200,
+      dataSource: "live",
+    };
+    const entries = new Map([
+      [buildQuoteKey({ symbol: "AAPL", exchange: "NASDAQ" }), readyEntry(quote)],
+    ]);
+
+    expect(overlayScreenerQuoteEntries(rows, entries)[0]).toMatchObject({
+      name: "Apple Inc.",
+      price: 192,
+      changePercent: 1.59,
+      volume: 20,
+      size: 3_000_000_000_000,
+    });
+  });
+
+  test("marks complete fresh Cloud stream coverage as live", () => {
+    const now = 1_000;
+    const rows = [
+      { symbol: "AAPL", exchange: "NASDAQ" },
+      { symbol: "MSFT", exchange: "NASDAQ" },
+    ];
+    const targets = buildScreenerQuoteTargets(rows, "AAPL");
+    const entries = new Map<string, QueryEntry<Quote>>();
+    for (const row of rows) {
+      const quote: Quote = {
+        symbol: row.symbol,
+        price: 200,
+        change: 1,
+        changePercent: 0.5,
+        currency: "USD",
+        lastUpdated: now,
+        receivedAt: now,
+        delivery: "stream",
+        stale: false,
+        dataSource: "live",
+      };
+      entries.set(buildQuoteKey(row), readyEntry(quote));
+    }
+
+    expect(targets[0]).toMatchObject({ selected: true, weight: 100 });
+    expect(resolveScreenerQuoteFeedStatus(targets, entries, {
+      now,
+      subscriptionStartedAt: 900,
+    })).toBe("live");
+  });
+});

--- a/src/plugins/builtin/shared/screener-live-quotes.ts
+++ b/src/plugins/builtin/shared/screener-live-quotes.ts
@@ -1,0 +1,134 @@
+import type { QuoteSubscriptionTarget } from "../../../types/data-provider";
+import type { Quote } from "../../../types/financials";
+import { buildQuoteKey, resolveEntryData } from "../../../market-data/selectors";
+import type { QueryEntry } from "../../../market-data/result-types";
+
+const STREAM_FRESHNESS_MS = 2 * 60_000;
+const STREAM_CONNECTING_GRACE_MS = 15_000;
+
+export interface ScreenerQuoteRow {
+  symbol: string;
+  name: string;
+  price: number;
+  change: number;
+  changePercent: number;
+  volume: number | null;
+  currency: string;
+  exchange: string;
+  lastUpdated?: number;
+}
+
+export interface ScreenerQuoteFreshness {
+  now: number;
+  subscriptionStartedAt: number;
+}
+
+export type ScreenerQuoteFeedStatus = "live" | "mixed" | "connecting" | "polling";
+
+export function buildScreenerQuoteTargets(
+  rows: readonly Pick<ScreenerQuoteRow, "symbol" | "exchange">[],
+  selectedSymbol: string | null,
+): QuoteSubscriptionTarget[] {
+  return rows.map((row) => ({
+    symbol: row.symbol,
+    exchange: row.exchange,
+    surface: "screener",
+    visible: true,
+    selected: row.symbol === selectedSymbol,
+    weight: row.symbol === selectedSymbol ? 100 : 70,
+  }));
+}
+
+function quoteKey(row: Pick<ScreenerQuoteRow, "symbol" | "exchange">): string {
+  return buildQuoteKey({ symbol: row.symbol, exchange: row.exchange });
+}
+
+function finite(value: number | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+export function overlayScreenerQuoteEntries<T extends ScreenerQuoteRow>(
+  rows: readonly T[],
+  entries: ReadonlyMap<string, QueryEntry<Quote>>,
+): T[] {
+  return rows.map((row) => {
+    const quote = resolveEntryData(entries.get(quoteKey(row)));
+    if (!quote || !finite(quote.price)) return row;
+    if (
+      row.lastUpdated != null
+      && Number.isFinite(row.lastUpdated)
+      && quote.lastUpdated < row.lastUpdated
+    ) {
+      return row;
+    }
+
+    return {
+      ...row,
+      name: quote.name?.trim() || row.name,
+      price: quote.price,
+      change: finite(quote.change) ? quote.change : row.change,
+      changePercent: finite(quote.changePercent)
+        ? quote.changePercent
+        : row.changePercent,
+      volume: finite(quote.volume) ? quote.volume : row.volume,
+      currency: quote.currency || row.currency,
+      lastUpdated: quote.lastUpdated,
+    };
+  });
+}
+
+function freshQuote(
+  entry: QueryEntry<Quote> | undefined,
+  freshness: ScreenerQuoteFreshness,
+): Quote | null {
+  const quote = resolveEntryData(entry);
+  if (!quote || quote.stale === true) return null;
+  const receivedAt = quote.receivedAt ?? 0;
+  if (
+    !Number.isFinite(receivedAt)
+    || receivedAt < freshness.subscriptionStartedAt
+    || freshness.now - receivedAt > STREAM_FRESHNESS_MS
+  ) {
+    return null;
+  }
+  return quote;
+}
+
+export function resolveScreenerQuoteFeedStatus(
+  targets: readonly QuoteSubscriptionTarget[],
+  entries: ReadonlyMap<string, QueryEntry<Quote>>,
+  freshness: ScreenerQuoteFreshness,
+): ScreenerQuoteFeedStatus | null {
+  if (targets.length === 0) return null;
+  let liveCount = 0;
+  let fallbackCount = 0;
+
+  for (const target of targets) {
+    const quote = freshQuote(
+      entries.get(buildQuoteKey({
+        symbol: target.symbol,
+        exchange: target.exchange,
+      })),
+      freshness,
+    );
+    if (
+      quote?.dataSource === "live"
+      && quote.delivery === "stream"
+      && quote.stale === false
+    ) {
+      liveCount += 1;
+    } else if (quote) {
+      fallbackCount += 1;
+    }
+  }
+
+  if (liveCount === targets.length) return "live";
+  if (liveCount > 0) return "mixed";
+  if (
+    fallbackCount === 0
+    && freshness.now - freshness.subscriptionStartedAt < STREAM_CONNECTING_GRACE_MS
+  ) {
+    return "connecting";
+  }
+  return "polling";
+}

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -11,7 +11,6 @@ import {
   exchangeShortName,
   marketStateColor,
   marketStateLabel,
-  quoteSourceLabel,
 } from "../../../market-data/market/status";
 import { selectEffectiveExchangeRates } from "../../../utils/exchange-rate-map";
 import { EmptyState } from "../../../components";
@@ -74,15 +73,7 @@ export function OverviewTab({
     quote?.listingExchangeFullName ?? quote?.fullExchangeName,
   );
   const routingVenue = exchangeShortName(quote?.routingExchangeName, quote?.routingExchangeFullName);
-  const priceSource = quote?.provenance?.price ? quoteSourceLabel(quote.provenance.price, "price") : "";
-  const sessionSource = quote?.provenance?.session ? quoteSourceLabel(quote.provenance.session, "session") : "";
-  const sourceSummary = priceSource && sessionSource && priceSource !== sessionSource
-    ? `src ${priceSource}/${sessionSource}`
-    : priceSource || sessionSource
-      ? `src ${priceSource || sessionSource}`
-      : "";
   const metadataParts = [
-    sourceSummary,
     routingVenue && routingVenue !== listingVenue ? `route ${routingVenue}` : "",
   ].filter((part) => part.length > 0);
 
@@ -102,7 +93,6 @@ export function OverviewTab({
     style: "area",
     axis: "right",
     panelId: "price",
-    providerId: quote?.provenance?.price?.providerId ?? quote?.providerId,
     timeBasis: chartTimeZone ? { kind: "market", timeZone: chartTimeZone } : undefined,
   });
   const hasBidAsk = quote?.bid != null || quote?.ask != null;


### PR DESCRIPTION
## Summary

- prefer Cloud mover rankings for eligible accounts while retaining fallback metadata and resilience
- stream current quotes into Market Movers and Market Heatmap when live streaming is enabled
- poll once per minute when the pane's zap toggle is disabled
- refresh mover membership in the background once per minute
- keep provider routing invisible while showing only useful freshness states such as live, polling, and stale

## Impact

Pro users receive live Cloud-backed mover and heatmap prices. Other accounts continue through the existing fallback path. Market-data provider names are no longer exposed in pane errors, ticker Overview, or price-chart details.

Depends on vincelwt/gloomberb-platform#70 for the Cloud mover ranking endpoint.

## Validation

- `bun test` (1,879 passing)
- `bun run typecheck`
- terminal UI smoke for Market Movers and AAPL ticker Overview
