### PR TITLE
Add a Data Catalog pane for chartable Custom Chart series.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Use `HELP` inside Gloomberb for the live shortcut list. The common command-bar p
 | `DES <ticker>` / `T <ticker>` | Security details for a ticker |
 | `FA <ticker>` | Financial statement view |
 | `G <series>` | Custom chart composer |
+| `CAT [query]` | Browse and search chartable series |
 | `GP <ticker>` | Price chart |
 | `GIP <ticker>` | Intraday price chart |
 | `HP <ticker>` | Historical OHLCV prices |
@@ -235,7 +236,7 @@ Use `HELP` inside Gloomberb for the live shortcut list. The common command-bar p
 
 ### Chart Composer
 
-`G`, `GP`, `GIP`, `CMP`, `GF`, and `GE` all open the same chart composer with different starting presets. A custom expression can mix unrelated data sources on one synchronized timeline:
+`G`, `GP`, `GIP`, `CMP`, `GF`, and `GE` all open the same chart composer with different starting presets. `CAT` opens a searchable catalog of those chartable series so you can graph one without typing the expression. A custom expression can mix unrelated data sources on one synchronized timeline:
 
 ```text
 G AAPL:price, MSFT:revenue, FRED:CPIAUCSL

--- a/src/plugins/builtin/chart-composer/catalog-inventory.test.ts
+++ b/src/plugins/builtin/chart-composer/catalog-inventory.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import {
+  catalogEmptyCopy,
+  catalogExpressionForRow,
+  catalogRowsForResolvedInstruments,
+  filterCatalogRows,
+  listStaticCatalogInventory,
+  looksLikeCatalogTickerQuery,
+} from "./catalog-inventory";
+
+const AAPL = { symbol: "AAPL", exchange: "NASDAQ", name: "Apple Inc." };
+const MSFT = { symbol: "MSFT", exchange: "NASDAQ", name: "Microsoft Corp." };
+
+describe("data catalog inventory", () => {
+  test("lists equity fields once and asks for a ticker when graphing", () => {
+    const rows = listStaticCatalogInventory([AAPL, MSFT]);
+    const securities = filterCatalogRows(rows, "securities", "");
+    expect(securities.some((row) => row.label === "Close")).toBe(true);
+    expect(securities.every((row) => row.needsTicker && row.expression.startsWith("TICKER:"))).toBe(true);
+    expect(securities.every((row) => !row.label.includes("AAPL") && !row.label.includes("MSFT"))).toBe(true);
+    expect(securities.filter((row) => row.label === "Close")).toHaveLength(1);
+
+    const close = securities.find((row) => row.label === "Close");
+    expect(catalogExpressionForRow(close!, "aapl")).toBe("AAPL:close");
+    expect(catalogExpressionForRow(close!, "")).toBeNull();
+    expect(securities.find((row) => row.id === "field:market.ohlcv")?.expression).toBe("TICKER:price");
+  });
+
+  test("options tab lists contract market fields and asks for an option symbol", () => {
+    const rows = listStaticCatalogInventory([AAPL]);
+    const options = filterCatalogRows(rows, "options", "");
+    expect(options.some((row) => row.label === "Close")).toBe(true);
+    expect(options.some((row) => row.label === "Volume")).toBe(true);
+    expect(options.every((row) => row.needsTicker && row.expression.startsWith("TICKER:"))).toBe(true);
+    expect(options.every((row) => row.kind === "Options" && row.sourceId === "option")).toBe(true);
+    expect(options.some((row) => row.label === "PEG Ratio")).toBe(false);
+
+    const close = options.find((row) => row.label === "Close");
+    expect(catalogExpressionForRow(close!, "AAPL 260618C00200000")).toBe("AAPL260618C00200000:close");
+    expect(catalogExpressionForRow(close!, "aapl260618c00200000")).toBe("AAPL260618C00200000:close");
+    expect(catalogExpressionForRow(close!, "")).toBeNull();
+  });
+
+  test("crypto tab lists pairs, not equity fields", () => {
+    const rows = listStaticCatalogInventory([
+      AAPL,
+      { symbol: "ETH-USD", exchange: "CCC", name: "Ethereum USD" },
+    ]);
+    const crypto = filterCatalogRows(rows, "crypto", "");
+    expect(crypto.length).toBeGreaterThan(0);
+    expect(crypto.every((row) => row.sourceId === "crypto" && row.kind === "Crypto")).toBe(true);
+    expect(crypto.some((row) => row.expression === "ETH-USD:price")).toBe(true);
+    expect(crypto.some((row) => row.expression === "BTC-USD:price")).toBe(true);
+    expect(crypto.every((row) => !row.needsTicker)).toBe(true);
+    expect(filterCatalogRows(rows, "securities", "").some((row) => row.sourceId === "crypto")).toBe(false);
+  });
+
+  test("FRED tab includes mapped series and treasuries; futures stay on their own tab", () => {
+    const rows = listStaticCatalogInventory([]);
+    const fred = filterCatalogRows(rows, "fred", "");
+    const seriesIds = fred.filter((row) => row.sourceId === "fred").map((row) => row.expression);
+    expect(new Set(seriesIds).size).toBe(seriesIds.length);
+    expect(fred.some((row) => row.expression === "FRED:CPIAUCSL")).toBe(true);
+    expect(fred.some((row) => row.expression === "UST:10Y" && row.kind === "Treasury")).toBe(true);
+    expect(fred.every((row) => row.sourceId === "fred" || row.sourceId === "treasury")).toBe(true);
+
+    const futures = filterCatalogRows(rows, "futures", "");
+    expect(futures.some((row) => row.expression === "FUT:ES")).toBe(true);
+    expect(futures.every((row) => row.sourceId === "futures")).toBe(true);
+    expect(futures.some((row) => row.sourceId === "treasury")).toBe(false);
+  });
+
+  test("resolves a ticker query onto chartable rows without treating field names as tickers", () => {
+    expect(looksLikeCatalogTickerQuery("AAPL")).toBe(true);
+    expect(looksLikeCatalogTickerQuery("btc-usd")).toBe(true);
+    expect(looksLikeCatalogTickerQuery("close")).toBe(false);
+    expect(looksLikeCatalogTickerQuery("price")).toBe(false);
+
+    const resolved = catalogRowsForResolvedInstruments([AAPL]);
+    expect(resolved.some((row) => row.expression === "AAPL:close")).toBe(true);
+    expect(resolved.some((row) => row.expression === "AAPL:price")).toBe(true);
+    expect(resolved.every((row) => !row.needsTicker && row.label.startsWith("AAPL"))).toBe(true);
+    expect(filterCatalogRows(resolved, "securities", "AAPL").some((row) => row.expression === "AAPL:close")).toBe(true);
+  });
+
+  test("empty copy covers loading and query misses without a retry hint", () => {
+    expect(catalogEmptyCopy(true, "AAPL")).toEqual({ title: "Loading catalog…" });
+    expect(catalogEmptyCopy(false, "AAPL")).toEqual({
+      title: 'No series matching "AAPL"',
+      hint: "Press / to search.",
+    });
+    expect(catalogEmptyCopy(false, "")).toEqual({
+      title: "No series",
+      hint: "Press / to search.",
+    });
+  });
+});

--- a/src/plugins/builtin/chart-composer/catalog-inventory.ts
+++ b/src/plugins/builtin/chart-composer/catalog-inventory.ts
@@ -1,0 +1,366 @@
+import { resolveAssetDisplayKind } from "../../../market-data/market/format";
+import {
+  getTimeSeriesField,
+  isMarketFieldId,
+  listTimeSeriesFields,
+} from "../../../time-series/field-catalog";
+import { parseOptionSymbol } from "../../../utils/options";
+import { listFredCatalogSeries } from "../econ/fred-series-map";
+import {
+  FUTURES_CONTRACTS,
+  FUTURES_SECTOR_LABELS,
+} from "../futures/contracts";
+import { TREASURY_MATURITIES } from "../yield-curve/treasury-data";
+import { fieldCategory, type SeriesCatalogInstrument } from "./series-catalog";
+
+export const CHART_COMPOSER_TEMPLATE_ID = "chart-composer-pane";
+export const DATA_CATALOG_PANE_ID = "data-catalog";
+export const DATA_CATALOG_TEMPLATE_ID = "data-catalog-pane";
+
+export type CatalogSourceId =
+  | "security"
+  | "option"
+  | "crypto"
+  | "fred"
+  | "futures"
+  | "treasury";
+
+export type CatalogFilterId =
+  | "all"
+  | "securities"
+  | "options"
+  | "crypto"
+  | "fred"
+  | "futures";
+
+export interface CatalogSeriesRow {
+  id: string;
+  label: string;
+  source: string;
+  sourceId: CatalogSourceId;
+  kind: string;
+  expression: string;
+  url?: string;
+  searchText: string;
+  needsTicker?: boolean;
+  fieldToken?: string;
+}
+
+export const CATALOG_FILTERS: ReadonlyArray<{ id: CatalogFilterId; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "securities", label: "Securities" },
+  { id: "options", label: "Options" },
+  { id: "crypto", label: "Crypto" },
+  { id: "fred", label: "FRED" },
+  { id: "futures", label: "Futures" },
+];
+
+const FILTER_SOURCES: Record<CatalogFilterId, ReadonlySet<CatalogSourceId> | null> = {
+  all: null,
+  securities: new Set(["security"]),
+  options: new Set(["option"]),
+  crypto: new Set(["crypto"]),
+  fred: new Set(["fred", "treasury"]),
+  futures: new Set(["futures"]),
+};
+
+const CRYPTO_CATALOG: ReadonlyArray<{ symbol: string; name: string }> = [
+  { symbol: "BTC-USD", name: "Bitcoin" },
+  { symbol: "ETH-USD", name: "Ethereum" },
+  { symbol: "SOL-USD", name: "Solana" },
+  { symbol: "XRP-USD", name: "XRP" },
+  { symbol: "BNB-USD", name: "BNB" },
+  { symbol: "DOGE-USD", name: "Dogecoin" },
+  { symbol: "ADA-USD", name: "Cardano" },
+  { symbol: "AVAX-USD", name: "Avalanche" },
+  { symbol: "LINK-USD", name: "Chainlink" },
+  { symbol: "DOT-USD", name: "Polkadot" },
+  { symbol: "LTC-USD", name: "Litecoin" },
+  { symbol: "UNI-USD", name: "Uniswap" },
+  { symbol: "ATOM-USD", name: "Cosmos" },
+  { symbol: "NEAR-USD", name: "NEAR" },
+  { symbol: "APT-USD", name: "Aptos" },
+  { symbol: "SUI-USD", name: "Sui" },
+  { symbol: "TON-USD", name: "Toncoin" },
+  { symbol: "SHIB-USD", name: "Shiba Inu" },
+];
+
+function isOptionInstrument(instrument: SeriesCatalogInstrument): boolean {
+  const category = instrument.assetCategory?.trim().toUpperCase();
+  return category === "OPT" || parseOptionSymbol(instrument.symbol) != null;
+}
+
+function chartFieldToken(fieldId: string): string {
+  if (fieldId === "market.ohlcv") return "price";
+  return fieldId.split(".").at(-1) ?? fieldId;
+}
+
+function row(entry: {
+  id: string;
+  label: string;
+  source: string;
+  sourceId: CatalogSourceId;
+  kind: string;
+  expression: string;
+  url?: string;
+  searchExtra?: string;
+  needsTicker?: boolean;
+  fieldToken?: string;
+}): CatalogSeriesRow {
+  const { searchExtra, ...fields } = entry;
+  return {
+    ...fields,
+    searchText: [
+      entry.label,
+      entry.source,
+      entry.kind,
+      entry.expression,
+      entry.sourceId,
+      searchExtra,
+    ].filter(Boolean).join(" ").toLowerCase(),
+  };
+}
+
+function isCatalogCryptoInstrument(instrument: SeriesCatalogInstrument): boolean {
+  if (isOptionInstrument(instrument)) return false;
+  const exchange = instrument.exchange?.trim().toUpperCase();
+  if (exchange === "CCC") return true;
+  if (resolveAssetDisplayKind({ assetCategory: instrument.assetCategory }) === "crypto") return true;
+  return /^[A-Z0-9]{2,10}[-/]USD$/i.test(instrument.symbol.trim());
+}
+
+const COMPACT_OCC_RE = /^([A-Z]{1,6})(\d{6}[CP]\d{8})$/;
+
+function compactOccSymbol(value: string): string | null {
+  const upper = value.trim().toUpperCase();
+  const compact = COMPACT_OCC_RE.exec(upper.replace(/\s+/g, ""));
+  if (compact) return `${compact[1]}${compact[2]}`;
+  const spaced = parseOptionSymbol(upper);
+  if (!spaced) return null;
+  const expiry = new Date(spaced.expTs * 1000);
+  const yy = String(expiry.getUTCFullYear()).slice(2);
+  const mm = String(expiry.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(expiry.getUTCDate()).padStart(2, "0");
+  const strike = String(Math.round(spaced.strike * 1000)).padStart(8, "0");
+  return `${spaced.underlying}${yy}${mm}${dd}${spaced.side}${strike}`;
+}
+
+function catalogTickerFromInput(value: string): string | null {
+  const option = compactOccSymbol(value);
+  if (option) return option;
+  const symbol = value.trim().toUpperCase();
+  return /^[A-Z0-9^][A-Z0-9.^_/-]{0,31}$/.test(symbol) ? symbol : null;
+}
+
+function isCatalogFieldNameQuery(query: string): boolean {
+  const lower = query.trim().toLowerCase();
+  if (!lower) return false;
+  if (getTimeSeriesField(lower)) return true;
+  return listTimeSeriesFields().some((field) => (
+    field.label.toLowerCase() === lower
+    || field.shortLabel.toLowerCase() === lower
+  ));
+}
+
+export function looksLikeCatalogTickerQuery(query: string): boolean {
+  const trimmed = query.trim();
+  if (!trimmed || /\s/.test(trimmed) || trimmed.includes(":")) return false;
+  const symbol = catalogTickerFromInput(trimmed);
+  if (!symbol) return false;
+  if (compactOccSymbol(trimmed) || /\d/.test(symbol) || /[-.^/_]/.test(symbol)) return true;
+  if (isCatalogFieldNameQuery(trimmed)) return false;
+  return symbol.length <= 6;
+}
+
+export function catalogInstrumentMatchesQuery(
+  instrument: SeriesCatalogInstrument,
+  query: string,
+): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return false;
+  if (instrument.symbol.toLowerCase().includes(needle)) return true;
+  return (instrument.name ?? "").toLowerCase().includes(needle);
+}
+
+export function catalogRowsForResolvedInstruments(
+  instruments: readonly SeriesCatalogInstrument[],
+): CatalogSeriesRow[] {
+  const fields = listTimeSeriesFields();
+  const marketFields = fields.filter((field) => isMarketFieldId(field.id));
+  return instruments.flatMap((instrument) => {
+    if (isCatalogCryptoInstrument(instrument)) {
+      return [cryptoPairRow(catalogSecuritySymbol(instrument), instrument.name)];
+    }
+    if (isOptionInstrument(instrument)) {
+      const symbol = compactOccSymbol(instrument.symbol)
+        ?? catalogTickerFromInput(instrument.symbol);
+      if (!symbol) return [];
+      return marketFields.map((field) => {
+        const token = chartFieldToken(field.id);
+        return row({
+          id: `option:${symbol}:${field.id}`,
+          label: `${symbol} · ${field.label}`,
+          source: "Yahoo",
+          sourceId: "option",
+          kind: "Options",
+          expression: `${symbol}:${token}`,
+          searchExtra: [instrument.name, "option", field.shortLabel].filter(Boolean).join(" "),
+        });
+      });
+    }
+    const symbol = catalogTickerFromInput(instrument.symbol);
+    if (!symbol) return [];
+    return fields.map((field) => {
+      const token = chartFieldToken(field.id);
+      return row({
+        id: `ticker:${symbol}:${field.id}`,
+        label: `${symbol} · ${field.label}`,
+        source: "Yahoo",
+        sourceId: "security",
+        kind: fieldCategory(field),
+        expression: `${symbol}:${token}`,
+        searchExtra: [instrument.name, field.shortLabel].filter(Boolean).join(" "),
+      });
+    });
+  });
+}
+
+export function catalogExpressionForRow(entry: CatalogSeriesRow, ticker?: string): string | null {
+  if (!entry.needsTicker) return entry.expression;
+  const symbol = ticker ? catalogTickerFromInput(ticker) : null;
+  if (!symbol || !entry.fieldToken) return null;
+  return `${symbol}:${entry.fieldToken}`;
+}
+
+function catalogSecuritySymbol(instrument: SeriesCatalogInstrument): string {
+  return instrument.symbol.trim();
+}
+
+function securityFieldRows(): CatalogSeriesRow[] {
+  return listTimeSeriesFields().map((field) => {
+    const token = chartFieldToken(field.id);
+    return row({
+      id: `field:${field.id}`,
+      label: field.label,
+      source: "Yahoo",
+      sourceId: "security",
+      kind: fieldCategory(field),
+      expression: `TICKER:${token}`,
+      needsTicker: true,
+      fieldToken: token,
+      searchExtra: field.shortLabel,
+    });
+  });
+}
+
+function optionFieldRows(): CatalogSeriesRow[] {
+  return listTimeSeriesFields().flatMap((field) => {
+    if (!isMarketFieldId(field.id)) return [];
+    const token = chartFieldToken(field.id);
+    return [row({
+      id: `option:${field.id}`,
+      label: field.label,
+      source: "Yahoo",
+      sourceId: "option",
+      kind: "Options",
+      expression: `TICKER:${token}`,
+      needsTicker: true,
+      fieldToken: token,
+      searchExtra: `option ${field.shortLabel}`,
+    })];
+  });
+}
+
+function cryptoPairRow(symbol: string, name?: string): CatalogSeriesRow {
+  return row({
+    id: `crypto:${symbol.toUpperCase()}`,
+    label: name ? `${symbol} · ${name}` : symbol,
+    source: "Yahoo",
+    sourceId: "crypto",
+    kind: "Crypto",
+    expression: `${symbol}:price`,
+    searchExtra: name,
+  });
+}
+
+function cryptoRows(instruments: readonly SeriesCatalogInstrument[]): CatalogSeriesRow[] {
+  const seen = new Set<string>();
+  const rows: CatalogSeriesRow[] = [];
+  const add = (symbol: string, name?: string) => {
+    const key = symbol.trim().toUpperCase().replace("/", "-");
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    rows.push(cryptoPairRow(key, name));
+  };
+  for (const instrument of instruments) {
+    if (!isCatalogCryptoInstrument(instrument)) continue;
+    add(catalogSecuritySymbol(instrument), instrument.name);
+  }
+  for (const entry of CRYPTO_CATALOG) add(entry.symbol, entry.name);
+  return rows;
+}
+
+const STATIC_CATALOG_INVENTORY: readonly CatalogSeriesRow[] = [
+  ...securityFieldRows(),
+  ...optionFieldRows(),
+  ...listFredCatalogSeries().map((entry) => row({
+    id: `fred:${entry.seriesId}`,
+    label: entry.label,
+    source: "FRED",
+    sourceId: "fred",
+    kind: "Economic",
+    expression: `FRED:${entry.seriesId}`,
+    url: `https://fred.stlouisfed.org/series/${entry.seriesId}`,
+  })),
+  ...TREASURY_MATURITIES.map((entry) => row({
+    id: `ust:${entry.maturity}`,
+    label: `${entry.maturity} Treasury Yield`,
+    source: "FRED",
+    sourceId: "treasury",
+    kind: "Treasury",
+    expression: `UST:${entry.maturity}`,
+    url: `https://fred.stlouisfed.org/series/${entry.seriesId}`,
+  })),
+  ...FUTURES_CONTRACTS.map((entry) => row({
+    id: `fut:${entry.code}`,
+    label: `${entry.name} (${entry.code})`,
+    source: "Yahoo",
+    sourceId: "futures",
+    kind: FUTURES_SECTOR_LABELS[entry.sector],
+    expression: `FUT:${entry.code}`,
+  })),
+];
+
+export function listStaticCatalogInventory(
+  instruments: readonly SeriesCatalogInstrument[] = [],
+): CatalogSeriesRow[] {
+  return [...STATIC_CATALOG_INVENTORY, ...cryptoRows(instruments)];
+}
+
+function matchesCatalogQuery(entry: CatalogSeriesRow, query: string): boolean {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return true;
+  return normalized.split(/\s+/).every((token) => entry.searchText.includes(token));
+}
+
+export function filterCatalogRows(
+  rows: readonly CatalogSeriesRow[],
+  filter: CatalogFilterId,
+  query: string,
+): CatalogSeriesRow[] {
+  const sources = FILTER_SOURCES[filter];
+  return rows.filter((entry) => (
+    (sources ? sources.has(entry.sourceId) : true)
+    && matchesCatalogQuery(entry, query)
+  ));
+}
+
+export function catalogEmptyCopy(
+  loading: boolean,
+  searchQuery: string,
+): { title: string; hint?: string } {
+  if (loading) return { title: "Loading catalog…" };
+  const query = searchQuery.trim();
+  if (query) return { title: `No series matching "${query}"`, hint: "Press / to search." };
+  return { title: "No series", hint: "Press / to search." };
+}

--- a/src/plugins/builtin/chart-composer/data-catalog-pane.tsx
+++ b/src/plugins/builtin/chart-composer/data-catalog-pane.tsx
@@ -1,0 +1,307 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, type InputRenderable } from "../../../ui";
+import {
+  DataTableView,
+  InputSearchBar,
+  Tabs,
+  type DataTableCell,
+  type DataTableColumn,
+  type DataTableKeyEvent,
+  type DataTableRootKeyContext,
+} from "../../../components";
+import type { PaneProps } from "../../../types/plugin";
+import { colors } from "../../../theme/colors";
+import { compareSortValues, type SortDirection } from "../../../utils/sort-values";
+import { useShortcut } from "../../../react/input";
+import { isPlainKey } from "../../../utils/keyboard";
+import { isPlainArrowUp, stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
+import { usePaneSettingValue } from "../../../state/app/context";
+import { usePluginAppActions } from "../../runtime";
+import { usePaneStatusLinkFooter } from "../shared/pane-footer";
+import { PaneTemplateInputStep } from "../../../components/pane-template-wizard";
+import { type PromptContext, useDialog } from "../../../ui/dialog";
+import {
+  CATALOG_FILTERS,
+  CHART_COMPOSER_TEMPLATE_ID,
+  DATA_CATALOG_PANE_ID,
+  catalogEmptyCopy,
+  catalogExpressionForRow,
+  catalogInstrumentMatchesQuery,
+  catalogRowsForResolvedInstruments,
+  filterCatalogRows,
+  listStaticCatalogInventory,
+  looksLikeCatalogTickerQuery,
+  type CatalogFilterId,
+  type CatalogSeriesRow,
+} from "./catalog-inventory";
+import { useCatalogUniverse } from "./use-series-catalog";
+
+type CatalogColumnId = "series" | "source" | "kind" | "expression";
+type CatalogColumn = DataTableColumn & { id: CatalogColumnId };
+
+interface CatalogSortPreference {
+  columnId: CatalogColumnId;
+  direction: SortDirection;
+}
+
+const DEFAULT_SORT: CatalogSortPreference = { columnId: "source", direction: "asc" };
+
+function nextSortPreference(
+  current: CatalogSortPreference,
+  columnId: string,
+): CatalogSortPreference {
+  const typed = columnId as CatalogColumnId;
+  if (current.columnId !== typed) return { columnId: typed, direction: "asc" };
+  if (current.direction === "asc") return { columnId: typed, direction: "desc" };
+  return DEFAULT_SORT;
+}
+
+function sortValue(columnId: CatalogColumnId, row: CatalogSeriesRow): string {
+  switch (columnId) {
+    case "series":
+      return row.label;
+    case "source":
+      return row.source;
+    case "kind":
+      return row.kind;
+    case "expression":
+      return row.expression;
+  }
+}
+
+function buildColumns(width: number): CatalogColumn[] {
+  const sourceWidth = 18;
+  const kindWidth = 12;
+  const expressionWidth = Math.min(28, Math.max(16, Math.floor(width * 0.28)));
+  const seriesWidth = Math.max(18, width - 2 - 4 - sourceWidth - kindWidth - expressionWidth);
+  return [
+    { id: "series", label: "SERIES", width: seriesWidth, align: "left" },
+    { id: "source", label: "SOURCE", width: sourceWidth, align: "left" },
+    { id: "kind", label: "KIND", width: kindWidth, align: "left" },
+    { id: "expression", label: "G", width: expressionWidth, align: "left" },
+  ];
+}
+
+export function DataCatalogPane({ focused, width, height }: PaneProps) {
+  const { createPaneFromTemplate } = usePluginAppActions();
+  const dialog = useDialog();
+  const [seedQuery] = usePaneSettingValue("query", "");
+  const [searchQuery, setSearchQuery] = useState(seedQuery);
+  const [filter, setFilter] = useState<CatalogFilterId>("all");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [sortPreference, setSortPreference] = useState<CatalogSortPreference>(DEFAULT_SORT);
+  const [searchFocused, setSearchFocused] = useState(false);
+  const [searchFocusToken, setSearchFocusToken] = useState(0);
+  const searchInputRef = useRef<InputRenderable | null>(null);
+
+  const tickerQuery = looksLikeCatalogTickerQuery(searchQuery);
+  const { instruments, loading: universeLoading } = useCatalogUniverse(
+    tickerQuery ? searchQuery : "",
+  );
+  const loading = tickerQuery && universeLoading;
+  const emptyCopy = catalogEmptyCopy(loading, searchQuery);
+
+  const rows = useMemo(() => {
+    const staticRows = listStaticCatalogInventory(instruments);
+    const resolvedRows = tickerQuery
+      ? catalogRowsForResolvedInstruments(
+        instruments.filter((instrument) => catalogInstrumentMatchesQuery(instrument, searchQuery)),
+      )
+      : [];
+    const merged = new Map<string, CatalogSeriesRow>();
+    for (const entry of [...resolvedRows, ...staticRows]) {
+      if (!merged.has(entry.id)) merged.set(entry.id, entry);
+    }
+    const filtered = filterCatalogRows([...merged.values()], filter, searchQuery);
+    const direction = sortPreference.direction;
+    const columnId = sortPreference.columnId;
+    return [...filtered].sort((left, right) => (
+      compareSortValues(sortValue(columnId, left), sortValue(columnId, right), direction)
+      || left.label.localeCompare(right.label)
+    ));
+  }, [filter, instruments, searchQuery, sortPreference, tickerQuery]);
+
+  useEffect(() => {
+    if (selectedId && rows.some((row) => row.id === selectedId)) return;
+    setSelectedId(rows[0]?.id ?? null);
+  }, [rows, selectedId]);
+
+  const selectedRow = useMemo(
+    () => rows.find((row) => row.id === selectedId) ?? null,
+    [rows, selectedId],
+  );
+  const selectedUrl = selectedRow?.url ?? null;
+
+  const columns = useMemo(() => buildColumns(width), [width]);
+
+  const focusSearch = useCallback(() => {
+    setSearchFocused(true);
+    setSearchFocusToken((token) => token + 1);
+  }, []);
+  const blurSearch = useCallback(() => {
+    setSearchFocused(false);
+  }, []);
+
+  const chartSelected = useCallback(async (row: CatalogSeriesRow | null) => {
+    if (!row) return;
+    if (row.needsTicker) {
+      const option = row.sourceId === "option";
+      const ticker = await dialog.prompt<string>({
+        closeOnClickOutside: true,
+        content: (context: PromptContext<string>) => (
+          <PaneTemplateInputStep
+            {...context}
+            step={{
+              key: "ticker",
+              label: `Chart ${row.label}`,
+              placeholder: option ? "AAPL 260618C00200000" : "AAPL",
+              type: "text",
+              body: [option
+                ? `Enter an option symbol to chart ${row.label}.`
+                : `Enter a ticker to chart ${row.label}.`],
+            }}
+          />
+        ),
+      }).catch(() => undefined);
+      const expression = catalogExpressionForRow(row, ticker);
+      if (!expression) return;
+      createPaneFromTemplate(CHART_COMPOSER_TEMPLATE_ID, { arg: expression });
+      return;
+    }
+    createPaneFromTemplate(CHART_COMPOSER_TEMPLATE_ID, { arg: row.expression });
+  }, [createPaneFromTemplate, dialog]);
+
+  useShortcut((event) => {
+    if (!focused || searchFocused || event.targetEditable) return;
+    if (isPlainKey(event, "/")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      focusSearch();
+    }
+  }, { enabled: focused && !searchFocused });
+
+  useShortcut((event) => {
+    if (!focused || searchFocused || event.targetEditable) return;
+    if (isPlainKey(event, "g") && selectedRow) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      chartSelected(selectedRow);
+    }
+  }, { enabled: focused && !searchFocused && !!selectedRow });
+
+  const handleTableKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (event.name === "/") {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      focusSearch();
+      return true;
+    }
+    if (event.name === "g" && selectedRow) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      chartSelected(selectedRow);
+      return true;
+    }
+    return false;
+  }, [chartSelected, focusSearch, selectedRow]);
+
+  const handleRootKeyDown = useCallback((
+    event: DataTableKeyEvent,
+    context: DataTableRootKeyContext,
+  ) => {
+    if (context.selectedIndex <= 0 && isPlainArrowUp(event)) {
+      stopSearchFocusNavigation(event);
+      focusSearch();
+      return true;
+    }
+    return handleTableKeyDown(event);
+  }, [focusSearch, handleTableKeyDown]);
+
+  const renderCell = useCallback((
+    row: CatalogSeriesRow,
+    column: CatalogColumn,
+    _index: number,
+    rowState: { selected: boolean },
+  ): DataTableCell => {
+    const selectedColor = rowState.selected ? colors.selectedText : undefined;
+    switch (column.id) {
+      case "series":
+        return { text: row.label, color: selectedColor ?? colors.textBright };
+      case "source":
+        return { text: row.source, color: selectedColor ?? colors.textMuted };
+      case "kind":
+        return { text: row.kind, color: selectedColor ?? colors.textDim };
+      case "expression":
+        return { text: row.expression, color: selectedColor ?? colors.text };
+    }
+  }, []);
+
+  usePaneStatusLinkFooter({
+    registrationId: DATA_CATALOG_PANE_ID,
+    focused,
+    url: selectedUrl,
+    source: selectedUrl ? selectedRow?.source : null,
+    label: "source",
+    loading,
+    hints: [
+      { id: "graph", key: "g", label: "raph", onPress: () => chartSelected(selectedRow), disabled: !selectedRow },
+      { id: "search", key: "/", label: "search", onPress: focusSearch },
+    ],
+    showOpenHint: !!selectedUrl,
+  });
+
+  const tabs = useMemo(
+    () => CATALOG_FILTERS.map((entry) => ({ label: entry.label, value: entry.id })),
+    [],
+  );
+
+  return (
+    <DataTableView<CatalogSeriesRow, CatalogColumn>
+      focused={focused && !searchFocused}
+      rootWidth={width}
+      rootHeight={height}
+      rootBefore={(
+        <Box flexDirection="column">
+          <InputSearchBar
+            value={searchQuery}
+            focused={focused}
+            active={searchFocused}
+            width={width}
+            focusToken={searchFocusToken}
+            inputRef={searchInputRef}
+            placeholder="series, source, or expression"
+            debounceMs={80}
+            onFocus={focusSearch}
+            onBlur={blurSearch}
+            onNavigateDown={blurSearch}
+            onQueryChange={setSearchQuery}
+          />
+          <Tabs
+            tabs={tabs}
+            activeValue={filter}
+            onSelect={(value) => setFilter(value as CatalogFilterId)}
+            focused={focused && !searchFocused}
+            compact
+          />
+        </Box>
+      )}
+      selection={{
+        kind: "id",
+        selectedId,
+        getId: (row) => row.id,
+        onChange: (id) => setSelectedId(id),
+      }}
+      onRootKeyDown={handleRootKeyDown}
+      columns={columns}
+      items={rows}
+      sortColumnId={sortPreference.columnId}
+      sortDirection={sortPreference.direction}
+      onHeaderClick={(columnId) => setSortPreference((current) => nextSortPreference(current, columnId))}
+      getItemKey={(row) => row.id}
+      onActivate={chartSelected}
+      renderCell={renderCell}
+      emptyStateTitle={emptyCopy.title}
+      emptyStateHint={emptyCopy.hint}
+    />
+  );
+}

--- a/src/plugins/builtin/chart-composer/index.tsx
+++ b/src/plugins/builtin/chart-composer/index.tsx
@@ -8,6 +8,12 @@ import { parseTickerListInput } from "../../../tickers/list";
 import { publicTickerKey } from "../../../utils/exchanges";
 import type { ChartSpec } from "../../../time-series/types";
 import { ChartComposerPane, ChartComposerResearchTab } from "./pane";
+import { DataCatalogPane } from "./data-catalog-pane";
+import {
+  CHART_COMPOSER_TEMPLATE_ID,
+  DATA_CATALOG_PANE_ID,
+  DATA_CATALOG_TEMPLATE_ID,
+} from "./catalog-inventory";
 import { CHART_SPEC_SETTING_KEY } from "./chart-spec";
 import {
   buildComparisonChartPreset,
@@ -23,8 +29,6 @@ import {
   LIVE_STREAMING_QUICK_SETTING,
   withLiveStreamingSetting,
 } from "../shared/live-streaming";
-
-const CHART_COMPOSER_TEMPLATE_ID = "chart-composer-pane";
 
 function normalizedSymbol(value: string | null | undefined): string | null {
   const symbol = value?.trim().toUpperCase() ?? "";
@@ -148,6 +152,34 @@ const chartComposerTemplates: PaneTemplateDef[] = [
       return instanceFor(buildCustomChartPreset(expression, context.activeTicker), "G");
     },
   },
+  {
+    id: DATA_CATALOG_TEMPLATE_ID,
+    paneId: DATA_CATALOG_PANE_ID,
+    label: "Data Catalog",
+    description: "Browse and search the series Custom Chart already knows: securities, options, crypto, FRED, treasuries, and futures.",
+    keywords: [
+      "catalog",
+      "series",
+      "data",
+      "chart",
+      "fred",
+      "futures",
+      "treasury",
+      "crypto",
+      "options",
+      "option",
+    ],
+    shortcut: { prefix: "CAT", argPlaceholder: "query", argKind: "text", argOptional: true },
+    canCreate: () => true,
+    createInstance: (_context, options) => {
+      const query = options?.arg?.trim() ?? options?.values?.query?.trim() ?? "";
+      return {
+        title: query ? `Catalog · ${query}` : "Data Catalog",
+        placement: "floating" as const,
+        ...(query ? { settings: { query } } : {}),
+      };
+    },
+  },
   securityTemplate({
     id: "graph-price-pane",
     prefix: "GP",
@@ -212,6 +244,14 @@ export const chartComposerModule: PluginModule = {
       ),
       context.settings,
     ),
+  }, {
+    id: DATA_CATALOG_PANE_ID,
+    name: "Data Catalog",
+    icon: "C",
+    component: DataCatalogPane,
+    defaultPosition: "right",
+    defaultMode: "floating",
+    defaultFloatingSize: { width: 110, height: 32 },
   }],
   paneTemplates: chartComposerTemplates,
   setup(ctx) {

--- a/src/plugins/builtin/chart-composer/series-catalog.ts
+++ b/src/plugins/builtin/chart-composer/series-catalog.ts
@@ -26,6 +26,7 @@ export interface SeriesCatalogInstrument {
   symbol: string;
   exchange?: string;
   name?: string;
+  assetCategory?: string;
 }
 
 export interface SeriesCatalogSuggestion {
@@ -184,7 +185,7 @@ export function analyzeSeriesSearchQuery(query: string): SeriesSearchAnalysis {
   };
 }
 
-function fieldCategory(field: TimeSeriesFieldDefinition): string {
+export function fieldCategory(field: TimeSeriesFieldDefinition): string {
   if (field.id.startsWith("market.")) return "Market";
   if (field.id.startsWith("valuation.")) return "Valuation";
   return "Fundamentals";

--- a/src/plugins/builtin/chart-composer/use-series-catalog.ts
+++ b/src/plugins/builtin/chart-composer/use-series-catalog.ts
@@ -1,5 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
-import { searchTickerCandidates } from "../../../tickers/search";
+import {
+  buildTickerSearchCandidates,
+  searchTickerCandidates,
+} from "../../../tickers/search";
 import { useOptionalAppSelector } from "../../../state/app/context";
 import type { TickerRecord } from "../../../types/ticker";
 import { searchChartSeriesCapabilities } from "../../../capabilities";
@@ -13,6 +16,158 @@ import {
 } from "./series-catalog";
 
 const EMPTY_TICKERS: ReadonlyMap<string, TickerRecord> = new Map();
+const EMPTY_RECENT: readonly string[] = [];
+const DEFAULT_CATALOG_INSTRUMENTS: readonly SeriesCatalogInstrument[] = [
+  { symbol: "AAPL", exchange: "NASDAQ", name: "Apple Inc." },
+  { symbol: "MSFT", exchange: "NASDAQ", name: "Microsoft Corporation" },
+  { symbol: "GOOGL", exchange: "NASDAQ", name: "Alphabet Inc." },
+  { symbol: "AMZN", exchange: "NASDAQ", name: "Amazon.com Inc." },
+  { symbol: "NVDA", exchange: "NASDAQ", name: "NVIDIA Corporation" },
+  { symbol: "TSLA", exchange: "NASDAQ", name: "Tesla Inc." },
+  { symbol: "META", exchange: "NASDAQ", name: "Meta Platforms Inc." },
+  { symbol: "BRK.B", exchange: "NYSE", name: "Berkshire Hathaway Inc." },
+  { symbol: "JPM", exchange: "NYSE", name: "JPMorgan Chase & Co." },
+  { symbol: "V", exchange: "NYSE", name: "Visa Inc." },
+  { symbol: "BTC-USD", exchange: "CCC", name: "Bitcoin USD" },
+  { symbol: "ETH-USD", exchange: "CCC", name: "Ethereum USD" },
+];
+
+function instrumentFromTicker(ticker: TickerRecord): SeriesCatalogInstrument {
+  return {
+    symbol: ticker.metadata.ticker,
+    ...(ticker.metadata.exchange ? { exchange: ticker.metadata.exchange } : {}),
+    ...(ticker.metadata.name ? { name: ticker.metadata.name } : {}),
+    ...(ticker.metadata.assetCategory ? { assetCategory: ticker.metadata.assetCategory } : {}),
+  };
+}
+
+function uniqueCatalogInstruments(
+  instruments: readonly SeriesCatalogInstrument[],
+): SeriesCatalogInstrument[] {
+  const seen = new Set<string>();
+  return instruments.filter((instrument) => {
+    const key = `${instrument.symbol}:${instrument.exchange ?? ""}:${instrument.assetCategory ?? ""}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function candidateToInstrument(candidate: {
+  symbol: string;
+  ticker?: TickerRecord;
+  result?: { primaryExchange?: string; exchange?: string; name?: string; type?: string };
+}): SeriesCatalogInstrument {
+  const exchange = candidate.ticker?.metadata.exchange
+    || candidate.result?.primaryExchange
+    || candidate.result?.exchange;
+  const name = candidate.ticker?.metadata.name || candidate.result?.name;
+  const assetCategory = candidate.ticker?.metadata.assetCategory || candidate.result?.type;
+  return {
+    symbol: candidate.symbol,
+    ...(exchange ? { exchange } : {}),
+    ...(name ? { name } : {}),
+    ...(assetCategory ? { assetCategory } : {}),
+  };
+}
+
+export function useCatalogUniverse(query: string): {
+  instruments: SeriesCatalogInstrument[];
+  loading: boolean;
+} {
+  const tickers = useOptionalAppSelector((state) => state.tickers, EMPTY_TICKERS);
+  const recentSymbols = useOptionalAppSelector((state) => state.recentTickers, EMPTY_RECENT);
+  const watchlist = useMemo(
+    () => [...tickers.values()].map(instrumentFromTicker),
+    [tickers],
+  );
+  const recents = useMemo(
+    () => recentSymbols.flatMap((symbol) => {
+      const ticker = tickers.get(symbol);
+      if (ticker) return [instrumentFromTicker(ticker)];
+      const trimmed = symbol.trim();
+      return trimmed ? [{ symbol: trimmed }] : [];
+    }),
+    [recentSymbols, tickers],
+  );
+  const [search, setSearch] = useState<{
+    query: string;
+    instruments: SeriesCatalogInstrument[];
+    loading: boolean;
+  }>({ query: "", instruments: [], loading: false });
+
+  useEffect(() => {
+    const instrumentQuery = query.trim();
+    if (!instrumentQuery || instrumentQuery.includes(":")) {
+      setSearch((current) => (
+        current.query === "" && current.instruments.length === 0 && !current.loading
+          ? current
+          : { query: "", instruments: [], loading: false }
+      ));
+      return;
+    }
+
+    const applyLocal = () => {
+      const candidates = buildTickerSearchCandidates({
+        query: instrumentQuery,
+        tickers,
+        providerResults: [],
+        totalLimit: 12,
+        localLimit: 8,
+        includeOptionContracts: true,
+      });
+      setSearch({
+        query: instrumentQuery,
+        instruments: candidates.map(candidateToInstrument),
+        loading: false,
+      });
+    };
+
+    const registry = getSharedRegistry();
+    if (!registry) {
+      applyLocal();
+      return;
+    }
+
+    let cancelled = false;
+    setSearch({ query: instrumentQuery, instruments: [], loading: true });
+    const timer = setTimeout(() => {
+      void searchTickerCandidates({
+        query: instrumentQuery,
+        tickers,
+        dataProvider: registry.marketData,
+        totalLimit: 12,
+        localLimit: 8,
+        includeOptionContracts: true,
+      }).then((candidates) => {
+        if (cancelled) return;
+        setSearch({
+          query: instrumentQuery,
+          instruments: candidates.map(candidateToInstrument),
+          loading: false,
+        });
+      }).catch(() => {
+        if (!cancelled) applyLocal();
+      });
+    }, 80);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [query, tickers]);
+
+  const searched = search.query === query.trim() ? search.instruments : [];
+  const instruments = useMemo(() => {
+    const merged = uniqueCatalogInstruments([...watchlist, ...recents, ...searched]);
+    return merged.length > 0 ? merged : [...DEFAULT_CATALOG_INSTRUMENTS];
+  }, [recents, searched, watchlist]);
+
+  return {
+    instruments,
+    loading: search.loading && search.query === query.trim(),
+  };
+}
 
 export interface SeriesCatalogSearchResult {
   suggestions: SeriesCatalogSuggestion[];
@@ -113,17 +268,7 @@ export function useSeriesCatalogSuggestions({
         if (cancelled) return;
         setSearch({
           query: instrumentQuery,
-          instruments: candidates.map((candidate) => ({
-            symbol: candidate.symbol,
-            ...(candidate.ticker?.metadata.exchange
-              ? { exchange: candidate.ticker.metadata.exchange }
-              : candidate.result?.primaryExchange || candidate.result?.exchange
-                ? { exchange: candidate.result?.primaryExchange || candidate.result?.exchange }
-                : {}),
-            ...(candidate.ticker?.metadata.name || candidate.result?.name
-              ? { name: candidate.ticker?.metadata.name || candidate.result?.name }
-              : {}),
-          })),
+          instruments: candidates.map(candidateToInstrument),
           loading: false,
           error: null,
         });

--- a/src/plugins/builtin/econ/fred-series-map.ts
+++ b/src/plugins/builtin/econ/fred-series-map.ts
@@ -83,3 +83,21 @@ export function resolveFredMapping(eventTitle: string, country: string): FredMap
 export function getRelatedTickers(eventTitle: string, country: string): string[] {
   return resolveFredMapping(eventTitle, country)?.relatedTickers ?? [];
 }
+
+const FRED_CATALOG_SERIES: ReadonlyArray<{ seriesId: string; label: string }> = (() => {
+  const labels = new Map<string, string>();
+  for (const [key, mapping] of Object.entries(SERIES_MAP)) {
+    const existing = labels.get(mapping.seriesId);
+    if (existing == null || key.length < existing.length) {
+      labels.set(mapping.seriesId, key);
+    }
+  }
+  return [...labels.entries()].map(([seriesId, key]) => ({
+    seriesId,
+    label: key.replace(/\b\w/g, (char) => char.toUpperCase()),
+  }));
+})();
+
+export function listFredCatalogSeries(): ReadonlyArray<{ seriesId: string; label: string }> {
+  return FRED_CATALOG_SERIES;
+}


### PR DESCRIPTION
## Summary
- Adds a `CAT` Data Catalog pane so you can browse, search, and graph the series Custom Chart already knows without typing `SYMBOL:field` / `FRED:` / `FUT:` / `UST:` expressions.
- v1 is chartable-only: securities, options, crypto, FRED (including treasuries), and futures. Prediction markets, Adjacent, and Artificial Analysis are omitted because those series kinds are not on upstream `G` yet.
- Ticker-shaped queries resolve through the existing ticker search into concrete chart rows; `[g]`raph opens the selected row in Custom Chart.

## Test plan
- [ ] Open `CAT` from the command bar (and `CAT AAPL`) and confirm tabs All / Securities / Options / Crypto / FRED / Futures.
- [ ] Search `close` / `price` as field names (templates, ticker prompt on graph) vs `AAPL` / `btc-usd` as ticker queries (resolved `AAPL:close`, `BTC-USD:price` rows).
- [ ] Graph a security field, an option field (OCC symbol prompt), a FRED series, a treasury (`UST:10Y`), and a future (`FUT:ES`) into Custom Chart.
- [ ] Sort by clicking column headers; `/` focuses search; `[o]`pen appears only on FRED/treasury rows with a URL. Footer has no `[r]`efresh hint.


Made with [Cursor](https://cursor.com)