### PR TITLE
Derive the desktop backend plugin catalog

### DIFF
--- a/src/plugins/catalog-backend.ts
+++ b/src/plugins/catalog-backend.ts
@@ -1,50 +1,12 @@
 import type { GloomPlugin } from "../types/plugin";
-import { aiPlugin } from "./builtin/ai";
-import { alertsPlugin } from "./builtin/alerts";
-import { gloomberbCloudPlugin } from "./builtin/cloud";
-import {
-  applicationPlugin,
-  brokerPlugin,
-  macroPlugin,
-  marketOverviewPlugin,
-  portfolioPlugin,
-} from "./builtin/composite-plugins";
-import { debugPlugin } from "./builtin/debug";
-import { newsPlugin } from "./builtin/news";
-import { notesPlugin } from "./builtin/notes";
-import { substackPlugin } from "./builtin/substack";
 import { tickerResearchBackendPlugin } from "./builtin/ticker-research-backend-plugin";
-import { yahooPlugin } from "./builtin/yahoo";
-import { ibkrPlugin } from "./ibkr";
-import { publicPlugin } from "./broker-sync/public";
-import { robinhoodPlugin } from "./broker-sync/robinhood";
-import { simpleFinPlugin } from "./broker-sync/simplefin";
+import { getLoadablePlugins } from "./catalog";
 import { predictionMarketsBackendPlugin } from "./prediction-markets/backend-plugin";
-import { pollsPlugin } from "./builtin/polls";
-
-const desktopBackendPlugins: GloomPlugin[] = [
-  yahooPlugin,
-  gloomberbCloudPlugin,
-  portfolioPlugin,
-  tickerResearchBackendPlugin,
-  brokerPlugin,
-  ibkrPlugin,
-  publicPlugin,
-  robinhoodPlugin,
-  simpleFinPlugin,
-  applicationPlugin,
-  newsPlugin,
-  substackPlugin,
-  notesPlugin,
-  aiPlugin,
-  predictionMarketsBackendPlugin,
-  pollsPlugin,
-  marketOverviewPlugin,
-  macroPlugin,
-  alertsPlugin,
-  debugPlugin,
-];
 
 export function getDesktopBackendPlugins(): GloomPlugin[] {
-  return desktopBackendPlugins;
+  return getLoadablePlugins().map((plugin) => {
+    if (plugin.id === "ticker-research") return tickerResearchBackendPlugin;
+    if (plugin.id === "prediction-markets") return predictionMarketsBackendPlugin;
+    return plugin;
+  });
 }


### PR DESCRIPTION
## Summary
- Stop restating the builtin plugin list in the desktop bun catalog.
- Map the shared catalog and swap only ticker-research and prediction-markets for the headless variants.

## Test plan
- [x] `bun test src/plugins/catalog-backend.test.ts src/plugins/catalog-browser.test.ts`