### PR TITLE
Add ART command-bar lookup against the loaded news pool

### DIFF
--- a/src/components/command-bar/routes/root/article-results.test.ts
+++ b/src/components/command-bar/routes/root/article-results.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import type { NewsArticle } from "../../../../news/types";
+import { buildArticleSearchResultItems } from "./article-results";
+import { isArticleLookupShortcut } from "./results";
+
+function article(title: string, source: string): NewsArticle {
+  return {
+    id: title,
+    title,
+    source,
+    url: `https://example.com/${title}`,
+    publishedAt: new Date("2026-08-14T12:00:00Z"),
+    topic: "general",
+    topics: [],
+    sectors: [],
+    categories: [],
+    tickers: [],
+    scores: { importance: 50, urgency: 0, marketImpact: 0, novelty: 0, confidence: 0 },
+    isBreaking: false,
+    isDeveloping: false,
+    importance: 50,
+  };
+}
+
+describe("buildArticleSearchResultItems", () => {
+  test("offers the matching article to open", () => {
+    const opened: string[] = [];
+    const items = buildArticleSearchResultItems({
+      articles: [
+        article("Iran Threatens to Close the Strait of Hormuz", "Reuters"),
+        article("Fed holds rates", "CNBC Top News"),
+      ],
+      query: "article on the strait",
+      phase: "ready",
+      onOpen: (item) => {
+        opened.push(item.id);
+      },
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.label).toContain("Hormuz");
+    expect(items[0]?.detail).toBe("Reuters");
+    items[0]?.action();
+    expect(opened).toEqual(["Iran Threatens to Close the Strait of Hormuz"]);
+  });
+
+  test("shows a lookup row while subscribed feeds are still loading", () => {
+    const items = buildArticleSearchResultItems({
+      articles: [],
+      query: "article on the strait",
+      phase: "loading",
+      onOpen: () => {},
+    });
+    expect(items.map((item) => item.label)).toEqual(["Looking up articles…"]);
+  });
+
+  test("returns local matches without waiting on a still-loading lookup", () => {
+    const items = buildArticleSearchResultItems({
+      articles: [article("Trump administration pauses talks", "AP")],
+      query: "ART trum",
+      phase: "loading",
+      onOpen: () => {},
+    });
+    expect(items.map((item) => item.label)).toEqual(["Trump administration pauses talks"]);
+  });
+});
+
+describe("isArticleLookupShortcut", () => {
+  test("treats the ART plugin command as an article lookup", () => {
+    expect(isArticleLookupShortcut({ kind: "none" })).toBe(false);
+    expect(isArticleLookupShortcut({
+      kind: "partial",
+      source: "plugin-command",
+      prefix: "ART",
+      label: "Open Article",
+      description: "",
+      argKind: "text",
+      argText: "hormuz",
+      completionQuery: null,
+      command: { id: "open-news-article", label: "Open Article" } as never,
+    })).toBe(true);
+  });
+});

--- a/src/components/command-bar/routes/root/article-results.ts
+++ b/src/components/command-bar/routes/root/article-results.ts
@@ -1,0 +1,55 @@
+import type { NewsArticle } from "../../../../news/types";
+import {
+  looksLikeArticleQuery,
+  searchNewsArticles,
+} from "../../../../plugins/builtin/news/wire/article-search";
+import type { ResultItem } from "../../list/model";
+
+/**
+ * Builds command-bar rows for an article-lookup (`ART`) query by matching the
+ * typed text against the loaded news feed.
+ */
+export function buildArticleSearchResultItems(options: {
+  articles: readonly NewsArticle[];
+  query: string;
+  phase?: "idle" | "loading" | "ready" | "refreshing" | "error";
+  onOpen: (article: NewsArticle) => void;
+}): ResultItem[] {
+  const query = options.query.trim();
+  if (!query || !looksLikeArticleQuery(query)) return [];
+
+  const matches = searchNewsArticles(options.articles, query);
+  const items = matches.map((article) => ({
+    id: `article:${article.id}`,
+    label: article.title,
+    detail: article.source,
+    category: "Articles",
+    kind: "action" as const,
+    right: "ART",
+    searchText: [
+      article.title,
+      article.source,
+      article.summary ?? "",
+      ...article.topics,
+      ...article.categories,
+      "article",
+      "news",
+      "press",
+    ].join(" "),
+    action: () => options.onOpen(article),
+  }));
+
+  if (items.length > 0) return items;
+  if (options.phase === "loading" || options.phase === "idle" || options.phase === "refreshing") {
+    return [{
+      id: "article:loading",
+      label: "Looking up articles…",
+      detail: "",
+      category: "Articles",
+      kind: "info",
+      defaultSelectable: false,
+      action: () => {},
+    }];
+  }
+  return [];
+}

--- a/src/components/command-bar/routes/root/results.ts
+++ b/src/components/command-bar/routes/root/results.ts
@@ -21,6 +21,13 @@ import { buildRootShortcutItem } from "./shortcut-items";
 
 type RootShortcutIntent = ReturnType<typeof parseRootShortcutIntent>;
 
+/** The ART plugin command claims the prefix, so article rows must still be shown. */
+export function isArticleLookupShortcut(intent: RootShortcutIntent): boolean {
+  return intent.kind !== "none"
+    && intent.source === "plugin-command"
+    && intent.command.id === "open-news-article";
+}
+
 interface PaneTemplateItemOptions {
   category?: string;
   createOptions?: PaneTemplateCreateOptions;
@@ -67,6 +74,7 @@ export interface RootResultModelOptions {
   pluginCommandResultItems: (command: CommandDef, shortcutArg: string) => ResultItem[];
   rootQuery: string;
   rootShortcutIntent: RootShortcutIntent;
+  articleResultItems?: ResultItem[];
   runDirectCommand: (command: Command, arg: string) => void;
   runSecurityDescriptionShortcut: (query?: string) => void | Promise<void>;
   state: AppState;
@@ -108,6 +116,7 @@ export function buildRootResultModel(options: RootResultModelOptions): RootResul
     pluginCommandResultItems,
     rootQuery,
     rootShortcutIntent,
+    articleResultItems = [],
     runDirectCommand,
     runSecurityDescriptionShortcut,
     state,
@@ -168,8 +177,12 @@ export function buildRootResultModel(options: RootResultModelOptions): RootResul
     && rootShortcutIntent.source === "plugin-command"
     && shortcutItem
   ) {
-    const dynamicItems = pluginCommandResultItems(rootShortcutIntent.command, rootShortcutIntent.argText);
-    items.push(...(dynamicItems.length > 0 ? dynamicItems : [shortcutItem]));
+    if (isArticleLookupShortcut(rootShortcutIntent)) {
+      items.push(shortcutItem);
+    } else {
+      const dynamicItems = pluginCommandResultItems(rootShortcutIntent.command, rootShortcutIntent.argText);
+      items.push(...(dynamicItems.length > 0 ? dynamicItems : [shortcutItem]));
+    }
   } else if (match && match.command.id === "plugins") {
     items.push(...buildPluginItems(match.arg));
   } else if (match && match.command.id === "layout") {
@@ -225,6 +238,10 @@ export function buildRootResultModel(options: RootResultModelOptions): RootResul
     ];
     const matchedItems = fuzzyFilter(allItems, rootQuery, (item) => `${item.label} ${item.searchText || ""} ${item.detail} ${item.right || ""}`);
     items.push(...matchedItems);
+  }
+
+  if (rootShortcutIntent.kind === "none" || isArticleLookupShortcut(rootShortcutIntent)) {
+    items.push(...articleResultItems);
   }
 
   // Built from the local matches, then moved above them: the AI answers the

--- a/src/components/command-bar/routes/root/runtime.ts
+++ b/src/components/command-bar/routes/root/runtime.ts
@@ -63,6 +63,7 @@ interface UseCommandBarRootRuntimeOptions {
   }): ResultItem[];
   pluginCommandItems(): ResultItem[];
   pluginCommandResultItems(command: CommandDef, shortcutArg: string): ResultItem[];
+  articleResultItems?: ResultItem[];
   readTickerSearchCache(
     query: string,
     brokerId?: string | null,
@@ -114,6 +115,7 @@ export function useCommandBarRootRuntime({
   paneShortcutItems,
   pluginCommandItems,
   pluginCommandResultItems,
+  articleResultItems = [],
   readTickerSearchCache,
   rootModeKind,
   rootQuery,
@@ -187,6 +189,7 @@ export function useCommandBarRootRuntime({
     pluginCommandResultItems,
     rootQuery,
     rootShortcutIntent,
+    articleResultItems,
     runDirectCommand,
     runSecurityDescriptionShortcut,
     state,
@@ -215,6 +218,7 @@ export function useCommandBarRootRuntime({
     pluginCommandResultItems,
     rootQuery,
     rootShortcutIntent,
+    articleResultItems,
     runDirectCommand,
     runSecurityDescriptionShortcut,
     state,

--- a/src/components/command-bar/surface/index.tsx
+++ b/src/components/command-bar/surface/index.tsx
@@ -7,6 +7,14 @@ import { usePlanAccess } from "../../../plugins/builtin/shared/plan-access";
 import { buildAssistCommandInventory } from "../assist/inventory";
 import { useCommandBarAssist } from "../assist/runtime";
 import { shouldAutoAskAssist, type AssistRowHandlers } from "../assist/model";
+import { useNewsArticles } from "../../../news/hooks";
+import {
+  ARTICLE_SEARCH_QUERY,
+  cachedNewsArticles,
+  looksLikeArticleQuery,
+} from "../../../plugins/builtin/news/wire/article-search";
+import { buildArticleSearchResultItems } from "../routes/root/article-results";
+import { openUrl } from "../../ui/external-link";
 import { useRouteListState } from "../routing/list-state";
 import { useCommandBarRootRuntime } from "../routes/root/runtime";
 import { parseRootShortcutIntent } from "../routes/root/shortcuts";
@@ -247,6 +255,32 @@ export function CommandBar({
     ),
   }), [askAssistNow, assistActive, assistAutoAsk, assistState, planAccess.emailVerified, startAssistSignUp]);
 
+  const newsState = useNewsArticles(looksLikeArticleQuery(rootQuery) ? ARTICLE_SEARCH_QUERY : null);
+  const articleResultItems = useMemo(() => {
+    const cached = cachedNewsArticles();
+    const seen = new Set<string>();
+    const articles = [];
+    for (const article of [...cached, ...newsState.articles]) {
+      if (seen.has(article.id)) continue;
+      seen.add(article.id);
+      articles.push(article);
+    }
+    const localReady = cached.length > 0
+      || newsState.phase === "ready"
+      || newsState.phase === "refreshing"
+      || newsState.phase === "error";
+    const stillLoading = !localReady && (newsState.phase === "idle" || newsState.phase === "loading");
+    return buildArticleSearchResultItems({
+      articles,
+      query: rootQuery,
+      phase: stillLoading ? "loading" : "ready",
+      onOpen: (article) => {
+        openUrl(article.url);
+        closeAll({ revertThemePreview: false });
+      },
+    });
+  }, [closeAll, newsState.articles, newsState.phase, rootQuery]);
+
   const {
     activeMatch,
     orderedRootResults,
@@ -283,6 +317,7 @@ export function CommandBar({
     paneShortcutItems,
     pluginCommandItems,
     pluginCommandResultItems,
+    articleResultItems,
     readTickerSearchCache,
     rootModeKind: rootModeInfo.kind,
     rootQuery,

--- a/src/news/hooks.ts
+++ b/src/news/hooks.ts
@@ -8,6 +8,10 @@ export function setSharedNewsService(service: NewsService | null): void {
   sharedService = service;
 }
 
+export function getSharedNewsService(): NewsService | null {
+  return sharedService;
+}
+
 const IDLE_NEWS_QUERY_STATE: NewsQueryState = {
   phase: "idle",
   articles: [],

--- a/src/plugins/builtin/news/wire/article-search.test.ts
+++ b/src/plugins/builtin/news/wire/article-search.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import type { NewsArticle } from "../../../../news/types";
+import {
+  looksLikeArticleQuery,
+  searchNewsArticles,
+  tokenizeArticleQuery,
+} from "./article-search";
+
+function article(overrides: Partial<NewsArticle> & Pick<NewsArticle, "id" | "title" | "source">): NewsArticle {
+  return {
+    url: `https://example.com/${overrides.id}`,
+    publishedAt: new Date("2026-08-14T12:00:00Z"),
+    topic: "general",
+    topics: [],
+    sectors: [],
+    categories: [],
+    tickers: [],
+    scores: { importance: 50, urgency: 0, marketImpact: 0, novelty: 0, confidence: 0 },
+    isBreaking: false,
+    isDeveloping: false,
+    importance: 50,
+    ...overrides,
+  };
+}
+
+const hormuz = article({
+  id: "hormuz",
+  title: "Iran Threatens to Close the Strait of Hormuz",
+  source: "Reuters",
+  summary: "Shipping risk rises as Tehran warns it may shut the strait.",
+  publishedAt: new Date("2026-08-14T18:00:00Z"),
+});
+
+const other = article({
+  id: "fed",
+  title: "Fed holds rates as inflation cools",
+  source: "CNBC Top News",
+  publishedAt: new Date("2026-08-13T12:00:00Z"),
+});
+
+describe("looksLikeArticleQuery", () => {
+  test("treats article, news, and ART lookups as article searches", () => {
+    expect(looksLikeArticleQuery("article on the strait")).toBe(true);
+    expect(looksLikeArticleQuery("ART hormuz")).toBe(true);
+    expect(looksLikeArticleQuery("open press story")).toBe(true);
+    expect(looksLikeArticleQuery("ADI")).toBe(false);
+    expect(looksLikeArticleQuery("nvda")).toBe(false);
+  });
+});
+
+describe("searchNewsArticles", () => {
+  test("matches headlines after dropping filler and intent words", () => {
+    expect(tokenizeArticleQuery("article on the strait of hormuz")).toEqual(["strait", "hormuz"]);
+    const matches = searchNewsArticles([hormuz, other], "article on the strait of hormuz");
+    expect(matches.map((item) => item.id)).toEqual(["hormuz"]);
+  });
+
+  test("returns most recent articles when the query is only an intent word", () => {
+    const matches = searchNewsArticles([other, hormuz], "article");
+    expect(matches.map((item) => item.id)).toEqual(["hormuz", "fed"]);
+  });
+
+  test("strips the ART command prefix so local headlines match immediately", () => {
+    const trump = article({
+      id: "trump",
+      title: "Trump administration pauses contentious trade talks",
+      source: "AP",
+    });
+    expect(tokenizeArticleQuery("art trum")).toEqual(["trum"]);
+    expect(searchNewsArticles([trump, other], "ART trum").map((item) => item.id)).toEqual(["trump"]);
+  });
+});

--- a/src/plugins/builtin/news/wire/article-search.ts
+++ b/src/plugins/builtin/news/wire/article-search.ts
@@ -1,0 +1,140 @@
+import type { NewsArticle, NewsQuery } from "../../../../news/types";
+import { getSharedNewsService } from "../../../../news/hooks";
+
+const ARTICLE_SEARCH_LIMIT = 8;
+
+const STOPWORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "on",
+  "of",
+  "in",
+  "to",
+  "for",
+  "and",
+  "or",
+  "from",
+  "with",
+  "about",
+  "by",
+  "at",
+  "as",
+  "is",
+  "are",
+  "was",
+  "be",
+]);
+
+const INTENT_WORDS = new Set([
+  "article",
+  "articles",
+  "news",
+  "headline",
+  "headlines",
+  "story",
+  "stories",
+  "rss",
+  "feed",
+  "feeds",
+  "press",
+]);
+
+const COMMAND_WORDS = new Set([
+  "open",
+  "read",
+  "show",
+  "find",
+  "search",
+  "please",
+  "me",
+  "latest",
+  "recent",
+  "lookup",
+  "look",
+  "up",
+]);
+
+/** Pulls the freshest slice of the global feed to search over. */
+export const ARTICLE_SEARCH_QUERY: NewsQuery = { feed: "latest", limit: 200 };
+
+export function tokenizeArticleQuery(query: string): string[] {
+  // `ART trump` is the command prefix plus a topic — "art" is not a search term.
+  const withoutArtPrefix = query.replace(/^\s*art\b/i, " ");
+  return withoutArtPrefix
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => (
+      token.length >= 2
+      && !STOPWORDS.has(token)
+      && !INTENT_WORDS.has(token)
+      && !COMMAND_WORDS.has(token)
+    ));
+}
+
+export function looksLikeArticleQuery(query: string): boolean {
+  const tokens = query.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  if (tokens.some((token) => INTENT_WORDS.has(token))) return true;
+  return /^\s*art\b/i.test(query);
+}
+
+export function scoreArticleMatch(article: NewsArticle, tokens: readonly string[]): number {
+  if (tokens.length === 0) return 0;
+  const title = article.title.toLowerCase();
+  const source = article.source.toLowerCase();
+  const haystack = [
+    title,
+    source,
+    article.summary ?? "",
+    ...article.topics,
+    ...article.categories,
+    ...article.tickers,
+  ].join(" ").toLowerCase();
+
+  let score = 0;
+  for (const token of tokens) {
+    if (title.includes(token)) score += 10;
+    else if (source.includes(token)) score += 6;
+    else if (haystack.includes(token)) score += 3;
+    else return 0;
+  }
+  return score;
+}
+
+export function searchNewsArticles(
+  articles: readonly NewsArticle[],
+  query: string,
+  limit = ARTICLE_SEARCH_LIMIT,
+): NewsArticle[] {
+  const tokens = tokenizeArticleQuery(query);
+  if (tokens.length === 0) {
+    return [...articles]
+      .sort((left, right) => right.publishedAt.getTime() - left.publishedAt.getTime())
+      .slice(0, limit);
+  }
+
+  return articles
+    .map((article) => ({ article, score: scoreArticleMatch(article, tokens) }))
+    .filter((entry) => entry.score > 0)
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score;
+      return right.article.publishedAt.getTime() - left.article.publishedAt.getTime();
+    })
+    .slice(0, limit)
+    .map((entry) => entry.article);
+}
+
+/** Headlines already sitting in the shared news pool (firehose/RSS/breaking). */
+export function cachedNewsArticles(): NewsArticle[] {
+  const service = getSharedNewsService();
+  if (!service) return [];
+  const pooled = service.getFirehose(undefined, 500);
+  if (pooled.length > 0) return pooled;
+  return service.getQueryState(ARTICLE_SEARCH_QUERY).articles;
+}
+
+export async function loadNewsArticles(): Promise<NewsArticle[]> {
+  const service = getSharedNewsService();
+  if (!service) return [];
+  return (await service.load(ARTICLE_SEARCH_QUERY)).articles;
+}

--- a/src/plugins/builtin/news/wire/index.tsx
+++ b/src/plugins/builtin/news/wire/index.tsx
@@ -17,6 +17,12 @@ import { NewsPresetPane } from "./news/preset-pane";
 import { NEWS_QUERY_PRESETS } from "./news/query-presets";
 import type { NewsColumnId, NewsSortPreference } from "./news/table";
 import { createRssNewsCapability } from "./rss/source";
+import { openUrl } from "../../../../components/ui/external-link";
+import {
+  cachedNewsArticles,
+  loadNewsArticles,
+  searchNewsArticles,
+} from "./article-search";
 
 interface NewsPresetPaneConfig {
   paneKey: string;
@@ -98,6 +104,37 @@ export const newsWireModule: PluginModule = {
       { persistence: ctx.persistence },
     );
     ctx.registerCapability(source);
+
+    ctx.registerCommand({
+      id: "open-news-article",
+      label: "Open Article",
+      description: "Search loaded news headlines by topic, e.g. ART hormuz.",
+      keywords: ["article", "news", "rss", "headline", "story", "open"],
+      category: "navigation",
+      shortcut: "ART",
+      shortcutArg: {
+        placeholder: "headline or topic",
+        kind: "text",
+        parse: (arg) => ({ query: arg.trim() }),
+      },
+      async execute(values) {
+        const query = values?.query ?? values?.shortcut ?? "";
+        const articles = cachedNewsArticles().length > 0
+          ? cachedNewsArticles()
+          : await loadNewsArticles();
+        const match = searchNewsArticles(articles, query)[0];
+        if (!match) {
+          ctx.notify({
+            body: query.trim()
+              ? `No article matched "${query.trim()}".`
+              : "No articles loaded yet.",
+            type: "error",
+          });
+          return;
+        }
+        openUrl(match.url);
+      },
+    });
 
     ctx.registerCommand({
       id: "add-news-feed",


### PR DESCRIPTION
## Summary
- Adds an `ART` command-bar lookup that searches headlines already sitting in the shared news service (RSS / news feed / breaking).
- The `ART` prefix is stripped so `ART trum` matches Trump headlines immediately instead of treating `art` as a required token.
- Matching rows open the article URL in the browser. No Adjacent, hosted web, or in-app reader subsystem is included.

## Test plan
- [ ] `Ctrl+P` → `ART trum` after news/RSS has loaded — matching rows tagged `ART` appear without a long “Looking up articles…” stall.
- [ ] `article fed` / `news hormuz` also return article rows.
- [ ] Selecting a row opens the source URL.
- [ ] With no news loaded, the command bar does not hang.


Made with [Cursor](https://cursor.com)