### PR TITLE
Add missing GPW to WSE mapping

### DIFF
--- a/src/sources/yahoo-finance/symbols.ts
+++ b/src/sources/yahoo-finance/symbols.ts
@@ -17,7 +17,7 @@ const EXCHANGE_SUFFIX_MAP: Record<string, string> = {
   BVME: ".MI", BM: ".MC",
   SIX: ".SW", EBS: ".SW", SWX: ".SW",
   SFB: ".ST", Stockholm: ".ST", OMX: ".ST", CPH: ".CO", HEX: ".HE", OSE: ".OL", OMXNO: ".OL", ICEX: ".IC",
-  VSE: ".VI", WSE: ".WA", PRA: ".PR", BUX: ".BD", ATHEX: ".AT", BVB: ".RO", BIST: ".IS",
+  VSE: ".VI", WSE: ".WA", GPW: ".WA", PRA: ".PR", BUX: ".BD", ATHEX: ".AT", BVB: ".RO", BIST: ".IS",
   TASE: ".TA",
   JSE: ".JO",
   BVMF: ".SA", MEXI: ".MX", BYMA: ".BA", BCS: ".SN",

--- a/src/utils/exchanges.ts
+++ b/src/utils/exchanges.ts
@@ -82,6 +82,7 @@ export const CANONICAL_EXCHANGE_ALIASES: Record<string, string> = {
   ICEX: "ICEX",
   XICE: "ICEX",
   WSE: "WSE",
+  GPW: "WSE",
   XWAR: "WSE",
   PRA: "PSE",
   XPRA: "PSE",


### PR DESCRIPTION
# Problem
When trying to load data for several GPW listed indices like CDR.WA / PKN.WA / WTN.WA there was an error and missing data everywhere.

# Solution
Added missing GPW -> WSE mapping.