### PR TITLE
Add the official hosted browser terminal

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Build Electrobun view
         run: bun run desktop:view:build
 
+      - name: Build and audit browser app
+        run: bun run web:audit
+
+      - name: Dry-run Cloudflare Worker
+        run: bun run cloudflare:dry-run
+
       - name: Build core binary
         run: bun run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 # caches
 .eslintcache
 .cache
+.wrangler
 *.tsbuildinfo
 paseo.json
 src-tauri/target

--- a/README.md
+++ b/README.md
@@ -29,8 +29,24 @@ Gloomberb has two ways in:
 |---------|----------|-------------|
 | Desktop app | A polished app window, pop-out panes, OS shortcuts, and built-in updates | Published for macOS and Windows. It also installs a `gloomberb` terminal command for the TUI. |
 | Terminal UI | Fast keyboard workflows inside your terminal, SSH/dev boxes, Linux machines, and script-friendly setups | Runs with `gloomberb` on macOS, Linux, and Windows. |
+| Browser app | The shared DOM interface without an install | Open [term.gloom.sh](https://term.gloom.sh). |
 
-Both share the same command language, plugin system, market data surfaces, portfolios, watchlists, alerts, notes, and AI tools.
+The desktop app and TUI share the full command language and plugin system. The browser app uses the same official DOM renderer and layout with a reviewed browser plugin catalog.
+
+## Browser App
+
+[term.gloom.sh](https://term.gloom.sh) works anonymously with configuration, tickers, layouts, session state, and plugin state stored in the browser. Gloom Cloud login is optional and enables cloud-backed market data, chat, and sync. Cloud REST and WebSocket traffic goes directly to `https://api.gloom.sh`; the static host never receives Gloom credentials.
+
+The browser build intentionally omits brokers and native integrations, filesystem notes, local AI, external plugins, updater/debug tools, application menus, native window controls, pop-out native windows, and native context menus. Modules that still depend on desktop-only or CORS-blocked feeds are also absent for now: RSS/Substack, prediction markets and polls, market halts/heatmap/movers, dividend/ownership/SEC panes, earnings/IPO, and TV. Public shares open under `/s/:id` in a separate slim bundle. Share creation and owner deletion use the signed-in Gloom Cloud session directly on the API; public reads require no account.
+
+Local browser development:
+
+```bash
+bun run web:build
+bunx wrangler dev
+```
+
+Validate the public artifacts with `bun run web:audit` and `bun run cloudflare:dry-run`. `wrangler.jsonc` is intentionally generic and contains no account, route, domain, namespace, or secret. Production routing and the private Gloom Cloud API deployment are configured separately.
 
 ## Install
 

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "happy-dom": "^20.11.1",
         "png-to-ico": "^2.1.8",
         "rcedit": "^4.0.1",
+        "wrangler": "^4.0.0",
       },
       "peerDependencies": {
         "typescript": "^5.9.2",
@@ -100,13 +101,137 @@
 
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.13.0", "", {}, "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g=="],
 
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260820.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260820.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260820.1", "", { "os": "linux", "cpu": "x64" }, "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260820.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260820.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
     "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.81.1", "", { "dependencies": { "@earendil-works/pi-ai": "^0.81.1", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-yqbh68CyhqxMov/jUogFJfMqlu2Gd37GAki+tr59YCmAPHfomiCA5ESzusXtpGzABeiZFC/OrRdQ4GwCCOMIHA=="],
 
     "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.81.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-hzHE7Z8l5mgJk+ke67Lge0rwS2+wbKJrFKl9o5M1R1rh33+cCT7D1AHz1OAtX5wFs90E1/BTGhyJRTUHaMxGvQ=="],
 
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
     "@hono/node-server": ["@hono/node-server@2.1.1", "", { "peerDependencies": { "hono": "^4" } }, "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.1" }, "os": "darwin", "cpu": "arm64" }, "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.1" }, "os": "darwin", "cpu": "x64" }, "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw=="],
+
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "os": "freebsd" }, "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.1", "", { "os": "linux", "cpu": "arm" }, "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.1", "", { "os": "linux", "cpu": "none" }, "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.1" }, "os": "linux", "cpu": "arm" }, "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.1" }, "os": "linux", "cpu": "ppc64" }, "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.1" }, "os": "linux", "cpu": "none" }, "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.1" }, "os": "linux", "cpu": "s390x" }, "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
+
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "cpu": "none" }, "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.2", "", { "os": "win32", "cpu": "x64" }, "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ=="],
 
     "@jimp/core": ["@jimp/core@1.6.1", "", { "dependencies": { "@jimp/file-ops": "1.6.1", "@jimp/types": "1.6.1", "@jimp/utils": "1.6.1", "await-to-js": "^3.0.0", "exif-parser": "^0.1.12", "file-type": "^21.3.3", "mime": "3" } }, "sha512-+BoKC5G6hkrSy501zcJ2EpfnllP+avPevcBfRcZe/CW+EwEfY6X1EZ8QWyT7NpDIvEEJb1fdJnMMfUnFkxmw9A=="],
 
@@ -164,6 +289,12 @@
 
     "@jimp/utils": ["@jimp/utils@1.6.1", "", { "dependencies": { "@jimp/types": "1.6.1", "tinycolor2": "^1.6.0" } }, "sha512-veFPRd93FCnS7AgmCkPgARVGoDRrJ9cm1ujuNyA+UfQ5VKbED2002sm5XfFLFwTsKC8j04heTrwe+tU1dluXOw=="],
 
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
     "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@1.1.1", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ=="],
 
     "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
@@ -194,6 +325,12 @@
 
     "@opentui/react": ["@opentui/react@0.3.2", "", { "dependencies": { "@opentui/core": "0.3.2", "react-reconciler": "^0.33.0" }, "peerDependencies": { "react": ">=19.2.0", "react-devtools-core": "^7.0.1", "ws": "^8.18.0" } }, "sha512-l127HNixmoXzfyPJ7UOFhkF4BOonk27T6eoRjDQHlzMW7OyHkDWWb1HhFhr3WDaKhusVMQ/brxngA0aRaDhTHA=="],
 
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
@@ -212,6 +349,8 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
 
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
     "@smithy/core": ["@smithy/core@3.29.7", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-BiEE2bnnGoPKdlGe3L+gOYORDHFGPuYVRLP7iUow/Sflm0B4hC4XY3FC1MRuc7ltzpW2xNnXopKi34TTkULlKQ=="],
 
     "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.12", "", { "dependencies": { "@smithy/core": "^3.29.7", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-ZZPDbl/aRp77aycuoMlo3BTayT4CE2a3uoqETYZU5ySnVbhpl5IJiY7dCZedn+ZusyDLqVv44IvKBiXd2/nK0Q=="],
@@ -229,6 +368,8 @@
     "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.24", "", {}, "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw=="],
 
     "@stoqey/ib": ["@stoqey/ib@1.5.6", "", { "dependencies": { "colors": "^1.4.0", "command-buffer": "^0.1.0", "dotenv": "^16.4.7", "eventemitter3": "^5.0.1", "function-rate-limit": "^1.1.0", "rxjs": "^7.8.1" } }, "sha512-l1Uep43VU/atLKRA7XraUt8M4iMgbZ8O+lw6oi1On4Vlkvya1Ry2C83dKEVTrlPn6ZpTkm5YQaUw5+c+yX18gg=="],
 
@@ -286,6 +427,8 @@
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
     "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
 
     "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
@@ -334,6 +477,8 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
@@ -352,11 +497,15 @@
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
+
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
@@ -401,6 +550,8 @@
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -482,6 +633,8 @@
 
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
@@ -503,6 +656,8 @@
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "miniflare": ["miniflare@5.20260820.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260820.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -548,7 +703,9 @@
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
-    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pixelmatch": ["pixelmatch@5.3.0", "", { "dependencies": { "pngjs": "^6.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q=="],
 
@@ -600,11 +757,15 @@
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -638,6 +799,8 @@
 
     "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
 
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
     "three": ["three@0.165.0", "", {}, "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA=="],
 
     "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
@@ -658,7 +821,11 @@
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
     "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
@@ -674,6 +841,10 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "workerd": ["workerd@1.20260820.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260820.1", "@cloudflare/workerd-darwin-arm64": "1.20260820.1", "@cloudflare/workerd-linux-64": "1.20260820.1", "@cloudflare/workerd-linux-arm64": "1.20260820.1", "@cloudflare/workerd-windows-64": "1.20260820.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w=="],
+
+    "wrangler": ["wrangler@4.125.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260820.0-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260820.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260820.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.21.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw=="],
@@ -687,6 +858,10 @@
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
     "youtubei.js": ["youtubei.js@17.0.1", "", { "dependencies": { "@bufbuild/protobuf": "^2.0.0", "meriyah": "^6.1.4" } }, "sha512-1lO4b8UqMDzE0oh2qEGzbBOd4UYRdxn/4PdpRM7BGTHxM6ddsEsKZTu90jp8V9FHVgC2h1UirQyqoqLiKwl+Zg=="],
 
@@ -712,15 +887,21 @@
 
     "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
 
+    "miniflare/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "png-to-ico/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
 
     "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
+    "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
     "socks/ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "type-is/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
+
+    "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "electrobun/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
   }

--- a/knip.json
+++ b/knip.json
@@ -4,6 +4,8 @@
     "bin/gloomberb",
     "electrobun.config.ts",
     "scripts/install-electrobun-tui-shim.ts",
+    "scripts/build-web.ts",
+    "scripts/audit-web-bundle.ts",
     "src/cli/entry.ts",
     "src/renderers/electrobun/bun/index.ts",
     "src/renderers/electrobun/bun/tui-entry.ts",
@@ -11,7 +13,10 @@
     "src/renderers/electrobun/view/app-services.ts",
     "src/renderers/electrobun/view/cli-pane-shot-entry.tsx",
     "src/renderers/electrobun/view/notes-files.ts",
-    "src/renderers/electrobun/view/native-stubs/**/*.ts"
+    "src/renderers/electrobun/view/native-stubs/**/*.ts",
+    "src/renderers/browser/main.tsx",
+    "src/renderers/share/main.tsx",
+    "src/renderers/cloudflare/worker.ts"
   ],
   "project": [
     "scripts/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -19,15 +19,21 @@
     "build": "bun run scripts/build.ts",
     "build:all": "bun run scripts/build.ts --all",
     "desktop:view:build": "bun run scripts/build-electrobun-view.ts",
+    "web:build": "bun run scripts/build-web.ts",
+    "web:audit": "bun run web:build && bun run scripts/audit-web-bundle.ts",
+    "cloudflare:typecheck": "tsc --project tsconfig.cloudflare.json",
+    "cloudflare:dry-run": "bun run web:build && wrangler deploy --dry-run",
     "desktop:dev": "bun run scripts/electrobun-dev.ts",
     "desktop:build": "electrobun build",
     "desktop:release": "electrobun build --env=stable",
     "desktop:release:windows": "electrobun build --env=stable --targets=win-x64",
     "i18n:audit": "bun run scripts/i18n-audit.ts",
-    "typecheck": "bun run typecheck:opentui && bun run typecheck:electrobun-bun && bun run typecheck:electrobun-view && bun run typecheck:scripts",
+    "typecheck": "bun run typecheck:opentui && bun run typecheck:electrobun-bun && bun run typecheck:electrobun-view && bun run typecheck:browser && bun run typecheck:cloudflare && bun run typecheck:scripts",
     "typecheck:opentui": "tsc --project tsconfig.opentui.json",
     "typecheck:electrobun-bun": "tsc --project tsconfig.electrobun-bun.json",
     "typecheck:electrobun-view": "tsc --project tsconfig.electrobun-view.json",
+    "typecheck:browser": "tsc --project tsconfig.browser.json",
+    "typecheck:cloudflare": "tsc --project tsconfig.cloudflare.json",
     "typecheck:scripts": "tsc --project tsconfig.scripts.json",
     "test": "bun test",
     "test:global-upgrade": "bun run scripts/smoke-global-upgrade.ts",
@@ -52,7 +58,8 @@
     "electrobun": "^1.18.1",
     "happy-dom": "^20.11.1",
     "png-to-ico": "^2.1.8",
-    "rcedit": "^4.0.1"
+    "rcedit": "^4.0.1",
+    "wrangler": "^4.0.0"
   },
   "peerDependencies": {
     "typescript": "^5.9.2"

--- a/scripts/audit-web-bundle.ts
+++ b/scripts/audit-web-bundle.ts
@@ -1,0 +1,36 @@
+import { readdir, readFile, stat } from "fs/promises";
+import { join, relative } from "path";
+
+const root = join(process.cwd(), "dist", "web");
+
+async function files(dir: string): Promise<string[]> {
+  const result: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    result.push(...(entry.isDirectory() ? await files(path) : [path]));
+  }
+  return result;
+}
+
+const outputFiles = await files(root);
+const failures: string[] = [];
+for (const path of outputFiles) {
+  const name = relative(root, path);
+  if (name.endsWith(".map")) failures.push(`${name}: public source map`);
+  if (!/\.(?:html|js|css)$/.test(name)) continue;
+  const content = await readFile(path, "utf8");
+  if (/sourceMappingURL=/.test(content)) failures.push(`${name}: source map reference`);
+  if (/kohor\.st|__GLOOM_CLOUD_HOSTED|\/_gloomberb\/rpc|receiveMessageFromBun|__electrobun|api\.thebuildout\.ai|api\.votehub\.com|api\.elections\.kalshi\.com|nasdaqtrader\.com|stockanalysis\.com\/ipos|forms13f\.com/.test(content)) {
+    failures.push(`${name}: forbidden native, fork, or unsupported provider code`);
+  }
+  if (name.endsWith(".html")) {
+    if (/<script(?![^>]*\bsrc=)[^>]*>/i.test(content)) failures.push(`${name}: inline script`);
+    if (/<style\b/i.test(content)) failures.push(`${name}: inline style block`);
+    if (/bearer\s|session[_-]?token/i.test(content)) failures.push(`${name}: embedded credential material`);
+  }
+}
+const shareScripts = outputFiles.filter((path) => /assets\/share\/.*\.js$/.test(path));
+const shareBytes = (await Promise.all(shareScripts.map((path) => stat(path)))).reduce((sum, entry) => sum + entry.size, 0);
+if (shareBytes > 300_000) failures.push(`share bundle is ${shareBytes} bytes (limit 300000)`);
+if (failures.length) throw new Error(`Web bundle audit failed:\n${failures.join("\n")}`);
+console.log(`Web bundle audit passed (${outputFiles.length} files, share JS ${shareBytes} bytes).`);

--- a/scripts/build-web.ts
+++ b/scripts/build-web.ts
@@ -1,0 +1,55 @@
+import { mkdir, readFile, rm, writeFile } from "fs/promises";
+import { join, relative } from "path";
+import { TITLEBAR_OVERLAY_HEIGHT_PX } from "../src/components/layout/titlebar-overlay";
+import {
+  electrobunViewAliasPlugin,
+} from "../src/renderers/electrobun/view/build-assets";
+
+const root = process.cwd();
+const outdir = join(root, "dist", "web");
+await rm(outdir, { recursive: true, force: true });
+await mkdir(outdir, { recursive: true });
+await writeFile(join(outdir, "favicon.svg"), await readFile(join(root, "src/assets/gloomberb-logo.svg")));
+
+async function buildPage(name: string, entrypoint: string, title: string, loadingText: string, htmlName: string) {
+  const assetsDir = join(outdir, "assets", name);
+  const result = await Bun.build({
+    entrypoints: [entrypoint],
+    outdir: assetsDir,
+    target: "browser",
+    format: "esm",
+    splitting: false,
+    minify: true,
+    sourcemap: "none",
+    define: {
+      "process.env.NODE_ENV": '"production"',
+      __GLOOMBERB_API_URL__: '"https://api.gloom.sh"',
+    },
+    plugins: [electrobunViewAliasPlugin(`browser-${name}-native-stubs`)],
+  });
+  if (!result.success) throw new Error(result.logs.map((log) => log.message).join("\n"));
+  const script = result.outputs.find((output) => output.kind === "entry-point" && output.path.endsWith(".js"));
+  const stylesheet = result.outputs.find((output) => output.path.endsWith(".css"));
+  if (!script || !stylesheet) throw new Error(`${name} build did not emit JavaScript and CSS`);
+  const css = (await readFile(stylesheet.path, "utf8"))
+    .replaceAll("__TITLEBAR_OVERLAY_HEIGHT_PX__", String(TITLEBAR_OVERLAY_HEIGHT_PX));
+  await writeFile(stylesheet.path, css);
+  const href = (path: string) => `/${relative(outdir, path).replaceAll("\\", "/")}`;
+  await writeFile(join(outdir, htmlName), `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>${title}</title>
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="${href(stylesheet.path)}">
+</head>
+<body>
+  <div id="root"><div class="gloom-loading">${loadingText}</div></div>
+  <script type="module" src="${href(script.path)}"></script>
+</body>
+</html>\n`);
+}
+
+await buildPage("app", join(root, "src/renderers/browser/main.tsx"), "Gloomberb", "Loading Gloomberb...", "index.html");
+await buildPage("share", join(root, "src/renderers/share/main.tsx"), "Gloomberb Share", "Loading shared view...", "share.html");

--- a/src/api-client/auth.ts
+++ b/src/api-client/auth.ts
@@ -18,6 +18,7 @@ type CloudApiRequest = <T>(path: string, options?: RequestInit) => Promise<T>;
 interface CloudAuthApiOptions {
   getCurrentUser(): AuthUser | null;
   getSessionToken(): string | null;
+  hasSessionCredential(): boolean;
   request: CloudApiRequest;
   requireCapturedSession(message: string): void;
   setCurrentUser(user: AuthUser | null): void;
@@ -29,7 +30,7 @@ export class CloudAuthApi {
   constructor(private readonly options: CloudAuthApiOptions) {}
 
   restoreCachedUser(user: PersistedAuthUser | null): void {
-    if (!this.options.getSessionToken() || !user?.id) {
+    if (!this.options.hasSessionCredential() || !user?.id) {
       this.options.setCurrentUser(null);
       return;
     }
@@ -57,7 +58,7 @@ export class CloudAuthApi {
   }
 
   async ensureVerifiedSession(): Promise<AuthUser | null> {
-    if (!this.options.getSessionToken()) return null;
+    if (!this.options.hasSessionCredential()) return null;
     if (!this.options.getCurrentUser()) {
       await this.getSession();
     }

--- a/src/api-client/index.test.ts
+++ b/src/api-client/index.test.ts
@@ -104,10 +104,20 @@ afterEach(() => {
   setCloudApiFetchTransport(null);
   apiClient.setSessionToken(null);
   apiClient.setWebSocketToken(null);
+  apiClient.setCookieSessionMode(false);
   jest.useRealTimers();
 });
 
 describe("apiClient auth cookies", () => {
+  test("accepts a browser-managed api.gloom.sh cookie without exposing its value", async () => {
+    apiClient.setCookieSessionMode(true);
+    setCloudApiFetchTransport(mockFetch(() => createResponse({ user: verifiedUser })));
+
+    await expect(apiClient.signIn("test@example.com", "password")).resolves.toEqual(verifiedUser);
+    expect(apiClient.getSessionToken()).toBeNull();
+    expect(apiClient.isVerified()).toBe(true);
+  });
+
   test("captures secure session cookies after login and reuses them on session refresh", async () => {
     const seenCookies: Array<string | null> = [];
 

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -84,6 +84,7 @@ class GloomApiClient {
     this.auth = new CloudAuthApi({
       getCurrentUser: () => this.currentUser,
       getSessionToken: () => this.transport.getSessionToken(),
+      hasSessionCredential: () => this.transport.hasSessionCredential(),
       request: (path, options) => this.request(path, options),
       requireCapturedSession: (message) => this.requireCapturedSession(message),
       setCurrentUser: (user) => this.setCurrentUser(user),
@@ -93,6 +94,7 @@ class GloomApiClient {
     this.socket = new CloudApiSocket({
       getBaseUrl: () => this.transport.baseUrl,
       getSocketAuthToken: () => this.getSocketAuthToken(),
+      hasSessionCredential: () => this.transport.hasSessionCredential(),
       hasVerifiedUser: () => this.currentUser?.emailVerified === true,
       isUsingWebSocketToken: () => !!this.transport.getWebSocketToken(),
       clearWebSocketTokenForFallback: () => this.transport.clearWebSocketTokenForFallback(),
@@ -121,6 +123,10 @@ class GloomApiClient {
 
   getWebSocketToken(): string | null {
     return this.transport.getWebSocketToken();
+  }
+
+  setCookieSessionMode(enabled: boolean): void {
+    this.transport.setCookieSessionMode(enabled);
   }
 
   setSessionToken(token: string | null): void {
@@ -156,7 +162,7 @@ class GloomApiClient {
   }
 
   isVerified(): boolean {
-    return !!this.transport.getSessionToken() && !!this.currentUser?.emailVerified;
+    return this.transport.hasSessionCredential() && !!this.currentUser?.emailVerified;
   }
 
   private setCurrentUser(user: AuthUser | null): void {
@@ -187,7 +193,7 @@ class GloomApiClient {
   }
 
   private requireCapturedSession(message: string): void {
-    if (this.transport.getSessionToken()) return;
+    if (this.transport.hasSessionCredential()) return;
     this.transport.setWebSocketToken(null);
     this.setCurrentUser(null);
     throw new Error(message);

--- a/src/api-client/request.ts
+++ b/src/api-client/request.ts
@@ -43,6 +43,7 @@ export class CloudApiRequestTransport {
   private sessionToken: string | null = null;
   private sessionCookieName: SessionCookieName | null = null;
   private websocketToken: string | null = null;
+  private cookieSessionMode = false;
   private readonly fetchTransport: CloudApiFetchTransport | null;
   private readonly marketRequestTimeoutMs: number;
   private readonly connectionHealth: ConnectionHealthRegistry;
@@ -65,6 +66,14 @@ export class CloudApiRequestTransport {
 
   getWebSocketToken(): string | null {
     return this.websocketToken;
+  }
+
+  hasSessionCredential(): boolean {
+    return this.cookieSessionMode || !!this.sessionToken;
+  }
+
+  setCookieSessionMode(enabled: boolean): void {
+    this.cookieSessionMode = enabled;
   }
 
   setSessionToken(token: string | null): void {

--- a/src/api-client/socket-health.test.ts
+++ b/src/api-client/socket-health.test.ts
@@ -50,6 +50,7 @@ describe("CloudApiSocket connection health", () => {
     const socket = new CloudApiSocket({
       getBaseUrl: () => `http://127.0.0.1:${server.port}`,
       getSocketAuthToken: () => null,
+      hasSessionCredential: () => false,
       hasVerifiedUser: () => false,
       isUsingWebSocketToken: () => false,
       clearWebSocketTokenForFallback: () => false,

--- a/src/api-client/socket.ts
+++ b/src/api-client/socket.ts
@@ -49,6 +49,7 @@ function mergeQuoteStreamSubscriptions(
 type CloudApiSocketDelegate = {
   getBaseUrl: () => string;
   getSocketAuthToken: () => string | null;
+  hasSessionCredential: () => boolean;
   hasVerifiedUser: () => boolean;
   isUsingWebSocketToken: () => boolean;
   clearWebSocketTokenForFallback: () => boolean;
@@ -427,7 +428,7 @@ export class CloudApiSocket {
 
   private shouldKeepSocketOpen(): boolean {
     if (this.quoteTargets.size > 0 || this.scannerListeners.size > 0) return true;
-    return !!this.delegate.getSocketAuthToken()
+    return this.delegate.hasSessionCredential()
       && this.delegate.hasVerifiedUser()
       && this.channelListeners.size > 0;
   }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -24,7 +24,7 @@ import type { AppServicesFactory, AppTickerRepositoryPort } from "./core/app-ser
 import { useThemeColors } from "./theme/theme-context";
 import type { AppConfig } from "./types/config";
 import type { DesktopDeepLinkBridge } from "./types/desktop-deeplink";
-import type { CliLaunchRequest } from "./types/plugin";
+import type { CliLaunchRequest, GloomPlugin } from "./types/plugin";
 import type { DataProvider } from "./types/data-provider";
 import type { DesktopDockPreviewState, DesktopSharedStateSnapshot, DesktopThemePreviewState, DesktopWindowBridge } from "./types/desktop-window";
 import type { DesktopApplicationMenuBridge } from "./types/desktop-menu";
@@ -32,7 +32,6 @@ import type { LayoutBounds } from "./plugins/pane-manager";
 import type { AppSessionSnapshot } from "./core/state/session-persistence";
 import type { MarketDataCoordinator } from "./market-data/coordinator";
 import { createAppNotifier } from "./notifications/app-notifier";
-import { getLoadablePlugins } from "./plugins/catalog";
 import { useBrokerImportRuntime } from "./app/runtime/broker-import";
 import { useDesktopDeepLinkRuntime } from "./app/runtime/desktop-deeplink";
 import { useDesktopApplicationMenuRuntime } from "./app/runtime/desktop-menu";
@@ -68,6 +67,7 @@ interface AppInnerProps {
   desktopApplicationMenuBridge?: DesktopApplicationMenuBridge;
   desktopDeepLinkBridge?: DesktopDeepLinkBridge;
   remoteControlAdapter?: RemoteControlAdapter;
+  updatesEnabled?: boolean;
   onboardingActive?: boolean;
   onOnboardingComplete?: (config: AppConfig) => void | Promise<void>;
 }
@@ -100,6 +100,7 @@ function AppInner({
   desktopApplicationMenuBridge,
   desktopDeepLinkBridge,
   remoteControlAdapter,
+  updatesEnabled = true,
   onboardingActive = false,
   onOnboardingComplete,
 }: AppInnerProps) {
@@ -221,6 +222,7 @@ function AppInner({
   });
 
   const { runUpdateCheck, startUpdate } = useAppUpdateRuntime({
+    enabled: updatesEnabled,
     dispatch,
     isDetachedWindow,
     pluginRegistry,
@@ -399,7 +401,7 @@ function AppInner({
               tickerRepository={tickerRepository}
               pluginRegistry={pluginRegistry}
               quitApp={() => rendererHost.requestExit()}
-              onCheckForUpdates={() => runUpdateCheck(true)}
+              onCheckForUpdates={updatesEnabled ? () => runUpdateCheck(true) : undefined}
               onNativeOccluderChange={setCommandBarNativeOccluder}
             />
           )}
@@ -414,6 +416,7 @@ interface AppProps {
   config: AppConfig;
   servicesFactory: AppServicesFactory;
   externalPlugins?: LoadedExternalPlugin[];
+  plugins: readonly GloomPlugin[];
   cliLaunchRequest?: CliLaunchRequest | null;
   desktopWindowBridge?: DesktopWindowBridge;
   desktopApplicationMenuBridge?: DesktopApplicationMenuBridge;
@@ -421,12 +424,14 @@ interface AppProps {
   desktopSnapshot?: DesktopSharedStateSnapshot | null;
   desktopThemePreview?: DesktopThemePreviewState | null;
   remoteControlAdapter?: RemoteControlAdapter;
+  updatesEnabled?: boolean;
 }
 
 export function App({
   config: initialConfig,
   servicesFactory,
   externalPlugins: providedExternalPlugins,
+  plugins,
   cliLaunchRequest = null,
   desktopWindowBridge,
   desktopApplicationMenuBridge,
@@ -434,6 +439,7 @@ export function App({
   desktopSnapshot = null,
   desktopThemePreview = null,
   remoteControlAdapter,
+  updatesEnabled = true,
 }: AppProps) {
   useAppLanguage();
   const externalPlugins = providedExternalPlugins ?? EMPTY_EXTERNAL_PLUGINS;
@@ -469,14 +475,14 @@ export function App({
     return measurePerf("startup.app.create-services", () => (
       servicesFactory({
         config,
-        plugins: getLoadablePlugins(externalPlugins),
+        plugins,
       })
     ), {
       externalPluginCount: externalPlugins.length,
       disabledPluginCount: config.disabledPlugins.length,
       brokerInstanceCount: config.brokerInstances.length,
     });
-  }, [config.dataDir, externalPlugins, servicesFactory]);
+  }, [config.dataDir, externalPlugins, plugins, servicesFactory]);
 
   useEffect(() => {
     return () => services.destroy();
@@ -514,6 +520,7 @@ export function App({
           desktopApplicationMenuBridge={desktopApplicationMenuBridge}
           desktopDeepLinkBridge={desktopDeepLinkBridge}
           remoteControlAdapter={remoteControlAdapter}
+          updatesEnabled={updatesEnabled}
           onboardingActive={showOnboarding}
           onOnboardingComplete={(updatedConfig) => {
             setConfig(updatedConfig);

--- a/src/app/runtime/update.ts
+++ b/src/app/runtime/update.ts
@@ -13,6 +13,7 @@ import { VERSION } from "../../version";
 const UPDATE_CHECK_INTERVAL_MS = 60 * 60_000; // hourly
 
 export function useAppUpdateRuntime({
+  enabled = true,
   dispatch,
   isDetachedWindow,
   pluginRegistry,
@@ -21,6 +22,7 @@ export function useAppUpdateRuntime({
   updateCheckInProgress,
   updateProgress,
 }: {
+  enabled?: boolean;
   dispatch: Dispatch<AppAction>;
   isDetachedWindow: boolean;
   pluginRegistry: PluginRegistry;
@@ -76,15 +78,15 @@ export function useAppUpdateRuntime({
   }, [dispatch]);
 
   useEffect(() => {
-    if (isDetachedWindow) return;
+    if (!enabled || isDetachedWindow) return;
     void runUpdateCheck(false);
     const interval = setInterval(() => { void runUpdateCheck(false); }, UPDATE_CHECK_INTERVAL_MS);
     return () => { clearInterval(interval); };
-  }, [isDetachedWindow, runUpdateCheck]);
+  }, [enabled, isDetachedWindow, runUpdateCheck]);
 
   // First launch on a new version: show that release's notes, then remember the version.
   useEffect(() => {
-    if (isDetachedWindow) return;
+    if (!enabled || isDetachedWindow) return;
     const config = stateRef.current.config;
     if (config.lastLaunchedVersion === VERSION) return;
     const isUpgrade = !!config.lastLaunchedVersion;
@@ -95,14 +97,14 @@ export function useAppUpdateRuntime({
     void pluginRegistry.createPaneFromTemplateAsyncFn("changelog-pane", {
       values: { version: VERSION },
     }).catch(() => {});
-  }, [dispatch, isDetachedWindow, pluginRegistry, stateRef]);
+  }, [dispatch, enabled, isDetachedWindow, pluginRegistry, stateRef]);
 
   useEffect(() => {
-    if (isDetachedWindow) return;
+    if (!enabled || isDetachedWindow) return;
     if (!updateAvailable || updateProgress || updateCheckInProgress) return;
     if (!canSelfUpdate(updateAvailable)) return;
     startUpdate(updateAvailable);
-  }, [isDetachedWindow, startUpdate, updateAvailable, updateCheckInProgress, updateProgress]);
+  }, [enabled, isDetachedWindow, startUpdate, updateAvailable, updateCheckInProgress, updateProgress]);
 
   return {
     runUpdateCheck,

--- a/src/architecture/import-boundaries.test.ts
+++ b/src/architecture/import-boundaries.test.ts
@@ -61,7 +61,11 @@ describe("import boundaries", () => {
         return !file.startsWith("src/renderers/electrobun/");
       }
       if (specifier === "react-dom" || specifier.startsWith("react-dom/")) {
-        return !file.startsWith("src/renderers/electrobun/");
+        return ![
+          "src/renderers/electrobun/",
+          "src/renderers/browser/",
+          "src/renderers/share/",
+        ].some((prefix) => file.startsWith(prefix));
       }
       return false;
     });

--- a/src/components/command-bar/surface/index.tsx
+++ b/src/components/command-bar/surface/index.tsx
@@ -50,7 +50,7 @@ export function CommandBar({
     activePortfolio,
     activeTickerData,
     activeTickerSymbol,
-    availableCommands,
+    availableCommands: allAvailableCommands,
     cellHeightPx,
     cellWidthPx,
     dispatch,
@@ -67,6 +67,9 @@ export function CommandBar({
     titleBarOverlay,
     visibleListStateRef,
   } = useCommandBarEnvironment();
+  const availableCommands = useMemo(() => onCheckForUpdates
+    ? allAvailableCommands
+    : allAvailableCommands.filter((command) => command.id !== "check-for-updates"), [allAvailableCommands, onCheckForUpdates]);
   const {
     applyThemePreview,
     clearThemePreview,

--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -43,9 +43,15 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
     typeof document === "undefined" ? true : document.hasFocus()
   ));
   const { width, height } = useViewport();
-  const { cellHeightPx = 18, nativePaneChrome, titleBarOverlay, windowControls } = useUiCapabilities();
-  const showWindowControls = windowControls === "windows";
-  const titlebarLeadingInset = titleBarOverlay ? getTitlebarLeadingInset() : 0;
+  const {
+    cellHeightPx = 18,
+    nativePaneChrome,
+    titleBarOverlay,
+    nativeWindowChrome = titleBarOverlay,
+    windowControls,
+  } = useUiCapabilities();
+  const showWindowControls = nativeWindowChrome && windowControls === "windows";
+  const titlebarLeadingInset = titleBarOverlay && nativeWindowChrome ? getTitlebarLeadingInset() : 0;
   const instance = useAppSelector((state) => findPaneInstance(state.config.layout, desktopWindowBridge.paneId) ?? null);
   const paneDef = instance ? pluginRegistry.panes.get(instance.paneId) ?? null : null;
   const hasPaneSettings = !!instance && pluginRegistry.hasPaneSettings(instance.instanceId);
@@ -112,8 +118,8 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
 
   const startWindowDrag = useCallback(() => {
     focusPane();
-    void rendererHost.startWindowDrag?.();
-  }, [focusPane, rendererHost]);
+    if (nativeWindowChrome) void rendererHost.startWindowDrag?.();
+  }, [focusPane, nativeWindowChrome, rendererHost]);
 
   const openSettings = useCallback((event?: { stopPropagation?: () => void; preventDefault?: () => void }) => {
     stopMouse(event);

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -164,9 +164,9 @@ export function Header({
   const rendererHost = useRendererHost();
   const baseCurrency = useAppSelector(selectBaseCurrency);
   const appActive = useAppActive();
-  const { titleBarOverlay, windowControls } = useUiCapabilities();
-  const showWindowControls = windowControls === "windows";
-  const titlebarLeadingInset = titleBarOverlay ? getTitlebarLeadingInset() : 0;
+  const { titleBarOverlay, nativeWindowChrome = titleBarOverlay, windowControls } = useUiCapabilities();
+  const showWindowControls = nativeWindowChrome && windowControls === "windows";
+  const titlebarLeadingInset = titleBarOverlay && nativeWindowChrome ? getTitlebarLeadingInset() : 0;
   const spyQuoteEntry = useQuoteEntry("SPY", null);
   const spyQuote = useResolvedEntryValue(spyQuoteEntry);
   const mktState = spyQuote?.marketState;
@@ -198,9 +198,9 @@ export function Header({
     : "SPY —";
 
   const startWindowDrag = useCallback(() => {
-    if (!titleBarOverlay) return;
+    if (!titleBarOverlay || !nativeWindowChrome) return;
     void rendererHost.startWindowDrag?.();
-  }, [rendererHost, titleBarOverlay]);
+  }, [nativeWindowChrome, rendererHost, titleBarOverlay]);
 
   // Market status
   const mktCountdown = mktState ? marketStateCountdown(mktState, now) : null;

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Box, Text, useUiHost } from "../../../ui";
+import { Box, Text, useUiCapabilities, useUiHost } from "../../../ui";
 import {
   ChoiceDialog,
   Tabs,
@@ -59,6 +59,9 @@ import {
 import { resolveChartComposerShortcut } from "./shortcuts";
 import { ChartSeriesQuickAdd } from "./quick-add";
 import { useLiveStreamingSetting } from "../shared/live-streaming";
+import { usePublicShare } from "../shared/public-share";
+import { buildChartShareData } from "../../../shares/chart-snapshot";
+import { isPlainKey } from "../../../utils/keyboard";
 
 const RANGE_TABS = RANGES.map((range, index) => ({ label: `${index + 1}:${range}`, value: range }));
 const AUTO_VIEWPORT_DEBOUNCE_MS = 350;
@@ -107,6 +110,7 @@ function ChartComposerSurface({
   const dialog = useDialog();
   const dispatch = useAppDispatch();
   const isDesktopWeb = useUiHost().kind === "desktop-web";
+  const { publicSharing } = useUiCapabilities();
   const paneId = usePaneInstanceId();
   const liveStreaming = useLiveStreamingSetting();
   const dialogOpen = useDialogState((state) => state.isOpen);
@@ -220,6 +224,11 @@ function ChartComposerSurface({
     ),
     [resolution.bufferedSeries, resolution.legendSeries, resolution.series, spec],
   );
+  const shareData = useMemo(() => buildChartShareData(plottedSeries), [plottedSeries]);
+  const createPublicShare = usePublicShare();
+  const shareChart = useCallback(() => {
+    if (shareData) void createPublicShare({ kind: "chart", data: shareData });
+  }, [createPublicShare, shareData]);
   const [interactionCaptured, setInteractionCapturedState] = useState(false);
   // Typing in quick-add must not freeze the plot: it only takes the keyboard.
   const [modalCaptured, setModalCaptured] = useState(false);
@@ -444,6 +453,12 @@ function ChartComposerSurface({
 
   useShortcut((event) => {
     if (interactionCaptureRef.current || dialogOpen) return;
+    if (publicSharing && shareData && isPlainKey(event, "y")) {
+      event.preventDefault();
+      event.stopPropagation();
+      shareChart();
+      return;
+    }
     const shortcut = resolveChartComposerShortcut(event, RANGES.length);
     if (!shortcut) return;
     event.preventDefault();
@@ -479,6 +494,9 @@ function ChartComposerSurface({
       { id: "formulas", key: "f", label: "ormulas", onPress: openFormulas, disabled: formulasDisabled },
       { id: "resolution", key: "t", label: "imeframe", onPress: footerResolution },
       { id: "range", key: "1-8", label: "range", onPress: footerRange },
+      ...(publicSharing
+        ? [{ id: "share", key: "y", label: " share", onPress: shareChart, disabled: !shareData }]
+        : []),
     ],
   }), [
     footerRange,
@@ -489,6 +507,9 @@ function ChartComposerSurface({
     indicatorsDisabled,
     openFormulas,
     openIndicators,
+    publicSharing,
+    shareChart,
+    shareData,
     resolution.errors,
     resolution.loading,
     resolution.warnings,

--- a/src/plugins/builtin/cloud/browser.tsx
+++ b/src/plugins/builtin/cloud/browser.tsx
@@ -1,0 +1,9 @@
+import { ChatContent } from "../chat/content";
+import { createChatPane } from "../chat/pane";
+import { ChatStatusWidget } from "../chat/status-widget";
+import { createGloomberbCloudPlugin } from "./plugin";
+
+export const browserGloomberbCloudPlugin = createGloomberbCloudPlugin({
+  ChatPane: createChatPane(ChatContent),
+  ChatStatusWidget,
+});

--- a/src/plugins/builtin/cloud/buildout-module.tsx
+++ b/src/plugins/builtin/cloud/buildout-module.tsx
@@ -1,0 +1,23 @@
+import { BuildoutPane } from "../buildout/pane";
+import type { PluginModule } from "../plugin-module";
+
+export const buildoutModule: PluginModule = {
+  panes: [{
+    id: "buildout",
+    name: "TheBuildout",
+    icon: "T",
+    component: BuildoutPane,
+    defaultPosition: "right",
+    defaultMode: "floating",
+    defaultFloatingSize: { width: 110, height: 34 },
+  }],
+  paneTemplates: [{
+    id: "buildout-pane",
+    paneId: "buildout",
+    label: "TheBuildout",
+    description: "Open TheBuildout infrastructure intelligence.",
+    keywords: ["tbo", "buildout", "thebuildout", "infrastructure", "sites", "intel"],
+    shortcut: { prefix: "TBO" },
+    createInstance: () => ({ placement: "floating" }),
+  }],
+};

--- a/src/plugins/builtin/cloud/device-signin.ts
+++ b/src/plugins/builtin/cloud/device-signin.ts
@@ -4,7 +4,6 @@
  * adopted through the same persistence and API-client path boot restoration
  * uses, so the rest of the app sees a normal signed-in session.
  */
-import { hostname } from "os";
 import {
   apiClient,
   type AuthUser,
@@ -53,13 +52,8 @@ const START_RETRY_MAX_MS = 30_000;
 const POLL_BACKOFF_FACTOR = 2;
 
 function defaultClientName(): string {
-  try {
-    const name = hostname().trim();
-    if (name && name !== "localhost") return name;
-  } catch {
-    // Browser-bundled builds have no hostname; fall through to the generic name.
-  }
-  return "Gloomberb TUI";
+  const name = typeof process !== "undefined" ? process.env.HOSTNAME?.trim() : "";
+  return name && name !== "localhost" ? name : "Gloomberb";
 }
 
 function defaultClientPlatform(): string | undefined {

--- a/src/plugins/builtin/cloud/index.tsx
+++ b/src/plugins/builtin/cloud/index.tsx
@@ -1,4 +1,5 @@
 import { ChatContent } from "../chat/content";
+import { buildoutModule } from "./buildout-module";
 import { createChatPane } from "../chat/pane";
 import { ChatStatusWidget } from "../chat/status-widget";
 import { createGloomberbCloudPlugin } from "./plugin";
@@ -8,4 +9,5 @@ const ChatPane = createChatPane(ChatContent);
 export const gloomberbCloudPlugin = createGloomberbCloudPlugin({
   ChatPane,
   ChatStatusWidget,
+  extraModules: [buildoutModule],
 });

--- a/src/plugins/builtin/cloud/plugin.tsx
+++ b/src/plugins/builtin/cloud/plugin.tsx
@@ -3,7 +3,6 @@ import type { GloomPlugin, PaneProps } from "../../../types/plugin";
 import { apiClient } from "../../../api-client";
 import { createGloomberbCloudCapabilities, createGloomberbCloudProvider } from "../../../sources/gloomberb-cloud";
 import { AccountManagementPane } from "../account-management/pane";
-import { BuildoutPane } from "../buildout/pane";
 import { chatController } from "../chat/controller";
 import {
   buildDmCommandResults,
@@ -27,6 +26,7 @@ import { CloudUpgradeStatusWidget } from "./upgrade-status-widget";
 interface GloomberbCloudPluginComponents {
   ChatPane: (props: PaneProps) => ReactNode;
   ChatStatusWidget: ComponentType;
+  extraModules?: readonly PluginModule[];
 }
 
 function createCloudDataModule(): PluginModule {
@@ -154,27 +154,6 @@ const accountModule: PluginModule = {
   },
 };
 
-const buildoutModule: PluginModule = {
-  panes: [{
-    id: "buildout",
-    name: "TheBuildout",
-    icon: "T",
-    component: BuildoutPane,
-    defaultPosition: "right",
-    defaultMode: "floating",
-    defaultFloatingSize: { width: 110, height: 34 },
-  }],
-  paneTemplates: [{
-    id: "buildout-pane",
-    paneId: "buildout",
-    label: "TheBuildout",
-    description: "Open TheBuildout infrastructure intelligence.",
-    keywords: ["tbo", "buildout", "thebuildout", "infrastructure", "sites", "intel"],
-    shortcut: { prefix: "TBO" },
-    createInstance: () => ({ placement: "floating" }),
-  }],
-};
-
 const congressTradesModule: PluginModule = {
   panes: [{
     id: CONGRESS_TRADES_PANE_ID,
@@ -203,6 +182,7 @@ const twitterModule: PluginModule = {
 export function createGloomberbCloudPlugin({
   ChatPane,
   ChatStatusWidget,
+  extraModules = [],
 }: GloomberbCloudPluginComponents): GloomPlugin {
   return composeBuiltinPlugin({
     id: "gloomberb-cloud",
@@ -215,7 +195,7 @@ export function createGloomberbCloudPlugin({
       createCloudDataModule(),
       createChatModule(ChatPane, ChatStatusWidget),
       accountModule,
-      buildoutModule,
+      ...extraModules,
       congressTradesModule,
       twitterModule,
     ],

--- a/src/plugins/builtin/econ/index.test.tsx
+++ b/src/plugins/builtin/econ/index.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, setSystemTime, test } from "bun:test";
 import { act } from "react";
 import { testRender } from "../../../renderers/opentui/test-utils";
 import { PaneFooterProvider } from "../../../components/layout/pane/footer";
@@ -49,7 +49,12 @@ function seedCalendar(): void {
   attachEconCalendarPersistence(persistence);
 }
 
+beforeEach(() => {
+  setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
+});
+
 afterEach(async () => {
+  setSystemTime();
   if (setup) {
     await act(async () => setup?.renderer.destroy());
     setup = undefined;

--- a/src/plugins/builtin/news/index.tsx
+++ b/src/plugins/builtin/news/index.tsx
@@ -122,7 +122,7 @@ function TickerNewsView({ width, height, focused }: { width: number; height: num
   );
 }
 
-const tickerNewsModule: PluginModule = {
+export const tickerNewsModule: PluginModule = {
   panes: [
     {
       id: "ticker-news",

--- a/src/plugins/builtin/news/wire/news/footer.ts
+++ b/src/plugins/builtin/news/wire/news/footer.ts
@@ -1,14 +1,21 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import type { PaneFooterSegment } from "../../../../../components";
 import { t, tf } from "../../../../../i18n";
 import { useAppLanguage } from "../../../../../i18n/react";
+import { useShortcut } from "../../../../../react/input";
+import { useUiCapabilities } from "../../../../../ui";
+import { isPlainKey } from "../../../../../utils/keyboard";
 import { useCloudAccessFooter } from "../../../shared/cloud-upgrade";
 import { CLOUD_NEWS_DELAY_HOURS } from "../../../shared/plan-access";
 import { usePaneStatusLinkFooter } from "../../../shared/pane-footer";
+import { usePublicShare } from "../../../shared/public-share";
 
 interface NewsFooterArticle {
+  title?: string | null;
+  summary?: string | null;
   source?: string | null;
   url?: string | null;
+  items?: Array<{ title?: string | null; summary?: string | null }>;
 }
 
 interface UseNewsArticleFooterOptions {
@@ -29,6 +36,29 @@ export function useNewsArticleFooter({
   error,
 }: UseNewsArticleFooterOptions) {
   const language = useAppLanguage();
+  const { publicSharing } = useUiCapabilities();
+  const createPublicShare = usePublicShare();
+  const shareArticle = useCallback(() => {
+    if (!article?.title) return;
+    const text = [
+      article.summary,
+      ...(article.items ?? []).map((item) => item.summary || item.title),
+    ].filter((value): value is string => !!value?.trim()).join("\n\n").slice(0, 50_000);
+    void createPublicShare({
+      kind: "article",
+      data: {
+        title: article.title,
+        text,
+        ...(article.url ? { sourceUrl: article.url } : {}),
+      },
+    });
+  }, [article, createPublicShare]);
+  useShortcut((event) => {
+    if (!focused || !publicSharing || !article?.title || !isPlainKey(event, "y")) return;
+    event.preventDefault();
+    event.stopPropagation();
+    shareArticle();
+  });
   const { access, segment } = useCloudAccessFooter({
     delayLabel: tf("{count}h", { count: CLOUD_NEWS_DELAY_HOURS }),
     focused,
@@ -50,6 +80,9 @@ export function useNewsArticleFooter({
     url: article?.url,
     source: article?.source,
     info: footerInfo,
+    hints: publicSharing && article?.title
+      ? [{ id: "share", key: "y", label: " share", onPress: shareArticle }]
+      : undefined,
     showOpenHint: true,
     loading,
     error,

--- a/src/plugins/builtin/shared/public-share.ts
+++ b/src/plugins/builtin/shared/public-share.ts
@@ -1,0 +1,23 @@
+import { useCallback } from "react";
+import { useRendererHost } from "../../../ui";
+import { createShare, publicShareUrl } from "../../../shares/api";
+import type { SharePayload } from "../../../shares/payload";
+import { usePluginAppActions } from "../../runtime";
+
+export function usePublicShare(): (payload: SharePayload) => Promise<void> {
+  const renderer = useRendererHost();
+  const { notify } = usePluginAppActions();
+
+  return useCallback(async (payload: SharePayload) => {
+    try {
+      const { id } = await createShare(payload);
+      await renderer.copyText(publicShareUrl(id));
+      notify({ body: "Share link copied to clipboard", type: "success" });
+    } catch (error) {
+      notify({
+        body: error instanceof Error ? error.message : "Could not create share.",
+        type: "error",
+      });
+    }
+  }, [notify, renderer]);
+}

--- a/src/plugins/catalog-browser.test.ts
+++ b/src/plugins/catalog-browser.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { browserBuiltinPlugins } from "./catalog-browser";
+
+const ids = browserBuiltinPlugins.map((plugin) => plugin.id);
+const paneIds = browserBuiltinPlugins.flatMap((plugin) => plugin.panes?.map((pane) => pane.id) ?? []);
+
+describe("browser plugin catalog", () => {
+  test("contains the reviewed cloud, local, market, and research plugins", () => {
+    expect(ids).toEqual([
+      "gloomberb-cloud",
+      "portfolio",
+      "ticker-research",
+      "application",
+      "news",
+      "market-overview",
+      "macro",
+      "alerts",
+    ]);
+  });
+
+  test("excludes native, filesystem, local AI, debug, updater, and external plugins", () => {
+    for (const forbidden of [
+      "broker",
+      "ibkr",
+      "public",
+      "robinhood",
+      "simplefin",
+      "notes",
+      "substack",
+      "ai",
+      "debug",
+      "yahoo",
+      "prediction-markets",
+      "polls",
+      "updater",
+    ]) {
+      expect(ids).not.toContain(forbidden);
+    }
+  });
+
+  test("omits unsupported modules inside otherwise browser-safe product areas", () => {
+    expect(paneIds).toEqual(expect.arrayContaining([
+      "ticker-research",
+      "chart-composer",
+      "options-calculator",
+      "ticker-news",
+      "world-indices",
+      "econ-calendar",
+      "treasury-auctions",
+    ]));
+    for (const forbidden of [
+      "buildout",
+      "market-heatmap",
+      "market-movers",
+      "market-halts",
+      "earnings-calendar",
+      "ipo-calendar",
+      "tv",
+      "dividend-yield",
+      "short-interest",
+      "thirteenf",
+      "sec",
+      "insider",
+    ]) {
+      expect(paneIds).not.toContain(forbidden);
+    }
+  });
+});

--- a/src/plugins/catalog-browser.ts
+++ b/src/plugins/catalog-browser.ts
@@ -1,0 +1,134 @@
+import {
+  attachFredSeriesPersistence,
+  resetFredSeriesPersistence,
+} from "../data/fred-series";
+import type { GloomPlugin } from "../types/plugin";
+import { portfolioAnalyticsModule } from "./builtin/analytics";
+import { alertsPlugin } from "./builtin/alerts";
+import { browserGloomberbCloudPlugin } from "./builtin/cloud/browser";
+import { changelogModule } from "./builtin/changelog";
+import { chartComposerModule } from "./builtin/chart-composer";
+import { connectionsModule } from "./builtin/connections";
+import { correlationModule } from "./builtin/correlation";
+import { creditConditionsModule } from "./builtin/credit-conditions";
+import { economicCalendarModule } from "./builtin/econ";
+import { futuresModule } from "./builtin/futures";
+import { fxMatrixModule } from "./builtin/fx-matrix";
+import { helpModule } from "./builtin/help";
+import { positionSizerModule } from "./builtin/kelly-sizer";
+import { layoutManagerModule } from "./builtin/layout-manager";
+import { tickerNewsModule } from "./builtin/news";
+import { optionsModule } from "./builtin/options";
+import { optionsCalculatorModule } from "./builtin/options-calculator";
+import { composeBuiltinPlugin, type PluginModule } from "./builtin/plugin-module";
+import { portfolioListModule } from "./builtin/portfolio-list";
+import { researchModule } from "./builtin/research";
+import { scannerModule } from "./builtin/scanner";
+import { sectorsModule } from "./builtin/sectors";
+import { tickerDetailModule } from "./builtin/ticker-detail";
+import { treasuryAuctionsModule } from "./builtin/treasury-auctions";
+import { volatilityModule } from "./builtin/volatility";
+import { worldIndicesModule } from "./builtin/world-indices";
+import { yieldCurveModule } from "./builtin/yield-curve";
+
+const browserApplicationPlugin = composeBuiltinPlugin({
+  id: "application",
+  name: "Application",
+  version: "1.0.0",
+  description: "Core layout, help, and release information.",
+  modules: [layoutManagerModule, helpModule, changelogModule, connectionsModule],
+});
+
+const browserPortfolioPlugin = composeBuiltinPlugin({
+  id: "portfolio",
+  name: "Portfolio",
+  version: "1.0.0",
+  description: "Portfolio and watchlist management, analytics, and position sizing.",
+  toggleable: true,
+  modules: [portfolioListModule, portfolioAnalyticsModule, positionSizerModule],
+});
+
+const browserTickerResearchPlugin = composeBuiltinPlugin({
+  id: "ticker-research",
+  name: "Ticker Research",
+  version: "1.0.0",
+  description: "Company overview, charts, financials, options, and research.",
+  toggleable: true,
+  modules: [
+    tickerDetailModule,
+    chartComposerModule,
+    optionsModule,
+    optionsCalculatorModule,
+    researchModule,
+  ],
+});
+
+const browserNewsPlugin = composeBuiltinPlugin({
+  id: "news",
+  name: "News",
+  version: "1.0.0",
+  description: "View latest news for each ticker.",
+  toggleable: true,
+  modules: [tickerNewsModule],
+});
+
+const browserMarketOverviewPlugin = composeBuiltinPlugin({
+  id: "market-overview",
+  name: "Market Overview",
+  version: "1.0.0",
+  description: "Global indices, scanners, sectors, FX, futures, and correlations.",
+  toggleable: true,
+  modules: [
+    correlationModule,
+    worldIndicesModule,
+    scannerModule,
+    sectorsModule,
+    fxMatrixModule,
+    futuresModule,
+  ],
+});
+
+const browserFredResourcesModule: PluginModule = {
+  setup(ctx) {
+    attachFredSeriesPersistence(ctx.persistence);
+  },
+  dispose() {
+    resetFredSeriesPersistence();
+  },
+};
+
+const browserMacroPlugin = composeBuiltinPlugin({
+  id: "macro",
+  name: "Macro",
+  version: "1.0.0",
+  description: "Economic calendar, rates, volatility, credit spreads, and Treasury auctions.",
+  toggleable: true,
+  modules: [
+    browserFredResourcesModule,
+    economicCalendarModule,
+    yieldCurveModule,
+    volatilityModule,
+    creditConditionsModule,
+    treasuryAuctionsModule,
+  ],
+});
+
+/**
+ * Reviewed browser catalog. Native brokers, filesystem/local-process plugins,
+ * and modules whose data path is not available through Gloom Cloud or a
+ * browser-safe public API are absent rather than registered behind stubs.
+ */
+export const browserBuiltinPlugins: readonly GloomPlugin[] = [
+  browserGloomberbCloudPlugin,
+  browserPortfolioPlugin,
+  browserTickerResearchPlugin,
+  browserApplicationPlugin,
+  browserNewsPlugin,
+  browserMarketOverviewPlugin,
+  browserMacroPlugin,
+  alertsPlugin,
+];
+
+export function getBrowserBuiltinPlugins(): readonly GloomPlugin[] {
+  return browserBuiltinPlugins;
+}

--- a/src/renderers/browser/app-services.ts
+++ b/src/renderers/browser/app-services.ts
@@ -1,0 +1,61 @@
+import { newsProvider, type NewsCapability } from "../../capabilities";
+import type { AppRuntimeServices, AppServicesFactoryOptions } from "../../core/app-service-ports";
+import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../market-data/coordinator";
+import { NewsService } from "../../news/aggregator";
+import { setSharedNewsService } from "../../news/hooks";
+import { PluginRegistry } from "../../plugins/registry";
+import { createGloomberbCloudCapabilities, createGloomberbCloudProvider } from "../../sources/gloomberb-cloud";
+import { AssetDataRouter } from "../../sources/provider-router";
+import { BrowserPersistence } from "./persistence";
+import { BrowserTickerRepository } from "./ticker-repository";
+
+export function createBrowserAppServices({
+  config,
+  plugins,
+}: AppServicesFactoryOptions): AppRuntimeServices {
+  const persistence = new BrowserPersistence(localStorage);
+  const tickerRepository = new BrowserTickerRepository(localStorage);
+  const cloudProvider = createGloomberbCloudProvider();
+  const dataProvider = new AssetDataRouter(null, [cloudProvider]);
+  const marketData = new MarketDataCoordinator(dataProvider);
+  const cloudNews = createGloomberbCloudCapabilities(cloudProvider).find(
+    (capability): capability is NewsCapability => capability.kind === "news",
+  );
+  const pluginRegistry = new PluginRegistry(dataProvider, tickerRepository, persistence);
+  dataProvider.attachRegistry(pluginRegistry);
+  const newsService = new NewsService({
+    pollIntervalMs: () => Math.max(1, config.refreshIntervalMinutes) * 60_000,
+  });
+
+  pluginRegistry.getConfigFn = () => config;
+  pluginRegistry.getLayoutFn = () => config.layout;
+  pluginRegistry.registerNewsCapabilityFn = (capability) => newsService.register(capability);
+  pluginRegistry.watchNewsQueryFn = (query, listener) => newsService.watchQuery(query, listener);
+  newsService.register(newsProvider({
+    id: dataProvider.id,
+    name: dataProvider.name,
+    priority: 0,
+    provider: { fetchNews: (query) => cloudNews?.provider.fetchNews(query) ?? Promise.resolve([]) },
+  }));
+
+  setSharedMarketDataCoordinator(marketData);
+  setSharedNewsService(newsService);
+  const ready = Promise.all(plugins.map((plugin) => pluginRegistry.register(plugin))).then(() => {});
+  newsService.start();
+
+  return {
+    persistence,
+    tickerRepository,
+    dataProvider,
+    marketData,
+    pluginRegistry,
+    ready,
+    destroy() {
+      setSharedMarketDataCoordinator(null);
+      setSharedNewsService(null);
+      newsService.stop();
+      pluginRegistry.destroy();
+      persistence.close();
+    },
+  };
+}

--- a/src/renderers/browser/cloud-transport.test.ts
+++ b/src/renderers/browser/cloud-transport.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, expect, spyOn, test } from "bun:test";
+import { apiClient } from "../../api-client";
+import {
+  browserCredentialedFetch,
+  restoreBrowserCloudSession,
+} from "./cloud-transport";
+
+const originalFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = originalFetch; });
+
+test("browser cloud transport uses host cookies without forwarding forbidden headers", async () => {
+  let captured: RequestInit | undefined;
+  globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+    captured = init;
+    return new Response("{}", { headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+  await browserCredentialedFetch("https://api.gloom.sh/auth/get-session", {
+    headers: { Cookie: "must-not-leak", Origin: "https://api.gloom.sh", Accept: "application/json" },
+  });
+  const headers = new Headers(captured?.headers);
+  expect(captured?.credentials).toBe("include");
+  expect(headers.has("Cookie")).toBe(false);
+  expect(headers.has("Origin")).toBe(false);
+  expect(headers.get("Accept")).toBe("application/json");
+});
+
+test("browser boot restores an existing Gloom Cloud cookie session", async () => {
+  const getSession = spyOn(apiClient, "getSession").mockResolvedValue(null);
+  await restoreBrowserCloudSession();
+  expect(getSession).toHaveBeenCalledTimes(1);
+  getSession.mockRestore();
+});

--- a/src/renderers/browser/cloud-transport.ts
+++ b/src/renderers/browser/cloud-transport.ts
@@ -1,0 +1,29 @@
+import { apiClient, setCloudApiFetchTransport } from "../../api-client";
+import { setHttpFetchTransport } from "../../utils/http-transport";
+
+export function browserCredentialedFetch(url: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers);
+  // These are controlled by the browser. Desktop transports may set them, but
+  // carrying them into fetch would either fail or misrepresent the web origin.
+  headers.delete("Cookie");
+  headers.delete("Origin");
+  return fetch(url, { ...init, headers, credentials: "include" });
+}
+
+export function installBrowserFetchTransports(): void {
+  apiClient.setCookieSessionMode(true);
+  setCloudApiFetchTransport(browserCredentialedFetch);
+  setHttpFetchTransport((url, init) => fetch(url, init));
+}
+
+export async function restoreBrowserCloudSession(budgetMs = 5_000): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), budgetMs);
+  });
+  try {
+    await Promise.race([apiClient.getSession().catch(() => null), deadline]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/renderers/browser/config-host.ts
+++ b/src/renderers/browser/config-host.ts
@@ -1,0 +1,62 @@
+import {
+  setConfigStoreHost,
+  type ConfigStoreHost,
+} from "../../data/config/store";
+import {
+  normalizeConfigForSave,
+  normalizeLoadedConfig,
+} from "../../data/config/store/normalize";
+import { createDefaultConfig, type AppConfig } from "../../types/config";
+import { BROWSER_STORAGE_KEYS, SafeJsonStorage, type StorageLike } from "./storage";
+
+export const BROWSER_DATA_DIR = "browser://local";
+
+function browserReady(config: AppConfig): AppConfig {
+  return { ...config, onboardingComplete: true, onboardingProgress: undefined };
+}
+
+function createBrowserDefaultConfig(dataDir: string): AppConfig {
+  return browserReady(createDefaultConfig(dataDir));
+}
+
+export function createBrowserConfigStore(storage: StorageLike): ConfigStoreHost {
+  const data = new SafeJsonStorage<unknown>(storage, BROWSER_STORAGE_KEYS.config, null);
+  return {
+    async getDataDir() { return BROWSER_DATA_DIR; },
+    async loadConfig(dataDir) {
+      const saved = data.get();
+      if (!saved || typeof saved !== "object" || Array.isArray(saved)) {
+        return createBrowserDefaultConfig(dataDir);
+      }
+      return browserReady(normalizeLoadedConfig(saved as Record<string, unknown>, dataDir).config);
+    },
+    async saveConfig(config) {
+      data.set(normalizeConfigForSave(browserReady({ ...config, dataDir: BROWSER_DATA_DIR })));
+    },
+    async initDataDir(dataDir) {
+      const config = createBrowserDefaultConfig(dataDir);
+      data.set(config);
+      return config;
+    },
+    async resetAllData(dataDir) {
+      for (const key of Object.values(BROWSER_STORAGE_KEYS)) {
+        try { storage.removeItem(key); } catch {}
+      }
+      data.set(createBrowserDefaultConfig(dataDir));
+    },
+    async exportConfig() {
+      throw new Error("Config file export is unavailable in the browser.");
+    },
+    async importConfig() {
+      throw new Error("Config file import is unavailable in the browser.");
+    },
+  };
+}
+
+export function installBrowserConfigStore(storage: StorageLike = localStorage): void {
+  setConfigStoreHost(createBrowserConfigStore(storage));
+}
+
+export async function loadBrowserConfig(store = createBrowserConfigStore(localStorage)): Promise<AppConfig> {
+  return store.loadConfig(BROWSER_DATA_DIR);
+}

--- a/src/renderers/browser/error-boundary.tsx
+++ b/src/renderers/browser/error-boundary.tsx
@@ -1,0 +1,23 @@
+/** @jsxImportSource react */
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+export class BrowserErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: unknown }
+> {
+  override state = { error: null as unknown };
+
+  static getDerivedStateFromError(error: unknown) {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("Browser renderer crashed", error, info.componentStack);
+  }
+
+  override render() {
+    if (!this.state.error) return this.props.children;
+    const message = this.state.error instanceof Error ? this.state.error.message : String(this.state.error);
+    return <div className="gloom-fatal"><h1>Gloomberb crashed</h1><pre>{message}</pre><button onClick={() => window.location.reload()}>Reload</button></div>;
+  }
+}

--- a/src/renderers/browser/main.tsx
+++ b/src/renderers/browser/main.tsx
@@ -1,0 +1,61 @@
+/** @jsxImportSource react */
+import "../electrobun/view/styles.css";
+import { createRoot } from "react-dom/client";
+import { App } from "../../app";
+import { loadConfig } from "../../data/config/store";
+import { applyLanguageFromConfig } from "../../i18n";
+import { getBrowserBuiltinPlugins } from "../../plugins/catalog-browser";
+import { UiHostProvider } from "../../ui/host";
+import { WebDialogHostProvider } from "../electrobun/view/dialog-host";
+import { BrowserErrorBoundary } from "./error-boundary";
+import { installFocusScopeRelease } from "../electrobun/view/host/focus-scope";
+import { WebInputHostProvider } from "../electrobun/view/input-host";
+import { webNativeRenderer } from "../electrobun/view/native-renderer";
+import { WebToastHostProvider } from "../electrobun/view/toast-host";
+import { createBrowserAppServices } from "./app-services";
+import {
+  installBrowserFetchTransports,
+  restoreBrowserCloudSession,
+} from "./cloud-transport";
+import { BROWSER_DATA_DIR, installBrowserConfigStore } from "./config-host";
+import { browserRendererHost, browserUiHost } from "./ui-host";
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("Missing root element");
+const appRootElement = rootElement;
+appRootElement.tabIndex = -1;
+const root = createRoot(appRootElement);
+root.render(<div className="gloom-loading">Starting Gloomberb...</div>);
+
+async function boot(): Promise<void> {
+  installBrowserConfigStore();
+  installBrowserFetchTransports();
+  installFocusScopeRelease();
+  await restoreBrowserCloudSession();
+  const config = await loadConfig(BROWSER_DATA_DIR);
+  applyLanguageFromConfig(config);
+  root.render(
+    <BrowserErrorBoundary>
+      <UiHostProvider ui={browserUiHost} renderer={browserRendererHost} nativeRenderer={webNativeRenderer}>
+        <WebInputHostProvider>
+          <WebToastHostProvider>
+            <WebDialogHostProvider>
+              <App
+                config={config}
+                servicesFactory={createBrowserAppServices}
+                plugins={getBrowserBuiltinPlugins()}
+                updatesEnabled={false}
+              />
+            </WebDialogHostProvider>
+          </WebToastHostProvider>
+        </WebInputHostProvider>
+      </UiHostProvider>
+    </BrowserErrorBoundary>,
+  );
+  appRootElement.focus({ preventScroll: true });
+}
+
+void boot().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  root.render(<div className="gloom-fatal"><h1>Gloomberb failed to start</h1><pre>{message}</pre></div>);
+});

--- a/src/renderers/browser/persistence.ts
+++ b/src/renderers/browser/persistence.ts
@@ -1,0 +1,74 @@
+import type { AppPersistencePort } from "../../core/app-service-ports";
+import type { PluginStateRecord } from "../../data/plugin-state-store";
+import type { SessionSnapshotRecord } from "../../data/session-store";
+import { DesktopMemoryResourceStore } from "../electrobun/view/resource-store";
+import { BROWSER_STORAGE_KEYS, SafeJsonStorage, type StorageLike } from "./storage";
+
+type PluginState = Record<string, Record<string, PluginStateRecord>>;
+type Sessions = Record<string, SessionSnapshotRecord>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+export class BrowserPersistence implements AppPersistencePort {
+  readonly resources = new DesktopMemoryResourceStore();
+  private readonly pluginStateData: SafeJsonStorage<PluginState>;
+  private readonly sessionData: SafeJsonStorage<Sessions>;
+
+  constructor(storage: StorageLike) {
+    this.pluginStateData = new SafeJsonStorage(storage, BROWSER_STORAGE_KEYS.pluginState, {}, (value): value is PluginState => isRecord(value));
+    this.sessionData = new SafeJsonStorage(storage, BROWSER_STORAGE_KEYS.session, {}, (value): value is Sessions => isRecord(value));
+  }
+
+  readonly pluginState = {
+    get: <T>(pluginId: string, key: string, schemaVersion = 1): PluginStateRecord<T> | null => {
+      const record = this.pluginStateData.get()[pluginId]?.[key];
+      if (!isRecord(record) || record.schemaVersion !== schemaVersion || !("value" in record)) return null;
+      return record as unknown as PluginStateRecord<T>;
+    },
+    set: (pluginId: string, key: string, value: unknown, schemaVersion = 1): void => {
+      const state = this.pluginStateData.get();
+      this.pluginStateData.set({
+        ...state,
+        [pluginId]: {
+          ...state[pluginId],
+          [key]: { value, schemaVersion, updatedAt: Date.now() },
+        },
+      });
+    },
+    delete: (pluginId: string, key: string): void => {
+      const state = this.pluginStateData.get();
+      const plugin = { ...state[pluginId] };
+      delete plugin[key];
+      this.pluginStateData.set({ ...state, [pluginId]: plugin });
+    },
+    keys: (pluginId: string): string[] => Object.keys(this.pluginStateData.get()[pluginId] ?? {}),
+    clear: (pluginId: string): void => {
+      const state = { ...this.pluginStateData.get() };
+      delete state[pluginId];
+      this.pluginStateData.set(state);
+    },
+  };
+
+  readonly sessions = {
+    get: <T>(sessionId = "app", schemaVersion = 1): SessionSnapshotRecord<T> | null => {
+      const record = this.sessionData.get()[sessionId];
+      if (!isRecord(record) || record.schemaVersion !== schemaVersion || !("value" in record)) return null;
+      return record as unknown as SessionSnapshotRecord<T>;
+    },
+    set: (sessionId: string, value: unknown, schemaVersion = 1): void => {
+      this.sessionData.set({
+        ...this.sessionData.get(),
+        [sessionId]: { sessionId, value, schemaVersion, updatedAt: Date.now() },
+      });
+    },
+    delete: (sessionId: string): void => {
+      const state = { ...this.sessionData.get() };
+      delete state[sessionId];
+      this.sessionData.set(state);
+    },
+  };
+
+  close(): void {}
+}

--- a/src/renderers/browser/storage.test.ts
+++ b/src/renderers/browser/storage.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { createDefaultConfig } from "../../types/config";
+import { createBrowserConfigStore, BROWSER_DATA_DIR } from "./config-host";
+import { BrowserPersistence } from "./persistence";
+import { BROWSER_STORAGE_KEYS, SafeJsonStorage, type StorageLike } from "./storage";
+import { BrowserTickerRepository } from "./ticker-repository";
+
+class MemoryStorage implements StorageLike {
+  readonly values = new Map<string, string>();
+  failWrites = false;
+  getItem(key: string) { return this.values.get(key) ?? null; }
+  setItem(key: string, value: string) {
+    if (this.failWrites) throw new DOMException("full", "QuotaExceededError");
+    this.values.set(key, value);
+  }
+  removeItem(key: string) { this.values.delete(key); }
+}
+
+describe("browser local persistence", () => {
+  test("falls back safely for malformed JSON and quota failures", () => {
+    const storage = new MemoryStorage();
+    storage.values.set("key", "{");
+    const data = new SafeJsonStorage(storage, "key", { count: 0 });
+    expect(data.get()).toEqual({ count: 0 });
+    storage.values.set("wrong-shape", "[]");
+    const shaped = new SafeJsonStorage(storage, "wrong-shape", { ok: true }, (value): value is { ok: boolean } => !!value && typeof value === "object" && !Array.isArray(value));
+    expect(shaped.get()).toEqual({ ok: true });
+    storage.failWrites = true;
+    data.set({ count: 2 });
+    expect(data.get()).toEqual({ count: 2 });
+  });
+
+  test("normalizes config and persists tickers, plugin state, and session state", async () => {
+    const storage = new MemoryStorage();
+    storage.values.set(BROWSER_STORAGE_KEYS.config, JSON.stringify({ theme: 42 }));
+    const configStore = createBrowserConfigStore(storage);
+    const config = await configStore.loadConfig(BROWSER_DATA_DIR);
+    expect(config.theme).toBe(createDefaultConfig(BROWSER_DATA_DIR).theme);
+    expect(config.onboardingComplete).toBe(true);
+    config.baseCurrency = "EUR";
+    await configStore.saveConfig(config);
+    expect((await configStore.loadConfig(BROWSER_DATA_DIR)).baseCurrency).toBe("EUR");
+
+    const tickers = new BrowserTickerRepository(storage);
+    await tickers.createTicker({
+      ticker: "AAPL",
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: "Apple Inc.",
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    });
+    expect((await new BrowserTickerRepository(storage).loadTicker("aapl"))?.metadata.ticker).toBe("AAPL");
+
+    const persistence = new BrowserPersistence(storage);
+    persistence.pluginState.set("alerts", "draft", { enabled: true }, 2);
+    persistence.sessions.set("app", { focusedPaneId: "portfolio-list:main" }, 1);
+    const restored = new BrowserPersistence(storage);
+    expect(restored.pluginState.get("alerts", "draft", 2)?.value).toEqual({ enabled: true });
+    expect(restored.pluginState.get("alerts", "draft", 1)).toBeNull();
+    expect(restored.sessions.get("app", 1)?.value).toEqual({ focusedPaneId: "portfolio-list:main" });
+  });
+});

--- a/src/renderers/browser/storage.ts
+++ b/src/renderers/browser/storage.ts
@@ -1,0 +1,50 @@
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/** localStorage wrapper that keeps the app usable when JSON or quota is bad. */
+export class SafeJsonStorage<T> {
+  private value: T;
+
+  constructor(
+    private readonly storage: StorageLike,
+    readonly key: string,
+    fallback: T,
+    validate: (value: unknown) => value is T = (_value): _value is T => true,
+  ) {
+    this.value = fallback;
+    try {
+      const raw = storage.getItem(key);
+      if (raw !== null) {
+        const parsed: unknown = JSON.parse(raw);
+        if (!validate(parsed)) throw new Error("Invalid stored value");
+        this.value = parsed;
+      }
+    } catch {
+      try { storage.removeItem(key); } catch {}
+    }
+  }
+
+  get(): T {
+    return this.value;
+  }
+
+  set(value: T): void {
+    this.value = value;
+    try { this.storage.setItem(this.key, JSON.stringify(value)); } catch {}
+  }
+
+  clear(fallback: T): void {
+    this.value = fallback;
+    try { this.storage.removeItem(this.key); } catch {}
+  }
+}
+
+export const BROWSER_STORAGE_KEYS = {
+  config: "gloomberb.web.config.v1",
+  tickers: "gloomberb.web.tickers.v1",
+  pluginState: "gloomberb.web.plugin-state.v1",
+  session: "gloomberb.web.session.v1",
+} as const;

--- a/src/renderers/browser/ticker-repository.ts
+++ b/src/renderers/browser/ticker-repository.ts
@@ -1,0 +1,59 @@
+import type { AppTickerRepositoryPort } from "../../core/app-service-ports";
+import { hydrateTickerMetadata } from "../../tickers/metadata";
+import type { TickerMetadata, TickerRecord } from "../../types/ticker";
+import { BROWSER_STORAGE_KEYS, SafeJsonStorage, type StorageLike } from "./storage";
+
+type StoredTickers = Record<string, TickerMetadata>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeSymbol(symbol: string): string {
+  return symbol.trim().toUpperCase();
+}
+
+function hydrate(metadata: TickerMetadata): TickerRecord | null {
+  try {
+    return { metadata: hydrateTickerMetadata(metadata as unknown as Record<string, unknown>) };
+  } catch {
+    return null;
+  }
+}
+
+export class BrowserTickerRepository implements AppTickerRepositoryPort {
+  private readonly data: SafeJsonStorage<StoredTickers>;
+
+  constructor(storage: StorageLike) {
+    this.data = new SafeJsonStorage(storage, BROWSER_STORAGE_KEYS.tickers, {}, (value): value is StoredTickers => isRecord(value));
+  }
+
+  async loadAllTickers(): Promise<TickerRecord[]> {
+    return Object.values(this.data.get()).flatMap((metadata) => {
+      const ticker = hydrate(metadata);
+      return ticker ? [ticker] : [];
+    });
+  }
+
+  async loadTicker(symbol: string): Promise<TickerRecord | null> {
+    const metadata = this.data.get()[normalizeSymbol(symbol)];
+    return metadata ? hydrate(metadata) : null;
+  }
+
+  async saveTicker(ticker: TickerRecord): Promise<void> {
+    const symbol = normalizeSymbol(ticker.metadata.ticker);
+    this.data.set({ ...this.data.get(), [symbol]: ticker.metadata });
+  }
+
+  async createTicker(metadata: TickerMetadata): Promise<TickerRecord> {
+    const ticker = { metadata };
+    await this.saveTicker(ticker);
+    return ticker;
+  }
+
+  async deleteTicker(symbol: string): Promise<void> {
+    const tickers = { ...this.data.get() };
+    delete tickers[normalizeSymbol(symbol)];
+    this.data.set(tickers);
+  }
+}

--- a/src/renderers/browser/ui-host.tsx
+++ b/src/renderers/browser/ui-host.tsx
@@ -1,0 +1,40 @@
+/** @jsxImportSource react */
+import type { RendererHost, UiHost } from "../../ui/host";
+import { safeExternalUrl } from "../../utils/external-url";
+import { createDomUiHost } from "../electrobun/view/dom-ui-host";
+
+export const browserUiHost: UiHost = createDomUiHost("browser", {
+  nativePaneChrome: true,
+  titleBarOverlay: true,
+  nativeWindowChrome: false,
+  nativeContextMenu: false,
+  publicSharing: true,
+});
+
+export const browserRendererHost: RendererHost = {
+  supportsNativeDesktopNotifications: false,
+  requestExit() {},
+  notify() {},
+  async openExternal(rawUrl) {
+    const url = safeExternalUrl(rawUrl);
+    if (!url) return;
+    const opened = window.open(url, "_blank", "noopener,noreferrer");
+    if (opened) opened.opener = null;
+  },
+  async copyText(text) {
+    await navigator.clipboard.writeText(text);
+  },
+  async readText() {
+    return navigator.clipboard.readText();
+  },
+  async copyPngImage(pngBase64) {
+    const ClipboardItemCtor = globalThis.ClipboardItem;
+    if (!ClipboardItemCtor || !navigator.clipboard.write) {
+      throw new Error("Image clipboard is unavailable in this browser.");
+    }
+    const bytes = Uint8Array.from(atob(pngBase64), (char) => char.charCodeAt(0));
+    await navigator.clipboard.write([
+      new ClipboardItemCtor({ "image/png": new Blob([bytes], { type: "image/png" }) }),
+    ]);
+  },
+};

--- a/src/renderers/cloudflare/worker.test.ts
+++ b/src/renderers/cloudflare/worker.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { handleRequest, SECURITY_HEADERS, type WorkerEnv } from "./worker";
+
+function fixture() {
+  const requests: Request[] = [];
+  const env: WorkerEnv = {
+    ASSETS: {
+      async fetch(request) {
+        requests.push(request);
+        return new Response("<!doctype html>", { headers: { "content-type": "text/html" } });
+      },
+    },
+  };
+  return { env, requests };
+}
+
+describe("static Cloudflare host", () => {
+  test("reports health without invoking static assets", async () => {
+    const { env, requests } = fixture();
+    const response = await handleRequest(new Request("https://term.example/health"), env);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: "ok" });
+    expect(requests).toHaveLength(0);
+  });
+
+  test("serves app assets with an enforced CSP and security headers", async () => {
+    const { env } = fixture();
+    const response = await handleRequest(new Request("https://term.example/"), env);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-security-policy")).toBe(SECURITY_HEADERS["content-security-policy"]);
+    expect(response.headers.has("content-security-policy-report-only")).toBe(false);
+    expect(response.headers.get("x-frame-options")).toBe("DENY");
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  test("rewrites only valid public share paths to the slim document", async () => {
+    const { env, requests } = fixture();
+    const response = await handleRequest(new Request("https://term.example/s/0123456789abcdef0123456789abcdef"), env);
+    expect(new URL(requests[0]!.url).pathname).toBe("/share.html");
+    expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow, noarchive");
+  });
+
+  test("rejects every mutation without invoking assets or outbound fetch", async () => {
+    const { env, requests } = fixture();
+    const response = await handleRequest(new Request("https://term.example/shares", {
+      method: "POST",
+      headers: { Origin: "https://term.example" },
+    }), env);
+    expect(response.status).toBe(405);
+    expect(requests).toHaveLength(0);
+  });
+});

--- a/src/renderers/cloudflare/worker.ts
+++ b/src/renderers/cloudflare/worker.ts
@@ -1,0 +1,53 @@
+interface StaticAssetsBinding {
+  fetch(request: Request): Promise<Response>;
+}
+
+export interface WorkerEnv {
+  ASSETS: StaticAssetsBinding;
+}
+
+const SHARE_PATH = /^\/s\/[a-f0-9]{32}\/?$/;
+
+export const SECURITY_HEADERS = {
+  "content-security-policy": "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; media-src 'self' https:; connect-src 'self' https://api.gloom.sh wss://api.gloom.sh https://api.github.com https://api.fiscaldata.treasury.gov; form-action 'self' https://api.gloom.sh; upgrade-insecure-requests",
+  "cross-origin-opener-policy": "same-origin",
+  "cross-origin-resource-policy": "same-origin",
+  "permissions-policy": "camera=(), geolocation=(), microphone=(), payment=(), usb=()",
+  "referrer-policy": "no-referrer",
+  "strict-transport-security": "max-age=31536000; includeSubDomains",
+  "x-content-type-options": "nosniff",
+  "x-frame-options": "DENY",
+} as const;
+
+export function withSecurityHeaders(response: Response, options: { share?: boolean } = {}): Response {
+  const headers = new Headers(response.headers);
+  for (const [name, value] of Object.entries(SECURITY_HEADERS)) headers.set(name, value);
+  if (options.share) headers.set("x-robots-tag", "noindex, nofollow, noarchive");
+  if ((headers.get("content-type") ?? "").includes("text/html")) {
+    headers.set("cache-control", "no-store");
+  }
+  return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
+
+export async function handleRequest(request: Request, env: WorkerEnv): Promise<Response> {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return withSecurityHeaders(Response.json({ error: "Method not allowed" }, {
+      status: 405,
+      headers: { Allow: "GET, HEAD" },
+    }));
+  }
+
+  const url = new URL(request.url);
+  if (url.pathname === "/health") {
+    return withSecurityHeaders(Response.json({ status: "ok" }));
+  }
+  const share = SHARE_PATH.test(url.pathname);
+  if (share) {
+    const assetUrl = new URL("/share.html", url.origin);
+    const assetRequest = new Request(assetUrl, { method: request.method, headers: request.headers });
+    return withSecurityHeaders(await env.ASSETS.fetch(assetRequest), { share: true });
+  }
+  return withSecurityHeaders(await env.ASSETS.fetch(request));
+}
+
+export default { fetch: handleRequest };

--- a/src/renderers/electrobun/view/app-services.ts
+++ b/src/renderers/electrobun/view/app-services.ts
@@ -7,7 +7,6 @@ import type { AppRuntimeServices, AppServicesFactoryOptions } from "../../../cor
 import { newsProvider } from "../../../capabilities";
 import { debugLog } from "../../../utils/debug-log";
 import { measurePerf, measurePerfAsync } from "../../../utils/perf-marks";
-import { getRendererBuiltinPlugins } from "../../../plugins/catalog-ui";
 import { createRemoteAssetDataClient } from "./remote/asset-data-client";
 import { RemotePersistence } from "./remote/persistence";
 import { RemoteTickerRepository } from "./remote/ticker-repository";
@@ -17,7 +16,7 @@ import { createCapabilityInvoker } from "./remote/capability-invoker";
 
 const servicesLog = debugLog.createLogger("services");
 
-export function createElectrobunAppServices({ config }: AppServicesFactoryOptions): AppRuntimeServices {
+export function createElectrobunAppServices({ config, plugins }: AppServicesFactoryOptions): AppRuntimeServices {
   servicesLog.info("create desktop web services start", {
     brokerInstanceCount: config.brokerInstances.length,
   });
@@ -57,7 +56,6 @@ export function createElectrobunAppServices({ config }: AppServicesFactoryOption
     },
   }));
 
-  const plugins = getRendererBuiltinPlugins();
   const pluginReadyPromises: Promise<void>[] = [];
   for (const plugin of plugins) {
     pluginReadyPromises.push(measurePerfAsync("startup.services.register-plugin", () => (

--- a/src/renderers/electrobun/view/build-assets.ts
+++ b/src/renderers/electrobun/view/build-assets.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile } from "fs/promises";
 import { join, relative } from "path";
 import { TITLEBAR_OVERLAY_HEIGHT_PX } from "../../../components/layout/titlebar-overlay";
 
-type AliasRule = readonly [string, string] | readonly [string, string, string];
+export type AliasRule = readonly [string, string] | readonly [string, string, string];
 type PageOptions = {
   entrypoint: string;
   outdir: string;
@@ -61,15 +61,7 @@ async function buildElectrobunViewBundle({
       // already reads from the environment is baked in at build time.
       __GLOOMBERB_API_URL__: JSON.stringify(process.env.GLOOMBERB_API_URL ?? ""),
     },
-    plugins: [
-      {
-        name: pluginName,
-        setup(build) {
-          const aliasRules = [...extraAliasRules, ...COMMON_ALIAS_RULES];
-          build.onResolve({ filter: /.*/ }, (args) => resolveAlias(args, aliasRules));
-        },
-      },
-    ],
+    plugins: [electrobunViewAliasPlugin(pluginName, extraAliasRules)],
   });
 
   if (!result.success) {
@@ -111,6 +103,16 @@ ${bootstrapScript}
   </body>
 </html>
 `;
+}
+
+export function electrobunViewAliasPlugin(name: string, extraAliasRules: AliasRule[] = []) {
+  return {
+    name,
+    setup(build: { onResolve(options: { filter: RegExp }, callback: (args: { path: string; importer?: string }) => unknown): void }) {
+      const aliasRules = [...extraAliasRules, ...COMMON_ALIAS_RULES];
+      build.onResolve({ filter: /.*/ }, (args) => resolveAlias(args, aliasRules));
+    },
+  };
 }
 
 function resolveAlias(args: { path: string; importer?: string }, aliasRules: AliasRule[]) {

--- a/src/renderers/electrobun/view/dom-ui-host.tsx
+++ b/src/renderers/electrobun/view/dom-ui-host.tsx
@@ -1,0 +1,142 @@
+/** @jsxImportSource react */
+import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
+import type { UiHost } from "../../../ui/host";
+import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "./input-host";
+import { WebDataTable } from "./data-table";
+import {
+  WebButton,
+  WebCheckbox,
+  WebDialogFrame,
+  WebListView,
+  WebMessageComposer,
+  WebPageStackView,
+  WebSegmentedControl,
+  WebTextField,
+} from "./desktop/controls";
+import { WebPopover } from "./desktop/popover";
+import { WebBox } from "./host/box";
+import { WebChartSurface } from "./host/chart-surface";
+import { WebInput, WebTextarea } from "./host/input";
+import { WebMediaSurface } from "./host/media-surface";
+import { WebScrollBox } from "./host/scroll-box";
+import { cleanDomProps, commonStyle } from "./host/style";
+import { WebAsciiText, WebSpan, WebStrong, WebText, WebUnderline } from "./host/text";
+import { WebTabs } from "./host/tabs";
+
+function currentDesktopPlatform(): string {
+  const navigatorWithUserAgentData = navigator as Navigator & {
+    userAgentData?: { platform?: string };
+  };
+  return [
+    navigatorWithUserAgentData.userAgentData?.platform,
+    navigator.platform,
+    navigator.userAgent,
+  ].filter((value): value is string => Boolean(value)).join(" ");
+}
+
+const DESKTOP_PLATFORM = currentDesktopPlatform();
+const USES_WINDOWS_CONTROLS = !/(darwin|ipad|iphone|linux|mac)/i.test(DESKTOP_PLATFORM);
+const NON_WINDOWS_DESKTOP_PLATFORMS = /^(darwin|linux|freebsd|openbsd|aix|sunos)$/i;
+
+function usesWindowsWindowControls(desktopPlatform?: string): boolean {
+  const platform = desktopPlatform?.trim();
+  if (!platform) return USES_WINDOWS_CONTROLS;
+  if (/^win/i.test(platform)) return true;
+  if (NON_WINDOWS_DESKTOP_PLATFORMS.test(platform)) return false;
+  return USES_WINDOWS_CONTROLS;
+}
+
+export function createDomUiHost(
+  desktopPlatform?: string,
+  options: {
+    nativeContextMenu?: boolean;
+    titleBarOverlay?: boolean;
+    nativePaneChrome?: boolean;
+    nativeWindowChrome?: boolean;
+    publicSharing?: boolean;
+  } = {},
+): UiHost {
+  const usesWindowsControls = options.titleBarOverlay !== false
+    && options.nativeWindowChrome !== false
+    && usesWindowsWindowControls(desktopPlatform);
+  return {
+    kind: "desktop-web",
+    capabilities: {
+      nativePaneChrome: options.nativePaneChrome ?? true,
+      titleBarOverlay: options.titleBarOverlay ?? true,
+      nativeWindowChrome: options.nativeWindowChrome ?? true,
+      publicSharing: options.publicSharing ?? false,
+      precisePointer: true,
+      fractionalViewport: true,
+      cellWidthPx: WEB_CELL_WIDTH,
+      cellHeightPx: WEB_CELL_HEIGHT,
+      pixelRatio: Math.min(window.devicePixelRatio || 1, 2),
+      canvasCharts: true,
+      nativeContextMenu: options.nativeContextMenu ?? false,
+      windowControls: usesWindowsControls ? "windows" : undefined,
+    },
+    Box: WebBox,
+    Text: WebText,
+    Span: WebSpan,
+    Strong: WebStrong,
+    Underline: WebUnderline,
+    ScrollBox: WebScrollBox,
+    Input: WebInput,
+    Textarea: WebTextarea,
+    Button: WebButton,
+    Checkbox: WebCheckbox,
+    Popover: WebPopover,
+    TextField: WebTextField,
+    MessageComposer: WebMessageComposer,
+    ListView: WebListView,
+    SegmentedControl: WebSegmentedControl,
+    DialogFrame: WebDialogFrame,
+    PageStackView: WebPageStackView,
+    DataTable: WebDataTable,
+    Tabs: WebTabs,
+    ChartSurface: WebChartSurface,
+    ImageSurface: ({ children, src, alt = "", objectFit = "contain", ...props }) => {
+      const imageSrc = typeof src === "string" ? src.trim() : "";
+      const [failed, setFailed] = useState(false);
+      useEffect(() => setFailed(false), [imageSrc]);
+      const baseStyle = commonStyle(props);
+      return (
+        <div
+          {...cleanDomProps(props)}
+          style={{
+            ...baseStyle,
+            overflow: baseStyle.overflow ?? "hidden",
+            ...(props.style as CSSProperties | undefined),
+          }}
+        >
+          {imageSrc && !failed ? (
+            <img
+              src={imageSrc}
+              alt={alt}
+              draggable={false}
+              onError={() => setFailed(true)}
+              style={{ width: "100%", height: "100%", display: "block", objectFit }}
+            />
+          ) : children as ReactNode}
+        </div>
+      );
+    },
+    MediaSurface: WebMediaSurface,
+    SpinnerMark: ({ color, ...props }) => (
+      <span
+        {...cleanDomProps(props)}
+        aria-hidden="true"
+        style={{
+          color,
+          display: "inline-block",
+          width: "1ch",
+          animation: "gloom-spin 0.9s steps(8) infinite",
+          ...(props.style as CSSProperties | undefined),
+        }}
+      >
+        *
+      </span>
+    ),
+    AsciiText: (props) => <WebAsciiText {...props} desktopPlatform={desktopPlatform} />,
+  };
+}

--- a/src/renderers/electrobun/view/host/input.tsx
+++ b/src/renderers/electrobun/view/host/input.tsx
@@ -10,9 +10,9 @@ import {
   type KeyboardEvent,
   type RefObject,
 } from "react";
-import type { InputRenderable, TextareaRenderable } from "../../../../ui/host";
+import { editableTextContextMenuItems } from "../../../../ui/context-menu";
+import { useRendererHost, useUiCapabilities, type InputRenderable, type TextareaRenderable } from "../../../../ui/host";
 import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "../input-host";
-import { NATIVE_CONTEXT_MENU_SUPPORTED, showEditableTextContextMenu } from "./native";
 import { cellHeight, cellWidth, cleanDomProps, commonStyle } from "./style";
 
 function textInputStyle(props: Record<string, unknown>, multiline: boolean): CSSProperties {
@@ -205,6 +205,8 @@ function textareaMetrics(
 }
 
 export const WebInput = forwardRef<InputRenderable, Record<string, unknown>>(function WebInput(props, ref) {
+  const renderer = useRendererHost();
+  const { nativeContextMenu } = useUiCapabilities();
   const elementRef = useRef<HTMLInputElement | null>(null);
   const propsRef = useLatestRef(props);
   const { value, valueRef, setValue } = useEditableValue(props);
@@ -287,11 +289,11 @@ export const WebInput = forwardRef<InputRenderable, Record<string, unknown>>(fun
       }}
       onKeyDown={handleKeyDown}
       onContextMenu={(event) => {
-        if (!NATIVE_CONTEXT_MENU_SUPPORTED) return;
+        if (!nativeContextMenu || !renderer.showContextMenu) return;
         elementRef.current?.focus();
         event.preventDefault();
         event.stopPropagation();
-        void showEditableTextContextMenu();
+        void renderer.showContextMenu(editableTextContextMenuItems());
       }}
       onSelect={() => {
         setCursorOffset(elementRef.current?.selectionStart ?? valueRef.current.length);
@@ -303,6 +305,8 @@ export const WebInput = forwardRef<InputRenderable, Record<string, unknown>>(fun
 });
 
 export const WebTextarea = forwardRef<TextareaRenderable, Record<string, unknown>>(function WebTextarea(props, ref) {
+  const renderer = useRendererHost();
+  const { nativeContextMenu } = useUiCapabilities();
   const elementRef = useRef<HTMLTextAreaElement | null>(null);
   const propsRef = useLatestRef(props);
   const { value, valueRef, setValue } = useEditableValue(props);
@@ -400,11 +404,11 @@ export const WebTextarea = forwardRef<TextareaRenderable, Record<string, unknown
       }}
       onKeyDown={handleKeyDown}
       onContextMenu={(event) => {
-        if (!NATIVE_CONTEXT_MENU_SUPPORTED) return;
+        if (!nativeContextMenu || !renderer.showContextMenu) return;
         elementRef.current?.focus();
         event.preventDefault();
         event.stopPropagation();
-        void showEditableTextContextMenu();
+        void renderer.showContextMenu(editableTextContextMenuItems());
       }}
       onSelect={() => {
         setCursorOffset(elementRef.current?.selectionStart ?? valueRef.current.length);

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -30,6 +30,7 @@ import { createDesktopDeepLinkBridge } from "./desktop-deeplink-bridge";
 import { createDesktopWindowBridge } from "./desktop/window/bridge";
 import { prepareDetachedSnapshot } from "./desktop/window/snapshot";
 import { createElectrobunAppServices } from "./app-services";
+import { getRendererBuiltinPlugins } from "../../../plugins/catalog-ui";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {
@@ -112,6 +113,7 @@ async function boot() {
                 <App
                   config={config}
                   servicesFactory={createElectrobunAppServices}
+                  plugins={getRendererBuiltinPlugins()}
                   desktopWindowBridge={desktopWindowBridge}
                   desktopApplicationMenuBridge={desktopApplicationMenuBridge}
                   desktopDeepLinkBridge={desktopDeepLinkBridge}

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -1,149 +1,15 @@
 /** @jsxImportSource react */
-import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
 import type { RendererHost, UiHost } from "../../../ui/host";
-import { WEB_CELL_HEIGHT, WEB_CELL_WIDTH } from "./input-host";
 import { backendRequest } from "./backend-rpc";
-import { WebDataTable } from "./data-table";
-import {
-  WebButton,
-  WebCheckbox,
-  WebDialogFrame,
-  WebListView,
-  WebMessageComposer,
-  WebPageStackView,
-  WebSegmentedControl,
-  WebTextField,
-} from "./desktop/controls";
-import { WebPopover } from "./desktop/popover";
-import { WebBox } from "./host/box";
-import { WebChartSurface } from "./host/chart-surface";
-import { WebInput, WebTextarea } from "./host/input";
-import { WebMediaSurface } from "./host/media-surface";
 import {
   NATIVE_CONTEXT_MENU_SUPPORTED,
   showDesktopContextMenu,
   startElectrobunWindowDrag,
 } from "./host/native";
-import { WebScrollBox } from "./host/scroll-box";
-import { cleanDomProps, commonStyle } from "./host/style";
-import { WebAsciiText, WebSpan, WebStrong, WebText, WebUnderline } from "./host/text";
-import { WebTabs } from "./host/tabs";
-
-function currentDesktopPlatform(): string {
-  const navigatorWithUserAgentData = navigator as Navigator & {
-    userAgentData?: { platform?: string };
-  };
-  return [
-    navigatorWithUserAgentData.userAgentData?.platform,
-    navigator.platform,
-    navigator.userAgent,
-  ].filter((value): value is string => Boolean(value)).join(" ");
-}
-
-const DESKTOP_PLATFORM = currentDesktopPlatform();
-const USES_WINDOWS_CONTROLS = !/(darwin|ipad|iphone|linux|mac)/i.test(DESKTOP_PLATFORM);
-const NON_WINDOWS_DESKTOP_PLATFORMS = /^(darwin|linux|freebsd|openbsd|aix|sunos)$/i;
-
-function usesWindowsWindowControls(desktopPlatform?: string): boolean {
-  const platform = desktopPlatform?.trim();
-  if (!platform) {
-    return USES_WINDOWS_CONTROLS;
-  }
-  if (/^win/i.test(platform)) {
-    return true;
-  }
-  if (NON_WINDOWS_DESKTOP_PLATFORMS.test(platform)) {
-    return false;
-  }
-  return USES_WINDOWS_CONTROLS;
-}
+import { createDomUiHost } from "./dom-ui-host";
 
 export function createWebUiHost(desktopPlatform?: string): UiHost {
-  const usesWindowsControls = usesWindowsWindowControls(desktopPlatform);
-
-  return {
-    kind: "desktop-web",
-    capabilities: {
-      nativePaneChrome: true,
-      titleBarOverlay: true,
-      precisePointer: true,
-      fractionalViewport: true,
-      cellWidthPx: WEB_CELL_WIDTH,
-      cellHeightPx: WEB_CELL_HEIGHT,
-      pixelRatio: Math.min(window.devicePixelRatio || 1, 2),
-      canvasCharts: true,
-      nativeContextMenu: NATIVE_CONTEXT_MENU_SUPPORTED,
-      windowControls: usesWindowsControls ? "windows" : undefined,
-    },
-    Box: WebBox,
-    Text: WebText,
-    Span: WebSpan,
-    Strong: WebStrong,
-    Underline: WebUnderline,
-    ScrollBox: WebScrollBox,
-    Input: WebInput,
-    Textarea: WebTextarea,
-    Button: WebButton,
-    Checkbox: WebCheckbox,
-    Popover: WebPopover,
-    TextField: WebTextField,
-    MessageComposer: WebMessageComposer,
-    ListView: WebListView,
-    SegmentedControl: WebSegmentedControl,
-    DialogFrame: WebDialogFrame,
-    PageStackView: WebPageStackView,
-    DataTable: WebDataTable,
-    Tabs: WebTabs,
-    ChartSurface: WebChartSurface,
-    ImageSurface: ({ children, src, alt = "", objectFit = "contain", ...props }) => {
-      const imageSrc = typeof src === "string" ? src.trim() : "";
-      const [failed, setFailed] = useState(false);
-      useEffect(() => setFailed(false), [imageSrc]);
-      const baseStyle = commonStyle(props);
-      return (
-        <div
-          {...cleanDomProps(props)}
-          style={{
-            ...baseStyle,
-            overflow: baseStyle.overflow ?? "hidden",
-            ...(props.style as CSSProperties | undefined),
-          }}
-        >
-          {imageSrc && !failed ? (
-            <img
-              src={imageSrc}
-              alt={alt}
-              draggable={false}
-              onError={() => setFailed(true)}
-              style={{
-                width: "100%",
-                height: "100%",
-                display: "block",
-                objectFit,
-              }}
-            />
-          ) : children as ReactNode}
-        </div>
-      );
-    },
-    MediaSurface: WebMediaSurface,
-    SpinnerMark: ({ color, ...props }) => (
-      <span
-        {...cleanDomProps(props)}
-        aria-hidden="true"
-        style={{
-          color,
-          display: "inline-block",
-          width: "1ch",
-          animation: "gloom-spin 0.9s steps(8) infinite",
-          ...(props.style as CSSProperties | undefined),
-        }}
-      >
-        *
-      </span>
-    ),
-    AsciiText: (props) => <WebAsciiText {...props} desktopPlatform={desktopPlatform} />,
-  };
+  return createDomUiHost(desktopPlatform, { nativeContextMenu: NATIVE_CONTEXT_MENU_SUPPORTED });
 }
 
 export const webUiHost: UiHost = createWebUiHost();
@@ -189,7 +55,7 @@ export const webRendererHost: RendererHost = {
     try {
       return await navigator.clipboard.readText();
     } catch {
-      return await backendRequest("host.readText");
+      return backendRequest("host.readText");
     }
   },
   notify(notification) {

--- a/src/renderers/opentui/start.tsx
+++ b/src/renderers/opentui/start.tsx
@@ -6,6 +6,7 @@ import { getDataDir, initDataDir, setConfigStoreHost } from "../../data/config/s
 import { applyLanguageFromConfig } from "../../i18n";
 import * as nodeConfigStoreHost from "../../data/config/store/node";
 import { loadExternalPlugins } from "../../plugins/loader";
+import { getLoadablePlugins } from "../../plugins/catalog";
 import { OpenTuiInputHostProvider } from "./input-host";
 import { debugLog } from "../../utils/debug-log";
 import { UiHostProvider } from "../../ui/host";
@@ -143,6 +144,7 @@ export async function startOpenTuiApp(options: StartOpenTuiAppOptions = {}): Pro
                 config={config}
                 servicesFactory={createAppServices}
                 externalPlugins={externalPlugins}
+                plugins={getLoadablePlugins(externalPlugins)}
                 cliLaunchRequest={cliLaunchRequest}
                 remoteControlAdapter={remoteControlAdapter}
               />

--- a/src/renderers/share/main.tsx
+++ b/src/renderers/share/main.tsx
@@ -1,0 +1,54 @@
+/** @jsxImportSource react */
+import "./styles.css";
+import { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { deleteShare, getShare, parseShareId, type ShareRecord } from "../../shares/api";
+import { ShareView } from "./view";
+
+function ShareApp() {
+  const id = parseShareId(window.location.pathname);
+  const [state, setState] = useState<{
+    share?: ShareRecord;
+    error?: string;
+    deleting?: boolean;
+    deleted?: boolean;
+  }>({});
+  useEffect(() => {
+    if (!id) return setState({ error: "Invalid share link." });
+    const controller = new AbortController();
+    getShare(id, (url, init) => fetch(url, { ...init, signal: controller.signal }))
+      .then((share) => setState(share ? { share } : { error: "This share is unavailable or has expired." }))
+      .catch(() => { if (!controller.signal.aborted) setState({ error: "This share could not be loaded." }); });
+    return () => controller.abort();
+  }, [id]);
+  const remove = async () => {
+    if (!id || !state.share?.ownedByViewer || state.deleting) return;
+    setState((current) => ({ ...current, deleting: true, error: undefined }));
+    try {
+      await deleteShare(id);
+      setState({ deleted: true });
+    } catch (error) {
+      setState((current) => ({
+        ...current,
+        deleting: false,
+        error: error instanceof Error ? error.message : "Could not delete share.",
+      }));
+    }
+  };
+  if (state.deleted) return <main><h1>Share deleted</h1><p>This link is no longer available.</p></main>;
+  if (state.share) {
+    return (
+      <ShareView
+        share={state.share}
+        deleting={state.deleting === true}
+        deleteError={state.error}
+        onDelete={state.share.ownedByViewer ? remove : undefined}
+      />
+    );
+  }
+  return <main><h1>Gloomberb</h1><p>{state.error ?? "Loading shared view..."}</p></main>;
+}
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Missing root element");
+createRoot(root).render(<ShareApp />);

--- a/src/renderers/share/styles.css
+++ b/src/renderers/share/styles.css
@@ -1,0 +1,19 @@
+html { color-scheme: dark; background: #272a34; color: #f2f2f2; font: 14px/1.55 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+body { margin: 0; }
+main { width: min(760px, calc(100% - 40px)); margin: 0 auto; padding: 64px 0; }
+main.wide { width: min(1180px, calc(100% - 40px)); }
+h1 { margin: 0 0 28px; color: #f1b94a; font-size: 24px; }
+a { display: inline-block; margin-top: 24px; color: #f1b94a; }
+.article-text { white-space: pre-wrap; overflow-wrap: anywhere; }
+.table-wrap { overflow: auto; border: 1px solid #4a4e5c; }
+table { width: 100%; border-collapse: collapse; }
+th, td { padding: 8px 10px; border-bottom: 1px solid #3a3e49; text-align: left; white-space: nowrap; }
+th { color: #f1b94a; background: #30333d; }
+.chart { width: 100%; height: auto; border: 1px solid #4a4e5c; background: #20232b; }
+.series { fill: none; stroke: #f1b94a; stroke-width: 2; vector-effect: non-scaling-stroke; }
+.series-1 { stroke: #62b8f6; } .series-2 { stroke: #7fd18a; } .series-3 { stroke: #ef7f7f; } .series-4 { stroke: #b697ef; } .series-5 { stroke: #e29b63; }
+.legend { display: flex; flex-wrap: wrap; gap: 10px 24px; padding: 0; list-style: none; color: #b8bbc5; }
+.owner-actions { display: flex; align-items: center; gap: 12px; margin-top: 32px; }
+.owner-actions button { border: 1px solid #6d7180; border-radius: 4px; padding: 6px 10px; background: transparent; color: #f2f2f2; font: inherit; cursor: pointer; }
+.owner-actions button:disabled { cursor: default; opacity: 0.55; }
+.owner-actions [role="alert"] { color: #ef7f7f; }

--- a/src/renderers/share/view.test.tsx
+++ b/src/renderers/share/view.test.tsx
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ShareView } from "./view";
+
+test("share rendering escapes content and protects external links", () => {
+  const html = renderToStaticMarkup(<ShareView share={{
+    kind: "article",
+    data: {
+      title: "<img src=x onerror=alert(1)>",
+      text: "<script>alert(1)</script>",
+      sourceUrl: "https://example.com/story",
+    },
+    createdAt: "2026-08-21T00:00:00Z",
+    expiresAt: "2026-09-20T00:00:00Z",
+    ownedByViewer: true,
+  }} onDelete={() => {}} />);
+  expect(html).not.toContain("<script>");
+  expect(html).toContain("&lt;script&gt;");
+  expect(html).toContain('target="_blank"');
+  expect(html).toContain('rel="noopener noreferrer"');
+  expect(html).toContain("Delete share");
+});

--- a/src/renderers/share/view.tsx
+++ b/src/renderers/share/view.tsx
@@ -1,0 +1,79 @@
+/** @jsxImportSource react */
+import type { ShareRecord } from "../../shares/api";
+
+function SourceLink({ url }: { url?: string }) {
+  return url ? <a href={url} target="_blank" rel="noopener noreferrer">View source</a> : null;
+}
+
+function OwnerActions({
+  deleting,
+  error,
+  onDelete,
+}: {
+  deleting: boolean;
+  error?: string;
+  onDelete?: () => void;
+}) {
+  if (!onDelete) return null;
+  return (
+    <div className="owner-actions">
+      <button type="button" disabled={deleting} onClick={onDelete}>
+        {deleting ? "Deleting..." : "Delete share"}
+      </button>
+      {error ? <span role="alert">{error}</span> : null}
+    </div>
+  );
+}
+
+export function ShareView({
+  share,
+  deleting = false,
+  deleteError,
+  onDelete,
+}: {
+  share: ShareRecord;
+  deleting?: boolean;
+  deleteError?: string;
+  onDelete?: () => void;
+}) {
+  const ownerActions = (
+    <OwnerActions deleting={deleting} error={deleteError} onDelete={onDelete} />
+  );
+  if (share.kind === "article") {
+    return <main><h1>{share.data.title}</h1><p className="article-text">{share.data.text}</p><SourceLink url={share.data.sourceUrl} />{ownerActions}</main>;
+  }
+  if (share.kind === "table") {
+    return (
+      <main className="wide">
+        <h1>{share.data.title}</h1>
+        <div className="table-wrap"><table><thead><tr>{share.data.columns.map((column) => <th key={column.key}>{column.label}</th>)}</tr></thead>
+          <tbody>{share.data.rows.map((row, index) => <tr key={index}>{share.data.columns.map((column) => <td key={column.key}>{String(row[column.key] ?? "")}</td>)}</tr>)}</tbody>
+        </table></div>
+        <SourceLink url={share.data.sourceUrl} />
+        {ownerActions}
+      </main>
+    );
+  }
+  const values = share.data.series.flatMap((series) => series.points.map((point) => point.y));
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  return (
+    <main className="wide">
+      <h1>{share.data.title}</h1>
+      <svg className="chart" viewBox="0 0 1000 420" role="img" aria-label={share.data.title}>
+        {share.data.series.map((series, seriesIndex) => {
+          const points = series.points.map((point, index) => {
+            const x = series.points.length <= 1 ? 500 : 20 + (index / (series.points.length - 1)) * 960;
+            const y = 400 - ((point.y - min) / span) * 380;
+            return `${x},${y}`;
+          }).join(" ");
+          return <polyline key={series.name} points={points} className={`series series-${seriesIndex % 6}`} />;
+        })}
+      </svg>
+      <ul className="legend">{share.data.series.map((series) => <li key={series.name}>{series.name}</li>)}</ul>
+      <SourceLink url={share.data.sourceUrl} />
+      {ownerActions}
+    </main>
+  );
+}

--- a/src/shares/api.test.ts
+++ b/src/shares/api.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { createShare, deleteShare, getShare, publicShareUrl, SHARE_API_ORIGIN } from "./api";
+import { parseSharePayload } from "./payload";
+
+const article = { kind: "article", data: { title: "AAPL", text: "Research", sourceUrl: "https://example.com/a" } } as const;
+const shareId = "0123456789abcdef0123456789abcdef";
+
+describe("share API client", () => {
+  test("validates strict payloads and http(s)-only source URLs", () => {
+    expect(parseSharePayload(article)).toEqual(article);
+    expect(parseSharePayload({ ...article, data: { ...article.data, sourceUrl: "javascript:alert(1)" } })).toBeNull();
+    expect(parseSharePayload({ kind: "table", data: { title: "x", columns: [], rows: [] } })).toBeNull();
+  });
+
+  test("creates and deletes through api.gloom.sh with credentials", async () => {
+    const calls: Array<[string, RequestInit | undefined]> = [];
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push([String(url), init]);
+      return init?.method === "DELETE"
+        ? new Response(null, { status: 204 })
+        : Response.json({ id: shareId, expiresAt: "2026-09-20T00:00:00.000Z" });
+    }) as typeof fetch;
+    const created = await createShare(article, fetchImpl);
+    await deleteShare(created.id, fetchImpl);
+    expect(calls[0]).toEqual([`${SHARE_API_ORIGIN}/shares`, expect.objectContaining({ method: "POST", credentials: "include" })]);
+    expect(calls[1]).toEqual([`${SHARE_API_ORIGIN}/shares/${shareId}`, expect.objectContaining({ method: "DELETE", credentials: "include" })]);
+  });
+
+  test("loads public shares with optional owner credentials and builds current-origin URLs", async () => {
+    let init: RequestInit | undefined;
+    const fetchImpl = (async (_url: string | URL | Request, options?: RequestInit) => {
+      init = options;
+      return Response.json({
+        ...article,
+        createdAt: "2026-08-21T00:00:00Z",
+        expiresAt: "2026-09-20T00:00:00Z",
+        ownedByViewer: true,
+      });
+    }) as typeof fetch;
+    const share = await getShare(shareId, fetchImpl);
+    expect(share?.kind).toBe("article");
+    expect(share?.ownedByViewer).toBe(true);
+    expect(init?.credentials).toBe("include");
+    expect(publicShareUrl(shareId, "https://term.gloom.sh")).toBe(`https://term.gloom.sh/s/${shareId}`);
+  });
+});

--- a/src/shares/api.ts
+++ b/src/shares/api.ts
@@ -1,0 +1,92 @@
+import { parseSharePayload, type SharePayload } from "./payload";
+
+export const SHARE_API_ORIGIN = "https://api.gloom.sh";
+const SHARE_ID = /^[a-f0-9]{32}$/;
+type ShareFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+export type ShareRecord = SharePayload & {
+  createdAt: string;
+  expiresAt: string;
+  ownedByViewer: boolean;
+};
+
+export interface CreatedShare {
+  id: string;
+  expiresAt: string;
+}
+
+function validDate(value: unknown): value is string {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  try { return await response.json(); } catch { throw new Error("The share service returned an invalid response."); }
+}
+
+export async function createShare(payload: SharePayload, fetchImpl: ShareFetch = fetch): Promise<CreatedShare> {
+  const validated = parseSharePayload(payload);
+  if (!validated) throw new Error("Invalid share payload.");
+  const response = await fetchImpl(`${SHARE_API_ORIGIN}/shares`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(validated),
+  });
+  if (!response.ok) throw new Error(response.status === 401 ? "Sign in to Gloom Cloud to share." : "Could not create share.");
+  const body = await readJson(response);
+  if (!body || typeof body !== "object") throw new Error("The share service returned an invalid response.");
+  const { id, expiresAt } = body as Record<string, unknown>;
+  if (typeof id !== "string" || !SHARE_ID.test(id) || !validDate(expiresAt)) {
+    throw new Error("The share service returned an invalid response.");
+  }
+  return { id, expiresAt };
+}
+
+export async function getShare(id: string, fetchImpl: ShareFetch = fetch): Promise<ShareRecord | null> {
+  if (!SHARE_ID.test(id)) return null;
+  const response = await fetchImpl(`${SHARE_API_ORIGIN}/shares/${encodeURIComponent(id)}`, {
+    credentials: "include",
+  });
+  if (response.status === 404) return null;
+  if (!response.ok) throw new Error("Could not load share.");
+  const body = await readJson(response);
+  if (!body || typeof body !== "object") return null;
+  const object = body as Record<string, unknown>;
+  const payload = parseSharePayload({ kind: object.kind, data: object.data });
+  if (!payload || !validDate(object.createdAt) || !validDate(object.expiresAt)) return null;
+  return {
+    ...payload,
+    createdAt: object.createdAt,
+    expiresAt: object.expiresAt,
+    ownedByViewer: object.ownedByViewer === true,
+  };
+}
+
+export async function deleteShare(id: string, fetchImpl: ShareFetch = fetch): Promise<void> {
+  if (!SHARE_ID.test(id)) throw new Error("Invalid share id.");
+  const response = await fetchImpl(`${SHARE_API_ORIGIN}/shares/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    credentials: "include",
+  });
+  if (response.status !== 204) {
+    throw new Error(response.status === 401 || response.status === 403
+      ? "Only the signed-in owner can delete this share."
+      : "Could not delete share.");
+  }
+}
+
+export function publicShareUrl(id: string, origin = window.location.origin): string {
+  if (!SHARE_ID.test(id)) throw new Error("Invalid share id.");
+  return new URL(`/s/${encodeURIComponent(id)}`, origin).toString();
+}
+
+export function parseShareId(pathname: string): string | null {
+  const match = /^\/s\/([^/]+)\/?$/.exec(pathname);
+  if (!match) return null;
+  try {
+    const id = decodeURIComponent(match[1] ?? "");
+    return SHARE_ID.test(id) ? id : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/shares/chart-snapshot.test.ts
+++ b/src/shares/chart-snapshot.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import type { ResolvedSeries } from "../time-series/types";
+import { buildChartShareData } from "./chart-snapshot";
+
+function series(pointCount: number): ResolvedSeries {
+  return {
+    id: "price",
+    label: "AAPL",
+    color: "#fff",
+    unit: "USD",
+    unitGroup: "currency:USD",
+    nativeFrequency: "daily",
+    dataShape: "scalar",
+    style: "line",
+    transform: "raw",
+    axis: "left",
+    panelId: "main",
+    interpolation: "none",
+    points: Array.from({ length: pointCount }, (_, index) => ({
+      date: new Date(Date.UTC(2025, 0, index + 1)),
+      observedAt: new Date(Date.UTC(2025, 0, index + 1)),
+      value: index,
+    })),
+  };
+}
+
+describe("chart share snapshots", () => {
+  test("keeps endpoints while bounding shared chart points", () => {
+    const shared = buildChartShareData([series(1_000)]);
+    expect(shared?.series[0]?.points).toHaveLength(500);
+    expect(shared?.series[0]?.points[0]?.y).toBe(0);
+    expect(shared?.series[0]?.points.at(-1)?.y).toBe(999);
+  });
+})

--- a/src/shares/chart-snapshot.ts
+++ b/src/shares/chart-snapshot.ts
@@ -1,0 +1,28 @@
+import type { ResolvedSeries } from "../time-series/types";
+import type { ChartShareData } from "./payload";
+
+const MAX_POINTS = 500;
+
+function sample<T>(values: T[], limit: number): T[] {
+  if (values.length <= limit) return values;
+  return Array.from({ length: limit }, (_, index) => (
+    values[Math.round(index * (values.length - 1) / (limit - 1))]!
+  ));
+}
+
+export function buildChartShareData(series: ResolvedSeries[]): ChartShareData | null {
+  const sharedSeries = series.flatMap((entry) => {
+    const points = entry.points.flatMap((point) => {
+      const y = point.value ?? point.close;
+      return typeof y === "number" && Number.isFinite(y)
+        ? [{ x: point.date.toISOString(), y }]
+        : [];
+    });
+    return points.length > 0 ? [{ name: entry.label, points: sample(points, MAX_POINTS) }] : [];
+  });
+  if (sharedSeries.length === 0) return null;
+  return {
+    title: sharedSeries.map((entry) => entry.name).join(" / "),
+    series: sharedSeries,
+  };
+}

--- a/src/shares/payload.ts
+++ b/src/shares/payload.ts
@@ -1,0 +1,104 @@
+import { safeExternalUrl } from "../utils/external-url";
+
+export const MAX_SHARE_BYTES = 128 * 1024;
+const MAX_TITLE_LENGTH = 200;
+const MAX_TEXT_LENGTH = 50_000;
+const MAX_TABLE_COLUMNS = 20;
+const MAX_TABLE_ROWS = 200;
+const MAX_CHART_SERIES = 20;
+const MAX_CHART_POINTS = 500;
+
+type CellValue = string | number | boolean | null;
+
+export interface TableShareData {
+  title: string;
+  columns: Array<{ key: string; label: string }>;
+  rows: Array<Record<string, CellValue>>;
+  sourceUrl?: string;
+}
+
+export interface ChartShareData {
+  title: string;
+  series: Array<{
+    name: string;
+    points: Array<{ x: string | number; y: number }>;
+  }>;
+  sourceUrl?: string;
+}
+
+export interface ArticleShareData {
+  title: string;
+  text: string;
+  sourceUrl?: string;
+}
+
+export type SharePayload =
+  | { kind: "table"; data: TableShareData }
+  | { kind: "chart"; data: ChartShareData }
+  | { kind: "article"; data: ArticleShareData };
+
+function record(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function shortString(value: unknown, max = MAX_TITLE_LENGTH): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= max;
+}
+
+function safeOptionalUrl(value: unknown): value is string | undefined {
+  return value === undefined || (typeof value === "string" && safeExternalUrl(value) !== null);
+}
+
+function isCell(value: unknown): value is CellValue {
+  return value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+}
+
+function isTableData(value: unknown): value is TableShareData {
+  if (!record(value) || !shortString(value.title) || !safeOptionalUrl(value.sourceUrl)) return false;
+  if (!Array.isArray(value.columns) || value.columns.length === 0 || value.columns.length > MAX_TABLE_COLUMNS) return false;
+  const keys = new Set<string>();
+  for (const column of value.columns) {
+    if (!record(column) || !shortString(column.key, 80) || !shortString(column.label, 120) || keys.has(column.key)) return false;
+    keys.add(column.key);
+  }
+  return Array.isArray(value.rows)
+    && value.rows.length <= MAX_TABLE_ROWS
+    && value.rows.every((row) => record(row)
+      && Object.keys(row).every((key) => keys.has(key))
+      && Object.values(row).every(isCell));
+}
+
+function isChartData(value: unknown): value is ChartShareData {
+  if (!record(value) || !shortString(value.title) || !safeOptionalUrl(value.sourceUrl)) return false;
+  return Array.isArray(value.series)
+    && value.series.length > 0
+    && value.series.length <= MAX_CHART_SERIES
+    && value.series.every((series) => record(series)
+      && shortString(series.name, 120)
+      && Array.isArray(series.points)
+      && series.points.length > 0
+      && series.points.length <= MAX_CHART_POINTS
+      && series.points.every((point) => record(point)
+        && ((typeof point.x === "string" && point.x.length <= 100) || (typeof point.x === "number" && Number.isFinite(point.x)))
+        && typeof point.y === "number"
+        && Number.isFinite(point.y)));
+}
+
+function isArticleData(value: unknown): value is ArticleShareData {
+  return record(value)
+    && shortString(value.title)
+    && typeof value.text === "string"
+    && value.text.length <= MAX_TEXT_LENGTH
+    && safeOptionalUrl(value.sourceUrl);
+}
+
+export function parseSharePayload(value: unknown): SharePayload | null {
+  if (!record(value) || !shortString(value.kind, 20) || !("data" in value)) return null;
+  let json: string;
+  try { json = JSON.stringify(value); } catch { return null; }
+  if (new TextEncoder().encode(json).byteLength > MAX_SHARE_BYTES) return null;
+  if (value.kind === "table" && isTableData(value.data)) return value as unknown as SharePayload;
+  if (value.kind === "chart" && isChartData(value.data)) return value as unknown as SharePayload;
+  if (value.kind === "article" && isArticleData(value.data)) return value as unknown as SharePayload;
+  return null;
+}

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -336,6 +336,10 @@ export interface UiHost {
   capabilities?: {
     nativePaneChrome?: boolean;
     titleBarOverlay?: boolean;
+    /** Native drag regions and traffic-light/window-control spacing. */
+    nativeWindowChrome?: boolean;
+    /** Enables public snapshot sharing controls for this host. */
+    publicSharing?: boolean;
     precisePointer?: boolean;
     fractionalViewport?: boolean;
     cellWidthPx?: number;

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+  },
+  "files": [
+    "src/renderers/browser/main.tsx",
+    "src/renderers/share/main.tsx"
+  ]
+}

--- a/tsconfig.cloudflare.json
+++ b/tsconfig.cloudflare.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ESNext", "WebWorker"]
+  },
+  "files": ["src/renderers/cloudflare/worker.ts"]
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "gloomberb-web",
+  "main": "src/renderers/cloudflare/worker.ts",
+  "compatibility_date": "2026-08-21",
+  "assets": {
+    "directory": "./dist/web",
+    "binding": "ASSETS",
+    "run_worker_first": true
+  }
+}


### PR DESCRIPTION
## Summary

Adds an official browser-hosted Gloomberb target for `term.gloom.sh`.

- reuses the existing first-party DOM components and current official header/layout
- adds a reviewed browser plugin catalog rather than loading or stubbing native plugins
- stores anonymous browser config, tickers, layouts, sessions, and plugin state in localStorage
- talks directly to `api.gloom.sh` for credentialed Cloud REST, sync, chat, and WebSockets
- adds a slim public share bundle with authenticated creation, owner deletion, and public reads
- adds a static-only Cloudflare Worker with an enforced CSP and no API/session proxy
- adds browser builds, bundle audits, Worker dry-runs, typechecking, CI, and documentation

## Browser boundary

The initial browser catalog keeps Cloud-backed and browser-safe functionality, including portfolio/watchlists, ticker research, charts, options and OVME, news, scanners, market/macro boards, Treasury auctions, alerts, chat, and Cloud sync.

It excludes native brokers, filesystem notes, local AI, external plugins, updater/debug tools, native window functions, and modules still tied to CORS-blocked or desktop-only feeds. Unsupported modules are absent from discovery and from the public bundle.

Production account IDs, routes, domains, and deployment credentials are intentionally absent. The private platform repository owns the `term.gloom.sh` deployment and API share persistence.

## Security

- no browser-visible session token or inline bootstrap script
- exact reviewed plugin and outbound-origin sets
- no arbitrary HTTP proxy
- enforced CSP, frame denial, no-referrer, HSTS, CORP, and permissions policy
- bounded and validated share snapshots with http(s)-only source links
- public bundle audit rejects source maps, native bridge code, fork domains, and unsupported providers

## Validation

- `bun run typecheck`
- `bun test` (2,237 passed)
- `bun run web:audit`
- `bun run cloudflare:dry-run`
- `bun run desktop:view:build`
- `bun run build` including signed binary smoke test
- Playwriter smoke test in Chrome: current header and pane chrome, no native window controls, local persistence, AAPL ticker research, OVME, and live Treasury Auctions

## Attribution

Adapted from the hosted-web work developed by Lucas Kohorst in `Lucas-Kohorst/gloomberb`, especially foundational commit `85eab8f5`.

Co-authored-by: Lucas Kohorst <kohorstlucas@gmail.com>
