### PR TITLE
Add HILO and unusual options flow panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Open command mode with `Ctrl+P`, then type a command. Press `` ` `` to open tick
 | `TOP` | Ranked market stories |
 | `HM` | Market heatmap |
 | `MOST` | Market movers |
+| `HILO` | New highs and new lows |
 | `PF` | Portfolios and watchlists |
 | `KELLY AAPL` | Position sizing |
 | `HELP` | Full in-app shortcut list |
@@ -113,7 +114,7 @@ Open command mode with `Ctrl+P`, then type a command. Press `` ` `` to open tick
 ## What It Does
 
 - Research companies with quotes, charts, financials, filings, holders, insiders, options, analyst ratings, events, and relative valuation.
-- Follow markets with top stories, breaking news, sector feeds, Substack subscriptions, global indices, FX, macro events, yield curves, market movers, and fear/greed.
+- Follow markets with top stories, breaking news, sector feeds, Substack subscriptions, global indices, FX, macro events, yield curves, market movers, new-high/new-low and options-flow scanners, and fear/greed.
 - Track portfolios and watchlists, connect brokers, set alerts, keep notes, run AI screens, browse prediction markets, and use Gloom Cloud chat.
 
 ## CLI
@@ -239,6 +240,8 @@ The toolbar controls preset or exact date ranges, intervals from one minute thro
 | `TOP` | Ranked market stories |
 | `HM` | Market heatmap for large US stocks and ETFs |
 | `MOST` | Top gainers, losers, most active, and trending tickers |
+| `HILO` | Session new highs and new lows with 30s/1m/5m momentum |
+| `FLOW` | Unusual options activity: sweeps, blocks, and large premium |
 | `PM <query>` | Polymarket and Kalshi prediction data |
 | `N` | News feed |
 | `CN <ticker>` | Ticker news |

--- a/scripts/mock-scanner-server.ts
+++ b/scripts/mock-scanner-server.ts
@@ -1,0 +1,171 @@
+/**
+ * Dev-only stand-in for the cloud scanner feed, so HILO and FLOW can be built and
+ * smoke-tested before the server branch lands. Never imported by app code.
+ *
+ * Usage:
+ *   bun run scripts/mock-scanner-server.ts &
+ *   GLOOMBERB_API_URL=http://localhost:8791 bun run dev
+ *
+ * Pass --deny to exercise the non-pro `scanner.denied` path, or --freeze to send
+ * one snapshot and stop, which keeps rows stable while checking interactions.
+ */
+import type { ServerWebSocket } from "bun";
+
+const PORT = Number(process.env.MOCK_SCANNER_PORT ?? 8791);
+const DENY = process.argv.includes("--deny");
+const FREEZE = process.argv.includes("--freeze");
+
+type Scanner = "hilo" | "flow";
+type SocketData = { scanners: Set<Scanner> };
+
+const HILO_SYMBOLS = [
+  "RKLX", "ASTX", "PM", "AXSM", "NVDA", "SMCI", "CRWV", "PLTR", "HOOD", "SOFI",
+  "IONQ", "RGTI", "BBAI", "LUNR", "ACHR", "JOBY", "TSLA", "AMD", "MU", "AVGO",
+];
+const FLOW_SYMBOLS = ["NVDA", "TSLA", "SPY", "QQQ", "AAPL", "META", "AMD", "MSTR", "PLTR", "COIN"];
+const KINDS = ["sweep", "block", "split", "trade"] as const;
+const SIDES = ["ask", "bid", "mid", "unknown"] as const;
+
+function pick<T>(items: readonly T[]): T {
+  return items[Math.floor(Math.random() * items.length)]!;
+}
+
+const counts = new Map<string, number>();
+
+function hiloRow(symbol: string) {
+  const count = (counts.get(symbol) ?? Math.floor(Math.random() * 40)) + 1;
+  counts.set(symbol, count);
+  return {
+    symbol,
+    price: Number((Math.random() * 400 + 0.4).toFixed(4)),
+    volume: Math.floor(Math.random() * 900_000),
+    count,
+    at: Date.now() - Math.floor(Math.random() * 60_000),
+  };
+}
+
+function hiloPayload() {
+  const rows = (n: number) => Array.from({ length: n }, () => hiloRow(pick(HILO_SYMBOLS)))
+    .sort((left, right) => right.at - left.at);
+  const scale = 0.6 + Math.random() * 0.8;
+  return {
+    type: "scanner.hilo",
+    status: "live",
+    asOf: Date.now(),
+    windows: {
+      s30: { highs: Math.round(42 * scale), lows: Math.round(11 * scale) },
+      m1: { highs: Math.round(118 * scale), lows: Math.round(37 * scale) },
+      m5: { highs: Math.round(512 * scale), lows: Math.round(203 * scale) },
+    },
+    highs: rows(28),
+    lows: rows(28),
+  };
+}
+
+let flowEvents: unknown[] = [];
+
+function flowEvent() {
+  const underlying = pick(FLOW_SYMBOLS);
+  const right = Math.random() > 0.45 ? "C" : "P";
+  const strike = Math.round((Math.random() * 500 + 20) / 5) * 5;
+  const size = Math.floor(Math.random() * 4000) + 50;
+  const price = Number((Math.random() * 20 + 0.4).toFixed(2));
+  const openInterest = Math.floor(Math.random() * 6000) + 1;
+  const volume = Math.floor(Math.random() * 20_000);
+  const expiryDays = pick([2, 5, 9, 16, 30, 45, 120, 400]);
+  const expiry = new Date(Date.now() + expiryDays * 86_400_000).toISOString().slice(0, 10);
+  return {
+    id: `opt-${Date.now()}-${underlying}-${Math.random().toString(36).slice(2, 7)}`,
+    at: Date.now(),
+    underlying,
+    contract: `${underlying}${expiry.replaceAll("-", "").slice(2)}${right}${String(strike * 1000).padStart(8, "0")}`,
+    right,
+    strike,
+    expiry,
+    side: pick(SIDES),
+    kind: pick(KINDS),
+    size,
+    price,
+    premium: Math.round(price * size * 100),
+    volume,
+    openInterest,
+    volOi: Number((volume / openInterest).toFixed(2)),
+    iv: Number((Math.random() * 1.2).toFixed(2)),
+  };
+}
+
+function flowPayload(newEvents: number) {
+  flowEvents = [...Array.from({ length: newEvents }, flowEvent), ...flowEvents].slice(0, 200);
+  return { type: "scanner.flow", status: "live", asOf: Date.now(), events: flowEvents };
+}
+
+const clients = new Set<ServerWebSocket<SocketData>>();
+
+function broadcast(scanner: Scanner, payload: unknown): void {
+  const message = JSON.stringify(payload);
+  for (const client of clients) {
+    if (client.data.scanners.has(scanner)) client.send(message);
+  }
+}
+
+const server = Bun.serve<SocketData, never>({
+  port: PORT,
+  fetch(request, bunServer) {
+    const url = new URL(request.url);
+    if (url.pathname === "/cloud/ws") {
+      if (bunServer.upgrade(request, { data: { scanners: new Set<Scanner>() } })) return undefined;
+      return new Response("upgrade failed", { status: 400 });
+    }
+    if (url.pathname === "/market/scanner/hilo") {
+      const { type: _type, ...rest } = hiloPayload();
+      return Response.json(rest);
+    }
+    if (url.pathname === "/market/scanner/flow") {
+      const { type: _type, ...rest } = flowPayload(5);
+      return Response.json(rest);
+    }
+    return new Response("not found", { status: 404 });
+  },
+  websocket: {
+    open(ws) {
+      clients.add(ws);
+      ws.send(JSON.stringify({ type: "ready", user: { id: "mock", emailVerified: true, plan: "pro" } }));
+    },
+    close(ws) {
+      clients.delete(ws);
+    },
+    message(ws, raw) {
+      let parsed: any;
+      try {
+        parsed = JSON.parse(String(raw));
+      } catch {
+        return;
+      }
+      const scanner: Scanner | undefined = parsed?.scanner === "hilo" || parsed?.scanner === "flow"
+        ? parsed.scanner
+        : undefined;
+      if (!scanner) return;
+      if (parsed.type === "scanner.subscribe") {
+        if (DENY) {
+          ws.send(JSON.stringify({ type: "scanner.denied", scanner, reason: "pro_required" }));
+          return;
+        }
+        ws.data.scanners.add(scanner);
+        console.log(`[mock] subscribe ${scanner} (${clients.size} clients)`);
+        ws.send(JSON.stringify(scanner === "hilo" ? hiloPayload() : flowPayload(24)));
+      } else if (parsed.type === "scanner.unsubscribe") {
+        ws.data.scanners.delete(scanner);
+        console.log(`[mock] unsubscribe ${scanner}`);
+      }
+    },
+  },
+});
+
+if (!FREEZE) {
+  setInterval(() => {
+    broadcast("hilo", hiloPayload());
+    broadcast("flow", flowPayload(2));
+  }, 1000);
+}
+
+console.log(`[mock] scanner feed on http://localhost:${server.port} (deny=${DENY} freeze=${FREEZE})`);

--- a/scripts/mock-scanner-server.ts
+++ b/scripts/mock-scanner-server.ts
@@ -6,14 +6,25 @@
  *   bun run scripts/mock-scanner-server.ts &
  *   GLOOMBERB_API_URL=http://localhost:8791 bun run dev
  *
- * Pass --deny to exercise the non-pro `scanner.denied` path, or --freeze to send
- * one snapshot and stop, which keeps rows stable while checking interactions.
+ * Pass --freeze to send one snapshot and stop, which keeps rows stable while
+ * checking interactions, --delayed for the free-tier 15m HILO instance (FLOW is
+ * then denied), or --anon for the signed-out `auth_required` refusal.
  */
 import type { ServerWebSocket } from "bun";
 
 const PORT = Number(process.env.MOCK_SCANNER_PORT ?? 8791);
-const DENY = process.argv.includes("--deny");
 const FREEZE = process.argv.includes("--freeze");
+const ANON = process.argv.includes("--anon");
+const DELAYED = process.argv.includes("--delayed");
+// Free accounts get the delayed HILO instance and no options entitlement at all.
+const ACCESS = DELAYED
+  ? { access: "delayed" as const, delayMinutes: 15 }
+  : { access: "realtime" as const, delayMinutes: 0 };
+
+function denialFor(scanner: Scanner): string | null {
+  if (ANON) return "auth_required";
+  return DELAYED && scanner === "flow" ? "pro_required" : null;
+}
 
 type Scanner = "hilo" | "flow";
 type SocketData = { scanners: Set<Scanner> };
@@ -51,6 +62,7 @@ function hiloPayload() {
   return {
     type: "scanner.hilo",
     status: "live",
+    ...ACCESS,
     asOf: Date.now(),
     windows: {
       s30: { highs: Math.round(42 * scale), lows: Math.round(11 * scale) },
@@ -96,7 +108,7 @@ function flowEvent() {
 
 function flowPayload(newEvents: number) {
   flowEvents = [...Array.from({ length: newEvents }, flowEvent), ...flowEvents].slice(0, 200);
-  return { type: "scanner.flow", status: "live", asOf: Date.now(), events: flowEvents };
+  return { type: "scanner.flow", status: "live", ...ACCESS, asOf: Date.now(), events: flowEvents };
 }
 
 const clients = new Set<ServerWebSocket<SocketData>>();
@@ -116,12 +128,13 @@ const server = Bun.serve<SocketData, never>({
       if (bunServer.upgrade(request, { data: { scanners: new Set<Scanner>() } })) return undefined;
       return new Response("upgrade failed", { status: 400 });
     }
-    if (url.pathname === "/market/scanner/hilo") {
-      const { type: _type, ...rest } = hiloPayload();
-      return Response.json(rest);
-    }
-    if (url.pathname === "/market/scanner/flow") {
-      const { type: _type, ...rest } = flowPayload(5);
+    for (const scanner of ["hilo", "flow"] as const) {
+      if (url.pathname !== `/market/scanner/${scanner}`) continue;
+      const reason = denialFor(scanner);
+      if (reason) {
+        return Response.json({ status: "denied", reason }, { status: reason === "auth_required" ? 401 : 402 });
+      }
+      const { type: _type, ...rest } = scanner === "hilo" ? hiloPayload() : flowPayload(5);
       return Response.json(rest);
     }
     return new Response("not found", { status: 404 });
@@ -129,7 +142,18 @@ const server = Bun.serve<SocketData, never>({
   websocket: {
     open(ws) {
       clients.add(ws);
-      ws.send(JSON.stringify({ type: "ready", user: { id: "mock", emailVerified: true, plan: "pro" } }));
+      ws.send(JSON.stringify(ANON
+        ? { type: "ready", user: null }
+        : {
+          type: "ready",
+          user: {
+            id: "mock",
+            username: "mock",
+            emailVerified: true,
+            plan: DELAYED ? "free" : "pro",
+            effectivePlan: DELAYED ? "free" : "pro",
+          },
+        }));
     },
     close(ws) {
       clients.delete(ws);
@@ -146,8 +170,9 @@ const server = Bun.serve<SocketData, never>({
         : undefined;
       if (!scanner) return;
       if (parsed.type === "scanner.subscribe") {
-        if (DENY) {
-          ws.send(JSON.stringify({ type: "scanner.denied", scanner, reason: "pro_required" }));
+        const reason = denialFor(scanner);
+        if (reason) {
+          ws.send(JSON.stringify({ type: "scanner.denied", scanner, reason }));
           return;
         }
         ws.data.scanners.add(scanner);
@@ -168,4 +193,4 @@ if (!FREEZE) {
   }, 1000);
 }
 
-console.log(`[mock] scanner feed on http://localhost:${server.port} (deny=${DENY} freeze=${FREEZE})`);
+console.log(`[mock] scanner feed on http://localhost:${server.port} (anon=${ANON} delayed=${DELAYED} freeze=${FREEZE})`);

--- a/src/api-client/index.test.ts
+++ b/src/api-client/index.test.ts
@@ -605,6 +605,65 @@ describe("apiClient quote socket", () => {
   });
 });
 
+describe("apiClient scanner subscriptions", () => {
+  test("subscribes once for many panes, fans out, replays the snapshot, and unsubscribes last", () => {
+    const sockets = installTestWebSocket();
+    const first: unknown[] = [];
+    const second: unknown[] = [];
+
+    const unsubscribeFirst = apiClient.subscribeScanner("hilo", (event) => first.push(event));
+    const socket = sockets[0]!;
+    socket.open();
+    expect(socket.sent).toContainEqual({ type: "scanner.subscribe", scanner: "hilo" });
+
+    const payload = {
+      status: "live",
+      asOf: 1,
+      windows: { s30: { highs: 1, lows: 0 }, m1: { highs: 2, lows: 1 }, m5: { highs: 3, lows: 2 } },
+      highs: [],
+      lows: [],
+    };
+    socket.receive({ type: "scanner.hilo", ...payload });
+
+    // A second pane must not open a second upstream subscription, and must not
+    // wait a tick for its first frame.
+    const subscribeCount = () => socket.sent.filter((message: any) => message.type === "scanner.subscribe").length;
+    const before = subscribeCount();
+    const unsubscribeSecond = apiClient.subscribeScanner("hilo", (event) => second.push(event));
+    expect(subscribeCount()).toBe(before);
+    expect(second).toEqual([{ type: "data", payload }]);
+
+    socket.receive({ type: "scanner.hilo", ...payload, asOf: 2 });
+    expect(first).toHaveLength(2);
+    expect(second).toHaveLength(2);
+
+    unsubscribeFirst();
+    expect(socket.sent).not.toContainEqual({ type: "scanner.unsubscribe", scanner: "hilo" });
+    unsubscribeSecond();
+    expect(socket.sent).toContainEqual({ type: "scanner.unsubscribe", scanner: "hilo" });
+  });
+
+  test("replays scanner subscriptions after a reconnect and surfaces denials", () => {
+    const sockets = installTestWebSocket();
+    const seen: unknown[] = [];
+    const unsubscribe = apiClient.subscribeScanner("flow", (event) => seen.push(event));
+
+    const socket = sockets[0]!;
+    socket.open();
+    socket.receive({ type: "scanner.denied", scanner: "flow", reason: "pro_required" });
+    expect(seen).toEqual([{ type: "denied", reason: "pro_required" }]);
+
+    jest.useFakeTimers();
+    socket.closeWith({ code: 1006, reason: "network" });
+    jest.runAllTimers();
+    const reconnected = sockets[1]!;
+    reconnected.open();
+    expect(reconnected.sent).toContainEqual({ type: "scanner.subscribe", scanner: "flow" });
+
+    unsubscribe();
+  });
+});
+
 describe("apiClient chat timestamps", () => {
   test("sends the before cursor when loading older chat messages", async () => {
     let requestedUrl = "";

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -57,6 +57,8 @@ import type {
   CloudSyncPushResponse,
   CloudSyncSnapshotResponse,
   QuoteStreamTarget,
+  ScannerFeedEvent,
+  ScannerKind,
 } from "./types";
 import type { SyncSettings, SyncSnapshot } from "../sync/types";
 
@@ -409,6 +411,11 @@ class GloomApiClient {
     onQuote: (target: QuoteStreamTarget, quote: CloudQuotePayload) => void,
   ): () => void {
     return this.socket.subscribeQuotes(targets, onQuote);
+  }
+
+  /** Subscribes to a shared scanner feed; all panes of one kind share one upstream subscription. */
+  subscribeScanner(scanner: ScannerKind, listener: (event: ScannerFeedEvent) => void): () => void {
+    return this.socket.subscribeScanner(scanner, listener);
   }
 
   dispose(): void {

--- a/src/api-client/request.ts
+++ b/src/api-client/request.ts
@@ -16,7 +16,12 @@ export function setCloudApiFetchTransport(transport: CloudApiFetchTransport | nu
   cloudApiFetchTransport = transport ?? httpFetch;
 }
 
+declare const __GLOOMBERB_API_URL__: string | undefined;
+
 function getCloudApiBaseUrl(): string {
+  // Browser bundles have no `process`; the build replaces this with a literal.
+  const bundled = typeof __GLOOMBERB_API_URL__ === "string" ? __GLOOMBERB_API_URL__ : "";
+  if (bundled) return bundled;
   if (typeof process === "undefined") {
     return DEFAULT_API_URL;
   }

--- a/src/api-client/socket.ts
+++ b/src/api-client/socket.ts
@@ -4,6 +4,8 @@ import type {
   ChatNotification,
   CloudQuotePayload,
   QuoteStreamTarget,
+  ScannerFeedEvent,
+  ScannerKind,
 } from "./types";
 import {
   normalizeChatMessage,
@@ -23,6 +25,12 @@ type QuoteListener = (target: QuoteStreamTarget, quote: CloudQuotePayload) => vo
 type QuoteSubscription = {
   target: QuoteStreamTarget;
   listener: QuoteListener;
+};
+type ScannerListener = (event: ScannerFeedEvent) => void;
+
+const SCANNER_MESSAGE_KINDS: Record<string, ScannerKind> = {
+  "scanner.hilo": "hilo",
+  "scanner.flow": "flow",
 };
 
 function mergeQuoteStreamSubscriptions(
@@ -68,6 +76,9 @@ export class CloudApiSocket {
   private readonly pendingQuoteSubscribes = new Map<string, QuoteStreamTarget>();
   private readonly pendingQuoteUnsubscribes = new Map<string, QuoteStreamTarget>();
   private quoteSubscriptionFlushTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly scannerListeners = new Map<ScannerKind, Set<ScannerListener>>();
+  /** Latest fan-out payload, so a pane opened mid-stream does not wait for the next tick. */
+  private readonly scannerSnapshots = new Map<ScannerKind, ScannerFeedEvent>();
 
   constructor(private readonly delegate: CloudApiSocketDelegate) {}
 
@@ -160,6 +171,37 @@ export class CloudApiSocket {
     this.chatPresenceListeners.add(listener);
     return () => {
       this.chatPresenceListeners.delete(listener);
+    };
+  }
+
+  /**
+   * Subscribes to a shared server-computed scanner. Every open pane of the same
+   * kind shares one upstream subscription; the socket fans the payload out.
+   */
+  subscribeScanner(scanner: ScannerKind, listener: ScannerListener): () => void {
+    const listeners = this.scannerListeners.get(scanner) ?? new Set<ScannerListener>();
+    const firstListener = listeners.size === 0;
+    listeners.add(listener);
+    this.scannerListeners.set(scanner, listeners);
+    this.ensureSocket();
+    if (firstListener) {
+      this.sendSocketMessage({ type: "scanner.subscribe", scanner });
+    } else {
+      const snapshot = this.scannerSnapshots.get(scanner);
+      if (snapshot) listener(snapshot);
+    }
+
+    return () => {
+      const current = this.scannerListeners.get(scanner);
+      if (!current || !current.delete(listener)) return;
+      if (current.size === 0) {
+        this.scannerListeners.delete(scanner);
+        this.scannerSnapshots.delete(scanner);
+        this.sendSocketMessage({ type: "scanner.unsubscribe", scanner });
+      }
+      if (!this.shouldKeepSocketOpen()) {
+        this.teardown();
+      }
     };
   }
 
@@ -264,6 +306,8 @@ export class CloudApiSocket {
     this.quoteTargets.clear();
     this.pendingQuoteSubscribes.clear();
     this.pendingQuoteUnsubscribes.clear();
+    this.scannerListeners.clear();
+    this.scannerSnapshots.clear();
     if (this.quoteSubscriptionFlushTimer) {
       clearTimeout(this.quoteSubscriptionFlushTimer);
       this.quoteSubscriptionFlushTimer = null;
@@ -296,7 +340,7 @@ export class CloudApiSocket {
         return;
       }
       this.delegate.markCurrentUserUnverified();
-      if (this.quoteTargets.size > 0) {
+      if (this.quoteTargets.size > 0 || this.scannerListeners.size > 0) {
         return;
       }
       this.teardown();
@@ -326,6 +370,24 @@ export class CloudApiSocket {
       return;
     }
 
+    const scannerKind = typeof parsed?.type === "string" ? SCANNER_MESSAGE_KINDS[parsed.type] : undefined;
+    if (scannerKind) {
+      const { type: _type, ...payload } = parsed;
+      this.emitScannerEvent(scannerKind, { type: "data", payload });
+      return;
+    }
+
+    if (parsed?.type === "scanner.denied") {
+      const denied = SCANNER_MESSAGE_KINDS[`scanner.${parsed.scanner}`];
+      if (denied) {
+        this.emitScannerEvent(denied, {
+          type: "denied",
+          reason: typeof parsed.reason === "string" ? parsed.reason : "pro_required",
+        });
+      }
+      return;
+    }
+
     if (parsed?.type === "market.quote" && parsed.quote && typeof parsed.symbol === "string") {
       const key = marketKey(parsed.symbol, parsed.exchange);
       const quote: CloudQuotePayload = {
@@ -347,8 +409,15 @@ export class CloudApiSocket {
     return baseUrl.replace(/^https?/, wsProtocol);
   }
 
+  private emitScannerEvent(scanner: ScannerKind, event: ScannerFeedEvent): void {
+    this.scannerSnapshots.set(scanner, event);
+    for (const listener of this.scannerListeners.get(scanner) ?? []) {
+      listener(event);
+    }
+  }
+
   private shouldKeepSocketOpen(): boolean {
-    if (this.quoteTargets.size > 0) return true;
+    if (this.quoteTargets.size > 0 || this.scannerListeners.size > 0) return true;
     return !!this.delegate.getSocketAuthToken()
       && this.delegate.hasVerifiedUser()
       && this.channelListeners.size > 0;
@@ -428,6 +497,8 @@ export class CloudApiSocket {
         || type === "market.unsubscribe"
         || type === "chat.subscribe"
         || type === "chat.unsubscribe"
+        || type === "scanner.subscribe"
+        || type === "scanner.unsubscribe"
       ) {
         cloudApiLog.info("send websocket message", payload);
       }
@@ -440,6 +511,10 @@ export class CloudApiSocket {
 
     for (const channelId of this.channelListeners.keys()) {
       this.sendSocketMessage({ type: "chat.subscribe", channelId });
+    }
+
+    for (const scanner of this.scannerListeners.keys()) {
+      this.sendSocketMessage({ type: "scanner.subscribe", scanner });
     }
 
     if (this.quoteTargets.size > 0) {

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -627,6 +627,69 @@ export type DeviceAuthTokenResponse =
   | { status: "expired" }
   | { status: "approved"; sessionToken: string; user: AuthUser };
 
+/** Shared server-computed scanners fanned out to every subscriber. */
+export type ScannerKind = "hilo" | "flow";
+
+export type ScannerStatus = "live" | "starting" | "closed" | "degraded";
+
+export interface ScannerWindowCounts {
+  highs: number;
+  lows: number;
+}
+
+export interface ScannerHiloExtreme {
+  symbol: string;
+  price: number;
+  volume?: number | null;
+  /** Times this symbol printed a new session extreme today. */
+  count: number;
+  at: number;
+}
+
+export interface ScannerHiloPayload {
+  status: ScannerStatus;
+  asOf: number;
+  windows: {
+    s30: ScannerWindowCounts;
+    m1: ScannerWindowCounts;
+    m5: ScannerWindowCounts;
+  };
+  highs: ScannerHiloExtreme[];
+  lows: ScannerHiloExtreme[];
+}
+
+export interface ScannerFlowEvent {
+  id: string;
+  at: number;
+  underlying: string;
+  contract: string;
+  right: "C" | "P";
+  strike: number;
+  expiry: string;
+  side: "ask" | "bid" | "mid" | "unknown";
+  kind: "sweep" | "block" | "split" | "trade";
+  size: number;
+  price: number;
+  premium: number;
+  volume?: number | null;
+  openInterest?: number | null;
+  volOi?: number | null;
+  iv?: number | null;
+}
+
+export interface ScannerFlowPayload {
+  status: ScannerStatus;
+  asOf: number;
+  events: ScannerFlowEvent[];
+}
+
+export type ScannerPayload = ScannerHiloPayload | ScannerFlowPayload;
+
+/** What a scanner subscriber receives: data, or the entitlement refusal. */
+export type ScannerFeedEvent<T extends ScannerPayload = ScannerPayload> =
+  | { type: "data"; payload: T }
+  | { type: "denied"; reason: string };
+
 export interface QuoteStreamTarget {
   symbol: string;
   exchange?: string;

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -646,7 +646,14 @@ export interface ScannerHiloExtreme {
   at: number;
 }
 
-export interface ScannerHiloPayload {
+/** Which entitlement tier produced the payload: free accounts get a delayed instance. */
+export interface ScannerAccessInfo {
+  access: "realtime" | "delayed";
+  /** 0 on the realtime instance, 15 on the delayed one. */
+  delayMinutes: number;
+}
+
+export interface ScannerHiloPayload extends ScannerAccessInfo {
   status: ScannerStatus;
   asOf: number;
   windows: {
@@ -677,7 +684,7 @@ export interface ScannerFlowEvent {
   iv?: number | null;
 }
 
-export interface ScannerFlowPayload {
+export interface ScannerFlowPayload extends ScannerAccessInfo {
   status: ScannerStatus;
   asOf: number;
   events: ScannerFlowEvent[];

--- a/src/plugins/builtin/composite-plugins.ts
+++ b/src/plugins/builtin/composite-plugins.ts
@@ -14,6 +14,7 @@ import { marketMoversModule } from "./market-movers";
 import { tvModule } from "./tv";
 import { composeBuiltinPlugin } from "./plugin-module";
 import { portfolioListModule } from "./portfolio-list";
+import { scannerModule } from "./scanner";
 import { sectorsModule } from "./sectors";
 import { worldIndicesModule } from "./world-indices";
 import { yieldCurveModule } from "./yield-curve";
@@ -48,13 +49,14 @@ export const marketOverviewPlugin = composeBuiltinPlugin({
   id: "market-overview",
   name: "Market Overview",
   version: "1.0.0",
-  description: "Global indices, movers, sectors, FX, sentiment, and correlations.",
+  description: "Global indices, movers, scanners, sectors, FX, sentiment, and correlations.",
   toggleable: true,
   modules: [
     correlationModule,
     worldIndicesModule,
     marketHeatmapModule,
     marketMoversModule,
+    scannerModule,
     fearGreedModule,
     sectorsModule,
     fxMatrixModule,

--- a/src/plugins/builtin/scanner/denied.tsx
+++ b/src/plugins/builtin/scanner/denied.tsx
@@ -1,0 +1,24 @@
+import { Box } from "../../../ui";
+import { Button, EmptyState } from "../../../components";
+import { useCloudPlanAction, useCloudUpgradeAction } from "../shared/cloud-upgrade";
+
+/** Both scanners are Pro-only, so a refusal is a call to action, not an error. */
+export function ScannerDeniedState({ reason }: { reason: string | null }) {
+  const openUpgrade = useCloudUpgradeAction();
+  const openPlan = useCloudPlanAction();
+
+  return (
+    <Box flexDirection="column" paddingX={1} paddingY={1}>
+      <EmptyState
+        title={reason === "pro_required"
+          ? "Market scanners are part of Gloom Cloud Pro."
+          : "Sign in to stream the market scanners."}
+        message="One shared feed, streamed live to every Pro session."
+      />
+      <Box flexDirection="row" marginTop={1} gap={1}>
+        <Button label="Upgrade to Pro" onPress={openUpgrade} />
+        <Button label="Manage account" variant="secondary" onPress={openPlan} />
+      </Box>
+    </Box>
+  );
+}

--- a/src/plugins/builtin/scanner/denied.tsx
+++ b/src/plugins/builtin/scanner/denied.tsx
@@ -1,23 +1,30 @@
 import { Box } from "../../../ui";
 import { Button, EmptyState } from "../../../components";
+import { t } from "../../../i18n";
+import { CloudAuthNotice } from "../cloud/auth-actions";
 import { useCloudPlanAction, useCloudUpgradeAction } from "../shared/cloud-upgrade";
 
-/** Both scanners are Pro-only, so a refusal is a call to action, not an error. */
+/**
+ * Options flow is the one scanner with no delayed tier to fall back to, so a
+ * refusal is a call to action. Signed-out users need to sign in, not upgrade.
+ */
 export function ScannerDeniedState({ reason }: { reason: string | null }) {
   const openUpgrade = useCloudUpgradeAction();
   const openPlan = useCloudPlanAction();
 
+  if (reason === "auth_required") {
+    return <CloudAuthNotice message={t("Sign in to stream the market scanners.")} />;
+  }
+
   return (
     <Box flexDirection="column" paddingX={1} paddingY={1}>
       <EmptyState
-        title={reason === "pro_required"
-          ? "Market scanners are part of Gloom Cloud Pro."
-          : "Sign in to stream the market scanners."}
-        message="One shared feed, streamed live to every Pro session."
+        title="Options flow is part of Gloom Cloud Pro."
+        message="Live sweeps, blocks, and large premium prints from the full OPRA feed."
       />
       <Box flexDirection="row" marginTop={1} gap={1}>
-        <Button label="Upgrade to Pro" onPress={openUpgrade} />
-        <Button label="Manage account" variant="secondary" onPress={openPlan} />
+        <Button label={t("Upgrade to Pro")} onPress={openUpgrade} />
+        <Button label={t("Manage account")} variant="secondary" onPress={openPlan} />
       </Box>
     </Box>
   );

--- a/src/plugins/builtin/scanner/feed.ts
+++ b/src/plugins/builtin/scanner/feed.ts
@@ -1,0 +1,75 @@
+import { useEffect, useMemo, useState } from "react";
+import { apiClient } from "../../../api-client";
+import type {
+  ScannerFlowPayload,
+  ScannerHiloPayload,
+  ScannerPayload,
+} from "../../../api-client";
+import type { PaneFooterSegment } from "../../../components";
+import { usePaneStatusFooter } from "../shared/pane-footer";
+
+export interface ScannerFeedState<T extends ScannerPayload> {
+  payload: T | null;
+  /** True once the server refused the subscription (not signed in, or not Pro). */
+  denied: boolean;
+  deniedReason: string | null;
+}
+
+const INITIAL_STATE = { payload: null, denied: false, deniedReason: null } as const;
+
+function useScannerFeed<T extends ScannerPayload>(scanner: "hilo" | "flow"): ScannerFeedState<T> {
+  const [state, setState] = useState<ScannerFeedState<T>>(INITIAL_STATE);
+
+  useEffect(() => {
+    setState(INITIAL_STATE);
+    return apiClient.subscribeScanner(scanner, (event) => {
+      setState(event.type === "denied"
+        ? { payload: null, denied: true, deniedReason: event.reason }
+        : { payload: event.payload as unknown as T, denied: false, deniedReason: null });
+    });
+  }, [scanner]);
+
+  return state;
+}
+
+export function useHiloFeed(): ScannerFeedState<ScannerHiloPayload> {
+  return useScannerFeed<ScannerHiloPayload>("hilo");
+}
+
+export function useFlowFeed(): ScannerFeedState<ScannerFlowPayload> {
+  return useScannerFeed<ScannerFlowPayload>("flow");
+}
+
+/**
+ * The only status a scanner pane can change between: stream health while it is
+ * entitled, or the auth/entitlement refusal.
+ */
+export function useScannerStatusFooter(
+  registrationId: string,
+  state: ScannerFeedState<ScannerPayload>,
+): void {
+  const info = useMemo<PaneFooterSegment[]>(() => {
+    if (state.denied) {
+      return [{
+        id: "scanner-status",
+        parts: [{
+          text: state.deniedReason === "pro_required" ? "pro required" : "sign in required",
+          tone: "warning" as const,
+        }],
+      }];
+    }
+    const status = state.payload?.status;
+    if (!status || status === "starting") {
+      return [{ id: "scanner-status", parts: [{ text: "connecting", tone: "muted" as const }] }];
+    }
+    if (status === "live") {
+      return [{ id: "scanner-status", parts: [{ text: "live", tone: "positive" as const }] }];
+    }
+    if (status === "closed") {
+      return [{ id: "scanner-status", parts: [{ text: "market closed", tone: "muted" as const }] }];
+    }
+    return [{ id: "scanner-status", parts: [{ text: "degraded", tone: "warning" as const }] }];
+  }, [state.denied, state.deniedReason, state.payload?.status]);
+
+  usePaneStatusFooter({ registrationId, info });
+}

--- a/src/plugins/builtin/scanner/feed.ts
+++ b/src/plugins/builtin/scanner/feed.ts
@@ -6,7 +6,10 @@ import type {
   ScannerPayload,
 } from "../../../api-client";
 import type { PaneFooterSegment } from "../../../components";
+import { tf } from "../../../i18n";
+import { useCloudAccessFooter } from "../shared/cloud-upgrade";
 import { usePaneStatusFooter } from "../shared/pane-footer";
+import { CLOUD_QUOTE_DELAY_MINUTES } from "../shared/plan-access";
 
 export interface ScannerFeedState<T extends ScannerPayload> {
   payload: T | null;
@@ -41,14 +44,25 @@ export function useFlowFeed(): ScannerFeedState<ScannerFlowPayload> {
 }
 
 /**
- * The only status a scanner pane can change between: stream health while it is
- * entitled, or the auth/entitlement refusal.
+ * The only status a scanner pane can change between: the cloud entitlement this
+ * feed arrived on, stream health while it is entitled, or the auth/entitlement
+ * refusal. The delay comes from the payload, since the server moves a session
+ * between the realtime and delayed instances without a remount.
  */
 export function useScannerStatusFooter(
   registrationId: string,
   state: ScannerFeedState<ScannerPayload>,
+  focused: boolean,
 ): void {
-  const info = useMemo<PaneFooterSegment[]>(() => {
+  const { segment } = useCloudAccessFooter({
+    delayLabel: tf("{count}m", { count: state.payload?.delayMinutes || CLOUD_QUOTE_DELAY_MINUTES }),
+    degraded: state.payload?.access === "delayed",
+    focused,
+    segmentId: `${registrationId}-access`,
+    shortcutScope: `${registrationId}:upgrade`,
+  });
+
+  const status = useMemo<PaneFooterSegment[]>(() => {
     if (state.denied) {
       return [{
         id: "scanner-status",
@@ -70,6 +84,11 @@ export function useScannerStatusFooter(
     }
     return [{ id: "scanner-status", parts: [{ text: "degraded", tone: "warning" as const }] }];
   }, [state.denied, state.deniedReason, state.payload?.status]);
+
+  const info = useMemo(
+    () => (segment ? [segment, ...status] : status),
+    [segment, status],
+  );
 
   usePaneStatusFooter({ registrationId, info });
 }

--- a/src/plugins/builtin/scanner/flow-model.test.ts
+++ b/src/plugins/builtin/scanner/flow-model.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import type { ScannerFlowEvent } from "../../../api-client";
+import { DEFAULT_FLOW_FILTERS, filterFlowEvents, type FlowFilters } from "./flow-model";
+
+const NOW = Date.parse("2026-03-02T15:00:00Z");
+
+function event(overrides: Partial<ScannerFlowEvent> = {}): ScannerFlowEvent {
+  return {
+    id: overrides.id ?? `id-${Math.random()}`,
+    at: NOW,
+    underlying: "NVDA",
+    contract: "NVDA260320C01300000",
+    right: "C",
+    strike: 1300,
+    expiry: "2026-03-20",
+    side: "ask",
+    kind: "sweep",
+    size: 100,
+    price: 10,
+    premium: 500_000,
+    volume: 5000,
+    openInterest: 1000,
+    volOi: 5,
+    iv: 0.6,
+    ...overrides,
+  };
+}
+
+function filters(overrides: Partial<FlowFilters> = {}): FlowFilters {
+  return { ...DEFAULT_FLOW_FILTERS, ...overrides };
+}
+
+const watchlist = new Set(["NVDA"]);
+
+describe("client-side flow filters", () => {
+  test("composes every filter as an AND over the same shared feed", () => {
+    const events = [
+      event({ id: "keep" }),
+      event({ id: "cheap", premium: 100_000 }),
+      event({ id: "put", right: "P" }),
+      event({ id: "block", kind: "block" }),
+      event({ id: "thin-oi", volOi: 0.4 }),
+      event({ id: "far", expiry: "2026-12-18" }),
+      event({ id: "off-watchlist", underlying: "TSLA" }),
+    ];
+
+    const kept = filterFlowEvents(events, filters({
+      minPremium: "250000",
+      side: "calls",
+      kind: "sweeps",
+      volOi: "1",
+      expiry: "30",
+      universe: "watchlist",
+    }), watchlist, NOW);
+
+    expect(kept.map((entry) => entry.id)).toEqual(["keep"]);
+  });
+
+  test("defaults only apply the premium floor", () => {
+    const events = [
+      event({ id: "put-block-far", right: "P", kind: "block", expiry: "2027-01-15", volOi: null }),
+      event({ id: "small", premium: 60_000 }),
+      event({ id: "other-name", underlying: "SPY" }),
+    ];
+    expect(filterFlowEvents(events, filters(), watchlist, NOW).map((entry) => entry.id))
+      .toEqual(["put-block-far", "other-name"]);
+  });
+
+  test("drops events with unknown vol/OI only when a floor is set", () => {
+    const events = [event({ id: "unknown-oi", volOi: null })];
+    expect(filterFlowEvents(events, filters({ volOi: "off" }), watchlist, NOW)).toHaveLength(1);
+    expect(filterFlowEvents(events, filters({ volOi: "1" }), watchlist, NOW)).toHaveLength(0);
+  });
+
+  test("keeps today's expiry inside a 7 day window and rejects unparsable dates", () => {
+    const events = [
+      event({ id: "today", expiry: "2026-03-02" }),
+      event({ id: "in-7", expiry: "2026-03-09" }),
+      event({ id: "in-8", expiry: "2026-03-10" }),
+      event({ id: "bad", expiry: "not-a-date" }),
+    ];
+    expect(filterFlowEvents(events, filters({ expiry: "7" }), watchlist, NOW).map((entry) => entry.id))
+      .toEqual(["today", "in-7"]);
+  });
+});

--- a/src/plugins/builtin/scanner/flow-model.ts
+++ b/src/plugins/builtin/scanner/flow-model.ts
@@ -1,0 +1,95 @@
+import type { ScannerFlowEvent } from "../../../api-client";
+
+export type FlowMinPremium = "50000" | "250000" | "1000000";
+export type FlowSide = "calls" | "puts" | "both";
+export type FlowKind = "all" | "sweeps" | "blocks";
+export type FlowVolOi = "off" | "1" | "5";
+export type FlowExpiry = "7" | "30" | "all";
+export type FlowUniverse = "active" | "watchlist";
+
+export interface FlowFilters {
+  minPremium: FlowMinPremium;
+  side: FlowSide;
+  kind: FlowKind;
+  volOi: FlowVolOi;
+  expiry: FlowExpiry;
+  universe: FlowUniverse;
+}
+
+export const DEFAULT_FLOW_FILTERS: FlowFilters = {
+  minPremium: "250000",
+  side: "both",
+  kind: "all",
+  volOi: "off",
+  expiry: "all",
+  universe: "active",
+};
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function expiryDaysFromNow(expiry: string, now: number): number | null {
+  const parsed = Date.parse(`${expiry}T00:00:00Z`);
+  if (Number.isNaN(parsed)) return null;
+  return (parsed - now) / MS_PER_DAY;
+}
+
+/**
+ * The shared feed is published once for everyone, so every user preference is a
+ * local predicate over the same events. Never push these upstream.
+ */
+export function filterFlowEvents(
+  events: readonly ScannerFlowEvent[] | undefined,
+  filters: FlowFilters,
+  watchlist: ReadonlySet<string>,
+  now = Date.now(),
+): ScannerFlowEvent[] {
+  const minPremium = Number(filters.minPremium);
+  const minVolOi = filters.volOi === "off" ? null : Number(filters.volOi);
+  const maxExpiryDays = filters.expiry === "all" ? null : Number(filters.expiry);
+
+  return (events ?? []).filter((event) => {
+    if (!(event.premium >= minPremium)) return false;
+    if (filters.side === "calls" && event.right !== "C") return false;
+    if (filters.side === "puts" && event.right !== "P") return false;
+    if (filters.kind === "sweeps" && event.kind !== "sweep") return false;
+    if (filters.kind === "blocks" && event.kind !== "block") return false;
+    if (minVolOi != null && !(typeof event.volOi === "number" && event.volOi >= minVolOi)) return false;
+    if (maxExpiryDays != null) {
+      const days = expiryDaysFromNow(event.expiry, now);
+      if (days == null || days > maxExpiryDays || days < -1) return false;
+    }
+    if (filters.universe === "watchlist" && !watchlist.has(event.underlying.toUpperCase())) return false;
+    return true;
+  });
+}
+
+export function formatFlowPremium(premium: number): string {
+  if (premium >= 1e9) return `$${(premium / 1e9).toFixed(1)}B`;
+  if (premium >= 1e6) return `$${(premium / 1e6).toFixed(1)}M`;
+  if (premium >= 1e3) return `$${Math.round(premium / 1e3)}K`;
+  return `$${Math.round(premium)}`;
+}
+
+export function formatFlowType(event: ScannerFlowEvent): string {
+  return `${event.right} ${event.kind}`;
+}
+
+export function formatFlowSide(side: ScannerFlowEvent["side"]): string {
+  return side === "unknown" ? "—" : side;
+}
+
+export function formatFlowVolOi(volOi: number | null | undefined): string {
+  if (typeof volOi !== "number" || !Number.isFinite(volOi)) return "—";
+  return volOi >= 10 ? `${Math.round(volOi)}x` : `${volOi.toFixed(1)}x`;
+}
+
+export function formatFlowExpiry(expiry: string): string {
+  const parts = expiry.split("-");
+  return parts.length === 3 ? `${parts[1]}/${parts[2]}` : expiry;
+}
+
+export function formatFlowTime(at: number): string {
+  const date = new Date(at);
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}

--- a/src/plugins/builtin/scanner/flow-pane.tsx
+++ b/src/plugins/builtin/scanner/flow-pane.tsx
@@ -115,7 +115,7 @@ function FlowPane({ focused, width, height }: PaneProps) {
     [feed.payload?.events, filters, watchlist],
   );
 
-  useScannerStatusFooter("flow", feed);
+  useScannerStatusFooter("flow", feed, focused);
 
   const columns = useMemo(() => buildColumns(width), [width]);
 

--- a/src/plugins/builtin/scanner/flow-pane.tsx
+++ b/src/plugins/builtin/scanner/flow-pane.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useMemo, useState } from "react";
+import { TextAttributes } from "../../../ui";
+import {
+  DataTableView,
+  type DataTableCell,
+  type DataTableColumn,
+} from "../../../components";
+import { useAppSelector, usePaneSettingValue } from "../../../state/app/context";
+import { colors } from "../../../theme/colors";
+import { formatCompact, formatNumber } from "../../../utils/format";
+import type { PaneProps } from "../../../types/plugin";
+import type { ScannerFlowEvent } from "../../../api-client";
+import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
+import { usePluginPaneActions, usePluginTickerActions } from "../../runtime";
+import { ScannerDeniedState } from "./denied";
+import { useFlowFeed, useScannerStatusFooter } from "./feed";
+import {
+  DEFAULT_FLOW_FILTERS,
+  filterFlowEvents,
+  formatFlowExpiry,
+  formatFlowPremium,
+  formatFlowSide,
+  formatFlowTime,
+  formatFlowType,
+  formatFlowVolOi,
+  type FlowExpiry,
+  type FlowFilters,
+  type FlowKind,
+  type FlowMinPremium,
+  type FlowSide,
+  type FlowUniverse,
+  type FlowVolOi,
+} from "./flow-model";
+
+function buildColumns(width: number): DataTableColumn[] {
+  const fixed = { time: 8, ticker: 7, type: 8, strike: 8, exp: 6, side: 5, size: 7, prem: 7, volOi: 6 };
+  const total = Object.values(fixed).reduce((sum, value) => sum + value, 0);
+  // Table chrome is one gap per column, two cells of padding, and the scrollbar.
+  const slack = Math.max(0, width - total - 9 - 2 - 1);
+  return [
+    { id: "time", label: "TIME", width: fixed.time, align: "left" },
+    { id: "ticker", label: "TICKER", width: fixed.ticker + Math.min(4, slack), align: "left" },
+    { id: "type", label: "TYPE", width: fixed.type, align: "left" },
+    { id: "strike", label: "STRIKE", width: fixed.strike, align: "right" },
+    { id: "expiry", label: "EXP", width: fixed.exp, align: "right" },
+    { id: "side", label: "SIDE", width: fixed.side, align: "left" },
+    { id: "size", label: "SIZE", width: fixed.size, align: "right" },
+    { id: "premium", label: "PREM", width: fixed.prem, align: "right" },
+    { id: "volOi", label: "V/OI", width: fixed.volOi, align: "right" },
+  ];
+}
+
+function renderCell(
+  event: ScannerFlowEvent,
+  column: DataTableColumn,
+  rowState: { selected: boolean },
+): DataTableCell {
+  const selectedColor = rowState.selected ? colors.selectedText : undefined;
+  const rightColor = event.right === "C" ? colors.positive : colors.negative;
+  switch (column.id) {
+    case "time":
+      return { text: formatFlowTime(event.at), color: selectedColor ?? colors.textDim };
+    case "ticker":
+      return {
+        text: event.underlying,
+        color: selectedColor ?? colors.textBright,
+        attributes: TextAttributes.BOLD,
+      };
+    case "type":
+      return { text: formatFlowType(event), color: selectedColor ?? rightColor };
+    case "strike":
+      return { text: formatNumber(event.strike, event.strike % 1 === 0 ? 0 : 2), color: selectedColor };
+    case "expiry":
+      return { text: formatFlowExpiry(event.expiry), color: selectedColor ?? colors.textDim };
+    case "side":
+      return { text: formatFlowSide(event.side), color: selectedColor ?? colors.textDim };
+    case "size":
+      return { text: formatCompact(event.size), color: selectedColor };
+    case "premium":
+      return {
+        text: formatFlowPremium(event.premium),
+        color: selectedColor ?? rightColor,
+        attributes: TextAttributes.BOLD,
+      };
+    default:
+      return { text: formatFlowVolOi(event.volOi), color: selectedColor ?? colors.textDim };
+  }
+}
+
+function FlowPane({ focused, width, height }: PaneProps) {
+  const feed = useFlowFeed();
+  const { selectTicker } = usePluginPaneActions();
+  const { pinTicker } = usePluginTickerActions();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const [minPremium] = usePaneSettingValue<FlowMinPremium>("minPremium", DEFAULT_FLOW_FILTERS.minPremium);
+  const [side] = usePaneSettingValue<FlowSide>("side", DEFAULT_FLOW_FILTERS.side);
+  const [kind] = usePaneSettingValue<FlowKind>("kind", DEFAULT_FLOW_FILTERS.kind);
+  const [volOi] = usePaneSettingValue<FlowVolOi>("volOi", DEFAULT_FLOW_FILTERS.volOi);
+  const [expiry] = usePaneSettingValue<FlowExpiry>("expiry", DEFAULT_FLOW_FILTERS.expiry);
+  const [universe] = usePaneSettingValue<FlowUniverse>("universe", DEFAULT_FLOW_FILTERS.universe);
+
+  const trackedSymbols = useAppSelector((state) => state.tickers);
+  const watchlist = useMemo(
+    () => new Set([...trackedSymbols.keys()].map((symbol) => symbol.toUpperCase())),
+    [trackedSymbols],
+  );
+
+  const filters = useMemo<FlowFilters>(
+    () => ({ minPremium, side, kind, volOi, expiry, universe }),
+    [expiry, kind, minPremium, side, universe, volOi],
+  );
+  const events = useMemo(
+    () => filterFlowEvents(feed.payload?.events, filters, watchlist),
+    [feed.payload?.events, filters, watchlist],
+  );
+
+  useScannerStatusFooter("flow", feed);
+
+  const columns = useMemo(() => buildColumns(width), [width]);
+
+  const handleSelect = useCallback((event: ScannerFlowEvent) => {
+    setSelectedId(event.id);
+    selectTicker(event.underlying);
+  }, [selectTicker]);
+
+  if (feed.denied) {
+    return <ScannerDeniedState reason={feed.deniedReason} />;
+  }
+
+  return (
+    <DataTableView<ScannerFlowEvent>
+      focused={focused}
+      selection={{
+        kind: "id",
+        selectedId,
+        getId: (event) => event.id,
+        onChange: (_id, event) => handleSelect(event),
+      }}
+      rootWidth={width}
+      rootHeight={height}
+      columns={columns}
+      items={events}
+      sortColumnId={null}
+      sortDirection="desc"
+      onHeaderClick={() => {}}
+      getItemKey={(event) => event.id}
+      onActivate={(event) => pinTicker(event.underlying, { floating: true, paneType: TICKER_RESEARCH_PANE_ID })}
+      renderCell={(event, column, _index, rowState) => renderCell(event, column, rowState)}
+      emptyStateTitle={feed.payload ? "No prints match these filters." : "Waiting for the scanner..."}
+      emptyStateHint={feed.payload ? "Loosen the premium, expiry, or universe filter." : undefined}
+    />
+  );
+}
+
+export default FlowPane;

--- a/src/plugins/builtin/scanner/hilo-bars.tsx
+++ b/src/plugins/builtin/scanner/hilo-bars.tsx
@@ -1,0 +1,121 @@
+import { Box, Text, TextAttributes, useUiHost } from "../../../ui";
+import { colors } from "../../../theme/colors";
+import type { ScannerHiloPayload } from "../../../api-client";
+import { buildHiloBarRows, terminalBarCells, type HiloBarRow } from "./hilo-model";
+
+const LABEL_WIDTH = 8;
+const MIN_HALF_WIDTH = 4;
+
+export interface HiloBarsProps {
+  windows: ScannerHiloPayload["windows"] | null | undefined;
+  width: number;
+}
+
+function halfWidthFor(width: number): number {
+  return Math.max(MIN_HALF_WIDTH, Math.floor((width - LABEL_WIDTH - 2) / 2));
+}
+
+/** Desktop gets a real swatch element; the terminal gets the densest glyph. */
+function Swatch({ color, isDesktopWeb }: { color: string; isDesktopWeb: boolean }) {
+  if (!isDesktopWeb) return <Text fg={color}>■</Text>;
+  return (
+    <Box
+      backgroundColor={color}
+      style={{ width: "9px", height: "9px", borderRadius: "2px", alignSelf: "center" }}
+    />
+  );
+}
+
+function Legend({ width, isDesktopWeb }: { width: number; isDesktopWeb: boolean }) {
+  return (
+    <Box flexDirection="row" height={1} paddingX={1} width={width} alignItems="center">
+      <Swatch color={colors.negative} isDesktopWeb={isDesktopWeb} />
+      <Text fg={colors.textDim}> New Lows</Text>
+      <Box flexGrow={1} />
+      <Text fg={colors.textDim}>New Highs </Text>
+      <Swatch color={colors.positive} isDesktopWeb={isDesktopWeb} />
+    </Box>
+  );
+}
+
+function RowLabel({ row }: { row: HiloBarRow }) {
+  return (
+    <Box width={LABEL_WIDTH} flexShrink={0} justifyContent="center" alignItems="center">
+      <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>{row.label}</Text>
+    </Box>
+  );
+}
+
+/** Terminal bars are block runs at half-cell resolution, the densest option in cells. */
+function TerminalHiloBars({ rows, halfWidth, width }: { rows: HiloBarRow[]; halfWidth: number; width: number }) {
+  return (
+    <Box flexDirection="column" width={width}>
+      {rows.map((row) => {
+        const low = terminalBarCells(row.lowRatio, halfWidth);
+        const high = terminalBarCells(row.highRatio, halfWidth);
+        const lowBar = `${low.half ? "▐" : ""}${"█".repeat(low.full)}`;
+        const highBar = `${"█".repeat(high.full)}${high.half ? "▌" : ""}`;
+        return (
+          <Box key={row.key} flexDirection="row" height={1} paddingX={1}>
+            <Box width={halfWidth} flexShrink={0} justifyContent="flex-end">
+              <Text fg={colors.negative}>{lowBar}</Text>
+            </Box>
+            <RowLabel row={row} />
+            <Box width={halfWidth} flexShrink={0}>
+              <Text fg={colors.positive}>{highBar}</Text>
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+/** Desktop bars are real flex-sized divs, so length is fractional instead of cell-quantized. */
+function DesktopHiloBars({ rows, width }: { rows: HiloBarRow[]; width: number }) {
+  return (
+    <Box flexDirection="column" width={width}>
+      {rows.map((row) => (
+        <Box key={row.key} flexDirection="row" height={1} paddingX={1} alignItems="center">
+          <Box flexGrow={1} flexDirection="row" justifyContent="flex-end" overflow="hidden">
+            <Box
+              backgroundColor={colors.negative}
+              style={{
+                width: `${(row.lowRatio * 100).toFixed(2)}%`,
+                height: "11px",
+                borderRadius: "2px 0 0 2px",
+                minWidth: row.lows > 0 ? "2px" : "0",
+              }}
+            />
+          </Box>
+          <RowLabel row={row} />
+          <Box flexGrow={1} flexDirection="row" overflow="hidden">
+            <Box
+              backgroundColor={colors.positive}
+              style={{
+                width: `${(row.highRatio * 100).toFixed(2)}%`,
+                height: "11px",
+                borderRadius: "0 2px 2px 0",
+                minWidth: row.highs > 0 ? "2px" : "0",
+              }}
+            />
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+export function HiloBars({ windows, width }: HiloBarsProps) {
+  const isDesktopWeb = useUiHost().kind === "desktop-web";
+  const rows = buildHiloBarRows(windows);
+
+  return (
+    <Box flexDirection="column" width={width} flexShrink={0}>
+      <Legend width={width} isDesktopWeb={isDesktopWeb} />
+      {isDesktopWeb
+        ? <DesktopHiloBars rows={rows} width={width} />
+        : <TerminalHiloBars rows={rows} halfWidth={halfWidthFor(width)} width={width} />}
+    </Box>
+  );
+}

--- a/src/plugins/builtin/scanner/hilo-model.test.ts
+++ b/src/plugins/builtin/scanner/hilo-model.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { buildHiloBarRows, terminalBarCells } from "./hilo-model";
+
+const windows = {
+  s30: { highs: 42, lows: 11 },
+  m1: { highs: 118, lows: 37 },
+  m5: { highs: 512, lows: 203 },
+};
+
+describe("hilo bar scaling", () => {
+  test("scales every row against one shared maximum so the widest window dominates", () => {
+    const rows = buildHiloBarRows(windows);
+    const byKey = Object.fromEntries(rows.map((row) => [row.key, row]));
+
+    expect(byKey.m5!.highRatio).toBe(1);
+    expect(byKey.m1!.highRatio).toBeCloseTo(118 / 512, 6);
+    expect(byKey.s30!.highRatio).toBeCloseTo(42 / 512, 6);
+    // Lows share the same scale as highs, not a per-side one.
+    expect(byKey.m5!.lowRatio).toBeCloseTo(203 / 512, 6);
+  });
+
+  test("returns zero ratios instead of dividing by zero on an empty session", () => {
+    const rows = buildHiloBarRows({
+      s30: { highs: 0, lows: 0 },
+      m1: { highs: 0, lows: 0 },
+      m5: { highs: 0, lows: 0 },
+    });
+    expect(rows.every((row) => row.highRatio === 0 && row.lowRatio === 0)).toBe(true);
+    expect(buildHiloBarRows(null)).toHaveLength(3);
+  });
+
+  test("converts ratios to cells at half-cell resolution and never overflows the half width", () => {
+    expect(terminalBarCells(1, 20)).toEqual({ full: 20, half: false });
+    expect(terminalBarCells(0.5, 20)).toEqual({ full: 10, half: false });
+    expect(terminalBarCells(0.525, 20)).toEqual({ full: 10, half: true });
+    expect(terminalBarCells(2, 20)).toEqual({ full: 20, half: false });
+  });
+
+  test("keeps a nonzero count visible as a half cell instead of rounding it away", () => {
+    expect(terminalBarCells(42 / 512, 20)).toEqual({ full: 1, half: true });
+    expect(terminalBarCells(0.001, 20)).toEqual({ full: 0, half: true });
+    expect(terminalBarCells(0, 20)).toEqual({ full: 0, half: false });
+  });
+});

--- a/src/plugins/builtin/scanner/hilo-model.ts
+++ b/src/plugins/builtin/scanner/hilo-model.ts
@@ -1,0 +1,75 @@
+import type { ScannerHiloExtreme, ScannerHiloPayload } from "../../../api-client";
+
+export type HiloWindowKey = keyof ScannerHiloPayload["windows"];
+export type HiloMinPrice = "off" | "1" | "5";
+export type HiloSort = "recent" | "count";
+
+/** Widest window first, so the dominant bar reads as the top of the funnel. */
+export const HILO_WINDOW_ROWS: ReadonlyArray<{ key: HiloWindowKey; label: string }> = [
+  { key: "m5", label: "5 min" },
+  { key: "m1", label: "1 min" },
+  { key: "s30", label: "30 sec" },
+];
+
+export interface HiloBarRow {
+  key: HiloWindowKey;
+  label: string;
+  highs: number;
+  lows: number;
+  /** 0..1 against the single scale shared by every row and both sides. */
+  highRatio: number;
+  lowRatio: number;
+}
+
+/**
+ * One scale across all six counts, so the 5 min row visibly dominates instead of
+ * every row saturating its own half.
+ */
+export function buildHiloBarRows(windows: ScannerHiloPayload["windows"] | null | undefined): HiloBarRow[] {
+  const rows = HILO_WINDOW_ROWS.map(({ key, label }) => ({
+    key,
+    label,
+    highs: Math.max(0, windows?.[key]?.highs ?? 0),
+    lows: Math.max(0, windows?.[key]?.lows ?? 0),
+  }));
+  const scale = Math.max(0, ...rows.flatMap((row) => [row.highs, row.lows]));
+  return rows.map((row) => ({
+    ...row,
+    highRatio: scale > 0 ? row.highs / scale : 0,
+    lowRatio: scale > 0 ? row.lows / scale : 0,
+  }));
+}
+
+export interface TerminalBarCells {
+  full: number;
+  /** Trailing half cell, so small-but-nonzero counts stay visible in cell units. */
+  half: boolean;
+}
+
+/** Converts a 0..1 bar ratio into terminal cells at half-cell resolution. */
+export function terminalBarCells(ratio: number, halfWidth: number): TerminalBarCells {
+  if (!(ratio > 0) || halfWidth <= 0) return { full: 0, half: false };
+  const capped = Math.min(1, ratio);
+  const cells = capped * halfWidth;
+  let full = Math.floor(cells);
+  let half = cells - full >= 0.5;
+  if (full >= halfWidth) return { full: halfWidth, half: false };
+  if (full === 0 && !half) half = true;
+  return { full, half };
+}
+
+export function hiloMinPriceValue(setting: HiloMinPrice): number {
+  return setting === "1" ? 1 : setting === "5" ? 5 : 0;
+}
+
+export function filterHiloRows(
+  rows: readonly ScannerHiloExtreme[] | undefined,
+  minPrice: HiloMinPrice,
+  sort: HiloSort,
+): ScannerHiloExtreme[] {
+  const floor = hiloMinPriceValue(minPrice);
+  const filtered = (rows ?? []).filter((row) => row.price >= floor);
+  return sort === "count"
+    ? [...filtered].sort((left, right) => right.count - left.count || right.at - left.at)
+    : [...filtered].sort((left, right) => right.at - left.at);
+}

--- a/src/plugins/builtin/scanner/hilo-pane.tsx
+++ b/src/plugins/builtin/scanner/hilo-pane.tsx
@@ -84,7 +84,7 @@ function HiloPane({ focused, width, height }: PaneProps) {
     [feed.payload?.highs, minPrice, sort],
   );
 
-  useScannerStatusFooter("hilo", feed);
+  useScannerStatusFooter("hilo", feed, focused);
 
   // One cell of gutter keeps the two cursors from reading as a single wide row.
   const tableWidth = Math.max(20, Math.floor((width - 1) / 2));

--- a/src/plugins/builtin/scanner/hilo-pane.tsx
+++ b/src/plugins/builtin/scanner/hilo-pane.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useMemo, useState } from "react";
+import { Box, TextAttributes } from "../../../ui";
+import {
+  DataTableView,
+  type DataTableCell,
+  type DataTableColumn,
+  type DataTableKeyEvent,
+} from "../../../components";
+import { usePaneSettingValue } from "../../../state/app/context";
+import { colors } from "../../../theme/colors";
+import { formatCompact, formatNumber } from "../../../utils/format";
+import type { PaneProps } from "../../../types/plugin";
+import type { ScannerHiloExtreme } from "../../../api-client";
+import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
+import { usePluginPaneActions, usePluginTickerActions } from "../../runtime";
+import { ScannerDeniedState } from "./denied";
+import { useHiloFeed, useScannerStatusFooter } from "./feed";
+import { HiloBars } from "./hilo-bars";
+import { filterHiloRows, type HiloMinPrice, type HiloSort } from "./hilo-model";
+
+type Side = "lows" | "highs";
+
+function rowKey(row: ScannerHiloExtreme, index: number): string {
+  return `${row.symbol}:${row.at}:${index}`;
+}
+
+const BARS_HEIGHT = 4;
+
+function buildColumns(width: number): DataTableColumn[] {
+  const symbolWidth = 8;
+  const countWidth = 6;
+  // Table chrome is one gap per column, two cells of padding, and the scrollbar.
+  const priceWidth = Math.max(7, width - symbolWidth - countWidth - 3 - 2 - 1);
+  return [
+    { id: "symbol", label: "SYMBOL", width: symbolWidth, align: "left" },
+    { id: "price", label: "PRICE", width: priceWidth, align: "right" },
+    { id: "count", label: "COUNT", width: countWidth, align: "right" },
+  ];
+}
+
+function renderCell(
+  side: Side,
+  row: ScannerHiloExtreme,
+  column: DataTableColumn,
+  rowState: { selected: boolean },
+): DataTableCell {
+  const selectedColor = rowState.selected ? colors.selectedText : undefined;
+  const sideColor = side === "lows" ? colors.negative : colors.positive;
+  switch (column.id) {
+    case "symbol":
+      return {
+        text: row.symbol,
+        color: selectedColor ?? sideColor,
+        attributes: TextAttributes.BOLD,
+      };
+    case "price":
+      return {
+        text: row.price >= 1000 ? formatNumber(row.price, 2) : row.price.toFixed(4).replace(/0+$/, "").replace(/\.$/, ""),
+        color: selectedColor,
+      };
+    default:
+      return {
+        text: formatCompact(row.count),
+        color: selectedColor ?? colors.textDim,
+      };
+  }
+}
+
+function HiloPane({ focused, width, height }: PaneProps) {
+  const feed = useHiloFeed();
+  const { selectTicker } = usePluginPaneActions();
+  const { pinTicker } = usePluginTickerActions();
+  const [minPrice] = usePaneSettingValue<HiloMinPrice>("minPrice", "1");
+  const [sort] = usePaneSettingValue<HiloSort>("sort", "recent");
+  const [activeSide, setActiveSide] = useState<Side>("lows");
+  const [selected, setSelected] = useState<Record<Side, string | null>>({ lows: null, highs: null });
+
+  const lows = useMemo(
+    () => filterHiloRows(feed.payload?.lows, minPrice, sort),
+    [feed.payload?.lows, minPrice, sort],
+  );
+  const highs = useMemo(
+    () => filterHiloRows(feed.payload?.highs, minPrice, sort),
+    [feed.payload?.highs, minPrice, sort],
+  );
+
+  useScannerStatusFooter("hilo", feed);
+
+  // One cell of gutter keeps the two cursors from reading as a single wide row.
+  const tableWidth = Math.max(20, Math.floor((width - 1) / 2));
+  const columns = useMemo(() => buildColumns(tableWidth), [tableWidth]);
+
+  const handleSelect = useCallback((side: Side, row: ScannerHiloExtreme, index: number) => {
+    setActiveSide(side);
+    setSelected((current) => ({ ...current, [side]: rowKey(row, index) }));
+    selectTicker(row.symbol);
+  }, [selectTicker]);
+
+  const handleSideSwitchKey = useCallback((event: DataTableKeyEvent) => {
+    if (event.name !== "left" && event.name !== "right") return false;
+    event.preventDefault?.();
+    event.stopPropagation?.();
+    setActiveSide(event.name === "left" ? "lows" : "highs");
+    return true;
+  }, []);
+
+  if (feed.denied) {
+    return <ScannerDeniedState reason={feed.deniedReason} />;
+  }
+
+  const renderTable = (side: Side, rows: ScannerHiloExtreme[]) => (
+    <DataTableView<ScannerHiloExtreme>
+      focused={focused && activeSide === side}
+      selection={{
+        kind: "id",
+        selectedId: selected[side],
+        // The feed can report the same symbol more than once, so rows need a key
+        // of their own instead of the ticker.
+        getId: rowKey,
+        onChange: (_id, row, index) => handleSelect(side, row, index),
+      }}
+      onRootKeyDown={handleSideSwitchKey}
+      rootWidth={tableWidth}
+      rootHeight={Math.max(3, height - BARS_HEIGHT)}
+      columns={columns}
+      items={rows}
+      sortColumnId={null}
+      sortDirection="desc"
+      onHeaderClick={() => {}}
+      getItemKey={rowKey}
+      onActivate={(row) => pinTicker(row.symbol, { floating: true, paneType: TICKER_RESEARCH_PANE_ID })}
+      renderCell={(row, column, _index, rowState) => renderCell(side, row, column, rowState)}
+      emptyStateTitle={feed.payload ? "Nothing above the price filter yet." : "Waiting for the scanner..."}
+    />
+  );
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      <HiloBars windows={feed.payload?.windows} width={width} />
+      <Box flexDirection="row" flexGrow={1}>
+        {renderTable("lows", lows)}
+        <Box width={1} flexShrink={0} />
+        {renderTable("highs", highs)}
+      </Box>
+    </Box>
+  );
+}
+
+export default HiloPane;

--- a/src/plugins/builtin/scanner/index.ts
+++ b/src/plugins/builtin/scanner/index.ts
@@ -1,0 +1,150 @@
+import type { PaneSettingsDef } from "../../../types/plugin";
+import type { PluginModule } from "../plugin-module";
+import { DEFAULT_FLOW_FILTERS } from "./flow-model";
+import FlowPane from "./flow-pane";
+import HiloPane from "./hilo-pane";
+
+export const HILO_PANE_ID = "scanner-hilo";
+export const FLOW_PANE_ID = "scanner-flow";
+
+function hiloSettings(): PaneSettingsDef {
+  return {
+    title: "New Highs / Lows Settings",
+    fields: [
+      {
+        key: "minPrice",
+        label: "Minimum price",
+        description: "Sub-dollar names otherwise dominate both lists.",
+        type: "select",
+        options: [
+          { value: "off", label: "No filter" },
+          { value: "1", label: "$1" },
+          { value: "5", label: "$5" },
+        ],
+      },
+      {
+        key: "sort",
+        label: "Sort",
+        type: "select",
+        options: [
+          { value: "recent", label: "Most recent" },
+          { value: "count", label: "Highest count" },
+        ],
+      },
+    ],
+  };
+}
+
+function flowSettings(): PaneSettingsDef {
+  return {
+    title: "Options Flow Settings",
+    fields: [
+      {
+        key: "minPremium",
+        label: "Minimum premium",
+        type: "select",
+        options: [
+          { value: "50000", label: "$50K" },
+          { value: "250000", label: "$250K" },
+          { value: "1000000", label: "$1M" },
+        ],
+      },
+      {
+        key: "side",
+        label: "Contract side",
+        type: "select",
+        options: [
+          { value: "both", label: "Calls and puts" },
+          { value: "calls", label: "Calls only" },
+          { value: "puts", label: "Puts only" },
+        ],
+      },
+      {
+        key: "kind",
+        label: "Print kind",
+        type: "select",
+        options: [
+          { value: "all", label: "All prints" },
+          { value: "sweeps", label: "Sweeps only" },
+          { value: "blocks", label: "Blocks only" },
+        ],
+      },
+      {
+        key: "volOi",
+        label: "Volume / open interest floor",
+        type: "select",
+        options: [
+          { value: "off", label: "No floor" },
+          { value: "1", label: "1x and up" },
+          { value: "5", label: "5x and up" },
+        ],
+      },
+      {
+        key: "expiry",
+        label: "Expiry window",
+        type: "select",
+        options: [
+          { value: "all", label: "Any expiry" },
+          { value: "7", label: "7 days or less" },
+          { value: "30", label: "30 days or less" },
+        ],
+      },
+      {
+        key: "universe",
+        label: "Universe",
+        description: "Watchlist mode filters the same shared feed locally.",
+        type: "select",
+        options: [
+          { value: "active", label: "Active names" },
+          { value: "watchlist", label: "My tickers only" },
+        ],
+      },
+    ],
+  };
+}
+
+export const scannerModule: PluginModule = {
+  panes: [
+    {
+      id: HILO_PANE_ID,
+      name: "New Highs / Lows",
+      icon: "H",
+      component: HiloPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 76, height: 26 },
+      settings: hiloSettings(),
+    },
+    {
+      id: FLOW_PANE_ID,
+      name: "Options Flow",
+      icon: "F",
+      component: FlowPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 88, height: 28 },
+      settings: flowSettings(),
+    },
+  ],
+
+  paneTemplates: [
+    {
+      id: "scanner-hilo-pane",
+      paneId: HILO_PANE_ID,
+      label: "New Highs / Lows",
+      description: "Session new-high and new-low momentum with 30s/1m/5m counts.",
+      keywords: ["hilo", "highs", "lows", "new", "momentum", "breakout", "scanner"],
+      shortcut: { prefix: "HILO" },
+      createInstance: () => ({ settings: { minPrice: "1", sort: "recent" } }),
+    },
+    {
+      id: "scanner-flow-pane",
+      paneId: FLOW_PANE_ID,
+      label: "Options Flow",
+      description: "Unusual options activity: sweeps, blocks, and large premium prints.",
+      keywords: ["flow", "options", "sweep", "block", "unusual", "premium", "scanner"],
+      shortcut: { prefix: "FLOW" },
+      createInstance: () => ({ settings: { ...DEFAULT_FLOW_FILTERS } }),
+    },
+  ],
+};

--- a/src/renderers/electrobun/view/build-assets.ts
+++ b/src/renderers/electrobun/view/build-assets.ts
@@ -55,6 +55,9 @@ async function buildElectrobunViewBundle({
     minify: true,
     define: {
       "process.env.NODE_ENV": "\"production\"",
+      // The webview has no `process`, so the cloud endpoint override the terminal
+      // already reads from the environment is baked in at build time.
+      __GLOOMBERB_API_URL__: JSON.stringify(process.env.GLOOMBERB_API_URL ?? ""),
     },
     plugins: [
       {


### PR DESCRIPTION
## Summary
- add HILO with E*Trade-style diverging 30s, 1m, and 5m high/low momentum bars plus selectable low/high tables
- add FLOW unusual-options activity table with premium, contract side, kind, vol/OI, expiry, and watchlist filters
- share one socket subscription across duplicate pane instances and replay it after reconnects
- give free accounts delayed HILO with the standard upgrade footer; keep FLOW Pro-only because no delayed OPRA entitlement exists
- render HILO bars as terminal cells in OpenTUI and real DOM primitives on desktop

## Verification
- 1,931 tests passed
- all four TypeScript targets passed
- Biome passed on every changed file
- tmux smoke verified HILO and FLOW rendering, scrolling, selectable rows, and no runtime warnings
- desktop-web screenshots verified real DOM bar scaling and the dense FLOW table
- live production matrix checked Pro, free/delayed, and auth-required states on terminal and Electrobun
- `u` and the footer CTA open the existing Cloud upgrade flow

Depends on the platform scanner API PR.
