### PR TITLE
Fix desktop layout tab dragging

### DIFF
--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -136,6 +136,7 @@ test("desktop tabs reorder through mouse dragging", async () => {
 
   expect(buttons[0]?.style.transform).toBe("translateX(200px) scale(1.03)");
   expect(buttons[1]?.style.transform).toBe("translateX(-84px)");
+  expect(buttons[1]?.style.transition).toContain("transform var(--tab-reorder-duration, 160ms)");
   expect(buttons[2]?.style.transform).toBe("translateX(-84px)");
 
   await act(async () => {
@@ -150,6 +151,7 @@ test("desktop tabs reorder through mouse dragging", async () => {
     "translateX(0px)",
     "translateX(0px)",
   ]);
+  expect(buttons[1]?.style.transition).toContain("transform 0ms");
 
   await act(async () => {
     mouse("mousedown", buttons[1]!, 101);

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -150,5 +150,20 @@ test("desktop tabs reorder through mouse dragging", async () => {
     "translateX(0px)",
     "translateX(0px)",
   ]);
+
+  await act(async () => {
+    mouse("mousedown", buttons[1]!, 101);
+    mouse("mousemove", testWindow.document as never, 96);
+  });
+
+  expect(buttons[0]?.style.transform).toBe("translateX(0px)");
+  expect(buttons[1]?.style.transform).toBe("translateX(-5px) scale(1.03)");
+
+  await act(async () => {
+    mouse("mouseup", testWindow.document as never, 96);
+    mouse("click", buttons[1]!, 96);
+  });
+
+  expect(reordered).toEqual([["home", "news"]]);
   await act(async () => root.unmount());
 });

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -121,7 +121,7 @@ test("desktop tabs reorder through mouse dragging", async () => {
 
   const buttons = [...container.querySelectorAll('[data-gloom-role="tab-button"]')] as unknown as HTMLElement[];
   buttons.forEach((button, index) => {
-    button.getBoundingClientRect = () => ({ left: index * 100, right: index * 100 + 80 }) as DOMRect;
+    button.getBoundingClientRect = () => ({ left: index * 100, right: index * 100 + 80, width: 80 }) as DOMRect;
   });
   const mouse = (type: string, target: { dispatchEvent: (event: unknown) => unknown }, clientX: number) => {
     target.dispatchEvent(new MouseEvent(type, { bubbles: true, button: 0, clientX }));
@@ -132,11 +132,23 @@ test("desktop tabs reorder through mouse dragging", async () => {
   await act(async () => {
     mouse("mousedown", buttons[0]!, 20);
     mouse("mousemove", testWindow.document as never, 220);
+  });
+
+  expect(buttons[0]?.style.transform).toBe("translateX(200px) scale(1.03)");
+  expect(buttons[1]?.style.transform).toBe("translateX(-84px)");
+  expect(buttons[2]?.style.transform).toBe("translateX(-84px)");
+
+  await act(async () => {
     mouse("mouseup", testWindow.document as never, 220);
     mouse("click", buttons[0]!, 220);
   });
 
   expect(reordered).toEqual([["home", "news"]]);
   expect(selected).toEqual([]);
+  expect(buttons.map((button) => button.style.transform)).toEqual([
+    "translateX(0px)",
+    "translateX(0px)",
+    "translateX(0px)",
+  ]);
   await act(async () => root.unmount());
 });

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -153,6 +153,12 @@ test("desktop tabs reorder through mouse dragging", async () => {
 
   await act(async () => {
     mouse("mousedown", buttons[1]!, 101);
+  });
+
+  expect(buttons[0]?.style.transform).toBe("translateX(0px)");
+  expect(buttons[1]?.style.transform).toBe("translateX(0px)");
+
+  await act(async () => {
     mouse("mousemove", testWindow.document as never, 96);
   });
 

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -96,9 +96,10 @@ test("a tab bar occupies exactly the one row panes reserve for it", async () => 
   await act(async () => root.unmount());
 });
 
-test("desktop tabs reorder through native drag and drop", async () => {
+test("desktop tabs reorder through mouse dragging", async () => {
   const { WebTabs } = await import("./tabs");
   const reordered: Array<[string, string]> = [];
+  const selected: string[] = [];
   const container = testWindow.document.createElement("div");
   testWindow.document.body.appendChild(container);
   const root = createRoot(container as unknown as HTMLElement);
@@ -111,7 +112,7 @@ test("desktop tabs reorder through native drag and drop", async () => {
           { label: "News", value: "news" },
         ]}
         activeValue="home"
-        onSelect={() => {}}
+        onSelect={(value) => selected.push(value)}
         onReorder={(fromValue, toValue) => reordered.push([fromValue, toValue])}
         palette={{} as never}
       />,
@@ -119,27 +120,23 @@ test("desktop tabs reorder through native drag and drop", async () => {
   });
 
   const buttons = [...container.querySelectorAll('[data-gloom-role="tab-button"]')] as unknown as HTMLElement[];
-  const values = new Map<string, string>();
-  const dataTransfer = {
-    effectAllowed: "none",
-    dropEffect: "none",
-    setData(type: string, value: string) { values.set(type, value); },
-    getData(type: string) { return values.get(type) ?? ""; },
-  };
-  const drag = (type: string, target: HTMLElement) => {
-    const event = new Event(type, { bubbles: true, cancelable: true });
-    Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
-    target.dispatchEvent(event);
+  buttons.forEach((button, index) => {
+    button.getBoundingClientRect = () => ({ left: index * 100, right: index * 100 + 80 }) as DOMRect;
+  });
+  const mouse = (type: string, target: { dispatchEvent: (event: unknown) => unknown }, clientX: number) => {
+    target.dispatchEvent(new MouseEvent(type, { bubbles: true, button: 0, clientX }));
   };
 
   expect(buttons).toHaveLength(3);
-  expect(buttons[0]?.getAttribute("draggable")).toBe("true");
+  expect(buttons[0]?.getAttribute("draggable")).toBe("false");
   await act(async () => {
-    drag("dragstart", buttons[0]!);
-    drag("dragover", buttons[2]!);
-    drag("drop", buttons[2]!);
+    mouse("mousedown", buttons[0]!, 20);
+    mouse("mousemove", testWindow.document as never, 220);
+    mouse("mouseup", testWindow.document as never, 220);
+    mouse("click", buttons[0]!, 220);
   });
 
   expect(reordered).toEqual([["home", "news"]]);
+  expect(selected).toEqual([]);
   await act(async () => root.unmount());
 });

--- a/src/renderers/electrobun/view/host/tabs.tsx
+++ b/src/renderers/electrobun/view/host/tabs.tsx
@@ -57,6 +57,7 @@ export function WebTabs({
     if (event.button !== 0) return;
     dragCleanupRef.current?.();
     const sourceElement = event.currentTarget;
+    const sourceBounds = sourceElement.getBoundingClientRect();
     const startX = event.clientX;
     const targets = [...tabListRef.current?.querySelectorAll<HTMLButtonElement>("[data-reorderable='true']") ?? []]
       .map((button) => ({ value: button.dataset.tabValue ?? "", bounds: button.getBoundingClientRect() }));
@@ -89,10 +90,10 @@ export function WebTabs({
       dragOffsetXRef.current = offsetX;
       sourceElement.style.transform = `translateX(${offsetX}px) scale(1.03)`;
       document.body.classList.add("gloom-dragging");
-      setDragTargetValue(resolveTarget(moveEvent.clientX));
+      setDragTargetValue(resolveTarget(sourceBounds.left + offsetX + sourceBounds.width / 2));
     };
     const handleUp = (upEvent: MouseEvent) => {
-      const targetValue = resolveTarget(upEvent.clientX);
+      const targetValue = resolveTarget(sourceBounds.left + upEvent.clientX - startX + sourceBounds.width / 2);
       suppressClickRef.current = dragged;
       cleanup();
       if (dragged && targetValue && targetValue !== sourceValue) {
@@ -100,7 +101,7 @@ export function WebTabs({
       }
     };
 
-    dragSourceWidthRef.current = sourceElement.getBoundingClientRect().width;
+    dragSourceWidthRef.current = sourceBounds.width;
     setDragSourceValue(sourceValue);
     document.addEventListener("mousemove", handleMove);
     document.addEventListener("mouseup", handleUp);

--- a/src/renderers/electrobun/view/host/tabs.tsx
+++ b/src/renderers/electrobun/view/host/tabs.tsx
@@ -4,6 +4,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
   type WheelEvent as ReactWheelEvent,
 } from "react";
 import type { HostTabsProps } from "../../../../ui/host";
@@ -26,9 +27,12 @@ export function WebTabs({
   palette,
 }: HostTabsProps) {
   const activeTabRef = useRef<HTMLButtonElement | null>(null);
+  const tabListRef = useRef<HTMLDivElement | null>(null);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+  const suppressClickRef = useRef(false);
   const [hoveredValue, setHoveredValue] = useState<string | null>(null);
+  const [dragSourceValue, setDragSourceValue] = useState<string | null>(null);
   const [dragTargetValue, setDragTargetValue] = useState<string | null>(null);
-  const dragSourceValueRef = useRef<string | null>(null);
   const showUnderline = variant === "underline" && !compact;
   // A tab bar occupies exactly the one row every caller reserves for it. Any
   // extra pixels here are pixels the pane's children are told they own and the
@@ -44,6 +48,58 @@ export function WebTabs({
       inline: "nearest",
     });
   }, [activeValue, tabs]);
+
+  useEffect(() => () => dragCleanupRef.current?.(), []);
+
+  const resolveDragTarget = (clientX: number) => {
+    let targetValue: string | null = null;
+    let targetDistance = Number.POSITIVE_INFINITY;
+    for (const button of tabListRef.current?.querySelectorAll<HTMLButtonElement>("[data-reorderable='true']") ?? []) {
+      const bounds = button.getBoundingClientRect();
+      const distance = clientX < bounds.left ? bounds.left - clientX : clientX > bounds.right ? clientX - bounds.right : 0;
+      if (distance < targetDistance) {
+        targetDistance = distance;
+        targetValue = button.dataset.tabValue ?? null;
+      }
+    }
+    return targetValue;
+  };
+
+  const startReorder = (sourceValue: string, event: ReactMouseEvent<HTMLButtonElement>) => {
+    if (event.button !== 0) return;
+    dragCleanupRef.current?.();
+    const startX = event.clientX;
+    let dragged = false;
+
+    const cleanup = () => {
+      document.removeEventListener("mousemove", handleMove);
+      document.removeEventListener("mouseup", handleUp);
+      document.body.classList.remove("gloom-dragging");
+      dragCleanupRef.current = null;
+      setDragSourceValue(null);
+      setDragTargetValue(null);
+    };
+    const handleMove = (moveEvent: MouseEvent) => {
+      if (!dragged && Math.abs(moveEvent.clientX - startX) < 4) return;
+      dragged = true;
+      moveEvent.preventDefault();
+      document.body.classList.add("gloom-dragging");
+      setDragTargetValue(resolveDragTarget(moveEvent.clientX));
+    };
+    const handleUp = (upEvent: MouseEvent) => {
+      const targetValue = resolveDragTarget(upEvent.clientX);
+      suppressClickRef.current = dragged;
+      cleanup();
+      if (dragged && targetValue && targetValue !== sourceValue) {
+        onReorder?.(sourceValue, targetValue);
+      }
+    };
+
+    setDragSourceValue(sourceValue);
+    document.addEventListener("mousemove", handleMove);
+    document.addEventListener("mouseup", handleUp);
+    dragCleanupRef.current = cleanup;
+  };
 
   const handleWheel = (event: ReactWheelEvent<HTMLDivElement>) => {
     const element = event.currentTarget;
@@ -73,6 +129,7 @@ export function WebTabs({
 
   return (
     <div
+      ref={tabListRef}
       data-gloom-role="tab-list"
       role="tablist"
       onWheel={handleWheel}
@@ -98,7 +155,7 @@ export function WebTabs({
         const hovered = hoveredValue === tab.value && !disabled;
         const closeVisible = !!tab.onClose && (closeMode === "always" || active);
         const reorderable = !!onReorder && !disabled && tab.reorderable !== false;
-        const dragTarget = dragTargetValue === tab.value && dragSourceValueRef.current !== tab.value;
+        const dragTarget = dragTargetValue === tab.value && dragSourceValue !== tab.value;
         const tabStyle = {
           "--tab-fg": resolveTabColor(disabled, active, hovered),
           "--tab-hover-fg": palette.hoverFg,
@@ -134,7 +191,7 @@ export function WebTabs({
             ? `color-mix(in srgb, ${palette.activeUnderline} 35%, transparent)`
             : "transparent",
           transition: "background-color 110ms ease, border-color 110ms ease, color 110ms ease",
-          cursor: disabled ? "default" : reorderable ? "grab" : "pointer",
+          cursor: disabled ? "default" : dragSourceValue ? "grabbing" : reorderable ? "grab" : "pointer",
         } satisfies CssVars;
 
         return (
@@ -143,17 +200,26 @@ export function WebTabs({
             ref={active ? activeTabRef : undefined}
             data-gloom-role="tab-button"
             data-active={active ? "true" : undefined}
+            data-reorderable={reorderable ? "true" : undefined}
+            data-tab-value={tab.value}
             type="button"
             role="tab"
             aria-selected={active}
             aria-disabled={disabled || undefined}
             disabled={disabled}
-            draggable={reorderable}
-            aria-grabbed={reorderable && dragSourceValueRef.current === tab.value ? true : undefined}
+            draggable={false}
+            aria-grabbed={reorderable && dragSourceValue === tab.value ? true : undefined}
             style={tabStyle}
             onMouseEnter={() => setHoveredValue(tab.value)}
             onMouseLeave={() => setHoveredValue((current) => (current === tab.value ? null : current))}
-            onClick={() => {
+            onMouseDown={reorderable ? (event) => startReorder(tab.value, event) : undefined}
+            onClick={(event) => {
+              if (suppressClickRef.current) {
+                suppressClickRef.current = false;
+                event.preventDefault();
+                event.stopPropagation();
+                return;
+              }
               if (!disabled) onSelect(tab.value);
             }}
             onDoubleClick={() => {
@@ -163,32 +229,6 @@ export function WebTabs({
               event.preventDefault();
               event.stopPropagation();
               tab.onContextMenu?.(tab.value, event);
-            } : undefined}
-            onDragStart={reorderable ? (event) => {
-              dragSourceValueRef.current = tab.value;
-              event.dataTransfer.effectAllowed = "move";
-              event.dataTransfer.setData("text/plain", tab.value);
-            } : undefined}
-            onDragOver={reorderable ? (event) => {
-              const sourceValue = dragSourceValueRef.current;
-              if (!sourceValue || sourceValue === tab.value) return;
-              event.preventDefault();
-              event.dataTransfer.dropEffect = "move";
-              setDragTargetValue(tab.value);
-            } : undefined}
-            onDragLeave={reorderable ? () => {
-              setDragTargetValue((current) => (current === tab.value ? null : current));
-            } : undefined}
-            onDrop={reorderable ? (event) => {
-              event.preventDefault();
-              const sourceValue = dragSourceValueRef.current ?? event.dataTransfer.getData("text/plain");
-              dragSourceValueRef.current = null;
-              setDragTargetValue(null);
-              if (sourceValue && sourceValue !== tab.value) onReorder(sourceValue, tab.value);
-            } : undefined}
-            onDragEnd={reorderable ? () => {
-              dragSourceValueRef.current = null;
-              setDragTargetValue(null);
             } : undefined}
           >
             <span

--- a/src/renderers/electrobun/view/host/tabs.tsx
+++ b/src/renderers/electrobun/view/host/tabs.tsx
@@ -29,6 +29,8 @@ export function WebTabs({
   const activeTabRef = useRef<HTMLButtonElement | null>(null);
   const tabListRef = useRef<HTMLDivElement | null>(null);
   const dragCleanupRef = useRef<(() => void) | null>(null);
+  const dragOffsetXRef = useRef(0);
+  const dragSourceWidthRef = useRef(0);
   const suppressClickRef = useRef(false);
   const [hoveredValue, setHoveredValue] = useState<string | null>(null);
   const [dragSourceValue, setDragSourceValue] = useState<string | null>(null);
@@ -51,43 +53,46 @@ export function WebTabs({
 
   useEffect(() => () => dragCleanupRef.current?.(), []);
 
-  const resolveDragTarget = (clientX: number) => {
-    let targetValue: string | null = null;
-    let targetDistance = Number.POSITIVE_INFINITY;
-    for (const button of tabListRef.current?.querySelectorAll<HTMLButtonElement>("[data-reorderable='true']") ?? []) {
-      const bounds = button.getBoundingClientRect();
-      const distance = clientX < bounds.left ? bounds.left - clientX : clientX > bounds.right ? clientX - bounds.right : 0;
-      if (distance < targetDistance) {
-        targetDistance = distance;
-        targetValue = button.dataset.tabValue ?? null;
-      }
-    }
-    return targetValue;
-  };
-
   const startReorder = (sourceValue: string, event: ReactMouseEvent<HTMLButtonElement>) => {
     if (event.button !== 0) return;
     dragCleanupRef.current?.();
+    const sourceElement = event.currentTarget;
     const startX = event.clientX;
+    const targets = [...tabListRef.current?.querySelectorAll<HTMLButtonElement>("[data-reorderable='true']") ?? []]
+      .map((button) => ({ value: button.dataset.tabValue ?? "", bounds: button.getBoundingClientRect() }));
+    const resolveTarget = (clientX: number) => targets.reduce((closest, target) => {
+      const distance = clientX < target.bounds.left
+        ? target.bounds.left - clientX
+        : clientX > target.bounds.right ? clientX - target.bounds.right : 0;
+      return distance < closest.distance ? { value: target.value, distance } : closest;
+    }, { value: "", distance: Number.POSITIVE_INFINITY }).value || null;
     let dragged = false;
 
     const cleanup = () => {
       document.removeEventListener("mousemove", handleMove);
       document.removeEventListener("mouseup", handleUp);
       document.body.classList.remove("gloom-dragging");
+      for (const button of tabListRef.current?.querySelectorAll<HTMLButtonElement>("[data-reorderable='true']") ?? []) {
+        button.style.transform = "translateX(0px)";
+      }
       dragCleanupRef.current = null;
+      dragOffsetXRef.current = 0;
+      dragSourceWidthRef.current = 0;
       setDragSourceValue(null);
       setDragTargetValue(null);
     };
     const handleMove = (moveEvent: MouseEvent) => {
-      if (!dragged && Math.abs(moveEvent.clientX - startX) < 4) return;
+      const offsetX = moveEvent.clientX - startX;
+      if (!dragged && Math.abs(offsetX) < 4) return;
       dragged = true;
       moveEvent.preventDefault();
+      dragOffsetXRef.current = offsetX;
+      sourceElement.style.transform = `translateX(${offsetX}px) scale(1.03)`;
       document.body.classList.add("gloom-dragging");
-      setDragTargetValue(resolveDragTarget(moveEvent.clientX));
+      setDragTargetValue(resolveTarget(moveEvent.clientX));
     };
     const handleUp = (upEvent: MouseEvent) => {
-      const targetValue = resolveDragTarget(upEvent.clientX);
+      const targetValue = resolveTarget(upEvent.clientX);
       suppressClickRef.current = dragged;
       cleanup();
       if (dragged && targetValue && targetValue !== sourceValue) {
@@ -95,6 +100,7 @@ export function WebTabs({
       }
     };
 
+    dragSourceWidthRef.current = sourceElement.getBoundingClientRect().width;
     setDragSourceValue(sourceValue);
     document.addEventListener("mousemove", handleMove);
     document.addEventListener("mouseup", handleUp);
@@ -127,6 +133,10 @@ export function WebTabs({
     return palette.inactiveFg;
   };
 
+  const dragSourceIndex = tabs.findIndex((tab) => tab.value === dragSourceValue);
+  const dragTargetIndex = tabs.findIndex((tab) => tab.value === dragTargetValue);
+  const dragSlotWidth = dragSourceWidthRef.current + (dense ? 2 : 4);
+
   return (
     <div
       ref={tabListRef}
@@ -149,13 +159,21 @@ export function WebTabs({
         boxSizing: "border-box",
       }}
     >
-      {tabs.map((tab) => {
+      {tabs.map((tab, index) => {
         const active = tab.value === activeValue;
         const disabled = tab.disabled === true;
         const hovered = hoveredValue === tab.value && !disabled;
         const closeVisible = !!tab.onClose && (closeMode === "always" || active);
         const reorderable = !!onReorder && !disabled && tab.reorderable !== false;
         const dragTarget = dragTargetValue === tab.value && dragSourceValue !== tab.value;
+        const sourceDragging = dragSourceValue === tab.value && dragTargetValue !== null;
+        const dragTranslateX = dragSourceValue === tab.value
+          ? dragOffsetXRef.current
+          : dragSourceIndex < dragTargetIndex && index > dragSourceIndex && index <= dragTargetIndex
+            ? -dragSlotWidth
+            : dragSourceIndex > dragTargetIndex && index >= dragTargetIndex && index < dragSourceIndex
+              ? dragSlotWidth
+              : 0;
         const tabStyle = {
           "--tab-fg": resolveTabColor(disabled, active, hovered),
           "--tab-hover-fg": palette.hoverFg,
@@ -190,7 +208,10 @@ export function WebTabs({
           borderColor: active && focused && variant !== "pill"
             ? `color-mix(in srgb, ${palette.activeUnderline} 35%, transparent)`
             : "transparent",
-          transition: "background-color 110ms ease, border-color 110ms ease, color 110ms ease",
+          transform: `translateX(${dragTranslateX}px)${sourceDragging ? " scale(1.03)" : ""}`,
+          zIndex: dragSourceValue === tab.value ? 2 : undefined,
+          willChange: dragSourceValue ? "transform" : undefined,
+          transition: `background-color 110ms ease, border-color 110ms ease, color 110ms ease, transform ${dragSourceValue === tab.value ? "0ms" : "var(--tab-reorder-duration, 160ms)"} cubic-bezier(0.77, 0, 0.175, 1)`,
           cursor: disabled ? "default" : dragSourceValue ? "grabbing" : reorderable ? "grab" : "pointer",
         } satisfies CssVars;
 

--- a/src/renderers/electrobun/view/host/tabs.tsx
+++ b/src/renderers/electrobun/view/host/tabs.tsx
@@ -170,9 +170,9 @@ export function WebTabs({
         const sourceDragging = dragSourceValue === tab.value && dragTargetValue !== null;
         const dragTranslateX = dragSourceValue === tab.value
           ? dragOffsetXRef.current
-          : dragSourceIndex < dragTargetIndex && index > dragSourceIndex && index <= dragTargetIndex
+          : dragTargetIndex >= 0 && dragSourceIndex < dragTargetIndex && index > dragSourceIndex && index <= dragTargetIndex
             ? -dragSlotWidth
-            : dragSourceIndex > dragTargetIndex && index >= dragTargetIndex && index < dragSourceIndex
+            : dragTargetIndex >= 0 && dragSourceIndex > dragTargetIndex && index >= dragTargetIndex && index < dragSourceIndex
               ? dragSlotWidth
               : 0;
         const tabStyle = {

--- a/src/renderers/electrobun/view/host/tabs.tsx
+++ b/src/renderers/electrobun/view/host/tabs.tsx
@@ -73,9 +73,6 @@ export function WebTabs({
       document.removeEventListener("mousemove", handleMove);
       document.removeEventListener("mouseup", handleUp);
       document.body.classList.remove("gloom-dragging");
-      for (const button of tabListRef.current?.querySelectorAll<HTMLButtonElement>("[data-reorderable='true']") ?? []) {
-        button.style.transform = "translateX(0px)";
-      }
       dragCleanupRef.current = null;
       dragOffsetXRef.current = 0;
       dragSourceWidthRef.current = 0;
@@ -212,7 +209,7 @@ export function WebTabs({
           transform: `translateX(${dragTranslateX}px)${sourceDragging ? " scale(1.03)" : ""}`,
           zIndex: dragSourceValue === tab.value ? 2 : undefined,
           willChange: dragSourceValue ? "transform" : undefined,
-          transition: `background-color 110ms ease, border-color 110ms ease, color 110ms ease, transform ${dragSourceValue === tab.value ? "0ms" : "var(--tab-reorder-duration, 160ms)"} cubic-bezier(0.77, 0, 0.175, 1)`,
+          transition: `background-color 110ms ease, border-color 110ms ease, color 110ms ease, transform ${dragSourceValue && dragSourceValue !== tab.value ? "var(--tab-reorder-duration, 160ms)" : "0ms"} cubic-bezier(0.77, 0, 0.175, 1)`,
           cursor: disabled ? "default" : dragSourceValue ? "grabbing" : reorderable ? "grab" : "pointer",
         } satisfies CssVars;
 

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -265,6 +265,11 @@ body.gloom-dragging [data-gloom-role="chart-surface"] {
   all: unset;
   box-sizing: border-box;
 }
+@media (prefers-reduced-motion: reduce) {
+  [data-gloom-role="tab-button"] {
+    --tab-reorder-duration: 0ms;
+  }
+}
 [data-gloom-role="tab-button"]:focus-visible {
   outline: 1px solid var(--tab-hover-underline);
   outline-offset: -1px;


### PR DESCRIPTION
## Summary
- replace unreliable native HTML drag-and-drop with the desktop mouse drag path
- make the dragged chip track the pointer while neighboring chips slide aside
- keep the active layout selected after reordering and prevent the drag release from triggering a click
- disable positional transitions for reduced-motion users

## Validation
- `bun test`: 2,177 passed
- `bun run typecheck`
- reproduced the failed desktop drag in the packaged macOS app
- verified animated left/right dragging in a packaged build and restored the original layout order