### PR TITLE
Paint G from warm cache and downsample chart rasters

### DIFF
--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -615,6 +615,7 @@ interface CompositePanelSurfaceProps {
   onZoomViewport: (zoomFactor: number, anchorRatio: number) => void;
   onSetViewport: (range: CompositeViewportRange) => void;
   onToolSpanChange: (span: ChartToolSpan | null) => void;
+  showTextFallback: boolean;
 }
 
 function CompositePanelSurface({
@@ -641,11 +642,11 @@ function CompositePanelSurface({
   onZoomViewport,
   onSetViewport,
   onToolSpanChange,
+  showTextFallback,
 }: CompositePanelSurfaceProps) {
   const isDesktopWeb = useUiHost().kind === "desktop-web";
   const { cellHeightPx = 18, cellWidthPx = 8 } = useUiCapabilities();
   const renderer = useNativeRenderer();
-  const showTextFallback = useShowChartTextFallback();
   const plotRef = useRef<BoxRenderable | null>(null);
   const [cursorYRatio, setCursorYRatio] = useState<number | null>(null);
   const seriesCursorYRatio = useMemo(
@@ -1445,6 +1446,7 @@ export function CompositeChart({
 }: CompositeChartProps) {
   const { cellWidthPx = 8, pixelRatio = 1 } = useUiCapabilities();
   const isDesktopWeb = useUiHost().kind === "desktop-web";
+  const showTextFallback = useShowChartTextFallback();
   const [internalCursorDate, setInternalCursorDate] = useState<Date | null>(null);
   const [legendKeyboardIndex, setLegendKeyboardIndex] = useState<number | null>(null);
   const [toolSpan, setToolSpan] = useState<ChartToolSpan | null>(null);
@@ -2088,6 +2090,7 @@ export function CompositeChart({
           onZoomViewport={zoomViewport}
           onSetViewport={setViewportRange}
           onToolSpanChange={setToolSpan}
+          showTextFallback={showTextFallback}
         />
       ))}
       {timeAxisLayout ? (

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -18,6 +18,8 @@ import { formatPercentRaw } from "../../../utils/format";
 import { isPlainKey } from "../../../utils/keyboard";
 import { truncateWithEllipsis } from "../../../utils/text-wrap";
 import type { ResolvedSeries } from "../../../time-series/types";
+import { downsampleCompositeChartScene } from "./downsample";
+import { reuseResolvedSeriesList } from "./panel-series";
 import {
   consumeChartMouseEvent,
   getGlobalMouseX,
@@ -25,6 +27,7 @@ import {
   type ChartMouseEvent,
 } from "../core/pointer";
 import type { NativeChartBitmap } from "../native/chart-rasterizer";
+import { useShowChartTextFallback } from "../native/use-chart-text-fallback";
 import {
   useStaticChartBitmapSize,
   type StaticChartBitmapSize,
@@ -642,6 +645,7 @@ function CompositePanelSurface({
   const isDesktopWeb = useUiHost().kind === "desktop-web";
   const { cellHeightPx = 18, cellWidthPx = 8 } = useUiCapabilities();
   const renderer = useNativeRenderer();
+  const showTextFallback = useShowChartTextFallback();
   const plotRef = useRef<BoxRenderable | null>(null);
   const [cursorYRatio, setCursorYRatio] = useState<number | null>(null);
   const seriesCursorYRatio = useMemo(
@@ -788,10 +792,10 @@ function CompositePanelSurface({
     toolReadout?.direction,
   ]);
   const textLines = useMemo(
-    () => isDesktopWeb
+    () => isDesktopWeb || !showTextFallback
       ? []
       : renderCompositePanelText(panel, plotWidth, scene.cursorXRatio, activeCursorYRatio),
-    [activeCursorYRatio, isDesktopWeb, panel, plotWidth, scene.cursorXRatio],
+    [activeCursorYRatio, isDesktopWeb, panel, plotWidth, scene.cursorXRatio, showTextFallback],
   );
   const leftAxisLabels = useMemo(
     () => axisLabelRows(
@@ -1439,7 +1443,7 @@ export function CompositeChart({
   onToggleSeries,
   isSeriesToggleable,
 }: CompositeChartProps) {
-  const { cellWidthPx = 8 } = useUiCapabilities();
+  const { cellWidthPx = 8, pixelRatio = 1 } = useUiCapabilities();
   const isDesktopWeb = useUiHost().kind === "desktop-web";
   const [internalCursorDate, setInternalCursorDate] = useState<Date | null>(null);
   const [legendKeyboardIndex, setLegendKeyboardIndex] = useState<number | null>(null);
@@ -1479,7 +1483,10 @@ export function CompositeChart({
   const resolvedCursorDate = cursorDate === undefined ? internalCursorDate : cursorDate;
   const totalWidth = Math.max(1, Math.floor(width));
   const totalHeight = Math.max(1, Math.floor(height));
-  const visibleSeries = useMemo(() => series.filter((entry) => entry.points.length > 0), [series]);
+  const seriesIdentityRef = useRef<ResolvedSeries[]>([]);
+  const stableSeries = reuseResolvedSeriesList(seriesIdentityRef.current, series);
+  seriesIdentityRef.current = stableSeries;
+  const visibleSeries = useMemo(() => stableSeries.filter((entry) => entry.points.length > 0), [stableSeries]);
   const marketTimelineSeries = useMemo(() => {
     const supplied = timelineSeries?.filter((entry) => entry.points.length > 0) ?? [];
     return supplied.some((entry) => entry.timeBasis?.kind === "market")
@@ -1675,6 +1682,11 @@ export function CompositeChart({
     : 0;
   const timeAxisRows = showTimeAxis ? 1 : 0;
   const panelCount = new Set(visibleSeries.map((entry) => entry.panelId)).size;
+  const lastTickKey = visibleSeries.map((entry) => {
+    const last = entry.points.at(-1);
+    if (!last) return entry.id;
+    return `${entry.id}:${last.date.getTime()}:${last.close ?? ""}:${last.value ?? ""}:${entry.latestChangePercent ?? ""}`;
+  }).join("|");
   const plotHeight = Math.max(panelCount, totalHeight - legendRows - timeAxisRows);
   const resolvedColors = useMemo<CompositeChartColors>(() => ({
     background: colors?.background ?? themeColors.bg,
@@ -1684,12 +1696,16 @@ export function CompositeChart({
     textDim: colors?.textDim ?? themeColors.textDim,
     negative: colors?.negative ?? themeColors.negative,
   }), [colors]);
-  const projectedScene = useMemo(() => buildCompositeChartScene(visibleSeries, panels, {
-    width: 1,
-    height: Math.max(panelCount, 1),
-    viewport: effectiveViewport ?? undefined,
-    timelineSeries: marketTimelineSeries,
-  }), [effectiveViewport, marketTimelineSeries, panelCount, panels, visibleSeries]);
+  const projectedScene = useMemo(() => {
+    // lastTickKey busts this memo when a live tick mutates series identity in place.
+    void lastTickKey;
+    return buildCompositeChartScene(visibleSeries, panels, {
+      width: 1,
+      height: Math.max(panelCount, 1),
+      viewport: effectiveViewport ?? undefined,
+      timelineSeries: marketTimelineSeries,
+    });
+  }, [effectiveViewport, lastTickKey, marketTimelineSeries, panelCount, panels, visibleSeries]);
   // Gutters follow the axes the scene actually built. Reading the series list
   // instead drops a gutter the moment its series has no observation in view,
   // which is exactly what a zoom does, taking the axis labels with it.
@@ -1719,6 +1735,10 @@ export function CompositeChart({
   const horizontalReserved = leftAxisWidth + rightAxisWidth
     + axisGap * ((leftAxisWidth ? 1 : 0) + (rightAxisWidth ? 1 : 0));
   const plotWidth = Math.max(1, totalWidth - horizontalReserved);
+  const downsampleWidth = Math.max(
+    1,
+    Math.round(plotWidth * cellWidthPx * Math.max(1, pixelRatio)),
+  );
   const layoutPanels = useMemo<CompositePanelScene[] | null>(() => {
     if (!projectedScene) return null;
     const panelSpecById = new Map(panels.map((panel) => [panel.id, panel] as const));
@@ -1736,13 +1756,14 @@ export function CompositeChart({
   }, [panels, plotHeight, projectedScene]);
   const baseScene = useMemo<CompositeChartScene | null>(() => {
     if (!projectedScene || !layoutPanels) return null;
-    return {
+    const laidOut: CompositeChartScene = {
       ...projectedScene,
       width: plotWidth,
       height: layoutPanels.reduce((sum, panel) => sum + panel.height, 0),
       panels: layoutPanels,
     };
-  }, [layoutPanels, plotWidth, projectedScene]);
+    return downsampleCompositeChartScene(laidOut, downsampleWidth);
+  }, [downsampleWidth, layoutPanels, plotWidth, projectedScene]);
   const resolvedCursorTimestamp = resolvedCursorDate?.getTime() ?? null;
   const normalizedCursorTimestamp = resolvedCursorTimestamp !== null && Number.isFinite(resolvedCursorTimestamp)
     ? resolvedCursorTimestamp

--- a/src/components/chart/composite/downsample.test.ts
+++ b/src/components/chart/composite/downsample.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
+import {
+  downsampleCompositeChartScene,
+  downsampleLttb,
+  downsampleOhlcProjectedPoints,
+} from "./downsample";
+import { buildCompositeChartScene } from "./scene";
+
+function point(date: string, value: number): TimeSeriesPoint {
+  const observedAt = new Date(`${date}T00:00:00.000Z`);
+  return { date: observedAt, observedAt, value };
+}
+
+function ohlcPoint(
+  date: Date,
+  open: number,
+  high: number,
+  low: number,
+  close: number,
+): TimeSeriesPoint {
+  return {
+    date,
+    observedAt: date,
+    value: close,
+    open,
+    high,
+    low,
+    close,
+    volume: 1,
+  };
+}
+
+function series(
+  overrides: Partial<ResolvedSeries> & Pick<ResolvedSeries, "id" | "points">,
+): ResolvedSeries {
+  return {
+    id: overrides.id,
+    label: overrides.label ?? overrides.id,
+    color: overrides.color ?? "#00ff66",
+    unit: overrides.unit ?? "USD",
+    unitGroup: overrides.unitGroup ?? "currency",
+    nativeFrequency: overrides.nativeFrequency ?? "daily",
+    dataShape: overrides.dataShape ?? "scalar",
+    style: overrides.style ?? "line",
+    transform: overrides.transform ?? "raw",
+    axis: overrides.axis ?? "left",
+    panelId: overrides.panelId ?? "main",
+    interpolation: overrides.interpolation ?? "none",
+    timestampMode: overrides.timestampMode,
+    timeBasis: overrides.timeBasis,
+    points: overrides.points,
+    warning: overrides.warning,
+  };
+}
+
+function denseLineSeries(count: number): ResolvedSeries {
+  const start = Date.parse("2024-01-01T00:00:00.000Z");
+  return series({
+    id: "price",
+    points: Array.from({ length: count }, (_, index) => {
+      const date = new Date(start + index * 86_400_000);
+      const value = 100 + Math.sin(index / 8) * 20 + (index % 37 === 0 ? 40 : 0);
+      return { date, observedAt: date, value };
+    }),
+  });
+}
+
+describe("composite downsample", () => {
+  test("caps line series to the pixel width and keeps the shared date list", () => {
+    const scene = buildCompositeChartScene(
+      [denseLineSeries(400)],
+      [{ id: "main" }],
+      { width: 80, height: 12 },
+    );
+    expect(scene).not.toBeNull();
+    expect(scene!.panels[0]!.series[0]!.points.length).toBe(400);
+
+    const downsampled = downsampleCompositeChartScene(scene!, 64);
+    expect(downsampled.dates).toBe(scene!.dates);
+    expect(downsampled.dateRatios).toBe(scene!.dateRatios);
+    expect(downsampled.dates).toHaveLength(400);
+    expect(downsampled.panels[0]!.series[0]!.points.length).toBeLessThanOrEqual(64);
+    expect(downsampled.panels[0]!.series[0]!.points.length).toBeGreaterThan(2);
+  });
+
+  test("LTTB never exceeds the requested point budget", () => {
+    const scene = buildCompositeChartScene(
+      [denseLineSeries(250)],
+      [{ id: "main" }],
+      { width: 120, height: 10 },
+    )!;
+    const points = scene.panels[0]!.series[0]!.points;
+    expect(downsampleLttb(points, 40)).toHaveLength(40);
+    expect(downsampleLttb(points, points.length)).toBe(points);
+  });
+
+  test("OHLC buckets preserve the viewport high and low", () => {
+    const start = Date.parse("2024-01-01T00:00:00.000Z");
+    const candles = series({
+      id: "ohlc",
+      dataShape: "ohlcv",
+      style: "candles",
+      points: Array.from({ length: 180 }, (_, index) => {
+        const date = new Date(start + index * 86_400_000);
+        const close = 50 + index;
+        const high = index === 41 ? 900 : close + 1;
+        const low = index === 117 ? 2 : close - 1;
+        return ohlcPoint(date, close - 0.5, high, low, close);
+      }),
+    });
+    const scene = buildCompositeChartScene(
+      [candles],
+      [{ id: "main" }],
+      { width: 80, height: 12 },
+    )!;
+    const source = scene.panels[0]!.series[0]!.points;
+    const buckets = downsampleOhlcProjectedPoints(source, 40);
+    expect(buckets.length).toBeLessThanOrEqual(40);
+    expect(Math.max(...buckets.map((entry) => entry.point.high ?? entry.value))).toBe(900);
+    expect(Math.min(...buckets.map((entry) => entry.point.low ?? entry.value))).toBe(2);
+  });
+
+  test("does not downsample when the series already fits the budget", () => {
+    const scene = buildCompositeChartScene(
+      [series({
+        id: "short",
+        points: [point("2025-01-01", 10), point("2025-01-02", 12), point("2025-01-03", 11)],
+      })],
+      [{ id: "main" }],
+      { width: 80, height: 8 },
+    )!;
+    const downsampled = downsampleCompositeChartScene(scene, 64);
+    expect(downsampled.panels[0]!.series[0]!.points).toBe(scene.panels[0]!.series[0]!.points);
+  });
+});

--- a/src/components/chart/composite/downsample.ts
+++ b/src/components/chart/composite/downsample.ts
@@ -1,0 +1,208 @@
+import type { SeriesStyle } from "../../../time-series/types";
+import type { TimeSeriesPoint } from "../../../time-series/types";
+import type {
+  CompositeChartScene,
+  CompositePanelScene,
+  CompositeProjectedPoint,
+  CompositeProjectedSeries,
+} from "./types";
+
+function finiteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isOhlcStyle(style: SeriesStyle): boolean {
+  return style === "candles" || style === "ohlc" || style === "hlc";
+}
+
+function splitConnectedSegments(
+  points: readonly CompositeProjectedPoint[],
+): CompositeProjectedPoint[][] {
+  const segments: CompositeProjectedPoint[][] = [];
+  let current: CompositeProjectedPoint[] = [];
+  for (const point of points) {
+    if (point.breakBefore && current.length > 0) {
+      segments.push(current);
+      current = [];
+    }
+    current.push(point);
+  }
+  if (current.length > 0) segments.push(current);
+  return segments;
+}
+
+/**
+ * Largest-Triangle-Three-Buckets. Keeps the first and last samples and one
+ * representative from each interior bucket so a line still fits the pixel
+ * budget without flattening extrema.
+ */
+export function downsampleLttb(
+  points: readonly CompositeProjectedPoint[],
+  threshold: number,
+): CompositeProjectedPoint[] {
+  const count = points.length;
+  const budget = Math.max(Math.floor(threshold), 1);
+  if (count <= budget) return points as CompositeProjectedPoint[];
+  if (budget === 1) return [points[0]!];
+  if (budget === 2) return [points[0]!, points[count - 1]!];
+
+  const sampled: CompositeProjectedPoint[] = [points[0]!];
+  const bucketSize = (count - 2) / (budget - 2);
+  let previousIndex = 0;
+
+  for (let bucketIndex = 0; bucketIndex < budget - 2; bucketIndex += 1) {
+    const nextStart = Math.floor((bucketIndex + 1) * bucketSize) + 1;
+    const nextEnd = Math.min(Math.floor((bucketIndex + 2) * bucketSize) + 1, count);
+    let avgX = 0;
+    let avgY = 0;
+    const avgCount = Math.max(nextEnd - nextStart, 1);
+    for (let index = nextStart; index < nextEnd; index += 1) {
+      avgX += points[index]!.xRatio;
+      avgY += points[index]!.yRatio;
+    }
+    avgX /= avgCount;
+    avgY /= avgCount;
+
+    const currentStart = Math.floor(bucketIndex * bucketSize) + 1;
+    const currentEnd = Math.floor((bucketIndex + 1) * bucketSize) + 1;
+    const previous = points[previousIndex]!;
+    const prevX = previous.xRatio;
+    const prevY = previous.yRatio;
+    let maxArea = -1;
+    let maxIndex = currentStart;
+    for (let index = currentStart; index < currentEnd; index += 1) {
+      const point = points[index]!;
+      const area = Math.abs(
+        (prevX - avgX) * (point.yRatio - prevY) - (prevX - point.xRatio) * (avgY - prevY),
+      );
+      if (area > maxArea) {
+        maxArea = area;
+        maxIndex = index;
+      }
+    }
+    sampled.push(points[maxIndex]!);
+    previousIndex = maxIndex;
+  }
+
+  sampled.push(points[count - 1]!);
+  return sampled;
+}
+
+function downsampleLineProjectedPoints(
+  points: readonly CompositeProjectedPoint[],
+  pixelWidth: number,
+): CompositeProjectedPoint[] {
+  if (points.length <= pixelWidth) return points as CompositeProjectedPoint[];
+  const segments = splitConnectedSegments(points);
+  if (segments.length === 1) return downsampleLttb(points, pixelWidth);
+
+  const sampled: CompositeProjectedPoint[] = [];
+  for (const segment of segments) {
+    const budget = Math.max(2, Math.floor(pixelWidth * (segment.length / points.length)));
+    const next = downsampleLttb(segment, Math.min(budget, segment.length));
+    if (sampled.length > 0 && next[0] && !next[0].breakBefore) {
+      sampled.push({ ...next[0], breakBefore: true }, ...next.slice(1));
+      continue;
+    }
+    sampled.push(...next);
+  }
+  return sampled.length <= pixelWidth ? sampled : downsampleLttb(sampled, pixelWidth);
+}
+
+function sourceValue(point: CompositeProjectedPoint, key: "open" | "high" | "low" | "close"): number {
+  const candidate = point.point[key];
+  return finiteNumber(candidate) ? candidate : point.value;
+}
+
+function aggregateOhlcProjectedBucket(
+  bucket: readonly CompositeProjectedPoint[],
+): CompositeProjectedPoint {
+  const first = bucket[0]!;
+  const last = bucket[bucket.length - 1]!;
+  let high = sourceValue(first, "high");
+  let low = sourceValue(first, "low");
+  let volume = finiteNumber(first.point.volume) ? first.point.volume : 0;
+  let breakBefore = first.breakBefore;
+
+  for (let index = 1; index < bucket.length; index += 1) {
+    const point = bucket[index]!;
+    high = Math.max(high, sourceValue(point, "high"));
+    low = Math.min(low, sourceValue(point, "low"));
+    if (finiteNumber(point.point.volume)) volume += point.point.volume;
+    if (point.breakBefore) breakBefore = true;
+  }
+
+  const open = sourceValue(first, "open");
+  const close = sourceValue(last, "close");
+  const point: TimeSeriesPoint = {
+    ...last.point,
+    value: close,
+    open,
+    high,
+    low,
+    close,
+    volume,
+  };
+  return {
+    ...last,
+    point,
+    value: close,
+    breakBefore,
+  };
+}
+
+export function downsampleOhlcProjectedPoints(
+  points: readonly CompositeProjectedPoint[],
+  targetWidth: number,
+): CompositeProjectedPoint[] {
+  const budget = Math.max(Math.floor(targetWidth), 1);
+  if (points.length <= budget) return points as CompositeProjectedPoint[];
+
+  const buckets: CompositeProjectedPoint[][] = Array.from({ length: budget }, () => []);
+  for (const point of points) {
+    const index = Math.min(budget - 1, Math.max(0, Math.floor(point.xRatio * budget)));
+    buckets[index]!.push(point);
+  }
+  return buckets.flatMap((bucket) => (bucket.length > 0 ? [aggregateOhlcProjectedBucket(bucket)] : []));
+}
+
+export function downsampleProjectedSeries(
+  series: CompositeProjectedSeries,
+  pixelWidth: number,
+): CompositeProjectedSeries {
+  const width = Math.max(Math.floor(pixelWidth), 1);
+  if (series.points.length <= 1 || width <= 1) return series;
+  const points = isOhlcStyle(series.source.style)
+    ? downsampleOhlcProjectedPoints(series.points, Math.max(Math.floor(width / 2), 1))
+    : downsampleLineProjectedPoints(series.points, width);
+  return points === series.points ? series : { ...series, points };
+}
+
+function downsamplePanel(panel: CompositePanelScene, pixelWidth: number): CompositePanelScene {
+  let changed = false;
+  const series = panel.series.map((entry) => {
+    const next = downsampleProjectedSeries(entry, pixelWidth);
+    if (next !== entry) changed = true;
+    return next;
+  });
+  return changed ? { ...panel, series } : panel;
+}
+
+/**
+ * Caps each panel's projected series to the plot's pixel budget. Cursor
+ * snapping still uses the full `dates` / `dateRatios` lists on the scene.
+ */
+export function downsampleCompositeChartScene(
+  scene: CompositeChartScene,
+  pixelWidth: number,
+): CompositeChartScene {
+  const width = Math.max(Math.floor(pixelWidth), 1);
+  if (width <= 1) return scene;
+  let changed = false;
+  const panels = scene.panels.map((panel) => {
+    const next = downsamplePanel(panel, width);
+    if (next !== panel) changed = true;
+    return next;
+  });
+  return changed ? { ...scene, panels } : scene;
+}

--- a/src/components/chart/composite/downsample.ts
+++ b/src/components/chart/composite/downsample.ts
@@ -1,4 +1,4 @@
-import type { SeriesStyle } from "../../../time-series/types";
+import { isOhlcSeriesStyle } from "../../../time-series/spec";
 import type { TimeSeriesPoint } from "../../../time-series/types";
 import type {
   CompositeChartScene,
@@ -9,10 +9,6 @@ import type {
 
 function finiteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
-}
-
-function isOhlcStyle(style: SeriesStyle): boolean {
-  return style === "candles" || style === "ohlc" || style === "hlc";
 }
 
 function splitConnectedSegments(
@@ -158,12 +154,16 @@ export function downsampleOhlcProjectedPoints(
   const budget = Math.max(Math.floor(targetWidth), 1);
   if (points.length <= budget) return points as CompositeProjectedPoint[];
 
-  const buckets: CompositeProjectedPoint[][] = Array.from({ length: budget }, () => []);
+  const buckets = new Map<number, CompositeProjectedPoint[]>();
   for (const point of points) {
     const index = Math.min(budget - 1, Math.max(0, Math.floor(point.xRatio * budget)));
-    buckets[index]!.push(point);
+    const bucket = buckets.get(index);
+    if (bucket) bucket.push(point);
+    else buckets.set(index, [point]);
   }
-  return buckets.flatMap((bucket) => (bucket.length > 0 ? [aggregateOhlcProjectedBucket(bucket)] : []));
+  return [...buckets.entries()]
+    .sort((left, right) => left[0] - right[0])
+    .map(([, bucket]) => aggregateOhlcProjectedBucket(bucket));
 }
 
 export function downsampleProjectedSeries(
@@ -172,7 +172,7 @@ export function downsampleProjectedSeries(
 ): CompositeProjectedSeries {
   const width = Math.max(Math.floor(pixelWidth), 1);
   if (series.points.length <= 1 || width <= 1) return series;
-  const points = isOhlcStyle(series.source.style)
+  const points = isOhlcSeriesStyle(series.source.style)
     ? downsampleOhlcProjectedPoints(series.points, Math.max(Math.floor(width / 2), 1))
     : downsampleLineProjectedPoints(series.points, width);
   return points === series.points ? series : { ...series, points };

--- a/src/components/chart/composite/panel-series.test.ts
+++ b/src/components/chart/composite/panel-series.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
-import { groupSeriesByPanelId, reuseResolvedSeriesIdentity, reuseResolvedSeriesList } from "./panel-series";
+import { reuseResolvedSeriesIdentity, reuseResolvedSeriesList } from "./panel-series";
 
 function point(): TimeSeriesPoint {
   const date = new Date("2024-01-01T00:00:00.000Z");
@@ -24,34 +24,6 @@ function series(id: string, panelId: string): ResolvedSeries {
     points: [point()],
   };
 }
-
-describe("groupSeriesByPanelId", () => {
-  test("groups by panelId", () => {
-    const a = series("a", "main");
-    const b = series("b", "volume");
-    const c = series("c", "main");
-    const grouped = groupSeriesByPanelId([a, b, c]);
-    expect(grouped.get("main")).toEqual([a, c]);
-    expect(grouped.get("volume")).toEqual([b]);
-  });
-
-  test("reuses panel array identity when members are unchanged", () => {
-    const a = series("a", "main");
-    const b = series("b", "main");
-    const first = groupSeriesByPanelId([a, b]);
-    const second = groupSeriesByPanelId([a, b], first);
-    expect(second.get("main")).toBe(first.get("main"));
-  });
-
-  test("allocates a new panel array when membership changes", () => {
-    const a = series("a", "main");
-    const b = series("b", "main");
-    const first = groupSeriesByPanelId([a]);
-    const second = groupSeriesByPanelId([a, b], first);
-    expect(second.get("main")).not.toBe(first.get("main"));
-    expect(second.get("main")).toEqual([a, b]);
-  });
-});
 
 describe("reuseResolvedSeriesIdentity", () => {
   test("reuses the previous object when a parent clones identical series data", () => {

--- a/src/components/chart/composite/panel-series.test.ts
+++ b/src/components/chart/composite/panel-series.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
+import { groupSeriesByPanelId, reuseResolvedSeriesIdentity, reuseResolvedSeriesList } from "./panel-series";
+
+function point(): TimeSeriesPoint {
+  const date = new Date("2024-01-01T00:00:00.000Z");
+  return { date, observedAt: date, value: 1 };
+}
+
+function series(id: string, panelId: string): ResolvedSeries {
+  return {
+    id,
+    label: id,
+    color: "#0f0",
+    unit: "USD",
+    unitGroup: "currency",
+    nativeFrequency: "daily",
+    dataShape: "scalar",
+    style: "line",
+    transform: "raw",
+    axis: "left",
+    panelId,
+    interpolation: "none",
+    points: [point()],
+  };
+}
+
+describe("groupSeriesByPanelId", () => {
+  test("groups by panelId", () => {
+    const a = series("a", "main");
+    const b = series("b", "volume");
+    const c = series("c", "main");
+    const grouped = groupSeriesByPanelId([a, b, c]);
+    expect(grouped.get("main")).toEqual([a, c]);
+    expect(grouped.get("volume")).toEqual([b]);
+  });
+
+  test("reuses panel array identity when members are unchanged", () => {
+    const a = series("a", "main");
+    const b = series("b", "main");
+    const first = groupSeriesByPanelId([a, b]);
+    const second = groupSeriesByPanelId([a, b], first);
+    expect(second.get("main")).toBe(first.get("main"));
+  });
+
+  test("allocates a new panel array when membership changes", () => {
+    const a = series("a", "main");
+    const b = series("b", "main");
+    const first = groupSeriesByPanelId([a]);
+    const second = groupSeriesByPanelId([a, b], first);
+    expect(second.get("main")).not.toBe(first.get("main"));
+    expect(second.get("main")).toEqual([a, b]);
+  });
+});
+
+describe("reuseResolvedSeriesIdentity", () => {
+  test("reuses the previous object when a parent clones identical series data", () => {
+    const original = series("a", "main");
+    const clone: ResolvedSeries = { ...original, points: original.points.map((entry) => ({ ...entry })) };
+    expect(reuseResolvedSeriesIdentity(original, clone)).toBe(original);
+  });
+
+  test("keeps series identity when only the last bar close and time change", () => {
+    const start = new Date("2024-01-01T00:00:00.000Z");
+    const first: TimeSeriesPoint = { date: start, observedAt: start, value: 10, close: 10 };
+    const second: TimeSeriesPoint = {
+      date: new Date("2024-01-02T00:00:00.000Z"),
+      observedAt: new Date("2024-01-02T00:00:00.000Z"),
+      value: 11,
+      close: 11,
+    };
+    const previous = series("a", "main");
+    previous.points = [first, second];
+    const nextLast: TimeSeriesPoint = {
+      date: new Date("2024-01-02T00:00:01.000Z"),
+      observedAt: new Date("2024-01-02T00:00:01.000Z"),
+      value: 11.5,
+      close: 11.5,
+    };
+    const next: ResolvedSeries = {
+      ...previous,
+      points: [first, nextLast],
+    };
+    expect(reuseResolvedSeriesIdentity(previous, next)).toBe(previous);
+    expect(previous.points[1]).toBe(nextLast);
+  });
+
+  test("reuses the list identity when every member is reused", () => {
+    const a = series("a", "main");
+    const first = [a];
+    const second = reuseResolvedSeriesList(first, [{ ...a, points: a.points.map((entry) => ({ ...entry })) }]);
+    expect(second).toBe(first);
+  });
+});

--- a/src/components/chart/composite/panel-series.ts
+++ b/src/components/chart/composite/panel-series.ts
@@ -1,37 +1,5 @@
 import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
 
-/**
- * Groups series by panelId. When `previous` is supplied, reuses each panel's
- * array identity if the member series refs are unchanged.
- */
-export function groupSeriesByPanelId(
-  series: readonly ResolvedSeries[],
-  previous?: ReadonlyMap<string, readonly ResolvedSeries[]>,
-): Map<string, ResolvedSeries[]> {
-  const grouped = new Map<string, ResolvedSeries[]>();
-  for (const entry of series) {
-    const list = grouped.get(entry.panelId);
-    if (list) list.push(entry);
-    else grouped.set(entry.panelId, [entry]);
-  }
-  if (!previous || previous.size === 0) return grouped;
-
-  const next = new Map<string, ResolvedSeries[]>();
-  for (const [panelId, members] of grouped) {
-    const prior = previous.get(panelId);
-    if (
-      prior
-      && prior.length === members.length
-      && prior.every((entry, index) => entry === members[index])
-    ) {
-      next.set(panelId, prior as ResolvedSeries[]);
-    } else {
-      next.set(panelId, members);
-    }
-  }
-  return next;
-}
-
 function sameTime(left: Date | undefined, right: Date | undefined): boolean {
   if (left === right) return true;
   if (!left || !right) return left == right;
@@ -100,15 +68,20 @@ export function reuseResolvedSeriesIdentity(
     return previous;
   }
   if (previous.points.length !== next.points.length) return next;
+  const lastPrev = previous.points[previous.points.length - 1]!;
+  const lastNext = next.points[next.points.length - 1]!;
+  if (!samePoint(lastPrev, lastNext)) {
+    if (!prefixPointsEqual(previous.points, next.points)) return next;
+    previous.points[previous.points.length - 1] = lastNext;
+    previous.latestChangePercent = next.latestChangePercent;
+    return previous;
+  }
   if (previous.points.every((point, index) => samePoint(point, next.points[index]!))) {
     if (previous.latestChangePercent === next.latestChangePercent) return previous;
     previous.latestChangePercent = next.latestChangePercent;
     return previous;
   }
-  if (!prefixPointsEqual(previous.points, next.points)) return next;
-  previous.points[previous.points.length - 1] = next.points[next.points.length - 1]!;
-  previous.latestChangePercent = next.latestChangePercent;
-  return previous;
+  return next;
 }
 
 export function reuseResolvedSeriesList(

--- a/src/components/chart/composite/panel-series.ts
+++ b/src/components/chart/composite/panel-series.ts
@@ -1,0 +1,128 @@
+import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
+
+/**
+ * Groups series by panelId. When `previous` is supplied, reuses each panel's
+ * array identity if the member series refs are unchanged.
+ */
+export function groupSeriesByPanelId(
+  series: readonly ResolvedSeries[],
+  previous?: ReadonlyMap<string, readonly ResolvedSeries[]>,
+): Map<string, ResolvedSeries[]> {
+  const grouped = new Map<string, ResolvedSeries[]>();
+  for (const entry of series) {
+    const list = grouped.get(entry.panelId);
+    if (list) list.push(entry);
+    else grouped.set(entry.panelId, [entry]);
+  }
+  if (!previous || previous.size === 0) return grouped;
+
+  const next = new Map<string, ResolvedSeries[]>();
+  for (const [panelId, members] of grouped) {
+    const prior = previous.get(panelId);
+    if (
+      prior
+      && prior.length === members.length
+      && prior.every((entry, index) => entry === members[index])
+    ) {
+      next.set(panelId, prior as ResolvedSeries[]);
+    } else {
+      next.set(panelId, members);
+    }
+  }
+  return next;
+}
+
+function sameTime(left: Date | undefined, right: Date | undefined): boolean {
+  if (left === right) return true;
+  if (!left || !right) return left == right;
+  return left.getTime() === right.getTime();
+}
+
+function samePoint(left: TimeSeriesPoint, right: TimeSeriesPoint): boolean {
+  return left === right
+    || (
+      sameTime(left.date, right.date)
+      && sameTime(left.observedAt, right.observedAt)
+      && sameTime(left.availableAt, right.availableAt)
+      && left.value === right.value
+      && left.open === right.open
+      && left.high === right.high
+      && left.low === right.low
+      && left.close === right.close
+      && left.volume === right.volume
+      && left.periodLabel === right.periodLabel
+    );
+}
+
+function sameSeriesMeta(left: ResolvedSeries, right: ResolvedSeries): boolean {
+  return left.id === right.id
+    && left.label === right.label
+    && left.color === right.color
+    && left.unit === right.unit
+    && left.unitGroup === right.unitGroup
+    && left.nativeFrequency === right.nativeFrequency
+    && left.timestampMode === right.timestampMode
+    && left.dataShape === right.dataShape
+    && left.style === right.style
+    && left.transform === right.transform
+    && left.axis === right.axis
+    && left.panelId === right.panelId
+    && left.interpolation === right.interpolation
+    && left.warning === right.warning
+    && left.hidden === right.hidden
+    && left.timeBasis?.kind === right.timeBasis?.kind
+    && left.timeBasis?.timeZone === right.timeBasis?.timeZone
+    && left.timeBasis?.cadenceMs === right.timeBasis?.cadenceMs;
+}
+
+function prefixPointsEqual(left: readonly TimeSeriesPoint[], right: readonly TimeSeriesPoint[]): boolean {
+  if (left.length !== right.length || left.length === 0) return false;
+  for (let index = 0; index < left.length - 1; index += 1) {
+    if (!samePoint(left[index]!, right[index]!)) return false;
+  }
+  return true;
+}
+
+/**
+ * Reuses a previous ResolvedSeries object when a parent allocated a new wrapper
+ * for the same data, including live ticks that only change the last bar's
+ * close/time. Bitmap dirty detection keys off object identity, so this keeps
+ * an otherwise-stable plot from full-rerastering on every quote.
+ */
+export function reuseResolvedSeriesIdentity(
+  previous: ResolvedSeries | undefined,
+  next: ResolvedSeries,
+): ResolvedSeries {
+  if (!previous) return next;
+  if (previous === next) return next;
+  if (!sameSeriesMeta(previous, next)) return next;
+  if (previous.points === next.points && previous.latestChangePercent === next.latestChangePercent) {
+    return previous;
+  }
+  if (previous.points.length !== next.points.length) return next;
+  if (previous.points.every((point, index) => samePoint(point, next.points[index]!))) {
+    if (previous.latestChangePercent === next.latestChangePercent) return previous;
+    previous.latestChangePercent = next.latestChangePercent;
+    return previous;
+  }
+  if (!prefixPointsEqual(previous.points, next.points)) return next;
+  previous.points[previous.points.length - 1] = next.points[next.points.length - 1]!;
+  previous.latestChangePercent = next.latestChangePercent;
+  return previous;
+}
+
+export function reuseResolvedSeriesList(
+  previous: readonly ResolvedSeries[] | undefined,
+  next: readonly ResolvedSeries[],
+): ResolvedSeries[] {
+  if (!previous) return next as ResolvedSeries[];
+  if (previous === next) return previous as ResolvedSeries[];
+  const reused = next.map((series, index) => reuseResolvedSeriesIdentity(previous[index], series));
+  if (
+    reused.length === previous.length
+    && reused.every((series, index) => series === previous[index])
+  ) {
+    return previous as ResolvedSeries[];
+  }
+  return reused;
+}

--- a/src/components/chart/multi-line/renderer.ts
+++ b/src/components/chart/multi-line/renderer.ts
@@ -6,6 +6,7 @@ import { valueToPixelY, type MultiLineChartScene, type MultiLineProjectedPoint }
 export {
   buildMultiLineChartScene,
   resolveMultiLineCursorDate,
+  valueToPixelY,
 } from "./scene";
 export type {
   MultiLineChartColors,

--- a/src/components/chart/native/use-chart-text-fallback.ts
+++ b/src/components/chart/native/use-chart-text-fallback.ts
@@ -1,0 +1,19 @@
+import { useNativeRenderer } from "../../../ui";
+import { useOptionalAppSelector } from "../../../state/app/context";
+import type { ChartRendererPreference } from "../core/types";
+import { useResolvedChartRendererState } from "./renderer-selection";
+
+/**
+ * Cell-character plot text is only visible when kitty is not the active chart
+ * renderer. Skip rebuilding braille/ASCII fallback while the native bitmap is
+ * on screen.
+ */
+export function useShowChartTextFallback(): boolean {
+  const renderer = useNativeRenderer();
+  const preferredRenderer = useOptionalAppSelector<ChartRendererPreference>(
+    (state) => state.config.chartPreferences.renderer,
+    "braille",
+  );
+  const rendererState = useResolvedChartRendererState(preferredRenderer, renderer);
+  return rendererState.renderer !== "kitty";
+}

--- a/src/components/chart/static/chart/surface.tsx
+++ b/src/components/chart/static/chart/surface.tsx
@@ -8,8 +8,10 @@ import {
   computeGridLines,
   renderChart,
   type RenderChartOptions,
+  type RenderChartResult,
 } from "../../core/renderer";
 import { renderNativeChartBase, type NativeChartBitmap } from "../../native/chart-rasterizer";
+import { useShowChartTextFallback } from "../../native/use-chart-text-fallback";
 import { useStaticChartBitmapSize } from "./bitmap";
 import {
   StaticXAxisLabels,
@@ -103,6 +105,7 @@ export function StaticChartSurface({
 }: StaticChartSurfaceProps) {
   const themeColors = useThemeColors();
   const { cellWidthPx = 8, cellHeightPx = 18 } = useUiCapabilities();
+  const showTextFallback = useShowChartTextFallback();
   const plotRef = useRef<BoxRenderable | null>(null);
   const [cursor, setCursor] = useState<{ x: number; y: number } | null>(null);
   const xAxisRows = showTimeAxis || (xAxisLabels?.length ?? 0) > 0 ? 1 : 0;
@@ -157,13 +160,13 @@ export function StaticChartSurface({
   const axisGap = axisWidth > 0 ? 1 : 0;
   const plotWidth = Math.max(1, totalWidth - axisWidth - axisGap);
   const bitmapSize = useStaticChartBitmapSize(plotWidth, plotHeight);
-  const renderOptions = useMemo<RenderChartOptions>(() => ({
+  const plotOptions = useMemo<RenderChartOptions>(() => ({
     width: plotWidth,
     height: plotHeight,
     showVolume,
     volumeHeight,
-    cursorX: cursor?.x ?? null,
-    cursorY: cursor?.y ?? null,
+    cursorX: null,
+    cursorY: null,
     mode,
     axisMode,
     currency,
@@ -180,15 +183,38 @@ export function StaticChartSurface({
     mode,
     plotHeight,
     plotWidth,
-    cursor,
     showVolume,
     timeAxisDates,
     volumeHeight,
   ]);
-  const textResult = useMemo(
-    () => renderChart(points, renderOptions),
-    [points, renderOptions],
+  const cursorOptions = useMemo<RenderChartOptions>(() => ({
+    ...plotOptions,
+    cursorX: cursor?.x ?? null,
+    cursorY: cursor?.y ?? null,
+  }), [cursor, plotOptions]);
+  const cursorScene = useMemo(
+    () => buildChartScene(points, cursorOptions),
+    [cursorOptions, points],
   );
+  const textResult = useMemo<RenderChartResult>(() => {
+    if (showTextFallback) return renderChart(points, cursorOptions);
+    return {
+      lines: [],
+      axisLabels: [],
+      timeLabels: cursorScene?.timeLabels ?? "",
+      activePoint: cursorScene?.activePoint ?? null,
+      priceAtCursor: cursorScene?.priceAtCursor ?? null,
+      crosshairPrice: cursorScene?.crosshairPrice ?? null,
+      dateAtCursor: cursorScene?.dateAtCursor ?? null,
+      changeAtCursor: cursorScene?.changeAtCursor ?? null,
+      changePctAtCursor: cursorScene?.changePctAtCursor ?? null,
+      cursorColumn: cursorScene?.cursorColumn ?? null,
+      cursorRow: cursorScene?.cursorRow ?? null,
+      axisFractionDigits: null,
+      priceRange: cursorScene ? cursorScene.max - cursorScene.min : null,
+      pixelBuffer: null,
+    };
+  }, [cursorOptions, cursorScene, points, showTextFallback]);
   const effectiveAxisLabelsByRow = useMemo(() => {
     return new Map(axisLabels.map((entry) => [entry.row, entry.label] as const));
   }, [axisLabels]);
@@ -204,10 +230,10 @@ export function StaticChartSurface({
   const effectiveAxisGap = effectiveAxisWidth > 0 ? 1 : 0;
   const bitmap = useMemo<NativeChartBitmap | null>(() => {
     if (!bitmapSize) return null;
-    const scene = buildChartScene(points, renderOptions);
+    const scene = buildChartScene(points, plotOptions);
     if (!scene) return null;
     return renderNativeChartBase(scene, bitmapSize.pixelWidth, bitmapSize.pixelHeight);
-  }, [bitmapSize, points, renderOptions]);
+  }, [bitmapSize, plotOptions, points]);
   const canvasCrosshair = useMemo<ChartSurfaceProps["crosshair"]>(() => {
     if (!bitmap || !cursor) return null;
     return {

--- a/src/components/chart/static/chart/surface.tsx
+++ b/src/components/chart/static/chart/surface.tsx
@@ -192,9 +192,16 @@ export function StaticChartSurface({
     cursorX: cursor?.x ?? null,
     cursorY: cursor?.y ?? null,
   }), [cursor, plotOptions]);
+  const plotScene = useMemo(
+    () => buildChartScene(points, plotOptions),
+    [plotOptions, points],
+  );
   const cursorScene = useMemo(
-    () => buildChartScene(points, cursorOptions),
-    [cursorOptions, points],
+    () => {
+      if (showTextFallback || !cursor) return plotScene;
+      return buildChartScene(points, cursorOptions);
+    },
+    [cursor, cursorOptions, plotScene, points, showTextFallback],
   );
   const textResult = useMemo<RenderChartResult>(() => {
     if (showTextFallback) return renderChart(points, cursorOptions);
@@ -229,11 +236,9 @@ export function StaticChartSurface({
   const effectiveAxisWidth = axisWidth;
   const effectiveAxisGap = effectiveAxisWidth > 0 ? 1 : 0;
   const bitmap = useMemo<NativeChartBitmap | null>(() => {
-    if (!bitmapSize) return null;
-    const scene = buildChartScene(points, plotOptions);
-    if (!scene) return null;
-    return renderNativeChartBase(scene, bitmapSize.pixelWidth, bitmapSize.pixelHeight);
-  }, [bitmapSize, plotOptions, points]);
+    if (!bitmapSize || !plotScene) return null;
+    return renderNativeChartBase(plotScene, bitmapSize.pixelWidth, bitmapSize.pixelHeight);
+  }, [bitmapSize, plotScene]);
   const canvasCrosshair = useMemo<ChartSurfaceProps["crosshair"]>(() => {
     if (!bitmap || !cursor) return null;
     return {

--- a/src/components/chart/static/multi-line-chart-surface.tsx
+++ b/src/components/chart/static/multi-line-chart-surface.tsx
@@ -116,8 +116,8 @@ export function StaticMultiLineChartSurface({
     [plotOptions, series],
   );
   const cursorScene = useMemo(
-    () => buildMultiLineChartScene(series, { ...plotOptions, cursorDate }),
-    [cursorDate, plotOptions, series],
+    () => cursorDate == null ? scene : buildMultiLineChartScene(series, { ...plotOptions, cursorDate }),
+    [cursorDate, plotOptions, scene, series],
   );
   const showTextFallback = useShowChartTextFallback();
   const textLines = useMemo(() => {

--- a/src/components/chart/static/multi-line-chart-surface.tsx
+++ b/src/components/chart/static/multi-line-chart-surface.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useMemo, useRef } from "react";
-import { Box, ChartSurface, Text, type BoxRenderable } from "../../../ui";
+import { Box, ChartSurface, Text, type BoxRenderable, type ChartSurfaceProps } from "../../../ui";
 import { colors } from "../../../theme/colors";
 import { computeGridLines, formatAxisCell } from "../core/renderer";
 import type { NativeChartBitmap } from "../native/chart-rasterizer";
+import { useShowChartTextFallback } from "../native/use-chart-text-fallback";
 import { useStaticChartBitmapSize } from "./chart/bitmap";
 import {
   buildMultiLineChartScene,
@@ -10,6 +11,7 @@ import {
   renderMultiLineTimeAxis,
   renderNativeMultiLineChart,
   resolveMultiLineCursorDate,
+  valueToPixelY,
   type MultiLineChartColors,
   type MultiLineChartSeries,
 } from "../multi-line/renderer";
@@ -101,15 +103,27 @@ export function StaticMultiLineChartSurface({
     : 0;
   const axisGap = axisWidth > 0 ? 1 : 0;
   const plotWidth = Math.max(1, totalWidth - axisWidth - axisGap);
-  const scene = useMemo(() => buildMultiLineChartScene(series, {
+  const plotOptions = useMemo(() => ({
     width: plotWidth,
     height: plotHeight,
     colors: chartColors,
     dates,
-    cursorDate,
+    cursorDate: null as Date | null,
     yDomain,
-  }), [chartColors, cursorDate, dates, plotHeight, plotWidth, series, yDomain]);
-  const textLines = useMemo(() => scene ? renderMultiLineChart(scene) : [], [scene]);
+  }), [chartColors, dates, plotHeight, plotWidth, yDomain]);
+  const scene = useMemo(
+    () => buildMultiLineChartScene(series, plotOptions),
+    [plotOptions, series],
+  );
+  const cursorScene = useMemo(
+    () => buildMultiLineChartScene(series, { ...plotOptions, cursorDate }),
+    [cursorDate, plotOptions, series],
+  );
+  const showTextFallback = useShowChartTextFallback();
+  const textLines = useMemo(() => {
+    if (!showTextFallback) return [];
+    return cursorScene ? renderMultiLineChart(cursorScene) : [];
+  }, [cursorScene, showTextFallback]);
   const timeLabels = useMemo(() => scene ? renderMultiLineTimeAxis(scene) : "", [scene]);
   const effectiveAxisLabelsByRow = useMemo(() => {
     return new Map(axisLabels.map((entry) => [entry.row, entry.label] as const));
@@ -119,6 +133,27 @@ export function StaticMultiLineChartSurface({
     if (!scene || !bitmapSize) return null;
     return renderNativeMultiLineChart(scene, bitmapSize.pixelWidth, bitmapSize.pixelHeight);
   }, [bitmapSize, scene]);
+  const canvasCrosshair = useMemo<ChartSurfaceProps["crosshair"]>(() => {
+    if (!bitmap || !cursorScene || cursorScene.cursorX === null) return null;
+    const pixelX = (cursorScene.cursorX / Math.max(cursorScene.width - 1, 1)) * Math.max(bitmap.width - 1, 0);
+    const cursorIndex = cursorScene.cursorIndex;
+    const markers = cursorIndex === null
+      ? []
+      : cursorScene.series.flatMap((item) => {
+        const point = item.points[cursorIndex];
+        if (!point) return [];
+        return [{
+          pixelY: valueToPixelY(point.value, cursorScene.min, cursorScene.max, bitmap.height),
+          color: item.color,
+        }];
+      });
+    return {
+      pixelX,
+      pixelY: markers[0]?.pixelY ?? bitmap.height / 2,
+      color: chartColors.crosshairColor,
+      markers: markers.length > 0 ? markers : undefined,
+    };
+  }, [bitmap, chartColors.crosshairColor, cursorScene]);
 
   const handleCursorEvent = useCallback((event: ChartMouseEventLike) => {
     if (!scene || !onCursorDateChange) return;
@@ -152,6 +187,7 @@ export function StaticMultiLineChartSurface({
           height={plotHeight}
           flexDirection="column"
           bitmaps={bitmap ? [bitmap] : null}
+          crosshair={canvasCrosshair}
           onMouseMove={handleCursorEvent}
           onMouseDown={handleCursorEvent}
         >

--- a/src/market-data/coordinator/chart.ts
+++ b/src/market-data/coordinator/chart.ts
@@ -11,8 +11,9 @@ const TIME_RANGE_INDEX = new Map(TIME_RANGE_ORDER.map((range, index) => [range, 
 export function createBaselineChartRequest(instrument: InstrumentRef): ChartRequest {
   return {
     instrument,
-    bufferRange: "5Y",
-    granularity: "range",
+    bufferRange: "ALL",
+    granularity: "resolution",
+    resolution: "1wk",
   };
 }
 

--- a/src/market-data/hooks.tsx
+++ b/src/market-data/hooks.tsx
@@ -21,6 +21,7 @@ import {
   buildSecFilingsKey,
   buildSnapshotKey,
 } from "./selectors";
+import { createBaselineChartRequest } from "./coordinator/chart";
 
 const TICKER_FINANCIALS_LOAD_DELAY_MS = 250;
 export const DEFAULT_LIVE_CHART_REFRESH_INTERVAL_MS = 60_000;
@@ -104,7 +105,7 @@ export function useTickerFinancials(symbol: string | null | undefined, ticker: T
       ? [
         buildSnapshotKey(instrument),
         buildQuoteKey(instrument),
-        buildChartKey({ instrument, bufferRange: "5Y", granularity: "range" }),
+        buildChartKey(createBaselineChartRequest(instrument)),
       ]
       : []
   ), [instrument?.brokerId, instrument?.brokerInstanceId, instrument?.exchange, instrument?.instrument?.conId, instrument?.symbol]);
@@ -134,7 +135,7 @@ function buildTickerFinancialsKeys(tickers: TickerRecord[], options: TickerInstr
     keys.push(
       buildSnapshotKey(instrument),
       buildQuoteKey(instrument),
-      buildChartKey({ instrument, bufferRange: "5Y", granularity: "range" }),
+      buildChartKey(createBaselineChartRequest(instrument)),
     );
   }
   return keys;

--- a/src/plugins/builtin/chart-composer/chart-spec.ts
+++ b/src/plugins/builtin/chart-composer/chart-spec.ts
@@ -86,6 +86,16 @@ export function parseChartSpec(value: unknown): ChartSpec | null {
 }
 
 export function parseChartSpecOr(value: unknown, fallback: ChartSpec): ChartSpec {
+  if (
+    isRecord(value)
+    && value.version === CHART_SPEC_VERSION
+    && Array.isArray(value.series)
+    && Array.isArray(value.panels)
+    && Array.isArray(value.studies)
+  ) {
+    const spec = value as unknown as ChartSpec;
+    if (validateChartSpec(spec).valid) return spec;
+  }
   return parseChartSpec(value) ?? normalizeChartSpec(fallback, DEFAULT_CHART_SPEC);
 }
 

--- a/src/sources/provider-router/history.test.ts
+++ b/src/sources/provider-router/history.test.ts
@@ -283,8 +283,8 @@ describe("AssetDataRouter chart history", () => {
     persistence.close();
   });
 
-  test("refreshes stale cached chart history before falling back to cache", async () => {
-    const dbPath = createTempDbPath("stale-chart-refresh");
+  test("returns stale unexpired chart history immediately and refreshes in the background", async () => {
+    const dbPath = createTempDbPath("stale-chart-hit");
     const persistence = new AppPersistence(dbPath);
 
     const seedRouter = new AssetDataRouter({
@@ -299,19 +299,68 @@ describe("AssetDataRouter chart history", () => {
       .query("UPDATE resource_cache SET stale_at = ? WHERE namespace = ? AND kind = ? AND entity_key = ?")
       .run(Date.now() - 1, "market", "price-history", "AAPL");
 
+    let resolveFresh!: (points: Array<{ date: Date; close: number }>) => void;
+    const freshHistory = new Promise<Array<{ date: Date; close: number }>>((resolve) => {
+      resolveFresh = resolve;
+    });
     let providerCalls = 0;
     const refreshRouter = new AssetDataRouter({
       ...fallbackProvider,
       async getPriceHistory() {
         providerCalls += 1;
-        return [{ date: new Date("2026-03-28T00:00:00Z"), close: 202 }];
+        return freshHistory;
       },
     }, [], persistence.resources);
 
     const history = await refreshRouter.getPriceHistory("AAPL", "NASDAQ", "1Y");
 
+    expect(history[0]?.close).toBe(101);
+    await Promise.resolve();
     expect(providerCalls).toBe(1);
-    expect(history[0]?.close).toBe(202);
+
+    resolveFresh([{ date: new Date("2026-03-28T00:00:00Z"), close: 202 }]);
+    await freshHistory;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const refreshed = await refreshRouter.getPriceHistory("AAPL", "NASDAQ", "1Y");
+    expect(refreshed[0]?.close).toBe(202);
+
+    persistence.close();
+  });
+
+  test("clips a shorter resolution range from a wider cached series", async () => {
+    const dbPath = createTempDbPath("clip-wider-chart-cache");
+    const persistence = new AppPersistence(dbPath);
+    const now = Date.parse("2026-03-28T00:00:00Z");
+    const sixYearsAgo = new Date(now - 6 * 365 * 24 * 60 * 60_000);
+    const twoYearsAgo = new Date(now - 2 * 365 * 24 * 60 * 60_000);
+    const latest = new Date(now);
+
+    const seedRouter = new AssetDataRouter({
+      ...fallbackProvider,
+      async getPriceHistoryForResolution() {
+        return [
+          { date: sixYearsAgo, close: 50 },
+          { date: twoYearsAgo, close: 101 },
+          { date: latest, close: 110 },
+        ];
+      },
+    }, [], persistence.resources);
+    await seedRouter.getPriceHistoryForResolution("AAPL", "NASDAQ", "ALL", "1wk");
+
+    let providerCalls = 0;
+    const clipRouter = new AssetDataRouter({
+      ...fallbackProvider,
+      async getPriceHistoryForResolution() {
+        providerCalls += 1;
+        return [{ date: latest, close: 999 }];
+      },
+    }, [], persistence.resources);
+
+    const history = await clipRouter.getPriceHistoryForResolution("AAPL", "NASDAQ", "5Y", "1wk");
+
+    expect(providerCalls).toBe(0);
+    expect(history.map((point) => point.close)).toEqual([101, 110]);
 
     persistence.close();
   });

--- a/src/sources/provider-router/history.ts
+++ b/src/sources/provider-router/history.ts
@@ -6,9 +6,11 @@ import type { TimeRange } from "../../time-series/range";
 import {
   isIntradayResolution,
   normalizeChartResolutionSupport,
+  TIME_RANGE_ORDER,
   type ChartResolutionSupport,
   type ManualChartResolution,
 } from "../../time-series/resolution";
+import { clipPriceHistoryToRange } from "../../time-series/history-window";
 import { repairIsolatedIntradayOhlcOutliers } from "../../time-series/history-quality";
 import { canonicalExchange } from "../../utils/exchanges";
 import { resolvePriceHistoryCurrencyUnit } from "../../utils/currency-units";
@@ -35,6 +37,8 @@ const PRICE_HISTORY_CACHE_VERSION = 4;
 interface HistoryRequestDescriptor {
   identity: RouterRequestIdentity;
   cacheVariantKeys: string[];
+  exactCacheVariantKeys: string[];
+  requestedRange?: TimeRange;
   context?: MarketDataRequestContext;
   cachePolicyKey: PriceHistoryCachePolicyKey;
   missingProviderError?: string;
@@ -68,20 +72,53 @@ function makeHistoryRequestIdentity(
     variantParts: Array<[string, string | number | undefined | null]>;
     fallbackVariantParts: Array<[string, string | number | undefined | null]>;
   },
-): Pick<HistoryRequestDescriptor, "identity" | "cacheVariantKeys"> {
+): Pick<HistoryRequestDescriptor, "identity" | "cacheVariantKeys" | "exactCacheVariantKeys"> {
   const identity = makeRouterRequestIdentity(deps, {
     kind: input.kind,
     ticker: input.ticker,
     context: input.context,
     variantParts: priceHistoryVariantParts(input.variantParts, input.exchange),
   });
+  const cacheVariantKeys = [
+    identity.variantKey,
+    buildVariantKey(priceHistoryVariantParts(input.fallbackVariantParts, input.exchange)),
+  ];
   return {
     identity,
-    cacheVariantKeys: [
-      identity.variantKey,
-      buildVariantKey(priceHistoryVariantParts(input.fallbackVariantParts, input.exchange)),
-    ],
+    cacheVariantKeys,
+    exactCacheVariantKeys: cacheVariantKeys,
   };
+}
+
+function expandedHistoryCacheVariantKeys(
+  deps: Pick<ProviderRouterCoreDeps, "getEntityKey">,
+  input: {
+    ticker: string;
+    exchange: string;
+    context?: MarketDataRequestContext;
+    range: TimeRange;
+    resolution?: ManualChartResolution;
+  },
+): string[] {
+  const start = TIME_RANGE_ORDER.indexOf(input.range);
+  const ranges = start >= 0 ? TIME_RANGE_ORDER.slice(start) : [input.range];
+  const keys: string[] = [];
+  for (const range of ranges) {
+    const { cacheVariantKeys } = makeHistoryRequestIdentity(deps, {
+      kind: "price-history",
+      ticker: input.ticker,
+      exchange: input.exchange,
+      context: input.context,
+      variantParts: input.resolution
+        ? [["exchange", canonicalExchange(input.exchange)], ["range", range], ["resolution", input.resolution]]
+        : [["exchange", canonicalExchange(input.exchange)], ["range", range]],
+      fallbackVariantParts: input.resolution
+        ? [["range", range], ["resolution", input.resolution]]
+        : [["range", range]],
+    });
+    keys.push(...cacheVariantKeys);
+  }
+  return [...new Set(keys)];
 }
 
 function normalizeRequestHistory(
@@ -96,6 +133,7 @@ function normalizeRequestHistory(
 
 export class ProviderRouterHistoryRoutes {
   constructor(private readonly deps: ProviderRouterCoreDeps) {}
+  private readonly historyRefreshInFlight = new Map<string, Promise<void>>();
 
   async getPriceHistory(
     ticker: string,
@@ -114,6 +152,8 @@ export class ProviderRouterHistoryRoutes {
     const intraday = isIntradayRange(range);
     return this.executeHistoryRequest({
       ...identity,
+      cacheVariantKeys: expandedHistoryCacheVariantKeys(this.deps, { ticker, exchange, context, range }),
+      requestedRange: range,
       context,
       cachePolicyKey: intraday ? "priceHistoryIntraday" : "priceHistoryDaily",
       missingProviderError: `No history provider available for ${ticker}`,
@@ -154,6 +194,14 @@ export class ProviderRouterHistoryRoutes {
     const intraday = isIntradayResolution(resolution);
     return this.executeHistoryRequest({
       ...identity,
+      cacheVariantKeys: expandedHistoryCacheVariantKeys(this.deps, {
+        ticker,
+        exchange,
+        context,
+        range: bufferRange,
+        resolution,
+      }),
+      requestedRange: bufferRange,
       context,
       cachePolicyKey: intraday ? "priceHistoryIntraday" : "priceHistoryDaily",
       missingProviderError: `No resolution-aware history provider available for ${ticker}`,
@@ -296,8 +344,15 @@ export class ProviderRouterHistoryRoutes {
     const cachedValue = cached ? normalizeRequestHistory(cached.value, request) : [];
     const cachedHistoryStale = request.isCachedValueStale(cachedValue);
     const forceRefresh = request.context?.cacheMode === "refresh";
-    if (cachedValue.length > 0 && !forceRefresh && cached && !cached.stale && !cachedHistoryStale) {
-      return cachedValue;
+    const usableCached = cachedValue.length > 0 && cached && !cached.expired && !cachedHistoryStale;
+    if (usableCached && !forceRefresh) {
+      const exactHit = request.exactCacheVariantKeys.includes(cached.variantKey);
+      if (cached.stale && exactHit) {
+        this.scheduleHistoryRefresh(request);
+      }
+      return request.requestedRange
+        ? clipPriceHistoryToRange(cachedValue, request.requestedRange)
+        : cachedValue;
     }
 
     const brokerResult = await withBrokerTimeout(this.fetchBrokerHistory(request, brokerCandidates));
@@ -305,11 +360,35 @@ export class ProviderRouterHistoryRoutes {
 
     const providerResult = await this.fetchProviderHistory(request);
     if (providerResult && providerResult.value.length > 0) return providerResult.value;
-    if (cachedValue.length > 0 && !cachedHistoryStale) return cachedValue;
+    if (cachedValue.length > 0 && !cachedHistoryStale) {
+      return request.requestedRange
+        ? clipPriceHistoryToRange(cachedValue, request.requestedRange)
+        : cachedValue;
+    }
     if (!providerResult && request.missingProviderError) {
       throw new Error(request.missingProviderError);
     }
     return providerResult?.value ?? [];
+  }
+
+  private scheduleHistoryRefresh(request: HistoryRequestDescriptor): void {
+    const key = `${request.identity.kind}|${request.identity.entityKey}|${request.identity.variantKey}`;
+    if (this.historyRefreshInFlight.has(key)) return;
+    const pending = this.refreshHistory(request).finally(() => {
+      this.historyRefreshInFlight.delete(key);
+    });
+    this.historyRefreshInFlight.set(key, pending);
+  }
+
+  private async refreshHistory(request: HistoryRequestDescriptor): Promise<void> {
+    const brokerCandidates = this.deps.getBrokerCandidatesForContext(request.context, false);
+    try {
+      const brokerResult = await withBrokerTimeout(this.fetchBrokerHistory(request, brokerCandidates));
+      if (brokerResult && brokerResult.value.length > 0) return;
+      await this.fetchProviderHistory(request);
+    } catch {
+      // Background refresh is best-effort; callers already have cached points.
+    }
   }
 
   private fetchBrokerHistory(
@@ -371,20 +450,55 @@ export class ProviderRouterHistoryRoutes {
   private async firstProviderArrayResult<T>(
     fetch: (provider: DataProvider) => Promise<T[] | null>,
   ): Promise<SourceResult<T[]> | null> {
+    const providers = this.deps.providersInPriorityOrder();
     let firstEmptyResult: SourceResult<T[]> | null = null;
-    for (const provider of this.deps.providersInPriorityOrder()) {
+    const tryProvider = async (provider: DataProvider): Promise<SourceResult<T[]> | null> => {
       try {
         const value = await fetch(provider);
-        if (value === null) continue;
+        if (value === null) return null;
         const result = { sourceKey: this.deps.providerSourceKey(provider), value };
-        if (value.length > 0) return result;
-        firstEmptyResult ??= result;
+        if (value.length === 0) firstEmptyResult ??= result;
+        return result;
       } catch (error) {
         if (shouldLogProviderError(error)) {
           this.deps.logProviderError(`${provider.id} failed: ${error}`);
         }
+        return null;
       }
+    };
+
+    if (providers.length <= 1) {
+      for (const provider of providers) {
+        const result = await tryProvider(provider);
+        if (result && result.value.length > 0) return result;
+      }
+      return firstEmptyResult;
     }
-    return firstEmptyResult;
+
+    const preferred = tryProvider(providers[0]!);
+    const speculativeDelay = new Promise<"timeout">((resolve) => {
+      setTimeout(() => resolve("timeout"), 200);
+    });
+    const first = await Promise.race([preferred, speculativeDelay]);
+    if (first !== "timeout" && first && first.value.length > 0) return first;
+
+    const remaining = providers.slice(1).map((provider) => tryProvider(provider));
+    return await new Promise((resolve) => {
+      let settled = false;
+      const finish = (result: SourceResult<T[]> | null) => {
+        if (settled || !result || result.value.length === 0) return;
+        settled = true;
+        resolve(result);
+      };
+      void preferred.then((result) => {
+        if (result && result.value.length > 0) finish(result);
+      });
+      for (const pending of remaining) {
+        void pending.then(finish);
+      }
+      void Promise.all([preferred, ...remaining]).then(() => {
+        if (!settled) resolve(firstEmptyResult);
+      });
+    });
   }
 }

--- a/src/sources/provider-router/history.ts
+++ b/src/sources/provider-router/history.ts
@@ -26,7 +26,7 @@ import {
   type ProviderRouterCachePolicyKey,
 } from "./cache";
 import type { ProviderRouterCoreDeps, SourceResult } from "./route-types";
-import { makeRouterRequestIdentity, type RouterRequestIdentity } from "./routing";
+import { makeRouterRequestIdentity, scheduleRouterRevalidation, type RouterRequestIdentity } from "./routing";
 
 type PriceHistoryCachePolicyKey = Extract<
   ProviderRouterCachePolicyKey,
@@ -133,7 +133,7 @@ function normalizeRequestHistory(
 
 export class ProviderRouterHistoryRoutes {
   constructor(private readonly deps: ProviderRouterCoreDeps) {}
-  private readonly historyRefreshInFlight = new Map<string, Promise<void>>();
+  private readonly historyRefreshInFlight = new Map<string, Promise<unknown>>();
 
   async getPriceHistory(
     ticker: string,
@@ -348,11 +348,11 @@ export class ProviderRouterHistoryRoutes {
     if (usableCached && !forceRefresh) {
       const exactHit = request.exactCacheVariantKeys.includes(cached.variantKey);
       if (cached.stale && exactHit) {
-        this.scheduleHistoryRefresh(request);
+        scheduleRouterRevalidation(this.historyRefreshInFlight, request.identity.revalidationKey, () => this.refreshHistory(request));
       }
-      return request.requestedRange
-        ? clipPriceHistoryToRange(cachedValue, request.requestedRange)
-        : cachedValue;
+      return exactHit || !request.requestedRange
+        ? cachedValue
+        : clipPriceHistoryToRange(cachedValue, request.requestedRange);
     }
 
     const brokerResult = await withBrokerTimeout(this.fetchBrokerHistory(request, brokerCandidates));
@@ -369,15 +369,6 @@ export class ProviderRouterHistoryRoutes {
       throw new Error(request.missingProviderError);
     }
     return providerResult?.value ?? [];
-  }
-
-  private scheduleHistoryRefresh(request: HistoryRequestDescriptor): void {
-    const key = `${request.identity.kind}|${request.identity.entityKey}|${request.identity.variantKey}`;
-    if (this.historyRefreshInFlight.has(key)) return;
-    const pending = this.refreshHistory(request).finally(() => {
-      this.historyRefreshInFlight.delete(key);
-    });
-    this.historyRefreshInFlight.set(key, pending);
   }
 
   private async refreshHistory(request: HistoryRequestDescriptor): Promise<void> {

--- a/src/sources/yahoo-finance/history.ts
+++ b/src/sources/yahoo-finance/history.ts
@@ -1,7 +1,7 @@
 import type { TimeRange } from "../../time-series/range";
 import {
+  DEFAULT_CHART_RESOLUTION_SUPPORT,
   isIntradayResolution,
-  normalizeChartResolutionSupport,
   type ChartResolutionSupport,
   type ManualChartResolution,
 } from "../../time-series/resolution";
@@ -22,14 +22,7 @@ const RANGE_PARAMS: Record<TimeRange, { range: string; interval: ManualChartReso
   "ALL": { range: "max", interval: "1wk" },
 };
 
-const YAHOO_RESOLUTION_SUPPORT = normalizeChartResolutionSupport([
-  { resolution: "5m", maxRange: "1W" },
-  { resolution: "15m", maxRange: "1M" },
-  { resolution: "1h", maxRange: "3M" },
-  { resolution: "1d", maxRange: "5Y" },
-  { resolution: "1wk", maxRange: "ALL" },
-  { resolution: "1mo", maxRange: "ALL" },
-]);
+const YAHOO_RESOLUTION_SUPPORT = DEFAULT_CHART_RESOLUTION_SUPPORT;
 
 type YahooChartFetcher = (
   symbol: string,

--- a/src/sources/yahoo-finance/http.ts
+++ b/src/sources/yahoo-finance/http.ts
@@ -3,7 +3,7 @@ import { httpFetch } from "../../utils/http-transport";
 const MAX_RETRIES = 3;
 const RETRY_BASE_MS = 1500;
 const FETCH_TIMEOUT_MS = 20_000;
-const RETRYABLE_ERROR = /429|403|401|Too Many Requests|Forbidden|Unauthorized|ECONNRESET|ETIMEDOUT|ENOTFOUND|fetch failed|Failed to get crumb|socket hang up|503|502|504/i;
+const RETRYABLE_ERROR = /403|401|Forbidden|Unauthorized|ECONNRESET|ETIMEDOUT|ENOTFOUND|fetch failed|Failed to get crumb|socket hang up|503|502|504/i;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 

--- a/src/time-series/field-catalog.ts
+++ b/src/time-series/field-catalog.ts
@@ -300,6 +300,16 @@ export function isMarketFieldId(id: string): boolean {
   return canonicalTimeSeriesFieldId(id).startsWith("market.");
 }
 
+export function isPriceOnlyMarketFieldId(id: string): boolean {
+  const canonical = canonicalTimeSeriesFieldId(id);
+  return canonical === "market.ohlcv"
+    || canonical === "market.open"
+    || canonical === "market.high"
+    || canonical === "market.low"
+    || canonical === "market.close"
+    || canonical === "market.volume";
+}
+
 export function isFundamentalFieldId(id: string): boolean {
   const canonical = canonicalTimeSeriesFieldId(id);
   return canonical.startsWith("fundamental.") || canonical.startsWith("valuation.");

--- a/src/time-series/parsed-history-cache.ts
+++ b/src/time-series/parsed-history-cache.ts
@@ -1,0 +1,26 @@
+import type { PricePoint } from "../types/financials";
+
+const parsedHistory = new Map<string, PricePoint[]>();
+
+export function parsedPriceHistoryKey(
+  symbol: string,
+  exchange: string,
+  range: string,
+  resolution?: string,
+): string {
+  return [
+    symbol.trim().toUpperCase(),
+    exchange.trim().toUpperCase(),
+    range,
+    resolution ?? "",
+  ].join("|");
+}
+
+export function rememberParsedPriceHistory(key: string, points: PricePoint[]): void {
+  if (points.length === 0) return;
+  parsedHistory.set(key, points);
+}
+
+export function readParsedPriceHistory(key: string): PricePoint[] | undefined {
+  return parsedHistory.get(key);
+}

--- a/src/time-series/parsed-history-cache.ts
+++ b/src/time-series/parsed-history-cache.ts
@@ -1,12 +1,15 @@
 import type { PricePoint } from "../types/financials";
+import type { TimeRange } from "./range";
+import type { ManualChartResolution } from "./resolution";
 
+const MAX_PARSED_HISTORY = 32;
 const parsedHistory = new Map<string, PricePoint[]>();
 
 export function parsedPriceHistoryKey(
   symbol: string,
   exchange: string,
-  range: string,
-  resolution?: string,
+  range: TimeRange,
+  resolution?: ManualChartResolution,
 ): string {
   return [
     symbol.trim().toUpperCase(),
@@ -18,7 +21,13 @@ export function parsedPriceHistoryKey(
 
 export function rememberParsedPriceHistory(key: string, points: PricePoint[]): void {
   if (points.length === 0) return;
+  if (parsedHistory.has(key)) parsedHistory.delete(key);
   parsedHistory.set(key, points);
+  while (parsedHistory.size > MAX_PARSED_HISTORY) {
+    const oldest = parsedHistory.keys().next().value;
+    if (oldest === undefined) break;
+    parsedHistory.delete(oldest);
+  }
 }
 
 export function readParsedPriceHistory(key: string): PricePoint[] | undefined {

--- a/src/time-series/resolution.ts
+++ b/src/time-series/resolution.ts
@@ -169,6 +169,16 @@ export function normalizeChartResolutionSupport(support: readonly ChartResolutio
   );
 }
 
+/** Yahoo-shaped support used for first paint when broker/provider support is async. */
+export const DEFAULT_CHART_RESOLUTION_SUPPORT: ChartResolutionSupport[] = normalizeChartResolutionSupport([
+  { resolution: "5m", maxRange: "1W" },
+  { resolution: "15m", maxRange: "1M" },
+  { resolution: "1h", maxRange: "3M" },
+  { resolution: "1d", maxRange: "5Y" },
+  { resolution: "1wk", maxRange: "ALL" },
+  { resolution: "1mo", maxRange: "ALL" },
+]);
+
 export function intersectChartResolutionSupport(
   supportSets: Array<readonly ChartResolutionSupport[]>,
 ): ChartResolutionSupport[] {

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -211,6 +211,62 @@ describe("resolveChartSpecData", () => {
     }
   });
 
+  test("skips financials and broker resolution support for ohlcv charts with an exchange", async () => {
+    let financialCalls = 0;
+    let resolveSupport: (() => void) | null = null;
+    const supportGate = new Promise<void>((resolve) => {
+      resolveSupport = resolve;
+    });
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => {
+        financialCalls += 1;
+        return emptyFinancials();
+      },
+      getChartResolutionSupport: async () => {
+        await supportGate;
+        return [{ resolution: "1d" as const, maxRange: "5Y" as const }];
+      },
+      getPriceHistoryForResolution: async () => [
+        { date: new Date("2025-01-07T16:00:00Z"), close: 100 },
+      ],
+    });
+    const spec: ChartSpec = {
+      version: CHART_SPEC_VERSION,
+      viewport: { range: "5Y", resolution: "auto" },
+      panels: [{ id: "main" }],
+      series: [{
+        id: "price",
+        source: {
+          kind: "security",
+          instrument: { symbol: "TEST", exchange: "NASDAQ" },
+          fieldId: "market.ohlcv",
+        },
+        style: "candles",
+        transform: "raw",
+        axis: "left",
+        panelId: "main",
+        interpolation: "none",
+      }],
+      studies: [],
+    };
+
+    const result = await Promise.race([
+      resolveChartSpecData(spec, {
+        dataProvider: provider,
+        now: new Date("2025-01-08T00:00:00Z"),
+        loadFredSeries: async () => fredLoad(),
+      }),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("hung waiting for broker resolution support")), 200);
+      }),
+    ]);
+
+    expect(financialCalls).toBe(0);
+    expect(result.errors).toEqual([]);
+    expect(result.series[0]?.points).toHaveLength(1);
+    resolveSupport?.();
+  });
+
   test("does not relabel provider-default history as a manually requested resolution", async () => {
     let genericHistoryCalls = 0;
     const provider = createTestDataProvider({
@@ -1425,6 +1481,26 @@ describe("resolveChartSpecData", () => {
     const result = await resolveChartSpecData(spec, {
       dataProvider: provider,
       now: new Date(now),
+      quoteOverrides: new Map([[
+        chartQuoteOverrideKeyForSource({
+          kind: "security",
+          instrument: { symbol: "FRESH", exchange: "XNAS" },
+          fieldId: "market.ohlcv",
+        }),
+        {
+          symbol: "FRESH",
+          price: 130,
+          currency: "USD",
+          change: 30,
+          changePercent: 30,
+          lastUpdated: quoteTime,
+          listingExchangeName: "XNAS",
+          marketState: "POST",
+          postMarketPrice: 129,
+          postMarketChange: -1,
+          postMarketChangePercent: -0.77,
+        },
+      ]]),
       loadFredSeries: async () => fredLoad(),
     });
 

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -7,12 +7,14 @@ import {
 import {
   CHART_RESOLUTION_STEP_MS,
   clampTimeRangeToMaxRange,
+  DEFAULT_CHART_RESOLUTION_SUPPORT,
   getBestSupportedResolutionForVisibleWindow,
   getNextBufferRange,
   getPresetResolution,
   getSupportMaxRange,
   intersectChartResolutionSupport,
   isIntradayResolution,
+  normalizeChartResolutionSupport,
   TIME_RANGE_ORDER,
   type ChartResolutionSupport,
   type ManualChartResolution,
@@ -26,6 +28,7 @@ import {
   getTimeSeriesField,
   isFundamentalFieldId,
   isMarketFieldId,
+  isPriceOnlyMarketFieldId,
 } from "./field-catalog";
 import {
   fundamentalSeriesUsesAvailabilityFallback,
@@ -43,6 +46,10 @@ import { clipSeriesToWindow } from "./alignment";
 import { chartQuoteOverrideKeyForSource } from "./live-quotes";
 import { chartSeriesSourceKey } from "../capabilities/chart-series";
 import { resolutionForExplicitMarketPeriods } from "./market-resolution";
+import {
+  rememberParsedPriceHistory,
+  parsedPriceHistoryKey,
+} from "./parsed-history-cache";
 import {
   canonicalExchange,
   publicTickerKey,
@@ -360,6 +367,56 @@ function emptyFinancials(priceHistory: TickerFinancials["priceHistory"] = []): T
   return { annualStatements: [], quarterlyStatements: [], priceHistory };
 }
 
+export function seedChartResolutionResult(
+  spec: ChartSpec,
+  historyByInstrument: ReadonlyMap<string, TickerFinancials["priceHistory"]>,
+): ChartResolutionResult | null {
+  const series: ResolvedSeries[] = [];
+  spec.series.forEach((seriesSpec, index) => {
+    if (seriesSpec.visible === false || seriesSpec.source.kind !== "security") return;
+    if (!isMarketFieldId(seriesSpec.source.fieldId)) return;
+    const history = historyByInstrument.get(instrumentKey(seriesSpec.source));
+    if (!history?.length) return;
+    const resolved = baseSecuritySeries(seriesSpec, emptyFinancials(history), index);
+    if (resolved?.points.length) series.push(resolved);
+  });
+  if (series.length === 0) return null;
+  return {
+    series,
+    legendSeries: series,
+    bufferedSeries: series,
+    loading: false,
+    errors: [],
+    warnings: [],
+  };
+}
+
+function isThenable<T>(value: unknown): value is Promise<T> {
+  return typeof value === "object" && value !== null && "then" in value;
+}
+
+function readImmediateResolutionSupport(
+  provider: DataProvider,
+  source: Extract<ChartSeriesSpec["source"], { kind: "security" }>,
+): ChartResolutionSupport[] {
+  if (!provider.getChartResolutionSupport) return [];
+  const result = provider.getChartResolutionSupport(
+    source.instrument.symbol,
+    source.instrument.exchange ?? "",
+    requestContext(source),
+  );
+  if (Array.isArray(result)) return normalizeChartResolutionSupport(result);
+  if (isThenable(result)) return DEFAULT_CHART_RESOLUTION_SUPPORT;
+  return [];
+}
+
+function chartIsPriceOnly(spec: ChartSpec, calculationSeriesIds: ReadonlySet<string>): boolean {
+  return spec.series.every((entry) => {
+    if (!calculationSeriesIds.has(entry.id) || entry.source.kind !== "security") return true;
+    return isPriceOnlyMarketFieldId(entry.source.fieldId);
+  });
+}
+
 function isSortedPriceHistory(points: TickerFinancials["priceHistory"]): boolean {
   let previous = Number.NEGATIVE_INFINITY;
   for (const point of points) {
@@ -530,6 +587,15 @@ async function loadPriceHistory(
         resolved.length > 0
         && (!request.explicitWindow || historyIntersectsBounds(resolved, request.visibleBounds))
       ) {
+        rememberParsedPriceHistory(
+          parsedPriceHistoryKey(
+            source.instrument.symbol,
+            source.instrument.exchange ?? "",
+            request.fallbackRange,
+            request.resolution,
+          ),
+          resolved,
+        );
         return resolved;
       }
     } catch {
@@ -832,17 +898,20 @@ export async function resolveChartSpecData(
   };
   const loadResolutionSupport = (
     source: Extract<ChartSeriesSpec["source"], { kind: "security" }>,
+    immediate: boolean,
   ) => {
     const provider = sources.dataProvider!;
     if (!provider.getChartResolutionSupport) return Promise.resolve([]);
-    const key = `${provider.id}|${instrumentKey(source)}`;
+    const key = `${provider.id}|${instrumentKey(source)}|${immediate ? "immediate" : "live"}`;
     let pending = cache.resolutionSupportByInstrument.get(key);
     if (!pending) {
-      pending = Promise.resolve(provider.getChartResolutionSupport(
-        source.instrument.symbol,
-        source.instrument.exchange ?? "",
-        requestContext(source),
-      )).catch(() => []);
+      pending = immediate
+        ? Promise.resolve().then(() => readImmediateResolutionSupport(provider, source))
+        : Promise.resolve(provider.getChartResolutionSupport(
+          source.instrument.symbol,
+          source.instrument.exchange ?? "",
+          requestContext(source),
+        )).catch(() => []);
       cache.resolutionSupportByInstrument.set(key, pending);
     }
     return pending;
@@ -871,6 +940,7 @@ export async function resolveChartSpecData(
       ? [[instrumentKey(entry.source), entry.source] as const]
       : []
   ))).values()];
+  const priceOnly = chartIsPriceOnly(spec, calculationSeriesIds);
   const resolutionSupportSources = await Promise.all(activeMarketSources.map(async (source) => (
     source.instrument.exchange?.trim()
       ? source
@@ -878,7 +948,7 @@ export async function resolveChartSpecData(
   )));
   const sharedSupport = activeMarketSources.length > 0
     ? intersectChartResolutionSupport(await Promise.all(
-        resolutionSupportSources.map((source) => loadResolutionSupport(source)),
+        resolutionSupportSources.map((source) => loadResolutionSupport(source, priceOnly)),
       ))
     : [];
   const initialResolution = requestResolution(
@@ -909,7 +979,7 @@ export async function resolveChartSpecData(
     source: Extract<ChartSeriesSpec["source"], { kind: "security" }>,
     all = false,
   ) => {
-    const support = await loadResolutionSupport(source);
+    const support = await loadResolutionSupport(source, priceOnly);
     const maxRange = getSupportMaxRange(support, initialResolution);
     const historyBounds = clampHistoryBoundsToSupport(initialCalculationBounds, maxRange);
     const requestedFallbackRange = all
@@ -1015,10 +1085,12 @@ export async function resolveChartSpecData(
       const marketField = isMarketFieldId(source.fieldId);
       const quoteDerivedValuation = valuationSeriesUsesLiveQuote(source.fieldId);
       const needsHistory = marketField || quoteDerivedValuation;
+      const needsFinancials = !isPriceOnlyMarketFieldId(source.fieldId)
+        || !source.instrument.exchange?.trim();
       const quoteOverride = marketField || quoteDerivedValuation
         ? sources.quoteOverrides?.get(chartQuoteOverrideKeyForSource(source))
         : undefined;
-      const financialsPromise = loadFinancials(source);
+      const financialsPromise = needsFinancials ? loadFinancials(source) : Promise.resolve(null);
       let resolvedSource = source;
       let financials: TickerFinancials | null;
       let history: TickerFinancials["priceHistory"] | null;

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -399,7 +399,7 @@ function readImmediateResolutionSupport(
   provider: DataProvider,
   source: Extract<ChartSeriesSpec["source"], { kind: "security" }>,
 ): ChartResolutionSupport[] {
-  if (!provider.getChartResolutionSupport) return [];
+  if (!provider.getChartResolutionSupport) return DEFAULT_CHART_RESOLUTION_SUPPORT;
   const result = provider.getChartResolutionSupport(
     source.instrument.symbol,
     source.instrument.exchange ?? "",
@@ -407,7 +407,7 @@ function readImmediateResolutionSupport(
   );
   if (Array.isArray(result)) return normalizeChartResolutionSupport(result);
   if (isThenable(result)) return DEFAULT_CHART_RESOLUTION_SUPPORT;
-  return [];
+  return DEFAULT_CHART_RESOLUTION_SUPPORT;
 }
 
 function chartIsPriceOnly(spec: ChartSpec, calculationSeriesIds: ReadonlySet<string>): boolean {

--- a/src/time-series/use-chart-resolution.test.tsx
+++ b/src/time-series/use-chart-resolution.test.tsx
@@ -4,6 +4,10 @@ import { testRender } from "../renderers/opentui/test-utils";
 import { createTestDataProvider } from "../test-support/data-provider";
 import type { DataProvider } from "../types/data-provider";
 import type { PricePoint, TickerFinancials } from "../types/financials";
+import {
+  setSharedMarketDataCoordinator,
+} from "../market-data/coordinator";
+import { createIdleEntry } from "../market-data/result-types";
 import type { ChartResolveSources } from "./resolve";
 import { CHART_SPEC_VERSION, type ChartSpec } from "./types";
 import {
@@ -16,6 +20,7 @@ type AutoViewport = NonNullable<Parameters<typeof useChartResolution>[2]["autoVi
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let setAutoViewport: ((viewport: AutoViewport | null) => void) | null = null;
 let setRequestViewport: ((viewport: AutoViewport | null) => void) | null = null;
+let setChartSpec: ((spec: ChartSpec) => void) | null = null;
 let latestResult: UseChartResolutionResult | null = null;
 
 const EMPTY_FINANCIALS: TickerFinancials = {
@@ -85,17 +90,34 @@ function sourcesFor(dataProvider: DataProvider): ChartResolveSources {
 
 function ResolutionHarness({
   sources,
+  spec = SPEC,
 }: {
   sources: ChartResolveSources;
+  spec?: ChartSpec;
 }) {
   const [autoViewport, setAutoViewportState] = useState<AutoViewport | null>(null);
   const [requestViewport, setRequestViewportState] = useState<AutoViewport | null>(null);
   setAutoViewport = setAutoViewportState;
   setRequestViewport = setRequestViewportState;
-  latestResult = useChartResolution(SPEC, sources, {
+  latestResult = useChartResolution(spec, sources, {
     autoViewport,
     requestViewport,
     targetPointCount: 100,
+    liveRefreshIntervalMs: 0,
+  });
+  const pointCount = (latestResult.bufferedSeries ?? latestResult.series)
+    .reduce((total, series) => total + series.points.length, 0);
+  return <text>{`${latestResult.loading ? "loading" : "settled"}:${pointCount}`}</text>;
+}
+
+function MutableSpecHarness({
+  sources,
+}: {
+  sources: ChartResolveSources;
+}) {
+  const [spec, setSpecState] = useState(SPEC);
+  setChartSpec = setSpecState;
+  latestResult = useChartResolution(spec, sources, {
     liveRefreshIntervalMs: 0,
   });
   const pointCount = (latestResult.bufferedSeries ?? latestResult.series)
@@ -138,7 +160,9 @@ afterEach(async () => {
   }
   setAutoViewport = null;
   setRequestViewport = null;
+  setChartSpec = null;
   latestResult = null;
+  setSharedMarketDataCoordinator(null);
 });
 
 describe("useChartResolution", () => {
@@ -391,5 +415,85 @@ describe("useChartResolution", () => {
 
     expect(latestResult?.series.every((series) => series.points.length === 0)).toBe(true);
     expect(latestResult?.errors).toEqual([]);
+  });
+
+  test("paints coordinator-cached candles on the first frame", async () => {
+    const history = deferred<PricePoint[]>();
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => EMPTY_FINANCIALS,
+      getPriceHistoryForResolution: async () => history.promise,
+      getPriceHistory: async () => [],
+    });
+    setSharedMarketDataCoordinator({
+      subscribe: () => () => {},
+      getVersion: () => 1,
+      getKeysVersion: () => 1,
+      getChartEntry: () => ({
+        ...createIdleEntry<PricePoint[]>(),
+        phase: "ready",
+        data: INITIAL_HISTORY,
+        lastGoodData: INITIAL_HISTORY,
+        source: "test",
+        fetchedAt: Date.now(),
+      }),
+    } as never);
+
+    testSetup = await testRender(<ResolutionHarness sources={sourcesFor(provider)} spec={{
+      ...SPEC,
+      viewport: { range: "5Y", resolution: "auto" },
+    }} />, {
+      width: 24,
+      height: 1,
+    });
+
+    expect(latestResult?.series[0]?.points.length).toBe(2);
+    expect(latestResult?.loading).toBe(false);
+
+    await act(async () => {
+      history.resolve(INITIAL_HISTORY);
+      await testSetup!.renderOnce();
+    });
+    await waitFor(() => latestResult?.loading === false);
+  });
+
+  test("reuses cached history when the spec object identity changes", async () => {
+    const initialHistory = deferred<PricePoint[]>();
+    let historyCalls = 0;
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => EMPTY_FINANCIALS,
+      getPriceHistoryForResolution: async () => {
+        historyCalls += 1;
+        return historyCalls === 1 ? initialHistory.promise : INITIAL_HISTORY;
+      },
+      getPriceHistory: async () => [],
+    });
+    testSetup = await testRender(<MutableSpecHarness sources={sourcesFor(provider)} />, {
+      width: 24,
+      height: 1,
+    });
+
+    await waitFor(() => historyCalls === 1);
+    await act(async () => {
+      initialHistory.resolve(INITIAL_HISTORY);
+      await testSetup!.renderOnce();
+    });
+    await waitFor(() => latestResult?.loading === false && latestResult.series[0]?.points.length === 2);
+
+    await act(async () => {
+      setChartSpec?.({
+        ...SPEC,
+        series: [{
+          ...SPEC.series[0]!,
+          style: "line",
+        }],
+      });
+      await testSetup!.renderOnce();
+    });
+    await flushEffects(3);
+
+    expect(historyCalls).toBe(1);
+    expect(latestResult?.loading).toBe(false);
+    expect(latestResult?.series[0]?.points.length).toBe(2);
+    expect(latestResult?.series[0]?.style).toBe("line");
   });
 });

--- a/src/time-series/use-chart-resolution.ts
+++ b/src/time-series/use-chart-resolution.ts
@@ -50,7 +50,7 @@ function hasRenderableData(result: ChartResolutionResult): boolean {
   return (result.bufferedSeries ?? result.series).some((series) => series.points.length > 0);
 }
 
-function collectSeedHistory(spec: ChartSpec, _coordinatorVersion: number): Map<string, PricePoint[]> {
+function collectSeedHistory(spec: ChartSpec): Map<string, PricePoint[]> {
   const history = new Map<string, PricePoint[]>();
   const coordinator = getSharedMarketDataCoordinator();
   for (const series of spec.series) {
@@ -60,18 +60,19 @@ function collectSeedHistory(spec: ChartSpec, _coordinatorVersion: number): Map<s
     if (history.has(key)) continue;
     const symbol = source.instrument.symbol;
     const exchange = source.instrument.exchange ?? "";
+    const baseline = createBaselineChartRequest(source.instrument);
     const presetResolution = spec.viewport.resolution === "auto"
       ? getPresetResolution(spec.viewport.range)
       : spec.viewport.resolution;
-    const remembered = readParsedPriceHistory(parsedPriceHistoryKey(symbol, exchange, "ALL", "1wk"))
+    const remembered = readParsedPriceHistory(parsedPriceHistoryKey(symbol, exchange, baseline.bufferRange, baseline.resolution))
       ?? readParsedPriceHistory(parsedPriceHistoryKey(symbol, exchange, spec.viewport.range, presetResolution))
-      ?? readParsedPriceHistory(parsedPriceHistoryKey(symbol, exchange, "ALL", presetResolution));
+      ?? readParsedPriceHistory(parsedPriceHistoryKey(symbol, exchange, baseline.bufferRange, presetResolution));
     if (remembered?.length) {
       history.set(key, remembered);
       continue;
     }
     if (!coordinator) continue;
-    const entry = coordinator.getChartEntry(createBaselineChartRequest(source.instrument));
+    const entry = coordinator.getChartEntry(baseline);
     const data = resolveEntryData(entry);
     if (data?.length) history.set(key, data);
   }
@@ -97,13 +98,22 @@ export function useChartResolution(
   options: UseChartResolutionOptions = {},
 ): UseChartResolutionResult {
   const coordinator = getSharedMarketDataCoordinator();
-  const coordinatorVersion = useSyncExternalStore(
-    (listener) => coordinator?.subscribe(listener) ?? (() => {}),
-    () => coordinator?.getVersion() ?? 0,
-    () => 0,
+  const [result, setResult] = useState<ChartResolutionResult>(
+    () => seedChartResolutionResult(spec, collectSeedHistory(spec)) ?? EMPTY_RESULT,
   );
-  const seeded = seedChartResolutionResult(spec, collectSeedHistory(spec, coordinatorVersion));
-  const [result, setResult] = useState<ChartResolutionResult>(() => seeded ?? EMPTY_RESULT);
+  const needsSeed = !hasRenderableData(result);
+  const subscribeSeed = useCallback((listener: () => void) => {
+    if (!needsSeed || !coordinator) return () => {};
+    return coordinator.subscribe(listener);
+  }, [coordinator, needsSeed]);
+  const getSeedSnapshot = useCallback(() => {
+    if (!needsSeed || !coordinator) return 0;
+    return coordinator.getVersion();
+  }, [coordinator, needsSeed]);
+  useSyncExternalStore(subscribeSeed, getSeedSnapshot, () => 0);
+  const seeded = needsSeed
+    ? seedChartResolutionResult(spec, collectSeedHistory(spec))
+    : null;
   const displayed = hasRenderableData(result) ? result : (seeded ?? result);
   const resultRef = useRef(displayed);
   resultRef.current = displayed;

--- a/src/time-series/use-chart-resolution.ts
+++ b/src/time-series/use-chart-resolution.ts
@@ -1,17 +1,28 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import {
   ChartResolveCache,
   resolveChartSpecData,
+  seedChartResolutionResult,
   type ChartResolveOptions,
   type ChartResolveSources,
 } from "./resolve";
 import type { ChartResolutionResult, ChartSpec } from "./types";
 import {
   LIVE_CHART_REFRESH_INTERVAL_MS,
+  chartQuoteOverrideKeyForSource,
   liveChartQuoteTargetSignature,
   subscribeToLiveChartQuotes,
 } from "./live-quotes";
-import type { Quote } from "../types/financials";
+import type { PricePoint, Quote } from "../types/financials";
+import { createBaselineChartRequest } from "../market-data/coordinator/chart";
+import { getSharedMarketDataCoordinator } from "../market-data/coordinator";
+import { resolveEntryData } from "../market-data/selectors";
+import { isMarketFieldId } from "./field-catalog";
+import { getPresetResolution } from "./resolution";
+import {
+  parsedPriceHistoryKey,
+  readParsedPriceHistory,
+} from "./parsed-history-cache";
 
 export interface UseChartResolutionResult extends ChartResolutionResult {
   reload: () => void;
@@ -39,6 +50,34 @@ function hasRenderableData(result: ChartResolutionResult): boolean {
   return (result.bufferedSeries ?? result.series).some((series) => series.points.length > 0);
 }
 
+function collectSeedHistory(spec: ChartSpec, _coordinatorVersion: number): Map<string, PricePoint[]> {
+  const history = new Map<string, PricePoint[]>();
+  const coordinator = getSharedMarketDataCoordinator();
+  for (const series of spec.series) {
+    if (series.source.kind !== "security" || !isMarketFieldId(series.source.fieldId)) continue;
+    const source = series.source;
+    const key = chartQuoteOverrideKeyForSource(source);
+    if (history.has(key)) continue;
+    const symbol = source.instrument.symbol;
+    const exchange = source.instrument.exchange ?? "";
+    const presetResolution = spec.viewport.resolution === "auto"
+      ? getPresetResolution(spec.viewport.range)
+      : spec.viewport.resolution;
+    const remembered = readParsedPriceHistory(parsedPriceHistoryKey(symbol, exchange, "ALL", "1wk"))
+      ?? readParsedPriceHistory(parsedPriceHistoryKey(symbol, exchange, spec.viewport.range, presetResolution))
+      ?? readParsedPriceHistory(parsedPriceHistoryKey(symbol, exchange, "ALL", presetResolution));
+    if (remembered?.length) {
+      history.set(key, remembered);
+      continue;
+    }
+    if (!coordinator) continue;
+    const entry = coordinator.getChartEntry(createBaselineChartRequest(source.instrument));
+    const data = resolveEntryData(entry);
+    if (data?.length) history.set(key, data);
+  }
+  return history;
+}
+
 function withQuoteOverrides(
   sources: ChartResolveSources,
   liveOverrides: ReadonlyMap<string, Quote>,
@@ -57,9 +96,17 @@ export function useChartResolution(
   sources: ChartResolveSources,
   options: UseChartResolutionOptions = {},
 ): UseChartResolutionResult {
-  const [result, setResult] = useState<ChartResolutionResult>(EMPTY_RESULT);
-  const resultRef = useRef(result);
-  resultRef.current = result;
+  const coordinator = getSharedMarketDataCoordinator();
+  const coordinatorVersion = useSyncExternalStore(
+    (listener) => coordinator?.subscribe(listener) ?? (() => {}),
+    () => coordinator?.getVersion() ?? 0,
+    () => 0,
+  );
+  const seeded = seedChartResolutionResult(spec, collectSeedHistory(spec, coordinatorVersion));
+  const [result, setResult] = useState<ChartResolutionResult>(() => seeded ?? EMPTY_RESULT);
+  const displayed = hasRenderableData(result) ? result : (seeded ?? result);
+  const resultRef = useRef(displayed);
+  resultRef.current = displayed;
   const [revision, setRevision] = useState(0);
   const generationRef = useRef(0);
   const liveSubscriptionGenerationRef = useRef(0);
@@ -102,18 +149,15 @@ export function useChartResolution(
     generationRef.current += 1;
     const generation = generationRef.current;
     const cacheIdentity = cacheIdentityRef.current;
-    const resetCache = cacheIdentity.spec !== spec
-      || cacheIdentity.sources !== sources
-      || cacheIdentity.revision !== revision;
+    const isExplicitReload = cacheIdentity.revision !== revision && cacheIdentity.revision !== -1;
+    const resetCache = cacheIdentity.sources !== sources || isExplicitReload;
     if (resetCache) {
       resolveCacheRef.current = new ChartResolveCache();
-      cacheIdentityRef.current = { spec, sources, revision };
     }
+    cacheIdentityRef.current = { spec, sources, revision };
     const cache = resolveCacheRef.current;
     const current = resultRef.current;
-    const backgroundRefresh = !resetCache
-      && !current.loading
-      && hasRenderableData(current);
+    const backgroundRefresh = hasRenderableData(current) && !isExplicitReload;
     if (!backgroundRefresh) {
       setResult((currentResult) => ({ ...currentResult, loading: true, errors: [] }));
     }
@@ -220,5 +264,5 @@ export function useChartResolution(
     return () => clearInterval(intervalId);
   }, [liveStreaming, liveTargetSignature, quotePollingIntervalMs]);
 
-  return { ...result, reload };
+  return { ...displayed, reload };
 }


### PR DESCRIPTION
## Summary
- First-paint `G` from the warm sqlite/history cache instead of blocking on network history fetches, with background refresh for stale series.
- Cap composite/static rasters to pixel width so kitty still paints a native bitmap without walking every viewport point, and keep the plotted scene stable across cursor moves.
- Trim leftover work on that path (parsed-history LRU, skip extra clipping/grouping, reuse cursor-less scenes).

Kitty stays on. This is the chart-perf slice only — no hosted Cloudflare, TradingView, Adjacent, or other fork-only work.

## Test plan
- [ ] `bun test src/time-series/use-chart-resolution.test.tsx src/time-series/resolve.test.ts src/components/chart/composite/downsample.test.ts src/components/chart/composite/panel-series.test.ts src/sources/provider-router/history.test.ts`
- [ ] Open `G` on a previously viewed ticker and confirm the chart paints before history refetch
- [ ] Pan/zoom a dense candle chart and confirm kitty raster still looks sharp
- [ ] Move the cursor without the plot flickering or dropping kitty


Made with [Cursor](https://cursor.com)