### PR TITLE
Add corporate and municipal bond search pane (BOND shortcut) [DRAFT]

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ The toolbar controls preset or exact date ranges, intervals from one minute thro
 | `WEI` | Global equity indices |
 | `ECON` | Economic events and releases |
 | `GC` | Yield curve |
+| `BOND` | Corporate bond yields and spreads |
 | `ERN` | Earnings calendar |
 | `TV` | Live Bloomberg, CNBC, and Yahoo Finance television |
 | `BI` / `SP` | S&P 500 sector performance |

--- a/src/plugins/builtin/bond-search/fred-yields.ts
+++ b/src/plugins/builtin/bond-search/fred-yields.ts
@@ -1,0 +1,100 @@
+import { apiClient, type CloudYieldPointPayload } from "../../../api-client";
+import { loadCachedFredSeries } from "../../../data/fred-series";
+import { withConnectionRequest } from "../connections/register";
+import type { CorporateYieldEntry } from "./types";
+
+export const FRED_CORPORATE_YIELDS_CONNECTION_ID = "fred-corporate-yields";
+
+export interface CorporateSeriesMeta {
+  seriesId: string;
+  label: string;
+  rating: string;
+  maturityRange: string;
+  /** Treasury maturity used as the spread benchmark. */
+  treasuryMaturity: string;
+}
+
+/**
+ * ICE BofA US corporate yield indices, published daily by FRED. These are
+ * option-adjusted yields for broadly held corporate indices broken out by
+ * rating tier and maturity bucket. No auth required — fetched through the
+ * existing cloud FRED proxy.
+ */
+export const CORPORATE_SERIES: readonly CorporateSeriesMeta[] = [
+  { seriesId: "BAMLC0A1CAAA", label: "IG AAA", rating: "AAA", maturityRange: "All", treasuryMaturity: "10Y" },
+  { seriesId: "BAMLC0A2A", label: "IG AA", rating: "AA", maturityRange: "All", treasuryMaturity: "10Y" },
+  { seriesId: "BAMLC0A3A", label: "IG A", rating: "A", maturityRange: "All", treasuryMaturity: "10Y" },
+  { seriesId: "BAMLC0A4CBBB", label: "IG BBB", rating: "BBB", maturityRange: "All", treasuryMaturity: "10Y" },
+  { seriesId: "BAMLC0A0CM", label: "IG All-Rated", rating: "IG", maturityRange: "All", treasuryMaturity: "10Y" },
+  { seriesId: "BAMLH0A0HYM", label: "High Yield", rating: "HY", maturityRange: "All", treasuryMaturity: "10Y" },
+  { seriesId: "BAMLC0A0C13Y", label: "IG 1-3Y", rating: "IG", maturityRange: "1-3Y", treasuryMaturity: "2Y" },
+  { seriesId: "BAMLC0A0C510Y", label: "IG 5-10Y", rating: "IG", maturityRange: "5-10Y", treasuryMaturity: "10Y" },
+];
+
+export interface TreasuryYieldMap {
+  [maturity: string]: number | null;
+}
+
+export async function loadTreasuryYieldMap(): Promise<TreasuryYieldMap> {
+  const points: CloudYieldPointPayload[] = await apiClient.getCloudYieldCurve();
+  const map: TreasuryYieldMap = {};
+  for (const point of points) map[point.maturity] = point.yield;
+  return map;
+}
+
+function latestStartDate(): string {
+  // 60 days of history is plenty to find the most recent published value, even
+  // across weekends/holidays. Sorted descending so the head is the latest.
+  const days = 60;
+  const when = new Date();
+  when.setUTCDate(when.getUTCDate() - days);
+  return `${when.getUTCFullYear()}-${String(when.getUTCMonth() + 1).padStart(2, "0")}-${String(when.getUTCDate()).padStart(2, "0")}`;
+}
+
+export async function loadCorporateYields(force = false): Promise<CorporateYieldEntry[]> {
+  const startDate = latestStartDate();
+  // Treasury curve is best-effort: a failure to fetch it should not block the
+  // yields table — spreads just become unavailable.
+  const treasuryMap = await loadTreasuryYieldMap().catch(() => ({}) as TreasuryYieldMap);
+
+  const entries = await Promise.all(
+    CORPORATE_SERIES.map(async (meta): Promise<CorporateYieldEntry> => {
+      const result = await withConnectionRequest(
+        FRED_CORPORATE_YIELDS_CONNECTION_ID,
+        meta.seriesId,
+        () =>
+          loadCachedFredSeries(
+            { seriesId: meta.seriesId, startDate, sortOrder: "desc" },
+            () =>
+              apiClient.getCloudFredSeries(meta.seriesId, {
+                startDate,
+                sortOrder: "desc",
+                limit: 5,
+              }),
+            { force },
+          ),
+      );
+      const observations = result.data.observations;
+      // Descending sort means the first non-null observation is the latest.
+      const latest = observations.find((obs) => obs.value != null) ?? null;
+      const yieldValue = latest?.value ?? null;
+      const treasuryYield = treasuryMap[meta.treasuryMaturity] ?? null;
+      const spreadBp =
+        yieldValue != null && treasuryYield != null
+          ? Math.round((yieldValue - treasuryYield) * 100)
+          : null;
+      return {
+        seriesId: meta.seriesId,
+        label: meta.label,
+        rating: meta.rating,
+        maturityRange: meta.maturityRange,
+        yield: yieldValue,
+        treasuryYield,
+        spreadBp,
+        updatedAt: latest?.date ? new Date(`${latest.date}T00:00:00Z`) : null,
+      };
+    }),
+  );
+
+  return entries;
+}

--- a/src/plugins/builtin/bond-search/index.tsx
+++ b/src/plugins/builtin/bond-search/index.tsx
@@ -1,0 +1,62 @@
+import type { PluginModule } from "../plugin-module";
+import { attachFredSeriesPersistence } from "../../../data/fred-series";
+import { registerConnectionSource } from "../connections/register";
+import { BondSearchPane } from "./pane";
+import { BOND_SEARCH_PANE_ID } from "./model";
+import { FRED_CORPORATE_YIELDS_CONNECTION_ID } from "./fred-yields";
+
+let disposeConnection: (() => void) | null = null;
+
+export const bondSearchModule: PluginModule = {
+  panes: [
+    {
+      id: BOND_SEARCH_PANE_ID,
+      name: "Bond Search",
+      icon: "B",
+      component: BondSearchPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 100, height: 30 },
+    },
+  ],
+  paneTemplates: [
+    {
+      id: "bond-search-pane",
+      paneId: BOND_SEARCH_PANE_ID,
+      label: "Bond Search",
+      description:
+        "Corporate and municipal bond yields, spreads vs. Treasury, and search.",
+      keywords: [
+        "bond",
+        "bonds",
+        "corporate",
+        "municipal",
+        "muni",
+        "yield",
+        "spread",
+        "credit",
+        "fixed income",
+        "cusip",
+        "IG",
+        "HY",
+      ],
+      shortcut: { prefix: "BOND" },
+      createInstance: () => ({ placement: "floating" }),
+    },
+  ],
+  setup(ctx) {
+    // Share the FRED series cache/persistence namespace used by the econ plugin.
+    attachFredSeriesPersistence(ctx.persistence);
+    disposeConnection = registerConnectionSource({
+      id: FRED_CORPORATE_YIELDS_CONNECTION_ID,
+      name: "FRED Corporate Yields",
+      kind: "api",
+      pluginId: BOND_SEARCH_PANE_ID,
+      authRequired: false,
+    });
+  },
+  dispose() {
+    disposeConnection?.();
+    disposeConnection = null;
+  },
+};

--- a/src/plugins/builtin/bond-search/model.ts
+++ b/src/plugins/builtin/bond-search/model.ts
@@ -1,0 +1,92 @@
+import type { DataTableColumn } from "../../../components";
+import type { CorporateYieldEntry, YieldColumn } from "./types";
+
+export const BOND_SEARCH_PANE_ID = "bond-search";
+
+export type SortDirection = "asc" | "desc";
+
+export type YieldColumnId = YieldColumn["id"];
+
+export type YieldColumnDef = DataTableColumn & { id: YieldColumnId };
+
+function compareText(left: string, right: string): number {
+  return left.localeCompare(right, "en-US", { sensitivity: "base" });
+}
+
+function compareYield(
+  left: CorporateYieldEntry,
+  right: CorporateYieldEntry,
+  columnId: YieldColumnId,
+): number {
+  switch (columnId) {
+    case "label":
+      return compareText(left.label, right.label);
+    case "rating":
+      return compareText(left.rating, right.rating);
+    case "maturity":
+      return compareText(left.maturityRange, right.maturityRange);
+    case "yield":
+      return (left.yield ?? -Infinity) - (right.yield ?? -Infinity);
+    case "spread":
+      return (left.spreadBp ?? -Infinity) - (right.spreadBp ?? -Infinity);
+  }
+}
+
+export function nextSort(
+  current: { columnId: YieldColumnId; direction: SortDirection },
+  columnId: YieldColumnId,
+  defaultDirection: SortDirection,
+): { columnId: YieldColumnId; direction: SortDirection } {
+  if (current.columnId !== columnId) {
+    return { columnId, direction: defaultDirection };
+  }
+  return { columnId, direction: current.direction === "asc" ? "desc" : "asc" };
+}
+
+export function sortedYields(
+  entries: CorporateYieldEntry[],
+  sort: { columnId: YieldColumnId; direction: SortDirection },
+): CorporateYieldEntry[] {
+  return [...entries].sort((left, right) => {
+    const comparison = compareYield(left, right, sort.columnId);
+    if (comparison !== 0) return sort.direction === "asc" ? comparison : -comparison;
+    // Stable tie-break: keep the declared series order (rating tiers first).
+    return 0;
+  });
+}
+
+export function buildYieldColumns(width: number): YieldColumnDef[] {
+  const ratingWidth = 5;
+  const maturityWidth = 8;
+  const yieldWidth = 9;
+  const spreadWidth = 10;
+  // 4 inter-column gaps + 2 leading/trailing pad cells ≈ 6
+  const labelWidth = Math.max(14, width - ratingWidth - maturityWidth - yieldWidth - spreadWidth - 6);
+  return [
+    { id: "label", label: "LABEL", width: labelWidth, align: "left" },
+    { id: "rating", label: "RATING", width: ratingWidth, align: "left" },
+    { id: "maturity", label: "MATURITY", width: maturityWidth, align: "left" },
+    { id: "yield", label: "YIELD", width: yieldWidth, align: "right" },
+    { id: "spread", label: "SPREAD", width: spreadWidth, align: "right" },
+  ];
+}
+
+export function formatYieldPercent(value: number | null): string {
+  if (value == null) return "—";
+  return `${value.toFixed(2)}%`;
+}
+
+export function formatSpreadBp(value: number | null): string {
+  if (value == null) return "—";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value}bp`;
+}
+
+export function formatYieldDate(value: Date | null): string {
+  if (!value) return "--";
+  return value.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/src/plugins/builtin/bond-search/pane.tsx
+++ b/src/plugins/builtin/bond-search/pane.tsx
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, Text, TextAttributes, type InputRenderable } from "../../../ui";
+import { useShortcut } from "../../../react/input";
+import { isPlainArrowUp, stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
+import {
+  DataTableView,
+  EmptyState,
+  InputSearchBar,
+  Spinner,
+  Tabs,
+  usePaneFooter,
+  useUpdatedAgo,
+  type DataTableCell,
+  type DataTableColumn,
+  type DataTableKeyEvent,
+  type DataTableRootKeyContext,
+} from "../../../components";
+import { colors, priceColor } from "../../../theme/colors";
+import { isPlainKey } from "../../../utils/keyboard";
+import type { PaneProps } from "../../../types/plugin";
+import { usePluginPaneState } from "../../runtime";
+import { loadCorporateYields } from "./fred-yields";
+import {
+  BOND_SEARCH_PANE_ID,
+  buildYieldColumns,
+  formatSpreadBp,
+  formatYieldDate,
+  formatYieldPercent,
+  nextSort,
+  sortedYields,
+  type SortDirection,
+  type YieldColumnDef,
+  type YieldColumnId,
+} from "./model";
+import type { BondTab, CorporateYieldEntry, LoadStatus } from "./types";
+
+export { BOND_SEARCH_PANE_ID } from "./model";
+
+interface YieldColumn extends DataTableColumn {
+  id: YieldColumnId;
+}
+
+const TABS: Array<{ value: BondTab; label: string }> = [
+  { value: "yields", label: "Yields" },
+  { value: "search", label: "Search" },
+];
+
+function renderYieldCell(
+  entry: CorporateYieldEntry,
+  column: YieldColumn,
+  _index: number,
+  rowState: { selected: boolean },
+): DataTableCell {
+  const selectedColor = rowState.selected ? colors.selectedText : undefined;
+  switch (column.id) {
+    case "label":
+      return { text: entry.label, color: selectedColor ?? colors.text, attributes: TextAttributes.BOLD };
+    case "rating":
+      return { text: entry.rating, color: selectedColor ?? colors.textMuted };
+    case "maturity":
+      return { text: entry.maturityRange, color: selectedColor ?? colors.textDim };
+    case "yield":
+      return { text: formatYieldPercent(entry.yield), color: selectedColor ?? colors.textBright };
+    case "spread":
+      return {
+        text: formatSpreadBp(entry.spreadBp),
+        color: selectedColor ?? (entry.spreadBp == null ? colors.textDim : priceColor(entry.spreadBp)),
+      };
+  }
+}
+
+export function BondSearchPane({ focused, width, height }: PaneProps) {
+  const [activeTab, setActiveTab] = usePluginPaneState<BondTab>("activeTab", "yields");
+  const [entries, setEntries] = useState<CorporateYieldEntry[]>([]);
+  const [status, setStatus] = useState<LoadStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const [sort, setSort] = useState<{ columnId: YieldColumnId; direction: SortDirection }>({
+    columnId: "rating",
+    direction: "asc",
+  });
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+
+  // Search bar (Phase 2 — present but not wired to a live bond search backend).
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchFocused, setSearchFocused] = useState(false);
+  const [searchFocusToken, setSearchFocusToken] = useState(0);
+  const searchInputRef = useRef<InputRenderable | null>(null);
+
+  const fetchGenRef = useRef(0);
+
+  const load = useCallback((refresh = false) => {
+    fetchGenRef.current += 1;
+    const gen = fetchGenRef.current;
+    setStatus((current) => (current === "loaded" && !refresh ? "loaded" : "loading"));
+    setError(null);
+    loadCorporateYields(refresh)
+      .then((nextEntries) => {
+        if (fetchGenRef.current !== gen) return;
+        setEntries(nextEntries);
+        setLastUpdated(Date.now());
+        setStatus("loaded");
+      })
+      .catch((loadError) => {
+        if (fetchGenRef.current !== gen) return;
+        setError(loadError instanceof Error ? loadError.message : String(loadError));
+        setStatus("error");
+      });
+  }, []);
+
+  useEffect(() => {
+    load(false);
+  }, [load]);
+
+  const rows = useMemo(() => sortedYields(entries, sort), [entries, sort]);
+  const columns = useMemo<YieldColumnDef[]>(() => buildYieldColumns(width), [width]);
+
+  // Keep selection in range when rows change.
+  useEffect(() => {
+    if (rows.length === 0) {
+      if (selectedIdx !== 0) setSelectedIdx(0);
+      return;
+    }
+    if (selectedIdx >= rows.length) setSelectedIdx(0);
+  }, [rows.length, selectedIdx]);
+
+  const updatedAgo = useUpdatedAgo(lastUpdated);
+
+  const focusSearch = useCallback(() => {
+    setSearchFocused(true);
+    setSearchFocusToken((current) => current + 1);
+  }, []);
+  const blurSearch = useCallback(() => {
+    setSearchFocused(false);
+  }, []);
+
+  const selectTab = useCallback((value: string) => {
+    setActiveTab(value === "search" ? "search" : "yields");
+    setSearchQuery("");
+  }, [setActiveTab]);
+
+  const handleRootKeyDown = useCallback(
+    (event: DataTableKeyEvent, context: DataTableRootKeyContext) => {
+      if (event.name === "r") {
+        event.preventDefault?.();
+        event.stopPropagation?.();
+        load(true);
+        return true;
+      }
+      if (activeTab === "search") {
+        if (context.selectedIndex <= 0 && isPlainArrowUp(event)) {
+          stopSearchFocusNavigation(event);
+          focusSearch();
+          return true;
+        }
+        if (event.name === "s" || event.name === "/") {
+          event.preventDefault?.();
+          event.stopPropagation?.();
+          focusSearch();
+          return true;
+        }
+      }
+      return false;
+    },
+    [activeTab, focusSearch, load],
+  );
+
+  useShortcut((event) => {
+    if (!focused || searchFocused) return;
+    if (event.name === "1") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      selectTab("yields");
+    } else if (event.name === "2") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      selectTab("search");
+    }
+  });
+
+  usePaneFooter(
+    BOND_SEARCH_PANE_ID,
+    () => {
+      if (!focused) return null;
+      const info = [
+        ...(lastUpdated
+          ? [{ id: "asof", parts: [{ text: `updated ${updatedAgo}`, tone: "muted" as const }] }]
+          : []),
+        ...(status === "loading" ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+        ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
+      ];
+      const hints = [
+        { id: "refresh", key: "r", label: "efresh", onPress: () => load(true) },
+        ...(activeTab === "search"
+          ? [{ id: "search", key: "s", label: "earch", onPress: focusSearch }]
+          : []),
+      ];
+      return { info, hints };
+    },
+    [activeTab, error, focusSearch, focused, lastUpdated, load, status, updatedAgo],
+  );
+
+  const tabs = (
+    <Box height={1}>
+      <Tabs
+        tabs={TABS}
+        activeValue={activeTab}
+        onSelect={selectTab}
+        compact
+        variant="pill"
+        focused={focused && !searchFocused}
+      />
+    </Box>
+  );
+
+  const bodyHeight = Math.max(1, height - 1);
+
+  if (activeTab === "search") {
+    const searchBar = (
+      <InputSearchBar
+        value={searchQuery}
+        focused={focused}
+        active={searchFocused}
+        width={width}
+        focusToken={searchFocusToken}
+        inputRef={searchInputRef}
+        placeholder="issuer or CUSIP"
+        debounceMs={120}
+        onFocus={focusSearch}
+        onBlur={blurSearch}
+        onNavigateDown={blurSearch}
+        onQueryChange={setSearchQuery}
+      />
+    );
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {tabs}
+        <Box paddingX={1} marginTop={0}>
+          {searchBar}
+        </Box>
+        <Box flexGrow={1} padding={1}>
+          <EmptyState
+            title="Bond search coming soon"
+            hint="Corporate yield indices are available on the Yields tab."
+          />
+        </Box>
+      </Box>
+    );
+  }
+
+  if (status === "loading" && entries.length === 0) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {tabs}
+        <Box flexGrow={1} justifyContent="center" alignItems="center">
+          <Spinner label="Loading corporate yields..." />
+        </Box>
+      </Box>
+    );
+  }
+
+  if (error && entries.length === 0) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {tabs}
+        <Box padding={1}>
+          <EmptyState title="Corporate yields unavailable." message={error} hint="Press r to retry." />
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      {tabs}
+      <DataTableView<CorporateYieldEntry, YieldColumn>
+        focused={focused && !searchFocused}
+        rootWidth={width}
+        rootHeight={bodyHeight}
+        selection={{
+          kind: "index",
+          selectedIndex: selectedIdx,
+          onChange: (index) => setSelectedIdx(index),
+        }}
+        onRootKeyDown={handleRootKeyDown}
+        columns={columns}
+        items={rows}
+        sortColumnId={sort.columnId}
+        sortDirection={sort.direction}
+        onHeaderClick={(columnId) =>
+          setSort((current) =>
+            nextSort(current, columnId as YieldColumnId, columnId === "label" ? "asc" : "asc"),
+          )
+        }
+        getItemKey={(entry, index) => `${entry.seriesId}-${index}`}
+        renderCell={renderYieldCell}
+        emptyStateTitle="No corporate yield data."
+        emptyStateHint="Press r to refresh."
+      />
+    </Box>
+  );
+}
+
+// Re-exported for callers that want the latest update date label.
+export { formatYieldDate };

--- a/src/plugins/builtin/bond-search/types.ts
+++ b/src/plugins/builtin/bond-search/types.ts
@@ -1,0 +1,21 @@
+export interface CorporateYieldEntry {
+  seriesId: string; // "BAMLC0A0CM", "BAMLH0A0HYM", ...
+  label: string; // "IG All-Rated", "High Yield", "BBB", "AAA"
+  rating: string; // "AAA", "BBB", "HY", "IG"
+  maturityRange: string; // "1-3Y", "5-10Y", "All"
+  yield: number | null; // percent, e.g. 5.42
+  treasuryYield: number | null; // matched Treasury yield, percent
+  spreadBp: number | null; // (corporate - treasury) * 100, basis points
+  updatedAt: Date | null;
+}
+
+export type LoadStatus = "idle" | "loading" | "loaded" | "error";
+
+export type BondTab = "yields" | "search";
+
+export interface YieldColumn {
+  id: "label" | "rating" | "maturity" | "yield" | "spread";
+  label: string;
+  width: number;
+  align: "left" | "right";
+}

--- a/src/plugins/builtin/composite-plugins.ts
+++ b/src/plugins/builtin/composite-plugins.ts
@@ -1,3 +1,4 @@
+import { bondSearchModule } from "./bond-search";
 import { portfolioAnalyticsModule } from "./analytics";
 import { brokerManagerModule } from "./broker-manager";
 import { changelogModule } from "./changelog";
@@ -65,7 +66,8 @@ export const macroPlugin = composeBuiltinPlugin({
   id: "macro",
   name: "Macro",
   version: "1.0.0",
-  description: "Economic calendar, yield curve, earnings calendar, and live financial TV.",
+  description:
+    "Economic calendar, yield curve, corporate bond yields, earnings calendar, and live financial TV.",
   toggleable: true,
-  modules: [economicCalendarModule, yieldCurveModule, earningsModule, tvModule],
+  modules: [economicCalendarModule, yieldCurveModule, bondSearchModule, earningsModule, tvModule],
 });


### PR DESCRIPTION
Feature (Phase 1): new Bond Search pane with Yields tab showing 8 ICE BofA corporate yield FRED series (AAA/AA/A/BBB/IG/HY/1-3Y/5-10Y) with Treasury spread column. Search tab left as empty state.\n\n**Draft**: The cloud FRED proxy currently rejects BAML corporate series. Needs backend allowlist update for BAMLC0A0CM, BAMLH0A0HYM, etc. before this can go live.