### PR TITLE
Reap the terminal media player instead of stranding it

### DIFF
--- a/src/plugins/builtin/tv/pane.tsx
+++ b/src/plugins/builtin/tv/pane.tsx
@@ -167,6 +167,10 @@ export function TvPane({ paneId, focused, width, height }: PaneProps) {
     void playInTerminal();
   }, [channel.id, isDesktop, loading, playInTerminal, stream]);
 
+  // Closing the pane must take the player with it; the media process is not
+  // tied to the React tree that started it.
+  useEffect(() => () => renderer.stopTerminalMedia?.(), [renderer]);
+
   const togglePlayback = useCallback(async () => {
     setPlaybackError(null);
     try {

--- a/src/renderers/opentui/host.tsx
+++ b/src/renderers/opentui/host.tsx
@@ -6,8 +6,11 @@ import type { KeyEventLike } from "../../react/input";
 import type { NativeRendererHost, PixelResolution, RendererHost } from "../../ui/host";
 import { colors } from "../../theme/colors";
 import { safeExternalUrl } from "../../utils/external-url";
+import { createTerminalMediaReaper, terminalMediaStateFile } from "./terminal-media";
 
 export { useKeyboard, useTerminalDimensions };
+
+const terminalMedia = createTerminalMediaReaper({ stateFile: terminalMediaStateFile() });
 
 export interface OpenTuiHost {
   renderer: CliRenderer;
@@ -140,6 +143,9 @@ export async function createOpenTuiHost(): Promise<OpenTuiHost> {
         throw new Error("mpv is required for terminal TV playback. Install mpv and try again.");
       }
 
+      // A player stranded by a previous run keeps decoding video, so clear it
+      // before adding another one.
+      terminalMedia.reapStale();
       renderer.suspend();
       try {
         const proc = Bun.spawn([
@@ -161,6 +167,7 @@ export async function createOpenTuiHost(): Promise<OpenTuiHost> {
           stdout: "inherit",
           stderr: "pipe",
         });
+        terminalMedia.track(proc);
         const stderrPromise = new Response(proc.stderr).text();
         const exitCode = await proc.exited;
         const stderr = await stderrPromise;
@@ -169,9 +176,13 @@ export async function createOpenTuiHost(): Promise<OpenTuiHost> {
           throw new Error(detail || `mpv exited with status ${exitCode}`);
         }
       } finally {
+        terminalMedia.stopActive();
         renderer.resume();
         renderer.requestRender();
       }
+    },
+    stopTerminalMedia() {
+      terminalMedia.stopActive();
     },
   };
 

--- a/src/renderers/opentui/terminal-media.test.ts
+++ b/src/renderers/opentui/terminal-media.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createTerminalMediaReaper, type TerminalMediaChild } from "./terminal-media";
+
+const dirs: string[] = [];
+
+function stateFile(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gloom-media-"));
+  dirs.push(dir);
+  return join(dir, "terminal-media.pid");
+}
+
+function fakeChild(pid: number): TerminalMediaChild & { killed: boolean; exit(): void } {
+  let resolveExit: (code: number) => void = () => {};
+  const exited = new Promise<number>((resolve) => { resolveExit = resolve; });
+  return {
+    pid,
+    killed: false,
+    kill() { this.killed = true; },
+    exited,
+    exit() { resolveExit(0); },
+  };
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+test("kills the player left behind by a run that was killed without warning", () => {
+  const file = stateFile();
+  writeFileSync(file, "4242", "utf8");
+  const killed: number[] = [];
+  const reaper = createTerminalMediaReaper({
+    stateFile: file,
+    isPlayerProcess: (pid) => pid === 4242,
+    killProcess: (pid) => killed.push(pid),
+    installExitHooks: false,
+  });
+
+  reaper.reapStale();
+
+  expect(killed).toEqual([4242]);
+  // The pid must not linger, or a later run kills whatever inherits it.
+  expect(existsSync(file)).toBe(false);
+});
+
+test("leaves a recycled pid alone when it is not our player", () => {
+  const file = stateFile();
+  writeFileSync(file, "4242", "utf8");
+  const killed: number[] = [];
+  const reaper = createTerminalMediaReaper({
+    stateFile: file,
+    isPlayerProcess: () => false,
+    killProcess: (pid) => killed.push(pid),
+    installExitHooks: false,
+  });
+
+  reaper.reapStale();
+
+  expect(killed).toEqual([]);
+});
+
+test("replacing a player kills the previous one and records the new pid", () => {
+  const file = stateFile();
+  const reaper = createTerminalMediaReaper({
+    stateFile: file,
+    isPlayerProcess: () => false,
+    killProcess: () => {},
+    installExitHooks: false,
+  });
+
+  const first = fakeChild(11);
+  const second = fakeChild(22);
+  reaper.track(first);
+  expect(readFileSync(file, "utf8")).toBe("11");
+
+  reaper.track(second);
+
+  expect(first.killed).toBe(true);
+  expect(second.killed).toBe(false);
+  expect(readFileSync(file, "utf8")).toBe("22");
+});
+
+test("a player that exits on its own clears the recorded pid", async () => {
+  const file = stateFile();
+  const reaper = createTerminalMediaReaper({
+    stateFile: file,
+    isPlayerProcess: () => false,
+    killProcess: () => {},
+    installExitHooks: false,
+  });
+
+  const child = fakeChild(33);
+  reaper.track(child);
+  child.exit();
+  await child.exited;
+  await Promise.resolve();
+
+  expect(existsSync(file)).toBe(false);
+});

--- a/src/renderers/opentui/terminal-media.ts
+++ b/src/renderers/opentui/terminal-media.ts
@@ -1,0 +1,142 @@
+import { homedir } from "os";
+import { join } from "path";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "fs";
+
+/** The subset of `Bun.Subprocess` this module needs, so tests can supply a fake. */
+export interface TerminalMediaChild {
+  readonly pid: number;
+  kill(): void;
+  readonly exited: Promise<number>;
+}
+
+export interface TerminalMediaReaperOptions {
+  /** File holding the pid of the player started by the most recent run. */
+  stateFile: string;
+  /** True when the pid is still running and is actually our media player. */
+  isPlayerProcess?(pid: number): boolean;
+  killProcess?(pid: number): void;
+  /** Install process exit hooks. Off in tests so the suite keeps its handlers. */
+  installExitHooks?: boolean;
+}
+
+export interface TerminalMediaReaper {
+  /** Kill a player left behind by a previous run of the app. */
+  reapStale(): void;
+  /** Adopt a freshly spawned player, replacing and killing any current one. */
+  track(child: TerminalMediaChild): void;
+  /** Kill the player this run started, if it is still going. */
+  stopActive(): void;
+}
+
+export function terminalMediaStateFile(): string {
+  return join(process.env.HOME || homedir(), ".gloomberb", "terminal-media.pid");
+}
+
+function defaultIsPlayerProcess(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 1) return false;
+  try {
+    // A recycled pid could belong to anything, so confirm the command first.
+    const probe = Bun.spawnSync(["ps", "-p", String(pid), "-o", "comm="]);
+    if (probe.exitCode !== 0) return false;
+    return probe.stdout.toString().toLowerCase().includes("mpv");
+  } catch {
+    return false;
+  }
+}
+
+function defaultKillProcess(pid: number): void {
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    // Already gone, or not ours to kill.
+  }
+}
+
+/**
+ * `mpv` outlives the app: it is a plain child process, and `bun run --watch`
+ * restarts by SIGKILLing the parent, so no exit handler ever runs. Every reload
+ * with the TV pane open used to strand another player decoding video forever.
+ *
+ * Recording the pid on disk lets the next run kill the previous player even
+ * though that run was killed without warning.
+ */
+export function createTerminalMediaReaper(options: TerminalMediaReaperOptions): TerminalMediaReaper {
+  const {
+    stateFile,
+    isPlayerProcess = defaultIsPlayerProcess,
+    killProcess = defaultKillProcess,
+    installExitHooks = true,
+  } = options;
+
+  let active: TerminalMediaChild | null = null;
+  let hooksInstalled = false;
+
+  function forgetState(): void {
+    try {
+      rmSync(stateFile, { force: true });
+    } catch {
+      // A stale pid file is harmless; the next reap validates it anyway.
+    }
+  }
+
+  function rememberState(pid: number): void {
+    try {
+      writeFileSync(stateFile, String(pid), "utf8");
+    } catch {
+      // Losing the pid only costs us cross-restart reaping, never correctness.
+    }
+  }
+
+  function stopActive(): void {
+    const child = active;
+    active = null;
+    if (child) {
+      try {
+        child.kill();
+      } catch {
+        // Already exited.
+      }
+    }
+    forgetState();
+  }
+
+  function installExitCleanup(): void {
+    if (hooksInstalled || !installExitHooks) return;
+    hooksInstalled = true;
+    // Covers orderly shutdown. A SIGKILLed parent is handled by reapStale.
+    process.on("exit", stopActive);
+    for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+      process.on(signal, () => {
+        stopActive();
+        process.exit(0);
+      });
+    }
+  }
+
+  return {
+    reapStale() {
+      if (!existsSync(stateFile)) return;
+      let pid = 0;
+      try {
+        pid = Number.parseInt(readFileSync(stateFile, "utf8").trim(), 10);
+      } catch {
+        pid = 0;
+      }
+      forgetState();
+      if (Number.isFinite(pid) && pid > 0 && isPlayerProcess(pid)) killProcess(pid);
+    },
+    track(child) {
+      stopActive();
+      active = child;
+      rememberState(child.pid);
+      installExitCleanup();
+      void child.exited.then(() => {
+        if (active === child) {
+          active = null;
+          forgetState();
+        }
+      }).catch(() => {});
+    },
+    stopActive,
+  };
+}

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -386,6 +386,8 @@ export interface RendererHost {
   notify(notification: AppNotificationRequest): void;
   showContextMenu?(items: ContextMenuItem[]): Promise<boolean>;
   playTerminalMedia?(url: string, title?: string, options?: { muted?: boolean }): Promise<void>;
+  /** Stop terminal playback started by `playTerminalMedia`. */
+  stopTerminalMedia?(): void;
   resolveLiveStream?(request: LiveStreamResolveRequest): Promise<ResolvedLiveStream>;
 }
 


### PR DESCRIPTION
The TV pane spawns `mpv` and never reaps it, so players accumulate. Reported after a run left one burning CPU in the background.

## What happens today

`src/renderers/opentui/host.tsx` spawns mpv with `Bun.spawn`, keeps the handle in a local, and only awaits `proc.exited`. There is no kill path anywhere: not on pane close, not on app exit, not on signal.

That alone strands one player. Under a dev watcher it compounds, because `src/plugins/builtin/tv/pane.tsx` auto-plays on mount and guards it with a `useRef` that is empty in every fresh process. So each reload restores the layout, re-mounts the pane, and starts another mpv while the previous one is still decoding video.

## Why exit hooks are not enough

`bun run --watch` hard-kills the app. Measured with a scratch app that logs from `exit`, `SIGINT` and `SIGTERM` handlers, then triggering a reload:

```
=== handler log ===
START
START
```

Two starts, no handler output. The process never gets a chance to clean up, so anything relying on parent-side teardown cannot work here.

## Fix

Record the active player's pid next to the config and reap it on the next run.

- `reapStale()` runs before each spawn and kills a player left by a previous run, but only after `ps -p <pid> -o comm=` confirms the pid is still mpv, so a recycled pid is never killed.
- `track()` replaces the current player, killing the previous one, and clears the recorded pid when the player exits on its own.
- Exit, SIGINT, SIGTERM and SIGHUP hooks still cover orderly shutdown. The app had no signal handlers at all, so these are additive and preserve Ctrl-C.
- New `stopTerminalMedia()` host method, called from the TV pane's unmount effect, so closing the pane takes the player with it. Reachable while suspended via `pane.close` remote control or a layout switch.

## Verification

Unit tests cover stale reaping, the recycled-pid guard, replacement, and self-exit cleanup.

End to end against real OS processes, using `sleep` in place of a media player so no video was involved:

```
--- run 1 (will be SIGKILLed, like bun --watch) ---
spawned 49142
orphan alive after SIGKILL of parent: sleep      <- reproduces the bug
--- run 2 (should reap the orphan) ---
orphan from run 1 now: REAPED
run 2 player: sleep                              <- exactly one player
```

`bun run typecheck` clean across all four projects. `bun test` 2154 pass, 0 fail.

## Note

A SIGKILL delivered to mpv's parent still cannot be intercepted, which is why the fix reaps on the next start rather than trying to prevent the orphan. The window where an orphan exists is bounded by the next app start.
