### PR TITLE
Scale the desktop grid from FONT+ / FONT-

### DIFF
--- a/src/components/command-bar/commands/direct/index.ts
+++ b/src/components/command-bar/commands/direct/index.ts
@@ -11,6 +11,7 @@ import {
   applyTheme,
   clearTransientThemePreview,
 } from "../../../../theme/colors";
+import { clampFontSize, MIN_FONT_SIZE_PX } from "../../../../theme/font-scale";
 import type { AppAction, AppState } from "../../../../state/app/context";
 import { isManualPortfolio } from "../../../../plugins/builtin/portfolio-list/mutations";
 import { CHART_RENDERER_PREFERENCES } from "../../../chart/core/types";
@@ -259,6 +260,23 @@ export function runDirectCommandAction(options: {
       };
       dispatch({ type: "SET_CONFIG", config: nextConfig });
       persistConfig(nextConfig);
+      closeAll({ revertThemePreview: false });
+      return;
+    }
+    case "font-size-increase":
+    case "font-size-decrease": {
+      const delta = command.id === "font-size-increase" ? 1 : -1;
+      const current = clampFontSize(state.config.fontSize);
+      const next = clampFontSize(current + delta);
+      if (next === current) {
+        notify(`Font size already at ${next === MIN_FONT_SIZE_PX ? "minimum" : "maximum"} (${next}px)`, { type: "info" });
+        closeAll({ revertThemePreview: false });
+        return;
+      }
+      const nextConfig = { ...state.config, fontSize: next };
+      dispatch({ type: "SET_CONFIG", config: nextConfig });
+      persistConfig(nextConfig);
+      notify(`Font size: ${next}px`, { type: "success" });
       closeAll({ revertThemePreview: false });
       return;
     }

--- a/src/components/command-bar/commands/registry.ts
+++ b/src/components/command-bar/commands/registry.ts
@@ -174,6 +174,20 @@ export const commands: Command[] = [
     category: "Config",
   },
   {
+    id: "font-size-increase",
+    prefix: "FONT+",
+    label: "Increase Font Size",
+    description: "Increase the app-wide font size",
+    category: "Config",
+  },
+  {
+    id: "font-size-decrease",
+    prefix: "FONT-",
+    label: "Decrease Font Size",
+    description: "Decrease the app-wide font size",
+    category: "Config",
+  },
+  {
     id: "check-for-updates",
     prefix: "",
     label: "Check for Updates",

--- a/src/components/command-bar/routes/root/command-items.ts
+++ b/src/components/command-bar/routes/root/command-items.ts
@@ -142,6 +142,9 @@ export function createRootCommandItemBuilder({
         return command.description;
       case "toggle-value-flashing":
         return state.config.valueFlashingEnabled ? "Currently on" : "Currently off";
+      case "font-size-increase":
+      case "font-size-decrease":
+        return `Currently ${state.config.fontSize ?? 12}px`;
       default:
         return command.description;
     }

--- a/src/data/config/store/normalize.ts
+++ b/src/data/config/store/normalize.ts
@@ -13,6 +13,7 @@ import {
 } from "../../../types/config";
 import type { Portfolio, Watchlist } from "../../../types/ticker";
 import { isLanguagePreference } from "../../../i18n/languages";
+import { clampFontSize } from "../../../theme/font-scale";
 import { isLayoutConfig, sanitizeLayout } from "../layout";
 import { migrateSavedConfig } from "./migrations";
 
@@ -57,6 +58,7 @@ export function normalizeLoadedConfig(saved: Record<string, unknown>, dataDir: s
     theme: typeof candidate.theme === "string" ? candidate.theme : defaults.theme,
     chartPreferences: sanitizeChartPreferences(candidate.chartPreferences, defaults.chartPreferences),
     valueFlashingEnabled: typeof candidate.valueFlashingEnabled === "boolean" ? candidate.valueFlashingEnabled : defaults.valueFlashingEnabled,
+    fontSize: sanitizeFontSize(candidate.fontSize, defaults.fontSize),
     recentTickers: sanitizeStringArray(candidate.recentTickers, defaults.recentTickers),
     language: isLanguagePreference(candidate.language) ? candidate.language : undefined,
     onboardingComplete,
@@ -111,12 +113,18 @@ export function normalizeConfigForSave(config: AppConfig): AppConfig {
     pluginConfig: sanitizePluginConfig(config.pluginConfig),
     chartPreferences: sanitizeChartPreferences(config.chartPreferences, defaults.chartPreferences),
     valueFlashingEnabled: config.valueFlashingEnabled !== false,
+    fontSize: sanitizeFontSize(config.fontSize, defaults.fontSize),
     recentTickers: sanitizeStringArray(config.recentTickers, []),
     onboardingComplete: onboardingProgress ? false : config.onboardingComplete,
     onboardingProgress,
   };
 
   return persisted;
+}
+
+function sanitizeFontSize(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return clampFontSize(value);
 }
 
 const ONBOARDING_STAGES = new Set<OnboardingProgress["stage"]>([

--- a/src/renderers/electrobun/view/host/text.tsx
+++ b/src/renderers/electrobun/view/host/text.tsx
@@ -11,7 +11,10 @@ import { webAsciiTextLines, webAsciiTextWordmarkVariant } from "./ascii-text";
 import { mouseHandlers } from "./mouse";
 import { cleanDomProps, commonStyle, textStyle } from "./style";
 
-const WEB_WORDMARK_CHAR_WIDTH_PX = Math.max(10, WEB_CELL_WIDTH);
+// Read per render: the cell width tracks the configured font size.
+function wordmarkCharWidthPx(): number {
+  return Math.max(10, WEB_CELL_WIDTH);
+}
 
 interface WebAsciiTextProps extends AsciiTextProps {
   desktopPlatform?: string;
@@ -105,7 +108,7 @@ export function WebAsciiText({
   const resolvedBackground = bg ?? backgroundColor;
   const lineHeightPx = isCompatWordmark ? 16 : 12;
   const wordmarkWidthPx = isCompatWordmark
-    ? Math.max(...lines.map((line) => line.length)) * WEB_WORDMARK_CHAR_WIDTH_PX
+    ? Math.max(...lines.map((line) => line.length)) * wordmarkCharWidthPx()
     : undefined;
   return (
     <div

--- a/src/renderers/electrobun/view/input-host.tsx
+++ b/src/renderers/electrobun/view/input-host.tsx
@@ -18,9 +18,11 @@ import {
   shouldConsumeWebAppKeyDown,
   webKeySequence,
 } from "./key-event";
+import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "../../../theme/font-scale";
 
-export const WEB_CELL_WIDTH = 8;
-export const WEB_CELL_HEIGHT = 18;
+// Re-exported as live bindings so every consumer follows the configured font
+// size (see theme/font-scale) without threading metrics through the tree.
+export { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "../../../theme/font-scale";
 
 function toKeyEventLike(event: KeyboardEvent): KeyEventLike {
   const key = normalizeWebKeyName(event.key);

--- a/src/state/app/context/index.tsx
+++ b/src/state/app/context/index.tsx
@@ -14,6 +14,7 @@ import {
 } from "react";
 import type { AppSessionStorePort } from "../../../core/app-service-ports";
 import { ThemeProvider } from "../../../theme/theme-context";
+import { syncFontScale } from "../../../theme/font-scale";
 import {
   findPaneInstance,
   materializeDetachedPanesAsFloating,
@@ -500,6 +501,15 @@ export function AppProvider({
     lastDetachedPaneSyncRef.current = paneSignature;
     void desktopBridge.replaceDetachedPaneState(desktopBridge.paneId, state.paneState[desktopBridge.paneId] ?? {});
   }, [desktopBridge, serializePaneState, state.paneState]);
+
+  useLayoutEffect(() => {
+    // The DOM renderer measures everything in grid cells, so resizing the cell
+    // is what actually scales panes and windows. A resize notification makes
+    // viewport-derived measurements re-read the new grid immediately.
+    if (syncFontScale(state.config.fontSize) && typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
+      window.dispatchEvent(new Event("resize"));
+    }
+  }, [state.config.fontSize]);
 
   useLayoutEffect(() => {
     stateRef.current = state;

--- a/src/theme/font-scale.test.ts
+++ b/src/theme/font-scale.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { BASE_FONT_SIZE_PX, clampFontSize, MAX_FONT_SIZE_PX, MIN_FONT_SIZE_PX } from "./font-scale";
+
+describe("clampFontSize", () => {
+  test("keeps in-range sizes and falls back outside them", () => {
+    expect(clampFontSize(12)).toBe(BASE_FONT_SIZE_PX);
+    expect(clampFontSize(MIN_FONT_SIZE_PX)).toBe(MIN_FONT_SIZE_PX);
+    expect(clampFontSize(MAX_FONT_SIZE_PX)).toBe(MAX_FONT_SIZE_PX);
+    expect(clampFontSize(9)).toBe(MIN_FONT_SIZE_PX);
+    expect(clampFontSize(48)).toBe(MAX_FONT_SIZE_PX);
+    expect(clampFontSize("12")).toBe(BASE_FONT_SIZE_PX);
+    expect(clampFontSize(Number.NaN)).toBe(BASE_FONT_SIZE_PX);
+  });
+});

--- a/src/theme/font-scale.ts
+++ b/src/theme/font-scale.ts
@@ -1,0 +1,69 @@
+/**
+ * Font scaling for the DOM renderer.
+ *
+ * Every web measurement — pane geometry, table rows, floating windows, the
+ * command bar — is expressed in grid cells, so the whole app scales by resizing
+ * the cell in step with the root font size rather than by restyling each pane.
+ * `WEB_CELL_WIDTH` / `WEB_CELL_HEIGHT` are live bindings: importers read the
+ * current value, and a re-render after `syncFontScale()` picks up the new grid.
+ *
+ * The terminal renderer owns no font (the emulator does), so this no-ops there.
+ */
+
+export const BASE_FONT_SIZE_PX = 12;
+export const MIN_FONT_SIZE_PX = 10;
+export const MAX_FONT_SIZE_PX = 20;
+
+const BASE_CELL_WIDTH_PX = 8;
+const BASE_CELL_HEIGHT_PX = 18;
+
+export let WEB_CELL_WIDTH: number = BASE_CELL_WIDTH_PX;
+export let WEB_CELL_HEIGHT: number = BASE_CELL_HEIGHT_PX;
+
+let appliedFontSizePx = BASE_FONT_SIZE_PX;
+let appliedToDocument = false;
+
+export function clampFontSize(value: unknown): number {
+  const numeric = typeof value === "number" && Number.isFinite(value) ? value : BASE_FONT_SIZE_PX;
+  return Math.min(MAX_FONT_SIZE_PX, Math.max(MIN_FONT_SIZE_PX, Math.round(numeric)));
+}
+
+export function getFontSize(): number {
+  return appliedFontSizePx;
+}
+
+function roundToHundredth(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/**
+ * Applies a font size to the document grid. Returns true when the grid changed,
+ * so callers can force dependent measurements to refresh.
+ */
+export function syncFontScale(fontSizePx: unknown): boolean {
+  const size = clampFontSize(fontSizePx);
+  if (size === appliedFontSizePx && appliedToDocument) return false;
+
+  const scale = size / BASE_FONT_SIZE_PX;
+  appliedFontSizePx = size;
+  WEB_CELL_WIDTH = roundToHundredth(BASE_CELL_WIDTH_PX * scale);
+  WEB_CELL_HEIGHT = roundToHundredth(BASE_CELL_HEIGHT_PX * scale);
+
+  const style = (globalThis as {
+    document?: { body?: { style?: { setProperty: (name: string, value: string) => void } } };
+  }).document?.body?.style;
+  if (!style) return false;
+
+  style.setProperty("--cell-w", `${WEB_CELL_WIDTH}px`);
+  style.setProperty("--cell-h", `${WEB_CELL_HEIGHT}px`);
+  style.setProperty("font-size", `${size}px`);
+  appliedToDocument = true;
+  return true;
+}
+
+export function resetFontScaleForTests(): void {
+  appliedFontSizePx = BASE_FONT_SIZE_PX;
+  appliedToDocument = false;
+  WEB_CELL_WIDTH = BASE_CELL_WIDTH_PX;
+  WEB_CELL_HEIGHT = BASE_CELL_HEIGHT_PX;
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -153,6 +153,7 @@ export interface AppConfig {
   theme: string;
   chartPreferences: ChartPreferences;
   valueFlashingEnabled: boolean;
+  fontSize: number;
   recentTickers: string[];
   language?: LanguagePreference;
   onboardingComplete?: boolean;
@@ -633,6 +634,7 @@ export function createDefaultConfig(dataDir: string): AppConfig {
       renderer: "auto",
     },
     valueFlashingEnabled: true,
+    fontSize: 12,
     recentTickers: [],
   };
 }


### PR DESCRIPTION
## Summary
- Adds `FONT+` / `FONT-` (10–20px) and stores `fontSize` on config.
- The DOM renderer measures everything in grid cells, so changing font size resizes the cell (`--cell-w` / `--cell-h`) instead of restyling each pane.
- Terminal OpenTUI is unchanged; the emulator owns the font there.

## Test plan
- [ ] Desktop: `Ctrl+P` → `FONT+` / `FONT-` — panes, tables, and floating windows scale; command bar shows the current px.
- [ ] Hitting 10px / 20px notifies min/max instead of no-opping silently.
- [ ] Terminal session still starts; FONT commands persist but do not fight the emulator font.


Made with [Cursor](https://cursor.com)