### PR TITLE
fix(web): proxy cloud traffic through terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ The desktop app and TUI share the full command language and plugin system. The b
 
 ## Browser App
 
-[term.gloom.sh](https://term.gloom.sh) works anonymously with configuration, tickers, layouts, session state, and plugin state stored in the browser. Gloom Cloud login is optional and enables cloud-backed market data, chat, and sync. Cloud REST and WebSocket traffic goes directly to `https://api.gloom.sh`; the static host never receives Gloom credentials.
+[term.gloom.sh](https://term.gloom.sh) works anonymously with configuration, tickers, layouts, session state, and plugin state stored in the browser. Gloom Cloud login is optional and enables cloud-backed market data, chat, and sync. Cloud REST and WebSocket traffic uses the same-origin `/api` path, which the Worker forwards only to `https://api.gloom.sh`; it is not an arbitrary network proxy.
 
-The browser build intentionally omits brokers and native integrations, filesystem notes, local AI, external plugins, updater/debug tools, application menus, native window controls, pop-out native windows, and native context menus. Modules that still depend on desktop-only or CORS-blocked feeds are also absent for now: RSS/Substack, prediction markets and polls, market halts/heatmap/movers, dividend/ownership/SEC panes, earnings/IPO, and TV. Public shares open under `/s/:id` in a separate slim bundle. Share creation and owner deletion use the signed-in Gloom Cloud session directly on the API; public reads require no account.
+The browser build intentionally omits brokers and native integrations, filesystem notes, local AI, external plugins, updater/debug tools, application menus, native window controls, pop-out native windows, and native context menus. Modules that still depend on desktop-only or CORS-blocked feeds are also absent for now: RSS/Substack, prediction markets and polls, market halts/heatmap/movers, dividend/ownership/SEC panes, earnings/IPO, and TV. Public shares open under `/s/:id` in a separate slim bundle. Share creation and owner deletion use the signed-in Gloom Cloud session through the same fixed API path; public reads require no account.
 
 Local browser development:
 

--- a/scripts/build-web.ts
+++ b/scripts/build-web.ts
@@ -24,7 +24,6 @@ async function buildPage(name: string, entrypoint: string, title: string, loadin
     define: {
       "process.env.NODE_ENV": '"production"',
       __GLOOMBERB_API_URL__: "location.origin",
-      __GLOOMBERB_API_PATH__: '"/api"',
     },
     plugins: [electrobunViewAliasPlugin(`browser-${name}-native-stubs`)],
   });

--- a/scripts/build-web.ts
+++ b/scripts/build-web.ts
@@ -23,7 +23,8 @@ async function buildPage(name: string, entrypoint: string, title: string, loadin
     sourcemap: "none",
     define: {
       "process.env.NODE_ENV": '"production"',
-      __GLOOMBERB_API_URL__: '"https://api.gloom.sh"',
+      __GLOOMBERB_API_URL__: "location.origin",
+      __GLOOMBERB_API_PATH__: '"/api"',
     },
     plugins: [electrobunViewAliasPlugin(`browser-${name}-native-stubs`)],
   });

--- a/src/api-client/request.ts
+++ b/src/api-client/request.ts
@@ -23,11 +23,13 @@ export function setCloudApiFetchTransport(transport: CloudApiFetchTransport | nu
 }
 
 declare const __GLOOMBERB_API_URL__: string | undefined;
+declare const __GLOOMBERB_API_PATH__: string | undefined;
 
 function getCloudApiBaseUrl(): string {
-  // Browser bundles have no `process`; the build replaces this with a literal.
+  // Browser bundles have no `process`; the build replaces these with literals.
   const bundled = typeof __GLOOMBERB_API_URL__ === "string" ? __GLOOMBERB_API_URL__ : "";
-  if (bundled) return bundled;
+  const path = typeof __GLOOMBERB_API_PATH__ === "string" ? __GLOOMBERB_API_PATH__ : "";
+  if (bundled) return `${bundled}${path}`;
   if (typeof process === "undefined") {
     return DEFAULT_API_URL;
   }

--- a/src/api-client/request.ts
+++ b/src/api-client/request.ts
@@ -23,13 +23,15 @@ export function setCloudApiFetchTransport(transport: CloudApiFetchTransport | nu
 }
 
 declare const __GLOOMBERB_API_URL__: string | undefined;
-declare const __GLOOMBERB_API_PATH__: string | undefined;
 
 function getCloudApiBaseUrl(): string {
-  // Browser bundles have no `process`; the build replaces these with literals.
+  // Browser bundles have no `process`; the build replaces this with a literal.
   const bundled = typeof __GLOOMBERB_API_URL__ === "string" ? __GLOOMBERB_API_URL__ : "";
-  const path = typeof __GLOOMBERB_API_PATH__ === "string" ? __GLOOMBERB_API_PATH__ : "";
-  if (bundled) return `${bundled}${path}`;
+  if (bundled) {
+    return typeof location !== "undefined" && bundled === location.origin
+      ? `${bundled}/api`
+      : bundled;
+  }
   if (typeof process === "undefined") {
     return DEFAULT_API_URL;
   }

--- a/src/renderers/cloudflare/worker.test.ts
+++ b/src/renderers/cloudflare/worker.test.ts
@@ -41,7 +41,46 @@ describe("static Cloudflare host", () => {
     expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow, noarchive");
   });
 
-  test("rejects every mutation without invoking assets or outbound fetch", async () => {
+  test("proxies only the same-origin API path to api.gloom.sh", async () => {
+    const { env, requests } = fixture();
+    let upstream: Request | undefined;
+    const response = await handleRequest(new Request("https://term.example/api/chat/channels/everyone/messages?limit=1", {
+      method: "POST",
+      headers: {
+        Cookie: "session=browser-cookie",
+        Origin: "https://term.example",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ content: "hello" }),
+    }), env, async (request) => {
+      upstream = request;
+      return Response.json({ ok: true });
+    });
+
+    expect(response.status).toBe(200);
+    expect(requests).toHaveLength(0);
+    expect(upstream?.url).toBe("https://api.gloom.sh/chat/channels/everyone/messages?limit=1");
+    expect(upstream?.method).toBe("POST");
+    expect(upstream?.headers.get("cookie")).toBe("session=browser-cookie");
+    expect(upstream?.headers.get("origin")).toBe("https://term.example");
+    expect(await upstream?.text()).toBe('{"content":"hello"}');
+  });
+
+  test("rejects cross-origin API requests before proxying", async () => {
+    const { env } = fixture();
+    let proxied = false;
+    const response = await handleRequest(new Request("https://term.example/api/auth/sign-out", {
+      method: "POST",
+      headers: { Origin: "https://attacker.example" },
+    }), env, async () => {
+      proxied = true;
+      return new Response();
+    });
+    expect(response.status).toBe(403);
+    expect(proxied).toBe(false);
+  });
+
+  test("rejects every non-API mutation without invoking assets or outbound fetch", async () => {
     const { env, requests } = fixture();
     const response = await handleRequest(new Request("https://term.example/shares", {
       method: "POST",

--- a/src/renderers/cloudflare/worker.ts
+++ b/src/renderers/cloudflare/worker.ts
@@ -7,9 +7,13 @@ export interface WorkerEnv {
 }
 
 const SHARE_PATH = /^\/s\/[a-f0-9]{32}\/?$/;
+const API_PATH = /^\/api(?:\/|$)/;
+const API_ORIGIN = "https://api.gloom.sh";
+const API_METHODS = new Set(["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]);
+type ApiFetch = (request: Request) => Promise<Response>;
 
 export const SECURITY_HEADERS = {
-  "content-security-policy": "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; media-src 'self' https:; connect-src 'self' https://api.gloom.sh wss://api.gloom.sh https://api.github.com https://api.fiscaldata.treasury.gov; form-action 'self' https://api.gloom.sh; upgrade-insecure-requests",
+  "content-security-policy": "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; media-src 'self' https:; connect-src 'self' https://api.github.com https://api.fiscaldata.treasury.gov; form-action 'self'; upgrade-insecure-requests",
   "cross-origin-opener-policy": "same-origin",
   "cross-origin-resource-policy": "same-origin",
   "permissions-policy": "camera=(), geolocation=(), microphone=(), payment=(), usb=()",
@@ -29,7 +33,26 @@ export function withSecurityHeaders(response: Response, options: { share?: boole
   return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
 }
 
-export async function handleRequest(request: Request, env: WorkerEnv): Promise<Response> {
+async function proxyApi(request: Request, fetchApi: ApiFetch): Promise<Response> {
+  const url = new URL(request.url);
+  if (!API_METHODS.has(request.method)) {
+    return Response.json({ error: "Method not allowed" }, {
+      status: 405,
+      headers: { Allow: [...API_METHODS].join(", ") },
+    });
+  }
+  const origin = request.headers.get("origin");
+  if (origin && origin !== url.origin) {
+    return Response.json({ error: "Origin not allowed" }, { status: 403 });
+  }
+  const upstreamUrl = new URL(`${url.pathname.slice(4) || "/"}${url.search}`, API_ORIGIN);
+  return fetchApi(new Request(upstreamUrl, request));
+}
+
+export async function handleRequest(request: Request, env: WorkerEnv, fetchApi: ApiFetch = fetch): Promise<Response> {
+  const url = new URL(request.url);
+  if (API_PATH.test(url.pathname)) return proxyApi(request, fetchApi);
+
   if (request.method !== "GET" && request.method !== "HEAD") {
     return withSecurityHeaders(Response.json({ error: "Method not allowed" }, {
       status: 405,
@@ -37,7 +60,6 @@ export async function handleRequest(request: Request, env: WorkerEnv): Promise<R
     }));
   }
 
-  const url = new URL(request.url);
   if (url.pathname === "/health") {
     return withSecurityHeaders(Response.json({ status: "ok" }));
   }
@@ -50,4 +72,8 @@ export async function handleRequest(request: Request, env: WorkerEnv): Promise<R
   return withSecurityHeaders(await env.ASSETS.fetch(request));
 }
 
-export default { fetch: handleRequest };
+export default {
+  fetch(request: Request, env: WorkerEnv): Promise<Response> {
+    return handleRequest(request, env);
+  },
+};

--- a/src/renderers/electrobun/view/build-assets.ts
+++ b/src/renderers/electrobun/view/build-assets.ts
@@ -60,6 +60,7 @@ async function buildElectrobunViewBundle({
       // The webview has no `process`, so the cloud endpoint override the terminal
       // already reads from the environment is baked in at build time.
       __GLOOMBERB_API_URL__: JSON.stringify(process.env.GLOOMBERB_API_URL ?? ""),
+      __GLOOMBERB_API_PATH__: '""',
     },
     plugins: [electrobunViewAliasPlugin(pluginName, extraAliasRules)],
   });

--- a/src/renderers/electrobun/view/build-assets.ts
+++ b/src/renderers/electrobun/view/build-assets.ts
@@ -60,7 +60,6 @@ async function buildElectrobunViewBundle({
       // The webview has no `process`, so the cloud endpoint override the terminal
       // already reads from the environment is baked in at build time.
       __GLOOMBERB_API_URL__: JSON.stringify(process.env.GLOOMBERB_API_URL ?? ""),
-      __GLOOMBERB_API_PATH__: '""',
     },
     plugins: [electrobunViewAliasPlugin(pluginName, extraAliasRules)],
   });

--- a/src/shares/api.ts
+++ b/src/shares/api.ts
@@ -1,6 +1,13 @@
 import { parseSharePayload, type SharePayload } from "./payload";
 
-export const SHARE_API_ORIGIN = "https://api.gloom.sh";
+declare const __GLOOMBERB_API_URL__: string | undefined;
+declare const __GLOOMBERB_API_PATH__: string | undefined;
+
+const bundledApiOrigin = typeof __GLOOMBERB_API_URL__ === "string" ? __GLOOMBERB_API_URL__ : "";
+const bundledApiPath = typeof __GLOOMBERB_API_PATH__ === "string" ? __GLOOMBERB_API_PATH__ : "";
+export const SHARE_API_ORIGIN = bundledApiOrigin
+  ? `${bundledApiOrigin}${bundledApiPath}`
+  : "https://api.gloom.sh";
 const SHARE_ID = /^[a-f0-9]{32}$/;
 type ShareFetch = (input: string, init?: RequestInit) => Promise<Response>;
 

--- a/src/shares/api.ts
+++ b/src/shares/api.ts
@@ -1,12 +1,12 @@
 import { parseSharePayload, type SharePayload } from "./payload";
 
 declare const __GLOOMBERB_API_URL__: string | undefined;
-declare const __GLOOMBERB_API_PATH__: string | undefined;
 
 const bundledApiOrigin = typeof __GLOOMBERB_API_URL__ === "string" ? __GLOOMBERB_API_URL__ : "";
-const bundledApiPath = typeof __GLOOMBERB_API_PATH__ === "string" ? __GLOOMBERB_API_PATH__ : "";
 export const SHARE_API_ORIGIN = bundledApiOrigin
-  ? `${bundledApiOrigin}${bundledApiPath}`
+  ? typeof location !== "undefined" && bundledApiOrigin === location.origin
+    ? `${bundledApiOrigin}/api`
+    : bundledApiOrigin
   : "https://api.gloom.sh";
 const SHARE_ID = /^[a-f0-9]{32}$/;
 type ShareFetch = (input: string, init?: RequestInit) => Promise<Response>;


### PR DESCRIPTION
## Problem

Production browser requests to `api.gloom.sh` are intermittently rejected by Cloudflare before reaching the backend, returning a header-only 403 with no CORS headers. This broke anonymous Chat and News with `Failed to fetch`. Reducing duplicate session checks in #614 lowered the request burst but could not make the separate browser-to-API edge path reliable.

## Fix

- Build the browser and share bundles against same-origin `/api`
- Forward only `/api/*` to the fixed `https://api.gloom.sh` origin
- Preserve REST bodies, cookies, query strings, and WebSocket upgrades
- Reject foreign browser origins and unsupported methods before proxying
- Keep desktop API routing unchanged
- Tighten CSP to same-origin Cloud REST/WebSocket traffic

The Worker cannot fetch arbitrary hosts or URLs.

## Validation

- 2,241 tests passed
- Typecheck passed
- Browser bundle audit passed
- Cloudflare deployment dry-run passed
- Local Worker Playwriter test loaded real `#everyone` messages with 0 failed requests, 0 console errors, and no `Failed to fetch` text
- Manual proxied WebSocket handshake opened successfully