### PR TITLE
Show real short interest history and date the yield curve

### DIFF
--- a/src/api-client/data.ts
+++ b/src/api-client/data.ts
@@ -22,6 +22,7 @@ import {
 } from "./paths";
 import type {
   CloudAnalystResearchPayload,
+  CloudShortInterestPayload,
   CloudCompanyProfile,
   CloudCongressHousePayload,
   CloudCorporateActionsPayload,
@@ -128,6 +129,12 @@ export class CloudDataApi {
 
   async getCloudAnalystResearch(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudAnalystResearchPayload>> {
     return this.requestMarketSymbol("/market/analyst", symbol, exchange);
+  }
+
+  async getCloudShortInterest(symbol: string, years?: number): Promise<CloudMarketResponse<CloudShortInterestPayload>> {
+    const params = new URLSearchParams({ symbol: symbol.toUpperCase() });
+    if (years != null) params.set("years", String(years));
+    return this.request<CloudMarketResponse<CloudShortInterestPayload>>(`/market/short-interest?${params}`);
   }
 
   async getCloudCorporateActions(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudCorporateActionsPayload>> {

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -35,6 +35,7 @@ import type {
   CloudFundamentals,
   CloudHoldersPayload,
   CloudAnalystResearchPayload,
+  CloudShortInterestPayload,
   CloudBrowserHandoffResponse,
   CloudCorporateActionsPayload,
   CloudPricePointPayload,
@@ -474,6 +475,10 @@ class GloomApiClient {
 
   async getCloudHolders(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudHoldersPayload>> {
     return this.data.getCloudHolders(symbol, exchange);
+  }
+
+  async getCloudShortInterest(symbol: string, years?: number): Promise<CloudMarketResponse<CloudShortInterestPayload>> {
+    return this.data.getCloudShortInterest(symbol, years);
   }
 
   async getCloudAnalystResearch(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudAnalystResearchPayload>> {

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -322,10 +322,28 @@ export interface CloudFredSeriesPayload {
   info: CloudFredSeriesInfoPayload | null;
 }
 
+export interface CloudShortInterestPointPayload {
+  settlementDate: string;
+  sharesShort: number;
+  previousSharesShort: number | null;
+  averageDailyVolume: number | null;
+  daysToCover: number | null;
+  changePercent: number | null;
+  revised: boolean;
+}
+
+export interface CloudShortInterestPayload {
+  symbol: string;
+  issueName: string | null;
+  points: CloudShortInterestPointPayload[];
+}
+
 export interface CloudYieldPointPayload {
   maturity: string;
   maturityYears: number;
   yield: number | null;
+  /** FRED observation date. Absent on servers older than the field. */
+  asOf?: string | null;
 }
 
 type CloudCongressTradeSide = "BUY" | "SELL" | "EXCHANGE" | "OTHER";

--- a/src/plugins/builtin/short-interest/client.ts
+++ b/src/plugins/builtin/short-interest/client.ts
@@ -1,3 +1,5 @@
+import { apiClient } from "../../../api-client";
+import type { CloudShortInterestPayload } from "../../../api-client/types";
 import type { ConnectionHealthRegistry } from "../../../core/connection-health";
 import { YahooHttpClient } from "../../../sources/yahoo-finance/http";
 import { financeRawNumber, yahooRawDate } from "../../../sources/yahoo-finance/mappers";
@@ -78,9 +80,45 @@ async function requestShortInterest(symbol: string): Promise<ShortInterestRecord
   return normalizeRecords(result);
 }
 
-export async function fetchShortInterest(symbol: string): Promise<ShortInterestRecord[]> {
+function fetchYahooShortInterest(symbol: string): Promise<ShortInterestRecord[]> {
   const request = () => requestShortInterest(symbol);
   return connectionHealth?.hasSource(YAHOO_SHORT_INTEREST_CONNECTION_ID)
     ? connectionHealth.track(YAHOO_SHORT_INTEREST_CONNECTION_ID, "fetch", request)
     : request();
+}
+
+function normalizeCloudRecords(payload: CloudShortInterestPayload): ShortInterestRecord[] {
+  const records: ShortInterestRecord[] = [];
+  for (const point of payload.points) {
+    const settlementDate = new Date(`${point.settlementDate}T00:00:00.000Z`);
+    if (Number.isNaN(settlementDate.getTime())) continue;
+    records.push({
+      settlementDate,
+      sharesShort: point.sharesShort,
+      shortRatio: point.daysToCover,
+      averageDailyVolume: point.averageDailyVolume,
+      // FINRA publishes no float, so percent of float stays unknown rather than
+      // being invented from a float measured on a different date.
+      shortPercentFloat: null,
+    });
+  }
+  return records;
+}
+
+/**
+ * FINRA publishes every bi-monthly settlement, so it is the only real history.
+ * Yahoo carries the current and prior settlement plus percent of float, so it
+ * stays as the fallback when the cloud route is unavailable.
+ */
+export async function fetchShortInterest(symbol: string): Promise<ShortInterestRecord[]> {
+  try {
+    const response = await apiClient.getCloudShortInterest(symbol);
+    const records = response.status === "success" && response.data
+      ? normalizeCloudRecords(response.data)
+      : [];
+    if (records.length > 0) return records;
+  } catch {
+    // Fall through to Yahoo rather than failing the pane.
+  }
+  return fetchYahooShortInterest(symbol);
 }

--- a/src/plugins/builtin/short-interest/index.tsx
+++ b/src/plugins/builtin/short-interest/index.tsx
@@ -54,7 +54,7 @@ export const shortInterestModule: PluginModule = {
       paneId: "short-interest",
       label: "Short Interest",
       // Yahoo's key-statistics module only carries the current and prior settlement dates.
-      description: "Latest and prior-month short interest, days to cover, and short % of float.",
+      description: "Bi-monthly short interest settlements from FINRA with days to cover and average daily volume.",
       keywords: ["short", "interest", "si", "shorts", "borrow", "days", "cover"],
       shortcut: "SI",
     }),

--- a/src/plugins/builtin/yield-curve/index.tsx
+++ b/src/plugins/builtin/yield-curve/index.tsx
@@ -8,6 +8,7 @@ import { colors } from "../../../theme/colors";
 import { resolveChartPalette } from "../../../components/chart/core/renderer";
 import type { ProjectedChartPoint } from "../../../components/chart/core/data";
 import {
+  curveAsOf,
   loadYieldCurve,
   parseYieldPoints,
   isInverted,
@@ -75,12 +76,16 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
 
   const inverted = isInverted(points);
   const bp = spreadBp(points);
+  // Treasury series are daily closes, so which session the curve represents is
+  // status the user needs; "updated Xm ago" only says when we last fetched it.
+  const asOf = curveAsOf(points);
 
   const yieldStatus = useMemo<PaneFooterSegment[]>(() => [
       ...(inverted ? [{ id: "inverted", parts: [{ text: "INVERTED", tone: "warning" as const, bold: true }] }] : []),
       ...(bp != null ? [{ id: "spread", parts: [{ text: `2Y-10Y ${bp >= 0 ? "+" : ""}${bp}bp`, tone: bp < 0 ? "warning" as const : "muted" as const }] }] : []),
+      ...(asOf ? [{ id: "as-of", parts: [{ text: `as of ${asOf}`, tone: "muted" as const }] }] : []),
       ...(updatedAgo ? [{ id: "updated", parts: [{ text: `updated ${updatedAgo}`, tone: "muted" as const }] }] : []),
-  ], [bp, inverted, updatedAgo]);
+  ], [asOf, bp, inverted, updatedAgo]);
   usePaneStatusFooter({
     registrationId: "yield-curve",
     loading,

--- a/src/plugins/builtin/yield-curve/treasury-data.test.ts
+++ b/src/plugins/builtin/yield-curve/treasury-data.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import { curveAsOf, type YieldPoint } from "./treasury-data";
+
+function point(maturity: string, years: number, value: number | null, asOf?: string | null): YieldPoint {
+  return { maturity, maturityYears: years, yield: value, asOf };
+}
+
+test("dates the curve from the newest observation present", () => {
+  expect(curveAsOf([
+    point("2Y", 2, 4.19, "2026-08-15"),
+    point("10Y", 10, 4.72, "2026-08-17"),
+    point("30Y", 30, 5.31, "2026-08-17"),
+  ])).toBe("2026-08-17");
+});
+
+test("ignores points with no date rather than dropping the curve date", () => {
+  expect(curveAsOf([
+    point("2Y", 2, 4.19, null),
+    point("10Y", 10, 4.72, "2026-08-17"),
+  ])).toBe("2026-08-17");
+});
+
+test("reports no date when the server predates the field", () => {
+  expect(curveAsOf([point("2Y", 2, 4.19), point("10Y", 10, 4.72)])).toBeNull();
+});

--- a/src/plugins/builtin/yield-curve/treasury-data.ts
+++ b/src/plugins/builtin/yield-curve/treasury-data.ts
@@ -4,6 +4,7 @@ export interface YieldPoint {
   maturity: string;      // "1M", "3M", "6M", "1Y", "2Y", "5Y", "7Y", "10Y", "20Y", "30Y"
   maturityYears: number; // 0.083, 0.25, 0.5, 1, 2, 5, 7, 10, 20, 30
   yield: number | null;  // percent, e.g., 4.29
+  asOf?: string | null;  // FRED observation date, absent on older servers
 }
 
 export const TREASURY_MATURITIES: Array<{ maturity: string; years: number; seriesId: string }> = [
@@ -27,6 +28,21 @@ export function parseYieldPoints(points: YieldPoint[]): YieldPoint[] {
   return points
     .filter((p) => p.yield !== null)
     .sort((a, b) => a.maturityYears - b.maturityYears);
+}
+
+/**
+ * The newest observation date across the curve. Treasury series publish
+ * together, but a single stale series must not date the whole curve forward,
+ * so this reports the latest date actually present.
+ */
+export function curveAsOf(points: readonly YieldPoint[]): string | null {
+  let latest: string | null = null;
+  for (const point of points) {
+    const asOf = point.asOf;
+    if (!asOf) continue;
+    if (!latest || asOf > latest) latest = asOf;
+  }
+  return latest;
 }
 
 export function isInverted(points: YieldPoint[]): boolean {


### PR DESCRIPTION
Client half of gloomberb-platform#79. Merge that first.

## Short interest

The pane advertised history while its only source was Yahoo `defaultKeyStatistics`, which carries the current and prior settlement. Two points is not a history, and the audit flagged this as needing a provider route.

It now reads FINRA bi-monthly consolidated short interest through the new cloud endpoint. Verified against live data: **71 settlements over three years for AAPL, where Yahoo returned 2**, each with average daily volume and days to cover.

Yahoo stays as the fallback when the cloud route is unavailable, since it also carries percent of float, which FINRA does not publish. On FINRA rows percent of float is left unknown rather than derived from a float measured on a different date.

The pane description was corrected to say what it now actually serves.

## Yield curve date

The curve had no observation date because the endpoint dropped the one it already fetched, so today curve and Friday curve looked identical. The footer now shows it.

`curveAsOf` takes the newest date present across maturities, so one stale series cannot date the whole curve forward, and returns null when every point lacks a date. `asOf` is optional on the client type, so an older server just shows no date rather than breaking.

This is why I did not fix it client side earlier: the alternative was ten cold FRED requests per pane open to work around a missing server field.

## Verification

`bun run typecheck` clean across all four projects. `bun test` 2160 pass, 0 fail. FINRA normalization exercised against the live API, with an explicit check that no settlement came back as zero shares short.