### PR TITLE
Contain browser chart gestures

### DIFF
--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -71,6 +71,39 @@ test("reports a drag as a drag, never as a move, and keeps its modifiers", async
   expect(modifiers.every((entry) => entry.shift)).toBe(true);
 });
 
+test("chart surfaces consume browser pan and zoom gestures", async () => {
+  const directions: string[] = [];
+  const container = testWindow.document.createElement("div");
+  testWindow.document.body.appendChild(container);
+  const root = createRoot(container as unknown as HTMLElement);
+  await act(async () => {
+    root.render(
+      <WebChartSurface
+        width={40}
+        height={10}
+        onMouseScroll={(event: { scroll?: { direction?: string }; preventDefault: () => void }) => {
+          directions.push(event.scroll?.direction ?? "");
+          event.preventDefault();
+        }}
+      />,
+    );
+  });
+
+  const surface = container.firstElementChild as unknown as HTMLElement;
+  const wheel = new testWindow.WheelEvent("wheel", {
+    bubbles: true,
+    cancelable: true,
+    deltaX: 24,
+  });
+  expect(surface.dispatchEvent(wheel as never)).toBe(false);
+  expect(wheel.defaultPrevented).toBe(true);
+  expect(directions).toEqual(["right"]);
+  expect(surface.style.touchAction).toBe("none");
+  expect(surface.style.overscrollBehavior).toBe("none");
+
+  await act(async () => root.unmount());
+});
+
 test("a tab bar occupies exactly the one row panes reserve for it", async () => {
   const { WebTabs } = await import("./tabs");
   const { WEB_CELL_HEIGHT } = await import("../input-host");

--- a/src/renderers/electrobun/view/host/box.tsx
+++ b/src/renderers/electrobun/view/host/box.tsx
@@ -8,7 +8,6 @@ import {
   type MouseEvent,
   type ReactNode,
   type Ref,
-  type WheelEvent as ReactWheelEvent,
 } from "react";
 import {
   type CellMouseEvent,
@@ -96,6 +95,17 @@ export const WebBox = forwardRef<HTMLDivElement, Record<string, unknown> & { chi
       document.body.classList.remove("gloom-dragging");
     }, []);
 
+    const handlesWheel = typeof props.onMouseScroll === "function";
+    useEffect(() => {
+      const element = elementRef.current;
+      if (!element || !handlesWheel) return;
+      const handleWheel = (event: WheelEvent) => {
+        callMouseHandler(propsRef.current.onMouseScroll, event, "scroll");
+      };
+      element.addEventListener("wheel", handleWheel, { passive: false });
+      return () => element.removeEventListener("wheel", handleWheel);
+    }, [handlesWheel]);
+
     const stopDocumentDrag = () => {
       if (!draggingRef.current) return;
       draggingRef.current = false;
@@ -136,10 +146,6 @@ export const WebBox = forwardRef<HTMLDivElement, Record<string, unknown> & { chi
       callMouseHandler(propsRef.current.onMouseDownCapture, event, "down");
     };
 
-    const handleWheel = (event: ReactWheelEvent<HTMLDivElement>) => {
-      callMouseHandler(propsRef.current.onMouseScroll, event, "scroll");
-    };
-
     const handleMouseOver = (event: MouseEvent) => {
       callMouseHandler(propsRef.current.onMouseOver, event, "over");
     };
@@ -160,7 +166,6 @@ export const WebBox = forwardRef<HTMLDivElement, Record<string, unknown> & { chi
         onMouseMove={(event) => scheduleFrameMouseHandler(event, "move")}
         onMouseUp={(event) => callMouseHandler(propsRef.current.onMouseUp, event, "up")}
         onMouseOut={handleMouseOut}
-        onWheel={typeof props.onMouseScroll === "function" ? handleWheel : undefined}
         style={{
           ...commonStyle(props),
           "--gloom-box-hover-bg": hoverBackgroundColor,

--- a/src/renderers/electrobun/view/host/chart-surface.tsx
+++ b/src/renderers/electrobun/view/host/chart-surface.tsx
@@ -211,7 +211,13 @@ export const WebChartSurface = forwardRef<BoxRenderable, Record<string, unknown>
         {...props}
         ref={ref as Ref<HTMLDivElement>}
         data-gloom-role={(props["data-gloom-role"] as string | undefined) ?? "chart-surface"}
-        style={{ position: "relative", overflow: "hidden", ...(props.style as CSSProperties | undefined) }}
+        style={{
+          position: "relative",
+          overflow: "hidden",
+          touchAction: "none",
+          overscrollBehavior: "none",
+          ...(props.style as CSSProperties | undefined),
+        }}
       >
         {layers.length > 0
           ? layers.map((layer, index) => (


### PR DESCRIPTION
## Summary
- register wheel handlers as non-passive so chart pan and pinch zoom can cancel Chrome's native gestures
- contain touch and overscroll behavior inside chart surfaces
- keep the existing terminal-style chart interaction mapping unchanged

## Verification
- `bun test src/renderers/electrobun/view/host/box.test.tsx` (4 pass)
- `bun run typecheck:electrobun-view`
- `bun run typecheck:browser`
- `bun run web:audit`

The regression test dispatches a cancelable horizontal wheel gesture, verifies it is consumed, and checks the chart surface gesture-containment styles.