### PR TITLE
Explain share email verification

### DIFF
--- a/src/shares/api.test.ts
+++ b/src/shares/api.test.ts
@@ -26,6 +26,16 @@ describe("share API client", () => {
     expect(calls[1]).toEqual([`${SHARE_API_ORIGIN}/shares/${shareId}`, expect.objectContaining({ method: "DELETE", credentials: "include" })]);
   });
 
+  test("explains when a Cloud account still needs email verification", async () => {
+    const fetchImpl = (async () => Response.json(
+      { error: "Email verification required" },
+      { status: 403 },
+    )) as typeof fetch;
+    await expect(createShare(article, fetchImpl)).rejects.toThrow(
+      "Verify your Gloom Cloud email to share.",
+    );
+  });
+
   test("loads public shares with optional owner credentials and builds current-origin URLs", async () => {
     let init: RequestInit | undefined;
     const fetchImpl = (async (_url: string | URL | Request, options?: RequestInit) => {

--- a/src/shares/api.ts
+++ b/src/shares/api.ts
@@ -32,7 +32,11 @@ export async function createShare(payload: SharePayload, fetchImpl: ShareFetch =
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(validated),
   });
-  if (!response.ok) throw new Error(response.status === 401 ? "Sign in to Gloom Cloud to share." : "Could not create share.");
+  if (!response.ok) {
+    if (response.status === 401) throw new Error("Sign in to Gloom Cloud to share.");
+    if (response.status === 403) throw new Error("Verify your Gloom Cloud email to share.");
+    throw new Error("Could not create share.");
+  }
   const body = await readJson(response);
   if (!body || typeof body !== "object") throw new Error("The share service returned an invalid response.");
   const { id, expiresAt } = body as Record<string, unknown>;


### PR DESCRIPTION
## Summary

Shows a specific verification message when a signed-in but unverified Gloom Cloud account tries to create a public share.

## Validation

- share API tests
- browser TypeScript