### PR TITLE
Run legacy chart conversion only during migration

### DIFF
--- a/src/data/config/chart-settings.ts
+++ b/src/data/config/chart-settings.ts
@@ -372,7 +372,7 @@ export function migrateChartPaneSettings(
   settings: Record<string, unknown> | undefined,
   context: LegacyChartMigrationContext = {},
 ): Record<string, unknown> | undefined {
-  if (context.migrateLegacy === false) return settings;
+  if (!context.migrateLegacy) return settings;
   if (paneId === "chart-composer") {
     const retained = stripKeys(settings, [
       "chartAxisMode",

--- a/src/data/config/store/index.test.ts
+++ b/src/data/config/store/index.test.ts
@@ -210,7 +210,7 @@ describe("sanitizeLayout", () => {
       }],
       floating: [],
       detached: [],
-    }, DEFAULT_LAYOUT);
+    }, DEFAULT_LAYOUT, { migrateLegacy: true });
 
     const pane = findPaneInstance(layout, "comparison-chart:main");
     expect(pane?.paneId).toBe("chart-composer");
@@ -251,7 +251,7 @@ describe("sanitizeLayout", () => {
       }],
       floating: [],
       detached: [],
-    }, DEFAULT_LAYOUT);
+    }, DEFAULT_LAYOUT, { migrateLegacy: true });
 
     const settings = findPaneInstance(layout, "ticker-detail:aapl")?.settings;
     expect(settings).toEqual({
@@ -274,6 +274,28 @@ describe("sanitizeLayout", () => {
     expect(settings).not.toHaveProperty("chartAxisMode");
     expect(settings).not.toHaveProperty("chartRangePreset");
     expect(settings).not.toHaveProperty("chartResolution");
+  });
+
+  test("does not convert legacy chart settings during ordinary sanitization", () => {
+    const layout = sanitizeLayout({
+      dockRoot: { kind: "pane", instanceId: "ticker-detail:aapl" },
+      instances: [{
+        instanceId: "ticker-detail:aapl",
+        paneId: "ticker-research",
+        binding: { kind: "fixed", symbol: "AAPL" },
+        settings: {
+          chartRangePreset: "1Y",
+          chartResolution: "1wk",
+        },
+      }],
+      floating: [],
+      detached: [],
+    }, DEFAULT_LAYOUT);
+
+    expect(findPaneInstance(layout, "ticker-detail:aapl")?.settings).toEqual({
+      chartRangePreset: "1Y",
+      chartResolution: "1wk",
+    });
   });
 
   test("falls back to the default layout when given an obsolete column layout", () => {

--- a/src/data/config/store/normalize.ts
+++ b/src/data/config/store/normalize.ts
@@ -17,13 +17,11 @@ import { clampFontSize } from "../../../theme/font-scale";
 import { isLayoutConfig, sanitizeLayout } from "../layout";
 import { migrateSavedConfig } from "./migrations";
 
-const CURRENT_CHART_SANITIZATION = { migrateLegacy: false } as const;
-
 export function normalizeLoadedConfig(saved: Record<string, unknown>, dataDir: string): { config: AppConfig; needsSave: boolean } {
   const defaults = createDefaultConfig(dataDir);
   const migration = migrateSavedConfig(saved, dataDir);
   const candidate = migration.config;
-  const directLayout = sanitizeLayout(candidate.layout, defaults.layout, CURRENT_CHART_SANITIZATION);
+  const directLayout = sanitizeLayout(candidate.layout, defaults.layout);
   const layouts = sanitizeSavedLayouts(candidate.layouts, directLayout);
   const activeLayoutIndex = sanitizeActiveLayoutIndex(candidate.activeLayoutIndex, layouts.length);
   const layout = cloneLayout(layouts[activeLayoutIndex]?.layout ?? directLayout);
@@ -88,7 +86,7 @@ export function normalizeLoadedConfig(saved: Record<string, unknown>, dataDir: s
 
 export function normalizeConfigForSave(config: AppConfig): AppConfig {
   const defaults = createDefaultConfig(config.dataDir);
-  const directLayout = sanitizeLayout(config.layout, defaults.layout, CURRENT_CHART_SANITIZATION);
+  const directLayout = sanitizeLayout(config.layout, defaults.layout);
   const sanitizedLayouts = sanitizeSavedLayouts(config.layouts, directLayout);
   const activeLayoutIndex = sanitizeActiveLayoutIndex(config.activeLayoutIndex, sanitizedLayouts.length || 1);
   const layout = cloneLayout(sanitizedLayouts[activeLayoutIndex]?.layout ?? directLayout);
@@ -306,7 +304,7 @@ function sanitizeSavedLayouts(
       && typeof (entry as SavedLayout).name === "string",
     )
     .map((entry) => {
-      const layout = sanitizeLayout(entry.layout, fallbackLayout, CURRENT_CHART_SANITIZATION);
+      const layout = sanitizeLayout(entry.layout, fallbackLayout);
       const paneState = sanitizeSavedPaneState((entry as { paneState?: unknown }).paneState, layout);
       return {
         id: typeof entry.id === "string" ? entry.id : undefined,


### PR DESCRIPTION
## Summary
- `sanitizeLayout` treated missing `migrateLegacy` as \"convert old chart settings\".
- Normal config load/save now skips that conversion. Version migrations still pass `migrateLegacy: true`.

## Test plan
- [x] `bun test src/data/config/store/index.test.ts`
- [ ] Load a current config and confirm pane chart specs are unchanged
- [ ] Load a pre-v20 config and confirm retired chart panes still convert