### PR TITLE
Add market halts and options calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Use `HELP` inside Gloomberb for the live shortcut list. The common command-bar p
 | `ANR <ticker>` | Analyst targets and ratings |
 | `SEC <ticker>` | SEC filings and company disclosures |
 | `OMON <ticker>` | Options monitor |
+| `OVME` | Black-Scholes option calculator with Greeks and implied volatility |
 | `HDS <ticker>` | Institutional holders |
 | `DVD <ticker>` | Dividend yield and history |
 | `SI <ticker>` | Short interest |
@@ -273,6 +274,7 @@ The toolbar controls preset or exact date ranges, intervals from one minute thro
 | `CRD` | Credit spreads |
 | `ERN` | Earnings calendar |
 | `IPO` | Upcoming and recent IPOs |
+| `HALT` | US trading halts with reason and resumption times |
 | `TV` | Live Bloomberg, CNBC, and Yahoo Finance television |
 | `BI` / `SP` | S&P 500 sector performance |
 | `FXC` | Major FX cross rates |

--- a/src/plugins/builtin/composite-plugins.ts
+++ b/src/plugins/builtin/composite-plugins.ts
@@ -17,6 +17,7 @@ import { fxMatrixModule } from "./fx-matrix";
 import { helpModule } from "./help";
 import { positionSizerModule } from "./kelly-sizer";
 import { layoutManagerModule } from "./layout-manager";
+import { marketHaltsModule } from "./market-halts";
 import { marketHeatmapModule } from "./market-heatmap";
 import { marketMoversModule } from "./market-movers";
 import { tvModule } from "./tv";
@@ -75,6 +76,7 @@ export const marketOverviewPlugin = composeBuiltinPlugin({
     worldIndicesModule,
     marketHeatmapModule,
     marketMoversModule,
+    marketHaltsModule,
     scannerModule,
     fearGreedModule,
     sectorsModule,

--- a/src/plugins/builtin/market-halts/client.ts
+++ b/src/plugins/builtin/market-halts/client.ts
@@ -1,0 +1,114 @@
+import type { ConnectionHealthRegistry } from "../../../core/connection-health";
+import { decodeHtmlEntities } from "../../../utils/html-entities";
+import { httpFetch } from "../../../utils/http-transport";
+import { describeHaltReason, parseEtDateTime, type HaltRecord } from "./model";
+
+export const NASDAQ_HALTS_CONNECTION_ID = "nasdaq-trade-halts";
+
+const HALTS_FEED_URL = "https://www.nasdaqtrader.com/rss.aspx?feed=tradehalts";
+const FETCH_TIMEOUT_MS = 15_000;
+
+const healthRegistrations = new WeakMap<
+  ConnectionHealthRegistry,
+  { references: number; dispose: () => void }
+>();
+
+export function acquireMarketHaltsHealth(health: ConnectionHealthRegistry): () => void {
+  const current = healthRegistrations.get(health);
+  if (current) {
+    current.references += 1;
+  } else {
+    healthRegistrations.set(health, {
+      references: 1,
+      dispose: health.registerSource({
+        id: NASDAQ_HALTS_CONNECTION_ID,
+        name: "Nasdaq Trader",
+        kind: "api",
+        ownerId: "market-overview",
+        detail: "nasdaqtrader.com",
+        priority: 300,
+      }),
+    });
+  }
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    const registration = healthRegistrations.get(health);
+    if (!registration) return;
+    registration.references -= 1;
+    if (registration.references > 0) return;
+    registration.dispose();
+    healthRegistrations.delete(health);
+  };
+}
+
+function fieldValue(item: string, tag: string): string {
+  const match = item.match(new RegExp(`<ndaq:${tag}[^>]*>([\\s\\S]*?)</ndaq:${tag}>`, "i"));
+  return match ? decodeHtmlEntities(match[1]!).trim() : "";
+}
+
+export interface HaltFeedParseResult {
+  records: HaltRecord[];
+  /** `<item>` blocks seen, so an unparseable feed is not mistaken for a quiet day. */
+  itemCount: number;
+}
+
+export function parseHaltFeed(xml: string): HaltFeedParseResult {
+  const items = xml.match(/<item>[\s\S]*?<\/item>/gi) ?? [];
+  const records: HaltRecord[] = [];
+
+  for (const item of items) {
+    const symbol = fieldValue(item, "IssueSymbol").toUpperCase();
+    const haltDate = fieldValue(item, "HaltDate");
+    const haltTime = fieldValue(item, "HaltTime");
+    const haltedAt = parseEtDateTime(haltDate, haltTime);
+    if (!symbol || haltedAt == null) continue;
+
+    const resumptionDate = fieldValue(item, "ResumptionDate");
+    const reasonCode = fieldValue(item, "ReasonCode").toUpperCase();
+    records.push({
+      id: `${symbol}|${haltDate}|${haltTime}|${reasonCode}`,
+      symbol,
+      company: fieldValue(item, "IssueName"),
+      market: fieldValue(item, "Market"),
+      reasonCode,
+      reason: describeHaltReason(reasonCode),
+      haltedAt,
+      quoteResumeAt: parseEtDateTime(resumptionDate, fieldValue(item, "ResumptionQuoteTime")),
+      tradeResumeAt: parseEtDateTime(resumptionDate, fieldValue(item, "ResumptionTradeTime")),
+    });
+  }
+
+  return { records, itemCount: items.length };
+}
+
+async function loadHaltFeed(): Promise<HaltRecord[]> {
+  const response = await httpFetch(HALTS_FEED_URL, {
+    headers: { Accept: "application/rss+xml, application/xml;q=0.9, */*;q=0.8" },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`Nasdaq halt feed request failed (${response.status})`);
+  }
+
+  const xml = await response.text();
+  if (!/<rss\b/i.test(xml) || !/<channel\b/i.test(xml) || !/xmlns:ndaq=/i.test(xml)) {
+    throw new Error("Nasdaq halt feed response was not RSS");
+  }
+
+  const { records, itemCount } = parseHaltFeed(xml);
+  // Nasdaq publishes an empty channel on quiet days; items we cannot read mean
+  // the format moved, which must not render as "no halts today".
+  if (records.length === 0 && itemCount > 0) {
+    throw new Error("Nasdaq halt feed format was not recognized");
+  }
+  return records;
+}
+
+export async function fetchMarketHalts(health?: ConnectionHealthRegistry): Promise<HaltRecord[]> {
+  return health?.hasSource(NASDAQ_HALTS_CONNECTION_ID)
+    ? health.track(NASDAQ_HALTS_CONNECTION_ID, "fetchTradeHalts", loadHaltFeed)
+    : loadHaltFeed();
+}

--- a/src/plugins/builtin/market-halts/index.tsx
+++ b/src/plugins/builtin/market-halts/index.tsx
@@ -1,0 +1,29 @@
+import type { PluginModule } from "../plugin-module";
+import { MARKET_HALTS_PANE_ID } from "./model";
+import { MarketHaltsPane } from "./pane";
+
+export const marketHaltsModule: PluginModule = {
+  panes: [
+    {
+      id: MARKET_HALTS_PANE_ID,
+      name: "Market Halts",
+      icon: "H",
+      component: MarketHaltsPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 124, height: 26 },
+    },
+  ],
+
+  paneTemplates: [
+    {
+      id: "market-halts-pane",
+      paneId: MARKET_HALTS_PANE_ID,
+      label: "Market Halts",
+      description: "Current and recent US trading halts from Nasdaq Trader, with reason and resumption times.",
+      keywords: ["halt", "halts", "pause", "luld", "circuit", "breaker", "suspension", "resumption"],
+      shortcut: { prefix: "HALT" },
+      createInstance: () => ({ placement: "floating" }),
+    },
+  ],
+};

--- a/src/plugins/builtin/market-halts/model.test.ts
+++ b/src/plugins/builtin/market-halts/model.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { ConnectionHealthRegistry } from "../../../core/connection-health";
+import { setHttpFetchTransport } from "../../../utils/http-transport";
+import {
+  NASDAQ_HALTS_CONNECTION_ID,
+  acquireMarketHaltsHealth,
+  fetchMarketHalts,
+  parseHaltFeed,
+} from "./client";
+import {
+  DEFAULT_HALT_SORT,
+  etWallClockToUtcMs,
+  filterHalts,
+  formatEtResumption,
+  resolveHaltStatus,
+  sortHalts,
+} from "./model";
+
+function item(fields: Record<string, string>): string {
+  const body = Object.entries(fields)
+    .map(([tag, value]) => (value === "" ? `<ndaq:${tag} />` : `<ndaq:${tag}>${value}</ndaq:${tag}>`))
+    .join("");
+  return `<item><title>${fields.IssueSymbol ?? ""}</title>${body}</item>`;
+}
+
+const SUMMER_HALT = item({
+  HaltDate: "08/20/2026",
+  HaltTime: "15:41:44.413",
+  IssueSymbol: "adxn",
+  IssueName: "Addex &amp; Co ADS",
+  Market: "NASDAQ",
+  ReasonCode: "LUDP",
+  ResumptionDate: "08/20/2026",
+  ResumptionQuoteTime: "15:41:44",
+  ResumptionTradeTime: "15:46:44",
+});
+
+const WINTER_HALT = item({
+  HaltDate: "01/15/2026",
+  HaltTime: "09:30:00",
+  IssueSymbol: "WNTR",
+  IssueName: "Winter Corp",
+  Market: "NYSE",
+  ReasonCode: "T12",
+  ResumptionDate: "",
+  ResumptionQuoteTime: "",
+  ResumptionTradeTime: "",
+});
+
+const OVERNIGHT_HALT = item({
+  HaltDate: "08/19/2026",
+  HaltTime: "16:10:00",
+  IssueSymbol: "OVER",
+  IssueName: "Overnight Inc",
+  Market: "AMEX",
+  ReasonCode: "T3",
+  ResumptionDate: "08/20/2026",
+  ResumptionQuoteTime: "09:20:00",
+  ResumptionTradeTime: "09:30:00",
+});
+
+function feed(...items: string[]): string {
+  return `<?xml version="1.0" encoding="utf-8"?><rss xmlns:ndaq="http://www.nasdaqtrader.com/"><channel>${items.join("")}</channel></rss>`;
+}
+
+afterEach(() => {
+  setHttpFetchTransport(null);
+});
+
+describe("parseHaltFeed", () => {
+  test("reads Nasdaq fields as America/New_York across both DST offsets", () => {
+    const { records } = parseHaltFeed(feed(SUMMER_HALT, WINTER_HALT));
+
+    // 15:41:44.413 EDT is 19:41:44.413Z; 09:30:00 EST is 14:30:00Z.
+    expect(new Date(records[0]!.haltedAt).toISOString()).toBe("2026-08-20T19:41:44.413Z");
+    expect(new Date(records[1]!.haltedAt).toISOString()).toBe("2026-01-15T14:30:00.000Z");
+  });
+
+  test("normalizes the symbol, decodes entities, and expands the reason code", () => {
+    const [record] = parseHaltFeed(feed(SUMMER_HALT)).records;
+
+    expect(record?.symbol).toBe("ADXN");
+    expect(record?.company).toBe("Addex & Co ADS");
+    expect(record?.reason).toBe("Volatility pause");
+  });
+
+  test("leaves resumption times null when the feed has not set them", () => {
+    const [record] = parseHaltFeed(feed(WINTER_HALT)).records;
+
+    expect(record?.quoteResumeAt).toBeNull();
+    expect(record?.tradeResumeAt).toBeNull();
+  });
+
+  test("reports item count so an unreadable feed is not read as zero halts", () => {
+    const result = parseHaltFeed(feed("<item><title>ADXN</title><halt>who knows</halt></item>"));
+
+    expect(result.records).toHaveLength(0);
+    expect(result.itemCount).toBe(1);
+  });
+});
+
+describe("fetchMarketHalts", () => {
+  test("tracks parse failures as connection errors", async () => {
+    const health = new ConnectionHealthRegistry();
+    const release = acquireMarketHaltsHealth(health);
+    setHttpFetchTransport(async () => new Response(feed("<item><x/></item>")));
+
+    await expect(fetchMarketHalts(health)).rejects.toThrow(/format/i);
+    expect(health.getSnapshot().sources.find((source) => source.id === NASDAQ_HALTS_CONNECTION_ID)?.status)
+      .toBe("error");
+    release();
+  });
+
+  test("rejects a successful HTML response instead of reporting a quiet day", async () => {
+    setHttpFetchTransport(async () => new Response("<html>blocked</html>"));
+
+    await expect(fetchMarketHalts()).rejects.toThrow(/not RSS/i);
+  });
+
+  test("returns an empty list for a feed with no items", async () => {
+    setHttpFetchTransport(async () => new Response(feed()));
+
+    await expect(fetchMarketHalts()).resolves.toEqual([]);
+  });
+});
+
+describe("etWallClockToUtcMs", () => {
+  test("resolves the ambiguous fall-back hour with the offset in force", () => {
+    // 01:30 on 2026-11-01 happens twice; the first (EDT, -4) instant wins.
+    expect(new Date(etWallClockToUtcMs(2026, 11, 1, 1, 30, 0)).toISOString())
+      .toBe("2026-11-01T05:30:00.000Z");
+    // 03:00 the same morning is unambiguously EST (-5).
+    expect(new Date(etWallClockToUtcMs(2026, 11, 1, 3, 0, 0)).toISOString())
+      .toBe("2026-11-01T08:00:00.000Z");
+  });
+});
+
+describe("halt status", () => {
+  const [summer, winter, overnight] = parseHaltFeed(feed(SUMMER_HALT, WINTER_HALT, OVERNIGHT_HALT)).records;
+  const records = [summer!, winter!, overnight!];
+
+  test("walks halted, quote-resumed, then resumed as the clock passes each time", () => {
+    const beforeQuote = summer!.quoteResumeAt! - 1_000;
+    const betweenQuoteAndTrade = summer!.quoteResumeAt! + 1_000;
+    const afterTrade = summer!.tradeResumeAt! + 1_000;
+
+    expect(resolveHaltStatus(summer!, beforeQuote)).toBe("halted");
+    expect(resolveHaltStatus(summer!, betweenQuoteAndTrade)).toBe("quote");
+    expect(resolveHaltStatus(summer!, afterTrade)).toBe("resumed");
+  });
+
+  test("stays halted forever without resumption times", () => {
+    expect(resolveHaltStatus(winter!, Date.now())).toBe("halted");
+  });
+
+  test("filters active against resumed at the same instant", () => {
+    const now = summer!.tradeResumeAt! + 1_000;
+
+    expect(filterHalts(records, "active", now).map((row) => row.symbol)).toEqual(["WNTR"]);
+    expect(filterHalts(records, "resumed", now).map((row) => row.symbol)).toEqual(["ADXN", "OVER"]);
+    expect(filterHalts(records, "all", now)).toHaveLength(3);
+  });
+});
+
+describe("halt table", () => {
+  const records = parseHaltFeed(feed(SUMMER_HALT, WINTER_HALT, OVERNIGHT_HALT)).records;
+
+  test("defaults to newest halt first", () => {
+    expect(sortHalts(records, DEFAULT_HALT_SORT, Date.now()).map((row) => row.symbol))
+      .toEqual(["ADXN", "OVER", "WNTR"]);
+  });
+
+  test("sorts by a chosen column in both directions", () => {
+    expect(sortHalts(records, { columnId: "symbol", direction: "desc" }, Date.now()).map((row) => row.symbol))
+      .toEqual(["WNTR", "OVER", "ADXN"]);
+    expect(sortHalts(records, { columnId: "market", direction: "asc" }, Date.now()).map((row) => row.market))
+      .toEqual(["AMEX", "NASDAQ", "NYSE"]);
+  });
+
+  test("dates a resumption that lands on another session", () => {
+    const overnight = records.find((row) => row.symbol === "OVER")!;
+    const sameDay = records.find((row) => row.symbol === "ADXN")!;
+
+    expect(formatEtResumption(overnight.tradeResumeAt, overnight.haltedAt)).toBe("08/20 09:30");
+    expect(formatEtResumption(sameDay.tradeResumeAt, sameDay.haltedAt)).toBe("15:46:44");
+  });
+});

--- a/src/plugins/builtin/market-halts/model.ts
+++ b/src/plugins/builtin/market-halts/model.ts
@@ -1,0 +1,291 @@
+import type { DataTableColumn } from "../../../components";
+import { colors } from "../../../theme/colors";
+import { compareSortValues, type SortPreference } from "../../../utils/sort-values";
+import { zonedDateTimeParts, zonedWallClockToUtcMs } from "../../../utils/zoned-date-time";
+
+export const MARKET_HALTS_PANE_ID = "market-halts";
+
+/** Nasdaq publishes every field of this feed as America/New_York wall-clock time. */
+const EXCHANGE_TIME_ZONE = "America/New_York";
+
+export type HaltStatus = "halted" | "quote" | "resumed";
+
+export interface HaltRecord {
+  id: string;
+  symbol: string;
+  company: string;
+  market: string;
+  reasonCode: string;
+  /** Plain-English expansion of `reasonCode`. */
+  reason: string;
+  haltedAt: number;
+  quoteResumeAt: number | null;
+  tradeResumeAt: number | null;
+}
+
+/**
+ * Concise renderings of Nasdaq's trade halt codes
+ * (nasdaqtrader.com/trader.aspx?id=TradeHaltCodes), shortened to fit a column
+ * while keeping the meaning intact.
+ */
+const HALT_REASONS: Readonly<Record<string, string>> = {
+  T1: "News pending",
+  T2: "News released",
+  T3: "News released, resumption times set",
+  T5: "Single-stock pause, 10% move",
+  T6: "Extraordinary market activity",
+  T7: "Quotation-only period",
+  T8: "ETF halt",
+  T12: "Additional info requested by Nasdaq",
+  H4: "Listing non-compliance",
+  H9: "Filings not current",
+  H10: "SEC trading suspension",
+  H11: "Regulatory concern",
+  O1: "Operations halt",
+  IPO1: "IPO not yet trading",
+  IPOQ: "IPO released for quotation",
+  IPOE: "IPO positioning window extended",
+  M: "Volatility pause, listed issue",
+  M1: "Corporate action",
+  M2: "Quotation not available",
+  LUDP: "Volatility pause",
+  LUDS: "Volatility pause, straddle",
+  MWC0: "Circuit breaker carried over",
+  MWC1: "Market-wide circuit breaker, level 1",
+  MWC2: "Market-wide circuit breaker, level 2",
+  MWC3: "Market-wide circuit breaker, level 3",
+  MWCQ: "Market-wide circuit breaker resumption",
+  R1: "New issue available",
+  R2: "Issue available",
+  R4: "Qualification issues resolved",
+  R9: "Filing requirements satisfied",
+  C3: "Issuer news not forthcoming",
+  C4: "Qualifications halt ended",
+  C9: "Qualifications halt concluded",
+  C11: "Halt concluded by other regulator",
+  D: "Security deleted from Nasdaq/CQS",
+};
+
+export function describeHaltReason(code: string): string {
+  const normalized = code.trim().toUpperCase();
+  if (!normalized) return "Reason not available";
+  return HALT_REASONS[normalized] ?? `Reason code ${normalized}`;
+}
+
+function etParts(utcMs: number) {
+  return zonedDateTimeParts(utcMs, EXCHANGE_TIME_ZONE);
+}
+
+export function etWallClockToUtcMs(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  millisecond = 0,
+): number {
+  return zonedWallClockToUtcMs(
+    EXCHANGE_TIME_ZONE,
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    millisecond,
+  );
+}
+
+/** Parse Nasdaq's "MM/DD/YYYY" date and "HH:MM:SS[.mmm]" time pair. */
+export function parseEtDateTime(date: string, time: string): number | null {
+  const dateMatch = date.trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  const timeMatch = time.trim().match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?(?:\.(\d{1,3}))?$/);
+  if (!dateMatch || !timeMatch) return null;
+  const year = Number(dateMatch[3]);
+  const month = Number(dateMatch[1]);
+  const day = Number(dateMatch[2]);
+  const hour = Number(timeMatch[1]);
+  const minute = Number(timeMatch[2]);
+  const second = Number(timeMatch[3] ?? "0");
+  const millisecond = Number((timeMatch[4] ?? "0").padEnd(3, "0"));
+  const daysInMonth = month >= 1 && month <= 12
+    ? new Date(Date.UTC(year, month, 0)).getUTCDate()
+    : 0;
+  if (day < 1 || day > daysInMonth || hour > 23 || minute > 59 || second > 59) return null;
+  return etWallClockToUtcMs(year, month, day, hour, minute, second, millisecond);
+}
+
+function formatEtClock(utcMs: number): string {
+  const parts = etParts(utcMs);
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${pad(parts.hour)}:${pad(parts.minute)}:${pad(parts.second)}`;
+}
+
+/** "MM/DD/YY" in ET, because the feed carries halts that are years apart. */
+export function formatEtDate(utcMs: number): string {
+  const parts = etParts(utcMs);
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${pad(parts.month)}/${pad(parts.day)}/${String(parts.year).slice(2)}`;
+}
+
+export function formatEtTime(utcMs: number | null): string {
+  return utcMs == null ? "—" : formatEtClock(utcMs);
+}
+
+/**
+ * Resumption times usually share the halt's session, so the time alone reads
+ * cleanly; an overnight halt gets its ET date back rather than looking like it
+ * reopened before it stopped.
+ */
+export function formatEtResumption(utcMs: number | null, haltedAt: number): string {
+  if (utcMs == null) return "—";
+  const sameDay = formatEtDate(utcMs) === formatEtDate(haltedAt);
+  return sameDay ? formatEtClock(utcMs) : `${formatEtDate(utcMs).slice(0, 5)} ${formatEtClock(utcMs).slice(0, 5)}`;
+}
+
+export function resolveHaltStatus(record: HaltRecord, now: number): HaltStatus {
+  if (record.tradeResumeAt != null && now >= record.tradeResumeAt) return "resumed";
+  if (record.quoteResumeAt != null && now >= record.quoteResumeAt) return "quote";
+  return "halted";
+}
+
+export function haltStatusLabel(status: HaltStatus): string {
+  switch (status) {
+    case "halted":
+      return "HALTED";
+    case "quote":
+      return "QUOTE";
+    case "resumed":
+      return "RESUMED";
+  }
+}
+
+export function haltStatusColor(status: HaltStatus): string {
+  switch (status) {
+    case "halted":
+      return colors.negative;
+    case "quote":
+      return colors.warning;
+    case "resumed":
+      return colors.positive;
+  }
+}
+
+export type HaltFilter = "all" | "active" | "resumed";
+
+export const HALT_FILTERS: ReadonlyArray<{ label: string; value: HaltFilter }> = [
+  { label: "All", value: "all" },
+  { label: "Active", value: "active" },
+  { label: "Resumed", value: "resumed" },
+];
+
+export function nextHaltFilter(current: HaltFilter): HaltFilter {
+  const index = HALT_FILTERS.findIndex((entry) => entry.value === current);
+  return HALT_FILTERS[(index + 1) % HALT_FILTERS.length]!.value;
+}
+
+export function filterHalts(records: HaltRecord[], filter: HaltFilter, now: number): HaltRecord[] {
+  if (filter === "all") return records;
+  return records.filter((record) => {
+    const status = resolveHaltStatus(record, now);
+    return filter === "resumed" ? status === "resumed" : status !== "resumed";
+  });
+}
+
+export type HaltColumnId =
+  | "symbol"
+  | "market"
+  | "company"
+  | "code"
+  | "reason"
+  | "date"
+  | "halted"
+  | "quote"
+  | "trade"
+  | "status";
+
+export type HaltColumn = DataTableColumn & { id: HaltColumnId };
+
+export const HALT_SORT_COLUMN_IDS: readonly HaltColumnId[] = [
+  "symbol",
+  "market",
+  "company",
+  "code",
+  "reason",
+  "halted",
+  "quote",
+  "trade",
+  "status",
+];
+
+export type HaltSortPreference = SortPreference<HaltColumnId>;
+
+/** Newest halt first: the reason anyone opens this pane. */
+export const DEFAULT_HALT_SORT: HaltSortPreference = { columnId: "halted", direction: "desc" };
+
+export function buildHaltColumns(width: number): HaltColumn[] {
+  // "Non NASDAQ" and "NYSE Arca" are real feed values, so MKT holds all ten cells.
+  const fixed = 8 + 10 + 5 + 9 + 9 + 11 + 11 + 8;
+  const gaps = 12;
+  const flexible = Math.max(26, width - fixed - gaps);
+  const companyWidth = Math.max(12, Math.floor(flexible * 0.45));
+  const reasonWidth = Math.max(14, flexible - companyWidth);
+  return [
+    { id: "symbol", label: "SYMBOL", width: 8, align: "left" },
+    { id: "market", label: "MKT", width: 10, align: "left" },
+    { id: "company", label: "COMPANY", width: companyWidth, align: "left" },
+    { id: "code", label: "CODE", width: 5, align: "left" },
+    { id: "reason", label: "REASON", width: reasonWidth, align: "left" },
+    { id: "date", label: "DATE ET", width: 9, align: "left" },
+    { id: "halted", label: "HALT ET", width: 9, align: "left" },
+    { id: "quote", label: "QUOTE ET", width: 11, align: "left" },
+    { id: "trade", label: "TRADE ET", width: 11, align: "left" },
+    { id: "status", label: "STATUS", width: 8, align: "left" },
+  ];
+}
+
+function haltSortValue(columnId: HaltColumnId, record: HaltRecord, now: number): string | number | null {
+  switch (columnId) {
+    case "symbol":
+      return record.symbol;
+    case "market":
+      return record.market;
+    case "company":
+      return record.company;
+    case "code":
+      return record.reasonCode;
+    case "reason":
+      return record.reason;
+    case "date":
+    case "halted":
+      return record.haltedAt;
+    case "quote":
+      return record.quoteResumeAt;
+    case "trade":
+      return record.tradeResumeAt;
+    case "status":
+      return resolveHaltStatus(record, now);
+  }
+}
+
+export function sortHalts(records: HaltRecord[], sort: HaltSortPreference, now: number): HaltRecord[] {
+  const columnId = sort.columnId;
+  if (!columnId) return records;
+  return [...records].sort((a, b) => {
+    const compared = compareSortValues(
+      haltSortValue(columnId, a, now),
+      haltSortValue(columnId, b, now),
+      sort.direction,
+    );
+    // A stable secondary key keeps rows from shuffling between refreshes.
+    return compared !== 0 ? compared : b.haltedAt - a.haltedAt;
+  });
+}
+
+export function nextHaltSort(current: HaltSortPreference, columnId: string): HaltSortPreference {
+  const typed = columnId as HaltColumnId;
+  if (current.columnId !== typed) return { columnId: typed, direction: "asc" };
+  if (current.direction === "asc") return { columnId: typed, direction: "desc" };
+  return DEFAULT_HALT_SORT;
+}

--- a/src/plugins/builtin/market-halts/pane.tsx
+++ b/src/plugins/builtin/market-halts/pane.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  DataTableView,
+  EmptyState,
+  Spinner,
+  Tabs,
+  type DataTableCell,
+  type DataTableKeyEvent,
+} from "../../../components";
+import { useShortcut } from "../../../react/input";
+import { colors } from "../../../theme/colors";
+import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
+import type { PaneProps } from "../../../types/plugin";
+import { Box, TextAttributes } from "../../../ui";
+import { isPlainKey } from "../../../utils/keyboard";
+import { cycleSortPreference } from "../../../utils/sort-values";
+import { useConnectionHealth, usePluginTickerActions } from "../../runtime";
+import { useAutoRefresh } from "../shared/auto-refresh";
+import { usePaneStatusFooter } from "../shared/pane-footer";
+import { acquireMarketHaltsHealth, fetchMarketHalts } from "./client";
+import {
+  DEFAULT_HALT_SORT,
+  HALT_FILTERS,
+  HALT_SORT_COLUMN_IDS,
+  MARKET_HALTS_PANE_ID,
+  buildHaltColumns,
+  filterHalts,
+  formatEtDate,
+  formatEtResumption,
+  formatEtTime,
+  haltStatusColor,
+  haltStatusLabel,
+  nextHaltFilter,
+  nextHaltSort,
+  resolveHaltStatus,
+  sortHalts,
+  type HaltColumn,
+  type HaltFilter,
+  type HaltRecord,
+  type HaltSortPreference,
+} from "./model";
+
+/** Halted rows flip to resumed on the clock alone, so the pane re-reads it. */
+const STATUS_TICK_MS = 15_000;
+
+export function MarketHaltsPane({ focused, width, height }: PaneProps) {
+  const { pinTicker } = usePluginTickerActions();
+  const connectionHealth = useConnectionHealth();
+  const [records, setRecords] = useState<HaltRecord[]>([]);
+  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [fetchedAt, setFetchedAt] = useState<number | null>(null);
+  const [filter, setFilter] = useState<HaltFilter>("all");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [sortPreference, setSortPreference] = useState<HaltSortPreference>(DEFAULT_HALT_SORT);
+  const [now, setNow] = useState(() => Date.now());
+  const fetchGenRef = useRef(0);
+
+  const load = useCallback(() => {
+    fetchGenRef.current += 1;
+    const generation = fetchGenRef.current;
+    setStatus((current) => (current === "loaded" ? "loaded" : "loading"));
+    setError(null);
+    fetchMarketHalts(connectionHealth)
+      .then((next) => {
+        if (fetchGenRef.current !== generation) return;
+        setRecords(next);
+        setError(null);
+        setStatus("loaded");
+        setFetchedAt(Date.now());
+        setNow(Date.now());
+      })
+      .catch((loadError: unknown) => {
+        if (fetchGenRef.current !== generation) return;
+        setError(loadError instanceof Error ? loadError.message : String(loadError));
+        setStatus("error");
+      });
+  }, [connectionHealth]);
+
+  useEffect(() => acquireMarketHaltsHealth(connectionHealth), [connectionHealth]);
+  useEffect(() => { load(); }, [load]);
+  useAutoRefresh(fetchedAt, load);
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), STATUS_TICK_MS);
+    return () => clearInterval(timer);
+  }, []);
+
+  const rows = useMemo(
+    () => sortHalts(filterHalts(records, filter, now), sortPreference, now),
+    [filter, now, records, sortPreference],
+  );
+
+  useEffect(() => {
+    if (selectedId && rows.some((row) => row.id === selectedId)) return;
+    setSelectedId(rows[0]?.id ?? null);
+  }, [rows, selectedId]);
+
+  const refresh = useCallback(() => load(), [load]);
+  const cycleFilter = useCallback(() => setFilter((current) => nextHaltFilter(current)), []);
+  const cycleSort = useCallback((step: 1 | -1) => {
+    setSortPreference((current) => cycleSortPreference(HALT_SORT_COLUMN_IDS, current, step));
+  }, []);
+  const handleHeaderClick = useCallback((columnId: string) => {
+    setSortPreference((current) => nextHaltSort(current, columnId));
+  }, []);
+  const openTicker = useCallback((record: HaltRecord) => {
+    pinTicker(record.symbol, { floating: true, paneType: TICKER_RESEARCH_PANE_ID });
+  }, [pinTicker]);
+
+  const handlePaneKey = useCallback((event: DataTableKeyEvent): boolean => {
+    if (isPlainKey(event, "r")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      refresh();
+      return true;
+    }
+    if (isPlainKey(event, "f")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      cycleFilter();
+      return true;
+    }
+    if (isPlainKey(event, "]", "[")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      cycleSort(event.name === "]" ? 1 : -1);
+      return true;
+    }
+    return false;
+  }, [cycleFilter, cycleSort, refresh]);
+
+  useShortcut((event) => {
+    if (event.targetEditable || event.defaultPrevented || event.propagationStopped) return;
+    handlePaneKey(event as DataTableKeyEvent);
+  }, { enabled: focused });
+
+  const columns = useMemo(() => buildHaltColumns(width), [width]);
+
+  usePaneStatusFooter({
+    registrationId: MARKET_HALTS_PANE_ID,
+    loading: status === "loading",
+    error,
+    hints: [{ id: "filter", key: "f", label: "ilter", onPress: cycleFilter }],
+  });
+
+  const renderCell = useCallback((
+    row: HaltRecord,
+    column: HaltColumn,
+    _index: number,
+    rowState: { selected: boolean },
+  ): DataTableCell => {
+    const selectedColor = rowState.selected ? colors.selectedText : undefined;
+    switch (column.id) {
+      case "symbol":
+        return {
+          text: row.symbol,
+          color: selectedColor ?? colors.textBright,
+          attributes: TextAttributes.BOLD,
+        };
+      case "market":
+        return { text: row.market, color: selectedColor ?? colors.textDim };
+      case "company":
+        return { text: row.company, color: selectedColor ?? colors.text };
+      case "code":
+        return { text: row.reasonCode || "—", color: selectedColor ?? colors.textDim };
+      case "reason":
+        return { text: row.reason, color: selectedColor ?? colors.text };
+      case "date":
+        return { text: formatEtDate(row.haltedAt), color: selectedColor ?? colors.textMuted };
+      case "halted":
+        return { text: formatEtTime(row.haltedAt), color: selectedColor ?? colors.textMuted };
+      case "quote":
+        return {
+          text: formatEtResumption(row.quoteResumeAt, row.haltedAt),
+          color: selectedColor ?? colors.textDim,
+        };
+      case "trade":
+        return {
+          text: formatEtResumption(row.tradeResumeAt, row.haltedAt),
+          color: selectedColor ?? colors.textDim,
+        };
+      case "status": {
+        const rowStatus = resolveHaltStatus(row, now);
+        return {
+          text: haltStatusLabel(rowStatus),
+          color: selectedColor ?? haltStatusColor(rowStatus),
+          attributes: TextAttributes.BOLD,
+        };
+      }
+    }
+  }, [now]);
+
+  const tabs = (
+    <Box height={1} flexShrink={0} overflow="hidden">
+      <Tabs
+        tabs={HALT_FILTERS.map((entry) => ({ label: entry.label, value: entry.value }))}
+        activeValue={filter}
+        onSelect={(value) => setFilter(value as HaltFilter)}
+        compact
+        variant="bare"
+        focused={focused}
+        keyboardNavigation={false}
+      />
+    </Box>
+  );
+
+  if (status === "loading" && records.length === 0) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {tabs}
+        <Box flexGrow={1} justifyContent="center" alignItems="center">
+          <Spinner label="Loading trading halts..." />
+        </Box>
+      </Box>
+    );
+  }
+
+  if (status === "error" && records.length === 0) {
+    return (
+      <Box flexDirection="column" width={width} height={height}>
+        {tabs}
+        <Box padding={1}>
+          <EmptyState title="Trading halts unavailable." message={error ?? undefined} />
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      {tabs}
+      <DataTableView<HaltRecord, HaltColumn>
+        focused={focused}
+        rootWidth={width}
+        rootHeight={Math.max(1, height - 1)}
+        selection={{
+          kind: "id",
+          selectedId,
+          getId: (row) => row.id,
+          onChange: (id) => setSelectedId(id),
+        }}
+        onRootKeyDown={handlePaneKey}
+        columns={columns}
+        items={rows}
+        sortColumnId={sortPreference.columnId}
+        sortDirection={sortPreference.direction}
+        onHeaderClick={handleHeaderClick}
+        getItemKey={(row) => row.id}
+        onActivate={openTicker}
+        renderCell={renderCell}
+        emptyStateTitle={filter === "all" ? "No trading halts reported." : "No halts match this filter."}
+      />
+    </Box>
+  );
+}

--- a/src/plugins/builtin/options-calculator/index.tsx
+++ b/src/plugins/builtin/options-calculator/index.tsx
@@ -1,0 +1,35 @@
+import type { PluginModule } from "../plugin-module";
+import {
+  OPTIONS_CALCULATOR_PANE_ID,
+  OPTIONS_CALCULATOR_TEMPLATE_ID,
+} from "./model";
+import { OptionsCalculatorPane } from "./pane";
+
+export const optionsCalculatorModule: PluginModule = {
+  panes: [
+    {
+      id: OPTIONS_CALCULATOR_PANE_ID,
+      name: "Options Calculator",
+      icon: "V",
+      component: OptionsCalculatorPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 76, height: 16 },
+    },
+  ],
+
+  paneTemplates: [
+    {
+      id: OPTIONS_CALCULATOR_TEMPLATE_ID,
+      paneId: OPTIONS_CALCULATOR_PANE_ID,
+      label: "Options Calculator",
+      description: "Black-Scholes value, Greeks, and implied volatility for a European call or put.",
+      keywords: ["option", "options", "calculator", "black", "scholes", "greeks", "implied", "volatility", "ovme"],
+      shortcut: { prefix: "OVME" },
+      createInstance: (_context, options) => ({
+        params: options?.values ?? {},
+        placement: "floating",
+      }),
+    },
+  ],
+};

--- a/src/plugins/builtin/options-calculator/model.test.ts
+++ b/src/plugins/builtin/options-calculator/model.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_OPTION_CALC_DRAFT,
+  buildOptionCalcParams,
+  daysToExpiryFrom,
+  describeDraftProblem,
+  draftFromParams,
+  solveImpliedVolatility,
+  valueOption,
+  type OptionCalcDraft,
+} from "./model";
+
+const CANONICAL: OptionCalcDraft = {
+  ...DEFAULT_OPTION_CALC_DRAFT,
+  side: "call",
+  spot: 100,
+  strike: 100,
+  daysToExpiry: 365,
+  rate: 0.05,
+  volatility: 0.2,
+  dividendYield: 0,
+};
+
+describe("valueOption", () => {
+  test("matches the textbook Black-Scholes call and put", () => {
+    expect(valueOption(CANONICAL).price).toBeCloseTo(10.4506, 3);
+    expect(valueOption({ ...CANONICAL, side: "put" }).price).toBeCloseTo(5.5735, 3);
+  });
+
+  test("respects put-call parity with a dividend yield", () => {
+    const draft = { ...CANONICAL, spot: 120, strike: 110, dividendYield: 0.03 };
+    const call = valueOption(draft).price;
+    const put = valueOption({ ...draft, side: "put" }).price;
+    const forward = draft.spot * Math.exp(-draft.dividendYield) - draft.strike * Math.exp(-draft.rate);
+
+    expect(call - put).toBeCloseTo(forward, 6);
+  });
+
+  test("reports the greeks in per-day and per-point units", () => {
+    const greeks = valueOption(CANONICAL);
+
+    expect(greeks.delta).toBeCloseTo(0.6368, 3);
+    expect(greeks.gamma).toBeCloseTo(0.0188, 3);
+    // Annual theta is about -6.41, vega about 37.52, rho about 53.23 in unit terms.
+    expect(greeks.thetaPerDay).toBeCloseTo(-6.414 / 365, 4);
+    expect(greeks.vegaPerPoint).toBeCloseTo(0.3752, 3);
+    expect(greeks.rhoPerPoint).toBeCloseTo(0.5323, 3);
+  });
+
+  test("falls back to discounted intrinsic value at the degenerate edges", () => {
+    expect(valueOption({ ...CANONICAL, daysToExpiry: 0, spot: 110 }).price).toBeCloseTo(10, 6);
+    expect(valueOption({ ...CANONICAL, daysToExpiry: 0, spot: 90 }).price).toBe(0);
+    expect(valueOption({ ...CANONICAL, volatility: 0 }).price)
+      .toBeCloseTo(100 - 100 * Math.exp(-0.05), 6);
+  });
+
+  test("never returns NaN or Infinity for impossible inputs", () => {
+    const broken: OptionCalcDraft[] = [
+      { ...CANONICAL, spot: 0 },
+      { ...CANONICAL, strike: 0 },
+      { ...CANONICAL, spot: Number.NaN },
+      { ...CANONICAL, daysToExpiry: -10 },
+      { ...CANONICAL, volatility: -1 },
+      { ...CANONICAL, rate: Number.POSITIVE_INFINITY },
+    ];
+
+    for (const draft of broken) {
+      for (const value of Object.values(valueOption(draft))) {
+        expect(Number.isFinite(value)).toBe(true);
+      }
+    }
+  });
+});
+
+describe("solveImpliedVolatility", () => {
+  test("round-trips a priced option back to its volatility", () => {
+    for (const volatility of [0.05, 0.2, 0.85, 2.4]) {
+      for (const side of ["call", "put"] as const) {
+        const draft = { ...CANONICAL, side, volatility };
+        const solved = solveImpliedVolatility(draft, valueOption(draft).price);
+
+        expect(solved.volatility).toBeCloseTo(volatility, 5);
+      }
+    }
+  });
+
+  test("rejects a market price below intrinsic value", () => {
+    const draft = { ...CANONICAL, spot: 150 };
+    const result = solveImpliedVolatility(draft, 1);
+
+    expect(result.volatility).toBeNull();
+    expect(result.note).toMatch(/intrinsic/);
+  });
+
+  test("distinguishes impossible prices from prices above the solver ceiling", () => {
+    const aboveCeiling = solveImpliedVolatility(CANONICAL, 99);
+    const impossible = solveImpliedVolatility(CANONICAL, 101);
+
+    expect(aboveCeiling.volatility).toBeNull();
+    expect(aboveCeiling.note).toMatch(/volatility above/);
+    expect(impossible.volatility).toBeNull();
+    expect(impossible.note).toMatch(/no-arbitrage maximum/);
+  });
+
+  test("stays silent when no market price was entered", () => {
+    expect(solveImpliedVolatility(CANONICAL, 0)).toEqual({ volatility: null, note: null });
+  });
+
+  test("says so instead of solving an expired contract", () => {
+    const result = solveImpliedVolatility({ ...CANONICAL, daysToExpiry: 0 }, 5);
+
+    expect(result.volatility).toBeNull();
+    expect(result.note).toMatch(/expired/);
+  });
+});
+
+describe("seeding", () => {
+  const now = Date.UTC(2026, 7, 20, 18, 0, 0);
+
+  test("prices time through the expiration session close", () => {
+    expect(daysToExpiryFrom(Date.UTC(2026, 7, 28) / 1000, now)).toBeCloseTo(8 + 2 / 24, 8);
+    // Midnight has passed, but a same-day contract keeps its final two hours.
+    expect(daysToExpiryFrom(Date.UTC(2026, 7, 20) / 1000, now)).toBeCloseTo(2 / 24, 8);
+    expect(daysToExpiryFrom(Date.UTC(2026, 7, 19) / 1000, now)).toBe(0);
+  });
+
+  test("round-trips a seeded contract through pane params", () => {
+    const params = buildOptionCalcParams({
+      symbol: "aapl",
+      side: "put",
+      spot: 231.5,
+      strike: 230,
+      expiration: Date.UTC(2026, 8, 19) / 1000,
+      volatility: 0.284,
+      marketPrice: 7.35,
+      dividendYield: 0.0044,
+    }, now);
+
+    expect(draftFromParams(params)).toEqual({
+      symbol: "AAPL",
+      side: "put",
+      spot: 231.5,
+      strike: 230,
+      daysToExpiry: 30 + 2 / 24,
+      rate: DEFAULT_OPTION_CALC_DRAFT.rate,
+      volatility: 0.284,
+      dividendYield: 0.0044,
+      marketPrice: 7.35,
+    });
+  });
+
+  test("drops seed values a chain reports as zero rather than seeding zeros", () => {
+    const params = buildOptionCalcParams({ symbol: "MSFT", spot: 400, volatility: 0, marketPrice: 0 }, now);
+
+    expect(params.volatility).toBeUndefined();
+    expect(params.marketPrice).toBeUndefined();
+    expect(draftFromParams(params).volatility).toBe(DEFAULT_OPTION_CALC_DRAFT.volatility);
+  });
+
+  test("uses defaults when the pane is opened standalone", () => {
+    expect(draftFromParams(undefined)).toEqual(DEFAULT_OPTION_CALC_DRAFT);
+    expect(draftFromParams({})).toEqual(DEFAULT_OPTION_CALC_DRAFT);
+  });
+});
+
+describe("describeDraftProblem", () => {
+  test("names the first unusable input", () => {
+    expect(describeDraftProblem(CANONICAL)).toBeNull();
+    expect(describeDraftProblem({ ...CANONICAL, spot: 0 })).toMatch(/Spot/);
+    expect(describeDraftProblem({ ...CANONICAL, volatility: -0.1 })).toMatch(/Volatility/);
+  });
+});

--- a/src/plugins/builtin/options-calculator/model.ts
+++ b/src/plugins/builtin/options-calculator/model.ts
@@ -1,0 +1,273 @@
+import { zonedWallClockToUtcMs } from "../../../utils/zoned-date-time";
+
+export const OPTIONS_CALCULATOR_PANE_ID = "options-calculator";
+export const OPTIONS_CALCULATOR_TEMPLATE_ID = "options-calculator-pane";
+const DAY_MS = 86_400_000;
+const DAYS_PER_YEAR = 365;
+const OPTION_EXPIRY_TIME_ZONE = "America/New_York";
+const MIN_VOLATILITY = 1e-6;
+const MAX_VOLATILITY = 5;
+
+export type OptionSide = "call" | "put";
+
+export interface OptionCalcDraft {
+  symbol: string;
+  side: OptionSide;
+  spot: number;
+  strike: number;
+  daysToExpiry: number;
+  /** Continuously compounded, as a decimal (0.05 = 5%). */
+  rate: number;
+  volatility: number;
+  dividendYield: number;
+  /** 0 means "not supplied", which is also the only price no option can trade at. */
+  marketPrice: number;
+}
+
+export const DEFAULT_OPTION_CALC_DRAFT: OptionCalcDraft = {
+  symbol: "",
+  side: "call",
+  spot: 100,
+  strike: 100,
+  daysToExpiry: 30,
+  rate: 0.04,
+  volatility: 0.25,
+  dividendYield: 0,
+  marketPrice: 0,
+};
+
+export interface OptionValuation {
+  price: number;
+  delta: number;
+  gamma: number;
+  /** Value decay for one calendar day. */
+  thetaPerDay: number;
+  /** Value change for one volatility point (1%). */
+  vegaPerPoint: number;
+  /** Value change for one rate point (1%). */
+  rhoPerPoint: number;
+}
+
+const ZERO_GREEKS = { delta: 0, gamma: 0, thetaPerDay: 0, vegaPerPoint: 0, rhoPerPoint: 0 };
+
+/** Abramowitz & Stegun 26.2.17; |error| < 7.5e-8, well inside display precision. */
+function normalCdf(x: number): number {
+  const sign = x < 0 ? -1 : 1;
+  const z = Math.abs(x) / Math.SQRT2;
+  const t = 1 / (1 + 0.3275911 * z);
+  const poly = ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t - 0.284496736) * t + 0.254829592) * t;
+  return 0.5 * (1 + sign * (1 - poly * Math.exp(-z * z)));
+}
+
+function normalPdf(x: number): number {
+  return Math.exp(-0.5 * x * x) / Math.sqrt(2 * Math.PI);
+}
+
+function finite(value: number, fallback = 0): number {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+/**
+ * Value with no optionality left: the discounted forward payoff. Covers expiry,
+ * zero volatility, and a zero spot or strike, all of which make the
+ * Black-Scholes ratios divide by zero.
+ */
+function intrinsicValuation(
+  side: OptionSide,
+  spot: number,
+  strike: number,
+  years: number,
+  rate: number,
+  dividendYield: number,
+): OptionValuation {
+  const discountedSpot = spot * Math.exp(-dividendYield * years);
+  const discountedStrike = strike * Math.exp(-rate * years);
+  const inTheMoney = side === "call" ? discountedSpot > discountedStrike : discountedStrike > discountedSpot;
+  const price = side === "call"
+    ? Math.max(0, discountedSpot - discountedStrike)
+    : Math.max(0, discountedStrike - discountedSpot);
+  return {
+    ...ZERO_GREEKS,
+    price,
+    delta: inTheMoney ? (side === "call" ? Math.exp(-dividendYield * years) : -Math.exp(-dividendYield * years)) : 0,
+  };
+}
+
+/** Black-Scholes-Merton for European calls and puts with a continuous dividend yield. */
+export function valueOption(draft: OptionCalcDraft): OptionValuation {
+  const spot = Math.max(0, finite(draft.spot));
+  const strike = Math.max(0, finite(draft.strike));
+  const years = Math.max(0, finite(draft.daysToExpiry)) / DAYS_PER_YEAR;
+  const rate = finite(draft.rate);
+  const dividendYield = finite(draft.dividendYield);
+  const volatility = Math.max(0, finite(draft.volatility));
+  const { side } = draft;
+
+  if (years <= 0 || volatility <= 0 || spot <= 0 || strike <= 0) {
+    return intrinsicValuation(side, spot, strike, years, rate, dividendYield);
+  }
+
+  const sqrtYears = Math.sqrt(years);
+  const carryFactor = Math.exp(-dividendYield * years);
+  const discountFactor = Math.exp(-rate * years);
+  const d1 = (Math.log(spot / strike) + (rate - dividendYield + volatility * volatility / 2) * years)
+    / (volatility * sqrtYears);
+  const d2 = d1 - volatility * sqrtYears;
+  const pdf = normalPdf(d1);
+
+  const price = side === "call"
+    ? spot * carryFactor * normalCdf(d1) - strike * discountFactor * normalCdf(d2)
+    : strike * discountFactor * normalCdf(-d2) - spot * carryFactor * normalCdf(-d1);
+
+  const thetaPerYear = side === "call"
+    ? -(spot * pdf * volatility * carryFactor) / (2 * sqrtYears)
+      - rate * strike * discountFactor * normalCdf(d2)
+      + dividendYield * spot * carryFactor * normalCdf(d1)
+    : -(spot * pdf * volatility * carryFactor) / (2 * sqrtYears)
+      + rate * strike * discountFactor * normalCdf(-d2)
+      - dividendYield * spot * carryFactor * normalCdf(-d1);
+
+  const rhoPerUnit = side === "call"
+    ? strike * years * discountFactor * normalCdf(d2)
+    : -strike * years * discountFactor * normalCdf(-d2);
+
+  return {
+    price: Math.max(0, price),
+    delta: side === "call" ? carryFactor * normalCdf(d1) : carryFactor * (normalCdf(d1) - 1),
+    gamma: carryFactor * pdf / (spot * volatility * sqrtYears),
+    thetaPerDay: thetaPerYear / DAYS_PER_YEAR,
+    vegaPerPoint: spot * carryFactor * pdf * sqrtYears / 100,
+    rhoPerPoint: rhoPerUnit / 100,
+  };
+}
+
+export interface ImpliedVolatilityResult {
+  volatility: number | null;
+  /** Why no volatility could be solved, phrased for the pane body. */
+  note: string | null;
+}
+
+/**
+ * Price rises monotonically with volatility, so bisection always converges and
+ * cannot diverge the way a Newton step can near zero vega. The arbitrage bounds
+ * are checked first: outside them no volatility exists at all.
+ */
+export function solveImpliedVolatility(
+  draft: OptionCalcDraft,
+  marketPrice: number,
+): ImpliedVolatilityResult {
+  if (!Number.isFinite(marketPrice) || marketPrice <= 0) return { volatility: null, note: null };
+  if (!(draft.daysToExpiry > 0)) return { volatility: null, note: "expired, no implied volatility" };
+  if (!(draft.spot > 0) || !(draft.strike > 0)) return { volatility: null, note: "needs a positive spot and strike" };
+
+  const years = draft.daysToExpiry / DAYS_PER_YEAR;
+  const discountedSpot = draft.spot * Math.exp(-draft.dividendYield * years);
+  const discountedStrike = draft.strike * Math.exp(-draft.rate * years);
+  const lowerBound = draft.side === "call"
+    ? Math.max(0, discountedSpot - discountedStrike)
+    : Math.max(0, discountedStrike - discountedSpot);
+  const upperBound = draft.side === "call" ? discountedSpot : discountedStrike;
+  if (marketPrice < lowerBound - 1e-8) {
+    return { volatility: null, note: "market price is below intrinsic value" };
+  }
+  if (marketPrice > upperBound + 1e-8) {
+    return { volatility: null, note: "market price is above the no-arbitrage maximum" };
+  }
+
+  const priceAt = (volatility: number) => valueOption({ ...draft, volatility }).price;
+  const floor = priceAt(MIN_VOLATILITY);
+  const cap = priceAt(MAX_VOLATILITY);
+  if (marketPrice < floor - 1e-8) return { volatility: null, note: "market price is below intrinsic value" };
+  if (marketPrice > cap) return { volatility: null, note: `market price implies volatility above ${MAX_VOLATILITY * 100}%` };
+
+  let low = MIN_VOLATILITY;
+  let high = MAX_VOLATILITY;
+  for (let i = 0; i < 100 && high - low > 1e-8; i += 1) {
+    const mid = (low + high) / 2;
+    if (priceAt(mid) > marketPrice) high = mid;
+    else low = mid;
+  }
+  return { volatility: (low + high) / 2, note: null };
+}
+
+export function describeDraftProblem(draft: OptionCalcDraft): string | null {
+  if (!(draft.spot > 0)) return "Spot must be positive.";
+  if (!(draft.strike > 0)) return "Strike must be positive.";
+  if (draft.daysToExpiry < 0) return "Days to expiry cannot be negative.";
+  if (draft.volatility < 0) return "Volatility cannot be negative.";
+  return null;
+}
+
+/** Time to the option date's 16:00 ET close, preserving live 0DTE time value. */
+export function daysToExpiryFrom(expirationSeconds: number, now: number): number {
+  if (!Number.isFinite(expirationSeconds)) return 0;
+  const expirationDate = new Date(expirationSeconds * 1000);
+  const close = zonedWallClockToUtcMs(
+    OPTION_EXPIRY_TIME_ZONE,
+    expirationDate.getUTCFullYear(),
+    expirationDate.getUTCMonth() + 1,
+    expirationDate.getUTCDate(),
+    16,
+    0,
+    0,
+  );
+  return Math.max(0, (close - now) / DAY_MS);
+}
+
+export interface OptionCalcSeed {
+  symbol?: string | null;
+  side?: OptionSide | null;
+  spot?: number | null;
+  strike?: number | null;
+  /** Unix seconds, as options chains report it. */
+  expiration?: number | null;
+  volatility?: number | null;
+  dividendYield?: number | null;
+  marketPrice?: number | null;
+}
+
+function positive(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+export function buildOptionCalcParams(
+  seed: OptionCalcSeed,
+  now: number = Date.now(),
+): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (seed.symbol) params.symbol = seed.symbol.toUpperCase();
+  if (seed.side) params.side = seed.side;
+  const spot = positive(seed.spot);
+  const strike = positive(seed.strike);
+  const volatility = positive(seed.volatility);
+  const marketPrice = positive(seed.marketPrice);
+  if (spot != null) params.spot = String(spot);
+  if (strike != null) params.strike = String(strike);
+  if (seed.expiration != null) params.days = String(daysToExpiryFrom(seed.expiration, now));
+  if (volatility != null) params.volatility = String(volatility);
+  if (marketPrice != null) params.marketPrice = String(marketPrice);
+  if (seed.dividendYield != null && Number.isFinite(seed.dividendYield) && seed.dividendYield > 0) {
+    params.dividendYield = String(seed.dividendYield);
+  }
+  return params;
+}
+
+function numberParam(params: Record<string, string>, key: string, fallback: number): number {
+  const parsed = Number(params[key]);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function draftFromParams(params: Record<string, string> | undefined): OptionCalcDraft {
+  if (!params) return DEFAULT_OPTION_CALC_DRAFT;
+  return {
+    symbol: params.symbol ?? DEFAULT_OPTION_CALC_DRAFT.symbol,
+    side: params.side === "put" ? "put" : "call",
+    spot: numberParam(params, "spot", DEFAULT_OPTION_CALC_DRAFT.spot),
+    strike: numberParam(params, "strike", DEFAULT_OPTION_CALC_DRAFT.strike),
+    daysToExpiry: numberParam(params, "days", DEFAULT_OPTION_CALC_DRAFT.daysToExpiry),
+    rate: numberParam(params, "rate", DEFAULT_OPTION_CALC_DRAFT.rate),
+    volatility: numberParam(params, "volatility", DEFAULT_OPTION_CALC_DRAFT.volatility),
+    dividendYield: numberParam(params, "dividendYield", DEFAULT_OPTION_CALC_DRAFT.dividendYield),
+    marketPrice: numberParam(params, "marketPrice", DEFAULT_OPTION_CALC_DRAFT.marketPrice),
+  };
+}

--- a/src/plugins/builtin/options-calculator/pane.test.tsx
+++ b/src/plugins/builtin/options-calculator/pane.test.tsx
@@ -1,0 +1,127 @@
+import { afterEach, expect, test } from "bun:test";
+import { useReducer } from "react";
+import { act } from "react";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import {
+  AppContext,
+  PaneInstanceProvider,
+  appReducer,
+  createInitialState,
+} from "../../../state/app/context";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
+import { PluginRenderProvider } from "../../runtime";
+import { cloneLayout, createDefaultConfig } from "../../../types/config";
+import { OPTIONS_CALCULATOR_PANE_ID } from "./model";
+import { OptionsCalculatorPane } from "./pane";
+
+const TEST_PANE_ID = "options-calculator:test";
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+function Harness({ params }: { params?: Record<string, string> }) {
+  const config = createDefaultConfig("/tmp/gloomberb-options-calculator-test");
+  config.layout = {
+    dockRoot: { kind: "pane", instanceId: TEST_PANE_ID },
+    instances: [{
+      instanceId: TEST_PANE_ID,
+      paneId: OPTIONS_CALCULATOR_PANE_ID,
+      binding: { kind: "none" },
+      params,
+    }],
+    floating: [],
+    detached: [],
+  };
+  config.layouts = [{ name: "Default", layout: cloneLayout(config.layout) }];
+
+  const initialState = createInitialState(config);
+  initialState.focusedPaneId = TEST_PANE_ID;
+  const [state, dispatch] = useReducer(appReducer, initialState);
+
+  return (
+    <AppContext value={{ state, dispatch }}>
+      <PaneInstanceProvider paneId={TEST_PANE_ID}>
+        <PluginRenderProvider pluginId="ticker-research" runtime={createTestPluginRuntime()}>
+          <OptionsCalculatorPane
+            paneId={TEST_PANE_ID}
+            paneType={OPTIONS_CALCULATOR_PANE_ID}
+            focused
+            width={90}
+            height={18}
+          />
+        </PluginRenderProvider>
+      </PaneInstanceProvider>
+    </AppContext>
+  );
+}
+
+async function render(params?: Record<string, string>) {
+  await act(async () => {
+    testSetup = await testRender(<Harness params={params} />, { width: 90, height: 18 });
+    await Promise.resolve();
+    await testSetup.renderOnce();
+  });
+  for (let i = 0; i < 3; i += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await testSetup!.renderOnce();
+    });
+  }
+}
+
+afterEach(async () => {
+  if (testSetup) {
+    await act(async () => { testSetup!.renderer.destroy(); });
+    testSetup = undefined;
+  }
+});
+
+test("prices the seeded contract and solves its implied volatility", async () => {
+  await render({
+    symbol: "AAPL",
+    side: "put",
+    spot: "100",
+    strike: "100",
+    days: "365",
+    rate: "0.05",
+    volatility: "0.2",
+    marketPrice: "5.5735",
+  });
+
+  const frame = testSetup!.captureCharFrame();
+  expect(frame).toContain("AAPL");
+  expect(frame).toContain("5.5735");
+  // The seeded market price is exactly the model put value, so IV solves back to 20%.
+  expect(frame).toMatch(/Implied IV\s+20\.00%/);
+  expect(frame).toContain("European exercise");
+});
+
+test("opens on defaults with no seed and leaves implied volatility empty", async () => {
+  await render();
+
+  const frame = testSetup!.captureCharFrame();
+  expect(frame).toContain("Spot");
+  expect(frame).toContain("Market");
+  expect(frame).toMatch(/Implied IV\s+—/);
+});
+
+test("tabs into fields and edits them from the keyboard", async () => {
+  await render();
+
+  await act(async () => {
+    testSetup!.mockInput.pressTab();
+    await testSetup!.renderOnce();
+  });
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await testSetup!.renderOnce();
+    await testSetup!.renderOnce();
+  });
+  await act(async () => {
+    await testSetup!.mockInput.typeText("120");
+    testSetup!.mockInput.pressEnter();
+    await testSetup!.renderOnce();
+    await testSetup!.renderOnce();
+  });
+
+  expect(testSetup!.captureCharFrame()).toMatch(/Spot\s+120/);
+});

--- a/src/plugins/builtin/options-calculator/pane.tsx
+++ b/src/plugins/builtin/options-calculator/pane.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useMemo, useState } from "react";
+import { SegmentedControl, usePaneFooter } from "../../../components";
+import { usePaneInstance, usePaneStateValue } from "../../../state/app/context";
+import { colors } from "../../../theme/colors";
+import type { PaneProps } from "../../../types/plugin";
+import { Box, Text, TextAttributes, useUiHost } from "../../../ui";
+import { formatNumber } from "../../../utils/format";
+import { isPlainKey } from "../../../utils/keyboard";
+import { useShortcut } from "../../../react/input";
+import type { InlineField } from "../kelly-sizer/fields";
+import { InlineFieldView, MetricLine, truncateText } from "../kelly-sizer/view";
+import {
+  OPTIONS_CALCULATOR_PANE_ID,
+  describeDraftProblem,
+  draftFromParams,
+  solveImpliedVolatility,
+  valueOption,
+  type OptionCalcDraft,
+  type OptionSide,
+} from "./model";
+
+const SIDE_OPTIONS = [
+  { label: "Call", value: "call" },
+  { label: "Put", value: "put" },
+];
+
+function formatSigned(value: number, decimals: number): string {
+  return `${value > 0 ? "+" : ""}${formatNumber(value, decimals)}`;
+}
+
+export function OptionsCalculatorPane({ focused, width, height }: PaneProps) {
+  const ui = useUiHost();
+  const paneInstance = usePaneInstance();
+  const [draft, setDraft] = usePaneStateValue<OptionCalcDraft>("draft", draftFromParams(paneInstance?.params));
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [activeFieldId, setActiveFieldId] = useState<string | null>(null);
+
+  const updateDraft = useCallback((patch: Partial<OptionCalcDraft>) => {
+    setDraft((current) => ({ ...current, ...patch }));
+  }, [setDraft]);
+
+  const fields = useMemo<InlineField[]>(() => [
+    { id: "spot", label: "Spot", value: draft.spot, onValue: (value) => updateDraft({ spot: value }) },
+    { id: "strike", label: "Strike", value: draft.strike, onValue: (value) => updateDraft({ strike: value }) },
+    {
+      id: "days",
+      label: "Days",
+      value: draft.daysToExpiry,
+      // Whole days read better than the shared 2-decimal number format.
+      valueText: String(Math.round(draft.daysToExpiry)),
+      suffix: "d",
+      onValue: (value) => updateDraft({ daysToExpiry: Math.max(0, value) }),
+    },
+    { id: "volatility", label: "Vol", value: draft.volatility, percent: true, onValue: (value) => updateDraft({ volatility: Math.max(0, value) }) },
+    { id: "rate", label: "Rate", value: draft.rate, percent: true, allowNegative: true, onValue: (value) => updateDraft({ rate: value }) },
+    { id: "dividendYield", label: "Div yld", value: draft.dividendYield, percent: true, onValue: (value) => updateDraft({ dividendYield: value }) },
+    {
+      id: "marketPrice",
+      label: "Market",
+      value: draft.marketPrice,
+      // Clearing the field is how a standalone user says "no market price".
+      onValue: (value) => updateDraft({ marketPrice: Math.max(0, value) }),
+      onClear: () => updateDraft({ marketPrice: 0 }),
+    },
+  ], [draft, updateDraft]);
+
+  const valuation = useMemo(() => valueOption(draft), [draft]);
+  const implied = useMemo(
+    () => solveImpliedVolatility(draft, draft.marketPrice),
+    [draft],
+  );
+  const problem = describeDraftProblem(draft);
+
+  const setSide = useCallback((side: OptionSide) => updateDraft({ side }), [updateDraft]);
+  const moveFieldFocus = useCallback((offset: -1 | 1) => {
+    const nextIndex = activeFieldId
+      ? (selectedIndex + offset + fields.length) % fields.length
+      : offset > 0 ? 0 : fields.length - 1;
+    setSelectedIndex(nextIndex);
+    setActiveFieldId(fields[nextIndex]?.id ?? null);
+  }, [activeFieldId, fields, selectedIndex]);
+
+  useShortcut((event) => {
+    if (event.defaultPrevented || event.propagationStopped) return;
+    const plainTab = event.name === "tab"
+      && !event.ctrl && !event.meta && !event.super && !event.alt;
+    if (plainTab) {
+      event.preventDefault();
+      event.stopPropagation();
+      moveFieldFocus(event.shift ? -1 : 1);
+      return;
+    }
+    if (event.targetEditable) {
+      if (activeFieldId && isPlainKey(event, "escape", "esc")) {
+        event.preventDefault();
+        event.stopPropagation();
+        setActiveFieldId(null);
+      }
+      return;
+    }
+    if (ui.kind === "desktop-web" && isPlainKey(event, "left", "right")) {
+      event.preventDefault();
+      event.stopPropagation();
+      setSide(event.name === "left" ? "call" : "put");
+    } else if (isPlainKey(event, "enter", "return", "e")) {
+      event.preventDefault();
+      event.stopPropagation();
+      setActiveFieldId(fields[selectedIndex]?.id ?? null);
+    }
+  }, { allowEditable: true, enabled: focused });
+
+  usePaneFooter(OPTIONS_CALCULATOR_PANE_ID, () => ({
+    info: problem
+      ? [{ id: "input", parts: [{ text: problem, tone: "warning" as const }] }]
+      : implied.note
+        ? [{ id: "iv", parts: [{ text: implied.note, tone: "warning" as const }] }]
+        : [],
+  }), [implied.note, problem]);
+
+  const columns = width >= 78 ? 3 : width >= 42 ? 2 : 1;
+  const fieldWidth = Math.max(12, Math.min(26, Math.floor((width - 2) / columns)));
+  const rows = Math.max(1, Math.ceil(fields.length / columns));
+  const pairMetrics = width >= 50;
+  const metricWidth = pairMetrics ? Math.floor((width - 2) / 2) : Math.max(1, width - 2);
+  const trailingMetricWidth = pairMetrics ? Math.max(1, width - 2 - metricWidth) : metricWidth;
+  const showGreeks = height >= 1 + rows + 1 + (pairMetrics ? 1 : 2) + (pairMetrics ? 3 : 5) + 1;
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      <Box height={1} paddingX={1} flexDirection="row" gap={1}>
+        <SegmentedControl
+          options={SIDE_OPTIONS}
+          value={draft.side}
+          onChange={(value) => setSide(value as OptionSide)}
+          focused={focused && !activeFieldId}
+          shortcutScope="options-calculator:side"
+        />
+        {draft.symbol ? (
+          <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
+            {truncateText(draft.symbol, Math.max(0, width - 20))}
+          </Text>
+        ) : null}
+      </Box>
+
+      <Box flexDirection="column" paddingX={1} height={rows}>
+        {Array.from({ length: rows }, (_, rowIndex) => (
+          <Box key={rowIndex} height={1} flexDirection="row">
+            {fields.slice(rowIndex * columns, rowIndex * columns + columns).map((field, offset) => {
+              const index = rowIndex * columns + offset;
+              return (
+                <InlineFieldView
+                  key={field.id}
+                  field={field}
+                  active={activeFieldId === field.id}
+                  focused={focused}
+                  width={fieldWidth}
+                  onFocus={() => {
+                    setSelectedIndex(index);
+                    setActiveFieldId(field.id);
+                  }}
+                />
+              );
+            })}
+          </Box>
+        ))}
+      </Box>
+
+      <Box height={1} />
+
+      <Box flexDirection={pairMetrics ? "row" : "column"} paddingX={1}>
+        <MetricLine
+          label="Fair value"
+          value={formatNumber(valuation.price, 4)}
+          detail={draft.side === "call" ? "call" : "put"}
+          color={colors.textBright}
+          width={metricWidth}
+        />
+        <MetricLine
+          label="Implied IV"
+          value={implied.volatility != null ? `${formatNumber(implied.volatility * 100, 2)}%` : "—"}
+          detail={implied.volatility != null ? "from market" : undefined}
+          color={implied.volatility != null ? colors.positive : colors.textDim}
+          width={trailingMetricWidth}
+        />
+      </Box>
+
+      {showGreeks ? (
+        <Box flexDirection="column" paddingX={1}>
+          <Box flexDirection={pairMetrics ? "row" : "column"}>
+            <MetricLine label="Delta" value={formatSigned(valuation.delta, 4)} width={metricWidth} />
+            <MetricLine label="Gamma" value={formatNumber(valuation.gamma, 4)} width={trailingMetricWidth} />
+          </Box>
+          <Box flexDirection={pairMetrics ? "row" : "column"}>
+            <MetricLine label="Theta" value={formatSigned(valuation.thetaPerDay, 4)} detail="per day" width={metricWidth} />
+            <MetricLine label="Vega" value={formatNumber(valuation.vegaPerPoint, 4)} detail="per vol pt" width={trailingMetricWidth} />
+          </Box>
+          <MetricLine label="Rho" value={formatSigned(valuation.rhoPerPoint, 4)} detail="per rate pt" width={metricWidth} />
+        </Box>
+      ) : null}
+
+      <Box flexGrow={1} />
+
+      <Box height={1} paddingX={1} overflow="hidden">
+        <Text fg={colors.textMuted}>
+          {truncateText(
+            "European exercise only: no early exercise or discrete dividends.",
+            Math.max(1, width - 2),
+          )}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/plugins/builtin/options/calc-seed.test.ts
+++ b/src/plugins/builtin/options/calc-seed.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import type { OptionContract } from "../../../types/financials";
+import { draftFromParams } from "../options-calculator/model";
+import { buildChainCalcParams, resolveCalcSide } from "./calc-seed";
+import type { OptionTableRow } from "./types";
+
+const NOW = Date.UTC(2026, 7, 20, 18, 0, 0);
+const EXPIRATION = Date.UTC(2026, 8, 19) / 1000;
+
+function contract(overrides: Partial<OptionContract> = {}): OptionContract {
+  return {
+    contractSymbol: "AAPL260919C00230000",
+    strike: 230,
+    currency: "USD",
+    lastPrice: 7.35,
+    change: 0,
+    percentChange: 0,
+    volume: 10,
+    openInterest: 100,
+    bid: 7.2,
+    ask: 7.5,
+    impliedVolatility: 0.284,
+    inTheMoney: true,
+    expiration: EXPIRATION,
+    lastTradeDate: 0,
+    ...overrides,
+  };
+}
+
+function row(overrides: Partial<OptionTableRow> = {}): OptionTableRow {
+  return { strike: 230, call: contract(), put: contract(), isPositionStrike: false, ...overrides };
+}
+
+describe("resolveCalcSide", () => {
+  test("uses the explicit side a call or put cell click chose", () => {
+    expect(resolveCalcSide("put", "C", row())).toBe("put");
+  });
+
+  test("prefers the side of an option position when nothing was clicked", () => {
+    expect(resolveCalcSide(null, "P", row())).toBe("put");
+    expect(resolveCalcSide(null, "C", row())).toBe("call");
+  });
+
+  test("defaults to the call without a position", () => {
+    expect(resolveCalcSide(null, null, row())).toBe("call");
+  });
+
+  test("falls back to whichever contract the strike actually has", () => {
+    expect(resolveCalcSide("call", null, row({ call: undefined }))).toBe("put");
+    expect(resolveCalcSide(null, "P", row({ put: undefined }))).toBe("call");
+    expect(resolveCalcSide("call", null, row({ call: undefined, put: undefined }))).toBeNull();
+    expect(resolveCalcSide("call", null, null)).toBeNull();
+  });
+});
+
+describe("buildChainCalcParams", () => {
+  test("seeds the calculator from the selected contract", () => {
+    const params = buildChainCalcParams({
+      symbol: "AAPL",
+      row: row(),
+      side: "put",
+      spot: 231.5,
+      dividendYield: 0.0044,
+      now: NOW,
+    });
+
+    expect(draftFromParams(params!)).toMatchObject({
+      symbol: "AAPL",
+      side: "put",
+      spot: 231.5,
+      strike: 230,
+      volatility: 0.284,
+      marketPrice: 7.35,
+      dividendYield: 0.0044,
+    });
+    expect(draftFromParams(params!).daysToExpiry).toBeCloseTo(30 + 2 / 24, 8);
+  });
+
+  test("uses the mid when the contract has not traded", () => {
+    const params = buildChainCalcParams({
+      symbol: "AAPL",
+      row: row({ call: contract({ lastPrice: 0, bid: 7, ask: 8 }) }),
+      side: "call",
+      spot: 231.5,
+      dividendYield: null,
+      now: NOW,
+    });
+
+    expect(draftFromParams(params!).marketPrice).toBe(7.5);
+  });
+
+  test("returns nothing without a contract or a trustworthy underlying spot", () => {
+    expect(buildChainCalcParams({
+      symbol: "AAPL",
+      row: row({ put: undefined }),
+      side: "put",
+      spot: 231.5,
+      dividendYield: null,
+      now: NOW,
+    })).toBeNull();
+    expect(buildChainCalcParams({
+      symbol: "AAPL",
+      row: null,
+      side: null,
+      spot: 231.5,
+      dividendYield: null,
+      now: NOW,
+    })).toBeNull();
+    expect(buildChainCalcParams({
+      symbol: "AAPL",
+      row: row(),
+      side: "call",
+      spot: null,
+      dividendYield: null,
+      now: NOW,
+    })).toBeNull();
+  });
+});

--- a/src/plugins/builtin/options/calc-seed.ts
+++ b/src/plugins/builtin/options/calc-seed.ts
@@ -1,0 +1,52 @@
+import type { OptionContract } from "../../../types/financials";
+import { buildOptionCalcParams, type OptionSide } from "../options-calculator/model";
+import type { OptionTableRow } from "./types";
+
+/**
+ * Which contract the calculator should open on. An explicit pick (clicking a
+ * call or put cell) wins; otherwise an option position's own side is preferred,
+ * then calls, then whichever side the strike actually has.
+ */
+export function resolveCalcSide(
+  explicitSide: OptionSide | null,
+  positionSide: "C" | "P" | null | undefined,
+  row: OptionTableRow | null | undefined,
+): OptionSide | null {
+  if (!row) return null;
+  const preferred = explicitSide ?? (positionSide === "P" ? "put" : "call");
+  if (preferred === "call" && row.call) return "call";
+  if (preferred === "put" && row.put) return "put";
+  if (row.call) return "call";
+  if (row.put) return "put";
+  return null;
+}
+
+/** Last trade when there is one, otherwise the mid; never a one-sided quote. */
+function contractMarketPrice(contract: OptionContract): number {
+  if (contract.lastPrice > 0) return contract.lastPrice;
+  return contract.bid > 0 && contract.ask > 0 ? (contract.bid + contract.ask) / 2 : 0;
+}
+
+export function buildChainCalcParams(options: {
+  symbol: string;
+  row: OptionTableRow | null | undefined;
+  side: OptionSide | null;
+  spot: number | null | undefined;
+  dividendYield: number | null | undefined;
+  now?: number;
+}): Record<string, string> | null {
+  const { row, side } = options;
+  const contract = side === "put" ? row?.put : side === "call" ? row?.call : undefined;
+  if (!contract || !(options.spot != null && Number.isFinite(options.spot) && options.spot > 0)) return null;
+
+  return buildOptionCalcParams({
+    symbol: options.symbol,
+    side,
+    spot: options.spot,
+    strike: contract.strike,
+    expiration: contract.expiration,
+    volatility: contract.impliedVolatility,
+    marketPrice: contractMarketPrice(contract),
+    dividendYield: options.dividendYield,
+  }, options.now);
+}

--- a/src/plugins/builtin/options/footer.ts
+++ b/src/plugins/builtin/options/footer.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { PaneFooterSegment } from "../../../components";
+import type { PaneFooterSegment, PaneHint } from "../../../components";
 import { t, tf } from "../../../i18n";
 import type { OptionsChain } from "../../../types/financials";
 import { useCloudAccessFooter } from "../shared/cloud-upgrade";
@@ -31,12 +31,14 @@ export function useOptionsAccessFooter({
   chain,
   error,
   focused,
+  hints,
   loading,
   quoteCoverage,
 }: {
   chain: OptionsChain | null | undefined;
   error?: string | null;
   focused: boolean;
+  hints?: PaneHint[];
   loading?: boolean;
   quoteCoverage: Pick<OptionQuoteCoverage, "status">;
 }): void {
@@ -63,5 +65,6 @@ export function useOptionsAccessFooter({
     loading,
     error,
     info,
+    hints,
   });
 }

--- a/src/plugins/builtin/options/view.test.tsx
+++ b/src/plugins/builtin/options/view.test.tsx
@@ -10,6 +10,8 @@ import type { QuoteSubscriptionTarget } from "../../../types/data-provider";
 import type { OptionContract, OptionsChain, Quote, TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 import { formatExpDate } from "../../../utils/options";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
+import { PluginRenderProvider } from "../../runtime";
 import { OptionsView } from "./view";
 
 const TEST_PANE_ID = "ticker-detail:options-test";
@@ -115,7 +117,9 @@ function OptionsHarness({
   return (
     <AppContext value={{ state, dispatch: () => {} }}>
       <PaneInstanceProvider paneId={TEST_PANE_ID}>
-        <OptionsView width={width} height={14} focused onCapture={onCapture} />
+        <PluginRenderProvider pluginId="ticker-research" runtime={createTestPluginRuntime()}>
+          <OptionsView width={width} height={14} focused onCapture={onCapture} />
+        </PluginRenderProvider>
       </PaneInstanceProvider>
     </AppContext>
   );

--- a/src/plugins/builtin/options/view.tsx
+++ b/src/plugins/builtin/options/view.tsx
@@ -4,7 +4,7 @@ import { usePaneSettingValue, usePaneTicker } from "../../../state/app/context";
 import { colors } from "../../../theme/colors";
 import { isPlainKey } from "../../../utils/keyboard";
 import { formatExpDate, resolveOptionsTarget } from "../../../utils/options";
-import { useOptionsQuery, useResolvedEntryValue } from "../../../market-data/hooks";
+import { useOptionsQuery, useResolvedEntryValue, useTickerFinancials } from "../../../market-data/hooks";
 import {
   DataTableView,
   EmptyState,
@@ -15,6 +15,12 @@ import {
 } from "../../../components";
 import { useShortcut } from "../../../react/input";
 import { useLiveQuoteEntries } from "../../../state/hooks/quote-streaming";
+import { usePluginAppActions } from "../../runtime";
+import {
+  OPTIONS_CALCULATOR_TEMPLATE_ID,
+  type OptionSide,
+} from "../options-calculator/model";
+import { buildChainCalcParams, resolveCalcSide } from "./calc-seed";
 import {
   OPTION_COLUMNS,
   buildStrikeList,
@@ -35,8 +41,10 @@ import { useLiveStreamingSetting } from "../shared/live-streaming";
 
 export function OptionsView({ width, height, focused, onCapture = () => {} }: OptionsViewProps) {
   const { ticker, financials } = usePaneTicker();
+  const { createPaneFromTemplate } = usePluginAppActions();
   const liveStreaming = useLiveStreamingSetting();
   const [expIdx, setExpIdx] = useState(0);
+  const [calcSide, setCalcSide] = useState<OptionSide | null>(null);
   const [strikeIdx, setStrikeIdx] = useState(0);
   const [autoScrollVersion, setAutoScrollVersion] = useState(0);
   const [scrollToIndexAlign, setScrollToIndexAlign] = useState<"nearest" | "center">("nearest");
@@ -52,6 +60,7 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
   const parsed = target?.parsedOption ?? null;
   const effectiveTicker = target?.effectiveTicker ?? "";
   const effectiveExchange = target?.effectiveExchange ?? "";
+  const underlyingFinancials = useTickerFinancials(isOpt ? effectiveTicker : null, null);
   const instrument = target?.instrument ?? null;
   const baseRequest = target
     ? {
@@ -123,6 +132,7 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     onCaptureRef.current(false);
     setExpIdx(0);
     setStrikeIdx(0);
+    setCalcSide(null);
   }, [effectiveTicker]);
 
   useEffect(() => {
@@ -205,10 +215,55 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     headerColor: optionColumnColor(column.id, colors.panel),
   }));
 
+  const selectedRow = rows[strikeIdx] ?? null;
+  const calcParams = useMemo(() => buildChainCalcParams({
+    symbol: effectiveTicker,
+    row: selectedRow,
+    side: resolveCalcSide(calcSide, parsed?.side, selectedRow),
+    // On an option ticker the pane quote is the contract's own price, so load
+    // the underlying snapshot rather than silently using the option mark as spot.
+    spot: (isOpt ? underlyingFinancials : financials)?.quote?.price,
+    dividendYield: (isOpt ? underlyingFinancials : financials)?.fundamentals?.dividendYield,
+  }), [calcSide, effectiveTicker, financials, isOpt, parsed?.side, selectedRow, underlyingFinancials]);
+
+  const openCalculator = useCallback(() => {
+    if (!calcParams) return;
+    createPaneFromTemplate(OPTIONS_CALCULATOR_TEMPLATE_ID, { values: calcParams });
+  }, [calcParams, createPaneFromTemplate]);
+
+  const footerHints = useMemo(
+    () => (calcParams ? [{ id: "calc", key: "c", label: "alc", onPress: openCalculator }] : undefined),
+    [calcParams, openCalculator],
+  );
+
+  const renderCell = useCallback((
+    row: OptionTableRow,
+    column: OptionColumn,
+    index: number,
+    rowState: { selected: boolean },
+  ) => {
+    const cell = renderOptionCell(row, column, index, rowState);
+    if (column.id === "strike") return cell;
+    // Clicking a call or put cell is the mouse way to choose which contract
+    // [c]alc opens, so it has to select the row itself as well.
+    const side: OptionSide = column.id.startsWith("call") ? "call" : "put";
+    return {
+      ...cell,
+      onMouseDown: () => {
+        enterInteractive();
+        userSelectedStrikeRef.current = true;
+        setScrollToIndexAlign("nearest");
+        setStrikeIdx(index);
+        setCalcSide(side);
+      },
+    };
+  }, [enterInteractive]);
+
   useOptionsAccessFooter({
     chain,
     error,
     focused,
+    hints: footerHints,
     loading,
     quoteCoverage: optionQuoteCoverage,
   });
@@ -257,6 +312,12 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
       event.preventDefault();
       event.stopPropagation();
       selectAdjacentExpiration(1);
+      return;
+    }
+    if (isPlainKey(event, "c") && calcParams) {
+      event.preventDefault();
+      event.stopPropagation();
+      openCalculator();
     }
   }, { enabled: focused, phase: "before" });
 
@@ -288,6 +349,13 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
       return true;
     }
 
+    if (isPlainKey(event, "c") && calcParams) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      openCalculator();
+      return true;
+    }
+
     if (isPlainKey(event, "j", "down")) {
       if (strikes.length === 0) return true;
       event.preventDefault?.();
@@ -308,7 +376,15 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     }
 
     return false;
-  }, [enterInteractive, exitInteractive, interactive, selectAdjacentExpiration, strikes.length]);
+  }, [
+    calcParams,
+    enterInteractive,
+    exitInteractive,
+    interactive,
+    openCalculator,
+    selectAdjacentExpiration,
+    strikes.length,
+  ]);
 
   if (!ticker) {
     return <EmptyState title="No ticker selected." message="Select a ticker to view options." />;
@@ -392,7 +468,7 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
         visibleRangeKey={viewportKey}
         onVisibleRangeChange={handleVisibleStrikeRangeChange}
         getItemKey={(row) => String(row.strike)}
-        renderCell={renderOptionCell}
+        renderCell={renderCell}
         emptyStateTitle={strikesLoading ? "Loading strikes..." : "No strikes available."}
         rootWidth={Math.max(1, width - 2)}
         rootHeight={tableHeight}

--- a/src/plugins/builtin/ticker-research-plugin.ts
+++ b/src/plugins/builtin/ticker-research-plugin.ts
@@ -3,6 +3,7 @@ import { dividendYieldModule } from "./dividend-yield";
 import { holdersModule } from "./holders";
 import { insiderModule } from "./insider";
 import { optionsModule } from "./options";
+import { optionsCalculatorModule } from "./options-calculator";
 import { composeBuiltinPlugin } from "./plugin-module";
 import { researchModule } from "./research";
 import { secModule } from "./sec";
@@ -20,6 +21,7 @@ export const tickerResearchPlugin = composeBuiltinPlugin({
     tickerDetailModule,
     chartComposerModule,
     optionsModule,
+    optionsCalculatorModule,
     researchModule,
     dividendYieldModule,
     holdersModule,

--- a/src/renderers/electrobun/view/desktop/controls.test.tsx
+++ b/src/renderers/electrobun/view/desktop/controls.test.tsx
@@ -1,0 +1,68 @@
+/** @jsxImportSource react */
+import { Window } from "happy-dom";
+
+const testWindow = new Window({ url: "http://localhost" });
+Object.assign(globalThis, {
+  IS_REACT_ACT_ENVIRONMENT: true,
+  window: testWindow,
+  document: testWindow.document,
+  navigator: testWindow.navigator,
+  KeyboardEvent: testWindow.KeyboardEvent,
+  HTMLElement: testWindow.HTMLElement,
+  Node: testWindow.Node,
+});
+
+import { expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { UiHostProvider, type RendererHost, type UiHost } from "../../../../ui";
+import { WebBox } from "../host/box";
+import { WebText } from "../host/text";
+import { WebSegmentedControl } from "./controls";
+
+const renderer: RendererHost = {
+  requestExit() {},
+  async openExternal() {},
+  async copyText() {},
+  async readText() { return ""; },
+  notify() {},
+};
+
+const ui = {
+  kind: "desktop-web",
+  capabilities: { cellWidthPx: 8, fractionalViewport: true },
+  Box: WebBox,
+  Text: WebText,
+} as unknown as UiHost;
+
+test("desktop segmented controls expose radio semantics and keyboard selection", async () => {
+  const selected: string[] = [];
+  const container = testWindow.document.createElement("div");
+  testWindow.document.body.appendChild(container);
+  const root = createRoot(container as unknown as HTMLElement);
+  await act(async () => {
+    root.render(
+      <UiHostProvider ui={ui} renderer={renderer}>
+        <WebSegmentedControl
+          options={[{ label: "Call", value: "call" }, { label: "Put", value: "put" }]}
+          value="call"
+          onChange={(value) => selected.push(value)}
+        />
+      </UiHostProvider>,
+    );
+  });
+
+  const group = container.querySelector('[role="radiogroup"]');
+  const radios = [...container.querySelectorAll('[role="radio"]')] as unknown as HTMLElement[];
+  expect(group).not.toBeNull();
+  expect(radios.map((radio) => radio.getAttribute("aria-checked"))).toEqual(["true", "false"]);
+
+  await act(async () => {
+    radios[0]!.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    radios[1]!.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+  });
+  expect(selected).toEqual(["put", "put"]);
+
+  await act(async () => root.unmount());
+  container.remove();
+});

--- a/src/renderers/electrobun/view/desktop/controls.tsx
+++ b/src/renderers/electrobun/view/desktop/controls.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useRef, type RefObject } from "react";
+import { useRef, type KeyboardEvent, type RefObject } from "react";
 import { Box, Input, Text, Textarea, editableTextContextMenuItems, useRendererHost, useUiCapabilities } from "../../../../ui";
 import { TextAttributes, type InputRenderable } from "../../../../ui";
 import { useShortcut } from "../../../../react/input";
@@ -382,10 +382,18 @@ export function WebSegmentedControl({
   onChange,
 }: SegmentedControlProps) {
   const colors = useThemeColors();
+  const enabled = options.filter((option) => !option.disabled);
+  const selectAdjacent = (direction: -1 | 1) => {
+    const index = enabled.findIndex((option) => option.value === value);
+    const next = enabled[index < 0 ? 0 : (index + direction + enabled.length) % enabled.length];
+    if (next) onChange?.(next.value);
+  };
+
   return (
     <Box
       flexDirection="row"
       backgroundColor={panelFill(colors)}
+      role="radiogroup"
       style={{
         border: `1px solid ${panelBorder(colors)}`,
         borderRadius: CONTROL_RADIUS,
@@ -406,6 +414,22 @@ export function WebSegmentedControl({
               if (!option.disabled) onChange?.(option.value);
             }}
             data-gloom-interactive={option.disabled ? undefined : "true"}
+            role="radio"
+            aria-checked={active}
+            aria-disabled={option.disabled || undefined}
+            tabIndex={option.disabled ? -1 : 0}
+            onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+              if (option.disabled) return;
+              if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+                event.preventDefault();
+                event.stopPropagation();
+                selectAdjacent(event.key === "ArrowLeft" ? -1 : 1);
+              } else if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                event.stopPropagation();
+                onChange?.(option.value);
+              }
+            }}
             style={{
               borderRadius: CONTROL_RADIUS - 2,
               paddingInline: 10,

--- a/src/utils/zoned-date-time.ts
+++ b/src/utils/zoned-date-time.ts
@@ -1,0 +1,67 @@
+export interface ZonedDateTimeParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+const formatters = new Map<string, Intl.DateTimeFormat>();
+
+function formatter(timeZone: string): Intl.DateTimeFormat {
+  let value = formatters.get(timeZone);
+  if (!value) {
+    value = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hourCycle: "h23",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    formatters.set(timeZone, value);
+  }
+  return value;
+}
+
+export function zonedDateTimeParts(utcMs: number, timeZone: string): ZonedDateTimeParts {
+  const parts = new Map<string, string>();
+  for (const part of formatter(timeZone).formatToParts(new Date(utcMs))) {
+    if (part.type !== "literal") parts.set(part.type, part.value);
+  }
+  return {
+    year: Number(parts.get("year")),
+    month: Number(parts.get("month")),
+    day: Number(parts.get("day")),
+    hour: Number(parts.get("hour")),
+    minute: Number(parts.get("minute")),
+    second: Number(parts.get("second")),
+  };
+}
+
+function zonedOffsetMs(utcMs: number, timeZone: string): number {
+  const parts = zonedDateTimeParts(utcMs, timeZone);
+  const wallMs = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second);
+  return wallMs - Math.floor(utcMs / 1000) * 1000;
+}
+
+/** Convert a wall-clock reading in an IANA timezone to a real UTC instant. */
+export function zonedWallClockToUtcMs(
+  timeZone: string,
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  millisecond = 0,
+): number {
+  const wallMs = Date.UTC(year, month - 1, day, hour, minute, second, millisecond);
+  const firstOffset = zonedOffsetMs(wallMs, timeZone);
+  const candidate = wallMs - firstOffset;
+  const verifiedOffset = zonedOffsetMs(candidate, timeZone);
+  return wallMs - verifiedOffset;
+}


### PR DESCRIPTION
## Summary
- add `HALT`, a live Nasdaq Trader halt board with ET/DST-correct timestamps, reason/status filters, sorting, ticker navigation, refresh, and truthful connection health
- add `OVME`, an editable Black-Scholes call/put calculator with Greeks, no-arbitrage validation, implied volatility, and live 0DTE time through the 4pm ET close
- open `OVME` from the selected `OMON` contract with underlying spot, strike, expiry, IV, market price, dividend yield, and side prefilled
- make desktop segmented controls keyboard-accessible

## Validation
- `bun run typecheck`
- `bun test` (2,217 passing)
- tmux: live `HALT` feed, Active filter, `OMON AAPL` to `[c]alc`, editable `OVME`, and Connections reporting Nasdaq Trader as connected
