### PR TITLE
Load onboarding price from Cloud

### DIFF
--- a/src/components/onboarding/onboarding-wizard.test.tsx
+++ b/src/components/onboarding/onboarding-wizard.test.tsx
@@ -595,6 +595,49 @@ describe("OnboardingWizard", () => {
     expect(capturedConfig?.onboardingProgress?.stage).toBe("account");
   });
 
+  test("loads the current Cloud price on the Pro step", async () => {
+    tempDataDir = await mkdtemp(join(tmpdir(), "gloomberb-onboarding-pro-price-"));
+    const getCloudPricing = apiClient.getCloudPricing;
+    let resolvePricing!: (pricing: Awaited<ReturnType<typeof apiClient.getCloudPricing>>) => void;
+    apiClient.getCloudPricing = () => new Promise((resolve) => {
+      resolvePricing = resolve;
+    });
+
+    try {
+      const pluginRegistry = createPluginRegistry();
+      const config = {
+        ...createDefaultConfig(tempDataDir),
+        onboardingProgress: {
+          version: 1 as const,
+          stage: "upgrade" as const,
+          accountStatus: "signed-in" as const,
+        },
+      };
+      testSetup = await testRender(
+        <WizardHarness config={config} pluginRegistry={pluginRegistry} />,
+        { width: 100, height: 30 },
+      );
+      await testSetup.renderOnce();
+      await act(async () => {
+        resolvePricing({
+          currency: "usd",
+          trialDays: 7,
+          founding: true,
+          monthly: { amount: 3900, anchorAmount: 4900 },
+          yearly: { amount: 39000, anchorAmount: 49000 },
+        });
+        await Bun.sleep(0);
+        await testSetup!.renderOnce();
+      });
+
+      const frame = testSetup.captureCharFrame();
+      expect(frame).toContain("$49/mo");
+      expect(frame).not.toContain("$29/mo");
+    } finally {
+      apiClient.getCloudPricing = getCloudPricing;
+    }
+  });
+
   test("Not now skips Pro and moves directly to ready", async () => {
     tempDataDir = await mkdtemp(join(tmpdir(), "gloomberb-onboarding-cloud-skip-"));
     const pluginRegistry = createPluginRegistry();

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -5,7 +5,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { apiClient } from "../../api-client";
+import { apiClient, type CloudPricing } from "../../api-client";
 import type { AppBrokerImportRuntime } from "../../app/runtime/broker-import";
 import type { SyncBrokerInstanceResult } from "../../brokers/sync-broker-instance";
 import { saveConfigImmediately } from "../../state/config-save-scheduler";
@@ -28,6 +28,7 @@ import { t, tf } from "../../i18n";
 import { useAppLanguage } from "../../i18n/react";
 import type { PluginRegistry } from "../../plugins/registry";
 import { chatController } from "../../plugins/builtin/chat/controller";
+import { formatCloudMonthlyPrice } from "../../plugins/builtin/account-management/model";
 import { useCloudUpgradeAction } from "../../plugins/builtin/shared/cloud-upgrade";
 import { usePlanAccess } from "../../plugins/builtin/shared/plan-access";
 import type { ListViewItem } from "../ui";
@@ -71,6 +72,7 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
   const stage = progress.stage;
   const [persistenceError, setPersistenceError] = useState<string | null>(null);
   const [isFinishing, setIsFinishing] = useState(false);
+  const [pricing, setPricing] = useState<CloudPricing | null>(null);
 
   const [portfolioSub, setPortfolioSub] = useState<PortfolioSub>("choose");
   const [portfolioOptionIdx, setPortfolioOptionIdx] = useState(0);
@@ -253,6 +255,11 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
       });
     },
   ), [pluginRegistry.events, saveProgressInBackground, stateRef]);
+
+  useEffect(() => {
+    if (stage !== "upgrade" || pricing) return;
+    void apiClient.getCloudPricing().then(setPricing).catch(() => {});
+  }, [pricing, stage]);
 
   const appActive = useAppActive();
   const planAccess = usePlanAccess();
@@ -859,6 +866,7 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
 
   if (stage === "upgrade") {
     const primaryLabel = planAccess.hasProAccess ? t("Continue with Pro") : t("Start 7-day free trial");
+    const monthlyPrice = formatCloudMonthlyPrice(pricing);
     return (
       <OnboardingModal width={66} height={17}>
         <OnboardingHeader
@@ -871,10 +879,10 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
         />
         <OnboardingTitle
           step={desktop ? undefined : t("GLOOM CLOUD PRO")}
-          title={planAccess.hasProAccess ? t("Pro is active") : t("$29/mo for real-time market data")}
-          titlePrefix={!planAccess.hasProAccess ? (
+          title={planAccess.hasProAccess ? t("Pro is active") : monthlyPrice.price}
+          titlePrefix={!planAccess.hasProAccess && monthlyPrice.anchor ? (
             <Text fg={colors.textMuted} attributes={TextAttributes.STRIKETHROUGH}>
-              {t("$49/mo")}
+              {monthlyPrice.anchor}
             </Text>
           ) : undefined}
           description={planAccess.hasProAccess

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -1117,7 +1117,6 @@ export const es: Record<string, string> = {
     "Revisa tu bandeja de entrada para verificar tu correo. Después puedes empezar tu prueba Pro gratis de 7 días cuando quieras: escribe UPGRADE.",
 
   // ── Onboarding setup ────────────────────────────────────────
-  "$29/mo for real-time market data": "$29/mes por datos de mercado en tiempo real",
   "Limited founding offer. Start a free 7-day trial.": "Oferta limitada de lanzamiento. Empieza una prueba gratuita de 7 días.",
   "Start 7-day free trial": "Iniciar prueba gratuita de 7 días",
   "Adds quotes, financials, options, research, news, chat and AI commands.": "Añade cotizaciones, datos financieros, opciones, análisis, noticias, chat y comandos de IA.",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -1105,7 +1105,6 @@ export const ja: Record<string, string> = {
   "signing in...": "サインイン中...",
 
   // ── Onboarding setup ────────────────────────────────────────
-  "$29/mo for real-time market data": "リアルタイム市場データを月額$29で",
   "Limited founding offer. Start a free 7-day trial.": "創設記念の期間限定オファー。7日間の無料トライアルを開始できます。",
   "Start 7-day free trial": "7日間の無料トライアルを開始",
   "Adds quotes, financials, options, research, news, chat and AI commands.": "株価、財務情報、オプション、リサーチ、ニュース、チャット、AIコマンドを追加します。",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -1103,7 +1103,6 @@ export const ko: Record<string, string> = {
   "signing in...": "로그인 중...",
 
   // ── Onboarding setup ────────────────────────────────────────
-  "$29/mo for real-time market data": "실시간 시장 데이터 월 $29",
   "Limited founding offer. Start a free 7-day trial.": "창립 한정 혜택. 7일 무료 체험을 시작하세요.",
   "Start 7-day free trial": "7일 무료 체험 시작",
   "Adds quotes, financials, options, research, news, chat and AI commands.": "시세, 재무 정보, 옵션, 리서치, 뉴스, 채팅, AI 명령을 추가합니다.",

--- a/src/i18n/zh-cn.ts
+++ b/src/i18n/zh-cn.ts
@@ -1105,7 +1105,6 @@ export const zhCN: Record<string, string> = {
   "signing in...": "登录中...",
 
   // ── Onboarding setup ────────────────────────────────────────
-  "$29/mo for real-time market data": "实时市场数据每月 $29",
   "Limited founding offer. Start a free 7-day trial.": "限时创始优惠。开始 7 天免费试用。",
   "Start 7-day free trial": "开始 7 天免费试用",
   "Adds quotes, financials, options, research, news, chat and AI commands.": "增加行情、财务数据、期权、研报、新闻、聊天和 AI 命令。",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -1105,7 +1105,6 @@ export const zhTW: Record<string, string> = {
   "signing in...": "登入中...",
 
   // ── Onboarding setup ────────────────────────────────────────
-  "$29/mo for real-time market data": "即時市場資料每月 $29",
   "Limited founding offer. Start a free 7-day trial.": "限時創始優惠。開始 7 天免費試用。",
   "Start 7-day free trial": "開始 7 天免費試用",
   "Adds quotes, financials, options, research, news, chat and AI commands.": "增加報價、財務資料、選擇權、研究、新聞、聊天與 AI 指令。",


### PR DESCRIPTION
## Summary
- replace the onboarding wizard's hardcoded $29 price with the public Cloud pricing response
- reuse the account-management price formatter for the $49 anchor and localized monthly price
- remove stale $29 translation entries
- add a regression test that pins the onboarding display to API pricing

## Validation
- `bun test src/components/onboarding/onboarding-wizard.test.tsx` (12 pass)
- `bun run typecheck`
- `bun run web:build`
- isolated tmux smoke rendered `$49/mo $39/mo`, with no `$29` or runtime warnings
- `bun run i18n:audit` reported no extra/canonical/placeholder mismatches; it still exits on the seven pre-existing referenced keys missing from every locale
