### PR TITLE
Add truthful connection health monitoring

### DIFF
--- a/src/api-client/request.ts
+++ b/src/api-client/request.ts
@@ -1,6 +1,10 @@
 import { httpFetch } from "../utils/http-transport";
 import { withDeadline } from "../utils/async-deadline";
 import { ApiRequestError, parseApiErrorMessage } from "./errors";
+import {
+  connectionHealth,
+  GLOOM_CLOUD_HTTP_CONNECTION_ID,
+} from "../core/connection-health";
 
 const DEFAULT_API_URL = "https://api.gloom.sh";
 const DEFAULT_MARKET_REQUEST_TIMEOUT_MS = 10_000;
@@ -121,27 +125,33 @@ export class CloudApiRequestTransport {
     this.setSessionCookieHeader(headers);
     headers.set("Origin", this.baseUrl);
 
-    const res = await (this.fetchTransport ?? cloudApiFetchTransport)(`${this.baseUrl}${path}`, {
-      ...options,
-      headers,
-      credentials: "include",
-    });
-    throwIfRequestAborted(options?.signal);
-    this.extractSessionCookie(res);
-    const text = await res.text();
-    throwIfRequestAborted(options?.signal);
+    return connectionHealth.track(
+      GLOOM_CLOUD_HTTP_CONNECTION_ID,
+      `${options?.method ?? "GET"} ${path.split("?")[0]}`,
+      async () => {
+        const res = await (this.fetchTransport ?? cloudApiFetchTransport)(`${this.baseUrl}${path}`, {
+          ...options,
+          headers,
+          credentials: "include",
+        });
+        throwIfRequestAborted(options?.signal);
+        this.extractSessionCookie(res);
+        const text = await res.text();
+        throwIfRequestAborted(options?.signal);
 
-    if (!res.ok) {
-      const msg = parseApiErrorMessage(text);
-      throw new ApiRequestError(msg, res.status);
-    }
+        if (!res.ok) {
+          const msg = parseApiErrorMessage(text);
+          throw new ApiRequestError(msg, res.status);
+        }
 
-    if (!text) return undefined as T;
-    const parsed = JSON.parse(text) as T & { token?: string };
-    if (typeof parsed?.token === "string" && parsed.token.length > 0) {
-      this.websocketToken = parsed.token;
-    }
-    return parsed as T;
+        if (!text) return undefined as T;
+        const parsed = JSON.parse(text) as T & { token?: string };
+        if (typeof parsed?.token === "string" && parsed.token.length > 0) {
+          this.websocketToken = parsed.token;
+        }
+        return parsed as T;
+      },
+    );
   }
 
   private extractSessionCookie(res: CloudApiResponse): void {

--- a/src/api-client/socket-health.test.ts
+++ b/src/api-client/socket-health.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  ConnectionHealthRegistry,
+  GLOOM_CLOUD_SOCKET_CONNECTION_ID,
+} from "../core/connection-health";
+import { CloudApiSocket } from "./socket";
+
+const originalWebSocket = globalThis.WebSocket;
+
+afterEach(() => {
+  globalThis.WebSocket = originalWebSocket;
+});
+
+class TestWebSocket {
+  static readonly OPEN = 1;
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(readonly url: string) {}
+  send() {}
+  close() {}
+
+  open() {
+    this.readyState = TestWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  closeFromNetwork(code: number, reason: string) {
+    this.readyState = 3;
+    this.onclose?.({ code, reason });
+  }
+}
+
+describe("CloudApiSocket connection health", () => {
+  test("reports real connecting, open, and closed transitions", () => {
+    const sockets: TestWebSocket[] = [];
+    globalThis.WebSocket = class extends TestWebSocket {
+      constructor(url: string) {
+        super(url);
+        sockets.push(this);
+      }
+    } as unknown as typeof WebSocket;
+
+    const health = new ConnectionHealthRegistry();
+    health.registerSource({
+      id: GLOOM_CLOUD_SOCKET_CONNECTION_ID,
+      name: "Gloom Cloud Stream",
+      kind: "websocket",
+    });
+    const socket = new CloudApiSocket({
+      getBaseUrl: () => "https://api.gloom.sh",
+      getSocketAuthToken: () => null,
+      hasVerifiedUser: () => false,
+      isUsingWebSocketToken: () => false,
+      clearWebSocketTokenForFallback: () => false,
+      markCurrentUserUnverified: () => {},
+      updateCurrentUserFromSocket: () => {},
+    }, health);
+
+    socket.subscribeQuotes([{ symbol: "AAPL" }], () => {});
+    expect(health.getSnapshot().sources[0]).toMatchObject({ status: "connecting", socketState: "connecting" });
+
+    sockets[0]!.open();
+    expect(health.getSnapshot().sources[0]).toMatchObject({ status: "connected", socketState: "open" });
+
+    sockets[0]!.closeFromNetwork(1006, "network lost");
+    expect(health.getSnapshot().sources[0]).toMatchObject({
+      status: "disconnected",
+      socketState: "closed",
+      currentDetail: "network lost",
+    });
+    socket.dispose();
+  });
+});

--- a/src/api-client/socket-health.test.ts
+++ b/src/api-client/socket-health.test.ts
@@ -1,49 +1,46 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
   ConnectionHealthRegistry,
   GLOOM_CLOUD_SOCKET_CONNECTION_ID,
+  type ConnectionHealthStatus,
 } from "../core/connection-health";
 import { CloudApiSocket } from "./socket";
 
-const originalWebSocket = globalThis.WebSocket;
-
-afterEach(() => {
-  globalThis.WebSocket = originalWebSocket;
-});
-
-class TestWebSocket {
-  static readonly OPEN = 1;
-  readyState = 0;
-  onopen: (() => void) | null = null;
-  onmessage: ((event: { data: string }) => void) | null = null;
-  onclose: ((event: { code: number; reason: string }) => void) | null = null;
-  onerror: (() => void) | null = null;
-
-  constructor(readonly url: string) {}
-  send() {}
-  close() {}
-
-  open() {
-    this.readyState = TestWebSocket.OPEN;
-    this.onopen?.();
-  }
-
-  closeFromNetwork(code: number, reason: string) {
-    this.readyState = 3;
-    this.onclose?.({ code, reason });
-  }
+function waitForStatus(
+  health: ConnectionHealthRegistry,
+  status: ConnectionHealthStatus,
+): Promise<void> {
+  if (health.getSnapshot().sources[0]?.status === status) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      unsubscribe();
+      reject(new Error(`Timed out waiting for ${status}`));
+    }, 2_000);
+    const unsubscribe = health.subscribe(() => {
+      if (health.getSnapshot().sources[0]?.status !== status) return;
+      clearTimeout(timer);
+      unsubscribe();
+      resolve();
+    });
+  });
 }
 
 describe("CloudApiSocket connection health", () => {
-  test("reports real connecting, open, and closed transitions", () => {
-    const sockets: TestWebSocket[] = [];
-    globalThis.WebSocket = class extends TestWebSocket {
-      constructor(url: string) {
-        super(url);
-        sockets.push(this);
-      }
-    } as unknown as typeof WebSocket;
-
+  test("reports transitions from a real loopback websocket", async () => {
+    let peer: ServerWebSocket<unknown> | null = null;
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request, server) {
+        return server.upgrade(request) ? undefined : new Response("Upgrade required", { status: 426 });
+      },
+      websocket: {
+        open(socket) {
+          peer = socket;
+        },
+        message() {},
+      },
+    });
     const health = new ConnectionHealthRegistry();
     health.registerSource({
       id: GLOOM_CLOUD_SOCKET_CONNECTION_ID,
@@ -51,7 +48,7 @@ describe("CloudApiSocket connection health", () => {
       kind: "websocket",
     });
     const socket = new CloudApiSocket({
-      getBaseUrl: () => "https://api.gloom.sh",
+      getBaseUrl: () => `http://127.0.0.1:${server.port}`,
       getSocketAuthToken: () => null,
       hasVerifiedUser: () => false,
       isUsingWebSocketToken: () => false,
@@ -60,18 +57,23 @@ describe("CloudApiSocket connection health", () => {
       updateCurrentUserFromSocket: () => {},
     }, health);
 
-    socket.subscribeQuotes([{ symbol: "AAPL" }], () => {});
-    expect(health.getSnapshot().sources[0]).toMatchObject({ status: "connecting", socketState: "connecting" });
+    try {
+      socket.subscribeQuotes([{ symbol: "AAPL" }], () => {});
+      expect(health.getSnapshot().sources[0]).toMatchObject({
+        status: "connecting",
+        socketState: "connecting",
+      });
 
-    sockets[0]!.open();
-    expect(health.getSnapshot().sources[0]).toMatchObject({ status: "connected", socketState: "open" });
-
-    sockets[0]!.closeFromNetwork(1006, "network lost");
-    expect(health.getSnapshot().sources[0]).toMatchObject({
-      status: "disconnected",
-      socketState: "closed",
-      currentDetail: "network lost",
-    });
-    socket.dispose();
+      await waitForStatus(health, "connected");
+      peer!.close(1000, "network lost");
+      await waitForStatus(health, "disconnected");
+      expect(health.getSnapshot().sources[0]).toMatchObject({
+        socketState: "closed",
+        currentDetail: "network lost",
+      });
+    } finally {
+      socket.dispose();
+      void server.stop(true);
+    }
   });
 });

--- a/src/api-client/socket.ts
+++ b/src/api-client/socket.ts
@@ -14,6 +14,11 @@ import {
 import { debugLog } from "../utils/debug-log";
 import { canonicalExchange, normalizeSymbol } from "../utils/exchanges";
 import { mergeQuoteSubscriptionTargets } from "../market-data/quote-subscription-target";
+import {
+  connectionHealth,
+  GLOOM_CLOUD_SOCKET_CONNECTION_ID,
+  type ConnectionHealthRegistry,
+} from "../core/connection-health";
 
 const QUOTE_SUBSCRIPTION_FLUSH_MS = 25;
 const cloudApiLog = debugLog.createLogger("cloud-api");
@@ -80,7 +85,10 @@ export class CloudApiSocket {
   /** Latest fan-out payload, so a pane opened mid-stream does not wait for the next tick. */
   private readonly scannerSnapshots = new Map<ScannerKind, ScannerFeedEvent>();
 
-  constructor(private readonly delegate: CloudApiSocketDelegate) {}
+  constructor(
+    private readonly delegate: CloudApiSocketDelegate,
+    private readonly health: ConnectionHealthRegistry = connectionHealth,
+  ) {}
 
   syncAuthState(options: { reconnect?: boolean } = {}): void {
     if (!this.shouldKeepSocketOpen()) {
@@ -102,6 +110,7 @@ export class CloudApiSocket {
     this.ws = null;
     if (ws) {
       cloudApiLog.info("teardown websocket");
+      this.health.reportSocketState(GLOOM_CLOUD_SOCKET_CONNECTION_ID, "idle", "Socket closed locally");
     }
     try {
       ws?.close();
@@ -437,12 +446,24 @@ export class CloudApiSocket {
       quoteTargets: this.quoteTargets.size,
       channelTargets: this.channelListeners.size,
     });
-    const ws = new WebSocket(url);
+    this.health.reportSocketState(GLOOM_CLOUD_SOCKET_CONNECTION_ID, "connecting", this.getWebSocketBaseUrl());
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(url);
+    } catch (error) {
+      this.health.reportSocketState(
+        GLOOM_CLOUD_SOCKET_CONNECTION_ID,
+        "error",
+        error instanceof Error ? error.message : String(error),
+      );
+      throw error;
+    }
     this.ws = ws;
 
     ws.onopen = () => {
       if (this.ws !== ws) return;
       cloudApiLog.info("websocket open");
+      this.health.reportSocketState(GLOOM_CLOUD_SOCKET_CONNECTION_ID, "open", this.getWebSocketBaseUrl());
       this.reconnectDelayMs = 1000;
       this.flushSubscriptions();
     };
@@ -465,6 +486,11 @@ export class CloudApiSocket {
         tokenSource: usingWebSocketToken ? "websocket" : "session",
       });
       if (!activeSocket) return;
+      this.health.reportSocketState(
+        GLOOM_CLOUD_SOCKET_CONNECTION_ID,
+        "closed",
+        closeEvent?.reason || (closeEvent?.code ? `Closed (${closeEvent.code})` : "Socket closed"),
+      );
       if (usingWebSocketToken && this.delegate.clearWebSocketTokenForFallback()) {
         this.reconnectDelayMs = 1000;
         cloudApiLog.warn("cleared websocket token after socket close; falling back to session token");
@@ -474,7 +500,9 @@ export class CloudApiSocket {
     };
 
     ws.onerror = () => {
-      // reconnect is handled by onclose
+      if (this.ws !== ws) return;
+      this.health.reportSocketState(GLOOM_CLOUD_SOCKET_CONNECTION_ID, "error", "WebSocket error");
+      // Reconnect is handled by onclose.
     };
   }
 

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { CapabilityRegistry } from "./registry";
+import { ConnectionHealthRegistry } from "../core/connection-health";
 import type { CapabilitySchema, PluginCapability } from "./types";
 
 interface IncrementInput {
@@ -80,6 +81,33 @@ describe("CapabilityRegistry", () => {
 
     await expect(registry.invoke("plugin-service.test", "increment", { value: 1 }, { renderer: true }))
       .resolves.toBe(2);
+  });
+
+  test("reports invokable provider operations through the connection boundary", async () => {
+    let clock = 10;
+    const health = new ConnectionHealthRegistry({ clock: () => clock });
+    health.registerSource({ id: "asset-data.test", name: "Test", kind: "asset-data" });
+    const registry = new CapabilityRegistry({ connectionHealth: health });
+    registry.register("plugin-a", testCapability({
+      id: "asset-data.test",
+      kind: "asset-data",
+      operations: {
+        read: {
+          kind: "read",
+          handler: async () => {
+            clock = 16;
+            return "ok";
+          },
+        },
+      },
+    }));
+
+    await expect(registry.invoke("asset-data.test", "read", {})).resolves.toBe("ok");
+    expect(health.getSnapshot().sources[0]).toMatchObject({
+      status: "connected",
+      lastOperation: "read",
+      lastLatencyMs: 6,
+    });
   });
 
   test("emits renderer-safe manifests only when requested", () => {

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -110,6 +110,27 @@ describe("CapabilityRegistry", () => {
     });
   });
 
+  test("does not treat cached and static capability operations as network health", async () => {
+    const health = new ConnectionHealthRegistry();
+    health.registerSource({ id: "asset-data.test", name: "Test", kind: "asset-data" });
+    const registry = new CapabilityRegistry({ connectionHealth: health });
+    registry.register("plugin-a", testCapability({
+      id: "asset-data.test",
+      kind: "asset-data",
+      operations: Object.fromEntries([
+        "canProvide",
+        "getCachedFinancialsForTargets",
+        "getChartResolutionSupport",
+      ].map((id) => [id, { kind: "read", handler: () => true }])),
+    }));
+
+    await registry.invoke("asset-data.test", "canProvide", {});
+    await registry.invoke("asset-data.test", "getCachedFinancialsForTargets", {});
+    await registry.invoke("asset-data.test", "getChartResolutionSupport", {});
+
+    expect(health.getSnapshot().sources[0]).toMatchObject({ status: "idle", lastRequestAt: null });
+  });
+
   test("emits renderer-safe manifests only when requested", () => {
     const registry = new CapabilityRegistry();
     registry.register("plugin-a", testCapability());

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -12,7 +12,14 @@ interface SubscriptionEntry {
   dispose: () => void;
 }
 
-const LOCAL_READ_OPERATIONS = new Set(["getCachedFinancialsForTargets", "getCachedNews"]);
+const LOCAL_READ_OPERATIONS = new Set([
+  "canProvide",
+  "supports",
+  "getCachedFinancialsForTargets",
+  "getCachedNews",
+  "getChartResolutionSupport",
+  "getChartResolutionCapabilities",
+]);
 
 export class CapabilityRegistry {
   private readonly capabilities = new Map<string, RegisteredCapability>();

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -12,6 +12,8 @@ interface SubscriptionEntry {
   dispose: () => void;
 }
 
+const LOCAL_READ_OPERATIONS = new Set(["getCachedFinancialsForTargets", "getCachedNews"]);
+
 export class CapabilityRegistry {
   private readonly capabilities = new Map<string, RegisteredCapability>();
   private readonly subscriptions = new Map<string, SubscriptionEntry>();
@@ -87,7 +89,11 @@ export class CapabilityRegistry {
     const { capability, operation } = this.resolveOperation(capabilityId, operationId, options);
     if (!operation.handler) throw new Error(`Capability operation "${capabilityId}.${operationId}" is not invokable.`);
     const input = (operation.input ?? recordSchema).parse(payload);
-    const result = await operation.handler(input, { capability, operationId });
+    const invoke = () => Promise.resolve(operation.handler!(input, { capability, operationId }));
+    const health = this.options.connectionHealth;
+    const result = health?.hasSource(capabilityId) && !LOCAL_READ_OPERATIONS.has(operationId)
+      ? await health.track(capabilityId, operationId, invoke)
+      : await invoke();
     return (operation.output ? operation.output.parse(result) : result) as T;
   }
 

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -1,4 +1,5 @@
 import type { CachePolicyMap } from "../types/persistence";
+import type { ConnectionHealthRegistry } from "../core/connection-health";
 import type { AssetDataProvider } from "../types/data-provider";
 import type { NewsDataProvider } from "../types/capability-route-source";
 
@@ -92,6 +93,7 @@ export interface CapabilityManifest {
 export interface CapabilityRegistryOptions {
   isPluginEnabled?(pluginId: string): boolean;
   isCapabilityEnabled?(capability: PluginCapability, pluginId: string): boolean;
+  connectionHealth?: ConnectionHealthRegistry;
 }
 
 export interface RegisteredCapability {

--- a/src/cli/pane-functions/discovery.ts
+++ b/src/cli/pane-functions/discovery.ts
@@ -1,3 +1,4 @@
+import { ConnectionHealthRegistry } from "../../core/connection-health";
 import type {
   GloomPlugin,
   GloomPluginContext,
@@ -36,6 +37,7 @@ export async function createPaneCatalog(context: MarketContext, plugins: GloomPl
     getConfig: () => context.config,
     getPaneDef: (paneId: string) => panes.get(paneId),
     marketData: context.dataProvider,
+    connectionHealth: new ConnectionHealthRegistry(),
     tickerRepository: context.store,
     persistence: fakePersistence,
     log: {

--- a/src/core/app-services.ts
+++ b/src/core/app-services.ts
@@ -1,4 +1,5 @@
 import { join } from "path";
+import { connectionHealth } from "./connection-health";
 import { AppPersistence } from "../data/app-persistence";
 import { TickerRepository } from "../data/ticker-repository";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../market-data/coordinator";
@@ -39,11 +40,13 @@ export function createAppServices({
   const persistence = measurePerf("startup.services.persistence", () => new AppPersistence(dbPath));
   setIbkrPortfolioPerformanceResourceStore(persistence.resources);
   const tickerRepository = measurePerf("startup.services.ticker-repository", () => new TickerRepository(persistence.tickers));
-  const providerRouter = measurePerf("startup.services.asset-data-router", () => new AssetDataRouter(null, [], persistence.resources));
+  const providerRouter = measurePerf("startup.services.asset-data-router", () => (
+    new AssetDataRouter(null, [], persistence.resources, connectionHealth)
+  ));
   const dataProvider: DataProvider = providerRouter;
   const marketData = new MarketDataCoordinator(dataProvider);
-  const pluginRegistry = new PluginRegistry(dataProvider, tickerRepository, persistence);
-  const newsService = new NewsService();
+  const pluginRegistry = new PluginRegistry(dataProvider, tickerRepository, persistence, { connectionHealth });
+  const newsService = new NewsService({ connectionHealth });
   pluginRegistry.capabilities.register("core", assetDataProvider(providerRouter));
   pluginRegistry.capabilities.register("core", {
     ...newsProvider({

--- a/src/core/app-services.ts
+++ b/src/core/app-services.ts
@@ -1,5 +1,8 @@
 import { join } from "path";
-import { connectionHealth } from "./connection-health";
+import {
+  connectionHealth,
+  registerGloomCloudConnectionSources,
+} from "./connection-health";
 import { AppPersistence } from "../data/app-persistence";
 import { TickerRepository } from "../data/ticker-repository";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../market-data/coordinator";
@@ -40,6 +43,7 @@ export function createAppServices({
   const persistence = measurePerf("startup.services.persistence", () => new AppPersistence(dbPath));
   setIbkrPortfolioPerformanceResourceStore(persistence.resources);
   const tickerRepository = measurePerf("startup.services.ticker-repository", () => new TickerRepository(persistence.tickers));
+  const disposeCloudConnectionSources = registerGloomCloudConnectionSources(connectionHealth);
   const providerRouter = measurePerf("startup.services.asset-data-router", () => (
     new AssetDataRouter(null, [], persistence.resources, connectionHealth)
   ));
@@ -97,6 +101,7 @@ export function createAppServices({
       setSharedNewsService(null);
       newsService.stop();
       pluginRegistry.destroy();
+      disposeCloudConnectionSources();
       setIbkrPortfolioPerformanceResourceStore(null);
       persistence.close();
     },

--- a/src/core/connection-health.test.ts
+++ b/src/core/connection-health.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { ConnectionHealthRegistry } from "./connection-health";
+import {
+  ConnectionHealthRegistry,
+  registerGloomCloudConnectionSources,
+} from "./connection-health";
 
 function source(id = "quotes") {
   return { id, name: "Quotes", kind: "asset-data" as const, ownerId: "test" };
@@ -20,6 +23,21 @@ describe("ConnectionHealthRegistry", () => {
     expect(health.getSnapshot().sources).toEqual([]);
     expect(notifications).toBe(3);
     unsubscribe();
+  });
+
+  test("keeps source disposal scoped to its registry", () => {
+    const first = new ConnectionHealthRegistry();
+    const second = new ConnectionHealthRegistry();
+    const disposeFirst = registerGloomCloudConnectionSources(first);
+    registerGloomCloudConnectionSources(second);
+
+    disposeFirst();
+
+    expect(first.getSnapshot().sources).toEqual([]);
+    expect(second.getSnapshot().sources.map((entry) => entry.id)).toEqual([
+      "gloom-cloud-http",
+      "gloom-cloud-socket",
+    ]);
   });
 
   test("attributes success, error, latency, and recent outcomes to the source", async () => {
@@ -47,7 +65,7 @@ describe("ConnectionHealthRegistry", () => {
     expect(state.recentRequests.map((entry) => entry.operation)).toEqual(["getHistory", "getQuote"]);
   });
 
-  test("replays reports made before the source and pane are initialized", () => {
+  test("drops reports without an active source registration", () => {
     const health = new ConnectionHealthRegistry({ now: () => 500 });
     health.reportRequest("news", {
       operation: "fetchNews",
@@ -59,9 +77,66 @@ describe("ConnectionHealthRegistry", () => {
 
     expect(health.getSnapshot().sources[0]).toMatchObject({
       id: "news",
+      status: "idle",
+      lastRequestAt: null,
+    });
+  });
+
+  test("drops in-flight completions after disposal instead of applying them to a replacement", async () => {
+    let complete!: (value: number) => void;
+    const health = new ConnectionHealthRegistry();
+    const dispose = health.registerSource(source());
+    const request = health.track("quotes", "getQuote", () => new Promise<number>((resolve) => {
+      complete = resolve;
+    }));
+
+    dispose();
+    health.registerSource({ ...source(), name: "Replacement" });
+    complete(42);
+
+    await expect(request).resolves.toBe(42);
+    expect(health.getSnapshot().sources[0]).toMatchObject({
+      name: "Replacement",
+      status: "idle",
+      lastRequestAt: null,
+    });
+  });
+
+  test("returns request outcomes to idle after the freshness window", () => {
+    let now = 100;
+    const health = new ConnectionHealthRegistry({ now: () => now, requestStatusTtlMs: 1_000 });
+    health.registerSource(source());
+    health.reportRequest("quotes", { operation: "getQuote", success: true, latencyMs: 5 });
+
+    expect(health.getSnapshot().sources[0]?.status).toBe("connected");
+    now = 1_100;
+    expect(health.getSnapshot().sources[0]).toMatchObject({
+      status: "idle",
+      lastOperation: "getQuote",
+      lastLatencyMs: 5,
+    });
+  });
+
+  test("overlays external sources by canonical id without duplicate rows", () => {
+    const renderer = new ConnectionHealthRegistry();
+    renderer.registerSource({ id: "gloom-cloud-http", name: "Local HTTP", kind: "api" });
+    const backend = new ConnectionHealthRegistry();
+    backend.registerSource({ id: "gloom-cloud-http", name: "Backend HTTP", kind: "api" });
+    backend.reportRequest("gloom-cloud-http", { operation: "GET /market/quotes", success: true, latencyMs: 12 });
+
+    renderer.replaceExternalSnapshot("backend", backend.getSnapshot());
+    expect(renderer.getSnapshot().sources).toHaveLength(1);
+    expect(renderer.getSnapshot().sources[0]).toMatchObject({
+      id: "gloom-cloud-http",
+      name: "Backend HTTP",
       status: "connected",
-      lastLatencyMs: 18,
-      lastRequestAt: 500,
+    });
+
+    renderer.clearExternalSnapshot("backend");
+    expect(renderer.getSnapshot().sources[0]).toMatchObject({
+      id: "gloom-cloud-http",
+      name: "Local HTTP",
+      status: "idle",
     });
   });
 });

--- a/src/core/connection-health.test.ts
+++ b/src/core/connection-health.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { ConnectionHealthRegistry } from "./connection-health";
+
+function source(id = "quotes") {
+  return { id, name: "Quotes", kind: "asset-data" as const, ownerId: "test" };
+}
+
+describe("ConnectionHealthRegistry", () => {
+  test("registers, notifies, and removes only the active registration", () => {
+    const health = new ConnectionHealthRegistry();
+    let notifications = 0;
+    const unsubscribe = health.subscribe(() => notifications++);
+    const disposeFirst = health.registerSource(source());
+    const disposeSecond = health.registerSource({ ...source(), name: "Replacement" });
+
+    disposeFirst();
+    expect(health.getSnapshot().sources.map((entry) => entry.name)).toEqual(["Replacement"]);
+
+    disposeSecond();
+    expect(health.getSnapshot().sources).toEqual([]);
+    expect(notifications).toBe(3);
+    unsubscribe();
+  });
+
+  test("attributes success, error, latency, and recent outcomes to the source", async () => {
+    let now = 100;
+    let clock = 20;
+    const health = new ConnectionHealthRegistry({ now: () => now, clock: () => clock });
+    health.registerSource(source());
+
+    const result = await health.track("quotes", "getQuote", async () => {
+      clock = 32.5;
+      return 42;
+    });
+    now = 200;
+    clock = 40;
+    await expect(health.track("quotes", "getHistory", async () => {
+      clock = 47;
+      throw new Error("rate limited");
+    })).rejects.toThrow("rate limited");
+
+    const state = health.getSnapshot().sources[0]!;
+    expect(result).toBe(42);
+    expect(state.status).toBe("error");
+    expect(state.lastSuccess).toMatchObject({ operation: "getQuote", latencyMs: 12.5, at: 100 });
+    expect(state.lastError).toMatchObject({ operation: "getHistory", latencyMs: 7, at: 200, error: "rate limited" });
+    expect(state.recentRequests.map((entry) => entry.operation)).toEqual(["getHistory", "getQuote"]);
+  });
+
+  test("replays reports made before the source and pane are initialized", () => {
+    const health = new ConnectionHealthRegistry({ now: () => 500 });
+    health.reportRequest("news", {
+      operation: "fetchNews",
+      success: true,
+      latencyMs: 18,
+    });
+
+    health.registerSource({ id: "news", name: "News", kind: "news" });
+
+    expect(health.getSnapshot().sources[0]).toMatchObject({
+      id: "news",
+      status: "connected",
+      lastLatencyMs: 18,
+      lastRequestAt: 500,
+    });
+  });
+});

--- a/src/core/connection-health.ts
+++ b/src/core/connection-health.ts
@@ -49,17 +49,14 @@ export interface ConnectionRequestReport {
 interface ConnectionHealthOptions {
   now?: () => number;
   clock?: () => number;
+  requestStatusTtlMs?: number;
 }
-
-type PendingEvent =
-  | { type: "request"; sourceId: string; report: ConnectionRequestReport }
-  | { type: "socket"; sourceId: string; state: ConnectionSocketState; detail?: string };
 
 export const GLOOM_CLOUD_HTTP_CONNECTION_ID = "gloom-cloud-http";
 export const GLOOM_CLOUD_SOCKET_CONNECTION_ID = "gloom-cloud-socket";
 
 const MAX_RECENT_REQUESTS = 20;
-const MAX_PENDING_EVENTS = 200;
+const DEFAULT_REQUEST_STATUS_TTL_MS = 60_000;
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -86,15 +83,16 @@ export class ConnectionHealthRegistry {
   private readonly sources = new Map<string, ConnectionHealthState>();
   private readonly registrations = new Map<string, symbol>();
   private readonly listeners = new Set<() => void>();
-  private readonly pending: PendingEvent[] = [];
   private readonly external = new Map<string, ConnectionHealthState[]>();
   private readonly now: () => number;
   private readonly clock: () => number;
+  private readonly requestStatusTtlMs: number;
   private version = 0;
 
   constructor(options: ConnectionHealthOptions = {}) {
     this.now = options.now ?? Date.now;
     this.clock = options.clock ?? (() => performance.now());
+    this.requestStatusTtlMs = options.requestStatusTtlMs ?? DEFAULT_REQUEST_STATUS_TTL_MS;
   }
 
   registerSource(source: ConnectionHealthSource): () => void {
@@ -115,14 +113,6 @@ export class ConnectionHealthRegistry {
       currentDetail: source.detail ?? null,
     });
 
-    const queued = this.pending.filter((event) => event.sourceId === source.id);
-    for (let index = this.pending.length - 1; index >= 0; index--) {
-      if (this.pending[index]?.sourceId === source.id) this.pending.splice(index, 1);
-    }
-    for (const event of queued) {
-      if (event.type === "request") this.applyRequest(source.id, event.report);
-      else this.applySocketState(source.id, event.state, event.detail);
-    }
     this.emit();
 
     return () => {
@@ -134,26 +124,24 @@ export class ConnectionHealthRegistry {
   }
 
   reportRequest(sourceId: string, report: ConnectionRequestReport): void {
-    if (!this.sources.has(sourceId)) {
-      this.queue({ type: "request", sourceId, report: { ...report } });
-      return;
-    }
+    if (!this.sources.has(sourceId)) return;
     this.applyRequest(sourceId, report);
     this.emit();
   }
 
   async track<T>(sourceId: string, operation: string, request: () => Promise<T>): Promise<T> {
+    const registration = this.registrations.get(sourceId);
     const startedAt = this.clock();
     try {
       const result = await request();
-      this.reportRequest(sourceId, {
+      this.reportTrackedRequest(sourceId, registration, {
         operation,
         success: true,
         latencyMs: this.clock() - startedAt,
       });
       return result;
     } catch (error) {
-      this.reportRequest(sourceId, {
+      this.reportTrackedRequest(sourceId, registration, {
         operation,
         success: false,
         latencyMs: this.clock() - startedAt,
@@ -164,10 +152,7 @@ export class ConnectionHealthRegistry {
   }
 
   reportSocketState(sourceId: string, state: ConnectionSocketState, detail?: string): void {
-    if (!this.sources.has(sourceId)) {
-      this.queue({ type: "socket", sourceId, state, detail });
-      return;
-    }
+    if (!this.sources.has(sourceId)) return;
     this.applySocketState(sourceId, state, detail);
     this.emit();
   }
@@ -182,11 +167,15 @@ export class ConnectionHealthRegistry {
   }
 
   getSnapshot(): ConnectionHealthSnapshot {
-    const local = [...this.sources.values()].map(cloneState);
-    const external = [...this.external.values()].flatMap((states) => states.map(cloneState));
+    const sources = new Map(
+      [...this.sources.values()].map((source) => [source.id, this.snapshotState(source)]),
+    );
+    for (const external of this.external.values()) {
+      for (const source of external) sources.set(source.id, this.snapshotState(source));
+    }
     return {
       version: this.version,
-      sources: [...local, ...external].sort((left, right) => (
+      sources: [...sources.values()].sort((left, right) => (
         (left.priority ?? 1000) - (right.priority ?? 1000)
         || left.name.localeCompare(right.name)
       )),
@@ -194,11 +183,7 @@ export class ConnectionHealthRegistry {
   }
 
   replaceExternalSnapshot(namespace: string, snapshot: ConnectionHealthSnapshot): void {
-    this.external.set(namespace, snapshot.sources.map((source) => ({
-      ...cloneState(source),
-      id: `${namespace}:${source.id}`,
-      currentDetail: source.currentDetail ?? `Reported by ${namespace}`,
-    })));
+    this.external.set(namespace, snapshot.sources.map(cloneState));
     this.emit();
   }
 
@@ -207,11 +192,26 @@ export class ConnectionHealthRegistry {
     this.emit();
   }
 
-  private queue(event: PendingEvent): void {
-    this.pending.push(event);
-    if (this.pending.length > MAX_PENDING_EVENTS) {
-      this.pending.splice(0, this.pending.length - MAX_PENDING_EVENTS);
+  private reportTrackedRequest(
+    sourceId: string,
+    registration: symbol | undefined,
+    report: ConnectionRequestReport,
+  ): void {
+    if (!registration || this.registrations.get(sourceId) !== registration) return;
+    this.applyRequest(sourceId, report);
+    this.emit();
+  }
+
+  private snapshotState(source: ConnectionHealthState): ConnectionHealthState {
+    const snapshot = cloneState(source);
+    if (
+      snapshot.socketState === null
+      && snapshot.lastRequestAt !== null
+      && this.now() - snapshot.lastRequestAt >= this.requestStatusTtlMs
+    ) {
+      snapshot.status = "idle";
     }
+    return snapshot;
   }
 
   private applyRequest(sourceId: string, report: ConnectionRequestReport): void {
@@ -257,6 +257,30 @@ export class ConnectionHealthRegistry {
     this.version++;
     for (const listener of this.listeners) listener();
   }
+}
+
+export function registerGloomCloudConnectionSources(health: ConnectionHealthRegistry): () => void {
+  const disposers = [
+    health.registerSource({
+      id: GLOOM_CLOUD_HTTP_CONNECTION_ID,
+      name: "Gloom Cloud HTTP",
+      kind: "api",
+      ownerId: "gloomberb-cloud",
+      priority: 0,
+      detail: "api.gloom.sh",
+    }),
+    health.registerSource({
+      id: GLOOM_CLOUD_SOCKET_CONNECTION_ID,
+      name: "Gloom Cloud Stream",
+      kind: "websocket",
+      ownerId: "gloomberb-cloud",
+      priority: 1,
+      detail: "api.gloom.sh/cloud/ws",
+    }),
+  ];
+  return () => {
+    for (const dispose of disposers.reverse()) dispose();
+  };
 }
 
 export const connectionHealth = new ConnectionHealthRegistry();

--- a/src/core/connection-health.ts
+++ b/src/core/connection-health.ts
@@ -1,0 +1,262 @@
+export type ConnectionHealthKind = "asset-data" | "news" | "api" | "websocket" | "capability";
+export type ConnectionHealthStatus = "idle" | "connecting" | "connected" | "disconnected" | "error";
+export type ConnectionSocketState = "idle" | "connecting" | "open" | "closed" | "error";
+
+export interface ConnectionHealthSource {
+  id: string;
+  name: string;
+  kind: ConnectionHealthKind;
+  ownerId?: string;
+  detail?: string;
+  priority?: number;
+}
+
+export interface ConnectionRequestOutcome {
+  at: number;
+  operation: string;
+  success: boolean;
+  latencyMs: number;
+  detail?: string;
+  error?: string;
+}
+
+export interface ConnectionHealthState extends ConnectionHealthSource {
+  status: ConnectionHealthStatus;
+  lastRequestAt: number | null;
+  lastLatencyMs: number | null;
+  lastOperation: string | null;
+  lastSuccess: ConnectionRequestOutcome | null;
+  lastError: ConnectionRequestOutcome | null;
+  recentRequests: ConnectionRequestOutcome[];
+  socketState: ConnectionSocketState | null;
+  lastTransitionAt: number | null;
+  currentDetail: string | null;
+}
+
+export interface ConnectionHealthSnapshot {
+  version: number;
+  sources: ConnectionHealthState[];
+}
+
+export interface ConnectionRequestReport {
+  operation: string;
+  success: boolean;
+  latencyMs: number;
+  detail?: string;
+  error?: unknown;
+}
+
+interface ConnectionHealthOptions {
+  now?: () => number;
+  clock?: () => number;
+}
+
+type PendingEvent =
+  | { type: "request"; sourceId: string; report: ConnectionRequestReport }
+  | { type: "socket"; sourceId: string; state: ConnectionSocketState; detail?: string };
+
+export const GLOOM_CLOUD_HTTP_CONNECTION_ID = "gloom-cloud-http";
+export const GLOOM_CLOUD_SOCKET_CONNECTION_ID = "gloom-cloud-socket";
+
+const MAX_RECENT_REQUESTS = 20;
+const MAX_PENDING_EVENTS = 200;
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function socketStatus(state: ConnectionSocketState): ConnectionHealthStatus {
+  if (state === "open") return "connected";
+  if (state === "connecting") return "connecting";
+  if (state === "closed") return "disconnected";
+  if (state === "error") return "error";
+  return "idle";
+}
+
+function cloneState(state: ConnectionHealthState): ConnectionHealthState {
+  return {
+    ...state,
+    lastSuccess: state.lastSuccess ? { ...state.lastSuccess } : null,
+    lastError: state.lastError ? { ...state.lastError } : null,
+    recentRequests: state.recentRequests.map((request) => ({ ...request })),
+  };
+}
+
+export class ConnectionHealthRegistry {
+  private readonly sources = new Map<string, ConnectionHealthState>();
+  private readonly registrations = new Map<string, symbol>();
+  private readonly listeners = new Set<() => void>();
+  private readonly pending: PendingEvent[] = [];
+  private readonly external = new Map<string, ConnectionHealthState[]>();
+  private readonly now: () => number;
+  private readonly clock: () => number;
+  private version = 0;
+
+  constructor(options: ConnectionHealthOptions = {}) {
+    this.now = options.now ?? Date.now;
+    this.clock = options.clock ?? (() => performance.now());
+  }
+
+  registerSource(source: ConnectionHealthSource): () => void {
+    const registration = Symbol(source.id);
+    this.registrations.set(source.id, registration);
+    this.sources.set(source.id, {
+      ...source,
+      priority: source.priority ?? 1000,
+      status: "idle",
+      lastRequestAt: null,
+      lastLatencyMs: null,
+      lastOperation: null,
+      lastSuccess: null,
+      lastError: null,
+      recentRequests: [],
+      socketState: source.kind === "websocket" ? "idle" : null,
+      lastTransitionAt: null,
+      currentDetail: source.detail ?? null,
+    });
+
+    const queued = this.pending.filter((event) => event.sourceId === source.id);
+    for (let index = this.pending.length - 1; index >= 0; index--) {
+      if (this.pending[index]?.sourceId === source.id) this.pending.splice(index, 1);
+    }
+    for (const event of queued) {
+      if (event.type === "request") this.applyRequest(source.id, event.report);
+      else this.applySocketState(source.id, event.state, event.detail);
+    }
+    this.emit();
+
+    return () => {
+      if (this.registrations.get(source.id) !== registration) return;
+      this.registrations.delete(source.id);
+      this.sources.delete(source.id);
+      this.emit();
+    };
+  }
+
+  reportRequest(sourceId: string, report: ConnectionRequestReport): void {
+    if (!this.sources.has(sourceId)) {
+      this.queue({ type: "request", sourceId, report: { ...report } });
+      return;
+    }
+    this.applyRequest(sourceId, report);
+    this.emit();
+  }
+
+  async track<T>(sourceId: string, operation: string, request: () => Promise<T>): Promise<T> {
+    const startedAt = this.clock();
+    try {
+      const result = await request();
+      this.reportRequest(sourceId, {
+        operation,
+        success: true,
+        latencyMs: this.clock() - startedAt,
+      });
+      return result;
+    } catch (error) {
+      this.reportRequest(sourceId, {
+        operation,
+        success: false,
+        latencyMs: this.clock() - startedAt,
+        error,
+      });
+      throw error;
+    }
+  }
+
+  reportSocketState(sourceId: string, state: ConnectionSocketState, detail?: string): void {
+    if (!this.sources.has(sourceId)) {
+      this.queue({ type: "socket", sourceId, state, detail });
+      return;
+    }
+    this.applySocketState(sourceId, state, detail);
+    this.emit();
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  hasSource(sourceId: string): boolean {
+    return this.sources.has(sourceId);
+  }
+
+  getSnapshot(): ConnectionHealthSnapshot {
+    const local = [...this.sources.values()].map(cloneState);
+    const external = [...this.external.values()].flatMap((states) => states.map(cloneState));
+    return {
+      version: this.version,
+      sources: [...local, ...external].sort((left, right) => (
+        (left.priority ?? 1000) - (right.priority ?? 1000)
+        || left.name.localeCompare(right.name)
+      )),
+    };
+  }
+
+  replaceExternalSnapshot(namespace: string, snapshot: ConnectionHealthSnapshot): void {
+    this.external.set(namespace, snapshot.sources.map((source) => ({
+      ...cloneState(source),
+      id: `${namespace}:${source.id}`,
+      currentDetail: source.currentDetail ?? `Reported by ${namespace}`,
+    })));
+    this.emit();
+  }
+
+  clearExternalSnapshot(namespace: string): void {
+    if (!this.external.delete(namespace)) return;
+    this.emit();
+  }
+
+  private queue(event: PendingEvent): void {
+    this.pending.push(event);
+    if (this.pending.length > MAX_PENDING_EVENTS) {
+      this.pending.splice(0, this.pending.length - MAX_PENDING_EVENTS);
+    }
+  }
+
+  private applyRequest(sourceId: string, report: ConnectionRequestReport): void {
+    const source = this.sources.get(sourceId);
+    if (!source) return;
+    const latencyMs = Number.isFinite(report.latencyMs) ? Math.max(0, report.latencyMs) : 0;
+    const outcome: ConnectionRequestOutcome = {
+      at: this.now(),
+      operation: report.operation,
+      success: report.success,
+      latencyMs,
+      ...(report.detail ? { detail: report.detail } : {}),
+      ...(!report.success && report.error !== undefined ? { error: errorMessage(report.error) } : {}),
+    };
+    this.sources.set(sourceId, {
+      ...source,
+      status: report.success ? "connected" : "error",
+      lastRequestAt: outcome.at,
+      lastLatencyMs: latencyMs,
+      lastOperation: report.operation,
+      lastSuccess: report.success ? outcome : source.lastSuccess,
+      lastError: report.success ? source.lastError : outcome,
+      recentRequests: [outcome, ...source.recentRequests].slice(0, MAX_RECENT_REQUESTS),
+      currentDetail: report.success
+        ? (report.detail ?? source.detail ?? null)
+        : (outcome.error ?? report.detail ?? source.detail ?? null),
+    });
+  }
+
+  private applySocketState(sourceId: string, state: ConnectionSocketState, detail?: string): void {
+    const source = this.sources.get(sourceId);
+    if (!source) return;
+    this.sources.set(sourceId, {
+      ...source,
+      status: socketStatus(state),
+      socketState: state,
+      lastTransitionAt: this.now(),
+      currentDetail: detail ?? source.detail ?? null,
+    });
+  }
+
+  private emit(): void {
+    this.version++;
+    for (const listener of this.listeners) listener();
+  }
+}
+
+export const connectionHealth = new ConnectionHealthRegistry();

--- a/src/news/aggregator.ts
+++ b/src/news/aggregator.ts
@@ -1,4 +1,5 @@
 import type { NewsCapability } from "../capabilities";
+import type { ConnectionHealthRegistry } from "../core/connection-health";
 import type { NewsArticle, NewsQuery, NewsQueryState } from "./types";
 import {
   DEFAULT_GLOBAL_QUERY,
@@ -20,6 +21,7 @@ export interface NewsServiceOptions {
   inactiveQueryTtlMs?: number;
   maxInactiveQueries?: number;
   now?: () => number;
+  connectionHealth?: ConnectionHealthRegistry;
 }
 
 export type NewsQueryListener = (state: NewsQueryState) => void;
@@ -60,12 +62,14 @@ export class NewsService {
   private readonly inactiveQueryTtlMs: number;
   private readonly maxInactiveQueries: number;
   private readonly now: () => number;
+  private readonly connectionHealth?: ConnectionHealthRegistry;
 
   constructor(options: NewsServiceOptions = {}) {
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     this.inactiveQueryTtlMs = Math.max(1, options.inactiveQueryTtlMs ?? DEFAULT_INACTIVE_QUERY_TTL_MS);
     this.maxInactiveQueries = Math.max(1, Math.floor(options.maxInactiveQueries ?? DEFAULT_MAX_INACTIVE_QUERIES));
     this.now = options.now ?? Date.now;
+    this.connectionHealth = options.connectionHealth;
   }
 
   register(source: NewsCapability): () => void {
@@ -152,7 +156,11 @@ export class NewsService {
 
     for (const source of sources) {
       try {
-        const article = await source.provider.fetchNewsStory?.(storyId);
+        const article = await this.trackSourceRequest(
+          source,
+          "fetchNewsStory",
+          () => source.provider.fetchNewsStory?.(storyId) ?? Promise.resolve(null),
+        );
         if (!article) continue;
         this.mergeStoryDetail(article);
         return article;
@@ -289,8 +297,11 @@ export class NewsService {
     let firstEmpty: SourceFetchResult | null = null;
     for (const source of sources) {
       try {
-        const articles = (await source.provider.fetchNews(query))
-          .map((article) => markDetailCapableArticle(source, article));
+        const articles = (await this.trackSourceRequest(
+          source,
+          "fetchNews",
+          () => source.provider.fetchNews(query),
+        )).map((article) => markDetailCapableArticle(source, article));
         const result = { articles, sourceIds: [newsCapabilitySourceId(source)] };
         if (articles.length > 0) return result;
         firstEmpty ??= result;
@@ -305,8 +316,11 @@ export class NewsService {
     const settled = await Promise.allSettled(
       sources.map(async (source) => ({
         source,
-        articles: (await source.provider.fetchNews(query))
-          .map((article) => markDetailCapableArticle(source, article)),
+        articles: (await this.trackSourceRequest(
+          source,
+          "fetchNews",
+          () => source.provider.fetchNews(query),
+        )).map((article) => markDetailCapableArticle(source, article)),
       })),
     );
     const articles: NewsArticle[] = [];
@@ -317,6 +331,16 @@ export class NewsService {
       sourceIds.push(newsCapabilitySourceId(result.value.source));
     }
     return { articles, sourceIds };
+  }
+
+  private trackSourceRequest<T>(
+    source: NewsCapability,
+    operation: string,
+    request: () => Promise<T>,
+  ): Promise<T> {
+    return this.connectionHealth?.hasSource(source.id)
+      ? this.connectionHealth.track(source.id, operation, request)
+      : request();
   }
 
   private seedCachedSource(source: NewsCapability): void {

--- a/src/plugins/builtin/composite-plugins.ts
+++ b/src/plugins/builtin/composite-plugins.ts
@@ -1,6 +1,7 @@
 import { portfolioAnalyticsModule } from "./analytics";
 import { brokerManagerModule } from "./broker-manager";
 import { changelogModule } from "./changelog";
+import { connectionsModule } from "./connections";
 import { correlationModule } from "./correlation";
 import { economicCalendarModule } from "./econ";
 import { earningsModule } from "./earnings";
@@ -24,7 +25,7 @@ export const applicationPlugin = composeBuiltinPlugin({
   name: "Application",
   version: "1.0.0",
   description: "Core layout, help, and release information.",
-  modules: [layoutManagerModule, helpModule, changelogModule],
+  modules: [layoutManagerModule, helpModule, changelogModule, connectionsModule],
 });
 
 export const portfolioPlugin = composeBuiltinPlugin({

--- a/src/plugins/builtin/connections/index.ts
+++ b/src/plugins/builtin/connections/index.ts
@@ -1,0 +1,80 @@
+import type { PluginCapability } from "../../../capabilities";
+import type { ConnectionHealthRegistry } from "../../../core/connection-health";
+import {
+  GLOOM_CLOUD_HTTP_CONNECTION_ID,
+  GLOOM_CLOUD_SOCKET_CONNECTION_ID,
+} from "../../../core/connection-health";
+import type { PluginModule } from "../plugin-module";
+import { ConnectionsPane } from "./pane";
+
+export const CONNECTION_HEALTH_CAPABILITY_ID = "application.connection-health";
+
+function connectionHealthCapability(health: ConnectionHealthRegistry): PluginCapability {
+  return {
+    id: CONNECTION_HEALTH_CAPABILITY_ID,
+    kind: "plugin-service",
+    name: "Connection Health",
+    operations: {
+      snapshot: {
+        kind: "read",
+        rendererSafe: true,
+        handler: () => health.getSnapshot(),
+      },
+      subscribe: {
+        kind: "stream",
+        rendererSafe: true,
+        subscribe: (_input, emit) => {
+          const publish = () => emit(health.getSnapshot());
+          publish();
+          return health.subscribe(publish);
+        },
+      },
+    },
+  };
+}
+
+let disposers: Array<() => void> = [];
+
+export const connectionsModule: PluginModule = {
+  panes: [{
+    id: "connections",
+    name: "Connections",
+    icon: "C",
+    component: ConnectionsPane,
+    defaultPosition: "right",
+    defaultMode: "floating",
+    defaultFloatingSize: { width: 80, height: 24 },
+  }],
+  paneTemplates: [{
+    id: "connections-pane",
+    paneId: "connections",
+    label: "Connections",
+    description: "Inspect live request and socket health.",
+    keywords: ["connections", "health", "providers", "latency", "status"],
+    shortcut: { prefix: "CONN" },
+  }],
+  setup(ctx) {
+    disposers = [
+      ctx.connectionHealth.registerSource({
+        id: GLOOM_CLOUD_HTTP_CONNECTION_ID,
+        name: "Gloom Cloud HTTP",
+        kind: "api",
+        ownerId: "gloomberb-cloud",
+        priority: 0,
+        detail: "api.gloom.sh",
+      }),
+      ctx.connectionHealth.registerSource({
+        id: GLOOM_CLOUD_SOCKET_CONNECTION_ID,
+        name: "Gloom Cloud Stream",
+        kind: "websocket",
+        ownerId: "gloomberb-cloud",
+        priority: 1,
+        detail: "api.gloom.sh/cloud/ws",
+      }),
+    ];
+    ctx.registerCapability(connectionHealthCapability(ctx.connectionHealth));
+  },
+  dispose() {
+    for (const dispose of disposers.splice(0).reverse()) dispose();
+  },
+};

--- a/src/plugins/builtin/connections/index.ts
+++ b/src/plugins/builtin/connections/index.ts
@@ -1,9 +1,5 @@
 import type { PluginCapability } from "../../../capabilities";
 import type { ConnectionHealthRegistry } from "../../../core/connection-health";
-import {
-  GLOOM_CLOUD_HTTP_CONNECTION_ID,
-  GLOOM_CLOUD_SOCKET_CONNECTION_ID,
-} from "../../../core/connection-health";
 import type { PluginModule } from "../plugin-module";
 import { ConnectionsPane } from "./pane";
 
@@ -33,8 +29,6 @@ function connectionHealthCapability(health: ConnectionHealthRegistry): PluginCap
   };
 }
 
-let disposers: Array<() => void> = [];
-
 export const connectionsModule: PluginModule = {
   panes: [{
     id: "connections",
@@ -54,27 +48,6 @@ export const connectionsModule: PluginModule = {
     shortcut: { prefix: "CONN" },
   }],
   setup(ctx) {
-    disposers = [
-      ctx.connectionHealth.registerSource({
-        id: GLOOM_CLOUD_HTTP_CONNECTION_ID,
-        name: "Gloom Cloud HTTP",
-        kind: "api",
-        ownerId: "gloomberb-cloud",
-        priority: 0,
-        detail: "api.gloom.sh",
-      }),
-      ctx.connectionHealth.registerSource({
-        id: GLOOM_CLOUD_SOCKET_CONNECTION_ID,
-        name: "Gloom Cloud Stream",
-        kind: "websocket",
-        ownerId: "gloomberb-cloud",
-        priority: 1,
-        detail: "api.gloom.sh/cloud/ws",
-      }),
-    ];
     ctx.registerCapability(connectionHealthCapability(ctx.connectionHealth));
-  },
-  dispose() {
-    for (const dispose of disposers.splice(0).reverse()) dispose();
   },
 };

--- a/src/plugins/builtin/connections/pane.test.tsx
+++ b/src/plugins/builtin/connections/pane.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { PaneFooterBar, PaneFooterProvider } from "../../../components/layout/pane/footer";
+import { ConnectionHealthRegistry } from "../../../core/connection-health";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { AppContext, PaneInstanceProvider, createInitialState } from "../../../state/app/context";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
+import { createDefaultConfig } from "../../../types/config";
+import { Box } from "../../../ui";
+import { PluginRenderProvider } from "../../runtime";
+import { ConnectionsPane } from "./pane";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(async () => {
+  if (!testSetup) return;
+  await act(async () => testSetup!.renderer.destroy());
+  testSetup = undefined;
+});
+
+function harness() {
+  const health = new ConnectionHealthRegistry();
+  health.registerSource({ id: "quotes", name: "Quotes", kind: "asset-data" });
+  health.reportRequest("quotes", { operation: "getQuote", success: true, latencyMs: 12 });
+  const runtime = createTestPluginRuntime({ getConnectionHealth: () => health });
+  const state = createInitialState(createDefaultConfig("/tmp/gloomberb-connections-pane-test"));
+
+  return (
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <PaneInstanceProvider paneId="connections:test">
+        <PluginRenderProvider pluginId="application" runtime={runtime}>
+          <PaneFooterProvider>
+            {(footer) => (
+              <Box flexDirection="column" width={80} height={12}>
+                <ConnectionsPane paneId="connections:test" paneType="connections" focused width={80} height={11} />
+                <PaneFooterBar footer={footer} focused width={80} />
+              </Box>
+            )}
+          </PaneFooterProvider>
+        </PluginRenderProvider>
+      </PaneInstanceProvider>
+    </AppContext>
+  );
+}
+
+async function renderSettled() {
+  await act(async () => {
+    await testSetup!.renderOnce();
+    await testSetup!.renderOnce();
+  });
+}
+
+describe("ConnectionsPane", () => {
+  test("hides the clickable sort hint while detail blocks the sort key", async () => {
+    testSetup = await testRender(harness(), { width: 80, height: 12 });
+    await renderSettled();
+    expect(testSetup.captureCharFrame()).toContain("[s]ort");
+
+    await act(async () => {
+      testSetup!.renderer.keyInput.emit("keypress", {
+        name: "enter",
+        sequence: "\r",
+        ctrl: false,
+        meta: false,
+        option: false,
+        shift: false,
+        eventType: "press",
+        repeated: false,
+        preventDefault: () => {},
+        stopPropagation: () => {},
+      } as any);
+      await testSetup!.renderOnce();
+    });
+    await renderSettled();
+
+    expect(testSetup.captureCharFrame()).toContain("← Back Quotes");
+    expect(testSetup.captureCharFrame()).not.toContain("[s]ort");
+  });
+});

--- a/src/plugins/builtin/connections/pane.tsx
+++ b/src/plugins/builtin/connections/pane.tsx
@@ -1,0 +1,237 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Box, ScrollBox, Text, TextAttributes } from "../../../ui";
+import {
+  DataTableStackView,
+  type DataTableCell,
+  type DataTableColumn,
+  usePaneFooter,
+} from "../../../components";
+import { useConnectionHealth } from "../../runtime";
+import { useShortcut } from "../../../react/input";
+import type { PaneProps } from "../../../types/plugin";
+import type {
+  ConnectionHealthState,
+  ConnectionHealthStatus,
+} from "../../../core/connection-health";
+import { colors } from "../../../theme/colors";
+import { formatRelativeAge } from "../../../utils/relative-time";
+import { truncateToDisplayWidth } from "../../../utils/format";
+
+interface ConnectionColumn extends DataTableColumn {
+  id: "service" | "status" | "request" | "latency" | "last";
+}
+
+const SORT_COLUMNS: ConnectionColumn["id"][] = ["status", "service", "request", "latency", "last"];
+
+const STATUS_ORDER: Record<ConnectionHealthStatus, number> = {
+  error: 0,
+  disconnected: 1,
+  connecting: 2,
+  connected: 3,
+  idle: 4,
+};
+
+function statusLabel(status: ConnectionHealthStatus): string {
+  if (status === "connected") return "Connected";
+  if (status === "connecting") return "Connecting";
+  if (status === "disconnected") return "Disconnected";
+  if (status === "error") return "Error";
+  return "Idle";
+}
+
+function statusColor(status: ConnectionHealthStatus): string {
+  if (status === "connected") return colors.positive;
+  if (status === "connecting") return colors.warning;
+  if (status === "disconnected" || status === "error") return colors.negative;
+  return colors.textMuted;
+}
+
+function formatLatency(latencyMs: number | null): string {
+  if (latencyMs == null) return "-";
+  return latencyMs < 1000 ? `${Math.round(latencyMs)}ms` : `${(latencyMs / 1000).toFixed(1)}s`;
+}
+
+function columnsForWidth(width: number): ConnectionColumn[] {
+  const statusWidth = 13;
+  const latencyWidth = 8;
+  const lastWidth = 9;
+  const requestWidth = width >= 72 ? 18 : 0;
+  const serviceWidth = Math.max(16, width - statusWidth - latencyWidth - lastWidth - requestWidth - 4);
+  return [
+    { id: "service", label: "SERVICE", width: serviceWidth, align: "left" },
+    { id: "status", label: "STATUS", width: statusWidth, align: "left" },
+    ...(requestWidth > 0 ? [{ id: "request", label: "REQUEST", width: requestWidth, align: "left" } as ConnectionColumn] : []),
+    { id: "latency", label: "LATENCY", width: latencyWidth, align: "right" },
+    { id: "last", label: "LAST", width: lastWidth, align: "right" },
+  ];
+}
+
+function DetailLine({ label, value, color = colors.text }: { label: string; value: string; color?: string }) {
+  return (
+    <Box height={1} flexDirection="row">
+      <Box width={16}><Text fg={colors.textDim}>{label}</Text></Box>
+      <Text fg={color}>{value}</Text>
+    </Box>
+  );
+}
+
+function ConnectionDetail({ source, width, now }: { source: ConnectionHealthState; width: number; now: number }) {
+  const lineWidth = Math.max(24, width - 2);
+  return (
+    <ScrollBox scrollY focusable={false} flexGrow={1} paddingX={1}>
+      <Box flexDirection="column" width={lineWidth}>
+        <DetailLine label="Status" value={statusLabel(source.status)} color={statusColor(source.status)} />
+        <DetailLine label="Type" value={source.kind} color={colors.textDim} />
+        {source.ownerId ? <DetailLine label="Owner" value={source.ownerId} color={colors.textDim} /> : null}
+        {source.socketState ? <DetailLine label="Socket" value={source.socketState} color={statusColor(source.status)} /> : null}
+        {source.lastTransitionAt ? (
+          <DetailLine label="Transition" value={formatRelativeAge(source.lastTransitionAt, now)} color={colors.textMuted} />
+        ) : null}
+        <DetailLine label="Last request" value={source.lastRequestAt ? formatRelativeAge(source.lastRequestAt, now) : "never"} color={colors.textMuted} />
+        <DetailLine label="Operation" value={source.lastOperation ?? "-"} color={colors.textDim} />
+        <DetailLine label="Latency" value={formatLatency(source.lastLatencyMs)} color={colors.textMuted} />
+        {source.currentDetail ? (
+          <DetailLine label="Detail" value={truncateToDisplayWidth(source.currentDetail, Math.max(8, lineWidth - 16))} color={source.status === "error" ? colors.negative : colors.textDim} />
+        ) : null}
+        {source.lastSuccess ? (
+          <DetailLine
+            label="Last success"
+            value={`${formatRelativeAge(source.lastSuccess.at, now)} · ${formatLatency(source.lastSuccess.latencyMs)} · ${source.lastSuccess.operation}`}
+            color={colors.positive}
+          />
+        ) : null}
+        {source.lastError ? (
+          <DetailLine
+            label="Last error"
+            value={`${formatRelativeAge(source.lastError.at, now)} · ${source.lastError.error ?? source.lastError.operation}`}
+            color={colors.negative}
+          />
+        ) : null}
+        {source.recentRequests.length > 0 ? (
+          <>
+            <Box height={1} />
+            <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>Recent requests</Text>
+            {source.recentRequests.slice(0, 8).map((request, index) => (
+              <Box key={`${request.at}:${index}`} height={1} flexDirection="row">
+                <Box width={7}><Text fg={request.success ? colors.positive : colors.negative}>{request.success ? "ok" : "error"}</Text></Box>
+                <Box width={9}><Text fg={colors.textMuted}>{formatLatency(request.latencyMs)}</Text></Box>
+                <Box width={10}><Text fg={colors.textMuted}>{formatRelativeAge(request.at, now)}</Text></Box>
+                <Text fg={colors.textDim}>{truncateToDisplayWidth(request.error ?? request.operation, Math.max(8, lineWidth - 26))}</Text>
+              </Box>
+            ))}
+          </>
+        ) : null}
+      </Box>
+    </ScrollBox>
+  );
+}
+
+export function ConnectionsPane({ focused, width, height }: PaneProps) {
+  const health = useConnectionHealth();
+  const [snapshot, setSnapshot] = useState(() => health.getSnapshot());
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [sort, setSort] = useState<{ columnId: ConnectionColumn["id"]; direction: "asc" | "desc" }>({
+    columnId: "status",
+    direction: "asc",
+  });
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => health.subscribe(() => setSnapshot(health.getSnapshot())), [health]);
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 5000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const sources = useMemo(() => [...snapshot.sources].sort((left, right) => {
+    let comparison = 0;
+    if (sort.columnId === "status") comparison = STATUS_ORDER[left.status] - STATUS_ORDER[right.status];
+    else if (sort.columnId === "service") comparison = left.name.localeCompare(right.name);
+    else if (sort.columnId === "request") comparison = (left.lastOperation ?? "").localeCompare(right.lastOperation ?? "");
+    else if (sort.columnId === "latency") comparison = (left.lastLatencyMs ?? Number.POSITIVE_INFINITY) - (right.lastLatencyMs ?? Number.POSITIVE_INFINITY);
+    else comparison = (left.lastRequestAt ?? 0) - (right.lastRequestAt ?? 0);
+    return (sort.direction === "asc" ? comparison : -comparison)
+      || (left.priority ?? 1000) - (right.priority ?? 1000)
+      || left.name.localeCompare(right.name);
+  }), [snapshot, sort]);
+  const selected = sources.find((source) => source.id === selectedId) ?? sources[0] ?? null;
+  const issues = sources.filter((source) => source.status === "error" || source.status === "disconnected").length;
+  const connecting = sources.filter((source) => source.status === "connecting").length;
+
+  useEffect(() => {
+    if (!selectedId && sources[0]) setSelectedId(sources[0].id);
+    if (selectedId && !sources.some((source) => source.id === selectedId)) {
+      setSelectedId(sources[0]?.id ?? null);
+      setDetailOpen(false);
+    }
+  }, [selectedId, sources]);
+
+  const cycleSort = useCallback(() => {
+    setSort((current) => {
+      const currentIndex = SORT_COLUMNS.indexOf(current.columnId);
+      return current.direction === "asc"
+        ? { ...current, direction: "desc" }
+        : { columnId: SORT_COLUMNS[(currentIndex + 1) % SORT_COLUMNS.length]!, direction: "asc" };
+    });
+  }, []);
+
+  useShortcut((event) => {
+    if (!focused || detailOpen || event.name !== "s") return;
+    event.stopPropagation();
+    cycleSort();
+  });
+
+  usePaneFooter("connections", () => ({
+    info: [
+      ...(issues > 0 ? [{ id: "issues", parts: [{ text: `${issues} issue${issues === 1 ? "" : "s"}`, tone: "warning" as const }] }] : []),
+      ...(connecting > 0 ? [{ id: "connecting", parts: [{ text: `${connecting} connecting`, tone: "muted" as const }] }] : []),
+    ],
+    hints: [{ id: "sort", key: "s", label: "ort", onPress: cycleSort }],
+  }), [connecting, cycleSort, issues]);
+
+  const renderCell = useCallback((source: ConnectionHealthState, column: ConnectionColumn): DataTableCell => {
+    if (column.id === "service") return { text: truncateToDisplayWidth(source.name, column.width), color: colors.text };
+    if (column.id === "status") return { text: statusLabel(source.status), color: statusColor(source.status) };
+    if (column.id === "request") return { text: truncateToDisplayWidth(source.lastOperation ?? "-", column.width), color: colors.textDim };
+    if (column.id === "latency") return { text: formatLatency(source.lastLatencyMs), color: source.status === "error" ? colors.negative : colors.textMuted };
+    return { text: source.lastRequestAt ? formatRelativeAge(source.lastRequestAt, now) : "-", color: colors.textMuted };
+  }, [now]);
+
+  return (
+    <Box flexDirection="column" width={width} height={height} overflow="hidden">
+      <DataTableStackView<ConnectionHealthState, ConnectionColumn>
+        focused={focused}
+        detailOpen={detailOpen && !!selected}
+        onBack={() => setDetailOpen(false)}
+        detailTitle={selected?.name}
+        detailContent={selected ? <ConnectionDetail source={selected} width={width} now={now} /> : <Box />}
+        rootWidth={width}
+        rootHeight={height}
+        selection={{
+          kind: "id",
+          selectedId: selected?.id ?? null,
+          getId: (source) => source.id,
+          onChange: (id) => setSelectedId(id),
+        }}
+        onActivate={(source) => {
+          setSelectedId(source.id);
+          setDetailOpen(true);
+        }}
+        columns={columnsForWidth(width)}
+        items={sources}
+        sortColumnId={sort.columnId}
+        sortDirection={sort.direction}
+        onHeaderClick={(columnId) => {
+          setSort((current) => current.columnId === columnId
+            ? { ...current, direction: current.direction === "asc" ? "desc" : "asc" }
+            : { columnId: columnId as ConnectionColumn["id"], direction: "asc" });
+        }}
+        getItemKey={(source) => source.id}
+        renderCell={renderCell}
+        emptyStateTitle="No connection activity yet."
+        emptyStateHint="Sources appear when providers and services register."
+        showHorizontalScrollbar={false}
+      />
+    </Box>
+  );
+}

--- a/src/plugins/builtin/connections/pane.tsx
+++ b/src/plugins/builtin/connections/pane.tsx
@@ -139,9 +139,12 @@ export function ConnectionsPane({ focused, width, height }: PaneProps) {
 
   useEffect(() => health.subscribe(() => setSnapshot(health.getSnapshot())), [health]);
   useEffect(() => {
-    const timer = setInterval(() => setNow(Date.now()), 5000);
+    const timer = setInterval(() => {
+      setNow(Date.now());
+      setSnapshot(health.getSnapshot());
+    }, 5000);
     return () => clearInterval(timer);
-  }, []);
+  }, [health]);
 
   const sources = useMemo(() => [...snapshot.sources].sort((left, right) => {
     let comparison = 0;
@@ -186,8 +189,8 @@ export function ConnectionsPane({ focused, width, height }: PaneProps) {
       ...(issues > 0 ? [{ id: "issues", parts: [{ text: `${issues} issue${issues === 1 ? "" : "s"}`, tone: "warning" as const }] }] : []),
       ...(connecting > 0 ? [{ id: "connecting", parts: [{ text: `${connecting} connecting`, tone: "muted" as const }] }] : []),
     ],
-    hints: [{ id: "sort", key: "s", label: "ort", onPress: cycleSort }],
-  }), [connecting, cycleSort, issues]);
+    hints: detailOpen ? [] : [{ id: "sort", key: "s", label: "ort", onPress: cycleSort }],
+  }), [connecting, cycleSort, detailOpen, issues]);
 
   const renderCell = useCallback((source: ConnectionHealthState, column: ConnectionColumn): DataTableCell => {
     if (column.id === "service") return { text: truncateToDisplayWidth(source.name, column.width), color: colors.text };

--- a/src/plugins/registry/context.ts
+++ b/src/plugins/registry/context.ts
@@ -1,4 +1,5 @@
 import type { AppPersistencePort, AppTickerRepositoryPort } from "../../core/app-service-ports";
+import type { ConnectionHealthRegistry } from "../../core/connection-health";
 import type { BrokerInstanceConfig, LayoutConfig } from "../../types/config";
 import type { DataProvider } from "../../types/data-provider";
 import type { TickerFinancials } from "../../types/financials";
@@ -30,6 +31,7 @@ export interface RegistryPluginContextOptions {
   contributions: RegistryContributions;
   enableCapabilityHandlers: boolean;
   marketData: DataProvider;
+  connectionHealth: ConnectionHealthRegistry;
   tickerRepository: AppTickerRepositoryPort;
   persistence: AppPersistencePort;
   getLayout: () => LayoutConfig;
@@ -79,6 +81,7 @@ export function createRegistryPluginContext({
   contributions,
   enableCapabilityHandlers,
   marketData,
+  connectionHealth,
   tickerRepository,
   persistence,
   getLayout,
@@ -170,6 +173,7 @@ export function createRegistryPluginContext({
     getPaneDef: (paneId) => contributions.panesMap.get(paneId),
 
     marketData,
+    connectionHealth,
     tickerRepository,
     persistence: pluginPersistence,
     log,

--- a/src/plugins/registry/index.test.ts
+++ b/src/plugins/registry/index.test.ts
@@ -145,6 +145,7 @@ describe("built-in composite plugin ownership", () => {
     expect(registry.getPluginPaneIds("application")).toEqual(expect.arrayContaining([
       "help",
       "changelog",
+      "connections",
     ]));
     expect(registry.getPluginPaneIds("macro")).toEqual(expect.arrayContaining([
       "econ-calendar",
@@ -155,6 +156,7 @@ describe("built-in composite plugin ownership", () => {
     expect(registry.getPaneTemplatePluginId("macro-tv-pane")).toBe("macro");
     expect(registry.getPanePluginId("analytics")).toBe("portfolio");
     expect(registry.getPanePluginId("help")).toBe("application");
+    expect(registry.getPanePluginId("connections")).toBe("application");
     expect(registry.getPanePluginId("macro-tv")).toBe("macro");
     expect(registry.getCommandPluginId("earnings-monitor-shortcut")).toBe("macro");
     expect(registry.getCommandPluginId("gridlock-all")).toBe("application");

--- a/src/plugins/registry/index.ts
+++ b/src/plugins/registry/index.ts
@@ -312,7 +312,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
     if (ownedCapability.kind === "asset-data" || ownedCapability.kind === "news") {
       items.capabilityDisposers.push(this.connectionHealth.registerSource({
         id: ownedCapability.id,
-        name: ownedCapability.name,
+        name: `${ownedCapability.name} ${ownedCapability.kind === "news" ? "News" : "Market Data"}`,
         kind: ownedCapability.kind,
         ownerId: pluginId,
         priority: ownedCapability.priority,

--- a/src/plugins/registry/index.ts
+++ b/src/plugins/registry/index.ts
@@ -1,5 +1,9 @@
 import type { ReactNode } from "react";
 import type { AppPersistencePort, AppTickerRepositoryPort } from "../../core/app-service-ports";
+import {
+  connectionHealth as sharedConnectionHealth,
+  type ConnectionHealthRegistry,
+} from "../../core/connection-health";
 import type { BrokerAdapter } from "../../types/broker";
 import {
   CapabilityRegistry,
@@ -63,6 +67,7 @@ import { isReservedBuiltinPluginId } from "../ownership";
 interface PluginRegistryOptions {
   enableCapabilityHandlers?: boolean;
   wrapBrokerAdapter?: (broker: BrokerAdapter, pluginId: string) => BrokerAdapter;
+  connectionHealth?: ConnectionHealthRegistry;
 }
 
 export type WindowEditMode = "move" | "resize";
@@ -81,6 +86,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
 
   readonly events: EventBus;
   readonly capabilities: CapabilityRegistry;
+  readonly connectionHealth: ConnectionHealthRegistry;
   readonly marketData: DataProvider;
   readonly tickerRepository: AppTickerRepositoryPort;
   readonly persistence: AppPersistencePort;
@@ -113,6 +119,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
   pinTickerFn: ((symbol: string, options?: PinTickerOptions) => void) = () => {};
   navigateTickerFn: ((symbol: string, options?: { sourcePaneId?: string | null }) => void) = () => {};
   getMarketData = () => this.marketData;
+  getConnectionHealth = () => this.connectionHealth;
   getCapability = (capabilityId: string) => this.capabilities.get(capabilityId)?.capability ?? null;
   getBrokerAdapter = (brokerType: string) => this.contributions.brokersMap.get(brokerType) ?? null;
   connectBrokerInstance = (instanceId: string) => this.connectBrokerInstanceFn(instanceId);
@@ -191,6 +198,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
     options: PluginRegistryOptions = {},
   ) {
     this.marketData = marketData;
+    this.connectionHealth = options.connectionHealth ?? sharedConnectionHealth;
     this.tickerRepository = tickerRepository;
     this.persistence = persistence;
     this.enableCapabilityHandlers = options.enableCapabilityHandlers ?? true;
@@ -209,6 +217,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
         const disabledSources = this.getConfigFn().disabledSources ?? [];
         return !disabledSources.includes(capability.sourceId ?? capability.id) && !this.getConfigFn().disabledPlugins.includes(pluginId);
       },
+      connectionHealth: this.connectionHealth,
     });
     this.Slot = ({ name, ...props }: { name: keyof GloomSlots } & Record<string, unknown>) => (
       this.renderSlot(name, props as any)
@@ -300,6 +309,16 @@ export class PluginRegistry implements PluginRuntimeAccess {
     const disposeCapability = this.capabilities.register(pluginId, ownedCapability);
     this.contributions.registerCapability(pluginId, capability.id, items);
     items.capabilityDisposers.push(disposeCapability);
+    if (ownedCapability.kind === "asset-data" || ownedCapability.kind === "news") {
+      items.capabilityDisposers.push(this.connectionHealth.registerSource({
+        id: ownedCapability.id,
+        name: ownedCapability.name,
+        kind: ownedCapability.kind,
+        ownerId: pluginId,
+        priority: ownedCapability.priority,
+        detail: ownedCapability.sourceId,
+      }));
+    }
 
     if (ownedCapability.kind === "news") {
       const dispose = this.registerNewsCapabilityFn(ownedCapability as NewsCapability);
@@ -413,6 +432,7 @@ export class PluginRegistry implements PluginRuntimeAccess {
       contributions: this.contributions,
       enableCapabilityHandlers: this.enableCapabilityHandlers,
       marketData: this.marketData,
+      connectionHealth: this.connectionHealth,
       tickerRepository: this.tickerRepository,
       persistence: this.persistence,
       getLayout: () => this.getLayoutFn(),

--- a/src/plugins/runtime/context.tsx
+++ b/src/plugins/runtime/context.tsx
@@ -5,6 +5,7 @@ import {
   type ReactNode,
 } from "react";
 import type { BrokerAdapter } from "../../types/broker";
+import type { ConnectionHealthRegistry } from "../../core/connection-health";
 import type { PluginCapability } from "../../capabilities";
 import type { DataProvider } from "../../types/data-provider";
 import type {
@@ -18,6 +19,7 @@ import type {
 
 export interface PluginRuntimeAccess {
   getMarketData(): DataProvider | null;
+  getConnectionHealth(): ConnectionHealthRegistry;
   getCapability(capabilityId: string): PluginCapability | null;
   getBrokerAdapter(brokerType: string): BrokerAdapter | null;
   connectBrokerInstance(instanceId: string): Promise<void>;

--- a/src/plugins/runtime/index.tsx
+++ b/src/plugins/runtime/index.tsx
@@ -103,6 +103,11 @@ export function useAssetData(): ReturnType<PluginRuntimeAccess["getMarketData"]>
   return useMarketData();
 }
 
+export function useConnectionHealth(): ReturnType<PluginRuntimeAccess["getConnectionHealth"]> {
+  const { runtime } = usePluginRenderContext();
+  return runtime.getConnectionHealth();
+}
+
 export function usePluginBrokerActions() {
   const { runtime } = usePluginRenderContext();
   return {

--- a/src/renderers/electrobun/view/app-services.ts
+++ b/src/renderers/electrobun/view/app-services.ts
@@ -11,6 +11,7 @@ import { getRendererBuiltinPlugins } from "../../../plugins/catalog-ui";
 import { createRemoteAssetDataClient } from "./remote/asset-data-client";
 import { RemotePersistence } from "./remote/persistence";
 import { RemoteTickerRepository } from "./remote/ticker-repository";
+import { connectRemoteConnectionHealth } from "./remote/connection-health";
 
 const servicesLog = debugLog.createLogger("services");
 
@@ -26,7 +27,7 @@ export function createElectrobunAppServices({ config }: AppServicesFactoryOption
     enableCapabilityHandlers: false,
     wrapBrokerAdapter: (broker) => createRemoteBrokerAdapter(broker),
   });
-  const newsService = new NewsService();
+  const newsService = new NewsService({ connectionHealth: pluginRegistry.connectionHealth });
 
   pluginRegistry.getConfigFn = () => config;
   pluginRegistry.getLayoutFn = () => config.layout;
@@ -55,6 +56,10 @@ export function createElectrobunAppServices({ config }: AppServicesFactoryOption
   measurePerf("startup.services.news-start", () => {
     newsService.start();
   });
+  let disposeRemoteConnectionHealth = () => {};
+  const ready = Promise.all(pluginReadyPromises).then(() => {
+    disposeRemoteConnectionHealth = connectRemoteConnectionHealth(pluginRegistry.connectionHealth);
+  });
   servicesLog.info("create desktop web services complete", { pluginCount: plugins.length });
 
   return {
@@ -63,8 +68,9 @@ export function createElectrobunAppServices({ config }: AppServicesFactoryOption
     dataProvider,
     marketData,
     pluginRegistry,
-    ready: Promise.all(pluginReadyPromises).then(() => {}),
+    ready,
     destroy() {
+      disposeRemoteConnectionHealth();
       setSharedMarketDataCoordinator(null);
       setSharedNewsService(null);
       newsService.stop();

--- a/src/renderers/electrobun/view/app-services.ts
+++ b/src/renderers/electrobun/view/app-services.ts
@@ -11,7 +11,7 @@ import { getRendererBuiltinPlugins } from "../../../plugins/catalog-ui";
 import { createRemoteAssetDataClient } from "./remote/asset-data-client";
 import { RemotePersistence } from "./remote/persistence";
 import { RemoteTickerRepository } from "./remote/ticker-repository";
-import { connectRemoteConnectionHealth } from "./remote/connection-health";
+import { connectBackendConnectionHealth } from "./remote/connection-health-backend";
 
 const servicesLog = debugLog.createLogger("services");
 
@@ -56,9 +56,13 @@ export function createElectrobunAppServices({ config }: AppServicesFactoryOption
   measurePerf("startup.services.news-start", () => {
     newsService.start();
   });
-  let disposeRemoteConnectionHealth = () => {};
+  let destroyed = false;
+  let disposeRemoteConnectionHealth: (() => void) | null = null;
   const ready = Promise.all(pluginReadyPromises).then(() => {
-    disposeRemoteConnectionHealth = connectRemoteConnectionHealth(pluginRegistry.connectionHealth);
+    if (destroyed) return;
+    const dispose = connectBackendConnectionHealth(pluginRegistry.connectionHealth);
+    if (destroyed) dispose();
+    else disposeRemoteConnectionHealth = dispose;
   });
   servicesLog.info("create desktop web services complete", { pluginCount: plugins.length });
 
@@ -70,7 +74,9 @@ export function createElectrobunAppServices({ config }: AppServicesFactoryOption
     pluginRegistry,
     ready,
     destroy() {
-      disposeRemoteConnectionHealth();
+      destroyed = true;
+      disposeRemoteConnectionHealth?.();
+      disposeRemoteConnectionHealth = null;
       setSharedMarketDataCoordinator(null);
       setSharedNewsService(null);
       newsService.stop();

--- a/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
+++ b/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
@@ -2,7 +2,7 @@
 import { createRoot } from "react-dom/client";
 import { useEffect, type ComponentType, type ReactNode } from "react";
 import { AppProvider, useAppDispatch } from "../../../state/app/context";
-import { ConnectionHealthRegistry } from "../../../core/connection-health";
+import { createCliPaneShotConnectionHealth } from "./cli-pane-shot-health";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../../market-data/coordinator";
 import { instrumentFromTicker } from "../../../market-data/request-types";
 import { UiHostProvider, type RendererHost } from "../../../ui/host";
@@ -316,7 +316,7 @@ function installShotMarketData(payload: CliPaneShotPayload): void {
 
 function createRuntime(payload: CliPaneShotPayload): PluginRuntimeAccess {
   const resumeState = new Map<string, unknown>();
-  const connectionHealth = new ConnectionHealthRegistry();
+  const connectionHealth = createCliPaneShotConnectionHealth();
   function getResumeState<T = unknown>(_pluginId: string, key: string): T | null {
     return (resumeState.get(key) as T | undefined) ?? null;
   }

--- a/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
+++ b/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
@@ -2,6 +2,7 @@
 import { createRoot } from "react-dom/client";
 import { useEffect, type ComponentType, type ReactNode } from "react";
 import { AppProvider, useAppDispatch } from "../../../state/app/context";
+import { ConnectionHealthRegistry } from "../../../core/connection-health";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../../market-data/coordinator";
 import { instrumentFromTicker } from "../../../market-data/request-types";
 import { UiHostProvider, type RendererHost } from "../../../ui/host";
@@ -315,6 +316,7 @@ function installShotMarketData(payload: CliPaneShotPayload): void {
 
 function createRuntime(payload: CliPaneShotPayload): PluginRuntimeAccess {
   const resumeState = new Map<string, unknown>();
+  const connectionHealth = new ConnectionHealthRegistry();
   function getResumeState<T = unknown>(_pluginId: string, key: string): T | null {
     return (resumeState.get(key) as T | undefined) ?? null;
   }
@@ -323,6 +325,7 @@ function createRuntime(payload: CliPaneShotPayload): PluginRuntimeAccess {
   }
   return {
     getMarketData: () => shotDataProvider,
+    getConnectionHealth: () => connectionHealth,
     getCapability: () => null,
     getBrokerAdapter: () => null,
     connectBrokerInstance: async () => {},

--- a/src/renderers/electrobun/view/cli-pane-shot-health.test.ts
+++ b/src/renderers/electrobun/view/cli-pane-shot-health.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { createCliPaneShotConnectionHealth } from "./cli-pane-shot-health";
+
+describe("CLI pane shot connection health", () => {
+  test("seeds stable request, socket, and error rows", () => {
+    const sources = createCliPaneShotConnectionHealth(1_000).getSnapshot().sources;
+
+    expect(sources.map((source) => source.id)).toEqual([
+      "gloom-cloud-http",
+      "gloom-cloud-socket",
+      "asset-data.yahoo",
+    ]);
+    expect(sources.map((source) => ({
+      status: source.status,
+      operation: source.lastOperation,
+      latency: source.lastLatencyMs,
+    }))).toEqual([
+      { status: "connected", operation: "GET /market/quotes", latency: 84 },
+      { status: "connected", operation: null, latency: null },
+      { status: "error", operation: "getPriceHistory", latency: 240 },
+    ]);
+  });
+});

--- a/src/renderers/electrobun/view/cli-pane-shot-health.ts
+++ b/src/renderers/electrobun/view/cli-pane-shot-health.ts
@@ -1,0 +1,31 @@
+import {
+  ConnectionHealthRegistry,
+  GLOOM_CLOUD_HTTP_CONNECTION_ID,
+  GLOOM_CLOUD_SOCKET_CONNECTION_ID,
+  registerGloomCloudConnectionSources,
+} from "../../../core/connection-health";
+
+export function createCliPaneShotConnectionHealth(now = Date.now()): ConnectionHealthRegistry {
+  const health = new ConnectionHealthRegistry({ now: () => now });
+  registerGloomCloudConnectionSources(health);
+  health.reportRequest(GLOOM_CLOUD_HTTP_CONNECTION_ID, {
+    operation: "GET /market/quotes",
+    success: true,
+    latencyMs: 84,
+  });
+  health.reportSocketState(GLOOM_CLOUD_SOCKET_CONNECTION_ID, "open", "api.gloom.sh/cloud/ws");
+  health.registerSource({
+    id: "asset-data.yahoo",
+    name: "Yahoo Finance",
+    kind: "asset-data",
+    ownerId: "market-data",
+    priority: 20,
+  });
+  health.reportRequest("asset-data.yahoo", {
+    operation: "getPriceHistory",
+    success: false,
+    latencyMs: 240,
+    error: "Rate limited",
+  });
+  return health;
+}

--- a/src/renderers/electrobun/view/remote/connection-health-backend.ts
+++ b/src/renderers/electrobun/view/remote/connection-health-backend.ts
@@ -1,0 +1,19 @@
+import type { ConnectionHealthRegistry } from "../../../../core/connection-health";
+import { CONNECTION_HEALTH_CAPABILITY_ID } from "../../../../plugins/builtin/connections";
+import { backendRequest, onCapabilityEvent } from "../backend-rpc";
+import { connectRemoteConnectionHealth } from "./connection-health";
+
+const SUBSCRIPTION_ID = "connection-health";
+
+export function connectBackendConnectionHealth(health: ConnectionHealthRegistry): () => void {
+  return connectRemoteConnectionHealth(health, {
+    subscribe: () => backendRequest("capability.subscribe", {
+      subscriptionId: SUBSCRIPTION_ID,
+      capabilityId: CONNECTION_HEALTH_CAPABILITY_ID,
+      operationId: "subscribe",
+      payload: {},
+    }),
+    unsubscribe: () => backendRequest("capability.unsubscribe", { subscriptionId: SUBSCRIPTION_ID }),
+    onEvent: (listener) => onCapabilityEvent(SUBSCRIPTION_ID, (message) => listener(message.event)),
+  });
+}

--- a/src/renderers/electrobun/view/remote/connection-health.test.ts
+++ b/src/renderers/electrobun/view/remote/connection-health.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { ConnectionHealthRegistry } from "../../../../core/connection-health";
+import { connectRemoteConnectionHealth } from "./connection-health";
+
+describe("remote connection health bridge", () => {
+  test("disposes immediately and unsubscribes after an in-flight subscription completes", async () => {
+    let completeSubscribe!: () => void;
+    let listener: (event: unknown) => void = () => {};
+    let disposedListeners = 0;
+    let unsubscribes = 0;
+    const health = new ConnectionHealthRegistry();
+    const backend = new ConnectionHealthRegistry();
+    backend.registerSource({ id: "remote", name: "Remote", kind: "api" });
+
+    const dispose = connectRemoteConnectionHealth(health, {
+      subscribe: () => new Promise<void>((resolve) => {
+        completeSubscribe = resolve;
+      }),
+      unsubscribe: async () => {
+        unsubscribes += 1;
+      },
+      onEvent: (next) => {
+        listener = next;
+        return () => {
+          disposedListeners += 1;
+        };
+      },
+    });
+
+    listener(backend.getSnapshot());
+    expect(health.getSnapshot().sources.map((source) => source.id)).toEqual(["remote"]);
+
+    dispose();
+    listener(backend.getSnapshot());
+    expect(disposedListeners).toBe(1);
+    expect(health.getSnapshot().sources).toEqual([]);
+    expect(unsubscribes).toBe(0);
+
+    completeSubscribe();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(unsubscribes).toBe(1);
+  });
+});

--- a/src/renderers/electrobun/view/remote/connection-health.ts
+++ b/src/renderers/electrobun/view/remote/connection-health.ts
@@ -1,0 +1,40 @@
+import type {
+  ConnectionHealthRegistry,
+  ConnectionHealthSnapshot,
+} from "../../../../core/connection-health";
+import { CONNECTION_HEALTH_CAPABILITY_ID } from "../../../../plugins/builtin/connections";
+import { backendRequest, onCapabilityEvent } from "../backend-rpc";
+
+const SUBSCRIPTION_ID = "connection-health";
+
+function isSnapshot(value: unknown): value is ConnectionHealthSnapshot {
+  return !!value
+    && typeof value === "object"
+    && Array.isArray((value as ConnectionHealthSnapshot).sources)
+    && typeof (value as ConnectionHealthSnapshot).version === "number";
+}
+
+export function connectRemoteConnectionHealth(health: ConnectionHealthRegistry): () => void {
+  let disposed = false;
+  const disposeEvents = onCapabilityEvent(SUBSCRIPTION_ID, (message) => {
+    if (!disposed && isSnapshot(message.event)) {
+      health.replaceExternalSnapshot("backend", message.event);
+    }
+  });
+
+  void backendRequest("capability.subscribe", {
+    subscriptionId: SUBSCRIPTION_ID,
+    capabilityId: CONNECTION_HEALTH_CAPABILITY_ID,
+    operationId: "subscribe",
+    payload: {},
+  }).catch(() => {
+    if (!disposed) health.clearExternalSnapshot("backend");
+  });
+
+  return () => {
+    disposed = true;
+    disposeEvents();
+    health.clearExternalSnapshot("backend");
+    void backendRequest("capability.unsubscribe", { subscriptionId: SUBSCRIPTION_ID }).catch(() => {});
+  };
+}

--- a/src/renderers/electrobun/view/remote/connection-health.ts
+++ b/src/renderers/electrobun/view/remote/connection-health.ts
@@ -2,10 +2,12 @@ import type {
   ConnectionHealthRegistry,
   ConnectionHealthSnapshot,
 } from "../../../../core/connection-health";
-import { CONNECTION_HEALTH_CAPABILITY_ID } from "../../../../plugins/builtin/connections";
-import { backendRequest, onCapabilityEvent } from "../backend-rpc";
 
-const SUBSCRIPTION_ID = "connection-health";
+export interface RemoteConnectionHealthBridge {
+  subscribe(): Promise<unknown>;
+  unsubscribe(): Promise<unknown>;
+  onEvent(listener: (event: unknown) => void): () => void;
+}
 
 function isSnapshot(value: unknown): value is ConnectionHealthSnapshot {
   return !!value
@@ -14,27 +16,34 @@ function isSnapshot(value: unknown): value is ConnectionHealthSnapshot {
     && typeof (value as ConnectionHealthSnapshot).version === "number";
 }
 
-export function connectRemoteConnectionHealth(health: ConnectionHealthRegistry): () => void {
+export function connectRemoteConnectionHealth(
+  health: ConnectionHealthRegistry,
+  bridge: RemoteConnectionHealthBridge,
+): () => void {
   let disposed = false;
-  const disposeEvents = onCapabilityEvent(SUBSCRIPTION_ID, (message) => {
-    if (!disposed && isSnapshot(message.event)) {
-      health.replaceExternalSnapshot("backend", message.event);
-    }
+  let subscribed = false;
+  let unsubscribeStarted = false;
+  const unsubscribe = () => {
+    if (unsubscribeStarted) return;
+    unsubscribeStarted = true;
+    void bridge.unsubscribe().catch(() => {});
+  };
+  const disposeEvents = bridge.onEvent((event) => {
+    if (!disposed && isSnapshot(event)) health.replaceExternalSnapshot("backend", event);
   });
 
-  void backendRequest("capability.subscribe", {
-    subscriptionId: SUBSCRIPTION_ID,
-    capabilityId: CONNECTION_HEALTH_CAPABILITY_ID,
-    operationId: "subscribe",
-    payload: {},
+  void bridge.subscribe().then(() => {
+    subscribed = true;
+    if (disposed) unsubscribe();
   }).catch(() => {
     if (!disposed) health.clearExternalSnapshot("backend");
   });
 
   return () => {
+    if (disposed) return;
     disposed = true;
     disposeEvents();
     health.clearExternalSnapshot("backend");
-    void backendRequest("capability.unsubscribe", { subscriptionId: SUBSCRIPTION_ID }).catch(() => {});
+    if (subscribed) unsubscribe();
   };
 }

--- a/src/sources/provider-router/connection-health.test.ts
+++ b/src/sources/provider-router/connection-health.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { ConnectionHealthRegistry } from "../../core/connection-health";
+import type { DataProvider } from "../../types/data-provider";
+import { withProviderConnectionHealth } from "./connection-health";
+
+describe("withProviderConnectionHealth", () => {
+  test("attributes provider calls without reporting cache reads", async () => {
+    const health = new ConnectionHealthRegistry();
+    health.registerSource({ id: "asset-data.yahoo", name: "Yahoo", kind: "asset-data" });
+    const provider = withProviderConnectionHealth({
+      id: "yahoo",
+      name: "Yahoo",
+      getCachedFinancialsForTargets: () => new Map(),
+      getQuote: async () => ({ price: 1 }),
+    } as unknown as DataProvider, health);
+
+    provider.getCachedFinancialsForTargets?.([]);
+    await provider.getQuote("AAPL");
+
+    const state = health.getSnapshot().sources[0]!;
+    expect(state.lastOperation).toBe("getQuote");
+    expect(state.recentRequests).toHaveLength(1);
+  });
+});

--- a/src/sources/provider-router/connection-health.test.ts
+++ b/src/sources/provider-router/connection-health.test.ts
@@ -4,17 +4,21 @@ import type { DataProvider } from "../../types/data-provider";
 import { withProviderConnectionHealth } from "./connection-health";
 
 describe("withProviderConnectionHealth", () => {
-  test("attributes provider calls without reporting cache reads", async () => {
+  test("attributes network calls without reporting cached or static checks", async () => {
     const health = new ConnectionHealthRegistry();
     health.registerSource({ id: "asset-data.yahoo", name: "Yahoo", kind: "asset-data" });
     const provider = withProviderConnectionHealth({
       id: "yahoo",
       name: "Yahoo",
+      canProvide: () => true,
       getCachedFinancialsForTargets: () => new Map(),
+      getChartResolutionSupport: () => [],
       getQuote: async () => ({ price: 1 }),
     } as unknown as DataProvider, health);
 
+    await provider.canProvide?.("AAPL");
     provider.getCachedFinancialsForTargets?.([]);
+    await provider.getChartResolutionSupport?.("AAPL");
     await provider.getQuote("AAPL");
 
     const state = health.getSnapshot().sources[0]!;

--- a/src/sources/provider-router/connection-health.ts
+++ b/src/sources/provider-router/connection-health.ts
@@ -1,0 +1,50 @@
+import type { ConnectionHealthRegistry } from "../../core/connection-health";
+import type { DataProvider } from "../../types/data-provider";
+
+const REQUEST_METHODS = new Set([
+  "canProvide",
+  "getQuotesBatch",
+  "getTickerFinancialsBatch",
+  "getTickerFinancials",
+  "getQuote",
+  "getExchangeRate",
+  "search",
+  "getNews",
+  "getHolders",
+  "getAnalystResearch",
+  "getCorporateActions",
+  "getEarningsCalendar",
+  "getSecFilings",
+  "getSecFilingDocuments",
+  "getSecFilingContent",
+  "getArticleSummary",
+  "getPriceHistory",
+  "getPriceHistoryForResolution",
+  "getChartResolutionSupport",
+  "getChartResolutionCapabilities",
+  "getDetailedPriceHistory",
+  "getOptionsChain",
+]);
+
+/** Wraps provider calls without changing the provider object or treating router cache reads as requests. */
+export function withProviderConnectionHealth(
+  provider: DataProvider,
+  health: ConnectionHealthRegistry,
+): DataProvider {
+  const methods = new Map<PropertyKey, unknown>();
+  return new Proxy(provider, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+      if (typeof property !== "string" || typeof value !== "function") return value;
+      if (!REQUEST_METHODS.has(property)) return value.bind(target);
+      if (!methods.has(property)) {
+        methods.set(property, (...args: unknown[]) => health.track(
+          `asset-data.${provider.id}`,
+          property,
+          () => Promise.resolve(value.apply(target, args)),
+        ));
+      }
+      return methods.get(property);
+    },
+  });
+}

--- a/src/sources/provider-router/connection-health.ts
+++ b/src/sources/provider-router/connection-health.ts
@@ -2,7 +2,6 @@ import type { ConnectionHealthRegistry } from "../../core/connection-health";
 import type { DataProvider } from "../../types/data-provider";
 
 const REQUEST_METHODS = new Set([
-  "canProvide",
   "getQuotesBatch",
   "getTickerFinancialsBatch",
   "getTickerFinancials",
@@ -20,8 +19,6 @@ const REQUEST_METHODS = new Set([
   "getArticleSummary",
   "getPriceHistory",
   "getPriceHistoryForResolution",
-  "getChartResolutionSupport",
-  "getChartResolutionCapabilities",
   "getDetailedPriceHistory",
   "getOptionsChain",
 ]);

--- a/src/sources/provider-router/index.ts
+++ b/src/sources/provider-router/index.ts
@@ -1,4 +1,5 @@
 import type { ResourceStore } from "../../data/resource-store";
+import type { ConnectionHealthRegistry } from "../../core/connection-health";
 import type { PluginRegistry } from "../../plugins/registry";
 import type { BrokerAdapter } from "../../types/broker";
 import type { AppConfig } from "../../types/config";
@@ -39,6 +40,7 @@ import {
 import { ProviderRouterSearchRoutes } from "./search";
 import { collectCapabilityRouteSources, normalizeRouteSource } from "./sources";
 import type { ProviderRouterCoreDeps } from "./route-types";
+import { withProviderConnectionHealth } from "./connection-health";
 import {
   contextFromCachedTarget,
   getBrokerCandidates,
@@ -69,11 +71,13 @@ export class AssetDataRouter implements DataProvider {
   private readonly supplementalRoutes: ProviderRouterSupplementalRoutes;
   private readonly financialRoutes: ProviderRouterFinancialRoutes;
   private readonly documentRoutes: ProviderRouterDocumentRoutes;
+  private readonly healthyProviders = new WeakMap<DataProvider, DataProvider>();
 
   constructor(
     fallbackSource: CapabilityRouteSource | DataProvider | null = null,
     extraSources: Array<CapabilityRouteSource | DataProvider> = [],
     private readonly resources?: ResourceStore,
+    private readonly connectionHealth?: ConnectionHealthRegistry,
   ) {
     this.fallbackSource = fallbackSource ? normalizeRouteSource(fallbackSource) : null;
     this.extraSources = extraSources.map(normalizeRouteSource);
@@ -377,7 +381,14 @@ export class AssetDataRouter implements DataProvider {
     if (fallbackProvider && !providers.some((provider) => provider.id === fallbackProvider.id)) {
       providers.push(fallbackProvider);
     }
-    return providers;
+    if (!this.connectionHealth) return providers;
+    return providers.map((provider) => {
+      const existing = this.healthyProviders.get(provider);
+      if (existing) return existing;
+      const wrapped = withProviderConnectionHealth(provider, this.connectionHealth!);
+      this.healthyProviders.set(provider, wrapped);
+      return wrapped;
+    });
   }
 
   private newsSourcesInPriorityOrder(): CapabilityRouteSource[] {

--- a/src/test-support/plugin-runtime.ts
+++ b/src/test-support/plugin-runtime.ts
@@ -1,4 +1,5 @@
 import type { PluginRuntimeAccess } from "../plugins/runtime";
+import { ConnectionHealthRegistry } from "../core/connection-health";
 import type { AppConfig } from "../types/config";
 
 interface TestConfigAccess {
@@ -9,8 +10,10 @@ interface TestConfigAccess {
 export function createTestPluginRuntime(
   overrides: Partial<PluginRuntimeAccess> = {},
 ): PluginRuntimeAccess {
+  const connectionHealth = new ConnectionHealthRegistry();
   return {
     getMarketData: () => null,
+    getConnectionHealth: () => connectionHealth,
     getCapability: () => null,
     getBrokerAdapter: () => null,
     connectBrokerInstance: async () => {},

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import type { AppTickerRepositoryPort } from "../core/app-service-ports";
+import type { ConnectionHealthRegistry } from "../core/connection-health";
 import type { PluginEvents } from "../plugins/event-bus";
 import type { PluginLogger } from "../utils/debug-log";
 import type { BrokerAdapter } from "./broker";
@@ -526,6 +527,7 @@ export interface GloomPluginContext {
   getPaneDef(paneId: string): PaneDef | undefined;
 
   readonly marketData: DataProvider;
+  readonly connectionHealth: ConnectionHealthRegistry;
   readonly tickerRepository: AppTickerRepositoryPort;
   readonly persistence: PluginPersistence;
   readonly log: PluginLogger;


### PR DESCRIPTION
## Summary

- add an Application-owned `CONN` pane for real provider request and socket activity
- register sources explicitly through a shared connection-health service
- report bounded last-request outcomes, latency, errors, and actual WebSocket transitions
- bridge authoritative backend state into Electrobun without duplicate renderer rows
- instrument shared Cloud, provider-router, capability, and news request boundaries

## Design constraints

- no active health probes
- no login-derived or synthetic socket status
- no cache hits reported as network requests
- no Buildout, Congress Trades, or other plugin ownership changes
- request completions are generation-scoped and dropped after source disposal

## Verification

- focused registry, lifecycle, overlay, provider, socket, pane, and desktop-shot tests
- `bun run typecheck`
- `bun test` (1,956 passed)
- clean TUI smoke and seeded desktop pane shot

## Attribution

The product concept and initial Connections implementation came from @Lucas-Kohorst's [Gloomberb fork](https://github.com/Lucas-Kohorst/gloomberb). This PR rebuilds it around explicit current-upstream service boundaries.
