### PR TITLE
Fix theme refresh for charts and chat

### DIFF
--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -31,6 +31,9 @@ import {
   resolveCompositeMinimumSpanMs,
   zoomCompositeViewport,
 } from "./interactions";
+import { getThemeColors, syncTheme } from "../../../theme/colors";
+import { ThemeProvider } from "../../../theme/theme-context";
+import { DEFAULT_THEME } from "../../../theme/themes";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let chartShortcut: ((event: KeyEventLike) => void) | null = null;
@@ -131,12 +134,12 @@ function keyEvent(name: string, shift = false): KeyEventLike {
 }
 
 afterEach(async () => {
-  if (!testSetup) return;
-  await act(async () => testSetup!.renderer.destroy());
+  if (testSetup) await act(async () => testSetup!.renderer.destroy());
   testSetup = undefined;
   chartShortcut = null;
   capturedSurfaceProps = null;
   capturedSurfaceNode = null;
+  syncTheme(DEFAULT_THEME);
 });
 
 function point(date: string, value: number): TimeSeriesPoint {
@@ -204,6 +207,46 @@ function twoSessionCandles(): ResolvedSeries {
 }
 
 describe("CompositeChart", () => {
+  test("repaints cached chart rasters when the theme changes", async () => {
+    let setThemeId: ((themeId: string) => void) | null = null;
+    const chartSeries = [series("price", "main", "left", "USD", [100, 101, 102])];
+
+    function ThemedChart() {
+      const [themeId, setTheme] = useState(DEFAULT_THEME);
+      setThemeId = setTheme;
+      return (
+        <ThemeProvider themeId={themeId}>
+          <CaptureChartSurfaceProvider>
+            <CompositeChart
+              width={60}
+              height={12}
+              series={chartSeries}
+              panels={[{ id: "main" }]}
+            />
+          </CaptureChartSurfaceProvider>
+        </ThemeProvider>
+      );
+    }
+
+    testSetup = await testRender(<ThemedChart />, { width: 62, height: 14 });
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const nextThemeId = "github-light";
+    await act(async () => {
+      setThemeId?.(nextThemeId);
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    const bitmap = capturedSurfaceProps!.bitmaps[0] as { pixels: Uint8Array };
+    const expectedBackground = getThemeColors(nextThemeId).bg;
+    const expectedRgb = [1, 3, 5].map((offset) => parseInt(expectedBackground.slice(offset, offset + 2), 16));
+    expect(Array.from(bitmap.pixels.slice(0, 3))).toEqual(expectedRgb);
+  });
+
   test("shows the regular-session move beside the latest intraday value", async () => {
     testSetup = await testRender(
       <CompositeChart

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -14,6 +14,7 @@ import {
 import { useShortcut } from "../../../react/input";
 import { useOptionalPaneInstanceId, usePaneSettingValue } from "../../../state/app/context";
 import { colors as themeColors, hoverBg } from "../../../theme/colors";
+import { useThemeColors } from "../../../theme/theme-context";
 import { formatPercentRaw } from "../../../utils/format";
 import { isPlainKey } from "../../../utils/keyboard";
 import { truncateWithEllipsis } from "../../../utils/text-wrap";
@@ -1445,6 +1446,7 @@ export function CompositeChart({
   onToggleSeries,
   isSeriesToggleable,
 }: CompositeChartProps) {
+  const activeThemeColors = useThemeColors();
   const { cellWidthPx = 8, pixelRatio = 1 } = useUiCapabilities();
   const isDesktopWeb = useUiHost().kind === "desktop-web";
   const showTextFallback = useShowChartTextFallback();
@@ -1692,13 +1694,13 @@ export function CompositeChart({
   }).join("|");
   const plotHeight = Math.max(panelCount, totalHeight - legendRows - timeAxisRows);
   const resolvedColors = useMemo<CompositeChartColors>(() => ({
-    background: colors?.background ?? themeColors.bg,
-    grid: colors?.grid ?? themeColors.border,
-    crosshair: colors?.crosshair ?? themeColors.borderFocused,
-    text: colors?.text ?? themeColors.text,
-    textDim: colors?.textDim ?? themeColors.textDim,
-    negative: colors?.negative ?? themeColors.negative,
-  }), [colors]);
+    background: colors?.background ?? activeThemeColors.bg,
+    grid: colors?.grid ?? activeThemeColors.border,
+    crosshair: colors?.crosshair ?? activeThemeColors.borderFocused,
+    text: colors?.text ?? activeThemeColors.text,
+    textDim: colors?.textDim ?? activeThemeColors.textDim,
+    negative: colors?.negative ?? activeThemeColors.negative,
+  }), [activeThemeColors, colors]);
   const projectedScene = useMemo(() => {
     // lastTickKey busts this memo when a live tick mutates series identity in place.
     void lastTickKey;

--- a/src/plugins/builtin/chat/message/desktop.test.tsx
+++ b/src/plugins/builtin/chat/message/desktop.test.tsx
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createTestRenderer } from "@opentui/core/testing";
+import { act } from "react";
+import { createOpenTuiTestRoot as createRoot } from "../../../../renderers/opentui/test-utils";
+import { getThemeColors, syncTheme } from "../../../../theme/colors";
+import { ThemeProvider } from "../../../../theme/theme-context";
+import { DEFAULT_THEME } from "../../../../theme/themes";
+import type { ChatMessage } from "../../../../api-client";
+import { DesktopChatMessage } from "./desktop";
+
+let testSetup: Awaited<ReturnType<typeof createTestRenderer>> | undefined;
+let root: ReturnType<typeof createRoot> | undefined;
+const actEnvironment = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+
+function rgba(hex: string): string {
+  const value = hex.slice(1);
+  return [0, 2, 4].map((offset) => parseInt(value.slice(offset, offset + 2), 16)).concat(255).join(",");
+}
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => {
+      root?.unmount();
+      await Promise.resolve();
+    });
+  }
+  testSetup?.renderer.destroy();
+  root = undefined;
+  testSetup = undefined;
+  syncTheme(DEFAULT_THEME);
+});
+
+describe("DesktopChatMessage", () => {
+  test("updates memoized row colors when the theme changes", async () => {
+    const message: ChatMessage = {
+      id: "theme-message",
+      channelId: "everyone",
+      content: "theme message",
+      replyToId: null,
+      createdAt: "2026-08-25T12:00:00.000Z",
+      user: { id: "user-1", username: "vince", displayName: "Vince" },
+    };
+    const noop = () => {};
+    const messageElement = (
+      <DesktopChatMessage
+        msg={message}
+        index={0}
+        messages={[message]}
+        selectedIdx={0}
+        hoveredIdx={null}
+        canSend={false}
+        catalog={{}}
+        userByUsername={new Map()}
+        openTicker={noop}
+        onUserHover={noop}
+        onUserHoverEnd={noop}
+        beginReplyTo={noop}
+        beginEditMessage={() => false}
+        jumpToMessage={noop}
+        latestEditableMessageId={null}
+        registerMessageElement={noop}
+      />
+    );
+
+    testSetup = await createTestRenderer({ width: 60, height: 4 });
+    root = createRoot(testSetup.renderer);
+    act(() => root?.render(<ThemeProvider themeId={DEFAULT_THEME}>{messageElement}</ThemeProvider>));
+    await act(async () => {
+      await testSetup?.renderOnce();
+      await testSetup?.renderOnce();
+    });
+
+    const nextThemeId = "github-light";
+    act(() => root?.render(<ThemeProvider themeId={nextThemeId}>{messageElement}</ThemeProvider>));
+    await act(async () => {
+      await testSetup?.renderOnce();
+      await testSetup?.renderOnce();
+    });
+
+    const bodySpan = testSetup.captureSpans().lines
+      .flatMap((line) => line.spans)
+      .find((span) => span.text.includes(message.content));
+    const palette = getThemeColors(nextThemeId);
+    expect(bodySpan?.fg.toInts().join(",")).toBe(rgba(palette.selectedText));
+    expect(bodySpan?.bg.toInts().join(",")).toBe(rgba(palette.selected));
+  });
+});

--- a/src/plugins/builtin/chat/message/desktop.tsx
+++ b/src/plugins/builtin/chat/message/desktop.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import { Box, Span, Text } from "../../../../ui";
 import { hoverBg } from "../../../../theme/colors";
+import { useThemeColors } from "../../../../theme/theme-context";
 import { t } from "../../../../i18n";
 import { useAppLanguage } from "../../../../i18n/react";
 import { MESSAGE_ACTION_WIDTH, normalizeInlinePreview } from "../layout";
@@ -32,6 +33,7 @@ export const DesktopChatMessage = memo(function DesktopChatMessage({
   registerMessageElement: (messageId: string, node: unknown | null) => void;
 }) {
   useAppLanguage();
+  const themeColors = useThemeColors();
   const state = getChatMessageRenderState({ msg, index, messages, selectedIdx, hoveredIdx, canSend });
   const canEditMessage = msg.id === latestEditableMessageId;
   const showInlineReplyAction = !state.grouped && canSend;
@@ -58,7 +60,7 @@ export const DesktopChatMessage = memo(function DesktopChatMessage({
       data-gloom-role="chat-message"
       data-gloom-chat-message-id={msg.id}
       data-selected={state.isSelected ? "true" : "false"}
-      style={{ "--chat-hover-bg": hoverBg(), minWidth: 0 }}
+      style={{ "--chat-hover-bg": hoverBg(themeColors), minWidth: 0 }}
     >
       {msg.replyTo && (
         <Box


### PR DESCRIPTION
## Summary
- rebuild composite chart palettes and cached rasters when the active theme changes
- make memoized desktop chat messages subscribe to theme updates
- add regressions for chart backgrounds and chat row/text colors

## Tests
- `bun test src/components/chart/composite/composite-chart.test.tsx src/plugins/builtin/chat/message/desktop.test.tsx`
- `bun run typecheck:opentui`
- `bun run typecheck:electrobun-view`
- `bun run desktop:view:build`
- tmux smoke test with a live theme switch