### PR TITLE
feat(macro): add Buffett Indicator pane (BUF)

### DIFF
--- a/.cursor/plans/buffett-indicator.md
+++ b/.cursor/plans/buffett-indicator.md
@@ -1,0 +1,381 @@
+# Buffett Indicator — built-in macro pane
+
+## Context
+
+Gloomberb has no market-wide *valuation* read. The `macro` plugin covers the economic calendar,
+yield curve, volatility, credit spreads, and Treasury auctions, but nothing answers "is the whole US
+market expensive right now?" The Buffett Indicator (total US equity market cap ÷ GDP) is the
+canonical answer, and every input is already reachable through infrastructure this repo owns: the
+Gloom Cloud FRED proxy (`/cloud/econ/series/:id`) plus the shared FRED cache in
+`src/data/fred-series.ts`. No new data source, no new backend route, no new credentials.
+
+### Why built-in rather than an installable plugin
+
+This was checked against GitHub, not assumed:
+
+- `gh search code "GloomPlugin"` returns hits in **one repo** — `gloom-sh/gloomberb` itself. Despite
+  2005 stars and 124 forks, **no third-party plugin has ever been published.**
+- External plugins with UI cannot run today anyway. `package.json` has no `exports` map, so every
+  specifier PLUGINS.md documents (`gloomberb/ui`, `gloomberb/components`) fails to resolve; there is
+  no `Bun.plugin` resolver anywhere in `src/`; and `installPlugin` runs `bun install` inside the
+  plugin directory (`src/cli/commands/plugins.ts:76`), giving the plugin a **second React copy**.
+  Elements cross that boundary but every hook throws. Also, `loadExternalPlugins()` is called only
+  from `src/cli/entry.ts:39` and `src/renderers/opentui/start.tsx:76` — external plugins are
+  terminal-only and never appear in desktop or web.
+- The maintainer is actively **removing** unused plugin API: PR #652, "Drop unfinished plugin CLI
+  descriptors" — *"Remove the unused `GloomPlugin.cli` / `PluginCliCommandDescriptor` API."*
+
+**Every comparable feature ships as a built-in module.** PR #632 "Add single-name CDS activity
+monitor" is this pane's twin, and this plan mirrors its structure exactly.
+
+**Work happens on a feature branch only — do not merge to `main`.**
+
+---
+
+## Step 0 — Rebase onto upstream
+
+Branch `feat/buffett-indicator` already exists and this document is already at
+`.cursor/plans/buffett-indicator.md` (untracked — commit it as the first commit).
+
+The branch was cut from a checkout that is **~33 PRs behind upstream** (local base is `3a479776`,
+PR #621; upstream is at #654). `composite-plugins.ts` and `catalog-browser.ts` are precisely the
+files that have moved. **Rebase before writing code** or the registration hunks will conflict:
+
+```bash
+git remote add upstream https://github.com/gloom-sh/gloomberb.git   # if absent
+git fetch upstream
+git rebase upstream/main
+```
+
+Stay on `feat/buffett-indicator`. Do not merge to `main`.
+
+After rebasing, re-read `PLUGINS.md` — PR #652 removed the `cli.commands` API that the pre-rebase
+copy still documents. This plan adds no CLI command, so nothing here depends on it, but do not
+reintroduce it from the stale doc.
+
+---
+
+## Reference implementation
+
+`git show` PR #632 upstream before starting. Its shape is the target:
+
+```
+src/plugins/builtin/cds/model.ts        401   model.test.ts   232
+src/plugins/builtin/cds/pane.tsx        358   pane.test.tsx   132
+src/plugins/builtin/cds/client.ts        67   client.test.ts   83
+src/plugins/builtin/cds/index.tsx        47   ← module export only
+src/plugins/builtin/composite-plugins.ts  +3/-1
+src/plugins/catalog-browser.ts            +3/-1
+README.md                                 +1
+```
+
+Note the `pane.tsx` / `index.tsx` split — `index.tsx` holds only the `PluginModule` export. That is
+newer than `credit-conditions`, which puts both in `index.tsx`. **Follow #632.**
+
+Unlike #632, this pane needs **no `src/api-client/` changes** — it reuses the existing
+`/cloud/econ/series/:id` route via `apiClient.getCloudFredSeries`.
+
+---
+
+## The metric
+
+`Buffett Indicator = US total equity market capitalization ÷ US GDP × 100`
+
+Two numerator modes, both dimensionally correct in $ billions, both from FRED. Separate labeled
+views — no cross-calibration between them.
+
+| Mode | Numerator | Denominator | Notes |
+|------|-----------|-------------|-------|
+| **Wilshire** (default) | `WILL5000PRFC` — Wilshire 5000 Full Cap Price Index, daily. Index level ≈ market cap in $B by construction (≈50,000 ↔ ≈$50T). | `GDP` (billions, quarterly SAAR), linearly interpolated | Daily, history to 1971 |
+| **Z.1** | `NCBEILQ027S` — Nonfinancial Corporate Business; Corporate Equities; Liability, Level. **Units are millions — divide by 1000.** | `GDP`, same quarter | Quarterly, official Flow of Funds, to 1945, ~1 quarter lag |
+
+### ⚠️ Verify before building the UI
+
+FRED discontinued several Wilshire series, and `fred.stlouisfed.org` blocks automated fetches, so
+this could not be confirmed while planning. **First task after the branch exists:** run the app and
+confirm `WILL5000PRFC` returns recent observations through the cloud proxy. If it is dead or months
+stale:
+
+1. Try `WILL5000PR` (price index, non-full-cap).
+2. Otherwise make Z.1 the default and mark Wilshire unavailable.
+
+Z.1 is the guaranteed path and must work regardless. The pane degrades to whichever mode resolves and
+names the resolved source in the body — never an empty pane.
+
+### GDP handling
+
+Quarterly, seasonally adjusted at an annual rate, published with a lag.
+
+- **Wilshire mode:** linearly interpolate GDP between quarterly observations; hold the last value
+  flat forward past the final one. Do **not** extrapolate the trend.
+- **Z.1 mode:** align on the quarter, no interpolation.
+- Show the GDP vintage (`GDP as of 2026Q2`) in the body. The lag is a real caveat; hiding it
+  misrepresents the number.
+
+### Valuation zones
+
+| Ratio | Zone | Color |
+|-------|------|-------|
+| < 75% | Significantly Undervalued | `colors.positive` |
+| 75–90% | Modestly Undervalued | blended positive |
+| 90–115% | Fair Valued | `colors.textBright` |
+| 115–135% | Modestly Overvalued | `colors.warning` |
+| > 135% | Significantly Overvalued | `colors.negative` |
+
+### Trend deviation
+
+Fixed bands read "overvalued" for a decade straight because the ratio trends up secularly, so also
+fit a trend:
+
+- Regress `ln(ratio)` on time (OLS over the full resolved history).
+- Residual σ in log space; deviation = `(ln(current) − ln(trend_now)) / σ`.
+- Display as `+1.8σ above trend` next to the fixed-band zone.
+- Also compute all-time high/low with dates and the current historical percentile.
+
+---
+
+## Files
+
+New directory `src/plugins/builtin/buffett-indicator/`:
+
+| File | Contents |
+|------|----------|
+| `model.ts` | Series definitions, mode types, GDP interpolation, ratio construction, log-linear trend + σ, zone classification, percentile/extremes. Pure functions, no React, no network. |
+| `model.test.ts` | The math. See Tests. |
+| `settings.ts` | `buildBuffettSettingsDef()` + `getBuffettPaneSettings()`. |
+| `client.ts` | FRED fetch + cache orchestration. |
+| `pane.tsx` | `BuffettIndicatorPane` + the chart. |
+| `pane.test.tsx` | One render test over seeded persistence. |
+| `index.tsx` | `buffettIndicatorModule` export only. |
+
+### `client.ts`
+
+Mirror `src/plugins/builtin/credit-conditions/client.ts` in shape:
+
+- `requestFor(seriesId)` → `FredSeriesRequest`
+- `getCachedBuffettIndicator(mode)` — synchronous cached-first read via
+  `getCachedFredSeries(..., { allowExpired: true })`, so the pane paints instantly on open
+- `loadBuffettIndicator(mode, force)` — `Promise.allSettled` over the mode's two series through
+  `loadCachedFredSeries(request, () => apiClient.getCloudFredSeries(...), { force })`
+- Fail with one summarized message when both series fail — reuse the idea in `summarizeSeriesErrors`
+  (`credit-conditions/client.ts:100`), which exists because six failing series produced a message
+  several times wider than the pane
+
+Persistence is already attached: `macroSharedResourcesModule` calls `attachFredSeriesPersistence`
+(`composite-plugins.ts:33`) and `browserFredResourcesModule` does the same
+(`catalog-browser.ts:91`). Nothing to add, and do not call it from this module.
+
+History limits: Wilshire wants a long daily history — `sortOrder: "desc"` with a generous limit
+(≈4000 ≈ 16 years of business days) or a `startDate`. Z.1 is quarterly; ~340 covers 1945→now.
+
+### `settings.ts`
+
+Mode and range are pane **settings**, not component state — PLUGINS.md's pane-settings section is
+the documented home for per-instance options, and it brings layout persistence, the settings
+dialog, and command-bar editing along with it.
+
+Follow `src/plugins/builtin/correlation/settings.ts`: export
+`buildBuffettSettingsDef(): PaneSettingsDef` plus a `getBuffettPaneSettings(settings)` normalizer
+that coerces unknown stored values back to defaults.
+
+```typescript
+fields: [
+  { key: "mode",  label: "Numerator", type: "select",
+    options: [{ value: "wilshire", label: "Wilshire 5000 (daily)" },
+              { value: "z1",       label: "Z.1 corporate equities (quarterly)" }] },
+  { key: "range", label: "History",   type: "select",
+    options: [{ value: "10Y", label: "10Y" }, { value: "25Y", label: "25Y" }, { value: "ALL", label: "All" }] },
+]
+```
+
+Read with `usePaneSettingValue<Mode>("mode", defaults.mode)` (`correlation/index.tsx:50`) and bind
+the in-body `SegmentedControl`s to the same setter, so the header control and the dialog share one
+value. Do **not** use `usePluginPaneState` — PLUGINS.md describes it as per-pane transient state,
+and this is a persisted preference.
+
+### `pane.tsx`
+
+```
+Box, Text, TextAttributes                        from "../../../ui"
+SegmentedControl, SpeedometerGauge, StaticChartSurface,
+EmptyState, Spinner, usePaneFooter               from "../../../components"
+usePaneSettingValue                              from "../../../state/app/context"
+colors, blendHex                                 from "../../../theme/colors"
+useShortcut                                      from "../../../react/input"
+useAutoRefresh                                   from "../shared/auto-refresh"
+usePaneStatusFooter                              from "../shared/pane-footer"
+PaneProps                                        from "../../../types/plugin"
+```
+
+Top to bottom:
+
+1. **Header** — current ratio (bold, zone-colored), zone label, `±Nσ vs trend`, `as of <date>`. Per
+   AGENTS.md do not repeat the pane title; lead with the number.
+2. **`SpeedometerGauge`** — `min={0} max={250}`, segments from the zone table, `valueLabel="142%"`.
+   It is exported from `src/components/index.ts:11` and currently **has no consumer in the repo** —
+   this pane is its first. It picks `DesktopSpeedometerGauge` (SVG) or `TerminalSpeedometerGauge`
+   via `useUiHost()` internally, so both renderers are covered for free.
+3. **Chart** (below).
+4. **Stats strip** — market cap ($T), GDP ($T) + vintage quarter, ratio 1y ago, all-time high/low
+   with dates, percentile.
+5. **Controls** — `SegmentedControl` for mode and range, bound to the pane settings.
+
+**Footer** via `usePaneStatusFooter({ registrationId: "buffett-indicator", loading, error, info })`.
+Info segments: `as of <date>`, `delayed`, `STALE` when the newest observation is older than the
+series' cadence, `PARTIAL` when only one mode resolved. Per AGENTS.md the footer carries only
+changing status — no pane label, no row counts.
+
+> **Conflict, resolve in the repo's favor:** PLUGINS.md's footer section lists `[r]efresh` as an
+> acceptable pane hint. The repo has since decided otherwise — `r` refreshes every pane, so it is
+> global product knowledge and gets no per-pane hint (see the comment at
+> `src/plugins/builtin/shared/pane-footer.ts:12` and PR #589). Register **no** hints. Do not "fix"
+> this by following the older PLUGINS.md example.
+
+**Interactivity** (AGENTS.md: everything interactive gets mouse + cursor). `SegmentedControl`
+handles clicks; `r` reloads with `force` via `useShortcut` guarded on `focused`
+(`credit-conditions/index.tsx:133`); `useAutoRefresh(lastUpdated, refresh)` follows the global
+cadence and the FRED cache decides whether a tick hits the network; the chart crosshair comes from
+`StaticChartSurface`.
+
+### Chart (in `pane.tsx`)
+
+Model on `src/plugins/builtin/fear-greed/charts.tsx:186` — `StaticChartSurface` with `mode="line"`,
+a palette from `resolveChartPalette`, `showTimeAxis`, and
+`formatYAxisValue={(v) => \`${Math.round(v)}%\`}`. Ratio points become `ProjectedChartPoint[]`
+(`{ date, open, high, low, close, volume }`, all prices set to the ratio).
+
+Overlays via `ChartIndicatorOverlays`:
+- `bollinger: { middle: trend, upper: +2σ, lower: −2σ, color }` — drawn as three lines
+  (`chart-draw.ts:265`), no fill.
+- `smaLines: [{ period: 0, points: ±1σ, color }]` for the inner band, as fear-greed does for its
+  secondary line.
+
+Overlay points are `{ index, value }` indexed into the same point array.
+
+> **Gotcha:** the chart's y-scale comes from the data points alone —
+> `src/components/chart/core/scene.ts:113-119` takes min/max of `close` in line mode and ignores
+> `indicators` entirely. σ bands outside the data range clip silently. Clamp overlay values to
+> `[dataMin, dataMax]` before passing them. Over a long history the data crosses ±2σ anyway, so
+> clamping is the correct cheap fix.
+
+Do not draw lines, bands, or markers with terminal cell characters (AGENTS.md) —
+`StaticChartSurface` covers the renderer split. Never disable the kitty renderer to fix a chart
+issue; fix the cause.
+
+`resolveChartPalette` lives at `src/components/chart/core/palette.ts` and is not in the components
+barrel; `fear-greed/charts.tsx:7` deep-imports it. Either follow that precedent or add a one-line
+re-export to `src/components/index.ts` — the latter is slightly better, since PLUGINS.md tells
+plugin UI to consume shared APIs rather than unexported internals.
+
+### `index.tsx`
+
+```typescript
+export const buffettIndicatorModule: PluginModule = {
+  panes: [{
+    id: "buffett-indicator",
+    name: "Buffett Indicator",
+    icon: "B",
+    component: BuffettIndicatorPane,
+    defaultPosition: "right",
+    defaultMode: "floating",
+    defaultFloatingSize: { width: 84, height: 26 },
+    settings: buildBuffettSettingsDef(),
+  }],
+  paneTemplates: [{
+    id: "buffett-indicator-pane",
+    paneId: "buffett-indicator",
+    label: "Buffett Indicator",
+    description: "US total market cap to GDP with valuation zones and trend deviation.",
+    keywords: ["buffett", "indicator", "valuation", "market cap", "gdp", "wilshire", "macro", "bubble"],
+    shortcut: { prefix: "BUF" },
+  }],
+};
+```
+
+No `setup`/`dispose` — FRED persistence belongs to the macro plugin's shared module. Confirm `BUF`
+is unclaimed against the README pane table after rebasing; upstream added panes since #621.
+
+---
+
+## Registration
+
+Mirrors #632's `+3/-1` hunks:
+
+1. `src/plugins/builtin/composite-plugins.ts` — import `buffettIndicatorModule`, add to
+   `macroPlugin.modules` after `creditConditionsModule`.
+2. `src/plugins/catalog-browser.ts` — same, into `browserMacroPlugin.modules`. Safe because the data
+   path is the cloud FRED proxy the browser catalog already uses.
+3. `README.md` — add `| \`BUF\` | US market cap to GDP with valuation zones |` to the pane shortcut
+   table next to `CRD`. PLUGINS.md requires README tables to track the live registry. Check whether
+   `README.zh-CN.md` carries the same table upstream (PR #640 touched both) and update it if so.
+
+Optional doc fix, in the spirit of PLUGINS.md's "do not import unexported shared components" rule:
+add `SpeedometerGauge` and `StaticChartSurface` to PLUGINS.md's "Available components" list. Both are
+exported from `src/components/index.ts` but undocumented, so the guide currently steers plugin
+authors away from components they are allowed to use.
+
+---
+
+## Tests
+
+Per AGENTS.md — test the math and the integration boundary, nothing else. No tests for zone label
+strings, pane template metadata, or segment colors. #632 spent 232 test lines on `model.ts` and 132
+on the pane; that ratio is right.
+
+**`model.test.ts`** — the real value:
+- GDP interpolation: midpoint between two quarterly observations; flat-forward past the last one;
+  market observations that predate the first GDP point.
+- **Unit conversion: `NCBEILQ027S` millions → billions.** A 1000× error here is silently plausible
+  and would make the pane wrong by three orders of magnitude.
+- Ratio alignment: a daily market series against quarterly GDP yields one ratio point per market
+  observation, none dropped or duplicated.
+- Log-linear trend + σ: on a synthetic series with a known exponential growth rate, the fitted slope
+  and a known outlier's σ come back correct.
+- Zone classification at the exact boundaries (75, 90, 115, 135).
+
+**`pane.test.tsx`** — one test: render over `MemoryPluginPersistence` seeded with both FRED series
+and assert the ratio and zone appear. Copy the harness from
+`src/plugins/builtin/credit-conditions/index.test.tsx` — `testRender` from
+`renderers/opentui/test-utils`, `attachFredSeriesPersistence`, the `settle()` helper, and the
+`persistence.seedResource("fred-series", "<ID>:limit=N:sort=desc", ...)` key format. **That cache-key
+string must match `cacheKey()` in `src/data/fred-series.ts:62` exactly** or the seed is ignored and
+the test silently exercises the loading state instead.
+
+---
+
+## Verification
+
+```bash
+bun test src/plugins/builtin/buffett-indicator
+bun run typecheck          # all six projects
+bun test                   # full suite
+```
+
+**Terminal (OpenTUI)** — use tmux per the `tui-testing` skill, and kill the session when done:
+
+```bash
+bun run dev
+```
+
+Type `BUF`. Check: pane opens floating at a sane size; gauge needle sits in the right segment; chart
+draws with trend and σ lines visible and not clipped; mode and range toggles switch by click and
+survive closing and reopening the pane; `r` reloads; footer shows `as of` / `delayed` and nothing
+static. Narrow the pane to ~60 columns and confirm the layout degrades rather than overflowing.
+
+**Desktop (Electrobun)** — `bun run desktop:dev`, open `BUF`. Confirm the SVG speedometer renders
+(not the terminal fallback), the chart is canvas/DOM rather than cell characters, and mouse hover
+moves the crosshair. Per AGENTS.md do not load the OpenTUI or tui-testing skills for this pass.
+
+**Sanity-check the number.** As of 2026 the Wilshire reading should land in the 150–220% range. Near
+0.15 or near 150,000 means a unit conversion is wrong — fix that before calling the pane done.
+
+---
+
+## Out of scope
+
+- No CLI command. PR #652 removed the `cli.commands` API the local PLUGINS.md still documents.
+- No chart-composer preset or `chart-series` capability. The `ratio` study in
+  `src/time-series/types.ts` could express this, but a dedicated pane is the deliverable.
+- No external-plugin packaging work (`exports` map, react/gloomberb module linking). Real, but a
+  separate concern with no users today — raise it independently if it ever matters.
+- No merge to `main`. Branch `feat/buffett-indicator` only.

--- a/.cursor/plans/buffett-indicator.md
+++ b/.cursor/plans/buffett-indicator.md
@@ -91,16 +91,20 @@ views — no cross-calibration between them.
 
 ### ⚠️ Verify before building the UI
 
-FRED discontinued several Wilshire series, and `fred.stlouisfed.org` blocks automated fetches, so
-this could not be confirmed while planning. **First task after the branch exists:** run the app and
-confirm `WILL5000PRFC` returns recent observations through the cloud proxy. If it is dead or months
-stale:
+**Verified 2026-08-29 against `api.gloom.sh`:** `GDP` returns data. `WILL5000PRFC`,
+`WILL5000PR`, and `NCBEILQ027S` all return `500 Unsupported FRED series`. The cloud FRED proxy
+allowlists series; those IDs are not on it. Tracking: https://github.com/gloom-sh/gloomberb/issues/658
+
+Until the allowlist lands, build model/client/pane against injectable loaders and seeded
+`fred-series` persistence. Live Terminal/Desktop verification of real numbers waits on #658.
+
+If after allowlisting Wilshire is dead or months stale:
 
 1. Try `WILL5000PR` (price index, non-full-cap).
 2. Otherwise make Z.1 the default and mark Wilshire unavailable.
 
-Z.1 is the guaranteed path and must work regardless. The pane degrades to whichever mode resolves and
-names the resolved source in the body — never an empty pane.
+The pane degrades to whichever mode resolves and names the resolved source in the body — never an
+empty pane.
 
 ### GDP handling
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ The toolbar controls preset or exact date ranges, intervals from one minute thro
 | `AUCT` | Treasury auction results: high rate, bid-to-cover, indirect share, and size |
 | `VIX` | VIX 30-day/3-month implied-volatility curve |
 | `CRD` | Credit spreads |
+| `BUF` | US market cap to GDP with valuation zones |
 | `CDS [ticker]` | Single-name corporate CDS activity: most-active issuers, or one issuer's trades |
 | `ERN` | Earnings calendar |
 | `IPO` | Upcoming and recent IPOs |

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,7 @@
 
 export { PriceSelectorDialog } from "./price-selector-dialog";
 export { StaticChartSurface } from "./chart/static/chart/surface";
+export { resolveChartPalette } from "./chart/core/renderer";
 export {
   buildMetricTreemapNavigationTiles,
   findMetricTreemapNeighbor,

--- a/src/layout-marketplace/pane-imagery.ts
+++ b/src/layout-marketplace/pane-imagery.ts
@@ -22,6 +22,7 @@ const IMAGERY_RULES: ReadonlyArray<readonly [string, PaneImagery]> = [
   ["sectors", "heatmap"],
   ["treemap", "heatmap"],
   ["fear-greed", "gauge"],
+  ["buffett", "gauge"],
   ["kelly", "gauge"],
   ["gauge", "gauge"],
   ["calendar", "calendar"],

--- a/src/plugins/builtin/buffett-indicator/client.test.ts
+++ b/src/plugins/builtin/buffett-indicator/client.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  attachFredSeriesPersistence,
+  resetFredSeriesPersistence,
+} from "../../../data/fred-series";
+import { MemoryPluginPersistence } from "../../../test-support/plugin-persistence";
+import { loadBuffettBundle } from "./client";
+import type { BuffettSeriesLoader } from "./model";
+
+function payload(seriesId: string, observations: Array<{ date: string; value: number }>) {
+  return {
+    observations,
+    info: {
+      id: seriesId,
+      title: seriesId,
+      units: "Billions of Dollars",
+      frequency: "Quarterly",
+      seasonalAdjustment: "Seasonally Adjusted Annual Rate",
+      source: "FRED",
+      notes: "",
+    },
+  };
+}
+
+const wilshireObs = [
+  { date: "2024-01-02", value: 40_000 },
+  { date: "2024-04-02", value: 42_000 },
+  { date: "2025-01-02", value: 45_000 },
+];
+const z1Obs = [
+  { date: "2024-01-01", value: 5_000_000 },
+  { date: "2024-04-01", value: 5_200_000 },
+  { date: "2025-01-01", value: 5_500_000 },
+];
+const gdpObs = [
+  { date: "2024-01-01", value: 25_000 },
+  { date: "2024-04-01", value: 25_500 },
+  { date: "2025-01-01", value: 26_000 },
+];
+
+beforeEach(resetFredSeriesPersistence);
+afterEach(resetFredSeriesPersistence);
+
+describe("loadBuffettBundle", () => {
+  test("loader requests use fixed limits and never a range startDate", async () => {
+    const requests: Array<{ seriesId: string; limit?: number; sortOrder?: string; startDate?: string }> = [];
+    const loader: BuffettSeriesLoader = async (request) => {
+      requests.push({
+        seriesId: request.seriesId,
+        limit: request.limit,
+        sortOrder: request.sortOrder,
+        startDate: request.startDate,
+      });
+      if (request.seriesId === "WILL5000PRFC") return payload(request.seriesId, wilshireObs);
+      if (request.seriesId === "NCBEILQ027S") return payload(request.seriesId, z1Obs);
+      if (request.seriesId === "GDP") return payload(request.seriesId, gdpObs);
+      throw new Error(`unexpected ${request.seriesId}`);
+    };
+
+    const bundle = await loadBuffettBundle({ force: true, loader });
+    expect(Object.keys(bundle.modes).sort()).toEqual(["wilshire", "z1"]);
+    expect(requests.map((r) => r.seriesId).sort()).toEqual([
+      "GDP",
+      "NCBEILQ027S",
+      "WILL5000PRFC",
+    ]);
+    for (const request of requests) {
+      expect(request.startDate).toBeUndefined();
+      expect(request.sortOrder).toBe("desc");
+      if (request.seriesId === "WILL5000PRFC") expect(request.limit).toBe(4000);
+      else expect(request.limit).toBe(340);
+    }
+  });
+
+  test("degrades to one mode when a numerator fails", async () => {
+    const loader: BuffettSeriesLoader = async (request) => {
+      if (request.seriesId === "WILL5000PRFC" || request.seriesId === "WILL5000PR") {
+        throw new Error("Unsupported FRED series");
+      }
+      if (request.seriesId === "NCBEILQ027S") return payload(request.seriesId, z1Obs);
+      if (request.seriesId === "GDP") return payload(request.seriesId, gdpObs);
+      throw new Error(`unexpected ${request.seriesId}`);
+    };
+    const bundle = await loadBuffettBundle({ force: true, loader });
+    expect(bundle.modes.z1).toBeDefined();
+    expect(bundle.modes.wilshire).toBeUndefined();
+  });
+
+  test("retries Wilshire fallback after primary failure", async () => {
+    const seen: string[] = [];
+    const loader: BuffettSeriesLoader = async (request) => {
+      seen.push(request.seriesId);
+      if (request.seriesId === "WILL5000PRFC") throw new Error("Unsupported FRED series");
+      if (request.seriesId === "WILL5000PR") return payload(request.seriesId, wilshireObs);
+      if (request.seriesId === "NCBEILQ027S") throw new Error("Unsupported FRED series");
+      if (request.seriesId === "GDP") return payload(request.seriesId, gdpObs);
+      throw new Error(`unexpected ${request.seriesId}`);
+    };
+    const bundle = await loadBuffettBundle({ force: true, loader });
+    expect(seen).toContain("WILL5000PR");
+    expect(bundle.modes.wilshire?.series.resolvedNumeratorId).toBe("WILL5000PR");
+  });
+
+  test("throws when every mode fails", async () => {
+    await expect(loadBuffettBundle({
+      force: true,
+      loader: async () => {
+        throw new Error("offline");
+      },
+    })).rejects.toThrow("offline");
+  });
+
+  test("reads seeded fred-series cache keys without range segments", async () => {
+    const persistence = new MemoryPluginPersistence();
+    persistence.seedResource(
+      "fred-series",
+      "WILL5000PRFC:limit=4000:sort=desc",
+      payload("WILL5000PRFC", wilshireObs),
+      { sourceKey: "gloomberb-cloud", schemaVersion: 1 },
+    );
+    persistence.seedResource(
+      "fred-series",
+      "NCBEILQ027S:limit=340:sort=desc",
+      payload("NCBEILQ027S", z1Obs),
+      { sourceKey: "gloomberb-cloud", schemaVersion: 1 },
+    );
+    persistence.seedResource(
+      "fred-series",
+      "GDP:limit=340:sort=desc",
+      payload("GDP", gdpObs),
+      { sourceKey: "gloomberb-cloud", schemaVersion: 1 },
+    );
+    attachFredSeriesPersistence(persistence);
+
+    let calls = 0;
+    const bundle = await loadBuffettBundle({
+      force: false,
+      loader: async () => {
+        calls += 1;
+        throw new Error("should not hit network");
+      },
+    });
+    expect(calls).toBe(0);
+    expect(bundle.modes.wilshire).toBeDefined();
+    expect(bundle.modes.z1).toBeDefined();
+  });
+});

--- a/src/plugins/builtin/buffett-indicator/client.ts
+++ b/src/plugins/builtin/buffett-indicator/client.ts
@@ -1,0 +1,199 @@
+import { apiClient } from "../../../api-client";
+import {
+  getCachedFredSeries,
+  loadCachedFredSeries,
+  type FredSeriesData,
+  type FredSeriesRequest,
+} from "../../../data/fred-series";
+import {
+  BUFFETT_MODES,
+  WILSHIRE_NUMERATOR,
+  buildRatioSeries,
+  fitLogLinearTrend,
+  seriesRequest,
+  uniqueSeriesDefs,
+  type BuffettBundle,
+  type BuffettModeId,
+  type BuffettSeriesLoader,
+  type ModeBuild,
+  type ModeDef,
+  type SeriesDef,
+} from "./model";
+
+const defaultLoader: BuffettSeriesLoader = (request) =>
+  apiClient.getCloudFredSeries(request.seriesId, {
+    limit: request.limit,
+    sortOrder: request.sortOrder,
+  });
+
+function summarizeSeriesErrors(errors: readonly string[]): string {
+  if (errors.length === 0) return "Buffett Indicator data unavailable";
+  const reasons = new Set(errors.map((entry) => entry.replace(/^[A-Z0-9]+:\s*/, "")));
+  const reason = reasons.size === 1 ? [...reasons][0]! : `${errors.length} series failed`;
+  return errors.length > 1 ? `${reason} (${errors.length} series)` : reason;
+}
+
+function tryBuildMode(
+  mode: ModeDef,
+  byId: Map<string, { data: FredSeriesData; stale: boolean }>,
+  errors: string[],
+): ModeBuild | null {
+  const gdp = byId.get(mode.denominator.seriesId.trim().toUpperCase());
+  if (!gdp) return null;
+
+  const primaryId = mode.numerator.seriesId.trim().toUpperCase();
+  const fallbackId = mode.numerator.fallbackSeriesId?.trim().toUpperCase();
+  const primary = byId.get(primaryId);
+  const fallback = fallbackId ? byId.get(fallbackId) : undefined;
+  const numerator = primary ?? fallback;
+  if (!numerator) return null;
+
+  const resolvedNumeratorId = primary
+    ? mode.numerator.seriesId
+    : mode.numerator.fallbackSeriesId!;
+
+  try {
+    const series = buildRatioSeries(mode, numerator.data, gdp.data, resolvedNumeratorId);
+    return {
+      series,
+      trend: fitLogLinearTrend(series.points),
+      cacheStale: numerator.stale || gdp.stale,
+    };
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : String(error));
+    return null;
+  }
+}
+
+function assembleBundle(
+  byId: Map<string, { data: FredSeriesData; stale: boolean }>,
+  errors: string[],
+  fetchedAt: number,
+): BuffettBundle | null {
+  const modes: Partial<Record<BuffettModeId, ModeBuild>> = {};
+  for (const mode of Object.values(BUFFETT_MODES)) {
+    const built = tryBuildMode(mode, byId, errors);
+    if (built) modes[mode.id] = built;
+  }
+  if (Object.keys(modes).length === 0) return null;
+  return {
+    modes,
+    stale: Object.values(modes).some((mode) => mode!.cacheStale),
+    errors,
+    fetchedAt,
+  };
+}
+
+export function getCachedBuffettBundle(): BuffettBundle | null {
+  const byId = new Map<string, { data: FredSeriesData; stale: boolean }>();
+  for (const def of uniqueSeriesDefs()) {
+    const cached = getCachedFredSeries(seriesRequest(def), { allowExpired: true });
+    if (cached) {
+      byId.set(def.seriesId.trim().toUpperCase(), {
+        data: cached.data,
+        stale: cached.stale,
+      });
+    }
+    if (def.fallbackSeriesId) {
+      const fallbackReq = seriesRequest(def, def.fallbackSeriesId);
+      const fallbackCached = getCachedFredSeries(fallbackReq, { allowExpired: true });
+      if (fallbackCached) {
+        byId.set(def.fallbackSeriesId.trim().toUpperCase(), {
+          data: fallbackCached.data,
+          stale: fallbackCached.stale,
+        });
+      }
+    }
+  }
+  return assembleBundle(byId, [], Date.now());
+}
+
+async function loadSeries(
+  request: FredSeriesRequest,
+  force: boolean,
+  loader: BuffettSeriesLoader,
+): Promise<{ data: FredSeriesData; stale: boolean; refreshError?: string }> {
+  const result = await loadCachedFredSeries(
+    request,
+    () => loader(request),
+    { force },
+  );
+  return {
+    data: result.data,
+    stale: result.stale,
+    refreshError: result.refreshError,
+  };
+}
+
+export async function loadBuffettBundle(options?: {
+  force?: boolean;
+  loader?: BuffettSeriesLoader;
+}): Promise<BuffettBundle> {
+  const force = options?.force ?? false;
+  const loader = options?.loader ?? defaultLoader;
+  const errors: string[] = [];
+  const byId = new Map<string, { data: FredSeriesData; stale: boolean }>();
+
+  const defs = uniqueSeriesDefs();
+  const settled = await Promise.allSettled(
+    defs.map(async (def) => {
+      const request = seriesRequest(def);
+      try {
+        return {
+          def,
+          seriesId: def.seriesId,
+          result: await loadSeries(request, force, loader),
+        };
+      } catch (error) {
+        throw { def, seriesId: def.seriesId, error };
+      }
+    }),
+  );
+
+  for (const outcome of settled) {
+    if (outcome.status === "fulfilled") {
+      const { seriesId, result } = outcome.value;
+      byId.set(seriesId.trim().toUpperCase(), {
+        data: result.data,
+        stale: result.stale,
+      });
+      if (result.refreshError) {
+        errors.push(`${seriesId}: ${result.refreshError}`);
+      }
+      continue;
+    }
+    const reason = outcome.reason as { def: SeriesDef; seriesId: string; error: unknown };
+    const message = reason.error instanceof Error ? reason.error.message : String(reason.error);
+    errors.push(`${reason.seriesId}: ${message}`);
+
+    // Wilshire primary only: retry the fallback id with the same limit/sort.
+    if (
+      reason.def.seriesId === WILSHIRE_NUMERATOR.seriesId
+      && reason.def.fallbackSeriesId
+    ) {
+      try {
+        const fallbackReq = seriesRequest(reason.def, reason.def.fallbackSeriesId);
+        const result = await loadSeries(fallbackReq, force, loader);
+        byId.set(reason.def.fallbackSeriesId.trim().toUpperCase(), {
+          data: result.data,
+          stale: result.stale,
+        });
+        if (result.refreshError) {
+          errors.push(`${reason.def.fallbackSeriesId}: ${result.refreshError}`);
+        }
+      } catch (fallbackError) {
+        errors.push(
+          `${reason.def.fallbackSeriesId}: ${
+            fallbackError instanceof Error ? fallbackError.message : String(fallbackError)
+          }`,
+        );
+      }
+    }
+  }
+
+  const bundle = assembleBundle(byId, errors, Date.now());
+  if (!bundle) throw new Error(summarizeSeriesErrors(errors));
+  return bundle;
+}
+
+export type { BuffettSeriesLoader };

--- a/src/plugins/builtin/buffett-indicator/index.tsx
+++ b/src/plugins/builtin/buffett-indicator/index.tsx
@@ -1,0 +1,24 @@
+import type { PluginModule } from "../plugin-module";
+import { BuffettIndicatorPane } from "./pane";
+import { buildBuffettSettingsDef } from "./settings";
+
+export const buffettIndicatorModule: PluginModule = {
+  panes: [{
+    id: "buffett-indicator",
+    name: "Buffett Indicator",
+    icon: "B",
+    component: BuffettIndicatorPane,
+    defaultPosition: "right",
+    defaultMode: "floating",
+    defaultFloatingSize: { width: 84, height: 26 },
+    settings: buildBuffettSettingsDef(),
+  }],
+  paneTemplates: [{
+    id: "buffett-indicator-pane",
+    paneId: "buffett-indicator",
+    label: "Buffett Indicator",
+    description: "US total market cap to GDP with valuation zones and trend deviation.",
+    keywords: ["buffett", "indicator", "valuation", "market cap", "gdp", "wilshire", "macro", "bubble"],
+    shortcut: { prefix: "BUF" },
+  }],
+};

--- a/src/plugins/builtin/buffett-indicator/model.test.ts
+++ b/src/plugins/builtin/buffett-indicator/model.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import type { FredSeriesData } from "../../../data/fred-series";
+import {
+  BUFFETT_MODES,
+  buildRatioSeries,
+  classifyZone,
+  fitLogLinearTrend,
+  interpolateGdpAligner,
+  projectView,
+  sameQuarterAligner,
+  scaleObservations,
+  sigmaVsTrend,
+  sliceByRange,
+  trendAt,
+  Z1_NUMERATOR,
+  type ModeBuild,
+  type RatioPoint,
+  type ScaledObs,
+} from "./model";
+
+function scaled(date: string, value: number): ScaledObs {
+  return { date, value };
+}
+
+function series(observations: Array<{ date: string; value: number | null }>): FredSeriesData {
+  return {
+    observations,
+    info: null,
+  };
+}
+
+describe("interpolateGdpAligner", () => {
+  const gdp = [
+    scaled("2024-01-01", 20_000),
+    scaled("2024-04-01", 22_000),
+  ];
+
+  test("midpoint between two quarterlies is linear", () => {
+    const market = [scaled("2024-02-15", 40_000)];
+    const points = interpolateGdpAligner(market, gdp);
+    expect(points).toHaveLength(1);
+    const t0 = Date.parse("2024-01-01");
+    const t1 = Date.parse("2024-04-01");
+    const t = Date.parse("2024-02-15");
+    const expectedGdp = 20_000 + ((t - t0) / (t1 - t0)) * (22_000 - 20_000);
+    expect(points[0]!.gdpBillions).toBeCloseTo(expectedGdp, 6);
+    expect(points[0]!.ratio).toBeCloseTo((40_000 / expectedGdp) * 100, 6);
+  });
+
+  test("flat-forwards past the last GDP print", () => {
+    const market = [scaled("2024-06-01", 44_000)];
+    const points = interpolateGdpAligner(market, gdp);
+    expect(points).toHaveLength(1);
+    expect(points[0]!.gdpBillions).toBe(22_000);
+    expect(points[0]!.ratio).toBeCloseTo((44_000 / 22_000) * 100, 6);
+  });
+
+  test("drops market dates before the first GDP", () => {
+    const market = [scaled("2023-12-01", 39_000), scaled("2024-02-01", 40_000)];
+    const points = interpolateGdpAligner(market, gdp);
+    expect(points).toHaveLength(1);
+    expect(points[0]!.date).toBe("2024-02-01");
+  });
+});
+
+describe("scaleObservations Z.1", () => {
+  test("divides millions by 1000 so ratio is 20 not 20000", () => {
+    const market = scaleObservations(
+      Z1_NUMERATOR,
+      series([{ date: "2024-01-01", value: 5_000_000 }]),
+    );
+    const gdp = scaleObservations(
+      BUFFETT_MODES.z1.denominator,
+      series([{ date: "2024-01-01", value: 25_000 }]),
+    );
+    expect(market[0]!.value).toBe(5_000);
+    const points = sameQuarterAligner(market, gdp);
+    expect(points).toHaveLength(1);
+    expect(points[0]!.ratio).toBeCloseTo(20, 10);
+  });
+});
+
+describe("ratio alignment", () => {
+  test("daily market × quarterly GDP yields one ratio per market obs inside the span", () => {
+    const gdp = [
+      scaled("2024-01-01", 20_000),
+      scaled("2024-04-01", 21_000),
+    ];
+    const market = [
+      scaled("2024-01-02", 30_000),
+      scaled("2024-01-03", 30_100),
+      scaled("2024-03-15", 31_000),
+      scaled("2024-04-01", 31_500),
+    ];
+    const points = interpolateGdpAligner(market, gdp);
+    expect(points.map((p) => p.date)).toEqual(market.map((m) => m.date));
+    expect(new Set(points.map((p) => p.date)).size).toBe(points.length);
+  });
+
+  test("same-quarter drops unmatched quarters and keeps matches", () => {
+    const gdp = [scaled("2024-01-01", 20_000), scaled("2024-07-01", 21_000)];
+    const market = [
+      scaled("2024-01-01", 4_000),
+      scaled("2024-04-01", 4_100),
+      scaled("2024-07-01", 4_200),
+    ];
+    const points = sameQuarterAligner(market, gdp);
+    expect(points.map((p) => p.date)).toEqual(["2024-01-01", "2024-07-01"]);
+  });
+});
+
+describe("fitLogLinearTrend", () => {
+  test("recovers beta and places an outlier at the expected σ", () => {
+    const origin = "2000-01-01";
+    const originMs = Date.parse(origin);
+    const daysPerYear = 365.25;
+    const betaPerYear = 0.03;
+    const betaPerDay = betaPerYear / daysPerYear;
+    const points: RatioPoint[] = [];
+    for (let year = 0; year <= 20; year += 1) {
+      const tDays = year * daysPerYear;
+      const date = new Date(originMs + tDays * 86_400_000).toISOString().slice(0, 10);
+      // Rebuild tDays from the date string the fitter will see, so the series is exact in log space.
+      const exactDays = (Date.parse(date) - originMs) / 86_400_000;
+      const ratio = 80 * Math.exp(betaPerDay * exactDays);
+      points.push({
+        date,
+        ratio,
+        marketCapBillions: ratio,
+        gdpBillions: 100,
+      });
+    }
+    const fit = fitLogLinearTrend(points);
+    expect(fit.beta).toBeCloseTo(betaPerDay, 8);
+    expect(fit.sigma).toBeLessThan(1e-12);
+
+    const outlierDate = points[10]!.date;
+    const trend = trendAt(fit, outlierDate);
+    const outlierRatio = trend * Math.exp(2);
+    const forcedSigma = 0.05;
+    const forcedFit = { ...fit, sigma: forcedSigma };
+    expect(sigmaVsTrend(forcedFit, outlierRatio, outlierDate)).toBeCloseTo(2 / forcedSigma, 8);
+  });
+});
+
+describe("classifyZone", () => {
+  test("half-open boundaries at 75, 90, 115, 135", () => {
+    expect(classifyZone(74.999).id).toBe("significantly-undervalued");
+    expect(classifyZone(75).id).toBe("modestly-undervalued");
+    expect(classifyZone(89.999).id).toBe("modestly-undervalued");
+    expect(classifyZone(90).id).toBe("fair");
+    expect(classifyZone(114.999).id).toBe("fair");
+    expect(classifyZone(115).id).toBe("modestly-overvalued");
+    expect(classifyZone(134.999).id).toBe("modestly-overvalued");
+    expect(classifyZone(135).id).toBe("significantly-overvalued");
+  });
+});
+
+describe("projectView range independence", () => {
+  test("10Y vs ALL keep the same current, sigma, percentile, and ATH", () => {
+    const points: RatioPoint[] = [];
+    const start = Date.parse("2005-01-01");
+    for (let i = 0; i < 400; i += 1) {
+      const date = new Date(start + i * 30 * 86_400_000).toISOString().slice(0, 10);
+      const ratio = 80 + i * 0.2;
+      points.push({
+        date,
+        ratio,
+        marketCapBillions: ratio * 200,
+        gdpBillions: 20_000,
+      });
+    }
+    const series = {
+      mode: "wilshire" as const,
+      resolvedNumeratorId: "WILL5000PRFC",
+      points,
+      gdpVintageDate: points[points.length - 1]!.date,
+    };
+    const trend = fitLogLinearTrend(points);
+    const build: ModeBuild = { series, trend, cacheStale: false };
+    const view10 = projectView(build, "wilshire", "10Y", { partial: false });
+    const viewAll = projectView(build, "wilshire", "ALL", { partial: false });
+    expect(view10.current.ratio).toBe(viewAll.current.ratio);
+    expect(view10.sigmaVsTrend).toBe(viewAll.sigmaVsTrend);
+    expect(view10.percentile).toBe(viewAll.percentile);
+    expect(view10.allTimeHigh).toEqual(viewAll.allTimeHigh);
+    expect(view10.chart.points.length).not.toBe(viewAll.chart.points.length);
+    expect(sliceByRange(points, "10Y").length).toBeLessThan(points.length);
+  });
+});
+
+describe("buildRatioSeries", () => {
+  test("wires Z.1 scale through same-quarter alignment", () => {
+    const built = buildRatioSeries(
+      BUFFETT_MODES.z1,
+      series([
+        { date: "2024-01-01", value: 5_000_000 },
+        { date: "2024-04-01", value: 5_100_000 },
+      ]),
+      series([
+        { date: "2024-01-01", value: 25_000 },
+        { date: "2024-04-01", value: 25_500 },
+      ]),
+      "NCBEILQ027S",
+    );
+    expect(built.points[0]!.ratio).toBeCloseTo(20, 8);
+  });
+});

--- a/src/plugins/builtin/buffett-indicator/model.ts
+++ b/src/plugins/builtin/buffett-indicator/model.ts
@@ -429,7 +429,7 @@ export function projectChart(
   fit: TrendFit,
 ): BuffettChartProjection {
   const points: ProjectedChartPoint[] = visible.map((p) => ({
-    date: p.date,
+    date: new Date(p.date),
     open: p.ratio,
     high: p.ratio,
     low: p.ratio,

--- a/src/plugins/builtin/buffett-indicator/model.ts
+++ b/src/plugins/builtin/buffett-indicator/model.ts
@@ -1,0 +1,578 @@
+import type { ProjectedChartPoint } from "../../../components/chart/core/data";
+import type { ChartIndicatorOverlays } from "../../../components/chart/core/types";
+import type { FredSeriesData, FredSeriesRequest } from "../../../data/fred-series";
+import { blendHex, colors } from "../../../theme/colors";
+
+export type BuffettModeId = "wilshire" | "z1";
+export type BuffettRangeId = "10Y" | "25Y" | "ALL";
+export type AlignmentRuleId = "interpolate-gdp" | "same-quarter";
+
+export interface SeriesDef {
+  seriesId: string;
+  /** Multiply raw FRED values to $ billions. Z.1 is 1/1000; others 1. */
+  scaleToBillions: number;
+  request: Pick<FredSeriesRequest, "limit" | "sortOrder">;
+  /** Tried only if the primary seriesId fails to produce observations. */
+  fallbackSeriesId?: string;
+}
+
+export interface ModeDef {
+  id: BuffettModeId;
+  label: string;
+  numerator: SeriesDef;
+  denominator: SeriesDef;
+  align: AlignmentRuleId;
+  /** Observation cadence including publication lag. Footer STALE uses this. */
+  staleAfterMs: number;
+}
+
+export interface ScaledObs {
+  date: string;
+  value: number;
+}
+
+export interface RatioPoint {
+  date: string;
+  ratio: number;
+  marketCapBillions: number;
+  gdpBillions: number;
+}
+
+export interface RatioSeries {
+  mode: BuffettModeId;
+  resolvedNumeratorId: string;
+  points: RatioPoint[];
+  gdpVintageDate: string;
+}
+
+export interface TrendFit {
+  alpha: number;
+  beta: number;
+  sigma: number;
+  originMs: number;
+}
+
+export type ValuationZoneId =
+  | "significantly-undervalued"
+  | "modestly-undervalued"
+  | "fair"
+  | "modestly-overvalued"
+  | "significantly-overvalued";
+
+export interface ZoneHit {
+  id: ValuationZoneId;
+  label: string;
+  color: string;
+}
+
+export interface Extreme {
+  ratio: number;
+  date: string;
+}
+
+export interface BuffettChartProjection {
+  points: ProjectedChartPoint[];
+  overlays: ChartIndicatorOverlays;
+}
+
+export interface BuffettViewModel {
+  requestedMode: BuffettModeId;
+  displayedMode: BuffettModeId;
+  range: BuffettRangeId;
+  resolvedNumeratorId: string;
+  current: RatioPoint;
+  zone: ZoneHit;
+  sigmaVsTrend: number;
+  trendNow: number;
+  gdpVintageDate: string;
+  gdpVintageLabel: string;
+  ratioOneYearAgo: number | null;
+  allTimeHigh: Extreme;
+  allTimeLow: Extreme;
+  percentile: number;
+  chart: BuffettChartProjection;
+  asOf: string;
+  observationStale: boolean;
+  cacheStale: boolean;
+  partial: boolean;
+}
+
+export interface ModeBuild {
+  series: RatioSeries;
+  trend: TrendFit;
+  cacheStale: boolean;
+}
+
+export interface BuffettBundle {
+  modes: Partial<Record<BuffettModeId, ModeBuild>>;
+  stale: boolean;
+  errors: string[];
+  fetchedAt: number;
+}
+
+export type BuffettSeriesLoader = (request: FredSeriesRequest) => Promise<FredSeriesData>;
+
+const MS_PER_DAY = 86_400_000;
+const MS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1000;
+
+export const GDP: SeriesDef = {
+  seriesId: "GDP",
+  scaleToBillions: 1,
+  request: { limit: 340, sortOrder: "desc" },
+};
+
+export const WILSHIRE_NUMERATOR: SeriesDef = {
+  seriesId: "WILL5000PRFC",
+  scaleToBillions: 1,
+  request: { limit: 4000, sortOrder: "desc" },
+  fallbackSeriesId: "WILL5000PR",
+};
+
+export const Z1_NUMERATOR: SeriesDef = {
+  seriesId: "NCBEILQ027S",
+  scaleToBillions: 1 / 1000,
+  request: { limit: 340, sortOrder: "desc" },
+};
+
+export const BUFFETT_MODES: { readonly [K in BuffettModeId]: ModeDef } = {
+  wilshire: {
+    id: "wilshire",
+    label: "Wilshire 5000 (daily)",
+    numerator: WILSHIRE_NUMERATOR,
+    denominator: GDP,
+    align: "interpolate-gdp",
+    staleAfterMs: 5 * 24 * 60 * 60 * 1000,
+  },
+  z1: {
+    id: "z1",
+    label: "Z.1 corporate equities (quarterly)",
+    numerator: Z1_NUMERATOR,
+    denominator: GDP,
+    align: "same-quarter",
+    staleAfterMs: 150 * 24 * 60 * 60 * 1000,
+  },
+};
+
+export const RANGE_WINDOWS_MS: { readonly [K in BuffettRangeId]: number | null } = {
+  "10Y": 10 * MS_PER_YEAR,
+  "25Y": 25 * MS_PER_YEAR,
+  ALL: null,
+};
+
+export const ZONE_TABLE: readonly {
+  max: number | null;
+  id: ValuationZoneId;
+  label: string;
+}[] = [
+  { max: 75, id: "significantly-undervalued", label: "Significantly Undervalued" },
+  { max: 90, id: "modestly-undervalued", label: "Modestly Undervalued" },
+  { max: 115, id: "fair", label: "Fair Valued" },
+  { max: 135, id: "modestly-overvalued", label: "Modestly Overvalued" },
+  { max: null, id: "significantly-overvalued", label: "Significantly Overvalued" },
+];
+
+function zoneColor(id: ValuationZoneId): string {
+  switch (id) {
+    case "significantly-undervalued":
+      return colors.positive;
+    case "modestly-undervalued":
+      return blendHex(colors.bg, colors.positive, 0.55);
+    case "fair":
+      return colors.textBright;
+    case "modestly-overvalued":
+      return colors.warning;
+    case "significantly-overvalued":
+      return colors.negative;
+    default: {
+      const _exhaustive: never = id;
+      return _exhaustive;
+    }
+  }
+}
+
+export function seriesRequest(def: SeriesDef, seriesId = def.seriesId): FredSeriesRequest {
+  return { seriesId, limit: def.request.limit, sortOrder: def.request.sortOrder };
+}
+
+export function uniqueSeriesDefs(
+  modes: typeof BUFFETT_MODES = BUFFETT_MODES,
+): SeriesDef[] {
+  const seen = new Set<string>();
+  const defs: SeriesDef[] = [];
+  for (const mode of Object.values(modes)) {
+    for (const def of [mode.numerator, mode.denominator]) {
+      const key = def.seriesId.trim().toUpperCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      defs.push(def);
+    }
+  }
+  return defs;
+}
+
+export function scaleObservations(
+  def: SeriesDef,
+  data: FredSeriesData,
+): ScaledObs[] {
+  const points: ScaledObs[] = [];
+  for (const obs of data.observations) {
+    if (obs.value == null || !Number.isFinite(obs.value)) continue;
+    points.push({ date: obs.date, value: obs.value * def.scaleToBillions });
+  }
+  points.sort((a, b) => a.date.localeCompare(b.date));
+  return points;
+}
+
+function parseDateMs(date: string): number {
+  return Date.parse(date);
+}
+
+function yearQuarter(date: string): string {
+  const ms = parseDateMs(date);
+  const d = new Date(ms);
+  const year = d.getUTCFullYear();
+  const quarter = Math.floor(d.getUTCMonth() / 3) + 1;
+  return `${year}-Q${quarter}`;
+}
+
+export function gdpVintageLabel(gdpVintageDate: string): string {
+  const ms = parseDateMs(gdpVintageDate);
+  const d = new Date(ms);
+  const year = d.getUTCFullYear();
+  const quarter = Math.floor(d.getUTCMonth() / 3) + 1;
+  return `GDP as of ${year}Q${quarter}`;
+}
+
+function ratioPoint(
+  date: string,
+  marketCapBillions: number,
+  gdpBillions: number,
+): RatioPoint {
+  return {
+    date,
+    marketCapBillions,
+    gdpBillions,
+    ratio: (marketCapBillions / gdpBillions) * 100,
+  };
+}
+
+export function interpolateGdpAligner(
+  market: readonly ScaledObs[],
+  gdp: readonly ScaledObs[],
+): RatioPoint[] {
+  if (gdp.length === 0 || market.length === 0) return [];
+  const firstGdpMs = parseDateMs(gdp[0]!.date);
+  const lastGdp = gdp[gdp.length - 1]!;
+  const lastGdpMs = parseDateMs(lastGdp.date);
+  const out: RatioPoint[] = [];
+
+  for (const m of market) {
+    const t = parseDateMs(m.date);
+    if (t < firstGdpMs) continue;
+
+    let gdpValue: number;
+    if (t >= lastGdpMs) {
+      gdpValue = lastGdp.value;
+    } else {
+      let i = 0;
+      while (i + 1 < gdp.length && parseDateMs(gdp[i + 1]!.date) <= t) i += 1;
+      const left = gdp[i]!;
+      const right = gdp[i + 1];
+      if (!right || parseDateMs(left.date) === t) {
+        gdpValue = left.value;
+      } else {
+        const t0 = parseDateMs(left.date);
+        const t1 = parseDateMs(right.date);
+        const frac = (t - t0) / (t1 - t0);
+        gdpValue = left.value + frac * (right.value - left.value);
+      }
+    }
+    if (!(gdpValue > 0)) continue;
+    out.push(ratioPoint(m.date, m.value, gdpValue));
+  }
+  return out;
+}
+
+export function sameQuarterAligner(
+  market: readonly ScaledObs[],
+  gdp: readonly ScaledObs[],
+): RatioPoint[] {
+  const gdpByQuarter = new Map<string, number>();
+  for (const g of gdp) gdpByQuarter.set(yearQuarter(g.date), g.value);
+  const out: RatioPoint[] = [];
+  for (const m of market) {
+    const gdpValue = gdpByQuarter.get(yearQuarter(m.date));
+    if (gdpValue == null || !(gdpValue > 0)) continue;
+    out.push(ratioPoint(m.date, m.value, gdpValue));
+  }
+  return out;
+}
+
+const ALIGNERS: {
+  readonly [K in AlignmentRuleId]: (
+    market: readonly ScaledObs[],
+    gdp: readonly ScaledObs[],
+  ) => RatioPoint[];
+} = {
+  "interpolate-gdp": interpolateGdpAligner,
+  "same-quarter": sameQuarterAligner,
+};
+
+export function buildRatioSeries(
+  mode: ModeDef,
+  numerator: FredSeriesData,
+  denominator: FredSeriesData,
+  resolvedNumeratorId: string,
+): RatioSeries {
+  const market = scaleObservations(
+    { ...mode.numerator, seriesId: resolvedNumeratorId },
+    numerator,
+  );
+  const gdp = scaleObservations(mode.denominator, denominator);
+  const points = ALIGNERS[mode.align](market, gdp);
+  if (points.length === 0) throw new Error(`${mode.id}: no overlapping observations`);
+  return {
+    mode: mode.id,
+    resolvedNumeratorId,
+    points,
+    gdpVintageDate: gdp.at(-1)!.date,
+  };
+}
+
+export function fitLogLinearTrend(points: readonly RatioPoint[]): TrendFit {
+  const usable = points.filter((p) => p.ratio > 0 && Number.isFinite(p.ratio));
+  if (usable.length === 0) {
+    return { alpha: 0, beta: 0, sigma: 0, originMs: 0 };
+  }
+  const originMs = parseDateMs(usable[0]!.date);
+  if (usable.length < 2) {
+    return {
+      alpha: Math.log(usable[0]!.ratio),
+      beta: 0,
+      sigma: 0,
+      originMs,
+    };
+  }
+
+  const xs: number[] = [];
+  const ys: number[] = [];
+  for (const p of usable) {
+    xs.push((parseDateMs(p.date) - originMs) / MS_PER_DAY);
+    ys.push(Math.log(p.ratio));
+  }
+  const n = xs.length;
+  let sumX = 0;
+  let sumY = 0;
+  let sumXX = 0;
+  let sumXY = 0;
+  for (let i = 0; i < n; i += 1) {
+    sumX += xs[i]!;
+    sumY += ys[i]!;
+    sumXX += xs[i]! * xs[i]!;
+    sumXY += xs[i]! * ys[i]!;
+  }
+  const denom = n * sumXX - sumX * sumX;
+  const beta = denom === 0 ? 0 : (n * sumXY - sumX * sumY) / denom;
+  const alpha = (sumY - beta * sumX) / n;
+
+  if (n < 3) {
+    return { alpha, beta, sigma: 0, originMs };
+  }
+
+  let residualSq = 0;
+  for (let i = 0; i < n; i += 1) {
+    const residual = ys[i]! - (alpha + beta * xs[i]!);
+    residualSq += residual * residual;
+  }
+  const sigma = Math.sqrt(residualSq / (n - 2));
+  return { alpha, beta, sigma, originMs };
+}
+
+export function trendAt(fit: TrendFit, date: string): number {
+  const tDays = (parseDateMs(date) - fit.originMs) / MS_PER_DAY;
+  return Math.exp(fit.alpha + fit.beta * tDays);
+}
+
+export function sigmaVsTrend(fit: TrendFit, ratio: number, date: string): number {
+  if (!(fit.sigma > 0) || !(ratio > 0)) return 0;
+  return (Math.log(ratio) - Math.log(trendAt(fit, date))) / fit.sigma;
+}
+
+export function classifyZone(ratio: number): ZoneHit {
+  for (const row of ZONE_TABLE) {
+    if (row.max == null || ratio < row.max) {
+      return { id: row.id, label: row.label, color: zoneColor(row.id) };
+    }
+  }
+  const last = ZONE_TABLE[ZONE_TABLE.length - 1]!;
+  return { id: last.id, label: last.label, color: zoneColor(last.id) };
+}
+
+export function sliceByRange(
+  points: readonly RatioPoint[],
+  range: BuffettRangeId,
+  nowMs: number = Date.parse(points.at(-1)!.date),
+): RatioPoint[] {
+  const window = RANGE_WINDOWS_MS[range];
+  if (window == null) return [...points];
+  const cutoff = nowMs - window;
+  const sliced = points.filter((p) => parseDateMs(p.date) >= cutoff);
+  return sliced.length >= 2 ? sliced : [...points];
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function projectChart(
+  visible: readonly RatioPoint[],
+  fit: TrendFit,
+): BuffettChartProjection {
+  const points: ProjectedChartPoint[] = visible.map((p) => ({
+    date: p.date,
+    open: p.ratio,
+    high: p.ratio,
+    low: p.ratio,
+    close: p.ratio,
+    volume: 0,
+  }));
+  let yMin = Infinity;
+  let yMax = -Infinity;
+  for (const p of points) {
+    yMin = Math.min(yMin, p.close);
+    yMax = Math.max(yMax, p.close);
+  }
+  if (!Number.isFinite(yMin) || !Number.isFinite(yMax)) {
+    yMin = 0;
+    yMax = 1;
+  }
+
+  const middle: { index: number; value: number }[] = [];
+  const upper2: { index: number; value: number }[] = [];
+  const lower2: { index: number; value: number }[] = [];
+  const upper1: { index: number; value: number }[] = [];
+  const lower1: { index: number; value: number }[] = [];
+
+  for (let i = 0; i < visible.length; i += 1) {
+    const date = visible[i]!.date;
+    const mid = trendAt(fit, date);
+    const band = (k: number) => mid * Math.exp(k * fit.sigma);
+    middle.push({ index: i, value: clamp(mid, yMin, yMax) });
+    upper2.push({ index: i, value: clamp(band(2), yMin, yMax) });
+    lower2.push({ index: i, value: clamp(band(-2), yMin, yMax) });
+    upper1.push({ index: i, value: clamp(band(1), yMin, yMax) });
+    lower1.push({ index: i, value: clamp(band(-1), yMin, yMax) });
+  }
+
+  const overlays: ChartIndicatorOverlays = {
+    smaLines: [
+      { period: 0, points: upper1, color: colors.textMuted },
+      { period: 0, points: lower1, color: colors.textMuted },
+    ],
+    emaLines: [],
+    bollinger: {
+      middle,
+      upper: upper2,
+      lower: lower2,
+      color: colors.textDim,
+    },
+    rsi: null,
+    macd: null,
+  };
+
+  return { points, overlays };
+}
+
+function findExtreme(
+  points: readonly RatioPoint[],
+  pick: "high" | "low",
+): Extreme {
+  let best = points[0]!;
+  for (const p of points) {
+    if (pick === "high" ? p.ratio > best.ratio : p.ratio < best.ratio) best = p;
+  }
+  return { ratio: best.ratio, date: best.date };
+}
+
+function ratioOneYearAgo(points: readonly RatioPoint[], currentDate: string): number | null {
+  const cutoff = parseDateMs(currentDate) - 365 * MS_PER_DAY;
+  let found: RatioPoint | null = null;
+  for (const p of points) {
+    if (parseDateMs(p.date) <= cutoff) found = p;
+  }
+  return found?.ratio ?? null;
+}
+
+export function projectView(
+  build: ModeBuild,
+  requestedMode: BuffettModeId,
+  range: BuffettRangeId,
+  opts: { partial: boolean; nowMs?: number },
+): BuffettViewModel {
+  const { series, trend, cacheStale } = build;
+  const points = series.points;
+  const current = points[points.length - 1]!;
+  const nowMs = opts.nowMs ?? Date.now();
+  const visible = sliceByRange(points, range);
+  const zone = classifyZone(current.ratio);
+  const mode = BUFFETT_MODES[series.mode];
+  const observationAgeMs = nowMs - parseDateMs(current.date);
+  const atOrBelow = points.filter((p) => p.ratio <= current.ratio).length;
+
+  return {
+    requestedMode,
+    displayedMode: series.mode,
+    range,
+    resolvedNumeratorId: series.resolvedNumeratorId,
+    current,
+    zone,
+    sigmaVsTrend: sigmaVsTrend(trend, current.ratio, current.date),
+    trendNow: trendAt(trend, current.date),
+    gdpVintageDate: series.gdpVintageDate,
+    gdpVintageLabel: gdpVintageLabel(series.gdpVintageDate),
+    ratioOneYearAgo: ratioOneYearAgo(points, current.date),
+    allTimeHigh: findExtreme(points, "high"),
+    allTimeLow: findExtreme(points, "low"),
+    percentile: points.length === 0 ? 0 : (100 * atOrBelow) / points.length,
+    chart: projectChart(visible, trend),
+    asOf: current.date,
+    observationStale: observationAgeMs > mode.staleAfterMs,
+    cacheStale,
+    partial: opts.partial,
+  };
+}
+
+export function selectBuffettView(
+  bundle: BuffettBundle,
+  requestedMode: BuffettModeId,
+  range: BuffettRangeId,
+): BuffettViewModel {
+  const primary = bundle.modes[requestedMode];
+  const fallbackId: BuffettModeId = requestedMode === "wilshire" ? "z1" : "wilshire";
+  const chosen = primary ?? bundle.modes[fallbackId];
+  if (!chosen) throw new Error("Buffett Indicator unavailable");
+  return projectView(chosen, requestedMode, range, {
+    partial: Object.keys(bundle.modes).length === 1,
+  });
+}
+
+export function gaugeSegmentsFromZones(): {
+  from: number;
+  to: number;
+  label: string;
+  color: string;
+}[] {
+  const maxGauge = 250;
+  let from = 0;
+  return ZONE_TABLE.map((row) => {
+    const to = row.max == null ? maxGauge : row.max;
+    const segment = {
+      from,
+      to: row.max == null ? maxGauge : to - 0.001,
+      label: row.label,
+      color: zoneColor(row.id),
+    };
+    from = row.max ?? maxGauge;
+    return segment;
+  });
+}

--- a/src/plugins/builtin/buffett-indicator/pane.test.tsx
+++ b/src/plugins/builtin/buffett-indicator/pane.test.tsx
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { PaneFooterProvider } from "../../../components/layout/pane/footer";
+import {
+  attachFredSeriesPersistence,
+  resetFredSeriesPersistence,
+} from "../../../data/fred-series";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import {
+  AppContext,
+  createInitialState,
+  PaneInstanceProvider,
+} from "../../../state/app/context";
+import { MemoryPluginPersistence } from "../../../test-support/plugin-persistence";
+import { createDefaultConfig } from "../../../types/config";
+import { BuffettIndicatorPane } from "./pane";
+
+let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+const FRED_SEED_META = { sourceKey: "gloomberb-cloud", schemaVersion: 1 } as const;
+
+function payload(seriesId: string, observations: Array<{ date: string; value: number }>) {
+  return {
+    observations,
+    info: {
+      id: seriesId,
+      title: seriesId,
+      units: "Billions of Dollars",
+      frequency: "Daily",
+      seasonalAdjustment: "Not Seasonally Adjusted",
+      source: "FRED",
+      notes: "",
+    },
+  };
+}
+
+// Wilshire ≈ $45T against GDP ≈ $31.7T → ~142%
+const wilshireData = payload("WILL5000PRFC", [
+  { date: "2024-01-02", value: 40_000 },
+  { date: "2024-07-01", value: 42_000 },
+  { date: "2025-01-02", value: 43_500 },
+  { date: "2025-07-01", value: 44_000 },
+  { date: "2026-01-02", value: 44_500 },
+  { date: "2026-06-15", value: 45_000 },
+]);
+
+const z1Data = payload("NCBEILQ027S", [
+  { date: "2024-01-01", value: 40_000_000 },
+  { date: "2024-04-01", value: 42_000_000 },
+  { date: "2025-01-01", value: 43_000_000 },
+  { date: "2025-04-01", value: 44_000_000 },
+  { date: "2026-01-01", value: 44_500_000 },
+  { date: "2026-04-01", value: 45_000_000 },
+]);
+
+const gdpData = payload("GDP", [
+  { date: "2024-01-01", value: 28_000 },
+  { date: "2024-04-01", value: 28_500 },
+  { date: "2024-07-01", value: 29_000 },
+  { date: "2024-10-01", value: 29_500 },
+  { date: "2025-01-01", value: 30_000 },
+  { date: "2025-04-01", value: 30_500 },
+  { date: "2025-07-01", value: 31_000 },
+  { date: "2025-10-01", value: 31_200 },
+  { date: "2026-01-01", value: 31_400 },
+  { date: "2026-04-01", value: 31_700 },
+]);
+
+async function settle() {
+  await act(async () => {
+    for (let index = 0; index < 8; index += 1) {
+      await Promise.resolve();
+      await setup!.renderOnce();
+    }
+  });
+  for (let index = 0; index < 3; index += 1) {
+    await act(async () => {
+      await Promise.resolve();
+      await setup!.renderOnce();
+    });
+  }
+}
+
+beforeEach(() => {
+  resetFredSeriesPersistence();
+  const persistence = new MemoryPluginPersistence();
+  persistence.seedResource("fred-series", "WILL5000PRFC:limit=4000:sort=desc", wilshireData, FRED_SEED_META);
+  persistence.seedResource("fred-series", "NCBEILQ027S:limit=340:sort=desc", z1Data, FRED_SEED_META);
+  persistence.seedResource("fred-series", "GDP:limit=340:sort=desc", gdpData, FRED_SEED_META);
+  attachFredSeriesPersistence(persistence);
+});
+
+afterEach(async () => {
+  if (setup) {
+    await act(async () => setup?.renderer.destroy());
+    setup = undefined;
+  }
+  resetFredSeriesPersistence();
+});
+
+describe("BuffettIndicatorPane", () => {
+  test("renders ratio and valuation zone from seeded FRED cache", async () => {
+    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-buffett-test"));
+    setup = await testRender(
+      <AppContext value={{ state, dispatch: () => {} }}>
+        <PaneInstanceProvider paneId="buffett:test">
+          <PaneFooterProvider>
+            {() => (
+              <BuffettIndicatorPane
+                paneId="buffett:test"
+                paneType="buffett-indicator"
+                focused
+                width={84}
+                height={26}
+              />
+            )}
+          </PaneFooterProvider>
+        </PaneInstanceProvider>
+      </AppContext>,
+      { width: 84, height: 26 },
+    );
+    await settle();
+
+    const frame = setup.captureCharFrame();
+    // 45000 / 31700 * 100 ≈ 141.96 → 142%
+    expect(frame).toContain("142%");
+    expect(frame).toContain("Significantly Overvalued");
+  });
+});

--- a/src/plugins/builtin/buffett-indicator/pane.tsx
+++ b/src/plugins/builtin/buffett-indicator/pane.tsx
@@ -1,0 +1,301 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  EmptyState,
+  SegmentedControl,
+  SpeedometerGauge,
+  Spinner,
+  StaticChartSurface,
+  type PaneFooterSegment,
+  type SpeedometerSegment,
+} from "../../../components";
+import { resolveChartPalette } from "../../../components/chart/core/renderer";
+import { useShortcut } from "../../../react/input";
+import { usePaneSettingValue } from "../../../state/app/context";
+import { blendHex, colors } from "../../../theme/colors";
+import type { PaneProps } from "../../../types/plugin";
+import { Box, ScrollBox, Text, TextAttributes } from "../../../ui";
+import { formatNumber } from "../../../utils/format";
+import { useAutoRefresh } from "../shared/auto-refresh";
+import { usePaneStatusFooter } from "../shared/pane-footer";
+import { getCachedBuffettBundle, loadBuffettBundle } from "./client";
+import {
+  BUFFETT_MODES,
+  gaugeSegmentsFromZones,
+  selectBuffettView,
+  type BuffettBundle,
+  type BuffettModeId,
+  type BuffettRangeId,
+  type BuffettViewModel,
+} from "./model";
+import { BUFFETT_DEFAULTS } from "./settings";
+
+export type BuffettLoadState =
+  | { status: "idle" }
+  | { status: "loading"; previous: BuffettBundle | null }
+  | { status: "ready"; bundle: BuffettBundle }
+  | { status: "partial"; bundle: BuffettBundle }
+  | { status: "error"; message: string; previous: BuffettBundle | null };
+
+const MODE_OPTIONS = [
+  { value: "wilshire" as const, label: "Wilshire" },
+  { value: "z1" as const, label: "Z.1" },
+];
+
+const RANGE_OPTIONS = [
+  { value: "10Y" as const, label: "10Y" },
+  { value: "25Y" as const, label: "25Y" },
+  { value: "ALL" as const, label: "All" },
+];
+
+const GAUGE_SEGMENTS: SpeedometerSegment[] = gaugeSegmentsFromZones();
+
+function bundleOf(state: BuffettLoadState): BuffettBundle | null {
+  switch (state.status) {
+    case "idle":
+      return null;
+    case "loading":
+    case "error":
+      return state.previous;
+    case "ready":
+    case "partial":
+      return state.bundle;
+    default: {
+      const _exhaustive: never = state;
+      return _exhaustive;
+    }
+  }
+}
+
+function fromBundle(bundle: BuffettBundle): Extract<BuffettLoadState, { status: "ready" | "partial" }> {
+  return Object.keys(bundle.modes).length === 1
+    ? { status: "partial", bundle }
+    : { status: "ready", bundle };
+}
+
+function initialLoadState(): BuffettLoadState {
+  const cached = getCachedBuffettBundle();
+  return cached ? fromBundle(cached) : { status: "idle" };
+}
+
+function formatTrillions(billions: number): string {
+  return `${formatNumber(billions / 1000, 1)}T`;
+}
+
+function formatSigma(sigma: number): string {
+  const sign = sigma > 0 ? "+" : "";
+  return `${sign}${formatNumber(sigma, 1)}σ vs trend`;
+}
+
+function formatRatioPct(ratio: number): string {
+  return `${Math.round(ratio)}%`;
+}
+
+function footerInfoFromView(
+  view: BuffettViewModel | null,
+  state: BuffettLoadState,
+): PaneFooterSegment[] {
+  const info: PaneFooterSegment[] = [];
+  if (view) {
+    info.push({ id: "as-of", parts: [{ text: `as of ${view.asOf}`, tone: "muted" }] });
+    info.push({ id: "delayed", parts: [{ text: "delayed", tone: "muted" }] });
+    if (view.observationStale || view.cacheStale) {
+      info.push({ id: "stale", parts: [{ text: "STALE", tone: "warning", bold: true }] });
+    }
+    if (view.partial || state.status === "partial") {
+      info.push({ id: "partial", parts: [{ text: "PARTIAL", tone: "warning", bold: true }] });
+    }
+  }
+  return info;
+}
+
+export function BuffettIndicatorPane({ paneId, focused, width, height }: PaneProps) {
+  const [mode, setMode] = usePaneSettingValue<BuffettModeId>("mode", BUFFETT_DEFAULTS.mode);
+  const [range, setRange] = usePaneSettingValue<BuffettRangeId>("range", BUFFETT_DEFAULTS.range);
+  const [state, setState] = useState<BuffettLoadState>(initialLoadState);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+  const generation = useRef(0);
+
+  const load = useCallback(async (force = false) => {
+    const current = ++generation.current;
+    setState((previous) => ({ status: "loading", previous: bundleOf(previous) }));
+    try {
+      const next = await loadBuffettBundle({ force });
+      if (generation.current !== current) return;
+      setState(fromBundle(next));
+      if (!next.stale) setLastUpdated(Date.now());
+    } catch (error) {
+      if (generation.current !== current) return;
+      setState((previous) => ({
+        status: "error",
+        message: error instanceof Error ? error.message : String(error),
+        previous: bundleOf(previous),
+      }));
+    }
+  }, []);
+
+  useEffect(() => {
+    void load(false);
+  }, [load]);
+
+  const reload = useCallback(() => {
+    void load(true);
+  }, [load]);
+  const refresh = useCallback(() => {
+    void load(false);
+  }, [load]);
+  useAutoRefresh(lastUpdated, refresh);
+
+  useShortcut((event) => {
+    if (!focused || event.name !== "r") return;
+    if (state.status === "loading") return;
+    event.preventDefault?.();
+    event.stopPropagation?.();
+    reload();
+  });
+
+  const bundle = bundleOf(state);
+  const view = useMemo(
+    () => (bundle ? selectBuffettView(bundle, mode, range) : null),
+    [bundle, mode, range],
+  );
+
+  const loading = state.status === "loading" || state.status === "idle";
+  const error = state.status === "error" ? state.message : bundle?.errors[0] ?? null;
+  const footerInfo = useMemo(() => footerInfoFromView(view, state), [state, view]);
+
+  usePaneStatusFooter({
+    registrationId: "buffett-indicator",
+    loading: state.status === "loading",
+    error,
+    info: footerInfo,
+  });
+
+  const palette = useMemo(() => {
+    const zoneColor = view?.zone.color ?? colors.textBright;
+    const base = resolveChartPalette(colors, "neutral");
+    return {
+      ...base,
+      lineColor: zoneColor,
+      fillColor: blendHex(colors.bg, zoneColor, 0.18),
+      gridColor: blendHex(colors.bg, colors.border, 0.55),
+    };
+  }, [view?.zone.color]);
+
+  if (!bundle && loading) {
+    return (
+      <Box width={width} height={height} justifyContent="center" alignItems="center">
+        <Spinner label="Loading Buffett Indicator..." />
+      </Box>
+    );
+  }
+
+  if (!bundle || !view) {
+    return (
+      <Box width={width} height={height} padding={1} flexDirection="column" gap={1}>
+        <EmptyState
+          title="Buffett Indicator unavailable."
+          message={state.status === "error" ? state.message : error ?? undefined}
+        />
+      </Box>
+    );
+  }
+
+  const sourceLabel = BUFFETT_MODES[view.displayedMode].label;
+  const showFallbackSource = view.displayedMode !== view.requestedMode;
+  const chartWidth = Math.max(24, width - 2);
+  const chartHeight = width >= 96 ? 12 : 10;
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      <ScrollBox flexGrow={1} scrollY focusable={false}>
+        <Box flexDirection="column" paddingX={1} paddingBottom={1} gap={1}>
+          <Box flexDirection="column" gap={0}>
+            <Box flexDirection="row" height={1} overflow="hidden">
+              <Text fg={view.zone.color} attributes={TextAttributes.BOLD}>
+                {formatRatioPct(view.current.ratio)}
+              </Text>
+              <Text fg={colors.textDim}>{"  "}</Text>
+              <Text fg={view.zone.color}>{view.zone.label}</Text>
+              <Box flexGrow={1} />
+              <Text fg={colors.textMuted}>{formatSigma(view.sigmaVsTrend)}</Text>
+            </Box>
+            <Box flexDirection="row" height={1} overflow="hidden">
+              <Text fg={colors.textDim}>{`as of ${view.asOf}`}</Text>
+              {showFallbackSource ? (
+                <>
+                  <Text fg={colors.textDim}>{" · "}</Text>
+                  <Text fg={colors.warning}>{sourceLabel}</Text>
+                </>
+              ) : null}
+            </Box>
+          </Box>
+
+          <SpeedometerGauge
+            value={view.current.ratio}
+            valueLabel={formatRatioPct(view.current.ratio)}
+            width={width - 2}
+            min={0}
+            max={250}
+            segments={GAUGE_SEGMENTS}
+          />
+
+          {view.chart.points.length >= 2 ? (
+            <StaticChartSurface
+              points={view.chart.points}
+              width={chartWidth}
+              height={chartHeight}
+              mode="line"
+              colors={palette}
+              indicators={view.chart.overlays}
+              showTimeAxis
+              timeAxisColor={colors.textDim}
+              yAxisColor={colors.textDim}
+              formatYAxisValue={(v) => formatRatioPct(v)}
+            />
+          ) : (
+            <Box height={chartHeight} justifyContent="center" alignItems="center">
+              <Text fg={colors.textMuted}>Not enough chart data</Text>
+            </Box>
+          )}
+
+          <Box flexDirection="column" gap={0}>
+            <Box flexDirection="row" height={1} overflow="hidden">
+              <Text fg={colors.textDim}>Mkt cap </Text>
+              <Text fg={colors.textBright}>{formatTrillions(view.current.marketCapBillions)}</Text>
+              <Text fg={colors.textDim}>{"  GDP "}</Text>
+              <Text fg={colors.textBright}>{formatTrillions(view.current.gdpBillions)}</Text>
+              <Text fg={colors.textDim}>{`  ${view.gdpVintageLabel}`}</Text>
+            </Box>
+            <Box flexDirection="row" height={1} overflow="hidden">
+              <Text fg={colors.textDim}>1Y ago </Text>
+              <Text fg={colors.text}>
+                {view.ratioOneYearAgo == null ? "--" : formatRatioPct(view.ratioOneYearAgo)}
+              </Text>
+              <Text fg={colors.textDim}>{"  ATH "}</Text>
+              <Text fg={colors.text}>{`${formatRatioPct(view.allTimeHigh.ratio)} ${view.allTimeHigh.date}`}</Text>
+            </Box>
+            <Box flexDirection="row" height={1} overflow="hidden">
+              <Text fg={colors.textDim}>ATL </Text>
+              <Text fg={colors.text}>{`${formatRatioPct(view.allTimeLow.ratio)} ${view.allTimeLow.date}`}</Text>
+              <Text fg={colors.textDim}>{"  %ile "}</Text>
+              <Text fg={colors.textBright}>{formatNumber(view.percentile, 0)}</Text>
+            </Box>
+          </Box>
+
+          <Box flexDirection="row" height={1} gap={2} overflow="hidden">
+            <SegmentedControl
+              options={MODE_OPTIONS}
+              value={mode}
+              onChange={(value) => setMode(value as BuffettModeId)}
+            />
+            <SegmentedControl
+              options={RANGE_OPTIONS}
+              value={range}
+              onChange={(value) => setRange(value as BuffettRangeId)}
+            />
+          </Box>
+        </Box>
+      </ScrollBox>
+    </Box>
+  );
+}

--- a/src/plugins/builtin/buffett-indicator/pane.tsx
+++ b/src/plugins/builtin/buffett-indicator/pane.tsx
@@ -5,10 +5,10 @@ import {
   SpeedometerGauge,
   Spinner,
   StaticChartSurface,
+  resolveChartPalette,
   type PaneFooterSegment,
   type SpeedometerSegment,
 } from "../../../components";
-import { resolveChartPalette } from "../../../components/chart/core/renderer";
 import { useShortcut } from "../../../react/input";
 import { usePaneSettingValue } from "../../../state/app/context";
 import { blendHex, colors } from "../../../theme/colors";

--- a/src/plugins/builtin/buffett-indicator/settings.ts
+++ b/src/plugins/builtin/buffett-indicator/settings.ts
@@ -1,0 +1,54 @@
+import type { PaneSettingsDef } from "../../../types/plugin";
+import type { BuffettModeId, BuffettRangeId } from "./model";
+
+export const BUFFETT_DEFAULTS = { mode: "wilshire", range: "10Y" } as const satisfies {
+  mode: BuffettModeId;
+  range: BuffettRangeId;
+};
+
+const MODE_IDS = ["wilshire", "z1"] as const satisfies readonly BuffettModeId[];
+const RANGE_IDS = ["10Y", "25Y", "ALL"] as const satisfies readonly BuffettRangeId[];
+
+function isBuffettModeId(value: unknown): value is BuffettModeId {
+  return MODE_IDS.includes(value as BuffettModeId);
+}
+
+function isBuffettRangeId(value: unknown): value is BuffettRangeId {
+  return RANGE_IDS.includes(value as BuffettRangeId);
+}
+
+export function getBuffettPaneSettings(
+  settings: Record<string, unknown> | undefined,
+): { mode: BuffettModeId; range: BuffettRangeId } {
+  return {
+    mode: isBuffettModeId(settings?.mode) ? settings.mode : BUFFETT_DEFAULTS.mode,
+    range: isBuffettRangeId(settings?.range) ? settings.range : BUFFETT_DEFAULTS.range,
+  };
+}
+
+export function buildBuffettSettingsDef(): PaneSettingsDef {
+  return {
+    title: "Buffett Indicator Settings",
+    fields: [
+      {
+        key: "mode",
+        label: "Numerator",
+        type: "select",
+        options: [
+          { value: "wilshire", label: "Wilshire 5000 (daily)" },
+          { value: "z1", label: "Z.1 corporate equities (quarterly)" },
+        ],
+      },
+      {
+        key: "range",
+        label: "History",
+        type: "select",
+        options: [
+          { value: "10Y", label: "10Y" },
+          { value: "25Y", label: "25Y" },
+          { value: "ALL", label: "All" },
+        ],
+      },
+    ],
+  };
+}

--- a/src/plugins/builtin/composite-plugins.ts
+++ b/src/plugins/builtin/composite-plugins.ts
@@ -9,6 +9,7 @@ import { connectionsModule } from "./connections";
 import { correlationModule } from "./correlation";
 import { cdsModule } from "./cds";
 import { creditConditionsModule } from "./credit-conditions";
+import { buffettIndicatorModule } from "./buffett-indicator";
 import { economicCalendarModule } from "./econ";
 import { earningsModule } from "./earnings";
 import { ipoCalendarModule } from "./ipo-calendar";
@@ -98,6 +99,7 @@ export const macroPlugin = composeBuiltinPlugin({
     yieldCurveModule,
     volatilityModule,
     creditConditionsModule,
+    buffettIndicatorModule,
     cdsModule,
     treasuryAuctionsModule,
     earningsModule,

--- a/src/plugins/catalog-browser.ts
+++ b/src/plugins/catalog-browser.ts
@@ -12,6 +12,7 @@ import { connectionsModule } from "./builtin/connections";
 import { correlationModule } from "./builtin/correlation";
 import { cdsModule } from "./builtin/cds";
 import { creditConditionsModule } from "./builtin/credit-conditions";
+import { buffettIndicatorModule } from "./builtin/buffett-indicator";
 import { economicCalendarModule } from "./builtin/econ";
 import { futuresModule } from "./builtin/futures";
 import { fxMatrixModule } from "./builtin/fx-matrix";
@@ -110,6 +111,7 @@ const browserMacroPlugin = composeBuiltinPlugin({
     yieldCurveModule,
     volatilityModule,
     creditConditionsModule,
+    buffettIndicatorModule,
     cdsModule,
     treasuryAuctionsModule,
   ],


### PR DESCRIPTION
## Why

Gloomberb has no market-wide valuation read. The Buffett Indicator (US equity market cap ÷ GDP) answers that with data the cloud FRED proxy already serves, once the numerator series are allowlisted.

## Scope

- New builtin module `src/plugins/builtin/buffett-indicator/` (model, client, settings, pane, tests, `PluginModule` export).
- Fetch-once bundle over Wilshire / Z.1 / GDP; mode and range are view slices (no range in FRED cache keys).
- Pane load lifecycle is a `BuffettLoadState` union; UI uses `SpeedometerGauge`, `StaticChartSurface`, and pane settings.
- Registers in `composite-plugins.ts` and `catalog-browser.ts`; README shortcut `BUF`.
- Tracking allowlist: https://github.com/gloom-sh/gloomberb/issues/658

Out of scope: new API routes, CLI command, chart-composer preset, merge to main from this note.

## Tradeoffs

- Live Wilshire (`WILL5000PRFC` / `WILL5000PR`) and Z.1 (`NCBEILQ027S`) still return `Unsupported FRED series` from `api.gloom.sh`. Pane ships with seeded tests and an injectable loader; live numbers wait on #658.
- GDP is shared and works today. Until numerators land, `BUF` opens an empty state with a summarized FRED error.

## Blast Radius

- Macro plugin catalog only (native + browser). No `api-client` changes. FRED persistence stays on `macroSharedResourcesModule`.
- Safe to review and merge ahead of #658; production paint stays empty until allowlisting.

## Verification

- `bun test src/plugins/builtin/buffett-indicator` — 16 pass.
- `bun run typecheck` — all six projects pass.
- tmux `bun run dev` → command bar `BUF` → floating pane titled Buffett Indicator with `Unsupported FRED series (3 series)` (expected pre-#658). Session killed after capture.


Made with [Cursor](https://cursor.com)