### PR TITLE
Preserve terminal origin on API requests

### DIFF
--- a/src/renderers/cloudflare/worker.test.ts
+++ b/src/renderers/cloudflare/worker.test.ts
@@ -30,7 +30,7 @@ describe("static Cloudflare host", () => {
     expect(response.headers.get("content-security-policy")).toBe(SECURITY_HEADERS["content-security-policy"]);
     expect(response.headers.has("content-security-policy-report-only")).toBe(false);
     expect(response.headers.get("x-frame-options")).toBe("DENY");
-    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(response.headers.get("referrer-policy")).toBe("strict-origin-when-cross-origin");
     expect(response.headers.get("cache-control")).toBe("no-store");
   });
 

--- a/src/renderers/cloudflare/worker.ts
+++ b/src/renderers/cloudflare/worker.ts
@@ -13,7 +13,7 @@ export const SECURITY_HEADERS = {
   "cross-origin-opener-policy": "same-origin",
   "cross-origin-resource-policy": "same-origin",
   "permissions-policy": "camera=(), geolocation=(), microphone=(), payment=(), usb=()",
-  "referrer-policy": "no-referrer",
+  "referrer-policy": "strict-origin-when-cross-origin",
   "strict-transport-security": "max-age=31536000; includeSubDomains",
   "x-content-type-options": "nosniff",
   "x-frame-options": "DENY",


### PR DESCRIPTION
## Summary

Changes the hosted terminal referrer policy from `no-referrer` to `strict-origin-when-cross-origin`.

Cloudflare Browser Integrity Check rejects credentialed browser requests to `api.gloom.sh` when `term.gloom.sh` suppresses the referrer entirely. Sending only the origin preserves privacy while allowing the existing API security layer to validate first-party browser traffic.

## Validation

- Worker security-header tests
- Cloudflare TypeScript
- web bundle audit
- Wrangler dry-run
- reproduced the blocked credentialed request with Playwriter and Cloudflare Ray diagnostics