### PR TITLE
feat(ticker-research): add short interest pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Use `HELP` inside Gloomberb for the live shortcut list. The common command-bar p
 | `OMON <ticker>` | Options monitor |
 | `HDS <ticker>` | Institutional holders |
 | `DVD <ticker>` | Dividend yield and history |
+| `SI <ticker>` | Short interest |
 | `13F [fund/ticker/CIK]` | 13F fund filings and holdings |
 | `INS <ticker>` | Insider activity |
 | `EVT <ticker>` | Corporate actions, earnings, and estimates |

--- a/src/plugins/builtin/short-interest/client.ts
+++ b/src/plugins/builtin/short-interest/client.ts
@@ -1,0 +1,86 @@
+import type { ConnectionHealthRegistry } from "../../../core/connection-health";
+import { YahooHttpClient } from "../../../sources/yahoo-finance/http";
+import { financeRawNumber, yahooRawDate } from "../../../sources/yahoo-finance/mappers";
+import type { QuoteSummaryResponse, YahooQuoteSummaryResult } from "../../../sources/yahoo-finance/types";
+import type { ShortInterestRecord } from "./types";
+
+export const YAHOO_SHORT_INTEREST_CONNECTION_ID = "yahoo-short-interest";
+const yahoo = new YahooHttpClient();
+
+let connectionHealth: ConnectionHealthRegistry | null = null;
+
+export function attachShortInterestHealth(health?: ConnectionHealthRegistry): void {
+  connectionHealth = health ?? null;
+}
+
+export function resetShortInterestHealth(): void {
+  connectionHealth = null;
+}
+
+function rawDate(value: unknown): Date | null {
+  const iso = yahooRawDate(value);
+  if (!iso) return null;
+  const date = new Date(`${iso}T00:00:00.000Z`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function normalizeRecords(result: YahooQuoteSummaryResult): ShortInterestRecord[] {
+  const stats = result.defaultKeyStatistics;
+  if (!stats) return [];
+
+  const records: ShortInterestRecord[] = [];
+  const currentDate = rawDate(stats.dateShortInterest);
+  const currentShares = financeRawNumber(stats.sharesShort) ?? null;
+  const shortRatio = financeRawNumber(stats.shortRatio) ?? null;
+  const shortPercentFloat = financeRawNumber(stats.shortPercentOfFloat) ?? null;
+  const floatShares = financeRawNumber(stats.floatShares) ?? null;
+
+  if (currentDate && currentShares != null) {
+    records.push({
+      settlementDate: currentDate,
+      sharesShort: currentShares,
+      shortRatio,
+      averageDailyVolume: shortRatio != null && shortRatio > 0
+        ? Math.round(currentShares / shortRatio)
+        : null,
+      shortPercentFloat: shortPercentFloat != null
+        ? shortPercentFloat * 100
+        : floatShares != null && floatShares > 0
+          ? (currentShares / floatShares) * 100
+          : null,
+    });
+  }
+
+  const priorDate = rawDate(stats.sharesShortPreviousMonthDate);
+  const priorShares = financeRawNumber(stats.sharesShortPriorMonth) ?? null;
+
+  if (priorDate && priorShares != null) {
+    records.push({
+      settlementDate: priorDate,
+      sharesShort: priorShares,
+      shortRatio: null,
+      averageDailyVolume: null,
+      shortPercentFloat: floatShares != null && floatShares > 0
+        ? (priorShares / floatShares) * 100
+        : null,
+    });
+  }
+
+  return records.sort((a, b) => a.settlementDate.getTime() - b.settlementDate.getTime());
+}
+
+async function requestShortInterest(symbol: string): Promise<ShortInterestRecord[]> {
+  const params = new URLSearchParams({ modules: "defaultKeyStatistics" });
+  const url = `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(symbol)}?${params}`;
+  const data = await yahoo.fetchJsonWithCrumb<QuoteSummaryResponse>(url);
+  const result = data.quoteSummary?.result?.[0];
+  if (!result) throw new Error(`No short interest data for ${symbol}`);
+  return normalizeRecords(result);
+}
+
+export async function fetchShortInterest(symbol: string): Promise<ShortInterestRecord[]> {
+  const request = () => requestShortInterest(symbol);
+  return connectionHealth?.hasSource(YAHOO_SHORT_INTEREST_CONNECTION_ID)
+    ? connectionHealth.track(YAHOO_SHORT_INTEREST_CONNECTION_ID, "fetch", request)
+    : request();
+}

--- a/src/plugins/builtin/short-interest/index.tsx
+++ b/src/plugins/builtin/short-interest/index.tsx
@@ -1,0 +1,61 @@
+import type { PluginModule } from "../plugin-module";
+import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
+import {
+  attachShortInterestHealth,
+  resetShortInterestHealth,
+  YAHOO_SHORT_INTEREST_CONNECTION_ID,
+} from "./client";
+import { ShortInterestView } from "./pane";
+
+let disposeConnection: (() => void) | null = null;
+
+export const shortInterestModule: PluginModule = {
+  setup(ctx) {
+    attachShortInterestHealth(ctx.connectionHealth);
+    disposeConnection = ctx.connectionHealth.registerSource({
+      id: YAHOO_SHORT_INTEREST_CONNECTION_ID,
+      name: "Yahoo Finance Short Interest",
+      kind: "api",
+      ownerId: "ticker-research",
+      detail: "finance.yahoo.com",
+      priority: 300,
+    });
+
+    ctx.registerTickerResearchTab({
+      id: "short-interest",
+      name: "Short Interest",
+      order: 36,
+      component: ShortInterestView,
+      isVisible: ({ ticker }) => !!ticker,
+    });
+  },
+
+  dispose() {
+    disposeConnection?.();
+    disposeConnection = null;
+    resetShortInterestHealth();
+  },
+
+  panes: [
+    {
+      id: "short-interest",
+      name: "Short Interest",
+      icon: "S",
+      component: ShortInterestView,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 90, height: 25 },
+    },
+  ],
+
+  paneTemplates: [
+    createTickerSurfacePaneTemplate({
+      id: "short-interest-pane",
+      paneId: "short-interest",
+      label: "Short Interest",
+      description: "Historical short interest, days to cover, and short % of float.",
+      keywords: ["short", "interest", "si", "shorts", "borrow", "days", "cover"],
+      shortcut: "SI",
+    }),
+  ],
+};

--- a/src/plugins/builtin/short-interest/model.ts
+++ b/src/plugins/builtin/short-interest/model.ts
@@ -1,0 +1,113 @@
+import type { DataTableColumn } from "../../../components";
+import { formatCompact, formatNumber } from "../../../utils/format";
+import { compareSortValues } from "../../../utils/sort-values";
+import type { ShortInterestRecord } from "./types";
+
+export type ShortInterestColumnId =
+  | "settlementDate"
+  | "sharesShort"
+  | "shortRatio"
+  | "averageDailyVolume"
+  | "shortPercentFloat";
+
+export type ShortInterestColumn = DataTableColumn & { id: ShortInterestColumnId };
+
+export interface ShortInterestRow {
+  key: string;
+  record: ShortInterestRecord;
+  settlementDate: string;
+  sharesShort: string;
+  shortRatio: string;
+  averageDailyVolume: string;
+  shortPercentFloat: string;
+}
+
+export interface SortPreference {
+  columnId: ShortInterestColumnId;
+  direction: "asc" | "desc";
+}
+
+export const DEFAULT_SORT: SortPreference = {
+  columnId: "settlementDate",
+  direction: "desc",
+};
+
+function formatDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function formatMaybeCompact(value: number | null): string {
+  return value == null ? "-" : formatCompact(value);
+}
+
+function formatRatio(value: number | null): string {
+  return value == null ? "-" : formatNumber(value, 2);
+}
+
+function formatPercent(value: number | null): string {
+  return value == null ? "-" : `${formatNumber(value, 2)}%`;
+}
+
+export function buildRows(records: ShortInterestRecord[]): ShortInterestRow[] {
+  return records.map((record, index) => ({
+    key: `${record.settlementDate.toISOString()}:${index}`,
+    record,
+    settlementDate: formatDate(record.settlementDate),
+    sharesShort: formatMaybeCompact(record.sharesShort),
+    shortRatio: formatRatio(record.shortRatio),
+    averageDailyVolume: formatMaybeCompact(record.averageDailyVolume),
+    shortPercentFloat: formatPercent(record.shortPercentFloat),
+  }));
+}
+
+function sortValue(row: ShortInterestRow, columnId: ShortInterestColumnId): string | number | null {
+  switch (columnId) {
+    case "settlementDate":
+      return row.record.settlementDate.getTime();
+    case "sharesShort":
+      return row.record.sharesShort;
+    case "shortRatio":
+      return row.record.shortRatio;
+    case "averageDailyVolume":
+      return row.record.averageDailyVolume;
+    case "shortPercentFloat":
+      return row.record.shortPercentFloat;
+  }
+}
+
+export function sortRows(rows: ShortInterestRow[], preference: SortPreference): ShortInterestRow[] {
+  return [...rows].sort((a, b) =>
+    compareSortValues(sortValue(a, preference.columnId), sortValue(b, preference.columnId), preference.direction),
+  );
+}
+
+export function nextSortPreference(
+  current: SortPreference,
+  columnId: string,
+): SortPreference {
+  if (current.columnId === columnId) {
+    return {
+      columnId: columnId as ShortInterestColumnId,
+      direction: current.direction === "asc" ? "desc" : "asc",
+    };
+  }
+  return { columnId: columnId as ShortInterestColumnId, direction: "desc" };
+}
+
+export function buildColumns(width: number): ShortInterestColumn[] {
+  const dateWidth = 12;
+  const sharesWidth = 12;
+  const ratioWidth = 12;
+  const advWidth = Math.max(12, width - 2 - dateWidth - sharesWidth - ratioWidth - 12);
+  const percentWidth = 10;
+  return [
+    { id: "settlementDate", label: "DATE", width: dateWidth, align: "left" },
+    { id: "sharesShort", label: "SHARES SHORT", width: sharesWidth, align: "right" },
+    { id: "shortRatio", label: "DAYS TO COVER", width: ratioWidth, align: "right" },
+    { id: "averageDailyVolume", label: "AVG DAILY VOL", width: advWidth, align: "right" },
+    { id: "shortPercentFloat", label: "% FLOAT", width: percentWidth, align: "right" },
+  ];
+}

--- a/src/plugins/builtin/short-interest/pane.tsx
+++ b/src/plugins/builtin/short-interest/pane.tsx
@@ -1,0 +1,252 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, TextAttributes, useUiCapabilities } from "../../../ui";
+import {
+  DataTableView,
+  EmptyState,
+  Spinner,
+  StaticChartSurface,
+  usePaneFooter,
+  usePaneTicker,
+  type DataTableCell,
+  type DataTableKeyEvent,
+} from "../../../components";
+import { resolveChartPalette } from "../../../components/chart/core/renderer";
+import type { ProjectedChartPoint } from "../../../components/chart/core/data";
+import { colors, blendHex } from "../../../theme/colors";
+import { useShortcut } from "../../../react/input";
+import { isPlainKey } from "../../../utils/keyboard";
+import { formatCompact } from "../../../utils/format";
+import { usePluginPaneState } from "../../runtime";
+import { isUsEquityTicker } from "../../../utils/sec";
+import type { TickerRecord } from "../../../types/ticker";
+import { fetchShortInterest } from "./client";
+import {
+  buildColumns,
+  buildRows,
+  DEFAULT_SORT,
+  nextSortPreference,
+  sortRows,
+  type ShortInterestColumn,
+  type ShortInterestRow,
+  type SortPreference,
+} from "./model";
+import type { LoadStatus, ShortInterestRecord } from "./types";
+
+function hasClassifiableUsEquityMetadata(ticker: TickerRecord): boolean {
+  const contract = ticker.metadata.broker_contracts?.[0];
+  const currency = (contract?.currency ?? ticker.metadata.currency ?? "").trim();
+  const type = (contract?.secType ?? ticker.metadata.assetCategory ?? "").trim();
+  return currency.length > 0
+    || type.length > 0
+    || [contract?.primaryExchange, contract?.exchange, ticker.metadata.exchange]
+      .some((value) => (value ?? "").trim().length > 0);
+}
+
+function recordsToChartPoints(records: ShortInterestRecord[]): ProjectedChartPoint[] {
+  return records.map((record) => ({
+    date: record.settlementDate,
+    open: record.sharesShort,
+    high: record.sharesShort,
+    low: record.sharesShort,
+    close: record.sharesShort,
+    volume: 0,
+  }));
+}
+
+function ShortInterestView({ width, height, focused }: { width: number; height: number; focused: boolean }) {
+  const { nativePaneChrome } = useUiCapabilities();
+  const { ticker } = usePaneTicker();
+  const symbol = ticker?.metadata.ticker ?? null;
+
+  const [records, setRecords] = useState<ShortInterestRecord[]>([]);
+  const [status, setStatus] = useState<LoadStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [sortPreference, setSortPreference] = usePluginPaneState<SortPreference>(
+    "short-interest:sort",
+    DEFAULT_SORT,
+  );
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const fetchGenRef = useRef(0);
+
+  const rows = useMemo(() => buildRows(records), [records]);
+  const sortedRows = useMemo(() => sortRows(rows, sortPreference), [rows, sortPreference]);
+  const columns = useMemo(() => buildColumns(width), [width]);
+  const chartPoints = useMemo(() => recordsToChartPoints(records), [records]);
+
+  const boundedSelectedIdx = sortedRows.length > 0
+    ? Math.min(selectedIdx, sortedRows.length - 1)
+    : -1;
+
+  const skipNonUs = !!(ticker && hasClassifiableUsEquityMetadata(ticker) && !isUsEquityTicker(ticker));
+
+  const loadData = useCallback(async () => {
+    if (!symbol) {
+      setRecords([]);
+      setStatus("idle");
+      setError(null);
+      return;
+    }
+    if (skipNonUs) {
+      setRecords([]);
+      setStatus("loaded");
+      setError(null);
+      return;
+    }
+
+    fetchGenRef.current += 1;
+    const gen = fetchGenRef.current;
+    setStatus((current) => (current === "loaded" ? current : "loading"));
+    setError(null);
+
+    try {
+      const data = await fetchShortInterest(symbol);
+      if (fetchGenRef.current !== gen) return;
+      setRecords(data);
+      setStatus("loaded");
+      setSelectedIdx(0);
+    } catch (err) {
+      if (fetchGenRef.current !== gen) return;
+      setError(err instanceof Error ? err.message : String(err));
+      setRecords([]);
+      setStatus("error");
+    }
+  }, [skipNonUs, symbol]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  const refresh = useCallback(() => {
+    void loadData();
+  }, [loadData]);
+
+  const handleHeaderClick = useCallback((columnId: string) => {
+    setSortPreference((current) => nextSortPreference(current, columnId));
+  }, [setSortPreference]);
+
+  const handleKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (event.name === "r") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      refresh();
+      return true;
+    }
+    return false;
+  }, [refresh]);
+
+  useShortcut((event) => {
+    if (!focused) return;
+    if (isPlainKey(event, "r")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      refresh();
+    }
+  });
+
+  const renderCell = useCallback((
+    row: ShortInterestRow,
+    column: ShortInterestColumn,
+    _index: number,
+    rowState: { selected: boolean },
+  ): DataTableCell => {
+    const selectedColor = rowState.selected ? colors.selectedText : undefined;
+    switch (column.id) {
+      case "settlementDate":
+        return { text: row.settlementDate, color: selectedColor ?? colors.textDim };
+      case "sharesShort":
+        return { text: row.sharesShort, color: selectedColor ?? colors.textBright, attributes: TextAttributes.BOLD };
+      case "shortRatio":
+        return { text: row.shortRatio, color: selectedColor ?? colors.text };
+      case "averageDailyVolume":
+        return { text: row.averageDailyVolume, color: selectedColor ?? colors.textDim };
+      case "shortPercentFloat":
+        return { text: row.shortPercentFloat, color: selectedColor ?? colors.text };
+    }
+  }, []);
+
+  usePaneFooter("short-interest", () => ({
+    info: [
+      ...(status === "loading" ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
+      ...(status === "error" && error ? [{ id: "error", parts: [{ text: error.slice(0, 60), tone: "warning" as const }] }] : []),
+    ],
+    hints: [{ id: "refresh", key: "r", label: "efresh", onPress: refresh }],
+  }), [error, refresh, status]);
+
+  if (!ticker || !symbol) {
+    return <EmptyState title="No ticker selected" message="Select a ticker to view short interest." />;
+  }
+
+  if ((status === "idle" || status === "loading") && records.length === 0) {
+    return <Spinner label="Loading short interest..." />;
+  }
+
+  if (status === "error" && records.length === 0) {
+    return <EmptyState title="Failed to load short interest" message={error ?? undefined} hint="Press [r] to retry" />;
+  }
+
+  if (status === "loaded" && records.length === 0) {
+    const usEquitiesOnly = hasClassifiableUsEquityMetadata(ticker) && !isUsEquityTicker(ticker);
+    return (
+      <EmptyState
+        title={usEquitiesOnly ? "US equities only" : "No short interest data"}
+        message={usEquitiesOnly
+          ? "Short interest data is available for US equities."
+          : `No short interest found for ${symbol}.`}
+      />
+    );
+  }
+
+  const showChart = chartPoints.length >= 2;
+  const chartHeight = showChart ? Math.max(1, Math.floor((height - 1) * 0.35)) : 0;
+  const tableHeight = Math.max(1, height - chartHeight - 1 - (nativePaneChrome ? 1 : 0));
+  const chartWidth = Math.max(24, width - 2);
+  const palette = {
+    ...resolveChartPalette(colors, "neutral"),
+    lineColor: colors.warning,
+    fillColor: blendHex(colors.bg, colors.warning, 0.18),
+    gridColor: blendHex(colors.bg, colors.border, 0.55),
+  };
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      {showChart ? (
+        <Box flexDirection="column" marginTop={1} paddingX={1} flexShrink={0}>
+          <StaticChartSurface
+            points={chartPoints}
+            width={chartWidth}
+            height={chartHeight}
+            mode="line"
+            colors={palette}
+            showTimeAxis
+            timeAxisColor={colors.textDim}
+            yAxisColor={colors.textDim}
+            formatYAxisValue={(value: number) => formatCompact(value)}
+          />
+        </Box>
+      ) : null}
+      <Box flexGrow={1} marginTop={chartPoints.length >= 2 ? 1 : 0}>
+        <DataTableView<ShortInterestRow, ShortInterestColumn>
+          focused={focused}
+          selection={{
+            kind: "index",
+            selectedIndex: boundedSelectedIdx,
+            onChange: (index) => setSelectedIdx(index),
+          }}
+          onRootKeyDown={handleKeyDown}
+          rootWidth={width}
+          rootHeight={tableHeight}
+          columns={columns}
+          items={sortedRows}
+          sortColumnId={sortPreference.columnId}
+          sortDirection={sortPreference.direction}
+          onHeaderClick={handleHeaderClick}
+          getItemKey={(row) => row.key}
+          renderCell={renderCell}
+          emptyStateTitle={status === "loading" ? "Loading..." : "No data"}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+export { ShortInterestView };

--- a/src/plugins/builtin/short-interest/types.ts
+++ b/src/plugins/builtin/short-interest/types.ts
@@ -1,0 +1,9 @@
+export interface ShortInterestRecord {
+  settlementDate: Date;
+  sharesShort: number;
+  shortRatio: number | null;
+  averageDailyVolume: number | null;
+  shortPercentFloat: number | null;
+}
+
+export type LoadStatus = "idle" | "loading" | "loaded" | "error";

--- a/src/plugins/builtin/ticker-research-plugin.ts
+++ b/src/plugins/builtin/ticker-research-plugin.ts
@@ -6,6 +6,7 @@ import { optionsModule } from "./options";
 import { composeBuiltinPlugin } from "./plugin-module";
 import { researchModule } from "./research";
 import { secModule } from "./sec";
+import { shortInterestModule } from "./short-interest";
 import { thirteenFModule } from "./thirteenf";
 import { tickerDetailModule } from "./ticker-detail";
 
@@ -22,6 +23,7 @@ export const tickerResearchPlugin = composeBuiltinPlugin({
     researchModule,
     dividendYieldModule,
     holdersModule,
+    shortInterestModule,
     thirteenFModule,
     secModule,
     insiderModule,

--- a/src/plugins/ownership.ts
+++ b/src/plugins/ownership.ts
@@ -14,6 +14,7 @@ const BUILTIN_PLUGIN_OWNER_ALIASES: Record<string, string> = {
   holders: "ticker-research",
   insider: "ticker-research",
   "dividend-yield": "ticker-research",
+  "short-interest": "ticker-research",
   "kelly-sizer": "portfolio",
   "layout-manager": "application",
   "macro-tv": "macro",

--- a/src/sources/yahoo-finance/types.ts
+++ b/src/sources/yahoo-finance/types.ts
@@ -153,6 +153,13 @@ export type QuoteSummaryResponse = {
       };
       defaultKeyStatistics?: {
         payoutRatio?: { raw?: number } | number | null;
+        sharesShort?: { raw?: number } | number | null;
+        sharesShortPriorMonth?: { raw?: number } | number | null;
+        sharesShortPreviousMonthDate?: { raw?: number; fmt?: string } | number | string | null;
+        dateShortInterest?: { raw?: number; fmt?: string } | number | string | null;
+        shortRatio?: { raw?: number } | number | null;
+        shortPercentOfFloat?: { raw?: number } | number | null;
+        floatShares?: { raw?: number } | number | null;
       };
       majorHoldersBreakdown?: {
         insidersPercentHeld?: { raw?: number } | number | null;


### PR DESCRIPTION
## Description

Adds `SI <ticker>` and a Short Interest research tab. Data comes from Yahoo `quoteSummary` defaultKeyStatistics through the shared `YahooHttpClient` crumb client.

Non-US names with classifiable metadata skip the Yahoo call and show an in-pane empty state. The command bar still opens the pane.

## Related Issue

N/A

## Potential Risk & Impact

Yahoo only returns current + prior-month short interest, not a long history. 429s are retried by `YahooHttpClient`.

## How Has This Been Tested?

- Live `fetchShortInterest("AAPL")`: 2 rows (2026-06-30 / 2026-07-31).
- `typecheck:opentui` passes.