### PR TITLE
Fix CDS ticker search

### DIFF
--- a/src/components/command-bar/pane-templates/workflow.ts
+++ b/src/components/command-bar/pane-templates/workflow.ts
@@ -112,6 +112,10 @@ export function useCommandBarPaneTemplateActions({
     const trimmedArg = rawArg?.trim() || "";
     const argKind = template.shortcut?.argKind ?? template.shortcut?.argPlaceholder;
     if (argKind === "ticker") {
+      if (!trimmedArg && template.shortcut?.argOptional) {
+        await openPaneTemplateDirect(template);
+        return;
+      }
       const resolvedTicker = await resolveTickerInput(
         trimmedArg || undefined,
         activeTickerSymbol,

--- a/src/components/command-bar/routes/root/shortcut-feedback.ts
+++ b/src/components/command-bar/routes/root/shortcut-feedback.ts
@@ -34,6 +34,9 @@ export function buildRootShortcutFeedback({
   if (rootShortcutIntent.source === "pane-template") {
     const argKind = getPaneTemplateArgKind(rootShortcutIntent.template);
     if (argKind === "ticker") {
+      if (rootShortcutIntent.template.shortcut?.argOptional && !rootShortcutIntent.argText) {
+        return `Shortcut: ${rootShortcutIntent.label}`;
+      }
       const symbol = normalizeTickerInput(activeTickerSymbol, rootShortcutIntent.argText);
       if (symbol) {
         return rootShortcutIntent.kind === "inferred-complete"

--- a/src/components/command-bar/routes/root/shortcuts.test.ts
+++ b/src/components/command-bar/routes/root/shortcuts.test.ts
@@ -46,6 +46,13 @@ const paneTemplates: PaneTemplateDef[] = [
     description: "Search provider instruments",
     shortcut: { prefix: "SRCH", argPlaceholder: "query", argKind: "text" },
   },
+  {
+    id: "cds-pane",
+    paneId: "cds",
+    label: "Single-Name CDS",
+    description: "CDS shortcut",
+    shortcut: { prefix: "CDS", argPlaceholder: "ticker", argKind: "ticker", argOptional: true },
+  },
 ];
 
 const pluginCommands: CommandDef[] = [{
@@ -133,6 +140,18 @@ describe("ticker data root shortcuts", () => {
       expect(intent.template.id).toBe("provider-search-pane");
       expect(intent.argText).toBe("");
     }
+  });
+
+  test("optional ticker shortcuts do not infer the active ticker", () => {
+    const bare = parse("CDS", "MSFT");
+    expect(bare.kind).toBe("partial");
+    if (bare.kind === "none") throw new Error("Expected shortcut intent");
+    expect(bare.completionQuery).toBeNull();
+
+    const scoped = parse("CDS ORCL", "MSFT");
+    expect(scoped.kind).toBe("complete");
+    if (scoped.kind === "none") throw new Error("Expected shortcut intent");
+    expect(scoped.argText).toBe("ORCL");
   });
 
   test("EM accepts optional text tickers without active ticker inference", () => {

--- a/src/components/command-bar/routes/root/shortcuts.ts
+++ b/src/components/command-bar/routes/root/shortcuts.ts
@@ -145,7 +145,9 @@ export function parseRootShortcutIntent({
   if (!match) return { kind: "none" };
 
   const argText = trimmed.slice(match.prefix.length).trim();
-  const inferredArg = inferShortcutArg(match.argKind, activeTicker);
+  const inferredArg = match.source === "pane-template" && match.template?.shortcut?.argOptional
+    ? null
+    : inferShortcutArg(match.argKind, activeTicker);
   const completionQuery = inferredArg ? `${match.prefix} ${inferredArg}` : null;
 
   let kind: Exclude<ShortcutIntentKind, "none">;

--- a/src/components/command-bar/surface/pane.test.tsx
+++ b/src/components/command-bar/surface/pane.test.tsx
@@ -142,6 +142,23 @@ function registerOptionalTextPane(pluginRegistry: MutablePaneRegistry): void {
   });
 }
 
+function registerOptionalTickerPane(pluginRegistry: MutablePaneRegistry): void {
+  mutableRegistryMap(pluginRegistry.panes).set("optional-ticker", {
+    id: "optional-ticker",
+    name: "Optional Ticker",
+    component: () => null,
+    defaultPosition: "right",
+    defaultMode: "floating",
+  });
+  mutableRegistryMap(pluginRegistry.paneTemplates).set("optional-ticker-pane", {
+    id: "optional-ticker-pane",
+    paneId: "optional-ticker",
+    label: "Optional Ticker",
+    description: "Open market-wide or for one ticker.",
+    shortcut: { prefix: "OT", argPlaceholder: "ticker", argKind: "ticker", argOptional: true },
+  });
+}
+
 function registerQueryOnlyPane(pluginRegistry: MutablePaneRegistry): void {
   mutableRegistryMap(pluginRegistry.panes).set("prediction-markets", {
     id: "prediction-markets",
@@ -351,6 +368,33 @@ describe("CommandBar pane and layout routes", () => {
 
     expect(created).toEqual([{ templateId: "optional-search-pane", options: undefined }]);
     expect(testSetup.captureCharFrame()).not.toContain("Create Pane");
+  });
+
+  test("keeps an optional ticker shortcut market-wide when a ticker is active", async () => {
+    const created: CreatedPaneCall[] = [];
+
+    testSetup = await testRender(<CommandBarHarness
+      query="OT"
+      selectedTicker="AAPL"
+      live
+      configurePluginRegistry={(pluginRegistry) => {
+        registerOptionalTickerPane(pluginRegistry);
+        recordPaneCreations(pluginRegistry, created);
+      }}
+    />, {
+      width: 100,
+      height: 18,
+    });
+
+    await testSetup.renderOnce();
+
+    await act(async () => {
+      testSetup!.mockInput.pressEnter();
+      await Bun.sleep(0);
+      await testSetup!.renderOnce();
+    });
+
+    expect(created).toEqual([{ templateId: "optional-ticker-pane", options: undefined }]);
   });
 
   for (const scenario of [

--- a/src/plugins/builtin/cds/index.tsx
+++ b/src/plugins/builtin/cds/index.tsx
@@ -3,11 +3,7 @@ import type { PluginModule } from "../plugin-module";
 import { CDS_PANE_ID } from "./model";
 import { CdsPane } from "./pane";
 
-/**
- * Only an explicit argument binds a ticker. `CDS` on its own is the
- * market-wide view, so it must not inherit the focused ticker the way the
- * shared ticker-surface templates do.
- */
+/** Only an explicit argument binds a ticker; bare `CDS` stays market-wide. */
 function explicitSymbol(options?: PaneTemplateCreateOptions): string | null {
   const raw = options?.symbol ?? options?.ticker?.metadata.ticker ?? options?.arg;
   return raw?.trim().toUpperCase() || null;
@@ -29,9 +25,7 @@ export const cdsModule: PluginModule = {
     label: "Single-Name CDS",
     description: "Single-name corporate CDS trade activity from DTCC public dissemination.",
     keywords: ["cds", "credit", "default", "swap", "single name", "issuer", "dtcc", "protection"],
-    // Deliberately "text": a "ticker" arg would resolve the focused ticker when
-    // the argument is omitted, and bare CDS must stay market-wide.
-    shortcut: { prefix: "CDS", argPlaceholder: "issuer", argKind: "text", argOptional: true },
+    shortcut: { prefix: "CDS", argPlaceholder: "ticker", argKind: "ticker", argOptional: true },
     createInstance: (_context, options) => {
       const symbol = explicitSymbol(options);
       return symbol

--- a/src/plugins/builtin/kelly-sizer/index.tsx
+++ b/src/plugins/builtin/kelly-sizer/index.tsx
@@ -30,7 +30,7 @@ export const positionSizerModule: PluginModule = {
       label: "Position Sizer",
       description: "Open Kelly-based position sizing for a ticker.",
       keywords: ["kelly", "position", "sizing", "risk", "bet", "portfolio"],
-      shortcut: { prefix: "KELLY", argPlaceholder: "ticker", argKind: "ticker", argOptional: true },
+      shortcut: { prefix: "KELLY", argPlaceholder: "ticker", argKind: "ticker" },
       canCreate: (context, options) => !!resolveTemplateSymbol(context, options),
       createInstance: (context, options) => {
         const symbol = resolveTemplateSymbol(context, options);


### PR DESCRIPTION
## Summary
- route `CDS <text>` through the standard ticker-search flow
- keep bare `CDS` market-wide even when another ticker is focused
- make optional ticker shortcuts consistently avoid implicit focused-ticker binding

## Verification
- 2312 full tests passed on the patch
- focused tests passed on current main
- all TypeScript targets passed
- tmux smoke verified `CDS Oracle` opens Security Description ticker results, including ORCL
- runtime warning scan and leak sweep clean