### PR TITLE
Search cloud news from ART

### DIFF
--- a/src/api-client/data.ts
+++ b/src/api-client/data.ts
@@ -14,6 +14,7 @@ import {
   cloudMarketSearchPath,
   cloudMarketSymbolPath,
   cloudNewsPath,
+  cloudNewsSearchPath,
   cloudOptionsChainPath,
   cloudStatementsPath,
   cloudTickerTweetsPath,
@@ -247,6 +248,10 @@ export class CloudDataApi {
 
   async getCloudNewsStory(storyId: string): Promise<CloudNewsPayload> {
     return this.request<CloudNewsPayload>(`/news/${encodeURIComponent(storyId)}`);
+  }
+
+  async searchCloudNews(query: string, limit = 8): Promise<CloudNewsListResponse> {
+    return this.request<CloudNewsListResponse>(cloudNewsSearchPath(query, limit));
   }
 
   async getCloudTickerTweets(params: CloudTickerTweetsParams): Promise<CloudTweetSearchResponse> {

--- a/src/api-client/index.test.ts
+++ b/src/api-client/index.test.ts
@@ -1097,6 +1097,21 @@ describe("apiClient cloud news", () => {
     expect(result).toEqual({ items: [], nextCursor: null });
   });
 
+  test("searches cloud news with an encoded query and limit", async () => {
+    let seenUrl = "";
+    globalThis.fetch = mockFetch(async (input: Request | string | URL) => {
+      seenUrl = String(input);
+      return createResponse({ items: [], nextCursor: null });
+    });
+
+    await apiClient.searchCloudNews("strait hormuz", 8);
+
+    const url = new URL(seenUrl);
+    expect(url.pathname).toBe("/news/search");
+    expect(url.searchParams.get("query")).toBe("strait hormuz");
+    expect(url.searchParams.get("limit")).toBe("8");
+  });
+
   test("fetches news story details from the story route", async () => {
     let seenUrl = "";
     globalThis.fetch = mockFetch(async (input: Request | string | URL) => {

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -676,6 +676,10 @@ class GloomApiClient {
     return this.data.getCloudNewsStory(storyId);
   }
 
+  async searchCloudNews(query: string, limit = 8): Promise<CloudNewsListResponse> {
+    return this.data.searchCloudNews(query, limit);
+  }
+
   async getCloudTickerTweets(params: CloudTickerTweetsParams): Promise<CloudTweetSearchResponse> {
     return this.data.getCloudTickerTweets(params);
   }

--- a/src/api-client/paths.ts
+++ b/src/api-client/paths.ts
@@ -245,6 +245,13 @@ export function cloudNewsPath(params: CloudNewsParams = {}): string {
   return appendQuery("/news", search);
 }
 
+export function cloudNewsSearchPath(query: string, limit: number): string {
+  return appendQuery("/news/search", new URLSearchParams({
+    query,
+    limit: String(limit),
+  }));
+}
+
 export function cloudTickerTweetsPath(params: CloudTickerTweetsParams): string {
   const search = new URLSearchParams({ ticker: params.ticker });
   if (params.limit != null) search.set("limit", String(params.limit));

--- a/src/components/command-bar/routes/root/article-results.test.ts
+++ b/src/components/command-bar/routes/root/article-results.test.ts
@@ -44,6 +44,19 @@ describe("buildArticleSearchResultItems", () => {
     expect(opened).toEqual(["Iran Threatens to Close the Strait of Hormuz"]);
   });
 
+  test("shows typo-tolerant cloud matches without re-filtering them locally", () => {
+    const items = buildArticleSearchResultItems({
+      articles: [],
+      cloudArticles: [article("Microsoft announces new cloud region", "Reuters")],
+      query: "ART mikrosoft",
+      phase: "ready",
+      onOpen: () => {},
+    });
+    expect(items.map((item) => item.label)).toEqual([
+      "Microsoft announces new cloud region",
+    ]);
+  });
+
   test("shows a lookup row while subscribed feeds are still loading", () => {
     const items = buildArticleSearchResultItems({
       articles: [],

--- a/src/components/command-bar/routes/root/article-results.ts
+++ b/src/components/command-bar/routes/root/article-results.ts
@@ -11,6 +11,7 @@ import type { ResultItem } from "../../list/model";
  */
 export function buildArticleSearchResultItems(options: {
   articles: readonly NewsArticle[];
+  cloudArticles?: readonly NewsArticle[];
   query: string;
   phase?: "idle" | "loading" | "ready" | "refreshing" | "error";
   onOpen: (article: NewsArticle) => void;
@@ -18,7 +19,15 @@ export function buildArticleSearchResultItems(options: {
   const query = options.query.trim();
   if (!query || !looksLikeArticleQuery(query)) return [];
 
-  const matches = searchNewsArticles(options.articles, query);
+  const seen = new Set<string>();
+  const matches = [
+    ...(options.cloudArticles ?? []),
+    ...searchNewsArticles(options.articles, query),
+  ].filter((article) => {
+    if (seen.has(article.id)) return false;
+    seen.add(article.id);
+    return true;
+  }).slice(0, 8);
   const items = matches.map((article) => ({
     id: `article:${article.id}`,
     label: article.title,

--- a/src/components/command-bar/surface/index.tsx
+++ b/src/components/command-bar/surface/index.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { DataProvider } from "../../../types/data-provider";
+import type { NewsArticle } from "../../../news/types";
 import type { AppTickerRepositoryPort } from "../../../core/app-service-ports";
 import type { PluginRegistry } from "../../../plugins/registry";
 import type { LayoutBounds } from "../../../plugins/pane-manager";
@@ -12,6 +13,8 @@ import {
   ARTICLE_SEARCH_QUERY,
   cachedNewsArticles,
   looksLikeArticleQuery,
+  searchCloudNewsArticles,
+  tokenizeArticleQuery,
 } from "../../../plugins/builtin/news/wire/article-search";
 import { buildArticleSearchResultItems } from "../routes/root/article-results";
 import { openUrl } from "../../ui/external-link";
@@ -258,7 +261,39 @@ export function CommandBar({
     ),
   }), [askAssistNow, assistActive, assistAutoAsk, assistState, planAccess.emailVerified, startAssistSignUp]);
 
-  const newsState = useNewsArticles(looksLikeArticleQuery(rootQuery) ? ARTICLE_SEARCH_QUERY : null);
+  const articleLookupQuery = looksLikeArticleQuery(rootQuery) ? rootQuery.trim() : "";
+  const newsState = useNewsArticles(articleLookupQuery ? ARTICLE_SEARCH_QUERY : null);
+  const [cloudArticleSearch, setCloudArticleSearch] = useState<{
+    query: string;
+    phase: "loading" | "ready";
+    articles: NewsArticle[];
+  }>({ query: "", phase: "ready", articles: [] });
+  useEffect(() => {
+    if (tokenizeArticleQuery(articleLookupQuery).length === 0) {
+      setCloudArticleSearch((current) => (
+        current.query === articleLookupQuery && current.phase === "ready" && current.articles.length === 0
+          ? current
+          : { query: articleLookupQuery, phase: "ready", articles: [] }
+      ));
+      return;
+    }
+
+    let cancelled = false;
+    setCloudArticleSearch({ query: articleLookupQuery, phase: "loading", articles: [] });
+    const timer = setTimeout(() => {
+      void searchCloudNewsArticles(articleLookupQuery)
+        .then((articles) => {
+          if (!cancelled) setCloudArticleSearch({ query: articleLookupQuery, phase: "ready", articles });
+        })
+        .catch(() => {
+          if (!cancelled) setCloudArticleSearch({ query: articleLookupQuery, phase: "ready", articles: [] });
+        });
+    }, 120);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [articleLookupQuery]);
   const articleResultItems = useMemo(() => {
     const cached = cachedNewsArticles();
     const seen = new Set<string>();
@@ -272,17 +307,20 @@ export function CommandBar({
       || newsState.phase === "ready"
       || newsState.phase === "refreshing"
       || newsState.phase === "error";
-    const stillLoading = !localReady && (newsState.phase === "idle" || newsState.phase === "loading");
+    const localLoading = !localReady && (newsState.phase === "idle" || newsState.phase === "loading");
+    const cloudCurrent = cloudArticleSearch.query === articleLookupQuery;
+    const cloudLoading = !!articleLookupQuery && (!cloudCurrent || cloudArticleSearch.phase === "loading");
     return buildArticleSearchResultItems({
       articles,
+      cloudArticles: cloudCurrent ? cloudArticleSearch.articles : [],
       query: rootQuery,
-      phase: stillLoading ? "loading" : "ready",
+      phase: localLoading || cloudLoading ? "loading" : "ready",
       onOpen: (article) => {
         openUrl(article.url);
         closeAll({ revertThemePreview: false });
       },
     });
-  }, [closeAll, newsState.articles, newsState.phase, rootQuery]);
+  }, [articleLookupQuery, closeAll, cloudArticleSearch, newsState.articles, newsState.phase, rootQuery]);
 
   const {
     activeMatch,

--- a/src/plugins/builtin/news/wire/article-search.ts
+++ b/src/plugins/builtin/news/wire/article-search.ts
@@ -1,5 +1,7 @@
 import type { NewsArticle, NewsQuery } from "../../../../news/types";
 import { getSharedNewsService } from "../../../../news/hooks";
+import { apiClient } from "../../../../api-client";
+import { mapCloudNewsArticle } from "../../../../sources/gloomberb-cloud/news";
 
 const ARTICLE_SEARCH_LIMIT = 8;
 
@@ -137,4 +139,11 @@ export async function loadNewsArticles(): Promise<NewsArticle[]> {
   const service = getSharedNewsService();
   if (!service) return [];
   return (await service.load(ARTICLE_SEARCH_QUERY)).articles;
+}
+
+export async function searchCloudNewsArticles(query: string): Promise<NewsArticle[]> {
+  const search = tokenizeArticleQuery(query).join(" ");
+  if (!search) return [];
+  const response = await apiClient.searchCloudNews(search, ARTICLE_SEARCH_LIMIT);
+  return response.items.map((item) => mapCloudNewsArticle(item));
 }

--- a/src/plugins/builtin/news/wire/index.tsx
+++ b/src/plugins/builtin/news/wire/index.tsx
@@ -21,6 +21,7 @@ import { openUrl } from "../../../../components/ui/external-link";
 import {
   cachedNewsArticles,
   loadNewsArticles,
+  searchCloudNewsArticles,
   searchNewsArticles,
 } from "./article-search";
 
@@ -108,7 +109,7 @@ export const newsWireModule: PluginModule = {
     ctx.registerCommand({
       id: "open-news-article",
       label: "Open Article",
-      description: "Search loaded news headlines by topic, e.g. ART hormuz.",
+      description: "Search cloud and loaded news headlines, e.g. ART hormuz.",
       keywords: ["article", "news", "rss", "headline", "story", "open"],
       category: "navigation",
       shortcut: "ART",
@@ -119,10 +120,10 @@ export const newsWireModule: PluginModule = {
       },
       async execute(values) {
         const query = values?.query ?? values?.shortcut ?? "";
-        const articles = cachedNewsArticles().length > 0
-          ? cachedNewsArticles()
-          : await loadNewsArticles();
-        const match = searchNewsArticles(articles, query)[0];
+        const cached = cachedNewsArticles();
+        const cloudMatches = searchCloudNewsArticles(query).catch(() => []);
+        const articles = cached.length > 0 ? cached : await loadNewsArticles();
+        const match = searchNewsArticles(articles, query)[0] ?? (await cloudMatches)[0];
         if (!match) {
           ctx.notify({
             body: query.trim()


### PR DESCRIPTION
## Summary
- query the live cloud news index while an `ART` lookup is typed
- keep loaded local/RSS matches available immediately
- debounce cloud requests and discard stale responses
- accept backend-ranked typo matches without substring re-filtering

## Backend
- `GET /news/search` deployed in vincelwt/gloomberb-platform#146
- empty-query validation deployed in vincelwt/gloomberb-platform#147
- PostgreSQL `pg_trgm` GIN index applied to headline, summary, source, and category text
- anonymous and free searches retain the existing 12-hour news delay

## Verification
- focused command bar, API client, and article search tests: 53 pass
- local full suite: 2,387 pass; 4 pre-existing timing-sensitive AI assist failures pass when rerun focused
- both Linux CI build-and-test runs pass
- all six TypeScript projects pass
- packaged Linux binary builds and smoke-tests
- tmux smoke: `ART mikrosoft` returned eight Microsoft cloud stories with no runtime warnings
- production database plan uses `idx_news_stories_search_trgm`; typo query executed in 26.9 ms at 62,354 stories
- live API typo requests measured 125-170 ms end to end after deployment
