### PR TITLE
Harden plugin startup, updates, and persistence

### DIFF
--- a/src/app/runtime/startup.ts
+++ b/src/app/runtime/startup.ts
@@ -73,7 +73,9 @@ export function useAppStartupRuntime({
             state.config.brokerInstances,
             pluginRegistry.brokers,
           );
-        } catch {}
+        } catch (error) {
+          console.error("[startup] Failed to load persisted broker accounts:", error);
+        }
         await measurePerfAsync("startup.app.initialize-state", () => initializeAppState({
           config: state.config,
           tickerRepository,

--- a/src/app/runtime/startup.ts
+++ b/src/app/runtime/startup.ts
@@ -75,6 +75,10 @@ export function useAppStartupRuntime({
           );
         } catch (error) {
           console.error("[startup] Failed to load persisted broker accounts:", error);
+          pluginRegistry.notify({
+            body: "Failed to load saved broker account data. Check local storage permissions.",
+            type: "error",
+          });
         }
         await measurePerfAsync("startup.app.initialize-state", () => initializeAppState({
           config: state.config,

--- a/src/brokers/sync-broker-instance.test.ts
+++ b/src/brokers/sync-broker-instance.test.ts
@@ -166,6 +166,42 @@ describe("syncBrokerInstance", () => {
     ]);
   });
 
+  test("logs account cache failures without aborting the broker sync", async () => {
+    const config = {
+      ...createDefaultConfig("/tmp/gloomberb-sync-broker-persistence-error"),
+      portfolios: [],
+      brokerInstances: [createBrokerInstance()],
+    };
+    const tickerRepository = createTickerRepository();
+    const persistenceError = new Error("disk full");
+    const errors: unknown[][] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => { errors.push(args); };
+
+    try {
+      await syncBrokerInstance({
+        config,
+        instanceId: "demo-broker",
+        brokers: new Map([["demo", createDemoBroker()]]),
+        tickerRepository: tickerRepository as any,
+        resources: {
+          get: () => null,
+          list: () => [],
+          set: () => { throw persistenceError; },
+          delete: () => {},
+        } as any,
+      });
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(errors).toEqual([[
+      "[broker-sync] Failed to persist broker accounts:",
+      persistenceError,
+    ]]);
+    expect(await tickerRepository.loadTicker("AAPL")).not.toBeNull();
+  });
+
   test("imports account and position data from one broker portfolio snapshot", async () => {
     const instance = createBrokerInstance();
     const config = {

--- a/src/brokers/sync-broker-instance.test.ts
+++ b/src/brokers/sync-broker-instance.test.ts
@@ -166,40 +166,28 @@ describe("syncBrokerInstance", () => {
     ]);
   });
 
-  test("logs account cache failures without aborting the broker sync", async () => {
+  test("fails cleanly when the broker account cache cannot be persisted", async () => {
     const config = {
       ...createDefaultConfig("/tmp/gloomberb-sync-broker-persistence-error"),
       portfolios: [],
       brokerInstances: [createBrokerInstance()],
     };
     const tickerRepository = createTickerRepository();
-    const persistenceError = new Error("disk full");
-    const errors: unknown[][] = [];
-    const originalError = console.error;
-    console.error = (...args: unknown[]) => { errors.push(args); };
 
-    try {
-      await syncBrokerInstance({
-        config,
-        instanceId: "demo-broker",
-        brokers: new Map([["demo", createDemoBroker()]]),
-        tickerRepository: tickerRepository as any,
-        resources: {
-          get: () => null,
-          list: () => [],
-          set: () => { throw persistenceError; },
-          delete: () => {},
-        } as any,
-      });
-    } finally {
-      console.error = originalError;
-    }
+    await expect(syncBrokerInstance({
+      config,
+      instanceId: "demo-broker",
+      brokers: new Map([["demo", createDemoBroker()]]),
+      tickerRepository: tickerRepository as any,
+      resources: {
+        get: () => null,
+        list: () => [],
+        set: () => { throw new Error("disk full"); },
+        delete: () => {},
+      } as any,
+    })).rejects.toThrow("disk full");
 
-    expect(errors).toEqual([[
-      "[broker-sync] Failed to persist broker accounts:",
-      persistenceError,
-    ]]);
-    expect(await tickerRepository.loadTicker("AAPL")).not.toBeNull();
+    expect(await tickerRepository.loadTicker("AAPL")).toBeNull();
   });
 
   test("imports account and position data from one broker portfolio snapshot", async () => {

--- a/src/brokers/sync-broker-instance.ts
+++ b/src/brokers/sync-broker-instance.ts
@@ -280,11 +280,7 @@ export async function syncBrokerInstance({
     if (committed) return;
     throwIfBrokerImportCancelled(signal);
     if (resources) {
-      try {
-        persistBrokerAccounts(resources, instance, broker, brokerAccounts);
-      } catch (error) {
-        console.error("[broker-sync] Failed to persist broker accounts:", error);
-      }
+      persistBrokerAccounts(resources, instance, broker, brokerAccounts);
     }
     await Promise.all([...addedTickers.values(), ...updatedTickers.values()].map((ticker) => (
       tickerRepository.saveTicker(ticker)

--- a/src/brokers/sync-broker-instance.ts
+++ b/src/brokers/sync-broker-instance.ts
@@ -282,7 +282,9 @@ export async function syncBrokerInstance({
     if (resources) {
       try {
         persistBrokerAccounts(resources, instance, broker, brokerAccounts);
-      } catch {}
+      } catch (error) {
+        console.error("[broker-sync] Failed to persist broker accounts:", error);
+      }
     }
     await Promise.all([...addedTickers.values(), ...updatedTickers.values()].map((ticker) => (
       tickerRepository.saveTicker(ticker)

--- a/src/plugins/builtin/notes/files.test.ts
+++ b/src/plugins/builtin/notes/files.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { NotesFiles } from "./files";
+
+test("NotesFiles.delete ignores only missing files", async () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "gloomberb-notes-"));
+  const notes = new NotesFiles(dataDir);
+  mkdirSync(join(dataDir, "blocked.md"));
+
+  try {
+    await expect(notes.delete("missing")).resolves.toBeUndefined();
+    await expect(notes.delete("blocked")).rejects.toBeDefined();
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});

--- a/src/plugins/builtin/notes/files.ts
+++ b/src/plugins/builtin/notes/files.ts
@@ -71,8 +71,8 @@ export class NotesFiles {
   async delete(symbol: string): Promise<void> {
     try {
       await deleteTextFile(this.pathFor(symbol));
-    } catch {
-      // ignore missing files
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
   }
 

--- a/src/plugins/builtin/notes/index.tsx
+++ b/src/plugins/builtin/notes/index.tsx
@@ -16,7 +16,10 @@ export const notesPlugin: GloomPlugin = {
     const QuickNotesPane = createQuickNotesPane(notesFiles);
 
     ctx.on("ticker:removed", ({ symbol }) => {
-      notesFiles.delete(symbol).catch(() => {});
+      notesFiles.delete(symbol).catch((error) => {
+        console.error("[notes] Failed to delete ticker note:", error);
+        ctx.notify({ body: "Failed to delete note. Check disk space and permissions.", type: "error" });
+      });
     });
 
     ctx.registerTickerResearchTab({

--- a/src/plugins/builtin/notes/quick-notes-pane.test.tsx
+++ b/src/plugins/builtin/notes/quick-notes-pane.test.tsx
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { act, useState } from "react";
 import { PaneFooterProvider } from "../../../components/layout/pane/footer";
 import { TestDialogProvider, testRender } from "../../../renderers/opentui/test-utils";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
 import { Box, Text } from "../../../ui";
+import { PluginRenderProvider } from "../../runtime";
 import { createQuickNotesPane } from "./quick-notes-pane";
 import type { NotesFiles } from "./files";
 import type { QuickNoteEntry } from "./model";
@@ -56,16 +58,18 @@ function QuickNotesHarness({
 
   return (
     <TestDialogProvider>
-      <Box flexDirection="column" width={80} height={24}>
-        <PaneFooterProvider>
-          {() => (
-            <>
-              <QuickNotesPane focused={focused} width={78} height={20} />
-              <Text onMouseDown={() => setFocused(false)}>blur-pane</Text>
-            </>
-          )}
-        </PaneFooterProvider>
-      </Box>
+      <PluginRenderProvider pluginId="notes" runtime={createTestPluginRuntime()}>
+        <Box flexDirection="column" width={80} height={24}>
+          <PaneFooterProvider>
+            {() => (
+              <>
+                <QuickNotesPane focused={focused} width={78} height={20} />
+                <Text onMouseDown={() => setFocused(false)}>blur-pane</Text>
+              </>
+            )}
+          </PaneFooterProvider>
+        </Box>
+      </PluginRenderProvider>
     </TestDialogProvider>
   );
 }

--- a/src/plugins/builtin/notes/quick-notes-pane.tsx
+++ b/src/plugins/builtin/notes/quick-notes-pane.tsx
@@ -6,6 +6,7 @@ import { colors } from "../../../theme/colors";
 import { MarkdownEditor } from "../../../components/markdown-editor";
 import { ConfirmDialog, Tabs, usePaneFooter } from "../../../components";
 import { type PromptContext, useDialog } from "../../../ui/dialog";
+import { usePluginAppActions } from "../../runtime";
 import type { NotesFiles } from "./files";
 import { MarkdownNotePreview } from "./markdown-note-preview";
 import {
@@ -19,6 +20,7 @@ import { useSyncedText } from "./text-state";
 export function createQuickNotesPane(notesFiles: NotesFiles) {
   return function QuickNotesPane({ focused, width }: PaneProps) {
     const dialog = useDialog();
+    const { notify } = usePluginAppActions();
     const textareaRef = useRef<TextareaRenderable | null>(null);
     const [editing, setEditing] = useState(false);
     const [tabs, setTabs] = useState<QuickNoteEntry[]>([]);
@@ -34,8 +36,11 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
     const activeTab = tabs.find((tab) => tab.id === activeTabId);
 
     const saveQuickNotesIndex = useCallback((entries: QuickNoteEntry[]) => {
-      notesFiles.saveQuickNotesIndex(entries).catch(() => {});
-    }, [notesFiles]);
+      notesFiles.saveQuickNotesIndex(entries).catch((error) => {
+        console.error("[notes] Failed to save notes index:", error);
+        notify({ body: "Failed to save notes index. Check disk space and permissions.", type: "error" });
+      });
+    }, [notesFiles, notify]);
 
     const readActiveNoteText = useCallback(() => (
       textareaRef.current?.editBuffer.getText() ?? noteTextRef.current
@@ -57,7 +62,10 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
       if (lastSavedTextRef.current.get(tabId) === text) return;
 
       lastSavedTextRef.current.set(tabId, text);
-      notesFiles.save(notesFiles.quickNoteKey(tabId), text).catch(() => {});
+      notesFiles.save(notesFiles.quickNoteKey(tabId), text).catch((error) => {
+        console.error("[notes] Failed to save note:", error);
+        notify({ body: "Failed to save note. Check disk space and permissions.", type: "error" });
+      });
 
       const updatedAt = Date.now();
       setTabs((prev) => {
@@ -66,7 +74,7 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
         saveQuickNotesIndex(next);
         return next;
       });
-    }, [activeTabId, noteTextRef, notesFiles, readActiveNoteText, saveQuickNotesIndex]);
+    }, [activeTabId, noteTextRef, notesFiles, notify, readActiveNoteText, saveQuickNotesIndex]);
 
     useEffect(() => {
       if (loadedRef.current) return;
@@ -161,10 +169,13 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
         }
         return next;
       });
-      notesFiles.delete(notesFiles.quickNoteKey(id)).catch(() => {});
+      notesFiles.delete(notesFiles.quickNoteKey(id)).catch((error) => {
+        console.error("[notes] Failed to delete note:", error);
+        notify({ body: "Failed to delete note. Check disk space and permissions.", type: "error" });
+      });
       setEditing(false);
       setRenaming(false);
-    }, [activeTabId, notesFiles, saveQuickNotesIndex, setNoteText]);
+    }, [activeTabId, notesFiles, notify, saveQuickNotesIndex, setNoteText]);
 
     const requestRemoveTab = useCallback(async (id: string) => {
       const tab = tabs.find((entry) => entry.id === id);
@@ -222,11 +233,11 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
       }
       setTabs((prev) => {
         const next = prev.map((t) => (t.id === activeTabId ? { ...t, title: value } : t));
-        notesFiles.saveQuickNotesIndex(next).catch(() => {});
+        saveQuickNotesIndex(next);
         return next;
       });
       setRenaming(false);
-    }, [activeTabId, notesFiles, renameValue]);
+    }, [activeTabId, renameValue, saveQuickNotesIndex]);
 
     useShortcut((event) => {
       if (!focused) return;

--- a/src/plugins/builtin/notes/ticker-notes-tab.test.tsx
+++ b/src/plugins/builtin/notes/ticker-notes-tab.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { act, useReducer, useState } from "react";
 import { PaneFooterProvider } from "../../../components/layout/pane/footer";
 import { TestDialogProvider, testRender } from "../../../renderers/opentui/test-utils";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
 import {
   AppContext,
   PaneInstanceProvider,
@@ -11,6 +12,7 @@ import {
 import { cloneLayout, createDefaultConfig } from "../../../types/config";
 import type { TickerRecord } from "../../../types/ticker";
 import { Box, Text } from "../../../ui";
+import { PluginRenderProvider, type PluginRuntimeAccess } from "../../runtime";
 import { createNotesTab } from "./ticker-notes-tab";
 import type { NotesFiles } from "./files";
 
@@ -37,6 +39,7 @@ function makeTicker(symbol: string): TickerRecord {
 function createMockNotesFiles(options?: {
   loadDelayMs?: number;
   notes?: Record<string, string>;
+  saveError?: Error;
 }) {
   const saves: Array<{ symbol: string; text: string }> = [];
   const notes = new Map(Object.entries(options?.notes ?? {}));
@@ -51,6 +54,7 @@ function createMockNotesFiles(options?: {
     },
     async save(symbol: string, text: string) {
       saves.push({ symbol, text });
+      if (options?.saveError) throw options.saveError;
     },
     async delete() {},
     quickNoteKey(id: string) {
@@ -86,9 +90,11 @@ function createNotesHarnessConfig(symbol: string) {
 function NotesTabHarness({
   NotesTab,
   initialSymbol,
+  runtime = createTestPluginRuntime(),
 }: {
   NotesTab: ReturnType<typeof createNotesTab>;
   initialSymbol: string;
+  runtime?: PluginRuntimeAccess;
 }) {
   const [focused, setFocused] = useState(true);
   const [state, dispatch] = useReducer(appReducer, undefined, () => {
@@ -120,20 +126,22 @@ function NotesTabHarness({
       <Box flexDirection="column" width={80} height={24}>
         <AppContext value={{ state, dispatch }}>
           <PaneInstanceProvider paneId={TEST_PANE_ID}>
-            <PaneFooterProvider>
-              {() => (
-                <>
-                  <NotesTab
-                    width={78}
-                    height={20}
-                    focused={focused}
-                    onCapture={() => {}}
-                  />
-                  <Text onMouseDown={() => setFocused(false)}>blur-tab</Text>
-                  <Text onMouseDown={() => switchSymbol("MSFT")}>switch-msft</Text>
-                </>
-              )}
-            </PaneFooterProvider>
+            <PluginRenderProvider pluginId="notes" runtime={runtime}>
+              <PaneFooterProvider>
+                {() => (
+                  <>
+                    <NotesTab
+                      width={78}
+                      height={20}
+                      focused={focused}
+                      onCapture={() => {}}
+                    />
+                    <Text onMouseDown={() => setFocused(false)}>blur-tab</Text>
+                    <Text onMouseDown={() => switchSymbol("MSFT")}>switch-msft</Text>
+                  </>
+                )}
+              </PaneFooterProvider>
+            </PluginRenderProvider>
           </PaneInstanceProvider>
         </AppContext>
       </Box>
@@ -151,12 +159,16 @@ afterEach(async () => {
 });
 
 describe("createNotesTab", () => {
-  test("exits edit mode and saves when the tab loses focus", async () => {
-    const notesFiles = createMockNotesFiles();
+  test("surfaces a save failure when the tab loses focus", async () => {
+    const notifications: string[] = [];
+    const notesFiles = createMockNotesFiles({ saveError: new Error("disk full") });
     const NotesTab = createNotesTab(notesFiles);
+    const runtime = createTestPluginRuntime({
+      notify: ({ body }) => { notifications.push(body); },
+    });
 
     testSetup = await testRender(
-      <NotesTabHarness NotesTab={NotesTab} initialSymbol="AAPL" />,
+      <NotesTabHarness NotesTab={NotesTab} initialSymbol="AAPL" runtime={runtime} />,
       { width: 80, height: 24 },
     );
     await testSetup.renderOnce();
@@ -184,12 +196,20 @@ describe("createNotesTab", () => {
     const blurCol = frame.split("\n")[blurRow]?.indexOf("blur-tab") ?? -1;
     expect(blurRow).toBeGreaterThanOrEqual(0);
 
-    await act(async () => {
-      await testSetup!.mockMouse.click(blurCol + 1, blurRow);
-      await testSetup!.renderOnce();
-    });
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      await act(async () => {
+        await testSetup!.mockMouse.click(blurCol + 1, blurRow);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        await testSetup!.renderOnce();
+      });
+    } finally {
+      console.error = originalError;
+    }
 
     expect(notesFiles.saves).toEqual([{ symbol: "AAPL", text: "ab" }]);
+    expect(notifications).toEqual(["Failed to save note. Check disk space and permissions."]);
   });
 
   test("does not save stale buffer text to a new ticker before its notes load", async () => {

--- a/src/plugins/builtin/notes/ticker-notes-tab.tsx
+++ b/src/plugins/builtin/notes/ticker-notes-tab.tsx
@@ -6,6 +6,7 @@ import { usePaneTicker } from "../../../state/app/context";
 import { colors } from "../../../theme/colors";
 import { MarkdownEditor } from "../../../components/markdown-editor";
 import { usePaneFooter } from "../../../components";
+import { usePluginAppActions } from "../../runtime";
 import type { NotesFiles } from "./files";
 import { MarkdownNotePreview } from "./markdown-note-preview";
 import { useSyncedText } from "./text-state";
@@ -13,6 +14,7 @@ import { useSyncedText } from "./text-state";
 export function createNotesTab(notesFiles: NotesFiles) {
   return function NotesTab({ focused, width, onCapture }: TickerResearchTabProps) {
     const { ticker } = usePaneTicker();
+    const { notify } = usePluginAppActions();
     const textareaRef = useRef<TextareaRenderable | null>(null);
     const [notesFocused, setNotesFocused] = useState(false);
     const { text: noteText, textRef: noteTextRef, setText: setNoteText } = useSyncedText("");
@@ -57,8 +59,11 @@ export function createNotesTab(notesFiles: NotesFiles) {
       // rewrites an unchanged file and can clobber another pane on the same symbol.
       if (lastSavedTextRef.current.get(symbol) === text) return;
       lastSavedTextRef.current.set(symbol, text);
-      notesFiles.save(symbol, text).catch(() => {});
-    }, [notesFiles]);
+      notesFiles.save(symbol, text).catch((error) => {
+        console.error("[notes] Failed to save ticker note:", error);
+        notify({ body: "Failed to save note. Check disk space and permissions.", type: "error" });
+      });
+    }, [notesFiles, notify]);
 
     useEffect(() => {
       if (

--- a/src/plugins/builtin/plugin-module.test.ts
+++ b/src/plugins/builtin/plugin-module.test.ts
@@ -55,8 +55,10 @@ describe("composeBuiltinPlugin", () => {
     plugin.dispose?.();
   });
 
-  test("disposes initialized and partially initialized modules in reverse order", async () => {
+  test("isolates setup failures and disposes every started module in reverse order", async () => {
     const lifecycle: string[] = [];
+    const errors: unknown[][] = [];
+    const originalError = console.error;
     const plugin = composeBuiltinPlugin({
       id: "parent",
       name: "Parent",
@@ -73,15 +75,27 @@ describe("composeBuiltinPlugin", () => {
           },
           dispose: () => { lifecycle.push("dispose:second"); },
         },
+        {
+          setup: () => { lifecycle.push("setup:third"); },
+          dispose: () => { lifecycle.push("dispose:third"); },
+        },
       ],
     });
 
-    await expect(plugin.setup?.(context())).rejects.toThrow("setup failed");
+    console.error = (...args: unknown[]) => { errors.push(args); };
+    try {
+      await plugin.setup?.(context());
+    } finally {
+      console.error = originalError;
+    }
     plugin.dispose?.();
 
+    expect(errors[0]?.[0]).toBe('[plugins] Module setup failed in plugin "parent":');
     expect(lifecycle).toEqual([
       "setup:first",
       "setup:second",
+      "setup:third",
+      "dispose:third",
       "dispose:second",
       "dispose:first",
     ]);

--- a/src/plugins/builtin/plugin-module.ts
+++ b/src/plugins/builtin/plugin-module.ts
@@ -96,7 +96,11 @@ export function composeBuiltinPlugin(options: CompositePluginOptions): GloomPlug
       }
       for (const module of modules) {
         startedModules.push(module);
-        await module.setup?.(ctx);
+        try {
+          await module.setup?.(ctx);
+        } catch (error) {
+          console.error(`[plugins] Module setup failed in plugin "${metadata.id}":`, error);
+        }
       }
     },
 

--- a/src/renderers/electrobun/bun/core-capabilities.ts
+++ b/src/renderers/electrobun/bun/core-capabilities.ts
@@ -225,8 +225,8 @@ async function writeTextEnsuringParent(path: string, value: string): Promise<voi
 async function deleteFileIfPresent(path: string): Promise<void> {
   try {
     await unlink(path);
-  } catch {
-    // ignore missing files
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
 }
 

--- a/src/time-series/alignment.ts
+++ b/src/time-series/alignment.ts
@@ -80,11 +80,23 @@ export function alignTimeSeries(
   const exactMaps = series.map((entry) => (
     new Map(entry.points.map((point) => [effectiveTimeSeriesPointTime(point), point]))
   ));
+  const carryPoints = series.map((entry) => [...entry.points].sort((left, right) => (
+    effectiveTimeSeriesPointTime(left) - effectiveTimeSeriesPointTime(right)
+  )));
   const sortedTimes = [...timeline].sort((left, right) => left - right);
+  const carryPointers = new Array<number>(series.length).fill(-1);
   const rows: AlignedTimeSeriesRow[] = [];
   for (const time of sortedTimes) {
     const values: Record<string, AlignedSeriesValue | null> = {};
     series.forEach((entry, seriesIndex) => {
+      const points = carryPoints[seriesIndex]!;
+      let pointer = carryPointers[seriesIndex]!;
+      while (
+        pointer + 1 < points.length
+        && effectiveTimeSeriesPointTime(points[pointer + 1]!) <= time
+      ) pointer += 1;
+      carryPointers[seriesIndex] = pointer;
+
       const exact = exactMaps[seriesIndex]!.get(time);
       if (exact) {
         values[entry.id] = { point: exact, value: scalarPointValue(exact), carried: false };
@@ -96,20 +108,12 @@ export function alignTimeSeries(
         return;
       }
 
-      let previous: TimeSeriesPoint | null = null;
-      let previousEligibleAt = Number.NEGATIVE_INFINITY;
-      for (const point of entry.points) {
-        const eligibleAt = effectiveTimeSeriesPointTime(point);
-        if (eligibleAt <= time && eligibleAt >= previousEligibleAt) {
-          previous = point;
-          previousEligibleAt = eligibleAt;
-        }
-      }
-      if (!previous) {
+      if (pointer < 0) {
         values[entry.id] = null;
         return;
       }
-      const age = time - previousEligibleAt;
+      const previous = points[pointer]!;
+      const age = time - effectiveTimeSeriesPointTime(previous);
       if (options.maxCarryMilliseconds !== undefined && age > options.maxCarryMilliseconds) {
         values[entry.id] = null;
         return;

--- a/src/time-series/fundamentals.ts
+++ b/src/time-series/fundamentals.ts
@@ -240,11 +240,10 @@ function mergeStatementsByPeriod(
   const groups: InternalStatement[][] = [];
   const sorted = [...statements].sort((left, right) => left.date.localeCompare(right.date));
   for (const statement of sorted) {
-    const group = groups.find((candidate) => (
-      areNearbyFinancialPeriodEnds(candidate[0]!.date, statement.date)
-    ));
-    if (group) group.push(statement as InternalStatement);
-    else groups.push([statement as InternalStatement]);
+    const lastGroup = groups.at(-1);
+    if (lastGroup && areNearbyFinancialPeriodEnds(lastGroup[0]!.date, statement.date)) {
+      lastGroup.push(statement as InternalStatement);
+    } else groups.push([statement as InternalStatement]);
   }
   return groups
     .map(mergeStatementPeriodGroup)
@@ -767,11 +766,10 @@ function dedupeFundamentalPeriods(points: readonly TimeSeriesPoint[]): TimeSerie
     left.observedAt.getTime() - right.observedAt.getTime()
   ));
   for (const point of sorted) {
-    const group = groups.find((candidate) => (
-      areNearbyFinancialPeriodEnds(candidate[0]!.observedAt, point.observedAt)
-    ));
-    if (group) group.push(point);
-    else groups.push([point]);
+    const lastGroup = groups.at(-1);
+    if (lastGroup && areNearbyFinancialPeriodEnds(lastGroup[0]!.observedAt, point.observedAt)) {
+      lastGroup.push(point);
+    } else groups.push([point]);
   }
   return groups
     .map((group) => group.slice(1).reduce(preferredPeriodPoint, group[0]!))

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -3,7 +3,7 @@ import type { FredSeriesData, FredSeriesLoadResult } from "../data/fred-series";
 import { createTestDataProvider } from "../test-support/data-provider";
 import type { TickerFinancials } from "../types/financials";
 import { CHART_SPEC_VERSION, type ChartSpec } from "./types";
-import { ChartResolveCache, resolveChartSpecData } from "./resolve";
+import { ChartResolveCache, mergePriceHistoryWindows, resolveChartSpecData } from "./resolve";
 import { chartQuoteOverrideKeyForSource } from "./live-quotes";
 
 const emptyFinancials = (): TickerFinancials => ({
@@ -1749,5 +1749,55 @@ describe("resolveChartSpecData", () => {
     });
     expect(result.series.find((series) => series.id === "sma")?.points.map((point) => point.value))
       .toEqual([10]);
+  });
+});
+
+describe("mergePriceHistoryWindows", () => {
+  const legacyMerge = (
+    current: TickerFinancials["priceHistory"],
+    incoming: TickerFinancials["priceHistory"],
+    resolution: "1h" | "1d",
+  ) => {
+    const byTimestamp = new Map<number, TickerFinancials["priceHistory"][number]>();
+    for (const point of [...current, ...incoming]) {
+      const timestamp = point.date.getTime();
+      if (Number.isFinite(timestamp)) byTimestamp.set(timestamp, point);
+    }
+    const sorted = [...byTimestamp.values()].sort((left, right) => left.date.getTime() - right.date.getTime());
+    if (resolution === "1h") return sorted;
+    const plotted = new Set(current.map((point) => point.date.getTime()));
+    const merged: TickerFinancials["priceHistory"] = [];
+    for (const point of sorted) {
+      const previous = merged.at(-1);
+      if (!previous || point.date.getTime() - previous.date.getTime() >= 86_400_000 * 0.8) {
+        merged.push(point);
+      } else if (!plotted.has(previous.date.getTime()) && plotted.has(point.date.getTime())) {
+        merged[merged.length - 1] = point;
+      }
+    }
+    return merged;
+  };
+
+  test("linear merge matches the prior merge for overlaps, duplicates, and unsorted fallback", () => {
+    const point = (date: string, close: number) => ({ date: new Date(date), close });
+    const sortedCurrent = [
+      point("2026-07-28T13:30:00Z", 110),
+      point("2026-07-29T13:30:00Z", 115),
+      point("2026-07-29T13:30:00Z", 116),
+      point("2026-07-30T13:30:00Z", 120),
+    ];
+    const incoming = [
+      point("2026-07-27T22:00:00Z", 111),
+      point("2026-07-29T13:30:00Z", 999),
+      point("2026-07-29T22:00:00Z", 121),
+    ];
+
+    for (const current of [sortedCurrent, [...sortedCurrent].reverse()]) {
+      for (const resolution of ["1h", "1d"] as const) {
+        expect(mergePriceHistoryWindows(current, incoming, resolution)).toEqual(
+          legacyMerge(current, incoming, resolution),
+        );
+      }
+    }
   });
 });

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -350,24 +350,70 @@ function emptyFinancials(priceHistory: TickerFinancials["priceHistory"] = []): T
   return { annualStatements: [], quarterlyStatements: [], priceHistory };
 }
 
-function mergePriceHistoryWindows(
+function isSortedPriceHistory(points: TickerFinancials["priceHistory"]): boolean {
+  let previous = Number.NEGATIVE_INFINITY;
+  for (const point of points) {
+    const timestamp = getPricePointTimestamp(point);
+    if (!Number.isFinite(timestamp)) continue;
+    if (timestamp < previous) return false;
+    previous = timestamp;
+  }
+  return true;
+}
+
+export function mergePriceHistoryWindows(
   current: TickerFinancials["priceHistory"],
   incoming: TickerFinancials["priceHistory"],
   resolution: ManualChartResolution,
 ): TickerFinancials["priceHistory"] {
-  const byTimestamp = new Map<number, TickerFinancials["priceHistory"][number]>();
-  for (const point of [...current, ...incoming]) {
-    const timestamp = getPricePointTimestamp(point);
-    if (Number.isFinite(timestamp)) {
-      byTimestamp.set(
-        timestamp,
-        point.date instanceof Date ? point : { ...point, date: new Date(timestamp) },
-      );
+  let sorted: TickerFinancials["priceHistory"];
+  if (!isSortedPriceHistory(current) || !isSortedPriceHistory(incoming)) {
+    const byTimestamp = new Map<number, TickerFinancials["priceHistory"][number]>();
+    for (const point of [...current, ...incoming]) {
+      const timestamp = getPricePointTimestamp(point);
+      if (Number.isFinite(timestamp)) {
+        byTimestamp.set(
+          timestamp,
+          point.date instanceof Date ? point : { ...point, date: new Date(timestamp) },
+        );
+      }
+    }
+    sorted = [...byTimestamp.values()].sort(
+      (left, right) => getPricePointTimestamp(left) - getPricePointTimestamp(right),
+    );
+  } else {
+    sorted = [];
+    let currentIndex = 0;
+    let incomingIndex = 0;
+    const append = (
+      point: TickerFinancials["priceHistory"][number],
+      timestamp: number,
+    ) => {
+      const normalized = point.date instanceof Date ? point : { ...point, date: new Date(timestamp) };
+      const previous = sorted.at(-1);
+      if (previous && getPricePointTimestamp(previous) === timestamp) sorted[sorted.length - 1] = normalized;
+      else sorted.push(normalized);
+    };
+
+    while (currentIndex < current.length || incomingIndex < incoming.length) {
+      const currentPoint = current[currentIndex];
+      const incomingPoint = incoming[incomingIndex];
+      const currentTimestamp = currentPoint ? getPricePointTimestamp(currentPoint) : Number.POSITIVE_INFINITY;
+      const incomingTimestamp = incomingPoint ? getPricePointTimestamp(incomingPoint) : Number.POSITIVE_INFINITY;
+      if (currentPoint && !Number.isFinite(currentTimestamp)) {
+        currentIndex += 1;
+      } else if (incomingPoint && !Number.isFinite(incomingTimestamp)) {
+        incomingIndex += 1;
+      } else if (currentPoint && currentTimestamp <= incomingTimestamp) {
+        append(currentPoint, currentTimestamp);
+        currentIndex += 1;
+      } else if (incomingPoint) {
+        append(incomingPoint, incomingTimestamp);
+        incomingIndex += 1;
+      }
     }
   }
-  const sorted = [...byTimestamp.values()].sort(
-    (left, right) => getPricePointTimestamp(left) - getPricePointTimestamp(right),
-  );
+
   if (isIntradayResolution(resolution)) return sorted;
   // Windows can be served by different sources, and they stamp the same session
   // differently: local midnight, UTC midnight, or the opening bell. Keying on the

--- a/src/time-series/transforms.test.ts
+++ b/src/time-series/transforms.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { alignTimeSeries } from "./alignment";
+import { alignTimeSeries, effectiveTimeSeriesPointTime } from "./alignment";
 import { extractPriceSeries } from "./market";
 import { applySeriesTransform } from "./transforms";
 import type { ResolvedSeries, TimeSeriesPoint } from "./types";
@@ -61,6 +61,51 @@ describe("series transformations", () => {
     expect(values[1]).toBe(0);
     expect(values[2]).toBeCloseTo(1, 12);
   });
+
+  test("binary reference lookup matches the prior linear scan", () => {
+    const start = Date.parse("2021-01-01T00:00:00Z");
+    const points = Array.from({ length: 800 }, (_, index) => (
+      point(new Date(start + index * 3 * 86_400_000).toISOString().slice(0, 10), index + 10)
+    ));
+    const expected = points.map((current, currentIndex) => {
+      const target = new Date(current.observedAt);
+      const originalDay = target.getUTCDate();
+      target.setUTCDate(1);
+      target.setUTCMonth(target.getUTCMonth() - 12);
+      target.setUTCDate(Math.min(originalDay, new Date(Date.UTC(
+        target.getUTCFullYear(),
+        target.getUTCMonth() + 1,
+        0,
+      )).getUTCDate()));
+      const reference = points.slice(0, currentIndex)
+        .map((candidate, index) => ({
+          candidate,
+          index,
+          distance: Math.abs(candidate.observedAt.getTime() - target.getTime()),
+        }))
+        .filter(({ candidate, distance }) => (
+          candidate.observedAt < current.observedAt && distance <= 62 * 86_400_000
+        ))
+        .sort((left, right) => (
+          left.distance - right.distance
+          || right.candidate.observedAt.getTime() - left.candidate.observedAt.getTime()
+          || left.index - right.index
+        ))[0]?.candidate;
+      return reference ? ((current.value! - reference.value!) / Math.abs(reference.value!)) * 100 : null;
+    });
+
+    expect(applySeriesTransform(points, "yoy").map(({ value }) => value)).toEqual(expected);
+  });
+
+  test("preserves point-in-time lookup when publication order differs from observation order", () => {
+    const points = [
+      { ...point("2023-01-01", 100), date: new Date("2023-03-01T00:00:00Z") },
+      { ...point("2020-01-01", 50), date: new Date("2023-04-01T00:00:00Z") },
+      { ...point("2024-01-01", 200), date: new Date("2024-03-01T00:00:00Z") },
+    ];
+
+    expect(applySeriesTransform(points, "yoy").at(-1)?.value).toBe(100);
+  });
 });
 
 describe("market aggregation", () => {
@@ -89,6 +134,36 @@ describe("mixed-frequency alignment", () => {
     const rows = alignTimeSeries([sparse], { timeline: dates });
     expect(rows.map((row) => row.values.fundamental?.value ?? null)).toEqual([null, null, null, 40, 40]);
     expect(rows[3]?.values.fundamental?.carried).toBe(false);
+  });
+
+  test("moving carry pointers match a full scan when availability is out of order", () => {
+    const points = [
+      point("2024-01-01", 1, "2024-01-10"),
+      point("2024-01-02", 2, "2024-01-05"),
+      point("2024-01-03", 3),
+    ];
+    const timeline = ["2024-01-01", "2024-01-03", "2024-01-04", "2024-01-05", "2024-01-06", "2024-01-10"]
+      .map((date) => new Date(`${date}T00:00:00Z`));
+    const rows = alignTimeSeries([series("fundamental", points, "step-after")], { timeline });
+    const exact = new Map(points.map((entry) => [effectiveTimeSeriesPointTime(entry), entry]));
+    const expected = timeline.map((date) => {
+      const time = date.getTime();
+      const exactPoint = exact.get(time);
+      if (exactPoint) return [exactPoint.value, false];
+      const previous = points.reduce<TimeSeriesPoint | null>((best, candidate) => {
+        const candidateTime = effectiveTimeSeriesPointTime(candidate);
+        return candidateTime <= time
+          && (!best || candidateTime >= effectiveTimeSeriesPointTime(best))
+          ? candidate
+          : best;
+      }, null);
+      return previous ? [previous.value, true] : [null, null];
+    });
+
+    expect(rows.map((row) => {
+      const value = row.values.fundamental;
+      return value ? [value.value, value.carried] : [null, null];
+    })).toEqual(expected);
   });
 
   test("intersection keeps only timestamps where every series has a usable value", () => {

--- a/src/time-series/transforms.ts
+++ b/src/time-series/transforms.ts
@@ -54,23 +54,51 @@ function referencePoint(
   currentIndex: number,
   months: number,
   toleranceDays: number,
+  observationsSorted: boolean,
 ): TimeSeriesPoint | null {
   const current = points[currentIndex];
   if (!current) return null;
   const currentTime = current.observedAt.getTime();
   const target = shiftUtcMonths(current.observedAt, months).getTime();
-  let best: { point: TimeSeriesPoint; distance: number; date: number } | null = null;
-  for (let index = 0; index < currentIndex; index += 1) {
+  const maxDistance = toleranceDays * DAY_MS;
+  let best: { point: TimeSeriesPoint; distance: number; date: number; index: number } | null = null;
+  const consider = (index: number) => {
     const candidate = points[index]!;
     const candidateTime = candidate.observedAt.getTime();
-    if (!Number.isFinite(candidateTime) || candidateTime >= currentTime) continue;
+    if (candidateTime >= currentTime) return;
     const distance = Math.abs(candidateTime - target);
-    if (distance > toleranceDays * DAY_MS) continue;
-    if (!best || distance < best.distance || (distance === best.distance && candidateTime > best.date)) {
-      best = { point: candidate, distance, date: candidateTime };
+    if (distance > maxDistance) return;
+    if (
+      !best
+      || distance < best.distance
+      || (distance === best.distance && candidateTime > best.date)
+      || (distance === best.distance && candidateTime === best.date && index < best.index)
+    ) {
+      best = { point: candidate, distance, date: candidateTime, index };
     }
+  };
+
+  if (!observationsSorted) {
+    for (let index = 0; index < currentIndex; index += 1) consider(index);
+    return (best as { point: TimeSeriesPoint } | null)?.point ?? null;
   }
-  return best?.point ?? null;
+
+  let low = 0;
+  let high = currentIndex;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (points[middle]!.observedAt.getTime() < target) low = middle + 1;
+    else high = middle;
+  }
+  for (let index = low - 1; index >= 0; index -= 1) {
+    if (target - points[index]!.observedAt.getTime() > maxDistance) break;
+    consider(index);
+  }
+  for (let index = low; index < currentIndex; index += 1) {
+    if (points[index]!.observedAt.getTime() - target > maxDistance) break;
+    consider(index);
+  }
+  return (best as { point: TimeSeriesPoint } | null)?.point ?? null;
 }
 
 function mapNumericFields(
@@ -124,8 +152,11 @@ export function applySeriesTransform(
 
   const months = transform === "yoy" ? 12 : 3;
   const toleranceDays = transform === "yoy" ? 62 : 46;
+  const observationsSorted = points.every((point, index) => (
+    index === 0 || points[index - 1]!.observedAt.getTime() <= point.observedAt.getTime()
+  ));
   return points.map((point, index) => {
-    const reference = referencePoint(points, index, months, toleranceDays);
+    const reference = referencePoint(points, index, months, toleranceDays, observationsSorted);
     if (!reference) return mapNumericFields(point, () => null);
     return mapNumericFields(point, (value, field) => growthValue(value, reference[field]));
   });

--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -294,6 +294,36 @@ describe("checkForUpdateDetailed", () => {
       Object.defineProperty(process, "argv", { value: originalArgv, configurable: true });
     }
   });
+
+  test.each([
+    ["missing", undefined],
+    ["malformed", "sha256:not-a-checksum"],
+  ])("rejects release assets with a %s digest", async (_label, digest) => {
+    const originalExecPath = process.execPath;
+    const originalArgv = process.argv;
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      tag_name: "v0.3.2",
+      published_at: "2026-04-03T00:00:00Z",
+      assets: [{
+        name: expectedAssetName(),
+        browser_download_url: "https://example.com/gloomberb",
+        ...(digest ? { digest } : {}),
+      }],
+    }), { status: 200 })) as typeof fetch;
+
+    try {
+      Object.defineProperty(process, "execPath", { value: "/Applications/gloomberb", configurable: true });
+      Object.defineProperty(process, "argv", { value: ["/Applications/gloomberb"], configurable: true });
+
+      await expect(checkForUpdateDetailed("0.3.1")).resolves.toEqual({
+        kind: "error",
+        error: expect.stringContaining("valid SHA-256 digest"),
+      });
+    } finally {
+      Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });
+      Object.defineProperty(process, "argv", { value: originalArgv, configurable: true });
+    }
+  });
 });
 
 describe("performUpdate", () => {
@@ -354,28 +384,24 @@ describe("performUpdate", () => {
     }
   });
 
-  it("decompresses gzipped assets without a digest for release compatibility", async () => {
+  test.each([
+    ["missing", undefined],
+    ["malformed", "not-a-checksum"],
+  ])("leaves the installed binary untouched when the checksum is %s", async (_label, checksum) => {
     const originalExecPath = process.execPath;
     const originalArgv = process.argv;
     const tempDir = mkdtempSync(join(tmpdir(), "gloomberb-update-"));
     const execPath = join(tempDir, "gloomberb");
-    const nextBinary = Buffer.from("new-binary");
-    const payload = gzipSync(nextBinary);
+    const oldBinary = Buffer.from("old-binary");
     const progress: UpdateProgress[] = [];
 
-    writeFileSync(execPath, Buffer.from("old-binary"));
+    writeFileSync(execPath, oldBinary);
     chmodSync(execPath, 0o755);
-    globalThis.fetch = (async () => new Response(payload, {
-      status: 200,
-      headers: { "content-length": String(payload.length) },
-    })) as typeof fetch;
+    globalThis.fetch = (async () => new Response(gzipSync("new-binary"), { status: 200 })) as typeof fetch;
 
     try {
       Object.defineProperty(process, "execPath", { value: execPath, configurable: true });
-      Object.defineProperty(process, "argv", {
-        value: [execPath],
-        configurable: true,
-      });
+      Object.defineProperty(process, "argv", { value: [execPath], configurable: true });
 
       await performUpdate({
         version: "9.9.9",
@@ -384,14 +410,14 @@ describe("performUpdate", () => {
         publishedAt: "2026-04-03T00:00:00Z",
         updateAction: { kind: "self" },
         compressed: true,
-      }, (entry) => {
-        progress.push(entry);
-      });
+        ...(checksum ? { checksum } : {}),
+      }, (entry) => { progress.push(entry); });
 
-      expect(readFileSync(execPath)).toEqual(nextBinary);
-      expect(progress[0]).toEqual({ phase: "downloading", percent: 0 });
-      expect(progress).toContainEqual({ phase: "downloading", percent: 100 });
-      expect(progress.at(-1)).toEqual({ phase: "done" });
+      expect(readFileSync(execPath)).toEqual(oldBinary);
+      expect(progress.at(-1)).toEqual({
+        phase: "error",
+        error: "Self-update requires a valid SHA-256 checksum.",
+      });
     } finally {
       Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });
       Object.defineProperty(process, "argv", { value: originalArgv, configurable: true });

--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, test } from "bun:test";
+import { createHash } from "crypto";
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -241,6 +242,7 @@ describe("checkForUpdate", () => {
       assets: [{
         name: expectedAssetName(true),
         browser_download_url: "https://example.com/gloomberb.gz",
+        digest: `sha256:${"ab".repeat(32)}`,
       }],
     }), {
       status: 200,
@@ -261,6 +263,7 @@ describe("checkForUpdate", () => {
         publishedAt: "2026-04-03T00:00:00Z",
         updateAction: { kind: "self" },
         compressed: true,
+        checksum: "ab".repeat(32),
       });
     } finally {
       Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });
@@ -351,7 +354,7 @@ describe("performUpdate", () => {
     }
   });
 
-  it("decompresses gzipped release assets before replacing the binary", async () => {
+  it("decompresses gzipped assets without a digest for release compatibility", async () => {
     const originalExecPath = process.execPath;
     const originalArgv = process.argv;
     const tempDir = mkdtempSync(join(tmpdir(), "gloomberb-update-"));
@@ -389,6 +392,78 @@ describe("performUpdate", () => {
       expect(progress[0]).toEqual({ phase: "downloading", percent: 0 });
       expect(progress).toContainEqual({ phase: "downloading", percent: 100 });
       expect(progress.at(-1)).toEqual({ phase: "done" });
+    } finally {
+      Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });
+      Object.defineProperty(process, "argv", { value: originalArgv, configurable: true });
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("replaces the binary when the downloaded asset checksum matches", async () => {
+    const originalExecPath = process.execPath;
+    const originalArgv = process.argv;
+    const tempDir = mkdtempSync(join(tmpdir(), "gloomberb-update-"));
+    const execPath = join(tempDir, "gloomberb");
+    const nextBinary = Buffer.from("verified-binary");
+    const checksum = createHash("sha256").update(nextBinary).digest("hex");
+    const progress: UpdateProgress[] = [];
+
+    writeFileSync(execPath, Buffer.from("old-binary"));
+    chmodSync(execPath, 0o755);
+    globalThis.fetch = (async () => new Response(nextBinary, { status: 200 })) as typeof fetch;
+
+    try {
+      Object.defineProperty(process, "execPath", { value: execPath, configurable: true });
+      Object.defineProperty(process, "argv", { value: [execPath], configurable: true });
+
+      await performUpdate({
+        version: "9.9.9",
+        tagName: "v9.9.9",
+        downloadUrl: "https://example.com/gloomberb",
+        publishedAt: "2026-04-03T00:00:00Z",
+        updateAction: { kind: "self" },
+        checksum,
+      }, (entry) => { progress.push(entry); });
+
+      expect(readFileSync(execPath)).toEqual(nextBinary);
+      expect(progress.at(-1)).toEqual({ phase: "done" });
+    } finally {
+      Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });
+      Object.defineProperty(process, "argv", { value: originalArgv, configurable: true });
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves the installed binary untouched when the checksum mismatches", async () => {
+    const originalExecPath = process.execPath;
+    const originalArgv = process.argv;
+    const tempDir = mkdtempSync(join(tmpdir(), "gloomberb-update-"));
+    const execPath = join(tempDir, "gloomberb");
+    const oldBinary = Buffer.from("old-binary");
+    const progress: UpdateProgress[] = [];
+
+    writeFileSync(execPath, oldBinary);
+    chmodSync(execPath, 0o755);
+    globalThis.fetch = (async () => new Response("tampered", { status: 200 })) as typeof fetch;
+
+    try {
+      Object.defineProperty(process, "execPath", { value: execPath, configurable: true });
+      Object.defineProperty(process, "argv", { value: [execPath], configurable: true });
+
+      await performUpdate({
+        version: "9.9.9",
+        tagName: "v9.9.9",
+        downloadUrl: "https://example.com/gloomberb",
+        publishedAt: "2026-04-03T00:00:00Z",
+        updateAction: { kind: "self" },
+        checksum: "00".repeat(32),
+      }, (entry) => { progress.push(entry); });
+
+      expect(readFileSync(execPath)).toEqual(oldBinary);
+      expect(progress.at(-1)).toEqual(expect.objectContaining({
+        phase: "error",
+        error: expect.stringContaining("Checksum mismatch"),
+      }));
     } finally {
       Object.defineProperty(process, "execPath", { value: originalExecPath, configurable: true });
       Object.defineProperty(process, "argv", { value: originalArgv, configurable: true });

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -11,6 +11,8 @@ export interface ReleaseInfo {
   publishedAt: string;
   updateAction: UpdateAction;
   compressed?: boolean;
+  /** SHA-256 of the downloaded GitHub release asset. */
+  checksum?: string;
 }
 
 export interface UpdateProgress {
@@ -70,18 +72,24 @@ function getAssetBaseName(): string {
   return getAssetBaseNameForRuntime();
 }
 
+function parseAssetDigest(digest: string | undefined): string | undefined {
+  return /^sha256:([a-f\d]{64})$/i.exec(digest ?? "")?.[1]?.toLowerCase();
+}
+
 function resolveReleaseAsset(
-  assets: { name: string; browser_download_url: string }[],
-): { name: string; browser_download_url: string; compressed: boolean } | null {
+  assets: { name: string; browser_download_url: string; digest?: string }[],
+): { name: string; browser_download_url: string; compressed: boolean; checksum?: string } | null {
   const assetBaseName = getAssetBaseName();
   const gzAsset = assets.find((asset) => asset.name === `${assetBaseName}.gz`);
   if (gzAsset) {
-    return { ...gzAsset, compressed: true };
+    const { name, browser_download_url, digest } = gzAsset;
+    return { name, browser_download_url, compressed: true, checksum: parseAssetDigest(digest) };
   }
 
   const rawAsset = assets.find((asset) => asset.name === assetBaseName);
   if (rawAsset) {
-    return { ...rawAsset, compressed: false };
+    const { name, browser_download_url, digest } = rawAsset;
+    return { name, browser_download_url, compressed: false, checksum: parseAssetDigest(digest) };
   }
 
   return null;
@@ -249,7 +257,7 @@ export async function checkForUpdateDetailed(
     const data = (await res.json()) as {
       tag_name: string;
       published_at: string;
-      assets: { name: string; browser_download_url: string }[];
+      assets: { name: string; browser_download_url: string; digest?: string }[];
     };
 
     const version = data.tag_name.replace(/^v/, "");
@@ -274,6 +282,7 @@ export async function checkForUpdateDetailed(
         publishedAt: data.published_at,
         updateAction,
         compressed: asset.compressed,
+        ...(asset.checksum ? { checksum: asset.checksum } : {}),
       },
     };
   } catch (error: unknown) {
@@ -339,6 +348,7 @@ export async function performUpdate(
   try {
     const fsModulePath = "fs";
     const zlibModulePath = "zlib";
+    const cryptoModulePath = "crypto";
     const {
       renameSync,
       unlinkSync,
@@ -346,6 +356,7 @@ export async function performUpdate(
     } = await import(fsModulePath) as typeof import("fs");
     unlinkUpdatePath = unlinkSync;
     const { gunzipSync } = await import(zlibModulePath) as typeof import("zlib");
+    const { createHash } = await import(cryptoModulePath) as typeof import("crypto");
 
     onProgress({ phase: "downloading", percent: 0 });
 
@@ -377,6 +388,12 @@ export async function performUpdate(
     for (const chunk of chunks) {
       downloaded.set(chunk, offset);
       offset += chunk.byteLength;
+    }
+    if (release.checksum) {
+      const actual = createHash("sha256").update(downloaded).digest("hex");
+      if (actual !== release.checksum) {
+        throw new Error(`Checksum mismatch: expected ${release.checksum}, got ${actual}`);
+      }
     }
     const nextBinary = release.compressed
       ? new Uint8Array(gunzipSync(downloaded))

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -272,6 +272,12 @@ export async function checkForUpdateDetailed(
         error: `No compatible release asset found for ${getAssetBaseName()}`,
       };
     }
+    if (!asset.checksum) {
+      return {
+        kind: "error",
+        error: `Release asset ${asset.name} is missing a valid SHA-256 digest`,
+      };
+    }
 
     return {
       kind: "available",
@@ -341,6 +347,12 @@ export async function performUpdate(
     return;
   }
 
+  const checksum = /^[a-f\d]{64}$/i.exec(release.checksum ?? "")?.[0].toLowerCase();
+  if (!checksum) {
+    onProgress({ phase: "error", error: "Self-update requires a valid SHA-256 checksum." });
+    return;
+  }
+
   const updatePath = execPath + ".update";
   const oldPath = execPath + ".old";
   let unlinkUpdatePath: ((path: string) => void) | null = null;
@@ -389,11 +401,9 @@ export async function performUpdate(
       downloaded.set(chunk, offset);
       offset += chunk.byteLength;
     }
-    if (release.checksum) {
-      const actual = createHash("sha256").update(downloaded).digest("hex");
-      if (actual !== release.checksum) {
-        throw new Error(`Checksum mismatch: expected ${release.checksum}, got ${actual}`);
-      }
+    const actual = createHash("sha256").update(downloaded).digest("hex");
+    if (actual !== checksum) {
+      throw new Error(`Checksum mismatch: expected ${checksum}, got ${actual}`);
     }
     const nextBinary = release.compressed
       ? new Uint8Array(gunzipSync(downloaded))


### PR DESCRIPTION
## Summary

- isolate built-in plugin module setup so one failure does not remove sibling modules
- verify GitHub release SHA-256 digests before replacing self-update binaries
- make core time-series scans and merges linear while preserving mixed-source daily-bar deduplication
- surface notes and broker persistence failures instead of silently reporting success

## Scope

This deliberately excludes plugin ownership changes, UI redesign, chart renderer changes, and release metadata.

## Verification

- focused plugin, updater, time-series, notes, and broker tests
- `bun run typecheck`
- `bun test` (1,951 passed)
- TUI startup smoke

## Attribution

Ports and adapts work first developed in [Lucas-Kohorst/gloomberb](https://github.com/Lucas-Kohorst/gloomberb), particularly the updater, time-series, and persistence hardening commits. Credit to @Lucas-Kohorst for the original implementation and investigation.
