### PR TITLE
Fix smooth desktop chart panning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 Stack: Bun + OpenTUI
 
+Before making any code change, kill every project dev server/watcher and app process it spawned. Keep them stopped throughout editing and build/test work; restart only after the code changes and checks are complete.
+
 Tests:
 - Be selective: add or keep a test only when it protects behavior that is easy to break and hard to catch in review.
 - Good test targets: parser/math/state complexity, async/cache/persistence behavior, integration boundaries, and regressions with a concrete failure mode that could plausibly return.

--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -54,7 +54,13 @@ function assignRef(ref: ForwardedRef<any>, value: any) {
   else if (ref) ref.current = value;
 }
 
-function CaptureChartSurfaceProvider({ children }: { children: ReactNode }) {
+function CaptureChartSurfaceProvider({
+  children,
+  desktop = false,
+}: {
+  children: ReactNode;
+  desktop?: boolean;
+}) {
   const baseUi = useUiHost();
   const renderer = useRendererHost();
   const nativeRenderer = useNativeRenderer();
@@ -72,8 +78,8 @@ function CaptureChartSurfaceProvider({ children }: { children: ReactNode }) {
     });
   }, [baseUi]);
   const ui = useMemo(
-    () => ({ ...baseUi, ChartSurface: CapturingChartSurface }),
-    [CapturingChartSurface, baseUi],
+    () => ({ ...baseUi, kind: desktop ? "desktop-web" as const : baseUi.kind, ChartSurface: CapturingChartSurface }),
+    [CapturingChartSurface, baseUi, desktop],
   );
   return (
     <UiHostProvider ui={ui} renderer={renderer} nativeRenderer={nativeRenderer}>
@@ -1309,6 +1315,57 @@ describe("CompositeChart", () => {
     expect(frame).toContain("106%");
     expect(frame).toContain("2025-01-03");
     expect(frame).toContain("────────");
+  });
+
+  test("uses one live scene path for mouse and trackpad panning", async () => {
+    testSetup = await testRender(
+      <CaptureChartSurfaceProvider desktop>
+        <CompositeChart
+          width={60}
+          height={12}
+          showLegend={false}
+          interactive
+          allowHistoricalBackfill={false}
+          series={[series("price", "main", "left", "USD", [
+            10, 20, 30, 40, 50, 60, 700, 800, 900, 1000, 1100,
+          ])]}
+          panels={[{ id: "main" }]}
+          viewport={{
+            start: new Date("2025-01-03T00:00:00.000Z"),
+            end: new Date("2025-01-08T00:00:00.000Z"),
+          }}
+        />
+      </CaptureChartSurfaceProvider>,
+      { width: 62, height: 14 },
+    );
+    await act(async () => testSetup!.renderOnce());
+
+    const source = capturedSurfaceProps!.paintSource;
+    const width = source.getFrame().width as number;
+    const mouseX = (width - 1) * 0.6;
+    const input = (x: number) => ({ x, y: 4, shift: false, alt: false, ctrl: false });
+    const initialAxisLabels = testSetup.captureCharFrame().match(/\$[\d,.]+/g);
+
+    await act(async () => {
+      expect(source.pointerDown(input((width - 1) * 0.3))).toBe(true);
+      source.pointerMove(input(mouseX));
+      source.panFrame(input(mouseX));
+      await testSetup!.renderOnce();
+    });
+
+    expect(capturedSurfaceProps!.paintSource).toBe(source);
+    expect(capturedSurfaceProps!.crosshair.pixelX).toBeCloseTo(mouseX, 6);
+    expect(testSetup.captureCharFrame().match(/\$[\d,.]+/g)).not.toEqual(initialAxisLabels);
+
+    await act(async () => {
+      source.pointerUp(input(mouseX));
+      expect(source.scrollPan(-12)).toBe(true);
+      source.panFrame(input((width - 1) * 0.4));
+      await testSetup!.renderOnce();
+    });
+    expect(capturedSurfaceProps!.paintSource).toBe(source);
+    expect(capturedSurfaceProps!.crosshair.pixelX).toBeCloseTo((width - 1) * 0.4, 6);
+    await act(async () => source.scrollPanEnd());
   });
 
   test("zooms around the mouse pointer with control-wheel", async () => {

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -583,6 +583,15 @@ function CompositePanelSurface({
   const plotAspect = (plotWidth * cellWidthPx) / Math.max(panel.height * cellHeightPx, 1);
   const bitmapSize = useStaticChartBitmapSize(plotWidth, panel.height);
   const bitmap = useCompositePanelBitmap({ panel, bitmapSize, colors, isDesktopWeb });
+  const paintCallbacksRef = useRef({ onActivate, onCursorDateChange });
+  paintCallbacksRef.current = { onActivate, onCursorDateChange };
+  const activatePaintSource = useCallback(() => paintCallbacksRef.current.onActivate?.(), []);
+  const updateScrollCrosshair = useCallback((_date: Date | null, yRatio: number) => {
+    setCursorYRatio((current) => current === yRatio ? current : yRatio);
+  }, []);
+  const commitScrollCrosshair = useCallback((date: Date | null) => {
+    paintCallbacksRef.current.onCursorDateChange(date);
+  }, []);
   const paintSource = useMemo(() => (
     isDesktopWeb
       ? createCompositePanelPaintSource({
@@ -592,21 +601,25 @@ function CompositePanelSurface({
           width: plotWidth * cellWidthPx,
           height: panel.height * cellHeightPx,
           interactive: interactive && armedTool === null,
-          onActivate,
+          onActivate: activatePaintSource,
+          onScrollPanFrame: updateScrollCrosshair,
+          onScrollPanEnd: commitScrollCrosshair,
         })
       : null
   ), [
+    activatePaintSource,
     armedTool,
     cellHeightPx,
     cellWidthPx,
     colors,
+    commitScrollCrosshair,
     engine,
     interactive,
     isDesktopWeb,
-    onActivate,
     panel.height,
     panel.id,
     plotWidth,
+    updateScrollCrosshair,
   ]);
   const columnLayout = useMemo(() => buildCompositeColumnLayout(panel), [panel]);
   const crosshairSurface = isDesktopWeb
@@ -1556,7 +1569,7 @@ export function CompositeChart({
   const maximumAxisWidth = Math.max(0, Math.floor(axisWidth));
   // Gutters follow their labels. A fixed budget left dead space beside short
   // prices, which costs plot width on every chart that does not need it.
-  const resolvedAxisWidth = useMemo(() => Math.min(
+  const computedAxisWidth = useMemo(() => Math.min(
     maximumAxisWidth,
     Math.max(
       MINIMUM_AXIS_LABEL_WIDTH,
@@ -1566,6 +1579,9 @@ export function CompositeChart({
       ]),
     ),
   ), [maximumAxisWidth, projectedScene]);
+  const restingAxisWidthRef = useRef(computedAxisWidth);
+  if (!engine.isDragging()) restingAxisWidthRef.current = computedAxisWidth;
+  const resolvedAxisWidth = engine.isDragging() ? restingAxisWidthRef.current : computedAxisWidth;
   const leftAxisWidth = hasLeftAxis ? resolvedAxisWidth : 0;
   const rightAxisWidth = hasRightAxis ? resolvedAxisWidth : 0;
   const axisGap = resolvedAxisWidth > 0 ? 1 : 0;
@@ -1584,15 +1600,17 @@ export function CompositeChart({
     nextViewport: CompositeViewportRange,
     axisDomains?: CompositeAxisDomains,
     widthScale = 1,
+    cursorDate?: Date | null,
   ) => {
     // lastTickKey busts the builder when a live source mutates in place.
     void lastTickKey;
+    const cursorTimestamp = cursorDate === undefined
+      ? normalizedCursorTimestamp
+      : cursorDate?.getTime() ?? null;
     const next = buildCompositeChartScene(visibleSeries, panels, {
       width: Math.max(1, Math.round(plotWidth * widthScale)),
       height: plotHeight,
-      cursorDate: normalizedCursorTimestamp === null
-        ? null
-        : new Date(normalizedCursorTimestamp),
+      cursorDate: cursorTimestamp === null ? null : new Date(cursorTimestamp),
       viewport: nextViewport,
       timelineSeries: marketTimelineSeries,
       axisDomains,

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -521,6 +521,7 @@ interface CompositePanelSurfaceProps {
   onSelectDrawing: (id: string | null) => void;
   onActivate?: () => void;
   onCursorDateChange: (date: Date | null) => void;
+  onPanSceneChange: (scene: CompositeChartScene | null) => void;
   onPanViewport: (shiftRatio: number, fromViewport?: CompositeViewportRange) => void;
   onZoomViewport: (zoomFactor: number, anchorRatio: number) => void;
   onSetViewport: (range: CompositeViewportRange) => void;
@@ -549,6 +550,7 @@ function CompositePanelSurface({
   onSelectDrawing,
   onActivate,
   onCursorDateChange,
+  onPanSceneChange,
   onPanViewport,
   onZoomViewport,
   onSetViewport,
@@ -583,14 +585,19 @@ function CompositePanelSurface({
   const plotAspect = (plotWidth * cellWidthPx) / Math.max(panel.height * cellHeightPx, 1);
   const bitmapSize = useStaticChartBitmapSize(plotWidth, panel.height);
   const bitmap = useCompositePanelBitmap({ panel, bitmapSize, colors, isDesktopWeb });
-  const paintCallbacksRef = useRef({ onActivate, onCursorDateChange });
-  paintCallbacksRef.current = { onActivate, onCursorDateChange };
+  const paintCallbacksRef = useRef({ onActivate, onCursorDateChange, onPanSceneChange });
+  paintCallbacksRef.current = { onActivate, onCursorDateChange, onPanSceneChange };
   const activatePaintSource = useCallback(() => paintCallbacksRef.current.onActivate?.(), []);
-  const updateScrollCrosshair = useCallback((_date: Date | null, yRatio: number) => {
+  const updatePanCrosshair = useCallback((nextScene: CompositeChartScene | null, yRatio: number) => {
     setCursorYRatio((current) => current === yRatio ? current : yRatio);
+    paintCallbacksRef.current.onPanSceneChange(nextScene);
   }, []);
-  const commitScrollCrosshair = useCallback((date: Date | null) => {
+  const commitPanCrosshair = useCallback((date: Date | null) => {
+    paintCallbacksRef.current.onPanSceneChange(null);
     paintCallbacksRef.current.onCursorDateChange(date);
+  }, []);
+  const cancelPanCrosshair = useCallback(() => {
+    paintCallbacksRef.current.onPanSceneChange(null);
   }, []);
   const paintSource = useMemo(() => (
     isDesktopWeb
@@ -602,24 +609,26 @@ function CompositePanelSurface({
           height: panel.height * cellHeightPx,
           interactive: interactive && armedTool === null,
           onActivate: activatePaintSource,
-          onScrollPanFrame: updateScrollCrosshair,
-          onScrollPanEnd: commitScrollCrosshair,
+          onPanFrame: updatePanCrosshair,
+          onPanEnd: commitPanCrosshair,
+          onPanCancel: cancelPanCrosshair,
         })
       : null
   ), [
     activatePaintSource,
     armedTool,
+    cancelPanCrosshair,
     cellHeightPx,
     cellWidthPx,
     colors,
-    commitScrollCrosshair,
+    commitPanCrosshair,
     engine,
     interactive,
     isDesktopWeb,
     panel.height,
     panel.id,
     plotWidth,
-    updateScrollCrosshair,
+    updatePanCrosshair,
   ]);
   const columnLayout = useMemo(() => buildCompositeColumnLayout(panel), [panel]);
   const crosshairSurface = isDesktopWeb
@@ -1489,6 +1498,7 @@ export function CompositeChart({
     ? `viewport:${viewportResetSequenceRef.current}`
     : `authored:${viewportResetKey}`;
   const engineRef = useRef<CompositeChartEngine | null>(null);
+  const [panScene, setPanScene] = useState<CompositeChartScene | null>(null);
   if (!engineRef.current) engineRef.current = new CompositeChartEngine();
   const engine = engineRef.current;
   const engineSnapshot = useSyncExternalStore(
@@ -1658,9 +1668,10 @@ export function CompositeChart({
   useLayoutEffect(() => {
     if (engineConfig) engine.configure(engineConfig);
   }, [engine, engineConfig]);
-  const scene = engineConfig && engine.isConfigured(engineConfig)
+  const settledScene = engineConfig && engine.isConfigured(engineConfig)
     ? engineSnapshot.scene
     : fallbackScene;
+  const scene = panScene ?? settledScene;
   const liveViewport = engineConfig && engine.isConfigured(engineConfig)
     ? engineSnapshot.viewport ?? effectiveViewport
     : effectiveViewport;
@@ -1986,6 +1997,7 @@ export function CompositeChart({
           onSelectDrawing={setSelectedDrawingId}
           onActivate={onActivate}
           onCursorDateChange={updateCursor}
+          onPanSceneChange={setPanScene}
           onPanViewport={panViewport}
           onZoomViewport={zoomViewport}
           onSetViewport={setViewportRange}

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -583,10 +583,6 @@ function CompositePanelSurface({
   const plotAspect = (plotWidth * cellWidthPx) / Math.max(panel.height * cellHeightPx, 1);
   const bitmapSize = useStaticChartBitmapSize(plotWidth, panel.height);
   const bitmap = useCompositePanelBitmap({ panel, bitmapSize, colors, isDesktopWeb });
-  const handlePanFrame = useCallback((date: Date | null, yRatio: number) => {
-    setCursorYRatio((current) => current === yRatio ? current : yRatio);
-    onCursorDateChange(date);
-  }, [onCursorDateChange]);
   const paintSource = useMemo(() => (
     isDesktopWeb
       ? createCompositePanelPaintSource({
@@ -597,7 +593,6 @@ function CompositePanelSurface({
           height: panel.height * cellHeightPx,
           interactive: interactive && armedTool === null,
           onActivate,
-          onPanFrame: handlePanFrame,
         })
       : null
   ), [
@@ -606,7 +601,6 @@ function CompositePanelSurface({
     cellWidthPx,
     colors,
     engine,
-    handlePanFrame,
     interactive,
     isDesktopWeb,
     onActivate,
@@ -1590,17 +1584,15 @@ export function CompositeChart({
     nextViewport: CompositeViewportRange,
     axisDomains?: CompositeAxisDomains,
     widthScale = 1,
-    cursorDate?: Date | null,
   ) => {
     // lastTickKey busts the builder when a live source mutates in place.
     void lastTickKey;
-    const cursorTimestamp = cursorDate === undefined
-      ? normalizedCursorTimestamp
-      : cursorDate?.getTime() ?? null;
     const next = buildCompositeChartScene(visibleSeries, panels, {
       width: Math.max(1, Math.round(plotWidth * widthScale)),
       height: plotHeight,
-      cursorDate: cursorTimestamp === null ? null : new Date(cursorTimestamp),
+      cursorDate: normalizedCursorTimestamp === null
+        ? null
+        : new Date(normalizedCursorTimestamp),
       viewport: nextViewport,
       timelineSeries: marketTimelineSeries,
       axisDomains,

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -609,7 +609,9 @@ function CompositePanelSurface({
     plotWidth,
   ]);
   const columnLayout = useMemo(() => buildCompositeColumnLayout(panel), [panel]);
-  const crosshairSurface = paintSource?.getFrame() ?? bitmap;
+  const crosshairSurface = isDesktopWeb
+    ? { width: plotWidth * cellWidthPx, height: panel.height * cellHeightPx }
+    : bitmap;
   const crosshair = useMemo(
     () => resolvePanelCrosshair(
       panel,
@@ -1581,11 +1583,12 @@ export function CompositeChart({
   const buildEngineScene = useCallback((
     nextViewport: CompositeViewportRange,
     axisDomains?: CompositeAxisDomains,
+    widthScale = 1,
   ) => {
     // lastTickKey busts the builder when a live source mutates in place.
     void lastTickKey;
     const next = buildCompositeChartScene(visibleSeries, panels, {
-      width: plotWidth,
+      width: Math.max(1, Math.round(plotWidth * widthScale)),
       height: plotHeight,
       cursorDate: normalizedCursorTimestamp === null
         ? null
@@ -1594,7 +1597,9 @@ export function CompositeChart({
       timelineSeries: marketTimelineSeries,
       axisDomains,
     });
-    return next ? downsampleCompositeChartScene(next, downsampleWidth) : null;
+    return next
+      ? downsampleCompositeChartScene(next, Math.max(1, Math.round(downsampleWidth * widthScale)))
+      : null;
   }, [
     downsampleWidth,
     lastTickKey,

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import {
   Box,
   ChartSurface,
@@ -48,17 +56,19 @@ import {
   COMPOSITE_KEYBOARD_PAN_RATIO,
   COMPOSITE_ZOOM_STEP_FACTOR,
   clampCompositeViewport,
-  panCompositeViewport,
   resolveCompositeChartInteraction,
   resolveCompositeMinimumSpanMs,
   resolveCompositeNavigationBounds,
   resolveCompositeWheelPanRatio,
-  sameCompositeViewport,
   shouldResetCompositeViewport,
-  zoomCompositeViewport,
   type CompositeViewportRange,
 } from "./interactions";
 import { buildCompositeColumnLayout, type CompositeColumnLayout } from "./column-layout";
+import {
+  CompositeChartEngine,
+  createCompositePanelPaintSource,
+  type CompositeAxisDomains,
+} from "./engine";
 import { renderCompositePanelBitmap } from "./rasterizer";
 import {
   buildChartToolVectors,
@@ -84,8 +94,6 @@ import {
 } from "./tools";
 import { unprojectCompositeTimestamp } from "./time-scale";
 import {
-  allocateCompositePanelHeights,
-  applyCompositeChartCursor,
   buildCompositeChartScene,
   projectCompositeValue,
   resolveAdjacentCompositeCursorDate,
@@ -108,9 +116,6 @@ import type {
   CompositePanelScene,
 } from "./types";
 
-// A short resize-only delay coalesces geometry churn without delaying
-// live-data paints or depending on a foreground animation frame.
-const DESKTOP_BITMAP_RESIZE_DEBOUNCE_MS = 32;
 const LEGEND_WHEEL_DELTA_PER_CELL = 8;
 
 function isVerticalWheelDirection(
@@ -142,120 +147,20 @@ function useCompositePanelBitmap({
   colors: CompositeChartColors;
   isDesktopWeb: boolean;
 }): NativeChartBitmap | null {
-  const [desktopBitmap, setDesktopBitmap] = useState<NativeChartBitmap | null>(null);
-  const desktopBitmapRef = useRef<NativeChartBitmap | null>(null);
-  const desktopRenderInputRef = useRef<{
-    panel: CompositePanelScene;
-    pixelWidth: number;
-    pixelHeight: number;
-    colors: CompositeChartColors;
-  } | null>(null);
-  const desktopRequestedSizeRef = useRef<{ pixelWidth: number; pixelHeight: number } | null>(null);
-  const desktopRenderedSizeRef = useRef<{ pixelWidth: number; pixelHeight: number } | null>(null);
-  const desktopRenderTimerRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
-  const desktopActiveRef = useRef(false);
-  const pixelWidth = bitmapSize?.pixelWidth ?? null;
-  const pixelHeight = bitmapSize?.pixelHeight ?? null;
-
-  desktopRenderInputRef.current = isDesktopWeb && pixelWidth !== null && pixelHeight !== null
-    ? { panel, pixelWidth, pixelHeight, colors }
-    : null;
-
-  // The cursor is drawn as a separate overlay, so the plot raster stays cached
-  // (and resident in the terminal) while the crosshair moves.
-  const terminalBitmap = useMemo(() => {
-    if (isDesktopWeb || !bitmapSize) return null;
-    return renderPanelBitmap(panel, bitmapSize, colors);
-  }, [bitmapSize, colors, isDesktopWeb, panel]);
-
-  useEffect(() => {
-    const cancelRender = () => {
-      if (desktopRenderTimerRef.current === null) return;
-      clearTimeout(desktopRenderTimerRef.current);
-      desktopRenderTimerRef.current = null;
-    };
-    const scheduleRender = (delay: number) => {
-      if (desktopRenderTimerRef.current !== null) return;
-      desktopRenderTimerRef.current = globalThis.setTimeout(() => {
-        desktopRenderTimerRef.current = null;
-        if (!desktopActiveRef.current) return;
-        const input = desktopRenderInputRef.current;
-        if (!input) return;
-        const next = renderPanelBitmap(
-          input.panel,
-          { pixelWidth: input.pixelWidth, pixelHeight: input.pixelHeight },
-          input.colors,
-        );
-        if (!desktopActiveRef.current) return;
-        desktopRenderedSizeRef.current = {
-          pixelWidth: input.pixelWidth,
-          pixelHeight: input.pixelHeight,
-        };
-        desktopBitmapRef.current = next;
-        setDesktopBitmap(next);
-      }, delay);
-    };
-
-    if (!isDesktopWeb) {
-      desktopActiveRef.current = false;
-      cancelRender();
-      desktopRequestedSizeRef.current = null;
-      desktopRenderedSizeRef.current = null;
-      return;
-    }
-    if (pixelWidth === null || pixelHeight === null) {
-      desktopActiveRef.current = false;
-      cancelRender();
-      desktopRequestedSizeRef.current = null;
-      desktopRenderedSizeRef.current = null;
-      desktopBitmapRef.current = null;
-      setDesktopBitmap((current) => current === null ? current : null);
-      return;
-    }
-
-    desktopActiveRef.current = true;
-    const nextSize = { pixelWidth, pixelHeight };
-    const requestedSize = desktopRequestedSizeRef.current;
-    const requestedSizeChanged = !requestedSize
-      || requestedSize.pixelWidth !== pixelWidth
-      || requestedSize.pixelHeight !== pixelHeight;
-    desktopRequestedSizeRef.current = nextSize;
-    const renderedSize = desktopRenderedSizeRef.current;
-    const sizeAlreadyRendered = !!renderedSize
-      && renderedSize.pixelWidth === pixelWidth
-      && renderedSize.pixelHeight === pixelHeight;
-
-    if (!desktopBitmapRef.current || sizeAlreadyRendered) {
-      if (requestedSizeChanged) cancelRender();
-      scheduleRender(0);
-      return;
-    }
-
-    if (!requestedSizeChanged || desktopRenderTimerRef.current !== null) return;
-    scheduleRender(DESKTOP_BITMAP_RESIZE_DEBOUNCE_MS);
-  }, [colors, isDesktopWeb, panel, pixelHeight, pixelWidth]);
-
-  useEffect(() => () => {
-    desktopActiveRef.current = false;
-    if (desktopRenderTimerRef.current !== null) {
-      clearTimeout(desktopRenderTimerRef.current);
-      desktopRenderTimerRef.current = null;
-    }
-  }, []);
-
-  if (!bitmapSize) return null;
-  return isDesktopWeb ? desktopBitmap : terminalBitmap;
+  return useMemo(() => (
+    isDesktopWeb || !bitmapSize ? null : renderPanelBitmap(panel, bitmapSize, colors)
+  ), [bitmapSize, colors, isDesktopWeb, panel]);
 }
 
 function resolvePanelCrosshair(
   panel: CompositePanelScene,
   columnLayout: CompositeColumnLayout,
-  bitmap: NativeChartBitmap | null,
+  surface: { width: number; height: number } | null,
   cursorXRatio: number | null,
   cursorYRatio: number | null,
   color: string,
 ): ChartSurfaceProps["crosshair"] {
-  if (!bitmap || cursorXRatio === null || cursorYRatio === null) return null;
+  if (!surface || cursorXRatio === null || cursorYRatio === null) return null;
   const markers = panel.series.flatMap((series) => {
     // Column cohorts are drawn at their group center, not each observation's
     // own timestamp, so match the position the bar actually occupies.
@@ -267,14 +172,14 @@ function resolvePanelCrosshair(
     });
     return cursorPoint
       ? [{
-        pixelY: cursorPoint.yRatio * Math.max(bitmap.height - 1, 0),
+        pixelY: cursorPoint.yRatio * Math.max(surface.height - 1, 0),
         color: series.source.color,
       }]
       : [];
   });
   return {
-    pixelX: cursorXRatio * Math.max(bitmap.width - 1, 0),
-    pixelY: cursorYRatio * Math.max(bitmap.height - 1, 0),
+    pixelX: cursorXRatio * Math.max(surface.width - 1, 0),
+    pixelY: cursorYRatio * Math.max(surface.height - 1, 0),
     color,
     markers,
   };
@@ -596,6 +501,7 @@ function resolveSeriesCursorYRatio(
 }
 
 interface CompositePanelSurfaceProps {
+  engine: CompositeChartEngine;
   panel: CompositePanelScene;
   scene: CompositeChartScene;
   plotWidth: number;
@@ -623,6 +529,7 @@ interface CompositePanelSurfaceProps {
 }
 
 function CompositePanelSurface({
+  engine,
   panel,
   scene,
   plotWidth,
@@ -676,10 +583,43 @@ function CompositePanelSurface({
   const plotAspect = (plotWidth * cellWidthPx) / Math.max(panel.height * cellHeightPx, 1);
   const bitmapSize = useStaticChartBitmapSize(plotWidth, panel.height);
   const bitmap = useCompositePanelBitmap({ panel, bitmapSize, colors, isDesktopWeb });
+  const paintSource = useMemo(() => (
+    isDesktopWeb
+      ? createCompositePanelPaintSource({
+          engine,
+          panelId: panel.id,
+          colors,
+          width: plotWidth * cellWidthPx,
+          height: panel.height * cellHeightPx,
+          interactive: interactive && armedTool === null,
+          onActivate,
+        })
+      : null
+  ), [
+    armedTool,
+    cellHeightPx,
+    cellWidthPx,
+    colors,
+    engine,
+    interactive,
+    isDesktopWeb,
+    onActivate,
+    panel.height,
+    panel.id,
+    plotWidth,
+  ]);
   const columnLayout = useMemo(() => buildCompositeColumnLayout(panel), [panel]);
+  const crosshairSurface = paintSource?.getFrame() ?? bitmap;
   const crosshair = useMemo(
-    () => resolvePanelCrosshair(panel, columnLayout, bitmap, scene.cursorXRatio, activeCursorYRatio, colors.crosshair),
-    [activeCursorYRatio, bitmap, colors.crosshair, columnLayout, panel, scene.cursorXRatio],
+    () => resolvePanelCrosshair(
+      panel,
+      columnLayout,
+      crosshairSurface,
+      scene.cursorXRatio,
+      activeCursorYRatio,
+      colors.crosshair,
+    ),
+    [activeCursorYRatio, colors.crosshair, columnLayout, crosshairSurface, panel, scene.cursorXRatio],
   );
   const measureDomain = useMemo(() => resolveMeasureAxisDomain(panel), [panel]);
   const toolReadout = useMemo(() => {
@@ -943,7 +883,9 @@ function CompositePanelSurface({
       updateCursor(event);
       return;
     }
-    if (!updateCursor(event)) return;
+    // Desktop panning belongs to the Canvas pointer path. Falling back here
+    // would quantize the drag through terminal-cell mouse coordinates.
+    if (isDesktopWeb || !updateCursor(event)) return;
     dragRef.current = {
       kind: "pan",
       startGlobalX: getGlobalMouseX(event, renderer),
@@ -952,6 +894,7 @@ function CompositePanelSurface({
   }, [
     armedTool,
     drawings,
+    isDesktopWeb,
     onActivate,
     onSelectDrawing,
     panel,
@@ -1108,6 +1051,7 @@ function CompositePanelSurface({
         height={panel.height}
         flexDirection="column"
         bitmaps={bitmapLayers}
+        paintSource={paintSource}
         crosshair={crosshair}
         vectors={vectors}
         onMouseMove={interactive ? handleMouseMove : undefined}
@@ -1518,19 +1462,28 @@ export function CompositeChart({
     ));
   }, [visibleLegendSeries.length]);
   const previousAuthoredViewportRef = useRef<CompositeViewportRange | null>(viewport ?? null);
-  const previousViewportResetKeyRef = useRef(viewportResetKey);
-  const [interactionViewport, setInteractionViewport] = useState<CompositeViewportRange | null>(null);
-  const hasViewportResetKey = viewportResetKey !== undefined
-    || previousViewportResetKeyRef.current !== undefined;
-  const authoredViewportChanged = hasViewportResetKey
-    ? previousViewportResetKeyRef.current !== viewportResetKey
-    : shouldResetCompositeViewport(
-        previousAuthoredViewportRef.current,
-        viewport ?? null,
-      );
-  const navigationAnchorViewport = authoredViewportChanged
-    ? viewport
-    : interactionViewport ?? viewport;
+  const viewportResetSequenceRef = useRef(0);
+  if (viewportResetKey === undefined && shouldResetCompositeViewport(
+    previousAuthoredViewportRef.current,
+    viewport ?? null,
+  )) {
+    viewportResetSequenceRef.current += 1;
+  }
+  previousAuthoredViewportRef.current = viewport ?? null;
+  const engineResetKey = viewportResetKey === undefined
+    ? `viewport:${viewportResetSequenceRef.current}`
+    : `authored:${viewportResetKey}`;
+  const engineRef = useRef<CompositeChartEngine | null>(null);
+  if (!engineRef.current) engineRef.current = new CompositeChartEngine();
+  const engine = engineRef.current;
+  const engineSnapshot = useSyncExternalStore(
+    engine.subscribeState,
+    engine.getSnapshot,
+    engine.getSnapshot,
+  );
+  const navigationAnchorViewport = engine.hasResetKey(engineResetKey) && !engine.isDragging()
+    ? engineSnapshot.interactionViewport ?? viewport
+    : viewport;
   const navigationBounds = useMemo(
     () => resolveCompositeNavigationBounds(
       visibleSeries,
@@ -1546,137 +1499,13 @@ export function CompositeChart({
         : navigationBounds
       : null
   ), [navigationBounds, viewport]);
-  const viewportSeriesKey = visibleLegendSeries
-    .map((entry) => `${entry.id}:${entry.label}`)
-    .join("|");
-  const clampedInteractionViewport = interactionViewport && navigationBounds
-    ? clampCompositeViewport(interactionViewport, navigationBounds)
-    : interactionViewport;
-  const interactionViewportNeedsSync = !!interactionViewport
-    && !!clampedInteractionViewport
-    && !sameCompositeViewport(interactionViewport, clampedInteractionViewport);
-  const currentInteractionViewport = authoredViewportChanged
-    ? null
-    : clampedInteractionViewport;
-  const effectiveViewport = navigationBounds
-    ? currentInteractionViewport
-      ? clampCompositeViewport(currentInteractionViewport, navigationBounds)
-      : initialViewport
-    : null;
-  const interactionViewportStart = currentInteractionViewport?.start.getTime() ?? null;
-  const interactionViewportEnd = currentInteractionViewport?.end.getTime() ?? null;
-  const lastReportedViewportRef = useRef<string | null>(null);
-  const viewportInteractionRef = useRef<"pan" | "reset" | "sync" | "zoom">("reset");
-  useEffect(() => {
-    if (!onViewportChange) return;
-    if (interactionViewportNeedsSync) return;
-    const interactionKey = interactionViewportStart === null || interactionViewportEnd === null
-      ? "none"
-      : `${interactionViewportStart}:${interactionViewportEnd}`;
-    const key = `${viewportSeriesKey}|${interactionKey}`;
-    // The callback drives adaptive data loading. Seed it from the authored
-    // viewport without echoing that controlled value back into the loader.
-    if (lastReportedViewportRef.current === null) {
-      lastReportedViewportRef.current = key;
-      return;
-    }
-    if (lastReportedViewportRef.current === key) return;
-    lastReportedViewportRef.current = key;
-    onViewportChange(
-      interactionViewportStart === null || interactionViewportEnd === null
-        ? null
-        : {
-            start: new Date(interactionViewportStart),
-            end: new Date(interactionViewportEnd),
-          },
-      viewportInteractionRef.current,
-    );
-  }, [
-    interactionViewportEnd,
-    interactionViewportNeedsSync,
-    interactionViewportStart,
-    onViewportChange,
-    viewportSeriesKey,
-  ]);
+  const effectiveViewport = engine.hasResetKey(engineResetKey)
+    ? engineSnapshot.viewport ?? initialViewport
+    : initialViewport;
   const minimumViewportSpanMs = useMemo(
     () => navigationBounds ? resolveCompositeMinimumSpanMs(visibleSeries, navigationBounds) : 1,
     [navigationBounds, visibleSeries],
   );
-
-  useEffect(() => {
-    previousAuthoredViewportRef.current = viewport ?? null;
-    previousViewportResetKeyRef.current = viewportResetKey;
-    if (
-      authoredViewportChanged
-      || (interactionViewport && !navigationBounds)
-    ) {
-      viewportInteractionRef.current = "reset";
-      setInteractionViewport(null);
-      return;
-    }
-    if (interactionViewportNeedsSync && clampedInteractionViewport) {
-      viewportInteractionRef.current = "sync";
-      setInteractionViewport(clampedInteractionViewport);
-    }
-  }, [
-    authoredViewportChanged,
-    clampedInteractionViewport,
-    interactionViewport,
-    interactionViewportNeedsSync,
-    navigationBounds,
-    viewport,
-    viewportResetKey,
-  ]);
-
-  const zoomViewport = useCallback((zoomFactor: number, anchorRatio = 1) => {
-    if (!navigationBounds || !initialViewport) return;
-    viewportInteractionRef.current = "zoom";
-    setInteractionViewport((current) => {
-      const base = current ?? initialViewport;
-      const next = zoomCompositeViewport(
-        base,
-        navigationBounds,
-        zoomFactor,
-        anchorRatio,
-        minimumViewportSpanMs,
-        marketTimelineSeries,
-      );
-      if (sameCompositeViewport(next, base)) return current;
-      return sameCompositeViewport(next, initialViewport) ? null : next;
-    });
-  }, [initialViewport, marketTimelineSeries, minimumViewportSpanMs, navigationBounds]);
-  const panViewport = useCallback((
-    shiftRatio: number,
-    fromViewport?: CompositeViewportRange,
-  ) => {
-    if (!navigationBounds || !initialViewport) return;
-    viewportInteractionRef.current = "pan";
-    setInteractionViewport((current) => {
-      const base = fromViewport ?? current ?? initialViewport;
-      const next = panCompositeViewport(
-        base,
-        navigationBounds,
-        shiftRatio,
-        marketTimelineSeries,
-        allowHistoricalBackfill,
-      );
-      if (sameCompositeViewport(next, base)) {
-        if (!fromViewport) return current;
-        return sameCompositeViewport(base, initialViewport) ? null : base;
-      }
-      return sameCompositeViewport(next, initialViewport) ? null : next;
-    });
-  }, [allowHistoricalBackfill, initialViewport, marketTimelineSeries, navigationBounds]);
-  const setViewportRange = useCallback((range: CompositeViewportRange) => {
-    if (!navigationBounds || !initialViewport) return;
-    viewportInteractionRef.current = "zoom";
-    const next = clampCompositeViewport(range, navigationBounds);
-    setInteractionViewport(sameCompositeViewport(next, initialViewport) ? null : next);
-  }, [initialViewport, navigationBounds]);
-  const resetViewport = useCallback(() => {
-    viewportInteractionRef.current = "reset";
-    setInteractionViewport(null);
-  }, []);
   // Sticky while armed: the toolbar chip shows which tool owns the drag, and a
   // one-shot tool would blink off before the user could see it.
   const armTool = useCallback((tool: ChartToolKind | null) => {
@@ -1745,43 +1574,86 @@ export function CompositeChart({
     1,
     Math.round(plotWidth * cellWidthPx * Math.max(1, pixelRatio)),
   );
-  const layoutPanels = useMemo<CompositePanelScene[] | null>(() => {
-    if (!projectedScene) return null;
-    const panelSpecById = new Map(panels.map((panel) => [panel.id, panel] as const));
-    const panelHeights = allocateCompositePanelHeights(
-      projectedScene.panels.map((panel) => ({
-        id: panel.id,
-        height: panelSpecById.get(panel.id)?.height,
-      })),
-      plotHeight,
-    );
-    return projectedScene.panels.map((panel) => {
-      const height = panelHeights.get(panel.id) ?? 1;
-      return panel.height === height ? panel : { ...panel, height };
-    });
-  }, [panels, plotHeight, projectedScene]);
-  const baseScene = useMemo<CompositeChartScene | null>(() => {
-    if (!projectedScene || !layoutPanels) return null;
-    const laidOut: CompositeChartScene = {
-      ...projectedScene,
-      width: plotWidth,
-      height: layoutPanels.reduce((sum, panel) => sum + panel.height, 0),
-      panels: layoutPanels,
-    };
-    return downsampleCompositeChartScene(laidOut, downsampleWidth);
-  }, [downsampleWidth, layoutPanels, plotWidth, projectedScene]);
   const resolvedCursorTimestamp = resolvedCursorDate?.getTime() ?? null;
   const normalizedCursorTimestamp = resolvedCursorTimestamp !== null && Number.isFinite(resolvedCursorTimestamp)
     ? resolvedCursorTimestamp
     : null;
-  const scene = useMemo(() => (
-    baseScene
-      ? applyCompositeChartCursor(
-        baseScene,
-        normalizedCursorTimestamp === null ? null : new Date(normalizedCursorTimestamp),
-      )
+  const buildEngineScene = useCallback((
+    nextViewport: CompositeViewportRange,
+    axisDomains?: CompositeAxisDomains,
+  ) => {
+    // lastTickKey busts the builder when a live source mutates in place.
+    void lastTickKey;
+    const next = buildCompositeChartScene(visibleSeries, panels, {
+      width: plotWidth,
+      height: plotHeight,
+      cursorDate: normalizedCursorTimestamp === null
+        ? null
+        : new Date(normalizedCursorTimestamp),
+      viewport: nextViewport,
+      timelineSeries: marketTimelineSeries,
+      axisDomains,
+    });
+    return next ? downsampleCompositeChartScene(next, downsampleWidth) : null;
+  }, [
+    downsampleWidth,
+    lastTickKey,
+    marketTimelineSeries,
+    normalizedCursorTimestamp,
+    panels,
+    plotHeight,
+    plotWidth,
+    visibleSeries,
+  ]);
+  const fallbackScene = useMemo(() => (
+    effectiveViewport ? buildEngineScene(effectiveViewport) : null
+  ), [buildEngineScene, effectiveViewport]);
+  const engineConfig = useMemo(() => (
+    initialViewport && navigationBounds
+      ? {
+          resetKey: engineResetKey,
+          initialViewport,
+          navigationBounds,
+          series: marketTimelineSeries,
+          allowHistoricalBackfill,
+          buildScene: buildEngineScene,
+          onCommit: (
+            next: CompositeViewportRange | null,
+            interaction: "pan" | "reset" | "sync" | "zoom",
+          ) => onViewportChange?.(next, interaction),
+        }
       : null
-  ), [baseScene, normalizedCursorTimestamp]);
+  ), [
+    allowHistoricalBackfill,
+    buildEngineScene,
+    engineResetKey,
+    initialViewport,
+    marketTimelineSeries,
+    navigationBounds,
+    onViewportChange,
+  ]);
+  useLayoutEffect(() => {
+    if (engineConfig) engine.configure(engineConfig);
+  }, [engine, engineConfig]);
+  const scene = engineConfig && engine.isConfigured(engineConfig)
+    ? engineSnapshot.scene
+    : fallbackScene;
+  const liveViewport = engineConfig && engine.isConfigured(engineConfig)
+    ? engineSnapshot.viewport ?? effectiveViewport
+    : effectiveViewport;
+  const zoomViewport = useCallback((zoomFactor: number, anchorRatio = 1) => {
+    engine.zoom(zoomFactor, anchorRatio, minimumViewportSpanMs);
+  }, [engine, minimumViewportSpanMs]);
+  const panViewport = useCallback((
+    shiftRatio: number,
+    fromViewport?: CompositeViewportRange,
+  ) => {
+    engine.pan(shiftRatio, fromViewport);
+  }, [engine]);
+  const setViewportRange = useCallback((range: CompositeViewportRange) => {
+    engine.setViewport(range);
+  }, [engine]);
+  const resetViewport = useCallback(() => engine.reset(), [engine]);
   const handleEmptyMouseScroll = useCallback((event: ChartMouseEvent) => {
     const direction = event.scroll?.direction;
     if (!interactive || !navigationBounds || !direction) return;
@@ -1931,8 +1803,8 @@ export function CompositeChart({
   const timeAxisLayout = scene && showTimeAxis
     ? buildCompositeTimeAxisLayout(scene, plotWidth)
     : null;
-  const emptyTimeAxisLayout = !scene && showTimeAxis && effectiveViewport
-    ? buildCompositeViewportTimeAxisLayout(effectiveViewport, plotWidth)
+  const emptyTimeAxisLayout = !scene && showTimeAxis && liveViewport
+    ? buildCompositeViewportTimeAxisLayout(liveViewport, plotWidth)
     : null;
 
   if (!scene) {
@@ -2071,6 +1943,7 @@ export function CompositeChart({
       {scene.panels.map((panel) => (
         <CompositePanelSurface
           key={panel.id}
+          engine={engine}
           panel={panel}
           scene={scene}
           plotWidth={plotWidth}
@@ -2079,7 +1952,7 @@ export function CompositeChart({
           axisGap={axisGap}
           colors={resolvedColors}
           interactive={interactive}
-          viewport={effectiveViewport!}
+          viewport={liveViewport!}
           minimumViewportSpanMs={minimumViewportSpanMs}
           armedTool={armedTool}
           drawings={drawings}

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -583,6 +583,10 @@ function CompositePanelSurface({
   const plotAspect = (plotWidth * cellWidthPx) / Math.max(panel.height * cellHeightPx, 1);
   const bitmapSize = useStaticChartBitmapSize(plotWidth, panel.height);
   const bitmap = useCompositePanelBitmap({ panel, bitmapSize, colors, isDesktopWeb });
+  const handlePanFrame = useCallback((date: Date | null, yRatio: number) => {
+    setCursorYRatio((current) => current === yRatio ? current : yRatio);
+    onCursorDateChange(date);
+  }, [onCursorDateChange]);
   const paintSource = useMemo(() => (
     isDesktopWeb
       ? createCompositePanelPaintSource({
@@ -593,6 +597,7 @@ function CompositePanelSurface({
           height: panel.height * cellHeightPx,
           interactive: interactive && armedTool === null,
           onActivate,
+          onPanFrame: handlePanFrame,
         })
       : null
   ), [
@@ -601,6 +606,7 @@ function CompositePanelSurface({
     cellWidthPx,
     colors,
     engine,
+    handlePanFrame,
     interactive,
     isDesktopWeb,
     onActivate,
@@ -1584,15 +1590,17 @@ export function CompositeChart({
     nextViewport: CompositeViewportRange,
     axisDomains?: CompositeAxisDomains,
     widthScale = 1,
+    cursorDate?: Date | null,
   ) => {
     // lastTickKey busts the builder when a live source mutates in place.
     void lastTickKey;
+    const cursorTimestamp = cursorDate === undefined
+      ? normalizedCursorTimestamp
+      : cursorDate?.getTime() ?? null;
     const next = buildCompositeChartScene(visibleSeries, panels, {
       width: Math.max(1, Math.round(plotWidth * widthScale)),
       height: plotHeight,
-      cursorDate: normalizedCursorTimestamp === null
-        ? null
-        : new Date(normalizedCursorTimestamp),
+      cursorDate: cursorTimestamp === null ? null : new Date(cursorTimestamp),
       viewport: nextViewport,
       timelineSeries: marketTimelineSeries,
       axisDomains,

--- a/src/components/chart/composite/engine.test.ts
+++ b/src/components/chart/composite/engine.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
-import { CompositeChartEngine } from "./engine";
+import { CompositeChartEngine, createCompositePanelPaintSource } from "./engine";
 import { buildCompositeChartScene } from "./scene";
 import type { CompositeViewportRange } from "./interactions";
 
@@ -125,6 +125,51 @@ test("reverses immediately after overscrolling the newest boundary", () => {
   expect(engine.getPaintState(101).offsetX - boundaryOffset).toBeCloseTo(1, 6);
 
   engine.endPixelPan();
+  expect(commits).toHaveLength(1);
+});
+
+test("scroll panning uses the pixel hot path and commits once", () => {
+  const data = priceSeries();
+  const commits: Array<CompositeViewportRange | null> = [];
+  const engine = new CompositeChartEngine();
+  engine.configure({
+    resetKey: "price:1D",
+    initialViewport: viewport(3, 9),
+    navigationBounds: viewport(1, 11),
+    series: [data],
+    allowHistoricalBackfill: false,
+    buildScene: (next, axisDomains) => buildCompositeChartScene(
+      [data],
+      [{ id: "main" }],
+      { width: 101, height: 20, viewport: next, axisDomains },
+    ),
+    onCommit: (next) => commits.push(next),
+  });
+  const source = createCompositePanelPaintSource({
+    engine,
+    panelId: "main",
+    colors: {
+      background: "#000",
+      grid: "#111",
+      crosshair: "#fff",
+      text: "#fff",
+      textDim: "#888",
+      negative: "#f00",
+    },
+    width: 101,
+    height: 20,
+    interactive: true,
+  });
+
+  expect(source.scrollPan?.(100)).toBe(true);
+  const boundaryOffset = engine.getPaintState(101).offsetX;
+  expect(source.scrollPan?.(10)).toBe(true);
+  expect(engine.getPaintState(101).offsetX).toBe(boundaryOffset);
+  expect(commits).toHaveLength(0);
+
+  expect(source.scrollPan?.(-1)).toBe(true);
+  expect(engine.getPaintState(101).offsetX - boundaryOffset).toBeCloseTo(1, 6);
+  source.scrollPanEnd?.();
   expect(commits).toHaveLength(1);
 });
 

--- a/src/components/chart/composite/engine.test.ts
+++ b/src/components/chart/composite/engine.test.ts
@@ -128,10 +128,9 @@ test("reverses immediately after overscrolling the newest boundary", () => {
   expect(commits).toHaveLength(1);
 });
 
-test("scroll panning adapts axes and crosshair without losing the pixel hot path", () => {
+test("scroll panning uses the pixel hot path and commits once", () => {
   const data = priceSeries();
   const commits: Array<CompositeViewportRange | null> = [];
-  const panFrames: Array<{ date: Date | null; yRatio: number }> = [];
   const engine = new CompositeChartEngine();
   engine.configure({
     resetKey: "price:1D",
@@ -139,16 +138,13 @@ test("scroll panning adapts axes and crosshair without losing the pixel hot path
     navigationBounds: viewport(1, 11),
     series: [data],
     allowHistoricalBackfill: false,
-    buildScene: (next, axisDomains, _widthScale, cursorDate) => buildCompositeChartScene(
+    buildScene: (next, axisDomains) => buildCompositeChartScene(
       [data],
       [{ id: "main" }],
-      { width: 101, height: 20, viewport: next, axisDomains, cursorDate },
+      { width: 101, height: 20, viewport: next, axisDomains },
     ),
     onCommit: (next) => commits.push(next),
   });
-  const initialAxisMin = engine.getSnapshot().scene!.panels[0]!.axes.left!.min;
-  let semanticUpdates = 0;
-  engine.subscribeState(() => semanticUpdates += 1);
   const source = createCompositePanelPaintSource({
     engine,
     panelId: "main",
@@ -163,20 +159,14 @@ test("scroll panning adapts axes and crosshair without losing the pixel hot path
     width: 101,
     height: 20,
     interactive: true,
-    onPanFrame: (date, yRatio) => panFrames.push({ date, yRatio }),
   });
 
   expect(source.scrollPan?.(100)).toBe(true);
-  source.panFrame?.({ x: 50, y: 10, shift: false, alt: false, ctrl: false });
-  expect(engine.getSnapshot().scene!.panels[0]!.axes.left!.min).toBeGreaterThan(initialAxisMin);
-  expect(panFrames[0]?.date).not.toBeNull();
-  expect(panFrames[0]?.yRatio).toBeCloseTo(10 / 19, 6);
-  expect(semanticUpdates).toBe(1);
-  expect(commits).toHaveLength(0);
-
   const boundaryOffset = engine.getPaintState(101).offsetX;
   expect(source.scrollPan?.(10)).toBe(true);
   expect(engine.getPaintState(101).offsetX).toBe(boundaryOffset);
+  expect(commits).toHaveLength(0);
+
   expect(source.scrollPan?.(-1)).toBe(true);
   expect(engine.getPaintState(101).offsetX - boundaryOffset).toBeCloseTo(1, 6);
   source.scrollPanEnd?.();

--- a/src/components/chart/composite/engine.test.ts
+++ b/src/components/chart/composite/engine.test.ts
@@ -99,6 +99,37 @@ test("drag frames always derive from the pointer-down viewport", () => {
   expect(offsets[1]!).toBeLessThan(offsets[2]!);
 });
 
+test("reverses immediately after overscrolling the newest boundary", () => {
+  const data = priceSeries();
+  const commits: Array<CompositeViewportRange | null> = [];
+  const engine = new CompositeChartEngine();
+  engine.configure({
+    resetKey: "price:1D",
+    initialViewport: viewport(3, 9),
+    navigationBounds: viewport(1, 11),
+    series: [data],
+    allowHistoricalBackfill: false,
+    buildScene: (next, axisDomains) => buildCompositeChartScene(
+      [data],
+      [{ id: "main" }],
+      { width: 101, height: 20, viewport: next, axisDomains },
+    ),
+    onCommit: (next) => commits.push(next),
+  });
+
+  engine.beginPixelPan(100, 101);
+  engine.movePixelPan(0);
+  const boundaryOffset = engine.getPaintState(101).offsetX;
+  engine.movePixelPan(-100);
+  expect(engine.getPaintState(101).offsetX).toBe(boundaryOffset);
+
+  engine.movePixelPan(-99);
+  expect(engine.getPaintState(101).offsetX - boundaryOffset).toBeCloseTo(1, 6);
+
+  engine.endPixelPan();
+  expect(commits).toHaveLength(1);
+});
+
 test("data refreshes stay outside an active pixel drag", () => {
   const data = priceSeries();
   const engine = new CompositeChartEngine();

--- a/src/components/chart/composite/engine.test.ts
+++ b/src/components/chart/composite/engine.test.ts
@@ -54,16 +54,14 @@ test("one CSS pixel of dragging moves chart geometry by one CSS pixel", () => {
     onCommit: (next) => commits.push(next),
   });
 
-  const pointX = () => engine.getSnapshot().scene!.panels[0]!.series[0]!.points
-    .find((point) => point.timestamp === Date.UTC(2025, 0, 6))!.xRatio * 400;
-  const startX = pointX();
   let semanticUpdates = 0;
   engine.subscribeState(() => semanticUpdates += 1);
 
   expect(engine.beginPixelPan(200, 401)).toBe(true);
+  const startOffset = engine.getPaintState(401).offsetX;
   engine.movePixelPan(201);
 
-  expect(pointX() - startX).toBeCloseTo(1, 6);
+  expect(engine.getPaintState(401).offsetX - startOffset).toBeCloseTo(1, 6);
   expect(commits).toHaveLength(0);
   expect(semanticUpdates).toBe(0);
 
@@ -89,17 +87,16 @@ test("drag frames always derive from the pointer-down viewport", () => {
     ),
     onCommit: () => {},
   });
-  const starts: number[] = [];
-  engine.subscribeFrame(() => starts.push(engine.getSnapshot().viewport!.start.getTime()));
-
+  const offsets: number[] = [];
   engine.beginPixelPan(200, 401);
+  engine.subscribeFrame(() => offsets.push(engine.getPaintState(401).offsetX));
   engine.movePixelPan(201);
   engine.movePixelPan(202);
   engine.movePixelPan(203);
 
-  expect(starts).toHaveLength(3);
-  expect(starts[0]!).toBeGreaterThan(starts[1]!);
-  expect(starts[1]!).toBeGreaterThan(starts[2]!);
+  expect(offsets).toHaveLength(3);
+  expect(offsets[0]!).toBeLessThan(offsets[1]!);
+  expect(offsets[1]!).toBeLessThan(offsets[2]!);
 });
 
 test("data refreshes stay outside an active pixel drag", () => {
@@ -127,18 +124,17 @@ test("data refreshes stay outside an active pixel drag", () => {
     onCommit: () => commits.push(label),
   });
   engine.configure(config("initial"));
-  const pointX = () => engine.getSnapshot().scene!.panels[0]!.series[0]!.points
-    .find((point) => point.timestamp === Date.UTC(2025, 0, 6))!.xRatio * 400;
-  const startX = pointX();
-
   engine.beginPixelPan(200, 401);
+  const startOffset = engine.getPaintState(401).offsetX;
   engine.movePixelPan(201);
   engine.configure(config("refresh"));
 
   expect(engine.isDragging()).toBe(true);
   expect(builds.at(-1)).toBe("initial");
+  const buildCount = builds.length;
   engine.movePixelPan(202);
-  expect(pointX() - startX).toBeCloseTo(2, 6);
+  expect(builds).toHaveLength(buildCount);
+  expect(engine.getPaintState(401).offsetX - startOffset).toBeCloseTo(2, 6);
 
   engine.endPixelPan();
   expect(builds.at(-1)).toBe("refresh");

--- a/src/components/chart/composite/engine.test.ts
+++ b/src/components/chart/composite/engine.test.ts
@@ -133,6 +133,7 @@ test("scroll panning adapts axes and crosshair without losing the pixel hot path
   const commits: Array<CompositeViewportRange | null> = [];
   const panFrames: Array<{ date: Date | null; yRatio: number }> = [];
   const panEnds: Array<Date | null> = [];
+  let sceneBuilds = 0;
   const engine = new CompositeChartEngine();
   engine.configure({
     resetKey: "price:1D",
@@ -140,11 +141,14 @@ test("scroll panning adapts axes and crosshair without losing the pixel hot path
     navigationBounds: viewport(1, 11),
     series: [data],
     allowHistoricalBackfill: false,
-    buildScene: (next, axisDomains, _widthScale, cursorDate) => buildCompositeChartScene(
-      [data],
-      [{ id: "main" }],
-      { width: 101, height: 20, viewport: next, axisDomains, cursorDate },
-    ),
+    buildScene: (next, axisDomains, _widthScale, cursorDate) => {
+      sceneBuilds += 1;
+      return buildCompositeChartScene(
+        [data],
+        [{ id: "main" }],
+        { width: 101, height: 20, viewport: next, axisDomains, cursorDate },
+      );
+    },
     onCommit: (next) => commits.push(next),
   });
   const initialAxisMin = engine.getSnapshot().scene!.panels[0]!.axes.left!.min;
@@ -166,8 +170,10 @@ test("scroll panning adapts axes and crosshair without losing the pixel hot path
     onPanEnd: (date) => panEnds.push(date),
   });
 
-  expect(source.scrollPan?.(10)).toBe(true);
+  expect(source.scrollPan?.(1)).toBe(true);
+  const buildsBeforeFrame = sceneBuilds;
   source.panFrame?.({ x: 50, y: 10, shift: false, alt: false, ctrl: false });
+  expect(sceneBuilds).toBe(buildsBeforeFrame + 1);
   expect(engine.getSnapshot().scene!.panels[0]!.axes.left!.min).toBeGreaterThan(initialAxisMin);
   expect(panFrames[0]?.date).not.toBeNull();
   expect(panFrames[0]?.yRatio).toBeCloseTo(10 / 19, 6);

--- a/src/components/chart/composite/engine.test.ts
+++ b/src/components/chart/composite/engine.test.ts
@@ -128,9 +128,11 @@ test("reverses immediately after overscrolling the newest boundary", () => {
   expect(commits).toHaveLength(1);
 });
 
-test("scroll panning uses the pixel hot path and commits once", () => {
+test("scroll panning adapts axes and crosshair without losing the pixel hot path", () => {
   const data = priceSeries();
   const commits: Array<CompositeViewportRange | null> = [];
+  const panFrames: Array<{ date: Date | null; yRatio: number }> = [];
+  const panEnds: Array<Date | null> = [];
   const engine = new CompositeChartEngine();
   engine.configure({
     resetKey: "price:1D",
@@ -138,13 +140,14 @@ test("scroll panning uses the pixel hot path and commits once", () => {
     navigationBounds: viewport(1, 11),
     series: [data],
     allowHistoricalBackfill: false,
-    buildScene: (next, axisDomains) => buildCompositeChartScene(
+    buildScene: (next, axisDomains, _widthScale, cursorDate) => buildCompositeChartScene(
       [data],
       [{ id: "main" }],
-      { width: 101, height: 20, viewport: next, axisDomains },
+      { width: 101, height: 20, viewport: next, axisDomains, cursorDate },
     ),
     onCommit: (next) => commits.push(next),
   });
+  const initialAxisMin = engine.getSnapshot().scene!.panels[0]!.axes.left!.min;
   const source = createCompositePanelPaintSource({
     engine,
     panelId: "main",
@@ -159,18 +162,36 @@ test("scroll panning uses the pixel hot path and commits once", () => {
     width: 101,
     height: 20,
     interactive: true,
+    onScrollPanFrame: (date, yRatio) => panFrames.push({ date, yRatio }),
+    onScrollPanEnd: (date) => panEnds.push(date),
   });
 
-  expect(source.scrollPan?.(100)).toBe(true);
+  expect(source.scrollPan?.(10)).toBe(true);
+  source.scrollPanFrame?.({ x: 50, y: 10, shift: false, alt: false, ctrl: false });
+  expect(engine.getSnapshot().scene!.panels[0]!.axes.left!.min).toBeGreaterThan(initialAxisMin);
+  expect(panFrames[0]?.date).not.toBeNull();
+  expect(panFrames[0]?.yRatio).toBeCloseTo(10 / 19, 6);
+  expect(commits).toHaveLength(0);
+
+  const firstViewport = engine.getSnapshot().viewport!;
+  expect(source.scrollPan?.(1)).toBe(true);
+  source.scrollPanFrame?.({ x: 50, y: 10, shift: false, alt: false, ctrl: false });
+  const secondViewport = engine.getSnapshot().viewport!;
+  expect(secondViewport.start.getTime() - firstViewport.start.getTime()).toBeCloseTo(
+    6 * DAY_MS / 100,
+    6,
+  );
+
+  expect(source.scrollPan?.(200)).toBe(true);
+  source.scrollPanFrame?.({ x: 50, y: 10, shift: false, alt: false, ctrl: false });
   const boundaryOffset = engine.getPaintState(101).offsetX;
   expect(source.scrollPan?.(10)).toBe(true);
   expect(engine.getPaintState(101).offsetX).toBe(boundaryOffset);
-  expect(commits).toHaveLength(0);
-
   expect(source.scrollPan?.(-1)).toBe(true);
   expect(engine.getPaintState(101).offsetX - boundaryOffset).toBeCloseTo(1, 6);
   source.scrollPanEnd?.();
   expect(commits).toHaveLength(1);
+  expect(panEnds).toEqual([panFrames.at(-1)!.date]);
 });
 
 test("reverses immediately after overscrolling the oldest boundary", () => {

--- a/src/components/chart/composite/engine.test.ts
+++ b/src/components/chart/composite/engine.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
 import { CompositeChartEngine, createCompositePanelPaintSource } from "./engine";
-import { buildCompositeChartScene } from "./scene";
+import { buildCompositeChartScene, resolveCompositeCursorDate } from "./scene";
 import type { CompositeViewportRange } from "./interactions";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -162,12 +162,12 @@ test("scroll panning adapts axes and crosshair without losing the pixel hot path
     width: 101,
     height: 20,
     interactive: true,
-    onScrollPanFrame: (date, yRatio) => panFrames.push({ date, yRatio }),
-    onScrollPanEnd: (date) => panEnds.push(date),
+    onPanFrame: (scene, yRatio) => panFrames.push({ date: scene?.cursorDate ?? null, yRatio }),
+    onPanEnd: (date) => panEnds.push(date),
   });
 
   expect(source.scrollPan?.(10)).toBe(true);
-  source.scrollPanFrame?.({ x: 50, y: 10, shift: false, alt: false, ctrl: false });
+  source.panFrame?.({ x: 50, y: 10, shift: false, alt: false, ctrl: false });
   expect(engine.getSnapshot().scene!.panels[0]!.axes.left!.min).toBeGreaterThan(initialAxisMin);
   expect(panFrames[0]?.date).not.toBeNull();
   expect(panFrames[0]?.yRatio).toBeCloseTo(10 / 19, 6);
@@ -175,7 +175,7 @@ test("scroll panning adapts axes and crosshair without losing the pixel hot path
 
   const firstViewport = engine.getSnapshot().viewport!;
   expect(source.scrollPan?.(1)).toBe(true);
-  source.scrollPanFrame?.({ x: 50, y: 10, shift: false, alt: false, ctrl: false });
+  source.panFrame?.({ x: 50, y: 10, shift: false, alt: false, ctrl: false });
   const secondViewport = engine.getSnapshot().viewport!;
   expect(secondViewport.start.getTime() - firstViewport.start.getTime()).toBeCloseTo(
     6 * DAY_MS / 100,
@@ -183,7 +183,7 @@ test("scroll panning adapts axes and crosshair without losing the pixel hot path
   );
 
   expect(source.scrollPan?.(200)).toBe(true);
-  source.scrollPanFrame?.({ x: 50, y: 10, shift: false, alt: false, ctrl: false });
+  source.panFrame?.({ x: 50, y: 10, shift: false, alt: false, ctrl: false });
   const boundaryOffset = engine.getPaintState(101).offsetX;
   expect(source.scrollPan?.(10)).toBe(true);
   expect(engine.getPaintState(101).offsetX).toBe(boundaryOffset);
@@ -192,6 +192,17 @@ test("scroll panning adapts axes and crosshair without losing the pixel hot path
   source.scrollPanEnd?.();
   expect(commits).toHaveLength(1);
   expect(panEnds).toEqual([panFrames.at(-1)!.date]);
+
+  expect(source.pointerDown?.({ x: 20, y: 5, shift: false, alt: false, ctrl: false })).toBe(true);
+  source.pointerMove?.({ x: 60, y: 5, shift: false, alt: false, ctrl: false });
+  source.panFrame?.({ x: 60, y: 5, shift: false, alt: false, ctrl: false });
+  const mouseScene = engine.getSnapshot().scene!;
+  expect(mouseScene.cursorDate).toEqual(resolveCompositeCursorDate(mouseScene, 60));
+  expect(mouseScene.cursorXRatio).toBeCloseTo(0.6, 6);
+  expect(panFrames.at(-1)?.yRatio).toBeCloseTo(5 / 19, 6);
+  source.pointerUp?.({ x: 60, y: 5, shift: false, alt: false, ctrl: false });
+  expect(commits).toHaveLength(2);
+  expect(panEnds.at(-1)).toEqual(mouseScene.cursorDate);
 });
 
 test("reverses immediately after overscrolling the oldest boundary", () => {

--- a/src/components/chart/composite/engine.test.ts
+++ b/src/components/chart/composite/engine.test.ts
@@ -1,0 +1,146 @@
+import { expect, test } from "bun:test";
+import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
+import { CompositeChartEngine } from "./engine";
+import { buildCompositeChartScene } from "./scene";
+import type { CompositeViewportRange } from "./interactions";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function viewport(startDay: number, endDay: number): CompositeViewportRange {
+  return {
+    start: new Date(Date.UTC(2025, 0, startDay)),
+    end: new Date(Date.UTC(2025, 0, endDay)),
+  };
+}
+
+function priceSeries(): ResolvedSeries {
+  const points: TimeSeriesPoint[] = Array.from({ length: 11 }, (_, index) => {
+    const date = new Date(Date.UTC(2025, 0, index + 1));
+    return { date, observedAt: date, value: 100 + index };
+  });
+  return {
+    id: "price",
+    label: "Price",
+    color: "#00ff66",
+    unit: "USD",
+    unitGroup: "currency",
+    nativeFrequency: "daily",
+    dataShape: "scalar",
+    style: "line",
+    transform: "raw",
+    axis: "left",
+    panelId: "main",
+    interpolation: "none",
+    points,
+  };
+}
+
+test("one CSS pixel of dragging moves chart geometry by one CSS pixel", () => {
+  const data = priceSeries();
+  const initialViewport = viewport(3, 9);
+  const commits: Array<CompositeViewportRange | null> = [];
+  const engine = new CompositeChartEngine();
+  engine.configure({
+    resetKey: "price:1D",
+    initialViewport,
+    navigationBounds: viewport(1, 11),
+    series: [data],
+    allowHistoricalBackfill: false,
+    buildScene: (next, axisDomains) => buildCompositeChartScene(
+      [data],
+      [{ id: "main" }],
+      { width: 401, height: 20, viewport: next, axisDomains },
+    ),
+    onCommit: (next) => commits.push(next),
+  });
+
+  const pointX = () => engine.getSnapshot().scene!.panels[0]!.series[0]!.points
+    .find((point) => point.timestamp === Date.UTC(2025, 0, 6))!.xRatio * 400;
+  const startX = pointX();
+  let semanticUpdates = 0;
+  engine.subscribeState(() => semanticUpdates += 1);
+
+  expect(engine.beginPixelPan(200, 401)).toBe(true);
+  engine.movePixelPan(201);
+
+  expect(pointX() - startX).toBeCloseTo(1, 6);
+  expect(commits).toHaveLength(0);
+  expect(semanticUpdates).toBe(0);
+
+  engine.endPixelPan();
+  expect(commits).toHaveLength(1);
+  expect(semanticUpdates).toBe(1);
+  expect(commits[0]!.end.getTime() - commits[0]!.start.getTime()).toBe(6 * DAY_MS);
+});
+
+test("drag frames always derive from the pointer-down viewport", () => {
+  const data = priceSeries();
+  const engine = new CompositeChartEngine();
+  engine.configure({
+    resetKey: "price:1D",
+    initialViewport: viewport(3, 9),
+    navigationBounds: viewport(1, 11),
+    series: [data],
+    allowHistoricalBackfill: false,
+    buildScene: (next, axisDomains) => buildCompositeChartScene(
+      [data],
+      [{ id: "main" }],
+      { width: 401, height: 20, viewport: next, axisDomains },
+    ),
+    onCommit: () => {},
+  });
+  const starts: number[] = [];
+  engine.subscribeFrame(() => starts.push(engine.getSnapshot().viewport!.start.getTime()));
+
+  engine.beginPixelPan(200, 401);
+  engine.movePixelPan(201);
+  engine.movePixelPan(202);
+  engine.movePixelPan(203);
+
+  expect(starts).toHaveLength(3);
+  expect(starts[0]!).toBeGreaterThan(starts[1]!);
+  expect(starts[1]!).toBeGreaterThan(starts[2]!);
+});
+
+test("data refreshes stay outside an active pixel drag", () => {
+  const data = priceSeries();
+  const engine = new CompositeChartEngine();
+  const builds: string[] = [];
+  const commits: string[] = [];
+  const config = (label: string) => ({
+    resetKey: "price:1D",
+    initialViewport: viewport(3, 9),
+    navigationBounds: viewport(1, 11),
+    series: [data],
+    allowHistoricalBackfill: false,
+    buildScene: (
+      next: CompositeViewportRange,
+      axisDomains: Parameters<typeof buildCompositeChartScene>[2]["axisDomains"],
+    ) => {
+      builds.push(label);
+      return buildCompositeChartScene(
+        [data],
+        [{ id: "main" }],
+        { width: 401, height: 20, viewport: next, axisDomains },
+      );
+    },
+    onCommit: () => commits.push(label),
+  });
+  engine.configure(config("initial"));
+  const pointX = () => engine.getSnapshot().scene!.panels[0]!.series[0]!.points
+    .find((point) => point.timestamp === Date.UTC(2025, 0, 6))!.xRatio * 400;
+  const startX = pointX();
+
+  engine.beginPixelPan(200, 401);
+  engine.movePixelPan(201);
+  engine.configure(config("refresh"));
+
+  expect(engine.isDragging()).toBe(true);
+  expect(builds.at(-1)).toBe("initial");
+  engine.movePixelPan(202);
+  expect(pointX() - startX).toBeCloseTo(2, 6);
+
+  engine.endPixelPan();
+  expect(builds.at(-1)).toBe("refresh");
+  expect(commits).toEqual(["refresh"]);
+});

--- a/src/components/chart/composite/engine.test.ts
+++ b/src/components/chart/composite/engine.test.ts
@@ -128,9 +128,10 @@ test("reverses immediately after overscrolling the newest boundary", () => {
   expect(commits).toHaveLength(1);
 });
 
-test("scroll panning uses the pixel hot path and commits once", () => {
+test("scroll panning adapts axes and crosshair without losing the pixel hot path", () => {
   const data = priceSeries();
   const commits: Array<CompositeViewportRange | null> = [];
+  const panFrames: Array<{ date: Date | null; yRatio: number }> = [];
   const engine = new CompositeChartEngine();
   engine.configure({
     resetKey: "price:1D",
@@ -138,13 +139,16 @@ test("scroll panning uses the pixel hot path and commits once", () => {
     navigationBounds: viewport(1, 11),
     series: [data],
     allowHistoricalBackfill: false,
-    buildScene: (next, axisDomains) => buildCompositeChartScene(
+    buildScene: (next, axisDomains, _widthScale, cursorDate) => buildCompositeChartScene(
       [data],
       [{ id: "main" }],
-      { width: 101, height: 20, viewport: next, axisDomains },
+      { width: 101, height: 20, viewport: next, axisDomains, cursorDate },
     ),
     onCommit: (next) => commits.push(next),
   });
+  const initialAxisMin = engine.getSnapshot().scene!.panels[0]!.axes.left!.min;
+  let semanticUpdates = 0;
+  engine.subscribeState(() => semanticUpdates += 1);
   const source = createCompositePanelPaintSource({
     engine,
     panelId: "main",
@@ -159,14 +163,20 @@ test("scroll panning uses the pixel hot path and commits once", () => {
     width: 101,
     height: 20,
     interactive: true,
+    onPanFrame: (date, yRatio) => panFrames.push({ date, yRatio }),
   });
 
   expect(source.scrollPan?.(100)).toBe(true);
+  source.panFrame?.({ x: 50, y: 10, shift: false, alt: false, ctrl: false });
+  expect(engine.getSnapshot().scene!.panels[0]!.axes.left!.min).toBeGreaterThan(initialAxisMin);
+  expect(panFrames[0]?.date).not.toBeNull();
+  expect(panFrames[0]?.yRatio).toBeCloseTo(10 / 19, 6);
+  expect(semanticUpdates).toBe(1);
+  expect(commits).toHaveLength(0);
+
   const boundaryOffset = engine.getPaintState(101).offsetX;
   expect(source.scrollPan?.(10)).toBe(true);
   expect(engine.getPaintState(101).offsetX).toBe(boundaryOffset);
-  expect(commits).toHaveLength(0);
-
   expect(source.scrollPan?.(-1)).toBe(true);
   expect(engine.getPaintState(101).offsetX - boundaryOffset).toBeCloseTo(1, 6);
   source.scrollPanEnd?.();

--- a/src/components/chart/composite/engine.test.ts
+++ b/src/components/chart/composite/engine.test.ts
@@ -120,14 +120,37 @@ test("reverses immediately after overscrolling the newest boundary", () => {
   engine.beginPixelPan(100, 101);
   engine.movePixelPan(0);
   const boundaryOffset = engine.getPaintState(101).offsetX;
-  engine.movePixelPan(-100);
-  expect(engine.getPaintState(101).offsetX).toBe(boundaryOffset);
 
-  engine.movePixelPan(-99);
+  engine.movePixelPan(1);
   expect(engine.getPaintState(101).offsetX - boundaryOffset).toBeCloseTo(1, 6);
 
   engine.endPixelPan();
   expect(commits).toHaveLength(1);
+});
+
+test("reverses immediately after overscrolling the oldest boundary", () => {
+  const data = priceSeries();
+  const engine = new CompositeChartEngine();
+  engine.configure({
+    resetKey: "price:1D",
+    initialViewport: viewport(3, 9),
+    navigationBounds: viewport(1, 11),
+    series: [data],
+    allowHistoricalBackfill: false,
+    buildScene: (next, axisDomains) => buildCompositeChartScene(
+      [data],
+      [{ id: "main" }],
+      { width: 101, height: 20, viewport: next, axisDomains },
+    ),
+    onCommit: () => {},
+  });
+
+  engine.beginPixelPan(0, 101);
+  engine.movePixelPan(100);
+  const boundaryOffset = engine.getPaintState(101).offsetX;
+
+  engine.movePixelPan(99);
+  expect(engine.getPaintState(101).offsetX - boundaryOffset).toBeCloseTo(-1, 6);
 });
 
 test("data refreshes stay outside an active pixel drag", () => {

--- a/src/components/chart/composite/engine.ts
+++ b/src/components/chart/composite/engine.ts
@@ -302,10 +302,11 @@ export class CompositeChartEngine {
   movePixelPan(x: number): void {
     const drag = this.drag;
     if (!drag || !this.config) return;
+    const shiftRatio = (x - drag.anchorX) / drag.width;
     const next = panCompositeViewport(
       drag.anchorViewport,
       this.config.navigationBounds,
-      (x - drag.anchorX) / drag.width,
+      shiftRatio,
       this.config.series,
       this.config.allowHistoricalBackfill,
     );
@@ -321,6 +322,14 @@ export class CompositeChartEngine {
     this.interactionViewport = sameCompositeViewport(next, this.config.initialViewport)
       ? null
       : next;
+    const bounds = this.config.navigationBounds;
+    if (
+      (shiftRatio < 0 && next.end.getTime() === bounds.end.getTime())
+      || (shiftRatio > 0 && next.start.getTime() === bounds.start.getTime())
+    ) {
+      drag.anchorX = x;
+      drag.anchorViewport = next;
+    }
     const ratios = drag.previewScene ? viewportRatios(drag.previewScene, next) : null;
     if (ratios) drag.offsetX = -ratios.start * (drag.previewWidth - 1);
     this.emit(false);

--- a/src/components/chart/composite/engine.ts
+++ b/src/components/chart/composite/engine.ts
@@ -12,7 +12,7 @@ import {
   type CompositeViewportRange,
 } from "./interactions";
 import { paintCompositePanel } from "./painter";
-import { projectCompositeTimestamp } from "./time-scale";
+import { projectCompositeTimestamp, unprojectCompositeTimestamp } from "./time-scale";
 import type {
   CompositeAxisDomain,
   CompositeAxisSide,
@@ -35,6 +35,7 @@ export interface CompositeChartEngineConfig {
     viewport: CompositeViewportRange,
     axisDomains?: CompositeAxisDomains,
     widthScale?: number,
+    cursorDate?: Date | null,
   ): CompositeChartScene | null;
   onCommit(
     viewport: CompositeViewportRange | null,
@@ -59,6 +60,33 @@ interface CompositePaintState {
 function axisDomains(scene: CompositeChartScene | null): CompositeAxisDomains | undefined {
   if (!scene) return undefined;
   return new Map(scene.panels.map((panel) => [panel.id, panel.axes] as const));
+}
+
+function sameAxisDomains(
+  left: CompositeAxisDomains | undefined,
+  right: CompositeAxisDomains | undefined,
+): boolean {
+  if (!left || !right) return left === right;
+  if (left.size !== right.size) return false;
+  for (const [panelId, leftAxes] of left) {
+    const rightAxes = right.get(panelId);
+    if (!rightAxes) return false;
+    for (const side of ["left", "right"] as const) {
+      const a = leftAxes[side];
+      const b = rightAxes[side];
+      if (a === b) continue;
+      if (
+        !a || !b
+        || a.min !== b.min
+        || a.max !== b.max
+        || a.scale !== b.scale
+        || a.unit !== b.unit
+        || a.unitGroup !== b.unitGroup
+        || a.seriesIds.join("\0") !== b.seriesIds.join("\0")
+      ) return false;
+    }
+  }
+  return true;
 }
 
 function viewportRatios(
@@ -87,6 +115,7 @@ export class CompositeChartEngine {
     axes: CompositeAxisDomains | undefined;
     previewScene: CompositeChartScene | null;
     previewWidth: number;
+    previewRevision: number;
     offsetX: number;
   } | null = null;
   private snapshot: CompositeChartEngineSnapshot = {
@@ -148,7 +177,7 @@ export class CompositeChartEngine {
           scene: this.drag.previewScene,
           width: this.drag.previewWidth,
           offsetX: this.drag.offsetX,
-          revision: this.snapshot.version + 0.5,
+          revision: this.drag.previewRevision,
         }
       : {
           scene: this.snapshot.scene,
@@ -293,6 +322,7 @@ export class CompositeChartEngine {
       axes,
       previewScene,
       previewWidth,
+      previewRevision: this.snapshot.version + 0.5,
       offsetX: ratios ? -ratios.start * (previewWidth - 1) : 0,
     };
     this.emit(false);
@@ -335,16 +365,94 @@ export class CompositeChartEngine {
     this.emit(false);
   }
 
+  refreshPixelPanState(panX: number, pointerX: number): CompositeChartScene | null {
+    const drag = this.drag;
+    const viewport = this.effectiveViewport();
+    const config = this.pendingConfig ?? this.config;
+    if (!drag || !viewport || !config) return null;
+    const ratio = Math.max(0, Math.min(
+      1,
+      (pointerX - drag.offsetX) / Math.max(drag.previewWidth - 1, 1),
+    ));
+    const cursorDate = drag.previewScene
+      ? new Date(unprojectCompositeTimestamp(drag.previewScene.timeScale, ratio))
+      : null;
+    const scene = config.buildScene(viewport, undefined, 1, cursorDate);
+    const nextVersion = this.snapshot.version + 1;
+    this.snapshot = {
+      viewport,
+      interactionViewport: this.interactionViewport,
+      scene,
+      version: nextVersion,
+    };
+
+    const nextAxes = axisDomains(scene);
+    const visibleRatios = drag.previewScene
+      ? viewportRatios(drag.previewScene, viewport)
+      : null;
+    const bounds = config.navigationBounds;
+    const needsRecentering = !visibleRatios
+      || (visibleRatios.start < 0.15 && viewport.start.getTime() > bounds.start.getTime())
+      || (visibleRatios.end > 0.85 && viewport.end.getTime() < bounds.end.getTime());
+    if (!sameAxisDomains(drag.axes, nextAxes) || needsRecentering) {
+      const older = panCompositeViewport(
+        viewport,
+        bounds,
+        0.5,
+        config.series,
+        config.allowHistoricalBackfill,
+      );
+      const newer = panCompositeViewport(
+        viewport,
+        bounds,
+        -0.5,
+        config.series,
+        config.allowHistoricalBackfill,
+      );
+      const previewScene = config.buildScene(
+        { start: older.start, end: newer.end },
+        nextAxes,
+        2,
+        cursorDate,
+      ) ?? scene;
+      const ratios = previewScene ? viewportRatios(previewScene, viewport) : null;
+      const previewWidth = ratios
+        ? 1 + drag.width / (ratios.end - ratios.start)
+        : drag.width + 1;
+      drag.anchorX = panX;
+      drag.anchorViewport = viewport;
+      drag.axes = nextAxes;
+      drag.previewScene = previewScene;
+      drag.previewWidth = previewWidth;
+      drag.previewRevision = nextVersion + 0.5;
+      drag.offsetX = ratios ? -ratios.start * (previewWidth - 1) : 0;
+      this.emit(true);
+    } else {
+      for (const listener of this.stateListeners) listener();
+    }
+    return scene;
+  }
+
   endPixelPan(): void {
     const drag = this.drag;
     if (!drag) return;
     const pendingConfig = this.pendingConfig;
     const commit = (pendingConfig ?? this.config)?.onCommit;
+    const viewport = this.effectiveViewport();
+    const hasLiveScene = !!viewport
+      && !!this.snapshot.viewport
+      && sameCompositeViewport(viewport, this.snapshot.viewport);
     this.drag = null;
-    if (!sameCompositeViewport(drag.startViewport, this.effectiveViewport())) {
+    if (!sameCompositeViewport(drag.startViewport, viewport)) {
       commit?.(this.interactionViewport, "pan");
     }
-    if (pendingConfig) {
+    if (hasLiveScene) {
+      if (pendingConfig) {
+        this.pendingConfig = null;
+        this.config = pendingConfig;
+      }
+      this.emit(true);
+    } else if (pendingConfig) {
       this.pendingConfig = null;
       this.configure(pendingConfig);
     } else {
@@ -377,6 +485,8 @@ export function createCompositePanelPaintSource({
   height,
   interactive,
   onActivate,
+  onScrollPanFrame,
+  onScrollPanEnd,
 }: {
   engine: CompositeChartEngine;
   panelId: string;
@@ -385,6 +495,8 @@ export function createCompositePanelPaintSource({
   height: number;
   interactive: boolean;
   onActivate?: () => void;
+  onScrollPanFrame?: (cursorDate: Date | null, yRatio: number) => void;
+  onScrollPanEnd?: (cursorDate: Date | null) => void;
 }): ChartPaintSource {
   const frame = (): ChartPaintFrame | null => {
     const paintState = engine.getPaintState(width);
@@ -411,7 +523,9 @@ export function createCompositePanelPaintSource({
     if (!scrollPanning) return;
     scrollPanning = false;
     scrollPosition = 0;
+    const cursorDate = engine.getSnapshot().scene?.cursorDate ?? null;
     engine.endPixelPan();
+    onScrollPanEnd?.(cursorDate);
   };
   return {
     getFrame: frame,
@@ -437,6 +551,13 @@ export function createCompositePanelPaintSource({
       scrollPosition -= deltaPixels;
       engine.movePixelPan(scrollPosition);
       return true;
+    },
+    scrollPanFrame(input) {
+      const scene = engine.refreshPixelPanState(scrollPosition, input.x);
+      onScrollPanFrame?.(
+        scene?.cursorDate ?? null,
+        Math.max(0, Math.min(1, input.y / Math.max(height - 1, 1))),
+      );
     },
     scrollPanEnd: endScrollPan,
   };

--- a/src/components/chart/composite/engine.ts
+++ b/src/components/chart/composite/engine.ts
@@ -12,8 +12,8 @@ import {
   type CompositeViewportRange,
 } from "./interactions";
 import { paintCompositePanel } from "./painter";
+import { applyCompositeChartCursor, projectCompositeValue } from "./scene";
 import { projectCompositeTimestamp, unprojectCompositeTimestamp } from "./time-scale";
-import { applyCompositeChartCursor } from "./scene";
 import type {
   CompositeAxisDomain,
   CompositeAxisSide,
@@ -88,6 +88,22 @@ function sameAxisDomains(
     }
   }
   return true;
+}
+
+function reprojectSceneAxes(
+  scene: CompositeChartScene,
+  domains: CompositeAxisDomains,
+): void {
+  for (const panel of scene.panels) {
+    panel.axes = domains.get(panel.id) ?? panel.axes;
+    for (const series of panel.series) {
+      const domain = panel.axes[series.source.axis];
+      if (!domain) continue;
+      for (const point of series.points) {
+        point.yRatio = projectCompositeValue(point.value, domain) ?? point.yRatio;
+      }
+    }
+  }
 }
 
 function viewportRatios(
@@ -398,7 +414,8 @@ export class CompositeChartEngine {
     const needsRecentering = !visibleRatios
       || (visibleRatios.start < 0.15 && viewport.start.getTime() > bounds.start.getTime())
       || (visibleRatios.end > 0.85 && viewport.end.getTime() < bounds.end.getTime());
-    if (!sameAxisDomains(drag.axes, nextAxes) || needsRecentering) {
+    const axesChanged = !sameAxisDomains(drag.axes, nextAxes);
+    if (needsRecentering) {
       const older = panCompositeViewport(
         viewport,
         bounds,
@@ -430,6 +447,11 @@ export class CompositeChartEngine {
       drag.previewWidth = previewWidth;
       drag.previewRevision = nextVersion + 0.5;
       drag.offsetX = ratios ? -ratios.start * (previewWidth - 1) : 0;
+      this.emit(true);
+    } else if (axesChanged && drag.previewScene && nextAxes) {
+      drag.axes = nextAxes;
+      reprojectSceneAxes(drag.previewScene, nextAxes);
+      drag.previewRevision = nextVersion + 0.5;
       this.emit(true);
     } else {
       for (const listener of this.stateListeners) listener();

--- a/src/components/chart/composite/engine.ts
+++ b/src/components/chart/composite/engine.ts
@@ -1,0 +1,311 @@
+import type {
+  ChartPaintFrame,
+  ChartPaintSource,
+  ChartPointerInput,
+} from "../core/painter";
+import type { ResolvedSeries } from "../../../time-series/types";
+import {
+  clampCompositeViewport,
+  panCompositeViewport,
+  sameCompositeViewport,
+  zoomCompositeViewport,
+  type CompositeViewportRange,
+} from "./interactions";
+import { paintCompositePanel } from "./painter";
+import type {
+  CompositeAxisDomain,
+  CompositeAxisSide,
+  CompositeChartColors,
+  CompositeChartScene,
+} from "./types";
+
+export type CompositeAxisDomains = ReadonlyMap<
+  string,
+  Partial<Record<CompositeAxisSide, CompositeAxisDomain>>
+>;
+
+export interface CompositeChartEngineConfig {
+  resetKey: string;
+  initialViewport: CompositeViewportRange;
+  navigationBounds: CompositeViewportRange;
+  series: ResolvedSeries[];
+  allowHistoricalBackfill: boolean;
+  buildScene(
+    viewport: CompositeViewportRange,
+    axisDomains?: CompositeAxisDomains,
+  ): CompositeChartScene | null;
+  onCommit(
+    viewport: CompositeViewportRange | null,
+    interaction: "pan" | "reset" | "sync" | "zoom",
+  ): void;
+}
+
+export interface CompositeChartEngineSnapshot {
+  viewport: CompositeViewportRange | null;
+  interactionViewport: CompositeViewportRange | null;
+  scene: CompositeChartScene | null;
+  version: number;
+}
+
+function axisDomains(scene: CompositeChartScene | null): CompositeAxisDomains | undefined {
+  if (!scene) return undefined;
+  return new Map(scene.panels.map((panel) => [panel.id, panel.axes] as const));
+}
+
+export class CompositeChartEngine {
+  private config: CompositeChartEngineConfig | null = null;
+  private pendingConfig: CompositeChartEngineConfig | null = null;
+  private frameListeners = new Set<() => void>();
+  private stateListeners = new Set<() => void>();
+  private interactionViewport: CompositeViewportRange | null = null;
+  private drag: {
+    startX: number;
+    width: number;
+    startViewport: CompositeViewportRange;
+    axes: CompositeAxisDomains | undefined;
+  } | null = null;
+  private snapshot: CompositeChartEngineSnapshot = {
+    viewport: null,
+    interactionViewport: null,
+    scene: null,
+    version: 0,
+  };
+
+  configure(config: CompositeChartEngineConfig): void {
+    if (this.config === config || this.pendingConfig === config) return;
+    if (this.drag && this.config?.resetKey === config.resetKey) {
+      this.pendingConfig = config;
+      return;
+    }
+    this.pendingConfig = null;
+    const hadConfig = this.config !== null;
+    const reset = hadConfig && this.config?.resetKey !== config.resetKey;
+    const previousInteraction = this.interactionViewport;
+    this.config = config;
+    const clampedInteraction = previousInteraction
+      ? clampCompositeViewport(previousInteraction, config.navigationBounds)
+      : null;
+    this.interactionViewport = reset
+      ? null
+      : previousInteraction && clampedInteraction
+        ? sameCompositeViewport(previousInteraction, clampedInteraction)
+          ? previousInteraction
+          : clampedInteraction
+        : null;
+    this.drag = null;
+    this.rebuild();
+    if (reset && previousInteraction) {
+      config.onCommit(null, "reset");
+    } else if (
+      previousInteraction
+      && this.interactionViewport
+      && !sameCompositeViewport(previousInteraction, this.interactionViewport)
+    ) {
+      config.onCommit(this.interactionViewport, "sync");
+    }
+  }
+
+  subscribeFrame = (listener: () => void): (() => void) => {
+    this.frameListeners.add(listener);
+    return () => this.frameListeners.delete(listener);
+  };
+
+  subscribeState = (listener: () => void): (() => void) => {
+    this.stateListeners.add(listener);
+    return () => this.stateListeners.delete(listener);
+  };
+
+  getSnapshot = (): CompositeChartEngineSnapshot => this.snapshot;
+
+  isConfigured(config: CompositeChartEngineConfig): boolean {
+    return this.config === config || this.pendingConfig === config;
+  }
+
+  hasResetKey(resetKey: string): boolean {
+    return this.config?.resetKey === resetKey;
+  }
+
+  isDragging(): boolean {
+    return this.drag !== null;
+  }
+
+  private emit(publishState: boolean): void {
+    for (const listener of this.frameListeners) listener();
+    if (publishState) {
+      for (const listener of this.stateListeners) listener();
+    }
+  }
+
+  private effectiveViewport(): CompositeViewportRange | null {
+    if (!this.config) return null;
+    return this.interactionViewport ?? this.config.initialViewport;
+  }
+
+  private rebuild(axes?: CompositeAxisDomains, publishState = true): void {
+    const viewport = this.effectiveViewport();
+    const scene = this.config && viewport
+      ? this.config.buildScene(viewport, axes)
+      : null;
+    this.snapshot = {
+      viewport,
+      interactionViewport: this.interactionViewport,
+      scene,
+      version: this.snapshot.version + 1,
+    };
+    this.emit(publishState);
+  }
+
+  private updateViewport(
+    next: CompositeViewportRange,
+    axes?: CompositeAxisDomains,
+    publishState = true,
+  ): boolean {
+    if (!this.config || sameCompositeViewport(next, this.effectiveViewport())) return false;
+    this.interactionViewport = sameCompositeViewport(next, this.config.initialViewport)
+      ? null
+      : next;
+    this.rebuild(axes, publishState);
+    return true;
+  }
+
+  pan(
+    shiftRatio: number,
+    fromViewport?: CompositeViewportRange,
+    commit = true,
+  ): void {
+    if (!this.config) return;
+    const base = fromViewport ?? this.effectiveViewport();
+    if (!base) return;
+    const next = panCompositeViewport(
+      base,
+      this.config.navigationBounds,
+      shiftRatio,
+      this.config.series,
+      this.config.allowHistoricalBackfill,
+    );
+    const changed = this.updateViewport(next, this.drag?.axes, commit);
+    if (changed && commit) this.commit("pan");
+  }
+
+  zoom(zoomFactor: number, anchorRatio: number, minimumSpanMs: number): void {
+    if (!this.config) return;
+    const base = this.effectiveViewport();
+    if (!base) return;
+    const changed = this.updateViewport(zoomCompositeViewport(
+      base,
+      this.config.navigationBounds,
+      zoomFactor,
+      anchorRatio,
+      minimumSpanMs,
+      this.config.series,
+    ));
+    if (changed) this.commit("zoom");
+  }
+
+  setViewport(viewport: CompositeViewportRange): void {
+    if (!this.config) return;
+    if (this.updateViewport(clampCompositeViewport(viewport, this.config.navigationBounds))) {
+      this.commit("zoom");
+    }
+  }
+
+  reset(): void {
+    if (!this.config) return;
+    this.interactionViewport = null;
+    this.rebuild();
+    this.config.onCommit(null, "reset");
+  }
+
+  beginPixelPan(x: number, width: number): boolean {
+    const viewport = this.effectiveViewport();
+    if (!this.config || !viewport || !(width > 0)) return false;
+    this.drag = {
+      startX: x,
+      width: Math.max(width - 1, 1),
+      startViewport: viewport,
+      axes: axisDomains(this.snapshot.scene),
+    };
+    return true;
+  }
+
+  movePixelPan(x: number): void {
+    const drag = this.drag;
+    if (!drag) return;
+    this.pan((x - drag.startX) / drag.width, drag.startViewport, false);
+  }
+
+  endPixelPan(): void {
+    const drag = this.drag;
+    if (!drag) return;
+    const pendingConfig = this.pendingConfig;
+    const commit = (pendingConfig ?? this.config)?.onCommit;
+    this.drag = null;
+    if (!sameCompositeViewport(drag.startViewport, this.effectiveViewport())) {
+      commit?.(this.interactionViewport, "pan");
+    }
+    if (pendingConfig) {
+      this.pendingConfig = null;
+      this.configure(pendingConfig);
+    } else {
+      this.rebuild();
+    }
+  }
+
+  cancelPixelPan(): void {
+    const drag = this.drag;
+    if (!drag) return;
+    const pendingConfig = this.pendingConfig;
+    this.drag = null;
+    this.updateViewport(drag.startViewport);
+    if (pendingConfig) {
+      this.pendingConfig = null;
+      this.configure(pendingConfig);
+    }
+  }
+
+  private commit(interaction: "pan" | "zoom"): void {
+    this.config?.onCommit(this.interactionViewport, interaction);
+  }
+}
+
+export function createCompositePanelPaintSource({
+  engine,
+  panelId,
+  colors,
+  width,
+  height,
+  interactive,
+  onActivate,
+}: {
+  engine: CompositeChartEngine;
+  panelId: string;
+  colors: CompositeChartColors;
+  width: number;
+  height: number;
+  interactive: boolean;
+  onActivate?: () => void;
+}): ChartPaintSource {
+  const frame = (): ChartPaintFrame | null => {
+    const panel = engine.getSnapshot().scene?.panels.find((entry) => entry.id === panelId);
+    return panel
+      ? {
+          width,
+          height,
+          paint: (painter) => paintCompositePanel(painter, panel, colors, width, height),
+        }
+      : null;
+  };
+  return {
+    getFrame: frame,
+    subscribe: engine.subscribeFrame,
+    pointerDown(input: ChartPointerInput): boolean {
+      if (!interactive || input.shift || input.alt || input.ctrl) return false;
+      const accepted = engine.beginPixelPan(input.x, width);
+      if (accepted) onActivate?.();
+      return accepted;
+    },
+    pointerMove: (input) => engine.movePixelPan(input.x),
+    pointerUp: () => engine.endPixelPan(),
+    pointerCancel: () => engine.cancelPixelPan(),
+  };
+}

--- a/src/components/chart/composite/engine.ts
+++ b/src/components/chart/composite/engine.ts
@@ -12,6 +12,7 @@ import {
   type CompositeViewportRange,
 } from "./interactions";
 import { paintCompositePanel } from "./painter";
+import { projectCompositeTimestamp } from "./time-scale";
 import type {
   CompositeAxisDomain,
   CompositeAxisSide,
@@ -33,6 +34,7 @@ export interface CompositeChartEngineConfig {
   buildScene(
     viewport: CompositeViewportRange,
     axisDomains?: CompositeAxisDomains,
+    widthScale?: number,
   ): CompositeChartScene | null;
   onCommit(
     viewport: CompositeViewportRange | null,
@@ -47,9 +49,27 @@ export interface CompositeChartEngineSnapshot {
   version: number;
 }
 
+interface CompositePaintState {
+  scene: CompositeChartScene | null;
+  width: number;
+  offsetX: number;
+  revision: number;
+}
+
 function axisDomains(scene: CompositeChartScene | null): CompositeAxisDomains | undefined {
   if (!scene) return undefined;
   return new Map(scene.panels.map((panel) => [panel.id, panel.axes] as const));
+}
+
+function viewportRatios(
+  scene: CompositeChartScene,
+  viewport: CompositeViewportRange,
+): { start: number; end: number } | null {
+  const start = projectCompositeTimestamp(scene.timeScale, viewport.start.getTime())?.ratio;
+  const end = projectCompositeTimestamp(scene.timeScale, viewport.end.getTime())?.ratio;
+  return typeof start === "number" && typeof end === "number" && end > start
+    ? { start, end }
+    : null;
 }
 
 export class CompositeChartEngine {
@@ -63,6 +83,9 @@ export class CompositeChartEngine {
     width: number;
     startViewport: CompositeViewportRange;
     axes: CompositeAxisDomains | undefined;
+    previewScene: CompositeChartScene | null;
+    previewWidth: number;
+    offsetX: number;
   } | null = null;
   private snapshot: CompositeChartEngineSnapshot = {
     viewport: null,
@@ -116,6 +139,22 @@ export class CompositeChartEngine {
   };
 
   getSnapshot = (): CompositeChartEngineSnapshot => this.snapshot;
+
+  getPaintState(surfaceWidth: number): CompositePaintState {
+    return this.drag
+      ? {
+          scene: this.drag.previewScene,
+          width: this.drag.previewWidth,
+          offsetX: this.drag.offsetX,
+          revision: this.snapshot.version + 0.5,
+        }
+      : {
+          scene: this.snapshot.scene,
+          width: surfaceWidth,
+          offsetX: 0,
+          revision: this.snapshot.version,
+        };
+  }
 
   isConfigured(config: CompositeChartEngineConfig): boolean {
     return this.config === config || this.pendingConfig === config;
@@ -219,19 +258,60 @@ export class CompositeChartEngine {
   beginPixelPan(x: number, width: number): boolean {
     const viewport = this.effectiveViewport();
     if (!this.config || !viewport || !(width > 0)) return false;
+    const axes = axisDomains(this.snapshot.scene);
+    const older = panCompositeViewport(
+      viewport,
+      this.config.navigationBounds,
+      1,
+      this.config.series,
+      this.config.allowHistoricalBackfill,
+    );
+    const newer = panCompositeViewport(
+      viewport,
+      this.config.navigationBounds,
+      -1,
+      this.config.series,
+      this.config.allowHistoricalBackfill,
+    );
+    const previewScene = this.config.buildScene(
+      { start: older.start, end: newer.end },
+      axes,
+      3,
+    ) ?? this.snapshot.scene;
+    const ratios = previewScene ? viewportRatios(previewScene, viewport) : null;
+    const previewWidth = ratios
+      ? 1 + Math.max(width - 1, 1) / (ratios.end - ratios.start)
+      : width;
     this.drag = {
       startX: x,
       width: Math.max(width - 1, 1),
       startViewport: viewport,
-      axes: axisDomains(this.snapshot.scene),
+      axes,
+      previewScene,
+      previewWidth,
+      offsetX: ratios ? -ratios.start * (previewWidth - 1) : 0,
     };
+    this.emit(false);
     return true;
   }
 
   movePixelPan(x: number): void {
     const drag = this.drag;
-    if (!drag) return;
-    this.pan((x - drag.startX) / drag.width, drag.startViewport, false);
+    if (!drag || !this.config) return;
+    const next = panCompositeViewport(
+      drag.startViewport,
+      this.config.navigationBounds,
+      (x - drag.startX) / drag.width,
+      this.config.series,
+      this.config.allowHistoricalBackfill,
+    );
+    if (sameCompositeViewport(next, this.effectiveViewport())) return;
+    this.interactionViewport = sameCompositeViewport(next, this.config.initialViewport)
+      ? null
+      : next;
+    const ratios = drag.previewScene ? viewportRatios(drag.previewScene, next) : null;
+    if (ratios) drag.offsetX = -ratios.start * (drag.previewWidth - 1);
+    this.emit(false);
   }
 
   endPixelPan(): void {
@@ -256,7 +336,7 @@ export class CompositeChartEngine {
     if (!drag) return;
     const pendingConfig = this.pendingConfig;
     this.drag = null;
-    this.updateViewport(drag.startViewport);
+    if (!this.updateViewport(drag.startViewport)) this.rebuild();
     if (pendingConfig) {
       this.pendingConfig = null;
       this.configure(pendingConfig);
@@ -286,12 +366,21 @@ export function createCompositePanelPaintSource({
   onActivate?: () => void;
 }): ChartPaintSource {
   const frame = (): ChartPaintFrame | null => {
-    const panel = engine.getSnapshot().scene?.panels.find((entry) => entry.id === panelId);
+    const paintState = engine.getPaintState(width);
+    const panel = paintState.scene?.panels.find((entry) => entry.id === panelId);
     return panel
       ? {
-          width,
+          width: paintState.width,
           height,
-          paint: (painter) => paintCompositePanel(painter, panel, colors, width, height),
+          revision: paintState.revision,
+          offsetX: paintState.offsetX,
+          paint: (painter) => paintCompositePanel(
+            painter,
+            panel,
+            colors,
+            paintState.width,
+            height,
+          ),
         }
       : null;
   };

--- a/src/components/chart/composite/engine.ts
+++ b/src/components/chart/composite/engine.ts
@@ -405,11 +405,20 @@ export function createCompositePanelPaintSource({
         }
       : null;
   };
+  let scrollPosition = 0;
+  let scrollPanning = false;
+  const endScrollPan = () => {
+    if (!scrollPanning) return;
+    scrollPanning = false;
+    scrollPosition = 0;
+    engine.endPixelPan();
+  };
   return {
     getFrame: frame,
     subscribe: engine.subscribeFrame,
     pointerDown(input: ChartPointerInput): boolean {
       if (!interactive || input.shift || input.alt || input.ctrl) return false;
+      endScrollPan();
       const accepted = engine.beginPixelPan(input.x, width);
       if (accepted) onActivate?.();
       return accepted;
@@ -417,5 +426,18 @@ export function createCompositePanelPaintSource({
     pointerMove: (input) => engine.movePixelPan(input.x),
     pointerUp: () => engine.endPixelPan(),
     pointerCancel: () => engine.cancelPixelPan(),
+    scrollPan(deltaPixels: number): boolean {
+      if (!interactive || !Number.isFinite(deltaPixels) || deltaPixels === 0) return false;
+      if (!scrollPanning) {
+        if (engine.isDragging() || !engine.beginPixelPan(0, width)) return false;
+        scrollPanning = true;
+        scrollPosition = 0;
+        onActivate?.();
+      }
+      scrollPosition -= deltaPixels;
+      engine.movePixelPan(scrollPosition);
+      return true;
+    },
+    scrollPanEnd: endScrollPan,
   };
 }

--- a/src/components/chart/composite/engine.ts
+++ b/src/components/chart/composite/engine.ts
@@ -371,7 +371,6 @@ export function createCompositePanelPaintSource({
     return panel
       ? {
           width: paintState.width,
-          surfaceWidth: width,
           height,
           revision: paintState.revision,
           offsetX: paintState.offsetX,

--- a/src/components/chart/composite/engine.ts
+++ b/src/components/chart/composite/engine.ts
@@ -12,7 +12,7 @@ import {
   type CompositeViewportRange,
 } from "./interactions";
 import { paintCompositePanel } from "./painter";
-import { projectCompositeTimestamp, unprojectCompositeTimestamp } from "./time-scale";
+import { projectCompositeTimestamp } from "./time-scale";
 import type {
   CompositeAxisDomain,
   CompositeAxisSide,
@@ -35,7 +35,6 @@ export interface CompositeChartEngineConfig {
     viewport: CompositeViewportRange,
     axisDomains?: CompositeAxisDomains,
     widthScale?: number,
-    cursorDate?: Date | null,
   ): CompositeChartScene | null;
   onCommit(
     viewport: CompositeViewportRange | null,
@@ -60,33 +59,6 @@ interface CompositePaintState {
 function axisDomains(scene: CompositeChartScene | null): CompositeAxisDomains | undefined {
   if (!scene) return undefined;
   return new Map(scene.panels.map((panel) => [panel.id, panel.axes] as const));
-}
-
-function sameAxisDomains(
-  left: CompositeAxisDomains | undefined,
-  right: CompositeAxisDomains | undefined,
-): boolean {
-  if (!left || !right) return left === right;
-  if (left.size !== right.size) return false;
-  for (const [panelId, leftAxes] of left) {
-    const rightAxes = right.get(panelId);
-    if (!rightAxes) return false;
-    for (const side of ["left", "right"] as const) {
-      const a = leftAxes[side];
-      const b = rightAxes[side];
-      if (a === b) continue;
-      if (
-        !a || !b
-        || a.min !== b.min
-        || a.max !== b.max
-        || a.scale !== b.scale
-        || a.unit !== b.unit
-        || a.unitGroup !== b.unitGroup
-        || a.seriesIds.join("\0") !== b.seriesIds.join("\0")
-      ) return false;
-    }
-  }
-  return true;
 }
 
 function viewportRatios(
@@ -115,7 +87,6 @@ export class CompositeChartEngine {
     axes: CompositeAxisDomains | undefined;
     previewScene: CompositeChartScene | null;
     previewWidth: number;
-    previewRevision: number;
     offsetX: number;
   } | null = null;
   private snapshot: CompositeChartEngineSnapshot = {
@@ -177,7 +148,7 @@ export class CompositeChartEngine {
           scene: this.drag.previewScene,
           width: this.drag.previewWidth,
           offsetX: this.drag.offsetX,
-          revision: this.drag.previewRevision,
+          revision: this.snapshot.version + 0.5,
         }
       : {
           scene: this.snapshot.scene,
@@ -322,7 +293,6 @@ export class CompositeChartEngine {
       axes,
       previewScene,
       previewWidth,
-      previewRevision: this.snapshot.version + 0.5,
       offsetX: ratios ? -ratios.start * (previewWidth - 1) : 0,
     };
     this.emit(false);
@@ -365,94 +335,16 @@ export class CompositeChartEngine {
     this.emit(false);
   }
 
-  refreshPixelPanState(pointerX: number): CompositeChartScene | null {
-    const drag = this.drag;
-    const viewport = this.effectiveViewport();
-    const config = this.pendingConfig ?? this.config;
-    if (!drag || !viewport || !config) return null;
-    const ratio = Math.max(0, Math.min(
-      1,
-      (pointerX - drag.offsetX) / Math.max(drag.previewWidth - 1, 1),
-    ));
-    const cursorDate = drag.previewScene
-      ? new Date(unprojectCompositeTimestamp(drag.previewScene.timeScale, ratio))
-      : null;
-    const scene = config.buildScene(viewport, undefined, 1, cursorDate);
-    const nextVersion = this.snapshot.version + 1;
-    this.snapshot = {
-      viewport,
-      interactionViewport: this.interactionViewport,
-      scene,
-      version: nextVersion,
-    };
-
-    const nextAxes = axisDomains(scene);
-    const visibleRatios = drag.previewScene
-      ? viewportRatios(drag.previewScene, viewport)
-      : null;
-    const bounds = config.navigationBounds;
-    const needsRecentering = !visibleRatios
-      || (visibleRatios.start < 0.15 && viewport.start.getTime() > bounds.start.getTime())
-      || (visibleRatios.end > 0.85 && viewport.end.getTime() < bounds.end.getTime());
-    if (!sameAxisDomains(drag.axes, nextAxes) || needsRecentering) {
-      const older = panCompositeViewport(
-        viewport,
-        bounds,
-        0.5,
-        config.series,
-        config.allowHistoricalBackfill,
-      );
-      const newer = panCompositeViewport(
-        viewport,
-        bounds,
-        -0.5,
-        config.series,
-        config.allowHistoricalBackfill,
-      );
-      const previewScene = config.buildScene(
-        { start: older.start, end: newer.end },
-        nextAxes,
-        2,
-        cursorDate,
-      ) ?? scene;
-      const ratios = previewScene ? viewportRatios(previewScene, viewport) : null;
-      const previewWidth = ratios
-        ? 1 + drag.width / (ratios.end - ratios.start)
-        : drag.width + 1;
-      drag.anchorX = pointerX;
-      drag.anchorViewport = viewport;
-      drag.axes = nextAxes;
-      drag.previewScene = previewScene;
-      drag.previewWidth = previewWidth;
-      drag.previewRevision = nextVersion + 0.5;
-      drag.offsetX = ratios ? -ratios.start * (previewWidth - 1) : 0;
-      this.emit(true);
-    } else {
-      for (const listener of this.stateListeners) listener();
-    }
-    return scene;
-  }
-
   endPixelPan(): void {
     const drag = this.drag;
     if (!drag) return;
     const pendingConfig = this.pendingConfig;
     const commit = (pendingConfig ?? this.config)?.onCommit;
-    const viewport = this.effectiveViewport();
-    const hasLiveScene = !!viewport
-      && !!this.snapshot.viewport
-      && sameCompositeViewport(viewport, this.snapshot.viewport);
     this.drag = null;
-    if (!sameCompositeViewport(drag.startViewport, viewport)) {
+    if (!sameCompositeViewport(drag.startViewport, this.effectiveViewport())) {
       commit?.(this.interactionViewport, "pan");
     }
-    if (hasLiveScene) {
-      if (pendingConfig) {
-        this.pendingConfig = null;
-        this.config = pendingConfig;
-      }
-      this.emit(true);
-    } else if (pendingConfig) {
+    if (pendingConfig) {
       this.pendingConfig = null;
       this.configure(pendingConfig);
     } else {
@@ -485,7 +377,6 @@ export function createCompositePanelPaintSource({
   height,
   interactive,
   onActivate,
-  onPanFrame,
 }: {
   engine: CompositeChartEngine;
   panelId: string;
@@ -494,7 +385,6 @@ export function createCompositePanelPaintSource({
   height: number;
   interactive: boolean;
   onActivate?: () => void;
-  onPanFrame?: (cursorDate: Date | null, yRatio: number) => void;
 }): ChartPaintSource {
   const frame = (): ChartPaintFrame | null => {
     const paintState = engine.getPaintState(width);
@@ -547,13 +437,6 @@ export function createCompositePanelPaintSource({
       scrollPosition -= deltaPixels;
       engine.movePixelPan(scrollPosition);
       return true;
-    },
-    panFrame(input) {
-      const scene = engine.refreshPixelPanState(input.x);
-      onPanFrame?.(
-        scene?.cursorDate ?? null,
-        Math.max(0, Math.min(1, input.y / Math.max(height - 1, 1))),
-      );
     },
     scrollPanEnd: endScrollPan,
   };

--- a/src/components/chart/composite/engine.ts
+++ b/src/components/chart/composite/engine.ts
@@ -12,7 +12,7 @@ import {
   type CompositeViewportRange,
 } from "./interactions";
 import { paintCompositePanel } from "./painter";
-import { projectCompositeTimestamp } from "./time-scale";
+import { projectCompositeTimestamp, unprojectCompositeTimestamp } from "./time-scale";
 import type {
   CompositeAxisDomain,
   CompositeAxisSide,
@@ -35,6 +35,7 @@ export interface CompositeChartEngineConfig {
     viewport: CompositeViewportRange,
     axisDomains?: CompositeAxisDomains,
     widthScale?: number,
+    cursorDate?: Date | null,
   ): CompositeChartScene | null;
   onCommit(
     viewport: CompositeViewportRange | null,
@@ -59,6 +60,33 @@ interface CompositePaintState {
 function axisDomains(scene: CompositeChartScene | null): CompositeAxisDomains | undefined {
   if (!scene) return undefined;
   return new Map(scene.panels.map((panel) => [panel.id, panel.axes] as const));
+}
+
+function sameAxisDomains(
+  left: CompositeAxisDomains | undefined,
+  right: CompositeAxisDomains | undefined,
+): boolean {
+  if (!left || !right) return left === right;
+  if (left.size !== right.size) return false;
+  for (const [panelId, leftAxes] of left) {
+    const rightAxes = right.get(panelId);
+    if (!rightAxes) return false;
+    for (const side of ["left", "right"] as const) {
+      const a = leftAxes[side];
+      const b = rightAxes[side];
+      if (a === b) continue;
+      if (
+        !a || !b
+        || a.min !== b.min
+        || a.max !== b.max
+        || a.scale !== b.scale
+        || a.unit !== b.unit
+        || a.unitGroup !== b.unitGroup
+        || a.seriesIds.join("\0") !== b.seriesIds.join("\0")
+      ) return false;
+    }
+  }
+  return true;
 }
 
 function viewportRatios(
@@ -87,6 +115,7 @@ export class CompositeChartEngine {
     axes: CompositeAxisDomains | undefined;
     previewScene: CompositeChartScene | null;
     previewWidth: number;
+    previewRevision: number;
     offsetX: number;
   } | null = null;
   private snapshot: CompositeChartEngineSnapshot = {
@@ -148,7 +177,7 @@ export class CompositeChartEngine {
           scene: this.drag.previewScene,
           width: this.drag.previewWidth,
           offsetX: this.drag.offsetX,
-          revision: this.snapshot.version + 0.5,
+          revision: this.drag.previewRevision,
         }
       : {
           scene: this.snapshot.scene,
@@ -293,6 +322,7 @@ export class CompositeChartEngine {
       axes,
       previewScene,
       previewWidth,
+      previewRevision: this.snapshot.version + 0.5,
       offsetX: ratios ? -ratios.start * (previewWidth - 1) : 0,
     };
     this.emit(false);
@@ -335,16 +365,94 @@ export class CompositeChartEngine {
     this.emit(false);
   }
 
+  refreshPixelPanState(pointerX: number): CompositeChartScene | null {
+    const drag = this.drag;
+    const viewport = this.effectiveViewport();
+    const config = this.pendingConfig ?? this.config;
+    if (!drag || !viewport || !config) return null;
+    const ratio = Math.max(0, Math.min(
+      1,
+      (pointerX - drag.offsetX) / Math.max(drag.previewWidth - 1, 1),
+    ));
+    const cursorDate = drag.previewScene
+      ? new Date(unprojectCompositeTimestamp(drag.previewScene.timeScale, ratio))
+      : null;
+    const scene = config.buildScene(viewport, undefined, 1, cursorDate);
+    const nextVersion = this.snapshot.version + 1;
+    this.snapshot = {
+      viewport,
+      interactionViewport: this.interactionViewport,
+      scene,
+      version: nextVersion,
+    };
+
+    const nextAxes = axisDomains(scene);
+    const visibleRatios = drag.previewScene
+      ? viewportRatios(drag.previewScene, viewport)
+      : null;
+    const bounds = config.navigationBounds;
+    const needsRecentering = !visibleRatios
+      || (visibleRatios.start < 0.15 && viewport.start.getTime() > bounds.start.getTime())
+      || (visibleRatios.end > 0.85 && viewport.end.getTime() < bounds.end.getTime());
+    if (!sameAxisDomains(drag.axes, nextAxes) || needsRecentering) {
+      const older = panCompositeViewport(
+        viewport,
+        bounds,
+        0.5,
+        config.series,
+        config.allowHistoricalBackfill,
+      );
+      const newer = panCompositeViewport(
+        viewport,
+        bounds,
+        -0.5,
+        config.series,
+        config.allowHistoricalBackfill,
+      );
+      const previewScene = config.buildScene(
+        { start: older.start, end: newer.end },
+        nextAxes,
+        2,
+        cursorDate,
+      ) ?? scene;
+      const ratios = previewScene ? viewportRatios(previewScene, viewport) : null;
+      const previewWidth = ratios
+        ? 1 + drag.width / (ratios.end - ratios.start)
+        : drag.width + 1;
+      drag.anchorX = pointerX;
+      drag.anchorViewport = viewport;
+      drag.axes = nextAxes;
+      drag.previewScene = previewScene;
+      drag.previewWidth = previewWidth;
+      drag.previewRevision = nextVersion + 0.5;
+      drag.offsetX = ratios ? -ratios.start * (previewWidth - 1) : 0;
+      this.emit(true);
+    } else {
+      for (const listener of this.stateListeners) listener();
+    }
+    return scene;
+  }
+
   endPixelPan(): void {
     const drag = this.drag;
     if (!drag) return;
     const pendingConfig = this.pendingConfig;
     const commit = (pendingConfig ?? this.config)?.onCommit;
+    const viewport = this.effectiveViewport();
+    const hasLiveScene = !!viewport
+      && !!this.snapshot.viewport
+      && sameCompositeViewport(viewport, this.snapshot.viewport);
     this.drag = null;
-    if (!sameCompositeViewport(drag.startViewport, this.effectiveViewport())) {
+    if (!sameCompositeViewport(drag.startViewport, viewport)) {
       commit?.(this.interactionViewport, "pan");
     }
-    if (pendingConfig) {
+    if (hasLiveScene) {
+      if (pendingConfig) {
+        this.pendingConfig = null;
+        this.config = pendingConfig;
+      }
+      this.emit(true);
+    } else if (pendingConfig) {
       this.pendingConfig = null;
       this.configure(pendingConfig);
     } else {
@@ -377,6 +485,7 @@ export function createCompositePanelPaintSource({
   height,
   interactive,
   onActivate,
+  onPanFrame,
 }: {
   engine: CompositeChartEngine;
   panelId: string;
@@ -385,6 +494,7 @@ export function createCompositePanelPaintSource({
   height: number;
   interactive: boolean;
   onActivate?: () => void;
+  onPanFrame?: (cursorDate: Date | null, yRatio: number) => void;
 }): ChartPaintSource {
   const frame = (): ChartPaintFrame | null => {
     const paintState = engine.getPaintState(width);
@@ -437,6 +547,13 @@ export function createCompositePanelPaintSource({
       scrollPosition -= deltaPixels;
       engine.movePixelPan(scrollPosition);
       return true;
+    },
+    panFrame(input) {
+      const scene = engine.refreshPixelPanState(input.x);
+      onPanFrame?.(
+        scene?.cursorDate ?? null,
+        Math.max(0, Math.min(1, input.y / Math.max(height - 1, 1))),
+      );
     },
     scrollPanEnd: endScrollPan,
   };

--- a/src/components/chart/composite/engine.ts
+++ b/src/components/chart/composite/engine.ts
@@ -79,9 +79,11 @@ export class CompositeChartEngine {
   private stateListeners = new Set<() => void>();
   private interactionViewport: CompositeViewportRange | null = null;
   private drag: {
-    startX: number;
     width: number;
     startViewport: CompositeViewportRange;
+    anchorX: number;
+    anchorViewport: CompositeViewportRange;
+    lastX: number;
     axes: CompositeAxisDomains | undefined;
     previewScene: CompositeChartScene | null;
     previewWidth: number;
@@ -283,9 +285,11 @@ export class CompositeChartEngine {
       ? 1 + Math.max(width - 1, 1) / (ratios.end - ratios.start)
       : width;
     this.drag = {
-      startX: x,
       width: Math.max(width - 1, 1),
       startViewport: viewport,
+      anchorX: x,
+      anchorViewport: viewport,
+      lastX: x,
       axes,
       previewScene,
       previewWidth,
@@ -299,13 +303,21 @@ export class CompositeChartEngine {
     const drag = this.drag;
     if (!drag || !this.config) return;
     const next = panCompositeViewport(
-      drag.startViewport,
+      drag.anchorViewport,
       this.config.navigationBounds,
-      (x - drag.startX) / drag.width,
+      (x - drag.anchorX) / drag.width,
       this.config.series,
       this.config.allowHistoricalBackfill,
     );
-    if (sameCompositeViewport(next, this.effectiveViewport())) return;
+    if (sameCompositeViewport(next, this.effectiveViewport())) {
+      if (x !== drag.lastX) {
+        drag.anchorX = x;
+        drag.anchorViewport = next;
+      }
+      drag.lastX = x;
+      return;
+    }
+    drag.lastX = x;
     this.interactionViewport = sameCompositeViewport(next, this.config.initialViewport)
       ? null
       : next;

--- a/src/components/chart/composite/engine.ts
+++ b/src/components/chart/composite/engine.ts
@@ -371,6 +371,7 @@ export function createCompositePanelPaintSource({
     return panel
       ? {
           width: paintState.width,
+          surfaceWidth: width,
           height,
           revision: paintState.revision,
           offsetX: paintState.offsetX,

--- a/src/components/chart/composite/engine.ts
+++ b/src/components/chart/composite/engine.ts
@@ -13,6 +13,7 @@ import {
 } from "./interactions";
 import { paintCompositePanel } from "./painter";
 import { projectCompositeTimestamp, unprojectCompositeTimestamp } from "./time-scale";
+import { applyCompositeChartCursor } from "./scene";
 import type {
   CompositeAxisDomain,
   CompositeAxisSide,
@@ -370,14 +371,17 @@ export class CompositeChartEngine {
     const viewport = this.effectiveViewport();
     const config = this.pendingConfig ?? this.config;
     if (!drag || !viewport || !config) return null;
-    const ratio = Math.max(0, Math.min(
-      1,
-      (pointerX - drag.offsetX) / Math.max(drag.previewWidth - 1, 1),
-    ));
-    const cursorDate = drag.previewScene
-      ? new Date(unprojectCompositeTimestamp(drag.previewScene.timeScale, ratio))
+    const pointerRatio = Math.max(0, Math.min(1, pointerX / drag.width));
+    const baseScene = config.buildScene(viewport, undefined, 1, null);
+    const cursorDate = baseScene
+      ? new Date(unprojectCompositeTimestamp(baseScene.timeScale, pointerRatio))
       : null;
-    const scene = config.buildScene(viewport, undefined, 1, cursorDate);
+    const cursorScene = baseScene && cursorDate
+      ? applyCompositeChartCursor(baseScene, cursorDate)
+      : baseScene;
+    const scene = cursorScene
+      ? { ...cursorScene, cursorXRatio: pointerRatio }
+      : null;
     const nextVersion = this.snapshot.version + 1;
     this.snapshot = {
       viewport,
@@ -485,8 +489,9 @@ export function createCompositePanelPaintSource({
   height,
   interactive,
   onActivate,
-  onScrollPanFrame,
-  onScrollPanEnd,
+  onPanFrame,
+  onPanEnd,
+  onPanCancel,
 }: {
   engine: CompositeChartEngine;
   panelId: string;
@@ -495,8 +500,9 @@ export function createCompositePanelPaintSource({
   height: number;
   interactive: boolean;
   onActivate?: () => void;
-  onScrollPanFrame?: (cursorDate: Date | null, yRatio: number) => void;
-  onScrollPanEnd?: (cursorDate: Date | null) => void;
+  onPanFrame?: (scene: CompositeChartScene | null, yRatio: number) => void;
+  onPanEnd?: (cursorDate: Date | null) => void;
+  onPanCancel?: () => void;
 }): ChartPaintSource {
   const frame = (): ChartPaintFrame | null => {
     const paintState = engine.getPaintState(width);
@@ -517,45 +523,63 @@ export function createCompositePanelPaintSource({
         }
       : null;
   };
-  let scrollPosition = 0;
+  let panPosition = 0;
+  let lastCursorDate: Date | null | undefined;
   let scrollPanning = false;
+  const endPan = () => {
+    const cursorDate = lastCursorDate ?? engine.getSnapshot().scene?.cursorDate ?? null;
+    lastCursorDate = undefined;
+    engine.endPixelPan();
+    onPanEnd?.(cursorDate);
+  };
   const endScrollPan = () => {
     if (!scrollPanning) return;
     scrollPanning = false;
-    scrollPosition = 0;
-    const cursorDate = engine.getSnapshot().scene?.cursorDate ?? null;
-    engine.endPixelPan();
-    onScrollPanEnd?.(cursorDate);
+    endPan();
   };
   return {
     getFrame: frame,
+    getViewportSize: () => ({ width, height }),
     subscribe: engine.subscribeFrame,
     pointerDown(input: ChartPointerInput): boolean {
       if (!interactive || input.shift || input.alt || input.ctrl) return false;
       endScrollPan();
       const accepted = engine.beginPixelPan(input.x, width);
-      if (accepted) onActivate?.();
+      if (accepted) {
+        panPosition = input.x;
+        lastCursorDate = undefined;
+        onActivate?.();
+      }
       return accepted;
     },
-    pointerMove: (input) => engine.movePixelPan(input.x),
-    pointerUp: () => engine.endPixelPan(),
-    pointerCancel: () => engine.cancelPixelPan(),
+    pointerMove(input) {
+      panPosition = input.x;
+      engine.movePixelPan(input.x);
+    },
+    pointerUp: endPan,
+    pointerCancel() {
+      lastCursorDate = undefined;
+      engine.cancelPixelPan();
+      onPanCancel?.();
+    },
     scrollPan(deltaPixels: number): boolean {
       if (!interactive || !Number.isFinite(deltaPixels) || deltaPixels === 0) return false;
       if (!scrollPanning) {
         if (engine.isDragging() || !engine.beginPixelPan(0, width)) return false;
         scrollPanning = true;
-        scrollPosition = 0;
+        panPosition = 0;
+        lastCursorDate = undefined;
         onActivate?.();
       }
-      scrollPosition -= deltaPixels;
-      engine.movePixelPan(scrollPosition);
+      panPosition -= deltaPixels;
+      engine.movePixelPan(panPosition);
       return true;
     },
-    scrollPanFrame(input) {
-      const scene = engine.refreshPixelPanState(scrollPosition, input.x);
-      onScrollPanFrame?.(
-        scene?.cursorDate ?? null,
+    panFrame(input) {
+      const scene = engine.refreshPixelPanState(panPosition, input.x);
+      lastCursorDate = scene?.cursorDate ?? null;
+      onPanFrame?.(
+        scene,
         Math.max(0, Math.min(1, input.y / Math.max(height - 1, 1))),
       );
     },

--- a/src/components/chart/composite/painter.ts
+++ b/src/components/chart/composite/painter.ts
@@ -1,0 +1,330 @@
+import type { ChartPaintPoint, ChartPainter } from "../core/painter";
+import {
+  buildCompositeColumnLayout,
+  type CompositeColumnGroupCenter,
+  type CompositeColumnLayout,
+} from "./column-layout";
+import { projectCompositeValue } from "./scene";
+import type {
+  CompositeAxisDomain,
+  CompositeChartColors,
+  CompositePanelScene,
+  CompositeProjectedPoint,
+  CompositeProjectedSeries,
+} from "./types";
+
+const clamp = (value: number, minimum: number, maximum: number) => (
+  Math.max(minimum, Math.min(maximum, value))
+);
+
+function pixelPoint(
+  point: CompositeProjectedPoint,
+  width: number,
+  height: number,
+): ChartPaintPoint {
+  return {
+    x: clamp(point.xRatio * Math.max(width - 1, 0), 0, Math.max(width - 1, 0)),
+    y: clamp(point.yRatio * Math.max(height - 1, 0), 0, Math.max(height - 1, 0)),
+  };
+}
+
+function pixelY(value: number, domain: CompositeAxisDomain, height: number): number | null {
+  const ratio = projectCompositeValue(value, domain);
+  return ratio === null
+    ? null
+    : clamp(ratio * Math.max(height - 1, 0), 0, Math.max(height - 1, 0));
+}
+
+function connectedRuns(
+  series: CompositeProjectedSeries,
+  width: number,
+  height: number,
+): ChartPaintPoint[][] {
+  const runs: ChartPaintPoint[][] = [];
+  series.points.forEach((point, index) => {
+    if (index === 0 || point.breakBefore || runs.length === 0) runs.push([]);
+    runs.at(-1)!.push(pixelPoint(point, width, height));
+  });
+  return runs;
+}
+
+function paintConnectedSeries(
+  painter: ChartPainter,
+  width: number,
+  height: number,
+  series: CompositeProjectedSeries,
+  domain: CompositeAxisDomain,
+  area: boolean,
+): void {
+  const runs = connectedRuns(series, width, height);
+  const baseline = pixelY(0, domain, height) ?? height - 1;
+  const step = series.source.style === "step" || series.source.interpolation === "step-after";
+  const lineWidth = step ? 1.4 : 1.5;
+
+  for (const run of runs) {
+    if (run.length === 1) {
+      painter.circle(run[0]!.x, run[0]!.y, 2.2, series.source.color);
+      continue;
+    }
+    if (area) painter.area(run, baseline, series.source.color, 0.14, step);
+    painter.path(run, series.source.color, lineWidth, step);
+  }
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1]! + sorted[middle]!) / 2
+    : sorted[middle]!;
+}
+
+function ratioGaps(ratios: readonly number[], pixelWidth: number): number[] {
+  const xs = ratios
+    .map((ratio) => ratio * Math.max(pixelWidth - 1, 0))
+    .sort((left, right) => left - right);
+  const positiveGaps: number[] = [];
+  for (let index = 1; index < xs.length; index += 1) {
+    const gap = xs[index]! - xs[index - 1]!;
+    if (gap > 0) positiveGaps.push(gap);
+  }
+  return positiveGaps;
+}
+
+export function resolveCompositeObservationWidth(
+  points: CompositeProjectedPoint[],
+  extent: number,
+  minimum: number,
+  maximum: number,
+): number {
+  const typicalGap = median(ratioGaps(points.map((point) => point.xRatio), extent));
+  return clamp(typicalGap === null ? maximum : typicalGap * 0.58, minimum, maximum);
+}
+
+function columnObservationWidth(
+  ratios: readonly number[],
+  pixelWidth: number,
+  maximum: number,
+): number {
+  const typicalGap = median(ratioGaps(ratios, pixelWidth));
+  return clamp(typicalGap === null ? maximum : typicalGap * 0.58, 2, maximum);
+}
+
+function columnCenterGaps(
+  centers: readonly CompositeColumnGroupCenter[],
+  pixelWidth: number,
+): number[] {
+  const scale = Math.max(pixelWidth - 1, 0);
+  const positiveGaps: number[] = [];
+  for (let index = 1; index < centers.length; index += 1) {
+    const previous = centers[index - 1]!;
+    const current = centers[index]!;
+    const ordinalGap = previous.ordinal !== null
+      && current.ordinal !== null
+      && current.ordinal > previous.ordinal
+      ? current.ordinal - previous.ordinal
+      : 1;
+    const gap = (current.xRatio - previous.xRatio) * scale / ordinalGap;
+    if (gap > 0) positiveGaps.push(gap);
+  }
+  return positiveGaps;
+}
+
+function columnWidthFromCenters(
+  centers: readonly CompositeColumnGroupCenter[],
+  pixelWidth: number,
+  maximum: number,
+): number {
+  const typicalGap = median(columnCenterGaps(centers, pixelWidth));
+  return clamp(typicalGap === null ? maximum : typicalGap * 0.58, 2, maximum);
+}
+
+function maximumColumnClusterWidth(pixelWidth: number, seriesCount: number): number {
+  return clamp(pixelWidth * 0.04, 18, 72) * Math.max(1, seriesCount);
+}
+
+export function resolveCompositeColumnWidth(
+  points: CompositeProjectedPoint[],
+  pixelWidth: number,
+): number {
+  const maximum = clamp(pixelWidth * 0.04, 18, 72);
+  return columnObservationWidth(points.map((point) => point.xRatio), pixelWidth, maximum);
+}
+
+export function resolveCompositeOhlcWidth(
+  points: CompositeProjectedPoint[],
+  pixelWidth: number,
+): number {
+  const maximum = clamp(pixelWidth * 0.03, 12, 36);
+  return resolveCompositeObservationWidth(points, pixelWidth, 2, maximum);
+}
+
+function columnPixelGeometry(
+  projected: CompositeProjectedPoint,
+  width: number,
+  layout: CompositeColumnLayout,
+  widthByFamily: ReadonlyMap<string, number>,
+): { x: number; width: number } {
+  const group = layout.groupByPoint.get(projected) ?? {
+    index: 0,
+    count: 1,
+    xRatio: projected.xRatio,
+    familyKey: "",
+  };
+  const maximum = maximumColumnClusterWidth(width, group.count);
+  const clusterWidth = widthByFamily.get(group.familyKey) ?? maximum;
+  const drawableWidth = Math.min(clusterWidth, Math.max(width - 1, 1));
+  const slotWidth = drawableWidth / group.count;
+  const groupCenter = clamp(
+    group.xRatio * Math.max(width - 1, 0),
+    0,
+    Math.max(width - 1, 0),
+  );
+  const clusterLeft = clamp(
+    groupCenter - drawableWidth / 2,
+    0,
+    Math.max(width - 1 - drawableWidth, 0),
+  );
+  return {
+    x: clusterLeft + slotWidth * (group.index + 0.5),
+    width: group.count === 1 ? slotWidth : slotWidth * 0.78,
+  };
+}
+
+function paintColumns(
+  painter: ChartPainter,
+  width: number,
+  height: number,
+  series: CompositeProjectedSeries,
+  domain: CompositeAxisDomain,
+  layout: CompositeColumnLayout,
+  widthByFamily: ReadonlyMap<string, number>,
+  opacity: number,
+): void {
+  const baseline = pixelY(0, domain, height) ?? height - 1;
+  for (const projected of series.points) {
+    const point = pixelPoint(projected, width, height);
+    const geometry = columnPixelGeometry(projected, width, layout, widthByFamily);
+    painter.fillRect(
+      geometry.x - geometry.width / 2,
+      Math.min(point.y, baseline),
+      geometry.x + geometry.width / 2,
+      Math.max(point.y, baseline),
+      series.source.color,
+      opacity,
+    );
+  }
+}
+
+function paintOhlc(
+  painter: ChartPainter,
+  width: number,
+  height: number,
+  series: CompositeProjectedSeries,
+  domain: CompositeAxisDomain,
+  negative: string,
+): void {
+  const candleWidth = resolveCompositeOhlcWidth(series.points, width);
+  const halfWidth = Math.min(candleWidth / 2, Math.max(width - 1, 0) / 2);
+  for (const projected of series.points) {
+    const source = projected.point;
+    const x = clamp(
+      pixelPoint(projected, width, height).x,
+      halfWidth,
+      Math.max(width - 1 - halfWidth, halfWidth),
+    );
+    const close = source.close ?? projected.value;
+    const open = source.open ?? close;
+    const high = source.high ?? Math.max(open, close);
+    const low = source.low ?? Math.min(open, close);
+    const highY = pixelY(high, domain, height);
+    const lowY = pixelY(low, domain, height);
+    const openY = pixelY(open, domain, height);
+    const closeY = pixelY(close, domain, height);
+    if (highY === null || lowY === null || closeY === null) continue;
+    const color = close >= open ? series.source.color : negative;
+    painter.line(x, highY, x, lowY, color, 1.1);
+    if (series.source.style === "candles" && openY !== null) {
+      painter.fillRect(
+        x - halfWidth,
+        Math.min(openY, closeY),
+        x + halfWidth,
+        Math.max(openY, closeY) + 1,
+        color,
+      );
+      continue;
+    }
+    if (series.source.style === "ohlc" && openY !== null) {
+      painter.line(x - halfWidth, openY, x, openY, color, 1.2);
+    }
+    painter.line(x, closeY, x + halfWidth, closeY, color, 1.2);
+  }
+}
+
+export function paintCompositePanel(
+  painter: ChartPainter,
+  panel: CompositePanelScene,
+  colors: CompositeChartColors,
+  width: number,
+  height: number,
+): void {
+  painter.clear(colors.background);
+  for (let index = 1; index <= 3; index += 1) {
+    const y = (height - 1) * (index / 4);
+    painter.fillRect(0, y, width - 1, y + 0.6, colors.grid, 0.42);
+  }
+
+  const ordered = [...panel.series].sort((left, right) => {
+    const rank = (style: string) => style === "area" || style === "columns" ? 0 : 1;
+    return rank(left.source.style) - rank(right.source.style);
+  });
+  const columnLayout = buildCompositeColumnLayout(panel);
+  const columnWidthByFamily = new Map<string, number>();
+  for (const [family, centers] of columnLayout.centersByFamily) {
+    const maximum = maximumColumnClusterWidth(
+      width,
+      columnLayout.seriesCountByFamily.get(family) ?? 1,
+    );
+    columnWidthByFamily.set(family, columnWidthFromCenters(centers, width, maximum));
+  }
+  const mixesColumnsWithOtherMarks = panel.series.some((series) => series.source.style === "columns")
+    && panel.series.some((series) => series.source.style !== "columns");
+
+  for (const series of ordered) {
+    const domain = panel.axes[series.source.axis];
+    if (!domain) continue;
+    switch (series.source.style) {
+      case "columns":
+        paintColumns(
+          painter,
+          width,
+          height,
+          series,
+          domain,
+          columnLayout,
+          columnWidthByFamily,
+          mixesColumnsWithOtherMarks ? 0.48 : 0.72,
+        );
+        break;
+      case "area":
+        paintConnectedSeries(painter, width, height, series, domain, true);
+        break;
+      case "points":
+        for (const point of series.points) {
+          const projected = pixelPoint(point, width, height);
+          painter.circle(projected.x, projected.y, 2.4, series.source.color);
+        }
+        break;
+      case "candles":
+      case "ohlc":
+      case "hlc":
+        paintOhlc(painter, width, height, series, domain, colors.negative);
+        break;
+      case "line":
+      case "step":
+        paintConnectedSeries(painter, width, height, series, domain, false);
+        break;
+    }
+  }
+}

--- a/src/components/chart/composite/rasterizer.ts
+++ b/src/components/chart/composite/rasterizer.ts
@@ -7,19 +7,9 @@ import {
   parseHex,
   type RgbaColor,
 } from "../native/raster/primitives";
-import {
-  buildCompositeColumnLayout,
-  type CompositeColumnGroupCenter,
-  type CompositeColumnLayout,
-} from "./column-layout";
-import { projectCompositeValue } from "./scene";
-import type {
-  CompositeAxisDomain,
-  CompositeChartColors,
-  CompositePanelScene,
-  CompositeProjectedPoint,
-  CompositeProjectedSeries,
-} from "./types";
+import type { ChartPaintPoint, ChartPainter } from "../core/painter";
+import { paintCompositePanel } from "./painter";
+import type { CompositeChartColors, CompositePanelScene } from "./types";
 
 interface RenderCompositePanelBitmapOptions {
   pixelWidth: number;
@@ -27,264 +17,117 @@ interface RenderCompositePanelBitmapOptions {
   colors: CompositeChartColors;
 }
 
-const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+class BitmapCompositePainter implements ChartPainter {
+  private readonly colors = new Map<string, RgbaColor>();
 
-function pixelPoint(point: CompositeProjectedPoint, width: number, height: number): { x: number; y: number } {
-  return {
-    x: clamp(point.xRatio * Math.max(width - 1, 0), 0, Math.max(width - 1, 0)),
-    y: clamp(point.yRatio * Math.max(height - 1, 0), 0, Math.max(height - 1, 0)),
-  };
-}
+  constructor(
+    private readonly data: Uint8Array,
+    private readonly width: number,
+    private readonly height: number,
+  ) {}
 
-function pixelY(value: number, domain: CompositeAxisDomain, height: number): number | null {
-  const ratio = projectCompositeValue(value, domain);
-  return ratio === null ? null : clamp(ratio * Math.max(height - 1, 0), 0, Math.max(height - 1, 0));
-}
+  private color(value: string): RgbaColor {
+    const cached = this.colors.get(value);
+    if (cached) return cached;
+    const parsed = parseHex(value);
+    this.colors.set(value, parsed);
+    return parsed;
+  }
 
-function drawConnectedSeries(
-  data: Uint8Array,
-  width: number,
-  height: number,
-  series: CompositeProjectedSeries,
-  domain: CompositeAxisDomain,
-  color: RgbaColor,
-  area: boolean,
-): void {
-  const points = series.points.map((point) => pixelPoint(point, width, height));
-  if (points.length === 0) return;
-  const baseline = pixelY(0, domain, height) ?? height - 1;
-  const step = series.source.style === "step" || series.source.interpolation === "step-after";
+  clear(color: string): void {
+    fillOpaque(this.data, this.color(color));
+  }
 
-  for (let index = 1; index < points.length; index += 1) {
-    const previous = points[index - 1]!;
-    const current = points[index]!;
-    if (series.points[index]?.breakBefore) continue;
-    if (area) {
+  fillRect(
+    left: number,
+    top: number,
+    right: number,
+    bottom: number,
+    color: string,
+    opacity = 1,
+  ): void {
+    fillRect(
+      this.data,
+      this.width,
+      this.height,
+      left,
+      top,
+      right,
+      bottom,
+      this.color(color),
+      opacity,
+    );
+  }
+
+  line(
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number,
+    color: string,
+    width: number,
+  ): void {
+    drawLine(
+      this.data,
+      this.width,
+      this.height,
+      x0,
+      y0,
+      x1,
+      y1,
+      this.color(color),
+      width,
+    );
+  }
+
+  path(
+    points: readonly ChartPaintPoint[],
+    color: string,
+    width: number,
+    step: boolean,
+  ): void {
+    for (let index = 1; index < points.length; index += 1) {
+      const previous = points[index - 1]!;
+      const current = points[index]!;
+      if (step) {
+        this.line(previous.x, previous.y, current.x, previous.y, color, width);
+        this.line(current.x, previous.y, current.x, current.y, color, width);
+      } else {
+        this.line(previous.x, previous.y, current.x, current.y, color, width);
+      }
+    }
+  }
+
+  area(
+    points: readonly ChartPaintPoint[],
+    baseline: number,
+    color: string,
+    opacity: number,
+    step: boolean,
+  ): void {
+    for (let index = 1; index < points.length; index += 1) {
+      const previous = points[index - 1]!;
+      const current = points[index]!;
       const left = Math.round(Math.min(previous.x, current.x));
       const right = Math.round(Math.max(previous.x, current.x));
       for (let x = left; x <= right; x += 1) {
         const ratio = right === left ? 0 : (x - left) / (right - left);
         const y = step ? previous.y : previous.y + (current.y - previous.y) * ratio;
-        fillRect(data, width, height, x, Math.min(y, baseline), x, Math.max(y, baseline), color, 0.14);
+        this.fillRect(x, Math.min(y, baseline), x, Math.max(y, baseline), color, opacity);
       }
     }
-    if (step) {
-      drawLine(data, width, height, previous.x, previous.y, current.x, previous.y, color, 1.4);
-      drawLine(data, width, height, current.x, previous.y, current.x, current.y, color, 1.4);
-    } else {
-      drawLine(data, width, height, previous.x, previous.y, current.x, current.y, color, 1.5);
-    }
   }
 
-  // A line segment cannot represent a lone observation (or one isolated by
-  // missing values). Mark only those observations; do not extend them across
-  // time or add markers to normally connected lines.
-  for (let index = 0; index < points.length; index += 1) {
-    const connectedToPrevious = index > 0 && series.points[index]?.breakBefore === false;
-    const connectedToNext = index + 1 < points.length && series.points[index + 1]?.breakBefore === false;
-    if (!connectedToPrevious && !connectedToNext) {
-      const point = points[index]!;
-      drawCircle(data, width, height, point.x, point.y, 2.2, color);
-    }
-  }
-}
-
-function median(values: number[]): number | null {
-  if (values.length === 0) return null;
-  const sorted = [...values].sort((left, right) => left - right);
-  const middle = Math.floor(sorted.length / 2);
-  return sorted.length % 2 === 0
-    ? (sorted[middle - 1]! + sorted[middle]!) / 2
-    : sorted[middle]!;
-}
-
-function ratioGaps(ratios: readonly number[], pixelWidth: number): number[] {
-  const xs = ratios.map((ratio) => ratio * Math.max(pixelWidth - 1, 0)).sort((left, right) => left - right);
-  const positiveGaps: number[] = [];
-  for (let index = 1; index < xs.length; index += 1) {
-    const gap = xs[index]! - xs[index - 1]!;
-    if (gap > 0) positiveGaps.push(gap);
-  }
-  return positiveGaps;
-}
-
-export function resolveCompositeObservationWidth(
-  points: CompositeProjectedPoint[],
-  extent: number,
-  minimum: number,
-  maximum: number,
-): number {
-  const typicalGap = median(ratioGaps(points.map((point) => point.xRatio), extent));
-  return clamp(typicalGap === null ? maximum : typicalGap * 0.58, minimum, maximum);
-}
-
-function columnObservationWidth(
-  ratios: readonly number[],
-  pixelWidth: number,
-  maximum: number,
-): number {
-  const typicalGap = median(ratioGaps(ratios, pixelWidth));
-  return clamp(typicalGap === null ? maximum : typicalGap * 0.58, 2, maximum);
-}
-
-function columnCenterGaps(
-  centers: readonly CompositeColumnGroupCenter[],
-  pixelWidth: number,
-): number[] {
-  const scale = Math.max(pixelWidth - 1, 0);
-  const positiveGaps: number[] = [];
-  for (let index = 1; index < centers.length; index += 1) {
-    const previous = centers[index - 1]!;
-    const current = centers[index]!;
-    const ordinalGap = previous.ordinal !== null
-      && current.ordinal !== null
-      && current.ordinal > previous.ordinal
-      ? current.ordinal - previous.ordinal
-      : 1;
-    const gap = (current.xRatio - previous.xRatio) * scale / ordinalGap;
-    if (gap > 0) positiveGaps.push(gap);
-  }
-  return positiveGaps;
-}
-
-function columnWidthFromCenters(
-  centers: readonly CompositeColumnGroupCenter[],
-  pixelWidth: number,
-  maximum: number,
-): number {
-  const typicalGap = median(columnCenterGaps(centers, pixelWidth));
-  return clamp(typicalGap === null ? maximum : typicalGap * 0.58, 2, maximum);
-}
-
-function maximumColumnClusterWidth(pixelWidth: number, seriesCount: number): number {
-  const maximumSlotWidth = clamp(pixelWidth * 0.04, 18, 72);
-  return maximumSlotWidth * Math.max(1, seriesCount);
-}
-
-export function resolveCompositeColumnWidth(
-  points: CompositeProjectedPoint[],
-  pixelWidth: number,
-): number {
-  const maximum = clamp(pixelWidth * 0.04, 18, 72);
-  return columnObservationWidth(points.map((point) => point.xRatio), pixelWidth, maximum);
-}
-
-export function resolveCompositeOhlcWidth(
-  points: CompositeProjectedPoint[],
-  pixelWidth: number,
-): number {
-  const maximum = clamp(pixelWidth * 0.03, 12, 36);
-  return resolveCompositeObservationWidth(points, pixelWidth, 2, maximum);
-}
-
-function columnPixelGeometry(
-  projected: CompositeProjectedPoint,
-  width: number,
-  layout: CompositeColumnLayout,
-  widthByFamily: ReadonlyMap<string, number>,
-): { x: number; width: number } {
-  const group = layout.groupByPoint.get(projected) ?? {
-    index: 0,
-    count: 1,
-    xRatio: projected.xRatio,
-    familyKey: "",
-  };
-  const maximum = maximumColumnClusterWidth(width, group.count);
-  const clusterWidth = widthByFamily.get(group.familyKey) ?? maximum;
-  const drawableWidth = Math.min(clusterWidth, Math.max(width - 1, 1));
-  const slotWidth = drawableWidth / group.count;
-  const columnWidth = group.count === 1 ? slotWidth : slotWidth * 0.78;
-  const groupCenter = clamp(
-    group.xRatio * Math.max(width - 1, 0),
-    0,
-    Math.max(width - 1, 0),
-  );
-  const clusterLeft = clamp(
-    groupCenter - drawableWidth / 2,
-    0,
-    Math.max(width - 1 - drawableWidth, 0),
-  );
-  return {
-    x: clusterLeft + slotWidth * (group.index + 0.5),
-    width: columnWidth,
-  };
-}
-
-function drawColumns(
-  data: Uint8Array,
-  width: number,
-  height: number,
-  series: CompositeProjectedSeries,
-  domain: CompositeAxisDomain,
-  color: RgbaColor,
-  layout: CompositeColumnLayout,
-  widthByFamily: ReadonlyMap<string, number>,
-  opacity: number,
-): void {
-  const baseline = pixelY(0, domain, height) ?? height - 1;
-  for (const projected of series.points) {
-    const point = pixelPoint(projected, width, height);
-    const geometry = columnPixelGeometry(projected, width, layout, widthByFamily);
-    fillRect(
-      data,
-      width,
-      height,
-      geometry.x - geometry.width / 2,
-      Math.min(point.y, baseline),
-      geometry.x + geometry.width / 2,
-      Math.max(point.y, baseline),
-      color,
-      opacity,
+  circle(x: number, y: number, radius: number, color: string): void {
+    drawCircle(
+      this.data,
+      this.width,
+      this.height,
+      x,
+      y,
+      radius,
+      this.color(color),
     );
-  }
-}
-
-function drawOhlc(
-  data: Uint8Array,
-  width: number,
-  height: number,
-  series: CompositeProjectedSeries,
-  domain: CompositeAxisDomain,
-  color: RgbaColor,
-  negative: RgbaColor,
-): void {
-  const candleWidth = resolveCompositeOhlcWidth(series.points, width);
-  for (const projected of series.points) {
-    const source = projected.point;
-    const halfWidth = Math.min(candleWidth / 2, Math.max(width - 1, 0) / 2);
-    const x = clamp(
-      pixelPoint(projected, width, height).x,
-      halfWidth,
-      Math.max(width - 1 - halfWidth, halfWidth),
-    );
-    const close = source.close ?? projected.value;
-    const open = source.open ?? close;
-    const high = source.high ?? Math.max(open, close);
-    const low = source.low ?? Math.min(open, close);
-    const highY = pixelY(high, domain, height);
-    const lowY = pixelY(low, domain, height);
-    const openY = pixelY(open, domain, height);
-    const closeY = pixelY(close, domain, height);
-    if (highY === null || lowY === null || closeY === null) continue;
-    const candleColor = close >= open ? color : negative;
-    drawLine(data, width, height, x, highY, x, lowY, candleColor, 1.1);
-    if (series.source.style === "candles" && openY !== null) {
-      fillRect(
-        data,
-        width,
-        height,
-        x - candleWidth / 2,
-        Math.min(openY, closeY),
-        x + candleWidth / 2,
-        Math.max(openY, closeY) + 1,
-        candleColor,
-      );
-      continue;
-    }
-    if (series.source.style === "ohlc" && openY !== null) {
-      drawLine(data, width, height, x - candleWidth / 2, openY, x, openY, candleColor, 1.2);
-    }
-    drawLine(data, width, height, x, closeY, x + candleWidth / 2, closeY, candleColor, 1.2);
   }
 }
 
@@ -294,73 +137,13 @@ export function renderCompositePanelBitmap(
 ): NativeChartBitmap {
   const width = Math.max(1, Math.floor(options.pixelWidth));
   const height = Math.max(1, Math.floor(options.pixelHeight));
-  const data = new Uint8Array(width * height * 4);
-  const background = parseHex(options.colors.background);
-  const grid = parseHex(options.colors.grid);
-  const negative = parseHex(options.colors.negative);
-  fillOpaque(data, background);
-
-  for (let index = 1; index <= 3; index += 1) {
-    const y = (height - 1) * (index / 4);
-    fillRect(data, width, height, 0, y, width - 1, y + 0.6, grid, 0.42);
-  }
-
-  const ordered = [...panel.series].sort((left, right) => {
-    const rank = (style: string) => style === "area" || style === "columns" ? 0 : 1;
-    return rank(left.source.style) - rank(right.source.style);
-  });
-  const columnLayout = buildCompositeColumnLayout(panel);
-  const columnWidthByFamily = new Map<string, number>();
-  for (const [family, centers] of columnLayout.centersByFamily) {
-    const maximumColumnWidth = maximumColumnClusterWidth(
-      width,
-      columnLayout.seriesCountByFamily.get(family) ?? 1,
-    );
-    columnWidthByFamily.set(
-      family,
-      columnWidthFromCenters(centers, width, maximumColumnWidth),
-    );
-  }
-  const mixesColumnsWithOtherMarks = panel.series.some((series) => series.source.style === "columns")
-    && panel.series.some((series) => series.source.style !== "columns");
-  for (const series of ordered) {
-    const domain = panel.axes[series.source.axis];
-    if (!domain) continue;
-    const color = parseHex(series.source.color);
-    switch (series.source.style) {
-      case "columns":
-        drawColumns(
-          data,
-          width,
-          height,
-          series,
-          domain,
-          color,
-          columnLayout,
-          columnWidthByFamily,
-          mixesColumnsWithOtherMarks ? 0.48 : 0.72,
-        );
-        break;
-      case "area":
-        drawConnectedSeries(data, width, height, series, domain, color, true);
-        break;
-      case "points":
-        for (const point of series.points) {
-          const projected = pixelPoint(point, width, height);
-          drawCircle(data, width, height, projected.x, projected.y, 2.4, color);
-        }
-        break;
-      case "candles":
-      case "ohlc":
-      case "hlc":
-        drawOhlc(data, width, height, series, domain, color, negative);
-        break;
-      case "line":
-      case "step":
-        drawConnectedSeries(data, width, height, series, domain, color, false);
-        break;
-    }
-  }
-
-  return { width, height, pixels: data };
+  const pixels = new Uint8Array(width * height * 4);
+  paintCompositePanel(
+    new BitmapCompositePainter(pixels, width, height),
+    panel,
+    options.colors,
+    width,
+    height,
+  );
+  return { width, height, pixels };
 }

--- a/src/components/chart/composite/renderers.test.ts
+++ b/src/components/chart/composite/renderers.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
 import type { CompositePanelScene } from "./types";
+import { renderCompositePanelBitmap } from "./rasterizer";
 import {
-  renderCompositePanelBitmap,
   resolveCompositeColumnWidth,
   resolveCompositeOhlcWidth,
-} from "./rasterizer";
+} from "./painter";
 import { buildCompositeColumnLayout } from "./column-layout";
 import { buildCompositeChartScene, projectCompositeValue } from "./scene";
 import {

--- a/src/components/chart/composite/scene.ts
+++ b/src/components/chart/composite/scene.ts
@@ -472,8 +472,9 @@ export function buildCompositeChartScene(
     const domainSeries = emptyRange
       ? dataSeries.filter((entry) => entry.panelId === panel.id)
       : panelSeries;
-    const left = buildAxisDomain("left", domainSeries, scale);
-    const right = buildAxisDomain("right", domainSeries, scale);
+    const stableDomains = options.axisDomains?.get(panel.id);
+    const left = stableDomains?.left ?? buildAxisDomain("left", domainSeries, scale);
+    const right = stableDomains?.right ?? buildAxisDomain("right", domainSeries, scale);
     const axes: Partial<Record<CompositeAxisSide, CompositeAxisDomain>> = { left, right };
     return [{
       id: panel.id,

--- a/src/components/chart/composite/text-renderer.ts
+++ b/src/components/chart/composite/text-renderer.ts
@@ -1,6 +1,6 @@
 import { compositeAxisTicks } from "./format";
 import type { CompositeViewportRange } from "./interactions";
-import { resolveCompositeObservationWidth } from "./rasterizer";
+import { resolveCompositeObservationWidth } from "./painter";
 import { buildCompositeColumnLayout, type CompositeColumnLayout } from "./column-layout";
 import { projectCompositeValue } from "./scene";
 import {

--- a/src/components/chart/composite/types.ts
+++ b/src/components/chart/composite/types.ts
@@ -109,6 +109,11 @@ export interface BuildCompositeChartSceneOptions {
   };
   /** Authored series order retained even when the primary anchor is hidden. */
   timelineSeries?: ResolvedSeries[];
+  /** Stable value domains retained during direct manipulation. */
+  axisDomains?: ReadonlyMap<
+    string,
+    Partial<Record<CompositeAxisSide, CompositeAxisDomain>>
+  >;
 }
 
 export interface CompositeChartProps {

--- a/src/components/chart/core/painter.ts
+++ b/src/components/chart/core/painter.ts
@@ -65,4 +65,6 @@ export interface ChartPaintSource {
   pointerMove?(input: ChartPointerInput): void;
   pointerUp?(input: ChartPointerInput): void;
   pointerCancel?(): void;
+  scrollPan?(deltaPixels: number): boolean;
+  scrollPanEnd?(): void;
 }

--- a/src/components/chart/core/painter.ts
+++ b/src/components/chart/core/painter.ts
@@ -66,5 +66,6 @@ export interface ChartPaintSource {
   pointerUp?(input: ChartPointerInput): void;
   pointerCancel?(): void;
   scrollPan?(deltaPixels: number): boolean;
+  panFrame?(input: ChartPointerInput): void;
   scrollPanEnd?(): void;
 }

--- a/src/components/chart/core/painter.ts
+++ b/src/components/chart/core/painter.ts
@@ -40,7 +40,10 @@ export interface ChartPainter {
 
 /** A complete chart frame in logical surface pixels. */
 export interface ChartPaintFrame {
+  /** Width of the complete paintable strip. */
   width: number;
+  /** Width of the clipped visible surface. */
+  surfaceWidth: number;
   height: number;
   /** Changes only when pixels must be repainted. */
   revision: number;

--- a/src/components/chart/core/painter.ts
+++ b/src/components/chart/core/painter.ts
@@ -66,6 +66,5 @@ export interface ChartPaintSource {
   pointerUp?(input: ChartPointerInput): void;
   pointerCancel?(): void;
   scrollPan?(deltaPixels: number): boolean;
-  panFrame?(input: ChartPointerInput): void;
   scrollPanEnd?(): void;
 }

--- a/src/components/chart/core/painter.ts
+++ b/src/components/chart/core/painter.ts
@@ -66,5 +66,6 @@ export interface ChartPaintSource {
   pointerUp?(input: ChartPointerInput): void;
   pointerCancel?(): void;
   scrollPan?(deltaPixels: number): boolean;
+  scrollPanFrame?(input: ChartPointerInput): void;
   scrollPanEnd?(): void;
 }

--- a/src/components/chart/core/painter.ts
+++ b/src/components/chart/core/painter.ts
@@ -42,6 +42,10 @@ export interface ChartPainter {
 export interface ChartPaintFrame {
   width: number;
   height: number;
+  /** Changes only when pixels must be repainted. */
+  revision: number;
+  /** Compositor-only horizontal placement inside the clipped chart surface. */
+  offsetX: number;
   paint(painter: ChartPainter): void;
 }
 

--- a/src/components/chart/core/painter.ts
+++ b/src/components/chart/core/painter.ts
@@ -1,0 +1,64 @@
+export interface ChartPaintPoint {
+  x: number;
+  y: number;
+}
+
+/** Renderer-neutral drawing primitives shared by browser and terminal charts. */
+export interface ChartPainter {
+  clear(color: string): void;
+  fillRect(
+    left: number,
+    top: number,
+    right: number,
+    bottom: number,
+    color: string,
+    opacity?: number,
+  ): void;
+  line(
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number,
+    color: string,
+    width: number,
+  ): void;
+  path(
+    points: readonly ChartPaintPoint[],
+    color: string,
+    width: number,
+    step: boolean,
+  ): void;
+  area(
+    points: readonly ChartPaintPoint[],
+    baseline: number,
+    color: string,
+    opacity: number,
+    step: boolean,
+  ): void;
+  circle(x: number, y: number, radius: number, color: string): void;
+}
+
+/** A complete chart frame in logical surface pixels. */
+export interface ChartPaintFrame {
+  width: number;
+  height: number;
+  paint(painter: ChartPainter): void;
+}
+
+export interface ChartPointerInput {
+  x: number;
+  y: number;
+  shift: boolean;
+  alt: boolean;
+  ctrl: boolean;
+}
+
+/** Mutable frame source used by native chart surfaces outside React's render loop. */
+export interface ChartPaintSource {
+  getFrame(): ChartPaintFrame | null;
+  subscribe(listener: () => void): () => void;
+  pointerDown?(input: ChartPointerInput): boolean;
+  pointerMove?(input: ChartPointerInput): void;
+  pointerUp?(input: ChartPointerInput): void;
+  pointerCancel?(): void;
+}

--- a/src/components/chart/core/painter.ts
+++ b/src/components/chart/core/painter.ts
@@ -40,10 +40,7 @@ export interface ChartPainter {
 
 /** A complete chart frame in logical surface pixels. */
 export interface ChartPaintFrame {
-  /** Width of the complete paintable strip. */
   width: number;
-  /** Width of the clipped visible surface. */
-  surfaceWidth: number;
   height: number;
   /** Changes only when pixels must be repainted. */
   revision: number;

--- a/src/components/chart/core/painter.ts
+++ b/src/components/chart/core/painter.ts
@@ -60,12 +60,13 @@ export interface ChartPointerInput {
 /** Mutable frame source used by native chart surfaces outside React's render loop. */
 export interface ChartPaintSource {
   getFrame(): ChartPaintFrame | null;
+  getViewportSize(): { width: number; height: number };
   subscribe(listener: () => void): () => void;
   pointerDown?(input: ChartPointerInput): boolean;
   pointerMove?(input: ChartPointerInput): void;
   pointerUp?(input: ChartPointerInput): void;
   pointerCancel?(): void;
   scrollPan?(deltaPixels: number): boolean;
-  scrollPanFrame?(input: ChartPointerInput): void;
+  panFrame?(input: ChartPointerInput): void;
   scrollPanEnd?(): void;
 }

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -87,6 +87,9 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
   });
   const listeners = new Set<() => void>();
   const pointerXs: number[] = [];
+  const scrollDeltas: number[] = [];
+  let scrollEnds = 0;
+  let genericScrolls = 0;
   let revision = 1;
   let offsetX = 0;
   const container = testWindow.document.createElement("div");
@@ -117,7 +120,13 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
             },
             pointerMove: (input) => pointerXs.push(input.x),
             pointerUp: (input) => pointerXs.push(input.x),
+            scrollPan: (delta) => {
+              scrollDeltas.push(delta);
+              return true;
+            },
+            scrollPanEnd: () => scrollEnds += 1,
           }}
+          onMouseScroll={() => genericScrolls += 1}
         />,
       );
     });
@@ -151,6 +160,34 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
       mouse("mouseup", testWindow.document, 11);
     });
     expect(pointerXs).toEqual([10, 11, 11]);
+
+    const firstWheel = new testWindow.WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaX: 24,
+      deltaY: 1,
+    });
+    const secondWheel = new testWindow.WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaX: 2,
+      deltaY: 40,
+    });
+    expect(canvas.dispatchEvent(firstWheel as never)).toBe(false);
+    expect(canvas.dispatchEvent(secondWheel as never)).toBe(false);
+    expect(scrollDeltas).toEqual([24, 2]);
+    expect(genericScrolls).toBe(0);
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 150)));
+    expect(scrollEnds).toBe(1);
+
+    const controlWheel = new testWindow.WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: -4,
+    });
+    Object.defineProperty(controlWheel, "ctrlKey", { value: true });
+    canvas.dispatchEvent(controlWheel as never);
+    expect(genericScrolls).toBe(1);
   } finally {
     await act(async () => root.unmount());
     canvasPrototype.getContext = originalGetContext;

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -88,6 +88,7 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
   const listeners = new Set<() => void>();
   const pointerXs: number[] = [];
   let revision = 1;
+  let width = 320;
   let offsetX = 0;
   const container = testWindow.document.createElement("div");
   testWindow.document.body.appendChild(container);
@@ -101,7 +102,8 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
           height={10}
           paintSource={{
             getFrame: () => ({
-              width: 320,
+              width,
+              surfaceWidth: 320,
               height: 180,
               revision,
               offsetX,
@@ -132,9 +134,28 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
     listeners.forEach((listener) => listener());
     expect(canvas.style.transform).toBe("translate3d(12px, 0, 0)");
     expect(fillRects).toHaveLength(1);
+    width = 960;
+    offsetX = -320;
     revision = 2;
     listeners.forEach((listener) => listener());
-    expect(fillRects).toHaveLength(2);
+    const tiles = [...container.querySelectorAll("canvas")];
+    expect(tiles).toHaveLength(3);
+    expect(tiles.map((tile) => tile.width)).toEqual([320, 320, 320]);
+    expect(tiles.map((tile) => tile.style.transform)).toEqual([
+      "translate3d(-320px, 0, 0)",
+      "translate3d(0px, 0, 0)",
+      "translate3d(320px, 0, 0)",
+    ]);
+    expect(fillRects).toHaveLength(4);
+
+    offsetX = -308;
+    listeners.forEach((listener) => listener());
+    expect(tiles.map((tile) => tile.style.transform)).toEqual([
+      "translate3d(-308px, 0, 0)",
+      "translate3d(12px, 0, 0)",
+      "translate3d(332px, 0, 0)",
+    ]);
+    expect(fillRects).toHaveLength(4);
 
     const pointer = (type: string, clientX: number) => canvas.dispatchEvent(
       new testWindow.PointerEvent(type, {

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -88,7 +88,6 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
   const listeners = new Set<() => void>();
   const pointerXs: number[] = [];
   const scrollDeltas: number[] = [];
-  const panFrameXs: number[] = [];
   let scrollEnds = 0;
   let genericScrolls = 0;
   let revision = 1;
@@ -125,7 +124,6 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
               scrollDeltas.push(delta);
               return true;
             },
-            panFrame: (input) => panFrameXs.push(input.x),
             scrollPanEnd: () => scrollEnds += 1,
           }}
           onMouseScroll={() => genericScrolls += 1}
@@ -162,34 +160,24 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
       mouse("mouseup", testWindow.document, 11);
     });
     expect(pointerXs).toEqual([10, 11, 11]);
-    expect(panFrameXs).toEqual([11]);
 
     const firstWheel = new testWindow.WheelEvent("wheel", {
       bubbles: true,
       cancelable: true,
-      clientX: 12,
-      clientY: 5,
       deltaX: 24,
       deltaY: 1,
     });
     const secondWheel = new testWindow.WheelEvent("wheel", {
       bubbles: true,
       cancelable: true,
-      clientX: 12,
-      clientY: 5,
       deltaX: 2,
       deltaY: 40,
-    });
-    Object.defineProperties(secondWheel, {
-      clientX: { value: 12 },
-      clientY: { value: 5 },
     });
     expect(canvas.dispatchEvent(firstWheel as never)).toBe(false);
     expect(canvas.dispatchEvent(secondWheel as never)).toBe(false);
     expect(scrollDeltas).toEqual([24, 2]);
     expect(genericScrolls).toBe(0);
     await act(async () => new Promise((resolve) => setTimeout(resolve, 150)));
-    expect(panFrameXs).toEqual([11, 12]);
     expect(scrollEnds).toBe(1);
 
     const controlWheel = new testWindow.WheelEvent("wheel", {

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -88,6 +88,7 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
   const listeners = new Set<() => void>();
   const pointerXs: number[] = [];
   const scrollDeltas: number[] = [];
+  const scrollFrameXs: number[] = [];
   let scrollEnds = 0;
   let genericScrolls = 0;
   let revision = 1;
@@ -124,6 +125,7 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
               scrollDeltas.push(delta);
               return true;
             },
+            scrollPanFrame: (input) => scrollFrameXs.push(input.x),
             scrollPanEnd: () => scrollEnds += 1,
           }}
           onMouseScroll={() => genericScrolls += 1}
@@ -173,11 +175,16 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
       deltaX: 2,
       deltaY: 40,
     });
+    Object.defineProperties(secondWheel, {
+      clientX: { value: 12 },
+      clientY: { value: 5 },
+    });
     expect(canvas.dispatchEvent(firstWheel as never)).toBe(false);
     expect(canvas.dispatchEvent(secondWheel as never)).toBe(false);
     expect(scrollDeltas).toEqual([24, 2]);
     expect(genericScrolls).toBe(0);
     await act(async () => new Promise((resolve) => setTimeout(resolve, 150)));
+    expect(scrollFrameXs).toEqual([12]);
     expect(scrollEnds).toBe(1);
 
     const controlWheel = new testWindow.WheelEvent("wheel", {

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -88,7 +88,6 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
   const listeners = new Set<() => void>();
   const pointerXs: number[] = [];
   let revision = 1;
-  let width = 320;
   let offsetX = 0;
   const container = testWindow.document.createElement("div");
   testWindow.document.body.appendChild(container);
@@ -102,8 +101,7 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
           height={10}
           paintSource={{
             getFrame: () => ({
-              width,
-              surfaceWidth: 320,
+              width: 320,
               height: 180,
               revision,
               offsetX,
@@ -134,28 +132,9 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
     listeners.forEach((listener) => listener());
     expect(canvas.style.transform).toBe("translate3d(12px, 0, 0)");
     expect(fillRects).toHaveLength(1);
-    width = 960;
-    offsetX = -320;
     revision = 2;
     listeners.forEach((listener) => listener());
-    const tiles = [...container.querySelectorAll("canvas")];
-    expect(tiles).toHaveLength(3);
-    expect(tiles.map((tile) => tile.width)).toEqual([320, 320, 320]);
-    expect(tiles.map((tile) => tile.style.transform)).toEqual([
-      "translate3d(-320px, 0, 0)",
-      "translate3d(0px, 0, 0)",
-      "translate3d(320px, 0, 0)",
-    ]);
-    expect(fillRects).toHaveLength(4);
-
-    offsetX = -308;
-    listeners.forEach((listener) => listener());
-    expect(tiles.map((tile) => tile.style.transform)).toEqual([
-      "translate3d(-308px, 0, 0)",
-      "translate3d(12px, 0, 0)",
-      "translate3d(332px, 0, 0)",
-    ]);
-    expect(fillRects).toHaveLength(4);
+    expect(fillRects).toHaveLength(2);
 
     const pointer = (type: string, clientX: number) => canvas.dispatchEvent(
       new testWindow.PointerEvent(type, {

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -11,6 +11,8 @@ Object.assign(globalThis, {
   MouseEvent: testWindow.MouseEvent,
   Event: testWindow.Event,
   HTMLElement: testWindow.HTMLElement,
+  HTMLInputElement: testWindow.HTMLInputElement,
+  HTMLTextAreaElement: testWindow.HTMLTextAreaElement,
   Node: testWindow.Node,
   requestAnimationFrame: (callback: (time: number) => void) => setTimeout(() => callback(Date.now()), 8),
   cancelAnimationFrame: (id: number) => clearTimeout(id),
@@ -69,6 +71,79 @@ test("reports a drag as a drag, never as a move, and keeps its modifiers", async
 
   expect(seen).toEqual(["move", "down", "drag", "up"]);
   expect(modifiers.every((entry) => entry.shift)).toBe(true);
+});
+
+test("desktop charts paint renderer-neutral frames through canvas", async () => {
+  const fillRects: number[][] = [];
+  const canvasPrototype = testWindow.HTMLCanvasElement.prototype as unknown as {
+    getContext: (...args: unknown[]) => unknown;
+  };
+  const originalGetContext = canvasPrototype.getContext;
+  canvasPrototype.getContext = () => ({
+    globalAlpha: 1,
+    fillStyle: "",
+    setTransform: () => {},
+    fillRect: (...values: number[]) => fillRects.push(values),
+  });
+  const listeners = new Set<() => void>();
+  const pointerXs: number[] = [];
+  const container = testWindow.document.createElement("div");
+  testWindow.document.body.appendChild(container);
+  const root = createRoot(container as unknown as HTMLElement);
+
+  try {
+    await act(async () => {
+      root.render(
+        <WebChartSurface
+          width={40}
+          height={10}
+          paintSource={{
+            getFrame: () => ({
+              width: 320,
+              height: 180,
+              paint: (painter) => painter.clear("#101010"),
+            }),
+            subscribe: (listener) => {
+              listeners.add(listener);
+              return () => listeners.delete(listener);
+            },
+            pointerDown: (input) => {
+              pointerXs.push(input.x);
+              return true;
+            },
+            pointerMove: (input) => pointerXs.push(input.x),
+            pointerUp: (input) => pointerXs.push(input.x),
+          }}
+        />,
+      );
+    });
+
+    const canvas = container.querySelector("canvas") as unknown as HTMLCanvasElement;
+    expect(canvas.width).toBe(320);
+    expect(canvas.height).toBe(180);
+    expect(fillRects).toEqual([[0, 0, 320, 180]]);
+    expect(listeners.size).toBe(1);
+
+    const pointer = (type: string, clientX: number) => canvas.dispatchEvent(
+      new testWindow.PointerEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        clientX,
+        clientY: 20,
+        pointerId: 7,
+      }) as never,
+    );
+    await act(async () => {
+      pointer("pointerdown", 10);
+      pointer("pointermove", 11);
+      pointer("pointerup", 11);
+    });
+    expect(pointerXs).toEqual([10, 11, 11]);
+  } finally {
+    await act(async () => root.unmount());
+    canvasPrototype.getContext = originalGetContext;
+  }
 });
 
 test("chart surfaces consume browser pan and zoom gestures", async () => {

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -142,11 +142,6 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
     expect(canvas.height).toBe(180);
     expect(fillRects).toEqual([[0, 0, 320, 180]]);
     expect(listeners.size).toBe(1);
-    const verticalCrosshair = [...container.querySelectorAll("div")].find((element) => (
-      element.style.width === "1px" && element.style.bottom === "0px"
-    ));
-    expect(parseFloat(verticalCrosshair!.style.left)).toBeCloseTo((20 / 39) * 100, 6);
-
     offsetX = 12;
     listeners.forEach((listener) => listener());
     expect(canvas.style.transform).toBe("translate3d(12px, 0, 0)");
@@ -167,8 +162,9 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
     await act(async () => {
       mouse("mousedown", canvas, 10);
       mouse("mousemove", testWindow.document, 11);
-      mouse("mouseup", testWindow.document, 11);
     });
+    expect(canvas.parentElement!.style.getPropertyValue("--gloom-chart-pan-x")).toBe("11px");
+    await act(async () => mouse("mouseup", testWindow.document, 11));
     expect(pointerXs).toEqual([10, 11, 11]);
     expect(panFrameXs).toEqual([11]);
     expect(genericDrags).toBe(0);

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -87,6 +87,8 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
   });
   const listeners = new Set<() => void>();
   const pointerXs: number[] = [];
+  let revision = 1;
+  let offsetX = 0;
   const container = testWindow.document.createElement("div");
   testWindow.document.body.appendChild(container);
   const root = createRoot(container as unknown as HTMLElement);
@@ -101,6 +103,8 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
             getFrame: () => ({
               width: 320,
               height: 180,
+              revision,
+              offsetX,
               paint: (painter) => painter.clear("#101010"),
             }),
             subscribe: (listener) => {
@@ -123,6 +127,14 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
     expect(canvas.height).toBe(180);
     expect(fillRects).toEqual([[0, 0, 320, 180]]);
     expect(listeners.size).toBe(1);
+
+    offsetX = 12;
+    listeners.forEach((listener) => listener());
+    expect(canvas.style.transform).toBe("translate3d(12px, 0, 0)");
+    expect(fillRects).toHaveLength(1);
+    revision = 2;
+    listeners.forEach((listener) => listener());
+    expect(fillRects).toHaveLength(2);
 
     const pointer = (type: string, clientX: number) => canvas.dispatchEvent(
       new testWindow.PointerEvent(type, {

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -136,20 +136,19 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
     listeners.forEach((listener) => listener());
     expect(fillRects).toHaveLength(2);
 
-    const pointer = (type: string, clientX: number) => canvas.dispatchEvent(
-      new testWindow.PointerEvent(type, {
+    const mouse = (type: string, target: EventTarget, clientX: number) => target.dispatchEvent(
+      new testWindow.MouseEvent(type, {
         bubbles: true,
         cancelable: true,
         button: 0,
         clientX,
         clientY: 20,
-        pointerId: 7,
       }) as never,
     );
     await act(async () => {
-      pointer("pointerdown", 10);
-      pointer("pointermove", 11);
-      pointer("pointerup", 11);
+      mouse("mousedown", canvas, 10);
+      mouse("mousemove", testWindow.document, 11);
+      mouse("mouseup", testWindow.document, 11);
     });
     expect(pointerXs).toEqual([10, 11, 11]);
   } finally {

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -88,6 +88,7 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
   const listeners = new Set<() => void>();
   const pointerXs: number[] = [];
   const scrollDeltas: number[] = [];
+  const panFrameXs: number[] = [];
   let scrollEnds = 0;
   let genericScrolls = 0;
   let revision = 1;
@@ -124,6 +125,7 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
               scrollDeltas.push(delta);
               return true;
             },
+            panFrame: (input) => panFrameXs.push(input.x),
             scrollPanEnd: () => scrollEnds += 1,
           }}
           onMouseScroll={() => genericScrolls += 1}
@@ -160,24 +162,34 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
       mouse("mouseup", testWindow.document, 11);
     });
     expect(pointerXs).toEqual([10, 11, 11]);
+    expect(panFrameXs).toEqual([11]);
 
     const firstWheel = new testWindow.WheelEvent("wheel", {
       bubbles: true,
       cancelable: true,
+      clientX: 12,
+      clientY: 5,
       deltaX: 24,
       deltaY: 1,
     });
     const secondWheel = new testWindow.WheelEvent("wheel", {
       bubbles: true,
       cancelable: true,
+      clientX: 12,
+      clientY: 5,
       deltaX: 2,
       deltaY: 40,
+    });
+    Object.defineProperties(secondWheel, {
+      clientX: { value: 12 },
+      clientY: { value: 5 },
     });
     expect(canvas.dispatchEvent(firstWheel as never)).toBe(false);
     expect(canvas.dispatchEvent(secondWheel as never)).toBe(false);
     expect(scrollDeltas).toEqual([24, 2]);
     expect(genericScrolls).toBe(0);
     await act(async () => new Promise((resolve) => setTimeout(resolve, 150)));
+    expect(panFrameXs).toEqual([11, 12]);
     expect(scrollEnds).toBe(1);
 
     const controlWheel = new testWindow.WheelEvent("wheel", {

--- a/src/renderers/electrobun/view/host/box.test.tsx
+++ b/src/renderers/electrobun/view/host/box.test.tsx
@@ -88,8 +88,9 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
   const listeners = new Set<() => void>();
   const pointerXs: number[] = [];
   const scrollDeltas: number[] = [];
-  const scrollFrameXs: number[] = [];
+  const panFrameXs: number[] = [];
   let scrollEnds = 0;
+  let genericDrags = 0;
   let genericScrolls = 0;
   let revision = 1;
   let offsetX = 0;
@@ -111,6 +112,7 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
               offsetX,
               paint: (painter) => painter.clear("#101010"),
             }),
+            getViewportSize: () => ({ width: 40, height: 10 }),
             subscribe: (listener) => {
               listeners.add(listener);
               return () => listeners.delete(listener);
@@ -125,9 +127,11 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
               scrollDeltas.push(delta);
               return true;
             },
-            scrollPanFrame: (input) => scrollFrameXs.push(input.x),
+            panFrame: (input) => panFrameXs.push(input.x),
             scrollPanEnd: () => scrollEnds += 1,
           }}
+          crosshair={{ pixelX: 20, pixelY: 5, color: "#ffffff" }}
+          onMouseDrag={() => genericDrags += 1}
           onMouseScroll={() => genericScrolls += 1}
         />,
       );
@@ -138,6 +142,10 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
     expect(canvas.height).toBe(180);
     expect(fillRects).toEqual([[0, 0, 320, 180]]);
     expect(listeners.size).toBe(1);
+    const verticalCrosshair = [...container.querySelectorAll("div")].find((element) => (
+      element.style.width === "1px" && element.style.bottom === "0px"
+    ));
+    expect(parseFloat(verticalCrosshair!.style.left)).toBeCloseTo((20 / 39) * 100, 6);
 
     offsetX = 12;
     listeners.forEach((listener) => listener());
@@ -162,6 +170,8 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
       mouse("mouseup", testWindow.document, 11);
     });
     expect(pointerXs).toEqual([10, 11, 11]);
+    expect(panFrameXs).toEqual([11]);
+    expect(genericDrags).toBe(0);
 
     const firstWheel = new testWindow.WheelEvent("wheel", {
       bubbles: true,
@@ -184,7 +194,7 @@ test("desktop charts paint renderer-neutral frames through canvas", async () => 
     expect(scrollDeltas).toEqual([24, 2]);
     expect(genericScrolls).toBe(0);
     await act(async () => new Promise((resolve) => setTimeout(resolve, 150)));
-    expect(scrollFrameXs).toEqual([12]);
+    expect(panFrameXs).toEqual([11, 12]);
     expect(scrollEnds).toBe(1);
 
     const controlWheel = new testWindow.WheelEvent("wheel", {

--- a/src/renderers/electrobun/view/host/box.tsx
+++ b/src/renderers/electrobun/view/host/box.tsx
@@ -133,7 +133,7 @@ export const WebBox = forwardRef<HTMLDivElement, Record<string, unknown> & { chi
       const hasDirectDrag = typeof propsRef.current.onMouseDrag === "function" || typeof propsRef.current.onMouseDragEnd === "function";
       pendingMoveRef.current = null;
       callMouseHandler(propsRef.current.onMouseDown, event, "down");
-      if (event.button !== 0 || (event.isPropagationStopped() && !hasDirectDrag)) return;
+      if (event.button !== 0 || event.isPropagationStopped()) return;
       if (!hasSyntheticDrag && !hasDirectDrag) return;
       callMouseHandler(propsRef.current.onMouse, event, "down");
       draggingRef.current = true;

--- a/src/renderers/electrobun/view/host/chart-painter.ts
+++ b/src/renderers/electrobun/view/host/chart-painter.ts
@@ -1,0 +1,111 @@
+import type {
+  ChartPaintPoint,
+  ChartPainter,
+} from "../../../../components/chart/core/painter";
+
+export class CanvasChartPainter implements ChartPainter {
+  constructor(
+    private readonly context: CanvasRenderingContext2D,
+    private readonly width: number,
+    private readonly height: number,
+  ) {}
+
+  clear(color: string): void {
+    this.context.globalAlpha = 1;
+    this.context.fillStyle = color;
+    this.context.fillRect(0, 0, this.width, this.height);
+  }
+
+  fillRect(
+    left: number,
+    top: number,
+    right: number,
+    bottom: number,
+    color: string,
+    opacity = 1,
+  ): void {
+    this.context.globalAlpha = opacity;
+    this.context.fillStyle = color;
+    this.context.fillRect(
+      left,
+      top,
+      Math.max(right - left, 1),
+      Math.max(bottom - top, 1),
+    );
+    this.context.globalAlpha = 1;
+  }
+
+  line(
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number,
+    color: string,
+    width: number,
+  ): void {
+    this.context.beginPath();
+    this.context.moveTo(x0, y0);
+    this.context.lineTo(x1, y1);
+    this.context.strokeStyle = color;
+    this.context.lineWidth = width;
+    this.context.lineCap = "round";
+    this.context.stroke();
+  }
+
+  path(
+    points: readonly ChartPaintPoint[],
+    color: string,
+    width: number,
+    step: boolean,
+  ): void {
+    const first = points[0];
+    if (!first) return;
+    this.context.beginPath();
+    this.context.moveTo(first.x, first.y);
+    for (let index = 1; index < points.length; index += 1) {
+      const previous = points[index - 1]!;
+      const current = points[index]!;
+      if (step) this.context.lineTo(current.x, previous.y);
+      this.context.lineTo(current.x, current.y);
+    }
+    this.context.strokeStyle = color;
+    this.context.lineWidth = width;
+    this.context.lineCap = "round";
+    this.context.lineJoin = "round";
+    this.context.stroke();
+  }
+
+  area(
+    points: readonly ChartPaintPoint[],
+    baseline: number,
+    color: string,
+    opacity: number,
+    step: boolean,
+  ): void {
+    const first = points[0];
+    const last = points.at(-1);
+    if (!first || !last) return;
+    this.context.beginPath();
+    this.context.moveTo(first.x, baseline);
+    this.context.lineTo(first.x, first.y);
+    for (let index = 1; index < points.length; index += 1) {
+      const previous = points[index - 1]!;
+      const current = points[index]!;
+      if (step) this.context.lineTo(current.x, previous.y);
+      this.context.lineTo(current.x, current.y);
+    }
+    this.context.lineTo(last.x, baseline);
+    this.context.closePath();
+    this.context.globalAlpha = opacity;
+    this.context.fillStyle = color;
+    this.context.fill();
+    this.context.globalAlpha = 1;
+  }
+
+  circle(x: number, y: number, radius: number, color: string): void {
+    this.context.beginPath();
+    this.context.arc(x, y, radius, 0, Math.PI * 2);
+    this.context.fillStyle = color;
+    this.context.fill();
+  }
+}

--- a/src/renderers/electrobun/view/host/chart-surface.tsx
+++ b/src/renderers/electrobun/view/host/chart-surface.tsx
@@ -49,65 +49,36 @@ const CanvasBitmap = memo(function CanvasBitmap({ bitmap }: { bitmap: BitmapSurf
 });
 
 const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaintSource }) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const pointerIdRef = useRef<number | null>(null);
   const lastPointerXRef = useRef<number | null>(null);
 
   useLayoutEffect(() => {
     let paintedRevision = Number.NaN;
-    const canvases: HTMLCanvasElement[] = [];
     const paint = () => {
-      const container = containerRef.current;
+      const canvas = canvasRef.current;
       const frame = source.getFrame();
-      if (!container || !frame) return;
-      const tileWidth = Math.max(1, frame.surfaceWidth);
-      const tileCount = Math.max(1, Math.ceil(frame.width / tileWidth));
-      while (canvases.length < tileCount) {
-        const canvas = document.createElement("canvas");
-        canvas.style.position = "absolute";
-        canvas.style.left = "0";
-        canvas.style.top = "0";
-        canvas.style.pointerEvents = "none";
-        canvas.style.willChange = "transform";
-        container.appendChild(canvas);
-        canvases.push(canvas);
-      }
-      while (canvases.length > tileCount) canvases.pop()?.remove();
-
-      canvases.forEach((canvas, index) => {
-        const startX = index * tileWidth;
-        const width = Math.min(tileWidth, frame.width - startX);
-        canvas.style.width = `${width}px`;
-        canvas.style.height = `${frame.height}px`;
-        canvas.style.transform = `translate3d(${startX + frame.offsetX}px, 0, 0)`;
-      });
+      if (!canvas || !frame) return;
+      canvas.style.width = `${frame.width}px`;
+      canvas.style.transform = `translate3d(${frame.offsetX}px, 0, 0)`;
       if (paintedRevision === frame.revision) return;
-
       const ratio = Math.min(window.devicePixelRatio || 1, 2);
-      canvases.forEach((canvas, index) => {
-        const startX = index * tileWidth;
-        const width = Math.min(tileWidth, frame.width - startX);
-        const pixelWidth = Math.max(1, Math.round(width * ratio));
-        const pixelHeight = Math.max(1, Math.round(frame.height * ratio));
-        if (canvas.width !== pixelWidth) canvas.width = pixelWidth;
-        if (canvas.height !== pixelHeight) canvas.height = pixelHeight;
-        const context = canvas.getContext("2d");
-        if (!context) return;
-        context.setTransform(ratio, 0, 0, ratio, -startX * ratio, 0);
-        frame.paint(new CanvasChartPainter(context, frame.width, frame.height));
-      });
+      const width = Math.max(1, Math.round(frame.width * ratio));
+      const height = Math.max(1, Math.round(frame.height * ratio));
+      if (canvas.width !== width) canvas.width = width;
+      if (canvas.height !== height) canvas.height = height;
+      const context = canvas.getContext("2d");
+      if (!context) return;
+      context.setTransform(ratio, 0, 0, ratio, 0, 0);
+      frame.paint(new CanvasChartPainter(context, frame.width, frame.height));
       paintedRevision = frame.revision;
     };
     paint();
-    const unsubscribe = source.subscribe(paint);
-    return () => {
-      unsubscribe();
-      for (const canvas of canvases) canvas.remove();
-    };
+    return source.subscribe(paint);
   }, [source]);
 
-  const pointerInput = (event: PointerEvent<HTMLDivElement>): ChartPointerInput => {
-    const bounds = event.currentTarget.getBoundingClientRect();
+  const pointerInput = (event: PointerEvent<HTMLCanvasElement>): ChartPointerInput => {
+    const bounds = (event.currentTarget.parentElement ?? event.currentTarget).getBoundingClientRect();
     return {
       x: event.clientX - bounds.left,
       y: event.clientY - bounds.top,
@@ -116,7 +87,7 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       ctrl: event.ctrlKey || event.metaKey,
     };
   };
-  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+  const handlePointerDown = (event: PointerEvent<HTMLCanvasElement>) => {
     if (event.button !== 0 || !source.pointerDown?.(pointerInput(event))) return;
     pointerIdRef.current = event.pointerId;
     lastPointerXRef.current = event.clientX;
@@ -126,14 +97,14 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
     event.preventDefault();
     event.stopPropagation();
   };
-  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+  const handlePointerMove = (event: PointerEvent<HTMLCanvasElement>) => {
     if (pointerIdRef.current !== event.pointerId) return;
     source.pointerMove?.(pointerInput(event));
     lastPointerXRef.current = event.clientX;
     event.preventDefault();
     event.stopPropagation();
   };
-  const finishPointer = (event: PointerEvent<HTMLDivElement>, cancelled: boolean) => {
+  const finishPointer = (event: PointerEvent<HTMLCanvasElement>, cancelled: boolean) => {
     if (pointerIdRef.current !== event.pointerId) return;
     pointerIdRef.current = null;
     if (event.currentTarget.hasPointerCapture(event.pointerId)) {
@@ -152,8 +123,8 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   };
 
   return (
-    <div
-      ref={containerRef}
+    <canvas
+      ref={canvasRef}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={(event) => finishPointer(event, false)}
@@ -169,8 +140,13 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       }}
       onPointerCancel={(event) => finishPointer(event, true)}
       style={{
+        display: "block",
+        width: "100%",
+        height: "100%",
         position: "absolute",
-        inset: 0,
+        left: 0,
+        top: 0,
+        willChange: "transform",
       }}
     />
   );
@@ -338,10 +314,7 @@ export const WebChartSurface = forwardRef<BoxRenderable, Record<string, unknown>
     const layers = bitmaps ?? (bitmap ? [bitmap] : []);
     const crosshair = (props.crosshair ?? null) as ChartCrosshairOverlay | null;
     const vectors = (props.vectors ?? null) as readonly ChartVectorShape[] | null;
-    const frame = paintSource?.getFrame() ?? null;
-    const surface = frame
-      ? { width: frame.surfaceWidth, height: frame.height }
-      : layers[0] ?? null;
+    const surface = paintSource?.getFrame() ?? layers[0] ?? null;
     return (
       <WebBox
         {...props}

--- a/src/renderers/electrobun/view/host/chart-surface.tsx
+++ b/src/renderers/electrobun/view/host/chart-surface.tsx
@@ -18,6 +18,7 @@ import type {
 } from "../../../../ui/host";
 import { WebBox } from "./box";
 import { CanvasChartPainter } from "./chart-painter";
+import { cancelWebFrame, requestWebFrame } from "./mouse";
 
 const CanvasBitmap = memo(function CanvasBitmap({ bitmap }: { bitmap: BitmapSurface }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -53,6 +54,8 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   const lastMouseXRef = useRef<number | null>(null);
   const scrollEndTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollAxisRef = useRef<"x" | "y" | null>(null);
+  const panFrameRef = useRef<number | null>(null);
+  const latestPanInputRef = useRef<ChartPointerInput | null>(null);
 
   useLayoutEffect(() => {
     let paintedRevision = Number.NaN;
@@ -90,6 +93,24 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
     };
   };
 
+  const flushPanFrame = () => {
+    if (panFrameRef.current !== null) cancelWebFrame(panFrameRef.current);
+    panFrameRef.current = null;
+    const input = latestPanInputRef.current;
+    latestPanInputRef.current = null;
+    if (input) source.panFrame?.(input);
+  };
+  const schedulePanFrame = (input: ChartPointerInput) => {
+    latestPanInputRef.current = input;
+    if (!source.panFrame || panFrameRef.current !== null) return;
+    panFrameRef.current = requestWebFrame(() => {
+      panFrameRef.current = null;
+      const latest = latestPanInputRef.current;
+      latestPanInputRef.current = null;
+      if (latest) source.panFrame?.(latest);
+    });
+  };
+
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas || !source.scrollPan) return;
@@ -97,6 +118,7 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       if (scrollEndTimerRef.current !== null) clearTimeout(scrollEndTimerRef.current);
       scrollEndTimerRef.current = null;
       scrollAxisRef.current = null;
+      flushPanFrame();
       source.scrollPanEnd?.();
     };
     const wheel = (event: globalThis.WheelEvent) => {
@@ -105,6 +127,7 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
         ?? (Math.abs(event.deltaX) > Math.abs(event.deltaY) ? "x" : "y");
       const delta = axis === "x" ? event.deltaX : event.deltaY;
       if (delta === 0 || !source.scrollPan?.(delta)) return;
+      schedulePanFrame(mouseInput(event));
       scrollAxisRef.current = axis;
       if (scrollEndTimerRef.current !== null) clearTimeout(scrollEndTimerRef.current);
       scrollEndTimerRef.current = setTimeout(finish, 120);
@@ -121,7 +144,9 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   useEffect(() => {
     const move = (event: globalThis.MouseEvent) => {
       if (!draggingRef.current) return;
-      source.pointerMove?.(mouseInput(event));
+      const input = mouseInput(event);
+      source.pointerMove?.(input);
+      schedulePanFrame(input);
       lastMouseXRef.current = event.clientX;
       event.preventDefault();
       event.stopPropagation();
@@ -131,6 +156,8 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       draggingRef.current = false;
       const input = mouseInput(event);
       if (lastMouseXRef.current !== event.clientX) source.pointerMove?.(input);
+      latestPanInputRef.current = input;
+      flushPanFrame();
       source.pointerUp?.(input);
       lastMouseXRef.current = null;
       event.preventDefault();
@@ -140,6 +167,9 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       if (!draggingRef.current) return;
       draggingRef.current = false;
       lastMouseXRef.current = null;
+      if (panFrameRef.current !== null) cancelWebFrame(panFrameRef.current);
+      panFrameRef.current = null;
+      latestPanInputRef.current = null;
       source.pointerCancel?.();
     };
     window.addEventListener("mousemove", move, true);

--- a/src/renderers/electrobun/view/host/chart-surface.tsx
+++ b/src/renderers/electrobun/view/host/chart-surface.tsx
@@ -18,6 +18,7 @@ import type {
 } from "../../../../ui/host";
 import { WebBox } from "./box";
 import { CanvasChartPainter } from "./chart-painter";
+import { cancelWebFrame, requestWebFrame } from "./mouse";
 
 const CanvasBitmap = memo(function CanvasBitmap({ bitmap }: { bitmap: BitmapSurface }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -53,6 +54,8 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   const lastMouseXRef = useRef<number | null>(null);
   const scrollEndTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollAxisRef = useRef<"x" | "y" | null>(null);
+  const scrollFrameRef = useRef<number | null>(null);
+  const latestScrollInputRef = useRef<ChartPointerInput | null>(null);
 
   useLayoutEffect(() => {
     let paintedRevision = Number.NaN;
@@ -93,10 +96,18 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas || !source.scrollPan) return;
+    const flushFrame = () => {
+      if (scrollFrameRef.current !== null) cancelWebFrame(scrollFrameRef.current);
+      scrollFrameRef.current = null;
+      const input = latestScrollInputRef.current;
+      latestScrollInputRef.current = null;
+      if (input) source.scrollPanFrame?.(input);
+    };
     const finish = () => {
       if (scrollEndTimerRef.current !== null) clearTimeout(scrollEndTimerRef.current);
       scrollEndTimerRef.current = null;
       scrollAxisRef.current = null;
+      flushFrame();
       source.scrollPanEnd?.();
     };
     const wheel = (event: globalThis.WheelEvent) => {
@@ -105,6 +116,15 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
         ?? (Math.abs(event.deltaX) > Math.abs(event.deltaY) ? "x" : "y");
       const delta = axis === "x" ? event.deltaX : event.deltaY;
       if (delta === 0 || !source.scrollPan?.(delta)) return;
+      latestScrollInputRef.current = mouseInput(event);
+      if (source.scrollPanFrame && scrollFrameRef.current === null) {
+        scrollFrameRef.current = requestWebFrame(() => {
+          scrollFrameRef.current = null;
+          const input = latestScrollInputRef.current;
+          latestScrollInputRef.current = null;
+          if (input) source.scrollPanFrame?.(input);
+        });
+      }
       scrollAxisRef.current = axis;
       if (scrollEndTimerRef.current !== null) clearTimeout(scrollEndTimerRef.current);
       scrollEndTimerRef.current = setTimeout(finish, 120);

--- a/src/renderers/electrobun/view/host/chart-surface.tsx
+++ b/src/renderers/electrobun/view/host/chart-surface.tsx
@@ -20,6 +20,10 @@ import { WebBox } from "./box";
 import { CanvasChartPainter } from "./chart-painter";
 import { cancelWebFrame, requestWebFrame } from "./mouse";
 
+const PAN_SCENE_INTERVAL_MS = 50;
+const PAN_CROSSHAIR_X = "--gloom-chart-pan-x";
+const PAN_CROSSHAIR_Y = "--gloom-chart-pan-y";
+
 const CanvasBitmap = memo(function CanvasBitmap({ bitmap }: { bitmap: BitmapSurface }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
@@ -56,6 +60,12 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   const scrollAxisRef = useRef<"x" | "y" | null>(null);
   const panFrameRef = useRef<number | null>(null);
   const latestPanInputRef = useRef<ChartPointerInput | null>(null);
+  const lastPanFrameTimeRef = useRef(Number.NEGATIVE_INFINITY);
+  const crosshairClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (crosshairClearTimerRef.current !== null) clearTimeout(crosshairClearTimerRef.current);
+  }, []);
 
   useLayoutEffect(() => {
     let paintedRevision = Number.NaN;
@@ -93,6 +103,33 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
     };
   };
 
+  const setTransientCrosshair = (input: ChartPointerInput) => {
+    if (crosshairClearTimerRef.current !== null) clearTimeout(crosshairClearTimerRef.current);
+    crosshairClearTimerRef.current = null;
+    const surface = canvasRef.current?.parentElement;
+    if (!surface) return;
+    const viewport = source.getViewportSize();
+    surface.style.setProperty(
+      PAN_CROSSHAIR_X,
+      `${Math.max(0, Math.min(viewport.width - 1, input.x))}px`,
+    );
+    surface.style.setProperty(
+      PAN_CROSSHAIR_Y,
+      `${Math.max(0, Math.min(viewport.height - 1, input.y))}px`,
+    );
+  };
+  const clearTransientCrosshair = () => {
+    const surface = canvasRef.current?.parentElement;
+    surface?.style.removeProperty(PAN_CROSSHAIR_X);
+    surface?.style.removeProperty(PAN_CROSSHAIR_Y);
+  };
+  const scheduleCrosshairClear = () => {
+    if (crosshairClearTimerRef.current !== null) clearTimeout(crosshairClearTimerRef.current);
+    crosshairClearTimerRef.current = setTimeout(() => {
+      crosshairClearTimerRef.current = null;
+      clearTransientCrosshair();
+    }, 100);
+  };
   const flushPanFrame = () => {
     if (panFrameRef.current !== null) cancelWebFrame(panFrameRef.current);
     panFrameRef.current = null;
@@ -103,12 +140,18 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   const schedulePanFrame = (input: ChartPointerInput) => {
     latestPanInputRef.current = input;
     if (!source.panFrame || panFrameRef.current !== null) return;
-    panFrameRef.current = requestWebFrame(() => {
+    const update = (timestamp: number) => {
+      if (timestamp - lastPanFrameTimeRef.current < PAN_SCENE_INTERVAL_MS) {
+        panFrameRef.current = requestWebFrame(update);
+        return;
+      }
       panFrameRef.current = null;
+      lastPanFrameTimeRef.current = timestamp;
       const latest = latestPanInputRef.current;
       latestPanInputRef.current = null;
       if (latest) source.panFrame?.(latest);
-    });
+    };
+    panFrameRef.current = requestWebFrame(update);
   };
 
   useEffect(() => {
@@ -120,6 +163,7 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       scrollAxisRef.current = null;
       flushPanFrame();
       source.scrollPanEnd?.();
+      scheduleCrosshairClear();
     };
     const wheel = (event: globalThis.WheelEvent) => {
       if (event.ctrlKey || event.metaKey || event.deltaMode !== 0) return;
@@ -127,7 +171,9 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
         ?? (Math.abs(event.deltaX) > Math.abs(event.deltaY) ? "x" : "y");
       const delta = axis === "x" ? event.deltaX : event.deltaY;
       if (delta === 0 || !source.scrollPan?.(delta)) return;
-      schedulePanFrame(mouseInput(event));
+      const input = mouseInput(event);
+      setTransientCrosshair(input);
+      schedulePanFrame(input);
       scrollAxisRef.current = axis;
       if (scrollEndTimerRef.current !== null) clearTimeout(scrollEndTimerRef.current);
       scrollEndTimerRef.current = setTimeout(finish, 120);
@@ -146,6 +192,7 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       if (!draggingRef.current) return;
       const input = mouseInput(event);
       source.pointerMove?.(input);
+      setTransientCrosshair(input);
       schedulePanFrame(input);
       lastMouseXRef.current = event.clientX;
       event.preventDefault();
@@ -159,6 +206,7 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       latestPanInputRef.current = input;
       flushPanFrame();
       source.pointerUp?.(input);
+      scheduleCrosshairClear();
       lastMouseXRef.current = null;
       event.preventDefault();
       event.stopPropagation();
@@ -171,6 +219,7 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       panFrameRef.current = null;
       latestPanInputRef.current = null;
       source.pointerCancel?.();
+      clearTransientCrosshair();
     };
     window.addEventListener("mousemove", move, true);
     window.addEventListener("mouseup", finish, true);
@@ -190,6 +239,7 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
         if (event.button !== 0 || !source.pointerDown?.(mouseInput(event.nativeEvent))) return;
         draggingRef.current = true;
         lastMouseXRef.current = event.clientX;
+        setTransientCrosshair(mouseInput(event.nativeEvent));
         const active = document.activeElement;
         if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) active.blur();
         event.preventDefault();
@@ -319,7 +369,7 @@ function ChartCrosshair({
           position: "absolute",
           top: 0,
           bottom: 0,
-          left: `${clampedX}%`,
+          left: `var(${PAN_CROSSHAIR_X}, ${clampedX}%)`,
           width: 1,
           backgroundColor: crosshair.color,
           opacity: 0.78,
@@ -333,7 +383,7 @@ function ChartCrosshair({
           position: "absolute",
           left: 0,
           right: 0,
-          top: `${clampedY}%`,
+          top: `var(${PAN_CROSSHAIR_Y}, ${clampedY}%)`,
           height: 1,
           backgroundColor: crosshair.color,
           opacity: 0.78,
@@ -345,8 +395,8 @@ function ChartCrosshair({
       <div
         style={{
           position: "absolute",
-          left: `${clampedX}%`,
-          top: `${clampedY}%`,
+          left: `var(${PAN_CROSSHAIR_X}, ${clampedX}%)`,
+          top: `var(${PAN_CROSSHAIR_Y}, ${clampedY}%)`,
           width: 7,
           height: 7,
           borderRadius: 7,

--- a/src/renderers/electrobun/view/host/chart-surface.tsx
+++ b/src/renderers/electrobun/view/host/chart-surface.tsx
@@ -6,7 +6,6 @@ import {
   useLayoutEffect,
   useRef,
   type CSSProperties,
-  type PointerEvent,
   type ReactNode,
   type Ref,
 } from "react";
@@ -50,8 +49,8 @@ const CanvasBitmap = memo(function CanvasBitmap({ bitmap }: { bitmap: BitmapSurf
 
 const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaintSource }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const pointerIdRef = useRef<number | null>(null);
-  const lastPointerXRef = useRef<number | null>(null);
+  const draggingRef = useRef(false);
+  const lastMouseXRef = useRef<number | null>(null);
 
   useLayoutEffect(() => {
     let paintedRevision = Number.NaN;
@@ -77,8 +76,9 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
     return source.subscribe(paint);
   }, [source]);
 
-  const pointerInput = (event: PointerEvent<HTMLCanvasElement>): ChartPointerInput => {
-    const bounds = (event.currentTarget.parentElement ?? event.currentTarget).getBoundingClientRect();
+  const mouseInput = (event: Pick<globalThis.MouseEvent, "clientX" | "clientY" | "shiftKey" | "altKey" | "ctrlKey" | "metaKey">): ChartPointerInput => {
+    const surface = canvasRef.current?.parentElement ?? canvasRef.current;
+    const bounds = surface?.getBoundingClientRect() ?? { left: 0, top: 0 };
     return {
       x: event.clientX - bounds.left,
       y: event.clientY - bounds.top,
@@ -87,58 +87,54 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       ctrl: event.ctrlKey || event.metaKey,
     };
   };
-  const handlePointerDown = (event: PointerEvent<HTMLCanvasElement>) => {
-    if (event.button !== 0 || !source.pointerDown?.(pointerInput(event))) return;
-    pointerIdRef.current = event.pointerId;
-    lastPointerXRef.current = event.clientX;
-    event.currentTarget.setPointerCapture(event.pointerId);
-    const active = document.activeElement;
-    if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) active.blur();
-    event.preventDefault();
-    event.stopPropagation();
-  };
-  const handlePointerMove = (event: PointerEvent<HTMLCanvasElement>) => {
-    if (pointerIdRef.current !== event.pointerId) return;
-    source.pointerMove?.(pointerInput(event));
-    lastPointerXRef.current = event.clientX;
-    event.preventDefault();
-    event.stopPropagation();
-  };
-  const finishPointer = (event: PointerEvent<HTMLCanvasElement>, cancelled: boolean) => {
-    if (pointerIdRef.current !== event.pointerId) return;
-    pointerIdRef.current = null;
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    }
-    if (cancelled) {
-      source.pointerCancel?.();
-    } else {
-      const input = pointerInput(event);
-      if (lastPointerXRef.current !== event.clientX) source.pointerMove?.(input);
+
+  useEffect(() => {
+    const move = (event: globalThis.MouseEvent) => {
+      if (!draggingRef.current) return;
+      source.pointerMove?.(mouseInput(event));
+      lastMouseXRef.current = event.clientX;
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    const finish = (event: globalThis.MouseEvent) => {
+      if (!draggingRef.current || event.button !== 0) return;
+      draggingRef.current = false;
+      const input = mouseInput(event);
+      if (lastMouseXRef.current !== event.clientX) source.pointerMove?.(input);
       source.pointerUp?.(input);
-    }
-    lastPointerXRef.current = null;
-    event.preventDefault();
-    event.stopPropagation();
-  };
+      lastMouseXRef.current = null;
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    const cancel = () => {
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+      lastMouseXRef.current = null;
+      source.pointerCancel?.();
+    };
+    window.addEventListener("mousemove", move, true);
+    window.addEventListener("mouseup", finish, true);
+    window.addEventListener("blur", cancel);
+    return () => {
+      window.removeEventListener("mousemove", move, true);
+      window.removeEventListener("mouseup", finish, true);
+      window.removeEventListener("blur", cancel);
+      cancel();
+    };
+  }, [source]);
 
   return (
     <canvas
       ref={canvasRef}
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={(event) => finishPointer(event, false)}
       onMouseDown={(event) => {
-        if (pointerIdRef.current === null) return;
+        if (event.button !== 0 || !source.pointerDown?.(mouseInput(event.nativeEvent))) return;
+        draggingRef.current = true;
+        lastMouseXRef.current = event.clientX;
+        const active = document.activeElement;
+        if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) active.blur();
         event.preventDefault();
         event.stopPropagation();
       }}
-      onMouseMove={(event) => {
-        if (pointerIdRef.current === null) return;
-        event.preventDefault();
-        event.stopPropagation();
-      }}
-      onPointerCancel={(event) => finishPointer(event, true)}
       style={{
         display: "block",
         width: "100%",

--- a/src/renderers/electrobun/view/host/chart-surface.tsx
+++ b/src/renderers/electrobun/view/host/chart-surface.tsx
@@ -19,7 +19,6 @@ import type {
 } from "../../../../ui/host";
 import { WebBox } from "./box";
 import { CanvasChartPainter } from "./chart-painter";
-import { cancelWebFrame, requestWebFrame } from "./mouse";
 
 const CanvasBitmap = memo(function CanvasBitmap({ bitmap }: { bitmap: BitmapSurface }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -52,8 +51,7 @@ const CanvasBitmap = memo(function CanvasBitmap({ bitmap }: { bitmap: BitmapSurf
 const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaintSource }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const pointerIdRef = useRef<number | null>(null);
-  const pointerFrameRef = useRef<number | null>(null);
-  const pendingPointerRef = useRef<ChartPointerInput | null>(null);
+  const lastPointerXRef = useRef<number | null>(null);
 
   useLayoutEffect(() => {
     const paint = () => {
@@ -74,10 +72,6 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
     return source.subscribe(paint);
   }, [source]);
 
-  useEffect(() => () => {
-    if (pointerFrameRef.current !== null) cancelWebFrame(pointerFrameRef.current);
-  }, []);
-
   const pointerInput = (event: PointerEvent<HTMLCanvasElement>): ChartPointerInput => {
     const bounds = event.currentTarget.getBoundingClientRect();
     return {
@@ -88,13 +82,10 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       ctrl: event.ctrlKey || event.metaKey,
     };
   };
-  const flushPointerMove = (input: ChartPointerInput) => {
-    pendingPointerRef.current = null;
-    source.pointerMove?.(input);
-  };
   const handlePointerDown = (event: PointerEvent<HTMLCanvasElement>) => {
     if (event.button !== 0 || !source.pointerDown?.(pointerInput(event))) return;
     pointerIdRef.current = event.pointerId;
+    lastPointerXRef.current = event.clientX;
     event.currentTarget.setPointerCapture(event.pointerId);
     const active = document.activeElement;
     if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) active.blur();
@@ -103,34 +94,25 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   };
   const handlePointerMove = (event: PointerEvent<HTMLCanvasElement>) => {
     if (pointerIdRef.current !== event.pointerId) return;
-    pendingPointerRef.current = pointerInput(event);
-    if (pointerFrameRef.current === null) {
-      pointerFrameRef.current = requestWebFrame(() => {
-        pointerFrameRef.current = null;
-        const input = pendingPointerRef.current;
-        if (input) flushPointerMove(input);
-      });
-    }
+    source.pointerMove?.(pointerInput(event));
+    lastPointerXRef.current = event.clientX;
     event.preventDefault();
     event.stopPropagation();
   };
   const finishPointer = (event: PointerEvent<HTMLCanvasElement>, cancelled: boolean) => {
     if (pointerIdRef.current !== event.pointerId) return;
     pointerIdRef.current = null;
-    if (pointerFrameRef.current !== null) {
-      cancelWebFrame(pointerFrameRef.current);
-      pointerFrameRef.current = null;
-    }
     if (event.currentTarget.hasPointerCapture(event.pointerId)) {
       event.currentTarget.releasePointerCapture(event.pointerId);
     }
     if (cancelled) {
-      pendingPointerRef.current = null;
       source.pointerCancel?.();
     } else {
-      flushPointerMove(pointerInput(event));
-      source.pointerUp?.(pointerInput(event));
+      const input = pointerInput(event);
+      if (lastPointerXRef.current !== event.clientX) source.pointerMove?.(input);
+      source.pointerUp?.(input);
     }
+    lastPointerXRef.current = null;
     event.preventDefault();
     event.stopPropagation();
   };

--- a/src/renderers/electrobun/view/host/chart-surface.tsx
+++ b/src/renderers/electrobun/view/host/chart-surface.tsx
@@ -54,10 +54,14 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   const lastPointerXRef = useRef<number | null>(null);
 
   useLayoutEffect(() => {
+    let paintedRevision = Number.NaN;
     const paint = () => {
       const canvas = canvasRef.current;
       const frame = source.getFrame();
       if (!canvas || !frame) return;
+      canvas.style.width = `${frame.width}px`;
+      canvas.style.transform = `translate3d(${frame.offsetX}px, 0, 0)`;
+      if (paintedRevision === frame.revision) return;
       const ratio = Math.min(window.devicePixelRatio || 1, 2);
       const width = Math.max(1, Math.round(frame.width * ratio));
       const height = Math.max(1, Math.round(frame.height * ratio));
@@ -67,13 +71,14 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       if (!context) return;
       context.setTransform(ratio, 0, 0, ratio, 0, 0);
       frame.paint(new CanvasChartPainter(context, frame.width, frame.height));
+      paintedRevision = frame.revision;
     };
     paint();
     return source.subscribe(paint);
   }, [source]);
 
   const pointerInput = (event: PointerEvent<HTMLCanvasElement>): ChartPointerInput => {
-    const bounds = event.currentTarget.getBoundingClientRect();
+    const bounds = (event.currentTarget.parentElement ?? event.currentTarget).getBoundingClientRect();
     return {
       x: event.clientX - bounds.left,
       y: event.clientY - bounds.top,
@@ -139,7 +144,9 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
         width: "100%",
         height: "100%",
         position: "absolute",
-        inset: 0,
+        left: 0,
+        top: 0,
+        willChange: "transform",
       }}
     />
   );

--- a/src/renderers/electrobun/view/host/chart-surface.tsx
+++ b/src/renderers/electrobun/view/host/chart-surface.tsx
@@ -18,7 +18,6 @@ import type {
 } from "../../../../ui/host";
 import { WebBox } from "./box";
 import { CanvasChartPainter } from "./chart-painter";
-import { cancelWebFrame, requestWebFrame } from "./mouse";
 
 const CanvasBitmap = memo(function CanvasBitmap({ bitmap }: { bitmap: BitmapSurface }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -54,8 +53,6 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   const lastMouseXRef = useRef<number | null>(null);
   const scrollEndTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollAxisRef = useRef<"x" | "y" | null>(null);
-  const panFrameRef = useRef<number | null>(null);
-  const latestPanInputRef = useRef<ChartPointerInput | null>(null);
 
   useLayoutEffect(() => {
     let paintedRevision = Number.NaN;
@@ -93,24 +90,6 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
     };
   };
 
-  const flushPanFrame = () => {
-    if (panFrameRef.current !== null) cancelWebFrame(panFrameRef.current);
-    panFrameRef.current = null;
-    const input = latestPanInputRef.current;
-    latestPanInputRef.current = null;
-    if (input) source.panFrame?.(input);
-  };
-  const schedulePanFrame = (input: ChartPointerInput) => {
-    latestPanInputRef.current = input;
-    if (!source.panFrame || panFrameRef.current !== null) return;
-    panFrameRef.current = requestWebFrame(() => {
-      panFrameRef.current = null;
-      const latest = latestPanInputRef.current;
-      latestPanInputRef.current = null;
-      if (latest) source.panFrame?.(latest);
-    });
-  };
-
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas || !source.scrollPan) return;
@@ -118,7 +97,6 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       if (scrollEndTimerRef.current !== null) clearTimeout(scrollEndTimerRef.current);
       scrollEndTimerRef.current = null;
       scrollAxisRef.current = null;
-      flushPanFrame();
       source.scrollPanEnd?.();
     };
     const wheel = (event: globalThis.WheelEvent) => {
@@ -127,7 +105,6 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
         ?? (Math.abs(event.deltaX) > Math.abs(event.deltaY) ? "x" : "y");
       const delta = axis === "x" ? event.deltaX : event.deltaY;
       if (delta === 0 || !source.scrollPan?.(delta)) return;
-      schedulePanFrame(mouseInput(event));
       scrollAxisRef.current = axis;
       if (scrollEndTimerRef.current !== null) clearTimeout(scrollEndTimerRef.current);
       scrollEndTimerRef.current = setTimeout(finish, 120);
@@ -144,9 +121,7 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   useEffect(() => {
     const move = (event: globalThis.MouseEvent) => {
       if (!draggingRef.current) return;
-      const input = mouseInput(event);
-      source.pointerMove?.(input);
-      schedulePanFrame(input);
+      source.pointerMove?.(mouseInput(event));
       lastMouseXRef.current = event.clientX;
       event.preventDefault();
       event.stopPropagation();
@@ -156,8 +131,6 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       draggingRef.current = false;
       const input = mouseInput(event);
       if (lastMouseXRef.current !== event.clientX) source.pointerMove?.(input);
-      latestPanInputRef.current = input;
-      flushPanFrame();
       source.pointerUp?.(input);
       lastMouseXRef.current = null;
       event.preventDefault();
@@ -167,9 +140,6 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       if (!draggingRef.current) return;
       draggingRef.current = false;
       lastMouseXRef.current = null;
-      if (panFrameRef.current !== null) cancelWebFrame(panFrameRef.current);
-      panFrameRef.current = null;
-      latestPanInputRef.current = null;
       source.pointerCancel?.();
     };
     window.addEventListener("mousemove", move, true);

--- a/src/renderers/electrobun/view/host/chart-surface.tsx
+++ b/src/renderers/electrobun/view/host/chart-surface.tsx
@@ -3,11 +3,14 @@ import {
   forwardRef,
   memo,
   useEffect,
+  useLayoutEffect,
   useRef,
   type CSSProperties,
+  type PointerEvent,
   type ReactNode,
   type Ref,
 } from "react";
+import type { ChartPaintSource, ChartPointerInput } from "../../../../components/chart/core/painter";
 import type {
   BitmapSurface,
   BoxRenderable,
@@ -15,6 +18,8 @@ import type {
   ChartVectorShape,
 } from "../../../../ui/host";
 import { WebBox } from "./box";
+import { CanvasChartPainter } from "./chart-painter";
+import { cancelWebFrame, requestWebFrame } from "./mouse";
 
 const CanvasBitmap = memo(function CanvasBitmap({ bitmap }: { bitmap: BitmapSurface }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -39,6 +44,120 @@ const CanvasBitmap = memo(function CanvasBitmap({ bitmap }: { bitmap: BitmapSurf
         display: "block",
         width: "100%",
         height: "100%",
+      }}
+    />
+  );
+});
+
+const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaintSource }) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const pointerIdRef = useRef<number | null>(null);
+  const pointerFrameRef = useRef<number | null>(null);
+  const pendingPointerRef = useRef<ChartPointerInput | null>(null);
+
+  useLayoutEffect(() => {
+    const paint = () => {
+      const canvas = canvasRef.current;
+      const frame = source.getFrame();
+      if (!canvas || !frame) return;
+      const ratio = Math.min(window.devicePixelRatio || 1, 2);
+      const width = Math.max(1, Math.round(frame.width * ratio));
+      const height = Math.max(1, Math.round(frame.height * ratio));
+      if (canvas.width !== width) canvas.width = width;
+      if (canvas.height !== height) canvas.height = height;
+      const context = canvas.getContext("2d");
+      if (!context) return;
+      context.setTransform(ratio, 0, 0, ratio, 0, 0);
+      frame.paint(new CanvasChartPainter(context, frame.width, frame.height));
+    };
+    paint();
+    return source.subscribe(paint);
+  }, [source]);
+
+  useEffect(() => () => {
+    if (pointerFrameRef.current !== null) cancelWebFrame(pointerFrameRef.current);
+  }, []);
+
+  const pointerInput = (event: PointerEvent<HTMLCanvasElement>): ChartPointerInput => {
+    const bounds = event.currentTarget.getBoundingClientRect();
+    return {
+      x: event.clientX - bounds.left,
+      y: event.clientY - bounds.top,
+      shift: event.shiftKey,
+      alt: event.altKey,
+      ctrl: event.ctrlKey || event.metaKey,
+    };
+  };
+  const flushPointerMove = (input: ChartPointerInput) => {
+    pendingPointerRef.current = null;
+    source.pointerMove?.(input);
+  };
+  const handlePointerDown = (event: PointerEvent<HTMLCanvasElement>) => {
+    if (event.button !== 0 || !source.pointerDown?.(pointerInput(event))) return;
+    pointerIdRef.current = event.pointerId;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    const active = document.activeElement;
+    if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) active.blur();
+    event.preventDefault();
+    event.stopPropagation();
+  };
+  const handlePointerMove = (event: PointerEvent<HTMLCanvasElement>) => {
+    if (pointerIdRef.current !== event.pointerId) return;
+    pendingPointerRef.current = pointerInput(event);
+    if (pointerFrameRef.current === null) {
+      pointerFrameRef.current = requestWebFrame(() => {
+        pointerFrameRef.current = null;
+        const input = pendingPointerRef.current;
+        if (input) flushPointerMove(input);
+      });
+    }
+    event.preventDefault();
+    event.stopPropagation();
+  };
+  const finishPointer = (event: PointerEvent<HTMLCanvasElement>, cancelled: boolean) => {
+    if (pointerIdRef.current !== event.pointerId) return;
+    pointerIdRef.current = null;
+    if (pointerFrameRef.current !== null) {
+      cancelWebFrame(pointerFrameRef.current);
+      pointerFrameRef.current = null;
+    }
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    if (cancelled) {
+      pendingPointerRef.current = null;
+      source.pointerCancel?.();
+    } else {
+      flushPointerMove(pointerInput(event));
+      source.pointerUp?.(pointerInput(event));
+    }
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  return (
+    <canvas
+      ref={canvasRef}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={(event) => finishPointer(event, false)}
+      onMouseDown={(event) => {
+        if (pointerIdRef.current === null) return;
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onMouseMove={(event) => {
+        if (pointerIdRef.current === null) return;
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onPointerCancel={(event) => finishPointer(event, true)}
+      style={{
+        display: "block",
+        width: "100%",
+        height: "100%",
+        position: "absolute",
+        inset: 0,
       }}
     />
   );
@@ -137,15 +256,15 @@ const ChartVectors = memo(function ChartVectors({ vectors }: { vectors: readonly
 });
 
 function ChartCrosshair({
-  bitmap,
+  surface,
   crosshair,
 }: {
-  bitmap: BitmapSurface | null;
+  surface: { width: number; height: number } | null;
   crosshair: ChartCrosshairOverlay | null;
 }) {
-  if (!bitmap || !crosshair) return null;
-  const x = bitmap.width <= 1 ? 0 : (crosshair.pixelX / (bitmap.width - 1)) * 100;
-  const y = bitmap.height <= 1 ? 0 : (crosshair.pixelY / (bitmap.height - 1)) * 100;
+  if (!surface || !crosshair) return null;
+  const x = surface.width <= 1 ? 0 : (crosshair.pixelX / (surface.width - 1)) * 100;
+  const y = surface.height <= 1 ? 0 : (crosshair.pixelY / (surface.height - 1)) * 100;
   const clampedX = Math.max(0, Math.min(100, x));
   const clampedY = Math.max(0, Math.min(100, y));
   return (
@@ -202,10 +321,11 @@ export const WebChartSurface = forwardRef<BoxRenderable, Record<string, unknown>
   function WebChartSurface({ children, ...props }, ref) {
     const bitmap = (props.bitmap ?? null) as BitmapSurface | null;
     const bitmaps = (props.bitmaps ?? null) as readonly BitmapSurface[] | null;
+    const paintSource = (props.paintSource ?? null) as ChartPaintSource | null;
     const layers = bitmaps ?? (bitmap ? [bitmap] : []);
     const crosshair = (props.crosshair ?? null) as ChartCrosshairOverlay | null;
     const vectors = (props.vectors ?? null) as readonly ChartVectorShape[] | null;
-    const baseLayer = layers[0] ?? null;
+    const surface = paintSource?.getFrame() ?? layers[0] ?? null;
     return (
       <WebBox
         {...props}
@@ -219,13 +339,15 @@ export const WebChartSurface = forwardRef<BoxRenderable, Record<string, unknown>
           ...(props.style as CSSProperties | undefined),
         }}
       >
-        {layers.length > 0
-          ? layers.map((layer, index) => (
-            <BoxLayer key={`layer:${index}`} index={index} bitmap={layer} />
-          ))
-          : children as ReactNode}
+        {paintSource
+          ? <PaintedChart source={paintSource} />
+          : layers.length > 0
+            ? layers.map((layer, index) => (
+              <BoxLayer key={`layer:${index}`} index={index} bitmap={layer} />
+            ))
+            : children as ReactNode}
         <ChartVectors vectors={vectors ?? []} />
-        <ChartCrosshair bitmap={baseLayer} crosshair={crosshair} />
+        <ChartCrosshair surface={surface} crosshair={crosshair} />
       </WebBox>
     );
   },

--- a/src/renderers/electrobun/view/host/chart-surface.tsx
+++ b/src/renderers/electrobun/view/host/chart-surface.tsx
@@ -49,36 +49,65 @@ const CanvasBitmap = memo(function CanvasBitmap({ bitmap }: { bitmap: BitmapSurf
 });
 
 const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaintSource }) {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const pointerIdRef = useRef<number | null>(null);
   const lastPointerXRef = useRef<number | null>(null);
 
   useLayoutEffect(() => {
     let paintedRevision = Number.NaN;
+    const canvases: HTMLCanvasElement[] = [];
     const paint = () => {
-      const canvas = canvasRef.current;
+      const container = containerRef.current;
       const frame = source.getFrame();
-      if (!canvas || !frame) return;
-      canvas.style.width = `${frame.width}px`;
-      canvas.style.transform = `translate3d(${frame.offsetX}px, 0, 0)`;
+      if (!container || !frame) return;
+      const tileWidth = Math.max(1, frame.surfaceWidth);
+      const tileCount = Math.max(1, Math.ceil(frame.width / tileWidth));
+      while (canvases.length < tileCount) {
+        const canvas = document.createElement("canvas");
+        canvas.style.position = "absolute";
+        canvas.style.left = "0";
+        canvas.style.top = "0";
+        canvas.style.pointerEvents = "none";
+        canvas.style.willChange = "transform";
+        container.appendChild(canvas);
+        canvases.push(canvas);
+      }
+      while (canvases.length > tileCount) canvases.pop()?.remove();
+
+      canvases.forEach((canvas, index) => {
+        const startX = index * tileWidth;
+        const width = Math.min(tileWidth, frame.width - startX);
+        canvas.style.width = `${width}px`;
+        canvas.style.height = `${frame.height}px`;
+        canvas.style.transform = `translate3d(${startX + frame.offsetX}px, 0, 0)`;
+      });
       if (paintedRevision === frame.revision) return;
+
       const ratio = Math.min(window.devicePixelRatio || 1, 2);
-      const width = Math.max(1, Math.round(frame.width * ratio));
-      const height = Math.max(1, Math.round(frame.height * ratio));
-      if (canvas.width !== width) canvas.width = width;
-      if (canvas.height !== height) canvas.height = height;
-      const context = canvas.getContext("2d");
-      if (!context) return;
-      context.setTransform(ratio, 0, 0, ratio, 0, 0);
-      frame.paint(new CanvasChartPainter(context, frame.width, frame.height));
+      canvases.forEach((canvas, index) => {
+        const startX = index * tileWidth;
+        const width = Math.min(tileWidth, frame.width - startX);
+        const pixelWidth = Math.max(1, Math.round(width * ratio));
+        const pixelHeight = Math.max(1, Math.round(frame.height * ratio));
+        if (canvas.width !== pixelWidth) canvas.width = pixelWidth;
+        if (canvas.height !== pixelHeight) canvas.height = pixelHeight;
+        const context = canvas.getContext("2d");
+        if (!context) return;
+        context.setTransform(ratio, 0, 0, ratio, -startX * ratio, 0);
+        frame.paint(new CanvasChartPainter(context, frame.width, frame.height));
+      });
       paintedRevision = frame.revision;
     };
     paint();
-    return source.subscribe(paint);
+    const unsubscribe = source.subscribe(paint);
+    return () => {
+      unsubscribe();
+      for (const canvas of canvases) canvas.remove();
+    };
   }, [source]);
 
-  const pointerInput = (event: PointerEvent<HTMLCanvasElement>): ChartPointerInput => {
-    const bounds = (event.currentTarget.parentElement ?? event.currentTarget).getBoundingClientRect();
+  const pointerInput = (event: PointerEvent<HTMLDivElement>): ChartPointerInput => {
+    const bounds = event.currentTarget.getBoundingClientRect();
     return {
       x: event.clientX - bounds.left,
       y: event.clientY - bounds.top,
@@ -87,7 +116,7 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       ctrl: event.ctrlKey || event.metaKey,
     };
   };
-  const handlePointerDown = (event: PointerEvent<HTMLCanvasElement>) => {
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
     if (event.button !== 0 || !source.pointerDown?.(pointerInput(event))) return;
     pointerIdRef.current = event.pointerId;
     lastPointerXRef.current = event.clientX;
@@ -97,14 +126,14 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
     event.preventDefault();
     event.stopPropagation();
   };
-  const handlePointerMove = (event: PointerEvent<HTMLCanvasElement>) => {
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
     if (pointerIdRef.current !== event.pointerId) return;
     source.pointerMove?.(pointerInput(event));
     lastPointerXRef.current = event.clientX;
     event.preventDefault();
     event.stopPropagation();
   };
-  const finishPointer = (event: PointerEvent<HTMLCanvasElement>, cancelled: boolean) => {
+  const finishPointer = (event: PointerEvent<HTMLDivElement>, cancelled: boolean) => {
     if (pointerIdRef.current !== event.pointerId) return;
     pointerIdRef.current = null;
     if (event.currentTarget.hasPointerCapture(event.pointerId)) {
@@ -123,8 +152,8 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   };
 
   return (
-    <canvas
-      ref={canvasRef}
+    <div
+      ref={containerRef}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={(event) => finishPointer(event, false)}
@@ -140,13 +169,8 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       }}
       onPointerCancel={(event) => finishPointer(event, true)}
       style={{
-        display: "block",
-        width: "100%",
-        height: "100%",
         position: "absolute",
-        left: 0,
-        top: 0,
-        willChange: "transform",
+        inset: 0,
       }}
     />
   );
@@ -314,7 +338,10 @@ export const WebChartSurface = forwardRef<BoxRenderable, Record<string, unknown>
     const layers = bitmaps ?? (bitmap ? [bitmap] : []);
     const crosshair = (props.crosshair ?? null) as ChartCrosshairOverlay | null;
     const vectors = (props.vectors ?? null) as readonly ChartVectorShape[] | null;
-    const surface = paintSource?.getFrame() ?? layers[0] ?? null;
+    const frame = paintSource?.getFrame() ?? null;
+    const surface = frame
+      ? { width: frame.surfaceWidth, height: frame.height }
+      : layers[0] ?? null;
     return (
       <WebBox
         {...props}

--- a/src/renderers/electrobun/view/host/chart-surface.tsx
+++ b/src/renderers/electrobun/view/host/chart-surface.tsx
@@ -51,6 +51,8 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const draggingRef = useRef(false);
   const lastMouseXRef = useRef<number | null>(null);
+  const scrollEndTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scrollAxisRef = useRef<"x" | "y" | null>(null);
 
   useLayoutEffect(() => {
     let paintedRevision = Number.NaN;
@@ -87,6 +89,34 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       ctrl: event.ctrlKey || event.metaKey,
     };
   };
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !source.scrollPan) return;
+    const finish = () => {
+      if (scrollEndTimerRef.current !== null) clearTimeout(scrollEndTimerRef.current);
+      scrollEndTimerRef.current = null;
+      scrollAxisRef.current = null;
+      source.scrollPanEnd?.();
+    };
+    const wheel = (event: globalThis.WheelEvent) => {
+      if (event.ctrlKey || event.metaKey || event.deltaMode !== 0) return;
+      const axis = scrollAxisRef.current
+        ?? (Math.abs(event.deltaX) > Math.abs(event.deltaY) ? "x" : "y");
+      const delta = axis === "x" ? event.deltaX : event.deltaY;
+      if (delta === 0 || !source.scrollPan?.(delta)) return;
+      scrollAxisRef.current = axis;
+      if (scrollEndTimerRef.current !== null) clearTimeout(scrollEndTimerRef.current);
+      scrollEndTimerRef.current = setTimeout(finish, 120);
+      event.preventDefault();
+      event.stopPropagation();
+    };
+    canvas.addEventListener("wheel", wheel, { passive: false });
+    return () => {
+      canvas.removeEventListener("wheel", wheel);
+      finish();
+    };
+  }, [source]);
 
   useEffect(() => {
     const move = (event: globalThis.MouseEvent) => {

--- a/src/renderers/electrobun/view/host/chart-surface.tsx
+++ b/src/renderers/electrobun/view/host/chart-surface.tsx
@@ -54,8 +54,8 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   const lastMouseXRef = useRef<number | null>(null);
   const scrollEndTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollAxisRef = useRef<"x" | "y" | null>(null);
-  const scrollFrameRef = useRef<number | null>(null);
-  const latestScrollInputRef = useRef<ChartPointerInput | null>(null);
+  const panFrameRef = useRef<number | null>(null);
+  const latestPanInputRef = useRef<ChartPointerInput | null>(null);
 
   useLayoutEffect(() => {
     let paintedRevision = Number.NaN;
@@ -93,21 +93,32 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
     };
   };
 
+  const flushPanFrame = () => {
+    if (panFrameRef.current !== null) cancelWebFrame(panFrameRef.current);
+    panFrameRef.current = null;
+    const input = latestPanInputRef.current;
+    latestPanInputRef.current = null;
+    if (input) source.panFrame?.(input);
+  };
+  const schedulePanFrame = (input: ChartPointerInput) => {
+    latestPanInputRef.current = input;
+    if (!source.panFrame || panFrameRef.current !== null) return;
+    panFrameRef.current = requestWebFrame(() => {
+      panFrameRef.current = null;
+      const latest = latestPanInputRef.current;
+      latestPanInputRef.current = null;
+      if (latest) source.panFrame?.(latest);
+    });
+  };
+
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas || !source.scrollPan) return;
-    const flushFrame = () => {
-      if (scrollFrameRef.current !== null) cancelWebFrame(scrollFrameRef.current);
-      scrollFrameRef.current = null;
-      const input = latestScrollInputRef.current;
-      latestScrollInputRef.current = null;
-      if (input) source.scrollPanFrame?.(input);
-    };
     const finish = () => {
       if (scrollEndTimerRef.current !== null) clearTimeout(scrollEndTimerRef.current);
       scrollEndTimerRef.current = null;
       scrollAxisRef.current = null;
-      flushFrame();
+      flushPanFrame();
       source.scrollPanEnd?.();
     };
     const wheel = (event: globalThis.WheelEvent) => {
@@ -116,15 +127,7 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
         ?? (Math.abs(event.deltaX) > Math.abs(event.deltaY) ? "x" : "y");
       const delta = axis === "x" ? event.deltaX : event.deltaY;
       if (delta === 0 || !source.scrollPan?.(delta)) return;
-      latestScrollInputRef.current = mouseInput(event);
-      if (source.scrollPanFrame && scrollFrameRef.current === null) {
-        scrollFrameRef.current = requestWebFrame(() => {
-          scrollFrameRef.current = null;
-          const input = latestScrollInputRef.current;
-          latestScrollInputRef.current = null;
-          if (input) source.scrollPanFrame?.(input);
-        });
-      }
+      schedulePanFrame(mouseInput(event));
       scrollAxisRef.current = axis;
       if (scrollEndTimerRef.current !== null) clearTimeout(scrollEndTimerRef.current);
       scrollEndTimerRef.current = setTimeout(finish, 120);
@@ -141,7 +144,9 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
   useEffect(() => {
     const move = (event: globalThis.MouseEvent) => {
       if (!draggingRef.current) return;
-      source.pointerMove?.(mouseInput(event));
+      const input = mouseInput(event);
+      source.pointerMove?.(input);
+      schedulePanFrame(input);
       lastMouseXRef.current = event.clientX;
       event.preventDefault();
       event.stopPropagation();
@@ -151,6 +156,8 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       draggingRef.current = false;
       const input = mouseInput(event);
       if (lastMouseXRef.current !== event.clientX) source.pointerMove?.(input);
+      latestPanInputRef.current = input;
+      flushPanFrame();
       source.pointerUp?.(input);
       lastMouseXRef.current = null;
       event.preventDefault();
@@ -160,6 +167,9 @@ const PaintedChart = memo(function PaintedChart({ source }: { source: ChartPaint
       if (!draggingRef.current) return;
       draggingRef.current = false;
       lastMouseXRef.current = null;
+      if (panFrameRef.current !== null) cancelWebFrame(panFrameRef.current);
+      panFrameRef.current = null;
+      latestPanInputRef.current = null;
       source.pointerCancel?.();
     };
     window.addEventListener("mousemove", move, true);
@@ -360,7 +370,7 @@ export const WebChartSurface = forwardRef<BoxRenderable, Record<string, unknown>
     const layers = bitmaps ?? (bitmap ? [bitmap] : []);
     const crosshair = (props.crosshair ?? null) as ChartCrosshairOverlay | null;
     const vectors = (props.vectors ?? null) as readonly ChartVectorShape[] | null;
-    const surface = paintSource?.getFrame() ?? layers[0] ?? null;
+    const surface = paintSource?.getViewportSize() ?? layers[0] ?? null;
     return (
       <WebBox
         {...props}

--- a/src/renderers/electrobun/view/host/style.ts
+++ b/src/renderers/electrobun/view/host/style.ts
@@ -103,7 +103,7 @@ export function cleanDomProps(props: Record<string, unknown>): Record<string, un
     "focused", "focusedBackgroundColor", "textColor", "focusedTextColor", "placeholderColor",
     "cursorColor", "selectionBg", "selectionFg", "showCursor", "keyBindings", "wrapText", "wrapMode",
     "initialValue", "value", "onInput", "onChange", "onSubmit", "onEscape", "onCursorChange", "onMouse",
-    "scrollX", "scrollY", "focusable", "bitmap", "bitmaps", "crosshair", "vectors", "text", "font",
+    "scrollX", "scrollY", "focusable", "bitmap", "bitmaps", "paintSource", "crosshair", "vectors", "text", "font",
     "hoverBackgroundColor",
   ]) {
     delete next[key];

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, type ComponentType, type ReactNode, type Ref
 import type { ContextMenuItem } from "../types/context-menu";
 import type { AppNotificationRequest } from "../types/plugin";
 import type { LiveStreamResolveRequest, ResolvedLiveStream } from "../types/media";
+import type { ChartPaintSource } from "../components/chart/core/painter";
 import type { AsciiFontName } from "./ascii-font";
 
 export const TextAttributes = {
@@ -227,6 +228,7 @@ export interface ChartSurfaceProps extends BoxProps {
   bitmap?: BitmapSurface | null;
   /** Desktop stacks every layer; the terminal renders only the first. */
   bitmaps?: readonly BitmapSurface[] | null;
+  paintSource?: ChartPaintSource | null;
   crosshair?: ChartCrosshairOverlay | null;
   vectors?: readonly ChartVectorShape[] | null;
   nativeBitmapsEnabled?: boolean;


### PR DESCRIPTION
## Summary
- move transient panning into a renderer-neutral chart engine with raw CSS-pixel input
- build one overscanned drag scene at mouse-down, then move the cached Canvas through compositor transforms without repainting
- retain the desktop's pre-refactor native `mousedown` / `mousemove` / `mouseup` delivery instead of routing WKWebView drags through Pointer Events
- keep scene rebuilding, React state, persistence, data refreshes, and axis rescaling outside active desktop drags
- paint the same chart geometry through browser Canvas and terminal bitmap adapters

## Root cause and measurement
The renderer was not the remaining bottleneck. An exact-window ScreenCaptureKit harness now records the real inactive WKWebView without focusing or raising it. It injects Mouse Events inside the page through the production chart path, so it measures actual WKWebView presentation but not macOS input delivery. The measured five-second drag produced:

- 288 presented frames over 4.95 seconds
- 57.98 presented FPS
- 15.0–18.334 ms frame intervals
- zero intervals above 20 ms
- exact monotonic displacement at every 100 ms sample, with no stalls or backsteps

This isolated the regression to the refactor's switch from the desktop's prior Mouse Event delivery to Pointer Events. The speculative Canvas tiling change was removed; the fix restores Mouse Events while retaining raw CSS-pixel coordinates and the renderer-neutral engine.

### Right-boundary regression

At a clamped navigation boundary, pointer overshoot kept accumulating against the original drag anchor. Reversing direction therefore had to cross that invisible overshoot before the chart moved again, which felt like renewed lag. The engine now rebases only its live drag anchor when clamped while preserving the original viewport for commit/cancel semantics.

An exact-window boundary probe dragged 300 px older, crossed 200 px past the newest boundary, then reversed 50 px. The chart remained fixed only while pushing into the hard boundary and resumed on the first sampled reverse movement. ScreenCaptureKit measured 417 presented frames over 7.14 seconds at 58.26 FPS.

## Verification
- `bun run typecheck` (all six projects)
- `bun test` (2,384 passed)
- `bun run desktop:view:build`
- focused chart, engine, terminal renderer, and desktop host tests
- exact-window WKWebView ScreenCaptureKit frame analysis above
- `git diff --check`

The PR remains open because this is a visual interaction change.
