### PR TITLE
Keep raw RSS out of Top News

### DIFF
--- a/src/plugins/builtin/news/wire/index.tsx
+++ b/src/plugins/builtin/news/wire/index.tsx
@@ -41,7 +41,7 @@ function createNewsPresetPane(config: NewsPresetPaneConfig) {
 }
 
 const TopPane = createNewsPresetPane({
-  paneKey: "top",
+  paneKey: "top:curated",
   title: "Top News",
   query: NEWS_QUERY_PRESETS.top,
   columns: ["time", "source", "title", "tickers", "categories", "importance"],

--- a/src/plugins/builtin/news/wire/rss/source.test.ts
+++ b/src/plugins/builtin/news/wire/rss/source.test.ts
@@ -20,6 +20,18 @@ const RSS_FIXTURE = `<rss version="2.0"><channel><item>
 </item></channel></rss>`;
 
 describe("createRssNewsCapability", () => {
+  test("does not serve unclassified RSS stories as top news", async () => {
+    const fetchText = mock(async () => ({
+      ok: true,
+      text: async () => RSS_FIXTURE,
+    }));
+    const source = createRssNewsCapability([FEED], { fetchText });
+
+    expect(source.provider.supports?.({ feed: "top" })).toBe(false);
+    expect(await source.provider.fetchNews({ feed: "top" })).toEqual([]);
+    expect(fetchText).not.toHaveBeenCalled();
+  });
+
   test("caches fetched feed items with feed authority scoring", async () => {
     const persistence = new MemoryPersistence();
     const fetchText = mock(async () => ({

--- a/src/plugins/builtin/news/wire/rss/source.ts
+++ b/src/plugins/builtin/news/wire/rss/source.ts
@@ -37,7 +37,7 @@ export interface RssNewsCapabilityOptions {
 
 function supportsQuery(query: NewsQuery): boolean {
   const feed = query.feed ?? (query.scope === "ticker" ? "ticker" : "latest");
-  return feed === "latest" || feed === "top";
+  return feed === "latest";
 }
 
 function serializeItem(item: MarketNewsItem): CachedNewsItem {


### PR DESCRIPTION
## Summary
- restrict local RSS feeds to the chronological News Feed
- keep Top News limited to Gloom Cloud classified stories
- reset the persisted Top News cache so old RSS rows cannot linger
- add regression coverage for the feed boundary

## Verification
- `bun test src/plugins/builtin/news/wire/rss/source.test.ts`
- `bun run typecheck`
- tmux smoke: Top News rendered classified cloud sources with no raw Yahoo/CNBC RSS rows
- runtime warning and process leak sweeps clean