### PR TITLE
Replace O(n²) referencePoint scan with binary search

### DIFF
--- a/src/time-series/transforms.test.ts
+++ b/src/time-series/transforms.test.ts
@@ -61,6 +61,79 @@ describe("series transformations", () => {
     expect(values[1]).toBe(0);
     expect(values[2]).toBeCloseTo(1, 12);
   });
+
+  test("yoy returns null for every point when no observation is near the 12-month target", () => {
+    const points = [
+      point("2024-01-01", 100),
+      point("2024-02-01", 110),
+      point("2024-03-01", 120),
+    ];
+    expect(applySeriesTransform(points, "yoy").map(({ value }) => value)).toEqual(
+      [null, null, null],
+    );
+  });
+
+  test("yoy finds a reference at the exact 12-month boundary", () => {
+    const points = [
+      point("2023-01-01", 100),
+      point("2023-02-01", 110),
+      point("2023-03-01", 120),
+      point("2023-04-01", 130),
+      point("2023-05-01", 140),
+      point("2023-06-01", 150),
+      point("2023-07-01", 160),
+      point("2023-08-01", 170),
+      point("2023-09-01", 180),
+      point("2023-10-01", 190),
+      point("2023-11-01", 200),
+      point("2023-12-01", 210),
+      point("2024-01-01", 220),
+    ];
+    const values = applySeriesTransform(points, "yoy").map(({ value }) => value);
+    expect(values[0]).toBeNull();
+    expect(values[12]).toBeCloseTo(120, 10);
+  });
+
+  test("yoy handles 1000 daily points without timing out", () => {
+    const start = new Date("2004-01-01T00:00:00Z");
+    const points = Array.from({ length: 1000 }, (_, i) => {
+      const d = new Date(start);
+      d.setUTCDate(d.getUTCDate() + i);
+      const iso = d.toISOString().slice(0, 10);
+      return point(iso, 100 + Math.sin(i / 10) * 10);
+    });
+    const result = applySeriesTransform(points, "yoy");
+    expect(result).toHaveLength(1000);
+    expect(result[999]!.value).not.toBeNull();
+  });
+
+  test("yoy tie-breaks duplicate timestamps by preferring the later date", () => {
+    const points = [
+      point("2023-06-15", 100),
+      point("2024-06-15", 180),
+      point("2023-06-15", 120),
+      point("2024-06-15", 200),
+    ];
+    const values = applySeriesTransform(points, "yoy").map(({ value }) => value);
+    const sortedPoints = [...points].sort(
+      (a, b) => a.observedAt.getTime() - b.observedAt.getTime(),
+    );
+    const reference = sortedPoints.find((p) => p.observedAt.getTime() === new Date("2023-06-15T00:00:00Z").getTime());
+    expect(reference).toBeDefined();
+    const expected = ((200 - reference!.value) / Math.abs(reference!.value)) * 100;
+    const last = values[values.length - 1];
+    expect(last).toBeCloseTo(expected, 10);
+  });
+
+  test("yoy returns null when gaps exceed the tolerance window", () => {
+    const points = [
+      point("2022-01-01", 100),
+      point("2024-06-01", 150),
+    ];
+    expect(applySeriesTransform(points, "yoy").map(({ value }) => value)).toEqual(
+      [null, null],
+    );
+  });
 });
 
 describe("market aggregation", () => {

--- a/src/time-series/transforms.ts
+++ b/src/time-series/transforms.ts
@@ -59,17 +59,44 @@ function referencePoint(
   if (!current) return null;
   const currentTime = current.observedAt.getTime();
   const target = shiftUtcMonths(current.observedAt, months).getTime();
+  const maxDistance = toleranceDays * DAY_MS;
+
+  // Binary search for the insertion point of target in points[0..currentIndex),
+  // which is sorted ascending by observedAt.
+  let lo = 0;
+  let hi = currentIndex;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (points[mid]!.observedAt.getTime() < target) lo = mid + 1;
+    else hi = mid;
+  }
+
   let best: { point: TimeSeriesPoint; distance: number; date: number } | null = null;
-  for (let index = 0; index < currentIndex; index += 1) {
-    const candidate = points[index]!;
+
+  // Scan left from the insertion point — distances increase as we go back.
+  for (let i = lo - 1; i >= 0; i -= 1) {
+    const candidate = points[i]!;
     const candidateTime = candidate.observedAt.getTime();
     if (!Number.isFinite(candidateTime) || candidateTime >= currentTime) continue;
-    const distance = Math.abs(candidateTime - target);
-    if (distance > toleranceDays * DAY_MS) continue;
+    const distance = target - candidateTime;
+    if (distance > maxDistance) break;
     if (!best || distance < best.distance || (distance === best.distance && candidateTime > best.date)) {
       best = { point: candidate, distance, date: candidateTime };
     }
   }
+
+  // Scan right from the insertion point — distances increase as we go forward.
+  for (let i = lo; i < currentIndex; i += 1) {
+    const candidate = points[i]!;
+    const candidateTime = candidate.observedAt.getTime();
+    if (!Number.isFinite(candidateTime) || candidateTime >= currentTime) continue;
+    const distance = candidateTime - target;
+    if (distance > maxDistance) break;
+    if (!best || distance < best.distance || (distance === best.distance && candidateTime > best.date)) {
+      best = { point: candidate, distance, date: candidateTime };
+    }
+  }
+
   return best?.point ?? null;
 }
 


### PR DESCRIPTION
Performance: binary search in time-series transforms referencePoint, reducing O(n²) to O(n log n).