### PR TITLE
Add CSV exports to table panes

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -390,12 +390,15 @@ await ctx.removeBrokerInstance(instance.id);
 
 Panes can expose per-instance settings that persist with the layout. These settings are part of the pane definition, can be edited from the pane header or command bar, and are available to both first-party and external plugins.
 
+Table panes built with the shared `DataTable` can opt into an Excel-compatible CSV action with `tableExport: true`. The action exports the current sorted, filtered rows and visible columns. It is available when the pane has one active table.
+
 ```typescript
 ctx.registerPane({
   id: "my-pane",
   name: "My Pane",
   component: MyPane,
   defaultPosition: "right",
+  tableExport: true,
   settings: {
     title: "My Pane Settings",
     fields: [

--- a/src/cli/result.ts
+++ b/src/cli/result.ts
@@ -1,5 +1,6 @@
 import type { CliGlobalOptions } from "./options";
 import { renderTable, type CliTableColumn } from "../utils/cli-output";
+import { serializeCsv } from "../utils/csv";
 
 export interface CliResult<T = unknown> {
   data: T;
@@ -57,11 +58,6 @@ function inferColumns(rows: Record<string, unknown>[]): CliResultColumn<Record<s
   return [...keys].map((key) => ({ key, header: key }));
 }
 
-function csvEscape(value: string): string {
-  if (!/[",\n\r]/.test(value)) return value;
-  return `"${value.replace(/"/g, '""')}"`;
-}
-
 function serializeColumns<Row>(columns?: CliResultColumn<Row>[]) {
   return columns?.map((column) => ({
     key: column.key,
@@ -78,11 +74,12 @@ function renderCsv<Row extends Record<string, unknown>>(
   const resolvedColumns = columns && columns.length > 0
     ? columns
     : inferColumns(rows as Record<string, unknown>[]) as CliResultColumn<Row>[];
-  const header = resolvedColumns.map((column) => csvEscape(column.header)).join(",");
-  const body = rows.map((row) => resolvedColumns
-    .map((column) => csvEscape(normalizeCell(column.value ? column.value(row) : row[column.key])))
-    .join(","));
-  return [header, ...body].join("\n");
+  return serializeCsv([
+    resolvedColumns.map((column) => column.header),
+    ...rows.map((row) => resolvedColumns.map((column) => (
+      column.value ? column.value(row) : row[column.key]
+    ))),
+  ]);
 }
 
 function renderTextTable<Row extends Record<string, unknown>>(

--- a/src/components/data-table/export.test.ts
+++ b/src/components/data-table/export.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test";
+import { EXCEL_CSV_BOM } from "../../utils/csv";
+import { createDataTableCsv } from "./export";
+
+test("exports displayed table cells and skips section headers", () => {
+  const items = [
+    { type: "section", name: "Americas", value: "" },
+    { type: "row", name: "S&P 500", value: "+1.25%" },
+  ];
+  const csv = createDataTableCsv({
+    columns: [
+      { id: "name", label: "Name", width: 20, align: "left" },
+      { id: "value", label: "Change", width: 10, align: "right" },
+    ],
+    items,
+    renderSectionHeader: (item) => item.type === "section" ? { text: item.name } : null,
+    renderCell: (item, column) => ({ text: item[column.id as "name" | "value"] }),
+  });
+
+  expect(csv).toBe(`${EXCEL_CSV_BOM}Name,Change\nS&P 500,'+1.25%`);
+});

--- a/src/components/data-table/export.ts
+++ b/src/components/data-table/export.ts
@@ -1,0 +1,21 @@
+import type { DataTableColumn, DataTableProps } from "../ui";
+import { serializeCsv } from "../../utils/csv";
+
+export function createDataTableCsv<
+  T,
+  C extends DataTableColumn = DataTableColumn,
+>({
+  columns,
+  items,
+  renderCell,
+  renderSectionHeader,
+}: Pick<DataTableProps<T, C>, "columns" | "items" | "renderCell" | "renderSectionHeader">): string {
+  const rows = items.flatMap((item, index) => {
+    if (renderSectionHeader?.(item, index)) return [];
+    return [columns.map((column) => renderCell(item, column, index, { selected: false }).text)];
+  });
+  return serializeCsv([
+    columns.map((column) => column.label),
+    ...rows,
+  ], { excelCompatible: true });
+}

--- a/src/components/ui/data-table/index.tsx
+++ b/src/components/ui/data-table/index.tsx
@@ -1,5 +1,5 @@
-import { type ComponentType } from "react";
-import { useUiHost } from "../../../ui";
+import { type ComponentType, useEffect, useRef } from "react";
+import { useRendererHost, useUiHost } from "../../../ui";
 import { OpenTuiDataTable } from "./opentui";
 import type {
   DataTableColumn,
@@ -7,6 +7,9 @@ import type {
 } from "./types";
 import { useRemoteUiNode } from "../../../remote/semantic-tree";
 import { remoteNumberValue, resolveRemoteItemIndex } from "../../../remote/semantic-helpers";
+import { useOptionalPaneInstanceId } from "../../../state/app/context";
+import { registerPaneTableExporter } from "../../../state/pane-table-export-registry";
+import { createDataTableCsv } from "../../data-table/export";
 
 export type {
   DataTableCell,
@@ -19,6 +22,20 @@ export type {
 export function DataTable<T, C extends DataTableColumn = DataTableColumn>(
   props: DataTableProps<T, C>,
 ) {
+  const paneId = useOptionalPaneInstanceId();
+  const renderer = useRendererHost();
+  const propsRef = useRef(props);
+  propsRef.current = props;
+
+  useEffect(() => {
+    if (!paneId || !renderer.saveTextFile) return;
+    return registerPaneTableExporter(paneId, (filename) => renderer.saveTextFile!({
+      name: filename,
+      text: createDataTableCsv(propsRef.current),
+      mimeType: "text/csv;charset=utf-8",
+    }));
+  }, [paneId, renderer]);
+
   useRemoteUiNode({
     role: "table",
     label: "Data table",

--- a/src/plugins/builtin/earnings/index.tsx
+++ b/src/plugins/builtin/earnings/index.tsx
@@ -253,6 +253,7 @@ export const earningsModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 85, height: 25 },
+      tableExport: true,
       settings: earningsSettings,
     },
   ],

--- a/src/plugins/builtin/econ/index.tsx
+++ b/src/plugins/builtin/econ/index.tsx
@@ -399,6 +399,7 @@ export const economicCalendarModule: PluginModule = {
     defaultPosition: "right",
     defaultMode: "floating",
     defaultFloatingSize: { width: 100, height: 30 },
+    tableExport: true,
   }],
   paneTemplates: [{
     id: "econ-calendar-pane",

--- a/src/plugins/builtin/futures/index.tsx
+++ b/src/plugins/builtin/futures/index.tsx
@@ -250,6 +250,7 @@ export const futuresModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 76, height: 34 },
+      tableExport: true,
       // Resolved per open so the dialog shows the full default set until the
       // user saves a narrower selection.
       settings: (context) => ({

--- a/src/plugins/builtin/fx-matrix/index.tsx
+++ b/src/plugins/builtin/fx-matrix/index.tsx
@@ -169,6 +169,7 @@ export const fxMatrixModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 105, height: 14 },
+      tableExport: true,
       settings: (context) => ({
         title: "FX Cross Rates Settings",
         values: {

--- a/src/plugins/builtin/ipo-calendar/index.tsx
+++ b/src/plugins/builtin/ipo-calendar/index.tsx
@@ -40,6 +40,7 @@ export const ipoCalendarModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 110, height: 28 },
+      tableExport: true,
     },
   ],
 

--- a/src/plugins/builtin/market-halts/index.tsx
+++ b/src/plugins/builtin/market-halts/index.tsx
@@ -12,6 +12,7 @@ export const marketHaltsModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 124, height: 26 },
+      tableExport: true,
     },
   ],
 

--- a/src/plugins/builtin/market-movers/index.tsx
+++ b/src/plugins/builtin/market-movers/index.tsx
@@ -324,6 +324,7 @@ export const marketMoversModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 100, height: 36 },
+      tableExport: true,
       quickSettings: [LIVE_STREAMING_QUICK_SETTING],
       settings: (context) => withLiveStreamingSetting({
         title: "Market Movers Settings",

--- a/src/plugins/builtin/portfolio-list/index.tsx
+++ b/src/plugins/builtin/portfolio-list/index.tsx
@@ -48,6 +48,7 @@ export const portfolioListModule: PluginModule = {
       defaultMode: "floating",
       defaultWidth: "40%",
       tickerSource: true,
+      tableExport: true,
       quickSettings: [LIVE_STREAMING_QUICK_SETTING],
       portableShare: {
         private: {

--- a/src/plugins/builtin/scanner/index.ts
+++ b/src/plugins/builtin/scanner/index.ts
@@ -72,6 +72,7 @@ export const scannerModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 76, height: 26 },
+      tableExport: true,
       settings: hiloSettings(),
     },
     {
@@ -82,6 +83,7 @@ export const scannerModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 88, height: 28 },
+      tableExport: true,
       settings: flowSettings(),
     },
   ],

--- a/src/plugins/builtin/sectors/index.tsx
+++ b/src/plugins/builtin/sectors/index.tsx
@@ -320,6 +320,7 @@ export const sectorsModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 82, height: 18 },
+      tableExport: true,
       settings: (context) => ({
         title: "Sector Performance Settings",
         values: {

--- a/src/plugins/builtin/ticker-detail/index.tsx
+++ b/src/plugins/builtin/ticker-detail/index.tsx
@@ -52,6 +52,7 @@ export const tickerDetailModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 98, height: 30 },
+      tableExport: true,
     },
     {
       id: "quote-monitor",
@@ -72,6 +73,7 @@ export const tickerDetailModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 92, height: 26 },
+      tableExport: true,
     },
     {
       id: "provider-search-results",

--- a/src/plugins/builtin/treasury-auctions/index.tsx
+++ b/src/plugins/builtin/treasury-auctions/index.tsx
@@ -59,6 +59,7 @@ export const treasuryAuctionsModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 92, height: 28 },
+      tableExport: true,
       settings: treasuryAuctionsSettings(),
     },
   ],

--- a/src/plugins/builtin/world-indices/index.tsx
+++ b/src/plugins/builtin/world-indices/index.tsx
@@ -129,6 +129,7 @@ export const worldIndicesModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 96, height: 32 },
+      tableExport: true,
       // Resolved per open so the dialog shows the full board until the user
       // saves a narrower selection.
       settings: (context) => ({

--- a/src/plugins/registry/pane-settings.test.ts
+++ b/src/plugins/registry/pane-settings.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test";
+import { registerPaneTableExporter } from "../../state/pane-table-export-registry";
+import { createDefaultConfig } from "../../types/config";
+import type { AppNotificationRequest, PaneDef } from "../../types/plugin";
+import { resolveRegistryPaneSettings } from "./pane-settings";
+
+test("adds a working CSV action to exportable table panes", async () => {
+  const pane = { instanceId: "prices:main", paneId: "prices", title: "Market Prices" };
+  const config = createDefaultConfig("/tmp/gloomberb-pane-export-test");
+  config.layout.instances = [pane];
+  const filenames: string[] = [];
+  const unregister = registerPaneTableExporter(pane.instanceId, async (filename) => {
+    filenames.push(filename);
+    return `~/Downloads/${filename}`;
+  });
+
+  try {
+    const paneDef: PaneDef = {
+      id: pane.paneId,
+      name: "Prices",
+      component: () => null,
+      defaultPosition: "right",
+      tableExport: true,
+    };
+    const resolved = resolveRegistryPaneSettings({
+      config,
+      getConfigState: () => null,
+      getPaneRuntimeState: () => null,
+      layout: config.layout,
+      paneDefs: new Map([[pane.paneId, paneDef]]),
+      paneOwners: new Map(),
+      resolvePaneTarget: () => pane.instanceId,
+      requestedPaneId: pane.instanceId,
+    });
+    const field = resolved?.settingsDef.fields[0];
+    expect(field).toMatchObject({ type: "action", label: "Export CSV", disabled: false });
+    if (!field || field.type !== "action" || !resolved) throw new Error("Missing export action");
+
+    const notifications: AppNotificationRequest[] = [];
+    await field.action({
+      ...resolved.context,
+      surface: "pane-dialog",
+      close: () => {},
+      openCommandBar: () => {},
+      notify: (notification) => notifications.push(notification),
+    });
+
+    expect(filenames[0]).toMatch(/^Market-Prices-.*\.csv$/);
+    expect(notifications[0]).toMatchObject({ type: "success" });
+  } finally {
+    unregister();
+  }
+});

--- a/src/plugins/registry/pane-settings.ts
+++ b/src/plugins/registry/pane-settings.ts
@@ -12,6 +12,11 @@ import type {
   PaneSettingsContext,
   PaneSettingsDef,
 } from "../../types/plugin";
+import {
+  exportPaneTable,
+  hasPaneTableExporter,
+} from "../../state/pane-table-export-registry";
+import { createCsvExportFilename } from "../../utils/csv";
 
 export interface ResolvedRegistryPaneSettings {
   paneId: string;
@@ -76,7 +81,7 @@ export function resolveRegistryPaneSettings({
   if (!pane) return null;
 
   const paneDef = paneDefs.get(pane.paneId);
-  if (!paneDef?.settings) return null;
+  if (!paneDef || (!paneDef.settings && !paneDef.tableExport)) return null;
 
   const pluginId = paneOwners.get(pane.paneId);
   const paneSettings = getPaneSettings(pane);
@@ -99,10 +104,38 @@ export function resolveRegistryPaneSettings({
     activeTicker: resolveTickerForPane(stateView, targetPaneId),
     activeCollectionId: resolveCollectionForPane(stateView, targetPaneId),
   };
-  const settingsDef = typeof paneDef.settings === "function"
+  const baseSettingsDef = typeof paneDef.settings === "function"
     ? paneDef.settings(context)
     : paneDef.settings;
-  if (!settingsDef) return null;
+  if (!baseSettingsDef && !paneDef.tableExport) return null;
+  const settingsDef: PaneSettingsDef = paneDef.tableExport
+    ? {
+      ...(baseSettingsDef ?? {}),
+      fields: [
+        ...(baseSettingsDef?.fields ?? []),
+        {
+          key: "tableExport.csv",
+          label: "Export CSV",
+          description: "Export the current table as an Excel-compatible CSV file.",
+          type: "action",
+          actionId: "table.export-csv",
+          actionLabel: "Export",
+          disabled: !hasPaneTableExporter(targetPaneId),
+          action: async (actionContext) => {
+            try {
+              const location = await exportPaneTable(
+                targetPaneId,
+                createCsvExportFilename(pane.title ?? paneDef.name),
+              );
+              actionContext.notify({ body: `Exported to ${location}`, type: "success" });
+            } catch {
+              actionContext.notify({ body: "Failed to export CSV", type: "error" });
+            }
+          },
+        },
+      ],
+    }
+    : baseSettingsDef!;
 
   const rawSettings = { ...paneSettings };
   const resolvedSettings = {

--- a/src/renderers/browser/ui-host.tsx
+++ b/src/renderers/browser/ui-host.tsx
@@ -27,6 +27,17 @@ export const browserRendererHost: RendererHost = {
   async readText() {
     return navigator.clipboard.readText();
   },
+  async saveTextFile({ name, text, mimeType }) {
+    const url = URL.createObjectURL(new Blob([text], { type: mimeType }));
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = name;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+    return `Downloads/${name}`;
+  },
   async copyPngImage(pngBase64) {
     const ClipboardItemCtor = globalThis.ClipboardItem;
     if (!ClipboardItemCtor || !navigator.clipboard.write) {

--- a/src/renderers/electrobun/bun/desktop/host-requests.ts
+++ b/src/renderers/electrobun/bun/desktop/host-requests.ts
@@ -10,6 +10,7 @@ import type {
 import { safeExternalUrl } from "../../../../utils/external-url";
 import { getContextMenuRequestId, normalizeContextMenuItems } from "../context-menu/normalize";
 import { MAIN_WINDOW_RPC_KEY } from "../window/focus";
+import { saveTextFileToDownloads } from "../../../../utils/save-text-file";
 
 interface DesktopHostRequestOptions<TRpc> {
   clearMainWindow: () => void;
@@ -51,7 +52,7 @@ function normalizeWindowControlAction(action: unknown): DesktopWindowControlActi
   throw new Error("host.windowControl requires a valid action.");
 }
 
-export function handleDesktopHostRequest<TRpc>({
+export async function handleDesktopHostRequest<TRpc>({
   clearMainWindow,
   closeAllDetachedWindows,
   controlWindowForRpcKey,
@@ -63,7 +64,7 @@ export function handleDesktopHostRequest<TRpc>({
   rpc,
   teardownServices,
   trackContextMenuRequest,
-}: DesktopHostRequestOptions<TRpc>): DesktopBackendRequestResponse<DesktopHostRequest["method"]> {
+}: DesktopHostRequestOptions<TRpc>): Promise<DesktopBackendRequestResponse<DesktopHostRequest["method"]>> {
   switch (request.method) {
     case "host.restart":
       restartDesktopApp({
@@ -127,6 +128,12 @@ export function handleDesktopHostRequest<TRpc>({
     }
     case "host.readText":
       return Utils.clipboardReadText() ?? "";
+    case "host.saveTextFile": {
+      if (typeof request.payload.name !== "string" || typeof request.payload.text !== "string") {
+        throw new Error("host.saveTextFile requires a name and text.");
+      }
+      return saveTextFileToDownloads(request.payload.name, request.payload.text);
+    }
     case "host.notify":
       playNotificationSound(normalizeText(request.payload.sound));
       Utils.showNotification({

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -476,6 +476,7 @@ async function handleBackendRequest(
     case "host.focusWindow":
     case "host.copyPngImage":
     case "host.readText":
+    case "host.saveTextFile":
     case "host.notify":
     case "host.showContextMenu":
       return handleDesktopHostRequest({

--- a/src/renderers/electrobun/shared/protocol.ts
+++ b/src/renderers/electrobun/shared/protocol.ts
@@ -119,6 +119,10 @@ export interface DesktopBackendRequestMap {
   "host.focusWindow": { request: null; response: null };
   "host.copyPngImage": { request: { pngBase64: string }; response: null };
   "host.readText": { request: null; response: string };
+  "host.saveTextFile": {
+    request: { name: string; text: string; mimeType: string };
+    response: string;
+  };
   "host.notify": {
     request: { title?: string; body?: string; subtitle?: string; sound?: string };
     response: null;

--- a/src/renderers/electrobun/view/ui-host.tsx
+++ b/src/renderers/electrobun/view/ui-host.tsx
@@ -61,6 +61,9 @@ export const webRendererHost: RendererHost = {
       return backendRequest("host.readText");
     }
   },
+  async saveTextFile({ name, text, mimeType }) {
+    return backendRequest("host.saveTextFile", { name, text, mimeType });
+  },
   notify(notification) {
     void backendRequest("host.notify", {
       title: notification.title,

--- a/src/renderers/opentui/host.tsx
+++ b/src/renderers/opentui/host.tsx
@@ -7,6 +7,7 @@ import type { NativeRendererHost, PixelResolution, RendererHost } from "../../ui
 import { colors } from "../../theme/colors";
 import { safeExternalUrl } from "../../utils/external-url";
 import { createTerminalMediaReaper, terminalMediaStateFile } from "./terminal-media";
+import { saveTextFileToDownloads } from "../../utils/save-text-file";
 
 export { useKeyboard, useTerminalDimensions };
 
@@ -133,6 +134,9 @@ export async function createOpenTuiHost(): Promise<OpenTuiHost> {
         stderr: "ignore",
       });
       return await new Response(proc.stdout).text();
+    },
+    async saveTextFile({ name, text }) {
+      return saveTextFileToDownloads(name, text);
     },
     notify() {
       // The app-level notifier still owns toast/desktop notification behavior.

--- a/src/state/pane-table-export-registry.ts
+++ b/src/state/pane-table-export-registry.ts
@@ -1,0 +1,31 @@
+export type PaneTableExporter = (filename: string) => Promise<string>;
+
+const exporters = new Map<string, Map<symbol, PaneTableExporter>>();
+
+export function registerPaneTableExporter(
+  paneId: string,
+  exporter: PaneTableExporter,
+): () => void {
+  const token = Symbol(paneId);
+  const paneExporters = exporters.get(paneId) ?? new Map<symbol, PaneTableExporter>();
+  paneExporters.set(token, exporter);
+  exporters.set(paneId, paneExporters);
+
+  return () => {
+    const current = exporters.get(paneId);
+    current?.delete(token);
+    if (current?.size === 0) exporters.delete(paneId);
+  };
+}
+
+export function hasPaneTableExporter(paneId: string): boolean {
+  return exporters.get(paneId)?.size === 1;
+}
+
+export async function exportPaneTable(paneId: string, filename: string): Promise<string> {
+  const paneExporters = exporters.get(paneId);
+  if (paneExporters?.size !== 1) {
+    throw new Error("This pane does not have one active exportable table.");
+  }
+  return [...paneExporters.values()][0]!(filename);
+}

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -67,6 +67,8 @@ export interface PaneDef {
   defaultMode?: "docked" | "floating";
   /** Pane publishes its selected symbol as pane-state `cursorSymbol`, so ticker panes can follow it. */
   tickerSource?: boolean;
+  /** Add an Excel-compatible CSV action for the pane's single active DataTable. */
+  tableExport?: true;
   settings?: PaneSettingsDef | ((context: PaneSettingsContext) => PaneSettingsDef | null);
   /** Portable sharing is public by default; list the few pane-owned fields that must remain local. */
   portableShare?: PanePortableShareDef;

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -378,6 +378,12 @@ export interface UiHost {
   colorFromHex?(hex: string): unknown;
 }
 
+export interface SaveTextFileRequest {
+  name: string;
+  text: string;
+  mimeType: string;
+}
+
 export interface RendererHost {
   requestExit(): void;
   startWindowDrag?(): Promise<void> | void;
@@ -386,6 +392,7 @@ export interface RendererHost {
   copyText(text: string): Promise<void>;
   copyPngImage?(pngBase64: string): Promise<void>;
   readText(): Promise<string>;
+  saveTextFile?(request: SaveTextFileRequest): Promise<string>;
   supportsNativeDesktopNotifications?: boolean;
   notify(notification: AppNotificationRequest): void;
   showContextMenu?(items: ContextMenuItem[]): Promise<boolean>;

--- a/src/utils/csv.test.ts
+++ b/src/utils/csv.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { EXCEL_CSV_BOM, serializeCsv } from "./csv";
+
+describe("serializeCsv", () => {
+  test("escapes cells and can emit an Excel UTF-8 BOM", () => {
+    const csv = serializeCsv([
+      ["Name", "Note", "Value"],
+      ["ACME, Inc.", "said \"hello\"\nagain", "=1+1"],
+    ], { excelCompatible: true });
+
+    expect(csv).toBe(`${EXCEL_CSV_BOM}Name,Note,Value\n"ACME, Inc.","said ""hello""\nagain",'=1+1`);
+  });
+});

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,37 @@
+export const EXCEL_CSV_BOM = "\uFEFF";
+
+function normalizeCsvCell(value: unknown): string {
+  if (value == null) return "";
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function escapeCsvCell(value: unknown, excelCompatible: boolean): string {
+  const normalized = normalizeCsvCell(value);
+  const text = excelCompatible && /^[\t\r ]*[=+\-@]/.test(normalized)
+    ? `'${normalized}`
+    : normalized;
+  if (!/[",\n\r]/.test(text)) return text;
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+export function serializeCsv(
+  rows: readonly (readonly unknown[])[],
+  options: { excelCompatible?: boolean } = {},
+): string {
+  const excelCompatible = options.excelCompatible === true;
+  const csv = rows.map((row) => row.map((cell) => escapeCsvCell(cell, excelCompatible)).join(",")).join("\n");
+  return excelCompatible ? `${EXCEL_CSV_BOM}${csv}` : csv;
+}
+
+export function createCsvExportFilename(title: string): string {
+  const stem = title.trim()
+    .replace(/[<>:"/\\|?*\u0000-\u001f]/g, "-")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[. -]+|[. -]+$/g, "")
+    .slice(0, 80) || "gloomberb-table";
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return `${stem}-${timestamp}.csv`;
+}

--- a/src/utils/save-text-file.test.ts
+++ b/src/utils/save-text-file.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveTextFileToDirectory } from "./save-text-file";
+
+let directory: string | null = null;
+
+afterEach(async () => {
+  if (directory) await rm(directory, { recursive: true, force: true });
+  directory = null;
+});
+
+test("keeps existing exports instead of overwriting them", async () => {
+  directory = await mkdtemp(join(tmpdir(), "gloomberb-export-"));
+
+  const first = await saveTextFileToDirectory(directory, "prices.csv", "first");
+  const second = await saveTextFileToDirectory(directory, "prices.csv", "second");
+
+  expect(first).toBe("prices.csv");
+  expect(second).toBe("prices (2).csv");
+  expect(await readFile(join(directory, first), "utf-8")).toBe("first");
+  expect(await readFile(join(directory, second), "utf-8")).toBe("second");
+});

--- a/src/utils/save-text-file.ts
+++ b/src/utils/save-text-file.ts
@@ -1,0 +1,36 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, extname, join } from "node:path";
+
+function safeFilename(name: string): string {
+  const safe = basename(name.replace(/\\/g, "/"))
+    .replace(/[<>:"|?*\u0000-\u001f]/g, "-")
+    .replace(/[. ]+$/g, "");
+  return !safe || safe === "." || safe === ".." ? "gloomberb-export.txt" : safe;
+}
+
+export async function saveTextFileToDirectory(
+  directory: string,
+  name: string,
+  text: string,
+): Promise<string> {
+  await mkdir(directory, { recursive: true });
+  const safeName = safeFilename(name);
+  const extension = extname(safeName);
+  const stem = safeName.slice(0, safeName.length - extension.length);
+
+  for (let copy = 1; ; copy += 1) {
+    const filename = copy === 1 ? safeName : `${stem} (${copy})${extension}`;
+    try {
+      await writeFile(join(directory, filename), text, { encoding: "utf-8", flag: "wx" });
+      return filename;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+  }
+}
+
+export async function saveTextFileToDownloads(name: string, text: string): Promise<string> {
+  const filename = await saveTextFileToDirectory(join(homedir(), "Downloads"), name, text);
+  return `~/Downloads/${filename}`;
+}


### PR DESCRIPTION
## Summary
- add a shared `DataTable` export path for current sorted, filtered rows and visible columns
- save Excel-compatible UTF-8 CSV files through terminal, desktop, and browser renderer hosts
- expose Export CSV in pane settings for portfolio, market board, calendar, scanner, historical price, and financial statement tables
- avoid overwrites and guard Excel formula cells

## Checks
- all 6 TypeScript projects pass
- focused export tests pass: 4/4
- desktop view and browser builds pass
- terminal tmux smoke exported a real Portfolio CSV to `~/Downloads` with no runtime warnings
- full suite: 2,380 pass; 4 command-bar AI assist timing tests fail under the full parallel run, then pass 6/6 in focused rerun
- i18n audit still reports the existing 52 referenced-key gaps per locale
