### PR TITLE
Add provider-neutral chart series capability

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -243,6 +243,7 @@ Plugins contribute data and services through capabilities. A capability declares
 
 - `asset-data` for quotes, financials, search, FX, price history, options, filings, holders, analyst research, corporate actions, earnings calendars, article summaries, and quote streams.
 - `news` for ticker and global news feeds.
+- `chart-series` for searchable provider-owned time series that resolve into normal chart data.
 - `plugin-service` for narrow renderer-safe service escape hatches.
 
 Capability operations can also include CLI manifest metadata. This is what makes the operation understandable to automation without plugin-specific documentation:

--- a/src/capabilities/chart-series.ts
+++ b/src/capabilities/chart-series.ts
@@ -1,0 +1,62 @@
+import type {
+  CapabilitySeriesSource,
+  ChartSeriesSpec,
+  ChartViewportSpec,
+  ResolvedSeries,
+} from "../time-series/types";
+import type {
+  CapabilityInvoker,
+  ChartSeriesCatalogItem,
+  ChartSeriesResolveRequest,
+} from "./types";
+
+export const CHART_SERIES_CAPABILITY_KIND = "chart-series";
+
+export function chartSeriesCapabilityManifests(invoker: CapabilityInvoker) {
+  return invoker.capabilityManifests(CHART_SERIES_CAPABILITY_KIND);
+}
+
+export async function searchChartSeriesCapabilities(
+  invoker: CapabilityInvoker,
+  query: string,
+  limit = 8,
+): Promise<Array<ChartSeriesCatalogItem & { capabilityId: string; capabilityName: string }>> {
+  const manifests = chartSeriesCapabilityManifests(invoker);
+  const results = await Promise.all(manifests.map(async (manifest) => {
+    try {
+      const items = await invoker.invokeCapability<ChartSeriesCatalogItem[]>(
+        manifest.id,
+        query.trim() ? "search" : "catalog",
+        { query, limit },
+      );
+      return items.map((item) => ({
+        ...item,
+        capabilityId: manifest.id,
+        capabilityName: manifest.name,
+      }));
+    } catch {
+      return [];
+    }
+  }));
+  return results.flat().slice(0, limit);
+}
+
+export function chartSeriesSourceKey(source: CapabilitySeriesSource): string {
+  return `${source.capabilityId}|${source.seriesId}|${JSON.stringify(source.parameters ?? {})}`;
+}
+
+export function createChartSeriesResolver(invoker: CapabilityInvoker) {
+  return async (
+    source: CapabilitySeriesSource,
+    viewport: ChartViewportSpec,
+    _spec: ChartSeriesSpec,
+  ): Promise<ResolvedSeries> => invoker.invokeCapability<ResolvedSeries>(
+    source.capabilityId,
+    "resolve",
+    {
+      seriesId: source.seriesId,
+      parameters: source.parameters,
+      viewport,
+    } satisfies ChartSeriesResolveRequest,
+  );
+}

--- a/src/capabilities/chart-series.ts
+++ b/src/capabilities/chart-series.ts
@@ -1,16 +1,256 @@
+import { debugLog } from "../utils/debug-log";
 import type {
   CapabilitySeriesSource,
   ChartSeriesSpec,
   ChartViewportSpec,
   ResolvedSeries,
+  SeriesStyle,
+  SeriesTimestampMode,
+  SeriesTransform,
+  TimeSeriesPoint,
 } from "../time-series/types";
 import type {
   CapabilityInvoker,
+  CapabilitySchema,
   ChartSeriesCatalogItem,
+  ChartSeriesCatalogRequest,
   ChartSeriesResolveRequest,
 } from "./types";
 
 export const CHART_SERIES_CAPABILITY_KIND = "chart-series";
+export const MAX_CHART_SERIES_CATALOG_ITEMS = 32;
+export const MAX_CHART_SERIES_POINTS = 20_000;
+
+const CAPABILITY_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/;
+const SERIES_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._~%:/-]{0,239}$/;
+const chartSeriesLog = debugLog.createLogger("chart-series");
+const ranges = new Set(["1D", "1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"]);
+const resolutions = new Set(["auto", "1m", "5m", "15m", "30m", "45m", "1h", "1d", "1wk", "1mo"]);
+const periods = new Set(["auto", "daily", "weekly", "monthly", "quarterly", "annual", "ttm"]);
+const styles = new Set(["line", "area", "step", "columns", "points", "candles", "ohlc", "hlc"]);
+const transforms = new Set(["raw", "percent", "index100", "yoy", "qoq", "log"]);
+const shapes = new Set(["scalar", "ohlcv", "event", "band"]);
+const axes = new Set(["left", "right"]);
+const interpolations = new Set(["none", "step-after"]);
+
+export function isValidChartCapabilityId(value: string): boolean {
+  return CAPABILITY_ID_PATTERN.test(value);
+}
+
+export function isValidChartSeriesId(value: string): boolean {
+  return SERIES_ID_PATTERN.test(value);
+}
+
+function fail(path: string, message: string): never {
+  throw new Error(`Invalid chart series ${path}: ${message}`);
+}
+
+function object(value: unknown, path: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(path, "expected an object.");
+  return value as Record<string, unknown>;
+}
+
+function onlyKeys(input: Record<string, unknown>, path: string, allowed: readonly string[]): void {
+  const extra = Object.keys(input).find((key) => !allowed.includes(key));
+  if (extra) fail(path, `unsupported field "${extra}".`);
+}
+
+function boundedString(value: unknown, path: string, max: number): string {
+  if (typeof value !== "string" || value.length === 0 || value.length > max) {
+    fail(path, `expected a non-empty string of at most ${max} characters.`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown, path: string, max: number): string | undefined {
+  return value === undefined ? undefined : boundedString(value, path, max);
+}
+
+function enumValue<T extends string>(value: unknown, path: string, allowed: Set<string>): T {
+  if (typeof value !== "string" || !allowed.has(value)) fail(path, `unsupported value ${String(value)}.`);
+  return value as T;
+}
+
+function finiteNumber(value: unknown, path: string, nullable = false): number | null {
+  if (nullable && value === null) return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) fail(path, "expected a finite number.");
+  return value;
+}
+
+function optionalNumber(value: unknown, path: string, nullable = false): number | null | undefined {
+  return value === undefined ? undefined : finiteNumber(value, path, nullable);
+}
+
+function dateValue(value: unknown, path: string): Date {
+  const date = value instanceof Date ? new Date(value) : new Date(value as string | number);
+  if (!Number.isFinite(date.getTime())) fail(path, "expected a valid date.");
+  return date;
+}
+
+function catalogRequest(value: unknown): ChartSeriesCatalogRequest {
+  const input = object(value, "catalog request");
+  onlyKeys(input, "catalog request", ["query", "limit"]);
+  const query = input.query === undefined ? undefined : optionalString(input.query, "catalog query", 200);
+  const limit = input.limit === undefined ? 8 : input.limit;
+  if (!Number.isInteger(limit) || (limit as number) < 1 || (limit as number) > MAX_CHART_SERIES_CATALOG_ITEMS) {
+    fail("catalog limit", `expected an integer from 1 to ${MAX_CHART_SERIES_CATALOG_ITEMS}.`);
+  }
+  return { ...(query !== undefined ? { query } : {}), limit: limit as number };
+}
+
+function viewport(value: unknown): ChartViewportSpec {
+  const input = object(value, "resolve viewport");
+  onlyKeys(input, "resolve viewport", ["range", "resolution", "dateWindow", "maxPoints"]);
+  const range = enumValue<ChartViewportSpec["range"]>(input.range, "viewport range", ranges);
+  const resolution = enumValue<ChartViewportSpec["resolution"]>(input.resolution, "viewport resolution", resolutions);
+  let dateWindow: ChartViewportSpec["dateWindow"];
+  if (input.dateWindow !== undefined) {
+    const window = object(input.dateWindow, "viewport date window");
+    onlyKeys(window, "viewport date window", ["start", "end"]);
+    const start = boundedString(window.start, "viewport start", 40);
+    const end = boundedString(window.end, "viewport end", 40);
+    const startTime = Date.parse(start);
+    const endTime = Date.parse(end);
+    if (!Number.isFinite(startTime) || !Number.isFinite(endTime) || startTime > endTime) {
+      fail("viewport date window", "expected valid ordered bounds.");
+    }
+    dateWindow = { start, end };
+  }
+  let maxPoints: number | undefined;
+  if (input.maxPoints !== undefined) {
+    if (!Number.isInteger(input.maxPoints) || (input.maxPoints as number) < 1 || (input.maxPoints as number) > 10_000) {
+      fail("viewport maxPoints", "expected an integer from 1 to 10000.");
+    }
+    maxPoints = input.maxPoints as number;
+  }
+  return { range, resolution, ...(dateWindow ? { dateWindow } : {}), ...(maxPoints ? { maxPoints } : {}) };
+}
+
+function resolveRequest(value: unknown): ChartSeriesResolveRequest {
+  const input = object(value, "resolve request");
+  onlyKeys(input, "resolve request", ["seriesId", "viewport"]);
+  const seriesId = boundedString(input.seriesId, "series ID", 240);
+  if (!isValidChartSeriesId(seriesId)) fail("series ID", "contains unsupported characters.");
+  return { seriesId, viewport: viewport(input.viewport) };
+}
+
+function catalogItem(value: unknown, index: number): ChartSeriesCatalogItem {
+  const item = object(value, `catalog item ${index}`);
+  onlyKeys(item, `catalog item ${index}`, ["seriesId", "label", "description", "detail", "style", "transform"]);
+  const seriesId = boundedString(item.seriesId, `catalog item ${index} series ID`, 240);
+  if (!isValidChartSeriesId(seriesId)) fail(`catalog item ${index} series ID`, "contains unsupported characters.");
+  return {
+    seriesId,
+    label: boundedString(item.label, `catalog item ${index} label`, 160),
+    ...(optionalString(item.description, `catalog item ${index} description`, 500) !== undefined
+      ? { description: item.description as string }
+      : {}),
+    ...(optionalString(item.detail, `catalog item ${index} detail`, 100) !== undefined
+      ? { detail: item.detail as string }
+      : {}),
+    ...(item.style !== undefined ? { style: enumValue<SeriesStyle>(item.style, `catalog item ${index} style`, styles) } : {}),
+    ...(item.transform !== undefined ? { transform: enumValue<SeriesTransform>(item.transform, `catalog item ${index} transform`, transforms) } : {}),
+  };
+}
+
+function catalogOutput(value: unknown): ChartSeriesCatalogItem[] {
+  if (!Array.isArray(value)) fail("catalog output", "expected an array.");
+  if (value.length > MAX_CHART_SERIES_CATALOG_ITEMS) {
+    fail("catalog output", `returned ${value.length} items; maximum is ${MAX_CHART_SERIES_CATALOG_ITEMS}.`);
+  }
+  return value.map(catalogItem);
+}
+
+function point(value: unknown, index: number): TimeSeriesPoint {
+  const input = object(value, `point ${index}`);
+  onlyKeys(input, `point ${index}`, [
+    "date", "observedAt", "availableAt", "value", "open", "high", "low", "close", "volume", "periodLabel", "provenance",
+  ]);
+  const provenance = input.provenance === undefined ? undefined : object(input.provenance, `point ${index} provenance`);
+  if (provenance) onlyKeys(provenance, `point ${index} provenance`, ["providerId", "quality"]);
+  const quality = provenance?.quality === undefined
+    ? undefined
+    : enumValue<"reported" | "derived" | "estimated">(
+        provenance.quality,
+        `point ${index} provenance quality`,
+        new Set(["reported", "derived", "estimated"]),
+      );
+  return {
+    date: dateValue(input.date, `point ${index} date`),
+    observedAt: dateValue(input.observedAt, `point ${index} observedAt`),
+    ...(input.availableAt !== undefined ? { availableAt: dateValue(input.availableAt, `point ${index} availableAt`) } : {}),
+    value: finiteNumber(input.value, `point ${index} value`, true),
+    ...(input.open !== undefined ? { open: optionalNumber(input.open, `point ${index} open`, true) } : {}),
+    ...(input.high !== undefined ? { high: optionalNumber(input.high, `point ${index} high`, true) } : {}),
+    ...(input.low !== undefined ? { low: optionalNumber(input.low, `point ${index} low`, true) } : {}),
+    ...(input.close !== undefined ? { close: optionalNumber(input.close, `point ${index} close`, true) } : {}),
+    ...(input.volume !== undefined ? { volume: optionalNumber(input.volume, `point ${index} volume`, true) } : {}),
+    ...(input.periodLabel !== undefined ? { periodLabel: boundedString(input.periodLabel, `point ${index} period label`, 120) } : {}),
+    ...(provenance ? {
+      provenance: {
+        ...(provenance.providerId !== undefined
+          ? { providerId: boundedString(provenance.providerId, `point ${index} provider ID`, 80) }
+          : {}),
+        ...(quality ? { quality } : {}),
+      },
+    } : {}),
+  };
+}
+
+function resolvedOutput(value: unknown): ResolvedSeries {
+  const input = object(value, "resolve output");
+  onlyKeys(input, "resolve output", [
+    "id", "label", "color", "unit", "unitGroup", "nativeFrequency", "timestampMode", "dataShape", "style", "transform",
+    "axis", "panelId", "interpolation", "timeBasis", "latestChangePercent", "points", "warning", "hidden",
+  ]);
+  if (!Array.isArray(input.points)) fail("resolve output points", "expected an array.");
+  if (input.points.length > MAX_CHART_SERIES_POINTS) {
+    fail("resolve output points", `returned ${input.points.length} points; maximum is ${MAX_CHART_SERIES_POINTS}.`);
+  }
+  const timeBasis = input.timeBasis === undefined ? undefined : object(input.timeBasis, "resolve output time basis");
+  if (timeBasis) onlyKeys(timeBasis, "resolve output time basis", ["kind", "timeZone", "cadenceMs"]);
+  const kind = timeBasis?.kind === undefined ? undefined : enumValue<"market">(timeBasis.kind, "time basis kind", new Set(["market"]));
+  const warning = optionalString(input.warning, "resolve output warning", 500);
+  return {
+    id: boundedString(input.id, "resolve output ID", 160),
+    label: boundedString(input.label, "resolve output label", 160),
+    color: boundedString(input.color, "resolve output color", 64),
+    unit: typeof input.unit === "string" && input.unit.length <= 64 ? input.unit : fail("resolve output unit", "expected a string of at most 64 characters."),
+    unitGroup: boundedString(input.unitGroup, "resolve output unit group", 64),
+    nativeFrequency: enumValue(input.nativeFrequency, "resolve output frequency", periods),
+    ...(input.timestampMode !== undefined
+      ? { timestampMode: enumValue<SeriesTimestampMode>(input.timestampMode, "resolve output timestamp mode", new Set(["available-at", "period-end"])) }
+      : {}),
+    dataShape: enumValue(input.dataShape, "resolve output data shape", shapes),
+    style: enumValue(input.style, "resolve output style", styles),
+    transform: enumValue(input.transform, "resolve output transform", transforms),
+    axis: enumValue(input.axis, "resolve output axis", axes),
+    panelId: boundedString(input.panelId, "resolve output panel ID", 80),
+    interpolation: enumValue(input.interpolation, "resolve output interpolation", interpolations),
+    ...(timeBasis ? {
+      timeBasis: {
+        kind: kind!,
+        timeZone: boundedString(timeBasis.timeZone, "time basis timezone", 80),
+        ...(timeBasis.cadenceMs !== undefined
+          ? { cadenceMs: finiteNumber(timeBasis.cadenceMs, "time basis cadence") as number }
+          : {}),
+      },
+    } : {}),
+    ...(input.latestChangePercent !== undefined
+      ? { latestChangePercent: finiteNumber(input.latestChangePercent, "resolve output latest change") as number }
+      : {}),
+    points: input.points.map(point),
+    ...(warning !== undefined ? { warning } : {}),
+    ...(input.hidden !== undefined
+      ? typeof input.hidden === "boolean" ? { hidden: input.hidden } : fail("resolve output hidden", "expected a boolean.")
+      : {}),
+  };
+}
+
+export const chartSeriesCatalogRequestSchema: CapabilitySchema<ChartSeriesCatalogRequest> = { parse: catalogRequest };
+export const chartSeriesCatalogOutputSchema: CapabilitySchema<ChartSeriesCatalogItem[]> = { parse: catalogOutput };
+export const chartSeriesResolveRequestSchema: CapabilitySchema<ChartSeriesResolveRequest> = { parse: resolveRequest };
+export const chartSeriesResolveOutputSchema: CapabilitySchema<ResolvedSeries> = { parse: resolvedOutput };
 
 export function chartSeriesCapabilityManifests(invoker: CapabilityInvoker) {
   return invoker.capabilityManifests(CHART_SERIES_CAPABILITY_KIND);
@@ -20,29 +260,49 @@ export async function searchChartSeriesCapabilities(
   invoker: CapabilityInvoker,
   query: string,
   limit = 8,
+  signal?: AbortSignal,
 ): Promise<Array<ChartSeriesCatalogItem & { capabilityId: string; capabilityName: string }>> {
   const manifests = chartSeriesCapabilityManifests(invoker);
-  const results = await Promise.all(manifests.map(async (manifest) => {
-    try {
-      const items = await invoker.invokeCapability<ChartSeriesCatalogItem[]>(
-        manifest.id,
-        query.trim() ? "search" : "catalog",
-        { query, limit },
-      );
-      return items.map((item) => ({
-        ...item,
-        capabilityId: manifest.id,
-        capabilityName: manifest.name,
-      }));
-    } catch {
-      return [];
-    }
+  const results = await Promise.allSettled(manifests.map(async (manifest) => {
+    const items = await invoker.invokeCapability<ChartSeriesCatalogItem[]>(
+      manifest.id,
+      query.trim() ? "search" : "catalog",
+      { query, limit },
+      { signal },
+    );
+    return items.map((item) => ({
+      ...item,
+      capabilityId: manifest.id,
+      capabilityName: manifest.name,
+    }));
   }));
-  return results.flat().slice(0, limit);
+  if (signal?.aborted) throw signal.reason ?? new DOMException("Aborted", "AbortError");
+  for (const [index, result] of results.entries()) {
+    if (result.status === "rejected") {
+      chartSeriesLog.warn("Chart series provider catalog failed", {
+        capabilityId: manifests[index]?.id,
+        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+      });
+    }
+  }
+  return results.flatMap((result) => result.status === "fulfilled" ? result.value : []).slice(0, limit);
 }
 
-export function chartSeriesSourceKey(source: CapabilitySeriesSource): string {
-  return `${source.capabilityId}|${source.seriesId}|${JSON.stringify(source.parameters ?? {})}`;
+export function chartSeriesSourceKey(
+  source: CapabilitySeriesSource,
+  viewport?: ChartViewportSpec,
+): string {
+  return JSON.stringify([
+    "chart-series",
+    source.capabilityId,
+    source.seriesId,
+    viewport ? {
+      range: viewport.range,
+      resolution: viewport.resolution,
+      dateWindow: viewport.dateWindow ?? null,
+      maxPoints: viewport.maxPoints ?? null,
+    } : null,
+  ]);
 }
 
 export function createChartSeriesResolver(invoker: CapabilityInvoker) {
@@ -53,10 +313,6 @@ export function createChartSeriesResolver(invoker: CapabilityInvoker) {
   ): Promise<ResolvedSeries> => invoker.invokeCapability<ResolvedSeries>(
     source.capabilityId,
     "resolve",
-    {
-      seriesId: source.seriesId,
-      parameters: source.parameters,
-      viewport,
-    } satisfies ChartSeriesResolveRequest,
+    { seriesId: source.seriesId, viewport } satisfies ChartSeriesResolveRequest,
   );
 }

--- a/src/capabilities/factories.ts
+++ b/src/capabilities/factories.ts
@@ -3,6 +3,8 @@ import type { NewsDataProvider } from "../types/capability-route-source";
 import type {
   AssetDataCapability,
   CapabilityOperation,
+  ChartSeriesCapability,
+  ChartSeriesProvider,
   NewsCapability,
 } from "./types";
 
@@ -80,6 +82,26 @@ export function assetDataProvider(provider: AssetDataProvider): AssetDataCapabil
         if (!provider.subscribeQuotes) throw new Error(`${provider.name} does not provide quote streaming.`);
         return provider.subscribeQuotes(input.targets ?? [], (target, quote) => emit({ target, quote }));
       }),
+    },
+  };
+}
+
+export function chartSeriesProvider(options: {
+  id: string;
+  name: string;
+  priority?: number;
+  provider: ChartSeriesProvider;
+}): ChartSeriesCapability {
+  return {
+    id: options.id,
+    kind: "chart-series",
+    name: options.name,
+    priority: options.priority,
+    provider: options.provider,
+    operations: {
+      catalog: op((input: any) => options.provider.catalog?.(input) ?? [], "query"),
+      search: op((input: any) => options.provider.search?.(input) ?? options.provider.catalog?.(input) ?? [], "query"),
+      resolve: op((input: any) => options.provider.resolve(input), "query"),
     },
   };
 }

--- a/src/capabilities/factories.ts
+++ b/src/capabilities/factories.ts
@@ -1,5 +1,12 @@
 import type { AssetDataProvider } from "../types/data-provider";
 import type { NewsDataProvider } from "../types/capability-route-source";
+import {
+  chartSeriesCatalogOutputSchema,
+  chartSeriesCatalogRequestSchema,
+  chartSeriesResolveOutputSchema,
+  chartSeriesResolveRequestSchema,
+  isValidChartCapabilityId,
+} from "./chart-series";
 import type {
   AssetDataCapability,
   CapabilityOperation,
@@ -92,6 +99,9 @@ export function chartSeriesProvider(options: {
   priority?: number;
   provider: ChartSeriesProvider;
 }): ChartSeriesCapability {
+  if (!isValidChartCapabilityId(options.id)) {
+    throw new Error(`Invalid chart series capability ID "${options.id}".`);
+  }
   return {
     id: options.id,
     kind: "chart-series",
@@ -99,9 +109,23 @@ export function chartSeriesProvider(options: {
     priority: options.priority,
     provider: options.provider,
     operations: {
-      catalog: op((input: any) => options.provider.catalog?.(input) ?? [], "query"),
-      search: op((input: any) => options.provider.search?.(input) ?? options.provider.catalog?.(input) ?? [], "query"),
-      resolve: op((input: any) => options.provider.resolve(input), "query"),
+      catalog: {
+        ...op((input: any, ctx) => options.provider.catalog?.({ ...input, signal: ctx.signal }) ?? [], "query"),
+        input: chartSeriesCatalogRequestSchema,
+        output: chartSeriesCatalogOutputSchema,
+      },
+      search: {
+        ...op((input: any, ctx) => options.provider.search?.({ ...input, signal: ctx.signal })
+          ?? options.provider.catalog?.({ ...input, signal: ctx.signal })
+          ?? [], "query"),
+        input: chartSeriesCatalogRequestSchema,
+        output: chartSeriesCatalogOutputSchema,
+      },
+      resolve: {
+        ...op((input: any) => options.provider.resolve(input), "query"),
+        input: chartSeriesResolveRequestSchema,
+        output: chartSeriesResolveOutputSchema,
+      },
     },
   };
 }

--- a/src/capabilities/factories.ts
+++ b/src/capabilities/factories.ts
@@ -122,7 +122,7 @@ export function chartSeriesProvider(options: {
         output: chartSeriesCatalogOutputSchema,
       },
       resolve: {
-        ...op((input: any) => options.provider.resolve(input), "query"),
+        ...op((input: any, ctx) => options.provider.resolve({ ...input, signal: ctx.signal }), "query"),
         input: chartSeriesResolveRequestSchema,
         output: chartSeriesResolveOutputSchema,
       },

--- a/src/capabilities/index.ts
+++ b/src/capabilities/index.ts
@@ -2,3 +2,4 @@ export * from "./types";
 export * from "./registry";
 export * from "./factories";
 export * from "./service-capabilities";
+export * from "./chart-series";

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -230,6 +230,50 @@ describe("CapabilityRegistry", () => {
     await expect(registry.invoke("charts.test", "search", {})).rejects.toThrow("not available");
   });
 
+  test("rejects unsafe chart-series requests and provider output before rendering", async () => {
+    const registry = new CapabilityRegistry();
+    registry.register("charts", chartSeriesProvider({
+      id: "charts.unsafe",
+      name: "Unsafe Charts",
+      provider: {
+        catalog: () => [{ seriesId: "ok", label: "x".repeat(161) }],
+        resolve: ({ seriesId }) => ({
+          id: seriesId,
+          label: "Unsafe",
+          color: "#ffffff",
+          unit: "value",
+          unitGroup: "value",
+          nativeFrequency: "daily",
+          dataShape: "scalar",
+          style: "line",
+          transform: "raw",
+          axis: "left",
+          panelId: "main",
+          interpolation: "none",
+          points: [{ date: new Date("invalid"), observedAt: new Date(), value: 1 }],
+        }),
+      },
+    }));
+
+    await expect(registry.invoke("charts.unsafe", "catalog", { query: "x".repeat(201), limit: 8 }, { renderer: true }))
+      .rejects.toThrow("catalog query");
+    await expect(registry.invoke("charts.unsafe", "catalog", { query: "x", limit: 8 }, { renderer: true }))
+      .rejects.toThrow("catalog item 0 label");
+    await expect(registry.invoke("charts.unsafe", "resolve", {
+      seriesId: "bad?query",
+      viewport: { range: "1M", resolution: "auto" },
+    }, { renderer: true })).rejects.toThrow("series ID");
+    await expect(registry.invoke("charts.unsafe", "resolve", {
+      seriesId: "safe-id",
+      parameters: {},
+      viewport: { range: "1M", resolution: "auto" },
+    }, { renderer: true })).rejects.toThrow('unsupported field "parameters"');
+    await expect(registry.invoke("charts.unsafe", "resolve", {
+      seriesId: "safe-id",
+      viewport: { range: "1M", resolution: "auto" },
+    }, { renderer: true })).rejects.toThrow("point 0 date");
+  });
+
   test("disposes subscriptions that finish after their capability is removed", async () => {
     const registry = new CapabilityRegistry();
     let finishSubscribe!: (dispose: () => void) => void;

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { chartSeriesProvider } from "./factories";
 import { CapabilityRegistry } from "./registry";
 import { ConnectionHealthRegistry } from "../core/connection-health";
 import type { CapabilitySchema, PluginCapability } from "./types";
@@ -186,6 +187,47 @@ describe("CapabilityRegistry", () => {
     expect(events).toEqual(["first", "second"]);
     expect(disposed).toBe(2);
     expect(registry.list()).toEqual([]);
+  });
+
+  test("registers, searches, resolves, disables, and disposes chart-series providers", async () => {
+    let enabled = true;
+    const registry = new CapabilityRegistry({ isPluginEnabled: () => enabled });
+    const dispose = registry.register("charts", chartSeriesProvider({
+      id: "charts.test",
+      name: "Test Charts",
+      provider: {
+        search: ({ query }) => [{ seriesId: "one", label: `Result ${query}` }],
+        resolve: ({ seriesId }) => ({
+          id: seriesId,
+          label: "Resolved",
+          color: "#fff",
+          unit: "value",
+          unitGroup: "value",
+          nativeFrequency: "daily",
+          dataShape: "scalar",
+          style: "line",
+          transform: "raw",
+          axis: "left",
+          panelId: "main",
+          interpolation: "none",
+          points: [{ date: new Date("2026-01-01"), observedAt: new Date("2026-01-01"), value: 1 }],
+        }),
+      },
+    }));
+
+    await expect(registry.invoke<any[]>("charts.test", "search", { query: "x" }))
+      .resolves.toEqual([{ seriesId: "one", label: "Result x" }]);
+    await expect(registry.invoke<any>("charts.test", "resolve", {
+      seriesId: "one",
+      viewport: { range: "1M", resolution: "auto" },
+    })).resolves.toMatchObject({ id: "one", points: [{ value: 1 }] });
+
+    enabled = false;
+    expect(registry.list("chart-series")).toEqual([]);
+    await expect(registry.invoke("charts.test", "search", {})).rejects.toThrow("not available");
+    enabled = true;
+    dispose();
+    await expect(registry.invoke("charts.test", "search", {})).rejects.toThrow("not available");
   });
 
   test("disposes subscriptions that finish after their capability is removed", async () => {

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -66,8 +66,17 @@ export class CapabilityRegistry {
       ));
   }
 
-  manifests({ rendererOnly = false }: { rendererOnly?: boolean } = {}): CapabilityManifest[] {
-    return this.list().map(({ capability }) => {
+  manifests({
+    rendererOnly = false,
+    includeDisabled = false,
+  }: { rendererOnly?: boolean; includeDisabled?: boolean } = {}): CapabilityManifest[] {
+    const entries = includeDisabled
+      ? [...this.capabilities.values()].sort((left, right) => (
+          (left.capability.priority ?? 1000) - (right.capability.priority ?? 1000)
+          || left.capability.id.localeCompare(right.capability.id)
+        ))
+      : this.list();
+    return entries.map(({ capability }) => {
       const operations: CapabilityOperationManifest[] = Object.entries(capability.operations)
         .filter(([, operation]) => !rendererOnly || operation.rendererSafe === true)
         .map(([id, operation]) => ({
@@ -91,12 +100,17 @@ export class CapabilityRegistry {
     capabilityId: string,
     operationId: string,
     payload: unknown,
-    options: { renderer?: boolean } = {},
+    options: { renderer?: boolean; signal?: AbortSignal } = {},
   ): Promise<T> {
     const { capability, operation } = this.resolveOperation(capabilityId, operationId, options);
     if (!operation.handler) throw new Error(`Capability operation "${capabilityId}.${operationId}" is not invokable.`);
+    options.signal?.throwIfAborted();
     const input = (operation.input ?? recordSchema).parse(payload);
-    const invoke = () => Promise.resolve(operation.handler!(input, { capability, operationId }));
+    const invoke = () => Promise.resolve(operation.handler!(input, {
+      capability,
+      operationId,
+      signal: options.signal,
+    }));
     const health = this.options.connectionHealth;
     const result = health?.hasSource(capabilityId) && !LOCAL_READ_OPERATIONS.has(operationId)
       ? await health.track(capabilityId, operationId, invoke)

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -92,6 +92,7 @@ export interface ChartSeriesCatalogRequest {
 export interface ChartSeriesResolveRequest {
   seriesId: string;
   viewport: ChartViewportSpec;
+  signal?: AbortSignal;
 }
 
 export interface ChartSeriesProvider {

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -3,7 +3,6 @@ import type { ConnectionHealthRegistry } from "../core/connection-health";
 import type { AssetDataProvider } from "../types/data-provider";
 import type { NewsDataProvider } from "../types/capability-route-source";
 import type {
-  CapabilitySeriesSource,
   ChartViewportSpec,
   ResolvedSeries,
   SeriesStyle,
@@ -26,6 +25,7 @@ export interface CapabilitySchema<T = unknown> {
 interface CapabilityHandlerContext {
   capability: PluginCapability;
   operationId: string;
+  signal?: AbortSignal;
 }
 
 type CapabilityStreamEmit<T = unknown> = (event: T) => void;
@@ -79,7 +79,6 @@ export interface ChartSeriesCatalogItem {
   label: string;
   description?: string;
   detail?: string;
-  parameters?: CapabilitySeriesSource["parameters"];
   style?: SeriesStyle;
   transform?: SeriesTransform;
 }
@@ -87,11 +86,11 @@ export interface ChartSeriesCatalogItem {
 export interface ChartSeriesCatalogRequest {
   query?: string;
   limit?: number;
+  signal?: AbortSignal;
 }
 
 export interface ChartSeriesResolveRequest {
   seriesId: string;
-  parameters?: CapabilitySeriesSource["parameters"];
   viewport: ChartViewportSpec;
 }
 
@@ -138,7 +137,12 @@ export interface CapabilityRegistryOptions {
 
 export interface CapabilityInvoker {
   capabilityManifests(kind?: string): CapabilityManifest[];
-  invokeCapability<T = unknown>(capabilityId: string, operationId: string, payload: unknown): Promise<T>;
+  invokeCapability<T = unknown>(
+    capabilityId: string,
+    operationId: string,
+    payload: unknown,
+    options?: { signal?: AbortSignal },
+  ): Promise<T>;
 }
 
 export interface RegisteredCapability {

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -2,6 +2,13 @@ import type { CachePolicyMap } from "../types/persistence";
 import type { ConnectionHealthRegistry } from "../core/connection-health";
 import type { AssetDataProvider } from "../types/data-provider";
 import type { NewsDataProvider } from "../types/capability-route-source";
+import type {
+  CapabilitySeriesSource,
+  ChartViewportSpec,
+  ResolvedSeries,
+  SeriesStyle,
+  SeriesTransform,
+} from "../time-series/types";
 
 type CapabilityOperationKind = "read" | "query" | "action" | "stream";
 type CapabilitySideEffectLevel = "none" | "local-write" | "network-write" | "external-trade" | "external-side-effect";
@@ -9,6 +16,7 @@ type CapabilitySideEffectLevel = "none" | "local-write" | "network-write" | "ext
 type CapabilityKind =
   | "asset-data"
   | "news"
+  | "chart-series"
   | "plugin-service";
 
 export interface CapabilitySchema<T = unknown> {
@@ -66,6 +74,38 @@ export interface NewsCapability extends PluginCapability {
   readonly provider: NewsDataProvider;
 }
 
+export interface ChartSeriesCatalogItem {
+  seriesId: string;
+  label: string;
+  description?: string;
+  detail?: string;
+  parameters?: CapabilitySeriesSource["parameters"];
+  style?: SeriesStyle;
+  transform?: SeriesTransform;
+}
+
+export interface ChartSeriesCatalogRequest {
+  query?: string;
+  limit?: number;
+}
+
+export interface ChartSeriesResolveRequest {
+  seriesId: string;
+  parameters?: CapabilitySeriesSource["parameters"];
+  viewport: ChartViewportSpec;
+}
+
+export interface ChartSeriesProvider {
+  catalog?(request: ChartSeriesCatalogRequest): Promise<ChartSeriesCatalogItem[]> | ChartSeriesCatalogItem[];
+  search?(request: ChartSeriesCatalogRequest): Promise<ChartSeriesCatalogItem[]> | ChartSeriesCatalogItem[];
+  resolve(request: ChartSeriesResolveRequest): Promise<ResolvedSeries> | ResolvedSeries;
+}
+
+export interface ChartSeriesCapability extends PluginCapability {
+  readonly kind: "chart-series";
+  readonly provider: ChartSeriesProvider;
+}
+
 export interface CapabilityOperationManifest {
   id: string;
   kind: CapabilityOperationKind;
@@ -94,6 +134,11 @@ export interface CapabilityRegistryOptions {
   isPluginEnabled?(pluginId: string): boolean;
   isCapabilityEnabled?(capability: PluginCapability, pluginId: string): boolean;
   connectionHealth?: ConnectionHealthRegistry;
+}
+
+export interface CapabilityInvoker {
+  capabilityManifests(kind?: string): CapabilityManifest[];
+  invokeCapability<T = unknown>(capabilityId: string, operationId: string, payload: unknown): Promise<T>;
 }
 
 export interface RegisteredCapability {

--- a/src/cli/desktop-pane-shot.ts
+++ b/src/cli/desktop-pane-shot.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { pathToFileURL } from "url";
 import type { AppConfig } from "../types/config";
+import type { ResolvedSeries } from "../time-series/types";
 import type { OptionsChain, TickerFinancials } from "../types/financials";
 import type { TickerRecord } from "../types/ticker";
 import type { PaneRuntimeState } from "../core/state/app/state";
@@ -24,6 +25,7 @@ export interface DesktopPaneShotPayload {
   financials: Array<[string, TickerFinancials]>;
   optionsChains: Array<[string, OptionsChain]>;
   fredSeries: Array<[string, FredSeriesCacheEntry]>;
+  capabilitySeries: Array<[string, ResolvedSeries]>;
   paneState: Record<string, PaneRuntimeState>;
 }
 

--- a/src/cli/pane-functions/report.test.ts
+++ b/src/cli/pane-functions/report.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, expect, test } from "bun:test";
+import { createDefaultConfig } from "../../types/config";
+import { CHART_SPEC_VERSION, type ChartSpec } from "../../time-series/types";
+import { createTestDataProvider } from "../../test-support/data-provider";
+import { setSharedRegistryForTests } from "../../plugins/registry";
+import { buildFunctionReport } from "./report";
+import type { ResolvedPaneFunction } from "./resolver";
+import type { MarketContext } from "../types";
+
+const spec: ChartSpec = {
+  version: CHART_SPEC_VERSION,
+  viewport: { range: "1M", resolution: "auto" },
+  panels: [{ id: "main" }],
+  series: [{
+    id: "prediction",
+    source: { kind: "capability", capabilityId: "prediction.series", seriesId: "market-one" },
+    style: "area",
+    transform: "raw",
+    axis: "auto",
+    panelId: "main",
+    interpolation: "none",
+  }],
+  studies: [],
+};
+
+afterEach(() => setSharedRegistryForTests(undefined));
+
+test("chart composer reports accept capability-backed series", async () => {
+  const date = new Date(Date.now() - 24 * 60 * 60 * 1_000);
+  setSharedRegistryForTests({
+    capabilityManifests: () => [{
+      id: "prediction.series",
+      kind: "chart-series",
+      name: "Prediction",
+      operations: [{ id: "resolve", kind: "query", rendererSafe: true }],
+    }],
+    invokeCapability: async () => ({
+      id: "provider-id",
+      label: "Prediction",
+      color: "#fff",
+      unit: "probability",
+      unitGroup: "probability",
+      nativeFrequency: "daily",
+      dataShape: "scalar",
+      style: "line",
+      transform: "raw",
+      axis: "left",
+      panelId: "main",
+      interpolation: "none",
+      points: [{ date, observedAt: date, value: 0.62 }],
+    }),
+  } as any);
+  const resolved = {
+    token: "chart-composer",
+    label: "Chart Composer",
+    description: "",
+    pane: { id: "chart-composer", name: "Chart Composer" },
+    instance: { settings: { chartSpec: spec } },
+    capability: { id: "chart-composer", reportReadiness: "ready" },
+  } as unknown as ResolvedPaneFunction;
+  const context = {
+    config: createDefaultConfig("/tmp/gloomberb-chart-report"),
+    dataProvider: createTestDataProvider(),
+    store: { loadTicker: async () => null },
+  } as unknown as MarketContext;
+
+  const report = await buildFunctionReport(resolved, context, "");
+  expect(report.data).toMatchObject({
+    kind: "chart-composer",
+    complete: true,
+    empty: false,
+    unavailableSymbols: [],
+    rowCount: 1,
+  });
+  expect(report.text).toContain("Prediction");
+});

--- a/src/cli/pane-functions/report.ts
+++ b/src/cli/pane-functions/report.ts
@@ -29,6 +29,8 @@ import { publicTickerKey } from "../../utils/exchanges";
 import { apiClient } from "../../api-client";
 import { parseChartSpec } from "../../plugins/builtin/chart-composer/chart-spec";
 import { resolveChartSpecData } from "../../time-series/resolve";
+import { createChartSeriesResolver } from "../../capabilities";
+import { getSharedRegistry } from "../../plugins/registry";
 import { formatTimestamp } from "../helpers";
 import { buildTickerReport } from "../commands/ticker";
 import { createBaseConverter } from "../base-converter";
@@ -226,8 +228,10 @@ async function buildChartComposerReport(
         : series;
     })),
   };
+  const capabilityInvoker = getSharedRegistry();
   const result = await resolveChartSpecData(spec, {
     dataProvider: context.dataProvider,
+    ...(capabilityInvoker ? { resolveCapabilitySeries: createChartSeriesResolver(capabilityInvoker) } : {}),
     loadFredSeries: async (request) => ({
       data: await apiClient.getCloudFredSeries(request.seriesId, {
         startDate: request.startDate,
@@ -261,7 +265,9 @@ async function buildChartComposerReport(
     if (output?.points.length) return [];
     return [entry.source.kind === "security"
       ? publicTickerKey(entry.source.instrument.symbol, entry.source.instrument.exchange)
-      : `FRED:${entry.source.seriesId}`];
+      : entry.source.kind === "economic"
+        ? `FRED:${entry.source.seriesId}`
+        : `CAP:${entry.source.capabilityId}:${entry.source.seriesId}`];
   });
   const rowCount = series.reduce((count, entry) => count + entry.observations.length, 0);
   const tableRows = series.map((entry) => {

--- a/src/cli/pane-functions/screenshot.test.ts
+++ b/src/cli/pane-functions/screenshot.test.ts
@@ -178,6 +178,31 @@ describe("pane screenshot chart-composer inputs", () => {
     expect(shotUnavailableSymbols(composer, payload([]), semanticUi)).toEqual([]);
   });
 
+  test("accepts capability-backed composer evidence and reports an empty provider series", () => {
+    const composer = resolved("chart-composer", {});
+    const populated: RemoteUiNodeSnapshot[] = [{
+      id: "chart-composer-data",
+      role: "chart-data",
+      actions: [],
+      metadata: {
+        kind: "chart-composer",
+        baseSeries: [{
+          sourceKind: "capability",
+          capabilityId: "prediction-markets.series",
+          providerSeriesId: "polymarket:one",
+          pointCount: 5,
+        }],
+      },
+    }];
+    expect(shotSemanticRowCount(composer, payload([]), populated)).toBe(5);
+    expect(shotUnavailableSymbols(composer, payload([]), populated)).toEqual([]);
+
+    const empty = structuredClone(populated);
+    (empty[0]!.metadata as any).baseSeries[0].pointCount = 0;
+    expect(shotUnavailableSymbols(composer, payload([]), empty))
+      .toEqual(["CAP:prediction-markets.series:polymarket:one"]);
+  });
+
   test("reports an empty FRED composer source as unavailable", () => {
     const semanticUi: RemoteUiNodeSnapshot[] = [{
       id: "chart-composer-data",

--- a/src/cli/pane-functions/screenshot.test.ts
+++ b/src/cli/pane-functions/screenshot.test.ts
@@ -130,6 +130,18 @@ describe("pane screenshot chart-data verification", () => {
           panelId: "macro",
           visible: true,
         },
+        {
+          id: "prediction",
+          sourceKind: "capability",
+          capabilityId: "prediction-markets.series",
+          providerSeriesId: "polymarket/event-1/market-1",
+          first: { date: "2026-01-01T00:00:00.000Z", value: 0.4 },
+          last: { date: "2026-01-02T00:00:00.000Z", value: 0.6 },
+          style: "area",
+          transform: "raw",
+          panelId: "prediction",
+          visible: true,
+        },
       ],
     };
     const metadata = {
@@ -137,12 +149,18 @@ describe("pane screenshot chart-data verification", () => {
       projectedPointCount: 42,
       baseSeries: expectedComposer.baseSeries?.map((series) => ({ ...series, pointCount: 12 })),
     };
-    expect(chartEvidenceMismatchesFor([{
+    const semanticUi = [{
       id: "chart-composer-data",
-      role: "chart-data",
+      role: "chart-data" as const,
       actions: [],
       metadata,
-    }], expectedComposer)).toEqual([]);
+    }];
+    expect(chartEvidenceMismatchesFor(semanticUi, expectedComposer)).toEqual([]);
+
+    const wrong = structuredClone(semanticUi);
+    (wrong[0]!.metadata.baseSeries![3]!.last as { value: number }).value = 0.7;
+    expect(chartEvidenceMismatchesFor(wrong, expectedComposer))
+      .toContain("rendered chart series prediction does not match");
   });
 });
 

--- a/src/cli/pane-functions/screenshot.ts
+++ b/src/cli/pane-functions/screenshot.ts
@@ -40,6 +40,9 @@ import { parseChartSpec } from "../../plugins/builtin/chart-composer/chart-spec"
 import { publicTickerKey } from "../../utils/exchanges";
 import { apiClient } from "../../api-client";
 import type { FredSeriesCacheEntry } from "../../data/fred-series";
+import type { ResolvedSeries } from "../../time-series/types";
+import { chartSeriesSourceKey, createChartSeriesResolver } from "../../capabilities";
+import { getSharedRegistry } from "../../plugins/registry";
 import {
   collectShotSymbols,
   clipPriceHistoryToRange,
@@ -76,6 +79,23 @@ async function collectShotFredSeries(
   return loaded.filter((entry): entry is [string, FredSeriesCacheEntry] => !!entry);
 }
 
+async function collectShotCapabilitySeries(
+  resolved: ResolvedPaneFunction,
+): Promise<Array<[string, ResolvedSeries]>> {
+  if (resolved.pane.id !== CHART_COMPOSER_PANE_ID) return [];
+  const spec = parseChartSpec(resolved.instance.settings?.chartSpec);
+  const invoker = getSharedRegistry();
+  if (!spec || !invoker) return [];
+  const resolveSeries = createChartSeriesResolver(invoker);
+  return (await Promise.all(spec.series.flatMap((series) => {
+    if (series.source.kind !== "capability") return [];
+    const source = series.source;
+    return [resolveSeries(source, spec.viewport, series)
+      .then((value) => [chartSeriesSourceKey(source), value] as [string, ResolvedSeries])
+      .catch(() => null)];
+  }))).filter((entry): entry is [string, ResolvedSeries] => entry !== null);
+}
+
 export interface PaneScreenshotExpectedSelection {
   control: "metric" | "statement" | "period";
   value?: string;
@@ -106,10 +126,12 @@ export interface PaneScreenshotExpectedChartEvidence {
   sourceSeries?: PaneScreenshotChartSeriesEvidence[];
   baseSeries?: Array<{
     id: string;
-    sourceKind: "security" | "economic";
+    sourceKind: "security" | "economic" | "capability";
     symbol?: string;
     fieldId?: string;
     economicSeriesId?: string;
+    capabilityId?: string;
+    providerSeriesId?: string;
     style: string;
     transform: string;
     panelId: string;
@@ -259,7 +281,10 @@ async function buildDesktopShotPayload(
   const tickers: TickerRecord[] = [];
   const financials: Array<[string, TickerFinancials]> = [];
   const optionsChains: Array<[string, OptionsChain]> = [];
-  const fredSeries = await collectShotFredSeries(resolved);
+  const [fredSeries, capabilitySeries] = await Promise.all([
+    collectShotFredSeries(resolved),
+    collectShotCapabilitySeries(resolved),
+  ]);
   const includeOptionsChains = resolved.pane.id === OPTIONS_PANE_ID || resolved.template?.paneId === OPTIONS_PANE_ID;
   for (const symbol of collectShotSymbols(resolved, rawArg)) {
     const entry = await fetchTickerFinancials(context, symbol);
@@ -302,6 +327,7 @@ async function buildDesktopShotPayload(
     financials,
     optionsChains,
     fredSeries,
+    capabilitySeries,
     paneState,
   };
 }
@@ -629,7 +655,12 @@ function shotExpectedChart(
             symbol: publicTickerKey(series.source.instrument.symbol, series.source.instrument.exchange),
             fieldId: series.source.fieldId,
           }
-          : { economicSeriesId: series.source.seriesId }),
+          : series.source.kind === "economic"
+            ? { economicSeriesId: series.source.seriesId }
+            : {
+              capabilityId: series.source.capabilityId,
+              providerSeriesId: series.source.seriesId,
+            }),
         style: series.style,
         transform: series.transform,
         panelId: series.panelId,
@@ -780,6 +811,8 @@ export function chartEvidenceMismatchesFor(
           || actual.symbol !== series.symbol
           || actual.fieldId !== series.fieldId
           || actual.economicSeriesId !== series.economicSeriesId
+          || actual.capabilityId !== series.capabilityId
+          || actual.providerSeriesId !== series.providerSeriesId
           || actual.style !== series.style
           || actual.transform !== series.transform
           || actual.panelId !== series.panelId
@@ -885,6 +918,9 @@ export function shotUnavailableSymbols(
       if (entry.sourceKind === "security" && typeof entry.symbol === "string") return [entry.symbol];
       if (entry.sourceKind === "economic" && typeof entry.economicSeriesId === "string") {
         return [`FRED:${entry.economicSeriesId}`];
+      }
+      if (entry.sourceKind === "capability" && typeof entry.capabilityId === "string" && typeof entry.providerSeriesId === "string") {
+        return [`CAP:${entry.capabilityId}:${entry.providerSeriesId}`];
       }
       return [];
     });

--- a/src/cli/pane-functions/screenshot.ts
+++ b/src/cli/pane-functions/screenshot.ts
@@ -31,6 +31,7 @@ import type {
 } from "../../time-series/reporting";
 import type { TimeRange } from "../../time-series/range";
 import { appendLiveQuotePoint } from "../../time-series/chart-data";
+import { applyResolvedSeriesTransform } from "../../time-series/transforms";
 import { subtractTimeRange } from "../../time-series/date-window";
 import {
   buildPresetDateWindow,
@@ -132,6 +133,8 @@ export interface PaneScreenshotExpectedChartEvidence {
     economicSeriesId?: string;
     capabilityId?: string;
     providerSeriesId?: string;
+    first?: { date: string; value: number | null } | null;
+    last?: { date: string; value: number | null } | null;
     style: string;
     transform: string;
     panelId: string;
@@ -638,6 +641,13 @@ function shotExpectedChart(
   if (resolved.pane.id === CHART_COMPOSER_PANE_ID) {
     const spec = parseChartSpec(resolved.instance.settings?.chartSpec);
     if (!spec) return null;
+    const capabilitySeries = new Map(payload.capabilitySeries);
+    const capabilityPoint = (point: ResolvedSeries["points"][number] | undefined) => point
+      ? {
+          date: point.date.toISOString(),
+          value: typeof (point.value ?? point.close) === "number" ? point.value ?? point.close ?? null : null,
+        }
+      : null;
     return {
       kind: "chart-composer",
       symbols: [...new Set(spec.series.flatMap((series) => (
@@ -657,10 +667,16 @@ function shotExpectedChart(
           }
           : series.source.kind === "economic"
             ? { economicSeriesId: series.source.seriesId }
-            : {
-              capabilityId: series.source.capabilityId,
-              providerSeriesId: series.source.seriesId,
-            }),
+            : (() => {
+                const loaded = capabilitySeries.get(chartSeriesSourceKey(series.source));
+                const resolvedSeries = loaded ? applyResolvedSeriesTransform(loaded, series.transform) : undefined;
+                return {
+                  capabilityId: series.source.capabilityId,
+                  providerSeriesId: series.source.seriesId,
+                  first: capabilityPoint(resolvedSeries?.points[0]),
+                  last: capabilityPoint(resolvedSeries?.points.at(-1)),
+                };
+              })()),
         style: series.style,
         transform: series.transform,
         panelId: series.panelId,
@@ -813,6 +829,10 @@ export function chartEvidenceMismatchesFor(
           || actual.economicSeriesId !== series.economicSeriesId
           || actual.capabilityId !== series.capabilityId
           || actual.providerSeriesId !== series.providerSeriesId
+          || (series.sourceKind === "capability" && (
+            JSON.stringify(actual.first) !== JSON.stringify(series.first)
+            || JSON.stringify(actual.last) !== JSON.stringify(series.last)
+          ))
           || actual.style !== series.style
           || actual.transform !== series.transform
           || actual.panelId !== series.panelId

--- a/src/data/config/chart-settings.ts
+++ b/src/data/config/chart-settings.ts
@@ -155,8 +155,17 @@ function parsedChartSpec(value: unknown): ChartSpec | null {
       return null;
     }
   }
-  if (!record(decoded)) return null;
-  const spec = normalizeChartSpec(decoded);
+  const input = record(decoded);
+  if (!input) return null;
+  const version = input.version;
+  const legacySeries = Array.isArray(input.series) ? input.series : [];
+  const legacyIsCapabilityFree = legacySeries.every((entry) => {
+    const source = record(entry) ? record(entry.source) : null;
+    return source?.kind === "security" || source?.kind === "economic";
+  });
+  if (version !== CHART_SPEC_VERSION
+    && !((version === 1 || version === undefined) && legacyIsCapabilityFree)) return null;
+  const spec = normalizeChartSpec(input);
   return validateChartSpec(spec).valid ? spec : null;
 }
 

--- a/src/data/config/store/index.test.ts
+++ b/src/data/config/store/index.test.ts
@@ -217,7 +217,7 @@ describe("sanitizeLayout", () => {
     expect(pane?.paneId).toBe("chart-composer");
     expect(pane?.settings).toEqual({
       chartSpec: expect.objectContaining({
-        version: 1,
+        version: 2,
         viewport: { range: "1Y", resolution: "1d" },
         series: [
           expect.objectContaining({
@@ -259,7 +259,7 @@ describe("sanitizeLayout", () => {
       hideTabs: true,
       lockedTabId: "chart",
       chartSpec: expect.objectContaining({
-        version: 1,
+        version: 2,
         viewport: { range: "1Y", resolution: "1wk" },
         series: [expect.objectContaining({
           transform: "percent",

--- a/src/plugins/builtin/chart-composer/chart-spec.ts
+++ b/src/plugins/builtin/chart-composer/chart-spec.ts
@@ -66,11 +66,21 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+function canMigrateV1(decoded: Record<string, unknown>): boolean {
+  return !Array.isArray(decoded.series) || decoded.series.every((entry) => {
+    const source = isRecord(entry) && isRecord(entry.source) ? entry.source : null;
+    return source?.kind === "security" || source?.kind === "economic";
+  });
+}
+
 /** Parse, migrate, normalize, and semantically validate a persisted chart spec. */
 export function parseChartSpec(value: unknown): ChartSpec | null {
   const decoded = decodeSpec(value);
   if (!isRecord(decoded)) return null;
-  if (decoded.version !== undefined && decoded.version !== CHART_SPEC_VERSION) return null;
+  const version = decoded.version;
+  if (version !== CHART_SPEC_VERSION && !((version === 1 || version === undefined) && canMigrateV1(decoded))) {
+    return null;
+  }
   const spec = normalizeChartSpec(decoded, DEFAULT_CHART_SPEC);
   return validateChartSpec(spec).valid ? spec : null;
 }

--- a/src/plugins/builtin/chart-composer/editor/controller.ts
+++ b/src/plugins/builtin/chart-composer/editor/controller.ts
@@ -223,7 +223,7 @@ export function useSeriesEditorController({
     if (!selected) return false;
     const parsed = parseSeriesExpression(expression);
     if (!parsed) {
-      setError("Use SYMBOL, SYMBOL:field, SYMBOL:EXCHANGE:field, or FRED:series.");
+      setError("Use SYMBOL, SYMBOL:field, FRED:series, or CAP:capability-id:series-id.");
       return false;
     }
     expressionCommitLockRef.current = true;

--- a/src/plugins/builtin/chart-composer/index.tsx
+++ b/src/plugins/builtin/chart-composer/index.tsx
@@ -63,7 +63,9 @@ function chartTitle(spec: ChartSpec, prefix = "G"): string {
   const labels = spec.series.slice(0, 3).map((series) => (
     series.source.kind === "security"
       ? publicTickerKey(series.source.instrument.symbol, series.source.instrument.exchange)
-      : `FRED:${series.source.seriesId}`
+      : series.source.kind === "economic"
+        ? `FRED:${series.source.seriesId}`
+        : series.label?.trim() || series.source.seriesId
   ));
   if (labels.length === 0) return "Custom Chart";
   const remaining = spec.series.length - labels.length;

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -16,6 +16,7 @@ import type { ChartResolution, TimeRange } from "../../../components/chart/core/
 import type { ChartSpec, ResolvedSeries } from "../../../time-series/types";
 import { getSupportedChartResolutionsForViewport } from "../../../time-series/resolution";
 import { useResolvedChartSpec } from "../../../time-series/hooks";
+import { chartSeriesSourceKey } from "../../../capabilities";
 import { useShortcut } from "../../../react/input";
 import { useDialog, useDialogState, type PromptContext } from "../../../ui/dialog";
 import {
@@ -128,13 +129,7 @@ function ChartComposerSurface({
         ]
       : entry.source.kind === "economic"
         ? [entry.id, entry.source.kind, entry.source.seriesId]
-        : [
-            entry.id,
-            entry.source.kind,
-            entry.source.capabilityId,
-            entry.source.seriesId,
-            JSON.stringify(entry.source.parameters ?? {}),
-          ]),
+        : [entry.id, entry.source.kind, chartSeriesSourceKey(entry.source)]),
   }), [spec.series, spec.viewport.dateWindow, spec.viewport.maxPoints, spec.viewport.range, spec.viewport.resolution]);
   const [runtimeViewportState, setRuntimeViewportState] = useState<{
     key: string;

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -126,7 +126,15 @@ function ChartComposerSurface({
             ?? defaultFinancialTimestampMode(entry.source.fieldId)
             ?? "",
         ]
-      : [entry.id, entry.source.kind, entry.source.seriesId]),
+      : entry.source.kind === "economic"
+        ? [entry.id, entry.source.kind, entry.source.seriesId]
+        : [
+            entry.id,
+            entry.source.kind,
+            entry.source.capabilityId,
+            entry.source.seriesId,
+            JSON.stringify(entry.source.parameters ?? {}),
+          ]),
   }), [spec.series, spec.viewport.dateWindow, spec.viewport.maxPoints, spec.viewport.range, spec.viewport.resolution]);
   const [runtimeViewportState, setRuntimeViewportState] = useState<{
     key: string;

--- a/src/plugins/builtin/chart-composer/presets.test.ts
+++ b/src/plugins/builtin/chart-composer/presets.test.ts
@@ -47,6 +47,23 @@ describe("chart composer expressions", () => {
     expect(parseSeriesExpression(`CAP:provider:${"x".repeat(241)}`)).toBeNull();
   });
 
+  test("maps futures and Treasury aliases onto existing core source kinds", () => {
+    expect(parseSeriesExpression("fut:es")).toEqual({
+      kind: "security",
+      symbol: "ES=F",
+      fieldId: "market.ohlcv",
+      label: "E-Mini S&P 500",
+    });
+    expect(parseSeriesExpression("ust:10y")).toEqual({
+      kind: "economic",
+      provider: "fred",
+      seriesId: "DGS10",
+      label: "10Y Treasury Yield",
+    });
+    expect(parseSeriesExpression("FUT:UNKNOWN")).toBeNull();
+    expect(parseSeriesExpression("UST:4Y")).toBeNull();
+  });
+
   test("appends catalog series with required panels and collision-safe IDs", () => {
     const initial = buildCustomChartPreset("AAPL:price, MSFT:price");
     const withVolume = appendChartSeries(initial, {

--- a/src/plugins/builtin/chart-composer/presets.test.ts
+++ b/src/plugins/builtin/chart-composer/presets.test.ts
@@ -29,12 +29,11 @@ import {
 import { applyChartComposerCapabilityOptions } from "./cli-options";
 
 describe("chart composer expressions", () => {
-  test("round-trips provider-neutral capability expressions and parameters", () => {
+  test("round-trips bounded provider-neutral capability expressions", () => {
     const expression = {
       kind: "capability" as const,
       capabilityId: "prediction-markets.series",
-      seriesId: "polymarket:one",
-      parameters: { outcome: "yes", nested: { token: "123" } },
+      seriesId: "polymarket/event-1/market-1",
       label: "Will it happen?",
     };
     const series = buildSeriesSpec(expression, 0);
@@ -42,8 +41,10 @@ describe("chart composer expressions", () => {
       kind: "capability",
       capabilityId: expression.capabilityId,
       seriesId: expression.seriesId,
-      parameters: expression.parameters,
     });
+    expect(parseSeriesExpression("CAP:provider:series?params=%7B%7D")).toBeNull();
+    expect(parseSeriesExpression(`CAP:${"x".repeat(81)}:series`)).toBeNull();
+    expect(parseSeriesExpression(`CAP:provider:${"x".repeat(241)}`)).toBeNull();
   });
 
   test("appends catalog series with required panels and collision-safe IDs", () => {
@@ -532,6 +533,17 @@ describe("chart composer spec persistence", () => {
       { style: "line", timestampMode: "period-end" },
       { style: "columns", timestampMode: "available-at" },
     ]);
+  });
+
+  test("migrates v1 security and economic specs but never treats v1 as capability-aware", () => {
+    const legacy = buildCustomChartPreset("AAPL:price, FRED:CPIAUCSL");
+    const migrated = parseChartSpec({ ...legacy, version: 1 });
+    expect(migrated?.version).toBe(2);
+    expect(migrated?.series.map((series) => series.source.kind)).toEqual(["security", "economic"]);
+
+    const capability = buildCustomChartPreset("CAP:prediction-markets.series:polymarket/event-1/market-1");
+    expect(parseChartSpec({ ...capability, version: 1 })).toBeNull();
+    expect(parseChartSpec(serializeChartSpec(capability))).toEqual(parseChartSpec(capability));
   });
 
   test("rejects chart specs authored by a newer unsupported version", () => {

--- a/src/plugins/builtin/chart-composer/presets.test.ts
+++ b/src/plugins/builtin/chart-composer/presets.test.ts
@@ -18,7 +18,9 @@ import {
   applySeriesTimestampMode,
   getSelectedBuiltinStudies,
   getSelectedPairStudies,
+  formatSeriesExpression,
   parseChartExpression,
+  parseSeriesExpression,
   rebindChartSecuritySymbol,
   resolveChartFieldAlias,
   setBuiltinStudies,
@@ -27,6 +29,23 @@ import {
 import { applyChartComposerCapabilityOptions } from "./cli-options";
 
 describe("chart composer expressions", () => {
+  test("round-trips provider-neutral capability expressions and parameters", () => {
+    const expression = {
+      kind: "capability" as const,
+      capabilityId: "prediction-markets.series",
+      seriesId: "polymarket:one",
+      parameters: { outcome: "yes", nested: { token: "123" } },
+      label: "Will it happen?",
+    };
+    const series = buildSeriesSpec(expression, 0);
+    expect(parseSeriesExpression(formatSeriesExpression(series))).toEqual({
+      kind: "capability",
+      capabilityId: expression.capabilityId,
+      seriesId: expression.seriesId,
+      parameters: expression.parameters,
+    });
+  });
+
   test("appends catalog series with required panels and collision-safe IDs", () => {
     const initial = buildCustomChartPreset("AAPL:price, MSFT:price");
     const withVolume = appendChartSeries(initial, {

--- a/src/plugins/builtin/chart-composer/presets.ts
+++ b/src/plugins/builtin/chart-composer/presets.ts
@@ -33,6 +33,8 @@ import {
   isValidChartCapabilityId,
   isValidChartSeriesId,
 } from "../../../capabilities/chart-series";
+import { FUTURES_CONTRACTS } from "../futures/contracts";
+import { TREASURY_MATURITIES } from "../yield-curve/treasury-data";
 
 const CHART_FIELD_IDS = {
   price: "market.ohlcv",
@@ -118,6 +120,25 @@ export function parseSeriesExpression(value: string): ParsedSeriesExpression | n
       ? { kind: "economic", provider: "fred", seriesId }
       : null;
   }
+  if (parts.length === 2 && parts[0]?.trim().toUpperCase() === "FUT") {
+    const code = parts[1]?.trim().toUpperCase();
+    const contract = FUTURES_CONTRACTS.find((entry) => entry.code === code);
+    return contract
+      ? { kind: "security", symbol: contract.symbol, fieldId: CHART_FIELD_IDS.price, label: contract.name }
+      : null;
+  }
+  if (parts.length === 2 && parts[0]?.trim().toUpperCase() === "UST") {
+    const maturity = parts[1]?.trim().toUpperCase();
+    const treasury = TREASURY_MATURITIES.find((entry) => entry.maturity === maturity);
+    return treasury
+      ? {
+          kind: "economic",
+          provider: "fred",
+          seriesId: treasury.seriesId,
+          label: `${treasury.maturity} Treasury Yield`,
+        }
+      : null;
+  }
 
   let instrument: { symbol: string; exchange?: string } | null = null;
   let fieldId: string = CHART_FIELD_IDS.price;
@@ -157,7 +178,7 @@ export function parseChartExpression(value: string): ParsedSeriesExpression[] {
     if (parsed) return parsed;
     const display = leg.trim() || "empty series";
     throw new Error(
-      `Invalid chart series "${display}". Use SYMBOL, SYMBOL:field, FRED:series, or CAP:capability-id:series-id.`,
+      `Invalid chart series "${display}". Use SYMBOL, SYMBOL:field, FUT:code, UST:maturity, FRED:series, or CAP:capability-id:series-id.`,
     );
   });
 }

--- a/src/plugins/builtin/chart-composer/presets.ts
+++ b/src/plugins/builtin/chart-composer/presets.ts
@@ -1,5 +1,6 @@
 import {
   CHART_SPEC_VERSION,
+  type CapabilitySeriesSource,
   type ChartPanelSpec,
   type ChartSeriesSpec,
   type ChartSpec,
@@ -47,7 +48,16 @@ const CHART_FIELD_IDS = {
 
 export type ParsedSeriesExpression =
   | { kind: "security"; symbol: string; exchange?: string; fieldId: string; label?: string }
-  | { kind: "economic"; provider: "fred"; seriesId: string; label?: string };
+  | { kind: "economic"; provider: "fred"; seriesId: string; label?: string }
+  | {
+      kind: "capability";
+      capabilityId: string;
+      seriesId: string;
+      parameters?: CapabilitySeriesSource["parameters"];
+      label?: string;
+      style?: SeriesStyle;
+      transform?: SeriesTransform;
+    };
 
 function normalizeBaseSymbol(value: string): string | null {
   const symbol = value.trim().toUpperCase();
@@ -91,6 +101,25 @@ export function parseSeriesExpression(value: string): ParsedSeriesExpression | n
   const trimmed = value.trim();
   if (!trimmed) return null;
   const parts = trimmed.split(":");
+  if (parts[0]?.trim().toUpperCase() === "CAP") {
+    const separator = trimmed.indexOf(":", trimmed.indexOf(":") + 1);
+    if (separator < 0) return null;
+    try {
+      const capabilityId = decodeURIComponent(trimmed.slice(4, separator)).trim();
+      const [encodedSeriesId, query = ""] = trimmed.slice(separator + 1).split("?", 2);
+      const seriesId = decodeURIComponent(encodedSeriesId ?? "").trim();
+      const encodedParameters = new URLSearchParams(query).get("params");
+      const parsedParameters = encodedParameters ? JSON.parse(encodedParameters) : undefined;
+      const parameters = parsedParameters && typeof parsedParameters === "object" && !Array.isArray(parsedParameters)
+        ? parsedParameters as CapabilitySeriesSource["parameters"]
+        : undefined;
+      return capabilityId && seriesId
+        ? { kind: "capability", capabilityId, seriesId, ...(parameters ? { parameters } : {}) }
+        : null;
+    } catch {
+      return null;
+    }
+  }
   if (parts[0]?.trim().toUpperCase() === "FRED") {
     const seriesId = parts.length === 2 ? parts[1]?.trim().toUpperCase() ?? "" : "";
     return /^[A-Z0-9._-]{1,80}$/.test(seriesId)
@@ -136,19 +165,26 @@ export function parseChartExpression(value: string): ParsedSeriesExpression[] {
     if (parsed) return parsed;
     const display = leg.trim() || "empty series";
     throw new Error(
-      `Invalid chart series "${display}". Use SYMBOL, SYMBOL:field, or FRED:series, for example AAPL:price or FRED:CPIAUCSL.`,
+      `Invalid chart series "${display}". Use SYMBOL, SYMBOL:field, FRED:series, or CAP:capability-id:series-id.`,
     );
   });
 }
 
 export function formatSeriesExpression(series: ChartSeriesSpec): string {
   if (series.source.kind === "economic") return `FRED:${series.source.seriesId}`;
+  if (series.source.kind === "capability") {
+    const parameters = series.source.parameters
+      ? `?params=${encodeURIComponent(JSON.stringify(series.source.parameters))}`
+      : "";
+    return `CAP:${encodeURIComponent(series.source.capabilityId)}:${encodeURIComponent(series.source.seriesId)}${parameters}`;
+  }
   return `${publicTickerKey(series.source.instrument.symbol, series.source.instrument.exchange)}:${series.source.fieldId}`;
 }
 
 export function chartSeriesLabel(series: ChartSeriesSpec): string {
   if (series.label?.trim()) return series.label.trim();
   if (series.source.kind === "economic") return `FRED ${series.source.seriesId}`;
+  if (series.source.kind === "capability") return series.source.seriesId;
   const instrument = publicTickerKey(
     series.source.instrument.symbol,
     series.source.instrument.exchange,
@@ -221,6 +257,25 @@ export function buildSeriesSpec(
   index: number,
   overrides: Partial<Omit<ChartSeriesSpec, "id" | "source">> = {},
 ): ChartSeriesSpec {
+  if (expression.kind === "capability") {
+    const style = overrides.style ?? expression.style ?? "line";
+    return {
+      id: `${slug(expression.capabilityId)}-${slug(expression.seriesId)}-${index + 1}`,
+      source: {
+        kind: "capability",
+        capabilityId: expression.capabilityId,
+        seriesId: expression.seriesId,
+        ...(expression.parameters ? { parameters: expression.parameters } : {}),
+      },
+      ...(expression.label ? { label: expression.label } : {}),
+      transform: expression.transform ?? "raw",
+      axis: "auto",
+      panelId: "main",
+      ...overrides,
+      style,
+      interpolation: coerceSeriesInterpolationForStyle(style),
+    };
+  }
   if (expression.kind === "economic") {
     const style = overrides.style ?? "step";
     return {
@@ -295,7 +350,9 @@ function effectiveSeriesUnitGroup(series: ChartSeriesSpec): string {
   if (series.transform === "index100") return "index";
   return series.source.kind === "economic"
     ? `economic:${series.source.seriesId}`
-    : getTimeSeriesField(series.source.fieldId)?.unitGroup ?? series.source.fieldId;
+    : series.source.kind === "capability"
+      ? `capability:${series.source.capabilityId}`
+      : getTimeSeriesField(series.source.fieldId)?.unitGroup ?? series.source.fieldId;
 }
 
 function nextGeneratedPanelId(

--- a/src/plugins/builtin/chart-composer/presets.ts
+++ b/src/plugins/builtin/chart-composer/presets.ts
@@ -1,6 +1,5 @@
 import {
   CHART_SPEC_VERSION,
-  type CapabilitySeriesSource,
   type ChartPanelSpec,
   type ChartSeriesSpec,
   type ChartSpec,
@@ -30,6 +29,10 @@ import {
   publicTickerKey,
 } from "../../../utils/exchanges";
 import { MAX_CHART_COMPOSER_SERIES } from "./chart-spec";
+import {
+  isValidChartCapabilityId,
+  isValidChartSeriesId,
+} from "../../../capabilities/chart-series";
 
 const CHART_FIELD_IDS = {
   price: "market.ohlcv",
@@ -53,7 +56,6 @@ export type ParsedSeriesExpression =
       kind: "capability";
       capabilityId: string;
       seriesId: string;
-      parameters?: CapabilitySeriesSource["parameters"];
       label?: string;
       style?: SeriesStyle;
       transform?: SeriesTransform;
@@ -102,23 +104,13 @@ export function parseSeriesExpression(value: string): ParsedSeriesExpression | n
   if (!trimmed) return null;
   const parts = trimmed.split(":");
   if (parts[0]?.trim().toUpperCase() === "CAP") {
-    const separator = trimmed.indexOf(":", trimmed.indexOf(":") + 1);
+    const separator = trimmed.indexOf(":", 4);
     if (separator < 0) return null;
-    try {
-      const capabilityId = decodeURIComponent(trimmed.slice(4, separator)).trim();
-      const [encodedSeriesId, query = ""] = trimmed.slice(separator + 1).split("?", 2);
-      const seriesId = decodeURIComponent(encodedSeriesId ?? "").trim();
-      const encodedParameters = new URLSearchParams(query).get("params");
-      const parsedParameters = encodedParameters ? JSON.parse(encodedParameters) : undefined;
-      const parameters = parsedParameters && typeof parsedParameters === "object" && !Array.isArray(parsedParameters)
-        ? parsedParameters as CapabilitySeriesSource["parameters"]
-        : undefined;
-      return capabilityId && seriesId
-        ? { kind: "capability", capabilityId, seriesId, ...(parameters ? { parameters } : {}) }
-        : null;
-    } catch {
-      return null;
-    }
+    const capabilityId = trimmed.slice(4, separator);
+    const seriesId = trimmed.slice(separator + 1);
+    return isValidChartCapabilityId(capabilityId) && isValidChartSeriesId(seriesId)
+      ? { kind: "capability", capabilityId, seriesId }
+      : null;
   }
   if (parts[0]?.trim().toUpperCase() === "FRED") {
     const seriesId = parts.length === 2 ? parts[1]?.trim().toUpperCase() ?? "" : "";
@@ -173,10 +165,7 @@ export function parseChartExpression(value: string): ParsedSeriesExpression[] {
 export function formatSeriesExpression(series: ChartSeriesSpec): string {
   if (series.source.kind === "economic") return `FRED:${series.source.seriesId}`;
   if (series.source.kind === "capability") {
-    const parameters = series.source.parameters
-      ? `?params=${encodeURIComponent(JSON.stringify(series.source.parameters))}`
-      : "";
-    return `CAP:${encodeURIComponent(series.source.capabilityId)}:${encodeURIComponent(series.source.seriesId)}${parameters}`;
+    return `CAP:${series.source.capabilityId}:${series.source.seriesId}`;
   }
   return `${publicTickerKey(series.source.instrument.symbol, series.source.instrument.exchange)}:${series.source.fieldId}`;
 }
@@ -265,7 +254,6 @@ export function buildSeriesSpec(
         kind: "capability",
         capabilityId: expression.capabilityId,
         seriesId: expression.seriesId,
-        ...(expression.parameters ? { parameters: expression.parameters } : {}),
       },
       ...(expression.label ? { label: expression.label } : {}),
       transform: expression.transform ?? "raw",

--- a/src/plugins/builtin/chart-composer/semantic.ts
+++ b/src/plugins/builtin/chart-composer/semantic.ts
@@ -25,20 +25,24 @@ function viewportEvidence(viewport: UseChartResolutionResult["viewport"]) {
 }
 
 function sourceEvidence(series: ChartSeriesSpec) {
-  return series.source.kind === "security"
-    ? {
-      sourceKind: "security",
-      symbol: publicTickerKey(series.source.instrument.symbol, series.source.instrument.exchange),
-      exchange: series.source.instrument.exchange ?? null,
-      fieldId: series.source.fieldId,
-      period: series.source.period ?? "auto",
-      timestampMode: series.source.timestampMode ?? null,
-    }
-    : {
-      sourceKind: "economic",
-      provider: series.source.provider,
-      economicSeriesId: series.source.seriesId,
-    };
+  if (series.source.kind === "security") return {
+    sourceKind: "security",
+    symbol: publicTickerKey(series.source.instrument.symbol, series.source.instrument.exchange),
+    exchange: series.source.instrument.exchange ?? null,
+    fieldId: series.source.fieldId,
+    period: series.source.period ?? "auto",
+    timestampMode: series.source.timestampMode ?? null,
+  };
+  if (series.source.kind === "economic") return {
+    sourceKind: "economic",
+    provider: series.source.provider,
+    economicSeriesId: series.source.seriesId,
+  };
+  return {
+    sourceKind: "capability",
+    capabilityId: series.source.capabilityId,
+    providerSeriesId: series.source.seriesId,
+  };
 }
 
 /** Stable semantic evidence used by desktop automation and bot-safe screenshots. */

--- a/src/plugins/builtin/chart-composer/series-catalog.test.ts
+++ b/src/plugins/builtin/chart-composer/series-catalog.test.ts
@@ -1,12 +1,34 @@
 import { describe, expect, test } from "bun:test";
 import {
   analyzeSeriesSearchQuery,
+  buildCapabilitySeriesSuggestions,
   buildSeriesCatalogSuggestions,
 } from "./series-catalog";
 
 const AAPL = { symbol: "AAPL", exchange: "NASDAQ", name: "Apple Inc." };
 
 describe("chart composer series catalog", () => {
+  test("maps provider catalog metadata without provider-specific core branches", () => {
+    expect(buildCapabilitySeriesSuggestions([{
+      capabilityId: "custom.series",
+      capabilityName: "Custom Provider",
+      seriesId: "series-1",
+      label: "Custom history",
+      parameters: { contract: "one" },
+      style: "step",
+    }])[0]).toMatchObject({
+      label: "Custom history",
+      detail: "Custom Provider",
+      expression: {
+        kind: "capability",
+        capabilityId: "custom.series",
+        seriesId: "series-1",
+        parameters: { contract: "one" },
+        style: "step",
+      },
+    });
+  });
+
   test("maps a metric-only query onto the current security", () => {
     const suggestions = buildSeriesCatalogSuggestions("revenue", AAPL);
 

--- a/src/plugins/builtin/chart-composer/series-catalog.test.ts
+++ b/src/plugins/builtin/chart-composer/series-catalog.test.ts
@@ -72,6 +72,25 @@ describe("chart composer series catalog", () => {
     });
   });
 
+  test("suggests futures contracts and Treasury maturities from the board catalogs", () => {
+    expect(buildSeriesCatalogSuggestions("e-mini s&p", AAPL)[0]).toMatchObject({
+      label: "FUT:ES · E-Mini S&P 500",
+      expression: {
+        kind: "security",
+        symbol: "ES=F",
+        fieldId: "market.ohlcv",
+      },
+    });
+    expect(buildSeriesCatalogSuggestions("UST:10Y", AAPL)[0]).toMatchObject({
+      label: "10Y Treasury Yield",
+      expression: {
+        kind: "economic",
+        provider: "fred",
+        seriesId: "DGS10",
+      },
+    });
+  });
+
   test("keeps direct FRED IDs available for advanced sources", () => {
     expect(buildSeriesCatalogSuggestions("FRED:CPIAUCSL", AAPL)[0]).toMatchObject({
       label: "FRED · CPIAUCSL",

--- a/src/plugins/builtin/chart-composer/series-catalog.test.ts
+++ b/src/plugins/builtin/chart-composer/series-catalog.test.ts
@@ -14,7 +14,6 @@ describe("chart composer series catalog", () => {
       capabilityName: "Custom Provider",
       seriesId: "series-1",
       label: "Custom history",
-      parameters: { contract: "one" },
       style: "step",
     }])[0]).toMatchObject({
       label: "Custom history",
@@ -23,7 +22,6 @@ describe("chart composer series catalog", () => {
         kind: "capability",
         capabilityId: "custom.series",
         seriesId: "series-1",
-        parameters: { contract: "one" },
         style: "step",
       },
     });

--- a/src/plugins/builtin/chart-composer/series-catalog.ts
+++ b/src/plugins/builtin/chart-composer/series-catalog.ts
@@ -8,6 +8,11 @@ import {
 } from "../../../capabilities";
 import type { TimeSeriesFieldDefinition } from "../../../time-series/types";
 import {
+  FUTURES_CONTRACTS,
+  FUTURES_SECTOR_LABELS,
+} from "../futures/contracts";
+import { TREASURY_MATURITIES } from "../yield-curve/treasury-data";
+import {
   canonicalExchange,
   parsePublicTickerKey,
   publicTickerKey,
@@ -230,7 +235,7 @@ function exactExpressionSuggestion(query: string): SeriesCatalogSuggestion | nul
   if (expression.kind === "economic") {
     return {
       id: `fred:${expression.seriesId}`,
-      label: `FRED · ${expression.seriesId}`,
+      label: expression.label ?? `FRED · ${expression.seriesId}`,
       description: "Economic series from FRED",
       detail: "FRED",
       expression,
@@ -253,13 +258,65 @@ function exactExpressionSuggestion(query: string): SeriesCatalogSuggestion | nul
   const instrument = publicTickerKey(expression.symbol, expression.exchange);
   return {
     id: `${instrument}:${expression.fieldId}`,
-    label: `${instrument} · ${field?.label ?? expression.fieldId}`,
+    label: expression.label ?? `${instrument} · ${field?.label ?? expression.fieldId}`,
     description: field
       ? `${fieldCategory(field)} · ${fieldFrequency(field)}`
       : "Security series",
     detail: field ? fieldFrequency(field) : "Security",
     expression,
   };
+}
+
+function matchesAliasQuery(query: string, ...values: string[]): boolean {
+  const tokens = words(query).map(compact);
+  const searchable = compact(values.join(" "));
+  return tokens.length > 0 && tokens.every((token) => searchable.includes(token));
+}
+
+function coreAliasSuggestions(query: string): SeriesCatalogSuggestion[] {
+  const futures = FUTURES_CONTRACTS
+    .filter((contract) => matchesAliasQuery(
+      query,
+      `FUT:${contract.code}`,
+      contract.code,
+      contract.name,
+      `${contract.name} futures`,
+      contract.sector,
+      FUTURES_SECTOR_LABELS[contract.sector],
+    ))
+    .map((contract): SeriesCatalogSuggestion => ({
+      id: `${contract.symbol}:market.ohlcv`,
+      label: `FUT:${contract.code} · ${contract.name}`,
+      description: `${FUTURES_SECTOR_LABELS[contract.sector]} futures`,
+      detail: "Futures",
+      expression: {
+        kind: "security",
+        symbol: contract.symbol,
+        fieldId: "market.ohlcv",
+        label: contract.name,
+      },
+    }));
+  const treasuries = TREASURY_MATURITIES
+    .filter((treasury) => matchesAliasQuery(
+      query,
+      `UST:${treasury.maturity}`,
+      treasury.maturity,
+      treasury.seriesId,
+      `${treasury.maturity.replace("M", " month").replace("Y", " year")} US Treasury yield`,
+    ))
+    .map((treasury): SeriesCatalogSuggestion => ({
+      id: `fred:${treasury.seriesId}`,
+      label: `UST:${treasury.maturity} · Treasury Yield`,
+      description: `U.S. Treasury ${treasury.maturity} yield · FRED ${treasury.seriesId}`,
+      detail: "Treasury",
+      expression: {
+        kind: "economic",
+        provider: "fred",
+        seriesId: treasury.seriesId,
+        label: `${treasury.maturity} Treasury Yield`,
+      },
+    }));
+  return [...futures, ...treasuries];
 }
 
 export function buildCapabilitySeriesSuggestions(
@@ -307,6 +364,9 @@ export function buildSeriesCatalogSuggestions(
     .sort((left, right) => right.score - left.score || left.field.label.localeCompare(right.field.label));
 
   const suggestions: SeriesCatalogSuggestion[] = exact ? [exact] : [];
+  for (const suggestion of coreAliasSuggestions(query)) {
+    if (!suggestions.some((entry) => entry.id === suggestion.id)) suggestions.push(suggestion);
+  }
   const fieldLimit = instruments.length > 1 && !analysis.metricQuery ? 1 : rankedFields.length;
   for (const instrument of instruments) {
     const instrumentLabel = publicTickerKey(instrument.symbol, instrument.exchange);

--- a/src/plugins/builtin/chart-composer/series-catalog.ts
+++ b/src/plugins/builtin/chart-composer/series-catalog.ts
@@ -2,7 +2,10 @@ import {
   getTimeSeriesField,
   listTimeSeriesFields,
 } from "../../../time-series/field-catalog";
-import type { ChartSeriesCatalogItem } from "../../../capabilities";
+import {
+  chartSeriesSourceKey,
+  type ChartSeriesCatalogItem,
+} from "../../../capabilities";
 import type { TimeSeriesFieldDefinition } from "../../../time-series/types";
 import {
   canonicalExchange,
@@ -235,7 +238,11 @@ function exactExpressionSuggestion(query: string): SeriesCatalogSuggestion | nul
   }
   if (expression.kind === "capability") {
     return {
-      id: `${expression.capabilityId}:${expression.seriesId}`,
+      id: chartSeriesSourceKey({
+        kind: "capability",
+        capabilityId: expression.capabilityId,
+        seriesId: expression.seriesId,
+      }),
       label: expression.label ?? expression.seriesId,
       description: `Plugin series from ${expression.capabilityId}`,
       detail: "Plugin",
@@ -259,7 +266,11 @@ export function buildCapabilitySeriesSuggestions(
   items: ReadonlyArray<ChartSeriesCatalogItem & { capabilityId: string; capabilityName: string }>,
 ): SeriesCatalogSuggestion[] {
   return items.map((item) => ({
-    id: `${item.capabilityId}:${item.seriesId}`,
+    id: chartSeriesSourceKey({
+      kind: "capability",
+      capabilityId: item.capabilityId,
+      seriesId: item.seriesId,
+    }),
     label: item.label,
     description: item.description ?? item.capabilityName,
     detail: item.detail ?? item.capabilityName,
@@ -267,7 +278,6 @@ export function buildCapabilitySeriesSuggestions(
       kind: "capability",
       capabilityId: item.capabilityId,
       seriesId: item.seriesId,
-      parameters: item.parameters,
       label: item.label,
       style: item.style,
       transform: item.transform,

--- a/src/plugins/builtin/chart-composer/series-catalog.ts
+++ b/src/plugins/builtin/chart-composer/series-catalog.ts
@@ -2,6 +2,7 @@ import {
   getTimeSeriesField,
   listTimeSeriesFields,
 } from "../../../time-series/field-catalog";
+import type { ChartSeriesCatalogItem } from "../../../capabilities";
 import type { TimeSeriesFieldDefinition } from "../../../time-series/types";
 import {
   canonicalExchange,
@@ -232,6 +233,15 @@ function exactExpressionSuggestion(query: string): SeriesCatalogSuggestion | nul
       expression,
     };
   }
+  if (expression.kind === "capability") {
+    return {
+      id: `${expression.capabilityId}:${expression.seriesId}`,
+      label: expression.label ?? expression.seriesId,
+      description: `Plugin series from ${expression.capabilityId}`,
+      detail: "Plugin",
+      expression,
+    };
+  }
   const field = getTimeSeriesField(expression.fieldId);
   const instrument = publicTickerKey(expression.symbol, expression.exchange);
   return {
@@ -243,6 +253,26 @@ function exactExpressionSuggestion(query: string): SeriesCatalogSuggestion | nul
     detail: field ? fieldFrequency(field) : "Security",
     expression,
   };
+}
+
+export function buildCapabilitySeriesSuggestions(
+  items: ReadonlyArray<ChartSeriesCatalogItem & { capabilityId: string; capabilityName: string }>,
+): SeriesCatalogSuggestion[] {
+  return items.map((item) => ({
+    id: `${item.capabilityId}:${item.seriesId}`,
+    label: item.label,
+    description: item.description ?? item.capabilityName,
+    detail: item.detail ?? item.capabilityName,
+    expression: {
+      kind: "capability",
+      capabilityId: item.capabilityId,
+      seriesId: item.seriesId,
+      parameters: item.parameters,
+      label: item.label,
+      style: item.style,
+      transform: item.transform,
+    },
+  }));
 }
 
 export function buildSeriesCatalogSuggestions(

--- a/src/plugins/builtin/chart-composer/use-series-catalog.ts
+++ b/src/plugins/builtin/chart-composer/use-series-catalog.ts
@@ -2,9 +2,11 @@ import { useEffect, useMemo, useState } from "react";
 import { searchTickerCandidates } from "../../../tickers/search";
 import { useOptionalAppSelector } from "../../../state/app/context";
 import type { TickerRecord } from "../../../types/ticker";
+import { searchChartSeriesCapabilities } from "../../../capabilities";
 import { getSharedRegistry } from "../../registry";
 import {
   analyzeSeriesSearchQuery,
+  buildCapabilitySeriesSuggestions,
   buildSeriesCatalogSuggestions,
   type SeriesCatalogInstrument,
   type SeriesCatalogSuggestion,
@@ -30,11 +32,42 @@ export function useSeriesCatalogSuggestions({
 }): SeriesCatalogSearchResult {
   const tickers = useOptionalAppSelector((state) => state.tickers, EMPTY_TICKERS);
   const analysis = useMemo(() => analyzeSeriesSearchQuery(query), [query]);
+  const [providerSearch, setProviderSearch] = useState<{
+    query: string;
+    suggestions: SeriesCatalogSuggestion[];
+    loading: boolean;
+  }>({ query: "", suggestions: [], loading: false });
   const [search, setSearch] = useState<{
     query: string;
     instruments: SeriesCatalogInstrument[];
     loading: boolean;
   }>({ query: "", instruments: [], loading: false });
+
+  useEffect(() => {
+    const normalizedQuery = query.trim();
+    const registry = getSharedRegistry();
+    if (!enabled || !normalizedQuery || !registry) {
+      setProviderSearch({ query: "", suggestions: [], loading: false });
+      return;
+    }
+    let cancelled = false;
+    setProviderSearch({ query: normalizedQuery, suggestions: [], loading: true });
+    const timer = setTimeout(() => {
+      void searchChartSeriesCapabilities(registry, normalizedQuery).then((items) => {
+        if (!cancelled) setProviderSearch({
+          query: normalizedQuery,
+          suggestions: buildCapabilitySeriesSuggestions(items),
+          loading: false,
+        });
+      }).catch(() => {
+        if (!cancelled) setProviderSearch({ query: normalizedQuery, suggestions: [], loading: false });
+      });
+    }, 80);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [enabled, query]);
 
   useEffect(() => {
     const instrumentQuery = analysis.instrumentQuery.trim();
@@ -90,14 +123,16 @@ export function useSeriesCatalogSuggestions({
   const instruments = search.query === analysis.instrumentQuery
     ? search.instruments
     : [];
-  const suggestions = useMemo(
-    () => buildSeriesCatalogSuggestions(query, defaultInstrument, instruments),
-    [defaultInstrument, instruments, query],
-  );
+  const suggestions = useMemo(() => {
+    const builtIn = buildSeriesCatalogSuggestions(query, defaultInstrument, instruments);
+    const provider = providerSearch.query === query.trim() ? providerSearch.suggestions : [];
+    return [...provider, ...builtIn.filter((entry) => !provider.some((candidate) => candidate.id === entry.id))].slice(0, 8);
+  }, [defaultInstrument, instruments, providerSearch, query]);
 
   return {
     suggestions,
     instruments,
-    loading: search.loading && search.query === analysis.instrumentQuery,
+    loading: (search.loading && search.query === analysis.instrumentQuery)
+      || (providerSearch.loading && providerSearch.query === query.trim()),
   };
 }

--- a/src/plugins/builtin/chart-composer/use-series-catalog.ts
+++ b/src/plugins/builtin/chart-composer/use-series-catalog.ts
@@ -51,9 +51,10 @@ export function useSeriesCatalogSuggestions({
       return;
     }
     let cancelled = false;
+    const controller = new AbortController();
     setProviderSearch({ query: normalizedQuery, suggestions: [], loading: true });
     const timer = setTimeout(() => {
-      void searchChartSeriesCapabilities(registry, normalizedQuery).then((items) => {
+      void searchChartSeriesCapabilities(registry, normalizedQuery, 8, controller.signal).then((items) => {
         if (!cancelled) setProviderSearch({
           query: normalizedQuery,
           suggestions: buildCapabilitySeriesSuggestions(items),
@@ -62,9 +63,10 @@ export function useSeriesCatalogSuggestions({
       }).catch(() => {
         if (!cancelled) setProviderSearch({ query: normalizedQuery, suggestions: [], loading: false });
       });
-    }, 80);
+    }, 250);
     return () => {
       cancelled = true;
+      controller.abort();
       clearTimeout(timer);
     };
   }, [enabled, query]);

--- a/src/plugins/prediction-markets/backend-plugin.ts
+++ b/src/plugins/prediction-markets/backend-plugin.ts
@@ -3,6 +3,7 @@ import {
   attachPredictionMarketsPersistence,
   resetPredictionMarketsPersistence,
 } from "./services/fetch";
+import { predictionChartSeriesCapability } from "./capability";
 
 export const predictionMarketsBackendPlugin: GloomPlugin = {
   id: "prediction-markets",
@@ -10,6 +11,7 @@ export const predictionMarketsBackendPlugin: GloomPlugin = {
   version: "1.0.0",
   description: "Browse prediction markets (Polymarket and Kalshi).",
   toggleable: true,
+  capabilities: [predictionChartSeriesCapability],
   setup(ctx) {
     attachPredictionMarketsPersistence(ctx.persistence);
   },

--- a/src/plugins/prediction-markets/capability.test.ts
+++ b/src/plugins/prediction-markets/capability.test.ts
@@ -1,5 +1,30 @@
-import { expect, test } from "bun:test";
-import { predictionHistoryPoints } from "./capability";
+import { afterEach, expect, test } from "bun:test";
+import { setHttpFetchTransport } from "../../utils/http-transport";
+import {
+  predictionChartSeriesCapability,
+  predictionHistoryPoints,
+  predictionSeriesId,
+} from "./capability";
+import { resetPredictionMarketsPersistence } from "./services/fetch";
+import type { PredictionMarketSummary } from "./types";
+
+function json(value: unknown) {
+  return new Response(JSON.stringify(value), { status: 200 });
+}
+
+function identity(overrides: Partial<PredictionMarketSummary>): PredictionMarketSummary {
+  return {
+    venue: "polymarket",
+    marketId: "market-1",
+    eventId: "event-1",
+    ...overrides,
+  } as PredictionMarketSummary;
+}
+
+afterEach(() => {
+  setHttpFetchTransport(null);
+  resetPredictionMarketsPersistence();
+});
 
 test("prediction chart history restores persisted dates, drops invalid rows, and sorts observations", () => {
   const points = predictionHistoryPoints([
@@ -13,4 +38,127 @@ test("prediction chart history restores persisted dates, drops invalid rows, and
     ["2026-02-02T00:00:00.000Z", 0.6],
   ]);
   expect(points[0]).toMatchObject({ open: 0.3, provenance: { providerId: "polymarket", quality: "reported" } });
+});
+
+test("stable prediction IDs retain provider lookup identity", () => {
+  expect(predictionSeriesId(identity({ venue: "kalshi", eventTicker: "EVT-1", marketId: "MKT-1" })))
+    .toBe("kalshi/EVT-1/MKT-1");
+  expect(predictionSeriesId(identity({ venue: "polymarket", eventId: "123", marketId: "456" })))
+    .toBe("polymarket/123/456");
+  expect(predictionSeriesId(identity({ venue: "polymarket", eventId: undefined }))).toBeNull();
+});
+
+test("catalog limit bounds provider search hydration", async () => {
+  const requested: string[] = [];
+  setHttpFetchTransport(async (url) => {
+    requested.push(url);
+    if (url.includes("public-search")) {
+      return json({ events: Array.from({ length: 5 }, (_, index) => ({ id: `event-${index + 1}` })) });
+    }
+    if (url.includes("gamma-api.polymarket.com/events/event-")) {
+      const eventId = url.split("/").at(-1)!;
+      return json({
+        id: eventId,
+        title: `Rates ${eventId}`,
+        markets: [{
+          id: `market-${eventId}`,
+          question: `Rates ${eventId}`,
+          active: true,
+          closed: false,
+          outcomes: ["Yes", "No"],
+          outcomePrices: ["0.5", "0.5"],
+          clobTokenIds: [`yes-${eventId}`, `no-${eventId}`],
+        }],
+      });
+    }
+    if (url.includes("api.elections.kalshi.com/trade-api/v2/events")) {
+      return json({ events: [] });
+    }
+    throw new Error(`Unexpected URL ${url}`);
+  });
+
+  const items = await predictionChartSeriesCapability.provider.search!({ query: "rates", limit: 2 });
+
+  expect(items).toHaveLength(2);
+  expect(requested.filter((url) => url.includes("gamma-api.polymarket.com/events/event-"))).toHaveLength(2);
+  expect(requested.some((url) => url.includes("api.elections.kalshi.com") && url.includes("limit=20"))).toBe(true);
+});
+
+test("polymarket resolution reloads the event and follows a rotated YES token", async () => {
+  const requested: string[] = [];
+  setHttpFetchTransport(async (url) => {
+    requested.push(url);
+    if (url.endsWith("/events/event-1")) {
+      return json({
+        id: "event-1",
+        title: "Current event",
+        markets: [{
+          id: "market-1",
+          question: "Current market title",
+          active: true,
+          closed: false,
+          outcomes: ["Yes", "No"],
+          outcomePrices: ["0.7", "0.3"],
+          clobTokenIds: ["rotated-yes", "rotated-no"],
+        }],
+      });
+    }
+    if (url.includes("prices-history")) return json({ history: [{ t: 1_700_000_000, p: 0.7 }] });
+    throw new Error(`Unexpected URL ${url}`);
+  });
+
+  const resolved = await predictionChartSeriesCapability.provider.resolve({
+    seriesId: "polymarket/event-1/market-1",
+    viewport: { range: "1M", resolution: "auto" },
+  });
+
+  expect(resolved.label).toBe("Current market title");
+  expect(resolved.points[0]?.value).toBe(0.7);
+  expect(requested.some((url) => url.includes("market=rotated-yes"))).toBe(true);
+});
+
+test("kalshi resolution reloads the event before requesting current market history", async () => {
+  const requested: string[] = [];
+  setHttpFetchTransport(async (url) => {
+    requested.push(url);
+    if (url.endsWith("/events/EVT-1")) {
+      return json({
+        event: { title: "Current event", event_ticker: "EVT-1", series_ticker: "SERIES-NEW" },
+        markets: [{
+          ticker: "MKT-1",
+          event_ticker: "EVT-1",
+          title: "Current Kalshi market",
+          status: "active",
+          market_type: "binary",
+          last_price_dollars: "0.55",
+        }],
+      });
+    }
+    if (url.includes("/candlesticks")) {
+      return json({ candlesticks: [{ end_period_ts: 1_700_000_000, price: { close_dollars: "0.55" } }] });
+    }
+    throw new Error(`Unexpected URL ${url}`);
+  });
+
+  const resolved = await predictionChartSeriesCapability.provider.resolve({
+    seriesId: "kalshi/EVT-1/MKT-1",
+    viewport: {
+      range: "1W",
+      resolution: "auto",
+      dateWindow: { start: "2026-01-01T00:00:00.000Z", end: "2026-01-08T00:00:00.000Z" },
+    },
+  });
+
+  expect(resolved.label).toBe("Current Kalshi market");
+  expect(requested.some((url) => url.includes("/series/SERIES-NEW/markets/MKT-1/candlesticks"))).toBe(true);
+  expect(requested.some((url) => url.includes("start_ts=1767225600") && url.includes("end_ts=1767830400"))).toBe(true);
+});
+
+test("resolution reports an actionable error when a persisted market disappears", async () => {
+  setHttpFetchTransport(async () => json({ id: "event-1", title: "Current event", markets: [] }));
+
+  await expect(predictionChartSeriesCapability.provider.resolve({
+    seriesId: "polymarket/event-1/missing",
+    viewport: { range: "1M", resolution: "auto" },
+  })).rejects.toThrow("no longer resolvable. Remove or replace this chart series");
 });

--- a/src/plugins/prediction-markets/capability.test.ts
+++ b/src/plugins/prediction-markets/capability.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+import { predictionHistoryPoints } from "./capability";
+
+test("prediction chart history restores persisted dates, drops invalid rows, and sorts observations", () => {
+  const points = predictionHistoryPoints([
+    { date: "2026-02-02T00:00:00Z" as unknown as Date, close: 0.6 },
+    { date: new Date("invalid"), close: 0.9 },
+    { date: "2026-02-01T00:00:00Z" as unknown as Date, close: 0.4, open: 0.3 },
+  ], "polymarket");
+
+  expect(points.map((point) => [point.date.toISOString(), point.value])).toEqual([
+    ["2026-02-01T00:00:00.000Z", 0.4],
+    ["2026-02-02T00:00:00.000Z", 0.6],
+  ]);
+  expect(points[0]).toMatchObject({ open: 0.3, provenance: { providerId: "polymarket", quality: "reported" } });
+});

--- a/src/plugins/prediction-markets/capability.test.ts
+++ b/src/plugins/prediction-markets/capability.test.ts
@@ -5,7 +5,11 @@ import {
   predictionHistoryPoints,
   predictionSeriesId,
 } from "./capability";
-import { resetPredictionMarketsPersistence } from "./services/fetch";
+import {
+  attachPredictionMarketsPersistence,
+  resetPredictionMarketsPersistence,
+} from "./services/fetch";
+import { MemoryPersistence } from "./test-helpers";
 import type { PredictionMarketSummary } from "./types";
 
 function json(value: unknown) {
@@ -115,6 +119,119 @@ test("polymarket resolution reloads the event and follows a rotated YES token", 
   expect(resolved.label).toBe("Current market title");
   expect(resolved.points[0]?.value).toBe(0.7);
   expect(requested.some((url) => url.includes("market=rotated-yes"))).toBe(true);
+});
+
+test("polymarket pans request and cache their bounded history windows", async () => {
+  attachPredictionMarketsPersistence(new MemoryPersistence());
+  const historyRequests: string[] = [];
+  setHttpFetchTransport(async (url) => {
+    if (url.endsWith("/events/event-1")) {
+      return json({
+        id: "event-1",
+        title: "Current event",
+        markets: [{
+          id: "market-1",
+          question: "Current market title",
+          active: true,
+          closed: false,
+          outcomes: ["Yes", "No"],
+          outcomePrices: ["0.7", "0.3"],
+          clobTokenIds: ["yes-token", "no-token"],
+        }],
+      });
+    }
+    if (url.includes("prices-history")) {
+      historyRequests.push(url);
+      const start = Number(new URL(url).searchParams.get("startTs"));
+      return json({ history: [{ t: start + 1, p: 0.7 }] });
+    }
+    throw new Error(`Unexpected URL ${url}`);
+  });
+  const viewport = (start: string, end: string) => ({
+    range: "1W" as const,
+    resolution: "auto" as const,
+    dateWindow: { start, end },
+  });
+  const january = viewport("2026-01-01T00:00:00.000Z", "2026-01-08T00:00:00.000Z");
+  const february = viewport("2026-02-01T00:00:00.000Z", "2026-02-08T00:00:00.000Z");
+
+  await predictionChartSeriesCapability.provider.resolve({
+    seriesId: "polymarket/event-1/market-1",
+    viewport: january,
+  });
+  const panned = await predictionChartSeriesCapability.provider.resolve({
+    seriesId: "polymarket/event-1/market-1",
+    viewport: february,
+  });
+  await predictionChartSeriesCapability.provider.resolve({
+    seriesId: "polymarket/event-1/market-1",
+    viewport: january,
+  });
+
+  expect(historyRequests).toHaveLength(2);
+  expect(historyRequests.map((url) => {
+    const params = new URL(url).searchParams;
+    return [params.get("startTs"), params.get("endTs"), params.get("interval")];
+  })).toEqual([
+    [String(Date.parse(january.dateWindow.start) / 1000), String(Date.parse(january.dateWindow.end) / 1000), null],
+    [String(Date.parse(february.dateWindow.start) / 1000), String(Date.parse(february.dateWindow.end) / 1000), null],
+  ]);
+  expect(panned.points[0]?.date.toISOString()).toBe("2026-02-01T00:00:01.000Z");
+});
+
+test("aborting catalog search stops Polymarket event hydration without caching it", async () => {
+  attachPredictionMarketsPersistence(new MemoryPersistence());
+  let searchRequests = 0;
+  let eventRequests = 0;
+  let markHydrationStarted: (() => void) | undefined;
+  const hydrationStarted = new Promise<void>((resolve) => {
+    markHydrationStarted = resolve;
+  });
+  setHttpFetchTransport(async (url, init) => {
+    if (url.includes("public-search")) {
+      searchRequests += 1;
+      return json({ events: [{ id: "event-1" }] });
+    }
+    if (url.endsWith("/events/event-1")) {
+      eventRequests += 1;
+      if (eventRequests === 1) {
+        markHydrationStarted?.();
+        return await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+        });
+      }
+      return json({
+        id: "event-1",
+        title: "Rates",
+        markets: [{
+          id: "market-1",
+          question: "Rates",
+          active: true,
+          closed: false,
+          outcomes: ["Yes", "No"],
+          outcomePrices: ["0.5", "0.5"],
+          clobTokenIds: ["yes", "no"],
+        }],
+      });
+    }
+    if (url.includes("api.elections.kalshi.com")) return json({ events: [] });
+    throw new Error(`Unexpected URL ${url}`);
+  });
+
+  const controller = new AbortController();
+  const pending = predictionChartSeriesCapability.provider.search!({
+    query: "rates",
+    limit: 1,
+    signal: controller.signal,
+  });
+  await hydrationStarted;
+  controller.abort();
+  await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+
+  const retried = await predictionChartSeriesCapability.provider.search!({ query: "rates", limit: 1 });
+  expect(retried).toHaveLength(1);
+  expect(searchRequests).toBe(2);
+  expect(eventRequests).toBe(2);
 });
 
 test("kalshi resolution reloads the event before requesting current market history", async () => {

--- a/src/plugins/prediction-markets/capability.ts
+++ b/src/plugins/prediction-markets/capability.ts
@@ -137,18 +137,20 @@ export const predictionChartSeriesCapability = chartSeriesProvider({
     search: (request) => catalog(request.query, request.limit, request.signal),
     async resolve(request): Promise<ResolvedSeries> {
       const identity = parsePredictionSeriesId(request.seriesId);
-      const summary = await resolveCurrentSummary(identity);
+      const summary = await resolveCurrentSummary(identity, request.signal);
       const range = historyRange(request);
       const dateWindow = request.viewport.dateWindow;
+      const historyOptions = {
+        ...(dateWindow ? {
+          start: new Date(dateWindow.start),
+          end: new Date(dateWindow.end),
+        } : {}),
+        signal: request.signal,
+        strict: true,
+      };
       const history = summary.venue === "kalshi"
-        ? await loadKalshiHistory(summary, range, {
-            ...(dateWindow ? {
-              start: new Date(dateWindow.start),
-              end: new Date(dateWindow.end),
-            } : {}),
-            strict: true,
-          })
-        : await loadPolymarketHistory(summary, range, { strict: true });
+        ? await loadKalshiHistory(summary, range, historyOptions)
+        : await loadPolymarketHistory(summary, range, historyOptions);
       return {
         id: request.seriesId,
         label: summary.title.slice(0, 160),

--- a/src/plugins/prediction-markets/capability.ts
+++ b/src/plugins/prediction-markets/capability.ts
@@ -1,42 +1,63 @@
 import { chartSeriesProvider, type ChartSeriesCatalogItem, type ChartSeriesResolveRequest } from "../../capabilities";
-import type { ChartSeriesParameterValue, ResolvedSeries, TimeSeriesPoint } from "../../time-series/types";
-import { loadKalshiCatalog, loadKalshiHistory } from "./services/kalshi/adapter";
+import { debugLog } from "../../utils/debug-log";
+import type { ResolvedSeries, TimeSeriesPoint } from "../../time-series/types";
+import {
+  loadKalshiCatalog,
+  loadKalshiHistory,
+  resolveKalshiChartSummary,
+} from "./services/kalshi/adapter";
 import { loadPolymarketCatalog } from "./services/polymarket/adapter";
-import { loadPolymarketHistory } from "./services/polymarket/detail";
-import type { PredictionHistoryPoint, PredictionHistoryRange, PredictionMarketSummary } from "./types";
+import {
+  loadPolymarketHistory,
+  resolvePolymarketChartSummary,
+} from "./services/polymarket/detail";
+import type { PredictionHistoryPoint, PredictionHistoryRange, PredictionMarketSummary, PredictionVenue } from "./types";
 
 export const PREDICTION_CHART_SERIES_CAPABILITY_ID = "prediction-markets.series";
+const predictionSeriesLog = debugLog.createLogger("prediction-markets.series");
+
+interface PredictionSeriesIdentity {
+  venue: PredictionVenue;
+  eventId: string;
+  marketId: string;
+}
+
+export function predictionSeriesId(summary: PredictionMarketSummary): string | null {
+  const eventId = summary.venue === "kalshi" ? summary.eventTicker : summary.eventId;
+  if (!eventId?.trim() || !summary.marketId.trim()) return null;
+  const id = `${summary.venue}/${encodeURIComponent(eventId)}/${encodeURIComponent(summary.marketId)}`;
+  return id.length <= 240 ? id : null;
+}
+
+function parsePredictionSeriesId(seriesId: string): PredictionSeriesIdentity {
+  const parts = seriesId.split("/");
+  if (parts.length !== 3 || (parts[0] !== "kalshi" && parts[0] !== "polymarket")) {
+    throw new Error(`Prediction series ID ${seriesId} is invalid. Remove and add the series again.`);
+  }
+  try {
+    const eventId = decodeURIComponent(parts[1] ?? "");
+    const marketId = decodeURIComponent(parts[2] ?? "");
+    if (!eventId || !marketId) throw new Error("missing identity");
+    return { venue: parts[0], eventId, marketId };
+  } catch {
+    throw new Error(`Prediction series ID ${seriesId} is invalid. Remove and add the series again.`);
+  }
+}
 
 function historyRange(request: ChartSeriesResolveRequest): PredictionHistoryRange {
+  if (request.viewport.dateWindow) {
+    const span = Date.parse(request.viewport.dateWindow.end) - Date.parse(request.viewport.dateWindow.start);
+    if (span <= 24 * 60 * 60_000) return "1D";
+    if (span <= 7 * 24 * 60 * 60_000) return "1W";
+    if (span <= 31 * 24 * 60 * 60_000) return "1M";
+    return "ALL";
+  }
   switch (request.viewport.range) {
     case "1D": return "1D";
     case "1W": return "1W";
     case "1M": return "1M";
     default: return "ALL";
   }
-}
-
-function summaryParameters(summary: PredictionMarketSummary) {
-  return { summary: JSON.parse(JSON.stringify({
-    venue: summary.venue,
-    key: summary.key,
-    marketId: summary.marketId,
-    title: summary.title,
-    eventTicker: summary.eventTicker,
-    yesTokenId: summary.yesTokenId,
-  })) as ChartSeriesParameterValue };
-}
-
-function summaryFrom(request: ChartSeriesResolveRequest): PredictionMarketSummary {
-  const value = request.parameters?.summary;
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`Prediction market metadata is missing for ${request.seriesId}. Add the series again from search.`);
-  }
-  const summary = value as unknown as PredictionMarketSummary;
-  if ((summary.venue !== "kalshi" && summary.venue !== "polymarket") || !summary.marketId || !summary.key || !summary.title) {
-    throw new Error(`Prediction market metadata is invalid for ${request.seriesId}.`);
-  }
-  return summary;
 }
 
 export function predictionHistoryPoints(points: PredictionHistoryPoint[], venue: string): TimeSeriesPoint[] {
@@ -57,43 +78,80 @@ export function predictionHistoryPoints(points: PredictionHistoryPoint[], venue:
   }).sort((left, right) => left.date.getTime() - right.date.getTime());
 }
 
-function catalogItem(summary: PredictionMarketSummary): ChartSeriesCatalogItem {
+function catalogItem(summary: PredictionMarketSummary): ChartSeriesCatalogItem | null {
+  const seriesId = predictionSeriesId(summary);
+  if (!seriesId) return null;
   return {
-    seriesId: summary.key,
-    label: summary.title,
+    seriesId,
+    label: summary.title.slice(0, 160),
     description: `${summary.venue === "kalshi" ? "Kalshi" : "Polymarket"} · YES probability`,
     detail: summary.venue === "kalshi" ? "Kalshi" : "Polymarket",
-    parameters: summaryParameters(summary),
     style: "area",
   };
 }
 
-async function catalog(query = "", limit = 8): Promise<ChartSeriesCatalogItem[]> {
-  const [polymarket, kalshi] = await Promise.all([
-    loadPolymarketCatalog(query).catch(() => []),
-    loadKalshiCatalog(query).catch(() => []),
-  ]);
-  return [...polymarket, ...kalshi]
+async function catalog(
+  query = "",
+  limit = 8,
+  signal?: AbortSignal,
+): Promise<ChartSeriesCatalogItem[]> {
+  const providers = [
+    { id: "polymarket", load: () => loadPolymarketCatalog(query, "all", { limit, signal }) },
+    { id: "kalshi", load: () => loadKalshiCatalog(query, "all", { limit, signal }) },
+  ] as const;
+  const results = await Promise.allSettled(providers.map((provider) => provider.load()));
+  if (signal?.aborted) throw signal.reason ?? new DOMException("Aborted", "AbortError");
+  const failures = results.flatMap((result, index) => {
+    if (result.status === "fulfilled") return [];
+    const error = result.reason instanceof Error ? result.reason.message : String(result.reason);
+    predictionSeriesLog.warn("Prediction chart catalog provider failed", {
+      provider: providers[index]?.id,
+      error,
+    });
+    return [`${providers[index]?.id}: ${error}`];
+  });
+  if (failures.length === providers.length) {
+    throw new Error(`Prediction chart catalog failed (${failures.join("; ")}).`);
+  }
+  return results
+    .flatMap((result) => result.status === "fulfilled" ? result.value : [])
     .sort((left, right) => (right.volume24h ?? 0) - (left.volume24h ?? 0))
-    .slice(0, limit)
-    .map(catalogItem);
+    .flatMap((summary) => {
+      const item = catalogItem(summary);
+      return item ? [item] : [];
+    })
+    .slice(0, limit);
+}
+
+async function resolveCurrentSummary(identity: PredictionSeriesIdentity, signal?: AbortSignal) {
+  return identity.venue === "kalshi"
+    ? resolveKalshiChartSummary(identity.eventId, identity.marketId, signal)
+    : resolvePolymarketChartSummary(identity.eventId, identity.marketId, signal);
 }
 
 export const predictionChartSeriesCapability = chartSeriesProvider({
   id: PREDICTION_CHART_SERIES_CAPABILITY_ID,
   name: "Prediction Markets",
   provider: {
-    catalog: (request) => catalog(request.query, request.limit),
-    search: (request) => catalog(request.query, request.limit),
+    catalog: (request) => catalog(request.query, request.limit, request.signal),
+    search: (request) => catalog(request.query, request.limit, request.signal),
     async resolve(request): Promise<ResolvedSeries> {
-      const summary = summaryFrom(request);
+      const identity = parsePredictionSeriesId(request.seriesId);
+      const summary = await resolveCurrentSummary(identity);
       const range = historyRange(request);
+      const dateWindow = request.viewport.dateWindow;
       const history = summary.venue === "kalshi"
-        ? await loadKalshiHistory(summary, range)
-        : await loadPolymarketHistory(summary, range);
+        ? await loadKalshiHistory(summary, range, {
+            ...(dateWindow ? {
+              start: new Date(dateWindow.start),
+              end: new Date(dateWindow.end),
+            } : {}),
+            strict: true,
+          })
+        : await loadPolymarketHistory(summary, range, { strict: true });
       return {
         id: request.seriesId,
-        label: summary.title,
+        label: summary.title.slice(0, 160),
         color: "#4dabf7",
         unit: "probability",
         unitGroup: "probability",

--- a/src/plugins/prediction-markets/capability.ts
+++ b/src/plugins/prediction-markets/capability.ts
@@ -1,0 +1,111 @@
+import { chartSeriesProvider, type ChartSeriesCatalogItem, type ChartSeriesResolveRequest } from "../../capabilities";
+import type { ChartSeriesParameterValue, ResolvedSeries, TimeSeriesPoint } from "../../time-series/types";
+import { loadKalshiCatalog, loadKalshiHistory } from "./services/kalshi/adapter";
+import { loadPolymarketCatalog } from "./services/polymarket/adapter";
+import { loadPolymarketHistory } from "./services/polymarket/detail";
+import type { PredictionHistoryPoint, PredictionHistoryRange, PredictionMarketSummary } from "./types";
+
+export const PREDICTION_CHART_SERIES_CAPABILITY_ID = "prediction-markets.series";
+
+function historyRange(request: ChartSeriesResolveRequest): PredictionHistoryRange {
+  switch (request.viewport.range) {
+    case "1D": return "1D";
+    case "1W": return "1W";
+    case "1M": return "1M";
+    default: return "ALL";
+  }
+}
+
+function summaryParameters(summary: PredictionMarketSummary) {
+  return { summary: JSON.parse(JSON.stringify({
+    venue: summary.venue,
+    key: summary.key,
+    marketId: summary.marketId,
+    title: summary.title,
+    eventTicker: summary.eventTicker,
+    yesTokenId: summary.yesTokenId,
+  })) as ChartSeriesParameterValue };
+}
+
+function summaryFrom(request: ChartSeriesResolveRequest): PredictionMarketSummary {
+  const value = request.parameters?.summary;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Prediction market metadata is missing for ${request.seriesId}. Add the series again from search.`);
+  }
+  const summary = value as unknown as PredictionMarketSummary;
+  if ((summary.venue !== "kalshi" && summary.venue !== "polymarket") || !summary.marketId || !summary.key || !summary.title) {
+    throw new Error(`Prediction market metadata is invalid for ${request.seriesId}.`);
+  }
+  return summary;
+}
+
+export function predictionHistoryPoints(points: PredictionHistoryPoint[], venue: string): TimeSeriesPoint[] {
+  return points.flatMap((point) => {
+    const date = point.date instanceof Date ? new Date(point.date) : new Date(point.date as unknown as string);
+    if (!Number.isFinite(date.getTime()) || !Number.isFinite(point.close)) return [];
+    return [{
+      date,
+      observedAt: new Date(date),
+      value: point.close,
+      open: point.open,
+      high: point.high,
+      low: point.low,
+      close: point.close,
+      volume: point.volume,
+      provenance: { providerId: venue, quality: "reported" as const },
+    }];
+  }).sort((left, right) => left.date.getTime() - right.date.getTime());
+}
+
+function catalogItem(summary: PredictionMarketSummary): ChartSeriesCatalogItem {
+  return {
+    seriesId: summary.key,
+    label: summary.title,
+    description: `${summary.venue === "kalshi" ? "Kalshi" : "Polymarket"} · YES probability`,
+    detail: summary.venue === "kalshi" ? "Kalshi" : "Polymarket",
+    parameters: summaryParameters(summary),
+    style: "area",
+  };
+}
+
+async function catalog(query = "", limit = 8): Promise<ChartSeriesCatalogItem[]> {
+  const [polymarket, kalshi] = await Promise.all([
+    loadPolymarketCatalog(query).catch(() => []),
+    loadKalshiCatalog(query).catch(() => []),
+  ]);
+  return [...polymarket, ...kalshi]
+    .sort((left, right) => (right.volume24h ?? 0) - (left.volume24h ?? 0))
+    .slice(0, limit)
+    .map(catalogItem);
+}
+
+export const predictionChartSeriesCapability = chartSeriesProvider({
+  id: PREDICTION_CHART_SERIES_CAPABILITY_ID,
+  name: "Prediction Markets",
+  provider: {
+    catalog: (request) => catalog(request.query, request.limit),
+    search: (request) => catalog(request.query, request.limit),
+    async resolve(request): Promise<ResolvedSeries> {
+      const summary = summaryFrom(request);
+      const range = historyRange(request);
+      const history = summary.venue === "kalshi"
+        ? await loadKalshiHistory(summary, range)
+        : await loadPolymarketHistory(summary, range);
+      return {
+        id: request.seriesId,
+        label: summary.title,
+        color: "#4dabf7",
+        unit: "probability",
+        unitGroup: "probability",
+        nativeFrequency: "auto",
+        dataShape: "scalar",
+        style: "area",
+        transform: "raw",
+        axis: "left",
+        panelId: "main",
+        interpolation: "none",
+        points: predictionHistoryPoints(history, summary.venue),
+      };
+    },
+  },
+});

--- a/src/plugins/prediction-markets/detail.test.tsx
+++ b/src/plugins/prediction-markets/detail.test.tsx
@@ -59,7 +59,7 @@ describe("prediction markets detail views", () => {
     const frame = testSetup.captureCharFrame();
     expect(frame).toContain("Outcomes");
     expect(frame).toContain("Above 4.25%");
-    expect(frame).toContain("Loading chart...");
+    expect(frame).toContain("Chart");
     expect(frame).not.toContain("No chart history.");
     expect(frame).not.toContain("Loading market detail...");
   });

--- a/src/plugins/prediction-markets/detail/overview.tsx
+++ b/src/plugins/prediction-markets/detail/overview.tsx
@@ -2,9 +2,7 @@ import { Box, Text } from "../../../ui";
 import { TextAttributes } from "../../../ui";
 import { colors } from "../../../theme/colors";
 import { formatPercentRaw } from "../../../utils/format";
-import { PredictionMarketChart } from "../chart";
 import type {
-  PredictionHistoryRange,
   PredictionListRow,
   PredictionMarketDetail,
   PredictionMarketSummary,
@@ -15,20 +13,12 @@ import { SummaryLink } from "./shared";
 export function PredictionMarketOverviewView({
   detail,
   detailWidth,
-  height,
-  historyRange,
-  loading,
-  onHistoryRangeChange,
   onSelectMarket,
   selectedRow,
   summary,
 }: {
   detail: PredictionMarketDetail | null;
   detailWidth: number;
-  height: number;
-  historyRange: PredictionHistoryRange;
-  loading: boolean;
-  onHistoryRangeChange: (range: PredictionHistoryRange) => void;
   onSelectMarket: (marketKey: string) => void;
   selectedRow: PredictionListRow | null;
   summary: PredictionMarketSummary;
@@ -45,14 +35,6 @@ export function PredictionMarketOverviewView({
           selectedRow={selectedRow}
         />
       )}
-      <PredictionMarketChart
-        history={detail?.history ?? []}
-        width={detailWidth}
-        height={Math.max(Math.floor(height * 0.36), 10)}
-        loading={loading}
-        range={historyRange}
-        onRangeSelect={onHistoryRangeChange}
-      />
       <SummaryLink
         url={summary.url}
         maxLength={Math.max(detailWidth - 8, 12)}

--- a/src/plugins/prediction-markets/detail/pane.tsx
+++ b/src/plugins/prediction-markets/detail/pane.tsx
@@ -26,6 +26,7 @@ import { PredictionMarketOverviewView } from "./overview";
 import { PredictionMarketRulesView } from "./rules";
 import { truncatePredictionText } from "./shared";
 import { PredictionMarketTradesView } from "./trades";
+import { PredictionMarketChart } from "../chart";
 
 type RelatedMarketPointerEvent = { preventDefault(): void };
 
@@ -262,10 +263,6 @@ export function PredictionMarketDetailPane({
             <PredictionMarketOverviewView
               detail={detail}
               detailWidth={detailWidth}
-              height={height}
-              historyRange={historyRange}
-              loading={detailLoading}
-              onHistoryRangeChange={onHistoryRangeChange}
               onSelectMarket={onSelectMarket}
               selectedRow={selectedRow}
               summary={summaryMetrics}
@@ -280,6 +277,17 @@ export function PredictionMarketDetailPane({
           )}
         </ScrollBox>
       ) : null}
+
+      {detailTab === "chart" && (
+        <PredictionMarketChart
+          history={detail?.history ?? []}
+          width={detailWidth}
+          height={Math.max(height - 8, 8)}
+          loading={detailLoading}
+          range={historyRange}
+          onRangeSelect={onHistoryRangeChange}
+        />
+      )}
 
       {detailTab === "book" && (
         detail ? (

--- a/src/plugins/prediction-markets/index.tsx
+++ b/src/plugins/prediction-markets/index.tsx
@@ -3,6 +3,7 @@ import { parsePredictionSearchShortcut } from "./navigation";
 import { PredictionMarketsPane } from "./pane";
 import { attachPredictionMarketsPersistence, resetPredictionMarketsPersistence } from "./services/fetch";
 import { predictionMarketsCliCommand } from "./cli";
+import { predictionChartSeriesCapability } from "./capability";
 import {
   buildPredictionMarketsPaneSettingsDef,
   createPredictionMarketsPaneSettings,
@@ -28,6 +29,7 @@ export const predictionMarketsPlugin: GloomPlugin = {
     "Browse prediction markets (Polymarket and Kalshi).",
   toggleable: true,
   cliCommands: [predictionMarketsCliCommand],
+  capabilities: [predictionChartSeriesCapability],
   panes: [
     {
       id: PANE_ID,

--- a/src/plugins/prediction-markets/navigation.ts
+++ b/src/plugins/prediction-markets/navigation.ts
@@ -28,6 +28,7 @@ export const DETAIL_TABS: ReadonlyArray<{
   value: PredictionDetailTab;
 }> = [
   { label: "Overview", value: "overview" },
+  { label: "Chart", value: "chart" },
   { label: "Book", value: "book" },
   { label: "Trades", value: "trades" },
   { label: "Rules", value: "rules" },

--- a/src/plugins/prediction-markets/pane.test.tsx
+++ b/src/plugins/prediction-markets/pane.test.tsx
@@ -278,7 +278,7 @@ describe("prediction markets pane interactions", () => {
       url.includes("/trade-api/v2/series/FED/markets/KAL-1/candlesticks"),
     );
 
-    expect(eventFetches).toHaveLength(2);
+    expect(eventFetches).toHaveLength(1);
     expect(orderbookFetches).toHaveLength(1);
     expect(tradeFetches).toHaveLength(1);
     expect(historyFetches).toHaveLength(1);

--- a/src/plugins/prediction-markets/services/fetch.ts
+++ b/src/plugins/prediction-markets/services/fetch.ts
@@ -40,8 +40,8 @@ export function resetPredictionMarketsPersistence(): void {
   predictionMarketsPersistence = null;
 }
 
-export async function fetchJson<T>(url: string): Promise<T> {
-  const response = await PREDICTION_FETCH.fetch(url);
+export async function fetchJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const response = await PREDICTION_FETCH.fetch(url, { signal });
   if (!response.ok) {
     throw new Error(`Request failed (${response.status}) for ${url}`);
   }
@@ -98,6 +98,7 @@ export async function loadCachedPredictionResource<T>(
     setCachedPredictionResource(kind, key, nextValue, cachePolicy);
     return nextValue;
   } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") throw error;
     if (cached) return cached.value;
     throw error;
   }

--- a/src/plugins/prediction-markets/services/kalshi/adapter.ts
+++ b/src/plugins/prediction-markets/services/kalshi/adapter.ts
@@ -39,9 +39,9 @@ const KALSHI_EVENT_PAGE_LIMIT = 200;
 const DEFAULT_KALSHI_EVENT_MAX_PAGES = 3;
 const SEARCH_KALSHI_EVENT_MAX_PAGES = 3;
 
-function buildKalshiCatalogUrl(cursor?: string, category?: string): string {
+function buildKalshiCatalogUrl(cursor?: string, category?: string, limit = KALSHI_EVENT_PAGE_LIMIT): string {
   const url = new URL("https://api.elections.kalshi.com/trade-api/v2/events");
-  url.searchParams.set("limit", String(KALSHI_EVENT_PAGE_LIMIT));
+  url.searchParams.set("limit", String(limit));
   url.searchParams.set("status", "open");
   url.searchParams.set("with_nested_markets", "true");
   if (category) url.searchParams.set("category", category);
@@ -51,13 +51,16 @@ function buildKalshiCatalogUrl(cursor?: string, category?: string): string {
 
 async function fetchKalshiCatalogEvents(
   maxPages = DEFAULT_KALSHI_EVENT_MAX_PAGES,
+  limit = KALSHI_EVENT_PAGE_LIMIT,
+  signal?: AbortSignal,
 ): Promise<KalshiEventRecord[]> {
   const events: KalshiEventRecord[] = [];
   let cursor: string | undefined;
 
   for (let page = 0; page < maxPages; page += 1) {
     const response = await fetchJson<KalshiEventsResponse>(
-      buildKalshiCatalogUrl(cursor),
+      buildKalshiCatalogUrl(cursor, undefined, limit),
+      signal,
     );
     events.push(...(response.events ?? []));
     cursor = response.cursor?.trim() || undefined;
@@ -70,16 +73,19 @@ async function fetchKalshiCatalogEvents(
 async function fetchKalshiCatalogEventsForCategory(
   categoryId: PredictionCategoryId,
   maxPages = DEFAULT_KALSHI_EVENT_MAX_PAGES,
+  limit = KALSHI_EVENT_PAGE_LIMIT,
+  signal?: AbortSignal,
 ): Promise<KalshiEventRecord[]> {
   const categories = getKalshiCategoryNames(categoryId);
-  if (categories.length === 0) return await fetchKalshiCatalogEvents(maxPages);
+  if (categories.length === 0) return await fetchKalshiCatalogEvents(maxPages, limit, signal);
 
   const deduped = new Map<string, KalshiEventRecord>();
   for (const category of categories) {
     let cursor: string | undefined;
     for (let page = 0; page < maxPages; page += 1) {
       const response = await fetchJson<KalshiEventsResponse>(
-        buildKalshiCatalogUrl(cursor, category),
+        buildKalshiCatalogUrl(cursor, category, limit),
+        signal,
       );
       for (const event of response.events ?? []) {
         const key = event.event_ticker ?? event.title;
@@ -96,20 +102,20 @@ async function fetchKalshiCatalogEventsForCategory(
 export async function loadKalshiCatalog(
   searchQuery = "",
   categoryId: PredictionCategoryId = "all",
+  options: { limit?: number; signal?: AbortSignal } = {},
 ): Promise<PredictionMarketSummary[]> {
   const normalizedQuery = searchQuery.trim().toLowerCase();
+  const requestedLimit = Math.max(1, Math.min(KALSHI_EVENT_PAGE_LIMIT, options.limit ?? KALSHI_EVENT_PAGE_LIMIT));
+  const pageLimit = Math.max(20, requestedLimit);
+  const maxPages = options.limit ? 1 : normalizedQuery ? SEARCH_KALSHI_EVENT_MAX_PAGES : DEFAULT_KALSHI_EVENT_MAX_PAGES;
   return await loadCachedPredictionResource(
     "catalog",
-    buildPredictionCatalogResourceKey("kalshi", categoryId, normalizedQuery),
+    `${buildPredictionCatalogResourceKey("kalshi", categoryId, normalizedQuery)}:${requestedLimit}`,
     async () => {
-      const maxPages = normalizedQuery
-        ? SEARCH_KALSHI_EVENT_MAX_PAGES
-        : DEFAULT_KALSHI_EVENT_MAX_PAGES;
-      const events =
-        categoryId === "all"
-          ? await fetchKalshiCatalogEvents(maxPages)
-          : await fetchKalshiCatalogEventsForCategory(categoryId, maxPages);
-      return normalizeKalshiCatalog(events, normalizedQuery, categoryId);
+      const events = categoryId === "all"
+        ? await fetchKalshiCatalogEvents(maxPages, pageLimit, options.signal)
+        : await fetchKalshiCatalogEventsForCategory(categoryId, maxPages, pageLimit, options.signal);
+      return normalizeKalshiCatalog(events, normalizedQuery, categoryId).slice(0, requestedLimit);
     },
     PREDICTION_CACHE_POLICIES.catalog,
   );
@@ -132,6 +138,23 @@ async function loadKalshiEvent(
   } catch {
     return null;
   }
+}
+
+export async function resolveKalshiChartSummary(
+  eventTicker: string,
+  marketTicker: string,
+  signal?: AbortSignal,
+): Promise<PredictionMarketSummary> {
+  const response = await fetchJson<KalshiEventResponse>(
+    `https://api.elections.kalshi.com/trade-api/v2/events/${eventTicker}`,
+    signal,
+  );
+  const market = response.markets?.find((candidate) => candidate.ticker === marketTicker);
+  const summary = market ? normalizeKalshiMarket(market, response.event) : null;
+  if (!summary) {
+    throw new Error(`Kalshi market ${marketTicker} in event ${eventTicker} is no longer resolvable. Remove or replace this chart series.`);
+  }
+  return summary;
 }
 
 async function loadKalshiTrades(
@@ -194,11 +217,15 @@ async function loadKalshiBook(
 export async function loadKalshiHistory(
   summary: PredictionMarketSummary,
   range: "1D" | "1W" | "1M" | "ALL",
+  options: { start?: Date; end?: Date; signal?: AbortSignal; strict?: boolean } = {},
 ): Promise<PredictionHistoryPoint[]> {
-  const event = await loadKalshiEvent(summary.eventTicker);
-  if (!event?.event?.series_ticker) return [];
+  const seriesTicker = summary.seriesTicker ?? (await loadKalshiEvent(summary.eventTicker))?.event?.series_ticker;
+  if (!seriesTicker) {
+    if (options.strict) throw new Error(`Kalshi event ${summary.eventTicker ?? "unknown"} no longer exposes chart history.`);
+    return [];
+  }
 
-  const now = Math.floor(Date.now() / 1000);
+  const now = Math.floor((options.end?.getTime() ?? Date.now()) / 1000);
   const rangeSeconds =
     range === "1D"
       ? 24 * 60 * 60
@@ -208,15 +235,16 @@ export async function loadKalshiHistory(
           ? 30 * 24 * 60 * 60
           : 365 * 24 * 60 * 60;
   const periodInterval = range === "1D" ? 60 : range === "1W" ? 60 : 1440;
-  const start = now - rangeSeconds;
+  const start = Math.floor((options.start?.getTime() ?? (now * 1000 - rangeSeconds * 1000)) / 1000);
 
   try {
     return await loadCachedPredictionResource(
       "history",
-      `${summary.key}:${range}`,
+      `${summary.key}:${range}:${start}:${now}`,
       async () => {
         const response = await fetchJson<KalshiCandlestickResponse>(
-          `https://api.elections.kalshi.com/trade-api/v2/series/${event.event.series_ticker}/markets/${summary.marketId}/candlesticks?start_ts=${start}&end_ts=${now}&period_interval=${periodInterval}`,
+          `https://api.elections.kalshi.com/trade-api/v2/series/${seriesTicker}/markets/${summary.marketId}/candlesticks?start_ts=${start}&end_ts=${now}&period_interval=${periodInterval}`,
+          options.signal,
         );
         return (response.candlesticks ?? [])
           .map((candle) => ({
@@ -234,7 +262,8 @@ export async function loadKalshiHistory(
       },
       PREDICTION_CACHE_POLICIES.history,
     );
-  } catch {
+  } catch (error) {
+    if (options.strict) throw error;
     return [];
   }
 }

--- a/src/plugins/prediction-markets/services/kalshi/normalize.ts
+++ b/src/plugins/prediction-markets/services/kalshi/normalize.ts
@@ -66,6 +66,7 @@ export function normalizeKalshiMarket(
     title?: string;
     category?: string;
     series_ticker?: string;
+    event_ticker?: string;
     sub_title?: string;
   },
 ): PredictionMarketSummary | null {
@@ -103,7 +104,7 @@ export function normalizeKalshiMarket(
     title: record.title,
     marketLabel,
     eventLabel: eventLabel || eventMeta?.title || record.title,
-    eventTicker: record.event_ticker,
+    eventTicker: record.event_ticker ?? eventMeta?.event_ticker,
     seriesTicker: eventMeta?.series_ticker,
     category,
     tags: category ? [category] : [],
@@ -161,6 +162,7 @@ function flattenKalshiEvents(
         title: event.title,
         category: event.category,
         series_ticker: event.series_ticker,
+        event_ticker: event.event_ticker,
         sub_title: event.sub_title,
       });
       if (!normalized) continue;

--- a/src/plugins/prediction-markets/services/polymarket/adapter.ts
+++ b/src/plugins/prediction-markets/services/polymarket/adapter.ts
@@ -99,7 +99,7 @@ export async function loadPolymarketCatalog(
         const hydratedEvents = (
           await Promise.all(
             [...new Set(searchEvents.map((event) => event.id).filter(Boolean))]
-              .map((eventId) => loadPolymarketEvent(eventId)),
+              .map((eventId) => loadPolymarketEvent(eventId, options.signal)),
           )
         ).filter((event): event is PolymarketEventRecord => event != null);
         const resolvedEvents = reconcilePolymarketSearchEvents(

--- a/src/plugins/prediction-markets/services/polymarket/adapter.ts
+++ b/src/plugins/prediction-markets/services/polymarket/adapter.ts
@@ -31,9 +31,9 @@ export { loadPolymarketDetail } from "./detail";
 const POLYMARKET_CATALOG_OFFSETS = [0, 200, 400];
 const POLYMARKET_CATEGORY_OFFSETS = [0, 200];
 
-function buildPolymarketCatalogUrl(offset: number, tagSlug?: string): string {
+function buildPolymarketCatalogUrl(offset: number, tagSlug?: string, limit = 200): string {
   const url = new URL("https://gamma-api.polymarket.com/events");
-  url.searchParams.set("limit", "200");
+  url.searchParams.set("limit", String(limit));
   url.searchParams.set("offset", String(offset));
   url.searchParams.set("active", "true");
   url.searchParams.set("closed", "false");
@@ -43,10 +43,10 @@ function buildPolymarketCatalogUrl(offset: number, tagSlug?: string): string {
   return url.toString();
 }
 
-function buildPolymarketSearchUrl(query: string): string {
+function buildPolymarketSearchUrl(query: string, limit = 40): string {
   const url = new URL("https://gamma-api.polymarket.com/public-search");
   url.searchParams.set("q", query);
-  url.searchParams.set("limit_per_type", "40");
+  url.searchParams.set("limit_per_type", String(limit));
   url.searchParams.set("search_profiles", "false");
   url.searchParams.set("search_tags", "false");
   url.searchParams.set("events_status", "open");
@@ -57,11 +57,14 @@ function buildPolymarketSearchUrl(query: string): string {
 async function loadPolymarketCatalogPages(
   offsets: number[],
   tagSlug?: string,
+  limit = 200,
+  signal?: AbortSignal,
 ): Promise<PolymarketEventRecord[]> {
   const results = await Promise.allSettled(
     offsets.map((offset) =>
       fetchJson<PolymarketEventRecord[]>(
-        buildPolymarketCatalogUrl(offset, tagSlug),
+        buildPolymarketCatalogUrl(offset, tagSlug, limit),
+        signal,
       ),
     ),
   );
@@ -78,17 +81,21 @@ async function loadPolymarketCatalogPages(
 export async function loadPolymarketCatalog(
   searchQuery = "",
   categoryId: PredictionCategoryId = "all",
+  options: { limit?: number; signal?: AbortSignal } = {},
 ): Promise<PredictionMarketSummary[]> {
   const normalizedQuery = searchQuery.trim().toLowerCase();
+  const requestedLimit = Math.max(1, Math.min(200, options.limit ?? 200));
+  const pageLimit = Math.max(20, requestedLimit);
   return await loadCachedPredictionResource(
     "catalog",
-    buildPredictionCatalogResourceKey("polymarket", categoryId, normalizedQuery),
+    `${buildPredictionCatalogResourceKey("polymarket", categoryId, normalizedQuery)}:${requestedLimit}`,
     async () => {
       if (normalizedQuery.length > 0) {
         const response = await fetchJson<PolymarketSearchResponse>(
-          buildPolymarketSearchUrl(normalizedQuery),
+          buildPolymarketSearchUrl(normalizedQuery, Math.min(40, pageLimit)),
+          options.signal,
         );
-        const searchEvents = response.events ?? [];
+        const searchEvents = (response.events ?? []).slice(0, requestedLimit);
         const hydratedEvents = (
           await Promise.all(
             [...new Set(searchEvents.map((event) => event.id).filter(Boolean))]
@@ -103,7 +110,7 @@ export async function loadPolymarketCatalog(
           resolvedEvents,
           normalizedQuery,
           categoryId,
-        );
+        ).slice(0, requestedLimit);
       }
 
       if (categoryId !== "all") {
@@ -111,8 +118,10 @@ export async function loadPolymarketCatalog(
         const categoryPages = await Promise.all(
           tagSlugs.map((tagSlug) =>
             loadPolymarketCatalogPages(
-              POLYMARKET_CATEGORY_OFFSETS,
+              options.limit ? [0] : POLYMARKET_CATEGORY_OFFSETS,
               tagSlug,
+              pageLimit,
+              options.signal,
             ).catch(() => []),
           ),
         );
@@ -121,13 +130,16 @@ export async function loadPolymarketCatalog(
           "",
           categoryId,
         );
-        if (categorized.length > 0) return categorized;
+        if (categorized.length > 0) return categorized.slice(0, requestedLimit);
       }
 
       const pages = await loadPolymarketCatalogPages(
-        POLYMARKET_CATALOG_OFFSETS,
+        options.limit ? [0] : POLYMARKET_CATALOG_OFFSETS,
+        undefined,
+        pageLimit,
+        options.signal,
       );
-      return normalizePolymarketCatalog(pages, "", categoryId);
+      return normalizePolymarketCatalog(pages, "", categoryId).slice(0, requestedLimit);
     },
     PREDICTION_CACHE_POLICIES.catalog,
   );

--- a/src/plugins/prediction-markets/services/polymarket/detail.ts
+++ b/src/plugins/prediction-markets/services/polymarket/detail.ts
@@ -81,6 +81,25 @@ function findCanonicalPolymarketMarket(
   );
 }
 
+export async function resolvePolymarketChartSummary(
+  eventId: string,
+  marketId: string,
+  signal?: AbortSignal,
+): Promise<PredictionMarketSummary> {
+  const event = await fetchJson<PolymarketEventRecord>(
+    `https://gamma-api.polymarket.com/events/${eventId}`,
+    signal,
+  );
+  const market = event.markets?.find((candidate) => candidate.id === marketId);
+  const summary = market
+    ? normalizePolymarketMarket(hydratePolymarketMarket(market, event))
+    : null;
+  if (!summary) {
+    throw new Error(`Polymarket market ${marketId} in event ${eventId} is no longer resolvable. Remove or replace this chart series.`);
+  }
+  return summary;
+}
+
 async function resolvePolymarketSummary(
   summary: PredictionMarketSummary,
 ): Promise<{
@@ -124,9 +143,13 @@ async function resolvePolymarketSummary(
 export async function loadPolymarketHistory(
   summary: PredictionMarketSummary,
   range: "1D" | "1W" | "1M" | "ALL",
+  options: { signal?: AbortSignal; strict?: boolean } = {},
 ): Promise<PredictionHistoryPoint[]> {
   const tokenId = summary.yesTokenId;
-  if (!tokenId) return [];
+  if (!tokenId) {
+    if (options.strict) throw new Error(`Polymarket market ${summary.marketId} no longer exposes a YES token for chart history.`);
+    return [];
+  }
   const interval =
     range === "1D"
       ? "1d"
@@ -144,6 +167,7 @@ export async function loadPolymarketHistory(
     async () => {
       const response = await fetchJson<PolymarketHistoryResponse>(
         `https://clob.polymarket.com/prices-history?market=${tokenId}&interval=${interval}&fidelity=${fidelity}`,
+        options.signal,
       );
       return (response.history ?? [])
         .map((point) => ({

--- a/src/plugins/prediction-markets/services/polymarket/detail.ts
+++ b/src/plugins/prediction-markets/services/polymarket/detail.ts
@@ -36,8 +36,10 @@ import type {
 
 export async function loadPolymarketEvent(
   eventId: string | undefined,
+  signal?: AbortSignal,
 ): Promise<PolymarketEventRecord | null> {
   if (!eventId) return null;
+  signal?.throwIfAborted();
   try {
     return await loadCachedPredictionResource(
       "rules",
@@ -45,10 +47,12 @@ export async function loadPolymarketEvent(
       async () =>
         await fetchJson<PolymarketEventRecord>(
           `https://gamma-api.polymarket.com/events/${eventId}`,
+          signal,
         ),
       PREDICTION_CACHE_POLICIES.rules,
     );
-  } catch {
+  } catch (error) {
+    if (signal?.aborted) throw signal.reason ?? error;
     return null;
   }
 }
@@ -143,7 +147,7 @@ async function resolvePolymarketSummary(
 export async function loadPolymarketHistory(
   summary: PredictionMarketSummary,
   range: "1D" | "1W" | "1M" | "ALL",
-  options: { signal?: AbortSignal; strict?: boolean } = {},
+  options: { start?: Date; end?: Date; signal?: AbortSignal; strict?: boolean } = {},
 ): Promise<PredictionHistoryPoint[]> {
   const tokenId = summary.yesTokenId;
   if (!tokenId) {
@@ -160,15 +164,24 @@ export async function loadPolymarketHistory(
           : "max";
   const fidelity =
     range === "1D" ? 15 : range === "1W" ? 60 : range === "1M" ? 240 : 1440;
+  const start = options.start ? Math.floor(options.start.getTime() / 1000) : null;
+  const end = options.end ? Math.floor(options.end.getTime() / 1000) : null;
+  const bounded = start !== null && end !== null && Number.isFinite(start) && Number.isFinite(end) && start <= end;
 
   return await loadCachedPredictionResource(
     "history",
-    `${summary.key}:${range}`,
+    `${summary.key}:${range}${bounded ? `:${start}:${end}` : ""}`,
     async () => {
-      const response = await fetchJson<PolymarketHistoryResponse>(
-        `https://clob.polymarket.com/prices-history?market=${tokenId}&interval=${interval}&fidelity=${fidelity}`,
-        options.signal,
-      );
+      const url = new URL("https://clob.polymarket.com/prices-history");
+      url.searchParams.set("market", tokenId);
+      url.searchParams.set("fidelity", String(fidelity));
+      if (bounded) {
+        url.searchParams.set("startTs", String(start));
+        url.searchParams.set("endTs", String(end));
+      } else {
+        url.searchParams.set("interval", interval);
+      }
+      const response = await fetchJson<PolymarketHistoryResponse>(url.toString(), options.signal);
       return (response.history ?? [])
         .map((point) => ({
           date: new Date(point.t * 1000),

--- a/src/plugins/prediction-markets/services/polymarket/detail.ts
+++ b/src/plugins/prediction-markets/services/polymarket/detail.ts
@@ -121,7 +121,7 @@ async function resolvePolymarketSummary(
   };
 }
 
-async function loadPolymarketHistory(
+export async function loadPolymarketHistory(
   summary: PredictionMarketSummary,
   range: "1D" | "1W" | "1M" | "ALL",
 ): Promise<PredictionHistoryPoint[]> {

--- a/src/plugins/prediction-markets/types.ts
+++ b/src/plugins/prediction-markets/types.ts
@@ -4,7 +4,7 @@ import type { PredictionCategoryId } from "./categories";
 export type PredictionVenue = "polymarket" | "kalshi";
 export type PredictionVenueScope = "all" | PredictionVenue;
 export type PredictionBrowseTab = "top" | "ending" | "new" | "watchlist";
-export type PredictionDetailTab = "overview" | "book" | "trades" | "rules";
+export type PredictionDetailTab = "overview" | "chart" | "book" | "trades" | "rules";
 export type PredictionHistoryRange = "1D" | "1W" | "1M" | "ALL";
 export type PredictionVolumeUnit = "usd" | "contracts";
 type PredictionSortDirection = "asc" | "desc";

--- a/src/plugins/registry/index.ts
+++ b/src/plugins/registry/index.ts
@@ -7,6 +7,7 @@ import {
 import type { BrokerAdapter } from "../../types/broker";
 import {
   CapabilityRegistry,
+  type CapabilityManifest,
   type NewsCapability,
   type PluginCapability,
 } from "../../capabilities";
@@ -68,6 +69,8 @@ interface PluginRegistryOptions {
   enableCapabilityHandlers?: boolean;
   wrapBrokerAdapter?: (broker: BrokerAdapter, pluginId: string) => BrokerAdapter;
   connectionHealth?: ConnectionHealthRegistry;
+  remoteCapabilityManifests?: () => CapabilityManifest[];
+  remoteCapabilityInvoke?: <T>(capabilityId: string, operationId: string, payload: unknown) => Promise<T>;
 }
 
 export type WindowEditMode = "move" | "resize";
@@ -92,6 +95,8 @@ export class PluginRegistry implements PluginRuntimeAccess {
   readonly persistence: AppPersistencePort;
   private readonly enableCapabilityHandlers: boolean;
   private readonly wrapBrokerAdapter?: (broker: BrokerAdapter, pluginId: string) => BrokerAdapter;
+  private readonly remoteCapabilityManifests?: () => CapabilityManifest[];
+  private readonly remoteCapabilityInvoke?: <T>(capabilityId: string, operationId: string, payload: unknown) => Promise<T>;
 
   getTickerFn: ((symbol: string) => TickerRecord | null) = () => null;
   getDataFn: ((symbol: string) => TickerFinancials | null) = () => null;
@@ -121,6 +126,13 @@ export class PluginRegistry implements PluginRuntimeAccess {
   getMarketData = () => this.marketData;
   getConnectionHealth = () => this.connectionHealth;
   getCapability = (capabilityId: string) => this.capabilities.get(capabilityId)?.capability ?? null;
+  capabilityManifests = (kind?: string) => (this.remoteCapabilityManifests?.() ?? this.capabilities.manifests({ rendererOnly: true }))
+    .filter((manifest) => !kind || manifest.kind === kind);
+  invokeCapability = <T = unknown>(capabilityId: string, operationId: string, payload: unknown): Promise<T> => (
+    this.remoteCapabilityInvoke
+      ? this.remoteCapabilityInvoke<T>(capabilityId, operationId, payload)
+      : this.capabilities.invoke<T>(capabilityId, operationId, payload, { renderer: true })
+  );
   getBrokerAdapter = (brokerType: string) => this.contributions.brokersMap.get(brokerType) ?? null;
   connectBrokerInstance = (instanceId: string) => this.connectBrokerInstanceFn(instanceId);
   updateBrokerInstance = (instanceId: string, values: Record<string, unknown>, options?: BrokerInstanceUpdateOptions) => (
@@ -203,6 +215,8 @@ export class PluginRegistry implements PluginRuntimeAccess {
     this.persistence = persistence;
     this.enableCapabilityHandlers = options.enableCapabilityHandlers ?? true;
     this.wrapBrokerAdapter = options.wrapBrokerAdapter;
+    this.remoteCapabilityManifests = options.remoteCapabilityManifests;
+    this.remoteCapabilityInvoke = options.remoteCapabilityInvoke;
     this.events = new EventBus();
     this.contributions = new RegistryContributions({
       wrapPaneDef: (pluginId, pane) => wrapPaneDefWithRuntime(pluginId, pane, this),

--- a/src/plugins/registry/index.ts
+++ b/src/plugins/registry/index.ts
@@ -70,7 +70,12 @@ interface PluginRegistryOptions {
   wrapBrokerAdapter?: (broker: BrokerAdapter, pluginId: string) => BrokerAdapter;
   connectionHealth?: ConnectionHealthRegistry;
   remoteCapabilityManifests?: () => CapabilityManifest[];
-  remoteCapabilityInvoke?: <T>(capabilityId: string, operationId: string, payload: unknown) => Promise<T>;
+  remoteCapabilityInvoke?: <T>(
+    capabilityId: string,
+    operationId: string,
+    payload: unknown,
+    options?: { signal?: AbortSignal },
+  ) => Promise<T>;
 }
 
 export type WindowEditMode = "move" | "resize";
@@ -96,7 +101,12 @@ export class PluginRegistry implements PluginRuntimeAccess {
   private readonly enableCapabilityHandlers: boolean;
   private readonly wrapBrokerAdapter?: (broker: BrokerAdapter, pluginId: string) => BrokerAdapter;
   private readonly remoteCapabilityManifests?: () => CapabilityManifest[];
-  private readonly remoteCapabilityInvoke?: <T>(capabilityId: string, operationId: string, payload: unknown) => Promise<T>;
+  private readonly remoteCapabilityInvoke?: <T>(
+    capabilityId: string,
+    operationId: string,
+    payload: unknown,
+    options?: { signal?: AbortSignal },
+  ) => Promise<T>;
 
   getTickerFn: ((symbol: string) => TickerRecord | null) = () => null;
   getDataFn: ((symbol: string) => TickerFinancials | null) = () => null;
@@ -128,10 +138,15 @@ export class PluginRegistry implements PluginRuntimeAccess {
   getCapability = (capabilityId: string) => this.capabilities.get(capabilityId)?.capability ?? null;
   capabilityManifests = (kind?: string) => (this.remoteCapabilityManifests?.() ?? this.capabilities.manifests({ rendererOnly: true }))
     .filter((manifest) => !kind || manifest.kind === kind);
-  invokeCapability = <T = unknown>(capabilityId: string, operationId: string, payload: unknown): Promise<T> => (
+  invokeCapability = <T = unknown>(
+    capabilityId: string,
+    operationId: string,
+    payload: unknown,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<T> => (
     this.remoteCapabilityInvoke
-      ? this.remoteCapabilityInvoke<T>(capabilityId, operationId, payload)
-      : this.capabilities.invoke<T>(capabilityId, operationId, payload, { renderer: true })
+      ? this.remoteCapabilityInvoke<T>(capabilityId, operationId, payload, options)
+      : this.capabilities.invoke<T>(capabilityId, operationId, payload, { renderer: true, signal: options.signal })
   );
   getBrokerAdapter = (brokerType: string) => this.contributions.brokersMap.get(brokerType) ?? null;
   connectBrokerInstance = (instanceId: string) => this.connectBrokerInstanceFn(instanceId);

--- a/src/plugins/runtime/context.tsx
+++ b/src/plugins/runtime/context.tsx
@@ -6,7 +6,7 @@ import {
 } from "react";
 import type { BrokerAdapter } from "../../types/broker";
 import type { ConnectionHealthRegistry } from "../../core/connection-health";
-import type { PluginCapability } from "../../capabilities";
+import type { CapabilityInvoker, PluginCapability } from "../../capabilities";
 import type { DataProvider } from "../../types/data-provider";
 import type {
   AppNotificationRequest,
@@ -17,7 +17,7 @@ import type {
   TickerResearchTabDef,
 } from "../../types/plugin";
 
-export interface PluginRuntimeAccess {
+export interface PluginRuntimeAccess extends CapabilityInvoker {
   getMarketData(): DataProvider | null;
   getConnectionHealth(): ConnectionHealthRegistry;
   getCapability(capabilityId: string): PluginCapability | null;

--- a/src/plugins/runtime/index.tsx
+++ b/src/plugins/runtime/index.tsx
@@ -108,6 +108,10 @@ export function useConnectionHealth(): ReturnType<PluginRuntimeAccess["getConnec
   return runtime.getConnectionHealth();
 }
 
+export function useCapabilityInvoker(): PluginRuntimeAccess {
+  return usePluginRenderContext().runtime;
+}
+
 export function usePluginBrokerActions() {
   const { runtime } = usePluginRenderContext();
   return {

--- a/src/renderers/electrobun/bun/desktop/capability-bridge.test.ts
+++ b/src/renderers/electrobun/bun/desktop/capability-bridge.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test";
+import { CapabilityRegistry } from "../../../../capabilities/registry";
+import { DesktopCapabilityBridge } from "./capability-bridge";
+
+type TestRpc = {
+  key: string;
+  send: { "capability.event": (_payload: { subscriptionId: string; event: unknown }) => void };
+};
+
+const rpc = (key: string): TestRpc => ({
+  key,
+  send: { "capability.event": () => {} },
+});
+
+test("desktop capability cancellation is window-scoped and window cleanup aborts active work", async () => {
+  const signals = new Map<string, AbortSignal>();
+  const registry = new CapabilityRegistry();
+  registry.register("test", {
+    id: "test.capability",
+    kind: "plugin-service",
+    name: "Test",
+    operations: {
+      wait: {
+        kind: "query",
+        rendererSafe: true,
+        handler: (input: { name: string }, context) => new Promise((_resolve, reject) => {
+          const signal = context.signal!;
+          signals.set(input.name, signal);
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+      },
+    },
+  });
+  const bridge = new DesktopCapabilityBridge<TestRpc>({
+    getRegistry: () => registry,
+    getWindowKey: (client) => client.key,
+  });
+  const windowA = rpc("window-a");
+  const windowB = rpc("window-b");
+  const invoke = (client: TestRpc, name: string) => bridge.handle(client, {
+    method: "capability.invoke",
+    payload: {
+      capabilityId: "test.capability",
+      operationId: "wait",
+      payload: { name },
+      invocationId: "same-client-id",
+    },
+  });
+
+  const first = invoke(windowA, "first").catch((error) => error);
+  const second = invoke(windowB, "second").catch((error) => error);
+
+  await bridge.handle(windowA, {
+    method: "capability.cancel",
+    payload: { invocationId: "same-client-id" },
+  });
+  expect(await first).toMatchObject({ name: "AbortError" });
+  expect(signals.get("first")?.aborted).toBe(true);
+  expect(signals.get("second")?.aborted).toBe(false);
+
+  bridge.disposeWindow("window-b");
+  expect(await second).toMatchObject({ name: "AbortError" });
+  expect(signals.get("second")?.aborted).toBe(true);
+});

--- a/src/renderers/electrobun/bun/desktop/capability-bridge.ts
+++ b/src/renderers/electrobun/bun/desktop/capability-bridge.ts
@@ -17,6 +17,7 @@ interface DesktopCapabilityBridgeOptions<Rpc extends DesktopCapabilityRpc> {
 
 export class DesktopCapabilityBridge<Rpc extends DesktopCapabilityRpc> {
   private readonly subscriptions = new Map<string, () => void>();
+  private readonly invocations = new Map<string, AbortController>();
 
   constructor(private readonly options: DesktopCapabilityBridgeOptions<Rpc>) {}
 
@@ -29,6 +30,8 @@ export class DesktopCapabilityBridge<Rpc extends DesktopCapabilityRpc> {
       }
     }
     this.subscriptions.clear();
+    for (const controller of this.invocations.values()) controller.abort();
+    this.invocations.clear();
   }
 
   disposeWindow(windowKey: string): void {
@@ -42,6 +45,11 @@ export class DesktopCapabilityBridge<Rpc extends DesktopCapabilityRpc> {
       }
       this.subscriptions.delete(id);
     }
+    for (const [id, controller] of this.invocations) {
+      if (!id.startsWith(scopedPrefix)) continue;
+      controller.abort();
+      this.invocations.delete(id);
+    }
   }
 
   async handle(
@@ -50,13 +58,39 @@ export class DesktopCapabilityBridge<Rpc extends DesktopCapabilityRpc> {
   ): Promise<unknown> {
     const registry = this.options.getRegistry();
     switch (request.method) {
-      case "capability.invoke":
-        return registry.invoke(
-          request.payload.capabilityId,
-          request.payload.operationId,
-          request.payload.payload,
-          { renderer: true },
-        );
+      case "capability.invoke": {
+        const clientInvocationId = request.payload.invocationId;
+        if (!clientInvocationId) {
+          return registry.invoke(
+            request.payload.capabilityId,
+            request.payload.operationId,
+            request.payload.payload,
+            { renderer: true },
+          );
+        }
+        const scopedInvocationId = this.scopeClientId(rpc, clientInvocationId);
+        if (this.invocations.has(scopedInvocationId)) {
+          throw new Error(`Capability invocation "${clientInvocationId}" is already active.`);
+        }
+        const controller = new AbortController();
+        this.invocations.set(scopedInvocationId, controller);
+        try {
+          return await registry.invoke(
+            request.payload.capabilityId,
+            request.payload.operationId,
+            request.payload.payload,
+            { renderer: true, signal: controller.signal },
+          );
+        } finally {
+          if (this.invocations.get(scopedInvocationId) === controller) {
+            this.invocations.delete(scopedInvocationId);
+          }
+        }
+      }
+      case "capability.cancel": {
+        this.invocations.get(this.scopeClientId(rpc, request.payload.invocationId))?.abort();
+        return null;
+      }
       case "capability.subscribe": {
         const clientSubscriptionId = request.payload.subscriptionId;
         const scopedSubscriptionId = this.scopeClientId(rpc, clientSubscriptionId);

--- a/src/renderers/electrobun/bun/desktop/initialization.test.ts
+++ b/src/renderers/electrobun/bun/desktop/initialization.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import { CapabilityRegistry } from "../../../../capabilities";
+import { desktopRendererCapabilityManifests } from "./initialization";
+
+test("desktop init includes disabled renderer-safe manifests while invocation stays disabled", async () => {
+  let enabled = false;
+  const registry = new CapabilityRegistry({ isPluginEnabled: () => enabled });
+  registry.register("charts", {
+    id: "charts.test",
+    kind: "chart-series",
+    name: "Test Charts",
+    operations: {
+      resolve: { kind: "query", rendererSafe: true, handler: () => "ok" },
+      private: { kind: "read", handler: () => "private" },
+    },
+  });
+
+  expect(desktopRendererCapabilityManifests(registry)).toEqual([expect.objectContaining({
+    id: "charts.test",
+    operations: [expect.objectContaining({ id: "resolve" })],
+  })]);
+  await expect(registry.invoke("charts.test", "resolve", {}, { renderer: true }))
+    .rejects.toThrow("not available");
+
+  enabled = true;
+  await expect(registry.invoke("charts.test", "resolve", {}, { renderer: true })).resolves.toBe("ok");
+});

--- a/src/renderers/electrobun/bun/desktop/initialization.ts
+++ b/src/renderers/electrobun/bun/desktop/initialization.ts
@@ -25,6 +25,7 @@ import {
   paneIdFromDetachedRpcKey,
 } from "../window/focus";
 import type { DesktopBackendRequestPayload, ElectrobunBackendInit } from "../../shared/protocol";
+import type { CapabilityRegistry } from "../../../../capabilities";
 
 interface DesktopWindowTarget {
   kind: "main" | "detached";
@@ -81,6 +82,10 @@ function normalizeInitWindowTarget<TRpc>(
   };
 }
 
+export function desktopRendererCapabilityManifests(registry: CapabilityRegistry) {
+  return registry.manifests({ rendererOnly: true, includeDisabled: true });
+}
+
 function buildInitializationPayload(
   config: AppConfig,
   services: AppServices,
@@ -93,7 +98,7 @@ function buildInitializationPayload(
     desktopSnapshot: options.getDesktopSnapshot(),
     desktopThemePreview: options.desktopThemePreview,
     pluginState: loadDesktopPluginState(services.pluginRegistry),
-    capabilityManifests: services.pluginRegistry.capabilities.manifests({ rendererOnly: true }),
+    capabilityManifests: desktopRendererCapabilityManifests(services.pluginRegistry.capabilities),
     desktopPlatform: process.platform,
     windowKind: windowTarget.kind,
     paneId: windowTarget.paneId,

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -441,6 +441,7 @@ async function handleBackendRequest(
     case "remote.forward":
       return forwardRemoteControlRequest(request.payload.request);
     case "capability.invoke":
+    case "capability.cancel":
     case "capability.subscribe":
     case "capability.unsubscribe":
       return capabilityBridge.handle(rpc, request);

--- a/src/renderers/electrobun/shared/protocol.ts
+++ b/src/renderers/electrobun/shared/protocol.ts
@@ -76,6 +76,7 @@ export interface DesktopCapabilityInvokeRequest {
   capabilityId: string;
   operationId: string;
   payload?: unknown;
+  invocationId?: string;
 }
 
 export interface DesktopCapabilitySubscribeRequest extends DesktopCapabilityInvokeRequest {
@@ -91,6 +92,7 @@ export interface DesktopBackendRequestMap {
   "media.resolveLiveStream": { request: LiveStreamResolveRequest; response: ResolvedLiveStream };
   "remote.forward": { request: { request: RemoteControlRequest }; response: RemoteControlResponse };
   "capability.invoke": { request: DesktopCapabilityInvokeRequest; response: unknown };
+  "capability.cancel": { request: { invocationId: string }; response: null };
   "capability.subscribe": { request: DesktopCapabilitySubscribeRequest; response: null };
   "capability.unsubscribe": { request: { subscriptionId: string }; response: null };
   "desktop.syncMainState": { request: { snapshot: DesktopSharedStateSnapshot }; response: null };

--- a/src/renderers/electrobun/view/app-services.ts
+++ b/src/renderers/electrobun/view/app-services.ts
@@ -12,6 +12,7 @@ import { createRemoteAssetDataClient } from "./remote/asset-data-client";
 import { RemotePersistence } from "./remote/persistence";
 import { RemoteTickerRepository } from "./remote/ticker-repository";
 import { connectBackendConnectionHealth } from "./remote/connection-health-backend";
+import { backendRequest, getElectrobunBackendInitSnapshot } from "./backend-rpc";
 
 const servicesLog = debugLog.createLogger("services");
 
@@ -26,6 +27,12 @@ export function createElectrobunAppServices({ config }: AppServicesFactoryOption
   const pluginRegistry = new PluginRegistry(dataProvider, tickerRepository, persistence, {
     enableCapabilityHandlers: false,
     wrapBrokerAdapter: (broker) => createRemoteBrokerAdapter(broker),
+    remoteCapabilityManifests: () => getElectrobunBackendInitSnapshot()?.capabilityManifests ?? [],
+    remoteCapabilityInvoke: (capabilityId, operationId, payload) => backendRequest("capability.invoke", {
+      capabilityId,
+      operationId,
+      payload,
+    }),
   });
   const newsService = new NewsService({ connectionHealth: pluginRegistry.connectionHealth });
 

--- a/src/renderers/electrobun/view/app-services.ts
+++ b/src/renderers/electrobun/view/app-services.ts
@@ -13,6 +13,7 @@ import { RemotePersistence } from "./remote/persistence";
 import { RemoteTickerRepository } from "./remote/ticker-repository";
 import { connectBackendConnectionHealth } from "./remote/connection-health-backend";
 import { backendRequest, getElectrobunBackendInitSnapshot } from "./backend-rpc";
+import { createCapabilityInvoker } from "./remote/capability-invoker";
 
 const servicesLog = debugLog.createLogger("services");
 
@@ -24,15 +25,18 @@ export function createElectrobunAppServices({ config }: AppServicesFactoryOption
   const tickerRepository = measurePerf("startup.services.ticker-repository", () => new RemoteTickerRepository());
   const dataProvider = measurePerf("startup.services.data-provider", () => createRemoteAssetDataClient());
   const marketData = new MarketDataCoordinator(dataProvider);
+  const invokeCapability = createCapabilityInvoker({
+    request: backendRequest,
+    shouldApplyDeadline: () => false,
+    timeoutMs: 0,
+  });
   const pluginRegistry = new PluginRegistry(dataProvider, tickerRepository, persistence, {
     enableCapabilityHandlers: false,
     wrapBrokerAdapter: (broker) => createRemoteBrokerAdapter(broker),
     remoteCapabilityManifests: () => getElectrobunBackendInitSnapshot()?.capabilityManifests ?? [],
-    remoteCapabilityInvoke: (capabilityId, operationId, payload) => backendRequest("capability.invoke", {
-      capabilityId,
-      operationId,
-      payload,
-    }),
+    remoteCapabilityInvoke: (capabilityId, operationId, payload, options) => (
+      invokeCapability(capabilityId, operationId, payload, options)
+    ),
   });
   const newsService = new NewsService({ connectionHealth: pluginRegistry.connectionHealth });
 

--- a/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
+++ b/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
@@ -327,7 +327,15 @@ function createRuntime(payload: CliPaneShotPayload): PluginRuntimeAccess {
     return (payload.config.pluginConfig[pluginId]?.[key] as T | undefined) ?? null;
   }
   const capabilitySeries = new Map(payload.capabilitySeries ?? []);
-  const capabilityIds = [...new Set([...capabilitySeries.keys()].map((key) => key.split("|", 1)[0]!).filter(Boolean))];
+  const capabilityIds = [...new Set(payload.config.layout.instances.flatMap((instance) => {
+    const chartSpec = instance.settings?.chartSpec;
+    if (!chartSpec || typeof chartSpec !== "object" || !Array.isArray((chartSpec as any).series)) return [];
+    return (chartSpec as any).series.flatMap((series: any) => (
+      series?.source?.kind === "capability" && typeof series.source.capabilityId === "string"
+        ? [series.source.capabilityId]
+        : []
+    ));
+  }))];
   return {
     getMarketData: () => shotDataProvider,
     getConnectionHealth: () => connectionHealth,
@@ -342,12 +350,11 @@ function createRuntime(payload: CliPaneShotPayload): PluginRuntimeAccess {
       if (operationId !== "resolve" || !input || typeof input !== "object") {
         throw new Error(`Screenshot capability operation ${capabilityId}.${operationId} is unavailable.`);
       }
-      const request = input as { seriesId?: string; parameters?: Record<string, any> };
+      const request = input as { seriesId?: string };
       const value = capabilitySeries.get(chartSeriesSourceKey({
         kind: "capability",
         capabilityId,
         seriesId: request.seriesId ?? "",
-        parameters: request.parameters,
       }));
       if (!value) throw new Error(`No screenshot chart series data is available for ${request.seriesId ?? capabilityId}.`);
       return value as T;

--- a/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
+++ b/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
@@ -38,6 +38,8 @@ import type { PaneDef } from "../../../types/plugin";
 import { canonicalTickerKey, parsePublicTickerKey } from "../../../utils/exchanges";
 import { hydrateFredSeries, type FredSeriesCacheEntry } from "../../../data/fred-series";
 import { clipPriceHistoryToRange } from "../../../time-series/history-window";
+import type { ResolvedSeries } from "../../../time-series/types";
+import { chartSeriesSourceKey } from "../../../capabilities";
 
 interface CliPaneShotPayload {
   config: AppConfig;
@@ -48,6 +50,7 @@ interface CliPaneShotPayload {
   financials: Array<[string, TickerFinancials]>;
   optionsChains: Array<[string, OptionsChain]>;
   fredSeries: Array<[string, FredSeriesCacheEntry]>;
+  capabilitySeries: Array<[string, ResolvedSeries]>;
   paneState: Record<string, PaneRuntimeState>;
 }
 
@@ -323,10 +326,32 @@ function createRuntime(payload: CliPaneShotPayload): PluginRuntimeAccess {
   function getConfigState<T = unknown>(pluginId: string, key: string): T | null {
     return (payload.config.pluginConfig[pluginId]?.[key] as T | undefined) ?? null;
   }
+  const capabilitySeries = new Map(payload.capabilitySeries ?? []);
+  const capabilityIds = [...new Set([...capabilitySeries.keys()].map((key) => key.split("|", 1)[0]!).filter(Boolean))];
   return {
     getMarketData: () => shotDataProvider,
     getConnectionHealth: () => connectionHealth,
     getCapability: () => null,
+    capabilityManifests: (kind) => kind && kind !== "chart-series" ? [] : capabilityIds.map((id) => ({
+      id,
+      kind: "chart-series",
+      name: id,
+      operations: [{ id: "resolve", kind: "query", rendererSafe: true }],
+    })),
+    invokeCapability: async <T,>(capabilityId: string, operationId: string, input: unknown) => {
+      if (operationId !== "resolve" || !input || typeof input !== "object") {
+        throw new Error(`Screenshot capability operation ${capabilityId}.${operationId} is unavailable.`);
+      }
+      const request = input as { seriesId?: string; parameters?: Record<string, any> };
+      const value = capabilitySeries.get(chartSeriesSourceKey({
+        kind: "capability",
+        capabilityId,
+        seriesId: request.seriesId ?? "",
+        parameters: request.parameters,
+      }));
+      if (!value) throw new Error(`No screenshot chart series data is available for ${request.seriesId ?? capabilityId}.`);
+      return value as T;
+    },
     getBrokerAdapter: () => null,
     connectBrokerInstance: async () => {},
     updateBrokerInstance: async () => {},

--- a/src/renderers/electrobun/view/remote/capability-invoker.test.ts
+++ b/src/renderers/electrobun/view/remote/capability-invoker.test.ts
@@ -47,4 +47,50 @@ describe("createCapabilityInvoker", () => {
     rawResolvers[1]?.({ price: 101 });
     await expect(retryAfterRawSettles).resolves.toEqual({ price: 101 });
   });
+
+  test("sends scoped cancellation for an aborted invocation and removes settled listeners", async () => {
+    const invokes: Array<Record<string, unknown>> = [];
+    const cancellations: Array<Record<string, unknown>> = [];
+    let rejectInvoke: ((error: unknown) => void) | undefined;
+    const invoke = createCapabilityInvoker({
+      request: <T>(method: string, payload: unknown) => {
+        if (method === "capability.cancel") {
+          cancellations.push(payload as Record<string, unknown>);
+          rejectInvoke?.(new DOMException("Aborted", "AbortError"));
+          return Promise.resolve(null as T);
+        }
+        invokes.push(payload as Record<string, unknown>);
+        return new Promise<T>((_resolve, reject) => {
+          rejectInvoke = reject;
+        });
+      },
+      shouldApplyDeadline: () => false,
+      timeoutMs: 0,
+    });
+    const controller = new AbortController();
+
+    const pending = invoke("prediction-markets.series", "search", { query: "rates" }, {
+      signal: controller.signal,
+    }).catch((error) => error);
+    controller.abort();
+    expect(await pending).toMatchObject({ name: "AbortError" });
+
+    expect(cancellations).toEqual([{ invocationId: invokes[0]?.invocationId }]);
+
+    let settledCancellations = 0;
+    const settledInvoke = createCapabilityInvoker({
+      request: <T>(method: string) => {
+        if (method === "capability.cancel") settledCancellations += 1;
+        return Promise.resolve("done" as T);
+      },
+      shouldApplyDeadline: () => false,
+      timeoutMs: 0,
+    });
+    const settledController = new AbortController();
+    await settledInvoke("prediction-markets.series", "catalog", {}, {
+      signal: settledController.signal,
+    });
+    settledController.abort();
+    expect(settledCancellations).toBe(0);
+  });
 });

--- a/src/renderers/electrobun/view/remote/capability-invoker.ts
+++ b/src/renderers/electrobun/view/remote/capability-invoker.ts
@@ -1,6 +1,7 @@
 import { withDeadline } from "../../../../utils/async-deadline";
 
 type CapabilityRequest = <T>(method: string, payload: unknown) => Promise<T>;
+let nextCapabilityInvocationId = 1;
 
 export function createCapabilityInvoker(options: {
   request: CapabilityRequest;
@@ -9,13 +10,31 @@ export function createCapabilityInvoker(options: {
 }) {
   const inFlightRequests = new Map<string, Promise<unknown>>();
 
-  return function invoke<T>(capabilityId: string, operationId: string, payload: unknown): Promise<T> {
-    const requestPayload = { capabilityId, operationId, payload };
-    const key = JSON.stringify(requestPayload);
-    const inFlight = inFlightRequests.get(key);
+  return function invoke<T>(
+    capabilityId: string,
+    operationId: string,
+    payload: unknown,
+    invokeOptions: { signal?: AbortSignal } = {},
+  ): Promise<T> {
+    invokeOptions.signal?.throwIfAborted();
+    const key = JSON.stringify({ capabilityId, operationId, payload });
+    const inFlight = invokeOptions.signal ? undefined : inFlightRequests.get(key);
     if (inFlight) return inFlight as Promise<T>;
 
-    const request = options.request<T>("capability.invoke", requestPayload);
+    const invocationId = `view:${nextCapabilityInvocationId++}`;
+    const request = options.request<T>("capability.invoke", {
+      capabilityId,
+      operationId,
+      payload,
+      invocationId,
+    });
+    const cancel = () => {
+      void options.request<null>("capability.cancel", { invocationId }).catch(() => {});
+    };
+    invokeOptions.signal?.addEventListener("abort", cancel, { once: true });
+    if (invokeOptions.signal?.aborted) cancel();
+    void request.finally(() => invokeOptions.signal?.removeEventListener("abort", cancel)).catch(() => {});
+
     const boundedRequest = options.shouldApplyDeadline(capabilityId)
       ? withDeadline(
         request,
@@ -23,14 +42,16 @@ export function createCapabilityInvoker(options: {
         `Asset data request timed out after ${options.timeoutMs}ms: ${operationId}`,
       )
       : request;
-    inFlightRequests.set(key, boundedRequest);
-    void request.finally(() => {
-      if (inFlightRequests.get(key) === boundedRequest) {
-        inFlightRequests.delete(key);
-      }
-    }).catch(() => {
-      // The returned bounded request owns error delivery to the caller.
-    });
+    if (!invokeOptions.signal) {
+      inFlightRequests.set(key, boundedRequest);
+      void request.finally(() => {
+        if (inFlightRequests.get(key) === boundedRequest) {
+          inFlightRequests.delete(key);
+        }
+      }).catch(() => {
+        // The returned bounded request owns error delivery to the caller.
+      });
+    }
     return boundedRequest;
   };
 }

--- a/src/time-series/hooks.ts
+++ b/src/time-series/hooks.ts
@@ -2,7 +2,8 @@ import { useMemo } from "react";
 import { apiClient } from "../api-client";
 import { loadCachedFredSeries } from "../data/fred-series";
 import { instrumentFromTicker } from "../market-data/request-types";
-import { useAssetData } from "../plugins/runtime";
+import { useAssetData, useCapabilityInvoker } from "../plugins/runtime";
+import { createChartSeriesResolver } from "../capabilities";
 import { useAppSelector } from "../state/app/context";
 import type { FredSeriesRequest } from "../data/fred-series";
 import type { TickerRecord } from "../types/ticker";
@@ -56,11 +57,16 @@ export function useResolvedChartSpec(
   options: UseChartResolutionOptions = {},
 ): UseChartResolutionResult {
   const dataProvider = useAssetData();
+  const capabilityInvoker = useCapabilityInvoker();
   const tickers = useAppSelector((state) => state.tickers);
   const hydratedSpec = useMemo(
     () => hydrateChartSpecInstruments(spec, tickers),
     [spec, tickers],
   );
-  const sources = useMemo(() => ({ dataProvider, loadFredSeries: loadFred }), [dataProvider]);
+  const sources = useMemo(() => ({
+    dataProvider,
+    loadFredSeries: loadFred,
+    resolveCapabilitySeries: createChartSeriesResolver(capabilityInvoker),
+  }), [capabilityInvoker, dataProvider]);
   return useChartResolution(hydratedSpec, sources, options);
 }

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -6,6 +6,7 @@ import { CHART_SPEC_VERSION, type ChartSpec } from "./types";
 import { ChartResolveCache, mergePriceHistoryWindows, resolveChartSpecData } from "./resolve";
 import { chartQuoteOverrideKeyForSource } from "./live-quotes";
 import { chartSeriesSourceKey } from "../capabilities";
+import { buildCustomChartPreset } from "../plugins/builtin/chart-composer/presets";
 
 const emptyFinancials = (): TickerFinancials => ({
   annualStatements: [],
@@ -25,6 +26,39 @@ const fredLoad = (
 });
 
 describe("resolveChartSpecData", () => {
+  test("routes futures and Treasury aliases through the existing market and FRED pipelines", async () => {
+    const marketRequests: string[] = [];
+    const fredRequests: string[] = [];
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => emptyFinancials(),
+      getPriceHistoryForResolution: async (symbol) => {
+        marketRequests.push(symbol);
+        return [{ date: new Date("2026-02-01T00:00:00Z"), close: 6_100 }];
+      },
+    });
+
+    const result = await resolveChartSpecData(
+      buildCustomChartPreset("FUT:ES, UST:10Y"),
+      {
+        dataProvider: provider,
+        now: new Date("2026-03-01T00:00:00Z"),
+        loadFredSeries: async ({ seriesId }) => {
+          fredRequests.push(seriesId);
+          return fredLoad({
+            observations: [{ date: "2026-02-01", value: 4.25 }],
+            info: null,
+          });
+        },
+      },
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(marketRequests).toEqual(["ES=F"]);
+    expect(fredRequests).toEqual(["DGS10"]);
+    expect(result.series.map((series) => series.points[0]?.value ?? series.points[0]?.close))
+      .toEqual([6_100, 4.25]);
+  });
+
   test("keeps missing capability series visible with a useful error and resolves them through the injected boundary", async () => {
     const spec: ChartSpec = {
       version: CHART_SPEC_VERSION,

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -24,6 +24,51 @@ const fredLoad = (
 });
 
 describe("resolveChartSpecData", () => {
+  test("keeps missing capability series visible with a useful error and resolves them through the injected boundary", async () => {
+    const spec: ChartSpec = {
+      version: CHART_SPEC_VERSION,
+      viewport: { range: "1M", resolution: "auto" },
+      panels: [{ id: "main" }],
+      series: [{
+        id: "plugin-series",
+        source: { kind: "capability", capabilityId: "charts.test", seriesId: "one" },
+        style: "area",
+        transform: "raw",
+        axis: "auto",
+        panelId: "main",
+        interpolation: "none",
+      }],
+      studies: [],
+    };
+    const sources = { dataProvider: null, loadFredSeries: async () => fredLoad(), now: new Date("2026-02-01") };
+    const missing = await resolveChartSpecData(spec, sources);
+    expect(missing.series).toHaveLength(1);
+    expect(missing.series[0]?.points).toEqual([]);
+    expect(missing.errors[0]).toContain('Chart series capability "charts.test" is unavailable');
+
+    const resolved = await resolveChartSpecData(spec, {
+      ...sources,
+      resolveCapabilitySeries: async () => ({
+        id: "provider-id",
+        label: "Provider Label",
+        color: "#fff",
+        unit: "value",
+        unitGroup: "value",
+        nativeFrequency: "daily",
+        dataShape: "scalar",
+        style: "line",
+        transform: "raw",
+        axis: "left",
+        panelId: "provider",
+        interpolation: "none",
+        points: [{ date: new Date("2026-01-15"), observedAt: new Date("2026-01-15"), value: 42 }],
+      }),
+    });
+    expect(resolved.errors).toEqual([]);
+    expect(resolved.series[0]).toMatchObject({ id: "plugin-series", style: "area", panelId: "main" });
+    expect(resolved.series[0]?.points[0]?.value).toBe(42);
+  });
+
   test("derives Auto fetch resolution from the finest explicit market period", async () => {
     const cases = [
       { range: "ALL" as const, periods: ["daily", "monthly"] as const, expected: "1d" },

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -5,6 +5,7 @@ import type { TickerFinancials } from "../types/financials";
 import { CHART_SPEC_VERSION, type ChartSpec } from "./types";
 import { ChartResolveCache, mergePriceHistoryWindows, resolveChartSpecData } from "./resolve";
 import { chartQuoteOverrideKeyForSource } from "./live-quotes";
+import { chartSeriesSourceKey } from "../capabilities";
 
 const emptyFinancials = (): TickerFinancials => ({
   annualStatements: [],
@@ -67,6 +68,63 @@ describe("resolveChartSpecData", () => {
     expect(resolved.errors).toEqual([]);
     expect(resolved.series[0]).toMatchObject({ id: "plugin-series", style: "area", panelId: "main" });
     expect(resolved.series[0]?.points[0]?.value).toBe(42);
+  });
+
+  test("resolves capability coverage for each effective panned viewport and caches by structured bounds", async () => {
+    const spec: ChartSpec = {
+      version: CHART_SPEC_VERSION,
+      viewport: { range: "1M", resolution: "auto" },
+      panels: [{ id: "main" }],
+      series: [{
+        id: "plugin-series",
+        source: { kind: "capability", capabilityId: "charts.test", seriesId: "provider/series" },
+        style: "line",
+        transform: "raw",
+        axis: "left",
+        panelId: "main",
+        interpolation: "none",
+      }],
+      studies: [],
+    };
+    const requested: ChartSpec["viewport"][] = [];
+    const cache = new ChartResolveCache();
+    const sources = {
+      dataProvider: null,
+      loadFredSeries: async () => fredLoad(),
+      now: new Date("2026-03-01T00:00:00.000Z"),
+      resolveCapabilitySeries: async (_source: any, viewport: ChartSpec["viewport"]) => {
+        requested.push(viewport);
+        const date = new Date(viewport.dateWindow!.start);
+        return {
+          id: "provider",
+          label: "Provider",
+          color: "#ffffff",
+          unit: "value",
+          unitGroup: "value",
+          nativeFrequency: "daily" as const,
+          dataShape: "scalar" as const,
+          style: "line" as const,
+          transform: "raw" as const,
+          axis: "left" as const,
+          panelId: "main",
+          interpolation: "none" as const,
+          points: [{ date, observedAt: date, value: 1 }],
+        };
+      },
+    };
+    const firstViewport = { start: new Date("2026-01-01T00:00:00.000Z"), end: new Date("2026-01-08T00:00:00.000Z") };
+    const secondViewport = { start: new Date("2026-02-01T00:00:00.000Z"), end: new Date("2026-02-08T00:00:00.000Z") };
+
+    await resolveChartSpecData(spec, sources, cache, { requestViewport: firstViewport });
+    await resolveChartSpecData(spec, sources, cache, { requestViewport: secondViewport });
+    await resolveChartSpecData(spec, sources, cache, { requestViewport: firstViewport });
+
+    expect(requested.map((viewport) => viewport.dateWindow)).toEqual([
+      { start: firstViewport.start.toISOString(), end: firstViewport.end.toISOString() },
+      { start: secondViewport.start.toISOString(), end: secondViewport.end.toISOString() },
+    ]);
+    expect(chartSeriesSourceKey({ kind: "capability", capabilityId: "a", seriesId: "b:c" }))
+      .not.toBe(chartSeriesSourceKey({ kind: "capability", capabilityId: "a-b", seriesId: "c" }));
   });
 
   test("derives Auto fetch resolution from the finest explicit market period", async () => {

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -150,9 +150,11 @@ describe("resolveChartSpecData", () => {
     const secondViewport = { start: new Date("2026-02-01T00:00:00.000Z"), end: new Date("2026-02-08T00:00:00.000Z") };
 
     await resolveChartSpecData(spec, sources, cache, { requestViewport: firstViewport });
-    await resolveChartSpecData(spec, sources, cache, { requestViewport: secondViewport });
+    const panned = await resolveChartSpecData(spec, sources, cache, { requestViewport: secondViewport });
     await resolveChartSpecData(spec, sources, cache, { requestViewport: firstViewport });
 
+    expect(panned.series[0]?.points[0]?.date.toISOString()).toBe(secondViewport.start.toISOString());
+    expect(panned.viewport).toEqual(secondViewport);
     expect(requested.map((viewport) => viewport.dateWindow)).toEqual([
       { start: firstViewport.start.toISOString(), end: firstViewport.end.toISOString() },
       { start: secondViewport.start.toISOString(), end: secondViewport.end.toISOString() },
@@ -586,8 +588,8 @@ describe("resolveChartSpecData", () => {
     expect(detailedRequests).toHaveLength(1);
     expect(detailedRequests[0]?.resolution).toBe("15m");
     expect(detailedRequests[0]?.end).toBe("2025-01-17T00:00:00.001Z");
-    expect(result.viewport?.start.toISOString()).toBe("2025-01-01T00:00:00.000Z");
-    expect(result.viewport?.end.toISOString()).toBe("2025-04-01T00:00:00.000Z");
+    expect(result.viewport?.start.toISOString()).toBe("2025-01-10T00:00:00.000Z");
+    expect(result.viewport?.end.toISOString()).toBe("2025-01-17T00:00:00.000Z");
     expect(result.series[0]?.timeBasis).toMatchObject({
       kind: "market",
       timeZone: "America/New_York",

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -1067,7 +1067,7 @@ export async function resolveChartSpecData(
   // untouched market viewport by the same amount instead of clipping its tail.
   // Explicit and user-created windows stay fixed through hasExplicitWindow.
   const bounds = hasExplicitWindow
-    ? initialVisibleBounds
+    ? requestVisibleBounds
     : followLatestMarketObservation(initialVisibleBounds, rawSeries);
   const resolution = initialResolution;
   const studyBounds = bounds.end !== null

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -75,6 +75,12 @@ export interface ChartResolveSources {
   now?: Date;
   /** Latest streamed quote per security identity, layered over snapshot data. */
   quoteOverrides?: ReadonlyMap<string, Quote>;
+  /** Provider-neutral boundary for plugin-owned chart series. */
+  resolveCapabilitySeries?: (
+    source: Extract<ChartSeriesSpec["source"], { kind: "capability" }>,
+    viewport: ChartSpec["viewport"],
+    spec: ChartSeriesSpec,
+  ) => Promise<ResolvedSeries>;
 }
 
 export interface ChartResolveOptions {
@@ -93,6 +99,7 @@ export class ChartResolveCache {
   readonly accumulatedPriceHistory = new Map<string, TickerFinancials["priceHistory"]>();
   readonly resolutionSupportByInstrument = new Map<string, Promise<ChartResolutionSupport[]>>();
   readonly fredSeriesByRequest = new Map<string, Promise<FredSeriesLoadResult>>();
+  readonly capabilitySeriesByRequest = new Map<string, Promise<ResolvedSeries>>();
 }
 
 interface DateBounds {
@@ -134,9 +141,11 @@ function instrumentLabel(spec: Extract<ChartSeriesSpec["source"], { kind: "secur
 // in the series editor, with nothing on screen to explain the difference.
 function unloadableSeries(spec: ChartSeriesSpec, index: number, warning: string): ResolvedSeries {
   const field = spec.source.kind === "security" ? getTimeSeriesField(spec.source.fieldId) : undefined;
-  const label = spec.source.kind === "economic"
-    ? `FRED ${spec.source.seriesId}`
-    : `${instrumentLabel(spec.source)} ${field?.shortLabel ?? spec.source.fieldId.split(".").at(-1) ?? "Series"}`;
+  const label = spec.source.kind === "security"
+    ? `${instrumentLabel(spec.source)} ${field?.shortLabel ?? spec.source.fieldId.split(".").at(-1) ?? "Series"}`
+    : spec.source.kind === "economic"
+      ? `FRED ${spec.source.seriesId}`
+      : spec.source.seriesId;
   return {
     id: spec.id,
     label: spec.label?.trim() || label,
@@ -638,6 +647,31 @@ function baseEconomicSeries(
   };
 }
 
+function baseCapabilitySeries(
+  spec: ChartSeriesSpec,
+  loaded: ResolvedSeries,
+  index: number,
+): ResolvedSeries {
+  const points = loaded.points.flatMap((point) => {
+    const date = finiteDate(point.date as unknown as string | Date | undefined);
+    const observedAt = finiteDate(point.observedAt as unknown as string | Date | undefined) ?? date;
+    const availableAt = finiteDate(point.availableAt as unknown as string | Date | undefined) ?? undefined;
+    return date && observedAt ? [{ ...point, date, observedAt, ...(availableAt ? { availableAt } : {}) }] : [];
+  });
+  return {
+    ...loaded,
+    id: spec.id,
+    label: spec.label?.trim() || loaded.label || (spec.source.kind === "capability" ? spec.source.seriesId : spec.id),
+    color: spec.color ?? loaded.color ?? SERIES_COLORS[index % SERIES_COLORS.length]!,
+    style: spec.style,
+    transform: spec.transform,
+    axis: spec.axis === "right" ? "right" : spec.axis === "left" ? "left" : loaded.axis,
+    panelId: spec.panelId,
+    interpolation: spec.interpolation,
+    points,
+  };
+}
+
 function staleFredWarning(loaded: FredSeriesLoadResult): string | null {
   if (!loaded.stale) return null;
   return `FRED refresh failed${loaded.refreshError ? ` (${loaded.refreshError})` : ""}; showing cached data fetched ${new Date(loaded.fetchedAt).toISOString().slice(0, 10)}.`;
@@ -938,6 +972,18 @@ export async function resolveChartSpecData(
   const loaded = await Promise.all(spec.series.map(async (seriesSpec, index) => {
     if (!calculationSeriesIds.has(seriesSpec.id)) return null;
     try {
+      if (seriesSpec.source.kind === "capability") {
+        if (!sources.resolveCapabilitySeries) {
+          throw new Error(`Chart series capability "${seriesSpec.source.capabilityId}" is unavailable. Enable its plugin or provider.`);
+        }
+        const key = `${seriesSpec.source.capabilityId}|${seriesSpec.source.seriesId}|${JSON.stringify(seriesSpec.source.parameters ?? {})}|${JSON.stringify(spec.viewport)}`;
+        let pending = cache.capabilitySeriesByRequest.get(key);
+        if (!pending) {
+          pending = sources.resolveCapabilitySeries(seriesSpec.source, spec.viewport, seriesSpec);
+          cache.capabilitySeriesByRequest.set(key, pending);
+        }
+        return baseCapabilitySeries(seriesSpec, await pending, index);
+      }
       if (seriesSpec.source.kind === "economic") {
         const request: FredSeriesRequest = {
           seriesId: seriesSpec.source.seriesId,

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -41,6 +41,7 @@ import { isOhlcSeriesStyle } from "./spec";
 import { applyResolvedSeriesTransform } from "./transforms";
 import { clipSeriesToWindow } from "./alignment";
 import { chartQuoteOverrideKeyForSource } from "./live-quotes";
+import { chartSeriesSourceKey } from "../capabilities/chart-series";
 import { resolutionForExplicitMarketPeriods } from "./market-resolution";
 import {
   canonicalExchange,
@@ -976,10 +977,21 @@ export async function resolveChartSpecData(
         if (!sources.resolveCapabilitySeries) {
           throw new Error(`Chart series capability "${seriesSpec.source.capabilityId}" is unavailable. Enable its plugin or provider.`);
         }
-        const key = `${seriesSpec.source.capabilityId}|${seriesSpec.source.seriesId}|${JSON.stringify(seriesSpec.source.parameters ?? {})}|${JSON.stringify(spec.viewport)}`;
+        const capabilityViewport: ChartSpec["viewport"] = {
+          ...spec.viewport,
+          ...(requestVisibleBounds.start !== null && requestVisibleBounds.end !== null
+            ? {
+                dateWindow: {
+                  start: new Date(requestVisibleBounds.start).toISOString(),
+                  end: new Date(requestVisibleBounds.end).toISOString(),
+                },
+              }
+            : {}),
+        };
+        const key = chartSeriesSourceKey(seriesSpec.source, capabilityViewport);
         let pending = cache.capabilitySeriesByRequest.get(key);
         if (!pending) {
-          pending = sources.resolveCapabilitySeries(seriesSpec.source, spec.viewport, seriesSpec);
+          pending = sources.resolveCapabilitySeries(seriesSpec.source, capabilityViewport, seriesSpec);
           cache.capabilitySeriesByRequest.set(key, pending);
         }
         return baseCapabilitySeries(seriesSpec, await pending, index);

--- a/src/time-series/spec-studies.test.ts
+++ b/src/time-series/spec-studies.test.ts
@@ -69,7 +69,7 @@ describe("chart spec normalization and validation", () => {
     expect(validateChartSpec(normalized).valid).toBe(true);
   });
 
-  test("persists and clones unknown capability sources without requiring the provider", () => {
+  test("persists and clones bounded opaque capability sources without requiring the provider", () => {
     const normalized = normalizeChartSpec({
       viewport: { range: "1M", resolution: "auto" },
       panels: [{ id: "main" }],
@@ -78,8 +78,7 @@ describe("chart spec normalization and validation", () => {
         source: {
           kind: "capability",
           capabilityId: "missing.provider",
-          seriesId: "market-1",
-          parameters: { outcome: "yes", nested: { venue: "test" } },
+          seriesId: "polymarket/event-1/market-1",
         },
         style: "area",
         transform: "raw",
@@ -90,10 +89,6 @@ describe("chart spec normalization and validation", () => {
     const cloned = normalizeChartSpec(normalized);
     expect(cloned.series[0]?.source).toEqual(normalized.series[0]?.source);
     expect(cloned.series[0]?.source).not.toBe(normalized.series[0]?.source);
-    if (cloned.series[0]?.source.kind !== "capability" || normalized.series[0]?.source.kind !== "capability") {
-      throw new Error("expected capability source");
-    }
-    expect(cloned.series[0].source.parameters).not.toBe(normalized.series[0].source.parameters);
     expect(validateChartSpec(cloned).valid).toBe(true);
   });
 

--- a/src/time-series/spec-studies.test.ts
+++ b/src/time-series/spec-studies.test.ts
@@ -69,6 +69,34 @@ describe("chart spec normalization and validation", () => {
     expect(validateChartSpec(normalized).valid).toBe(true);
   });
 
+  test("persists and clones unknown capability sources without requiring the provider", () => {
+    const normalized = normalizeChartSpec({
+      viewport: { range: "1M", resolution: "auto" },
+      panels: [{ id: "main" }],
+      series: [{
+        id: "plugin-series",
+        source: {
+          kind: "capability",
+          capabilityId: "missing.provider",
+          seriesId: "market-1",
+          parameters: { outcome: "yes", nested: { venue: "test" } },
+        },
+        style: "area",
+        transform: "raw",
+        panelId: "main",
+      }],
+      studies: [],
+    });
+    const cloned = normalizeChartSpec(normalized);
+    expect(cloned.series[0]?.source).toEqual(normalized.series[0]?.source);
+    expect(cloned.series[0]?.source).not.toBe(normalized.series[0]?.source);
+    if (cloned.series[0]?.source.kind !== "capability" || normalized.series[0]?.source.kind !== "capability") {
+      throw new Error("expected capability source");
+    }
+    expect(cloned.series[0].source.parameters).not.toBe(normalized.series[0].source.parameters);
+    expect(validateChartSpec(cloned).valid).toBe(true);
+  });
+
   test("coerces OHLC modes away from scalar economic series", () => {
     const normalized = normalizeChartSpec({
       viewport: { range: "1Y", resolution: "auto" },

--- a/src/time-series/spec.ts
+++ b/src/time-series/spec.ts
@@ -12,6 +12,7 @@ import {
 import {
   CHART_SPEC_VERSION,
   type ChartPanelSpec,
+  type ChartSeriesParameterValue,
   type ChartSeriesSource,
   type ChartSeriesSpec,
   type ChartSpec,
@@ -117,7 +118,9 @@ function cloneSpec(spec: ChartSpec): ChartSpec {
       ...entry,
       source: entry.source.kind === "security"
         ? { ...entry.source, instrument: { ...entry.source.instrument } }
-        : { ...entry.source },
+        : entry.source.kind === "capability"
+          ? { ...entry.source, parameters: entry.source.parameters ? structuredClone(entry.source.parameters) : undefined }
+          : { ...entry.source },
     })),
     studies: spec.studies.map((study) => ({
       ...study,
@@ -127,6 +130,26 @@ function cloneSpec(spec: ChartSpec): ChartSpec {
   };
 }
 
+function normalizeParameterValue(value: unknown): ChartSeriesParameterValue | undefined {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (Array.isArray(value)) {
+    const values = value.map(normalizeParameterValue);
+    return values.some((entry) => entry === undefined)
+      ? undefined
+      : values as ChartSeriesParameterValue[];
+  }
+  const input = record(value);
+  if (!input) return undefined;
+  const output: Record<string, ChartSeriesParameterValue> = {};
+  for (const [key, entry] of Object.entries(input)) {
+    const normalized = normalizeParameterValue(entry);
+    if (normalized === undefined) return undefined;
+    output[key] = normalized;
+  }
+  return output;
+}
+
 function normalizeSource(value: unknown): ChartSeriesSource | null {
   const source = record(value);
   if (!source) return null;
@@ -134,6 +157,21 @@ function normalizeSource(value: unknown): ChartSeriesSource | null {
     const seriesId = nonEmptyString(source.seriesId);
     if (!seriesId || source.provider !== "fred") return null;
     return { kind: "economic", provider: "fred", seriesId };
+  }
+  if (source.kind === "capability") {
+    const capabilityId = nonEmptyString(source.capabilityId);
+    const seriesId = nonEmptyString(source.seriesId);
+    const parameters = source.parameters === undefined ? undefined : normalizeParameterValue(source.parameters);
+    if (!capabilityId || !seriesId) return null;
+    if (source.parameters !== undefined && (
+      !parameters || typeof parameters !== "object" || Array.isArray(parameters)
+    )) return null;
+    return {
+      kind: "capability",
+      capabilityId,
+      seriesId,
+      ...(parameters ? { parameters: parameters as Record<string, ChartSeriesParameterValue> } : {}),
+    };
   }
   if (source.kind !== "security") return null;
   const instrument = record(source.instrument);
@@ -425,12 +463,19 @@ export function validateChartSpec(spec: ChartSpec): ChartSpecValidationResult {
             : definition.unitGroup);
         unitGroupsByPanel.set(entry.panelId, groups);
       }
-    } else {
+    } else if (entry.source.kind === "economic") {
       if (!entry.source.seriesId.trim()) {
         errors.push(issue(`${path}.source.seriesId`, "missing-series", "Economic series ID is required."));
       }
       if (!ECONOMIC_STYLES.has(entry.style)) {
         errors.push(issue(`${path}.style`, "unsupported-style", `${entry.style} is not valid for an economic scalar series.`));
+      }
+    } else {
+      if (!entry.source.capabilityId.trim()) {
+        errors.push(issue(`${path}.source.capabilityId`, "missing-capability", "Chart series capability ID is required."));
+      }
+      if (!entry.source.seriesId.trim()) {
+        errors.push(issue(`${path}.source.seriesId`, "missing-series", "Provider series ID is required."));
       }
     }
     if (isOhlcSeriesStyle(entry.style)) {
@@ -440,7 +485,7 @@ export function validateChartSpec(spec: ChartSpec): ChartSpecValidationResult {
         firstCandleByPanel.set(
           entry.panelId,
           entry.label?.trim()
-            || (entry.source.kind === "economic" ? entry.source.seriesId : entry.source.instrument.symbol),
+            || (entry.source.kind === "security" ? entry.source.instrument.symbol : entry.source.seriesId),
         );
       }
       if (entry.transform !== "raw") {

--- a/src/time-series/spec.ts
+++ b/src/time-series/spec.ts
@@ -12,7 +12,6 @@ import {
 import {
   CHART_SPEC_VERSION,
   type ChartPanelSpec,
-  type ChartSeriesParameterValue,
   type ChartSeriesSource,
   type ChartSeriesSpec,
   type ChartSpec,
@@ -27,6 +26,10 @@ import {
   type SeriesTransform,
   type SecuritySeriesSource,
 } from "./types";
+import {
+  isValidChartCapabilityId,
+  isValidChartSeriesId,
+} from "../capabilities/chart-series";
 
 const TIME_RANGES = new Set<TimeRange>(["1D", "1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"]);
 const RESOLUTIONS = new Set<ChartResolution>(["auto", "1m", "5m", "15m", "30m", "45m", "1h", "1d", "1wk", "1mo"]);
@@ -118,9 +121,7 @@ function cloneSpec(spec: ChartSpec): ChartSpec {
       ...entry,
       source: entry.source.kind === "security"
         ? { ...entry.source, instrument: { ...entry.source.instrument } }
-        : entry.source.kind === "capability"
-          ? { ...entry.source, parameters: entry.source.parameters ? structuredClone(entry.source.parameters) : undefined }
-          : { ...entry.source },
+        : { ...entry.source },
     })),
     studies: spec.studies.map((study) => ({
       ...study,
@@ -128,26 +129,6 @@ function cloneSpec(spec: ChartSpec): ChartSpec {
       parameters: { ...study.parameters },
     })),
   };
-}
-
-function normalizeParameterValue(value: unknown): ChartSeriesParameterValue | undefined {
-  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
-  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
-  if (Array.isArray(value)) {
-    const values = value.map(normalizeParameterValue);
-    return values.some((entry) => entry === undefined)
-      ? undefined
-      : values as ChartSeriesParameterValue[];
-  }
-  const input = record(value);
-  if (!input) return undefined;
-  const output: Record<string, ChartSeriesParameterValue> = {};
-  for (const [key, entry] of Object.entries(input)) {
-    const normalized = normalizeParameterValue(entry);
-    if (normalized === undefined) return undefined;
-    output[key] = normalized;
-  }
-  return output;
 }
 
 function normalizeSource(value: unknown): ChartSeriesSource | null {
@@ -161,17 +142,10 @@ function normalizeSource(value: unknown): ChartSeriesSource | null {
   if (source.kind === "capability") {
     const capabilityId = nonEmptyString(source.capabilityId);
     const seriesId = nonEmptyString(source.seriesId);
-    const parameters = source.parameters === undefined ? undefined : normalizeParameterValue(source.parameters);
-    if (!capabilityId || !seriesId) return null;
-    if (source.parameters !== undefined && (
-      !parameters || typeof parameters !== "object" || Array.isArray(parameters)
-    )) return null;
-    return {
-      kind: "capability",
-      capabilityId,
-      seriesId,
-      ...(parameters ? { parameters: parameters as Record<string, ChartSeriesParameterValue> } : {}),
-    };
+    if (!capabilityId || !seriesId
+      || !isValidChartCapabilityId(capabilityId)
+      || !isValidChartSeriesId(seriesId)) return null;
+    return { kind: "capability", capabilityId, seriesId };
   }
   if (source.kind !== "security") return null;
   const instrument = record(source.instrument);
@@ -471,11 +445,11 @@ export function validateChartSpec(spec: ChartSpec): ChartSpecValidationResult {
         errors.push(issue(`${path}.style`, "unsupported-style", `${entry.style} is not valid for an economic scalar series.`));
       }
     } else {
-      if (!entry.source.capabilityId.trim()) {
-        errors.push(issue(`${path}.source.capabilityId`, "missing-capability", "Chart series capability ID is required."));
+      if (!isValidChartCapabilityId(entry.source.capabilityId)) {
+        errors.push(issue(`${path}.source.capabilityId`, "invalid-capability", "Chart series capability ID is invalid."));
       }
-      if (!entry.source.seriesId.trim()) {
-        errors.push(issue(`${path}.source.seriesId`, "missing-series", "Provider series ID is required."));
+      if (!isValidChartSeriesId(entry.source.seriesId)) {
+        errors.push(issue(`${path}.source.seriesId`, "invalid-series", "Provider series ID is invalid."));
       }
     }
     if (isOhlcSeriesStyle(entry.style)) {

--- a/src/time-series/types.ts
+++ b/src/time-series/types.ts
@@ -26,7 +26,23 @@ export interface EconomicSeriesSource {
   seriesId: string;
 }
 
-export type ChartSeriesSource = SecuritySeriesSource | EconomicSeriesSource;
+export type ChartSeriesParameterValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ChartSeriesParameterValue[]
+  | { [key: string]: ChartSeriesParameterValue };
+
+/** Persisted provider-owned source. Capability availability is resolved at runtime. */
+export interface CapabilitySeriesSource {
+  kind: "capability";
+  capabilityId: string;
+  seriesId: string;
+  parameters?: Record<string, ChartSeriesParameterValue>;
+}
+
+export type ChartSeriesSource = SecuritySeriesSource | EconomicSeriesSource | CapabilitySeriesSource;
 
 export interface ChartSeriesSpec {
   id: string;

--- a/src/time-series/types.ts
+++ b/src/time-series/types.ts
@@ -2,7 +2,7 @@ import type { ChartResolution, TimeRange } from "./range";
 import type { ChartResolutionSupport } from "./resolution";
 import type { InstrumentRef } from "../market-data/request-types";
 
-export const CHART_SPEC_VERSION = 1 as const;
+export const CHART_SPEC_VERSION = 2 as const;
 
 export type SeriesPeriod = "auto" | "daily" | "weekly" | "monthly" | "quarterly" | "annual" | "ttm";
 export type SeriesStyle = "line" | "area" | "step" | "columns" | "points" | "candles" | "ohlc" | "hlc";
@@ -26,20 +26,11 @@ export interface EconomicSeriesSource {
   seriesId: string;
 }
 
-export type ChartSeriesParameterValue =
-  | string
-  | number
-  | boolean
-  | null
-  | ChartSeriesParameterValue[]
-  | { [key: string]: ChartSeriesParameterValue };
-
-/** Persisted provider-owned source. Capability availability is resolved at runtime. */
+/** Persisted provider-owned source. The opaque series ID includes provider lookup identity. */
 export interface CapabilitySeriesSource {
   kind: "capability";
   capabilityId: string;
   seriesId: string;
-  parameters?: Record<string, ChartSeriesParameterValue>;
 }
 
 export type ChartSeriesSource = SecuritySeriesSource | EconomicSeriesSource | CapabilitySeriesSource;


### PR DESCRIPTION
## Summary

- add a provider-neutral `chart-series` plugin capability for catalog search and historical resolution
- persist one generic capability source shape with bounded opaque series IDs, strict renderer-safe input/output schemas, and capped point/catalog payloads
- make Prediction Markets the first provider, with stable Kalshi/Polymarket identity re-resolution across restarts and token changes
- add a dedicated Prediction Market Chart tab
- add thin core aliases for `FUT:<code>` and `UST:<maturity>` using the existing security and FRED pipelines
- preserve CLI reports, desktop screenshots, OpenTUI, kitty, and Electrobun capability bridging

## Runtime behavior

Capability loads use effective panned bounds and canonical cache keys. Polymarket and Kalshi receive bounded history windows. Catalog cancellation propagates through Electrobun RPC into backend AbortControllers and provider fetches. Disabled capability manifests remain discoverable for later re-enable while invocation still enforces enabled state.

Chart specs migrate from v1 to v2. Old security/economic specs remain valid; missing or disabled capability providers retain a useful error/legend entry instead of silently deleting the series.

## Exclusions

- no AI Benchmarks in core
- no VoteHub or Adjacent source kinds in core
- no TradingView/lightweight-charts renderer
- no header or chart shortcut redesign
- no fabricated historical observations

AI Benchmarks can now be implemented as an external plugin using this capability.

## Verification

- `bun run typecheck`
- `bun test` (2,092 passed after the final rebase; final capability-fix run also passed 2,080 tests before the onboarding merge)
- desktop view and full Electrobun QA build
- clean TUI smoke for `G FUT:ES, UST:10Y`
- Electrobun desktop rendering of the same mixed chart with mouse range selection
- focused capability schema, persistence, pan, cancellation, Prediction Market refresh, CLI report, and desktop-shot tests
- final independent blocker review: merge-ready, no P0/P1/P2 findings

## Attribution

The universal-series direction was first explored in @Lucas-Kohorst's [Gloomberb fork](https://github.com/Lucas-Kohorst/gloomberb). This PR redesigns it as a provider-neutral plugin boundary suitable for external features such as AI Benchmarks.
