### PR TITLE
Stop cloud sync from overwriting CLI and offline edits, and sync notes

### DIFF
--- a/src/plugins/builtin/notes/files.ts
+++ b/src/plugins/builtin/notes/files.ts
@@ -4,7 +4,15 @@ export interface QuickNoteEntry {
   updatedAt?: number;
 }
 
+/** A stored note: `key` is what `load`/`save` take, not the file path. */
+export interface NoteFileEntry {
+  key: string;
+  text: string;
+  updatedAt: number;
+}
+
 const QUICK_NOTES_INDEX = "__quick-notes-index__";
+const LOCAL_TIMESTAMP_KEY = "gloomberb:notes:__updated-at__";
 
 function joinPath(...parts: string[]): string {
   return parts.join("/").replace(/\/+/g, "/");
@@ -29,6 +37,28 @@ async function readTextFile(path: string): Promise<string> {
   return getLocalStorage()?.getItem(`gloomberb:notes:${path}`) ?? "";
 }
 
+/** Browsers have no mtime, so note writes keep their own timestamp index. */
+function readLocalTimestamps(): Record<string, number> {
+  try {
+    const raw = getLocalStorage()?.getItem(LOCAL_TIMESTAMP_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, number>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeLocalTimestamp(path: string, updatedAt: number | null): void {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  const timestamps = readLocalTimestamps();
+  if (updatedAt == null) delete timestamps[path];
+  else timestamps[path] = updatedAt;
+  try { storage.setItem(LOCAL_TIMESTAMP_KEY, JSON.stringify(timestamps)); } catch {}
+}
+
 async function writeTextFile(path: string, value: string): Promise<void> {
   if (typeof Bun !== "undefined") {
     const fsModulePath = "fs/promises";
@@ -37,6 +67,7 @@ async function writeTextFile(path: string, value: string): Promise<void> {
     return;
   }
   getLocalStorage()?.setItem(`gloomberb:notes:${path}`, value);
+  writeLocalTimestamp(path, Date.now());
 }
 
 async function deleteTextFile(path: string): Promise<void> {
@@ -47,6 +78,7 @@ async function deleteTextFile(path: string): Promise<void> {
     return;
   }
   getLocalStorage()?.removeItem(`gloomberb:notes:${path}`);
+  writeLocalTimestamp(path, null);
 }
 
 export class NotesFiles {
@@ -80,6 +112,54 @@ export class NotesFiles {
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
+  }
+
+  /** Every stored note, ticker notes and quick notes alike, newest first. */
+  async list(): Promise<NoteFileEntry[]> {
+    const entries: NoteFileEntry[] = [];
+    for (const [key, updatedAt] of await this.listKeys()) {
+      try {
+        entries.push({ key, text: await this.load(key), updatedAt });
+      } catch {
+        // An unreadable note is skipped rather than synced as empty.
+      }
+    }
+    return entries.sort((left, right) => right.updatedAt - left.updatedAt);
+  }
+
+  private async listKeys(): Promise<Array<[string, number]>> {
+    if (typeof Bun !== "undefined") {
+      const fsModulePath = "fs/promises";
+      const { readdir, stat } = await import(fsModulePath) as typeof import("fs/promises");
+      let names: string[];
+      try {
+        names = await readdir(this.dataDir);
+      } catch {
+        return [];
+      }
+      const keys: Array<[string, number]> = [];
+      for (const name of names) {
+        if (!name.endsWith(".md")) continue;
+        try {
+          const info = await stat(joinPath(this.dataDir, name));
+          keys.push([name.slice(0, -3), Math.round(info.mtimeMs)]);
+        } catch {}
+      }
+      return keys;
+    }
+    const prefix = joinPath(this.dataDir, "");
+    const timestamps = readLocalTimestamps();
+    const storageKeyPrefix = `gloomberb:notes:${prefix}`;
+    // Notes written before the index existed are stamped now rather than at
+    // the epoch, so an older cloud copy cannot overwrite them on first sync.
+    for (const storageKey of Object.keys(globalThis.localStorage ?? {})) {
+      if (!storageKey.startsWith(storageKeyPrefix) || !storageKey.endsWith(".md")) continue;
+      const path = storageKey.slice("gloomberb:notes:".length);
+      if (timestamps[path] == null) writeLocalTimestamp(path, timestamps[path] = Date.now());
+    }
+    return Object.entries(timestamps)
+      .filter(([path]) => path.startsWith(prefix) && path.endsWith(".md"))
+      .map(([path, updatedAt]) => [path.slice(prefix.length, -3), updatedAt]);
   }
 
   private indexPath(): string {

--- a/src/plugins/builtin/notes/index.tsx
+++ b/src/plugins/builtin/notes/index.tsx
@@ -1,6 +1,7 @@
 import type { GloomPlugin } from "../../../types/plugin";
 import { NotesFiles } from "./files";
 import { createQuickNotesPane } from "./quick-notes-pane";
+import { createNotesSyncContributor } from "./sync";
 import { createNotesTab } from "./ticker-notes-tab";
 
 export const notesPlugin: GloomPlugin = {
@@ -21,6 +22,8 @@ export const notesPlugin: GloomPlugin = {
         ctx.notify({ body: "Failed to delete note. Check disk space and permissions.", type: "error" });
       });
     });
+
+    ctx.registerSyncContributor(createNotesSyncContributor(notesFiles));
 
     ctx.registerTickerResearchTab({
       id: "notes",

--- a/src/plugins/builtin/notes/sync.test.ts
+++ b/src/plugins/builtin/notes/sync.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { SyncApplyContext } from "../../../sync/types";
+import { NotesFiles } from "./files";
+import { createNotesSyncContributor } from "./sync";
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  for (const directory of directories.splice(0)) {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+async function createNotesFiles(): Promise<NotesFiles> {
+  const directory = await mkdtemp(join(tmpdir(), "gloomberb-notes-sync-"));
+  directories.push(directory);
+  return new NotesFiles(directory);
+}
+
+const applyContext = { isCurrent: () => true } as unknown as SyncApplyContext;
+
+test("resolves each note to whichever side wrote it last", async () => {
+  const notesFiles = await createNotesFiles();
+  await notesFiles.save("AAPL", "local aapl");
+  await notesFiles.save("MSFT", "local msft");
+  const contributor = createNotesSyncContributor(notesFiles);
+
+  await contributor.apply?.({
+    notes: [
+      { key: "AAPL", text: "remote aapl", updatedAt: Date.now() + 60_000 },
+      { key: "MSFT", text: "remote msft", updatedAt: Date.now() - 60_000 },
+      { key: "TSLA", text: "remote tsla", updatedAt: Date.now() },
+    ],
+    quickNotes: [{ id: "note-1", title: "Remote", updatedAt: Date.now() }],
+  }, applyContext);
+
+  expect(await notesFiles.load("AAPL")).toBe("remote aapl");
+  expect(await notesFiles.load("MSFT")).toBe("local msft");
+  expect(await notesFiles.load("TSLA")).toBe("remote tsla");
+  expect(await notesFiles.loadQuickNotesIndex()).toEqual([
+    { id: "note-1", title: "Remote", updatedAt: expect.any(Number) },
+  ]);
+
+  const payload = await contributor.collect({} as never) as { notes: Array<{ key: string }> };
+  expect(payload.notes.map((note) => note.key).sort()).toEqual(["AAPL", "MSFT", "TSLA"]);
+});

--- a/src/plugins/builtin/notes/sync.ts
+++ b/src/plugins/builtin/notes/sync.ts
@@ -1,0 +1,98 @@
+import type { SyncContributor } from "../../../sync/types";
+import type { NoteFileEntry, NotesFiles, QuickNoteEntry } from "./files";
+
+// The server rejects snapshots over 1.5MB, and notes share it with portfolios.
+const MAX_NOTE_CHARS = 100_000;
+const MAX_NOTES_CHARS = 400_000;
+
+interface SyncedNote {
+  key: string;
+  text: string;
+  updatedAt: number;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseNotes(value: unknown): SyncedNote[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => (
+    isPlainObject(entry) && typeof entry.key === "string" && typeof entry.text === "string"
+      ? [{
+        key: entry.key,
+        text: entry.text,
+        updatedAt: typeof entry.updatedAt === "number" && Number.isFinite(entry.updatedAt)
+          ? entry.updatedAt
+          : 0,
+      }]
+      : []
+  ));
+}
+
+function parseQuickNotes(value: unknown): QuickNoteEntry[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => (
+    isPlainObject(entry) && typeof entry.id === "string" && typeof entry.title === "string"
+      ? [{
+        id: entry.id,
+        title: entry.title,
+        updatedAt: typeof entry.updatedAt === "number" ? entry.updatedAt : undefined,
+      }]
+      : []
+  ));
+}
+
+function withinBudget(entries: NoteFileEntry[]): SyncedNote[] {
+  const notes: SyncedNote[] = [];
+  let total = 0;
+  for (const entry of entries) {
+    if (entry.text.length > MAX_NOTE_CHARS) continue;
+    if (total + entry.text.length > MAX_NOTES_CHARS) break;
+    total += entry.text.length;
+    notes.push(entry);
+  }
+  return notes;
+}
+
+/**
+ * Notes live in files rather than app state, so they carry their own
+ * timestamps and merge per note: newest write wins, identical text is left
+ * alone so the two sides converge instead of ping-ponging.
+ *
+ * ponytail: deletions do not propagate, a note deleted on one device comes
+ * back from the cloud. Add tombstones if that turns out to matter.
+ */
+export function createNotesSyncContributor(notesFiles: NotesFiles): SyncContributor {
+  return {
+    id: "notes",
+    schemaVersion: 1,
+    collect: async () => ({
+      // list() is newest first, so the budget keeps the notes worked on last.
+      notes: withinBudget(await notesFiles.list()),
+      quickNotes: await notesFiles.loadQuickNotesIndex(),
+    }),
+    apply: async (payload, { isCurrent }) => {
+      if (!isPlainObject(payload)) return;
+      const local = new Map((await notesFiles.list()).map((entry) => [entry.key, entry]));
+
+      for (const remote of parseNotes(payload.notes)) {
+        if (!isCurrent()) return;
+        const current = local.get(remote.key);
+        if (current && (current.text === remote.text || current.updatedAt >= remote.updatedAt)) continue;
+        await notesFiles.save(remote.key, remote.text);
+      }
+
+      if (!isCurrent()) return;
+      const merged = new Map((await notesFiles.loadQuickNotesIndex()).map((entry) => [entry.id, entry]));
+      let changed = false;
+      for (const remote of parseQuickNotes(payload.quickNotes)) {
+        const current = merged.get(remote.id);
+        if (current && (current.updatedAt ?? 0) >= (remote.updatedAt ?? 0)) continue;
+        merged.set(remote.id, remote);
+        changed = true;
+      }
+      if (changed) await notesFiles.saveQuickNotesIndex([...merged.values()]);
+    },
+  };
+}

--- a/src/sync/baseline.ts
+++ b/src/sync/baseline.ts
@@ -1,0 +1,32 @@
+import type { AppPluginStateStorePort } from "../core/app-service-ports";
+import type { SyncBaselineStore } from "./types";
+
+const BASELINE_PLUGIN_ID = "core.sync";
+const BASELINE_KEY = "last-synced-payloads";
+
+/**
+ * Persists what this device last pushed so the next pull can tell "the cloud is
+ * newer" from "local changed while the app was closed". Without it every launch
+ * treats local state as pristine and the cloud overwrites CLI/offline edits.
+ *
+ * Storage failures are swallowed: a missing baseline only falls back to keeping
+ * local state, never to discarding it.
+ */
+export function createSyncBaselineStore(pluginState: AppPluginStateStorePort): SyncBaselineStore {
+  return {
+    load: () => {
+      try {
+        return pluginState.get<Record<string, unknown>>(BASELINE_PLUGIN_ID, BASELINE_KEY)?.value ?? null;
+      } catch {
+        return null;
+      }
+    },
+    save: (payloads) => {
+      try {
+        pluginState.set(BASELINE_PLUGIN_ID, BASELINE_KEY, payloads);
+      } catch {
+        // Ignored: a stale baseline only makes the next pull more conservative.
+      }
+    },
+  };
+}

--- a/src/sync/controller.test.ts
+++ b/src/sync/controller.test.ts
@@ -14,11 +14,78 @@ import {
 import { CloudSyncController } from "./controller";
 import {
   SYNC_SNAPSHOT_SCHEMA_VERSION,
+  type SyncBaselineStore,
   type SyncContributor,
   type SyncSnapshot,
   type SyncSnapshotResponse,
   type SyncTransport,
 } from "./types";
+
+test("keeps workspace edits made while the app was closed and uploads them", async () => {
+  // The CLI writes config.json directly, so at launch local state looks
+  // pristine and the cloud copy used to overwrite it.
+  const syncedConfig = createDefaultConfig("/tmp/gloomberb-sync-offline-edit-test");
+  syncedConfig.portfolios = [{ id: "main", name: "Main", currency: "USD" }];
+  const syncedPayload = __syncContributorInternalsForTests.collectCoreConfigPayload(syncedConfig);
+  const stored: Record<string, unknown> = { "core.config": syncedPayload };
+  const baselineStore: SyncBaselineStore = {
+    load: () => stored,
+    save: (payloads) => Object.assign(stored, payloads),
+  };
+
+  let state = createInitialState({
+    ...syncedConfig,
+    portfolios: [...syncedConfig.portfolios, { id: "research", name: "Research", currency: "USD" }],
+  });
+  const dispatch = (action: AppAction) => {
+    state = appReducer(state, action);
+  };
+  const pushes: SyncSnapshot[] = [];
+  const transport: SyncTransport = {
+    id: "offline-edit",
+    isAvailable: () => true,
+    pullSnapshot: async () => ({
+      snapshot: {
+        schemaVersion: SYNC_SNAPSHOT_SCHEMA_VERSION,
+        appId: "gloomberb",
+        clientId: "remote-client",
+        createdAt: "2026-08-23T10:00:00.000Z",
+        contributors: {
+          "core.config": {
+            schemaVersion: 1,
+            updatedAt: "2026-08-23T10:00:00.000Z",
+            payload: syncedPayload,
+          },
+        },
+      },
+      revision: 4,
+      updatedAt: "2026-08-23T10:00:00.000Z",
+    }),
+    pushSnapshot: async (snapshot) => {
+      pushes.push(snapshot);
+      return { revision: 5, updatedAt: "2026-08-23T10:00:05.000Z" };
+    },
+  };
+
+  const controller = new CloudSyncController();
+  controller.setRuntime({
+    getState: () => state,
+    dispatch,
+    tickerRepository: {} as TickerRepository,
+    baselineStore,
+    getContributors: () => [{ pluginId: "core", contributor: coreConfigSyncContributor }],
+    getTransport: () => ({ pluginId: "test", transport }),
+  });
+
+  await controller.requestSync({ reason: "startup" });
+
+  const pushedPortfolios = (pushes[0]?.contributors["core.config"]?.payload as {
+    portfolios: Array<{ id: string }>;
+  }).portfolios.map((portfolio) => portfolio.id);
+  expect(state.config.portfolios.map((portfolio) => portfolio.id)).toEqual(["main", "research"]);
+  expect(pushedPortfolios).toEqual(["main", "research"]);
+  expect((stored["core.config"] as { portfolios: Array<{ id: string }> }).portfolios).toHaveLength(2);
+});
 
 test("does not push local state when the initial pull fails", async () => {
   let pushes = 0;

--- a/src/sync/controller.ts
+++ b/src/sync/controller.ts
@@ -6,6 +6,7 @@ import {
   SYNC_SNAPSHOT_SCHEMA_VERSION,
   type RegisteredSyncContributor,
   type RegisteredSyncTransport,
+  type SyncBaselineStore,
   type SyncContributor,
   type SyncSnapshot,
   type SyncTransport,
@@ -28,6 +29,7 @@ interface SyncRuntime {
   tickerRepository: AppTickerRepositoryPort;
   getContributors: () => RegisteredSyncContributor[];
   getTransport: () => RegisteredSyncTransport | null;
+  baselineStore?: SyncBaselineStore;
 }
 
 const CLIENT_ID_STORAGE_KEY = "gloomberb.sync.clientId";
@@ -65,6 +67,9 @@ export class CloudSyncController {
   private syncQueued = false;
   private clientId: string | null = null;
   private lastSignature: string | null = null;
+  private baseline: Record<string, unknown> | null = null;
+  private baselineLoaded = false;
+  private pulledContributors: SyncSnapshot["contributors"] = {};
   private hasPulledForTransport = new Set<string>();
   private status: CloudSyncStatus = {
     phase: "idle",
@@ -198,6 +203,7 @@ export class CloudSyncController {
       const result = await transport.pushSnapshot(snapshot, { baseRevision: this.status.revision });
       if (!this.isCurrent(runtime, transport)) return;
       this.lastSignature = signature;
+      this.saveBaseline(runtime, snapshot);
       this.setStatus({
         phase: "synced",
         transportId: transport.id,
@@ -224,6 +230,7 @@ export class CloudSyncController {
 
       if (response.snapshot) {
         this.assertSnapshotCompatible(response.snapshot, runtime.getContributors());
+        this.pulledContributors = response.snapshot.contributors;
         for (const entry of runtime.getContributors()) {
           if (!this.isCurrent(runtime, transport)) return false;
           const contributorPayload = response.snapshot.contributors[entry.contributor.id];
@@ -231,6 +238,7 @@ export class CloudSyncController {
           await entry.contributor.apply(contributorPayload.payload, {
             snapshot: response.snapshot,
             baselineState,
+            baselinePayload: this.loadBaseline(runtime)?.[entry.contributor.id] ?? null,
             state: runtime.getState(),
             getState: runtime.getState,
             isCurrent: () => this.isCurrent(runtime, transport),
@@ -287,7 +295,10 @@ export class CloudSyncController {
   private async assembleSnapshot(runtime: SyncRuntime): Promise<SyncSnapshot> {
     const contributors = runtime.getContributors();
     const createdAt = nowIso();
-    const payloads: SyncSnapshot["contributors"] = {};
+    // The snapshot replaces the stored one wholesale, so data owned by a
+    // contributor this client does not run (disabled plugin, older build) is
+    // carried over instead of being deleted for every other device.
+    const payloads: SyncSnapshot["contributors"] = { ...this.pulledContributors };
     for (const entry of contributors) {
       const payload = await entry.contributor.collect({ state: runtime.getState() });
       payloads[entry.contributor.id] = {
@@ -305,6 +316,23 @@ export class CloudSyncController {
     };
   }
 
+  private loadBaseline(runtime: SyncRuntime): Record<string, unknown> | null {
+    if (!this.baselineLoaded) {
+      this.baselineLoaded = true;
+      this.baseline = runtime.baselineStore?.load() ?? null;
+    }
+    return this.baseline;
+  }
+
+  private saveBaseline(runtime: SyncRuntime, snapshot: SyncSnapshot): void {
+    const payloads = Object.fromEntries(
+      Object.entries(snapshot.contributors).map(([id, contributor]) => [id, contributor.payload]),
+    );
+    this.baseline = payloads;
+    this.baselineLoaded = true;
+    runtime.baselineStore?.save(payloads);
+  }
+
   private isCurrent(runtime: SyncRuntime, transport: SyncTransport): boolean {
     return this.runtime === runtime && runtime.getTransport()?.transport === transport;
   }
@@ -316,6 +344,9 @@ export class CloudSyncController {
     this.syncQueued = false;
     this.hasPulledForTransport.clear();
     this.lastSignature = null;
+    this.baseline = null;
+    this.baselineLoaded = false;
+    this.pulledContributors = {};
   }
 
   private updateAvailability(): void {

--- a/src/sync/core-contributors.test.ts
+++ b/src/sync/core-contributors.test.ts
@@ -260,6 +260,50 @@ describe("core sync contributors", () => {
     expect((payload as any).analyticsByPortfolio.main.oneYearReturn).toBe(0.42);
   });
 
+  test("keeps a position written while the app was closed", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-sync-position-test");
+    config.portfolios = [{ id: "main", name: "Main", currency: "USD" }];
+    const withoutPosition: TickerRecord = {
+      metadata: {
+        ticker: "NVDA",
+        exchange: "NASDAQ",
+        currency: "USD",
+        name: "NVIDIA",
+        portfolios: ["main"],
+        watchlists: [],
+        positions: [],
+        custom: {},
+        tags: [],
+      },
+    };
+    const syncedState = createInitialState(config);
+    syncedState.tickers = new Map([["NVDA", withoutPosition]]);
+    const syncedPayload = await coreCollectionsSyncContributor.collect({ state: syncedState });
+
+    // `gloomberb portfolio position set` wrote this straight to the database.
+    const state = createInitialState(config);
+    state.tickers = new Map([["NVDA", {
+      metadata: {
+        ...withoutPosition.metadata,
+        positions: [{ portfolio: "main", shares: 10, avgCost: 100, broker: "manual", currency: "USD" }],
+      },
+    }]]);
+
+    const saved: TickerRecord[] = [];
+    await coreCollectionsSyncContributor.apply?.(syncedPayload, {
+      baselinePayload: syncedPayload,
+      baselineState: state,
+      state,
+      getState: () => state,
+      isCurrent: () => true,
+      dispatch: () => {},
+      tickerRepository: { saveTicker: async (record: TickerRecord) => { saved.push(record); } },
+    } as unknown as Parameters<NonNullable<typeof coreCollectionsSyncContributor.apply>>[1]);
+
+    expect(saved).toHaveLength(0);
+    expect(state.tickers.get("NVDA")?.metadata.positions).toHaveLength(1);
+  });
+
   test("syncs only public return and beta analytics", async () => {
     const config = createDefaultConfig("/tmp/gloomberb-sync-test");
     config.baseCurrency = "USD";

--- a/src/sync/core-contributors.ts
+++ b/src/sync/core-contributors.ts
@@ -307,6 +307,15 @@ function collectAccountsByPortfolio(
   return output;
 }
 
+type SanitizedTickerMetadata = ReturnType<typeof sanitizeTickerMetadata>;
+
+/** Only tickers the user actually filed somewhere are worth syncing. */
+function isSyncableTicker(metadata: Pick<SanitizedTickerMetadata, "portfolios" | "watchlists" | "positions">): boolean {
+  return metadata.portfolios.length > 0
+    || metadata.watchlists.length > 0
+    || metadata.positions.length > 0;
+}
+
 function collectCoreCollectionsPayload(
   config: AppConfig,
   tickers: Map<string, TickerRecord>,
@@ -316,11 +325,7 @@ function collectCoreCollectionsPayload(
 ) {
   const records = [...tickers.values()]
     .map((ticker) => sanitizeTickerMetadata(ticker.metadata, financials.get(ticker.metadata.ticker)))
-    .filter((metadata) => (
-      metadata.portfolios.length > 0 ||
-      metadata.watchlists.length > 0 ||
-      metadata.positions.length > 0
-    ));
+    .filter(isSyncableTicker);
 
   return {
     baseCurrency: config.baseCurrency,
@@ -375,11 +380,22 @@ function mergeConfigPayload(
   config: AppConfig,
   payload: unknown,
   baselineConfig: AppConfig = config,
+  lastSyncedPayload?: unknown,
 ): AppConfig | null {
   if (!isPlainObject(payload)) return null;
   const next: AppConfig = { ...config };
+  // Two guards, both needed. baselineConfig catches edits made while this pull
+  // was in flight; lastSyncedPayload catches edits made while the app was not
+  // running at all (CLI writes, offline edits), which otherwise look pristine.
+  const lastSynced = isPlainObject(lastSyncedPayload) ? lastSyncedPayload : null;
+  const localPayload = lastSynced
+    ? collectCoreConfigPayload(config) as Record<string, unknown>
+    : null;
+  const matchesLastSynced = (key: string) => (
+    !lastSynced || valuesEqual(localPayload?.[key], lastSynced[key])
+  );
   const canApply = <K extends keyof AppConfig>(key: K) => (
-    valuesEqual(config[key], baselineConfig[key])
+    valuesEqual(config[key], baselineConfig[key]) && matchesLastSynced(key as string)
   );
   const assign = <K extends keyof AppConfig>(key: K) => {
     if (key in payload && canApply(key)) {
@@ -420,7 +436,8 @@ function mergeConfigPayload(
 
   const layoutStateUntouched = config.layout === baselineConfig.layout
     && config.layouts === baselineConfig.layouts
-    && config.activeLayoutIndex === baselineConfig.activeLayoutIndex;
+    && config.activeLayoutIndex === baselineConfig.activeLayoutIndex
+    && ["layout", "layouts", "activeLayoutIndex"].every(matchesLastSynced);
   if (
     layoutStateUntouched
     && ["layout", "layouts", "activeLayoutIndex"].every((key) => key in payload)
@@ -450,12 +467,40 @@ function mergeConfigPayload(
   return next;
 }
 
+function lastSyncedTickersById(baselinePayload: unknown): Map<string, Record<string, unknown>> | null {
+  if (!isPlainObject(baselinePayload) || !Array.isArray(baselinePayload.tickers)) return null;
+  const byId = new Map<string, Record<string, unknown>>();
+  for (const entry of baselinePayload.tickers) {
+    if (isPlainObject(entry) && typeof entry.ticker === "string") byId.set(entry.ticker, entry);
+  }
+  return byId;
+}
+
+/** Quotes churn on every refresh, so they cannot signal a user edit. */
+function withoutQuote(metadata: Record<string, unknown>): Record<string, unknown> {
+  const { quote: _quote, ...rest } = metadata;
+  return rest;
+}
+
+function tickerChangedSinceLastSync(
+  current: TickerRecord | null | undefined,
+  lastSyncedTickers: Map<string, Record<string, unknown>> | null,
+): boolean {
+  if (!lastSyncedTickers || !current) return false;
+  const local = sanitizeTickerMetadata(current.metadata);
+  const baseline = lastSyncedTickers.get(current.metadata.ticker);
+  // No baseline entry means this device never uploaded the ticker: filed
+  // locally it is unsynced work, unfiled it is not something sync tracks.
+  if (!baseline) return isSyncableTicker(local);
+  return !valuesEqual(withoutQuote(local), withoutQuote(baseline));
+}
+
 export const coreConfigSyncContributor: SyncContributor = {
   id: "core.config",
   schemaVersion: 1,
   collect: ({ state }) => collectCoreConfigPayload(state.config),
-  apply: (payload, { baselineState, state, dispatch }) => {
-    const nextConfig = mergeConfigPayload(state.config, payload, baselineState.config);
+  apply: (payload, { baselinePayload, baselineState, state, dispatch }) => {
+    const nextConfig = mergeConfigPayload(state.config, payload, baselineState.config, baselinePayload);
     if (!nextConfig || valuesEqual(nextConfig, state.config)) return;
     dispatch({ type: "SET_CONFIG", config: nextConfig });
     scheduleConfigSave(nextConfig);
@@ -472,9 +517,10 @@ export const coreCollectionsSyncContributor: SyncContributor = {
     state.exchangeRates,
     state.brokerAccounts,
   ),
-  apply: async (payload, { getState, isCurrent, dispatch, tickerRepository }) => {
+  apply: async (payload, { baselinePayload, getState, isCurrent, dispatch, tickerRepository }) => {
     if (!isPlainObject(payload)) return;
     hydrateProfileAnalytics(payload);
+    const lastSyncedTickers = lastSyncedTickersById(baselinePayload);
     const incomingRecords: TickerRecord[] = [];
     const rawTickers = Array.isArray(payload.tickers) ? payload.tickers : [];
     for (const rawTicker of rawTickers) {
@@ -483,6 +529,9 @@ export const coreCollectionsSyncContributor: SyncContributor = {
       const current = typeof rawTicker.ticker === "string"
         ? getState().tickers.get(rawTicker.ticker)
         : null;
+      // Local edits the cloud has never seen (CLI positions, offline changes)
+      // win here and are uploaded by the push that follows this pull.
+      if (tickerChangedSinceLastSync(current, lastSyncedTickers)) continue;
       const metadata = hydrateTickerMetadata({
         ...current?.metadata,
         ...rawTicker,

--- a/src/sync/react.ts
+++ b/src/sync/react.ts
@@ -1,9 +1,10 @@
-import { useEffect, useSyncExternalStore, type Dispatch } from "react";
+import { useEffect, useMemo, useSyncExternalStore, type Dispatch } from "react";
 import type { AppAction, AppState } from "../core/state/app/state";
 import type { AppTickerRepositoryPort } from "../core/app-service-ports";
 import { apiClient } from "../api-client";
 import type { PluginRegistry } from "../plugins/registry";
 import { subscribeToCloudVerification } from "./auth-transition";
+import { createSyncBaselineStore } from "./baseline";
 import { cloudSyncController } from "./controller";
 
 interface CloudSyncRuntimeOptions {
@@ -23,15 +24,21 @@ export function useCloudSyncRuntime({
   pluginRegistry,
   initialized,
 }: CloudSyncRuntimeOptions): void {
+  const baselineStore = useMemo(
+    () => createSyncBaselineStore(pluginRegistry.persistence.pluginState),
+    [pluginRegistry],
+  );
+
   useEffect(() => {
     return cloudSyncController.setRuntime({
       getState,
       dispatch,
       tickerRepository,
+      baselineStore,
       getContributors: () => pluginRegistry.getEnabledSyncContributors(),
       getTransport: () => pluginRegistry.getActiveSyncTransport(),
     });
-  }, [dispatch, getState, pluginRegistry, tickerRepository]);
+  }, [baselineStore, dispatch, getState, pluginRegistry, tickerRepository]);
 
   useEffect(() => {
     if (!initialized) return;

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -26,6 +26,12 @@ export interface SyncCollectContext {
 export interface SyncApplyContext {
   snapshot: SyncSnapshot;
   baselineState: AppState;
+  /**
+   * The payload this device last pushed for this contributor, or null when it
+   * never synced. Anything that differs from it is local work the cloud has
+   * never seen (CLI edits, offline edits) and must survive the pull.
+   */
+  baselinePayload: unknown;
   state: AppState;
   getState: () => AppState;
   isCurrent: () => boolean;
@@ -67,6 +73,12 @@ export interface SyncSettings {
   selectedSharedPortfolioId?: string | null;
   lastSyncAt?: string | null;
   lastRoundupEmailAt?: string | null;
+}
+
+/** Durable record of the payloads this device last pushed to the cloud. */
+export interface SyncBaselineStore {
+  load(): Record<string, unknown> | null;
+  save(payloads: Record<string, unknown>): void;
 }
 
 export interface RegisteredSyncContributor {


### PR DESCRIPTION
## What broke

Create a portfolio or position with the CLI, launch the app, and the change was gone.

Sync kept no record of what a device had already uploaded. `mergeConfigPayload` only compared local state against a baseline captured *at the start of the pull*, which at launch is identical to the state just loaded from disk. Everything therefore looked pristine, so the cloud copy was applied wholesale and written back to `config.json`. Ticker records had no baseline check at all: remote metadata was shallow-spread over local, dropping CLI-written positions.

## The fix

- Every successful push stores its contributor payloads in plugin state (`core.sync/last-synced-payloads`, SQLite on desktop, localStorage on web).
- The next pull passes that payload to each contributor as `baselinePayload`. A remote field is applied only when the local one still matches what this device last uploaded; anything else is unsynced local work, kept and then uploaded by the push that follows the pull.
- Ticker records compare per symbol with the quote stripped, so price refreshes are not mistaken for user edits. A filed ticker missing from the baseline counts as never uploaded and is kept.
- Contributor payloads this client does not produce (disabled plugin, older build) are now carried through a push instead of being deleted for every other device.

With no stored baseline the old behaviour still applies, so a fresh install signing in still adopts the cloud workspace. Practically: the first launch after updating seeds the baseline, and CLI edits survive from then on.

## Notes sync

Notes were never synced, they live in files rather than app state. The notes plugin now registers a `notes` contributor: ticker notes and quick notes merge per note by write time (mtime on desktop, a maintained timestamp index in the browser), newest wins, identical text is left alone so the two sides converge. A per-note and total size budget keeps notes inside the server's 1.5MB snapshot cap. Deletions do not propagate yet.

## Tests

- `keeps workspace edits made while the app was closed and uploads them` reproduces the reported bug end to end and fails without the fix.
- `keeps a position written while the app was closed` covers the ticker path.
- `resolves each note to whichever side wrote it last` covers the notes merge.
- Full suite: 2270 pass. Typecheck across all six runtimes, plus the web bundle audit.

## Still missing

`gloomberb sync` for headless boxes: CLI edits reach the cloud the next time the app runs, not immediately. Pushing straight from the CLI needs the collections payload to preserve quotes and analytics the CLI cannot compute, so that is a separate change.
