### PR TITLE
Standardize pane footer actions and search shortcuts

### DIFF
--- a/src/components/layout/pane/footer/index.test.tsx
+++ b/src/components/layout/pane/footer/index.test.tsx
@@ -21,11 +21,11 @@ afterEach(async () => {
 });
 
 function Registration({
-  onRefresh,
-  refreshDisabled = false,
+  onOpen,
+  openDisabled = false,
 }: {
-  onRefresh?: () => void;
-  refreshDisabled?: boolean;
+  onOpen?: () => void;
+  openDisabled?: boolean;
 }) {
   usePaneFooter("test", () => {
     return {
@@ -39,10 +39,10 @@ function Registration({
         },
       ],
       hints: [
-        { id: "refresh", key: "r", label: "efresh", onPress: onRefresh, disabled: refreshDisabled },
+        { id: "open", key: "o", label: "pen", onPress: onOpen, disabled: openDisabled },
       ],
     };
-  }, [onRefresh, refreshDisabled]);
+  }, [onOpen, openDisabled]);
   return null;
 }
 
@@ -78,18 +78,18 @@ function TranslatedFooterHarness() {
 
 function FooterHarness({
   focused = false,
-  onRefresh,
-  refreshDisabled = false,
+  onOpen,
+  openDisabled = false,
 }: {
   focused?: boolean;
-  onRefresh?: () => void;
-  refreshDisabled?: boolean;
+  onOpen?: () => void;
+  openDisabled?: boolean;
 }) {
   return (
     <PaneFooterProvider>
       {(footer) => (
         <Box width={64} height={1}>
-          <Registration onRefresh={onRefresh} refreshDisabled={refreshDisabled} />
+          <Registration onOpen={onOpen} openDisabled={openDisabled} />
           <PaneFooterBar footer={footer} focused={focused} width={64} />
         </Box>
       )}
@@ -141,7 +141,7 @@ describe("PaneFooterBar", () => {
 
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Rows 12");
-    expect(frame).not.toContain("[r]efresh");
+    expect(frame).not.toContain("[o]pen");
   });
 
   test("keeps raw external URLs out of footer text", async () => {
@@ -159,7 +159,7 @@ describe("PaneFooterBar", () => {
 
   test("omits disabled controls instead of rendering muted hints", async () => {
     testSetup = await testRender(
-      <FooterHarness focused refreshDisabled onRefresh={() => {}} />,
+      <FooterHarness focused openDisabled onOpen={() => {}} />,
       { width: 64, height: 1 },
     );
     await act(async () => {
@@ -169,31 +169,31 @@ describe("PaneFooterBar", () => {
 
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Rows 12");
-    expect(frame).not.toContain("[r]efresh");
+    expect(frame).not.toContain("[o]pen");
   });
 
   test("calls hint onPress from mouse interaction", async () => {
-    let refreshCount = 0;
-    testSetup = await testRender(<FooterHarness focused onRefresh={() => { refreshCount += 1; }} />, { width: 64, height: 1 });
+    let openCount = 0;
+    testSetup = await testRender(<FooterHarness focused onOpen={() => { openCount += 1; }} />, { width: 64, height: 1 });
     await act(async () => {
       await testSetup!.renderOnce();
       await testSetup!.renderOnce();
     });
 
     const line = testSetup.captureCharFrame().split("\n")[0] ?? "";
-    const col = line.indexOf("[r]efresh");
+    const col = line.indexOf("[o]pen");
     expect(col).toBeGreaterThanOrEqual(0);
 
     await act(async () => {
       await testSetup!.mockMouse.release(col + 1, 0);
       await testSetup!.renderOnce();
     });
-    expect(refreshCount).toBe(0);
+    expect(openCount).toBe(0);
 
     await act(async () => {
       await testSetup!.mockMouse.click(col + 1, 0);
       await testSetup!.renderOnce();
     });
-    expect(refreshCount).toBe(1);
+    expect(openCount).toBe(1);
   });
 });

--- a/src/components/use-external-link-footer.ts
+++ b/src/components/use-external-link-footer.ts
@@ -14,6 +14,7 @@ interface UseExternalLinkFooterOptions {
   source?: string | null;
   info?: PaneFooterSegment[];
   hints?: PaneHint[];
+  trailingHints?: PaneHint[];
   label?: string;
   showHint?: boolean;
 }
@@ -33,6 +34,7 @@ export function useExternalLinkFooter({
   source,
   info = EMPTY_INFO,
   hints = EMPTY_HINTS,
+  trailingHints = EMPTY_HINTS,
   label = "link",
   showHint = true,
 }: UseExternalLinkFooterOptions) {
@@ -71,9 +73,10 @@ export function useExternalLinkFooter({
       hints: [
         ...hints,
         ...(url && showHint ? [{ id: "open", key: "o", label: "pen", onPress: openUrl }] : []),
+        ...trailingHints,
       ],
     };
-  }, [hints, info, label, openUrl, showHint, sourceLabel, url]);
+  }, [hints, info, label, openUrl, showHint, sourceLabel, trailingHints, url]);
 
   usePaneFooter(registrationId, () => footer, [footer]);
 

--- a/src/components/use-external-link-footer.ts
+++ b/src/components/use-external-link-footer.ts
@@ -14,7 +14,6 @@ interface UseExternalLinkFooterOptions {
   source?: string | null;
   info?: PaneFooterSegment[];
   hints?: PaneHint[];
-  trailingHints?: PaneHint[];
   label?: string;
   showHint?: boolean;
 }
@@ -34,7 +33,6 @@ export function useExternalLinkFooter({
   source,
   info = EMPTY_INFO,
   hints = EMPTY_HINTS,
-  trailingHints = EMPTY_HINTS,
   label = "link",
   showHint = true,
 }: UseExternalLinkFooterOptions) {
@@ -73,10 +71,9 @@ export function useExternalLinkFooter({
       hints: [
         ...hints,
         ...(url && showHint ? [{ id: "open", key: "o", label: "pen", onPress: openUrl }] : []),
-        ...trailingHints,
       ],
     };
-  }, [hints, info, label, openUrl, showHint, sourceLabel, trailingHints, url]);
+  }, [hints, info, label, openUrl, showHint, sourceLabel, url]);
 
   usePaneFooter(registrationId, () => footer, [footer]);
 

--- a/src/plugins/builtin/ai/screener/footer.ts
+++ b/src/plugins/builtin/ai/screener/footer.ts
@@ -12,7 +12,6 @@ interface UseAiScreenerFooterOptions {
   onCancelRun: () => void;
   onCloseEditor: () => void;
   onEdit: () => void;
-  onRefresh: () => void;
   onSaveEditor: () => void;
 }
 
@@ -25,7 +24,6 @@ export function useAiScreenerFooter({
   onCancelRun,
   onCloseEditor,
   onEdit,
-  onRefresh,
   onSaveEditor,
 }: UseAiScreenerFooterOptions) {
   const language = useAppLanguage();
@@ -81,13 +79,6 @@ export function useAiScreenerFooter({
               onPress: onAddTab,
             },
             {
-              id: "refresh",
-              key: "r",
-              label: t("efresh"),
-              onPress: onRefresh,
-              disabled: !activeTab,
-            },
-            {
               id: "edit",
               key: "e",
               label: t("dit"),
@@ -104,7 +95,6 @@ export function useAiScreenerFooter({
     onCancelRun,
     onCloseEditor,
     onEdit,
-    onRefresh,
     onSaveEditor,
     runState,
   ]);

--- a/src/plugins/builtin/ai/screener/pane.test.tsx
+++ b/src/plugins/builtin/ai/screener/pane.test.tsx
@@ -242,7 +242,7 @@ describe("AiScreenerPane", () => {
     expect(frame).toContain("Initial pass");
     expect(frame).toContain("Strong cash flow durability");
     expect(frame.match(/Strong cash flow durability/g)?.length).toBe(1);
-    expect(frame).toContain("[r]efresh");
+    expect(frame).not.toContain("[r]efresh");
     expect(frame).not.toContain("[Shift+R]");
     const lines = frame.split("\n");
     const tabLine = lines.findIndex((line) => line.includes("Compounders"));

--- a/src/plugins/builtin/ai/screener/pane.tsx
+++ b/src/plugins/builtin/ai/screener/pane.tsx
@@ -341,7 +341,6 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
     onCancelRun: cancelRun,
     onCloseEditor: closeEditor,
     onEdit: editActiveTab,
-    onRefresh: refreshActiveTab,
     onSaveEditor: saveEditor,
   });
 

--- a/src/plugins/builtin/buildout/pane/index.tsx
+++ b/src/plugins/builtin/buildout/pane/index.tsx
@@ -158,9 +158,8 @@ export function BuildoutPane({ focused, width, height }: PaneProps) {
     if (detailCompanyTicker) {
       hints.push({ id: "open-ticker", key: "o", label: "pen", onPress: openDetailTicker });
     }
-    hints.push({ id: "refresh", key: "r", label: "efresh", onPress: refresh });
     return hints;
-  }, [detailCompanyTicker, openDetailTicker, refresh, startUpgrade, state]);
+  }, [detailCompanyTicker, openDetailTicker, startUpgrade, state]);
 
   usePaneFooter("buildout", () => ({
     info: updateBuildoutFooterInfo(state, activeTab, selectedList, favoriteMessage),

--- a/src/plugins/builtin/buildout/pane/index.tsx
+++ b/src/plugins/builtin/buildout/pane/index.tsx
@@ -158,8 +158,9 @@ export function BuildoutPane({ focused, width, height }: PaneProps) {
     if (detailCompanyTicker) {
       hints.push({ id: "open-ticker", key: "o", label: "pen", onPress: openDetailTicker });
     }
+    hints.push({ id: "refresh", key: "r", label: "efresh", onPress: refresh });
     return hints;
-  }, [detailCompanyTicker, openDetailTicker, startUpgrade, state]);
+  }, [detailCompanyTicker, openDetailTicker, refresh, startUpgrade, state]);
 
   usePaneFooter("buildout", () => ({
     info: updateBuildoutFooterInfo(state, activeTab, selectedList, favoriteMessage),

--- a/src/plugins/builtin/changelog/index.tsx
+++ b/src/plugins/builtin/changelog/index.tsx
@@ -10,7 +10,6 @@ import {
   type DataTableColumn,
   type DataTableKeyEvent,
   type PaneFooterSegment,
-  type PaneHint,
 } from "../../../components";
 import { MarkdownText } from "../../../components/markdown-text";
 import { fetchChangelogReleases, type ChangelogRelease } from "../../../updater/github-releases";
@@ -287,15 +286,6 @@ function ChangelogPane({ focused, width, height }: PaneProps) {
     return segments;
   }, [status]);
 
-  const footerHints = useMemo<PaneHint[]>(() => [{
-    id: "refresh",
-    key: "r",
-    label: "efresh",
-    onPress: () => {
-      void loadReleases();
-    },
-  }], [loadReleases]);
-
   useExternalLinkFooter({
     registrationId: "changelog",
     focused,
@@ -303,7 +293,6 @@ function ChangelogPane({ focused, width, height }: PaneProps) {
     source: openRelease?.version,
     label: "release",
     info: footerInfo,
-    hints: footerHints,
   });
 
   if (status === "loading" && releases.length === 0) {

--- a/src/plugins/builtin/congress-trades/detail.tsx
+++ b/src/plugins/builtin/congress-trades/detail.tsx
@@ -224,7 +224,6 @@ export function MemberTradesDetail({
       ...(maybeTruncated ? [{ id: "member-truncated", parts: [{ text: `limited to ${CONGRESS_MEMBER_TRADE_LIMIT} trades`, tone: "warning" as const }] }] : []),
     ],
     hints: [
-      { id: "member-refresh", key: "r", label: "efresh", onPress: refresh },
       { id: "member-ticker", key: "t", label: "icker", onPress: openSelectedTicker, disabled: !selectedTrade?.ticker },
       { id: "member-open", key: "o", label: "pen", onPress: openSelectedSource, disabled: !selectedTrade?.sourceUrl },
     ],
@@ -233,7 +232,6 @@ export function MemberTradesDetail({
     maybeTruncated,
     openSelectedSource,
     openSelectedTicker,
-    refresh,
     selectedTrade?.sourceUrl,
     selectedTrade?.ticker,
     status,

--- a/src/plugins/builtin/congress-trades/footer.ts
+++ b/src/plugins/builtin/congress-trades/footer.ts
@@ -16,7 +16,6 @@ export function useCongressTradesFooter({
   detailMode,
   detailTrade,
   error,
-  load,
   openSelectedTicker,
   openSelectedTradeMember,
   openSelectedTradeSource,
@@ -28,7 +27,6 @@ export function useCongressTradesFooter({
   detailMode: DetailMode;
   detailTrade: CloudCongressTradePayload | null;
   error: string | null;
-  load: (refresh?: boolean) => void;
   openSelectedTicker: () => void;
   openSelectedTradeMember: () => void;
   openSelectedTradeSource: () => void;
@@ -47,22 +45,18 @@ export function useCongressTradesFooter({
       ...(status === "loading" ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
     ],
-    hints: detailMode?.kind === "member"
-      ? []
-      : [
-          { id: "refresh", key: "r", label: "efresh", onPress: () => load(true) },
-          ...(activeTab === "trades" ? [
-            { id: "member", key: "m", label: "ember", onPress: openSelectedTradeMember, disabled: !selectedTrade },
-            { id: "ticker", key: "t", label: "icker", onPress: openSelectedTicker, disabled: !(detailTrade?.ticker ?? selectedTrade?.ticker) },
-            { id: "open", key: "o", label: "pen", onPress: openSelectedTradeSource, disabled: !(detailTrade ?? selectedTrade)?.sourceUrl },
-          ] : []),
-        ],
+    hints: detailMode?.kind !== "member" && activeTab === "trades"
+      ? [
+          { id: "member", key: "m", label: "ember", onPress: openSelectedTradeMember, disabled: !selectedTrade },
+          { id: "ticker", key: "t", label: "icker", onPress: openSelectedTicker, disabled: !(detailTrade?.ticker ?? selectedTrade?.ticker) },
+          { id: "open", key: "o", label: "pen", onPress: openSelectedTradeSource, disabled: !(detailTrade ?? selectedTrade)?.sourceUrl },
+        ]
+      : [],
   }), [
     activeTab,
     detailMode,
     detailTrade,
     error,
-    load,
     openSelectedTicker,
     openSelectedTradeMember,
     openSelectedTradeSource,

--- a/src/plugins/builtin/congress-trades/pane.tsx
+++ b/src/plugins/builtin/congress-trades/pane.tsx
@@ -182,7 +182,6 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
     detailMode,
     detailTrade,
     error,
-    load,
     openSelectedTicker,
     openSelectedTradeMember,
     openSelectedTradeSource,
@@ -240,7 +239,7 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
       <Box flexDirection="column" width={width} height={height}>
         {tabs}
         <Box padding={1}>
-          <EmptyState title="Congress trades unavailable." message={error} hint="Press r to retry." />
+          <EmptyState title="Congress trades unavailable." message={error} />
         </Box>
       </Box>
     );
@@ -278,7 +277,6 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
           getItemKey={(trade) => trade.id}
           renderCell={renderCongressTradeCell}
           emptyStateTitle="No House PTR trades."
-          emptyStateHint="Press r to refresh."
         />
       ) : (
         <DataTableStackView<CloudCongressMemberPayload, MemberColumn>
@@ -309,7 +307,6 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
           getItemKey={(member) => member.id}
           renderCell={renderCongressMemberCell}
           emptyStateTitle="No House PTR members."
-          emptyStateHint="Press r to refresh."
         />
       )}
     </Box>

--- a/src/plugins/builtin/credit-conditions/index.tsx
+++ b/src/plugins/builtin/credit-conditions/index.tsx
@@ -144,10 +144,7 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
     ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
     ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
   ], [error, loading, partial, stale]);
-  usePaneFooter(paneId, () => ({
-    info: footerInfo,
-    hints: [{ id: "reload", key: "r", label: "eload", onPress: reload, disabled: loading }],
-  }), [footerInfo, loading, paneId, reload]);
+  usePaneFooter(paneId, () => ({ info: footerInfo }), [footerInfo, paneId]);
 
   if (rows.length === 0 && loading) {
     return <Box width={width} height={height} justifyContent="center" alignItems="center"><Text fg={colors.textMuted}>Loading credit spreads...</Text></Box>;
@@ -187,7 +184,6 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
       getItemKey={(row) => row.seriesId}
       renderCell={renderRowCell}
       emptyStateTitle="No credit spread data."
-      emptyStateHint="Press r to reload."
     />
   );
 }

--- a/src/plugins/builtin/dividend-yield/pane.tsx
+++ b/src/plugins/builtin/dividend-yield/pane.tsx
@@ -12,7 +12,7 @@ import type { ProjectedChartPoint } from "../../../components/chart/core/data";
 import { resolveChartPalette } from "../../../components/chart/core/renderer";
 import { colors, priceColor } from "../../../theme/colors";
 import { formatCurrency, formatNumber, formatPercentRaw } from "../../../utils/format";
-import { handleRefreshKey, loadingErrorFooterInfo, refreshFooterHint } from "../shared/table-pane";
+import { handleRefreshKey, loadingErrorFooterInfo } from "../shared/table-pane";
 import { fetchDividendData, type DividendData } from "./client";
 import {
   buildDividendColumns,
@@ -236,8 +236,7 @@ export function DividendYieldPane({ focused, width, height }: { focused: boolean
 
   usePaneFooter("dividend-yield", () => ({
     info: loadingErrorFooterInfo(loading, error),
-    hints: [{ ...refreshFooterHint(refresh), disabled: !symbol || loading }],
-  }), [error, loading, refresh, symbol]);
+  }), [error, loading]);
 
   const payments = data?.payments ?? [];
   const metrics = data?.metrics;

--- a/src/plugins/builtin/earnings/index.tsx
+++ b/src/plugins/builtin/earnings/index.tsx
@@ -132,8 +132,7 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
       ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
     ],
-    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: () => reload(true) }],
-  }), [error, loading, reload]);
+  }), [error, loading]);
 
   return (
     <DataTableView<EarningsDisplayRow, EarningsColumn>

--- a/src/plugins/builtin/econ/index.tsx
+++ b/src/plugins/builtin/econ/index.tsx
@@ -235,7 +235,6 @@ function EconCalendarPane({ focused, width, height }: PaneProps) {
     loading,
     error,
     info: calendarStatus,
-    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: () => load(true) }],
   });
 
   const handleHeaderClick = useCallback(() => {}, []);

--- a/src/plugins/builtin/econ/index.tsx
+++ b/src/plugins/builtin/econ/index.tsx
@@ -235,6 +235,7 @@ function EconCalendarPane({ focused, width, height }: PaneProps) {
     loading,
     error,
     info: calendarStatus,
+    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: () => load(true) }],
   });
 
   const handleHeaderClick = useCallback(() => {}, []);

--- a/src/plugins/builtin/fear-greed/pane.tsx
+++ b/src/plugins/builtin/fear-greed/pane.tsx
@@ -83,8 +83,7 @@ export function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
       ...(footerAge ? [{ id: "age", parts: [{ text: footerAge, tone: loading ? "muted" as const : "value" as const }] }] : []),
       ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
     ],
-    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refresh, disabled: loading }],
-  }), [data, error, footerAge, loading, paneId, refresh]);
+  }), [data, error, footerAge, loading, paneId]);
 
   if (loading && !data) {
     return (

--- a/src/plugins/builtin/futures/index.tsx
+++ b/src/plugins/builtin/futures/index.tsx
@@ -128,7 +128,7 @@ function FuturesPane({ focused, width, height }: PaneProps) {
       refresh();
       return true;
     }
-    if (isPlainKey(event, "s") || isPlainKey(event, "/")) {
+    if (isPlainKey(event, "/")) {
       stopSearchFocusNavigation(event);
       focusSearch();
       return true;
@@ -161,14 +161,10 @@ function FuturesPane({ focused, width, height }: PaneProps) {
     }
     return {
       info,
-      hints: [
-        { id: "search", key: "s", label: "earch", onPress: focusSearch },
-        { id: "refresh", key: "r", label: "efresh", onPress: refresh },
-      ],
+      hints: [{ id: "search", key: "/", label: "search", onPress: focusSearch }],
     };
   }, [
     focusSearch,
-    refresh,
     searchQuery,
     status.latestTs,
     status.loading,
@@ -209,7 +205,7 @@ function FuturesPane({ focused, width, height }: PaneProps) {
         : null}
       renderCell={renderCell}
       emptyStateTitle={searchQuery.trim() ? "No matching contracts." : "No contracts configured."}
-      emptyStateHint={searchQuery.trim() ? "Clear search or press r to refresh." : "Press s to search."}
+      emptyStateHint={searchQuery.trim() ? "Clear search." : "Press / to search."}
       rootBefore={(
         <InputSearchBar
           value={searchQuery}

--- a/src/plugins/builtin/futures/pane.test.tsx
+++ b/src/plugins/builtin/futures/pane.test.tsx
@@ -190,7 +190,7 @@ describe("FuturesPane", () => {
     await renderSettled();
     expect(testSetup.captureCharFrame()).not.toContain("E-Mini Dow");
 
-    await emitKeypress({ name: "s", sequence: "s" });
+    await emitKeypress({ name: "/", sequence: "/" });
     for (const character of "dow") {
       await emitKeypress({ name: character, sequence: character });
     }
@@ -221,7 +221,7 @@ describe("FuturesPane", () => {
     testSetup = await testRender(<Harness />, { width: 80, height: 24 });
     await renderSettled();
 
-    await emitKeypress({ name: "s", sequence: "s" });
+    await emitKeypress({ name: "/", sequence: "/" });
     await renderSettled();
     for (const character of "gold") {
       await emitKeypress({ name: character, sequence: character });

--- a/src/plugins/builtin/fx-matrix/index.tsx
+++ b/src/plugins/builtin/fx-matrix/index.tsx
@@ -80,8 +80,7 @@ function FxMatrixPane({ focused, width, height }: PaneProps) {
 
   usePaneFooter("fx-matrix", () => ({
     info: ageText ? [{ id: "updated", parts: [{ text: ageText, tone: loading ? "muted" : "value" }] }] : [],
-    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: fetchRates }],
-  }), [ageText, fetchRates, loading]);
+  }), [ageText, loading]);
 
   // Row header: just the 3-letter code, no emoji (keeps width predictable)
   // Rates use flexGrow so they fill available space dynamically

--- a/src/plugins/builtin/holders/pane.tsx
+++ b/src/plugins/builtin/holders/pane.tsx
@@ -261,12 +261,11 @@ export function HoldersView({ focused, width, height }: { focused: boolean; widt
         ...(fundMatching ? [{ id: "fund-matching", parts: [{ text: "13F matching", tone: "muted" as const }] }] : []),
       ],
       hints: [
-        { id: "refresh", key: "r", label: "efresh", onPress: refresh },
         { id: "view", key: "s", label: "witch", onPress: toggleView },
         ...(selectedFundMatch ? [{ id: "fund", key: "f", label: "und", onPress: () => openFundDetail(selectedRow) }] : []),
       ],
     };
-  }, [data?.asOf, fundMatching, loading, openFundDetail, refresh, selectedFundMatch, selectedRow, toggleView]);
+  }, [data?.asOf, fundMatching, loading, openFundDetail, selectedFundMatch, selectedRow, toggleView]);
 
   const emptyTitle = !symbol
     ? "No ticker selected"

--- a/src/plugins/builtin/ipo-calendar/pane.tsx
+++ b/src/plugins/builtin/ipo-calendar/pane.tsx
@@ -131,7 +131,7 @@ export function IPOCalendarPane({ focused, width, height }: PaneProps) {
       refresh();
       return true;
     }
-    if (isPlainKey(event, "/") || isPlainKey(event, "s")) {
+    if (isPlainKey(event, "/")) {
       event.preventDefault?.();
       event.stopPropagation?.();
       focusSearch();
@@ -147,7 +147,7 @@ export function IPOCalendarPane({ focused, width, height }: PaneProps) {
   useShortcut((event) => {
     if (!focused || searchFocused) return;
     if (event.targetEditable) return;
-    if (isPlainKey(event, "/") || isPlainKey(event, "s")) {
+    if (isPlainKey(event, "/")) {
       event.stopPropagation?.();
       event.preventDefault?.();
       focusSearch();
@@ -171,10 +171,10 @@ export function IPOCalendarPane({ focused, width, height }: PaneProps) {
     }] : []),
   ], [error, searchQuery, status]);
 
-  const footerHints = useMemo(() => [
-    { id: "search", key: "s", label: "earch", onPress: focusSearch },
-    { id: "refresh", key: "r", label: "efresh", onPress: refresh },
-  ], [focusSearch, refresh]);
+  const footerHints = useMemo(
+    () => [{ id: "search", key: "/", label: "search", onPress: focusSearch }],
+    [focusSearch],
+  );
 
   useExternalLinkFooter({
     registrationId: IPO_CALENDAR_PANE_ID,

--- a/src/plugins/builtin/kelly-sizer/index.test.tsx
+++ b/src/plugins/builtin/kelly-sizer/index.test.tsx
@@ -149,14 +149,14 @@ describe("KellySizerPane", () => {
     expect(frame).not.toContain("Kelly Curve");
   });
 
-  test("focuses ticker search with t", async () => {
+  test("focuses ticker search with slash", async () => {
     await renderPane();
     await flushFrame();
 
     await act(async () => {
       (testSetup!.renderer.keyInput as any).emit("keypress", {
-        name: "t",
-        sequence: "t",
+        name: "/",
+        sequence: "/",
         ctrl: false,
         meta: false,
         shift: false,

--- a/src/plugins/builtin/kelly-sizer/pane.tsx
+++ b/src/plugins/builtin/kelly-sizer/pane.tsx
@@ -340,7 +340,7 @@ export function KellySizerPane({ focused, width, height }: PaneProps) {
       toggleSensitivity();
       return;
     }
-    if (isPlainShortcut(event, "t")) {
+    if (isPlainShortcut(event, "/")) {
       event.preventDefault?.();
       event.stopPropagation?.();
       focusTickerSearch();
@@ -360,7 +360,7 @@ export function KellySizerPane({ focused, width, height }: PaneProps) {
         ? [{ id: "clip", parts: [{ text: `clip ${result.clipReasons.join(", ")}`, tone: "muted" as const }] }]
         : [],
     hints: [
-      { id: "ticker", key: "t", label: "icker", onPress: focusTickerSearch },
+      { id: "search", key: "/", label: "search", onPress: focusTickerSearch },
       { id: "sensitivity", key: "s", label: showSensitivity ? "ensitivity off" : "ensitivity", onPress: toggleSensitivity },
     ],
   }), [focusTickerSearch, result.clipReasons, result.warnings, showSensitivity, toggleSensitivity]);

--- a/src/plugins/builtin/market-heatmap/index.tsx
+++ b/src/plugins/builtin/market-heatmap/index.tsx
@@ -278,7 +278,8 @@ function MarketHeatmapPane({ focused, width, height }: PaneProps) {
         parts: [{ text: feedStatus, tone: feedStatus === "live" ? "value" as const : "muted" as const }],
       }] : []),
     ],
-  }), [feedStatus, loadError, loading, selectedAsset, updated]);
+    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refresh }],
+  }), [feedStatus, loadError, loading, refresh, selectedAsset, updated]);
 
   const emptyStateTitle = loading
     ? "Loading market heatmap..."

--- a/src/plugins/builtin/market-heatmap/index.tsx
+++ b/src/plugins/builtin/market-heatmap/index.tsx
@@ -278,8 +278,7 @@ function MarketHeatmapPane({ focused, width, height }: PaneProps) {
         parts: [{ text: feedStatus, tone: feedStatus === "live" ? "value" as const : "muted" as const }],
       }] : []),
     ],
-    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refresh }],
-  }), [feedStatus, loadError, loading, refresh, selectedAsset, updated]);
+  }), [feedStatus, loadError, loading, selectedAsset, updated]);
 
   const emptyStateTitle = loading
     ? "Loading market heatmap..."

--- a/src/plugins/builtin/market-movers/index.tsx
+++ b/src/plugins/builtin/market-movers/index.tsx
@@ -263,8 +263,7 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
         parts: [{ text: "stale", tone: "muted" as const }],
       }] : []),
     ],
-    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refreshActiveTab }],
-  }), [feedStatus, loading, moversStale, refreshActiveTab, summaryQuotes]);
+  }), [feedStatus, loading, moversStale, summaryQuotes]);
 
   return (
     <Box flexDirection="column" width={width} height={height}>

--- a/src/plugins/builtin/news/wire/news/footer.ts
+++ b/src/plugins/builtin/news/wire/news/footer.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
-import type { PaneFooterSegment } from "../../../../../components";
+import { useShortcut } from "../../../../../react/input";
+import type { PaneFooterSegment, PaneHint } from "../../../../../components";
 import { t, tf } from "../../../../../i18n";
 import { useAppLanguage } from "../../../../../i18n/react";
 import { useCloudAccessFooter } from "../../../shared/cloud-upgrade";
@@ -18,6 +19,7 @@ interface UseNewsArticleFooterOptions {
   info?: PaneFooterSegment[];
   loading?: boolean;
   error?: string | null;
+  onRefresh?: () => void;
 }
 
 export function useNewsArticleFooter({
@@ -27,6 +29,7 @@ export function useNewsArticleFooter({
   info,
   loading = false,
   error,
+  onRefresh,
 }: UseNewsArticleFooterOptions) {
   const language = useAppLanguage();
   const { access, segment } = useCloudAccessFooter({
@@ -43,6 +46,19 @@ export function useNewsArticleFooter({
     return segment ? [segment] : [];
   }, [access.isPayingPro, language, segment]);
   const footerInfo = useMemo(() => [...accessInfo, ...(info ?? [])], [accessInfo, info]);
+  const hints = useMemo<PaneHint[]>(() => (
+    onRefresh
+      ? [{ id: "refresh", key: "r", label: "efresh", onPress: onRefresh }]
+      : []
+  ), [onRefresh]);
+
+  useShortcut((event) => {
+    const key = (event.name ?? event.key ?? "").toLowerCase();
+    if (!focused || !onRefresh || key !== "r") return;
+    event.stopPropagation?.();
+    event.preventDefault?.();
+    onRefresh();
+  }, { enabled: focused && !!onRefresh });
 
   usePaneStatusLinkFooter({
     registrationId,
@@ -50,6 +66,8 @@ export function useNewsArticleFooter({
     url: article?.url,
     source: article?.source,
     info: footerInfo,
+    hints,
+    showOpenHint: true,
     loading,
     error,
   });

--- a/src/plugins/builtin/news/wire/news/footer.ts
+++ b/src/plugins/builtin/news/wire/news/footer.ts
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
-import { useShortcut } from "../../../../../react/input";
-import type { PaneFooterSegment, PaneHint } from "../../../../../components";
+import type { PaneFooterSegment } from "../../../../../components";
 import { t, tf } from "../../../../../i18n";
 import { useAppLanguage } from "../../../../../i18n/react";
 import { useCloudAccessFooter } from "../../../shared/cloud-upgrade";
@@ -19,7 +18,6 @@ interface UseNewsArticleFooterOptions {
   info?: PaneFooterSegment[];
   loading?: boolean;
   error?: string | null;
-  onRefresh?: () => void;
 }
 
 export function useNewsArticleFooter({
@@ -29,7 +27,6 @@ export function useNewsArticleFooter({
   info,
   loading = false,
   error,
-  onRefresh,
 }: UseNewsArticleFooterOptions) {
   const language = useAppLanguage();
   const { access, segment } = useCloudAccessFooter({
@@ -46,19 +43,6 @@ export function useNewsArticleFooter({
     return segment ? [segment] : [];
   }, [access.isPayingPro, language, segment]);
   const footerInfo = useMemo(() => [...accessInfo, ...(info ?? [])], [accessInfo, info]);
-  const hints = useMemo<PaneHint[]>(() => (
-    onRefresh
-      ? [{ id: "refresh", key: "r", label: "efresh", onPress: onRefresh }]
-      : []
-  ), [onRefresh]);
-
-  useShortcut((event) => {
-    const key = (event.name ?? event.key ?? "").toLowerCase();
-    if (!focused || !onRefresh || key !== "r") return;
-    event.stopPropagation?.();
-    event.preventDefault?.();
-    onRefresh();
-  }, { enabled: focused && !!onRefresh });
 
   usePaneStatusLinkFooter({
     registrationId,
@@ -66,7 +50,6 @@ export function useNewsArticleFooter({
     url: article?.url,
     source: article?.source,
     info: footerInfo,
-    hints,
     showOpenHint: true,
     loading,
     error,

--- a/src/plugins/builtin/polls/pane.tsx
+++ b/src/plugins/builtin/polls/pane.tsx
@@ -524,7 +524,7 @@ export function PollsPane({ focused, width, height }: PaneProps) {
       focusSearch();
       return true;
     }
-    if (event.name === "s" || event.name === "/") {
+    if (event.name === "/") {
       event.preventDefault?.();
       event.stopPropagation?.();
       focusSearch();
@@ -547,7 +547,7 @@ export function PollsPane({ focused, width, height }: PaneProps) {
 
   useShortcut((event) => {
     if (!focused || detailOpen || searchFocused) return;
-    if (event.name === "s" || event.name === "/") {
+    if (event.name === "/") {
       event.preventDefault?.();
       event.stopPropagation?.();
       focusSearch();
@@ -606,16 +606,12 @@ export function PollsPane({ focused, width, height }: PaneProps) {
       ...(updatedAgo ? [{ id: "updated", parts: [{ text: `updated ${updatedAgo}`, tone: "muted" as const }] }] : []),
     ],
     hints: detailOpen
-      ? [
-          { id: "refresh", key: "r", label: "efresh", onPress: () => load(tab) },
-          { id: "open", key: "o", label: "pen", onPress: openSelected, disabled: !selected?.url },
-        ]
+      ? [{ id: "open", key: "o", label: "pen", onPress: openSelected, disabled: !selected?.url }]
       : [
-          { id: "search", key: "s", label: "earch", onPress: focusSearch },
-          { id: "refresh", key: "r", label: "efresh", onPress: () => load(tab) },
+          { id: "search", key: "/", label: "search", onPress: focusSearch },
           { id: "open", key: "o", label: "pen", onPress: openSelected, disabled: !selected?.url },
         ],
-  }), [error, detailOpen, focusSearch, load, openSelected, selected?.url, status, searchQuery, tab, updatedAgo]);
+  }), [error, detailOpen, focusSearch, openSelected, selected?.url, status, searchQuery, updatedAgo]);
 
   const tabs = (
     <Box height={1} flexShrink={0} overflow="hidden">
@@ -667,7 +663,7 @@ export function PollsPane({ focused, width, height }: PaneProps) {
       <Box flexDirection="column" width={width} height={height}>
         {tabs}
         <Box padding={1}>
-          <EmptyState title="Polls unavailable." message={error} hint="Press r to retry." />
+          <EmptyState title="Polls unavailable." message={error} />
         </Box>
       </Box>
     );
@@ -723,7 +719,7 @@ export function PollsPane({ focused, width, height }: PaneProps) {
         getItemKey={(row) => row.id}
         renderCell={renderCell}
         emptyStateTitle={searchQuery.trim() ? "No matching polls." : "No polls in this category."}
-        emptyStateHint={searchQuery.trim() ? "Clear search or press r to refresh." : "Press r to refresh."}
+        emptyStateHint={searchQuery.trim() ? "Clear search." : undefined}
       />
     </Box>
   );

--- a/src/plugins/builtin/research/analyst-pane.tsx
+++ b/src/plugins/builtin/research/analyst-pane.tsx
@@ -13,7 +13,7 @@ import { blendHex, colors, priceColor } from "../../../theme/colors";
 import { formatCurrency, formatNumber, formatPercent } from "../../../utils/format";
 import { compareSortValues, type SortDirection } from "../../../utils/sort-values";
 import { useAssetData } from "../../runtime";
-import { handleRefreshKey, loadingErrorFooterInfo, refreshFooterHint } from "../shared/table-pane";
+import { handleRefreshKey, loadingErrorFooterInfo } from "../shared/table-pane";
 import { useBoundTicker as useSymbolBinding, useTickerRequest } from "../shared/ticker-request";
 
 function compactPeriod(period: string): string {
@@ -358,8 +358,7 @@ export function AnalystResearchView({ focused, width, height }: { focused: boole
       ...buildAnalystFooterInfo(data),
       ...loadingErrorFooterInfo(loading, error),
     ],
-    hints: [refreshFooterHint(reload)],
-  }), [data, error, loading, reload]);
+  }), [data, error, loading]);
 
   return (
     <DataTableView<AnalystResearchData["ratings"][number], RatingColumn>

--- a/src/plugins/builtin/research/corporate-actions-pane.tsx
+++ b/src/plugins/builtin/research/corporate-actions-pane.tsx
@@ -23,7 +23,7 @@ import { useResolvedEntryValue, useSecFilingDocuments, useSecFilingsQuery } from
 import { instrumentFromTicker } from "../../../market-data/request-types";
 import { isUsEquityTicker } from "../../../utils/sec";
 import { useAssetData } from "../../runtime";
-import { handleRefreshKey, loadingErrorFooterInfo, refreshFooterHint } from "../shared/table-pane";
+import { handleRefreshKey, loadingErrorFooterInfo } from "../shared/table-pane";
 import { useBoundTicker as useSymbolBinding, useTickerRequest } from "../shared/ticker-request";
 import {
   documentContentKey,
@@ -700,8 +700,7 @@ export function CorporateActionsView({
 
   usePaneFooter(footerPaneId, () => ({
     info: loadingErrorFooterInfo(loading, error),
-    hints: [refreshFooterHint(reload)],
-  }), [error, footerPaneId, loading, reload]);
+  }), [error, footerPaneId, loading]);
 
   return (
     <DataTableStackView<EventRow, EventColumn>

--- a/src/plugins/builtin/research/relative-valuation-pane.tsx
+++ b/src/plugins/builtin/research/relative-valuation-pane.tsx
@@ -13,7 +13,7 @@ import { usePaneInstance } from "../../../state/app/context";
 import { blendHex, colors, priceColor } from "../../../theme/colors";
 import { formatCompact, formatCurrency, formatNumber, formatPercent, formatPercentRaw } from "../../../utils/format";
 import { useAssetData, usePluginTickerActions } from "../../runtime";
-import { handleRefreshKey, loadingErrorFooterInfo, refreshFooterHint, useClampSelectedIndex } from "../shared/table-pane";
+import { handleRefreshKey, loadingErrorFooterInfo, useClampSelectedIndex } from "../shared/table-pane";
 import { useBoundTicker as useSymbolBinding } from "../shared/ticker-request";
 
 type RelativeColumnId = "symbol" | "price" | "change" | "marketCap" | "pe" | "forwardPe" | "evSales" | "fcfYield" | "revenueGrowth" | "margin";
@@ -159,8 +159,7 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
       { id: "tickers", parts: [{ text: `${symbols.length} tickers`, tone: symbols.length > 0 ? "value" as const : "muted" as const }] },
       ...loadingErrorFooterInfo(loading, error),
     ],
-    hints: [refreshFooterHint(() => reload(true))],
-  }), [error, loading, reload, symbols.length]);
+  }), [error, loading, symbols.length]);
 
   return (
     <DataTableView<RelativeRow, RelativeColumn>

--- a/src/plugins/builtin/sec/index.tsx
+++ b/src/plugins/builtin/sec/index.tsx
@@ -295,6 +295,7 @@ function SecView({ width, height, focused }: { width: number; height: number; fo
     label: "filing",
     loading,
     error,
+    showOpenHint: !error && !!openFiling?.filingUrl,
   });
 
   if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view SEC filings.</Text>;

--- a/src/plugins/builtin/sectors/index.tsx
+++ b/src/plugins/builtin/sectors/index.tsx
@@ -251,8 +251,7 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
         parts: [{ text: lastRefreshText, tone: lastRefreshMs ? "value" : "muted" }],
       },
     ],
-    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: fetchAll }],
-  }), [activeCollection.label, fetchAll, lastRefreshMs, lastRefreshText]);
+  }), [activeCollection.label, lastRefreshMs, lastRefreshText]);
 
   const rootBefore = (
     <Box height={1} paddingX={1}>

--- a/src/plugins/builtin/shared/pane-footer.ts
+++ b/src/plugins/builtin/shared/pane-footer.ts
@@ -62,7 +62,6 @@ export function usePaneStatusLinkFooter({
   error,
   info = EMPTY_STATUS_INFO,
   hints,
-  trailingHints,
   showOpenHint = false,
 }: {
   registrationId: string;
@@ -74,7 +73,6 @@ export function usePaneStatusLinkFooter({
   error?: string | null;
   info?: readonly PaneFooterSegment[];
   hints?: PaneHint[];
-  trailingHints?: PaneHint[];
   showOpenHint?: boolean;
 }) {
   const statusInfo = useMemo(
@@ -89,7 +87,6 @@ export function usePaneStatusLinkFooter({
     label,
     info: statusInfo,
     hints,
-    trailingHints,
     showHint: showOpenHint,
   });
 }

--- a/src/plugins/builtin/shared/pane-footer.ts
+++ b/src/plugins/builtin/shared/pane-footer.ts
@@ -3,6 +3,7 @@ import {
   useExternalLinkFooter,
   usePaneFooter,
   type PaneFooterSegment,
+  type PaneHint,
 } from "../../../components";
 
 const EMPTY_STATUS_INFO: PaneFooterSegment[] = [];
@@ -28,12 +29,14 @@ export function usePaneStatusFooter({
   loading = false,
   error,
   info = EMPTY_STATUS_INFO,
+  hints,
   enabled = true,
 }: {
   registrationId: string;
   loading?: boolean;
   error?: string | null;
   info?: readonly PaneFooterSegment[];
+  hints?: PaneHint[];
   enabled?: boolean;
 }) {
   const statusInfo = useMemo(
@@ -42,8 +45,10 @@ export function usePaneStatusFooter({
   );
   usePaneFooter(
     registrationId,
-    () => enabled && statusInfo.length > 0 ? { info: statusInfo } : null,
-    [enabled, registrationId, statusInfo],
+    () => enabled && (statusInfo.length > 0 || (hints?.length ?? 0) > 0)
+      ? { info: statusInfo, hints }
+      : null,
+    [enabled, hints, registrationId, statusInfo],
   );
 }
 
@@ -56,6 +61,9 @@ export function usePaneStatusLinkFooter({
   loading = false,
   error,
   info = EMPTY_STATUS_INFO,
+  hints,
+  trailingHints,
+  showOpenHint = false,
 }: {
   registrationId: string;
   focused: boolean;
@@ -65,6 +73,9 @@ export function usePaneStatusLinkFooter({
   loading?: boolean;
   error?: string | null;
   info?: readonly PaneFooterSegment[];
+  hints?: PaneHint[];
+  trailingHints?: PaneHint[];
+  showOpenHint?: boolean;
 }) {
   const statusInfo = useMemo(
     () => buildPaneStatusInfo({ loading, error, info }),
@@ -77,6 +88,8 @@ export function usePaneStatusLinkFooter({
     source,
     label,
     info: statusInfo,
-    showHint: false,
+    hints,
+    trailingHints,
+    showHint: showOpenHint,
   });
 }

--- a/src/plugins/builtin/shared/table-pane.ts
+++ b/src/plugins/builtin/shared/table-pane.ts
@@ -1,15 +1,11 @@
 import { useEffect } from "react";
-import type { DataTableKeyEvent, PaneFooterSegment, PaneHint } from "../../../components";
+import type { DataTableKeyEvent, PaneFooterSegment } from "../../../components";
 
 export function loadingErrorFooterInfo(loading: boolean, error: string | null | undefined): PaneFooterSegment[] {
   return [
     ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
     ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
   ];
-}
-
-export function refreshFooterHint(reload: () => void): PaneHint {
-  return { id: "refresh", key: "r", label: "efresh", onPress: reload };
 }
 
 export function handleRefreshKey(event: DataTableKeyEvent, reload: () => void, options: { stopPropagation?: boolean } = {}): boolean {

--- a/src/plugins/builtin/short-interest/pane.tsx
+++ b/src/plugins/builtin/short-interest/pane.tsx
@@ -169,8 +169,7 @@ function ShortInterestView({ width, height, focused }: { width: number; height: 
       ...(status === "loading" ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(status === "error" && error ? [{ id: "error", parts: [{ text: error.slice(0, 60), tone: "warning" as const }] }] : []),
     ],
-    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refresh }],
-  }), [error, refresh, status]);
+  }), [error, status]);
 
   if (!ticker || !symbol) {
     return <EmptyState title="No ticker selected" message="Select a ticker to view short interest." />;
@@ -181,7 +180,7 @@ function ShortInterestView({ width, height, focused }: { width: number; height: 
   }
 
   if (status === "error" && records.length === 0) {
-    return <EmptyState title="Failed to load short interest" message={error ?? undefined} hint="Press [r] to retry" />;
+    return <EmptyState title="Failed to load short interest" message={error ?? undefined} />;
   }
 
   if (status === "loaded" && records.length === 0) {

--- a/src/plugins/builtin/substack/pane-footer.ts
+++ b/src/plugins/builtin/substack/pane-footer.ts
@@ -16,7 +16,6 @@ export function useSubstackPaneFooter({
   activeFeedState,
   activeDetail,
   selectedArticle,
-  refreshActive,
   openSelectedArticle,
 }: {
   auth: SubstackAuthState | null;
@@ -24,7 +23,6 @@ export function useSubstackPaneFooter({
   activeFeedState: ActiveFeedState;
   activeDetail: DetailState;
   selectedArticle: SubstackArticleSummary | null;
-  refreshActive: () => void;
   openSelectedArticle: () => void;
 }) {
   const statusLabel = cacheStatusLabel(activeFeedState.fetchedAt, activeFeedState.stale);
@@ -46,10 +44,9 @@ export function useSubstackPaneFooter({
       ...(activeFeedState.error ? [{ id: "error", parts: [{ text: activeFeedState.error, tone: "warning" as const }] }] : []),
       ...(activeDetail.error && detailOpen ? [{ id: "detail-error", parts: [{ text: activeDetail.error, tone: "warning" as const }] }] : []),
     ],
-    hints: auth ? [
-      { id: "refresh", key: "r", label: "efresh", onPress: refreshActive },
-      { id: "open", key: "o", label: "pen", onPress: openSelectedArticle, disabled: !selectedArticle?.url },
-    ] : [],
+    hints: auth
+      ? [{ id: "open", key: "o", label: "pen", onPress: openSelectedArticle, disabled: !selectedArticle?.url }]
+      : [],
   }), [
     activeDetail.error,
     activeDetail.loading,
@@ -64,7 +61,6 @@ export function useSubstackPaneFooter({
     auth,
     detailOpen,
     openSelectedArticle,
-    refreshActive,
     selectedArticle?.url,
     statusLabel,
   ]);

--- a/src/plugins/builtin/substack/pane.tsx
+++ b/src/plugins/builtin/substack/pane.tsx
@@ -411,7 +411,6 @@ export function SubstackPane({ focused, width, height }: PaneProps) {
     activeFeedState,
     activeDetail,
     selectedArticle,
-    refreshActive,
     openSelectedArticle,
   });
 
@@ -452,7 +451,7 @@ export function SubstackPane({ focused, width, height }: PaneProps) {
       <Box flexDirection="column" width={width} height={height}>
         {tabs}
         <Box padding={1}>
-          <EmptyState title="Substack unavailable." message={home.error} hint="Press r to retry." />
+          <EmptyState title="Substack unavailable." message={home.error} />
         </Box>
       </Box>
     );

--- a/src/plugins/builtin/thirteenf/pane.tsx
+++ b/src/plugins/builtin/thirteenf/pane.tsx
@@ -277,6 +277,10 @@ export function ThirteenFPane({ focused, width, height }: PaneProps) {
     loading: status === "loading",
     error,
     info: browserStatusInfo,
+    hints: [
+      { id: "search", key: "/", label: "search", onPress: focusSearch },
+      { id: "refresh", key: "r", label: "efresh", onPress: refresh },
+    ],
   });
 
   const rootBefore = (
@@ -542,6 +546,7 @@ function FundDetailView({
     loading: status === "loading",
     error,
     info: detailStatusInfo,
+    showOpenHint: true,
   });
 
   if ((status === "loading" || status === "idle") && !data) {

--- a/src/plugins/builtin/thirteenf/pane.tsx
+++ b/src/plugins/builtin/thirteenf/pane.tsx
@@ -277,10 +277,7 @@ export function ThirteenFPane({ focused, width, height }: PaneProps) {
     loading: status === "loading",
     error,
     info: browserStatusInfo,
-    hints: [
-      { id: "search", key: "/", label: "search", onPress: focusSearch },
-      { id: "refresh", key: "r", label: "efresh", onPress: refresh },
-    ],
+    hints: [{ id: "search", key: "/", label: "search", onPress: focusSearch }],
   });
 
   const rootBefore = (
@@ -563,7 +560,7 @@ function FundDetailView({
     return (
       <Box flexDirection="column" width={width} flexGrow={1} overflow="hidden">
         <Box padding={1}>
-          <EmptyState title="13F fund unavailable." message={error ?? "Failed to load fund."} hint="Press r to retry." />
+          <EmptyState title="13F fund unavailable." message={error ?? "Failed to load fund."} />
         </Box>
       </Box>
     );

--- a/src/plugins/builtin/ticker-detail/data-panes/historical-prices.tsx
+++ b/src/plugins/builtin/ticker-detail/data-panes/historical-prices.tsx
@@ -17,7 +17,7 @@ import {
   useDebouncedPluginPaneState,
   usePluginPaneState,
 } from "../../../runtime";
-import { loadingErrorFooterInfo, refreshFooterHint, useClampSelectedIndex } from "../../shared/table-pane";
+import { loadingErrorFooterInfo, useClampSelectedIndex } from "../../shared/table-pane";
 import { formatDateTime, useBoundTicker, useTickerRequest } from "../../shared/ticker-request";
 
 type HistoryColumnId = "date" | "open" | "high" | "low" | "close" | "change" | "changePercent" | "volume";
@@ -163,11 +163,8 @@ export function HistoricalPricesPane({ focused, width, height }: PaneProps) {
       { id: "range", parts: [{ text: range, tone: "muted" as const }] },
       ...loadingErrorFooterInfo(loading, error),
     ],
-    hints: [
-      { id: "range", key: "t", label: "oggle range", onPress: cycleRange },
-      refreshFooterHint(reload),
-    ],
-  }), [cycleRange, error, loading, range, reload]);
+    hints: [{ id: "range", key: "t", label: "oggle range", onPress: cycleRange }],
+  }), [cycleRange, error, loading, range]);
 
   return (
     <DataTableView<HistoricalPriceRow, HistoryColumn>

--- a/src/plugins/builtin/ticker-detail/data-panes/provider-search.tsx
+++ b/src/plugins/builtin/ticker-detail/data-panes/provider-search.tsx
@@ -13,7 +13,7 @@ import type { InstrumentSearchResult } from "../../../../types/instrument";
 import { usePaneInstance } from "../../../../state/app/context";
 import { colors } from "../../../../theme/colors";
 import { useAssetData, usePluginPaneState, usePluginTickerActions } from "../../../runtime";
-import { handleRefreshKey, loadingErrorFooterInfo, refreshFooterHint, useClampSelectedIndex } from "../../shared/table-pane";
+import { handleRefreshKey, loadingErrorFooterInfo, useClampSelectedIndex } from "../../shared/table-pane";
 import type { LoadState } from "../../shared/ticker-request";
 
 function resultSymbol(result: InstrumentSearchResult): string {
@@ -115,8 +115,7 @@ export function ProviderSearchPane({ focused, width, height }: PaneProps) {
       ...(query ? [{ id: "query", parts: [{ text: query, tone: "muted" as const }] }] : []),
       ...loadingErrorFooterInfo(state.loading, state.error),
     ],
-    hints: [refreshFooterHint(() => load(true))],
-  }), [load, query, state.error, state.loading]);
+  }), [query, state.error, state.loading]);
 
   return (
     <DataTableView<InstrumentSearchResult, DataTableColumn & { id: "symbol" | "name" | "exchange" | "type" }>

--- a/src/plugins/builtin/treasury-auctions/pane.tsx
+++ b/src/plugins/builtin/treasury-auctions/pane.tsx
@@ -277,7 +277,7 @@ export function TreasuryAuctionsPane({ focused, width, height }: PaneProps) {
       focusSearch();
       return true;
     }
-    if (isPlainKey(event, "s") || isPlainKey(event, "/")) {
+    if (isPlainKey(event, "/")) {
       stopSearchFocusNavigation(event);
       focusSearch();
       return true;
@@ -303,11 +303,10 @@ export function TreasuryAuctionsPane({ focused, width, height }: PaneProps) {
     return {
       info,
       hints: detailOpen
-        ? [{ id: "refresh", key: "r", label: "efresh", onPress: () => load(true) }]
+        ? []
         : [
-          { id: "search", key: "s", label: "earch", onPress: focusSearch },
+          { id: "search", key: "/", label: "search", onPress: focusSearch },
           { id: "filter", key: "f", label: "ilter", onPress: cycleFilter },
-          { id: "refresh", key: "r", label: "efresh", onPress: () => load(true) },
         ],
     };
   }, [
@@ -318,7 +317,6 @@ export function TreasuryAuctionsPane({ focused, width, height }: PaneProps) {
     fetchedAt,
     filter,
     focusSearch,
-    load,
     searchQuery,
     stale,
     status,
@@ -353,7 +351,7 @@ export function TreasuryAuctionsPane({ focused, width, height }: PaneProps) {
       <Box flexDirection="column" width={width} height={height}>
         {tabs}
         <Box padding={1}>
-          <EmptyState title="Treasury auctions unavailable." message={error} hint="Press r to retry." />
+          <EmptyState title="Treasury auctions unavailable." message={error} />
         </Box>
       </Box>
     );
@@ -408,7 +406,7 @@ export function TreasuryAuctionsPane({ focused, width, height }: PaneProps) {
         getItemKey={(auction) => auction.id}
         renderCell={(auction, column, _index, rowState) => renderAuctionCell(auction, column, rowState)}
         emptyStateTitle={searchQuery.trim() ? "No matching auctions." : "No recent auctions."}
-        emptyStateHint={searchQuery.trim() ? "Clear search or press r to refresh." : "Press r to refresh."}
+        emptyStateHint={searchQuery.trim() ? "Clear search." : undefined}
       />
     </Box>
   );

--- a/src/plugins/builtin/tv/pane.tsx
+++ b/src/plugins/builtin/tv/pane.tsx
@@ -234,7 +234,6 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
         onPress: toggleMute,
         disabled: loading || !stream,
       },
-      { id: "refresh", key: "r", label: "efresh", onPress: refresh, disabled: loading },
       {
         id: "open",
         key: "o",
@@ -242,7 +241,7 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
         onPress: () => { void renderer.openExternal(channel.channelUrl); },
       },
     ],
-  }), [channel.channelUrl, error, loading, muted, paneId, playbackError, playbackState, refresh, renderer, status, stream, toggleMute, togglePlayback]);
+  }), [channel.channelUrl, error, loading, muted, paneId, playbackError, playbackState, renderer, status, stream, toggleMute, togglePlayback]);
 
   const channelTabs = useMemo(() => TV_CHANNELS.map((item, index) => ({
     label: `${index + 1} ${item.name}`,

--- a/src/plugins/builtin/volatility/index.tsx
+++ b/src/plugins/builtin/volatility/index.tsx
@@ -115,10 +115,7 @@ export function VolatilityPane({ paneId, focused, width, height }: PaneProps) {
     ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
     ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
   ], [data?.termState, error, loading, stale]);
-  usePaneFooter(paneId, () => ({
-    info: footerInfo,
-    hints: [{ id: "reload", key: "r", label: "eload", onPress: reload, disabled: loading }],
-  }), [footerInfo, loading, paneId, reload]);
+  usePaneFooter(paneId, () => ({ info: footerInfo }), [footerInfo, paneId]);
 
   if (!data && loading) {
     return <Box width={width} height={height} justifyContent="center" alignItems="center"><Text fg={colors.textMuted}>Loading volatility data...</Text></Box>;

--- a/src/plugins/builtin/world-indices/footer.ts
+++ b/src/plugins/builtin/world-indices/footer.ts
@@ -1,16 +1,27 @@
 import { usePaneFooter } from "../../../components";
+import { isPlainKey } from "../../../utils/keyboard";
+import { useShortcut } from "../../../react/input";
 import {
   quoteBoardFooterInfo,
   quoteBoardStatus,
   type BoardQuoteMap,
 } from "../shared/use-quote-board";
 
-export function useWorldIndicesFooter(quotes: BoardQuoteMap) {
+export function useWorldIndicesFooter(quotes: BoardQuoteMap, onRefresh: () => void, focused: boolean) {
   const status = quoteBoardStatus(quotes);
+
+  useShortcut((event) => {
+    if (!focused || !isPlainKey(event, "r")) return;
+    event.preventDefault?.();
+    onRefresh();
+  }, { enabled: focused });
 
   usePaneFooter(
     "world-indices",
-    () => ({ info: quoteBoardFooterInfo(status) }),
-    [status.latestTs, status.loading, status.stale, status.unavailable],
+    () => ({
+      info: quoteBoardFooterInfo(status),
+      hints: [{ id: "refresh", key: "r", label: "efresh", onPress: onRefresh }],
+    }),
+    [focused, onRefresh, status.latestTs, status.loading, status.stale, status.unavailable],
   );
 }

--- a/src/plugins/builtin/world-indices/footer.ts
+++ b/src/plugins/builtin/world-indices/footer.ts
@@ -18,10 +18,7 @@ export function useWorldIndicesFooter(quotes: BoardQuoteMap, onRefresh: () => vo
 
   usePaneFooter(
     "world-indices",
-    () => ({
-      info: quoteBoardFooterInfo(status),
-      hints: [{ id: "refresh", key: "r", label: "efresh", onPress: onRefresh }],
-    }),
+    () => ({ info: quoteBoardFooterInfo(status) }),
     [focused, onRefresh, status.latestTs, status.loading, status.stale, status.unavailable],
   );
 }

--- a/src/plugins/builtin/world-indices/index.tsx
+++ b/src/plugins/builtin/world-indices/index.tsx
@@ -25,7 +25,7 @@ const WORLD_INDEX_SYMBOLS = WORLD_INDICES.map((entry) => entry.symbol);
 
 function WorldIndicesPane({ focused, width, height }: PaneProps) {
   const { pinTicker } = usePluginTickerActions();
-  const { quotes } = useQuoteBoard(WORLD_INDEX_SYMBOLS, REFRESH_INTERVAL_MS);
+  const { quotes, refresh } = useQuoteBoard(WORLD_INDEX_SYMBOLS, REFRESH_INTERVAL_MS);
   const [selectedSymbol, setSelectedSymbol] = useState<string | null>(null);
   const [sortPreference, setSortPreference] = useState<WorldIndexSortPreference>(DEFAULT_SORT_PREFERENCE);
 
@@ -74,7 +74,7 @@ function WorldIndicesPane({ focused, width, height }: PaneProps) {
     return renderWorldIndexCell(row, column, rowState, quotes);
   }, [quotes]);
 
-  useWorldIndicesFooter(quotes);
+  useWorldIndicesFooter(quotes, refresh, focused);
 
   return (
     <DataTableView<WorldIndexTableRow, WorldIndexColumn>

--- a/src/plugins/ibkr/trade/tab/footer.ts
+++ b/src/plugins/ibkr/trade/tab/footer.ts
@@ -37,7 +37,6 @@ export function useTradeTabFooter({
     ],
     hints: [
       ...(!ticketState.busy ? [
-        { id: "refresh", key: "r", label: "efresh", onPress: () => actions.refresh().catch(() => {}) },
         { id: "profile", key: "i", label: "profile", onPress: () => actions.chooseBrokerInstance().catch(() => {}) },
         { id: "account", key: "a", label: "ccount", onPress: () => actions.chooseAccount().catch(() => {}) },
       ] : []),

--- a/src/plugins/ibkr/trading/pane.tsx
+++ b/src/plugins/ibkr/trading/pane.tsx
@@ -259,7 +259,6 @@ export function TradingPane({ focused, width, height }: PaneProps) {
       { id: "account", key: "a", label: "ccount", onPress: () => footerActionsRef.current.chooseAccount().catch(() => {}) },
       { id: "open", key: "m", label: "open", onPress: () => footerActionsRef.current.openSelectedOrder() },
       { id: "cancel", key: "c", label: "ancel", onPress: () => footerActionsRef.current.cancelSelectedOrder().catch(() => {}) },
-      { id: "refresh", key: "r", label: "efresh", onPress: () => footerActionsRef.current.refresh().catch(() => {}) },
     ],
   }), []);
 


### PR DESCRIPTION
## Summary
- Keeps contextual `[o]pen` actions on news, SEC, and 13F detail footers.
- Removes refresh/reload footer actions and retry copy across panes. Existing `r` handlers remain, and Help already documents refresh as a global key.
- Standardizes every inline pane search bar on `/`, replacing the older `s` or `t` variants in Futures, Treasury Auctions, Polls, IPO Calendar, and Kelly Sizer. Cloud Tweets, 13F, and Prediction Markets already used `/`.
- Lets status footer helpers carry contextual actions without adding unused refresh plumbing.

## Validation
- Full TypeScript checks pass for OpenTUI, Electrobun bun/view, and scripts.
- Focused footer, search, Futures, Treasury Auctions, 13F, and AI Screener tests pass.
