### PR TITLE
Keep cloud sync live and persist desktop login

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -287,6 +287,7 @@ function AppInner({
     dispatch,
     tickerRepository,
     pluginRegistry,
+    appActive,
     // Keep a first-run workspace stable while the local guide is active. Once
     // onboarding finishes, the normal pull-before-push sync starts immediately.
     initialized: state.initialized

--- a/src/data/plugin-state-store.ts
+++ b/src/data/plugin-state-store.ts
@@ -126,6 +126,17 @@ export class PluginStateStore {
     ));
   }
 
+  pluginIds(): string[] {
+    return withSqliteBusyRetry("list plugin state ids", () => (
+      this.db
+        .query<{ plugin_id: string }, []>(
+          "SELECT DISTINCT plugin_id FROM plugin_state ORDER BY plugin_id",
+        )
+        .all()
+        .map((row) => row.plugin_id)
+    ));
+  }
+
   clear(pluginId: string): void {
     withSqliteBusyRetry("clear plugin state", () => {
       this.db.query("DELETE FROM plugin_state WHERE plugin_id = ?").run(pluginId);

--- a/src/data/sqlite/cache.test.ts
+++ b/src/data/sqlite/cache.test.ts
@@ -221,6 +221,16 @@ describe("AppPersistence", () => {
     persistence.close();
   });
 
+  test("lists plugin ids that have stored state", () => {
+    const dbPath = createTempDbPath("plugin-state-ids");
+    const persistence = new AppPersistence(dbPath);
+    persistence.pluginState.set("gloomberb-cloud", "session", { sessionToken: "token" }, 1);
+    persistence.pluginState.set("ai", "provider", "openai", 1);
+
+    expect(persistence.pluginState.pluginIds()).toEqual(["ai", "gloomberb-cloud"]);
+    persistence.close();
+  });
+
   test("stores multiple plugin state records in one batch", () => {
     const dbPath = createTempDbPath("plugin-state-batch");
     const persistence = new AppPersistence(dbPath);

--- a/src/plugins/builtin/chat/controller.test.ts
+++ b/src/plugins/builtin/chat/controller.test.ts
@@ -453,6 +453,55 @@ describe("ChatController", () => {
     }
   });
 
+  test("keeps a persisted native session when get-session returns no user", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+
+    controller.attachPersistence(persistence);
+    apiClient.getSession = async () => null;
+
+    await controller.refreshSession();
+
+    expect(apiClient.getSessionToken()).toBe("token-123");
+    expect(persistence.getState<{
+      sessionToken: string;
+      user: { id: string; username: string; emailVerified: boolean };
+    }>("session", { schemaVersion: 1 })).toEqual({
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    });
+    expect(controller.getSnapshot().user).toEqual({
+      id: "u1",
+      username: "vince",
+      emailVerified: true,
+    });
+    controller.dispose();
+  });
+
+  test("signs out when get-session returns no user and no token is stored", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+
+    persistence.setState("session", {
+      sessionToken: null,
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+
+    controller.attachPersistence(persistence);
+    apiClient.getSession = async () => null;
+
+    await controller.refreshSession();
+
+    expect(apiClient.getSessionToken()).toBeNull();
+    expect(controller.getSnapshot().user).toBeNull();
+    controller.dispose();
+  });
+
   test("keeps the cached session when session refresh fails transiently", async () => {
     const persistence = new MemoryPersistence();
     const controller = new ChatController();

--- a/src/plugins/builtin/chat/controller/session-runtime.ts
+++ b/src/plugins/builtin/chat/controller/session-runtime.ts
@@ -119,8 +119,20 @@ export async function refreshChatControllerSession({
   session.sessionToken = apiClient.getSessionToken();
   const apiSession = await apiClient.getSession();
   if (!apiSession) {
-    apiClient.setSessionToken(null);
-    session.sessionToken = null;
+    const persistedToken = apiClient.getSessionToken() || session.sessionToken;
+    // A 200 with no user is what /auth/get-session returns when no cookie
+    // reached the server. Desktop's backend process used to treat that as a
+    // real sign-out and persist a wiped token, so the next launch was logged
+    // out. Keep a captured native session; hard account-missing responses
+    // already clear the token inside getSession().
+    if (persistedToken) {
+      session.sessionToken = persistedToken;
+      session.user = session.user ?? normalizeSessionUser(apiClient.getCurrentUser());
+      session.sessionChecked = true;
+      persistSession(session.sessionToken, session.user);
+      emit();
+      return;
+    }
     applySignedOut();
     return;
   }

--- a/src/plugins/builtin/cloud/auth-commands.ts
+++ b/src/plugins/builtin/cloud/auth-commands.ts
@@ -74,10 +74,6 @@ export function registerCloudAuthCommands(ctx: GloomPluginContext): void {
     },
   });
 
-  if (apiClient.getSessionToken()) {
-    void chatController.refreshSession().catch(() => {});
-  }
-
   ctx.registerCommand({
     id: "auth-logout",
     label: "Logout",

--- a/src/plugins/builtin/cloud/auth-model.ts
+++ b/src/plugins/builtin/cloud/auth-model.ts
@@ -126,7 +126,10 @@ export async function performEmailAuth(mode: AccountMode, email: string, passwor
   if (!user.emailVerified) {
     await apiClient.sendVerification().catch(() => {});
   }
-  chatController.clearSession();
+  const sessionToken = apiClient.getSessionToken();
+  if (sessionToken) {
+    chatController.adoptSession(sessionToken, user);
+  }
   await chatController.refreshSession().catch(() => {});
   return user;
 }

--- a/src/renderers/electrobun/bun/desktop/initialization.ts
+++ b/src/renderers/electrobun/bun/desktop/initialization.ts
@@ -142,6 +142,7 @@ export async function initializeDesktopBackend<TRpc>(
     plugins: getDesktopBackendPlugins(),
   });
   options.setServices(services);
+  await services.ready;
   options.syncConfigAccessors();
   options.registerCoreCapabilities();
   options.setDesktopWorkspace(createDesktopWorkspace(config, options.getSessionSnapshot()));

--- a/src/renderers/electrobun/bun/desktop/plugin-state.ts
+++ b/src/renderers/electrobun/bun/desktop/plugin-state.ts
@@ -76,9 +76,15 @@ export function handleDesktopPluginStateRequest(
   }
 }
 
+function pluginStateIds(registry: PluginRegistry): string[] {
+  const store = registry.persistence.pluginState as { pluginIds?: () => string[] };
+  const storedIds = typeof store.pluginIds === "function" ? store.pluginIds() : [];
+  return [...new Set(["gloomberb-cloud", ...registry.allPlugins.keys(), ...storedIds])];
+}
+
 export function loadDesktopPluginState(registry: PluginRegistry): Record<string, Record<string, unknown>> {
   const state: Record<string, Record<string, unknown>> = {};
-  for (const pluginId of registry.allPlugins.keys()) {
+  for (const pluginId of pluginStateIds(registry)) {
     const keys = registry.persistence.pluginState.keys(pluginId);
     if (keys.length === 0) continue;
     state[pluginId] = {};

--- a/src/renderers/electrobun/view/remote/persistence.ts
+++ b/src/renderers/electrobun/view/remote/persistence.ts
@@ -77,6 +77,11 @@ class RemotePluginStateStore {
     if (!this.state.has(pluginId)) this.state.set(pluginId, new Map());
     this.state.get(pluginId)!.set(key, value);
     this.getScheduler(pluginId, key).schedule({ pluginId, key, value, schemaVersion });
+    // Closing the window tears down the RPC before a debounced save can land.
+    // Auth has to reach SQLite immediately or the next launch is signed out.
+    if (key === "session" || key === "resume:session") {
+      void this.flush();
+    }
   }
 
   delete(pluginId: string, key: string): void {

--- a/src/sync/controller.test.ts
+++ b/src/sync/controller.test.ts
@@ -307,7 +307,7 @@ test("keeps startup layout changes while serializing pull and push", async () =>
   const pushedConfig = pushes[0]?.snapshot.contributors["core.config"]?.payload as {
     layout: AppState["config"]["layout"];
   };
-  expect(pulls).toBe(1);
+  expect(pulls).toBe(2);
   expect(pushes).toHaveLength(1);
   expect(pushes[0]?.options).toEqual({ baseRevision: 7 });
   expect(state.config.theme).toBe("green");
@@ -380,4 +380,60 @@ test("keeps the latest layout when switching away and back during a pull", async
   expect(state.config.theme).toBe("green");
   expect(state.config.activeLayoutIndex).toBe(0);
   expect(pushedConfig.activeLayoutIndex).toBe(0);
+});
+
+test("pulls remote changes on later syncs instead of only once per session", async () => {
+  const applied: unknown[] = [];
+  const contributor: SyncContributor = {
+    id: "test.data",
+    schemaVersion: 1,
+    collect: () => ({ local: applied.at(-1) ?? null }),
+    apply: (payload) => {
+      applied.push(payload);
+    },
+  };
+  let remote = { value: 1 };
+  let remoteRevision = 4;
+  let pulls = 0;
+  const transport: SyncTransport = {
+    id: "repeat-pull",
+    isAvailable: () => true,
+    pullSnapshot: async () => {
+      pulls += 1;
+      return {
+        snapshot: {
+          schemaVersion: SYNC_SNAPSHOT_SCHEMA_VERSION,
+          appId: "gloomberb",
+          clientId: "remote-client",
+          createdAt: "2026-08-27T00:00:00.000Z",
+          contributors: {
+            "test.data": {
+              schemaVersion: 1,
+              updatedAt: "2026-08-27T00:00:00.000Z",
+              payload: remote,
+            },
+          },
+        },
+        revision: remoteRevision,
+        updatedAt: "2026-08-27T00:00:00.000Z",
+      };
+    },
+    pushSnapshot: async () => ({ revision: remoteRevision + 1, updatedAt: "2026-08-27T00:00:01.000Z" }),
+  };
+  const controller = new CloudSyncController();
+  controller.setRuntime({
+    getState: () => ({} as AppState),
+    dispatch: () => {},
+    tickerRepository: {} as TickerRepository,
+    getContributors: () => [{ pluginId: "test", contributor }],
+    getTransport: () => ({ pluginId: "test", transport }),
+  });
+
+  await controller.requestSync({ reason: "startup" });
+  remote = { value: 2 };
+  remoteRevision = 12;
+  await controller.requestSync({ reason: "poll" });
+
+  expect(pulls).toBe(2);
+  expect(applied).toEqual([{ value: 1 }, { value: 2 }]);
 });

--- a/src/sync/controller.ts
+++ b/src/sync/controller.ts
@@ -70,7 +70,7 @@ export class CloudSyncController {
   private baseline: Record<string, unknown> | null = null;
   private baselineLoaded = false;
   private pulledContributors: SyncSnapshot["contributors"] = {};
-  private hasPulledForTransport = new Set<string>();
+  private appliedRevision: number | null = null;
   private status: CloudSyncStatus = {
     phase: "idle",
     transportId: null,
@@ -186,12 +186,11 @@ export class CloudSyncController {
     }
     const transport = registration.transport;
 
-    if (!this.hasPulledForTransport.has(transport.id)) {
-      this.lastSignature = null;
-      if (!await this.runPull(runtime, transport)) return;
-      if (!this.isCurrent(runtime, transport)) return;
-      this.hasPulledForTransport.add(transport.id);
-    }
+    // Always pull before push. Another device (TUI, browser, phone) may have
+    // written since this process last synced, and contributors already merge
+    // so local-only edits survive the apply.
+    if (!await this.runPull(runtime, transport)) return;
+    if (!this.isCurrent(runtime, transport)) return;
 
     const snapshot = await this.assembleSnapshot(runtime);
     if (!this.isCurrent(runtime, transport)) return;
@@ -203,6 +202,7 @@ export class CloudSyncController {
       const result = await transport.pushSnapshot(snapshot, { baseRevision: this.status.revision });
       if (!this.isCurrent(runtime, transport)) return;
       this.lastSignature = signature;
+      this.appliedRevision = result.revision;
       this.saveBaseline(runtime, snapshot);
       this.setStatus({
         phase: "synced",
@@ -228,7 +228,7 @@ export class CloudSyncController {
       const response = await transport.pullSnapshot();
       if (!this.isCurrent(runtime, transport)) return false;
 
-      if (response.snapshot) {
+      if (response.snapshot && this.shouldApplyPulledRevision(response.revision)) {
         this.assertSnapshotCompatible(response.snapshot, runtime.getContributors());
         this.pulledContributors = response.snapshot.contributors;
         for (const entry of runtime.getContributors()) {
@@ -246,15 +246,16 @@ export class CloudSyncController {
             tickerRepository: runtime.tickerRepository,
           });
         }
+        if (response.revision != null) this.appliedRevision = response.revision;
       }
 
       if (!this.isCurrent(runtime, transport)) return false;
       this.setStatus({
         phase: response.snapshot ? "synced" : "idle",
         transportId: transport.id,
-        revision: response.revision,
+        revision: this.newerRevision(response.revision),
         lastPullAt: response.updatedAt ?? nowIso(),
-        lastSyncAt: response.updatedAt,
+        lastSyncAt: response.updatedAt ?? this.status.lastSyncAt,
         error: null,
       });
       return true;
@@ -337,13 +338,23 @@ export class CloudSyncController {
     return this.runtime === runtime && runtime.getTransport()?.transport === transport;
   }
 
+  private shouldApplyPulledRevision(revision: number | null): boolean {
+    return revision == null || this.appliedRevision == null || revision > this.appliedRevision;
+  }
+
+  private newerRevision(revision: number | null): number | null {
+    if (revision == null) return this.status.revision;
+    if (this.status.revision == null || revision > this.status.revision) return revision;
+    return this.status.revision;
+  }
+
   private resetOperations(): void {
     if (this.pushTimer) clearTimeout(this.pushTimer);
     this.pushTimer = null;
     this.inFlight = null;
     this.syncQueued = false;
-    this.hasPulledForTransport.clear();
     this.lastSignature = null;
+    this.appliedRevision = null;
     this.baseline = null;
     this.baselineLoaded = false;
     this.pulledContributors = {};

--- a/src/sync/react.ts
+++ b/src/sync/react.ts
@@ -7,6 +7,8 @@ import { subscribeToCloudVerification } from "./auth-transition";
 import { createSyncBaselineStore } from "./baseline";
 import { cloudSyncController } from "./controller";
 
+const CLOUD_SYNC_POLL_MS = 15_000;
+
 interface CloudSyncRuntimeOptions {
   state: AppState;
   getState: () => AppState;
@@ -14,6 +16,7 @@ interface CloudSyncRuntimeOptions {
   tickerRepository: AppTickerRepositoryPort;
   pluginRegistry: PluginRegistry;
   initialized: boolean;
+  appActive?: boolean;
 }
 
 export function useCloudSyncRuntime({
@@ -23,6 +26,7 @@ export function useCloudSyncRuntime({
   tickerRepository,
   pluginRegistry,
   initialized,
+  appActive = true,
 }: CloudSyncRuntimeOptions): void {
   const baselineStore = useMemo(
     () => createSyncBaselineStore(pluginRegistry.persistence.pluginState),
@@ -44,6 +48,15 @@ export function useCloudSyncRuntime({
     if (!initialized) return;
     void cloudSyncController.requestSync({ reason: "startup" });
   }, [initialized, pluginRegistry]);
+
+  useEffect(() => {
+    if (!initialized || !appActive) return;
+    void cloudSyncController.requestSync({ reason: "foreground" });
+    const timer = setInterval(() => {
+      void cloudSyncController.requestSync({ reason: "poll" });
+    }, CLOUD_SYNC_POLL_MS);
+    return () => clearInterval(timer);
+  }, [appActive, initialized]);
 
   useEffect(() => subscribeToCloudVerification(apiClient, () => {
     if (!initialized) return;


### PR DESCRIPTION
## Summary
- Cloud sync only pulled once per login, so TUI portfolio edits stayed invisible in the browser until logout/login. Sync now pulls before each push, applies only newer revisions, and polls while the app is focused.
- Desktop treated a cookieless `/auth/get-session` 200 as a real sign-out and persisted a wiped token, so closing the app logged you out and blocked sync. The captured session is kept, email login adopts the token immediately, and session state flushes to SQLite before the window dies.

## Test plan
- [ ] Add a position in the TUI while the browser is already signed in; it should appear in the browser within ~15s or on window focus, without logging out
- [ ] Sign in on desktop, quit, and reopen; the session should still be there and portfolios should sync
- [ ] Explicit Logout still signs out; deleting/disabling the account still clears the local session
- [ ] `bun test src/sync/controller.test.ts src/plugins/builtin/chat/controller.test.ts src/data/sqlite/cache.test.ts`