### PR TITLE
Load SEC and 13F through the cloud

### DIFF
--- a/src/api-client/data.ts
+++ b/src/api-client/data.ts
@@ -4,6 +4,10 @@ import { normalizeTweetSearchResponse } from "./normalizers";
 import {
   cloudCongressHousePath,
   cloudExchangeRatePath,
+  cloudSec13FPath,
+  cloudSecFilingContentPath,
+  cloudSecFilingDocumentsPath,
+  cloudSecFilingsPath,
   cloudFredSeriesPath,
   cloudHistoryPath,
   cloudMarketSearchPath,
@@ -17,6 +21,8 @@ import {
   type CloudFredSeriesParams,
   type CloudHistoryParams,
   type CloudNewsParams,
+  type CloudSecFilingParams,
+  type CloudSecFilingsParams,
   type CloudTickerTweetsParams,
   type CloudTweetSearchParams,
 } from "./paths";
@@ -37,6 +43,9 @@ import type {
   CloudMarketScreenerPayload,
   CloudNewsListResponse,
   CloudNewsPayload,
+  CloudSecContentResponse,
+  CloudSecDocumentsResponse,
+  CloudSecFilingsResponse,
   CloudOptionsChainPayload,
   CloudPricePointPayload,
   CloudQuotePayload,
@@ -180,6 +189,22 @@ export class CloudDataApi {
 
   async getCloudCongressHouse(params: CloudCongressHouseParams = {}): Promise<CloudCongressHousePayload> {
     return this.request<CloudCongressHousePayload>(cloudCongressHousePath(params));
+  }
+
+  async getCloudSecFilings(params: CloudSecFilingsParams): Promise<CloudSecFilingsResponse> {
+    return this.request<CloudSecFilingsResponse>(cloudSecFilingsPath(params));
+  }
+
+  async getCloudSecFilingDocuments(params: CloudSecFilingParams): Promise<CloudSecDocumentsResponse> {
+    return this.request<CloudSecDocumentsResponse>(cloudSecFilingDocumentsPath(params));
+  }
+
+  async getCloudSecFilingContent(params: CloudSecFilingParams): Promise<CloudSecContentResponse> {
+    return this.request<CloudSecContentResponse>(cloudSecFilingContentPath(params));
+  }
+
+  async getCloudSec13F(path: string, params: Record<string, string | number | undefined> = {}): Promise<unknown> {
+    return this.request<unknown>(cloudSec13FPath(path, params));
   }
 
   async getCloudNews(params: CloudNewsParams = {}): Promise<CloudNewsListResponse> {

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -8,6 +8,8 @@ import { CloudApiSocket } from "./socket";
 import type {
   CloudCongressHouseParams,
   CloudFredSeriesParams,
+  CloudSecFilingParams,
+  CloudSecFilingsParams,
   CloudHistoryParams,
   CloudNewsParams,
   CloudTickerTweetsParams,
@@ -44,6 +46,9 @@ import type {
   CloudYieldPointPayload,
   CloudCongressHousePayload,
   CloudNewsPayload,
+  CloudSecContentResponse,
+  CloudSecDocumentsResponse,
+  CloudSecFilingsResponse,
   CloudNewsListResponse,
   CloudTweetSearchResponse,
   CloudMarketResponse,
@@ -526,6 +531,22 @@ class GloomApiClient {
 
   async getCloudCongressHouse(params: CloudCongressHouseParams = {}): Promise<CloudCongressHousePayload> {
     return this.data.getCloudCongressHouse(params);
+  }
+
+  async getCloudSecFilings(params: CloudSecFilingsParams): Promise<CloudSecFilingsResponse> {
+    return this.data.getCloudSecFilings(params);
+  }
+
+  async getCloudSecFilingDocuments(params: CloudSecFilingParams): Promise<CloudSecDocumentsResponse> {
+    return this.data.getCloudSecFilingDocuments(params);
+  }
+
+  async getCloudSecFilingContent(params: CloudSecFilingParams): Promise<CloudSecContentResponse> {
+    return this.data.getCloudSecFilingContent(params);
+  }
+
+  async getCloudSec13F(path: string, params: Record<string, string | number | undefined> = {}): Promise<unknown> {
+    return this.data.getCloudSec13F(path, params);
   }
 
   async getCloudNews(params: CloudNewsParams = {}): Promise<CloudNewsListResponse> {

--- a/src/api-client/paths.ts
+++ b/src/api-client/paths.ts
@@ -120,6 +120,21 @@ export function cloudFredSeriesPath(seriesId: string, params: CloudFredSeriesPar
   return appendQuery(`/cloud/econ/series/${encodeURIComponent(seriesId)}`, search);
 }
 
+export type CloudSecFilingsParams = {
+  ticker: string;
+  limit?: number;
+  offset?: number;
+};
+
+export type CloudSecFilingParams = {
+  cik?: string;
+  accession?: string;
+  form?: string;
+  primaryDocument?: string;
+  primaryDocumentUrl?: string;
+  filingUrl?: string;
+};
+
 export function cloudCongressHousePath(params: CloudCongressHouseParams = {}): string {
   const search = new URLSearchParams();
   if (params.year != null) search.set("year", String(params.year));
@@ -131,6 +146,43 @@ export function cloudCongressHousePath(params: CloudCongressHouseParams = {}): s
   if (params.ticker) search.set("ticker", params.ticker);
   if (params.refresh != null) search.set("refresh", String(params.refresh));
   return appendQuery("/cloud/congress/house", search);
+}
+
+export function cloudSecFilingsPath(params: CloudSecFilingsParams): string {
+  const search = new URLSearchParams({ ticker: params.ticker });
+  if (params.limit != null) search.set("limit", String(params.limit));
+  if (params.offset != null) search.set("offset", String(params.offset));
+  return appendQuery("/cloud/sec/filings", search);
+}
+
+export function cloudSecFilingDocumentsPath(params: CloudSecFilingParams): string {
+  const search = new URLSearchParams();
+  if (params.cik) search.set("cik", params.cik);
+  if (params.accession) search.set("accession", params.accession);
+  if (params.form) search.set("form", params.form);
+  if (params.primaryDocument) search.set("primaryDocument", params.primaryDocument);
+  if (params.filingUrl) search.set("filingUrl", params.filingUrl);
+  return appendQuery("/cloud/sec/filing/documents", search);
+}
+
+export function cloudSecFilingContentPath(params: CloudSecFilingParams): string {
+  const search = new URLSearchParams();
+  if (params.cik) search.set("cik", params.cik);
+  if (params.accession) search.set("accession", params.accession);
+  if (params.form) search.set("form", params.form);
+  if (params.primaryDocument) search.set("primaryDocument", params.primaryDocument);
+  if (params.primaryDocumentUrl) search.set("primaryDocumentUrl", params.primaryDocumentUrl);
+  if (params.filingUrl) search.set("filingUrl", params.filingUrl);
+  return appendQuery("/cloud/sec/filing/content", search);
+}
+
+export function cloudSec13FPath(path: string, params: Record<string, string | number | undefined> = {}): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) search.set(key, String(value));
+  }
+  const normalized = path.startsWith("/") ? path.slice(1) : path;
+  return appendQuery(`/cloud/sec/13f/${normalized}`, search);
 }
 
 export function cloudNewsPath(params: CloudNewsParams = {}): string {

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -408,6 +408,57 @@ export interface CloudCongressHousePayload {
   members: CloudCongressMemberPayload[];
 }
 
+export interface CloudSecFilingPayload {
+  accessionNumber: string;
+  form: string;
+  filingDate: string;
+  acceptedAt?: string;
+  primaryDocument?: string;
+  primaryDocDescription?: string;
+  items?: string;
+  cik: string;
+  companyName?: string;
+  filingUrl: string;
+  primaryDocumentUrl?: string;
+}
+
+export interface CloudSecDocumentPayload {
+  sequence?: string;
+  type: string;
+  description?: string;
+  document: string;
+  url: string;
+  size?: string;
+  isPrimary: boolean;
+}
+
+export interface CloudSecFilingsResponse {
+  filings: CloudSecFilingPayload[];
+  hasMore: boolean;
+  nextOffset: number;
+}
+
+export interface CloudSecDocumentsResponse {
+  documents: CloudSecDocumentPayload[];
+}
+
+export interface CloudSecForm4Payload {
+  filingDate: string;
+  reportedName: string;
+  title: string;
+  transactionType: "P" | "S" | "A" | "D" | "";
+  shares: number;
+  pricePerShare: number | null;
+  totalValue: number | null;
+  sharesOwned: number | null;
+  form: string;
+}
+
+export interface CloudSecContentResponse {
+  content: string | null;
+  form4: CloudSecForm4Payload | null;
+}
+
 interface CloudNewsEntityPayload {
   id: string;
   entityType: string;

--- a/src/plugins/builtin/thirteenf/api.test.ts
+++ b/src/plugins/builtin/thirteenf/api.test.ts
@@ -26,7 +26,7 @@ describe("13F API", () => {
 
     const funds = await searchThirteenFFunds("transport-smoke", 1);
 
-    expect(urls[0]).toContain("https://forms13f.com/api/v1/funds");
+    expect(urls[0]).toContain("/cloud/sec/13f/funds");
     expect(funds).toEqual([{ cik: "0001067983", name: "BERKSHIRE HATHAWAY INC" }]);
   });
 

--- a/src/plugins/builtin/thirteenf/api.ts
+++ b/src/plugins/builtin/thirteenf/api.ts
@@ -7,6 +7,7 @@ import type {
   ThirteenFTopFund,
 } from "./types";
 import type { PluginPersistence } from "../../../types/plugin";
+import { apiClient } from "../../../api-client";
 import { httpFetch } from "../../../utils/http-transport";
 
 const FORMS_13F_BASE_URL = "https://forms13f.com/api/v1";
@@ -124,17 +125,22 @@ async function fetchForms13F<T>(
     if (cached) return cached;
   }
 
-  const url = `${FORMS_13F_BASE_URL}${path}?${searchParams.toString()}`;
-  const response = await httpFetch(url, {
-    headers: { Accept: "application/json" },
-    signal: options.signal,
-  });
-  if (!response.ok) {
-    const stale = options.cache !== false ? readApiCache<T>(key, { allowExpired: true }) : null;
-    if (stale) return stale;
-    throw new Error(`Forms13F ${response.status} for ${path}`);
+  let value: T;
+  try {
+    value = await apiClient.getCloudSec13F(path, params) as T;
+  } catch {
+    const url = `${FORMS_13F_BASE_URL}${path}?${searchParams.toString()}`;
+    const response = await httpFetch(url, {
+      headers: { Accept: "application/json" },
+      signal: options.signal,
+    });
+    if (!response.ok) {
+      const stale = options.cache !== false ? readApiCache<T>(key, { allowExpired: true }) : null;
+      if (stale) return stale;
+      throw new Error(`Forms13F ${response.status} for ${path}`);
+    }
+    value = await response.json() as T;
   }
-  const value = await response.json() as T;
   if (value != null && options.cache !== false) {
     writeApiCache(key, value);
   }

--- a/src/sources/gloomberb-cloud/index.ts
+++ b/src/sources/gloomberb-cloud/index.ts
@@ -8,6 +8,8 @@ import { assetDataProvider, newsProvider, type PluginCapability } from "../../ca
 import type {
   AssetDataProvider,
   CachedFinancialsTarget,
+  SecFilingDocument,
+  SecFilingItem,
   MarketDataRequestContext,
   QuoteBatchResult,
   QuoteSubscriptionTarget,
@@ -65,6 +67,34 @@ const CLOUD_PROVIDER_MISS_PATTERNS = [
   /figi.*missing or invalid/i,
   /error in the query/i,
 ];
+
+function mapCloudSecFiling(item: {
+  accessionNumber: string;
+  form: string;
+  filingDate: string;
+  acceptedAt?: string;
+  primaryDocument?: string;
+  primaryDocDescription?: string;
+  items?: string;
+  cik: string;
+  companyName?: string;
+  filingUrl: string;
+  primaryDocumentUrl?: string;
+}): SecFilingItem {
+  return {
+    accessionNumber: item.accessionNumber,
+    form: item.form,
+    filingDate: new Date(`${item.filingDate}T00:00:00Z`),
+    acceptedAt: item.acceptedAt ? new Date(item.acceptedAt) : undefined,
+    primaryDocument: item.primaryDocument,
+    primaryDocDescription: item.primaryDocDescription,
+    items: item.items,
+    cik: item.cik,
+    companyName: item.companyName,
+    filingUrl: item.filingUrl,
+    primaryDocumentUrl: item.primaryDocumentUrl,
+  };
+}
 
 function isCloudProviderMiss(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
@@ -269,6 +299,43 @@ export class GloomberbCloudProvider implements AssetDataProvider {
       () => apiClient.searchInstruments(query, 10),
       "Cloud search is unavailable",
     );
+  }
+
+  async getSecFilings(ticker: string, count = 15): Promise<SecFilingItem[]> {
+    await requireVerifiedSession();
+    return withCloudFallback(async () => {
+      const response = await apiClient.getCloudSecFilings({ ticker, limit: count, offset: 0 });
+      return response.filings.map(mapCloudSecFiling);
+    }, `Cloud SEC filings are unavailable for ${ticker}`);
+  }
+
+  async getSecFilingDocuments(filing: SecFilingItem): Promise<SecFilingDocument[]> {
+    await requireVerifiedSession();
+    return withCloudFallback(async () => {
+      const response = await apiClient.getCloudSecFilingDocuments({
+        cik: filing.cik,
+        accession: filing.accessionNumber,
+        form: filing.form,
+        primaryDocument: filing.primaryDocument,
+        filingUrl: filing.filingUrl,
+      });
+      return response.documents;
+    }, "Cloud SEC filing documents are unavailable");
+  }
+
+  async getSecFilingContent(filing: SecFilingItem): Promise<string | null> {
+    await requireVerifiedSession();
+    return withCloudFallback(async () => {
+      const response = await apiClient.getCloudSecFilingContent({
+        cik: filing.cik,
+        accession: filing.accessionNumber,
+        form: filing.form,
+        primaryDocument: filing.primaryDocument,
+        primaryDocumentUrl: filing.primaryDocumentUrl,
+        filingUrl: filing.filingUrl,
+      });
+      return response.content;
+    }, "Cloud SEC filing content is unavailable");
   }
 
   async getHolders(ticker: string, exchange = "", _context?: MarketDataRequestContext): Promise<HolderData> {


### PR DESCRIPTION
## Summary
- Point SEC/Insider filings and documents at `/cloud/sec/*`.
- Send 13F API traffic through `/cloud/sec/13f/:path` with the old host as fallback.

Depends on gloomberb-platform #93.

## Test plan
- `bun test src/plugins/builtin/thirteenf/api.test.ts src/sources/gloomberb-cloud/index.test.ts`
- After platform deploy: open INS AAPL and 13F, confirm data loads.