### PR TITLE
Replace mergePriceHistoryWindows re-sort with two-pointer merge

### DIFF
--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -3,7 +3,7 @@ import type { FredSeriesData, FredSeriesLoadResult } from "../data/fred-series";
 import { createTestDataProvider } from "../test-support/data-provider";
 import type { TickerFinancials } from "../types/financials";
 import { CHART_SPEC_VERSION, type ChartSpec } from "./types";
-import { ChartResolveCache, resolveChartSpecData } from "./resolve";
+import { ChartResolveCache, mergePriceHistoryWindows, resolveChartSpecData } from "./resolve";
 import { chartQuoteOverrideKeyForSource } from "./live-quotes";
 
 const emptyFinancials = (): TickerFinancials => ({
@@ -1685,5 +1685,65 @@ describe("resolveChartSpecData", () => {
     });
     expect(result.series.find((series) => series.id === "sma")?.points.map((point) => point.value))
       .toEqual([10]);
+  });
+});
+
+describe("mergePriceHistoryWindows", () => {
+  const pp = (date: string, close: number) => ({ date: new Date(date), close });
+
+  test("merges two non-overlapping sorted windows in order", () => {
+    const current = [pp("2025-01-01T00:00:00Z", 100), pp("2025-01-03T00:00:00Z", 102)];
+    const incoming = [pp("2025-01-02T00:00:00Z", 101), pp("2025-01-04T00:00:00Z", 103)];
+    const merged = mergePriceHistoryWindows(current, incoming);
+    expect(merged.map((p) => p.date.getTime())).toEqual([
+      Date.parse("2025-01-01T00:00:00Z"),
+      Date.parse("2025-01-02T00:00:00Z"),
+      Date.parse("2025-01-03T00:00:00Z"),
+      Date.parse("2025-01-04T00:00:00Z"),
+    ]);
+  });
+
+  test("incoming overrides current for overlapping timestamps", () => {
+    const current = [pp("2025-01-01T00:00:00Z", 100), pp("2025-01-02T00:00:00Z", 200)];
+    const incoming = [pp("2025-01-02T00:00:00Z", 101), pp("2025-01-03T00:00:00Z", 103)];
+    const merged = mergePriceHistoryWindows(current, incoming);
+    expect(merged).toHaveLength(3);
+    expect(merged.find((p) => p.date.getTime() === Date.parse("2025-01-02T00:00:00Z"))?.close).toBe(101);
+  });
+
+  test("creates a Date instance for points missing one", () => {
+    const current = [{ date: "2025-01-01T00:00:00Z" as unknown as Date, close: 100 }];
+    const incoming: TickerFinancials["priceHistory"] = [];
+    const merged = mergePriceHistoryWindows(current, incoming);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.date).toBeInstanceOf(Date);
+    expect(merged[0]!.date.getTime()).toBe(Date.parse("2025-01-01T00:00:00Z"));
+  });
+
+  test("drops points with non-finite timestamps", () => {
+    const current = [
+      { date: new Date(Number.NaN), close: 100 },
+      pp("2025-01-02T00:00:00Z", 102),
+    ];
+    const incoming = [pp("2025-01-01T00:00:00Z", 101)];
+    const merged = mergePriceHistoryWindows(current, incoming);
+    expect(merged).toHaveLength(2);
+    expect(merged.map((p) => p.date.getTime())).toEqual([
+      Date.parse("2025-01-01T00:00:00Z"),
+      Date.parse("2025-01-02T00:00:00Z"),
+    ]);
+  });
+
+  test("merges empty current with non-empty incoming", () => {
+    const incoming = [pp("2025-01-01T00:00:00Z", 100), pp("2025-01-02T00:00:00Z", 101)];
+    const merged = mergePriceHistoryWindows([], incoming);
+    expect(merged.map((p) => p.date.getTime())).toEqual([
+      Date.parse("2025-01-01T00:00:00Z"),
+      Date.parse("2025-01-02T00:00:00Z"),
+    ]);
+  });
+
+  test("returns empty for two empty arrays", () => {
+    expect(mergePriceHistoryWindows([], [])).toEqual([]);
   });
 });

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -349,23 +349,62 @@ function emptyFinancials(priceHistory: TickerFinancials["priceHistory"] = []): T
   return { annualStatements: [], quarterlyStatements: [], priceHistory };
 }
 
-function mergePriceHistoryWindows(
+export function mergePriceHistoryWindows(
   current: TickerFinancials["priceHistory"],
   incoming: TickerFinancials["priceHistory"],
 ): TickerFinancials["priceHistory"] {
-  const byTimestamp = new Map<number, TickerFinancials["priceHistory"][number]>();
-  for (const point of [...current, ...incoming]) {
-    const timestamp = getPricePointTimestamp(point);
-    if (Number.isFinite(timestamp)) {
-      byTimestamp.set(
-        timestamp,
-        point.date instanceof Date ? point : { ...point, date: new Date(timestamp) },
-      );
+  const result: TickerFinancials["priceHistory"] = [];
+  let ci = 0;
+  let ii = 0;
+
+  const normalize = (
+    point: TickerFinancials["priceHistory"][number],
+    timestamp: number,
+  ): TickerFinancials["priceHistory"][number] => {
+    if (point.date instanceof Date) return point;
+    return { ...point, date: new Date(timestamp) };
+  };
+
+  while (ci < current.length && ii < incoming.length) {
+    const currentTs = getPricePointTimestamp(current[ci]!);
+    const incomingTs = getPricePointTimestamp(incoming[ii]!);
+
+    if (!Number.isFinite(currentTs)) {
+      ci++;
+      continue;
+    }
+    if (!Number.isFinite(incomingTs)) {
+      ii++;
+      continue;
+    }
+
+    if (currentTs < incomingTs) {
+      result.push(normalize(current[ci]!, currentTs));
+      ci++;
+    } else if (incomingTs < currentTs) {
+      result.push(normalize(incoming[ii]!, incomingTs));
+      ii++;
+    } else {
+      // Equal timestamps: incoming overrides current (dedup).
+      result.push(normalize(incoming[ii]!, incomingTs));
+      ci++;
+      ii++;
     }
   }
-  return [...byTimestamp.values()].sort(
-    (left, right) => getPricePointTimestamp(left) - getPricePointTimestamp(right),
-  );
+
+  while (ci < current.length) {
+    const ts = getPricePointTimestamp(current[ci]!);
+    if (Number.isFinite(ts)) result.push(normalize(current[ci]!, ts));
+    ci++;
+  }
+
+  while (ii < incoming.length) {
+    const ts = getPricePointTimestamp(incoming[ii]!);
+    if (Number.isFinite(ts)) result.push(normalize(incoming[ii]!, ts));
+    ii++;
+  }
+
+  return result;
 }
 
 function historyIntersectsBounds(


### PR DESCRIPTION
Performance: two-pointer merge replacing Map+sort in mergePriceHistoryWindows.