### PR TITLE
Serve the Apple app site association for share links

### DIFF
--- a/src/renderers/cloudflare/worker.test.ts
+++ b/src/renderers/cloudflare/worker.test.ts
@@ -41,6 +41,47 @@ describe("static Cloudflare host", () => {
     expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow, noarchive");
   });
 
+  test("serves the Apple app site association without touching static assets", async () => {
+    const { env, requests } = fixture();
+    const response = await handleRequest(
+      new Request("https://term.example/.well-known/apple-app-site-association"),
+      env,
+    );
+
+    // Apple's fetcher accepts none of: a redirect, an HTML body, a 404. Any of
+    // those disables universal links silently, so pin the exact contract.
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(requests).toHaveLength(0);
+
+    const body = (await response.json()) as {
+      applinks: { details: { appIDs: string[]; components: { "/": string }[] }[] };
+    };
+    const detail = body.applinks.details[0]!;
+    expect(detail.appIDs).toEqual(["3XQML3UV65.sh.gloom.companion"]);
+    // Only share links are claimed; everything else must stay in the browser.
+    expect(detail.components[0]!["/"]).toBe("/s/*");
+  });
+
+  test("claims exactly the share paths the worker itself rewrites", async () => {
+    const { env } = fixture();
+    const response = await handleRequest(
+      new Request("https://term.example/.well-known/apple-app-site-association"),
+      env,
+    );
+    const body = (await response.json()) as {
+      applinks: { details: { components: { "/": string }[] }[] };
+    };
+    const claimed = body.applinks.details[0]!.components[0]!["/"];
+
+    // A real share id must match the pattern advertised to Apple, otherwise the
+    // app is claiming links the site does not serve, or missing ones it does.
+    const shareId = "0123456789abcdef0123456789abcdef";
+    const pattern = new RegExp(`^${claimed.replace("*", ".*")}$`);
+    expect(pattern.test(`/s/${shareId}`)).toBe(true);
+    expect(pattern.test("/settings")).toBe(false);
+  });
+
   test("proxies only the same-origin API path to api.gloom.sh", async () => {
     const { env, requests } = fixture();
     let upstream: Request | undefined;

--- a/src/renderers/cloudflare/worker.ts
+++ b/src/renderers/cloudflare/worker.ts
@@ -8,6 +8,31 @@ export interface WorkerEnv {
 
 const SHARE_PATH = /^\/s\/[a-f0-9]{32}\/?$/;
 const API_PATH = /^\/api(?:\/|$)/;
+const APPLE_APP_SITE_ASSOCIATION_PATH = "/.well-known/apple-app-site-association";
+
+/**
+ * Lets the iOS app claim `https://term.gloom.sh/s/...` share links.
+ *
+ * Apple fetches this over HTTPS with its own client, so it has to be a direct
+ * 200 with JSON content type: a redirect, an HTML error page, or a 404 all
+ * silently disable universal links with no visible failure on device.
+ *
+ * The path list mirrors `SHARE_PATH` above. Only shares are claimed, so every
+ * other page on the site still opens in the browser, which is what someone
+ * clicking a marketing or docs link expects.
+ *
+ * `3XQML3UV65` is the Apple team id that prefixes the app id.
+ */
+const APPLE_APP_SITE_ASSOCIATION = {
+  applinks: {
+    details: [
+      {
+        appIDs: ["3XQML3UV65.sh.gloom.companion"],
+        components: [{ "/": "/s/*", comment: "Public portfolio shares" }],
+      },
+    ],
+  },
+} as const;
 const API_ORIGIN = "https://api.gloom.sh";
 const API_METHODS = new Set(["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]);
 type ApiFetch = (request: Request) => Promise<Response>;
@@ -62,6 +87,17 @@ export async function handleRequest(request: Request, env: WorkerEnv, fetchApi: 
 
   if (url.pathname === "/health") {
     return withSecurityHeaders(Response.json({ status: "ok" }));
+  }
+
+  // Served before the asset handler so it cannot be shadowed by a static file
+  // or the SPA fallback, either of which would hand Apple HTML and quietly
+  // break universal links.
+  if (url.pathname === APPLE_APP_SITE_ASSOCIATION_PATH) {
+    return withSecurityHeaders(
+      Response.json(APPLE_APP_SITE_ASSOCIATION, {
+        headers: { "cache-control": "public, max-age=3600" },
+      }),
+    );
   }
   const share = SHARE_PATH.test(url.pathname);
   if (share) {


### PR DESCRIPTION
Claims `term.gloom.sh/s/<id>` links for the iOS app, so a shared link opens the app instead of a browser tab.

Apple fetches this file with its own client and accepts **no redirect, no HTML and no 404**. Any of those disables universal links silently, with no visible failure on device, so it is served before the asset handler where the SPA fallback cannot shadow it, and the tests pin the exact contract: 200, JSON content type, and static assets never consulted.

Only `/s/*` is claimed. Every other page still opens in the browser, which is what someone following a docs or marketing link expects. A second test verifies the advertised pattern matches a real 32-hex share id and does not match an ordinary page, so the app cannot claim links the site does not serve.

Pairs with the app-side change in `gloom-expo` (associated domains entitlement, share screen, and an auth-gate exemption so a share opens for someone with no account).