### PR TITLE
Add SHA-256 checksum verification to self-updater

### DIFF
--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, test } from "bun:test";
+import { createHash } from "crypto";
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -388,6 +389,138 @@ describe("performUpdate", () => {
       expect(readFileSync(execPath)).toEqual(nextBinary);
       expect(progress[0]).toEqual({ phase: "downloading", percent: 0 });
       expect(progress).toContainEqual({ phase: "downloading", percent: 100 });
+      expect(progress.at(-1)).toEqual({ phase: "done" });
+    } finally {
+      Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });
+      Object.defineProperty(process, "argv", { value: originalArgv, configurable: true });
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("installs the binary when the SHA-256 checksum matches the compressed asset", async () => {
+    const originalExecPath = process.execPath;
+    const originalArgv = process.argv;
+    const tempDir = mkdtempSync(join(tmpdir(), "gloomberb-update-"));
+    const execPath = join(tempDir, "gloomberb");
+    const nextBinary = Buffer.from("new-binary-verified");
+    const payload = gzipSync(nextBinary);
+    const checksum = createHash("sha256").update(payload).digest("hex");
+    const progress: UpdateProgress[] = [];
+
+    writeFileSync(execPath, Buffer.from("old-binary"));
+    chmodSync(execPath, 0o755);
+    globalThis.fetch = (async () => new Response(payload, {
+      status: 200,
+      headers: { "content-length": String(payload.length) },
+    })) as typeof fetch;
+
+    try {
+      Object.defineProperty(process, "execPath", { value: execPath, configurable: true });
+      Object.defineProperty(process, "argv", {
+        value: [execPath],
+        configurable: true,
+      });
+
+      await performUpdate({
+        version: "9.9.9",
+        tagName: "v9.9.9",
+        downloadUrl: "https://example.com/gloomberb.gz",
+        publishedAt: "2026-04-03T00:00:00Z",
+        updateAction: { kind: "self" },
+        compressed: true,
+        checksum,
+      }, (entry) => {
+        progress.push(entry);
+      });
+
+      expect(readFileSync(execPath)).toEqual(nextBinary);
+      expect(progress.at(-1)).toEqual({ phase: "done" });
+    } finally {
+      Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });
+      Object.defineProperty(process, "argv", { value: originalArgv, configurable: true });
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a tampered binary with a checksum mismatch and leaves the running binary intact", async () => {
+    const originalExecPath = process.execPath;
+    const originalArgv = process.argv;
+    const tempDir = mkdtempSync(join(tmpdir(), "gloomberb-update-"));
+    const execPath = join(tempDir, "gloomberb");
+    const oldBinary = Buffer.from("old-binary");
+    const payload = gzipSync(Buffer.from("tampered-binary"));
+    const progress: UpdateProgress[] = [];
+
+    writeFileSync(execPath, oldBinary);
+    chmodSync(execPath, 0o755);
+    globalThis.fetch = (async () => new Response(payload, {
+      status: 200,
+      headers: { "content-length": String(payload.length) },
+    })) as typeof fetch;
+
+    try {
+      Object.defineProperty(process, "execPath", { value: execPath, configurable: true });
+      Object.defineProperty(process, "argv", {
+        value: [execPath],
+        configurable: true,
+      });
+
+      await performUpdate({
+        version: "9.9.9",
+        tagName: "v9.9.9",
+        downloadUrl: "https://example.com/gloomberb.gz",
+        publishedAt: "2026-04-03T00:00:00Z",
+        updateAction: { kind: "self" },
+        compressed: true,
+        checksum: "deadbeef".repeat(8),
+      }, (entry) => {
+        progress.push(entry);
+      });
+
+      // Running binary must be untouched.
+      expect(readFileSync(execPath)).toEqual(oldBinary);
+      expect(progress.at(-1)?.phase).toBe("error");
+      expect(progress.at(-1)?.error).toContain("Checksum mismatch");
+    } finally {
+      Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });
+      Object.defineProperty(process, "argv", { value: originalArgv, configurable: true });
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("installs the binary when no checksum is available (backward compatible)", async () => {
+    const originalExecPath = process.execPath;
+    const originalArgv = process.argv;
+    const tempDir = mkdtempSync(join(tmpdir(), "gloomberb-update-"));
+    const execPath = join(tempDir, "gloomberb");
+    const nextBinary = Buffer.from("new-binary-no-checksum");
+    const progress: UpdateProgress[] = [];
+
+    writeFileSync(execPath, Buffer.from("old-binary"));
+    chmodSync(execPath, 0o755);
+    globalThis.fetch = (async () => new Response(nextBinary, {
+      status: 200,
+      headers: { "content-length": String(nextBinary.length) },
+    })) as typeof fetch;
+
+    try {
+      Object.defineProperty(process, "execPath", { value: execPath, configurable: true });
+      Object.defineProperty(process, "argv", {
+        value: [execPath],
+        configurable: true,
+      });
+
+      await performUpdate({
+        version: "9.9.9",
+        tagName: "v9.9.9",
+        downloadUrl: "https://example.com/gloomberb",
+        publishedAt: "2026-04-03T00:00:00Z",
+        updateAction: { kind: "self" },
+      }, (entry) => {
+        progress.push(entry);
+      });
+
+      expect(readFileSync(execPath)).toEqual(nextBinary);
       expect(progress.at(-1)).toEqual({ phase: "done" });
     } finally {
       Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -11,6 +11,8 @@ export interface ReleaseInfo {
   publishedAt: string;
   updateAction: UpdateAction;
   compressed?: boolean;
+  /** Expected SHA-256 (hex) of the downloaded asset, from GitHub's asset digest. */
+  checksum?: string;
 }
 
 export interface UpdateProgress {
@@ -70,18 +72,29 @@ function getAssetBaseName(): string {
   return getAssetBaseNameForRuntime();
 }
 
+function parseAssetDigest(digest: string | undefined): string | undefined {
+  if (!digest) return undefined;
+  const prefix = "sha256:";
+  if (digest.startsWith(prefix)) {
+    return digest.slice(prefix.length).toLowerCase();
+  }
+  return undefined;
+}
+
 function resolveReleaseAsset(
-  assets: { name: string; browser_download_url: string }[],
-): { name: string; browser_download_url: string; compressed: boolean } | null {
+  assets: { name: string; browser_download_url: string; digest?: string }[],
+): { name: string; browser_download_url: string; compressed: boolean; checksum?: string } | null {
   const assetBaseName = getAssetBaseName();
   const gzAsset = assets.find((asset) => asset.name === `${assetBaseName}.gz`);
   if (gzAsset) {
-    return { ...gzAsset, compressed: true };
+    const { name, browser_download_url, digest } = gzAsset;
+    return { name, browser_download_url, compressed: true, checksum: parseAssetDigest(digest) };
   }
 
   const rawAsset = assets.find((asset) => asset.name === assetBaseName);
   if (rawAsset) {
-    return { ...rawAsset, compressed: false };
+    const { name, browser_download_url, digest } = rawAsset;
+    return { name, browser_download_url, compressed: false, checksum: parseAssetDigest(digest) };
   }
 
   return null;
@@ -249,7 +262,7 @@ export async function checkForUpdateDetailed(
     const data = (await res.json()) as {
       tag_name: string;
       published_at: string;
-      assets: { name: string; browser_download_url: string }[];
+      assets: { name: string; browser_download_url: string; digest?: string }[];
     };
 
     const version = data.tag_name.replace(/^v/, "");
@@ -274,6 +287,7 @@ export async function checkForUpdateDetailed(
         publishedAt: data.published_at,
         updateAction,
         compressed: asset.compressed,
+        checksum: asset.checksum,
       },
     };
   } catch (error: unknown) {
@@ -339,6 +353,7 @@ export async function performUpdate(
   try {
     const fsModulePath = "fs";
     const zlibModulePath = "zlib";
+    const cryptoModulePath = "crypto";
     const {
       renameSync,
       unlinkSync,
@@ -346,6 +361,7 @@ export async function performUpdate(
     } = await import(fsModulePath) as typeof import("fs");
     unlinkUpdatePath = unlinkSync;
     const { gunzipSync } = await import(zlibModulePath) as typeof import("zlib");
+    const { createHash } = await import(cryptoModulePath) as typeof import("crypto");
 
     onProgress({ phase: "downloading", percent: 0 });
 
@@ -378,6 +394,20 @@ export async function performUpdate(
       downloaded.set(chunk, offset);
       offset += chunk.byteLength;
     }
+
+    // Verify the SHA-256 checksum of the downloaded asset before installing.
+    // GitHub's asset digest covers the uploaded file (the compressed .gz when
+    // gzipped), so hash the raw bytes before decompression.
+    if (release.checksum) {
+      const hash = createHash("sha256").update(downloaded).digest("hex");
+      if (hash !== release.checksum) {
+        throw new Error(
+          `Checksum mismatch: expected ${release.checksum}, got ${hash}. ` +
+          "The downloaded binary may be corrupted or tampered with.",
+        );
+      }
+    }
+
     const nextBinary = release.compressed
       ? new Uint8Array(gunzipSync(downloaded))
       : downloaded;


### PR DESCRIPTION
Security: verify downloaded binary checksum using GitHub release digest field before replacing executable.