### PR TITLE
Collapse duplicate daily bars from mixed history sources

### DIFF
--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -539,6 +539,70 @@ describe("resolveChartSpecData", () => {
     expect(revisitedCurrent.bufferedSeries?.[0]?.points.at(-1)?.value).toBe(120);
   });
 
+  test("keeps one daily bar per session when windows come from sources that stamp bars differently", async () => {
+    // The trailing window is stamped at the opening bell, the panned window at
+    // local midnight, so the same sessions arrive with timestamps hours apart.
+    const currentHistory = [
+      { date: new Date("2026-07-28T13:30:00.000Z"), close: 110 },
+      { date: new Date("2026-07-29T13:30:00.000Z"), close: 115 },
+      { date: new Date("2026-07-30T13:30:00.000Z"), close: 120 },
+    ];
+    const historicalHistory = [
+      { date: new Date("2026-07-23T22:00:00.000Z"), close: 100 },
+      { date: new Date("2026-07-27T22:00:00.000Z"), close: 111 },
+      { date: new Date("2026-07-28T22:00:00.000Z"), close: 116 },
+      { date: new Date("2026-07-29T22:00:00.000Z"), close: 121 },
+    ];
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => emptyFinancials(),
+      getChartResolutionSupport: () => [{ resolution: "1d", maxRange: "ALL" }],
+      getPriceHistoryForResolution: async () => currentHistory,
+      getDetailedPriceHistory: async () => historicalHistory,
+    });
+    const spec: ChartSpec = {
+      version: CHART_SPEC_VERSION,
+      viewport: { range: "1Y", resolution: "1d" },
+      panels: [{ id: "main" }],
+      series: [{
+        id: "price",
+        source: {
+          kind: "security",
+          instrument: { symbol: "TEST", exchange: "NASDAQ" },
+          fieldId: "market.close",
+        },
+        style: "line",
+        transform: "raw",
+        axis: "left",
+        panelId: "main",
+        interpolation: "none",
+      }],
+      studies: [],
+    };
+    const sources = {
+      dataProvider: provider,
+      now: new Date("2026-07-30T16:00:00.000Z"),
+      loadFredSeries: async () => fredLoad(),
+    };
+    const cache = new ChartResolveCache();
+
+    await resolveChartSpecData(spec, sources, cache);
+    const panned = await resolveChartSpecData(spec, sources, cache, {
+      requestViewport: {
+        start: new Date("2026-07-20T00:00:00.000Z"),
+        end: new Date("2026-07-30T16:00:00.000Z"),
+      },
+    });
+
+    const points = panned.bufferedSeries?.[0]?.points ?? [];
+    expect(points.map((point) => point.date.toISOString())).toEqual([
+      "2026-07-23T22:00:00.000Z",
+      "2026-07-28T13:30:00.000Z",
+      "2026-07-29T13:30:00.000Z",
+      "2026-07-30T13:30:00.000Z",
+    ]);
+    expect(points.map((point) => point.value)).toEqual([100, 110, 115, 120]);
+  });
+
   test("keeps percent transforms and studies defined in a panned history window", async () => {
     const provider = createTestDataProvider({
       getTickerFinancials: async () => emptyFinancials(),

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -12,6 +12,7 @@ import {
   getPresetResolution,
   getSupportMaxRange,
   intersectChartResolutionSupport,
+  isIntradayResolution,
   TIME_RANGE_ORDER,
   type ChartResolutionSupport,
   type ManualChartResolution,
@@ -352,6 +353,7 @@ function emptyFinancials(priceHistory: TickerFinancials["priceHistory"] = []): T
 function mergePriceHistoryWindows(
   current: TickerFinancials["priceHistory"],
   incoming: TickerFinancials["priceHistory"],
+  resolution: ManualChartResolution,
 ): TickerFinancials["priceHistory"] {
   const byTimestamp = new Map<number, TickerFinancials["priceHistory"][number]>();
   for (const point of [...current, ...incoming]) {
@@ -363,9 +365,30 @@ function mergePriceHistoryWindows(
       );
     }
   }
-  return [...byTimestamp.values()].sort(
+  const sorted = [...byTimestamp.values()].sort(
     (left, right) => getPricePointTimestamp(left) - getPricePointTimestamp(right),
   );
+  if (isIntradayResolution(resolution)) return sorted;
+  // Windows can be served by different sources, and they stamp the same session
+  // differently: local midnight, UTC midnight, or the opening bell. Keying on the
+  // exact timestamp keeps both copies, so the chart draws every bar twice and
+  // carries twice the points through every pan. Daily and slower bars are never
+  // closer than one step apart, so anything closer is the same session; keep the
+  // copy already plotted to leave existing bars where they are.
+  const minimumGapMs = CHART_RESOLUTION_STEP_MS[resolution] * 0.8;
+  const plotted = new Set(current.map(getPricePointTimestamp));
+  const merged: TickerFinancials["priceHistory"] = [];
+  for (const point of sorted) {
+    const previous = merged.at(-1);
+    if (!previous || getPricePointTimestamp(point) - getPricePointTimestamp(previous) >= minimumGapMs) {
+      merged.push(point);
+      continue;
+    }
+    if (!plotted.has(getPricePointTimestamp(previous)) && plotted.has(getPricePointTimestamp(point))) {
+      merged[merged.length - 1] = point;
+    }
+  }
+  return merged;
 }
 
 function historyIntersectsBounds(
@@ -850,6 +873,7 @@ export async function resolveChartSpecData(
     const accumulated = mergePriceHistoryWindows(
       previousHistory,
       history,
+      request.resolution,
     );
     cache.accumulatedPriceHistory.set(accumulationKey, accumulated);
     return accumulated;


### PR DESCRIPTION
## Problem

Panning or zooming a price chart could end up drawing every candle twice, with the doubled point count making pans and zooms crawl (screenshot: AAPL 1Y, every bar rendered as an adjacent pair ~15h apart).

The chart accumulates every fetched window in `ChartResolveCache.accumulatedPriceHistory`, keyed only by instrument and resolution. `mergePriceHistoryWindows` deduped on the exact timestamp, but the three fetch paths can be served by different sources:

- `getPriceHistoryForResolution` / `getPriceHistory` (trailing preset ranges)
- `getDetailedPriceHistory` (the explicit window every pan/zoom requests)

Yahoo stamps a daily bar at the opening bell (13:30Z), the IBKR gateway parses `20240221` with `new Date(y, m, d)` (app-local midnight, e.g. 22:00Z the previous day), and cloud upstreams vary. Same session, different instant, so both copies survived the merge and every later pan carried twice the points.

## Fix

For daily and slower resolutions, collapse points closer than one bar step (0.8 x step) after merging: real daily bars are never that close, so anything closer is the same session. The copy already plotted wins, so existing bars do not shift and pre-existing doubled buffers self-heal on the next fetch. Intraday keeps exact-timestamp dedupe, where partial bars can legitimately sit closer than a full step.

## Test

`bun test src/time-series` - new case feeds a trailing window stamped at the opening bell and a panned window stamped at local midnight, and asserts one bar per session at the already plotted timestamps.

## Known related issue, not fixed here

`parseIbkrHistoricalBarTime` interprets IBKR bar dates in the app's local timezone rather than the exchange's, so IBKR-served bars sit hours off on their own. Fixing that needs the exchange timezone plumbed into the parser.