### PR TITLE
Add header market countdowns and changelog link

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -369,7 +369,14 @@ function AppInner({
         desktopWindowBridge={desktopWindowBridge}
       >
         <ThemedAppRoot>
-          <Header onOpenHelp={() => pluginRegistry.showPane("help")} />
+          <Header
+            onOpenHelp={() => pluginRegistry.showPane("help")}
+            onOpenChangelog={(version) => {
+              void pluginRegistry.createPaneFromTemplateAsyncFn("changelog-pane", {
+                values: { version },
+              }).catch(() => {});
+            }}
+          />
           <TransientLayoutProvider>
             <Shell
               pluginRegistry={pluginRegistry}

--- a/src/components/layout/header.test.tsx
+++ b/src/components/layout/header.test.tsx
@@ -1,0 +1,35 @@
+import { afterEach, expect, test } from "bun:test";
+import { testRender } from "../../renderers/opentui/test-utils";
+import { AppContext, createInitialState } from "../../state/app/context";
+import { createDefaultConfig } from "../../types/config";
+import { VERSION } from "../../version";
+import { act } from "react";
+import { Header } from "./header";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(() => {
+  testSetup?.renderer.destroy();
+  testSetup = undefined;
+});
+
+test("opens the current version changelog from the header", async () => {
+  let openedVersion = "";
+  const state = createInitialState(createDefaultConfig("/tmp/gloomberb-header-test"));
+  testSetup = await testRender(
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <Header onOpenChangelog={(version) => { openedVersion = version; }} />
+    </AppContext>,
+    { width: 100, height: 1 },
+  );
+
+  await testSetup.renderOnce();
+  const versionX = testSetup.captureCharFrame().indexOf(`v${VERSION}`);
+  expect(versionX).toBeGreaterThanOrEqual(0);
+
+  await act(async () => {
+    await testSetup!.mockMouse.click(versionX + 1, 0);
+    await testSetup!.renderOnce();
+  });
+  expect(openedVersion).toBe(VERSION);
+});

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,5 +1,5 @@
 import { Box, SpinnerMark, Text, TextAttributes, useRendererHost, useUiCapabilities } from "../../ui";
-import { useCallback, useEffect, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { blendHex, priceColor } from "../../theme/colors";
 import { useThemeColors } from "../../theme/theme-context";
 import { useAppActive } from "../../state/app/activity";
@@ -16,7 +16,7 @@ import { t, tf } from "../../i18n";
 import { useQuoteEntry, useResolvedEntryValue } from "../../market-data/hooks";
 import { formatPercentRaw } from "../../utils/format";
 import { formatMarketPrice } from "../../market-data/market/format";
-import { marketStateLabel, marketStateColor, getActiveQuoteDisplay } from "../../market-data/market/status";
+import { getActiveQuoteDisplay, marketStateColor, marketStateCountdown, marketStateLabel } from "../../market-data/market/status";
 import { VERSION } from "../../version";
 import { getTitlebarLeadingInset } from "./titlebar-overlay";
 import { WindowControls, WINDOWS_CONTROL_GROUP_WIDTH_PX } from "./window-controls";
@@ -24,14 +24,24 @@ import { WindowControls, WINDOWS_CONTROL_GROUP_WIDTH_PX } from "./window-control
 const SPY_REFRESH_MS = 5 * 60_000; // 5 min
 const UPDATE_NOTICE_DURATION_MS = 5_000;
 
+type HeaderActionEvent = {
+  key?: string;
+  preventDefault?: () => void;
+  stopPropagation?: () => void;
+};
+
 function DesktopHeaderPill({
   children,
   backgroundColor,
   borderColor,
+  onPress,
+  ariaLabel,
 }: {
   children: ReactNode;
   backgroundColor?: string;
   borderColor?: string;
+  onPress?: (event?: HeaderActionEvent) => void;
+  ariaLabel?: string;
 }) {
   const colors = useThemeColors();
   const resolvedBackgroundColor = backgroundColor ?? blendHex(colors.header, colors.bg, 0.28);
@@ -42,10 +52,20 @@ function DesktopHeaderPill({
       flexDirection="row"
       alignItems="center"
       backgroundColor={resolvedBackgroundColor}
+      data-gloom-interactive={onPress ? "true" : undefined}
+      role={onPress ? "button" : undefined}
+      tabIndex={onPress ? 0 : undefined}
+      aria-label={ariaLabel}
+      onMouseDown={onPress}
+      onKeyDown={(event: HeaderActionEvent) => {
+        if (event.key === "Enter" || event.key === " ") onPress?.(event);
+      }}
+      hoverBackgroundColor={onPress ? blendHex(resolvedBackgroundColor, colors.headerText, 0.12) : undefined}
       style={{
         border: `1px solid ${resolvedBorderColor}`,
         borderRadius: 5,
         paddingInline: 6,
+        cursor: onPress ? "pointer" : undefined,
       }}
     >
       {children}
@@ -133,7 +153,13 @@ function UpdateStatus() {
   return null;
 }
 
-export function Header({ onOpenHelp }: { onOpenHelp?: () => void }) {
+export function Header({
+  onOpenHelp,
+  onOpenChangelog,
+}: {
+  onOpenHelp?: () => void;
+  onOpenChangelog?: (version: string) => void;
+}) {
   const colors = useThemeColors();
   const rendererHost = useRendererHost();
   const baseCurrency = useAppSelector(selectBaseCurrency);
@@ -143,6 +169,15 @@ export function Header({ onOpenHelp }: { onOpenHelp?: () => void }) {
   const titlebarLeadingInset = titleBarOverlay ? getTitlebarLeadingInset() : 0;
   const spyQuoteEntry = useQuoteEntry("SPY", null);
   const spyQuote = useResolvedEntryValue(spyQuoteEntry);
+  const mktState = spyQuote?.marketState;
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    if (!appActive || (mktState !== "PRE" && mktState !== "REGULAR")) return;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 1_000);
+    return () => clearInterval(id);
+  }, [appActive, mktState]);
 
   useEffect(() => {
     if (!appActive) return;
@@ -168,11 +203,19 @@ export function Header({ onOpenHelp }: { onOpenHelp?: () => void }) {
   }, [rendererHost, titleBarOverlay]);
 
   // Market status
-  const mktState = spyQuote?.marketState;
-  const mktLabel = mktState ? t(marketStateLabel(mktState)) : "";
+  const mktCountdown = mktState ? marketStateCountdown(mktState, now) : null;
+  const mktLabel = mktState
+    ? `${t(marketStateLabel(mktState))}${mktCountdown ? ` · ${mktCountdown}` : ""}`
+    : "";
   const mktColor = mktState ? marketStateColor(mktState, colors) : colors.headerText;
 
-  const openHelp = useCallback((event?: { preventDefault?: () => void; stopPropagation?: () => void }) => {
+  const openChangelog = useCallback((event?: HeaderActionEvent) => {
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
+    onOpenChangelog?.(VERSION);
+  }, [onOpenChangelog]);
+
+  const openHelp = useCallback((event?: HeaderActionEvent) => {
     event?.preventDefault?.();
     event?.stopPropagation?.();
     onOpenHelp?.();
@@ -202,6 +245,8 @@ export function Header({ onOpenHelp }: { onOpenHelp?: () => void }) {
           <DesktopHeaderPill
             backgroundColor={blendHex(colors.header, colors.headerText, 0.1)}
             borderColor={blendHex(colors.border, colors.headerText, 0.28)}
+            onPress={onOpenChangelog ? openChangelog : undefined}
+            ariaLabel={onOpenChangelog ? `Open changelog for v${VERSION}` : undefined}
           >
             <Text fg={colors.headerText} style={{ fontSize: 11 }}>v{VERSION}</Text>
           </DesktopHeaderPill>
@@ -269,10 +314,22 @@ export function Header({ onOpenHelp }: { onOpenHelp?: () => void }) {
       data-titlebar-overlay={titleBarOverlay ? "true" : undefined}
       onMouseDown={startWindowDrag}
     >
-      <Box paddingLeft={titleBarOverlay ? titlebarLeadingInset : 1}>
-        <Text attributes={TextAttributes.BOLD} fg={colors.headerText}>
-          Gloomberb v{VERSION}
-        </Text>
+      <Box paddingLeft={titleBarOverlay ? titlebarLeadingInset : 1} flexDirection="row">
+        <Text attributes={TextAttributes.BOLD} fg={colors.headerText}>Gloomberb </Text>
+        <Box
+          data-gloom-interactive={onOpenChangelog ? "true" : undefined}
+          role={onOpenChangelog ? "button" : undefined}
+          tabIndex={onOpenChangelog ? 0 : undefined}
+          aria-label={onOpenChangelog ? `Open changelog for v${VERSION}` : undefined}
+          onMouseDown={onOpenChangelog ? openChangelog : undefined}
+          onKeyDown={(event: HeaderActionEvent) => {
+            if (event.key === "Enter" || event.key === " ") openChangelog(event);
+          }}
+          hoverBackgroundColor={onOpenChangelog ? blendHex(colors.header, colors.headerText, 0.15) : undefined}
+          style={{ cursor: onOpenChangelog ? "pointer" : undefined }}
+        >
+          <Text attributes={TextAttributes.BOLD} fg={colors.headerText}>v{VERSION}</Text>
+        </Box>
       </Box>
       <Box flexGrow={1} paddingLeft={2}>
         <UpdateStatus />

--- a/src/market-data/market/status.test.ts
+++ b/src/market-data/market/status.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { marketStateCountdown } from "./status";
+
+describe("marketStateCountdown", () => {
+  test("adds precision as the US session boundary approaches", () => {
+    expect(marketStateCountdown("PRE", Date.parse("2026-08-18T12:21:42Z"))).toBe("1h 9m");
+    expect(marketStateCountdown("PRE", Date.parse("2026-08-18T13:25:09Z"))).toBe("4m 51s");
+    expect(marketStateCountdown("REGULAR", Date.parse("2026-08-18T18:59:59Z"))).toBeNull();
+    expect(marketStateCountdown("REGULAR", Date.parse("2026-08-18T19:00:00Z"))).toBe("1h");
+    expect(marketStateCountdown("REGULAR", Date.parse("2026-08-18T19:50:42Z"))).toBe("9m 18s");
+  });
+});

--- a/src/market-data/market/status.ts
+++ b/src/market-data/market/status.ts
@@ -2,6 +2,17 @@ import type { MarketState, Quote } from "../../types/financials";
 import { blendHex, colors, priceColor, type ThemeColors } from "../../theme/colors";
 
 const CLOSED_CHANGE_MUTING_RATIO = 0.55;
+const US_SESSION_TIME = new Intl.DateTimeFormat("en-US", {
+  timeZone: "America/New_York",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hourCycle: "h23",
+});
+const REGULAR_OPEN_SECONDS = (9 * 60 + 30) * 60;
+// ponytail: Standard SPY close; use provider session bounds if early-close countdowns matter.
+const REGULAR_CLOSE_SECONDS = 16 * 60 * 60;
+const CLOSING_COUNTDOWN_WINDOW_SECONDS = 60 * 60;
 
 export interface ActiveQuoteDisplay {
   price: number;
@@ -18,6 +29,28 @@ export function marketStateLabel(state: MarketState): string {
     case "POSTPOST":
     case "CLOSED": return "CLOSED";
   }
+}
+
+export function marketStateCountdown(state: MarketState, now = Date.now()): string | null {
+  if (state !== "PRE" && state !== "REGULAR") return null;
+
+  const parts = US_SESSION_TIME.formatToParts(new Date(now));
+  const value = (type: Intl.DateTimeFormatPartTypes) => Number(parts.find((part) => part.type === type)?.value ?? 0);
+  const currentSeconds = (value("hour") * 60 + value("minute")) * 60 + value("second");
+  const remainingSeconds = (state === "PRE" ? REGULAR_OPEN_SECONDS : REGULAR_CLOSE_SECONDS) - currentSeconds;
+  if (remainingSeconds <= 0 || (state === "REGULAR" && remainingSeconds > CLOSING_COUNTDOWN_WINDOW_SECONDS)) return null;
+
+  if (remainingSeconds >= 60 * 60) {
+    const roundedMinutes = Math.ceil(remainingSeconds / 60);
+    const hours = Math.floor(roundedMinutes / 60);
+    const minutes = roundedMinutes % 60;
+    return minutes ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  if (remainingSeconds >= 10 * 60) return `${Math.ceil(remainingSeconds / 60)}m`;
+
+  const minutes = Math.floor(remainingSeconds / 60);
+  const seconds = remainingSeconds % 60;
+  return minutes ? `${minutes}m ${seconds}s` : `${seconds}s`;
 }
 
 export function marketStateColor(state: MarketState, palette: ThemeColors = colors): string {


### PR DESCRIPTION
## Summary
- open the matching release notes when the header version is clicked
- show time to the US market open during pre-market
- show a closing countdown during the final trading hour, with second precision near the boundary

## Validation
- `bun test` (1,940 passing)
- `bun run typecheck`
- `bun run desktop:view:build`
- tmux smoke: live header rendered `PRE-MKT · 59m` with no runtime warnings