### PR TITLE
Enable delayed anonymous browser market data

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The desktop app and TUI share the full command language and plugin system. The b
 
 ## Browser App
 
-[term.gloom.sh](https://term.gloom.sh) works anonymously with configuration, tickers, layouts, session state, and plugin state stored in the browser. Gloom Cloud login is optional and enables cloud-backed market data, chat, and sync. Cloud REST and WebSocket traffic uses the same-origin `/api` path, which the Worker forwards only to `https://api.gloom.sh`; it is not an arbitrary network proxy.
+[term.gloom.sh](https://term.gloom.sh) works anonymously with configuration, tickers, layouts, session state, and plugin state stored in the browser. Anonymous sessions receive rate-limited, 15-minute-delayed Gloom Cloud market data and read-only chat. Login remains optional and enables sync and chat posting; Pro accounts receive realtime market data. Cloud REST and WebSocket traffic uses the same-origin `/api` path, which the Worker forwards only to `https://api.gloom.sh`; it is not an arbitrary network proxy.
 
 The browser build intentionally omits brokers and native integrations, filesystem notes, local AI, external plugins, updater/debug tools, application menus, native window controls, pop-out native windows, and native context menus. Modules that still depend on desktop-only or CORS-blocked feeds are also absent for now: RSS/Substack, prediction markets and polls, market halts/heatmap/movers, dividend/ownership/SEC panes, earnings/IPO, and TV. Public shares open under `/s/:id` in a separate slim bundle. Share creation and owner deletion use the signed-in Gloom Cloud session through the same fixed API path; public reads require no account.
 

--- a/src/sources/gloomberb-cloud/index.test.ts
+++ b/src/sources/gloomberb-cloud/index.test.ts
@@ -18,6 +18,7 @@ const verifiedUser: AuthUser = {
 const originalEnsureVerifiedSession = apiClient.ensureVerifiedSession.bind(apiClient);
 const originalGetCloudHistory = apiClient.getCloudHistory.bind(apiClient);
 const originalGetCloudQuote = apiClient.getCloudQuote.bind(apiClient);
+const originalGetCloudExchangeRate = apiClient.getCloudExchangeRate.bind(apiClient);
 const originalGetCloudHolders = apiClient.getCloudHolders.bind(apiClient);
 const originalGetCloudAnalystResearch = apiClient.getCloudAnalystResearch.bind(apiClient);
 const originalGetCloudCorporateActions = apiClient.getCloudCorporateActions.bind(apiClient);
@@ -88,6 +89,7 @@ afterEach(() => {
   apiClient.ensureVerifiedSession = originalEnsureVerifiedSession;
   apiClient.getCloudHistory = originalGetCloudHistory;
   apiClient.getCloudQuote = originalGetCloudQuote;
+  apiClient.getCloudExchangeRate = originalGetCloudExchangeRate;
   apiClient.getCloudHolders = originalGetCloudHolders;
   apiClient.getCloudAnalystResearch = originalGetCloudAnalystResearch;
   apiClient.getCloudCorporateActions = originalGetCloudCorporateActions;
@@ -98,7 +100,65 @@ afterEach(() => {
 });
 
 describe("GloomberbCloudProvider", () => {
-  test("fetches detailed intraday chart history with Twelve Data intervals", async () => {
+  test("uses public delayed market routes anonymously but keeps research protected", async () => {
+    let sessionChecks = 0;
+    apiClient.ensureVerifiedSession = async () => {
+      sessionChecks += 1;
+      return null;
+    };
+    apiClient.getCloudQuote = async () => ({
+      status: "success",
+      data: {
+        symbol: "AAPL",
+        providerId: "gloomberb-cloud",
+        price: 200,
+        currency: "USD",
+        change: 1,
+        changePercent: 0.5,
+        lastUpdated: Date.now(),
+        dataSource: "delayed",
+      },
+    });
+    apiClient.getCloudHistory = async () => ({
+      status: "success",
+      providerMeta: { provider: "yahoo" },
+      data: [{ date: "2026-08-21", close: 200 }],
+    });
+    apiClient.getCloudOptionsChain = async () => ({
+      status: "success",
+      data: {
+        providerId: "gloomberb-cloud",
+        underlyingSymbol: "AAPL",
+        expirationDates: [1_800_000_000],
+        calls: [],
+        puts: [],
+        dataSource: "delayed",
+        feed: "yahoo",
+        delayMinutes: 15,
+        realtimeEligible: false,
+        asOf: "2026-08-21T20:00:00.000Z",
+      },
+    });
+    apiClient.getCloudExchangeRate = async () => ({
+      status: "success",
+      data: { rate: 1.25 },
+    });
+
+    const provider = new GloomberbCloudProvider();
+    expect(await provider.canProvide()).toBe(true);
+    expect((await provider.getQuote("AAPL", "NASDAQ")).price).toBe(200);
+    expect(await provider.getPriceHistory("AAPL", "NASDAQ", "1M")).toHaveLength(1);
+    expect((await provider.getOptionsChain("AAPL", "NASDAQ")).feed).toBe("yahoo");
+    expect(await provider.getExchangeRate("GBP")).toBe(1.25);
+    expect(sessionChecks).toBe(0);
+
+    await expect(provider.getAnalystResearch("AAPL", "NASDAQ")).rejects.toThrow(
+      "requires signup and email verification",
+    );
+    expect(sessionChecks).toBe(1);
+  });
+
+  test("fetches detailed intraday chart history with cloud intervals", async () => {
     apiClient.ensureVerifiedSession = async () => verifiedUser;
 
     const requestArgs: { current: { symbol: string; exchange: string; params: Record<string, string | number | undefined> } | null } = { current: null };

--- a/src/sources/gloomberb-cloud/index.ts
+++ b/src/sources/gloomberb-cloud/index.ts
@@ -185,11 +185,10 @@ export class GloomberbCloudProvider implements AssetDataProvider {
   }
 
   async canProvide(): Promise<boolean> {
-    return !!(await apiClient.ensureVerifiedSession());
+    return true;
   }
 
   async getTickerFinancials(ticker: string, exchange = "", _context?: MarketDataRequestContext): Promise<TickerFinancials> {
-    await requireVerifiedSession();
     return withCloudFallback(async () => {
       const response = await apiClient.getCloudFinancials(ticker, exchange);
       if (isStaleCloudResponse(response)) {
@@ -206,7 +205,6 @@ export class GloomberbCloudProvider implements AssetDataProvider {
     targets: CachedFinancialsTarget[],
     options: { forceRefresh?: boolean } = {},
   ): Promise<TickerFinancialsBatchResult[]> {
-    await requireVerifiedSession();
     return withCloudFallback(async () => {
       const response = await apiClient.getCloudFinancialsBatch(
         targets.map((target) => ({
@@ -240,7 +238,6 @@ export class GloomberbCloudProvider implements AssetDataProvider {
   }
 
   async getQuote(ticker: string, exchange = "", _context?: MarketDataRequestContext): Promise<Quote> {
-    await requireVerifiedSession();
     return withCloudFallback(
       async () => {
         const response = await apiClient.getCloudQuote(ticker, exchange);
@@ -260,7 +257,6 @@ export class GloomberbCloudProvider implements AssetDataProvider {
     targets: QuoteSubscriptionTarget[],
     options: { forceRefresh?: boolean } = {},
   ): Promise<QuoteBatchResult[]> {
-    await requireVerifiedSession();
     return withCloudFallback(async () => {
       const response = await apiClient.getCloudQuotesBatch(
         targets.map((target) => ({
@@ -294,13 +290,11 @@ export class GloomberbCloudProvider implements AssetDataProvider {
   }
 
   async getExchangeRate(fromCurrency: string): Promise<number> {
-    await requireVerifiedSession();
     const response = await apiClient.getCloudExchangeRate(fromCurrency);
     return unwrapRequiredCloudResponse(response, `Cloud exchange rate is unavailable for ${fromCurrency}`).rate;
   }
 
   async search(query: string, _context?: SearchRequestContext): Promise<InstrumentSearchResult[]> {
-    await requireVerifiedSession();
     return withCloudFallback(
       () => apiClient.searchInstruments(query, 10),
       "Cloud search is unavailable",
@@ -373,7 +367,6 @@ export class GloomberbCloudProvider implements AssetDataProvider {
   }
 
   async getPriceHistory(ticker: string, exchange: string, range: TimeRange, _context?: MarketDataRequestContext): Promise<PricePoint[]> {
-    await requireVerifiedSession();
     const request = toHistoryRequest(range);
     const response = await withCloudFallback(
       () => apiClient.getCloudHistory(ticker, exchange, request),
@@ -389,7 +382,6 @@ export class GloomberbCloudProvider implements AssetDataProvider {
     resolution: ManualChartResolution,
     _context?: MarketDataRequestContext,
   ): Promise<PricePoint[]> {
-    await requireVerifiedSession();
     const interval = toCloudInterval(resolution);
     const endDate = new Date();
     const startDate = getRangeStartDate(bufferRange, endDate);
@@ -413,7 +405,6 @@ export class GloomberbCloudProvider implements AssetDataProvider {
     barSize: string,
     _context?: MarketDataRequestContext,
   ): Promise<PricePoint[]> {
-    await requireVerifiedSession();
     const interval = toCloudInterval(barSize);
     const includeTime = /(min|h)$/i.test(interval);
     const response = await withCloudFallback(
@@ -428,7 +419,6 @@ export class GloomberbCloudProvider implements AssetDataProvider {
   }
 
   async getOptionsChain(ticker: string, exchange?: string, expirationDate?: number, _context?: MarketDataRequestContext): Promise<OptionsChain> {
-    await requireVerifiedSession();
     return withCloudFallback(async () => {
       const response = await apiClient.getCloudOptionsChain(ticker, exchange, expirationDate);
       const chain = unwrapRequiredCloudResponse(

--- a/src/utils/price-history.ts
+++ b/src/utils/price-history.ts
@@ -89,10 +89,11 @@ export function isPriceHistoryStaleForCurrentWindow(
   ) {
     return true;
   }
-  if (age <= MAX_CURRENT_INTRADAY_HISTORY_LAG_MS) {
-    return Boolean(options.exchange && resolveExchangeTimeZone(options.exchange));
-  }
-  return true;
+  const hasExchangeSession = Boolean(
+    options.exchange && resolveExchangeTimeZone(options.exchange),
+  );
+  if (age <= MAX_CURRENT_INTRADAY_HISTORY_LAG_MS) return hasExchangeSession;
+  return !hasExchangeSession;
 }
 
 export function normalizeTickerFinancialsPriceHistory(financials: TickerFinancials): TickerFinancials {


### PR DESCRIPTION
## Summary
- let the shared Gloom Cloud provider call public delayed market endpoints without a verified session
- keep analyst, holdings, corporate actions, and filing data behind verification
- enable charts, options, indices, FX, futures, sectors, correlation, and delayed HILO in the hosted browser runtime
- document anonymous delayed access
- remove all public-repository mentions of private upstream market vendors
- preserve previous-session chart history while exchanges are closed after rebasing onto current main

## Validation
- 2,262 tests passed
- all TypeScript targets passed
- browser bundle audit passed
- Cloudflare typecheck and dry-run passed
- public vendor-name grep returned no matches

Depends on private platform PR #94 being deployed first.