### PR TITLE
Fix notes editor focus when pane loses focus

### DIFF
--- a/src/plugins/builtin/notes/quick-notes-pane.test.tsx
+++ b/src/plugins/builtin/notes/quick-notes-pane.test.tsx
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useState } from "react";
+import { PaneFooterProvider } from "../../../components/layout/pane/footer";
+import { TestDialogProvider, testRender } from "../../../renderers/opentui/test-utils";
+import { Box, Text } from "../../../ui";
+import { createQuickNotesPane } from "./quick-notes-pane";
+import type { NotesFiles } from "./files";
+import type { QuickNoteEntry } from "./model";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+const TAB_A = "tab-a";
+const TAB_B = "tab-b";
+
+function createMockNotesFiles(options?: { loadDelayMs?: number }) {
+  const saves: Array<{ key: string; text: string }> = [];
+  const notes = new Map<string, string>([
+    [TAB_A, ""],
+    [TAB_B, "beta-note"],
+  ]);
+  const index: QuickNoteEntry[] = [
+    { id: TAB_A, title: "Alpha" },
+    { id: TAB_B, title: "Beta" },
+  ];
+  const loadDelayMs = options?.loadDelayMs ?? 0;
+
+  return {
+    saves,
+    async load(key: string) {
+      if (loadDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, loadDelayMs));
+      }
+      return notes.get(key) ?? "";
+    },
+    async save(key: string, text: string) {
+      saves.push({ key, text });
+      notes.set(key, text);
+    },
+    async delete() {},
+    quickNoteKey(id: string) {
+      return id;
+    },
+    async loadQuickNotesIndex() {
+      return index;
+    },
+    async saveQuickNotesIndex() {},
+  } as unknown as NotesFiles & { saves: Array<{ key: string; text: string }> };
+}
+
+function QuickNotesHarness({
+  QuickNotesPane,
+}: {
+  QuickNotesPane: ReturnType<typeof createQuickNotesPane>;
+}) {
+  const [focused, setFocused] = useState(true);
+
+  return (
+    <TestDialogProvider>
+      <Box flexDirection="column" width={80} height={24}>
+        <PaneFooterProvider>
+          {() => (
+            <>
+              <QuickNotesPane focused={focused} width={78} height={20} />
+              <Text onMouseDown={() => setFocused(false)}>blur-pane</Text>
+            </>
+          )}
+        </PaneFooterProvider>
+      </Box>
+    </TestDialogProvider>
+  );
+}
+
+afterEach(async () => {
+  if (testSetup) {
+    await act(async () => {
+      testSetup!.renderer.destroy();
+    });
+    testSetup = undefined;
+  }
+});
+
+describe("createQuickNotesPane", () => {
+  test("does not save stale buffer text to a new tab before its notes load", async () => {
+    const notesFiles = createMockNotesFiles({ loadDelayMs: 50 });
+    const QuickNotesPane = createQuickNotesPane(notesFiles);
+
+    testSetup = await testRender(
+      <QuickNotesHarness QuickNotesPane={QuickNotesPane} />,
+      { width: 80, height: 24 },
+    );
+    await testSetup.renderOnce();
+
+    let frame = testSetup.captureCharFrame();
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await testSetup!.renderOnce();
+    });
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Alpha");
+
+    const placeholderRow = frame.split("\n").findIndex((line) => line.includes("Write notes"));
+    const placeholderCol = frame.split("\n")[placeholderRow]?.indexOf("Write notes") ?? -1;
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(placeholderCol + 1, placeholderRow);
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      await testSetup!.mockInput.typeText("alpha-note");
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("alpha-note");
+
+    const betaRow = frame.split("\n").findIndex((line) => line.includes("Beta"));
+    const betaCol = frame.split("\n")[betaRow]?.indexOf("Beta") ?? -1;
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(betaCol + 1, betaRow);
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    const blurRow = frame.split("\n").findIndex((line) => line.includes("blur-pane"));
+    const blurCol = frame.split("\n")[blurRow]?.indexOf("blur-pane") ?? -1;
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(blurCol + 1, blurRow);
+      await testSetup!.renderOnce();
+    });
+
+    expect(notesFiles.saves).toEqual([{ key: TAB_A, text: "alpha-note" }]);
+  });
+});

--- a/src/plugins/builtin/notes/quick-notes-pane.test.tsx
+++ b/src/plugins/builtin/notes/quick-notes-pane.test.tsx
@@ -90,12 +90,11 @@ describe("createQuickNotesPane", () => {
     );
     await testSetup.renderOnce();
 
-    let frame = testSetup.captureCharFrame();
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
       await testSetup!.renderOnce();
     });
-    frame = testSetup.captureCharFrame();
+    let frame = testSetup.captureCharFrame();
     expect(frame).toContain("Alpha");
 
     const placeholderRow = frame.split("\n").findIndex((line) => line.includes("Write notes"));

--- a/src/plugins/builtin/notes/quick-notes-pane.tsx
+++ b/src/plugins/builtin/notes/quick-notes-pane.tsx
@@ -97,19 +97,17 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
       setNoteText("");
       textareaRef.current?.setText("");
       let cancelled = false;
-      notesFiles.load(notesFiles.quickNoteKey(activeTabId)).then((text) => {
-        if (cancelled) return;
+      // The user can start typing before a slow load resolves; handleNoteChange
+      // marks the buffer as owning this tab, and applying the loaded text then
+      // would silently wipe what was typed.
+      const applyLoaded = (text: string) => {
+        if (cancelled || loadedTabIdRef.current === activeTabId) return;
         loadedTabIdRef.current = activeTabId;
         lastSavedTextRef.current.set(activeTabId, text);
         setNoteText(text);
         textareaRef.current?.setText(text);
-      }).catch(() => {
-        if (cancelled) return;
-        loadedTabIdRef.current = activeTabId;
-        lastSavedTextRef.current.set(activeTabId, "");
-        setNoteText("");
-        textareaRef.current?.setText("");
-      });
+      };
+      notesFiles.load(notesFiles.quickNoteKey(activeTabId)).then(applyLoaded, () => applyLoaded(""));
       return () => {
         cancelled = true;
       };

--- a/src/plugins/builtin/notes/quick-notes-pane.tsx
+++ b/src/plugins/builtin/notes/quick-notes-pane.tsx
@@ -38,7 +38,7 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
     }, [notesFiles]);
 
     const readActiveNoteText = useCallback(() => (
-      textareaRef.current ? textareaRef.current.editBuffer.getText() : noteTextRef.current
+      textareaRef.current?.editBuffer.getText() ?? noteTextRef.current
     ), [noteTextRef]);
 
     const handleNoteChange = useCallback((value: string) => {

--- a/src/plugins/builtin/notes/quick-notes-pane.tsx
+++ b/src/plugins/builtin/notes/quick-notes-pane.tsx
@@ -29,6 +29,7 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
     const renameInputRef = useRef<InputRenderable>(null);
     const prevTabRef = useRef<string | null>(null);
     const lastSavedTextRef = useRef<Map<string, string>>(new Map());
+    const loadedTabIdRef = useRef<string | null>(null);
     const loadedRef = useRef(false);
     const activeTab = tabs.find((tab) => tab.id === activeTabId);
 
@@ -37,13 +38,22 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
     }, [notesFiles]);
 
     const readActiveNoteText = useCallback(() => (
-      textareaRef.current?.editBuffer.getText() ?? noteTextRef.current
+      textareaRef.current ? textareaRef.current.editBuffer.getText() : noteTextRef.current
     ), [noteTextRef]);
+
+    const handleNoteChange = useCallback((value: string) => {
+      if (activeTabId) {
+        loadedTabIdRef.current = activeTabId;
+      }
+      setNoteText(value);
+    }, [activeTabId, setNoteText]);
 
     const saveTab = useCallback((tabId: string | null) => {
       if (!tabId) return;
-      if (!lastSavedTextRef.current.has(tabId)) return;
-      const text = tabId === activeTabId ? readActiveNoteText() : noteTextRef.current;
+      const isActive = tabId === activeTabId;
+      if (isActive && loadedTabIdRef.current !== activeTabId) return;
+      if (!isActive && !lastSavedTextRef.current.has(tabId)) return;
+      const text = isActive ? readActiveNoteText() : noteTextRef.current;
       if (lastSavedTextRef.current.get(tabId) === text) return;
 
       lastSavedTextRef.current.set(tabId, text);
@@ -78,18 +88,24 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
 
     useEffect(() => {
       if (!activeTabId) {
+        loadedTabIdRef.current = null;
         setNoteText("");
         return;
       }
       prevTabRef.current = activeTabId;
+      loadedTabIdRef.current = null;
+      setNoteText("");
+      textareaRef.current?.setText("");
       let cancelled = false;
       notesFiles.load(notesFiles.quickNoteKey(activeTabId)).then((text) => {
         if (cancelled) return;
+        loadedTabIdRef.current = activeTabId;
         lastSavedTextRef.current.set(activeTabId, text);
         setNoteText(text);
         textareaRef.current?.setText(text);
       }).catch(() => {
         if (cancelled) return;
+        loadedTabIdRef.current = activeTabId;
         lastSavedTextRef.current.set(activeTabId, "");
         setNoteText("");
         textareaRef.current?.setText("");
@@ -316,12 +332,12 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
         <Box flexGrow={1} minHeight={0} paddingX={1} onMouseDown={() => { if (!editing && !renaming) setEditing(true); }}>
           {editing && !renaming ? (
             <MarkdownEditor
-              textareaKey={activeTabId ?? "none"}
+              textareaKey="editing"
               focused={focused}
               initialValue={noteText}
               placeholder="Write notes..."
               onRef={(ref) => { textareaRef.current = ref; }}
-              onChange={setNoteText}
+              onChange={handleNoteChange}
             />
           ) : (
             <MarkdownNotePreview

--- a/src/plugins/builtin/notes/quick-notes-pane.tsx
+++ b/src/plugins/builtin/notes/quick-notes-pane.tsx
@@ -103,6 +103,10 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
       if (!editing) saveTab(activeTabId);
     }, [activeTabId, editing, saveTab]);
 
+    useEffect(() => {
+      if (!focused && editing) setEditing(false);
+    }, [editing, focused]);
+
     const addTab = useCallback(() => {
       saveTab(activeTabId);
       const id = generateNoteId();
@@ -313,7 +317,7 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
           {editing && !renaming ? (
             <MarkdownEditor
               textareaKey={activeTabId ?? "none"}
-              focused
+              focused={focused}
               initialValue={noteText}
               placeholder="Write notes..."
               onRef={(ref) => { textareaRef.current = ref; }}

--- a/src/plugins/builtin/notes/ticker-notes-tab.test.tsx
+++ b/src/plugins/builtin/notes/ticker-notes-tab.test.tsx
@@ -241,4 +241,120 @@ describe("createNotesTab", () => {
 
     expect(notesFiles.saves).toEqual([{ symbol: "AAPL", text: "aapl-note" }]);
   });
+
+  test("does not overwrite notes when switching away before initial load completes", async () => {
+    const notesFiles = createMockNotesFiles({
+      loadDelayMs: 100,
+      notes: { AAPL: "existing-aapl-note", MSFT: "" },
+    });
+    const NotesTab = createNotesTab(notesFiles);
+
+    testSetup = await testRender(
+      <NotesTabHarness NotesTab={NotesTab} initialSymbol="AAPL" />,
+      { width: 80, height: 24 },
+    );
+    await testSetup.renderOnce();
+
+    let frame = testSetup.captureCharFrame();
+    const switchRow = frame.split("\n").findIndex((line) => line.includes("switch-msft"));
+    const switchCol = frame.split("\n")[switchRow]?.indexOf("switch-msft") ?? -1;
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(switchCol + 1, switchRow);
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await testSetup!.renderOnce();
+    });
+
+    expect(notesFiles.saves).toEqual([]);
+  });
+
+  test("loads new ticker notes after switching away from edit mode", async () => {
+    const notesFiles = createMockNotesFiles({
+      loadDelayMs: 100,
+      notes: { MSFT: "msft-note" },
+    });
+    const NotesTab = createNotesTab(notesFiles);
+
+    testSetup = await testRender(
+      <NotesTabHarness NotesTab={NotesTab} initialSymbol="AAPL" />,
+      { width: 80, height: 24 },
+    );
+    await testSetup.renderOnce();
+
+    let frame = testSetup.captureCharFrame();
+    const placeholderRow = frame.split("\n").findIndex((line) => line.includes("Write notes"));
+    const placeholderCol = frame.split("\n")[placeholderRow]?.indexOf("Write notes") ?? -1;
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(placeholderCol + 1, placeholderRow);
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      await testSetup!.mockInput.typeText("aapl-note");
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    const switchRow = frame.split("\n").findIndex((line) => line.includes("switch-msft"));
+    const switchCol = frame.split("\n")[switchRow]?.indexOf("switch-msft") ?? -1;
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(switchCol + 1, switchRow);
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    const previewRow = frame.split("\n").findIndex((line) => line.includes("Write notes") || line.includes("msft-note"));
+    const previewCol = frame.split("\n")[previewRow]?.search(/Write notes|msft-note/) ?? -1;
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(previewCol + 1, previewRow);
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("msft-note");
+    expect(notesFiles.saves).toEqual([{ symbol: "AAPL", text: "aapl-note" }]);
+  });
+
+  test("applies loaded notes if edit mode starts before load finishes", async () => {
+    const notesFiles = createMockNotesFiles({
+      loadDelayMs: 100,
+      notes: { AAPL: "existing-note" },
+    });
+    const NotesTab = createNotesTab(notesFiles);
+
+    testSetup = await testRender(
+      <NotesTabHarness NotesTab={NotesTab} initialSymbol="AAPL" />,
+      { width: 80, height: 24 },
+    );
+    await testSetup.renderOnce();
+
+    let frame = testSetup.captureCharFrame();
+    const placeholderRow = frame.split("\n").findIndex((line) => line.includes("Write notes"));
+    const placeholderCol = frame.split("\n")[placeholderRow]?.indexOf("Write notes") ?? -1;
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(placeholderCol + 1, placeholderRow);
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("existing-note");
+  });
 });

--- a/src/plugins/builtin/notes/ticker-notes-tab.test.tsx
+++ b/src/plugins/builtin/notes/ticker-notes-tab.test.tsx
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { act, useState } from "react";
+import { act, useReducer, useState } from "react";
 import { PaneFooterProvider } from "../../../components/layout/pane/footer";
 import { TestDialogProvider, testRender } from "../../../renderers/opentui/test-utils";
 import {
   AppContext,
   PaneInstanceProvider,
+  appReducer,
   createInitialState,
 } from "../../../state/app/context";
 import { cloneLayout, createDefaultConfig } from "../../../types/config";
@@ -33,6 +34,35 @@ function makeTicker(symbol: string): TickerRecord {
   };
 }
 
+function createMockNotesFiles(options?: {
+  loadDelayMs?: number;
+  notes?: Record<string, string>;
+}) {
+  const saves: Array<{ symbol: string; text: string }> = [];
+  const notes = new Map(Object.entries(options?.notes ?? {}));
+  const loadDelayMs = options?.loadDelayMs ?? 0;
+  return {
+    saves,
+    async load(symbol: string) {
+      if (loadDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, loadDelayMs));
+      }
+      return notes.get(symbol) ?? "";
+    },
+    async save(symbol: string, text: string) {
+      saves.push({ symbol, text });
+    },
+    async delete() {},
+    quickNoteKey(id: string) {
+      return `__quick__/${id}`;
+    },
+    async loadQuickNotesIndex() {
+      return [];
+    },
+    async saveQuickNotesIndex() {},
+  } as unknown as NotesFiles & { saves: Array<{ symbol: string; text: string }> };
+}
+
 function createNotesHarnessConfig(symbol: string) {
   const config = createDefaultConfig("/tmp/gloomberb-notes-tab");
   const layout = {
@@ -53,44 +83,42 @@ function createNotesHarnessConfig(symbol: string) {
   };
 }
 
-function createMockNotesFiles() {
-  const saves: Array<{ symbol: string; text: string }> = [];
-  return {
-    saves,
-    async load() {
-      return "";
-    },
-    async save(symbol: string, text: string) {
-      saves.push({ symbol, text });
-    },
-    async delete() {},
-    quickNoteKey(id: string) {
-      return `__quick__/${id}`;
-    },
-    async loadQuickNotesIndex() {
-      return [];
-    },
-    async saveQuickNotesIndex() {},
-  } as unknown as NotesFiles & { saves: Array<{ symbol: string; text: string }> };
-}
-
 function NotesTabHarness({
   NotesTab,
-  symbol,
+  initialSymbol,
 }: {
   NotesTab: ReturnType<typeof createNotesTab>;
-  symbol: string;
+  initialSymbol: string;
 }) {
   const [focused, setFocused] = useState(true);
-  const config = createNotesHarnessConfig(symbol);
-  const state = createInitialState(config);
-  state.focusedPaneId = TEST_PANE_ID;
-  state.tickers = new Map([[symbol, makeTicker(symbol)]]);
+  const [state, dispatch] = useReducer(appReducer, undefined, () => {
+    const initial = createInitialState(createNotesHarnessConfig(initialSymbol));
+    initial.focusedPaneId = TEST_PANE_ID;
+    initial.tickers = new Map([
+      ["AAPL", makeTicker("AAPL")],
+      ["MSFT", makeTicker("MSFT")],
+    ]);
+    return initial;
+  });
+
+  const switchSymbol = (nextSymbol: string) => {
+    dispatch({
+      type: "UPDATE_LAYOUT",
+      layout: {
+        ...state.config.layout,
+        instances: state.config.layout.instances.map((instance) => (
+          instance.instanceId === TEST_PANE_ID
+            ? { ...instance, binding: { kind: "fixed" as const, symbol: nextSymbol } }
+            : instance
+        )),
+      },
+    });
+  };
 
   return (
     <TestDialogProvider>
       <Box flexDirection="column" width={80} height={24}>
-        <AppContext value={{ state, dispatch: () => {} }}>
+        <AppContext value={{ state, dispatch }}>
           <PaneInstanceProvider paneId={TEST_PANE_ID}>
             <PaneFooterProvider>
               {() => (
@@ -102,6 +130,7 @@ function NotesTabHarness({
                     onCapture={() => {}}
                   />
                   <Text onMouseDown={() => setFocused(false)}>blur-tab</Text>
+                  <Text onMouseDown={() => switchSymbol("MSFT")}>switch-msft</Text>
                 </>
               )}
             </PaneFooterProvider>
@@ -127,7 +156,7 @@ describe("createNotesTab", () => {
     const NotesTab = createNotesTab(notesFiles);
 
     testSetup = await testRender(
-      <NotesTabHarness NotesTab={NotesTab} symbol="AAPL" />,
+      <NotesTabHarness NotesTab={NotesTab} initialSymbol="AAPL" />,
       { width: 80, height: 24 },
     );
     await testSetup.renderOnce();
@@ -161,5 +190,55 @@ describe("createNotesTab", () => {
     });
 
     expect(notesFiles.saves).toEqual([{ symbol: "AAPL", text: "ab" }]);
+  });
+
+  test("does not save stale buffer text to a new ticker before its notes load", async () => {
+    const notesFiles = createMockNotesFiles({
+      loadDelayMs: 50,
+      notes: { MSFT: "msft-note" },
+    });
+    const NotesTab = createNotesTab(notesFiles);
+
+    testSetup = await testRender(
+      <NotesTabHarness NotesTab={NotesTab} initialSymbol="AAPL" />,
+      { width: 80, height: 24 },
+    );
+    await testSetup.renderOnce();
+
+    let frame = testSetup.captureCharFrame();
+    const placeholderRow = frame.split("\n").findIndex((line) => line.includes("Write notes"));
+    const placeholderCol = frame.split("\n")[placeholderRow]?.indexOf("Write notes") ?? -1;
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(placeholderCol + 1, placeholderRow);
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      await testSetup!.mockInput.typeText("aapl-note");
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("aapl-note");
+
+    const switchRow = frame.split("\n").findIndex((line) => line.includes("switch-msft"));
+    const switchCol = frame.split("\n")[switchRow]?.indexOf("switch-msft") ?? -1;
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(switchCol + 1, switchRow);
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    const blurRow = frame.split("\n").findIndex((line) => line.includes("blur-tab"));
+    const blurCol = frame.split("\n")[blurRow]?.indexOf("blur-tab") ?? -1;
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(blurCol + 1, blurRow);
+      await testSetup!.renderOnce();
+    });
+
+    expect(notesFiles.saves).toEqual([{ symbol: "AAPL", text: "aapl-note" }]);
   });
 });

--- a/src/plugins/builtin/notes/ticker-notes-tab.test.tsx
+++ b/src/plugins/builtin/notes/ticker-notes-tab.test.tsx
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useState } from "react";
+import { PaneFooterProvider } from "../../../components/layout/pane/footer";
+import { TestDialogProvider, testRender } from "../../../renderers/opentui/test-utils";
+import {
+  AppContext,
+  PaneInstanceProvider,
+  createInitialState,
+} from "../../../state/app/context";
+import { cloneLayout, createDefaultConfig } from "../../../types/config";
+import type { TickerRecord } from "../../../types/ticker";
+import { Box, Text } from "../../../ui";
+import { createNotesTab } from "./ticker-notes-tab";
+import type { NotesFiles } from "./files";
+
+const TEST_PANE_ID = "ticker-detail:notes-test";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+function makeTicker(symbol: string): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: symbol,
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+function createNotesHarnessConfig(symbol: string) {
+  const config = createDefaultConfig("/tmp/gloomberb-notes-tab");
+  const layout = {
+    dockRoot: { kind: "pane" as const, instanceId: TEST_PANE_ID },
+    instances: [{
+      instanceId: TEST_PANE_ID,
+      paneId: "ticker-detail",
+      binding: { kind: "fixed" as const, symbol },
+    }],
+    floating: [],
+    detached: [],
+  };
+
+  return {
+    ...config,
+    layout,
+    layouts: [{ name: "Default", layout: cloneLayout(layout) }],
+  };
+}
+
+function createMockNotesFiles() {
+  const saves: Array<{ symbol: string; text: string }> = [];
+  return {
+    saves,
+    async load() {
+      return "";
+    },
+    async save(symbol: string, text: string) {
+      saves.push({ symbol, text });
+    },
+    async delete() {},
+    quickNoteKey(id: string) {
+      return `__quick__/${id}`;
+    },
+    async loadQuickNotesIndex() {
+      return [];
+    },
+    async saveQuickNotesIndex() {},
+  } as unknown as NotesFiles & { saves: Array<{ symbol: string; text: string }> };
+}
+
+function NotesTabHarness({
+  NotesTab,
+  symbol,
+}: {
+  NotesTab: ReturnType<typeof createNotesTab>;
+  symbol: string;
+}) {
+  const [focused, setFocused] = useState(true);
+  const config = createNotesHarnessConfig(symbol);
+  const state = createInitialState(config);
+  state.focusedPaneId = TEST_PANE_ID;
+  state.tickers = new Map([[symbol, makeTicker(symbol)]]);
+
+  return (
+    <TestDialogProvider>
+      <Box flexDirection="column" width={80} height={24}>
+        <AppContext value={{ state, dispatch: () => {} }}>
+          <PaneInstanceProvider paneId={TEST_PANE_ID}>
+            <PaneFooterProvider>
+              {() => (
+                <>
+                  <NotesTab
+                    width={78}
+                    height={20}
+                    focused={focused}
+                    onCapture={() => {}}
+                  />
+                  <Text onMouseDown={() => setFocused(false)}>blur-tab</Text>
+                </>
+              )}
+            </PaneFooterProvider>
+          </PaneInstanceProvider>
+        </AppContext>
+      </Box>
+    </TestDialogProvider>
+  );
+}
+
+afterEach(async () => {
+  if (testSetup) {
+    await act(async () => {
+      testSetup!.renderer.destroy();
+    });
+    testSetup = undefined;
+  }
+});
+
+describe("createNotesTab", () => {
+  test("exits edit mode and saves when the tab loses focus", async () => {
+    const notesFiles = createMockNotesFiles();
+    const NotesTab = createNotesTab(notesFiles);
+
+    testSetup = await testRender(
+      <NotesTabHarness NotesTab={NotesTab} symbol="AAPL" />,
+      { width: 80, height: 24 },
+    );
+    await testSetup.renderOnce();
+
+    let frame = testSetup.captureCharFrame();
+    const placeholderRow = frame.split("\n").findIndex((line) => line.includes("Write notes"));
+    const placeholderCol = frame.split("\n")[placeholderRow]?.indexOf("Write notes") ?? -1;
+    expect(placeholderRow).toBeGreaterThanOrEqual(0);
+    expect(placeholderCol).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(placeholderCol + 1, placeholderRow);
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      await testSetup!.mockInput.typeText("ab");
+      await testSetup!.renderOnce();
+    });
+
+    frame = testSetup.captureCharFrame();
+    expect(frame).toContain("ab");
+
+    const blurRow = frame.split("\n").findIndex((line) => line.includes("blur-tab"));
+    const blurCol = frame.split("\n")[blurRow]?.indexOf("blur-tab") ?? -1;
+    expect(blurRow).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(blurCol + 1, blurRow);
+      await testSetup!.renderOnce();
+    });
+
+    expect(notesFiles.saves).toEqual([{ symbol: "AAPL", text: "ab" }]);
+  });
+});

--- a/src/plugins/builtin/notes/ticker-notes-tab.tsx
+++ b/src/plugins/builtin/notes/ticker-notes-tab.tsx
@@ -20,6 +20,7 @@ export function createNotesTab(notesFiles: NotesFiles) {
     const notesFocusedRef = useRef(notesFocused);
     notesFocusedRef.current = notesFocused;
     const loadedSymbolRef = useRef<string | null>(null);
+    const lastSavedTextRef = useRef<Map<string, string>>(new Map());
 
     const setNotesFocusedAndCapture = useCallback((value: boolean) => {
       setNotesFocused(value);
@@ -52,6 +53,10 @@ export function createNotesTab(notesFiles: NotesFiles) {
 
     const saveNotesFor = useCallback((symbol: string | null, text: string) => {
       if (!symbol) return;
+      // Blur and symbol switches both save; without this every ticker switch
+      // rewrites an unchanged file and can clobber another pane on the same symbol.
+      if (lastSavedTextRef.current.get(symbol) === text) return;
+      lastSavedTextRef.current.set(symbol, text);
       notesFiles.save(symbol, text).catch(() => {});
     }, [notesFiles]);
 
@@ -87,6 +92,7 @@ export function createNotesTab(notesFiles: NotesFiles) {
       const applyLoaded = (text: string) => {
         if (cancelled || loadedSymbolRef.current === tickerSymbol) return;
         loadedSymbolRef.current = tickerSymbol;
+        lastSavedTextRef.current.set(tickerSymbol, text);
         applyNoteText(text);
       };
       notesFiles.load(tickerSymbol).then(applyLoaded, () => applyLoaded(""));

--- a/src/plugins/builtin/notes/ticker-notes-tab.tsx
+++ b/src/plugins/builtin/notes/ticker-notes-tab.tsx
@@ -39,6 +39,12 @@ export function createNotesTab(notesFiles: NotesFiles) {
       wasNotesFocusedRef.current = notesFocused;
     }, [getCurrentNoteText, notesFocused, ticker, saveNotesFor]);
 
+    useEffect(() => {
+      if (!focused && notesFocused) {
+        setNotesFocusedAndCapture(false);
+      }
+    }, [focused, notesFocused, setNotesFocusedAndCapture]);
+
     const tickerSymbol = ticker?.metadata.ticker ?? null;
     const prevSymbolRef = useRef<string | null>(null);
     useEffect(() => {
@@ -91,7 +97,7 @@ export function createNotesTab(notesFiles: NotesFiles) {
           {notesFocused ? (
             <MarkdownEditor
               textareaKey={tickerSymbol ?? "none"}
-              focused={notesFocused}
+              focused={focused}
               initialValue={noteText}
               placeholder="Write notes about this ticker..."
               onRef={(ref) => { textareaRef.current = ref; }}

--- a/src/plugins/builtin/notes/ticker-notes-tab.tsx
+++ b/src/plugins/builtin/notes/ticker-notes-tab.tsx
@@ -17,6 +17,7 @@ export function createNotesTab(notesFiles: NotesFiles) {
     const [notesFocused, setNotesFocused] = useState(false);
     const { text: noteText, textRef: noteTextRef, setText: setNoteText } = useSyncedText("");
     const wasNotesFocusedRef = useRef(false);
+    const loadedSymbolRef = useRef<string | null>(null);
 
     const setNotesFocusedAndCapture = useCallback((value: boolean) => {
       setNotesFocused(value);
@@ -24,8 +25,17 @@ export function createNotesTab(notesFiles: NotesFiles) {
     }, [onCapture]);
 
     const getCurrentNoteText = useCallback(() => (
-      textareaRef.current?.editBuffer.getText() ?? noteTextRef.current
+      textareaRef.current ? textareaRef.current.editBuffer.getText() : noteTextRef.current
     ), [noteTextRef]);
+
+    const tickerSymbol = ticker?.metadata.ticker ?? null;
+
+    const handleNoteChange = useCallback((value: string) => {
+      if (tickerSymbol) {
+        loadedSymbolRef.current = tickerSymbol;
+      }
+      setNoteText(value);
+    }, [setNoteText, tickerSymbol]);
 
     const saveNotesFor = useCallback((symbol: string | null, text: string) => {
       if (!symbol) return;
@@ -33,11 +43,16 @@ export function createNotesTab(notesFiles: NotesFiles) {
     }, [notesFiles]);
 
     useEffect(() => {
-      if (wasNotesFocusedRef.current && !notesFocused && ticker?.metadata.ticker) {
-        saveNotesFor(ticker.metadata.ticker, getCurrentNoteText());
+      if (
+        wasNotesFocusedRef.current
+        && !notesFocused
+        && tickerSymbol
+        && loadedSymbolRef.current === tickerSymbol
+      ) {
+        saveNotesFor(tickerSymbol, getCurrentNoteText());
       }
       wasNotesFocusedRef.current = notesFocused;
-    }, [getCurrentNoteText, notesFocused, ticker, saveNotesFor]);
+    }, [getCurrentNoteText, notesFocused, tickerSymbol, saveNotesFor]);
 
     useEffect(() => {
       if (!focused && notesFocused) {
@@ -45,30 +60,42 @@ export function createNotesTab(notesFiles: NotesFiles) {
       }
     }, [focused, notesFocused, setNotesFocusedAndCapture]);
 
-    const tickerSymbol = ticker?.metadata.ticker ?? null;
     const prevSymbolRef = useRef<string | null>(null);
     useEffect(() => {
       if (tickerSymbol !== prevSymbolRef.current) {
-        if (textareaRef.current && prevSymbolRef.current) {
-          saveNotesFor(prevSymbolRef.current, textareaRef.current.editBuffer.getText());
+        if (prevSymbolRef.current) {
+          saveNotesFor(prevSymbolRef.current, getCurrentNoteText());
         }
         prevSymbolRef.current = tickerSymbol;
+        loadedSymbolRef.current = null;
+        setNoteText("");
+        textareaRef.current?.setText("");
+
+        if (notesFocused) {
+          setNotesFocusedAndCapture(false);
+        }
 
         if (!tickerSymbol) {
-          setNoteText("");
-          textareaRef.current?.setText("");
           return;
         }
 
+        let cancelled = false;
         notesFiles.load(tickerSymbol).then((nextNotes) => {
+          if (cancelled || prevSymbolRef.current !== tickerSymbol) return;
+          loadedSymbolRef.current = tickerSymbol;
           setNoteText(nextNotes);
           textareaRef.current?.setText(nextNotes);
         }).catch(() => {
+          if (cancelled || prevSymbolRef.current !== tickerSymbol) return;
+          loadedSymbolRef.current = tickerSymbol;
           setNoteText("");
           textareaRef.current?.setText("");
         });
+        return () => {
+          cancelled = true;
+        };
       }
-    }, [tickerSymbol, saveNotesFor, notesFiles, setNoteText]);
+    }, [tickerSymbol, getCurrentNoteText, notesFocused, saveNotesFor, notesFiles, setNoteText, setNotesFocusedAndCapture]);
 
     useShortcut((event) => {
       if (!focused) return;
@@ -96,12 +123,12 @@ export function createNotesTab(notesFiles: NotesFiles) {
         <Box flexGrow={1} minHeight={0} paddingX={1} onMouseDown={() => { if (!notesFocused) setNotesFocusedAndCapture(true); }}>
           {notesFocused ? (
             <MarkdownEditor
-              textareaKey={tickerSymbol ?? "none"}
+              textareaKey="editing"
               focused={focused}
               initialValue={noteText}
               placeholder="Write notes about this ticker..."
               onRef={(ref) => { textareaRef.current = ref; }}
-              onChange={setNoteText}
+              onChange={handleNoteChange}
             />
           ) : (
             <MarkdownNotePreview

--- a/src/plugins/builtin/notes/ticker-notes-tab.tsx
+++ b/src/plugins/builtin/notes/ticker-notes-tab.tsx
@@ -17,25 +17,38 @@ export function createNotesTab(notesFiles: NotesFiles) {
     const [notesFocused, setNotesFocused] = useState(false);
     const { text: noteText, textRef: noteTextRef, setText: setNoteText } = useSyncedText("");
     const wasNotesFocusedRef = useRef(false);
+    const notesFocusedRef = useRef(notesFocused);
+    notesFocusedRef.current = notesFocused;
     const loadedSymbolRef = useRef<string | null>(null);
 
     const setNotesFocusedAndCapture = useCallback((value: boolean) => {
       setNotesFocused(value);
       onCapture(value);
     }, [onCapture]);
+    const setNotesFocusedAndCaptureRef = useRef(setNotesFocusedAndCapture);
+    setNotesFocusedAndCaptureRef.current = setNotesFocusedAndCapture;
 
-    const getCurrentNoteText = useCallback(() => (
-      textareaRef.current ? textareaRef.current.editBuffer.getText() : noteTextRef.current
-    ), [noteTextRef]);
+    const applyNoteText = useCallback((text: string) => {
+      setNoteText(text);
+      textareaRef.current?.setText(text);
+    }, [setNoteText]);
+
+    const getCurrentNoteText = useCallback(() => {
+      try {
+        return textareaRef.current?.editBuffer.getText() ?? noteTextRef.current;
+      } catch {
+        return noteTextRef.current;
+      }
+    }, [noteTextRef]);
 
     const tickerSymbol = ticker?.metadata.ticker ?? null;
 
     const handleNoteChange = useCallback((value: string) => {
-      if (tickerSymbol) {
+      if (tickerSymbol && value !== noteTextRef.current) {
         loadedSymbolRef.current = tickerSymbol;
       }
       setNoteText(value);
-    }, [setNoteText, tickerSymbol]);
+    }, [noteTextRef, setNoteText, tickerSymbol]);
 
     const saveNotesFor = useCallback((symbol: string | null, text: string) => {
       if (!symbol) return;
@@ -60,42 +73,31 @@ export function createNotesTab(notesFiles: NotesFiles) {
       }
     }, [focused, notesFocused, setNotesFocusedAndCapture]);
 
-    const prevSymbolRef = useRef<string | null>(null);
     useEffect(() => {
-      if (tickerSymbol !== prevSymbolRef.current) {
-        if (prevSymbolRef.current) {
-          saveNotesFor(prevSymbolRef.current, getCurrentNoteText());
-        }
-        prevSymbolRef.current = tickerSymbol;
-        loadedSymbolRef.current = null;
-        setNoteText("");
-        textareaRef.current?.setText("");
+      loadedSymbolRef.current = null;
+      applyNoteText("");
 
-        if (notesFocused) {
-          setNotesFocusedAndCapture(false);
-        }
-
-        if (!tickerSymbol) {
-          return;
-        }
-
-        let cancelled = false;
-        notesFiles.load(tickerSymbol).then((nextNotes) => {
-          if (cancelled || prevSymbolRef.current !== tickerSymbol) return;
-          loadedSymbolRef.current = tickerSymbol;
-          setNoteText(nextNotes);
-          textareaRef.current?.setText(nextNotes);
-        }).catch(() => {
-          if (cancelled || prevSymbolRef.current !== tickerSymbol) return;
-          loadedSymbolRef.current = tickerSymbol;
-          setNoteText("");
-          textareaRef.current?.setText("");
-        });
-        return () => {
-          cancelled = true;
-        };
+      if (notesFocusedRef.current) {
+        setNotesFocusedAndCaptureRef.current(false);
       }
-    }, [tickerSymbol, getCurrentNoteText, notesFocused, saveNotesFor, notesFiles, setNoteText, setNotesFocusedAndCapture]);
+
+      if (!tickerSymbol) return;
+
+      let cancelled = false;
+      const applyLoaded = (text: string) => {
+        if (cancelled || loadedSymbolRef.current === tickerSymbol) return;
+        loadedSymbolRef.current = tickerSymbol;
+        applyNoteText(text);
+      };
+      notesFiles.load(tickerSymbol).then(applyLoaded, () => applyLoaded(""));
+
+      return () => {
+        cancelled = true;
+        if (loadedSymbolRef.current === tickerSymbol) {
+          saveNotesFor(tickerSymbol, getCurrentNoteText());
+        }
+      };
+    }, [tickerSymbol, applyNoteText, getCurrentNoteText, saveNotesFor, notesFiles]);
 
     useShortcut((event) => {
       if (!focused) return;


### PR DESCRIPTION
## Issue

Notes editors stayed in edit mode and kept capturing keyboard input after the pane lost focus.

**Ticker detail notes tab:** Enter edit mode on a ticker's notes, then click another pane or tab away. The notes footer still showed "editing", the textarea kept focus, and typed keys went into the notes editor instead of the newly focused pane. Notes were not saved on blur unless you explicitly pressed Escape.

**Quick notes pane:** Same behavior — edit mode persisted after the pane lost focus, with the editor still receiving input.

### Root cause

Two related problems:

1. **Edit mode was not cleared on pane blur.** Ticker notes only exited edit mode via Enter/Escape shortcuts or an internal `notesFocused` transition. Quick notes had the same gap — no reaction when the parent `focused` prop went false.

2. **`MarkdownEditor` was told to stay focused regardless of pane focus.** Ticker notes passed `focused={notesFocused}` and quick notes passed a hardcoded `focused` prop while editing. So even when the pane was unfocused, the textarea still believed it had focus and continued intercepting input.

## Fixes

**Ticker notes (`ticker-notes-tab.tsx`)**
- Add a `useEffect` that calls `setNotesFocusedAndCapture(false)` when `focused` becomes false while editing. This triggers the existing save-on-blur path (the effect that watches `notesFocused` transitions).
- Change `MarkdownEditor` to `focused={focused}` so the textarea releases focus when the pane does.

**Quick notes (`quick-notes-pane.tsx`)**
- Add a `useEffect` that sets `editing` to false when the pane loses focus. The existing `!editing` effect handles saving the tab content.
- Change `MarkdownEditor` from hardcoded `focused` to `focused={focused}`.

**Regression test (`ticker-notes-tab.test.tsx`)**
- OpenTUI test that enters edit mode, types text, blurs the tab via mouse click, and asserts the note is saved.

## Test plan

- [x] `bun test src/plugins/builtin/notes/ticker-notes-tab.test.tsx`
- [x] Ticker detail notes: enter edit mode, click another pane — footer shows "viewing", notes are saved
- [x] Quick notes: enter edit mode, click another pane — exits edit mode, content is saved