### PR TITLE
Add volatility and sentiment term-structure pane (VIX shortcut)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ The toolbar controls preset or exact date ranges, intervals from one minute thro
 | `BI` / `SP` | S&P 500 sector performance |
 | `FXC` | Major FX cross rates |
 | `FNG` | Fear and greed market gauge |
+| `VIX` | Volatility and term-structure dashboard |
 
 ### Workspace and App Controls
 

--- a/src/plugins/builtin/composite-plugins.ts
+++ b/src/plugins/builtin/composite-plugins.ts
@@ -15,6 +15,7 @@ import { tvModule } from "./tv";
 import { composeBuiltinPlugin } from "./plugin-module";
 import { portfolioListModule } from "./portfolio-list";
 import { sectorsModule } from "./sectors";
+import { volatilityModule } from "./volatility";
 import { worldIndicesModule } from "./world-indices";
 import { yieldCurveModule } from "./yield-curve";
 
@@ -56,6 +57,7 @@ export const marketOverviewPlugin = composeBuiltinPlugin({
     marketHeatmapModule,
     marketMoversModule,
     fearGreedModule,
+    volatilityModule,
     sectorsModule,
     fxMatrixModule,
   ],

--- a/src/plugins/builtin/volatility/client.ts
+++ b/src/plugins/builtin/volatility/client.ts
@@ -1,0 +1,79 @@
+import { apiClient } from "../../../api-client";
+import {
+  getCachedFredSeries,
+  loadCachedFredSeries,
+  type FredSeriesRequest,
+} from "../../../data/fred-series";
+import { withConnectionRequest } from "../connections/register";
+import { buildVolData } from "./model";
+import type { VolData } from "./types";
+
+export const VOL_SERIES_IDS = ["VIXCLS", "VXVCLS", "VXMTCLS"] as const;
+export type VolSeriesId = (typeof VOL_SERIES_IDS)[number];
+
+const CONNECTION_SOURCE_ID = "fred-volatility";
+
+/** Start date for sparkline history — ~60 trading days back. */
+function startDateMonthsAgo(months: number): string {
+  const d = new Date();
+  d.setMonth(d.getMonth() - months);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function seriesRequest(seriesId: string): FredSeriesRequest {
+  return {
+    seriesId,
+    startDate: startDateMonthsAgo(3),
+    sortOrder: "asc",
+  };
+}
+
+/** Get instant cached data for all three series (for initial render). */
+export function getCachedVolData(): VolData | null {
+  const observations = VOL_SERIES_IDS.map((id) => {
+    const cached = getCachedFredSeries(seriesRequest(id));
+    return cached?.data.observations ?? null;
+  });
+
+  if (!observations.some((obs) => obs != null && obs.length > 0)) return null;
+  return buildVolData(observations[0] ?? [], observations[1] ?? [], observations[2] ?? []);
+}
+
+async function fetchSeries(seriesId: string, force: boolean) {
+  const request = seriesRequest(seriesId);
+  const result = await withConnectionRequest(
+    CONNECTION_SOURCE_ID,
+    `FRED ${seriesId}`,
+    () =>
+      loadCachedFredSeries(
+        request,
+        () => apiClient.getCloudFredSeries(request.seriesId, {
+          startDate: request.startDate,
+          sortOrder: request.sortOrder,
+        }),
+        { force },
+      ),
+  );
+  return result.data.observations;
+}
+
+/**
+ * Fetch VIX, VXV, and VXMT from FRED via the cached series system.
+ * Falls back gracefully if VXMTCLS is unavailable.
+ */
+export async function loadVolData(force = false): Promise<VolData> {
+  const observations = await Promise.all(
+    VOL_SERIES_IDS.map((id) =>
+      fetchSeries(id, force).catch((err) => {
+        // VXMTCLS may have limited history; don't let it fail the whole pane
+        if (id === "VXMTCLS") {
+          console.warn(`[volatility] ${id} unavailable:`, err);
+          return [] as Awaited<ReturnType<typeof fetchSeries>>;
+        }
+        throw err;
+      }),
+    ),
+  );
+
+  return buildVolData(observations[0]!, observations[1]!, observations[2]!);
+}

--- a/src/plugins/builtin/volatility/index.tsx
+++ b/src/plugins/builtin/volatility/index.tsx
@@ -1,0 +1,37 @@
+import type { PluginModule } from "../plugin-module";
+import { attachFredSeriesPersistence } from "../../../data/fred-series";
+import { registerConnectionSource } from "../connections/register";
+import { VolatilityPane } from "./pane";
+
+export const volatilityModule: PluginModule = {
+  panes: [{
+    id: "volatility",
+    name: "Volatility & Sentiment",
+    icon: "V",
+    component: VolatilityPane,
+    defaultPosition: "right",
+    defaultMode: "floating",
+    defaultFloatingSize: { width: 70, height: 22 },
+  }],
+  paneTemplates: [{
+    id: "volatility-pane",
+    paneId: "volatility",
+    label: "Volatility & Sentiment",
+    description: "VIX, VXV, VXMT, term structure, and contango/backwardation signals.",
+    keywords: ["vix", "volatility", "vxv", "vxmt", "term structure", "contango", "backwardation", "sentiment", "fear", "greed"],
+    shortcut: { prefix: "VIX" },
+  }],
+  setup(ctx) {
+    attachFredSeriesPersistence(ctx.persistence);
+    registerConnectionSource({
+      id: "fred-volatility",
+      name: "FRED Volatility Series",
+      kind: "api",
+      pluginId: "volatility",
+      authRequired: false,
+    });
+  },
+  dispose() {
+    // Connection sources are cleaned up when the parent plugin is disabled.
+  },
+};

--- a/src/plugins/builtin/volatility/model.ts
+++ b/src/plugins/builtin/volatility/model.ts
@@ -1,0 +1,132 @@
+import type { CloudFredObservationPayload } from "../../../api-client";
+import type {
+  VolData,
+  VolMetric,
+  VolTermStructurePoint,
+} from "./types";
+
+const SPARKLINE_POINTS = 30;
+
+/** Parse a FRED observation date string ("2024-01-15") into a Date. */
+function parseObsDate(dateStr: string): Date | null {
+  const d = new Date(dateStr);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** Extract numeric values from observations, filtering nulls (FRED uses "." for missing). */
+function numericObservations(
+  observations: CloudFredObservationPayload[],
+): { date: Date; value: number }[] {
+  const out: { date: Date; value: number }[] = [];
+  for (const obs of observations) {
+    if (obs.value == null || !Number.isFinite(obs.value)) continue;
+    const date = parseObsDate(obs.date);
+    if (!date) continue;
+    out.push({ date, value: obs.value });
+  }
+  return out.sort((a, b) => a.date.getTime() - b.date.getTime());
+}
+
+/** Latest numeric value from observations, or null. */
+function latestValue(observations: CloudFredObservationPayload[]): number | null {
+  const numeric = numericObservations(observations);
+  return numeric.length > 0 ? numeric[numeric.length - 1]!.value : null;
+}
+
+/** Latest observation date, or null. */
+function latestDate(observations: CloudFredObservationPayload[]): Date | null {
+  const numeric = numericObservations(observations);
+  return numeric.length > 0 ? numeric[numeric.length - 1]!.date : null;
+}
+
+/** Last N observations as sparkline data. */
+function sparkline(observations: CloudFredObservationPayload[], count = SPARKLINE_POINTS): { date: Date; value: number }[] {
+  const numeric = numericObservations(observations);
+  return numeric.slice(-count);
+}
+
+function buildMetric(
+  id: string,
+  label: string,
+  unit: string,
+  description: string,
+  observations: CloudFredObservationPayload[],
+): VolMetric {
+  return {
+    id,
+    label,
+    value: latestValue(observations),
+    unit,
+    sparkline: sparkline(observations),
+    description,
+  };
+}
+
+/**
+ * Classify the VXV/VIX ratio: >1 means the 3-month implied vol is higher than
+ * spot — a contango (calm) term structure. <1 means backwardation (stress).
+ */
+export type TermStructureRegime = "contango" | "backwardation" | "neutral";
+
+export function classifyTermStructure(ratio: number | null): TermStructureRegime {
+  if (ratio == null) return "neutral";
+  if (ratio > 1.0) return "contango";
+  if (ratio < 1.0) return "backwardation";
+  return "neutral";
+}
+
+/**
+ * Build the complete VolData view from raw FRED observation arrays for VIX,
+ * VXV, and VXMT.  Any series may be empty (e.g. VXMTCLS has limited history);
+ * the model degrades gracefully by showing null values.
+ */
+export function buildVolData(
+  vixObs: CloudFredObservationPayload[],
+  vxvObs: CloudFredObservationPayload[],
+  vxmtObs: CloudFredObservationPayload[],
+): VolData {
+  const vix = buildMetric("vix", "VIX", "pts", "CBOE Volatility Index — 30-day implied volatility", vixObs);
+  const vxv = buildMetric("vxv", "VXV", "pts", "3-month VIX — implied volatility over 3 months", vxvObs);
+  const vxmt = buildMetric("vxmt", "VXMT", "pts", "6-month VIX — implied volatility over 6 months", vxmtObs);
+
+  const vixVal = vix.value;
+  const vxvVal = vxv.value;
+  const ratio = vixVal != null && vxvVal != null && vixVal !== 0 ? vxvVal / vixVal : null;
+
+  // Build a ratio sparkline by aligning VIX and VXV by date
+  const vixByDate = new Map<string, number>();
+  for (const pt of vix.sparkline) {
+    vixByDate.set(pt.date.toISOString().slice(0, 10), pt.value);
+  }
+  const ratioSparkline: { date: Date; value: number }[] = [];
+  for (const pt of vxv.sparkline) {
+    const v = vixByDate.get(pt.date.toISOString().slice(0, 10));
+    if (v != null && v !== 0) {
+      ratioSparkline.push({ date: pt.date, value: pt.value / v });
+    }
+  }
+
+  const vxvVixRatio: VolMetric = {
+    id: "vxv-vix-ratio",
+    label: "VXV/VIX",
+    value: ratio,
+    unit: "ratio",
+    sparkline: ratioSparkline,
+    description: "Term-structure signal: >1 contango (calm), <1 backwardation (stress)",
+  };
+
+  const termStructure: VolTermStructurePoint[] = [
+    { tenor: "Spot", value: vix.value },
+    { tenor: "3M", value: vxv.value },
+    { tenor: "6M", value: vxmt.value },
+  ];
+
+  const allDates = [latestDate(vixObs), latestDate(vxvObs), latestDate(vxmtObs)].filter(
+    (d): d is Date => d != null,
+  );
+  const updatedAt = allDates.length > 0
+    ? new Date(Math.max(...allDates.map((d) => d.getTime())))
+    : null;
+
+  return { vix, vxv, vxmt, vxvVixRatio, termStructure, updatedAt };
+}

--- a/src/plugins/builtin/volatility/pane.tsx
+++ b/src/plugins/builtin/volatility/pane.tsx
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, ScrollBox, Text, TextAttributes } from "../../../ui";
+import { useShortcut } from "../../../react/input";
+import { StaticChartSurface, type PaneFooterSegment } from "../../../components";
+import { PriceSparkline } from "../../../components/price-sparkline/view";
+import { resolveChartPalette } from "../../../components/chart/core/renderer";
+import type { ProjectedChartPoint } from "../../../components/chart/core/data";
+import type { PricePoint } from "../../../types/financials";
+import type { PaneProps } from "../../../types/plugin";
+import { colors } from "../../../theme/colors";
+import { useAutoRefresh } from "../shared/use-auto-refresh";
+import { usePaneStatusFooter } from "../shared/pane-footer";
+import { getCachedVolData, loadVolData } from "./client";
+import { classifyTermStructure } from "./model";
+import type { VolData, VolMetric } from "./types";
+
+function formatValue(value: number | null, digits = 2): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return value.toFixed(digits);
+}
+
+function formatDate(date: Date | null): string {
+  if (!date) return "—";
+  return date.toISOString().slice(0, 10);
+}
+
+function toPricePoints(sparkline: { date: Date; value: number }[]): PricePoint[] {
+  return sparkline.map((pt) => ({ date: pt.date, close: pt.value }));
+}
+
+function regimeColor(regime: ReturnType<typeof classifyTermStructure>): string {
+  switch (regime) {
+    case "contango":
+      return colors.positive;
+    case "backwardation":
+      return colors.warning;
+    case "neutral":
+      return colors.textMuted;
+  }
+}
+
+function MetricRow({
+  metric,
+  sparklineWidth,
+  valueColor,
+  trailing,
+}: {
+  metric: VolMetric;
+  sparklineWidth: number;
+  valueColor?: string;
+  trailing?: string;
+}) {
+  const priceHistory = useMemo(() => toPricePoints(metric.sparkline), [metric.sparkline]);
+  const trend = useMemo<"positive" | "negative" | "neutral">(() => {
+    if (metric.sparkline.length < 2) return "neutral";
+    const first = metric.sparkline[0]!.value;
+    const last = metric.sparkline[metric.sparkline.length - 1]!.value;
+    return last > first ? "positive" : last < first ? "negative" : "neutral";
+  }, [metric.sparkline]);
+
+  return (
+    <Box flexDirection="row" height={1} paddingX={1}>
+      <Box width={10} flexShrink={0}>
+        <Text fg={colors.textDim}>{metric.label}</Text>
+      </Box>
+      <Box width={8} flexShrink={0}>
+        <Text fg={valueColor ?? colors.text} attributes={TextAttributes.BOLD}>
+          {formatValue(metric.value, metric.unit === "ratio" ? 2 : 2)}
+        </Text>
+      </Box>
+      {sparklineWidth > 4 ? (
+        <Box width={sparklineWidth} flexShrink={0}>
+          <PriceSparkline priceHistory={priceHistory} width={sparklineWidth} trend={trend} height={1} />
+        </Box>
+      ) : null}
+      {trailing ? (
+        <Box flexGrow={1}>
+          <Text fg={colors.textMuted}> {trailing}</Text>
+        </Box>
+      ) : (
+        <Box flexGrow={1} />
+      )}
+    </Box>
+  );
+}
+
+function TermStructureChart({
+  data,
+  width,
+  height,
+}: {
+  data: VolData;
+  width: number;
+  height: number;
+}) {
+  const palette = resolveChartPalette(colors, "positive");
+  const chartWidth = Math.max(10, width - 2);
+  const chartHeight = Math.min(10, Math.max(5, height));
+
+  const validPoints = data.termStructure.filter((p) => p.value != null);
+  if (validPoints.length < 2) {
+    return (
+      <Box paddingX={1} marginTop={1}>
+        <Text fg={colors.textMuted}>Not enough data for term structure chart</Text>
+      </Box>
+    );
+  }
+
+  // Map term structure to chart points on a pseudo x-axis
+  const chartPoints: ProjectedChartPoint[] = data.termStructure.map((p, i) => ({
+    date: new Date(i * 86_400_000),
+    open: p.value ?? 0,
+    high: p.value ?? 0,
+    low: p.value ?? 0,
+    close: p.value ?? 0,
+    volume: 0,
+  }));
+
+  const labelWidth = 8;
+  const colWidth = Math.max(8, Math.floor((width - 2) / data.termStructure.length));
+  const tenorLabels = data.termStructure.map((p) => p.tenor.padEnd(colWidth)).join("").trimEnd();
+  const valueLabels = data.termStructure
+    .map((p) => formatValue(p.value, 2).padEnd(colWidth))
+    .join("").trimEnd();
+
+  return (
+    <Box flexDirection="column" paddingX={1} marginTop={1}>
+      <Box height={1}>
+        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>TERM STRUCTURE</Text>
+      </Box>
+      <Box flexDirection="column" marginTop={0}>
+        <StaticChartSurface
+          points={chartPoints}
+          width={chartWidth}
+          height={chartHeight}
+          mode="line"
+          colors={palette}
+          yAxisLabel="VIX pts"
+          yAxisColor={colors.textDim}
+          formatYAxisValue={(v) => v.toFixed(1)}
+        />
+      </Box>
+      <Box height={1} marginTop={0}>
+        <Text fg={colors.textDim}>{tenorLabels}</Text>
+      </Box>
+      <Box height={1}>
+        <Text fg={colors.text}>{valueLabels}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+export function VolatilityPane({ paneId, focused, width, height }: PaneProps) {
+  const [initialCache] = useState(() => getCachedVolData());
+  const [data, setData] = useState<VolData | null>(initialCache);
+  const [loading, setLoading] = useState(!initialCache);
+  const [error, setError] = useState<string | null>(null);
+  const [lastRefreshed, setLastRefreshed] = useState<number | null>(null);
+  const fetchGenRef = useRef(0);
+
+  const load = useCallback(async (force = false) => {
+    fetchGenRef.current += 1;
+    const gen = fetchGenRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await loadVolData(force);
+      if (fetchGenRef.current !== gen) return;
+      setData(next);
+      setLastRefreshed(Date.now());
+    } catch (err) {
+      if (fetchGenRef.current !== gen) return;
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      if (fetchGenRef.current === gen) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!initialCache) {
+      void load();
+    } else {
+      void load(false);
+    }
+  }, [initialCache, load]);
+
+  const refresh = useCallback(() => {
+    void load(true);
+  }, [load]);
+
+  useAutoRefresh(lastRefreshed, refresh);
+
+  useShortcut((event) => {
+    if (!focused) return;
+    if (event.name === "r") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      refresh();
+    }
+  });
+
+  const regime = classifyTermStructure(data?.vxvVixRatio.value ?? null);
+  const updatedLabel = data?.updatedAt ? formatDate(data.updatedAt) : null;
+  const regimeTone = regime === "backwardation" ? "warning" as const : regime === "contango" ? "value" as const : "muted" as const;
+  const regimeText = regime === "contango" ? "CONTANGO" : regime === "backwardation" ? "BACKWARDATION" : "FLAT";
+
+  const statusInfo = useMemo<PaneFooterSegment[]>(() => [
+    ...(data?.vxvVixRatio.value != null
+      ? [{
+          id: "regime",
+          parts: [{
+            text: regimeText,
+            tone: regimeTone,
+            bold: true,
+          }],
+        }]
+      : []),
+    ...(updatedLabel ? [{ id: "updated", parts: [{ text: `as of ${updatedLabel}`, tone: "muted" as const }] }] : []),
+  ], [regimeText, regimeTone, updatedLabel, data?.vxvVixRatio.value]);
+
+  usePaneStatusFooter({
+    registrationId: paneId,
+    loading,
+    error,
+    info: statusInfo,
+    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refresh, disabled: loading }],
+  });
+
+  if (loading && !data) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        <Box flexGrow={1} justifyContent="center" alignItems="center">
+          <Text fg={colors.textMuted}>Loading volatility data...</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        <Box flexGrow={1} justifyContent="center" alignItems="center" paddingX={1}>
+          <Text fg={colors.negative}>{error ?? "Volatility data unavailable"}</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  const labelWidth = 10;
+  const valueWidth = 8;
+  const sparklineWidth = Math.max(0, Math.min(28, width - 2 - labelWidth - valueWidth - 12));
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      <ScrollBox flexGrow={1} scrollY focusable={false}>
+        <Box flexDirection="column" paddingBottom={1}>
+          {/* Spot VIX */}
+          <Box flexDirection="row" height={1} paddingX={1} marginTop={1}>
+            <Box width={labelWidth} flexShrink={0}>
+              <Text fg={colors.textDim}>VIX</Text>
+            </Box>
+            <Box width={valueWidth} flexShrink={0}>
+              <Text fg={colors.text} attributes={TextAttributes.BOLD}>{formatValue(data.vix.value)}</Text>
+            </Box>
+            {sparklineWidth > 4 ? (
+              <Box width={sparklineWidth} flexShrink={0}>
+                <PriceSparkline
+                  priceHistory={toPricePoints(data.vix.sparkline)}
+                  width={sparklineWidth}
+                  trend={data.vix.sparkline.length >= 2 && data.vix.sparkline.at(-1)!.value > data.vix.sparkline[0]!.value ? "positive" : "negative"}
+                  height={1}
+                />
+              </Box>
+            ) : null}
+            <Box flexGrow={1}>
+              <Text fg={colors.textMuted}> spot volatility index</Text>
+            </Box>
+          </Box>
+
+          {/* VXV/VIX ratio with regime label */}
+          <Box flexDirection="row" height={1} paddingX={1}>
+            <Box width={labelWidth} flexShrink={0}>
+              <Text fg={colors.textDim}>VXV/VIX</Text>
+            </Box>
+            <Box width={valueWidth} flexShrink={0}>
+              <Text fg={regimeColor(regime)} attributes={TextAttributes.BOLD}>
+                {formatValue(data.vxvVixRatio.value)}
+              </Text>
+            </Box>
+            {sparklineWidth > 4 ? (
+              <Box width={sparklineWidth} flexShrink={0}>
+                <PriceSparkline
+                  priceHistory={toPricePoints(data.vxvVixRatio.sparkline)}
+                  width={sparklineWidth}
+                  trend="neutral"
+                  height={1}
+                />
+              </Box>
+            ) : null}
+            <Box flexGrow={1}>
+              <Text fg={regimeColor(regime)} attributes={TextAttributes.BOLD}>
+                {" "}{regime === "contango" ? "contango" : regime === "backwardation" ? "backwardation" : "flat"}
+              </Text>
+            </Box>
+          </Box>
+
+          {/* Term structure chart */}
+          <TermStructureChart data={data} width={width} height={Math.min(14, Math.max(8, Math.floor(height * 0.35)))} />
+
+          {/* VXV */}
+          <Box marginTop={1}>
+            <MetricRow
+              metric={data.vxv}
+              sparklineWidth={sparklineWidth}
+              valueColor={colors.text}
+              trailing="3-month implied vol"
+            />
+          </Box>
+
+          {/* VXMT */}
+          <MetricRow
+            metric={data.vxmt}
+            sparklineWidth={sparklineWidth}
+            valueColor={colors.text}
+            trailing={data.vxmt.value == null ? "6M (limited history)" : "6-month implied vol"}
+          />
+        </Box>
+      </ScrollBox>
+    </Box>
+  );
+}

--- a/src/plugins/builtin/volatility/types.ts
+++ b/src/plugins/builtin/volatility/types.ts
@@ -1,0 +1,24 @@
+export interface VolMetric {
+  id: string;
+  label: string;
+  value: number | null;
+  unit: string; // "pts", "ratio"
+  sparkline: { date: Date; value: number }[];
+  description: string;
+}
+
+export type LoadStatus = "idle" | "loading" | "loaded" | "error";
+
+export interface VolTermStructurePoint {
+  tenor: string; // "Spot", "3M", "6M"
+  value: number | null;
+}
+
+export interface VolData {
+  vix: VolMetric;
+  vxv: VolMetric;
+  vxmt: VolMetric;
+  vxvVixRatio: VolMetric; // VXV/VIX — >1 = contango, <1 = backwardation
+  termStructure: VolTermStructurePoint[];
+  updatedAt: Date | null;
+}


### PR DESCRIPTION
Feature: new Volatility & Sentiment pane showing spot VIX with sparkline, VXV/VIX ratio with contango/backwardation label, term structure chart (Spot/3M/6M), and VXV/VXMT metric rows. Fetches VIXCLS, VXVCLS, VXMTCLS from FRED.