### PR TITLE
Drop unfinished plugin CLI descriptors

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -75,7 +75,7 @@ For external plugins, create a directory in `~/.gloomberb/plugins/`:
 
 ## What plugins can do
 
-Use `setup()` for interactive runtime registration, `capabilities` for reusable headless services, and `cli.commands` for root-level CLI commands that should be discoverable without rendering panes. The older `cliCommands` array still works, but new plugins should prefer the typed `cli.commands` descriptor because it exposes summaries, input/output shape, formats, safety notes, and side-effect level to `gloomberb help`, `gloomberb catalog --json`, and `gloomberb api list`.
+Use `setup()` for interactive runtime registration, `capabilities` for reusable headless services, and `cliCommands` for root-level CLI commands that should be discoverable without rendering panes. Capability operations can still declare `cli` manifests (`summary`, input/output shape, formats, safety notes, side-effect level) for `gloomberb api list`.
 
 ## Renderer-neutral UI
 
@@ -145,7 +145,7 @@ Commands registered with `ctx.registerCommand({ shortcut, shortcutArg })` and pa
 
 ### CLI commands
 
-Plugins can declare root CLI commands directly on the plugin object. Prefer `cli.commands` for new commands; keep `cliCommands` only for compatibility with older plugins.
+Plugins can declare root CLI commands directly on the plugin object with `cliCommands`.
 
 ```typescript
 import type { GloomPlugin } from "gloomberb/types/plugin";
@@ -154,44 +154,40 @@ export const myPlugin: GloomPlugin = {
   id: "my-plugin",
   name: "My Plugin",
   version: "1.0.0",
-  cli: {
-    commands: [
-      {
-        name: "my-plugin",
-        aliases: ["mp"],
-        summary: "Run a plugin-owned CLI command",
-        inputShape: "my-plugin run [--limit N]",
-        outputShape: "rows: [{ id, label }]",
-        formats: ["text", "json", "csv", "ndjson"],
-        sideEffectLevel: "none",
-        examples: ["gloomberb my-plugin run --json"],
-        async execute(args, ctx) {
-          if (args[0] !== "run") {
-            ctx.fail("Usage: gloomberb my-plugin run");
-          }
-
-          const services = await ctx.initServices();
-          try {
-            ctx.printResult(
-              {
-                data: [
-                  { id: "demo", label: `Using data dir ${services.config.dataDir}` },
-                ],
-              },
-              {
-                columns: [
-                  { key: "id", header: "ID" },
-                  { key: "label", header: "Label" },
-                ],
-              },
-            );
-          } finally {
-            services.close();
-          }
-        },
+  cliCommands: [
+    {
+      name: "my-plugin",
+      aliases: ["mp"],
+      description: "Run a plugin-owned CLI command",
+      help: {
+        usage: ["my-plugin run [--limit N]"],
       },
-    ],
-  },
+      async execute(args, ctx) {
+        if (args[0] !== "run") {
+          ctx.fail("Usage: gloomberb my-plugin run");
+        }
+
+        const services = await ctx.initServices();
+        try {
+          ctx.printResult(
+            {
+              data: [
+                { id: "demo", label: `Using data dir ${services.config.dataDir}` },
+              ],
+            },
+            {
+              columns: [
+                { key: "id", header: "ID" },
+                { key: "label", header: "Label" },
+              ],
+            },
+          );
+        } finally {
+          services.close();
+        }
+      },
+    },
+  ],
 };
 ```
 

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -4,7 +4,6 @@ import type {
   CliCommandDef,
   CliDispatchResult,
   GloomPlugin,
-  PluginCliCommandDescriptor,
 } from "../types/plugin";
 import type { LoadedExternalPlugin } from "../plugins/loader";
 import { getPluginCatalog } from "../plugins/catalog";
@@ -35,7 +34,6 @@ export interface CliCommandRegistry {
   config: AppConfig | null;
   plugins: GloomPlugin[];
   externalPlugins: LoadedExternalPlugin[];
-  descriptors: Array<{ pluginId: string; descriptor: PluginCliCommandDescriptor }>;
 }
 
 interface BuildCliCommandRegistryOptions {
@@ -69,19 +67,6 @@ export function normalizeCliDispatchResult(result: void | CliDispatchResult): Cl
 
 function getCommandUsageLabel(command: CliCommandDef): string {
   return command.help?.usage?.[0] ?? command.name;
-}
-
-function descriptorToCommand(descriptor: PluginCliCommandDescriptor): CliCommandDef | null {
-  if (!descriptor.execute) return null;
-  return {
-    name: descriptor.name,
-    aliases: descriptor.aliases,
-    description: descriptor.summary,
-    help: descriptor.examples?.length
-      ? { usage: descriptor.examples }
-      : undefined,
-    execute: descriptor.execute,
-  };
 }
 
 function renderHelpSections(registry: CliCommandRegistry): string[] {
@@ -172,7 +157,6 @@ export function buildCliCommandRegistry({
   }
 
   const loadablePlugins: GloomPlugin[] = [];
-  const descriptors: Array<{ pluginId: string; descriptor: PluginCliCommandDescriptor }> = [];
   for (const entry of catalog) {
     if (entry.error) {
       registryLog.warn(`Skipping external plugin "${entry.plugin.id}" for CLI registration.`, {
@@ -184,11 +168,6 @@ export function buildCliCommandRegistry({
     loadablePlugins.push(entry.plugin);
     for (const command of entry.plugin.cliCommands ?? []) {
       registerCommand(command, entry.plugin.id, "plugin");
-    }
-    for (const descriptor of entry.plugin.cli?.commands ?? []) {
-      descriptors.push({ pluginId: entry.plugin.id, descriptor });
-      const command = descriptorToCommand(descriptor);
-      if (command) registerCommand(command, entry.plugin.id, "plugin");
     }
   }
 
@@ -210,7 +189,6 @@ export function buildCliCommandRegistry({
     config,
     plugins: loadablePlugins.filter((plugin) => !disabledPlugins.has(plugin.id)),
     externalPlugins,
-    descriptors,
   };
 }
 

--- a/src/plugins/builtin/plugin-module.test.ts
+++ b/src/plugins/builtin/plugin-module.test.ts
@@ -19,8 +19,7 @@ describe("composeBuiltinPlugin", () => {
   test("combines every declarative contribution under the parent plugin", async () => {
     const registeredBrokers: string[] = [];
     const first: PluginModule = {
-      cliCommands: [{ name: "legacy", description: "Legacy", execute: () => {} }],
-      cli: { commands: [{ name: "typed", summary: "Typed" }] },
+      cliCommands: [{ name: "example", description: "Example", execute: () => {} }],
       panes: [{ id: "one", name: "One", component: () => null, defaultPosition: "right" }],
       paneTemplates: [{ id: "one-pane", paneId: "one", label: "One", description: "One" }],
       capabilities: [{ id: "capability-one" } as never],
@@ -40,8 +39,7 @@ describe("composeBuiltinPlugin", () => {
       modules: [first, second],
     });
 
-    expect(plugin.cliCommands?.map((command) => command.name)).toEqual(["legacy"]);
-    expect(plugin.cli?.commands?.map((command) => command.name)).toEqual(["typed"]);
+    expect(plugin.cliCommands?.map((command) => command.name)).toEqual(["example"]);
     expect(plugin.panes?.map((pane) => pane.id)).toEqual(["one", "two"]);
     expect(plugin.paneTemplates?.map((template) => template.id)).toEqual(["one-pane"]);
     expect(plugin.capabilities?.map((capability) => capability.id)).toEqual(["capability-one"]);

--- a/src/plugins/builtin/plugin-module.ts
+++ b/src/plugins/builtin/plugin-module.ts
@@ -2,7 +2,6 @@ import { Fragment, createElement, type ReactNode } from "react";
 import type {
   GloomPlugin,
   GloomPluginContext,
-  PluginCliDescriptor,
 } from "../../types/plugin";
 
 type PluginMetadataKey = "id" | "name" | "version" | "description" | "toggleable" | "order";
@@ -12,7 +11,6 @@ export type PluginModule = Omit<GloomPlugin, PluginMetadataKey>;
 
 const HANDLED_MODULE_KEYS = [
   "cliCommands",
-  "cli",
   "setup",
   "dispose",
   "panes",
@@ -23,11 +21,8 @@ const HANDLED_MODULE_KEYS = [
 ] as const satisfies readonly (keyof PluginModule)[];
 
 type MissingModuleKey = Exclude<keyof PluginModule, typeof HANDLED_MODULE_KEYS[number]>;
-type MissingCliDescriptorKey = Exclude<keyof PluginCliDescriptor, "commands">;
 const ALL_MODULE_KEYS_HANDLED: MissingModuleKey extends never ? true : never = true;
-const ALL_CLI_DESCRIPTOR_KEYS_HANDLED: MissingCliDescriptorKey extends never ? true : never = true;
 void ALL_MODULE_KEYS_HANDLED;
-void ALL_CLI_DESCRIPTOR_KEYS_HANDLED;
 
 interface CompositePluginOptions extends PluginMetadata {
   modules: readonly PluginModule[];
@@ -72,7 +67,6 @@ function composeSlots(modules: readonly PluginModule[]): GloomPlugin["slots"] {
 export function composeBuiltinPlugin(options: CompositePluginOptions): GloomPlugin {
   const { modules, ...metadata } = options;
   const cliCommands = modules.flatMap((module) => module.cliCommands ?? []);
-  const cliDescriptors = modules.flatMap((module) => module.cli?.commands ?? []);
   const panes = modules.flatMap((module) => module.panes ?? []);
   const paneTemplates = modules.flatMap((module) => module.paneTemplates ?? []);
   const capabilities = modules.flatMap((module) => module.capabilities ?? []);
@@ -83,7 +77,6 @@ export function composeBuiltinPlugin(options: CompositePluginOptions): GloomPlug
   return {
     ...metadata,
     ...(cliCommands.length > 0 ? { cliCommands } : {}),
-    ...(cliDescriptors.length > 0 ? { cli: { commands: cliDescriptors } } : {}),
     ...(panes.length > 0 ? { panes } : {}),
     ...(paneTemplates.length > 0 ? { paneTemplates } : {}),
     ...(capabilities.length > 0 ? { capabilities } : {}),

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -356,25 +356,6 @@ export interface CliCommandDef {
   execute(args: string[], ctx: CliCommandContext): void | CliDispatchResult | Promise<void | CliDispatchResult>;
 }
 
-export interface PluginCliCommandDescriptor {
-  name: string;
-  aliases?: string[];
-  summary: string;
-  inputShape?: string;
-  outputShape?: string;
-  examples?: string[];
-  sideEffectLevel?: "none" | "local-write" | "network-write" | "external-trade" | "external-side-effect";
-  requirements?: string[];
-  batch?: boolean;
-  formats?: Array<"text" | "json" | "csv" | "ndjson">;
-  safety?: string[];
-  execute?: CliCommandDef["execute"];
-}
-
-export interface PluginCliDescriptor {
-  commands?: PluginCliCommandDescriptor[];
-}
-
 export interface CommandDef {
   id: string;
   label: string;
@@ -602,7 +583,6 @@ export interface GloomPlugin {
   toggleable?: boolean;
   order?: number;
   cliCommands?: CliCommandDef[];
-  cli?: PluginCliDescriptor;
 
   setup?(ctx: GloomPluginContext): void | Promise<void>;
   dispose?(): void;


### PR DESCRIPTION
## Summary
- Remove the unused `GloomPlugin.cli` / `PluginCliCommandDescriptor` API. Real plugins already register with `cliCommands`.
- Drop the registry converter that only mapped name/summary/execute and never consumed the extra descriptor fields.
- Document `cliCommands` as the plugin CLI surface. Capability operation `cli` manifests for `gloomberb api` are unchanged.

## Test plan
- [x] `bun test src/plugins/builtin/plugin-module.test.ts src/cli/registry.test.ts`