### PR TITLE
Add Equity Diagnostic research view

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Use `HELP` inside Gloomberb for the live shortcut list. The common command-bar p
 | `CMP <tickers>` | Normalized price comparison |
 | `CORR <tickers>` | Ticker return correlations |
 | `ANR <ticker>` | Analyst targets and ratings |
+| `DIAG <ticker>` | Equity Diagnostic with cited flags and anomalies |
 | `SEC <ticker>` | SEC filings and company disclosures |
 | `OMON <ticker>` | Options monitor |
 | `OVME` | Black-Scholes option calculator with Greeks and implied volatility |

--- a/src/api-client/data.ts
+++ b/src/api-client/data.ts
@@ -34,7 +34,7 @@ import type {
   CloudCorporateActionsPayload,
   CloudEconEventPayload,
   CloudEquityDiagnosticMode,
-  CloudEquityDiagnosticResponse,
+  CloudEquityDiagnosticResult,
   CloudFredSeriesPayload,
   CloudFundamentals,
   CloudHoldersPayload,
@@ -183,8 +183,8 @@ export class CloudDataApi {
     symbol: string,
     exchange?: string,
     mode: CloudEquityDiagnosticMode = "cache-first",
-  ): Promise<CloudEquityDiagnosticResponse> {
-    return this.request<CloudEquityDiagnosticResponse>("/research/equity-diagnostic", {
+  ): Promise<CloudEquityDiagnosticResult> {
+    return this.request<CloudEquityDiagnosticResult>("/research/equity-diagnostic", {
       method: "POST",
       body: JSON.stringify({
         symbol: symbol.trim().toUpperCase(),

--- a/src/api-client/data.ts
+++ b/src/api-client/data.ts
@@ -33,6 +33,8 @@ import type {
   CloudCongressHousePayload,
   CloudCorporateActionsPayload,
   CloudEconEventPayload,
+  CloudEquityDiagnosticMode,
+  CloudEquityDiagnosticResponse,
   CloudFredSeriesPayload,
   CloudFundamentals,
   CloudHoldersPayload,
@@ -170,6 +172,26 @@ export class CloudDataApi {
 
   async getCloudExchangeRate(fromCurrency: string): Promise<CloudMarketResponse<{ rate: number }>> {
     return this.request<CloudMarketResponse<{ rate: number }>>(cloudExchangeRatePath(fromCurrency));
+  }
+
+  /**
+   * On-demand single-company evidence review. This is a cloud product endpoint,
+   * not a market-data capability, so it is called directly instead of routed
+   * through the asset-data provider.
+   */
+  async getCloudEquityDiagnostic(
+    symbol: string,
+    exchange?: string,
+    mode: CloudEquityDiagnosticMode = "cache-first",
+  ): Promise<CloudEquityDiagnosticResponse> {
+    return this.request<CloudEquityDiagnosticResponse>("/research/equity-diagnostic", {
+      method: "POST",
+      body: JSON.stringify({
+        symbol: symbol.trim().toUpperCase(),
+        ...(exchange ? { exchange } : {}),
+        mode,
+      }),
+    });
   }
 
   async getCloudEconomicCalendar(): Promise<CloudEconEventPayload[]> {

--- a/src/api-client/index.test.ts
+++ b/src/api-client/index.test.ts
@@ -1082,3 +1082,37 @@ describe("apiClient cloud news", () => {
     expect(story.id).toBe("story-1");
   });
 });
+
+describe("apiClient equity diagnostic", () => {
+  test("posts the symbol, exchange, and cache mode to the research route", async () => {
+    let seenUrl = "";
+    let seenInit: RequestInit | undefined;
+    globalThis.fetch = mockFetch(async (input: Request | string | URL, init?: RequestInit) => {
+      seenUrl = String(input);
+      seenInit = init;
+      return createResponse({ symbol: "AAPL", status: "complete" });
+    });
+
+    await apiClient.getCloudEquityDiagnostic(" aapl ", "NASDAQ", "refresh");
+
+    expect(new URL(seenUrl).pathname).toBe("/research/equity-diagnostic");
+    expect(seenInit?.method).toBe("POST");
+    expect(JSON.parse(String(seenInit?.body))).toEqual({
+      symbol: "AAPL",
+      exchange: "NASDAQ",
+      mode: "refresh",
+    });
+  });
+
+  test("omits an unknown exchange and defaults to the cached answer", async () => {
+    let seenInit: RequestInit | undefined;
+    globalThis.fetch = mockFetch(async (_input: Request | string | URL, init?: RequestInit) => {
+      seenInit = init;
+      return createResponse({ symbol: "AAPL", status: "complete" });
+    });
+
+    await apiClient.getCloudEquityDiagnostic("AAPL");
+
+    expect(JSON.parse(String(seenInit?.body))).toEqual({ symbol: "AAPL", mode: "cache-first" });
+  });
+});

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -42,6 +42,8 @@ import type {
   CloudCorporateActionsPayload,
   CloudPricePointPayload,
   CloudEconEventPayload,
+  CloudEquityDiagnosticMode,
+  CloudEquityDiagnosticResponse,
   CloudFredSeriesPayload,
   CloudYieldPointPayload,
   CloudCongressHousePayload,
@@ -559,6 +561,14 @@ class GloomApiClient {
 
   async getCloudEconomicCalendar(): Promise<CloudEconEventPayload[]> {
     return this.data.getCloudEconomicCalendar();
+  }
+
+  async getCloudEquityDiagnostic(
+    symbol: string,
+    exchange?: string,
+    mode: CloudEquityDiagnosticMode = "cache-first",
+  ): Promise<CloudEquityDiagnosticResponse> {
+    return this.data.getCloudEquityDiagnostic(symbol, exchange, mode);
   }
 
   async getCloudFredSeries(

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -43,7 +43,7 @@ import type {
   CloudPricePointPayload,
   CloudEconEventPayload,
   CloudEquityDiagnosticMode,
-  CloudEquityDiagnosticResponse,
+  CloudEquityDiagnosticResult,
   CloudFredSeriesPayload,
   CloudYieldPointPayload,
   CloudCongressHousePayload,
@@ -567,7 +567,7 @@ class GloomApiClient {
     symbol: string,
     exchange?: string,
     mode: CloudEquityDiagnosticMode = "cache-first",
-  ): Promise<CloudEquityDiagnosticResponse> {
+  ): Promise<CloudEquityDiagnosticResult> {
     return this.data.getCloudEquityDiagnostic(symbol, exchange, mode);
   }
 

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -713,6 +713,11 @@ export interface CloudEquityDiagnosticEvidence {
   url?: string;
 }
 
+export interface CloudEquityDiagnosticPending {
+  status: "generating";
+  retryAfterMs: number;
+}
+
 export interface CloudEquityDiagnosticResponse {
   schemaVersion: 1;
   symbol: string;
@@ -735,6 +740,10 @@ export interface CloudEquityDiagnosticResponse {
   promptVersion: 1;
   model: "gpt-5.6-luna";
 }
+
+export type CloudEquityDiagnosticResult =
+  | CloudEquityDiagnosticPending
+  | CloudEquityDiagnosticResponse;
 
 export interface CloudVerificationResponse {
   sent: boolean;

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -673,6 +673,69 @@ export interface CloudMarketScreenerPayload {
   items: CloudMarketScreenerItem[];
 }
 
+/** Cache reuse policy for one Equity Diagnostic request. */
+export type CloudEquityDiagnosticMode = "cache-first" | "refresh";
+
+export type CloudEquityDiagnosticFindingKind = "red_flag" | "green_flag" | "anomaly";
+
+/** 3 is the most severe. */
+export type CloudEquityDiagnosticSeverity = 1 | 2 | 3;
+
+export interface CloudEquityDiagnosticFinding {
+  id: string;
+  kind: CloudEquityDiagnosticFindingKind;
+  severity: CloudEquityDiagnosticSeverity;
+  confidence: number;
+  title: string;
+  /** What the data says, with no reading attached. */
+  observation: string;
+  /** What the observation may mean; kept apart from the observation on purpose. */
+  interpretation: string;
+  /** Ids into `evidence`; unresolved ids are dropped by the client. */
+  evidenceIds: string[];
+}
+
+export interface CloudEquityDiagnosticCoverage {
+  dataset: string;
+  status: "available" | "no_data" | "unsupported" | "failed";
+  asOf?: string;
+  provider?: string;
+  note?: string;
+}
+
+/** The server owns citation URLs; the client never builds them. */
+export interface CloudEquityDiagnosticEvidence {
+  id: string;
+  dataset: string;
+  label: string;
+  asOf?: string;
+  provider?: string;
+  url?: string;
+}
+
+export interface CloudEquityDiagnosticResponse {
+  schemaVersion: 1;
+  symbol: string;
+  exchange: string;
+  companyName?: string;
+  status: "complete" | "partial" | "insufficient_data";
+  verdict: "risk_skewed" | "balanced" | "opportunity_skewed" | "unclear";
+  summary: string;
+  confidence: number;
+  findings: CloudEquityDiagnosticFinding[];
+  watchItems: string[];
+  coverage: CloudEquityDiagnosticCoverage[];
+  evidence: CloudEquityDiagnosticEvidence[];
+  generatedAt: string;
+  expiresAt: string;
+  /** Before this instant a `refresh` request may still answer from cache. */
+  refreshAllowedAt: string;
+  cached: boolean;
+  stale: boolean;
+  promptVersion: 1;
+  model: "gpt-5.6-luna";
+}
+
 export interface CloudVerificationResponse {
   sent: boolean;
   email?: string;

--- a/src/plugins/builtin/cloud/auth-actions.tsx
+++ b/src/plugins/builtin/cloud/auth-actions.tsx
@@ -53,16 +53,19 @@ export function InlineAuthActions({ showSignup = true }: { showSignup?: boolean 
 export function CloudAuthNotice({
   message,
   showSignup = true,
+  needsVerification = false,
 }: {
   message: string;
   showSignup?: boolean;
+  /** Forces the verification branch and uses `message` as its headline. */
+  needsVerification?: boolean;
 }) {
   const { openCommandBar } = usePluginAppActions();
 
-  if (/verification/i.test(message)) {
+  if (needsVerification || /verification/i.test(message)) {
     return (
       <Box flexDirection="column" padding={1} gap={1}>
-        <Text fg={colors.positive}>{t("Verify your email to use Cloud tweets.")}</Text>
+        <Text fg={colors.positive}>{needsVerification ? message : t("Verify your email to use Cloud tweets.")}</Text>
         <Button label={t("Resend Verification Email")} variant="secondary" onPress={() => openCommandBar("Resend Verification Email")} />
       </Box>
     );

--- a/src/plugins/builtin/research/equity-diagnostic-pane.test.tsx
+++ b/src/plugins/builtin/research/equity-diagnostic-pane.test.tsx
@@ -1,0 +1,282 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { apiClient, setCloudApiFetchTransport } from "../../../api-client";
+import type { CloudEquityDiagnosticResponse } from "../../../api-client";
+import { PaneFooterBar, PaneFooterProvider } from "../../../components/layout/pane/footer";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { AppContext, PaneInstanceProvider, createInitialState } from "../../../state/app/context";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
+import { cloneLayout, createDefaultConfig } from "../../../types/config";
+import type { TickerRecord } from "../../../types/ticker";
+import { Box } from "../../../ui";
+import { PluginRenderProvider } from "../../runtime";
+import { EquityDiagnosticView } from "./equity-diagnostic-pane";
+
+const TEST_PANE_ID = "equity-diagnostic:AAPL";
+const WIDTH = 96;
+/** Tall enough that a full report fits without scrolling the assertions away. */
+const HEIGHT = 44;
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+function makeTicker(symbol: string): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange: "NASDAQ",
+      currency: "USD",
+      name: symbol,
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+function signIn(plan: "free" | "pro"): void {
+  apiClient.setSessionToken("equity-diagnostic-test-token");
+  apiClient.restoreCachedUser({
+    id: "user-1",
+    name: "Tester",
+    email: "tester@example.com",
+    username: "tester",
+    emailVerified: true,
+    plan,
+  } as never);
+}
+
+/** Answers the diagnostic endpoint locally and records the request bodies. */
+function mockDiagnosticTransport(
+  respond: (body: { symbol: string; exchange?: string; mode?: string }) => Response,
+): Array<{ symbol: string; exchange?: string; mode?: string }> {
+  const requests: Array<{ symbol: string; exchange?: string; mode?: string }> = [];
+  setCloudApiFetchTransport(async (url, init) => {
+    if (!url.endsWith("/research/equity-diagnostic")) {
+      throw new Error(`unexpected cloud request: ${url}`);
+    }
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    requests.push(body);
+    return respond(body);
+  });
+  return requests;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+function makeReport(overrides: Partial<CloudEquityDiagnosticResponse> = {}): CloudEquityDiagnosticResponse {
+  return {
+    schemaVersion: 1,
+    symbol: "AAPL",
+    exchange: "NASDAQ",
+    companyName: "Apple Inc.",
+    status: "partial",
+    verdict: "risk_skewed",
+    summary: "Margins slipped while inventory built up.",
+    confidence: 0.72,
+    findings: [
+      {
+        id: "f-low",
+        kind: "red_flag",
+        severity: 1,
+        confidence: 0.4,
+        title: "Receivables grew faster than sales",
+        observation: "Receivables rose 18 percent against 4 percent revenue growth.",
+        interpretation: "Collection may be slowing.",
+        evidenceIds: [],
+      },
+      {
+        id: "f-high",
+        kind: "red_flag",
+        severity: 3,
+        confidence: 0.81,
+        title: "Gross margin fell for three quarters",
+        observation: "Gross margin fell to 38.2 percent from 44.6 percent.",
+        interpretation: "Pricing pressure is outpacing mix improvement.",
+        evidenceIds: ["ev-10k", "ev-missing"],
+      },
+      {
+        id: "f-green",
+        kind: "green_flag",
+        severity: 2,
+        confidence: 0.6,
+        title: "Buyback pace accelerated",
+        observation: "Shares outstanding fell 3 percent.",
+        interpretation: "Capital return is intact.",
+        evidenceIds: ["ev-news"],
+      },
+    ],
+    watchItems: ["Next quarter gross margin guidance"],
+    coverage: [
+      { dataset: "financials", status: "available", asOf: "2026-02-01", provider: "polygon" },
+      { dataset: "insider", status: "no_data" },
+    ],
+    evidence: [
+      { id: "ev-10k", dataset: "filings", label: "10-K", asOf: "2026-02-01", url: "https://sec.gov/aapl-10k" },
+      { id: "ev-news", dataset: "news", label: "Reuters" },
+    ],
+    generatedAt: new Date(Date.now() - 4 * 60_000).toISOString(),
+    expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    refreshAllowedAt: new Date(Date.now() + 600_000).toISOString(),
+    cached: true,
+    stale: true,
+    promptVersion: 1,
+    model: "gpt-5.6-luna",
+    ...overrides,
+  };
+}
+
+function DiagnosticHarness() {
+  const config = createDefaultConfig("/tmp/gloomberb-equity-diagnostic-test");
+  config.layout = {
+    dockRoot: { kind: "pane", instanceId: TEST_PANE_ID },
+    instances: [{
+      instanceId: TEST_PANE_ID,
+      paneId: "equity-diagnostic",
+      binding: { kind: "fixed", symbol: "AAPL" },
+    }],
+    floating: [],
+    detached: [],
+  };
+  config.layouts = [{ name: "Default", layout: cloneLayout(config.layout) }];
+
+  const state = createInitialState(config);
+  state.focusedPaneId = TEST_PANE_ID;
+  state.tickers = new Map([["AAPL", makeTicker("AAPL")]]);
+
+  return (
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <PaneInstanceProvider paneId={TEST_PANE_ID}>
+        <PluginRenderProvider pluginId="ticker-research" runtime={createTestPluginRuntime()}>
+          <PaneFooterProvider>
+            {(footer) => (
+              <Box flexDirection="column" width={WIDTH} height={HEIGHT}>
+                <EquityDiagnosticView width={WIDTH} height={HEIGHT - 1} focused />
+                <PaneFooterBar footer={footer} focused width={WIDTH} />
+              </Box>
+            )}
+          </PaneFooterProvider>
+        </PluginRenderProvider>
+      </PaneInstanceProvider>
+    </AppContext>
+  );
+}
+
+async function renderHarness(): Promise<void> {
+  await act(async () => {
+    testSetup = await testRender(<DiagnosticHarness />, { width: WIDTH, height: HEIGHT });
+  });
+  await settle();
+}
+
+async function settle(): Promise<void> {
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    await act(async () => {
+      await Bun.sleep(1);
+      await testSetup!.renderOnce();
+    });
+  }
+}
+
+async function pressKey(name: string): Promise<void> {
+  await act(async () => {
+    testSetup!.renderer.keyInput.emit("keypress", {
+      name,
+      sequence: name,
+      ctrl: false,
+      meta: false,
+      option: false,
+      shift: false,
+      eventType: "press",
+      repeated: false,
+      stopPropagation: () => {},
+      preventDefault: () => {},
+    } as never);
+    await testSetup!.renderOnce();
+  });
+  await settle();
+}
+
+afterEach(async () => {
+  if (testSetup) {
+    await act(async () => testSetup!.renderer.destroy());
+    testSetup = undefined;
+  }
+  setCloudApiFetchTransport(null);
+  apiClient.setSessionToken(null);
+  apiClient.restoreCachedUser(null);
+});
+
+test("keeps the diagnostic behind Pro and never asks the server for a free account", async () => {
+  signIn("free");
+  const requests = mockDiagnosticTransport(() => jsonResponse(makeReport()));
+
+  await renderHarness();
+
+  const frame = testSetup!.captureCharFrame();
+  expect(requests).toHaveLength(0);
+  expect(frame).toContain("Gloom Cloud Pro");
+  expect(frame).toContain("Upgrade to Pro");
+  expect(frame).toContain("Manage account");
+  // A gated pane has nothing to refresh.
+  expect(frame).not.toContain("efresh");
+});
+
+test("renders a stale partial report with severity order, split observation, and citations", async () => {
+  signIn("pro");
+  mockDiagnosticTransport(() => jsonResponse(makeReport()));
+
+  await renderHarness();
+
+  const frame = testSetup!.captureCharFrame();
+  expect(frame).toContain("Risk skewed");
+  expect(frame).toContain("Apple Inc.");
+  expect(frame).toContain("4m ago");
+  expect(frame).toContain("confidence 72%");
+  expect(frame).toContain("Margins slipped");
+
+  // Severity sorted inside a kind, and split into observation versus reading.
+  expect(frame.indexOf("Gross margin fell for three quarters"))
+    .toBeLessThan(frame.indexOf("Receivables grew faster than sales"));
+  expect(frame).toContain("Observed");
+  expect(frame).toContain("Reading");
+  expect(frame).toContain("Pricing pressure is outpacing mix improvement.");
+
+  // Citations resolve against the server catalog; unknown ids are dropped.
+  expect(frame).toContain("10-K 2026-02-01");
+  expect(frame).toContain("Reuters");
+  expect(frame).not.toContain("ev-missing");
+
+  expect(frame).toContain("WATCH ITEMS");
+  expect(frame).toContain("COVERAGE");
+  expect(frame).toContain("no data");
+
+  // Footer carries changing state only, and the model stays an implementation detail.
+  expect(frame).toContain("partial");
+  expect(frame).toContain("stale");
+  expect(frame).toContain("efresh");
+  expect(frame).not.toContain("luna");
+});
+
+test("asks for a refresh on r and keeps the last report when the retry is rate limited", async () => {
+  signIn("pro");
+  const requests = mockDiagnosticTransport((body) => (
+    body.mode === "refresh"
+      ? jsonResponse({ message: "Too many requests" }, 429)
+      : jsonResponse(makeReport())
+  ));
+
+  await renderHarness();
+  expect(requests).toEqual([{ symbol: "AAPL", exchange: "NASDAQ", mode: "cache-first" }]);
+
+  await pressKey("r");
+
+  expect(requests.at(-1)?.mode).toBe("refresh");
+  const frame = testSetup!.captureCharFrame();
+  expect(frame).toContain("Rate limited");
+  expect(frame).toContain("Gross margin fell for three quarters");
+  expect(frame).toContain("Retry");
+});

--- a/src/plugins/builtin/research/equity-diagnostic-pane.test.tsx
+++ b/src/plugins/builtin/research/equity-diagnostic-pane.test.tsx
@@ -261,6 +261,27 @@ test("renders a stale partial report with severity order, split observation, and
   expect(frame).not.toContain("luna");
 });
 
+test("polls an uncached diagnostic until the background report is ready", async () => {
+  signIn("pro");
+  let attempts = 0;
+  const requests = mockDiagnosticTransport(() => {
+    attempts += 1;
+    return attempts === 1
+      ? jsonResponse({ status: "generating", retryAfterMs: 10 }, 202)
+      : jsonResponse(makeReport());
+  });
+
+  await renderHarness();
+  await Bun.sleep(20);
+  await settle();
+
+  expect(requests).toEqual([
+    { symbol: "AAPL", exchange: "NASDAQ", mode: "cache-first" },
+    { symbol: "AAPL", exchange: "NASDAQ", mode: "cache-first" },
+  ]);
+  expect(testSetup!.captureCharFrame()).toContain("Gross margin fell for three quarters");
+});
+
 test("asks for a refresh on r and keeps the last report when the retry is rate limited", async () => {
   signIn("pro");
   const requests = mockDiagnosticTransport((body) => (

--- a/src/plugins/builtin/research/equity-diagnostic-pane.tsx
+++ b/src/plugins/builtin/research/equity-diagnostic-pane.tsx
@@ -58,29 +58,50 @@ function useEquityDiagnostic(symbol: string | null, exchange: string, enabled: b
     failure: DiagnosticFailure | null;
   }>({ report: null, loading: false, failure: null });
   const generationRef = useRef(0);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearPoll = useCallback(() => {
+    if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+    pollTimerRef.current = null;
+  }, []);
 
   const load = useCallback((mode: CloudEquityDiagnosticMode) => {
     if (!symbol || !enabled) return;
+    clearPoll();
     generationRef.current += 1;
     const generation = generationRef.current;
     setState((current) => ({ ...current, loading: true, failure: null }));
-    apiClient.getCloudEquityDiagnostic(symbol, exchange || undefined, mode)
-      .then((report) => {
-        if (generationRef.current !== generation) return;
-        setState({ report, loading: false, failure: null });
-      })
-      .catch((error: unknown) => {
-        if (generationRef.current !== generation) return;
-        setState((current) => ({ report: current.report, loading: false, failure: toFailure(error) }));
-      });
-  }, [enabled, exchange, symbol]);
+
+    const request = (nextMode: CloudEquityDiagnosticMode) => {
+      apiClient.getCloudEquityDiagnostic(symbol, exchange || undefined, nextMode)
+        .then((result) => {
+          if (generationRef.current !== generation) return;
+          if (result.status === "generating") {
+            const retryAfterMs = Math.max(10, Math.min(5_000, result.retryAfterMs));
+            pollTimerRef.current = setTimeout(() => request("cache-first"), retryAfterMs);
+            return;
+          }
+          clearPoll();
+          setState({ report: result, loading: false, failure: null });
+        })
+        .catch((error: unknown) => {
+          if (generationRef.current !== generation) return;
+          clearPoll();
+          setState((current) => ({ report: current.report, loading: false, failure: toFailure(error) }));
+        });
+    };
+
+    request(mode);
+  }, [clearPoll, enabled, exchange, symbol]);
 
   useEffect(() => {
     // A report belongs to one company, so drop it rather than show it under the next.
     generationRef.current += 1;
+    clearPoll();
     setState({ report: null, loading: false, failure: null });
     load("cache-first");
-  }, [load]);
+    return clearPoll;
+  }, [clearPoll, load]);
 
   return { ...state, load };
 }

--- a/src/plugins/builtin/research/equity-diagnostic-pane.tsx
+++ b/src/plugins/builtin/research/equity-diagnostic-pane.tsx
@@ -1,0 +1,464 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { Box, ScrollBox, Text, TextAttributes, useUiCapabilities } from "../../../ui";
+import { Button, EmptyState, Spinner, usePaneFooter } from "../../../components";
+import { ExternalLinkText } from "../../../components/ui";
+import { CloudAuthNotice } from "../cloud/auth-actions";
+import { apiClient } from "../../../api-client";
+import type {
+  CloudEquityDiagnosticCoverage,
+  CloudEquityDiagnosticEvidence,
+  CloudEquityDiagnosticFinding,
+  CloudEquityDiagnosticFindingKind,
+  CloudEquityDiagnosticMode,
+  CloudEquityDiagnosticResponse,
+} from "../../../api-client";
+import { ApiRequestError } from "../../../api-client/errors";
+import { colors } from "../../../theme/colors";
+import { t, tf } from "../../../i18n";
+import { useShortcut } from "../../../react/input";
+import { formatTimeAgo, truncateToDisplayWidth } from "../../../utils/format";
+import { isPlainKey } from "../../../utils/keyboard";
+import { usePlanAccess } from "../shared/plan-access";
+import { useCloudPlanAction, useCloudUpgradeAction } from "../shared/cloud-upgrade";
+import { useBoundTicker } from "../shared/ticker-request";
+
+const FOOTER_ID = "equity-diagnostic";
+const REFRESH_SCOPE = "equity-diagnostic:refresh";
+/** Width of the "Observed"/"Reading" label column before the layout stacks. */
+const LABEL_WIDTH = 10;
+const STACK_BELOW_WIDTH = 44;
+const COVERAGE_LABEL_WIDTH = 16;
+
+interface DiagnosticFailure {
+  status?: number;
+  message: string;
+}
+
+function toFailure(error: unknown): DiagnosticFailure {
+  return {
+    status: error instanceof ApiRequestError ? error.status : undefined,
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+function failureText(failure: DiagnosticFailure): string {
+  if (failure.status === 429) return t("Rate limited. Try again in a moment.");
+  if (failure.status != null && failure.status >= 500) return t("Diagnostic service is unavailable.");
+  return failure.message;
+}
+
+/**
+ * One report request per visited surface. A failed refresh keeps the report the
+ * user is already reading, so a rate limit or an outage never blanks the pane.
+ */
+function useEquityDiagnostic(symbol: string | null, exchange: string, enabled: boolean) {
+  const [state, setState] = useState<{
+    report: CloudEquityDiagnosticResponse | null;
+    loading: boolean;
+    failure: DiagnosticFailure | null;
+  }>({ report: null, loading: false, failure: null });
+  const generationRef = useRef(0);
+
+  const load = useCallback((mode: CloudEquityDiagnosticMode) => {
+    if (!symbol || !enabled) return;
+    generationRef.current += 1;
+    const generation = generationRef.current;
+    setState((current) => ({ ...current, loading: true, failure: null }));
+    apiClient.getCloudEquityDiagnostic(symbol, exchange || undefined, mode)
+      .then((report) => {
+        if (generationRef.current !== generation) return;
+        setState({ report, loading: false, failure: null });
+      })
+      .catch((error: unknown) => {
+        if (generationRef.current !== generation) return;
+        setState((current) => ({ report: current.report, loading: false, failure: toFailure(error) }));
+      });
+  }, [enabled, exchange, symbol]);
+
+  useEffect(() => {
+    // A report belongs to one company, so drop it rather than show it under the next.
+    generationRef.current += 1;
+    setState({ report: null, loading: false, failure: null });
+    load("cache-first");
+  }, [load]);
+
+  return { ...state, load };
+}
+
+function verdictLabel(verdict: CloudEquityDiagnosticResponse["verdict"]): string {
+  switch (verdict) {
+    case "risk_skewed": return t("Risk skewed");
+    case "opportunity_skewed": return t("Opportunity skewed");
+    case "balanced": return t("Balanced");
+    default: return t("Unclear");
+  }
+}
+
+function verdictColor(verdict: CloudEquityDiagnosticResponse["verdict"]): string {
+  switch (verdict) {
+    case "risk_skewed": return colors.negative;
+    case "opportunity_skewed": return colors.positive;
+    case "balanced": return colors.text;
+    default: return colors.textDim;
+  }
+}
+
+function findingColor(kind: CloudEquityDiagnosticFindingKind): string {
+  switch (kind) {
+    case "red_flag": return colors.negative;
+    case "green_flag": return colors.positive;
+    default: return colors.warning;
+  }
+}
+
+function severityLabel(severity: CloudEquityDiagnosticFinding["severity"]): string {
+  if (severity >= 3) return t("HIGH");
+  if (severity === 2) return t("MEDIUM");
+  return t("LOW");
+}
+
+function coverageColor(status: CloudEquityDiagnosticCoverage["status"]): string {
+  if (status === "available") return colors.textDim;
+  return status === "failed" ? colors.warning : colors.textMuted;
+}
+
+function coverageLabel(status: CloudEquityDiagnosticCoverage["status"]): string {
+  switch (status) {
+    case "available": return t("available");
+    case "no_data": return t("no data");
+    case "unsupported": return t("unsupported");
+    default: return t("failed");
+  }
+}
+
+function percent(value: number): string {
+  const scaled = value <= 1 ? value * 100 : value;
+  return `${Math.round(scaled)}%`;
+}
+
+function citationLabel(evidence: CloudEquityDiagnosticEvidence): string {
+  const date = evidence.asOf?.slice(0, 10);
+  return date && !evidence.label.includes(date) ? `${evidence.label} ${date}` : evidence.label;
+}
+
+function datasetLabel(dataset: string): string {
+  return dataset.replaceAll("_", " ");
+}
+
+function sortFindings(findings: readonly CloudEquityDiagnosticFinding[]): CloudEquityDiagnosticFinding[] {
+  return [...findings].sort((left, right) => (
+    right.severity - left.severity || right.confidence - left.confidence
+  ));
+}
+
+function Paragraph({ text: value, width, color, bold }: {
+  text: string;
+  width: number;
+  color: string;
+  bold?: boolean;
+}) {
+  return (
+    <Text
+      fg={color}
+      width={width}
+      wrapText
+      wrapMode="word"
+      attributes={bold ? TextAttributes.BOLD : undefined}
+    >
+      {value}
+    </Text>
+  );
+}
+
+function SectionHeading({ label }: { label: string }) {
+  return (
+    <Box height={1}>
+      <Text fg={colors.textMuted} attributes={TextAttributes.BOLD}>{t(label)}</Text>
+    </Box>
+  );
+}
+
+/** Label plus body text, stacked instead of columned once the pane gets narrow. */
+function LabeledText({ label, text: value, width, color }: {
+  label: string;
+  text: string;
+  width: number;
+  color: string;
+}) {
+  if (width < STACK_BELOW_WIDTH) {
+    return (
+      <Box flexDirection="column" width={width}>
+        <Box height={1}><Text fg={colors.textMuted}>{t(label)}</Text></Box>
+        <Paragraph text={value} width={width} color={color} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="row" width={width}>
+      <Box width={LABEL_WIDTH} flexShrink={0}>
+        <Text fg={colors.textMuted}>{t(label)}</Text>
+      </Box>
+      <Box flexDirection="column" flexGrow={1} minWidth={0}>
+        <Paragraph text={value} width={width - LABEL_WIDTH} color={color} />
+      </Box>
+    </Box>
+  );
+}
+
+function FindingView({ finding, evidenceById, width }: {
+  finding: CloudEquityDiagnosticFinding;
+  evidenceById: Map<string, CloudEquityDiagnosticEvidence>;
+  width: number;
+}) {
+  const kindColor = findingColor(finding.kind);
+  const citations = finding.evidenceIds
+    .map((id) => evidenceById.get(id))
+    .filter((evidence): evidence is CloudEquityDiagnosticEvidence => !!evidence);
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Box flexDirection="row" width={width}>
+        <Box width={8} flexShrink={0}>
+          <Text fg={kindColor} attributes={TextAttributes.BOLD}>{severityLabel(finding.severity)}</Text>
+        </Box>
+        <Box flexDirection="column" flexGrow={1} minWidth={0}>
+          <Paragraph text={finding.title} width={width - 8} color={colors.textBright} bold />
+        </Box>
+      </Box>
+      <LabeledText label="Observed" text={finding.observation} width={width} color={colors.text} />
+      <LabeledText label="Reading" text={finding.interpretation} width={width} color={colors.textDim} />
+      <Box flexDirection="row" flexWrap="wrap" width={width}>
+        <Text fg={colors.textMuted}>{tf("{value} confidence", { value: percent(finding.confidence) })}</Text>
+        {citations.map((evidence) => (
+          <Box key={evidence.id} flexDirection="row">
+            <Text fg={colors.textMuted}>{"  ·  "}</Text>
+            {evidence.url
+              ? <ExternalLinkText url={evidence.url} label={citationLabel(evidence)} color={colors.textDim} />
+              : <Text fg={colors.textMuted}>{citationLabel(evidence)}</Text>}
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+function FindingSection({ heading, findings, evidenceById, width }: {
+  heading: string;
+  findings: CloudEquityDiagnosticFinding[];
+  evidenceById: Map<string, CloudEquityDiagnosticEvidence>;
+  width: number;
+}) {
+  if (findings.length === 0) return null;
+  return (
+    <Box flexDirection="column" width={width} gap={1}>
+      <SectionHeading label={heading} />
+      {findings.map((finding) => (
+        <FindingView key={finding.id} finding={finding} evidenceById={evidenceById} width={width} />
+      ))}
+    </Box>
+  );
+}
+
+function CoverageSection({ coverage, width }: {
+  coverage: CloudEquityDiagnosticCoverage[];
+  width: number;
+}) {
+  if (coverage.length === 0) return null;
+  const detailWidth = Math.max(12, width - COVERAGE_LABEL_WIDTH);
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <SectionHeading label="COVERAGE" />
+      {coverage.map((entry) => {
+        const detail = [coverageLabel(entry.status), entry.asOf?.slice(0, 10), entry.provider, entry.note]
+          .filter(Boolean)
+          .join(" · ");
+        return (
+          <Box key={`${entry.dataset}:${entry.status}`} flexDirection="row" width={width}>
+            <Box width={COVERAGE_LABEL_WIDTH} flexShrink={0}>
+              <Text fg={colors.textDim}>
+                {truncateToDisplayWidth(datasetLabel(entry.dataset), COVERAGE_LABEL_WIDTH - 1)}
+              </Text>
+            </Box>
+            <Box flexDirection="column" flexGrow={1} minWidth={0}>
+              <Paragraph text={detail} width={detailWidth} color={coverageColor(entry.status)} />
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+function ReportView({ report, width, failure, onRetry }: {
+  report: CloudEquityDiagnosticResponse;
+  width: number;
+  failure: DiagnosticFailure | null;
+  onRetry: () => void;
+}) {
+  const evidenceById = useMemo(
+    () => new Map(report.evidence.map((evidence) => [evidence.id, evidence])),
+    [report.evidence],
+  );
+  const sorted = useMemo(() => sortFindings(report.findings), [report.findings]);
+  const byKind = (kind: CloudEquityDiagnosticFindingKind) => sorted.filter((finding) => finding.kind === kind);
+  const meta = [
+    report.companyName,
+    tf("generated {age}", { age: formatTimeAgo(report.generatedAt) }),
+    tf("confidence {value}", { value: percent(report.confidence) }),
+  ].filter(Boolean).join(" · ");
+
+  return (
+    <Box flexDirection="column" width={width} gap={1}>
+      <Box flexDirection="column" width={width}>
+        <Box height={1}>
+          <Text fg={verdictColor(report.verdict)} attributes={TextAttributes.BOLD}>
+            {verdictLabel(report.verdict)}
+          </Text>
+        </Box>
+        <Paragraph text={meta} width={width} color={colors.textMuted} />
+      </Box>
+
+      {failure && (
+        <Box flexDirection="row" gap={1} width={width}>
+          <Text fg={colors.warning}>{failureText(failure)}</Text>
+          <Button label="Retry" variant="secondary" onPress={onRetry} />
+        </Box>
+      )}
+
+      {report.status === "insufficient_data"
+        ? <EmptyState title="Not enough coverage to review this company yet." message={report.summary} />
+        : <Paragraph text={report.summary} width={width} color={colors.text} />}
+
+      <FindingSection heading="RED FLAGS" findings={byKind("red_flag")} evidenceById={evidenceById} width={width} />
+      <FindingSection heading="ANOMALIES" findings={byKind("anomaly")} evidenceById={evidenceById} width={width} />
+      <FindingSection heading="GREEN FLAGS" findings={byKind("green_flag")} evidenceById={evidenceById} width={width} />
+
+      {report.watchItems.length > 0 && (
+        <Box flexDirection="column" width={width}>
+          <SectionHeading label="WATCH ITEMS" />
+          {report.watchItems.map((item, index) => (
+            <Box key={`${index}:${item.slice(0, 24)}`} flexDirection="row" width={width}>
+              <Box width={2} flexShrink={0}><Text fg={colors.textMuted}>{"· "}</Text></Box>
+              <Box flexDirection="column" flexGrow={1} minWidth={0}>
+                <Paragraph text={item} width={width - 2} color={colors.text} />
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      <CoverageSection coverage={report.coverage} width={width} />
+    </Box>
+  );
+}
+
+export function EquityDiagnosticView({ focused, width }: {
+  focused: boolean;
+  width: number;
+  height: number;
+}) {
+  const { symbol, exchange } = useBoundTicker();
+  const access = usePlanAccess();
+  const openUpgrade = useCloudUpgradeAction();
+  const openPlan = useCloudPlanAction();
+  const { nativePaneChrome } = useUiCapabilities();
+
+  const entitled = access.emailVerified && access.hasProAccess;
+  const { report, loading, failure, load } = useEquityDiagnostic(symbol, exchange, entitled);
+
+  const signInRequired = !access.signedIn || failure?.status === 401;
+  const verificationRequired = !signInRequired && (!access.emailVerified || failure?.status === 403);
+  const proRequired = !signInRequired && !verificationRequired && (!access.hasProAccess || failure?.status === 402);
+  const canRefresh = !!symbol && !signInRequired && !verificationRequired && !proRequired;
+
+  const refresh = useCallback(() => load("refresh"), [load]);
+  const retry = useCallback(() => load("cache-first"), [load]);
+
+  useShortcut((event) => {
+    if (!isPlainKey(event, "r")) return;
+    event.preventDefault();
+    event.stopPropagation();
+    refresh();
+  }, { enabled: focused && canRefresh && !loading, scope: REFRESH_SCOPE });
+
+  usePaneFooter(FOOTER_ID, () => ({
+    info: [
+      ...(loading ? [{ id: "loading", parts: [{ text: t("scanning"), tone: "muted" as const }] }] : []),
+      ...(failure ? [{ id: "error", parts: [{ text: failureText(failure), tone: "warning" as const }] }] : []),
+      ...(report?.status === "partial" ? [{ id: "partial", parts: [{ text: t("partial"), tone: "warning" as const }] }] : []),
+      ...(report?.stale ? [{ id: "stale", parts: [{ text: t("stale"), tone: "warning" as const }] }] : []),
+      ...(report?.cached && !report.stale ? [{ id: "cached", parts: [{ text: t("cached"), tone: "muted" as const }] }] : []),
+    ],
+    hints: canRefresh
+      ? [{ id: "refresh", key: "r", label: "efresh", onPress: refresh, disabled: loading }]
+      : [],
+  }), [canRefresh, failure, loading, refresh, report]);
+
+  const contentWidth = Math.max(12, width - 2);
+
+  const body = (): ReactNode => {
+    if (!symbol) {
+      return (
+        <EmptyState
+          title="No ticker selected."
+          hint="Move the cursor in a list pane to populate this view."
+        />
+      );
+    }
+    if (signInRequired) {
+      return <CloudAuthNotice message={t("Sign in to run the Equity Diagnostic.")} />;
+    }
+    if (verificationRequired) {
+      return <CloudAuthNotice needsVerification message={t("Verify your email to run the Equity Diagnostic.")} />;
+    }
+    if (proRequired) {
+      return (
+        <Box flexDirection="column">
+          <EmptyState
+            title="The Equity Diagnostic is part of Gloom Cloud Pro."
+            message="An on-demand review of one company's filings, financials, ownership, and news, with red flags, anomalies, and green flags cited back to their source."
+          />
+          <Box flexDirection="row" marginTop={1} gap={1}>
+            <Button label={t("Upgrade to Pro")} onPress={openUpgrade} />
+            <Button label={t("Manage account")} variant="secondary" onPress={openPlan} />
+          </Box>
+        </Box>
+      );
+    }
+    if (loading && !report) {
+      return <Spinner label="Scanning financials, filings, ownership and news..." />;
+    }
+    if (!report) {
+      return (
+        <Box flexDirection="column">
+          <EmptyState
+            title={failure ? failureText(failure) : t("No diagnostic available yet.")}
+          />
+          <Box flexDirection="row" marginTop={1}>
+            <Button label="Retry" variant="secondary" onPress={retry} />
+          </Box>
+        </Box>
+      );
+    }
+    return <ReportView report={report} width={contentWidth} failure={failure} onRetry={retry} />;
+  };
+
+  return (
+    <Box
+      flexDirection="column"
+      width={nativePaneChrome ? "100%" : width}
+      flexGrow={1}
+      flexBasis={0}
+      minHeight={0}
+      overflow="hidden"
+    >
+      <ScrollBox flexGrow={1} flexBasis={0} minHeight={0} scrollY focusable={false}>
+        <Box flexDirection="column" paddingX={1} paddingY={1} width={nativePaneChrome ? "100%" : width}>
+          {body()}
+        </Box>
+      </ScrollBox>
+    </Box>
+  );
+}

--- a/src/plugins/builtin/research/index.tsx
+++ b/src/plugins/builtin/research/index.tsx
@@ -3,6 +3,7 @@ import { parseTickerListInput, formatTickerListInput } from "../../../tickers/li
 import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
 import { AnalystResearchView } from "./analyst-pane";
 import { CorporateActionsView } from "./corporate-actions-pane";
+import { EquityDiagnosticView } from "./equity-diagnostic-pane";
 import { RelativeValuationPane } from "./relative-valuation-pane";
 
 function EarningsEstimatesPane(props: { focused: boolean; width: number; height: number }) {
@@ -25,6 +26,13 @@ export const researchModule: PluginModule = {
       isVisible: ({ ticker }) => !!ticker,
     });
     ctx.registerTickerResearchTab({
+      id: "equity-diagnostic",
+      name: "Diagnostic",
+      order: 33,
+      component: EquityDiagnosticView,
+      isVisible: ({ ticker }) => !!ticker,
+    });
+    ctx.registerTickerResearchTab({
       id: "corporate-actions",
       name: "Events",
       order: 34,
@@ -42,6 +50,15 @@ export const researchModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 90, height: 28 },
+    },
+    {
+      id: "equity-diagnostic",
+      name: "Equity Diagnostic",
+      icon: "D",
+      component: EquityDiagnosticView,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 96, height: 30 },
     },
     {
       id: "corporate-actions",
@@ -80,6 +97,14 @@ export const researchModule: PluginModule = {
       description: "Price targets, recommendations, and recent analyst actions.",
       keywords: ["analyst", "research", "ratings", "target", "anr"],
       shortcut: "ANR",
+    }),
+    createTickerSurfacePaneTemplate({
+      id: "equity-diagnostic-pane",
+      paneId: "equity-diagnostic",
+      label: "Equity Diagnostic",
+      description: "Red flags, anomalies, green flags, and watch items for one company, with cited evidence.",
+      keywords: ["diagnostic", "diag", "red flags", "anomalies", "green flags", "review", "evidence"],
+      shortcut: "DIAG",
     }),
     createTickerSurfacePaneTemplate({
       id: "corporate-actions-pane",


### PR DESCRIPTION
## Summary
- add the renderer-neutral Equity Diagnostic tab and floating pane under Ticker Research
- add `DIAG <ticker>` with bare `DIAG` falling back to the active ticker
- show cited Red Flags, Anomalies, Green Flags, Watch Items, and source coverage with Pro gating and stale/error preservation
- poll uncached background generation while keeping every UI request fast and preserving the previous report on errors

Luna remains an implementation detail and is not shown in the feature name or normal UI. This is distinct from the existing prompt-driven AI Screener.

Backend PRs are merged and deployed:
- https://github.com/vincelwt/gloomberb-platform/pull/118
- https://github.com/vincelwt/gloomberb-platform/pull/119
- https://github.com/vincelwt/gloomberb-platform/pull/120

## Verification
- 53 focused API, research, and OpenTUI tests pass locally, including polling, Pro gating, partial/stale rendering, citation resolution, refresh, and retained reports after 429s
- OpenTUI, browser, and Electrobun view typechecks pass
- all GitHub build, typecheck, CLI, Windows desktop, and Windows ARM64 compatibility checks pass
- tmux smoke opened `DIAG AAPL` in a clean isolated home and rendered the sign-in gate with no runtime warnings or leaked processes
- authenticated production QA returned `202 generating` in 106-216 ms, then cached reports in 106-122 ms
- production AAPL returned balanced; production CVNA and HOOD surfaced profitability alongside dilution, short-interest, insider, volatility, and coverage risks
- the four-worker production smoke emitted exactly one Luna generation for HOOD after the cross-worker lease fix
