### PR TITLE
Prune unused leftover helpers

### DIFF
--- a/src/components/chart/composite/scene.ts
+++ b/src/components/chart/composite/scene.ts
@@ -17,7 +17,6 @@ import type {
 import {
   buildCompositeTimeScale,
   projectCompositeTimestamp,
-  unprojectCompositeTimestamp,
 } from "./time-scale";
 import type { CompositeTimeScale } from "./types";
 
@@ -521,26 +520,6 @@ export function resolveCompositeCursorDate(scene: CompositeChartScene, localX: n
     }
   });
   return scene.dates[nearestIndex] ?? null;
-}
-
-export function resolveCompositeTimeAxisDate(
-  scene: CompositeChartScene,
-  ratio: number,
-): Date {
-  const safeRatio = Math.max(0, Math.min(1, ratio));
-  if (scene.timeScale.kind === "market" && scene.dates.length > 0) {
-    let nearestIndex = 0;
-    let nearestDistance = Number.POSITIVE_INFINITY;
-    scene.dateRatios.forEach((candidate, index) => {
-      const distance = Math.abs(candidate - safeRatio);
-      if (distance < nearestDistance) {
-        nearestIndex = index;
-        nearestDistance = distance;
-      }
-    });
-    return scene.dates[nearestIndex] ?? new Date(scene.startTime);
-  }
-  return new Date(unprojectCompositeTimestamp(scene.timeScale, safeRatio));
 }
 
 export function resolveAdjacentCompositeCursorDate(

--- a/src/market-data/hooks.tsx
+++ b/src/market-data/hooks.tsx
@@ -213,47 +213,6 @@ export function useQuoteEntries(
   }, [coordinator, instrumentKey, keysVersion]);
 }
 
-export function useChartQuery(
-  request: ChartRequest | null | undefined,
-  options: ChartQueryOptions = {},
-): QueryEntry<PricePoint[]> | null {
-  const key = request ? buildChartKey(request) : null;
-  useCoordinatorKeysVersion(key ? [key] : []);
-  const coordinator = getSharedMarketDataCoordinator();
-  const entry = coordinator && request ? coordinator.getChartEntry(request) : null;
-  const appActive = useAppActive();
-  const wasActiveRef = useRef(appActive);
-  const refreshIntervalMs = Math.max(0, options.refreshIntervalMs ?? 0);
-
-  useEffect(() => {
-    const coordinator = getSharedMarketDataCoordinator();
-    if (!coordinator || !request) {
-      wasActiveRef.current = appActive;
-      return;
-    }
-    if (!appActive) {
-      wasActiveRef.current = false;
-      return;
-    }
-
-    const forceRefresh = refreshIntervalMs > 0 && !wasActiveRef.current;
-    wasActiveRef.current = true;
-    void coordinator.loadChart(request, { forceRefresh }).catch(() => {});
-  }, [appActive, key, refreshIntervalMs]);
-
-  useEffect(() => {
-    const coordinator = getSharedMarketDataCoordinator();
-    if (!coordinator || !request || !appActive || refreshIntervalMs <= 0) return;
-
-    const interval = setInterval(() => {
-      void coordinator.loadChart(request, { forceRefresh: true }).catch(() => {});
-    }, refreshIntervalMs);
-    return () => clearInterval(interval);
-  }, [appActive, key, refreshIntervalMs]);
-
-  return entry;
-}
-
 export function useChartQueries(
   requests: readonly ChartRequest[],
   options: ChartQueryOptions = {},

--- a/src/plugins/builtin/econ/calendar-model.ts
+++ b/src/plugins/builtin/econ/calendar-model.ts
@@ -168,11 +168,6 @@ export function getCalendarCache(options?: { allowExpired?: boolean }): EconCale
   return readPersistedCache(options);
 }
 
-export function getFreshCalendarCache(): EconCalendarCacheEntry | null {
-  const cached = getCalendarCache();
-  return cached && !cached.stale ? cached : null;
-}
-
 export interface EconCalendarLoadResult extends EconCalendarCacheEntry {
   /** Set when the network failed and cached events were served instead. */
   refreshError?: string;

--- a/src/renderers/browser/config-host.ts
+++ b/src/renderers/browser/config-host.ts
@@ -56,7 +56,3 @@ export function createBrowserConfigStore(storage: StorageLike): ConfigStoreHost 
 export function installBrowserConfigStore(storage: StorageLike = localStorage): void {
   setConfigStoreHost(createBrowserConfigStore(storage));
 }
-
-export async function loadBrowserConfig(store = createBrowserConfigStore(localStorage)): Promise<AppConfig> {
-  return store.loadConfig(BROWSER_DATA_DIR);
-}

--- a/src/renderers/electrobun/view/host/native.ts
+++ b/src/renderers/electrobun/view/host/native.ts
@@ -1,5 +1,4 @@
 import type { ContextMenuItem } from "../../../../types/context-menu";
-import { editableTextContextMenuItems } from "../../../../ui/context-menu";
 import { backendRequest, onContextMenuSelect } from "../backend-rpc";
 import {
   DesktopContextMenuActionScope,
@@ -41,8 +40,4 @@ export async function showDesktopContextMenu(items: ContextMenuItem[]): Promise<
     contextMenuActionScope.clearRequest(requestId);
     return false;
   }
-}
-
-export function showEditableTextContextMenu(): Promise<boolean> {
-  return showDesktopContextMenu(editableTextContextMenuItems());
 }

--- a/src/theme/font-scale.ts
+++ b/src/theme/font-scale.ts
@@ -28,10 +28,6 @@ export function clampFontSize(value: unknown): number {
   return Math.min(MAX_FONT_SIZE_PX, Math.max(MIN_FONT_SIZE_PX, Math.round(numeric)));
 }
 
-export function getFontSize(): number {
-  return appliedFontSizePx;
-}
-
 function roundToHundredth(value: number): number {
   return Math.round(value * 100) / 100;
 }
@@ -59,11 +55,4 @@ export function syncFontScale(fontSizePx: unknown): boolean {
   style.setProperty("font-size", `${size}px`);
   appliedToDocument = true;
   return true;
-}
-
-export function resetFontScaleForTests(): void {
-  appliedFontSizePx = BASE_FONT_SIZE_PX;
-  appliedToDocument = false;
-  WEB_CELL_WIDTH = BASE_CELL_WIDTH_PX;
-  WEB_CELL_HEIGHT = BASE_CELL_HEIGHT_PX;
 }

--- a/src/utils/back-navigation.ts
+++ b/src/utils/back-navigation.ts
@@ -31,10 +31,6 @@ export function isPlainEscape(event: BackNavigationEventLike): boolean {
     && !event.shift;
 }
 
-export function isBackNavigationKey(event: BackNavigationEventLike): boolean {
-  return isPlainBackspace(event) || isPlainEscape(event);
-}
-
 export function isDetailBackNavigationKey(
   event: BackNavigationEventLike,
 ): boolean {


### PR DESCRIPTION
## Summary
- Remove never-called helpers left after shared APIs landed: `useChartQuery` (superseded by `useChartQueries`), `resolveCompositeTimeAxisDate`, `getFreshCalendarCache`, `loadBrowserConfig`, `showEditableTextContextMenu`, `getFontSize` / `resetFontScaleForTests`, and `isBackNavigationKey`.
- No behavior change; these had zero callers.

## Test plan
- [x] `bun test src/market-data/hooks.test.tsx src/theme/font-scale.test.ts src/utils/double-escape-close.test.ts src/plugins/builtin/econ src/components/chart/composite/composite-chart.test.tsx src/renderers/browser`