### PR TITLE
Deploy terminal automatically from main

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -46,3 +46,40 @@ jobs:
 
       - name: Test global upgrade from 0.5.0
         run: bun run test:global-upgrade
+
+  deploy-web:
+    name: Deploy terminal to Cloudflare
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs:
+      - typecheck
+      - build-and-test
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Build browser app
+        run: bun run web:build
+
+      - name: Deploy terminal Worker
+        run: bunx wrangler deploy --config wrangler.production.jsonc --message "$GITHUB_SHA"
+
+      - name: Verify production
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in {1..12}; do
+            if curl --fail --silent --show-error --max-time 15 https://term.gloom.sh/health >/dev/null \
+              && curl --fail --silent --show-error --max-time 15 "https://term.gloom.sh/l/00000000000000000000000000000000?ref=$GITHUB_SHA" \
+                | grep --fixed-strings --quiet '/assets/share/main.js'; then
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "term.gloom.sh did not become healthy at $GITHUB_SHA" >&2
+          exit 1

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ bun run web:build
 bunx wrangler dev
 ```
 
-Validate the public artifacts with `bun run web:audit` and `bun run cloudflare:dry-run`. `wrangler.jsonc` is intentionally generic and contains no account, route, domain, namespace, or secret. Production routing and the private Gloom Cloud API deployment are configured separately.
+Validate the public artifacts with `bun run web:audit` and `bun run cloudflare:dry-run`. `wrangler.jsonc` remains generic for local checks. After verification passes on `main`, GitHub Actions deploys `term.gloom.sh` with `wrangler.production.jsonc`. The private Gloom Cloud API is deployed separately.
 
 ## Install
 

--- a/wrangler.production.jsonc
+++ b/wrangler.production.jsonc
@@ -1,0 +1,24 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "gloomberb-terminal",
+  "main": "src/renderers/cloudflare/worker.ts",
+  "compatibility_date": "2026-08-21",
+  "workers_dev": false,
+  "preview_urls": false,
+  "routes": [
+    {
+      "pattern": "term.gloom.sh",
+      "custom_domain": true
+    }
+  ],
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  },
+  "assets": {
+    "directory": "./dist/web",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": true
+  }
+}


### PR DESCRIPTION
## Summary
- deploy `gloomberb-terminal` after typecheck and browser tests pass on pushes to `main`
- keep production Worker routing in a dedicated `wrangler.production.jsonc`
- verify both Worker health and the public share renderer after deployment

## Validation
- parsed workflow YAML
- production Wrangler dry-run
- least-privilege Cloudflare deploy token completed a production credential check
- live health and share-route verification passed