### PR TITLE
Add volatility curve and credit spread panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ The toolbar controls preset or exact date ranges, intervals from one minute thro
 | `ECON` | Economic events and releases |
 | `GC` | Yield curve |
 | `AUCT` | Treasury auction results: high rate, bid-to-cover, indirect share, and size |
-| `VIX` | VIX term structure |
+| `VIX` | VIX 30-day/3-month implied-volatility curve |
 | `CRD` | Credit spreads |
 | `ERN` | Earnings calendar |
 | `TV` | Live Bloomberg, CNBC, and Yahoo Finance television |

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ The toolbar controls preset or exact date ranges, intervals from one minute thro
 | `ECON` | Economic events and releases |
 | `GC` | Yield curve |
 | `AUCT` | Treasury auction results: high rate, bid-to-cover, indirect share, and size |
+| `VIX` | VIX term structure |
+| `CRD` | Credit spreads |
 | `ERN` | Earnings calendar |
 | `TV` | Live Bloomberg, CNBC, and Yahoo Finance television |
 | `BI` / `SP` | S&P 500 sector performance |

--- a/src/api-client/request.test.ts
+++ b/src/api-client/request.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import {
+  ConnectionHealthRegistry,
+  registerGloomCloudConnectionSources,
+} from "../core/connection-health";
 import { CloudApiRequestTransport } from "./request";
 
 function responseWithBody(body: () => Promise<string>): Response {
@@ -9,6 +13,32 @@ function responseWithBody(body: () => Promise<string>): Response {
     text: body,
   } as Response;
 }
+
+describe("CloudApiRequestTransport connection reporting", () => {
+  test("reports real FRED requests to both Gloom and FRED sources", async () => {
+    const health = new ConnectionHealthRegistry();
+    const dispose = registerGloomCloudConnectionSources(health);
+    const transport = new CloudApiRequestTransport({
+      connectionHealth: health,
+      fetchTransport: async () => responseWithBody(async () => JSON.stringify({ observations: [], info: null })),
+    });
+
+    await transport.request("/cloud/econ/series/VIXCLS?limit=120&sortOrder=desc");
+
+    expect(health.getSnapshot().sources.map((source) => ({
+      id: source.id,
+      status: source.status,
+      operation: source.lastOperation,
+    }))).toEqual([
+      { id: "gloom-cloud-http", status: "connected", operation: "GET /cloud/econ/series/VIXCLS" },
+      { id: "gloom-cloud-socket", status: "idle", operation: null },
+      { id: "gloom-cloud-fred", status: "connected", operation: "GET /cloud/econ/series/VIXCLS" },
+    ]);
+
+    dispose();
+    expect(health.getSnapshot().sources).toEqual([]);
+  });
+});
 
 describe("CloudApiRequestTransport market deadlines", () => {
   test("aborts when response headers never arrive", async () => {

--- a/src/api-client/request.ts
+++ b/src/api-client/request.ts
@@ -3,7 +3,9 @@ import { withDeadline } from "../utils/async-deadline";
 import { ApiRequestError, parseApiErrorMessage } from "./errors";
 import {
   connectionHealth,
+  GLOOM_CLOUD_FRED_CONNECTION_ID,
   GLOOM_CLOUD_HTTP_CONNECTION_ID,
+  type ConnectionHealthRegistry,
 } from "../core/connection-health";
 
 const DEFAULT_API_URL = "https://api.gloom.sh";
@@ -43,15 +45,18 @@ export class CloudApiRequestTransport {
   private websocketToken: string | null = null;
   private readonly fetchTransport: CloudApiFetchTransport | null;
   private readonly marketRequestTimeoutMs: number;
+  private readonly connectionHealth: ConnectionHealthRegistry;
 
   readonly baseUrl = getCloudApiBaseUrl();
 
   constructor(options: {
     fetchTransport?: CloudApiFetchTransport;
     marketRequestTimeoutMs?: number;
+    connectionHealth?: ConnectionHealthRegistry;
   } = {}) {
     this.fetchTransport = options.fetchTransport ?? null;
     this.marketRequestTimeoutMs = options.marketRequestTimeoutMs ?? DEFAULT_MARKET_REQUEST_TIMEOUT_MS;
+    this.connectionHealth = options.connectionHealth ?? connectionHealth;
   }
 
   getSessionToken(): string | null {
@@ -125,32 +130,36 @@ export class CloudApiRequestTransport {
     this.setSessionCookieHeader(headers);
     headers.set("Origin", this.baseUrl);
 
-    return connectionHealth.track(
+    const operation = `${options?.method ?? "GET"} ${path.split("?")[0]}`;
+    const request = async () => {
+      const res = await (this.fetchTransport ?? cloudApiFetchTransport)(`${this.baseUrl}${path}`, {
+        ...options,
+        headers,
+        credentials: "include",
+      });
+      throwIfRequestAborted(options?.signal);
+      this.extractSessionCookie(res);
+      const text = await res.text();
+      throwIfRequestAborted(options?.signal);
+
+      if (!res.ok) {
+        const msg = parseApiErrorMessage(text);
+        throw new ApiRequestError(msg, res.status);
+      }
+
+      if (!text) return undefined as T;
+      const parsed = JSON.parse(text) as T & { token?: string };
+      if (typeof parsed?.token === "string" && parsed.token.length > 0) {
+        this.websocketToken = parsed.token;
+      }
+      return parsed as T;
+    };
+    return this.connectionHealth.track(
       GLOOM_CLOUD_HTTP_CONNECTION_ID,
-      `${options?.method ?? "GET"} ${path.split("?")[0]}`,
-      async () => {
-        const res = await (this.fetchTransport ?? cloudApiFetchTransport)(`${this.baseUrl}${path}`, {
-          ...options,
-          headers,
-          credentials: "include",
-        });
-        throwIfRequestAborted(options?.signal);
-        this.extractSessionCookie(res);
-        const text = await res.text();
-        throwIfRequestAborted(options?.signal);
-
-        if (!res.ok) {
-          const msg = parseApiErrorMessage(text);
-          throw new ApiRequestError(msg, res.status);
-        }
-
-        if (!text) return undefined as T;
-        const parsed = JSON.parse(text) as T & { token?: string };
-        if (typeof parsed?.token === "string" && parsed.token.length > 0) {
-          this.websocketToken = parsed.token;
-        }
-        return parsed as T;
-      },
+      operation,
+      () => path.startsWith("/cloud/econ/series/")
+        ? this.connectionHealth.track(GLOOM_CLOUD_FRED_CONNECTION_ID, operation, request)
+        : request(),
     );
   }
 

--- a/src/core/connection-health.test.ts
+++ b/src/core/connection-health.test.ts
@@ -37,6 +37,7 @@ describe("ConnectionHealthRegistry", () => {
     expect(second.getSnapshot().sources.map((entry) => entry.id)).toEqual([
       "gloom-cloud-http",
       "gloom-cloud-socket",
+      "gloom-cloud-fred",
     ]);
   });
 

--- a/src/core/connection-health.ts
+++ b/src/core/connection-health.ts
@@ -54,6 +54,7 @@ interface ConnectionHealthOptions {
 
 export const GLOOM_CLOUD_HTTP_CONNECTION_ID = "gloom-cloud-http";
 export const GLOOM_CLOUD_SOCKET_CONNECTION_ID = "gloom-cloud-socket";
+export const GLOOM_CLOUD_FRED_CONNECTION_ID = "gloom-cloud-fred";
 
 const MAX_RECENT_REQUESTS = 20;
 const DEFAULT_REQUEST_STATUS_TTL_MS = 60_000;
@@ -276,6 +277,14 @@ export function registerGloomCloudConnectionSources(health: ConnectionHealthRegi
       ownerId: "gloomberb-cloud",
       priority: 1,
       detail: "api.gloom.sh/cloud/ws",
+    }),
+    health.registerSource({
+      id: GLOOM_CLOUD_FRED_CONNECTION_ID,
+      name: "Gloom / FRED",
+      kind: "api",
+      ownerId: "macro",
+      priority: 2,
+      detail: "api.gloom.sh/cloud/econ/series",
     }),
   ];
   return () => {

--- a/src/data/fred-series.ts
+++ b/src/data/fred-series.ts
@@ -19,7 +19,8 @@ export interface FredSeriesData {
 
 export interface FredSeriesRequest {
   seriesId: string;
-  startDate: string;
+  startDate?: string;
+  limit?: number;
   sortOrder: "asc" | "desc";
 }
 
@@ -59,7 +60,12 @@ export function resetFredSeriesPersistence(): void {
 }
 
 function cacheKey(request: FredSeriesRequest): string {
-  return `${request.seriesId.trim().toUpperCase()}:start=${request.startDate}:sort=${request.sortOrder}`;
+  const range = [
+    request.startDate ? `start=${request.startDate}` : "",
+    request.limit ? `limit=${request.limit}` : "",
+    `sort=${request.sortOrder}`,
+  ].filter(Boolean).join(":");
+  return `${request.seriesId.trim().toUpperCase()}:${range}`;
 }
 
 export function getCachedFredSeries(

--- a/src/plugins/builtin/chart-composer/index.tsx
+++ b/src/plugins/builtin/chart-composer/index.tsx
@@ -4,7 +4,6 @@ import type {
   PaneTemplateDef,
 } from "../../../types/plugin";
 import { CHART_COMPOSER_PANE_ID } from "../../../types/config";
-import { attachFredSeriesPersistence } from "../../../data/fred-series";
 import { parseTickerListInput } from "../../../tickers/list";
 import { publicTickerKey } from "../../../utils/exchanges";
 import type { ChartSpec } from "../../../time-series/types";
@@ -214,7 +213,6 @@ export const chartComposerModule: PluginModule = {
   }],
   paneTemplates: chartComposerTemplates,
   setup(ctx) {
-    attachFredSeriesPersistence(ctx.persistence);
     ctx.registerTickerResearchTab({
       id: "chart",
       name: "Chart",

--- a/src/plugins/builtin/composite-plugins.ts
+++ b/src/plugins/builtin/composite-plugins.ts
@@ -3,6 +3,7 @@ import { brokerManagerModule } from "./broker-manager";
 import { changelogModule } from "./changelog";
 import { connectionsModule } from "./connections";
 import { correlationModule } from "./correlation";
+import { creditConditionsModule } from "./credit-conditions";
 import { economicCalendarModule } from "./econ";
 import { earningsModule } from "./earnings";
 import { fearGreedModule } from "./fear-greed";
@@ -14,6 +15,7 @@ import { layoutManagerModule } from "./layout-manager";
 import { marketHeatmapModule } from "./market-heatmap";
 import { marketMoversModule } from "./market-movers";
 import { tvModule } from "./tv";
+import { volatilityModule } from "./volatility";
 import { composeBuiltinPlugin } from "./plugin-module";
 import { portfolioListModule } from "./portfolio-list";
 import { scannerModule } from "./scanner";
@@ -71,11 +73,13 @@ export const macroPlugin = composeBuiltinPlugin({
   id: "macro",
   name: "Macro",
   version: "1.0.0",
-  description: "Economic calendar, yield curve, Treasury auctions, earnings calendar, and live financial TV.",
+  description: "Economic calendar, rates, volatility, credit spreads, Treasury auctions, earnings, and live financial TV.",
   toggleable: true,
   modules: [
     economicCalendarModule,
     yieldCurveModule,
+    volatilityModule,
+    creditConditionsModule,
     treasuryAuctionsModule,
     earningsModule,
     tvModule,

--- a/src/plugins/builtin/composite-plugins.ts
+++ b/src/plugins/builtin/composite-plugins.ts
@@ -1,3 +1,7 @@
+import {
+  attachFredSeriesPersistence,
+  resetFredSeriesPersistence,
+} from "../../data/fred-series";
 import { portfolioAnalyticsModule } from "./analytics";
 import { brokerManagerModule } from "./broker-manager";
 import { changelogModule } from "./changelog";
@@ -16,13 +20,22 @@ import { marketHeatmapModule } from "./market-heatmap";
 import { marketMoversModule } from "./market-movers";
 import { tvModule } from "./tv";
 import { volatilityModule } from "./volatility";
-import { composeBuiltinPlugin } from "./plugin-module";
+import { composeBuiltinPlugin, type PluginModule } from "./plugin-module";
 import { portfolioListModule } from "./portfolio-list";
 import { scannerModule } from "./scanner";
 import { sectorsModule } from "./sectors";
 import { treasuryAuctionsModule } from "./treasury-auctions";
 import { worldIndicesModule } from "./world-indices";
 import { yieldCurveModule } from "./yield-curve";
+
+const macroSharedResourcesModule = {
+  setup(ctx) {
+    attachFredSeriesPersistence(ctx.persistence);
+  },
+  dispose() {
+    resetFredSeriesPersistence();
+  },
+} satisfies PluginModule;
 
 export const applicationPlugin = composeBuiltinPlugin({
   id: "application",
@@ -76,6 +89,7 @@ export const macroPlugin = composeBuiltinPlugin({
   description: "Economic calendar, rates, volatility, credit spreads, Treasury auctions, earnings, and live financial TV.",
   toggleable: true,
   modules: [
+    macroSharedResourcesModule,
     economicCalendarModule,
     yieldCurveModule,
     volatilityModule,

--- a/src/plugins/builtin/credit-conditions/client.test.ts
+++ b/src/plugins/builtin/credit-conditions/client.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  attachFredSeriesPersistence,
+  resetFredSeriesPersistence,
+} from "../../../data/fred-series";
+import { MemoryPluginPersistence } from "../../../test-support/plugin-persistence";
+import { loadCreditConditions } from "./client";
+import { CREDIT_SERIES, type CreditSeriesId } from "./model";
+
+function payload(seriesId: CreditSeriesId, count = 3) {
+  return {
+    observations: Array.from({ length: count }, (_, index) => ({
+      date: `2026-07-${String(index + 1).padStart(2, "0")}`,
+      value: 0.8 + index / 100,
+    })),
+    info: {
+      id: seriesId,
+      title: `${seriesId} Option-Adjusted Spread`,
+      units: "Percent",
+      frequency: "Daily, Close",
+      seasonalAdjustment: "Not Seasonally Adjusted",
+      source: "FRED",
+      notes: "",
+    },
+  };
+}
+
+beforeEach(resetFredSeriesPersistence);
+afterEach(resetFredSeriesPersistence);
+
+describe("loadCreditConditions", () => {
+  test("returns available rows and reports partial failures", async () => {
+    const result = await loadCreditConditions(false, async (seriesId) => {
+      if (seriesId !== CREDIT_SERIES[0].seriesId) throw new Error("unavailable");
+      return payload(seriesId);
+    });
+
+    expect(result.rows.map((row) => row.seriesId)).toEqual([CREDIT_SERIES[0].seriesId]);
+    expect(result.errors).toHaveLength(CREDIT_SERIES.length - 1);
+  });
+
+  test("throws when every credit series fails", async () => {
+    await expect(loadCreditConditions(false, async () => {
+      throw new Error("offline");
+    })).rejects.toThrow("offline");
+  });
+
+  test("reuses bounded persisted history across midnight", async () => {
+    const persistence = new MemoryPluginPersistence();
+    attachFredSeriesPersistence(persistence);
+    const originalNow = Date.now;
+    let calls = 0;
+
+    try {
+      Date.now = () => Date.UTC(2026, 7, 18, 23, 58);
+      await loadCreditConditions(false, async (seriesId) => {
+        calls += 1;
+        return payload(seriesId, 60);
+      });
+      expect(persistence.getResource<{ observations: unknown[] }>(
+        "fred-series",
+        `${CREDIT_SERIES[0].seriesId}:limit=45:sort=desc`,
+        { sourceKey: "gloomberb-cloud", schemaVersion: 1 },
+      )?.value.observations).toHaveLength(45);
+
+      resetFredSeriesPersistence();
+      attachFredSeriesPersistence(persistence);
+      Date.now = () => Date.UTC(2026, 7, 19, 0, 2);
+      const cached = await loadCreditConditions(false, async () => {
+        calls += 1;
+        throw new Error("cache miss");
+      });
+
+      expect(calls).toBe(CREDIT_SERIES.length);
+      expect(cached.rows).toHaveLength(CREDIT_SERIES.length);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+});

--- a/src/plugins/builtin/credit-conditions/client.ts
+++ b/src/plugins/builtin/credit-conditions/client.ts
@@ -1,4 +1,4 @@
-import { apiClient } from "../../../api-client";
+import { apiClient, type CloudFredSeriesPayload } from "../../../api-client";
 import {
   getCachedFredSeries,
   loadCachedFredSeries,
@@ -17,12 +17,19 @@ export interface CreditConditionsLoadResult {
   errors: string[];
 }
 
-function startDate(): string {
-  return new Date(Date.now() - 45 * 86_400_000).toISOString().slice(0, 10);
-}
+const HISTORY_LIMIT = 45;
+
+type CreditSeriesLoader = (
+  seriesId: CreditSeriesId,
+  options: { limit: number; sortOrder: "desc" },
+) => Promise<CloudFredSeriesPayload>;
 
 function requestFor(seriesId: CreditSeriesId): FredSeriesRequest {
-  return { seriesId, startDate: startDate(), sortOrder: "asc" };
+  return { seriesId, limit: HISTORY_LIMIT, sortOrder: "desc" };
+}
+
+function trimHistory(data: CloudFredSeriesPayload): CloudFredSeriesPayload {
+  return { ...data, observations: data.observations.slice(0, HISTORY_LIMIT) };
 }
 
 export function getCachedCreditConditions(): CreditConditionsLoadResult | null {
@@ -44,14 +51,18 @@ export function getCachedCreditConditions(): CreditConditionsLoadResult | null {
   };
 }
 
-async function loadSeries(definition: typeof CREDIT_SERIES[number], force: boolean) {
+async function loadSeries(
+  definition: typeof CREDIT_SERIES[number],
+  force: boolean,
+  loader: CreditSeriesLoader,
+) {
   const request = requestFor(definition.seriesId);
   const result = await loadCachedFredSeries(
     request,
-    () => apiClient.getCloudFredSeries(definition.seriesId, {
-      startDate: request.startDate,
-      sortOrder: "asc",
-    }),
+    async () => trimHistory(await loader(definition.seriesId, {
+      limit: HISTORY_LIMIT,
+      sortOrder: "desc",
+    })),
     { force },
   );
   return {
@@ -60,9 +71,12 @@ async function loadSeries(definition: typeof CREDIT_SERIES[number], force: boole
   };
 }
 
-export async function loadCreditConditions(force = false): Promise<CreditConditionsLoadResult> {
+export async function loadCreditConditions(
+  force = false,
+  loader: CreditSeriesLoader = (seriesId, options) => apiClient.getCloudFredSeries(seriesId, options),
+): Promise<CreditConditionsLoadResult> {
   const settled = await Promise.allSettled(
-    CREDIT_SERIES.map((definition) => loadSeries(definition, force)),
+    CREDIT_SERIES.map((definition) => loadSeries(definition, force, loader)),
   );
   const rows: CreditConditionRow[] = [];
   const errors: string[] = [];

--- a/src/plugins/builtin/credit-conditions/client.ts
+++ b/src/plugins/builtin/credit-conditions/client.ts
@@ -1,0 +1,80 @@
+import { apiClient } from "../../../api-client";
+import {
+  getCachedFredSeries,
+  loadCachedFredSeries,
+  type FredSeriesRequest,
+} from "../../../data/fred-series";
+import {
+  CREDIT_SERIES,
+  normalizeCreditSeries,
+  type CreditConditionRow,
+  type CreditSeriesId,
+} from "./model";
+
+export interface CreditConditionsLoadResult {
+  rows: CreditConditionRow[];
+  stale: boolean;
+  errors: string[];
+}
+
+function startDate(): string {
+  return new Date(Date.now() - 45 * 86_400_000).toISOString().slice(0, 10);
+}
+
+function requestFor(seriesId: CreditSeriesId): FredSeriesRequest {
+  return { seriesId, startDate: startDate(), sortOrder: "asc" };
+}
+
+export function getCachedCreditConditions(): CreditConditionsLoadResult | null {
+  const rows: CreditConditionRow[] = [];
+  const errors: string[] = [];
+  for (const definition of CREDIT_SERIES) {
+    const cached = getCachedFredSeries(requestFor(definition.seriesId), { allowExpired: true });
+    if (!cached) continue;
+    try {
+      rows.push(normalizeCreditSeries(definition, cached.data, cached.stale));
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+  return rows.length === 0 ? null : {
+    rows,
+    stale: rows.some((row) => row.stale),
+    errors,
+  };
+}
+
+async function loadSeries(definition: typeof CREDIT_SERIES[number], force: boolean) {
+  const request = requestFor(definition.seriesId);
+  const result = await loadCachedFredSeries(
+    request,
+    () => apiClient.getCloudFredSeries(definition.seriesId, {
+      startDate: request.startDate,
+      sortOrder: "asc",
+    }),
+    { force },
+  );
+  return {
+    row: normalizeCreditSeries(definition, result.data, result.stale),
+    refreshError: result.refreshError,
+  };
+}
+
+export async function loadCreditConditions(force = false): Promise<CreditConditionsLoadResult> {
+  const settled = await Promise.allSettled(
+    CREDIT_SERIES.map((definition) => loadSeries(definition, force)),
+  );
+  const rows: CreditConditionRow[] = [];
+  const errors: string[] = [];
+  settled.forEach((result, index) => {
+    if (result.status === "rejected") {
+      const seriesId = CREDIT_SERIES[index]!.seriesId;
+      errors.push(`${seriesId}: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`);
+      return;
+    }
+    rows.push(result.value.row);
+    if (result.value.refreshError) errors.push(`${result.value.row.seriesId}: ${result.value.refreshError}`);
+  });
+  if (rows.length === 0) throw new Error(errors.join("; ") || "Credit spread data unavailable");
+  return { rows, stale: rows.some((row) => row.stale), errors };
+}

--- a/src/plugins/builtin/credit-conditions/index.test.tsx
+++ b/src/plugins/builtin/credit-conditions/index.test.tsx
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { PaneFooterProvider } from "../../../components/layout/pane/footer";
+import {
+  attachFredSeriesPersistence,
+  resetFredSeriesPersistence,
+  type FredSeriesCacheEntry,
+} from "../../../data/fred-series";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { MemoryPluginPersistence } from "../../../test-support/plugin-persistence";
+import {
+  AppContext,
+  createInitialState,
+  PaneInstanceProvider,
+} from "../../../state/app/context";
+import { createDefaultConfig } from "../../../types/config";
+import { CREDIT_SERIES, type CreditConditionRow } from "./model";
+import { CreditConditionsPane, moveCreditSelection } from "./index";
+
+let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+function entry(seriesId: string, index: number): FredSeriesCacheEntry {
+  return {
+    fetchedAt: Date.now(),
+    stale: false,
+    data: {
+      observations: [
+        { date: "2026-08-17", value: 0.8 + index / 10 },
+        { date: "2026-08-18", value: 0.81 + index / 10 },
+      ],
+      info: {
+        id: seriesId,
+        title: `${seriesId} Option-Adjusted Spread`,
+        units: "Percent",
+        frequency: "Daily, Close",
+        seasonalAdjustment: "Not Seasonally Adjusted",
+        source: "FRED",
+        notes: "",
+      },
+    },
+  };
+}
+
+async function settle() {
+  await act(async () => {
+    for (let index = 0; index < 8; index += 1) {
+      await Promise.resolve();
+      await setup!.renderOnce();
+    }
+  });
+  for (let index = 0; index < 3; index += 1) {
+    await act(async () => {
+      await Promise.resolve();
+      await setup!.renderOnce();
+    });
+  }
+}
+
+beforeEach(() => {
+  resetFredSeriesPersistence();
+  const persistence = new MemoryPluginPersistence();
+  for (const [index, { seriesId }] of CREDIT_SERIES.entries()) {
+    persistence.seedResource(
+      "fred-series",
+      `${seriesId}:limit=45:sort=desc`,
+      entry(seriesId, index).data,
+      { sourceKey: "gloomberb-cloud", schemaVersion: 1 },
+    );
+  }
+  attachFredSeriesPersistence(persistence);
+});
+
+afterEach(async () => {
+  if (setup) {
+    await act(async () => setup?.renderer.destroy());
+    setup = undefined;
+  }
+  resetFredSeriesPersistence();
+});
+
+describe("CreditConditionsPane", () => {
+  test("selects credit rows with keyboard and mouse", async () => {
+    const keyboardRows = CREDIT_SERIES.map((definition) => ({ ...definition }) as CreditConditionRow);
+    expect(moveCreditSelection(keyboardRows, CREDIT_SERIES[5].seriesId, -1)).toBe(CREDIT_SERIES[4].seriesId);
+
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-credit-test"));
+    setup = await testRender(
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <PaneInstanceProvider paneId="credit:test">
+          <PaneFooterProvider>
+            {() => <CreditConditionsPane paneId="credit:test" paneType="credit-conditions" focused width={72} height={18} />}
+          </PaneFooterProvider>
+        </PaneInstanceProvider>
+      </AppContext>,
+      { width: 72, height: 18 },
+    );
+    await settle();
+
+    expect(setup.captureCharFrame()).toContain(`${CREDIT_SERIES[0].seriesId} Option-Adjusted Spread`);
+
+    let mouseSelected = false;
+    for (let row = 3; row < 9 && !mouseSelected; row += 1) {
+      await act(async () => {
+        await setup!.mockMouse.click(2, row);
+        await setup!.renderOnce();
+      });
+      mouseSelected = !setup.captureCharFrame().includes(`${CREDIT_SERIES[0].seriesId} Option-Adjusted Spread`);
+    }
+    expect(mouseSelected).toBe(true);
+  });
+});

--- a/src/plugins/builtin/credit-conditions/index.tsx
+++ b/src/plugins/builtin/credit-conditions/index.tsx
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, Text, TextAttributes } from "../../../ui";
+import {
+  DataTableView,
+  usePaneFooter,
+  type DataTableCell,
+  type DataTableColumn,
+  type DataTableKeyEvent,
+  type PaneFooterSegment,
+} from "../../../components";
+import type { PaneProps } from "../../../types/plugin";
+import { colors } from "../../../theme/colors";
+import type { PluginModule } from "../plugin-module";
+import { getCachedCreditConditions, loadCreditConditions } from "./client";
+import {
+  CREDIT_SERIES,
+  type CreditConditionRow,
+  type CreditSeriesId,
+} from "./model";
+
+type SortId = "label" | "oas" | "change" | "date";
+interface Column extends DataTableColumn { id: SortId }
+
+const COLUMNS: readonly Column[] = [
+  { id: "label", label: "INDEX", width: 12, align: "left" },
+  { id: "oas", label: "OAS", width: 10, align: "right" },
+  { id: "change", label: "1D", width: 9, align: "right" },
+  { id: "date", label: "AS OF", width: 12, align: "right" },
+];
+
+function formatBp(value: number | null, signed = false): string {
+  if (value == null) return "--";
+  const sign = signed && value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(1)}bp`;
+}
+
+function sortRows(rows: CreditConditionRow[], id: SortId, descending: boolean): CreditConditionRow[] {
+  return [...rows].sort((left, right) => {
+    let comparison = 0;
+    if (id === "label") comparison = left.label.localeCompare(right.label);
+    else if (id === "oas") comparison = left.oasBp - right.oasBp;
+    else if (id === "change") comparison = (left.dailyChangeBp ?? -Infinity) - (right.dailyChangeBp ?? -Infinity);
+    else comparison = left.date.localeCompare(right.date);
+    return descending ? -comparison : comparison;
+  });
+}
+
+function renderCell(
+  row: CreditConditionRow,
+  column: Column,
+  _index: number,
+  state: { selected: boolean },
+): DataTableCell {
+  const selected = state.selected ? colors.selectedText : undefined;
+  if (column.id === "label") return { text: row.label, color: selected ?? colors.text, attributes: TextAttributes.BOLD };
+  if (column.id === "oas") return { text: formatBp(row.oasBp), color: selected ?? colors.textBright };
+  if (column.id === "date") return { text: row.date, color: selected ?? colors.textDim };
+  return {
+    text: formatBp(row.dailyChangeBp, true),
+    color: selected ?? (row.dailyChangeBp == null
+      ? colors.textDim
+      : row.dailyChangeBp > 0
+        ? colors.negative
+        : row.dailyChangeBp < 0
+          ? colors.positive
+          : colors.textDim),
+  };
+}
+
+export function CreditConditionsPane({ paneId, focused, width, height }: PaneProps) {
+  const [initial] = useState(getCachedCreditConditions);
+  const [rows, setRows] = useState(initial?.rows ?? []);
+  const [selectedId, setSelectedId] = useState<CreditSeriesId | null>(initial?.rows[0]?.seriesId ?? null);
+  const [sort, setSort] = useState<{ id: SortId; descending: boolean }>({ id: "label", descending: false });
+  const [loading, setLoading] = useState(!initial);
+  const [stale, setStale] = useState(initial?.stale ?? false);
+  const [error, setError] = useState<string | null>(initial?.errors[0] ?? null);
+  const generation = useRef(0);
+
+  const load = useCallback(async (force = false) => {
+    const current = ++generation.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await loadCreditConditions(force);
+      if (generation.current !== current) return;
+      setRows(result.rows);
+      setSelectedId((id) => id && result.rows.some((row) => row.seriesId === id) ? id : result.rows[0]?.seriesId ?? null);
+      setStale(result.stale);
+      setError(result.errors[0] ?? null);
+    } catch (loadError) {
+      if (generation.current !== current) return;
+      setError(loadError instanceof Error ? loadError.message : String(loadError));
+    } finally {
+      if (generation.current === current) setLoading(false);
+    }
+  }, []);
+  useEffect(() => { void load(false); }, [load]);
+  const refresh = useCallback(() => { void load(true); }, [load]);
+
+  const sorted = useMemo(() => sortRows(rows, sort.id, sort.descending), [rows, sort]);
+  const selectedRow = rows.find((row) => row.seriesId === selectedId) ?? rows[0] ?? null;
+  const columns = useMemo<Column[]>(() => {
+    const labelWidth = Math.max(12, width - 35);
+    return COLUMNS.map((column) => column.id === "label" ? { ...column, width: labelWidth } : { ...column });
+  }, [width]);
+  const partial = rows.length > 0 && rows.length < CREDIT_SERIES.length;
+  const footerInfo = useMemo<PaneFooterSegment[]>(() => [
+    ...(partial ? [{ id: "partial", parts: [{ text: "PARTIAL", tone: "warning" as const, bold: true }] }] : []),
+    ...(stale ? [{ id: "stale", parts: [{ text: "STALE", tone: "warning" as const }] }] : []),
+    ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+    ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
+  ], [error, loading, partial, stale]);
+  usePaneFooter(paneId, () => ({
+    info: footerInfo,
+    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refresh, disabled: loading }],
+  }), [footerInfo, loading, paneId, refresh]);
+
+  const handleKey = useCallback((event: DataTableKeyEvent) => {
+    if (event.name !== "r") return false;
+    event.preventDefault?.();
+    event.stopPropagation?.();
+    refresh();
+    return true;
+  }, [refresh]);
+
+  if (rows.length === 0 && loading) {
+    return <Box width={width} height={height} justifyContent="center" alignItems="center"><Text fg={colors.textMuted}>Loading credit spreads...</Text></Box>;
+  }
+  if (rows.length === 0) {
+    return <Box width={width} height={height} padding={1}><Text fg={colors.negative}>{error ?? "Credit spread data unavailable"}</Text></Box>;
+  }
+
+  const metadata = (
+    <Box height={2} flexDirection="column" paddingX={1}>
+      <Text fg={colors.textMuted}>FRED · option-adjusted spread · daily close · delayed</Text>
+      <Text fg={colors.textDim}>{selectedRow?.title ?? ""}</Text>
+    </Box>
+  );
+
+  return (
+    <DataTableView<CreditConditionRow, Column>
+      focused={focused}
+      rootWidth={width}
+      rootHeight={height}
+      rootBefore={metadata}
+      selection={{
+        kind: "id",
+        selectedId,
+        getId: (row) => row.seriesId,
+        onChange: (id) => setSelectedId(id as CreditSeriesId),
+      }}
+      onRootKeyDown={handleKey}
+      columns={columns}
+      items={sorted}
+      sortColumnId={sort.id}
+      sortDirection={sort.descending ? "desc" : "asc"}
+      onHeaderClick={(id) => setSort((current) => ({
+        id: id as SortId,
+        descending: current.id === id ? !current.descending : id !== "label",
+      }))}
+      getItemKey={(row) => row.seriesId}
+      renderCell={renderCell}
+      emptyStateTitle="No credit spread data."
+      emptyStateHint="Press r to retry."
+    />
+  );
+}
+
+export const creditConditionsModule: PluginModule = {
+  panes: [{
+    id: "credit-conditions",
+    name: "Credit Spreads",
+    icon: "C",
+    component: CreditConditionsPane,
+    defaultPosition: "right",
+    defaultMode: "floating",
+    defaultFloatingSize: { width: 72, height: 18 },
+  }],
+  paneTemplates: [{
+    id: "credit-conditions-pane",
+    paneId: "credit-conditions",
+    label: "Credit Spreads",
+    description: "ICE BofA US corporate option-adjusted spreads from FRED.",
+    keywords: ["credit", "spread", "oas", "corporate", "high yield", "investment grade", "macro"],
+    shortcut: { prefix: "CRD" },
+  }],
+};

--- a/src/plugins/builtin/credit-conditions/index.tsx
+++ b/src/plugins/builtin/credit-conditions/index.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, TextAttributes } from "../../../ui";
+import { useShortcut } from "../../../react/input";
 import {
   DataTableView,
   usePaneFooter,
   type DataTableCell,
   type DataTableColumn,
-  type DataTableKeyEvent,
   type PaneFooterSegment,
 } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
@@ -43,6 +43,16 @@ function sortRows(rows: CreditConditionRow[], id: SortId, descending: boolean): 
     else comparison = left.date.localeCompare(right.date);
     return descending ? -comparison : comparison;
   });
+}
+
+export function moveCreditSelection(
+  rows: CreditConditionRow[],
+  selectedId: CreditSeriesId | null,
+  offset: -1 | 1,
+): CreditSeriesId | null {
+  if (rows.length === 0) return null;
+  const current = Math.max(0, rows.findIndex((row) => row.seriesId === selectedId));
+  return rows[Math.max(0, Math.min(current + offset, rows.length - 1))]!.seriesId;
 }
 
 function renderCell(
@@ -96,7 +106,7 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
     }
   }, []);
   useEffect(() => { void load(false); }, [load]);
-  const refresh = useCallback(() => { void load(true); }, [load]);
+  const reload = useCallback(() => { void load(true); }, [load]);
 
   const sorted = useMemo(() => sortRows(rows, sort.id, sort.descending), [rows, sort]);
   const selectedRow = rows.find((row) => row.seriesId === selectedId) ?? rows[0] ?? null;
@@ -104,6 +114,29 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
     const labelWidth = Math.max(12, width - 35);
     return COLUMNS.map((column) => column.id === "label" ? { ...column, width: labelWidth } : { ...column });
   }, [width]);
+  const renderRowCell = useCallback((
+    row: CreditConditionRow,
+    column: Column,
+    index: number,
+    state: { selected: boolean },
+  ): DataTableCell => ({
+    ...renderCell(row, column, index, state),
+    onMouseDown: () => setSelectedId(row.seriesId),
+  }), []);
+  useShortcut((event) => {
+    if (!focused) return;
+    if (event.name === "r") {
+      if (loading) return;
+      reload();
+    } else if (["up", "k", "down", "j"].includes(event.name ?? "")) {
+      const offset = event.name === "up" || event.name === "k" ? -1 : 1;
+      setSelectedId(moveCreditSelection(sorted, selectedId, offset));
+    } else {
+      return;
+    }
+    event.preventDefault?.();
+    event.stopPropagation?.();
+  });
   const partial = rows.length > 0 && rows.length < CREDIT_SERIES.length;
   const footerInfo = useMemo<PaneFooterSegment[]>(() => [
     ...(partial ? [{ id: "partial", parts: [{ text: "PARTIAL", tone: "warning" as const, bold: true }] }] : []),
@@ -113,16 +146,8 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
   ], [error, loading, partial, stale]);
   usePaneFooter(paneId, () => ({
     info: footerInfo,
-    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refresh, disabled: loading }],
-  }), [footerInfo, loading, paneId, refresh]);
-
-  const handleKey = useCallback((event: DataTableKeyEvent) => {
-    if (event.name !== "r") return false;
-    event.preventDefault?.();
-    event.stopPropagation?.();
-    refresh();
-    return true;
-  }, [refresh]);
+    hints: [{ id: "reload", key: "r", label: "eload", onPress: reload, disabled: loading }],
+  }), [footerInfo, loading, paneId, reload]);
 
   if (rows.length === 0 && loading) {
     return <Box width={width} height={height} justifyContent="center" alignItems="center"><Text fg={colors.textMuted}>Loading credit spreads...</Text></Box>;
@@ -150,7 +175,7 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
         getId: (row) => row.seriesId,
         onChange: (id) => setSelectedId(id as CreditSeriesId),
       }}
-      onRootKeyDown={handleKey}
+      onCursorChange={(row) => setSelectedId(row.seriesId)}
       columns={columns}
       items={sorted}
       sortColumnId={sort.id}
@@ -160,9 +185,9 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
         descending: current.id === id ? !current.descending : id !== "label",
       }))}
       getItemKey={(row) => row.seriesId}
-      renderCell={renderCell}
+      renderCell={renderRowCell}
       emptyStateTitle="No credit spread data."
-      emptyStateHint="Press r to retry."
+      emptyStateHint="Press r to reload."
     />
   );
 }

--- a/src/plugins/builtin/credit-conditions/model.test.ts
+++ b/src/plugins/builtin/credit-conditions/model.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { CREDIT_SERIES, normalizeCreditSeries } from "./model";
+
+function payload(overrides: Record<string, unknown> = {}) {
+  return {
+    observations: [
+      { date: "2026-08-17", value: 0.81 },
+      { date: "2026-08-14", value: 0.8 },
+      { date: "2026-08-16", value: null },
+    ],
+    info: {
+      id: "BAMLC0A0CM",
+      title: "ICE BofA US Corporate Index Option-Adjusted Spread",
+      units: "Percent",
+      frequency: "Daily, Close",
+      seasonalAdjustment: "Not Seasonally Adjusted",
+      source: "",
+      notes: "",
+      ...overrides,
+    },
+  };
+}
+
+describe("normalizeCreditSeries", () => {
+  test("converts the official percent OAS to basis points", () => {
+    const row = normalizeCreditSeries(CREDIT_SERIES[0], payload(), true);
+
+    expect(row).toMatchObject({
+      label: "US IG",
+      oasBp: 81,
+      dailyChangeBp: 1,
+      date: "2026-08-17",
+      units: "Percent",
+      frequency: "Daily, Close",
+      stale: true,
+    });
+  });
+
+  test("rejects metadata that would make spread normalization misleading", () => {
+    expect(() => normalizeCreditSeries(CREDIT_SERIES[0], payload({ units: "Index" }))).toThrow("unexpected FRED metadata");
+    expect(() => normalizeCreditSeries(CREDIT_SERIES[0], payload({ title: "Corporate Effective Yield" }))).toThrow("unexpected FRED metadata");
+  });
+});

--- a/src/plugins/builtin/credit-conditions/model.ts
+++ b/src/plugins/builtin/credit-conditions/model.ts
@@ -1,0 +1,64 @@
+import type { CloudFredSeriesPayload } from "../../../api-client";
+
+export const CREDIT_SERIES = [
+  { seriesId: "BAMLC0A0CM", label: "US IG" },
+  { seriesId: "BAMLC0A1CAAA", label: "AAA" },
+  { seriesId: "BAMLC0A2CAA", label: "AA" },
+  { seriesId: "BAMLC0A3CA", label: "A" },
+  { seriesId: "BAMLC0A4CBBB", label: "BBB" },
+  { seriesId: "BAMLH0A0HYM2", label: "US HY" },
+] as const;
+
+export type CreditSeriesId = typeof CREDIT_SERIES[number]["seriesId"];
+
+export interface CreditConditionRow {
+  seriesId: CreditSeriesId;
+  label: string;
+  title: string;
+  units: string;
+  frequency: string;
+  oasBp: number;
+  dailyChangeBp: number | null;
+  date: string;
+  stale: boolean;
+}
+
+function roundTenth(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+export function normalizeCreditSeries(
+  definition: typeof CREDIT_SERIES[number],
+  payload: CloudFredSeriesPayload,
+  stale = false,
+): CreditConditionRow {
+  const info = payload.info;
+  if (!info
+    || info.units.toLowerCase() !== "percent"
+    || !info.frequency.toLowerCase().startsWith("daily")
+    || !info.title.toLowerCase().includes("option-adjusted spread")) {
+    throw new Error(`${definition.seriesId}: unexpected FRED metadata`);
+  }
+
+  const observations = payload.observations
+    .filter((observation): observation is { date: string; value: number } =>
+      /^\d{4}-\d{2}-\d{2}$/.test(observation.date)
+      && observation.value != null
+      && Number.isFinite(observation.value),
+    )
+    .sort((left, right) => left.date.localeCompare(right.date));
+  const latest = observations.at(-1);
+  if (!latest) throw new Error(`${definition.seriesId}: no observations`);
+  const previous = observations.at(-2);
+
+  return {
+    ...definition,
+    title: info.title,
+    units: info.units,
+    frequency: info.frequency,
+    oasBp: roundTenth(latest.value * 100),
+    dailyChangeBp: previous ? roundTenth((latest.value - previous.value) * 100) : null,
+    date: latest.date,
+    stale,
+  };
+}

--- a/src/plugins/builtin/econ/index.tsx
+++ b/src/plugins/builtin/econ/index.tsx
@@ -29,7 +29,6 @@ import {
   type EconCalendarColumn,
   type ImpactFilter,
 } from "./calendar-model";
-import { attachFredSeriesPersistence } from "../../../data/fred-series";
 import { usePaneStatusFooter } from "../shared/pane-footer";
 
 function EconCalendarPane({ focused, width, height }: PaneProps) {
@@ -366,7 +365,6 @@ export const economicCalendarModule: PluginModule = {
   }],
   setup(ctx) {
     attachEconCalendarPersistence(ctx.persistence);
-    attachFredSeriesPersistence(ctx.persistence);
   },
   dispose() {
     resetEconCalendarPersistence();

--- a/src/plugins/builtin/ticker-research-backend-plugin.ts
+++ b/src/plugins/builtin/ticker-research-backend-plugin.ts
@@ -1,11 +1,4 @@
-import { attachFredSeriesPersistence } from "../../data/fred-series";
-import { composeBuiltinPlugin, type PluginModule } from "./plugin-module";
-
-const chartSeriesPersistenceModule: PluginModule = {
-  setup(ctx) {
-    attachFredSeriesPersistence(ctx.persistence);
-  },
-};
+import { composeBuiltinPlugin } from "./plugin-module";
 
 export const tickerResearchBackendPlugin = composeBuiltinPlugin({
   id: "ticker-research",
@@ -13,5 +6,5 @@ export const tickerResearchBackendPlugin = composeBuiltinPlugin({
   version: "1.0.0",
   description: "Company research workspace: overview, charts, financials, filings, ownership, options, analyst research, and events.",
   toggleable: true,
-  modules: [chartSeriesPersistenceModule],
+  modules: [],
 });

--- a/src/plugins/builtin/volatility/client.ts
+++ b/src/plugins/builtin/volatility/client.ts
@@ -1,0 +1,86 @@
+import { apiClient } from "../../../api-client";
+import {
+  getCachedFredSeries,
+  loadCachedFredSeries,
+  type FredSeriesLoadResult,
+  type FredSeriesRequest,
+} from "../../../data/fred-series";
+import {
+  buildVolatilityData,
+  VOLATILITY_SERIES,
+  type VolatilityData,
+  type VolatilitySeriesId,
+  type VolatilitySeriesInput,
+} from "./model";
+
+export interface VolatilityLoadResult {
+  data: VolatilityData;
+  stale: boolean;
+  errors: string[];
+}
+
+function startDate(): string {
+  return new Date(Date.now() - 120 * 86_400_000).toISOString().slice(0, 10);
+}
+
+function requestFor(seriesId: VolatilitySeriesId): FredSeriesRequest {
+  return { seriesId, startDate: startDate(), sortOrder: "asc" };
+}
+
+function toInput(result: Pick<FredSeriesLoadResult, "data">): VolatilitySeriesInput {
+  return result.data;
+}
+
+export function getCachedVolatilityData(): VolatilityLoadResult | null {
+  const entries = VOLATILITY_SERIES.flatMap(({ seriesId }) => {
+    const cached = getCachedFredSeries(requestFor(seriesId), { allowExpired: true });
+    return cached ? [[seriesId, cached] as const] : [];
+  });
+  if (entries.length === 0) return null;
+  return {
+    data: buildVolatilityData(Object.fromEntries(entries.map(([id, entry]) => [id, toInput(entry)]))),
+    stale: entries.some(([, entry]) => entry.stale),
+    errors: [],
+  };
+}
+
+async function loadSeries(
+  seriesId: VolatilitySeriesId,
+  force: boolean,
+): Promise<FredSeriesLoadResult> {
+  const request = requestFor(seriesId);
+  return loadCachedFredSeries(
+    request,
+    () => apiClient.getCloudFredSeries(seriesId, {
+      startDate: request.startDate,
+      sortOrder: "asc",
+    }),
+    { force },
+  );
+}
+
+export async function loadVolatilityData(force = false): Promise<VolatilityLoadResult> {
+  const settled = await Promise.allSettled(
+    VOLATILITY_SERIES.map(({ seriesId }) => loadSeries(seriesId, force)),
+  );
+  const inputs: Partial<Record<VolatilitySeriesId, VolatilitySeriesInput>> = {};
+  const errors: string[] = [];
+  let stale = false;
+
+  settled.forEach((result, index) => {
+    const seriesId = VOLATILITY_SERIES[index]!.seriesId;
+    if (result.status === "rejected") {
+      errors.push(`${seriesId}: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`);
+      return;
+    }
+    inputs[seriesId] = toInput(result.value);
+    stale ||= result.value.stale;
+    if (result.value.refreshError) errors.push(`${seriesId}: ${result.value.refreshError}`);
+  });
+
+  const data = buildVolatilityData(inputs);
+  if (data.metrics.every((metric) => metric.value == null)) {
+    throw new Error(errors.join("; ") || "Volatility data unavailable");
+  }
+  return { data, stale, errors };
+}

--- a/src/plugins/builtin/volatility/client.ts
+++ b/src/plugins/builtin/volatility/client.ts
@@ -19,16 +19,17 @@ export interface VolatilityLoadResult {
   errors: string[];
 }
 
-function startDate(): string {
-  return new Date(Date.now() - 120 * 86_400_000).toISOString().slice(0, 10);
-}
+const HISTORY_LIMIT = 120;
 
 function requestFor(seriesId: VolatilitySeriesId): FredSeriesRequest {
-  return { seriesId, startDate: startDate(), sortOrder: "asc" };
+  return { seriesId, limit: HISTORY_LIMIT, sortOrder: "desc" };
 }
 
 function toInput(result: Pick<FredSeriesLoadResult, "data">): VolatilitySeriesInput {
-  return result.data;
+  return {
+    ...result.data,
+    observations: result.data.observations.slice(0, HISTORY_LIMIT),
+  };
 }
 
 export function getCachedVolatilityData(): VolatilityLoadResult | null {
@@ -51,10 +52,10 @@ async function loadSeries(
   const request = requestFor(seriesId);
   return loadCachedFredSeries(
     request,
-    () => apiClient.getCloudFredSeries(seriesId, {
-      startDate: request.startDate,
-      sortOrder: "asc",
-    }),
+    async () => toInput({ data: await apiClient.getCloudFredSeries(seriesId, {
+      limit: request.limit,
+      sortOrder: request.sortOrder,
+    }) }),
     { force },
   );
 }

--- a/src/plugins/builtin/volatility/index.test.tsx
+++ b/src/plugins/builtin/volatility/index.test.tsx
@@ -69,6 +69,9 @@ describe("VolatilityPane", () => {
 
     let frame = setup.captureCharFrame();
     expect(frame).toMatch(/▸\s+VIX\s+16\.00/);
+    expect(frame).toContain("3M/30D");
+    expect(frame).toContain("3M premium +3.00 pts");
+    expect(frame).not.toContain("contango");
 
     await act(async () => {
       setup!.mockInput.pressArrow("right");

--- a/src/plugins/builtin/volatility/index.test.tsx
+++ b/src/plugins/builtin/volatility/index.test.tsx
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { PaneFooterProvider } from "../../../components/layout/pane/footer";
+import {
+  hydrateFredSeries,
+  resetFredSeriesPersistence,
+  type FredSeriesCacheEntry,
+} from "../../../data/fred-series";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { VolatilityPane } from "./index";
+
+let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+function entry(id: string, title: string, values: number[]): FredSeriesCacheEntry {
+  return {
+    fetchedAt: Date.now(),
+    stale: false,
+    data: {
+      observations: values.map((value, index) => ({
+        date: `2026-08-${String(14 + index).padStart(2, "0")}`,
+        value,
+      })),
+      info: {
+        id,
+        title,
+        units: "Index",
+        frequency: "Daily, Close",
+        seasonalAdjustment: "Not Seasonally Adjusted",
+        source: "",
+        notes: "",
+      },
+    },
+  };
+}
+
+async function settle() {
+  await act(async () => {
+    await Promise.resolve();
+    await setup!.renderOnce();
+    await setup!.renderOnce();
+  });
+}
+
+beforeEach(() => {
+  resetFredSeriesPersistence();
+  hydrateFredSeries([
+    ["VIXCLS", entry("VIXCLS", "CBOE Volatility Index: VIX", [15, 16])],
+    ["VXVCLS", entry("VXVCLS", "CBOE S&P 500 3-Month Volatility Index", [18, 19])],
+  ]);
+});
+
+afterEach(async () => {
+  if (setup) {
+    await act(async () => setup?.renderer.destroy());
+    setup = undefined;
+  }
+  resetFredSeriesPersistence();
+});
+
+describe("VolatilityPane", () => {
+  test("selects volatility tenors with keyboard", async () => {
+    setup = await testRender(
+      <PaneFooterProvider>
+        {() => <VolatilityPane paneId="volatility:test" paneType="volatility-term-structure" focused width={76} height={23} />}
+      </PaneFooterProvider>,
+      { width: 76, height: 23 },
+    );
+    await settle();
+
+    let frame = setup.captureCharFrame();
+    expect(frame).toMatch(/▸\s+VIX\s+16\.00/);
+
+    await act(async () => {
+      setup!.mockInput.pressArrow("right");
+      await setup!.renderOnce();
+    });
+    frame = setup.captureCharFrame();
+    expect(frame).toMatch(/▸\s+VIX 3M\s+19\.00/);
+
+    expect(frame).toContain("CBOE S&P 500 3-Month Volatility Index");
+  });
+});

--- a/src/plugins/builtin/volatility/index.tsx
+++ b/src/plugins/builtin/volatility/index.tsx
@@ -20,9 +20,16 @@ function formatValue(value: number | null, suffix = ""): string {
 }
 
 function termColor(state: TermState): string {
-  if (state === "contango") return colors.positive;
-  if (state === "backwardation") return colors.warning;
+  if (state === "normal") return colors.positive;
+  if (state === "inverted") return colors.warning;
   return colors.textMuted;
+}
+
+function slopeLabel(slope: number | null): string {
+  if (slope == null || !Number.isFinite(slope)) return "3M spread --";
+  if (slope > 0) return `3M premium +${slope.toFixed(2)} pts`;
+  if (slope < 0) return `3M discount ${slope.toFixed(2)} pts`;
+  return "3M spread 0.00 pts";
 }
 
 function TermChart({ data, width, height }: { data: VolatilityData; width: number; height: number }) {
@@ -35,7 +42,7 @@ function TermChart({ data, width, height }: { data: VolatilityData; width: numbe
     volume: 0,
   }]);
   if (points.length < 2) {
-    return <Box paddingX={1}><Text fg={colors.warning}>Term structure partial: aligned closes unavailable.</Text></Box>;
+    return <Box paddingX={1}><Text fg={colors.warning}>VIX curve partial: aligned closes unavailable.</Text></Box>;
   }
   const colWidth = Math.max(10, Math.floor((width - 2) / data.termPoints.length));
   return (
@@ -46,7 +53,7 @@ function TermChart({ data, width, height }: { data: VolatilityData; width: numbe
         height={Math.max(5, Math.min(10, height))}
         mode="line"
         colors={resolveChartPalette(colors, "positive")}
-        yAxisLabel="Index"
+        yAxisLabel="Vol"
         yAxisColor={colors.textDim}
         formatYAxisValue={(value) => value.toFixed(1)}
       />
@@ -85,11 +92,13 @@ export function VolatilityPane({ paneId, focused, width, height }: PaneProps) {
 
   useEffect(() => { void load(false); }, [load]);
 
-  const refresh = useCallback(() => { void load(true); }, [load]);
+  const reload = useCallback(() => { void load(true); }, [load]);
   useShortcut((event) => {
     if (!focused) return;
-    if (event.name === "r") refresh();
-    else if (["left", "up", "k"].includes(event.name ?? "")) setSelected((value) => Math.max(0, value - 1));
+    if (event.name === "r") {
+      if (loading) return;
+      reload();
+    } else if (["left", "up", "k"].includes(event.name ?? "")) setSelected((value) => Math.max(0, value - 1));
     else if (["right", "down", "j"].includes(event.name ?? "")) setSelected((value) => Math.min(1, value + 1));
     else return;
     event.preventDefault();
@@ -99,7 +108,7 @@ export function VolatilityPane({ paneId, focused, width, height }: PaneProps) {
   const footerInfo = useMemo<PaneFooterSegment[]>(() => [
     ...(data?.termState && data.termState !== "partial" ? [{
       id: "term-state",
-      parts: [{ text: data.termState.toUpperCase(), tone: data.termState === "backwardation" ? "warning" as const : "value" as const, bold: true }],
+      parts: [{ text: data.termState.toUpperCase(), tone: data.termState === "inverted" ? "warning" as const : "value" as const, bold: true }],
     }] : []),
     ...(data?.termState === "partial" ? [{ id: "partial", parts: [{ text: "PARTIAL", tone: "warning" as const, bold: true }] }] : []),
     ...(stale ? [{ id: "stale", parts: [{ text: "STALE", tone: "warning" as const }] }] : []),
@@ -108,8 +117,8 @@ export function VolatilityPane({ paneId, focused, width, height }: PaneProps) {
   ], [data?.termState, error, loading, stale]);
   usePaneFooter(paneId, () => ({
     info: footerInfo,
-    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refresh, disabled: loading }],
-  }), [footerInfo, loading, paneId, refresh]);
+    hints: [{ id: "reload", key: "r", label: "eload", onPress: reload, disabled: loading }],
+  }), [footerInfo, loading, paneId, reload]);
 
   if (!data && loading) {
     return <Box width={width} height={height} justifyContent="center" alignItems="center"><Text fg={colors.textMuted}>Loading volatility data...</Text></Box>;
@@ -123,9 +132,9 @@ export function VolatilityPane({ paneId, focused, width, height }: PaneProps) {
     <Box flexDirection="column" width={width} height={height} paddingBottom={1}>
           <Box paddingX={1}><Text fg={colors.textMuted}>FRED · daily close · delayed</Text></Box>
           <Box flexDirection="row" paddingX={1} marginTop={1}>
-            <Text fg={colors.textDim}>VXV/VIX </Text>
+            <Text fg={colors.textDim}>3M/30D </Text>
             <Text fg={termColor(data.termState)} attributes={TextAttributes.BOLD}>{formatValue(data.ratio)}</Text>
-            <Text fg={colors.textDim}>{`  slope ${formatValue(data.slope, " pts")}  as of ${data.termDate ?? "--"}`}</Text>
+            <Text fg={colors.textDim}>{`  ${slopeLabel(data.slope)}  as of ${data.termDate ?? "--"}`}</Text>
           </Box>
           <Box marginTop={1} height={2}>
             <ListView
@@ -159,7 +168,7 @@ export function VolatilityPane({ paneId, focused, width, height }: PaneProps) {
 export const volatilityModule: PluginModule = {
   panes: [{
     id: "volatility-term-structure",
-    name: "VIX Term Structure",
+    name: "VIX 30D/3M Curve",
     icon: "V",
     component: VolatilityPane,
     defaultPosition: "right",
@@ -169,9 +178,9 @@ export const volatilityModule: PluginModule = {
   paneTemplates: [{
     id: "volatility-term-structure-pane",
     paneId: "volatility-term-structure",
-    label: "VIX Term Structure",
-    description: "Aligned daily VIX and three-month volatility closes from FRED.",
-    keywords: ["vix", "volatility", "term structure", "contango", "backwardation", "macro"],
+    label: "VIX 30D/3M Curve",
+    description: "Aligned daily 30-day and three-month VIX implied-volatility closes from FRED.",
+    keywords: ["vix", "volatility", "implied volatility", "curve", "slope", "normal", "inverted", "macro"],
     shortcut: { prefix: "VIX" },
   }],
 };

--- a/src/plugins/builtin/volatility/index.tsx
+++ b/src/plugins/builtin/volatility/index.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, Text, TextAttributes } from "../../../ui";
+import { useShortcut } from "../../../react/input";
+import {
+  StaticChartSurface,
+  usePaneFooter,
+  type PaneFooterSegment,
+} from "../../../components";
+import { ListView } from "../../../components/ui/list-view";
+import type { ProjectedChartPoint } from "../../../components/chart/core/data";
+import { resolveChartPalette } from "../../../components/chart/core/renderer";
+import type { PaneProps } from "../../../types/plugin";
+import { colors } from "../../../theme/colors";
+import type { PluginModule } from "../plugin-module";
+import { getCachedVolatilityData, loadVolatilityData } from "./client";
+import type { TermState, VolatilityData } from "./model";
+
+function formatValue(value: number | null, suffix = ""): string {
+  return value == null || !Number.isFinite(value) ? "--" : `${value.toFixed(2)}${suffix}`;
+}
+
+function termColor(state: TermState): string {
+  if (state === "contango") return colors.positive;
+  if (state === "backwardation") return colors.warning;
+  return colors.textMuted;
+}
+
+function TermChart({ data, width, height }: { data: VolatilityData; width: number; height: number }) {
+  const points: ProjectedChartPoint[] = data.termPoints.flatMap((point, index) => point.value == null ? [] : [{
+    date: new Date(index * 86_400_000),
+    open: point.value,
+    high: point.value,
+    low: point.value,
+    close: point.value,
+    volume: 0,
+  }]);
+  if (points.length < 2) {
+    return <Box paddingX={1}><Text fg={colors.warning}>Term structure partial: aligned closes unavailable.</Text></Box>;
+  }
+  const colWidth = Math.max(10, Math.floor((width - 2) / data.termPoints.length));
+  return (
+    <Box flexDirection="column" paddingX={1} marginTop={1}>
+      <StaticChartSurface
+        points={points}
+        width={Math.max(12, width - 2)}
+        height={Math.max(5, Math.min(10, height))}
+        mode="line"
+        colors={resolveChartPalette(colors, "positive")}
+        yAxisLabel="Index"
+        yAxisColor={colors.textDim}
+        formatYAxisValue={(value) => value.toFixed(1)}
+      />
+      <Text fg={colors.textDim}>{data.termPoints.map((point) => point.tenor.padEnd(colWidth)).join("").trimEnd()}</Text>
+      <Text fg={colors.text}>{data.termPoints.map((point) => formatValue(point.value).padEnd(colWidth)).join("").trimEnd()}</Text>
+    </Box>
+  );
+}
+
+export function VolatilityPane({ paneId, focused, width, height }: PaneProps) {
+  const [initial] = useState(getCachedVolatilityData);
+  const [data, setData] = useState<VolatilityData | null>(initial?.data ?? null);
+  const [loading, setLoading] = useState(!initial);
+  const [stale, setStale] = useState(initial?.stale ?? false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState(0);
+  const generation = useRef(0);
+
+  const load = useCallback(async (force = false) => {
+    const current = ++generation.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await loadVolatilityData(force);
+      if (generation.current !== current) return;
+      setData(result.data);
+      setStale(result.stale);
+      setError(result.errors[0] ?? null);
+    } catch (loadError) {
+      if (generation.current !== current) return;
+      setError(loadError instanceof Error ? loadError.message : String(loadError));
+    } finally {
+      if (generation.current === current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(false); }, [load]);
+
+  const refresh = useCallback(() => { void load(true); }, [load]);
+  useShortcut((event) => {
+    if (!focused) return;
+    if (event.name === "r") refresh();
+    else if (["left", "up", "k"].includes(event.name ?? "")) setSelected((value) => Math.max(0, value - 1));
+    else if (["right", "down", "j"].includes(event.name ?? "")) setSelected((value) => Math.min(1, value + 1));
+    else return;
+    event.preventDefault();
+    event.stopPropagation();
+  });
+
+  const footerInfo = useMemo<PaneFooterSegment[]>(() => [
+    ...(data?.termState && data.termState !== "partial" ? [{
+      id: "term-state",
+      parts: [{ text: data.termState.toUpperCase(), tone: data.termState === "backwardation" ? "warning" as const : "value" as const, bold: true }],
+    }] : []),
+    ...(data?.termState === "partial" ? [{ id: "partial", parts: [{ text: "PARTIAL", tone: "warning" as const, bold: true }] }] : []),
+    ...(stale ? [{ id: "stale", parts: [{ text: "STALE", tone: "warning" as const }] }] : []),
+    ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+    ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
+  ], [data?.termState, error, loading, stale]);
+  usePaneFooter(paneId, () => ({
+    info: footerInfo,
+    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refresh, disabled: loading }],
+  }), [footerInfo, loading, paneId, refresh]);
+
+  if (!data && loading) {
+    return <Box width={width} height={height} justifyContent="center" alignItems="center"><Text fg={colors.textMuted}>Loading volatility data...</Text></Box>;
+  }
+  if (!data) {
+    return <Box width={width} height={height} padding={1}><Text fg={colors.negative}>{error ?? "Volatility data unavailable"}</Text></Box>;
+  }
+
+  const selectedMetric = data.metrics[selected] ?? data.metrics[0]!;
+  return (
+    <Box flexDirection="column" width={width} height={height} paddingBottom={1}>
+          <Box paddingX={1}><Text fg={colors.textMuted}>FRED · daily close · delayed</Text></Box>
+          <Box flexDirection="row" paddingX={1} marginTop={1}>
+            <Text fg={colors.textDim}>VXV/VIX </Text>
+            <Text fg={termColor(data.termState)} attributes={TextAttributes.BOLD}>{formatValue(data.ratio)}</Text>
+            <Text fg={colors.textDim}>{`  slope ${formatValue(data.slope, " pts")}  as of ${data.termDate ?? "--"}`}</Text>
+          </Box>
+          <Box marginTop={1} height={2}>
+            <ListView
+              items={data.metrics.map((metric) => ({
+                id: metric.seriesId,
+                label: `${metric.label.padEnd(8)} ${formatValue(metric.value).padStart(7)}   ${metric.tenor} · ${metric.date ?? "--"}`,
+              }))}
+              selectedIndex={selected}
+              onSelect={setSelected}
+              renderRow={(item, state, index) => (
+                <Text
+                  fg={state.selected ? colors.selectedText : colors.text}
+                  attributes={state.selected ? TextAttributes.BOLD : 0}
+                  onMouseDown={() => setSelected(index)}
+                  onMouseUp={() => setSelected(index)}
+                >
+                  {state.selected ? "▸ " : "  "}{item.label}
+                </Text>
+              )}
+              height={2}
+              surface="plain"
+              remoteLabel="Volatility tenors"
+            />
+          </Box>
+          <Box paddingX={1}><Text fg={colors.textDim}>{selectedMetric.title}</Text></Box>
+          <TermChart data={data} width={width} height={Math.floor(height * 0.35)} />
+    </Box>
+  );
+}
+
+export const volatilityModule: PluginModule = {
+  panes: [{
+    id: "volatility-term-structure",
+    name: "VIX Term Structure",
+    icon: "V",
+    component: VolatilityPane,
+    defaultPosition: "right",
+    defaultMode: "floating",
+    defaultFloatingSize: { width: 76, height: 23 },
+  }],
+  paneTemplates: [{
+    id: "volatility-term-structure-pane",
+    paneId: "volatility-term-structure",
+    label: "VIX Term Structure",
+    description: "Aligned daily VIX and three-month volatility closes from FRED.",
+    keywords: ["vix", "volatility", "term structure", "contango", "backwardation", "macro"],
+    shortcut: { prefix: "VIX" },
+  }],
+};

--- a/src/plugins/builtin/volatility/model.test.ts
+++ b/src/plugins/builtin/volatility/model.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { buildVolatilityData } from "./model";
+
+const info = {
+  id: "VIXCLS",
+  title: "CBOE Volatility Index: VIX",
+  units: "Index",
+  frequency: "Daily, Close",
+  seasonalAdjustment: "Not Seasonally Adjusted",
+  source: "",
+  notes: "",
+};
+
+describe("buildVolatilityData", () => {
+  test("aligns term values and ratios to the latest shared close", () => {
+    const data = buildVolatilityData({
+      VIXCLS: {
+        info,
+        observations: [
+          { date: "2026-08-17", value: 20 },
+          { date: "2026-08-14", value: 10 },
+        ],
+      },
+      VXVCLS: {
+        info: { ...info, id: "VXVCLS", title: "CBOE S&P 500 3-Month Volatility Index" },
+        observations: [{ date: "2026-08-14", value: 15 }],
+      },
+    });
+
+    expect(data.metrics[0]?.value).toBe(20);
+    expect(data.termDate).toBe("2026-08-14");
+    expect(data.termPoints.map((point) => point.value)).toEqual([10, 15]);
+    expect(data.ratio).toBe(1.5);
+    expect(data.slope).toBe(5);
+    expect(data.termState).toBe("contango");
+  });
+
+  test("reports partial state instead of combining unmatched dates", () => {
+    const data = buildVolatilityData({
+      VIXCLS: {
+        info,
+        observations: [{ date: "2026-08-17", value: 15 }],
+      },
+      VXVCLS: {
+        info: { ...info, id: "VXVCLS" },
+        observations: [{ date: "2026-08-14", value: 19 }],
+      },
+    });
+
+    expect(data.termDate).toBeNull();
+    expect(data.ratio).toBeNull();
+    expect(data.termPoints.map((point) => point.value)).toEqual([null, null]);
+    expect(data.termState).toBe("partial");
+  });
+
+  test("classifies an aligned inverted curve as backwardation", () => {
+    const data = buildVolatilityData({
+      VIXCLS: { info, observations: [{ date: "2026-08-17", value: 24 }] },
+      VXVCLS: { info: { ...info, id: "VXVCLS" }, observations: [{ date: "2026-08-17", value: 20 }] },
+    });
+
+    expect(data.termState).toBe("backwardation");
+    expect(data.ratio).toBeCloseTo(20 / 24);
+    expect(data.slope).toBe(-4);
+  });
+});

--- a/src/plugins/builtin/volatility/model.test.ts
+++ b/src/plugins/builtin/volatility/model.test.ts
@@ -32,7 +32,7 @@ describe("buildVolatilityData", () => {
     expect(data.termPoints.map((point) => point.value)).toEqual([10, 15]);
     expect(data.ratio).toBe(1.5);
     expect(data.slope).toBe(5);
-    expect(data.termState).toBe("contango");
+    expect(data.termState).toBe("normal");
   });
 
   test("reports partial state instead of combining unmatched dates", () => {
@@ -53,13 +53,13 @@ describe("buildVolatilityData", () => {
     expect(data.termState).toBe("partial");
   });
 
-  test("classifies an aligned inverted curve as backwardation", () => {
+  test("classifies a lower three-month implied-volatility close as inverted", () => {
     const data = buildVolatilityData({
       VIXCLS: { info, observations: [{ date: "2026-08-17", value: 24 }] },
       VXVCLS: { info: { ...info, id: "VXVCLS" }, observations: [{ date: "2026-08-17", value: 20 }] },
     });
 
-    expect(data.termState).toBe("backwardation");
+    expect(data.termState).toBe("inverted");
     expect(data.ratio).toBeCloseTo(20 / 24);
     expect(data.slope).toBe(-4);
   });

--- a/src/plugins/builtin/volatility/model.ts
+++ b/src/plugins/builtin/volatility/model.ts
@@ -1,0 +1,113 @@
+import type {
+  CloudFredObservationPayload,
+  CloudFredSeriesInfoPayload,
+} from "../../../api-client";
+
+export const VOLATILITY_SERIES = [
+  { seriesId: "VIXCLS", label: "VIX", tenor: "30D" },
+  { seriesId: "VXVCLS", label: "VIX 3M", tenor: "3M" },
+] as const;
+
+export type VolatilitySeriesId = typeof VOLATILITY_SERIES[number]["seriesId"];
+export type TermState = "contango" | "backwardation" | "flat" | "partial";
+
+export interface VolatilitySeriesInput {
+  observations: CloudFredObservationPayload[];
+  info: CloudFredSeriesInfoPayload | null;
+}
+
+export interface VolatilityMetric {
+  seriesId: VolatilitySeriesId;
+  label: string;
+  tenor: string;
+  title: string;
+  value: number | null;
+  date: string | null;
+  history: Array<{ date: string; value: number }>;
+}
+
+export interface VolatilityData {
+  metrics: VolatilityMetric[];
+  termPoints: Array<{
+    seriesId: VolatilitySeriesId;
+    label: string;
+    tenor: string;
+    value: number | null;
+  }>;
+  termDate: string | null;
+  ratio: number | null;
+  slope: number | null;
+  ratioHistory: Array<{ date: string; value: number }>;
+  termState: TermState;
+}
+
+function normalizeObservations(
+  observations: CloudFredObservationPayload[],
+): Array<{ date: string; value: number }> {
+  return observations
+    .filter((observation): observation is { date: string; value: number } =>
+      /^\d{4}-\d{2}-\d{2}$/.test(observation.date)
+      && observation.value != null
+      && Number.isFinite(observation.value),
+    )
+    .sort((left, right) => left.date.localeCompare(right.date));
+}
+
+function metricFor(
+  definition: typeof VOLATILITY_SERIES[number],
+  input: VolatilitySeriesInput | undefined,
+): VolatilityMetric {
+  const history = normalizeObservations(input?.observations ?? []);
+  const latest = history.at(-1);
+  return {
+    ...definition,
+    title: input?.info?.title ?? definition.label,
+    value: latest?.value ?? null,
+    date: latest?.date ?? null,
+    history: history.slice(-60),
+  };
+}
+
+export function classifyTermState(
+  spot: number | null,
+  threeMonth: number | null,
+): TermState {
+  if (spot == null || threeMonth == null || spot === 0) return "partial";
+  if (threeMonth > spot) return "contango";
+  if (threeMonth < spot) return "backwardation";
+  return "flat";
+}
+
+export function buildVolatilityData(
+  inputs: Partial<Record<VolatilitySeriesId, VolatilitySeriesInput>>,
+): VolatilityData {
+  const metrics = VOLATILITY_SERIES.map((definition) =>
+    metricFor(definition, inputs[definition.seriesId]),
+  );
+  const spotByDate = new Map(metrics[0]!.history.map((point) => [point.date, point.value]));
+  const ratioHistory = metrics[1]!.history.flatMap((point) => {
+    const spot = spotByDate.get(point.date);
+    return spot == null || spot === 0
+      ? []
+      : [{ date: point.date, value: point.value / spot }];
+  });
+  const latestRatio = ratioHistory.at(-1);
+  const termDate = latestRatio?.date ?? null;
+  const spot = termDate == null ? null : spotByDate.get(termDate) ?? null;
+  const threeMonth = termDate == null
+    ? null
+    : metrics[1]!.history.find((point) => point.date === termDate)?.value ?? null;
+
+  return {
+    metrics,
+    termPoints: [
+      { ...VOLATILITY_SERIES[0], value: spot },
+      { ...VOLATILITY_SERIES[1], value: threeMonth },
+    ],
+    termDate,
+    ratio: latestRatio?.value ?? null,
+    slope: spot == null || threeMonth == null ? null : threeMonth - spot,
+    ratioHistory,
+    termState: classifyTermState(spot, threeMonth),
+  };
+}

--- a/src/plugins/builtin/volatility/model.ts
+++ b/src/plugins/builtin/volatility/model.ts
@@ -9,7 +9,7 @@ export const VOLATILITY_SERIES = [
 ] as const;
 
 export type VolatilitySeriesId = typeof VOLATILITY_SERIES[number]["seriesId"];
-export type TermState = "contango" | "backwardation" | "flat" | "partial";
+export type TermState = "normal" | "inverted" | "flat" | "partial";
 
 export interface VolatilitySeriesInput {
   observations: CloudFredObservationPayload[];
@@ -73,8 +73,8 @@ export function classifyTermState(
   threeMonth: number | null,
 ): TermState {
   if (spot == null || threeMonth == null || spot === 0) return "partial";
-  if (threeMonth > spot) return "contango";
-  if (threeMonth < spot) return "backwardation";
+  if (threeMonth > spot) return "normal";
+  if (threeMonth < spot) return "inverted";
   return "flat";
 }
 

--- a/src/renderers/electrobun/bun/desktop/http-fetch.test.ts
+++ b/src/renderers/electrobun/bun/desktop/http-fetch.test.ts
@@ -1,11 +1,21 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import {
+  connectionHealth,
+  registerGloomCloudConnectionSources,
+} from "../../../../core/connection-health";
 import { handleHttpFetch } from "./http-fetch";
 
 let server: ReturnType<typeof Bun.serve> | null = null;
+let disposeConnections: (() => void) | null = null;
+const originalApiUrl = process.env.GLOOMBERB_API_URL;
 
 afterEach(() => {
   server?.stop(true);
   server = null;
+  disposeConnections?.();
+  disposeConnections = null;
+  if (originalApiUrl === undefined) delete process.env.GLOOMBERB_API_URL;
+  else process.env.GLOOMBERB_API_URL = originalApiUrl;
 });
 
 describe("handleHttpFetch", () => {
@@ -38,6 +48,29 @@ describe("handleHttpFetch", () => {
     expect(response.status).toBe(302);
     expect(response.headers.location).toBe("/reader");
     expect(response.setCookie).toEqual(["substack.sid=sid123; Path=/; HttpOnly"]);
+  });
+
+  test("reports proxied Gloom FRED requests in the backend registry", async () => {
+    server = Bun.serve({
+      port: 0,
+      fetch: () => Response.json({ observations: [], info: null }),
+    });
+    process.env.GLOOMBERB_API_URL = server.url.origin;
+    disposeConnections = registerGloomCloudConnectionSources(connectionHealth);
+
+    await handleHttpFetch({
+      url: new URL("/cloud/econ/series/VIXCLS", server.url).toString(),
+    });
+
+    expect(connectionHealth.getSnapshot().sources.map((source) => ({
+      id: source.id,
+      status: source.status,
+      operation: source.lastOperation,
+    }))).toEqual([
+      { id: "gloom-cloud-http", status: "connected", operation: "GET /cloud/econ/series/VIXCLS" },
+      { id: "gloom-cloud-socket", status: "idle", operation: null },
+      { id: "gloom-cloud-fred", status: "connected", operation: "GET /cloud/econ/series/VIXCLS" },
+    ]);
   });
 
   test("aborts the backend fetch at the requested deadline", async () => {

--- a/src/renderers/electrobun/bun/desktop/http-fetch.ts
+++ b/src/renderers/electrobun/bun/desktop/http-fetch.ts
@@ -1,4 +1,37 @@
+import {
+  connectionHealth,
+  GLOOM_CLOUD_FRED_CONNECTION_ID,
+  GLOOM_CLOUD_HTTP_CONNECTION_ID,
+} from "../../../../core/connection-health";
 import type { DesktopBackendRequestPayload, DesktopHttpFetchResponse } from "../../shared/protocol";
+
+function isGloomCloudUrl(url: URL): boolean {
+  try {
+    return url.origin === new URL(process.env.GLOOMBERB_API_URL ?? "https://api.gloom.sh").origin;
+  } catch {
+    return false;
+  }
+}
+
+function reportCloudRequest(
+  url: URL,
+  method: string,
+  latencyMs: number,
+  success: boolean,
+  error?: unknown,
+): void {
+  if (!isGloomCloudUrl(url)) return;
+  const report = {
+    operation: `${method} ${url.pathname}`,
+    success,
+    latencyMs,
+    ...(error === undefined ? {} : { error }),
+  };
+  connectionHealth.reportRequest(GLOOM_CLOUD_HTTP_CONNECTION_ID, report);
+  if (url.pathname.startsWith("/cloud/econ/series/")) {
+    connectionHealth.reportRequest(GLOOM_CLOUD_FRED_CONNECTION_ID, report);
+  }
+}
 
 function normalizeHttpFetchHeaders(headers: unknown): Record<string, string> {
   if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
@@ -46,13 +79,27 @@ export async function handleHttpFetch(
       ? init.timeoutMs
       : undefined;
 
-  const response = await fetch(url, {
+  const startedAt = performance.now();
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method,
+      headers: normalizeHttpFetchHeaders(init.headers),
+      body,
+      redirect,
+      signal: timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined,
+    });
+  } catch (error) {
+    reportCloudRequest(url, method, performance.now() - startedAt, false, error);
+    throw error;
+  }
+  reportCloudRequest(
+    url,
     method,
-    headers: normalizeHttpFetchHeaders(init.headers),
-    body,
-    redirect,
-    signal: timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined,
-  });
+    performance.now() - startedAt,
+    response.ok,
+    response.ok ? undefined : new Error(`${response.status} ${response.statusText}`.trim()),
+  );
   const responseHeaders: Record<string, string> = {};
   response.headers.forEach((value, key) => {
     responseHeaders[key] = value;

--- a/src/renderers/electrobun/view/cli-pane-shot-health.test.ts
+++ b/src/renderers/electrobun/view/cli-pane-shot-health.test.ts
@@ -8,6 +8,7 @@ describe("CLI pane shot connection health", () => {
     expect(sources.map((source) => source.id)).toEqual([
       "gloom-cloud-http",
       "gloom-cloud-socket",
+      "gloom-cloud-fred",
       "asset-data.yahoo",
     ]);
     expect(sources.map((source) => ({
@@ -17,6 +18,7 @@ describe("CLI pane shot connection health", () => {
     }))).toEqual([
       { status: "connected", operation: "GET /market/quotes", latency: 84 },
       { status: "connected", operation: null, latency: null },
+      { status: "idle", operation: null, latency: null },
       { status: "error", operation: "getPriceHistory", latency: 240 },
     ]);
   });


### PR DESCRIPTION
## Summary

- add `VIX`, a truthful VIX 30-day/3-month implied-volatility curve and slope view
- add `CRD`, an ICE BofA corporate option-adjusted spread board from FRED
- show aligned daily closes, the 3M premium/discount, normal/inverted curve state, spread levels, and daily basis-point moves
- use stable Macro-owned persistent FRED caching with partial, stale, and error fallback
- report Gloom/FRED requests through Connections in terminal and Electrobun backend paths

## Data path

Companion platform PR [vincelwt/gloomberb-platform#77](https://github.com/vincelwt/gloomberb-platform/pull/77) allowlists only the exact required official series. It is merged and deployed to `api.gloom.sh`.

Live official-path validation succeeded for VIXCLS, VXVCLS, and six ICE BofA OAS series, all current through 2026-08-17. VXMTCLS was excluded because FRED returns 404.

## Product accuracy

This intentionally does not call the two-index view a VIX futures term structure and does not claim futures contango/backwardation. It reports the 30D/3M implied-volatility slope as normal or inverted. The credit pane is a spread/conditions board, not the fork's incomplete individual Bond Search.

## Verification

- `bun run typecheck`
- `bun test` (2,068 passed)
- live official Gloom/FRED checks for all eight series
- TUI VIX and CRD rendering, reload, footer, and runtime-warning smoke
- Electrobun desktop build and background GUI verification for both panes
- desktop backend FRED health-report regression test

## Attribution

The volatility and credit feature direction was first explored in @Lucas-Kohorst's [Gloomberb fork](https://github.com/Lucas-Kohorst/gloomberb). This PR validates and reframes it against the official Gloom data path.
