### PR TITLE
fix(security): only hand http(s) links to the OS opener (#15)

### DIFF
--- a/src/components/ui/external-link.tsx
+++ b/src/components/ui/external-link.tsx
@@ -1,10 +1,12 @@
 import { Box, Text } from "../../ui";
 import { TextAttributes } from "../../ui";
 import { colors } from "../../theme/colors";
+import { safeExternalUrl } from "../../utils/external-url";
 import { linkContextMenuItems, useContextMenu, useRendererHost, useUiCapabilities } from "../../ui";
 
-export function openUrl(url: string) {
-  if (!url.trim()) return;
+export function openUrl(rawUrl: string) {
+  const url = safeExternalUrl(rawUrl);
+  if (!url) return;
 
   const browserWindow = (globalThis as { window?: { open?: (url: string, target?: string, features?: string) => void } }).window;
   if (typeof browserWindow?.open === "function") {

--- a/src/plugins/builtin/ai/pi/host.ts
+++ b/src/plugins/builtin/ai/pi/host.ts
@@ -2,6 +2,7 @@ import type { AuthEvent, AuthPrompt } from "@earendil-works/pi-ai";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Type, type Static } from "typebox";
 import { sendRemoteControlRequest } from "../../../../remote/client";
+import { safeExternalUrl } from "../../../../utils/external-url";
 import type {
   RemoteAppKind,
   RemoteControlRequest,
@@ -141,18 +142,18 @@ export function toAiRuntimeCatalog(catalog: PiCatalog): AiRuntimeCatalog {
 }
 
 async function defaultOpenExternal(url: string): Promise<void> {
-  const parsed = new URL(url);
-  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+  const safeUrl = safeExternalUrl(url);
+  if (!safeUrl) {
     throw new Error("AI sign-in returned an unsupported URL.");
   }
   if (typeof Bun === "undefined" || typeof Bun.spawn !== "function") {
     throw new Error("Opening AI sign-in requires the native app host.");
   }
   const command = process.platform === "darwin"
-    ? ["open", parsed.toString()]
+    ? ["open", safeUrl]
     : process.platform === "win32"
-      ? ["cmd", "/c", "start", "", parsed.toString()]
-      : ["xdg-open", parsed.toString()];
+      ? ["cmd", "/c", "start", "", safeUrl]
+      : ["xdg-open", safeUrl];
   const processRef = Bun.spawn(command, { stdout: "ignore", stderr: "ignore" });
   const exitCode = await processRef.exited;
   if (exitCode !== 0) throw new Error("Could not open the AI sign-in page.");

--- a/src/renderers/electrobun/bun/desktop/host-requests.ts
+++ b/src/renderers/electrobun/bun/desktop/host-requests.ts
@@ -7,6 +7,7 @@ import type {
   DesktopRestartMessage,
   DesktopWindowControlAction,
 } from "../../shared/protocol";
+import { safeExternalUrl } from "../../../../utils/external-url";
 import { getContextMenuRequestId, normalizeContextMenuItems } from "../context-menu/normalize";
 import { MAIN_WINDOW_RPC_KEY } from "../window/focus";
 
@@ -102,12 +103,14 @@ export function handleDesktopHostRequest<TRpc>({
       }
       return null;
     }
-    case "host.openExternal":
+    case "host.openExternal": {
       if (typeof request.payload.url !== "string") {
         throw new Error("host.openExternal requires a URL.");
       }
-      Utils.openExternal(request.payload.url);
+      const externalUrl = safeExternalUrl(request.payload.url);
+      if (externalUrl) Utils.openExternal(externalUrl);
       return null;
+    }
     case "host.copyText":
       Utils.clipboardWriteText(normalizeText(request.payload.text) ?? "");
       return null;

--- a/src/renderers/opentui/host.tsx
+++ b/src/renderers/opentui/host.tsx
@@ -5,6 +5,7 @@ import { resetTerminalInputState } from "../../utils/terminal-input-reset";
 import type { KeyEventLike } from "../../react/input";
 import type { NativeRendererHost, PixelResolution, RendererHost } from "../../ui/host";
 import { colors } from "../../theme/colors";
+import { safeExternalUrl } from "../../utils/external-url";
 
 export { useKeyboard, useTerminalDimensions };
 
@@ -95,7 +96,9 @@ export async function createOpenTuiHost(): Promise<OpenTuiHost> {
 
   const rendererHost: RendererHost = {
     requestExit: () => renderer.destroy(),
-    async openExternal(url) {
+    async openExternal(rawUrl) {
+      const url = safeExternalUrl(rawUrl);
+      if (!url) return;
       const command = process.platform === "darwin"
         ? ["open", url]
         : process.platform === "win32"

--- a/src/utils/external-url.test.ts
+++ b/src/utils/external-url.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { safeExternalUrl } from "./external-url";
+
+describe("safeExternalUrl", () => {
+  test("accepts the web schemes and returns the normalised URL", () => {
+    expect(safeExternalUrl("https://example.com/a?b=1")).toBe("https://example.com/a?b=1");
+    expect(safeExternalUrl("http://example.com")).toBe("http://example.com/");
+    expect(safeExternalUrl("  https://example.com/x  ")).toBe("https://example.com/x");
+  });
+
+  test("rejects schemes that would let a feed reach the local machine", () => {
+    // These reach openUrl straight from RSS, news, and market payloads, and
+    // end up as arguments to `open` / `xdg-open` / `cmd /c start`.
+    for (const hostile of [
+      "file:///etc/passwd",
+      "javascript:alert(1)",
+      "data:text/html,<script>alert(1)</script>",
+      "vbscript:msgbox(1)",
+      "smb://attacker/share",
+      "gloomberb://open",
+    ]) {
+      expect(safeExternalUrl(hostile)).toBeNull();
+    }
+  });
+
+  test("rejects input that is not a URL at all", () => {
+    expect(safeExternalUrl("")).toBeNull();
+    expect(safeExternalUrl("   ")).toBeNull();
+    expect(safeExternalUrl("not-a-url")).toBeNull();
+    expect(safeExternalUrl("//example.com")).toBeNull();
+  });
+});

--- a/src/utils/external-url.ts
+++ b/src/utils/external-url.ts
@@ -1,0 +1,23 @@
+/**
+ * Scheme validation for links handed to the operating system.
+ *
+ * Opening a link natively means spawning `open` / `xdg-open` / `cmd /c start`
+ * with a string that usually came from an external feed: RSS items, prediction
+ * markets, news, filings, Substack. Two things make an unvalidated string
+ * dangerous there — `file://` launches local content, and Windows routes the
+ * argument through cmd's parser.
+ *
+ * Restricting to http(s) removes both. Returns the normalised URL so callers
+ * spawn the parsed form rather than the raw input.
+ */
+export function safeExternalUrl(value: string): string | null {
+  if (!value.trim()) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  return parsed.toString();
+}


### PR DESCRIPTION
Opening a link natively spawns `open` / `xdg-open` / `cmd /c start` with a string that usually came from an external feed — RSS, news, prediction markets, filings, Substack. Three of the four spawn sites passed that string through unvalidated, so a hostile feed could serve `file://` to launch local content, and on Windows the argument goes through cmd's own parser.

`safeExternalUrl()` restricts to http(s) and returns the parsed form, so callers spawn the normalised URL rather than raw input. Applied to `openUrl`, the OpenTUI renderer host, and the Electrobun `host.openExternal` handler. The AI sign-in path already did this check inline and now shares the helper.

No caller opens a non-web scheme: there is no mailto:/tel: usage, and `gloomberb://` only ever arrives inbound through the deep-link resolver.