### PR TITLE
Add futures and Treasury auction boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Open command mode with `Ctrl+P`, then type a command. Press `` ` `` to open tick
 ## What It Does
 
 - Research companies with quotes, charts, financials, filings, holders, insiders, options, analyst ratings, events, and relative valuation.
-- Follow markets with top stories, breaking news, sector feeds, Substack subscriptions, global indices, FX, macro events, yield curves, market movers, new-high/new-low and options-flow scanners, and fear/greed.
+- Follow markets with top stories, breaking news, sector feeds, Substack subscriptions, global indices, futures, FX, macro events, yield curves, Treasury auctions, market movers, new-high/new-low and options-flow scanners, and fear/greed.
 - Track portfolios and watchlists, connect brokers, set alerts, keep notes, run AI screens, browse prediction markets, and use Gloom Cloud chat.
 
 ### Broker position sync
@@ -262,8 +262,10 @@ The toolbar controls preset or exact date ranges, intervals from one minute thro
 | `TBO` | TheBuildout infrastructure intelligence |
 | `CG` | Congress trading disclosures |
 | `WEI` | Global equity indices |
+| `FUT` | Front-month futures across index, rates, energy, metals, grains, and FX |
 | `ECON` | Economic events and releases |
 | `GC` | Yield curve |
+| `AUCT` | Treasury auction results: high rate, bid-to-cover, indirect share, and size |
 | `ERN` | Earnings calendar |
 | `TV` | Live Bloomberg, CNBC, and Yahoo Finance television |
 | `BI` / `SP` | S&P 500 sector performance |

--- a/src/components/ui/data-table/opentui/index.tsx
+++ b/src/components/ui/data-table/opentui/index.tsx
@@ -395,6 +395,7 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
                       onMouseDown={(event: any) => {
                         focusPane();
                         onTableMouseDown?.(event);
+                        sectionHeader.onMouseDown?.(event);
                         event.preventDefault();
                       }}
                     >

--- a/src/components/ui/data-table/types.ts
+++ b/src/components/ui/data-table/types.ts
@@ -25,6 +25,8 @@ export interface DataTableSectionHeader {
   color?: string;
   backgroundColor?: string;
   attributes?: number;
+  /** Makes the header itself clickable, e.g. to collapse its group. */
+  onMouseDown?: (event: any) => void;
 }
 
 export type DataTableScrollAlign = "nearest" | "center";

--- a/src/plugins/builtin/composite-plugins.ts
+++ b/src/plugins/builtin/composite-plugins.ts
@@ -6,6 +6,7 @@ import { correlationModule } from "./correlation";
 import { economicCalendarModule } from "./econ";
 import { earningsModule } from "./earnings";
 import { fearGreedModule } from "./fear-greed";
+import { futuresModule } from "./futures";
 import { fxMatrixModule } from "./fx-matrix";
 import { helpModule } from "./help";
 import { positionSizerModule } from "./kelly-sizer";
@@ -17,6 +18,7 @@ import { composeBuiltinPlugin } from "./plugin-module";
 import { portfolioListModule } from "./portfolio-list";
 import { scannerModule } from "./scanner";
 import { sectorsModule } from "./sectors";
+import { treasuryAuctionsModule } from "./treasury-auctions";
 import { worldIndicesModule } from "./world-indices";
 import { yieldCurveModule } from "./yield-curve";
 
@@ -50,7 +52,7 @@ export const marketOverviewPlugin = composeBuiltinPlugin({
   id: "market-overview",
   name: "Market Overview",
   version: "1.0.0",
-  description: "Global indices, movers, scanners, sectors, FX, sentiment, and correlations.",
+  description: "Global indices, movers, scanners, sectors, FX, futures, sentiment, and correlations.",
   toggleable: true,
   modules: [
     correlationModule,
@@ -61,6 +63,7 @@ export const marketOverviewPlugin = composeBuiltinPlugin({
     fearGreedModule,
     sectorsModule,
     fxMatrixModule,
+    futuresModule,
   ],
 });
 
@@ -68,7 +71,13 @@ export const macroPlugin = composeBuiltinPlugin({
   id: "macro",
   name: "Macro",
   version: "1.0.0",
-  description: "Economic calendar, yield curve, earnings calendar, and live financial TV.",
+  description: "Economic calendar, yield curve, Treasury auctions, earnings calendar, and live financial TV.",
   toggleable: true,
-  modules: [economicCalendarModule, yieldCurveModule, earningsModule, tvModule],
+  modules: [
+    economicCalendarModule,
+    yieldCurveModule,
+    treasuryAuctionsModule,
+    earningsModule,
+    tvModule,
+  ],
 });

--- a/src/plugins/builtin/futures/contracts.ts
+++ b/src/plugins/builtin/futures/contracts.ts
@@ -13,6 +13,18 @@ export interface FuturesContract {
   code: string;
   name: string;
   sector: FuturesSector;
+  /**
+   * Minimum price increment of the outright contract. It is the display
+   * precision: silver ticks at $0.005, so rendering it with two decimals
+   * collapses every tick. Rates contracts leave this unset because their
+   * 32nd-based ticks (down to 1/256) do not map to a readable decimal count.
+   */
+  tick?: number;
+}
+
+/** 0.005 -> 3, 0.25 -> 2, 1 -> 0. Written for ticks, not general numbers. */
+export function tickDecimals(tick: number): number {
+  return tick.toFixed(10).replace(/0+$/, "").split(".")[1]?.length ?? 0;
 }
 
 /**
@@ -21,10 +33,10 @@ export interface FuturesContract {
  * index is already on the world indices board as `DX-Y.NYB`.
  */
 export const FUTURES_CONTRACTS: FuturesContract[] = [
-  { symbol: "ES=F", code: "ES", name: "E-Mini S&P 500", sector: "equity-index" },
-  { symbol: "NQ=F", code: "NQ", name: "E-Mini Nasdaq 100", sector: "equity-index" },
-  { symbol: "YM=F", code: "YM", name: "E-Mini Dow", sector: "equity-index" },
-  { symbol: "RTY=F", code: "RTY", name: "E-Mini Russell 2000", sector: "equity-index" },
+  { symbol: "ES=F", code: "ES", name: "E-Mini S&P 500", sector: "equity-index", tick: 0.25 },
+  { symbol: "NQ=F", code: "NQ", name: "E-Mini Nasdaq 100", sector: "equity-index", tick: 0.25 },
+  { symbol: "YM=F", code: "YM", name: "E-Mini Dow", sector: "equity-index", tick: 1 },
+  { symbol: "RTY=F", code: "RTY", name: "E-Mini Russell 2000", sector: "equity-index", tick: 0.1 },
 
   { symbol: "ZT=F", code: "ZT", name: "2-Year T-Note", sector: "rates" },
   { symbol: "ZF=F", code: "ZF", name: "5-Year T-Note", sector: "rates" },
@@ -32,32 +44,33 @@ export const FUTURES_CONTRACTS: FuturesContract[] = [
   { symbol: "ZB=F", code: "ZB", name: "30-Year T-Bond", sector: "rates" },
   { symbol: "UB=F", code: "UB", name: "Ultra T-Bond", sector: "rates" },
 
-  { symbol: "CL=F", code: "CL", name: "WTI Crude Oil", sector: "energy" },
-  { symbol: "BZ=F", code: "BZ", name: "Brent Crude Oil", sector: "energy" },
-  { symbol: "NG=F", code: "NG", name: "Natural Gas", sector: "energy" },
-  { symbol: "RB=F", code: "RB", name: "RBOB Gasoline", sector: "energy" },
-  { symbol: "HO=F", code: "HO", name: "Heating Oil", sector: "energy" },
+  { symbol: "CL=F", code: "CL", name: "WTI Crude Oil", sector: "energy", tick: 0.01 },
+  { symbol: "BZ=F", code: "BZ", name: "Brent Crude Oil", sector: "energy", tick: 0.01 },
+  { symbol: "NG=F", code: "NG", name: "Natural Gas", sector: "energy", tick: 0.001 },
+  { symbol: "RB=F", code: "RB", name: "RBOB Gasoline", sector: "energy", tick: 0.0001 },
+  { symbol: "HO=F", code: "HO", name: "Heating Oil", sector: "energy", tick: 0.0001 },
 
-  { symbol: "GC=F", code: "GC", name: "Gold", sector: "metals" },
-  { symbol: "SI=F", code: "SI", name: "Silver", sector: "metals" },
-  { symbol: "HG=F", code: "HG", name: "Copper", sector: "metals" },
-  { symbol: "PL=F", code: "PL", name: "Platinum", sector: "metals" },
-  { symbol: "PA=F", code: "PA", name: "Palladium", sector: "metals" },
+  { symbol: "GC=F", code: "GC", name: "Gold", sector: "metals", tick: 0.1 },
+  { symbol: "SI=F", code: "SI", name: "Silver", sector: "metals", tick: 0.005 },
+  { symbol: "HG=F", code: "HG", name: "Copper", sector: "metals", tick: 0.0005 },
+  { symbol: "PL=F", code: "PL", name: "Platinum", sector: "metals", tick: 0.1 },
+  { symbol: "PA=F", code: "PA", name: "Palladium", sector: "metals", tick: 0.1 },
 
-  { symbol: "ZC=F", code: "ZC", name: "Corn", sector: "agriculture" },
-  { symbol: "ZS=F", code: "ZS", name: "Soybeans", sector: "agriculture" },
-  { symbol: "ZW=F", code: "ZW", name: "Chicago SRW Wheat", sector: "agriculture" },
-  { symbol: "KC=F", code: "KC", name: "Coffee", sector: "agriculture" },
-  { symbol: "SB=F", code: "SB", name: "Sugar #11", sector: "agriculture" },
-  { symbol: "CC=F", code: "CC", name: "Cocoa", sector: "agriculture" },
-  { symbol: "CT=F", code: "CT", name: "Cotton #2", sector: "agriculture" },
+  // Grains and softs quote in US cents; the tick is in those same cents.
+  { symbol: "ZC=F", code: "ZC", name: "Corn", sector: "agriculture", tick: 0.25 },
+  { symbol: "ZS=F", code: "ZS", name: "Soybeans", sector: "agriculture", tick: 0.25 },
+  { symbol: "ZW=F", code: "ZW", name: "Chicago SRW Wheat", sector: "agriculture", tick: 0.25 },
+  { symbol: "KC=F", code: "KC", name: "Coffee", sector: "agriculture", tick: 0.05 },
+  { symbol: "SB=F", code: "SB", name: "Sugar #11", sector: "agriculture", tick: 0.01 },
+  { symbol: "CC=F", code: "CC", name: "Cocoa", sector: "agriculture", tick: 1 },
+  { symbol: "CT=F", code: "CT", name: "Cotton #2", sector: "agriculture", tick: 0.01 },
 
-  { symbol: "6E=F", code: "6E", name: "Euro FX", sector: "currencies" },
-  { symbol: "6J=F", code: "6J", name: "Japanese Yen", sector: "currencies" },
-  { symbol: "6B=F", code: "6B", name: "British Pound", sector: "currencies" },
-  { symbol: "6A=F", code: "6A", name: "Australian Dollar", sector: "currencies" },
-  { symbol: "6C=F", code: "6C", name: "Canadian Dollar", sector: "currencies" },
-  { symbol: "6S=F", code: "6S", name: "Swiss Franc", sector: "currencies" },
+  { symbol: "6E=F", code: "6E", name: "Euro FX", sector: "currencies", tick: 0.00005 },
+  { symbol: "6J=F", code: "6J", name: "Japanese Yen", sector: "currencies", tick: 0.0000005 },
+  { symbol: "6B=F", code: "6B", name: "British Pound", sector: "currencies", tick: 0.0001 },
+  { symbol: "6A=F", code: "6A", name: "Australian Dollar", sector: "currencies", tick: 0.00005 },
+  { symbol: "6C=F", code: "6C", name: "Canadian Dollar", sector: "currencies", tick: 0.00005 },
+  { symbol: "6S=F", code: "6S", name: "Swiss Franc", sector: "currencies", tick: 0.00005 },
 ];
 
 export const FUTURES_SECTOR_LABELS: Record<FuturesSector, string> = {

--- a/src/plugins/builtin/futures/contracts.ts
+++ b/src/plugins/builtin/futures/contracts.ts
@@ -1,0 +1,87 @@
+export type FuturesSector =
+  | "equity-index"
+  | "rates"
+  | "energy"
+  | "metals"
+  | "agriculture"
+  | "currencies";
+
+export interface FuturesContract {
+  /** Yahoo continuous front-month symbol. */
+  symbol: string;
+  /** Exchange code traders quote, e.g. ES. */
+  code: string;
+  name: string;
+  sector: FuturesSector;
+}
+
+/**
+ * Front-month continuous contracts, every one confirmed to resolve through the
+ * Yahoo provider. `DX=F` is deliberately absent: Yahoo 404s it, and the dollar
+ * index is already on the world indices board as `DX-Y.NYB`.
+ */
+export const FUTURES_CONTRACTS: FuturesContract[] = [
+  { symbol: "ES=F", code: "ES", name: "E-Mini S&P 500", sector: "equity-index" },
+  { symbol: "NQ=F", code: "NQ", name: "E-Mini Nasdaq 100", sector: "equity-index" },
+  { symbol: "YM=F", code: "YM", name: "E-Mini Dow", sector: "equity-index" },
+  { symbol: "RTY=F", code: "RTY", name: "E-Mini Russell 2000", sector: "equity-index" },
+
+  { symbol: "ZT=F", code: "ZT", name: "2-Year T-Note", sector: "rates" },
+  { symbol: "ZF=F", code: "ZF", name: "5-Year T-Note", sector: "rates" },
+  { symbol: "ZN=F", code: "ZN", name: "10-Year T-Note", sector: "rates" },
+  { symbol: "ZB=F", code: "ZB", name: "30-Year T-Bond", sector: "rates" },
+  { symbol: "UB=F", code: "UB", name: "Ultra T-Bond", sector: "rates" },
+
+  { symbol: "CL=F", code: "CL", name: "WTI Crude Oil", sector: "energy" },
+  { symbol: "BZ=F", code: "BZ", name: "Brent Crude Oil", sector: "energy" },
+  { symbol: "NG=F", code: "NG", name: "Natural Gas", sector: "energy" },
+  { symbol: "RB=F", code: "RB", name: "RBOB Gasoline", sector: "energy" },
+  { symbol: "HO=F", code: "HO", name: "Heating Oil", sector: "energy" },
+
+  { symbol: "GC=F", code: "GC", name: "Gold", sector: "metals" },
+  { symbol: "SI=F", code: "SI", name: "Silver", sector: "metals" },
+  { symbol: "HG=F", code: "HG", name: "Copper", sector: "metals" },
+  { symbol: "PL=F", code: "PL", name: "Platinum", sector: "metals" },
+  { symbol: "PA=F", code: "PA", name: "Palladium", sector: "metals" },
+
+  { symbol: "ZC=F", code: "ZC", name: "Corn", sector: "agriculture" },
+  { symbol: "ZS=F", code: "ZS", name: "Soybeans", sector: "agriculture" },
+  { symbol: "ZW=F", code: "ZW", name: "Chicago SRW Wheat", sector: "agriculture" },
+  { symbol: "KC=F", code: "KC", name: "Coffee", sector: "agriculture" },
+  { symbol: "SB=F", code: "SB", name: "Sugar #11", sector: "agriculture" },
+  { symbol: "CC=F", code: "CC", name: "Cocoa", sector: "agriculture" },
+  { symbol: "CT=F", code: "CT", name: "Cotton #2", sector: "agriculture" },
+
+  { symbol: "6E=F", code: "6E", name: "Euro FX", sector: "currencies" },
+  { symbol: "6J=F", code: "6J", name: "Japanese Yen", sector: "currencies" },
+  { symbol: "6B=F", code: "6B", name: "British Pound", sector: "currencies" },
+  { symbol: "6A=F", code: "6A", name: "Australian Dollar", sector: "currencies" },
+  { symbol: "6C=F", code: "6C", name: "Canadian Dollar", sector: "currencies" },
+  { symbol: "6S=F", code: "6S", name: "Swiss Franc", sector: "currencies" },
+];
+
+export const FUTURES_SECTOR_LABELS: Record<FuturesSector, string> = {
+  "equity-index": "Equity Index",
+  rates: "Rates",
+  energy: "Energy",
+  metals: "Metals",
+  agriculture: "Agriculture",
+  currencies: "Currencies",
+};
+
+export const FUTURES_SECTOR_ORDER: FuturesSector[] = [
+  "equity-index",
+  "rates",
+  "energy",
+  "metals",
+  "agriculture",
+  "currencies",
+];
+
+export function getContractsBySector(): Map<FuturesSector, FuturesContract[]> {
+  const map = new Map<FuturesSector, FuturesContract[]>();
+  for (const sector of FUTURES_SECTOR_ORDER) {
+    map.set(sector, FUTURES_CONTRACTS.filter((contract) => contract.sector === sector));
+  }
+  return map;
+}

--- a/src/plugins/builtin/futures/index.tsx
+++ b/src/plugins/builtin/futures/index.tsx
@@ -17,8 +17,8 @@ import { cycleSortPreference } from "../../../utils/sort-values";
 import { usePluginTickerActions } from "../../runtime";
 import type { PluginModule } from "../plugin-module";
 import {
-  countLoadingQuotes,
-  latestQuoteTimestamp,
+  quoteBoardFooterInfo,
+  quoteBoardStatus,
   useQuoteBoard,
 } from "../shared/use-quote-board";
 import {
@@ -30,6 +30,7 @@ import {
 import {
   buildFuturesRows,
   DEFAULT_FUTURES_SORT,
+  effectiveCollapsedSectors,
   futuresRowId,
   nextFuturesSort,
   type FuturesColumnId,
@@ -62,6 +63,7 @@ function FuturesPane({ focused, width, height }: PaneProps) {
   const searchInputRef = useRef<InputRenderable | null>(null);
 
   const contractsBySector = useMemo(() => getContractsBySector(), []);
+  const visibleCollapsed = effectiveCollapsedSectors(collapsedSectors, searchQuery);
   const rows = useMemo(
     () => buildFuturesRows(contractsBySector, sortPreference, quotes, {
       query: searchQuery,
@@ -151,24 +153,9 @@ function FuturesPane({ focused, width, height }: PaneProps) {
     return handlePaneKey(event);
   }, [focusSearch, handlePaneKey]);
 
-  const loadingCount = countLoadingQuotes(quotes);
-  const latestTs = latestQuoteTimestamp(quotes);
-  const errorCount = Array.from(quotes.values()).filter((state) => state.error).length;
+  const status = quoteBoardStatus(quotes);
   usePaneFooter(FUTURES_PANE_ID, () => {
-    const info: PaneFooterSegment[] = [];
-    if (loadingCount > 0) info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
-    if (errorCount > 0) {
-      info.push({ id: "error", parts: [{ text: `${errorCount} unavailable`, tone: "warning" }] });
-    }
-    if (latestTs > 0) {
-      info.push({
-        id: "fresh",
-        parts: [{
-          text: new Date(latestTs).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
-          tone: "muted",
-        }],
-      });
-    }
+    const info: PaneFooterSegment[] = quoteBoardFooterInfo(status);
     if (searchQuery.trim()) {
       info.push({ id: "search", parts: [{ text: `search: ${searchQuery.trim()}`, tone: "value" }] });
     }
@@ -179,7 +166,15 @@ function FuturesPane({ focused, width, height }: PaneProps) {
         { id: "refresh", key: "r", label: "efresh", onPress: refresh },
       ],
     };
-  }, [errorCount, focusSearch, latestTs, loadingCount, refresh, searchQuery]);
+  }, [
+    focusSearch,
+    refresh,
+    searchQuery,
+    status.latestTs,
+    status.loading,
+    status.stale,
+    status.unavailable,
+  ]);
 
   return (
     <DataTableView<FuturesTableRow, FuturesColumn>
@@ -208,7 +203,7 @@ function FuturesPane({ focused, width, height }: PaneProps) {
       getItemKey={(row) => futuresRowId(row)}
       renderSectionHeader={(row) => row.type === "header"
         ? {
-          text: `${collapsedSectors.has(row.sector) ? "▶" : "▼"} ${FUTURES_SECTOR_LABELS[row.sector]}`,
+          text: `${visibleCollapsed.has(row.sector) ? "▶" : "▼"} ${FUTURES_SECTOR_LABELS[row.sector]}`,
           onMouseDown: () => toggleSector(row.sector),
         }
         : null}

--- a/src/plugins/builtin/futures/index.tsx
+++ b/src/plugins/builtin/futures/index.tsx
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  DataTableView,
+  InputSearchBar,
+  usePaneFooter,
+  type DataTableKeyEvent,
+  type DataTableRootKeyContext,
+  type PaneFooterSegment,
+} from "../../../components";
+import { usePaneInstance } from "../../../state/app/context";
+import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
+import type { PaneProps } from "../../../types/plugin";
+import { type InputRenderable } from "../../../ui";
+import { isPlainKey } from "../../../utils/keyboard";
+import { isPlainArrowUp, stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
+import { cycleSortPreference } from "../../../utils/sort-values";
+import { usePluginTickerActions } from "../../runtime";
+import type { PluginModule } from "../plugin-module";
+import {
+  countLoadingQuotes,
+  latestQuoteTimestamp,
+  useQuoteBoard,
+} from "../shared/use-quote-board";
+import {
+  FUTURES_CONTRACTS,
+  FUTURES_SECTOR_LABELS,
+  getContractsBySector,
+  type FuturesSector,
+} from "./contracts";
+import {
+  buildFuturesRows,
+  DEFAULT_FUTURES_SORT,
+  futuresRowId,
+  nextFuturesSort,
+  type FuturesColumnId,
+  type FuturesSortPreference,
+  type FuturesTableRow,
+} from "./model";
+import {
+  createFuturesColumns,
+  FUTURES_COLUMN_DEFS,
+  renderFuturesCell,
+  resolveFuturesColumnIds,
+  type FuturesColumn,
+} from "./table";
+
+export const FUTURES_PANE_ID = "futures";
+
+const REFRESH_INTERVAL_MS = 60_000;
+const FUTURES_SYMBOLS = FUTURES_CONTRACTS.map((contract) => contract.symbol);
+
+function FuturesPane({ focused, width, height }: PaneProps) {
+  const { pinTicker } = usePluginTickerActions();
+  const paneInstance = usePaneInstance();
+  const { quotes, refresh } = useQuoteBoard(FUTURES_SYMBOLS, REFRESH_INTERVAL_MS);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [sortPreference, setSortPreference] = useState<FuturesSortPreference>(DEFAULT_FUTURES_SORT);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchFocused, setSearchFocused] = useState(false);
+  const [searchFocusToken, setSearchFocusToken] = useState(0);
+  const [collapsedSectors, setCollapsedSectors] = useState<ReadonlySet<FuturesSector>>(new Set());
+  const searchInputRef = useRef<InputRenderable | null>(null);
+
+  const contractsBySector = useMemo(() => getContractsBySector(), []);
+  const rows = useMemo(
+    () => buildFuturesRows(contractsBySector, sortPreference, quotes, {
+      query: searchQuery,
+      collapsed: collapsedSectors,
+    }),
+    [collapsedSectors, contractsBySector, quotes, searchQuery, sortPreference],
+  );
+
+  const visibleColumnIds = useMemo(
+    () => resolveFuturesColumnIds(paneInstance?.settings?.columnIds as string[] | undefined),
+    [paneInstance?.settings?.columnIds],
+  );
+  const columns = useMemo<FuturesColumn[]>(
+    () => createFuturesColumns(width, visibleColumnIds),
+    [visibleColumnIds, width],
+  );
+
+  const renderCell = useCallback((
+    row: FuturesTableRow,
+    column: FuturesColumn,
+    _index: number,
+    rowState: { selected: boolean },
+  ) => renderFuturesCell(row, column, rowState, quotes), [quotes]);
+
+  const focusSearch = useCallback(() => {
+    setSearchFocused(true);
+    setSearchFocusToken((current) => current + 1);
+  }, []);
+  const blurSearch = useCallback(() => setSearchFocused(false), []);
+
+  const toggleSector = useCallback((sector: FuturesSector) => {
+    setCollapsedSectors((current) => {
+      const next = new Set(current);
+      if (next.has(sector)) next.delete(sector);
+      else next.add(sector);
+      return next;
+    });
+  }, []);
+
+  const cycleSort = useCallback((step: 1 | -1) => {
+    setSortPreference((current) => cycleSortPreference<FuturesColumnId>(
+      visibleColumnIds,
+      current,
+      step,
+      { allowUnsorted: true },
+    ));
+  }, [visibleColumnIds]);
+
+  useEffect(() => {
+    if (rows.length === 0) {
+      if (selectedId !== null) setSelectedId(null);
+      return;
+    }
+    if (selectedId && rows.some((row) => futuresRowId(row) === selectedId)) return;
+    const firstNavigable = rows.find((row) => row.type === "row") ?? rows[0];
+    setSelectedId(firstNavigable ? futuresRowId(firstNavigable) : null);
+  }, [rows, selectedId]);
+
+  const handlePaneKey = useCallback((event: DataTableKeyEvent): boolean => {
+    if (isPlainKey(event, "r")) {
+      stopSearchFocusNavigation(event);
+      refresh();
+      return true;
+    }
+    if (isPlainKey(event, "s") || isPlainKey(event, "/")) {
+      stopSearchFocusNavigation(event);
+      focusSearch();
+      return true;
+    }
+    if (isPlainKey(event, "]") || isPlainKey(event, "[")) {
+      stopSearchFocusNavigation(event);
+      cycleSort(event.name === "]" ? 1 : -1);
+      return true;
+    }
+    return false;
+  }, [cycleSort, focusSearch, refresh]);
+
+  const handleRootKeyDown = useCallback((
+    event: DataTableKeyEvent,
+    context: DataTableRootKeyContext,
+  ) => {
+    if (context.selectedIndex <= 0 && isPlainArrowUp(event)) {
+      stopSearchFocusNavigation(event);
+      focusSearch();
+      return true;
+    }
+    return handlePaneKey(event);
+  }, [focusSearch, handlePaneKey]);
+
+  const loadingCount = countLoadingQuotes(quotes);
+  const latestTs = latestQuoteTimestamp(quotes);
+  const errorCount = Array.from(quotes.values()).filter((state) => state.error).length;
+  usePaneFooter(FUTURES_PANE_ID, () => {
+    const info: PaneFooterSegment[] = [];
+    if (loadingCount > 0) info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
+    if (errorCount > 0) {
+      info.push({ id: "error", parts: [{ text: `${errorCount} unavailable`, tone: "warning" }] });
+    }
+    if (latestTs > 0) {
+      info.push({
+        id: "fresh",
+        parts: [{
+          text: new Date(latestTs).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+          tone: "muted",
+        }],
+      });
+    }
+    if (searchQuery.trim()) {
+      info.push({ id: "search", parts: [{ text: `search: ${searchQuery.trim()}`, tone: "value" }] });
+    }
+    return {
+      info,
+      hints: [
+        { id: "search", key: "s", label: "earch", onPress: focusSearch },
+        { id: "refresh", key: "r", label: "efresh", onPress: refresh },
+      ],
+    };
+  }, [errorCount, focusSearch, latestTs, loadingCount, refresh, searchQuery]);
+
+  return (
+    <DataTableView<FuturesTableRow, FuturesColumn>
+      focused={focused && !searchFocused}
+      selection={{
+        kind: "id",
+        selectedId,
+        getId: (row) => futuresRowId(row),
+        onChange: (id) => setSelectedId(id),
+      }}
+      isNavigable={() => true}
+      onActivate={(row) => {
+        if (row.type === "header") {
+          toggleSector(row.sector);
+          return;
+        }
+        pinTicker(row.contract.symbol, { floating: true, paneType: TICKER_RESEARCH_PANE_ID });
+      }}
+      rootWidth={width}
+      rootHeight={height}
+      columns={columns}
+      items={rows}
+      sortColumnId={sortPreference.columnId}
+      sortDirection={sortPreference.direction}
+      onHeaderClick={(columnId) => setSortPreference((current) => nextFuturesSort(current, columnId))}
+      getItemKey={(row) => futuresRowId(row)}
+      renderSectionHeader={(row) => row.type === "header"
+        ? {
+          text: `${collapsedSectors.has(row.sector) ? "▶" : "▼"} ${FUTURES_SECTOR_LABELS[row.sector]}`,
+          onMouseDown: () => toggleSector(row.sector),
+        }
+        : null}
+      renderCell={renderCell}
+      emptyStateTitle={searchQuery.trim() ? "No matching contracts." : "No contracts configured."}
+      emptyStateHint={searchQuery.trim() ? "Clear search or press r to refresh." : "Press s to search."}
+      rootBefore={(
+        <InputSearchBar
+          value={searchQuery}
+          focused={focused}
+          active={searchFocused}
+          width={width}
+          focusToken={searchFocusToken}
+          inputRef={searchInputRef}
+          placeholder="ticker or name"
+          debounceMs={80}
+          onFocus={focusSearch}
+          onBlur={blurSearch}
+          onNavigateDown={blurSearch}
+          onQueryChange={setSearchQuery}
+        />
+      )}
+      onRootKeyDown={handleRootKeyDown}
+    />
+  );
+}
+
+export const futuresModule: PluginModule = {
+  panes: [
+    {
+      id: FUTURES_PANE_ID,
+      name: "Futures",
+      icon: "F",
+      component: FuturesPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 76, height: 34 },
+      // Resolved per open so the dialog shows the full default set until the
+      // user saves a narrower selection.
+      settings: (context) => ({
+        title: "Futures Settings",
+        values: {
+          columnIds: resolveFuturesColumnIds(context.settings.columnIds as string[] | undefined),
+        },
+        fields: [{
+          key: "columnIds",
+          label: "Columns",
+          type: "ordered-multi-select",
+          options: FUTURES_COLUMN_DEFS.map((column) => ({
+            value: column.id,
+            label: column.label,
+            description: column.description,
+          })),
+        }],
+      }),
+    },
+  ],
+
+  paneTemplates: [
+    {
+      id: "futures-pane",
+      paneId: FUTURES_PANE_ID,
+      label: "Futures Board",
+      description:
+        "Front-month futures across equity index, rates, energy, metals, agriculture, and FX with last price, session change, search, and collapsible sectors.",
+      keywords: [
+        "futures",
+        "commodities",
+        "crude",
+        "oil",
+        "gold",
+        "silver",
+        "copper",
+        "corn",
+        "wheat",
+        "treasuries",
+        "contracts",
+        "cme",
+      ],
+      shortcut: { prefix: "FUT" },
+    },
+  ],
+};

--- a/src/plugins/builtin/futures/model.test.ts
+++ b/src/plugins/builtin/futures/model.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, test } from "bun:test";
 import type { Quote } from "../../../types/financials";
 import { cycleSortPreference } from "../../../utils/sort-values";
 import type { BoardQuoteMap } from "../shared/use-quote-board";
-import { getContractsBySector } from "./contracts";
+import { getContractsBySector, type FuturesSector } from "./contracts";
 import {
   buildFuturesRows,
   DEFAULT_FUTURES_SORT,
+  effectiveCollapsedSectors,
   nextFuturesSort,
   type FuturesColumnId,
   type FuturesTableRow,
@@ -22,7 +23,7 @@ function quoteMap(entries: Record<string, Partial<Quote>>): BoardQuoteMap {
   return new Map(
     Object.entries(entries).map(([symbol, quote]) => [
       symbol,
-      { quote: quote as Quote, loading: false, error: null },
+      { quote: quote as Quote, loading: false, error: null, stale: false },
     ]),
   );
 }
@@ -57,12 +58,20 @@ describe("buildFuturesRows collapse", () => {
     expect(rows.some((row) => row.type === "row" && row.contract.sector === "metals")).toBe(true);
   });
 
-  test("collapsing hides rows a search would otherwise have surfaced", () => {
+  test("a live search overrides collapsed sectors instead of hiding its own matches", () => {
     const rows = buildFuturesRows(contractsBySector, DEFAULT_FUTURES_SORT, EMPTY_QUOTES, {
       query: "gold",
       collapsed: new Set(["metals"]),
     });
-    expect(rowIds(rows)).toEqual(["header:metals"]);
+    expect(rowIds(rows)).toEqual(["header:metals", "GC=F"]);
+  });
+
+  test("clearing the search restores the collapsed state, whitespace included", () => {
+    const collapsed = new Set<FuturesSector>(["metals"]);
+    expect(effectiveCollapsedSectors(collapsed, "gold").has("metals")).toBe(false);
+    expect(effectiveCollapsedSectors(collapsed, "   ").has("metals")).toBe(true);
+    expect(effectiveCollapsedSectors(collapsed, "").has("metals")).toBe(true);
+    expect(effectiveCollapsedSectors(collapsed, undefined).has("metals")).toBe(true);
   });
 });
 

--- a/src/plugins/builtin/futures/model.test.ts
+++ b/src/plugins/builtin/futures/model.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import type { Quote } from "../../../types/financials";
+import { cycleSortPreference } from "../../../utils/sort-values";
+import type { BoardQuoteMap } from "../shared/use-quote-board";
+import { getContractsBySector } from "./contracts";
+import {
+  buildFuturesRows,
+  DEFAULT_FUTURES_SORT,
+  nextFuturesSort,
+  type FuturesColumnId,
+  type FuturesTableRow,
+} from "./model";
+
+const contractsBySector = getContractsBySector();
+const EMPTY_QUOTES: BoardQuoteMap = new Map();
+
+function rowIds(rows: FuturesTableRow[]): string[] {
+  return rows.map((row) => row.type === "header" ? `header:${row.sector}` : row.contract.symbol);
+}
+
+function quoteMap(entries: Record<string, Partial<Quote>>): BoardQuoteMap {
+  return new Map(
+    Object.entries(entries).map(([symbol, quote]) => [
+      symbol,
+      { quote: quote as Quote, loading: false, error: null },
+    ]),
+  );
+}
+
+describe("buildFuturesRows search", () => {
+  test("matches contract code, name, and Yahoo symbol case-insensitively", () => {
+    expect(rowIds(buildFuturesRows(contractsBySector, DEFAULT_FUTURES_SORT, EMPTY_QUOTES, { query: "gc" })))
+      .toEqual(["header:metals", "GC=F"]);
+    expect(rowIds(buildFuturesRows(contractsBySector, DEFAULT_FUTURES_SORT, EMPTY_QUOTES, { query: "crude" })))
+      .toEqual(["header:energy", "CL=F", "BZ=F"]);
+    expect(rowIds(buildFuturesRows(contractsBySector, DEFAULT_FUTURES_SORT, EMPTY_QUOTES, { query: "6J=f" })))
+      .toEqual(["header:currencies", "6J=F"]);
+  });
+
+  test("drops a sector header when every contract in it is filtered out", () => {
+    const rows = buildFuturesRows(contractsBySector, DEFAULT_FUTURES_SORT, EMPTY_QUOTES, { query: "copper" });
+    expect(rowIds(rows)).toEqual(["header:metals", "HG=F"]);
+  });
+
+  test("a query matching nothing yields no rows at all, not bare headers", () => {
+    expect(buildFuturesRows(contractsBySector, DEFAULT_FUTURES_SORT, EMPTY_QUOTES, { query: "zzz" })).toEqual([]);
+  });
+});
+
+describe("buildFuturesRows collapse", () => {
+  test("keeps a collapsed sector's header while hiding its contracts", () => {
+    const rows = buildFuturesRows(contractsBySector, DEFAULT_FUTURES_SORT, EMPTY_QUOTES, {
+      collapsed: new Set(["energy"]),
+    });
+    expect(rows.some((row) => row.type === "header" && row.sector === "energy")).toBe(true);
+    expect(rows.some((row) => row.type === "row" && row.contract.sector === "energy")).toBe(false);
+    expect(rows.some((row) => row.type === "row" && row.contract.sector === "metals")).toBe(true);
+  });
+
+  test("collapsing hides rows a search would otherwise have surfaced", () => {
+    const rows = buildFuturesRows(contractsBySector, DEFAULT_FUTURES_SORT, EMPTY_QUOTES, {
+      query: "gold",
+      collapsed: new Set(["metals"]),
+    });
+    expect(rowIds(rows)).toEqual(["header:metals"]);
+  });
+});
+
+describe("futures sorting", () => {
+  test("sorts within a sector, never across sectors", () => {
+    const quotes = quoteMap({
+      "ES=F": { price: 7731 },
+      "NQ=F": { price: 29670 },
+      "YM=F": { price: 53499 },
+      "RTY=F": { price: 3046 },
+      "GC=F": { price: 4451 },
+    });
+    const rows = buildFuturesRows(
+      contractsBySector,
+      { columnId: "price", direction: "desc" },
+      quotes,
+      { query: "e-mini" },
+    );
+    expect(rowIds(rows)).toEqual(["header:equity-index", "YM=F", "NQ=F", "ES=F", "RTY=F"]);
+  });
+
+  test("header clicks walk ascending, descending, then back to catalog order", () => {
+    const ascending = nextFuturesSort(DEFAULT_FUTURES_SORT, "code");
+    const descending = nextFuturesSort(ascending, "code");
+    expect(ascending).toEqual({ columnId: "code", direction: "asc" });
+    expect(descending).toEqual({ columnId: "code", direction: "desc" });
+    expect(nextFuturesSort(descending, "code")).toEqual(DEFAULT_FUTURES_SORT);
+    expect(nextFuturesSort(descending, "price")).toEqual({ columnId: "price", direction: "asc" });
+  });
+
+  test("the keyboard cycle reaches every state a header click can, and wraps", () => {
+    const columnIds: FuturesColumnId[] = ["code", "price"];
+    const seen = [DEFAULT_FUTURES_SORT];
+    let current = DEFAULT_FUTURES_SORT;
+    for (let step = 0; step < 4; step += 1) {
+      current = cycleSortPreference(columnIds, current, 1, { allowUnsorted: true });
+      seen.push(current);
+    }
+    expect(seen).toEqual([
+      { columnId: null, direction: "asc" },
+      { columnId: "code", direction: "asc" },
+      { columnId: "code", direction: "desc" },
+      { columnId: "price", direction: "asc" },
+      { columnId: "price", direction: "desc" },
+    ]);
+    expect(cycleSortPreference(columnIds, current, 1, { allowUnsorted: true })).toEqual(DEFAULT_FUTURES_SORT);
+    expect(cycleSortPreference(columnIds, DEFAULT_FUTURES_SORT, -1, { allowUnsorted: true }))
+      .toEqual({ columnId: "price", direction: "desc" });
+  });
+
+  test("cycling skips columns the user hid", () => {
+    expect(cycleSortPreference<FuturesColumnId>(["name"], { columnId: "name", direction: "desc" }, 1))
+      .toEqual({ columnId: "name", direction: "asc" });
+  });
+});

--- a/src/plugins/builtin/futures/model.ts
+++ b/src/plugins/builtin/futures/model.ts
@@ -1,0 +1,105 @@
+import { compareSortValues, type SortDirection } from "../../../utils/sort-values";
+import type { BoardQuoteMap } from "../shared/use-quote-board";
+import { FUTURES_SECTOR_ORDER, type FuturesContract, type FuturesSector } from "./contracts";
+
+export type FuturesTableRow =
+  | { type: "header"; sector: FuturesSector }
+  | { type: "row"; contract: FuturesContract };
+
+export type FuturesColumnId = "status" | "code" | "name" | "price" | "change" | "changePercent";
+
+export interface FuturesSortPreference {
+  columnId: FuturesColumnId | null;
+  direction: SortDirection;
+}
+
+export const DEFAULT_FUTURES_SORT: FuturesSortPreference = {
+  columnId: null,
+  direction: "asc",
+};
+
+export function futuresRowId(row: FuturesTableRow): string {
+  return row.type === "header" ? `header-${row.sector}` : row.contract.symbol;
+}
+
+function matchesFuturesSearch(contract: FuturesContract, query: string): boolean {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return true;
+  return (
+    contract.code.toLowerCase().includes(normalized)
+    || contract.name.toLowerCase().includes(normalized)
+    || contract.symbol.toLowerCase().includes(normalized)
+  );
+}
+
+function getSortValue(
+  columnId: FuturesColumnId,
+  contract: FuturesContract,
+  quotes: BoardQuoteMap,
+): string | number | null {
+  const quote = quotes.get(contract.symbol)?.quote;
+  switch (columnId) {
+    case "status":
+      return quote?.marketState === "REGULAR" ? 0 : 1;
+    case "code":
+      return contract.code;
+    case "name":
+      return contract.name;
+    case "price":
+      return quote?.price ?? null;
+    case "change":
+      return quote?.change ?? null;
+    case "changePercent":
+      return quote?.changePercent ?? null;
+  }
+}
+
+function sortContracts(
+  contracts: FuturesContract[],
+  sortPreference: FuturesSortPreference,
+  quotes: BoardQuoteMap,
+): FuturesContract[] {
+  const columnId = sortPreference.columnId;
+  if (!columnId) return contracts;
+  return [...contracts].sort((left, right) => compareSortValues(
+    getSortValue(columnId, left, quotes),
+    getSortValue(columnId, right, quotes),
+    sortPreference.direction,
+  ));
+}
+
+export interface BuildFuturesRowsOptions {
+  /** Free-text query matched against contract code, symbol, and name. */
+  query?: string;
+  /** Sectors whose contracts are hidden under their header. */
+  collapsed?: ReadonlySet<FuturesSector>;
+}
+
+export function buildFuturesRows(
+  contractsBySector: Map<FuturesSector, FuturesContract[]>,
+  sortPreference: FuturesSortPreference,
+  quotes: BoardQuoteMap,
+  options?: BuildFuturesRowsOptions,
+): FuturesTableRow[] {
+  const rows: FuturesTableRow[] = [];
+  const query = options?.query ?? "";
+  for (const sector of FUTURES_SECTOR_ORDER) {
+    const contracts = sortContracts(contractsBySector.get(sector) ?? [], sortPreference, quotes)
+      .filter((contract) => matchesFuturesSearch(contract, query));
+    if (contracts.length === 0) continue;
+    rows.push({ type: "header", sector });
+    if (options?.collapsed?.has(sector)) continue;
+    for (const contract of contracts) rows.push({ type: "row", contract });
+  }
+  return rows;
+}
+
+export function nextFuturesSort(
+  current: FuturesSortPreference,
+  columnId: string,
+): FuturesSortPreference {
+  const typed = columnId as FuturesColumnId;
+  if (current.columnId !== typed) return { columnId: typed, direction: "asc" };
+  if (current.direction === "asc") return { columnId: typed, direction: "desc" };
+  return DEFAULT_FUTURES_SORT;
+}

--- a/src/plugins/builtin/futures/model.ts
+++ b/src/plugins/builtin/futures/model.ts
@@ -75,6 +75,21 @@ export interface BuildFuturesRowsOptions {
   collapsed?: ReadonlySet<FuturesSector>;
 }
 
+const NO_COLLAPSED_SECTORS: ReadonlySet<FuturesSector> = new Set();
+
+/**
+ * A search that hides its own matches is useless, so a live query outranks
+ * collapsed sectors. The pane draws its carets from this too, otherwise a
+ * sector would show ▶ above the rows it is supposedly hiding.
+ */
+export function effectiveCollapsedSectors(
+  collapsed: ReadonlySet<FuturesSector> | undefined,
+  query: string | undefined,
+): ReadonlySet<FuturesSector> {
+  if (query?.trim()) return NO_COLLAPSED_SECTORS;
+  return collapsed ?? NO_COLLAPSED_SECTORS;
+}
+
 export function buildFuturesRows(
   contractsBySector: Map<FuturesSector, FuturesContract[]>,
   sortPreference: FuturesSortPreference,
@@ -83,12 +98,13 @@ export function buildFuturesRows(
 ): FuturesTableRow[] {
   const rows: FuturesTableRow[] = [];
   const query = options?.query ?? "";
+  const collapsed = effectiveCollapsedSectors(options?.collapsed, query);
   for (const sector of FUTURES_SECTOR_ORDER) {
     const contracts = sortContracts(contractsBySector.get(sector) ?? [], sortPreference, quotes)
       .filter((contract) => matchesFuturesSearch(contract, query));
     if (contracts.length === 0) continue;
     rows.push({ type: "header", sector });
-    if (options?.collapsed?.has(sector)) continue;
+    if (collapsed.has(sector)) continue;
     for (const contract of contracts) rows.push({ type: "row", contract });
   }
   return rows;

--- a/src/plugins/builtin/futures/pane.test.tsx
+++ b/src/plugins/builtin/futures/pane.test.tsx
@@ -148,6 +148,63 @@ describe("FuturesPane", () => {
     expect(testSetup.captureCharFrame()).toContain("E-Mini S&P 500");
   });
 
+  test("clicking a sector header collapses it, and clicking again expands it", async () => {
+    testSetup = await testRender(<Harness />, { width: 80, height: 24 });
+    await renderSettled();
+
+    const headerRow = () => testSetup!.captureCharFrame()
+      .split("\n")
+      .findIndex((line) => line.includes("Equity Index"));
+    const row = headerRow();
+    expect(row).toBeGreaterThanOrEqual(0);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(4, row);
+      await testSetup!.renderOnce();
+    });
+    await renderSettled();
+
+    const collapsed = testSetup.captureCharFrame();
+    expect(collapsed).toContain("▶ Equity Index");
+    expect(collapsed).not.toContain("E-Mini S&P 500");
+    // A header click must not also open the pinned-ticker pane.
+    expect(pinned).toEqual([]);
+
+    await act(async () => {
+      await testSetup!.mockMouse.click(4, headerRow());
+      await testSetup!.renderOnce();
+    });
+    await renderSettled();
+
+    expect(testSetup.captureCharFrame()).toContain("E-Mini S&P 500");
+    expect(pinned).toEqual([]);
+  });
+
+  test("a search shows matches inside a collapsed sector", async () => {
+    testSetup = await testRender(<Harness />, { width: 80, height: 24 });
+    await renderSettled();
+
+    // Collapse Equity Index from its header, then search for one of its rows.
+    await emitKeypress({ name: "up", sequence: "\u001B[A" });
+    await emitKeypress({ name: "enter", sequence: "\r" });
+    await renderSettled();
+    expect(testSetup.captureCharFrame()).not.toContain("E-Mini Dow");
+
+    await emitKeypress({ name: "s", sequence: "s" });
+    for (const character of "dow") {
+      await emitKeypress({ name: character, sequence: character });
+    }
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await testSetup!.renderOnce();
+    });
+    await renderSettled();
+
+    const searching = testSetup.captureCharFrame();
+    expect(searching).toContain("E-Mini Dow");
+    expect(searching).toContain("▼ Equity Index");
+  });
+
   test("opens the selected contract in ticker research", async () => {
     testSetup = await testRender(<Harness />, { width: 80, height: 24 });
     await renderSettled();

--- a/src/plugins/builtin/futures/pane.test.tsx
+++ b/src/plugins/builtin/futures/pane.test.tsx
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { AppContext, createInitialState, PaneInstanceProvider } from "../../../state/app/context";
+import { createDefaultConfig } from "../../../types/config";
+import type { PinTickerOptions, QuoteBatchResult } from "../../../types/plugin";
+import { PluginRenderProvider, type PluginRuntimeAccess } from "../../runtime";
+import { futuresModule } from "./index";
+
+const FuturesPane = futuresModule.panes![0]!.component as (props: {
+  paneId: string;
+  paneType: string;
+  focused: boolean;
+  width: number;
+  height: number;
+}) => React.ReactNode;
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+const pinned: Array<{ symbol: string; options?: PinTickerOptions }> = [];
+
+afterEach(async () => {
+  pinned.length = 0;
+  if (!testSetup) return;
+  await act(async () => {
+    testSetup!.renderer.destroy();
+  });
+  testSetup = undefined;
+});
+
+function makeRuntime(): PluginRuntimeAccess {
+  const marketData = {
+    getQuote: async (symbol: string) => ({
+      symbol,
+      price: 100,
+      change: 1,
+      changePercent: 1,
+      marketState: "REGULAR" as const,
+      lastUpdated: Date.now(),
+    }),
+    getQuotesBatch: async (targets: Array<{ symbol: string }>): Promise<QuoteBatchResult[]> => (
+      targets.map((target) => ({
+        target: { symbol: target.symbol, exchange: "" },
+        quote: {
+          symbol: target.symbol,
+          price: 100,
+          change: 1,
+          changePercent: 1,
+          marketState: "REGULAR" as const,
+          lastUpdated: Date.now(),
+        },
+      })) as QuoteBatchResult[]
+    ),
+  };
+
+  return {
+    getMarketData: () => marketData as never,
+    getCapability: () => null,
+    getBrokerAdapter: () => null,
+    connectBrokerInstance: async () => {},
+    updateBrokerInstance: async () => {},
+    syncBrokerInstance: async () => {},
+    removeBrokerInstance: async () => {},
+    pinTicker: (symbol, options) => {
+      pinned.push({ symbol, options });
+    },
+    navigateTicker: () => {},
+    selectTicker: () => {},
+    switchTab: () => {},
+    switchPanel: () => {},
+    openCommandBar: () => {},
+    showPane: () => {},
+    createPaneFromTemplate: () => {},
+    hidePane: () => {},
+    openPaneSettings: () => {},
+    openPluginCommandWorkflow: () => {},
+    notify: () => {},
+    subscribeResumeState: () => () => {},
+    getResumeState: () => null,
+    setResumeState: () => {},
+    deleteResumeState: () => {},
+    getConfigState: () => null,
+    setConfigState: async () => {},
+    setConfigStates: async () => {},
+    deleteConfigState: async () => {},
+    getConfigStateKeys: () => [],
+  } as unknown as PluginRuntimeAccess;
+}
+
+function Harness() {
+  const state = createInitialState(createDefaultConfig("/tmp/gloomberb-futures-pane-test"));
+  return (
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <PluginRenderProvider runtime={makeRuntime()} pluginId="market-overview">
+        <PaneInstanceProvider paneId="futures">
+          <FuturesPane paneId="futures" paneType="futures" focused width={80} height={24} />
+        </PaneInstanceProvider>
+      </PluginRenderProvider>
+    </AppContext>
+  );
+}
+
+async function renderSettled() {
+  await act(async () => {
+    await testSetup!.renderOnce();
+    await testSetup!.renderOnce();
+  });
+}
+
+async function emitKeypress(event: { name?: string; sequence?: string }) {
+  await act(async () => {
+    testSetup!.renderer.keyInput.emit("keypress", {
+      ctrl: false,
+      meta: false,
+      option: false,
+      shift: false,
+      eventType: "press",
+      repeated: false,
+      defaultPrevented: false,
+      propagationStopped: false,
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      ...event,
+    } as never);
+    await testSetup!.renderOnce();
+  });
+}
+
+describe("FuturesPane", () => {
+  test("collapses and expands a sector from the keyboard", async () => {
+    testSetup = await testRender(<Harness />, { width: 80, height: 24 });
+    await renderSettled();
+
+    // Selection starts on the first contract, so step up onto its header.
+    expect(testSetup.captureCharFrame()).toContain("E-Mini S&P 500");
+    expect(testSetup.captureCharFrame()).toContain("▼ Equity Index");
+
+    await emitKeypress({ name: "up", sequence: "\u001B[A" });
+    await emitKeypress({ name: "enter", sequence: "\r" });
+    await renderSettled();
+    const collapsed = testSetup.captureCharFrame();
+    expect(collapsed).toContain("▶ Equity Index");
+    expect(collapsed).not.toContain("E-Mini S&P 500");
+    // Other sectors keep their contracts.
+    expect(collapsed).toContain("WTI Crude Oil");
+
+    await emitKeypress({ name: "enter", sequence: "\r" });
+    await renderSettled();
+    expect(testSetup.captureCharFrame()).toContain("E-Mini S&P 500");
+  });
+
+  test("opens the selected contract in ticker research", async () => {
+    testSetup = await testRender(<Harness />, { width: 80, height: 24 });
+    await renderSettled();
+
+    await emitKeypress({ name: "enter", sequence: "\r" });
+    await renderSettled();
+
+    expect(pinned).toHaveLength(1);
+    expect(pinned[0]!.symbol).toBe("ES=F");
+    expect(pinned[0]!.options).toMatchObject({ floating: true });
+  });
+
+  test("search narrows the board to matching contracts", async () => {
+    testSetup = await testRender(<Harness />, { width: 80, height: 24 });
+    await renderSettled();
+
+    await emitKeypress({ name: "s", sequence: "s" });
+    await renderSettled();
+    for (const character of "gold") {
+      await emitKeypress({ name: character, sequence: character });
+    }
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await testSetup!.renderOnce();
+    });
+    await renderSettled();
+
+    const filtered = testSetup.captureCharFrame();
+    expect(filtered).toContain("Gold");
+    expect(filtered).not.toContain("E-Mini S&P 500");
+  });
+});

--- a/src/plugins/builtin/futures/table.test.ts
+++ b/src/plugins/builtin/futures/table.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import type { Quote } from "../../../types/financials";
 import type { BoardQuoteMap } from "../shared/use-quote-board";
-import { FUTURES_CONTRACTS, type FuturesContract, type FuturesSector } from "./contracts";
+import {
+  FUTURES_CONTRACTS,
+  tickDecimals,
+  type FuturesContract,
+  type FuturesSector,
+} from "./contracts";
 import type { FuturesColumnId, FuturesTableRow } from "./model";
 import {
   createFuturesColumns,
@@ -18,12 +23,13 @@ function cellText(
   id: FuturesColumnId,
   quote: Partial<Quote>,
   sector: FuturesSector = "energy",
+  tick?: number,
 ): string {
-  const contract = contractFor(sector);
+  const contract = { ...contractFor(sector), tick };
   const row: FuturesTableRow = { type: "row", contract };
   const column = createFuturesColumns(100).find((candidate) => candidate.id === id) as FuturesColumn;
   const quotes: BoardQuoteMap = new Map([
-    ["X=F", { quote: quote as Quote, loading: false, error: null }],
+    ["X=F", { quote: quote as Quote, loading: false, error: null, stale: false }],
   ]);
   return renderFuturesCell(row, column, { selected: false }, quotes).text;
 }
@@ -89,6 +95,39 @@ describe("futures columns", () => {
       expect(total).toBeLessThanOrEqual(80);
       expect(columns.find((column) => column.id === "name")?.width ?? 0).toBeGreaterThanOrEqual(10);
     }
+  });
+});
+
+describe("contract tick precision", () => {
+  test("renders a contract to its own tick, not to its price magnitude", () => {
+    // Regression: silver ticks at $0.005, so two decimals collapsed every tick
+    // and printed the same price for 51.235 and 51.240.
+    expect(cellText("price", { price: 51.235 }, "metals", 0.005)).toBe("51.235");
+    expect(cellText("change", { price: 51.235, change: -0.045 }, "metals", 0.005)).toBe("-0.045");
+    // The magnitude fallback would have used two decimals for both.
+    expect(cellText("price", { price: 51.235 }, "metals")).toBe("51.24");
+  });
+
+  test("a declared tick also fixes precision when the price is unusable", () => {
+    expect(cellText("change", { price: Number.NaN, change: 0.01 }, "metals", 0.005)).toBe("+0.010");
+  });
+
+  test("the live catalog carries silver's tick and leaves 32nd-quoted rates alone", () => {
+    const bySymbol = new Map(FUTURES_CONTRACTS.map((contract) => [contract.symbol, contract]));
+    expect(bySymbol.get("SI=F")?.tick).toBe(0.005);
+    expect(bySymbol.get("GC=F")?.tick).toBe(0.1);
+    for (const contract of FUTURES_CONTRACTS) {
+      if (contract.sector === "rates") expect(contract.tick).toBeUndefined();
+      else expect(contract.tick).toBeGreaterThan(0);
+    }
+  });
+
+  test("tick decimals survive the ticks JS prints in exponential form", () => {
+    expect(tickDecimals(1)).toBe(0);
+    expect(tickDecimals(0.25)).toBe(2);
+    expect(tickDecimals(0.005)).toBe(3);
+    // String(0.0000005) is "5e-7", which a naive decimal count reads as 0.
+    expect(tickDecimals(0.0000005)).toBe(7);
   });
 });
 

--- a/src/plugins/builtin/futures/table.test.ts
+++ b/src/plugins/builtin/futures/table.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import type { Quote } from "../../../types/financials";
+import type { BoardQuoteMap } from "../shared/use-quote-board";
+import { FUTURES_CONTRACTS, type FuturesContract, type FuturesSector } from "./contracts";
+import type { FuturesColumnId, FuturesTableRow } from "./model";
+import {
+  createFuturesColumns,
+  renderFuturesCell,
+  resolveFuturesColumnIds,
+  type FuturesColumn,
+} from "./table";
+
+function contractFor(sector: FuturesSector): FuturesContract {
+  return { symbol: "X=F", code: "X", name: "Test", sector };
+}
+
+function cellText(
+  id: FuturesColumnId,
+  quote: Partial<Quote>,
+  sector: FuturesSector = "energy",
+): string {
+  const contract = contractFor(sector);
+  const row: FuturesTableRow = { type: "row", contract };
+  const column = createFuturesColumns(100).find((candidate) => candidate.id === id) as FuturesColumn;
+  const quotes: BoardQuoteMap = new Map([
+    ["X=F", { quote: quote as Quote, loading: false, error: null }],
+  ]);
+  return renderFuturesCell(row, column, { selected: false }, quotes).text;
+}
+
+describe("futures price formatting", () => {
+  test("scales precision to the contract's price", () => {
+    // Index futures trade in quarter points, FX futures in ten-thousandths,
+    // and the yen contract in millionths. One fixed precision serves none.
+    expect(cellText("price", { price: 7809.25 })).toBe("7,809.25");
+    expect(cellText("price", { price: 16.6 })).toBe("16.60");
+    expect(cellText("price", { price: 2.678 })).toBe("2.6780");
+    expect(cellText("price", { price: 1.1588 }, "currencies")).toBe("1.1588");
+    expect(cellText("price", { price: 0.006282 }, "currencies")).toBe("0.006282");
+  });
+
+  test("keeps trailing zeros so a column stays aligned", () => {
+    // Regression: 1.16 rendered beside 1.3544 and beside its own +0.0002 change.
+    expect(cellText("price", { price: 1.16 }, "currencies")).toBe("1.1600");
+    expect(cellText("change", { price: 1.16, change: 0.0002 }, "currencies")).toBe("+0.0002");
+  });
+
+  test("keeps Treasury tick detail that two decimals would collapse", () => {
+    // ZT ticks in 1/8 of a 32nd (0.0078); 103.05 and 103.06 would merge ticks.
+    expect(cellText("price", { price: 103.05469 }, "rates")).toBe("103.0547");
+    expect(cellText("price", { price: 108.53125 }, "rates")).toBe("108.5313");
+    expect(cellText("change", { price: 108.53125, change: 0.078125 }, "rates")).toBe("+0.0781");
+  });
+
+  test("marks cent-quoted grains so they are not read as dollars", () => {
+    expect(cellText("price", { price: 483.25, currency: "USX" }, "agriculture")).toBe("483.25c");
+    expect(cellText("price", { price: 483.25, currency: "USD" }, "agriculture")).toBe("483.25");
+  });
+
+  test("scales the session change to the price, not to its own magnitude", () => {
+    // Regression: a 0.400098 move on a 3,075 contract rendered as "+0.400098"
+    // beside a price showing two decimals.
+    expect(cellText("change", { price: 3075.3, change: 0.400098 })).toBe("+0.40");
+    expect(cellText("change", { price: 82.39, change: -0.010002 })).toBe("-0.01");
+    expect(cellText("change", { price: 2.678, change: -0.055 })).toBe("-0.0550");
+  });
+
+  test("renders a placeholder rather than NaN for unusable numbers", () => {
+    expect(cellText("price", {})).toBe("—");
+    expect(cellText("change", { price: 100 })).toBe("—");
+    expect(cellText("price", { price: Number.NaN })).toBe("—");
+    expect(cellText("change", { price: 100, change: Number.NaN })).toBe("—");
+    expect(cellText("changePercent", { price: 100, changePercent: Number.NaN })).toBe("—");
+  });
+});
+
+describe("futures columns", () => {
+  test("honors a saved column selection and falls back when it is unusable", () => {
+    expect(resolveFuturesColumnIds(["code", "price"])).toEqual(["code", "price"]);
+    expect(resolveFuturesColumnIds([])).toHaveLength(6);
+    expect(resolveFuturesColumnIds(["bogus"])).toHaveLength(6);
+    expect(resolveFuturesColumnIds(undefined)).toHaveLength(6);
+  });
+
+  test("gives the name column the leftover width whichever columns are visible", () => {
+    for (const visible of [undefined, ["code", "name", "price"]]) {
+      const columns = createFuturesColumns(80, visible);
+      const total = columns.reduce((sum, column) => sum + (column.width ?? 0), 0);
+      expect(total).toBeLessThanOrEqual(80);
+      expect(columns.find((column) => column.id === "name")?.width ?? 0).toBeGreaterThanOrEqual(10);
+    }
+  });
+});
+
+describe("futures catalog", () => {
+  test("holds only live-validated Yahoo continuous symbols", () => {
+    // DX=F 404s on Yahoo; the dollar index lives on the world indices board.
+    expect(FUTURES_CONTRACTS.some((contract) => contract.symbol === "DX=F")).toBe(false);
+    const symbols = FUTURES_CONTRACTS.map((contract) => contract.symbol);
+    expect(new Set(symbols).size).toBe(symbols.length);
+    for (const symbol of symbols) expect(symbol).toMatch(/^[A-Z0-9]+=F$/);
+  });
+});

--- a/src/plugins/builtin/futures/table.tsx
+++ b/src/plugins/builtin/futures/table.tsx
@@ -1,0 +1,155 @@
+import type { DataTableCell, DataTableColumn } from "../../../components";
+import { colors, priceColor } from "../../../theme/colors";
+import type { Quote } from "../../../types/financials";
+import { TextAttributes } from "../../../ui";
+import { formatNumber, formatPercentRaw } from "../../../utils/format";
+import { marketStatusDot, type BoardQuoteMap } from "../shared/use-quote-board";
+import type { FuturesContract } from "./contracts";
+import type { FuturesColumnId, FuturesTableRow } from "./model";
+
+export type FuturesColumn = DataTableColumn & { id: FuturesColumnId };
+
+export interface FuturesColumnDef {
+  id: FuturesColumnId;
+  label: string;
+  description: string;
+}
+
+export const FUTURES_COLUMN_DEFS: readonly FuturesColumnDef[] = [
+  { id: "status", label: "Session", description: "Live trading session indicator." },
+  { id: "code", label: "Symbol", description: "Exchange contract code." },
+  { id: "name", label: "Contract", description: "Contract name." },
+  { id: "price", label: "Last", description: "Last traded price." },
+  { id: "change", label: "Change", description: "Change on the session." },
+  { id: "changePercent", label: "Change %", description: "Percent change on the session." },
+];
+
+const DEFAULT_FUTURES_COLUMN_IDS = FUTURES_COLUMN_DEFS.map((column) => column.id);
+
+const COLUMN_WIDTHS: Record<Exclude<FuturesColumnId, "name">, number> = {
+  status: 1,
+  code: 5,
+  price: 12,
+  change: 10,
+  changePercent: 9,
+};
+
+export function createFuturesColumns(width: number, visibleIds?: readonly string[]): FuturesColumn[] {
+  const ids = resolveFuturesColumnIds(visibleIds);
+  const fixed = ids
+    .filter((id): id is Exclude<FuturesColumnId, "name"> => id !== "name")
+    .reduce((total, id) => total + COLUMN_WIDTHS[id], 0);
+  const nameWidth = Math.max(10, width - 2 - ids.length - fixed);
+
+  return ids.map((id) => {
+    const label = FUTURES_HEADER_LABELS[id];
+    if (id === "name") return { id, label, width: nameWidth, align: "left" };
+    return {
+      id,
+      label,
+      width: COLUMN_WIDTHS[id],
+      align: id === "code" || id === "status" ? "left" : "right",
+    };
+  });
+}
+
+const FUTURES_HEADER_LABELS: Record<FuturesColumnId, string> = {
+  status: "",
+  code: "SYM",
+  name: "CONTRACT",
+  price: "LAST",
+  change: "CHG",
+  changePercent: "CHG%",
+};
+
+/** Falls back to the full column set when the saved selection is empty or unknown. */
+export function resolveFuturesColumnIds(visibleIds?: readonly string[]): FuturesColumnId[] {
+  const resolved = (visibleIds ?? [])
+    .filter((id): id is FuturesColumnId => DEFAULT_FUTURES_COLUMN_IDS.includes(id as FuturesColumnId));
+  return resolved.length > 0 ? resolved : [...DEFAULT_FUTURES_COLUMN_IDS];
+}
+
+/**
+ * Futures are not quoted in dollars the way equities are: grains come back in
+ * US cents (`USX`), FX contracts run to six decimals, and Treasury contracts
+ * trade in fractions of a 32nd. Scale precision to the contract instead of
+ * rendering everything as a currency amount.
+ *
+ * ponytail: rates render as decimals, not the 32nds tick notation traders
+ * quote (108'17). Add a tick formatter if rates users ask for it.
+ */
+function priceDecimals(price: number, contract: FuturesContract): number {
+  if (contract.sector === "rates") return 4;
+  const magnitude = Math.abs(price);
+  if (magnitude >= 10) return 2;
+  if (magnitude >= 1) return 4;
+  return 6;
+}
+
+/**
+ * Trailing zeros are kept: a EUR contract at 1.1600 has to line up with the
+ * 1.3544 pound contract beside it, and with its own "+0.0002" change.
+ */
+function formatContractPrice(quote: Quote, contract: FuturesContract): string {
+  if (!Number.isFinite(quote.price)) return "—";
+  const text = formatNumber(quote.price, priceDecimals(quote.price, contract));
+  return quote.currency === "USX" ? `${text}c` : text;
+}
+
+/**
+ * The session change is scaled to the contract's price, not to its own
+ * magnitude, otherwise a four-tick move on an index future renders with six
+ * decimals next to a price showing two.
+ */
+function formatContractChange(quote: Quote, contract: FuturesContract): string {
+  if (!Number.isFinite(quote.change)) return "—";
+  const decimals = Number.isFinite(quote.price) ? priceDecimals(quote.price, contract) : 2;
+  const text = formatNumber(Math.abs(quote.change), decimals);
+  return `${quote.change >= 0 ? "+" : "-"}${text}`;
+}
+
+export function renderFuturesCell(
+  row: FuturesTableRow,
+  column: FuturesColumn,
+  rowState: { selected: boolean },
+  quotes: BoardQuoteMap,
+): DataTableCell {
+  if (row.type === "header") return { text: "" };
+
+  const { contract } = row;
+  const state = quotes.get(contract.symbol);
+  const quote = state?.quote;
+  const selectedColor = rowState.selected ? colors.selectedText : undefined;
+  const dimmed = rowState.selected ? colors.selectedText : colors.textDim;
+
+  switch (column.id) {
+    case "status": {
+      const dot = marketStatusDot(quote?.marketState);
+      return { text: dot.char, color: rowState.selected ? colors.selectedText : dot.color };
+    }
+    case "code":
+      return {
+        text: contract.code,
+        color: selectedColor ?? colors.textBright,
+        attributes: TextAttributes.BOLD,
+      };
+    case "name":
+      return { text: contract.name, color: selectedColor };
+    case "price":
+      if (state?.loading && !quote) return { text: "…", color: dimmed };
+      if (state?.error || !quote) return { text: "—", color: dimmed };
+      return { text: formatContractPrice(quote, contract), color: selectedColor };
+    case "change":
+      if (!quote || !Number.isFinite(quote.change)) return { text: "—", color: dimmed };
+      return {
+        text: formatContractChange(quote, contract),
+        color: selectedColor ?? priceColor(quote.change),
+      };
+    case "changePercent":
+      if (!quote || !Number.isFinite(quote.changePercent)) return { text: "—", color: dimmed };
+      return {
+        text: formatPercentRaw(quote.changePercent),
+        color: selectedColor ?? priceColor(quote.changePercent),
+      };
+  }
+}

--- a/src/plugins/builtin/futures/table.tsx
+++ b/src/plugins/builtin/futures/table.tsx
@@ -4,7 +4,7 @@ import type { Quote } from "../../../types/financials";
 import { TextAttributes } from "../../../ui";
 import { formatNumber, formatPercentRaw } from "../../../utils/format";
 import { marketStatusDot, type BoardQuoteMap } from "../shared/use-quote-board";
-import type { FuturesContract } from "./contracts";
+import { tickDecimals, type FuturesContract } from "./contracts";
 import type { FuturesColumnId, FuturesTableRow } from "./model";
 
 export type FuturesColumn = DataTableColumn & { id: FuturesColumnId };
@@ -75,10 +75,15 @@ export function resolveFuturesColumnIds(visibleIds?: readonly string[]): Futures
  * trade in fractions of a 32nd. Scale precision to the contract instead of
  * rendering everything as a currency amount.
  *
+ * The contract's own tick wins when the catalog knows it, so silver keeps its
+ * $0.005 increments instead of being rounded into two decimals with gold. The
+ * magnitude fallback only covers contracts without a declared tick.
+ *
  * ponytail: rates render as decimals, not the 32nds tick notation traders
  * quote (108'17). Add a tick formatter if rates users ask for it.
  */
 function priceDecimals(price: number, contract: FuturesContract): number {
+  if (contract.tick) return tickDecimals(contract.tick);
   if (contract.sector === "rates") return 4;
   const magnitude = Math.abs(price);
   if (magnitude >= 10) return 2;
@@ -103,7 +108,9 @@ function formatContractPrice(quote: Quote, contract: FuturesContract): string {
  */
 function formatContractChange(quote: Quote, contract: FuturesContract): string {
   if (!Number.isFinite(quote.change)) return "—";
-  const decimals = Number.isFinite(quote.price) ? priceDecimals(quote.price, contract) : 2;
+  const decimals = contract.tick || Number.isFinite(quote.price)
+    ? priceDecimals(quote.price, contract)
+    : 2;
   const text = formatNumber(Math.abs(quote.change), decimals);
   return `${quote.change >= 0 ? "+" : "-"}${text}`;
 }
@@ -137,8 +144,12 @@ export function renderFuturesCell(
       return { text: contract.name, color: selectedColor };
     case "price":
       if (state?.loading && !quote) return { text: "…", color: dimmed };
-      if (state?.error || !quote) return { text: "—", color: dimmed };
-      return { text: formatContractPrice(quote, contract), color: selectedColor };
+      if (!quote) return { text: "—", color: dimmed };
+      // A retained quote still beats a dash; dim it so stale is visible.
+      return {
+        text: formatContractPrice(quote, contract),
+        color: state?.stale ? dimmed : selectedColor,
+      };
     case "change":
       if (!quote || !Number.isFinite(quote.change)) return { text: "—", color: dimmed };
       return {

--- a/src/plugins/builtin/shared/use-quote-board.test.tsx
+++ b/src/plugins/builtin/shared/use-quote-board.test.tsx
@@ -196,11 +196,10 @@ describe("useQuoteBoard failure handling", () => {
     expect(quoteBoardStatus(quotes).stale).toBe(2);
   });
 
-  test("a symbol that never resolved reports unavailable, not stale", async () => {
+  test("a symbol that never resolved reports unavailable without requiring an error", async () => {
     const { provider } = batchProvider(() => SYMBOLS.map((symbol) => ({
       target: { symbol, exchange: "" },
       quote: symbol === "^GSPC" ? quote(symbol, 100) : null,
-      error: symbol === "^GSPC" ? undefined : new Error("unknown symbol"),
     })));
     await mount(provider);
 

--- a/src/plugins/builtin/shared/use-quote-board.test.tsx
+++ b/src/plugins/builtin/shared/use-quote-board.test.tsx
@@ -1,0 +1,212 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useMemo } from "react";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import type { MarketDataRequestContext, QuoteBatchResult } from "../../../types/data-provider";
+import type { Quote } from "../../../types/financials";
+import { Text } from "../../../ui";
+import { PluginRenderProvider, type PluginRuntimeAccess } from "../../runtime";
+import {
+  quoteBoardFooterInfo,
+  quoteBoardStatus,
+  useQuoteBoard,
+  type BoardQuoteMap,
+} from "./use-quote-board";
+
+const SYMBOLS = ["^GSPC", "^FTSE"];
+const POLL_MS = 40;
+
+function quote(symbol: string, price: number): Quote {
+  return {
+    symbol,
+    price,
+    change: 1,
+    changePercent: 1,
+    marketState: "REGULAR",
+    lastUpdated: 1_700_000_000_000,
+  } as Quote;
+}
+
+interface BatchCall {
+  symbols: string[];
+  forceRefresh: boolean | undefined;
+}
+
+/** Batch-capable provider whose next answer the test swaps between loads. */
+function batchProvider(reply: () => QuoteBatchResult[] | Error) {
+  const calls: BatchCall[] = [];
+  const provider = {
+    getQuotesBatch: async (
+      targets: Array<{ symbol: string }>,
+      options?: { forceRefresh?: boolean },
+    ): Promise<QuoteBatchResult[]> => {
+      calls.push({
+        symbols: targets.map((target) => target.symbol),
+        forceRefresh: options?.forceRefresh,
+      });
+      const answer = reply();
+      if (answer instanceof Error) throw answer;
+      return answer;
+    },
+  };
+  return { provider, calls };
+}
+
+let quotes: BoardQuoteMap = new Map();
+let refreshBoard: () => void = () => {};
+
+function Probe({ intervalMs }: { intervalMs: number }) {
+  const board = useQuoteBoard(SYMBOLS, intervalMs);
+  quotes = board.quotes;
+  refreshBoard = board.refresh;
+  return <Text>{`${board.quotes.size}`}</Text>;
+}
+
+function Harness({ provider, intervalMs }: { provider: object; intervalMs: number }) {
+  const runtime = useMemo(
+    () => ({ getMarketData: () => provider }) as unknown as PluginRuntimeAccess,
+    [provider],
+  );
+  return (
+    <PluginRenderProvider runtime={runtime} pluginId="test">
+      <Probe intervalMs={intervalMs} />
+    </PluginRenderProvider>
+  );
+}
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(async () => {
+  quotes = new Map();
+  refreshBoard = () => {};
+  if (!testSetup) return;
+  await act(async () => {
+    testSetup!.renderer.destroy();
+  });
+  testSetup = undefined;
+});
+
+async function mount(provider: object, intervalMs = 10_000) {
+  testSetup = await testRender(<Harness provider={provider} intervalMs={intervalMs} />, {
+    width: 40,
+    height: 6,
+  });
+  await settle();
+}
+
+async function settle(waitMs = 0) {
+  await act(async () => {
+    if (waitMs > 0) await new Promise((resolve) => setTimeout(resolve, waitMs));
+    await testSetup!.renderOnce();
+    await testSetup!.renderOnce();
+  });
+}
+
+describe("useQuoteBoard cache bypass", () => {
+  test("serves the cache on open, then forces every refresh after it", async () => {
+    const { provider, calls } = batchProvider(() => (
+      SYMBOLS.map((symbol) => ({ target: { symbol, exchange: "" }, quote: quote(symbol, 100) }))
+    ));
+    await mount(provider, POLL_MS);
+
+    // Opening a pane may paint from cache; a refresh that returns cache is a lie.
+    expect(calls[0]).toEqual({ symbols: SYMBOLS, forceRefresh: false });
+
+    await act(async () => {
+      refreshBoard();
+    });
+    await settle();
+    expect(calls[1]?.forceRefresh).toBe(true);
+
+    // The poll is a refresh too, so it must bypass the provider cache as well.
+    await settle(POLL_MS * 2);
+    expect(calls.length).toBeGreaterThan(2);
+    expect(calls.slice(1).every((call) => call.forceRefresh === true)).toBe(true);
+  });
+
+  test("the serial fallback asks for a fresh quote the same way", async () => {
+    const contexts: Array<MarketDataRequestContext | undefined> = [];
+    const provider = {
+      getQuote: async (symbol: string, _exchange?: string, context?: MarketDataRequestContext) => {
+        contexts.push(context);
+        return quote(symbol, 100);
+      },
+    };
+    await mount(provider);
+
+    await act(async () => {
+      refreshBoard();
+    });
+    await settle();
+
+    expect(contexts.slice(0, SYMBOLS.length).every((context) => context === undefined)).toBe(true);
+    expect(contexts.slice(SYMBOLS.length).every((context) => context?.cacheMode === "refresh"))
+      .toBe(true);
+  });
+});
+
+describe("useQuoteBoard failure handling", () => {
+  test("keeps the last good quote and reports it stale instead of blanking", async () => {
+    let fail = false;
+    const { provider } = batchProvider(() => (
+      fail
+        ? SYMBOLS.map((symbol) => ({
+          target: { symbol, exchange: "" },
+          quote: null,
+          error: new Error("upstream 503"),
+        }))
+        : SYMBOLS.map((symbol) => ({ target: { symbol, exchange: "" }, quote: quote(symbol, 100) }))
+    ));
+    await mount(provider);
+    expect(quotes.get("^GSPC")?.quote?.price).toBe(100);
+
+    fail = true;
+    await act(async () => {
+      refreshBoard();
+    });
+    await settle();
+
+    const state = quotes.get("^GSPC");
+    expect(state?.quote?.price).toBe(100);
+    expect(state?.stale).toBe(true);
+    expect(state?.error).toBe("upstream 503");
+
+    const status = quoteBoardStatus(quotes);
+    expect(status).toMatchObject({ loading: 0, stale: 2, unavailable: 0 });
+    expect(quoteBoardFooterInfo(status).map((segment) => segment.id))
+      .toEqual(["stale", "fresh"]);
+  });
+
+  test("a whole batch call that throws still leaves the board readable", async () => {
+    let fail = false;
+    const { provider } = batchProvider(() => (
+      fail
+        ? new Error("network down")
+        : SYMBOLS.map((symbol) => ({ target: { symbol, exchange: "" }, quote: quote(symbol, 100) }))
+    ));
+    await mount(provider);
+
+    fail = true;
+    await act(async () => {
+      refreshBoard();
+    });
+    await settle();
+
+    expect(quotes.get("^FTSE")?.quote?.price).toBe(100);
+    expect(quotes.get("^FTSE")?.stale).toBe(true);
+    expect(quoteBoardStatus(quotes).stale).toBe(2);
+  });
+
+  test("a symbol that never resolved reports unavailable, not stale", async () => {
+    const { provider } = batchProvider(() => SYMBOLS.map((symbol) => ({
+      target: { symbol, exchange: "" },
+      quote: symbol === "^GSPC" ? quote(symbol, 100) : null,
+      error: symbol === "^GSPC" ? undefined : new Error("unknown symbol"),
+    })));
+    await mount(provider);
+
+    expect(quotes.get("^FTSE")?.quote).toBeNull();
+    const status = quoteBoardStatus(quotes);
+    expect(status).toMatchObject({ stale: 0, unavailable: 1 });
+    expect(quoteBoardFooterInfo(status).map((segment) => segment.id)).toEqual(["error", "fresh"]);
+  });
+});

--- a/src/plugins/builtin/shared/use-quote-board.ts
+++ b/src/plugins/builtin/shared/use-quote-board.ts
@@ -147,7 +147,7 @@ export function quoteBoardStatus(quotes: BoardQuoteMap): QuoteBoardStatus {
   for (const state of quotes.values()) {
     if (state.loading) loading += 1;
     if (state.stale) stale += 1;
-    else if (!state.quote && state.error) unavailable += 1;
+    else if (!state.quote && !state.loading) unavailable += 1;
     latestTs = Math.max(latestTs, state.quote?.lastUpdated ?? 0);
   }
   return { loading, stale, unavailable, latestTs };

--- a/src/plugins/builtin/shared/use-quote-board.ts
+++ b/src/plugins/builtin/shared/use-quote-board.ts
@@ -1,18 +1,41 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { PaneFooterSegment } from "../../../components";
 import { colors } from "../../../theme/colors";
 import type { MarketState, Quote } from "../../../types/financials";
 import { useAssetData } from "../../runtime";
 
-interface BoardQuoteState {
+export interface BoardQuoteState {
   quote: Quote | null;
   loading: boolean;
   error: string | null;
+  /** The quote is the last good one, kept because the newest load returned nothing. */
+  stale: boolean;
 }
 
 export type BoardQuoteMap = Map<string, BoardQuoteState>;
 
+const EMPTY_STATE: BoardQuoteState = { quote: null, loading: false, error: null, stale: false };
+
 function errorMessage(value: unknown): string {
   return value instanceof Error ? value.message : String(value);
+}
+
+/**
+ * A failed refresh must not blank a board that was showing prices a second
+ * ago: keep the last good quote and mark it stale instead.
+ */
+function mergeQuotes(previous: BoardQuoteMap, loaded: BoardQuoteMap): BoardQuoteMap {
+  const next = new Map(previous);
+  for (const [symbol, state] of loaded) {
+    const retained = state.quote ?? previous.get(symbol)?.quote ?? null;
+    next.set(symbol, {
+      quote: retained,
+      loading: false,
+      error: state.error,
+      stale: !state.quote && retained !== null,
+    });
+  }
+  return next;
 }
 
 /**
@@ -21,6 +44,10 @@ function errorMessage(value: unknown): string {
  * Boards differ only in which symbols they watch, so the batch/serial fallback
  * and the stale-response guard live here instead of in each pane. `symbols`
  * must be a stable reference; boards build theirs from module-level catalogs.
+ *
+ * The first load may serve the provider cache, which is what makes a board
+ * paint instantly on open. Every load after it is a refresh the user asked for
+ * (manually or on the poll interval) and bypasses those caches.
  */
 export function useQuoteBoard(symbols: string[], refreshIntervalMs: number): {
   quotes: BoardQuoteMap;
@@ -32,7 +59,7 @@ export function useQuoteBoard(symbols: string[], refreshIntervalMs: number): {
   // request is allowed to write.
   const fetchGenRef = useRef(0);
 
-  const refresh = useCallback(() => {
+  const load = useCallback((forceRefresh: boolean) => {
     if (!dataProvider) return;
 
     fetchGenRef.current += 1;
@@ -41,7 +68,7 @@ export function useQuoteBoard(symbols: string[], refreshIntervalMs: number): {
     setQuotes((prev) => {
       const next = new Map(prev);
       for (const symbol of symbols) {
-        next.set(symbol, { quote: prev.get(symbol)?.quote ?? null, loading: true, error: null });
+        next.set(symbol, { ...(prev.get(symbol) ?? EMPTY_STATE), loading: true });
       }
       return next;
     });
@@ -51,6 +78,7 @@ export function useQuoteBoard(symbols: string[], refreshIntervalMs: number): {
       if (dataProvider.getQuotesBatch) {
         const results = await dataProvider.getQuotesBatch(
           symbols.map((symbol) => ({ symbol, exchange: "" })),
+          { forceRefresh },
         );
         const bySymbol = new Map(results.map((result) => [result.target.symbol, result]));
         for (const symbol of symbols) {
@@ -59,16 +87,19 @@ export function useQuoteBoard(symbols: string[], refreshIntervalMs: number): {
             quote: result?.quote ?? null,
             loading: false,
             error: result?.error ? errorMessage(result.error) : null,
+            stale: false,
           });
         }
         return next;
       }
 
+      const context = forceRefresh ? { cacheMode: "refresh" as const } : undefined;
       await Promise.all(symbols.map(async (symbol) => {
         try {
-          next.set(symbol, { quote: await dataProvider.getQuote(symbol, ""), loading: false, error: null });
+          const quote = await dataProvider.getQuote(symbol, "", context);
+          next.set(symbol, { quote, loading: false, error: null, stale: false });
         } catch (error: unknown) {
-          next.set(symbol, { quote: null, loading: false, error: errorMessage(error) });
+          next.set(symbol, { quote: null, loading: false, error: errorMessage(error), stale: false });
         }
       }));
       return next;
@@ -76,37 +107,72 @@ export function useQuoteBoard(symbols: string[], refreshIntervalMs: number): {
 
     loadQuotes().then((loaded) => {
       if (fetchGenRef.current !== gen) return;
-      setQuotes((prev) => {
-        const next = new Map(prev);
-        for (const [symbol, state] of loaded) next.set(symbol, state);
-        return next;
-      });
+      setQuotes((prev) => mergeQuotes(prev, loaded));
     }).catch((error: unknown) => {
       if (fetchGenRef.current !== gen) return;
       const message = errorMessage(error);
-      setQuotes((prev) => {
-        const next = new Map(prev);
-        for (const symbol of symbols) next.set(symbol, { quote: null, loading: false, error: message });
-        return next;
-      });
+      const failed: BoardQuoteMap = new Map(symbols.map((symbol) => [
+        symbol,
+        { quote: null, loading: false, error: message, stale: false },
+      ]));
+      setQuotes((prev) => mergeQuotes(prev, failed));
     });
   }, [dataProvider, symbols]);
 
+  const refresh = useCallback(() => load(true), [load]);
+
   useEffect(() => {
-    refresh();
-    const interval = setInterval(refresh, refreshIntervalMs);
+    load(false);
+    const interval = setInterval(() => load(true), refreshIntervalMs);
     return () => clearInterval(interval);
-  }, [refresh, refreshIntervalMs]);
+  }, [load, refreshIntervalMs]);
 
   return { quotes, refresh };
 }
 
-export function countLoadingQuotes(quotes: BoardQuoteMap): number {
-  return Array.from(quotes.values()).filter((state) => state.loading).length;
+export interface QuoteBoardStatus {
+  loading: number;
+  /** Symbols showing their last good quote after a failed load. */
+  stale: number;
+  /** Symbols with no quote to show at all. */
+  unavailable: number;
+  latestTs: number;
 }
 
-export function latestQuoteTimestamp(quotes: BoardQuoteMap): number {
-  return Math.max(0, ...Array.from(quotes.values()).map((state) => state.quote?.lastUpdated ?? 0));
+export function quoteBoardStatus(quotes: BoardQuoteMap): QuoteBoardStatus {
+  let loading = 0;
+  let stale = 0;
+  let unavailable = 0;
+  let latestTs = 0;
+  for (const state of quotes.values()) {
+    if (state.loading) loading += 1;
+    if (state.stale) stale += 1;
+    else if (!state.quote && state.error) unavailable += 1;
+    latestTs = Math.max(latestTs, state.quote?.lastUpdated ?? 0);
+  }
+  return { loading, stale, unavailable, latestTs };
+}
+
+/** Board footer status: everything here changes as loads succeed or fail. */
+export function quoteBoardFooterInfo(status: QuoteBoardStatus): PaneFooterSegment[] {
+  const info: PaneFooterSegment[] = [];
+  if (status.loading > 0) info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
+  if (status.stale > 0) {
+    info.push({ id: "stale", parts: [{ text: `${status.stale} stale`, tone: "warning" }] });
+  }
+  if (status.unavailable > 0) {
+    info.push({ id: "error", parts: [{ text: `${status.unavailable} unavailable`, tone: "warning" }] });
+  }
+  if (status.latestTs > 0) {
+    info.push({
+      id: "fresh",
+      parts: [{
+        text: new Date(status.latestTs).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+        tone: "muted",
+      }],
+    });
+  }
+  return info;
 }
 
 /**

--- a/src/plugins/builtin/shared/use-quote-board.ts
+++ b/src/plugins/builtin/shared/use-quote-board.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { colors } from "../../../theme/colors";
+import type { MarketState, Quote } from "../../../types/financials";
+import { useAssetData } from "../../runtime";
+
+interface BoardQuoteState {
+  quote: Quote | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export type BoardQuoteMap = Map<string, BoardQuoteState>;
+
+function errorMessage(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
+
+/**
+ * Polls a fixed symbol list for a quote board (world indices, futures).
+ *
+ * Boards differ only in which symbols they watch, so the batch/serial fallback
+ * and the stale-response guard live here instead of in each pane. `symbols`
+ * must be a stable reference; boards build theirs from module-level catalogs.
+ */
+export function useQuoteBoard(symbols: string[], refreshIntervalMs: number): {
+  quotes: BoardQuoteMap;
+  refresh: () => void;
+} {
+  const dataProvider = useAssetData();
+  const [quotes, setQuotes] = useState<BoardQuoteMap>(new Map());
+  // A manual refresh can land after an in-flight poll, so only the newest
+  // request is allowed to write.
+  const fetchGenRef = useRef(0);
+
+  const refresh = useCallback(() => {
+    if (!dataProvider) return;
+
+    fetchGenRef.current += 1;
+    const gen = fetchGenRef.current;
+
+    setQuotes((prev) => {
+      const next = new Map(prev);
+      for (const symbol of symbols) {
+        next.set(symbol, { quote: prev.get(symbol)?.quote ?? null, loading: true, error: null });
+      }
+      return next;
+    });
+
+    const loadQuotes = async (): Promise<BoardQuoteMap> => {
+      const next: BoardQuoteMap = new Map();
+      if (dataProvider.getQuotesBatch) {
+        const results = await dataProvider.getQuotesBatch(
+          symbols.map((symbol) => ({ symbol, exchange: "" })),
+        );
+        const bySymbol = new Map(results.map((result) => [result.target.symbol, result]));
+        for (const symbol of symbols) {
+          const result = bySymbol.get(symbol);
+          next.set(symbol, {
+            quote: result?.quote ?? null,
+            loading: false,
+            error: result?.error ? errorMessage(result.error) : null,
+          });
+        }
+        return next;
+      }
+
+      await Promise.all(symbols.map(async (symbol) => {
+        try {
+          next.set(symbol, { quote: await dataProvider.getQuote(symbol, ""), loading: false, error: null });
+        } catch (error: unknown) {
+          next.set(symbol, { quote: null, loading: false, error: errorMessage(error) });
+        }
+      }));
+      return next;
+    };
+
+    loadQuotes().then((loaded) => {
+      if (fetchGenRef.current !== gen) return;
+      setQuotes((prev) => {
+        const next = new Map(prev);
+        for (const [symbol, state] of loaded) next.set(symbol, state);
+        return next;
+      });
+    }).catch((error: unknown) => {
+      if (fetchGenRef.current !== gen) return;
+      const message = errorMessage(error);
+      setQuotes((prev) => {
+        const next = new Map(prev);
+        for (const symbol of symbols) next.set(symbol, { quote: null, loading: false, error: message });
+        return next;
+      });
+    });
+  }, [dataProvider, symbols]);
+
+  useEffect(() => {
+    refresh();
+    const interval = setInterval(refresh, refreshIntervalMs);
+    return () => clearInterval(interval);
+  }, [refresh, refreshIntervalMs]);
+
+  return { quotes, refresh };
+}
+
+export function countLoadingQuotes(quotes: BoardQuoteMap): number {
+  return Array.from(quotes.values()).filter((state) => state.loading).length;
+}
+
+export function latestQuoteTimestamp(quotes: BoardQuoteMap): number {
+  return Math.max(0, ...Array.from(quotes.values()).map((state) => state.quote?.lastUpdated ?? 0));
+}
+
+/**
+ * Board session indicator: one glyph whose color carries the whole signal.
+ * `marketStateDot` in `src/market-data/market/status.ts` encodes the state in
+ * the glyph instead, which reads poorly in a one-cell column.
+ */
+export function marketStatusDot(state: MarketState | undefined): { char: string; color: string } {
+  switch (state) {
+    case "REGULAR":
+      return { char: "●", color: colors.positive };
+    case "PRE":
+    case "POST":
+    case "PREPRE":
+    case "POSTPOST":
+      return { char: "●", color: colors.warning };
+    default:
+      return { char: "●", color: colors.negative };
+  }
+}

--- a/src/plugins/builtin/treasury-auctions/cache.test.ts
+++ b/src/plugins/builtin/treasury-auctions/cache.test.ts
@@ -110,6 +110,20 @@ describe("loadTreasuryAuctions", () => {
     expect(writes).toHaveLength(0);
   });
 
+  test("never caches an empty payload, so the next load can still recover", async () => {
+    const { persistence, writes } = fakePersistence();
+    attachTreasuryAuctionsPersistence(persistence);
+
+    // Nothing to fall back on: an empty window is a failure, not "no auctions".
+    await expect(loadTreasuryAuctions(true, async () => [])).rejects.toThrow(/no auctions/);
+    expect(writes).toHaveLength(0);
+
+    const recovered = await loadTreasuryAuctions(false, async () => [auctionFixture("network")]);
+    expect(recovered.auctions[0]!.id).toBe("network");
+    expect(recovered.stale).toBe(false);
+    expect(writes).toHaveLength(1);
+  });
+
   test("shares one in-flight fetch across concurrent callers", async () => {
     const { persistence } = fakePersistence();
     attachTreasuryAuctionsPersistence(persistence);

--- a/src/plugins/builtin/treasury-auctions/cache.test.ts
+++ b/src/plugins/builtin/treasury-auctions/cache.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { ConnectionHealthRegistry } from "../../../core/connection-health";
 import type { PluginPersistence } from "../../../types/plugin";
 import {
   attachTreasuryAuctionsPersistence,
   loadTreasuryAuctions,
   resetTreasuryAuctionsPersistence,
+  TREASURY_FISCAL_DATA_CONNECTION_ID,
 } from "./cache";
 import type { TreasuryAuction } from "./types";
 
@@ -143,6 +145,25 @@ describe("loadTreasuryAuctions", () => {
     expect(calls).toBe(1);
     expect(first.auctions[0]!.id).toBe("network");
     expect(second.auctions[0]!.id).toBe("network");
+  });
+
+  test("reports real Fiscal Data requests through Connections", async () => {
+    const { persistence } = fakePersistence();
+    const health = new ConnectionHealthRegistry();
+    health.registerSource({
+      id: TREASURY_FISCAL_DATA_CONNECTION_ID,
+      name: "Treasury Fiscal Data",
+      kind: "api",
+    });
+    attachTreasuryAuctionsPersistence(persistence, health);
+
+    await loadTreasuryAuctions(true, async () => [auctionFixture("network")]);
+
+    expect(health.getSnapshot().sources[0]).toMatchObject({
+      id: TREASURY_FISCAL_DATA_CONNECTION_ID,
+      status: "connected",
+      lastOperation: "fetchAuctions",
+    });
   });
 
   test("works with no persistence attached at all", async () => {

--- a/src/plugins/builtin/treasury-auctions/cache.test.ts
+++ b/src/plugins/builtin/treasury-auctions/cache.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { PluginPersistence } from "../../../types/plugin";
+import {
+  attachTreasuryAuctionsPersistence,
+  loadTreasuryAuctions,
+  resetTreasuryAuctionsPersistence,
+} from "./cache";
+import type { TreasuryAuction } from "./types";
+
+function auctionFixture(id: string): TreasuryAuction {
+  return {
+    id,
+    secType: "Note",
+    securityTerm: "10-Year",
+    auctionDate: "2026-08-12",
+    highInvestmentRate: null,
+    highYield: 4.683,
+    avgMedYield: null,
+    highPrice: null,
+    lowPrice: null,
+    avgMedPrice: null,
+    bidToCoverRatio: 2.53,
+    competitiveAccepted: null,
+    indirectAccepted: null,
+    primaryDealerAccepted: null,
+    totalAccepted: null,
+    offeringAmount: null,
+  };
+}
+
+/** Minimal stand-in for the resource cache: one slot, explicit stale/expiry. */
+function fakePersistence(seed?: { value: TreasuryAuction[]; stale: boolean; expired: boolean }) {
+  const writes: TreasuryAuction[][] = [];
+  let stored = seed ? { value: seed.value, fetchedAt: 1_000, stale: seed.stale, expired: seed.expired } : null;
+  const persistence = {
+    getResource: (_kind: string, _key: string, options?: { allowExpired?: boolean }) => {
+      if (!stored) return null;
+      if (stored.expired && !options?.allowExpired) return null;
+      return { value: stored.value, fetchedAt: stored.fetchedAt, stale: stored.stale };
+    },
+    setResource: (_kind: string, _key: string, value: TreasuryAuction[]) => {
+      writes.push(value);
+      stored = { value, fetchedAt: Date.now(), stale: false, expired: false };
+      return { value, fetchedAt: Date.now(), stale: false };
+    },
+  } as unknown as PluginPersistence;
+  return { persistence, writes };
+}
+
+afterEach(() => {
+  resetTreasuryAuctionsPersistence();
+});
+
+describe("loadTreasuryAuctions", () => {
+  test("serves fresh cache without hitting the network", async () => {
+    const { persistence } = fakePersistence({ value: [auctionFixture("cached")], stale: false, expired: false });
+    attachTreasuryAuctionsPersistence(persistence);
+    let calls = 0;
+
+    const result = await loadTreasuryAuctions(false, async () => {
+      calls += 1;
+      return [auctionFixture("network")];
+    });
+
+    expect(calls).toBe(0);
+    expect(result.auctions[0]!.id).toBe("cached");
+    expect(result.stale).toBe(false);
+  });
+
+  test("refetches once the entry is stale and caches the result", async () => {
+    const { persistence, writes } = fakePersistence({ value: [auctionFixture("cached")], stale: true, expired: false });
+    attachTreasuryAuctionsPersistence(persistence);
+
+    const result = await loadTreasuryAuctions(false, async () => [auctionFixture("network")]);
+
+    expect(result.auctions[0]!.id).toBe("network");
+    expect(result.stale).toBe(false);
+    expect(writes).toHaveLength(1);
+  });
+
+  test("falls back to expired cache when the endpoint fails", async () => {
+    const { persistence } = fakePersistence({ value: [auctionFixture("expired")], stale: true, expired: true });
+    attachTreasuryAuctionsPersistence(persistence);
+
+    const result = await loadTreasuryAuctions(true, async () => {
+      throw new Error("503");
+    });
+
+    expect(result.auctions[0]!.id).toBe("expired");
+    expect(result.stale).toBe(true);
+  });
+
+  test("propagates the failure when there is nothing cached to fall back to", async () => {
+    const { persistence } = fakePersistence();
+    attachTreasuryAuctionsPersistence(persistence);
+
+    await expect(loadTreasuryAuctions(true, async () => {
+      throw new Error("503");
+    })).rejects.toThrow("503");
+  });
+
+  test("keeps the cached board when a refresh returns an empty payload", async () => {
+    const { persistence, writes } = fakePersistence({ value: [auctionFixture("cached")], stale: true, expired: false });
+    attachTreasuryAuctionsPersistence(persistence);
+
+    const result = await loadTreasuryAuctions(true, async () => []);
+
+    expect(result.auctions[0]!.id).toBe("cached");
+    expect(result.stale).toBe(true);
+    expect(writes).toHaveLength(0);
+  });
+
+  test("shares one in-flight fetch across concurrent callers", async () => {
+    const { persistence } = fakePersistence();
+    attachTreasuryAuctionsPersistence(persistence);
+    let calls = 0;
+
+    const [first, second] = await Promise.all([
+      loadTreasuryAuctions(true, async () => {
+        calls += 1;
+        return [auctionFixture("network")];
+      }),
+      loadTreasuryAuctions(true, async () => {
+        calls += 1;
+        return [auctionFixture("other")];
+      }),
+    ]);
+
+    expect(calls).toBe(1);
+    expect(first.auctions[0]!.id).toBe("network");
+    expect(second.auctions[0]!.id).toBe("network");
+  });
+
+  test("works with no persistence attached at all", async () => {
+    const result = await loadTreasuryAuctions(true, async () => [auctionFixture("network")]);
+    expect(result.auctions[0]!.id).toBe("network");
+  });
+});

--- a/src/plugins/builtin/treasury-auctions/cache.ts
+++ b/src/plugins/builtin/treasury-auctions/cache.ts
@@ -61,8 +61,13 @@ export async function loadTreasuryAuctions(
   const fallback = cached ?? readCache({ allowExpired: true });
   activeFetch = loader()
     .then((auctions) => {
-      // An empty payload is a bad response, not a market with no auctions.
-      if (auctions.length === 0 && fallback) return { ...fallback, stale: true };
+      // Treasury auctions several times a week, so an empty window is a bad
+      // response, never the truth. It is never cached: persisting [] would
+      // serve the bad response back for an hour.
+      if (auctions.length === 0) {
+        if (fallback) return { ...fallback, stale: true };
+        throw new Error("Treasury Fiscal Data returned no auctions");
+      }
       persistence?.setResource(CACHE_KIND, CACHE_KEY, auctions, {
         sourceKey: CACHE_SOURCE,
         schemaVersion: CACHE_SCHEMA_VERSION,

--- a/src/plugins/builtin/treasury-auctions/cache.ts
+++ b/src/plugins/builtin/treasury-auctions/cache.ts
@@ -1,0 +1,81 @@
+import type { PluginPersistence } from "../../../types/plugin";
+import { fetchTreasuryAuctions } from "./client";
+import type { TreasuryAuction } from "./types";
+
+const CACHE_KIND = "treasury-auctions";
+const CACHE_KEY = "recent";
+const CACHE_SOURCE = "treasury-fiscal-data";
+const CACHE_SCHEMA_VERSION = 1;
+/**
+ * Auctions settle a few times a week and results never change once published,
+ * so an hour of freshness is plenty; the week-long expiry is what keeps an
+ * offline start usable.
+ */
+const CACHE_POLICY = {
+  staleMs: 60 * 60 * 1000,
+  expireMs: 7 * 24 * 60 * 60 * 1000,
+} as const;
+
+export interface TreasuryAuctionsResult {
+  auctions: TreasuryAuction[];
+  fetchedAt: number;
+  /** True when the network failed and expired cache was served instead. */
+  stale: boolean;
+}
+
+let persistence: PluginPersistence | null = null;
+let activeFetch: Promise<TreasuryAuctionsResult> | null = null;
+
+export function attachTreasuryAuctionsPersistence(next: PluginPersistence): void {
+  persistence = next;
+}
+
+export function resetTreasuryAuctionsPersistence(): void {
+  persistence = null;
+  activeFetch = null;
+}
+
+function readCache(options?: { allowExpired?: boolean }): TreasuryAuctionsResult | null {
+  const record = persistence?.getResource<TreasuryAuction[]>(CACHE_KIND, CACHE_KEY, {
+    sourceKey: CACHE_SOURCE,
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    allowExpired: options?.allowExpired,
+  });
+  if (!record || !Array.isArray(record.value)) return null;
+  return { auctions: record.value, fetchedAt: record.fetchedAt, stale: !!record.stale };
+}
+
+/**
+ * Serves fresh cache without a request, shares one in-flight fetch across
+ * panes, and falls back to whatever is cached (expired included) when the
+ * Treasury endpoint is unreachable.
+ */
+export async function loadTreasuryAuctions(
+  force = false,
+  loader: () => Promise<TreasuryAuction[]> = fetchTreasuryAuctions,
+): Promise<TreasuryAuctionsResult> {
+  const cached = readCache();
+  if (!force && cached && !cached.stale) return cached;
+  if (activeFetch) return activeFetch;
+
+  const fallback = cached ?? readCache({ allowExpired: true });
+  activeFetch = loader()
+    .then((auctions) => {
+      // An empty payload is a bad response, not a market with no auctions.
+      if (auctions.length === 0 && fallback) return { ...fallback, stale: true };
+      persistence?.setResource(CACHE_KIND, CACHE_KEY, auctions, {
+        sourceKey: CACHE_SOURCE,
+        schemaVersion: CACHE_SCHEMA_VERSION,
+        cachePolicy: CACHE_POLICY,
+      });
+      return { auctions, fetchedAt: Date.now(), stale: false };
+    })
+    .catch((error: unknown) => {
+      if (fallback) return { ...fallback, stale: true };
+      throw error;
+    })
+    .finally(() => {
+      activeFetch = null;
+    });
+  return activeFetch;
+}

--- a/src/plugins/builtin/treasury-auctions/cache.ts
+++ b/src/plugins/builtin/treasury-auctions/cache.ts
@@ -1,3 +1,4 @@
+import type { ConnectionHealthRegistry } from "../../../core/connection-health";
 import type { PluginPersistence } from "../../../types/plugin";
 import { fetchTreasuryAuctions } from "./client";
 import type { TreasuryAuction } from "./types";
@@ -6,6 +7,7 @@ const CACHE_KIND = "treasury-auctions";
 const CACHE_KEY = "recent";
 const CACHE_SOURCE = "treasury-fiscal-data";
 const CACHE_SCHEMA_VERSION = 1;
+export const TREASURY_FISCAL_DATA_CONNECTION_ID = "treasury-fiscal-data";
 /**
  * Auctions settle a few times a week and results never change once published,
  * so an hour of freshness is plenty; the week-long expiry is what keeps an
@@ -24,14 +26,20 @@ export interface TreasuryAuctionsResult {
 }
 
 let persistence: PluginPersistence | null = null;
+let connectionHealth: ConnectionHealthRegistry | null = null;
 let activeFetch: Promise<TreasuryAuctionsResult> | null = null;
 
-export function attachTreasuryAuctionsPersistence(next: PluginPersistence): void {
+export function attachTreasuryAuctionsPersistence(
+  next: PluginPersistence,
+  health?: ConnectionHealthRegistry,
+): void {
   persistence = next;
+  connectionHealth = health ?? null;
 }
 
 export function resetTreasuryAuctionsPersistence(): void {
   persistence = null;
+  connectionHealth = null;
   activeFetch = null;
 }
 
@@ -59,7 +67,10 @@ export async function loadTreasuryAuctions(
   if (activeFetch) return activeFetch;
 
   const fallback = cached ?? readCache({ allowExpired: true });
-  activeFetch = loader()
+  const request = () => loader();
+  activeFetch = (connectionHealth?.hasSource(TREASURY_FISCAL_DATA_CONNECTION_ID)
+    ? connectionHealth.track(TREASURY_FISCAL_DATA_CONNECTION_ID, "fetchAuctions", request)
+    : request())
     .then((auctions) => {
       // Treasury auctions several times a week, so an empty window is a bad
       // response, never the truth. It is never cached: persisting [] would

--- a/src/plugins/builtin/treasury-auctions/client.test.ts
+++ b/src/plugins/builtin/treasury-auctions/client.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { buildAuctionsUrl, normalizeAuction, parseTreasuryAuctionsPayload } from "./client";
+import {
+  buildAuctionsUrl,
+  fetchAuctionPages,
+  normalizeAuction,
+  parseTreasuryAuctionsPayload,
+  totalPages,
+} from "./client";
 
 // Shape captured from the live auctions_query endpoint on 2026-08-18.
 const LIVE_NOTE_ROW = {
@@ -89,6 +95,74 @@ describe("buildAuctionsUrl", () => {
     expect(url).toContain("filter=auction_date:gte:2026-07-19");
     expect(url).toContain("sort=-auction_date");
     expect(url).toContain("page%5Bsize%5D=");
+    expect(url).toContain("page%5Bnumber%5D=1");
     expect(url).not.toContain("page[size]");
+    expect(url).not.toContain("page[number]");
+    expect(buildAuctionsUrl(30, Date.parse("2026-08-18T00:00:00Z"), 3))
+      .toContain("page%5Bnumber%5D=3");
+  });
+});
+
+describe("fetchAuctionPages", () => {
+  function page(rows: Array<Record<string, string>>, pages: number) {
+    // Live shape: the page count arrives as a string under meta["total-pages"].
+    return { data: rows, meta: { count: rows.length, "total-pages": String(pages) } };
+  }
+
+  function row(term: string, date: string) {
+    return { ...LIVE_NOTE_ROW, security_term: term, auction_date: date };
+  }
+
+  test("walks every page the first response reports and keeps all of them", async () => {
+    const requested: number[] = [];
+    const pages = [
+      page([row("10-Year", "2026-08-12"), row("4-Week", "2026-08-11")], 3),
+      page([row("30-Year", "2026-08-10")], 3),
+      page([row("2-Year", "2026-08-09")], 3),
+    ];
+
+    const auctions = await fetchAuctionPages(async (pageNumber) => {
+      requested.push(pageNumber);
+      return pages[pageNumber - 1];
+    });
+
+    expect(requested).toEqual([1, 2, 3]);
+    expect(auctions.map((auction) => auction.securityTerm))
+      .toEqual(["10-Year", "4-Week", "30-Year", "2-Year"]);
+  });
+
+  test("dedupes rows a later page repeats after the window shifts", async () => {
+    const auctions = await fetchAuctionPages(async (pageNumber) => (
+      pageNumber === 1
+        ? page([row("10-Year", "2026-08-12")], 2)
+        : page([row("10-Year", "2026-08-12"), row("4-Week", "2026-08-11")], 2)
+    ));
+    expect(auctions.map((auction) => auction.securityTerm)).toEqual(["10-Year", "4-Week"]);
+  });
+
+  test("stops after one page when the metadata says there is one", async () => {
+    let calls = 0;
+    await fetchAuctionPages(async () => {
+      calls += 1;
+      return page([row("10-Year", "2026-08-12")], 1);
+    });
+    expect(calls).toBe(1);
+  });
+
+  test("bounded: absurd page metadata cannot walk forever", async () => {
+    let calls = 0;
+    await fetchAuctionPages(async (pageNumber) => {
+      calls += 1;
+      return page([row("10-Year", `2026-0${pageNumber}-12`)], 9_999);
+    });
+    expect(calls).toBe(5);
+  });
+
+  test("treats missing or unusable page metadata as a single page", () => {
+    expect(totalPages({ meta: {} })).toBe(1);
+    expect(totalPages({ meta: { "total-pages": "nope" } })).toBe(1);
+    expect(totalPages({ meta: { "total-pages": 0 } })).toBe(1);
+    expect(totalPages(null)).toBe(1);
+    expect(totalPages({ meta: { "total-pages": 4 } })).toBe(4);
   });
 });

--- a/src/plugins/builtin/treasury-auctions/client.test.ts
+++ b/src/plugins/builtin/treasury-auctions/client.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { buildAuctionsUrl, normalizeAuction, parseTreasuryAuctionsPayload } from "./client";
+
+// Shape captured from the live auctions_query endpoint on 2026-08-18.
+const LIVE_NOTE_ROW = {
+  security_type: "Note",
+  security_term: "10-Year",
+  auction_date: "2026-08-12",
+  high_investment_rate: "null",
+  high_yield: "4.6830",
+  avg_med_yield: "4.630000",
+  high_price: "99.540696",
+  low_price: "null",
+  avg_med_price: "null",
+  bid_to_cover_ratio: "2.530000",
+  comp_accepted: "41821613600",
+  indirect_bidder_accepted: "32087936000",
+  primary_dealer_accepted: "3597810000",
+  total_accepted: "52623557100",
+  offering_amt: "42000000000",
+};
+
+describe("normalizeAuction", () => {
+  test("parses a live note row into numbers", () => {
+    const auction = normalizeAuction(LIVE_NOTE_ROW);
+    expect(auction).toMatchObject({
+      id: "Note|2026-08-12|10-Year",
+      secType: "Note",
+      securityTerm: "10-Year",
+      highYield: 4.683,
+      avgMedYield: 4.63,
+      bidToCoverRatio: 2.53,
+      totalAccepted: 52_623_557_100,
+      offeringAmount: 42_000_000_000,
+    });
+  });
+
+  test("turns the API's literal \"null\" strings into null, not NaN", () => {
+    // Every metric arrives as a string, and unreported ones arrive as "null".
+    const auction = normalizeAuction(LIVE_NOTE_ROW)!;
+    expect(auction.highInvestmentRate).toBeNull();
+    expect(auction.lowPrice).toBeNull();
+    expect(auction.avgMedPrice).toBeNull();
+  });
+
+  test("keeps announced auctions whose results are not published yet", () => {
+    const auction = normalizeAuction({
+      security_type: "Bond",
+      security_term: "29-Year 6-Month",
+      auction_date: "2026-08-20",
+      high_yield: "null",
+      bid_to_cover_ratio: "null",
+    });
+    expect(auction).toMatchObject({ secType: "Bond", highYield: null, bidToCoverRatio: null });
+  });
+
+  test("drops rows without the identity fields and tolerates junk", () => {
+    expect(normalizeAuction({ security_term: "4-Week", auction_date: "2026-08-17" })).toBeNull();
+    expect(normalizeAuction({ security_type: "Bill", security_term: "4-Week" })).toBeNull();
+    expect(normalizeAuction(null)).toBeNull();
+    expect(normalizeAuction("Bill")).toBeNull();
+    expect(normalizeAuction({ security_type: "Bill", auction_date: "2026-08-17" })?.securityTerm).toBe("—");
+  });
+});
+
+describe("parseTreasuryAuctionsPayload", () => {
+  test("skips unusable rows instead of failing the whole payload", () => {
+    const auctions = parseTreasuryAuctionsPayload({
+      data: [LIVE_NOTE_ROW, { security_type: "" }, null, { security_type: "Bill", auction_date: "2026-08-17" }],
+    });
+    expect(auctions.map((auction) => auction.secType)).toEqual(["Note", "Bill"]);
+  });
+
+  test("collapses repeated (type, date, term) rows", () => {
+    const auctions = parseTreasuryAuctionsPayload({ data: [LIVE_NOTE_ROW, { ...LIVE_NOTE_ROW }] });
+    expect(auctions).toHaveLength(1);
+  });
+
+  test("returns nothing for a body that is not a data array", () => {
+    expect(parseTreasuryAuctionsPayload({ error: "boom" })).toEqual([]);
+    expect(parseTreasuryAuctionsPayload(null)).toEqual([]);
+    expect(parseTreasuryAuctionsPayload("<html>")).toEqual([]);
+  });
+});
+
+describe("buildAuctionsUrl", () => {
+  test("requests a bounded window with encoded pagination brackets", () => {
+    const url = buildAuctionsUrl(30, Date.parse("2026-08-18T00:00:00Z"));
+    expect(url).toContain("filter=auction_date:gte:2026-07-19");
+    expect(url).toContain("sort=-auction_date");
+    expect(url).toContain("page%5Bsize%5D=");
+    expect(url).not.toContain("page[size]");
+  });
+});

--- a/src/plugins/builtin/treasury-auctions/client.ts
+++ b/src/plugins/builtin/treasury-auctions/client.ts
@@ -136,8 +136,9 @@ export async function fetchAuctionPages(
 export async function fetchTreasuryAuctions(
   sinceDays: number = AUCTION_HISTORY_DAYS,
 ): Promise<TreasuryAuction[]> {
+  const requestedAt = Date.now();
   return fetchAuctionPages(async (page) => {
-    const response = await TREASURY_FETCH.fetch(buildAuctionsUrl(sinceDays, Date.now(), page));
+    const response = await TREASURY_FETCH.fetch(buildAuctionsUrl(sinceDays, requestedAt, page));
     if (!response.ok) {
       throw new Error(`Treasury Fiscal Data request failed (${response.status})`);
     }

--- a/src/plugins/builtin/treasury-auctions/client.ts
+++ b/src/plugins/builtin/treasury-auctions/client.ts
@@ -1,0 +1,110 @@
+import { createThrottledFetch } from "../../../utils/throttled-fetch";
+import type { TreasuryAuction, TreasuryAuctionRaw } from "./types";
+
+const BASE_URL =
+  "https://api.fiscaldata.treasury.gov/services/api/fiscal_service/v1/accounting/od/auctions_query";
+
+/** The endpoint returns 114 columns per row; ask only for what the pane renders. */
+const FIELDS = [
+  "security_type",
+  "security_term",
+  "auction_date",
+  "high_investment_rate",
+  "high_yield",
+  "avg_med_yield",
+  "high_price",
+  "low_price",
+  "avg_med_price",
+  "bid_to_cover_ratio",
+  "comp_accepted",
+  "indirect_bidder_accepted",
+  "primary_dealer_accepted",
+  "total_accepted",
+  "offering_amt",
+].join(",");
+
+const AUCTION_HISTORY_DAYS = 120;
+const PAGE_SIZE = 300;
+
+const TREASURY_FETCH = createThrottledFetch({
+  requestsPerMinute: 20,
+  maxRetries: 2,
+  timeoutMs: 15_000,
+  backoffBaseMs: 800,
+  defaultHeaders: { Accept: "application/json" },
+});
+
+function isoDateDaysAgo(days: number, now = Date.now()): string {
+  return new Date(now - days * 86_400_000).toISOString().slice(0, 10);
+}
+
+/** `page[size]` brackets are percent-encoded; the API rejects some proxies otherwise. */
+export function buildAuctionsUrl(sinceDays: number, now = Date.now()): string {
+  const params = [
+    `fields=${FIELDS}`,
+    `filter=auction_date:gte:${isoDateDaysAgo(sinceDays, now)}`,
+    "sort=-auction_date",
+    `page%5Bsize%5D=${PAGE_SIZE}`,
+  ];
+  return `${BASE_URL}?${params.join("&")}`;
+}
+
+/** Fiscal Data sends missing metrics as the literal string "null". */
+function toNumber(value: string | undefined | null): number | null {
+  if (value == null || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function normalizeAuction(raw: unknown): TreasuryAuction | null {
+  if (!raw || typeof raw !== "object") return null;
+  const record = raw as TreasuryAuctionRaw;
+  const secType = (record.security_type ?? "").trim();
+  const auctionDate = (record.auction_date ?? "").trim();
+  const securityTerm = (record.security_term ?? "").trim();
+  if (!secType || !auctionDate) return null;
+
+  return {
+    id: `${secType}|${auctionDate}|${securityTerm}`,
+    secType,
+    securityTerm: securityTerm || "—",
+    auctionDate,
+    highInvestmentRate: toNumber(record.high_investment_rate),
+    highYield: toNumber(record.high_yield),
+    avgMedYield: toNumber(record.avg_med_yield),
+    highPrice: toNumber(record.high_price),
+    lowPrice: toNumber(record.low_price),
+    avgMedPrice: toNumber(record.avg_med_price),
+    bidToCoverRatio: toNumber(record.bid_to_cover_ratio),
+    competitiveAccepted: toNumber(record.comp_accepted),
+    indirectAccepted: toNumber(record.indirect_bidder_accepted),
+    primaryDealerAccepted: toNumber(record.primary_dealer_accepted),
+    totalAccepted: toNumber(record.total_accepted),
+    offeringAmount: toNumber(record.offering_amt),
+  };
+}
+
+export function parseTreasuryAuctionsPayload(body: unknown): TreasuryAuction[] {
+  const data = (body as { data?: unknown } | null)?.data;
+  if (!Array.isArray(data)) return [];
+  const seen = new Set<string>();
+  const auctions: TreasuryAuction[] = [];
+  for (const raw of data) {
+    const auction = normalizeAuction(raw);
+    // Reopenings can repeat a (type, date, term) triple; the first wins.
+    if (!auction || seen.has(auction.id)) continue;
+    seen.add(auction.id);
+    auctions.push(auction);
+  }
+  return auctions;
+}
+
+export async function fetchTreasuryAuctions(
+  sinceDays: number = AUCTION_HISTORY_DAYS,
+): Promise<TreasuryAuction[]> {
+  const response = await TREASURY_FETCH.fetch(buildAuctionsUrl(sinceDays));
+  if (!response.ok) {
+    throw new Error(`Treasury Fiscal Data request failed (${response.status})`);
+  }
+  return parseTreasuryAuctionsPayload(await response.json());
+}

--- a/src/plugins/builtin/treasury-auctions/client.ts
+++ b/src/plugins/builtin/treasury-auctions/client.ts
@@ -25,6 +25,8 @@ const FIELDS = [
 
 const AUCTION_HISTORY_DAYS = 120;
 const PAGE_SIZE = 300;
+/** 120 days is ~150 auctions, one page; the bound only exists so bad metadata cannot loop. */
+const MAX_PAGES = 5;
 
 const TREASURY_FETCH = createThrottledFetch({
   requestsPerMinute: 20,
@@ -39,14 +41,22 @@ function isoDateDaysAgo(days: number, now = Date.now()): string {
 }
 
 /** `page[size]` brackets are percent-encoded; the API rejects some proxies otherwise. */
-export function buildAuctionsUrl(sinceDays: number, now = Date.now()): string {
+export function buildAuctionsUrl(sinceDays: number, now = Date.now(), page = 1): string {
   const params = [
     `fields=${FIELDS}`,
     `filter=auction_date:gte:${isoDateDaysAgo(sinceDays, now)}`,
     "sort=-auction_date",
     `page%5Bsize%5D=${PAGE_SIZE}`,
+    `page%5Bnumber%5D=${page}`,
   ];
   return `${BASE_URL}?${params.join("&")}`;
+}
+
+/** Fiscal Data reports the page count as `meta["total-pages"]`. */
+export function totalPages(body: unknown): number {
+  const meta = (body as { meta?: Record<string, unknown> } | null)?.meta;
+  const pages = Number(meta?.["total-pages"]);
+  return Number.isFinite(pages) && pages > 1 ? Math.floor(pages) : 1;
 }
 
 /** Fiscal Data sends missing metrics as the literal string "null". */
@@ -99,12 +109,38 @@ export function parseTreasuryAuctionsPayload(body: unknown): TreasuryAuction[] {
   return auctions;
 }
 
+/**
+ * Walks pages until the count reported by the first response is exhausted.
+ * Pages overlap whenever an auction is announced mid-walk, so ids are deduped
+ * across the whole run and not just within a payload.
+ */
+export async function fetchAuctionPages(
+  loadPage: (page: number) => Promise<unknown>,
+): Promise<TreasuryAuction[]> {
+  const auctions: TreasuryAuction[] = [];
+  const seen = new Set<string>();
+  let pages = 1;
+
+  for (let page = 1; page <= Math.min(pages, MAX_PAGES); page += 1) {
+    const body = await loadPage(page);
+    if (page === 1) pages = totalPages(body);
+    for (const auction of parseTreasuryAuctionsPayload(body)) {
+      if (seen.has(auction.id)) continue;
+      seen.add(auction.id);
+      auctions.push(auction);
+    }
+  }
+  return auctions;
+}
+
 export async function fetchTreasuryAuctions(
   sinceDays: number = AUCTION_HISTORY_DAYS,
 ): Promise<TreasuryAuction[]> {
-  const response = await TREASURY_FETCH.fetch(buildAuctionsUrl(sinceDays));
-  if (!response.ok) {
-    throw new Error(`Treasury Fiscal Data request failed (${response.status})`);
-  }
-  return parseTreasuryAuctionsPayload(await response.json());
+  return fetchAuctionPages(async (page) => {
+    const response = await TREASURY_FETCH.fetch(buildAuctionsUrl(sinceDays, Date.now(), page));
+    if (!response.ok) {
+      throw new Error(`Treasury Fiscal Data request failed (${response.status})`);
+    }
+    return response.json();
+  });
 }

--- a/src/plugins/builtin/treasury-auctions/index.tsx
+++ b/src/plugins/builtin/treasury-auctions/index.tsx
@@ -1,0 +1,55 @@
+import type { PluginModule } from "../plugin-module";
+import {
+  attachTreasuryAuctionsPersistence,
+  resetTreasuryAuctionsPersistence,
+} from "./cache";
+import { TreasuryAuctionsPane } from "./pane";
+import { TREASURY_AUCTIONS_PANE_ID } from "./types";
+
+export const treasuryAuctionsModule: PluginModule = {
+  setup(ctx) {
+    attachTreasuryAuctionsPersistence(ctx.persistence);
+  },
+
+  dispose() {
+    resetTreasuryAuctionsPersistence();
+  },
+
+  panes: [
+    {
+      id: TREASURY_AUCTIONS_PANE_ID,
+      name: "Treasury Auctions",
+      icon: "A",
+      component: TreasuryAuctionsPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 92, height: 28 },
+    },
+  ],
+
+  paneTemplates: [
+    {
+      id: "treasury-auctions-pane",
+      paneId: TREASURY_AUCTIONS_PANE_ID,
+      label: "Treasury Auctions",
+      description:
+        "Bill, note, bond, and TIPS auction results from Treasury Fiscal Data: high rate, bid-to-cover, indirect share, and size.",
+      keywords: [
+        "treasury",
+        "auction",
+        "auctions",
+        "bills",
+        "notes",
+        "bonds",
+        "tips",
+        "frn",
+        "bid",
+        "cover",
+        "indirect",
+        "issuance",
+      ],
+      shortcut: { prefix: "AUCT" },
+      createInstance: () => ({ placement: "floating" }),
+    },
+  ],
+};

--- a/src/plugins/builtin/treasury-auctions/index.tsx
+++ b/src/plugins/builtin/treasury-auctions/index.tsx
@@ -2,16 +2,29 @@ import type { PluginModule } from "../plugin-module";
 import {
   attachTreasuryAuctionsPersistence,
   resetTreasuryAuctionsPersistence,
+  TREASURY_FISCAL_DATA_CONNECTION_ID,
 } from "./cache";
 import { TreasuryAuctionsPane } from "./pane";
 import { TREASURY_AUCTIONS_PANE_ID } from "./types";
 
+let disposeConnection: (() => void) | null = null;
+
 export const treasuryAuctionsModule: PluginModule = {
   setup(ctx) {
-    attachTreasuryAuctionsPersistence(ctx.persistence);
+    attachTreasuryAuctionsPersistence(ctx.persistence, ctx.connectionHealth);
+    disposeConnection = ctx.connectionHealth.registerSource({
+      id: TREASURY_FISCAL_DATA_CONNECTION_ID,
+      name: "Treasury Fiscal Data",
+      kind: "api",
+      ownerId: "macro",
+      priority: 300,
+      detail: "fiscaldata.treasury.gov",
+    });
   },
 
   dispose() {
+    disposeConnection?.();
+    disposeConnection = null;
     resetTreasuryAuctionsPersistence();
   },
 

--- a/src/plugins/builtin/treasury-auctions/model.test.ts
+++ b/src/plugins/builtin/treasury-auctions/model.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_AUCTION_SORT,
+  indirectPct,
+  isPendingAuction,
+  matchesFilter,
+  nextAuctionSort,
+  nextFilter,
+  rateValue,
+  termLengthDays,
+  visibleAuctions,
+} from "./model";
+import type { TreasuryAuction } from "./types";
+
+function auction(overrides: Partial<TreasuryAuction> & { secType: string; securityTerm: string }): TreasuryAuction {
+  return {
+    id: `${overrides.secType}|${overrides.auctionDate ?? "2026-08-12"}|${overrides.securityTerm}`,
+    auctionDate: "2026-08-12",
+    highInvestmentRate: null,
+    highYield: null,
+    avgMedYield: null,
+    highPrice: null,
+    lowPrice: null,
+    avgMedPrice: null,
+    bidToCoverRatio: null,
+    competitiveAccepted: null,
+    indirectAccepted: null,
+    primaryDealerAccepted: null,
+    totalAccepted: null,
+    offeringAmount: null,
+    ...overrides,
+  };
+}
+
+describe("term ordering", () => {
+  test("orders the curve by length, not alphabetically", () => {
+    const terms = ["30-Year", "4-Week", "10-Year", "182-Day", "2-Year", "6-Month", "29-Year 6-Month"];
+    const sorted = [...terms].sort((left, right) => termLengthDays(left) - termLengthDays(right));
+    expect(sorted).toEqual(["4-Week", "6-Month", "182-Day", "2-Year", "10-Year", "29-Year 6-Month", "30-Year"]);
+  });
+
+  test("sends unparseable terms to the end rather than to the front", () => {
+    expect(termLengthDays("Cash Management")).toBe(Number.MAX_SAFE_INTEGER);
+    expect(termLengthDays("")).toBe(Number.MAX_SAFE_INTEGER);
+  });
+});
+
+describe("auction metrics", () => {
+  test("reads the rate each security type actually reports", () => {
+    expect(rateValue(auction({ secType: "Bill", securityTerm: "4-Week", highInvestmentRate: 3.9 }))).toBe(3.9);
+    expect(rateValue(auction({ secType: "Note", securityTerm: "10-Year", highYield: 4.683 }))).toBe(4.683);
+    expect(rateValue(auction({ secType: "Bond", securityTerm: "20-Year" }))).toBeNull();
+  });
+
+  test("indirect share needs both legs and survives a zero total", () => {
+    const filled = auction({
+      secType: "Note",
+      securityTerm: "10-Year",
+      indirectAccepted: 32_087_936_000,
+      totalAccepted: 52_623_557_100,
+    });
+    expect(indirectPct(filled)).toBeCloseTo(60.98, 1);
+    expect(indirectPct(auction({ secType: "Note", securityTerm: "10-Year", totalAccepted: 0, indirectAccepted: 5 })))
+      .toBeNull();
+    expect(indirectPct(auction({ secType: "Note", securityTerm: "10-Year", totalAccepted: 100 }))).toBeNull();
+  });
+
+  test("flags announced auctions that have no published results", () => {
+    expect(isPendingAuction(auction({ secType: "Bond", securityTerm: "20-Year" }))).toBe(true);
+    expect(isPendingAuction(auction({ secType: "Bond", securityTerm: "20-Year", bidToCoverRatio: 2.4 }))).toBe(false);
+  });
+});
+
+describe("filters", () => {
+  test("groups CMBs with bills, FRNs with notes, and TIPS with bonds", () => {
+    expect(matchesFilter(auction({ secType: "CMB", securityTerm: "42-Day" }), "bill")).toBe(true);
+    expect(matchesFilter(auction({ secType: "FRN", securityTerm: "2-Year" }), "note")).toBe(true);
+    expect(matchesFilter(auction({ secType: "TIPS", securityTerm: "10-Year" }), "bond")).toBe(true);
+    expect(matchesFilter(auction({ secType: "TIPS", securityTerm: "10-Year" }), "note")).toBe(false);
+    expect(matchesFilter(auction({ secType: "TIPS", securityTerm: "10-Year" }), "all")).toBe(true);
+  });
+
+  test("the filter key wraps through every tab", () => {
+    expect(nextFilter("all")).toBe("bill");
+    expect(nextFilter(nextFilter(nextFilter("bill")))).toBe("all");
+  });
+});
+
+describe("visibleAuctions", () => {
+  const rows = [
+    auction({ secType: "Bill", securityTerm: "4-Week", auctionDate: "2026-08-17", highInvestmentRate: 3.9 }),
+    auction({ secType: "Note", securityTerm: "10-Year", auctionDate: "2026-08-12", highYield: 4.683 }),
+    auction({ secType: "Bond", securityTerm: "30-Year", auctionDate: "2026-08-14", highYield: 5.1 }),
+  ];
+
+  test("newest first by default", () => {
+    expect(visibleAuctions(rows, { filter: "all", query: "", sort: DEFAULT_AUCTION_SORT })
+      .map((row) => row.auctionDate)).toEqual(["2026-08-17", "2026-08-14", "2026-08-12"]);
+  });
+
+  test("term sort walks the curve, not the alphabet", () => {
+    expect(visibleAuctions(rows, { filter: "all", query: "", sort: { columnId: "term", direction: "asc" } })
+      .map((row) => row.securityTerm)).toEqual(["4-Week", "10-Year", "30-Year"]);
+  });
+
+  test("search matches type, term, and auction date", () => {
+    const sort = DEFAULT_AUCTION_SORT;
+    expect(visibleAuctions(rows, { filter: "all", query: "bill", sort })).toHaveLength(1);
+    expect(visibleAuctions(rows, { filter: "all", query: "30-year", sort })).toHaveLength(1);
+    expect(visibleAuctions(rows, { filter: "all", query: "2026-08-1", sort })).toHaveLength(3);
+    expect(visibleAuctions(rows, { filter: "note", query: "bill", sort })).toHaveLength(0);
+  });
+
+  test("rows missing a metric sort last instead of jumping to the top", () => {
+    const withPending = [...rows, auction({ secType: "Bond", securityTerm: "20-Year", auctionDate: "2026-08-19" })];
+    const byRate = visibleAuctions(withPending, {
+      filter: "all",
+      query: "",
+      sort: { columnId: "rate", direction: "desc" },
+    });
+    expect(byRate.at(-1)?.securityTerm).toBe("20-Year");
+  });
+});
+
+describe("nextAuctionSort", () => {
+  test("toggles direction on the active column and picks a sane default per column", () => {
+    expect(nextAuctionSort(DEFAULT_AUCTION_SORT, "date")).toEqual({ columnId: "date", direction: "asc" });
+    expect(nextAuctionSort(DEFAULT_AUCTION_SORT, "btc")).toEqual({ columnId: "btc", direction: "desc" });
+    expect(nextAuctionSort(DEFAULT_AUCTION_SORT, "term")).toEqual({ columnId: "term", direction: "asc" });
+  });
+});

--- a/src/plugins/builtin/treasury-auctions/model.test.ts
+++ b/src/plugins/builtin/treasury-auctions/model.test.ts
@@ -52,6 +52,22 @@ describe("auction metrics", () => {
     expect(rateValue(auction({ secType: "Bond", securityTerm: "20-Year" }))).toBeNull();
   });
 
+  test("keeps a zero indirect allocation as 0%, not unknown", () => {
+    // A no-indirect auction is a real result and a notable one; "—" hides it.
+    const zeroIndirect = auction({
+      secType: "Bill",
+      securityTerm: "4-Week",
+      indirectAccepted: 0,
+      totalAccepted: 50_000_000_000,
+    });
+    expect(indirectPct(zeroIndirect)).toBe(0);
+    expect(visibleAuctions([zeroIndirect], {
+      filter: "all",
+      query: "",
+      sort: { columnId: "indirect", direction: "desc" },
+    })).toHaveLength(1);
+  });
+
   test("indirect share needs both legs and survives a zero total", () => {
     const filled = auction({
       secType: "Note",

--- a/src/plugins/builtin/treasury-auctions/model.ts
+++ b/src/plugins/builtin/treasury-auctions/model.ts
@@ -1,0 +1,174 @@
+import type { DataTableColumn } from "../../../components";
+import type { SortDirection } from "../../../utils/sort-values";
+import type { TreasuryAuction } from "./types";
+
+export type AuctionColumnId = "date" | "type" | "term" | "rate" | "btc" | "indirect" | "size";
+
+export interface AuctionColumn extends DataTableColumn {
+  id: AuctionColumnId;
+}
+
+export interface AuctionSortPreference {
+  columnId: AuctionColumnId;
+  direction: SortDirection;
+}
+
+export const DEFAULT_AUCTION_SORT: AuctionSortPreference = {
+  columnId: "date",
+  direction: "desc",
+};
+
+export const AUCTION_SORT_COLUMN_IDS: readonly AuctionColumnId[] = [
+  "date",
+  "type",
+  "term",
+  "rate",
+  "btc",
+  "indirect",
+  "size",
+];
+
+export type AuctionFilter = "all" | "bill" | "note" | "bond";
+
+export const AUCTION_FILTERS: ReadonlyArray<{ value: AuctionFilter; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "bill", label: "Bills" },
+  { value: "note", label: "Notes" },
+  { value: "bond", label: "Bonds" },
+];
+
+// CMBs are cash management bills; FRNs are issued off the 2-year note; TIPS
+// are auctioned as notes and bonds but group with the long end here.
+const FILTER_TYPES: Record<Exclude<AuctionFilter, "all">, ReadonlySet<string>> = {
+  bill: new Set(["Bill", "CMB"]),
+  note: new Set(["Note", "FRN"]),
+  bond: new Set(["Bond", "TIPS"]),
+};
+
+export function matchesFilter(auction: TreasuryAuction, filter: AuctionFilter): boolean {
+  return filter === "all" || FILTER_TYPES[filter].has(auction.secType);
+}
+
+export function nextFilter(current: AuctionFilter): AuctionFilter {
+  const index = AUCTION_FILTERS.findIndex((entry) => entry.value === current);
+  return AUCTION_FILTERS[(index + 1) % AUCTION_FILTERS.length]!.value;
+}
+
+function matchesAuctionQuery(auction: TreasuryAuction, query: string): boolean {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return true;
+  return (
+    auction.secType.toLowerCase().includes(normalized)
+    || auction.securityTerm.toLowerCase().includes(normalized)
+    || auction.auctionDate.includes(normalized)
+  );
+}
+
+function auctionDateValue(value: string): number {
+  const timestamp = Date.parse(`${value}T00:00:00Z`);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+/**
+ * Term length in days so "4-Week" sorts before "10-Year" instead of
+ * alphabetically. "29-Year 6-Month" only needs its leading unit to order
+ * correctly against the rest of the curve.
+ */
+export function termLengthDays(term: string): number {
+  const match = term.match(/^(\d+)\s*-\s*(Day|Week|Month|Year)/i);
+  if (!match) return Number.MAX_SAFE_INTEGER;
+  const count = Number(match[1]);
+  switch (match[2]!.toLowerCase()) {
+    case "day": return count;
+    case "week": return count * 7;
+    case "month": return count * 30;
+    default: return count * 365;
+  }
+}
+
+export function indirectPct(auction: TreasuryAuction): number | null {
+  if (!auction.indirectAccepted || !auction.totalAccepted) return null;
+  return (auction.indirectAccepted / auction.totalAccepted) * 100;
+}
+
+/**
+ * The headline rate: Bills and FRNs report a high investment rate, Notes,
+ * Bonds, and TIPS report a high yield.
+ */
+export function rateValue(auction: TreasuryAuction): number | null {
+  return auction.highInvestmentRate ?? auction.highYield;
+}
+
+/** Announced auctions appear in the feed days before any results are published. */
+export function isPendingAuction(auction: TreasuryAuction): boolean {
+  return rateValue(auction) == null && auction.bidToCoverRatio == null;
+}
+
+export function auctionSize(auction: TreasuryAuction): number | null {
+  return auction.totalAccepted ?? auction.offeringAmount;
+}
+
+function sortValue(auction: TreasuryAuction, columnId: AuctionColumnId): number | string {
+  switch (columnId) {
+    case "date": return auctionDateValue(auction.auctionDate);
+    case "type": return auction.secType;
+    case "term": return termLengthDays(auction.securityTerm);
+    case "rate": return rateValue(auction) ?? Number.NEGATIVE_INFINITY;
+    case "btc": return auction.bidToCoverRatio ?? Number.NEGATIVE_INFINITY;
+    case "indirect": return indirectPct(auction) ?? Number.NEGATIVE_INFINITY;
+    case "size": return auctionSize(auction) ?? Number.NEGATIVE_INFINITY;
+  }
+}
+
+export function visibleAuctions(
+  auctions: readonly TreasuryAuction[],
+  options: { filter: AuctionFilter; query: string; sort: AuctionSortPreference },
+): TreasuryAuction[] {
+  const direction = options.sort.direction === "asc" ? 1 : -1;
+  return auctions
+    .filter((auction) => matchesFilter(auction, options.filter) && matchesAuctionQuery(auction, options.query))
+    .sort((left, right) => {
+      const leftValue = sortValue(left, options.sort.columnId);
+      const rightValue = sortValue(right, options.sort.columnId);
+      const comparison = typeof leftValue === "string" && typeof rightValue === "string"
+        ? leftValue.localeCompare(rightValue, "en-US", { sensitivity: "base" })
+        : Number(leftValue) - Number(rightValue);
+      if (comparison !== 0) return comparison * direction;
+      // Ties keep the newest auction on top regardless of sort direction.
+      return auctionDateValue(right.auctionDate) - auctionDateValue(left.auctionDate);
+    });
+}
+
+export function nextAuctionSort(
+  current: AuctionSortPreference,
+  columnId: AuctionColumnId,
+): AuctionSortPreference {
+  if (current.columnId === columnId) {
+    const direction: SortDirection = current.direction === "asc" ? "desc" : "asc";
+    return { columnId, direction };
+  }
+  // Text columns read best ascending; every metric reads best highest-first.
+  return { columnId, direction: columnId === "type" || columnId === "term" ? "asc" : "desc" };
+}
+
+export function buildAuctionColumns(width: number): AuctionColumn[] {
+  const dateWidth = 8;
+  const typeWidth = 6;
+  const rateWidth = 8;
+  const btcWidth = 6;
+  const indirectWidth = 9;
+  const sizeWidth = 8;
+  const termWidth = Math.max(
+    10,
+    width - dateWidth - typeWidth - rateWidth - btcWidth - indirectWidth - sizeWidth - 8,
+  );
+  return [
+    { id: "date", label: "DATE", width: dateWidth, align: "left" },
+    { id: "type", label: "TYPE", width: typeWidth, align: "left" },
+    { id: "term", label: "TERM", width: termWidth, align: "left" },
+    { id: "rate", label: "RATE", width: rateWidth, align: "right" },
+    { id: "btc", label: "B/C", width: btcWidth, align: "right" },
+    { id: "indirect", label: "INDIRECT", width: indirectWidth, align: "right" },
+    { id: "size", label: "SIZE", width: sizeWidth, align: "right" },
+  ];
+}

--- a/src/plugins/builtin/treasury-auctions/model.ts
+++ b/src/plugins/builtin/treasury-auctions/model.ts
@@ -86,8 +86,12 @@ export function termLengthDays(term: string): number {
   }
 }
 
+/**
+ * Zero indirect bidding is a real, and notable, auction outcome, so only a
+ * missing leg or an unusable total is unknown.
+ */
 export function indirectPct(auction: TreasuryAuction): number | null {
-  if (!auction.indirectAccepted || !auction.totalAccepted) return null;
+  if (auction.indirectAccepted == null || !auction.totalAccepted) return null;
   return (auction.indirectAccepted / auction.totalAccepted) * 100;
 }
 

--- a/src/plugins/builtin/treasury-auctions/pane.test.tsx
+++ b/src/plugins/builtin/treasury-auctions/pane.test.tsx
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { AppContext, createInitialState, PaneInstanceProvider } from "../../../state/app/context";
+import { createDefaultConfig } from "../../../types/config";
+import type { PluginPersistence } from "../../../types/plugin";
+import {
+  attachTreasuryAuctionsPersistence,
+  resetTreasuryAuctionsPersistence,
+} from "./cache";
+import { TreasuryAuctionsPane } from "./pane";
+import type { TreasuryAuction } from "./types";
+
+function auction(overrides: Partial<TreasuryAuction> & { secType: string; securityTerm: string }): TreasuryAuction {
+  return {
+    id: `${overrides.secType}|${overrides.auctionDate ?? "2026-08-12"}|${overrides.securityTerm}`,
+    auctionDate: "2026-08-12",
+    highInvestmentRate: null,
+    highYield: null,
+    avgMedYield: null,
+    highPrice: null,
+    lowPrice: null,
+    avgMedPrice: null,
+    bidToCoverRatio: null,
+    competitiveAccepted: null,
+    indirectAccepted: null,
+    primaryDealerAccepted: null,
+    totalAccepted: null,
+    offeringAmount: null,
+    ...overrides,
+  };
+}
+
+const AUCTIONS: TreasuryAuction[] = [
+  auction({
+    secType: "Bond",
+    securityTerm: "20-Year",
+    auctionDate: "2026-08-19",
+    offeringAmount: 16_000_000_000,
+  }),
+  auction({
+    secType: "Bill",
+    securityTerm: "13-Week",
+    auctionDate: "2026-08-17",
+    highInvestmentRate: 3.802,
+    bidToCoverRatio: 2.86,
+    indirectAccepted: 48_000_000_000,
+    totalAccepted: 98_725_863_900,
+  }),
+  auction({
+    secType: "Note",
+    securityTerm: "10-Year",
+    auctionDate: "2026-08-12",
+    highYield: 4.683,
+    bidToCoverRatio: 2.53,
+    indirectAccepted: 32_087_936_000,
+    primaryDealerAccepted: 3_597_810_000,
+    totalAccepted: 52_623_557_100,
+  }),
+];
+
+/** Fresh cache so the pane renders without touching the Treasury endpoint. */
+function seedCache(): void {
+  attachTreasuryAuctionsPersistence({
+    getResource: () => ({ value: AUCTIONS, fetchedAt: Date.now(), stale: false }),
+    setResource: () => ({ value: AUCTIONS, fetchedAt: Date.now(), stale: false }),
+  } as unknown as PluginPersistence);
+}
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(async () => {
+  resetTreasuryAuctionsPersistence();
+  if (!testSetup) return;
+  await act(async () => {
+    testSetup!.renderer.destroy();
+  });
+  testSetup = undefined;
+});
+
+function Harness() {
+  const state = createInitialState(createDefaultConfig("/tmp/gloomberb-auctions-pane-test"));
+  return (
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <PaneInstanceProvider paneId="treasury-auctions">
+        <TreasuryAuctionsPane
+          paneId="treasury-auctions"
+          paneType="treasury-auctions"
+          focused
+          width={92}
+          height={20}
+        />
+      </PaneInstanceProvider>
+    </AppContext>
+  );
+}
+
+async function renderSettled() {
+  await act(async () => {
+    await testSetup!.renderOnce();
+    await testSetup!.renderOnce();
+  });
+}
+
+async function emitKeypress(event: { name?: string; sequence?: string }) {
+  await act(async () => {
+    testSetup!.renderer.keyInput.emit("keypress", {
+      ctrl: false,
+      meta: false,
+      option: false,
+      shift: false,
+      eventType: "press",
+      repeated: false,
+      defaultPrevented: false,
+      propagationStopped: false,
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      ...event,
+    } as never);
+    await testSetup!.renderOnce();
+  });
+}
+
+describe("TreasuryAuctionsPane", () => {
+  test("renders auction metrics and marks announced auctions as pending", async () => {
+    seedCache();
+    testSetup = await testRender(<Harness />, { width: 92, height: 20 });
+    await renderSettled();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("13-Week");
+    expect(frame).toContain("3.802%");
+    expect(frame).toContain("2.86");
+    // Indirect share is derived, not reported.
+    expect(frame).toContain("48.6%");
+    // The 20-Year is announced but has no published results yet.
+    expect(frame).toContain("pending");
+  });
+
+  test("opens a detail view for the selected auction", async () => {
+    seedCache();
+    testSetup = await testRender(<Harness />, { width: 92, height: 20 });
+    await renderSettled();
+
+    await emitKeypress({ name: "down", sequence: "\u001B[B" });
+    await emitKeypress({ name: "enter", sequence: "\r" });
+    await renderSettled();
+
+    const detail = testSetup.captureCharFrame();
+    expect(detail).toContain("Bill 13-Week");
+    expect(detail).toContain("Bid-to-cover");
+    expect(detail).toContain("Total accepted");
+  });
+
+  test("the filter key narrows the board to one security group", async () => {
+    seedCache();
+    testSetup = await testRender(<Harness />, { width: 92, height: 20 });
+    await renderSettled();
+
+    // all -> bills
+    await emitKeypress({ name: "f", sequence: "f" });
+    await renderSettled();
+
+    const bills = testSetup.captureCharFrame();
+    expect(bills).toContain("13-Week");
+    expect(bills).not.toContain("10-Year");
+  });
+});

--- a/src/plugins/builtin/treasury-auctions/pane.tsx
+++ b/src/plugins/builtin/treasury-auctions/pane.tsx
@@ -1,0 +1,415 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  DataTableStackView,
+  EmptyState,
+  InputSearchBar,
+  Spinner,
+  Tabs,
+  usePaneFooter,
+  type DataTableCell,
+  type DataTableKeyEvent,
+  type DataTableRootKeyContext,
+  type PaneFooterSegment,
+} from "../../../components";
+import { colors } from "../../../theme/colors";
+import type { PaneProps } from "../../../types/plugin";
+import { Box, ScrollBox, Text, TextAttributes, type InputRenderable } from "../../../ui";
+import { formatCompact } from "../../../utils/format";
+import { isPlainKey } from "../../../utils/keyboard";
+import { formatRelativeAge } from "../../../utils/relative-time";
+import { isPlainArrowUp, stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
+import { cycleSortPreference } from "../../../utils/sort-values";
+import { loadTreasuryAuctions } from "./cache";
+import {
+  AUCTION_FILTERS,
+  AUCTION_SORT_COLUMN_IDS,
+  DEFAULT_AUCTION_SORT,
+  buildAuctionColumns,
+  indirectPct,
+  isPendingAuction,
+  auctionSize,
+  nextAuctionSort,
+  nextFilter,
+  rateValue,
+  visibleAuctions,
+  type AuctionColumn,
+  type AuctionColumnId,
+  type AuctionFilter,
+  type AuctionSortPreference,
+} from "./model";
+import {
+  TREASURY_AUCTIONS_PANE_ID,
+  type LoadStatus,
+  type TreasuryAuction,
+} from "./types";
+
+// The poll is cheap because the cache decides whether it becomes a request;
+// only [r] forces the endpoint.
+const AUTO_REFRESH_MS = 15 * 60_000;
+
+function formatAuctionDate(value: string, withYear = false): string {
+  const timestamp = Date.parse(`${value}T00:00:00Z`);
+  if (!Number.isFinite(timestamp)) return "—";
+  return new Date(timestamp).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: withYear ? "numeric" : undefined,
+    timeZone: "UTC",
+  });
+}
+
+function formatRate(value: number | null): string {
+  return value == null ? "—" : `${value.toFixed(3)}%`;
+}
+
+function formatRatio(value: number | null): string {
+  return value == null ? "—" : value.toFixed(2);
+}
+
+function formatPct(value: number | null): string {
+  return value == null ? "—" : `${value.toFixed(1)}%`;
+}
+
+function formatMoney(value: number | null): string {
+  return value == null ? "—" : `$${formatCompact(value)}`;
+}
+
+function secTypeColor(secType: string, selected: boolean): string {
+  if (selected) return colors.selectedText;
+  switch (secType.toLowerCase()) {
+    case "bill":
+    case "cmb":
+      return colors.positive;
+    case "note":
+    case "frn":
+      return colors.textBright;
+    case "bond":
+    case "tips":
+      return colors.warning;
+    default:
+      return colors.text;
+  }
+}
+
+function renderAuctionCell(
+  auction: TreasuryAuction,
+  column: AuctionColumn,
+  rowState: { selected: boolean },
+): DataTableCell {
+  const selected = rowState.selected ? colors.selectedText : undefined;
+  const dimmed = selected ?? colors.textDim;
+
+  switch (column.id) {
+    case "date":
+      return { text: formatAuctionDate(auction.auctionDate), color: dimmed };
+    case "type":
+      return {
+        text: auction.secType,
+        color: secTypeColor(auction.secType, rowState.selected),
+        attributes: TextAttributes.BOLD,
+      };
+    case "term":
+      return { text: auction.securityTerm, color: selected ?? colors.text };
+    case "rate":
+      if (isPendingAuction(auction)) return { text: "pending", color: dimmed };
+      return { text: formatRate(rateValue(auction)), color: selected ?? colors.textBright };
+    case "btc":
+      return { text: formatRatio(auction.bidToCoverRatio), color: selected ?? colors.text };
+    case "indirect":
+      return { text: formatPct(indirectPct(auction)), color: selected ?? colors.text };
+    case "size":
+      return { text: formatMoney(auctionSize(auction)), color: dimmed };
+  }
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <Box flexDirection="row" height={1} gap={2}>
+      <Box width={20}>
+        <Text fg={colors.textDim}>{label}</Text>
+      </Box>
+      <Box flexGrow={1}>
+        <Text fg={colors.textBright} wrapMode="ellipsis">{value}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+function TreasuryAuctionDetail({ auction, width }: { auction: TreasuryAuction; width: number }) {
+  const total = auction.totalAccepted;
+  const share = (value: number | null): string => (
+    value == null || !total ? formatMoney(value) : `${formatMoney(value)} (${((value / total) * 100).toFixed(1)}%)`
+  );
+
+  return (
+    <ScrollBox flexGrow={1} scrollY>
+      <Box flexDirection="column" paddingX={1} width={width}>
+        <Box flexDirection="row" height={1} gap={2}>
+          <Text fg={colors.textDim}>{formatAuctionDate(auction.auctionDate, true)}</Text>
+          {isPendingAuction(auction) && <Text fg={colors.warning}>results pending</Text>}
+        </Box>
+        <Box height={1} />
+        <DetailRow label="High rate" value={formatRate(rateValue(auction))} />
+        {auction.avgMedYield != null && (
+          <DetailRow label="Median yield" value={formatRate(auction.avgMedYield)} />
+        )}
+        <DetailRow label="Bid-to-cover" value={formatRatio(auction.bidToCoverRatio)} />
+        <Box height={1} />
+        <DetailRow label="High price" value={auction.highPrice?.toFixed(4) ?? "—"} />
+        <DetailRow label="Avg/median price" value={auction.avgMedPrice?.toFixed(4) ?? "—"} />
+        <DetailRow label="Low price" value={auction.lowPrice?.toFixed(4) ?? "—"} />
+        <Box height={1} />
+        <DetailRow label="Offering" value={formatMoney(auction.offeringAmount)} />
+        <DetailRow label="Total accepted" value={formatMoney(auction.totalAccepted)} />
+        <DetailRow label="Competitive" value={share(auction.competitiveAccepted)} />
+        <DetailRow label="Indirect" value={share(auction.indirectAccepted)} />
+        <DetailRow label="Primary dealer" value={share(auction.primaryDealerAccepted)} />
+      </Box>
+    </ScrollBox>
+  );
+}
+
+export function TreasuryAuctionsPane({ focused, width, height }: PaneProps) {
+  const [auctions, setAuctions] = useState<TreasuryAuction[]>([]);
+  const [status, setStatus] = useState<LoadStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [stale, setStale] = useState(false);
+  const [fetchedAt, setFetchedAt] = useState<number | null>(null);
+  const [filter, setFilter] = useState<AuctionFilter>("all");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [sortPreference, setSortPreference] = useState<AuctionSortPreference>(DEFAULT_AUCTION_SORT);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchFocused, setSearchFocused] = useState(false);
+  const [searchFocusToken, setSearchFocusToken] = useState(0);
+  const searchInputRef = useRef<InputRenderable | null>(null);
+  const fetchGenRef = useRef(0);
+
+  const focusSearch = useCallback(() => {
+    setSearchFocused(true);
+    setSearchFocusToken((current) => current + 1);
+  }, []);
+  const blurSearch = useCallback(() => setSearchFocused(false), []);
+
+  const load = useCallback((force = false) => {
+    fetchGenRef.current += 1;
+    const generation = fetchGenRef.current;
+    setStatus((current) => (current === "loaded" ? "loaded" : "loading"));
+    setError(null);
+    loadTreasuryAuctions(force)
+      .then((result) => {
+        if (fetchGenRef.current !== generation) return;
+        setAuctions(result.auctions);
+        setFetchedAt(result.fetchedAt);
+        setStale(result.stale);
+        setStatus("loaded");
+      })
+      .catch((loadError: unknown) => {
+        if (fetchGenRef.current !== generation) return;
+        setError(loadError instanceof Error ? loadError.message : String(loadError));
+        setStatus("error");
+      });
+  }, []);
+
+  useEffect(() => {
+    load(false);
+    const interval = setInterval(() => load(false), AUTO_REFRESH_MS);
+    return () => clearInterval(interval);
+  }, [load]);
+
+  const rows = useMemo(
+    () => visibleAuctions(auctions, { filter, query: searchQuery, sort: sortPreference }),
+    [auctions, filter, searchQuery, sortPreference],
+  );
+  const selected = rows.find((auction) => auction.id === selectedId) ?? null;
+
+  useEffect(() => {
+    if (rows.length === 0) {
+      if (selectedId !== null) setSelectedId(null);
+      setDetailOpen(false);
+      return;
+    }
+    if (!selectedId || !rows.some((auction) => auction.id === selectedId)) {
+      setSelectedId(rows[0]!.id);
+    }
+  }, [rows, selectedId]);
+
+  const selectFilter = useCallback((next: AuctionFilter) => {
+    setFilter(next);
+    setDetailOpen(false);
+  }, []);
+  const cycleFilter = useCallback(() => {
+    setFilter((current) => nextFilter(current));
+    setDetailOpen(false);
+  }, []);
+  const cycleSort = useCallback((step: 1 | -1) => {
+    setSortPreference((current) => {
+      const next = cycleSortPreference<AuctionColumnId>(AUCTION_SORT_COLUMN_IDS, current, step);
+      return { columnId: next.columnId ?? DEFAULT_AUCTION_SORT.columnId, direction: next.direction };
+    });
+  }, []);
+
+  const handlePaneKey = useCallback((event: DataTableKeyEvent): boolean => {
+    if (isPlainKey(event, "r")) {
+      stopSearchFocusNavigation(event);
+      load(true);
+      return true;
+    }
+    if (isPlainKey(event, "f")) {
+      stopSearchFocusNavigation(event);
+      cycleFilter();
+      return true;
+    }
+    if (isPlainKey(event, "]") || isPlainKey(event, "[")) {
+      stopSearchFocusNavigation(event);
+      cycleSort(event.name === "]" ? 1 : -1);
+      return true;
+    }
+    return false;
+  }, [cycleFilter, cycleSort, load]);
+
+  const handleRootKeyDown = useCallback((
+    event: DataTableKeyEvent,
+    context: DataTableRootKeyContext,
+  ) => {
+    if (context.selectedIndex <= 0 && isPlainArrowUp(event)) {
+      stopSearchFocusNavigation(event);
+      focusSearch();
+      return true;
+    }
+    if (isPlainKey(event, "s") || isPlainKey(event, "/")) {
+      stopSearchFocusNavigation(event);
+      focusSearch();
+      return true;
+    }
+    return handlePaneKey(event);
+  }, [focusSearch, handlePaneKey]);
+
+  const columns = useMemo(() => buildAuctionColumns(width), [width]);
+  const activeFilterLabel = AUCTION_FILTERS.find((entry) => entry.value === filter)?.label ?? "All";
+
+  usePaneFooter(TREASURY_AUCTIONS_PANE_ID, () => {
+    const info: PaneFooterSegment[] = [];
+    if (status === "loading") info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
+    if (error) info.push({ id: "error", parts: [{ text: "error", tone: "warning" }] });
+    if (stale) info.push({ id: "stale", parts: [{ text: "stale cache", tone: "warning" }] });
+    if (filter !== "all") info.push({ id: "filter", parts: [{ text: activeFilterLabel, tone: "value" }] });
+    if (searchQuery.trim()) {
+      info.push({ id: "search", parts: [{ text: `search: ${searchQuery.trim()}`, tone: "value" }] });
+    }
+    if (fetchedAt) {
+      info.push({ id: "updated", parts: [{ text: formatRelativeAge(fetchedAt), tone: "muted" }] });
+    }
+    return {
+      info,
+      hints: detailOpen
+        ? [{ id: "refresh", key: "r", label: "efresh", onPress: () => load(true) }]
+        : [
+          { id: "search", key: "s", label: "earch", onPress: focusSearch },
+          { id: "filter", key: "f", label: "ilter", onPress: cycleFilter },
+          { id: "refresh", key: "r", label: "efresh", onPress: () => load(true) },
+        ],
+    };
+  }, [
+    activeFilterLabel,
+    cycleFilter,
+    detailOpen,
+    error,
+    fetchedAt,
+    filter,
+    focusSearch,
+    load,
+    searchQuery,
+    stale,
+    status,
+  ]);
+
+  const tabs = (
+    <Box height={1} flexShrink={0} overflow="hidden">
+      <Tabs
+        tabs={AUCTION_FILTERS.map((entry) => ({ label: entry.label, value: entry.value }))}
+        activeValue={filter}
+        onSelect={(value) => selectFilter(value as AuctionFilter)}
+        compact
+        variant="bare"
+        focused={focused && !detailOpen && !searchFocused}
+      />
+    </Box>
+  );
+
+  if (status === "loading" && auctions.length === 0) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {tabs}
+        <Box flexGrow={1} justifyContent="center" alignItems="center">
+          <Spinner label="Loading Treasury auctions..." />
+        </Box>
+      </Box>
+    );
+  }
+
+  if (error && auctions.length === 0) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {tabs}
+        <Box padding={1}>
+          <EmptyState title="Treasury auctions unavailable." message={error} hint="Press r to retry." />
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      {tabs}
+      <DataTableStackView<TreasuryAuction, AuctionColumn>
+        focused={focused && !searchFocused}
+        detailOpen={detailOpen && !!selected}
+        onBack={() => setDetailOpen(false)}
+        detailContent={selected ? <TreasuryAuctionDetail auction={selected} width={width} /> : null}
+        detailTitle={selected ? `${selected.secType} ${selected.securityTerm}` : undefined}
+        rootBefore={(
+          <InputSearchBar
+            value={searchQuery}
+            focused={focused && !detailOpen}
+            active={searchFocused}
+            width={width}
+            focusToken={searchFocusToken}
+            inputRef={searchInputRef}
+            placeholder="type, term, or date"
+            debounceMs={80}
+            onFocus={focusSearch}
+            onBlur={blurSearch}
+            onNavigateDown={blurSearch}
+            onQueryChange={setSearchQuery}
+          />
+        )}
+        onRootKeyDown={handleRootKeyDown}
+        onDetailKeyDown={handlePaneKey}
+        selection={{
+          kind: "id",
+          selectedId,
+          getId: (auction) => auction.id,
+          onChange: (id) => setSelectedId(id),
+        }}
+        onActivate={() => {
+          blurSearch();
+          setDetailOpen(true);
+        }}
+        rootWidth={width}
+        rootHeight={Math.max(1, height - 1)}
+        columns={columns}
+        items={rows}
+        sortColumnId={sortPreference.columnId}
+        sortDirection={sortPreference.direction}
+        onHeaderClick={(columnId) => setSortPreference((current) => (
+          nextAuctionSort(current, columnId as AuctionColumnId)
+        ))}
+        getItemKey={(auction) => auction.id}
+        renderCell={(auction, column, _index, rowState) => renderAuctionCell(auction, column, rowState)}
+        emptyStateTitle={searchQuery.trim() ? "No matching auctions." : "No recent auctions."}
+        emptyStateHint={searchQuery.trim() ? "Clear search or press r to refresh." : "Press r to refresh."}
+      />
+    </Box>
+  );
+}

--- a/src/plugins/builtin/treasury-auctions/types.ts
+++ b/src/plugins/builtin/treasury-auctions/types.ts
@@ -1,0 +1,56 @@
+export const TREASURY_AUCTIONS_PANE_ID = "treasury-auctions";
+
+/**
+ * Normalized Treasury auction record. Fiscal Data returns every field as a
+ * string, including the literal `"null"` for metrics an auction does not
+ * report, so numbers are parsed once here.
+ */
+export interface TreasuryAuction {
+  /** security_type | auction_date | security_term */
+  id: string;
+  /** "Bill", "Note", "Bond", "CMB", "FRN", "TIPS". */
+  secType: string;
+  /** "4-Week", "2-Year", "29-Year 6-Month". */
+  securityTerm: string;
+  /** ISO "YYYY-MM-DD". */
+  auctionDate: string;
+  /** High investment rate, reported by Bills and FRNs. */
+  highInvestmentRate: number | null;
+  /** High yield, reported by Notes, Bonds, and TIPS. */
+  highYield: number | null;
+  avgMedYield: number | null;
+  highPrice: number | null;
+  lowPrice: number | null;
+  avgMedPrice: number | null;
+  bidToCoverRatio: number | null;
+  /** Competitive accepted dollar amount. */
+  competitiveAccepted: number | null;
+  /** Indirect bidder accepted dollars (foreign central banks and similar). */
+  indirectAccepted: number | null;
+  /** Primary dealer accepted dollars. */
+  primaryDealerAccepted: number | null;
+  totalAccepted: number | null;
+  /** Offering amount announced before the auction. */
+  offeringAmount: number | null;
+}
+
+/** Raw shape returned by the Fiscal Data auctions_query endpoint. */
+export interface TreasuryAuctionRaw {
+  security_type?: string;
+  security_term?: string;
+  auction_date?: string;
+  high_investment_rate?: string;
+  high_yield?: string;
+  avg_med_yield?: string;
+  high_price?: string;
+  low_price?: string;
+  avg_med_price?: string;
+  bid_to_cover_ratio?: string;
+  comp_accepted?: string;
+  indirect_bidder_accepted?: string;
+  primary_dealer_accepted?: string;
+  total_accepted?: string;
+  offering_amt?: string;
+}
+
+export type LoadStatus = "idle" | "loading" | "loaded" | "error";

--- a/src/plugins/builtin/world-indices/footer.ts
+++ b/src/plugins/builtin/world-indices/footer.ts
@@ -1,28 +1,16 @@
-import { usePaneFooter, type PaneFooterSegment } from "../../../components";
+import { usePaneFooter } from "../../../components";
 import {
-  countLoadingQuotes,
-  latestQuoteTimestamp,
+  quoteBoardFooterInfo,
+  quoteBoardStatus,
   type BoardQuoteMap,
 } from "../shared/use-quote-board";
 
 export function useWorldIndicesFooter(quotes: BoardQuoteMap) {
-  const loadingCount = countLoadingQuotes(quotes);
-  const latestQuoteTs = latestQuoteTimestamp(quotes);
+  const status = quoteBoardStatus(quotes);
 
-  usePaneFooter("world-indices", () => {
-    const info: PaneFooterSegment[] = [];
-    if (loadingCount > 0) {
-      info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
-    }
-    if (latestQuoteTs > 0) {
-      info.push({
-        id: "fresh",
-        parts: [{
-          text: new Date(latestQuoteTs).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
-          tone: "muted",
-        }],
-      });
-    }
-    return { info };
-  }, [latestQuoteTs, loadingCount]);
+  usePaneFooter(
+    "world-indices",
+    () => ({ info: quoteBoardFooterInfo(status) }),
+    [status.latestTs, status.loading, status.stale, status.unavailable],
+  );
 }

--- a/src/plugins/builtin/world-indices/footer.ts
+++ b/src/plugins/builtin/world-indices/footer.ts
@@ -2,10 +2,10 @@ import { usePaneFooter, type PaneFooterSegment } from "../../../components";
 import {
   countLoadingQuotes,
   latestQuoteTimestamp,
-  type QuoteMap,
-} from "./model";
+  type BoardQuoteMap,
+} from "../shared/use-quote-board";
 
-export function useWorldIndicesFooter(quotes: QuoteMap) {
+export function useWorldIndicesFooter(quotes: BoardQuoteMap) {
   const loadingCount = countLoadingQuotes(quotes);
   const latestQuoteTs = latestQuoteTimestamp(quotes);
 

--- a/src/plugins/builtin/world-indices/index.tsx
+++ b/src/plugins/builtin/world-indices/index.tsx
@@ -1,17 +1,16 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { DataTableView } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
-import { useAssetData, usePluginTickerActions } from "../../runtime";
+import { usePluginTickerActions } from "../../runtime";
+import { useQuoteBoard } from "../shared/use-quote-board";
 import { WORLD_INDICES, REGION_LABELS, getIndicesByRegion } from "./indices";
 import { useWorldIndicesFooter } from "./footer";
 import {
   buildFlatRows,
   DEFAULT_SORT_PREFERENCE,
   nextSortPreference,
-  type IndexQuoteState,
-  type QuoteMap,
   type WorldIndexSortPreference,
   type WorldIndexTableRow,
 } from "./model";
@@ -22,14 +21,13 @@ import {
 } from "./table";
 
 const REFRESH_INTERVAL_MS = 60_000;
+const WORLD_INDEX_SYMBOLS = WORLD_INDICES.map((entry) => entry.symbol);
 
 function WorldIndicesPane({ focused, width, height }: PaneProps) {
-  const dataProvider = useAssetData();
   const { pinTicker } = usePluginTickerActions();
-  const [quotes, setQuotes] = useState<QuoteMap>(new Map());
+  const { quotes } = useQuoteBoard(WORLD_INDEX_SYMBOLS, REFRESH_INTERVAL_MS);
   const [selectedSymbol, setSelectedSymbol] = useState<string | null>(null);
   const [sortPreference, setSortPreference] = useState<WorldIndexSortPreference>(DEFAULT_SORT_PREFERENCE);
-  const fetchGenRef = useRef(0);
 
   const indicesByRegion = useMemo(() => getIndicesByRegion(), []);
   const flatRows = useMemo(
@@ -48,84 +46,6 @@ function WorldIndicesPane({ focused, width, height }: PaneProps) {
       setSelectedSymbol(null);
     }
   }, [flatRows, selectedFlatIdx, selectedSymbol]);
-
-  const fetchAll = useCallback(() => {
-    if (!dataProvider) return;
-
-    fetchGenRef.current += 1;
-    const gen = fetchGenRef.current;
-
-    setQuotes((prev) => {
-      const next = new Map(prev);
-      for (const entry of WORLD_INDICES) {
-        const existing = next.get(entry.symbol);
-        next.set(entry.symbol, { quote: existing?.quote ?? null, loading: true, error: null });
-      }
-      return next;
-    });
-
-    const loadQuotes = async (): Promise<QuoteMap> => {
-      const next = new Map<string, IndexQuoteState>();
-      if (dataProvider.getQuotesBatch) {
-        const results = await dataProvider.getQuotesBatch(
-          WORLD_INDICES.map((entry) => ({ symbol: entry.symbol, exchange: "" })),
-        );
-        const bySymbol = new Map(results.map((result) => [result.target.symbol, result]));
-        for (const entry of WORLD_INDICES) {
-          const result = bySymbol.get(entry.symbol);
-          next.set(entry.symbol, {
-            quote: result?.quote ?? null,
-            loading: false,
-            error: result?.error
-              ? result.error instanceof Error ? result.error.message : String(result.error)
-              : null,
-          });
-        }
-        return next;
-      }
-
-      await Promise.all(WORLD_INDICES.map(async (entry) => {
-        try {
-          const quote = await dataProvider.getQuote(entry.symbol, "");
-          next.set(entry.symbol, { quote, loading: false, error: null });
-        } catch (err: unknown) {
-          next.set(entry.symbol, {
-            quote: null,
-            loading: false,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }));
-      return next;
-    };
-
-    loadQuotes().then((nextQuotes) => {
-      if (fetchGenRef.current !== gen) return;
-      setQuotes((prev) => {
-        const next = new Map(prev);
-        for (const [symbol, state] of nextQuotes) {
-          next.set(symbol, state);
-        }
-        return next;
-      });
-    }).catch((err: unknown) => {
-      if (fetchGenRef.current !== gen) return;
-      const message = err instanceof Error ? err.message : String(err);
-      setQuotes((prev) => {
-        const next = new Map(prev);
-        for (const entry of WORLD_INDICES) {
-          next.set(entry.symbol, { quote: null, loading: false, error: message });
-        }
-        return next;
-      });
-    });
-  }, [dataProvider]);
-
-  useEffect(() => {
-    fetchAll();
-    const interval = setInterval(fetchAll, REFRESH_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, [fetchAll]);
 
   const openSelected = useCallback((flatIdx: number) => {
     const row = flatRows[flatIdx];

--- a/src/plugins/builtin/world-indices/model.ts
+++ b/src/plugins/builtin/world-indices/model.ts
@@ -1,14 +1,7 @@
-import type { MarketState, Quote } from "../../../types/financials";
+import type { MarketState } from "../../../types/financials";
 import { compareSortValues, type SortDirection } from "../../../utils/sort-values";
+import type { BoardQuoteMap } from "../shared/use-quote-board";
 import { REGION_ORDER, type IndexEntry } from "./indices";
-
-export interface IndexQuoteState {
-  quote: Quote | null;
-  loading: boolean;
-  error: string | null;
-}
-
-export type QuoteMap = Map<string, IndexQuoteState>;
 
 export type WorldIndexTableRow =
   | { type: "header"; region: IndexEntry["region"] }
@@ -38,7 +31,7 @@ const MARKET_STATE_SORT_ORDER: Partial<Record<MarketState, number>> = {
 function getSortValue(
   columnId: WorldIndexColumnId,
   entry: IndexEntry,
-  quotes: QuoteMap,
+  quotes: BoardQuoteMap,
 ): string | number | null {
   const quote = quotes.get(entry.symbol)?.quote;
 
@@ -59,7 +52,7 @@ function getSortValue(
 function sortEntries(
   entries: IndexEntry[],
   sortPreference: WorldIndexSortPreference,
-  quotes: QuoteMap,
+  quotes: BoardQuoteMap,
 ): IndexEntry[] {
   const sortColumnId = sortPreference.columnId;
   if (!sortColumnId) return entries;
@@ -73,7 +66,7 @@ function sortEntries(
 export function buildFlatRows(
   indicesByRegion: Map<IndexEntry["region"], IndexEntry[]>,
   sortPreference: WorldIndexSortPreference,
-  quotes: QuoteMap,
+  quotes: BoardQuoteMap,
 ): WorldIndexTableRow[] {
   const rows: WorldIndexTableRow[] = [];
   for (const region of REGION_ORDER) {
@@ -99,15 +92,4 @@ export function nextSortPreference(
     return { columnId: typedColumnId, direction: "desc" };
   }
   return DEFAULT_SORT_PREFERENCE;
-}
-
-export function countLoadingQuotes(quotes: QuoteMap): number {
-  return Array.from(quotes.values()).filter((state) => state.loading).length;
-}
-
-export function latestQuoteTimestamp(quotes: QuoteMap): number {
-  return Math.max(
-    0,
-    ...Array.from(quotes.values()).map((state) => state.quote?.lastUpdated ?? 0),
-  );
 }

--- a/src/plugins/builtin/world-indices/pane.test.tsx
+++ b/src/plugins/builtin/world-indices/pane.test.tsx
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, useMemo, useState } from "react";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { AppContext, createInitialState, PaneInstanceProvider } from "../../../state/app/context";
+import { createDefaultConfig } from "../../../types/config";
+import type { QuoteBatchResult } from "../../../types/data-provider";
+import { PluginRenderProvider, type PluginRuntimeAccess } from "../../runtime";
+import { worldIndicesModule } from "./index";
+
+const WorldIndicesPane = worldIndicesModule.panes![0]!.component as (props: {
+  paneId: string;
+  paneType: string;
+  focused: boolean;
+  width: number;
+  height: number;
+}) => React.ReactNode;
+
+const PRICES: Record<string, number> = { "^GSPC": 6_812.44, "^FTSE": 9_431.2 };
+
+/**
+ * Provider identity is what the board's poll effect keys on, so swapping in a
+ * failing provider is how a test drives a second load without a 60s wait.
+ */
+function makeProvider(mode: "ok" | "fail") {
+  return {
+    getQuotesBatch: async (targets: Array<{ symbol: string }>): Promise<QuoteBatchResult[]> => (
+      targets.map((target) => ({
+        target: { symbol: target.symbol, exchange: "" },
+        quote: mode === "fail" ? null : {
+          symbol: target.symbol,
+          price: PRICES[target.symbol] ?? 1_000,
+          change: 12.5,
+          changePercent: 0.42,
+          currency: "USD",
+          marketState: "REGULAR" as const,
+          lastUpdated: Date.now(),
+        },
+        error: mode === "fail" ? new Error("upstream 503") : undefined,
+      })) as QuoteBatchResult[]
+    ),
+  };
+}
+
+let breakProvider: () => void = () => {};
+
+function Harness() {
+  const state = createInitialState(createDefaultConfig("/tmp/gloomberb-wei-pane-test"));
+  const [mode, setMode] = useState<"ok" | "fail">("ok");
+  breakProvider = () => setMode("fail");
+  const runtime = useMemo(() => {
+    const provider = makeProvider(mode);
+    return { getMarketData: () => provider } as unknown as PluginRuntimeAccess;
+  }, [mode]);
+
+  return (
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <PluginRenderProvider runtime={runtime} pluginId="market-overview">
+        <PaneInstanceProvider paneId="world-indices">
+          <WorldIndicesPane
+            paneId="world-indices"
+            paneType="world-indices"
+            focused
+            width={80}
+            height={24}
+          />
+        </PaneInstanceProvider>
+      </PluginRenderProvider>
+    </AppContext>
+  );
+}
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(async () => {
+  if (!testSetup) return;
+  await act(async () => {
+    testSetup!.renderer.destroy();
+  });
+  testSetup = undefined;
+});
+
+async function settle() {
+  await act(async () => {
+    await testSetup!.renderOnce();
+    await testSetup!.renderOnce();
+  });
+}
+
+describe("WorldIndicesPane", () => {
+  test("renders regions and prices from the shared quote board", async () => {
+    testSetup = await testRender(<Harness />, { width: 80, height: 24 });
+    await settle();
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Americas");
+    expect(frame).toContain("SPX");
+    expect(frame).toContain("6,812.44");
+    expect(frame).toContain("+0.42%");
+  });
+
+  test("keeps the last good prices when the provider starts failing", async () => {
+    testSetup = await testRender(<Harness />, { width: 80, height: 24 });
+    await settle();
+    expect(testSetup.captureCharFrame()).toContain("6,812.44");
+
+    await act(async () => {
+      breakProvider();
+    });
+    await settle();
+
+    // Regression: a failed load blanked every price to "—" mid-session.
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("6,812.44");
+    expect(frame).toContain("SPX");
+  });
+});

--- a/src/plugins/builtin/world-indices/table.tsx
+++ b/src/plugins/builtin/world-indices/table.tsx
@@ -40,6 +40,7 @@ export function renderWorldIndexCell(
   const state = quotes.get(entry.symbol);
   const quote = state?.quote;
   const selectedColor = rowState.selected ? colors.selectedText : undefined;
+  const dimmed = rowState.selected ? colors.selectedText : colors.textDim;
 
   switch (column.id) {
     case "status": {
@@ -58,20 +59,15 @@ export function renderWorldIndexCell(
         color: selectedColor,
       };
     case "price":
-      if (state?.loading && !quote) {
-        return { text: "…", color: rowState.selected ? colors.selectedText : colors.textDim };
-      }
-      if (state?.error || quote?.price === undefined) {
-        return { text: "—", color: rowState.selected ? colors.selectedText : colors.textDim };
-      }
+      if (state?.loading && !quote) return { text: "…", color: dimmed };
+      if (quote?.price === undefined) return { text: "—", color: dimmed };
+      // A retained quote still beats a dash; dim it so stale is visible.
       return {
         text: formatCurrency(quote.price, quote.currency ?? "USD"),
-        color: selectedColor,
+        color: state?.stale ? dimmed : selectedColor,
       };
     case "changePercent":
-      if (!quote || quote.changePercent === undefined) {
-        return { text: "—", color: rowState.selected ? colors.selectedText : colors.textDim };
-      }
+      if (!quote || quote.changePercent === undefined) return { text: "—", color: dimmed };
       return {
         text: formatPercentRaw(quote.changePercent),
         color: selectedColor ?? priceColor(quote.changePercent),

--- a/src/plugins/builtin/world-indices/table.tsx
+++ b/src/plugins/builtin/world-indices/table.tsx
@@ -1,10 +1,9 @@
 import type { DataTableCell, DataTableColumn } from "../../../components";
 import { colors, priceColor } from "../../../theme/colors";
-import type { MarketState } from "../../../types/financials";
 import { TextAttributes } from "../../../ui";
 import { formatCurrency, formatPercentRaw } from "../../../utils/format";
+import { marketStatusDot, type BoardQuoteMap } from "../shared/use-quote-board";
 import type {
-  QuoteMap,
   WorldIndexColumnId,
   WorldIndexTableRow,
 } from "./model";
@@ -29,26 +28,11 @@ export function createWorldIndexColumns(width: number): WorldIndexColumn[] {
   ];
 }
 
-function marketStatusDot(state: MarketState | undefined): { char: string; color: string } {
-  switch (state) {
-    case "REGULAR":
-      return { char: "●", color: colors.positive };
-    case "PRE":
-    case "POST":
-    case "PREPRE":
-    case "POSTPOST":
-      return { char: "●", color: colors.warning };
-    case "CLOSED":
-    default:
-      return { char: "●", color: colors.negative };
-  }
-}
-
 export function renderWorldIndexCell(
   row: WorldIndexTableRow,
   column: WorldIndexColumn,
   rowState: { selected: boolean },
-  quotes: QuoteMap,
+  quotes: BoardQuoteMap,
 ): DataTableCell {
   if (row.type === "header") return { text: "" };
 

--- a/src/renderers/electrobun/view/data-table/row.tsx
+++ b/src/renderers/electrobun/view/data-table/row.tsx
@@ -208,10 +208,12 @@ function WebDataTableRowInner<
         style={{
           ...baseRowStyle,
           backgroundColor: sectionHeader.backgroundColor ?? CSS_BG,
+          cursor: sectionHeader.onMouseDown ? "pointer" : undefined,
         }}
         onMouseDown={(event) => {
           focusPane();
           onTableMouseDown?.(event);
+          sectionHeader.onMouseDown?.(event);
           event.preventDefault();
         }}
       >

--- a/src/utils/sort-values.ts
+++ b/src/utils/sort-values.ts
@@ -15,3 +15,34 @@ export function compareSortValues(
     : Number(left) - Number(right);
   return direction === "asc" ? comparison : -comparison;
 }
+
+export interface SortPreference<Id extends string> {
+  columnId: Id | null;
+  direction: SortDirection;
+}
+
+/**
+ * Keyboard equivalent of clicking column headers: walks every sort state the
+ * mouse can reach (each column ascending then descending, plus the unsorted
+ * state when the table has one) so sorting is not mouse-only.
+ */
+export function cycleSortPreference<Id extends string>(
+  columnIds: readonly Id[],
+  current: SortPreference<Id>,
+  step: 1 | -1,
+  options?: { allowUnsorted?: boolean },
+): SortPreference<Id> {
+  const states: SortPreference<Id>[] = options?.allowUnsorted
+    ? [{ columnId: null, direction: "asc" }]
+    : [];
+  for (const columnId of columnIds) {
+    states.push({ columnId, direction: "asc" }, { columnId, direction: "desc" });
+  }
+  if (states.length === 0) return current;
+
+  const index = states.findIndex(
+    (state) => state.columnId === current.columnId && state.direction === current.direction,
+  );
+  const next = (index < 0 ? 0 : index + step + states.length) % states.length;
+  return states[next]!;
+}


### PR DESCRIPTION
## Summary

- add `FUT`, a live front-month futures board across equity indices, rates, energy, metals, agriculture, and currencies
- add `AUCT`, a Treasury Fiscal Data auction board for bills, notes, bonds, and TIPS
- share the quote-board polling path with World Indices while preserving last good quotes on failures
- support search, sorting, configurable columns, sector collapse, detail views, keyboard control, and mouse interaction
- report Fiscal Data requests through the Connections pane

## Data correctness

- all 32 included Yahoo symbols were live-validated; unsupported DXY was excluded
- contract tick metadata preserves values such as half-cent silver ticks
- Fiscal Data normalization handles pending auctions, null sentinels, zero indirect allocations, pagination, deduplication, empty-response rejection, and stale cache fallback
- manual and scheduled quote refreshes bypass provider caches without blanking useful stale data

## Ownership and exclusions

Futures remains inside Market Overview and Treasury Auctions inside Macro. No Buildout or Congress Trades ownership changes. No chart-series syntax, TradingView, order entry, or header changes.

## Verification

- `bun run typecheck`
- `bun test` (2,055 passed)
- live Yahoo validation for 32 contracts
- live Fiscal Data validation
- TUI smoke for FUT, refresh, AUCT, and Connections telemetry
- Electrobun desktop build and background GUI verification, including live rendering and mouse tab activation

## Attribution

The Futures board and interaction design adapt work first developed by @Lucas-Kohorst in [Lucas-Kohorst/gloomberb](https://github.com/Lucas-Kohorst/gloomberb). Treasury Auctions also follows the product direction established in that fork.
