### PR TITLE
Replace O(n²) mergeStatementsByPeriod with last-group-only check

### DIFF
--- a/src/time-series/fundamentals.ts
+++ b/src/time-series/fundamentals.ts
@@ -240,10 +240,10 @@ function mergeStatementsByPeriod(
   const groups: InternalStatement[][] = [];
   const sorted = [...statements].sort((left, right) => left.date.localeCompare(right.date));
   for (const statement of sorted) {
-    const group = groups.find((candidate) => (
-      areNearbyFinancialPeriodEnds(candidate[0]!.date, statement.date)
-    ));
-    if (group) group.push(statement as InternalStatement);
+    const lastGroup = groups.at(-1);
+    if (lastGroup && areNearbyFinancialPeriodEnds(lastGroup[0]!.date, statement.date)) {
+      lastGroup.push(statement as InternalStatement);
+    }
     else groups.push([statement as InternalStatement]);
   }
   return groups
@@ -767,10 +767,10 @@ function dedupeFundamentalPeriods(points: readonly TimeSeriesPoint[]): TimeSerie
     left.observedAt.getTime() - right.observedAt.getTime()
   ));
   for (const point of sorted) {
-    const group = groups.find((candidate) => (
-      areNearbyFinancialPeriodEnds(candidate[0]!.observedAt, point.observedAt)
-    ));
-    if (group) group.push(point);
+    const lastGroup = groups.at(-1);
+    if (lastGroup && areNearbyFinancialPeriodEnds(lastGroup[0]!.observedAt, point.observedAt)) {
+      lastGroup.push(point);
+    }
     else groups.push([point]);
   }
   return groups


### PR DESCRIPTION
Performance: replace groups.find() with groups.at(-1) in mergeStatementsByPeriod and dedupeFundamentalPeriods, reducing O(n²) to O(n).