### PR TITLE
Polish desktop notifications

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -158,7 +158,9 @@ function AppInner({
       const type = notification.type ?? "info";
       let toastId: string | number | undefined;
       const options = {
-        duration: notification.duration,
+        title: notification.title,
+        subtitle: notification.subtitle,
+        duration: notification.persistent ? 0 : notification.duration,
         action: notification.action
           ? {
             label: notification.action.label,

--- a/src/plugins/builtin/alerts/index.tsx
+++ b/src/plugins/builtin/alerts/index.tsx
@@ -135,6 +135,10 @@ export const alertsPlugin: GloomPlugin = {
             desktop: "always",
             persistent: true,
             sound: "Glass",
+            action: {
+              label: "Open",
+              onClick: () => ctx.showPane("alerts"),
+            },
           });
         }
         Object.assign(alert, quoteAlertFields(quote));

--- a/src/plugins/builtin/chat/controller.test.ts
+++ b/src/plugins/builtin/chat/controller.test.ts
@@ -1099,8 +1099,7 @@ describe("ChatController", () => {
     (controller as any).handleChatNotification(mentionNotification());
 
     expect(notifications).toEqual([{
-      title: "Gloomberb chat",
-      subtitle: "#everyone",
+      title: "#everyone",
       body: "@bob mentioned you: hey @vince",
       type: "info",
       desktop: "when-inactive",
@@ -1324,8 +1323,7 @@ describe("ChatController", () => {
       unreadCount: 3,
     });
     expect(notifications).toEqual([{
-      title: "Gloomberb chat",
-      subtitle: "#options",
+      title: "#options",
       body: "@bob replied to you: answering you",
       type: "info",
       desktop: "when-inactive",
@@ -1405,10 +1403,11 @@ describe("ChatController", () => {
     expect(notifications).toHaveLength(1);
   });
 
-  test("displays server-issued channel notifications", () => {
+  test("opens a server-issued channel notification at its exact message", () => {
     const persistence = new MemoryPersistence();
     const controller = new ChatController();
     const notifications: AppNotificationRequest[] = [];
+    const openedMessages: string[] = [];
     const message: ChatMessage = {
       id: "m1",
       channelId: "options",
@@ -1424,6 +1423,8 @@ describe("ChatController", () => {
     }, { schemaVersion: 1 });
     controller.setNotifier((entry) => {
       notifications.push(entry);
+    }, (channelId, messageId) => {
+      openedMessages.push(`${channelId}:${messageId}`);
     });
     controller.attachPersistence(persistence);
 
@@ -1437,15 +1438,17 @@ describe("ChatController", () => {
     } satisfies ChatNotification);
 
     expect(notifications).toEqual([{
-      title: "Gloomberb chat",
-      subtitle: "#options",
-      body: "#options @bob: new option flow",
+      title: "#options",
+      body: "@bob: new option flow",
       type: "info",
       desktop: "when-inactive",
+      action: expect.objectContaining({ label: "Open" }),
     }]);
+    notifications[0]?.action?.onClick();
+    expect(openedMessages).toEqual(["options:m1"]);
   });
 
-  test("uses direct channel labels in server-issued notification subtitles", async () => {
+  test("uses direct channel labels in server-issued notification titles", async () => {
     const persistence = new MemoryPersistence();
     const controller = new ChatController();
     const notifications: AppNotificationRequest[] = [];
@@ -1496,9 +1499,8 @@ describe("ChatController", () => {
     } satisfies ChatNotification);
 
     expect(notifications).toEqual([{
-      title: "Gloomberb chat",
-      subtitle: "@bob",
-      body: "@bob: ping",
+      title: "@bob",
+      body: "ping",
       type: "info",
       desktop: "when-inactive",
     }]);
@@ -1569,8 +1571,7 @@ describe("ChatController", () => {
     } satisfies ChatNotification);
 
     expect(notifications).toEqual([{
-      title: "Gloomberb chat",
-      subtitle: "#options",
+      title: "#options",
       body: "@bob replied to you: reply without channel notify",
       type: "info",
       desktop: "when-inactive",

--- a/src/plugins/builtin/chat/controller/index.ts
+++ b/src/plugins/builtin/chat/controller/index.ts
@@ -73,6 +73,7 @@ export class ChatController {
   private readonly session = createChatControllerSessionState();
   private pendingMessageSeq = 0;
   private notifyFn: (notification: AppNotificationRequest) => AppNotificationDelivery | void = () => {};
+  private openMessageFn: ((channelId: string, messageId: string) => void) | undefined;
   private notifiedMessageIds = new Set<string>();
 
   private readonly storage = new ChatControllerStorage({
@@ -125,8 +126,12 @@ export class ChatController {
     this.hydrate();
   }
 
-  setNotifier(notify: (notification: AppNotificationRequest) => AppNotificationDelivery | void): void {
+  setNotifier(
+    notify: (notification: AppNotificationRequest) => AppNotificationDelivery | void,
+    openMessage?: (channelId: string, messageId: string) => void,
+  ): void {
     this.notifyFn = notify;
+    this.openMessageFn = openMessage;
   }
 
   hydrate(): void {
@@ -374,6 +379,7 @@ export class ChatController {
       flushDraftSync: (channelId) => this.storage.flushDraftSync(channelId),
       resetNotifier: () => {
         this.notifyFn = () => {};
+        this.openMessageFn = undefined;
       },
       stopRealtime: () => this.realtime.stopAll(),
     });
@@ -527,6 +533,7 @@ export class ChatController {
       getChannel: (channelId) => this.channelCatalog.getChannels().find((channel) => channel.id === channelId),
       notifiedMessageIds: this.notifiedMessageIds,
       notify: this.notifyFn,
+      openMessage: this.openMessageFn,
     });
   }
 

--- a/src/plugins/builtin/chat/controller/notifications.ts
+++ b/src/plugins/builtin/chat/controller/notifications.ts
@@ -20,11 +20,13 @@ function notifyChatServerMessage({
   channel,
   notifiedMessageIds,
   notify,
+  openMessage,
 }: {
   notification: ChatNotification;
   channel: ChatChannel | undefined;
   notifiedMessageIds: Set<string>;
   notify: (notification: AppNotificationRequest) => AppNotificationDelivery | void;
+  openMessage?: (channelId: string, messageId: string) => void;
 }): boolean {
   if (notifiedMessageIds.has(notification.messageId)) return true;
   const channelTitle = formatChatPaneTitle(channel, notification.channelId);
@@ -32,13 +34,18 @@ function notifyChatServerMessage({
     ? formatReplyToast(notification.message)
     : notification.type === "mention"
       ? formatMentionToast(notification.message)
-      : formatChannelToast(channelTitle, notification.message, channel?.kind);
+      : formatChannelToast(notification.message, channel?.kind === "direct");
   const delivered = wasNotificationDelivered(notify({
-    title: "Gloomberb chat",
-    subtitle: channelTitle,
+    title: channelTitle,
     body,
     type: "info",
     desktop: "when-inactive",
+    ...(openMessage ? {
+      action: {
+        label: "Open",
+        onClick: () => openMessage(notification.channelId, notification.messageId),
+      },
+    } : {}),
   }));
   if (delivered) {
     notifiedMessageIds.add(notification.messageId);
@@ -55,6 +62,7 @@ export function handleChatNotification({
   getChannel,
   notifiedMessageIds,
   notify,
+  openMessage,
 }: {
   notification: ChatNotification;
   options?: { countUnread?: boolean };
@@ -64,6 +72,7 @@ export function handleChatNotification({
   getChannel: (channelId: string) => ChatChannel | undefined;
   notifiedMessageIds: Set<string>;
   notify: (notification: AppNotificationRequest) => AppNotificationDelivery | void;
+  openMessage?: (channelId: string, messageId: string) => void;
 }): void {
   mergeMessages(notification.channelId, [notification.message], { countUnread: options.countUnread });
   const channel = ensureChannelState(notification.channelId);
@@ -73,6 +82,7 @@ export function handleChatNotification({
     channel: getChannel(notification.channelId),
     notifiedMessageIds,
     notify,
+    openMessage,
   });
   if (activelyViewed) {
     notifiedMessageIds.add(notification.messageId);

--- a/src/plugins/builtin/chat/controller/utils.ts
+++ b/src/plugins/builtin/chat/controller/utils.ts
@@ -1,4 +1,4 @@
-import type { ChatChannel, ChatMessage } from "../../../../api-client";
+import type { ChatMessage } from "../../../../api-client";
 import { t, tf } from "../../../../i18n";
 
 const ISO_TIMESTAMP_CURSOR = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
@@ -43,13 +43,11 @@ export function formatReplyToast(message: ChatMessage): string {
   return tf("@{author} replied to you: {snippet}", { author, snippet });
 }
 
-export function formatChannelToast(channelTitle: string, message: ChatMessage, channelKind?: ChatChannel["kind"]): string {
+export function formatChannelToast(message: ChatMessage, direct = false): string {
   const author = message.user.username || t("Someone");
   const snippet = formatMessageSnippet(message.content);
-  if (channelKind === "direct") {
-    return snippet ? `@${author}: ${snippet}` : tf("@{author} sent a message.", { author });
-  }
-  return snippet ? `${channelTitle} @${author}: ${snippet}` : tf("{channel} @{author} sent a message.", { channel: channelTitle, author });
+  if (direct && snippet) return snippet;
+  return snippet ? `@${author}: ${snippet}` : tf("@{author} sent a message.", { author });
 }
 
 export function isLegacyTimestampCursor(cursor: string | null): boolean {

--- a/src/plugins/builtin/cloud/plugin.tsx
+++ b/src/plugins/builtin/cloud/plugin.tsx
@@ -96,7 +96,9 @@ function createChatModule(
     },
     setup(ctx) {
       chatController.attachPersistence(ctx.persistence, ctx.resume);
-      chatController.setNotifier(ctx.notify);
+      chatController.setNotifier(ctx.notify, (channelId, messageId) => {
+        ctx.createPaneFromTemplate("new-chat-pane", { arg: channelId, values: { messageId } });
+      });
       ctx.registerCommand({
         id: "direct-message",
         label: "DM",

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -422,21 +422,121 @@ body.gloom-dragging [data-gloom-role="chart-surface"] {
   right: 16px;
   bottom: 16px;
   display: flex;
+  width: min(380px, calc(100vw - 32px));
   flex-direction: column;
   gap: 8px;
+  pointer-events: none;
   z-index: 10000;
 }
 .gloom-toast {
-  min-width: 260px;
-  max-width: 420px;
-  padding: 10px 12px;
-  border: 1px solid;
-  box-shadow: 0 12px 24px color-mix(in srgb, var(--gloom-bg) 28%, transparent);
+  --gloom-toast-accent: var(--gloom-border-focused);
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: start;
+  width: 100%;
+  padding: 11px 10px 11px 12px;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--gloom-toast-accent) 54%, var(--gloom-border));
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--gloom-panel) 94%, var(--gloom-bg));
+  color: var(--gloom-text);
+  box-shadow: 0 14px 32px color-mix(in srgb, var(--gloom-bg) 42%, transparent);
+  pointer-events: auto;
+}
+.gloom-toast[data-type="success"] { --gloom-toast-accent: var(--gloom-positive); }
+.gloom-toast[data-type="error"] { --gloom-toast-accent: var(--gloom-negative); }
+.gloom-toast[data-actionable="true"] {
+  cursor: pointer;
+  transition: transform 120ms cubic-bezier(0.23, 1, 0.32, 1), border-color 120ms ease, background-color 120ms ease;
+}
+.gloom-toast[data-actionable="true"]:active { transform: scale(0.985); }
+.gloom-toast-indicator {
+  width: 8px;
+  height: 8px;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: var(--gloom-toast-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--gloom-toast-accent) 14%, transparent);
+}
+.gloom-toast-content { min-width: 0; }
+.gloom-toast-heading {
+  display: flex;
+  min-width: 0;
+  margin-bottom: 2px;
+  align-items: baseline;
+  gap: 7px;
+}
+.gloom-toast-title {
+  overflow: hidden;
+  color: var(--gloom-text-bright);
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gloom-toast-subtitle {
+  overflow: hidden;
+  color: var(--gloom-text-dim);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gloom-toast-body {
+  color: var(--gloom-text);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+.gloom-toast-controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.gloom-toast-action,
+.gloom-toast-dismiss {
+  appearance: none;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--gloom-text-dim);
 }
 .gloom-toast-action {
-  margin-top: 8px;
-  padding: 4px 8px;
+  padding: 3px 7px;
+  border-color: color-mix(in srgb, var(--gloom-toast-accent) 42%, var(--gloom-border));
   border-radius: 4px;
+  color: var(--gloom-text-bright);
+}
+.gloom-toast-dismiss {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: 4px;
+  place-items: center;
+}
+.gloom-toast-dismiss svg {
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 1.5;
+}
+.gloom-toast-action:focus-visible,
+.gloom-toast-dismiss:focus-visible {
+  outline: 1px solid var(--gloom-border-focused);
+  outline-offset: 1px;
+}
+@media (hover: hover) and (pointer: fine) {
+  .gloom-toast[data-actionable="true"]:hover {
+    border-color: var(--gloom-toast-accent);
+    background: color-mix(in srgb, var(--gloom-panel) 88%, var(--gloom-toast-accent));
+  }
+  .gloom-toast-action:hover,
+  .gloom-toast-dismiss:hover {
+    background: color-mix(in srgb, var(--gloom-text) 10%, transparent);
+    color: var(--gloom-text-bright);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .gloom-toast[data-actionable="true"] { transition: none; }
+  .gloom-toast[data-actionable="true"]:active { transform: none; }
 }
 .gloom-dialog-backdrop {
   position: fixed;

--- a/src/renderers/electrobun/view/toast-host.test.tsx
+++ b/src/renderers/electrobun/view/toast-host.test.tsx
@@ -1,0 +1,78 @@
+/** @jsxImportSource react */
+import { Window } from "happy-dom";
+
+const testWindow = new Window({ url: "http://localhost" });
+Object.assign(globalThis, {
+  IS_REACT_ACT_ENVIRONMENT: true,
+  window: testWindow,
+  document: testWindow.document,
+  navigator: testWindow.navigator,
+  HTMLElement: testWindow.HTMLElement,
+  MouseEvent: testWindow.MouseEvent,
+});
+
+import { expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { useToastHost, type ToastHost } from "../../../ui/toast";
+import { WebToastHostProvider } from "./toast-host";
+
+let toastHost: ToastHost | null = null;
+
+function ToastViewport() {
+  const host = useToastHost();
+  toastHost = host;
+  const Viewport = host.Viewport;
+  return <Viewport />;
+}
+
+test("DOM notifications show context and open from the whole card", async () => {
+  const container = testWindow.document.createElement("div");
+  testWindow.document.body.appendChild(container);
+  const root = createRoot(container as unknown as HTMLElement);
+  let opened = 0;
+
+  await act(async () => {
+    root.render(
+      <WebToastHostProvider>
+        <ToastViewport />
+      </WebToastHostProvider>,
+    );
+  });
+  await act(async () => {
+    toastHost?.info("@bob mentioned you", {
+      title: "Gloomberb chat",
+      subtitle: "#everyone",
+      duration: 0,
+      action: { label: "Open", onClick: () => opened++ },
+    });
+  });
+
+  const toast = container.querySelector(".gloom-toast") as unknown as HTMLElement;
+  expect(toast.textContent).toContain("Gloomberb chat");
+  expect(toast.textContent).toContain("#everyone");
+  expect(toast.getAttribute("data-actionable")).toBe("true");
+
+  await act(async () => {
+    toast.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  expect(opened).toBe(1);
+  expect(container.querySelector(".gloom-toast")).toBeNull();
+
+  await act(async () => {
+    toastHost?.info("Another message", {
+      duration: 0,
+      action: { label: "Open", onClick: () => opened++ },
+    });
+  });
+  const dismiss = container.querySelector(".gloom-toast-dismiss") as unknown as HTMLElement;
+  await act(async () => {
+    dismiss.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  expect(opened).toBe(1);
+  expect(container.querySelector(".gloom-toast")).toBeNull();
+
+  await act(async () => root.unmount());
+  container.remove();
+  toastHost = null;
+});

--- a/src/renderers/electrobun/view/toast-host.tsx
+++ b/src/renderers/electrobun/view/toast-host.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useMemo, useState, type CSSProperties, type ReactNode } from "react";
-import { colors } from "../../../theme/colors";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { ToastHostProvider, type ToastHost, type ToastOptions } from "../../../ui/toast";
 
 type WebToastType = "info" | "success" | "error";
@@ -9,32 +8,12 @@ interface ToastEntry {
   id: number;
   body: string;
   type: WebToastType;
+  title?: string;
+  subtitle?: string;
   action?: ToastOptions["action"];
 }
 
 let nextToastId = 1;
-
-function webToastBorderColor(type: WebToastType): string {
-  if (type === "success") return colors.positive;
-  if (type === "error") return colors.negative;
-  return colors.borderFocused;
-}
-
-function getToastStyle(type: WebToastType): CSSProperties {
-  return {
-    background: colors.panel,
-    borderColor: webToastBorderColor(type),
-    color: colors.text,
-  };
-}
-
-function getToastActionStyle(): CSSProperties {
-  return {
-    background: colors.selected,
-    border: `1px solid ${colors.borderFocused}`,
-    color: colors.selectedText,
-  };
-}
 
 export function WebToastHostProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastEntry[]>([]);
@@ -45,7 +24,14 @@ export function WebToastHostProvider({ children }: { children: ReactNode }) {
 
   const push = useCallback((type: ToastEntry["type"], body: string, options?: ToastOptions) => {
     const id = nextToastId++;
-    setToasts((current) => [...current, { id, type, body, action: options?.action }].slice(-6));
+    setToasts((current) => [...current, {
+      id,
+      type,
+      body,
+      title: options?.title,
+      subtitle: options?.subtitle,
+      action: options?.action,
+    }]);
     if (options?.duration !== 0) {
       setTimeout(() => dismiss(id), options?.duration ?? 4500);
     }
@@ -55,24 +41,64 @@ export function WebToastHostProvider({ children }: { children: ReactNode }) {
   const host = useMemo<ToastHost>(() => ({
     Viewport() {
       return (
-        <div className="gloom-toast-viewport">
-          {toasts.map((toast) => (
-            <div key={toast.id} className="gloom-toast" style={getToastStyle(toast.type)}>
-              <div>{toast.body}</div>
-              {toast.action && (
-                <button
-                  className="gloom-toast-action"
-                  style={getToastActionStyle()}
-                  onClick={() => {
-                    toast.action?.onClick();
-                    dismiss(toast.id);
-                  }}
-                >
-                  {toast.action.label}
-                </button>
-              )}
-            </div>
-          ))}
+        <div className="gloom-toast-viewport" aria-label="Notifications" aria-live="polite">
+          {toasts.map((toast) => {
+            const activate = () => {
+              if (!toast.action) return;
+              try {
+                toast.action.onClick();
+              } finally {
+                dismiss(toast.id);
+              }
+            };
+            return (
+              <div
+                key={toast.id}
+                className="gloom-toast"
+                data-type={toast.type}
+                data-actionable={toast.action ? "true" : "false"}
+                onClick={toast.action ? activate : undefined}
+              >
+                <span className="gloom-toast-indicator" aria-hidden="true" />
+                <div className="gloom-toast-content">
+                  {(toast.title || toast.subtitle) && (
+                    <div className="gloom-toast-heading">
+                      {toast.title && <span className="gloom-toast-title">{toast.title}</span>}
+                      {toast.subtitle && <span className="gloom-toast-subtitle">{toast.subtitle}</span>}
+                    </div>
+                  )}
+                  <div className="gloom-toast-body">{toast.body}</div>
+                </div>
+                <div className="gloom-toast-controls">
+                  {toast.action && (
+                    <button
+                      type="button"
+                      className="gloom-toast-action"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        activate();
+                      }}
+                    >
+                      {toast.action.label}
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    className="gloom-toast-dismiss"
+                    aria-label="Dismiss notification"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      dismiss(toast.id);
+                    }}
+                  >
+                    <svg viewBox="0 0 12 12" width="12" height="12" aria-hidden="true">
+                      <path d="M2.25 2.25 9.75 9.75M9.75 2.25 2.25 9.75" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            );
+          })}
         </div>
       );
     },

--- a/src/ui/toast.tsx
+++ b/src/ui/toast.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, type ComponentType, type ReactNode } from "react";
 
 export interface ToastOptions {
+  title?: string;
+  subtitle?: string;
   duration?: number;
   action?: {
     label: string;


### PR DESCRIPTION
## Summary
- restyle DOM notifications with clearer hierarchy, tone accents, dismiss controls, and preserved title/subtitle context
- make the full notification card open its action while keeping the action and dismiss buttons accessible
- route chat notifications to the exact message and price alerts to the alerts pane
- honor persistent in-app notifications

## Verification
- `bun test` (2,315 passed)
- `bun run typecheck`
- `bun run build`
- `bun run desktop:view:build`
- `bun run web:build`
- browser visual check at 1200x800
