### PR TITLE
fix(web): stop anonymous session request storms

### DIFF
--- a/src/api-client/auth.ts
+++ b/src/api-client/auth.ts
@@ -57,15 +57,6 @@ export class CloudAuthApi {
     });
   }
 
-  async ensureVerifiedSession(): Promise<AuthUser | null> {
-    if (!this.options.hasSessionCredential()) return null;
-    if (!this.options.getCurrentUser()) {
-      await this.getSession();
-    }
-    const user = this.options.getCurrentUser();
-    return user?.emailVerified ? user : null;
-  }
-
   async signUp(email: string, username: string, name: string, password: string): Promise<AuthUser> {
     const result = await this.options.request<{ user: AuthUser }>("/auth/sign-up/email", {
       method: "POST",

--- a/src/api-client/index.test.ts
+++ b/src/api-client/index.test.ts
@@ -118,6 +118,29 @@ describe("apiClient auth cookies", () => {
     expect(apiClient.isVerified()).toBe(true);
   });
 
+  test("coalesces anonymous browser session checks and remembers the result", async () => {
+    apiClient.setCookieSessionMode(true);
+    let requests = 0;
+    let finishRequest!: () => void;
+    setCloudApiFetchTransport(async () => {
+      requests += 1;
+      await new Promise<void>((resolve) => { finishRequest = resolve; });
+      return createResponse({ user: null });
+    });
+
+    const checks = [
+      apiClient.ensureVerifiedSession(),
+      apiClient.ensureVerifiedSession(),
+      apiClient.ensureVerifiedSession(),
+    ];
+    expect(requests).toBe(1);
+    finishRequest();
+
+    await expect(Promise.all(checks)).resolves.toEqual([null, null, null]);
+    await expect(apiClient.ensureVerifiedSession()).resolves.toBeNull();
+    expect(requests).toBe(1);
+  });
+
   test("captures secure session cookies after login and reuses them on session refresh", async () => {
     const seenCookies: Array<string | null> = [];
 

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -73,6 +73,8 @@ const ASSIST_REQUEST_TIMEOUT_MS = 6_000;
 
 class GloomApiClient {
   private currentUser: AuthUser | null = null;
+  private sessionChecked = false;
+  private sessionRequest: Promise<AuthUser | null> | null = null;
   private readonly currentUserListeners = new Set<() => void>();
   private readonly transport = new CloudApiRequestTransport();
   private readonly auth: CloudAuthApi;
@@ -126,11 +128,13 @@ class GloomApiClient {
   }
 
   setCookieSessionMode(enabled: boolean): void {
+    this.sessionChecked = false;
     this.transport.setCookieSessionMode(enabled);
   }
 
   setSessionToken(token: string | null): void {
     const changed = this.transport.getSessionToken() !== token;
+    this.sessionChecked = false;
     this.transport.setSessionToken(token);
     if (!token) {
       this.currentUser = null;
@@ -208,7 +212,9 @@ class GloomApiClient {
   }
 
   async ensureVerifiedSession(): Promise<AuthUser | null> {
-    return this.auth.ensureVerifiedSession();
+    if (!this.transport.hasSessionCredential()) return null;
+    if (!this.currentUser && !this.sessionChecked) await this.getSession();
+    return this.currentUser?.emailVerified ? this.currentUser : null;
   }
 
   async signUp(email: string, username: string, name: string, password: string): Promise<AuthUser> {
@@ -232,7 +238,15 @@ class GloomApiClient {
   }
 
   async getSession(): Promise<AuthUser | null> {
-    return this.auth.getSession();
+    if (this.sessionRequest) return this.sessionRequest;
+    this.sessionRequest = this.auth.getSession();
+    try {
+      const user = await this.sessionRequest;
+      this.sessionChecked = true;
+      return user;
+    } finally {
+      this.sessionRequest = null;
+    }
   }
 
   async sendVerification(): Promise<CloudVerificationResponse> {

--- a/src/plugins/builtin/portfolio-list/pane/index.test.tsx
+++ b/src/plugins/builtin/portfolio-list/pane/index.test.tsx
@@ -431,6 +431,7 @@ async function renderHiddenChangePctSortWarmup(options: { staleCachedSiveSnapsho
           previousClose: 0,
           listingExchangeName: "NASDAQ",
           lastUpdated: Date.now() - 24 * 60 * 60_000,
+          stale: true,
         }),
       },
     }]);


### PR DESCRIPTION
## Problem

Anonymous browser sessions mark cookie auth as available because HttpOnly cookies cannot be inspected from JavaScript. Every cloud provider check therefore repeated `/auth/get-session` after the initial empty session result. A normal page load issued 8 session requests and 14 API requests at once, triggering intermittent Cloudflare 403 responses before CORS and leaving Chat and News on `Failed to fetch`.

## Fix

- Coalesce concurrent session reads through one in-flight request
- Remember a completed anonymous session check until auth state changes
- Preserve retry behavior after transient failures
- Add a regression test for concurrent and repeated anonymous checks
- Make an existing stale-snapshot fixture explicitly stale so weekend CI is deterministic

## Validation

- Focused API/browser tests: 35 passed
- Portfolio pane tests: 20 passed
- Typecheck: passed
- Web bundle audit: passed

Production Playwriter baseline before this patch: 14 API requests, 8 duplicate session requests, all 14 failed with Cloudflare 403/CORS.