### PR TITLE
Add Polls (VoteHub) pane

### DIFF
--- a/src/plugins/builtin/polls/client.ts
+++ b/src/plugins/builtin/polls/client.ts
@@ -1,0 +1,57 @@
+import { createThrottledFetch } from "../../../utils/throttled-fetch";
+import { httpFetch } from "../../../utils/http-transport";
+import type { VoteHubPoll } from "./types";
+
+const BASE_URL = "https://api.votehub.com";
+
+const VOTEHUB_FETCH = createThrottledFetch({
+  requestsPerMinute: 30,
+  maxRetries: 2,
+  timeoutMs: 12_000,
+  backoffBaseMs: 500,
+  dedupeGetRequests: true,
+  defaultHeaders: {
+    Accept: "application/json",
+    "User-Agent": "gloomberb-polls",
+  },
+  transport: httpFetch,
+});
+
+export function parseVoteHubPollsPayload(body: unknown): VoteHubPoll[] {
+  if (Array.isArray(body)) return body.filter(isVoteHubPoll);
+  if (body && typeof body === "object" && Array.isArray((body as { polls?: unknown }).polls)) {
+    return (body as { polls: unknown[] }).polls.filter(isVoteHubPoll);
+  }
+  return [];
+}
+
+function isVoteHubPoll(value: unknown): value is VoteHubPoll {
+  if (!value || typeof value !== "object") return false;
+  const poll = value as Record<string, unknown>;
+  return typeof poll.id === "string" && typeof poll.pollster === "string" && typeof poll.subject === "string";
+}
+
+function buildUrl(path: string, params?: Record<string, string | undefined>): string {
+  const url = new URL(`${BASE_URL}${path}`);
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value) url.searchParams.set(key, value);
+    }
+  }
+  return url.toString();
+}
+
+export async function fetchVoteHubPolls(params?: {
+  pollType?: string;
+  subject?: string;
+}): Promise<VoteHubPoll[]> {
+  const url = buildUrl("/polls", {
+    poll_type: params?.pollType,
+    subject: params?.subject,
+  });
+  const response = await VOTEHUB_FETCH.fetch(url);
+  if (!response.ok) {
+    throw new Error(`VoteHub request failed (${response.status})`);
+  }
+  return parseVoteHubPollsPayload(await response.json());
+}

--- a/src/plugins/builtin/polls/hooks.ts
+++ b/src/plugins/builtin/polls/hooks.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+
+function formatApproximateAge(timestamp: number | null | undefined, now: number = Date.now()): string {
+  if (!timestamp || !Number.isFinite(timestamp)) return "~0m";
+  const seconds = Math.floor((now - timestamp) / 1000);
+  if (seconds < 60) return "~0m";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `~${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `~${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `~${days}d`;
+  const weeks = Math.floor(days / 7);
+  return `~${weeks}w`;
+}
+
+/**
+ * Returns a compact "~5m" age label for a timestamp that re-renders every
+ * minute so the count increments without another fetch. Returns null when no
+ * timestamp is provided.
+ */
+export function useUpdatedAgo(timestamp: number | null | undefined): string | null {
+  const [, tick] = useState(0);
+  useEffect(() => {
+    if (!timestamp) return;
+    const interval = setInterval(() => tick((n) => n + 1), 60_000);
+    return () => clearInterval(interval);
+  }, [timestamp]);
+  if (!timestamp) return null;
+  return formatApproximateAge(timestamp);
+}
+
+interface StackSortPreference<C extends string> {
+  columnId: C;
+  direction: "asc" | "desc";
+}
+
+/**
+ * Cycles a table's sort preference when a header is clicked: toggles direction
+ * on the active column, otherwise switches to the new column at its default
+ * direction.
+ */
+export function nextStackSortPreference<C extends string>(
+  current: StackSortPreference<C>,
+  columnId: C,
+  defaultDirection: "asc" | "desc" = "desc",
+): StackSortPreference<C> {
+  if (current.columnId === columnId) {
+    return { columnId, direction: current.direction === "asc" ? "desc" : "asc" };
+  }
+  return { columnId, direction: defaultDirection };
+}

--- a/src/plugins/builtin/polls/index.tsx
+++ b/src/plugins/builtin/polls/index.tsx
@@ -1,0 +1,35 @@
+import type { GloomPlugin } from "../../../types/plugin";
+import { PollsPane } from "./pane";
+import { POLLS_PANE_ID, POLLS_PLUGIN_ID } from "./types";
+
+export const pollsPlugin: GloomPlugin = {
+  id: POLLS_PLUGIN_ID,
+  name: "Polls",
+  version: "1.0.0",
+  description: "Political polls from VoteHub (CC BY 4.0)",
+  toggleable: true,
+
+  panes: [
+    {
+      id: POLLS_PANE_ID,
+      name: "Polls",
+      icon: "P",
+      component: PollsPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 100, height: 32 },
+    },
+  ],
+
+  paneTemplates: [
+    {
+      id: "polls-pane",
+      paneId: POLLS_PANE_ID,
+      label: "Polls",
+      description: "Browse VoteHub political polls by type — approval, favorability, generic ballot, Senate, governor, House — with trend charts, pollster breakdowns, search, and source links.",
+      keywords: ["polls", "votehub", "approval", "favorability", "generic", "ballot", "senate", "governor"],
+      shortcut: { prefix: "POLL" },
+      createInstance: () => ({ placement: "floating" }),
+    },
+  ],
+};

--- a/src/plugins/builtin/polls/normalize.test.ts
+++ b/src/plugins/builtin/polls/normalize.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from "bun:test";
+import { parseVoteHubPollsPayload } from "./client";
+import {
+  computeMarginOfError,
+  computeMovingAverage,
+  computePollAverages,
+  computePollsterAverages,
+  computePollTrend,
+  filterPollRows,
+  normalizeVoteHubPoll,
+  parseSampleSize,
+  populationLabel,
+  sortPollRows,
+  summarizeAnswers,
+} from "./normalize";
+import type { PollRow, VoteHubPoll } from "./types";
+
+function makePoll(overrides: Partial<VoteHubPoll> = {}): VoteHubPoll {
+  return {
+    id: "p1",
+    poll_type: "approval",
+    sample_size: 1000,
+    population: "rv",
+    url: null,
+    created_at: null,
+    start_date: "2026-01-01",
+    end_date: "2026-01-03",
+    pollster: "Test Pollster",
+    answers: [
+      { choice: "Approve", pct: 45 },
+      { choice: "Disapprove", pct: 50 },
+    ],
+    seat_name: null,
+    sponsors: [],
+    internal: false,
+    partisan: null,
+    subject: "Donald Trump",
+    ...overrides,
+  };
+}
+
+describe("VoteHub normalize", () => {
+  test("accepts a bare poll array or a { polls } envelope", () => {
+    const poll = makePoll();
+    expect(parseVoteHubPollsPayload([poll])).toHaveLength(1);
+    expect(parseVoteHubPollsPayload({ polls: [poll] })).toHaveLength(1);
+    expect(parseVoteHubPollsPayload({ data: [poll] })).toHaveLength(0);
+  });
+
+  test("summarizes a two-way result and lead", () => {
+    const summary = summarizeAnswers([
+      { choice: "Disapprove", pct: 51 },
+      { choice: "Approve", pct: 44 },
+    ]);
+    expect(summary.leadChoice).toBe("Disapprove");
+    expect(summary.lead).toBeCloseTo(7);
+    expect(summary.result).toContain("Disapprove");
+    expect(summary.result).toContain("Approve");
+  });
+
+  test("maps wire fields onto list rows including margin of error", () => {
+    const row = normalizeVoteHubPoll(makePoll({
+      poll_type: "generic-ballot",
+      sample_size: "1,500",
+      population: "lv",
+      answers: [
+        { choice: "Dem", pct: 44.4 },
+        { choice: "Rep", pct: 48.4 },
+      ],
+    }));
+    expect(row.pollTypeLabel).toBe("Generic");
+    expect(row.population).toBe("LV");
+    expect(row.sampleSize).toBe(1500);
+    expect(row.leadChoice).toBe("Rep");
+    expect(row.lead).toBeCloseTo(4);
+    expect(row.marginOfError).not.toBeNull();
+    expect(parseSampleSize("800")).toBe(800);
+    expect(populationLabel("rv")).toBe("RV");
+  });
+
+  test("sorts poll rows by date, pollster, or lead", () => {
+    const older = normalizeVoteHubPoll(makePoll({
+      id: "old",
+      start_date: "2026-07-01",
+      end_date: "2026-07-02",
+      pollster: "YouGov",
+      answers: [{ choice: "Approve", pct: 40 }, { choice: "Disapprove", pct: 50 }],
+    }));
+    const newer = normalizeVoteHubPoll(makePoll({
+      id: "new",
+      start_date: "2026-08-01",
+      end_date: "2026-08-10",
+      pollster: "Emerson",
+      answers: [{ choice: "Approve", pct: 55 }, { choice: "Disapprove", pct: 40 }],
+    }));
+
+    expect(sortPollRows([older, newer]).map((row) => row.id)).toEqual(["new", "old"]);
+    expect(sortPollRows([older, newer], { columnId: "pollster", direction: "asc" }).map((row) => row.id))
+      .toEqual(["new", "old"]);
+    expect(sortPollRows([older, newer], { columnId: "result", direction: "desc" }).map((row) => row.id))
+      .toEqual(["new", "old"]);
+  });
+});
+
+describe("computeMarginOfError", () => {
+  test("returns null for missing or invalid sample sizes", () => {
+    expect(computeMarginOfError(null)).toBeNull();
+    expect(computeMarginOfError(0)).toBeNull();
+    expect(computeMarginOfError(-5)).toBeNull();
+  });
+
+  test("computes MoE decreasing with larger samples", () => {
+    const small = computeMarginOfError(100);
+    const large = computeMarginOfError(10_000);
+    expect(small).not.toBeNull();
+    expect(large).not.toBeNull();
+    expect(small!).toBeGreaterThan(large!);
+    // 0.98 / sqrt(1000) ≈ 3.1
+    expect(computeMarginOfError(1000)).toBeCloseTo(3.1, 0);
+  });
+});
+
+describe("filterPollRows", () => {
+  const rows = [
+    normalizeVoteHubPoll(makePoll({ id: "a", subject: "Donald Trump", pollster: "Ipsos" })),
+    normalizeVoteHubPoll(makePoll({ id: "b", subject: "Congress", pollster: "Gallup" })),
+    normalizeVoteHubPoll(makePoll({ id: "c", subject: "Donald Trump", pollster: "Emerson" })),
+  ];
+
+  test("returns all rows for empty query", () => {
+    expect(filterPollRows(rows, "")).toHaveLength(3);
+    expect(filterPollRows(rows, "   ")).toHaveLength(3);
+  });
+
+  test("filters by subject case-insensitively", () => {
+    expect(filterPollRows(rows, "trump").map((r) => r.id)).toEqual(["a", "c"]);
+  });
+
+  test("filters by pollster case-insensitively", () => {
+    expect(filterPollRows(rows, "gallup").map((r) => r.id)).toEqual(["b"]);
+  });
+});
+
+describe("computePollTrend", () => {
+  const rows = [
+    normalizeVoteHubPoll(makePoll({ id: "t1", end_date: "2026-01-10", subject: "Donald Trump", answers: [{ choice: "Approve", pct: 45 }, { choice: "Disapprove", pct: 50 }] })),
+    normalizeVoteHubPoll(makePoll({ id: "t2", end_date: "2026-02-10", subject: "Donald Trump", answers: [{ choice: "Approve", pct: 42 }, { choice: "Disapprove", pct: 53 }] })),
+    normalizeVoteHubPoll(makePoll({ id: "t3", end_date: "2026-03-10", subject: "Congress", answers: [{ choice: "Approve", pct: 20 }, { choice: "Disapprove", pct: 70 }] })),
+  ];
+
+  test("collects sorted time series for matching subject and choice", () => {
+    const trend = computePollTrend(rows, "Donald Trump", "Approve");
+    expect(trend).toHaveLength(2);
+    expect(trend[0]!.date).toBe("2026-01-10");
+    expect(trend[1]!.date).toBe("2026-02-10");
+    expect(trend[0]!.value).toBe(45);
+  });
+
+  test("returns empty for non-matching subject", () => {
+    expect(computePollTrend(rows, "Unknown", "Approve")).toHaveLength(0);
+  });
+});
+
+describe("computeMovingAverage", () => {
+  const points = [
+    { date: "2026-01-01", value: 40, pollster: "A" },
+    { date: "2026-01-02", value: 50, pollster: "B" },
+    { date: "2026-01-03", value: 60, pollster: "C" },
+    { date: "2026-01-04", value: 30, pollster: "D" },
+  ];
+
+  test("computes rolling mean with the given window", () => {
+    const ma = computeMovingAverage(points, 2);
+    expect(ma).toHaveLength(3);
+    expect(ma[0]!.value).toBe(45); // (40+50)/2
+    expect(ma[1]!.value).toBe(55); // (50+60)/2
+    expect(ma[2]!.value).toBe(45); // (60+30)/2
+  });
+
+  test("returns empty when fewer points than window", () => {
+    expect(computeMovingAverage(points, 5)).toHaveLength(0);
+  });
+});
+
+describe("computePollsterAverages", () => {
+  const rows: PollRow[] = [
+    normalizeVoteHubPoll(makePoll({ id: "pa1", pollster: "Ipsos", sample_size: 1000, subject: "Donald Trump", answers: [{ choice: "Approve", pct: 45 }, { choice: "Disapprove", pct: 50 }] })),
+    normalizeVoteHubPoll(makePoll({ id: "pa2", pollster: "Ipsos", sample_size: 2000, subject: "Donald Trump", answers: [{ choice: "Approve", pct: 48 }, { choice: "Disapprove", pct: 47 }] })),
+    normalizeVoteHubPoll(makePoll({ id: "pa3", pollster: "Gallup", sample_size: 1000, subject: "Donald Trump", answers: [{ choice: "Approve", pct: 50 }, { choice: "Disapprove", pct: 45 }] })),
+  ];
+
+  test("groups by pollster with sample-weighted average", () => {
+    const result = computePollsterAverages(rows, "Donald Trump", "Approve");
+    expect(result).toHaveLength(2);
+    const ipsos = result.find((r) => r.pollster === "Ipsos")!;
+    expect(ipsos.count).toBe(2);
+    expect(ipsos.totalSample).toBe(3000);
+    // (45*1000 + 48*2000) / 3000 = 147000/3000 = 47
+    expect(ipsos.avgPct).toBeCloseTo(47, 0);
+  });
+
+  test("sorts by poll count descending", () => {
+    const result = computePollsterAverages(rows, "Donald Trump", "Approve");
+    expect(result[0]!.count).toBeGreaterThanOrEqual(result[1]!.count);
+  });
+});
+
+describe("computePollAverages", () => {
+  const rows: PollRow[] = [
+    normalizeVoteHubPoll(makePoll({ id: "avg1", end_date: "2026-03-01", pollster: "Ipsos", sample_size: 1000, subject: "Donald Trump", answers: [{ choice: "Approve", pct: 44 }, { choice: "Disapprove", pct: 50 }] })),
+    normalizeVoteHubPoll(makePoll({ id: "avg2", end_date: "2026-02-01", pollster: "Gallup", sample_size: 2000, subject: "Donald Trump", answers: [{ choice: "Approve", pct: 46 }, { choice: "Disapprove", pct: 48 }] })),
+  ];
+
+  test("computes sample-weighted average per choice across recent polls", () => {
+    const result = computePollAverages(rows, "Donald Trump", 10);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.choice).toBe("Disapprove");
+    // Disapprove: (50*1000 + 48*2000) / 3000 = 146000/3000 ≈ 48.67
+    expect(result[0]!.avgPct).toBeCloseTo(48.67, 0);
+    expect(result[0]!.pollCount).toBe(2);
+  });
+
+  test("respects recentCount limit", () => {
+    const result = computePollAverages(rows, "Donald Trump", 1);
+    // Only the most recent poll (avg1, end_date 2026-03-01)
+    const approve = result.find((r) => r.choice === "Approve")!;
+    expect(approve.pollCount).toBe(1);
+    expect(approve.avgPct).toBe(44);
+  });
+});

--- a/src/plugins/builtin/polls/normalize.ts
+++ b/src/plugins/builtin/polls/normalize.ts
@@ -1,0 +1,318 @@
+import type {
+  PollAverageSummary,
+  PollRow,
+  PollTrendPoint,
+  PollsterAverage,
+  VoteHubPoll,
+  VoteHubPollAnswer,
+} from "./types";
+
+const POLL_TYPE_LABELS: Record<string, string> = {
+  approval: "Approval",
+  favorability: "Favorability",
+  "generic-ballot": "Generic",
+  "us-senator": "Senate",
+  governor: "Governor",
+  "us-representative": "House",
+  mayor: "Mayor",
+  "attorney-general": "AG",
+  "presidential-primary": "Primary",
+  "proposition-50": "Prop",
+};
+
+const POPULATION_LABELS: Record<string, string> = {
+  a: "A",
+  rv: "RV",
+  lv: "LV",
+};
+
+export function pollTypeLabel(pollType: string): string {
+  return POLL_TYPE_LABELS[pollType] ?? pollType.replace(/-/g, " ");
+}
+
+export function populationLabel(population: string | null | undefined): string {
+  if (!population) return "—";
+  return POPULATION_LABELS[population.toLowerCase()] ?? population.toUpperCase();
+}
+
+export function parseSampleSize(value: number | string | null | undefined): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value.replace(/,/g, ""));
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+/**
+ * Approximate 95% confidence margin of error for a proportion at 50/50,
+ * derived from sample size: MoE ≈ 0.98 / sqrt(n).
+ * Returns null when sample size is missing or too small to be meaningful.
+ */
+export function computeMarginOfError(sampleSize: number | null): number | null {
+  if (sampleSize == null || sampleSize < 1) return null;
+  const moe = (0.98 / Math.sqrt(sampleSize)) * 100;
+  return Number.isFinite(moe) ? Math.round(moe * 10) / 10 : null;
+}
+
+export function formatPollDate(value: string | null | undefined): string {
+  if (!value) return "—";
+  const date = new Date(`${value}T00:00:00Z`);
+  if (!Number.isFinite(date.getTime())) return value;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+}
+
+function sortedAnswers(answers: VoteHubPollAnswer[] | undefined): VoteHubPollAnswer[] {
+  return [...(answers ?? [])]
+    .filter((answer) => typeof answer.choice === "string" && Number.isFinite(answer.pct))
+    .sort((left, right) => right.pct - left.pct);
+}
+
+export function summarizeAnswers(answers: VoteHubPollAnswer[] | undefined): {
+  result: string;
+  lead: number | null;
+  leadChoice: string | null;
+} {
+  const ranked = sortedAnswers(answers);
+  const first = ranked[0];
+  const second = ranked[1];
+  if (!first) return { result: "—", lead: null, leadChoice: null };
+  if (!second) {
+    return {
+      result: `${first.choice} ${formatPct(first.pct)}`,
+      lead: first.pct,
+      leadChoice: first.choice,
+    };
+  }
+  const lead = first.pct - second.pct;
+  return {
+    result: `${shortChoice(first.choice)} ${formatPct(first.pct)}  ${shortChoice(second.choice)} ${formatPct(second.pct)}`,
+    lead,
+    leadChoice: first.choice,
+  };
+}
+
+function shortChoice(choice: string): string {
+  const trimmed = choice.trim();
+  if (trimmed.length <= 10) return trimmed;
+  return trimmed.slice(0, 9);
+}
+
+function formatPct(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+export function normalizeVoteHubPoll(poll: VoteHubPoll): PollRow {
+  const summary = summarizeAnswers(poll.answers);
+  const sampleSize = parseSampleSize(poll.sample_size);
+  return {
+    id: poll.id,
+    subject: poll.subject,
+    pollType: poll.poll_type,
+    pollTypeLabel: pollTypeLabel(poll.poll_type),
+    pollster: poll.pollster,
+    population: populationLabel(poll.population),
+    sampleSize,
+    marginOfError: computeMarginOfError(sampleSize),
+    startDate: poll.start_date,
+    endDate: poll.end_date,
+    result: summary.result,
+    lead: summary.lead,
+    leadChoice: summary.leadChoice,
+    url: poll.url,
+    sponsors: Array.isArray(poll.sponsors) ? poll.sponsors.filter((sponsor) => typeof sponsor === "string") : [],
+    partisan: typeof poll.partisan === "string" ? poll.partisan : null,
+    internal: poll.internal === true,
+    answers: sortedAnswers(poll.answers),
+  };
+}
+
+export type PollSortColumnId = "date" | "subject" | "pollster" | "pop" | "result";
+
+export interface PollSortPreference {
+  columnId: PollSortColumnId;
+  direction: "asc" | "desc";
+}
+
+export const DEFAULT_POLL_SORT: PollSortPreference = { columnId: "date", direction: "desc" };
+
+export function comparePollRows(
+  left: PollRow,
+  right: PollRow,
+  columnId: PollSortColumnId,
+): number {
+  switch (columnId) {
+    case "date":
+      return dateValue(left.endDate ?? left.startDate) - dateValue(right.endDate ?? right.startDate);
+    case "subject":
+      return left.subject.localeCompare(right.subject);
+    case "pollster":
+      return left.pollster.localeCompare(right.pollster);
+    case "pop":
+      return left.population.localeCompare(right.population);
+    case "result":
+      return (left.lead ?? Number.NEGATIVE_INFINITY) - (right.lead ?? Number.NEGATIVE_INFINITY);
+  }
+}
+
+export function sortPollRows(
+  rows: PollRow[],
+  preference: PollSortPreference = DEFAULT_POLL_SORT,
+): PollRow[] {
+  const sign = preference.direction === "asc" ? 1 : -1;
+  return [...rows].sort((left, right) => {
+    const primary = comparePollRows(left, right, preference.columnId);
+    if (primary !== 0) return sign * primary;
+    return left.subject.localeCompare(right.subject);
+  });
+}
+
+function dateValue(value: string | null): number {
+  if (!value) return 0;
+  const time = new Date(`${value}T00:00:00Z`).getTime();
+  return Number.isFinite(time) ? time : 0;
+}
+
+/**
+ * Case-insensitive substring filter across subject, pollster, and seat name.
+ * Returns the original array when the query is empty.
+ */
+export function filterPollRows(rows: PollRow[], query: string): PollRow[] {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) return rows;
+  return rows.filter((row) =>
+    row.subject.toLowerCase().includes(trimmed) ||
+    row.pollster.toLowerCase().includes(trimmed) ||
+    row.pollTypeLabel.toLowerCase().includes(trimmed),
+  );
+}
+
+/**
+ * Collect a time series of percentage values for a specific choice across all
+ * polls sharing the same subject. Points are sorted chronologically by end date.
+ */
+export function computePollTrend(
+  rows: PollRow[],
+  subject: string,
+  choice: string,
+): PollTrendPoint[] {
+  const target = choice.toLowerCase();
+  const points: PollTrendPoint[] = [];
+  for (const row of rows) {
+    if (row.subject !== subject) continue;
+    const answer = row.answers.find((a) => a.choice.toLowerCase() === target);
+    if (!answer) continue;
+    const date = row.endDate ?? row.startDate;
+    if (!date) continue;
+    points.push({ date, value: answer.pct, pollster: row.pollster });
+  }
+  return points.sort((a, b) => dateValue(a.date) - dateValue(b.date));
+}
+
+/**
+ * Simple moving average over a sorted trend series. Each output point is the
+ * mean of the current and preceding `window - 1` values. Returns an empty
+ * array when there are fewer than `window` points.
+ */
+export function computeMovingAverage(
+  points: PollTrendPoint[],
+  window: number,
+): Array<{ date: string; value: number }> {
+  if (window < 1 || points.length < window) return [];
+  const result: Array<{ date: string; value: number }> = [];
+  for (let i = window - 1; i < points.length; i++) {
+    let sum = 0;
+    for (let j = i - window + 1; j <= i; j++) {
+      sum += points[j]!.value;
+    }
+    result.push({ date: points[i]!.date, value: sum / window });
+  }
+  return result;
+}
+
+/**
+ * Group polls by pollster for a given subject and compute the sample-size-
+ * weighted average of the leading choice's percentage, poll count, total
+ * sample, and most recent end date. Sorted by poll count descending.
+ */
+export function computePollsterAverages(
+  rows: PollRow[],
+  subject: string,
+  choice: string | null,
+): PollsterAverage[] {
+  const target = choice?.toLowerCase();
+  const byPollster = new Map<string, { sum: number; weight: number; count: number; lastDate: string | null }>();
+  for (const row of rows) {
+    if (row.subject !== subject) continue;
+    const answer = target
+      ? row.answers.find((a) => a.choice.toLowerCase() === target)
+      : row.answers[0];
+    if (!answer) continue;
+    const weight = row.sampleSize ?? 0;
+    const entry = byPollster.get(row.pollster);
+    if (entry) {
+      entry.sum += answer.pct * weight;
+      entry.weight += weight;
+      entry.count += 1;
+      const d = row.endDate ?? row.startDate;
+      if (d && (!entry.lastDate || dateValue(d) > dateValue(entry.lastDate))) {
+        entry.lastDate = d;
+      }
+    } else {
+      byPollster.set(row.pollster, {
+        sum: answer.pct * weight,
+        weight,
+        count: 1,
+        lastDate: row.endDate ?? row.startDate,
+      });
+    }
+  }
+  return [...byPollster.entries()]
+    .map(([pollster, entry]) => ({
+      pollster,
+      count: entry.count,
+      avgPct: entry.weight > 0 ? entry.sum / entry.weight : entry.sum / entry.count,
+      totalSample: entry.weight,
+      lastDate: entry.lastDate,
+    }))
+    .sort((a, b) => b.count - a.count);
+}
+
+/**
+ * Compute a sample-size-weighted average for each choice across recent polls
+ * sharing a subject. `recentCount` limits to the most recent N polls by end
+ * date. Returns summaries sorted by average percentage descending.
+ */
+export function computePollAverages(
+  rows: PollRow[],
+  subject: string,
+  recentCount: number,
+): PollAverageSummary[] {
+  const matching = rows
+    .filter((row) => row.subject === subject)
+    .sort((a, b) => dateValue(b.endDate ?? b.startDate) - dateValue(a.endDate ?? a.startDate))
+    .slice(0, Math.max(1, recentCount));
+
+  const byChoice = new Map<string, { sum: number; weight: number; count: number }>();
+  for (const row of matching) {
+    for (const answer of row.answers) {
+      const weight = row.sampleSize ?? 1;
+      const entry = byChoice.get(answer.choice);
+      if (entry) {
+        entry.sum += answer.pct * weight;
+        entry.weight += weight;
+        entry.count += 1;
+      } else {
+        byChoice.set(answer.choice, { sum: answer.pct * weight, weight, count: 1 });
+      }
+    }
+  }
+  return [...byChoice.entries()]
+    .map(([choice, entry]) => ({
+      choice,
+      avgPct: entry.weight > 0 ? entry.sum / entry.weight : entry.sum / entry.count,
+      pollCount: entry.count,
+      totalSample: entry.weight,
+    }))
+    .sort((a, b) => b.avgPct - a.avgPct);
+}

--- a/src/plugins/builtin/polls/pane.tsx
+++ b/src/plugins/builtin/polls/pane.tsx
@@ -1,0 +1,730 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, ScrollBox, Text, TextAttributes, type InputRenderable } from "../../../ui";
+import { useShortcut } from "../../../react/input";
+import { isPlainArrowUp, stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
+import {
+  DataTableStackView,
+  EmptyState,
+  InputSearchBar,
+  Spinner,
+  Tabs,
+  usePaneFooter,
+  type DataTableCell,
+  type DataTableColumn,
+  type DataTableKeyEvent,
+  type DataTableRootKeyContext,
+} from "../../../components";
+import {
+  CompositeChart,
+  pricePointsToResolvedSeries,
+} from "../../../components/chart/composite";
+import { colors, priceColor } from "../../../theme/colors";
+import { isPlainKey } from "../../../utils/keyboard";
+import { openUrl } from "../../../components/ui/external-link";
+import type { PricePoint } from "../../../types/financials";
+import type { PaneProps } from "../../../types/plugin";
+import { useUpdatedAgo, nextStackSortPreference } from "./hooks";
+import { fetchVoteHubPolls } from "./client";
+import {
+  computeMovingAverage,
+  computePollAverages,
+  computePollsterAverages,
+  computePollTrend,
+  DEFAULT_POLL_SORT,
+  filterPollRows,
+  formatPollDate,
+  normalizeVoteHubPoll,
+  sortPollRows,
+  type PollSortColumnId,
+  type PollSortPreference,
+} from "./normalize";
+import type { PollDetailTab, PollRow, PollTabId } from "./types";
+
+type LoadStatus = "idle" | "loading" | "loaded" | "error";
+
+interface PollColumn extends DataTableColumn {
+  id: "date" | "subject" | "pollster" | "pop" | "result";
+}
+
+const TABS: Array<{ value: PollTabId; label: string }> = [
+  { value: "approval", label: "Approval" },
+  { value: "favorability", label: "Favorability" },
+  { value: "generic-ballot", label: "Generic" },
+  { value: "us-senator", label: "Senate" },
+  { value: "governor", label: "Governor" },
+  { value: "us-representative", label: "House" },
+];
+
+const DETAIL_TABS: Array<{ value: PollDetailTab; label: string }> = [
+  { value: "overview", label: "Overview" },
+  { value: "trend", label: "Trend" },
+  { value: "pollsters", label: "Pollsters" },
+];
+
+const TREND_WINDOW = 5;
+const RECENT_POLL_COUNT = 10;
+
+/**
+ * Maps a poll answer label to a semantic color: approve/yes → positive,
+ * disapprove/no → negative, everything else stays neutral. A leading
+ * "approve" poll at 40% is still semantically positive, so this is label-based
+ * (not probability-based like prediction markets).
+ */
+function answerChoiceColor(choice: string): string | undefined {
+  const normalized = choice.trim().toLowerCase();
+  if (/\b(approve|yes|favor|support|positive)\b/.test(normalized)) return colors.positive;
+  if (/\b(disapprove|no|oppose|against|negative|unfavor)\b/.test(normalized)) return colors.negative;
+  return undefined;
+}
+
+function createColumns(width: number): PollColumn[] {
+  const dateWidth = 8;
+  const popWidth = 4;
+  const resultWidth = 22;
+  const pollsterWidth = 14;
+  const subjectWidth = Math.max(12, width - dateWidth - popWidth - resultWidth - pollsterWidth - 8);
+  return [
+    { id: "date", label: "DATE", width: dateWidth, align: "left" },
+    { id: "subject", label: "SUBJECT", width: subjectWidth, align: "left" },
+    { id: "pollster", label: "POLLSTER", width: pollsterWidth, align: "left" },
+    { id: "pop", label: "POP", width: popWidth, align: "left" },
+    { id: "result", label: "RESULT", width: resultWidth, align: "left" },
+  ];
+}
+
+function renderPollCell(row: PollRow, column: PollColumn, selected: boolean): DataTableCell {
+  const sel = selected ? colors.selectedText : undefined;
+  switch (column.id) {
+    case "date":
+      return { text: formatPollDate(row.endDate), color: sel ?? colors.textDim };
+    case "subject":
+      return { text: row.subject, color: sel ?? colors.textBright, attributes: TextAttributes.BOLD };
+    case "pollster":
+      return { text: row.pollster, color: sel ?? colors.textMuted };
+    case "pop":
+      return { text: row.population, color: sel ?? colors.textDim };
+    case "result":
+      return {
+        text: row.result,
+        color: sel ?? (row.lead != null ? priceColor(row.lead) : colors.text),
+      };
+  }
+}
+
+function AnswerBar({ pct, color, maxPct, width }: { pct: number; color: string; maxPct: number; width: number }) {
+  const barWidth = maxPct > 0 ? Math.max(1, Math.round((pct / maxPct) * width)) : 0;
+  return (
+    <Box flexDirection="row" height={1} gap={1}>
+      <Box width={barWidth} backgroundColor={color} />
+      <Box flexGrow={1} />
+    </Box>
+  );
+}
+
+function PollOverview({ poll, allRows, width }: { poll: PollRow; allRows: PollRow[]; width: number }) {
+  const lineWidth = Math.max(12, width - 2);
+  const maxPct = Math.max(...poll.answers.map((a) => a.pct), 1);
+  const labelWidth = Math.min(16, Math.floor(lineWidth * 0.35));
+  const barWidth = Math.max(10, lineWidth - labelWidth - 12);
+
+  const averages = useMemo(
+    () => computePollAverages(allRows, poll.subject, RECENT_POLL_COUNT),
+    [allRows, poll.subject],
+  );
+  const maxAvg = Math.max(...averages.map((a) => a.avgPct), 1);
+
+  return (
+    <ScrollBox flexGrow={1} scrollY>
+      <Box flexDirection="column" paddingX={1} gap={1}>
+        <Text fg={colors.textDim}>
+          {poll.pollTypeLabel}
+          {poll.sponsors.length > 0 ? ` · ${poll.sponsors.join(", ")}` : ""}
+        </Text>
+        <Text fg={colors.textDim}>
+          {formatPollDate(poll.startDate)}–{formatPollDate(poll.endDate)}
+          {` · ${poll.pollster} · ${poll.population}`}
+          {poll.sampleSize != null ? ` · n=${poll.sampleSize.toLocaleString("en-US")}` : ""}
+          {poll.marginOfError != null ? ` · ±${poll.marginOfError}%` : ""}
+        </Text>
+        {poll.partisan ? <Text fg={colors.textMuted}>Partisan: {poll.partisan}</Text> : null}
+        {poll.internal ? <Text fg={colors.textMuted}>Internal poll</Text> : null}
+
+        <Box height={1} />
+        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>This poll</Text>
+        {poll.answers.map((answer) => {
+          const choiceColor = answerChoiceColor(answer.choice);
+          return (
+          <Box key={answer.choice} flexDirection="row" height={1} gap={2}>
+            <Box width={labelWidth}>
+              <Text fg={choiceColor ?? colors.text} wrapMode="ellipsis">{answer.choice}</Text>
+            </Box>
+            <Box width={4} justifyContent="flex-end" flexDirection="row">
+              <Text fg={choiceColor ?? (poll.leadChoice === answer.choice ? colors.textBright : colors.textDim)} attributes={TextAttributes.BOLD}>
+                {Number.isInteger(answer.pct) ? `${answer.pct}` : answer.pct.toFixed(1)}
+              </Text>
+            </Box>
+            <Box width={barWidth}>
+              <AnswerBar
+                pct={answer.pct}
+                color={choiceColor ?? (poll.leadChoice === answer.choice ? colors.positive : colors.border)}
+                maxPct={maxPct}
+                width={barWidth}
+              />
+            </Box>
+          </Box>
+          );
+        })}
+
+        {averages.length > 0 && (
+          <>
+            <Box height={1} />
+            <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+              {RECENT_POLL_COUNT}-poll weighted avg
+            </Text>
+            {averages.map((avg) => {
+              const avgColor = answerChoiceColor(avg.choice);
+              return (
+              <Box key={avg.choice} flexDirection="row" height={1} gap={2}>
+                <Box width={labelWidth}>
+                  <Text fg={avgColor ?? colors.text} wrapMode="ellipsis">{avg.choice}</Text>
+                </Box>
+                <Box width={4} justifyContent="flex-end" flexDirection="row">
+                  <Text fg={avgColor ?? colors.textBright} attributes={TextAttributes.BOLD}>
+                    {avg.avgPct.toFixed(1)}
+                  </Text>
+                </Box>
+                <Box width={barWidth}>
+                  <AnswerBar
+                    pct={avg.avgPct}
+                    color={avgColor ?? colors.textBright}
+                    maxPct={maxAvg}
+                    width={barWidth}
+                  />
+                </Box>
+                <Text fg={colors.textDim}>{avg.pollCount}</Text>
+              </Box>
+              );
+            })}
+          </>
+        )}
+      </Box>
+    </ScrollBox>
+  );
+}
+
+function PollTrend({
+  poll,
+  allRows,
+  width,
+  height,
+}: {
+  poll: PollRow;
+  allRows: PollRow[];
+  width: number;
+  height: number;
+}) {
+  const leadingChoice = poll.leadChoice ?? poll.answers[0]?.choice ?? null;
+
+  const trendData = useMemo(() => {
+    if (!leadingChoice) return { points: [], ma: [] };
+    const points = computePollTrend(allRows, poll.subject, leadingChoice);
+    const ma = computeMovingAverage(points, TREND_WINDOW);
+    return { points, ma };
+  }, [allRows, poll.subject, leadingChoice]);
+
+  if (!leadingChoice || trendData.points.length === 0) {
+    return (
+      <Box flexGrow={1} justifyContent="center" alignItems="center">
+        <EmptyState title="No trend data." hint="Not enough polls for this subject." />
+      </Box>
+    );
+  }
+
+  if (trendData.points.length < 2) {
+    return (
+      <Box flexGrow={1} justifyContent="center" alignItems="center">
+        <EmptyState title="Not enough data for a trend." hint="Need at least 2 polls." />
+      </Box>
+    );
+  }
+
+  const rawPoints: PricePoint[] = trendData.points.map((p) => ({
+    date: new Date(`${p.date}T00:00:00Z`),
+    close: p.value,
+  }));
+
+  const maPoints: PricePoint[] = trendData.ma.map((p) => ({
+    date: new Date(`${p.date}T00:00:00Z`),
+    close: p.value,
+  }));
+
+  const chartHeight = Math.max(height - 2, 4);
+
+  const rawSeries = pricePointsToResolvedSeries(rawPoints, {
+    id: "raw",
+    label: leadingChoice,
+    color: colors.textDim,
+    unit: "%",
+    unitGroup: "percent",
+    style: "points",
+    axis: "left",
+    panelId: "pct",
+  });
+
+  const maSeries = maPoints.length > 0
+    ? pricePointsToResolvedSeries(maPoints, {
+        id: "ma",
+        label: `${TREND_WINDOW}-poll avg`,
+        color: colors.positive,
+        unit: "%",
+        unitGroup: "percent",
+        style: "line",
+        axis: "left",
+        panelId: "pct",
+      })
+    : null;
+
+  const series = maSeries ? [rawSeries, maSeries] : [rawSeries];
+
+  return (
+    <Box flexDirection="column" height={height}>
+      <Box flexDirection="row" height={1} paddingX={1} gap={2}>
+        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{leadingChoice}</Text>
+        <Text fg={colors.textDim}>
+          {trendData.points.length} polls · {formatPollDate(trendData.points[0]!.date)}–{formatPollDate(trendData.points[trendData.points.length - 1]!.date)}
+        </Text>
+      </Box>
+      <CompositeChart
+        width={width}
+        height={chartHeight}
+        focused={false}
+        interactive={false}
+        series={series}
+        panels={[{ id: "pct", scale: "linear" }]}
+        axisWidth={8}
+        showLegend={true}
+        showTimeAxis={true}
+        formatValue={(value: number) => `${value.toFixed(1)}%`}
+      />
+    </Box>
+  );
+}
+
+function PollPollsters({
+  poll,
+  allRows,
+  width,
+}: {
+  poll: PollRow;
+  allRows: PollRow[];
+  width: number;
+}) {
+  const leadingChoice = poll.leadChoice ?? poll.answers[0]?.choice ?? null;
+  const pollsters = useMemo(
+    () => computePollsterAverages(allRows, poll.subject, leadingChoice),
+    [allRows, poll.subject, leadingChoice],
+  );
+
+  if (pollsters.length === 0) {
+    return (
+      <Box flexGrow={1} justifyContent="center" alignItems="center">
+        <EmptyState title="No pollster data." hint="Not enough polls for this subject." />
+      </Box>
+    );
+  }
+
+  const lineWidth = Math.max(12, width - 2);
+  const pollsterWidth = Math.min(22, Math.floor(lineWidth * 0.4));
+  const numWidth = 4;
+  const sampleWidth = 8;
+  const barWidth = Math.max(8, lineWidth - pollsterWidth - numWidth - sampleWidth - 8);
+  const maxAvg = Math.max(...pollsters.map((p) => p.avgPct), 1);
+
+  return (
+    <ScrollBox flexGrow={1} scrollY>
+      <Box flexDirection="column" paddingX={1} gap={1}>
+        <Box flexDirection="row" height={1} gap={2}>
+          <Box width={pollsterWidth}>
+            <Text fg={colors.textDim}>POLLSTER</Text>
+          </Box>
+          <Box width={numWidth} justifyContent="flex-end" flexDirection="row">
+            <Text fg={colors.textDim}>AVG</Text>
+          </Box>
+          <Box width={sampleWidth} justifyContent="flex-end" flexDirection="row">
+            <Text fg={colors.textDim}>N</Text>
+          </Box>
+          <Box width={3} justifyContent="flex-end" flexDirection="row">
+            <Text fg={colors.textDim}>#</Text>
+          </Box>
+        </Box>
+        {pollsters.map((entry) => (
+          <Box key={entry.pollster} flexDirection="row" height={1} gap={2}>
+            <Box width={pollsterWidth}>
+              <Text fg={colors.text} wrapMode="ellipsis">{entry.pollster}</Text>
+            </Box>
+            <Box width={numWidth} justifyContent="flex-end" flexDirection="row">
+              <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+                {entry.avgPct.toFixed(1)}
+              </Text>
+            </Box>
+            <Box width={sampleWidth} justifyContent="flex-end" flexDirection="row">
+              <Text fg={colors.textDim}>
+                {entry.totalSample > 0 ? entry.totalSample.toLocaleString("en-US") : "—"}
+              </Text>
+            </Box>
+            <Box width={3} justifyContent="flex-end" flexDirection="row">
+              <Text fg={colors.textDim}>{entry.count}</Text>
+            </Box>
+            <Box width={barWidth}>
+              <AnswerBar
+                pct={entry.avgPct}
+                color={colors.positive}
+                maxPct={maxAvg}
+                width={barWidth}
+              />
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </ScrollBox>
+  );
+}
+
+function PollDetail({
+  poll,
+  allRows,
+  width,
+  height,
+  detailTab,
+  onDetailTabChange,
+}: {
+  poll: PollRow;
+  allRows: PollRow[];
+  width: number;
+  height: number;
+  detailTab: PollDetailTab;
+  onDetailTabChange: (tab: PollDetailTab) => void;
+}) {
+  const tabs = (
+    <Box paddingBottom={1}>
+      <Tabs
+        tabs={DETAIL_TABS}
+        activeValue={detailTab}
+        onSelect={(v) => onDetailTabChange(v as PollDetailTab)}
+        compact
+      />
+    </Box>
+  );
+
+  const contentHeight = Math.max(height - 2, 1);
+
+  if (detailTab === "trend") {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {tabs}
+        <PollTrend poll={poll} allRows={allRows} width={width} height={contentHeight} />
+      </Box>
+    );
+  }
+
+  if (detailTab === "pollsters") {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {tabs}
+        <PollPollsters poll={poll} allRows={allRows} width={width} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      {tabs}
+      <PollOverview poll={poll} allRows={allRows} width={width} />
+    </Box>
+  );
+}
+
+export function PollsPane({ focused, width, height }: PaneProps) {
+  const [tab, setTab] = useState<PollTabId>("approval");
+  const [rowsByTab, setRowsByTab] = useState<Partial<Record<PollTabId, PollRow[]>>>({});
+  const [status, setStatus] = useState<LoadStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [detailTab, setDetailTab] = useState<PollDetailTab>("overview");
+  const [sortPreference, setSortPreference] = useState<PollSortPreference>(DEFAULT_POLL_SORT);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchFocused, setSearchFocused] = useState(false);
+  const [searchFocusToken, setSearchFocusToken] = useState(0);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+  const searchInputRef = useRef<InputRenderable | null>(null);
+  const genRef = useRef(0);
+
+  const allRows = rowsByTab[tab] ?? [];
+  const filteredRows = useMemo(() => filterPollRows(allRows, searchQuery), [allRows, searchQuery]);
+  const rows = useMemo(() => sortPollRows(filteredRows, sortPreference), [filteredRows, sortPreference]);
+  const selected = rows.find((row) => row.id === selectedId) ?? null;
+
+  const focusSearch = useCallback(() => {
+    setSearchFocused(true);
+    setSearchFocusToken((current) => current + 1);
+  }, []);
+  const blurSearch = useCallback(() => {
+    setSearchFocused(false);
+  }, []);
+
+  const load = useCallback((pollType: PollTabId) => {
+    genRef.current += 1;
+    const gen = genRef.current;
+    setStatus("loading");
+    setError(null);
+    fetchVoteHubPolls({ pollType })
+      .then((polls) => {
+        if (genRef.current !== gen) return;
+        setRowsByTab((current) => ({
+          ...current,
+          [pollType]: polls.map(normalizeVoteHubPoll),
+        }));
+        setStatus("loaded");
+        setLastUpdated(Date.now());
+      })
+      .catch((loadError) => {
+        if (genRef.current !== gen) return;
+        setError(loadError instanceof Error ? loadError.message : String(loadError));
+        setStatus("error");
+      });
+  }, []);
+
+  useEffect(() => {
+    load(tab);
+  }, [load, tab]);
+
+  useEffect(() => {
+    if (rows.length === 0) {
+      if (selectedId !== null) setSelectedId(null);
+      setDetailOpen(false);
+      return;
+    }
+    if (!selectedId || !rows.some((row) => row.id === selectedId)) {
+      setSelectedId(rows[0]!.id);
+    }
+  }, [rows, selectedId]);
+
+  const openSelected = useCallback(() => {
+    if (!selected?.url) return;
+    openUrl(selected.url);
+  }, [selected]);
+
+  const handleRootKeyDown = useCallback((
+    event: DataTableKeyEvent,
+    context: DataTableRootKeyContext,
+  ) => {
+    if (context.selectedIndex <= 0 && isPlainArrowUp(event)) {
+      stopSearchFocusNavigation(event);
+      focusSearch();
+      return true;
+    }
+    if (event.name === "s" || event.name === "/") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      focusSearch();
+      return true;
+    }
+    if (isPlainKey(event, "r")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      load(tab);
+      return true;
+    }
+    if (isPlainKey(event, "o")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      if (selected?.url) openUrl(selected.url);
+      return true;
+    }
+    return false;
+  }, [focusSearch, load, openSelected, selected?.url, tab]);
+
+  useShortcut((event) => {
+    if (!focused || detailOpen || searchFocused) return;
+    if (event.name === "s" || event.name === "/") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      focusSearch();
+    }
+  }, { enabled: focused && !detailOpen && !searchFocused });
+
+  const handleDetailKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (isPlainKey(event, "h") || event.name === "left") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      setDetailTab((current) => {
+        const idx = DETAIL_TABS.findIndex((t) => t.value === current);
+        if (idx <= 0) return DETAIL_TABS[DETAIL_TABS.length - 1]!.value;
+        return DETAIL_TABS[idx - 1]!.value;
+      });
+      return true;
+    }
+    if (isPlainKey(event, "l") || event.name === "right") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      setDetailTab((current) => {
+        const idx = DETAIL_TABS.findIndex((t) => t.value === current);
+        if (idx < 0 || idx >= DETAIL_TABS.length - 1) return DETAIL_TABS[0]!.value;
+        return DETAIL_TABS[idx + 1]!.value;
+      });
+      return true;
+    }
+    if (isPlainKey(event, "r")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      load(tab);
+      return true;
+    }
+    if (isPlainKey(event, "o")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      if (selected?.url) openUrl(selected.url);
+      return true;
+    }
+    return false;
+  }, [load, selected?.url, tab]);
+
+  const columns = useMemo(() => createColumns(width), [width]);
+  const updatedAgo = useUpdatedAgo(status === "loaded" ? lastUpdated : null);
+  const renderCell = useCallback(
+    (row: PollRow, column: PollColumn, _index: number, rowState: { selected: boolean }) =>
+      renderPollCell(row, column, rowState.selected),
+    [],
+  );
+
+  usePaneFooter("polls", () => ({
+    info: [
+      ...(status === "loading" ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+      ...(error ? [{ id: "error", parts: [{ text: "error", tone: "warning" as const }] }] : []),
+      ...(searchQuery.trim() ? [{ id: "search", parts: [{ text: `search: ${searchQuery.trim()}`, tone: "value" as const }] }] : []),
+      ...(updatedAgo ? [{ id: "updated", parts: [{ text: `updated ${updatedAgo}`, tone: "muted" as const }] }] : []),
+    ],
+    hints: detailOpen
+      ? [
+          { id: "refresh", key: "r", label: "efresh", onPress: () => load(tab) },
+          { id: "open", key: "o", label: "pen", onPress: openSelected, disabled: !selected?.url },
+        ]
+      : [
+          { id: "search", key: "s", label: "earch", onPress: focusSearch },
+          { id: "refresh", key: "r", label: "efresh", onPress: () => load(tab) },
+          { id: "open", key: "o", label: "pen", onPress: openSelected, disabled: !selected?.url },
+        ],
+  }), [error, detailOpen, focusSearch, load, openSelected, selected?.url, status, searchQuery, tab, updatedAgo]);
+
+  const tabs = (
+    <Box height={1} flexShrink={0} overflow="hidden">
+      <Tabs
+        tabs={TABS}
+        activeValue={tab}
+        onSelect={(value) => {
+          setTab(value as PollTabId);
+          setDetailOpen(false);
+          setSearchQuery("");
+        }}
+        compact
+        variant="bare"
+        focused={focused && !detailOpen && !searchFocused}
+      />
+    </Box>
+  );
+
+  const searchBar = (
+    <InputSearchBar
+      value={searchQuery}
+      focused={focused && !detailOpen}
+      active={searchFocused}
+      width={width}
+      focusToken={searchFocusToken}
+      inputRef={searchInputRef}
+      placeholder="subject or pollster"
+      debounceMs={80}
+      onFocus={focusSearch}
+      onBlur={blurSearch}
+      onNavigateDown={blurSearch}
+      onQueryChange={setSearchQuery}
+    />
+  );
+
+  if (status === "loading" && allRows.length === 0) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {tabs}
+        <Box flexGrow={1} justifyContent="center" alignItems="center">
+          <Spinner label="Loading polls..." />
+        </Box>
+      </Box>
+    );
+  }
+
+  if (error && allRows.length === 0) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {tabs}
+        <Box padding={1}>
+          <EmptyState title="Polls unavailable." message={error} hint="Press r to retry." />
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      {tabs}
+      <DataTableStackView<PollRow, PollColumn>
+        focused={focused && !searchFocused}
+        detailOpen={detailOpen && !!selected}
+        onBack={() => setDetailOpen(false)}
+        detailContent={
+          selected ? (
+            <PollDetail
+              poll={selected}
+              allRows={allRows}
+              width={width}
+              height={Math.max(height - 1, 1)}
+              detailTab={detailTab}
+              onDetailTabChange={setDetailTab}
+            />
+          ) : null
+        }
+        detailTitle={selected?.subject}
+        rootBefore={searchBar}
+        onRootKeyDown={handleRootKeyDown}
+        onDetailKeyDown={handleDetailKeyDown}
+        selection={{
+          kind: "id",
+          selectedId,
+          getId: (row) => row.id,
+          onChange: (id) => setSelectedId(id),
+        }}
+        onActivate={() => {
+          blurSearch();
+          setDetailOpen(true);
+        }}
+        rootWidth={width}
+        rootHeight={Math.max(1, height - 1)}
+        columns={columns}
+        items={rows}
+        sortColumnId={sortPreference.columnId}
+        sortDirection={sortPreference.direction}
+        onHeaderClick={(columnId) => {
+          const next = columnId as PollSortColumnId;
+          setSortPreference((current) => nextStackSortPreference(
+            current,
+            next,
+            next === "subject" || next === "pollster" || next === "pop" ? "asc" : "desc",
+          ));
+        }}
+        getItemKey={(row) => row.id}
+        renderCell={renderCell}
+        emptyStateTitle={searchQuery.trim() ? "No matching polls." : "No polls in this category."}
+        emptyStateHint={searchQuery.trim() ? "Clear search or press r to refresh." : "Press r to refresh."}
+      />
+    </Box>
+  );
+}

--- a/src/plugins/builtin/polls/types.ts
+++ b/src/plugins/builtin/polls/types.ts
@@ -1,0 +1,77 @@
+export const POLLS_PLUGIN_ID = "polls";
+export const POLLS_PANE_ID = "polls";
+
+export interface VoteHubPollAnswer {
+  choice: string;
+  pct: number;
+}
+
+export interface VoteHubPoll {
+  id: string;
+  poll_type: string;
+  sample_size: number | string | null;
+  population: string | null;
+  url: string | null;
+  created_at: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  pollster: string;
+  answers: VoteHubPollAnswer[];
+  seat_name: string | null;
+  sponsors: string[];
+  internal: boolean | null;
+  partisan: string | null;
+  subject: string;
+}
+
+export interface PollRow {
+  id: string;
+  subject: string;
+  pollType: string;
+  pollTypeLabel: string;
+  pollster: string;
+  population: string;
+  sampleSize: number | null;
+  marginOfError: number | null;
+  startDate: string | null;
+  endDate: string | null;
+  result: string;
+  lead: number | null;
+  leadChoice: string | null;
+  url: string | null;
+  sponsors: string[];
+  partisan: string | null;
+  internal: boolean;
+  answers: VoteHubPollAnswer[];
+}
+
+export type PollTabId =
+  | "approval"
+  | "favorability"
+  | "generic-ballot"
+  | "us-senator"
+  | "governor"
+  | "us-representative";
+
+export type PollDetailTab = "overview" | "trend" | "pollsters";
+
+export interface PollTrendPoint {
+  date: string;
+  value: number;
+  pollster: string;
+}
+
+export interface PollsterAverage {
+  pollster: string;
+  count: number;
+  avgPct: number;
+  totalSample: number;
+  lastDate: string | null;
+}
+
+export interface PollAverageSummary {
+  choice: string;
+  avgPct: number;
+  pollCount: number;
+  totalSample: number;
+}

--- a/src/plugins/catalog-backend.ts
+++ b/src/plugins/catalog-backend.ts
@@ -20,6 +20,7 @@ import { publicPlugin } from "./broker-sync/public";
 import { robinhoodPlugin } from "./broker-sync/robinhood";
 import { simpleFinPlugin } from "./broker-sync/simplefin";
 import { predictionMarketsBackendPlugin } from "./prediction-markets/backend-plugin";
+import { pollsPlugin } from "./builtin/polls";
 
 const desktopBackendPlugins: GloomPlugin[] = [
   yahooPlugin,
@@ -37,6 +38,7 @@ const desktopBackendPlugins: GloomPlugin[] = [
   notesPlugin,
   aiPlugin,
   predictionMarketsBackendPlugin,
+  pollsPlugin,
   marketOverviewPlugin,
   macroPlugin,
   alertsPlugin,

--- a/src/plugins/catalog-ui.ts
+++ b/src/plugins/catalog-ui.ts
@@ -9,6 +9,7 @@ import { publicPlugin } from "./broker-sync/public";
 import { robinhoodPlugin } from "./broker-sync/robinhood";
 import { simpleFinPlugin } from "./broker-sync/simplefin";
 import { predictionMarketsPlugin } from "./prediction-markets";
+import { pollsPlugin } from "./builtin/polls";
 import { alertsPlugin } from "./builtin/alerts";
 import {
   applicationPlugin,
@@ -34,6 +35,7 @@ export const uiBuiltinPlugins: GloomPlugin[] = [
   notesPlugin,
   aiPlugin,
   predictionMarketsPlugin,
+  pollsPlugin,
   marketOverviewPlugin,
   macroPlugin,
   alertsPlugin,


### PR DESCRIPTION
Pane-only extraction: browse VoteHub political polls (approval, favorability, generic ballot, Senate, governor, House) with trend charts, pollster breakdowns, search, and source links via the POLL command.

Self-contained under src/plugins/builtin/polls plus catalog registration. Connection-source instrumentation and the G POLY: chart-series integration are intentionally omitted; small shared helpers are inlined in hooks.ts.