### PR TITLE
Bind a plugin registry in screenshots and consolidate quote monitor fetches

### DIFF
--- a/src/cli/pane-functions/screenshot.test.ts
+++ b/src/cli/pane-functions/screenshot.test.ts
@@ -5,6 +5,7 @@ import {
   chartEvidenceMismatchesFor,
   missingActiveTabSelections,
   shotDataEvidenceFor,
+  shotExpectedText,
   shotPriceHistoryRange,
   shotSemanticRowCount,
   shotUnavailableSymbols,
@@ -219,6 +220,15 @@ describe("pane screenshot chart-composer inputs", () => {
     (empty[0]!.metadata as any).baseSeries[0].pointCount = 0;
     expect(shotUnavailableSymbols(composer, payload([]), empty))
       .toEqual(["CAP:prediction-markets.series:polymarket:one"]);
+  });
+
+  test("expects the composer legend short label, not the catalog metric label", () => {
+    const valuation = {
+      ...resolved("valuation-series", { metric: "priceSales", period: "annual" }),
+      pane: { id: CHART_COMPOSER_PANE_ID },
+    } as unknown as ResolvedPaneFunction;
+
+    expect(shotExpectedText(valuation, ["AAPL"], payload([]))).toEqual(["AAPL", "P/S"]);
   });
 
   test("reports an empty FRED composer source as unavailable", () => {

--- a/src/cli/pane-functions/screenshot.ts
+++ b/src/cli/pane-functions/screenshot.ts
@@ -20,6 +20,7 @@ import {
   limitGraphRowsBySymbol,
   metricDef,
 } from "../../time-series/reporting";
+import { getTimeSeriesField } from "../../time-series/field-catalog";
 import {
   buildFinancialTableModel,
   formatFinancialHeader,
@@ -1022,7 +1023,7 @@ export function shotSemanticRowCount(
   return payload.financials.filter(([, financials]) => !!financials.quote).length;
 }
 
-function shotExpectedText(
+export function shotExpectedText(
   resolved: ResolvedPaneFunction,
   symbols: string[],
   payload: DesktopPaneShotPayload,
@@ -1034,8 +1035,14 @@ function shotExpectedText(
     const definition = metricDef(graphKind, metric);
     const period = resolved.options.period as FundamentalPeriod;
     const periodCount = resolved.options.periods == null ? null : Number(resolved.options.periods);
+    if (resolved.pane.id === CHART_COMPOSER_PANE_ID) {
+      // Chart series are labelled with the field short label ("P/S"), not the
+      // catalog label ("Price / Sales").
+      const field = getTimeSeriesField(`${graphKind}.${metric}`);
+      expected.push(field?.shortLabel ?? definition.label);
+      return expected.filter(Boolean);
+    }
     expected.push(definition.label);
-    if (resolved.pane.id === CHART_COMPOSER_PANE_ID) return expected.filter(Boolean);
     for (const [symbol, financials] of payload.financials) {
       const latestRow = limitGraphRowsBySymbol(
         graphRowsForFinancials(financials, graphKind, metric, period, symbol),

--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -25,6 +25,8 @@ import {
   type KeyEventLike,
 } from "../../../react/input";
 import { CompositeChart } from "./composite-chart";
+import { createDefaultConfig } from "../../../types/config";
+import { AppContext, createInitialState, PaneInstanceProvider } from "../../../state/app/context";
 import {
   resolveCompositeMinimumSpanMs,
   zoomCompositeViewport,
@@ -1515,6 +1517,58 @@ describe("CompositeChart", () => {
     expect(recoveredFrame).toContain("•");
     expect(recoveredFrame).toContain("2025-01-01");
     expect(recoveredFrame).toContain("Jan 9");
+  });
+
+  test("restores persisted drawings from pane settings on mount", async () => {
+    const renderWithSettings = async (settings: Record<string, unknown>) => {
+      const config = createDefaultConfig("/tmp/gloomberb-composite-drawings");
+      config.layout.instances.push({
+        instanceId: "chart:test",
+        paneId: "chart-composer",
+        title: "Chart",
+        binding: { kind: "fixed", symbol: "ACME" },
+        settings,
+      });
+      testSetup = await testRender(
+        <AppContext value={{ state: createInitialState(config), dispatch: () => {} }}>
+          <PaneInstanceProvider paneId="chart:test">
+            <CaptureChartSurfaceProvider>
+              <CompositeChart
+                width={60}
+                height={12}
+                series={[series("price", "main", "left", "USD", [100, 101, 102, 103, 104, 105, 106, 107, 108])]}
+                panels={[{ id: "main" }]}
+              />
+            </CaptureChartSurfaceProvider>
+          </PaneInstanceProvider>
+        </AppContext>,
+        { width: 62, height: 14 },
+      );
+      await act(async () => {
+        await testSetup!.renderOnce();
+        await testSetup!.renderOnce();
+      });
+      const bitmap = capturedSurfaceProps!.bitmaps?.[0] as { pixels: Uint8Array };
+      const pixels = Buffer.from(bitmap.pixels);
+      await act(async () => testSetup!.renderer.destroy());
+      testSetup = undefined;
+      return pixels;
+    };
+
+    const blank = await renderWithSettings({});
+    const restored = await renderWithSettings({
+      chartDrawings: [{
+        id: "drawing-1",
+        panelId: "main",
+        color: "#f5a524",
+        points: [
+          { time: Date.UTC(2025, 0, 2), value: 101 },
+          { time: Date.UTC(2025, 0, 8), value: 107 },
+        ],
+      }],
+    });
+
+    expect(restored.equals(blank)).toBe(false);
   });
 
   test("shows useful UTC times for an intraday shared cursor and time axis", async () => {

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -12,6 +12,7 @@ import {
   type ScrollBoxRenderable,
 } from "../../../ui";
 import { useShortcut } from "../../../react/input";
+import { useOptionalPaneInstanceId, usePaneSettingValue } from "../../../state/app/context";
 import { colors as themeColors, hoverBg } from "../../../theme/colors";
 import { formatPercentRaw } from "../../../utils/format";
 import { isPlainKey } from "../../../utils/keyboard";
@@ -1364,6 +1365,52 @@ function CompositeLegend({
   );
 }
 
+const CHART_DRAWINGS_SETTING_KEY = "chartDrawings";
+const NO_DRAWINGS: readonly ChartDrawing[] = [];
+/** Coalesces a drag into one write instead of one per pointer move. */
+const DRAWING_PERSIST_DELAY_MS = 400;
+
+/**
+ * Drawings are anchored to data, so they outlive the mounted chart: they ride
+ * along with the pane settings that already carry the chart spec. Only mounted
+ * inside a pane, so a standalone chart still renders without app state.
+ */
+function ChartDrawingStore({
+  paneInstanceId,
+  drawings,
+  onRestore,
+}: {
+  paneInstanceId: string;
+  drawings: readonly ChartDrawing[];
+  onRestore: (drawings: readonly ChartDrawing[]) => void;
+}) {
+  const [stored, setStored] = usePaneSettingValue<readonly ChartDrawing[]>(
+    CHART_DRAWINGS_SETTING_KEY,
+    NO_DRAWINGS,
+    paneInstanceId,
+  );
+  const restoredRef = useRef<readonly ChartDrawing[] | null>(null);
+  if (restoredRef.current === null) {
+    restoredRef.current = Array.isArray(stored) ? stored : NO_DRAWINGS;
+  }
+
+  useEffect(() => {
+    const restored = restoredRef.current;
+    if (restored && restored.length > 0) onRestore(restored);
+    // Restoring once on mount: later writes must not scroll back in time.
+  }, []);
+
+  useEffect(() => {
+    const restored = restoredRef.current ?? NO_DRAWINGS;
+    if (drawings === restored) return;
+    if (drawings.length === 0 && restored.length === 0) return;
+    const timer = setTimeout(() => setStored(drawings), DRAWING_PERSIST_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [drawings, setStored]);
+
+  return null;
+}
+
 export function CompositeChart({
   series,
   legendSeries,
@@ -1398,9 +1445,8 @@ export function CompositeChart({
   const [legendKeyboardIndex, setLegendKeyboardIndex] = useState<number | null>(null);
   const [toolSpan, setToolSpan] = useState<ChartToolSpan | null>(null);
   const [armedTool, setArmedTool] = useState<ChartToolKind | null>(null);
-  // ponytail: drawings live with the mounted chart. Persisting them belongs with
-  // pane settings, which is a separate plumbing job.
-  const [drawings, setDrawings] = useState<readonly ChartDrawing[]>([]);
+  const paneInstanceId = useOptionalPaneInstanceId();
+  const [drawings, setDrawings] = useState<readonly ChartDrawing[]>(NO_DRAWINGS);
   const [selectedDrawingId, setSelectedDrawingId] = useState<string | null>(null);
   const [drawColor, setDrawColor] = useState<string>(CHART_DRAWING_COLORS[0]);
   const addDrawing = useCallback((drawing: ChartDrawing) => {
@@ -1986,6 +2032,13 @@ export function CompositeChart({
             onActivate?.();
             pickDrawColor(color);
           }}
+        />
+      ) : null}
+      {paneInstanceId ? (
+        <ChartDrawingStore
+          paneInstanceId={paneInstanceId}
+          drawings={drawings}
+          onRestore={setDrawings}
         />
       ) : null}
       {scene.panels.map((panel) => (

--- a/src/components/onboarding/onboarding-wizard.test.tsx
+++ b/src/components/onboarding/onboarding-wizard.test.tsx
@@ -171,12 +171,16 @@ async function emitKeypress(event: { name?: string; sequence?: string }) {
   });
 }
 
-async function waitForFrame(text: string, attempts = 20): Promise<string> {
+async function waitForFrame(text: string, attempts = 40): Promise<string> {
   for (let index = 0; index < attempts; index += 1) {
     const frame = testSetup!.captureCharFrame();
     if (frame.includes(text)) return frame;
     await act(async () => {
-      await Bun.sleep(0);
+      // Sleeping zero only drains the task queue. These steps wait on real
+      // filesystem writes, so once the fast path has not settled the retries
+      // need actual elapsed time; otherwise a loaded machine runs out of
+      // attempts while the write is still in flight.
+      await Bun.sleep(index < 5 ? 0 : 5);
       await testSetup!.renderOnce();
     });
   }

--- a/src/components/ui/status.tsx
+++ b/src/components/ui/status.tsx
@@ -10,18 +10,21 @@ export interface EmptyStateProps {
 }
 
 export function EmptyState({ title, message, hint }: EmptyStateProps) {
+  // A fixed one-cell height clipped long text at the pane edge with no marker,
+  // so provider messages lost their tail. These rows own the pane body, so let
+  // them wrap instead.
   return (
     <Box flexDirection="column">
-      <Box height={1}>
+      <Box>
         <Text fg={colors.textDim}>{t(title)}</Text>
       </Box>
       {message && (
-        <Box height={1}>
+        <Box>
           <Text fg={colors.textMuted}>{t(message)}</Text>
         </Box>
       )}
       {hint && (
-        <Box height={1}>
+        <Box>
           <Text fg={colors.textMuted}>{t(hint)}</Text>
         </Box>
       )}

--- a/src/plugins/builtin/credit-conditions/client.ts
+++ b/src/plugins/builtin/credit-conditions/client.ts
@@ -89,6 +89,17 @@ export async function loadCreditConditions(
     rows.push(result.value.row);
     if (result.value.refreshError) errors.push(`${result.value.row.seriesId}: ${result.value.refreshError}`);
   });
-  if (rows.length === 0) throw new Error(errors.join("; ") || "Credit spread data unavailable");
+  if (rows.length === 0) throw new Error(summarizeSeriesErrors(errors));
   return { rows, stale: rows.some((row) => row.stale), errors };
+}
+
+/**
+ * Every series failing is one outage, not six. Joining all of them produced a
+ * message several times wider than the pane, which then got cut mid-word.
+ */
+function summarizeSeriesErrors(errors: readonly string[]): string {
+  if (errors.length === 0) return "Credit spread data unavailable";
+  const reasons = new Set(errors.map((entry) => entry.replace(/^[A-Z0-9]+:\s*/, "")));
+  const reason = reasons.size === 1 ? [...reasons][0]! : `${errors.length} series failed`;
+  return errors.length > 1 ? `${reason} (${errors.length} series)` : reason;
 }

--- a/src/plugins/builtin/ticker-detail/quote-monitor/card.test.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor/card.test.tsx
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../../../../renderers/opentui/test-utils";
+import type { Quote } from "../../../../types/financials";
+import type { QueryEntry } from "../../../../market-data/result-types";
+import { createIdleEntry } from "../../../../market-data/result-types";
+import { QuoteMonitorCard } from "./card";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+afterEach(async () => {
+  if (!testSetup) return;
+  await act(async () => {
+    testSetup!.renderer.destroy();
+  });
+  testSetup = undefined;
+});
+
+async function renderCard(quoteEntry: QueryEntry<Quote> | null): Promise<string> {
+  await act(async () => {
+    testSetup = await testRender(
+      <QuoteMonitorCard
+        symbol="MSFT"
+        ticker={null}
+        cachedFinancials={null}
+        quoteEntry={quoteEntry}
+        chartEntry={null}
+        width={40}
+        height={4}
+        showRightDivider={false}
+        showBottomDivider={false}
+        chartPeriod="1M"
+        valueFlashingEnabled={false}
+        onOpen={() => {}}
+      />,
+      { width: 40, height: 4 },
+    );
+  });
+  await act(async () => {
+    await testSetup!.renderOnce();
+  });
+  return testSetup!.captureCharFrame();
+}
+
+describe("QuoteMonitorCard without a quote", () => {
+  test("separates loading, unknown symbol and provider failure", async () => {
+    expect(await renderCard({ ...createIdleEntry<Quote>(), phase: "loading" }))
+      .toContain("Loading quote");
+
+    await act(async () => {
+      testSetup!.renderer.destroy();
+      testSetup = undefined;
+    });
+    expect(await renderCard({
+      ...createIdleEntry<Quote>(),
+      phase: "error",
+      error: { reasonCode: "NOT_FOUND", message: "No match" },
+    })).toContain("MSFT not recognized");
+
+    await act(async () => {
+      testSetup!.renderer.destroy();
+      testSetup = undefined;
+    });
+    expect(await renderCard({
+      ...createIdleEntry<Quote>(),
+      phase: "error",
+      error: { reasonCode: "UPSTREAM_ERROR", message: "Provider is down" },
+    })).toContain("Provider is down");
+  });
+});

--- a/src/plugins/builtin/ticker-detail/quote-monitor/card.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor/card.tsx
@@ -1,13 +1,8 @@
 import { useMemo } from "react";
 import { Box, Text, TextAttributes, useUiCapabilities } from "../../../../ui";
-import type { TickerFinancials } from "../../../../types/financials";
+import type { PricePoint, Quote, TickerFinancials } from "../../../../types/financials";
 import type { TickerRecord } from "../../../../types/ticker";
-import {
-  DEFAULT_LIVE_CHART_REFRESH_INTERVAL_MS,
-  useChartQuery,
-  useTickerFinancials,
-} from "../../../../market-data/hooks";
-import { instrumentFromTicker } from "../../../../market-data/request-types";
+import type { QueryEntry } from "../../../../market-data/result-types";
 import { resolveEntryData } from "../../../../market-data/selectors";
 import { useDoubleClickActivation } from "../../../../components/use-double-click-activation";
 import { colors, priceColor } from "../../../../theme/colors";
@@ -28,10 +23,31 @@ function quoteTrend(value: number | null | undefined): PriceSparklineTrend {
   return value > 0 ? "positive" : "negative";
 }
 
+/** A mistyped ticker and a broken provider are not the same problem. */
+const UNKNOWN_SYMBOL_REASONS = new Set(["NOT_FOUND", "BAD_MAPPING"]);
+
+interface QuoteStatus {
+  failed: boolean;
+  text: string;
+}
+
+function resolveQuoteStatus(entry: QueryEntry<Quote> | null, symbol: string): QuoteStatus {
+  const error = entry?.error;
+  if (error) {
+    return UNKNOWN_SYMBOL_REASONS.has(error.reasonCode)
+      ? { failed: true, text: `${symbol} not recognized` }
+      : { failed: true, text: error.message || "Quote unavailable" };
+  }
+  if (entry?.phase === "ready") return { failed: false, text: "No quote data" };
+  return { failed: false, text: "Loading quote..." };
+}
+
 export function QuoteMonitorCard({
   symbol,
   ticker,
   cachedFinancials,
+  quoteEntry,
+  chartEntry,
   width,
   height,
   showRightDivider,
@@ -43,6 +59,8 @@ export function QuoteMonitorCard({
   symbol: string;
   ticker: TickerRecord | null;
   cachedFinancials: TickerFinancials | null;
+  quoteEntry: QueryEntry<Quote> | null;
+  chartEntry: QueryEntry<PricePoint[]> | null;
   width: number;
   height: number;
   showRightDivider: boolean;
@@ -52,28 +70,18 @@ export function QuoteMonitorCard({
   onOpen: (symbol: string) => void;
 }) {
   const { nativePaneChrome } = useUiCapabilities();
-  const marketFinancials = useTickerFinancials(symbol, ticker);
-  const financials = marketFinancials ?? cachedFinancials;
-  const chartRequest = useMemo(() => {
-    const instrument = instrumentFromTicker(ticker, symbol);
-    return instrument
-      ? {
-        instrument,
-        bufferRange: chartPeriod,
-        granularity: "range" as const,
-      }
-      : null;
-  }, [chartPeriod, symbol, ticker]);
-  const chartEntry = useChartQuery(chartRequest, {
-    refreshIntervalMs: DEFAULT_LIVE_CHART_REFRESH_INTERVAL_MS,
-  });
+  const quote = resolveEntryData(quoteEntry) ?? cachedFinancials?.quote;
   const queriedPriceHistory = resolveEntryData(chartEntry);
   const priceHistory = queriedPriceHistory && queriedPriceHistory.length >= 2
     ? queriedPriceHistory
-    : financials?.priceHistory;
-  const flashDirection = useQuoteFlashDirection(financials, valueFlashingEnabled);
-  const quote = financials?.quote;
+    : cachedFinancials?.priceHistory;
+  const flashFinancials = useMemo<TickerFinancials | null>(
+    () => quote ? { quote, annualStatements: [], quarterlyStatements: [], priceHistory: [] } : null,
+    [quote],
+  );
+  const flashDirection = useQuoteFlashDirection(flashFinancials, valueFlashingEnabled);
   const display = getActiveQuoteDisplay(quote);
+  const quoteStatus = resolveQuoteStatus(quoteEntry, symbol);
   const changeColor = priceColor(display?.change ?? 0);
   const priceAttributes = flashDirection ? TextAttributes.DIM : TextAttributes.BOLD;
   const changeAttributes = flashDirection ? TextAttributes.DIM : TextAttributes.NONE;
@@ -155,7 +163,7 @@ export function QuoteMonitorCard({
           <Text attributes={TextAttributes.BOLD} fg={colors.textBright} style={desktopSymbolStyle}>
             {symbol}
           </Text>
-          <Text fg={colors.textDim}>Waiting for quote...</Text>
+          <Text fg={quoteStatus.failed ? colors.negative : colors.textDim}>{quoteStatus.text}</Text>
         </Box>
       ) : nativePaneChrome ? (
         <Box

--- a/src/plugins/builtin/ticker-detail/quote-monitor/index.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor/index.tsx
@@ -1,11 +1,16 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { Box, useUiCapabilities } from "../../../../ui";
 import type { PaneProps } from "../../../../types/plugin";
 import { TICKER_RESEARCH_PANE_ID } from "../../../../types/config";
 import type { QuoteSubscriptionTarget } from "../../../../types/data-provider";
-import { quoteSubscriptionTargetFromTicker } from "../../../../market-data/request-types";
+import type { TickerRecord } from "../../../../types/ticker";
+import type { ChartRequest, InstrumentRef } from "../../../../market-data/request-types";
+import { instrumentFromTicker, quoteSubscriptionTargetFromTicker } from "../../../../market-data/request-types";
+import { getSharedMarketDataCoordinator } from "../../../../market-data/coordinator";
+import { buildChartKey, buildQuoteKey } from "../../../../market-data/selectors";
+import { DEFAULT_LIVE_CHART_REFRESH_INTERVAL_MS, useChartQueries } from "../../../../market-data/hooks";
 import { useAppSelector, usePaneInstance, usePaneTicker } from "../../../../state/app/context";
-import { useQuoteUpdates } from "../../../../state/hooks/quote-streaming";
+import { useLiveQuoteEntries } from "../../../../state/hooks/quote-streaming";
 import { usePluginAppActions, usePluginTickerActions } from "../../../runtime";
 import { colors } from "../../../../theme/colors";
 import { EmptyState } from "../../../../components";
@@ -14,10 +19,18 @@ import { useShortcut } from "../../../../react/input";
 import { QuoteMonitorCard } from "./card";
 import { useLiveStreamingSetting } from "../../shared/live-streaming";
 
-function chunkSymbols(symbols: string[], columns: number): string[][] {
-  const rows: string[][] = [];
-  for (let index = 0; index < symbols.length; index += columns) {
-    rows.push(symbols.slice(index, index + columns));
+interface BoardEntry {
+  symbol: string;
+  ticker: TickerRecord | null;
+  instrument: InstrumentRef | null;
+  chartRequest: ChartRequest | null;
+  quoteKey: string | null;
+}
+
+function chunkEntries(entries: BoardEntry[], columns: number): BoardEntry[][] {
+  const rows: BoardEntry[][] = [];
+  for (let index = 0; index < entries.length; index += columns) {
+    rows.push(entries.slice(index, index + columns));
   }
   return rows;
 }
@@ -68,18 +81,54 @@ export function QuoteMonitorPane({ paneId, focused, width, height }: PaneProps) 
   const financialsBySymbol = useAppSelector((state) => state.financials);
   const tickersBySymbol = useAppSelector((state) => state.tickers);
   const valueFlashingEnabled = useAppSelector((state) => state.config.valueFlashingEnabled);
+  // One board-wide subscription and one board-wide history batch. Each card used
+  // to load its own snapshot and its own chart, so a twelve symbol board issued
+  // twenty four extra requests on top of the subscription it already had.
+  const boardEntries = useMemo<BoardEntry[]>(() => symbols.map((symbol) => {
+    const ticker = tickersBySymbol.get(symbol) ?? (fallbackTicker?.metadata.ticker === symbol ? fallbackTicker : null);
+    const instrument = instrumentFromTicker(ticker, symbol);
+    const chartRequest: ChartRequest | null = instrument
+      ? { instrument, bufferRange: settings.chartPeriod, granularity: "range" }
+      : null;
+    return {
+      symbol,
+      ticker,
+      instrument,
+      chartRequest,
+      quoteKey: instrument ? buildQuoteKey(instrument) : null,
+    };
+  }), [fallbackTicker, settings.chartPeriod, symbols, tickersBySymbol]);
   const streamingTargets = useMemo<QuoteSubscriptionTarget[]>(() => {
     const targets: QuoteSubscriptionTarget[] = [];
-    for (const symbol of symbols) {
-        const ticker = tickersBySymbol.get(symbol) ?? (fallbackTicker?.metadata.ticker === symbol ? fallbackTicker : null);
+    for (const { symbol, ticker } of boardEntries) {
         const target = quoteSubscriptionTargetFromTicker(ticker, symbol, "provider");
         if (target) {
           targets.push({ ...target, surface: "monitor", visible: true, selected: symbol === fallbackSymbol, weight: symbol === fallbackSymbol ? 100 : 90 });
         }
     }
     return targets;
-  }, [fallbackSymbol, fallbackTicker, symbols, tickersBySymbol]);
-  useQuoteUpdates(streamingTargets, { liveStreaming });
+  }, [boardEntries, fallbackSymbol]);
+  const { entries: quoteEntries } = useLiveQuoteEntries(streamingTargets, { liveStreaming });
+  const chartRequests = useMemo(
+    () => boardEntries.flatMap((entry) => entry.chartRequest ? [entry.chartRequest] : []),
+    [boardEntries],
+  );
+  const chartEntries = useChartQueries(chartRequests, {
+    refreshIntervalMs: DEFAULT_LIVE_CHART_REFRESH_INTERVAL_MS,
+  });
+  // Providers without a quote stream never fill the subscription, so warm the
+  // board with a single batched request instead of one snapshot per card. The
+  // polling path already batches when streaming is off.
+  const boardInstruments = useMemo(
+    () => boardEntries.flatMap((entry) => entry.instrument ? [entry.instrument] : []),
+    [boardEntries],
+  );
+  const boardInstrumentKey = boardEntries.map((entry) => entry.quoteKey ?? "").join("\u001f");
+  useEffect(() => {
+    const coordinator = getSharedMarketDataCoordinator();
+    if (!coordinator || !liveStreaming || boardInstruments.length === 0) return;
+    void coordinator.loadQuotesBatch(boardInstruments).catch(() => {});
+  }, [boardInstrumentKey, liveStreaming]);
   const { pinTicker } = usePluginTickerActions();
   const { openPaneSettings } = usePluginAppActions();
   const { nativePaneChrome } = useUiCapabilities();
@@ -102,7 +151,7 @@ export function QuoteMonitorPane({ paneId, focused, width, height }: PaneProps) 
   }
 
   const columns = resolveGridColumnCount(symbols.length, width, height, nativePaneChrome === true);
-  const rows = chunkSymbols(symbols, columns);
+  const rows = chunkEntries(boardEntries, columns);
   const contentWidth = Math.max(1, width - (nativePaneChrome ? 0 : 2));
   const contentHeight = Math.max(3, height);
   const cardHeight = Math.max(nativePaneChrome ? 4 : 3, Math.floor(contentHeight / rows.length));
@@ -124,24 +173,23 @@ export function QuoteMonitorPane({ paneId, focused, width, height }: PaneProps) 
           height: "100%",
         }}
       >
-        {symbols.map((symbol) => {
-          const ticker = tickersBySymbol.get(symbol) ?? (fallbackTicker?.metadata.ticker === symbol ? fallbackTicker : null);
-          return (
-            <QuoteMonitorCard
-              key={symbol}
-              symbol={symbol}
-              ticker={ticker}
-              cachedFinancials={financialsBySymbol.get(symbol) ?? null}
-              width={width}
-              height={height}
-              showRightDivider={false}
-              showBottomDivider
-              chartPeriod={settings.chartPeriod}
-              valueFlashingEnabled={valueFlashingEnabled}
-              onOpen={openTicker}
-            />
-          );
-        })}
+        {boardEntries.map((entry) => (
+          <QuoteMonitorCard
+            key={entry.symbol}
+            symbol={entry.symbol}
+            ticker={entry.ticker}
+            cachedFinancials={financialsBySymbol.get(entry.symbol) ?? null}
+            quoteEntry={entry.quoteKey ? quoteEntries.get(entry.quoteKey) ?? null : null}
+            chartEntry={entry.chartRequest ? chartEntries.get(buildChartKey(entry.chartRequest)) ?? null : null}
+            width={width}
+            height={height}
+            showRightDivider={false}
+            showBottomDivider
+            chartPeriod={settings.chartPeriod}
+            valueFlashingEnabled={valueFlashingEnabled}
+            onOpen={openTicker}
+          />
+        ))}
       </Box>
     );
   }
@@ -156,25 +204,24 @@ export function QuoteMonitorPane({ paneId, focused, width, height }: PaneProps) 
       overflow="hidden"
     >
       {rows.map((row, rowIndex) => (
-        <Box key={`${rowIndex}:${row.join(",")}`} flexDirection="row" height={cardHeight}>
-          {row.map((symbol, columnIndex) => {
-            const ticker = tickersBySymbol.get(symbol) ?? (fallbackTicker?.metadata.ticker === symbol ? fallbackTicker : null);
-            return (
-              <QuoteMonitorCard
-                key={symbol}
-                symbol={symbol}
-                ticker={ticker}
-                cachedFinancials={financialsBySymbol.get(symbol) ?? null}
-                width={cardWidth}
-                height={cardHeight}
-                showRightDivider={columnIndex < row.length - 1}
-                showBottomDivider={rowIndex < rows.length - 1}
-                chartPeriod={settings.chartPeriod}
-                valueFlashingEnabled={valueFlashingEnabled}
-                onOpen={openTicker}
-              />
-            );
-          })}
+        <Box key={`${rowIndex}:${row.map((entry) => entry.symbol).join(",")}`} flexDirection="row" height={cardHeight}>
+          {row.map((entry, columnIndex) => (
+            <QuoteMonitorCard
+              key={entry.symbol}
+              symbol={entry.symbol}
+              ticker={entry.ticker}
+              cachedFinancials={financialsBySymbol.get(entry.symbol) ?? null}
+              quoteEntry={entry.quoteKey ? quoteEntries.get(entry.quoteKey) ?? null : null}
+              chartEntry={entry.chartRequest ? chartEntries.get(buildChartKey(entry.chartRequest)) ?? null : null}
+              width={cardWidth}
+              height={cardHeight}
+              showRightDivider={columnIndex < row.length - 1}
+              showBottomDivider={rowIndex < rows.length - 1}
+              chartPeriod={settings.chartPeriod}
+              valueFlashingEnabled={valueFlashingEnabled}
+              onOpen={openTicker}
+            />
+          ))}
         </Box>
       ))}
     </Box>

--- a/src/plugins/builtin/ticker-detail/research-tabs.ts
+++ b/src/plugins/builtin/ticker-detail/research-tabs.ts
@@ -9,9 +9,10 @@ function hasStatementFinancials(financials: TickerFinancials | null | undefined)
 
 /**
  * Tabs this module owns. They are registered through `setup()` like any other
- * contribution, but the pane also falls back to them when it renders in a host
- * without a plugin registry (the desktop screenshot renderer), where an
- * unresolved registry would otherwise leave the body completely empty.
+ * contribution, and the pane also falls back to them in a host that has no
+ * plugin registry bound, where an unresolved registry would otherwise leave the
+ * body completely empty. Every shipping host binds one, so the fallback is a
+ * backstop rather than a code path anything relies on.
  */
 export const TICKER_RESEARCH_BUILTIN_TABS: TickerResearchTabDef[] = [
   {

--- a/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
+++ b/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { createRoot } from "react-dom/client";
-import { useEffect, type ComponentType, type ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { AppProvider, useAppDispatch } from "../../../state/app/context";
 import { createCliPaneShotConnectionHealth } from "./cli-pane-shot-health";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../../market-data/coordinator";
@@ -12,9 +12,7 @@ import { webNativeRenderer } from "./native-renderer";
 import { WebToastHostProvider } from "./toast-host";
 import { webUiHost } from "./ui-host";
 import { getLoadablePlugins } from "../../../plugins/catalog";
-import { createPaneDiscoveryContext } from "../../../cli/pane-functions/discovery";
-import { setSharedMarketDataForTests } from "../../../plugins/registry";
-import { PluginRenderProvider, type PluginRuntimeAccess } from "../../../plugins/runtime";
+import { PluginRegistry, setSharedMarketDataForTests } from "../../../plugins/registry";
 import {
   RemoteUiRegistryProvider,
   useRemoteUiRegistry,
@@ -31,6 +29,11 @@ import {
 } from "../../../time-series/resolution";
 import type { TimeRange } from "../../../components/chart/core/types";
 import type { AppConfig } from "../../../types/config";
+import type {
+  AppPersistencePort,
+  AppTickerRepositoryPort,
+} from "../../../core/app-service-ports";
+import type { CachedResourceRecord, ResourceCacheKey, SetResourceOptions } from "../../../data/resource-store";
 import type { CachedFinancialsTarget, DataProvider, QuoteSubscriptionTarget } from "../../../types/data-provider";
 import type { OptionsChain, TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
@@ -85,6 +88,7 @@ const TRACKED_RESPONSE_METHODS = new Set<PropertyKey>([
 let pendingShotWork = 0;
 let didInstallShotFetchTracker = false;
 let shotDataProvider: DataProvider | null = null;
+let shotRegistry: PluginRegistry | null = null;
 const SHOT_CHART_RESOLUTION_SUPPORT = normalizeChartResolutionSupport(
   TIME_RANGE_ORDER.map((maxRange) => ({
     resolution: getPresetResolution(maxRange),
@@ -347,15 +351,89 @@ function installShotMarketData(payload: CliPaneShotPayload): void {
   setSharedMarketDataCoordinator(coordinator);
 }
 
-function createRuntime(payload: CliPaneShotPayload): PluginRuntimeAccess {
-  const resumeState = new Map<string, unknown>();
-  const connectionHealth = createCliPaneShotConnectionHealth();
-  function getResumeState<T = unknown>(_pluginId: string, key: string): T | null {
-    return (resumeState.get(key) as T | undefined) ?? null;
-  }
-  function getConfigState<T = unknown>(pluginId: string, key: string): T | null {
-    return (payload.config.pluginConfig[pluginId]?.[key] as T | undefined) ?? null;
-  }
+/**
+ * The screenshot renderer has no database and no Electrobun backend. Plugins
+ * still need somewhere to read and write state while the render runs, so state
+ * lives in memory for the lifetime of the page and the resource cache always
+ * reports a miss instead of pretending something was persisted.
+ */
+function createShotPersistence(): AppPersistencePort {
+  const pluginState = new Map<string, { value: unknown; schemaVersion: number; updatedAt: number }>();
+  const stateKey = (pluginId: string, key: string) => `${pluginId}:${key}`;
+  return {
+    pluginState: {
+      get: <T,>(pluginId: string, key: string, schemaVersion = 1) => {
+        const record = pluginState.get(stateKey(pluginId, key));
+        if (!record || record.schemaVersion !== schemaVersion) return null;
+        return { value: record.value as T, schemaVersion: record.schemaVersion, updatedAt: record.updatedAt };
+      },
+      set: (pluginId: string, key: string, value: unknown, schemaVersion = 1) => {
+        pluginState.set(stateKey(pluginId, key), { value, schemaVersion, updatedAt: Date.now() });
+      },
+      delete: (pluginId: string, key: string) => {
+        pluginState.delete(stateKey(pluginId, key));
+      },
+      keys: (pluginId: string) => [...pluginState.keys()]
+        .filter((entry) => entry.startsWith(`${pluginId}:`))
+        .map((entry) => entry.slice(pluginId.length + 1))
+        .sort(),
+      clear: (pluginId: string) => {
+        for (const entry of [...pluginState.keys()]) {
+          if (entry.startsWith(`${pluginId}:`)) pluginState.delete(entry);
+        }
+      },
+    },
+    resources: {
+      get: () => null,
+      list: () => [],
+      set: <T,>(key: ResourceCacheKey, value: T, options: SetResourceOptions): CachedResourceRecord<T> => {
+        const fetchedAt = options.fetchedAt ?? Date.now();
+        return {
+          namespace: key.namespace,
+          kind: key.kind,
+          entityKey: key.entityKey,
+          variantKey: key.variantKey ?? "",
+          sourceKey: key.sourceKey ?? "",
+          value,
+          fetchedAt,
+          staleAt: fetchedAt + options.cachePolicy.staleMs,
+          expiresAt: fetchedAt + options.cachePolicy.expireMs,
+          schemaVersion: options.schemaVersion ?? 1,
+          provenance: options.provenance ?? null,
+          lastAccessedAt: fetchedAt,
+          sizeBytes: 0,
+        };
+      },
+      delete: () => {},
+    },
+    sessions: {
+      get: () => null,
+      set: () => {},
+      delete: () => {},
+    },
+    close() {},
+  };
+}
+
+function createShotTickerRepository(tickers: TickerRecord[]): AppTickerRepositoryPort {
+  const bySymbol = new Map(tickers.map((ticker) => [ticker.metadata.ticker, ticker]));
+  return {
+    loadAllTickers: async () => [...bySymbol.values()],
+    loadTicker: async (symbol) => bySymbol.get(normalizeSymbol(symbol)) ?? bySymbol.get(symbol) ?? null,
+    saveTicker: async () => {},
+    createTicker: async (metadata) => ({ metadata }),
+    deleteTicker: async () => {},
+  };
+}
+
+/**
+ * Screenshots render the same tree the desktop app renders, so they need the
+ * same registry: plugin-contributed tabs, slots, shortcuts, context menus and
+ * setup-registered panes all resolve through it. Only the capability surface is
+ * replaced, because the offline render can answer chart series from the payload
+ * but cannot reach a backend.
+ */
+async function installShotPluginRegistry(payload: CliPaneShotPayload): Promise<PluginRegistry> {
   const capabilitySeries = new Map(payload.capabilitySeries ?? []);
   const capabilityIds = [...new Set(payload.config.layout.instances.flatMap((instance) => {
     const chartSpec = instance.settings?.chartSpec;
@@ -366,88 +444,54 @@ function createRuntime(payload: CliPaneShotPayload): PluginRuntimeAccess {
         : []
     ));
   }))];
-  return {
-    getMarketData: () => shotDataProvider,
-    getConnectionHealth: () => connectionHealth,
-    getCapability: () => null,
-    capabilityManifests: (kind) => kind && kind !== "chart-series" ? [] : capabilityIds.map((id) => ({
-      id,
-      kind: "chart-series",
-      name: id,
-      operations: [{ id: "resolve", kind: "query", rendererSafe: true }],
-    })),
-    invokeCapability: async <T,>(capabilityId: string, operationId: string, input: unknown) => {
-      if (operationId !== "resolve" || !input || typeof input !== "object") {
-        throw new Error(`Screenshot capability operation ${capabilityId}.${operationId} is unavailable.`);
-      }
-      const request = input as { seriesId?: string };
-      const value = capabilitySeries.get(chartSeriesSourceKey({
-        kind: "capability",
-        capabilityId,
-        seriesId: request.seriesId ?? "",
-      }));
-      if (!value) throw new Error(`No screenshot chart series data is available for ${request.seriesId ?? capabilityId}.`);
-      return value as T;
+
+  const registry = new PluginRegistry(
+    shotDataProvider!,
+    createShotTickerRepository(payload.tickers),
+    createShotPersistence(),
+    {
+      enableCapabilityHandlers: false,
+      connectionHealth: createCliPaneShotConnectionHealth(),
+      remoteCapabilityManifests: () => capabilityIds.map((id) => ({
+        id,
+        kind: "chart-series",
+        name: id,
+        operations: [{ id: "resolve", kind: "query", rendererSafe: true }],
+      })),
+      remoteCapabilityInvoke: async <T,>(capabilityId: string, operationId: string, input: unknown) => {
+        if (operationId !== "resolve" || !input || typeof input !== "object") {
+          throw new Error(`Screenshot capability operation ${capabilityId}.${operationId} is unavailable.`);
+        }
+        const request = input as { seriesId?: string };
+        const value = capabilitySeries.get(chartSeriesSourceKey({
+          kind: "capability",
+          capabilityId,
+          seriesId: request.seriesId ?? "",
+        }));
+        if (!value) throw new Error(`No screenshot chart series data is available for ${request.seriesId ?? capabilityId}.`);
+        return value as T;
+      },
     },
-    getBrokerAdapter: () => null,
-    connectBrokerInstance: async () => {},
-    updateBrokerInstance: async () => {},
-    syncBrokerInstance: async () => {},
-    removeBrokerInstance: async () => {},
-    pinTicker: () => {},
-    navigateTicker: () => {},
-    selectTicker: () => {},
-    switchTab: () => {},
-    switchPanel: () => {},
-    openCommandBar: () => {},
-    showPane: () => {},
-    createPaneFromTemplate: () => {},
-    hidePane: () => {},
-    focusPane: () => {},
-    openPaneSettings: () => {},
-    openPluginCommandWorkflow: () => {},
-    notify: () => {},
-    subscribeResumeState: () => () => {},
-    getResumeState,
-    setResumeState: (_pluginId, key, value) => {
-      resumeState.set(key, value);
-    },
-    deleteResumeState: (_pluginId, key) => {
-      resumeState.delete(key);
-    },
-    getConfigState,
-    setConfigState: async () => {},
-    setConfigStates: async () => {},
-    deleteConfigState: async () => {},
-    getConfigStateKeys: (pluginId) => Object.keys(payload.config.pluginConfig[pluginId] ?? {}),
-  };
+  );
+  registry.getConfigFn = () => payload.config;
+  registry.getLayoutFn = () => payload.config.layout;
+  registry.getPaneRuntimeStateFn = (paneId) => payload.paneState[paneId] ?? null;
+
+  for (const plugin of getLoadablePlugins()) {
+    try {
+      await registry.register(plugin);
+    } catch (error) {
+      // One failing plugin must not cost the screenshot every other pane.
+      console.error(`[shot] Plugin ${plugin.id} failed to register:`, error);
+    }
+  }
+  shotRegistry = registry;
+  return registry;
 }
 
-function findPaneDef(paneId: string, config: AppConfig): { pluginId: string; pane: PaneDef } | null {
-  const plugins = getLoadablePlugins();
-  for (const plugin of plugins) {
-    for (const pane of plugin.panes ?? []) {
-      if (pane.id === paneId) return { pluginId: plugin.id, pane };
-    }
-  }
-
-  // Panes contributed from setup() never reach plugin.panes, so replay setup
-  // with a collect-only context until the requested pane shows up.
-  for (const plugin of plugins) {
-    if (!plugin.setup) continue;
-    const discovery = createPaneDiscoveryContext({
-      getConfig: () => config,
-      marketData: shotDataProvider ?? undefined,
-    });
-    try {
-      void plugin.setup(discovery);
-    } catch {
-      // A plugin that fails partway can still have registered its pane.
-    }
-    const pane = discovery.panes.get(paneId);
-    if (pane) return { pluginId: plugin.id, pane };
-  }
-  return null;
+function findPaneDef(paneId: string): { pluginId: string; pane: PaneDef } | null {
+  const pane = shotRegistry?.panes.get(paneId);
+  return pane ? { pluginId: shotRegistry?.getPanePluginId(paneId) ?? "", pane } : null;
 }
 
 function HydratePayload({
@@ -493,19 +537,11 @@ function ShotPane({ payload }: { payload: CliPaneShotPayload }) {
   const instance = payload.config.layout.instances.find((entry) => entry.instanceId === payload.paneId);
   if (!instance) throw new Error(`Pane instance ${payload.paneId} is missing from the screenshot layout.`);
 
-  const found = findPaneDef(instance.paneId, payload.config);
+  const found = findPaneDef(instance.paneId);
   if (!found) throw new Error(`Pane ${instance.paneId} is not registered in the desktop renderer.`);
 
-  const runtime = createRuntime(payload);
-  const PaneComponent = found.pane.component as ComponentType<any>;
-  const pane: PaneDef = {
-    ...found.pane,
-    component: (props) => (
-      <PluginRenderProvider pluginId={found.pluginId} runtime={runtime}>
-        <PaneComponent {...props} />
-      </PluginRenderProvider>
-    ),
-  };
+  // The registry already bound its runtime to this pane component.
+  const pane = found.pane;
   const titleState = {
     config: payload.config,
     paneState: payload.paneState,
@@ -545,13 +581,16 @@ function ShotPane({ payload }: { payload: CliPaneShotPayload }) {
   );
 }
 
-function render() {
+async function render() {
   const payload = window.__GLOOM_CLI_SHOT_PAYLOAD__;
   if (!payload) throw new Error("Missing CLI pane screenshot payload.");
   revivePayloadDates(payload);
   installShotFetchTracker();
   hydrateFredSeries(payload.fredSeries ?? []);
   installShotMarketData(payload);
+  // Panes contributed from an async setup() only exist once every plugin has
+  // finished registering, so the tree cannot mount before that resolves.
+  await installShotPluginRegistry(payload);
 
   const rootElement = document.getElementById("root");
   if (!rootElement) throw new Error("Missing root element.");
@@ -582,9 +621,7 @@ function render() {
   );
 }
 
-try {
-  render();
-} catch (error) {
+render().catch((error) => {
   window.__GLOOM_CLI_SHOT_ERROR__ = error instanceof Error ? error.stack ?? error.message : String(error);
   throw error;
-}
+});

--- a/src/renderers/electrobun/view/data-table/index.tsx
+++ b/src/renderers/electrobun/view/data-table/index.tsx
@@ -199,16 +199,12 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
     scheduleVisibleRangeMeasure();
   }, [items.length, scheduleVisibleRangeMeasure, visibleRangeKey]);
 
+  // Rows sit on a whole-cell grid, so the offset is computed in rows and only
+  // then converted to pixels. Letting the virtualizer scroll by pixels landed
+  // mid-row and clipped the first and last visible rows into slivers.
   useEffect(() => {
     if (scrollToIndex == null || items.length === 0) return;
     const targetIndex = Math.max(0, Math.min(scrollToIndex, items.length - 1));
-    if (virtualize) {
-      rowVirtualizer.scrollToIndex(targetIndex, {
-        align: scrollToIndexAlign === "center" ? "center" : "auto",
-      });
-      scheduleVisibleRangeMeasure();
-      return;
-    }
     const element = bodyElementRef.current;
     if (!element) return;
     const viewportRows = Math.max(1, Math.floor(element.clientHeight / WEB_CELL_HEIGHT) - 1);
@@ -227,12 +223,10 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
     scheduleVisibleRangeMeasure();
   }, [
     items.length,
-    rowVirtualizer,
     scrollToIndex,
     scrollToIndexAlign,
     scrollToIndexVersion,
     scheduleVisibleRangeMeasure,
-    virtualize,
   ]);
 
   useScrollBoxHandle(
@@ -276,6 +270,9 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
     overflowX: horizontalScrollEnabled ? "auto" : "hidden",
     overflowY: "auto",
     backgroundColor: CSS_BG,
+    // Trim the viewport to whole rows so the bottom row is never a sliver.
+    // Browsers without CSS round() drop this and keep the previous behavior.
+    maxHeight: "round(down, 100%, var(--cell-h))",
   };
 
   return (

--- a/src/renderers/electrobun/view/native-stubs/backend-rpc.ts
+++ b/src/renderers/electrobun/view/native-stubs/backend-rpc.ts
@@ -1,3 +1,4 @@
+import { NOTES_FILES_CAPABILITY_ID } from "../../../../capabilities";
 import type {
   ApplicationMenuSelectMessage,
   CapabilityEventMessage,
@@ -28,8 +29,25 @@ export function backendRequest<K extends Exclude<DesktopBackendRequestMethod, "c
   method: K,
   ...args: DesktopBackendRequestArgs<K>
 ): Promise<DesktopBackendRequestResponse<K>>;
-export async function backendRequest(): Promise<unknown> {
+export async function backendRequest(method: string, payload?: unknown): Promise<unknown> {
+  const neutral = neutralReadResult(method, payload);
+  if (neutral !== undefined) return neutral;
   throw new Error("Electrobun backend requests are unavailable in the CLI screenshot renderer.");
+}
+
+/**
+ * There is no backend behind a screenshot, so a read that only feeds the view
+ * degrades to an empty result and the pane renders its real empty state instead
+ * of the whole render dying on one rejected request. Writes keep throwing: a
+ * pane must never believe it saved something that went nowhere.
+ */
+function neutralReadResult(method: string, payload: unknown): unknown {
+  if (method !== "capability.invoke") return undefined;
+  const request = payload as { capabilityId?: string; operationId?: string } | undefined;
+  if (request?.capabilityId !== NOTES_FILES_CAPABILITY_ID) return undefined;
+  if (request.operationId === "load") return "";
+  if (request.operationId === "loadQuickNotesIndex") return [];
+  return undefined;
 }
 
 export async function initElectrobunBackend(): Promise<ElectrobunBackendInit> {


### PR DESCRIPTION
Follow-ups from the pane audit that the first pass (#598) left open. Independent of #599.

## Screenshot renderer bound no plugin registry

`cli-pane-shot-entry.tsx` hand-rolled a `PluginRuntimeAccess` and never constructed a `PluginRegistry`, so `getSharedRegistry()` was `undefined` for the entire render. Every registry-driven surface was silently degraded: plugin slots, inline tickers, context menus, help shortcuts and the Kelly ticker lookup.

This is what made Ticker Research render a blank body in #598. That was worked around by having the module own its tab list; the workaround stays as a backstop, but the cause is fixed and `T AAPL` now renders plugin-contributed tabs including `Tweets`.

## X Feed could not be screenshotted

Separate cause, and a subtle one. `composeBuiltinPlugin.setup` is `async` and awaits each module, but the discovery replay added in #598 called `void plugin.setup(...)` and then read `discovery.panes` synchronously, so it only ever saw the first module's panes. `twitter-feed` is the sixth module of `gloomberb-cloud`. Registration is now awaited before mount and `findPaneDef` is a plain registry lookup.

The three panes #598 did fix (`alerts`, `local-agent-workspace`, `ibkr-trading`) passed by luck of module ordering.

## Quick Notes could not be screenshotted

The desktop backend stub threw for every request. Reads now degrade to an empty note and an empty index so the pane renders its real empty state. Writes still throw, so a pane can never believe it persisted something it did not.

## Quote Monitor issued redundant requests per symbol

The board streamed quotes, and then every card independently called `useTickerFinancials` and `useChartQuery`. A twelve symbol board meant twelve snapshot loads and twelve history loads layered on the subscription. Cards now receive batched entries from one board-level load: one subscription, one batched history query, one quote warmup.

The card also conflated three states behind `Waiting for quote...`: a pending request, an unknown symbol, and a failed provider all looked identical and permanent. It now reads the entry error and distinguishes not recognized, provider failure, no data, and loading.

## Desktop tables clipped their first and last rows

The web scroll container scrolls by pixels while rows are a fixed cell height, so `scrollToIndex` landed mid-row and the top and bottom rows rendered as half-height slivers. Scroll offsets now land on whole rows and the viewport is trimmed to a whole number of them. Fixed in the host, so it applies to every desktop table rather than only the options chain where it was noticed.

## Chart annotations vanished on remount

Trend lines and drawings lived only in mounted component state even though the chart spec is persisted, so closing a pane, switching layouts or restarting silently discarded them. They now persist through the same pane setting as the spec, restored on mount and written debounced so a drag is one write rather than one per pointer move.

## Smaller items

- The valuation graph screenshot expectation wanted `Price / Sales`, but the composer legend emits the field `shortLabel`, so it renders `P/S`. `GF` only passed because its label and short label happen to match. `GE AAPL` went from `mismatch=true; usable=false` to `mismatch=false; usable=true`.
- Credit spreads joined all six FRED series failures into one message several times wider than the pane, which then cut mid-word. One outage now reads `Failed to fetch (6 series)`.
- `EmptyState` pinned each row to one cell of height, clipping long text with no ellipsis. Rows now wrap, since they own the pane body.

## Verification

`bun run typecheck` clean across all four projects. `bun test` 2153 pass, 0 fail.

Full screenshot sweep of all 64 non-TV catalog tokens: **64 rendered, 0 failures**. For reference, that number was 55 before #598 and 62 before this branch.

Row clipping and annotation persistence were both verified by comparing rendered images before and after, not by reasoning.

## Still open, and why

- The yield curve has no as-of date. The data exists via the FRED series path, but switching the pane to it would mean ten cold requests instead of one to work around `/cloud/econ/yield-curve` omitting the field. That belongs on the API.
- Real historical short interest needs a new provider route.
- There is no batched financials snapshot hook in `market-data/hooks.tsx` (`useTickerFinancialsMap` observes but never loads), so the quote monitor warms up through the coordinator directly. A `useQuoteWarmup` style hook belongs next to `useQuoteEntries`.
- The five news panes still have no source/category/sentiment filter bar. Those fields are now visible sortable columns, so this is a feature rather than a defect.
