### PR TITLE
Add Greeks and volatility stats to options chain

### DIFF
--- a/src/plugins/builtin/options/analytics.test.ts
+++ b/src/plugins/builtin/options/analytics.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test";
+import type { OptionContract, OptionsChain, PricePoint } from "../../../types/financials";
+import {
+  calculateOptionGreeks,
+  calculateOptionsSummary,
+  historicalVolatility30d,
+} from "./analytics";
+
+function contract(
+  strike: number,
+  impliedVolatility: number,
+  volume: number,
+  openInterest: number,
+): OptionContract {
+  return {
+    contractSymbol: String(strike),
+    strike,
+    currency: "USD",
+    lastPrice: 1,
+    change: 0,
+    percentChange: 0,
+    volume,
+    openInterest,
+    bid: 0.95,
+    ask: 1.05,
+    impliedVolatility,
+    inTheMoney: false,
+    expiration: Date.UTC(2027, 0, 15) / 1000,
+    lastTradeDate: 0,
+  };
+}
+
+function priceHistory(): PricePoint[] {
+  const points: PricePoint[] = [{ date: new Date(Date.UTC(2026, 0, 1)), close: 100 }];
+  for (let index = 0; index < 30; index += 1) {
+    points.push({
+      date: new Date(Date.UTC(2026, 0, index + 2)),
+      close: points.at(-1)!.close * Math.exp(index % 2 === 0 ? 0.01 : -0.01),
+    });
+  }
+  return points;
+}
+
+test("annualizes the latest 30 daily log returns, including persisted dates", () => {
+  const expected = Math.sqrt((30 * 0.01 ** 2 / 29) * 252);
+  expect(historicalVolatility30d(priceHistory())).toBeCloseTo(expected, 10);
+  expect(historicalVolatility30d(priceHistory().map((point) => ({
+    ...point,
+    date: point.date.toISOString() as unknown as Date,
+  })))).toBeCloseTo(expected, 10);
+  expect(historicalVolatility30d(priceHistory().slice(1))).toBeNull();
+});
+
+test("summarizes the selected expiration without presenting it as whole-chain volume", () => {
+  const chain: OptionsChain = {
+    underlyingSymbol: "AAPL",
+    expirationDates: [Date.UTC(2027, 0, 15) / 1000],
+    calls: [contract(100, 0.2, 100, 200), contract(105, 0.3, 200, 400)],
+    puts: [contract(100, 0.22, 150, 180), contract(105, 0.4, 300, 420)],
+  };
+  const summary = calculateOptionsSummary(chain, 101, priceHistory());
+
+  expect(summary.atmImpliedVolatility).toBeCloseTo(0.21, 10);
+  expect(summary.expirationVolume).toBe(750);
+  expect(summary.putCallVolumeRatio).toBe(1.5);
+  expect(summary.putCallOpenInterestRatio).toBe(1);
+  expect(summary.impliedHistoricalRatio).toBeCloseTo(
+    summary.atmImpliedVolatility! / summary.historicalVolatility30d!,
+    10,
+  );
+});
+
+test("derives call and put Greeks from the chain IV", () => {
+  const option = contract(100, 0.25, 0, 0);
+  const now = Date.UTC(2026, 11, 15);
+  const call = calculateOptionGreeks(option, "call", 100, 0, now);
+  const put = calculateOptionGreeks(option, "put", 100, 0, now);
+
+  expect(call?.delta).toBeGreaterThan(0);
+  expect(put?.delta).toBeLessThan(0);
+  expect(call?.gamma).toBeCloseTo(put!.gamma, 10);
+  expect(call?.vegaPerPoint).toBeCloseTo(put!.vegaPerPoint, 10);
+});

--- a/src/plugins/builtin/options/analytics.ts
+++ b/src/plugins/builtin/options/analytics.ts
@@ -1,0 +1,110 @@
+import type { OptionContract, OptionsChain, PricePoint } from "../../../types/financials";
+import {
+  DEFAULT_OPTION_CALC_DRAFT,
+  daysToExpiryFrom,
+  valueOption,
+  type OptionSide,
+  type OptionValuation,
+} from "../options-calculator/model";
+
+const TRADING_DAYS_PER_YEAR = 252;
+const HISTORICAL_VOLATILITY_SESSIONS = 30;
+
+export interface OptionsSummary {
+  atmImpliedVolatility: number | null;
+  historicalVolatility30d: number | null;
+  impliedHistoricalRatio: number | null;
+  expirationVolume: number;
+  putCallVolumeRatio: number | null;
+  putCallOpenInterestRatio: number | null;
+}
+
+function positive(value: number | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function ratio(numerator: number, denominator: number): number | null {
+  return denominator > 0 ? numerator / denominator : null;
+}
+
+function sum(contracts: readonly OptionContract[], field: "volume" | "openInterest"): number {
+  return contracts.reduce((total, contract) => {
+    const value = contract[field];
+    return total + (Number.isFinite(value) && value > 0 ? value : 0);
+  }, 0);
+}
+
+function atmImpliedVolatility(chain: OptionsChain, spot: number | undefined): number | null {
+  if (!positive(spot)) return null;
+  const contracts = [...chain.calls, ...chain.puts].filter((contract) => positive(contract.impliedVolatility));
+  if (contracts.length === 0) return null;
+  const distance = Math.min(...contracts.map((contract) => Math.abs(contract.strike - spot)));
+  const atTheMoney = contracts
+    .filter((contract) => Math.abs(Math.abs(contract.strike - spot) - distance) < 1e-8)
+    .map((contract) => contract.impliedVolatility);
+  return atTheMoney.reduce((total, value) => total + value, 0) / atTheMoney.length;
+}
+
+/** Annualized standard deviation of the latest 30 daily log returns. */
+export function historicalVolatility30d(points: readonly PricePoint[]): number | null {
+  const closes = points
+    .map((point) => ({
+      close: point.close,
+      time: point.date instanceof Date ? point.date.getTime() : Date.parse(String(point.date)),
+    }))
+    .filter((point) => positive(point.close) && Number.isFinite(point.time))
+    .sort((a, b) => a.time - b.time)
+    .slice(-(HISTORICAL_VOLATILITY_SESSIONS + 1))
+    .map((point) => point.close);
+  if (closes.length < HISTORICAL_VOLATILITY_SESSIONS + 1) return null;
+
+  const returns = closes.slice(1).map((close, index) => Math.log(close / closes[index]!));
+  const mean = returns.reduce((total, value) => total + value, 0) / returns.length;
+  const variance = returns.reduce((total, value) => total + (value - mean) ** 2, 0) / (returns.length - 1);
+  return Math.sqrt(variance * TRADING_DAYS_PER_YEAR);
+}
+
+export function calculateOptionsSummary(
+  chain: OptionsChain,
+  spot: number | undefined,
+  priceHistory: readonly PricePoint[],
+): OptionsSummary {
+  const atmIv = atmImpliedVolatility(chain, spot);
+  const historicalVolatility = historicalVolatility30d(priceHistory);
+  const callVolume = sum(chain.calls, "volume");
+  const putVolume = sum(chain.puts, "volume");
+  const callOpenInterest = sum(chain.calls, "openInterest");
+  const putOpenInterest = sum(chain.puts, "openInterest");
+
+  return {
+    atmImpliedVolatility: atmIv,
+    historicalVolatility30d: historicalVolatility,
+    impliedHistoricalRatio: atmIv != null && historicalVolatility != null && historicalVolatility > 0
+      ? atmIv / historicalVolatility
+      : null,
+    expirationVolume: callVolume + putVolume,
+    putCallVolumeRatio: ratio(putVolume, callVolume),
+    putCallOpenInterestRatio: ratio(putOpenInterest, callOpenInterest),
+  };
+}
+
+export function calculateOptionGreeks(
+  contract: OptionContract | undefined,
+  side: OptionSide,
+  spot: number | undefined,
+  dividendYield: number | undefined,
+  now: number = Date.now(),
+): OptionValuation | undefined {
+  if (!contract || !positive(spot) || !positive(contract.strike) || !positive(contract.impliedVolatility)) {
+    return undefined;
+  }
+  return valueOption({
+    ...DEFAULT_OPTION_CALC_DRAFT,
+    side,
+    spot,
+    strike: contract.strike,
+    daysToExpiry: daysToExpiryFrom(contract.expiration, now),
+    volatility: contract.impliedVolatility,
+    dividendYield: Number.isFinite(dividendYield) ? dividendYield! : 0,
+  });
+}

--- a/src/plugins/builtin/options/index.tsx
+++ b/src/plugins/builtin/options/index.tsx
@@ -6,11 +6,26 @@ import {
   LIVE_STREAMING_QUICK_SETTING,
   withLiveStreamingSetting,
 } from "../shared/live-streaming";
+import { OPTION_FIELD_DEFS, resolveOptionFieldIds } from "./table";
 
-function optionsSettings(): PaneSettingsDef {
+function optionsSettings(settings: Record<string, unknown>): PaneSettingsDef {
   return {
     title: "Options Settings",
+    values: {
+      optionColumnIds: resolveOptionFieldIds(settings.optionColumnIds),
+    },
     fields: [
+      {
+        key: "optionColumnIds",
+        label: "Columns",
+        description: "Choose and order the fields mirrored around the strike.",
+        type: "ordered-multi-select",
+        options: OPTION_FIELD_DEFS.map((field) => ({
+          value: field.id,
+          label: field.label,
+          description: field.description,
+        })),
+      },
       {
         key: "chainRefreshMinutes",
         label: "Chain refresh",
@@ -38,7 +53,7 @@ export const optionsModule: PluginModule = {
       defaultMode: "floating",
       defaultFloatingSize: { width: 112, height: 28 },
       quickSettings: [LIVE_STREAMING_QUICK_SETTING],
-      settings: (context) => withLiveStreamingSetting(optionsSettings(), context.settings),
+      settings: (context) => withLiveStreamingSetting(optionsSettings(context.settings), context.settings),
     },
   ],
 

--- a/src/plugins/builtin/options/table.ts
+++ b/src/plugins/builtin/options/table.ts
@@ -1,31 +1,80 @@
 import { TextAttributes } from "../../../ui";
 import type { DataTableCell } from "../../../components";
 import type { OptionContract, OptionsChain } from "../../../types/financials";
-import { blendHex, colors, hoverBg } from "../../../theme/colors";
+import { blendHex, colors } from "../../../theme/colors";
 import { blendForContrast, contrastRatio } from "../../../theme/color-utils";
 import { formatCompact, formatNumber } from "../../../utils/format";
 import { formatMarketPrice } from "../../../market-data/market/format";
-import type { OptionColumn, OptionColumnId, OptionTableRow } from "./types";
+import type {
+  OptionColumn,
+  OptionFieldId,
+  OptionTableRow,
+} from "./types";
+import type { OptionSide, OptionValuation } from "../options-calculator/model";
 
 type OptionColorRole = "call" | "put" | "price" | "activity" | "iv" | "strike";
 
+type OptionFieldDef = {
+  id: OptionFieldId;
+  label: string;
+  header: string;
+  width: number;
+  description: string;
+};
+
 const OPTION_TEXT_MIN_CONTRAST = 4.5;
 
-export const OPTION_COLUMNS: Array<Omit<OptionColumn, "headerColor">> = [
-  { id: "callOpenInterest", label: "C OI", width: 6, align: "right" },
-  { id: "callVolume", label: "C VOL", width: 6, align: "right" },
-  { id: "callLast", label: "C LAST", width: 7, align: "right" },
-  { id: "callIv", label: "C IV", width: 6, align: "right" },
-  { id: "callBid", label: "C BID", width: 7, align: "right" },
-  { id: "callAsk", label: "C ASK", width: 7, align: "right" },
-  { id: "strike", label: "STRIKE", width: 9, align: "right" },
-  { id: "putBid", label: "P BID", width: 7, align: "right" },
-  { id: "putAsk", label: "P ASK", width: 7, align: "right" },
-  { id: "putIv", label: "P IV", width: 6, align: "right" },
-  { id: "putLast", label: "P LAST", width: 7, align: "right" },
-  { id: "putVolume", label: "P VOL", width: 6, align: "right" },
-  { id: "putOpenInterest", label: "P OI", width: 6, align: "right" },
+export const OPTION_FIELD_DEFS: OptionFieldDef[] = [
+  { id: "bid", label: "Bid", header: "BID", width: 7, description: "Best bid price." },
+  { id: "ask", label: "Ask", header: "ASK", width: 7, description: "Best ask price." },
+  { id: "last", label: "Last", header: "LAST", width: 7, description: "Last traded price." },
+  { id: "delta", label: "Delta", header: "Δ", width: 6, description: "Price sensitivity to a $1 move in the underlying." },
+  { id: "gamma", label: "Gamma", header: "Γ", width: 7, description: "Delta sensitivity to a $1 move in the underlying." },
+  { id: "theta", label: "Theta", header: "Θ", width: 7, description: "Estimated value decay per calendar day." },
+  { id: "vega", label: "Vega", header: "VEGA", width: 7, description: "Price sensitivity to one volatility point." },
+  { id: "rho", label: "Rho", header: "RHO", width: 7, description: "Price sensitivity to one interest-rate point." },
+  { id: "iv", label: "Implied volatility", header: "IV", width: 6, description: "Volatility implied by the contract price." },
+  { id: "volume", label: "Volume", header: "VOL", width: 6, description: "Contracts traded in the current session." },
+  { id: "openInterest", label: "Open interest", header: "OI", width: 6, description: "Outstanding open contracts." },
 ];
+
+export const DEFAULT_OPTION_FIELD_IDS: OptionFieldId[] = ["bid", "ask", "last", "delta", "gamma"];
+
+const OPTION_FIELDS_BY_ID = new Map(OPTION_FIELD_DEFS.map((field) => [field.id, field]));
+
+export function resolveOptionFieldIds(value: unknown): OptionFieldId[] {
+  if (!Array.isArray(value)) return [...DEFAULT_OPTION_FIELD_IDS];
+  const seen = new Set<OptionFieldId>();
+  const fields = value.filter((id): id is OptionFieldId => {
+    if (typeof id !== "string" || !OPTION_FIELDS_BY_ID.has(id as OptionFieldId) || seen.has(id as OptionFieldId)) {
+      return false;
+    }
+    seen.add(id as OptionFieldId);
+    return true;
+  });
+  return fields.length > 0 ? fields : [...DEFAULT_OPTION_FIELD_IDS];
+}
+
+function sideColumn(side: OptionSide, field: OptionFieldId): Omit<OptionColumn, "headerColor"> {
+  const definition = OPTION_FIELDS_BY_ID.get(field)!;
+  return {
+    id: `${side}${field[0]!.toUpperCase()}${field.slice(1)}` as OptionColumn["id"],
+    field,
+    side,
+    label: `${side === "call" ? "C" : "P"} ${definition.header}`,
+    width: definition.width,
+    align: "right",
+  };
+}
+
+export function createOptionColumns(fieldIds: readonly OptionFieldId[]): Array<Omit<OptionColumn, "headerColor">> {
+  const fields = resolveOptionFieldIds(fieldIds);
+  return [
+    ...fields.map((field) => sideColumn("call", field)),
+    { id: "strike", field: "strike", side: null, label: "STRIKE", width: 9, align: "right" },
+    ...[...fields].reverse().map((field) => sideColumn("put", field)),
+  ];
+}
 
 export function buildStrikeList(chain: OptionsChain): number[] {
   const set = new Set<number>();
@@ -68,20 +117,32 @@ export function formatIv(value: number | undefined): string {
   return `${(value * 100).toFixed(1)}%`;
 }
 
-export function optionColumnColor(columnId: OptionColumnId, surface = colors.bg): string {
-  return optionRoleColor(optionColumnRole(columnId), surface);
+function formatGreek(value: number | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "\u2014";
+  return value.toFixed(3).replace(/^(-?)0\./, "$1.");
 }
 
-function optionContractForColumn(row: OptionTableRow, columnId: OptionColumnId): OptionContract | undefined {
-  return columnId.startsWith("call") ? row.call : row.put;
+export function optionColumnColor(
+  column: Pick<OptionColumn, "field" | "side">,
+  surface = colors.bg,
+): string {
+  return optionRoleColor(optionColumnRole(column), surface);
 }
 
-function optionColumnRole(columnId: OptionColumnId): OptionColorRole {
-  if (columnId === "strike") return "strike";
-  if (columnId.endsWith("Iv")) return "iv";
-  if (columnId.endsWith("Volume") || columnId.endsWith("OpenInterest")) return "activity";
-  if (columnId.endsWith("Bid") || columnId.endsWith("Ask")) return "price";
-  return columnId.startsWith("call") ? "call" : "put";
+function optionContractForColumn(row: OptionTableRow, column: OptionColumn): OptionContract | undefined {
+  return column.side === "call" ? row.call : row.put;
+}
+
+function optionGreeksForColumn(row: OptionTableRow, column: OptionColumn): OptionValuation | undefined {
+  return column.side === "call" ? row.callGreeks : row.putGreeks;
+}
+
+function optionColumnRole(column: Pick<OptionColumn, "field" | "side">): OptionColorRole {
+  if (column.field === "strike") return "strike";
+  if (column.field === "iv") return "iv";
+  if (column.field === "volume" || column.field === "openInterest") return "activity";
+  if (column.field === "bid" || column.field === "ask") return "price";
+  return column.side ?? "strike";
 }
 
 function optionRoleThemeColor(role: OptionColorRole): string {
@@ -131,12 +192,12 @@ function optionMutedColor(surface: string): string {
 function optionMoneynessBackground(
   row: OptionTableRow,
   contract: OptionContract | undefined,
-  columnId: OptionColumnId,
+  column: OptionColumn,
   rowState: { selected: boolean },
 ): string | undefined {
-  if (rowState.selected) return undefined;
-  const inTheMoney = inferColumnMoneyness(row, contract, columnId);
-  const sideColor = columnId.startsWith("call") ? colors.positive : colors.negative;
+  if (rowState.selected || !column.side) return undefined;
+  const inTheMoney = inferColumnMoneyness(row, contract, column.side);
+  const sideColor = column.side === "call" ? colors.positive : colors.negative;
   return inTheMoney
     ? blendHex(colors.bg, sideColor, 0.13)
     : blendHex(colors.bg, colors.neutral, 0.055);
@@ -145,34 +206,43 @@ function optionMoneynessBackground(
 function inferColumnMoneyness(
   row: OptionTableRow,
   contract: OptionContract | undefined,
-  columnId: OptionColumnId,
+  side: OptionSide,
 ): boolean {
   if (contract) return contract.inTheMoney;
-  const oppositeContract = columnId.startsWith("call") ? row.put : row.call;
+  const oppositeContract = side === "call" ? row.put : row.call;
   return oppositeContract ? !oppositeContract.inTheMoney : false;
 }
 
-function formatOptionContractCell(contract: OptionContract | undefined, column: OptionColumn): string {
+function formatOptionContractCell(
+  row: OptionTableRow,
+  contract: OptionContract | undefined,
+  column: OptionColumn,
+): string {
   if (!contract) return "—";
-  switch (column.id) {
-    case "callLast":
-    case "putLast":
+  const greeks = optionGreeksForColumn(row, column);
+  switch (column.field) {
+    case "last":
       return formatMarketPrice(contract.lastPrice, { assetCategory: "OPT", maxWidth: column.width });
-    case "callBid":
-    case "putBid":
+    case "bid":
       return formatMarketPrice(contract.bid, { assetCategory: "OPT", maxWidth: column.width });
-    case "callAsk":
-    case "putAsk":
+    case "ask":
       return formatMarketPrice(contract.ask, { assetCategory: "OPT", maxWidth: column.width });
-    case "callVolume":
-    case "putVolume":
+    case "volume":
       return formatCompact(contract.volume);
-    case "callOpenInterest":
-    case "putOpenInterest":
+    case "openInterest":
       return formatCompact(contract.openInterest);
-    case "callIv":
-    case "putIv":
+    case "iv":
       return formatIv(contract.impliedVolatility);
+    case "delta":
+      return formatGreek(greeks?.delta);
+    case "gamma":
+      return formatGreek(greeks?.gamma);
+    case "theta":
+      return formatGreek(greeks?.thetaPerDay);
+    case "vega":
+      return formatGreek(greeks?.vegaPerPoint);
+    case "rho":
+      return formatGreek(greeks?.rhoPerPoint);
     case "strike":
       return formatStrikeLabel(contract.strike);
   }
@@ -187,7 +257,7 @@ export function renderOptionCell(
   const selectedColor = rowState.selected ? colors.selectedText : undefined;
   const rowSurface = rowState.selected ? colors.selected : colors.bg;
 
-  if (column.id === "strike") {
+  if (column.field === "strike") {
     const backgroundColor = rowState.selected
       ? undefined
       : blendHex(colors.bg, row.isPositionStrike ? colors.borderFocused : colors.header, row.isPositionStrike ? 0.18 : 0.1);
@@ -200,12 +270,12 @@ export function renderOptionCell(
     };
   }
 
-  const contract = optionContractForColumn(row, column.id);
-  const backgroundColor = optionMoneynessBackground(row, contract, column.id, rowState);
+  const contract = optionContractForColumn(row, column);
+  const backgroundColor = optionMoneynessBackground(row, contract, column, rowState);
   const surface = backgroundColor ?? rowSurface;
   return {
-    text: formatOptionContractCell(contract, column),
-    color: selectedColor ?? (contract ? optionRoleColor(optionColumnRole(column.id), surface) : optionMutedColor(surface)),
+    text: formatOptionContractCell(row, contract, column),
+    color: selectedColor ?? (contract ? optionRoleColor(optionColumnRole(column), surface) : optionMutedColor(surface)),
     backgroundColor,
   };
 }

--- a/src/plugins/builtin/options/types.ts
+++ b/src/plugins/builtin/options/types.ts
@@ -1,27 +1,34 @@
 import type { DataTableColumn } from "../../../components";
 import type { OptionContract } from "../../../types/financials";
+import type { OptionSide, OptionValuation } from "../options-calculator/model";
 
-export type OptionColumnId =
-  | "callLast"
-  | "callBid"
-  | "callAsk"
-  | "callVolume"
-  | "callOpenInterest"
-  | "callIv"
-  | "strike"
-  | "putLast"
-  | "putBid"
-  | "putAsk"
-  | "putVolume"
-  | "putOpenInterest"
-  | "putIv";
+export type OptionFieldId =
+  | "bid"
+  | "ask"
+  | "last"
+  | "delta"
+  | "gamma"
+  | "theta"
+  | "vega"
+  | "rho"
+  | "iv"
+  | "volume"
+  | "openInterest";
 
-export type OptionColumn = DataTableColumn & { id: OptionColumnId };
+export type OptionColumnId = "strike" | `${OptionSide}${Capitalize<OptionFieldId>}`;
+
+export type OptionColumn = DataTableColumn & {
+  id: OptionColumnId;
+  field: OptionFieldId | "strike";
+  side: OptionSide | null;
+};
 
 export interface OptionTableRow {
   strike: number;
   call?: OptionContract;
   put?: OptionContract;
+  callGreeks?: OptionValuation;
+  putGreeks?: OptionValuation;
   isPositionStrike: boolean;
 }
 

--- a/src/plugins/builtin/options/view.test.tsx
+++ b/src/plugins/builtin/options/view.test.tsx
@@ -176,6 +176,30 @@ test("defaults the table around the nearest strike to the current quote", async 
   expect(frame).not.toContain(" 50 ");
 });
 
+test("shows volatility statistics and mirrored default Greeks", async () => {
+  const provider = createTestDataProvider({
+    getOptionsChain: async () => makeChain([100, 101], 101),
+  });
+  setSharedMarketDataCoordinator(new MarketDataCoordinator(provider));
+
+  await act(async () => {
+    testSetup = await testRender(
+      <OptionsHarness ticker={makeTicker("AAPL")} quotePrice={101} />,
+      { width: 124, height: 16 },
+    );
+  });
+  await renderSettled();
+
+  const frame = testSetup!.captureCharFrame();
+  expect(frame).toContain("ATM IV 20.0%");
+  expect(frame).toContain("HV30 —");
+  expect(frame).toContain("EXP VOL");
+  expect(frame).toContain("C Δ");
+  expect(frame).toContain("C Γ");
+  expect(frame).toContain("P Γ");
+  expect(frame).toContain("P Δ");
+});
+
 test("streams live quotes without resetting manual scroll", async () => {
   const strikes = Array.from({ length: 100 }, (_, index) => 50 + index);
   const subscriptions: QuoteSubscriptionTarget[][] = [];

--- a/src/plugins/builtin/options/view.tsx
+++ b/src/plugins/builtin/options/view.tsx
@@ -3,6 +3,7 @@ import { Box, Text } from "../../../ui";
 import { usePaneSettingValue, usePaneTicker } from "../../../state/app/context";
 import { colors } from "../../../theme/colors";
 import { isPlainKey } from "../../../utils/keyboard";
+import { formatCompact } from "../../../utils/format";
 import { formatExpDate, resolveOptionsTarget } from "../../../utils/options";
 import { useOptionsQuery, useResolvedEntryValue, useTickerFinancials } from "../../../market-data/hooks";
 import {
@@ -21,15 +22,19 @@ import {
   type OptionSide,
 } from "../options-calculator/model";
 import { buildChainCalcParams, resolveCalcSide } from "./calc-seed";
+import { calculateOptionGreeks, calculateOptionsSummary, type OptionsSummary } from "./analytics";
 import {
-  OPTION_COLUMNS,
+  DEFAULT_OPTION_FIELD_IDS,
   buildStrikeList,
+  createOptionColumns,
   findNearestStrikeIndex,
+  formatIv,
   optionColumnColor,
   renderOptionCell,
   resolveDefaultStrikeTarget,
+  resolveOptionFieldIds,
 } from "./table";
-import type { OptionColumn, OptionTableRow, OptionsViewProps } from "./types";
+import type { OptionColumn, OptionFieldId, OptionTableRow, OptionsViewProps } from "./types";
 import {
   buildOptionQuoteTargets,
   overlayOptionRowQuotes,
@@ -38,6 +43,48 @@ import {
 } from "./live-quotes";
 import { useOptionsAccessFooter } from "./footer";
 import { useLiveStreamingSetting } from "../shared/live-streaming";
+
+type SummaryMetric = { label: string; value: string };
+
+function formatRatio(value: number | null | undefined): string {
+  return value == null || !Number.isFinite(value) ? "—" : value.toFixed(2);
+}
+
+function SummaryRow({ metrics }: { metrics: SummaryMetric[] }) {
+  return (
+    <Box flexDirection="row" height={1} gap={3} overflow="hidden">
+      {metrics.map((metric) => (
+        <Box key={metric.label} flexDirection="row" flexShrink={0}>
+          <Text fg={colors.textDim}>{`${metric.label} `}</Text>
+          <Text fg={colors.textBright}>{metric.value}</Text>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+function OptionsSummaryStrip({ summary, secondary }: {
+  summary: OptionsSummary | null;
+  secondary: boolean;
+}) {
+  const volatility: SummaryMetric[] = [
+    { label: "ATM IV", value: formatIv(summary?.atmImpliedVolatility ?? undefined) },
+    { label: "HV30", value: formatIv(summary?.historicalVolatility30d ?? undefined) },
+    { label: "IV/HV", value: formatRatio(summary?.impliedHistoricalRatio) },
+  ];
+  return (
+    <Box flexDirection="column" height={secondary ? 2 : 1}>
+      <SummaryRow metrics={volatility} />
+      {secondary && (
+        <SummaryRow metrics={[
+          { label: "EXP VOL", value: summary ? formatCompact(summary.expirationVolume) : "—" },
+          { label: "P/C VOL", value: formatRatio(summary?.putCallVolumeRatio) },
+          { label: "P/C OI", value: formatRatio(summary?.putCallOpenInterestRatio) },
+        ]} />
+      )}
+    </Box>
+  );
+}
 
 export function OptionsView({ width, height, focused, onCapture = () => {} }: OptionsViewProps) {
   const { ticker, financials } = usePaneTicker();
@@ -61,6 +108,9 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
   const effectiveTicker = target?.effectiveTicker ?? "";
   const effectiveExchange = target?.effectiveExchange ?? "";
   const underlyingFinancials = useTickerFinancials(isOpt ? effectiveTicker : null, null);
+  const underlying = isOpt ? underlyingFinancials : financials;
+  const spot = underlying?.quote?.price;
+  const dividendYield = underlying?.fundamentals?.dividendYield;
   const instrument = target?.instrument ?? null;
   const baseRequest = target
     ? {
@@ -74,6 +124,8 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     }
     : null;
   const [chainRefreshMinutes] = usePaneSettingValue<string>("chainRefreshMinutes", "");
+  const [storedOptionFieldIds] = usePaneSettingValue<OptionFieldId[]>("optionColumnIds", DEFAULT_OPTION_FIELD_IDS);
+  const optionFieldIds = useMemo(() => resolveOptionFieldIds(storedOptionFieldIds), [storedOptionFieldIds]);
   const initialChainEntry = useOptionsQuery(baseRequest);
   const initialChain = useResolvedEntryValue(initialChainEntry);
   const selectedExpiration = initialChain?.expirationDates[expIdx];
@@ -157,12 +209,27 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     () => new Map(strikeChain?.puts.map((p) => [p.strike, p]) ?? []),
     [strikeChain],
   );
-  const snapshotRows = useMemo<OptionTableRow[]>(() => strikes.map((strike) => ({
-    strike,
-    call: callsByStrike.get(strike),
-    put: putsByStrike.get(strike),
-    isPositionStrike: !!parsed && Math.abs(strike - parsed.strike) < 0.01,
-  })), [callsByStrike, parsed, putsByStrike, strikes]);
+  const snapshotRows = useMemo<OptionTableRow[]>(() => {
+    const now = Date.now();
+    return strikes.map((strike) => {
+      const call = callsByStrike.get(strike);
+      const put = putsByStrike.get(strike);
+      return {
+        strike,
+        call,
+        put,
+        callGreeks: calculateOptionGreeks(call, "call", spot, dividendYield, now),
+        putGreeks: calculateOptionGreeks(put, "put", spot, dividendYield, now),
+        isPositionStrike: !!parsed && Math.abs(strike - parsed.strike) < 0.01,
+      };
+    });
+  }, [callsByStrike, dividendYield, parsed, putsByStrike, spot, strikes]);
+  const summary = useMemo(
+    () => strikeChain
+      ? calculateOptionsSummary(strikeChain, spot, underlying?.priceHistory ?? [])
+      : null,
+    [spot, strikeChain, underlying?.priceHistory],
+  );
   const visibleStrikeRange = visibleStrikeViewport?.key === viewportKey
     ? visibleStrikeViewport.range
     : null;
@@ -210,10 +277,10 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     ),
     [optionQuoteEntries, optionQuoteFreshness, optionQuoteTargets],
   );
-  const optionColumns: OptionColumn[] = OPTION_COLUMNS.map((column) => ({
+  const optionColumns = useMemo<OptionColumn[]>(() => createOptionColumns(optionFieldIds).map((column) => ({
     ...column,
-    headerColor: optionColumnColor(column.id, colors.panel),
-  }));
+    headerColor: optionColumnColor(column, colors.panel),
+  })), [optionFieldIds]);
 
   const selectedRow = rows[strikeIdx] ?? null;
   const calcParams = useMemo(() => buildChainCalcParams({
@@ -222,9 +289,9 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     side: resolveCalcSide(calcSide, parsed?.side, selectedRow),
     // On an option ticker the pane quote is the contract's own price, so load
     // the underlying snapshot rather than silently using the option mark as spot.
-    spot: (isOpt ? underlyingFinancials : financials)?.quote?.price,
-    dividendYield: (isOpt ? underlyingFinancials : financials)?.fundamentals?.dividendYield,
-  }), [calcSide, effectiveTicker, financials, isOpt, parsed?.side, selectedRow, underlyingFinancials]);
+    spot,
+    dividendYield,
+  }), [calcSide, dividendYield, effectiveTicker, parsed?.side, selectedRow, spot]);
 
   const openCalculator = useCallback(() => {
     if (!calcParams) return;
@@ -243,10 +310,10 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     rowState: { selected: boolean },
   ) => {
     const cell = renderOptionCell(row, column, index, rowState);
-    if (column.id === "strike") return cell;
+    if (!column.side) return cell;
     // Clicking a call or put cell is the mouse way to choose which contract
     // [c]alc opens, so it has to select the row itself as well.
-    const side: OptionSide = column.id.startsWith("call") ? "call" : "put";
+    const side: OptionSide = column.side;
     return {
       ...cell,
       onMouseDown: () => {
@@ -277,12 +344,12 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
 
   useEffect(() => {
     if (strikes.length === 0 || userSelectedStrikeRef.current) return;
-    const targetStrike = resolveDefaultStrikeTarget(parsed?.strike, financials?.quote?.price);
+    const targetStrike = resolveDefaultStrikeTarget(parsed?.strike, spot);
     if (targetStrike == null) return;
     setScrollToIndexAlign("center");
     setStrikeIdx(findNearestStrikeIndex(strikes, targetStrike));
     setAutoScrollVersion((version) => version + 1);
-  }, [expIdx, financials?.quote?.price, parsed?.strike, strikes]);
+  }, [expIdx, parsed?.strike, spot, strikes]);
 
   useShortcut((event) => {
     if (event.defaultPrevented || event.propagationStopped || event.targetEditable) return;
@@ -399,13 +466,18 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     ? ticker.metadata.positions.reduce((sum, p) => sum + p.shares, 0)
     : 0;
   const expirationTabsWidth = Math.max(width - 9 - (loading ? 2 : 0), 8);
-  const tableHeight = Math.max(1, height - 1 - (isOpt && parsed ? 1 : 0));
+  const summaryRowCount = height >= 10 ? 2 : height >= 7 ? 1 : 0;
+  const tableHeight = Math.max(1, height - 1 - summaryRowCount - (isOpt && parsed ? 1 : 0));
   // The strip scrolls; without a marker a clipped last date reads as the last expiry.
   const expirationStripOverflows = chain.expirationDates
     .reduce((total, ts) => total + formatExpDate(ts).length + 2, 0) > expirationTabsWidth;
 
   return (
     <Box flexDirection="column" flexGrow={1} paddingX={1} onMouseDown={() => { if (!interactive) enterInteractive(); }}>
+      {summaryRowCount > 0 && (
+        <OptionsSummaryStrip summary={summary} secondary={summaryRowCount > 1} />
+      )}
+
       <Box flexDirection="row" height={1} gap={1}>
         <Text fg={colors.textDim}>Exp:</Text>
         <Box width={expirationTabsWidth} height={1} overflow="hidden">


### PR DESCRIPTION
## Summary
- add an IBKR-style volatility strip with ATM IV, HV30, IV/HV, expiration volume, and put/call ratios
- show mirrored bid, ask, last, delta, and gamma columns by default
- let users order and enable theta, vega, rho, IV, volume, and open interest in pane settings
- derive Greeks with the existing Black-Scholes model and handle persisted price-history dates when calculating HV30

## Validation
- `bun test src/plugins/builtin/options/analytics.test.ts src/plugins/builtin/options/view.test.tsx` (9 passed)
- `bun run typecheck`
- `bun run desktop:view:build`
- full suite: 2,385 passed; four unrelated command-bar AI assist timing tests failed under parallel load, then passed 6/6 in isolation
- live AAPL options pane smoke-tested in tmux, including column settings and runtime warning scan
