### PR TITLE
feat(ticker-research): add dividend yield pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Use `HELP` inside Gloomberb for the live shortcut list. The common command-bar p
 | `SEC <ticker>` | SEC filings and company disclosures |
 | `OMON <ticker>` | Options monitor |
 | `HDS <ticker>` | Institutional holders |
+| `DVD <ticker>` | Dividend yield and history |
 | `13F [fund/ticker/CIK]` | 13F fund filings and holdings |
 | `INS <ticker>` | Insider activity |
 | `EVT <ticker>` | Corporate actions, earnings, and estimates |

--- a/src/plugins/builtin/dividend-yield/client.test.ts
+++ b/src/plugins/builtin/dividend-yield/client.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { extractDividendFields } from "./client";
+
+describe("extractDividendFields", () => {
+  test("reads dividend modules from quoteSummary.result[0], not the response root", () => {
+    const fields = extractDividendFields({
+      summaryDetail: {
+        trailingAnnualDividendRate: { raw: 99 },
+        trailingAnnualDividendYield: { raw: 0.99 },
+        currency: "EUR",
+      },
+      quoteSummary: {
+        result: [{
+          summaryDetail: {
+            trailingAnnualDividendRate: { raw: 1.02 },
+            trailingAnnualDividendYield: { raw: 0.0045 },
+            forwardAnnualDividendRate: { raw: 1.04 },
+            dividendRate: { raw: 9.99 },
+            payoutRatio: { raw: 0.99 },
+            exDividendDate: { raw: 1719792000 },
+            dividendDate: { raw: 1720396800 },
+            currency: "USD",
+          },
+          financialData: {
+            payoutRatio: { raw: 0.14 },
+          },
+        }],
+      },
+    });
+
+    expect(fields).toEqual({
+      trailingAnnualDividendRate: 1.02,
+      trailingAnnualDividendYield: 0.0045,
+      forwardAnnualDividendRate: 1.04,
+      payoutRatio: 0.14,
+      exDividendDate: 1719792000,
+      dividendDate: 1720396800,
+      currency: "USD",
+    });
+  });
+
+  test("falls back to Yahoo's current summaryDetail field names", () => {
+    const fields = extractDividendFields({
+      quoteSummary: {
+        result: [{
+          summaryDetail: {
+            dividendRate: { raw: 1.08 },
+            payoutRatio: { raw: 0.1204 },
+            currency: "USD",
+          },
+        }],
+      },
+    });
+
+    expect(fields.forwardAnnualDividendRate).toBe(1.08);
+    expect(fields.payoutRatio).toBe(0.1204);
+  });
+});

--- a/src/plugins/builtin/dividend-yield/client.ts
+++ b/src/plugins/builtin/dividend-yield/client.ts
@@ -1,0 +1,252 @@
+import type { ConnectionHealthRegistry } from "../../../core/connection-health";
+import { YahooHttpClient } from "../../../sources/yahoo-finance/http";
+import { financeRawNumber, mapYahooDividends } from "../../../sources/yahoo-finance/mappers";
+import { fetchYahooChart } from "../../../sources/yahoo-finance/requests";
+import type { QuoteSummaryResponse } from "../../../sources/yahoo-finance/types";
+import type { DividendMetrics, DividendPayment } from "./types";
+
+export const YAHOO_DIVIDENDS_CONNECTION_ID = "yahoo-dividends";
+const DAY_MS = 24 * 60 * 60 * 1000;
+const yahoo = new YahooHttpClient();
+
+let connectionHealth: ConnectionHealthRegistry | null = null;
+
+export function attachDividendYieldHealth(health?: ConnectionHealthRegistry): void {
+  connectionHealth = health ?? null;
+}
+
+export function resetDividendYieldHealth(): void {
+  connectionHealth = null;
+}
+
+function trackRequest<T>(operation: string, request: () => Promise<T>): Promise<T> {
+  return connectionHealth?.hasSource(YAHOO_DIVIDENDS_CONNECTION_ID)
+    ? connectionHealth.track(YAHOO_DIVIDENDS_CONNECTION_ID, operation, request)
+    : request();
+}
+
+interface QuoteSummaryDividendFields {
+  trailingAnnualDividendRate: number | null;
+  trailingAnnualDividendYield: number | null;
+  forwardAnnualDividendRate: number | null;
+  payoutRatio: number | null;
+  exDividendDate: number | null;
+  dividendDate: number | null;
+  currency: string | null;
+}
+
+const EMPTY_DIVIDEND_FIELDS: QuoteSummaryDividendFields = {
+  trailingAnnualDividendRate: null,
+  trailingAnnualDividendYield: null,
+  forwardAnnualDividendRate: null,
+  payoutRatio: null,
+  exDividendDate: null,
+  dividendDate: null,
+  currency: null,
+};
+
+/**
+ * Yahoo nests quote modules at quoteSummary.result[0], not the response root.
+ */
+export function extractDividendFields(payload: unknown): QuoteSummaryDividendFields {
+  if (typeof payload !== "object" || payload === null) return { ...EMPTY_DIVIDEND_FIELDS };
+  const result = (payload as QuoteSummaryResponse).quoteSummary?.result?.[0];
+  if (!result) return { ...EMPTY_DIVIDEND_FIELDS };
+
+  const summaryDetail = result.summaryDetail;
+  const financialData = result.financialData;
+  const defaultKeyStats = result.defaultKeyStatistics;
+
+  return {
+    trailingAnnualDividendRate: financeRawNumber(summaryDetail?.trailingAnnualDividendRate) ?? null,
+    trailingAnnualDividendYield: financeRawNumber(summaryDetail?.trailingAnnualDividendYield) ?? null,
+    forwardAnnualDividendRate: financeRawNumber(summaryDetail?.forwardAnnualDividendRate)
+      ?? financeRawNumber(summaryDetail?.dividendRate)
+      ?? null,
+    payoutRatio: financeRawNumber(financialData?.payoutRatio)
+      ?? financeRawNumber(defaultKeyStats?.payoutRatio)
+      ?? financeRawNumber(summaryDetail?.payoutRatio)
+      ?? null,
+    exDividendDate: financeRawNumber(summaryDetail?.exDividendDate) ?? null,
+    dividendDate: financeRawNumber(summaryDetail?.dividendDate) ?? null,
+    currency: typeof summaryDetail?.currency === "string" ? summaryDetail.currency : null,
+  };
+}
+
+function toDividendPayment(
+  exDate: string,
+  amount: number,
+  currency: string,
+): DividendPayment | null {
+  if (amount <= 0) return null;
+  const parsed = new Date(`${exDate}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return {
+    exDate: parsed,
+    recordDate: null,
+    paymentDate: null,
+    declarationDate: null,
+    amount,
+    currency,
+    type: "cash",
+  };
+}
+
+export interface DividendData {
+  payments: DividendPayment[];
+  metrics: DividendMetrics;
+  price: number | null;
+}
+
+export async function fetchDividendData(
+  symbol: string,
+  currentPrice: number | null,
+): Promise<DividendData> {
+  const quoteUrl =
+    `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(symbol)}`
+    + "?modules=summaryDetail,financialData,defaultKeyStatistics";
+
+  const [chartResult, quoteResult] = await Promise.allSettled([
+    trackRequest("dividend-history", () =>
+      fetchYahooChart(yahoo, symbol, "10y", "1mo"),
+    ),
+    trackRequest("quote-summary", () =>
+      yahoo.fetchJsonWithCrumb<QuoteSummaryResponse>(quoteUrl),
+    ),
+  ]);
+
+  const quoteFields = quoteResult.status === "fulfilled"
+    ? extractDividendFields(quoteResult.value)
+    : null;
+
+  const currency = quoteFields?.currency
+    ?? (chartResult.status === "fulfilled" ? chartResult.value.meta.currency ?? null : null)
+    ?? "USD";
+
+  const payments: DividendPayment[] = [];
+  if (chartResult.status === "fulfilled") {
+    for (const dividend of mapYahooDividends(chartResult.value.events)) {
+      const payment = toDividendPayment(dividend.exDate, dividend.amount, currency);
+      if (payment) payments.push(payment);
+    }
+    payments.sort((a, b) => b.exDate.getTime() - a.exDate.getTime());
+  }
+
+  const resolvedPrice = currentPrice
+    ?? (chartResult.status === "fulfilled" ? chartResult.value.meta.regularMarketPrice ?? null : null)
+    ?? null;
+
+  const metrics = buildMetrics(payments, quoteFields, resolvedPrice);
+
+  if (payments.length === 0 && !quoteFields?.trailingAnnualDividendRate) {
+    throw new Error(`No dividend data found for ${symbol}`);
+  }
+
+  return { payments, metrics, price: resolvedPrice };
+}
+
+function buildMetrics(
+  payments: DividendPayment[],
+  quoteFields: QuoteSummaryDividendFields | null,
+  currentPrice: number | null,
+): DividendMetrics {
+  const trailingRate = quoteFields?.trailingAnnualDividendRate
+    ?? (payments.length > 0
+      ? payments
+        .filter((p) => p.exDate >= new Date(Date.now() - 365 * DAY_MS))
+        .reduce((sum, p) => sum + p.amount, 0)
+      : null);
+
+  const forwardRate = quoteFields?.forwardAnnualDividendRate ?? null;
+
+  const trailingYield = quoteFields?.trailingAnnualDividendYield != null
+    ? quoteFields.trailingAnnualDividendYield
+    : trailingRate != null && currentPrice != null && currentPrice > 0
+      ? trailingRate / currentPrice
+      : null;
+
+  const forwardYield = forwardRate != null && currentPrice != null && currentPrice > 0
+    ? forwardRate / currentPrice
+    : null;
+
+  const growth1Y = payments.length >= 2 ? computeGrowth1Y(payments) : null;
+  const growth3Y = payments.length >= 4 ? computeGrowth3Y(payments) : null;
+
+  const exDividendDate = quoteFields?.exDividendDate != null
+    ? new Date(quoteFields.exDividendDate * 1000)
+    : payments.length > 0
+      ? payments[0]!.exDate
+      : null;
+
+  const nextPayDate = quoteFields?.dividendDate != null
+    ? new Date(quoteFields.dividendDate * 1000)
+    : null;
+
+  return {
+    trailingYield,
+    forwardYield,
+    trailingRate,
+    forwardRate,
+    payoutRatio: quoteFields?.payoutRatio ?? null,
+    growth1Y,
+    growth3Y,
+    paymentFrequency: inferFrequency(payments),
+    exDividendDate,
+    nextPayDate,
+  };
+}
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function computeGrowth1Y(payments: DividendPayment[]): number | null {
+  const now = new Date();
+  const recentCutoff = new Date(now.getTime() - 365 * DAY);
+  const priorCutoff = new Date(now.getTime() - 2 * 365 * DAY);
+  const recent = payments
+    .filter((p) => p.exDate >= recentCutoff && p.exDate <= now)
+    .reduce((sum, p) => sum + p.amount, 0);
+  const prior = payments
+    .filter((p) => p.exDate >= priorCutoff && p.exDate < recentCutoff)
+    .reduce((sum, p) => sum + p.amount, 0);
+  if (prior <= 0) return null;
+  return (recent - prior) / prior;
+}
+
+function computeGrowth3Y(payments: DividendPayment[]): number | null {
+  const regular = payments.filter((p) => p.type === "cash" || p.type === "unknown");
+  if (regular.length < 4) return null;
+  const freq = inferFrequency(regular);
+  if (!freq || freq === "irregular") return null;
+  const annualCount = freq === "monthly" ? 12 : freq === "quarterly" ? 4 : freq === "semi-annual" ? 2 : 1;
+
+  const now = new Date();
+  const recentStart = new Date(now.getTime() - 365 * DAY);
+  const threeYearsAgo = new Date(now.getTime() - 3 * 365 * DAY);
+  const priorStart = new Date(now.getTime() - 4 * 365 * DAY);
+
+  const sorted = [...regular].sort((a, b) => a.exDate.getTime() - b.exDate.getTime());
+  const recentAvg = sorted
+    .filter((p) => p.exDate >= recentStart && p.exDate <= now)
+    .reduce((sum, p) => sum + p.amount, 0) / annualCount;
+  const priorAvg = sorted
+    .filter((p) => p.exDate >= priorStart && p.exDate <= threeYearsAgo)
+    .reduce((sum, p) => sum + p.amount, 0) / annualCount;
+
+  if (priorAvg <= 0 || recentAvg <= 0) return null;
+  return Math.pow(recentAvg / priorAvg, 1 / 3) - 1;
+}
+
+function inferFrequency(payments: DividendPayment[]): DividendMetrics["paymentFrequency"] {
+  if (payments.length < 2) return null;
+  const sorted = [...payments].sort((a, b) => a.exDate.getTime() - b.exDate.getTime());
+  const gaps: number[] = [];
+  for (let i = 1; i < sorted.length; i++) {
+    gaps.push((sorted[i]!.exDate.getTime() - sorted[i - 1]!.exDate.getTime()) / DAY);
+  }
+  const avgGapDays = gaps.reduce((sum, g) => sum + g, 0) / gaps.length;
+  if (Math.abs(avgGapDays - 30) < 8) return "monthly";
+  if (Math.abs(avgGapDays - 91) < 18) return "quarterly";
+  if (Math.abs(avgGapDays - 182) < 36) return "semi-annual";
+  if (Math.abs(avgGapDays - 365) < 73) return "annual";
+  return "irregular";
+}

--- a/src/plugins/builtin/dividend-yield/index.tsx
+++ b/src/plugins/builtin/dividend-yield/index.tsx
@@ -1,0 +1,61 @@
+import type { PluginModule } from "../plugin-module";
+import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
+import {
+  attachDividendYieldHealth,
+  resetDividendYieldHealth,
+  YAHOO_DIVIDENDS_CONNECTION_ID,
+} from "./client";
+import { DividendYieldPane } from "./pane";
+
+let disposeConnection: (() => void) | null = null;
+
+export const dividendYieldModule: PluginModule = {
+  setup(ctx) {
+    attachDividendYieldHealth(ctx.connectionHealth);
+    disposeConnection = ctx.connectionHealth.registerSource({
+      id: YAHOO_DIVIDENDS_CONNECTION_ID,
+      name: "Yahoo Finance Dividends",
+      kind: "api",
+      ownerId: "ticker-research",
+      detail: "finance.yahoo.com",
+      priority: 300,
+    });
+
+    ctx.registerTickerResearchTab({
+      id: "dividend-yield",
+      name: "Dividends",
+      order: 38,
+      component: DividendYieldPane,
+      isVisible: ({ ticker }) => !!ticker,
+    });
+  },
+
+  dispose() {
+    disposeConnection?.();
+    disposeConnection = null;
+    resetDividendYieldHealth();
+  },
+
+  panes: [
+    {
+      id: "dividend-yield",
+      name: "Dividend Yield",
+      icon: "D",
+      component: DividendYieldPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 90, height: 28 },
+    },
+  ],
+
+  paneTemplates: [
+    createTickerSurfacePaneTemplate({
+      id: "dividend-yield-pane",
+      paneId: "dividend-yield",
+      label: "Dividend Yield",
+      description: "Dividend history, trailing/forward yield, growth rates, and payment schedule.",
+      keywords: ["dividend", "yield", "dvd", "income", "payout", "ex-date", "distribution"],
+      shortcut: "DVD",
+    }),
+  ],
+};

--- a/src/plugins/builtin/dividend-yield/model.ts
+++ b/src/plugins/builtin/dividend-yield/model.ts
@@ -1,0 +1,83 @@
+import type { DataTableColumn } from "../../../components";
+import { compareSortValues, type SortDirection } from "../../../utils/sort-values";
+import type { DividendPayment } from "./types";
+
+export type DividendColumnId = "exDate" | "amount" | "currency";
+export type DividendColumn = DataTableColumn & { id: DividendColumnId };
+
+export interface DividendRow {
+  key: string;
+  exDate: string;
+  amount: number;
+  currency: string;
+}
+
+export interface DividendSortPreference {
+  columnId: DividendColumnId | null;
+  direction: SortDirection;
+}
+
+export const DEFAULT_SORT_PREFERENCE: DividendSortPreference = {
+  columnId: "exDate",
+  direction: "desc",
+};
+
+export function buildDividendColumns(width: number): DividendColumn[] {
+  const dateWidth = 14;
+  const currencyWidth = 6;
+  const amountWidth = 10;
+  const leftover = Math.max(dateWidth, width - 2 - amountWidth - currencyWidth);
+  return [
+    { id: "exDate", label: "EX-DATE", width: leftover, align: "left" },
+    { id: "amount", label: "AMOUNT", width: amountWidth, align: "right" },
+    { id: "currency", label: "CCY", width: currencyWidth, align: "left" },
+  ];
+}
+
+function getSortValue(columnId: DividendColumnId, row: DividendRow): string | number | null {
+  switch (columnId) {
+    case "exDate": return row.exDate;
+    case "amount": return row.amount;
+    case "currency": return row.currency;
+  }
+}
+
+export function sortRows(
+  rows: DividendRow[],
+  sortPreference: DividendSortPreference,
+): DividendRow[] {
+  if (!sortPreference.columnId) return rows;
+  return [...rows].sort((left, right) => compareSortValues(
+    getSortValue(sortPreference.columnId!, left),
+    getSortValue(sortPreference.columnId!, right),
+    sortPreference.direction,
+  ));
+}
+
+export function nextSortPreference(
+  current: DividendSortPreference,
+  columnId: string,
+): DividendSortPreference {
+  const typedColumnId = columnId as DividendColumnId;
+  if (current.columnId !== typedColumnId) {
+    return { columnId: typedColumnId, direction: "desc" };
+  }
+  if (current.direction === "desc") {
+    return { columnId: typedColumnId, direction: "asc" };
+  }
+  return DEFAULT_SORT_PREFERENCE;
+}
+
+export function toDividendRows(payments: DividendPayment[]): DividendRow[] {
+  return payments.map((p, i) => ({
+    key: `${p.exDate.toISOString()}:${i}`,
+    exDate: formatDate(p.exDate),
+    amount: p.amount,
+    currency: p.currency,
+  }));
+}
+
+function formatDate(date: Date): string {
+  const iso = date.toISOString();
+  return iso.slice(0, 10);
+}

--- a/src/plugins/builtin/dividend-yield/pane.tsx
+++ b/src/plugins/builtin/dividend-yield/pane.tsx
@@ -1,0 +1,296 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, Text, TextAttributes } from "../../../ui";
+import {
+  DataTableView,
+  StaticChartSurface,
+  usePaneFooter,
+  usePaneTicker,
+  type DataTableCell,
+  type DataTableKeyEvent,
+} from "../../../components";
+import type { ProjectedChartPoint } from "../../../components/chart/core/data";
+import { resolveChartPalette } from "../../../components/chart/core/renderer";
+import { colors, priceColor } from "../../../theme/colors";
+import { formatCurrency, formatNumber, formatPercentRaw } from "../../../utils/format";
+import { handleRefreshKey, loadingErrorFooterInfo, refreshFooterHint } from "../shared/table-pane";
+import { fetchDividendData, type DividendData } from "./client";
+import {
+  buildDividendColumns,
+  DEFAULT_SORT_PREFERENCE,
+  nextSortPreference,
+  sortRows,
+  toDividendRows,
+  type DividendColumn,
+  type DividendRow,
+  type DividendSortPreference,
+} from "./model";
+import type { DividendMetrics, DividendPayment } from "./types";
+
+function formatYield(value: number | null): string {
+  if (value == null) return "—";
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+function formatRate(value: number | null, currency: string): string {
+  if (value == null) return "—";
+  return formatCurrency(value, currency);
+}
+
+function formatGrowth(value: number | null): string {
+  if (value == null) return "—";
+  return formatPercentRaw(value * 100);
+}
+
+function formatDate(date: Date | null): string {
+  if (!date) return "—";
+  return date.toISOString().slice(0, 10);
+}
+
+function formatFrequency(freq: DividendMetrics["paymentFrequency"]): string {
+  if (!freq) return "—";
+  switch (freq) {
+    case "monthly": return "Monthly";
+    case "quarterly": return "Quarterly";
+    case "semi-annual": return "Semi-Annual";
+    case "annual": return "Annual";
+    case "irregular": return "Irregular";
+  }
+}
+
+interface MetricRow {
+  label: string;
+  value: string;
+  color?: string;
+  bold?: boolean;
+}
+
+function buildMetricRows(metrics: DividendMetrics, currency: string): MetricRow[] {
+  return [
+    { label: "Trailing Yield", value: formatYield(metrics.trailingYield), color: priceColor(metrics.trailingYield ?? 0), bold: true },
+    { label: "Forward Yield", value: formatYield(metrics.forwardYield), color: priceColor(metrics.forwardYield ?? 0) },
+    { label: "Trailing Rate", value: formatRate(metrics.trailingRate, currency) },
+    { label: "Forward Rate", value: formatRate(metrics.forwardRate, currency) },
+    { label: "1Y Growth", value: formatGrowth(metrics.growth1Y), color: priceColor(metrics.growth1Y ?? 0) },
+    { label: "3Y Growth", value: formatGrowth(metrics.growth3Y), color: priceColor(metrics.growth3Y ?? 0) },
+    { label: "Payout Ratio", value: metrics.payoutRatio != null ? `${(metrics.payoutRatio * 100).toFixed(1)}%` : "—" },
+    { label: "Frequency", value: formatFrequency(metrics.paymentFrequency) },
+    { label: "Ex-Dividend", value: formatDate(metrics.exDividendDate) },
+    { label: "Next Pay", value: formatDate(metrics.nextPayDate) },
+  ];
+}
+
+function buildYieldChartPoints(payments: DividendPayment[], currentPrice: number | null): ProjectedChartPoint[] {
+  if (payments.length === 0 || currentPrice == null || currentPrice <= 0) return [];
+  const sorted = [...payments].sort((a, b) => a.exDate.getTime() - b.exDate.getTime());
+  const DAY = 24 * 60 * 60 * 1000;
+  const points: ProjectedChartPoint[] = [];
+
+  for (const payment of sorted) {
+    const trailingCutoff = new Date(payment.exDate.getTime() - 365 * DAY);
+    const trailingSum = sorted
+      .filter((p) => p.exDate >= trailingCutoff && p.exDate <= payment.exDate)
+      .reduce((sum, p) => sum + p.amount, 0);
+    const yieldPct = (trailingSum / currentPrice) * 100;
+    points.push({
+      date: payment.exDate,
+      open: yieldPct,
+      high: yieldPct,
+      low: yieldPct,
+      close: yieldPct,
+      volume: 0,
+    });
+  }
+
+  return points;
+}
+
+function renderMetricCell(row: MetricRow, width: number) {
+  const valueWidth = Math.min(row.value.length, Math.max(6, width - 8));
+  const labelWidth = Math.max(8, width - valueWidth - 1);
+  return (
+    <Box height={1} flexDirection="row">
+      <Text fg={colors.textDim}>{row.label.slice(0, labelWidth).padEnd(labelWidth)}</Text>
+      <Text
+        fg={row.color ?? colors.text}
+        attributes={row.bold ? TextAttributes.BOLD : undefined}
+      >
+        {row.value}
+      </Text>
+    </Box>
+  );
+}
+
+function DividendSummary({
+  metrics,
+  currency,
+  width,
+  chartPoints,
+}: {
+  metrics: DividendMetrics;
+  currency: string;
+  width: number;
+  chartPoints: ProjectedChartPoint[];
+}) {
+  const metricRows = buildMetricRows(metrics, currency);
+  const colWidth = Math.max(18, Math.floor((width - 2) / 2));
+  const chartHeight = chartPoints.length >= 2 ? 6 : 0;
+  const palette = resolveChartPalette(colors, "positive");
+
+  return (
+    <Box flexDirection="column">
+      <Box flexDirection="column" paddingX={1} height={Math.ceil(metricRows.length / 2)}>
+        {Array.from({ length: Math.ceil(metricRows.length / 2) }, (_, i) => {
+          const left = metricRows[i * 2]!;
+          const right = metricRows[i * 2 + 1];
+          return (
+            <Box key={left.label} height={1} flexDirection="row">
+              <Box width={colWidth}>{renderMetricCell(left, colWidth)}</Box>
+              {right ? <Box width={colWidth}>{renderMetricCell(right, colWidth)}</Box> : null}
+            </Box>
+          );
+        })}
+      </Box>
+      {chartPoints.length >= 2 && (
+        <Box flexDirection="column" paddingX={1} height={chartHeight}>
+          <StaticChartSurface
+            points={chartPoints}
+            width={Math.max(10, width - 2)}
+            height={chartHeight}
+            mode="line"
+            colors={palette}
+            yAxisLabel="Yield %"
+            yAxisColor={colors.textDim}
+            formatYAxisValue={(value) => `${value.toFixed(2)}%`}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function renderCell(
+  row: DividendRow,
+  column: DividendColumn,
+  _index: number,
+  rowState: { selected: boolean },
+): DataTableCell {
+  const selectedColor = rowState.selected ? colors.selectedText : undefined;
+  switch (column.id) {
+    case "exDate":
+      return { text: row.exDate, color: selectedColor ?? colors.textDim };
+    case "amount":
+      return {
+        text: formatNumber(row.amount, 4),
+        color: selectedColor ?? colors.textBright,
+        attributes: TextAttributes.BOLD,
+      };
+    case "currency":
+      return { text: row.currency, color: selectedColor ?? colors.textDim };
+  }
+}
+
+export function DividendYieldPane({ focused, width, height }: { focused: boolean; width: number; height: number }) {
+  const { symbol, ticker, financials } = usePaneTicker();
+  const currency = ticker?.metadata.currency ?? "USD";
+  const quotePrice = financials?.quote?.price ?? null;
+
+  const [data, setData] = useState<DividendData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sortPreference, setSortPreference] = useState<DividendSortPreference>(DEFAULT_SORT_PREFERENCE);
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const fetchGenRef = useRef(0);
+
+  const load = useCallback(async (sym: string, price: number | null) => {
+    fetchGenRef.current += 1;
+    const gen = fetchGenRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchDividendData(sym, price);
+      if (fetchGenRef.current !== gen) return;
+      setData(result);
+      setSelectedIdx(0);
+    } catch (err) {
+      if (fetchGenRef.current !== gen) return;
+      setError(err instanceof Error ? err.message : String(err));
+      setData(null);
+    } finally {
+      if (fetchGenRef.current === gen) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!symbol) {
+      setData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    void load(symbol, quotePrice);
+  }, [load, quotePrice, symbol]);
+
+  const refresh = useCallback(() => {
+    if (symbol) void load(symbol, quotePrice);
+  }, [load, quotePrice, symbol]);
+
+  usePaneFooter("dividend-yield", () => ({
+    info: loadingErrorFooterInfo(loading, error),
+    hints: [{ ...refreshFooterHint(refresh), disabled: !symbol || loading }],
+  }), [error, loading, refresh, symbol]);
+
+  const payments = data?.payments ?? [];
+  const metrics = data?.metrics;
+  const rows = useMemo(() => toDividendRows(payments), [payments]);
+  const sortedRows = useMemo(() => sortRows(rows, sortPreference), [rows, sortPreference]);
+  const columns = useMemo(() => buildDividendColumns(width), [width]);
+  const chartPoints = useMemo(
+    () => buildYieldChartPoints(payments, data?.price ?? quotePrice),
+    [data?.price, payments, quotePrice],
+  );
+
+  const handleHeaderClick = useCallback((columnId: string) => {
+    setSortPreference((current) => nextSortPreference(current, columnId));
+  }, []);
+
+  const handleKeyDown = useCallback((event: DataTableKeyEvent) => {
+    return handleRefreshKey(event, refresh, { stopPropagation: true });
+  }, [refresh]);
+
+  const emptyTitle = !symbol
+    ? "No ticker selected"
+    : loading
+      ? "Loading dividends..."
+      : error ?? "No dividend history";
+
+  return (
+    <DataTableView<DividendRow, DividendColumn>
+      focused={focused}
+      selection={{
+        kind: "index",
+        selectedIndex: sortedRows.length === 0 ? null : Math.min(selectedIdx, sortedRows.length - 1),
+        onChange: (index) => setSelectedIdx(index),
+      }}
+      onRootKeyDown={handleKeyDown}
+      resetScrollKey={symbol}
+      rootWidth={width}
+      rootHeight={height}
+      rootBefore={metrics ? (
+        <DividendSummary
+          metrics={metrics}
+          currency={payments[0]?.currency ?? currency}
+          width={width}
+          chartPoints={chartPoints}
+        />
+      ) : undefined}
+      columns={columns}
+      items={sortedRows}
+      sortColumnId={sortPreference.columnId}
+      sortDirection={sortPreference.direction}
+      onHeaderClick={handleHeaderClick}
+      getItemKey={(row) => row.key}
+      renderCell={renderCell}
+      emptyStateTitle={emptyTitle}
+    />
+  );
+}

--- a/src/plugins/builtin/dividend-yield/types.ts
+++ b/src/plugins/builtin/dividend-yield/types.ts
@@ -1,0 +1,22 @@
+export interface DividendPayment {
+  exDate: Date;
+  recordDate: Date | null;
+  paymentDate: Date | null;
+  declarationDate: Date | null;
+  amount: number;
+  currency: string;
+  type: "cash" | "special" | "stock" | "unknown";
+}
+
+export interface DividendMetrics {
+  trailingYield: number | null;
+  forwardYield: number | null;
+  trailingRate: number | null;
+  forwardRate: number | null;
+  payoutRatio: number | null;
+  growth1Y: number | null;
+  growth3Y: number | null;
+  paymentFrequency: "monthly" | "quarterly" | "semi-annual" | "annual" | "irregular" | null;
+  exDividendDate: Date | null;
+  nextPayDate: Date | null;
+}

--- a/src/plugins/builtin/ticker-research-plugin.ts
+++ b/src/plugins/builtin/ticker-research-plugin.ts
@@ -1,4 +1,5 @@
 import { chartComposerModule } from "./chart-composer";
+import { dividendYieldModule } from "./dividend-yield";
 import { holdersModule } from "./holders";
 import { insiderModule } from "./insider";
 import { optionsModule } from "./options";
@@ -19,6 +20,7 @@ export const tickerResearchPlugin = composeBuiltinPlugin({
     chartComposerModule,
     optionsModule,
     researchModule,
+    dividendYieldModule,
     holdersModule,
     thirteenFModule,
     secModule,

--- a/src/plugins/ownership.ts
+++ b/src/plugins/ownership.ts
@@ -12,6 +12,7 @@ const BUILTIN_PLUGIN_OWNER_ALIASES: Record<string, string> = {
   help: "application",
   holders: "ticker-research",
   insider: "ticker-research",
+  "dividend-yield": "ticker-research",
   "kelly-sizer": "portfolio",
   "layout-manager": "application",
   "macro-tv": "macro",

--- a/src/sources/yahoo-finance/types.ts
+++ b/src/sources/yahoo-finance/types.ts
@@ -49,6 +49,7 @@ export type QuoteSummaryResponse = {
         targetMeanPrice?: { raw?: number } | number | null;
         targetMedianPrice?: { raw?: number } | number | null;
         recommendationMean?: { raw?: number } | number | null;
+        payoutRatio?: { raw?: number } | number | null;
       };
       recommendationTrend?: {
         trend?: Array<{
@@ -141,6 +142,17 @@ export type QuoteSummaryResponse = {
         open?: { raw?: number } | number | null;
         dayHigh?: { raw?: number } | number | null;
         dayLow?: { raw?: number } | number | null;
+        trailingAnnualDividendRate?: { raw?: number } | number | null;
+        trailingAnnualDividendYield?: { raw?: number } | number | null;
+        forwardAnnualDividendRate?: { raw?: number } | number | null;
+        dividendRate?: { raw?: number } | number | null;
+        payoutRatio?: { raw?: number } | number | null;
+        exDividendDate?: { raw?: number } | number | null;
+        dividendDate?: { raw?: number } | number | null;
+        currency?: string;
+      };
+      defaultKeyStatistics?: {
+        payoutRatio?: { raw?: number } | number | null;
       };
       majorHoldersBreakdown?: {
         insidersPercentHeld?: { raw?: number } | number | null;


### PR DESCRIPTION
## Description

Adds `DVD <ticker>` and a Dividends research tab. History is Yahoo v8 chart dividend events; yield/payout come from crumbed `quoteSummary.result[0]`.

## Related Issue

N/A

## Potential Risk & Impact

Yahoo no longer ships payment/declaration dates on the chart events endpoint, so the table is ex-date + amount only. Chart range is `10y` at `1mo` to keep the payload small.

## How Has This Been Tested?

- Unit tests for quoteSummary unwrap and field-name fallbacks.
- Live `fetchDividendData("AAPL")`: 40 payments, trailing yield ~0.34%.
- `typecheck:opentui` passes.