### PR TITLE
Remove dead dependencies and complete .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,8 @@
 GLOOMBERB_API_URL=http://localhost:3355
+
+# Override the interface language. One of: auto, en, es, zh-CN, zh-TW, ja, ko.
+# Defaults to auto-detection from system locale.
+# GLOOMBERB_LANG=auto
+
+# Set to 1 when building the Cloudflare-hosted web client (used by cloud:build).
+# GLOOMBERB_CLOUD_HOSTED=1

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,6 @@
         "react-dom": "19.2.7",
         "rxjs": "^7.8.2",
         "typebox": "1.1.38",
-        "web-tree-sitter": "0.25.10",
         "youtubei.js": "17.0.1",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "react-dom": "19.2.7",
     "rxjs": "^7.8.2",
     "typebox": "1.1.38",
-    "web-tree-sitter": "0.25.10",
     "youtubei.js": "17.0.1"
   },
   "patchedDependencies": {


### PR DESCRIPTION
Tech debt: remove web-tree-sitter from package.json, add GLOOMBERB_LANG and GLOOMBERB_CLOUD_HOSTED to .env.example.