### PR TITLE
Validate URL scheme before opening external links

### DIFF
--- a/src/components/ui/external-link.test.ts
+++ b/src/components/ui/external-link.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { openUrl } from "./external-link";
+
+const spawnSpy = spyOn(Bun, "spawn").mockImplementation(
+  (() => ({ unref: () => {}, exited: Promise.resolve(0) })) as any,
+);
+
+afterEach(() => {
+  spawnSpy.mockClear();
+});
+
+describe("openUrl scheme validation", () => {
+  test("opens https URLs", () => {
+    openUrl("https://example.com");
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("opens http URLs", () => {
+    openUrl("http://example.com");
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects file:// URLs without spawning", () => {
+    openUrl("file:///etc/passwd");
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  test("rejects javascript: URLs without spawning", () => {
+    openUrl("javascript:alert(1)");
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  test("rejects empty strings without spawning", () => {
+    openUrl("");
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  test("rejects malformed URLs without spawning", () => {
+    openUrl("not-a-url");
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/external-link.tsx
+++ b/src/components/ui/external-link.tsx
@@ -6,6 +6,14 @@ import { linkContextMenuItems, useContextMenu, useRendererHost, useUiCapabilitie
 export function openUrl(url: string) {
   if (!url.trim()) return;
 
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return;
+
   const browserWindow = (globalThis as { window?: { open?: (url: string, target?: string, features?: string) => void } }).window;
   if (typeof browserWindow?.open === "function") {
     browserWindow.open(url, "_blank", "noopener,noreferrer");

--- a/src/renderers/opentui/host.tsx
+++ b/src/renderers/opentui/host.tsx
@@ -96,6 +96,14 @@ export async function createOpenTuiHost(): Promise<OpenTuiHost> {
   const rendererHost: RendererHost = {
     requestExit: () => renderer.destroy(),
     async openExternal(url) {
+      let parsed: URL;
+      try {
+        parsed = new URL(url);
+      } catch {
+        return;
+      }
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return;
+
       const command = process.platform === "darwin"
         ? ["open", url]
         : process.platform === "win32"


### PR DESCRIPTION
Security: reject non-http(s) URLs in openUrl/openExternal to prevent javascript:/data: scheme attacks.