### PR TITLE
Share one chart range and resolution list

### DIFF
--- a/src/capabilities/chart-series.ts
+++ b/src/capabilities/chart-series.ts
@@ -9,6 +9,7 @@ import type {
   SeriesTransform,
   TimeSeriesPoint,
 } from "../time-series/types";
+import { CHART_RESOLUTIONS, TIME_RANGES } from "../time-series/range";
 import type {
   CapabilityInvoker,
   CapabilitySchema,
@@ -24,8 +25,8 @@ export const MAX_CHART_SERIES_POINTS = 20_000;
 const CAPABILITY_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/;
 const SERIES_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._~%:/-]{0,239}$/;
 const chartSeriesLog = debugLog.createLogger("chart-series");
-const ranges = new Set(["1D", "1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"]);
-const resolutions = new Set(["auto", "1m", "5m", "15m", "30m", "45m", "1h", "1d", "1wk", "1mo"]);
+const ranges = new Set<string>(TIME_RANGES);
+const resolutions = new Set<string>(CHART_RESOLUTIONS);
 const periods = new Set(["auto", "daily", "weekly", "monthly", "quarterly", "annual", "ttm"]);
 const styles = new Set(["line", "area", "step", "columns", "points", "candles", "ohlc", "hlc"]);
 const transforms = new Set(["raw", "percent", "index100", "yoy", "qoq", "log"]);

--- a/src/cli/commands/market.ts
+++ b/src/cli/commands/market.ts
@@ -1,5 +1,5 @@
 import type { CliCommandDef } from "../../types/plugin";
-import type { TimeRange } from "../../time-series/range";
+import { TIME_RANGES, type TimeRange } from "../../time-series/range";
 import type { EarningsEvent, QuoteBatchResult, SecFilingItem } from "../../types/data-provider";
 import type { NewsArticle, NewsFeed, NewsQuery } from "../../news/types";
 import type {
@@ -15,7 +15,7 @@ import { formatCompact } from "../../utils/format";
 import { withCliServices, withMarketData } from "../context";
 import { isoDate, parsePositiveInt, requireArg, takeOption } from "./command-utils";
 
-const VALID_RANGES = new Set<TimeRange>(["1D", "1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"]);
+const VALID_RANGES = new Set<TimeRange>(TIME_RANGES);
 const VALID_NEWS_FEEDS = new Set<NewsFeed>(["latest", "top", "breaking", "ticker", "sector", "topic"]);
 
 type QuoteCliRecord = Omit<QuoteBatchResult, "error"> & { error: string | null };

--- a/src/cli/pane-functions/capabilities.ts
+++ b/src/cli/pane-functions/capabilities.ts
@@ -1,3 +1,4 @@
+import { CHART_RESOLUTIONS } from "../../time-series/range";
 import type { PaneDef, PaneTemplateDef } from "../../types/plugin";
 
 export type PaneFunctionReadiness = "ready" | "partial" | "unsupported";
@@ -128,8 +129,7 @@ const CAPABILITIES: Record<string, PaneFunctionCapability> = {
         description: "Market-price sampling resolution.",
         type: "enum",
         aliases: ["resolution"],
-        values: ["auto", "1m", "5m", "15m", "30m", "45m", "1h", "1d", "1wk", "1mo"]
-          .map((value) => ({ value })),
+        values: CHART_RESOLUTIONS.map((value) => ({ value })),
       },
     ],
   },
@@ -251,7 +251,7 @@ const CAPABILITIES: Record<string, PaneFunctionCapability> = {
         description: "Price sampling resolution.",
         type: "enum",
         aliases: ["resolution"],
-        values: ["1m", "5m", "15m", "30m", "45m", "1h", "1d", "1wk", "1mo"].map((value) => ({ value })),
+        values: CHART_RESOLUTIONS.filter((value) => value !== "auto").map((value) => ({ value })),
         defaultValue: "1d",
       },
     ],

--- a/src/data/config/chart-settings.ts
+++ b/src/data/config/chart-settings.ts
@@ -1,4 +1,4 @@
-import type { ChartResolution, TimeRange } from "../../time-series/range";
+import { CHART_RESOLUTIONS, TIME_RANGES, type ChartResolution, type TimeRange } from "../../time-series/range";
 import type { LayoutConfig, PaneBinding } from "../../types/config";
 import type {
   ChartPanelSpec,
@@ -16,8 +16,8 @@ import {
   validateChartSpec,
 } from "../../time-series/spec";
 
-const CHART_RANGES = new Set<TimeRange>(["1D", "1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"]);
-const CHART_RESOLUTIONS = new Set<ChartResolution>(["auto", "1m", "5m", "15m", "30m", "45m", "1h", "1d", "1wk", "1mo"]);
+const CHART_RANGES = new Set<TimeRange>(TIME_RANGES);
+const CHART_RESOLUTION_SET = new Set<ChartResolution>(CHART_RESOLUTIONS);
 const PRICE_RENDER_MODES = new Set<SeriesStyle>(["area", "line", "candles", "ohlc", "hlc"]);
 const LEGACY_INDICATOR_IDS = new Set<LegacyChartIndicatorId>([
   "volume",
@@ -94,7 +94,7 @@ function range(value: unknown, fallback: TimeRange): TimeRange {
 }
 
 function resolution(value: unknown, fallback: ChartResolution): ChartResolution {
-  return CHART_RESOLUTIONS.has(value as ChartResolution) ? value as ChartResolution : fallback;
+  return CHART_RESOLUTION_SET.has(value as ChartResolution) ? value as ChartResolution : fallback;
 }
 
 function makeSpec(

--- a/src/plugins/builtin/chart-composer/cli-options.ts
+++ b/src/plugins/builtin/chart-composer/cli-options.ts
@@ -1,5 +1,11 @@
 import type { NormalizedPaneFunctionOptions } from "../../../cli/pane-functions/capabilities";
 import {
+  CHART_RESOLUTIONS,
+  TIME_RANGES,
+  type ChartResolution,
+  type TimeRange,
+} from "../../../time-series/range";
+import {
   coerceSeriesTransformForStyle,
   normalizeChartSpec,
 } from "../../../time-series/spec";
@@ -7,20 +13,17 @@ import type { ChartSeriesSpec, ChartSpec, SeriesPeriod } from "../../../time-ser
 
 const PRICE_CAPABILITIES = new Set(["price-chart", "intraday-price-chart", "price-comparison"]);
 
-function chartRange(options: NormalizedPaneFunctionOptions): ChartSpec["viewport"]["range"] | null {
+function chartRange(options: NormalizedPaneFunctionOptions): TimeRange | null {
   const value = options.rangePreset ?? options.range;
-  return value === "1D" || value === "1W" || value === "1M" || value === "3M"
-    || value === "6M" || value === "1Y" || value === "5Y" || value === "ALL"
-    ? value
+  return typeof value === "string" && (TIME_RANGES as readonly string[]).includes(value)
+    ? value as TimeRange
     : null;
 }
 
-function chartResolution(options: NormalizedPaneFunctionOptions): ChartSpec["viewport"]["resolution"] | null {
+function chartResolution(options: NormalizedPaneFunctionOptions): ChartResolution | null {
   const value = options.chartResolution ?? options.resolution;
-  return value === "auto" || value === "1m" || value === "5m" || value === "15m"
-    || value === "30m" || value === "45m" || value === "1h" || value === "1d"
-    || value === "1wk" || value === "1mo"
-    ? value
+  return typeof value === "string" && (CHART_RESOLUTIONS as readonly string[]).includes(value)
+    ? value as ChartResolution
     : null;
 }
 

--- a/src/plugins/builtin/chart-composer/settings.ts
+++ b/src/plugins/builtin/chart-composer/settings.ts
@@ -1,4 +1,5 @@
 import type { ChartResolution, TimeRange } from "../../../components/chart/core/types";
+import { CHART_RESOLUTIONS, TIME_RANGES as CHART_RANGES } from "../../../time-series/range";
 import type {
   PaneSettingField,
   PaneSettingOption,
@@ -33,19 +34,7 @@ import {
   parseChartSpecOr,
 } from "./chart-spec";
 
-export const CHART_RANGES: TimeRange[] = ["1D", "1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"];
-export const CHART_RESOLUTIONS: ChartResolution[] = [
-  "auto",
-  "1m",
-  "5m",
-  "15m",
-  "30m",
-  "45m",
-  "1h",
-  "1d",
-  "1wk",
-  "1mo",
-];
+export { CHART_RANGES, CHART_RESOLUTIONS };
 
 export const CHART_STUDY_OPTIONS: Array<PaneSettingOption & { value: BuiltinStudySelection }> = [
   { value: "volume", label: "Volume", description: "Volume columns in a lower panel." },

--- a/src/plugins/builtin/ticker-detail/data-panes/historical-prices.tsx
+++ b/src/plugins/builtin/ticker-detail/data-panes/historical-prices.tsx
@@ -9,7 +9,7 @@ import {
   type DataTableColumn,
   type DataTableKeyEvent,
 } from "../../../../components";
-import type { TimeRange } from "../../../../components/chart/core/types";
+import { TIME_RANGES, type TimeRange } from "../../../../time-series/range";
 import type { PaneProps } from "../../../../types/plugin";
 import type { PricePoint } from "../../../../types/financials";
 import { colors, priceColor } from "../../../../theme/colors";
@@ -32,8 +32,6 @@ export type HistoricalPriceRow = {
   change: number | null;
   changePercent: number | null;
 };
-
-const HISTORY_RANGES: TimeRange[] = ["1D", "1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"];
 
 function pricePointDate(point: PricePoint): Date | null {
   const value = point.date as Date | string | number;
@@ -93,8 +91,8 @@ function buildHistoryColumns(width: number): HistoryColumn[] {
 }
 
 function nextHistoryRange(current: TimeRange): TimeRange {
-  const index = HISTORY_RANGES.indexOf(current);
-  return HISTORY_RANGES[(index + 1) % HISTORY_RANGES.length] ?? "1Y";
+  const index = TIME_RANGES.indexOf(current);
+  return TIME_RANGES[(index + 1) % TIME_RANGES.length] ?? "1Y";
 }
 
 export function HistoricalPricesPane({ focused, width, height }: PaneProps) {

--- a/src/time-series/range.ts
+++ b/src/time-series/range.ts
@@ -7,3 +7,15 @@ export interface ChartDateWindow {
 }
 
 export const TIME_RANGES: TimeRange[] = ["1D", "1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"];
+export const CHART_RESOLUTIONS: ChartResolution[] = [
+  "auto",
+  "1m",
+  "5m",
+  "15m",
+  "30m",
+  "45m",
+  "1h",
+  "1d",
+  "1wk",
+  "1mo",
+];

--- a/src/time-series/resolution.ts
+++ b/src/time-series/resolution.ts
@@ -1,5 +1,5 @@
 import type { ChartResolution, TimeRange } from "./range";
-import { TIME_RANGES } from "./range";
+import { CHART_RESOLUTIONS, TIME_RANGES } from "./range";
 import { isDateWindowWithinTimeRange } from "./date-window";
 
 export type ManualChartResolution = Exclude<ChartResolution, "auto">;
@@ -9,20 +9,8 @@ export interface ChartResolutionSupport {
   maxRange: TimeRange;
 }
 
-export const TIME_RANGE_ORDER: TimeRange[] = [...TIME_RANGES];
-
-const CHART_RESOLUTION_ORDER: ChartResolution[] = [
-  "auto",
-  "1m",
-  "5m",
-  "15m",
-  "30m",
-  "45m",
-  "1h",
-  "1d",
-  "1wk",
-  "1mo",
-];
+export const TIME_RANGE_ORDER = TIME_RANGES;
+const CHART_RESOLUTION_ORDER = CHART_RESOLUTIONS;
 
 const CHART_RESOLUTION_LABELS: Record<ChartResolution, string> = {
   auto: "AUTO",

--- a/src/time-series/spec.ts
+++ b/src/time-series/spec.ts
@@ -1,4 +1,4 @@
-import type { ChartResolution, TimeRange } from "./range";
+import { CHART_RESOLUTIONS, TIME_RANGES, type ChartResolution, type TimeRange } from "./range";
 import { getChartResolutionLabel } from "./resolution";
 import {
   canonicalTimeSeriesFieldId,
@@ -31,8 +31,8 @@ import {
   isValidChartSeriesId,
 } from "../capabilities/chart-series";
 
-const TIME_RANGES = new Set<TimeRange>(["1D", "1W", "1M", "3M", "6M", "1Y", "5Y", "ALL"]);
-const RESOLUTIONS = new Set<ChartResolution>(["auto", "1m", "5m", "15m", "30m", "45m", "1h", "1d", "1wk", "1mo"]);
+const RANGE_SET = new Set<TimeRange>(TIME_RANGES);
+const RESOLUTIONS = new Set<ChartResolution>(CHART_RESOLUTIONS);
 const PERIODS = new Set<SeriesPeriod>(["auto", "daily", "weekly", "monthly", "quarterly", "annual", "ttm"]);
 const STYLES = new Set<SeriesStyle>(["line", "area", "step", "columns", "points", "candles", "ohlc", "hlc"]);
 const ECONOMIC_STYLES = new Set<SeriesStyle>(["line", "area", "step", "columns", "points"]);
@@ -306,7 +306,7 @@ export function normalizeChartSpec(value: unknown, fallback: ChartSpec = DEFAULT
   return {
     version: CHART_SPEC_VERSION,
     viewport: {
-      range: TIME_RANGES.has(viewport?.range as TimeRange)
+      range: RANGE_SET.has(viewport?.range as TimeRange)
         ? viewport!.range as TimeRange
         : fallbackCopy.viewport.range,
       resolution: RESOLUTIONS.has(viewport?.resolution as ChartResolution)
@@ -340,7 +340,7 @@ export function validateChartSpec(spec: ChartSpec): ChartSpecValidationResult {
   if (spec.version !== CHART_SPEC_VERSION) {
     errors.push(issue("version", "unsupported-version", `Unsupported chart spec version ${String(spec.version)}.`));
   }
-  if (!TIME_RANGES.has(spec.viewport.range)) errors.push(issue("viewport.range", "invalid-range", "Invalid date range."));
+  if (!RANGE_SET.has(spec.viewport.range)) errors.push(issue("viewport.range", "invalid-range", "Invalid date range."));
   if (!RESOLUTIONS.has(spec.viewport.resolution)) {
     errors.push(issue("viewport.resolution", "invalid-resolution", "Invalid chart resolution."));
   }


### PR DESCRIPTION
## Summary
- Export `CHART_RESOLUTIONS` next to the existing `TIME_RANGES` list.
- Point spec validation, chart settings, composer CLI, historical prices, capabilities, and market CLI at those lists instead of restating the same literals.

## Test plan
- [x] `bun test src/time-series/spec-studies.test.ts src/time-series/resolution.test.ts src/plugins/builtin/chart-composer/settings.test.ts src/data/config/store/index.test.ts src/cli/pane-functions`
- [x] `bun run typecheck:opentui`