### PR TITLE
Drop unfinished headless CLI stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,9 @@ Human-readable output is the default. Automation can opt into structured output 
 | `gloomberb portfolio [action]` | Manage manual portfolios |
 | `gloomberb watchlist [action]` | Manage watchlists |
 | `gloomberb notes|alerts [action]` | Manage local notes and alerts |
-| `gloomberb broker|ibkr [action]` | Inspect broker integrations; trading actions require explicit account/profile and `--yes` |
-| `gloomberb ai providers|ask|screen` | Use configured AI providers and screeners |
+| `gloomberb broker|ibkr [action]` | Inspect broker profiles |
+| `gloomberb ai providers|ask` | Use configured AI providers |
 | `gloomberb rss fetch <url>` | Fetch an RSS feed |
-| `gloomberb buildout|congress|substack|x-feed|tweets` | Access cloud and social data sources when an existing session is available |
 | `gloomberb provider status` | Inspect enabled data providers |
 | `gloomberb config|cache|plugin|layout|pane|debug|doctor|version|changelog` | Inspect and manage local app state |
 | `gloomberb fn [...]` | Run a pane-backed report command |
@@ -179,8 +178,6 @@ Human-readable output is the default. Automation can opt into structured output 
 | `gloomberb install <user/repo>` | Install a plugin from GitHub |
 | `gloomberb remove <name>` | Remove an installed plugin |
 | `gloomberb update [name]` | Update plugins |
-
-Commands that need a signed-in cloud session may return `auth_required`; sign-in, account management, and chat workflows are still handled in the app UI for now.
 
 ## Plugins
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -136,10 +136,9 @@ gloomberb
 | `gloomberb portfolio [action]` | 管理手动投资组合 |
 | `gloomberb watchlist [action]` | 管理自选列表 |
 | `gloomberb notes\|alerts [action]` | 管理本地笔记与提醒 |
-| `gloomberb broker\|ibkr [action]` | 查看券商集成状态；交易操作需要显式指定账户/配置并加 `--yes` |
-| `gloomberb ai providers\|ask\|screen` | 使用已配置的 AI 服务商与选股器 |
+| `gloomberb broker\|ibkr [action]` | 查看券商配置 |
+| `gloomberb ai providers\|ask` | 使用已配置的 AI 服务商 |
 | `gloomberb rss fetch <url>` | 抓取 RSS 订阅源 |
-| `gloomberb buildout\|congress\|substack\|x-feed\|tweets` | 在已有会话可用时访问云端与社交数据源 |
 | `gloomberb provider status` | 查看已启用的数据源 |
 | `gloomberb config\|cache\|plugin\|layout\|pane\|debug\|doctor\|version\|changelog` | 查看和管理本地应用状态 |
 | `gloomberb fn [...]` | 运行基于面板的报告命令 |
@@ -149,8 +148,6 @@ gloomberb
 | `gloomberb install <user/repo>` | 从 GitHub 安装插件 |
 | `gloomberb remove <name>` | 移除已安装插件 |
 | `gloomberb update [name]` | 更新插件 |
-
-需要已登录云端会话的命令可能返回 `auth_required`；登录、账户管理与聊天相关操作目前仍需在应用界面中完成。
 
 ## 插件
 

--- a/src/cli/commands/automation.test.ts
+++ b/src/cli/commands/automation.test.ts
@@ -199,4 +199,13 @@ describe("headless Pi AI command", () => {
     expect(disconnected.runs).toEqual([]);
     expect(disconnected.closed()).toBe(1);
   });
+
+  test("rejects unsupported verbs instead of returning a stub payload", async () => {
+    const harness = createHarness({
+      catalog: { providers: [], refreshErrors: {} },
+    });
+    await expect(harness.command.execute(["screen"], harness.context))
+      .rejects.toThrow("Usage: gloomberb ai providers|ask");
+    expect(harness.output).toEqual([]);
+  });
 });

--- a/src/cli/commands/automation.ts
+++ b/src/cli/commands/automation.ts
@@ -13,38 +13,26 @@ import type { CliCommandDef } from "../../types/plugin";
 import { withCliServices, withConfigData } from "../context";
 import { requireArg, takeOption } from "./command-utils";
 
-function deferredResult(command: string, code: "auth_required" | "not_implemented", message: string) {
-  return {
-    command,
-    status: code,
-    code,
-    message,
-  };
-}
-
 export const brokerCliCommand: CliCommandDef = {
   name: "broker",
   aliases: ["brokers"],
-  description: "Inspect broker profiles and guarded broker operations",
-  help: { usage: ["broker list", "broker status", "broker add|edit|remove|connect|sync"] },
+  description: "Inspect broker profiles",
+  help: { usage: ["broker list", "broker status"] },
   execute: async (args, ctx) => {
     const action = args[0] ?? "list";
+    if (action !== "list" && action !== "status") {
+      ctx.fail("Usage: gloomberb broker list|status");
+    }
     await withCliServices(ctx, async (services) => {
-      if (action === "list" || action === "status") {
-        const rows = services.config.brokerInstances.map((instance) => ({
+      ctx.printResult({
+        data: services.config.brokerInstances.map((instance) => ({
           id: instance.id,
           type: instance.brokerType,
           label: instance.label,
           enabled: instance.enabled !== false,
           connectionMode: instance.connectionMode ?? "",
           lastSyncedAt: instance.lastSyncedAt ? new Date(instance.lastSyncedAt).toISOString() : "",
-        }));
-        ctx.printResult({ data: rows });
-        return;
-      }
-
-      ctx.printResult({
-        data: deferredResult("broker", "not_implemented", "Broker mutation and connection commands need shared non-UI broker service extraction before they can safely run headless."),
+        })),
       });
     });
   },
@@ -52,36 +40,24 @@ export const brokerCliCommand: CliCommandDef = {
 
 export const ibkrCliCommand: CliCommandDef = {
   name: "ibkr",
-  description: "Guarded IBKR account, order preview, and order action commands",
-  help: { usage: ["ibkr accounts|positions|orders|preview|place|cancel"] },
+  description: "Inspect IBKR profiles",
+  help: { usage: ["ibkr accounts", "ibkr status"] },
   execute: async (args, ctx) => {
     const action = args[0] ?? "status";
-    const profile = takeOption(args, "--profile");
-    const account = takeOption(args, "--account");
-    if ((action === "place" || action === "cancel") && (!profile || !account || !ctx.cliOptions.yes)) {
-      ctx.fail(`ibkr ${action} requires --profile, --account, and --yes.`);
+    if (action !== "accounts" && action !== "status") {
+      ctx.fail("Usage: gloomberb ibkr accounts|status");
     }
     await withCliServices(ctx, async (services) => {
-      const ibkrProfiles = services.config.brokerInstances.filter((instance) => instance.brokerType === "ibkr");
-      if (action === "accounts" || action === "status") {
-        ctx.printResult({ data: ibkrProfiles.map((instance) => ({
-          id: instance.id,
-          label: instance.label,
-          enabled: instance.enabled !== false,
-          connectionMode: instance.connectionMode ?? "",
-          lastSyncedAt: instance.lastSyncedAt ? new Date(instance.lastSyncedAt).toISOString() : "",
-        })) });
-        return;
-      }
       ctx.printResult({
-        data: {
-          ...deferredResult("ibkr", "not_implemented", "IBKR trading commands are registered with safety gates, but headless order/account service extraction is still required."),
-          action,
-          profile: profile ?? null,
-          account: account ?? null,
-          dryRun: ctx.cliOptions.dryRun,
-          confirmed: ctx.cliOptions.yes,
-        },
+        data: services.config.brokerInstances
+          .filter((instance) => instance.brokerType === "ibkr")
+          .map((instance) => ({
+            id: instance.id,
+            label: instance.label,
+            enabled: instance.enabled !== false,
+            connectionMode: instance.connectionMode ?? "",
+            lastSyncedAt: instance.lastSyncedAt ? new Date(instance.lastSyncedAt).toISOString() : "",
+          })),
       });
     });
   },
@@ -133,19 +109,12 @@ export function createAiCliCommand(options: CreateAiCliCommandOptions = {}): Cli
       usage: [
         "ai providers",
         "ai ask [--provider id] [--model id] <prompt>",
-        "ai screen list|show|delete|refresh|export",
       ],
     },
     execute: async (args, ctx) => {
       const action = args[0] ?? "providers";
-      if (action === "screen") {
-        ctx.printResult({
-          data: deferredResult("ai screen", "not_implemented", "AI screener tabs are still pane-state backed; expose them through a shared non-UI screener store before headless mutation."),
-        });
-        return;
-      }
       if (action !== "providers" && action !== "ask") {
-        ctx.fail("Usage: gloomberb ai providers|ask|screen");
+        ctx.fail("Usage: gloomberb ai providers|ask");
       }
 
       const rawArgs = args.slice(1);
@@ -258,23 +227,3 @@ export const rssCliCommand: CliCommandDef = {
     })) });
   },
 };
-
-function cloudCommand(name: string, description: string): CliCommandDef {
-  return {
-    name,
-    description,
-    execute: (_args, ctx) => {
-      ctx.printResult({
-        data: deferredResult(name, "auth_required", "This command needs an existing cloud/session token. New auth/account/chat CLI workflows are deferred in this pass."),
-      });
-    },
-  };
-}
-
-export const cloudCliCommands: CliCommandDef[] = [
-  cloudCommand("buildout", "Fetch Buildout company data through an existing cloud session"),
-  cloudCommand("congress", "Fetch congressional trade data through an existing cloud session"),
-  cloudCommand("substack", "Fetch Substack reader data through an existing session"),
-  cloudCommand("x-feed", "Fetch X/Twitter feed data through an existing cloud session"),
-  cloudCommand("tweets", "Alias for x-feed"),
-];

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,7 +23,6 @@ import { createSystemCliCommands } from "./commands/system";
 import {
   aiCliCommand,
   brokerCliCommand,
-  cloudCliCommands,
   ibkrCliCommand,
   rssCliCommand,
 } from "./commands/automation";
@@ -198,7 +197,6 @@ function createCoreCliCommands(
     ibkrCliCommand,
     aiCliCommand,
     rssCliCommand,
-    ...cloudCliCommands,
   ];
   return commands;
 }


### PR DESCRIPTION
## Summary
- Remove `buildout`, `congress`, `substack`, `x-feed`, and `tweets` CLI commands. They only returned `auth_required` stubs.
- Keep `broker` and `ibkr` as inspect-only (`list`/`status` and `accounts`/`status`). Advertised mutation and trading verbs printed `not_implemented`.
- Keep `ai providers` and `ai ask`. Drop the `ai screen` stub.

## Test plan
- [x] `bun test src/cli/commands/automation.test.ts src/cli/registry.test.ts`
- [ ] `gloomberb help` no longer lists the stub commands
- [ ] `gloomberb broker list` and `gloomberb ai providers` still work