### PR TITLE
Fall TV back to the latest replay and make mute stick

### DIFF
--- a/src/plugins/builtin/tv/pane.tsx
+++ b/src/plugins/builtin/tv/pane.tsx
@@ -14,9 +14,28 @@ import type { PaneProps } from "../../../types/plugin";
 import { Box, ImageSurface, MediaSurface, Text, useRendererHost, useUiHost, type MediaSurfaceHandle } from "../../../ui";
 import { getTvChannel, TV_CHANNELS, type TvChannelId } from "./channels";
 import type { ResolvedLiveStream } from "../../../types/media";
+import { buildYoutubeLiveEmbedUrl, isYoutubeEmbedUrl } from "./youtube-embed";
 import { resolveTvStream } from "./youtube-stream";
 
 type PlaybackState = "idle" | "loading" | "playing" | "paused" | "error";
+
+function activeWebOrigin(): string | undefined {
+  const location = (globalThis as { window?: { location?: { protocol?: string; origin?: string } } }).window?.location;
+  if (!location?.protocol || !location.origin) return undefined;
+  return /^https?:$/.test(location.protocol) ? location.origin : undefined;
+}
+
+function webMediaSource(stream: ResolvedLiveStream): string {
+  if (!isYoutubeEmbedUrl(stream.manifestUrl)) return stream.manifestUrl;
+  const origin = activeWebOrigin();
+  // Autoplay requires starting muted; unmuting afterwards goes through the
+  // iframe postMessage API so the URL (and therefore the player) stays stable.
+  return buildYoutubeLiveEmbedUrl(stream.videoId, {
+    muted: true,
+    origin,
+    widgetReferrer: origin,
+  });
+}
 
 export function TvPane({ paneId, focused, width, height }: PaneProps) {
   const isDesktop = useUiHost().kind === "desktop-web";
@@ -170,19 +189,26 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
     if (event.name === "m" && stream) {
       event.preventDefault?.();
       toggleMute();
+      return;
+    }
+    if (event.name === "o") {
+      event.preventDefault?.();
+      void renderer.openExternal(channel.channelUrl);
     }
   });
 
+  const streamKind = stream?.isLive === false ? "latest replay" : "live";
+  const replayDetail = stream?.isLive === false && stream.publishedText ? ` · ${stream.publishedText}` : "";
   const status = loading
     ? `resolving ${channel.name}`
     : error || playbackError
       ? "stream error"
       : playbackState === "playing"
-        ? "playing live"
+        ? `playing ${streamKind}${replayDetail}`
         : playbackState === "loading"
-          ? "buffering live"
+          ? `buffering ${streamKind}${replayDetail}`
           : stream
-            ? "live"
+            ? `${streamKind}${replayDetail}`
             : "offline";
 
   usePaneFooter(paneId, () => ({
@@ -209,8 +235,14 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
         disabled: loading || !stream,
       },
       { id: "refresh", key: "r", label: "efresh", onPress: refresh, disabled: loading },
+      {
+        id: "open",
+        key: "o",
+        label: "pen",
+        onPress: () => { void renderer.openExternal(channel.channelUrl); },
+      },
     ],
-  }), [error, loading, muted, paneId, playbackError, playbackState, refresh, status, stream, toggleMute, togglePlayback]);
+  }), [channel.channelUrl, error, loading, muted, paneId, playbackError, playbackState, refresh, renderer, status, stream, toggleMute, togglePlayback]);
 
   const channelTabs = useMemo(() => TV_CHANNELS.map((item, index) => ({
     label: `${index + 1} ${item.name}`,
@@ -242,7 +274,7 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
         </Box>
       ) : isDesktop ? (
         <MediaSurface
-          src={stream.manifestUrl}
+          src={webMediaSource(stream)}
           title={stream.title}
           poster={stream.posterUrl}
           autoPlay
@@ -269,6 +301,9 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
           >
             <Box flexGrow={1} justifyContent="center" alignItems="center">
               <Text fg={colors.text}>{stream.title}</Text>
+              {stream.isLive === false && stream.publishedText ? (
+                <Text fg={colors.textMuted}>{stream.publishedText}</Text>
+              ) : null}
             </Box>
           </ImageSurface>
           <Button

--- a/src/plugins/builtin/tv/youtube-embed.test.ts
+++ b/src/plugins/builtin/tv/youtube-embed.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildYoutubeLiveEmbedUrl,
+  extractPublishedTextForVideo,
+  extractYoutubeVideoId,
+  resolveYoutubeLivePage,
+  resolveHostedTvStream,
+} from "./youtube-embed";
+import { getTvChannel } from "./channels";
+
+describe("youtube TV embed", () => {
+  test("builds concrete video embeds, muted by default, with no captions", () => {
+    const videoUrl = buildYoutubeLiveEmbedUrl("abcdefghijk", {
+      muted: false,
+      origin: "https://example.com",
+    });
+    expect(videoUrl).toContain("/embed/abcdefghijk?");
+    expect(videoUrl).toContain("mute=0");
+    expect(videoUrl).toContain("origin=https%3A%2F%2Fexample.com");
+    expect(videoUrl).not.toContain("cc_load_policy");
+    expect(videoUrl).not.toContain("live_stream");
+    expect(() => buildYoutubeLiveEmbedUrl("")).toThrow("concrete YouTube video ID");
+  });
+
+  test("extracts video ids from watch, embed, and innertube html", () => {
+    expect(extractYoutubeVideoId("https://www.youtube.com/watch?v=abcdefghijk")).toBe("abcdefghijk");
+    expect(extractYoutubeVideoId("https://youtu.be/abcdefghijk")).toBe("abcdefghijk");
+    expect(extractYoutubeVideoId('{"videoId":"xyzXYZ-_123"}')).toBe("xyzXYZ-_123");
+  });
+
+  test("reports an unavailable live page instead of embedding a deprecated channel URL", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response("nope", { status: 503 })) as typeof fetch;
+    try {
+      await expect(resolveHostedTvStream("bloomberg")).rejects.toThrow("live page is unavailable (503)");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("reports a YouTube consent interstitial precisely", async () => {
+    const fetchImpl = (async () => ({
+      ok: true,
+      status: 200,
+      url: "https://consent.youtube.com/m",
+      text: async () => "<title>Before you continue to YouTube</title>",
+    })) as typeof fetch;
+    await expect(resolveYoutubeLivePage(getTvChannel("bloomberg"), fetchImpl))
+      .rejects.toThrow("YouTube returned a consent page");
+  });
+
+  test("falls back to the latest public video when the channel is not live", async () => {
+    const pages = [
+      "<title>Bloomberg - YouTube</title><script>{\"videoId\":\"abcdefghijk\"}</script>",
+      '<title>Bloomberg videos - YouTube</title><script>{"videoId":"zyxwvutsrqp","publishedTimeText":{"simpleText":"3 days ago"}}</script>',
+    ];
+    const fetchImpl = (async () => ({
+      ok: true,
+      status: 200,
+      url: "https://www.youtube.com/channel/UCIALMKvObZNtJ6AmdCLP7Lg/videos",
+      text: async () => pages.shift() ?? "",
+    })) as typeof fetch;
+    const stream = await resolveYoutubeLivePage(getTvChannel("bloomberg"), fetchImpl);
+
+    expect(stream.videoId).toBe("zyxwvutsrqp");
+    expect(stream.isLive).toBe(false);
+    expect(stream.publishedText).toBe("3 days ago");
+  });
+
+  test("extracts the publish label nearest a given video id", () => {
+    const html = '{"videoId":"zyxwvutsrqp","title":"x","publishedTimeText":{"simpleText":"Premiered Aug 12, 2026"}}';
+    expect(extractPublishedTextForVideo(html, "zyxwvutsrqp")).toBe("Premiered Aug 12, 2026");
+    expect(extractPublishedTextForVideo(html, "abcdefghijk")).toBeNull();
+  });
+
+  test("extracts the publish label from the current metadataParts markup", () => {
+    const html = '{"videoId":"zyxwvutsrqp","x":1}'
+      + `,"padding":"${"-".repeat(1200)}"`
+      + ',"metadataParts":[{"text":{"content":"718 views"}},{"text":{"content":"1 day ago"}}]'
+      + ',{"videoId":"abcdefghijk"},"metadataParts":[{"text":{"content":"2 views"}},{"text":{"content":"5 months ago"}}]';
+    expect(extractPublishedTextForVideo(html, "zyxwvutsrqp")).toBe("1 day ago");
+    expect(extractPublishedTextForVideo(html, "abcdefghijk")).toBe("5 months ago");
+  });
+});

--- a/src/plugins/builtin/tv/youtube-embed.ts
+++ b/src/plugins/builtin/tv/youtube-embed.ts
@@ -1,0 +1,173 @@
+import type { ResolvedLiveStream } from "../../../types/media";
+import { getTvChannel, TV_CHANNELS, type TvChannel } from "./channels";
+
+const YOUTUBE_VIDEO_ID = /(?:^|[^a-zA-Z0-9_-])([a-zA-Z0-9_-]{11})(?:[^a-zA-Z0-9_-]|$)/;
+
+/**
+ * Guards the render path: an embed URL may only ever be built from a concrete
+ * video id, and callers must check before building so a bad id degrades to the
+ * offline state instead of throwing mid-render.
+ */
+export function isValidYoutubeVideoId(videoId: string | undefined | null): videoId is string {
+  return !!videoId && YOUTUBE_VIDEO_ID.test(videoId);
+}
+
+export function buildYoutubeLiveEmbedUrl(
+  videoId: string,
+  options?: { muted?: boolean; origin?: string; widgetReferrer?: string },
+): string {
+  if (!isValidYoutubeVideoId(videoId)) {
+    throw new Error("A concrete YouTube video ID is required for an embed URL.");
+  }
+  const params = new URLSearchParams({
+    autoplay: "1",
+    mute: options?.muted === false ? "0" : "1",
+    playsinline: "1",
+    rel: "0",
+    modestbranding: "1",
+    enablejsapi: "1",
+  });
+  if (options?.origin) {
+    params.set("origin", options.origin);
+    params.set("widget_referrer", options.widgetReferrer ?? options.origin);
+  }
+  return `https://www.youtube.com/embed/${videoId}?${params}`;
+}
+
+export function isYoutubeEmbedUrl(url: string): boolean {
+  return /https?:\/\/(?:www\.)?youtube(?:-nocookie)?\.com\/embed\//.test(url);
+}
+
+export function fallbackTvStream(
+  channel: TvChannel,
+  options: { muted?: boolean; videoId: string; title?: string; isLive?: boolean; publishedText?: string },
+): ResolvedLiveStream {
+  const now = Date.now();
+  return {
+    provider: "youtube",
+    sourceId: channel.id,
+    videoId: options.videoId,
+    title: options?.title?.trim() || `${channel.name} ${options.isLive === false ? "latest video" : "Live"}`,
+    isLive: options.isLive ?? true,
+    publishedText: options.publishedText,
+    manifestUrl: buildYoutubeLiveEmbedUrl(options.videoId, {
+      muted: options.muted,
+    }),
+    watchUrl: `https://www.youtube.com/watch?v=${options.videoId}`,
+    resolvedAt: now,
+    expiresAt: now + 10 * 60 * 1000,
+  };
+}
+
+export function extractYoutubeVideoId(value: string): string | null {
+  const fromQuery = /(?:youtube\.com\/watch\?[^#]*v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/.exec(value);
+  if (fromQuery?.[1]) return fromQuery[1];
+  const fromJson = /"videoId":"([a-zA-Z0-9_-]{11})"/.exec(value);
+  if (fromJson?.[1]) return fromJson[1];
+  return null;
+}
+
+const PUBLISHED_LABEL = /^(?:\d+\s+\w+\s+ago|Streamed\b.*|Premiered\b.*|Scheduled\b.*)$/;
+
+/**
+ * Finds the human-readable publish label (e.g. "3 days ago", "Streamed 2 weeks ago")
+ * YouTube attaches to a specific video in the channel grid.
+ *
+ * Two markups are in the wild: the legacy `publishedTimeText.simpleText`, and the
+ * current `metadataParts` list where the label sits ~1.3k characters after the id,
+ * alongside the view count. Both are matched inside a window anchored on the id so
+ * a neighbouring grid item can never donate its date.
+ */
+export function extractPublishedTextForVideo(html: string, videoId: string): string | null {
+  const escaped = videoId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const legacy = new RegExp(`"videoId":"${escaped}"[\\s\\S]{0,3000}?"publishedTimeText":\\{"simpleText":"([^"]+)"`, "m");
+  const legacyMatch = legacy.exec(html);
+  if (legacyMatch?.[1]) return legacyMatch[1];
+
+  const anchor = new RegExp(`"videoId":"${escaped}"`, "g");
+  let occurrence: RegExpExecArray | null;
+  while ((occurrence = anchor.exec(html))) {
+    const window = html.slice(occurrence.index, occurrence.index + 3000);
+    for (const [, content] of window.matchAll(/"content":"([^"]+)"/g)) {
+      if (content && PUBLISHED_LABEL.test(content)) return content;
+    }
+  }
+  return null;
+}
+
+function extractLiveYoutubeVideoId(value: string): string | null {
+  const streamabilityLive = /"liveStreamabilityRenderer":\{"videoId":"([a-zA-Z0-9_-]{11})"/.exec(value);
+  if (streamabilityLive?.[1]) return streamabilityLive[1];
+  const videoDetailsLive = /"videoDetails":\{"videoId":"([a-zA-Z0-9_-]{11})"(?:(?!\}).){0,400}?"isLive":true/.exec(value);
+  if (videoDetailsLive?.[1]) return videoDetailsLive[1];
+  const liveMarker = /(?:BADGE_STYLE_TYPE_LIVE_NOW|"label":"LIVE")/;
+  const videoBeforeLive = /"videoId":"([a-zA-Z0-9_-]{11})"[\s\S]{0,2000}?(?:BADGE_STYLE_TYPE_LIVE_NOW|"label":"LIVE")/.exec(value)?.[1];
+  if (videoBeforeLive) return videoBeforeLive;
+  const liveBeforeVideo = /(?:BADGE_STYLE_TYPE_LIVE_NOW|"label":"LIVE")[\s\S]{0,2000}?"videoId":"([a-zA-Z0-9_-]{11})"/.exec(value)?.[1];
+  if (liveBeforeVideo) return liveBeforeVideo;
+  return liveMarker.test(value) ? extractYoutubeVideoId(value) : null;
+}
+
+function isYoutubeConsentPage(response: Response, html: string): boolean {
+  return response.url.includes("consent.youtube.com")
+    || /(?:Before you continue to YouTube|consent\.youtube\.com)/i.test(html);
+}
+
+async function fetchYoutubePage(url: string, fetchImpl: typeof fetch): Promise<{ response: Response; html: string }> {
+  const response = await fetchImpl(url, {
+    headers: {
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+      "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+      "Accept-Language": "en-US,en;q=0.9",
+      "Cookie": "CONSENT=YES+cb.20210328-17-p0.en+FX+667",
+    },
+    redirect: "follow",
+  });
+  if (!response.ok) {
+    throw new Error(`YouTube live page is unavailable (${response.status}).`);
+  }
+  return { response, html: await response.text() };
+}
+
+export async function resolveYoutubeLivePage(
+  channel: TvChannel,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ResolvedLiveStream> {
+  const livePage = await fetchYoutubePage(`https://www.youtube.com/channel/${channel.channelId}/live`, fetchImpl);
+  if (isYoutubeConsentPage(livePage.response, livePage.html)) {
+    throw new Error(`${channel.name} could not be resolved because YouTube returned a consent page.`);
+  }
+
+  const liveVideoId = extractYoutubeVideoId(livePage.response.url) ?? extractLiveYoutubeVideoId(livePage.html);
+  if (liveVideoId && YOUTUBE_VIDEO_ID.test(liveVideoId)) {
+    const rawTitle = /<title>([^<]+)<\/title>/i.exec(livePage.html)?.[1]?.replace(/\s+-+\s+YouTube\s*$/i, "").trim();
+    return fallbackTvStream(channel, {
+      videoId: liveVideoId,
+      title: rawTitle && rawTitle !== "YouTube" ? rawTitle : undefined,
+      isLive: true,
+    });
+  }
+
+  const videosPage = await fetchYoutubePage(`https://www.youtube.com/channel/${channel.channelId}/videos`, fetchImpl);
+  if (isYoutubeConsentPage(videosPage.response, videosPage.html)) {
+    throw new Error(`${channel.name} could not be resolved because YouTube returned a consent page.`);
+  }
+  const videoId = extractYoutubeVideoId(videosPage.response.url) ?? extractYoutubeVideoId(videosPage.html);
+  if (!videoId || !YOUTUBE_VIDEO_ID.test(videoId)) {
+    throw new Error(`${channel.name} does not currently have a public video.`);
+  }
+  const publishedText = extractPublishedTextForVideo(videosPage.html, videoId);
+  const rawTitle = /<title>([^<]+)<\/title>/i.exec(videosPage.html)?.[1]?.replace(/\s+-+\s+YouTube\s*$/i, "").trim();
+  return fallbackTvStream(channel, {
+    videoId,
+    title: rawTitle && rawTitle !== "YouTube" ? rawTitle : undefined,
+    isLive: false,
+    publishedText: publishedText ?? undefined,
+  });
+}
+
+export function resolveHostedTvStream(sourceId: string): Promise<ResolvedLiveStream> {
+  const channel = TV_CHANNELS.find((item) => item.id === sourceId);
+  if (!channel) throw new Error("Unknown TV channel.");
+  return resolveYoutubeLivePage(getTvChannel(channel.id));
+}

--- a/src/plugins/builtin/tv/youtube-stream.ts
+++ b/src/plugins/builtin/tv/youtube-stream.ts
@@ -1,4 +1,4 @@
-import type { TvChannel } from "./channels";
+import { TV_CHANNELS, type TvChannel } from "./channels";
 import type { ResolvedLiveStream } from "../../../types/media";
 import { resolveYoutubeLivePage } from "./youtube-embed";
 
@@ -24,6 +24,17 @@ async function getYoutubeClient(): Promise<{ client: YoutubeClient; module: Yout
     enable_session_cache: true,
   });
   return { client: await clientPromise, module };
+}
+
+function isTvSourceId(sourceId: string): sourceId is TvChannel["id"] {
+  return TV_CHANNELS.some((channel) => channel.id === sourceId);
+}
+
+function asResolvedTvStream(stream: ResolvedLiveStream): ResolvedTvStream {
+  if (!isTvSourceId(stream.sourceId)) {
+    throw new Error(`Unknown TV channel: ${stream.sourceId}`);
+  }
+  return { ...stream, sourceId: stream.sourceId };
 }
 
 function usableCachedStream(sourceId: TvChannel["id"]): ResolvedTvStream | null {
@@ -81,7 +92,7 @@ async function resolveUncached(channel: TvChannel): Promise<ResolvedTvStream> {
     return await resolveLiveStream(channel);
   } catch (liveError) {
     try {
-      return await resolveYoutubeLivePage(channel);
+      return asResolvedTvStream(await resolveYoutubeLivePage(channel));
     } catch {
       throw liveError;
     }

--- a/src/plugins/builtin/tv/youtube-stream.ts
+++ b/src/plugins/builtin/tv/youtube-stream.ts
@@ -1,5 +1,6 @@
 import type { TvChannel } from "./channels";
 import type { ResolvedLiveStream } from "../../../types/media";
+import { resolveYoutubeLivePage } from "./youtube-embed";
 
 const CACHE_TTL_MS = 10 * 60 * 1000;
 const MAX_LIVE_CANDIDATES = 6;
@@ -32,7 +33,7 @@ function usableCachedStream(sourceId: TvChannel["id"]): ResolvedTvStream | null 
   return Date.now() < validUntil ? cached : null;
 }
 
-async function resolveUncached(channel: TvChannel): Promise<ResolvedTvStream> {
+async function resolveLiveStream(channel: TvChannel): Promise<ResolvedTvStream> {
   const { client, module } = await getYoutubeClient();
   const channelFeed = await client.getChannel(channel.channelId);
   if (!channelFeed.has_live_streams) {
@@ -63,6 +64,7 @@ async function resolveUncached(channel: TvChannel): Promise<ResolvedTvStream> {
       sourceId: channel.id,
       videoId: candidate.content_id,
       title: info.basic_info.title || candidate.metadata?.title?.toString() || `${channel.name} Live`,
+      isLive: true,
       manifestUrl,
       watchUrl: `https://www.youtube.com/watch?v=${candidate.content_id}`,
       posterUrl: poster?.url,
@@ -72,6 +74,18 @@ async function resolveUncached(channel: TvChannel): Promise<ResolvedTvStream> {
   }
 
   throw new Error(`${channel.name} does not currently have a playable public live stream.`);
+}
+
+async function resolveUncached(channel: TvChannel): Promise<ResolvedTvStream> {
+  try {
+    return await resolveLiveStream(channel);
+  } catch (liveError) {
+    try {
+      return await resolveYoutubeLivePage(channel);
+    } catch {
+      throw liveError;
+    }
+  }
 }
 
 export function resolveTvStream(

--- a/src/renderers/electrobun/view/host/media-surface.tsx
+++ b/src/renderers/electrobun/view/host/media-surface.tsx
@@ -1,8 +1,13 @@
 /** @jsxImportSource react */
 import Hls from "hls.js";
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { isYoutubeEmbedUrl } from "../../../../plugins/builtin/tv/youtube-embed";
 import type { MediaSurfaceHandle, MediaSurfaceProps } from "../../../../ui/host";
 import { cleanDomProps, commonStyle } from "./style";
+
+function postYoutubeCommand(frame: HTMLIFrameElement | null, func: string, args: unknown[] = []): void {
+  frame?.contentWindow?.postMessage(JSON.stringify({ event: "command", func, args }), "*");
+}
 
 export const WebMediaSurface = forwardRef<HTMLVideoElement, MediaSurfaceProps>(function WebMediaSurface(rawProps, forwardedRef) {
   const {
@@ -30,19 +35,47 @@ export const WebMediaSurface = forwardRef<HTMLVideoElement, MediaSurfaceProps>(f
     onError?: (message: string) => void;
   };
   const videoRef = useRef<HTMLVideoElement | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const youtubeMutedRef = useRef(muted);
+  const youtubePlayingRef = useRef(autoPlay);
   const [failed, setFailed] = useState(false);
   const mediaSrc = typeof src === "string" ? src.trim() : "";
+  const youtubeEmbed = isYoutubeEmbedUrl(mediaSrc);
   const baseStyle = commonStyle(props);
 
   useImperativeHandle(forwardedRef, () => videoRef.current as HTMLVideoElement, []);
   useImperativeHandle(mediaHandleRef, (): MediaSurfaceHandle => ({
     async play() {
+      if (youtubeEmbed) {
+        postYoutubeCommand(iframeRef.current, "playVideo");
+        youtubePlayingRef.current = true;
+        onPlaybackStateChange?.("playing");
+        return;
+      }
       if (videoRef.current) await videoRef.current.play();
     },
     pause() {
+      if (youtubeEmbed) {
+        postYoutubeCommand(iframeRef.current, "pauseVideo");
+        youtubePlayingRef.current = false;
+        onPlaybackStateChange?.("paused");
+        return;
+      }
       videoRef.current?.pause();
     },
     async toggle() {
+      if (youtubeEmbed) {
+        if (youtubePlayingRef.current) {
+          postYoutubeCommand(iframeRef.current, "pauseVideo");
+          youtubePlayingRef.current = false;
+          onPlaybackStateChange?.("paused");
+        } else {
+          postYoutubeCommand(iframeRef.current, "playVideo");
+          youtubePlayingRef.current = true;
+          onPlaybackStateChange?.("playing");
+        }
+        return;
+      }
       const video = videoRef.current;
       if (!video) return;
       if (video.paused) {
@@ -52,14 +85,27 @@ export const WebMediaSurface = forwardRef<HTMLVideoElement, MediaSurfaceProps>(f
       }
     },
     toggleMuted() {
+      if (youtubeEmbed) {
+        youtubeMutedRef.current = !youtubeMutedRef.current;
+        postYoutubeCommand(iframeRef.current, youtubeMutedRef.current ? "mute" : "unMute");
+        onMutedChange?.(youtubeMutedRef.current);
+        return youtubeMutedRef.current;
+      }
       const video = videoRef.current;
       if (!video) return muted;
       video.muted = !video.muted;
       return video.muted;
     },
-  }), [muted]);
+  }), [muted, onMutedChange, onPlaybackStateChange, youtubeEmbed]);
 
   useEffect(() => {
+    youtubeMutedRef.current = muted;
+    if (youtubeEmbed) {
+      setFailed(false);
+      onPlaybackStateChange?.(autoPlay ? "playing" : "paused");
+      onMutedChange?.(muted);
+      return;
+    }
     const video = videoRef.current;
     if (!video || !mediaSrc) {
       onPlaybackStateChange?.("idle");
@@ -131,7 +177,7 @@ export const WebMediaSurface = forwardRef<HTMLVideoElement, MediaSurfaceProps>(f
       video.removeAttribute("src");
       video.load();
     };
-  }, [autoPlay, mediaSrc, onError, onMutedChange, onPlaybackStateChange]);
+  }, [autoPlay, mediaSrc, onError, onMutedChange, onPlaybackStateChange, youtubeEmbed]);
 
   return (
     <div
@@ -144,7 +190,28 @@ export const WebMediaSurface = forwardRef<HTMLVideoElement, MediaSurfaceProps>(f
         ...(props.style as CSSProperties | undefined),
       }}
     >
-      {mediaSrc && !failed ? (
+      {mediaSrc && !failed && youtubeEmbed ? (
+        <iframe
+          key={mediaSrc}
+          ref={iframeRef}
+          title={title || "Live TV stream"}
+          src={mediaSrc}
+          referrerPolicy="strict-origin-when-cross-origin"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+          onLoad={() => {
+            iframeRef.current?.contentWindow?.postMessage(JSON.stringify({ event: "listening", id: 1 }), "*");
+            onPlaybackStateChange?.(autoPlay ? "playing" : "paused");
+          }}
+          style={{
+            width: "100%",
+            height: "100%",
+            border: 0,
+            display: "block",
+            background: "#050505",
+          }}
+        />
+      ) : mediaSrc && !failed ? (
         <video
           key={mediaSrc}
           ref={videoRef}

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -9,6 +9,8 @@ export interface ResolvedLiveStream {
   sourceId: string;
   videoId: string;
   title: string;
+  isLive?: boolean;
+  publishedText?: string;
   manifestUrl: string;
   watchUrl: string;
   posterUrl?: string;


### PR DESCRIPTION
## Summary
- When a TV channel is not live, fall back to the latest public video and show its air time (`latest replay · 3 days ago`) instead of going offline.
- Mute/unmute through the YouTube iframe API so the player is not rebuilt; captions stay off.
- Footer `[o]pen` / `o` opens the channel URL.

## Test plan
- [ ] `TV` → a live channel still plays; `[m]`ute toggles without restarting the stream.
- [ ] A channel that is not live shows the latest replay and published time in the footer/status.
- [ ] `[o]`pen opens the YouTube channel page.
- [ ] Captions are not forced on.


Made with [Cursor](https://cursor.com)