### PR TITLE
Polish pane reuse and workspace shortcuts

### DIFF
--- a/src/app/global-shortcuts.test.tsx
+++ b/src/app/global-shortcuts.test.tsx
@@ -247,6 +247,19 @@ describe("useAppGlobalShortcuts", () => {
     expect(event.propagationStopped).toBe(true);
   });
 
+  test("consumes primary-modifier numbers with only one layout", async () => {
+    const actions: AppAction[] = [];
+    const config = createDefaultConfig("/tmp/gloomberb-global-shortcuts-one-layout");
+    const state = { ...createInitialState(config), commandBarOpen: true };
+    await renderHarness(state, createRegistry(), (action) => actions.push(action));
+
+    const event = await emitKeypress({ name: "1", super: true });
+
+    expect(actions).toEqual([]);
+    expect(event.defaultPrevented).toBe(true);
+    expect(event.propagationStopped).toBe(true);
+  });
+
   test("consumes layout numbers while an editable field owns the keyboard", async () => {
     const actions: AppAction[] = [];
     await renderHarness(layoutState("layouts-editable"), createRegistry(), (action) => actions.push(action));

--- a/src/app/global-shortcuts.test.tsx
+++ b/src/app/global-shortcuts.test.tsx
@@ -100,6 +100,14 @@ async function renderHarness(
   });
 }
 
+/** The OpenTUI input host derives `targetEditable` from the focused editor. */
+function focusEditor() {
+  Object.defineProperty(testSetup!.renderer, "currentFocusedEditor", {
+    configurable: true,
+    get: () => ({}),
+  });
+}
+
 async function emitKeypress(event: {
   name?: string;
   ctrl?: boolean;
@@ -222,7 +230,9 @@ describe("useAppGlobalShortcuts", () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
-  test("ignores layout numbers while the command bar is open", async () => {
+  // Leaving the digit unclaimed lets the desktop webview treat Cmd-digit as its
+  // own browser tab shortcut, which navigates the app away.
+  test("consumes layout numbers while the command bar is open without switching", async () => {
     const actions: AppAction[] = [];
     await renderHarness(
       layoutState("layouts-command-bar", { commandBarOpen: true }),
@@ -233,7 +243,20 @@ describe("useAppGlobalShortcuts", () => {
     const event = await emitKeypress({ name: "2", ctrl: true });
 
     expect(actions).toEqual([]);
-    expect(event.defaultPrevented).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+    expect(event.propagationStopped).toBe(true);
+  });
+
+  test("consumes layout numbers while an editable field owns the keyboard", async () => {
+    const actions: AppAction[] = [];
+    await renderHarness(layoutState("layouts-editable"), createRegistry(), (action) => actions.push(action));
+    focusEditor();
+
+    const event = await emitKeypress({ name: "2", super: true });
+
+    expect(actions).toEqual([]);
+    expect(event.defaultPrevented).toBe(true);
+    expect(event.propagationStopped).toBe(true);
   });
 
   test("does not run plain plugin shortcuts while input is captured", async () => {

--- a/src/app/global-shortcuts.test.tsx
+++ b/src/app/global-shortcuts.test.tsx
@@ -100,12 +100,20 @@ async function renderHarness(
   });
 }
 
-async function emitKeypress(event: { name?: string; ctrl?: boolean; meta?: boolean; super?: boolean; shift?: boolean }) {
+async function emitKeypress(event: {
+  name?: string;
+  ctrl?: boolean;
+  meta?: boolean;
+  super?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+}) {
   const keyEvent = {
     ctrl: false,
     meta: false,
     super: false,
     option: false,
+    alt: false,
     shift: false,
     eventType: "press",
     repeated: false,
@@ -168,23 +176,64 @@ describe("useAppGlobalShortcuts", () => {
     expect(event.propagationStopped).toBe(true);
   });
 
-  test("switches saved layouts with Ctrl-number and consumes the shortcut", async () => {
-    const actions: AppAction[] = [];
-    const config = createDefaultConfig("/tmp/gloomberb-global-shortcuts-layouts");
+  function layoutState(suffix: string, options: { commandBarOpen?: boolean } = {}) {
+    const config = createDefaultConfig(`/tmp/gloomberb-global-shortcuts-${suffix}`);
     config.layouts = [
       { name: "One", layout: cloneLayout(config.layout) },
       { name: "Two", layout: cloneLayout(config.layout) },
       { name: "Three", layout: cloneLayout(config.layout) },
     ];
     config.activeLayoutIndex = 0;
-    const state = createInitialState(config);
-    await renderHarness(state, createRegistry(), (action) => actions.push(action));
+    return { ...createInitialState(config), ...options };
+  }
+
+  test("switches saved layouts with Ctrl-number and consumes the shortcut", async () => {
+    const actions: AppAction[] = [];
+    await renderHarness(layoutState("layouts"), createRegistry(), (action) => actions.push(action));
 
     const event = await emitKeypress({ name: "2", ctrl: true });
 
     expect(actions).toEqual([{ type: "SWITCH_LAYOUT", index: 1 }]);
     expect(event.defaultPrevented).toBe(true);
     expect(event.propagationStopped).toBe(true);
+  });
+
+  // Browsers and the desktop webview report Cmd as meta; the OpenTUI host maps
+  // the kitty `super` modifier onto the same field.
+  test("switches saved layouts with the Cmd-number reported by web and kitty hosts", async () => {
+    const actions: AppAction[] = [];
+    await renderHarness(layoutState("layouts-meta"), createRegistry(), (action) => actions.push(action));
+
+    const event = await emitKeypress({ name: "3", super: true });
+
+    expect(actions).toEqual([{ type: "SWITCH_LAYOUT", index: 2 }]);
+    expect(event.defaultPrevented).toBe(true);
+    expect(event.propagationStopped).toBe(true);
+  });
+
+  // Alt-digit keeps its terminal meaning; only the primary modifier switches.
+  test("ignores Alt-number", async () => {
+    const actions: AppAction[] = [];
+    await renderHarness(layoutState("layouts-alt"), createRegistry(), (action) => actions.push(action));
+
+    const event = await emitKeypress({ name: "2", alt: true });
+
+    expect(actions).toEqual([]);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("ignores layout numbers while the command bar is open", async () => {
+    const actions: AppAction[] = [];
+    await renderHarness(
+      layoutState("layouts-command-bar", { commandBarOpen: true }),
+      createRegistry(),
+      (action) => actions.push(action),
+    );
+
+    const event = await emitKeypress({ name: "2", ctrl: true });
+
+    expect(actions).toEqual([]);
+    expect(event.defaultPrevented).toBe(false);
   });
 
   test("does not run plain plugin shortcuts while input is captured", async () => {

--- a/src/app/global-shortcuts.ts
+++ b/src/app/global-shortcuts.ts
@@ -48,6 +48,27 @@ export function useAppGlobalShortcuts({
       return;
     }
 
+    // Terminals send Ctrl; the browser and the desktop webview send Cmd on
+    // macOS, which the OpenTUI host also reports as `super` under the kitty
+    // protocol. Alt stays out so Alt-digit keeps its terminal meaning. While a
+    // dialog, the command bar or an editable field owns the keyboard the digit
+    // must not move layouts, but it still has to be swallowed there or the
+    // webview hands Cmd-digit to the browser's own tab switcher.
+    if (!isDetachedWindow
+      && /^[1-9]$/.test(event.name ?? "")
+      && (event.ctrl || event.meta || event.super)
+      && (state.config.layouts ?? []).length > 1) {
+      const layouts = state.config.layouts ?? [];
+      const idx = parseInt(event.name!, 10) - 1;
+      const uiOwnsKeyboard = dialogOpen || state.commandBarOpen || event.targetEditable === true;
+      if (!uiOwnsKeyboard && idx < layouts.length && idx !== state.config.activeLayoutIndex) {
+        dispatch({ type: "SWITCH_LAYOUT", index: idx });
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
     if (dialogOpen) return;
 
     if (!isDetachedWindow && (
@@ -74,23 +95,6 @@ export function useAppGlobalShortcuts({
     const hasShortcutModifier = event.ctrl || event.meta || event.super || event.alt;
 
     if (state.commandBarOpen) return;
-
-    // Terminals send Ctrl; the browser and the desktop webview send Cmd on
-    // macOS, which the OpenTUI host also reports as `super` under the kitty
-    // protocol. Alt stays out so Alt-digit keeps its terminal meaning.
-    if (!isDetachedWindow
-      && /^[1-9]$/.test(event.name ?? "")
-      && (event.ctrl || event.meta || event.super)
-      && (state.config.layouts ?? []).length > 1) {
-      const idx = parseInt(event.name!, 10) - 1;
-      const layouts = state.config.layouts ?? [];
-      if (idx < layouts.length && idx !== state.config.activeLayoutIndex) {
-        dispatch({ type: "SWITCH_LAYOUT", index: idx });
-      }
-      event.preventDefault();
-      event.stopPropagation();
-      return;
-    }
 
     if (event.name === "tab") {
       const paneOrder = getVisiblePaneCycleOrder(

--- a/src/app/global-shortcuts.ts
+++ b/src/app/global-shortcuts.ts
@@ -70,7 +70,18 @@ export function useAppGlobalShortcuts({
       });
       return;
     }
-    if (!isDetachedWindow && /^[1-9]$/.test(event.name ?? "") && event.ctrl && (state.config.layouts ?? []).length > 1) {
+
+    const hasShortcutModifier = event.ctrl || event.meta || event.super || event.alt;
+
+    if (state.commandBarOpen) return;
+
+    // Terminals send Ctrl; the browser and the desktop webview send Cmd on
+    // macOS, which the OpenTUI host also reports as `super` under the kitty
+    // protocol. Alt stays out so Alt-digit keeps its terminal meaning.
+    if (!isDetachedWindow
+      && /^[1-9]$/.test(event.name ?? "")
+      && (event.ctrl || event.meta || event.super)
+      && (state.config.layouts ?? []).length > 1) {
       const idx = parseInt(event.name!, 10) - 1;
       const layouts = state.config.layouts ?? [];
       if (idx < layouts.length && idx !== state.config.activeLayoutIndex) {
@@ -80,10 +91,6 @@ export function useAppGlobalShortcuts({
       event.stopPropagation();
       return;
     }
-
-    const hasShortcutModifier = event.ctrl || event.meta || event.super || event.alt;
-
-    if (state.commandBarOpen) return;
 
     if (event.name === "tab") {
       const paneOrder = getVisiblePaneCycleOrder(

--- a/src/app/global-shortcuts.ts
+++ b/src/app/global-shortcuts.ts
@@ -56,8 +56,7 @@ export function useAppGlobalShortcuts({
     // webview hands Cmd-digit to the browser's own tab switcher.
     if (!isDetachedWindow
       && /^[1-9]$/.test(event.name ?? "")
-      && (event.ctrl || event.meta || event.super)
-      && (state.config.layouts ?? []).length > 1) {
+      && (event.ctrl || event.meta || event.super)) {
       const layouts = state.config.layouts ?? [];
       const idx = parseInt(event.name!, 10) - 1;
       const uiOwnsKeyboard = dialogOpen || state.commandBarOpen || event.targetEditable === true;

--- a/src/components/command-bar/routes/root/results.ts
+++ b/src/components/command-bar/routes/root/results.ts
@@ -13,6 +13,7 @@ import {
 } from "../../assist/model";
 import { matchPrefix, type Command } from "../../commands/registry";
 import { isCollectionCommand } from "../../helpers";
+import { dedupeById } from "../../view-model";
 import type { ResultItem } from "../../list/model";
 import type { parseRootShortcutIntent } from "./shortcuts";
 import type { CommandBarRoute } from "../../workflow/types";
@@ -157,12 +158,7 @@ export function buildRootResultModel(options: RootResultModelOptions): RootResul
         includePromptableTickerTemplates: true,
       })
       : [];
-    const seenItemIds = new Set<string>();
-    for (const item of [...templateItems, ...relatedTemplateItems]) {
-      if (seenItemIds.has(item.id)) continue;
-      seenItemIds.add(item.id);
-      items.push(item);
-    }
+    items.push(...templateItems, ...relatedTemplateItems);
   } else if (
     rootShortcutIntent.kind !== "none"
     && rootShortcutIntent.source === "plugin-command"
@@ -234,5 +230,5 @@ export function buildRootResultModel(options: RootResultModelOptions): RootResul
     ? buildAssistResultItems({ ...assist, query: rootQuery })
     : [];
 
-  return { items: [...assistItems, ...items], initialIdx };
+  return { items: dedupeById([...assistItems, ...items]), initialIdx };
 }

--- a/src/components/command-bar/view-model.ts
+++ b/src/components/command-bar/view-model.ts
@@ -4,6 +4,23 @@ import { truncateToDisplayWidth } from "../../utils/format";
 
 export { rankTickerSearchItems } from "../../tickers/search";
 
+/**
+ * Drop repeats of an id, keeping the first. The root list is assembled from
+ * overlapping sources (pane shortcuts, commands, plugin commands, ticker
+ * actions, layout items) in priority order, so the first hit is the one whose
+ * category and detail fit best.
+ */
+export function dedupeById<T extends { id: string }>(items: T[]): T[] {
+  const seen = new Set<string>();
+  const result: T[] = [];
+  for (const item of items) {
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    result.push(item);
+  }
+  return result;
+}
+
 export type CommandBarMode = "default" | "search" | "themes" | "plugins" | "layout" | "direct-command";
 
 export interface CommandBarModeInfo {

--- a/src/components/command-bar/workflow/ops.test.ts
+++ b/src/components/command-bar/workflow/ops.test.ts
@@ -122,6 +122,92 @@ describe("createPaneTemplateOrThrow", () => {
   });
 });
 
+describe("createPaneTemplateOrThrow pane reuse", () => {
+  async function runTemplate(
+    spec: Record<string, unknown>,
+    existing: Array<Record<string, unknown>>,
+  ): Promise<{ focused: string[]; created: number }> {
+    const config = createDefaultConfig("/tmp/gloomberb-workflow-ops-reuse");
+    const layout = cloneLayout(config.layout);
+    layout.instances = existing as never;
+    const state = createInitialState({ ...config, layout });
+    const focused: string[] = [];
+    let created = 0;
+
+    await createPaneTemplateOrThrow("template", undefined, {
+      dataProvider: makeDataProvider() as any,
+      tickerRepository: makeTickerRepository() as any,
+      dispatch: () => {},
+      getState: () => state,
+      pluginRegistry: {
+        paneTemplates: new Map([
+          ["template", {
+            id: "template",
+            paneId: "chat",
+            label: "Chat",
+            description: "Chat",
+            createInstance: () => spec,
+          }],
+        ]),
+        panes: new Map([["chat", { id: "chat", name: "Chat", component: () => null }]]),
+        getPaneTemplatePluginId: () => undefined,
+        focusPaneFn: (paneId: string) => focused.push(paneId),
+        events: { emit: () => {} },
+      } as any,
+      buildPaneInstance: () => {
+        created += 1;
+        return { instanceId: "chat:new", paneId: "chat" } as any;
+      },
+      placePaneInstance: () => {},
+    });
+
+    return { focused, created };
+  }
+
+  test("focuses the instance a stable id owns even after its settings drifted", async () => {
+    const result = await runTemplate(
+      { instanceId: "chat:general", settings: { channelId: "general" } },
+      [{ instanceId: "chat:general", paneId: "chat", settings: { channelId: "random" } }],
+    );
+
+    expect(result.focused).toEqual(["chat:general"]);
+    expect(result.created).toBe(0);
+  });
+
+  test("keeps a different stable id on its own pane", async () => {
+    const result = await runTemplate(
+      { instanceId: "chat:trading", settings: { channelId: "trading" } },
+      [{ instanceId: "chat:general", paneId: "chat", settings: { channelId: "general" } }],
+    );
+
+    expect(result.focused).toEqual([]);
+    expect(result.created).toBe(1);
+  });
+
+  test("reuses an unkeyed template only on an equivalent spec, ignoring settings key order", async () => {
+    const existing = [{
+      instanceId: "chat:stored",
+      paneId: "chat",
+      binding: { kind: "fixed", symbol: "AAPL" },
+      settings: { limit: 10, channelId: "general" },
+    }];
+
+    const same = await runTemplate(
+      { binding: { kind: "fixed", symbol: "AAPL" }, settings: { channelId: "general", limit: 10 } },
+      existing,
+    );
+    expect(same.focused).toEqual(["chat:stored"]);
+    expect(same.created).toBe(0);
+
+    const different = await runTemplate(
+      { binding: { kind: "fixed", symbol: "MSFT" }, settings: { channelId: "general", limit: 10 } },
+      existing,
+    );
+    expect(different.focused).toEqual([]);
+    expect(different.created).toBe(1);
+  });
+});
+
 describe("applyPaneSettingFieldValue", () => {
   test("lets a pane map derived setting fields back to its canonical settings object", async () => {
     const config = createDefaultConfig("/tmp/gloomberb-workflow-ops-test");

--- a/src/components/command-bar/workflow/ops.test.ts
+++ b/src/components/command-bar/workflow/ops.test.ts
@@ -126,13 +126,20 @@ describe("createPaneTemplateOrThrow pane reuse", () => {
   async function runTemplate(
     spec: Record<string, unknown>,
     existing: Array<Record<string, unknown>>,
-  ): Promise<{ focused: string[]; created: number }> {
+  ): Promise<{
+    focused: string[];
+    created: number;
+    createdWith: Record<string, unknown> | null;
+    layouts: LayoutConfig[];
+  }> {
     const config = createDefaultConfig("/tmp/gloomberb-workflow-ops-reuse");
     const layout = cloneLayout(config.layout);
     layout.instances = existing as never;
     const state = createInitialState({ ...config, layout });
     const focused: string[] = [];
+    const layouts: LayoutConfig[] = [];
     let created = 0;
+    let createdWith: Record<string, unknown> | null = null;
 
     await createPaneTemplateOrThrow("template", undefined, {
       dataProvider: makeDataProvider() as any,
@@ -152,26 +159,69 @@ describe("createPaneTemplateOrThrow pane reuse", () => {
         panes: new Map([["chat", { id: "chat", name: "Chat", component: () => null }]]),
         getPaneTemplatePluginId: () => undefined,
         focusPaneFn: (paneId: string) => focused.push(paneId),
+        updateLayoutFn: (next: LayoutConfig) => {
+          layouts.push(next);
+          state.config.layout = next;
+        },
         events: { emit: () => {} },
       } as any,
-      buildPaneInstance: () => {
+      buildPaneInstance: (_paneType: string, options?: Record<string, unknown>) => {
         created += 1;
+        createdWith = options ?? null;
         return { instanceId: "chat:new", paneId: "chat" } as any;
       },
       placePaneInstance: () => {},
     });
 
-    return { focused, created };
+    return { focused, created, createdWith, layouts };
   }
 
-  test("focuses the instance a stable id owns even after its settings drifted", async () => {
+  // The pane rewrites its own channelId as the user switches channels inside it,
+  // so reuse has to move it back onto the requested channel before focusing.
+  test("retargets the instance a stable id owns when its persisted channel drifted", async () => {
     const result = await runTemplate(
-      { instanceId: "chat:general", settings: { channelId: "general" } },
-      [{ instanceId: "chat:general", paneId: "chat", settings: { channelId: "random" } }],
+      { instanceId: "chat:general", title: "#general", settings: { channelId: "general" } },
+      [{
+        instanceId: "chat:general",
+        paneId: "chat",
+        title: "#random",
+        settings: { channelId: "random", fontScale: 2 },
+      }],
     );
 
     expect(result.focused).toEqual(["chat:general"]);
     expect(result.created).toBe(0);
+    expect(findPaneInstance(result.layouts[0]!, "chat:general")).toMatchObject({
+      title: "#general",
+      settings: { channelId: "general", fontScale: 2 },
+    });
+  });
+
+  test("focuses a matching stable-id pane without rewriting the layout", async () => {
+    const result = await runTemplate(
+      { instanceId: "chat:general", title: "#general", settings: { channelId: "general" } },
+      [{
+        instanceId: "chat:general",
+        paneId: "chat",
+        title: "#general",
+        settings: { channelId: "general" },
+      }],
+    );
+
+    expect(result.focused).toEqual(["chat:general"]);
+    expect(result.layouts).toEqual([]);
+  });
+
+  test("never focuses another pane type holding the same stable id", async () => {
+    const result = await runTemplate(
+      { instanceId: "chat:general", settings: { channelId: "general" } },
+      [{ instanceId: "chat:general", paneId: "notes", settings: { channelId: "general" } }],
+    );
+
+    expect(result.focused).toEqual([]);
+    expect(result.created).toBe(1);
+    // Reusing the taken id would put two panes on one instance id.
+    expect(result.createdWith).toMatchObject({ instanceId: undefined });
   });
 
   test("keeps a different stable id on its own pane", async () => {

--- a/src/components/command-bar/workflow/ops.ts
+++ b/src/components/command-bar/workflow/ops.ts
@@ -91,26 +91,45 @@ function stableKey(value: unknown): string {
 
 /**
  * Find the pane a template would otherwise duplicate. A template that owns a
- * stable instance id (Chat keys one pane per channel) claims that instance
- * even after its settings drifted at runtime; everything else has to match the
- * whole create spec, so a different ticker, collection or setting still opens
- * its own pane.
+ * stable instance id (Chat keys one pane per channel) claims that instance even
+ * after its settings drifted at runtime, as long as the id still belongs to the
+ * same kind of pane; everything else has to match the whole create spec, so a
+ * different ticker, collection or setting still opens its own pane.
  */
 function findReusablePaneInstance(
   instances: PaneInstanceConfig[],
   paneId: string,
   spec: PaneTemplateInstanceConfig,
-): string | null {
+): PaneInstanceConfig | null {
   if (spec.instanceId) {
-    return instances.some((instance) => instance.instanceId === spec.instanceId)
-      ? spec.instanceId
-      : null;
+    const owner = instances.find((instance) => instance.instanceId === spec.instanceId);
+    return owner?.paneId === paneId ? owner : null;
   }
   const specKey = stableKey([spec.binding ?? { kind: "none" }, spec.params ?? {}, spec.settings ?? {}]);
   return instances.find((instance) => (
     instance.paneId === paneId
     && stableKey([instance.binding ?? { kind: "none" }, instance.params ?? {}, instance.settings ?? {}]) === specKey
-  ))?.instanceId ?? null;
+  )) ?? null;
+}
+
+/**
+ * A stable-id pane outlives the spec that opened it (Chat rewrites its own
+ * channelId as the user switches channels inside the pane), so reuse has to put
+ * the pane back on the requested spec before focusing it, or the command lands
+ * on a pane showing something else. Returns null when nothing has to change.
+ */
+function retargetPaneInstance(
+  instance: PaneInstanceConfig,
+  spec: PaneTemplateInstanceConfig,
+): PaneInstanceConfig | null {
+  const next: PaneInstanceConfig = {
+    ...instance,
+    title: spec.title ?? instance.title,
+    binding: spec.binding ?? instance.binding,
+    params: spec.params ? { ...(instance.params ?? {}), ...spec.params } : instance.params,
+    settings: spec.settings ? { ...(instance.settings ?? {}), ...spec.settings } : instance.settings,
+  };
+  return stableKey(next) === stableKey(instance) ? null : next;
 }
 
 async function resolvePaneTemplateOptions(
@@ -198,18 +217,24 @@ export async function createPaneTemplateOrThrow(
     throw new Error(`Unknown pane "${template.paneId}".`);
   }
 
-  const existingInstanceId = findReusablePaneInstance(
-    deps.getState().config.layout.instances,
-    template.paneId,
-    spec,
-  );
-  if (existingInstanceId) {
-    deps.pluginRegistry.focusPaneFn(existingInstanceId);
+  const instances = deps.getState().config.layout.instances;
+  const existing = findReusablePaneInstance(instances, template.paneId, spec);
+  if (existing) {
+    const retargeted = retargetPaneInstance(existing, spec);
+    if (retargeted) {
+      deps.pluginRegistry.updateLayoutFn(updatePaneInstance(
+        deps.getState().config.layout,
+        existing.instanceId,
+        () => retargeted,
+      ));
+    }
+    deps.pluginRegistry.focusPaneFn(existing.instanceId);
     return;
   }
 
   const instance = deps.buildPaneInstance(template.paneId, {
-    instanceId: spec.instanceId,
+    // A stable id another pane type already holds would collide, so the new pane picks its own.
+    instanceId: instances.some((entry) => entry.instanceId === spec.instanceId) ? undefined : spec.instanceId,
     title: spec.title,
     binding: spec.binding,
     params: spec.params,

--- a/src/components/command-bar/workflow/ops.ts
+++ b/src/components/command-bar/workflow/ops.ts
@@ -78,6 +78,41 @@ function updateTickerListPane(
   }));
 }
 
+/** Key order in stored settings is not guaranteed, so compare on sorted keys. */
+function stableKey(value: unknown): string {
+  return JSON.stringify(value, (_key, entry) => (
+    entry && typeof entry === "object" && !Array.isArray(entry)
+      ? Object.fromEntries(Object.entries(entry as Record<string, unknown>).sort(
+        ([left], [right]) => left.localeCompare(right),
+      ))
+      : entry
+  ));
+}
+
+/**
+ * Find the pane a template would otherwise duplicate. A template that owns a
+ * stable instance id (Chat keys one pane per channel) claims that instance
+ * even after its settings drifted at runtime; everything else has to match the
+ * whole create spec, so a different ticker, collection or setting still opens
+ * its own pane.
+ */
+function findReusablePaneInstance(
+  instances: PaneInstanceConfig[],
+  paneId: string,
+  spec: PaneTemplateInstanceConfig,
+): string | null {
+  if (spec.instanceId) {
+    return instances.some((instance) => instance.instanceId === spec.instanceId)
+      ? spec.instanceId
+      : null;
+  }
+  const specKey = stableKey([spec.binding ?? { kind: "none" }, spec.params ?? {}, spec.settings ?? {}]);
+  return instances.find((instance) => (
+    instance.paneId === paneId
+    && stableKey([instance.binding ?? { kind: "none" }, instance.params ?? {}, instance.settings ?? {}]) === specKey
+  ))?.instanceId ?? null;
+}
+
 async function resolvePaneTemplateOptions(
   template: PaneTemplateDef,
   options: PaneTemplateCreateOptions | undefined,
@@ -161,6 +196,16 @@ export async function createPaneTemplateOrThrow(
   const paneDef = deps.pluginRegistry.panes.get(template.paneId);
   if (!paneDef) {
     throw new Error(`Unknown pane "${template.paneId}".`);
+  }
+
+  const existingInstanceId = findReusablePaneInstance(
+    deps.getState().config.layout.instances,
+    template.paneId,
+    spec,
+  );
+  if (existingInstanceId) {
+    deps.pluginRegistry.focusPaneFn(existingInstanceId);
+    return;
   }
 
   const instance = deps.buildPaneInstance(template.paneId, {

--- a/src/plugins/builtin/cloud/plugin.tsx
+++ b/src/plugins/builtin/cloud/plugin.tsx
@@ -64,7 +64,7 @@ function createChatModule(
       id: "new-chat-pane",
       paneId: "chat",
       label: "New Chat Pane",
-      description: "Open another floating chat window",
+      description: "Open the floating chat window for a channel",
       keywords: ["new", "chat", "pane", "message"],
       shortcut: { prefix: "CHAT", argPlaceholder: "channel", argKind: "text" },
       createInstance: async (context, options) => {
@@ -77,6 +77,12 @@ function createChatModule(
         const targetMessageId = options?.values?.messageId?.trim() || null;
         return {
           placement: "floating",
+          // One pane per channel: re-opening the same channel focuses the pane
+          // that already holds it, even though its channelId setting drifts as
+          // the user switches channels inside the pane. A jump to a specific
+          // message stays unkeyed so it never lands on a pane that already
+          // scrolled past the target.
+          ...(targetMessageId ? {} : { instanceId: `chat:${channelId}` }),
           title: formatChatPaneTitle(channel, channelId),
           settings: {
             channelId,

--- a/src/plugins/builtin/fear-greed/format.ts
+++ b/src/plugins/builtin/fear-greed/format.ts
@@ -85,12 +85,3 @@ export function formatUpdatedAt(date: Date | null): string {
   const part = (type: Intl.DateTimeFormatPartTypes) => parts.find((entry) => entry.type === type)?.value ?? "";
   return `Last updated ${part("month")} ${part("day")} at ${part("hour")}:${part("minute")} ${part("dayPeriod")} ET`;
 }
-
-export function formatAge(ms: number): string {
-  const secs = Math.max(0, Math.floor(ms / 1000));
-  if (secs < 60) return `${secs}s ago`;
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  return `${hours}h ago`;
-}

--- a/src/plugins/builtin/fear-greed/pane.tsx
+++ b/src/plugins/builtin/fear-greed/pane.tsx
@@ -5,11 +5,11 @@ import { SpeedometerGauge, usePaneFooter } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import { colors } from "../../../theme/colors";
 import type { FearGreedData } from "./data";
+import { useAutoRefresh, useUpdatedAgo } from "../shared/auto-refresh";
 import { getCachedFearGreedData, loadFearGreed } from "./cache";
 import { IndicatorChart, IndexHistoryChart, PreviousScoreGrid } from "./charts";
 import {
   FEAR_GREED_GAUGE_SEGMENTS,
-  formatAge,
   formatScore,
   ratingColor,
   ratingLabel,
@@ -24,7 +24,6 @@ export function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
   const [loading, setLoading] = useState(!initialCache || initialCache.stale);
   const [error, setError] = useState<string | null>(null);
   const [lastRefreshed, setLastRefreshed] = useState<number | null>(initialCache?.fetchedAt ?? null);
-  const [now, setNow] = useState(Date.now());
   const fetchGenRef = useRef(0);
 
   const load = useCallback(async (force = false) => {
@@ -51,14 +50,12 @@ export function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
     }
   }, [initialCache, load]);
 
-  useEffect(() => {
-    const interval = setInterval(() => setNow(Date.now()), 10_000);
-    return () => clearInterval(interval);
-  }, []);
-
   const refresh = useCallback(() => {
     void load(true);
   }, [load]);
+
+  const updatedAgo = useUpdatedAgo(lastRefreshed);
+  useAutoRefresh(lastRefreshed, refresh);
 
   const stackDesktopSummary = isDesktopWeb && width < DESKTOP_SUMMARY_STACK_WIDTH;
   const desktopSummaryRailWidth = stackDesktopSummary ? Math.max(18, Math.min(width - 2, 42)) : 26;
@@ -74,7 +71,7 @@ export function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
     }
   });
 
-  const footerAge = lastRefreshed ? `refreshed ${formatAge(now - lastRefreshed)}` : loading ? "loading" : "";
+  const footerAge = updatedAgo ? `refreshed ${updatedAgo}` : loading ? "loading" : "";
   usePaneFooter(paneId, () => ({
     info: [
       ...(data ? [{

--- a/src/plugins/builtin/fx-matrix/index.tsx
+++ b/src/plugins/builtin/fx-matrix/index.tsx
@@ -7,24 +7,18 @@ import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import { colors, blendHex } from "../../../theme/colors";
 import { useAssetData } from "../../runtime";
+import { useUpdatedAgo } from "../shared/auto-refresh";
 import { MAJOR_CURRENCIES, formatRate, type MajorCurrency } from "./pairs";
 
+// Cross rates are a live board, so this pane keeps its own fast cadence rather
+// than following the global refresh interval.
 const REFRESH_INTERVAL_MS = 60_000;
-
-function formatAge(ms: number): string {
-  const secs = Math.floor(ms / 1000);
-  if (secs < 60) return `${secs}s ago`;
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ago`;
-  return `${Math.floor(mins / 60)}h ago`;
-}
 
 function FxMatrixPane({ focused, width, height }: PaneProps) {
   const dataProvider = useAssetData();
   const [rates, setRates] = useState<Map<MajorCurrency, number>>(new Map());
   const [loading, setLoading] = useState(true);
   const [lastRefreshed, setLastRefreshed] = useState<number | null>(null);
-  const [now, setNow] = useState(Date.now());
   const fetchGenRef = useRef(0);
 
   const fetchRates = useCallback(async () => {
@@ -64,11 +58,6 @@ function FxMatrixPane({ focused, width, height }: PaneProps) {
     return () => clearInterval(interval);
   }, [fetchRates]);
 
-  useEffect(() => {
-    const interval = setInterval(() => setNow(Date.now()), 5_000);
-    return () => clearInterval(interval);
-  }, []);
-
   useShortcut((event) => {
     if (!focused) return;
     if (event.name === "r") {
@@ -86,7 +75,8 @@ function FxMatrixPane({ focused, width, height }: PaneProps) {
     return rowUsd / colUsd;
   }
 
-  const ageText = lastRefreshed ? `updated ${formatAge(now - lastRefreshed)}` : loading ? "loading…" : "";
+  const updatedAgo = useUpdatedAgo(lastRefreshed);
+  const ageText = updatedAgo ? `updated ${updatedAgo}` : loading ? "loading…" : "";
 
   usePaneFooter("fx-matrix", () => ({
     info: ageText ? [{ id: "updated", parts: [{ text: ageText, tone: loading ? "muted" : "value" }] }] : [],

--- a/src/plugins/builtin/market-heatmap/index.tsx
+++ b/src/plugins/builtin/market-heatmap/index.tsx
@@ -25,6 +25,7 @@ import {
   type MarketHeatmapAsset,
   type MarketHeatmapUniverseId,
 } from "./data";
+import { useAutoRefresh, useUpdatedAgo } from "../shared/auto-refresh";
 import {
   LIVE_STREAMING_QUICK_SETTING,
   useLiveStreamingSetting,
@@ -45,14 +46,6 @@ function formatMoneyCompact(value: number | null | undefined, currency: string):
 function sizeLabel(asset: MarketHeatmapAsset): string {
   const label = asset.sizeKind === "net-assets" ? "Assets" : "Mkt";
   return `${label} ${formatMoneyCompact(asset.size, asset.currency)}`;
-}
-
-function updatedLabel(timestamp: number | null): string | null {
-  if (!timestamp) return null;
-  return new Date(timestamp).toLocaleTimeString("en-US", {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
 }
 
 function buildItems(assets: MarketHeatmapAsset[]): Array<MetricTreemapItem<MarketHeatmapAsset>> {
@@ -261,34 +254,31 @@ function MarketHeatmapPane({ focused, width, height }: PaneProps) {
     }
   });
 
-  usePaneFooter("market-heatmap", () => {
-    const updated = updatedLabel(lastUpdated);
-    return {
-      info: [
-        ...(selectedAsset ? [{
-          id: "selected",
-          parts: [
-            { text: selectedAsset.symbol, tone: "label" as const },
-            { text: formatCurrency(selectedAsset.price, selectedAsset.currency), tone: "value" as const },
-            { text: formatPercentRaw(selectedAsset.changePercent), tone: "value" as const, color: priceColor(selectedAsset.changePercent), bold: true },
-          ],
-        }] : []),
-        ...(updated ? [{
-          id: "updated",
-          parts: [
-            { text: "updated", tone: "label" as const },
-            { text: updated, tone: "value" as const },
-          ],
-        }] : []),
-        ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
-        ...(loadError ? [{ id: "error", parts: [{ text: "error", tone: "muted" as const }] }] : []),
-        ...(feedStatus ? [{
-          id: "feed",
-          parts: [{ text: feedStatus, tone: feedStatus === "live" ? "value" as const : "muted" as const }],
-        }] : []),
-      ],
-    };
-  }, [feedStatus, lastUpdated, loadError, loading, selectedAsset]);
+  const updated = useUpdatedAgo(lastUpdated);
+  useAutoRefresh(lastUpdated, refresh);
+
+  usePaneFooter("market-heatmap", () => ({
+    info: [
+      ...(selectedAsset ? [{
+        id: "selected",
+        parts: [
+          { text: selectedAsset.symbol, tone: "label" as const },
+          { text: formatCurrency(selectedAsset.price, selectedAsset.currency), tone: "value" as const },
+          { text: formatPercentRaw(selectedAsset.changePercent), tone: "value" as const, color: priceColor(selectedAsset.changePercent), bold: true },
+        ],
+      }] : []),
+      ...(updated ? [{
+        id: "updated",
+        parts: [{ text: `updated ${updated}`, tone: "muted" as const }],
+      }] : []),
+      ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+      ...(loadError ? [{ id: "error", parts: [{ text: "error", tone: "muted" as const }] }] : []),
+      ...(feedStatus ? [{
+        id: "feed",
+        parts: [{ text: feedStatus, tone: feedStatus === "live" ? "value" as const : "muted" as const }],
+      }] : []),
+    ],
+  }), [feedStatus, loadError, loading, selectedAsset, updated]);
 
   const emptyStateTitle = loading
     ? "Loading market heatmap..."

--- a/src/plugins/builtin/shared/auto-refresh.ts
+++ b/src/plugins/builtin/shared/auto-refresh.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from "react";
+import { useAppSelector } from "../../../state/app/context";
+import { formatRelativeAge } from "../../../utils/relative-time";
+
+/** The label only changes once a minute, so a coarse tick is enough. */
+const AGE_TICK_MS = 30_000;
+
+/**
+ * How old a pane's data is, as a footer-ready label that keeps ageing on its
+ * own. Returns null before the first successful load so callers can leave the
+ * footer empty instead of claiming a freshness they do not have.
+ */
+export function useUpdatedAgo(lastUpdated: number | null): string | null {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!lastUpdated) return;
+    const timer = setInterval(() => setNow(Date.now()), AGE_TICK_MS);
+    return () => clearInterval(timer);
+  }, [lastUpdated]);
+
+  return lastUpdated ? formatRelativeAge(lastUpdated, now) : null;
+}
+
+/**
+ * Re-pull a pane once its data is older than the global refresh interval, so
+ * network panes follow the one cadence the user already configured instead of
+ * each hardcoding its own.
+ *
+ * The timer runs on the interval itself rather than a faster poll: a load that
+ * failed is retried on the next tick, and a load that succeeded early is left
+ * alone, so a dead endpoint can never turn into a retry storm.
+ */
+export function useAutoRefresh(lastUpdated: number | null, refresh: () => void): void {
+  const intervalMinutes = useAppSelector((state) => state.config.refreshIntervalMinutes);
+  const refreshRef = useRef(refresh);
+  const lastUpdatedRef = useRef(lastUpdated);
+  refreshRef.current = refresh;
+  lastUpdatedRef.current = lastUpdated;
+
+  useEffect(() => {
+    if (!(intervalMinutes > 0)) return;
+    const intervalMs = intervalMinutes * 60_000;
+    const timer = setInterval(() => {
+      const previous = lastUpdatedRef.current;
+      if (previous && Date.now() - previous < intervalMs) return;
+      refreshRef.current();
+    }, intervalMs);
+    return () => clearInterval(timer);
+  }, [intervalMinutes]);
+}

--- a/src/renderers/electrobun/view/input-host.test.tsx
+++ b/src/renderers/electrobun/view/input-host.test.tsx
@@ -39,7 +39,7 @@ function Probe({ onKey }: { onKey: (event: KeyEventLike) => void }) {
   return null;
 }
 
-async function mountProbe(): Promise<KeyEventLike[]> {
+async function mountProbe(onKey?: (event: KeyEventLike) => void): Promise<KeyEventLike[]> {
   const seen: KeyEventLike[] = [];
   const container = testWindow.document.createElement("div");
   testWindow.document.body.appendChild(container);
@@ -47,7 +47,10 @@ async function mountProbe(): Promise<KeyEventLike[]> {
   await act(async () => {
     root.render(
       <WebInputHostProvider>
-        <Probe onKey={(event) => seen.push(event)} />
+        <Probe onKey={(event) => {
+          seen.push(event);
+          onKey?.(event);
+        }} />
       </WebInputHostProvider>,
     );
   });
@@ -117,4 +120,21 @@ test("reports Cmd-digit as a meta shortcut so layout switching can claim it", as
       { name: "2", ctrl: false, meta: true, super: true },
       { name: "3", ctrl: true, meta: false, super: false },
     ]);
+});
+
+// Cmd-digit is a browser tab shortcut, so the app only keeps it if its handler
+// still sees the key while a field is focused and can cancel the default there.
+test("delivers Cmd-digit from an editable field and lets a handler cancel the browser default", async () => {
+  const seen = await mountProbe((event) => {
+    if (event.name === "1" && event.meta) event.preventDefault();
+  });
+  const input = testWindow.document.createElement("input");
+  testWindow.document.body.appendChild(input);
+
+  const result = await pressKey("1", { target: input, metaKey: true });
+
+  expect(seen.map((event) => ({ name: event.name, meta: event.meta, editable: event.targetEditable })))
+    .toEqual([{ name: "1", meta: true, editable: true }]);
+  expect(result.defaultPrevented).toBe(true);
+  input.remove();
 });

--- a/src/renderers/electrobun/view/input-host.test.tsx
+++ b/src/renderers/electrobun/view/input-host.test.tsx
@@ -1,0 +1,120 @@
+/** @jsxImportSource react */
+import { Window } from "happy-dom";
+
+// The desktop/browser host is the only renderer with a real DOM underneath it,
+// so the keys the shared shortcut model depends on have to be proven here.
+const testWindow = new Window({ url: "http://localhost" });
+Object.assign(globalThis, {
+  window: testWindow,
+  document: testWindow.document,
+  navigator: testWindow.navigator,
+  KeyboardEvent: testWindow.KeyboardEvent,
+  Event: testWindow.Event,
+  HTMLElement: testWindow.HTMLElement,
+  Node: testWindow.Node,
+  requestAnimationFrame: (callback: (time: number) => void) => setTimeout(() => callback(Date.now()), 8),
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+});
+
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { useShortcut, type KeyEventLike } from "../../../react/input";
+import { WebInputHostProvider } from "./input-host";
+
+let cleanup: (() => void) | null = null;
+
+afterEach(async () => {
+  const teardown = cleanup;
+  cleanup = null;
+  if (!teardown) return;
+  await act(async () => {
+    teardown();
+    await Promise.resolve();
+  });
+});
+
+function Probe({ onKey }: { onKey: (event: KeyEventLike) => void }) {
+  useShortcut(onKey, { phase: "before" });
+  return null;
+}
+
+async function mountProbe(): Promise<KeyEventLike[]> {
+  const seen: KeyEventLike[] = [];
+  const container = testWindow.document.createElement("div");
+  testWindow.document.body.appendChild(container);
+  const root = createRoot(container as unknown as HTMLElement);
+  await act(async () => {
+    root.render(
+      <WebInputHostProvider>
+        <Probe onKey={(event) => seen.push(event)} />
+      </WebInputHostProvider>,
+    );
+  });
+  cleanup = () => {
+    root.unmount();
+    container.remove();
+  };
+  return seen;
+}
+
+async function pressKey(
+  key: string,
+  options: { target?: unknown; shiftKey?: boolean; metaKey?: boolean; ctrlKey?: boolean } = {},
+): Promise<{ defaultPrevented: boolean }> {
+  const event = new testWindow.KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+    shiftKey: options.shiftKey ?? false,
+    metaKey: options.metaKey ?? false,
+    ctrlKey: options.ctrlKey ?? false,
+  });
+  const target = (options.target ?? testWindow.document.body) as { dispatchEvent: (event: unknown) => void };
+  await act(async () => {
+    target.dispatchEvent(event);
+    await Promise.resolve();
+  });
+  return { defaultPrevented: event.defaultPrevented };
+}
+
+test("delivers plain Tab and Shift-Tab outside editable controls", async () => {
+  const seen = await mountProbe();
+
+  await pressKey("Tab");
+  await pressKey("Tab", { shiftKey: true });
+
+  expect(seen.map((event) => ({ name: event.name, shift: event.shift, editable: event.targetEditable })))
+    .toEqual([
+      { name: "tab", shift: false, editable: false },
+      { name: "tab", shift: true, editable: false },
+    ]);
+});
+
+test("leaves Tab to the field when an editable control owns the focus", async () => {
+  const seen = await mountProbe();
+  const input = testWindow.document.createElement("input");
+  testWindow.document.body.appendChild(input);
+
+  const result = await pressKey("Tab", { target: input });
+
+  // The event still reaches the registry, but the shared model refuses to
+  // deliver an unmodified key to a handler while a field is focused, and the
+  // host must not swallow the browser's own focus move either.
+  expect(seen).toEqual([]);
+  expect(result.defaultPrevented).toBe(false);
+  input.remove();
+});
+
+test("reports Cmd-digit as a meta shortcut so layout switching can claim it", async () => {
+  const seen = await mountProbe();
+
+  await pressKey("2", { metaKey: true });
+  await pressKey("3", { ctrlKey: true });
+
+  expect(seen.map((event) => ({ name: event.name, ctrl: event.ctrl, meta: event.meta, super: event.super })))
+    .toEqual([
+      { name: "2", ctrl: false, meta: true, super: true },
+      { name: "3", ctrl: true, meta: false, super: false },
+    ]);
+});


### PR DESCRIPTION
## Summary

- deduplicate command-bar results and reuse only equivalent pane instances
- retarget stable chat panes before focusing them, preserving distinct channels and message deep links
- support Ctrl, Cmd, and kitty Super number layout switching without changing existing Tab handling
- consume layout-number shortcuts while dialogs, the command bar, or editors own input so the webview cannot switch browser tabs
- reuse the existing refresh interval for shared freshness and bounded auto-reload on representative network panes

## Desktop and terminal safety

The desktop/browser Tab path was already correct and is intentionally unchanged. Regression tests pin native editable Tab, Tab/Shift-Tab pane delivery, existing Ctrl-number behavior, Cmd/Super-number behavior, single-layout handling, and command-bar/editor ownership.

Explicitly excludes the fork header redesign, font scaling, row animation, and TradingView.

## Verification

- focused global shortcut, input-host, pane workflow, and refresh tests
- `bun run typecheck`
- `bun test` (1,953 passed before the final single-layout regression, which also passes focused)
- `bun run desktop:view:build`

## Attribution

Ports and adapts the interaction work first developed by @Lucas-Kohorst in [Lucas-Kohorst/gloomberb](https://github.com/Lucas-Kohorst/gloomberb), with additional desktop-safety and pane-retargeting fixes.
