### PR TITLE
Fix data integrity, loading states, and layout across market panes

### DIFF
--- a/.agents/skills/tui-testing/SKILL.md
+++ b/.agents/skills/tui-testing/SKILL.md
@@ -15,13 +15,32 @@ Three testing approaches. **Start with the simplest level that covers your chang
 
 This skill is for terminal TUI and OpenTUI test workflows. For Electrobun/desktop-web-only fixes, use focused desktop builds/tests instead unless the task explicitly asks for tmux or terminal rendering coverage.
 
-## Critical Rule
+## Critical Rules
 
 Cleanup is part of testing. If you start `tmux`, a dev server, a watcher, or any other background process while testing, stop it before you finish the task, even if the test fails.
 
 - Prefer named `tmux` sessions and end them with `tmux kill-session -t <name>`.
 - If you start a background process without `tmux`, capture its PID and terminate it explicitly with `kill <pid>` or the matching shutdown command.
 - Do not leave test helpers running across iterations unless the workflow explicitly requires it and you clean them up before handoff.
+
+**Never open the TV pane in a live app.** `macro-tv` (shortcut `TV`) spawns an external media player such as `mpv`, plus `yt-dlp`/`ffmpeg`. Those processes outlive the `tmux` session that started them, keep playing audio, and burn CPU on the developer's machine until they are killed by hand. Verify TV changes by reading the code and with unit tests. The same rule applies to any pane or feature that shells out to a media player.
+
+**Never run an unbounded or streaming log scan.** A `tail -c 4000000 <log> | strings | grep ... | head -20` health scan once pinned a core at 100% for over five hours. Scan a bounded slice of a file that is no longer being written, and never involve `strings`:
+
+```bash
+head -c 200000 /tmp/gloomberb-test.log | grep -aE "<pattern>" | head -20
+```
+
+**Finish with a leak sweep.** Before you report a test as done, confirm nothing you started is still alive:
+
+```bash
+ps -Ao pid,%cpu,etime,command \
+  | grep -iE "mpv|yt-dlp|ffmpeg|ffplay|tail -c|strings|bun run dev" \
+  | grep -v grep
+tmux ls 2>&1
+```
+
+Kill anything of yours that shows up and re-run until the sweep is clean.
 
 ```
 What are you testing?

--- a/src/cli/commands/overview.ts
+++ b/src/cli/commands/overview.ts
@@ -95,7 +95,7 @@ async function runFearGreed(_args: string[], ctx: Parameters<CliCommandDef["exec
       "fear-greed",
     ));
     try {
-      const data = await loadFearGreed(ctx.cliOptions.refresh);
+      const { data } = await loadFearGreed(ctx.cliOptions.refresh);
       ctx.printResult({
         data: [{
           score: data.overall.score,
@@ -119,7 +119,7 @@ async function runEcon(args: string[], ctx: Parameters<CliCommandDef["execute"]>
   const country = (takeOption(rawArgs, "--country") ?? "all") as CountryFilter;
   const impact = (takeOption(rawArgs, "--impact") ?? "all") as ImpactFilter;
   await withCliServices(ctx, async (services) => {
-    const events = await loadCalendar(ctx.cliOptions.refresh);
+    const { data: events } = await loadCalendar(ctx.cliOptions.refresh);
     const rows = events
       .filter((event) => matchesCountry(event, country) && matchesImpact(event, impact))
       .sort((left, right) => left.date.getTime() - right.date.getTime())

--- a/src/cli/pane-functions/catalog.ts
+++ b/src/cli/pane-functions/catalog.ts
@@ -55,8 +55,12 @@ function registerResolverToken(
 
 export function buildPaneFunctionLookup(registry: PaneFunctionCatalog): Map<string, PaneTemplateDef | PaneDef> {
   const lookup = new Map<string, PaneTemplateDef | PaneDef>();
+  // Shortcut prefixes first: "AI" must open the pane that owns the shortcut, not
+  // one that happens to list "ai" as a keyword.
   for (const template of registry.paneTemplates.values()) {
     registerResolverToken(lookup, template.shortcut?.prefix, template);
+  }
+  for (const template of registry.paneTemplates.values()) {
     registerResolverToken(lookup, template.id, template);
     registerResolverToken(lookup, template.label, template);
     for (const keyword of template.keywords ?? []) registerResolverToken(lookup, keyword, template);

--- a/src/cli/pane-functions/data.ts
+++ b/src/cli/pane-functions/data.ts
@@ -93,9 +93,14 @@ export function collectShotSymbols(resolved: ResolvedPaneFunction, rawArg: strin
       )).filter(Boolean))];
     }
   }
+  // A text argument is a phrase, not a symbol, so it must never be looked up as one.
+  const argIsTicker = resolved.template?.shortcut?.argKind !== "text";
   let symbols = resolved.createOptions?.symbols?.length
     ? resolved.createOptions.symbols
-    : [resolved.createOptions?.symbol ?? normalizeTickerInput(null, cleanTickerInput(rawArg))].filter((symbol): symbol is string => !!symbol);
+    : [
+      resolved.createOptions?.symbol
+        ?? (argIsTicker ? normalizeTickerInput(null, cleanTickerInput(rawArg)) : null),
+    ].filter((symbol): symbol is string => !!symbol);
   if (resolved.capability.id === "security-relationship" && symbols.length === 1) {
     symbols = [...symbols, "SPY"];
   }

--- a/src/cli/pane-functions/discovery.ts
+++ b/src/cli/pane-functions/discovery.ts
@@ -1,4 +1,6 @@
 import { ConnectionHealthRegistry } from "../../core/connection-health";
+import type { AppConfig } from "../../types/config";
+import type { DataProvider } from "../../types/data-provider";
 import type {
   GloomPlugin,
   GloomPluginContext,
@@ -7,17 +9,69 @@ import type {
   PluginPersistence,
 } from "../../types/plugin";
 import type { PersistedResourceValue } from "../../types/persistence";
+import type { TickerRepository } from "../../data/ticker-repository";
 import type { MarketContext } from "../types";
 import type { PaneFunctionCatalog } from "./catalog";
 
-export async function createPaneCatalog(context: MarketContext, plugins: GloomPlugin[]): Promise<PaneFunctionCatalog> {
-  const panes = new Map<string, PaneDef>();
-  const paneTemplates = new Map<string, PaneTemplateDef>();
-  const setupPlugins: GloomPlugin[] = [];
+export interface PaneDiscoveryOptions {
+  getConfig: () => AppConfig;
+  marketData?: DataProvider;
+  tickerRepository?: TickerRepository;
+  panes?: Map<string, PaneDef>;
+  paneTemplates?: Map<string, PaneTemplateDef>;
+}
+
+/** Throws only if a plugin actually reaches for a dependency discovery has no answer for. */
+function unavailable<T>(name: string): T {
+  return new Proxy({}, {
+    get() {
+      throw new Error(`${name} is unavailable during pane discovery.`);
+    },
+  }) as T;
+}
+
+/**
+ * Context that collects `setup()`-registered panes and templates without
+ * booting the real plugin runtime or its polling engines. Keep this object
+ * exhaustively typed so additions to GloomPluginContext fail at compile time
+ * instead of crashing `gloomberb catalog` at runtime.
+ */
+export function createPaneDiscoveryContext(options: PaneDiscoveryOptions): GloomPluginContext & {
+  panes: Map<string, PaneDef>;
+  paneTemplates: Map<string, PaneTemplateDef>;
+} {
+  const panes = options.panes ?? new Map<string, PaneDef>();
+  const paneTemplates = options.paneTemplates ?? new Map<string, PaneTemplateDef>();
+  return {
+    ...buildDiscoveryContext({
+      panes,
+      paneTemplates,
+      getConfig: options.getConfig,
+      marketData: options.marketData ?? unavailable<DataProvider>("Market data"),
+      tickerRepository: options.tickerRepository ?? unavailable<TickerRepository>("The ticker repository"),
+      connectionHealth: new ConnectionHealthRegistry(),
+    }),
+    panes,
+    paneTemplates,
+  };
+}
+
+function buildDiscoveryContext({
+  panes,
+  paneTemplates,
+  getConfig,
+  marketData,
+  tickerRepository,
+  connectionHealth,
+}: {
+  panes: Map<string, PaneDef>;
+  paneTemplates: Map<string, PaneTemplateDef>;
+  getConfig: () => AppConfig;
+  marketData: DataProvider;
+  tickerRepository: TickerRepository;
+  connectionHealth: ConnectionHealthRegistry;
+}): GloomPluginContext {
   const fakePersistence = createDiscoveryPluginPersistence();
-  // Collect setup-registered panes without booting the real plugin runtime or polling engines.
-  // Keep this object exhaustively typed so additions to GloomPluginContext fail at
-  // compile time instead of crashing `gloomberb catalog` at runtime.
   const discoveryContext: GloomPluginContext = {
     registerPane: (pane: PaneDef) => panes.set(pane.id, pane),
     registerPaneTemplate: (template: PaneTemplateDef) => paneTemplates.set(template.id, template),
@@ -34,11 +88,11 @@ export async function createPaneCatalog(context: MarketContext, plugins: GloomPl
     watchNewsQuery: () => () => {},
     getData: () => null,
     getTicker: () => null,
-    getConfig: () => context.config,
+    getConfig,
     getPaneDef: (paneId: string) => panes.get(paneId),
-    marketData: context.dataProvider,
-    connectionHealth: new ConnectionHealthRegistry(),
-    tickerRepository: context.store,
+    marketData,
+    connectionHealth,
+    tickerRepository,
     persistence: fakePersistence,
     log: {
       debug: () => {},
@@ -86,6 +140,16 @@ export async function createPaneCatalog(context: MarketContext, plugins: GloomPl
     emit: () => {},
     notify: () => {},
   };
+  return discoveryContext;
+}
+
+export async function createPaneCatalog(context: MarketContext, plugins: GloomPlugin[]): Promise<PaneFunctionCatalog> {
+  const setupPlugins: GloomPlugin[] = [];
+  const { panes, paneTemplates, ...discoveryContext } = createPaneDiscoveryContext({
+    getConfig: () => context.config,
+    marketData: context.dataProvider,
+    tickerRepository: context.store,
+  });
 
   for (const plugin of plugins) {
     for (const pane of plugin.panes ?? []) panes.set(pane.id, pane);

--- a/src/cli/pane-functions/resolver.ts
+++ b/src/cli/pane-functions/resolver.ts
@@ -45,9 +45,12 @@ async function buildPaneInstance(
   context: MarketContext,
   target: string,
 ): Promise<PaneInstanceConfig> {
+  // A text argument is a phrase, not a symbol: uppercasing it and binding it as
+  // a ticker makes the pane look for a provider for "HIGH GROWTH SOFTWARE".
+  const argKind = resolved.template?.shortcut?.argKind;
   const primarySymbol = resolved.createOptions?.symbol
     ?? resolved.createOptions?.symbols?.[0]
-    ?? normalizeTickerInput(null, cleanTickerInput(target));
+    ?? (argKind === "text" ? null : normalizeTickerInput(null, cleanTickerInput(target)));
   const templateContext = buildTemplateContext(context, primarySymbol ?? null);
   const spec = await resolved.template?.createInstance?.(templateContext, resolved.createOptions) ?? {};
   const instanceId = `${resolved.pane.id}:cli-${slugifyName(target || resolved.pane.id, "pane")}`;

--- a/src/components/chart/native/kitty/index.test.ts
+++ b/src/components/chart/native/kitty/index.test.ts
@@ -11,7 +11,11 @@ import {
 } from "../chart-rasterizer";
 import { KittyImageManager } from "./manager";
 import { chunkBase64Payload, encodeKittyTransmitRgba } from "./protocol";
-import { ensureKittySupport, getCachedKittySupport } from "./support";
+import {
+  ensureKittySupport,
+  getCachedKittySupport,
+  resolveKittySupport,
+} from "./support";
 import { resolveChartRendererState } from "../renderer-selection";
 import { computeSurfaceVisibleFragments, NativeSurfaceManager } from "../surface/manager";
 import { syncCachedNativeSurface } from "../surface/sync";
@@ -42,9 +46,27 @@ describe("resolveChartRendererState", () => {
   });
 });
 
+describe("resolveKittySupport", () => {
+  const noMultiplexer = { TERM: "xterm-kitty" } as Record<string, string | undefined>;
+
+  test("never claims support behind a multiplexer, whatever it advertises", () => {
+    expect(resolveKittySupport({ kitty_graphics: true, multiplexer: "tmux" }, noMultiplexer)).toBe(false);
+    expect(resolveKittySupport({ kitty_graphics: true }, { TERM: "tmux-256color" })).toBe(false);
+    expect(resolveKittySupport({ kitty_graphics: true }, { TERM_PROGRAM: "tmux" })).toBe(false);
+    expect(resolveKittySupport({ kitty_graphics: true }, { TMUX: "/tmp/tmux-501/default,1,0" })).toBe(false);
+  });
+
+  test("keeps confirmed support and leaves an unanswered query undecided", () => {
+    expect(resolveKittySupport({ kitty_graphics: true, multiplexer: "none" }, noMultiplexer)).toBe(true);
+    expect(resolveKittySupport({ kitty_graphics: false }, noMultiplexer)).toBe(false);
+    expect(resolveKittySupport({}, noMultiplexer)).toBe(null);
+    expect(resolveKittySupport(null, noMultiplexer)).toBe(null);
+  });
+});
+
 describe("getCachedKittySupport", () => {
   test("prefers later renderer capabilities over a failed query cache", async () => {
-    let capabilities: { kitty_graphics?: boolean } | null = null;
+    let capabilities: { kitty_graphics?: boolean; multiplexer?: string } | null = null;
     const renderer = {
       isDestroyed: false,
       get capabilities() {
@@ -60,7 +82,7 @@ describe("getCachedKittySupport", () => {
     expect(await ensureKittySupport(renderer)).toBe(false);
     expect(getCachedKittySupport(renderer)).toBe(false);
 
-    capabilities = { kitty_graphics: true };
+    capabilities = { kitty_graphics: true, multiplexer: "none" };
     expect(getCachedKittySupport(renderer)).toBe(true);
   });
 });

--- a/src/components/chart/native/kitty/support.ts
+++ b/src/components/chart/native/kitty/support.ts
@@ -2,8 +2,9 @@ import { type NativeRendererHost as CliRenderer } from "../../../../ui";
 import { writeRendererRaw } from "./adapter";
 import { buildKittyGraphicsQuery } from "./protocol";
 
-interface RendererCapabilities {
+export interface RendererCapabilities {
   kitty_graphics?: boolean;
+  multiplexer?: string;
 }
 
 interface SupportCacheEntry {
@@ -14,9 +15,40 @@ interface SupportCacheEntry {
 const supportCache = new WeakMap<CliRenderer, SupportCacheEntry>();
 const QUERY_TIMEOUT_MS = 250;
 
-function readKnownSupport(renderer: CliRenderer): boolean | null {
-  const capabilities = renderer.capabilities as RendererCapabilities | null;
+/**
+ * A multiplexer swallows the graphics query and then passes image payloads
+ * through as literal text, which shreds the screen. Whatever it advertises,
+ * kitty graphics are not usable behind one.
+ */
+export function isMultiplexedTerminal(
+  capabilities: RendererCapabilities | null | undefined,
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const reported = capabilities?.multiplexer;
+  // The renderer's own detection wins when it has one; the environment is only
+  // consulted when nothing was reported.
+  if (typeof reported === "string") return reported !== "none";
+  if (env.TMUX) return true;
+  const termProgram = (env.TERM_PROGRAM ?? "").toLowerCase();
+  if (termProgram === "tmux" || termProgram === "screen") return true;
+  const term = (env.TERM ?? "").toLowerCase();
+  return term.startsWith("tmux") || term.startsWith("screen");
+}
+
+/**
+ * What is known about kitty graphics before querying: `null` means undecided,
+ * so the query result (or its absence) decides.
+ */
+export function resolveKittySupport(
+  capabilities: RendererCapabilities | null | undefined,
+  env: Record<string, string | undefined> = process.env,
+): boolean | null {
+  if (isMultiplexedTerminal(capabilities, env)) return false;
   return typeof capabilities?.kitty_graphics === "boolean" ? capabilities.kitty_graphics : null;
+}
+
+function readKnownSupport(renderer: CliRenderer): boolean | null {
+  return resolveKittySupport(renderer.capabilities as RendererCapabilities | null);
 }
 
 export function getCachedKittySupport(renderer: CliRenderer): boolean | null {
@@ -54,6 +86,8 @@ export function ensureKittySupport(renderer: CliRenderer): Promise<boolean> {
       if (supported !== null) finish(supported);
     };
 
+    // No answer means unsupported: a terminal that speaks the protocol answers,
+    // and anything that swallows the query would also swallow the image.
     const timer = setTimeout(() => finish(false), QUERY_TIMEOUT_MS);
     renderer.on("capabilities", onCapabilities);
     if (!writeRendererRaw(renderer, `${buildKittyGraphicsQuery()}\x1b[c`)) {

--- a/src/components/command-bar/routes/root/results.ts
+++ b/src/components/command-bar/routes/root/results.ts
@@ -83,9 +83,17 @@ export interface RootResultModelOptions {
 }
 
 /** An in-flight or answered request keeps its rows even if the heuristic lapses. */
-function isAssistSectionVisible(assist: AssistRowHandlers, query: string, resultCount: number): boolean {
+function isAssistSectionVisible(
+  assist: AssistRowHandlers,
+  query: string,
+  resultCount: number,
+  hasShortcutIntent: boolean,
+): boolean {
   if (!query.trim()) return false;
   if (assist.state.status !== "idle" && assist.state.query === query.trim()) return true;
+  // A resolved shortcut is the user speaking the command language, so nothing is
+  // asked of the AI, and a sign-up offer must not outrank that exact match.
+  if (hasShortcutIntent) return false;
   // Signed out there is nothing to wait for, so the older heuristic still picks
   // the queries worth offering a sign-up row for.
   if (!assist.enabled) return shouldShowAssistRow({ query, resultCount });
@@ -243,7 +251,13 @@ export function buildRootResultModel(options: RootResultModelOptions): RootResul
   // Built from the local matches, then moved above them: the AI answers the
   // question the user typed, so it leads the list. Rows landing here renumber
   // everything below, which the root selection effect absorbs by identity.
-  const assistItems = assist && isAssistSectionVisible(assist, rootQuery, items.length)
+  const assistItems = assist
+    && isAssistSectionVisible(
+      assist,
+      rootQuery,
+      items.length,
+      rootShortcutIntent.kind !== "none" && !isArticleLookupShortcut(rootShortcutIntent),
+    )
     ? buildAssistResultItems({ ...assist, query: rootQuery })
     : [];
 

--- a/src/components/command-bar/view-model.test.ts
+++ b/src/components/command-bar/view-model.test.ts
@@ -47,6 +47,25 @@ describe("command bar view model helpers", () => {
     expect(sections.map((section) => section.category)).toEqual(["Tickers", "Config", "Danger", "Debug"]);
   });
 
+  test("drops an offer-only section below real matches even when its category leads", () => {
+    const sections = buildSections([
+      { id: "assist:sign-up", category: "Ask AI", disabled: true, defaultSelectable: false },
+      { id: "holders", category: "Panes" },
+    ]);
+
+    expect(sections.map((section) => section.category)).toEqual(["Panes", "Ask AI"]);
+    expect(sections[0]?.items[0]?.id).toBe("holders");
+  });
+
+  test("keeps an answered AI section leading the list", () => {
+    const sections = buildSections([
+      { id: "assist:candidate:0", category: "Ask AI" },
+      { id: "holders", category: "Panes" },
+    ]);
+
+    expect(sections.map((section) => section.category)).toEqual(["Ask AI", "Panes"]);
+  });
+
   test("keeps non-exact ticker suggestions behind app sections in app-first order", () => {
     const sections = buildSections([
       { id: "pane", category: "Panes" },

--- a/src/components/command-bar/view-model.ts
+++ b/src/components/command-bar/view-model.ts
@@ -83,7 +83,24 @@ export function resolveCommandBarMode(query: string, commandList?: Command[]): C
   }
 }
 
-export function buildSections<T extends { category: string }>(
+/**
+ * A section whose every row is disabled or unselectable is an offer, not an
+ * answer, so it sorts below real matches however its category is prioritized.
+ */
+const OFFER_SECTION_DEMOTION = 200;
+
+interface SectionSortableItem {
+  category: string;
+  disabled?: boolean;
+  defaultSelectable?: boolean;
+}
+
+function isOfferOnlySection<T extends SectionSortableItem>(items: T[]): boolean {
+  return items.length > 0
+    && items.every((item) => item.disabled === true || item.defaultSelectable === false);
+}
+
+export function buildSections<T extends SectionSortableItem>(
   items: T[],
   options?: { sectionOrder?: CommandBarSectionOrder },
 ): Array<CommandBarSection<T>> {
@@ -99,8 +116,10 @@ export function buildSections<T extends { category: string }>(
   return sections
     .map((section, index) => ({ section, index }))
     .sort((a, b) => {
-      const leftPriority = getCategoryPriority(a.section.category, options?.sectionOrder);
-      const rightPriority = getCategoryPriority(b.section.category, options?.sectionOrder);
+      const leftPriority = getCategoryPriority(a.section.category, options?.sectionOrder)
+        + (isOfferOnlySection(a.section.items) ? OFFER_SECTION_DEMOTION : 0);
+      const rightPriority = getCategoryPriority(b.section.category, options?.sectionOrder)
+        + (isOfferOnlySection(b.section.items) ? OFFER_SECTION_DEMOTION : 0);
       const priorityDiff = leftPriority - rightPriority;
       return priorityDiff !== 0 ? priorityDiff : a.index - b.index;
     })

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -42,7 +42,7 @@ export { ConfirmDialog } from "./ui/confirm-dialog";
 export { ChoiceDialog } from "./ui/choice-dialog";
 export type { ChoiceDialogChoice } from "./ui/choice-dialog";
 export type { DataTableCell, DataTableColumn, DataTableVisibleRange } from "./ui/data-table";
-export { EmptyState } from "./ui/status";
+export { EmptyState, PaneStatusBody, loadingText, unavailableText } from "./ui/status";
 export { getMessageComposerBlockHeight, MessageComposer } from "./ui/message-composer";
 export { NumberField, TextField } from "./ui/fields";
 export { SegmentedControl } from "./ui/toggle";

--- a/src/components/ui/data-table/opentui/index.tsx
+++ b/src/components/ui/data-table/opentui/index.tsx
@@ -4,13 +4,14 @@ import { hoverBg } from "../../../../theme/colors";
 import { useThemeColors } from "../../../../theme/theme-context";
 import { useAppDispatch, usePaneInstance } from "../../../../state/app/context";
 import { useViewport } from "../../../../react/input";
-import { padTo } from "../../../../utils/format";
 import { measurePerf } from "../../../../utils/perf-marks";
 import { useDoubleClickActivation } from "../../../use-double-click-activation";
 import { useScrollBoxScrollActivity } from "../../../table-view-shared";
 import { EmptyState } from "../../status";
 import {
   expandTableColumns,
+  fitTableCellText,
+  fitTableHeaderText,
   getTableWidth,
   hasMeaningfulTableHorizontalOverflow,
   tableContentWidthProps,
@@ -30,6 +31,21 @@ import {
 interface DataTableRowPointerTarget<T> {
   item: T;
   index: number;
+}
+
+type ManagedScrollBar = {
+  visible: boolean;
+  resetVisibilityControl?: () => void;
+};
+
+function setScrollBarVisible(scrollBar: unknown, visible: boolean): void {
+  const bar = scrollBar as ManagedScrollBar | undefined;
+  if (!bar) return;
+  if (visible && bar.resetVisibilityControl) {
+    bar.resetVisibilityControl();
+    return;
+  }
+  bar.visible = visible;
 }
 
 export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
@@ -243,11 +259,13 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
     }
     const body = scrollRef.current;
     if (body) {
-      if (body.horizontalScrollBar) {
-        body.horizontalScrollBar.visible = horizontalScrollbarVisible;
-      }
-      if (body.verticalScrollBar && body.viewport) {
-        body.verticalScrollBar.visible = items.length > body.viewport.height;
+      // Forcing a bar visible latches manual visibility, and the scroll box then
+      // paints a full-length solid thumb whenever there is nothing to scroll.
+      // Only the hidden side is forced; otherwise the scroll box decides from
+      // its own content size.
+      setScrollBarVisible(body.horizontalScrollBar, horizontalScrollbarVisible);
+      if (body.viewport) {
+        setScrollBarVisible(body.verticalScrollBar, items.length > body.viewport.height);
       }
       if (!horizontalScrollbarVisible) {
         body.scrollLeft = 0;
@@ -316,17 +334,18 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
           paddingX={horizontalPadding}
           backgroundColor={colors.panel}
         >
-          {displayColumns.map((column) => {
+          {displayColumns.map((column, columnIndex) => {
             const isSorted = sortColumnId === column.id;
             const indicator = isSorted
               ? sortDirection === "asc"
                 ? " ▲"
                 : " ▼"
               : "";
-            const labelText = padTo(
+            const labelText = fitTableHeaderText(
               column.label + indicator,
               column.width,
               column.align,
+              columnIndex < displayColumns.length - 1,
             );
             return (
               <Box
@@ -484,7 +503,7 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
                                 (selected ? colors.selectedText : colors.text)
                               }
                             >
-                              {padTo(cell.text, column.width, column.align)}
+                              {fitTableCellText(cell.text, column.width, column.align)}
                             </Text>
                           )}
                         </Box>

--- a/src/components/ui/loading.tsx
+++ b/src/components/ui/loading.tsx
@@ -8,7 +8,7 @@ export interface SpinnerProps {
 
 export function Spinner({ label }: SpinnerProps) {
   return (
-    <Box flexDirection="row" gap={1}>
+    <Box flexDirection="row" gap={1} data-gloom-status="loading">
       <SpinnerMark name="dots" color={colors.textDim} />
       {label && <Text fg={colors.textDim}>{t(label)}</Text>}
     </Box>

--- a/src/components/ui/status.tsx
+++ b/src/components/ui/status.tsx
@@ -1,6 +1,7 @@
+import type { ReactNode } from "react";
 import { Box, Text } from "../../ui";
 import { colors } from "../../theme/colors";
-import { t } from "../../i18n";
+import { t, tf } from "../../i18n";
 
 export interface EmptyStateProps {
   title: string;
@@ -26,4 +27,72 @@ export function EmptyState({ title, message, hint }: EmptyStateProps) {
       )}
     </Box>
   );
+}
+
+/** The one loading phrasing: "Loading ..." with three dots, never the ellipsis glyph. */
+export function loadingText(thing?: string): string {
+  return thing ? tf("Loading {thing}...", { thing }) : t("Loading...");
+}
+
+/** The one failure phrasing: "<Thing> unavailable." */
+export function unavailableText(thing: string): string {
+  return tf("{thing} unavailable.", { thing });
+}
+
+export interface PaneStatusBodyProps {
+  loading?: boolean;
+  error?: string | null;
+  /** True when there is nothing to show and nothing is in flight. */
+  empty?: boolean;
+  /** Names what is being loaded or what failed, e.g. "movers". */
+  subject?: string;
+  emptyTitle?: string;
+  emptyMessage?: string;
+  children?: ReactNode;
+}
+
+/**
+ * Standard loading/error/empty body for a pane. Returns `children` once there
+ * is something to render, so a pane can wrap its content in one place instead
+ * of hand-rolling three near-identical states.
+ */
+export function PaneStatusBody({
+  loading = false,
+  error,
+  empty = false,
+  subject,
+  emptyTitle,
+  emptyMessage,
+  children,
+}: PaneStatusBodyProps) {
+  if (error) {
+    return (
+      <Box paddingX={1} paddingY={1}>
+        <EmptyState
+          title={subject ? unavailableText(subject) : error}
+          message={subject ? error : undefined}
+        />
+      </Box>
+    );
+  }
+  if (loading) {
+    // The screenshot renderer waits on this marker to know a pane is still
+    // fetching. It must be a real attribute, never a word match on body text.
+    return (
+      <Box paddingX={1} paddingY={1} data-gloom-status="loading">
+        <EmptyState title={loadingText(subject)} />
+      </Box>
+    );
+  }
+  if (empty) {
+    return (
+      <Box paddingX={1} paddingY={1}>
+        <EmptyState
+          title={emptyTitle ?? t("Nothing to show yet.")}
+          message={emptyMessage}
+        />
+      </Box>
+    );
+  }
+  return <>{children}</>;
 }

--- a/src/components/ui/table-layout.test.ts
+++ b/src/components/ui/table-layout.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildTableGridTemplateColumns,
+  fitTableCellText,
+  fitTableHeaderText,
   getTableWidth,
   hasMeaningfulTableHorizontalOverflow,
+  tableColumnWidth,
 } from "./table-layout";
 
 describe("table layout", () => {
@@ -32,6 +35,27 @@ describe("table layout", () => {
     expect(noPaddingWidth).toBe(20);
     expect(hasMeaningfulTableHorizontalOverflow(tableWidth, tableWidth, 0)).toBe(false);
     expect(hasMeaningfulTableHorizontalOverflow(tableWidth, tableWidth - 1, 0)).toBe(true);
+  });
+
+  test("widens a column that cannot fit its own header plus the sort indicator", () => {
+    expect(tableColumnWidth({ width: 4, label: "Time" })).toBe(6);
+    expect(tableColumnWidth({ width: 4, label: "AS OF" })).toBe(7);
+    expect(tableColumnWidth({ width: 12, label: "SECTOR" })).toBe(12);
+    expect(getTableWidth([{ width: 2, label: "OI" }, { width: 4, label: "ENDS" }], 1, 0)).toBe(12);
+  });
+
+  test("marks clipped cells so a cut number cannot read as a smaller value", () => {
+    expect(fitTableCellText("2026-08-17", 9, "right")).toBe("2026-0...");
+    expect(fitTableCellText("globenewswire", 10)).toBe("globene...");
+    expect(fitTableCellText("12.5", 6, "right")).toBe("  12.5");
+  });
+
+  test("keeps a blank cell between adjacent headers without shortening a label", () => {
+    expect(fitTableHeaderText("OI", 4, "right")).toBe(" OI ");
+    expect(fitTableHeaderText("ENDS", 6, "left")).toBe("ENDS  ");
+    // A header that already fills its column keeps every character.
+    expect(fitTableHeaderText("WEIGHT \u25bc", 8, "right")).toBe("WEIGHT \u25bc");
+    expect(fitTableHeaderText("ALLOCATION", 10, "left", false)).toBe("ALLOCATION");
   });
 
   test("keeps non-flex web table columns fixed", () => {

--- a/src/components/ui/table-layout.ts
+++ b/src/components/ui/table-layout.ts
@@ -1,21 +1,85 @@
 import { useCallback, useEffect, useState, type RefObject } from "react";
 import type { ScrollBoxRenderable } from "../../ui";
+import { displayWidth, truncateToDisplayWidth } from "../../utils/format";
 
 export interface TableWidthColumn {
   width: number;
   flexGrow?: number;
   align?: string;
+  label?: string;
 }
 
 const TRAILING_COLUMN_GUTTER_WIDTH = 1;
 const WEB_CELL_UNIT = "var(--cell-w)";
+
+/** Space the sort indicator (" \u25b2") needs on top of the header label. */
+const HEADER_RESERVED_WIDTH = 2;
+
+/** Cells the data table puts between two columns. */
+export const TABLE_COLUMN_GAP = 1;
+
+/**
+ * Width a column actually needs: its configured data width, but never less than
+ * its own header label plus the sort indicator, so a header is only ever
+ * shortened when the pane itself is too narrow for it.
+ */
+export function tableColumnWidth(column: TableWidthColumn): number {
+  const width = Math.max(1, Math.floor(column.width));
+  if (!column.label) return width;
+  return Math.max(width, displayWidth(column.label) + HEADER_RESERVED_WIDTH);
+}
+
+export function normalizeTableColumns<C extends TableWidthColumn>(columns: readonly C[]): C[] {
+  return columns.map((column) => {
+    const width = tableColumnWidth(column);
+    return width === column.width ? column : { ...column, width };
+  });
+}
+
+function padToWidth(text: string, width: number, align: string | undefined): string {
+  const padding = Math.max(0, width - displayWidth(text));
+  if (align === "right") return " ".repeat(padding) + text;
+  if (align === "center") {
+    const left = Math.floor(padding / 2);
+    return " ".repeat(left) + text + " ".repeat(padding - left);
+  }
+  return text + " ".repeat(padding);
+}
+
+/**
+ * Fit cell text to a fixed column width. Overlong text always keeps an ellipsis
+ * marker, so a clipped number or date can never be misread as a shorter valid
+ * value.
+ */
+export function fitTableCellText(text: string, width: number, align?: string): string {
+  return padToWidth(truncateToDisplayWidth(text, width), width, align);
+}
+
+/**
+ * Fit a header label to its column, keeping one cell clear on the side facing
+ * the next column. One blank is a word separator, so without this two adjacent
+ * headers read as a single label ("OI ENDS").
+ */
+export function fitTableHeaderText(
+  text: string,
+  width: number,
+  align?: string,
+  hasNextColumn = true,
+): string {
+  // Never bought at the price of shortening the label: a header that already
+  // fills its column keeps every character.
+  const reserve = hasNextColumn && displayWidth(text) < width ? 1 : 0;
+  const available = width - reserve;
+  const inner = padToWidth(truncateToDisplayWidth(text, available), available, align);
+  return reserve > 0 ? `${inner} ` : inner;
+}
 
 export function getTableWidth(
   columns: readonly TableWidthColumn[],
   columnGap = 1,
   horizontalPadding = 1,
 ): number {
-  return columns.reduce((sum, column) => sum + column.width + columnGap, horizontalPadding * 2);
+  return columns.reduce((sum, column) => sum + tableColumnWidth(column) + columnGap, horizontalPadding * 2);
 }
 
 export function hasMeaningfulTableHorizontalOverflow(
@@ -32,39 +96,42 @@ export function expandTableColumns<C extends TableWidthColumn>(
   columnGap = 1,
   horizontalPadding = 1,
 ): C[] {
-  const currentWidth = getTableWidth(columns, columnGap, horizontalPadding);
+  const normalized = normalizeTableColumns(columns);
+  const currentWidth = getTableWidth(normalized, columnGap, horizontalPadding);
   const extraWidth = Math.floor(targetWidth) - currentWidth;
-  if (extraWidth <= 0) return [...columns];
+  if (extraWidth <= 0) return normalized;
 
-  const growIndex = columns.findIndex((column) => (column.flexGrow ?? 0) > 0);
-  if (growIndex < 0) return [...columns];
+  const growIndex = normalized.findIndex((column) => (column.flexGrow ?? 0) > 0);
+  if (growIndex < 0) return normalized;
 
-  return columns.map((column, index) => {
+  return normalized.map((column, index) => {
     return index === growIndex ? { ...column, width: column.width + extraWidth } : column;
   });
 }
 
-function normalizedColumnWidth(column: TableWidthColumn): number {
-  return Math.max(1, Math.floor(column.width));
-}
-
 function columnMinCh(column: TableWidthColumn): number {
-  const width = normalizedColumnWidth(column);
-  if ((column.flexGrow ?? 0) > 0) {
-    return Math.max(8, Math.min(18, Math.floor(width * 0.35)));
-  }
-  if (column.align === "right") {
-    return Math.max(3, Math.min(width, 8));
-  }
-  if (width >= 16) {
-    return Math.max(8, Math.min(16, Math.floor(width * 0.35)));
-  }
-  return Math.max(1, Math.min(width, 8));
+  const width = tableColumnWidth(column);
+  const headerFloor = column.label
+    ? Math.min(width, displayWidth(column.label) + HEADER_RESERVED_WIDTH)
+    : 0;
+  const heuristic = (() => {
+    if ((column.flexGrow ?? 0) > 0) {
+      return Math.max(8, Math.min(18, Math.floor(width * 0.35)));
+    }
+    if (column.align === "right") {
+      return Math.max(3, Math.min(width, 8));
+    }
+    if (width >= 16) {
+      return Math.max(8, Math.min(16, Math.floor(width * 0.35)));
+    }
+    return Math.max(1, Math.min(width, 8));
+  })();
+  return Math.max(heuristic, headerFloor);
 }
 
 function columnFlexWeight(column: TableWidthColumn): number {
   const flexGrow = column.flexGrow ?? 0;
-  const baseWeight = normalizedColumnWidth(column);
+  const baseWeight = tableColumnWidth(column);
   return flexGrow > 0 ? baseWeight * Math.max(1, flexGrow) : baseWeight;
 }
 
@@ -79,7 +146,7 @@ export function buildTableGridTemplateColumns(
   const hasFlexColumn = columns.some((column) => (column.flexGrow ?? 0) > 0);
   return columns
     .map((column) => {
-      const width = normalizedColumnWidth(column);
+      const width = tableColumnWidth(column);
       const minWidth = cellWidthCss(columnMinCh(column));
       if (!fillAvailableWidth) {
         return `minmax(${minWidth}, ${cellWidthCss(width)})`;

--- a/src/core/app-services.ts
+++ b/src/core/app-services.ts
@@ -50,7 +50,10 @@ export function createAppServices({
   const dataProvider: DataProvider = providerRouter;
   const marketData = new MarketDataCoordinator(dataProvider);
   const pluginRegistry = new PluginRegistry(dataProvider, tickerRepository, persistence, { connectionHealth });
-  const newsService = new NewsService({ connectionHealth });
+  const newsService = new NewsService({
+    connectionHealth,
+    pollIntervalMs: () => Math.max(1, config.refreshIntervalMinutes) * 60 * 1000,
+  });
   pluginRegistry.capabilities.register("core", assetDataProvider(providerRouter));
   pluginRegistry.capabilities.register("core", {
     ...newsProvider({

--- a/src/news/aggregator.test.ts
+++ b/src/news/aggregator.test.ts
@@ -51,6 +51,18 @@ function makeCachedSource(id: string, cachedItems: MarketNewsItem[], fetchItems:
   });
 }
 
+function makeFailingSource(id: string): NewsCapability {
+  return newsProvider({
+    id,
+    name: id,
+    provider: {
+      fetchNews: mock(async () => {
+        throw new Error("boom");
+      }),
+    },
+  });
+}
+
 function makeStorySource(id: string, items: MarketNewsItem[], story: MarketNewsItem): NewsCapability {
   return newsProvider({
     id,
@@ -71,6 +83,33 @@ describe("NewsService", () => {
 
   afterEach(() => {
     agg.stop();
+  });
+
+  it("reports an error instead of an empty feed when every source fails", async () => {
+    agg.register(makeFailingSource("broken"));
+    const state = await agg.load({ feed: "latest" });
+
+    expect(state.phase).toBe("error");
+    expect(state.articles).toHaveLength(0);
+  });
+
+  it("stays ready but reports the gap when only some sources fail", async () => {
+    agg.register(makeSource("ok", [makeItem({ url: "https://partial.example.com/1" })]));
+    agg.register(makeFailingSource("broken"));
+    const state = await agg.load({ feed: "latest" });
+
+    expect(state.phase).toBe("ready");
+    expect(state.articles).toHaveLength(1);
+    expect(state.error).toContain("unavailable");
+  });
+
+  it("watchQuery shows loading while the initial fetch is in flight", () => {
+    agg.register(makeSource("watch-loading", [makeItem({ url: "https://loading.example.com/1" })]));
+    const phases: string[] = [];
+    const dispose = agg.watchQuery({ feed: "latest" }, (state) => phases.push(state.phase));
+
+    expect(phases[0]).toBe("loading");
+    dispose();
   });
 
   it("deduplicates by URL, keeping higher importance", async () => {

--- a/src/news/aggregator.ts
+++ b/src/news/aggregator.ts
@@ -17,7 +17,8 @@ import {
 export { buildNewsQueryKey } from "./news-model";
 
 export interface NewsServiceOptions {
-  pollIntervalMs?: number;
+  /** Pass a function to follow the user's configured refresh interval. */
+  pollIntervalMs?: number | (() => number);
   inactiveQueryTtlMs?: number;
   maxInactiveQueries?: number;
   now?: () => number;
@@ -27,12 +28,14 @@ export interface NewsServiceOptions {
 export type NewsQueryListener = (state: NewsQueryState) => void;
 
 const DEFAULT_POLL_INTERVAL_MS = 2 * 60 * 1000;
+const MIN_POLL_INTERVAL_MS = 15 * 1000;
 const DEFAULT_INACTIVE_QUERY_TTL_MS = 10 * 60 * 1000;
 const DEFAULT_MAX_INACTIVE_QUERIES = 50;
 
 interface SourceFetchResult {
   articles: NewsArticle[];
   sourceIds: string[];
+  failedSourceIds: string[];
 }
 
 interface NewsQueryEntry {
@@ -57,15 +60,17 @@ export class NewsService {
   private readonly queries = new Map<string, NewsQueryEntry>();
   private articles: NewsArticle[] = [];
   private version = 0;
-  private pollTimer: ReturnType<typeof setInterval> | null = null;
-  private readonly pollIntervalMs: number;
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  private polling = false;
+  private readonly pollIntervalMs: () => number;
   private readonly inactiveQueryTtlMs: number;
   private readonly maxInactiveQueries: number;
   private readonly now: () => number;
   private readonly connectionHealth?: ConnectionHealthRegistry;
 
   constructor(options: NewsServiceOptions = {}) {
-    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const pollInterval = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.pollIntervalMs = typeof pollInterval === "function" ? pollInterval : () => pollInterval;
     this.inactiveQueryTtlMs = Math.max(1, options.inactiveQueryTtlMs ?? DEFAULT_INACTIVE_QUERY_TTL_MS);
     this.maxInactiveQueries = Math.max(1, Math.floor(options.maxInactiveQueries ?? DEFAULT_MAX_INACTIVE_QUERIES));
     this.now = options.now ?? Date.now;
@@ -75,7 +80,7 @@ export class NewsService {
   register(source: NewsCapability): () => void {
     this.sources.set(source.id, source);
     this.seedCachedSource(source);
-    if (this.pollTimer !== null) {
+    if (this.polling) {
       void this.pollActiveQueries();
     }
     return () => {
@@ -90,15 +95,27 @@ export class NewsService {
   }
 
   start(): void {
-    if (this.pollTimer !== null) return;
-    this.pollTimer = setInterval(() => void this.pollActiveQueries(), this.pollIntervalMs);
+    if (this.polling) return;
+    this.polling = true;
+    this.scheduleNextPoll();
   }
 
   stop(): void {
+    this.polling = false;
     if (this.pollTimer !== null) {
-      clearInterval(this.pollTimer);
+      clearTimeout(this.pollTimer);
       this.pollTimer = null;
     }
+  }
+
+  /** Rescheduled every cycle so a config change takes effect on the next tick. */
+  private scheduleNextPoll(): void {
+    if (!this.polling) return;
+    const interval = Math.max(MIN_POLL_INTERVAL_MS, this.pollIntervalMs());
+    this.pollTimer = setTimeout(() => {
+      this.pollTimer = null;
+      void this.pollActiveQueries().catch(() => {}).then(() => this.scheduleNextPoll());
+    }, interval);
   }
 
   subscribe(listener: () => void): () => void {
@@ -114,8 +131,10 @@ export class NewsService {
 
     const emit = () => listener(this.queries.get(key)?.state ?? createIdleNewsQueryState());
     const unsubscribe = this.subscribe(emit);
+    // Show loading before emitting: the fetch below starts immediately, and an
+    // idle first frame paints an empty pane instead of a loading one.
+    void this.refreshQuery(normalized, true);
     emit();
-    void this.refreshQuery(normalized, false);
 
     let disposed = false;
     return () => {
@@ -205,11 +224,18 @@ export class NewsService {
     const promise = (async () => {
       try {
         const result = await this.fetchFromSources(query);
+        if (result.sourceIds.length === 0 && result.failedSourceIds.length > 0) {
+          throw new Error("News sources unavailable.");
+        }
         const articles = filterNewsArticlesForQuery(dedupeNewsArticles(result.articles), query);
         const state: NewsQueryState = {
           phase: "ready",
           articles,
-          error: null,
+          // A partial failure still has stories, so it stays ready and reports
+          // the gap instead of pretending the feed is complete.
+          error: result.failedSourceIds.length > 0
+            ? `${result.failedSourceIds.length} of ${result.failedSourceIds.length + result.sourceIds.length} news sources unavailable.`
+            : null,
           updatedAt: this.now(),
           sourceIds: result.sourceIds,
         };
@@ -295,6 +321,7 @@ export class NewsService {
 
   private async fetchTickerNews(query: NewsQuery, sources: NewsCapability[]): Promise<SourceFetchResult> {
     let firstEmpty: SourceFetchResult | null = null;
+    const failedSourceIds: string[] = [];
     for (const source of sources) {
       try {
         const articles = (await this.trackSourceRequest(
@@ -302,14 +329,14 @@ export class NewsService {
           "fetchNews",
           () => source.provider.fetchNews(query),
         )).map((article) => markDetailCapableArticle(source, article));
-        const result = { articles, sourceIds: [newsCapabilitySourceId(source)] };
+        const result = { articles, sourceIds: [newsCapabilitySourceId(source)], failedSourceIds };
         if (articles.length > 0) return result;
         firstEmpty ??= result;
       } catch {
-        // Continue to lower-priority sources.
+        failedSourceIds.push(newsCapabilitySourceId(source));
       }
     }
-    return firstEmpty ?? { articles: [], sourceIds: [] };
+    return firstEmpty ?? { articles: [], sourceIds: [], failedSourceIds };
   }
 
   private async fetchMergedNews(query: NewsQuery, sources: NewsCapability[]): Promise<SourceFetchResult> {
@@ -325,12 +352,17 @@ export class NewsService {
     );
     const articles: NewsArticle[] = [];
     const sourceIds: string[] = [];
-    for (const result of settled) {
-      if (result.status !== "fulfilled") continue;
+    const failedSourceIds: string[] = [];
+    settled.forEach((result, index) => {
+      if (result.status !== "fulfilled") {
+        const source = sources[index];
+        if (source) failedSourceIds.push(newsCapabilitySourceId(source));
+        return;
+      }
       articles.push(...result.value.articles);
       sourceIds.push(newsCapabilitySourceId(result.value.source));
-    }
-    return { articles, sourceIds };
+    });
+    return { articles, sourceIds, failedSourceIds };
   }
 
   private trackSourceRequest<T>(

--- a/src/plugins/builtin/account-management/footer.ts
+++ b/src/plugins/builtin/account-management/footer.ts
@@ -1,24 +1,22 @@
 import { useMemo } from "react";
 import { usePaneFooter, type PaneHint } from "../../../components";
-import type { AccountProfile } from "../../../api-client";
-import { resolvePlanAccess } from "../shared/plan-access";
-import { formatPlan, type AccountDraft } from "./model";
-import { t, tf } from "../../../i18n";
+import { t } from "../../../i18n";
 import { useAppLanguage } from "../../../i18n/react";
 
+/**
+ * Email, plan, and visibility are fixed account metadata already rendered in the
+ * tabs, so the footer carries only what changes: the save action and the last
+ * save or error message.
+ */
 export function useAccountManagementFooter({
   busy,
-  draft,
   hasSession,
   message,
-  profile,
   saveProfile,
 }: {
   busy: "profile" | "password" | "alerts" | "billing" | "delete" | null;
-  draft: AccountDraft;
   hasSession: boolean;
   message: { tone: "info" | "success" | "error"; text: string } | null;
-  profile: AccountProfile | null;
   saveProfile: () => Promise<void>;
 }) {
   const language = useAppLanguage();
@@ -26,20 +24,11 @@ export function useAccountManagementFooter({
     { id: "save", key: "Ctrl+S", label: t("save"), onPress: () => { void saveProfile(); }, disabled: !!busy || !hasSession },
   ], [busy, hasSession, language, saveProfile]);
 
-  const planAccess = resolvePlanAccess(profile);
-  const planText = planAccess.isTrialActive
-    ? tf("Pro trial · {days}d left", { days: planAccess.trialDaysLeft })
-    : formatPlan(profile?.plan);
-
   usePaneFooter("account-management", () => ({
     info: [
+      ...(busy ? [{ id: "busy", parts: [{ text: t("saving"), tone: "muted" as const }] }] : []),
       ...(message ? [{ id: "status", parts: [{ text: message.text, tone: message.tone === "error" ? "negative" as const : message.tone === "success" ? "positive" as const : "muted" as const }] }] : []),
-      ...(profile ? [
-        { id: "account", parts: [{ text: profile.email, tone: "muted" as const }] },
-        { id: "plan", parts: [{ text: planText, tone: planAccess.hasProAccess ? "positive" as const : "muted" as const }] },
-        { id: "visibility", parts: [{ text: draft.profilePublic ? t("public") : t("private"), tone: "muted" as const }] },
-      ] : []),
     ],
     hints: footerHints,
-  }), [draft.profilePublic, footerHints, language, message, planAccess.hasProAccess, planText, profile]);
+  }), [busy, footerHints, language, message]);
 }

--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -408,9 +408,13 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
     () => portfolios.find((portfolio) => portfolio.id === draft.sharedPortfolioId) ?? null,
     [draft.sharedPortfolioId, portfolios],
   );
+  // Only the Profile tab renders the shared-portfolio preview, so the quote,
+  // FX, and chart requests below stay off on every other tab.
   const portfolioTickers = useMemo(
-    () => draft.sharedPortfolioId ? getPortfolioPositionTickers(tickers, draft.sharedPortfolioId) : [],
-    [draft.sharedPortfolioId, tickers],
+    () => activeTab === "profile" && draft.sharedPortfolioId
+      ? getPortfolioPositionTickers(tickers, draft.sharedPortfolioId)
+      : [],
+    [activeTab, draft.sharedPortfolioId, tickers],
   );
   const marketFinancials = useTickerFinancialsMap(portfolioTickers);
   const financials = useMemo(() => {
@@ -460,7 +464,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
       chartEntries,
       financials,
       columnContext,
-    }),
+    }).returns,
     [chartEntries, chartTargets, columnContext, financials],
   );
   const spyReturnSeries = useMemo(
@@ -494,10 +498,13 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
   );
   useEffect(() => {
     const portfolioId = selectedAnalyticsPortfolio?.id;
-    if (!portfolioId) return;
+    // Off the Profile tab the preview is computed from no holdings, so publishing
+    // it would overwrite real analytics with blanks.
+    if (!portfolioId || activeTab !== "profile") return;
     const changed = setSyncedProfileAnalytics(portfolioId, localAnalyticsPreview.publicAnalytics);
     if (changed) cloudSyncController.schedulePush("profile-analytics");
   }, [
+    activeTab,
     localAnalyticsPreview.publicAnalytics?.oneYearReturn,
     localAnalyticsPreview.publicAnalytics?.spyBeta,
     selectedAnalyticsPortfolio?.id,
@@ -820,10 +827,8 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
 
   useAccountManagementFooter({
     busy,
-    draft,
     hasSession,
     message,
-    profile,
     saveProfile,
   });
 

--- a/src/plugins/builtin/ai/screener/footer.ts
+++ b/src/plugins/builtin/ai/screener/footer.ts
@@ -12,6 +12,7 @@ interface UseAiScreenerFooterOptions {
   onCancelRun: () => void;
   onCloseEditor: () => void;
   onEdit: () => void;
+  onRefresh: () => void;
   onSaveEditor: () => void;
 }
 
@@ -24,6 +25,7 @@ export function useAiScreenerFooter({
   onCancelRun,
   onCloseEditor,
   onEdit,
+  onRefresh,
   onSaveEditor,
 }: UseAiScreenerFooterOptions) {
   const language = useAppLanguage();
@@ -95,6 +97,7 @@ export function useAiScreenerFooter({
     onCancelRun,
     onCloseEditor,
     onEdit,
+    onRefresh,
     onSaveEditor,
     runState,
   ]);

--- a/src/plugins/builtin/ai/screener/pane.test.tsx
+++ b/src/plugins/builtin/ai/screener/pane.test.tsx
@@ -242,6 +242,7 @@ describe("AiScreenerPane", () => {
     expect(frame).toContain("Initial pass");
     expect(frame).toContain("Strong cash flow durability");
     expect(frame.match(/Strong cash flow durability/g)?.length).toBe(1);
+    // `r` refreshes every pane, so it is never advertised per pane.
     expect(frame).not.toContain("[r]efresh");
     expect(frame).not.toContain("[Shift+R]");
     const lines = frame.split("\n");

--- a/src/plugins/builtin/ai/screener/pane.tsx
+++ b/src/plugins/builtin/ai/screener/pane.tsx
@@ -52,6 +52,7 @@ import {
   AI_DEFAULT_PROVIDER_SETTING_KEY,
   resolveAiPaneSelection,
 } from "../pane-settings";
+import { AGE_TICK_MS } from "../../shared/auto-refresh";
 import { useLiveStreamingSetting } from "../../shared/live-streaming";
 
 export function AiScreenerPane({ focused, width, height }: PaneProps) {
@@ -90,8 +91,9 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
   const initializedRef = useRef(false);
   const pendingInitialRunRef = useRef<string | null>(null);
 
+  // Same cadence as every other relative-age label in the app.
   useEffect(() => {
-    const timer = setInterval(() => setNow(Date.now()), 60_000);
+    const timer = setInterval(() => setNow(Date.now()), AGE_TICK_MS);
     return () => clearInterval(timer);
   }, []);
 
@@ -341,6 +343,7 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
     onCancelRun: cancelRun,
     onCloseEditor: closeEditor,
     onEdit: editActiveTab,
+    onRefresh: refreshActiveTab,
     onSaveEditor: saveEditor,
   });
 

--- a/src/plugins/builtin/ai/screener/results-view.tsx
+++ b/src/plugins/builtin/ai/screener/results-view.tsx
@@ -78,6 +78,14 @@ export function AiScreenerResultsView({
         </Box>
       )}
 
+      {activeTab && promptDirty && !isRunningActiveTab && activeTab.results.length > 0 && (
+        <Box flexDirection="column" paddingX={1} paddingTop={1} height={1}>
+          <Text fg={warningColor}>
+            {t("Prompt or provider changed. These matches are from the previous run.")}
+          </Text>
+        </Box>
+      )}
+
       {activeTab && summaryLines.length > 0 && !activeTab.lastError && (
         <Box flexDirection="column" paddingX={1}>
           {summaryLines.map((line, index) => (

--- a/src/plugins/builtin/ai/screener/runner.ts
+++ b/src/plugins/builtin/ai/screener/runner.ts
@@ -98,8 +98,9 @@ export function useAiScreenerRunner({
     }));
 
     let rawOutput = "";
+    let run: AiRunController | null = null;
     try {
-      const run = runAiPrompt({
+      run = runAiPrompt({
         providerId: provider.id,
         prompt,
         modelId: selection.modelId ?? undefined,
@@ -141,10 +142,13 @@ export function useAiScreenerRunner({
         debugOutput: rawOutput.trim() || current.debugOutput,
       }));
     } finally {
-      if (runRef.current) {
+      // Only tear down if this run is still the active one: a newer run may have
+      // replaced it while this one was finishing, and clearing the ref then would
+      // leave the new run uncancellable.
+      if (runRef.current === run) {
         runRef.current = null;
+        setRunState((current) => (current?.tabId === tab.id ? null : current));
       }
-      setRunState((current) => (current?.tabId === tab.id ? null : current));
     }
   }, [dataProvider, dispatch, providers, resolveSelection, tabs, tickers, upsertTab]);
 

--- a/src/plugins/builtin/ai/workspace/pane.tsx
+++ b/src/plugins/builtin/ai/workspace/pane.tsx
@@ -695,6 +695,15 @@ export function LocalAgentWorkspacePane({ paneId, focused, width, height }: Pane
   const showSidebar = shouldShowPaneSidebar(workspace.threads.length, width, height, 1);
   const sidebarWidth = showSidebar ? getPaneSidebarWidth(width, !!nativePaneChrome) : 0;
   const contentWidth = Math.max(20, width - sidebarWidth - (nativePaneChrome ? 0 : 2));
+  // Separators, prev/next arrows, and "+ New" take about 30 cells on top of the
+  // provider/model label.
+  const narrowHeaderTitleWidth = Math.max(
+    6,
+    contentWidth - 30 - formatAiRunnerSelection(
+      providerLabel(activeThreadProviderSupported ? activeSelection.providerId : activeThread.providerId),
+      activeThreadProviderSupported ? activeSelection.modelId : activeThread.modelId,
+    ).length,
+  );
   const composerHeight = nativePaneChrome ? 3 : 2;
 
   return (
@@ -759,7 +768,7 @@ export function LocalAgentWorkspacePane({ paneId, focused, width, height }: Pane
       )}
 
       <Box flexDirection="column" flexGrow={1} minWidth={0} overflow="hidden">
-        <Box height={1} paddingX={1} flexDirection="row">
+        <Box height={1} paddingX={1} flexDirection="row" overflow="hidden">
           <Text fg={colors.positive} attributes={TextAttributes.BOLD}>
             {formatAiRunnerSelection(
               providerLabel(activeThreadProviderSupported ? activeSelection.providerId : activeThread.providerId),
@@ -771,7 +780,9 @@ export function LocalAgentWorkspacePane({ paneId, focused, width, height }: Pane
             <>
               <Text fg={colors.textDim}> · </Text>
               <Text fg={colors.textBright} onMouseDown={() => cycleThread(-1)} style={{ cursor: "pointer" }}>‹ </Text>
-              <Text fg={colors.text}>{activeThread.title}</Text>
+              {/* Truncated so a long title cannot push the prev, next, and New
+                  controls off the single header row. */}
+              <Text fg={colors.text}>{truncateWithEllipsis(activeThread.title, narrowHeaderTitleWidth)}</Text>
               <Text fg={colors.textBright} onMouseDown={() => cycleThread(1)} style={{ cursor: "pointer" }}> ›</Text>
               <Text fg={colors.textBright} onMouseDown={() => { if (!busyRef.current) beginCreateThread(); }} style={{ cursor: "pointer" }}>  + New</Text>
             </>

--- a/src/plugins/builtin/alerts/alert-engine.ts
+++ b/src/plugins/builtin/alerts/alert-engine.ts
@@ -42,6 +42,19 @@ export function serializeAlerts(alerts: AlertRule[]): string {
   return JSON.stringify(alerts);
 }
 
+/**
+ * Non-null when the stored blob is not valid alert JSON. Without this a corrupt
+ * store deserializes to `[]` and the pane claims the user has no alerts.
+ */
+export function readAlertsStoreError(json: string): string | null {
+  if (!json.trim()) return null;
+  try {
+    return Array.isArray(JSON.parse(json)) ? null : "Saved alerts are not a list.";
+  } catch (error) {
+    return error instanceof Error ? error.message : "Saved alerts could not be read.";
+  }
+}
+
 export function deserializeAlerts(json: string): AlertRule[] {
   try {
     const parsed = JSON.parse(json);

--- a/src/plugins/builtin/alerts/constants.ts
+++ b/src/plugins/builtin/alerts/constants.ts
@@ -1,3 +1,4 @@
 export const ALERTS_KEY = "alerts";
+/** Fallback cadence when the pane's Check interval setting is unset. */
 export const POLL_INTERVAL_MS = 30_000;
-export const PANE_QUOTE_REFRESH_MS = 30_000;
+export const POLL_SECONDS_KEY = "pollSeconds";

--- a/src/plugins/builtin/alerts/index.tsx
+++ b/src/plugins/builtin/alerts/index.tsx
@@ -1,4 +1,5 @@
 import type { GloomPlugin } from "../../../types/plugin";
+import type { Quote } from "../../../types/financials";
 import { formatMarketPrice } from "../../../market-data/market/format";
 import {
   createAlert,
@@ -9,7 +10,7 @@ import {
   parseAlertCommandValues,
   parseAlertShortcutValues,
 } from "./command";
-import { POLL_INTERVAL_MS } from "./constants";
+import { POLL_INTERVAL_MS, POLL_SECONDS_KEY } from "./constants";
 import { AlertsPane } from "./pane";
 import {
   createQuoteErrorMessage,
@@ -22,7 +23,7 @@ import {
   saveAlerts,
 } from "./storage";
 
-let pollInterval: ReturnType<typeof setInterval> | null = null;
+let pollTimer: ReturnType<typeof setTimeout> | null = null;
 
 export const alertsPlugin: GloomPlugin = {
   id: "alerts",
@@ -99,40 +100,44 @@ export const alertsPlugin: GloomPlugin = {
 
       ctx.log.info("poll", { total: alerts.length, active: activeAlerts.length });
 
+      // One batched pass over the distinct symbols: the alerts pane reads the same
+      // persisted store, so this is the only place that talks to the provider.
+      const symbols = [...new Set(activeAlerts.map((alert) => alert.symbol))];
+      const results = await Promise.all(symbols.map(async (symbol): Promise<[string, Quote | string]> => {
+        try {
+          return [symbol, await resolveAlertQuote(ctx.marketData, symbol)];
+        } catch (err) {
+          ctx.log.warn("poll: no quote", { symbol, error: String(err) });
+          return [symbol, createQuoteErrorMessage(symbol, err)];
+        }
+      }));
+      const quotes = new Map<string, Quote | string>(results);
+
       let changed = false;
       for (const alert of alerts) {
         if (alert.status !== "active") continue;
-        try {
-          const quote = await ctx.marketData.getQuote(alert.symbol, "");
-          if (!quote || typeof quote.price !== "number") {
-            ctx.log.warn("poll: no quote", { symbol: alert.symbol });
-            Object.assign(alert, quoteErrorAlertFields(`No quote found for "${alert.symbol}".`));
-            changed = true;
-            continue;
-          }
-
-          const triggered = evaluateAlert(alert, quote.price);
-
-          if (triggered) {
-            alert.status = "triggered";
-            alert.triggeredAt = Date.now();
-            ctx.log.info("poll: TRIGGERED", { symbol: alert.symbol, price: quote.price });
-            ctx.notify({
-              body: `${formatAlertDescription(alert)} triggered at ${quote.price}`,
-              type: "success",
-              desktop: "always",
-              persistent: true,
-              sound: "Glass",
-            });
-            changed = true;
-          }
-          Object.assign(alert, quoteAlertFields(quote));
+        const quote = quotes.get(alert.symbol);
+        if (quote === undefined) continue;
+        if (typeof quote === "string") {
+          Object.assign(alert, quoteErrorAlertFields(quote));
           changed = true;
-        } catch (err) {
-          ctx.log.error("poll: error", { symbol: alert.symbol, error: String(err) });
-          Object.assign(alert, quoteErrorAlertFields(createQuoteErrorMessage(alert.symbol, err)));
-          changed = true;
+          continue;
         }
+
+        if (evaluateAlert(alert, quote.price)) {
+          alert.status = "triggered";
+          alert.triggeredAt = Date.now();
+          ctx.log.info("poll: TRIGGERED", { symbol: alert.symbol, price: quote.price });
+          ctx.notify({
+            body: `${formatAlertDescription(alert)} triggered at ${quote.price}`,
+            type: "success",
+            desktop: "always",
+            persistent: true,
+            sound: "Glass",
+          });
+        }
+        Object.assign(alert, quoteAlertFields(quote));
+        changed = true;
       }
 
       if (changed) {
@@ -140,8 +145,17 @@ export const alertsPlugin: GloomPlugin = {
       }
     };
 
-    poll();
-    pollInterval = setInterval(poll, POLL_INTERVAL_MS);
+    // Re-armed each cycle so a change to the pane's Check interval setting takes
+    // effect on the next tick without a restart.
+    const scheduleNextPoll = () => {
+      const seconds = Number(ctx.paneSettings?.get<string>("alerts", POLL_SECONDS_KEY));
+      const delay = Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : POLL_INTERVAL_MS;
+      pollTimer = setTimeout(() => {
+        void poll().finally(scheduleNextPoll);
+      }, delay);
+    };
+
+    void poll().finally(scheduleNextPoll);
 
     ctx.registerPane({
       id: "alerts",
@@ -151,6 +165,23 @@ export const alertsPlugin: GloomPlugin = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 82, height: 20 },
+      settings: {
+        title: "Alerts Settings",
+        fields: [
+          {
+            key: POLL_SECONDS_KEY,
+            label: "Check interval",
+            description: "How often active alerts are re-quoted.",
+            type: "select",
+            options: [
+              { value: "15", label: "15 seconds" },
+              { value: "30", label: "30 seconds" },
+              { value: "60", label: "1 minute" },
+              { value: "300", label: "5 minutes" },
+            ],
+          },
+        ],
+      },
     });
 
     ctx.registerPaneTemplate({
@@ -164,9 +195,9 @@ export const alertsPlugin: GloomPlugin = {
   },
 
   dispose() {
-    if (pollInterval) {
-      clearInterval(pollInterval);
-      pollInterval = null;
+    if (pollTimer) {
+      clearTimeout(pollTimer);
+      pollTimer = null;
     }
   },
 };

--- a/src/plugins/builtin/alerts/pane.tsx
+++ b/src/plugins/builtin/alerts/pane.tsx
@@ -9,12 +9,13 @@ import {
 import { colors } from "../../../theme/colors";
 import { TextAttributes } from "../../../ui";
 import type { PaneProps } from "../../../types/plugin";
-import { useMarketData, usePluginAppActions, usePluginConfigState } from "../../runtime";
+import { usePluginAppActions, usePluginConfigState } from "../../runtime";
 import {
   deserializeAlerts,
+  readAlertsStoreError,
   serializeAlerts,
 } from "./alert-engine";
-import { ALERTS_KEY, PANE_QUOTE_REFRESH_MS } from "./constants";
+import { ALERTS_KEY } from "./constants";
 import {
   conditionLabel,
   formatAlertDistance,
@@ -23,12 +24,6 @@ import {
   formatQuoteChecked,
   relativeTime,
 } from "./format";
-import {
-  createQuoteErrorMessage,
-  quoteAlertFields,
-  quoteErrorAlertFields,
-  resolveAlertQuote,
-} from "./quotes";
 import type { AlertRule } from "./types";
 
 type AlertColumnId =
@@ -63,13 +58,12 @@ const ALERT_TABLE_CONTENT_WIDTH = ALERT_COLUMNS.reduce(
 
 export function AlertsPane({ focused, width, height, close }: PaneProps) {
   const [alertsJson, setAlertsJson] = usePluginConfigState<string>(ALERTS_KEY, "[]");
-  const marketData = useMarketData();
   const { openPluginCommandWorkflow } = usePluginAppActions();
   const [selectedIdx, setSelectedIdx] = useState(0);
-  const marketDataId = marketData?.id ?? null;
   const showHorizontalScrollbar = ALERT_TABLE_CONTENT_WIDTH > width;
+  const storeError = useMemo(() => readAlertsStoreError(alertsJson), [alertsJson]);
 
-  const { alerts, rows, activeCount, triggeredCount } = useMemo(() => {
+  const { alerts, rows, quoteError } = useMemo(() => {
     const parsed = deserializeAlerts(alertsJson);
     const activeAlerts = parsed.filter((a) => a.status === "active");
     const triggeredAlerts = parsed
@@ -79,8 +73,7 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
     return {
       alerts: parsed,
       rows: [...activeAlerts, ...triggeredAlerts],
-      activeCount: activeAlerts.length,
-      triggeredCount: triggeredAlerts.length,
+      quoteError: parsed.find((alert) => alert.lastCheckError)?.lastCheckError ?? null,
     };
   }, [alertsJson]);
 
@@ -119,56 +112,15 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
     if (selected) deleteAlert(selected.id);
   }, [deleteAlert, rows, selectedIdx]);
 
-  useEffect(() => {
-    if (!marketData || rows.length === 0) return;
-    const now = Date.now();
-    const dueAlerts = rows.filter((alert) => (
-      !alert.lastCheckedAt || now - alert.lastCheckedAt > PANE_QUOTE_REFRESH_MS
-    ));
-    if (dueAlerts.length === 0) return;
-
-    let cancelled = false;
-    void Promise.all(dueAlerts.map(async (alert) => {
-      try {
-        const quote = await resolveAlertQuote(marketData, alert.symbol);
-        return { id: alert.id, patch: quoteAlertFields(quote) };
-      } catch (error) {
-        return {
-          id: alert.id,
-          patch: quoteErrorAlertFields(createQuoteErrorMessage(alert.symbol, error)),
-        };
-      }
-    })).then((updates) => {
-      if (cancelled || updates.length === 0) return;
-      const patches = new Map(updates.map((update) => [update.id, update.patch]));
-      savePaneAlerts((current) => current.map((alert) => {
-        const patch = patches.get(alert.id);
-        return patch ? { ...alert, ...patch } : alert;
-      }));
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [marketDataId, rows, savePaneAlerts]);
+  // Quotes come from the plugin's single background poll, which writes into the
+  // same persisted store, so the pane never fetches on its own.
 
   usePaneFooter("alerts", () => ({
-    info: [
-      {
-        id: "active",
-        parts: [
-          { text: String(activeCount), tone: "value", bold: true },
-          { text: "active", tone: "label" },
-        ],
-      },
-      ...(triggeredCount > 0 ? [{
-        id: "triggered",
-        parts: [
-          { text: String(triggeredCount), tone: "warning" as const, bold: true },
-          { text: "triggered", tone: "label" as const },
-        ],
-      }] : []),
-    ],
+    info: storeError
+      ? [{ id: "store-error", parts: [{ text: storeError, tone: "warning" as const }] }]
+      : quoteError
+        ? [{ id: "quote-error", parts: [{ text: quoteError, tone: "warning" as const }] }]
+        : [],
     hints: [
       { id: "add", key: "a", label: "dd alert", onPress: startAddAlert },
       {
@@ -180,11 +132,11 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
       },
     ],
   }), [
-    activeCount,
     deleteSelectedAlert,
+    quoteError,
     rows.length,
     startAddAlert,
-    triggeredCount,
+    storeError,
   ]);
 
   useEffect(() => {
@@ -298,8 +250,8 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
         if (alert.status === "triggered") rearmAlert(alert.id);
       }}
       renderCell={renderCell}
-      emptyStateTitle="No alerts"
-      emptyStateHint="Use the action bar to create one."
+      emptyStateTitle={storeError ? "Saved alerts could not be read." : "No alerts"}
+      emptyStateHint={storeError ?? "Press a to add a price alert."}
       showHorizontalScrollbar={showHorizontalScrollbar}
     />
   );

--- a/src/plugins/builtin/analytics/index.tsx
+++ b/src/plugins/builtin/analytics/index.tsx
@@ -1,7 +1,7 @@
 import { Box, Text } from "../../../ui";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TextAttributes } from "../../../ui";
-import { Tabs } from "../../../components";
+import { EmptyState, Tabs } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import { colors } from "../../../theme/colors";
@@ -44,7 +44,7 @@ import {
   type SectorSortPreference,
   type SectorTableRow,
 } from "./sector-model";
-import { resolvePortfolioId, resolveTemplatePortfolioId } from "./portfolio-selection";
+import { describePortfolioTab, resolvePortfolioId, resolveTemplatePortfolioId } from "./portfolio-selection";
 import {
   AnalyticsMetricsPanel,
   PortfolioHistorySection,
@@ -81,8 +81,11 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
     [activePortfolioId, portfolios],
   );
   const portfolioTabs = useMemo(
-    () => portfolios.map((portfolio) => ({ label: portfolio.name, value: portfolio.id })),
-    [portfolios],
+    () => portfolios.map((portfolio) => ({
+      label: describePortfolioTab(portfolio, config.brokerInstances),
+      value: portfolio.id,
+    })),
+    [config.brokerInstances, portfolios],
   );
 
   const handlePortfolioSelect = useCallback((portfolioId: string) => {
@@ -132,7 +135,7 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
     [brokerPerformance.performance],
   );
   const accountStateInput = useMemo(() => ({ brokerAccounts, config }), [brokerAccounts, config]);
-  const accountState = usePortfolioAccountState(activePortfolio, accountStateInput);
+  const { accountState, accountsError } = usePortfolioAccountState(activePortfolio, accountStateInput);
   const trackedCurrencies = useMemo(
     () => buildTrackedCurrencies(portfolioTickers, financials, baseCurrency),
     [baseCurrency, financials, portfolioTickers],
@@ -158,7 +161,7 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
     [activePortfolioId, baseCurrency, effectiveExchangeRates, financials, portfolioTickers],
   );
 
-  const portfolioReturnSeries = useMemo(
+  const returnSeriesResult = useMemo(
     () => buildPortfolioReturnSeries({
       chartTargets,
       chartEntries,
@@ -167,6 +170,7 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
     }),
     [chartEntries, chartTargets, columnContext, financials],
   );
+  const portfolioReturnSeries = returnSeriesResult.returns;
 
   const portfolioReturns = useMemo(
     () => portfolioReturnSeries?.map((point) => point.value) ?? null,
@@ -213,8 +217,13 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
   );
 
   const riskRows = useMemo(
-    () => buildAnalyticsRiskRows({ sharpe, beta }),
-    [beta, sharpe],
+    () => buildAnalyticsRiskRows({
+      sharpe,
+      beta,
+      coverage: returnSeriesResult.coverage,
+      missingCount: returnSeriesResult.missingCount,
+    }),
+    [beta, returnSeriesResult.coverage, returnSeriesResult.missingCount, sharpe],
   );
   const metricsHeight = summaryRows.length + riskRows.length + 5;
   const availableHistoryChartHeight = height - metricsHeight - 7;
@@ -267,9 +276,13 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
 
           {!hasPositions ? (
             <Box paddingX={1} paddingY={1}>
-              <Text fg={colors.textMuted}>
-                No positions found for {activePortfolio?.name ?? "this portfolio"}
-              </Text>
+              <EmptyState
+                title="No positions in this portfolio."
+                message={accountsError ?? undefined}
+                hint={accountsError
+                  ? "Reconnect the broker in the Brokers pane (BR), then refresh."
+                  : "Add holdings from the Portfolio pane (PF), or connect a broker in BR to sync them."}
+              />
             </Box>
           ) : (
             <>

--- a/src/plugins/builtin/analytics/pane-model.ts
+++ b/src/plugins/builtin/analytics/pane-model.ts
@@ -78,6 +78,14 @@ export function buildPortfolioChartTargets(portfolioTickers: TickerRecord[]): Po
   });
 }
 
+export interface PortfolioReturnSeriesResult {
+  returns: DatedReturn[] | null;
+  /** Share of portfolio value whose history actually made it into the weighted series, 0..1. */
+  coverage: number;
+  /** Holdings dropped because their history was missing, still loading, or too short. */
+  missingCount: number;
+}
+
 export function buildPortfolioReturnSeries({
   chartTargets,
   chartEntries,
@@ -88,24 +96,35 @@ export function buildPortfolioReturnSeries({
   chartEntries: ChartEntryLookup;
   financials: Map<string, TickerFinancials>;
   columnContext: ColumnContext;
-}): DatedReturn[] | null {
+}): PortfolioReturnSeriesResult {
   const weightedSeries: WeightedReturnSeries[] = [];
+  let coveredValue = 0;
+  let totalValue = 0;
+  let missingCount = 0;
   for (const { ticker, request } of chartTargets) {
+    const value = getPortfolioPositionValue(ticker, financials.get(ticker.metadata.ticker), columnContext);
+    const weight = value == null ? 0 : Math.abs(value);
+    totalValue += weight;
+
     const key = buildChartKey(request);
     const entry = chartEntries.get(key);
     const history = entry?.data ?? entry?.lastGoodData ?? null;
-    if (!history || history.length < 11) continue;
+    const returns = history && history.length >= 11 ? computeDatedReturns(history) : [];
+    if (value == null || returns.length < 10) {
+      missingCount += 1;
+      continue;
+    }
 
-    const returns = computeDatedReturns(history);
-    if (returns.length < 10) continue;
-
-    const value = getPortfolioPositionValue(ticker, financials.get(ticker.metadata.ticker), columnContext);
-    if (value == null) continue;
+    coveredValue += weight;
     weightedSeries.push({ weight: value, returns });
   }
 
   const returns = computeWeightedPortfolioReturns(weightedSeries);
-  return returns.length > 0 ? returns : null;
+  return {
+    returns: returns.length > 0 ? returns : null,
+    coverage: totalValue > 0 ? coveredValue / totalValue : chartTargets.length === 0 ? 1 : 0,
+    missingCount,
+  };
 }
 
 export function buildBenchmarkReturnSeries(
@@ -256,27 +275,42 @@ export function buildAnalyticsSummaryRows({
   return rows;
 }
 
+/**
+ * Names the slice of the portfolio the risk numbers actually describe, so a
+ * Sharpe built on half the book is never presented as the whole book.
+ */
+export function formatRiskCoverage(coverage: number, missingCount: number): string | null {
+  if (missingCount <= 0 || coverage >= 0.999) return null;
+  return `${formatPercentRaw(coverage * 100)} of value, ${missingCount} holding${missingCount === 1 ? "" : "s"} pending`;
+}
+
 export function buildAnalyticsRiskRows({
   sharpe,
   beta,
+  coverage = 1,
+  missingCount = 0,
 }: {
   sharpe: number | null;
   beta: number | null;
+  coverage?: number;
+  missingCount?: number;
 }): AnalyticsMetricRow[] {
+  const partial = formatRiskCoverage(coverage, missingCount);
+  const partialSuffix = partial ? ` - partial: ${partial}` : "";
   return [
     sharpe !== null
       ? {
         id: "sharpe",
         label: "Sharpe Ratio",
         value: formatNumber(sharpe, 2),
-        detail: sharpeLabel(sharpe),
-        color: sharpeColor(sharpe),
+        detail: `${sharpeLabel(sharpe)}${partialSuffix}`,
+        color: partial ? colors.textMuted : sharpeColor(sharpe),
       }
       : {
         id: "sharpe",
         label: "Sharpe Ratio",
         value: "—",
-        detail: "insufficient data",
+        detail: partial ?? "insufficient data",
         color: colors.textMuted,
       },
     beta !== null
@@ -284,14 +318,14 @@ export function buildAnalyticsRiskRows({
         id: "beta",
         label: "Beta (SPY)",
         value: formatNumber(beta, 2),
-        detail: betaLabel(beta),
-        color: betaColor(beta),
+        detail: `${betaLabel(beta)}${partialSuffix}`,
+        color: partial ? colors.textMuted : betaColor(beta),
       }
       : {
         id: "beta",
         label: "Beta (SPY)",
         value: "—",
-        detail: "insufficient data",
+        detail: partial ?? "insufficient data",
         color: colors.textMuted,
       },
   ];

--- a/src/plugins/builtin/analytics/portfolio-selection.ts
+++ b/src/plugins/builtin/analytics/portfolio-selection.ts
@@ -1,4 +1,23 @@
+import type { BrokerInstanceConfig } from "../../../types/config";
 import type { Portfolio } from "../../../types/ticker";
+
+/** Broker account ids look like "U13268153" or "DU1234567": a letter prefix then digits. */
+const RAW_ACCOUNT_ID = /^[A-Z]{1,2}\d{5,}$/;
+
+/**
+ * A portfolio auto-created from a broker sync is named after the raw account id,
+ * which is meaningless on its own, so prefix it with the broker instance label.
+ */
+export function describePortfolioTab(
+  portfolio: Portfolio,
+  brokerInstances: BrokerInstanceConfig[] | undefined,
+): string {
+  const name = portfolio.name.trim();
+  if (!RAW_ACCOUNT_ID.test(name)) return portfolio.name;
+  const instance = brokerInstances?.find((candidate) => candidate.id === portfolio.brokerInstanceId);
+  const prefix = instance?.label?.trim() || instance?.brokerType?.toUpperCase();
+  return prefix ? `${prefix} ${name}` : name;
+}
 
 export function resolvePortfolioId(portfolios: Portfolio[], portfolioId: string | null | undefined): string | null {
   if (!portfolioId) return null;

--- a/src/plugins/builtin/analytics/view.tsx
+++ b/src/plugins/builtin/analytics/view.tsx
@@ -2,6 +2,8 @@ import { Box, Text, TextAttributes } from "../../../ui";
 import {
   DataTableView,
   StaticChartSurface,
+  loadingText,
+  unavailableText,
 } from "../../../components";
 import type { StaticChartSurfaceProps } from "../../../components/chart/static/chart/surface";
 import type { ProjectedChartPoint } from "../../../components/chart/core/data";
@@ -125,15 +127,15 @@ export function PortfolioHistorySection({
   if (loading) {
     return (
       <Box height={1} paddingX={1}>
-        <Text fg={colors.textDim}>Loading IBKR history...</Text>
+        <Text fg={colors.textDim}>{loadingText("IBKR history")}</Text>
       </Box>
     );
   }
 
   if (error) {
     return (
-      <Box height={1} paddingX={1}>
-        <Text fg={colors.textDim}>IBKR history unavailable</Text>
+      <Box height={1} paddingX={1} overflow="hidden">
+        <Text fg={colors.warning}>{`${unavailableText("IBKR history")} ${error}`}</Text>
       </Box>
     );
   }

--- a/src/plugins/builtin/broker-manager/detail.tsx
+++ b/src/plugins/builtin/broker-manager/detail.tsx
@@ -25,6 +25,7 @@ function BrokerConfigFieldEditor({
   previous,
   adapter,
   focused,
+  width,
   onFocus,
   onChange,
   onSubmit,
@@ -34,6 +35,7 @@ function BrokerConfigFieldEditor({
   previous: BrokerInstanceConfig;
   adapter: BrokerAdapter;
   focused: boolean;
+  width: number;
   onFocus: () => void;
   onChange: (key: string, value: string) => void;
   onSubmit: () => void;
@@ -65,7 +67,7 @@ function BrokerConfigFieldEditor({
         label={brokerFieldLabel(field, focused)}
         value={value}
         focused={focused}
-        width={34}
+        width={width}
         type={field.type === "password" ? "password" : "text"}
         placeholder={field.type === "password" && previousPassword ? t(PRESERVED_PASSWORD_HINT) : field.placeholder ? t(field.placeholder) : undefined}
         hint={field.placeholder ? t(field.placeholder) : undefined}
@@ -130,6 +132,8 @@ export function BrokerDetailContent({
 }) {
   if (!row) return <Box flexGrow={1} />;
 
+  // Never wider than the detail pane, so a narrow floating pane shrinks instead of clipping.
+  const fieldWidth = Math.max(12, Math.min(34, width - 2));
   const detailStatusMessage = isBrokerErrorMessage(message) ? message : row.message || t("No status message.");
   const editAdapter = row.adapter;
 
@@ -161,7 +165,7 @@ export function BrokerDetailContent({
                 label={activeEditKey === "label" ? `> ${t("Profile Label")}` : `  ${t("Profile Label")}`}
                 value={editDraft.label}
                 focused={activeEditKey === "label"}
-                width={34}
+                width={fieldWidth}
                 onChange={onDraftLabelChange}
                 onSubmit={onSaveEdit}
               />
@@ -187,6 +191,7 @@ export function BrokerDetailContent({
                 previous={row.instance}
                 adapter={editAdapter}
                 focused={activeEditKey === field.key}
+                width={fieldWidth}
                 onFocus={() => onActiveEditKeyChange(field.key)}
                 onChange={onDraftValueChange}
                 onSubmit={onSaveEdit}

--- a/src/plugins/builtin/broker-manager/footer.ts
+++ b/src/plugins/builtin/broker-manager/footer.ts
@@ -17,25 +17,20 @@ export function useBrokerManagerFooter({
   canRemoveSelected,
   canUseSelectedBroker,
   editing,
-  onCancelEdit,
 }: {
   actions: BrokerManagerFooterActions;
   canOpenSelectedAction: boolean;
   canRemoveSelected: boolean;
   canUseSelectedBroker: boolean;
   editing: boolean;
-  onCancelEdit: () => void;
 }) {
   const actionsRef = useRef(actions);
   actionsRef.current = actions;
 
   const footerHints = useMemo<PaneHint[]>(() => {
-    if (editing) {
-      return [
-        { id: "save", key: "enter", label: "save", onPress: () => actionsRef.current.saveEdit().catch(() => {}) },
-        { id: "cancel", key: "esc", label: "cancel", onPress: onCancelEdit },
-      ];
-    }
+    // Enter to save and Esc to cancel are app-wide form conventions, and the edit
+    // form already renders its own Save and Cancel buttons, so the footer stays empty.
+    if (editing) return [];
 
     const hints: PaneHint[] = [
       { id: "add", key: "a", label: "dd", onPress: () => actionsRef.current.openAddBroker() },
@@ -54,7 +49,7 @@ export function useBrokerManagerFooter({
       hints.push({ id: "disconnect", key: "d", label: "isconnect", onPress: () => actionsRef.current.removeSelected().catch(() => {}) });
     }
     return hints;
-  }, [canOpenSelectedAction, canRemoveSelected, canUseSelectedBroker, editing, onCancelEdit]);
+  }, [canOpenSelectedAction, canRemoveSelected, canUseSelectedBroker, editing]);
 
   usePaneFooter("broker-manager", () => ({
     hints: footerHints,

--- a/src/plugins/builtin/broker-manager/index.tsx
+++ b/src/plugins/builtin/broker-manager/index.tsx
@@ -148,7 +148,6 @@ export function BrokersPane({ focused, width, height }: PaneProps) {
     canRemoveSelected,
     canUseSelectedBroker,
     editing: !!editDraft,
-    onCancelEdit: cancelEdit,
   });
 
   useBrokerManagerKeyboard({
@@ -251,10 +250,7 @@ export function BrokersPane({ focused, width, height }: PaneProps) {
   return (
     <Box flexDirection="column" flexGrow={1} paddingX={1}>
       <Box height={1} flexDirection="row">
-        <Box flexGrow={1} flexDirection="row">
-          <Box width={8}>
-            <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{t("Brokers")}</Text>
-          </Box>
+        <Box flexGrow={1} flexDirection="row" overflow="hidden">
           <Text fg={colors.textDim}>{tf("{profiles} profiles · {connected} connected · {issues} issues", { profiles: rows.length, connected: connectedCount, issues: errorCount })}</Text>
         </Box>
         {busy && <Text fg={colors.textDim}>{busy}</Text>}
@@ -295,7 +291,6 @@ export function BrokersPane({ focused, width, height }: PaneProps) {
           renderCell={renderBrokerCell}
           emptyStateTitle={t("No broker profiles.")}
           emptyStateHint={t("Add a broker profile to test connections and sync positions.")}
-          showHorizontalScrollbar={false}
         />
       </Box>
     </Box>

--- a/src/plugins/builtin/buildout/detail/ui.tsx
+++ b/src/plugins/builtin/buildout/detail/ui.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { Box, Text, TextAttributes } from "../../../../ui";
 import { Button, TickerBadgeList } from "../../../../components";
+import { ExternalLinkText } from "../../../../components/ui/external-link";
 import { MarkdownText } from "../../../../components/markdown-text";
 import { colors } from "../../../../theme/colors";
 import type { InlineTickerCatalogEntry } from "../../../../state/hooks/inline-tickers";
@@ -160,6 +161,7 @@ export function SourceDetailLines({
       const flatTitle = source.title ?? source.snippet ?? source.reasoning;
       const flat = flatUrl || flatTitle
         ? [{
+          url: flatUrl ?? null,
           domain: source.domain ?? domainFromUrl(flatUrl) ?? null,
           title: flatTitle,
           note: source.reasoning ?? source.snippet,
@@ -167,6 +169,7 @@ export function SourceDetailLines({
         }]
         : [];
       const citations = (source.citations ?? []).map((citation) => ({
+        url: citation.url ?? null,
         domain: domainFromUrl(citation.url) ?? null,
         title: citation.title ?? citation.excerpts?.[0] ?? null,
         note: citation.excerpts?.[0] ?? null,
@@ -181,12 +184,20 @@ export function SourceDetailLines({
   return (
     <Box marginTop={1} flexDirection="column" width={width}>
       {entries.map((entry, index) => {
-        const prefix = entry.domain ? `${entry.domain}${entry.tier ? ` T${entry.tier}` : ""}: ` : "";
+        const prefix = entry.domain ? `${entry.domain}${entry.tier ? ` T${entry.tier}` : ""}` : "";
         const body = entry.title ?? entry.note ?? "";
+        const bodyText = truncate(prefix ? `: ${body}` : body, Math.max(0, width - prefix.length));
         return (
-          <Text key={`${entry.domain ?? "source"}:${index}`} fg={colors.textMuted}>
-            {truncate(`${prefix}${body}`, width)}
-          </Text>
+          <Box key={`${entry.domain ?? "source"}:${index}`} flexDirection="row" height={1} width={width} overflow="hidden">
+            {prefix ? (
+              entry.url ? (
+                <ExternalLinkText url={entry.url} label={prefix} color={colors.textMuted} />
+              ) : (
+                <Text fg={colors.textMuted}>{prefix}</Text>
+              )
+            ) : null}
+            <Text fg={colors.textMuted}>{bodyText}</Text>
+          </Box>
         );
       })}
     </Box>

--- a/src/plugins/builtin/buildout/pane/header.tsx
+++ b/src/plugins/builtin/buildout/pane/header.tsx
@@ -39,6 +39,7 @@ export function BuildoutPaneHeader({
       {showCompanyListCrumb ? (
         <Box height={1} flexDirection="row" paddingX={1}>
           <Box
+            style={{ cursor: "pointer" }}
             onMouseDown={(event: any) => {
               event.preventDefault();
               onCloseCompanyList();

--- a/src/plugins/builtin/changelog/index.tsx
+++ b/src/plugins/builtin/changelog/index.tsx
@@ -4,7 +4,7 @@ import { useShortcut } from "../../../react/input";
 import { usePaneInstance } from "../../../state/app/context";
 import {
   DataTableStackView,
-  Spinner,
+  PaneStatusBody,
   useExternalLinkFooter,
   type DataTableCell,
   type DataTableColumn,
@@ -26,9 +26,16 @@ import {
 } from "./model";
 
 const CHANGELOG_LIMIT = 40;
+/** GitHub can hang or be blocked outright; the pane must still reach a verdict. */
+const CHANGELOG_TIMEOUT_MS = 5_000;
+const CHANGELOG_CACHE_TTL_MS = 10 * 60 * 1000;
+
+// ponytail: process-lifetime cache, move into the updater module if other
+// surfaces start reading releases too.
+let cachedReleases: { releases: ChangelogRelease[]; fetchedAt: number } | null = null;
 
 type ChangelogColumn = DataTableColumn & { id: ChangelogColumnId };
-type LoadStatus = "idle" | "loading" | "loaded" | "error";
+type LoadStatus = "loading" | "loaded" | "error";
 
 function formatReleaseDate(value: string): string {
   const timestamp = Date.parse(value);
@@ -94,9 +101,8 @@ function ChangelogDetail({
         focusable={false}
       >
         <Box flexDirection="column" width={lineWidth}>
-          <Text fg={colors.textMuted}>
-            {`${formatReleaseDate(release.publishedAt)} | ${release.version}`}
-          </Text>
+          {/* The stack title already carries the version. */}
+          <Text fg={colors.textMuted}>{formatReleaseDate(release.publishedAt)}</Text>
           <Text>{" "}</Text>
           <MarkdownText text={release.body} lineWidth={lineWidth} />
         </Box>
@@ -108,8 +114,10 @@ function ChangelogDetail({
 function ChangelogPane({ focused, width, height }: PaneProps) {
   const paneInstance = usePaneInstance();
   const requestedVersion = paneInstance?.params?.version ?? null;
-  const [releases, setReleases] = useState<ChangelogRelease[]>([]);
-  const [status, setStatus] = useState<LoadStatus>("idle");
+  const [releases, setReleases] = useState<ChangelogRelease[]>(() => cachedReleases?.releases ?? []);
+  // The mount effect starts the request immediately, so the first paint is a
+  // spinner and never "No changelog entries found".
+  const [status, setStatus] = useState<LoadStatus>(() => (cachedReleases ? "loaded" : "loading"));
   const [error, setError] = useState<string | null>(null);
   const [selectedReleaseId, setSelectedReleaseId] = useState<string | null>(null);
   const [sortPreference, setSortPreference] = useState(DEFAULT_CHANGELOG_SORT);
@@ -118,27 +126,39 @@ function ChangelogPane({ focused, width, height }: PaneProps) {
   const abortRef = useRef<AbortController | null>(null);
   const requestedVersionOpenedRef = useRef(false);
 
-  const loadReleases = useCallback(async () => {
+  const loadReleases = useCallback(async (force = false) => {
+    if (!force && cachedReleases && Date.now() - cachedReleases.fetchedAt < CHANGELOG_CACHE_TTL_MS) {
+      setReleases(cachedReleases.releases);
+      setError(null);
+      setStatus("loaded");
+      return;
+    }
+
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, CHANGELOG_TIMEOUT_MS);
     setStatus("loading");
     setError(null);
 
     try {
       const nextReleases = await fetchChangelogReleases(CHANGELOG_LIMIT, controller.signal);
+      cachedReleases = { releases: nextReleases, fetchedAt: Date.now() };
       setReleases(nextReleases);
       setStatus("loaded");
     } catch (loadError) {
-      if (
-        loadError instanceof Error
-        && loadError.name === "AbortError"
-      ) {
-        return;
-      }
-      setError(loadError instanceof Error ? loadError.message : "Failed to load changelog");
+      // A newer load or an unmount owns the state now; a timeout does not.
+      if (!timedOut && abortRef.current !== controller) return;
+      setError(timedOut
+        ? "GitHub did not answer in time"
+        : loadError instanceof Error ? loadError.message : "Failed to load changelog");
       setStatus("error");
     } finally {
+      clearTimeout(timer);
       if (abortRef.current === controller) {
         abortRef.current = null;
       }
@@ -200,7 +220,7 @@ function ChangelogPane({ focused, width, height }: PaneProps) {
     if (!focused || !isPlainKey(event, "r")) return;
     event.stopPropagation?.();
     event.preventDefault?.();
-    void loadReleases();
+    void loadReleases(true);
   });
 
   const columns = useMemo(() => buildColumns(width, releases), [releases, width]);
@@ -295,25 +315,13 @@ function ChangelogPane({ focused, width, height }: PaneProps) {
     info: footerInfo,
   });
 
-  if (status === "loading" && releases.length === 0) {
-    return <Spinner label="Loading changelog..." />;
-  }
-
-  if (status === "error" && releases.length === 0) {
+  if (releases.length === 0 && (status === "loading" || status === "error")) {
     return (
-      <Box paddingX={1} paddingY={1}>
-        <Text fg={colors.textDim}>
-          {`Failed to load changelog: ${error ?? "unknown error"}`}
-        </Text>
-      </Box>
-    );
-  }
-
-  if (sortedReleases.length === 0) {
-    return (
-      <Box paddingX={1} paddingY={1}>
-        <Text fg={colors.textDim}>No changelog entries found.</Text>
-      </Box>
+      <PaneStatusBody
+        loading={status === "loading"}
+        error={status === "error" ? error ?? "unknown error" : null}
+        subject="Changelog"
+      />
     );
   }
 

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -429,14 +429,17 @@ function ChartComposerSurface({
     openSeriesEditor,
     openResolutionPicker,
     openRangePicker,
+    reload: resolution.reload,
   });
   currentActionsRef.current = {
     openSeriesEditor,
     openResolutionPicker,
     openRangePicker,
+    reload: resolution.reload,
   };
   const footerSeries = useCallback(() => { void currentActionsRef.current.openSeriesEditor(); }, []);
   const footerResolution = useCallback(() => { void currentActionsRef.current.openResolutionPicker(); }, []);
+  const footerReload = useCallback(() => { currentActionsRef.current.reload(); }, []);
   const footerRange = useCallback(() => { void currentActionsRef.current.openRangePicker(); }, []);
 
   useShortcut((event) => {
@@ -474,11 +477,12 @@ function ChartComposerSurface({
       { id: "series", key: "s", label: "eries", onPress: footerSeries },
       { id: "indicators", key: "i", label: "ndicators", onPress: openIndicators, disabled: indicatorsDisabled },
       { id: "formulas", key: "f", label: "ormulas", onPress: openFormulas, disabled: formulasDisabled },
-      { id: "resolution", key: "r", label: "es", onPress: footerResolution },
+      { id: "resolution", key: "t", label: "imeframe", onPress: footerResolution },
       { id: "range", key: "1-8", label: "range", onPress: footerRange },
     ],
   }), [
     footerRange,
+    footerReload,
     footerResolution,
     footerSeries,
     formulasDisabled,

--- a/src/plugins/builtin/chart-composer/quick-add.tsx
+++ b/src/plugins/builtin/chart-composer/quick-add.tsx
@@ -119,7 +119,7 @@ export function ChartSeriesQuickAdd({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const defaultInstrument = useMemo(() => defaultCatalogInstrument(spec), [spec]);
-  const { suggestions, loading } = useSeriesCatalogSuggestions({
+  const { suggestions, loading, error: searchError } = useSeriesCatalogSuggestions({
     query,
     defaultInstrument,
     enabled: active,
@@ -129,10 +129,13 @@ export function ChartSeriesQuickAdd({
     : Math.max(8, Math.min(IDLE_QUICK_ADD_WIDTH, width));
   const drawerStatus = error
     ?? (loading && suggestions.length === 0
-      ? "Searching instruments…"
-      : active && query.trim().length > 0 && suggestions.length === 0
-        ? "No matching security or metric."
-        : null);
+      ? "Searching instruments..."
+      // A failed lookup is not zero matches, so it keeps its own message.
+      : searchError && suggestions.length === 0
+        ? searchError
+        : active && query.trim().length > 0 && suggestions.length === 0
+          ? "No matching security or metric."
+          : null);
   const maximumDrawerHeight = Math.max(
     0,
     Math.min(

--- a/src/plugins/builtin/chart-composer/shortcuts.test.ts
+++ b/src/plugins/builtin/chart-composer/shortcuts.test.ts
@@ -34,8 +34,9 @@ describe("resolveChartComposerShortcut", () => {
     expect(resolveChartComposerShortcut(keyEvent("s"), 8)).toBe("series");
     expect(resolveChartComposerShortcut(keyEvent("w"), 8)).toBeNull();
     expect(resolveChartComposerShortcut(keyEvent("m"), 8)).toBeNull();
-    expect(resolveChartComposerShortcut(keyEvent("r"), 8)).toBe("resolution");
-    expect(resolveChartComposerShortcut(keyEvent("r", { shift: true }), 8)).toBe("reload");
+    expect(resolveChartComposerShortcut(keyEvent("r"), 8)).toBe("reload");
+    expect(resolveChartComposerShortcut(keyEvent("t"), 8)).toBe("resolution");
+    expect(resolveChartComposerShortcut(keyEvent("r", { shift: true }), 8)).toBeNull();
     expect(resolveChartComposerShortcut(keyEvent("3"), 8)).toEqual({ type: "range", index: 2 });
     expect(resolveChartComposerShortcut(keyEvent("9"), 8)).toBeNull();
     expect(resolveChartComposerShortcut(keyEvent("3", { alt: true }), 8)).toBeNull();

--- a/src/plugins/builtin/chart-composer/shortcuts.ts
+++ b/src/plugins/builtin/chart-composer/shortcuts.ts
@@ -13,15 +13,11 @@ export function resolveChartComposerShortcut(
 ): ChartComposerShortcut | null {
   if (event.defaultPrevented || event.propagationStopped || event.targetEditable) return null;
 
-  const exactShiftReload = event.name === "r"
-    && event.shift
-    && !event.ctrl
-    && !event.meta
-    && !event.super
-    && !event.alt;
-  if (exactShiftReload) return "reload";
+  // `r` is the app-wide refresh key, so it reloads here too and the resolution
+  // picker moved to its own mnemonic, [t]imeframe.
   if (isPlainKey(event, "s")) return "series";
-  if (isPlainKey(event, "r")) return "resolution";
+  if (isPlainKey(event, "r")) return "reload";
+  if (isPlainKey(event, "t")) return "resolution";
   if (!isPlainKey(event, event.name ?? "")) return null;
 
   const rangeIndex = Number(event.name) - 1;

--- a/src/plugins/builtin/chart-composer/use-series-catalog.ts
+++ b/src/plugins/builtin/chart-composer/use-series-catalog.ts
@@ -18,6 +18,12 @@ export interface SeriesCatalogSearchResult {
   suggestions: SeriesCatalogSuggestion[];
   instruments: SeriesCatalogInstrument[];
   loading: boolean;
+  /** Set when a lookup failed, so an outage is never reported as zero matches. */
+  error: string | null;
+}
+
+function searchFailureMessage(error: unknown): string {
+  return error instanceof Error && error.message.trim() ? error.message : "Series search failed.";
 }
 
 /** Shared smart-series search used by both inline quick-add and the full editor. */
@@ -36,32 +42,41 @@ export function useSeriesCatalogSuggestions({
     query: string;
     suggestions: SeriesCatalogSuggestion[];
     loading: boolean;
-  }>({ query: "", suggestions: [], loading: false });
+    error: string | null;
+  }>({ query: "", suggestions: [], loading: false, error: null });
   const [search, setSearch] = useState<{
     query: string;
     instruments: SeriesCatalogInstrument[];
     loading: boolean;
-  }>({ query: "", instruments: [], loading: false });
+    error: string | null;
+  }>({ query: "", instruments: [], loading: false, error: null });
 
   useEffect(() => {
     const normalizedQuery = query.trim();
     const registry = getSharedRegistry();
     if (!enabled || !normalizedQuery || !registry) {
-      setProviderSearch({ query: "", suggestions: [], loading: false });
+      setProviderSearch({ query: "", suggestions: [], loading: false, error: null });
       return;
     }
     let cancelled = false;
     const controller = new AbortController();
-    setProviderSearch({ query: normalizedQuery, suggestions: [], loading: true });
+    setProviderSearch({ query: normalizedQuery, suggestions: [], loading: true, error: null });
     const timer = setTimeout(() => {
       void searchChartSeriesCapabilities(registry, normalizedQuery, 8, controller.signal).then((items) => {
         if (!cancelled) setProviderSearch({
           query: normalizedQuery,
           suggestions: buildCapabilitySeriesSuggestions(items),
           loading: false,
+          error: null,
         });
-      }).catch(() => {
-        if (!cancelled) setProviderSearch({ query: normalizedQuery, suggestions: [], loading: false });
+      }).catch((error: unknown) => {
+        if (controller.signal.aborted || cancelled) return;
+        setProviderSearch({
+          query: normalizedQuery,
+          suggestions: [],
+          loading: false,
+          error: searchFailureMessage(error),
+        });
       });
     }, 250);
     return () => {
@@ -74,18 +89,18 @@ export function useSeriesCatalogSuggestions({
   useEffect(() => {
     const instrumentQuery = analysis.instrumentQuery.trim();
     if (!enabled || !instrumentQuery || analysis.directInstrument) {
-      setSearch({ query: "", instruments: [], loading: false });
+      setSearch({ query: "", instruments: [], loading: false, error: null });
       return;
     }
 
     const registry = getSharedRegistry();
     if (!registry) {
-      setSearch({ query: instrumentQuery, instruments: [], loading: false });
+      setSearch({ query: instrumentQuery, instruments: [], loading: false, error: null });
       return;
     }
 
     let cancelled = false;
-    setSearch({ query: instrumentQuery, instruments: [], loading: true });
+    setSearch({ query: instrumentQuery, instruments: [], loading: true, error: null });
     const timer = setTimeout(() => {
       void searchTickerCandidates({
         query: instrumentQuery,
@@ -110,9 +125,17 @@ export function useSeriesCatalogSuggestions({
               : {}),
           })),
           loading: false,
+          error: null,
         });
-      }).catch(() => {
-        if (!cancelled) setSearch({ query: instrumentQuery, instruments: [], loading: false });
+      }).catch((error: unknown) => {
+        if (!cancelled) {
+          setSearch({
+            query: instrumentQuery,
+            instruments: [],
+            loading: false,
+            error: searchFailureMessage(error),
+          });
+        }
       });
     }, 80);
 
@@ -136,5 +159,7 @@ export function useSeriesCatalogSuggestions({
     instruments,
     loading: (search.loading && search.query === analysis.instrumentQuery)
       || (providerSearch.loading && providerSearch.query === query.trim()),
+    error: (search.query === analysis.instrumentQuery ? search.error : null)
+      ?? (providerSearch.query === query.trim() ? providerSearch.error : null),
   };
 }

--- a/src/plugins/builtin/chat/content/index.tsx
+++ b/src/plugins/builtin/chat/content/index.tsx
@@ -116,6 +116,9 @@ export function ChatContent({
     const nextRows = estimateComposerHeight(draft, composerTextWidthRef.current);
     setComposerRows((current) => (current === nextRows ? current : nextRows));
   }, []);
+  const retryMessages = useCallback(() => {
+    void controller.refreshChannelMessages(channelId).catch(() => {});
+  }, [channelId, controller]);
   const {
     channels,
     channelsLoading,
@@ -125,6 +128,7 @@ export function ChatContent({
     loading,
     loadingOlderMessages,
     messages,
+    messagesError,
     onlineCount,
     replyTo,
     setReplyTo,
@@ -573,6 +577,8 @@ export function ChatContent({
         jumpToMessage={jumpToMessage}
         loading={loading}
         loadingOlderMessages={loadingOlderMessages}
+        messagesError={messagesError}
+        onRetryMessages={retryMessages}
         messageAreaHeight={messageAreaHeight}
         messageBodyWidth={messageBodyWidth}
         messages={messages}

--- a/src/plugins/builtin/chat/content/snapshot.ts
+++ b/src/plugins/builtin/chat/content/snapshot.ts
@@ -83,6 +83,7 @@ export function useChatSnapshotState({
   const [hasSavedSession, setHasSavedSession] = useState(initialSnapshot.hasSavedSession);
   const [user, setUser] = useState<{ id: string; username: string; emailVerified: boolean } | null>(initialSnapshot.user);
   const [loading, setLoading] = useState(initialSnapshot.loading);
+  const [messagesError, setMessagesError] = useState(initialSnapshot.messagesError);
   const [loadingOlderMessages, setLoadingOlderMessages] = useState(initialSnapshot.loadingOlderMessages);
   const [hasOlderMessages, setHasOlderMessages] = useState(initialSnapshot.hasOlderMessages);
   const [replyTo, setReplyTo] = useState<ChatMessage | null>(() => resolveReplyTo(initialSnapshot));
@@ -113,6 +114,7 @@ export function useChatSnapshotState({
       setHasSavedSession(snapshot.hasSavedSession);
       setUser(snapshot.user);
       setLoading(snapshot.loading);
+      setMessagesError(snapshot.messagesError);
       setLoadingOlderMessages(snapshot.loadingOlderMessages);
       setHasOlderMessages(snapshot.hasOlderMessages);
       syncDraftFromSnapshot({
@@ -157,6 +159,7 @@ export function useChatSnapshotState({
     loading,
     loadingOlderMessages,
     messages,
+    messagesError,
     onlineCount,
     replyTo,
     setReplyTo,

--- a/src/plugins/builtin/chat/content/transcript.tsx
+++ b/src/plugins/builtin/chat/content/transcript.tsx
@@ -1,6 +1,7 @@
 import { Box, ScrollBox, Text, type ScrollBoxRenderable } from "../../../../ui";
 import type { Dispatch, SetStateAction } from "react";
 import type { InlineTickerCatalogEntry } from "../../../../state/hooks/inline-tickers";
+import { Button } from "../../../../components";
 import { colors } from "../../../../theme/colors";
 import { t } from "../../../../i18n";
 import type { ChatMessage, ChatUserSummary } from "../../../../api-client";
@@ -25,6 +26,8 @@ interface ChatTranscriptProps {
   jumpToMessage: (messageId: string) => void;
   loading: boolean;
   loadingOlderMessages: boolean;
+  messagesError: string | null;
+  onRetryMessages: () => void;
   messageAreaHeight: number;
   messageBodyWidth: number;
   messages: ChatMessage[];
@@ -57,6 +60,8 @@ export function ChatTranscript({
   jumpToMessage,
   loading,
   loadingOlderMessages,
+  messagesError,
+  onRetryMessages,
   messageAreaHeight,
   messageBodyWidth,
   messages,
@@ -96,6 +101,11 @@ export function ChatTranscript({
         {loading && messages.length === 0 ? (
           <Box alignItems="center" justifyContent="center" flexGrow={1}>
             <Text fg={colors.textDim}>{t("Loading...")}</Text>
+          </Box>
+        ) : messagesError && messages.length === 0 ? (
+          // A failed load must not read as an empty channel.
+          <Box alignItems="center" justifyContent="center" flexGrow={1} flexDirection="column" gap={1}>
+            <Text fg={colors.warning}>{messagesError}</Text>
           </Box>
         ) : messages.length === 0 && (
           <Box alignItems="center" justifyContent="center" flexGrow={1}>

--- a/src/plugins/builtin/chat/controller/channels.ts
+++ b/src/plugins/builtin/chat/controller/channels.ts
@@ -25,6 +25,7 @@ export class ChatControllerChannels {
   private onlineCount = 0;
   private channelsLoading = false;
   private channelsPromise: Promise<void> | null = null;
+  private presencePromise: Promise<void> | null = null;
 
   constructor(private readonly options: ChatControllerChannelsOptions) {}
 
@@ -82,10 +83,19 @@ export class ChatControllerChannels {
     return request;
   }
 
+  /** Single-flight: every open chat pane calls this on mount. */
   async refreshPresence(): Promise<void> {
-    const presence = await apiClient.getChatPresence();
-    this.onlineCount = presence.onlineCount;
-    this.options.emit();
+    if (this.presencePromise) return this.presencePromise;
+    const request = apiClient.getChatPresence()
+      .then((presence) => {
+        this.onlineCount = presence.onlineCount;
+        this.options.emit();
+      })
+      .finally(() => {
+        this.presencePromise = null;
+      });
+    this.presencePromise = request;
+    return request;
   }
 
   async refreshChatState(): Promise<void> {

--- a/src/plugins/builtin/chat/controller/index.ts
+++ b/src/plugins/builtin/chat/controller/index.ts
@@ -190,7 +190,19 @@ export class ChatController {
     return this.storage.ensureChannelState(channelId);
   }
 
+  /** Single-flight: every open chat pane calls this on mount. */
   async refreshSession(): Promise<void> {
+    if (this.sessionRefreshPromise) return this.sessionRefreshPromise;
+    const request = this.runSessionRefresh().finally(() => {
+      this.sessionRefreshPromise = null;
+    });
+    this.sessionRefreshPromise = request;
+    return request;
+  }
+
+  private sessionRefreshPromise: Promise<void> | null = null;
+
+  private async runSessionRefresh(): Promise<void> {
     return refreshChatControllerSession({
       applySignedOut: () => this.applySignedOutSession(),
       channelStates: this.storage.channelStates,

--- a/src/plugins/builtin/chat/controller/lifecycle.ts
+++ b/src/plugins/builtin/chat/controller/lifecycle.ts
@@ -32,6 +32,7 @@ function resetChannelRuntimeState(channel: ChannelRuntimeState): void {
 
 function disposeChannelRuntimeState(channel: ChannelRuntimeState): void {
   channel.messagesLoading = false;
+  channel.messagesError = null;
   channel.olderMessagesLoading = false;
   channel.refreshMessagesPromise = null;
   channel.loadOlderMessagesPromise = null;

--- a/src/plugins/builtin/chat/controller/message-loading.ts
+++ b/src/plugins/builtin/chat/controller/message-loading.ts
@@ -32,6 +32,7 @@ export class ChatControllerMessageLoading {
     const channel = this.options.ensureChannelState(channelId);
     if (channel.refreshMessagesPromise) return channel.refreshMessagesPromise;
 
+    channel.messagesError = null;
     if (options.showLoading) {
       channel.messagesLoading = true;
       this.options.emit(channelId);
@@ -45,7 +46,10 @@ export class ChatControllerMessageLoading {
         this.options.persistChannelState(nextChannelId);
       },
     })
-      .catch(() => {
+      .catch((error: unknown) => {
+        channel.messagesError = error instanceof Error && error.message.trim()
+          ? error.message
+          : "Could not load messages.";
         this.options.persistChannelState(channelId);
       })
       .finally(() => {

--- a/src/plugins/builtin/chat/controller/state.ts
+++ b/src/plugins/builtin/chat/controller/state.ts
@@ -48,6 +48,8 @@ export interface ChatControllerSnapshot {
   channelStates: ChatChannelState[];
   channelsLoading: boolean;
   loading: boolean;
+  /** Last message-load failure for this channel, or null. */
+  messagesError: string | null;
   loadingOlderMessages: boolean;
   hasOlderMessages: boolean;
   hasSavedSession: boolean;
@@ -69,6 +71,8 @@ export type MergeMessagesOptions = { countUnread?: boolean };
 export interface ChannelRuntimeState {
   hydrated: boolean;
   messagesLoading: boolean;
+  /** Last message-load failure, so an empty transcript is never mistaken for "no messages". */
+  messagesError: string | null;
   olderMessagesLoading: boolean;
   refreshMessagesPromise: Promise<void> | null;
   loadOlderMessagesPromise: Promise<void> | null;
@@ -108,6 +112,7 @@ export function createEmptyChannelState(): ChannelRuntimeState {
   return {
     hydrated: false,
     messagesLoading: false,
+    messagesError: null,
     olderMessagesLoading: false,
     refreshMessagesPromise: null,
     loadOlderMessagesPromise: null,

--- a/src/plugins/builtin/chat/controller/view.ts
+++ b/src/plugins/builtin/chat/controller/view.ts
@@ -66,6 +66,7 @@ export class ChatControllerView {
       channelStates: this.options.getChannelStateSnapshots(),
       channelsLoading: this.options.isChannelsLoading(),
       loading: !this.options.isSessionChecked() || channel.messagesLoading,
+      messagesError: channel.messagesError,
       loadingOlderMessages: channel.olderMessagesLoading,
       hasOlderMessages: channel.messages.length > 0 && !channel.reachedOldestMessage,
       hasSavedSession: this.options.hasSessionToken(),

--- a/src/plugins/builtin/cloud-tweets/table.tsx
+++ b/src/plugins/builtin/cloud-tweets/table.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { Box, ScrollBox, Text, TextAttributes } from "../../../ui";
 import {
   DataTableStackView,
+  PaneStatusBody,
   TickerBadgeList,
   type DataTableCell,
   type DataTableKeyEvent,
@@ -37,6 +38,29 @@ import { usePaneStatusLinkFooter } from "../shared/pane-footer";
 
 function isAuthError(error: string | null): boolean {
   return !!error && /unauthorized|verification/i.test(error);
+}
+
+// Result rows only lived in table state, so switching feed tabs refetched an
+// identical search. Cached per request key for the life of the process; `r`
+// still forces a fresh search.
+// ponytail: in-memory only, move to plugin state if results must survive restarts
+const TWEET_RESULT_CACHE = new Map<string, { data: CloudTweetSearchResponse; fetchedAt: number }>();
+const TWEET_CACHE_TTL_MS = 5 * 60 * 1000;
+// Every edited query is its own key, so the map is capped instead of growing
+// with each keystroke-sized search.
+const TWEET_CACHE_MAX_ENTRIES = 20;
+
+function cacheTweetResult(requestKey: string, data: CloudTweetSearchResponse): void {
+  TWEET_RESULT_CACHE.set(requestKey, { data, fetchedAt: Date.now() });
+  while (TWEET_RESULT_CACHE.size > TWEET_CACHE_MAX_ENTRIES) {
+    const oldest = TWEET_RESULT_CACHE.keys().next().value;
+    if (oldest === undefined) break;
+    TWEET_RESULT_CACHE.delete(oldest);
+  }
+}
+
+function cachedTweetResult(requestKey: string): { data: CloudTweetSearchResponse; fetchedAt: number } | undefined {
+  return TWEET_RESULT_CACHE.get(requestKey);
 }
 
 function TweetDetail({
@@ -97,10 +121,15 @@ function useTweetSearchData(
   onError?: (message: string) => void,
   enabled = true,
 ) {
-  const [state, setState] = useState<TweetLoadState>({
-    data: null,
-    loading: false,
-    error: null,
+  // Starts loading when a request is about to run so the first paint is not a
+  // premature "No tweets".
+  const [state, setState] = useState<TweetLoadState>(() => {
+    const cached = cachedTweetResult(requestKey);
+    return {
+      data: cached?.data ?? null,
+      loading: enabled && !cached,
+      error: null,
+    };
   });
   const fetchGenRef = useRef(0);
   const onResultRef = useRef(onResult);
@@ -108,7 +137,7 @@ function useTweetSearchData(
   onResultRef.current = onResult;
   onErrorRef.current = onError;
 
-  const reload = useCallback(() => {
+  const reload = useCallback((force = false) => {
     if (!enabled) {
       fetchGenRef.current += 1;
       setState((current) => (
@@ -121,9 +150,16 @@ function useTweetSearchData(
 
     fetchGenRef.current += 1;
     const gen = fetchGenRef.current;
-    setState((current) => ({ ...current, loading: true, error: null }));
+    const cached = force ? undefined : cachedTweetResult(requestKey);
+    const fresh = cached && Date.now() - cached.fetchedAt < TWEET_CACHE_TTL_MS;
+    if (cached) setState({ data: cached.data, loading: !fresh, error: null });
+    if (fresh) return;
+    // A forced reload keeps the rows on screen; a new request key must not show
+    // the previous feed's tweets while its own search runs.
+    if (!cached) setState((current) => ({ data: force ? current.data : null, loading: true, error: null }));
     load()
       .then((data) => {
+        cacheTweetResult(requestKey, data);
         if (fetchGenRef.current !== gen) return;
         setState({ data, loading: false, error: null });
         onResultRef.current?.(data);
@@ -134,7 +170,7 @@ function useTweetSearchData(
         setState({ data: null, loading: false, error: message });
         onErrorRef.current?.(message);
       });
-  }, [enabled, load]);
+  }, [enabled, load, requestKey]);
 
   useEffect(() => {
     reload();
@@ -241,7 +277,7 @@ export function TweetSearchTable({
     if (event.name !== "r") return false;
     event.preventDefault?.();
     event.stopPropagation?.();
-    reload();
+    reload(true);
     return true;
   }, [onFocusSearch, reload]);
 
@@ -293,9 +329,20 @@ export function TweetSearchTable({
     }
   }, []);
 
+  // Owns the whole empty body so loading, failure, and "nothing found" each get
+  // their own rows instead of the table's single run-on empty line.
   const emptyContent = error && isAuthError(error)
     ? <CloudAuthNotice message={error} showSignup />
-    : undefined;
+    : (
+      <PaneStatusBody
+        loading={loading}
+        error={error}
+        empty
+        subject="Tweets"
+        emptyTitle={emptyStateTitle ?? "No tweets"}
+        emptyMessage={emptyStateHint ?? data?.query}
+      />
+    );
 
   return (
     <DataTableStackView<CloudTweetPayload, TweetColumn>
@@ -327,7 +374,7 @@ export function TweetSearchTable({
       getItemKey={(tweet) => tweet.id}
       renderCell={renderCell}
       emptyContent={emptyContent}
-      emptyStateTitle={loading ? "Loading tweets..." : error ?? emptyStateTitle ?? "No tweets"}
+      emptyStateTitle={emptyStateTitle ?? "No tweets"}
       emptyStateHint={emptyStateHint ?? data?.query}
     />
   );

--- a/src/plugins/builtin/congress-trades/detail.tsx
+++ b/src/plugins/builtin/congress-trades/detail.tsx
@@ -72,9 +72,9 @@ export function TradeDetail({
   return (
     <ScrollBox scrollY focusable={false} flexGrow={1} paddingX={1}>
       <Box flexDirection="column" width={lineWidth}>
-        <DetailLine label="member" value={`${trade.memberName} ${trade.stateDistrict}`} tone="value" bold />
+        {/* The detail title already carries the member and ticker. */}
+        <DetailLine label="district" value={trade.stateDistrict || "--"} tone="muted" />
         <DetailLine label="side" value={trade.transactionType} tone={trade.side === "BUY" ? "positive" : trade.side === "SELL" ? "negative" : "warning"} />
-        <DetailLine label="ticker" value={trade.ticker ?? "--"} tone={trade.ticker ? "positive" : "muted"} bold={!!trade.ticker} />
         <DetailLine label="asset" value={truncate(trade.assetName, Math.max(10, lineWidth - 16))} />
         <DetailLine label="amount" value={trade.amount} tone="value" />
         <DetailLine label="owner" value={trade.owner} />

--- a/src/plugins/builtin/congress-trades/footer.ts
+++ b/src/plugins/builtin/congress-trades/footer.ts
@@ -36,18 +36,15 @@ export function useCongressTradesFooter({
 }) {
   usePaneFooter(CONGRESS_TRADES_PANE_ID, () => ({
     info: [
-      { id: "source", parts: [{ text: "House PTR", tone: "value" as const }] },
       ...(payload ? [
-        { id: "filings", parts: [{ text: `${payload.filingsScanned}/${payload.filingCount} filings`, tone: "muted" as const }] },
-        { id: "trades", parts: [{ text: `${payload.trades.length} trades`, tone: "muted" as const }] },
         { id: "asof", parts: [{ text: `updated ${formatTimeAgo(payload.asOf)}`, tone: "muted" as const }] },
       ] : []),
       ...(status === "loading" ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
     ],
-    hints: detailMode?.kind !== "member" && activeTab === "trades"
+    hints: detailMode?.kind !== "member" && activeTab === "trades" && (detailTrade ?? selectedTrade)
       ? [
-          { id: "member", key: "m", label: "ember", onPress: openSelectedTradeMember, disabled: !selectedTrade },
+          { id: "member", key: "m", label: "ember", onPress: openSelectedTradeMember },
           { id: "ticker", key: "t", label: "icker", onPress: openSelectedTicker, disabled: !(detailTrade?.ticker ?? selectedTrade?.ticker) },
           { id: "open", key: "o", label: "pen", onPress: openSelectedTradeSource, disabled: !(detailTrade ?? selectedTrade)?.sourceUrl },
         ]

--- a/src/plugins/builtin/congress-trades/pane.tsx
+++ b/src/plugins/builtin/congress-trades/pane.tsx
@@ -2,11 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, useRendererHost } from "../../../ui";
 import {
   DataTableStackView,
-  EmptyState,
-  Spinner,
+  PaneStatusBody,
   Tabs,
 } from "../../../components";
 import { useDebouncedPluginPaneState, usePluginPaneState } from "../../runtime";
+import { useAutoRefresh } from "../shared/auto-refresh";
 import { useInlineTickerOpener } from "../../../state/hooks/inline-tickers";
 import {
   apiClient,
@@ -49,6 +49,7 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
   const [payload, setPayload] = useState<CloudCongressHousePayload | null>(null);
   const [status, setStatus] = useState<LoadStatus>("idle");
   const [error, setError] = useState<string | null>(null);
+  const [lastLoadedAt, setLastLoadedAt] = useState<number | null>(null);
   const [activeTab, setActiveTab] = usePluginPaneState<CongressTab>("activeTab", "trades");
   const [selectedTradeId, setSelectedTradeId] = useDebouncedPluginPaneState<string | null>("selectedTradeId", null);
   const [selectedMemberId, setSelectedMemberId] = useDebouncedPluginPaneState<string | null>("selectedMemberId", null);
@@ -77,6 +78,7 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
         if (fetchGenRef.current !== gen) return;
         setPayload(nextPayload);
         setStatus("loaded");
+        setLastLoadedAt(Date.now());
       })
       .catch((loadError) => {
         if (fetchGenRef.current !== gen) return;
@@ -88,6 +90,12 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
   useEffect(() => {
     load(false);
   }, [load]);
+
+  // Filings would otherwise age indefinitely in an open pane.
+  const refresh = useCallback(() => {
+    load(true);
+  }, [load]);
+  useAutoRefresh(lastLoadedAt, refresh);
 
   const trades = payload?.trades ?? [];
   const members = payload?.members ?? [];
@@ -223,24 +231,11 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
     </Box>
   );
 
-  if (status === "loading" && !payload) {
+  if (!payload && (status === "loading" || error)) {
     return (
       <Box flexDirection="column" width={width} height={height}>
         {tabs}
-        <Box flexGrow={1} justifyContent="center" alignItems="center">
-          <Spinner label="Loading House PTRs..." />
-        </Box>
-      </Box>
-    );
-  }
-
-  if (error && !payload) {
-    return (
-      <Box flexDirection="column" width={width} height={height}>
-        {tabs}
-        <Box padding={1}>
-          <EmptyState title="Congress trades unavailable." message={error} />
-        </Box>
+        <PaneStatusBody loading={status === "loading"} error={error} subject="House PTR filings" />
       </Box>
     );
   }

--- a/src/plugins/builtin/connections/pane.tsx
+++ b/src/plugins/builtin/connections/pane.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, ScrollBox, Text, TextAttributes } from "../../../ui";
 import {
   DataTableStackView,
+  Spinner,
   type DataTableCell,
   type DataTableColumn,
   usePaneFooter,
@@ -56,7 +57,8 @@ function columnsForWidth(width: number): ConnectionColumn[] {
   const latencyWidth = 8;
   const lastWidth = 9;
   const requestWidth = width >= 72 ? 18 : 0;
-  const serviceWidth = Math.max(16, width - statusWidth - latencyWidth - lastWidth - requestWidth - 4);
+  // Floor low enough that a narrow pane scrolls horizontally instead of clipping.
+  const serviceWidth = Math.max(10, width - statusWidth - latencyWidth - lastWidth - requestWidth - 4);
   return [
     { id: "service", label: "SERVICE", width: serviceWidth, align: "left" },
     { id: "status", label: "STATUS", width: statusWidth, align: "left" },
@@ -136,8 +138,20 @@ export function ConnectionsPane({ focused, width, height }: PaneProps) {
     direction: "asc",
   });
   const [now, setNow] = useState(Date.now());
+  // Sources register asynchronously at boot, so an empty first snapshot is a load,
+  // not an answer.
+  const [settled, setSettled] = useState(() => health.getSnapshot().sources.length > 0);
 
-  useEffect(() => health.subscribe(() => setSnapshot(health.getSnapshot())), [health]);
+  useEffect(() => {
+    if (settled) return;
+    const timer = setTimeout(() => setSettled(true), 2000);
+    return () => clearTimeout(timer);
+  }, [settled]);
+
+  useEffect(() => health.subscribe(() => {
+    setSnapshot(health.getSnapshot());
+    setSettled(true);
+  }), [health]);
   useEffect(() => {
     const timer = setInterval(() => {
       setNow(Date.now());
@@ -231,9 +245,13 @@ export function ConnectionsPane({ focused, width, height }: PaneProps) {
         }}
         getItemKey={(source) => source.id}
         renderCell={renderCell}
+        emptyContent={settled ? undefined : (
+          <Box paddingX={1} paddingY={1}>
+            <Spinner label="Waiting for services to register..." />
+          </Box>
+        )}
         emptyStateTitle="No connection activity yet."
         emptyStateHint="Sources appear when providers and services register."
-        showHorizontalScrollbar={false}
       />
     </Box>
   );

--- a/src/plugins/builtin/correlation/index.test.tsx
+++ b/src/plugins/builtin/correlation/index.test.tsx
@@ -121,7 +121,8 @@ describe("correlationModule", () => {
     });
 
     const lines = testSetup!.captureCharFrame().split("\n");
-    const headerY = lines.findIndex((line) => line.includes("AAPL") && line.includes("MSFT"));
+    // The first AAPL+MSFT line is the in-pane ticker input, so skip comma-separated rows.
+    const headerY = lines.findIndex((line) => line.includes("AAPL") && line.includes("MSFT") && !line.includes(","));
     const headerCol = lines[headerY]?.indexOf("AAPL") ?? -1;
     expect(headerY).toBeGreaterThanOrEqual(0);
     expect(headerCol).toBeGreaterThanOrEqual(0);

--- a/src/plugins/builtin/correlation/index.tsx
+++ b/src/plugins/builtin/correlation/index.tsx
@@ -1,21 +1,23 @@
-import { Box, ScrollBox, Text } from "../../../ui";
-import { useCallback, useMemo, useState } from "react";
-import { usePaneFooter } from "../../../components";
+import { Box, ScrollBox, Text, type InputRenderable } from "../../../ui";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { InputSearchBar, SegmentedControl, usePaneFooter } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
 import { colors } from "../../../theme/colors";
 import { usePluginTickerActions } from "../../runtime";
-import { useAppSelector, usePaneInstance } from "../../../state/app/context";
+import { useAppSelector, usePaneInstance, usePaneSettingValue } from "../../../state/app/context";
 import { useChartQueries } from "../../../market-data/hooks";
 import { buildChartKey } from "../../../market-data/selectors";
 import { formatTickerListInput } from "../../../tickers/list";
 import { formatCorrelation } from "./compute";
 import {
+  CORRELATION_RANGE_OPTIONS,
   DEFAULT_CORRELATION_SYMBOLS,
   MAX_CORRELATION_TICKERS,
   buildCorrelationSettingsDef,
   getCorrelationPaneSettings,
+  type CorrelationRangePreset,
 } from "./settings";
 import { resolveCorrelationHeatmapCellColors } from "./colors";
 import {
@@ -39,12 +41,17 @@ import {
 } from "./matrix/model";
 import { SymbolLabelCell } from "./matrix/symbol-cell";
 
-function CorrelationMatrixPane({ width, height }: PaneProps) {
+function CorrelationMatrixPane({ focused, width, height }: PaneProps) {
   const pane = usePaneInstance();
   const { navigateTicker, pinTicker } = usePluginTickerActions();
   const tickers = useAppSelector((state) => state.tickers);
   const [hoveredSymbol, setHoveredSymbol] = useState<string | null>(null);
   const settings = useMemo(() => getCorrelationPaneSettings(pane?.settings), [pane?.settings]);
+  const [rangePreset, setRangePreset] = usePaneSettingValue<CorrelationRangePreset>("rangePreset", settings.rangePreset);
+  const [symbolsText, setSymbolsText] = usePaneSettingValue<string>("symbolsText", settings.symbolsText);
+  const [symbolsEditing, setSymbolsEditing] = useState(false);
+  const [symbolsFocusToken, setSymbolsFocusToken] = useState(0);
+  const symbolsInputRef = useRef<InputRenderable | null>(null);
 
   const instruments = useMemo(() => {
     if (settings.symbolsError) return [];
@@ -94,19 +101,19 @@ function CorrelationMatrixPane({ width, height }: PaneProps) {
   }, [symbolsKey, seriesBySymbol]);
 
   const statusSummary = useMemo(
-    () => buildStatusSummary(symbols, seriesBySymbol, matrix.sampleMin, matrix.sampleMax),
-    [symbolsKey, seriesBySymbol, matrix.sampleMin, matrix.sampleMax],
+    () => buildStatusSummary(symbols, seriesBySymbol, matrix.sampleMin, matrix.sampleMax, matrix.hasThinPair),
+    [symbolsKey, seriesBySymbol, matrix.sampleMin, matrix.sampleMax, matrix.hasThinPair],
   );
 
+  // The ticker set and range are visible in-pane, so the footer only carries
+  // load state and errors.
   usePaneFooter("correlation", () => ({
-    info: [
-      { id: "tickers", parts: [{ text: `${symbols.length} tickers`, tone: symbols.length >= 2 ? "value" : "warning", bold: symbols.length >= 2 }] },
-      { id: "range", parts: [{ text: settings.rangePreset, tone: "muted" }] },
-      ...(settings.symbolsError
-        ? [{ id: "error", parts: [{ text: settings.symbolsError, tone: "warning" as const }] }]
-        : [{ id: "status", parts: [{ text: statusSummary, tone: "muted" as const }] }]),
-    ],
-  }), [settings.rangePreset, settings.symbolsError, statusSummary, symbols.length]);
+    info: settings.symbolsError
+      ? [{ id: "error", parts: [{ text: settings.symbolsError, tone: "warning" as const }] }]
+      : statusSummary
+        ? [{ id: "status", parts: [{ text: statusSummary, tone: "muted" as const }] }]
+        : [],
+  }), [settings.symbolsError, statusSummary]);
 
   const openSymbol = useCallback((symbol: string) => {
     if (tickers.has(symbol)) {
@@ -144,11 +151,43 @@ function CorrelationMatrixPane({ width, height }: PaneProps) {
   );
   const availableCellWidth = Math.floor((Math.max(width - rowHeaderWidth - 4, symbols.length * MIN_MATRIX_CELL_WIDTH)) / symbols.length);
   const cellWidth = Math.max(MIN_MATRIX_CELL_WIDTH, Math.min(MATRIX_CELL_WIDTH, availableCellWidth));
+  // Rows are exactly as wide as the matrix, so the zebra and hover bands stop at
+  // the last column instead of running to the pane edge.
+  const matrixRowWidth = rowHeaderWidth + symbols.length * cellWidth + 2;
 
   return (
     <Box flexDirection="column" width={width} height={height}>
+      <Box height={1} flexDirection="row" overflow="hidden">
+        <Box flexShrink={1} overflow="hidden">
+          <InputSearchBar
+            value={symbolsText}
+            focused={focused}
+            active={symbolsEditing}
+            width={Math.max(12, Math.min(40, width - 24))}
+            focusToken={symbolsFocusToken}
+            inputRef={symbolsInputRef}
+            placeholder="tickers"
+            debounceMs={500}
+            onFocus={() => {
+              setSymbolsEditing(true);
+              setSymbolsFocusToken((token) => token + 1);
+            }}
+            onBlur={() => setSymbolsEditing(false)}
+            onQueryChange={(query) => setSymbolsText(query)}
+          />
+        </Box>
+        <Box flexGrow={1} />
+        <SegmentedControl
+          options={CORRELATION_RANGE_OPTIONS.map((range) => ({ label: range, value: range }))}
+          value={rangePreset}
+          onChange={(value) => setRangePreset(value as CorrelationRangePreset)}
+          focused={focused && !symbolsEditing}
+          shortcutScope="correlation:range"
+        />
+      </Box>
+
       {/* Column header row */}
-      <Box flexDirection="row" paddingX={1} height={1} backgroundColor={headerBg}>
+      <Box flexDirection="row" paddingX={1} height={1} width={matrixRowWidth} backgroundColor={headerBg}>
         <Box width={rowHeaderWidth} flexShrink={0} />
         {symbols.map((sym) => (
           <SymbolLabelCell
@@ -166,10 +205,10 @@ function CorrelationMatrixPane({ width, height }: PaneProps) {
       </Box>
 
       {/* Matrix rows */}
-      <ScrollBox flexGrow={1} scrollY focusable={false}>
+      <ScrollBox flexGrow={1} scrollY scrollX focusable={false}>
         <Box flexDirection="column">
           {symbols.map((rowSym, rowIndex) => (
-            <Box key={rowSym} flexDirection="row" paddingX={1} backgroundColor={rowIndex % 2 === 0 ? colors.bg : undefined}>
+            <Box key={rowSym} flexDirection="row" paddingX={1} width={matrixRowWidth} backgroundColor={rowIndex % 2 === 0 ? colors.bg : undefined}>
               {/* Row header */}
               <Box
                 width={rowHeaderWidth}
@@ -267,7 +306,7 @@ export const correlationModule: PluginModule = {
           ? options.symbols
           : DEFAULT_CORRELATION_SYMBOLS;
         return {
-          title: buildCorrelationPaneTitle(symbols, "1Y"),
+          title: buildCorrelationPaneTitle(),
           placement: "floating",
           settings: {
             rangePreset: "1Y",

--- a/src/plugins/builtin/correlation/matrix/model.ts
+++ b/src/plugins/builtin/correlation/matrix/model.ts
@@ -93,9 +93,11 @@ export function buildCorrelationMatrix(
   results: Map<string, CorrelationResult>;
   sampleMin: number | null;
   sampleMax: number | null;
+  hasThinPair: boolean;
 } {
   const results = new Map<string, CorrelationResult>();
   const sampleSizes: number[] = [];
+  let hasThinPair = false;
 
   for (let rowIndex = 0; rowIndex < symbols.length; rowIndex++) {
     for (let colIndex = 0; colIndex < symbols.length; colIndex++) {
@@ -108,8 +110,11 @@ export function buildCorrelationMatrix(
         ? correlateDatedReturns(rowSeries.returns, colSeries.returns, MIN_CORRELATION_OBSERVATIONS)
         : { correlation: null, sampleSize: 0 };
       results.set(pairKey(rowSym, colSym), result);
-      if (rowIndex < colIndex && result.sampleSize > 0) {
-        sampleSizes.push(result.sampleSize);
+      if (rowIndex < colIndex) {
+        if (result.sampleSize > 0) sampleSizes.push(result.sampleSize);
+        if (result.correlation == null && result.sampleSize < MIN_CORRELATION_OBSERVATIONS) {
+          hasThinPair = true;
+        }
       }
     }
   }
@@ -118,6 +123,7 @@ export function buildCorrelationMatrix(
     results,
     sampleMin: sampleSizes.length > 0 ? Math.min(...sampleSizes) : null,
     sampleMax: sampleSizes.length > 0 ? Math.max(...sampleSizes) : null,
+    hasThinPair,
   };
 }
 
@@ -126,6 +132,7 @@ export function buildStatusSummary(
   seriesBySymbol: Map<string, CorrelationSeries>,
   sampleMin: number | null,
   sampleMax: number | null,
+  hasThinPair = false,
 ): string {
   const parts: string[] = [];
   const byStatus = (status: SeriesStatus) => symbols.filter((symbol) => seriesBySymbol.get(symbol)?.status === status);
@@ -144,12 +151,16 @@ export function buildStatusSummary(
     parts.push("No paired dates yet");
   }
 
-  parts.push(`— <${MIN_CORRELATION_OBSERVATIONS} shared`);
+  // Only legend the blank cells when at least one pair actually has too few
+  // shared dates to correlate.
+  if (hasThinPair) parts.push(`- <${MIN_CORRELATION_OBSERVATIONS} shared`);
   return parts.join(" · ");
 }
 
-export function buildCorrelationPaneTitle(symbols: string[], rangePreset: CorrelationRangePreset): string {
-  if (symbols.length === 0) return `Correlation ${rangePreset}`;
-  if (symbols.length <= 3) return `${symbols.join(" · ")} ${rangePreset}`;
-  return `${symbols.slice(0, 2).join(" · ")} +${symbols.length - 2} ${rangePreset}`;
+/**
+ * The matrix already labels every symbol on both axes and the pane now carries
+ * its own range control, so the title stays generic instead of repeating them.
+ */
+export function buildCorrelationPaneTitle(): string {
+  return "Correlation";
 }

--- a/src/plugins/builtin/correlation/relationship/pane.tsx
+++ b/src/plugins/builtin/correlation/relationship/pane.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, Text } from "../../../../ui";
-import { usePaneFooter } from "../../../../components";
+import { Button, usePaneFooter } from "../../../../components";
 import { useShortcut, type KeyEventLike } from "../../../../react/input";
 import { StaticMultiLineChartSurface } from "../../../../components/chart/static/multi-line-chart-surface";
 import { StaticScatterChartSurface } from "../../../../components/chart/static/scatter-chart-surface";
@@ -45,6 +45,10 @@ export {
 
 type RelationshipGraphShortcut = "range" | "window" | "correlation" | "regression";
 
+/**
+ * Keys are the first letter of their hint label: [t]ime range, [p]eriod, [c]orr,
+ * [f]it line. `r` stays reserved for the app-wide refresh.
+ */
 export function resolveRelationshipGraphShortcut(
   event: Pick<KeyEventLike, "name" | "key" | "ctrl" | "shift" | "alt" | "meta" | "super">,
 ): RelationshipGraphShortcut | null {
@@ -57,7 +61,7 @@ export function resolveRelationshipGraphShortcut(
       return "window";
     case "c":
       return "correlation";
-    case "g":
+    case "f":
       return "regression";
     default:
       return null;
@@ -93,19 +97,28 @@ export function RelationshipGraphPane({ focused, width, height }: PaneProps) {
     : "negative";
   const ratioPalette = useMemo(() => resolveChartPalette(colors, ratioTrend), [ratioTrend]);
   const chartWidth = Math.max(20, width - 2);
-  const headerRows = 1;
-  const availableChartRows = Math.max(8, height - headerRows);
-  const showScatter = showRegression && availableChartRows >= 17;
-  const priceHeight = Math.max(5, Math.floor(availableChartRows * (showScatter ? 0.26 : 0.34)));
-  const ratioHeight = Math.max(4, Math.floor(availableChartRows * (showScatter ? 0.22 : 0.33)));
-  const correlationHeight = showCorrelation
-    ? Math.max(4, Math.floor(availableChartRows * (showScatter ? 0.22 : 0.33)))
+  // Panels are allocated in priority order out of the rows that actually exist, so
+  // a short pane drops the lowest-priority chart instead of clipping every axis.
+  const headerRows = 2;
+  const availableChartRows = Math.max(0, height - headerRows);
+  const railWidth = chartWidth >= 68 ? Math.min(34, Math.floor(chartWidth * 0.3)) : 0;
+  const statsBelowRows = railWidth === 0 ? 1 : 0;
+  let remainingRows = availableChartRows;
+  const priceHeight = Math.min(remainingRows, Math.max(5, Math.floor(availableChartRows * 0.28)));
+  remainingRows -= priceHeight;
+  const ratioHeight = remainingRows >= 4
+    ? Math.min(remainingRows, Math.max(4, Math.floor(availableChartRows * 0.24)))
     : 0;
-  const statsRailWidth = showScatter && chartWidth >= 68 ? Math.min(34, Math.floor(chartWidth * 0.3)) : 0;
-  const statsBelowRows = showScatter && statsRailWidth === 0 ? 1 : 0;
-  const scatterHeight = showScatter
-    ? Math.max(5, availableChartRows - priceHeight - ratioHeight - correlationHeight - statsBelowRows)
+  remainingRows -= ratioHeight;
+  const showCorrelationChart = showCorrelation && remainingRows >= 4;
+  const correlationHeight = showCorrelationChart
+    ? Math.min(remainingRows, Math.max(4, Math.floor(availableChartRows * 0.24)))
     : 0;
+  remainingRows -= correlationHeight;
+  // Scatter needs its own two label rows on top of a usable plot.
+  const showScatter = showRegression && remainingRows >= 7 + statsBelowRows;
+  const scatterHeight = showScatter ? remainingRows - statsBelowRows : 0;
+  const statsRailWidth = showScatter ? railWidth : 0;
   const scatterWidth = statsRailWidth > 0 ? Math.max(20, chartWidth - statsRailWidth - 1) : chartWidth;
   const stats = analysis?.stats ?? null;
   const alignedDates = useMemo(() => analysis?.aligned.map((entry) => entry.date) ?? [], [analysis]);
@@ -213,10 +226,10 @@ export function RelationshipGraphPane({ focused, width, height }: PaneProps) {
       ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
     ],
     hints: [
-      { id: "range", key: "t", label: "range", onPress: cycleRange },
+      { id: "range", key: "t", label: "ime range", onPress: cycleRange },
       { id: "window", key: "p", label: "eriod", onPress: cycleWindow },
       { id: "correlation", key: "c", label: "orr", onPress: toggleCorrelation },
-      { id: "regression", key: "g", label: "reg", onPress: toggleRegression },
+      { id: "regression", key: "f", label: "it line", onPress: toggleRegression },
     ],
   }), [
     cycleRange,
@@ -256,8 +269,17 @@ export function RelationshipGraphPane({ focused, width, height }: PaneProps) {
     >
       <Box height={1} flexDirection="row" gap={2}>
         <RelationshipToggle checked={showCorrelation} label="Correlation" onPress={toggleCorrelation} />
-        <RelationshipToggle checked={showRegression} label="Regression" onPress={toggleRegression} />
-        <Text fg={colors.textDim}>Range {range}  Window {correlationWindow}d</Text>
+        <RelationshipToggle checked={showRegression} label="Fit line" onPress={toggleRegression} />
+        <Button label={`Range ${range}`} variant="ghost" onPress={cycleRange} />
+        <Button label={`Window ${correlationWindow}d`} variant="ghost" onPress={cycleWindow} />
+      </Box>
+      <Box height={1} flexDirection="row" gap={2}>
+        {priceSeries.map((series) => (
+          <Box key={series.id} flexDirection="row" gap={1}>
+            <Box width={2} height={1} backgroundColor={series.color} />
+            <Text fg={colors.textDim}>{series.label}</Text>
+          </Box>
+        ))}
       </Box>
       <StaticMultiLineChartSurface
         series={priceSeries}
@@ -272,6 +294,7 @@ export function RelationshipGraphPane({ focused, width, height }: PaneProps) {
         formatYAxisValue={(value) => formatNumber(value, 0)}
         onCursorDateChange={selectCursorDate}
       />
+      {ratioHeight > 0 ? (
       <StaticMultiLineChartSurface
         series={ratioSeries}
         width={chartWidth}
@@ -285,7 +308,8 @@ export function RelationshipGraphPane({ focused, width, height }: PaneProps) {
         formatYAxisValue={(value) => formatNumber(value, Math.abs(value) >= 10 ? 1 : 3)}
         onCursorDateChange={selectCursorDate}
       />
-      {showCorrelation ? (
+      ) : null}
+      {showCorrelationChart ? (
         <StaticMultiLineChartSurface
           series={correlationSeries}
           width={chartWidth}
@@ -320,7 +344,7 @@ export function RelationshipGraphPane({ focused, width, height }: PaneProps) {
           ) : null}
         </Box>
       ) : null}
-      {showRegression && (!showScatter || statsRailWidth === 0) ? (
+      {showScatter && statsRailWidth === 0 ? (
         <Text fg={colors.textDim}>
           {metricsRows.map((row) => `${row.label} ${row.value}`).join("  ")}
         </Text>

--- a/src/plugins/builtin/correlation/settings.ts
+++ b/src/plugins/builtin/correlation/settings.ts
@@ -4,7 +4,7 @@ import { formatTickerListInput, MAX_TICKER_LIST_SIZE, parseTickerListInput } fro
 
 export const MAX_CORRELATION_TICKERS = MAX_TICKER_LIST_SIZE;
 const DEFAULT_CORRELATION_RANGE: CorrelationRangePreset = "1Y";
-const CORRELATION_RANGE_OPTIONS = ["1M", "3M", "6M", "1Y", "5Y"] as const;
+export const CORRELATION_RANGE_OPTIONS = ["1M", "3M", "6M", "1Y", "5Y"] as const;
 export const DEFAULT_CORRELATION_SYMBOLS = ["AAPL", "MSFT", "NVDA", "AMD"];
 
 export type CorrelationRangePreset = Extract<TimeRange, typeof CORRELATION_RANGE_OPTIONS[number]>;

--- a/src/plugins/builtin/credit-conditions/index.tsx
+++ b/src/plugins/builtin/credit-conditions/index.tsx
@@ -2,12 +2,16 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, TextAttributes } from "../../../ui";
 import { useShortcut } from "../../../react/input";
 import {
+  Button,
   DataTableView,
+  EmptyState,
+  Spinner,
   usePaneFooter,
   type DataTableCell,
   type DataTableColumn,
   type PaneFooterSegment,
 } from "../../../components";
+import { useAutoRefresh } from "../shared/auto-refresh";
 import type { PaneProps } from "../../../types/plugin";
 import { colors } from "../../../theme/colors";
 import type { PluginModule } from "../plugin-module";
@@ -18,14 +22,13 @@ import {
   type CreditSeriesId,
 } from "./model";
 
-type SortId = "label" | "oas" | "change" | "date";
+type SortId = "label" | "oas" | "change";
 interface Column extends DataTableColumn { id: SortId }
 
 const COLUMNS: readonly Column[] = [
   { id: "label", label: "INDEX", width: 12, align: "left" },
   { id: "oas", label: "OAS", width: 10, align: "right" },
   { id: "change", label: "1D", width: 9, align: "right" },
-  { id: "date", label: "AS OF", width: 12, align: "right" },
 ];
 
 function formatBp(value: number | null, signed = false): string {
@@ -39,8 +42,7 @@ function sortRows(rows: CreditConditionRow[], id: SortId, descending: boolean): 
     let comparison = 0;
     if (id === "label") comparison = left.label.localeCompare(right.label);
     else if (id === "oas") comparison = left.oasBp - right.oasBp;
-    else if (id === "change") comparison = (left.dailyChangeBp ?? -Infinity) - (right.dailyChangeBp ?? -Infinity);
-    else comparison = left.date.localeCompare(right.date);
+    else comparison = (left.dailyChangeBp ?? -Infinity) - (right.dailyChangeBp ?? -Infinity);
     return descending ? -comparison : comparison;
   });
 }
@@ -64,7 +66,6 @@ function renderCell(
   const selected = state.selected ? colors.selectedText : undefined;
   if (column.id === "label") return { text: row.label, color: selected ?? colors.text, attributes: TextAttributes.BOLD };
   if (column.id === "oas") return { text: formatBp(row.oasBp), color: selected ?? colors.textBright };
-  if (column.id === "date") return { text: row.date, color: selected ?? colors.textDim };
   return {
     text: formatBp(row.dailyChangeBp, true),
     color: selected ?? (row.dailyChangeBp == null
@@ -85,6 +86,7 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
   const [loading, setLoading] = useState(!initial);
   const [stale, setStale] = useState(initial?.stale ?? false);
   const [error, setError] = useState<string | null>(initial?.errors[0] ?? null);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
   const generation = useRef(0);
 
   const load = useCallback(async (force = false) => {
@@ -97,6 +99,7 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
       setRows(result.rows);
       setSelectedId((id) => id && result.rows.some((row) => row.seriesId === id) ? id : result.rows[0]?.seriesId ?? null);
       setStale(result.stale);
+      if (!result.stale) setLastUpdated(Date.now());
       setError(result.errors[0] ?? null);
     } catch (loadError) {
       if (generation.current !== current) return;
@@ -107,11 +110,15 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
   }, []);
   useEffect(() => { void load(false); }, [load]);
   const reload = useCallback(() => { void load(true); }, [load]);
+  const refresh = useCallback(() => { void load(false); }, [load]);
+  // The shared FRED cache decides whether a tick actually hits the network, so
+  // the pane can follow the global cadence without refetching daily data.
+  useAutoRefresh(lastUpdated, refresh);
 
   const sorted = useMemo(() => sortRows(rows, sort.id, sort.descending), [rows, sort]);
   const selectedRow = rows.find((row) => row.seriesId === selectedId) ?? rows[0] ?? null;
   const columns = useMemo<Column[]>(() => {
-    const labelWidth = Math.max(12, width - 35);
+    const labelWidth = Math.max(12, width - 23);
     return COLUMNS.map((column) => column.id === "label" ? { ...column, width: labelWidth } : { ...column });
   }, [width]);
   const renderRowCell = useCallback((
@@ -138,24 +145,35 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
     event.stopPropagation?.();
   });
   const partial = rows.length > 0 && rows.length < CREDIT_SERIES.length;
+  const asOf = rows.reduce<string | null>((latest, row) => !latest || row.date > latest ? row.date : latest, null);
   const footerInfo = useMemo<PaneFooterSegment[]>(() => [
-    ...(partial ? [{ id: "partial", parts: [{ text: "PARTIAL", tone: "warning" as const, bold: true }] }] : []),
+    ...(asOf ? [{ id: "as-of", parts: [{ text: `as of ${asOf}`, tone: "muted" as const }] }] : []),
+    ...(rows.length > 0 ? [{ id: "delayed", parts: [{ text: "delayed", tone: "muted" as const }] }] : []),
+    ...(partial ? [{ id: "partial", parts: [{ text: `PARTIAL ${rows.length}/${CREDIT_SERIES.length}`, tone: "warning" as const, bold: true }] }] : []),
     ...(stale ? [{ id: "stale", parts: [{ text: "STALE", tone: "warning" as const }] }] : []),
     ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
     ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
-  ], [error, loading, partial, stale]);
+  ], [asOf, error, loading, partial, rows.length, stale]);
   usePaneFooter(paneId, () => ({ info: footerInfo }), [footerInfo, paneId]);
 
   if (rows.length === 0 && loading) {
-    return <Box width={width} height={height} justifyContent="center" alignItems="center"><Text fg={colors.textMuted}>Loading credit spreads...</Text></Box>;
+    return (
+      <Box width={width} height={height} justifyContent="center" alignItems="center">
+        <Spinner label="Loading credit spreads..." />
+      </Box>
+    );
   }
   if (rows.length === 0) {
-    return <Box width={width} height={height} padding={1}><Text fg={colors.negative}>{error ?? "Credit spread data unavailable"}</Text></Box>;
+    return (
+      <Box width={width} height={height} padding={1} flexDirection="column" gap={1}>
+        <EmptyState title="Credit spreads unavailable." message={error ?? undefined} />
+      </Box>
+    );
   }
 
   const metadata = (
     <Box height={2} flexDirection="column" paddingX={1}>
-      <Text fg={colors.textMuted}>FRED · option-adjusted spread · daily close · delayed</Text>
+      <Text fg={colors.textMuted}>FRED · option-adjusted spread · daily close</Text>
       <Text fg={colors.textDim}>{selectedRow?.title ?? ""}</Text>
     </Box>
   );
@@ -183,7 +201,7 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
       }))}
       getItemKey={(row) => row.seriesId}
       renderCell={renderRowCell}
-      emptyStateTitle="No credit spread data."
+      emptyStateTitle={loading ? "Loading credit spreads..." : error ?? "No credit spread data."}
     />
   );
 }

--- a/src/plugins/builtin/debug/index.tsx
+++ b/src/plugins/builtin/debug/index.tsx
@@ -136,7 +136,7 @@ function DebugPane({ focused, width, height }: PaneProps) {
     }
 
     // Clear
-    if (event.name === "x") {
+    if (event.name === "c") {
       clearLogs();
       return;
     }
@@ -225,14 +225,17 @@ function DebugPane({ focused, width, height }: PaneProps) {
       ...(autoScroll ? [{ id: "auto", parts: [{ text: "AUTO", tone: "muted" as const }] }] : []),
     ],
     hints: [
+      // Every label is the mnemonic suffix of its key, so the footer reads
+      // "[l]evel [s]ource [e]xport [x] clear ..." consistently.
       { id: "level", key: "l", label: "evel", onPress: cycleLevelFilter },
       { id: "source", key: "s", label: "ource", onPress: cycleSourceFilter },
       { id: "export", key: "e", label: "xport", onPress: exportLogs },
-      { id: "clear", key: "x", label: "clear", onPress: clearLogs },
+      { id: "clear", key: "c", label: "lear", onPress: clearLogs },
       { id: "auto", key: "a", label: "uto", onPress: () => setAutoScroll((prev) => !prev) },
-      { id: "jump", key: "g/G", label: "jump", onPress: jumpBottom },
+      { id: "jump-top", key: "g", label: "o to top", onPress: jumpTop },
+      { id: "jump-end", key: "G", label: "o to end", onPress: jumpBottom },
     ],
-  }), [autoScroll, clearLogs, cycleLevelFilter, cycleSourceFilter, exportLogs, filterLevel, filterSource, jumpBottom]);
+  }), [autoScroll, clearLogs, cycleLevelFilter, cycleSourceFilter, exportLogs, filterLevel, filterSource, jumpBottom, jumpTop]);
 
   return (
     <Box flexDirection="column" width={width} height={height}>
@@ -265,9 +268,11 @@ function DebugPane({ focused, width, height }: PaneProps) {
           const ts = formatTimestamp(entry.timestamp);
           const lvl = LEVEL_LABELS[entry.level];
           const sourceTag = entry.source;
-          const maxMsg = Math.max(0, contentWidth - ts.length - lvl.length - sourceTag.length - 8);
+          // Floor of 1: at maxMsg 0 the old slice(0, -1) kept almost the whole
+          // message and only appended an ellipsis.
+          const maxMsg = Math.max(1, contentWidth - ts.length - lvl.length - sourceTag.length - 8);
           const msg = entry.message.length > maxMsg
-            ? entry.message.slice(0, maxMsg - 1) + "…"
+            ? `${entry.message.slice(0, Math.max(0, maxMsg - 1))}…`
             : entry.message;
 
           return (

--- a/src/plugins/builtin/dividend-yield/pane.tsx
+++ b/src/plugins/builtin/dividend-yield/pane.tsx
@@ -120,6 +120,8 @@ function renderMetricCell(row: MetricRow, width: number) {
   );
 }
 
+const MIN_METRIC_COLUMN_WIDTH = 18;
+
 function DividendSummary({
   metrics,
   currency,
@@ -132,16 +134,19 @@ function DividendSummary({
   chartPoints: ProjectedChartPoint[];
 }) {
   const metricRows = buildMetricRows(metrics, currency);
-  const colWidth = Math.max(18, Math.floor((width - 2) / 2));
+  // Two 18-cell blocks overflow anything narrower than 38 cells, so collapse.
+  const columnCount = width - 2 >= MIN_METRIC_COLUMN_WIDTH * 2 ? 2 : 1;
+  const colWidth = Math.max(MIN_METRIC_COLUMN_WIDTH, Math.floor((width - 2) / columnCount));
+  const rowCount = Math.ceil(metricRows.length / columnCount);
   const chartHeight = chartPoints.length >= 2 ? 6 : 0;
   const palette = resolveChartPalette(colors, "positive");
 
   return (
     <Box flexDirection="column">
-      <Box flexDirection="column" paddingX={1} height={Math.ceil(metricRows.length / 2)}>
-        {Array.from({ length: Math.ceil(metricRows.length / 2) }, (_, i) => {
-          const left = metricRows[i * 2]!;
-          const right = metricRows[i * 2 + 1];
+      <Box flexDirection="column" paddingX={1} height={rowCount}>
+        {Array.from({ length: rowCount }, (_, i) => {
+          const left = metricRows[i * columnCount]!;
+          const right = columnCount > 1 ? metricRows[i * columnCount + 1] : undefined;
           return (
             <Box key={left.label} height={1} flexDirection="row">
               <Box width={colWidth}>{renderMetricCell(left, colWidth)}</Box>
@@ -220,6 +225,11 @@ export function DividendYieldPane({ focused, width, height }: { focused: boolean
     }
   }, []);
 
+  // Ten years of history must not be refetched on every live price tick, so the
+  // quote is read through a ref instead of being an effect dependency.
+  const quotePriceRef = useRef(quotePrice);
+  quotePriceRef.current = quotePrice;
+
   useEffect(() => {
     if (!symbol) {
       setData(null);
@@ -227,12 +237,12 @@ export function DividendYieldPane({ focused, width, height }: { focused: boolean
       setLoading(false);
       return;
     }
-    void load(symbol, quotePrice);
-  }, [load, quotePrice, symbol]);
+    void load(symbol, quotePriceRef.current);
+  }, [load, symbol]);
 
   const refresh = useCallback(() => {
-    if (symbol) void load(symbol, quotePrice);
-  }, [load, quotePrice, symbol]);
+    if (symbol) void load(symbol, quotePriceRef.current);
+  }, [load, symbol]);
 
   usePaneFooter("dividend-yield", () => ({
     info: loadingErrorFooterInfo(loading, error),
@@ -257,7 +267,7 @@ export function DividendYieldPane({ focused, width, height }: { focused: boolean
   }, [refresh]);
 
   const emptyTitle = !symbol
-    ? "No ticker selected"
+    ? "No ticker selected."
     : loading
       ? "Loading dividends..."
       : error ?? "No dividend history";

--- a/src/plugins/builtin/earnings/data/cache.test.ts
+++ b/src/plugins/builtin/earnings/data/cache.test.ts
@@ -63,9 +63,9 @@ describe("loadEarningsCalendar", () => {
     const msft = await loadEarningsCalendar(provider, ["MSFT"]);
     const aaplAgain = await loadEarningsCalendar(provider, ["aapl"]);
 
-    expect(aapl.map((event) => event.symbol)).toEqual(["AAPL"]);
-    expect(msft.map((event) => event.symbol)).toEqual(["MSFT"]);
-    expect(aaplAgain.map((event) => event.symbol)).toEqual(["AAPL"]);
+    expect(aapl.events.map((event) => event.symbol)).toEqual(["AAPL"]);
+    expect(msft.events.map((event) => event.symbol)).toEqual(["MSFT"]);
+    expect(aaplAgain.events.map((event) => event.symbol)).toEqual(["AAPL"]);
     expect(calls).toEqual([["AAPL"], ["MSFT"]]);
   });
 
@@ -85,10 +85,13 @@ describe("loadEarningsCalendar", () => {
       throw new Error("offline");
     });
 
-    const events = await loadEarningsCalendar(provider, ["AAPL"], { force: true });
+    const result = await loadEarningsCalendar(provider, ["AAPL"], { force: true });
 
-    expect(events).toHaveLength(1);
-    expect(events[0]!.symbol).toBe("AAPL");
-    expect(events[0]!.earningsDate).toBeInstanceOf(Date);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]!.symbol).toBe("AAPL");
+    expect(result.events[0]!.earningsDate).toBeInstanceOf(Date);
+    // Cached events after a provider failure are stale, not a fresh load.
+    expect(result.stale).toBe(true);
+    expect(result.refreshError).toContain("offline");
   });
 });

--- a/src/plugins/builtin/earnings/data/cache.ts
+++ b/src/plugins/builtin/earnings/data/cache.ts
@@ -21,9 +21,17 @@ type PersistedEarningsEvent = Omit<EarningsEvent, "earningsDate" | "earningsCall
   earningsCallDate?: string | null;
 };
 
+export interface EarningsCalendarResult {
+  events: EarningsEvent[];
+  fetchedAt: number;
+  /** True when the provider failed and cached events were served instead. */
+  stale: boolean;
+  refreshError?: string;
+}
+
 let earningsPersistence: PluginPersistence | null = null;
 const memoryCache = new Map<string, MemoryCacheEntry>();
-const activeFetches = new Map<string, Promise<EarningsEvent[]>>();
+const activeFetches = new Map<string, Promise<EarningsCalendarResult>>();
 
 export function attachEarningsCalendarPersistence(persistence: PluginPersistence): void {
   earningsPersistence = persistence;
@@ -98,22 +106,24 @@ export async function loadEarningsCalendar(
   provider: DataProvider | null | undefined,
   symbols: string[],
   options?: { force?: boolean },
-): Promise<EarningsEvent[]> {
+): Promise<EarningsCalendarResult> {
   const normalizedSymbols = normalizeEarningsSymbols(symbols);
-  if (normalizedSymbols.length === 0 || !provider?.getEarningsCalendar) return [];
+  if (normalizedSymbols.length === 0 || !provider?.getEarningsCalendar) {
+    return { events: [], fetchedAt: Date.now(), stale: false };
+  }
 
   const key = buildEarningsCacheKey(normalizedSymbols);
   const force = options?.force ?? false;
   const memoryEntry = memoryCache.get(key);
   if (!force && memoryEntry && Date.now() - memoryEntry.fetchedAt < EARNINGS_CALENDAR_CACHE_POLICY.staleMs) {
-    return memoryEntry.data;
+    return { events: memoryEntry.data, fetchedAt: memoryEntry.fetchedAt, stale: false };
   }
 
   const freshPersisted = readPersistedCache(key);
   if (!force && freshPersisted && !freshPersisted.stale) {
     const data = deserializeEvents(freshPersisted.value);
     memoryCache.set(key, { data, fetchedAt: freshPersisted.fetchedAt });
-    return data;
+    return { events: data, fetchedAt: freshPersisted.fetchedAt, stale: false };
   }
 
   const activeFetch = activeFetches.get(key);
@@ -122,16 +132,20 @@ export async function loadEarningsCalendar(
   const fetchPromise = provider.getEarningsCalendar(normalizedSymbols)
     .then((data) => {
       writeCache(key, data);
-      return data;
+      return { events: data, fetchedAt: Date.now(), stale: false };
     })
-    .catch((error) => {
+    .catch((error: unknown) => {
+      // Cached events survive a provider outage, but never as a fresh load.
+      const refreshError = error instanceof Error ? error.message : String(error);
       const stalePersisted = freshPersisted ?? readPersistedCache(key, { allowExpired: true });
       if (stalePersisted) {
         const data = deserializeEvents(stalePersisted.value);
         memoryCache.set(key, { data, fetchedAt: stalePersisted.fetchedAt });
-        return data;
+        return { events: data, fetchedAt: stalePersisted.fetchedAt, stale: true, refreshError };
       }
-      if (memoryEntry) return memoryEntry.data;
+      if (memoryEntry) {
+        return { events: memoryEntry.data, fetchedAt: memoryEntry.fetchedAt, stale: true, refreshError };
+      }
       throw error;
     })
     .finally(() => {

--- a/src/plugins/builtin/earnings/index.tsx
+++ b/src/plugins/builtin/earnings/index.tsx
@@ -6,6 +6,9 @@ import type { EarningsEvent } from "../../../types/data-provider";
 import { useAppSelector, usePaneInstance } from "../../../state/app/context";
 import { parseTickerListInput, formatTickerListInput } from "../../../tickers/list";
 import { useAssetData, usePluginPaneState, usePluginTickerActions } from "../../runtime";
+import { useAutoRefresh } from "../shared/auto-refresh";
+import type { PaneSettingsContext, PaneSettingsDef } from "../../../types/plugin";
+import { formatTickerListInput as formatTickers } from "../../../tickers/list";
 import {
   attachEarningsCalendarPersistence,
   loadEarningsCalendar,
@@ -32,8 +35,11 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
   const { navigateTicker } = usePluginTickerActions();
   const pane = usePaneInstance();
   const [events, setEvents] = useState<EarningsEvent[]>([]);
-  const [loading, setLoading] = useState(false);
+  // Starts loading so the first frame never claims there are no earnings.
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [stale, setStale] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
   const [selectedIdx, setSelectedIdx] = usePluginPaneState<number>("selectedIdx", 0);
   const requestIdRef = useRef(0);
 
@@ -70,6 +76,7 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
     if (tickerSymbols.length === 0) {
       setEvents([]);
       setError(null);
+      setStale(false);
       setLoading(false);
       return;
     }
@@ -77,9 +84,12 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
     setLoading(true);
     setError(null);
     loadEarningsCalendar(dataProvider, tickerSymbols, { force })
-      .then((data) => {
+      .then((result) => {
         if (requestId !== requestIdRef.current) return;
-        setEvents(data);
+        setEvents(result.events);
+        setStale(result.stale);
+        setError(result.refreshError ?? null);
+        setLastUpdated(result.fetchedAt);
       })
       .catch((err) => {
         if (requestId !== requestIdRef.current) return;
@@ -94,6 +104,10 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
   useEffect(() => {
     reload(false);
   }, [reload]);
+
+  // The 30-minute cache decides whether a tick reaches the provider.
+  const refresh = useCallback(() => reload(false), [reload]);
+  useAutoRefresh(stale ? null : lastUpdated, refresh);
 
   useEffect(() => () => {
     requestIdRef.current += 1;
@@ -129,10 +143,11 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
 
   usePaneFooter("earnings-calendar", () => ({
     info: [
+      ...(stale ? [{ id: "stale", parts: [{ text: "STALE", tone: "warning" as const }] }] : []),
       ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
     ],
-  }), [error, loading]);
+  }), [error, loading, stale]);
 
   return (
     <DataTableView<EarningsDisplayRow, EarningsColumn>
@@ -159,9 +174,45 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
       getItemKey={(row) => row.key}
       renderSectionHeader={renderEarningsSectionHeader}
       renderCell={renderCell}
-      emptyStateTitle={loading ? "Loading earnings..." : "No upcoming earnings found"}
+      emptyStateTitle={
+        loading
+          ? "Loading earnings..."
+          : tickerSymbols.length === 0
+            ? "No tickers in scope."
+            : "No upcoming earnings found"
+      }
     />
   );
+}
+
+/** The monitor's scope lives in pane settings, so it has to be editable there too. */
+function earningsSettings(context: PaneSettingsContext): PaneSettingsDef {
+  const collections = [
+    ...context.config.portfolios.map((portfolio) => ({ value: portfolio.id, label: portfolio.name })),
+    ...context.config.watchlists.map((watchlist) => ({ value: watchlist.id, label: watchlist.name })),
+  ];
+  const symbols = scopedSymbolsFromSettings(context.settings);
+  return {
+    title: "Earnings Scope",
+    values: { symbolsText: symbols.length > 0 ? formatTickers(symbols) : "" },
+    fields: [
+      {
+        key: "symbolsText",
+        label: "Tickers",
+        description: "Leave empty to follow a collection instead.",
+        type: "text",
+        placeholder: "AAPL, MSFT",
+        clearOnChange: ["symbols"],
+      },
+      ...(collections.length > 0 ? [{
+        key: "collectionId",
+        label: "Collection",
+        description: "Used when no tickers are listed above.",
+        type: "select" as const,
+        options: [{ value: "", label: "All tracked tickers" }, ...collections],
+      }] : []),
+    ],
+  };
 }
 
 export const earningsModule: PluginModule = {
@@ -200,6 +251,7 @@ export const earningsModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 85, height: 25 },
+      settings: earningsSettings,
     },
   ],
 

--- a/src/plugins/builtin/econ/calendar-model.test.ts
+++ b/src/plugins/builtin/econ/calendar-model.test.ts
@@ -4,6 +4,8 @@ import type { EconEvent } from "./types";
 import {
   attachEconCalendarPersistence,
   loadCalendar,
+  matchesCountry,
+  matchesImpact,
   resetEconCalendarPersistence,
 } from "./calendar-model";
 
@@ -36,13 +38,45 @@ describe("econ calendar cache", () => {
     attachEconCalendarPersistence(persistence);
 
     let calls = 0;
-    const events = await loadCalendar(false, async () => {
+    const result = await loadCalendar(false, async () => {
       calls += 1;
       return [makeEvent("fallback")];
     });
 
     expect(calls).toBe(0);
-    expect(events.map((event) => event.id)).toEqual(["pce"]);
-    expect(events[0]!.date).toBeInstanceOf(Date);
+    expect(result.data.map((event) => event.id)).toEqual(["pce"]);
+    expect(result.data[0]!.date).toBeInstanceOf(Date);
+    expect(result.stale).toBe(false);
+  });
+
+  test("marks a failed refresh stale instead of passing the cache off as fresh", async () => {
+    const persistence = new MemoryPluginPersistence();
+    attachEconCalendarPersistence(persistence);
+    await loadCalendar(false, async () => [makeEvent("pce")]);
+
+    const result = await loadCalendar(true, async () => {
+      throw new Error("calendar endpoint down");
+    });
+
+    expect(result.data.map((event) => event.id)).toEqual(["pce"]);
+    expect(result.stale).toBe(true);
+    expect(result.refreshError).toContain("calendar endpoint down");
+  });
+});
+
+describe("econ calendar filters", () => {
+  test("each impact level selects only its own events", () => {
+    const low = { ...makeEvent("low"), impact: "low" as const };
+    const high = makeEvent("high");
+    expect(matchesImpact(low, "low")).toBe(true);
+    expect(matchesImpact(high, "low")).toBe(false);
+    expect(matchesImpact(high, "all")).toBe(true);
+  });
+
+  test("G7 covers every member, not just the ones with a cached flag", () => {
+    for (const country of ["US", "GB", "FR", "DE", "IT", "JP", "CA", "EU"]) {
+      expect(matchesCountry({ ...makeEvent(country), country }, "G7")).toBe(true);
+    }
+    expect(matchesCountry({ ...makeEvent("cn"), country: "CN" }, "G7")).toBe(false);
   });
 });

--- a/src/plugins/builtin/econ/calendar-model.ts
+++ b/src/plugins/builtin/econ/calendar-model.ts
@@ -19,12 +19,8 @@ export type CountryFilter = "all" | "US" | "G7" | "EU";
 export const FILTER_CYCLE: ImpactFilter[] = ["all", "high", "medium", "low"];
 export const COUNTRY_CYCLE: CountryFilter[] = ["all", "US", "G7", "EU"];
 
-const G7_COUNTRIES = new Set(["US", "GB", "EU", "JP", "CA", "DE"]);
-
-const FLAG_MAP: Record<string, string> = {
-  US: "🇺🇸", GB: "🇬🇧", EU: "🇪🇺", JP: "🇯🇵", CA: "🇨🇦",
-  AU: "🇦🇺", CH: "🇨🇭", CN: "🇨🇳", NZ: "🇳🇿", SE: "🇸🇪", "--": "🌐",
-};
+/** The seven members plus the EU, which attends every summit. */
+const G7_COUNTRIES = new Set(["US", "GB", "FR", "DE", "IT", "JP", "CA", "EU"]);
 
 const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
 const MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] as const;
@@ -48,7 +44,7 @@ type PersistedEconEvent = Omit<EconEvent, "date"> & { date: string };
 export type EconCalendarCacheEntry = { data: EconEvent[]; fetchedAt: number; stale: boolean };
 
 let econCalendarPersistence: PluginPersistence | null = null;
-let activeFetch: Promise<EconEvent[]> | null = null;
+let activeFetch: Promise<EconCalendarLoadResult> | null = null;
 
 export function attachEconCalendarPersistence(persistence: PluginPersistence): void {
   econCalendarPersistence = persistence;
@@ -59,18 +55,15 @@ export function resetEconCalendarPersistence(): void {
   activeFetch = null;
 }
 
-export function countryFlag(code: string): string {
-  return FLAG_MAP[code] ?? code;
-}
-
+/** Words rather than dots: a three-wide column has no room for a legend. */
 export function impactIndicator(impact: EconImpact): { text: string; color: string } {
   switch (impact) {
     case "high":
-      return { text: "●●●", color: colors.negative };
+      return { text: "HIGH", color: colors.negative };
     case "medium":
-      return { text: "●● ", color: colors.warning };
+      return { text: "MED", color: colors.warning };
     case "low":
-      return { text: "●  ", color: colors.textDim };
+      return { text: "LOW", color: colors.textDim };
   }
 }
 
@@ -91,17 +84,18 @@ export function dayLabel(d: Date, today: Date): string {
   const dateNum = d.getDate();
   const suffix = `${dayName} ${monthName} ${dateNum}`;
 
-  if (dk === todayKey) return `TODAY — ${suffix}`;
-  if (dk === dateKey(tomorrow)) return `TOMORROW — ${suffix}`;
-  if (dk === dateKey(yesterday)) return `YESTERDAY — ${suffix}`;
+  if (dk === todayKey) return `TODAY · ${suffix}`;
+  if (dk === dateKey(tomorrow)) return `TOMORROW · ${suffix}`;
+  if (dk === dateKey(yesterday)) return `YESTERDAY · ${suffix}`;
   return suffix;
 }
 
+/**
+ * Each level selects exactly its own events. "At least this impact" made the
+ * lowest level identical to "all", which read as a broken filter.
+ */
 export function matchesImpact(event: EconEvent, filter: ImpactFilter): boolean {
-  if (filter === "all") return true;
-  if (filter === "high") return event.impact === "high";
-  if (filter === "medium") return event.impact === "medium" || event.impact === "high";
-  return true;
+  return filter === "all" || event.impact === filter;
 }
 
 export function matchesCountry(event: EconEvent, filter: CountryFilter): boolean {
@@ -179,22 +173,34 @@ export function getFreshCalendarCache(): EconCalendarCacheEntry | null {
   return cached && !cached.stale ? cached : null;
 }
 
+export interface EconCalendarLoadResult extends EconCalendarCacheEntry {
+  /** Set when the network failed and cached events were served instead. */
+  refreshError?: string;
+}
+
 export async function loadCalendar(
   force = false,
   loader: () => Promise<EconEvent[]> = fetchEconCalendar,
-): Promise<EconEvent[]> {
+): Promise<EconCalendarLoadResult> {
   const cached = getCalendarCache();
-  if (!force && cached && !cached.stale) return cached.data;
+  if (!force && cached && !cached.stale) return cached;
   if (activeFetch) return activeFetch;
 
   const fallback = cached ?? getCalendarCache({ allowExpired: true });
   activeFetch = loader().then((data) => {
     writeCache(data);
     activeFetch = null;
-    return data;
-  }).catch((err) => {
+    return { data, fetchedAt: Date.now(), stale: false };
+  }).catch((err: unknown) => {
     activeFetch = null;
-    if (fallback) return fallback.data;
+    // A failed refresh must not pass old events off as a fresh load.
+    if (fallback) {
+      return {
+        ...fallback,
+        stale: true,
+        refreshError: err instanceof Error ? err.message : String(err),
+      };
+    }
     throw err;
   });
   return activeFetch;

--- a/src/plugins/builtin/econ/index.test.tsx
+++ b/src/plugins/builtin/econ/index.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { PaneFooterProvider } from "../../../components/layout/pane/footer";
+import { AppContext, createInitialState, PaneInstanceProvider } from "../../../state/app/context";
+import { createDefaultConfig } from "../../../types/config";
+import { MemoryPluginPersistence } from "../../../test-support/plugin-persistence";
+import { PluginRenderProvider, type PluginRuntimeAccess } from "../../runtime";
+import { attachEconCalendarPersistence, resetEconCalendarPersistence } from "./calendar-model";
+import { economicCalendarModule } from "./index";
+
+const EconPane = economicCalendarModule.panes![0]!.component as (props: {
+  paneId: string;
+  paneType: string;
+  focused: boolean;
+  width: number;
+  height: number;
+}) => React.ReactNode;
+
+let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+function seedCalendar(): void {
+  const persistence = new MemoryPluginPersistence();
+  const now = Date.now();
+  persistence.seedResource("calendar", "global", [
+    {
+      id: "a",
+      date: new Date(now + 3_600_000).toISOString(),
+      time: "23:00",
+      country: "US",
+      event: "CPI m/m",
+      impact: "high",
+      actual: null,
+      forecast: "0.3%",
+      prior: "0.2%",
+    },
+    {
+      id: "b",
+      date: new Date(now - 90_000_000).toISOString(),
+      time: "14:00",
+      country: "FR",
+      event: "Retail Sales",
+      impact: "low",
+      actual: "1.1%",
+      forecast: "0.9%",
+      prior: "0.8%",
+    },
+  ], { sourceKey: "gloomberb-cloud", schemaVersion: 1 });
+  attachEconCalendarPersistence(persistence);
+}
+
+afterEach(async () => {
+  if (setup) {
+    await act(async () => setup?.renderer.destroy());
+    setup = undefined;
+  }
+  resetEconCalendarPersistence();
+});
+
+async function renderPane(width: number) {
+  const state = createInitialState(createDefaultConfig("/tmp/gloomberb-econ-test"));
+  setup = await testRender(
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <PluginRenderProvider runtime={{} as unknown as PluginRuntimeAccess} pluginId="econ">
+        <PaneInstanceProvider paneId="econ-calendar">
+          <PaneFooterProvider>
+            {() => (
+              <EconPane paneId="econ-calendar" paneType="econ-calendar" focused width={width} height={24} />
+            )}
+          </PaneFooterProvider>
+        </PaneInstanceProvider>
+      </PluginRenderProvider>
+    </AppContext>,
+    { width, height: 24 },
+  );
+  await act(async () => {
+    for (let index = 0; index < 6; index += 1) {
+      await Promise.resolve();
+      await setup!.renderOnce();
+    }
+  });
+  return setup.captureCharFrame();
+}
+
+describe("EconCalendarPane", () => {
+  // The column math has to leave room for gaps, padding, and the scrollbar
+  // lane; one column short silently clipped the last value of every row.
+  test("fits the last column instead of clipping released values", async () => {
+    seedCalendar();
+    const frame = await renderPane(110);
+
+    expect(frame).toContain("PRIOR");
+    expect(frame).toContain("0.2%");
+    expect(frame).toContain("0.8%");
+  });
+
+  test("separates days so a row's date is never ambiguous", async () => {
+    seedCalendar();
+    const frame = await renderPane(110);
+
+    expect(frame).toContain("TODAY");
+    expect(frame).toContain("YESTERDAY");
+    expect(frame).toContain("NOW");
+  });
+});

--- a/src/plugins/builtin/econ/index.tsx
+++ b/src/plugins/builtin/econ/index.tsx
@@ -1,7 +1,14 @@
-import { Box } from "../../../ui";
+import { Box, Text } from "../../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TextAttributes, type ScrollBoxRenderable } from "../../../ui";
-import { DataTableStackView, type DataTableCell, type PaneFooterSegment } from "../../../components";
+import {
+  DataTableStackView,
+  SegmentedControl,
+  type DataTableCell,
+  type PaneFooterSegment,
+} from "../../../components";
+import { usePluginPaneState } from "../../runtime";
+import { useAutoRefresh } from "../shared/auto-refresh";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import { colors, blendHex } from "../../../theme/colors";
@@ -12,13 +19,11 @@ import {
   FILTER_CYCLE,
   attachEconCalendarPersistence,
   actualColor,
-  countryFlag,
   dateKey,
   dayLabel,
   formatCountdown,
   formatStaleness,
   getCalendarCache,
-  getFreshCalendarCache,
   impactIndicator,
   loadCalendar,
   matchesCountry,
@@ -31,14 +36,24 @@ import {
 } from "./calendar-model";
 import { usePaneStatusFooter } from "../shared/pane-footer";
 
+const IMPACT_LABELS: Record<ImpactFilter, string> = {
+  all: "All",
+  high: "High",
+  medium: "Med",
+  low: "Low",
+};
+
 function EconCalendarPane({ focused, width, height }: PaneProps) {
   const [initialCache] = useState(() => getCalendarCache());
   const [events, setEvents] = useState<EconEvent[]>(initialCache?.data ?? []);
-  const [loading, setLoading] = useState(!initialCache || initialCache.stale);
+  const [loading, setLoading] = useState(true);
+  const [settled, setSettled] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [stale, setStale] = useState(initialCache?.stale ?? false);
+  const [fetchedAt, setFetchedAt] = useState<number | null>(initialCache?.fetchedAt ?? null);
   const [selectedIdx, setSelectedIdx] = useState(0);
-  const [impactFilter, setImpactFilter] = useState<ImpactFilter>("all");
-  const [countryFilter, setCountryFilter] = useState<CountryFilter>("all");
+  const [impactFilter, setImpactFilter] = usePluginPaneState<ImpactFilter>("impactFilter", "all");
+  const [countryFilter, setCountryFilter] = usePluginPaneState<CountryFilter>("countryFilter", "all");
   const [now, setNow] = useState(Date.now());
   const [detailEvent, setDetailEvent] = useState<EconEvent | null>(null);
 
@@ -53,26 +68,29 @@ function EconCalendarPane({ focused, width, height }: PaneProps) {
     setError(null);
 
     try {
-      const data = await loadCalendar(force);
+      const result = await loadCalendar(force);
       if (fetchGenRef.current !== gen) return;
-      setEvents(data);
+      setEvents(result.data);
+      setFetchedAt(result.fetchedAt);
+      setStale(result.stale);
+      setError(result.refreshError ?? null);
       if (force) setSelectedIdx(0);
     } catch (err) {
       if (fetchGenRef.current !== gen) return;
       setError(err instanceof Error ? err.message : String(err));
     } finally {
-      if (fetchGenRef.current === gen) setLoading(false);
+      if (fetchGenRef.current === gen) {
+        setLoading(false);
+        setSettled(true);
+      }
     }
   }, []);
 
-  useEffect(() => {
-    const cached = getFreshCalendarCache();
-    if (cached) {
-      setEvents(cached.data);
-      return;
-    }
-    load();
-  }, [load]);
+  // loadCalendar serves a fresh cache without a request, so the pane can always
+  // ask and still follow the global cadence once the cache goes stale.
+  useEffect(() => { void load(); }, [load]);
+  const refresh = useCallback(() => { void load(false); }, [load]);
+  useAutoRefresh(stale ? null : fetchedAt, refresh);
 
   // Tick every 30s to update staleness + countdown
   useEffect(() => {
@@ -150,20 +168,22 @@ function EconCalendarPane({ focused, width, height }: PaneProps) {
   // Next upcoming event for countdown
   const nextEvent = nextUpcomingEventIdx >= 0 ? filtered[nextUpcomingEventIdx] : undefined;
   const nextCountdown = nextEvent ? formatCountdown(nextEvent.date.getTime() - now) : null;
+  const selectImpactFilter = useCallback((value: ImpactFilter) => {
+    setImpactFilter(value);
+    setSelectedIdx(0);
+  }, [setImpactFilter]);
+  const selectCountryFilter = useCallback((value: CountryFilter) => {
+    setCountryFilter(value);
+    setSelectedIdx(0);
+  }, [setCountryFilter]);
   const cycleImpactFilter = useCallback(() => {
-    setImpactFilter((prev) => {
-      const idx = FILTER_CYCLE.indexOf(prev);
-      return FILTER_CYCLE[(idx + 1) % FILTER_CYCLE.length]!;
-    });
+    setImpactFilter((prev) => FILTER_CYCLE[(FILTER_CYCLE.indexOf(prev) + 1) % FILTER_CYCLE.length]!);
     setSelectedIdx(0);
-  }, []);
+  }, [setImpactFilter]);
   const cycleCountryFilter = useCallback(() => {
-    setCountryFilter((prev) => {
-      const idx = COUNTRY_CYCLE.indexOf(prev);
-      return COUNTRY_CYCLE[(idx + 1) % COUNTRY_CYCLE.length]!;
-    });
+    setCountryFilter((prev) => COUNTRY_CYCLE[(COUNTRY_CYCLE.indexOf(prev) + 1) % COUNTRY_CYCLE.length]!);
     setSelectedIdx(0);
-  }, []);
+  }, [setCountryFilter]);
 
   const handleRootKeyDown = useCallback((event: {
     name?: string;
@@ -192,19 +212,21 @@ function EconCalendarPane({ focused, width, height }: PaneProps) {
   const columns = useMemo<EconCalendarColumn[]>(() => {
     const timeWidth = 6;
     const impactWidth = 4;
-    const flagWidth = 2;
+    const flagWidth = 3;
     const actualWidth = 9;
     const forecastWidth = 10;
     const priorWidth = 9;
     const minEventWidth = 12;
     const fixedWidth = timeWidth + impactWidth + flagWidth + actualWidth + forecastWidth + priorWidth;
+    // Padding, one gap per column boundary, and the vertical scrollbar lane;
+    // one column short of that clipped the PRIOR values at the right edge.
     const columnCount = 7;
-    const eventWidth = Math.max(minEventWidth, width - 2 - columnCount - fixedWidth);
+    const eventWidth = Math.max(minEventWidth, width - 3 - columnCount - fixedWidth);
 
     return [
       { id: "time", label: "TIME", width: timeWidth, align: "left" },
       { id: "impact", label: "IMP", width: impactWidth, align: "left" },
-      { id: "country", label: "🌐", width: flagWidth, align: "left" },
+      { id: "country", label: "CTY", width: flagWidth, align: "left" },
       { id: "event", label: "EVENT", width: eventWidth, align: "left" },
       { id: "actual", label: "ACTUAL", width: actualWidth, align: "right" },
       { id: "forecast", label: "FORECAST", width: forecastWidth, align: "right" },
@@ -212,9 +234,8 @@ function EconCalendarPane({ focused, width, height }: PaneProps) {
     ];
   }, [width]);
   const separatorBg = blendHex(colors.bg, colors.border, 0.3);
-  const calendarCache = getCalendarCache();
-  const staleness = calendarCache ? formatStaleness(calendarCache.fetchedAt, now) : "";
-  const emptyStateHint = !loading && !error
+  const staleness = fetchedAt ? formatStaleness(fetchedAt, now) : "";
+  const emptyStateHint = settled && !loading && !error
     ? [
         impactFilter !== "all" ? `impact: ${impactFilter}` : null,
         countryFilter !== "all" ? `country: ${countryFilter}` : null,
@@ -222,14 +243,9 @@ function EconCalendarPane({ focused, width, height }: PaneProps) {
     : undefined;
 
   const calendarStatus = useMemo<PaneFooterSegment[]>(() => [
-    ...(impactFilter !== "all" ? [{ id: "impact", parts: [{ text: `impact: ${impactFilter}`, tone: "value" as const }] }] : []),
-    ...(countryFilter !== "all" ? [{ id: "country", parts: [{ text: `country: ${countryFilter}`, tone: "value" as const }] }] : []),
-    ...(nextEvent && nextCountdown ? [{
-      id: "next",
-      parts: [{ text: `Next: ${nextEvent.event.length > 18 ? nextEvent.event.slice(0, 18).trimEnd() : nextEvent.event} ${nextCountdown}`, tone: "muted" as const }],
-    }] : []),
-    ...(staleness ? [{ id: "stale", parts: [{ text: staleness, tone: "muted" as const }] }] : []),
-  ], [countryFilter, impactFilter, nextCountdown, nextEvent?.event, staleness]);
+    ...(stale ? [{ id: "stale", parts: [{ text: "STALE", tone: "warning" as const }] }] : []),
+    ...(staleness ? [{ id: "updated", parts: [{ text: staleness, tone: "muted" as const }] }] : []),
+  ], [stale, staleness]);
   usePaneStatusFooter({
     registrationId: "econ-calendar",
     loading,
@@ -252,16 +268,17 @@ function EconCalendarPane({ focused, width, height }: PaneProps) {
       };
     }
     if (row.kind === "now") {
-      const label = " ▸ NOW ";
-      const line = "─".repeat(Math.max(0, width - label.length - 2));
+      // A filled band instead of repeated rule characters, so the desktop
+      // webview paints a real background rather than terminal glyphs.
       return {
-        text: `${label}${line}`,
+        text: " NOW ",
         color: colors.warning,
-        attributes: 0,
+        backgroundColor: blendHex(colors.bg, colors.warning, 0.22),
+        attributes: TextAttributes.BOLD,
       };
     }
     return null;
-  }, [separatorBg, width]);
+  }, [separatorBg]);
   const renderCell = useCallback((
     row: DisplayRow,
     column: EconCalendarColumn,
@@ -284,7 +301,9 @@ function EconCalendarPane({ focused, width, height }: PaneProps) {
         };
       }
       case "country":
-        return { text: countryFlag(ev.country), color: selectedColor };
+        // The ISO code, not a flag emoji: emoji widths do not match a fixed
+        // column and pushed the right-hand columns off the pane.
+        return { text: ev.country, color: selectedColor ?? colors.textMuted };
       case "event":
         return { text: ev.event, color: selectedColor ?? colors.text };
       case "actual":
@@ -298,6 +317,31 @@ function EconCalendarPane({ focused, width, height }: PaneProps) {
         return { text: ev.prior ?? "—", color: selectedColor ?? colors.textDim };
     }
   }, []);
+
+  const selectedEvent = filtered[selectedIdx];
+  const filterControls = (
+    <Box height={1} flexDirection="row" paddingX={1} gap={2} overflow="hidden">
+      <SegmentedControl
+        options={FILTER_CYCLE.map((value) => ({ value, label: IMPACT_LABELS[value] }))}
+        value={impactFilter}
+        onChange={(value) => selectImpactFilter(value as ImpactFilter)}
+      />
+      <SegmentedControl
+        options={COUNTRY_CYCLE.map((value) => ({ value, label: value === "all" ? "All" : value }))}
+        value={countryFilter}
+        onChange={(value) => selectCountryFilter(value as CountryFilter)}
+      />
+      <Box flexGrow={1} />
+      {nextEvent && nextCountdown && width >= 88 && (
+        <Text fg={colors.textMuted}>
+          {`next ${nextEvent.event.slice(0, 16).trimEnd()} ${nextCountdown}`}
+        </Text>
+      )}
+      {selectedEvent && (
+        <Text fg={colors.textDim}>{dayLabel(selectedEvent.date, today)}</Text>
+      )}
+    </Box>
+  );
 
   const detailContent = detailEvent ? (
     <EconDetailView
@@ -317,7 +361,8 @@ function EconCalendarPane({ focused, width, height }: PaneProps) {
       onBack={() => setDetailEvent(null)}
       detailContent={detailContent}
       rootWidth={width}
-      rootHeight={height}
+      rootHeight={Math.max(1, height - 1)}
+      rootBefore={filterControls}
       onRootKeyDown={handleRootKeyDown}
       selection={{
         kind: "index",
@@ -338,7 +383,7 @@ function EconCalendarPane({ focused, width, height }: PaneProps) {
       onActivate={openDisplayRow}
       renderSectionHeader={renderSectionHeader}
       renderCell={renderCell}
-      emptyStateTitle={loading ? "Loading economic events..." : "No events"}
+      emptyStateTitle={loading || !settled ? "Loading economic events..." : "No events"}
       emptyStateHint={emptyStateHint}
       showHorizontalScrollbar={false}
     />

--- a/src/plugins/builtin/fear-greed/cache.test.ts
+++ b/src/plugins/builtin/fear-greed/cache.test.ts
@@ -68,8 +68,23 @@ describe("fear-greed cache", () => {
     });
 
     expect(calls).toBe(0);
-    expect(cached.overall.score).toBe(64);
-    expect(cached.overall.updatedAt).toBeInstanceOf(Date);
-    expect(cached.overall.history[0]!.date).toBeInstanceOf(Date);
+    expect(cached.stale).toBe(false);
+    expect(cached.data.overall.score).toBe(64);
+    expect(cached.data.overall.updatedAt).toBeInstanceOf(Date);
+    expect(cached.data.overall.history[0]!.date).toBeInstanceOf(Date);
+  });
+
+  test("reports a failed refresh as stale instead of a fresh load", async () => {
+    const persistence = new MemoryPluginPersistence();
+    attachFearGreedPersistence(persistence);
+    await loadFearGreed(false, async () => makeFearGreedData(64));
+
+    const result = await loadFearGreed(true, async () => {
+      throw new Error("CNN unreachable");
+    });
+
+    expect(result.data.overall.score).toBe(64);
+    expect(result.stale).toBe(true);
+    expect(result.refreshError).toContain("CNN unreachable");
   });
 });

--- a/src/plugins/builtin/fear-greed/cache.ts
+++ b/src/plugins/builtin/fear-greed/cache.ts
@@ -32,8 +32,13 @@ export type FearGreedCacheEntry = {
   stale: boolean;
 };
 
+export interface FearGreedLoadResult extends FearGreedCacheEntry {
+  /** Set when the network failed and cached data was served instead. */
+  refreshError?: string;
+}
+
 let fearGreedPersistence: PluginPersistence | null = null;
-let activeFetch: Promise<FearGreedData> | null = null;
+let activeFetch: Promise<FearGreedLoadResult> | null = null;
 
 export function attachFearGreedPersistence(persistence: PluginPersistence): void {
   fearGreedPersistence = persistence;
@@ -118,10 +123,10 @@ export function getCachedFearGreedData(options?: { allowExpired?: boolean }): Fe
 export async function loadFearGreed(
   force = false,
   loader: () => Promise<FearGreedData> = fetchFearGreedData,
-): Promise<FearGreedData> {
+): Promise<FearGreedLoadResult> {
   const cached = getCachedFearGreedData();
   if (!force && cached && !cached.stale) {
-    return cached.data;
+    return cached;
   }
   if (activeFetch) return activeFetch;
 
@@ -129,10 +134,17 @@ export async function loadFearGreed(
   activeFetch = loader()
     .then((data) => {
       writeCache(data);
-      return data;
+      return { data, fetchedAt: Date.now(), stale: false };
     })
-    .catch((error) => {
-      if (fallback) return fallback.data;
+    .catch((error: unknown) => {
+      // A failed refresh must not be reported as a fresh load.
+      if (fallback) {
+        return {
+          ...fallback,
+          stale: true,
+          refreshError: error instanceof Error ? error.message : String(error),
+        };
+      }
       throw error;
     })
     .finally(() => {

--- a/src/plugins/builtin/fear-greed/charts.tsx
+++ b/src/plugins/builtin/fear-greed/charts.tsx
@@ -237,12 +237,19 @@ function ChartStats({
   secondaryValue?: number | null;
   valueFormat: FearGreedValueFormat;
 }) {
+  // The index history charts the score itself, so its "latest" repeats the score.
+  const latestText = formatIndicatorValue(latest, valueFormat);
+  const showLatest = latestText !== formatScore(score);
   return (
     <>
       <Text fg={colors.textDim}>score </Text>
       <Text fg={color} attributes={TextAttributes.BOLD}>{formatScore(score)}</Text>
-      <Text fg={colors.textDim}>  latest </Text>
-      <Text fg={colors.text}>{formatIndicatorValue(latest, valueFormat)}</Text>
+      {showLatest ? (
+        <>
+          <Text fg={colors.textDim}>  latest </Text>
+          <Text fg={colors.text}>{latestText}</Text>
+        </>
+      ) : null}
       {secondaryLabel && secondaryValue != null ? (
         <>
           <Text fg={colors.textDim}>  avg </Text>

--- a/src/plugins/builtin/fear-greed/pane.tsx
+++ b/src/plugins/builtin/fear-greed/pane.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Box, ScrollBox, Text, TextAttributes, useUiHost } from "../../../ui";
 import { useShortcut } from "../../../react/input";
-import { SpeedometerGauge, usePaneFooter } from "../../../components";
+import { Button, EmptyState, Spinner, SpeedometerGauge, usePaneFooter } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import { colors } from "../../../theme/colors";
 import type { FearGreedData } from "./data";
@@ -23,6 +23,7 @@ export function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
   const [data, setData] = useState<FearGreedData | null>(initialCache?.data ?? null);
   const [loading, setLoading] = useState(!initialCache || initialCache.stale);
   const [error, setError] = useState<string | null>(null);
+  const [stale, setStale] = useState(initialCache?.stale ?? false);
   const [lastRefreshed, setLastRefreshed] = useState<number | null>(initialCache?.fetchedAt ?? null);
   const fetchGenRef = useRef(0);
 
@@ -32,10 +33,12 @@ export function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
     setLoading(true);
     setError(null);
     try {
-      const nextData = await loadFearGreed(force);
+      const result = await loadFearGreed(force);
       if (fetchGenRef.current !== gen) return;
-      setData(nextData);
-      setLastRefreshed(getCachedFearGreedData({ allowExpired: true })?.fetchedAt ?? Date.now());
+      setData(result.data);
+      setStale(result.stale);
+      setError(result.refreshError ?? null);
+      setLastRefreshed(result.fetchedAt);
     } catch (err) {
       if (fetchGenRef.current !== gen) return;
       setError(err instanceof Error ? err.message : String(err));
@@ -55,7 +58,7 @@ export function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
   }, [load]);
 
   const updatedAgo = useUpdatedAgo(lastRefreshed);
-  useAutoRefresh(lastRefreshed, refresh);
+  useAutoRefresh(stale ? null : lastRefreshed, refresh);
 
   const stackDesktopSummary = isDesktopWeb && width < DESKTOP_SUMMARY_STACK_WIDTH;
   const desktopSummaryRailWidth = stackDesktopSummary ? Math.max(18, Math.min(width - 2, 42)) : 26;
@@ -71,7 +74,7 @@ export function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
     }
   });
 
-  const footerAge = updatedAgo ? `refreshed ${updatedAgo}` : loading ? "loading" : "";
+  const footerAge = updatedAgo ? `updated ${updatedAgo}` : loading ? "loading" : "";
   usePaneFooter(paneId, () => ({
     info: [
       ...(data ? [{
@@ -80,16 +83,17 @@ export function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
           { text: `${formatScore(data.overall.score)} ${ratingLabel(data.overall.rating)}`, color: ratingColor(data.overall.rating), bold: true },
         ],
       }] : []),
+      ...(stale ? [{ id: "stale", parts: [{ text: "STALE", tone: "warning" as const }] }] : []),
       ...(footerAge ? [{ id: "age", parts: [{ text: footerAge, tone: loading ? "muted" as const : "value" as const }] }] : []),
       ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
     ],
-  }), [data, error, footerAge, loading, paneId]);
+  }), [data, error, footerAge, loading, paneId, stale]);
 
   if (loading && !data) {
     return (
       <Box flexDirection="column" width={width} height={height}>
         <Box flexGrow={1} justifyContent="center" alignItems="center">
-          <Text fg={colors.textMuted}>Loading Fear & Greed...</Text>
+          <Spinner label="Loading Fear & Greed..." />
         </Box>
       </Box>
     );
@@ -97,10 +101,8 @@ export function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
 
   if (!data) {
     return (
-      <Box flexDirection="column" width={width} height={height}>
-        <Box flexGrow={1} justifyContent="center" alignItems="center" paddingX={1}>
-          <Text fg={colors.negative}>{error ?? "Fear & Greed data unavailable"}</Text>
-        </Box>
+      <Box flexDirection="column" width={width} height={height} padding={1} gap={1}>
+        <EmptyState title="Fear & Greed unavailable." message={error ?? undefined} />
       </Box>
     );
   }
@@ -143,7 +145,7 @@ export function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
           )}
           {loading ? (
             <Box height={1} paddingX={1} marginTop={1} justifyContent="center">
-              <Text fg={colors.textMuted}>refreshing...</Text>
+              <Spinner label="refreshing..." />
             </Box>
           ) : null}
           {error ? (
@@ -153,7 +155,9 @@ export function FearGreedPane({ paneId, focused, width, height }: PaneProps) {
           ) : null}
           <IndexHistoryChart data={data} width={width} />
           <Box flexDirection="row" paddingX={1} marginTop={2} height={1}>
-            <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>7 FEAR & GREED INDICATORS</Text>
+            <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+              {`${data.indicators.length} FEAR & GREED INDICATORS`}
+            </Text>
           </Box>
           {data.indicators.map((indicator) => (
             <IndicatorChart key={indicator.definition.id} indicator={indicator} width={width} />

--- a/src/plugins/builtin/futures/index.tsx
+++ b/src/plugins/builtin/futures/index.tsx
@@ -7,20 +7,21 @@ import {
   type DataTableRootKeyContext,
   type PaneFooterSegment,
 } from "../../../components";
-import { usePaneInstance } from "../../../state/app/context";
+import { useAppSelector, usePaneInstance } from "../../../state/app/context";
 import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
 import type { PaneProps } from "../../../types/plugin";
 import { type InputRenderable } from "../../../ui";
 import { isPlainKey } from "../../../utils/keyboard";
 import { isPlainArrowUp, stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
 import { cycleSortPreference } from "../../../utils/sort-values";
-import { usePluginTickerActions } from "../../runtime";
+import { useAssetData, usePluginTickerActions } from "../../runtime";
 import type { PluginModule } from "../plugin-module";
 import {
   quoteBoardFooterInfo,
   quoteBoardStatus,
   useQuoteBoard,
 } from "../shared/use-quote-board";
+import { boardErrorMessage } from "../world-indices/footer";
 import {
   FUTURES_CONTRACTS,
   FUTURES_SECTOR_LABELS,
@@ -42,18 +43,24 @@ import {
   FUTURES_COLUMN_DEFS,
   renderFuturesCell,
   resolveFuturesColumnIds,
+  usesSessionText,
   type FuturesColumn,
 } from "./table";
 
 export const FUTURES_PANE_ID = "futures";
 
-const REFRESH_INTERVAL_MS = 60_000;
 const FUTURES_SYMBOLS = FUTURES_CONTRACTS.map((contract) => contract.symbol);
 
 function FuturesPane({ focused, width, height }: PaneProps) {
   const { pinTicker } = usePluginTickerActions();
+  const dataProvider = useAssetData();
   const paneInstance = usePaneInstance();
-  const { quotes, refresh } = useQuoteBoard(FUTURES_SYMBOLS, REFRESH_INTERVAL_MS);
+  // One cadence, the one the user configured, instead of a private 60s timer.
+  const refreshIntervalMinutes = useAppSelector((state) => state.config.refreshIntervalMinutes);
+  const { quotes, refresh } = useQuoteBoard(
+    FUTURES_SYMBOLS,
+    Math.max(1, refreshIntervalMinutes || 1) * 60_000,
+  );
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [sortPreference, setSortPreference] = useState<FuturesSortPreference>(DEFAULT_FUTURES_SORT);
   const [searchQuery, setSearchQuery] = useState("");
@@ -81,12 +88,13 @@ function FuturesPane({ focused, width, height }: PaneProps) {
     [visibleColumnIds, width],
   );
 
+  const sessionText = usesSessionText(width);
   const renderCell = useCallback((
     row: FuturesTableRow,
     column: FuturesColumn,
     _index: number,
     rowState: { selected: boolean },
-  ) => renderFuturesCell(row, column, rowState, quotes), [quotes]);
+  ) => renderFuturesCell(row, column, rowState, quotes, { sessionText }), [quotes, sessionText]);
 
   const focusSearch = useCallback(() => {
     setSearchFocused(true);
@@ -154,8 +162,10 @@ function FuturesPane({ focused, width, height }: PaneProps) {
   }, [focusSearch, handlePaneKey]);
 
   const status = quoteBoardStatus(quotes);
+  const errorMessage = boardErrorMessage(quotes);
   usePaneFooter(FUTURES_PANE_ID, () => {
     const info: PaneFooterSegment[] = quoteBoardFooterInfo(status);
+    if (errorMessage) info.push({ id: "reason", parts: [{ text: errorMessage, tone: "warning" }] });
     if (searchQuery.trim()) {
       info.push({ id: "search", parts: [{ text: `search: ${searchQuery.trim()}`, tone: "value" }] });
     }
@@ -164,6 +174,7 @@ function FuturesPane({ focused, width, height }: PaneProps) {
       hints: [{ id: "search", key: "/", label: "search", onPress: focusSearch }],
     };
   }, [
+    errorMessage,
     focusSearch,
     searchQuery,
     status.latestTs,
@@ -192,7 +203,7 @@ function FuturesPane({ focused, width, height }: PaneProps) {
       rootWidth={width}
       rootHeight={height}
       columns={columns}
-      items={rows}
+      items={dataProvider ? rows : []}
       sortColumnId={sortPreference.columnId}
       sortDirection={sortPreference.direction}
       onHeaderClick={(columnId) => setSortPreference((current) => nextFuturesSort(current, columnId))}
@@ -204,8 +215,10 @@ function FuturesPane({ focused, width, height }: PaneProps) {
         }
         : null}
       renderCell={renderCell}
-      emptyStateTitle={searchQuery.trim() ? "No matching contracts." : "No contracts configured."}
-      emptyStateHint={searchQuery.trim() ? "Clear search." : "Press / to search."}
+      emptyStateTitle={searchQuery.trim()
+        ? "No matching contracts."
+        : "No market data provider connected."}
+      emptyStateHint={searchQuery.trim() ? "Clear search." : undefined}
       rootBefore={(
         <InputSearchBar
           value={searchQuery}

--- a/src/plugins/builtin/futures/model.ts
+++ b/src/plugins/builtin/futures/model.ts
@@ -6,7 +6,16 @@ export type FuturesTableRow =
   | { type: "header"; sector: FuturesSector }
   | { type: "row"; contract: FuturesContract };
 
-export type FuturesColumnId = "status" | "code" | "name" | "price" | "change" | "changePercent";
+export type FuturesColumnId =
+  | "status"
+  | "code"
+  | "name"
+  | "price"
+  | "change"
+  | "changePercent"
+  | "volume"
+  | "prevClose"
+  | "time";
 
 export interface FuturesSortPreference {
   columnId: FuturesColumnId | null;
@@ -51,6 +60,12 @@ function getSortValue(
       return quote?.change ?? null;
     case "changePercent":
       return quote?.changePercent ?? null;
+    case "volume":
+      return quote?.volume ?? null;
+    case "prevClose":
+      return quote?.previousClose ?? null;
+    case "time":
+      return quote?.lastUpdated ?? null;
   }
 }
 

--- a/src/plugins/builtin/futures/table.test.ts
+++ b/src/plugins/builtin/futures/table.test.ts
@@ -10,6 +10,7 @@ import {
 import type { FuturesColumnId, FuturesTableRow } from "./model";
 import {
   createFuturesColumns,
+  FUTURES_COLUMN_DEFS,
   renderFuturesCell,
   resolveFuturesColumnIds,
   type FuturesColumn,
@@ -82,10 +83,11 @@ describe("futures price formatting", () => {
 
 describe("futures columns", () => {
   test("honors a saved column selection and falls back when it is unusable", () => {
+    const fullSet = FUTURES_COLUMN_DEFS.length;
     expect(resolveFuturesColumnIds(["code", "price"])).toEqual(["code", "price"]);
-    expect(resolveFuturesColumnIds([])).toHaveLength(6);
-    expect(resolveFuturesColumnIds(["bogus"])).toHaveLength(6);
-    expect(resolveFuturesColumnIds(undefined)).toHaveLength(6);
+    expect(resolveFuturesColumnIds([])).toHaveLength(fullSet);
+    expect(resolveFuturesColumnIds(["bogus"])).toHaveLength(fullSet);
+    expect(resolveFuturesColumnIds(undefined)).toHaveLength(fullSet);
   });
 
   test("gives the name column the leftover width whichever columns are visible", () => {
@@ -95,6 +97,17 @@ describe("futures columns", () => {
       expect(total).toBeLessThanOrEqual(80);
       expect(columns.find((column) => column.id === "name")?.width ?? 0).toBeGreaterThanOrEqual(10);
     }
+  });
+
+  test("drops the extra columns a narrow board cannot fit instead of clipping them", () => {
+    const narrow = createFuturesColumns(80).map((column) => column.id);
+    expect(narrow).not.toContain("volume");
+    expect(narrow).not.toContain("time");
+
+    const wide = createFuturesColumns(130).map((column) => column.id);
+    expect(wide).toContain("volume");
+    expect(wide).toContain("prevClose");
+    expect(wide).toContain("time");
   });
 });
 

--- a/src/plugins/builtin/futures/table.tsx
+++ b/src/plugins/builtin/futures/table.tsx
@@ -1,9 +1,11 @@
 import type { DataTableCell, DataTableColumn } from "../../../components";
+import { marketStateColor, marketStateLabel } from "../../../market-data/market/status";
 import { colors, priceColor } from "../../../theme/colors";
 import type { Quote } from "../../../types/financials";
 import { TextAttributes } from "../../../ui";
-import { formatNumber, formatPercentRaw } from "../../../utils/format";
+import { formatCompact, formatNumber, formatPercentRaw } from "../../../utils/format";
 import { marketStatusDot, type BoardQuoteMap } from "../shared/use-quote-board";
+import { formatQuoteTime } from "../world-indices/table";
 import { tickDecimals, type FuturesContract } from "./contracts";
 import type { FuturesColumnId, FuturesTableRow } from "./model";
 
@@ -22,9 +24,23 @@ export const FUTURES_COLUMN_DEFS: readonly FuturesColumnDef[] = [
   { id: "price", label: "Last", description: "Last traded price." },
   { id: "change", label: "Change", description: "Change on the session." },
   { id: "changePercent", label: "Change %", description: "Percent change on the session." },
+  { id: "volume", label: "Volume", description: "Contracts traded on the session." },
+  { id: "prevClose", label: "Prev close", description: "Previous session close." },
+  { id: "time", label: "Time", description: "Local time of the last quote." },
 ];
 
 const DEFAULT_FUTURES_COLUMN_IDS = FUTURES_COLUMN_DEFS.map((column) => column.id);
+
+/**
+ * Extra columns only earn their width once the board is wide enough to keep a
+ * readable contract name; a narrow pane drops them instead of clipping.
+ */
+const COLUMN_MIN_PANE_WIDTH: Partial<Record<FuturesColumnId, number>> = {
+  volume: 92,
+  prevClose: 104,
+  time: 114,
+};
+const SESSION_TEXT_MIN_WIDTH = 100;
 
 const COLUMN_WIDTHS: Record<Exclude<FuturesColumnId, "name">, number> = {
   status: 1,
@@ -32,23 +48,46 @@ const COLUMN_WIDTHS: Record<Exclude<FuturesColumnId, "name">, number> = {
   price: 12,
   change: 10,
   changePercent: 9,
+  volume: 9,
+  prevClose: 12,
+  // 5-char 24h time in an 8-wide column: the shared table's floating-pane width
+  // accounting runs a few cells long, and the slack keeps the value intact.
+  time: 8,
 };
 
+/** A colored dot needs a legend; the session word does not, so wide boards spell it out. */
+export function usesSessionText(width: number): boolean {
+  return width >= SESSION_TEXT_MIN_WIDTH;
+}
+
+function columnWidth(id: Exclude<FuturesColumnId, "name">, paneWidth: number): number {
+  if (id === "status") return usesSessionText(paneWidth) ? 9 : 1;
+  return COLUMN_WIDTHS[id];
+}
+
 export function createFuturesColumns(width: number, visibleIds?: readonly string[]): FuturesColumn[] {
-  const ids = resolveFuturesColumnIds(visibleIds);
+  const ids = resolveFuturesColumnIds(visibleIds)
+    .filter((id) => width >= (COLUMN_MIN_PANE_WIDTH[id] ?? 0));
   const fixed = ids
     .filter((id): id is Exclude<FuturesColumnId, "name"> => id !== "name")
-    .reduce((total, id) => total + COLUMN_WIDTHS[id], 0);
-  const nameWidth = Math.max(10, width - 2 - ids.length - fixed);
+    .reduce((total, id) => total + columnWidth(id, width), 0);
+  // Leaves room for the pane border and scrollbar gutter; the name column grows
+  // back into any slack because it is the flexible one.
+  const nameWidth = Math.max(10, width - 6 - ids.length - fixed);
 
   return ids.map((id) => {
-    const label = FUTURES_HEADER_LABELS[id];
-    if (id === "name") return { id, label, width: nameWidth, align: "left" };
+    const label = id === "status" && usesSessionText(width) ? "SESSION" : FUTURES_HEADER_LABELS[id];
+    // The leftover width lands on the contract name rather than being spread
+    // across the number columns, which is what left a dead zone after it.
+    if (id === "name") return { id, label, width: nameWidth, align: "left", flexGrow: 1 };
     return {
       id,
       label,
-      width: COLUMN_WIDTHS[id],
-      align: id === "code" || id === "status" ? "left" : "right",
+      width: columnWidth(id, width),
+      // TIME is left-aligned like the text columns: the shared table trims a few
+      // cells off the right edge of a floating pane, and a right-aligned value
+      // there would lose digits.
+      align: id === "code" || id === "status" || id === "time" ? "left" : "right",
     };
   });
 }
@@ -60,6 +99,9 @@ const FUTURES_HEADER_LABELS: Record<FuturesColumnId, string> = {
   price: "LAST",
   change: "CHG",
   changePercent: "CHG%",
+  volume: "VOL",
+  prevClose: "PREV",
+  time: "TIME",
 };
 
 /** Falls back to the full column set when the saved selection is empty or unknown. */
@@ -120,6 +162,7 @@ export function renderFuturesCell(
   column: FuturesColumn,
   rowState: { selected: boolean },
   quotes: BoardQuoteMap,
+  options?: { sessionText?: boolean },
 ): DataTableCell {
   if (row.type === "header") return { text: "" };
 
@@ -128,9 +171,21 @@ export function renderFuturesCell(
   const quote = state?.quote;
   const selectedColor = rowState.selected ? colors.selectedText : undefined;
   const dimmed = rowState.selected ? colors.selectedText : colors.textDim;
+  // One row must not mix a loading marker with a no-data marker.
+  const loadingCell = !quote && (state?.loading ?? true);
 
   switch (column.id) {
     case "status": {
+      if (loadingCell) return { text: "", color: dimmed };
+      if (options?.sessionText) {
+        const marketState = quote?.marketState;
+        return {
+          text: marketState ? marketStateLabel(marketState) : "—",
+          color: rowState.selected
+            ? colors.selectedText
+            : marketState ? marketStateColor(marketState) : colors.textDim,
+        };
+      }
       const dot = marketStatusDot(quote?.marketState);
       return { text: dot.char, color: rowState.selected ? colors.selectedText : dot.color };
     }
@@ -143,7 +198,7 @@ export function renderFuturesCell(
     case "name":
       return { text: contract.name, color: selectedColor };
     case "price":
-      if (state?.loading && !quote) return { text: "…", color: dimmed };
+      if (loadingCell) return { text: "…", color: dimmed };
       if (!quote) return { text: "—", color: dimmed };
       // A retained quote still beats a dash; dim it so stale is visible.
       return {
@@ -151,16 +206,36 @@ export function renderFuturesCell(
         color: state?.stale ? dimmed : selectedColor,
       };
     case "change":
+      if (loadingCell) return { text: "…", color: dimmed };
       if (!quote || !Number.isFinite(quote.change)) return { text: "—", color: dimmed };
       return {
         text: formatContractChange(quote, contract),
         color: selectedColor ?? priceColor(quote.change),
       };
     case "changePercent":
+      if (loadingCell) return { text: "…", color: dimmed };
       if (!quote || !Number.isFinite(quote.changePercent)) return { text: "—", color: dimmed };
       return {
         text: formatPercentRaw(quote.changePercent),
         color: selectedColor ?? priceColor(quote.changePercent),
       };
+    case "volume":
+      if (loadingCell) return { text: "…", color: dimmed };
+      if (!quote || quote.volume == null || !Number.isFinite(quote.volume)) {
+        return { text: "—", color: dimmed };
+      }
+      return { text: formatCompact(quote.volume), color: selectedColor ?? colors.textDim };
+    case "prevClose":
+      if (loadingCell) return { text: "…", color: dimmed };
+      if (!quote || quote.previousClose == null || !Number.isFinite(quote.previousClose)) {
+        return { text: "—", color: dimmed };
+      }
+      return {
+        text: formatContractPrice({ ...quote, price: quote.previousClose }, contract),
+        color: selectedColor ?? colors.textDim,
+      };
+    case "time":
+      if (loadingCell) return { text: "…", color: dimmed };
+      return { text: formatQuoteTime(quote?.lastUpdated), color: dimmed };
   }
 }

--- a/src/plugins/builtin/fx-matrix/index.tsx
+++ b/src/plugins/builtin/fx-matrix/index.tsx
@@ -1,156 +1,193 @@
-import { Box, ScrollBox, Text } from "../../../ui";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { TextAttributes } from "../../../ui";
-import { useShortcut } from "../../../react/input";
-import { usePaneFooter } from "../../../components";
+import { useCallback, useMemo, useState } from "react";
+import {
+  DataTableView,
+  usePaneFooter,
+  type DataTableCell,
+  type DataTableColumn,
+  type DataTableKeyEvent,
+  type PaneFooterSegment,
+} from "../../../components";
+import { getSharedMarketDataCoordinator } from "../../../market-data/coordinator";
+import { useFxRatesMap } from "../../../market-data/hooks";
+import { usePaneSettingValue } from "../../../state/app/context";
+import { colors } from "../../../theme/colors";
 import type { PaneProps } from "../../../types/plugin";
-import type { PluginModule } from "../plugin-module";
-import { colors, blendHex } from "../../../theme/colors";
+import { TextAttributes } from "../../../ui";
+import { isPlainKey } from "../../../utils/keyboard";
 import { useAssetData } from "../../runtime";
-import { useUpdatedAgo } from "../shared/auto-refresh";
-import { MAJOR_CURRENCIES, formatRate, type MajorCurrency } from "./pairs";
+import type { PluginModule } from "../plugin-module";
+import { useAutoRefresh, useUpdatedAgo } from "../shared/auto-refresh";
+import { MAJOR_CURRENCIES, formatRate, resolveCurrencies, type MajorCurrency } from "./pairs";
 
-// Cross rates are a live board, so this pane keeps its own fast cadence rather
-// than following the global refresh interval.
-const REFRESH_INTERVAL_MS = 60_000;
+const FX_MATRIX_PANE_ID = "fx-matrix";
+/** Stable identity: a fresh literal here would reload the board every render. */
+const NO_SAVED_CURRENCIES: string[] = [];
+const BASE_COLUMN_WIDTH = 5;
+const RATE_COLUMN_WIDTH = 10;
+
+interface FxStatus {
+  loading: number;
+  unavailable: number;
+  latestTs: number;
+}
+
+/**
+ * Per-currency load state for the footer and the cell placeholders. The rates
+ * map above already subscribes this pane to the same coordinator keys, so
+ * reading the entries here re-renders with it.
+ */
+function readFxStatus(currencies: readonly MajorCurrency[], rates: Map<string, number>): FxStatus {
+  const coordinator = getSharedMarketDataCoordinator();
+  let loading = 0;
+  let unavailable = 0;
+  let latestTs = 0;
+  for (const currency of currencies) {
+    if (currency === "USD") continue;
+    const entry = coordinator?.getFxEntry(currency) ?? null;
+    if (entry?.phase === "loading") loading += 1;
+    else if (!rates.has(currency)) unavailable += 1;
+    latestTs = Math.max(latestTs, entry?.fetchedAt ?? 0);
+  }
+  return { loading, unavailable, latestTs };
+}
 
 function FxMatrixPane({ focused, width, height }: PaneProps) {
   const dataProvider = useAssetData();
-  const [rates, setRates] = useState<Map<MajorCurrency, number>>(new Map());
-  const [loading, setLoading] = useState(true);
-  const [lastRefreshed, setLastRefreshed] = useState<number | null>(null);
-  const fetchGenRef = useRef(0);
+  const [savedCurrencies] = usePaneSettingValue<string[]>("currencies", NO_SAVED_CURRENCIES);
+  const currencies = useMemo(() => resolveCurrencies(savedCurrencies), [savedCurrencies]);
+  const [selectedCurrency, setSelectedCurrency] = useState<string | null>(null);
 
-  const fetchRates = useCallback(async () => {
-    if (!dataProvider) return;
+  const rates = useFxRatesMap(currencies);
+  const status = useMemo(() => readFxStatus(currencies, rates), [currencies, rates]);
 
-    fetchGenRef.current += 1;
-    const gen = fetchGenRef.current;
-
-    try {
-      const results = await Promise.allSettled(
-        MAJOR_CURRENCIES.map(async (currency) => {
-          if (currency === "USD") return { currency, rate: 1 };
-          const rate = await dataProvider.getExchangeRate(currency);
-          return { currency, rate };
-        }),
-      );
-
-      if (fetchGenRef.current !== gen) return;
-
-      const newRates = new Map<MajorCurrency, number>();
-      for (const result of results) {
-        if (result.status === "fulfilled") {
-          newRates.set(result.value.currency as MajorCurrency, result.value.rate);
-        }
-      }
-
-      setRates(newRates);
-      setLastRefreshed(Date.now());
-    } finally {
-      if (fetchGenRef.current === gen) setLoading(false);
+  const refresh = useCallback(() => {
+    const coordinator = getSharedMarketDataCoordinator();
+    if (!coordinator) return;
+    // A rate that is still fresh is left alone by the coordinator; a failed one
+    // is retried, which is the case that matters here.
+    for (const currency of currencies) {
+      if (currency === "USD") continue;
+      void coordinator.loadFxRate(currency).catch(() => {});
     }
-  }, [dataProvider]);
+  }, [currencies]);
 
-  useEffect(() => {
-    fetchRates();
-    const interval = setInterval(fetchRates, REFRESH_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, [fetchRates]);
+  useAutoRefresh(status.latestTs || null, refresh);
 
-  useShortcut((event) => {
-    if (!focused) return;
-    if (event.name === "r") {
-      fetchRates();
+  const columns = useMemo<DataTableColumn[]>(() => [
+    { id: "base", label: "", width: BASE_COLUMN_WIDTH, align: "left" },
+    ...currencies.map((currency) => ({
+      id: currency,
+      label: currency,
+      width: RATE_COLUMN_WIDTH,
+      align: "right" as const,
+    })),
+  ], [currencies]);
+
+  const renderCell = useCallback((
+    row: MajorCurrency,
+    column: DataTableColumn,
+    _index: number,
+    rowState: { selected: boolean },
+  ): DataTableCell => {
+    const selectedColor = rowState.selected ? colors.selectedText : undefined;
+    if (column.id === "base") {
+      return {
+        text: row,
+        color: selectedColor ?? colors.textBright,
+        attributes: TextAttributes.BOLD,
+      };
     }
-  });
 
-  const headerBg = blendHex(colors.bg, colors.border, 0.3);
+    const quoteCurrency = column.id as MajorCurrency;
+    const dimmed = selectedColor ?? colors.textDim;
+    if (row === quoteCurrency) return { text: formatRate(1, quoteCurrency), color: dimmed };
 
-  function crossRate(row: MajorCurrency, col: MajorCurrency): number | null {
-    if (row === col) return 1;
-    const rowUsd = rates.get(row);
-    const colUsd = rates.get(col);
-    if (rowUsd == null || colUsd == null) return null;
-    return rowUsd / colUsd;
-  }
+    const base = rates.get(row);
+    const quote = rates.get(quoteCurrency);
+    if (base == null || quote == null) {
+      // A missing leg must never fall back to parity: 1.0000 on EUR/JPY reads
+      // as a real rate.
+      const pending = status.loading > 0;
+      return { text: pending ? "…" : "—", color: dimmed };
+    }
+    return { text: formatRate(base / quote, quoteCurrency), color: selectedColor ?? colors.text };
+  }, [rates, status.loading]);
 
-  const updatedAgo = useUpdatedAgo(lastRefreshed);
-  const ageText = updatedAgo ? `updated ${updatedAgo}` : loading ? "loading…" : "";
+  const handleKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (!isPlainKey(event, "r")) return false;
+    event.preventDefault?.();
+    refresh();
+    return true;
+  }, [refresh]);
 
-  usePaneFooter("fx-matrix", () => ({
-    info: ageText ? [{ id: "updated", parts: [{ text: ageText, tone: loading ? "muted" : "value" }] }] : [],
-  }), [ageText, loading]);
+  const updatedAgo = useUpdatedAgo(status.latestTs || null);
 
-  // Row header: just the 3-letter code, no emoji (keeps width predictable)
-  // Rates use flexGrow so they fill available space dynamically
+  usePaneFooter(FX_MATRIX_PANE_ID, () => {
+    const info: PaneFooterSegment[] = [];
+    if (status.loading > 0) info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
+    if (status.unavailable > 0) {
+      info.push({
+        id: "unavailable",
+        parts: [{ text: `${status.unavailable} unavailable`, tone: "warning" }],
+      });
+    }
+    if (updatedAgo) info.push({ id: "updated", parts: [{ text: `updated ${updatedAgo}`, tone: "muted" }] });
+    return { info };
+  }, [status.loading, status.unavailable, updatedAgo]);
 
   return (
-    <Box flexDirection="column" width={width} height={height}>
-      {/* Column header row */}
-      <Box flexDirection="row" paddingX={1} height={1} backgroundColor={headerBg}>
-        <Box width={5} flexShrink={0} />
-        {MAJOR_CURRENCIES.map((col) => (
-          <Box key={col} flexGrow={1} justifyContent="flex-end" paddingRight={1}>
-            <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>{col}</Text>
-          </Box>
-        ))}
-      </Box>
-
-      {/* Matrix rows */}
-      <ScrollBox flexGrow={1} scrollY focusable={false}>
-        <Box flexDirection="column">
-          {loading && rates.size === 0 ? (
-            <Box paddingX={1} paddingY={1}>
-              <Text fg={colors.textMuted}>Fetching rates…</Text>
-            </Box>
-          ) : (
-            MAJOR_CURRENCIES.map((row) => (
-              <Box key={row} flexDirection="row" paddingX={1}>
-                <Box width={5} flexShrink={0}>
-                  <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{row}</Text>
-                </Box>
-                {MAJOR_CURRENCIES.map((col) => {
-                  const rate = crossRate(row, col);
-                  const isDiag = row === col;
-                  return (
-                    <Box key={col} flexGrow={1} justifyContent="flex-end" paddingRight={1}>
-                      {rate == null ? (
-                        <Text fg={colors.textDim}>—</Text>
-                      ) : (
-                        <Text fg={isDiag ? colors.textDim : colors.text}>
-                          {formatRate(rate, col)}
-                        </Text>
-                      )}
-                    </Box>
-                  );
-                })}
-              </Box>
-            ))
-          )}
-        </Box>
-      </ScrollBox>
-    </Box>
+    <DataTableView<MajorCurrency>
+      focused={focused}
+      selection={{
+        kind: "id",
+        selectedId: selectedCurrency ?? currencies[0] ?? null,
+        getId: (row) => row,
+        onChange: (id) => setSelectedCurrency(id),
+      }}
+      rootWidth={width}
+      rootHeight={height}
+      columns={columns}
+      items={dataProvider ? currencies : []}
+      sortColumnId={null}
+      sortDirection="asc"
+      onHeaderClick={() => {}}
+      getItemKey={(row) => row}
+      renderCell={renderCell}
+      onRootKeyDown={handleKeyDown}
+      emptyStateTitle="No market data provider connected."
+    />
   );
 }
 
 export const fxMatrixModule: PluginModule = {
   panes: [
     {
-      id: "fx-matrix",
+      id: FX_MATRIX_PANE_ID,
       name: "FX Cross Rates",
       icon: "F",
       component: FxMatrixPane,
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 105, height: 14 },
+      settings: (context) => ({
+        title: "FX Cross Rates Settings",
+        values: {
+          currencies: resolveCurrencies(context.settings.currencies as string[] | undefined),
+        },
+        fields: [{
+          key: "currencies",
+          label: "Currencies",
+          type: "ordered-multi-select",
+          options: MAJOR_CURRENCIES.map((currency) => ({ value: currency, label: currency })),
+        }],
+      }),
     },
   ],
 
   paneTemplates: [
     {
       id: "fx-matrix-pane",
-      paneId: "fx-matrix",
+      paneId: FX_MATRIX_PANE_ID,
       label: "FX Cross Rates",
       description: "Currency cross-rate matrix for major FX pairs.",
       keywords: ["fx", "forex", "currency", "exchange", "rates", "cross", "matrix"],

--- a/src/plugins/builtin/fx-matrix/pairs.ts
+++ b/src/plugins/builtin/fx-matrix/pairs.ts
@@ -3,7 +3,18 @@ export const MAJOR_CURRENCIES = ["USD", "EUR", "GBP", "JPY", "CHF", "CAD", "AUD"
 export type MajorCurrency = typeof MAJOR_CURRENCIES[number];
 
 /** Format rate with appropriate precision — JPY pairs get 2 decimals, others get 4 */
-export function formatRate(rate: number, toCurrency: MajorCurrency): string {
+export function formatRate(rate: number, toCurrency: string): string {
   const decimals = toCurrency === "JPY" ? 2 : 4;
   return rate.toFixed(decimals);
+}
+
+/**
+ * The saved currency selection, falling back to the majors when it is empty or
+ * holds codes this board does not carry.
+ */
+export function resolveCurrencies(saved?: readonly string[]): MajorCurrency[] {
+  const resolved = (saved ?? []).filter(
+    (code): code is MajorCurrency => MAJOR_CURRENCIES.includes(code as MajorCurrency),
+  );
+  return resolved.length > 0 ? resolved : [...MAJOR_CURRENCIES];
 }

--- a/src/plugins/builtin/fx-matrix/pane.test.tsx
+++ b/src/plugins/builtin/fx-matrix/pane.test.tsx
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import {
+  MarketDataCoordinator,
+  setSharedMarketDataCoordinator,
+} from "../../../market-data/coordinator";
+import type { QueryEntry } from "../../../market-data/result-types";
+import { AppContext, createInitialState, PaneInstanceProvider } from "../../../state/app/context";
+import { createDefaultConfig } from "../../../types/config";
+import { PluginRenderProvider, type PluginRuntimeAccess } from "../../runtime";
+import { fxMatrixModule } from "./index";
+
+const FxMatrixPane = fxMatrixModule.panes![0]!.component as (props: {
+  paneId: string;
+  paneType: string;
+  focused: boolean;
+  width: number;
+  height: number;
+}) => React.ReactNode;
+
+function readyEntry(rate: number): QueryEntry<number> {
+  return {
+    phase: "ready",
+    data: rate,
+    lastGoodData: rate,
+    source: "test",
+    fetchedAt: 1,
+    staleAt: null,
+    error: null,
+    attempts: [],
+  };
+}
+
+function errorEntry(): QueryEntry<number> {
+  return {
+    phase: "error",
+    data: null,
+    lastGoodData: null,
+    source: "test",
+    fetchedAt: null,
+    staleAt: null,
+    error: { reasonCode: "upstream", message: "no rate" },
+    attempts: [],
+  };
+}
+
+/** Every currency resolves except JPY, which has no rate at all. */
+const RATES: Record<string, number> = { EUR: 1.08, GBP: 1.27, CHF: 1.12, CAD: 0.73, AUD: 0.65, NZD: 0.6 };
+
+function installCoordinator(): void {
+  setSharedMarketDataCoordinator({
+    subscribe: () => () => {},
+    subscribeKeys: () => () => {},
+    getVersion: () => 1,
+    getFxEntry: (currency: string) => (
+      RATES[currency] != null ? readyEntry(RATES[currency]!) : errorEntry()
+    ),
+    loadFxRate: async () => {},
+  } as unknown as MarketDataCoordinator);
+}
+
+function Harness() {
+  const state = createInitialState(createDefaultConfig("/tmp/gloomberb-fxc-pane-test"));
+  const runtime = { getMarketData: () => ({}) } as unknown as PluginRuntimeAccess;
+
+  return (
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <PluginRenderProvider runtime={runtime} pluginId="market-overview">
+        <PaneInstanceProvider paneId="fx-matrix">
+          <FxMatrixPane paneId="fx-matrix" paneType="fx-matrix" focused width={100} height={14} />
+        </PaneInstanceProvider>
+      </PluginRenderProvider>
+    </AppContext>
+  );
+}
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(async () => {
+  if (testSetup) {
+    await act(async () => {
+      testSetup!.renderer.destroy();
+    });
+    testSetup = undefined;
+  }
+  setSharedMarketDataCoordinator(null);
+});
+
+describe("FxMatrixPane", () => {
+  test("renders a missing rate as unavailable instead of parity", async () => {
+    installCoordinator();
+    testSetup = await testRender(<Harness />, { width: 100, height: 14 });
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const frame = testSetup.captureCharFrame();
+    // EUR/USD is a real cross built from the two USD legs.
+    expect(frame).toContain("1.0800");
+
+    // Regression: a currency with no rate rendered 1.0000 against everything.
+    const jpyRow = frame.split("\n").find((line) => line.trimStart().startsWith("JPY"));
+    expect(jpyRow).toBeDefined();
+    expect(jpyRow).not.toContain("1.0000");
+    expect(jpyRow).toContain("—");
+  });
+});

--- a/src/plugins/builtin/help/components.tsx
+++ b/src/plugins/builtin/help/components.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { Box, Text, TextAttributes } from "../../../ui";
-import { colors, hoverBg } from "../../../theme/colors";
+import { colors } from "../../../theme/colors";
 import { t } from "../../../i18n";
 
 export interface HelpShortcutEntry {
@@ -44,35 +44,6 @@ export function HelpSection({ title, children }: { title: string; children: Reac
     <Box flexDirection="column" marginTop={1}>
       <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{t(title)}</Text>
       {children}
-    </Box>
-  );
-}
-
-export function ActionButton({
-  id,
-  label,
-  hovered,
-  onHover,
-  onPress,
-}: {
-  id: string;
-  label: string;
-  hovered: boolean;
-  onHover: (id: string | null) => void;
-  onPress: () => void;
-}) {
-  return (
-    <Box
-      backgroundColor={hovered ? hoverBg() : colors.panel}
-      onMouseOver={() => onHover(id)}
-      onMouseOut={() => onHover(null)}
-      onMouseDown={(event: any) => {
-        event.stopPropagation?.();
-        event.preventDefault?.();
-        onPress();
-      }}
-    >
-      <Text fg={hovered ? colors.textBright : colors.text}>{` ${t(label)} `}</Text>
     </Box>
   );
 }

--- a/src/plugins/builtin/help/index.tsx
+++ b/src/plugins/builtin/help/index.tsx
@@ -1,7 +1,7 @@
 import { Box, ScrollBox, Text, useUiHost } from "../../../ui";
 import { TextAttributes } from "../../../ui";
 import { useState } from "react";
-import { Tabs } from "../../../components";
+import { Button, Tabs } from "../../../components";
 import { ExternalLinkText } from "../../../components/ui";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
@@ -11,7 +11,6 @@ import { getSharedRegistry } from "../../registry";
 import { usePluginAppActions } from "../../runtime";
 import { detectShortcutPlatform, formatPrimaryShortcut, getShortcutDisplayMode } from "../../../utils/shortcut-labels";
 import {
-  ActionButton,
   HelpSection,
   ShortcutGroup,
   ShortcutRow,
@@ -37,7 +36,6 @@ function HelpPane({ focused, width, height }: PaneProps) {
   const registry = getSharedRegistry();
   const { openCommandBar, showPane } = usePluginAppActions();
   const [activeTabId, setActiveTabId] = useState<HelpTabId>("basics");
-  const [hoveredAction, setHoveredAction] = useState<string | null>(null);
   const commandShortcuts = resolveCommandShortcuts(registry);
   const pluginShortcuts = resolvePluginShortcuts(registry);
   const windowTemplates = resolveWindowTemplates(registry);
@@ -75,13 +73,7 @@ function HelpPane({ focused, width, height }: PaneProps) {
         return (
           <>
             <Box flexDirection="row" gap={1}>
-              <ActionButton
-                id="plugins"
-                label="Manage Plugins"
-                hovered={hoveredAction === "plugins"}
-                onHover={setHoveredAction}
-                onPress={openPluginManager}
-              />
+              <Button label="Manage Plugins" onPress={openPluginManager} />
             </Box>
 
             <HelpSection title="Command Prefixes">
@@ -306,13 +298,7 @@ function HelpPane({ focused, width, height }: PaneProps) {
         return (
           <>
             <Box flexDirection="row" gap={1}>
-              <ActionButton
-                id="debug"
-                label="Open Debug Log"
-                hovered={hoveredAction === "debug"}
-                onHover={setHoveredAction}
-                onPress={openDebugLog}
-              />
+              <Button label="Open Debug Log" onPress={openDebugLog} />
               <ExternalLinkText
                 url={GLOOMBERB_ISSUES_URL}
                 label={t("GitHub Issues")}
@@ -339,13 +325,7 @@ function HelpPane({ focused, width, height }: PaneProps) {
             </Box>
 
             <Box flexDirection="row" gap={1}>
-              <ActionButton
-                id="layout"
-                label="Layout Actions"
-                hovered={hoveredAction === "layout"}
-                onHover={setHoveredAction}
-                onPress={openLayoutActions}
-              />
+              <Button label="Layout Actions" onPress={openLayoutActions} />
             </Box>
 
             <HelpSection title="Command Bar">

--- a/src/plugins/builtin/holders/pane.tsx
+++ b/src/plugins/builtin/holders/pane.tsx
@@ -99,10 +99,12 @@ export function HoldersView({ focused, width, height }: { focused: boolean; widt
     setSelectedId(sortedRows[0]?.id ?? null);
   }, [selectedId, sortedRows]);
 
+  // Keyed on the holder set itself: re-sorting or a ticking market cap must not
+  // restart 25 two-request 13F lookups.
   useEffect(() => {
     fundMatchAbortRef.current?.abort();
     setFundMatches(new Map());
-    if (sortedRows.length === 0) {
+    if (rows.length === 0) {
       setFundMatching(false);
       return;
     }
@@ -110,7 +112,7 @@ export function HoldersView({ focused, width, height }: { focused: boolean; widt
     const controller = new AbortController();
     fundMatchAbortRef.current = controller;
     setFundMatching(true);
-    void loadHolder13FMatches(sortedRows, controller.signal)
+    void loadHolder13FMatches(rows, controller.signal)
       .then((matches) => {
         if (fundMatchAbortRef.current !== controller) return;
         setFundMatches(matches);
@@ -125,7 +127,7 @@ export function HoldersView({ focused, width, height }: { focused: boolean; widt
         fundMatchAbortRef.current = null;
       }
     };
-  }, [sortedRows]);
+  }, [rows]);
 
   const selectedRow = activeIdx >= 0 ? sortedRows[activeIdx] ?? null : null;
   const selectedFundMatch = selectedRow ? fundMatches.get(selectedRow.id) ?? null : null;
@@ -169,7 +171,7 @@ export function HoldersView({ focused, width, height }: { focused: boolean; widt
       toggleView();
       return true;
     }
-    if ((event.name === "f" || event.name === "enter" || event.name === "return") && selectedFundMatch) {
+    if ((event.name === "o" || event.name === "enter" || event.name === "return") && selectedFundMatch) {
       event.preventDefault?.();
       event.stopPropagation?.();
       openFundDetail(selectedRow);
@@ -208,7 +210,7 @@ export function HoldersView({ focused, width, height }: { focused: boolean; widt
       toggleView();
       return;
     }
-    if (isPlainKey(event, "f", "enter", "return") && selectedFundMatch) {
+    if (isPlainKey(event, "o", "enter", "return") && selectedFundMatch) {
       event.preventDefault?.();
       event.stopPropagation?.();
       openFundDetail(selectedRow);
@@ -262,16 +264,19 @@ export function HoldersView({ focused, width, height }: { focused: boolean; widt
       ],
       hints: [
         { id: "view", key: "s", label: "witch", onPress: toggleView },
-        ...(selectedFundMatch ? [{ id: "fund", key: "f", label: "und", onPress: () => openFundDetail(selectedRow) }] : []),
+        // `f` is the filter key in sibling panes, so opening a fund uses `o`.
+        ...(selectedFundMatch ? [{ id: "fund", key: "o", label: "pen 13F", onPress: () => openFundDetail(selectedRow) }] : []),
       ],
     };
   }, [data?.asOf, fundMatching, loading, openFundDetail, selectedFundMatch, selectedRow, toggleView]);
 
-  const emptyTitle = !symbol
-    ? "No ticker selected"
+  // Both views share one status; the treemap must not claim "no chartable
+  // values" while the request is still in flight or the pane has no ticker.
+  const statusTitle = !symbol
+    ? "No ticker selected."
     : loading
       ? "Loading holders..."
-      : error ?? "No holders available";
+      : error ?? (sortedRows.length === 0 ? "No holders available" : null);
   const chartHeight = Math.max(1, height - 1 - (nativePaneChrome ? 1 : 0));
 
   return (
@@ -307,11 +312,12 @@ export function HoldersView({ focused, width, height }: { focused: boolean; widt
           onHeaderClick={handleHeaderClick}
           getItemKey={(row) => row.id}
           renderCell={renderCell}
-          emptyStateTitle={emptyTitle}
+          emptyStateTitle={statusTitle ?? "No holders available"}
         />
       ) : (
         <HoldersTreemap
           rows={sortedRows}
+          emptyStateTitle={statusTitle ?? undefined}
           width={width}
           height={chartHeight}
           selectedId={selectedId}

--- a/src/plugins/builtin/holders/treemap.tsx
+++ b/src/plugins/builtin/holders/treemap.tsx
@@ -8,7 +8,7 @@ import {
 } from "./format";
 import type { HolderRow } from "./types";
 
-export function HoldersTreemap({ rows, width, height, selectedId, onSelect, onActivate, currency, marketCap }: {
+export function HoldersTreemap({ rows, width, height, selectedId, onSelect, onActivate, currency, marketCap, emptyStateTitle }: {
   rows: HolderRow[];
   width: number;
   height: number;
@@ -17,6 +17,8 @@ export function HoldersTreemap({ rows, width, height, selectedId, onSelect, onAc
   onActivate?: (row: HolderRow) => void;
   currency: string;
   marketCap?: number;
+  /** Loading, error, and no-ticker states the pane resolves for both views. */
+  emptyStateTitle?: string;
 }) {
   const items = useMemo<Array<MetricTreemapItem<HolderRow>>>(() => rows.map((row) => {
     const ownership = formatHolderOwnershipLine(row, marketCap);
@@ -43,7 +45,7 @@ export function HoldersTreemap({ rows, width, height, selectedId, onSelect, onAc
       selectedId={selectedId}
       onSelect={(item) => onSelect(item.data)}
       onActivate={onActivate ? (item) => onActivate(item.data) : undefined}
-      emptyStateTitle="No chartable holder values"
+      emptyStateTitle={emptyStateTitle ?? "No chartable holder values"}
     />
   );
 }

--- a/src/plugins/builtin/insider/index.tsx
+++ b/src/plugins/builtin/insider/index.tsx
@@ -1,4 +1,3 @@
-import { Text } from "../../../ui";
 import { useCallback, useMemo, useState } from "react";
 import type { PluginModule } from "../plugin-module";
 import type { SecFilingItem } from "../../../types/data-provider";
@@ -8,8 +7,7 @@ import {
 } from "../../../market-data/hooks";
 import { instrumentFromTicker } from "../../../market-data/request-types";
 import { usePaneTicker } from "../../../state/app/context";
-import { colors } from "../../../theme/colors";
-import { FeedDataTableStackView, Spinner, useExternalLinkFooter, type FeedDataTableItem } from "../../../components";
+import { EmptyState, FeedDataTableStackView, Spinner, useExternalLinkFooter, type FeedDataTableItem } from "../../../components";
 import { usePluginPaneState } from "../../runtime";
 import { isUsEquityTicker } from "../../../utils/sec";
 import { formatCompact, formatCurrency } from "../../../utils/format";
@@ -26,6 +24,10 @@ import {
 import { useSecFilingContentCache } from "../sec/filing-content";
 
 const FORM4_LIMIT = 20;
+// SEC returns one recent-submissions payload per company, so scanning deep for
+// Form 4s costs no extra request; filtering the newest 20 filings of any form
+// hides insider activity behind a burst of 8-Ks.
+const SEC_FILING_SCAN_LIMIT = 300;
 const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
 
 interface ParsedFiling {
@@ -34,7 +36,9 @@ interface ParsedFiling {
   isLoading: boolean;
 }
 
-function buildSummary(parsed: ParsedFiling[]): string {
+/** Null while filings are still parsing, so the pane never claims "no activity" early. */
+function buildSummary(parsed: ParsedFiling[]): string | null {
+  if (parsed.some(({ isLoading }) => isLoading)) return null;
   const cutoff = new Date(Date.now() - NINETY_DAYS_MS);
   let buyShares = 0;
   let sellShares = 0;
@@ -109,11 +113,11 @@ function InsiderView({ width, height, focused }: { width: number; height: number
   const instrument = instrumentFromTicker(ticker, ticker?.metadata.ticker ?? null);
 
   const filingsEntry = useSecFilingsQuery(
-    instrument && eligibleTicker ? { instrument, count: FORM4_LIMIT } : null,
+    instrument && eligibleTicker ? { instrument, count: SEC_FILING_SCAN_LIMIT } : null,
   );
   const allFilings = useResolvedEntryValue(filingsEntry) ?? [];
   const form4Filings = useMemo(
-    () => allFilings.filter((f) => f.form.trim() === "4"),
+    () => allFilings.filter((f) => f.form.trim() === "4").slice(0, FORM4_LIMIT),
     [allFilings],
   );
 
@@ -178,7 +182,7 @@ function InsiderView({ width, height, focused }: { width: number; height: number
   const selectedFilterName = selectedTransaction?.reportedName ?? null;
   const pendingLabel = pendingCount > 0 ? `loading ${pendingCount}...` : "";
   const footerInfo = useMemo(() => [
-    { id: "summary", parts: [{ text: truncateText(summary, Math.max(24, width - 20)), tone: "muted" as const }] },
+    ...(summary ? [{ id: "summary", parts: [{ text: truncateText(summary, Math.max(24, width - 20)), tone: "muted" as const }] }] : []),
     ...(nameFilter ? [{ id: "filter", parts: [{ text: `filter: ${truncateText(nameFilter, 24)}`, tone: "warning" as const }] }] : []),
     ...(pendingLabel ? [{ id: "pending", parts: [{ text: pendingLabel, tone: "muted" as const }] }] : []),
   ], [nameFilter, pendingLabel, summary, width]);
@@ -205,10 +209,12 @@ function InsiderView({ width, height, focused }: { width: number; height: number
     label: "filing",
   });
 
-  if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view insider activity.</Text>;
+  if (!ticker) {
+    return <EmptyState title="No ticker selected." message="Select a ticker to view insider activity." />;
+  }
   if (!eligibleTicker) return renderFilingNotice("Insider transactions are only shown for US equities.", width);
   if (loading && allFilings.length === 0) return <Spinner label="Loading insider filings..." />;
-  if (error) return renderFilingNotice(`Error: ${error}`, width);
+  if (error) return <EmptyState title="Insider filings unavailable." message={error} />;
   if (!loading && form4Filings.length === 0) {
     return renderFilingNotice(`No Form 4 filings found for ${ticker.metadata.ticker}.`, width);
   }
@@ -225,7 +231,11 @@ function InsiderView({ width, height, focused }: { width: number; height: number
       onRootKeyDown={handleRootKeyDown}
       sourceLabel="Insider"
       titleLabel="Transaction"
-      emptyStateTitle={nameFilter ? "No insider transactions for this filter." : "No insider transactions."}
+      emptyStateTitle={nameFilter
+        ? "No insider transactions for this filter."
+        : pendingCount > 0
+          ? "Loading Form 4 transactions..."
+          : "No insider transactions."}
     />
   );
 }

--- a/src/plugins/builtin/ipo-calendar/cache.ts
+++ b/src/plugins/builtin/ipo-calendar/cache.ts
@@ -1,0 +1,101 @@
+import type { PluginPersistence } from "../../../types/plugin";
+import { fetchIpoCalendar, type IpoCalendarFetchResult } from "./client";
+import type { IPORecord } from "./types";
+
+const CACHE_KIND = "ipo-calendar";
+const CACHE_KEY = "board";
+const CACHE_SOURCE = "stockanalysis";
+const CACHE_SCHEMA_VERSION = 1;
+/**
+ * The board moves on pricing days, not minutes, so a quarter hour of freshness
+ * is enough; the week-long expiry is what keeps an offline start usable.
+ */
+const CACHE_POLICY = {
+  staleMs: 15 * 60 * 1000,
+  expireMs: 7 * 24 * 60 * 60 * 1000,
+} as const;
+
+type PersistedIPORecord = Omit<IPORecord, "date"> & { date: string };
+
+export interface IpoCalendarResult {
+  records: IPORecord[];
+  fetchedAt: number;
+  /** True when the network failed and cached records were served instead. */
+  stale: boolean;
+  /** Endpoints that failed while others succeeded. */
+  errors: string[];
+}
+
+let persistence: PluginPersistence | null = null;
+let activeFetch: Promise<IpoCalendarResult> | null = null;
+
+export function attachIpoCalendarPersistence(next: PluginPersistence): void {
+  persistence = next;
+}
+
+export function resetIpoCalendarPersistence(): void {
+  persistence = null;
+  activeFetch = null;
+}
+
+function readCache(options?: { allowExpired?: boolean }): IpoCalendarResult | null {
+  const record = persistence?.getResource<PersistedIPORecord[]>(CACHE_KIND, CACHE_KEY, {
+    sourceKey: CACHE_SOURCE,
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    allowExpired: options?.allowExpired,
+  });
+  if (!record || !Array.isArray(record.value)) return null;
+  const records = record.value
+    .map((entry) => ({ ...entry, date: new Date(entry.date) }))
+    .filter((entry) => !Number.isNaN(entry.date.getTime()));
+  return { records, fetchedAt: record.fetchedAt, stale: !!record.stale, errors: [] };
+}
+
+export function getCachedIpoCalendar(): IpoCalendarResult | null {
+  return readCache({ allowExpired: true });
+}
+
+/**
+ * Serves fresh cache without a request, shares one in-flight fetch across
+ * panes, and falls back to whatever is cached when Stock Analysis is
+ * unreachable. A partial scrape is cached but keeps its errors so the pane can
+ * say so rather than presenting half a board as the whole one.
+ */
+export async function loadIpoCalendar(
+  force = false,
+  loader: () => Promise<IpoCalendarFetchResult> = fetchIpoCalendar,
+): Promise<IpoCalendarResult> {
+  const cached = readCache();
+  if (!force && cached && !cached.stale) return cached;
+  if (activeFetch) return activeFetch;
+
+  const fallback = cached ?? readCache({ allowExpired: true });
+  activeFetch = loader()
+    .then(({ records, errors }) => {
+      if (records.length === 0) {
+        if (fallback) return { ...fallback, stale: true, errors };
+        throw new Error(errors.join("; ") || "Stock Analysis returned no IPOs");
+      }
+      persistence?.setResource(
+        CACHE_KIND,
+        CACHE_KEY,
+        records.map((record) => ({ ...record, date: record.date.toISOString() })),
+        { sourceKey: CACHE_SOURCE, schemaVersion: CACHE_SCHEMA_VERSION, cachePolicy: CACHE_POLICY },
+      );
+      return { records, fetchedAt: Date.now(), stale: false, errors };
+    })
+    .catch((error: unknown) => {
+      if (fallback) {
+        return {
+          ...fallback,
+          stale: true,
+          errors: [error instanceof Error ? error.message : String(error)],
+        };
+      }
+      throw error;
+    })
+    .finally(() => {
+      activeFetch = null;
+    });
+  return activeFetch;
+}

--- a/src/plugins/builtin/ipo-calendar/client.ts
+++ b/src/plugins/builtin/ipo-calendar/client.ts
@@ -269,22 +269,28 @@ function dedupeAndSort(records: IPORecord[]): IPORecord[] {
   return [...byTicker.values()].sort((a, b) => b.date.getTime() - a.date.getTime());
 }
 
-export async function fetchIpoCalendar(): Promise<IPORecord[]> {
+export interface IpoCalendarFetchResult {
+  records: IPORecord[];
+  /** One entry per endpoint that failed, so a half board is never shown as whole. */
+  errors: string[];
+}
+
+export async function fetchIpoCalendar(): Promise<IpoCalendarFetchResult> {
   const [recentResult, upcomingResult] = await Promise.allSettled([
     fetchRecentIpos(),
     fetchUpcomingIpos(),
   ]);
 
   const records: IPORecord[] = [];
+  const errors: string[] = [];
   if (recentResult.status === "fulfilled") records.push(...recentResult.value);
+  else errors.push(`recent: ${recentResult.reason}`);
   if (upcomingResult.status === "fulfilled") records.push(...upcomingResult.value);
+  else errors.push(`upcoming: ${upcomingResult.reason}`);
 
-  if (records.length === 0) {
-    const errors: string[] = [];
-    if (recentResult.status === "rejected") errors.push(`recent: ${recentResult.reason}`);
-    if (upcomingResult.status === "rejected") errors.push(`upcoming: ${upcomingResult.reason}`);
-    if (errors.length > 0) throw new Error(`IPO data unavailable (${errors.join("; ")})`);
+  if (records.length === 0 && errors.length > 0) {
+    throw new Error(`IPO data unavailable (${errors.join("; ")})`);
   }
 
-  return dedupeAndSort(records);
+  return { records: dedupeAndSort(records), errors };
 }

--- a/src/plugins/builtin/ipo-calendar/index.tsx
+++ b/src/plugins/builtin/ipo-calendar/index.tsx
@@ -4,6 +4,7 @@ import {
   resetIpoCalendarHealth,
   STOCKANALYSIS_IPO_CONNECTION_ID,
 } from "./client";
+import { attachIpoCalendarPersistence, resetIpoCalendarPersistence } from "./cache";
 import { IPOCalendarPane } from "./pane";
 import { IPO_CALENDAR_PANE_ID } from "./types";
 
@@ -12,6 +13,7 @@ let disposeConnection: (() => void) | null = null;
 export const ipoCalendarModule: PluginModule = {
   setup(ctx) {
     attachIpoCalendarHealth(ctx.connectionHealth);
+    attachIpoCalendarPersistence(ctx.persistence);
     disposeConnection = ctx.connectionHealth.registerSource({
       id: STOCKANALYSIS_IPO_CONNECTION_ID,
       name: "Stock Analysis",
@@ -26,6 +28,7 @@ export const ipoCalendarModule: PluginModule = {
     disposeConnection?.();
     disposeConnection = null;
     resetIpoCalendarHealth();
+    resetIpoCalendarPersistence();
   },
 
   panes: [

--- a/src/plugins/builtin/ipo-calendar/model.ts
+++ b/src/plugins/builtin/ipo-calendar/model.ts
@@ -5,6 +5,7 @@ import type { IPORecord, IPOStatus } from "./types";
 
 type IPOColumnId =
   | "ticker"
+  | "company"
   | "date"
   | "status"
   | "exchange"
@@ -62,7 +63,7 @@ export function formatShares(value: number | null): string {
 
 export function formatPrice(record: IPORecord): string {
   if (record.pricedPrice != null) return `$${record.pricedPrice.toFixed(2)}`;
-  if (record.priceRange != null) return `$${record.priceRange[0].toFixed(2)}–$${record.priceRange[1].toFixed(2)}`;
+  if (record.priceRange != null) return `$${record.priceRange[0].toFixed(2)}-$${record.priceRange[1].toFixed(2)}`;
   return "—";
 }
 
@@ -76,14 +77,20 @@ export function stockAnalysisUrl(ticker: string): string {
   return `https://stockanalysis.com/stocks/${ticker.toLowerCase()}/`;
 }
 
-export function buildColumns(_width: number): IPOColumn[] {
+/** "$100.00-$120.00" is the widest price a row can hold; anything narrower clips a real number. */
+const PRICE_WIDTH = 15;
+
+export function buildColumns(width: number): IPOColumn[] {
+  const fixed = 7 + 11 + 9 + 8 + 8 + PRICE_WIDTH + 7 + 8;
+  const companyWidth = Math.max(10, width - fixed - 11);
   return [
     { id: "ticker", label: "TICKER", width: 7, align: "left" },
+    { id: "company", label: "COMPANY", width: companyWidth, align: "left" },
     { id: "date", label: "DATE", width: 11, align: "left" },
     { id: "status", label: "STATUS", width: 9, align: "left" },
     { id: "exchange", label: "EXCH", width: 8, align: "left" },
     { id: "offer", label: "OFFER", width: 8, align: "right" },
-    { id: "price", label: "PRICE", width: 12, align: "right" },
+    { id: "price", label: "PRICE", width: PRICE_WIDTH, align: "right" },
     { id: "shares", label: "SHARES", width: 7, align: "right" },
     { id: "return", label: "RETURN", width: 8, align: "right" },
   ];
@@ -93,6 +100,8 @@ function getSortValue(columnId: IPOColumnId, row: IPORecord): string | number | 
   switch (columnId) {
     case "ticker":
       return row.ticker;
+    case "company":
+      return row.companyName;
     case "date":
       return row.date.getTime();
     case "status":

--- a/src/plugins/builtin/ipo-calendar/pane.tsx
+++ b/src/plugins/builtin/ipo-calendar/pane.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  Button,
   DataTableView,
+  EmptyState,
   InputSearchBar,
   Spinner,
   useExternalLinkFooter,
@@ -16,7 +18,7 @@ import { isPlainKey } from "../../../utils/keyboard";
 import { usePluginTickerActions } from "../../runtime";
 import { useAutoRefresh } from "../shared/auto-refresh";
 import { loadingErrorFooterInfo } from "../shared/table-pane";
-import { fetchIpoCalendar } from "./client";
+import { getCachedIpoCalendar, loadIpoCalendar } from "./cache";
 import {
   DEFAULT_SORT_PREFERENCE,
   buildColumns,
@@ -39,30 +41,35 @@ const SEARCH_DEBOUNCE_MS = 250;
 
 export function IPOCalendarPane({ focused, width, height }: PaneProps) {
   const { pinTicker } = usePluginTickerActions();
-  const [records, setRecords] = useState<IPORecord[]>([]);
-  const [status, setStatus] = useState<LoadStatus>("idle");
+  const [initialCache] = useState(getCachedIpoCalendar);
+  const [records, setRecords] = useState<IPORecord[]>(initialCache?.records ?? []);
+  // "idle" would render the empty state for one frame before the first load.
+  const [status, setStatus] = useState<LoadStatus>(initialCache ? "loaded" : "loading");
   const [error, setError] = useState<string | null>(null);
+  const [stale, setStale] = useState(initialCache?.stale ?? false);
   const [selectedTicker, setSelectedTicker] = useState<string | null>(null);
   const [sortPreference, setSortPreference] = useState<IPOSortPreference>(DEFAULT_SORT_PREFERENCE);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchFocused, setSearchFocused] = useState(false);
   const [searchFocusToken, setSearchFocusToken] = useState(0);
-  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(initialCache?.fetchedAt ?? null);
   const searchInputRef = useRef<InputRenderable | null>(null);
   const fetchGenRef = useRef(0);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (force = false) => {
     fetchGenRef.current += 1;
     const gen = fetchGenRef.current;
     setStatus((current) => (current === "loaded" ? current : "loading"));
     setError(null);
 
     try {
-      const data = await fetchIpoCalendar();
+      const result = await loadIpoCalendar(force);
       if (fetchGenRef.current !== gen) return;
-      setRecords(data);
+      setRecords(result.records);
+      setStale(result.stale);
+      setError(result.errors[0] ?? null);
       setStatus("loaded");
-      setLastUpdated(Date.now());
+      setLastUpdated(result.fetchedAt);
     } catch (err) {
       if (fetchGenRef.current !== gen) return;
       setError(err instanceof Error ? err.message : String(err));
@@ -74,7 +81,8 @@ export function IPOCalendarPane({ focused, width, height }: PaneProps) {
     void load();
   }, [load]);
 
-  useAutoRefresh(status === "loaded" ? lastUpdated : null, () => {
+  // The cache decides whether a tick becomes a scrape; only [r] forces it.
+  useAutoRefresh(status === "loaded" && !stale ? lastUpdated : null, () => {
     void load();
   });
 
@@ -117,7 +125,7 @@ export function IPOCalendarPane({ focused, width, height }: PaneProps) {
   }, []);
 
   const refresh = useCallback(() => {
-    void load();
+    void load(true);
   }, [load]);
 
   const handleHeaderClick = useCallback((columnId: string) => {
@@ -164,12 +172,18 @@ export function IPOCalendarPane({ focused, width, height }: PaneProps) {
   );
 
   const footerInfo = useMemo(() => [
-    ...loadingErrorFooterInfo(status === "loading", status === "error" ? error : null),
+    ...loadingErrorFooterInfo(status === "loading", records.length === 0 ? error : null),
+    // One endpoint failed while the other returned rows: say so without
+    // spilling a scrape URL into the footer.
+    ...(error && records.length > 0
+      ? [{ id: "partial", parts: [{ text: "PARTIAL", tone: "warning" as const, bold: true }] }]
+      : []),
+    ...(stale ? [{ id: "stale", parts: [{ text: "STALE", tone: "warning" as const }] }] : []),
     ...(searchQuery ? [{
       id: "search",
       parts: [{ text: `filter: ${searchQuery}`, tone: "value" as const }],
     }] : []),
-  ], [error, searchQuery, status]);
+  ], [error, records.length, searchQuery, stale, status]);
 
   const footerHints = useMemo(
     () => [{ id: "search", key: "/", label: "search", onPress: focusSearch }],
@@ -195,6 +209,11 @@ export function IPOCalendarPane({ focused, width, height }: PaneProps) {
             text: row.ticker,
             color: selectedColor ?? colors.textBright,
             attributes: TextAttributes.BOLD,
+          };
+        case "company":
+          return {
+            text: row.companyName,
+            color: selectedColor ?? colors.text,
           };
         case "date":
           return {
@@ -269,8 +288,8 @@ export function IPOCalendarPane({ focused, width, height }: PaneProps) {
     return (
       <Box flexDirection="column" width={width} height={height}>
         {rootBefore}
-        <Box flexGrow={1} justifyContent="center" alignItems="center">
-          <Text fg={colors.negative}>Error: {error}</Text>
+        <Box padding={1} flexDirection="column" gap={1}>
+          <EmptyState title="IPO calendar unavailable." message={error ?? undefined} />
         </Box>
       </Box>
     );

--- a/src/plugins/builtin/kelly-sizer/model.ts
+++ b/src/plugins/builtin/kelly-sizer/model.ts
@@ -41,6 +41,8 @@ export type {
 } from "./types";
 
 const MAX_NUMERIC_KELLY_FRACTION = 10;
+/** Widest Kelly curve window worth drawing: 200% of bankroll. */
+const KELLY_CURVE_DISPLAY_CAP = 2;
 const SOLVER_ITERATIONS = 80;
 
 function finite(value: number): boolean {
@@ -552,7 +554,12 @@ export function getKellyCurveMaxFraction(
   const domainLimit = worstReturn < 0 ? (-1 / worstReturn) * 0.95 : MAX_NUMERIC_KELLY_FRACTION;
   const focusMax = Math.max(0, ...focusFractions.filter((value) => finite(value) && value >= 0));
   const maxFraction = clamp(
-    Math.max(result.fullKellyFraction * 1.4, result.clippedFraction * 2, focusMax * 1.15, 0.2),
+    // Capped for readability: a shallow downside pushes the mathematical domain
+    // past 600% of bankroll, which squeezes every decision point into one column.
+    Math.min(
+      Math.max(result.fullKellyFraction * 1.4, result.clippedFraction * 2, focusMax * 1.15, 0.2),
+      KELLY_CURVE_DISPLAY_CAP,
+    ),
     0.05,
     Math.min(MAX_NUMERIC_KELLY_FRACTION, domainLimit),
   );

--- a/src/plugins/builtin/kelly-sizer/pane.tsx
+++ b/src/plugins/builtin/kelly-sizer/pane.tsx
@@ -127,12 +127,19 @@ export function KellySizerPane({ focused, width, height }: PaneProps) {
     }
 
     setTickerSearchStatus("checking...");
-    const target = await resolveTickerOpenTarget({
-      query: normalizedQuery,
-      tickers: tickersBySymbol,
-      dataProvider: registry.marketData,
-      tickerRepository: registry.tickerRepository,
-    });
+    let target: Awaited<ReturnType<typeof resolveTickerOpenTarget>>;
+    try {
+      target = await resolveTickerOpenTarget({
+        query: normalizedQuery,
+        tickers: tickersBySymbol,
+        dataProvider: registry.marketData,
+        tickerRepository: registry.tickerRepository,
+      });
+    } catch (error) {
+      // Without this the status is stuck on "checking..." and the rejection is unhandled.
+      setTickerSearchStatus(error instanceof Error ? error.message : "lookup failed");
+      return;
+    }
 
     if (!target) {
       setTickerSearchStatus("not found");
@@ -179,7 +186,7 @@ export function KellySizerPane({ focused, width, height }: PaneProps) {
     if (requestedSymbol && financials) merged.set(requestedSymbol, financials);
     return merged;
   }, [cachedPortfolioFinancials, financials, livePortfolioFinancials, requestedSymbol]);
-  const accountState = usePortfolioAccountState(activePortfolio, { brokerAccounts, config });
+  const { accountState } = usePortfolioAccountState(activePortfolio, { brokerAccounts, config });
   const trackedCurrencies = useMemo(
     () => buildTrackedCurrencies(portfolioTickers, portfolioFinancials, accountState, config.baseCurrency),
     [accountState, config.baseCurrency, portfolioFinancials, portfolioTickers],
@@ -313,7 +320,8 @@ export function KellySizerPane({ focused, width, height }: PaneProps) {
         lineChar: "│",
       },
     ];
-    return markers.filter((marker) => Number.isFinite(marker.xRatio) && marker.xRatio >= 0);
+    // Anything past the window edge would be drawn on top of the axis, so drop it.
+    return markers.filter((marker) => Number.isFinite(marker.xRatio) && marker.xRatio >= 0 && marker.xRatio <= 1);
   }, [
     curveMaxFraction,
     result.clipReasons,
@@ -373,15 +381,17 @@ export function KellySizerPane({ focused, width, height }: PaneProps) {
   const commonColumns = width >= 78 ? 3 : 2;
   const commonRows = Math.max(1, Math.ceil(commonFields.length / commonColumns));
   const fieldsRows = Math.max(1, Math.ceil(fields.length / fieldColumns));
-  const commonFieldWidth = Math.max(22, Math.floor((width - 2) / commonColumns));
-  const fieldWidth = Math.max(22, Math.floor((width - 2) / fieldColumns));
-  const contextFieldWidth = Math.max(28, Math.floor((width - 2) / 2));
+  // Floors low enough that a narrow pane shrinks instead of clipping, ceilings so a
+  // wide pane keeps the label, value, and unit together.
+  const commonFieldWidth = Math.max(14, Math.min(30, Math.floor((width - 2) / commonColumns)));
+  const fieldWidth = Math.max(14, Math.min(30, Math.floor((width - 2) / fieldColumns)));
+  const contextFieldWidth = Math.max(16, Math.min(32, Math.floor((width - 2) / 2)));
   const metricsRows = 6;
   const curveDecisionRows = 1;
   const chartHeight = showSensitivity ? 0 : Math.max(7, Math.min(10, height - commonRows - fieldsRows - metricsRows - curveDecisionRows - 8));
   const showChart = !showSensitivity && chartHeight >= 6 && curvePoints.length > 0;
-  const leftMetricsWidth = Math.max(36, Math.floor((width - 2) * 0.52));
-  const rightMetricsWidth = Math.max(28, width - 2 - leftMetricsWidth);
+  const leftMetricsWidth = Math.max(18, Math.floor((width - 2) * 0.52));
+  const rightMetricsWidth = Math.max(16, width - 2 - leftMetricsWidth);
 
   if (!requestedSymbol || !ticker) {
     return (
@@ -526,6 +536,14 @@ export function KellySizerPane({ focused, width, height }: PaneProps) {
           </Box>
         ))}
       </Box>
+
+      {bankroll > 0 ? null : (
+        <Box height={1} paddingX={1} overflow="hidden">
+          <Text fg={colors.warning}>
+            No bankroll yet, so every size below reads 0%. Click Bankroll above to set one.
+          </Text>
+        </Box>
+      )}
 
       <KellyResultMetrics
         result={result}

--- a/src/plugins/builtin/kelly-sizer/view.tsx
+++ b/src/plugins/builtin/kelly-sizer/view.tsx
@@ -58,7 +58,9 @@ export function InlineFieldView({
 }) {
   const labelWidth = Math.min(12, Math.max(7, Math.floor(width * 0.38)));
   const suffixWidth = field.suffix ? field.suffix.length + 1 : field.percent ? 2 : 0;
-  const valueWidth = Math.max(5, width - labelWidth - suffixWidth - 2);
+  // Capped so the unit sits next to the number instead of being pushed to the far
+  // edge of a wide pane.
+  const valueWidth = Math.max(5, Math.min(12, width - labelWidth - suffixWidth - 2));
   const inputNodeRef = useRef<InputRenderable | null>(null);
   const displayValue = field.valueText ?? formatInputNumber(field.value ?? 0, field.percent);
   const fieldRef = useRef(field);
@@ -246,10 +248,15 @@ export function InlineFieldView({
           onBlur={handleBlur}
         />
       ) : (
-        <Box width={valueWidth} height={1} onMouseDown={() => {
-          onFocus();
-          focusInput();
-        }}>
+        <Box
+          width={valueWidth}
+          height={1}
+          backgroundColor={colors.bg}
+          onMouseDown={() => {
+            onFocus();
+            focusInput();
+          }}
+        >
           <Text fg={fg}>{truncateText(displayValue, valueWidth)}</Text>
         </Box>
       )}

--- a/src/plugins/builtin/market-heatmap/data.test.ts
+++ b/src/plugins/builtin/market-heatmap/data.test.ts
@@ -39,6 +39,7 @@ describe("market heatmap data", () => {
       price: 143,
       change: 2.5,
       changePercent: 1.78,
+      hasChange: true,
       size: 3_500_000_000_000,
       sizeKind: "market-cap",
       volume: 45_000_000,

--- a/src/plugins/builtin/market-heatmap/data.ts
+++ b/src/plugins/builtin/market-heatmap/data.ts
@@ -16,6 +16,12 @@ export interface MarketHeatmapAsset {
   price: number;
   change: number;
   changePercent: number;
+  /**
+   * Whether the source actually carried a session change. `changePercent` keeps
+   * a numeric 0 for the shared screener row shape, so tiles must read this
+   * before showing a flat session that was really missing data.
+   */
+  hasChange: boolean;
   size: number | null;
   sizeKind: MarketHeatmapSizeKind;
   volume: number | null;
@@ -140,14 +146,15 @@ export function parseYahooMarketHeatmapResponse(data: unknown, universe: MarketH
       : getNumber(quote, "marketCap") ?? getNumber(quote, "intradayMarketCap");
     const price = getNumber(quote, "regularMarketPrice") ?? 0;
     const change = getNumber(quote, "regularMarketChange") ?? 0;
-    const changePercent = getNumber(quote, "regularMarketChangePercent") ?? 0;
+    const changePercentValue = getNumber(quote, "regularMarketChangePercent");
 
     assets.push({
       symbol,
       name: getString(quote, "shortName") ?? getString(quote, "longName") ?? getString(quote, "displayName") ?? symbol,
       price,
       change,
-      changePercent,
+      changePercent: changePercentValue ?? 0,
+      hasChange: changePercentValue != null,
       size,
       sizeKind,
       volume: getNumber(quote, "regularMarketVolume"),
@@ -176,13 +183,15 @@ export function parseNasdaqMarketHeatmapResponse(data: unknown): MarketHeatmapAs
     const size = parseLooseNumber(row.marketCap);
     if (size == null || size <= 0) continue;
     const price = parseLooseNumber(row.lastsale) ?? 0;
+    const changePercentValue = parseLooseNumber(row.pctchange);
 
     assets.push({
       symbol,
       name: getString(row, "name") ?? symbol,
       price,
       change: parseLooseNumber(row.netchange) ?? 0,
-      changePercent: parseLooseNumber(row.pctchange) ?? 0,
+      changePercent: changePercentValue ?? 0,
+      hasChange: changePercentValue != null,
       size,
       sizeKind: "market-cap",
       volume: parseLooseNumber(row.volume),

--- a/src/plugins/builtin/market-heatmap/index.tsx
+++ b/src/plugins/builtin/market-heatmap/index.tsx
@@ -16,7 +16,8 @@ import type { PluginModule } from "../plugin-module";
 import { priceColor } from "../../../theme/colors";
 import { formatCompact, formatCurrency, formatPercentRaw } from "../../../utils/format";
 import { isPlainKey } from "../../../utils/keyboard";
-import { usePluginPaneState, usePluginTickerActions } from "../../runtime";
+import { usePaneSettingValue } from "../../../state/app/context";
+import { usePluginTickerActions } from "../../runtime";
 import { useLiveQuoteEntries } from "../../../state/hooks/quote-streaming";
 import {
   MARKET_HEATMAP_UNIVERSES,
@@ -43,7 +44,8 @@ function formatMoneyCompact(value: number | null | undefined, currency: string):
   return `${formatCompact(value)} ${currency}`;
 }
 
-function sizeLabel(asset: MarketHeatmapAsset): string {
+function sizeLabel(asset: MarketHeatmapAsset): string | null {
+  if (asset.size == null) return null;
   const label = asset.sizeKind === "net-assets" ? "Assets" : "Mkt";
   return `${label} ${formatMoneyCompact(asset.size, asset.currency)}`;
 }
@@ -53,22 +55,53 @@ function buildItems(assets: MarketHeatmapAsset[]): Array<MetricTreemapItem<Marke
     id: asset.symbol,
     label: asset.symbol,
     weight: asset.size ?? 0,
-    colorValue: asset.changePercent,
-    primaryText: formatPercentRaw(asset.changePercent),
+    colorValue: asset.hasChange ? asset.changePercent : null,
+    // No change data is not a flat session; 0.00% would be a made-up number.
+    primaryText: asset.hasChange ? formatPercentRaw(asset.changePercent) : "—",
     secondaryText: sizeLabel(asset),
     tertiaryText: asset.volume != null ? `Vol ${formatCompact(asset.volume)}` : asset.exchange || null,
     data: asset,
   }));
 }
 
+/**
+ * A tile that clips "$1.0T" into "$1.0" reads as a real, wrong number, so a
+ * metric that does not fit its tile is dropped instead of truncated. Layout
+ * depends on weights alone, so re-rendering with shorter text keeps the same
+ * geometry.
+ */
+function fitItemsToTiles(
+  items: Array<MetricTreemapItem<MarketHeatmapAsset>>,
+  tiles: Array<{ item: { id: string }; width: number; height: number }>,
+): Array<MetricTreemapItem<MarketHeatmapAsset>> {
+  const tileById = new Map(tiles.map((tile) => [tile.item.id, tile]));
+  return items.map((item) => {
+    const tile = tileById.get(item.id);
+    if (!tile) return item;
+    // Mirrors the terminal tile's own padding: one cell of border, one of gutter.
+    const innerWidth = Math.max(1, Math.floor(tile.width) - (tile.width > 2 ? 1 : 0) - 1);
+    const fits = (text: string | null | undefined) => (
+      text != null && text.length <= innerWidth ? text : null
+    );
+    return {
+      ...item,
+      primaryText: fits(item.primaryText),
+      secondaryText: fits(item.secondaryText),
+      tertiaryText: fits(item.tertiaryText),
+    };
+  });
+}
+
 function MarketHeatmapPane({ focused, width, height }: PaneProps) {
   const { pinTicker } = usePluginTickerActions();
   const liveStreaming = useLiveStreamingSetting();
   const { cellWidthPx = 8, cellHeightPx = 18, nativePaneChrome } = useUiCapabilities();
-  const [activeUniverse, setActiveUniverse] = usePluginPaneState<MarketHeatmapUniverseId>("universe", "us-equity");
+  // A pane setting, not private pane state, so the settings dialog can show it.
+  const [activeUniverse, setActiveUniverse] = usePaneSettingValue<MarketHeatmapUniverseId>("universe", "us-equity");
   const [assets, setAssets] = useState<MarketHeatmapAsset[]>([]);
   const [lastUpdated, setLastUpdated] = useState<number | null>(null);
-  const [loading, setLoading] = useState(false);
+  // The first load starts before the effect runs; an empty board is not "no data".
+  const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [selectedSymbol, setSelectedSymbol] = useState<string | null>(null);
   const fetchGenRef = useRef(0);
@@ -104,6 +137,11 @@ function MarketHeatmapPane({ focused, width, height }: PaneProps) {
     () => buildMetricTreemapNavigationTiles(items, chartWidth, chartHeight, cellAspect, nativePaneChrome ? "float" : "integer"),
     [cellAspect, chartHeight, chartWidth, items, nativePaneChrome],
   );
+  // Desktop tiles ellipsize, which is visible; terminal cells clip silently.
+  const displayItems = useMemo(
+    () => (nativePaneChrome ? items : fitItemsToTiles(items, navigationTiles)),
+    [items, nativePaneChrome, navigationTiles],
+  );
   const selectedIdx = selectedSymbol
     ? resolvedAssets.findIndex((asset) => asset.symbol === selectedSymbol)
     : -1;
@@ -124,7 +162,7 @@ function MarketHeatmapPane({ focused, width, height }: PaneProps) {
       if (fetchGenRef.current !== gen) return;
       setAssets(result.assets);
       setLastUpdated(result.fetchedAt);
-      setSelectedSymbol(result.assets[0]?.symbol ?? null);
+      // Selection is the user's; the effect below only fills it when it is gone.
     } catch {
       if (fetchGenRef.current !== gen) return;
       setAssets([]);
@@ -264,7 +302,12 @@ function MarketHeatmapPane({ focused, width, height }: PaneProps) {
         parts: [
           { text: selectedAsset.symbol, tone: "label" as const },
           { text: formatCurrency(selectedAsset.price, selectedAsset.currency), tone: "value" as const },
-          { text: formatPercentRaw(selectedAsset.changePercent), tone: "value" as const, color: priceColor(selectedAsset.changePercent), bold: true },
+          {
+            text: selectedAsset.hasChange ? formatPercentRaw(selectedAsset.changePercent) : "—",
+            tone: "value" as const,
+            color: selectedAsset.hasChange ? priceColor(selectedAsset.changePercent) : undefined,
+            bold: true,
+          },
         ],
       }] : []),
       ...(updated ? [{
@@ -302,7 +345,7 @@ function MarketHeatmapPane({ focused, width, height }: PaneProps) {
       </Box>
 
       <MetricTreemapSurface
-        items={items}
+        items={displayItems}
         width={width}
         height={chartHeight}
         selectedId={selectedSymbol}
@@ -329,7 +372,18 @@ export const marketHeatmapModule: PluginModule = {
       defaultMode: "floating",
       defaultFloatingSize: { width: 110, height: 36 },
       quickSettings: [LIVE_STREAMING_QUICK_SETTING],
-      settings: (context) => withLiveStreamingSetting({ fields: [] }, context.settings),
+      settings: (context) => withLiveStreamingSetting({
+        title: "Market Heatmap Settings",
+        fields: [{
+          key: "universe",
+          label: "Universe",
+          type: "select",
+          options: MARKET_HEATMAP_UNIVERSES.map((universe) => ({
+            value: universe.id,
+            label: universe.label,
+          })),
+        }],
+      }, context.settings),
     },
   ],
 

--- a/src/plugins/builtin/market-movers/index.tsx
+++ b/src/plugins/builtin/market-movers/index.tsx
@@ -1,13 +1,16 @@
 import { Box } from "../../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { DataTableView, Tabs, usePaneFooter, type DataTableKeyEvent } from "../../../components";
+import { DataTableView, EmptyState, Tabs, usePaneFooter, type DataTableKeyEvent } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
 import { priceColor } from "../../../theme/colors";
 import { formatPercentRaw } from "../../../utils/format";
+import { useAppSelector, usePaneSettingValue } from "../../../state/app/context";
 import { useAssetData, usePluginTickerActions } from "../../runtime";
 import { useLiveQuoteEntries } from "../../../state/hooks/quote-streaming";
+import { useAutoRefresh } from "../shared/auto-refresh";
+import { useQuoteBoard } from "../shared/use-quote-board";
 import {
   attachMarketMoversPersistence,
   fetchPreferredMarketMovers,
@@ -24,6 +27,8 @@ import {
   TABS,
   createRows,
   nextSortPreference,
+  resolveSummarySymbols,
+  resolveTabs,
   screenerQuoteFromQuote,
   sortRows,
   summaryQuoteFromQuote,
@@ -44,18 +49,29 @@ import {
   resolveScreenerQuoteFeedStatus,
 } from "../shared/screener-live-quotes";
 
+/** Stable identity: a fresh literal here would reload the board every render. */
+const NO_SAVED_SELECTION: string[] = [];
+
 function MarketMoversPane({ focused, width, height }: PaneProps) {
   const dataProvider = useAssetData();
   const { pinTicker } = usePluginTickerActions();
   const liveStreaming = useLiveStreamingSetting();
-  const [activeTab, setActiveTab] = useState<TabId>("gainers");
+  const [savedTabs] = usePaneSettingValue<string[]>("tabs", NO_SAVED_SELECTION);
+  const [savedSummarySymbols] = usePaneSettingValue<string[]>("summarySymbols", NO_SAVED_SELECTION);
+  const tabs = useMemo(() => resolveTabs(savedTabs), [savedTabs]);
+  const summarySymbols = useMemo(() => resolveSummarySymbols(savedSummarySymbols), [savedSummarySymbols]);
+  // One cadence, the one the user configured, instead of a private 60s timer.
+  const refreshIntervalMinutes = useAppSelector((state) => state.config.refreshIntervalMinutes);
+  const refreshIntervalMs = Math.max(1, refreshIntervalMinutes || 1) * 60_000;
+  const [activeTab, setActiveTab] = useState<TabId>(tabs[0]!.id);
   const [quotes, setQuotes] = useState<ScreenerQuote[]>([]);
-  const [loading, setLoading] = useState(false);
+  // The first load starts before the effect runs; an empty board is not "no data".
+  const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [selectedSymbol, setSelectedSymbol] = useState<string | null>(null);
   const [sortPreference, setSortPreference] = useState<MarketMoverSortPreference>(DEFAULT_SORT_PREFERENCE);
-  const [summaryQuotes, setSummaryQuotes] = useState<MarketSummaryQuote[]>([]);
   const [moversStale, setMoversStale] = useState(false);
+  const [lastLoadedAt, setLastLoadedAt] = useState<number | null>(null);
 
   const fetchGenRef = useRef(0);
 
@@ -98,44 +114,17 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
     }
   }, [rows, selectedIdx, selectedSymbol]);
 
-  // Fetch market summary via the asset-data client.
-  useEffect(() => {
-    if (!dataProvider) return;
-    const loadSummary = async () => {
-      if (dataProvider.getQuotesBatch) {
-        const batchResults = await dataProvider.getQuotesBatch(
-          MARKET_SUMMARY_SYMBOLS.map((symbol) => ({ symbol, exchange: "" })),
-        ).catch(() => []);
-        const bySymbol = new Map(batchResults.map((result) => [result.target.symbol, result]));
-        setSummaryQuotes(
-          MARKET_SUMMARY_SYMBOLS
-            .map((symbol) => {
-              const result = bySymbol.get(symbol);
-              return result?.quote ? summaryQuoteFromQuote(symbol, result.quote) : null;
-            })
-            .filter((quote): quote is MarketSummaryQuote => !!quote),
-        );
-        return;
-      }
-
-      const results = await Promise.all(MARKET_SUMMARY_SYMBOLS.map(async (symbol) => {
-        try {
-          const quote = await dataProvider.getQuote(symbol, "");
-          return quote ? summaryQuoteFromQuote(symbol, quote) : null;
-        } catch {
-          return null;
-        }
-      }));
-      setSummaryQuotes(
-        MARKET_SUMMARY_SYMBOLS
-          .map((s) => results.find((r) => r?.symbol === s))
-          .filter((r): r is MarketSummaryQuote => !!r),
-      );
-    };
-    loadSummary();
-    const interval = setInterval(loadSummary, 60_000);
-    return () => clearInterval(interval);
-  }, [dataProvider]);
+  // The index summary is a quote board like any other, so it runs on the shared
+  // one instead of a third parallel pipeline against the same upstream.
+  const { quotes: summaryBoard } = useQuoteBoard(summarySymbols, refreshIntervalMs);
+  const summaryQuotes = useMemo<MarketSummaryQuote[]>(() => (
+    summarySymbols
+      .map((symbol) => {
+        const quote = summaryBoard.get(symbol)?.quote;
+        return quote ? summaryQuoteFromQuote(symbol, quote) : null;
+      })
+      .filter((quote): quote is MarketSummaryQuote => !!quote)
+  ), [summaryBoard, summarySymbols]);
 
   const loadTab = useCallback(async (
     tab: TabId,
@@ -199,10 +188,15 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
       setQuotes(data);
       if (!options?.background) setSelectedSymbol(null);
       setLoadError(null);
+      setLastLoadedAt(Date.now());
     } catch {
-      if (fetchGenRef.current === gen && !options?.background) {
-        setLoadError("Market movers temporarily unavailable");
+      if (fetchGenRef.current !== gen) return;
+      if (options?.background) {
+        // Rows stay, but they are no longer what the pane just fetched.
+        setMoversStale(true);
+        return;
       }
+      setLoadError("Market movers temporarily unavailable");
     }
     finally {
       if (fetchGenRef.current === gen && !options?.background) setLoading(false);
@@ -210,12 +204,18 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
   }, [dataProvider]);
 
   useEffect(() => {
+    if (tabs.some((tab) => tab.id === activeTab)) return;
+    setActiveTab(tabs[0]!.id);
+  }, [activeTab, tabs]);
+
+  useEffect(() => {
     void loadTab(activeTab);
-    const interval = setInterval(() => {
-      void loadTab(activeTab, { background: true });
-    }, 60_000);
-    return () => clearInterval(interval);
   }, [activeTab, loadTab]);
+
+  const backgroundRefresh = useCallback(() => {
+    void loadTab(activeTab, { background: true });
+  }, [activeTab, loadTab]);
+  useAutoRefresh(lastLoadedAt, backgroundRefresh);
 
   const openSymbol = useCallback((symbol: string) => {
     pinTicker(symbol, { floating: true, paneType: TICKER_RESEARCH_PANE_ID });
@@ -235,10 +235,6 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
       return true;
     }
     return false;
-  }, [activeTab, loadTab]);
-
-  const refreshActiveTab = useCallback(() => {
-    void loadTab(activeTab, { forceRefresh: true });
   }, [activeTab, loadTab]);
 
   usePaneFooter("market-movers", () => ({
@@ -269,7 +265,7 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
     <Box flexDirection="column" width={width} height={height}>
       <Box height={1} paddingX={1}>
         <Tabs
-          tabs={TABS.map((tab) => ({ label: tab.label, value: tab.id }))}
+          tabs={tabs.map((tab) => ({ label: tab.label, value: tab.id }))}
           activeValue={activeTab}
           onSelect={(value) => {
             setActiveTab(value as TabId);
@@ -299,8 +295,12 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
         getItemKey={(row) => `${row.symbol}-${row.rank}`}
         onActivate={(row) => openSymbol(row.symbol)}
         renderCell={renderMarketMoverCell}
-        emptyStateTitle={loading ? "Loading movers..." : loadError ?? "No data"}
-        emptyStateHint={loadError ? "Try again in a moment." : undefined}
+        emptyStateTitle={loading ? "Loading movers..." : loadError ?? "No movers returned."}
+        emptyContent={loadError ? (
+          <Box paddingX={1} paddingY={1}>
+            <EmptyState title={loadError} message="Try again in a moment." />
+          </Box>
+        ) : undefined}
       />
     </Box>
   );
@@ -325,7 +325,30 @@ export const marketMoversModule: PluginModule = {
       defaultMode: "floating",
       defaultFloatingSize: { width: 100, height: 36 },
       quickSettings: [LIVE_STREAMING_QUICK_SETTING],
-      settings: (context) => withLiveStreamingSetting({ fields: [] }, context.settings),
+      settings: (context) => withLiveStreamingSetting({
+        title: "Market Movers Settings",
+        values: {
+          tabs: resolveTabs(context.settings.tabs as string[] | undefined).map((tab) => tab.id),
+          summarySymbols: resolveSummarySymbols(context.settings.summarySymbols as string[] | undefined),
+        },
+        fields: [
+          {
+            key: "tabs",
+            label: "Lists",
+            type: "ordered-multi-select",
+            options: TABS.map((tab) => ({ value: tab.id, label: tab.label })),
+          },
+          {
+            key: "summarySymbols",
+            label: "Index summary",
+            type: "ordered-multi-select",
+            options: MARKET_SUMMARY_SYMBOLS.map((symbol) => ({
+              value: symbol,
+              label: INDEX_SHORT[symbol] ?? symbol,
+            })),
+          },
+        ],
+      }, context.settings),
     },
   ],
 

--- a/src/plugins/builtin/market-movers/model.ts
+++ b/src/plugins/builtin/market-movers/model.ts
@@ -1,6 +1,6 @@
 import type { DataTableColumn } from "../../../components";
 import { compareSortValues, type SortDirection } from "../../../utils/sort-values";
-import type { MarketSummaryQuote, ScreenerCategory, ScreenerQuote } from "./screener";
+import { MARKET_SUMMARY_SYMBOLS, type MarketSummaryQuote, type ScreenerCategory, type ScreenerQuote } from "./screener";
 
 export type TabId = "gainers" | "losers" | "actives" | "trending";
 
@@ -39,6 +39,21 @@ export const DEFAULT_SORT_PREFERENCE: MarketMoverSortPreference = {
   columnId: null,
   direction: "asc",
 };
+
+/** The saved list selection, falling back to every list when it is unusable. */
+export function resolveTabs(saved?: readonly string[]): Array<{ id: TabId; label: string }> {
+  const byId = new Map(TABS.map((tab) => [tab.id as string, tab]));
+  const resolved = (saved ?? [])
+    .map((id) => byId.get(id))
+    .filter((tab): tab is { id: TabId; label: string } => !!tab);
+  return resolved.length > 0 ? resolved : [...TABS];
+}
+
+/** The saved index-summary selection, falling back to every index. */
+export function resolveSummarySymbols(saved?: readonly string[]): string[] {
+  const resolved = (saved ?? []).filter((symbol) => MARKET_SUMMARY_SYMBOLS.includes(symbol as never));
+  return resolved.length > 0 ? resolved : [...MARKET_SUMMARY_SYMBOLS];
+}
 
 export const INDEX_SHORT: Record<string, string> = {
   "^GSPC": "SPX",

--- a/src/plugins/builtin/market-movers/screener.test.ts
+++ b/src/plugins/builtin/market-movers/screener.test.ts
@@ -5,6 +5,7 @@ import {
   createYahooScreenerApi,
   fetchPreferredMarketMovers,
   fetchScreener,
+  fetchScreenerResult,
   parseScreenerResponse,
   parseTrendingResponse,
   resetMarketMoversPersistence,
@@ -171,7 +172,7 @@ describe("fetchScreener", () => {
           },
         };
       },
-      fetchYahoo: async () => yahooQuotes,
+      fetchYahoo: async () => ({ data: yahooQuotes, stale: false }),
     };
 
     const result = await fetchPreferredMarketMovers(
@@ -205,7 +206,7 @@ describe("fetchScreener", () => {
         cloudCalls += 1;
         throw new Error("not expected");
       },
-      fetchYahoo: async () => parseScreenerResponse(SAMPLE_SCREENER_RESPONSE),
+      fetchYahoo: async () => ({ data: parseScreenerResponse(SAMPLE_SCREENER_RESPONSE), stale: false }),
     };
 
     const result = await fetchPreferredMarketMovers(
@@ -218,6 +219,31 @@ describe("fetchScreener", () => {
     expect(cloudCalls).toBe(0);
     expect(result.source).toBe("yahoo");
     expect(result.quotes.map((quote) => quote.symbol)).toEqual(["AAPL", "MSFT"]);
+  });
+
+  test("reports a cached Yahoo fallback as stale", async () => {
+    // Regression: an expired cache served after a failed fetch reported
+    // stale: false, so the pane's stale marker never appeared.
+    const persistence = new MemoryPluginPersistence();
+    attachMarketMoversPersistence(persistence);
+    let calls = 0;
+    const api: YahooScreenerApi = {
+      async fetchJson<T = unknown>() {
+        calls += 1;
+        if (calls === 1) return SAMPLE_SCREENER_RESPONSE as T;
+        throw new Error("upstream down");
+      },
+    };
+
+    const fresh = await fetchScreenerResult("day_gainers", 2, api, { cache: true });
+    expect(fresh.stale).toBe(false);
+
+    const fallback = await fetchScreenerResult("day_gainers", 2, api, {
+      cache: true,
+      forceRefresh: true,
+    });
+    expect(fallback.stale).toBe(true);
+    expect(fallback.data.map((quote) => quote.symbol)).toEqual(["AAPL", "MSFT"]);
   });
 
   test("falls back to the secondary Yahoo host when the primary host fails", async () => {

--- a/src/plugins/builtin/market-movers/screener.ts
+++ b/src/plugins/builtin/market-movers/screener.ts
@@ -110,27 +110,34 @@ function writeCache<T>(key: string, data: T): void {
   });
 }
 
+/** A cached value plus whether it is a fallback rather than a fresh load. */
+export interface CachedResult<T> {
+  data: T;
+  stale: boolean;
+}
+
 async function loadCached<T>(
   key: string,
   fetcher: () => Promise<T>,
   options?: FetchCacheOptions,
-): Promise<T> {
-  if (options?.cache === false) return fetcher();
+): Promise<CachedResult<T>> {
+  if (options?.cache === false) return { data: await fetcher(), stale: false };
 
   const cached = readCache<T>(key);
-  if (!options?.forceRefresh && cached && !cached.stale) return cached.data;
+  if (!options?.forceRefresh && cached && !cached.stale) return { data: cached.data, stale: false };
 
-  const activeFetch = activeFetches.get(key) as Promise<T> | undefined;
+  const activeFetch = activeFetches.get(key) as Promise<CachedResult<T>> | undefined;
   if (activeFetch) return activeFetch;
 
   const fallback = cached ?? readCache<T>(key, { allowExpired: true });
   const fetchPromise = fetcher()
     .then((data) => {
       writeCache(key, data);
-      return data;
+      return { data, stale: false };
     })
     .catch((error) => {
-      if (fallback) return fallback.data;
+      // Serving the expired copy is right; hiding that it is expired is not.
+      if (fallback) return { data: fallback.data, stale: true };
       throw error;
     })
     .finally(() => {
@@ -183,7 +190,7 @@ export interface PreferredMarketMoverSources {
     category: ScreenerCategory,
     count: number,
     options?: FetchCacheOptions,
-  ): Promise<ScreenerQuote[]>;
+  ): Promise<CachedResult<ScreenerQuote[]>>;
 }
 
 export interface TrendingSymbol {
@@ -231,12 +238,12 @@ export function parseScreenerResponse(data: any): ScreenerQuote[] {
   }
 }
 
-export async function fetchScreener(
+export async function fetchScreenerResult(
   category: ScreenerCategory,
   count = 25,
   api: YahooScreenerApi = screenerApi,
   options?: FetchCacheOptions,
-): Promise<ScreenerQuote[]> {
+): Promise<CachedResult<ScreenerQuote[]>> {
   const load = async () => {
     const data = await api.fetchJson("/v1/finance/screener/predefined/saved", {
       formatted: "false",
@@ -247,8 +254,17 @@ export async function fetchScreener(
     });
     return parseScreenerResponse(data);
   };
-  if (!shouldUseCache(api, options)) return load();
+  if (!shouldUseCache(api, options)) return { data: await load(), stale: false };
   return loadCached(`screener:${category}:count=${count}`, load, options);
+}
+
+export async function fetchScreener(
+  category: ScreenerCategory,
+  count = 25,
+  api: YahooScreenerApi = screenerApi,
+  options?: FetchCacheOptions,
+): Promise<ScreenerQuote[]> {
+  return (await fetchScreenerResult(category, count, api, options)).data;
 }
 
 function cloudScreenerCategory(category: ScreenerCategory): CloudMarketScreenerCategory {
@@ -265,7 +281,7 @@ function isCloudScreenerEligible(): boolean {
 const defaultPreferredMarketMoverSources: PreferredMarketMoverSources = {
   isCloudEligible: isCloudScreenerEligible,
   fetchCloud: (category, count, mode) => apiClient.getCloudMarketScreener(category, count, mode),
-  fetchYahoo: (category, count, options) => fetchScreener(category, count, undefined, options),
+  fetchYahoo: (category, count, options) => fetchScreenerResult(category, count, undefined, options),
 };
 
 function mergeCloudScreenerItem(
@@ -297,12 +313,12 @@ function mergeCloudScreenerItem(
 }
 
 async function bestEffortYahooMetadata(
-  request: Promise<ScreenerQuote[]>,
+  request: Promise<CachedResult<ScreenerQuote[]>>,
 ): Promise<ScreenerQuote[]> {
   let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
-      request.catch(() => []),
+      request.then((result) => result.data).catch(() => []),
       new Promise<ScreenerQuote[]>((resolve) => {
         timeout = setTimeout(() => resolve([]), YAHOO_METADATA_WAIT_MS);
       }),
@@ -319,11 +335,8 @@ export async function fetchPreferredMarketMovers(
   sources: PreferredMarketMoverSources = defaultPreferredMarketMoverSources,
 ): Promise<MarketMoversResult> {
   if (!sources.isCloudEligible()) {
-    return {
-      quotes: await sources.fetchYahoo(category, count, options),
-      source: "yahoo",
-      stale: false,
-    };
+    const result = await sources.fetchYahoo(category, count, options);
+    return { quotes: result.data, source: "yahoo", stale: result.stale };
   }
 
   const yahooMetadata = sources.fetchYahoo(
@@ -356,10 +369,11 @@ export async function fetchPreferredMarketMovers(
     // Yahoo remains the resilient fallback when Cloud is unavailable.
   }
 
+  const fallback = await yahooMetadata;
   return {
-    quotes: await yahooMetadata,
+    quotes: fallback.data,
     source: "yahoo",
-    stale: false,
+    stale: fallback.stale,
   };
 }
 
@@ -390,7 +404,7 @@ export async function fetchTrending(
     return parseTrendingResponse(data);
   };
   if (!shouldUseCache(api, options)) return load();
-  return loadCached(`trending:US:count=${count}`, load, options);
+  return (await loadCached(`trending:US:count=${count}`, load, options)).data;
 }
 
 export const MARKET_SUMMARY_SYMBOLS = ["^GSPC", "^DJI", "^IXIC", "^RUT"] as const;

--- a/src/plugins/builtin/news/index.tsx
+++ b/src/plugins/builtin/news/index.tsx
@@ -1,61 +1,37 @@
-import { Text } from "../../../ui";
-import { useRef, useEffect, useMemo, useState } from "react";
+import { Box } from "../../../ui";
 import { composeBuiltinPlugin, type PluginModule } from "../plugin-module";
 import { usePaneTicker } from "../../../state/app/context";
-import { colors } from "../../../theme/colors";
-import type { NewsArticle } from "../../../types/news-source";
 import { useArticleSummary, useResolvedEntryValue } from "../../../market-data/hooks";
 import { instrumentFromTicker } from "../../../market-data/request-types";
-import { useDebouncedPluginPaneState } from "../../runtime";
-import { FeedDataTableStackView, Spinner, type FeedDataTableItem } from "../../../components";
-import { useNewsArticles } from "../../../news/hooks";
+import { useDebouncedPluginPaneState, usePluginPaneState } from "../../runtime";
+import { EmptyState } from "../../../components";
+import { useLoadNewsStory, useNewsArticles } from "../../../news/hooks";
 import { newsWireModule } from "./wire";
+import { NewsDetailView, useNewsArticleDetail } from "./wire/news/detail-view";
+import {
+  NewsArticleStackView,
+  newsTableStatusContent,
+  type NewsSortPreference,
+} from "./wire/news/table";
 import { useNewsArticleFooter } from "./wire/news/footer";
 import { usePersistedNewsArticles } from "./wire/persisted-articles";
 import { useNewsReadState } from "./wire/read-state";
 import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
 
 const NEWS_ITEM_LIMIT = 50;
-
-function getFeedItems(
-  news: NewsArticle[],
-  selectedUrl: string | undefined,
-  summaryCache: Map<string, string>,
-  loadingSummary: boolean,
-): FeedDataTableItem[] {
-  return news.map((item) => {
-    const preview = summaryCache.get(item.url) ?? item.summary ?? undefined;
-    const isSelected = item.url === selectedUrl;
-    return {
-      id: item.id,
-      eyebrow: item.source,
-      title: item.title,
-      timestamp: item.publishedAt,
-      detailTitle: item.title,
-      detailMeta: [
-        item.source,
-        `Published ${item.publishedAt.toLocaleString("en-US", {
-          month: "short",
-          day: "numeric",
-          year: "numeric",
-          hour: "numeric",
-          minute: "2-digit",
-        })}`,
-      ],
-      detailBody: isSelected
-        ? preview ?? (loadingSummary ? "Loading preview..." : "No preview available.")
-        : preview ?? "",
-      detailNote: item.url,
-    };
-  });
-}
+const DEFAULT_SORT: NewsSortPreference = { columnId: "time", direction: "desc" };
 
 function TickerNewsView({ width, height, focused }: { width: number; height: number; focused: boolean }) {
   const { ticker } = usePaneTicker();
-  const selectionKey = `selectedIdx:${ticker?.metadata.ticker ?? "none"}`;
-  const [selectedIdx, setSelectedIdx] = useDebouncedPluginPaneState<number>(selectionKey, 0);
-  const [summaryCache, setSummaryCache] = useState<Map<string, string>>(new Map());
-  const summaryFetchRef = useRef(0);
+  const symbol = ticker?.metadata.ticker ?? "none";
+  const [selectedArticleId, setSelectedArticleId] = useDebouncedPluginPaneState<string | null>(
+    `selectedArticleId:${symbol}`,
+    null,
+  );
+  const [sortPreference, setSortPreference] = usePluginPaneState<NewsSortPreference>(
+    "ticker-news:sort",
+    DEFAULT_SORT,
+  );
   const instrument = instrumentFromTicker(ticker, ticker?.metadata.ticker ?? null);
   const newsState = useNewsArticles(instrument ? {
     feed: "ticker",
@@ -64,81 +40,84 @@ function TickerNewsView({ width, height, focused }: { width: number; height: num
     tickerTier: "primary",
     limit: NEWS_ITEM_LIMIT,
   } : null);
-  const liveNews = newsState.articles;
   const news = usePersistedNewsArticles(
     `articles:${instrument?.symbol ?? "none"}:${instrument?.exchange ?? ""}`,
-    liveNews,
+    newsState.articles,
   );
   const { readArticleIds, markArticleRead } = useNewsReadState();
-  const [openItemId, setOpenItemId] = useState<string | null>(null);
-  const loading = newsState.phase === "loading" || (newsState.phase === "refreshing" && news.length === 0);
-  const error = newsState.phase === "error" ? newsState.error ?? "Failed to load news" : null;
+  const loadNewsStory = useLoadNewsStory();
+  const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(news, loadNewsStory);
+  const loading = newsState.phase === "loading"
+    || (newsState.phase === "refreshing" && news.length === 0);
+  const error = newsState.error;
 
-  useEffect(() => {
-    summaryFetchRef.current += 1;
-    setSummaryCache(new Map());
-  }, [ticker?.metadata.ticker]);
-
-  const selected = news[selectedIdx];
-  const openArticle = openItemId
-    ? news.find((article) => article.id === openItemId) ?? null
-    : null;
-  const cachedSelectedSummary = selected ? summaryCache.get(selected.url) : undefined;
   const articleSummaryEntry = useArticleSummary(
-    selected && !selected.summary && !cachedSelectedSummary ? selected.url : null,
+    detailArticle && !detailArticle.summary ? detailArticle.url : null,
   );
-  const selectedSummary = useResolvedEntryValue(articleSummaryEntry);
-  const loadingSummary = articleSummaryEntry?.phase === "loading" || articleSummaryEntry?.phase === "refreshing";
-
-  useEffect(() => {
-    if (!selected?.summary) return;
-    const summary = selected.summary;
-    setSummaryCache((prev) => prev.has(selected.url) ? prev : new Map(prev).set(selected.url, summary));
-  }, [selected?.summary, selected?.url]);
-
-  useEffect(() => {
-    if (!selected?.url || !selectedSummary) return;
-    setSummaryCache((prev) => new Map(prev).set(selected.url, selectedSummary));
-  }, [selected?.url, selectedSummary]);
-
-  useEffect(() => {
-    if (news.length > 0 && selectedIdx >= news.length) {
-      setSelectedIdx(Math.max(0, news.length - 1));
-    }
-  }, [news.length, selectedIdx, setSelectedIdx]);
+  const fetchedSummary = useResolvedEntryValue(articleSummaryEntry);
+  const loadingSummary = articleSummaryEntry?.phase === "loading"
+    || articleSummaryEntry?.phase === "refreshing";
+  const detailWithSummary = detailArticle && !detailArticle.summary && fetchedSummary
+    ? { ...detailArticle, summary: fetchedSummary }
+    : detailArticle;
 
   useNewsArticleFooter({
     registrationId: "news",
     focused,
-    article: openArticle,
-    loading,
+    article: detailArticle,
+    // Stale rows stay on screen during a refresh or a failure, so the pane says
+    // so in the footer instead of replacing them.
+    loading: loading && news.length > 0,
     error,
     info: loadingSummary
       ? [{ id: "summary", parts: [{ text: "summary loading", tone: "muted" as const }] }]
       : undefined,
   });
 
-  if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view news.</Text>;
-  if (loading && news.length === 0) return <Spinner label="Loading news..." />;
-  if (error) return <Text fg={colors.textDim}>Error: {error}</Text>;
-  if (news.length === 0) return <Text fg={colors.textDim}>No news available for {ticker.metadata.ticker}.</Text>;
-
-  const items = getFeedItems(news, selected?.url, summaryCache, loadingSummary);
+  if (!ticker) {
+    return (
+      <Box paddingX={1} paddingY={1}>
+        <EmptyState title="No ticker selected." message="Pick a ticker to load its news." />
+      </Box>
+    );
+  }
 
   return (
-    <FeedDataTableStackView
-      width={width}
-      height={height}
+    <NewsArticleStackView
+      articles={news}
       focused={focused}
-      items={items}
-      selectedIdx={selectedIdx}
-      onSelect={setSelectedIdx}
-      isItemRead={(item) => readArticleIds.has(item.id)}
-      onOpenItem={(item) => markArticleRead(item.id)}
-      onOpenItemIdChange={setOpenItemId}
-      sourceLabel="Source"
-      titleLabel="Headline"
-      emptyStateTitle="No news."
+      width={width}
+      rootHeight={height}
+      readArticleIds={readArticleIds}
+      selectedArticleId={selectedArticleId}
+      setSelectedArticleId={setSelectedArticleId}
+      sortPreference={sortPreference}
+      setSortPreference={setSortPreference}
+      onOpenArticle={openArticle}
+      onArticleRead={markArticleRead}
+      detailOpen={!!detailWithSummary}
+      onBack={closeDetail}
+      detailContent={detailWithSummary ? (
+        <NewsDetailView
+          item={detailWithSummary}
+          focused={focused}
+          width={width}
+          showTitle={false}
+        />
+      ) : (
+        <Box flexGrow={1} />
+      )}
+      detailTitle={detailWithSummary?.title}
+      columns={["time", "source", "title", "categories", "sentiment"]}
+      emptyContent={newsTableStatusContent({
+        loading,
+        error,
+        subject: "News",
+        emptyTitle: `No news for ${ticker.metadata.ticker}`,
+        emptyMessage: "Stories appear as sources publish them.",
+      })}
+      emptyStateTitle={`No news for ${ticker.metadata.ticker}`}
+      emptyStateHint="Stories appear as sources publish them."
     />
   );
 }

--- a/src/plugins/builtin/news/wire/breaking/pane.tsx
+++ b/src/plugins/builtin/news/wire/breaking/pane.tsx
@@ -2,9 +2,12 @@ import { Box } from "../../../../../ui";
 import type { PaneProps } from "../../../../../types/plugin";
 import { useLoadNewsStory, useNewsArticles } from "../../../../../news/hooks";
 import { useDebouncedPluginPaneState, usePluginPaneState } from "../../../../runtime";
-import { Spinner } from "../../../../../components";
 import { NewsDetailView, useNewsArticleDetail } from "../news/detail-view";
-import { NewsArticleStackView, type NewsSortPreference } from "../news/table";
+import {
+  NewsArticleStackView,
+  newsTableStatusContent,
+  type NewsSortPreference,
+} from "../news/table";
 import { useNewsArticleFooter } from "../news/footer";
 import { NEWS_QUERY_PRESETS } from "../news/query-presets";
 import { usePersistedNewsArticles } from "../persisted-articles";
@@ -15,7 +18,9 @@ const DEFAULT_SORT: NewsSortPreference = { columnId: "importance", direction: "d
 export function BreakingPane({ focused, width, height }: PaneProps) {
   const breakingState = useNewsArticles(NEWS_QUERY_PRESETS.breaking);
   const articles = usePersistedNewsArticles("breaking:articles", breakingState.articles);
-  const loading = breakingState.phase === "loading" || (breakingState.phase === "refreshing" && articles.length === 0);
+  const loading = breakingState.phase === "loading"
+    || (breakingState.phase === "refreshing" && articles.length === 0);
+  const error = breakingState.error;
   const [selectedArticleId, setSelectedArticleId] = useDebouncedPluginPaneState<string | null>("breaking:selectedArticleId", null);
   const [sortPreference, setSortPreference] = usePluginPaneState<NewsSortPreference>("breaking:sort", DEFAULT_SORT);
   const loadNewsStory = useLoadNewsStory();
@@ -26,6 +31,8 @@ export function BreakingPane({ focused, width, height }: PaneProps) {
     registrationId: "news-wire:breaking",
     focused,
     article: detailArticle,
+    loading: loading && articles.length > 0,
+    error,
   });
 
   const detailContent = detailArticle ? (
@@ -38,10 +45,6 @@ export function BreakingPane({ focused, width, height }: PaneProps) {
   ) : (
     <Box flexGrow={1} />
   );
-
-  if (loading && articles.length === 0) {
-    return <Spinner label="Loading breaking news..." />;
-  }
 
   return (
     <NewsArticleStackView
@@ -60,7 +63,14 @@ export function BreakingPane({ focused, width, height }: PaneProps) {
       onBack={closeDetail}
       detailContent={detailContent}
       detailTitle={detailArticle?.title}
-      columns={["time", "title", "tickers", "importance"]}
+      columns={["time", "source", "title", "tickers", "categories", "importance"]}
+      emptyContent={newsTableStatusContent({
+        loading,
+        error,
+        subject: "Breaking news",
+        emptyTitle: "No breaking news",
+        emptyMessage: "Breaking stories appear when high-priority headlines arrive.",
+      })}
       emptyStateTitle="No breaking news"
       emptyStateHint="Breaking stories appear when high-priority headlines arrive."
     />

--- a/src/plugins/builtin/news/wire/categories.ts
+++ b/src/plugins/builtin/news/wire/categories.ts
@@ -11,6 +11,41 @@ const CATEGORY_KEYWORDS: Record<string, string[]> = {
   geopolitical: ["war", "sanctions", "nato", "military", "conflict", "diplomacy"],
 };
 
+/**
+ * Feed and cloud sources emit snake_case category ids. Panes show people
+ * words, so every id passes through here before it reaches a cell.
+ */
+const CATEGORY_LABELS: Record<string, string> = {
+  mna: "M&A",
+  ma: "M&A",
+  ipo: "IPO",
+  macro_politics: "Politics",
+  macro_policy: "Policy",
+  central_bank: "Central bank",
+  fx: "FX",
+  esg: "ESG",
+  ai: "AI",
+  it: "IT",
+  us: "US",
+};
+
+export function formatNewsCategory(value: string | null | undefined): string {
+  const raw = value?.trim();
+  if (!raw) return "";
+  const key = raw.toLowerCase().replace(/[\s-]+/g, "_");
+  const mapped = CATEGORY_LABELS[key];
+  if (mapped) return mapped;
+  const words = key.split("_").filter(Boolean);
+  if (words.length === 0) return "";
+  return words
+    .map((word, index) => (
+      CATEGORY_LABELS[word] ?? (index === 0
+        ? word.charAt(0).toUpperCase() + word.slice(1)
+        : word)
+    ))
+    .join(" ");
+}
+
 const KNOWN_TICKERS = new Set([
   "AAPL", "MSFT", "GOOGL", "AMZN", "NVDA", "META", "TSLA", "JPM", "JNJ", "UNH",
   "PG", "XOM", "CVX", "HD", "BAC", "V", "MA", "PFE", "KO", "PEP", "ABBV", "MRK",

--- a/src/plugins/builtin/news/wire/default-feeds.ts
+++ b/src/plugins/builtin/news/wire/default-feeds.ts
@@ -1,3 +1,49 @@
 import type { RssFeedConfig } from "./rss/parser";
 
-export const DEFAULT_FEEDS: RssFeedConfig[] = [];
+/**
+ * Bundled so a terminal without a Gloom Cloud session still has a wire to read.
+ * All of these are public, key-free RSS endpoints; users can disable any of
+ * them and add their own with the Add News Feed command.
+ */
+export const DEFAULT_FEEDS: RssFeedConfig[] = [
+  {
+    id: "default-cnbc-top",
+    url: "https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01&id=100003114",
+    name: "CNBC",
+    category: "general",
+    authority: 70,
+    enabled: true,
+  },
+  {
+    id: "default-marketwatch-top",
+    url: "https://feeds.content.dowjones.io/public/rss/mw_topstories",
+    name: "MarketWatch",
+    category: "general",
+    authority: 70,
+    enabled: true,
+  },
+  {
+    id: "default-yahoo-finance",
+    url: "https://finance.yahoo.com/news/rssindex",
+    name: "Yahoo Finance",
+    category: "general",
+    authority: 60,
+    enabled: true,
+  },
+  {
+    id: "default-bbc-business",
+    url: "https://feeds.bbci.co.uk/news/business/rss.xml",
+    name: "BBC Business",
+    category: "general",
+    authority: 65,
+    enabled: true,
+  },
+  {
+    id: "default-fed-press",
+    url: "https://www.federalreserve.gov/feeds/press_all.xml",
+    name: "Federal Reserve",
+    category: "macro",
+    authority: 90,
+    enabled: true,
+  },
+];

--- a/src/plugins/builtin/news/wire/feed-config.test.ts
+++ b/src/plugins/builtin/news/wire/feed-config.test.ts
@@ -31,7 +31,7 @@ class MemoryConfigState implements PluginConfigState {
 }
 
 describe("news feed config", () => {
-  test("normalizes legacy JSON feed storage and ignores removed default feed names", () => {
+  test("normalizes legacy JSON feed storage and migrates disabled default feed names to ids", () => {
     const config = new MemoryConfigState();
     config.values.set("feeds", JSON.stringify([
       { url: "https://example.com/rss.xml", name: "Example", authority: 120 },
@@ -44,7 +44,7 @@ describe("news feed config", () => {
     expect(settings.userFeeds).toHaveLength(1);
     expect(settings.userFeeds[0]!.id).toMatch(/^user-/);
     expect(settings.userFeeds[0]!.authority).toBe(100);
-    expect(settings.disabledDefaultFeedIds).toEqual([]);
+    expect(settings.disabledDefaultFeedIds).toEqual(["default-cnbc-top"]);
   });
 
   test("adds, updates, and removes user feeds through typed helpers", async () => {
@@ -69,17 +69,22 @@ describe("news feed config", () => {
     expect(loadNewsFeedSettings(config).userFeeds).toHaveLength(0);
   });
 
-  test("returns only user feeds when the default feed catalog is empty", async () => {
+  test("serves bundled default feeds alongside user feeds and honours disabled defaults", async () => {
     const config = new MemoryConfigState();
 
-    expect(getEnabledNewsFeeds(loadNewsFeedSettings(config))).toEqual([]);
+    const bundledIds = getEnabledNewsFeeds(loadNewsFeedSettings(config)).map((feed) => feed.id);
+    expect(bundledIds).toContain("default-cnbc-top");
 
     const added = await addUserNewsFeed(config, {
       url: "https://example.com/feed",
       name: "Example",
     });
+    expect(getEnabledNewsFeeds(loadNewsFeedSettings(config)).map((feed) => feed.id))
+      .toEqual([...bundledIds, added.id]);
 
-    expect(getEnabledNewsFeeds(loadNewsFeedSettings(config)).map((feed) => feed.id)).toEqual([added.id]);
+    expect(await setDefaultNewsFeedEnabled(config, "default-cnbc-top", false)).toBe(true);
+    expect(getEnabledNewsFeeds(loadNewsFeedSettings(config)).map((feed) => feed.id))
+      .not.toContain("default-cnbc-top");
     expect(await setDefaultNewsFeedEnabled(config, "missing-default-feed", false)).toBe(false);
   });
 

--- a/src/plugins/builtin/news/wire/index.tsx
+++ b/src/plugins/builtin/news/wire/index.tsx
@@ -44,20 +44,20 @@ const TopPane = createNewsPresetPane({
   paneKey: "top",
   title: "Top News",
   query: NEWS_QUERY_PRESETS.top,
-  columns: ["time", "title", "tickers", "importance"],
+  columns: ["time", "source", "title", "tickers", "categories", "importance"],
   defaultSort: { columnId: "importance", direction: "desc" },
   emptyStateTitle: "No top stories yet",
-  emptyStateHint: "Try refreshing later as new headlines are ranked.",
+  emptyStateHint: "Run the Add News Feed command to wire up another source.",
 });
 
 const FeedPane = createNewsPresetPane({
   paneKey: "feed",
   title: "News Feed",
   query: NEWS_QUERY_PRESETS.feed,
-  columns: ["time", "source", "title", "tickers", "categories"],
+  columns: ["time", "source", "title", "tickers", "categories", "sentiment"],
   defaultSort: { columnId: "time", direction: "desc" },
   emptyStateTitle: "No feed stories yet",
-  emptyStateHint: "Try refreshing later as wire stories arrive.",
+  emptyStateHint: "Run the Add News Feed command to wire up another source.",
 });
 
 let disposeBreakingNewsNotifications: (() => void) | null = null;

--- a/src/plugins/builtin/news/wire/industry-pane.tsx
+++ b/src/plugins/builtin/news/wire/industry-pane.tsx
@@ -3,11 +3,14 @@ import { useEffect, useMemo } from "react";
 import type { PaneProps } from "../../../../types/plugin";
 import type { MarketNewsItem } from "../../../../types/news-source";
 import { useLoadNewsStory, useNewsArticles } from "../../../../news/hooks";
-import type { NewsQueryPhase } from "../../../../news/types";
 import { useDebouncedPluginPaneState, usePluginPaneState } from "../../../runtime";
-import { Spinner, Tabs } from "../../../../components";
+import { Tabs } from "../../../../components";
 import { NewsDetailView, useNewsArticleDetail } from "./news/detail-view";
-import { NewsArticleStackView, type NewsSortPreference } from "./news/table";
+import {
+  NewsArticleStackView,
+  newsTableStatusContent,
+  type NewsSortPreference,
+} from "./news/table";
 import { useNewsArticleFooter } from "./news/footer";
 import { useNewsReadState } from "./read-state";
 import { usePersistedNewsArticles } from "./persisted-articles";
@@ -22,18 +25,31 @@ const SECTOR_TABS = ["all", ...SECTOR_NEWS_SECTORS] as const;
 
 const DEFAULT_SORT: NewsSortPreference = { columnId: "time", direction: "desc" };
 
-function useIndustryArticles(sector: SectorNewsSelection): { articles: MarketNewsItem[]; allArticles: MarketNewsItem[]; phase: NewsQueryPhase } {
+/**
+ * The all-sector response is already fetched for the tab counts, so a sector
+ * tab filters that list instead of issuing a second identical request.
+ */
+function useIndustryArticles(sector: SectorNewsSelection): {
+  articles: MarketNewsItem[];
+  allArticles: MarketNewsItem[];
+  loading: boolean;
+  error: string | null;
+} {
   const allState = useNewsArticles(NEWS_QUERY_PRESETS.sectorAll);
-  const sectorState = useNewsArticles(
-    sector === "all" ? null : NEWS_QUERY_PRESETS.sector(sector),
-  );
   const allArticles = usePersistedNewsArticles("industry:sector:all:articles", allState.articles);
-  const sectorArticles = usePersistedNewsArticles(`industry:sector:${sector}:articles`, sectorState.articles);
-  const phase = sector === "all" ? allState.phase : sectorState.phase;
+  const articles = useMemo(() => (
+    sector === "all"
+      ? allArticles
+      : allArticles.filter((article) => (
+        article.sectors.some((entry) => entry.toLowerCase() === sector)
+      ))
+  ), [allArticles, sector]);
   return {
-    articles: sector === "all" ? allArticles : sectorArticles,
+    articles,
     allArticles,
-    phase,
+    loading: allState.phase === "loading"
+      || (allState.phase === "refreshing" && allArticles.length === 0),
+    error: allState.error,
   };
 }
 
@@ -41,8 +57,7 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
   const [category, setCategory] = usePluginPaneState<SectorNewsSelection>("industry:category", "all");
   const [selectedArticleId, setSelectedArticleId] = useDebouncedPluginPaneState<string | null>("industry:selectedArticleId", null);
   const [sortPreference, setSortPreference] = usePluginPaneState<NewsSortPreference>("industry:sort", DEFAULT_SORT);
-  const { articles, allArticles, phase } = useIndustryArticles(category);
-  const loading = phase === "loading" || (phase === "refreshing" && articles.length === 0);
+  const { articles, allArticles, loading, error } = useIndustryArticles(category);
   const loadNewsStory = useLoadNewsStory();
   const { detailArticle, openArticle, closeDetail } = useNewsArticleDetail(articles, loadNewsStory);
   const { readArticleIds, markArticleRead } = useNewsReadState();
@@ -69,6 +84,8 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
     registrationId: "news-wire:industry",
     focused,
     article: detailArticle,
+    loading: loading && allArticles.length > 0,
+    error,
   });
 
   const rootBefore = (
@@ -113,12 +130,14 @@ export function IndustryPane({ focused, width, height }: PaneProps) {
       detailContent={detailContent}
       detailTitle={detailArticle?.title}
       rootBefore={rootBefore}
-      columns={["time", "source", "title", "tickers", "categories"]}
-      emptyContent={loading && articles.length === 0 ? (
-        <Box width="100%" paddingX={1} paddingY={1}>
-          <Spinner label="Loading sector news..." />
-        </Box>
-      ) : undefined}
+      columns={["time", "source", "title", "tickers", "categories", "sentiment"]}
+      emptyContent={newsTableStatusContent({
+        loading,
+        error,
+        subject: "Sector news",
+        emptyTitle: "No news in this category",
+        emptyMessage: "Try another category or wait for the next feed refresh.",
+      })}
       emptyStateTitle="No news in this category"
       emptyStateHint="Try another category or wait for the next feed refresh."
     />

--- a/src/plugins/builtin/news/wire/news/detail-view.tsx
+++ b/src/plugins/builtin/news/wire/news/detail-view.tsx
@@ -11,6 +11,7 @@ import { useInlineTickers } from "../../../../../state/hooks/inline-tickers";
 import { isPlainKey } from "../../../../../utils/keyboard";
 import { wrapTextLines } from "../../../../../utils/text-wrap";
 import { formatDetailDate } from "../../../../../utils/datetime-format";
+import { formatNewsCategory } from "../categories";
 
 function hasStoryItems(article: MarketNewsItem | null): boolean {
   return (article?.items?.length ?? 0) > 0;
@@ -193,6 +194,10 @@ export function NewsDetailView({ item, focused, width, showTitle = true }: {
   const { catalog, openTicker } = useInlineTickers(tickerTexts);
   const [hoveredTicker, setHoveredTicker] = useState<string | null>(null);
   const timelineItems = useMemo(() => sortStoryItems(item.items), [item.items]);
+  const categoryLabels = useMemo(
+    () => item.categories.map(formatNewsCategory).filter(Boolean).join(" · "),
+    [item.categories],
+  );
   const lastUpdatedAt = timelineItems[0]?.publishedAt ?? item.publishedAt;
   const lastUpdatedStr = formatDetailDate(storyItemDate(lastUpdatedAt));
 
@@ -239,7 +244,9 @@ export function NewsDetailView({ item, focused, width, showTitle = true }: {
             </Box>
           )}
           <Box height={1} flexDirection="row">
-            <Text fg={colors.textDim}>Last updated at {lastUpdatedStr}</Text>
+            <Text fg={colors.textDim}>
+              {`${item.source} · last updated at ${lastUpdatedStr} · score ${item.importance}/100`}
+            </Text>
           </Box>
           <TextLines text={item.summary} width={innerW} color={colors.text} nativePaneChrome={nativePaneChrome === true} />
           {tickers.length > 0 && (
@@ -275,12 +282,10 @@ export function NewsDetailView({ item, focused, width, showTitle = true }: {
           )}
           {item.categories.length > 0 && (
             nativePaneChrome ? (
-              <TextLines text={item.categories.join(" · ")} width={innerW} color={colors.textMuted} nativePaneChrome />
+              <TextLines text={categoryLabels} width={innerW} color={colors.textMuted} nativePaneChrome />
             ) : (
               <Box height={1} flexDirection="row">
-                <Text fg={colors.textMuted}>
-                  {item.categories.join(" · ")}
-                </Text>
+                <Text fg={colors.textMuted}>{categoryLabels}</Text>
               </Box>
             )
           )}

--- a/src/plugins/builtin/news/wire/news/preset-pane.tsx
+++ b/src/plugins/builtin/news/wire/news/preset-pane.tsx
@@ -3,10 +3,10 @@ import type { NewsQuery } from "../../../../../news/types";
 import { useLoadNewsStory, useNewsArticles } from "../../../../../news/hooks";
 import type { PaneProps } from "../../../../../types/plugin";
 import { useDebouncedPluginPaneState, usePluginPaneState } from "../../../../runtime";
-import { Spinner } from "../../../../../components";
 import { NewsDetailView, useNewsArticleDetail } from "./detail-view";
 import {
   NewsArticleStackView,
+  newsTableStatusContent,
   type NewsColumnId,
   type NewsSortPreference,
 } from "./table";
@@ -36,7 +36,11 @@ export function NewsPresetPane({
 }) {
   const newsState = useNewsArticles(query);
   const articles = usePersistedNewsArticles(`${paneKey}:articles`, newsState.articles);
-  const loading = newsState.phase === "loading" || (newsState.phase === "refreshing" && articles.length === 0);
+  // The aggregator opens a query in "loading", so the first paint is a loading
+  // body rather than a definitive empty wire.
+  const loading = newsState.phase === "loading"
+    || (newsState.phase === "refreshing" && articles.length === 0);
+  const error = newsState.error;
   const [selectedArticleId, setSelectedArticleId] = useDebouncedPluginPaneState<string | null>(
     `${paneKey}:selectedArticleId`,
     null,
@@ -56,6 +60,8 @@ export function NewsPresetPane({
     registrationId: `news-wire:${paneKey}`,
     focused,
     article: detailArticle,
+    loading: loading && articles.length > 0,
+    error,
   });
 
   const detailContent = detailArticle ? (
@@ -68,10 +74,6 @@ export function NewsPresetPane({
   ) : (
     <Box flexGrow={1} />
   );
-
-  if (loading && articles.length === 0) {
-    return <Spinner label={`Loading ${title.toLowerCase()}...`} />;
-  }
 
   return (
     <NewsArticleStackView
@@ -91,6 +93,13 @@ export function NewsPresetPane({
       detailContent={detailContent}
       detailTitle={detailArticle?.title}
       columns={columns}
+      emptyContent={newsTableStatusContent({
+        loading,
+        error,
+        subject: title,
+        emptyTitle: emptyStateTitle,
+        emptyMessage: emptyStateHint,
+      })}
       emptyStateTitle={emptyStateTitle}
       emptyStateHint={emptyStateHint}
     />

--- a/src/plugins/builtin/news/wire/news/query-presets.ts
+++ b/src/plugins/builtin/news/wire/news/query-presets.ts
@@ -34,7 +34,21 @@ export const NEWS_QUERY_PRESETS = {
   },
 } as const;
 
+/** Short enough that the whole sector strip fits a normal pane width. */
+const SECTOR_LABELS: Record<string, string> = {
+  information_technology: "Tech",
+  energy: "Energy",
+  financials: "Financials",
+  health_care: "Health",
+  industrials: "Industry",
+  consumer_discretionary: "Cons disc",
+  consumer_staples: "Cons stap",
+  communication_services: "Comms",
+  materials: "Materials",
+  utilities: "Utilities",
+};
+
 export function sectorNewsLabel(value: SectorNewsSelection): string {
-  if (value === "all") return "all";
-  return value.replace(/_/g, " ");
+  if (value === "all") return "All";
+  return SECTOR_LABELS[value] ?? value.replace(/_/g, " ");
 }

--- a/src/plugins/builtin/news/wire/news/table.test.tsx
+++ b/src/plugins/builtin/news/wire/news/table.test.tsx
@@ -108,6 +108,60 @@ describe("NewsArticleStackView", () => {
     expect(boldText).not.toContain("Read story");
   });
 
+  test("keeps the last column and human labels inside the pane width", async () => {
+    const state = createInitialState(
+      createDefaultConfig("/tmp/gloomberb-news-table-layout-test"),
+    );
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <PaneInstanceProvider paneId="news-top:main">
+          <NewsArticleStackView
+            articles={[
+              makeArticle({
+                id: "macro",
+                title: "Fed officials signal caution on further rate cuts as inflation stays sticky",
+                source: "globenewswire-releases",
+                categories: ["macro_politics"],
+                importance: 87,
+              }),
+            ]}
+            focused
+            width={90}
+            rootHeight={10}
+            selectedArticleId="macro"
+            setSelectedArticleId={() => {}}
+            sortPreference={{ columnId: "importance", direction: "desc" }}
+            setSortPreference={() => {}}
+            onOpenArticle={() => {}}
+            detailOpen={false}
+            onBack={() => {}}
+            detailContent={<Box />}
+            columns={["time", "source", "title", "tickers", "categories", "importance"]}
+            emptyStateTitle="No stories"
+          />
+        </PaneInstanceProvider>
+      </AppContext>,
+      { width: 90, height: 10 },
+    );
+
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const lines = testSetup.captureCharFrame().split("\n");
+    // The sorted column and its indicator must survive the layout arithmetic.
+    expect(lines[0]).toContain("SCORE");
+    expect(lines[0]).toContain("\u25bc");
+    expect(lines[0]!.length).toBeLessThanOrEqual(90);
+    expect(lines[1]).toContain("87");
+    // Snake_case ids and mid-word clipping never reach the user.
+    expect(lines[1]).toContain("Politics");
+    expect(lines[1]).not.toContain("macro_politics");
+    expect(lines[1]).toContain("globenews...");
+  });
+
   test("dedupes exchange-qualified ticker aliases in table cells", async () => {
     const state = createInitialState(
       createDefaultConfig("/tmp/gloomberb-news-table-ticker-dedupe-test"),

--- a/src/plugins/builtin/news/wire/news/table.tsx
+++ b/src/plugins/builtin/news/wire/news/table.tsx
@@ -2,18 +2,79 @@ import { useCallback, useEffect, useMemo, type ReactNode } from "react";
 import { TextAttributes } from "../../../../../ui";
 import {
   DataTableStackView,
+  PaneStatusBody,
   TickerBadgeList,
   sortStackItems,
   type DataTableCell,
   type DataTableColumn,
   type StackSortPreference,
 } from "../../../../../components";
+import { TABLE_COLUMN_GAP, tableColumnWidth } from "../../../../../components/ui/table-layout";
 import type { MarketNewsItem } from "../../../../../types/news-source";
 import { colors } from "../../../../../theme/colors";
 import { collectNewsDisplayTickers } from "../../../../../news/ticker-symbols";
 import { formatRelativeTime } from "../../../../../utils/datetime-format";
+import { truncateWithEllipsis } from "../../../../../utils/text-wrap";
+import { formatNewsCategory } from "../categories";
 
-export type NewsColumnId = "rank" | "time" | "source" | "title" | "tickers" | "categories" | "importance";
+export type NewsColumnId =
+  | "rank"
+  | "time"
+  | "source"
+  | "title"
+  | "tickers"
+  | "categories"
+  | "sentiment"
+  | "importance";
+
+const SENTIMENT_ORDER: Record<string, number> = { negative: -1, neutral: 0, positive: 1 };
+
+/**
+ * Ticker badges are laid out by content, so a column that cannot fit them all
+ * bleeds stray characters into the next column. Keep only the badges that fit.
+ */
+function fitTickerSymbols(symbols: string[], width: number): string[] {
+  const fitted: string[] = [];
+  let used = 0;
+  for (const symbol of symbols) {
+    const badgeWidth = symbol.length + 3;
+    if (used + badgeWidth > width) break;
+    used += badgeWidth;
+    fitted.push(symbol);
+  }
+  return fitted;
+}
+
+/**
+ * Body for a table with no rows yet: loading while the query is in flight, the
+ * failure when the sources errored, and the empty state otherwise. Always own
+ * the body rather than falling back to the table's built-in empty state, whose
+ * desktop markup runs the title and the hint together on one line.
+ */
+export function newsTableStatusContent({
+  loading,
+  error,
+  subject,
+  emptyTitle,
+  emptyMessage,
+}: {
+  loading: boolean;
+  error?: string | null;
+  subject: string;
+  emptyTitle: string;
+  emptyMessage?: string;
+}): ReactNode {
+  return (
+    <PaneStatusBody
+      loading={loading}
+      error={error}
+      empty
+      subject={subject}
+      emptyTitle={emptyTitle}
+      emptyMessage={emptyMessage}
+    />
+  );
+}
 
 export type NewsSortPreference = StackSortPreference<NewsColumnId>;
 
@@ -59,6 +120,8 @@ function compareArticle(a: MarketNewsItem, b: MarketNewsItem, columnId: NewsColu
       );
     case "categories":
       return compareText(a.categories.join(" "), b.categories.join(" "));
+    case "sentiment":
+      return (SENTIMENT_ORDER[a.sentiment ?? ""] ?? 0) - (SENTIMENT_ORDER[b.sentiment ?? ""] ?? 0);
   }
 }
 
@@ -83,7 +146,9 @@ function nextSortPreference(current: NewsSortPreference, columnId: NewsColumnId)
   }
   return {
     columnId,
-    direction: columnId === "title" || columnId === "source" || columnId === "categories" ? "asc" : "desc",
+    direction: columnId === "title" || columnId === "source" || columnId === "categories"
+      ? "asc"
+      : "desc",
   };
 }
 
@@ -91,26 +156,35 @@ function buildColumns(width: number, columnIds: NewsColumnId[]): NewsTableColumn
   const fixedWidths: Record<Exclude<NewsColumnId, "title">, number> = {
     rank: 4,
     time: 4,
-    source: 10,
-    tickers: 24,
+    source: 12,
+    tickers: 18,
     categories: 10,
-    importance: 5,
+    sentiment: 4,
+    // Wide enough to keep the sort indicator next to the label.
+    importance: 7,
   };
   const labels: Record<NewsColumnId, string> = {
     rank: "#",
-    time: "Time",
-    source: "Source",
-    title: "Headline",
-    tickers: "Tickers",
-    categories: "Category",
-    importance: "Score",
+    time: "TIME",
+    source: "SOURCE",
+    title: "HEADLINE",
+    tickers: "TICKERS",
+    categories: "CATEGORY",
+    sentiment: "SENT",
+    importance: "SCORE",
   };
 
+  // A column occupies its header-floored width plus the gap, and the table adds
+  // one cell of padding on each side. Anything the fixed columns do not take is
+  // the headline's, so the last column never falls off the right edge.
   const fixedTotal = columnIds
     .filter((id) => id !== "title")
-    .reduce((sum, id) => sum + fixedWidths[id as Exclude<NewsColumnId, "title">] + 1, 0);
+    .reduce((sum, id) => sum + tableColumnWidth({
+      width: fixedWidths[id as Exclude<NewsColumnId, "title">],
+      label: labels[id],
+    }) + TABLE_COLUMN_GAP, 0);
   const tablePadding = 2;
-  const titleWidth = Math.max(16, width - fixedTotal - tablePadding - 1);
+  const titleWidth = Math.max(16, width - fixedTotal - tablePadding - TABLE_COLUMN_GAP);
 
   return columnIds.map((id) => ({
     id,
@@ -194,17 +268,20 @@ export function NewsArticleStackView({
       case "time":
         return { text: formatRelativeTime(item.publishedAt), color: selectedColor ?? colors.textDim };
       case "source":
-        return { text: item.source, color: selectedColor ?? colors.textMuted };
+        return {
+          text: truncateWithEllipsis(item.source, column.width),
+          color: selectedColor ?? colors.textMuted,
+        };
       case "title":
         return {
-          text: titleForArticle?.(item) ?? item.title,
+          text: truncateWithEllipsis(titleForArticle?.(item) ?? item.title, column.width),
           color: selectedColor ?? colors.text,
           attributes: readArticleIds?.has(item.id)
             ? TextAttributes.NONE
             : TextAttributes.BOLD,
         };
       case "tickers": {
-        const tickers = collectNewsDisplayTickers(item.tickers);
+        const tickers = fitTickerSymbols(collectNewsDisplayTickers(item.tickers), column.width);
         return {
           text: tickers.join(" "),
           content: (
@@ -212,13 +289,30 @@ export function NewsArticleStackView({
               symbols={tickers}
               width={column.width}
               fallbackColor={selectedColor ?? colors.textBright}
+              liveQuote={false}
             />
           ),
           color: selectedColor ?? colors.textBright,
         };
       }
       case "categories":
-        return { text: item.categories[0] ?? "—", color: selectedColor ?? colors.textDim };
+        return {
+          text: truncateWithEllipsis(formatNewsCategory(item.categories[0]) || "-", column.width),
+          color: selectedColor ?? colors.textDim,
+        };
+      case "sentiment": {
+        const sentiment = item.sentiment;
+        return {
+          text: sentiment ? sentiment.slice(0, 3) : "-",
+          color: selectedColor ?? (
+            sentiment === "positive"
+              ? colors.positive
+              : sentiment === "negative"
+                ? colors.negative
+                : colors.textDim
+          ),
+        };
+      }
       case "importance":
         return {
           text: String(item.importance),

--- a/src/plugins/builtin/notes/files.ts
+++ b/src/plugins/builtin/notes/files.ts
@@ -56,11 +56,17 @@ export class NotesFiles {
     return joinPath(this.dataDir, `${symbol}.md`);
   }
 
+  /**
+   * A note that was never written is empty, but any other read failure is
+   * rethrown: an unreadable note must not present itself as an empty editable
+   * one, or the next save silently overwrites real content.
+   */
   async load(symbol: string): Promise<string> {
     try {
       return await readTextFile(this.pathFor(symbol));
-    } catch {
-      return "";
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return "";
+      throw error;
     }
   }
 

--- a/src/plugins/builtin/notes/quick-notes-pane.test.tsx
+++ b/src/plugins/builtin/notes/quick-notes-pane.test.tsx
@@ -136,4 +136,47 @@ describe("createQuickNotesPane", () => {
 
     expect(notesFiles.saves).toEqual([{ key: TAB_A, text: "alpha-note" }]);
   });
+
+  test("never presents an unreadable note as an empty editable one", async () => {
+    const notesFiles = createMockNotesFiles();
+    const failing = {
+      ...notesFiles,
+      async load() {
+        throw new Error("EACCES: permission denied");
+      },
+    } as unknown as NotesFiles & { saves: Array<{ key: string; text: string }> };
+    const QuickNotesPane = createQuickNotesPane(failing);
+
+    testSetup = await testRender(
+      <QuickNotesHarness QuickNotesPane={QuickNotesPane} />,
+      { width: 80, height: 24 },
+    );
+    for (let attempt = 0; attempt < 5; attempt++) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        await testSetup!.renderOnce();
+      });
+      if (testSetup.captureCharFrame().includes("could not be read")) break;
+    }
+
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("could not be read");
+    expect(frame).not.toContain("Write notes");
+
+    // Clicking the body must not open an editor over content we failed to read.
+    const errorRow = frame.split("\n").findIndex((line) => line.includes("could not be read"));
+    await act(async () => {
+      await testSetup!.mockMouse.click(2, errorRow);
+      await testSetup!.mockInput.typeText("clobber");
+      await testSetup!.renderOnce();
+    });
+
+    const blurRow = testSetup.captureCharFrame().split("\n").findIndex((line) => line.includes("blur-pane"));
+    await act(async () => {
+      await testSetup!.mockMouse.click(2, blurRow);
+      await testSetup!.renderOnce();
+    });
+
+    expect(notesFiles.saves).toEqual([]);
+  });
 });

--- a/src/plugins/builtin/notes/quick-notes-pane.tsx
+++ b/src/plugins/builtin/notes/quick-notes-pane.tsx
@@ -4,7 +4,7 @@ import { useShortcut } from "../../../react/input";
 import type { PaneProps } from "../../../types/plugin";
 import { colors } from "../../../theme/colors";
 import { MarkdownEditor } from "../../../components/markdown-editor";
-import { ConfirmDialog, Tabs, usePaneFooter } from "../../../components";
+import { ConfirmDialog, EmptyState, Tabs, usePaneFooter } from "../../../components";
 import { type PromptContext, useDialog } from "../../../ui/dialog";
 import { usePluginAppActions } from "../../runtime";
 import type { NotesFiles } from "./files";
@@ -27,6 +27,7 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
     const [activeTabId, setActiveTabId] = useState<string | null>(null);
     const [renaming, setRenaming] = useState(false);
     const [renameValue, setRenameValue] = useState("");
+    const [loadError, setLoadError] = useState<string | null>(null);
     const { text: noteText, textRef: noteTextRef, setText: setNoteText } = useSyncedText("");
     const renameInputRef = useRef<InputRenderable>(null);
     const prevTabRef = useRef<string | null>(null);
@@ -103,6 +104,7 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
       prevTabRef.current = activeTabId;
       loadedTabIdRef.current = null;
       setNoteText("");
+      setLoadError(null);
       textareaRef.current?.setText("");
       let cancelled = false;
       // The user can start typing before a slow load resolves; handleNoteChange
@@ -115,7 +117,10 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
         setNoteText(text);
         textareaRef.current?.setText(text);
       };
-      notesFiles.load(notesFiles.quickNoteKey(activeTabId)).then(applyLoaded, () => applyLoaded(""));
+      notesFiles.load(notesFiles.quickNoteKey(activeTabId)).then(applyLoaded, (error: unknown) => {
+        // Leave the tab unloaded so nothing can save over content we failed to read.
+        if (!cancelled) setLoadError(error instanceof Error ? error.message : String(error));
+      });
       return () => {
         cancelled = true;
       };
@@ -264,7 +269,7 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
         return;
       }
       if (!editing) {
-        if (event.name === "n" || event.name === "t") {
+        if (event.name === "n") {
           addTab();
           return;
         }
@@ -272,7 +277,8 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
           if (activeTabId) void requestRemoveTab(activeTabId);
           return;
         }
-        if (event.name === "r") {
+        // Not `r`: that is the app-wide refresh key.
+        if (event.name === "t") {
           startRename();
           return;
         }
@@ -289,16 +295,18 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
     }, { allowEditable: true });
 
     usePaneFooter("quick-notes", () => ({
-      info: [
-        { id: "edited", parts: [{ text: editing || renaming ? "editing" : formatLastEdited(activeTab?.updatedAt), tone: "muted" }] },
-      ],
+      info: loadError
+        ? [{ id: "load-error", parts: [{ text: loadError, tone: "warning" as const }] }]
+        : [
+            { id: "edited", parts: [{ text: editing || renaming ? "editing" : formatLastEdited(activeTab?.updatedAt), tone: "muted" as const }] },
+          ],
       hints: editing || renaming
         ? []
         : [
             { id: "new", key: "n", label: "ew", onPress: addTab },
-            { id: "rename", key: "r", label: "ename", onPress: startRename, disabled: !activeTabId },
+            { id: "title", key: "t", label: "itle", onPress: startRename, disabled: !activeTabId },
           ],
-    }), [activeTab, activeTabId, addTab, editing, renaming, startRename]);
+    }), [activeTab, activeTabId, addTab, editing, loadError, renaming, startRename]);
 
     return (
       <Box flexDirection="column" flexGrow={1}>
@@ -338,8 +346,14 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
             />
           </Box>
         )}
-        <Box flexGrow={1} minHeight={0} paddingX={1} onMouseDown={() => { if (!editing && !renaming) setEditing(true); }}>
-          {editing && !renaming ? (
+        <Box flexGrow={1} minHeight={0} paddingX={1} onMouseDown={() => { if (!editing && !renaming && !loadError) setEditing(true); }}>
+          {loadError ? (
+            <EmptyState
+              title="This note could not be read."
+              message={loadError}
+              hint="Editing is disabled so the saved note is not overwritten. Fix the file, then reopen the pane."
+            />
+          ) : editing && !renaming ? (
             <MarkdownEditor
               textareaKey="editing"
               focused={focused}
@@ -353,7 +367,7 @@ export function createQuickNotesPane(notesFiles: NotesFiles) {
               text={noteText}
               width={width}
               placeholder="Write notes..."
-              onActivate={() => { if (!renaming) setEditing(true); }}
+              onActivate={() => { if (!renaming && !loadError) setEditing(true); }}
             />
           )}
         </Box>

--- a/src/plugins/builtin/notes/ticker-notes-tab.tsx
+++ b/src/plugins/builtin/notes/ticker-notes-tab.tsx
@@ -5,7 +5,7 @@ import type { TickerResearchTabProps } from "../../../types/plugin";
 import { usePaneTicker } from "../../../state/app/context";
 import { colors } from "../../../theme/colors";
 import { MarkdownEditor } from "../../../components/markdown-editor";
-import { usePaneFooter } from "../../../components";
+import { EmptyState, usePaneFooter } from "../../../components";
 import { usePluginAppActions } from "../../runtime";
 import type { NotesFiles } from "./files";
 import { MarkdownNotePreview } from "./markdown-note-preview";
@@ -17,6 +17,7 @@ export function createNotesTab(notesFiles: NotesFiles) {
     const { notify } = usePluginAppActions();
     const textareaRef = useRef<TextareaRenderable | null>(null);
     const [notesFocused, setNotesFocused] = useState(false);
+    const [loadError, setLoadError] = useState<string | null>(null);
     const { text: noteText, textRef: noteTextRef, setText: setNoteText } = useSyncedText("");
     const wasNotesFocusedRef = useRef(false);
     const notesFocusedRef = useRef(notesFocused);
@@ -86,6 +87,7 @@ export function createNotesTab(notesFiles: NotesFiles) {
     useEffect(() => {
       loadedSymbolRef.current = null;
       applyNoteText("");
+      setLoadError(null);
 
       if (notesFocusedRef.current) {
         setNotesFocusedAndCaptureRef.current(false);
@@ -100,7 +102,10 @@ export function createNotesTab(notesFiles: NotesFiles) {
         lastSavedTextRef.current.set(tickerSymbol, text);
         applyNoteText(text);
       };
-      notesFiles.load(tickerSymbol).then(applyLoaded, () => applyLoaded(""));
+      notesFiles.load(tickerSymbol).then(applyLoaded, (error: unknown) => {
+        // Leave the symbol unloaded so the unmount save below cannot overwrite it.
+        if (!cancelled) setLoadError(error instanceof Error ? error.message : String(error));
+      });
 
       return () => {
         cancelled = true;
@@ -111,7 +116,7 @@ export function createNotesTab(notesFiles: NotesFiles) {
     }, [tickerSymbol, applyNoteText, getCurrentNoteText, saveNotesFor, notesFiles]);
 
     useShortcut((event) => {
-      if (!focused) return;
+      if (!focused || loadError) return;
       const isEnter = event.name === "enter" || event.name === "return";
       if (isEnter && !notesFocused) {
         setNotesFocusedAndCapture(true);
@@ -124,17 +129,23 @@ export function createNotesTab(notesFiles: NotesFiles) {
     }, { allowEditable: true });
 
     usePaneFooter("ticker-notes", () => ({
-      info: [
-        { id: "mode", parts: [{ text: notesFocused ? "editing" : "viewing", tone: "muted" }] },
-      ],
-    }), [notesFocused]);
+      info: loadError
+        ? [{ id: "load-error", parts: [{ text: loadError, tone: "warning" as const }] }]
+        : [{ id: "mode", parts: [{ text: notesFocused ? "editing" : "viewing", tone: "muted" as const }] }],
+    }), [loadError, notesFocused]);
 
     if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view notes.</Text>;
 
     return (
       <Box flexDirection="column" flexGrow={1}>
-        <Box flexGrow={1} minHeight={0} paddingX={1} onMouseDown={() => { if (!notesFocused) setNotesFocusedAndCapture(true); }}>
-          {notesFocused ? (
+        <Box flexGrow={1} minHeight={0} paddingX={1} onMouseDown={() => { if (!notesFocused && !loadError) setNotesFocusedAndCapture(true); }}>
+          {loadError ? (
+            <EmptyState
+              title="These notes could not be read."
+              message={loadError}
+              hint="Editing is disabled so the saved note is not overwritten."
+            />
+          ) : notesFocused ? (
             <MarkdownEditor
               textareaKey="editing"
               focused={focused}
@@ -148,7 +159,7 @@ export function createNotesTab(notesFiles: NotesFiles) {
               text={noteText}
               width={width}
               placeholder="Write notes about this ticker..."
-              onActivate={() => setNotesFocusedAndCapture(true)}
+              onActivate={() => { if (!loadError) setNotesFocusedAndCapture(true); }}
             />
           )}
         </Box>

--- a/src/plugins/builtin/options/index.tsx
+++ b/src/plugins/builtin/options/index.tsx
@@ -1,3 +1,4 @@
+import type { PaneSettingsDef } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
 import { OptionsView } from "./view";
@@ -5,6 +6,26 @@ import {
   LIVE_STREAMING_QUICK_SETTING,
   withLiveStreamingSetting,
 } from "../shared/live-streaming";
+
+function optionsSettings(): PaneSettingsDef {
+  return {
+    title: "Options Settings",
+    fields: [
+      {
+        key: "chainRefreshMinutes",
+        label: "Chain refresh",
+        description: "How often the whole chain snapshot is refetched. Quotes for visible strikes stream separately.",
+        type: "select",
+        options: [
+          { value: "1", label: "Every minute" },
+          { value: "5", label: "Every 5 minutes" },
+          { value: "10", label: "Every 10 minutes" },
+          { value: "30", label: "Every 30 minutes" },
+        ],
+      },
+    ],
+  };
+}
 
 export const optionsModule: PluginModule = {
   panes: [
@@ -17,7 +38,7 @@ export const optionsModule: PluginModule = {
       defaultMode: "floating",
       defaultFloatingSize: { width: 112, height: 28 },
       quickSettings: [LIVE_STREAMING_QUICK_SETTING],
-      settings: (context) => withLiveStreamingSetting({ fields: [] }, context.settings),
+      settings: (context) => withLiveStreamingSetting(optionsSettings(), context.settings),
     },
   ],
 

--- a/src/plugins/builtin/options/live-quotes.ts
+++ b/src/plugins/builtin/options/live-quotes.ts
@@ -6,6 +6,14 @@ import type { OptionTableRow } from "./types";
 
 export const OPTIONS_QUOTE_EXCHANGE = "OPTIONS";
 export const OPTIONS_CHAIN_REFRESH_INTERVAL_MS = 10 * 60_000;
+
+/** Minutes come from the pane setting; anything unparseable keeps the default. */
+export function resolveChainRefreshIntervalMs(minutes: string | number | undefined): number {
+  const parsed = Number(minutes);
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed * 60_000
+    : OPTIONS_CHAIN_REFRESH_INTERVAL_MS;
+}
 export const OPTIONS_STREAM_FRESHNESS_MS = 2 * 60_000;
 export const OPTIONS_STREAM_CONNECTING_GRACE_MS = 15_000;
 

--- a/src/plugins/builtin/options/table.ts
+++ b/src/plugins/builtin/options/table.ts
@@ -62,7 +62,9 @@ export function formatStrikeLabel(strike: number): string {
 }
 
 export function formatIv(value: number | undefined): string {
-  if (value == null || !Number.isFinite(value)) return "—";
+  // Providers send 0 for contracts with no implied volatility; "0.0%" would read
+  // as a real quote of zero vol.
+  if (value == null || !Number.isFinite(value) || value <= 0) return "\u2014";
   return `${(value * 100).toFixed(1)}%`;
 }
 

--- a/src/plugins/builtin/options/view.tsx
+++ b/src/plugins/builtin/options/view.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text } from "../../../ui";
-import { usePaneTicker } from "../../../state/app/context";
+import { usePaneSettingValue, usePaneTicker } from "../../../state/app/context";
 import { colors } from "../../../theme/colors";
 import { isPlainKey } from "../../../utils/keyboard";
 import { formatExpDate, resolveOptionsTarget } from "../../../utils/options";
 import { useOptionsQuery, useResolvedEntryValue } from "../../../market-data/hooks";
 import {
   DataTableView,
+  EmptyState,
   Spinner,
   Tabs,
   type DataTableKeyEvent,
@@ -25,9 +26,9 @@ import {
 import type { OptionColumn, OptionTableRow, OptionsViewProps } from "./types";
 import {
   buildOptionQuoteTargets,
-  OPTIONS_CHAIN_REFRESH_INTERVAL_MS,
   overlayOptionRowQuotes,
   resolveOptionQuoteCoverage,
+  resolveChainRefreshIntervalMs,
 } from "./live-quotes";
 import { useOptionsAccessFooter } from "./footer";
 import { useLiveStreamingSetting } from "../shared/live-streaming";
@@ -63,6 +64,7 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
       },
     }
     : null;
+  const [chainRefreshMinutes] = usePaneSettingValue<string>("chainRefreshMinutes", "");
   const initialChainEntry = useOptionsQuery(baseRequest);
   const initialChain = useResolvedEntryValue(initialChainEntry);
   const selectedExpiration = initialChain?.expirationDates[expIdx];
@@ -71,10 +73,17 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     baseRequest && selectedExpiration != null
       ? { ...baseRequest, expirationDate: selectedExpiration }
       : null,
-    { refreshIntervalMs: OPTIONS_CHAIN_REFRESH_INTERVAL_MS },
+    { refreshIntervalMs: resolveChainRefreshIntervalMs(chainRefreshMinutes) },
   );
   const expirationChain = useResolvedEntryValue(expirationChainEntry);
+  // The expiration strip is expiry-independent, but strikes must never come from
+  // a different expiration than the selected one: the initial chain only covers
+  // whichever expiry the provider defaulted to.
   const chain = expirationChain ?? initialChain;
+  const initialChainExpiration = initialChain?.calls[0]?.expiration ?? initialChain?.puts[0]?.expiration ?? null;
+  const strikeChain = expirationChain
+    ?? (selectedExpiration == null || initialChainExpiration === selectedExpiration ? initialChain : null);
+  const strikesLoading = strikeChain === null;
   const expirationCount = chain?.expirationDates.length ?? 0;
   const loading = (initialChainEntry?.phase === "loading" || initialChainEntry?.phase === "refreshing") && !chain
     || (expirationChainEntry?.phase === "loading" || expirationChainEntry?.phase === "refreshing");
@@ -129,14 +138,14 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     userSelectedStrikeRef.current = false;
   }, [expIdx]);
 
-  const strikes = useMemo(() => chain ? buildStrikeList(chain) : [], [chain]);
+  const strikes = useMemo(() => strikeChain ? buildStrikeList(strikeChain) : [], [strikeChain]);
   const callsByStrike = useMemo(
-    () => new Map(chain?.calls.map((c) => [c.strike, c]) ?? []),
-    [chain],
+    () => new Map(strikeChain?.calls.map((c) => [c.strike, c]) ?? []),
+    [strikeChain],
   );
   const putsByStrike = useMemo(
-    () => new Map(chain?.puts.map((p) => [p.strike, p]) ?? []),
-    [chain],
+    () => new Map(strikeChain?.puts.map((p) => [p.strike, p]) ?? []),
+    [strikeChain],
   );
   const snapshotRows = useMemo<OptionTableRow[]>(() => strikes.map((strike) => ({
     strike,
@@ -301,15 +310,23 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     return false;
   }, [enterInteractive, exitInteractive, interactive, selectAdjacentExpiration, strikes.length]);
 
-  if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view options.</Text>;
+  if (!ticker) {
+    return <EmptyState title="No ticker selected." message="Select a ticker to view options." />;
+  }
   if (loading && !chain) return <Spinner label="Loading options chain..." />;
-  if (error) return <Text fg={colors.textDim}>{error}</Text>;
-  if (!chain || chain.expirationDates.length === 0) return <Text fg={colors.textDim}>No options available for {effectiveTicker}.</Text>;
+  if (error) return <EmptyState title="Options chain unavailable." message={error} />;
+  if (!chain || chain.expirationDates.length === 0) {
+    return <EmptyState title={`No options available for ${effectiveTicker}.`} />;
+  }
 
   const posShares = isOpt && parsed
     ? ticker.metadata.positions.reduce((sum, p) => sum + p.shares, 0)
     : 0;
-  const expirationTabsWidth = Math.max(width - 7 - (loading ? 2 : 0), 8);
+  const expirationTabsWidth = Math.max(width - 9 - (loading ? 2 : 0), 8);
+  const tableHeight = Math.max(1, height - 1 - (isOpt && parsed ? 1 : 0));
+  // The strip scrolls; without a marker a clipped last date reads as the last expiry.
+  const expirationStripOverflows = chain.expirationDates
+    .reduce((total, ts) => total + formatExpDate(ts).length + 2, 0) > expirationTabsWidth;
 
   return (
     <Box flexDirection="column" flexGrow={1} paddingX={1} onMouseDown={() => { if (!interactive) enterInteractive(); }}>
@@ -333,6 +350,7 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
             scrollId="options-expiration-tabs-scroll"
           />
         </Box>
+        {expirationStripOverflows && <Text fg={colors.textDim}>{"\u203a"}</Text>}
         {loading && <Spinner />}
       </Box>
 
@@ -375,10 +393,11 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
         onVisibleRangeChange={handleVisibleStrikeRangeChange}
         getItemKey={(row) => String(row.strike)}
         renderCell={renderOptionCell}
-        emptyStateTitle="No strikes available."
+        emptyStateTitle={strikesLoading ? "Loading strikes..." : "No strikes available."}
+        rootWidth={Math.max(1, width - 2)}
+        rootHeight={tableHeight}
         columnGap={0}
         horizontalPadding={0}
-        fillAvailableWidth={false}
         scrollToIndex={strikeIdx}
         scrollToIndexAlign={scrollToIndexAlign}
         scrollToIndexVersion={autoScrollVersion}

--- a/src/plugins/builtin/polls/hooks.ts
+++ b/src/plugins/builtin/polls/hooks.ts
@@ -1,35 +1,3 @@
-import { useEffect, useState } from "react";
-
-function formatApproximateAge(timestamp: number | null | undefined, now: number = Date.now()): string {
-  if (!timestamp || !Number.isFinite(timestamp)) return "~0m";
-  const seconds = Math.floor((now - timestamp) / 1000);
-  if (seconds < 60) return "~0m";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `~${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `~${hours}h`;
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `~${days}d`;
-  const weeks = Math.floor(days / 7);
-  return `~${weeks}w`;
-}
-
-/**
- * Returns a compact "~5m" age label for a timestamp that re-renders every
- * minute so the count increments without another fetch. Returns null when no
- * timestamp is provided.
- */
-export function useUpdatedAgo(timestamp: number | null | undefined): string | null {
-  const [, tick] = useState(0);
-  useEffect(() => {
-    if (!timestamp) return;
-    const interval = setInterval(() => tick((n) => n + 1), 60_000);
-    return () => clearInterval(interval);
-  }, [timestamp]);
-  if (!timestamp) return null;
-  return formatApproximateAge(timestamp);
-}
-
 interface StackSortPreference<C extends string> {
   columnId: C;
   direction: "asc" | "desc";

--- a/src/plugins/builtin/polls/normalize.test.ts
+++ b/src/plugins/builtin/polls/normalize.test.ts
@@ -69,13 +69,13 @@ describe("VoteHub normalize", () => {
       ],
     }));
     expect(row.pollTypeLabel).toBe("Generic");
-    expect(row.population).toBe("LV");
+    expect(row.population).toBe("Likely");
     expect(row.sampleSize).toBe(1500);
     expect(row.leadChoice).toBe("Rep");
     expect(row.lead).toBeCloseTo(4);
     expect(row.marginOfError).not.toBeNull();
     expect(parseSampleSize("800")).toBe(800);
-    expect(populationLabel("rv")).toBe("RV");
+    expect(populationLabel("rv")).toBe("Reg");
   });
 
   test("sorts poll rows by date, pollster, or lead", () => {

--- a/src/plugins/builtin/polls/normalize.ts
+++ b/src/plugins/builtin/polls/normalize.ts
@@ -20,10 +20,11 @@ const POLL_TYPE_LABELS: Record<string, string> = {
   "proposition-50": "Prop",
 };
 
+/** Readable sample populations; "A"/"RV"/"LV" meant nothing without a legend. */
 const POPULATION_LABELS: Record<string, string> = {
-  a: "A",
-  rv: "RV",
-  lv: "LV",
+  a: "Adults",
+  rv: "Reg",
+  lv: "Likely",
 };
 
 export function pollTypeLabel(pollType: string): string {
@@ -79,7 +80,7 @@ export function summarizeAnswers(answers: VoteHubPollAnswer[] | undefined): {
   if (!first) return { result: "—", lead: null, leadChoice: null };
   if (!second) {
     return {
-      result: `${first.choice} ${formatPct(first.pct)}`,
+      result: `${shortChoice(first.choice)} ${formatPct(first.pct)}`,
       lead: first.pct,
       leadChoice: first.choice,
     };

--- a/src/plugins/builtin/polls/pane.tsx
+++ b/src/plugins/builtin/polls/pane.tsx
@@ -6,7 +6,7 @@ import {
   DataTableStackView,
   EmptyState,
   InputSearchBar,
-  Spinner,
+  PaneStatusBody,
   Tabs,
   usePaneFooter,
   type DataTableCell,
@@ -23,7 +23,8 @@ import { isPlainKey } from "../../../utils/keyboard";
 import { openUrl } from "../../../components/ui/external-link";
 import type { PricePoint } from "../../../types/financials";
 import type { PaneProps } from "../../../types/plugin";
-import { useUpdatedAgo, nextStackSortPreference } from "./hooks";
+import { nextStackSortPreference } from "./hooks";
+import { useAutoRefresh, useUpdatedAgo } from "../shared/auto-refresh";
 import { fetchVoteHubPolls } from "./client";
 import {
   computeMovingAverage,
@@ -40,7 +41,7 @@ import {
 } from "./normalize";
 import type { PollDetailTab, PollRow, PollTabId } from "./types";
 
-type LoadStatus = "idle" | "loading" | "loaded" | "error";
+type LoadStatus = "loading" | "loaded" | "error";
 
 interface PollColumn extends DataTableColumn {
   id: "date" | "subject" | "pollster" | "pop" | "result";
@@ -79,15 +80,17 @@ function answerChoiceColor(choice: string): string | undefined {
 
 function createColumns(width: number): PollColumn[] {
   const dateWidth = 8;
-  const popWidth = 4;
-  const resultWidth = 22;
+  const popWidth = 7;
+  // Both answers and both percentages of a two-way result must fit; a clipped
+  // number is worse than a narrower subject column.
+  const resultWidth = 32;
   const pollsterWidth = 14;
   const subjectWidth = Math.max(12, width - dateWidth - popWidth - resultWidth - pollsterWidth - 8);
   return [
     { id: "date", label: "DATE", width: dateWidth, align: "left" },
     { id: "subject", label: "SUBJECT", width: subjectWidth, align: "left" },
     { id: "pollster", label: "POLLSTER", width: pollsterWidth, align: "left" },
-    { id: "pop", label: "POP", width: popWidth, align: "left" },
+    { id: "pop", label: "SAMPLE", width: popWidth, align: "left" },
     { id: "result", label: "RESULT", width: resultWidth, align: "left" },
   ];
 }
@@ -447,7 +450,9 @@ function PollDetail({
 export function PollsPane({ focused, width, height }: PaneProps) {
   const [tab, setTab] = useState<PollTabId>("approval");
   const [rowsByTab, setRowsByTab] = useState<Partial<Record<PollTabId, PollRow[]>>>({});
-  const [status, setStatus] = useState<LoadStatus>("idle");
+  // The mount effect loads immediately, so the first paint is a spinner rather
+  // than a premature "No polls in this category".
+  const [status, setStatus] = useState<LoadStatus>("loading");
   const [error, setError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
@@ -498,6 +503,11 @@ export function PollsPane({ focused, width, height }: PaneProps) {
   useEffect(() => {
     load(tab);
   }, [load, tab]);
+
+  const refreshActiveTab = useCallback(() => {
+    load(tab);
+  }, [load, tab]);
+  useAutoRefresh(status === "loaded" ? lastUpdated : null, refreshActiveTab);
 
   useEffect(() => {
     if (rows.length === 0) {
@@ -602,7 +612,6 @@ export function PollsPane({ focused, width, height }: PaneProps) {
     info: [
       ...(status === "loading" ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(error ? [{ id: "error", parts: [{ text: "error", tone: "warning" as const }] }] : []),
-      ...(searchQuery.trim() ? [{ id: "search", parts: [{ text: `search: ${searchQuery.trim()}`, tone: "value" as const }] }] : []),
       ...(updatedAgo ? [{ id: "updated", parts: [{ text: `updated ${updatedAgo}`, tone: "muted" as const }] }] : []),
     ],
     hints: detailOpen
@@ -611,7 +620,7 @@ export function PollsPane({ focused, width, height }: PaneProps) {
           { id: "search", key: "/", label: "search", onPress: focusSearch },
           { id: "open", key: "o", label: "pen", onPress: openSelected, disabled: !selected?.url },
         ],
-  }), [error, detailOpen, focusSearch, openSelected, selected?.url, status, searchQuery, updatedAgo]);
+  }), [error, detailOpen, focusSearch, openSelected, selected?.url, status, updatedAgo]);
 
   const tabs = (
     <Box height={1} flexShrink={0} overflow="hidden">
@@ -647,24 +656,11 @@ export function PollsPane({ focused, width, height }: PaneProps) {
     />
   );
 
-  if (status === "loading" && allRows.length === 0) {
+  if (allRows.length === 0 && (status === "loading" || error)) {
     return (
       <Box flexDirection="column" width={width} height={height}>
         {tabs}
-        <Box flexGrow={1} justifyContent="center" alignItems="center">
-          <Spinner label="Loading polls..." />
-        </Box>
-      </Box>
-    );
-  }
-
-  if (error && allRows.length === 0) {
-    return (
-      <Box flexDirection="column" width={width} height={height}>
-        {tabs}
-        <Box padding={1}>
-          <EmptyState title="Polls unavailable." message={error} />
-        </Box>
+        <PaneStatusBody loading={status === "loading"} error={error} subject="Polls" />
       </Box>
     );
   }

--- a/src/plugins/builtin/portfolio-list/header.tsx
+++ b/src/plugins/builtin/portfolio-list/header.tsx
@@ -27,10 +27,16 @@ export function shouldToggleCashMarginDrawer(key: string | undefined, showCashDr
   return key === "c" && showCashDrawer;
 }
 
+export interface PortfolioAccountStateResult {
+  accountState: ResolvedPortfolioAccountState | null;
+  /** Set when the broker refused to list accounts, so "no cash" is not mistaken for a clean empty. */
+  accountsError: string | null;
+}
+
 export function usePortfolioAccountState(
   portfolio: Portfolio | null,
   state: Pick<AppState, "config" | "brokerAccounts">,
-): ResolvedPortfolioAccountState | null {
+): PortfolioAccountStateResult {
   const instanceId = portfolio?.brokerInstanceId;
   const brokerInstance = useMemo(
     () => instanceId ? getBrokerInstance(state.config.brokerInstances, instanceId) : null,
@@ -48,16 +54,20 @@ export function usePortfolioAccountState(
     });
   }, [broker, brokerInstance]);
   const [liveAccounts, setLiveAccounts] = useState<BrokerAccount[]>([]);
+  const [accountsError, setAccountsError] = useState<string | null>(null);
   useEffect(() => {
     let cancelled = false;
     setLiveAccounts([]);
+    setAccountsError(null);
     if (!brokerInstance || !broker?.listAccounts || liveStatus?.state !== "connected") return;
     broker.listAccounts(brokerInstance)
       .then((accounts) => {
         if (!cancelled) setLiveAccounts(accounts);
       })
-      .catch(() => {
-        if (!cancelled) setLiveAccounts([]);
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setLiveAccounts([]);
+        setAccountsError(error instanceof Error ? error.message : String(error));
       });
     return () => {
       cancelled = true;
@@ -67,10 +77,11 @@ export function usePortfolioAccountState(
     () => ({ status: liveStatus, accounts: liveAccounts }),
     [liveAccounts, liveStatus],
   );
-  return useMemo(
+  const accountState = useMemo(
     () => resolvePortfolioAccountState(portfolio, state, snapshot),
     [portfolio, snapshot, state.brokerAccounts, state.config],
   );
+  return useMemo(() => ({ accountState, accountsError }), [accountState, accountsError]);
 }
 
 export function PortfolioCashMarginDrawer({

--- a/src/plugins/builtin/portfolio-list/pane/index.tsx
+++ b/src/plugins/builtin/portfolio-list/pane/index.tsx
@@ -125,7 +125,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
   const flashSymbols = useQuoteFlashMap(financialsMap, valueFlashingEnabled);
 
   const accountStateInput = useMemo(() => ({ brokerAccounts, config }), [brokerAccounts, config]);
-  const accountState = usePortfolioAccountState(currentPortfolio, accountStateInput);
+  const { accountState, accountsError } = usePortfolioAccountState(currentPortfolio, accountStateInput);
   const columns = useMemo(
     () => resolveVisibleColumns(paneSettings.columnIds, isPortfolioTab),
     [isPortfolioTab, paneSettings.columnIds],
@@ -307,7 +307,8 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
 
   useEffect(() => {
     if (!appActive) return;
-    const timerId = setInterval(() => setNow(Date.now()), 1000);
+    // Only ages relative labels (quote age, days held), so the shared 30s cadence is enough.
+    const timerId = setInterval(() => setNow(Date.now()), 30_000);
     return () => clearInterval(timerId);
   }, [appActive]);
 
@@ -347,7 +348,9 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
 
   const summaryFooterInfo = useMemo(() => buildPortfolioFooterSegments({
     accountState: accountState ? { account: accountState.account, sourceLabel: accountState.sourceLabel } : null,
-    accountStatusText: isPortfolioTab && currentPortfolio?.brokerInstanceId && !accountState ? "Acct missing" : undefined,
+    accountStatusText: accountsError
+      ? `Accounts unavailable: ${accountsError}`
+      : isPortfolioTab && currentPortfolio?.brokerInstanceId && !accountState ? "Acct missing" : undefined,
     activeCollectionId,
     baseCurrency: config.baseCurrency,
     exchangeRates: effectiveExchangeRates,
@@ -359,6 +362,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     width,
   }), [
     accountState,
+    accountsError,
     activeCollectionId,
     currentPortfolio?.brokerInstanceId,
     effectiveExchangeRates,

--- a/src/plugins/builtin/portfolio-list/pane/supplemental.ts
+++ b/src/plugins/builtin/portfolio-list/pane/supplemental.ts
@@ -231,7 +231,7 @@ function useEarningsSupplemental(
     inFlightRef.current = true;
     let cancelled = false;
     loadEarningsCalendar(provider, missingSymbols)
-      .then((events) => {
+      .then(({ events }) => {
         if (cancelled) return;
         setState((current) => setEarningsValues(current, missingSymbols, events));
       })

--- a/src/plugins/builtin/portfolio-list/summary/index.tsx
+++ b/src/plugins/builtin/portfolio-list/summary/index.tsx
@@ -346,7 +346,8 @@ export function buildPortfolioFooterSegments({
     ];
   }
 
-  if (!totals.hasPositions && !accountState) return [];
+  // An account error must still reach the footer, otherwise a failed load looks like an empty portfolio.
+  if (!totals.hasPositions && !accountState && !accountStatusText) return [];
   return buildPortfolioSummarySegments({
     totals,
     accountState,

--- a/src/plugins/builtin/research/analyst-pane.tsx
+++ b/src/plugins/builtin/research/analyst-pane.tsx
@@ -6,7 +6,6 @@ import {
   type DataTableCell,
   type DataTableColumn,
   type DataTableKeyEvent,
-  type PaneFooterSegment,
 } from "../../../components";
 import type { AnalystRatingRecord, AnalystResearchData } from "../../../types/financials";
 import { blendHex, colors, priceColor } from "../../../theme/colors";
@@ -90,22 +89,45 @@ function ratingTargetBackground(delta: number | null): string | undefined {
   return blendHex(colors.bg, delta > 0 ? colors.positive : colors.negative, 0.42);
 }
 
+/**
+ * Price targets and the recommendation mix are pane content, not status, so the
+ * summary block owns them and the footer stays empty unless something changed.
+ */
+export function buildAnalystSummaryLines(data: AnalystResearchData | null): string[] {
+  if (!data) return [];
+
+  const target = data.priceTarget;
+  const currency = target?.currency ?? data.currency ?? "USD";
+  const price = (value: number | undefined) => value != null ? formatCurrency(value, currency) : "-";
+  const rec = latestRecommendation(data);
+  const total = recommendationTotal(data);
+  const lines: string[] = [];
+
+  if (target) {
+    lines.push(`low ${price(target.low)}   med ${price(target.median)}   high ${price(target.high)}`);
+  }
+  if (data.recommendationRating != null || rec || total > 0) {
+    lines.push([
+      data.recommendationRating != null ? `rating ${formatRatingLabel(data.recommendationRating)}` : null,
+      rec ? `SB ${rec.strongBuy ?? 0}  B ${rec.buy ?? 0}  H ${rec.hold ?? 0}  S ${(rec.sell ?? 0) + (rec.strongSell ?? 0)}` : null,
+      total > 0 ? `${total} analysts${rec?.period ? ` (${compactPeriod(rec.period)})` : ""}` : null,
+    ].filter(Boolean).join("   "));
+  }
+
+  return lines;
+}
+
 function AnalystSummary({ data }: { data: AnalystResearchData | null }) {
   const target = data?.priceTarget;
   const upside = targetUpside(target);
   const currency = target?.currency ?? data?.currency ?? "USD";
+  const lines = buildAnalystSummaryLines(data);
 
-  if (!data) {
-    return (
-      <Box flexDirection="column" paddingX={1} height={2}>
-        <Text fg={colors.textDim}>Analyst data</Text>
-        <Text fg={colors.textDim}>Waiting for asset data.</Text>
-      </Box>
-    );
-  }
+  // The table body already reports loading, error, and empty states.
+  if (!data) return null;
 
   return (
-    <Box flexDirection="column" paddingX={1} height={1}>
+    <Box flexDirection="column" paddingX={1} height={1 + lines.length}>
       <Box height={1} flexDirection="row">
         <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
           {target?.average != null ? formatCurrency(target.average, currency) : "-"}
@@ -116,58 +138,13 @@ function AnalystSummary({ data }: { data: AnalystResearchData | null }) {
         </Text>
         <Text fg={colors.textDim}> upside</Text>
       </Box>
+      {lines.map((line) => (
+        <Box key={line} height={1}>
+          <Text fg={colors.textDim}>{line}</Text>
+        </Box>
+      ))}
     </Box>
   );
-}
-
-export function buildAnalystFooterInfo(data: AnalystResearchData | null): PaneFooterSegment[] {
-  if (!data) return [];
-
-  const target = data.priceTarget;
-  const currency = target?.currency ?? data.currency ?? "USD";
-  const rec = latestRecommendation(data);
-  const total = recommendationTotal(data);
-  const info: PaneFooterSegment[] = [];
-
-  if (target) {
-    info.push({
-      id: "target-range",
-      parts: [
-        { text: "low", tone: "label" },
-        { text: target.low != null ? formatCurrency(target.low, currency) : "-", tone: "muted" },
-        { text: "med", tone: "label" },
-        { text: target.median != null ? formatCurrency(target.median, currency) : "-", tone: "muted" },
-        { text: "high", tone: "label" },
-        { text: target.high != null ? formatCurrency(target.high, currency) : "-", tone: "value" },
-      ],
-    });
-  }
-
-  if (data.recommendationRating != null) {
-    info.push({
-      id: "rating",
-      parts: [
-        { text: "rating", tone: "label" },
-        { text: formatRatingLabel(data.recommendationRating), tone: "value", bold: true },
-      ],
-    });
-  }
-
-  if (rec || total > 0) {
-    info.push({
-      id: "recommendations",
-      parts: [
-        { text: compactPeriod(rec?.period ?? ""), tone: "muted" },
-        { text: `SB ${rec?.strongBuy ?? 0}`, tone: "positive" },
-        { text: `B ${rec?.buy ?? 0}`, tone: "value" },
-        { text: `H ${rec?.hold ?? 0}`, tone: "muted" },
-        { text: `S ${(rec?.sell ?? 0) + (rec?.strongSell ?? 0)}`, tone: "negative" },
-        { text: `n=${total}`, tone: "muted" },
-      ],
-    });
-  }
-
-  return info;
 }
 
 type RatingColumnId = "date" | "firm" | "action" | "current" | "target" | "prior";
@@ -354,11 +331,8 @@ export function AnalystResearchView({ focused, width, height }: { focused: boole
   }, []);
 
   usePaneFooter("analyst-research", () => ({
-    info: [
-      ...buildAnalystFooterInfo(data),
-      ...loadingErrorFooterInfo(loading, error),
-    ],
-  }), [data, error, loading]);
+    info: loadingErrorFooterInfo(loading, error),
+  }), [error, loading]);
 
   return (
     <DataTableView<AnalystResearchData["ratings"][number], RatingColumn>

--- a/src/plugins/builtin/research/corporate-actions-pane.tsx
+++ b/src/plugins/builtin/research/corporate-actions-pane.tsx
@@ -21,6 +21,7 @@ import { isPlainKey } from "../../../utils/keyboard";
 import { wrapTextLines } from "../../../utils/text-wrap";
 import { useResolvedEntryValue, useSecFilingDocuments, useSecFilingsQuery } from "../../../market-data/hooks";
 import { instrumentFromTicker } from "../../../market-data/request-types";
+import { usePaneTicker } from "../../../state/app/context";
 import { isUsEquityTicker } from "../../../utils/sec";
 import { useAssetData } from "../../runtime";
 import { handleRefreshKey, loadingErrorFooterInfo } from "../shared/table-pane";
@@ -474,19 +475,26 @@ function buildEventDetailBody({
   return lines.join("\n");
 }
 
+/** Statuses the Earnings Estimates surface keeps; the rest are corporate actions. */
+const EARNINGS_STATUSES = new Set<EventStatus>(["Q Est", "FY Est", "Earnings", "TTM"]);
+
 export function CorporateActionsView({
   focused,
   width,
   height,
   footerPaneId = "corporate-actions",
+  variant = "corporate-actions",
 }: {
   focused: boolean;
   width: number;
   height: number;
   footerPaneId?: string;
+  variant?: "corporate-actions" | "earnings-estimates";
 }) {
   const dataProvider = useAssetData();
   const { symbol, ticker, exchange, currency } = useSymbolBinding();
+  // The shared ticker snapshot already subscribes to financials for this pane.
+  const { financials: financialsData } = usePaneTicker();
   const actionsLoader = useCallback((nextSymbol: string, nextExchange: string, forceRefresh: boolean) => {
     if (!dataProvider?.getCorporateActions) throw new Error("Corporate actions source unavailable");
     return dataProvider.getCorporateActions(nextSymbol, nextExchange, forceRefresh ? { cacheMode: "refresh" } : undefined);
@@ -494,10 +502,6 @@ export function CorporateActionsView({
   const analystLoader = useCallback(async (nextSymbol: string, nextExchange: string, forceRefresh: boolean) => {
     if (!dataProvider?.getAnalystResearch) return null;
     return dataProvider.getAnalystResearch(nextSymbol, nextExchange, forceRefresh ? { cacheMode: "refresh" } : undefined);
-  }, [dataProvider]);
-  const financialsLoader = useCallback(async (nextSymbol: string, nextExchange: string, forceRefresh: boolean) => {
-    if (!dataProvider) return null;
-    return dataProvider.getTickerFinancials(nextSymbol, nextExchange, forceRefresh ? { cacheMode: "refresh" } : undefined);
   }, [dataProvider]);
   const {
     data: actionsData,
@@ -511,29 +515,30 @@ export function CorporateActionsView({
     error: analystError,
     reload: reloadAnalyst,
   } = useTickerRequest<AnalystResearchData | null>(analystLoader, symbol, exchange);
-  const {
-    data: financialsData,
-    loading: financialsLoading,
-    error: financialsError,
-    reload: reloadFinancials,
-  } = useTickerRequest<TickerFinancials | null>(financialsLoader, symbol, exchange);
   const displayCurrency = actionsData?.currency ?? analystData?.currency ?? currency;
-  const rows = useMemo(() => (
+  const allRows = useMemo(() => (
     buildEventRows(actionsData, analystData, financialsData, displayCurrency)
   ), [actionsData, analystData, displayCurrency, financialsData]);
+  const rows = useMemo(() => (
+    variant === "earnings-estimates"
+      ? allRows.filter((row) => EARNINGS_STATUSES.has(row.status))
+      : allRows
+  ), [allRows, variant]);
   const columns = useMemo(() => buildEventColumns(), []);
   const [selectedIdx, setSelectedIdx] = useState(0);
   const [openRowId, setOpenRowId] = useState<string | null>(null);
   const detailScrollRef = useRef<ScrollBoxRenderable>(null);
   const todayKey = todayDateKey();
   const futureRowBackground = blendHex(colors.bg, colors.positive, 0.16);
-  const loading = actionsLoading || analystLoading || financialsLoading;
-  const error = [actionsError, analystError, financialsError].filter(Boolean).join(" | ") || null;
+  const loading = actionsLoading || analystLoading;
+  // Parallel requests fail with the same message ("No ticker selected"), so the
+  // footer must report each distinct reason once.
+  const error = [...new Set([actionsError, analystError].filter((value): value is string => !!value))]
+    .join(" | ") || null;
   const reload = useCallback(() => {
     reloadActions();
     reloadAnalyst();
-    reloadFinancials();
-  }, [reloadActions, reloadAnalyst, reloadFinancials]);
+  }, [reloadActions, reloadAnalyst]);
   const openRow = openRowId
     ? rows.find((row) => row.id === openRowId) ?? null
     : null;
@@ -729,7 +734,9 @@ export function CorporateActionsView({
       getRowBackgroundColor={(row) => (
         row.date > todayKey ? futureRowBackground : undefined
       )}
-      emptyStateTitle={loading ? "Loading events..." : error ?? "No events"}
+      emptyStateTitle={loading
+        ? (variant === "earnings-estimates" ? "Loading earnings estimates..." : "Loading events...")
+        : error ?? (variant === "earnings-estimates" ? "No earnings estimates" : "No events")}
     />
   );
 }

--- a/src/plugins/builtin/research/index.test.ts
+++ b/src/plugins/builtin/research/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { AnalystRatingRecord, AnalystResearchData } from "../../../types/financials";
 import {
-  buildAnalystFooterInfo,
+  buildAnalystSummaryLines,
   buildRatingColumns,
   formatRatingTarget,
   nextRatingSortPreference,
@@ -145,9 +145,9 @@ describe("analyst rating columns", () => {
   });
 });
 
-describe("analyst footer summary", () => {
-  test("moves target range and recommendation mix into footer segments", () => {
-    const footerInfo = buildAnalystFooterInfo({
+describe("analyst summary", () => {
+  test("keeps target range and recommendation mix in the body summary", () => {
+    const lines = buildAnalystSummaryLines({
       providerId: "test",
       symbol: "AMD",
       currency: "USD",
@@ -173,27 +173,8 @@ describe("analyst footer summary", () => {
       revenueEstimates: [],
     } satisfies AnalystResearchData);
 
-    expect(footerInfo.map((segment) => segment.id)).toEqual([
-      "target-range",
-      "rating",
-      "recommendations",
-    ]);
-    expect(footerInfo[0]?.parts.map((part) => part.text)).toEqual([
-      "low",
-      "$225.00",
-      "med",
-      "$482.50",
-      "high",
-      "$625.00",
-    ]);
-    expect(footerInfo[2]?.parts.map((part) => part.text)).toEqual([
-      "month",
-      "SB 12",
-      "B 18",
-      "H 4",
-      "S 1",
-      "n=35",
-    ]);
+    expect(lines[0]).toBe("low $225.00   med $482.50   high $625.00");
+    expect(lines[1]).toBe("rating 8.8/10   SB 12  B 18  H 4  S 1   35 analysts (month)");
   });
 });
 

--- a/src/plugins/builtin/research/index.tsx
+++ b/src/plugins/builtin/research/index.tsx
@@ -5,8 +5,14 @@ import { AnalystResearchView } from "./analyst-pane";
 import { CorporateActionsView } from "./corporate-actions-pane";
 import { RelativeValuationPane } from "./relative-valuation-pane";
 
-function EarningsEstimatesAliasPane(props: { focused: boolean; width: number; height: number }) {
-  return <CorporateActionsView {...props} footerPaneId="earnings-estimates" />;
+function EarningsEstimatesPane(props: { focused: boolean; width: number; height: number }) {
+  return (
+    <CorporateActionsView
+      {...props}
+      footerPaneId="earnings-estimates"
+      variant="earnings-estimates"
+    />
+  );
 }
 
 export const researchModule: PluginModule = {
@@ -59,7 +65,7 @@ export const researchModule: PluginModule = {
       id: "earnings-estimates",
       name: "Earnings Estimates",
       icon: "E",
-      component: EarningsEstimatesAliasPane,
+      component: EarningsEstimatesPane,
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 104, height: 22 },
@@ -85,9 +91,9 @@ export const researchModule: PluginModule = {
     }),
     createTickerSurfacePaneTemplate({
       id: "earnings-estimates-pane",
-      paneId: "corporate-actions",
+      paneId: "earnings-estimates",
       label: "Earnings Estimates",
-      description: "Open the Events view with EPS and revenue estimates.",
+      description: "EPS and revenue estimates with reported earnings.",
       keywords: ["earnings", "estimates", "ee", "analyst", "eps", "revenue", "events"],
       shortcut: "EE",
     }),

--- a/src/plugins/builtin/research/relative-valuation-pane.tsx
+++ b/src/plugins/builtin/research/relative-valuation-pane.tsx
@@ -10,9 +10,11 @@ import {
 import type { TickerFinancials } from "../../../types/financials";
 import type { PaneProps } from "../../../types/plugin";
 import { usePaneInstance } from "../../../state/app/context";
-import { blendHex, colors, priceColor } from "../../../theme/colors";
+import { getSharedMarketDataCoordinator } from "../../../market-data/coordinator";
+import { colors, priceColor } from "../../../theme/colors";
+import { compareSortValues, type SortDirection } from "../../../utils/sort-values";
 import { formatCompact, formatCurrency, formatNumber, formatPercent, formatPercentRaw } from "../../../utils/format";
-import { useAssetData, usePluginTickerActions } from "../../runtime";
+import { usePluginTickerActions } from "../../runtime";
 import { handleRefreshKey, loadingErrorFooterInfo, useClampSelectedIndex } from "../shared/table-pane";
 import { useBoundTicker as useSymbolBinding } from "../shared/ticker-request";
 
@@ -52,6 +54,13 @@ function buildRelativeColumns(width: number): RelativeColumn[] {
   ];
 }
 
+interface RelativeSortPreference {
+  columnId: RelativeColumnId;
+  direction: SortDirection;
+}
+
+const DEFAULT_RELATIVE_SORT: RelativeSortPreference = { columnId: "marketCap", direction: "desc" };
+
 function evSales(financials: TickerFinancials | null): number | undefined {
   const ev = financials?.fundamentals?.enterpriseValue;
   const revenue = financials?.fundamentals?.revenue;
@@ -64,6 +73,49 @@ function fcfYield(financials: TickerFinancials | null): number | undefined {
   return fcf != null && marketCap ? fcf / marketCap : undefined;
 }
 
+function relativeSortValue(row: RelativeRow, columnId: RelativeColumnId): string | number | null {
+  const quote = row.financials?.quote;
+  const fundamentals = row.financials?.fundamentals;
+  switch (columnId) {
+    case "symbol":
+      return row.symbol.toLocaleLowerCase();
+    case "price":
+      return quote?.price ?? null;
+    case "change":
+      return quote?.changePercent ?? null;
+    case "marketCap":
+      return quote?.marketCap ?? null;
+    case "pe":
+      return fundamentals?.trailingPE ?? null;
+    case "forwardPe":
+      return fundamentals?.forwardPE ?? null;
+    case "evSales":
+      return evSales(row.financials) ?? null;
+    case "fcfYield":
+      return fcfYield(row.financials) ?? null;
+    case "revenueGrowth":
+      return fundamentals?.revenueGrowth ?? fundamentals?.lastQuarterGrowth ?? null;
+    case "margin":
+      return fundamentals?.operatingMargin ?? null;
+  }
+}
+
+function sortRelativeRows(
+  rows: readonly RelativeRow[],
+  preference: RelativeSortPreference,
+): RelativeRow[] {
+  return rows
+    .map((row, index) => ({ row, index }))
+    .sort((left, right) => (
+      compareSortValues(
+        relativeSortValue(left.row, preference.columnId),
+        relativeSortValue(right.row, preference.columnId),
+        preference.direction,
+      ) || left.index - right.index
+    ))
+    .map((entry) => entry.row);
+}
+
 export function RelativeValuationPane({ focused, width, height }: PaneProps) {
   const pane = usePaneInstance();
   const { symbol } = useSymbolBinding();
@@ -71,12 +123,12 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
     () => relativeSymbolsFromPane(symbol, pane?.settings),
     [pane?.settings, symbol],
   );
-  const dataProvider = useAssetData();
   const { navigateTicker } = usePluginTickerActions();
   const [rows, setRows] = useState<RelativeRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedIdx, setSelectedIdx] = useState(0);
+  const [sortPreference, setSortPreference] = useState<RelativeSortPreference>(DEFAULT_RELATIVE_SORT);
   const columns = useMemo(() => buildRelativeColumns(width), [width]);
   const fetchGenRef = useRef(0);
 
@@ -86,7 +138,8 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
       setError("No tickers selected");
       return;
     }
-    if (!dataProvider) {
+    const coordinator = getSharedMarketDataCoordinator();
+    if (!coordinator) {
       setRows([]);
       setError("Market data unavailable");
       return;
@@ -95,17 +148,18 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
     const gen = fetchGenRef.current;
     setLoading(true);
     setError(null);
-    Promise.all(symbols.map(async (nextSymbol): Promise<RelativeRow> => {
-      try {
-        const financials = await dataProvider.getTickerFinancials(nextSymbol, "", forceRefresh ? { cacheMode: "refresh" } : undefined);
-        return { symbol: nextSymbol, financials };
-      } catch (err) {
-        return { symbol: nextSymbol, financials: null, error: err instanceof Error ? err.message : String(err) };
-      }
-    }))
-      .then((nextRows) => {
+    // One batched snapshot request instead of one request per peer.
+    coordinator.loadSnapshotsBatch(symbols.map((peer) => ({ symbol: peer })), { forceRefresh })
+      .then((entries) => {
         if (fetchGenRef.current !== gen) return;
-        setRows(nextRows);
+        setRows(symbols.map((peer, index) => {
+          const entry = entries[index];
+          return {
+            symbol: peer,
+            financials: entry?.data ?? entry?.lastGoodData ?? null,
+            error: entry?.error?.message,
+          };
+        }));
       })
       .catch((err) => {
         if (fetchGenRef.current !== gen) return;
@@ -114,11 +168,13 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
       .finally(() => {
         if (fetchGenRef.current === gen) setLoading(false);
       });
-  }, [dataProvider, symbols]);
+  }, [symbols]);
 
   useEffect(() => {
     reload(false);
   }, [reload]);
+
+  const sortedRows = useMemo(() => sortRelativeRows(rows, sortPreference), [rows, sortPreference]);
 
   useClampSelectedIndex(rows.length, selectedIdx, setSelectedIdx);
 
@@ -154,12 +210,17 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
     return handleRefreshKey(event, () => reload(true), { stopPropagation: true });
   }, [reload]);
 
+  const handleHeaderClick = useCallback((columnId: string) => {
+    setSortPreference((current) => (
+      current.columnId === columnId
+        ? { columnId: current.columnId, direction: current.direction === "asc" ? "desc" : "asc" }
+        : { columnId: columnId as RelativeColumnId, direction: columnId === "symbol" ? "asc" : "desc" }
+    ));
+  }, []);
+
   usePaneFooter("relative-valuation", () => ({
-    info: [
-      { id: "tickers", parts: [{ text: `${symbols.length} tickers`, tone: symbols.length > 0 ? "value" as const : "muted" as const }] },
-      ...loadingErrorFooterInfo(loading, error),
-    ],
-  }), [error, loading, symbols.length]);
+    info: loadingErrorFooterInfo(loading, error),
+  }), [error, loading]);
 
   return (
     <DataTableView<RelativeRow, RelativeColumn>
@@ -174,10 +235,10 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
       rootWidth={width}
       rootHeight={height}
       columns={columns}
-      items={rows}
-      sortColumnId={null}
-      sortDirection="asc"
-      onHeaderClick={() => {}}
+      items={sortedRows}
+      sortColumnId={sortPreference.columnId}
+      sortDirection={sortPreference.direction}
+      onHeaderClick={handleHeaderClick}
       getItemKey={(row) => row.symbol}
       renderCell={renderCell}
       emptyStateTitle={loading ? "Loading peers..." : error ?? "No peers"}

--- a/src/plugins/builtin/scanner/flow-model.ts
+++ b/src/plugins/builtin/scanner/flow-model.ts
@@ -25,6 +25,44 @@ export const DEFAULT_FLOW_FILTERS: FlowFilters = {
   universe: "active",
 };
 
+/**
+ * One source for the in-pane filter chips and the settings dialog. `label` is the
+ * dialog wording, `short` the chip wording.
+ */
+export const FLOW_FILTER_OPTIONS = {
+  minPremium: [
+    { value: "50000", label: "$50K", short: "50K" },
+    { value: "250000", label: "$250K", short: "250K" },
+    { value: "1000000", label: "$1M", short: "1M" },
+  ],
+  side: [
+    { value: "both", label: "Calls and puts", short: "C+P" },
+    { value: "calls", label: "Calls only", short: "C" },
+    { value: "puts", label: "Puts only", short: "P" },
+  ],
+  kind: [
+    { value: "all", label: "All prints", short: "all" },
+    { value: "sweeps", label: "Sweeps only", short: "swp" },
+    { value: "blocks", label: "Blocks only", short: "blk" },
+  ],
+  volOi: [
+    { value: "off", label: "No floor", short: "any" },
+    { value: "1", label: "1x and up", short: "1x" },
+    { value: "5", label: "5x and up", short: "5x" },
+  ],
+  expiry: [
+    { value: "all", label: "Any expiry", short: "any" },
+    { value: "7", label: "7 days or less", short: "7d" },
+    { value: "30", label: "30 days or less", short: "30d" },
+  ],
+  universe: [
+    { value: "active", label: "Active names", short: "active" },
+    { value: "watchlist", label: "My tickers only", short: "mine" },
+  ],
+} as const satisfies {
+  [K in keyof FlowFilters]: readonly { value: FlowFilters[K]; label: string; short: string }[]
+};
+
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 function expiryDaysFromNow(expiry: string, now: number): number | null {

--- a/src/plugins/builtin/scanner/flow-pane.tsx
+++ b/src/plugins/builtin/scanner/flow-pane.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useMemo, useState } from "react";
-import { TextAttributes } from "../../../ui";
+import { Box, TextAttributes } from "../../../ui";
 import {
+  Button,
   DataTableView,
   type DataTableCell,
   type DataTableColumn,
 } from "../../../components";
+import { ScannerWaitingState } from "./waiting";
 import { useAppSelector, usePaneSettingValue } from "../../../state/app/context";
 import { colors } from "../../../theme/colors";
 import { formatCompact, formatNumber } from "../../../utils/format";
@@ -16,6 +18,7 @@ import { ScannerDeniedState } from "./denied";
 import { useFlowFeed, useScannerStatusFooter } from "./feed";
 import {
   DEFAULT_FLOW_FILTERS,
+  FLOW_FILTER_OPTIONS,
   filterFlowEvents,
   formatFlowExpiry,
   formatFlowPremium,
@@ -32,8 +35,35 @@ import {
   type FlowVolOi,
 } from "./flow-model";
 
+/** Cycles a select-style pane setting, so every filter is reachable without the settings dialog. */
+function FilterChip<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: T;
+  options: readonly { value: T; label: string; short: string }[];
+  onChange: (value: T) => void;
+}) {
+  const current = options.find((option) => option.value === value) ?? options[0]!;
+  return (
+    <Button
+      label={`${label} ${current.short}`}
+      variant="ghost"
+      onPress={() => {
+        const index = options.findIndex((option) => option.value === value);
+        onChange(options[(index + 1 + options.length) % options.length]!.value);
+      }}
+    />
+  );
+}
+
 function buildColumns(width: number): DataTableColumn[] {
-  const fixed = { time: 8, ticker: 7, type: 8, strike: 8, exp: 6, side: 5, size: 7, prem: 7, volOi: 6 };
+  // EXP is right aligned and SIDE is left aligned, so EXP needs an extra cell or
+  // the two header labels read as one "EXP SIDE" word.
+  const fixed = { time: 8, ticker: 7, type: 8, strike: 8, exp: 7, side: 5, size: 7, prem: 7, volOi: 6 };
   const total = Object.values(fixed).reduce((sum, value) => sum + value, 0);
   // Table chrome is one gap per column, two cells of padding, and the scrollbar.
   const slack = Math.max(0, width - total - 9 - 2 - 1);
@@ -93,12 +123,12 @@ function FlowPane({ focused, width, height }: PaneProps) {
   const { pinTicker } = usePluginTickerActions();
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  const [minPremium] = usePaneSettingValue<FlowMinPremium>("minPremium", DEFAULT_FLOW_FILTERS.minPremium);
-  const [side] = usePaneSettingValue<FlowSide>("side", DEFAULT_FLOW_FILTERS.side);
-  const [kind] = usePaneSettingValue<FlowKind>("kind", DEFAULT_FLOW_FILTERS.kind);
-  const [volOi] = usePaneSettingValue<FlowVolOi>("volOi", DEFAULT_FLOW_FILTERS.volOi);
-  const [expiry] = usePaneSettingValue<FlowExpiry>("expiry", DEFAULT_FLOW_FILTERS.expiry);
-  const [universe] = usePaneSettingValue<FlowUniverse>("universe", DEFAULT_FLOW_FILTERS.universe);
+  const [minPremium, setMinPremium] = usePaneSettingValue<FlowMinPremium>("minPremium", DEFAULT_FLOW_FILTERS.minPremium);
+  const [side, setSide] = usePaneSettingValue<FlowSide>("side", DEFAULT_FLOW_FILTERS.side);
+  const [kind, setKind] = usePaneSettingValue<FlowKind>("kind", DEFAULT_FLOW_FILTERS.kind);
+  const [volOi, setVolOi] = usePaneSettingValue<FlowVolOi>("volOi", DEFAULT_FLOW_FILTERS.volOi);
+  const [expiry, setExpiry] = usePaneSettingValue<FlowExpiry>("expiry", DEFAULT_FLOW_FILTERS.expiry);
+  const [universe, setUniverse] = usePaneSettingValue<FlowUniverse>("universe", DEFAULT_FLOW_FILTERS.universe);
 
   const trackedSymbols = useAppSelector((state) => state.tickers);
   const watchlist = useMemo(
@@ -129,27 +159,38 @@ function FlowPane({ focused, width, height }: PaneProps) {
   }
 
   return (
-    <DataTableView<ScannerFlowEvent>
-      focused={focused}
-      selection={{
-        kind: "id",
-        selectedId,
-        getId: (event) => event.id,
-        onChange: (_id, event) => handleSelect(event),
-      }}
-      rootWidth={width}
-      rootHeight={height}
-      columns={columns}
-      items={events}
-      sortColumnId={null}
-      sortDirection="desc"
-      onHeaderClick={() => {}}
-      getItemKey={(event) => event.id}
-      onActivate={(event) => pinTicker(event.underlying, { floating: true, paneType: TICKER_RESEARCH_PANE_ID })}
-      renderCell={(event, column, _index, rowState) => renderCell(event, column, rowState)}
-      emptyStateTitle={feed.payload ? "No prints match these filters." : "Waiting for the scanner..."}
-      emptyStateHint={feed.payload ? "Loosen the premium, expiry, or universe filter." : undefined}
-    />
+    <Box flexDirection="column" width={width} height={height}>
+      <Box height={1} flexDirection="row" overflow="hidden">
+        <FilterChip label="Prem" value={minPremium} options={FLOW_FILTER_OPTIONS.minPremium} onChange={setMinPremium} />
+        <FilterChip label="Side" value={side} options={FLOW_FILTER_OPTIONS.side} onChange={setSide} />
+        <FilterChip label="Kind" value={kind} options={FLOW_FILTER_OPTIONS.kind} onChange={setKind} />
+        <FilterChip label="V/OI" value={volOi} options={FLOW_FILTER_OPTIONS.volOi} onChange={setVolOi} />
+        <FilterChip label="Exp" value={expiry} options={FLOW_FILTER_OPTIONS.expiry} onChange={setExpiry} />
+        <FilterChip label="Univ" value={universe} options={FLOW_FILTER_OPTIONS.universe} onChange={setUniverse} />
+      </Box>
+      <DataTableView<ScannerFlowEvent>
+        focused={focused}
+        selection={{
+          kind: "id",
+          selectedId,
+          getId: (event) => event.id,
+          onChange: (_id, event) => handleSelect(event),
+        }}
+        rootWidth={width}
+        rootHeight={Math.max(2, height - 1)}
+        columns={columns}
+        items={events}
+        sortColumnId={null}
+        sortDirection="desc"
+        onHeaderClick={() => {}}
+        getItemKey={(event) => event.id}
+        onActivate={(event) => pinTicker(event.underlying, { floating: true, paneType: TICKER_RESEARCH_PANE_ID })}
+        renderCell={(event, column, _index, rowState) => renderCell(event, column, rowState)}
+        emptyContent={feed.payload ? undefined : <ScannerWaitingState />}
+        emptyStateTitle="No prints match these filters."
+        emptyStateHint="Loosen the premium, expiry, or universe filter."
+      />
+    </Box>
   );
 }
 

--- a/src/plugins/builtin/scanner/hilo-pane.tsx
+++ b/src/plugins/builtin/scanner/hilo-pane.tsx
@@ -16,6 +16,7 @@ import { usePluginPaneActions, usePluginTickerActions } from "../../runtime";
 import { ScannerDeniedState } from "./denied";
 import { useHiloFeed, useScannerStatusFooter } from "./feed";
 import { HiloBars } from "./hilo-bars";
+import { ScannerWaitingState } from "./waiting";
 import { filterHiloRows, type HiloMinPrice, type HiloSort } from "./hilo-model";
 
 type Side = "lows" | "highs";
@@ -25,6 +26,10 @@ function rowKey(row: ScannerHiloExtreme, index: number): string {
 }
 
 const BARS_HEIGHT = 4;
+/** Below this the two tables cannot both stay legible, so only the focused side is shown. */
+const SPLIT_MIN_WIDTH = 42;
+/** The bars are the lowest-priority panel: they go first when rows run out. */
+const BARS_MIN_HEIGHT = BARS_HEIGHT + 4;
 
 function buildColumns(width: number): DataTableColumn[] {
   const symbolWidth = 8;
@@ -86,8 +91,11 @@ function HiloPane({ focused, width, height }: PaneProps) {
 
   useScannerStatusFooter("hilo", feed, focused);
 
+  const split = width >= SPLIT_MIN_WIDTH;
+  const showBars = height >= BARS_MIN_HEIGHT;
   // One cell of gutter keeps the two cursors from reading as a single wide row.
-  const tableWidth = Math.max(20, Math.floor((width - 1) / 2));
+  const tableWidth = split ? Math.max(12, Math.floor((width - 1) / 2)) : Math.max(12, width);
+  const tableHeight = Math.max(2, height - (showBars ? BARS_HEIGHT : 0));
   const columns = useMemo(() => buildColumns(tableWidth), [tableWidth]);
 
   const handleSelect = useCallback((side: Side, row: ScannerHiloExtreme, index: number) => {
@@ -121,7 +129,7 @@ function HiloPane({ focused, width, height }: PaneProps) {
       }}
       onRootKeyDown={handleSideSwitchKey}
       rootWidth={tableWidth}
-      rootHeight={Math.max(3, height - BARS_HEIGHT)}
+      rootHeight={tableHeight}
       columns={columns}
       items={rows}
       sortColumnId={null}
@@ -130,17 +138,25 @@ function HiloPane({ focused, width, height }: PaneProps) {
       getItemKey={rowKey}
       onActivate={(row) => pinTicker(row.symbol, { floating: true, paneType: TICKER_RESEARCH_PANE_ID })}
       renderCell={(row, column, _index, rowState) => renderCell(side, row, column, rowState)}
-      emptyStateTitle={feed.payload ? "Nothing above the price filter yet." : "Waiting for the scanner..."}
+      emptyContent={feed.payload ? undefined : <ScannerWaitingState />}
+      emptyStateTitle="Nothing above the price filter yet."
     />
   );
 
   return (
     <Box flexDirection="column" width={width} height={height}>
-      <HiloBars windows={feed.payload?.windows} width={width} />
-      <Box flexDirection="row" flexGrow={1}>
-        {renderTable("lows", lows)}
-        <Box width={1} flexShrink={0} />
-        {renderTable("highs", highs)}
+      {showBars && <HiloBars windows={feed.payload?.windows} width={width} />}
+      <Box flexDirection="row" flexGrow={1} overflow="hidden">
+        {split ? (
+          <>
+            {renderTable("lows", lows)}
+            <Box width={1} flexShrink={0} />
+            {renderTable("highs", highs)}
+          </>
+        ) : (
+          // Too narrow for both: show the focused side and keep left/right switching it.
+          renderTable(activeSide, activeSide === "lows" ? lows : highs)
+        )}
       </Box>
     </Box>
   );

--- a/src/plugins/builtin/scanner/index.ts
+++ b/src/plugins/builtin/scanner/index.ts
@@ -1,6 +1,6 @@
 import type { PaneSettingsDef } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
-import { DEFAULT_FLOW_FILTERS } from "./flow-model";
+import { DEFAULT_FLOW_FILTERS, FLOW_FILTER_OPTIONS } from "./flow-model";
 import FlowPane from "./flow-pane";
 import HiloPane from "./hilo-pane";
 
@@ -35,69 +35,28 @@ function hiloSettings(): PaneSettingsDef {
   };
 }
 
+function toSettingOptions(
+  options: readonly { value: string; label: string }[],
+): { value: string; label: string }[] {
+  return options.map(({ value, label }) => ({ value, label }));
+}
+
 function flowSettings(): PaneSettingsDef {
   return {
     title: "Options Flow Settings",
+    // Options come from the pane's own filter chips so the two never drift.
     fields: [
-      {
-        key: "minPremium",
-        label: "Minimum premium",
-        type: "select",
-        options: [
-          { value: "50000", label: "$50K" },
-          { value: "250000", label: "$250K" },
-          { value: "1000000", label: "$1M" },
-        ],
-      },
-      {
-        key: "side",
-        label: "Contract side",
-        type: "select",
-        options: [
-          { value: "both", label: "Calls and puts" },
-          { value: "calls", label: "Calls only" },
-          { value: "puts", label: "Puts only" },
-        ],
-      },
-      {
-        key: "kind",
-        label: "Print kind",
-        type: "select",
-        options: [
-          { value: "all", label: "All prints" },
-          { value: "sweeps", label: "Sweeps only" },
-          { value: "blocks", label: "Blocks only" },
-        ],
-      },
-      {
-        key: "volOi",
-        label: "Volume / open interest floor",
-        type: "select",
-        options: [
-          { value: "off", label: "No floor" },
-          { value: "1", label: "1x and up" },
-          { value: "5", label: "5x and up" },
-        ],
-      },
-      {
-        key: "expiry",
-        label: "Expiry window",
-        type: "select",
-        options: [
-          { value: "all", label: "Any expiry" },
-          { value: "7", label: "7 days or less" },
-          { value: "30", label: "30 days or less" },
-        ],
-      },
+      { key: "minPremium", label: "Minimum premium", type: "select", options: toSettingOptions(FLOW_FILTER_OPTIONS.minPremium) },
+      { key: "side", label: "Contract side", type: "select", options: toSettingOptions(FLOW_FILTER_OPTIONS.side) },
+      { key: "kind", label: "Print kind", type: "select", options: toSettingOptions(FLOW_FILTER_OPTIONS.kind) },
+      { key: "volOi", label: "Volume / open interest floor", type: "select", options: toSettingOptions(FLOW_FILTER_OPTIONS.volOi) },
+      { key: "expiry", label: "Expiry window", type: "select", options: toSettingOptions(FLOW_FILTER_OPTIONS.expiry) },
       {
         key: "universe",
         label: "Universe",
         description: "Watchlist mode filters the same shared feed locally.",
         type: "select",
-        options: [
-          { value: "active", label: "Active names" },
-          { value: "watchlist", label: "My tickers only" },
-        ],
+        options: toSettingOptions(FLOW_FILTER_OPTIONS.universe),
       },
     ],
   };

--- a/src/plugins/builtin/scanner/waiting.tsx
+++ b/src/plugins/builtin/scanner/waiting.tsx
@@ -1,0 +1,11 @@
+import { Box } from "../../../ui";
+import { Spinner } from "../../../components";
+
+/** Shown until the first scanner payload arrives, so a live connection never reads as empty. */
+export function ScannerWaitingState() {
+  return (
+    <Box paddingX={1} paddingY={1}>
+      <Spinner label="Waiting for the scanner..." />
+    </Box>
+  );
+}

--- a/src/plugins/builtin/sec/index.tsx
+++ b/src/plugins/builtin/sec/index.tsx
@@ -1,4 +1,3 @@
-import { Text } from "../../../ui";
 import { useEffect, useMemo, useState } from "react";
 import type { PluginModule } from "../plugin-module";
 import type { SecFilingDocument, SecFilingItem } from "../../../types/data-provider";
@@ -6,8 +5,7 @@ import { useResolvedEntryValue, useSecFilingDocuments, useSecFilingsQuery } from
 import { instrumentFromTicker } from "../../../market-data/request-types";
 import { useDebouncedPluginPaneState } from "../../runtime";
 import { usePaneTicker } from "../../../state/app/context";
-import { colors } from "../../../theme/colors";
-import { FeedDataTableStackView, Spinner, type FeedDataTableItem } from "../../../components";
+import { EmptyState, FeedDataTableStackView, Spinner, type FeedDataTableItem } from "../../../components";
 import { isUsEquityTicker } from "../../../utils/sec";
 import { parseForm4Xml, transactionTypeLabel } from "../insider/insider-data";
 import { formatCompact, formatCurrency } from "../../../utils/format";
@@ -270,11 +268,14 @@ function SecView({ width, height, focused }: { width: number; height: number; fo
     || documentsEntry?.phase === "refreshing"
   );
 
+  // Only the filing in view needs its content; queueing every ownership form in
+  // the list fires dozens of SEC requests the user never looks at.
+  const selectedFiling = filings[selectedIdx];
   const contentTargets = useMemo(() => [
     ...(openFiling ? [openFiling] : []),
     ...buildInlineFilingContentTargets(openFiling, openDocuments),
-    ...filings.filter((filing) => OWNERSHIP_FORMS.has(filing.form.trim())),
-  ], [filings, openDocuments, openFiling]);
+    ...(selectedFiling && OWNERSHIP_FORMS.has(selectedFiling.form.trim()) ? [selectedFiling] : []),
+  ], [openDocuments, openFiling, selectedFiling]);
   const { contentCache } = useSecFilingContentCache({
     scopeKey: `${ticker?.metadata.ticker ?? "none"}:${ticker?.metadata.exchange ?? ""}:${eligibleTicker}`,
     targets: contentTargets,
@@ -298,10 +299,12 @@ function SecView({ width, height, focused }: { width: number; height: number; fo
     showOpenHint: !error && !!openFiling?.filingUrl,
   });
 
-  if (!ticker) return <Text fg={colors.textDim}>Select a ticker to view SEC filings.</Text>;
+  if (!ticker) {
+    return <EmptyState title="No ticker selected." message="Select a ticker to view SEC filings." />;
+  }
   if (!eligibleTicker) return renderFilingNotice("SEC filings are only shown for US equities.", width);
   if (loading && filings.length === 0) return <Spinner label="Loading SEC filings..." />;
-  if (error) return renderFilingNotice(`Error: ${error}`, width);
+  if (error) return <EmptyState title="SEC filings unavailable." message={error} />;
   if (filings.length === 0) return renderFilingNotice(`No recent SEC filings for ${ticker.metadata.ticker}.`, width);
 
   return (

--- a/src/plugins/builtin/sectors/index.tsx
+++ b/src/plugins/builtin/sectors/index.tsx
@@ -1,15 +1,20 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box } from "../../../ui";
-import { DataTableView, Tabs, usePaneFooter, type DataTableCell, type DataTableKeyEvent } from "../../../components";
+import { DataTableView, Tabs, usePaneFooter, type DataTableCell, type DataTableKeyEvent, type PaneFooterSegment } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
-import type { Quote } from "../../../types/financials";
+import type { PricePoint, Quote } from "../../../types/financials";
+import { usePaneSettingValue } from "../../../state/app/context";
 import { colors, priceColor } from "../../../theme/colors";
 import { formatCurrency, formatPercentRaw } from "../../../utils/format";
 import { useAssetData, useDebouncedPluginPaneState, usePluginPaneState, usePluginTickerActions } from "../../runtime";
+import { useAutoRefresh, useUpdatedAgo } from "../shared/auto-refresh";
+import { SectorMoveBar } from "./move-bar";
 import {
   SECTOR_COLLECTIONS,
+  collectionSettingKey,
   getSectorCollection,
+  resolveCollectionItems,
   type SectorCollectionId,
 } from "./sector-data";
 import {
@@ -19,11 +24,8 @@ import {
   INITIAL_ROWS_BY_COLLECTION,
   ONE_MONTH_DAYS,
   ONE_YEAR_DAYS,
-  REFRESH_INTERVAL_MS,
-  buildBar,
   buildSectorColumns,
   computeTrailingReturn,
-  formatTime,
   latestHistoryClose,
   nextSortPreference,
   normalizeRowsForCollection,
@@ -36,6 +38,9 @@ import {
   type SectorSortPreference,
 } from "./sector-model";
 
+/** Stable identity: a fresh literal here would refetch the board every render. */
+const NO_SAVED_ETFS: string[] = [];
+
 function SectorPerformancePane({ focused, width, height }: PaneProps) {
   const dataProvider = useAssetData();
   const { navigateTicker } = usePluginTickerActions();
@@ -44,6 +49,15 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
     DEFAULT_COLLECTION_ID,
   );
   const activeCollection = getSectorCollection(activeCollectionId);
+  const [savedSectorEtfs] = usePaneSettingValue<string[]>("sectorEtfs", NO_SAVED_ETFS);
+  const [savedIndustryEtfs] = usePaneSettingValue<string[]>("industryEtfs", NO_SAVED_ETFS);
+  const activeItems = useMemo(
+    () => resolveCollectionItems(
+      activeCollection.id,
+      activeCollection.id === "industries" ? savedIndustryEtfs : savedSectorEtfs,
+    ),
+    [activeCollection.id, savedIndustryEtfs, savedSectorEtfs],
+  );
   const [rowsByCollection, setRowsByCollection] = useDebouncedPluginPaneState<SectorRowsByCollection>(
     "rowsByCollection:v1",
     INITIAL_ROWS_BY_COLLECTION,
@@ -59,15 +73,16 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
   );
 
   const fetchGenRef = useRef(0);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const columns = useMemo(() => buildSectorColumns(width), [width]);
   const rows = useMemo(
-    () => normalizeRowsForCollection(rowsByCollection, activeCollection.id),
-    [activeCollection.id, rowsByCollection],
+    () => normalizeRowsForCollection(rowsByCollection, activeCollection.id, activeItems),
+    [activeCollection.id, activeItems, rowsByCollection],
   );
   const sortedRows = useMemo(() => sortRows(rows, sortPreference), [rows, sortPreference]);
-  const lastRefreshMs = lastRefreshByCollection[activeCollection.id];
-  const lastRefreshText = lastRefreshMs ? formatTime(new Date(lastRefreshMs)) : "loading";
+  const lastRefreshMs = lastRefreshByCollection[activeCollection.id] ?? null;
+  const loading = rows.some((row) => row.loading);
   const tabs = useMemo(() => SECTOR_COLLECTIONS.map((collection) => ({
     label: collection.label,
     value: collection.id,
@@ -75,23 +90,26 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
   const fetchAll = useCallback(() => {
     fetchGenRef.current += 1;
     const gen = fetchGenRef.current;
+    const collectionId = activeCollection.id;
+    const sectorDefs = activeItems;
+
     if (!dataProvider) {
-      setRowsByCollection((prev) => updateRowsForCollection(prev, activeCollection.id, (rows) => (
+      setLoadError("No market data provider connected.");
+      setRowsByCollection((prev) => updateRowsForCollection(prev, collectionId, sectorDefs, (rows) => (
         rows.map((row) => ({ ...row, loading: false }))
       )));
       return;
     }
 
-    const sectorDefs = activeCollection.items;
-    const collectionId = activeCollection.id;
-
-    setRowsByCollection((prev) => updateRowsForCollection(prev, collectionId, (rows) => (
+    setRowsByCollection((prev) => updateRowsForCollection(prev, collectionId, sectorDefs, (rows) => (
       rows.map((row) => ({ ...row, loading: true }))
     )));
 
     const loadQuotes = async (): Promise<Map<string, Quote | null>> => {
       const quotes = new Map<string, Quote | null>();
       if (dataProvider.getQuotesBatch) {
+        // A failed batch leaves every quote missing, which the row outcome below
+        // reports as unavailable instead of stamping the pane as fresh.
         const results = await dataProvider.getQuotesBatch(
           sectorDefs.map((sector) => ({ symbol: sector.etf, exchange: "" })),
         ).catch(() => []);
@@ -111,58 +129,53 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
       return quotes;
     };
 
-    const fetches = loadQuotes().then((quotesByEtf) => Promise.allSettled(sectorDefs.map(async (sector) => {
-      try {
-        const historyResult = await dataProvider.getPriceHistory(sector.etf, "", "1Y")
-          .then((value) => ({ status: "fulfilled" as const, value }))
-          .catch(() => ({ status: "rejected" as const }));
-        if (fetchGenRef.current !== gen) return;
+    const loadRows = async (): Promise<Array<{ etf: string; row: Partial<SectorRow> | null }>> => {
+      const quotesByEtf = await loadQuotes();
+      return Promise.all(sectorDefs.map(async (sector) => {
+        const history: PricePoint[] = await dataProvider.getPriceHistory(sector.etf, "", "1Y")
+          .catch(() => []);
         const quote = quotesByEtf.get(sector.etf) ?? null;
-        const history = historyResult.status === "fulfilled" ? historyResult.value : [];
-        const historyClose = latestHistoryClose(history);
-        const price = quote?.price ?? historyClose;
-        const return1M = computeTrailingReturn(history, ONE_MONTH_DAYS, price);
-        const return1Y = computeTrailingReturn(history, ONE_YEAR_DAYS, price);
-        setRowsByCollection((prev) => updateRowsForCollection(prev, collectionId, (rows) => (
-          rows.map((row) =>
-            row.etf === sector.etf
-              ? {
-                  ...row,
-                  price,
-                  changePercent: quote?.changePercent ?? null,
-                  return1M,
-                  return1Y,
-                  currency: quote?.currency ?? "USD",
-                  loading: false,
-                }
-              : row,
-          )
-        )));
-      } catch {
-        if (fetchGenRef.current !== gen) return;
-        setRowsByCollection((prev) => updateRowsForCollection(prev, collectionId, (rows) => (
-          rows.map((row) =>
-            row.etf === sector.etf ? { ...row, loading: false } : row,
-          )
-        )));
-      }
-    })));
+        if (!quote && history.length === 0) return { etf: sector.etf, row: null };
+        const price = quote?.price ?? latestHistoryClose(history);
+        return {
+          etf: sector.etf,
+          row: {
+            price,
+            changePercent: quote?.changePercent ?? null,
+            return1M: computeTrailingReturn(history, ONE_MONTH_DAYS, price),
+            return1Y: computeTrailingReturn(history, ONE_YEAR_DAYS, price),
+            currency: quote?.currency ?? "USD",
+          },
+        };
+      }));
+    };
 
-    fetches.then(() => {
-      if (fetchGenRef.current === gen) {
-        setLastRefreshByCollection((prev) => ({
-          ...prev,
-          [collectionId]: Date.now(),
-        }));
-      }
+    loadRows().then((outcomes) => {
+      if (fetchGenRef.current !== gen) return;
+      const loadedByEtf = new Map(outcomes.map((outcome) => [outcome.etf, outcome.row]));
+      setRowsByCollection((prev) => updateRowsForCollection(prev, collectionId, sectorDefs, (rows) => (
+        rows.map((row) => ({ ...row, ...(loadedByEtf.get(row.etf) ?? {}), loading: false }))
+      )));
+
+      const loadedCount = outcomes.filter((outcome) => outcome.row).length;
+      setLoadError(loadedCount === 0 ? "Sector data unavailable" : null);
+      // A refresh that returned nothing must not claim the board is current.
+      if (loadedCount === 0) return;
+      setLastRefreshByCollection((prev) => ({ ...prev, [collectionId]: Date.now() }));
+    }).catch(() => {
+      if (fetchGenRef.current !== gen) return;
+      setLoadError("Sector data unavailable");
+      setRowsByCollection((prev) => updateRowsForCollection(prev, collectionId, sectorDefs, (rows) => (
+        rows.map((row) => ({ ...row, loading: false }))
+      )));
     });
-  }, [activeCollection, dataProvider, setLastRefreshByCollection, setRowsByCollection]);
+  }, [activeCollection.id, activeItems, dataProvider, setLastRefreshByCollection, setRowsByCollection]);
 
   useEffect(() => {
     fetchAll();
-    const interval = setInterval(fetchAll, REFRESH_INTERVAL_MS);
-    return () => clearInterval(interval);
   }, [fetchAll]);
+
+  useAutoRefresh(lastRefreshMs, fetchAll);
 
   useEffect(() => {
     if (activeCollectionId === activeCollection.id) return;
@@ -229,29 +242,23 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
           text: row.loading && row.return1Y === null ? "…" : row.return1Y !== null ? formatPercentRaw(row.return1Y) : "—",
           color: selectedColor ?? (row.return1Y !== null ? priceColor(row.return1Y) : colors.textDim),
         };
-      case "bar": {
-        const bar = row.changePercent !== null ? buildBar(row.changePercent, column.width) : "";
-        const barColor = row.changePercent !== null && row.changePercent >= 0 ? colors.positive : colors.negative;
+      case "bar":
         return {
-          text: bar,
-          color: selectedColor ?? (bar ? barColor : colors.textDim),
+          text: "",
+          content: <SectorMoveBar changePercent={row.changePercent} width={column.width} />,
         };
-      }
     }
   }, []);
 
-  usePaneFooter("sectors", () => ({
-    info: [
-      {
-        id: "collection",
-        parts: [{ text: activeCollection.label, tone: "label" }],
-      },
-      {
-        id: "updated",
-        parts: [{ text: lastRefreshText, tone: lastRefreshMs ? "value" : "muted" }],
-      },
-    ],
-  }), [activeCollection.label, lastRefreshMs, lastRefreshText]);
+  const updatedAgo = useUpdatedAgo(lastRefreshMs);
+
+  usePaneFooter("sectors", () => {
+    const info: PaneFooterSegment[] = [];
+    if (loading) info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
+    if (loadError) info.push({ id: "error", parts: [{ text: loadError, tone: "warning" }] });
+    if (updatedAgo) info.push({ id: "updated", parts: [{ text: `updated ${updatedAgo}`, tone: "muted" }] });
+    return { info };
+  }, [loadError, loading, updatedAgo]);
 
   const rootBefore = (
     <Box height={1} paddingX={1}>
@@ -298,8 +305,7 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
       onHeaderClick={handleHeaderClick}
       getItemKey={(row) => row.etf}
       renderCell={renderCell}
-      emptyStateTitle="No sector data available"
-      showHorizontalScrollbar={false}
+      emptyStateTitle={loadError ?? "No sectors selected."}
     />
   );
 }
@@ -314,6 +320,25 @@ export const sectorsModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 82, height: 18 },
+      settings: (context) => ({
+        title: "Sector Performance Settings",
+        values: {
+          sectorEtfs: resolveCollectionItems("sectors", context.settings.sectorEtfs as string[] | undefined)
+            .map((item) => item.etf),
+          industryEtfs: resolveCollectionItems("industries", context.settings.industryEtfs as string[] | undefined)
+            .map((item) => item.etf),
+        },
+        fields: SECTOR_COLLECTIONS.map((collection) => ({
+          key: collectionSettingKey(collection.id),
+          label: collection.label,
+          type: "ordered-multi-select" as const,
+          options: collection.items.map((item) => ({
+            value: item.etf,
+            label: item.name,
+            description: item.etf,
+          })),
+        })),
+      }),
     },
   ],
 

--- a/src/plugins/builtin/sectors/move-bar.tsx
+++ b/src/plugins/builtin/sectors/move-bar.tsx
@@ -1,0 +1,43 @@
+import { Box, Text, useUiHost } from "../../../ui";
+import { colors } from "../../../theme/colors";
+import { moveBarRatio } from "./sector-model";
+
+export interface SectorMoveBarProps {
+  changePercent: number | null;
+  width: number;
+}
+
+/**
+ * The session move as a length, not as a number that is already in the 1D
+ * column. Desktop draws a real element; the terminal falls back to block cells,
+ * so box-drawing characters never reach the browser renderer.
+ */
+export function SectorMoveBar({ changePercent, width }: SectorMoveBarProps) {
+  const isDesktopWeb = useUiHost().kind === "desktop-web";
+  if (changePercent == null || width <= 0) return <Text fg={colors.textDim}>{""}</Text>;
+
+  const ratio = moveBarRatio(changePercent);
+  const color = changePercent >= 0 ? colors.positive : colors.negative;
+
+  if (isDesktopWeb) {
+    return (
+      <Box width={width} flexDirection="row" alignItems="center" overflow="hidden">
+        <Box
+          backgroundColor={color}
+          style={{
+            width: `${(ratio * 100).toFixed(2)}%`,
+            height: "9px",
+            borderRadius: "2px",
+            minWidth: ratio > 0 ? "2px" : "0",
+          }}
+        />
+      </Box>
+    );
+  }
+
+  const cells = ratio * width;
+  const full = Math.floor(cells);
+  const half = cells - full >= 0.5;
+  const bar = `${"█".repeat(full)}${half ? "▌" : ""}`;
+  return <Text fg={color}>{bar}</Text>;
+}

--- a/src/plugins/builtin/sectors/sector-data.ts
+++ b/src/plugins/builtin/sectors/sector-data.ts
@@ -55,3 +55,21 @@ export const SECTOR_COLLECTIONS: SectorCollection[] = [
 export function getSectorCollection(id: SectorCollectionId): SectorCollection {
   return SECTOR_COLLECTIONS.find((collection) => collection.id === id) ?? SECTOR_COLLECTIONS[0]!;
 }
+
+/** Settings key holding the saved ETF selection for a collection. */
+export function collectionSettingKey(id: SectorCollectionId): string {
+  return id === "industries" ? "industryEtfs" : "sectorEtfs";
+}
+
+/** The saved ETF selection, falling back to the full list when it is unusable. */
+export function resolveCollectionItems(
+  id: SectorCollectionId,
+  saved?: readonly string[],
+): SectorDef[] {
+  const all = getSectorCollection(id).items;
+  const byEtf = new Map(all.map((item) => [item.etf, item]));
+  const resolved = (saved ?? [])
+    .map((etf) => byEtf.get(etf))
+    .filter((item): item is SectorDef => !!item);
+  return resolved.length > 0 ? resolved : [...all];
+}

--- a/src/plugins/builtin/sectors/sector-model.ts
+++ b/src/plugins/builtin/sectors/sector-model.ts
@@ -8,7 +8,6 @@ import {
   type SectorDef,
 } from "./sector-data";
 
-export const REFRESH_INTERVAL_MS = 60_000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 export const ONE_MONTH_DAYS = 30;
 export const ONE_YEAR_DAYS = 365;
@@ -38,15 +37,12 @@ export const DEFAULT_SORT_PREFERENCE: SectorSortPreference = {
   direction: "desc",
 };
 
-export function buildBar(changePercent: number, barWidth: number): string {
-  if (barWidth <= 0) return "";
-  const filled = Math.round(Math.abs(changePercent) / 5 * barWidth);
-  const clamped = Math.min(filled, barWidth);
-  return "━".repeat(clamped);
-}
+/** Full length at a 5% session move, which covers all but crash days. */
+const MOVE_BAR_FULL_SCALE_PERCENT = 5;
 
-export function formatTime(date: Date): string {
-  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+/** 0..1 length for a session move, monotonic in the size of the move. */
+export function moveBarRatio(changePercent: number): number {
+  return Math.min(1, Math.abs(changePercent) / MOVE_BAR_FULL_SCALE_PERCENT);
 }
 
 function createLoadingRows(sectors: readonly SectorDef[]): SectorRow[] {
@@ -74,10 +70,10 @@ export const INITIAL_REFRESH_BY_COLLECTION: SectorRefreshByCollection = {};
 export function normalizeRowsForCollection(
   rowsByCollection: SectorRowsByCollection,
   collectionId: SectorCollectionId,
+  items: readonly SectorDef[] = getSectorCollection(collectionId).items,
 ): SectorRow[] {
-  const collection = getSectorCollection(collectionId);
   const rows = rowsByCollection[collectionId] ?? [];
-  return collection.items.map((sector) => {
+  return items.map((sector) => {
     const existing = rows.find((row) => row.etf === sector.etf);
     return {
       ...sector,
@@ -94,11 +90,12 @@ export function normalizeRowsForCollection(
 export function updateRowsForCollection(
   rowsByCollection: SectorRowsByCollection,
   collectionId: SectorCollectionId,
+  items: readonly SectorDef[],
   updater: (rows: SectorRow[]) => SectorRow[],
 ): SectorRowsByCollection {
   return {
     ...rowsByCollection,
-    [collectionId]: updater(normalizeRowsForCollection(rowsByCollection, collectionId)),
+    [collectionId]: updater(normalizeRowsForCollection(rowsByCollection, collectionId, items)),
   };
 }
 
@@ -152,10 +149,10 @@ export function buildSectorColumns(width: number): SectorColumn[] {
     : 0;
   const columnCount = showBar ? 7 : 6;
   const fixedWidth = etfWidth + priceWidth + changeWidth + returnWidth * 2 + barWidth;
-  const nameWidth = Math.max(12, Math.min(22, width - 2 - columnCount - fixedWidth));
+  const nameWidth = Math.max(10, Math.min(22, width - 2 - columnCount - fixedWidth));
 
   const columns: SectorColumn[] = [
-    { id: "name", label: "SECTOR", width: nameWidth, align: "left" },
+    { id: "name", label: "SECTOR", width: nameWidth, align: "left", flexGrow: 1 },
     { id: "etf", label: "ETF", width: etfWidth, align: "left" },
     { id: "price", label: "LAST", width: priceWidth, align: "right" },
     { id: "changePercent", label: "1D", width: changeWidth, align: "right" },
@@ -163,7 +160,8 @@ export function buildSectorColumns(width: number): SectorColumn[] {
     { id: "return1Y", label: "1Y", width: returnWidth, align: "right" },
   ];
   if (showBar) {
-    columns.push({ id: "bar", label: "MOVE", width: barWidth, align: "left" });
+    // Labelled with the window it encodes: it sits after 1Y but tracks 1D.
+    columns.push({ id: "bar", label: "1D MOVE", width: barWidth, align: "left" });
   }
   return columns;
 }

--- a/src/plugins/builtin/shared/auto-refresh.ts
+++ b/src/plugins/builtin/shared/auto-refresh.ts
@@ -3,7 +3,7 @@ import { useAppSelector } from "../../../state/app/context";
 import { formatRelativeAge } from "../../../utils/relative-time";
 
 /** The label only changes once a minute, so a coarse tick is enough. */
-const AGE_TICK_MS = 30_000;
+export const AGE_TICK_MS = 30_000;
 
 /**
  * How old a pane's data is, as a footer-ready label that keeps ageing on its

--- a/src/plugins/builtin/shared/pane-footer.ts
+++ b/src/plugins/builtin/shared/pane-footer.ts
@@ -8,6 +8,9 @@ import {
 
 const EMPTY_STATUS_INFO: PaneFooterSegment[] = [];
 
+// `r` refreshes every pane, so it is global product knowledge and deliberately
+// has no per-pane footer hint. Do not reintroduce one. See PR #589.
+
 function buildPaneStatusInfo({
   loading = false,
   error,

--- a/src/plugins/builtin/short-interest/index.tsx
+++ b/src/plugins/builtin/short-interest/index.tsx
@@ -53,7 +53,8 @@ export const shortInterestModule: PluginModule = {
       id: "short-interest-pane",
       paneId: "short-interest",
       label: "Short Interest",
-      description: "Historical short interest, days to cover, and short % of float.",
+      // Yahoo's key-statistics module only carries the current and prior settlement dates.
+      description: "Latest and prior-month short interest, days to cover, and short % of float.",
       keywords: ["short", "interest", "si", "shorts", "borrow", "days", "cover"],
       shortcut: "SI",
     }),

--- a/src/plugins/builtin/short-interest/pane.tsx
+++ b/src/plugins/builtin/short-interest/pane.tsx
@@ -5,6 +5,7 @@ import {
   EmptyState,
   Spinner,
   StaticChartSurface,
+  unavailableText,
   usePaneFooter,
   usePaneTicker,
   type DataTableCell,
@@ -172,7 +173,7 @@ function ShortInterestView({ width, height, focused }: { width: number; height: 
   }), [error, status]);
 
   if (!ticker || !symbol) {
-    return <EmptyState title="No ticker selected" message="Select a ticker to view short interest." />;
+    return <EmptyState title="No ticker selected." message="Select a ticker to view short interest." />;
   }
 
   if ((status === "idle" || status === "loading") && records.length === 0) {
@@ -180,7 +181,7 @@ function ShortInterestView({ width, height, focused }: { width: number; height: 
   }
 
   if (status === "error" && records.length === 0) {
-    return <EmptyState title="Failed to load short interest" message={error ?? undefined} />;
+    return <EmptyState title={unavailableText("Short interest")} message={error ?? undefined} />;
   }
 
   if (status === "loaded" && records.length === 0) {

--- a/src/plugins/builtin/substack/article-detail.tsx
+++ b/src/plugins/builtin/substack/article-detail.tsx
@@ -5,6 +5,7 @@ import { RemoteImage } from "../../../components/ui";
 import { TickerBadgeText } from "../../../components/ticker/badge/text";
 import { useInlineTickers } from "../../../state/hooks/inline-tickers";
 import { colors } from "../../../theme/colors";
+import { formatReadTime, formatWordCount } from "./table";
 import type {
   SubstackArticleDetail,
   SubstackArticleSummary,
@@ -253,7 +254,10 @@ function ArticleBlockView({
         </Box>
       );
     case "divider":
-      return <Text fg={colors.border}>{"-".repeat(Math.max(1, Math.min(lineWidth, 96)))}</Text>;
+      // A real filled rule in both renderers instead of a row of hyphens.
+      return (
+        <Box height={1} width={Math.max(1, Math.min(lineWidth, 96))} backgroundColor={colors.border} />
+      );
     case "paragraph":
     default:
       return (
@@ -361,6 +365,16 @@ export const ArticleDetail = memo(function ArticleDetail({
   return (
     <ScrollBox ref={scrollRef} scrollY focusable={false} flexGrow={1} paddingX={1}>
       <Box flexDirection="column" width={lineWidth} gap={1}>
+        {/* The stack title already names the article, so the body opens on its metadata. */}
+        <Box height={1}>
+          <Text fg={colors.textDim}>
+            {[
+              article.publicationName,
+              formatReadTime(resolved?.readMinutes ?? article.readMinutes),
+              formatWordCount(resolved?.wordCount ?? article.wordCount),
+            ].filter(Boolean).join("  ·  ")}
+          </Text>
+        </Box>
         {loading && !resolved ? <Spinner label="Loading article..." /> : null}
         {error ? <Text fg={colors.negative}>{error}</Text> : null}
         <ArticleRichContent

--- a/src/plugins/builtin/substack/pane-footer.ts
+++ b/src/plugins/builtin/substack/pane-footer.ts
@@ -1,10 +1,6 @@
 import { usePaneFooter } from "../../../components";
 import type { SubstackAuthState } from "./api/types";
 import {
-  formatReadTime,
-  formatWordCount,
-} from "./table";
-import {
   SUBSTACK_PANE_ID,
   type SubstackArticleSummary,
 } from "./types";
@@ -26,18 +22,10 @@ export function useSubstackPaneFooter({
   openSelectedArticle: () => void;
 }) {
   const statusLabel = cacheStatusLabel(activeFeedState.fetchedAt, activeFeedState.stale);
-  const articleMetaLabel = detailOpen && selectedArticle
-    ? [
-      selectedArticle.publicationName,
-      formatReadTime(activeDetail.data?.readMinutes ?? selectedArticle.readMinutes),
-      formatWordCount(activeDetail.data?.wordCount ?? selectedArticle.wordCount),
-    ].filter(Boolean).join("  |  ")
-    : null;
 
   usePaneFooter(SUBSTACK_PANE_ID, () => ({
     info: [
       ...(!auth ? [{ id: "auth", parts: [{ text: "login required", tone: "warning" as const }] }] : []),
-      ...(articleMetaLabel ? [{ id: "article-meta", parts: [{ text: articleMetaLabel, tone: "muted" as const }] }] : []),
       ...(activeFeedState.loading || activeFeedState.loadingMore ? [{ id: "loading", parts: [{ text: activeFeedState.loadingMore ? "loading more" : "loading", tone: "muted" as const }] }] : []),
       ...(activeDetail.loading && detailOpen ? [{ id: "detail-loading", parts: [{ text: "loading article", tone: "muted" as const }] }] : []),
       ...(statusLabel && auth ? [{ id: "cache", parts: [{ text: statusLabel, tone: activeFeedState.stale ? "warning" as const : "muted" as const }] }] : []),
@@ -50,14 +38,11 @@ export function useSubstackPaneFooter({
   }), [
     activeDetail.error,
     activeDetail.loading,
-    activeDetail.data?.readMinutes,
-    activeDetail.data?.wordCount,
     activeFeedState.error,
     activeFeedState.fetchedAt,
     activeFeedState.loading,
     activeFeedState.loadingMore,
     activeFeedState.stale,
-    articleMetaLabel,
     auth,
     detailOpen,
     openSelectedArticle,

--- a/src/plugins/builtin/thirteenf/api.ts
+++ b/src/plugins/builtin/thirteenf/api.ts
@@ -11,7 +11,10 @@ import { httpFetch } from "../../../utils/http-transport";
 
 const FORMS_13F_BASE_URL = "https://forms13f.com/api/v1";
 const FORM_PAGE_LIMIT = 100;
-const MAX_FORM_ROWS = 2_000;
+// ponytail: large funds file well past 2,000 positions, and a silently clipped
+// list makes every weight, total, and buy/sell action wrong. Paging further is
+// slower but truthful; page in parallel if the wait becomes the problem.
+const MAX_FORM_ROWS = 20_000;
 const CACHE_KIND = "forms13f-api";
 const CACHE_SOURCE = "forms13f";
 const CACHE_SCHEMA_VERSION = 1;

--- a/src/plugins/builtin/thirteenf/model.ts
+++ b/src/plugins/builtin/thirteenf/model.ts
@@ -58,6 +58,8 @@ const CIK_RE = /^\d{6,10}$/;
 export function inferBrowserTabFromQuery(query: string): ThirteenFBrowserTab {
   const trimmed = query.trim();
   if (!trimmed) return "performance";
+  // The recent-filings feed has no tab of its own; this keyword is how it is reached.
+  if (/^(latest|recent)$/i.test(trimmed)) return "latest";
   if (!/[a-z]/.test(trimmed) && TICKER_LIKE_RE.test(trimmed.replace(/^\$/, "").toUpperCase())) return "byTicker";
   return "funds";
 }

--- a/src/plugins/builtin/thirteenf/pane.tsx
+++ b/src/plugins/builtin/thirteenf/pane.tsx
@@ -277,7 +277,9 @@ export function ThirteenFPane({ focused, width, height }: PaneProps) {
     loading: status === "loading",
     error,
     info: browserStatusInfo,
-    hints: [{ id: "search", key: "/", label: "search", onPress: focusSearch }],
+    hints: [
+      { id: "search", key: "/", label: "search", onPress: focusSearch },
+    ],
   });
 
   const rootBefore = (
@@ -289,7 +291,7 @@ export function ThirteenFPane({ focused, width, height }: PaneProps) {
         width={width}
         focusToken={searchFocusToken}
         inputRef={searchInputRef}
-        placeholder="fund, ticker, or CIK"
+        placeholder="fund, ticker, CIK, or latest"
         debounceMs={SEARCH_DEBOUNCE_MS}
         normalizeValue={trimSearchValue}
         onFocus={focusSearch}

--- a/src/plugins/builtin/ticker-detail/data-panes/historical-prices.tsx
+++ b/src/plugins/builtin/ticker-detail/data-panes/historical-prices.tsx
@@ -2,6 +2,8 @@ import { useCallback, useMemo } from "react";
 import { TextAttributes } from "../../../../ui";
 import {
   DataTableView,
+  loadingText,
+  unavailableText,
   usePaneFooter,
   type DataTableCell,
   type DataTableColumn,
@@ -163,7 +165,9 @@ export function HistoricalPricesPane({ focused, width, height }: PaneProps) {
       { id: "range", parts: [{ text: range, tone: "muted" as const }] },
       ...loadingErrorFooterInfo(loading, error),
     ],
-    hints: [{ id: "range", key: "t", label: "oggle range", onPress: cycleRange }],
+    hints: [
+      { id: "range", key: "t", label: "oggle range", onPress: cycleRange },
+    ],
   }), [cycleRange, error, loading, range]);
 
   return (
@@ -184,7 +188,12 @@ export function HistoricalPricesPane({ focused, width, height }: PaneProps) {
       onHeaderClick={() => {}}
       getItemKey={(row) => row.key}
       renderCell={renderCell}
-      emptyStateTitle={loading ? "Loading historical prices..." : "No historical prices"}
+      emptyStateTitle={error
+        ? unavailableText("Historical prices")
+        : loading
+          ? loadingText("historical prices")
+          : "No historical prices"}
+      emptyStateHint={error ?? undefined}
     />
   );
 }

--- a/src/plugins/builtin/ticker-detail/data-panes/provider-search.tsx
+++ b/src/plugins/builtin/ticker-detail/data-panes/provider-search.tsx
@@ -1,12 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { TextAttributes } from "../../../../ui";
+import { TextAttributes, type InputRenderable } from "../../../../ui";
 import {
   DataTableView,
+  InputSearchBar,
+  loadingText,
+  unavailableText,
   usePaneFooter,
   type DataTableCell,
   type DataTableColumn,
   type DataTableKeyEvent,
 } from "../../../../components";
+import { useShortcut } from "../../../../react/input";
+import { isPlainKey } from "../../../../utils/keyboard";
 import type { PaneProps, PaneTemplateDef } from "../../../../types/plugin";
 import { TICKER_RESEARCH_PANE_ID } from "../../../../types/config";
 import type { InstrumentSearchResult } from "../../../../types/instrument";
@@ -15,6 +20,8 @@ import { colors } from "../../../../theme/colors";
 import { useAssetData, usePluginPaneState, usePluginTickerActions } from "../../../runtime";
 import { handleRefreshKey, loadingErrorFooterInfo, useClampSelectedIndex } from "../../shared/table-pane";
 import type { LoadState } from "../../shared/ticker-request";
+
+const SEARCH_DEBOUNCE_MS = 250;
 
 function resultSymbol(result: InstrumentSearchResult): string {
   return result.symbol.trim().toUpperCase();
@@ -41,9 +48,13 @@ function buildSearchColumns(width: number): Array<DataTableColumn & { id: "symbo
 
 export function ProviderSearchPane({ focused, width, height }: PaneProps) {
   const dataProvider = useAssetData();
-  const query = useSearchQuerySetting();
+  const initialQuery = useSearchQuerySetting();
   const { pinTicker } = usePluginTickerActions();
+  const [query, setQuery] = usePluginPaneState<string>("query", initialQuery);
   const [selectedIdx, setSelectedIdx] = usePluginPaneState<number>("selectedIdx", 0);
+  const [searchFocused, setSearchFocused] = useState(false);
+  const [searchFocusToken, setSearchFocusToken] = useState(0);
+  const searchInputRef = useRef<InputRenderable | null>(null);
   const [state, setState] = useState<LoadState<InstrumentSearchResult[]>>({
     data: null,
     loading: false,
@@ -87,9 +98,33 @@ export function ProviderSearchPane({ focused, width, height }: PaneProps) {
 
   useClampSelectedIndex(rows.length, selectedIdx, setSelectedIdx);
 
+  const focusSearch = useCallback(() => {
+    setSearchFocused(true);
+    setSearchFocusToken((token) => token + 1);
+  }, []);
+  const blurSearch = useCallback(() => setSearchFocused(false), []);
+  const updateQuery = useCallback((nextQuery: string) => {
+    setQuery(nextQuery.trim());
+    setSelectedIdx(0);
+  }, [setQuery, setSelectedIdx]);
+
   const handleKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (isPlainKey(event, "/")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      focusSearch();
+      return true;
+    }
     return handleRefreshKey(event, () => load(true));
-  }, [load]);
+  }, [focusSearch, load]);
+
+  useShortcut((event) => {
+    if (!focused || searchFocused || event.targetEditable) return;
+    if (!isPlainKey(event, "/")) return;
+    event.preventDefault?.();
+    event.stopPropagation?.();
+    focusSearch();
+  }, { allowEditable: true, enabled: focused });
 
   const renderCell = useCallback((
     row: InstrumentSearchResult,
@@ -111,15 +146,32 @@ export function ProviderSearchPane({ focused, width, height }: PaneProps) {
   }, []);
 
   usePaneFooter("provider-search", () => ({
-    info: [
-      ...(query ? [{ id: "query", parts: [{ text: query, tone: "muted" as const }] }] : []),
-      ...loadingErrorFooterInfo(state.loading, state.error),
+    info: loadingErrorFooterInfo(state.loading, state.error),
+    hints: [
+      { id: "search", key: "/", label: "search", onPress: focusSearch },
     ],
-  }), [query, state.error, state.loading]);
+  }), [focusSearch, state.error, state.loading]);
 
   return (
     <DataTableView<InstrumentSearchResult, DataTableColumn & { id: "symbol" | "name" | "exchange" | "type" }>
-      focused={focused}
+      focused={focused && !searchFocused}
+      rootBefore={(
+        <InputSearchBar
+          value={query}
+          focused={focused}
+          active={searchFocused}
+          width={width}
+          focusToken={searchFocusToken}
+          inputRef={searchInputRef}
+          placeholder="symbol or company name"
+          debounceMs={SEARCH_DEBOUNCE_MS}
+          normalizeValue={(value) => value.trim()}
+          onFocus={focusSearch}
+          onBlur={blurSearch}
+          onNavigateDown={blurSearch}
+          onQueryChange={updateQuery}
+        />
+      )}
       selection={{
         kind: "index",
         selectedIndex: boundedSelectedIdx,
@@ -136,7 +188,12 @@ export function ProviderSearchPane({ focused, width, height }: PaneProps) {
       onHeaderClick={() => {}}
       getItemKey={(row, index) => `${row.providerId}:${row.symbol}:${row.exchange}:${row.type}:${index}`}
       renderCell={renderCell}
-      emptyStateTitle={state.loading ? "Searching..." : query ? "No search results" : "No search query"}
+      emptyStateTitle={state.error
+        ? unavailableText("Provider search")
+        : state.loading
+          ? loadingText("search results")
+          : query ? "No search results" : "No search query"}
+      emptyStateHint={state.error ?? (query ? undefined : "Press / to search.")}
     />
   );
 }

--- a/src/plugins/builtin/ticker-detail/financials/tab.tsx
+++ b/src/plugins/builtin/ticker-detail/financials/tab.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type SetStateAction 
 import { usePaneStateValue, usePaneTicker } from "../../../../state/app/context";
 import {
   DataTableView,
+  PaneStatusBody,
   Tabs,
   usePaneFooter,
   type DataTableCell,
@@ -94,7 +95,6 @@ export function ResolvedFinancialsTab({
   const [selectedRowId, setSelectedRowId] = useState<string | null>(null);
   const bodyScrollRef = useRef<ScrollBoxRenderable>(null);
   const headerScrollRef = useRef<ScrollBoxRenderable>(null);
-  const resolvedPeriodForFooter = resolveFinancialPeriod(period, hasAnnualStatements, hasQuarterlyStatements);
   const { nativePaneChrome } = useUiCapabilities();
   const subTab = FINANCIAL_SUB_TABS[subTabIdx]!;
   const currentGroupIds = useMemo(() => collectGroupIds(subTab.rows), [subTab]);
@@ -147,11 +147,10 @@ export function ResolvedFinancialsTab({
     });
   }, [currentGroupIds]);
 
+  // The active section and period are already the visible tab selections, so the
+  // footer only carries what the controls cannot show.
   usePaneFooter("financials", () => ({
-    info: financials ? [
-      { id: "section", parts: [{ text: FINANCIAL_SUB_TABS[subTabIdx]?.name ?? "Financials", tone: "value", bold: true }] },
-      { id: "period", parts: [{ text: resolvedPeriodForFooter === "annual" ? "Annual" : "Quarterly", tone: "muted" }] },
-    ] : [],
+    info: [],
     hints: [
       {
         id: "section",
@@ -190,8 +189,7 @@ export function ResolvedFinancialsTab({
     hasCollapsedCurrentGroup,
     hasExpandedCurrentGroup,
     hasQuarterlyStatements,
-    resolvedPeriodForFooter,
-    subTabIdx,
+    setSubTabIdx,
     togglePeriod,
   ]);
 
@@ -283,8 +281,17 @@ export function ResolvedFinancialsTab({
     setSelectedRowId(rows[0]!.id);
   }, [rows, selectedRowId]);
 
+  // A null snapshot is still in flight; only a loaded one can say "no coverage".
   if (!financials || (!hasAnnualStatements && !hasQuarterlyStatements)) {
-    return <Text fg={colors.textDim}>No financial data available.</Text>;
+    return (
+      <PaneStatusBody
+        loading={!financials}
+        empty={!!financials}
+        subject="financials"
+        emptyTitle="No financial statements."
+        emptyMessage="This ticker has no annual or quarterly statement coverage."
+      />
+    );
   }
 
   const renderCell = (

--- a/src/plugins/builtin/ticker-detail/index.tsx
+++ b/src/plugins/builtin/ticker-detail/index.tsx
@@ -1,16 +1,15 @@
 import type { PluginModule } from "../plugin-module";
-import type { TickerFinancials } from "../../../types/financials";
 import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
 import { normalizeTickerInput } from "../../../tickers/search";
 import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
-import { FinancialAnalysisPane, FinancialsResearchTab } from "./financials/pane";
+import { FinancialAnalysisPane } from "./financials/pane";
 import { HistoricalPricesPane } from "./data-panes/historical-prices";
 import {
   createProviderSearchPaneTemplate,
   ProviderSearchPane,
 } from "./data-panes/provider-search";
 import { TickerResearchPane } from "./pane";
-import { OverviewResearchTab } from "./overview/pane";
+import { TICKER_RESEARCH_BUILTIN_TABS } from "./research-tabs";
 import { QuoteMonitorPane } from "./quote-monitor";
 import {
   buildQuoteMonitorSettingsDef,
@@ -24,26 +23,11 @@ import {
   withLiveStreamingSetting,
 } from "../shared/live-streaming";
 
-function hasStatementFinancials(financials: TickerFinancials | null | undefined): boolean {
-  return (financials?.annualStatements.length ?? 0) > 0 || (financials?.quarterlyStatements.length ?? 0) > 0;
-}
-
 export const tickerDetailModule: PluginModule = {
   setup(ctx) {
-    ctx.registerTickerResearchTab({
-      id: "overview",
-      name: "Overview",
-      order: 10,
-      component: OverviewResearchTab,
-      isVisible: ({ ticker }) => !!ticker,
-    });
-    ctx.registerTickerResearchTab({
-      id: "financials",
-      name: "Financials",
-      order: 20,
-      component: FinancialsResearchTab,
-      isVisible: ({ financials }) => hasStatementFinancials(financials),
-    });
+    for (const tab of TICKER_RESEARCH_BUILTIN_TABS) {
+      ctx.registerTickerResearchTab(tab);
+    }
   },
 
   panes: [

--- a/src/plugins/builtin/ticker-detail/overview/components.tsx
+++ b/src/plugins/builtin/ticker-detail/overview/components.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, TextAttributes } from "../../../../ui";
+import { Box, Text, TextAttributes, useUiHost } from "../../../../ui";
 import { colors, priceColor } from "../../../../theme/colors";
 import { displayWidth, formatNumber, padTo } from "../../../../utils/format";
 import { formatMarketPriceWithCurrency } from "../../../../market-data/market/format";
@@ -18,6 +18,59 @@ interface PositionColumn {
   width: number;
   align?: "left" | "right";
   color?: (row: PositionTableRow) => string;
+  /** Lowest pane width that still has room for this column. */
+  minPaneWidth?: number;
+}
+
+function RangeTrack({
+  barWidth,
+  markerIndex,
+  position,
+  markerColor,
+}: {
+  barWidth: number;
+  markerIndex: number;
+  position: number;
+  markerColor: string;
+}) {
+  // The desktop webview must not draw rules out of box-drawing glyphs.
+  if (useUiHost().kind === "desktop-web") {
+    return (
+      <Box
+        marginLeft={1}
+        marginRight={1}
+        width={barWidth}
+        height={1}
+        style={{ position: "relative", justifyContent: "center" }}
+      >
+        <Box style={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          height: "2px",
+          borderRadius: "1px",
+          backgroundColor: colors.border,
+        }} />
+        <Box style={{
+          position: "absolute",
+          left: `${position * 100}%`,
+          width: "8px",
+          height: "8px",
+          marginLeft: "-4px",
+          borderRadius: "50%",
+          backgroundColor: markerColor,
+        }} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box marginLeft={1} marginRight={1} width={barWidth} flexDirection="row">
+      <Text fg={colors.border}>{"\u2500".repeat(markerIndex)}</Text>
+      <Text fg={markerColor}>{"\u25cf"}</Text>
+      <Text fg={colors.border}>{"\u2500".repeat(Math.max(0, barWidth - markerIndex - 1))}</Text>
+    </Box>
+  );
 }
 
 export function CompactRangeBar({
@@ -65,11 +118,12 @@ export function CompactRangeBar({
         <Box width={endpointWidth} overflow="hidden">
           <Text fg={colors.textDim}>{lowText}</Text>
         </Box>
-        <Box marginLeft={1} marginRight={1} width={barWidth} flexDirection="row">
-          <Text fg={colors.border}>{"─".repeat(markerIndex)}</Text>
-          <Text fg={markerColor}>{"●"}</Text>
-          <Text fg={colors.border}>{"─".repeat(Math.max(0, barWidth - markerIndex - 1))}</Text>
-        </Box>
+        <RangeTrack
+          barWidth={barWidth}
+          markerIndex={markerIndex}
+          position={position}
+          markerColor={markerColor}
+        />
         <Box flexDirection="row" width={endpointWidth} justifyContent="flex-end" overflow="hidden">
           <Text fg={colors.textDim}>{highText}</Text>
         </Box>
@@ -178,33 +232,19 @@ export function SectionHeader({ title }: { title: string }) {
   );
 }
 
+const POSITION_COLUMNS: readonly PositionColumn[] = [
+  { key: "account", label: "Account", width: 0 },
+  { key: "qty", label: "Qty", width: 8, align: "right" },
+  { key: "avg", label: "Avg", width: 9, align: "right", minPaneWidth: 70 },
+  { key: "mark", label: "Mark", width: 9, align: "right", minPaneWidth: 70 },
+  { key: "cost", label: "Cost", width: 11, align: "right", minPaneWidth: 84 },
+  { key: "value", label: "Value", width: 11, align: "right" },
+  { key: "pnl", label: "P&L", width: 12, align: "right", color: (row) => priceColor(row.pnlValue ?? 0) },
+  { key: "ret", label: "Ret", width: 7, align: "right", color: (row) => priceColor(row.pnlValue ?? 0), minPaneWidth: 84 },
+];
+
 function createPositionColumns(width: number): PositionColumn[] {
-  const columns: PositionColumn[] = width >= 84
-    ? [
-        { key: "account", label: "Account", width: 0 },
-        { key: "qty", label: "Qty", width: 8, align: "right" },
-        { key: "avg", label: "Avg", width: 9, align: "right" },
-        { key: "mark", label: "Mark", width: 9, align: "right" },
-        { key: "cost", label: "Cost", width: 11, align: "right" },
-        { key: "value", label: "Value", width: 11, align: "right" },
-        { key: "pnl", label: "P&L", width: 12, align: "right", color: (row) => priceColor(row.pnlValue ?? 0) },
-        { key: "ret", label: "Ret", width: 7, align: "right", color: (row) => priceColor(row.pnlValue ?? 0) },
-      ]
-    : width >= 70
-      ? [
-          { key: "account", label: "Account", width: 0 },
-          { key: "qty", label: "Qty", width: 8, align: "right" },
-          { key: "avg", label: "Avg", width: 9, align: "right" },
-          { key: "mark", label: "Mark", width: 9, align: "right" },
-          { key: "value", label: "Value", width: 11, align: "right" },
-          { key: "pnl", label: "P&L", width: 12, align: "right", color: (row) => priceColor(row.pnlValue ?? 0) },
-        ]
-      : [
-          { key: "account", label: "Account", width: 0 },
-          { key: "qty", label: "Qty", width: 8, align: "right" },
-          { key: "value", label: "Value", width: 11, align: "right" },
-          { key: "pnl", label: "P&L", width: 12, align: "right", color: (row) => priceColor(row.pnlValue ?? 0) },
-        ];
+  const columns = POSITION_COLUMNS.filter((column) => width >= (column.minPaneWidth ?? 0)).map((column) => ({ ...column }));
   const fixedWidth = columns.reduce((sum, column) => sum + column.width, 0) + POSITION_COLUMN_GAP * (columns.length - 1);
   const accountColumn = columns[0]!;
   accountColumn.width = Math.max(8, width - fixedWidth);

--- a/src/plugins/builtin/ticker-detail/pane.tsx
+++ b/src/plugins/builtin/ticker-detail/pane.tsx
@@ -22,6 +22,7 @@ import {
   getTickerResearchPaneSettings,
   resolveLockedTabId,
 } from "./settings";
+import { TICKER_RESEARCH_BUILTIN_TABS } from "./research-tabs";
 import { useLiveStreamingSetting } from "../shared/live-streaming";
 import { useCloudAccessFooter } from "../shared/cloud-upgrade";
 import { CLOUD_QUOTE_DELAY_MINUTES } from "../shared/plan-access";
@@ -121,13 +122,15 @@ export function TickerResearchPane({ focused, width, height }: PaneProps) {
   const disabledPlugins = config.disabledPlugins;
   const registry = getSharedRegistry();
   const tickerResearchTabsSnapshot = useRegistryTickerResearchTabsSnapshot(registry);
+  // Hosts that render a pane without booting the plugin registry (the desktop
+  // screenshot renderer) would otherwise leave the body with no tabs at all.
   const tickerResearchTabs = useMemo<TickerResearchTabDef[]>(() => (
     registry
       ? [...registry.tickerResearchTabs.values()].filter((tab) => {
         const ownerId = registry.getTickerResearchTabPluginId?.(tab.id);
         return !ownerId || !disabledPlugins.includes(ownerId);
       })
-      : []
+      : TICKER_RESEARCH_BUILTIN_TABS
   ), [disabledPlugins, registry, tickerResearchTabsSnapshot]);
   const allTabs = buildVisibleTickerResearchTabs(tickerResearchTabs, ticker, financials, {
     config,

--- a/src/plugins/builtin/ticker-detail/research-tabs.ts
+++ b/src/plugins/builtin/ticker-detail/research-tabs.ts
@@ -1,0 +1,31 @@
+import type { TickerFinancials } from "../../../types/financials";
+import type { TickerResearchTabDef } from "../../../types/plugin";
+import { FinancialsResearchTab } from "./financials/pane";
+import { OverviewResearchTab } from "./overview/pane";
+
+function hasStatementFinancials(financials: TickerFinancials | null | undefined): boolean {
+  return (financials?.annualStatements.length ?? 0) > 0 || (financials?.quarterlyStatements.length ?? 0) > 0;
+}
+
+/**
+ * Tabs this module owns. They are registered through `setup()` like any other
+ * contribution, but the pane also falls back to them when it renders in a host
+ * without a plugin registry (the desktop screenshot renderer), where an
+ * unresolved registry would otherwise leave the body completely empty.
+ */
+export const TICKER_RESEARCH_BUILTIN_TABS: TickerResearchTabDef[] = [
+  {
+    id: "overview",
+    name: "Overview",
+    order: 10,
+    component: OverviewResearchTab,
+    isVisible: ({ ticker }) => !!ticker,
+  },
+  {
+    id: "financials",
+    name: "Financials",
+    order: 20,
+    component: FinancialsResearchTab,
+    isVisible: ({ financials }) => hasStatementFinancials(financials),
+  },
+];

--- a/src/plugins/builtin/treasury-auctions/cache.ts
+++ b/src/plugins/builtin/treasury-auctions/cache.ts
@@ -1,12 +1,12 @@
 import type { ConnectionHealthRegistry } from "../../../core/connection-health";
 import type { PluginPersistence } from "../../../types/plugin";
-import { fetchTreasuryAuctions } from "./client";
+import { AUCTION_HISTORY_DAYS, fetchTreasuryAuctions } from "./client";
 import type { TreasuryAuction } from "./types";
 
 const CACHE_KIND = "treasury-auctions";
-const CACHE_KEY = "recent";
 const CACHE_SOURCE = "treasury-fiscal-data";
-const CACHE_SCHEMA_VERSION = 1;
+/** 2: rows carry a CUSIP, so reopenings no longer share an id with the original. */
+const CACHE_SCHEMA_VERSION = 2;
 export const TREASURY_FISCAL_DATA_CONNECTION_ID = "treasury-fiscal-data";
 /**
  * Auctions settle a few times a week and results never change once published,
@@ -27,7 +27,11 @@ export interface TreasuryAuctionsResult {
 
 let persistence: PluginPersistence | null = null;
 let connectionHealth: ConnectionHealthRegistry | null = null;
-let activeFetch: Promise<TreasuryAuctionsResult> | null = null;
+const activeFetches = new Map<number, Promise<TreasuryAuctionsResult>>();
+
+function cacheKey(sinceDays: number): string {
+  return `recent:${sinceDays}`;
+}
 
 export function attachTreasuryAuctionsPersistence(
   next: PluginPersistence,
@@ -40,11 +44,11 @@ export function attachTreasuryAuctionsPersistence(
 export function resetTreasuryAuctionsPersistence(): void {
   persistence = null;
   connectionHealth = null;
-  activeFetch = null;
+  activeFetches.clear();
 }
 
-function readCache(options?: { allowExpired?: boolean }): TreasuryAuctionsResult | null {
-  const record = persistence?.getResource<TreasuryAuction[]>(CACHE_KIND, CACHE_KEY, {
+function readCache(sinceDays: number, options?: { allowExpired?: boolean }): TreasuryAuctionsResult | null {
+  const record = persistence?.getResource<TreasuryAuction[]>(CACHE_KIND, cacheKey(sinceDays), {
     sourceKey: CACHE_SOURCE,
     schemaVersion: CACHE_SCHEMA_VERSION,
     allowExpired: options?.allowExpired,
@@ -60,15 +64,17 @@ function readCache(options?: { allowExpired?: boolean }): TreasuryAuctionsResult
  */
 export async function loadTreasuryAuctions(
   force = false,
-  loader: () => Promise<TreasuryAuction[]> = fetchTreasuryAuctions,
+  loader: (sinceDays: number) => Promise<TreasuryAuction[]> = fetchTreasuryAuctions,
+  sinceDays: number = AUCTION_HISTORY_DAYS,
 ): Promise<TreasuryAuctionsResult> {
-  const cached = readCache();
+  const cached = readCache(sinceDays);
   if (!force && cached && !cached.stale) return cached;
-  if (activeFetch) return activeFetch;
+  const inFlight = activeFetches.get(sinceDays);
+  if (inFlight) return inFlight;
 
-  const fallback = cached ?? readCache({ allowExpired: true });
-  const request = () => loader();
-  activeFetch = (connectionHealth?.hasSource(TREASURY_FISCAL_DATA_CONNECTION_ID)
+  const fallback = cached ?? readCache(sinceDays, { allowExpired: true });
+  const request = () => loader(sinceDays);
+  const fetchPromise = (connectionHealth?.hasSource(TREASURY_FISCAL_DATA_CONNECTION_ID)
     ? connectionHealth.track(TREASURY_FISCAL_DATA_CONNECTION_ID, "fetchAuctions", request)
     : request())
     .then((auctions) => {
@@ -79,7 +85,7 @@ export async function loadTreasuryAuctions(
         if (fallback) return { ...fallback, stale: true };
         throw new Error("Treasury Fiscal Data returned no auctions");
       }
-      persistence?.setResource(CACHE_KIND, CACHE_KEY, auctions, {
+      persistence?.setResource(CACHE_KIND, cacheKey(sinceDays), auctions, {
         sourceKey: CACHE_SOURCE,
         schemaVersion: CACHE_SCHEMA_VERSION,
         cachePolicy: CACHE_POLICY,
@@ -91,7 +97,8 @@ export async function loadTreasuryAuctions(
       throw error;
     })
     .finally(() => {
-      activeFetch = null;
+      if (activeFetches.get(sinceDays) === fetchPromise) activeFetches.delete(sinceDays);
     });
-  return activeFetch;
+  activeFetches.set(sinceDays, fetchPromise);
+  return fetchPromise;
 }

--- a/src/plugins/builtin/treasury-auctions/client.test.ts
+++ b/src/plugins/builtin/treasury-auctions/client.test.ts
@@ -9,6 +9,7 @@ import {
 
 // Shape captured from the live auctions_query endpoint on 2026-08-18.
 const LIVE_NOTE_ROW = {
+  cusip: "91282CNH3",
   security_type: "Note",
   security_term: "10-Year",
   auction_date: "2026-08-12",
@@ -30,7 +31,8 @@ describe("normalizeAuction", () => {
   test("parses a live note row into numbers", () => {
     const auction = normalizeAuction(LIVE_NOTE_ROW);
     expect(auction).toMatchObject({
-      id: "Note|2026-08-12|10-Year",
+      id: "91282CNH3|2026-08-12",
+      cusip: "91282CNH3",
       secType: "Note",
       securityTerm: "10-Year",
       highYield: 4.683,
@@ -77,9 +79,20 @@ describe("parseTreasuryAuctionsPayload", () => {
     expect(auctions.map((auction) => auction.secType)).toEqual(["Note", "Bill"]);
   });
 
-  test("collapses repeated (type, date, term) rows", () => {
+  test("collapses a row the payload repeats verbatim", () => {
     const auctions = parseTreasuryAuctionsPayload({ data: [LIVE_NOTE_ROW, { ...LIVE_NOTE_ROW }] });
     expect(auctions).toHaveLength(1);
+  });
+
+  test("keeps two same-day auctions of the same type and term", () => {
+    // A reopening and a new issue share (type, date, term) but never a CUSIP.
+    const auctions = parseTreasuryAuctionsPayload({
+      data: [
+        { ...LIVE_NOTE_ROW, cusip: "91282CAB1" },
+        { ...LIVE_NOTE_ROW, cusip: "91282CZZ9" },
+      ],
+    });
+    expect(auctions.map((entry) => entry.cusip)).toEqual(["91282CAB1", "91282CZZ9"]);
   });
 
   test("returns nothing for a body that is not a data array", () => {

--- a/src/plugins/builtin/treasury-auctions/client.ts
+++ b/src/plugins/builtin/treasury-auctions/client.ts
@@ -6,6 +6,7 @@ const BASE_URL =
 
 /** The endpoint returns 114 columns per row; ask only for what the pane renders. */
 const FIELDS = [
+  "cusip",
   "security_type",
   "security_term",
   "auction_date",
@@ -23,7 +24,7 @@ const FIELDS = [
   "offering_amt",
 ].join(",");
 
-const AUCTION_HISTORY_DAYS = 120;
+export const AUCTION_HISTORY_DAYS = 120;
 const PAGE_SIZE = 300;
 /** 120 days is ~150 auctions, one page; the bound only exists so bad metadata cannot loop. */
 const MAX_PAGES = 5;
@@ -72,10 +73,14 @@ export function normalizeAuction(raw: unknown): TreasuryAuction | null {
   const secType = (record.security_type ?? "").trim();
   const auctionDate = (record.auction_date ?? "").trim();
   const securityTerm = (record.security_term ?? "").trim();
+  const cusip = (record.cusip ?? "").trim();
   if (!secType || !auctionDate) return null;
 
   return {
-    id: `${secType}|${auctionDate}|${securityTerm}`,
+    // A reopening reuses its original CUSIP but is auctioned on its own date,
+    // so CUSIP plus date is what keeps reopenings from collapsing into one row.
+    id: cusip ? `${cusip}|${auctionDate}` : `${secType}|${auctionDate}|${securityTerm}`,
+    cusip: cusip || null,
     secType,
     securityTerm: securityTerm || "—",
     auctionDate,
@@ -101,7 +106,6 @@ export function parseTreasuryAuctionsPayload(body: unknown): TreasuryAuction[] {
   const auctions: TreasuryAuction[] = [];
   for (const raw of data) {
     const auction = normalizeAuction(raw);
-    // Reopenings can repeat a (type, date, term) triple; the first wins.
     if (!auction || seen.has(auction.id)) continue;
     seen.add(auction.id);
     auctions.push(auction);

--- a/src/plugins/builtin/treasury-auctions/index.tsx
+++ b/src/plugins/builtin/treasury-auctions/index.tsx
@@ -1,3 +1,4 @@
+import type { PaneSettingsDef } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import {
   attachTreasuryAuctionsPersistence,
@@ -8,6 +9,26 @@ import { TreasuryAuctionsPane } from "./pane";
 import { TREASURY_AUCTIONS_PANE_ID } from "./types";
 
 let disposeConnection: (() => void) | null = null;
+
+function treasuryAuctionsSettings(): PaneSettingsDef {
+  return {
+    title: "Treasury Auctions Settings",
+    fields: [
+      {
+        key: "historyDays",
+        label: "History window",
+        description: "How far back auction results are requested.",
+        type: "select",
+        options: [
+          { value: "30", label: "30 days" },
+          { value: "90", label: "90 days" },
+          { value: "120", label: "120 days" },
+          { value: "365", label: "1 year" },
+        ],
+      },
+    ],
+  };
+}
 
 export const treasuryAuctionsModule: PluginModule = {
   setup(ctx) {
@@ -37,6 +58,7 @@ export const treasuryAuctionsModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 92, height: 28 },
+      settings: treasuryAuctionsSettings(),
     },
   ],
 

--- a/src/plugins/builtin/treasury-auctions/model.ts
+++ b/src/plugins/builtin/treasury-auctions/model.ts
@@ -1,6 +1,16 @@
 import type { DataTableColumn } from "../../../components";
 import type { SortDirection } from "../../../utils/sort-values";
+import { AUCTION_HISTORY_DAYS } from "./client";
 import type { TreasuryAuction } from "./types";
+
+/** Windows the Fiscal Data query supports without paging past MAX_PAGES. */
+export const AUCTION_HISTORY_WINDOWS = [30, 90, 120, 365] as const;
+
+/** Pane settings arrive as unvalidated strings, so anything unknown falls back. */
+export function auctionHistoryDays(settings: Record<string, unknown> | undefined): number {
+  const value = Number(settings?.historyDays);
+  return (AUCTION_HISTORY_WINDOWS as readonly number[]).includes(value) ? value : AUCTION_HISTORY_DAYS;
+}
 
 export type AuctionColumnId = "date" | "type" | "term" | "rate" | "btc" | "indirect" | "size";
 

--- a/src/plugins/builtin/treasury-auctions/pane.test.tsx
+++ b/src/plugins/builtin/treasury-auctions/pane.test.tsx
@@ -122,7 +122,7 @@ async function emitKeypress(event: { name?: string; sequence?: string }) {
 }
 
 describe("TreasuryAuctionsPane", () => {
-  test("renders auction metrics and marks announced auctions as pending", async () => {
+  test("renders auction metrics and keeps one placeholder for unpublished results", async () => {
     seedCache();
     testSetup = await testRender(<Harness />, { width: 92, height: 20 });
     await renderSettled();
@@ -133,8 +133,10 @@ describe("TreasuryAuctionsPane", () => {
     expect(frame).toContain("2.86");
     // Indirect share is derived, not reported.
     expect(frame).toContain("48.6%");
-    // The 20-Year is announced but has no published results yet.
-    expect(frame).toContain("pending");
+    // The 20-Year is announced but unpublished: every metric cell reads the
+    // same placeholder the reported-but-missing cells use.
+    expect(frame).toContain("20-Year");
+    expect(frame).not.toContain("pending");
   });
 
   test("opens a detail view for the selected auction", async () => {

--- a/src/plugins/builtin/treasury-auctions/pane.tsx
+++ b/src/plugins/builtin/treasury-auctions/pane.tsx
@@ -19,9 +19,12 @@ import { isPlainKey } from "../../../utils/keyboard";
 import { formatRelativeAge } from "../../../utils/relative-time";
 import { isPlainArrowUp, stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
 import { cycleSortPreference } from "../../../utils/sort-values";
+import { usePaneInstance } from "../../../state/app/context";
+import { useAutoRefresh } from "../shared/auto-refresh";
 import { loadTreasuryAuctions } from "./cache";
 import {
   AUCTION_FILTERS,
+  auctionHistoryDays,
   AUCTION_SORT_COLUMN_IDS,
   DEFAULT_AUCTION_SORT,
   buildAuctionColumns,
@@ -42,10 +45,6 @@ import {
   type LoadStatus,
   type TreasuryAuction,
 } from "./types";
-
-// The poll is cheap because the cache decides whether it becomes a request;
-// only [r] forces the endpoint.
-const AUTO_REFRESH_MS = 15 * 60_000;
 
 function formatAuctionDate(value: string, withYear = false): string {
   const timestamp = Date.parse(`${value}T00:00:00Z`);
@@ -101,7 +100,12 @@ function renderAuctionCell(
 
   switch (column.id) {
     case "date":
-      return { text: formatAuctionDate(auction.auctionDate), color: dimmed };
+      // Announced auctions have no results yet; every metric cell reads "—",
+      // so the date carries the distinction instead of a second placeholder.
+      return {
+        text: formatAuctionDate(auction.auctionDate),
+        color: rowState.selected ? colors.selectedText : isPendingAuction(auction) ? colors.warning : colors.textDim,
+      };
     case "type":
       return {
         text: auction.secType,
@@ -111,7 +115,6 @@ function renderAuctionCell(
     case "term":
       return { text: auction.securityTerm, color: selected ?? colors.text };
     case "rate":
-      if (isPendingAuction(auction)) return { text: "pending", color: dimmed };
       return { text: formatRate(rateValue(auction)), color: selected ?? colors.textBright };
     case "btc":
       return { text: formatRatio(auction.bidToCoverRatio), color: selected ?? colors.text };
@@ -170,6 +173,7 @@ function TreasuryAuctionDetail({ auction, width }: { auction: TreasuryAuction; w
 }
 
 export function TreasuryAuctionsPane({ focused, width, height }: PaneProps) {
+  const historyDays = auctionHistoryDays(usePaneInstance()?.settings);
   const [auctions, setAuctions] = useState<TreasuryAuction[]>([]);
   const [status, setStatus] = useState<LoadStatus>("idle");
   const [error, setError] = useState<string | null>(null);
@@ -196,7 +200,7 @@ export function TreasuryAuctionsPane({ focused, width, height }: PaneProps) {
     const generation = fetchGenRef.current;
     setStatus((current) => (current === "loaded" ? "loaded" : "loading"));
     setError(null);
-    loadTreasuryAuctions(force)
+    loadTreasuryAuctions(force, undefined, historyDays)
       .then((result) => {
         if (fetchGenRef.current !== generation) return;
         setAuctions(result.auctions);
@@ -209,13 +213,12 @@ export function TreasuryAuctionsPane({ focused, width, height }: PaneProps) {
         setError(loadError instanceof Error ? loadError.message : String(loadError));
         setStatus("error");
       });
-  }, []);
+  }, [historyDays]);
 
-  useEffect(() => {
-    load(false);
-    const interval = setInterval(() => load(false), AUTO_REFRESH_MS);
-    return () => clearInterval(interval);
-  }, [load]);
+  useEffect(() => { load(false); }, [load]);
+  // The cache decides whether a tick becomes a request; only [r] forces it.
+  const refresh = useCallback(() => load(false), [load]);
+  useAutoRefresh(stale ? null : fetchedAt, refresh);
 
   const rows = useMemo(
     () => visibleAuctions(auctions, { filter, query: searchQuery, sort: sortPreference }),
@@ -302,7 +305,7 @@ export function TreasuryAuctionsPane({ focused, width, height }: PaneProps) {
     }
     return {
       info,
-      hints: detailOpen
+      hints: detailOpen || auctions.length === 0
         ? []
         : [
           { id: "search", key: "/", label: "search", onPress: focusSearch },
@@ -311,6 +314,7 @@ export function TreasuryAuctionsPane({ focused, width, height }: PaneProps) {
     };
   }, [
     activeFilterLabel,
+    auctions.length,
     cycleFilter,
     detailOpen,
     error,

--- a/src/plugins/builtin/treasury-auctions/types.ts
+++ b/src/plugins/builtin/treasury-auctions/types.ts
@@ -6,8 +6,10 @@ export const TREASURY_AUCTIONS_PANE_ID = "treasury-auctions";
  * report, so numbers are parsed once here.
  */
 export interface TreasuryAuction {
-  /** security_type | auction_date | security_term */
+  /** cusip | auction_date, or security_type | auction_date | security_term when the feed omits a CUSIP. */
   id: string;
+  /** Security identifier; a reopening repeats the original issue's CUSIP. */
+  cusip: string | null;
   /** "Bill", "Note", "Bond", "CMB", "FRN", "TIPS". */
   secType: string;
   /** "4-Week", "2-Year", "29-Year 6-Month". */
@@ -36,6 +38,7 @@ export interface TreasuryAuction {
 
 /** Raw shape returned by the Fiscal Data auctions_query endpoint. */
 export interface TreasuryAuctionRaw {
+  cusip?: string;
   security_type?: string;
   security_term?: string;
   auction_date?: string;

--- a/src/plugins/builtin/tv/pane.tsx
+++ b/src/plugins/builtin/tv/pane.tsx
@@ -55,6 +55,7 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
   const [muted, setMuted] = useState(true);
   const mediaRef = useRef<MediaSurfaceHandle | null>(null);
   const terminalAutoPlayedRef = useRef<string | null>(null);
+  const recoveredStreamRef = useRef<string | null>(null);
   const generationRef = useRef(0);
   const channel = getTvChannel(channelId);
 
@@ -112,6 +113,27 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
       generationRef.current += 1;
     };
   }, [load]);
+
+  // Resolved YouTube manifests expire within minutes, so an open pane re-resolves
+  // shortly before the current one dies instead of playing into an error.
+  useEffect(() => {
+    if (!stream) return;
+    const delay = Math.max(5_000, stream.expiresAt - 60_000 - Date.now());
+    const timer = setTimeout(() => {
+      void load(true);
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [load, stream]);
+
+  // A dead manifest surfaces as a media error; re-resolve once per stream so a
+  // silent expiry recovers without the user pressing anything.
+  const handlePlaybackError = useCallback((message: string) => {
+    setPlaybackError(message);
+    const streamKey = stream ? `${stream.sourceId}:${stream.videoId}` : null;
+    if (!streamKey || recoveredStreamRef.current === streamKey) return;
+    recoveredStreamRef.current = streamKey;
+    void load(true);
+  }, [load, stream]);
 
   useEffect(() => {
     persistChannelSelection(channelId);
@@ -241,7 +263,7 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
         onPress: () => { void renderer.openExternal(channel.channelUrl); },
       },
     ],
-  }), [channel.channelUrl, error, loading, muted, paneId, playbackError, playbackState, renderer, status, stream, toggleMute, togglePlayback]);
+  }), [channel.channelUrl, error, loading, muted, paneId, playbackError, playbackState, refresh, renderer, status, stream, toggleMute, togglePlayback]);
 
   const channelTabs = useMemo(() => TV_CHANNELS.map((item, index) => ({
     label: `${index + 1} ${item.name}`,
@@ -283,7 +305,7 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
           flexGrow={1}
           onPlaybackStateChange={setPlaybackState}
           onMutedChange={setMuted}
-          onError={setPlaybackError}
+          onError={handlePlaybackError}
         >
           <Box flexGrow={1} justifyContent="center" alignItems="center">
             <Text fg={colors.warning}>{playbackError ?? "Live video unavailable."}</Text>

--- a/src/plugins/builtin/volatility/index.test.tsx
+++ b/src/plugins/builtin/volatility/index.test.tsx
@@ -7,6 +7,8 @@ import {
   type FredSeriesCacheEntry,
 } from "../../../data/fred-series";
 import { testRender } from "../../../renderers/opentui/test-utils";
+import { AppContext, createInitialState } from "../../../state/app/context";
+import { createDefaultConfig } from "../../../types/config";
 import { VolatilityPane } from "./index";
 
 let setup: Awaited<ReturnType<typeof testRender>> | undefined;
@@ -59,10 +61,13 @@ afterEach(async () => {
 
 describe("VolatilityPane", () => {
   test("selects volatility tenors with keyboard", async () => {
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-volatility-test"));
     setup = await testRender(
-      <PaneFooterProvider>
-        {() => <VolatilityPane paneId="volatility:test" paneType="volatility-term-structure" focused width={76} height={23} />}
-      </PaneFooterProvider>,
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <PaneFooterProvider>
+          {() => <VolatilityPane paneId="volatility:test" paneType="volatility-term-structure" focused width={76} height={23} />}
+        </PaneFooterProvider>
+      </AppContext>,
       { width: 76, height: 23 },
     );
     await settle();
@@ -73,10 +78,27 @@ describe("VolatilityPane", () => {
     expect(frame).toContain("3M premium +3.00 pts");
     expect(frame).not.toContain("contango");
 
+    // Emitting the key directly, then flushing more than one frame: a single
+    // render can capture the pre-selection frame when the suite runs loaded.
     await act(async () => {
-      setup!.mockInput.pressArrow("right");
+      setup!.renderer.keyInput.emit("keypress", {
+        name: "right",
+        sequence: "\u001B[C",
+        ctrl: false,
+        meta: false,
+        option: false,
+        shift: false,
+        eventType: "press",
+        repeated: false,
+        defaultPrevented: false,
+        propagationStopped: false,
+        preventDefault: () => {},
+        stopPropagation: () => {},
+      } as never);
+      await setup!.renderOnce();
       await setup!.renderOnce();
     });
+    await act(async () => { await setup!.renderOnce(); });
     frame = setup.captureCharFrame();
     expect(frame).toMatch(/▸\s+VIX 3M\s+19\.00/);
 

--- a/src/plugins/builtin/volatility/index.tsx
+++ b/src/plugins/builtin/volatility/index.tsx
@@ -2,10 +2,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, TextAttributes } from "../../../ui";
 import { useShortcut } from "../../../react/input";
 import {
+  Button,
+  EmptyState,
+  Spinner,
   StaticChartSurface,
   usePaneFooter,
   type PaneFooterSegment,
 } from "../../../components";
+import { useAutoRefresh } from "../shared/auto-refresh";
 import { ListView } from "../../../components/ui/list-view";
 import type { ProjectedChartPoint } from "../../../components/chart/core/data";
 import { resolveChartPalette } from "../../../components/chart/core/renderer";
@@ -70,6 +74,7 @@ export function VolatilityPane({ paneId, focused, width, height }: PaneProps) {
   const [stale, setStale] = useState(initial?.stale ?? false);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState(0);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
   const generation = useRef(0);
 
   const load = useCallback(async (force = false) => {
@@ -81,6 +86,7 @@ export function VolatilityPane({ paneId, focused, width, height }: PaneProps) {
       if (generation.current !== current) return;
       setData(result.data);
       setStale(result.stale);
+      if (!result.stale) setLastUpdated(Date.now());
       setError(result.errors[0] ?? null);
     } catch (loadError) {
       if (generation.current !== current) return;
@@ -93,6 +99,10 @@ export function VolatilityPane({ paneId, focused, width, height }: PaneProps) {
   useEffect(() => { void load(false); }, [load]);
 
   const reload = useCallback(() => { void load(true); }, [load]);
+  const refresh = useCallback(() => { void load(false); }, [load]);
+  // The shared FRED cache decides whether a tick reaches the network, so daily
+  // closes follow the global cadence without refetching unchanged data.
+  useAutoRefresh(lastUpdated, refresh);
   useShortcut((event) => {
     if (!focused) return;
     if (event.name === "r") {
@@ -111,52 +121,52 @@ export function VolatilityPane({ paneId, focused, width, height }: PaneProps) {
       parts: [{ text: data.termState.toUpperCase(), tone: data.termState === "inverted" ? "warning" as const : "value" as const, bold: true }],
     }] : []),
     ...(data?.termState === "partial" ? [{ id: "partial", parts: [{ text: "PARTIAL", tone: "warning" as const, bold: true }] }] : []),
+    ...(data ? [{ id: "delayed", parts: [{ text: "delayed", tone: "muted" as const }] }] : []),
     ...(stale ? [{ id: "stale", parts: [{ text: "STALE", tone: "warning" as const }] }] : []),
     ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
     ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
-  ], [data?.termState, error, loading, stale]);
+  ], [data, error, loading, stale]);
   usePaneFooter(paneId, () => ({ info: footerInfo }), [footerInfo, paneId]);
 
   if (!data && loading) {
-    return <Box width={width} height={height} justifyContent="center" alignItems="center"><Text fg={colors.textMuted}>Loading volatility data...</Text></Box>;
+    return (
+      <Box width={width} height={height} justifyContent="center" alignItems="center">
+        <Spinner label="Loading volatility data..." />
+      </Box>
+    );
   }
   if (!data) {
-    return <Box width={width} height={height} padding={1}><Text fg={colors.negative}>{error ?? "Volatility data unavailable"}</Text></Box>;
+    return (
+      <Box width={width} height={height} padding={1} flexDirection="column" gap={1}>
+        <EmptyState title="Volatility data unavailable." message={error ?? undefined} />
+      </Box>
+    );
   }
 
   const selectedMetric = data.metrics[selected] ?? data.metrics[0]!;
   return (
     <Box flexDirection="column" width={width} height={height} paddingBottom={1}>
-          <Box paddingX={1}><Text fg={colors.textMuted}>FRED · daily close · delayed</Text></Box>
+          <Box paddingX={1}><Text fg={colors.textMuted}>FRED · daily close</Text></Box>
           <Box flexDirection="row" paddingX={1} marginTop={1}>
             <Text fg={colors.textDim}>3M/30D </Text>
             <Text fg={termColor(data.termState)} attributes={TextAttributes.BOLD}>{formatValue(data.ratio)}</Text>
             <Text fg={colors.textDim}>{`  ${slopeLabel(data.slope)}  as of ${data.termDate ?? "--"}`}</Text>
           </Box>
-          <Box marginTop={1} height={2}>
+          <Box marginTop={1} paddingX={1}><Text fg={colors.textDim}>{selectedMetric.title}</Text></Box>
+          <Box height={2}>
             <ListView
               items={data.metrics.map((metric) => ({
                 id: metric.seriesId,
-                label: `${metric.label.padEnd(8)} ${formatValue(metric.value).padStart(7)}   ${metric.tenor} · ${metric.date ?? "--"}`,
+                label: metric.label,
+                detail: `${formatValue(metric.value)}   ${metric.tenor} · ${metric.date ?? "--"}`,
               }))}
               selectedIndex={selected}
               onSelect={setSelected}
-              renderRow={(item, state, index) => (
-                <Text
-                  fg={state.selected ? colors.selectedText : colors.text}
-                  attributes={state.selected ? TextAttributes.BOLD : 0}
-                  onMouseDown={() => setSelected(index)}
-                  onMouseUp={() => setSelected(index)}
-                >
-                  {state.selected ? "▸ " : "  "}{item.label}
-                </Text>
-              )}
               height={2}
               surface="plain"
               remoteLabel="Volatility tenors"
             />
           </Box>
-          <Box paddingX={1}><Text fg={colors.textDim}>{selectedMetric.title}</Text></Box>
           <TermChart data={data} width={width} height={Math.floor(height * 0.35)} />
     </Box>
   );

--- a/src/plugins/builtin/world-indices/footer.ts
+++ b/src/plugins/builtin/world-indices/footer.ts
@@ -1,4 +1,4 @@
-import { usePaneFooter } from "../../../components";
+import { usePaneFooter, type PaneFooterSegment } from "../../../components";
 import { isPlainKey } from "../../../utils/keyboard";
 import { useShortcut } from "../../../react/input";
 import {
@@ -7,8 +7,28 @@ import {
   type BoardQuoteMap,
 } from "../shared/use-quote-board";
 
+const ERROR_MESSAGE_MAX_LENGTH = 48;
+
+/** The reason a board is empty, taken from the per-symbol errors the board records. */
+export function boardErrorMessage(quotes: BoardQuoteMap): string | null {
+  let total = 0;
+  let unavailable = 0;
+  let message: string | null = null;
+  for (const state of quotes.values()) {
+    total += 1;
+    if (state.quote || state.loading) continue;
+    unavailable += 1;
+    message ??= state.error;
+  }
+  if (total === 0 || unavailable < total || !message) return null;
+  return message.length > ERROR_MESSAGE_MAX_LENGTH
+    ? `${message.slice(0, ERROR_MESSAGE_MAX_LENGTH - 1)}…`
+    : message;
+}
+
 export function useWorldIndicesFooter(quotes: BoardQuoteMap, onRefresh: () => void, focused: boolean) {
   const status = quoteBoardStatus(quotes);
+  const errorMessage = boardErrorMessage(quotes);
 
   useShortcut((event) => {
     if (!focused || !isPlainKey(event, "r")) return;
@@ -18,7 +38,11 @@ export function useWorldIndicesFooter(quotes: BoardQuoteMap, onRefresh: () => vo
 
   usePaneFooter(
     "world-indices",
-    () => ({ info: quoteBoardFooterInfo(status) }),
-    [focused, onRefresh, status.latestTs, status.loading, status.stale, status.unavailable],
+    () => {
+      const info: PaneFooterSegment[] = quoteBoardFooterInfo(status);
+      if (errorMessage) info.push({ id: "reason", parts: [{ text: errorMessage, tone: "warning" }] });
+      return { info };
+    },
+    [errorMessage, focused, onRefresh, status.latestTs, status.loading, status.stale, status.unavailable],
   );
 }

--- a/src/plugins/builtin/world-indices/index.tsx
+++ b/src/plugins/builtin/world-indices/index.tsx
@@ -3,9 +3,10 @@ import { DataTableView } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
-import { usePluginTickerActions } from "../../runtime";
+import { useAppSelector, usePaneSettingValue } from "../../../state/app/context";
+import { useAssetData, usePluginTickerActions } from "../../runtime";
 import { useQuoteBoard } from "../shared/use-quote-board";
-import { WORLD_INDICES, REGION_LABELS, getIndicesByRegion } from "./indices";
+import { WORLD_INDICES, REGION_LABELS, getIndicesByRegion, resolveIndexEntries } from "./indices";
 import { useWorldIndicesFooter } from "./footer";
 import {
   buildFlatRows,
@@ -17,19 +18,29 @@ import {
 import {
   createWorldIndexColumns,
   renderWorldIndexCell,
+  usesSessionText,
   type WorldIndexColumn,
 } from "./table";
 
-const REFRESH_INTERVAL_MS = 60_000;
-const WORLD_INDEX_SYMBOLS = WORLD_INDICES.map((entry) => entry.symbol);
+/** Stable identity: a fresh literal here would remount the board every render. */
+const NO_SAVED_SYMBOLS: string[] = [];
 
 function WorldIndicesPane({ focused, width, height }: PaneProps) {
   const { pinTicker } = usePluginTickerActions();
-  const { quotes, refresh } = useQuoteBoard(WORLD_INDEX_SYMBOLS, REFRESH_INTERVAL_MS);
+  const dataProvider = useAssetData();
+  const [savedSymbols] = usePaneSettingValue<string[]>("symbols", NO_SAVED_SYMBOLS);
+  const entries = useMemo(() => resolveIndexEntries(savedSymbols), [savedSymbols]);
+  const symbols = useMemo(() => entries.map((entry) => entry.symbol), [entries]);
+  // One cadence, the one the user configured, instead of a private 60s timer.
+  const refreshIntervalMinutes = useAppSelector((state) => state.config.refreshIntervalMinutes);
+  const { quotes, refresh } = useQuoteBoard(
+    symbols,
+    Math.max(1, refreshIntervalMinutes || 1) * 60_000,
+  );
   const [selectedSymbol, setSelectedSymbol] = useState<string | null>(null);
   const [sortPreference, setSortPreference] = useState<WorldIndexSortPreference>(DEFAULT_SORT_PREFERENCE);
 
-  const indicesByRegion = useMemo(() => getIndicesByRegion(), []);
+  const indicesByRegion = useMemo(() => getIndicesByRegion(entries), [entries]);
   const flatRows = useMemo(
     () => buildFlatRows(indicesByRegion, sortPreference, quotes),
     [indicesByRegion, quotes, sortPreference],
@@ -65,14 +76,15 @@ function WorldIndicesPane({ focused, width, height }: PaneProps) {
 
   const columns = useMemo<WorldIndexColumn[]>(() => createWorldIndexColumns(width), [width]);
 
+  const sessionText = usesSessionText(width);
   const renderCell = useCallback((
     row: WorldIndexTableRow,
     column: WorldIndexColumn,
     _index: number,
     rowState: { selected: boolean },
   ) => {
-    return renderWorldIndexCell(row, column, rowState, quotes);
-  }, [quotes]);
+    return renderWorldIndexCell(row, column, rowState, quotes, { sessionText });
+  }, [quotes, sessionText]);
 
   useWorldIndicesFooter(quotes, refresh, focused);
 
@@ -92,7 +104,7 @@ function WorldIndicesPane({ focused, width, height }: PaneProps) {
       rootWidth={width}
       rootHeight={height}
       columns={columns}
-      items={flatRows}
+      items={dataProvider ? flatRows : []}
       sortColumnId={sortPreference.columnId}
       sortDirection={sortPreference.direction}
       onHeaderClick={handleHeaderClick}
@@ -101,7 +113,7 @@ function WorldIndicesPane({ focused, width, height }: PaneProps) {
         ? { text: REGION_LABELS[row.region] }
         : null}
       renderCell={renderCell}
-      emptyStateTitle="No indices configured."
+      emptyStateTitle="No market data provider connected."
     />
   );
 }
@@ -115,7 +127,26 @@ export const worldIndicesModule: PluginModule = {
       component: WorldIndicesPane,
       defaultPosition: "right",
       defaultMode: "floating",
-      defaultFloatingSize: { width: 72, height: 32 },
+      defaultFloatingSize: { width: 96, height: 32 },
+      // Resolved per open so the dialog shows the full board until the user
+      // saves a narrower selection.
+      settings: (context) => ({
+        title: "World Indices Settings",
+        values: {
+          symbols: resolveIndexEntries(context.settings.symbols as string[] | undefined)
+            .map((entry) => entry.symbol),
+        },
+        fields: [{
+          key: "symbols",
+          label: "Indices",
+          type: "ordered-multi-select",
+          options: WORLD_INDICES.map((entry) => ({
+            value: entry.symbol,
+            label: entry.shortName,
+            description: entry.name,
+          })),
+        }],
+      }),
     },
   ],
 

--- a/src/plugins/builtin/world-indices/indices.ts
+++ b/src/plugins/builtin/world-indices/indices.ts
@@ -44,10 +44,19 @@ export const REGION_LABELS: Record<IndexEntry["region"], string> = {
 
 export const REGION_ORDER: IndexEntry["region"][] = ["americas", "europe", "asia-pacific", "other"];
 
-export function getIndicesByRegion(): Map<IndexEntry["region"], IndexEntry[]> {
+export function getIndicesByRegion(entries: readonly IndexEntry[] = WORLD_INDICES): Map<IndexEntry["region"], IndexEntry[]> {
   const map = new Map<IndexEntry["region"], IndexEntry[]>();
   for (const region of REGION_ORDER) {
-    map.set(region, WORLD_INDICES.filter((entry) => entry.region === region));
+    map.set(region, entries.filter((entry) => entry.region === region));
   }
   return map;
+}
+
+/** The saved index selection, falling back to the full board when it is unusable. */
+export function resolveIndexEntries(saved?: readonly string[]): IndexEntry[] {
+  const bySymbol = new Map(WORLD_INDICES.map((entry) => [entry.symbol, entry]));
+  const resolved = (saved ?? [])
+    .map((symbol) => bySymbol.get(symbol))
+    .filter((entry): entry is IndexEntry => !!entry);
+  return resolved.length > 0 ? resolved : [...WORLD_INDICES];
 }

--- a/src/plugins/builtin/world-indices/model.ts
+++ b/src/plugins/builtin/world-indices/model.ts
@@ -7,7 +7,14 @@ export type WorldIndexTableRow =
   | { type: "header"; region: IndexEntry["region"] }
   | { type: "row"; entry: IndexEntry };
 
-export type WorldIndexColumnId = "status" | "symbol" | "name" | "price" | "changePercent";
+export type WorldIndexColumnId =
+  | "status"
+  | "symbol"
+  | "name"
+  | "price"
+  | "change"
+  | "changePercent"
+  | "time";
 
 export interface WorldIndexSortPreference {
   columnId: WorldIndexColumnId | null;
@@ -44,8 +51,12 @@ function getSortValue(
       return entry.name;
     case "price":
       return quote?.price ?? null;
+    case "change":
+      return quote?.change ?? null;
     case "changePercent":
       return quote?.changePercent ?? null;
+    case "time":
+      return quote?.lastUpdated ?? null;
   }
 }
 

--- a/src/plugins/builtin/world-indices/table.tsx
+++ b/src/plugins/builtin/world-indices/table.tsx
@@ -1,7 +1,8 @@
 import type { DataTableCell, DataTableColumn } from "../../../components";
+import { marketStateColor, marketStateLabel } from "../../../market-data/market/status";
 import { colors, priceColor } from "../../../theme/colors";
 import { TextAttributes } from "../../../ui";
-import { formatCurrency, formatPercentRaw } from "../../../utils/format";
+import { formatCurrency, formatNumber, formatPercentRaw } from "../../../utils/format";
 import { marketStatusDot, type BoardQuoteMap } from "../shared/use-quote-board";
 import type {
   WorldIndexColumnId,
@@ -10,22 +11,62 @@ import type {
 
 export type WorldIndexColumn = DataTableColumn & { id: WorldIndexColumnId };
 
+const SESSION_TEXT_MIN_WIDTH = 84;
+const CHANGE_MIN_WIDTH = 62;
+const TIME_MIN_WIDTH = 78;
+
+/** A colored dot needs a legend; the session word does not, so wide panes spell it out. */
+export function usesSessionText(width: number): boolean {
+  return width >= SESSION_TEXT_MIN_WIDTH;
+}
+
 export function createWorldIndexColumns(width: number): WorldIndexColumn[] {
-  const statusWidth = 1;
+  const statusWidth = usesSessionText(width) ? 9 : 1;
   const symbolWidth = 8;
   const priceWidth = 15;
-  const changeWidth = 9;
-  const columnCount = 5;
-  const fixedWidth = statusWidth + symbolWidth + priceWidth + changeWidth;
-  const nameWidth = Math.max(10, width - 2 - columnCount - fixedWidth);
+  const changeWidth = 12;
+  const changePercentWidth = 9;
+  // 5-char 24h time in an 8-wide column: the shared table's floating-pane width
+  // accounting runs a few cells long, and the slack keeps the value intact.
+  const timeWidth = 8;
+  const showChange = width >= CHANGE_MIN_WIDTH;
+  const showTime = width >= TIME_MIN_WIDTH;
+
+  const trailing: WorldIndexColumn[] = [
+    { id: "price", label: "LAST", width: priceWidth, align: "right" },
+    ...(showChange
+      ? [{ id: "change" as const, label: "CHG", width: changeWidth, align: "right" as const }]
+      : []),
+    { id: "changePercent", label: "CHG%", width: changePercentWidth, align: "right" },
+    // Left-aligned on purpose: the shared table trims a few cells off the right
+    // edge of a floating pane, and a right-aligned value would lose digits.
+    ...(showTime
+      ? [{ id: "time" as const, label: "TIME", width: timeWidth, align: "left" as const }]
+      : []),
+  ];
+
+  const columnCount = trailing.length + 3;
+  const fixedWidth = statusWidth + symbolWidth
+    + trailing.reduce((total, column) => total + (column.width ?? 0), 0);
+  // Leaves room for the pane border and scrollbar gutter; the name column grows
+  // back into any slack because it is the flexible one.
+  const nameWidth = Math.max(10, width - 6 - columnCount - fixedWidth);
 
   return [
-    { id: "status", label: "", width: statusWidth, align: "left" },
+    { id: "status", label: usesSessionText(width) ? "SESSION" : "", width: statusWidth, align: "left" },
     { id: "symbol", label: "INDEX", width: symbolWidth, align: "left" },
-    { id: "name", label: "NAME", width: nameWidth, align: "left" },
-    { id: "price", label: "LAST", width: priceWidth, align: "right" },
-    { id: "changePercent", label: "CHG%", width: changeWidth, align: "right" },
+    // The leftover width lands here rather than being spread across the number
+    // columns, which is what left a dead zone between NAME and LAST.
+    { id: "name", label: "NAME", width: nameWidth, align: "left", flexGrow: 1 },
+    ...trailing,
   ];
+}
+
+/** 24-hour so the cell stays 5 wide in every locale and never clips. */
+export function formatQuoteTime(lastUpdated: number | undefined): string {
+  if (!lastUpdated) return "—";
+  const date = new Date(lastUpdated);
+  return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
 }
 
 export function renderWorldIndexCell(
@@ -33,6 +74,7 @@ export function renderWorldIndexCell(
   column: WorldIndexColumn,
   rowState: { selected: boolean },
   quotes: BoardQuoteMap,
+  options?: { sessionText?: boolean },
 ): DataTableCell {
   if (row.type === "header") return { text: "" };
 
@@ -41,11 +83,23 @@ export function renderWorldIndexCell(
   const quote = state?.quote;
   const selectedColor = rowState.selected ? colors.selectedText : undefined;
   const dimmed = rowState.selected ? colors.selectedText : colors.textDim;
+  // One row must not mix a loading marker with a no-data marker.
+  const loadingCell = !quote && (state?.loading ?? true);
 
   switch (column.id) {
     case "status": {
+      if (loadingCell) return { text: "", color: dimmed };
+      if (options?.sessionText) {
+        const marketState = quote?.marketState;
+        return {
+          text: marketState ? marketStateLabel(marketState) : "—",
+          color: rowState.selected
+            ? colors.selectedText
+            : marketState ? marketStateColor(marketState) : colors.textDim,
+        };
+      }
       const dot = marketStatusDot(quote?.marketState);
-      return { text: dot.char, color: dot.color };
+      return { text: dot.char, color: rowState.selected ? colors.selectedText : dot.color };
     }
     case "symbol":
       return {
@@ -59,18 +113,29 @@ export function renderWorldIndexCell(
         color: selectedColor,
       };
     case "price":
-      if (state?.loading && !quote) return { text: "…", color: dimmed };
+      if (loadingCell) return { text: "…", color: dimmed };
       if (quote?.price === undefined) return { text: "—", color: dimmed };
       // A retained quote still beats a dash; dim it so stale is visible.
       return {
         text: formatCurrency(quote.price, quote.currency ?? "USD"),
         color: state?.stale ? dimmed : selectedColor,
       };
+    case "change":
+      if (loadingCell) return { text: "…", color: dimmed };
+      if (!quote || !Number.isFinite(quote.change)) return { text: "—", color: dimmed };
+      return {
+        text: `${quote.change >= 0 ? "+" : "-"}${formatNumber(Math.abs(quote.change), 2)}`,
+        color: selectedColor ?? priceColor(quote.change),
+      };
     case "changePercent":
+      if (loadingCell) return { text: "…", color: dimmed };
       if (!quote || quote.changePercent === undefined) return { text: "—", color: dimmed };
       return {
         text: formatPercentRaw(quote.changePercent),
         color: selectedColor ?? priceColor(quote.changePercent),
       };
+    case "time":
+      if (loadingCell) return { text: "…", color: dimmed };
+      return { text: formatQuoteTime(quote?.lastUpdated), color: dimmed };
   }
 }

--- a/src/plugins/builtin/yield-curve/index.tsx
+++ b/src/plugins/builtin/yield-curve/index.tsx
@@ -1,7 +1,7 @@
 import { Box, ScrollBox, Text } from "../../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShortcut } from "../../../react/input";
-import { StaticChartSurface, type PaneFooterSegment } from "../../../components";
+import { Button, EmptyState, Spinner, StaticChartSurface, type PaneFooterSegment } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import { colors } from "../../../theme/colors";
@@ -15,6 +15,7 @@ import {
   type YieldPoint,
 } from "./treasury-data";
 import { usePaneStatusFooter } from "../shared/pane-footer";
+import { useAutoRefresh, useUpdatedAgo } from "../shared/auto-refresh";
 
 function formatYield(y: number | null): string {
   if (y == null) return "—";
@@ -36,6 +37,7 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
   const [points, setPoints] = useState<YieldPoint[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
 
   const fetchGenRef = useRef(0);
 
@@ -49,6 +51,7 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
       const data = await loadYieldCurve();
       if (fetchGenRef.current !== gen) return;
       setPoints(data);
+      setLastUpdated(Date.now());
     } catch (err) {
       if (fetchGenRef.current !== gen) return;
       setError(err instanceof Error ? err.message : String(err));
@@ -60,6 +63,8 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
   useEffect(() => {
     load();
   }, [load]);
+  useAutoRefresh(lastUpdated, load);
+  const updatedAgo = useUpdatedAgo(lastUpdated);
 
   useShortcut((ev) => {
     if (!focused) return;
@@ -74,7 +79,8 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
   const yieldStatus = useMemo<PaneFooterSegment[]>(() => [
       ...(inverted ? [{ id: "inverted", parts: [{ text: "INVERTED", tone: "warning" as const, bold: true }] }] : []),
       ...(bp != null ? [{ id: "spread", parts: [{ text: `2Y-10Y ${bp >= 0 ? "+" : ""}${bp}bp`, tone: bp < 0 ? "warning" as const : "muted" as const }] }] : []),
-  ], [bp, inverted]);
+      ...(updatedAgo ? [{ id: "updated", parts: [{ text: `updated ${updatedAgo}`, tone: "muted" as const }] }] : []),
+  ], [bp, inverted, updatedAgo]);
   usePaneStatusFooter({
     registrationId: "yield-curve",
     loading,
@@ -86,7 +92,7 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
     return (
       <Box flexDirection="column" width={width} height={height}>
         <Box flexGrow={1} justifyContent="center" alignItems="center">
-          <Text fg={colors.textMuted}>Loading...</Text>
+          <Spinner label="Loading yield curve..." />
         </Box>
       </Box>
     );
@@ -94,10 +100,8 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
 
   if (error && points.length === 0) {
     return (
-      <Box flexDirection="column" width={width} height={height}>
-        <Box flexGrow={1} justifyContent="center" alignItems="center">
-          <Text fg={colors.negative}>{error}</Text>
-        </Box>
+      <Box flexDirection="column" width={width} height={height} padding={1} gap={1}>
+        <EmptyState title="Yield curve unavailable." message={error} />
       </Box>
     );
   }

--- a/src/plugins/ibkr/trade/tab/footer.ts
+++ b/src/plugins/ibkr/trade/tab/footer.ts
@@ -1,46 +1,37 @@
 import { usePaneFooter } from "../../../../components";
 import type { TickerRecord } from "../../../../types/ticker";
 import type { TradeTicketState } from "../../trading/state";
-import type { TradeTone } from "../utils";
 import type { TradeTabActions } from "./actions";
 
+/**
+ * Ticket status (next step, capture state, last message) lives in the tab header,
+ * which shows it untruncated and interactively, so the footer only carries actions.
+ */
 export function useTradeTabFooter({
   actions,
-  interactive,
-  nextStep,
+  canEnterOrder,
   showLimit,
   showStop,
-  statusText,
-  statusTone,
   symbol,
   ticketState,
   ticker,
-  workflowTone,
 }: {
   actions: TradeTabActions;
-  interactive: boolean;
-  nextStep: string;
+  /** False until a broker profile and account are picked, so order fields cannot be edited yet. */
+  canEnterOrder: boolean;
   showLimit: boolean;
   showStop: boolean;
-  statusText: string;
-  statusTone: TradeTone;
   symbol: string | null;
   ticketState: TradeTicketState;
   ticker: TickerRecord | null;
-  workflowTone: TradeTone;
 }) {
   usePaneFooter("ibkr-trade", () => ({
-    info: [
-      { id: "next", parts: [{ text: nextStep, tone: workflowTone === "positive" ? "positive" : workflowTone === "accent" ? "value" : "muted", bold: workflowTone !== "neutral" }] },
-      { id: "ticket", parts: [{ text: interactive ? "captured" : "standby", tone: interactive ? "positive" : "muted" }] },
-      ...(statusText ? [{ id: "status", parts: [{ text: statusText, tone: statusTone === "negative" ? "negative" as const : statusTone === "positive" ? "positive" as const : "muted" as const }] }] : []),
-    ],
     hints: [
       ...(!ticketState.busy ? [
         { id: "profile", key: "i", label: "profile", onPress: () => actions.chooseBrokerInstance().catch(() => {}) },
         { id: "account", key: "a", label: "ccount", onPress: () => actions.chooseAccount().catch(() => {}) },
       ] : []),
-      ...(!ticketState.busy && symbol && ticker ? [
+      ...(!ticketState.busy && canEnterOrder && symbol && ticker ? [
         { id: "side", key: "b/v", label: "side", onPress: actions.toggleSide },
         { id: "quantity", key: "q", label: "ty", onPress: () => actions.editQuantity().catch(() => {}) },
         { id: "type", key: "t", label: "ype", onPress: () => actions.editOrderType().catch(() => {}) },
@@ -51,16 +42,12 @@ export function useTradeTabFooter({
     ],
   }), [
     actions,
-    interactive,
-    nextStep,
+    canEnterOrder,
     showLimit,
     showStop,
-    statusText,
-    statusTone,
     symbol,
     ticketState.busy,
     ticketState.draft,
     ticker,
-    workflowTone,
   ]);
 }

--- a/src/plugins/ibkr/trade/tab/index.tsx
+++ b/src/plugins/ibkr/trade/tab/index.tsx
@@ -195,16 +195,12 @@ export function TradeTab({ focused, width, onCapture }: TickerResearchTabProps) 
 
   useTradeTabFooter({
     actions,
-    interactive,
-    nextStep,
+    canEnterOrder: hasProfile && hasAccount,
     showLimit,
     showStop,
-    statusText,
-    statusTone,
     symbol,
     ticketState,
     ticker,
-    workflowTone,
   });
 
   if (!ticker || !symbol) {

--- a/src/plugins/ibkr/trading/pane-view.tsx
+++ b/src/plugins/ibkr/trading/pane-view.tsx
@@ -1,12 +1,95 @@
-import { Box, ScrollBox, Text, TextAttributes } from "../../../ui";
+import { useMemo } from "react";
+import { Box, Text, TextAttributes } from "../../../ui";
+import { DataTableView, type DataTableCell, type DataTableColumn } from "../../../components";
 import { colors, priceColor } from "../../../theme/colors";
 import type { BrokerInstanceConfig } from "../../../types/config";
 import type { Quote } from "../../../types/financials";
 import type { BrokerAccount } from "../../../types/trading";
-import { formatCurrency, padTo } from "../../../utils/format";
+import { formatCurrency } from "../../../utils/format";
 import { formatMarketPrice, formatMarketQuantity } from "../../../market-data/market/format";
 import type { IbkrSnapshot } from "../gateway/types";
 import type { TradingPaneState } from "./state";
+
+type OpenOrder = IbkrSnapshot["openOrders"][number];
+type Execution = IbkrSnapshot["executions"][number];
+
+/** Below this the two panels cannot both hold a readable table, so they stack. */
+const STACK_BELOW_WIDTH = 72;
+
+const OPEN_ORDER_COLUMNS: DataTableColumn[] = [
+  { id: "orderId", label: "ID", width: 7, align: "left" },
+  { id: "action", label: "SIDE", width: 5, align: "left" },
+  { id: "symbol", label: "SYMBOL", width: 14, align: "left" },
+  { id: "status", label: "STATUS", width: 10, align: "left" },
+  { id: "remaining", label: "QTY", width: 6, align: "right" },
+  { id: "price", label: "PRICE", width: 9, align: "right" },
+  { id: "bid", label: "BID", width: 8, align: "right" },
+  { id: "ask", label: "ASK", width: 8, align: "right" },
+];
+
+const EXECUTION_COLUMNS: DataTableColumn[] = [
+  { id: "side", label: "SIDE", width: 5, align: "left" },
+  { id: "symbol", label: "SYMBOL", width: 16, align: "left" },
+  { id: "shares", label: "QTY", width: 7, align: "right" },
+  { id: "price", label: "PRICE", width: 10, align: "right" },
+];
+
+function renderOpenOrderCell(
+  order: OpenOrder,
+  column: DataTableColumn,
+  getOrderQuote: (symbol: string) => Quote | null,
+): DataTableCell {
+  const secType = order.contract.secType;
+  switch (column.id) {
+    case "orderId":
+      return { text: String(order.orderId), color: colors.text };
+    case "action":
+      return { text: order.action, color: priceColor(order.action.toUpperCase() === "BUY" ? 1 : -1) };
+    case "symbol":
+      return { text: order.contract.localSymbol || order.contract.symbol, color: colors.text, attributes: TextAttributes.BOLD };
+    case "status":
+      return { text: order.status, color: colors.textDim };
+    case "remaining":
+      return { text: formatMarketQuantity(order.remaining, { contractSecType: secType, maxWidth: 6 }), color: colors.text };
+    case "price":
+      return {
+        text: order.limitPrice != null
+          ? formatMarketPrice(order.limitPrice, { contractSecType: secType, maxWidth: 9 })
+          : order.stopPrice != null
+            ? formatMarketPrice(order.stopPrice, { contractSecType: secType, maxWidth: 9 })
+            : "MKT",
+        color: colors.text,
+      };
+    case "bid": {
+      const bid = getOrderQuote(order.contract.symbol)?.bid;
+      return {
+        text: bid != null ? formatMarketPrice(bid, { contractSecType: secType, maxWidth: 8 }) : "---",
+        color: colors.textDim,
+      };
+    }
+    default: {
+      const ask = getOrderQuote(order.contract.symbol)?.ask;
+      return {
+        text: ask != null ? formatMarketPrice(ask, { contractSecType: secType, maxWidth: 8 }) : "---",
+        color: colors.textDim,
+      };
+    }
+  }
+}
+
+function renderExecutionCell(execution: Execution, column: DataTableColumn): DataTableCell {
+  const secType = execution.contract.secType;
+  switch (column.id) {
+    case "side":
+      return { text: execution.side, color: priceColor(execution.side.toUpperCase() === "BOT" ? 1 : -1) };
+    case "symbol":
+      return { text: execution.contract.localSymbol || execution.contract.symbol, color: colors.text };
+    case "shares":
+      return { text: formatMarketQuantity(execution.shares, { contractSecType: secType, maxWidth: 7 }), color: colors.text };
+    default:
+      return { text: formatMarketPrice(execution.price, { contractSecType: secType }), color: colors.text };
+  }
+}
 
 export function TradingPaneView({
   activeAccount,
@@ -23,6 +106,7 @@ export function TradingPaneView({
   selectedInstance,
   tradeState,
   width,
+  focused = false,
 }: {
   activeAccount: BrokerAccount | undefined;
   displayStatusState: IbkrSnapshot["status"]["state"];
@@ -38,15 +122,24 @@ export function TradingPaneView({
   selectedInstance: BrokerInstanceConfig | undefined;
   tradeState: TradingPaneState;
   width: number;
+  focused?: boolean;
 }) {
-  const orderPanelWidth = Math.max(36, Math.floor(width * 0.6));
-  const listPanelWidth = Math.max(24, width - orderPanelWidth - 1);
-  const listHeight = Math.max(4, height - 4);
+  const stacked = width < STACK_BELOW_WIDTH;
+  const bodyHeight = Math.max(4, height - 4);
+  const orderPanelWidth = stacked ? Math.max(8, width - 2) : Math.max(24, Math.floor(width * 0.6));
+  const listPanelWidth = stacked ? Math.max(8, width - 2) : Math.max(16, width - orderPanelWidth - 1);
+  const orderPanelHeight = stacked ? Math.max(2, Math.ceil(bodyHeight / 2)) : bodyHeight;
+  const executionPanelHeight = stacked ? Math.max(2, bodyHeight - orderPanelHeight) : bodyHeight;
+
+  const executions = useMemo(
+    () => gatewaySnapshot.executions.slice(0, 20),
+    [gatewaySnapshot.executions],
+  );
 
   return (
     <Box flexDirection="column" flexGrow={1} paddingX={1}>
       <Box flexDirection="row" height={1}>
-        <Box flexGrow={1}>
+        <Box flexGrow={1} overflow="hidden">
           <Text fg={
             displayStatusState === "connected"
               ? colors.positive
@@ -59,10 +152,10 @@ export function TradingPaneView({
               : "IBKR · no profile selected"}
           </Text>
         </Box>
-        {tradeState.busy && <Text fg={colors.textDim}>Working…</Text>}
+        {tradeState.busy && <Text fg={colors.textDim}>Working...</Text>}
       </Box>
 
-      <Box height={1}>
+      <Box height={1} overflow="hidden">
         <Text fg={colors.textDim}>
           {activeAccount
             ? `${selectedInstance?.label || "IBKR"} → ${activeAccount.accountId} · ${formatCurrency(activeAccount.netLiquidation || 0, activeAccount.currency || "USD")} net liq`
@@ -76,7 +169,7 @@ export function TradingPaneView({
         </Text>
       </Box>
 
-      <Box height={1}>
+      <Box height={1} overflow="hidden">
         <Text fg={tradeState.lastError ? colors.negative : colors.textDim}>
           {tradeState.lastError
             || gatewaySnapshot.status.message
@@ -86,88 +179,57 @@ export function TradingPaneView({
         </Text>
       </Box>
 
-      <Box height={1}>
-        <Text fg={colors.border}>{"─".repeat(Math.max(1, width - 2))}</Text>
-      </Box>
+      <Box height={1} width={Math.max(1, width - 2)} backgroundColor={colors.border} />
 
-      <Box flexDirection="row" height={listHeight}>
-        <Box width={orderPanelWidth} flexDirection="column">
-          <Text attributes={TextAttributes.BOLD} fg={colors.textBright}>Open Orders</Text>
-          <ScrollBox flexGrow={1} scrollY>
-            {gatewaySnapshot.openOrders.length === 0 ? (
-              <Text fg={colors.textDim}>No open IBKR orders.</Text>
-            ) : (
-              gatewaySnapshot.openOrders.map((order, index) => {
-                const selected = index === tradeState.selectedOpenOrderIndex;
-                const orderSymbol = order.contract.symbol;
-                const orderQuote = getOrderQuote(orderSymbol);
-                const bidStr = orderQuote?.bid != null ? formatMarketPrice(orderQuote.bid, { contractSecType: order.contract.secType, maxWidth: 6 }) : "---";
-                const askStr = orderQuote?.ask != null ? formatMarketPrice(orderQuote.ask, { contractSecType: order.contract.secType, maxWidth: 6 }) : "---";
-                const orderPrice = order.limitPrice != null
-                  ? formatMarketPrice(order.limitPrice, { contractSecType: order.contract.secType, maxWidth: 9 })
-                  : order.stopPrice != null
-                    ? formatMarketPrice(order.stopPrice, { contractSecType: order.contract.secType, maxWidth: 9 })
-                    : "MKT";
-                return (
-                  <Box
-                    key={order.orderId}
-                    backgroundColor={selected ? colors.selected : colors.bg}
-                    onMouseDown={() => {
-                      if (selected) {
-                        onOpenSelectedOrder();
-                      } else {
-                        onSelectOpenOrderIndex(index);
-                      }
-                    }}
-                  >
-                    <Text fg={selected ? colors.text : colors.textDim}>
-                      {selected ? "▸ " : "  "}
-                      {padTo(String(order.orderId), 6)}
-                      {padTo(order.action, 5)}
-                      {padTo(order.contract.localSymbol || order.contract.symbol, 14)}
-                      {padTo(order.status, 10)}
-                      {padTo(formatMarketQuantity(order.remaining, { contractSecType: order.contract.secType, maxWidth: 5 }), 5, "right")}
-                      {" "}
-                      {padTo(orderPrice, 9)}
-                      {padTo(`B:${bidStr}`, 10)}
-                      {`A:${askStr}`}
-                    </Text>
-                  </Box>
-                );
-              })
-            )}
-          </ScrollBox>
+      <Box flexDirection={stacked ? "column" : "row"} height={bodyHeight}>
+        <Box width={orderPanelWidth} height={orderPanelHeight} flexDirection="column">
+          <Box height={1}>
+            <Text attributes={TextAttributes.BOLD} fg={colors.textBright}>Open Orders</Text>
+          </Box>
+          <DataTableView<OpenOrder>
+            focused={focused}
+            columns={OPEN_ORDER_COLUMNS}
+            items={gatewaySnapshot.openOrders}
+            sortColumnId={null}
+            sortDirection="asc"
+            onHeaderClick={() => {}}
+            getItemKey={(order) => String(order.orderId)}
+            renderCell={(order, column) => renderOpenOrderCell(order, column, getOrderQuote)}
+            selection={{
+              kind: "index",
+              selectedIndex: tradeState.selectedOpenOrderIndex,
+              onChange: (index) => onSelectOpenOrderIndex(index),
+            }}
+            onActivate={onOpenSelectedOrder}
+            emptyStateTitle="No open IBKR orders."
+          />
         </Box>
 
-        <Box width={1}>
-          <Text fg={colors.border}>│</Text>
-        </Box>
+        {!stacked && <Box width={1} height={bodyHeight} backgroundColor={colors.border} />}
 
-        <Box width={listPanelWidth} flexDirection="column">
-          <Text attributes={TextAttributes.BOLD} fg={colors.textBright}>Executions</Text>
-          <ScrollBox flexGrow={1} scrollY>
-            {gatewaySnapshot.executions.length === 0 ? (
-              <Text fg={colors.textDim}>No recent executions.</Text>
-            ) : (
-              gatewaySnapshot.executions.slice(0, 20).map((execution) => (
-                <Box
-                  key={execution.execId}
-                  onMouseDown={() => {
-                    const symbol = execution.contract.symbol;
-                    if (symbol) onSelectExecutionSymbol(symbol);
-                  }}
-                >
-                  <Text fg={priceColor(execution.side.toUpperCase() === "BOT" ? 1 : -1)}>
-                    {padTo(execution.side, 5)}
-                    {padTo(execution.contract.localSymbol || execution.contract.symbol, 18)}
-                    {padTo(formatMarketQuantity(execution.shares, { contractSecType: execution.contract.secType, maxWidth: 6 }), 6, "right")}
-                    {" "}
-                    {formatMarketPrice(execution.price, { contractSecType: execution.contract.secType })}
-                  </Text>
-                </Box>
-              ))
-            )}
-          </ScrollBox>
+        <Box width={listPanelWidth} height={executionPanelHeight} flexDirection="column">
+          <Box height={1}>
+            <Text attributes={TextAttributes.BOLD} fg={colors.textBright}>Executions</Text>
+          </Box>
+          <DataTableView<Execution>
+            columns={EXECUTION_COLUMNS}
+            items={executions}
+            sortColumnId={null}
+            sortDirection="asc"
+            onHeaderClick={() => {}}
+            getItemKey={(execution) => execution.execId}
+            renderCell={renderExecutionCell}
+            selection={{ kind: "none" }}
+            onActivate={(execution) => {
+              const symbol = execution.contract.symbol;
+              if (symbol) onSelectExecutionSymbol(symbol);
+            }}
+            onRowMouseDown={(execution) => {
+              const symbol = execution.contract.symbol;
+              if (symbol) onSelectExecutionSymbol(symbol);
+            }}
+            emptyStateTitle="No recent executions."
+          />
         </Box>
       </Box>
     </Box>

--- a/src/plugins/ibkr/trading/pane.tsx
+++ b/src/plugins/ibkr/trading/pane.tsx
@@ -257,7 +257,7 @@ export function TradingPane({ focused, width, height }: PaneProps) {
     hints: [
       { id: "profile", key: "i", label: "profile", onPress: () => footerActionsRef.current.chooseBrokerInstance().catch(() => {}) },
       { id: "account", key: "a", label: "ccount", onPress: () => footerActionsRef.current.chooseAccount().catch(() => {}) },
-      { id: "open", key: "m", label: "open", onPress: () => footerActionsRef.current.openSelectedOrder() },
+      { id: "modify", key: "m", label: "odify", onPress: () => footerActionsRef.current.openSelectedOrder() },
       { id: "cancel", key: "c", label: "ancel", onPress: () => footerActionsRef.current.cancelSelectedOrder().catch(() => {}) },
     ],
   }), []);
@@ -326,6 +326,7 @@ export function TradingPane({ focused, width, height }: PaneProps) {
       selectedInstance={selectedInstance}
       tradeState={tradeState}
       width={width}
+      focused={focused}
     />
   );
 }

--- a/src/plugins/prediction-markets/chart.tsx
+++ b/src/plugins/prediction-markets/chart.tsx
@@ -1,11 +1,10 @@
 import { Box, Text } from "../../ui";
 import { useMemo } from "react";
-import { TextAttributes } from "../../ui";
+import { Tabs } from "../../components";
 import {
   CompositeChart,
   pricePointsToResolvedSeries,
 } from "../../components/chart/composite";
-import type { ChartMouseEvent } from "../../components/chart/core/pointer";
 import { EmptyState } from "../../components/ui/status";
 import { colors } from "../../theme/colors";
 import { formatNumber, formatPercentRaw } from "../../utils/format";
@@ -40,38 +39,27 @@ function toPricePoints(points: PredictionHistoryPoint[]): PricePoint[] {
   });
 }
 
+const RANGE_TABS = RANGES.map((entry) => ({ label: entry, value: entry }));
+
+/** Shared Tabs so the range picker keeps keyboard navigation, not just clicks. */
 function PredictionRangeTabs({
   activeRange,
+  focused,
   onRangeSelect,
 }: {
   activeRange: PredictionHistoryRange;
+  focused: boolean;
   onRangeSelect: (range: PredictionHistoryRange) => void;
 }) {
   return (
-    <Box flexDirection="row" gap={1}>
-      {RANGES.map((entry) => {
-        const active = entry === activeRange;
-        return (
-          <Box
-            key={entry}
-            onMouseDown={(event: ChartMouseEvent) => {
-              event.preventDefault?.();
-              onRangeSelect(entry);
-            }}
-            cursor="pointer"
-            data-gloom-interactive="true"
-            data-gloom-label={`${entry} prediction history`}
-          >
-            <Text
-              fg={active ? colors.textBright : colors.textDim}
-              attributes={active ? TextAttributes.BOLD : 0}
-            >
-              {entry}
-            </Text>
-          </Box>
-        );
-      })}
-    </Box>
+    <Tabs
+      tabs={RANGE_TABS}
+      activeValue={activeRange}
+      onSelect={(value) => onRangeSelect(value as PredictionHistoryRange)}
+      compact
+      variant="bare"
+      focused={focused}
+    />
   );
 }
 
@@ -80,6 +68,7 @@ export function PredictionMarketChart({
   width,
   height,
   loading = false,
+  focused = false,
   range,
   onRangeSelect,
 }: {
@@ -87,6 +76,7 @@ export function PredictionMarketChart({
   width: number;
   height: number;
   loading?: boolean;
+  focused?: boolean;
   range: PredictionHistoryRange;
   onRangeSelect: (range: PredictionHistoryRange) => void;
 }) {
@@ -98,6 +88,7 @@ export function PredictionMarketChart({
         <Box flexDirection="row" height={1}>
           <PredictionRangeTabs
             activeRange={range}
+            focused={focused}
             onRangeSelect={onRangeSelect}
           />
         </Box>
@@ -135,6 +126,7 @@ export function PredictionMarketChart({
       <Box flexDirection="row" height={1}>
         <PredictionRangeTabs
           activeRange={range}
+          focused={focused}
           onRangeSelect={onRangeSelect}
         />
         <Box flexGrow={1} />

--- a/src/plugins/prediction-markets/columns.ts
+++ b/src/plugins/prediction-markets/columns.ts
@@ -53,8 +53,10 @@ export const PREDICTION_COLUMN_DEFS: PredictionColumnDef[] = [
   },
   {
     id: "open_interest",
+    // One cell wider than the value needs: OI is right aligned and ENDS is left
+    // aligned, so without the slack the two headers read as one "OI ENDS" word.
     label: "OI",
-    width: 10,
+    width: 11,
     align: "right",
     description: "Open interest.",
   },
@@ -125,7 +127,6 @@ export const DEFAULT_PREDICTION_COLUMN_IDS = [
   "vol_24h",
   "open_interest",
   "ends",
-  "status",
 ];
 
 export const PREDICTION_COLUMNS_BY_ID = new Map(

--- a/src/plugins/prediction-markets/controller/catalog.ts
+++ b/src/plugins/prediction-markets/controller/catalog.ts
@@ -11,6 +11,7 @@ import {
   formatPredictionLoadError,
   getPredictionCatalogStatus,
 } from "./status";
+import { useAutoRefresh } from "../../builtin/shared/auto-refresh";
 import { getCachedPredictionResource } from "../services/fetch";
 import { loadKalshiCatalog } from "../services/kalshi/adapter";
 import { loadPolymarketCatalog } from "../services/polymarket/adapter";
@@ -43,6 +44,8 @@ export function usePredictionCatalogData({
     Record<string, string | null>
   >({});
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(searchQuery);
+  const [polymarketLoadedAt, setPolymarketLoadedAt] = useState<number | null>(null);
+  const [kalshiLoadedAt, setKalshiLoadedAt] = useState<number | null>(null);
   const activeCatalogRef = useRef<PredictionCatalogCache>({});
 
   const normalizedCatalogQuery = debouncedSearchQuery.trim().toLowerCase();
@@ -198,6 +201,7 @@ export function usePredictionCatalogData({
           ),
         );
       } finally {
+        setPolymarketLoadedAt(Date.now());
         if (showPending) {
           setCatalogPending((current) =>
             updatePredictionPendingCounts(current, cacheKey, -1),
@@ -248,6 +252,7 @@ export function usePredictionCatalogData({
           ),
         );
       } finally {
+        setKalshiLoadedAt(Date.now());
         if (showPending) {
           setCatalogPending((current) =>
             updatePredictionPendingCounts(current, cacheKey, -1),
@@ -269,6 +274,8 @@ export function usePredictionCatalogData({
     return () => clearTimeout(timeoutId);
   }, [searchQuery]);
 
+  // Reloads follow the one refresh cadence the user configured, instead of two
+  // hardcoded intervals nobody can change.
   useEffect(() => {
     if (!includePolymarket) return;
     void loadPolymarket(
@@ -276,14 +283,6 @@ export function usePredictionCatalogData({
       debouncedSearchQuery,
       categoryId,
     );
-    const intervalId = setInterval(() => {
-      void loadPolymarket(
-        polymarketCatalogKey,
-        debouncedSearchQuery,
-        categoryId,
-      );
-    }, 30_000);
-    return () => clearInterval(intervalId);
   }, [
     categoryId,
     debouncedSearchQuery,
@@ -292,13 +291,13 @@ export function usePredictionCatalogData({
     polymarketCatalogKey,
   ]);
 
+  useAutoRefresh(includePolymarket ? polymarketLoadedAt : null, useCallback(() => {
+    void loadPolymarket(polymarketCatalogKey, debouncedSearchQuery, categoryId);
+  }, [categoryId, debouncedSearchQuery, loadPolymarket, polymarketCatalogKey]));
+
   useEffect(() => {
     if (!includeKalshi) return;
     void loadKalshi(kalshiCatalogKey, debouncedSearchQuery, categoryId);
-    const intervalId = setInterval(() => {
-      void loadKalshi(kalshiCatalogKey, debouncedSearchQuery, categoryId);
-    }, 20_000);
-    return () => clearInterval(intervalId);
   }, [
     categoryId,
     debouncedSearchQuery,
@@ -306,6 +305,10 @@ export function usePredictionCatalogData({
     kalshiCatalogKey,
     loadKalshi,
   ]);
+
+  useAutoRefresh(includeKalshi ? kalshiLoadedAt : null, useCallback(() => {
+    void loadKalshi(kalshiCatalogKey, debouncedSearchQuery, categoryId);
+  }, [categoryId, debouncedSearchQuery, kalshiCatalogKey, loadKalshi]));
 
   return {
     allMarkets,

--- a/src/plugins/prediction-markets/controller/detail.ts
+++ b/src/plugins/prediction-markets/controller/detail.ts
@@ -167,7 +167,10 @@ export function usePredictionDetailData({
   }, [focused, loadSelectedDetail, selectedSummaryKey, selectedSummaryVenue]);
 
   useEffect(() => {
+    // Same focus gate as the Kalshi polling above: an unfocused pane must not keep
+    // a live socket open.
     if (
+      !focused ||
       selectedSummaryVenue !== "polymarket" ||
       (!selectedYesTokenId && !selectedNoTokenId) ||
       !selectedSummaryKey
@@ -220,6 +223,7 @@ export function usePredictionDetailData({
       },
     );
   }, [
+    focused,
     selectedNoTokenId,
     selectedSummaryKey,
     selectedSummaryVenue,

--- a/src/plugins/prediction-markets/controller/index.ts
+++ b/src/plugins/prediction-markets/controller/index.ts
@@ -22,7 +22,6 @@ import type {
   PredictionDetailTab,
   PredictionHistoryRange,
   PredictionListRow,
-  PredictionOrderPreviewIntent,
   PredictionSortPreference,
   PredictionVenueScope,
 } from "../types";
@@ -92,12 +91,6 @@ export function usePredictionMarketsController({
       "sortPreference",
       defaultSortPreference,
     );
-  const [, setOrderPreviewIntent] =
-    usePluginPaneState<PredictionOrderPreviewIntent | null>(
-      "orderPreviewIntent",
-      null,
-    );
-
   const [detailOpen, setDetailOpen] = useState(false);
   const [searchFocused, setSearchFocused] = useState(false);
   const [initialParamsApplied, setInitialParamsApplied] = useState(false);
@@ -294,13 +287,6 @@ export function usePredictionMarketsController({
     [setSortPreference],
   );
 
-  const previewOrder = useCallback(
-    (intent: PredictionOrderPreviewIntent) => {
-      setOrderPreviewIntent(intent);
-    },
-    [setOrderPreviewIntent],
-  );
-
   usePredictionControllerKeyboard({
     categoryId,
     detailOpen,
@@ -361,7 +347,6 @@ export function usePredictionMarketsController({
       focusSearch,
       handleSortHeaderClick,
       openSelectedRow,
-      previewOrder,
       selectBrowseTab,
       selectCategory,
       selectMarket,

--- a/src/plugins/prediction-markets/detail/book.tsx
+++ b/src/plugins/prediction-markets/detail/book.tsx
@@ -6,7 +6,6 @@ import { formatPredictionProbability } from "../metrics";
 import type {
   PredictionBookLevel,
   PredictionMarketDetail,
-  PredictionOrderPreviewIntent,
 } from "../types";
 
 type BookColumnId = "outcome" | "side" | "price" | "size";
@@ -17,7 +16,6 @@ interface BookRow {
   outcome: "yes" | "no";
   side: "buy" | "sell";
   level: PredictionBookLevel;
-  intent: PredictionOrderPreviewIntent;
 }
 
 const BOOK_COLUMNS: BookColumn[] = [
@@ -29,12 +27,10 @@ const BOOK_COLUMNS: BookColumn[] = [
 
 function bookRowsForLevels({
   levels,
-  marketKey,
   outcome,
   side,
 }: {
   levels: PredictionBookLevel[];
-  marketKey: string;
   outcome: "yes" | "no";
   side: "buy" | "sell";
 }): BookRow[] {
@@ -43,40 +39,28 @@ function bookRowsForLevels({
     outcome,
     side,
     level,
-    intent: {
-      marketKey,
-      outcome,
-      side,
-      price: level.price,
-      size: level.size,
-    },
   }));
 }
 
 function buildBookRows(detail: PredictionMarketDetail): BookRow[] {
-  const marketKey = detail.summary.key;
   return [
     ...bookRowsForLevels({
       levels: detail.book.yesBids,
-      marketKey,
       outcome: "yes",
       side: "buy",
     }),
     ...bookRowsForLevels({
       levels: detail.book.yesAsks,
-      marketKey,
       outcome: "yes",
       side: "sell",
     }),
     ...bookRowsForLevels({
       levels: detail.book.noBids,
-      marketKey,
       outcome: "no",
       side: "buy",
     }),
     ...bookRowsForLevels({
       levels: detail.book.noAsks,
-      marketKey,
       outcome: "no",
       side: "sell",
     }),
@@ -86,12 +70,10 @@ function buildBookRows(detail: PredictionMarketDetail): BookRow[] {
 export function PredictionMarketBookView({
   detail,
   focused,
-  onPreviewOrder,
   width,
 }: {
   detail: PredictionMarketDetail;
   focused: boolean;
-  onPreviewOrder: (intent: PredictionOrderPreviewIntent) => void;
   width: number;
 }) {
   const rows = useMemo(() => buildBookRows(detail), [detail]);
@@ -124,11 +106,9 @@ export function PredictionMarketBookView({
       sortDirection="asc"
       onHeaderClick={() => {}}
       getItemKey={(row) => row.id}
-      onActivate={(row) => onPreviewOrder(row.intent)}
-      onRowMouseDown={(row, index, event) => {
+      onRowMouseDown={(_row, index, event) => {
         event.preventDefault();
         setSelectedIndex(index);
-        onPreviewOrder(row.intent);
         return true;
       }}
       renderCell={(row, column, _index, rowState) => {
@@ -157,8 +137,8 @@ export function PredictionMarketBookView({
             };
         }
       }}
-      emptyStateTitle="No book levels."
-      emptyStateHint="This venue did not return current order book depth."
+      emptyStateTitle={detail.book.error ? "Order book unavailable." : "No book levels."}
+      emptyStateHint={detail.book.error ?? "This venue did not return current order book depth."}
     />
   );
 }

--- a/src/plugins/prediction-markets/detail/pane.tsx
+++ b/src/plugins/prediction-markets/detail/pane.tsx
@@ -19,7 +19,6 @@ import type {
   PredictionListRow,
   PredictionMarketDetail,
   PredictionMarketSummary,
-  PredictionOrderPreviewIntent,
 } from "../types";
 import { PredictionMarketBookView } from "./book";
 import { PredictionMarketOverviewView } from "./overview";
@@ -35,6 +34,22 @@ interface MetricCell {
   value: string;
   width: number;
   color?: string;
+}
+
+/**
+ * Drops trailing metrics that do not fit rather than letting the strip overflow
+ * the detail pane. YES and NO always survive.
+ */
+function fitMetrics(metrics: MetricCell[], width: number): MetricCell[] {
+  const fitted: MetricCell[] = [];
+  let used = 0;
+  for (const metric of metrics) {
+    const next = used + metric.width + (fitted.length > 0 ? 1 : 0);
+    if (fitted.length >= 2 && next > width) break;
+    fitted.push(metric);
+    used = next;
+  }
+  return fitted;
 }
 
 function MetricLabelRow({ metrics }: { metrics: MetricCell[] }) {
@@ -83,7 +98,6 @@ export function PredictionMarketDetailPane({
   historyRange,
   onDetailTabChange,
   onHistoryRangeChange,
-  onPreviewOrder,
   onSelectMarket,
   selectedRow,
   selectedSummary,
@@ -99,7 +113,6 @@ export function PredictionMarketDetailPane({
   historyRange: PredictionHistoryRange;
   onDetailTabChange: (tab: PredictionDetailTab) => void;
   onHistoryRangeChange: (range: PredictionHistoryRange) => void;
-  onPreviewOrder: (intent: PredictionOrderPreviewIntent) => void;
   onSelectMarket: (marketKey: string) => void;
   selectedRow: PredictionListRow | null;
   selectedSummary: PredictionMarketSummary | null;
@@ -182,6 +195,7 @@ export function PredictionMarketDetailPane({
       width: 7,
     },
   ];
+  const visibleMetrics = fitMetrics(metrics, Math.max(12, detailWidth));
   const relatedSiblings =
     selectedRow?.kind === "group"
       ? []
@@ -208,8 +222,8 @@ export function PredictionMarketDetailPane({
       )}
 
       <Box flexDirection="column" height={3} paddingBottom={1}>
-        <MetricLabelRow metrics={metrics} />
-        <MetricValueRow metrics={metrics} />
+        <MetricLabelRow metrics={visibleMetrics} />
+        <MetricValueRow metrics={visibleMetrics} />
       </Box>
 
       {relatedSiblings.length > 0 && (
@@ -244,7 +258,9 @@ export function PredictionMarketDetailPane({
         />
       </Box>
 
-      {detailError && !detail && (
+      {/* Shown even when cached detail is on screen, so a failed refresh is never
+          presented as current data. */}
+      {detailError && (
         <Box paddingBottom={1}>
           <Text
             fg={colors.negative}
@@ -252,7 +268,7 @@ export function PredictionMarketDetailPane({
             wrapMode="word"
             wrapText
           >
-            {detailError}
+            {detail ? `Showing cached data: ${detailError}` : detailError}
           </Text>
         </Box>
       )}
@@ -284,6 +300,7 @@ export function PredictionMarketDetailPane({
           width={detailWidth}
           height={Math.max(height - 8, 8)}
           loading={detailLoading}
+          focused={focused}
           range={historyRange}
           onRangeSelect={onHistoryRangeChange}
         />
@@ -294,7 +311,6 @@ export function PredictionMarketDetailPane({
           <PredictionMarketBookView
             detail={detail}
             focused={focused}
-            onPreviewOrder={onPreviewOrder}
             width={detailWidth}
           />
         ) : (

--- a/src/plugins/prediction-markets/metrics.ts
+++ b/src/plugins/prediction-markets/metrics.ts
@@ -81,27 +81,38 @@ export function formatPredictionMetric(
   return formatCompactSigned(value ?? null, unit);
 }
 
+/**
+ * One shape per row: a signed countdown inside a week, an absolute date beyond
+ * it. A market whose stated close has passed while the venue still reports it
+ * open is labelled as such rather than as an age, because "22h ago" next to
+ * status OPEN reads as a bug.
+ */
 export function formatPredictionEndsAt(
   value: string | null | undefined,
+  status?: string,
+  now = Date.now(),
 ): string {
   if (!value) return "—";
   const date = new Date(value);
   if (!Number.isFinite(date.getTime())) return "—";
-  const delta = date.getTime() - Date.now();
-  if (Math.abs(delta) < 24 * 60 * 60_000) {
-    const absMinutes = Math.round(Math.abs(delta) / 60_000);
-    if (absMinutes < 60)
-      return delta >= 0 ? `${absMinutes}m left` : `${absMinutes}m ago`;
-    const hours = Math.floor(absMinutes / 60);
-    const minutes = absMinutes % 60;
-    return delta >= 0 ? `${hours}h ${minutes}m` : `${hours}h ago`;
+  const delta = date.getTime() - now;
+  const absMinutes = Math.round(Math.abs(delta) / 60_000);
+
+  if (delta < 0 && status === "open") return "past due";
+
+  if (absMinutes < 7 * 24 * 60) {
+    const magnitude = absMinutes < 60
+      ? `${absMinutes}m`
+      : absMinutes < 24 * 60
+        ? `${Math.floor(absMinutes / 60)}h`
+        : `${Math.floor(absMinutes / (24 * 60))}d`;
+    return delta >= 0 ? `${magnitude} left` : `${magnitude} ago`;
   }
-  return date.toLocaleString("en-US", {
-    month: "numeric",
+
+  return date.toLocaleDateString("en-US", {
+    month: "short",
     day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
+    year: date.getFullYear() === new Date(now).getFullYear() ? undefined : "numeric",
   });
 }
 
@@ -256,11 +267,10 @@ export function getPredictionColumnValue(
     case "venue":
       return { text: market.venue === "polymarket" ? "Polymkt" : "Kalshi" };
     case "yes":
+      // Always percentage then outcome label, so the cell never changes shape
+      // between grouped and single rows.
       return {
-        text:
-          market.kind === "group"
-            ? `${formatPredictionPercent(market.focusYesPrice)} ${market.focusMarketLabel}`
-            : formatPredictionPercent(market.focusYesPrice),
+        text: `${formatPredictionPercent(market.focusYesPrice)} ${market.focusMarketLabel}`.trim(),
         color: getPredictionProbabilityColor(market.focusYesPrice),
       };
     case "spread":
@@ -282,7 +292,7 @@ export function getPredictionColumnValue(
         ),
       };
     case "ends":
-      return { text: formatPredictionEndsAt(market.endsAt) };
+      return { text: formatPredictionEndsAt(market.endsAt, market.status) };
     case "status":
       return {
         text: market.status.toUpperCase(),

--- a/src/plugins/prediction-markets/pane.tsx
+++ b/src/plugins/prediction-markets/pane.tsx
@@ -271,7 +271,6 @@ export function PredictionMarketsPane({ focused, width, height }: PaneProps) {
           historyRange={controller.historyRange}
           onDetailTabChange={controller.actions.setDetailTab}
           onHistoryRangeChange={controller.actions.setHistoryRange}
-          onPreviewOrder={controller.actions.previewOrder}
           onSelectMarket={controller.actions.selectMarket}
           scrollRef={controller.detailScrollRef}
           selectedRow={controller.selectedRow}

--- a/src/plugins/prediction-markets/services/polymarket/detail.ts
+++ b/src/plugins/prediction-markets/services/polymarket/detail.ts
@@ -241,19 +241,31 @@ async function loadPolymarketBook(
     "book",
     summary.key,
     async () => {
-      const [yesBook, noBook] = await Promise.all([
-        yesTokenId
-          ? fetchJson<PolymarketBookResponse>(
-              `https://clob.polymarket.com/book?token_id=${yesTokenId}`,
-            ).catch(() => null)
-          : Promise.resolve(null),
-        noTokenId
-          ? fetchJson<PolymarketBookResponse>(
-              `https://clob.polymarket.com/book?token_id=${noTokenId}`,
-            ).catch(() => null)
-          : Promise.resolve(null),
+      const loadSide = async (tokenId: string | null | undefined) => {
+        if (!tokenId) return { book: null, error: null as string | null };
+        try {
+          return {
+            book: await fetchJson<PolymarketBookResponse>(
+              `https://clob.polymarket.com/book?token_id=${tokenId}`,
+            ),
+            error: null as string | null,
+          };
+        } catch (error) {
+          // Keep the failure: an empty book and a failed book look identical downstream.
+          return {
+            book: null,
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      };
+      const [yesResult, noResult] = await Promise.all([
+        loadSide(yesTokenId),
+        loadSide(noTokenId),
       ]);
+      const yesBook = yesResult.book;
+      const noBook = noResult.book;
       return {
+        error: yesResult.error ?? noResult.error,
         yesBids: (yesBook?.bids ?? [])
           .map(normalizePolymarketBookLevel)
           .filter((level): level is PredictionBookLevel => level != null),

--- a/src/plugins/prediction-markets/test-helpers.tsx
+++ b/src/plugins/prediction-markets/test-helpers.tsx
@@ -522,7 +522,6 @@ export function GroupedDetailHarness({
           historyRange="1M"
           onDetailTabChange={() => {}}
           onHistoryRangeChange={() => {}}
-          onPreviewOrder={() => {}}
           onSelectMarket={() => {}}
           scrollRef={scrollRef}
           selectedRow={selectedRow!}

--- a/src/plugins/prediction-markets/types.ts
+++ b/src/plugins/prediction-markets/types.ts
@@ -99,6 +99,8 @@ export interface PredictionBookSnapshot {
   noBids: PredictionBookLevel[];
   noAsks: PredictionBookLevel[];
   lastTradePrice: number | null;
+  /** Set when the venue book request failed, so empty depth is never reported as "no depth". */
+  error?: string | null;
 }
 
 export interface PredictionTrade {
@@ -117,14 +119,6 @@ export interface PredictionMarketDetail {
   history: PredictionHistoryPoint[];
   book: PredictionBookSnapshot;
   trades: PredictionTrade[];
-}
-
-export interface PredictionOrderPreviewIntent {
-  marketKey: string;
-  outcome: "yes" | "no";
-  side: "buy" | "sell";
-  price: number;
-  size: number;
 }
 
 export interface PredictionColumnDef extends ColumnConfig {

--- a/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
+++ b/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
@@ -12,6 +12,7 @@ import { webNativeRenderer } from "./native-renderer";
 import { WebToastHostProvider } from "./toast-host";
 import { webUiHost } from "./ui-host";
 import { getLoadablePlugins } from "../../../plugins/catalog";
+import { createPaneDiscoveryContext } from "../../../cli/pane-functions/discovery";
 import { setSharedMarketDataForTests } from "../../../plugins/registry";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "../../../plugins/runtime";
 import {
@@ -68,7 +69,11 @@ declare global {
 // frames can capture the shell before those requests register, leaving a
 // loading chart or stale performance table in an otherwise valid PNG.
 const SHOT_READY_STABLE_FRAMES = 10;
-const SHOT_LOADING_TEXT_PATTERN = /\b(Loading|Rendering pane)\b/i;
+// Loading is detected from an explicit marker rendered by Spinner and
+// PaneStatusBody. Matching on body text instead made any pane whose real
+// content contains the word "loading" (a changelog release note, a news
+// headline) wait forever and time out.
+const SHOT_LOADING_SELECTOR = "[data-gloom-status=\"loading\"]";
 const TRACKED_RESPONSE_METHODS = new Set<PropertyKey>([
   "arrayBuffer",
   "blob",
@@ -137,7 +142,23 @@ function resolveShotWork<T>(value: T): Promise<T> {
 }
 
 function isShotLoadingTextVisible(): boolean {
-  return SHOT_LOADING_TEXT_PATTERN.test(document.body.textContent ?? "");
+  return document.querySelector(SHOT_LOADING_SELECTOR) !== null;
+}
+
+/**
+ * The payload crosses into the webview as JSON, so every `Date` arrives as a
+ * string while the types still claim `Date`. Anything calling `date.getTime()`
+ * then throws, which is what made the valuation graph preset fail while the
+ * price presets passed.
+ */
+function revivePayloadDates(payload: CliPaneShotPayload): void {
+  for (const [, data] of payload.financials) {
+    const history = data.priceHistory;
+    if (!Array.isArray(history)) continue;
+    for (const point of history) {
+      if (!(point.date instanceof Date)) point.date = new Date(point.date as unknown as string);
+    }
+  }
 }
 
 function hasUnresolvedChartData(): boolean {
@@ -252,8 +273,17 @@ function createShotDataProvider(payload: CliPaneShotPayload): DataProvider {
           ?? financials.get(normalizeSymbol(target.symbol)))?.quote ?? null,
       })));
     },
-    getExchangeRate() {
-      return resolveShotWork(1);
+    getExchangeRate(fromCurrency: string) {
+      // Returning 1 for every currency used to render the FX matrix as a grid
+      // of 1.0000, which reads as real data. Only the identity conversion is
+      // known offline; anything else has to fail so the pane reports it as
+      // unavailable instead of inventing a parity rate.
+      if (normalizeSymbol(fromCurrency) === normalizeSymbol(payload.config.baseCurrency)) {
+        return resolveShotWork(1);
+      }
+      return trackShotWork(Promise.reject(
+        new Error(`No screenshot exchange rate available for ${fromCurrency}.`),
+      ));
     },
     getOptionsChain(ticker, exchange) {
       return trackShotWork(Promise.resolve().then(() => {
@@ -393,11 +423,29 @@ function createRuntime(payload: CliPaneShotPayload): PluginRuntimeAccess {
   };
 }
 
-function findPaneDef(paneId: string): { pluginId: string; pane: PaneDef } | null {
-  for (const plugin of getLoadablePlugins()) {
+function findPaneDef(paneId: string, config: AppConfig): { pluginId: string; pane: PaneDef } | null {
+  const plugins = getLoadablePlugins();
+  for (const plugin of plugins) {
     for (const pane of plugin.panes ?? []) {
       if (pane.id === paneId) return { pluginId: plugin.id, pane };
     }
+  }
+
+  // Panes contributed from setup() never reach plugin.panes, so replay setup
+  // with a collect-only context until the requested pane shows up.
+  for (const plugin of plugins) {
+    if (!plugin.setup) continue;
+    const discovery = createPaneDiscoveryContext({
+      getConfig: () => config,
+      marketData: shotDataProvider ?? undefined,
+    });
+    try {
+      void plugin.setup(discovery);
+    } catch {
+      // A plugin that fails partway can still have registered its pane.
+    }
+    const pane = discovery.panes.get(paneId);
+    if (pane) return { pluginId: plugin.id, pane };
   }
   return null;
 }
@@ -445,7 +493,7 @@ function ShotPane({ payload }: { payload: CliPaneShotPayload }) {
   const instance = payload.config.layout.instances.find((entry) => entry.instanceId === payload.paneId);
   if (!instance) throw new Error(`Pane instance ${payload.paneId} is missing from the screenshot layout.`);
 
-  const found = findPaneDef(instance.paneId);
+  const found = findPaneDef(instance.paneId, payload.config);
   if (!found) throw new Error(`Pane ${instance.paneId} is not registered in the desktop renderer.`);
 
   const runtime = createRuntime(payload);
@@ -500,6 +548,7 @@ function ShotPane({ payload }: { payload: CliPaneShotPayload }) {
 function render() {
   const payload = window.__GLOOM_CLI_SHOT_PAYLOAD__;
   if (!payload) throw new Error("Missing CLI pane screenshot payload.");
+  revivePayloadDates(payload);
   installShotFetchTracker();
   hydrateFredSeries(payload.fredSeries ?? []);
   installShotMarketData(payload);

--- a/src/renderers/electrobun/view/data-table/index.tsx
+++ b/src/renderers/electrobun/view/data-table/index.tsx
@@ -333,11 +333,13 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
                   lineHeight: "var(--cell-h)",
                 }}
               >
-                <div style={cellTextStyle(CSS_TEXT_BRIGHT, TextAttributes.BOLD)}>
+                {/* cellTextStyle is inline-block for real cells, so the title and
+                    hint would share one line and read as a single run-on string. */}
+                <div style={{ ...cellTextStyle(CSS_TEXT_BRIGHT, TextAttributes.BOLD), display: "block" }}>
                   {emptyStateTitle}
                 </div>
                 {emptyStateHint ? (
-                  <div style={cellTextStyle(CSS_TEXT_DIM, TextAttributes.NONE)}>
+                  <div style={{ ...cellTextStyle(CSS_TEXT_DIM, TextAttributes.NONE), display: "block" }}>
                     {emptyStateHint}
                   </div>
                 ) : null}

--- a/src/renderers/electrobun/view/native-stubs/chart/kitty-support.ts
+++ b/src/renderers/electrobun/view/native-stubs/chart/kitty-support.ts
@@ -7,3 +7,13 @@ export function getCachedKittySupport(_renderer: NativeRendererHost): boolean {
 export function ensureKittySupport(_renderer: NativeRendererHost): Promise<boolean> {
   return Promise.resolve(false);
 }
+
+// The desktop webview is never behind a terminal multiplexer and never draws
+// kitty graphics, so both answers are constant here.
+export function isMultiplexedTerminal(): boolean {
+  return false;
+}
+
+export function resolveKittySupport(): boolean {
+  return false;
+}

--- a/src/time-series/fundamentals.ts
+++ b/src/time-series/fundamentals.ts
@@ -600,12 +600,22 @@ function pointForStatement(
   };
 }
 
+/**
+ * `PricePoint.date` is typed as a `Date`, but history that has crossed a JSON
+ * boundary (persisted caches, the screenshot payload) arrives as a string. Read
+ * it defensively so a serialized round trip cannot crash valuation history.
+ */
+function pointTime(point: PricePoint): number {
+  const date = point.date;
+  return date instanceof Date ? date.getTime() : Date.parse(date as unknown as string);
+}
+
 function priceAtOrBefore(priceHistory: readonly PricePoint[], date: string): number | null {
   const target = Date.parse(date);
   if (!Number.isFinite(target)) return null;
   let closest: { time: number; close: number } | undefined;
   for (const point of priceHistory) {
-    const time = point.date.getTime();
+    const time = pointTime(point);
     if (!Number.isFinite(time) || time > target || !finiteNumber(point.close) || point.close <= 0) continue;
     if (!closest || time > closest.time) closest = { time, close: point.close };
   }


### PR DESCRIPTION
A sweep of all 71 registered panes across both renderers, checked with `gloomberb shot` for the desktop tree and a driven TUI instance for the terminal tree. Most of what came back reduces to three root causes, so this fixes the causes rather than each symptom.

## Wrong data presented as real

- **FX Cross Rates rendered a full grid of `1.0000`** when rates failed. `Promise.allSettled` swallowed the rejections, the pane stamped a fresh timestamp, and missing legs fell back to 1.0, so EUR/JPY read as parity. Missing legs now render unavailable and the failure reaches the footer.
- The screenshot renderer stubbed `getExchangeRate` as `1` for every currency, which is what produced that matrix offline. Only the identity conversion resolves now.
- **Market Heatmap clipped tile metrics mid-digit**: `$1.0T` became `Mkt $1.0`, `-2.63%` became `-2.63`. Tiles now drop a metric that does not fit.
- **Table cells and headers truncated with no marker**, producing `2026-08-1` dates and an `AS O` header. Column width now accounts for the header label, truncation always leaves an ellipsis, and adjacent headers keep a gap so `OI ENDS` and `EXP SIDE` stop reading as one column.
- **Insider** capped SEC filings at 20 before filtering Form 4, so an issuer with 20 newer non-Form-4 filings looked like it had none. **13F** silently truncated holdings at 2,000 rows, making large-fund weights wrong.
- **`EE` opened `corporate-actions`**, so Earnings Estimates returned dividends and splits.
- **Econ**: the `low` impact filter was identical to `all`, and the G7 country filter excluded France and Italy.
- **Correlation** always appended `<5 shared` regardless of sample count.
- **OMON** could show another expiry's strikes while the selected expiration was still loading.

## "No data" while the request was in flight

Around sixteen panes started `idle`, began fetching after first paint, and rendered a definitive negative in between. They now distinguish not-loaded, failed, and genuinely empty.

Failures that resolved to cached or partial data were also reported as fresh. Sectors, market movers, econ, earnings, fear and greed, IPO and the news aggregator now carry stale and error state through to the pane.

A shared `PaneStatusBody` standardizes the three states with one loading phrasing (`Loading x...`) and one failure phrasing (`X unavailable.`), replacing five spellings and two different ellipsis characters.

Two panes concatenated their empty-state title and message into one run-on string (`Market movers temporarily unavailableTry again in a moment.`). Root cause was `cellTextStyle` applying `display: inline-block` to the desktop empty state rows.

## Polling and sourcing

- Ad-hoc intervals in fx-matrix, sectors, market movers, treasury auctions, prediction markets and the news service ignored the user's configured cadence. All now use it.
- Yield curve, credit spreads, volatility, congress trades and earnings only refreshed on mount or manual reload.
- Removed duplicate fetch paths in alerts, relative valuation (per-peer instead of `loadSnapshotsBatch`), corporate actions, dividend yield (reloaded 10y of history on every price tick), holders, SEC, account management and sector news.
- The Polymarket detail socket stayed live after the pane lost focus. TV never re-resolved an expired stream.

## Platform

- **Kitty graphics are no longer claimed behind a terminal multiplexer.** Inside tmux the payload leaked as base64 text and destroyed the screen. Support is only claimed when the terminal answers the query; a non-answer means unsupported and the braille renderer takes over. Kitty support itself is unchanged.
- `gloomberb shot` now resolves runtime-registered panes (alerts, agent, IBKR) and stops uppercasing text arguments, so `shot AI "high growth software"` works.
- Shot readiness was gated on the word "loading" appearing anywhere in the body, so the changelog pane (whose release notes contain "loading") never settled. It now keys off an explicit status marker.
- Valuation-graph shots crashed on `point.date.getTime` because the payload crosses a JSON boundary that turns `Date` into a string.
- **Ticker Research rendered an empty body in the desktop screenshot path** because its tabs came from a plugin registry that renderer never binds. The module now owns its tab list.
- An exact shortcut match now outranks the signed-out AI row in the command bar; `HDS AAPL` used to put a disabled upsell first.

## UI conventions

- Footers no longer carry fixed labels or row counts (congress `House PTR`, `N tickers`, `N active`, analyst price targets, ACM plan metadata, substack article metadata, econ filter echo).
- Hint mnemonics normalized (`t` to "range", `r` to "es", `x` to "clear", `i` to "profile", `m` to "open"). Refresh stays unadvertised per pane, per #589.
- Terminal cell drawing replaced with real primitives: the ticker 52-week range bar, IBKR order tables, the econ NOW divider, substack article dividers, the volatility tenor selector, and the sector move bar.
- Reused kit components where panes had rolled their own: `DataTableView` for the FX matrix and IBKR tables, `Tabs` for the prediction-markets range strip, `Button` in help, shared `useUpdatedAgo` in polls and the AI screener.

## New surface

Pane settings for the quote-board panes (symbols and cadence), treasury history window, options chain refresh, alerts check interval, earnings monitor scope, and heatmap universe. In-pane filter chips for Options Flow, mouse-reachable country/impact filters for Econ, an in-pane search for Provider Search, and range/symbol controls for Correlation.

## Verification

`bun run typecheck` clean across all four projects. `bun test` 2150 pass, 0 fail. Re-shot the panes each fix targeted and confirmed the rendered output.

## Known limitations

- `shot` for quick-notes and X Feed still fails on the desktop backend RPC stub, which throws for any backend call. Separate from the pane registration fix.
- The shot renderer binds no plugin registry, so plugin-contributed tabs are still absent in screenshots. Ticker Research no longer depends on it; other registry-driven surfaces may.
- The yield curve has no as-of date because `/cloud/econ/yield-curve` does not return one. Faking it from fetch time would be a lie.
- OMON's first and last rows can still be half-clipped: the web scroll container scrolls by pixels, so row snapping belongs in the DataTable web host.
- Real historical short interest needs a new provider route.
