### PR TITLE
Fix quote, portfolio, and research data mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,11 @@ The toolbar controls preset or exact date ranges, intervals from one minute thro
 | `SB` | Toggle the status bar |
 | `VF` | Toggle quote value flashing |
 | `TH <theme>` | Change color theme |
+| `FONT+` / `FONT-` | Increase or decrease desktop font size |
+| `CONN` | Connection health |
+| `POLL` | Prediction-market polls |
+| `ART` | Loaded article lookup |
+| `UPGRADE` | Account upgrade |
 | `CR` | Cycle chart renderer |
 | `LANG <locale>` | Change interface language (`auto`, `en`, `es`, `zh-CN`, `zh-TW`, `ja`, or `ko`) |
 | `PL <plugin>` | Manage plugins |

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,7 +35,10 @@ import {
 } from "./commands/plugins";
 import { runPaneCatalog, runPaneFunction, runPaneScreenshot } from "./pane-functions";
 
-function createCoreCliCommands(renderHelp: () => string): CliCommandDef[] {
+function createCoreCliCommands(
+  renderHelp: () => string,
+  allCommands: () => CliCommandDef[],
+): CliCommandDef[] {
   let commands: CliCommandDef[] = [];
   const launchUiRequest: CliLaunchRequest = {
     applyConfig: (config) => ({ config }),
@@ -53,7 +56,7 @@ function createCoreCliCommands(renderHelp: () => string): CliCommandDef[] {
           console.log(renderHelp());
           return;
         }
-        ctx.printResult({ data: commands.map((command) => ({
+        ctx.printResult({ data: allCommands().map((command) => ({
           name: command.name,
           aliases: command.aliases ?? [],
           description: command.description,
@@ -190,7 +193,7 @@ function createCoreCliCommands(renderHelp: () => string): CliCommandDef[] {
     ...marketDataCliCommands,
     ...overviewCliCommands,
     remoteCliCommand,
-    ...createSystemCliCommands(() => commands),
+    ...createSystemCliCommands(allCommands),
     brokerCliCommand,
     ibkrCliCommand,
     aiCliCommand,
@@ -207,7 +210,10 @@ export interface DispatchCliOptions {
 async function createRegistry(options: DispatchCliOptions = {}): Promise<CliCommandRegistry> {
   const config = await loadCliConfigIfAvailable();
   let registry: CliCommandRegistry | null = null;
-  const coreCommands = createCoreCliCommands(() => renderCliHelp(registry!, VERSION));
+  const coreCommands = createCoreCliCommands(
+    () => renderCliHelp(registry!, VERSION),
+    () => registry!.commands.map((entry) => entry.command),
+  );
   registry = buildCliCommandRegistry({
     coreCommands,
     externalPlugins: options.externalPlugins ?? [],

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -208,7 +208,7 @@ export function buildCliCommandRegistry({
     commands,
     lookup,
     config,
-    plugins: loadablePlugins,
+    plugins: loadablePlugins.filter((plugin) => !disabledPlugins.has(plugin.id)),
     externalPlugins,
     descriptors,
   };

--- a/src/market-data/coordinator/index.test.ts
+++ b/src/market-data/coordinator/index.test.ts
@@ -810,8 +810,8 @@ describe("MarketDataCoordinator", () => {
         },
       );
 
-      expect(coordinator.getQuoteEntry(instrument).data).toBeNull();
-      expect(coordinator.getQuoteEntry(instrument).lastGoodData?.price).toBe(598);
+      expect(coordinator.getQuoteEntry(instrument).data?.price).toBe(598);
+      expect(coordinator.getQuoteEntry(instrument).data?.providerId).toBe("yahoo");
       expect(coordinator.getTickerFinancialsSync(instrument)?.quote?.price).toBe(598);
       expect(coordinator.getTickerFinancialsSync(instrument)?.quote?.providerId).toBe("yahoo");
     } finally {

--- a/src/market-data/coordinator/index.ts
+++ b/src/market-data/coordinator/index.ts
@@ -386,7 +386,7 @@ export class MarketDataCoordinator {
         && typeof quote.lastUpdated === "number"
         && quote.lastUpdated < snapshot.quote.lastUpdated
       ) {
-        return quote;
+        return snapshot.quote;
       }
     }
     const cachedFinancials = snapshot ?? this.readCachedFinancialsForInstrument(instrument);

--- a/src/market-data/market/freshness.ts
+++ b/src/market-data/market/freshness.ts
@@ -5,6 +5,7 @@ const US_EXTENDED_HOURS_EXCHANGES = new Set(["NASDAQ", "NYSE", "AMEX", "ARCA", "
 const ALWAYS_OPEN_EXCHANGES = new Set(["CCC"]);
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const OVERNIGHT_CLOSE_MAX_AGE_MS = 20 * 60 * 60 * 1000;
+const ALWAYS_OPEN_MAX_AGE_MS = 2 * 60 * 60 * 1000;
 const REGULAR_OPEN_MINUTES: Record<string, number> = {
   NASDAQ: 9 * 60 + 30,
   NYSE: 9 * 60 + 30,
@@ -174,11 +175,13 @@ function isTimestampStaleForExchangeSessionUnsafe(
   const canonical = canonicalExchange(exchange);
   if (!canonical || !Number.isFinite(timestampMs) || !Number.isFinite(now)) return false;
 
+  if (ALWAYS_OPEN_EXCHANGES.has(canonical)) {
+    return now - timestampMs > ALWAYS_OPEN_MAX_AGE_MS;
+  }
+
   const timestampDate = exchangeLocalDate(canonical, timestampMs);
   const currentDate = exchangeLocalDate(canonical, now);
   if (!timestampDate || !currentDate || timestampDate === currentDate) return false;
-
-  if (ALWAYS_OPEN_EXCHANGES.has(canonical)) return true;
   if (marketState === "REGULAR" && !isBeforeKnownRegularOpen(canonical, now)) return true;
 
   if (isUsExtendedHoursExchange(canonical)) {

--- a/src/market-data/quotes/freshness.test.ts
+++ b/src/market-data/quotes/freshness.test.ts
@@ -58,6 +58,22 @@ describe("quote freshness", () => {
     ).toBe(true);
   });
 
+  test("treats same-day crypto quotes older than two hours as stale", () => {
+    expect(
+      isQuoteStaleForCurrentSession(
+        quote({
+          symbol: "BTC-USD",
+          currency: "USD",
+          lastUpdated: Date.parse("2026-05-13T12:00:00Z"),
+          listingExchangeName: "CCC",
+          exchangeName: "CCC",
+          marketState: "REGULAR",
+        }),
+        Date.parse("2026-05-13T21:00:00Z"),
+      ),
+    ).toBe(true);
+  });
+
   test("treats old crypto quotes as stale on the 24/7 venue", () => {
     expect(
       isQuoteStaleForCurrentSession(

--- a/src/plugins/broker-sync/broker-sync.test.ts
+++ b/src/plugins/broker-sync/broker-sync.test.ts
@@ -108,6 +108,35 @@ describe("broker authentication boundaries", () => {
     ])).toThrow("read-only get_equity_positions");
   });
 
+  test("aggregates identical same-account lots instead of keeping only the last row", () => {
+    const snapshot = normalizeRobinhoodSnapshot(
+      { accounts: [{ account_number: "RH-1", currency: "USD" }] },
+      { positions: [
+        {
+          accountNumber: "RH-1",
+          instrument: { symbol: "HOOD" },
+          quantity: "2",
+          total_cost: "80",
+          market_value: "100",
+        },
+        {
+          accountNumber: "RH-1",
+          instrument: { symbol: "HOOD" },
+          quantity: "3",
+          total_cost: "150",
+          market_value: "150",
+        },
+      ] },
+    );
+
+    expect(snapshot.positions).toEqual([expect.objectContaining({
+      ticker: "HOOD",
+      shares: 5,
+      avgCost: 46,
+      marketValue: 250,
+    })]);
+  });
+
   test("SimpleFIN accepts URL-safe setup tokens and rejects non-HTTPS claims", () => {
     const claimUrl = "https://bridge.simplefin.org/simplefin/claim/demo";
     const token = Buffer.from(claimUrl).toString("base64url");

--- a/src/plugins/broker-sync/normalize.ts
+++ b/src/plugins/broker-sync/normalize.ts
@@ -80,11 +80,41 @@ function uniqueSnapshot(accounts: BrokerAccount[], positions: BrokerPosition[]):
       currency: position.currency,
     });
   }
-  const uniquePositions = [...new Map(positions.map((position) => [
-    `${position.accountId ?? ""}:${position.ticker}:${position.assetCategory ?? ""}`,
-    position,
-  ])).values()];
-  return { accounts: uniqueAccounts, positions: uniquePositions };
+  return { accounts: uniqueAccounts, positions: mergeIdenticalPositions(positions) };
+}
+
+function mergeIdenticalPositions(positions: BrokerPosition[]): BrokerPosition[] {
+  const merged = new Map<string, BrokerPosition>();
+  for (const position of positions) {
+    const key = [
+      position.accountId ?? "",
+      position.ticker,
+      position.assetCategory ?? "",
+      position.exchange ?? "",
+      position.brokerContract?.conId ?? "",
+    ].join(":");
+    const existing = merged.get(key);
+    if (!existing) {
+      merged.set(key, position);
+      continue;
+    }
+    const shares = existing.shares + position.shares;
+    const existingCost = (existing.avgCost ?? 0) * existing.shares;
+    const nextCost = (position.avgCost ?? 0) * position.shares;
+    merged.set(key, {
+      ...existing,
+      shares,
+      avgCost: shares > 0 ? (existingCost + nextCost) / shares : existing.avgCost,
+      marketValue: sumOptional(existing.marketValue, position.marketValue),
+      unrealizedPnl: sumOptional(existing.unrealizedPnl, position.unrealizedPnl),
+    });
+  }
+  return [...merged.values()];
+}
+
+function sumOptional(left?: number, right?: number): number | undefined {
+  if (left == null && right == null) return undefined;
+  return (left ?? 0) + (right ?? 0);
 }
 
 export function normalizeRobinhoodSnapshot(accountsPayload: unknown, positionsPayload: unknown): BrokerPortfolioSnapshot {

--- a/src/plugins/builtin/alerts/alert-engine.ts
+++ b/src/plugins/builtin/alerts/alert-engine.ts
@@ -2,10 +2,16 @@ import type { AlertCondition, AlertRule } from "./types";
 
 export type { AlertRule };
 
-export function createAlert(symbol: string, condition: AlertCondition, targetPrice: number): AlertRule {
+export function createAlert(
+  symbol: string,
+  condition: AlertCondition,
+  targetPrice: number,
+  exchange?: string,
+): AlertRule {
   return {
     id: `alert-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`,
     symbol: symbol.toUpperCase(),
+    exchange: exchange?.trim() || undefined,
     condition,
     targetPrice,
     createdAt: Date.now(),

--- a/src/plugins/builtin/alerts/index.tsx
+++ b/src/plugins/builtin/alerts/index.tsx
@@ -102,13 +102,14 @@ export const alertsPlugin: GloomPlugin = {
 
       // One batched pass over the distinct symbols: the alerts pane reads the same
       // persisted store, so this is the only place that talks to the provider.
-      const symbols = [...new Set(activeAlerts.map((alert) => alert.symbol))];
-      const results = await Promise.all(symbols.map(async (symbol): Promise<[string, Quote | string]> => {
+      const quoteKeys = [...new Set(activeAlerts.map((alert) => `${alert.symbol}\0${alert.exchange ?? ""}`))];
+      const results = await Promise.all(quoteKeys.map(async (key): Promise<[string, Quote | string]> => {
+        const [symbol, exchange = ""] = key.split("\0");
         try {
-          return [symbol, await resolveAlertQuote(ctx.marketData, symbol)];
+          return [key, await resolveAlertQuote(ctx.marketData, symbol ?? "", exchange)];
         } catch (err) {
-          ctx.log.warn("poll: no quote", { symbol, error: String(err) });
-          return [symbol, createQuoteErrorMessage(symbol, err)];
+          ctx.log.warn("poll: no quote", { symbol, exchange, error: String(err) });
+          return [key, createQuoteErrorMessage(symbol ?? "", err)];
         }
       }));
       const quotes = new Map<string, Quote | string>(results);
@@ -116,7 +117,7 @@ export const alertsPlugin: GloomPlugin = {
       let changed = false;
       for (const alert of alerts) {
         if (alert.status !== "active") continue;
-        const quote = quotes.get(alert.symbol);
+        const quote = quotes.get(`${alert.symbol}\0${alert.exchange ?? ""}`);
         if (quote === undefined) continue;
         if (typeof quote === "string") {
           Object.assign(alert, quoteErrorAlertFields(quote));

--- a/src/plugins/builtin/alerts/quotes.ts
+++ b/src/plugins/builtin/alerts/quotes.ts
@@ -1,5 +1,6 @@
 import type { DataProvider } from "../../../types/data-provider";
 import type { Quote } from "../../../types/financials";
+import { getActiveQuoteDisplay } from "../../../market-data/market/status";
 import type { AlertRule } from "./types";
 
 export function normalizeAlertSymbol(value: string | null | undefined): string {
@@ -17,12 +18,19 @@ export function createQuoteErrorMessage(
 export async function resolveAlertQuote(
   marketData: Pick<DataProvider, "getQuote">,
   symbol: string,
+  exchange = "",
 ): Promise<Quote> {
-  const quote = await marketData.getQuote(symbol, "");
-  if (!quote || typeof quote.price !== "number" || !Number.isFinite(quote.price)) {
+  const quote = await marketData.getQuote(symbol, exchange);
+  const display = getActiveQuoteDisplay(quote);
+  if (!display || !Number.isFinite(display.price)) {
     throw new Error(`No quote found for "${symbol}".`);
   }
-  return quote;
+  return {
+    ...quote,
+    price: display.price,
+    change: display.change,
+    changePercent: display.changePercent,
+  };
 }
 
 export function quoteAlertFields(

--- a/src/plugins/builtin/alerts/types.ts
+++ b/src/plugins/builtin/alerts/types.ts
@@ -6,6 +6,7 @@ export type AlertStatus = "active" | "triggered" | "expired";
 export interface AlertRule {
   id: string;
   symbol: string;
+  exchange?: string;
   condition: AlertCondition;
   targetPrice: number;
   createdAt: number;

--- a/src/plugins/builtin/analytics/index.tsx
+++ b/src/plugins/builtin/analytics/index.tsx
@@ -5,6 +5,7 @@ import { EmptyState, Tabs } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import { colors } from "../../../theme/colors";
+import { convertCurrency } from "../../../utils/format";
 import {
   getFocusedCollectionId,
   useAppSelector,
@@ -212,8 +213,14 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
       activePortfolio,
       brokerPerformance: brokerPerformance.performance,
       portfolioStats,
+      convertAccountValue: (value) => convertCurrency(
+        value,
+        accountState?.account.currency || baseCurrency,
+        baseCurrency,
+        effectiveExchangeRates,
+      ),
     }),
-    [accountState, activePortfolio, brokerPerformance.performance, portfolioStats],
+    [accountState, activePortfolio, baseCurrency, brokerPerformance.performance, effectiveExchangeRates, portfolioStats],
   );
 
   const riskRows = useMemo(

--- a/src/plugins/builtin/analytics/pane-model.ts
+++ b/src/plugins/builtin/analytics/pane-model.ts
@@ -142,23 +142,25 @@ export function buildAnalyticsSummaryRows({
   accountState,
   brokerPerformance,
   portfolioStats,
+  convertAccountValue = (value) => value,
 }: {
   accountState: ResolvedPortfolioAccountState | null;
   activePortfolio: Portfolio | null;
   brokerPerformance: BrokerPortfolioPerformance | null;
   portfolioStats: PortfolioSummaryTotals;
+  convertAccountValue?: (value: number) => number;
 }): AnalyticsMetricRow[] {
   const rows: AnalyticsMetricRow[] = [];
   const account = accountState?.account;
-  const accountMetrics = resolvePortfolioAccountMetrics(portfolioStats, account);
+  const accountMetrics = resolvePortfolioAccountMetrics(portfolioStats, account, convertAccountValue);
   const accountFreshness = formatAccountFreshness(account);
-  const totalMarketValue = resolvePortfolioMarketValue(portfolioStats, account);
+  const totalMarketValue = resolvePortfolioMarketValue(portfolioStats, account, convertAccountValue);
 
   if (account?.netLiquidation != null) {
     rows.push({
       id: "net-liquidation",
       label: "Net Liq",
-      value: formatCompact(account.netLiquidation),
+      value: formatCompact(convertAccountValue(account.netLiquidation)),
       color: colors.text,
     });
   }
@@ -184,7 +186,7 @@ export function buildAnalyticsSummaryRows({
     rows.push({
       id: "cash",
       label: "Cash",
-      value: formatCompact(account.totalCashValue),
+      value: formatCompact(convertAccountValue(account.totalCashValue)),
       color: colors.text,
     });
   }

--- a/src/plugins/builtin/cloud-tweets/registration.ts
+++ b/src/plugins/builtin/cloud-tweets/registration.ts
@@ -1,4 +1,5 @@
 import type { GloomPluginContext } from "../../../types/plugin";
+import { canonicalExchange } from "../../../utils/exchanges";
 import {
   TWITTER_FEED_LAUNCH_SCHEMA_VERSION,
   TWITTER_FEED_LAUNCH_STATE_KEY,
@@ -16,7 +17,11 @@ export function registerTwitterFeedFeature(ctx: GloomPluginContext): void {
     name: "Tweets",
     order: 38,
     component: TwitterTickerTab,
-    isVisible: ({ ticker }) => !!ticker,
+    isVisible: ({ ticker }) => {
+      if (!ticker) return false;
+      const exchange = canonicalExchange(ticker.metadata.exchange);
+      return !exchange || ["NASDAQ", "NYSE", "AMEX", "ARCA", "BATS", "OTC", "PINK"].includes(exchange);
+    },
   });
 
   ctx.registerPane({

--- a/src/plugins/builtin/dividend-yield/client.ts
+++ b/src/plugins/builtin/dividend-yield/client.ts
@@ -2,6 +2,7 @@ import type { ConnectionHealthRegistry } from "../../../core/connection-health";
 import { YahooHttpClient } from "../../../sources/yahoo-finance/http";
 import { financeRawNumber, mapYahooDividends } from "../../../sources/yahoo-finance/mappers";
 import { fetchYahooChart } from "../../../sources/yahoo-finance/requests";
+import { getYahooSymbolsToTry } from "../../../sources/yahoo-finance/symbols";
 import type { QuoteSummaryResponse } from "../../../sources/yahoo-finance/types";
 import type { DividendMetrics, DividendPayment } from "./types";
 
@@ -99,6 +100,23 @@ export interface DividendData {
 }
 
 export async function fetchDividendData(
+  symbol: string,
+  currentPrice: number | null,
+  exchange = "",
+): Promise<DividendData> {
+  const symbols = exchange ? getYahooSymbolsToTry(symbol, exchange) : [symbol];
+  let lastError: unknown;
+  for (const yahooSymbol of symbols) {
+    try {
+      return await fetchDividendDataForSymbol(yahooSymbol, currentPrice);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError ?? new Error(`No dividend data found for ${symbol}`);
+}
+
+async function fetchDividendDataForSymbol(
   symbol: string,
   currentPrice: number | null,
 ): Promise<DividendData> {

--- a/src/plugins/builtin/dividend-yield/pane.tsx
+++ b/src/plugins/builtin/dividend-yield/pane.tsx
@@ -197,6 +197,7 @@ function renderCell(
 export function DividendYieldPane({ focused, width, height }: { focused: boolean; width: number; height: number }) {
   const { symbol, ticker, financials } = usePaneTicker();
   const currency = ticker?.metadata.currency ?? "USD";
+  const exchange = ticker?.metadata.exchange ?? "";
   const quotePrice = financials?.quote?.price ?? null;
 
   const [data, setData] = useState<DividendData | null>(null);
@@ -206,13 +207,13 @@ export function DividendYieldPane({ focused, width, height }: { focused: boolean
   const [selectedIdx, setSelectedIdx] = useState(0);
   const fetchGenRef = useRef(0);
 
-  const load = useCallback(async (sym: string, price: number | null) => {
+  const load = useCallback(async (sym: string, price: number | null, listingExchange = "") => {
     fetchGenRef.current += 1;
     const gen = fetchGenRef.current;
     setLoading(true);
     setError(null);
     try {
-      const result = await fetchDividendData(sym, price);
+      const result = await fetchDividendData(sym, price, listingExchange);
       if (fetchGenRef.current !== gen) return;
       setData(result);
       setSelectedIdx(0);
@@ -237,12 +238,12 @@ export function DividendYieldPane({ focused, width, height }: { focused: boolean
       setLoading(false);
       return;
     }
-    void load(symbol, quotePriceRef.current);
-  }, [load, symbol]);
+    void load(symbol, quotePriceRef.current, exchange);
+  }, [exchange, load, symbol]);
 
   const refresh = useCallback(() => {
-    if (symbol) void load(symbol, quotePriceRef.current);
-  }, [load, symbol]);
+    if (symbol) void load(symbol, quotePriceRef.current, exchange);
+  }, [exchange, load, symbol]);
 
   usePaneFooter("dividend-yield", () => ({
     info: loadingErrorFooterInfo(loading, error),

--- a/src/plugins/builtin/earnings/index.tsx
+++ b/src/plugins/builtin/earnings/index.tsx
@@ -177,9 +177,11 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
       emptyStateTitle={
         loading
           ? "Loading earnings..."
-          : tickerSymbols.length === 0
-            ? "No tickers in scope."
-            : "No upcoming earnings found"
+          : error && events.length === 0
+            ? error
+            : tickerSymbols.length === 0
+              ? "No tickers in scope."
+              : "No upcoming earnings found"
       }
     />
   );

--- a/src/plugins/builtin/earnings/model.test.ts
+++ b/src/plugins/builtin/earnings/model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { TickerRecord } from "../../../types/ticker";
-import { resolveEarningsCollectionId, trackedEarningsSymbols } from "./model";
+import { groupEarningsByRelativeDate, resolveEarningsCollectionId, trackedEarningsSymbols } from "./model";
 
 function ticker(
   symbol: string,
@@ -48,5 +48,23 @@ describe("trackedEarningsSymbols", () => {
     ];
 
     expect(trackedEarningsSymbols(tickers, "main")).toEqual(["AAPL", "NVDA"]);
+  });
+});
+
+describe("groupEarningsByRelativeDate", () => {
+  test("groups date-only UTC midnight earnings on the UTC calendar day", () => {
+    const rows = groupEarningsByRelativeDate([
+      {
+        symbol: "AAPL",
+        name: "Apple",
+        earningsDate: new Date("2026-05-13T00:00:00.000Z"),
+        epsActual: null,
+        revenueActual: null,
+        surprise: null,
+      },
+    ], new Date("2026-05-13T21:00:00.000Z"));
+
+    expect(rows[0]).toMatchObject({ kind: "separator", label: "TODAY (1)" });
+    expect(rows[1]).toMatchObject({ kind: "event", event: expect.objectContaining({ symbol: "AAPL" }) });
   });
 });

--- a/src/plugins/builtin/earnings/model.ts
+++ b/src/plugins/builtin/earnings/model.ts
@@ -59,18 +59,20 @@ export function scopedSymbolsFromSettings(settings: Record<string, unknown> | un
   }
 }
 
-export function groupEarningsByRelativeDate(events: EarningsEvent[]): EarningsDisplayRow[] {
-  const now = new Date();
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const tomorrow = new Date(today);
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  const dayAfterTomorrow = new Date(today);
-  dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 2);
+function startOfUtcDay(date: Date): number {
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
 
-  const endOfWeek = new Date(today);
-  endOfWeek.setDate(endOfWeek.getDate() + (7 - endOfWeek.getDay()));
-  const endOfNextWeek = new Date(endOfWeek);
-  endOfNextWeek.setDate(endOfNextWeek.getDate() + 7);
+export function groupEarningsByRelativeDate(
+  events: EarningsEvent[],
+  now = new Date(),
+): EarningsDisplayRow[] {
+  const dayMs = 24 * 60 * 60 * 1000;
+  const today = startOfUtcDay(now);
+  const tomorrow = today + dayMs;
+  const dayAfterTomorrow = today + 2 * dayMs;
+  const endOfWeek = today + (7 - new Date(today).getUTCDay()) * dayMs;
+  const endOfNextWeek = endOfWeek + 7 * dayMs;
 
   const groups: { label: string; events: EarningsEvent[] }[] = [
     { label: "TODAY", events: [] },
@@ -81,12 +83,12 @@ export function groupEarningsByRelativeDate(events: EarningsEvent[]): EarningsDi
   ];
 
   for (const event of events) {
-    const date = event.earningsDate;
-    if (date >= today && date < tomorrow) {
+    const date = startOfUtcDay(event.earningsDate);
+    if (date === today) {
       groups[0]!.events.push(event);
-    } else if (date >= tomorrow && date < dayAfterTomorrow) {
+    } else if (date === tomorrow) {
       groups[1]!.events.push(event);
-    } else if (date >= dayAfterTomorrow && date < endOfWeek) {
+    } else if (date > tomorrow && date < endOfWeek) {
       groups[2]!.events.push(event);
     } else if (date >= endOfWeek && date < endOfNextWeek) {
       groups[3]!.events.push(event);

--- a/src/plugins/builtin/holders/thirteenf-match.ts
+++ b/src/plugins/builtin/holders/thirteenf-match.ts
@@ -29,8 +29,7 @@ function bestFundMatch(holderName: string, funds: Array<{ cik: string; name: str
       const normalizedFund = normalizeName(fund.name);
       return normalizedFund.includes(normalizedHolder)
         || normalizedHolder.includes(normalizedFund);
-    })
-    ?? funds[0];
+    });
 }
 
 export async function loadHolder13FMatches(

--- a/src/plugins/builtin/portfolio-list/account-metrics.test.ts
+++ b/src/plugins/builtin/portfolio-list/account-metrics.test.ts
@@ -38,6 +38,26 @@ describe("resolvePortfolioAccountMetrics", () => {
     });
   });
 
+  test("converts broker account money into the app base currency", () => {
+    const account: BrokerAccount = {
+      accountId: "DU12345",
+      name: "DU12345",
+      currency: "EUR",
+      netLiquidation: 10_000,
+      grossPositionValue: 8_000,
+      dailyPnl: 100,
+      unrealizedPnl: 400,
+    };
+    const toUsd = (value: number) => value * 1.1;
+
+    const metrics = resolvePortfolioAccountMetrics(createTotals(), account, toUsd);
+    expect(metrics.dailyPnl).toBeCloseTo(110);
+    expect(metrics.dailyPnlPct).toBeCloseTo(110 / 10_890 * 100);
+    expect(metrics.unrealizedPnl).toBeCloseTo(440);
+    expect(metrics.unrealizedPnlPct).toBeCloseTo(5.5);
+    expect(resolvePortfolioMarketValue(createTotals(), account, toUsd)).toBeCloseTo(8_800);
+  });
+
   test("falls back to reconstructed portfolio totals when broker P&L is missing", () => {
     expect(resolvePortfolioAccountMetrics(createTotals(), null)).toEqual({
       dailyPnl: 50,

--- a/src/plugins/builtin/portfolio-list/account-metrics.ts
+++ b/src/plugins/builtin/portfolio-list/account-metrics.ts
@@ -17,9 +17,12 @@ function percentChange(value: number, previousValue: number): number {
   return previousValue !== 0 ? (value / previousValue) * 100 : 0;
 }
 
-export function resolveBrokerPortfolioMarketValue(account?: BrokerAccount | null): number | null {
+export function resolveBrokerPortfolioMarketValue(
+  account?: BrokerAccount | null,
+  convertAccountValue: (value: number) => number = (value) => value,
+): number | null {
   if (finiteNumber(account?.grossPositionValue)) {
-    return account.grossPositionValue;
+    return convertAccountValue(account.grossPositionValue);
   }
   return null;
 }
@@ -27,24 +30,26 @@ export function resolveBrokerPortfolioMarketValue(account?: BrokerAccount | null
 export function resolvePortfolioMarketValue(
   totals: PortfolioSummaryTotals,
   account?: BrokerAccount | null,
+  convertAccountValue: (value: number) => number = (value) => value,
 ): number {
-  return resolveBrokerPortfolioMarketValue(account) ?? totals.totalMktValue;
+  return resolveBrokerPortfolioMarketValue(account, convertAccountValue) ?? totals.totalMktValue;
 }
 
 export function resolvePortfolioAccountMetrics(
   totals: PortfolioSummaryTotals,
   account?: BrokerAccount | null,
+  convertAccountValue: (value: number) => number = (value) => value,
 ): PortfolioAccountMetrics {
-  const brokerDailyPnl = finiteNumber(account?.dailyPnl) ? account.dailyPnl : null;
+  const brokerDailyPnl = finiteNumber(account?.dailyPnl) ? convertAccountValue(account.dailyPnl) : null;
   const dailyPnl = brokerDailyPnl ?? totals.dailyPnl;
   const previousNetLiquidation = brokerDailyPnl != null && finiteNumber(account?.netLiquidation)
-    ? account.netLiquidation - dailyPnl
+    ? convertAccountValue(account.netLiquidation) - dailyPnl
     : null;
   const dailyPnlPct = previousNetLiquidation != null
     ? percentChange(dailyPnl, previousNetLiquidation)
     : totals.dailyPnlPct;
 
-  const brokerUnrealizedPnl = finiteNumber(account?.unrealizedPnl) ? account.unrealizedPnl : null;
+  const brokerUnrealizedPnl = finiteNumber(account?.unrealizedPnl) ? convertAccountValue(account.unrealizedPnl) : null;
   const unrealizedPnl = brokerUnrealizedPnl ?? totals.unrealizedPnl;
   const unrealizedPnlPct = totals.totalCostBasis !== 0
     ? percentChange(unrealizedPnl, totals.totalCostBasis)

--- a/src/plugins/builtin/portfolio-list/pane/streaming.ts
+++ b/src/plugins/builtin/portfolio-list/pane/streaming.ts
@@ -71,7 +71,12 @@ export function usePortfolioPaneStreaming({
   const streamTargets = useMemo(() => (
     sortedTickers
       .map((ticker) => {
-        const target = quoteSubscriptionTargetFromTicker(ticker, ticker.metadata.ticker, "provider", instrumentOptions);
+        const target = quoteSubscriptionTargetFromTicker(
+          ticker,
+          ticker.metadata.ticker,
+          isPortfolioTab && (ticker.metadata.broker_contracts?.length ?? 0) > 0 ? "broker" : "provider",
+          instrumentOptions,
+        );
         if (!target) return null;
         const selected = ticker.metadata.ticker === cursorSymbol;
         const visible = priorityStreamSymbols.has(ticker.metadata.ticker);

--- a/src/plugins/builtin/portfolio-list/summary/index.tsx
+++ b/src/plugins/builtin/portfolio-list/summary/index.tsx
@@ -7,7 +7,7 @@ import type { BrokerConnectionStatus } from "../../../../types/broker";
 import type { TickerFinancials } from "../../../../types/financials";
 import type { Portfolio, TickerRecord } from "../../../../types/ticker";
 import type { BrokerAccount, BrokerCashBalance } from "../../../../types/trading";
-import { displayWidth, formatCompact, formatPercentRaw } from "../../../../utils/format";
+import { convertCurrency, displayWidth, formatCompact, formatPercentRaw } from "../../../../utils/format";
 import { getBrokerInstance } from "../../../../utils/broker-instances";
 import { resolvePortfolioAccountMetrics, resolvePortfolioMarketValue } from "../account-metrics";
 import { calculatePortfolioSummaryTotals, type PortfolioSummaryTotals } from "./totals";
@@ -188,21 +188,23 @@ export function buildPortfolioSummarySegments({
   accountStatusText,
   widthBudget,
   refreshText,
+  convertAccountValue = (value) => value,
 }: {
   totals: PortfolioSummaryTotals;
   accountState: PortfolioSummaryAccountState | null;
   accountStatusText?: string;
   widthBudget: number;
   refreshText?: string;
+  convertAccountValue?: (value: number) => number;
 }): PortfolioSummarySegment[] {
   const candidates: PortfolioSummarySegment[] = [];
-  const accountMetrics = resolvePortfolioAccountMetrics(totals, accountState?.account);
-  const totalMarketValue = resolvePortfolioMarketValue(totals, accountState?.account);
+  const accountMetrics = resolvePortfolioAccountMetrics(totals, accountState?.account, convertAccountValue);
+  const totalMarketValue = resolvePortfolioMarketValue(totals, accountState?.account, convertAccountValue);
 
   if (accountState?.account.netLiquidation != null) {
     candidates.push(createSummarySegment("netliq", [
       { text: "Net Liq", tone: "label" },
-      { text: formatCompact(accountState.account.netLiquidation), tone: "value", bold: true },
+      { text: formatCompact(convertAccountValue(accountState.account.netLiquidation)), tone: "value", bold: true },
     ]));
   }
 
@@ -214,7 +216,7 @@ export function buildPortfolioSummarySegments({
   if (accountState?.account.totalCashValue != null) {
     candidates.push(createSummarySegment("cash", [
       { text: "Cash", tone: "label" },
-      { text: formatCompact(accountState.account.totalCashValue), tone: "value", bold: true },
+      { text: formatCompact(convertAccountValue(accountState.account.totalCashValue)), tone: "value", bold: true },
     ]));
   }
 
@@ -348,12 +350,19 @@ export function buildPortfolioFooterSegments({
 
   // An account error must still reach the footer, otherwise a failed load looks like an empty portfolio.
   if (!totals.hasPositions && !accountState && !accountStatusText) return [];
+  const convertAccountValue = (value: number) => convertCurrency(
+    value,
+    accountState?.account.currency || baseCurrency,
+    baseCurrency,
+    exchangeRates,
+  );
   return buildPortfolioSummarySegments({
     totals,
     accountState,
     accountStatusText,
     widthBudget: Math.max(16, width - 14),
     refreshText,
+    convertAccountValue,
   }).map((segment) => ({
     id: segment.id,
     parts: segment.parts,

--- a/src/plugins/builtin/research/corporate-actions-pane.tsx
+++ b/src/plugins/builtin/research/corporate-actions-pane.tsx
@@ -23,6 +23,7 @@ import { useResolvedEntryValue, useSecFilingDocuments, useSecFilingsQuery } from
 import { instrumentFromTicker } from "../../../market-data/request-types";
 import { usePaneTicker } from "../../../state/app/context";
 import { isUsEquityTicker } from "../../../utils/sec";
+import { computeTTM } from "../ticker-detail/financials/aggregation";
 import { useAssetData } from "../../runtime";
 import { handleRefreshKey, loadingErrorFooterInfo } from "../shared/table-pane";
 import { useBoundTicker as useSymbolBinding, useTickerRequest } from "../shared/ticker-request";
@@ -241,16 +242,8 @@ function estimateValue(pair: EstimatePair): string {
 
 function ttmRow(quarterlyStatements: readonly FinancialStatement[]): EventRow | null {
   const latestFour = quarterlyStatements.slice(-4);
-  if (latestFour.length < 4) return null;
-  const fiscalRevenue = latestFour.reduce<number | undefined>((total, statement) => {
-    if (statement.totalRevenue == null) return total;
-    return (total ?? 0) + statement.totalRevenue;
-  }, undefined);
-  const fiscalEps = latestFour.reduce<number | undefined>((total, statement) => {
-    if (statement.eps == null) return total;
-    return (total ?? 0) + statement.eps;
-  }, undefined);
-  if (fiscalRevenue == null && fiscalEps == null) return null;
+  const ttm = computeTTM([...quarterlyStatements]);
+  if (!ttm || (ttm.totalRevenue == null && ttm.eps == null)) return null;
   const latest = latestFour.at(-1);
   return {
     id: `ttm:${latest?.date ?? ""}`,
@@ -258,8 +251,8 @@ function ttmRow(quarterlyStatements: readonly FinancialStatement[]): EventRow | 
     status: "TTM",
     period: "4 qtrs",
     detail: "sum",
-    annualEps: fiscalEps,
-    annualRevenue: fiscalRevenue,
+    annualEps: ttm.eps,
+    annualRevenue: ttm.totalRevenue,
     value: "-",
     tone: "muted",
   };

--- a/src/plugins/builtin/research/index.test.ts
+++ b/src/plugins/builtin/research/index.test.ts
@@ -293,6 +293,20 @@ describe("event rows", () => {
     expect(ttm?.qRevenue).toBeUndefined();
   });
 
+  test("omits a TTM row when a flow metric is missing from one of the last four quarters", () => {
+    const rows = buildEventRows(null, null, {
+      quarterlyStatements: [
+        { date: "2025-06-30", totalRevenue: 80, eps: 1 },
+        { date: "2025-09-30", totalRevenue: 90 },
+        { date: "2025-12-31", totalRevenue: 100, eps: 1.2 },
+        { date: "2026-03-31", totalRevenue: 110, eps: 1.3 },
+      ],
+    }, "USD");
+
+    expect(rows.find((row) => row.status === "TTM")?.annualEps).toBeUndefined();
+    expect(rows.find((row) => row.status === "TTM")?.annualRevenue).toBe(380);
+  });
+
   test("keeps dividends and splits in the event table without metric values", () => {
     const data = {
       symbol: "AAPL",

--- a/src/plugins/builtin/sectors/index.tsx
+++ b/src/plugins/builtin/sectors/index.tsx
@@ -342,6 +342,20 @@ export const sectorsModule: PluginModule = {
     },
   ],
 
+  setup(ctx) {
+    ctx.registerCommand({
+      id: "sectors-sp",
+      label: "Sector Performance",
+      description: "S&P 500 sector and industry performance sorted by daily change.",
+      keywords: ["sector", "sectors", "sp", "performance"],
+      category: "data",
+      shortcut: "SP",
+      execute: () => {
+        ctx.createPaneFromTemplate("sectors-pane");
+      },
+    });
+  },
+
   paneTemplates: [
     {
       id: "sectors-pane",

--- a/src/plugins/builtin/thirteenf/data.ts
+++ b/src/plugins/builtin/thirteenf/data.ts
@@ -82,8 +82,17 @@ export async function loadBrowserRows(
     const ticker = query.trim().toUpperCase();
     if (!ticker) return { rows: [], quarter };
     const tickers = await lookupThirteenFTickers([ticker], signal, apiOptions);
-    const cusip = tickers[0]?.cusip;
-    if (!cusip) return { rows: [], quarter, warning: `No CUSIP found for ${ticker}` };
+    const exact = tickers.filter((item) => item.ticker === ticker);
+    const candidates = exact.length > 0 ? exact : tickers;
+    const cusips = [...new Set(candidates.map((item) => item.cusip).filter(Boolean))];
+    const cusip = cusips.length === 1 ? cusips[0] : undefined;
+    if (!cusip) {
+      return {
+        rows: [],
+        quarter,
+        warning: cusips.length === 0 ? `No CUSIP found for ${ticker}` : `Ambiguous CUSIP for ${ticker}`,
+      };
+    }
     const periodOfReport = quarterToPeriod(quarter);
     try {
       const holders = await lookupThirteenFHoldersByCusip(cusip, periodOfReport, signal, apiOptions);

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -143,7 +143,7 @@ export function OverviewTab({
               <Text attributes={TextAttributes.BOLD} fg={colors.textBright}>
                 {ticker.metadata.ticker}
               </Text>
-              {ticker.metadata.name && ticker.metadata.name !== ticker.metadata.ticker && (
+              {(ticker.metadata.name || quote?.name) && (ticker.metadata.name || quote?.name) !== ticker.metadata.ticker && (
                 <Text fg={colors.textDim}>
                   {" "}- {ticker.metadata.name || quote?.name || ""}
                 </Text>

--- a/src/plugins/builtin/ticker-detail/quote-monitor/card.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor/card.tsx
@@ -82,7 +82,8 @@ export function QuoteMonitorCard({
   const flashDirection = useQuoteFlashDirection(flashFinancials, valueFlashingEnabled);
   const display = getActiveQuoteDisplay(quote);
   const quoteStatus = resolveQuoteStatus(quoteEntry, symbol);
-  const changeColor = priceColor(display?.change ?? 0);
+  const quoteFailed = quoteStatus.failed && !!display;
+  const changeColor = quoteFailed ? colors.textDim : priceColor(display?.change ?? 0);
   const priceAttributes = flashDirection ? TextAttributes.DIM : TextAttributes.BOLD;
   const changeAttributes = flashDirection ? TextAttributes.DIM : TextAttributes.NONE;
   const currency = quote?.currency ?? ticker?.metadata.currency ?? "USD";
@@ -192,7 +193,12 @@ export function QuoteMonitorCard({
             <Text attributes={TextAttributes.BOLD} fg={colors.textBright} style={desktopSymbolStyle}>
               {symbol}
             </Text>
-            {ticker?.metadata.name && (
+            {quoteFailed && (
+              <Text fg={colors.negative} style={{ fontSize: "12px", lineHeight: "14px" }}>
+                {quoteStatus.text}
+              </Text>
+            )}
+            {!quoteFailed && ticker?.metadata.name && (
               <Text
                 fg={colors.textDim}
                 style={{

--- a/src/plugins/builtin/ticker-detail/settings.ts
+++ b/src/plugins/builtin/ticker-detail/settings.ts
@@ -73,6 +73,18 @@ export function buildTickerResearchSettingsDef(settings: TickerResearchPaneSetti
           options: tabs.map((tab) => ({ value: tab.id, label: tab.name })),
         }]
         : []),
+      {
+        key: "chainRefreshMinutes",
+        label: "Options chain refresh",
+        description: "How often the Options tab refetches the whole chain snapshot.",
+        type: "select" as const,
+        options: [
+          { value: "1", label: "Every minute" },
+          { value: "5", label: "Every 5 minutes" },
+          { value: "10", label: "Every 10 minutes" },
+          { value: "30", label: "Every 30 minutes" },
+        ],
+      },
     ],
   };
 }

--- a/src/plugins/ibkr/flex/index.test.ts
+++ b/src/plugins/ibkr/flex/index.test.ts
@@ -27,6 +27,7 @@ describe("parseFlexPositions", () => {
     const positions = parseFlexPositions(xml);
     expect(positions).toHaveLength(1);
     expect(positions[0]?.ticker).toBe("SPY  260619C00500000");
+    expect(positions[0]?.side).toBe("long");
     expect(positions[0]?.brokerContract).toEqual({
       brokerId: "ibkr",
       conId: 123456,
@@ -41,6 +42,24 @@ describe("parseFlexPositions", () => {
       strike: 500,
       multiplier: "100",
       tradingClass: "SPY",
+    });
+  });
+
+  test("treats a negative Flex position without a side attribute as a short", () => {
+    const xml = `
+      <FlexQueryResponse>
+        <OpenPositions>
+          <OpenPosition accountId="DU12345" symbol="TSLA" assetCategory="STK" position="-50" costBasisPrice="200" currency="USD" listingExchange="NASDAQ" />
+        </OpenPositions>
+      </FlexQueryResponse>
+    `;
+
+    const positions = parseFlexPositions(xml);
+    expect(positions).toHaveLength(1);
+    expect(positions[0]).toMatchObject({
+      ticker: "TSLA",
+      shares: 50,
+      side: "short",
     });
   });
 });

--- a/src/plugins/ibkr/flex/index.ts
+++ b/src/plugins/ibkr/flex/index.ts
@@ -162,7 +162,7 @@ export function parseFlexPositions(xml: string): BrokerPosition[] {
       name: description || undefined,
       assetCategory: assetCategory || undefined,
       isin: isin || undefined,
-      side: side === "long" || side === "short" ? side : undefined,
+      side: side === "long" || side === "short" ? side : quantity < 0 ? "short" : "long",
       markPrice: numAttr("markPrice"),
       marketValue: numAttr("positionValue"),
       unrealizedPnl: numAttr("fifoPnlUnrealized") ?? numAttr("unrealizedCapitalGainsPnl"),

--- a/src/sources/gloomberb-cloud/index.ts
+++ b/src/sources/gloomberb-cloud/index.ts
@@ -215,6 +215,9 @@ export class GloomberbCloudProvider implements AssetDataProvider {
         })),
         options.forceRefresh ? "refresh" : "cache-first",
       );
+      if (isStaleCloudResponse(response)) {
+        throw createProviderMiss("Cloud financials are stale");
+      }
       const payload = unwrapRequiredCloudResponse(response, "Cloud financials are unavailable");
       return payload.items.map((item, index) => {
         const target = targets[index] ?? {
@@ -266,6 +269,9 @@ export class GloomberbCloudProvider implements AssetDataProvider {
         })),
         options.forceRefresh ? "refresh" : "cache-first",
       );
+      if (isStaleCloudResponse(response)) {
+        throw createProviderMiss("Cloud quotes are stale");
+      }
       const payload = unwrapRequiredCloudResponse(response, "Cloud quotes are unavailable");
       return payload.items.map((item, index) => {
         const target = targets[index] ?? {

--- a/src/sources/gloomberb-cloud/normalizers.test.ts
+++ b/src/sources/gloomberb-cloud/normalizers.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { mapCloudFinancials } from "./normalizers";
+
+describe("mapCloudFinancials", () => {
+  test("divides GBp history with the raw quote currency, not the normalized GBP quote", () => {
+    const financials = mapCloudFinancials({
+      quote: {
+        symbol: "VOD",
+        price: 23.1,
+        currency: "GBp",
+        change: 1,
+        changePercent: 4.5,
+        lastUpdated: Date.parse("2026-05-13T15:00:00Z"),
+        listingExchangeName: "LSE",
+        exchangeName: "LSE",
+      },
+      annualStatements: [],
+      quarterlyStatements: [],
+      priceHistory: [{
+        date: "2026-05-13 10:15:00",
+        open: 23,
+        high: 23.4,
+        low: 22.8,
+        close: 23.1,
+        volume: 1000,
+      }],
+    });
+
+    expect(financials.quote?.currency).toBe("GBP");
+    expect(financials.quote?.price).toBeCloseTo(0.231);
+    expect(financials.priceHistory[0]?.close).toBeCloseTo(0.231);
+    expect(financials.priceHistory[0]?.date.toISOString()).toBe("2026-05-13T09:15:00.000Z");
+  });
+});

--- a/src/sources/gloomberb-cloud/normalizers.ts
+++ b/src/sources/gloomberb-cloud/normalizers.ts
@@ -190,10 +190,10 @@ export function mapCloudFinancials(
   financials: TickerFinancials,
   providerMeta?: CloudProviderMeta,
 ): TickerFinancials {
-  const quote = financials.quote
-    ? mapQuote(financials.quote as CloudQuotePayload, providerMeta)
-    : undefined;
-  const divisor = quote ? resolveCurrencyUnit(quote.currency).divisor : 1;
+  const rawQuote = financials.quote as CloudQuotePayload | undefined;
+  const quote = rawQuote ? mapQuote(rawQuote, providerMeta) : undefined;
+  const divisor = rawQuote ? resolveCurrencyUnit(rawQuote.currency).divisor : 1;
+  const exchange = rawQuote?.listingExchangeName ?? rawQuote?.exchangeName ?? "";
   return {
     quote,
     quoteContributions: financials.quoteContributions,
@@ -204,7 +204,7 @@ export function mapCloudFinancials(
     priceHistory: (financials.priceHistory ?? []).map((point) =>
       point.date instanceof Date
         ? point
-        : mapPricePoint(point as unknown as CloudPricePointPayload, divisor),
+        : mapPricePoint(point as unknown as CloudPricePointPayload, divisor, exchange),
     ),
   };
 }

--- a/src/sources/provider-router/news.test.ts
+++ b/src/sources/provider-router/news.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { ProviderRouterNewsRoutes } from "./news";
+
+function failingSource() {
+  return {
+    id: "cloud",
+    name: "cloud",
+    news: {
+      fetchNews: async () => {
+        throw new Error("cloud down");
+      },
+    },
+  };
+}
+
+describe("ProviderRouterNewsRoutes", () => {
+  test("throws when every ticker news source fails", async () => {
+    const routes = new ProviderRouterNewsRoutes({
+      newsSourcesInPriorityOrder: () => [failingSource()],
+      logProviderError: () => {},
+    });
+
+    await expect(routes.getNews({ feed: "ticker", ticker: "AAPL" })).rejects.toThrow("cloud down");
+  });
+
+  test("throws when every global news source fails", async () => {
+    const routes = new ProviderRouterNewsRoutes({
+      newsSourcesInPriorityOrder: () => [failingSource()],
+      logProviderError: () => {},
+    });
+
+    await expect(routes.getNews({ feed: "latest" })).rejects.toThrow("cloud down");
+  });
+});

--- a/src/sources/provider-router/news.ts
+++ b/src/sources/provider-router/news.ts
@@ -16,21 +16,35 @@ export class ProviderRouterNewsRoutes {
     const feed = query.feed ?? (query.scope === "ticker" ? "ticker" : "latest");
     if (feed === "ticker") {
       let firstEmpty: NewsArticle[] | null = null;
+      let lastError: unknown = null;
+      let sawSuccess = false;
       for (const source of sources) {
         try {
           const articles = await source.news!.fetchNews(query);
+          sawSuccess = true;
           if (articles.length > 0) return articles;
           firstEmpty ??= articles;
         } catch (error) {
+          lastError = error;
           if (shouldLogProviderError(error)) {
             this.options.logProviderError(`${source.id} failed: ${error}`);
           }
         }
       }
+      if (!sawSuccess && lastError) throw lastError;
       return firstEmpty ?? [];
     }
 
     const settled = await Promise.allSettled(sources.map((source) => source.news!.fetchNews(query)));
-    return settled.flatMap((result) => result.status === "fulfilled" ? result.value : []);
+    const articles = settled.flatMap((result) => result.status === "fulfilled" ? result.value : []);
+    if (
+      articles.length === 0
+      && settled.length > 0
+      && settled.every((result) => result.status === "rejected")
+    ) {
+      const rejected = settled.find((result): result is PromiseRejectedResult => result.status === "rejected");
+      throw rejected?.reason ?? new Error("News sources are unavailable");
+    }
+    return articles;
   }
 }

--- a/src/sources/yahoo-finance.test.ts
+++ b/src/sources/yahoo-finance.test.ts
@@ -282,7 +282,7 @@ describe("YahooFinanceClient exchange aliases", () => {
       dividends: [{ exDate: "2026-02-03", amount: 0.12 }],
       splits: [{ date: "2026-01-02", description: "2:1 split", ratio: 2, fromFactor: 1, toFactor: 2 }],
       earnings: [
-        { date: "2026-03-16", time: "BMO", epsEstimate: -0.185 },
+        { date: "2026-03-16", time: "", epsEstimate: -0.185 },
         { date: "2026-01-31", epsActual: -0.35, epsEstimate: -0.13, difference: -0.22, surprisePercent: -169.23 },
       ],
     });

--- a/src/sources/yahoo-finance.ts
+++ b/src/sources/yahoo-finance.ts
@@ -137,7 +137,9 @@ export class YahooFinanceClient implements DataProvider {
         const result = await loadYahooTickerFinancials(symbol, {
           fetchAssetProfile: (targetSymbol) => this.fetchAssetProfile(targetSymbol),
           fetchChart: (targetSymbol, range, interval) => this.fetchChart(targetSymbol, range, interval),
-          fetchExtendedHoursData: (targetSymbol, meta) => this.fetchExtendedHoursData(targetSymbol, meta),
+          fetchExtendedHoursData: (targetSymbol, meta, regularClose) => (
+            this.fetchExtendedHoursData(targetSymbol, meta, regularClose)
+          ),
           fetchQuoteSupplement: (targetSymbol, currencyDivisor) =>
             this.fetchQuoteSupplement(targetSymbol, currencyDivisor),
           fetchTimeseries: (targetSymbol, types, period1) => this.fetchTimeseries(targetSymbol, types, period1),
@@ -176,7 +178,9 @@ export class YahooFinanceClient implements DataProvider {
       try {
         return await loadYahooQuote(symbol, {
           fetchChart: (targetSymbol, range, interval) => this.fetchChart(targetSymbol, range, interval),
-          fetchExtendedHoursData: (targetSymbol, meta) => this.fetchExtendedHoursData(targetSymbol, meta),
+          fetchExtendedHoursData: (targetSymbol, meta, regularClose) => (
+            this.fetchExtendedHoursData(targetSymbol, meta, regularClose)
+          ),
           fetchQuoteSupplement: (targetSymbol, currencyDivisor) =>
             this.fetchQuoteSupplement(targetSymbol, currencyDivisor),
           providerId: this.id,

--- a/src/sources/yahoo-finance/mappers.ts
+++ b/src/sources/yahoo-finance/mappers.ts
@@ -81,6 +81,9 @@ export function yahooRawDate(value: unknown): string | undefined {
 }
 
 function inferEarningsTiming(date: Date): EarningsEvent["timing"] {
+  if (date.getUTCHours() === 0 && date.getUTCMinutes() === 0 && date.getUTCSeconds() === 0) {
+    return "";
+  }
   const hour = date.getUTCHours();
   if (hour >= 20) return "AMC";
   if (hour <= 13) return "BMO";

--- a/src/sources/yahoo-finance/snapshots.ts
+++ b/src/sources/yahoo-finance/snapshots.ts
@@ -154,7 +154,7 @@ export async function loadYahooTickerFinancials(
     low52w: meta.fiftyTwoWeekLow,
     marketCap: latest("trailingMarketCap"),
     name: meta.shortName || meta.longName,
-    lastUpdated: Date.now(),
+    lastUpdated: yahooMarketTimestamp(meta),
     exchangeName: meta.exchangeName,
     fullExchangeName: meta.fullExchangeName,
     listingExchangeName: meta.exchangeName,
@@ -233,7 +233,7 @@ export async function loadYahooQuote(
     high52w: meta.fiftyTwoWeekHigh,
     low52w: meta.fiftyTwoWeekLow,
     name: meta.shortName || meta.longName,
-    lastUpdated: Date.now(),
+    lastUpdated: yahooMarketTimestamp(meta),
     exchangeName: meta.exchangeName,
     fullExchangeName: meta.fullExchangeName,
     listingExchangeName: meta.exchangeName,
@@ -244,4 +244,12 @@ export async function loadYahooQuote(
     ...quoteSupplement,
     ...extHours,
   };
+}
+
+function yahooMarketTimestamp(meta: NonNullable<ChartResult["meta"]>): number {
+  const marketTime = meta.regularMarketTime;
+  if (typeof marketTime === "number" && Number.isFinite(marketTime) && marketTime > 0) {
+    return marketTime < 1e12 ? marketTime * 1000 : marketTime;
+  }
+  return Date.now();
 }

--- a/src/sources/yahoo-finance/symbols.test.ts
+++ b/src/sources/yahoo-finance/symbols.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+import { getYahooSymbol, getYahooSymbolsToTry } from "./symbols";
+
+describe("Yahoo symbol routing", () => {
+  test("canonicalizes MIC aliases before applying exchange suffixes", () => {
+    expect(getYahooSymbol("VOD", "XLON")).toBe("VOD.L");
+    expect(getYahooSymbolsToTry("0700", "XHKG")).toEqual(["0700.HK"]);
+    expect(getYahooSymbolsToTry("SHOP", "XTSE")).toEqual(["SHOP.TO"]);
+  });
+});

--- a/src/sources/yahoo-finance/symbols.ts
+++ b/src/sources/yahoo-finance/symbols.ts
@@ -1,3 +1,5 @@
+import { canonicalExchange } from "../../utils/exchanges";
+
 const EXCHANGE_SUFFIX_MAP: Record<string, string> = {
   NASDAQ: "", NMS: "", NYSE: "", AMEX: "", ARCA: "", NYSEArca: "", BATS: "", BYX: "", IEX: "", PINK: "", OTC: "",
   TSX: ".TO", VENTURE: ".V", CSE2: ".CN", CNSX: ".CN",
@@ -46,17 +48,19 @@ const KNOWN_SUFFIXES = new Set(
 
 export function getYahooSymbol(ticker: string, exchange: string): string {
   if (tickerHasYahooSuffix(ticker)) return ticker;
-  const suffix = EXCHANGE_SUFFIX_MAP[exchange] ?? "";
-  return `${normalizeYahooTicker(ticker, exchange)}${suffix}`;
+  const canonical = canonicalExchange(exchange) || exchange;
+  const suffix = EXCHANGE_SUFFIX_MAP[canonical] ?? EXCHANGE_SUFFIX_MAP[exchange] ?? "";
+  return `${normalizeYahooTicker(ticker, canonical)}${suffix}`;
 }
 
 export function getYahooSymbolsToTry(ticker: string, exchange: string): string[] {
   if (tickerHasYahooSuffix(ticker)) return [ticker];
 
-  const normalized = normalizeYahooTicker(ticker, exchange);
+  const canonical = canonicalExchange(exchange) || exchange;
+  const normalized = normalizeYahooTicker(ticker, canonical);
   const dotVariant = normalized.includes(".") ? normalized.replace(/\./g, "-") : null;
 
-  if (!exchange) {
+  if (!canonical) {
     const symbols = new Set<string>();
     const candidates = [normalized];
     if (dotVariant) candidates.unshift(dotVariant);
@@ -69,16 +73,16 @@ export function getYahooSymbolsToTry(ticker: string, exchange: string): string[]
     return Array.from(symbols);
   }
 
-  const fallbacks = EXCHANGE_FALLBACKS[exchange];
+  const fallbacks = EXCHANGE_FALLBACKS[canonical] ?? EXCHANGE_FALLBACKS[exchange];
   if (fallbacks) {
     const results = fallbacks.map((suffix) => `${normalized}${suffix}`);
     if (dotVariant) results.unshift(...fallbacks.map((suffix) => `${dotVariant}${suffix}`));
     return results;
   }
 
-  const primary = getYahooSymbol(ticker, exchange);
+  const primary = getYahooSymbol(ticker, canonical);
   if (dotVariant) {
-    const suffix = EXCHANGE_SUFFIX_MAP[exchange] ?? "";
+    const suffix = EXCHANGE_SUFFIX_MAP[canonical] ?? EXCHANGE_SUFFIX_MAP[exchange] ?? "";
     return [`${dotVariant}${suffix}`, primary];
   }
   return [primary];
@@ -98,5 +102,6 @@ function normalizeYahooTicker(ticker: string, exchange: string): string {
 }
 
 function isHongKongExchange(exchange: string): boolean {
-  return exchange === "HKEX" || exchange === "SEHK" || exchange === "HKG";
+  const canonical = canonicalExchange(exchange) || exchange;
+  return canonical === "HKEX" || canonical === "SEHK" || canonical === "HKG";
 }

--- a/src/tickers/search/index.test.ts
+++ b/src/tickers/search/index.test.ts
@@ -521,6 +521,33 @@ describe("ticker-search utilities", () => {
     expect(saved).toHaveLength(1);
   });
 
+  test("replaces a saved listing when search selects a different exchange", async () => {
+    const existing = makeTicker("AAPL", "Apple Inc.");
+    existing.metadata.exchange = "NASDAQ";
+    existing.metadata.currency = "USD";
+    const saved: TickerRecord[] = [];
+    const repository = {
+      loadTicker: async () => existing,
+      createTicker: async (metadata: TickerRecord["metadata"]) => ({ metadata }),
+      saveTicker: async (ticker: TickerRecord) => {
+        saved.push(ticker);
+      },
+    };
+
+    const { ticker } = await upsertTickerFromSearchResult(repository as any, {
+      providerId: "test",
+      symbol: "AAPL",
+      name: "Apple Inc.",
+      exchange: "BYMA",
+      type: "EQUITY",
+      currency: "ARS",
+    });
+
+    expect(ticker.metadata.exchange).toBe("BYMA");
+    expect(ticker.metadata.currency).toBe("ARS");
+    expect(saved).toHaveLength(1);
+  });
+
   test("exposes local ticker candidates in saved category", () => {
     expect(createLocalTickerSearchCandidates([makeTicker("TSLA", "Tesla")])).toEqual([
       expect.objectContaining({

--- a/src/tickers/search/upsert.ts
+++ b/src/tickers/search/upsert.ts
@@ -8,6 +8,7 @@ import {
   getSearchResultSymbol,
   shouldReplaceTickerName,
 } from "./result";
+import { canonicalExchange } from "../../utils/exchanges";
 
 export async function upsertTickerFromSearchResult(
   tickerRepository: AppTickerRepositoryPort,
@@ -69,6 +70,15 @@ function mergeTickerMetadataFromSearchResult(metadata: TickerMetadata, result: I
   }
   if (nextExchange && !metadata.exchange) {
     metadata.exchange = nextExchange;
+    changed = true;
+  } else if (
+    nextExchange
+    && metadata.exchange
+    && canonicalExchange(nextExchange) !== canonicalExchange(metadata.exchange)
+  ) {
+    metadata.exchange = nextExchange;
+    if (nextName) metadata.name = nextName;
+    if (nextCurrency) metadata.currency = nextCurrency;
     changed = true;
   }
   if (nextCurrency && !metadata.currency) {

--- a/src/utils/price-history.ts
+++ b/src/utils/price-history.ts
@@ -3,6 +3,7 @@ import { resolveExchangeTimeZone } from "./exchanges";
 import { isTimestampStaleForExchangeSession } from "../market-data/market/freshness";
 
 const MAX_CURRENT_INTRADAY_HISTORY_LAG_MS = 18 * 60 * 60 * 1000;
+const MAX_SAME_SESSION_HISTORY_LAG_MS = 30 * 60 * 1000;
 
 interface PriceHistoryFreshnessOptions {
   exchange?: string;
@@ -78,18 +79,19 @@ export function isPriceHistoryStaleForCurrentWindow(
   if (!latest) return false;
 
   const latestTime = getPricePointTimestamp(latest);
-  if (!Number.isFinite(latestTime) || now - latestTime <= MAX_CURRENT_INTRADAY_HISTORY_LAG_MS) {
-    return false;
-  }
-
+  if (!Number.isFinite(latestTime)) return false;
+  const age = now - latestTime;
+  if (age <= MAX_SAME_SESSION_HISTORY_LAG_MS) return false;
   if (
     options.exchange
     && resolveExchangeTimeZone(options.exchange)
-    && !isTimestampStaleForExchangeSession(latestTime, options.exchange, now)
+    && isTimestampStaleForExchangeSession(latestTime, options.exchange, now)
   ) {
-    return false;
+    return true;
   }
-
+  if (age <= MAX_CURRENT_INTRADAY_HISTORY_LAG_MS) {
+    return Boolean(options.exchange && resolveExchangeTimeZone(options.exchange));
+  }
   return true;
 }
 

--- a/src/utils/sec.test.ts
+++ b/src/utils/sec.test.ts
@@ -35,6 +35,12 @@ describe("isUsEquityTicker", () => {
     }))).toBe(true);
   });
 
+  test("accepts US-listed ADRs", () => {
+    expect(isUsEquityTicker(makeTicker({
+      assetCategory: "ADR",
+    }))).toBe(true);
+  });
+
   test("rejects non-equity instruments", () => {
     expect(isUsEquityTicker(makeTicker({
       assetCategory: "OPT",

--- a/src/utils/sec.ts
+++ b/src/utils/sec.ts
@@ -24,7 +24,7 @@ function isUsExchange(value?: string): boolean {
 
 function isEquityType(value?: string): boolean {
   const normalized = normalize(value);
-  return normalized.length === 0 || normalized === "STK" || normalized === "EQUITY";
+  return normalized.length === 0 || normalized === "STK" || normalized === "EQUITY" || normalized === "ADR";
 }
 
 export function isUsEquityTicker(ticker: TickerRecord | null | undefined): boolean {


### PR DESCRIPTION
## Summary
- Keep Flex shorts, cross-currency account totals, GBp chart history, and Yahoo delayed timestamps from looking like current USD/GBP prices.
- Stop treating same-day crypto, 18-hour-old intraday charts, failed news, and retained quote-monitor prices as live.
- Route dividends, Yahoo suffixes, alerts, and portfolio streams with exchange/contract identity; refuse guessed 13F matches and partial TTM sums.
- Surface earnings load errors, Options chain refresh inside Ticker Research, and the documented `SP` shortcut. `help --json` now lists plugin commands; disabled plugins stay out of `catalog`.

## Test plan
- [x] `bun test` on the touched Flex, freshness, SEC, research, portfolio, broker-sync, earnings, Yahoo, Cloud, news, search, CLI, alerts, and options files
- [x] `bun run typecheck:opentui`, `typecheck:electrobun-view`, `typecheck:electrobun-bun`
- [ ] Open an IBKR Flex account with a short and confirm it stays short
- [ ] Open an LSE GBp name and confirm quote and chart share the same pounds scale
- [ ] Select a second same-symbol listing in search and confirm research follows that exchange
- [ ] Trigger a news outage / empty earnings error and confirm the pane does not say "none found"

Skipped for a later change: ticker `symbol` primary-key migration, desktop external plugins, i18n sweep, footer redesign, and tweets API exchange support.