### PR TITLE
Keep Polls UI out of desktop backend

### DIFF
--- a/src/plugins/builtin/polls/backend-plugin.ts
+++ b/src/plugins/builtin/polls/backend-plugin.ts
@@ -1,0 +1,10 @@
+import { composeBuiltinPlugin } from "../plugin-module";
+
+export const pollsBackendPlugin = composeBuiltinPlugin({
+  id: "polls",
+  name: "Polls",
+  version: "1.0.0",
+  description: "Political polls from VoteHub (CC BY 4.0)",
+  toggleable: true,
+  modules: [],
+});

--- a/src/plugins/catalog-backend.test.ts
+++ b/src/plugins/catalog-backend.test.ts
@@ -10,7 +10,7 @@ describe("desktop backend plugin catalog", () => {
       getLoadablePlugins().map((plugin) => plugin.id),
     );
 
-    for (const pluginId of ["ticker-research", "prediction-markets"]) {
+    for (const pluginId of ["ticker-research", "prediction-markets", "polls"]) {
       const plugin = backendPlugins.find((candidate) => candidate.id === pluginId);
       expect(plugin).toBeDefined();
       expect(plugin?.panes).toBeUndefined();

--- a/src/plugins/catalog-backend.ts
+++ b/src/plugins/catalog-backend.ts
@@ -20,7 +20,7 @@ import { publicPlugin } from "./broker-sync/public";
 import { robinhoodPlugin } from "./broker-sync/robinhood";
 import { simpleFinPlugin } from "./broker-sync/simplefin";
 import { predictionMarketsBackendPlugin } from "./prediction-markets/backend-plugin";
-import { pollsPlugin } from "./builtin/polls";
+import { pollsBackendPlugin } from "./builtin/polls/backend-plugin";
 
 const desktopBackendPlugins: GloomPlugin[] = [
   yahooPlugin,
@@ -38,7 +38,7 @@ const desktopBackendPlugins: GloomPlugin[] = [
   notesPlugin,
   aiPlugin,
   predictionMarketsBackendPlugin,
-  pollsPlugin,
+  pollsBackendPlugin,
   marketOverviewPlugin,
   macroPlugin,
   alertsPlugin,


### PR DESCRIPTION
## Summary
- register Polls with a metadata-only desktop backend plugin
- keep the Polls pane and renderer imports in the UI catalog only
- extend the backend catalog regression check to cover Polls

## Why
The Polls PR registered its full pane plugin in the desktop backend. That unnecessarily pulled the renderer/OpenTUI pane graph into the backend bundle and was the first main commit where the Windows ARM64 desktop smoke began exiting with code 5. Polls has no backend setup or capabilities, so the backend only needs matching plugin identity for state alignment.

## Validation
- `bun test src/plugins/catalog-backend.test.ts`
- `bun run typecheck`
