### PR TITLE
Prompt empty profiles in chat sidebar

### DIFF
--- a/src/plugins/builtin/chat/content/index.tsx
+++ b/src/plugins/builtin/chat/content/index.tsx
@@ -240,10 +240,11 @@ export function ChatContent({
   const {
     cancelProfilePopoverClose,
     closeProfilePopover,
+    ownProfileConfigured,
     profilePopoverUser,
     scheduleProfilePopoverClose,
     showProfilePopover,
-  } = useChatProfilePopover();
+  } = useChatProfilePopover(focused ? user?.id : undefined);
 
   const showUserProfilePopover = useCallback((targetUser: Parameters<typeof showProfilePopover>[0]) => {
     showProfilePopover(targetUser, { ownProfile: targetUser.id === user?.id });
@@ -537,6 +538,8 @@ export function ChatContent({
           loading={channelsLoading}
           canManageNotifications={!!user?.emailVerified}
           canCreateConversation={!!user?.emailVerified}
+          needsProfileSetup={!!user?.id && ownProfileConfigured === false}
+          onOpenProfile={openProfileSetup}
           directExpanded={directExpanded}
           onSelect={selectSidebarChannel}
           onFocusRequest={() => setSidebarFocused(true)}

--- a/src/plugins/builtin/chat/message/profile-popover.test.tsx
+++ b/src/plugins/builtin/chat/message/profile-popover.test.tsx
@@ -2,11 +2,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { act, useEffect } from "react";
 import {
   apiClient,
-  type AccountProfile,
   type ChatUserSummary,
 } from "../../../../api-client";
 import { testRender } from "../../../../renderers/opentui/test-utils";
 import { Box, Text } from "../../../../ui";
+import { makeAccountProfile } from "../test-harness";
 import { useChatProfilePopover } from "../profile-popover";
 import {
   hasPublicChatProfileInfo,
@@ -32,34 +32,6 @@ function makeUser(overrides: Partial<ChatUserSummary>): ChatUserSummary {
     username: "vince",
     displayName: "Vince",
     profilePublic: true,
-    ...overrides,
-  };
-}
-
-function makeAccountProfile(overrides: Partial<AccountProfile> = {}): AccountProfile {
-  return {
-    id: "u1",
-    email: "vince@example.com",
-    emailVerified: true,
-    plan: "pro",
-    username: "vince",
-    name: "Vince",
-    company: "Gloom",
-    title: null,
-    bio: "Made Gloomberb",
-    profilePublic: true,
-    publicEmail: null,
-    xAccount: null,
-    sharedPortfolioId: "broker:ibkr:coldstart",
-    acceptUnknownDms: false,
-    chatEmailNotificationsEnabled: true,
-    portfolioAnalytics: null,
-    syncEnabled: true,
-    weeklyRoundupEnabled: true,
-    positionAlertsEnabled: true,
-    lastSyncAt: null,
-    lastRoundupEmailAt: null,
-    updatedAt: "2026-07-21T22:03:59.832Z",
     ...overrides,
   };
 }

--- a/src/plugins/builtin/chat/profile-popover.ts
+++ b/src/plugins/builtin/chat/profile-popover.ts
@@ -23,8 +23,23 @@ function accountProfileToChatUser(profile: AccountProfile): ChatUserSummary {
   };
 }
 
-export function useChatProfilePopover() {
+const OPTIONAL_PROFILE_FIELDS = [
+  "company",
+  "title",
+  "bio",
+  "publicEmail",
+  "xAccount",
+  "sharedPortfolioId",
+] as const;
+
+/** `profilePublic` is a visibility switch, not a completion test: any filled optional field counts as set up. */
+export function isAccountProfileConfigured(profile: AccountProfile): boolean {
+  return OPTIONAL_PROFILE_FIELDS.some((field) => (profile[field] ?? "").trim().length > 0);
+}
+
+export function useChatProfilePopover(trackOwnProfileUserId?: string) {
   const [profilePopoverUser, setProfilePopoverUser] = useState<ChatUserSummary | null>(null);
+  const [ownProfileConfigured, setOwnProfileConfigured] = useState<boolean | null>(null);
   const profilePopoverCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const ownProfileRef = useRef<ChatUserSummary | null>(null);
   const ownProfileRequestRef = useRef<Promise<void> | null>(null);
@@ -50,6 +65,35 @@ export function useChatProfilePopover() {
     }, PROFILE_POPOVER_CLOSE_DELAY_MS);
   }, [cancelProfilePopoverClose]);
 
+  const refreshOwnProfile = useCallback((expectedUserId?: string, force = false) => {
+    if (
+      !apiClient.isSignedIn()
+      || ownProfileRequestRef.current
+      || (
+        !force
+        && ownProfileRef.current
+        && (!expectedUserId || ownProfileRef.current.id === expectedUserId)
+        && Date.now() - ownProfileLoadedAtRef.current < 10_000
+      )
+    ) return;
+    const request = apiClient.getAccountProfile()
+      .then((profile) => {
+        if (!activeRef.current || (expectedUserId && profile.id !== expectedUserId)) return;
+        const nextUser = accountProfileToChatUser(profile);
+        ownProfileRef.current = nextUser;
+        ownProfileLoadedAtRef.current = Date.now();
+        setOwnProfileConfigured(isAccountProfileConfigured(profile));
+        setProfilePopoverUser((current) => current?.id === profile.id ? nextUser : current);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (ownProfileRequestRef.current === request) {
+          ownProfileRequestRef.current = null;
+        }
+      });
+    ownProfileRequestRef.current = request;
+  }, []);
+
   const showProfilePopover = useCallback((
     targetUser: ChatUserSummary,
     options?: { ownProfile?: boolean },
@@ -64,29 +108,8 @@ export function useChatProfilePopover() {
     }
     cancelProfilePopoverClose();
     setProfilePopoverUser(cachedUser);
-
-    if (
-      !ownProfile
-      || !apiClient.isSignedIn()
-      || ownProfileRequestRef.current
-      || (ownProfileRef.current?.id === targetUser.id && Date.now() - ownProfileLoadedAtRef.current < 10_000)
-    ) return;
-    const request = apiClient.getAccountProfile()
-      .then((profile) => {
-        if (!activeRef.current || profile.id !== targetUser.id) return;
-        const nextUser = accountProfileToChatUser(profile);
-        ownProfileRef.current = nextUser;
-        ownProfileLoadedAtRef.current = Date.now();
-        setProfilePopoverUser((current) => current?.id === targetUser.id ? nextUser : current);
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (ownProfileRequestRef.current === request) {
-          ownProfileRequestRef.current = null;
-        }
-      });
-    ownProfileRequestRef.current = request;
-  }, [cancelProfilePopoverClose, closeProfilePopover]);
+    if (ownProfile) refreshOwnProfile(targetUser.id);
+  }, [cancelProfilePopoverClose, closeProfilePopover, refreshOwnProfile]);
 
   useEffect(() => {
     activeRef.current = true;
@@ -96,9 +119,17 @@ export function useChatProfilePopover() {
     };
   }, [cancelProfilePopoverClose]);
 
+  // Force a refresh when the pane regains focus so returning from Account Management settles the answer.
+  useEffect(() => {
+    if (!trackOwnProfileUserId) return;
+    if (ownProfileRef.current?.id !== trackOwnProfileUserId) setOwnProfileConfigured(null);
+    refreshOwnProfile(trackOwnProfileUserId, true);
+  }, [refreshOwnProfile, trackOwnProfileUserId]);
+
   return {
     cancelProfilePopoverClose,
     closeProfilePopover,
+    ownProfileConfigured,
     profilePopoverUser,
     scheduleProfilePopoverClose,
     showProfilePopover,

--- a/src/plugins/builtin/chat/sidebar.test.tsx
+++ b/src/plugins/builtin/chat/sidebar.test.tsx
@@ -12,6 +12,10 @@ import { ChatContent } from "./content";
 import { chatController } from "./controller";
 import { useChatChannelNavigation } from "./content/channel-navigation";
 import {
+  subscribeRequestedAccountManagementTab,
+  type AccountManagementTab,
+} from "../account-management/navigation";
+import {
   cleanupChatTest,
   createChatTestControls,
   createController,
@@ -19,6 +23,7 @@ import {
   installChatApiTestDefaults,
   installServerChannels,
   lineText,
+  makeAccountProfile,
   makeMessage,
   MemoryPersistence,
   type ChatTestSetup,
@@ -310,6 +315,82 @@ describe("ChatContent channel sidebar", () => {
     await flushFrame();
 
     expect(setup().captureCharFrame()).toContain("● 6 online");
+  });
+
+  test("offers a sidebar profile shortcut only until the account profile is filled in", async () => {
+    const controller = createController({ sessionToken: "token-123" });
+    installServerChannels(controller);
+    controller.refreshChannels = async () => {};
+    controller.refreshChannelMessages = async () => {};
+    const originalGetAccountProfile = apiClient.getAccountProfile.bind(apiClient);
+    apiClient.getAccountProfile = async () => makeAccountProfile({
+      id: "u0",
+      company: null,
+      title: null,
+      bio: null,
+      publicEmail: null,
+      xAccount: null,
+      // Set, and deliberately not part of the completion test.
+      profilePublic: true,
+      sharedPortfolioId: null,
+    });
+    const requestedTabs: AccountManagementTab[] = [];
+    const unsubscribe = subscribeRequestedAccountManagementTab((tab) => requestedTabs.push(tab));
+    const shownPanes: string[] = [];
+    const runtime = createTestPluginRuntime({
+      showPane: (paneId: string) => {
+        shownPanes.push(paneId);
+      },
+    });
+
+    try {
+      await act(async () => {
+        testSetup = await testRender(createHarness(controller, { width: 90, height: 14, runtime }), {
+          width: 90,
+          height: 14,
+        });
+      });
+      await flushFrame();
+      await flushFrame();
+
+      const lines = setup().captureCharFrame().split("\n");
+      const row = lines.findIndex((line) => line.includes("@ Profile"));
+      const col = lines[row]?.indexOf("Profile") ?? -1;
+      expect(row).toBeGreaterThanOrEqual(0);
+
+      await act(async () => {
+        await setup().mockMouse.click(col + 1, row);
+        await setup().renderOnce();
+        await setup().renderOnce();
+      });
+      await flushFrame();
+
+      expect(requestedTabs).toEqual(["profile"]);
+      expect(shownPanes).toEqual(["account-management"]);
+
+      apiClient.getAccountProfile = async () => makeAccountProfile({
+        id: "u0",
+        company: null,
+        title: "Trader",
+        bio: null,
+        profilePublic: false,
+        sharedPortfolioId: null,
+      });
+      await act(async () => {
+        testSetup?.renderer.destroy();
+        testSetup = await testRender(createHarness(controller, { width: 90, height: 14, runtime }), {
+          width: 90,
+          height: 14,
+        });
+      });
+      await flushFrame();
+      await flushFrame();
+
+      expect(setup().captureCharFrame()).not.toContain("@ Profile");
+    } finally {
+      unsubscribe();
+      apiClient.getAccountProfile = originalGetAccountProfile;
+    }
   });
 
   test("uses arrows to move between channel sidebar and chat content", async () => {

--- a/src/plugins/builtin/chat/sidebar.tsx
+++ b/src/plugins/builtin/chat/sidebar.tsx
@@ -96,6 +96,47 @@ function ChannelNotificationIcon({
   );
 }
 
+function ProfileIcon({
+  color,
+  onMouseDown,
+}: {
+  color: string;
+  onMouseDown?: (event: any) => void;
+}) {
+  const { nativePaneChrome } = useUiCapabilities();
+
+  if (!nativePaneChrome) {
+    return (
+      <Text fg={color} selectable={false} onMouseDown={onMouseDown}>@</Text>
+    );
+  }
+
+  return (
+    <Span
+      fg={color}
+      onMouseDown={onMouseDown}
+      style={{
+        color,
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: 16,
+        height: 16,
+      }}
+    >
+      <svg viewBox="0 0 24 24" width="15" height="15" fill="none" aria-hidden="true">
+        <circle cx="12" cy="8.5" r="3.4" stroke="currentColor" strokeWidth="1.8" />
+        <path
+          d="M5.5 19.5a6.5 6.5 0 0 1 13 0"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+        />
+      </svg>
+    </Span>
+  );
+}
+
 export function ChannelSidebar({
   channels,
   channelStates,
@@ -109,9 +150,11 @@ export function ChannelSidebar({
   canManageNotifications,
   canCreateConversation,
   directExpanded,
+  needsProfileSetup = false,
   onSelect,
   onFocusRequest,
   onCreateConversation,
+  onOpenProfile,
   onToggleNotifications,
   onToggleDirectExpanded,
 }: {
@@ -127,9 +170,11 @@ export function ChannelSidebar({
   canManageNotifications: boolean;
   canCreateConversation: boolean;
   directExpanded: boolean;
+  needsProfileSetup?: boolean;
   onSelect?: (channelId: string) => void;
   onFocusRequest?: () => void;
   onCreateConversation?: () => void;
+  onOpenProfile?: () => void;
   onToggleNotifications?: (channelId: string, enabled: boolean) => void;
   onToggleDirectExpanded?: () => void;
 }) {
@@ -240,6 +285,24 @@ export function ChannelSidebar({
               );
             })}
             <Box flexGrow={1} />
+            {needsProfileSetup && (
+              <PaneSidebarRow
+                active={false}
+                ariaLabel={t("Profile")}
+                onSelect={onOpenProfile}
+              >
+                {({ foregroundColor, onMouseDown }) => (
+                  <>
+                    <Text fg={foregroundColor} selectable={false} onMouseDown={onMouseDown}> </Text>
+                    <ProfileIcon color={foregroundColor} onMouseDown={onMouseDown} />
+                    <Text fg={foregroundColor} selectable={false} onMouseDown={onMouseDown}>
+                      {` ${truncateChannelLabel(t("Profile"), Math.max(listWidth - 3, 1))}`}
+                    </Text>
+                    <Box flexGrow={1} onMouseDown={onMouseDown} />
+                  </>
+                )}
+              </PaneSidebarRow>
+            )}
             {loading && focused && (
               <Box height={1} width={listWidth} flexDirection="row">
                 <Text fg={colors.textDim}>{` ${t("syncing")}`}</Text>

--- a/src/plugins/builtin/chat/test-harness.tsx
+++ b/src/plugins/builtin/chat/test-harness.tsx
@@ -6,7 +6,7 @@ import { MemoryPluginPersistence } from "../../../test-support/plugin-persistenc
 import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
 import { createDefaultConfig } from "../../../types/config";
 import { Box } from "../../../ui";
-import { apiClient, type ChatChannel, type ChatMessage } from "../../../api-client";
+import { apiClient, type AccountProfile, type ChatChannel, type ChatMessage } from "../../../api-client";
 import { PluginRenderProvider, type PluginRuntimeAccess } from "../../runtime";
 import { setSharedMarketDataForTests, setSharedRegistryForTests } from "../../registry";
 import { ChatContent } from "./content";
@@ -66,6 +66,34 @@ export function installServerChannels(controller: ChatController, channels = TES
 }
 
 export { MemoryPluginPersistence as MemoryPersistence } from "../../../test-support/plugin-persistence";
+
+export function makeAccountProfile(overrides: Partial<AccountProfile> = {}): AccountProfile {
+  return {
+    id: "u1",
+    email: "vince@example.com",
+    emailVerified: true,
+    plan: "pro",
+    username: "vince",
+    name: "Vince",
+    company: "Gloom",
+    title: null,
+    bio: "Made Gloomberb",
+    profilePublic: true,
+    publicEmail: null,
+    xAccount: null,
+    sharedPortfolioId: "broker:ibkr:coldstart",
+    acceptUnknownDms: false,
+    chatEmailNotificationsEnabled: true,
+    portfolioAnalytics: null,
+    syncEnabled: true,
+    weeklyRoundupEnabled: true,
+    positionAlertsEnabled: true,
+    lastSyncAt: null,
+    lastRoundupEmailAt: null,
+    updatedAt: "2026-07-21T22:03:59.832Z",
+    ...overrides,
+  };
+}
 
 export function makeMessage(index: number): ChatMessage {
   return {


### PR DESCRIPTION
## Summary
- show a Profile shortcut at the bottom of the chat sidebar when all optional profile fields are empty
- use a compact profile icon and the existing Account Management profile route
- refresh profile completion when chat regains focus so the shortcut disappears after setup

## Validation
- `bun test src/plugins/builtin/chat/message/profile-popover.test.tsx src/plugins/builtin/chat/sidebar.test.tsx`
- `bun run typecheck:opentui`
- `bun run typecheck:electrobun-view`
- `bun run typecheck:browser`
- terminal tmux smoke at 120x40 with no runtime errors