### PR TITLE
Show company logos on ticker overview

### DIFF
--- a/src/api-client/paths.ts
+++ b/src/api-client/paths.ts
@@ -62,6 +62,23 @@ export type CloudTweetSearchParams = {
   hours?: number;
 };
 
+const LOGO_SYMBOL_RE = /^[A-Z0-9][A-Z0-9._^:-]{0,23}$/;
+const CRYPTO_QUOTE = /[-/](USD|USDT|USDC|EUR|GBP|BTC)$/;
+
+export type CloudLogoKind = "ticker" | "crypto";
+
+export function normalizeCloudLogoSymbol(kind: CloudLogoKind, symbol: string): string | null {
+  let normalized = symbol.trim().toUpperCase();
+  if (kind === "crypto") normalized = normalized.replace(CRYPTO_QUOTE, "");
+  return LOGO_SYMBOL_RE.test(normalized) ? normalized : null;
+}
+
+export function cloudLogoPath(kind: CloudLogoKind, symbol: string): string | null {
+  const normalized = normalizeCloudLogoSymbol(kind, symbol);
+  if (!normalized) return null;
+  return `/cloud/logos/${kind}/${encodeURIComponent(normalized)}`;
+}
+
 function appendQuery(path: string, search: URLSearchParams): string {
   const query = search.toString();
   return `${path}${query ? `?${query}` : ""}`;

--- a/src/api-client/request.ts
+++ b/src/api-client/request.ts
@@ -24,7 +24,7 @@ export function setCloudApiFetchTransport(transport: CloudApiFetchTransport | nu
 
 declare const __GLOOMBERB_API_URL__: string | undefined;
 
-function getCloudApiBaseUrl(): string {
+export function getCloudApiBaseUrl(): string {
   // Browser bundles have no `process`; the build replaces this with a literal.
   const bundled = typeof __GLOOMBERB_API_URL__ === "string" ? __GLOOMBERB_API_URL__ : "";
   if (bundled) {

--- a/src/components/company-logo.test.ts
+++ b/src/components/company-logo.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { resolveCompanyLogoSrc } from "./company-logo";
+
+describe("resolveCompanyLogoSrc", () => {
+  test("builds a ticker logo URL", () => {
+    expect(resolveCompanyLogoSrc({ symbol: "aapl", assetCategory: "STK" }))
+      .toMatch(/\/cloud\/logos\/ticker\/AAPL$/);
+  });
+
+  test("maps crypto quote pairs onto the crypto path", () => {
+    expect(resolveCompanyLogoSrc({ symbol: "btc-usd", assetCategory: "CRYPTO" }))
+      .toMatch(/\/cloud\/logos\/crypto\/BTC$/);
+  });
+
+  test("skips cash and options", () => {
+    expect(resolveCompanyLogoSrc({ symbol: "USD", assetCategory: "CASH" })).toBeNull();
+    expect(resolveCompanyLogoSrc({ symbol: "AAPL  240119C00190000", assetCategory: "OPT" })).toBeNull();
+  });
+});

--- a/src/components/company-logo.tsx
+++ b/src/components/company-logo.tsx
@@ -1,0 +1,45 @@
+import { ImageSurface, useUiCapabilities } from "../ui";
+import { cloudLogoPath, type CloudLogoKind } from "../api-client/paths";
+import { getCloudApiBaseUrl } from "../api-client/request";
+import { resolveAssetDisplayKind } from "../market-data/market/format";
+
+export function resolveCompanyLogoSrc(input: {
+  symbol: string;
+  assetCategory?: string;
+}): string | null {
+  const kind = logoKindForAsset(input.assetCategory);
+  if (!kind) return null;
+  const path = cloudLogoPath(kind, input.symbol);
+  return path ? `${getCloudApiBaseUrl()}${path}` : null;
+}
+
+export function CompanyLogo({
+  symbol,
+  assetCategory,
+  name,
+}: {
+  symbol: string;
+  assetCategory?: string;
+  name?: string;
+}) {
+  const { nativePaneChrome } = useUiCapabilities();
+  const src = nativePaneChrome === true ? resolveCompanyLogoSrc({ symbol, assetCategory }) : null;
+  if (!src) return null;
+
+  return (
+    <ImageSurface
+      src={src}
+      alt={name || symbol}
+      width={2}
+      height={1}
+      marginRight={1}
+      objectFit="contain"
+    />
+  );
+}
+
+function logoKindForAsset(assetCategory?: string): CloudLogoKind | null {
+  const kind = resolveAssetDisplayKind({ assetCategory });
+  if (kind === "cash" || kind === "contract") return null;
+  return kind === "crypto" ? "crypto" : "ticker";
+}

--- a/src/components/company-logo.tsx
+++ b/src/components/company-logo.tsx
@@ -26,7 +26,7 @@ export function CompanyLogo({
   width?: number;
   height?: number;
 }) {
-  const { nativePaneChrome } = useUiCapabilities();
+  const { nativePaneChrome, cellWidthPx = 8, cellHeightPx = 18 } = useUiCapabilities();
   const src = nativePaneChrome === true ? resolveCompanyLogoSrc({ symbol, assetCategory }) : null;
   if (!src) return null;
 
@@ -38,7 +38,13 @@ export function CompanyLogo({
       height={height}
       marginRight={1}
       flexShrink={0}
+      overflow="visible"
       objectFit="contain"
+      style={{
+        width: cellWidthPx * width,
+        height: cellHeightPx * height,
+        flexShrink: 0,
+      }}
     />
   );
 }

--- a/src/components/company-logo.tsx
+++ b/src/components/company-logo.tsx
@@ -1,7 +1,8 @@
-import { ImageSurface, useUiCapabilities } from "../ui";
+import { ImageSurface, Text, useUiCapabilities } from "../ui";
 import { cloudLogoPath, type CloudLogoKind } from "../api-client/paths";
 import { getCloudApiBaseUrl } from "../api-client/request";
 import { resolveAssetDisplayKind } from "../market-data/market/format";
+import { colors } from "../theme/colors";
 
 export function resolveCompanyLogoSrc(input: {
   symbol: string;
@@ -38,14 +39,17 @@ export function CompanyLogo({
       height={height}
       marginRight={1}
       flexShrink={0}
-      overflow="visible"
+      alignItems="center"
+      justifyContent="center"
       objectFit="contain"
       style={{
         width: cellWidthPx * width,
         height: cellHeightPx * height,
         flexShrink: 0,
       }}
-    />
+    >
+      <Text fg={colors.textDim}>{symbol.trim().charAt(0).toUpperCase() || "?"}</Text>
+    </ImageSurface>
   );
 }
 

--- a/src/components/company-logo.tsx
+++ b/src/components/company-logo.tsx
@@ -17,10 +17,14 @@ export function CompanyLogo({
   symbol,
   assetCategory,
   name,
+  width = 5,
+  height = 2,
 }: {
   symbol: string;
   assetCategory?: string;
   name?: string;
+  width?: number;
+  height?: number;
 }) {
   const { nativePaneChrome } = useUiCapabilities();
   const src = nativePaneChrome === true ? resolveCompanyLogoSrc({ symbol, assetCategory }) : null;
@@ -30,9 +34,10 @@ export function CompanyLogo({
     <ImageSurface
       src={src}
       alt={name || symbol}
-      width={2}
-      height={1}
+      width={width}
+      height={height}
       marginRight={1}
+      flexShrink={0}
       objectFit="contain"
     />
   );

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../../market-data/market/status";
 import { selectEffectiveExchangeRates } from "../../../utils/exchange-rate-map";
 import { EmptyState } from "../../../components";
+import { CompanyLogo } from "../../../components/company-logo";
 import {
   CompositeChart,
   pricePointsToResolvedSeries,
@@ -140,6 +141,11 @@ export function OverviewTab({
         <Box flexDirection={quoteBookInline ? "row" : "column"} gap={quoteBookInline ? 2 : 0} width={contentWidth}>
           <Box flexDirection="column" width={quoteSummaryWidth}>
             <Box flexDirection="row">
+              <CompanyLogo
+                symbol={ticker.metadata.ticker}
+                assetCategory={ticker.metadata.assetCategory}
+                name={ticker.metadata.name || quote?.name}
+              />
               <Text attributes={TextAttributes.BOLD} fg={colors.textBright}>
                 {ticker.metadata.ticker}
               </Text>

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -139,13 +139,14 @@ export function OverviewTab({
     <ScrollBox flexGrow={1} flexBasis={0} scrollY focusable={false}>
       <Box flexDirection="column" paddingX={1} paddingBottom={1} gap={1}>
         <Box flexDirection={quoteBookInline ? "row" : "column"} gap={quoteBookInline ? 2 : 0} width={contentWidth}>
-          <Box flexDirection="column" width={quoteSummaryWidth}>
+          <Box flexDirection="row" width={quoteSummaryWidth}>
+            <CompanyLogo
+              symbol={ticker.metadata.ticker}
+              assetCategory={ticker.metadata.assetCategory}
+              name={ticker.metadata.name || quote?.name}
+            />
+            <Box flexDirection="column" flexGrow={1} flexShrink={1} minWidth={0}>
             <Box flexDirection="row">
-              <CompanyLogo
-                symbol={ticker.metadata.ticker}
-                assetCategory={ticker.metadata.assetCategory}
-                name={ticker.metadata.name || quote?.name}
-              />
               <Text attributes={TextAttributes.BOLD} fg={colors.textBright}>
                 {ticker.metadata.ticker}
               </Text>
@@ -199,6 +200,7 @@ export function OverviewTab({
             {metadataParts.length > 0 && (
               <Text fg={colors.textDim}>{metadataParts.join(" | ")}</Text>
             )}
+            </Box>
           </Box>
 
           {quote && hasBidAsk && (

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -49,7 +49,7 @@ export function OverviewTab({
   const baseCurrency = useAppSelector((state) => state.config.baseCurrency);
   const exchangeRatesState = useAppSelector((state) => state.exchangeRates);
   const { width: termWidth } = useViewport();
-  const { fractionalViewport = false } = useUiCapabilities();
+  const { fractionalViewport = false, nativePaneChrome } = useUiCapabilities();
 
   if (!ticker) return <EmptyState title={t("No ticker selected.")} />;
 
@@ -137,7 +137,7 @@ export function OverviewTab({
 
   return (
     <ScrollBox flexGrow={1} flexBasis={0} scrollY focusable={false}>
-      <Box flexDirection="column" paddingX={1} paddingBottom={1} gap={1}>
+      <Box flexDirection="column" paddingX={1} paddingTop={nativePaneChrome ? 1 : 0} paddingBottom={1} gap={1}>
         <Box flexDirection={quoteBookInline ? "row" : "column"} gap={quoteBookInline ? 2 : 0} width={contentWidth}>
           <Box flexDirection="row" width={quoteSummaryWidth}>
             <CompanyLogo

--- a/src/renderers/electrobun/view/dom-ui-host.tsx
+++ b/src/renderers/electrobun/view/dom-ui-host.tsx
@@ -111,6 +111,7 @@ export function createDomUiHost(
         >
           {imageSrc && !failed ? (
             <img
+              key={imageSrc}
               src={imageSrc}
               alt={alt}
               draggable={false}


### PR DESCRIPTION
## Summary
- Desktop and web overview shows a 2x1 company mark next to the ticker name.
- Images come from `GET /cloud/logos/{ticker|crypto}/{symbol}` on Gloom Cloud. Terminal does not render them.
- Depends on gloomberb-platform `feat/logo-proxy` plus `LOGOKIT_TOKEN` on the API. Until that ships, the mark just stays hidden.

## Test plan
- [x] `bun test src/components/company-logo.test.ts`
- [x] `bun test src/plugins/builtin/ticker-detail/index.test.tsx`
- [ ] On desktop, open AAPL overview and confirm the logo appears once the proxy is live
- [ ] On TUI, confirm the overview header is unchanged