### PR TITLE
Add single-name CDS activity monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ The toolbar controls preset or exact date ranges, intervals from one minute thro
 | `AUCT` | Treasury auction results: high rate, bid-to-cover, indirect share, and size |
 | `VIX` | VIX 30-day/3-month implied-volatility curve |
 | `CRD` | Credit spreads |
+| `CDS [ticker]` | Single-name corporate CDS activity: most-active issuers, or one issuer's trades |
 | `ERN` | Earnings calendar |
 | `IPO` | Upcoming and recent IPOs |
 | `HALT` | US trading halts with reason and resumption times |

--- a/src/api-client/data.ts
+++ b/src/api-client/data.ts
@@ -2,6 +2,7 @@ import type { TickerFinancials } from "../types/financials";
 import type { InstrumentSearchResult } from "../types/instrument";
 import { normalizeTweetSearchResponse } from "./normalizers";
 import {
+  cloudCdsPath,
   cloudCongressHousePath,
   cloudExchangeRatePath,
   cloudSec13FPath,
@@ -17,6 +18,7 @@ import {
   cloudStatementsPath,
   cloudTickerTweetsPath,
   cloudTweetSearchPath,
+  type CloudCdsParams,
   type CloudCongressHouseParams,
   type CloudFredSeriesParams,
   type CloudHistoryParams,
@@ -29,6 +31,7 @@ import {
 import type {
   CloudAnalystResearchPayload,
   CloudShortInterestPayload,
+  CloudCdsResponse,
   CloudCompanyProfile,
   CloudCongressHousePayload,
   CloudCorporateActionsPayload,
@@ -207,6 +210,10 @@ export class CloudDataApi {
 
   async getCloudYieldCurve(): Promise<CloudYieldPointPayload[]> {
     return this.request<CloudYieldPointPayload[]>("/cloud/econ/yield-curve");
+  }
+
+  async getCloudCds(params: CloudCdsParams = {}): Promise<CloudCdsResponse> {
+    return this.request<CloudCdsResponse>(cloudCdsPath(params));
   }
 
   async getCloudCongressHouse(params: CloudCongressHouseParams = {}): Promise<CloudCongressHousePayload> {

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -6,6 +6,7 @@ import { CloudDataApi } from "./data";
 import { CloudApiRequestTransport } from "./request";
 import { CloudApiSocket } from "./socket";
 import type {
+  CloudCdsParams,
   CloudCongressHouseParams,
   CloudFredSeriesParams,
   CloudSecFilingParams,
@@ -44,6 +45,7 @@ import type {
   CloudEconEventPayload,
   CloudEquityDiagnosticMode,
   CloudEquityDiagnosticResult,
+  CloudCdsResponse,
   CloudFredSeriesPayload,
   CloudYieldPointPayload,
   CloudCongressHousePayload,
@@ -580,6 +582,10 @@ class GloomApiClient {
 
   async getCloudYieldCurve(): Promise<CloudYieldPointPayload[]> {
     return this.data.getCloudYieldCurve();
+  }
+
+  async getCloudCds(params: CloudCdsParams = {}): Promise<CloudCdsResponse> {
+    return this.data.getCloudCds(params);
   }
 
   async getCloudCongressHouse(params: CloudCongressHouseParams = {}): Promise<CloudCongressHousePayload> {

--- a/src/api-client/paths.ts
+++ b/src/api-client/paths.ts
@@ -16,6 +16,13 @@ export type CloudFredSeriesParams = {
   sortOrder?: "asc" | "desc";
 };
 
+export type CloudCdsParams = {
+  /** Reference entity name, matched by the backend against DTCC issuer names. */
+  issuer?: string;
+  days?: number;
+  limit?: number;
+};
+
 export type CloudCongressHouseParams = {
   year?: number;
   limit?: number;
@@ -135,6 +142,15 @@ export function cloudFredSeriesPath(seriesId: string, params: CloudFredSeriesPar
   if (params.limit != null) search.set("limit", String(params.limit));
   if (params.sortOrder) search.set("sortOrder", params.sortOrder);
   return appendQuery(`/cloud/econ/series/${encodeURIComponent(seriesId)}`, search);
+}
+
+export function cloudCdsPath(params: CloudCdsParams = {}): string {
+  const search = new URLSearchParams();
+  const issuer = params.issuer?.trim();
+  if (issuer) search.set("issuer", issuer);
+  if (params.days != null) search.set("days", String(params.days));
+  if (params.limit != null) search.set("limit", String(params.limit));
+  return appendQuery("/cloud/credit/cds", search);
 }
 
 export type CloudSecFilingsParams = {

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -322,6 +322,40 @@ export interface CloudFredSeriesPayload {
   info: CloudFredSeriesInfoPayload | null;
 }
 
+/** One publicly disseminated single-name CDS transaction report. */
+export interface CloudCdsTradePayload {
+  disseminationId: string;
+  originalDisseminationId: string | null;
+  actionType: string;
+  eventTimestamp: string;
+  executionTimestamp: string | null;
+  effectiveDate: string | null;
+  expirationDate: string | null;
+  maturityDate: string | null;
+  issuerName: string | null;
+  underlierId: string | null;
+  underlierIdSource: string | null;
+  upi: string | null;
+  upiFisn: string | null;
+  upiUnderlierName: string | null;
+  notionalAmount: number | null;
+  /** Reported notional is a regulatory cap, so the real trade was at least this size. */
+  notionalCapped: boolean;
+  notionalCurrency: string | null;
+  fixedRate: number | null;
+  reportedSpread: number | null;
+  /** Unit of `reportedSpread`, e.g. basis points or percent. */
+  spreadNotation: string | null;
+  upfrontAmount: number | null;
+  upfrontCurrency: string | null;
+}
+
+export interface CloudCdsResponse {
+  source: string;
+  asOf: string | null;
+  trades: CloudCdsTradePayload[];
+}
+
 export interface CloudShortInterestPointPayload {
   settlementDate: string;
   sharesShort: number;

--- a/src/plugins/builtin/cds/client.test.ts
+++ b/src/plugins/builtin/cds/client.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import type { CloudCdsResponse } from "../../../api-client";
+import type { InstrumentSearchResult } from "../../../types/instrument";
+import { loadCdsActivity } from "./client";
+
+function result(symbol: string, name: string): InstrumentSearchResult {
+  return { providerId: "gloomberb-cloud", symbol, name, exchange: "NYSE", type: "STK" };
+}
+
+const EMPTY_CDS: CloudCdsResponse = { source: "DTCC PPD", asOf: null, trades: [] };
+
+/** Records what the loader searched for and what it then asked the backend. */
+function spy(searchResults: InstrumentSearchResult[] | Error = []) {
+  const searched: string[] = [];
+  const requested: Array<string | undefined> = [];
+  return {
+    searched,
+    requested,
+    fetchCds: async (params: { issuer?: string }) => {
+      requested.push(params.issuer);
+      return EMPTY_CDS;
+    },
+    searchInstruments: async (query: string) => {
+      searched.push(query);
+      if (searchResults instanceof Error) throw searchResults;
+      return searchResults;
+    },
+  };
+}
+
+describe("loadCdsActivity", () => {
+  test("expands a bare ticker through search before requesting CDS", async () => {
+    // A near-miss is returned first, so first-result-wins would send the wrong name.
+    const calls = spy([result("ORCL.MX", "Oracle de Mexico"), result("ORCL", "Oracle Corporation")]);
+
+    const activity = await loadCdsActivity("ORCL", calls.fetchCds, calls.searchInstruments);
+
+    expect(calls.searched).toEqual(["ORCL"]);
+    expect(calls.requested).toEqual(["Oracle Corporation"]);
+    // The pane body reads this back, so ORCL must not survive resolution.
+    expect(activity.issuer).toBe("Oracle Corporation");
+  });
+
+  test("falls back to the first result when no symbol matches exactly", async () => {
+    const calls = spy([result("AVGO", "Broadcom Inc."), result("AVGOP", "Broadcom Preferred")]);
+
+    await loadCdsActivity("BRCM", calls.fetchCds, calls.searchInstruments);
+
+    expect(calls.requested).toEqual(["Broadcom Inc."]);
+  });
+
+  test("sends a company name straight through without searching", async () => {
+    const calls = spy([result("ORCL", "Oracle Corporation")]);
+
+    const activity = await loadCdsActivity("Tencent Holdings Limited", calls.fetchCds, calls.searchInstruments);
+
+    expect(calls.searched).toEqual([]);
+    expect(calls.requested).toEqual(["Tencent Holdings Limited"]);
+    expect(activity.issuer).toBe("Tencent Holdings Limited");
+  });
+
+  test("keeps the raw ticker when search is empty or fails", async () => {
+    const empty = spy([]);
+    await loadCdsActivity("ORCL", empty.fetchCds, empty.searchInstruments);
+    expect(empty.requested).toEqual(["ORCL"]);
+
+    // A search outage must not also take out the CDS request.
+    const broken = spy(new Error("search unavailable"));
+    const activity = await loadCdsActivity("ORCL", broken.fetchCds, broken.searchInstruments);
+    expect(broken.requested).toEqual(["ORCL"]);
+    expect(activity.issuer).toBe("ORCL");
+  });
+
+  test("market-wide load searches nothing and sends no issuer", async () => {
+    const calls = spy([result("ORCL", "Oracle Corporation")]);
+
+    const activity = await loadCdsActivity(null, calls.fetchCds, calls.searchInstruments);
+
+    expect(calls.searched).toEqual([]);
+    expect(calls.requested).toEqual([undefined]);
+    expect(activity.issuer).toBeNull();
+  });
+});

--- a/src/plugins/builtin/cds/client.ts
+++ b/src/plugins/builtin/cds/client.ts
@@ -1,4 +1,5 @@
 import { apiClient, type CloudCdsResponse } from "../../../api-client";
+import type { InstrumentSearchResult } from "../../../types/instrument";
 import { normalizeCdsTrades, type CdsTrade } from "./model";
 
 /** One trading week of public dissemination is what "recent activity" means here. */
@@ -8,24 +9,59 @@ const CDS_TRADE_LIMIT = 500;
 export interface CdsActivity {
   source: string;
   asOf: string | null;
+  /** The issuer name actually sent, after any symbol lookup. */
+  issuer: string | null;
   trades: CdsTrade[];
 }
 
 export type CdsActivityLoader = (issuer: string | null) => Promise<CdsActivity>;
 
+type CdsFetch = (params: { issuer?: string; days?: number; limit?: number }) => Promise<CloudCdsResponse>;
+type InstrumentSearch = (query: string, limit?: number) => Promise<InstrumentSearchResult[]>;
+
+/**
+ * A bare ticker with normal symbol punctuation and no spaces. Anything longer or
+ * containing a space is already a company name and is sent to the backend as-is.
+ */
+const TICKER_LIKE = /^[A-Za-z0-9][A-Za-z0-9.^:-]{0,11}$/;
+
+/**
+ * The backend matches DTCC issuer names, so a ticker has to become a company
+ * name first. An untracked symbol has no local metadata to expand it, and its
+ * quote name never arrives for a fixed binding, so the shared instrument search
+ * is the only reliable expansion. A search outage falls back to the raw input
+ * rather than taking the CDS request down with it.
+ */
+export async function resolveIssuerName(
+  issuer: string,
+  searchInstruments: InstrumentSearch,
+): Promise<string> {
+  if (!TICKER_LIKE.test(issuer)) return issuer;
+  try {
+    const results = await searchInstruments(issuer);
+    const symbol = issuer.toUpperCase();
+    const match = results.find((result) => result.symbol.toUpperCase() === symbol) ?? results[0];
+    return match?.name?.trim() || issuer;
+  } catch {
+    return issuer;
+  }
+}
+
 export async function loadCdsActivity(
   issuer: string | null,
-  fetchCds: (params: { issuer?: string; days?: number; limit?: number }) => Promise<CloudCdsResponse>
-    = (params) => apiClient.getCloudCds(params),
+  fetchCds: CdsFetch = (params) => apiClient.getCloudCds(params),
+  searchInstruments: InstrumentSearch = (query, limit) => apiClient.searchInstruments(query, limit),
 ): Promise<CdsActivity> {
+  const resolved = issuer ? await resolveIssuerName(issuer, searchInstruments) : null;
   const response = await fetchCds({
-    ...(issuer ? { issuer } : {}),
+    ...(resolved ? { issuer: resolved } : {}),
     days: CDS_HISTORY_DAYS,
     limit: CDS_TRADE_LIMIT,
   });
   return {
     source: response.source,
     asOf: response.asOf,
+    issuer: resolved,
     trades: normalizeCdsTrades(response.trades ?? []),
   };
 }

--- a/src/plugins/builtin/cds/client.ts
+++ b/src/plugins/builtin/cds/client.ts
@@ -1,0 +1,31 @@
+import { apiClient, type CloudCdsResponse } from "../../../api-client";
+import { normalizeCdsTrades, type CdsTrade } from "./model";
+
+/** One trading week of public dissemination is what "recent activity" means here. */
+const CDS_HISTORY_DAYS = 5;
+const CDS_TRADE_LIMIT = 500;
+
+export interface CdsActivity {
+  source: string;
+  asOf: string | null;
+  trades: CdsTrade[];
+}
+
+export type CdsActivityLoader = (issuer: string | null) => Promise<CdsActivity>;
+
+export async function loadCdsActivity(
+  issuer: string | null,
+  fetchCds: (params: { issuer?: string; days?: number; limit?: number }) => Promise<CloudCdsResponse>
+    = (params) => apiClient.getCloudCds(params),
+): Promise<CdsActivity> {
+  const response = await fetchCds({
+    ...(issuer ? { issuer } : {}),
+    days: CDS_HISTORY_DAYS,
+    limit: CDS_TRADE_LIMIT,
+  });
+  return {
+    source: response.source,
+    asOf: response.asOf,
+    trades: normalizeCdsTrades(response.trades ?? []),
+  };
+}

--- a/src/plugins/builtin/cds/index.tsx
+++ b/src/plugins/builtin/cds/index.tsx
@@ -1,0 +1,47 @@
+import type { PaneTemplateCreateOptions } from "../../../types/plugin";
+import type { PluginModule } from "../plugin-module";
+import { CDS_PANE_ID } from "./model";
+import { CdsPane } from "./pane";
+
+/**
+ * Only an explicit argument binds a ticker. `CDS` on its own is the
+ * market-wide view, so it must not inherit the focused ticker the way the
+ * shared ticker-surface templates do.
+ */
+function explicitSymbol(options?: PaneTemplateCreateOptions): string | null {
+  const raw = options?.symbol ?? options?.ticker?.metadata.ticker ?? options?.arg;
+  return raw?.trim().toUpperCase() || null;
+}
+
+export const cdsModule: PluginModule = {
+  panes: [{
+    id: CDS_PANE_ID,
+    name: "Single-Name CDS",
+    icon: "D",
+    component: CdsPane,
+    defaultPosition: "right",
+    defaultMode: "floating",
+    defaultFloatingSize: { width: 92, height: 22 },
+  }],
+  paneTemplates: [{
+    id: "cds-pane",
+    paneId: CDS_PANE_ID,
+    label: "Single-Name CDS",
+    description: "Single-name corporate CDS trade activity from DTCC public dissemination.",
+    keywords: ["cds", "credit", "default", "swap", "single name", "issuer", "dtcc", "protection"],
+    // Deliberately "text": a "ticker" arg would resolve the focused ticker when
+    // the argument is omitted, and bare CDS must stay market-wide.
+    shortcut: { prefix: "CDS", argPlaceholder: "issuer", argKind: "text", argOptional: true },
+    createInstance: (_context, options) => {
+      const symbol = explicitSymbol(options);
+      return symbol
+        ? {
+          instanceId: `${CDS_PANE_ID}:${symbol}`,
+          title: `CDS ${symbol}`,
+          binding: { kind: "fixed", symbol },
+          placement: "floating",
+        }
+        : { instanceId: `${CDS_PANE_ID}:market`, title: "CDS", placement: "floating" };
+    },
+  }],
+};

--- a/src/plugins/builtin/cds/model.test.ts
+++ b/src/plugins/builtin/cds/model.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import type { CloudCdsTradePayload } from "../../../api-client";
+import {
+  formatNotional,
+  normalizeCdsTrades,
+  resolveIssuerQuery,
+  spreadToBasisPoints,
+  summarizeIssuers,
+} from "./model";
+
+function payload(overrides: Partial<CloudCdsTradePayload> = {}): CloudCdsTradePayload {
+  return {
+    disseminationId: "1",
+    originalDisseminationId: null,
+    actionType: "NEWT",
+    eventTimestamp: "2026-08-25T14:30:00Z",
+    executionTimestamp: null,
+    effectiveDate: null,
+    expirationDate: null,
+    maturityDate: "2031-06-20",
+    issuerName: "Oracle Corporation",
+    underlierId: null,
+    underlierIdSource: null,
+    upi: null,
+    upiFisn: null,
+    upiUnderlierName: null,
+    notionalAmount: 5_000_000,
+    notionalCapped: false,
+    notionalCurrency: "USD",
+    fixedRate: 1,
+    reportedSpread: null,
+    spreadNotation: null,
+    upfrontAmount: null,
+    upfrontCurrency: null,
+    ...overrides,
+  };
+}
+
+describe("CDS spread units", () => {
+  test("converts reported spreads to basis points by notation", () => {
+    expect(spreadToBasisPoints(85, "BPS")).toBe(85);
+    expect(spreadToBasisPoints(85, "Basis points")).toBe(85);
+    expect(spreadToBasisPoints(0.85, "Percentage")).toBeCloseTo(85, 6);
+    expect(spreadToBasisPoints(0.0085, "Decimal")).toBeCloseTo(85, 6);
+    // Unlabelled reports follow the percent convention used for the fixed rate.
+    expect(spreadToBasisPoints(0.85, null)).toBeCloseTo(85, 6);
+    expect(spreadToBasisPoints(null, "BPS")).toBeNull();
+  });
+});
+
+describe("normalizeCdsTrades", () => {
+  test("keeps the reported spread only, and falls back through issuer names", () => {
+    const [withSpread, withoutName] = normalizeCdsTrades([
+      payload({ reportedSpread: 1.23, spreadNotation: "Percentage", fixedRate: 5 }),
+      payload({ disseminationId: "2", issuerName: null, upiUnderlierName: "ACME INC" }),
+    ]);
+    expect(withSpread!.spreadBp).toBeCloseTo(123, 6);
+    expect(withSpread!.couponBp).toBeCloseTo(500, 6);
+    // A missing spread is never back-solved from coupon or upfront.
+    expect(withoutName!.spreadBp).toBeNull();
+    expect(withoutName!.issuer).toBe("ACME INC");
+  });
+
+  test("drops reports with an unusable timestamp instead of dating them to 1970", () => {
+    expect(normalizeCdsTrades([payload({ eventTimestamp: "not-a-date" })])).toHaveLength(0);
+  });
+
+  test("marks capped notionals so a floor is not read as the trade size", () => {
+    expect(formatNotional({ notional: 5_000_000, notionalCapped: true })).toBe("5M+");
+    expect(formatNotional({ notional: 5_000_000, notionalCapped: false })).toBe("5M");
+    expect(formatNotional({ notional: null, notionalCapped: false })).toBe("--");
+  });
+});
+
+describe("summarizeIssuers", () => {
+  const trades = normalizeCdsTrades([
+    payload({ disseminationId: "a", eventTimestamp: "2026-08-25T10:00:00Z", reportedSpread: 0.9, spreadNotation: "Percentage" }),
+    payload({ disseminationId: "b", eventTimestamp: "2026-08-25T14:00:00Z", reportedSpread: null }),
+    payload({ disseminationId: "c", eventTimestamp: "2026-08-25T12:00:00Z", reportedSpread: 1.1, spreadNotation: "Percentage" }),
+    payload({ disseminationId: "d", eventTimestamp: "2026-08-25T09:00:00Z", issuerName: "Ford Motor Company" }),
+  ]);
+
+  test("groups by issuer with count, last trade, and the newest available spread", () => {
+    const summaries = summarizeIssuers(trades);
+    const oracle = summaries.find((row) => row.issuer === "Oracle Corporation")!;
+    expect(oracle.trades).toBe(3);
+    expect(oracle.lastTradeAt).toBe(Date.parse("2026-08-25T14:00:00Z"));
+    // The newest print carried no spread, so the last quoted level survives.
+    expect(oracle.latestSpreadBp).toBeCloseTo(110, 6);
+    expect(summaries.find((row) => row.issuer === "Ford Motor Company")!.latestSpreadBp).toBeNull();
+  });
+});
+
+describe("resolveIssuerQuery", () => {
+  test("prefers the tracked company name and falls back to the raw symbol", () => {
+    const ticker = { metadata: { ticker: "ORCL", name: "Oracle Corporation" } } as never;
+    expect(resolveIssuerQuery("ORCL", ticker)).toBe("Oracle Corporation");
+    expect(resolveIssuerQuery("orcl", null)).toBe("ORCL");
+    expect(resolveIssuerQuery(null, null)).toBeNull();
+  });
+});

--- a/src/plugins/builtin/cds/model.test.ts
+++ b/src/plugins/builtin/cds/model.test.ts
@@ -115,6 +115,57 @@ describe("summarizeIssuers", () => {
   });
 });
 
+describe("generic obligation names", () => {
+  // Verbatim `UPI Underlier Name` values seen dominating the live market view.
+  const GENERIC = [
+    "SR NT",
+    "SR NT 144A",
+    "NT",
+    "SR GTD NT 144A",
+    "No name obtainable",
+    "MEDIUM TERM NOTES EUR 2.3750 S.10/CALL",
+    "GLOBAL BD",
+  ];
+
+  function unnamed(id: string, upiUnderlierName: string | null) {
+    return payload({ disseminationId: id, issuerName: null, upiUnderlierName });
+  }
+
+  test("drops records whose only name is a generic obligation label", () => {
+    const rows = normalizeCdsTrades([
+      ...GENERIC.map((name, index) => unnamed(`g${index}`, name)),
+      unnamed("empty", ""),
+      unnamed("missing", null),
+    ]);
+    expect(rows).toEqual([]);
+  });
+
+  test("accepts UPI underlier names that identify an issuer", () => {
+    const rows = normalizeCdsTrades([
+      unnamed("t", "Tencent Holdings Limited"),
+      unnamed("d", "DT.BANK MTN 17/20"),
+    ]);
+    expect(rows.map((row) => row.issuer)).toEqual(["Tencent Holdings Limited", "DT.BANK MTN 17/20"]);
+  });
+
+  test("keeps a reported issuer name and never falls back to an underlier id", () => {
+    const rows = normalizeCdsTrades([
+      payload({ disseminationId: "b", issuerName: "Broadcom Inc", upiUnderlierName: "SR NT 144A" }),
+      payload({ disseminationId: "x", issuerName: null, upiUnderlierName: null, underlierId: "US11135FAX50" }),
+    ]);
+    expect(rows.map((row) => row.issuer)).toEqual(["Broadcom Inc"]);
+  });
+
+  test("leaves the summary to real issuers when fake ones outnumber them", () => {
+    const summaries = summarizeIssuers(normalizeCdsTrades([
+      ...GENERIC.map((name, index) => unnamed(`g${index}`, name)),
+      payload({ disseminationId: "b", issuerName: "Broadcom Inc", upiUnderlierName: "SR GTD NT 144A" }),
+      payload({ disseminationId: "o", issuerName: "Oracle Corporation", upiUnderlierName: "SR NT" }),
+    ]));
+    expect(summaries.map((row) => row.issuer).sort()).toEqual(["Broadcom Inc", "Oracle Corporation"]);
+  });
+});
+
 describe("issuer aliases", () => {
   // Spellings the deployed backend actually returns for one reference entity,
   // deliberately in an order where the best one is not the first seen.

--- a/src/plugins/builtin/cds/model.test.ts
+++ b/src/plugins/builtin/cds/model.test.ts
@@ -14,7 +14,7 @@ function payload(overrides: Partial<CloudCdsTradePayload> = {}): CloudCdsTradePa
     originalDisseminationId: null,
     actionType: "NEWT",
     eventTimestamp: "2026-08-25T14:30:00Z",
-    executionTimestamp: null,
+    executionTimestamp: "2026-08-25T14:30:00Z",
     effectiveDate: null,
     expirationDate: null,
     maturityDate: "2031-06-20",
@@ -27,7 +27,8 @@ function payload(overrides: Partial<CloudCdsTradePayload> = {}): CloudCdsTradePa
     notionalAmount: 5_000_000,
     notionalCapped: false,
     notionalCurrency: "USD",
-    fixedRate: 1,
+    // Raw DTCC decimals: 0.01 is a 100bp coupon.
+    fixedRate: 0.01,
     reportedSpread: null,
     spreadNotation: null,
     upfrontAmount: null,
@@ -38,31 +39,52 @@ function payload(overrides: Partial<CloudCdsTradePayload> = {}): CloudCdsTradePa
 
 describe("CDS spread units", () => {
   test("converts reported spreads to basis points by notation", () => {
-    expect(spreadToBasisPoints(85, "BPS")).toBe(85);
-    expect(spreadToBasisPoints(85, "Basis points")).toBe(85);
-    expect(spreadToBasisPoints(0.85, "Percentage")).toBeCloseTo(85, 6);
-    expect(spreadToBasisPoints(0.0085, "Decimal")).toBeCloseTo(85, 6);
-    // Unlabelled reports follow the percent convention used for the fixed rate.
-    expect(spreadToBasisPoints(0.85, null)).toBeCloseTo(85, 6);
-    expect(spreadToBasisPoints(null, "BPS")).toBeNull();
+    // Notation code "3" is what the raw DTCC feed carries for a decimal spread.
+    expect(spreadToBasisPoints(0.00256, "3")).toBeCloseTo(25.6, 6);
+    expect(spreadToBasisPoints(0.00256, "Decimal")).toBeCloseTo(25.6, 6);
+    // Unlabelled raw values are decimals too, not percent.
+    expect(spreadToBasisPoints(0.00256, null)).toBeCloseTo(25.6, 6);
+    expect(spreadToBasisPoints(25.6, "BPS")).toBe(25.6);
+    expect(spreadToBasisPoints(25.6, "Basis points")).toBe(25.6);
+    expect(spreadToBasisPoints(0.256, "Percentage")).toBeCloseTo(25.6, 6);
+    expect(spreadToBasisPoints(null, "3")).toBeNull();
   });
 });
 
 describe("normalizeCdsTrades", () => {
   test("keeps the reported spread only, and falls back through issuer names", () => {
     const [withSpread, withoutName] = normalizeCdsTrades([
-      payload({ reportedSpread: 1.23, spreadNotation: "Percentage", fixedRate: 5 }),
+      payload({ reportedSpread: 0.00256, spreadNotation: "3", fixedRate: 0.05 }),
       payload({ disseminationId: "2", issuerName: null, upiUnderlierName: "ACME INC" }),
     ]);
-    expect(withSpread!.spreadBp).toBeCloseTo(123, 6);
+    expect(withSpread!.spreadBp).toBeCloseTo(25.6, 6);
     expect(withSpread!.couponBp).toBeCloseTo(500, 6);
     // A missing spread is never back-solved from coupon or upfront.
     expect(withoutName!.spreadBp).toBeNull();
+    expect(withoutName!.couponBp).toBeCloseTo(100, 6);
     expect(withoutName!.issuer).toBe("ACME INC");
   });
 
+  test("dates a trade by execution time so a late correction is not a new print", () => {
+    const [corrected, noExecution, unusableExecution] = normalizeCdsTrades([
+      payload({
+        actionType: "CORR",
+        originalDisseminationId: "9",
+        executionTimestamp: "2026-08-18T09:15:00Z",
+        eventTimestamp: "2026-08-25T14:30:00Z",
+      }),
+      payload({ disseminationId: "2", executionTimestamp: null }),
+      payload({ disseminationId: "3", executionTimestamp: "not-a-date" }),
+    ]);
+    expect(corrected!.eventAt).toBe(Date.parse("2026-08-18T09:15:00Z"));
+    expect(noExecution!.eventAt).toBe(Date.parse("2026-08-25T14:30:00Z"));
+    expect(unusableExecution!.eventAt).toBe(Date.parse("2026-08-25T14:30:00Z"));
+  });
+
   test("drops reports with an unusable timestamp instead of dating them to 1970", () => {
-    expect(normalizeCdsTrades([payload({ eventTimestamp: "not-a-date" })])).toHaveLength(0);
+    expect(normalizeCdsTrades([
+      payload({ executionTimestamp: null, eventTimestamp: "not-a-date" }),
+    ])).toHaveLength(0);
   });
 
   test("marks capped notionals so a floor is not read as the trade size", () => {
@@ -74,10 +96,10 @@ describe("normalizeCdsTrades", () => {
 
 describe("summarizeIssuers", () => {
   const trades = normalizeCdsTrades([
-    payload({ disseminationId: "a", eventTimestamp: "2026-08-25T10:00:00Z", reportedSpread: 0.9, spreadNotation: "Percentage" }),
-    payload({ disseminationId: "b", eventTimestamp: "2026-08-25T14:00:00Z", reportedSpread: null }),
-    payload({ disseminationId: "c", eventTimestamp: "2026-08-25T12:00:00Z", reportedSpread: 1.1, spreadNotation: "Percentage" }),
-    payload({ disseminationId: "d", eventTimestamp: "2026-08-25T09:00:00Z", issuerName: "Ford Motor Company" }),
+    payload({ disseminationId: "a", executionTimestamp: "2026-08-25T10:00:00Z", reportedSpread: 0.009, spreadNotation: "3" }),
+    payload({ disseminationId: "b", executionTimestamp: "2026-08-25T14:00:00Z", reportedSpread: null }),
+    payload({ disseminationId: "c", executionTimestamp: "2026-08-25T12:00:00Z", reportedSpread: 0.011, spreadNotation: "3" }),
+    payload({ disseminationId: "d", executionTimestamp: "2026-08-25T09:00:00Z", issuerName: "Ford Motor Company" }),
   ]);
 
   test("groups by issuer with count, last trade, and the newest available spread", () => {
@@ -92,10 +114,15 @@ describe("summarizeIssuers", () => {
 });
 
 describe("resolveIssuerQuery", () => {
-  test("prefers the tracked company name and falls back to the raw symbol", () => {
-    const ticker = { metadata: { ticker: "ORCL", name: "Oracle Corporation" } } as never;
-    expect(resolveIssuerQuery("ORCL", ticker)).toBe("Oracle Corporation");
-    expect(resolveIssuerQuery("orcl", null)).toBe("ORCL");
-    expect(resolveIssuerQuery(null, null)).toBeNull();
+  const ticker = { metadata: { ticker: "ORCL", name: "Oracle Corporation" } } as never;
+  const quoted = { quote: { name: "Oracle Corporation" } } as never;
+
+  test("prefers metadata, then the quote name, then the raw symbol", () => {
+    expect(resolveIssuerQuery("ORCL", ticker, null)).toBe("Oracle Corporation");
+    // ORCL is not in the ticker map, so the loaded quote resolves the issuer.
+    expect(resolveIssuerQuery("ORCL", null, quoted)).toBe("Oracle Corporation");
+    // Before the quote lands the raw symbol is still queried.
+    expect(resolveIssuerQuery("orcl", null, null)).toBe("ORCL");
+    expect(resolveIssuerQuery(null, null, null)).toBeNull();
   });
 });

--- a/src/plugins/builtin/cds/model.test.ts
+++ b/src/plugins/builtin/cds/model.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from "bun:test";
 import type { CloudCdsTradePayload } from "../../../api-client";
 import {
   formatNotional,
+  issuerGroupKey,
   normalizeCdsTrades,
   resolveIssuerQuery,
   spreadToBasisPoints,
   summarizeIssuers,
+  tradesForIssuer,
 } from "./model";
 
 function payload(overrides: Partial<CloudCdsTradePayload> = {}): CloudCdsTradePayload {
@@ -110,6 +112,59 @@ describe("summarizeIssuers", () => {
     // The newest print carried no spread, so the last quoted level survives.
     expect(oracle.latestSpreadBp).toBeCloseTo(110, 6);
     expect(summaries.find((row) => row.issuer === "Ford Motor Company")!.latestSpreadBp).toBeNull();
+  });
+});
+
+describe("issuer aliases", () => {
+  // Spellings the deployed backend actually returns for one reference entity,
+  // deliberately in an order where the best one is not the first seen.
+  const ORACLE = ["ORACLE CORPORATION", "Oracle Cop", "Oracle Corporation"];
+  const BOEING = ["THE BOEING COMPANY", "Boeing Co/The", "The Boeing Company"];
+
+  const aliasTrades = normalizeCdsTrades([
+    ...ORACLE.map((issuerName, index) => payload({
+      disseminationId: `o${index}`,
+      issuerName,
+      executionTimestamp: `2026-08-25T1${index}:00:00Z`,
+      reportedSpread: 0.009,
+      spreadNotation: "3",
+    })),
+    ...BOEING.map((issuerName, index) => payload({
+      disseminationId: `b${index}`,
+      issuerName,
+      executionTimestamp: `2026-08-25T0${index}:00:00Z`,
+    })),
+  ]);
+
+  test("collapses case, punctuation, and legal-suffix aliases onto one key", () => {
+    expect(new Set(ORACLE.map(issuerGroupKey))).toEqual(new Set(["oracle"]));
+    expect(new Set(BOEING.map(issuerGroupKey))).toEqual(new Set(["boeing"]));
+  });
+
+  test("keeps meaningful words that distinguish real entities", () => {
+    expect(issuerGroupKey("Oracle Holdings Corp")).not.toBe(issuerGroupKey("Oracle Corporation"));
+    expect(issuerGroupKey("Boeing Capital Group")).not.toBe(issuerGroupKey("The Boeing Company"));
+    expect(issuerGroupKey("Acme 2031 Ltd")).not.toBe(issuerGroupKey("Acme 2026 Ltd"));
+    // A name that is only noise keeps its own row instead of an empty key.
+    expect(issuerGroupKey("The Company")).toBe("the company");
+  });
+
+  test("counts every alias in one row and displays the best spelling", () => {
+    const summaries = summarizeIssuers(aliasTrades);
+    expect(summaries).toHaveLength(2);
+
+    const oracle = summaries.find((row) => row.key === "oracle")!;
+    expect(oracle.trades).toBe(3);
+    expect(oracle.issuer).toBe("Oracle Corporation");
+
+    const boeing = summaries.find((row) => row.key === "boeing")!;
+    expect(boeing.trades).toBe(3);
+    expect(boeing.issuer).toBe("The Boeing Company");
+  });
+
+  test("drills down on the key so aliases open together", () => {
+    expect(tradesForIssuer(aliasTrades, "oracle").map((row) => row.issuer)).toEqual(ORACLE);
+    expect(tradesForIssuer(aliasTrades, "boeing").map((row) => row.issuer)).toEqual(BOEING);
   });
 });
 

--- a/src/plugins/builtin/cds/model.test.ts
+++ b/src/plugins/builtin/cds/model.test.ts
@@ -222,14 +222,11 @@ describe("issuer aliases", () => {
 
 describe("resolveIssuerQuery", () => {
   const ticker = { metadata: { ticker: "ORCL", name: "Oracle Corporation" } } as never;
-  const quoted = { quote: { name: "Oracle Corporation" } } as never;
 
-  test("prefers metadata, then the quote name, then the raw symbol", () => {
-    expect(resolveIssuerQuery("ORCL", ticker, null)).toBe("Oracle Corporation");
-    // ORCL is not in the ticker map, so the loaded quote resolves the issuer.
-    expect(resolveIssuerQuery("ORCL", null, quoted)).toBe("Oracle Corporation");
-    // Before the quote lands the raw symbol is still queried.
-    expect(resolveIssuerQuery("orcl", null, null)).toBe("ORCL");
-    expect(resolveIssuerQuery(null, null, null)).toBeNull();
+  test("prefers tracked metadata and otherwise hands the loader a bare symbol", () => {
+    expect(resolveIssuerQuery("ORCL", ticker)).toBe("Oracle Corporation");
+    // Untracked: the loader expands this through instrument search.
+    expect(resolveIssuerQuery("orcl", null)).toBe("ORCL");
+    expect(resolveIssuerQuery(null, null)).toBeNull();
   });
 });

--- a/src/plugins/builtin/cds/model.test.ts
+++ b/src/plugins/builtin/cds/model.test.ts
@@ -124,6 +124,7 @@ describe("generic obligation names", () => {
     "SR GTD NT 144A",
     "No name obtainable",
     "MEDIUM TERM NOTES EUR 2.3750 S.10/CALL",
+    "MEDIUM TERM NOTES EUR 0.6250 S.001STLA/CALL",
     "GLOBAL BD",
   ];
 

--- a/src/plugins/builtin/cds/model.ts
+++ b/src/plugins/builtin/cds/model.ts
@@ -1,5 +1,6 @@
 import type { CloudCdsTradePayload } from "../../../api-client";
 import type { DataTableColumn } from "../../../components";
+import type { TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 import { formatCompact } from "../../../utils/format";
 import { compareSortValues, type SortPreference } from "../../../utils/sort-values";
@@ -7,10 +8,10 @@ import { compareSortValues, type SortPreference } from "../../../utils/sort-valu
 export const CDS_PANE_ID = "cds";
 
 /**
- * DTCC reports rates and spreads as percent unless the report says otherwise,
- * so both the running coupon and the reported spread are converted to basis
- * points here and nowhere else. If the backend ever switches units, this is the
- * single place that changes.
+ * Raw DTCC values are decimals: `Fixed rate-Leg 1 = 0.01` is a 100bp coupon and
+ * `Spread-Leg 1 = 0.00256` under notation code "3" is 25.6bp. Only a report that
+ * explicitly labels itself basis points or percent is read any other way. Both
+ * conversions happen here and nowhere else.
  */
 const PERCENT_TO_BP = 100;
 const DECIMAL_TO_BP = 10_000;
@@ -18,6 +19,7 @@ const DECIMAL_TO_BP = 10_000;
 export interface CdsTrade {
   id: string;
   issuer: string;
+  /** Execution time when the report carried a usable one, else event time. */
   eventAt: number;
   maturity: string | null;
   notional: number | null;
@@ -41,13 +43,26 @@ export function spreadToBasisPoints(value: number | null, notation: string | nul
   if (value == null || !Number.isFinite(value)) return null;
   const unit = (notation ?? "").trim().toLowerCase();
   if (unit.startsWith("bp") || unit.includes("basis")) return value;
-  if (unit.includes("decimal")) return value * DECIMAL_TO_BP;
-  return value * PERCENT_TO_BP;
+  if (unit.includes("percent") || unit === "%") return value * PERCENT_TO_BP;
+  // Notation code "3", textual "decimal", and an unlabelled raw value are all decimals.
+  return value * DECIMAL_TO_BP;
 }
 
 function couponToBasisPoints(fixedRate: number | null): number | null {
   if (fixedRate == null || !Number.isFinite(fixedRate)) return null;
-  return fixedRate * PERCENT_TO_BP;
+  return fixedRate * DECIMAL_TO_BP;
+}
+
+/**
+ * When the trade was struck, not when the tape carried it. A lifecycle
+ * correction is disseminated long after the fact, so using the event time would
+ * date an old trade as new.
+ */
+function tapeTime(trade: CloudCdsTradePayload): number | null {
+  const executed = trade.executionTimestamp ? Date.parse(trade.executionTimestamp) : Number.NaN;
+  if (Number.isFinite(executed)) return executed;
+  const event = Date.parse(trade.eventTimestamp);
+  return Number.isFinite(event) ? event : null;
 }
 
 function issuerOf(trade: CloudCdsTradePayload): string {
@@ -60,8 +75,8 @@ function issuerOf(trade: CloudCdsTradePayload): string {
 export function normalizeCdsTrades(trades: readonly CloudCdsTradePayload[]): CdsTrade[] {
   const rows: CdsTrade[] = [];
   for (const trade of trades) {
-    const eventAt = Date.parse(trade.eventTimestamp);
-    if (!Number.isFinite(eventAt)) continue;
+    const eventAt = tapeTime(trade);
+    if (eventAt == null) continue;
     rows.push({
       id: trade.disseminationId,
       issuer: issuerOf(trade),
@@ -113,12 +128,20 @@ export function tradesForIssuer(trades: readonly CdsTrade[], issuer: string): Cd
   return trades.filter((trade) => trade.issuer === issuer);
 }
 
-/** The company name the backend matches on, or the raw symbol when untracked. */
+/**
+ * The company name the backend matches on. An untracked symbol has no
+ * TickerRecord, but its quote arrives with a name shortly after the pane opens,
+ * so the raw symbol is only the last resort.
+ */
 export function resolveIssuerQuery(
   symbol: string | null,
   ticker: TickerRecord | null,
+  financials: TickerFinancials | null,
 ): string | null {
-  return ticker?.metadata.name?.trim() || symbol?.trim().toUpperCase() || null;
+  return ticker?.metadata.name?.trim()
+    || financials?.quote?.name?.trim()
+    || symbol?.trim().toUpperCase()
+    || null;
 }
 
 export function formatBp(value: number | null): string {

--- a/src/plugins/builtin/cds/model.ts
+++ b/src/plugins/builtin/cds/model.ts
@@ -1,0 +1,275 @@
+import type { CloudCdsTradePayload } from "../../../api-client";
+import type { DataTableColumn } from "../../../components";
+import type { TickerRecord } from "../../../types/ticker";
+import { formatCompact } from "../../../utils/format";
+import { compareSortValues, type SortPreference } from "../../../utils/sort-values";
+
+export const CDS_PANE_ID = "cds";
+
+/**
+ * DTCC reports rates and spreads as percent unless the report says otherwise,
+ * so both the running coupon and the reported spread are converted to basis
+ * points here and nowhere else. If the backend ever switches units, this is the
+ * single place that changes.
+ */
+const PERCENT_TO_BP = 100;
+const DECIMAL_TO_BP = 10_000;
+
+export interface CdsTrade {
+  id: string;
+  issuer: string;
+  eventAt: number;
+  maturity: string | null;
+  notional: number | null;
+  notionalCapped: boolean;
+  currency: string | null;
+  couponBp: number | null;
+  /** Only what the report carried. Never derived from upfront or coupon. */
+  spreadBp: number | null;
+  upfront: number | null;
+  upfrontCurrency: string | null;
+}
+
+export interface CdsIssuerSummary {
+  issuer: string;
+  trades: number;
+  lastTradeAt: number;
+  latestSpreadBp: number | null;
+}
+
+export function spreadToBasisPoints(value: number | null, notation: string | null): number | null {
+  if (value == null || !Number.isFinite(value)) return null;
+  const unit = (notation ?? "").trim().toLowerCase();
+  if (unit.startsWith("bp") || unit.includes("basis")) return value;
+  if (unit.includes("decimal")) return value * DECIMAL_TO_BP;
+  return value * PERCENT_TO_BP;
+}
+
+function couponToBasisPoints(fixedRate: number | null): number | null {
+  if (fixedRate == null || !Number.isFinite(fixedRate)) return null;
+  return fixedRate * PERCENT_TO_BP;
+}
+
+function issuerOf(trade: CloudCdsTradePayload): string {
+  const named = trade.issuerName?.trim()
+    || trade.upiUnderlierName?.trim()
+    || trade.underlierId?.trim();
+  return named || "Unknown issuer";
+}
+
+export function normalizeCdsTrades(trades: readonly CloudCdsTradePayload[]): CdsTrade[] {
+  const rows: CdsTrade[] = [];
+  for (const trade of trades) {
+    const eventAt = Date.parse(trade.eventTimestamp);
+    if (!Number.isFinite(eventAt)) continue;
+    rows.push({
+      id: trade.disseminationId,
+      issuer: issuerOf(trade),
+      eventAt,
+      maturity: trade.maturityDate ?? trade.expirationDate,
+      notional: trade.notionalAmount,
+      notionalCapped: trade.notionalCapped,
+      currency: trade.notionalCurrency,
+      couponBp: couponToBasisPoints(trade.fixedRate),
+      spreadBp: spreadToBasisPoints(trade.reportedSpread, trade.spreadNotation),
+      upfront: trade.upfrontAmount,
+      upfrontCurrency: trade.upfrontCurrency,
+    });
+  }
+  return rows;
+}
+
+/**
+ * Most-active issuers, with the spread of each issuer's newest report that
+ * actually carried one. A quoted issuer whose last print omitted the spread
+ * keeps its last known level instead of falling back to "--".
+ */
+export function summarizeIssuers(trades: readonly CdsTrade[]): CdsIssuerSummary[] {
+  const byIssuer = new Map<string, CdsIssuerSummary>();
+  const spreadAt = new Map<string, number>();
+  for (const trade of trades) {
+    const current = byIssuer.get(trade.issuer);
+    if (!current) {
+      byIssuer.set(trade.issuer, {
+        issuer: trade.issuer,
+        trades: 1,
+        lastTradeAt: trade.eventAt,
+        latestSpreadBp: trade.spreadBp,
+      });
+      if (trade.spreadBp != null) spreadAt.set(trade.issuer, trade.eventAt);
+      continue;
+    }
+    current.trades += 1;
+    if (trade.eventAt > current.lastTradeAt) current.lastTradeAt = trade.eventAt;
+    if (trade.spreadBp != null && trade.eventAt >= (spreadAt.get(trade.issuer) ?? -Infinity)) {
+      current.latestSpreadBp = trade.spreadBp;
+      spreadAt.set(trade.issuer, trade.eventAt);
+    }
+  }
+  return [...byIssuer.values()];
+}
+
+export function tradesForIssuer(trades: readonly CdsTrade[], issuer: string): CdsTrade[] {
+  return trades.filter((trade) => trade.issuer === issuer);
+}
+
+/** The company name the backend matches on, or the raw symbol when untracked. */
+export function resolveIssuerQuery(
+  symbol: string | null,
+  ticker: TickerRecord | null,
+): string | null {
+  return ticker?.metadata.name?.trim() || symbol?.trim().toUpperCase() || null;
+}
+
+export function formatBp(value: number | null): string {
+  if (value == null) return "--";
+  return `${Math.abs(value) >= 100 ? Math.round(value) : Math.round(value * 10) / 10}bp`;
+}
+
+export function formatNotional(trade: Pick<CdsTrade, "notional" | "notionalCapped">): string {
+  if (trade.notional == null) return "--";
+  return `${formatCompact(trade.notional)}${trade.notionalCapped ? "+" : ""}`;
+}
+
+export function formatUpfront(trade: Pick<CdsTrade, "upfront" | "upfrontCurrency">): string {
+  if (trade.upfront == null) return "--";
+  const sign = trade.upfront > 0 ? "+" : "";
+  return `${sign}${formatCompact(trade.upfront)}${trade.upfrontCurrency ? ` ${trade.upfrontCurrency}` : ""}`;
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+/** UTC, because DTCC disseminates in UTC and a guessed local zone misdates prints. */
+export function formatEventTime(eventAt: number): string {
+  const date = new Date(eventAt);
+  return `${pad(date.getUTCMonth() + 1)}/${pad(date.getUTCDate())} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`;
+}
+
+export function formatAsOf(asOf: string | null): string | null {
+  if (!asOf) return null;
+  const parsed = Date.parse(asOf);
+  return Number.isFinite(parsed) ? `${formatEventTime(parsed)}Z` : asOf;
+}
+
+export function formatMaturity(maturity: string | null): string {
+  return maturity ?? "--";
+}
+
+export type IssuerColumnId = "issuer" | "trades" | "last" | "spread";
+export type IssuerColumn = DataTableColumn & { id: IssuerColumnId };
+export type IssuerSortPreference = SortPreference<IssuerColumnId>;
+
+export const ISSUER_SORT_COLUMN_IDS: readonly IssuerColumnId[] = ["issuer", "trades", "last", "spread"];
+/** "Most active" is the reason the market-wide view exists. */
+export const DEFAULT_ISSUER_SORT: IssuerSortPreference = { columnId: "trades", direction: "desc" };
+
+export function buildIssuerColumns(width: number): IssuerColumn[] {
+  const issuerWidth = Math.max(16, width - 35);
+  return [
+    { id: "issuer", label: "ISSUER", width: issuerWidth, align: "left" },
+    { id: "trades", label: "TRADES", width: 7, align: "right" },
+    { id: "last", label: "LAST UTC", width: 12, align: "left" },
+    { id: "spread", label: "SPREAD", width: 10, align: "right" },
+  ];
+}
+
+function issuerSortValue(columnId: IssuerColumnId, row: CdsIssuerSummary): string | number | null {
+  switch (columnId) {
+    case "issuer":
+      return row.issuer;
+    case "trades":
+      return row.trades;
+    case "last":
+      return row.lastTradeAt;
+    case "spread":
+      return row.latestSpreadBp;
+  }
+}
+
+export function sortIssuers(
+  rows: readonly CdsIssuerSummary[],
+  sort: IssuerSortPreference,
+): CdsIssuerSummary[] {
+  const columnId = sort.columnId;
+  if (!columnId) return [...rows];
+  return [...rows].sort((left, right) => {
+    const compared = compareSortValues(
+      issuerSortValue(columnId, left),
+      issuerSortValue(columnId, right),
+      sort.direction,
+    );
+    // Stable secondary key so equal counts do not reshuffle between refreshes.
+    return compared !== 0 ? compared : left.issuer.localeCompare(right.issuer);
+  });
+}
+
+export type TradeColumnId = "time" | "maturity" | "notional" | "currency" | "coupon" | "spread" | "upfront";
+export type TradeColumn = DataTableColumn & { id: TradeColumnId };
+export type TradeSortPreference = SortPreference<TradeColumnId>;
+
+export const TRADE_SORT_COLUMN_IDS: readonly TradeColumnId[] = [
+  "time",
+  "maturity",
+  "notional",
+  "coupon",
+  "spread",
+  "upfront",
+];
+export const DEFAULT_TRADE_SORT: TradeSortPreference = { columnId: "time", direction: "desc" };
+
+export function buildTradeColumns(width: number): TradeColumn[] {
+  const maturityWidth = Math.max(10, Math.min(12, width - 55));
+  return [
+    { id: "time", label: "TIME UTC", width: 12, align: "left" },
+    { id: "maturity", label: "MATURITY", width: maturityWidth, align: "left" },
+    { id: "notional", label: "NOTIONAL", width: 11, align: "right" },
+    { id: "currency", label: "CCY", width: 5, align: "left" },
+    { id: "coupon", label: "COUPON", width: 9, align: "right" },
+    { id: "spread", label: "SPREAD", width: 10, align: "right" },
+    { id: "upfront", label: "UPFRONT", width: 13, align: "right" },
+  ];
+}
+
+function tradeSortValue(columnId: TradeColumnId, row: CdsTrade): string | number | null {
+  switch (columnId) {
+    case "time":
+      return row.eventAt;
+    case "maturity":
+      return row.maturity;
+    case "notional":
+      return row.notional;
+    case "currency":
+      return row.currency;
+    case "coupon":
+      return row.couponBp;
+    case "spread":
+      return row.spreadBp;
+    case "upfront":
+      return row.upfront;
+  }
+}
+
+export function sortTrades(rows: readonly CdsTrade[], sort: TradeSortPreference): CdsTrade[] {
+  const columnId = sort.columnId;
+  if (!columnId) return [...rows];
+  return [...rows].sort((left, right) => {
+    const compared = compareSortValues(
+      tradeSortValue(columnId, left),
+      tradeSortValue(columnId, right),
+      sort.direction,
+    );
+    return compared !== 0 ? compared : right.eventAt - left.eventAt;
+  });
+}
+
+export function nextSort<Id extends string>(
+  current: SortPreference<Id>,
+  columnId: Id,
+  fallback: SortPreference<Id>,
+): SortPreference<Id> {
+  if (current.columnId !== columnId) return { columnId, direction: "asc" };
+  if (current.direction === "asc") return { columnId, direction: "desc" };
+  return fallback;
+}

--- a/src/plugins/builtin/cds/model.ts
+++ b/src/plugins/builtin/cds/model.ts
@@ -94,7 +94,12 @@ function nameTokens(name: string): string[] {
  */
 function identifiesIssuer(name: string): boolean {
   const tokens = nameTokens(name);
-  if (tokens.length === 0 || NAME_PLACEHOLDERS.has(tokens.join(" "))) return false;
+  const folded = tokens.join(" ");
+  if (
+    tokens.length === 0
+    || NAME_PLACEHOLDERS.has(folded)
+    || folded.startsWith("medium term note")
+  ) return false;
   return tokens.some((token) => (
     !OBLIGATION_NOISE.has(token)
     && !LEGAL_NAME_NOISE.has(token)

--- a/src/plugins/builtin/cds/model.ts
+++ b/src/plugins/builtin/cds/model.ts
@@ -18,7 +18,10 @@ const DECIMAL_TO_BP = 10_000;
 
 export interface CdsTrade {
   id: string;
+  /** Reported spelling, kept verbatim so a display name can be chosen later. */
   issuer: string;
+  /** Alias-collapsed grouping key. Internal only; never shown or sent. */
+  issuerKey: string;
   /** Execution time when the report carried a usable one, else event time. */
   eventAt: number;
   maturity: string | null;
@@ -33,10 +36,59 @@ export interface CdsTrade {
 }
 
 export interface CdsIssuerSummary {
+  /** Grouping key, and the row's selection id. */
+  key: string;
+  /** Best spelling among the aliases in this group. */
   issuer: string;
   trades: number;
   lastTradeAt: number;
   latestSpreadBp: number | null;
+}
+
+/**
+ * Legal-name noise the tape spells inconsistently: "Oracle Corporation",
+ * "ORACLE CORPORATION", and "Oracle Cop" are one issuer. Only suffixes and
+ * articles belong here. Words that distinguish real entities, such as holdings,
+ * group, or a year, must keep their own row.
+ */
+const LEGAL_NAME_NOISE = new Set([
+  "the", "co", "company", "corp", "corporation", "cop",
+  "inc", "incorporated", "limited", "ltd", "plc",
+]);
+
+/** Case, accents, and punctuation folded away, then legal-name noise dropped. */
+export function issuerGroupKey(name: string): string {
+  const tokens = name
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^\p{Letter}\p{Number}]+/gu, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean);
+  const meaningful = tokens.filter((token) => !LEGAL_NAME_NOISE.has(token));
+  // A name made only of noise ("The Company") keeps its tokens rather than
+  // collapsing every such issuer into one empty-key row.
+  return (meaningful.length > 0 ? meaningful : tokens).join(" ") || name.trim().toLowerCase();
+}
+
+/** Mixed case reads as a real name; all-caps is the tape shouting. */
+function isMixedCase(name: string): boolean {
+  return name !== name.toUpperCase();
+}
+
+/**
+ * Picks the spelling a human would write. Mixed case wins over all-caps first,
+ * then the longer name, so a full legal name beats an abbreviated or inverted
+ * one ("Oracle Corporation" over "Oracle Cop", "The Boeing Company" over
+ * "Boeing Co/The"). Ties break lexically so refreshes do not reshuffle.
+ */
+function preferredIssuerName(current: string, candidate: string): string {
+  const currentMixed = isMixedCase(current);
+  const candidateMixed = isMixedCase(candidate);
+  if (currentMixed !== candidateMixed) return candidateMixed ? candidate : current;
+  if (current.length !== candidate.length) return candidate.length > current.length ? candidate : current;
+  return candidate.localeCompare(current) < 0 ? candidate : current;
 }
 
 export function spreadToBasisPoints(value: number | null, notation: string | null): number | null {
@@ -77,9 +129,11 @@ export function normalizeCdsTrades(trades: readonly CloudCdsTradePayload[]): Cds
   for (const trade of trades) {
     const eventAt = tapeTime(trade);
     if (eventAt == null) continue;
+    const issuer = issuerOf(trade);
     rows.push({
       id: trade.disseminationId,
-      issuer: issuerOf(trade),
+      issuer,
+      issuerKey: issuerGroupKey(issuer),
       eventAt,
       maturity: trade.maturityDate ?? trade.expirationDate,
       notional: trade.notionalAmount,
@@ -103,29 +157,31 @@ export function summarizeIssuers(trades: readonly CdsTrade[]): CdsIssuerSummary[
   const byIssuer = new Map<string, CdsIssuerSummary>();
   const spreadAt = new Map<string, number>();
   for (const trade of trades) {
-    const current = byIssuer.get(trade.issuer);
+    const current = byIssuer.get(trade.issuerKey);
     if (!current) {
-      byIssuer.set(trade.issuer, {
+      byIssuer.set(trade.issuerKey, {
+        key: trade.issuerKey,
         issuer: trade.issuer,
         trades: 1,
         lastTradeAt: trade.eventAt,
         latestSpreadBp: trade.spreadBp,
       });
-      if (trade.spreadBp != null) spreadAt.set(trade.issuer, trade.eventAt);
+      if (trade.spreadBp != null) spreadAt.set(trade.issuerKey, trade.eventAt);
       continue;
     }
     current.trades += 1;
+    current.issuer = preferredIssuerName(current.issuer, trade.issuer);
     if (trade.eventAt > current.lastTradeAt) current.lastTradeAt = trade.eventAt;
-    if (trade.spreadBp != null && trade.eventAt >= (spreadAt.get(trade.issuer) ?? -Infinity)) {
+    if (trade.spreadBp != null && trade.eventAt >= (spreadAt.get(trade.issuerKey) ?? -Infinity)) {
       current.latestSpreadBp = trade.spreadBp;
-      spreadAt.set(trade.issuer, trade.eventAt);
+      spreadAt.set(trade.issuerKey, trade.eventAt);
     }
   }
   return [...byIssuer.values()];
 }
 
-export function tradesForIssuer(trades: readonly CdsTrade[], issuer: string): CdsTrade[] {
-  return trades.filter((trade) => trade.issuer === issuer);
+export function tradesForIssuer(trades: readonly CdsTrade[], issuerKey: string): CdsTrade[] {
+  return trades.filter((trade) => trade.issuerKey === issuerKey);
 }
 
 /**

--- a/src/plugins/builtin/cds/model.ts
+++ b/src/plugins/builtin/cds/model.ts
@@ -56,9 +56,27 @@ const LEGAL_NAME_NOISE = new Set([
   "inc", "incorporated", "limited", "ltd", "plc",
 ]);
 
-/** Case, accents, and punctuation folded away, then legal-name noise dropped. */
-export function issuerGroupKey(name: string): string {
-  const tokens = name
+/**
+ * Obligation vocabulary the tape writes into `UPI Underlier Name` when it has
+ * no reference entity: seniority, instrument type, format, rule reference, and
+ * currency. A name built only from these describes a bond, not an issuer.
+ */
+const OBLIGATION_NOISE = new Set([
+  "sr", "senior", "sub", "subordinated", "jr", "junior",
+  "nt", "nts", "note", "notes", "bd", "bds", "bond", "bonds",
+  "gtd", "guaranteed", "global", "medium", "term", "mtn", "emtn",
+  "144a", "regs", "s", "call",
+  "eur", "usd", "gbp", "jpy", "chf", "cad", "aud",
+]);
+
+/** Whole-string sentinels the feed sends instead of leaving the field empty. */
+const NAME_PLACEHOLDERS = new Set([
+  "no name obtainable", "name not available", "not available", "unknown", "n a",
+]);
+
+/** Case, accents, and punctuation folded away into comparable tokens. */
+function nameTokens(name: string): string[] {
+  return name
     .normalize("NFKD")
     .replace(/[\u0300-\u036f]/g, "")
     .toLowerCase()
@@ -66,6 +84,27 @@ export function issuerGroupKey(name: string): string {
     .trim()
     .split(" ")
     .filter(Boolean);
+}
+
+/**
+ * Whether a `UPI Underlier Name` names a company at all. "SR GTD NT 144A" and
+ * "MEDIUM TERM NOTES EUR 2.3750 S.10/CALL" are obligation descriptions that
+ * would otherwise become fake issuers and outrank real ones, while
+ * "Tencent Holdings Limited" and "DT.BANK MTN 17/20" carry a real entity.
+ */
+function identifiesIssuer(name: string): boolean {
+  const tokens = nameTokens(name);
+  if (tokens.length === 0 || NAME_PLACEHOLDERS.has(tokens.join(" "))) return false;
+  return tokens.some((token) => (
+    !OBLIGATION_NOISE.has(token)
+    && !LEGAL_NAME_NOISE.has(token)
+    && !/^\d+$/.test(token)
+  ));
+}
+
+/** Case, accents, and punctuation folded away, then legal-name noise dropped. */
+export function issuerGroupKey(name: string): string {
+  const tokens = nameTokens(name);
   const meaningful = tokens.filter((token) => !LEGAL_NAME_NOISE.has(token));
   // A name made only of noise ("The Company") keeps its tokens rather than
   // collapsing every such issuer into one empty-key row.
@@ -117,11 +156,17 @@ function tapeTime(trade: CloudCdsTradePayload): number | null {
   return Number.isFinite(event) ? event : null;
 }
 
-function issuerOf(trade: CloudCdsTradePayload): string {
-  const named = trade.issuerName?.trim()
-    || trade.upiUnderlierName?.trim()
-    || trade.underlierId?.trim();
-  return named || "Unknown issuer";
+/**
+ * A reported issuer name is always trusted, even when the UPI underlier beside
+ * it is generic. Otherwise the UPI name is used only when it names a company.
+ * There is no third fallback: underlier IDs are opaque instrument codes, so
+ * showing one would just be a different kind of fake issuer.
+ */
+function issuerOf(trade: CloudCdsTradePayload): string | null {
+  const reported = trade.issuerName?.trim();
+  if (reported) return reported;
+  const underlier = trade.upiUnderlierName?.trim();
+  return underlier && identifiesIssuer(underlier) ? underlier : null;
 }
 
 export function normalizeCdsTrades(trades: readonly CloudCdsTradePayload[]): CdsTrade[] {
@@ -130,6 +175,8 @@ export function normalizeCdsTrades(trades: readonly CloudCdsTradePayload[]): Cds
     const eventAt = tapeTime(trade);
     if (eventAt == null) continue;
     const issuer = issuerOf(trade);
+    // Nothing names the reference entity, so the row would invent one.
+    if (!issuer) continue;
     rows.push({
       id: trade.disseminationId,
       issuer,

--- a/src/plugins/builtin/cds/model.ts
+++ b/src/plugins/builtin/cds/model.ts
@@ -1,6 +1,5 @@
 import type { CloudCdsTradePayload } from "../../../api-client";
 import type { DataTableColumn } from "../../../components";
-import type { TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 import { formatCompact } from "../../../utils/format";
 import { compareSortValues, type SortPreference } from "../../../utils/sort-values";
@@ -237,19 +236,15 @@ export function tradesForIssuer(trades: readonly CdsTrade[], issuerKey: string):
 }
 
 /**
- * The company name the backend matches on. An untracked symbol has no
- * TickerRecord, but its quote arrives with a name shortly after the pane opens,
- * so the raw symbol is only the last resort.
+ * What the pane asks for. A tracked ticker already carries its company name; an
+ * untracked one yields the bare symbol, which the loader expands through
+ * instrument search before it reaches the backend.
  */
 export function resolveIssuerQuery(
   symbol: string | null,
   ticker: TickerRecord | null,
-  financials: TickerFinancials | null,
 ): string | null {
-  return ticker?.metadata.name?.trim()
-    || financials?.quote?.name?.trim()
-    || symbol?.trim().toUpperCase()
-    || null;
+  return ticker?.metadata.name?.trim() || symbol?.trim().toUpperCase() || null;
 }
 
 export function formatBp(value: number | null): string {

--- a/src/plugins/builtin/cds/pane.test.tsx
+++ b/src/plugins/builtin/cds/pane.test.tsx
@@ -14,24 +14,24 @@ const ACTIVITY: CdsActivity = {
   source: "DTCC PPD",
   asOf: "2026-08-25T15:00:00Z",
   trades: normalizeCdsTrades([
-    trade("1", "Oracle Corporation", "2026-08-25T10:00:00Z", { reportedSpread: 0.9, spreadNotation: "Percentage" }),
+    trade("1", "Oracle Corporation", "2026-08-25T10:00:00Z", { reportedSpread: 0.009, spreadNotation: "3" }),
     trade("2", "Oracle Corporation", "2026-08-25T12:00:00Z", { reportedSpread: null }),
-    trade("3", "Ford Motor Company", "2026-08-25T11:00:00Z", { reportedSpread: 250, spreadNotation: "BPS" }),
+    trade("3", "Ford Motor Company", "2026-08-25T11:00:00Z", { reportedSpread: 0.025, spreadNotation: "3" }),
   ]),
 };
 
 function trade(
   id: string,
   issuerName: string,
-  eventTimestamp: string,
+  executionTimestamp: string,
   overrides: { reportedSpread: number | null; spreadNotation?: string | null },
 ) {
   return {
     disseminationId: id,
     originalDisseminationId: null,
     actionType: "NEWT",
-    eventTimestamp,
-    executionTimestamp: null,
+    eventTimestamp: executionTimestamp,
+    executionTimestamp,
     effectiveDate: null,
     expirationDate: null,
     maturityDate: "2031-06-20",
@@ -44,7 +44,8 @@ function trade(
     notionalAmount: 5_000_000,
     notionalCapped: true,
     notionalCurrency: "USD",
-    fixedRate: 1,
+    // Raw DTCC decimal: 0.01 renders as a 100bp coupon.
+    fixedRate: 0.01,
     reportedSpread: overrides.reportedSpread,
     spreadNotation: overrides.spreadNotation ?? null,
     upfrontAmount: null,

--- a/src/plugins/builtin/cds/pane.test.tsx
+++ b/src/plugins/builtin/cds/pane.test.tsx
@@ -13,6 +13,8 @@ let setup: Awaited<ReturnType<typeof testRender>> | undefined;
 const ACTIVITY: CdsActivity = {
   source: "DTCC PPD",
   asOf: "2026-08-25T15:00:00Z",
+  // Market-wide: nothing was resolved because nothing was asked for.
+  issuer: null,
   trades: normalizeCdsTrades([
     trade("1", "Oracle Corporation", "2026-08-25T10:00:00Z", { reportedSpread: 0.009, spreadNotation: "3" }),
     trade("2", "Oracle Corporation", "2026-08-25T12:00:00Z", { reportedSpread: null }),

--- a/src/plugins/builtin/cds/pane.test.tsx
+++ b/src/plugins/builtin/cds/pane.test.tsx
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { PaneFooterProvider } from "../../../components/layout/pane/footer";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { AppContext, createInitialState, PaneInstanceProvider } from "../../../state/app/context";
+import { createDefaultConfig } from "../../../types/config";
+import type { CdsActivity } from "./client";
+import { normalizeCdsTrades } from "./model";
+import { CdsPane } from "./pane";
+
+let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+const ACTIVITY: CdsActivity = {
+  source: "DTCC PPD",
+  asOf: "2026-08-25T15:00:00Z",
+  trades: normalizeCdsTrades([
+    trade("1", "Oracle Corporation", "2026-08-25T10:00:00Z", { reportedSpread: 0.9, spreadNotation: "Percentage" }),
+    trade("2", "Oracle Corporation", "2026-08-25T12:00:00Z", { reportedSpread: null }),
+    trade("3", "Ford Motor Company", "2026-08-25T11:00:00Z", { reportedSpread: 250, spreadNotation: "BPS" }),
+  ]),
+};
+
+function trade(
+  id: string,
+  issuerName: string,
+  eventTimestamp: string,
+  overrides: { reportedSpread: number | null; spreadNotation?: string | null },
+) {
+  return {
+    disseminationId: id,
+    originalDisseminationId: null,
+    actionType: "NEWT",
+    eventTimestamp,
+    executionTimestamp: null,
+    effectiveDate: null,
+    expirationDate: null,
+    maturityDate: "2031-06-20",
+    issuerName,
+    underlierId: null,
+    underlierIdSource: null,
+    upi: null,
+    upiFisn: null,
+    upiUnderlierName: null,
+    notionalAmount: 5_000_000,
+    notionalCapped: true,
+    notionalCurrency: "USD",
+    fixedRate: 1,
+    reportedSpread: overrides.reportedSpread,
+    spreadNotation: overrides.spreadNotation ?? null,
+    upfrontAmount: null,
+    upfrontCurrency: null,
+  };
+}
+
+const loadActivity = async () => ACTIVITY;
+
+async function settle() {
+  for (let index = 0; index < 6; index += 1) {
+    await act(async () => {
+      await Promise.resolve();
+      await setup!.renderOnce();
+    });
+  }
+}
+
+async function renderPane() {
+  const state = createInitialState(createDefaultConfig("/tmp/gloomberb-cds-test"));
+  await act(async () => {
+    setup = await testRender(
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <PaneInstanceProvider paneId="cds:market">
+        <PaneFooterProvider>
+          {() => (
+            <CdsPane
+              paneId="cds:market"
+              paneType="cds"
+              focused
+              width={92}
+              height={16}
+              loadActivity={loadActivity}
+            />
+          )}
+        </PaneFooterProvider>
+      </PaneInstanceProvider>
+    </AppContext>,
+      { width: 92, height: 16 },
+    );
+  });
+  await settle();
+}
+
+afterEach(async () => {
+  if (setup) {
+    await act(async () => setup?.renderer.destroy());
+    setup = undefined;
+  }
+});
+
+describe("CdsPane", () => {
+  test("groups market activity by issuer, keeping the newest available spread", async () => {
+    await renderPane();
+    const frame = setup!.captureCharFrame();
+
+    // Most active first, and the 250bp report stays 250bp while the percent one becomes 90bp.
+    const oracle = frame.indexOf("Oracle Corporation");
+    const ford = frame.indexOf("Ford Motor Company");
+    expect(oracle).toBeGreaterThanOrEqual(0);
+    expect(ford).toBeGreaterThan(oracle);
+    expect(frame).toContain("90bp");
+    expect(frame).toContain("250bp");
+  });
+
+  test("opens the selected issuer's trades and shows -- for an unreported spread", async () => {
+    await renderPane();
+    await act(async () => {
+      setup!.mockInput.pressEnter();
+      await setup!.renderOnce();
+    });
+    await settle();
+
+    const frame = setup!.captureCharFrame();
+    expect(frame).toContain("NOTIONAL");
+    // Capped notional keeps its "+", and the coupon is shown instead of an implied spread.
+    expect(frame).toContain("5M+");
+    expect(frame).toContain("100bp");
+    expect(frame).toContain("--");
+    expect(frame).not.toContain("Ford Motor Company");
+  });
+});

--- a/src/plugins/builtin/cds/pane.tsx
+++ b/src/plugins/builtin/cds/pane.tsx
@@ -1,0 +1,354 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  DataTableStackView,
+  DataTableView,
+  EmptyState,
+  Spinner,
+  usePaneTicker,
+  type DataTableCell,
+  type DataTableKeyEvent,
+  type PaneFooterSegment,
+} from "../../../components";
+import { colors } from "../../../theme/colors";
+import type { PaneProps } from "../../../types/plugin";
+import { Box, Text, TextAttributes } from "../../../ui";
+import { isPlainKey } from "../../../utils/keyboard";
+import { cycleSortPreference } from "../../../utils/sort-values";
+import { useAutoRefresh } from "../shared/auto-refresh";
+import { usePaneStatusFooter } from "../shared/pane-footer";
+import { loadCdsActivity, type CdsActivity, type CdsActivityLoader } from "./client";
+import {
+  buildIssuerColumns,
+  buildTradeColumns,
+  DEFAULT_ISSUER_SORT,
+  DEFAULT_TRADE_SORT,
+  formatAsOf,
+  formatBp,
+  formatEventTime,
+  formatMaturity,
+  formatNotional,
+  formatUpfront,
+  ISSUER_SORT_COLUMN_IDS,
+  nextSort,
+  resolveIssuerQuery,
+  sortIssuers,
+  sortTrades,
+  summarizeIssuers,
+  TRADE_SORT_COLUMN_IDS,
+  tradesForIssuer,
+  type CdsIssuerSummary,
+  type CdsTrade,
+  type IssuerColumn,
+  type IssuerColumnId,
+  type IssuerSortPreference,
+  type TradeColumn,
+  type TradeColumnId,
+  type TradeSortPreference,
+} from "./model";
+
+function renderIssuerCell(
+  row: CdsIssuerSummary,
+  column: IssuerColumn,
+  selected: boolean,
+): DataTableCell {
+  const selectedColor = selected ? colors.selectedText : undefined;
+  switch (column.id) {
+    case "issuer":
+      return {
+        text: row.issuer,
+        color: selectedColor ?? colors.textBright,
+        attributes: TextAttributes.BOLD,
+      };
+    case "trades":
+      return { text: String(row.trades), color: selectedColor ?? colors.text };
+    case "last":
+      return { text: formatEventTime(row.lastTradeAt), color: selectedColor ?? colors.textMuted };
+    case "spread":
+      return {
+        text: formatBp(row.latestSpreadBp),
+        color: selectedColor ?? (row.latestSpreadBp == null ? colors.textDim : colors.text),
+      };
+  }
+}
+
+function renderTradeCell(row: CdsTrade, column: TradeColumn, selected: boolean): DataTableCell {
+  const selectedColor = selected ? colors.selectedText : undefined;
+  switch (column.id) {
+    case "time":
+      return { text: formatEventTime(row.eventAt), color: selectedColor ?? colors.textMuted };
+    case "maturity":
+      return { text: formatMaturity(row.maturity), color: selectedColor ?? colors.text };
+    case "notional":
+      return { text: formatNotional(row), color: selectedColor ?? colors.textBright };
+    case "currency":
+      return { text: row.currency ?? "--", color: selectedColor ?? colors.textDim };
+    case "coupon":
+      return { text: formatBp(row.couponBp), color: selectedColor ?? colors.text };
+    case "spread":
+      return {
+        text: formatBp(row.spreadBp),
+        color: selectedColor ?? (row.spreadBp == null ? colors.textDim : colors.textBright),
+      };
+    case "upfront":
+      return {
+        text: formatUpfront(row),
+        color: selectedColor ?? (row.upfront == null ? colors.textDim : colors.text),
+      };
+  }
+}
+
+function CdsTradeTable({
+  trades,
+  focused,
+  width,
+  height,
+  sort,
+  onSort,
+  selectedId,
+  onSelect,
+  onKeyDown,
+  before,
+}: {
+  trades: CdsTrade[];
+  focused: boolean;
+  width: number;
+  height?: number;
+  sort: TradeSortPreference;
+  onSort: (columnId: TradeColumnId) => void;
+  selectedId: string | null;
+  onSelect: (id: string | null) => void;
+  onKeyDown: (event: DataTableKeyEvent) => boolean;
+  before?: ReactNode;
+}) {
+  const columns = useMemo(() => buildTradeColumns(width), [width]);
+  return (
+    <DataTableView<CdsTrade, TradeColumn>
+      focused={focused}
+      rootWidth={width}
+      rootHeight={height}
+      rootBefore={before}
+      selection={{
+        kind: "id",
+        selectedId,
+        getId: (trade) => trade.id,
+        onChange: (id) => onSelect(id),
+      }}
+      onRootKeyDown={onKeyDown}
+      columns={columns}
+      items={trades}
+      sortColumnId={sort.columnId}
+      sortDirection={sort.direction}
+      onHeaderClick={(columnId) => onSort(columnId as TradeColumnId)}
+      getItemKey={(trade) => trade.id}
+      renderCell={(trade, column, _index, state) => renderTradeCell(trade, column, state.selected)}
+      emptyStateTitle="No reported trades."
+    />
+  );
+}
+
+const NO_TRADES: CdsTrade[] = [];
+
+interface CdsPaneProps extends PaneProps {
+  /** Injected by tests so the pane renders without the cloud backend. */
+  loadActivity?: CdsActivityLoader;
+}
+
+export function CdsPane({
+  paneId,
+  focused,
+  width,
+  height,
+  loadActivity = loadCdsActivity,
+}: CdsPaneProps) {
+  const { symbol, ticker } = usePaneTicker();
+  const issuerQuery = useMemo(() => resolveIssuerQuery(symbol, ticker), [symbol, ticker]);
+
+  const [activity, setActivity] = useState<CdsActivity | null>(null);
+  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [fetchedAt, setFetchedAt] = useState<number | null>(null);
+  const [issuerSort, setIssuerSort] = useState<IssuerSortPreference>(DEFAULT_ISSUER_SORT);
+  const [tradeSort, setTradeSort] = useState<TradeSortPreference>(DEFAULT_TRADE_SORT);
+  const [selectedIssuer, setSelectedIssuer] = useState<string | null>(null);
+  const [selectedTradeId, setSelectedTradeId] = useState<string | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const generation = useRef(0);
+  // Held in a ref so an inline loader prop cannot turn every render into a fetch.
+  const loadActivityRef = useRef(loadActivity);
+  loadActivityRef.current = loadActivity;
+
+  const load = useCallback(() => {
+    generation.current += 1;
+    const current = generation.current;
+    setStatus((previous) => (previous === "loaded" ? "loaded" : "loading"));
+    setError(null);
+    loadActivityRef.current(issuerQuery)
+      .then((next) => {
+        if (generation.current !== current) return;
+        setActivity(next);
+        setStatus("loaded");
+        setFetchedAt(Date.now());
+      })
+      .catch((loadError: unknown) => {
+        if (generation.current !== current) return;
+        setError(loadError instanceof Error ? loadError.message : String(loadError));
+        setStatus("error");
+      });
+  }, [issuerQuery]);
+
+  useEffect(() => { load(); }, [load]);
+  useAutoRefresh(fetchedAt, load);
+
+  const trades = activity?.trades ?? NO_TRADES;
+  const issuers = useMemo(
+    () => (issuerQuery ? [] : sortIssuers(summarizeIssuers(trades), issuerSort)),
+    [issuerQuery, issuerSort, trades],
+  );
+  const visibleTrades = useMemo(() => sortTrades(
+    issuerQuery ? trades : selectedIssuer ? tradesForIssuer(trades, selectedIssuer) : [],
+    tradeSort,
+  ), [issuerQuery, selectedIssuer, tradeSort, trades]);
+
+  useEffect(() => {
+    if (issuerQuery) return;
+    if (selectedIssuer && issuers.some((row) => row.issuer === selectedIssuer)) return;
+    setSelectedIssuer(issuers[0]?.issuer ?? null);
+    setDetailOpen(false);
+  }, [issuerQuery, issuers, selectedIssuer]);
+
+  const cycleTradeSort = useCallback((step: 1 | -1) => {
+    setTradeSort((current) => {
+      const next = cycleSortPreference<TradeColumnId>(TRADE_SORT_COLUMN_IDS, current, step);
+      return { columnId: next.columnId ?? DEFAULT_TRADE_SORT.columnId, direction: next.direction };
+    });
+  }, []);
+  const cycleIssuerSort = useCallback((step: 1 | -1) => {
+    setIssuerSort((current) => {
+      const next = cycleSortPreference<IssuerColumnId>(ISSUER_SORT_COLUMN_IDS, current, step);
+      return { columnId: next.columnId ?? DEFAULT_ISSUER_SORT.columnId, direction: next.direction };
+    });
+  }, []);
+
+  const handleKey = useCallback((event: DataTableKeyEvent, cycle: (step: 1 | -1) => void): boolean => {
+    if (isPlainKey(event, "r")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      load();
+      return true;
+    }
+    if (isPlainKey(event, "]", "[")) {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      cycle(event.name === "]" ? 1 : -1);
+      return true;
+    }
+    return false;
+  }, [load]);
+  const handleIssuerKey = useCallback(
+    (event: DataTableKeyEvent) => handleKey(event, cycleIssuerSort),
+    [cycleIssuerSort, handleKey],
+  );
+  const handleTradeKey = useCallback(
+    (event: DataTableKeyEvent) => handleKey(event, cycleTradeSort),
+    [cycleTradeSort, handleKey],
+  );
+
+  const asOfLabel = formatAsOf(activity?.asOf ?? null);
+  const footerInfo = useMemo<PaneFooterSegment[]>(() => [
+    ...(asOfLabel ? [{ id: "as-of", parts: [{ text: `as of ${asOfLabel}`, tone: "muted" as const }] }] : []),
+    ...(activity ? [{ id: "delayed", parts: [{ text: "delayed", tone: "muted" as const }] }] : []),
+  ], [activity, asOfLabel]);
+  usePaneStatusFooter({
+    registrationId: paneId,
+    loading: status === "loading",
+    error,
+    info: footerInfo,
+  });
+
+  if (status === "loading" && !activity) {
+    return (
+      <Box width={width} height={height} justifyContent="center" alignItems="center">
+        <Spinner label="Loading CDS activity..." />
+      </Box>
+    );
+  }
+  if (!activity) {
+    return (
+      <Box width={width} height={height} padding={1} flexDirection="column">
+        {/* The reason lives in the footer, so the body never repeats it. */}
+        <EmptyState title="CDS activity unavailable." />
+      </Box>
+    );
+  }
+
+  if (issuerQuery) {
+    // The pane title already carries the ticker, so the body leads with the
+    // issuer name the backend was actually queried for.
+    const resolved = (
+      <Box height={1} paddingX={1}>
+        <Text fg={colors.textMuted} wrapMode="ellipsis">{`${issuerQuery} · ${activity.source}`}</Text>
+      </Box>
+    );
+    return (
+      <CdsTradeTable
+        trades={visibleTrades}
+        focused={focused}
+        width={width}
+        height={height}
+        sort={tradeSort}
+        onSort={(columnId) => setTradeSort((current) => nextSort(current, columnId, DEFAULT_TRADE_SORT))}
+        selectedId={selectedTradeId}
+        onSelect={setSelectedTradeId}
+        onKeyDown={handleTradeKey}
+        before={resolved}
+      />
+    );
+  }
+
+  const issuerColumns = buildIssuerColumns(width);
+  return (
+    <DataTableStackView<CdsIssuerSummary, IssuerColumn>
+      focused={focused}
+      detailOpen={detailOpen && !!selectedIssuer}
+      onBack={() => setDetailOpen(false)}
+      detailTitle={selectedIssuer ?? undefined}
+      detailContent={selectedIssuer ? (
+        <CdsTradeTable
+          trades={visibleTrades}
+          focused={focused && detailOpen}
+          width={width}
+          sort={tradeSort}
+          onSort={(columnId) => setTradeSort((current) => nextSort(current, columnId, DEFAULT_TRADE_SORT))}
+          selectedId={selectedTradeId}
+          onSelect={setSelectedTradeId}
+          onKeyDown={handleTradeKey}
+        />
+      ) : null}
+      onDetailKeyDown={handleTradeKey}
+      rootWidth={width}
+      rootHeight={height}
+      selection={{
+        kind: "id",
+        selectedId: selectedIssuer,
+        getId: (row) => row.issuer,
+        onChange: (id) => setSelectedIssuer(id),
+      }}
+      onActivate={(row) => {
+        setSelectedIssuer(row.issuer);
+        setSelectedTradeId(null);
+        setDetailOpen(true);
+      }}
+      onRootKeyDown={handleIssuerKey}
+      columns={issuerColumns}
+      items={issuers}
+      sortColumnId={issuerSort.columnId}
+      sortDirection={issuerSort.direction}
+      onHeaderClick={(columnId) => setIssuerSort((current) => (
+        nextSort(current, columnId as IssuerColumnId, DEFAULT_ISSUER_SORT)
+      ))}
+      getItemKey={(row) => row.issuer}
+      renderCell={(row, column, _index, state) => renderIssuerCell(row, column, state.selected)}
+      emptyStateTitle={error ? "CDS activity unavailable." : "No reported single-name CDS trades."}
+    />
+  );
+}

--- a/src/plugins/builtin/cds/pane.tsx
+++ b/src/plugins/builtin/cds/pane.tsx
@@ -160,8 +160,13 @@ export function CdsPane({
   height,
   loadActivity = loadCdsActivity,
 }: CdsPaneProps) {
-  const { symbol, ticker } = usePaneTicker();
-  const issuerQuery = useMemo(() => resolveIssuerQuery(symbol, ticker), [symbol, ticker]);
+  const { symbol, ticker, financials } = usePaneTicker();
+  // An untracked symbol resolves once its quote lands; the in-flight request for
+  // the raw symbol is superseded through the same generation guard as a refresh.
+  const issuerQuery = useMemo(
+    () => resolveIssuerQuery(symbol, ticker, financials),
+    [financials, symbol, ticker],
+  );
 
   const [activity, setActivity] = useState<CdsActivity | null>(null);
   const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");

--- a/src/plugins/builtin/cds/pane.tsx
+++ b/src/plugins/builtin/cds/pane.tsx
@@ -174,7 +174,7 @@ export function CdsPane({
   const [fetchedAt, setFetchedAt] = useState<number | null>(null);
   const [issuerSort, setIssuerSort] = useState<IssuerSortPreference>(DEFAULT_ISSUER_SORT);
   const [tradeSort, setTradeSort] = useState<TradeSortPreference>(DEFAULT_TRADE_SORT);
-  const [selectedIssuer, setSelectedIssuer] = useState<string | null>(null);
+  const [selectedIssuerKey, setSelectedIssuerKey] = useState<string | null>(null);
   const [selectedTradeId, setSelectedTradeId] = useState<string | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const generation = useRef(0);
@@ -210,16 +210,17 @@ export function CdsPane({
     [issuerQuery, issuerSort, trades],
   );
   const visibleTrades = useMemo(() => sortTrades(
-    issuerQuery ? trades : selectedIssuer ? tradesForIssuer(trades, selectedIssuer) : [],
+    issuerQuery ? trades : selectedIssuerKey ? tradesForIssuer(trades, selectedIssuerKey) : [],
     tradeSort,
-  ), [issuerQuery, selectedIssuer, tradeSort, trades]);
+  ), [issuerQuery, selectedIssuerKey, tradeSort, trades]);
+  const selectedSummary = issuers.find((row) => row.key === selectedIssuerKey) ?? null;
 
   useEffect(() => {
     if (issuerQuery) return;
-    if (selectedIssuer && issuers.some((row) => row.issuer === selectedIssuer)) return;
-    setSelectedIssuer(issuers[0]?.issuer ?? null);
+    if (selectedIssuerKey && issuers.some((row) => row.key === selectedIssuerKey)) return;
+    setSelectedIssuerKey(issuers[0]?.key ?? null);
     setDetailOpen(false);
-  }, [issuerQuery, issuers, selectedIssuer]);
+  }, [issuerQuery, issuers, selectedIssuerKey]);
 
   const cycleTradeSort = useCallback((step: 1 | -1) => {
     setTradeSort((current) => {
@@ -314,10 +315,10 @@ export function CdsPane({
   return (
     <DataTableStackView<CdsIssuerSummary, IssuerColumn>
       focused={focused}
-      detailOpen={detailOpen && !!selectedIssuer}
+      detailOpen={detailOpen && !!selectedSummary}
       onBack={() => setDetailOpen(false)}
-      detailTitle={selectedIssuer ?? undefined}
-      detailContent={selectedIssuer ? (
+      detailTitle={selectedSummary?.issuer}
+      detailContent={selectedSummary ? (
         <CdsTradeTable
           trades={visibleTrades}
           focused={focused && detailOpen}
@@ -334,12 +335,12 @@ export function CdsPane({
       rootHeight={height}
       selection={{
         kind: "id",
-        selectedId: selectedIssuer,
-        getId: (row) => row.issuer,
-        onChange: (id) => setSelectedIssuer(id),
+        selectedId: selectedIssuerKey,
+        getId: (row) => row.key,
+        onChange: (id) => setSelectedIssuerKey(id),
       }}
       onActivate={(row) => {
-        setSelectedIssuer(row.issuer);
+        setSelectedIssuerKey(row.key);
         setSelectedTradeId(null);
         setDetailOpen(true);
       }}
@@ -351,7 +352,7 @@ export function CdsPane({
       onHeaderClick={(columnId) => setIssuerSort((current) => (
         nextSort(current, columnId as IssuerColumnId, DEFAULT_ISSUER_SORT)
       ))}
-      getItemKey={(row) => row.issuer}
+      getItemKey={(row) => row.key}
       renderCell={(row, column, _index, state) => renderIssuerCell(row, column, state.selected)}
       emptyStateTitle={error ? "CDS activity unavailable." : "No reported single-name CDS trades."}
     />

--- a/src/plugins/builtin/cds/pane.tsx
+++ b/src/plugins/builtin/cds/pane.tsx
@@ -160,13 +160,8 @@ export function CdsPane({
   height,
   loadActivity = loadCdsActivity,
 }: CdsPaneProps) {
-  const { symbol, ticker, financials } = usePaneTicker();
-  // An untracked symbol resolves once its quote lands; the in-flight request for
-  // the raw symbol is superseded through the same generation guard as a refresh.
-  const issuerQuery = useMemo(
-    () => resolveIssuerQuery(symbol, ticker, financials),
-    [financials, symbol, ticker],
-  );
+  const { symbol, ticker } = usePaneTicker();
+  const issuerQuery = useMemo(() => resolveIssuerQuery(symbol, ticker), [symbol, ticker]);
 
   const [activity, setActivity] = useState<CdsActivity | null>(null);
   const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
@@ -289,10 +284,13 @@ export function CdsPane({
 
   if (issuerQuery) {
     // The pane title already carries the ticker, so the body leads with the
-    // issuer name the backend was actually queried for.
+    // issuer name the backend was actually queried for, which is the expanded
+    // company name once instrument search has resolved a bare symbol.
     const resolved = (
       <Box height={1} paddingX={1}>
-        <Text fg={colors.textMuted} wrapMode="ellipsis">{`${issuerQuery} · ${activity.source}`}</Text>
+        <Text fg={colors.textMuted} wrapMode="ellipsis">
+          {`${activity.issuer ?? issuerQuery} · ${activity.source}`}
+        </Text>
       </Box>
     );
     return (

--- a/src/plugins/builtin/composite-plugins.ts
+++ b/src/plugins/builtin/composite-plugins.ts
@@ -7,6 +7,7 @@ import { brokerManagerModule } from "./broker-manager";
 import { changelogModule } from "./changelog";
 import { connectionsModule } from "./connections";
 import { correlationModule } from "./correlation";
+import { cdsModule } from "./cds";
 import { creditConditionsModule } from "./credit-conditions";
 import { economicCalendarModule } from "./econ";
 import { earningsModule } from "./earnings";
@@ -89,7 +90,7 @@ export const macroPlugin = composeBuiltinPlugin({
   id: "macro",
   name: "Macro",
   version: "1.0.0",
-  description: "Economic calendar, rates, volatility, credit spreads, Treasury auctions, earnings, IPOs, and live financial TV.",
+  description: "Economic calendar, rates, volatility, credit spreads, single-name CDS, Treasury auctions, earnings, IPOs, and live financial TV.",
   toggleable: true,
   modules: [
     macroSharedResourcesModule,
@@ -97,6 +98,7 @@ export const macroPlugin = composeBuiltinPlugin({
     yieldCurveModule,
     volatilityModule,
     creditConditionsModule,
+    cdsModule,
     treasuryAuctionsModule,
     earningsModule,
     ipoCalendarModule,

--- a/src/plugins/catalog-browser.ts
+++ b/src/plugins/catalog-browser.ts
@@ -10,6 +10,7 @@ import { changelogModule } from "./builtin/changelog";
 import { chartComposerModule } from "./builtin/chart-composer";
 import { connectionsModule } from "./builtin/connections";
 import { correlationModule } from "./builtin/correlation";
+import { cdsModule } from "./builtin/cds";
 import { creditConditionsModule } from "./builtin/credit-conditions";
 import { economicCalendarModule } from "./builtin/econ";
 import { futuresModule } from "./builtin/futures";
@@ -101,7 +102,7 @@ const browserMacroPlugin = composeBuiltinPlugin({
   id: "macro",
   name: "Macro",
   version: "1.0.0",
-  description: "Economic calendar, rates, volatility, credit spreads, and Treasury auctions.",
+  description: "Economic calendar, rates, volatility, credit spreads, single-name CDS, and Treasury auctions.",
   toggleable: true,
   modules: [
     browserFredResourcesModule,
@@ -109,6 +110,7 @@ const browserMacroPlugin = composeBuiltinPlugin({
     yieldCurveModule,
     volatilityModule,
     creditConditionsModule,
+    cdsModule,
     treasuryAuctionsModule,
   ],
 });


### PR DESCRIPTION
## Summary
- add `CDS` market-wide issuer activity and `CDS <ticker>` trade views
- show DTCC execution time, notional caps, coupons, reported spreads, and upfront payments
- include the CDS pane in terminal, desktop, and hosted browser catalogs

## Verification
- `bun test` (2294 passed)
- `bun run typecheck`
- `bun run web:audit`
- tmux keyboard, sorting, drill-down, refresh, and runtime-health smoke

Depends on the `/cloud/credit/cds` backend endpoint in the platform repository.