### PR TITLE
feat(macro): add IPO calendar pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ The toolbar controls preset or exact date ranges, intervals from one minute thro
 | `VIX` | VIX 30-day/3-month implied-volatility curve |
 | `CRD` | Credit spreads |
 | `ERN` | Earnings calendar |
+| `IPO` | Upcoming and recent IPOs |
 | `TV` | Live Bloomberg, CNBC, and Yahoo Finance television |
 | `BI` / `SP` | S&P 500 sector performance |
 | `FXC` | Major FX cross rates |

--- a/src/plugins/builtin/composite-plugins.ts
+++ b/src/plugins/builtin/composite-plugins.ts
@@ -10,6 +10,7 @@ import { correlationModule } from "./correlation";
 import { creditConditionsModule } from "./credit-conditions";
 import { economicCalendarModule } from "./econ";
 import { earningsModule } from "./earnings";
+import { ipoCalendarModule } from "./ipo-calendar";
 import { fearGreedModule } from "./fear-greed";
 import { futuresModule } from "./futures";
 import { fxMatrixModule } from "./fx-matrix";
@@ -86,7 +87,7 @@ export const macroPlugin = composeBuiltinPlugin({
   id: "macro",
   name: "Macro",
   version: "1.0.0",
-  description: "Economic calendar, rates, volatility, credit spreads, Treasury auctions, earnings, and live financial TV.",
+  description: "Economic calendar, rates, volatility, credit spreads, Treasury auctions, earnings, IPOs, and live financial TV.",
   toggleable: true,
   modules: [
     macroSharedResourcesModule,
@@ -96,6 +97,7 @@ export const macroPlugin = composeBuiltinPlugin({
     creditConditionsModule,
     treasuryAuctionsModule,
     earningsModule,
+    ipoCalendarModule,
     tvModule,
   ],
 });

--- a/src/plugins/builtin/ipo-calendar/client.test.ts
+++ b/src/plugins/builtin/ipo-calendar/client.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { getFlatData } from "./client";
+
+describe("getFlatData", () => {
+  test("selects the node with IPO records, not the first object-shaped node", () => {
+    const payload = {
+      nodes: [
+        {
+          data: [
+            { session: "abc", user: null },
+            { cookie: "x" },
+          ],
+        },
+        { type: "skip" },
+        {
+          data: [
+            { type: "root" },
+            { s: "AAAA", n: "Alpha", ipoDate: "2026-08-13" },
+            { s: "BBBB", n: "Beta", ipoDate: "2026-08-20" },
+          ],
+        },
+      ],
+    };
+
+    const flat = getFlatData(payload);
+    expect(flat).not.toBeNull();
+    expect(flat).toHaveLength(3);
+    expect(flat?.[1]).toEqual({ s: "AAAA", n: "Alpha", ipoDate: "2026-08-13" });
+    expect(flat?.[2]).toEqual({ s: "BBBB", n: "Beta", ipoDate: "2026-08-20" });
+  });
+});

--- a/src/plugins/builtin/ipo-calendar/client.ts
+++ b/src/plugins/builtin/ipo-calendar/client.ts
@@ -1,0 +1,290 @@
+import type { ConnectionHealthRegistry } from "../../../core/connection-health";
+import { httpFetch } from "../../../utils/http-transport";
+import type { IPORecord, IPOStatus } from "./types";
+
+export const STOCKANALYSIS_IPO_CONNECTION_ID = "stockanalysis-ipo";
+
+const SA_RECENT_URL = "https://stockanalysis.com/ipos/__data.json";
+const SA_CALENDAR_URL = "https://stockanalysis.com/ipos/calendar/__data.json";
+const FETCH_TIMEOUT_MS = 15_000;
+
+const SA_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
+let connectionHealth: ConnectionHealthRegistry | null = null;
+
+export function attachIpoCalendarHealth(health?: ConnectionHealthRegistry): void {
+  connectionHealth = health ?? null;
+}
+
+export function resetIpoCalendarHealth(): void {
+  connectionHealth = null;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isRecordArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}
+
+function num(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return value;
+}
+
+function str(value: unknown): string | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  return value;
+}
+
+/**
+ * Resolve a SvelteKit devalue reference from the flat data array.
+ * Objects and arrays store integer indices into the same flat array;
+ * primitives are returned directly.
+ */
+function resolveRef(flat: unknown[], index: number, depth = 0): unknown {
+  if (depth > 20) return undefined;
+  if (typeof index !== "number" || index < 0 || index >= flat.length) return undefined;
+  const value = flat[index];
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      typeof item === "number" ? resolveRef(flat, item, depth + 1) : item,
+    );
+  }
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    result[key] = typeof val === "number" ? resolveRef(flat, val, depth + 1) : val;
+  }
+  return result;
+}
+
+function isIpoRecordShape(value: unknown): value is Record<string, unknown> {
+  return isObject(value) && "s" in value && "ipoDate" in value;
+}
+
+function countIpoRecords(flat: unknown[]): number {
+  let count = 0;
+  for (const item of flat) {
+    if (isIpoRecordShape(item)) count += 1;
+  }
+  return count;
+}
+
+/**
+ * SvelteKit `__data.json` ships several nodes. Node 0 is session/cookie
+ * boilerplate whose first entry is an object; the IPO rows live in a later
+ * node. Select by record shape, not by the first object-shaped node.
+ */
+export function getFlatData(payload: unknown): unknown[] | null {
+  const root = isObject(payload) ? payload : null;
+  const nodes = root?.nodes;
+  if (!isRecordArray(nodes)) return null;
+
+  let best: unknown[] | null = null;
+  let bestCount = 0;
+  for (const node of nodes) {
+    const nodeData = isObject(node) ? node.data : undefined;
+    if (!isRecordArray(nodeData) || nodeData.length === 0) continue;
+    const count = countIpoRecords(nodeData);
+    if (count > bestCount) {
+      best = nodeData;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+function findRecordObjects(flat: unknown[]): Record<string, unknown>[] {
+  const records: Record<string, unknown>[] = [];
+  for (const item of flat) {
+    if (isIpoRecordShape(item)) records.push(item);
+  }
+  return records;
+}
+
+function resolveRecord(flat: unknown[], record: Record<string, unknown>): Record<string, unknown> {
+  const resolved: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(record)) {
+    resolved[key] = typeof val === "number" ? resolveRef(flat, val) : val;
+  }
+  return resolved;
+}
+
+function parseDate(value: unknown): Date | null {
+  const text = str(value);
+  if (!text) return null;
+  const parsed = new Date(`${text}T00:00:00Z`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function parsePriceRange(value: unknown): [number, number] | null {
+  const text = str(value);
+  if (!text) return null;
+  const match = text.match(/\$?([\d.]+)\s*-\s*\$?([\d.]+)/);
+  if (!match) return null;
+  const low = parseFloat(match[1]!);
+  const high = parseFloat(match[2]!);
+  if (!Number.isFinite(low) || !Number.isFinite(high)) return null;
+  return [low, high];
+}
+
+function recordFromRecent(flat: unknown[], record: Record<string, unknown>): IPORecord | null {
+  const resolved = resolveRecord(flat, record);
+  const ticker = str(resolved.s);
+  const companyName = str(resolved.n);
+  const date = parseDate(resolved.ipoDate);
+  if (!ticker || !companyName || !date) return null;
+
+  const pricedPrice = num(resolved.ipoPrice);
+  const closePrice = num(resolved.ippc);
+  const change1D = num(resolved.ipr);
+  const hasPerformance = closePrice != null || change1D != null;
+  const status: IPOStatus = hasPerformance ? "trading" : "priced";
+
+  return {
+    ticker,
+    companyName,
+    date,
+    status,
+    exchange: null,
+    offerSize: null,
+    priceRange: null,
+    pricedPrice,
+    shares: null,
+    closePrice,
+    change1D,
+  };
+}
+
+function recordFromCalendar(flat: unknown[], record: Record<string, unknown>): IPORecord | null {
+  const resolved = resolveRecord(flat, record);
+  const ticker = str(resolved.s);
+  const companyName = str(resolved.n);
+  const date = parseDate(resolved.ipoDate);
+  if (!ticker || !companyName || !date) return null;
+
+  const exchange = str(resolved.exchange);
+  const priceRange = parsePriceRange(resolved.ipoPriceRange);
+  const shares = num(resolved.sharesOffered);
+  const dealSize = num(resolved.ds);
+  const offerSize = dealSize ?? (shares != null && priceRange != null ? shares * priceRange[0] : null);
+
+  return {
+    ticker,
+    companyName,
+    date,
+    status: "upcoming",
+    exchange,
+    offerSize,
+    priceRange,
+    pricedPrice: null,
+    shares,
+    closePrice: null,
+    change1D: null,
+  };
+}
+
+function getCalendarSectionIndices(flat: unknown[], root: Record<string, unknown>, field: string): number[] {
+  const index = num(root[field]);
+  if (index == null) return [];
+  const value = flat[index];
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is number => typeof item === "number");
+}
+
+function fetchJson(url: string, headers: Record<string, string>): Promise<unknown> {
+  return httpFetch(url, {
+    headers,
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  }).then((response) => {
+    if (!response.ok) {
+      throw new Error(`Request failed (${response.status}) for ${url}`);
+    }
+    return response.json();
+  });
+}
+
+function fetchStockAnalysis(url: string, operation: string): Promise<unknown> {
+  const request = () => fetchJson(url, {
+    "User-Agent": SA_USER_AGENT,
+    Accept: "application/json",
+  });
+  return connectionHealth?.hasSource(STOCKANALYSIS_IPO_CONNECTION_ID)
+    ? connectionHealth.track(STOCKANALYSIS_IPO_CONNECTION_ID, operation, request)
+    : request();
+}
+
+async function fetchRecentIpos(): Promise<IPORecord[]> {
+  const payload = await fetchStockAnalysis(SA_RECENT_URL, "fetchRecent");
+  const flat = getFlatData(payload);
+  if (!flat) return [];
+  const records = findRecordObjects(flat);
+  return records
+    .map((record) => recordFromRecent(flat, record))
+    .filter((record): record is IPORecord => record !== null);
+}
+
+function parseCalendarRecords(flat: unknown[]): IPORecord[] {
+  const root = isObject(flat[0]) ? flat[0] : null;
+  if (root) {
+    const sections = ["thisWeekData", "nextWeekData", "laterData"];
+    const results: IPORecord[] = [];
+    for (const field of sections) {
+      const indices = getCalendarSectionIndices(flat, root, field);
+      for (const idx of indices) {
+        const record = isObject(flat[idx]) ? flat[idx] as Record<string, unknown> : null;
+        if (!record) continue;
+        const parsed = recordFromCalendar(flat, record);
+        if (parsed) results.push(parsed);
+      }
+    }
+    if (results.length > 0) return results;
+  }
+
+  return findRecordObjects(flat)
+    .map((record) => recordFromCalendar(flat, record))
+    .filter((record): record is IPORecord => record !== null);
+}
+
+async function fetchUpcomingIpos(): Promise<IPORecord[]> {
+  const payload = await fetchStockAnalysis(SA_CALENDAR_URL, "fetchUpcoming");
+  const flat = getFlatData(payload);
+  if (!flat) return [];
+  return parseCalendarRecords(flat);
+}
+
+function dedupeAndSort(records: IPORecord[]): IPORecord[] {
+  const byTicker = new Map<string, IPORecord>();
+  const statusOrder: Record<IPOStatus, number> = { upcoming: 0, priced: 1, trading: 2 };
+  for (const record of records) {
+    const key = record.ticker.toUpperCase();
+    const existing = byTicker.get(key);
+    if (!existing || statusOrder[record.status] < statusOrder[existing.status]) {
+      byTicker.set(key, record);
+    }
+  }
+  return [...byTicker.values()].sort((a, b) => b.date.getTime() - a.date.getTime());
+}
+
+export async function fetchIpoCalendar(): Promise<IPORecord[]> {
+  const [recentResult, upcomingResult] = await Promise.allSettled([
+    fetchRecentIpos(),
+    fetchUpcomingIpos(),
+  ]);
+
+  const records: IPORecord[] = [];
+  if (recentResult.status === "fulfilled") records.push(...recentResult.value);
+  if (upcomingResult.status === "fulfilled") records.push(...upcomingResult.value);
+
+  if (records.length === 0) {
+    const errors: string[] = [];
+    if (recentResult.status === "rejected") errors.push(`recent: ${recentResult.reason}`);
+    if (upcomingResult.status === "rejected") errors.push(`upcoming: ${upcomingResult.reason}`);
+    if (errors.length > 0) throw new Error(`IPO data unavailable (${errors.join("; ")})`);
+  }
+
+  return dedupeAndSort(records);
+}

--- a/src/plugins/builtin/ipo-calendar/index.tsx
+++ b/src/plugins/builtin/ipo-calendar/index.tsx
@@ -1,0 +1,62 @@
+import type { PluginModule } from "../plugin-module";
+import {
+  attachIpoCalendarHealth,
+  resetIpoCalendarHealth,
+  STOCKANALYSIS_IPO_CONNECTION_ID,
+} from "./client";
+import { IPOCalendarPane } from "./pane";
+import { IPO_CALENDAR_PANE_ID } from "./types";
+
+let disposeConnection: (() => void) | null = null;
+
+export const ipoCalendarModule: PluginModule = {
+  setup(ctx) {
+    attachIpoCalendarHealth(ctx.connectionHealth);
+    disposeConnection = ctx.connectionHealth.registerSource({
+      id: STOCKANALYSIS_IPO_CONNECTION_ID,
+      name: "Stock Analysis",
+      kind: "api",
+      ownerId: "macro",
+      detail: "stockanalysis.com",
+      priority: 300,
+    });
+  },
+
+  dispose() {
+    disposeConnection?.();
+    disposeConnection = null;
+    resetIpoCalendarHealth();
+  },
+
+  panes: [
+    {
+      id: IPO_CALENDAR_PANE_ID,
+      name: "IPO Calendar",
+      icon: "I",
+      component: IPOCalendarPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 110, height: 28 },
+    },
+  ],
+
+  paneTemplates: [
+    {
+      id: "ipo-calendar-pane",
+      paneId: IPO_CALENDAR_PANE_ID,
+      label: "IPO Calendar",
+      description: "Upcoming and recent IPOs from Stock Analysis: pricing, offer size, and first-day return.",
+      keywords: [
+        "ipo",
+        "initial",
+        "public",
+        "offering",
+        "new",
+        "listing",
+        "debut",
+      ],
+      shortcut: { prefix: "IPO" },
+      createInstance: () => ({ placement: "floating" }),
+    },
+  ],
+};

--- a/src/plugins/builtin/ipo-calendar/model.ts
+++ b/src/plugins/builtin/ipo-calendar/model.ts
@@ -1,0 +1,136 @@
+import type { DataTableColumn } from "../../../components";
+import { colors } from "../../../theme/colors";
+import { compareSortValues, type SortDirection } from "../../../utils/sort-values";
+import type { IPORecord, IPOStatus } from "./types";
+
+type IPOColumnId =
+  | "ticker"
+  | "date"
+  | "status"
+  | "exchange"
+  | "offer"
+  | "price"
+  | "shares"
+  | "return";
+
+export type IPOColumn = DataTableColumn & { id: IPOColumnId };
+
+export interface IPOSortPreference {
+  columnId: IPOColumnId | null;
+  direction: SortDirection;
+}
+
+export const DEFAULT_SORT_PREFERENCE: IPOSortPreference = {
+  columnId: null,
+  direction: "asc",
+};
+
+export function statusColor(status: IPOStatus): string {
+  switch (status) {
+    case "upcoming":
+      return colors.warning;
+    case "priced":
+      return colors.textBright;
+    case "trading":
+      return colors.positive;
+  }
+}
+
+export function formatDate(date: Date): string {
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${date.getUTCFullYear()}-${month}-${day}`;
+}
+
+export function formatOfferSize(value: number | null): string {
+  if (value == null) return "—";
+  const abs = Math.abs(value);
+  if (abs >= 1e9) return `$${(value / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `$${(value / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3) return `$${(value / 1e3).toFixed(0)}K`;
+  return `$${value.toFixed(0)}`;
+}
+
+export function formatShares(value: number | null): string {
+  if (value == null) return "—";
+  const abs = Math.abs(value);
+  if (abs >= 1e9) return `${(value / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `${(value / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3) return `${(value / 1e3).toFixed(1)}K`;
+  return String(value);
+}
+
+export function formatPrice(record: IPORecord): string {
+  if (record.pricedPrice != null) return `$${record.pricedPrice.toFixed(2)}`;
+  if (record.priceRange != null) return `$${record.priceRange[0].toFixed(2)}–$${record.priceRange[1].toFixed(2)}`;
+  return "—";
+}
+
+export function formatReturn(value: number | null): string {
+  if (value == null) return "—";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(1)}%`;
+}
+
+export function stockAnalysisUrl(ticker: string): string {
+  return `https://stockanalysis.com/stocks/${ticker.toLowerCase()}/`;
+}
+
+export function buildColumns(_width: number): IPOColumn[] {
+  return [
+    { id: "ticker", label: "TICKER", width: 7, align: "left" },
+    { id: "date", label: "DATE", width: 11, align: "left" },
+    { id: "status", label: "STATUS", width: 9, align: "left" },
+    { id: "exchange", label: "EXCH", width: 8, align: "left" },
+    { id: "offer", label: "OFFER", width: 8, align: "right" },
+    { id: "price", label: "PRICE", width: 12, align: "right" },
+    { id: "shares", label: "SHARES", width: 7, align: "right" },
+    { id: "return", label: "RETURN", width: 8, align: "right" },
+  ];
+}
+
+function getSortValue(columnId: IPOColumnId, row: IPORecord): string | number | null {
+  switch (columnId) {
+    case "ticker":
+      return row.ticker;
+    case "date":
+      return row.date.getTime();
+    case "status":
+      return row.status;
+    case "exchange":
+      return row.exchange ?? "";
+    case "offer":
+      return row.offerSize;
+    case "price":
+      return row.pricedPrice ?? row.priceRange?.[0] ?? null;
+    case "shares":
+      return row.shares;
+    case "return":
+      return row.change1D;
+  }
+}
+
+export function sortRows(rows: IPORecord[], sort: IPOSortPreference): IPORecord[] {
+  if (!sort.columnId) return rows;
+  return [...rows].sort((a, b) =>
+    compareSortValues(getSortValue(sort.columnId!, a), getSortValue(sort.columnId!, b), sort.direction),
+  );
+}
+
+export function nextSortPreference(current: IPOSortPreference, columnId: string): IPOSortPreference {
+  const typed = columnId as IPOColumnId;
+  if (current.columnId !== typed) return { columnId: typed, direction: "asc" };
+  if (current.direction === "asc") return { columnId: typed, direction: "desc" };
+  return DEFAULT_SORT_PREFERENCE;
+}
+
+export function matchesSearch(record: IPORecord, query: string): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  return (
+    record.ticker.toLowerCase().includes(q)
+    || record.companyName.toLowerCase().includes(q)
+    || (record.exchange?.toLowerCase().includes(q) ?? false)
+    || record.status.includes(q)
+  );
+}

--- a/src/plugins/builtin/ipo-calendar/pane.tsx
+++ b/src/plugins/builtin/ipo-calendar/pane.tsx
@@ -1,0 +1,309 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  DataTableView,
+  InputSearchBar,
+  Spinner,
+  useExternalLinkFooter,
+  type DataTableCell,
+  type DataTableKeyEvent,
+} from "../../../components";
+import { useShortcut } from "../../../react/input";
+import { colors, priceColor } from "../../../theme/colors";
+import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
+import type { PaneProps } from "../../../types/plugin";
+import { Box, Text, TextAttributes, type InputRenderable } from "../../../ui";
+import { isPlainKey } from "../../../utils/keyboard";
+import { usePluginTickerActions } from "../../runtime";
+import { useAutoRefresh } from "../shared/auto-refresh";
+import { loadingErrorFooterInfo } from "../shared/table-pane";
+import { fetchIpoCalendar } from "./client";
+import {
+  DEFAULT_SORT_PREFERENCE,
+  buildColumns,
+  formatDate,
+  formatOfferSize,
+  formatPrice,
+  formatReturn,
+  formatShares,
+  matchesSearch,
+  nextSortPreference,
+  sortRows,
+  statusColor,
+  stockAnalysisUrl,
+  type IPOColumn,
+  type IPOSortPreference,
+} from "./model";
+import { IPO_CALENDAR_PANE_ID, type IPORecord, type LoadStatus } from "./types";
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+export function IPOCalendarPane({ focused, width, height }: PaneProps) {
+  const { pinTicker } = usePluginTickerActions();
+  const [records, setRecords] = useState<IPORecord[]>([]);
+  const [status, setStatus] = useState<LoadStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [selectedTicker, setSelectedTicker] = useState<string | null>(null);
+  const [sortPreference, setSortPreference] = useState<IPOSortPreference>(DEFAULT_SORT_PREFERENCE);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchFocused, setSearchFocused] = useState(false);
+  const [searchFocusToken, setSearchFocusToken] = useState(0);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+  const searchInputRef = useRef<InputRenderable | null>(null);
+  const fetchGenRef = useRef(0);
+
+  const load = useCallback(async () => {
+    fetchGenRef.current += 1;
+    const gen = fetchGenRef.current;
+    setStatus((current) => (current === "loaded" ? current : "loading"));
+    setError(null);
+
+    try {
+      const data = await fetchIpoCalendar();
+      if (fetchGenRef.current !== gen) return;
+      setRecords(data);
+      setStatus("loaded");
+      setLastUpdated(Date.now());
+    } catch (err) {
+      if (fetchGenRef.current !== gen) return;
+      setError(err instanceof Error ? err.message : String(err));
+      setStatus("error");
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useAutoRefresh(status === "loaded" ? lastUpdated : null, () => {
+    void load();
+  });
+
+  const filtered = useMemo(
+    () => records.filter((record) => matchesSearch(record, searchQuery)),
+    [records, searchQuery],
+  );
+
+  const sorted = useMemo(
+    () => sortRows(filtered, sortPreference),
+    [filtered, sortPreference],
+  );
+
+  const columns = useMemo(() => buildColumns(width), [width]);
+
+  useEffect(() => {
+    if (selectedTicker && sorted.some((record) => record.ticker === selectedTicker)) return;
+    const first = sorted[0];
+    if (first) {
+      setSelectedTicker(first.ticker);
+    } else if (selectedTicker !== null) {
+      setSelectedTicker(null);
+    }
+  }, [selectedTicker, sorted]);
+
+  const loading = status === "loading" && records.length === 0;
+
+  const focusSearch = useCallback(() => {
+    setSearchFocused(true);
+    setSearchFocusToken((token) => token + 1);
+  }, []);
+
+  const blurSearch = useCallback(() => {
+    setSearchFocused(false);
+  }, []);
+
+  const updateSearch = useCallback((query: string) => {
+    setSearchQuery(query);
+    setSelectedTicker(null);
+  }, []);
+
+  const refresh = useCallback(() => {
+    void load();
+  }, [load]);
+
+  const handleHeaderClick = useCallback((columnId: string) => {
+    setSortPreference((current) => nextSortPreference(current, columnId));
+  }, []);
+
+  const handleTableKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (isPlainKey(event, "r")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      refresh();
+      return true;
+    }
+    if (isPlainKey(event, "/") || isPlainKey(event, "s")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      focusSearch();
+      return true;
+    }
+    return false;
+  }, [focusSearch, refresh]);
+
+  const handleActivate = useCallback((record: IPORecord) => {
+    pinTicker(record.ticker, { floating: true, paneType: TICKER_RESEARCH_PANE_ID });
+  }, [pinTicker]);
+
+  useShortcut((event) => {
+    if (!focused || searchFocused) return;
+    if (event.targetEditable) return;
+    if (isPlainKey(event, "/") || isPlainKey(event, "s")) {
+      event.stopPropagation?.();
+      event.preventDefault?.();
+      focusSearch();
+    } else if (isPlainKey(event, "r")) {
+      event.stopPropagation?.();
+      event.preventDefault?.();
+      refresh();
+    }
+  }, { allowEditable: true, enabled: focused });
+
+  const selectedRecord = useMemo(
+    () => sorted.find((record) => record.ticker === selectedTicker) ?? null,
+    [selectedTicker, sorted],
+  );
+
+  const footerInfo = useMemo(() => [
+    ...loadingErrorFooterInfo(status === "loading", status === "error" ? error : null),
+    ...(searchQuery ? [{
+      id: "search",
+      parts: [{ text: `filter: ${searchQuery}`, tone: "value" as const }],
+    }] : []),
+  ], [error, searchQuery, status]);
+
+  const footerHints = useMemo(() => [
+    { id: "search", key: "s", label: "earch", onPress: focusSearch },
+    { id: "refresh", key: "r", label: "efresh", onPress: refresh },
+  ], [focusSearch, refresh]);
+
+  useExternalLinkFooter({
+    registrationId: IPO_CALENDAR_PANE_ID,
+    focused,
+    url: selectedRecord ? stockAnalysisUrl(selectedRecord.ticker) : null,
+    source: "stockanalysis.com",
+    info: footerInfo,
+    hints: footerHints,
+  });
+
+  const renderCell = useCallback(
+    (row: IPORecord, column: IPOColumn, _index: number, rowState: { selected: boolean }): DataTableCell => {
+      const selectedColor = rowState.selected ? colors.selectedText : undefined;
+
+      switch (column.id) {
+        case "ticker":
+          return {
+            text: row.ticker,
+            color: selectedColor ?? colors.textBright,
+            attributes: TextAttributes.BOLD,
+          };
+        case "date":
+          return {
+            text: formatDate(row.date),
+            color: selectedColor ?? colors.textMuted,
+          };
+        case "status":
+          return {
+            text: row.status,
+            color: selectedColor ?? statusColor(row.status),
+          };
+        case "exchange":
+          return {
+            text: row.exchange ?? "—",
+            color: selectedColor ?? colors.textDim,
+          };
+        case "offer":
+          return {
+            text: formatOfferSize(row.offerSize),
+            color: selectedColor ?? colors.textDim,
+          };
+        case "price":
+          return {
+            text: formatPrice(row),
+            color: selectedColor ?? colors.text,
+          };
+        case "shares":
+          return {
+            text: formatShares(row.shares),
+            color: selectedColor ?? colors.textDim,
+          };
+        case "return":
+          return {
+            text: formatReturn(row.change1D),
+            color: selectedColor ?? (row.change1D != null ? priceColor(row.change1D) : colors.textDim),
+          };
+      }
+    },
+    [],
+  );
+
+  const rootBefore = (
+    <InputSearchBar
+      value={searchQuery}
+      focused={focused}
+      active={searchFocused}
+      width={width}
+      focusToken={searchFocusToken}
+      inputRef={searchInputRef}
+      placeholder="ticker, company, or exchange"
+      debounceMs={SEARCH_DEBOUNCE_MS}
+      normalizeValue={(value) => value.trim()}
+      onFocus={focusSearch}
+      onBlur={blurSearch}
+      onNavigateDown={blurSearch}
+      onQueryChange={updateSearch}
+    />
+  );
+
+  if (loading) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {rootBefore}
+        <Box flexGrow={1} justifyContent="center" alignItems="center">
+          <Spinner label="Loading IPO calendar..." />
+        </Box>
+      </Box>
+    );
+  }
+
+  if (status === "error" && records.length === 0) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {rootBefore}
+        <Box flexGrow={1} justifyContent="center" alignItems="center">
+          <Text fg={colors.negative}>Error: {error}</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <DataTableView<IPORecord, IPOColumn>
+      focused={focused && !searchFocused}
+      rootBefore={rootBefore}
+      rootWidth={width}
+      rootHeight={height}
+      selection={{
+        kind: "id",
+        selectedId: selectedTicker,
+        getId: (row) => row.ticker,
+        onChange: (ticker) => setSelectedTicker(ticker),
+      }}
+      onRootKeyDown={handleTableKeyDown}
+      columns={columns}
+      items={sorted}
+      sortColumnId={sortPreference.columnId}
+      sortDirection={sortPreference.direction}
+      onHeaderClick={handleHeaderClick}
+      getItemKey={(row) => row.ticker}
+      onActivate={handleActivate}
+      renderCell={renderCell}
+      emptyStateTitle={
+        searchQuery
+          ? `No IPOs matching "${searchQuery}"`
+          : status === "error"
+            ? "Failed to load IPO data"
+            : "No IPO data"
+      }
+    />
+  );
+}

--- a/src/plugins/builtin/ipo-calendar/types.ts
+++ b/src/plugins/builtin/ipo-calendar/types.ts
@@ -1,0 +1,19 @@
+export const IPO_CALENDAR_PANE_ID = "ipo-calendar";
+
+export type IPOStatus = "upcoming" | "priced" | "trading";
+
+export interface IPORecord {
+  ticker: string;
+  companyName: string;
+  date: Date;
+  status: IPOStatus;
+  exchange: string | null;
+  offerSize: number | null;
+  priceRange: [number, number] | null;
+  pricedPrice: number | null;
+  shares: number | null;
+  closePrice: number | null;
+  change1D: number | null;
+}
+
+export type LoadStatus = "idle" | "loading" | "loaded" | "error";

--- a/src/plugins/ownership.ts
+++ b/src/plugins/ownership.ts
@@ -7,6 +7,7 @@ const BUILTIN_PLUGIN_OWNER_ALIASES: Record<string, string> = {
   "comparison-chart": "ticker-research",
   correlation: "market-overview",
   "earnings-calendar": "macro",
+  "ipo-calendar": "macro",
   "fear-greed": "market-overview",
   "fx-matrix": "market-overview",
   help: "application",


### PR DESCRIPTION
## Description

Adds an `IPO` pane to Macro: upcoming and recent listings from stockanalysis.com, with search and sortable columns.

Enter pins the ticker. `[o]` opens the Stock Analysis page. Connections reports the Stock Analysis source via `connectionHealth`.

## Related Issue

N/A

## Potential Risk & Impact

Stockanalysis `__data.json` is an undocumented SvelteKit payload. The parser selects the node with `{s, ipoDate}` records rather than the first object node (session boilerplate). If they change the shape, the pane will empty rather than crash.

## How Has This Been Tested?

- Unit test for node selection.
- Live fetch: 205 rows.
- `typecheck:opentui` passes.