### PR TITLE
Stop replaying onboarding for existing installs

### DIFF
--- a/src/data/config/store/index.test.ts
+++ b/src/data/config/store/index.test.ts
@@ -337,7 +337,7 @@ describe("loadConfig", () => {
       detached: [],
     };
     await writeConfigJson(dataDir, createSavedConfig({
-      configVersion: CURRENT_CONFIG_VERSION - 1,
+      configVersion: 19,
       layout: legacyLayout,
       layouts: [{
         name: "Graphs",
@@ -436,7 +436,7 @@ describe("loadConfig", () => {
       detached: [],
     };
     await writeConfigJson(dataDir, createSavedConfig({
-      configVersion: CURRENT_CONFIG_VERSION - 1,
+      configVersion: 19,
       layout: legacyLayout,
       layouts: [{ name: "Price", layout: legacyLayout }],
       activeLayoutIndex: 0,
@@ -473,7 +473,7 @@ describe("loadConfig", () => {
       detached: undefined,
     };
     await writeConfigJson(dataDir, createSavedConfig({
-      configVersion: CURRENT_CONFIG_VERSION - 1,
+      configVersion: 19,
       layout: layoutWithoutDetached,
       layouts: [{ name: "Default", layout: layoutWithoutDetached }],
     }));
@@ -519,6 +519,19 @@ describe("loadConfig", () => {
 
     const invalidConfig = await loadConfig(invalidDir);
     expect(invalidConfig.onboardingProgress).toBeUndefined();
+  });
+
+  test("marks pre-onboarding configs complete so existing users skip the wizard", async () => {
+    const dataDir = await createTempConfigDir();
+    await writeConfigJson(dataDir, createSavedConfig({
+      configVersion: 20,
+      onboardingProgress: { version: 1, stage: "ready" },
+    }));
+
+    const config = await loadConfig(dataDir);
+
+    expect(config.onboardingComplete).toBe(true);
+    expect(config.onboardingProgress).toBeUndefined();
   });
 
   test("fills in missing chart preferences for older configs", async () => {
@@ -608,7 +621,7 @@ describe("loadConfig", () => {
   test("migrates disabled built-in modules to their owning plugin ids", async () => {
     const dataDir = await createTempConfigDir();
     await writeConfigJson(dataDir, createSavedConfig({
-      configVersion: CURRENT_CONFIG_VERSION - 1,
+      configVersion: 19,
       disabledPlugins: [
         "options",
         "sec",
@@ -647,7 +660,7 @@ describe("loadConfig", () => {
   test("migrates grouped built-in plugin config keys", async () => {
     const dataDir = await createTempConfigDir();
     await writeConfigJson(dataDir, createSavedConfig({
-      configVersion: CURRENT_CONFIG_VERSION - 1,
+      configVersion: 19,
       pluginConfig: {
         options: {
           selectedExpiration: "2026-06-19",
@@ -688,7 +701,7 @@ describe("loadConfig", () => {
   test("does not repeat the legacy Cloud-to-Macro disable migration", async () => {
     const dataDir = await createTempConfigDir();
     await writeConfigJson(dataDir, createSavedConfig({
-      configVersion: CURRENT_CONFIG_VERSION - 1,
+      configVersion: 19,
       disabledPlugins: ["gloomberb-cloud"],
     }));
 
@@ -762,7 +775,7 @@ describe("loadConfig", () => {
   test("migrates legacy saved pane tab IDs and preserves focus metadata", async () => {
     const dataDir = await createTempConfigDir();
     await writeConfigJson(dataDir, createSavedConfig({
-      configVersion: CURRENT_CONFIG_VERSION - 1,
+      configVersion: 19,
       layouts: [{
         name: "Chart",
         layout: DEFAULT_LAYOUT,

--- a/src/data/config/store/migrations.ts
+++ b/src/data/config/store/migrations.ts
@@ -23,6 +23,7 @@ const CLOUD_DEFAULT_CONFIG_VERSION = 13;
 const CLOUD_MACRO_SPLIT_CONFIG_VERSION = 15;
 const PORTFOLIO_DEFAULT_COLUMNS_CONFIG_VERSION = 17;
 const BUILTIN_OWNERSHIP_AND_CHART_CONFIG_VERSION = 20;
+const ONBOARDING_BACKFILL_CONFIG_VERSION = 21;
 
 const LEGACY_MAIN_PORTFOLIO_COLUMN_IDS = DEFAULT_COLUMNS.map((column) => column.id);
 const PRE_SPARKLINE_PORTFOLIO_COLUMN_IDS = [
@@ -79,6 +80,11 @@ const CONFIG_MIGRATIONS: readonly ConfigMigration[] = [
     toVersion: BUILTIN_OWNERSHIP_AND_CHART_CONFIG_VERSION,
     migrate: migrateBuiltinOwnershipAndChartState,
   },
+  {
+    name: "backfill-onboarding-complete",
+    toVersion: ONBOARDING_BACKFILL_CONFIG_VERSION,
+    migrate: migrateOnboardingComplete,
+  },
 ];
 
 export function migrateSavedConfig(saved: Record<string, unknown>, dataDir: string): ConfigMigrationResult {
@@ -121,6 +127,16 @@ function pluginConfigMap(value: unknown): Record<string, Record<string, unknown>
       { ...(state as Record<string, unknown>) },
     ]),
   );
+}
+
+// Any config on disk predates this version, so the user already had a workspace and
+// should never be sent back through the wizard, whatever half-finished state it holds.
+function migrateOnboardingComplete(saved: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...saved,
+    onboardingComplete: true,
+    onboardingProgress: undefined,
+  };
 }
 
 function migrateCloudDefault(saved: Record<string, unknown>): Record<string, unknown> {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,7 +1,7 @@
 import type { Portfolio, Watchlist } from "./ticker";
 import type { LanguagePreference } from "../i18n/languages";
 
-export const CURRENT_CONFIG_VERSION = 20;
+export const CURRENT_CONFIG_VERSION = 21;
 
 type ChartRendererPreference = "auto" | "kitty" | "braille";
 


### PR DESCRIPTION
Closes #540.

## Root cause
The startup gate in `src/app.tsx` shows onboarding when `onboardingComplete !== true` **or** `onboardingProgress` exists, and there is no migration that backfills completion. Any install that predates the wizard (or that ever saved wizard progress, since `withOnboardingProgress` writes `onboardingComplete: false`) re-opens onboarding on every launch. Cloud sync cannot rescue it either, because sync is disabled while the wizard is showing.

This matches the debug report on the issue; verified each claim against the code.

## Fix
Config migration `backfill-onboarding-complete` (`CURRENT_CONFIG_VERSION` 20 -> 21): any config already on disk was written by an earlier build, so its owner already has a workspace and is marked complete with stale progress dropped. Fresh installs have no config file, so they still get the wizard.

## Verification
- Terminal app, isolated HOME: legacy config (v20, no `onboardingComplete`, stale `ready` progress) now boots straight to the workspace and persists v21 + `onboardingComplete: true`.
- Desktop (Electrobun) dev build, isolated HOME with the same legacy config: opens straight to the workspace, no wizard.
- Fresh install still shows the wizard, and F10 skip persists completion.
- `bun test` (2 unrelated flakes that pass in isolation), `bun run typecheck` clean.