### PR TITLE
Add price alert editing

### DIFF
--- a/src/plugins/builtin/alerts/alert-engine.test.ts
+++ b/src/plugins/builtin/alerts/alert-engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { evaluateAlert, createAlert, serializeAlerts, deserializeAlerts } from "./alert-engine";
+import { evaluateAlert, createAlert, editAlert, serializeAlerts, deserializeAlerts } from "./alert-engine";
 
 describe("evaluateAlert", () => {
   test("above: triggers when price exceeds target", () => {
@@ -38,6 +38,43 @@ describe("evaluateAlert", () => {
     const alert = createAlert("AAPL", "above", 200);
     alert.status = "triggered";
     expect(evaluateAlert(alert, 999)).toBe(false);
+  });
+});
+
+describe("editAlert", () => {
+  test("keeps identity, re-arms, and clears trigger/quote lifecycle state", () => {
+    const alert = {
+      ...createAlert("aapl", "above", 200, "NASDAQ"),
+      message: "watch this",
+      status: "triggered" as const,
+      triggeredAt: 123,
+      lastCheckedPrice: 205,
+      lastCheckedAt: 124,
+      lastCheckError: "boom",
+      lastQuoteUpdatedAt: 125,
+      lastQuoteSource: "live" as const,
+      lastQuoteProviderId: "yahoo",
+    };
+
+    const edited = editAlert(alert, "aapl", "crosses", 180);
+
+    expect(edited).toEqual({
+      id: alert.id,
+      symbol: "AAPL",
+      exchange: "NASDAQ",
+      condition: "crosses",
+      targetPrice: 180,
+      createdAt: alert.createdAt,
+      status: "active",
+      message: "watch this",
+    });
+    // A stale lastCheckedPrice would make `crosses` fire off the previous symbol's baseline.
+    expect(evaluateAlert(edited, 185)).toBe(false);
+  });
+
+  test("drops the exchange when the symbol changes", () => {
+    const alert = createAlert("AAPL", "above", 200, "NASDAQ");
+    expect(editAlert(alert, "tsla", "above", 200).exchange).toBeUndefined();
   });
 });
 

--- a/src/plugins/builtin/alerts/alert-engine.ts
+++ b/src/plugins/builtin/alerts/alert-engine.ts
@@ -19,6 +19,29 @@ export function createAlert(
   };
 }
 
+/**
+ * Rebuilt from a whitelist rather than spread so every trigger/quote lifecycle
+ * field is dropped: a re-armed `crosses` alert must start from a fresh baseline.
+ */
+export function editAlert(
+  alert: AlertRule,
+  symbol: string,
+  condition: AlertCondition,
+  targetPrice: number,
+): AlertRule {
+  const nextSymbol = symbol.trim().toUpperCase();
+  return {
+    id: alert.id,
+    symbol: nextSymbol,
+    exchange: nextSymbol === alert.symbol.trim().toUpperCase() ? alert.exchange : undefined,
+    condition,
+    targetPrice,
+    createdAt: alert.createdAt,
+    status: "active",
+    message: alert.message,
+  };
+}
+
 export function evaluateAlert(alert: AlertRule, currentPrice: number): boolean {
   if (alert.status !== "active") return false;
 

--- a/src/plugins/builtin/alerts/index.test.tsx
+++ b/src/plugins/builtin/alerts/index.test.tsx
@@ -148,13 +148,14 @@ function storedAlerts(): AlertRule[] {
   return JSON.parse(value);
 }
 
-afterEach(() => {
+afterEach(async () => {
   harnessState = null;
   harnessDispatch = null;
-  if (testSetup) {
-    testSetup.renderer.destroy();
-    testSetup = undefined;
-  }
+  if (!testSetup) return;
+  await act(async () => {
+    testSetup!.renderer.destroy();
+  });
+  testSetup = undefined;
 });
 
 describe("AlertsPane", () => {
@@ -179,6 +180,7 @@ describe("AlertsPane", () => {
     expect(frame).toContain("AAPL");
     expect(frame).toContain("MSFT");
     expect(frame).toContain("[a]dd alert");
+    expect(frame).toContain("[e]dit");
     expect(frame).toContain("[d]elete");
     expect(frame).not.toContain("Add Alert");
     expect(frame).not.toContain("Enter");
@@ -209,6 +211,45 @@ describe("AlertsPane", () => {
     expect(frame).toContain("[a]dd alert");
   });
 
+  test("edits the selected alert through the prefilled edit dialog", async () => {
+    testSetup = await testRender(
+      <AlertsHarness alerts={[makeAlert("alert-aapl", "AAPL", "above", 200)]} />,
+      { width: 110, height: 12 },
+    );
+
+    await renderSettled();
+    await act(async () => {
+      await testSetup!.mockInput.typeText("e");
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const dialogFrame = testSetup.captureCharFrame();
+    expect(dialogFrame).toContain("Edit alert");
+    expect(dialogFrame).toContain("AAPL above 200");
+
+    await act(async () => {
+      for (const _ of "AAPL above 200") testSetup!.mockInput.pressBackspace();
+      await testSetup!.mockInput.typeText("MSFT crosses 310");
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(storedAlerts()).toEqual([{
+      id: "alert-aapl",
+      symbol: "MSFT",
+      condition: "crosses",
+      targetPrice: 310,
+      createdAt: 1_700_000_000_000,
+      status: "active",
+    }]);
+  });
+
   test("opens the shared alert workflow from keyboard and mouse", async () => {
     const workflowCalls: string[] = [];
     const runtime = makeRuntime({
@@ -229,7 +270,9 @@ describe("AlertsPane", () => {
     });
     expect(workflowCalls).toEqual(["set-alert"]);
 
-    testSetup.renderer.destroy();
+    await act(async () => {
+      testSetup!.renderer.destroy();
+    });
     testSetup = await testRender(<AlertsHarness alerts={[]} runtime={runtime} />, {
       width: 110,
       height: 12,

--- a/src/plugins/builtin/alerts/pane.tsx
+++ b/src/plugins/builtin/alerts/pane.tsx
@@ -6,15 +6,19 @@ import {
   type DataTableColumn,
   type DataTableKeyEvent,
 } from "../../../components";
+import { TextFieldDialog } from "../../../components/pane-settings-dialog/field-dialogs";
 import { colors } from "../../../theme/colors";
 import { TextAttributes } from "../../../ui";
+import { useDialog, type AlertContext } from "../../../ui/dialog";
 import type { PaneProps } from "../../../types/plugin";
 import { usePluginAppActions, usePluginConfigState } from "../../runtime";
 import {
   deserializeAlerts,
+  editAlert,
   readAlertsStoreError,
   serializeAlerts,
 } from "./alert-engine";
+import { parseAlertCommandValues } from "./command";
 import { ALERTS_KEY } from "./constants";
 import {
   conditionLabel,
@@ -59,6 +63,7 @@ const ALERT_TABLE_CONTENT_WIDTH = ALERT_COLUMNS.reduce(
 export function AlertsPane({ focused, width, height, close }: PaneProps) {
   const [alertsJson, setAlertsJson] = usePluginConfigState<string>(ALERTS_KEY, "[]");
   const { openPluginCommandWorkflow } = usePluginAppActions();
+  const dialog = useDialog();
   const [selectedIdx, setSelectedIdx] = useState(0);
   const showHorizontalScrollbar = ALERT_TABLE_CONTENT_WIDTH > width;
   const storeError = useMemo(() => readAlertsStoreError(alertsJson), [alertsJson]);
@@ -112,6 +117,36 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
     if (selected) deleteAlert(selected.id);
   }, [deleteAlert, rows, selectedIdx]);
 
+  const editSelectedAlert = useCallback(() => {
+    const selected = rows[selectedIdx];
+    if (!selected) return;
+    void dialog.alert({
+      closeOnClickOutside: true,
+      content: (context: AlertContext) => (
+        <TextFieldDialog
+          {...context}
+          field={{
+            type: "text",
+            key: "alert",
+            label: "Edit alert",
+            description: "SYMBOL above|below|crosses PRICE",
+            placeholder: "AAPL above 200",
+          }}
+          currentValue={`${selected.symbol} ${selected.condition} ${selected.targetPrice}`}
+          onApply={async (value) => {
+            const parsed = parseAlertCommandValues({ shortcut: value });
+            if (!parsed) throw new Error("Use SYMBOL above|below|crosses PRICE.");
+            savePaneAlerts((current) => current.map((alert) => (
+              alert.id === selected.id
+                ? editAlert(alert, parsed.symbol, parsed.condition, parsed.price)
+                : alert
+            )));
+          }}
+        />
+      ),
+    });
+  }, [dialog, rows, savePaneAlerts, selectedIdx]);
+
   // Quotes come from the plugin's single background poll, which writes into the
   // same persisted store, so the pane never fetches on its own.
 
@@ -124,6 +159,13 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
     hints: [
       { id: "add", key: "a", label: "dd alert", onPress: startAddAlert },
       {
+        id: "edit",
+        key: "e",
+        label: "dit",
+        onPress: editSelectedAlert,
+        disabled: rows.length === 0,
+      },
+      {
         id: "delete",
         key: "d",
         label: "elete",
@@ -133,6 +175,7 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
     ],
   }), [
     deleteSelectedAlert,
+    editSelectedAlert,
     quoteError,
     rows.length,
     startAddAlert,
@@ -154,13 +197,18 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
       startAddAlert();
       return true;
     }
+    if (event.name === "e") {
+      event.preventDefault?.();
+      editSelectedAlert();
+      return true;
+    }
     if (event.name === "escape") {
       event.preventDefault?.();
       close?.();
       return true;
     }
     return false;
-  }, [close, deleteSelectedAlert, startAddAlert]);
+  }, [close, deleteSelectedAlert, editSelectedAlert, startAddAlert]);
 
   const renderCell = useCallback((
     alert: AlertRule,


### PR DESCRIPTION
## Summary
- add an edit action for the selected price alert on keyboard and clickable pane footer
- reuse the shared text-field dialog across terminal, desktop, and browser renderers
- re-arm edited alerts while clearing stale trigger and quote state

## Testing
- `bun test src/plugins/builtin/alerts/`
- `bun run typecheck:opentui`
- `bun run typecheck:browser`
- `bun run typecheck:electrobun-view`
- tmux smoke: opened Alerts, edited triggered `AAPL above 200` to active `MSFT below 250`, and verified no runtime warnings
