### PR TITLE
Fix persisted charts while markets are closed

### DIFF
--- a/src/sources/provider-router/history.test.ts
+++ b/src/sources/provider-router/history.test.ts
@@ -391,7 +391,7 @@ describe("AssetDataRouter chart history", () => {
     expect(history[0]?.close).toBe(102);
   });
 
-  test("accepts previous-session short-range chart history while the exchange is closed", async () => {
+  test("accepts previous-session history without persisted exchange metadata while closed", async () => {
     const originalDateNow = Date.now;
     Date.now = () => Date.parse("2026-05-17T12:00:00Z");
 
@@ -419,7 +419,7 @@ describe("AssetDataRouter chart history", () => {
       };
 
       const router = new AssetDataRouter(yahooProvider, [cloudProvider]);
-      const history = await router.getPriceHistoryForResolution("AAPL", "NASDAQ", "1M", "15m");
+      const history = await router.getPriceHistoryForResolution("AAPL", "", "1M", "15m");
 
       expect(history.map((point) => point.close)).toEqual([101, 102]);
     } finally {

--- a/src/utils/price-history.ts
+++ b/src/utils/price-history.ts
@@ -82,16 +82,14 @@ export function isPriceHistoryStaleForCurrentWindow(
   if (!Number.isFinite(latestTime)) return false;
   const age = now - latestTime;
   if (age <= MAX_SAME_SESSION_HISTORY_LAG_MS) return false;
+  const exchange = options.exchange || "NASDAQ";
   if (
-    options.exchange
-    && resolveExchangeTimeZone(options.exchange)
-    && isTimestampStaleForExchangeSession(latestTime, options.exchange, now)
+    resolveExchangeTimeZone(exchange)
+    && isTimestampStaleForExchangeSession(latestTime, exchange, now)
   ) {
     return true;
   }
-  const hasExchangeSession = Boolean(
-    options.exchange && resolveExchangeTimeZone(options.exchange),
-  );
+  const hasExchangeSession = Boolean(resolveExchangeTimeZone(exchange));
   if (age <= MAX_CURRENT_INTRADAY_HISTORY_LAG_MS) return hasExchangeSession;
   return !hasExchangeSession;
 }


### PR DESCRIPTION
## Summary
- treat missing persisted exchange metadata as the app's default US market for history freshness
- keep Friday intraday bars usable over the weekend
- preserve stale-history rejection once the regular session is active

## Production regression
A fresh load of the user's persisted `G AMD` 1W pane still showed `No history provider available` even though both exact Cloud history requests returned successful data. The public provider router independently rejected Friday bars as older than 18 hours because the persisted pane had an empty exchange.

## Verification
- `bun test src/utils/price-history.test.ts src/sources/provider-router/history.test.ts` (22 pass)
- `bun run typecheck:browser`
- reproduced against the exact persisted production pane before the fix