### PR TITLE
Make ticker pane links explicit

### DIFF
--- a/src/app/pane-runtime/index.tsx
+++ b/src/app/pane-runtime/index.tsx
@@ -11,6 +11,7 @@ import {
 import type { PluginRegistry } from "../../plugins/registry";
 import {
   getFocusedCollectionId,
+  resolveTickerForPane,
   syncConfigActiveLayoutState,
   type AppAction,
   type AppState,
@@ -75,7 +76,9 @@ export function useAppPaneRuntime({
 
   const persistLayout = useCallback((layout: LayoutConfig, options?: { pushHistory?: boolean; focusedPaneId?: string | null }) => {
     const currentState = stateRef.current;
-    const normalizedLayout = normalizePaneLayout(layout);
+    const normalizedLayout = normalizePaneLayout(layout, {
+      resolveOrphanSymbol: (instanceId) => resolveTickerForPane(currentState, instanceId),
+    });
     if (options?.pushHistory !== false) {
       dispatch({ type: "PUSH_LAYOUT_HISTORY" });
     }

--- a/src/app/pane-runtime/ticker-inspector-runtime.ts
+++ b/src/app/pane-runtime/ticker-inspector-runtime.ts
@@ -3,9 +3,12 @@ import {
   addPaneFloating,
   addPaneToLayout,
   findDockLeaf,
-  isPaneInLayout,
 } from "../../plugins/pane-manager";
 import type { PluginRegistry } from "../../plugins/registry";
+import {
+  findTickerResearchFollower,
+  listVisibleTickerSourcePanes,
+} from "../../plugins/ticker-navigation";
 import type {
   AppAction,
   AppState,
@@ -45,12 +48,25 @@ export function useAppTickerInspectorRuntime({
   pluginRegistry,
   state,
 }: UseAppTickerInspectorRuntimeOptions) {
+  // Only for APIs that must land in a collection (selecting a symbol inside a list).
   const resolveCollectionSourcePaneId = useCallback((preferredPaneId?: string | null) => {
     return resolveFollowBindingInstance(state.config.layout, preferredPaneId, isCollectionPaneInstance)?.instanceId
       ?? resolveFollowBindingInstance(state.config.layout, state.focusedPaneId, isCollectionPaneInstance)?.instanceId
       ?? findPrimaryPaneInstance(state.config.layout, "portfolio-list")?.instanceId
       ?? null;
   }, [state.config.layout, state.focusedPaneId]);
+
+  /** Any visible pane that publishes a cursor symbol can drive a follow binding. */
+  const resolveTickerSourcePaneId = useCallback((preferredPaneId?: string | null) => {
+    const isTickerSource = (instance: PaneInstanceConfig) => (
+      pluginRegistry.panes.get(instance.paneId)?.tickerSource === true
+    );
+    return resolveFollowBindingInstance(state.config.layout, preferredPaneId, isTickerSource)?.instanceId
+      ?? resolveFollowBindingInstance(state.config.layout, state.focusedPaneId, isTickerSource)?.instanceId
+      ?? findPrimaryPaneInstance(state.config.layout, "portfolio-list")?.instanceId
+      ?? listVisibleTickerSourcePanes(state.config.layout, pluginRegistry.panes)[0]?.instanceId
+      ?? null;
+  }, [pluginRegistry, state.config.layout, state.focusedPaneId]);
 
   const resolveTickerContextSourcePaneId = useCallback((preferredPaneId?: string | null) => {
     return resolveFollowBindingInstance(state.config.layout, preferredPaneId, isTickerContextPaneInstance)?.instanceId
@@ -67,12 +83,7 @@ export function useAppTickerInspectorRuntime({
   }, [dispatch, resolveCollectionSourcePaneId]);
 
   const resolveInspectorPane = useCallback((sourcePaneId: string): PaneInstanceConfig | null => {
-    return state.config.layout.instances.find((instance) =>
-      instance.paneId === TICKER_RESEARCH_PANE_ID
-      && instance.binding?.kind === "follow"
-      && instance.binding.sourceInstanceId === sourcePaneId
-      && isPaneInLayout(state.config.layout, instance.instanceId),
-    ) ?? null;
+    return findTickerResearchFollower(state.config.layout, sourcePaneId);
   }, [state.config.layout]);
 
   const ensureInspectorPane = useCallback((sourcePaneId: string) => {
@@ -104,7 +115,7 @@ export function useAppTickerInspectorRuntime({
       if (target?.paneId === TICKER_RESEARCH_PANE_ID) return target.instanceId;
       const focused = state.focusedPaneId ? resolvePaneInstance(state.config.layout, state.focusedPaneId) : null;
       if (focused?.paneId === TICKER_RESEARCH_PANE_ID) return focused.instanceId;
-      const sourcePaneId = resolveCollectionSourcePaneId(preferredPaneId);
+      const sourcePaneId = resolveTickerSourcePaneId(preferredPaneId);
       if (!sourcePaneId) return null;
       const ensured = ensureInspectorPane(sourcePaneId);
       if (!ensured) return null;
@@ -120,14 +131,14 @@ export function useAppTickerInspectorRuntime({
     dispatch,
     ensureInspectorPane,
     persistLayout,
-    resolveCollectionSourcePaneId,
+    resolveTickerSourcePaneId,
     state.config.layout,
     state.focusedPaneId,
   ]);
 
   const buildPaneBinding = useCallback((paneType: string, preferredPaneId?: string | null): PaneBinding | null => {
     if (normalizePaneId(paneType) === TICKER_RESEARCH_PANE_ID) {
-      const sourceInstanceId = resolveCollectionSourcePaneId(preferredPaneId);
+      const sourceInstanceId = resolveTickerSourcePaneId(preferredPaneId);
       return sourceInstanceId ? { kind: "follow", sourceInstanceId } : null;
     }
     if (isTickerPaneId(paneType)) {
@@ -135,12 +146,12 @@ export function useAppTickerInspectorRuntime({
       return sourceInstanceId ? { kind: "follow", sourceInstanceId } : null;
     }
     return { kind: "none" };
-  }, [resolveCollectionSourcePaneId, resolveTickerContextSourcePaneId]);
+  }, [resolveTickerContextSourcePaneId, resolveTickerSourcePaneId]);
 
   const showTickerResearchPane = useCallback(() => {
-    const sourcePaneId = resolveCollectionSourcePaneId();
+    const sourcePaneId = resolveTickerSourcePaneId();
     if (!sourcePaneId) {
-      notify("Open a collection pane first to inspect a ticker.");
+      notify("Open a ticker source pane first to inspect a ticker.");
       return;
     }
     const ensured = ensureInspectorPane(sourcePaneId);
@@ -154,7 +165,7 @@ export function useAppTickerInspectorRuntime({
     ensureInspectorPane,
     notify,
     persistLayout,
-    resolveCollectionSourcePaneId,
+    resolveTickerSourcePaneId,
     state.config.layout,
   ]);
 

--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -61,7 +61,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
     [config, paneState],
   );
   const title = instance && paneDef
-    ? getPaneDisplayTitle(titleState, instance, paneDef)
+    ? getPaneDisplayTitle(titleState, instance, paneDef, pluginRegistry.panes)
     : "Detached Pane";
   const focused = windowFocused;
 

--- a/src/components/layout/pane/title.ts
+++ b/src/components/layout/pane/title.ts
@@ -1,9 +1,16 @@
 import { resolveCollectionForPane, resolveTickerForPane, type AppState } from "../../../state/app/context";
-import { t } from "../../../i18n";
-import { TICKER_RESEARCH_PANE_ID, type PaneInstanceConfig } from "../../../types/config";
+import { t, tf } from "../../../i18n";
+import {
+  findPaneInstance,
+  TICKER_RESEARCH_PANE_ID,
+  type PaneInstanceConfig,
+} from "../../../types/config";
 import type { PaneDef } from "../../../types/plugin";
 
-export function getPaneDisplayTitle(
+/** Single-cell link glyph: emoji link icons render double-width in terminals. */
+const LINK_GLYPH = "\u29c9";
+
+function getBasePaneDisplayTitle(
   state: Pick<AppState, "config" | "paneState">,
   instance: PaneInstanceConfig,
   paneDef: PaneDef,
@@ -43,4 +50,22 @@ export function getPaneDisplayTitle(
 
   const ticker = resolveTickerForPane(state as AppState, instance.instanceId);
   return ticker ? `${t(paneDef.name)}: ${ticker}` : t(paneDef.name);
+}
+
+export function getPaneDisplayTitle(
+  state: Pick<AppState, "config" | "paneState">,
+  instance: PaneInstanceConfig,
+  paneDef: PaneDef,
+  panes?: ReadonlyMap<string, PaneDef>,
+): string {
+  const title = getBasePaneDisplayTitle(state, instance, paneDef);
+  if (instance.paneId !== TICKER_RESEARCH_PANE_ID || instance.binding?.kind !== "follow" || !panes) {
+    return title;
+  }
+
+  const source = findPaneInstance(state.config.layout, instance.binding.sourceInstanceId);
+  const sourceDef = source ? panes.get(source.paneId) : null;
+  if (!source || !sourceDef) return title;
+  const sourceTitle = getBasePaneDisplayTitle(state, source, sourceDef);
+  return `${title}  ${LINK_GLYPH} ${tf("Linked to {source}", { source: sourceTitle })}`;
 }

--- a/src/components/layout/pane/title.ts
+++ b/src/components/layout/pane/title.ts
@@ -38,6 +38,9 @@ export function getPaneDisplayTitle(
       ?? t(paneDef.name);
   }
 
+  // A source pane owns the cursor symbol; echoing it in its own title would just repeat the row.
+  if (paneDef.tickerSource) return t(paneDef.name);
+
   const ticker = resolveTickerForPane(state as AppState, instance.instanceId);
   return ticker ? `${t(paneDef.name)}: ${ticker}` : t(paneDef.name);
 }

--- a/src/components/layout/shell/index.test.tsx
+++ b/src/components/layout/shell/index.test.tsx
@@ -478,8 +478,8 @@ describe("Shell", () => {
 
     const frame = testSetup!.captureCharFrame();
     const rows = frame.split("\n");
-    expect(rows[2]?.indexOf("┌─:: Main Portfolio") ?? -1).toBeLessThan(0);
-    expect(rows[5]?.indexOf("┌─:: Main Portfolio")).toBeGreaterThanOrEqual(14);
+    expect(rows[2]?.indexOf(":: Main Portfolio") ?? -1).toBeLessThan(0);
+    expect(rows[5]?.indexOf(":: Main Portfolio")).toBeGreaterThanOrEqual(14);
 
     await act(async () => {
       await testSetup!.mockMouse.release(16, 6);

--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -37,6 +37,7 @@ import {
   menuForPane,
   menuItemsForFallback,
 } from "./menu";
+import { tickerLinkMenuItems } from "./ticker-link-menu";
 import {
   makeSnapGuides,
   resolveExternalDockPreview,
@@ -470,6 +471,13 @@ export function Shell({
       openPaneSettings,
       desktopWindowBridge,
       nativePaneChrome && rendererHost.copyPngImage ? copyPaneScreenshot : undefined,
+      tickerLinkMenuItems({
+        instance: pane.instance,
+        layout: visibleLayout,
+        panes: pluginRegistry.panes,
+        state: titleState,
+        persistLayout,
+      }),
     );
     void showContextMenu(context, items, event).then((shown) => {
       if (shown) return;
@@ -493,7 +501,7 @@ export function Shell({
         items: fallbackItems,
       });
     });
-  }, [contentHeight, copyPaneScreenshot, desktopWindowBridge, focusPane, getPaneTitle, nativePaneChrome, openPaneSettings, paneMap, persistLayout, pluginRegistry, rendererHost.copyPngImage, shortcutDisplayMode, showContextMenu, visibleLayout, width]);
+  }, [contentHeight, copyPaneScreenshot, desktopWindowBridge, focusPane, getPaneTitle, nativePaneChrome, openPaneSettings, paneMap, persistLayout, pluginRegistry, rendererHost.copyPngImage, shortcutDisplayMode, showContextMenu, titleState, visibleLayout, width]);
 
   const {
     handleFloatingCloseMouseDown,

--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -424,8 +424,8 @@ export function Shell({
     [config, paneState],
   );
   const getPaneTitle = useCallback(
-    (pane: ResolvedPane): string => getPaneDisplayTitle(titleState, pane.instance, pane.def),
-    [titleState],
+    (pane: ResolvedPane): string => getPaneDisplayTitle(titleState, pane.instance, pane.def, pluginRegistry.panes),
+    [pluginRegistry.panes, titleState],
   );
   const handlePaneQuickSetting = useCallback((paneId: string, key: string, event: any) => {
     event?.preventDefault?.();

--- a/src/components/layout/shell/menu.ts
+++ b/src/components/layout/shell/menu.ts
@@ -32,6 +32,7 @@ export function menuForPane(
   openPaneSettings: (paneId: string) => void,
   desktopWindowBridge?: DesktopWindowBridge,
   copyPaneScreenshot?: (paneId: string) => void | Promise<void>,
+  linkItems: ContextMenuItem[] = [],
 ): ContextMenuItem[] {
   const baseActions: ContextMenuItem[] = [];
   if (pluginRegistry.hasPaneSettings(pane.instance.instanceId)) {
@@ -90,6 +91,10 @@ export function menuForPane(
     accelerator: PANE_MANAGEMENT_ACCELERATORS.close,
     onSelect: () => persistLayout(removePane(layout, pane.instance.instanceId)),
   });
+
+  if (linkItems.length > 0) {
+    baseActions.push(contextMenuDivider("pane:link-divider"), ...linkItems);
+  }
 
   baseActions.push(
     contextMenuDivider("pane:layout-divider"),

--- a/src/components/layout/shell/ticker-link-menu.test.ts
+++ b/src/components/layout/shell/ticker-link-menu.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { createInitialState } from "../../../state/app/context";
+import {
+  createDefaultConfig,
+  createPaneInstance,
+  findPaneInstance,
+  TICKER_RESEARCH_PANE_ID,
+  type LayoutConfig,
+} from "../../../types/config";
+import type { PaneDef } from "../../../types/plugin";
+import { tickerLinkMenuItems } from "./ticker-link-menu";
+
+const panes = new Map<string, PaneDef>([
+  ["portfolio-list", {
+    id: "portfolio-list",
+    name: "Portfolio",
+    component: () => null,
+    defaultPosition: "left",
+    tickerSource: true,
+  }],
+  [TICKER_RESEARCH_PANE_ID, {
+    id: TICKER_RESEARCH_PANE_ID,
+    name: "Ticker Research",
+    component: () => null,
+    defaultPosition: "right",
+  }],
+]);
+
+describe("tickerLinkMenuItems", () => {
+  test("pins the current ticker when unlinking and can link back to the source", () => {
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-link-menu-test"));
+    state.paneState["portfolio-list:main"] = { collectionId: "main", cursorSymbol: "AAPL" };
+    const target = findPaneInstance(state.config.layout, "ticker-detail:main")!;
+    let layout: LayoutConfig = state.config.layout;
+
+    tickerLinkMenuItems({
+      instance: target,
+      layout,
+      panes,
+      state,
+      persistLayout: (nextLayout) => { layout = nextLayout; },
+    }).find((item) => item.id === "unlink:portfolio-list:main")?.onSelect?.();
+
+    const pinned = findPaneInstance(layout, target.instanceId)!;
+    expect(pinned.binding).toEqual({ kind: "fixed", symbol: "AAPL" });
+
+    const previousFollower = createPaneInstance(TICKER_RESEARCH_PANE_ID, {
+      instanceId: "ticker-detail:previous",
+      binding: { kind: "follow", sourceInstanceId: "portfolio-list:main" },
+    });
+    layout = {
+      ...layout,
+      instances: [...layout.instances, previousFollower],
+      floating: [
+        ...layout.floating,
+        { instanceId: previousFollower.instanceId, x: 1, y: 1, width: 40, height: 12 },
+      ],
+    };
+    const pinnedState = { ...state, config: { ...state.config, layout } };
+    tickerLinkMenuItems({
+      instance: pinned,
+      layout,
+      panes,
+      state: pinnedState,
+      persistLayout: (nextLayout) => { layout = nextLayout; },
+    }).find((item) => item.id === "link:portfolio-list:main")?.onSelect?.();
+
+    expect(findPaneInstance(layout, target.instanceId)?.binding).toEqual({
+      kind: "follow",
+      sourceInstanceId: "portfolio-list:main",
+    });
+    expect(findPaneInstance(layout, previousFollower.instanceId)?.binding).toEqual({
+      kind: "fixed",
+      symbol: "AAPL",
+    });
+  });
+});

--- a/src/components/layout/shell/ticker-link-menu.test.ts
+++ b/src/components/layout/shell/ticker-link-menu.test.ts
@@ -8,6 +8,7 @@ import {
   type LayoutConfig,
 } from "../../../types/config";
 import type { PaneDef } from "../../../types/plugin";
+import { getPaneDisplayTitle } from "../pane/title";
 import { tickerLinkMenuItems } from "./ticker-link-menu";
 
 const panes = new Map<string, PaneDef>([
@@ -32,6 +33,10 @@ describe("tickerLinkMenuItems", () => {
     state.paneState["portfolio-list:main"] = { collectionId: "main", cursorSymbol: "AAPL" };
     const target = findPaneInstance(state.config.layout, "ticker-detail:main")!;
     let layout: LayoutConfig = state.config.layout;
+
+    expect(getPaneDisplayTitle(state, target, panes.get(TICKER_RESEARCH_PANE_ID)!, panes)).toBe(
+      "AAPL  ⧉ Linked to Main Portfolio",
+    );
 
     tickerLinkMenuItems({
       instance: target,

--- a/src/components/layout/shell/ticker-link-menu.ts
+++ b/src/components/layout/shell/ticker-link-menu.ts
@@ -55,7 +55,7 @@ export function tickerLinkMenuItems({
   return listVisibleTickerSourcePanes(layout, panes).flatMap((source): ContextMenuItem[] => {
     const paneDef = panes.get(source.paneId);
     if (!paneDef) return [];
-    const title = getPaneDisplayTitle(state, source, paneDef);
+    const title = getPaneDisplayTitle(state, source, paneDef, panes);
 
     if (source.instanceId !== sourceInstanceId) {
       return [{

--- a/src/components/layout/shell/ticker-link-menu.ts
+++ b/src/components/layout/shell/ticker-link-menu.ts
@@ -1,0 +1,78 @@
+import { updatePaneInstance } from "../../../pane-settings";
+import { listVisibleTickerSourcePanes } from "../../../plugins/ticker-navigation";
+import { resolveTickerForPane, type AppState } from "../../../state/app/context";
+import {
+  TICKER_RESEARCH_PANE_ID,
+  type LayoutConfig,
+  type PaneInstanceConfig,
+} from "../../../types/config";
+import type { ContextMenuItem } from "../../../types/context-menu";
+import type { PaneDef } from "../../../types/plugin";
+import { getPaneDisplayTitle } from "../pane/title";
+
+/**
+ * Flat link controls for a Ticker Research pane: one entry per visible ticker source, plus an
+ * unlink entry that pins the pane on the symbol it currently shows.
+ */
+export function tickerLinkMenuItems({
+  instance,
+  layout,
+  panes,
+  state,
+  persistLayout,
+}: {
+  instance: PaneInstanceConfig;
+  layout: LayoutConfig;
+  panes: ReadonlyMap<string, PaneDef>;
+  state: Pick<AppState, "config" | "paneState">;
+  persistLayout: (nextLayout: LayoutConfig) => void;
+}): ContextMenuItem[] {
+  if (instance.paneId !== TICKER_RESEARCH_PANE_ID) return [];
+
+  const sourceInstanceId = instance.binding?.kind === "follow" ? instance.binding.sourceInstanceId : null;
+  const rebind = (binding: PaneInstanceConfig["binding"]) => {
+    persistLayout(updatePaneInstance(layout, instance.instanceId, (current) => ({ ...current, binding })));
+  };
+  const linkToSource = (nextSourceId: string) => {
+    persistLayout({
+      ...layout,
+      instances: layout.instances.map((current) => {
+        if (current.instanceId === instance.instanceId) {
+          return { ...current, binding: { kind: "follow" as const, sourceInstanceId: nextSourceId } };
+        }
+        if (
+          current.paneId !== TICKER_RESEARCH_PANE_ID
+          || current.binding?.kind !== "follow"
+          || current.binding.sourceInstanceId !== nextSourceId
+        ) return current;
+
+        const symbol = resolveTickerForPane(state as AppState, current.instanceId);
+        return { ...current, binding: symbol ? { kind: "fixed" as const, symbol } : { kind: "none" as const } };
+      }),
+    });
+  };
+
+  return listVisibleTickerSourcePanes(layout, panes).flatMap((source): ContextMenuItem[] => {
+    const paneDef = panes.get(source.paneId);
+    if (!paneDef) return [];
+    const title = getPaneDisplayTitle(state, source, paneDef);
+
+    if (source.instanceId !== sourceInstanceId) {
+      return [{
+        id: `link:${source.instanceId}`,
+        label: `Link to ${title}`,
+        onSelect: () => linkToSource(source.instanceId),
+      }];
+    }
+
+    // Unlinking keeps the pane alive, so it only works once a symbol has resolved.
+    const symbol = resolveTickerForPane(state as AppState, instance.instanceId);
+    return symbol
+      ? [{
+        id: `unlink:${source.instanceId}`,
+        label: `Unlink from ${title}`,
+        onSelect: () => rebind({ kind: "fixed", symbol }),
+      }]
+      : [];
+  });
+}

--- a/src/core/state/app/layout.ts
+++ b/src/core/state/app/layout.ts
@@ -118,15 +118,17 @@ function getPaneState(state: Pick<AppState, "paneState">, paneId: string): PaneR
   return state.paneState[paneId] ?? {};
 }
 
+/**
+ * Any pane that publishes `cursorSymbol` in its pane state is a ticker source; every other pane
+ * resolves through its binding, so follow chains keep working across source types.
+ */
 export function resolveTickerForPane(state: AppState, paneId: string, seen = new Set<string>()): string | null {
   if (seen.has(paneId)) return null;
   seen.add(paneId);
   const instance = findPaneInstance(state.config.layout, paneId);
   if (!instance) return null;
-  if (instance.paneId === "portfolio-list") {
-    const paneState = getPaneState(state, paneId);
-    return typeof paneState.cursorSymbol === "string" ? paneState.cursorSymbol : null;
-  }
+  const cursorSymbol = getPaneState(state, paneId).cursorSymbol;
+  if (typeof cursorSymbol === "string" && cursorSymbol.trim()) return cursorSymbol;
   return resolveTickerFromBinding(state, instance.binding, seen);
 }
 
@@ -388,7 +390,10 @@ export function withFocusedPane(
     activePanel?: "left" | "right";
   } = {},
 ): AppState {
-  const normalizedLayout = normalizePaneLayout(config.layout);
+  const normalizedLayout = normalizePaneLayout(config.layout, {
+    // Keep a follower alive on its last symbol when its source pane is gone.
+    resolveOrphanSymbol: (instanceId) => resolveTickerForPane(state, instanceId),
+  });
   const nextConfig = normalizedLayout === config.layout
     ? config
     : {

--- a/src/data/config/layout.ts
+++ b/src/data/config/layout.ts
@@ -220,6 +220,7 @@ export function sanitizeLayout(
     const layout = cloneLayout(fallback);
     return normalizePaneLayout(layout, {
       defaultFollowSourceInstanceId: getDefaultFollowSourceInstanceId(layout.instances),
+      resolveOrphanSymbol: () => null,
     });
   }
 
@@ -242,5 +243,6 @@ export function sanitizeLayout(
 
   return normalizePaneLayout(layout, {
     defaultFollowSourceInstanceId: getDefaultFollowSourceInstanceId(layout.instances),
+    resolveOrphanSymbol: () => null,
   });
 }

--- a/src/data/config/store/index.test.ts
+++ b/src/data/config/store/index.test.ts
@@ -118,7 +118,7 @@ describe("sanitizeLayout", () => {
     expect(getDockedPaneIds(layout)).toEqual(["portfolio-list:main", "ticker-detail:main"]);
   });
 
-  test("removes follow panes whose source pane is missing", () => {
+  test("keeps a ticker research pane safely unlinked when its source is missing", () => {
     const layout = sanitizeLayout({
       dockRoot: { kind: "pane", instanceId: "ticker-detail:main" },
       instances: [
@@ -132,9 +132,8 @@ describe("sanitizeLayout", () => {
       detached: [],
     }, DEFAULT_LAYOUT);
 
-    expect(findPaneInstance(layout, "ticker-detail:main")).toBeUndefined();
-    expect(getDockedPaneIds(layout)).toHaveLength(0);
-    expect(layout.dockRoot).toBeNull();
+    expect(findPaneInstance(layout, "ticker-detail:main")?.binding).toEqual({ kind: "none" });
+    expect(getDockedPaneIds(layout)).toEqual(["ticker-detail:main"]);
   });
 
   test("clamps floating placement memory and drops invalid docked placement hints", () => {

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -13,6 +13,7 @@ export const es: Record<string, string> = {
   "Cancel": "Cancelar",
   "Close": "Cerrar",
   "Open": "Abrir",
+  "Linked to {source}": "Vinculado a {source}",
   "Working…": "Procesando…",
   "Searching…": "Buscando…",
   "Loading...": "Cargando...",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -13,6 +13,7 @@ export const ja: Record<string, string> = {
   "Cancel": "キャンセル",
   "Close": "閉じる",
   "Open": "開く",
+  "Linked to {source}": "{source} にリンク中",
   "Working…": "処理中…",
   "Searching…": "検索中…",
   "Loading...": "読み込み中...",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -11,6 +11,7 @@ export const ko: Record<string, string> = {
   "Cancel": "취소",
   "Close": "닫기",
   "Open": "열기",
+  "Linked to {source}": "{source}에 연결됨",
   "Working…": "처리 중…",
   "Searching…": "검색 중…",
   "Loading...": "불러오는 중...",

--- a/src/i18n/zh-cn.ts
+++ b/src/i18n/zh-cn.ts
@@ -13,6 +13,7 @@ export const zhCN: Record<string, string> = {
   "Cancel": "取消",
   "Close": "关闭",
   "Open": "打开",
+  "Linked to {source}": "已链接到 {source}",
   "Working…": "处理中…",
   "Searching…": "搜索中…",
   "Loading...": "加载中...",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -13,6 +13,7 @@ export const zhTW: Record<string, string> = {
   "Cancel": "取消",
   "Close": "關閉",
   "Open": "開啟",
+  "Linked to {source}": "已連結至 {source}",
   "Working…": "處理中…",
   "Searching…": "搜尋中…",
   "Loading...": "載入中...",

--- a/src/plugins/builtin/ai/index.tsx
+++ b/src/plugins/builtin/ai/index.tsx
@@ -335,6 +335,7 @@ export const aiPlugin: GloomPlugin = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 76, height: 24 },
+      tickerSource: true,
       quickSettings: [LIVE_STREAMING_QUICK_SETTING],
       settings: (context) => {
         const providers = detectProviders();

--- a/src/plugins/builtin/ai/screener/pane.tsx
+++ b/src/plugins/builtin/ai/screener/pane.tsx
@@ -1,20 +1,20 @@
 import { Box, Text } from "../../../../ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PaneProps } from "../../../../types/plugin";
-import { TICKER_RESEARCH_PANE_ID } from "../../../../types/config";
 import {
   useAppDispatch,
   useAppSelector,
   usePaneInstance,
   usePaneInstanceId,
+  usePaneStateValue,
 } from "../../../../state/app/context";
 import {
   useAssetData,
   usePluginConfigState,
   usePluginPaneState,
   usePluginState,
-  usePluginTickerActions,
 } from "../../../runtime";
+import { useTickerSourceActivate } from "../../shared/ticker-source";
 import { type DataTableKeyEvent } from "../../../../components";
 import { colors } from "../../../../theme/colors";
 import { t } from "../../../../i18n";
@@ -57,7 +57,7 @@ import { useLiveStreamingSetting } from "../../shared/live-streaming";
 
 export function AiScreenerPane({ focused, width, height }: PaneProps) {
   const dataProvider = useAssetData();
-  const { pinTicker } = usePluginTickerActions();
+  const activateTicker = useTickerSourceActivate();
   const paneId = usePaneInstanceId();
   const paneInstance = usePaneInstance();
   const liveStreaming = useLiveStreamingSetting();
@@ -85,7 +85,8 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
     { schemaVersion: 1 },
   );
   const [activeTabId, setActiveTabId] = usePluginPaneState<string | null>("activeTabId", null);
-  const [cursorSymbol, setCursorSymbol] = usePluginPaneState<string | null>("cursorSymbol", null);
+  // Top-level pane state, not plugin-scoped: this is what follower panes resolve.
+  const [cursorSymbol, setCursorSymbol] = usePaneStateValue<string | null>("cursorSymbol", null);
   const [sorts, setSorts] = usePluginPaneState<Record<string, ScreenerSortPreference>>("sorts", {});
   const [now, setNow] = useState(Date.now());
   const initializedRef = useRef(false);
@@ -301,12 +302,9 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
     if (!isEnter || !cursorSymbol) return false;
     event.preventDefault?.();
     event.stopPropagation?.();
-    pinTicker(cursorSymbol, {
-      floating: !!event.shift,
-      paneType: TICKER_RESEARCH_PANE_ID,
-    });
+    activateTicker(cursorSymbol, { floating: !!event.shift, newPane: !!event.shift });
     return true;
-  }, [cursorSymbol, pinTicker]);
+  }, [activateTicker, cursorSymbol]);
 
   const contentHeight = Math.max(height - 3, 4);
   const editorProvider = editorState ? getAiProvider(editorState.providerId, providers) : null;
@@ -406,7 +404,8 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
           onHeaderClick={handleHeaderClick}
           onRootKeyDown={handleTableKeyDown}
           onRowActivate={(ticker) => {
-            pinTicker(ticker.metadata.ticker, { floating: true, paneType: TICKER_RESEARCH_PANE_ID });
+            setCursorSymbol(ticker.metadata.ticker);
+            activateTicker(ticker.metadata.ticker, { floating: true });
           }}
         />
       )}

--- a/src/plugins/builtin/portfolio-list/index.tsx
+++ b/src/plugins/builtin/portfolio-list/index.tsx
@@ -47,6 +47,7 @@ export const portfolioListModule: PluginModule = {
       defaultPosition: "left",
       defaultMode: "floating",
       defaultWidth: "40%",
+      tickerSource: true,
       quickSettings: [LIVE_STREAMING_QUICK_SETTING],
       settings: (context) => withLiveStreamingSetting(
         buildPortfolioPaneSettingsDef(

--- a/src/plugins/builtin/portfolio-list/pane/index.tsx
+++ b/src/plugins/builtin/portfolio-list/pane/index.tsx
@@ -6,7 +6,7 @@ import {
   type DataTableKeyEvent,
   type TickerListVisibleRange,
 } from "../../../../components";
-import { usePluginTickerActions } from "../../../runtime";
+import { useTickerSourceActivate } from "../../shared/ticker-source";
 import { useFxRatesMap, useTickerFinancialsMap } from "../../../../market-data/hooks";
 import { useAppActive } from "../../../../state/app/activity";
 import {
@@ -20,7 +20,6 @@ import {
 import { selectEffectiveExchangeRates } from "../../../../utils/exchange-rate-map";
 import type { TickerRecord } from "../../../../types/ticker";
 import type { PaneProps } from "../../../../types/plugin";
-import { TICKER_RESEARCH_PANE_ID } from "../../../../types/config";
 import { calculatePortfolioSummaryTotals, resolveCollectionSortPreference, type ColumnContext } from "../metrics";
 import {
   PortfolioCashMarginDrawer,
@@ -55,7 +54,7 @@ import { useLiveStreamingSetting } from "../../shared/live-streaming";
 import { useThrottledTickerOrder } from "../use-throttled-ticker-order";
 
 export function PortfolioListPane({ focused, width, height }: PaneProps) {
-  const { pinTicker } = usePluginTickerActions();
+  const activateTicker = useTickerSourceActivate();
   const paneInstance = usePaneInstance();
   const appActive = useAppActive();
   const config = useAppSelector((state) => state.config);
@@ -238,9 +237,9 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     setSortPreference({ columnId, direction: "asc" });
   }, [activeSort.columnId, activeSort.direction, setSortPreference]);
 
-  const openTickerFloating = useCallback((symbol: string) => {
-    pinTicker(symbol, { floating: true, paneType: TICKER_RESEARCH_PANE_ID });
-  }, [pinTicker]);
+  const openTickerFloating = useCallback((symbol: string, options?: { newPane?: boolean }) => {
+    activateTicker(symbol, { floating: true, newPane: options?.newPane });
+  }, [activateTicker]);
 
   const toggleViewMode = useCallback(() => {
     if (!isPortfolioTab) return;
@@ -266,7 +265,8 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
       event.stopPropagation?.();
       const ticker = sortedTickers[safeSelectedIdx];
       if (ticker) {
-        openTickerFloating(ticker.metadata.ticker);
+        flushCursorSymbol(ticker.metadata.ticker);
+        openTickerFloating(ticker.metadata.ticker, { newPane: true });
       }
       return true;
     }
@@ -288,6 +288,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
     return false;
   }, [
     cashDrawerExpanded,
+    flushCursorSymbol,
     focused,
     isPortfolioTab,
     openTickerFloating,

--- a/src/plugins/builtin/shared/ticker-source.ts
+++ b/src/plugins/builtin/shared/ticker-source.ts
@@ -1,0 +1,32 @@
+import { useCallback } from "react";
+import { useAppStateRef, usePaneInstanceId } from "../../../state/app/context";
+import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
+import { resolveTickerActivation } from "../../ticker-navigation";
+import { usePluginAppActions, usePluginTickerActions } from "../../runtime";
+
+/**
+ * Shared Enter routing for panes that publish a cursor symbol: reuse the Ticker Research pane
+ * already bound to this one instead of stacking another pane on top of it.
+ */
+export function useTickerSourceActivate(): (
+  symbol: string,
+  options?: { newPane?: boolean; floating?: boolean },
+) => void {
+  const paneId = usePaneInstanceId();
+  const stateRef = useAppStateRef();
+  const { pinTicker } = usePluginTickerActions();
+  const { focusPane } = usePluginAppActions();
+
+  return useCallback((symbol: string, options?: { newPane?: boolean; floating?: boolean }) => {
+    const activation = resolveTickerActivation(stateRef.current.config.layout, paneId, options);
+    if (activation.kind === "focus") {
+      focusPane(activation.paneId);
+      return;
+    }
+    pinTicker(symbol, {
+      floating: options?.floating ?? true,
+      forceNewPane: options?.newPane,
+      paneType: TICKER_RESEARCH_PANE_ID,
+    });
+  }, [focusPane, paneId, pinTicker, stateRef]);
+}

--- a/src/plugins/builtin/ticker-detail/pane.tsx
+++ b/src/plugins/builtin/ticker-detail/pane.tsx
@@ -11,6 +11,8 @@ import {
   usePaneStateValue,
   usePaneTicker,
 } from "../../../state/app/context";
+import { findPaneInstance } from "../../../types/config";
+import { getPaneDisplayTitle } from "../../../components/layout/pane/title";
 import { useQuoteUpdates } from "../../../state/hooks/quote-streaming";
 import { getCollectionName, getCollectionTickerCount } from "../../../state/selectors";
 import { getSharedRegistry } from "../../registry";
@@ -28,6 +30,8 @@ import { useCloudAccessFooter } from "../shared/cloud-upgrade";
 import { CLOUD_QUOTE_DELAY_MINUTES } from "../shared/plan-access";
 
 const TICKER_RESEARCH_TAB_COMMIT_DELAY_MS = 120;
+/** Single-cell chain glyph: emoji link icons render double-width in terminals. */
+const LINK_GLYPH = "\u29c9";
 
 function sameStringSet(left: Set<string>, right: Set<string>): boolean {
   if (left.size !== right.size) return false;
@@ -117,6 +121,32 @@ export function TickerResearchPane({ focused, width, height }: PaneProps) {
     "ticker-research-access",
     () => cloudAccess.segment ? { info: [cloudAccess.segment], order: -1 } : null,
     [cloudAccess.segment],
+  );
+
+  const linkedSourcePaneId = paneInstance?.binding?.kind === "follow"
+    ? paneInstance.binding.sourceInstanceId
+    : null;
+  const linkedSourceTitle = useAppSelector((state) => {
+    const source = linkedSourcePaneId ? findPaneInstance(state.config.layout, linkedSourcePaneId) : null;
+    const sourceDef = source ? getSharedRegistry()?.panes.get(source.paneId) : null;
+    return source && sourceDef ? getPaneDisplayTitle(state, source, sourceDef) : null;
+  });
+  usePaneFooter(
+    "ticker-research-link",
+    () => (linkedSourcePaneId && linkedSourceTitle
+      ? {
+        order: -2,
+        info: [{
+          id: "ticker-research-link",
+          parts: [
+            { text: LINK_GLYPH, tone: "muted" },
+            { text: tf("Linked to {source}", { source: linkedSourceTitle }), tone: "label" },
+          ],
+          onPress: () => dispatch({ type: "FOCUS_PANE", paneId: linkedSourcePaneId }),
+        }],
+      }
+      : null),
+    [dispatch, linkedSourcePaneId, linkedSourceTitle],
   );
 
   const disabledPlugins = config.disabledPlugins;

--- a/src/plugins/builtin/ticker-detail/pane.tsx
+++ b/src/plugins/builtin/ticker-detail/pane.tsx
@@ -11,8 +11,6 @@ import {
   usePaneStateValue,
   usePaneTicker,
 } from "../../../state/app/context";
-import { findPaneInstance } from "../../../types/config";
-import { getPaneDisplayTitle } from "../../../components/layout/pane/title";
 import { useQuoteUpdates } from "../../../state/hooks/quote-streaming";
 import { getCollectionName, getCollectionTickerCount } from "../../../state/selectors";
 import { getSharedRegistry } from "../../registry";
@@ -30,8 +28,6 @@ import { useCloudAccessFooter } from "../shared/cloud-upgrade";
 import { CLOUD_QUOTE_DELAY_MINUTES } from "../shared/plan-access";
 
 const TICKER_RESEARCH_TAB_COMMIT_DELAY_MS = 120;
-/** Single-cell chain glyph: emoji link icons render double-width in terminals. */
-const LINK_GLYPH = "\u29c9";
 
 function sameStringSet(left: Set<string>, right: Set<string>): boolean {
   if (left.size !== right.size) return false;
@@ -121,32 +117,6 @@ export function TickerResearchPane({ focused, width, height }: PaneProps) {
     "ticker-research-access",
     () => cloudAccess.segment ? { info: [cloudAccess.segment], order: -1 } : null,
     [cloudAccess.segment],
-  );
-
-  const linkedSourcePaneId = paneInstance?.binding?.kind === "follow"
-    ? paneInstance.binding.sourceInstanceId
-    : null;
-  const linkedSourceTitle = useAppSelector((state) => {
-    const source = linkedSourcePaneId ? findPaneInstance(state.config.layout, linkedSourcePaneId) : null;
-    const sourceDef = source ? getSharedRegistry()?.panes.get(source.paneId) : null;
-    return source && sourceDef ? getPaneDisplayTitle(state, source, sourceDef) : null;
-  });
-  usePaneFooter(
-    "ticker-research-link",
-    () => (linkedSourcePaneId && linkedSourceTitle
-      ? {
-        order: -2,
-        info: [{
-          id: "ticker-research-link",
-          parts: [
-            { text: LINK_GLYPH, tone: "muted" },
-            { text: tf("Linked to {source}", { source: linkedSourceTitle }), tone: "label" },
-          ],
-          onPress: () => dispatch({ type: "FOCUS_PANE", paneId: linkedSourcePaneId }),
-        }],
-      }
-      : null),
-    [dispatch, linkedSourcePaneId, linkedSourceTitle],
   );
 
   const disabledPlugins = config.disabledPlugins;

--- a/src/plugins/ticker-navigation.test.ts
+++ b/src/plugins/ticker-navigation.test.ts
@@ -7,6 +7,8 @@ import {
 } from "../types/config";
 import {
   findFixedTickerPaneForSymbol,
+  findTickerResearchFollower,
+  resolveTickerActivation,
   resolveTickerNavigationReplacementPane,
   shouldFocusTickerNavigationTarget,
 } from "./ticker-navigation";
@@ -25,6 +27,28 @@ function createLayout(instances: PaneInstanceConfig[]): LayoutConfig {
     detached: [],
   };
 }
+
+describe("ticker source activation", () => {
+  test("focuses a bound follower unless the caller asks for a new pane", () => {
+    const layout = createLayout([
+      createPaneInstance("portfolio-list", {
+        instanceId: "portfolio-list:main",
+        binding: { kind: "none" },
+      }),
+      createPaneInstance("ticker-detail", {
+        instanceId: "ticker-detail:main",
+        binding: { kind: "follow", sourceInstanceId: "portfolio-list:main" },
+      }),
+    ]);
+
+    expect(findTickerResearchFollower(layout, "portfolio-list:main")?.instanceId).toBe("ticker-detail:main");
+    expect(resolveTickerActivation(layout, "portfolio-list:main")).toEqual({
+      kind: "focus",
+      paneId: "ticker-detail:main",
+    });
+    expect(resolveTickerActivation(layout, "portfolio-list:main", { newPane: true })).toEqual({ kind: "open" });
+  });
+});
 
 describe("resolveTickerNavigationReplacementPane", () => {
   test("only replaces the Ticker Research pane that opened ticker navigation", () => {

--- a/src/plugins/ticker-navigation.ts
+++ b/src/plugins/ticker-navigation.ts
@@ -5,7 +5,47 @@ import {
   type LayoutConfig,
   type PaneInstanceConfig,
 } from "../types/config";
+import type { PaneDef } from "../types/plugin";
 import { isPaneInLayout } from "./pane-manager";
+
+/** Panes that publish a cursor symbol other panes can follow (`PaneDef.tickerSource`). */
+export function listVisibleTickerSourcePanes(
+  layout: LayoutConfig,
+  panes: ReadonlyMap<string, PaneDef>,
+): PaneInstanceConfig[] {
+  return layout.instances.filter((instance) => (
+    panes.get(instance.paneId)?.tickerSource === true
+    && isPaneInLayout(layout, instance.instanceId)
+  ));
+}
+
+/** The visible Ticker Research pane that follows `sourceInstanceId`, if any. */
+export function findTickerResearchFollower(
+  layout: LayoutConfig,
+  sourceInstanceId: string | null | undefined,
+): PaneInstanceConfig | null {
+  if (!sourceInstanceId) return null;
+  return layout.instances.find((instance) =>
+    instance.paneId === TICKER_RESEARCH_PANE_ID
+    && instance.binding?.kind === "follow"
+    && instance.binding.sourceInstanceId === sourceInstanceId
+    && isPaneInLayout(layout, instance.instanceId)
+  ) ?? null;
+}
+
+/**
+ * Enter opens the follower already bound to the source pane; Shift+Enter (`newPane`) and sources
+ * without a follower fall back to opening a ticker pane.
+ */
+export function resolveTickerActivation(
+  layout: LayoutConfig,
+  sourcePaneId: string | null | undefined,
+  options?: { newPane?: boolean },
+): { kind: "focus"; paneId: string } | { kind: "open" } {
+  if (options?.newPane) return { kind: "open" };
+  const follower = findTickerResearchFollower(layout, sourcePaneId);
+  return follower ? { kind: "focus", paneId: follower.instanceId } : { kind: "open" };
+}
 
 export function resolveTickerNavigationReplacementPane(
   layout: LayoutConfig,

--- a/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
+++ b/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
@@ -546,7 +546,7 @@ function ShotPane({ payload }: { payload: CliPaneShotPayload }) {
     config: payload.config,
     paneState: payload.paneState,
   } as Pick<AppState, "config" | "paneState">;
-  const title = getPaneDisplayTitle(titleState, instance, pane);
+  const title = getPaneDisplayTitle(titleState, instance, pane, shotRegistry?.panes);
   const width = payload.widthCells;
   const height = payload.heightCells;
   const bodyFrame = resolvePaneBodyFrame({

--- a/src/state/app/bootstrap.ts
+++ b/src/state/app/bootstrap.ts
@@ -105,13 +105,12 @@ function resolveSymbolForPane(
   const instance = findPaneInstance(config.layout, instanceId);
   if (!instance) return null;
 
-  if (instance.paneId === "portfolio-list") {
-    const cursor = paneStateSeed[instanceId]?.cursorSymbol
-      ?? (typeof sessionSnapshot?.paneState?.[instanceId]?.cursorSymbol === "string"
-        ? sessionSnapshot.paneState[instanceId]?.cursorSymbol as string
-        : null);
-    return cursor && tickerMap.has(cursor) ? cursor : null;
-  }
+  // Any pane can publish a cursor symbol; followers resolve through it.
+  const cursor = paneStateSeed[instanceId]?.cursorSymbol
+    ?? (typeof sessionSnapshot?.paneState?.[instanceId]?.cursorSymbol === "string"
+      ? sessionSnapshot.paneState[instanceId]?.cursorSymbol as string
+      : null);
+  if (cursor) return tickerMap.has(cursor) ? cursor : null;
 
   if (instance.binding?.kind === "fixed") {
     return tickerMap.has(instance.binding.symbol) ? instance.binding.symbol : null;

--- a/src/state/app/context/index.test.ts
+++ b/src/state/app/context/index.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { appReducer, createInitialState, resolveCollectionForPane, resolveTickerForPane } from "./index";
-import { cloneLayout, createDefaultConfig, createPaneInstance } from "../../../types/config";
+import { cloneLayout, createDefaultConfig, createPaneInstance, findPaneInstance } from "../../../types/config";
 import type { AppSessionSnapshot } from "../../../core/state/session-persistence";
+import { removePane } from "../../../plugins/pane-manager";
 import { buildBrokerPortfolioId } from "../../../utils/broker-instances";
 
 describe("resolveTickerForPane", () => {
@@ -16,6 +17,45 @@ describe("resolveTickerForPane", () => {
 
     expect(resolveTickerForPane(state, "portfolio-list:main")).toBe("AAPL");
     expect(resolveTickerForPane(state, "ticker-detail:main")).toBe("AAPL");
+  });
+
+  test("follows cursor symbols from any ticker source pane", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    const source = createPaneInstance("ai-screener", {
+      instanceId: "ai-screener:main",
+      binding: { kind: "none" },
+    });
+    const follower = createPaneInstance("ticker-detail", {
+      instanceId: "ticker-detail:screener",
+      binding: { kind: "follow", sourceInstanceId: source.instanceId },
+    });
+    config.layout.instances.push(source, follower);
+    config.layout.floating.push(
+      { instanceId: source.instanceId, x: 0, y: 0, width: 40, height: 12 },
+      { instanceId: follower.instanceId, x: 1, y: 1, width: 40, height: 12 },
+    );
+
+    const state = createInitialState(config);
+    state.paneState[source.instanceId] = { cursorSymbol: "NVDA" };
+
+    expect(resolveTickerForPane(state, source.instanceId)).toBe("NVDA");
+    expect(resolveTickerForPane(state, follower.instanceId)).toBe("NVDA");
+  });
+
+  test("pins a follower to its last ticker when its source closes", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    const state = createInitialState(config);
+    state.paneState["portfolio-list:main"] = { collectionId: "main", cursorSymbol: "AAPL" };
+
+    const next = appReducer(state, {
+      type: "UPDATE_LAYOUT",
+      layout: removePane(state.config.layout, "portfolio-list:main"),
+    });
+
+    expect(findPaneInstance(next.config.layout, "ticker-detail:main")?.binding).toEqual({
+      kind: "fixed",
+      symbol: "AAPL",
+    });
   });
 
   test("uses fixed ticker bindings for pinned panes", () => {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -504,7 +504,11 @@ export function removePaneInstances(layout: LayoutConfig, instanceIds: Iterable<
 
 export function normalizePaneLayout(
   layout: LayoutConfig,
-  options?: { defaultFollowSourceInstanceId?: string | null },
+  options?: {
+    defaultFollowSourceInstanceId?: string | null;
+    /** Last resolved symbol used to pin an orphaned follower; otherwise it remains safely unlinked. */
+    resolveOrphanSymbol?: (instanceId: string) => string | null;
+  },
 ): LayoutConfig {
   const fallbackSourceId = options?.defaultFollowSourceInstanceId ?? null;
   const fallbackAvailable = !!fallbackSourceId && layout.instances.some((instance) => instance.instanceId === fallbackSourceId);
@@ -530,14 +534,27 @@ export function normalizePaneLayout(
   for (;;) {
     const validInstanceIds = new Set(nextLayout.instances.map((instance) => instance.instanceId));
     const removedIds = new Set<string>();
+    const orphanBindings = new Map<string, PaneBinding>();
 
     for (const instance of nextLayout.instances) {
       if (instance.binding?.kind === "follow" && !validInstanceIds.has(instance.binding.sourceInstanceId)) {
-        removedIds.add(instance.instanceId);
+        // Structural helpers remove the source before the app can resolve its last ticker. Preserve
+        // the dangling binding until the runtime normalizes again with a resolver.
+        if (!options?.resolveOrphanSymbol) continue;
+        const orphanSymbol = options.resolveOrphanSymbol(instance.instanceId)?.trim();
+        orphanBindings.set(
+          instance.instanceId,
+          orphanSymbol ? { kind: "fixed", symbol: orphanSymbol } : { kind: "none" },
+        );
         continue;
       }
 
-      if (isTickerPaneInstance(instance) && instance.binding?.kind !== "follow" && instance.binding?.kind !== "fixed") {
+      if (
+        isTickerPaneInstance(instance)
+        && instance.paneId !== TICKER_RESEARCH_PANE_ID
+        && instance.binding?.kind !== "follow"
+        && instance.binding?.kind !== "fixed"
+      ) {
         removedIds.add(instance.instanceId);
         continue;
       }
@@ -547,8 +564,21 @@ export function normalizePaneLayout(
       }
     }
 
-    if (removedIds.size === 0) break;
-    nextLayout = removePaneInstances(nextLayout, removedIds);
+    if (orphanBindings.size > 0) {
+      nextLayout = {
+        ...nextLayout,
+        instances: nextLayout.instances.map((instance) => {
+          const binding = orphanBindings.get(instance.instanceId);
+          return binding ? { ...instance, binding } : instance;
+        }),
+      };
+    }
+
+    if (removedIds.size > 0) {
+      nextLayout = removePaneInstances(nextLayout, removedIds);
+      continue;
+    }
+    if (orphanBindings.size === 0) break;
   }
 
   const validInstanceIds = new Set(nextLayout.instances.map((instance) => instance.instanceId));

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -53,6 +53,8 @@ export interface PaneDef {
   defaultWidth?: string;
   defaultFloatingSize?: { width: number; height: number };
   defaultMode?: "docked" | "floating";
+  /** Pane publishes its selected symbol as pane-state `cursorSymbol`, so ticker panes can follow it. */
+  tickerSource?: boolean;
   settings?: PaneSettingsDef | ((context: PaneSettingsContext) => PaneSettingsDef | null);
   /** Compact controls surfaced next to the pane title. Toggle keys reference toggle fields in settings. */
   quickSettings?: readonly PaneQuickSettingDef[];


### PR DESCRIPTION
## Summary
- let ticker research panes follow any pane that declares itself as a ticker source
- expose link, unlink, and pinned behavior in pane menus with a clickable `⧉ Linked to …` status
- reuse linked panes on Enter, preserve Shift+Enter for new floating panes, and pin followers when sources close

## Validation
- `bun test` (2,314 passing)
- `bun run typecheck`
- isolated tmux QA: Enter reuse, Shift+Enter new pane, mouse link/unlink, source-close fallback, clean runtime warning scan

## Notes
- i18n audit still reports the pre-existing missing-key baseline; the new `Linked to {source}` key is translated in all dictionaries.