### PR TITLE
Keep calculator field focus inside pane

### DIFF
--- a/src/plugins/builtin/options-calculator/pane.test.tsx
+++ b/src/plugins/builtin/options-calculator/pane.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, expect, test } from "bun:test";
 import { useReducer } from "react";
 import { act } from "react";
+import { useShortcut } from "../../../react/input";
 import { testRender } from "../../../renderers/opentui/test-utils";
 import {
   AppContext,
@@ -17,6 +18,15 @@ import { OptionsCalculatorPane } from "./pane";
 const TEST_PANE_ID = "options-calculator:test";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+function GlobalTabHandler() {
+  useShortcut((event) => {
+    if (event.name !== "tab") return;
+    event.preventDefault();
+    event.stopPropagation();
+  }, { phase: "before" });
+  return null;
+}
 
 function Harness({ params }: { params?: Record<string, string> }) {
   const config = createDefaultConfig("/tmp/gloomberb-options-calculator-test");
@@ -39,6 +49,7 @@ function Harness({ params }: { params?: Record<string, string> }) {
 
   return (
     <AppContext value={{ state, dispatch }}>
+      <GlobalTabHandler />
       <PaneInstanceProvider paneId={TEST_PANE_ID}>
         <PluginRenderProvider pluginId="ticker-research" runtime={createTestPluginRuntime()}>
           <OptionsCalculatorPane

--- a/src/plugins/builtin/options-calculator/pane.tsx
+++ b/src/plugins/builtin/options-calculator/pane.tsx
@@ -107,7 +107,12 @@ export function OptionsCalculatorPane({ focused, width, height }: PaneProps) {
       event.stopPropagation();
       setActiveFieldId(fields[selectedIndex]?.id ?? null);
     }
-  }, { allowEditable: true, enabled: focused });
+  }, {
+    allowEditable: true,
+    enabled: focused,
+    phase: "before",
+    scope: "options-calculator:fields",
+  });
 
   usePaneFooter(OPTIONS_CALCULATOR_PANE_ID, () => ({
     info: problem


### PR DESCRIPTION
## Summary
- let `OVME` consume Tab before the app-wide pane focus shortcut
- keep calculator fields keyboard-editable in both the TUI and desktop app
- cover the real global-shortcut ordering in the pane test

## Validation
- `bun run typecheck`
- `bun test` (2,217 passing)
- isolated tmux: `HALT`, Active filter, standalone `OVME` edit, and `OMON AAPL` → `[c]alc`
- local Electrobun build: `HALT`, Active tab, standalone `OVME`, mouse and keyboard Call/Put, Tab field edit, and `OMON AAPL` → `[c]alc`
