### PR TITLE
fix(chart): show full-precision prices in legend and cursor

### DIFF
--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -38,6 +38,7 @@ import {
   compositeAxisTicks,
   formatCompositeAxisValue,
   formatCompositeCursorDate,
+  formatCompositeCursorValue,
   formatCompositePointDetails,
   formatCompositeSeriesValue,
   formatCompositeTimeAxisDate,
@@ -291,7 +292,7 @@ function cursorAxisLabel(
   const domain = panel.axes[side];
   if (!domain || cursorYRatio === null) return null;
   const value = unprojectCompositeValue(cursorYRatio, domain);
-  return value === null ? null : formatCompositeAxisValue(value, domain);
+  return value === null ? null : formatCompositeCursorValue(value, domain);
 }
 
 const MINIMUM_AXIS_LABEL_WIDTH = 3;
@@ -707,10 +708,10 @@ function CompositePanelSurface({
         domain: measureDomain,
       }),
       startValueLabel: measureDomain && startValue !== null
-        ? formatCompositeAxisValue(startValue, measureDomain)
+        ? formatCompositeCursorValue(startValue, measureDomain)
         : null,
       endValueLabel: measureDomain && endValue !== null
-        ? formatCompositeAxisValue(endValue, measureDomain)
+        ? formatCompositeCursorValue(endValue, measureDomain)
         : null,
     };
   }, [measureDomain, scene, toolDrag]);

--- a/src/components/chart/composite/format.test.ts
+++ b/src/components/chart/composite/format.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { CompositeChartScene } from "./types";
 import {
+  formatChartLegendValue,
   formatCompositeAxisValue,
   formatCompositeCursorDate,
+  formatCompositeCursorValue,
   formatCompositePointDetails,
   formatCompositeSeriesValue,
   formatCompositeTimeAxisDate,
@@ -146,5 +148,37 @@ describe("composite chart unit formatting", () => {
       unitGroup: "derived-unit:usd/jpy",
       seriesIds: ["ratio"],
     })).toBe("0.500");
+  });
+
+  test("shows full price precision in the legend and cursor, not compact axis ticks", () => {
+    const btc: ResolvedSeries = {
+      id: "btc",
+      label: "BTC-USD Price",
+      color: "#ffffff",
+      unit: "USD",
+      unitGroup: "price:USD",
+      nativeFrequency: "daily",
+      dataShape: "ohlcv",
+      style: "candles",
+      transform: "raw",
+      axis: "left",
+      panelId: "main",
+      interpolation: "none",
+      points: [],
+    };
+    const domain = {
+      side: "left" as const,
+      min: 70_000,
+      max: 80_000,
+      scale: "linear" as const,
+      unit: "USD",
+      unitGroup: "price:USD",
+      seriesIds: ["btc"],
+    };
+
+    expect(formatCompositeSeriesValue(79_432.18, btc)).toBe("$79,432.18");
+    expect(formatChartLegendValue(79_432.18, "USD", "price:USD")).toBe("$79,432.18");
+    expect(formatCompositeCursorValue(79_432.18, domain)).toBe("$79,432.18");
+    expect(formatCompositeAxisValue(79_432.18, domain)).toBe("$79K");
   });
 });

--- a/src/components/chart/composite/format.ts
+++ b/src/components/chart/composite/format.ts
@@ -1,3 +1,4 @@
+import { formatMarketPriceWithCurrency } from "../../../market-data/market/format";
 import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
 import type { CompositeAxisDomain } from "./types";
 
@@ -25,23 +26,37 @@ function compactNumber(value: number): string {
   return value.toPrecision(3);
 }
 
-function currencyPrefix(unit: string): string {
+function unitCurrencyCode(unit: string): string | null {
   const currency = unit.trim().toUpperCase().split(/[\s/]/)[0] ?? "";
-  return CURRENCY_SYMBOLS[currency] ?? "";
+  return CURRENCY_SYMBOLS[currency] ? currency : null;
+}
+
+function currencyPrefix(unit: string): string {
+  const currency = unitCurrencyCode(unit);
+  return currency ? CURRENCY_SYMBOLS[currency] ?? "" : "";
+}
+
+function formatFullCurrencyValue(value: number, unit: string): string | null {
+  const currency = unitCurrencyCode(unit);
+  return currency ? formatMarketPriceWithCurrency(value, currency) : null;
 }
 
 export function formatCompositeSeriesValue(value: number, series: ResolvedSeries): string {
-  const unit = series.unit.trim();
-  const group = series.unitGroup.toLowerCase();
+  return formatChartLegendValue(value, series.unit, series.unitGroup);
+}
+
+export function formatChartLegendValue(value: number, unit: string, unitGroup = ""): string {
+  const trimmed = unit.trim();
+  const group = unitGroup.toLowerCase();
   const compact = compactNumber(value);
-  if (group.includes("percent") || unit === "%" || unit.toLowerCase().includes("percent")) {
+  if (group.includes("percent") || trimmed === "%" || trimmed.toLowerCase().includes("percent")) {
     return `${compact}%`;
   }
-  if (group.includes("ratio") || unit.toLowerCase() === "x") return `${compact}x`;
-  if (group.startsWith("derived-unit:")) return `${compact} ${unit}`;
-  const currency = currencyPrefix(unit);
-  if (currency) return `${currency}${compact}`;
-  return unit && unit.length <= 6 ? `${compact}${unit.startsWith("/") ? "" : " "}${unit}` : compact;
+  if (group.includes("ratio") || trimmed.toLowerCase() === "x") return `${compact}x`;
+  if (group.startsWith("derived-unit:")) return `${compact} ${trimmed}`;
+  const fullPrice = formatFullCurrencyValue(value, trimmed);
+  if (fullPrice) return fullPrice;
+  return trimmed && trimmed.length <= 6 ? `${compact}${trimmed.startsWith("/") ? "" : " "}${trimmed}` : compact;
 }
 
 export function formatCompositeAxisValue(value: number, domain: CompositeAxisDomain): string {
@@ -53,6 +68,14 @@ export function formatCompositeAxisValue(value: number, domain: CompositeAxisDom
   // numeric so a narrow gutter cannot truncate USD/JPY into a false USD label.
   if (group.startsWith("derived-unit:")) return compact;
   return `${currencyPrefix(domain.unit)}${compact}`;
+}
+
+export function formatCompositeCursorValue(value: number, domain: CompositeAxisDomain): string {
+  const group = domain.unitGroup.toLowerCase();
+  if (group.startsWith("derived-unit:")) return compactNumber(value);
+  const fullPrice = formatFullCurrencyValue(value, domain.unit);
+  if (fullPrice) return fullPrice;
+  return formatCompositeAxisValue(value, domain);
 }
 
 export function compositeAxisTicks(domain: CompositeAxisDomain, count = 3): Array<{ ratio: number; value: number; label: string }> {

--- a/src/components/chart/core/axis-format.ts
+++ b/src/components/chart/core/axis-format.ts
@@ -1,4 +1,9 @@
-import { formatCompactMarketPriceWithCurrency, formatMarketPrice, resolveAssetDisplayKind } from "../../../market-data/market/format";
+import {
+  formatCompactMarketPriceWithCurrency,
+  formatMarketPrice,
+  formatMarketPriceWithCurrency,
+  resolveAssetDisplayKind,
+} from "../../../market-data/market/format";
 import type { ChartAxisMode } from "./types";
 
 export function formatPrice(
@@ -27,7 +32,7 @@ export function formatPriceWithCurrency(
   minimumFractionDigits = 0,
   fixedFractionDigits?: number,
 ): string {
-  return formatCompactMarketPriceWithCurrency(value, currency, {
+  return formatMarketPriceWithCurrency(value, currency, {
     assetCategory,
     fixedFractionDigits,
     minimumFractionDigits,
@@ -93,7 +98,11 @@ export function formatAxisValue(
   if (axisMode === "percent" && basePrice !== 0) {
     return formatPercentAxisValue(((value - basePrice) / basePrice) * 100);
   }
-  return formatPriceWithCurrency(value, currency, assetCategory, priceRange, 0, 0, fixedFractionDigits);
+  return formatCompactMarketPriceWithCurrency(value, currency, {
+    assetCategory,
+    fixedFractionDigits,
+    priceRange,
+  });
 }
 
 export function formatCursorAxisValue(
@@ -136,6 +145,7 @@ function getCursorAxisMinimumFractionDigits(value: number, assetCategory?: strin
     case "cash":
       return 4;
     case "crypto":
+      if (Math.abs(value) >= 100) return 2;
       return Math.abs(value) >= 1 ? 4 : 6;
     case "equity":
     case "contract":

--- a/src/components/chart/core/index.test.ts
+++ b/src/components/chart/core/index.test.ts
@@ -448,6 +448,13 @@ describe("renderChart", () => {
     expect(formatAxisValue(1.17364, "price", 0, "USD", "CURRENCY")).toBe("$1.17364");
   });
 
+  test("keeps legend and cursor prices precise while axis ticks stay compact", () => {
+    expect(formatAxisValue(79_432.18, "price", 0, "USD", "CRYPTO")).toBe("$79.4K");
+    expect(formatCursorAxisValue(79_432.18, "price", 0, "USD", "CRYPTO")).toBe("$79,432.18");
+    expect(formatAxisValue(79_432.18, "price", 0, "USD", "STK")).toBe("$79.4K");
+    expect(formatCursorAxisValue(79_432.18, "price", 0, "USD", "STK")).toBe("$79,432.18");
+  });
+
   test("adapts FX axis precision to the visible price range", () => {
     expect(formatAxisValue(1.167815, "price", 0, "USD", "CURRENCY", 0.12)).toBe("$1.17");
     expect(formatAxisValue(1.167815, "price", 0, "USD", "CURRENCY", 0.0024)).toBe("$1.1678");

--- a/src/components/chart/core/renderer.ts
+++ b/src/components/chart/core/renderer.ts
@@ -3,7 +3,6 @@ import type { ProjectedChartPoint } from "./data";
 import { buildTimeAxis } from "./time-axis";
 import {
   formatAxisValue,
-  formatPriceWithCurrency,
   getAxisFractionDigitFloor,
   resolveAxisFractionDigits,
 } from "./axis-format";
@@ -152,13 +151,13 @@ export function renderChart(
   const axisFractionDigits = axisMode === "price"
     ? resolveAxisFractionDigits(
       gridLines.map((line) => line.price),
-      (price, fixedFractionDigits) => formatPriceWithCurrency(
+      (price, fixedFractionDigits) => formatAxisValue(
         price,
+        axisMode,
+        points[0]!.close,
         currency,
         assetCategory,
         priceRange,
-        0,
-        0,
         fixedFractionDigits,
       ),
       getAxisFractionDigitFloor(assetCategory, priceRange),

--- a/src/market-data/market/format.test.ts
+++ b/src/market-data/market/format.test.ts
@@ -100,6 +100,13 @@ describe("formatMarketPriceWithCurrency", () => {
   test("preserves chart-style compact notation for large values", () => {
     expect(formatCompactMarketPriceWithCurrency(21_970, "JPY")).toBe("¥22.0K");
     expect(formatCompactMarketPriceWithCurrency(12_340, "HKD")).toBe("HK$12.3K");
+    expect(formatCompactMarketPriceWithCurrency(79_432.18, "USD", { assetCategory: "CRYPTO" })).toBe("$79.4K");
+  });
+
+  test("keeps full price precision for legend-style values", () => {
+    expect(formatMarketPriceWithCurrency(79_432.18, "USD", { assetCategory: "CRYPTO" })).toBe("$79,432.18");
+    expect(formatMarketPriceWithCurrency(79_432.18, "USD", { assetCategory: "STK" })).toBe("$79,432.18");
+    expect(formatMarketPriceWithCurrency(1.084567, "USD", { isCashBalance: true })).toBe("$1.084567");
   });
 
   test("formats position cost values with tighter equity precision", () => {


### PR DESCRIPTION
Compact $79k-style ticks stay on the axis. Legend, cursor, and share readouts use formatMarketPriceWithCurrency so BTC and similar assets show the actual price.