### PR TITLE
Stop rewriting news feeds on every startup

### DIFF
--- a/src/plugins/builtin/news/wire/feed-config.test.ts
+++ b/src/plugins/builtin/news/wire/feed-config.test.ts
@@ -6,6 +6,7 @@ import {
   getEnabledNewsFeeds,
   loadNewsFeedSettings,
   removeUserNewsFeed,
+  saveNewsFeedSettings,
   setDefaultNewsFeedEnabled,
   updateUserNewsFeed,
 } from "./feed-config";
@@ -31,7 +32,7 @@ class MemoryConfigState implements PluginConfigState {
 }
 
 describe("news feed config", () => {
-  test("normalizes legacy JSON feed storage and migrates disabled default feed names to ids", () => {
+  test("normalizes legacy JSON feed storage and migrates disabled default feed names to ids", async () => {
     const config = new MemoryConfigState();
     config.values.set("feeds", JSON.stringify([
       { url: "https://example.com/rss.xml", name: "Example", authority: 120 },
@@ -41,10 +42,23 @@ describe("news feed config", () => {
 
     const settings = loadNewsFeedSettings(config);
 
+    expect(settings.needsMigration).toBe(true);
     expect(settings.userFeeds).toHaveLength(1);
     expect(settings.userFeeds[0]!.id).toMatch(/^user-/);
     expect(settings.userFeeds[0]!.authority).toBe(100);
     expect(settings.disabledDefaultFeedIds).toEqual(["default-cnbc-top"]);
+
+    await saveNewsFeedSettings(config, settings);
+    expect(loadNewsFeedSettings(config).needsMigration).toBe(false);
+  });
+
+  test("does not rewrite canonical feed settings", async () => {
+    const config = new MemoryConfigState();
+    await addUserNewsFeed(config, {
+      url: "https://example.com/feed",
+      name: "Example",
+    });
+    expect(loadNewsFeedSettings(config).needsMigration).toBe(false);
   });
 
   test("adds, updates, and removes user feeds through typed helpers", async () => {

--- a/src/plugins/builtin/news/wire/feed-config.ts
+++ b/src/plugins/builtin/news/wire/feed-config.ts
@@ -12,7 +12,7 @@ const DEFAULT_FEED_IDS = new Set(DEFAULT_FEEDS.map((feed) => feed.id));
 export interface NewsFeedSettings {
   userFeeds: RssFeedConfig[];
   disabledDefaultFeedIds: string[];
-  migrated: boolean;
+  needsMigration: boolean;
 }
 
 export interface UserNewsFeedInput {
@@ -109,6 +109,26 @@ function normalizeDisabledDefaultFeedIds(values: unknown[]): string[] {
   return [...ids];
 }
 
+function sameUserFeeds(raw: unknown, normalized: RssFeedConfig[]): boolean {
+  if (!Array.isArray(raw) || raw.length !== normalized.length) return false;
+  return raw.every((entry, index) => {
+    const feed = normalized[index];
+    if (!feed || !entry || typeof entry !== "object") return false;
+    const record = entry as Record<string, unknown>;
+    return record.id === feed.id
+      && record.url === feed.url
+      && record.name === feed.name
+      && record.category === feed.category
+      && record.authority === feed.authority
+      && record.enabled === feed.enabled;
+  });
+}
+
+function sameIdList(raw: unknown, normalized: string[]): boolean {
+  if (!Array.isArray(raw) || raw.length !== normalized.length) return false;
+  return raw.every((value, index) => value === normalized[index]);
+}
+
 export function loadNewsFeedSettings(configState: PluginConfigState): NewsFeedSettings {
   const rawUserFeeds = configState.get<unknown>(USER_FEEDS_KEY);
   const userFeedValues = parseJsonArray(rawUserFeeds);
@@ -123,11 +143,11 @@ export function loadNewsFeedSettings(configState: PluginConfigState): NewsFeedSe
     ...parseJsonArray(rawLegacyDisabled),
   ]);
 
-  const migrated = rawUserFeeds !== null
-    || rawDisabledIds !== null
-    || rawLegacyDisabled !== null;
+  const needsMigration = rawLegacyDisabled !== null
+    || (rawUserFeeds !== null && !sameUserFeeds(rawUserFeeds, userFeeds))
+    || (rawDisabledIds !== null && !sameIdList(rawDisabledIds, disabledDefaultFeedIds));
 
-  return { userFeeds, disabledDefaultFeedIds, migrated };
+  return { userFeeds, disabledDefaultFeedIds, needsMigration };
 }
 
 export async function saveNewsFeedSettings(

--- a/src/plugins/builtin/news/wire/index.tsx
+++ b/src/plugins/builtin/news/wire/index.tsx
@@ -95,7 +95,7 @@ export const newsWireModule: PluginModule = {
   ],
   setup(ctx) {
     const initialSettings = loadNewsFeedSettings(ctx.configState);
-    if (initialSettings.migrated) {
+    if (initialSettings.needsMigration) {
       void saveNewsFeedSettings(ctx.configState, initialSettings);
     }
 


### PR DESCRIPTION
## Summary
- News setup treated any stored feed settings as a leftover migration, then saved config on every launch.
- Rewrite only when legacy keys, JSON-string storage, or normalized values actually differ from what is stored.

## Test plan
- [x] `bun test src/plugins/builtin/news/wire/feed-config.test.ts`
- [ ] Launch with existing news feed preferences and confirm config is not rewritten on a second start