### PR TITLE
Fix short P&L, web QR login, and command-bar click-through

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,9 +27,17 @@ case "$ARCH" in
     ;;
 esac
 
-# macOS x64 uses arm64 binary (runs via Rosetta 2)
+# Apple Silicon shells under Rosetta report x86_64. Genuine Intel Macs cannot
+# run the arm64 app and must fail instead of downloading a bad binary.
 if [ "$os" = "darwin" ] && [ "$arch" = "x64" ]; then
-  arch="arm64"
+  translated="$(sysctl -n sysctl.proc_translated 2>/dev/null || true)"
+  has_arm64="$(sysctl -n hw.optional.arm64 2>/dev/null || true)"
+  if [ "$translated" = "1" ] || [ "$has_arm64" = "1" ]; then
+    arch="arm64"
+  else
+    echo "Intel Macs are not supported. Gloomberb currently ships Apple Silicon (arm64) only."
+    exit 1
+  fi
 fi
 
 download_file() {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -277,7 +277,7 @@ function AppInner({
     importBrokerPositions,
     marketData,
     pluginRegistry,
-    state,
+    stateRef,
     tickerRepository,
   });
 

--- a/src/app/pane-runtime/plugin-bindings.ts
+++ b/src/app/pane-runtime/plugin-bindings.ts
@@ -112,7 +112,7 @@ export function bindAppPanePluginRegistry({
       launch: { kind: "plugin-command", commandId },
     });
   };
-  pluginRegistry.getLayoutFn = () => state.config.layout;
+  pluginRegistry.getLayoutFn = () => stateRef.current.config.layout;
   pluginRegistry.updateLayoutFn = (layout) => {
     if (isDetachedWindow) return;
     persistLayout(layout);
@@ -151,8 +151,9 @@ export function bindAppPanePluginRegistry({
   pluginRegistry.hidePaneFn = (paneId) => {
     if (isDetachedWindow) return;
     const instanceId = resolvePaneTarget(paneId);
-    if (!instanceId || !isPaneInLayout(state.config.layout, instanceId)) return;
-    persistLayout(removePane(state.config.layout, instanceId));
+    const layout = stateRef.current.config.layout;
+    if (!instanceId || !isPaneInLayout(layout, instanceId)) return;
+    persistLayout(removePane(layout, instanceId));
   };
   pluginRegistry.focusPaneFn = (paneId) => {
     if (isDetachedWindow) {
@@ -162,7 +163,7 @@ export function bindAppPanePluginRegistry({
       return;
     }
     const instanceId = resolvePaneTarget(paneId);
-    if (!instanceId || !isPaneInLayout(state.config.layout, instanceId)) {
+    if (!instanceId || !isPaneInLayout(stateRef.current.config.layout, instanceId)) {
       showPane(paneId);
       return;
     }

--- a/src/app/runtime/plugin-bindings.ts
+++ b/src/app/runtime/plugin-bindings.ts
@@ -23,7 +23,7 @@ export function bindPluginRegistryRuntimeAccess({
   importBrokerPositions,
   marketData,
   pluginRegistry,
-  state,
+  stateRef,
   tickerRepository,
 }: {
   dataProvider: DataProvider;
@@ -31,31 +31,32 @@ export function bindPluginRegistryRuntimeAccess({
   importBrokerPositions: (instanceId: string) => Promise<unknown>;
   marketData: MarketDataCoordinator;
   pluginRegistry: PluginRegistry;
-  state: AppState;
+  stateRef: { current: AppState };
   tickerRepository: AppTickerRepositoryPort;
 }) {
-  pluginRegistry.getTickerFn = (symbol) => state.tickers.get(symbol) ?? null;
+  pluginRegistry.getTickerFn = (symbol) => stateRef.current.tickers.get(symbol) ?? null;
   pluginRegistry.getDataFn = (symbol) => {
-    const ticker = state.tickers.get(symbol) ?? null;
+    const ticker = stateRef.current.tickers.get(symbol) ?? null;
     const instrument = instrumentFromTicker(ticker, symbol);
     return instrument ? marketData.getTickerFinancialsSync(instrument) : null;
   };
-  pluginRegistry.getConfigFn = () => state.config;
-  pluginRegistry.getPaneRuntimeStateFn = (paneId) => state.paneState[paneId] ?? null;
+  pluginRegistry.getConfigFn = () => stateRef.current.config;
+  pluginRegistry.getPaneRuntimeStateFn = (paneId) => stateRef.current.paneState[paneId] ?? null;
   pluginRegistry.updatePaneRuntimeStateFn = (paneId, patch) => {
     dispatch({ type: "UPDATE_PANE_STATE", paneId, patch });
   };
   pluginRegistry.getPluginConfigValueFn = (pluginId, key) => (
-    (state.config.pluginConfig[pluginId]?.[key] as any) ?? null
+    (stateRef.current.config.pluginConfig[pluginId]?.[key] as any) ?? null
   );
 
   const setPluginConfigValues = async (pluginId: string, values: Record<string, unknown>) => {
+    const currentConfig = stateRef.current.config;
     const nextConfig = {
-      ...state.config,
+      ...currentConfig,
       pluginConfig: {
-        ...state.config.pluginConfig,
+        ...currentConfig.pluginConfig,
         [pluginId]: {
-          ...(state.config.pluginConfig[pluginId] ?? {}),
+          ...(currentConfig.pluginConfig[pluginId] ?? {}),
           ...values,
         },
       },
@@ -70,13 +71,14 @@ export function bindPluginRegistryRuntimeAccess({
   };
   pluginRegistry.setPluginConfigValuesFn = setPluginConfigValues;
   pluginRegistry.deletePluginConfigValueFn = async (pluginId, key) => {
-    const currentPluginConfig = state.config.pluginConfig[pluginId];
+    const currentConfig = stateRef.current.config;
+    const currentPluginConfig = currentConfig.pluginConfig[pluginId];
     if (!currentPluginConfig || !(key in currentPluginConfig)) return;
 
     const nextPluginConfig = { ...currentPluginConfig };
     delete nextPluginConfig[key];
 
-    const nextAllPluginConfig = { ...state.config.pluginConfig };
+    const nextAllPluginConfig = { ...currentConfig.pluginConfig };
     if (Object.keys(nextPluginConfig).length === 0) {
       delete nextAllPluginConfig[pluginId];
     } else {
@@ -84,7 +86,7 @@ export function bindPluginRegistryRuntimeAccess({
     }
 
     const nextConfig = {
-      ...state.config,
+      ...currentConfig,
       pluginConfig: nextAllPluginConfig,
     };
     dispatch({ type: "SET_CONFIG", config: nextConfig });
@@ -96,14 +98,14 @@ export function bindPluginRegistryRuntimeAccess({
     setConfigAccessor?: (accessor: () => AppConfig) => void;
   };
   if (typeof configurableProvider.setConfigAccessor === "function") {
-    configurableProvider.setConfigAccessor(() => state.config);
+    configurableProvider.setConfigAccessor(() => stateRef.current.config);
   }
 
   pluginRegistry.createBrokerInstanceFn = async (brokerType, label, values) => {
     const instanceId = createBrokerInstanceId(
       brokerType,
       label,
-      state.config.brokerInstances.map((instance) => instance.id),
+      stateRef.current.config.brokerInstances.map((instance) => instance.id),
     );
     const instance: BrokerInstanceConfig = {
       id: instanceId,
@@ -114,8 +116,8 @@ export function bindPluginRegistryRuntimeAccess({
       enabled: true,
     };
     const nextConfig = {
-      ...state.config,
-      brokerInstances: [...state.config.brokerInstances, instance],
+      ...stateRef.current.config,
+      brokerInstances: [...stateRef.current.config.brokerInstances, instance],
     };
     dispatch({ type: "SET_CONFIG", config: nextConfig });
     await saveConfigImmediately(nextConfig);
@@ -124,7 +126,7 @@ export function bindPluginRegistryRuntimeAccess({
   };
 
   pluginRegistry.connectBrokerInstanceFn = async (instanceId) => {
-    const instance = getBrokerInstance(state.config.brokerInstances, instanceId);
+    const instance = getBrokerInstance(stateRef.current.config.brokerInstances, instanceId);
     if (!instance) throw new Error("Broker profile not found.");
     if (instance.enabled === false) throw new Error(`Broker profile "${instance.label}" is disabled.`);
 
@@ -142,8 +144,8 @@ export function bindPluginRegistryRuntimeAccess({
   };
 
   pluginRegistry.updateBrokerInstanceFn = async (instanceId, values, options = {}) => {
-    const currentInstance = state.config.brokerInstances.find((instance) => instance.id === instanceId);
-    const nextInstances = state.config.brokerInstances.map((instance) =>
+    const currentInstance = stateRef.current.config.brokerInstances.find((instance) => instance.id === instanceId);
+    const nextInstances = stateRef.current.config.brokerInstances.map((instance) =>
       instance.id === instanceId
         ? (() => {
           const nextValues = options.replaceConfig ? values : { ...instance.config, ...values };
@@ -167,7 +169,7 @@ export function bindPluginRegistryRuntimeAccess({
       clearPersistedBrokerAccounts(pluginRegistry.persistence.resources, currentInstance);
     }
     const nextConfig = {
-      ...state.config,
+      ...stateRef.current.config,
       brokerInstances: nextInstances,
     };
     dispatch({ type: "SET_CONFIG", config: nextConfig });
@@ -180,7 +182,7 @@ export function bindPluginRegistryRuntimeAccess({
   };
 
   pluginRegistry.removeBrokerInstanceFn = async (instanceId) => {
-    const instance = getBrokerInstance(state.config.brokerInstances, instanceId);
+    const instance = getBrokerInstance(stateRef.current.config.brokerInstances, instanceId);
     if (!instance) return;
 
     clearPersistedBrokerAccounts(pluginRegistry.persistence.resources, instance);
@@ -189,15 +191,15 @@ export function bindPluginRegistryRuntimeAccess({
     await broker?.disconnect?.(instance).catch(() => {});
 
     const removedPortfolioIds = new Set(
-      state.config.portfolios
+      stateRef.current.config.portfolios
         .filter((portfolio) => portfolio.brokerInstanceId === instanceId)
         .map((portfolio) => portfolio.id),
     );
 
-    const nextPortfolios = state.config.portfolios.filter((portfolio) => !removedPortfolioIds.has(portfolio.id));
-    const nextTickers = new Map(state.tickers);
+    const nextPortfolios = stateRef.current.config.portfolios.filter((portfolio) => !removedPortfolioIds.has(portfolio.id));
+    const nextTickers = new Map(stateRef.current.tickers);
 
-    for (const ticker of state.tickers.values()) {
+    for (const ticker of stateRef.current.tickers.values()) {
       const nextPositions = ticker.metadata.positions.filter((position) => position.brokerInstanceId !== instanceId);
       const nextPortfolioRefs = ticker.metadata.portfolios.filter((portfolioId) => !removedPortfolioIds.has(portfolioId));
       const nextBrokerContracts = (ticker.metadata.broker_contracts ?? []).filter((contract) => contract.brokerInstanceId !== instanceId);
@@ -233,8 +235,8 @@ export function bindPluginRegistryRuntimeAccess({
     }
 
     const nextConfig = {
-      ...state.config,
-      brokerInstances: state.config.brokerInstances.filter((entry) => entry.id !== instanceId),
+      ...stateRef.current.config,
+      brokerInstances: stateRef.current.config.brokerInstances.filter((entry) => entry.id !== instanceId),
       portfolios: nextPortfolios,
     };
 

--- a/src/components/layout/shell/drag/runtime.ts
+++ b/src/components/layout/shell/drag/runtime.ts
@@ -191,6 +191,7 @@ interface UseShellPointerRuntimeOptions {
   visibleLayout: LayoutConfig;
   width: number;
   windowMode: WindowEditState | null;
+  commandBarOpen: boolean;
 }
 
 export function useShellPointerRuntime({
@@ -221,6 +222,7 @@ export function useShellPointerRuntime({
   visibleLayout,
   width,
   windowMode,
+  commandBarOpen,
 }: UseShellPointerRuntimeOptions) {
   const handleActiveDrag = useShellActiveDrag({
     appHeaderHeight,
@@ -278,6 +280,7 @@ export function useShellPointerRuntime({
     setMenuState,
     transientFocusActive,
     windowMode,
+    commandBarOpen,
   });
 
   return {

--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -21,6 +21,7 @@ import {
   syncConfigActiveLayoutState,
   useAppDispatch,
   useAppSelector,
+  useAppStateRef,
 } from "../../../state/app/context";
 import {
   selectCommandBarOpen,
@@ -101,6 +102,7 @@ export function Shell({
   const previousFocusedPaneId = useAppSelector((state) => state.previousFocusedPaneId);
   const activePanel = useAppSelector((state) => state.activePanel);
   const commandBarOpen = useAppSelector(selectCommandBarOpen);
+  const stateRef = useAppStateRef();
   const inputCaptured = useAppSelector((state) => state.inputCaptured);
   const statusBarVisible = useAppSelector(selectStatusBarVisible);
   const rendererHost = useRendererHost();
@@ -120,8 +122,9 @@ export function Shell({
   const dialogOpen = useDialogState((dialog) => dialog.isOpen);
   const [hoveredPaneId, setHoveredPaneId] = useState<string | null>(null);
   const setHoveredPaneIfChanged = useCallback((paneId: string | null) => {
+    if (commandBarOpen) return;
     setHoveredPaneId((current) => (current === paneId ? current : paneId));
-  }, []);
+  }, [commandBarOpen]);
   const [menuState, setMenuState] = useState<ActionMenuState | null>(null);
   const [transientFocusLayoutState, setTransientFocusLayoutState] = useState<TransientFocusLayoutState | null>(null);
   const transientFocusLayoutStateRef = useRef<TransientFocusLayoutState | null>(null);
@@ -132,6 +135,9 @@ export function Shell({
     setHoveredMenuItemId(null);
   }, []);
   const overlayOpen = commandBarOpen || dialogOpen || !!menuState;
+  useEffect(() => {
+    if (commandBarOpen) setHoveredPaneId(null);
+  }, [commandBarOpen]);
 
   const dragRuntime = useShellDragRuntimeState({
     contentHeight,
@@ -166,13 +172,14 @@ export function Shell({
     dispatch(hasFocusTarget
       ? { type: "UPDATE_LAYOUT", layout: nextLayout, focusedPaneId: options.focusedPaneId ?? null }
       : { type: "UPDATE_LAYOUT", layout: nextLayout });
+    const currentState = stateRef.current;
     scheduleConfigSave(syncConfigActiveLayoutState(
-      { ...config, layout: nextLayout },
-      paneState,
-      hasFocusTarget ? (options.focusedPaneId ?? null) : focusedPaneId,
-      activePanel,
+      { ...currentState.config, layout: nextLayout },
+      currentState.paneState,
+      hasFocusTarget ? (options.focusedPaneId ?? null) : currentState.focusedPaneId,
+      currentState.activePanel,
     ));
-  }, [activePanel, config, dispatch, focusedPaneId, paneState]);
+  }, [dispatch, stateRef]);
 
   const focusPane = useCallback((paneId: string) => {
     dispatch({ type: "FOCUS_PANE", paneId });
@@ -542,6 +549,7 @@ export function Shell({
     visibleLayout,
     width,
     windowMode,
+    commandBarOpen,
   });
   const windowModeDockResizePathKey = windowMode?.focus.kind === "dock-resize"
     ? windowMode.focus.pathKey

--- a/src/components/layout/shell/native/pointer-runtime.ts
+++ b/src/components/layout/shell/native/pointer-runtime.ts
@@ -22,6 +22,7 @@ interface UseShellNativePointerRuntimeOptions {
   setMenuState: Dispatch<SetStateAction<ActionMenuState | null>>;
   transientFocusActive: boolean;
   windowMode: WindowEditState | null;
+  commandBarOpen?: boolean;
 }
 
 export function useShellNativePointerRuntime({
@@ -38,6 +39,7 @@ export function useShellNativePointerRuntime({
   setMenuState,
   transientFocusActive,
   windowMode,
+  commandBarOpen = false,
 }: UseShellNativePointerRuntimeOptions) {
   const {
     dragRef,
@@ -59,6 +61,11 @@ export function useShellNativePointerRuntime({
   }, [focusPane, menuState, setHoveredMenuItemId, setMenuState]);
 
   const handleNativePaneMouseDown = useCallback((paneId: string, event: ShellMouseEvent) => {
+    if (commandBarOpen) {
+      event.stopPropagation();
+      event.preventDefault();
+      return;
+    }
     if (windowMode) {
       selectWindowModePane(paneId);
       event.stopPropagation();
@@ -69,10 +76,11 @@ export function useShellNativePointerRuntime({
       if (event.isDefaultPrevented?.()) return;
       focusNativePane(paneId);
     });
-  }, [focusNativePane, selectWindowModePane, windowMode]);
+  }, [commandBarOpen, focusNativePane, selectWindowModePane, windowMode]);
 
   const startNativeFloatingDrag = useCallback((paneId: string, rect: FloatingRect, event: ShellMouseEvent) => {
     if (!nativePaneChrome) return;
+    if (commandBarOpen) return;
     if (windowMode) return;
     if (transientFocusActive) return;
     if (event.button === 2) return;
@@ -89,10 +97,11 @@ export function useShellNativePointerRuntime({
     };
     updateDragFloatingRect({ paneId, rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height } });
     event.preventDefault();
-  }, [dragRef, focusNativePane, getShellPointer, nativePaneChrome, transientFocusActive, updateDragFloatingRect, windowMode]);
+  }, [commandBarOpen, dragRef, focusNativePane, getShellPointer, nativePaneChrome, transientFocusActive, updateDragFloatingRect, windowMode]);
 
   const startNativeDockedDrag = useCallback((paneId: string, rect: LayoutBounds, event: ShellMouseEvent) => {
     if (!nativePaneChrome) return;
+    if (commandBarOpen) return;
     if (windowMode) return;
     if (transientFocusActive) return;
     if (event.button === 2) return;
@@ -108,10 +117,11 @@ export function useShellNativePointerRuntime({
       origRect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
     };
     event.preventDefault();
-  }, [dragRef, focusNativePane, getShellPointer, nativePaneChrome, transientFocusActive, windowMode]);
+  }, [commandBarOpen, dragRef, focusNativePane, getShellPointer, nativePaneChrome, transientFocusActive, windowMode]);
 
   const startNativeFloatResize = useCallback((paneId: string, rect: FloatingRect, event: ShellMouseEvent) => {
     if (!nativePaneChrome) return;
+    if (commandBarOpen) return;
     if (transientFocusActive) return;
 
     const pointer = getShellPointer(event);
@@ -130,10 +140,11 @@ export function useShellNativePointerRuntime({
     updateDragFloatingRect({ paneId, rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height } });
     event.stopPropagation();
     event.preventDefault();
-  }, [dragRef, focusNativePane, getShellPointer, nativePaneChrome, selectWindowModePane, transientFocusActive, updateDragFloatingRect, windowMode]);
+  }, [commandBarOpen, dragRef, focusNativePane, getShellPointer, nativePaneChrome, selectWindowModePane, transientFocusActive, updateDragFloatingRect, windowMode]);
 
   const startNativeDividerDrag = useCallback((divider: DockDividerLayout, event: ShellMouseEvent) => {
     if (!nativePaneChrome) return;
+    if (commandBarOpen) return;
     if (transientFocusActive) return;
 
     const pointer = getShellPointer(event);
@@ -157,27 +168,30 @@ export function useShellNativePointerRuntime({
     });
     event.stopPropagation();
     event.preventDefault();
-  }, [dragRef, getShellPointer, menuState, nativePaneChrome, setHoveredMenuItemId, setMenuState, transientFocusActive, updateDividerPreview]);
+  }, [commandBarOpen, dragRef, getShellPointer, menuState, nativePaneChrome, setHoveredMenuItemId, setMenuState, transientFocusActive, updateDividerPreview]);
 
   const handlePaneAction = useCallback((paneId: string, rect: LayoutBounds, event: ShellMouseEvent) => {
+    if (commandBarOpen) return;
     if (windowMode) return;
     if (event.button === 2) return;
     event.stopPropagation();
     event.preventDefault();
     openPaneMenu(paneId, rect, event);
-  }, [openPaneMenu, windowMode]);
+  }, [commandBarOpen, openPaneMenu, windowMode]);
 
   const handleNativePaneContextMenu = useCallback((paneId: string, rect: LayoutBounds, event: ShellMouseEvent) => {
+    if (commandBarOpen) return;
     if (windowMode) return;
     openPaneMenu(paneId, rect, event);
-  }, [openPaneMenu, windowMode]);
+  }, [commandBarOpen, openPaneMenu, windowMode]);
 
   const handleFloatingCloseMouseDown = useCallback((paneId: string, event: ShellMouseEvent) => {
+    if (commandBarOpen) return;
     if (windowMode) return;
     event.stopPropagation();
     event.preventDefault();
     handleFloatingClose(paneId);
-  }, [handleFloatingClose, windowMode]);
+  }, [commandBarOpen, handleFloatingClose, windowMode]);
 
   return {
     handleFloatingCloseMouseDown,

--- a/src/plugins/broker-sync/broker-sync.test.ts
+++ b/src/plugins/broker-sync/broker-sync.test.ts
@@ -55,6 +55,35 @@ describe("broker position normalization", () => {
       markPrice: 250,
     }));
   });
+
+  test("stores shorts as absolute shares and weighted-averages merged short lots", () => {
+    const snapshot = normalizeRobinhoodSnapshot(
+      { accounts: [{ account_number: "RH-1", account_type: "INDIVIDUAL" }] },
+      [{ result: { positions: [
+        {
+          accountNumber: "RH-1",
+          instrument: { symbol: "TSLA" },
+          quantity: "-10",
+          average_cost: "100",
+          market_value: "-800",
+        },
+        {
+          accountNumber: "RH-1",
+          instrument: { symbol: "TSLA" },
+          quantity: "-5",
+          average_cost: "110",
+          market_value: "-400",
+        },
+      ] } }],
+    );
+
+    expect(snapshot.positions).toEqual([expect.objectContaining({
+      ticker: "TSLA",
+      shares: 15,
+      avgCost: 1550 / 15,
+      side: "short",
+    })]);
+  });
 });
 
 describe("broker authentication boundaries", () => {

--- a/src/plugins/broker-sync/normalize.ts
+++ b/src/plugins/broker-sync/normalize.ts
@@ -80,7 +80,14 @@ function uniqueSnapshot(accounts: BrokerAccount[], positions: BrokerPosition[]):
       currency: position.currency,
     });
   }
-  return { accounts: uniqueAccounts, positions: mergeIdenticalPositions(positions) };
+  return { accounts: uniqueAccounts, positions: mergeIdenticalPositions(positions.map(withCanonicalShares)) };
+}
+
+function withCanonicalShares(position: BrokerPosition): BrokerPosition {
+  const side = position.side ?? (position.shares < 0 ? "short" : "long");
+  const shares = Math.abs(position.shares);
+  if (shares === position.shares && side === position.side) return position;
+  return { ...position, shares, side };
 }
 
 function mergeIdenticalPositions(positions: BrokerPosition[]): BrokerPosition[] {
@@ -104,7 +111,7 @@ function mergeIdenticalPositions(positions: BrokerPosition[]): BrokerPosition[] 
     merged.set(key, {
       ...existing,
       shares,
-      avgCost: shares > 0 ? (existingCost + nextCost) / shares : existing.avgCost,
+      avgCost: shares !== 0 ? (existingCost + nextCost) / shares : existing.avgCost,
       marketValue: sumOptional(existing.marketValue, position.marketValue),
       unrealizedPnl: sumOptional(existing.unrealizedPnl, position.unrealizedPnl),
     });

--- a/src/plugins/builtin/alerts/alert-engine.test.ts
+++ b/src/plugins/builtin/alerts/alert-engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { evaluateAlert, createAlert, editAlert, serializeAlerts, deserializeAlerts } from "./alert-engine";
+import { evaluateAlert, createAlert, editAlert, rearmAlert, serializeAlerts, deserializeAlerts } from "./alert-engine";
 
 describe("evaluateAlert", () => {
   test("above: triggers when price exceeds target", () => {
@@ -70,6 +70,21 @@ describe("editAlert", () => {
     });
     // A stale lastCheckedPrice would make `crosses` fire off the previous symbol's baseline.
     expect(evaluateAlert(edited, 185)).toBe(false);
+  });
+
+  test("rearming a crosses alert drops the old quote baseline", () => {
+    const alert = {
+      ...createAlert("AAPL", "crosses", 180),
+      status: "triggered" as const,
+      triggeredAt: 123,
+      lastCheckedPrice: 185,
+    };
+
+    const rearmed = rearmAlert(alert);
+
+    expect(rearmed.status).toBe("active");
+    expect(rearmed.lastCheckedPrice).toBeUndefined();
+    expect(evaluateAlert(rearmed, 175)).toBe(false);
   });
 
   test("drops the exchange when the symbol changes", () => {

--- a/src/plugins/builtin/alerts/alert-engine.ts
+++ b/src/plugins/builtin/alerts/alert-engine.ts
@@ -42,6 +42,10 @@ export function editAlert(
   };
 }
 
+export function rearmAlert(alert: AlertRule): AlertRule {
+  return editAlert(alert, alert.symbol, alert.condition, alert.targetPrice);
+}
+
 export function evaluateAlert(alert: AlertRule, currentPrice: number): boolean {
   if (alert.status !== "active") return false;
 

--- a/src/plugins/builtin/alerts/pane.tsx
+++ b/src/plugins/builtin/alerts/pane.tsx
@@ -15,6 +15,7 @@ import { usePluginAppActions, usePluginConfigState } from "../../runtime";
 import {
   deserializeAlerts,
   editAlert,
+  rearmAlert as rebuildAlert,
   readAlertsStoreError,
   serializeAlerts,
 } from "./alert-engine";
@@ -97,14 +98,7 @@ export function AlertsPane({ focused, width, height, close }: PaneProps) {
 
   const rearmAlert = useCallback((id: string) => {
     savePaneAlerts(
-      alerts.map((a) =>
-        a.id === id ? {
-          ...a,
-          status: "active" as const,
-          triggeredAt: undefined,
-          lastCheckError: undefined,
-        } : a,
-      ),
+      alerts.map((a) => (a.id === id ? rebuildAlert(a) : a)),
     );
   }, [alerts, savePaneAlerts]);
 

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -87,6 +87,7 @@ interface ChartComposerSurfaceProps {
   height: number;
   footerId: string;
   onCapture?: (capturing: boolean) => void;
+  liveWhenUnfocused?: boolean;
 }
 
 const QUICK_ADD_CAPTURE = "quick-add";
@@ -106,6 +107,7 @@ function ChartComposerSurface({
   height,
   footerId,
   onCapture,
+  liveWhenUnfocused = true,
 }: ChartComposerSurfaceProps) {
   const dialog = useDialog();
   const dispatch = useAppDispatch();
@@ -153,7 +155,7 @@ function ChartComposerSurface({
       : null,
     requestViewport: activeRuntimeViewport?.requestViewport,
     targetPointCount,
-    liveStreaming,
+    liveStreaming: liveStreaming && (liveWhenUnfocused || focused),
   });
   const availableResolutions = useMemo<ChartResolution[]>(() => {
     if (!resolution.resolutionSupport) {
@@ -656,6 +658,20 @@ export function ChartComposerPane({ paneId, focused, width, height }: PaneProps)
   );
 }
 
+function firstChartSecuritySymbol(spec: ChartSpec): string | null {
+  for (const entry of spec.series) {
+    if (entry.source.kind === "security") return entry.source.instrument.symbol;
+  }
+  return null;
+}
+
+function specHasSecuritySymbol(spec: ChartSpec, symbol: string | null | undefined): boolean {
+  if (!symbol) return false;
+  return spec.series.some((entry) => (
+    entry.source.kind === "security" && entry.source.instrument.symbol === symbol
+  ));
+}
+
 export function ChartComposerResearchTab({ focused, width, height, onCapture }: TickerResearchTabProps) {
   const { symbol } = usePaneTicker();
   const fallback = useMemo(() => symbol ? buildPriceChartPreset(symbol) : buildEmptyChartPreset(), [symbol]);
@@ -664,11 +680,18 @@ export function ChartComposerResearchTab({ focused, width, height, onCapture }: 
   const previousSymbolRef = useRef(symbol);
 
   useEffect(() => {
+    if (!symbol) return;
     const previousSymbol = previousSymbolRef.current;
-    previousSymbolRef.current = symbol;
-    if (!symbol || !previousSymbol || symbol === previousSymbol) return;
-    const rebound = rebindChartSecuritySymbol(spec, previousSymbol, symbol);
+    const fromSymbol = specHasSecuritySymbol(spec, previousSymbol)
+      ? previousSymbol
+      : firstChartSecuritySymbol(spec) ?? previousSymbol;
+    if (!fromSymbol || fromSymbol === symbol) {
+      previousSymbolRef.current = symbol;
+      return;
+    }
+    const rebound = rebindChartSecuritySymbol(spec, fromSymbol, symbol);
     if (rebound !== spec) setStoredSpec(rebound);
+    previousSymbolRef.current = symbol;
   }, [setStoredSpec, spec, symbol]);
 
   return (
@@ -680,6 +703,7 @@ export function ChartComposerResearchTab({ focused, width, height, onCapture }: 
       height={height}
       footerId="chart-composer:research"
       onCapture={onCapture}
+      liveWhenUnfocused={false}
     />
   );
 }

--- a/src/plugins/builtin/fear-greed/charts.tsx
+++ b/src/plugins/builtin/fear-greed/charts.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Box, Text, TextAttributes, useUiHost } from "../../../ui";
 import { StaticChartSurface } from "../../../components";
 import { colors, blendHex } from "../../../theme/colors";
@@ -126,13 +127,15 @@ function SentimentChart({
   const chartWidth = Math.max(24, width - 2);
   const chartHeight = width >= 96 ? 12 : 10;
   const color = ratingColor(rating);
-  const basePalette = resolveChartPalette(colors, ratingTrend(rating));
-  const palette = {
-    ...basePalette,
-    lineColor: color,
-    fillColor: blendHex(colors.bg, color, 0.18),
-    gridColor: blendHex(colors.bg, colors.border, 0.55),
-  };
+  const palette = useMemo(() => {
+    const basePalette = resolveChartPalette(colors, ratingTrend(rating));
+    return {
+      ...basePalette,
+      lineColor: color,
+      fillColor: blendHex(colors.bg, color, 0.18),
+      gridColor: blendHex(colors.bg, colors.border, 0.55),
+    };
+  }, [color, rating]);
   const latest = points.length > 0 ? points[points.length - 1]!.close : null;
 
   return (
@@ -294,6 +297,7 @@ export function IndexHistoryChart({ data, width }: { data: FearGreedData; width:
 }
 
 export function IndicatorChart({ indicator, width }: { indicator: FearGreedIndicator; width: number }) {
+  const overlays = useMemo(() => chartOverlay(indicator), [indicator.secondaryPoints]);
   return (
     <SentimentChart
       title={indicator.definition.title}
@@ -306,7 +310,7 @@ export function IndicatorChart({ indicator, width }: { indicator: FearGreedIndic
       primaryLabel={indicator.definition.primaryLabel}
       secondaryLabel={indicator.definition.secondaryLabel}
       secondaryValue={indicator.latestSecondaryValue}
-      overlays={chartOverlay(indicator)}
+      overlays={overlays}
     />
   );
 }

--- a/src/plugins/builtin/news/wire/index.tsx
+++ b/src/plugins/builtin/news/wire/index.tsx
@@ -47,7 +47,7 @@ const TopPane = createNewsPresetPane({
   columns: ["time", "source", "title", "tickers", "categories", "importance"],
   defaultSort: { columnId: "importance", direction: "desc" },
   emptyStateTitle: "No top stories yet",
-  emptyStateHint: "Run the Add News Feed command to wire up another source.",
+  emptyStateHint: "Top stories appear when curated market sources publish them.",
 });
 
 const FeedPane = createNewsPresetPane({

--- a/src/plugins/builtin/portfolio-list/account-metrics.test.ts
+++ b/src/plugins/builtin/portfolio-list/account-metrics.test.ts
@@ -47,6 +47,7 @@ describe("resolvePortfolioAccountMetrics", () => {
       grossPositionValue: 8_000,
       dailyPnl: 100,
       unrealizedPnl: 400,
+      realizedPnl: -50,
     };
     const toUsd = (value: number) => value * 1.1;
 
@@ -55,6 +56,7 @@ describe("resolvePortfolioAccountMetrics", () => {
     expect(metrics.dailyPnlPct).toBeCloseTo(110 / 10_890 * 100);
     expect(metrics.unrealizedPnl).toBeCloseTo(440);
     expect(metrics.unrealizedPnlPct).toBeCloseTo(5.5);
+    expect(metrics.realizedPnl).toBeCloseTo(-55);
     expect(resolvePortfolioMarketValue(createTotals(), account, toUsd)).toBeCloseTo(8_800);
   });
 

--- a/src/plugins/builtin/portfolio-list/account-metrics.ts
+++ b/src/plugins/builtin/portfolio-list/account-metrics.ts
@@ -60,6 +60,6 @@ export function resolvePortfolioAccountMetrics(
     dailyPnlPct,
     unrealizedPnl,
     unrealizedPnlPct,
-    realizedPnl: finiteNumber(account?.realizedPnl) ? account.realizedPnl : undefined,
+    realizedPnl: finiteNumber(account?.realizedPnl) ? convertAccountValue(account.realizedPnl) : undefined,
   };
 }

--- a/src/plugins/builtin/portfolio-list/cli/render.ts
+++ b/src/plugins/builtin/portfolio-list/cli/render.ts
@@ -142,11 +142,13 @@ async function showCollectionWithMarketData(
         const multiplier = position.multiplier ?? 1;
         const quoteCurrency = quote?.currency ?? ticker.metadata.currency ?? baseCurrency;
         const positionCurrency = position.currency ?? quoteCurrency;
+        const direction = position.side === "short" || position.shares < 0 ? -1 : 1;
+        const magnitude = Math.abs(position.shares);
         const currentValueBase = quote
-          ? await toBase(Math.abs(position.shares) * quote.price * multiplier, quoteCurrency)
+          ? await toBase(magnitude * quote.price * multiplier, quoteCurrency)
           : null;
-        const costBasisBase = await toBase(position.shares * position.avgCost * multiplier, positionCurrency);
-        const pnl = currentValueBase != null ? currentValueBase - costBasisBase : null;
+        const costBasisBase = await toBase(magnitude * position.avgCost * multiplier, positionCurrency);
+        const pnl = currentValueBase != null ? direction * (currentValueBase - costBasisBase) : null;
         if (pnl != null) totalPnl += pnl;
 
         rows.push([

--- a/src/plugins/builtin/portfolio-list/column-values.ts
+++ b/src/plugins/builtin/portfolio-list/column-values.ts
@@ -26,6 +26,7 @@ import {
   getPortfolioPositionMetrics,
   resolveBrokerFallbackMarketValue,
   resolveBrokerFallbackPnl,
+  signedQuoteUnrealizedPnl,
 } from "./position-metrics";
 
 export interface ColumnContext {
@@ -332,7 +333,11 @@ export function getColumnValue(
       return { text: "—" };
     case "pnl":
       if (activeQuote && totalPriceUnits !== 0) {
-        const pnl = toBaseQuote(Math.abs(totalPriceUnits) * activeQuote.price) - toBasePosition(totalCost);
+        const pnl = signedQuoteUnrealizedPnl(
+          toBaseQuote(Math.abs(totalPriceUnits) * activeQuote.price),
+          toBasePosition(totalCost),
+          totalPriceUnits,
+        );
         return { text: `${pnl >= 0 ? "+" : ""}${formatCompact(pnl)}`, color: priceColor(pnl) };
       }
       if (brokerFallbackPnl != null) {
@@ -344,7 +349,8 @@ export function getColumnValue(
       if (activeQuote && totalCost !== 0) {
         const marketValue = toBaseQuote(Math.abs(totalPriceUnits) * activeQuote.price);
         const costBasis = toBasePosition(totalCost);
-        const percent = costBasis !== 0 ? ((marketValue - costBasis) / costBasis) * 100 : 0;
+        const pnl = signedQuoteUnrealizedPnl(marketValue, costBasis, totalPriceUnits);
+        const percent = costBasis !== 0 ? (pnl / costBasis) * 100 : 0;
         return { text: formatPercentRaw(percent), color: priceColor(percent) };
       }
       if (brokerFallbackPnl != null && totalCost !== 0) {
@@ -530,7 +536,11 @@ export function getSortValue(
       return null;
     case "pnl":
       if (activeQuote && totalPriceUnits !== 0) {
-        return toBaseQuote(Math.abs(totalPriceUnits) * activeQuote.price) - toBasePosition(totalCost);
+        return signedQuoteUnrealizedPnl(
+          toBaseQuote(Math.abs(totalPriceUnits) * activeQuote.price),
+          toBasePosition(totalCost),
+          totalPriceUnits,
+        );
       }
       if (brokerFallbackPnl != null) {
         return toBasePosition(brokerFallbackPnl);
@@ -540,7 +550,8 @@ export function getSortValue(
       if (activeQuote && totalCost !== 0) {
         const marketValue = toBaseQuote(Math.abs(totalPriceUnits) * activeQuote.price);
         const costBasis = toBasePosition(totalCost);
-        return costBasis !== 0 ? ((marketValue - costBasis) / costBasis) * 100 : null;
+        const pnl = signedQuoteUnrealizedPnl(marketValue, costBasis, totalPriceUnits);
+        return costBasis !== 0 ? (pnl / costBasis) * 100 : null;
       }
       if (brokerFallbackPnl != null && totalCost !== 0) {
         const costBasis = toBasePosition(totalCost);

--- a/src/plugins/builtin/portfolio-list/header.tsx
+++ b/src/plugins/builtin/portfolio-list/header.tsx
@@ -7,7 +7,7 @@ import { colors } from "../../../theme/colors";
 import type { BrokerConnectionStatus } from "../../../types/broker";
 import type { Portfolio } from "../../../types/ticker";
 import type { BrokerAccount } from "../../../types/trading";
-import { formatCompact, padTo } from "../../../utils/format";
+import { convertCurrency, formatCompact, padTo } from "../../../utils/format";
 import { formatMarketQuantity } from "../../../market-data/market/format";
 import { getBrokerInstance } from "../../../utils/broker-instances";
 import { usePluginBrokerActions } from "../../runtime";
@@ -90,14 +90,24 @@ export function PortfolioCashMarginDrawer({
   onToggle,
   width,
   height,
+  baseCurrency,
+  exchangeRates,
 }: {
   accountState: ResolvedPortfolioAccountState;
   expanded: boolean;
   onToggle: () => void;
   width: number;
   height: number;
+  baseCurrency: string;
+  exchangeRates: Map<string, number>;
 }) {
-  const previewText = `${accountState.visibleCashBalances.length} ccy · Cash ${formatCompact(accountState.account.totalCashValue)} · ${accountState.sourceLabel}`;
+  const convertAccountValue = (value: number) => convertCurrency(
+    value,
+    accountState.account.currency || baseCurrency,
+    baseCurrency,
+    exchangeRates,
+  );
+  const previewText = `${accountState.visibleCashBalances.length} ccy · Cash ${formatCompact(convertAccountValue(accountState.account.totalCashValue ?? 0))} · ${accountState.sourceLabel}`;
   const drawerHeight = Math.max(1, height);
 
   if (!expanded) {
@@ -124,7 +134,7 @@ export function PortfolioCashMarginDrawer({
     );
   }
 
-  const metricSegments = buildDrawerMetricSegments(accountState.account, width);
+  const metricSegments = buildDrawerMetricSegments(accountState.account, width, convertAccountValue);
   const currencyRowsHeight = Math.max(1, drawerHeight - 2);
 
   return (

--- a/src/plugins/builtin/portfolio-list/metrics.test.ts
+++ b/src/plugins/builtin/portfolio-list/metrics.test.ts
@@ -199,7 +199,7 @@ describe("portfolio-metrics", () => {
 
     expect(totals.totalMktValue).toBeCloseTo(58803.06, 2);
     expect(totals.totalCostBasis).toBeCloseTo(50950.7295, 4);
-    expect(totals.unrealizedPnl).toBeCloseTo(7852.3305, 4);
+    expect(totals.unrealizedPnl).toBeCloseTo(7852.33, 4);
     expect(totals.hasPositions).toBe(true);
   });
 
@@ -274,6 +274,36 @@ describe("portfolio-metrics", () => {
     expect(getSortValue(pnlColumn, ticker, financials, defaultColumnContext)).toBe(200);
     expect(getColumnValue(latencyColumn, ticker, financials, defaultColumnContext)).toEqual({
       text: "10s",
+    });
+  });
+
+  test("signs short unrealized P&L from a live quote", () => {
+    const ticker = createTicker({
+      positions: [{ portfolio: "main", shares: 10, avgCost: 100, broker: "ibkr", side: "short" }],
+    });
+    const financials = createFinancials({
+      quote: { price: 80, change: -20, changePercent: -20, previousClose: 100 },
+    });
+    const dayPnlColumn: ColumnConfig = { id: "day_pnl", label: "DAY", width: 10, align: "right", format: "compact" };
+    const pnlColumn: ColumnConfig = { id: "pnl", label: "P&L", width: 10, align: "right", format: "compact" };
+
+    expect(getSortValue(dayPnlColumn, ticker, financials, defaultColumnContext)).toBe(200);
+    expect(getSortValue(pnlColumn, ticker, financials, defaultColumnContext)).toBe(200);
+    expect(getColumnValue(pnlColumn, ticker, financials, defaultColumnContext)).toEqual({
+      text: "+200",
+      color: expect.any(String),
+    });
+    expect(calculatePortfolioSummaryTotals(
+      [ticker],
+      new Map([["AAPL", financials]]),
+      "USD",
+      new Map([["USD", 1]]),
+      true,
+      "main",
+    )).toMatchObject({
+      totalMktValue: 800,
+      dailyPnl: 200,
+      unrealizedPnl: 200,
     });
   });
 

--- a/src/plugins/builtin/portfolio-list/pane/index.tsx
+++ b/src/plugins/builtin/portfolio-list/pane/index.tsx
@@ -476,6 +476,8 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
             onToggle={() => setCashDrawerExpanded(!cashDrawerExpanded)}
             width={Math.max(0, width - 2)}
             height={drawerHeight}
+            baseCurrency={config.baseCurrency}
+            exchangeRates={effectiveExchangeRates}
           />
         </Box>
       )}

--- a/src/plugins/builtin/portfolio-list/position-metrics.ts
+++ b/src/plugins/builtin/portfolio-list/position-metrics.ts
@@ -27,6 +27,24 @@ function normalizePositionMultiplier(multiplier: number | undefined): number {
     : 1;
 }
 
+export function signedPositionDirection(position: {
+  shares: number;
+  side?: "long" | "short";
+}): 1 | -1 {
+  if (position.side === "short") return -1;
+  if (position.side === "long") return 1;
+  return position.shares < 0 ? -1 : 1;
+}
+
+/** Quote-path unrealized P&L. Shorts profit when market value falls below cost. */
+export function signedQuoteUnrealizedPnl(
+  absMarketValue: number,
+  cost: number,
+  totalPriceUnits: number,
+): number {
+  return (totalPriceUnits < 0 ? -1 : 1) * (absMarketValue - cost);
+}
+
 function resolvePositionCostMultiplier(
   position: TickerRecord["metadata"]["positions"][number],
 ): number {
@@ -37,7 +55,7 @@ function resolvePositionCostMultiplier(
     return priceMultiplier;
   }
 
-  const costWithoutMultiplier = position.shares * position.avgCost;
+  const costWithoutMultiplier = Math.abs(position.shares) * position.avgCost;
   const costWithMultiplier = costWithoutMultiplier * priceMultiplier;
   const withoutMultiplierError = Math.abs((position.marketValue - costWithoutMultiplier) - position.unrealizedPnl);
   const withMultiplierError = Math.abs((position.marketValue - costWithMultiplier) - position.unrealizedPnl);
@@ -65,15 +83,16 @@ export function getPortfolioPositionMetrics(
   let brokerPnl = 0;
   let hasBrokerPnl = false;
   for (const position of tabPositions) {
-    const direction = position.side === "short" ? -1 : 1;
+    const direction = signedPositionDirection(position);
+    const magnitude = Math.abs(position.shares);
     const priceMultiplier = normalizePositionMultiplier(position.multiplier);
     const costMultiplier = resolvePositionCostMultiplier(position);
     multiplierHint = Math.max(multiplierHint, priceMultiplier, costMultiplier);
 
-    totalShares += position.shares * direction;
-    totalCost += position.shares * position.avgCost * costMultiplier;
-    totalCostUnits += position.shares * costMultiplier;
-    totalPriceUnits += position.shares * priceMultiplier * direction;
+    totalShares += magnitude * direction;
+    totalCost += magnitude * position.avgCost * costMultiplier;
+    totalCostUnits += magnitude * costMultiplier;
+    totalPriceUnits += magnitude * priceMultiplier * direction;
 
     if (position.marketValue != null) {
       brokerMktValue += position.marketValue;

--- a/src/plugins/builtin/portfolio-list/summary/index.tsx
+++ b/src/plugins/builtin/portfolio-list/summary/index.tsx
@@ -243,25 +243,25 @@ export function buildPortfolioSummarySegments({
       account.settledCash != null
         ? createSummarySegment("settled", [
           { text: "Settled", tone: "label" },
-          { text: formatCompact(account.settledCash), tone: "value", bold: true },
+          { text: formatCompact(convertAccountValue(account.settledCash)), tone: "value", bold: true },
         ])
         : null,
       account.availableFunds != null
         ? createSummarySegment("avail", [
           { text: "Avail", tone: "label" },
-          { text: formatCompact(account.availableFunds), tone: "value", bold: true },
+          { text: formatCompact(convertAccountValue(account.availableFunds)), tone: "value", bold: true },
         ])
         : null,
       account.excessLiquidity != null
         ? createSummarySegment("excess", [
           { text: "Excess", tone: "label" },
-          { text: formatCompact(account.excessLiquidity), tone: "value", bold: true },
+          { text: formatCompact(convertAccountValue(account.excessLiquidity)), tone: "value", bold: true },
         ])
         : null,
       account.buyingPower != null
         ? createSummarySegment("bp", [
           { text: "BP", tone: "label" },
-          { text: formatCompact(account.buyingPower), tone: "value", bold: true },
+          { text: formatCompact(convertAccountValue(account.buyingPower)), tone: "value", bold: true },
         ])
         : null,
       createSummarySegment("source", [
@@ -393,40 +393,45 @@ export function renderSummarySegments(segments: PortfolioSummarySegment[], width
   );
 }
 
-export function buildDrawerMetricSegments(account: BrokerAccount, widthBudget: number): PortfolioSummarySegment[] {
+export function buildDrawerMetricSegments(
+  account: BrokerAccount,
+  widthBudget: number,
+  convertAccountValue: (value: number) => number = (value) => value,
+): PortfolioSummarySegment[] {
+  const money = (value: number) => convertAccountValue(value);
   const candidates = [
     account.dailyPnl != null
-      ? createSummarySegment("day", [{ text: "Day", tone: "label" }, { text: formatSignedCompact(account.dailyPnl), tone: "value", color: priceColor(account.dailyPnl), bold: true }])
+      ? createSummarySegment("day", [{ text: "Day", tone: "label" }, { text: formatSignedCompact(money(account.dailyPnl)), tone: "value", color: priceColor(money(account.dailyPnl)), bold: true }])
       : null,
     account.unrealizedPnl != null
-      ? createSummarySegment("unreal", [{ text: "Unreal", tone: "label" }, { text: formatSignedCompact(account.unrealizedPnl), tone: "value", color: priceColor(account.unrealizedPnl), bold: true }])
+      ? createSummarySegment("unreal", [{ text: "Unreal", tone: "label" }, { text: formatSignedCompact(money(account.unrealizedPnl)), tone: "value", color: priceColor(money(account.unrealizedPnl)), bold: true }])
       : null,
     account.realizedPnl != null
-      ? createSummarySegment("realized", [{ text: "Realized", tone: "label" }, { text: formatSignedCompact(account.realizedPnl), tone: "value", color: priceColor(account.realizedPnl), bold: true }])
+      ? createSummarySegment("realized", [{ text: "Realized", tone: "label" }, { text: formatSignedCompact(money(account.realizedPnl)), tone: "value", color: priceColor(money(account.realizedPnl)), bold: true }])
       : null,
     account.totalCashValue != null
-      ? createSummarySegment("cash", [{ text: "Cash", tone: "label" }, { text: formatCompact(account.totalCashValue), tone: "value", bold: true }])
+      ? createSummarySegment("cash", [{ text: "Cash", tone: "label" }, { text: formatCompact(money(account.totalCashValue)), tone: "value", bold: true }])
       : null,
     account.settledCash != null
-      ? createSummarySegment("settled", [{ text: "Settled", tone: "label" }, { text: formatCompact(account.settledCash), tone: "value", bold: true }])
+      ? createSummarySegment("settled", [{ text: "Settled", tone: "label" }, { text: formatCompact(money(account.settledCash)), tone: "value", bold: true }])
       : null,
     account.netLiquidation != null
-      ? createSummarySegment("netliq", [{ text: "Net Liq", tone: "label" }, { text: formatCompact(account.netLiquidation), tone: "value", bold: true }])
+      ? createSummarySegment("netliq", [{ text: "Net Liq", tone: "label" }, { text: formatCompact(money(account.netLiquidation)), tone: "value", bold: true }])
       : null,
     account.availableFunds != null
-      ? createSummarySegment("avail", [{ text: "Avail", tone: "label" }, { text: formatCompact(account.availableFunds), tone: "value", bold: true }])
+      ? createSummarySegment("avail", [{ text: "Avail", tone: "label" }, { text: formatCompact(money(account.availableFunds)), tone: "value", bold: true }])
       : null,
     account.excessLiquidity != null
-      ? createSummarySegment("excess", [{ text: "Excess", tone: "label" }, { text: formatCompact(account.excessLiquidity), tone: "value", bold: true }])
+      ? createSummarySegment("excess", [{ text: "Excess", tone: "label" }, { text: formatCompact(money(account.excessLiquidity)), tone: "value", bold: true }])
       : null,
     account.buyingPower != null
-      ? createSummarySegment("bp", [{ text: "BP", tone: "label" }, { text: formatCompact(account.buyingPower), tone: "value", bold: true }])
+      ? createSummarySegment("bp", [{ text: "BP", tone: "label" }, { text: formatCompact(money(account.buyingPower)), tone: "value", bold: true }])
       : null,
     account.initMarginReq != null
-      ? createSummarySegment("init", [{ text: "Init", tone: "label" }, { text: formatCompact(account.initMarginReq), tone: "value", bold: true }])
+      ? createSummarySegment("init", [{ text: "Init", tone: "label" }, { text: formatCompact(money(account.initMarginReq)), tone: "value", bold: true }])
       : null,
     account.maintMarginReq != null
-      ? createSummarySegment("maint", [{ text: "Maint", tone: "label" }, { text: formatCompact(account.maintMarginReq), tone: "value", bold: true }])
+      ? createSummarySegment("maint", [{ text: "Maint", tone: "label" }, { text: formatCompact(money(account.maintMarginReq)), tone: "value", bold: true }])
       : null,
   ].filter((segment): segment is PortfolioSummarySegment => segment != null);
 

--- a/src/plugins/builtin/portfolio-list/summary/totals.ts
+++ b/src/plugins/builtin/portfolio-list/summary/totals.ts
@@ -2,7 +2,12 @@ import type { TickerFinancials } from "../../../../types/financials";
 import type { TickerRecord } from "../../../../types/ticker";
 import { convertCurrency } from "../../../../utils/format";
 import { getActiveQuoteDisplay } from "../../../../market-data/market/status";
-import { getPortfolioPositionMetrics, resolveBrokerFallbackMarketValue } from "../position-metrics";
+import {
+  getPortfolioPositionMetrics,
+  resolveBrokerFallbackMarketValue,
+  resolveBrokerFallbackPnl,
+  signedQuoteUnrealizedPnl,
+} from "../position-metrics";
 
 export interface PortfolioSummaryTotals {
   totalMktValue: number;
@@ -27,6 +32,8 @@ export function calculatePortfolioSummaryTotals(
   let totalMktValue = 0;
   let totalPrevValue = 0;
   let totalCostBasis = 0;
+  let signedDailyPnl = 0;
+  let signedUnrealizedPnl = 0;
   let hasPositions = false;
   let watchlistChangeSum = 0;
   let watchlistCount = 0;
@@ -54,21 +61,28 @@ export function calculatePortfolioSummaryTotals(
     if (quote && activeQuote && totalPriceUnits !== 0) {
       hasPositions = true;
       const marketValue = Math.abs(totalPriceUnits) * activeQuote.price;
-      totalMktValue += toBaseQuote(marketValue);
       const previousClose = quote.previousClose || (activeQuote.price - activeQuote.change);
-      totalPrevValue += toBaseQuote(Math.abs(totalPriceUnits) * previousClose);
-      totalCostBasis += toBasePosition(totalCost);
+      const previousValue = Math.abs(totalPriceUnits) * previousClose;
+      const convertedMarket = toBaseQuote(marketValue);
+      const convertedCost = toBasePosition(totalCost);
+      totalMktValue += convertedMarket;
+      totalPrevValue += toBaseQuote(previousValue);
+      totalCostBasis += convertedCost;
+      signedDailyPnl += toBaseQuote(totalPriceUnits * (activeQuote.price - previousClose));
+      signedUnrealizedPnl += signedQuoteUnrealizedPnl(convertedMarket, convertedCost, totalPriceUnits);
     } else if (brokerFallbackMktValue != null) {
       hasPositions = true;
       totalMktValue += toBasePosition(brokerFallbackMktValue);
       totalCostBasis += toBasePosition(totalCost);
       totalPrevValue += toBasePosition(brokerFallbackMktValue);
+      const brokerPnl = resolveBrokerFallbackPnl(positionMetrics, brokerFallbackMktValue);
+      if (brokerPnl != null) signedUnrealizedPnl += toBasePosition(brokerPnl);
     }
   }
 
-  const dailyPnl = totalMktValue - totalPrevValue;
+  const dailyPnl = signedDailyPnl;
   const dailyPnlPct = totalPrevValue !== 0 ? (dailyPnl / totalPrevValue) * 100 : 0;
-  const unrealizedPnl = totalMktValue - totalCostBasis;
+  const unrealizedPnl = signedUnrealizedPnl;
   const unrealizedPnlPct = totalCostBasis !== 0 ? (unrealizedPnl / totalCostBasis) * 100 : 0;
   const avgWatchlistChange = watchlistCount > 0 ? watchlistChangeSum / watchlistCount : 0;
 

--- a/src/renderers/browser/cloud-transport.test.ts
+++ b/src/renderers/browser/cloud-transport.test.ts
@@ -24,6 +24,42 @@ test("browser cloud transport uses host cookies without forwarding forbidden hea
   expect(headers.get("Accept")).toBe("application/json");
 });
 
+test("browser cloud transport plants session cookies before dropping the Cookie header", async () => {
+  const planted: string[] = [];
+  const previousDocument = (globalThis as { document?: unknown }).document;
+  (globalThis as { document?: { cookie: string } }).document = {
+    get cookie() {
+      return planted.join("; ");
+    },
+    set cookie(value: string) {
+      planted.push(value);
+    },
+  };
+  const previousLocation = (globalThis as { location?: unknown }).location;
+  (globalThis as { location?: { protocol: string } }).location = { protocol: "https:" };
+
+  globalThis.fetch = (async () => {
+    return new Response("{}", { headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+
+  try {
+    await browserCredentialedFetch("https://api.gloom.sh/auth/get-session", {
+      headers: {
+        Cookie: "__Secure-gloomberb.session_token=signed-token.value; gloomberb.session_token=signed-token.value",
+      },
+    });
+    expect(planted).toEqual([
+      "__Secure-gloomberb.session_token=signed-token.value; Path=/; SameSite=Lax; Secure",
+      "gloomberb.session_token=signed-token.value; Path=/; SameSite=Lax; Secure",
+    ]);
+  } finally {
+    if (previousDocument === undefined) delete (globalThis as { document?: unknown }).document;
+    else (globalThis as { document?: unknown }).document = previousDocument;
+    if (previousLocation === undefined) delete (globalThis as { location?: unknown }).location;
+    else (globalThis as { location?: unknown }).location = previousLocation;
+  }
+});
+
 test("browser boot restores an existing Gloom Cloud cookie session", async () => {
   const getSession = spyOn(apiClient, "getSession").mockResolvedValue(null);
   await restoreBrowserCloudSession();

--- a/src/renderers/browser/cloud-transport.ts
+++ b/src/renderers/browser/cloud-transport.ts
@@ -1,8 +1,27 @@
 import { apiClient, setCloudApiFetchTransport } from "../../api-client";
 import { setHttpFetchTransport } from "../../utils/http-transport";
 
+const SESSION_COOKIE_NAMES = ["__Secure-gloomberb.session_token", "gloomberb.session_token"] as const;
+
+function plantBrowserSessionCookies(cookieHeader: string): void {
+  if (typeof document === "undefined") return;
+  const secure = typeof location !== "undefined" && location.protocol === "https:";
+  for (const part of cookieHeader.split(";")) {
+    const trimmed = part.trim();
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const name = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (!(SESSION_COOKIE_NAMES as readonly string[]).includes(name) || !value) continue;
+    const useSecure = secure || name.startsWith("__Secure-");
+    document.cookie = `${name}=${value}; Path=/; SameSite=Lax${useSecure ? "; Secure" : ""}`;
+  }
+}
+
 export function browserCredentialedFetch(url: string, init: RequestInit = {}): Promise<Response> {
   const headers = new Headers(init.headers);
+  const cookieHeader = headers.get("Cookie");
+  if (cookieHeader) plantBrowserSessionCookies(cookieHeader);
   // These are controlled by the browser. Desktop transports may set them, but
   // carrying them into fetch would either fail or misrepresent the web origin.
   headers.delete("Cookie");


### PR DESCRIPTION
## Summary
- Short positions used a long-only quote P&L formula and broker-sync stored signed shares plus `side: "short"`, so live quotes and merged short lots could flip or drop P&L. Quote P&L is signed now, broker lots store abs shares + side, and remaining account cash fields convert into the app currency.
- Rearming a `crosses` alert kept the old price baseline, so it could fire immediately. The Intel installer no longer downloads the arm64 app on a genuine x86 Mac. QR/device login on the web client plants the session cookie so `getSession` still works after the Cookie header is stripped.
- Command-bar clicks no longer focus or drag panes underneath (kitty occlusion stays panel-sized). Config/layout writers read the latest state ref instead of a stale render. Fear & Greed palettes are memoized to cut kitty retransmit, Graphs keep-alive tabs stop live streaming when hidden, and ticker rebind uses the spec's security symbol so rapid switches do not miss.

## Test plan
- [ ] Portfolio: short 10 @ 100, last 80 — day and unrealized P&L should be +200, not -200
- [ ] Broker sync a short (or two lots of the same short) — shares stay positive, side is short, avg cost is the weighted blend
- [ ] Non-USD account: footer/drawer realized, settled, available, excess, and buying power convert with the rest of the cash fields
- [ ] Trigger a `crosses` alert, rearm it — it should wait for a new cross instead of firing on the old baseline
- [ ] term.gloom.sh: approve a QR/device login and confirm the session survives refresh
- [ ] Open the command bar on desktop and click a pane/chart behind it — focus should stay on the command bar
- [ ] Switch Graphs tickers quickly and leave the tab — series should follow the new symbol and hidden charts should stop live updates
- [ ] Intel Mac install script should error clearly; Rosetta-on-Apple-Silicon should still install arm64