### PR TITLE
Sync broker portfolio values to mobile

### DIFF
--- a/src/sync/core-contributors.test.ts
+++ b/src/sync/core-contributors.test.ts
@@ -334,7 +334,11 @@ describe("core sync contributors", () => {
         name: "U123",
         currency: "USD",
         source: "flex",
-        grossPositionValue: 1234,
+        netLiquidation: 1_900_000,
+        grossPositionValue: 2_320_000,
+        dailyPnl: 12_345,
+        unrealizedPnl: 456_789,
+        updatedAt: 123,
       }],
     };
 
@@ -346,6 +350,15 @@ describe("core sync contributors", () => {
     expect(payload.analyticsByPortfolio.main.spyBeta).toBeCloseTo(1.5, 5);
     expect(payload.analyticsByPortfolio["broker:ibkr:U123"].oneYearReturn).toBe(0.2);
     expect(payload.analyticsByPortfolio["broker:ibkr:U123"].spyBeta).toBeCloseTo(3, 5);
+    expect(payload.accountsByPortfolio).toEqual({
+      "broker:ibkr:U123": {
+        currency: "USD",
+        netLiquidation: 1_900_000,
+        dailyPnl: 12_345,
+        unrealizedPnl: 456_789,
+        updatedAt: 123,
+      },
+    });
     expect(payload.analyticsByPortfolio.main).not.toHaveProperty("marketValue");
     expect(payload.analyticsByPortfolio.main).not.toHaveProperty("holdingsCount");
     expect(payload.analyticsByPortfolio.main).not.toHaveProperty("currency");

--- a/src/sync/core-contributors.ts
+++ b/src/sync/core-contributors.ts
@@ -3,6 +3,7 @@ import { stableStringify } from "../remote/revision";
 import type { AppConfig, BrokerInstanceConfig } from "../types/config";
 import type { PricePoint, TickerFinancials } from "../types/financials";
 import type { Portfolio, TickerMetadata, TickerPosition, TickerRecord, Watchlist } from "../types/ticker";
+import type { BrokerAccount } from "../types/trading";
 import { hydrateTickerMetadata } from "../tickers/metadata";
 import type { SyncContributor } from "./types";
 import { convertCurrency } from "../utils/format";
@@ -284,11 +285,34 @@ function collectAnalyticsByPortfolio(
   return output;
 }
 
+function collectAccountsByPortfolio(
+  config: AppConfig,
+  brokerAccounts: Record<string, BrokerAccount[]>,
+) {
+  const output: Record<string, Record<string, string | number>> = {};
+  for (const portfolio of config.portfolios) {
+    if (!portfolio.brokerInstanceId || !portfolio.brokerAccountId) continue;
+    const account = brokerAccounts[portfolio.brokerInstanceId]?.find(
+      (entry) => entry.accountId === portfolio.brokerAccountId,
+    );
+    if (!account || !Number.isFinite(account.netLiquidation)) continue;
+    output[portfolio.id] = {
+      currency: account.currency ?? portfolio.currency ?? config.baseCurrency,
+      netLiquidation: account.netLiquidation!,
+      ...(Number.isFinite(account.dailyPnl) ? { dailyPnl: account.dailyPnl! } : {}),
+      ...(Number.isFinite(account.unrealizedPnl) ? { unrealizedPnl: account.unrealizedPnl! } : {}),
+      ...(Number.isFinite(account.updatedAt) ? { updatedAt: account.updatedAt! } : {}),
+    };
+  }
+  return output;
+}
+
 function collectCoreCollectionsPayload(
   config: AppConfig,
   tickers: Map<string, TickerRecord>,
   financials: Map<string, TickerFinancials>,
   exchangeRates: Map<string, number>,
+  brokerAccounts: Record<string, BrokerAccount[]>,
 ) {
   const records = [...tickers.values()]
     .map((ticker) => sanitizeTickerMetadata(ticker.metadata, financials.get(ticker.metadata.ticker)))
@@ -312,6 +336,7 @@ function collectCoreCollectionsPayload(
     portfolios: config.portfolios.map(sanitizePortfolio),
     watchlists: config.watchlists.map(sanitizeWatchlist),
     analyticsByPortfolio: collectAnalyticsByPortfolio(config, tickers, financials, exchangeRates),
+    accountsByPortfolio: collectAccountsByPortfolio(config, brokerAccounts),
     tickers: records,
   };
 }
@@ -445,6 +470,7 @@ export const coreCollectionsSyncContributor: SyncContributor = {
     state.tickers,
     state.financials,
     state.exchangeRates,
+    state.brokerAccounts,
   ),
   apply: async (payload, { getState, isCurrent, dispatch, tickerRepository }) => {
     if (!isPlainObject(payload)) return;


### PR DESCRIPTION
## Summary
- include private per-portfolio broker net liquidation and P&L in the existing user sync snapshot
- keep public profile analytics unchanged and continue omitting broker credentials/account identifiers
- let the companion app show account equity instead of gross mixed-currency position totals

## Validation
- `bun test src/sync/core-contributors.test.ts`
- `bun run typecheck`