### PR TITLE
Make the world venue map zoomable

### DIFF
--- a/src/plugins/builtin/world-venue-map/map.desktop.test.tsx
+++ b/src/plugins/builtin/world-venue-map/map.desktop.test.tsx
@@ -1,0 +1,106 @@
+/** @jsxImportSource react */
+import { Window } from "happy-dom";
+
+const testWindow = new Window({ url: "http://localhost" });
+const domGlobals = {
+  IS_REACT_ACT_ENVIRONMENT: true,
+  window: testWindow,
+  document: testWindow.document,
+  navigator: testWindow.navigator,
+  KeyboardEvent: testWindow.KeyboardEvent,
+  MouseEvent: testWindow.MouseEvent,
+  WheelEvent: testWindow.WheelEvent,
+  HTMLElement: testWindow.HTMLElement,
+  Node: testWindow.Node,
+};
+const priorGlobals = Object.fromEntries(
+  Object.keys(domGlobals).map((key) => [key, (globalThis as Record<string, unknown>)[key]]),
+);
+Object.assign(globalThis, domGlobals);
+
+import { afterAll, afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { UiHostProvider, type RendererHost, type UiHost } from "../../../ui";
+import { WebBox } from "../../../renderers/electrobun/view/host/box";
+import { WebText } from "../../../renderers/electrobun/view/host/text";
+import { WorldVenueMap } from "./map";
+import type { CloudWorldVenuePayload } from "../../../api-client";
+
+const renderer: RendererHost = {
+  requestExit() {},
+  async openExternal() {},
+  async copyText() {},
+  async readText() { return ""; },
+  notify() {},
+};
+
+const ui = {
+  kind: "desktop-web",
+  capabilities: { cellWidthPx: 8, cellHeightPx: 18, fractionalViewport: true },
+  Box: WebBox,
+  Text: WebText,
+} as unknown as UiHost;
+
+afterAll(() => {
+  for (const [key, value] of Object.entries(priorGlobals)) {
+    if (value === undefined) delete (globalThis as Record<string, unknown>)[key];
+    else (globalThis as Record<string, unknown>)[key] = value;
+  }
+});
+
+const venue: CloudWorldVenuePayload = {
+  mic: "XNYS",
+  name: "NYSE",
+  title: "New York Stock Exchange",
+  country: "United States",
+  countryCode: "US",
+  city: "New York",
+  timezone: "America/New_York",
+  latitude: 40.7127,
+  longitude: -74.006,
+  isOpen: true,
+};
+
+let root: ReturnType<typeof createRoot> | undefined;
+let container: HTMLElement | undefined;
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root!.unmount());
+    root = undefined;
+  }
+  container?.remove();
+  container = undefined;
+});
+
+test("zooms the desktop map toward the pointer on wheel", async () => {
+  container = testWindow.document.createElement("div") as unknown as HTMLElement;
+  testWindow.document.body.appendChild(container as unknown as Node);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(
+      <UiHostProvider ui={ui} renderer={renderer}>
+        <WorldVenueMap
+          venues={[venue]}
+          selectedMic="XNYS"
+          width={80}
+          height={24}
+          onSelect={() => {}}
+        />
+      </UiHostProvider>,
+    );
+  });
+
+  const surface = container.querySelector('[data-gloom-role="world-venue-map"]') as HTMLElement;
+  expect(surface).toBeTruthy();
+  expect(surface.getAttribute("data-zoomed")).toBe("false");
+
+  const wheel = new testWindow.WheelEvent("wheel", { deltaY: -180, bubbles: true, cancelable: true });
+  await act(async () => {
+    surface.dispatchEvent(wheel as unknown as Event);
+  });
+
+  expect(wheel.defaultPrevented).toBe(true);
+  expect(surface.getAttribute("data-zoomed")).toBe("true");
+});

--- a/src/plugins/builtin/world-venue-map/map.tsx
+++ b/src/plugins/builtin/world-venue-map/map.tsx
@@ -1,6 +1,6 @@
-import { createElement, useMemo, useRef } from "react";
+import { createElement, useCallback, useEffect, useMemo, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
 import type { CloudWorldVenuePayload } from "../../../api-client";
-import { ChartSurface, Text, useNativeRenderer, useUiHost } from "../../../ui";
+import { Box, ChartSurface, Text, useNativeRenderer, useUiHost } from "../../../ui";
 import { useThemeColors } from "../../../theme/theme-context";
 import { resolveNativeBitmapSize, shouldRenderNativeBitmap } from "../../../components/chart/native/bitmap-support";
 import { drawCircle, drawLine, fillOpaque, parseHex } from "../../../components/chart/native/raster/primitives";
@@ -9,7 +9,12 @@ import { getLocalPlotPointer, type ChartMouseEvent } from "../../../components/c
 import {
   closestWorldVenueCluster,
   clusterWorldVenues,
+  DEFAULT_WORLD_MAP_VIEWPORT,
+  panWorldMapViewport,
   projectWorldPoint,
+  zoomWorldMapViewport,
+  type WorldMapPoint,
+  type WorldMapViewport,
   type WorldVenueCluster,
 } from "./model";
 import { WORLD_OUTLINES } from "./world-outlines";
@@ -236,17 +241,67 @@ function TerminalWorldVenueMap(props: WorldVenueMapProps) {
   );
 }
 
+const DESKTOP_MAP_ASPECT = 2.12;
+const MAP_PAN_THRESHOLD_PX = 4;
+const MAP_CLICK_HIT_PX = 14;
+const MAP_DOUBLE_CLICK_ZOOM = 1.8;
+
+function wheelZoomFactor(event: WheelEvent): number {
+  const delta = event.deltaMode === 1 ? event.deltaY * 16 : event.deltaY;
+  return Math.exp(-delta * 0.002);
+}
+
+function clientToMapPoint(
+  event: { clientX: number; clientY: number },
+  element: HTMLElement,
+  width: number,
+  height: number,
+): WorldMapPoint {
+  const rect = element.getBoundingClientRect();
+  return {
+    x: rect.width <= 0 ? 0 : ((event.clientX - rect.left) / rect.width) * width,
+    y: rect.height <= 0 ? 0 : ((event.clientY - rect.top) / rect.height) * height,
+  };
+}
+
+function clientDeltaToMapDelta(
+  deltaX: number,
+  deltaY: number,
+  element: HTMLElement,
+  width: number,
+  height: number,
+): WorldMapPoint {
+  const rect = element.getBoundingClientRect();
+  return {
+    x: rect.width <= 0 ? 0 : (deltaX / rect.width) * width,
+    y: rect.height <= 0 ? 0 : (deltaY / rect.height) * height,
+  };
+}
+
 function DesktopWorldVenueMap(props: WorldVenueMapProps) {
   const colors = useThemeColors();
+  const surfaceRef = useRef<HTMLDivElement | null>(null);
+  const [viewport, setViewport] = useState<WorldMapViewport>(DEFAULT_WORLD_MAP_VIEWPORT);
+  const viewportRef = useRef(viewport);
+  viewportRef.current = viewport;
+  const [dragging, setDragging] = useState(false);
+  const dragRef = useRef<{
+    pointerId: number;
+    lastX: number;
+    lastY: number;
+    originX: number;
+    originY: number;
+    moved: boolean;
+  } | null>(null);
   // Desktop rows are roughly twice as tall as they are wide. Matching the SVG
   // view box to those pixels lets the contained world projection keep its shape.
-  const plotHeight = props.height * 2.12;
+  const plotHeight = props.height * DESKTOP_MAP_ASPECT;
+  const zoomed = viewport.zoom > 1;
   const clusters = useMemo(
-    () => clusterWorldVenues(props.venues, props.width, plotHeight),
-    [plotHeight, props.venues, props.width],
+    () => clusterWorldVenues(props.venues, props.width, plotHeight, 1, viewport),
+    [plotHeight, props.venues, props.width, viewport],
   );
-
-  const outlinePath = (outline: (typeof WORLD_OUTLINES)[number]) => {
+  const outlinePaths = useMemo(() => WORLD_OUTLINES.map((outline) => {
     let drawing = false;
     let previousLongitude: number | null = null;
     return outline.map(([longitude, latitude]) => {
@@ -255,78 +310,167 @@ function DesktopWorldVenueMap(props: WorldVenueMapProps) {
         previousLongitude = longitude;
         return "";
       }
-      const point = projectWorldPoint(longitude, latitude, props.width, plotHeight);
+      const point = projectWorldPoint(longitude, latitude, props.width, plotHeight, 1, viewport);
       previousLongitude = longitude;
       const command = drawing ? "L" : "M";
       drawing = true;
       return `${command}${point.x.toFixed(2)} ${point.y.toFixed(2)}`;
     }).join(" ");
+  }), [plotHeight, props.width, viewport]);
+
+  const selectAt = useCallback((point: WorldMapPoint, element: HTMLElement) => {
+    const rect = element.getBoundingClientRect();
+    const hit = rect.height <= 0 ? 2.4 : (MAP_CLICK_HIT_PX / rect.height) * plotHeight;
+    const cluster = closestWorldVenueCluster(clusters, point.x, point.y, Math.max(1.6, hit));
+    if (cluster) props.onSelect(clusterVenue(cluster, props.selectedMic));
+  }, [clusters, plotHeight, props]);
+
+  useEffect(() => {
+    const element = surfaceRef.current;
+    if (!element) return;
+    const onWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const point = clientToMapPoint(event, element, props.width, plotHeight);
+      const factor = wheelZoomFactor(event);
+      setViewport((current) => zoomWorldMapViewport(current, props.width, plotHeight, point, factor));
+    };
+    element.addEventListener("wheel", onWheel, { passive: false });
+    return () => element.removeEventListener("wheel", onWheel);
+  }, [plotHeight, props.width]);
+
+  const endDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    dragRef.current = null;
+    setDragging(false);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    if (!drag.moved) selectAt(clientToMapPoint(event, event.currentTarget, props.width, plotHeight), event.currentTarget);
   };
 
   return (
-    <svg
-      viewBox={`0 0 ${props.width} ${plotHeight}`}
-      width="100%"
-      height="100%"
-      role="img"
-      aria-label="World venue map"
-      style={{ display: "block", background: colors.bg }}
-    >
-      {WORLD_OUTLINES.map((outline, index) => (
-        <path
-          key={index}
-          d={outlinePath(outline)}
-          fill="none"
-          stroke={colors.textDim}
-          strokeOpacity="0.64"
-          strokeWidth="0.55"
-          vectorEffect="non-scaling-stroke"
-        />
-      ))}
-      {clusters.map((cluster) => {
-        const selected = isSelectedCluster(cluster, props.selectedMic);
-        const venue = clusterVenue(cluster, props.selectedMic);
-        const radius = Math.max(0.55, Math.min(1.5, 0.45 + Math.sqrt(cluster.venues.length) * 0.22));
-        return (
-          <g
-            key={cluster.id}
-            role="button"
-            tabIndex={0}
-            aria-label={`${cluster.venues.length} venues near ${venue.city}`}
-            style={{ cursor: "pointer" }}
-            onMouseDown={(event) => {
-              event.stopPropagation();
-              props.onSelect(venue);
-            }}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" || event.key === " ") props.onSelect(venue);
-            }}
-          >
-            <title>{`${cluster.venues.length} venue${cluster.venues.length === 1 ? "" : "s"} near ${venue.city}: ${cluster.venues.map((item) => `${item.mic} ${item.name}`).join(", ")}`}</title>
-            <circle
-              cx={cluster.x}
-              cy={cluster.y}
-              r={radius + (selected ? 0.24 : 0)}
-              fill={cluster.isOpen ? colors.positive : colors.textMuted}
-              stroke={selected ? colors.selectedText : colors.bg}
-              strokeWidth={selected ? 0.35 : 0.16}
+    <Box width={props.width} height={props.height} overflow="hidden">
+      <div
+        ref={surfaceRef}
+        data-gloom-role="world-venue-map"
+        data-zoomed={zoomed ? "true" : "false"}
+        role="application"
+        aria-label="World venue map"
+        onPointerDown={(event) => {
+          if (event.button !== 0) return;
+          event.stopPropagation();
+          dragRef.current = {
+            pointerId: event.pointerId,
+            lastX: event.clientX,
+            lastY: event.clientY,
+            originX: event.clientX,
+            originY: event.clientY,
+            moved: false,
+          };
+          event.currentTarget.setPointerCapture(event.pointerId);
+        }}
+        onPointerMove={(event) => {
+          const drag = dragRef.current;
+          if (!drag || drag.pointerId !== event.pointerId) return;
+          const travel = Math.hypot(event.clientX - drag.originX, event.clientY - drag.originY);
+          if (!drag.moved && travel < MAP_PAN_THRESHOLD_PX) return;
+          if (viewportRef.current.zoom <= 1) return;
+          drag.moved = true;
+          const delta = clientDeltaToMapDelta(
+            event.clientX - drag.lastX,
+            event.clientY - drag.lastY,
+            event.currentTarget,
+            props.width,
+            plotHeight,
+          );
+          drag.lastX = event.clientX;
+          drag.lastY = event.clientY;
+          setDragging(true);
+          setViewport((current) => panWorldMapViewport(current, props.width, plotHeight, delta.x, delta.y));
+        }}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        onDoubleClick={(event) => {
+          const point = clientToMapPoint(event, event.currentTarget, props.width, plotHeight);
+          setViewport((current) => zoomWorldMapViewport(current, props.width, plotHeight, point, MAP_DOUBLE_CLICK_ZOOM));
+        }}
+        style={{
+          position: "relative",
+          width: "100%",
+          height: "100%",
+          flex: 1,
+          minHeight: 0,
+          overflow: "hidden",
+          touchAction: "none",
+          userSelect: "none",
+          cursor: dragging ? "grabbing" : zoomed ? "grab" : "pointer",
+          background: colors.bg,
+        }}
+      >
+        <svg
+          viewBox={`0 0 ${props.width} ${plotHeight}`}
+          width="100%"
+          height="100%"
+          aria-hidden="true"
+          style={{ display: "block", background: colors.bg, pointerEvents: "none" }}
+        >
+          {outlinePaths.map((path, index) => (
+            <path
+              key={index}
+              d={path}
+              fill="none"
+              stroke={colors.textDim}
+              strokeOpacity="0.64"
+              strokeWidth="0.55"
               vectorEffect="non-scaling-stroke"
             />
-            {cluster.venues.length > 1 ? createElement("text", {
-              x: cluster.x,
-              y: cluster.y,
-              fill: colors.bg,
-              dy: "0.34em",
-              fontSize: Math.max(0.62, Math.min(0.95, radius * 0.78)),
-              fontWeight: "700",
-              fontFamily: "inherit",
-              textAnchor: "middle",
-              pointerEvents: "none",
-            }, cluster.venues.length) : null}
-          </g>
-        );
-      })}
-    </svg>
+          ))}
+          {clusters.map((cluster) => {
+            const selected = isSelectedCluster(cluster, props.selectedMic);
+            const venue = clusterVenue(cluster, props.selectedMic);
+            const radius = Math.max(0.55, Math.min(1.5, 0.45 + Math.sqrt(cluster.venues.length) * 0.22));
+            return (
+              <g
+                key={cluster.id}
+                role="button"
+                tabIndex={0}
+                aria-label={`${cluster.venues.length} venues near ${venue.city}`}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    props.onSelect(venue);
+                  }
+                }}
+              >
+                <title>{`${cluster.venues.length} venue${cluster.venues.length === 1 ? "" : "s"} near ${venue.city}: ${cluster.venues.map((item) => `${item.mic} ${item.name}`).join(", ")}`}</title>
+                <circle
+                  cx={cluster.x}
+                  cy={cluster.y}
+                  r={radius + (selected ? 0.24 : 0)}
+                  fill={cluster.isOpen ? colors.positive : colors.textMuted}
+                  stroke={selected ? colors.selectedText : colors.bg}
+                  strokeWidth={selected ? 0.35 : 0.16}
+                  vectorEffect="non-scaling-stroke"
+                />
+                {cluster.venues.length > 1 ? createElement("text", {
+                  x: cluster.x,
+                  y: cluster.y,
+                  fill: colors.bg,
+                  dy: "0.34em",
+                  fontSize: Math.max(0.62, Math.min(0.95, radius * 0.78)),
+                  fontWeight: "700",
+                  fontFamily: "inherit",
+                  textAnchor: "middle",
+                  pointerEvents: "none",
+                }, cluster.venues.length) : null}
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+    </Box>
   );
 }
 

--- a/src/plugins/builtin/world-venue-map/model.test.ts
+++ b/src/plugins/builtin/world-venue-map/model.test.ts
@@ -2,9 +2,13 @@ import { describe, expect, test } from "bun:test";
 import type { CloudWorldVenuePayload } from "../../../api-client";
 import {
   clusterWorldVenues,
+  DEFAULT_WORLD_MAP_VIEWPORT,
   filterWorldVenues,
+  panWorldMapViewport,
   projectWorldPoint,
+  unprojectWorldPoint,
   venueRemainingSeconds,
+  zoomWorldMapViewport,
 } from "./model";
 
 function venue(overrides: Partial<CloudWorldVenuePayload>): CloudWorldVenuePayload {
@@ -49,5 +53,33 @@ describe("world venue map model", () => {
     expect(filterWorldVenues(rows, "london").map((item) => item.mic)).toEqual(["XLON"]);
     expect(filterWorldVenues(rows, "")[0]?.mic).toBe("XASE");
     expect(venueRemainingSeconds(rows[0]!, 1_000, 61_000)).toBe(3_540);
+  });
+
+  test("keeps a cursor point anchored while zooming and splits nearby clusters", () => {
+    const width = 361;
+    const height = 146;
+    const cursor = { x: 90, y: 40 };
+    const geographic = unprojectWorldPoint(cursor.x, cursor.y, width, height);
+    const zoomed = zoomWorldMapViewport(DEFAULT_WORLD_MAP_VIEWPORT, width, height, cursor, 4);
+    expect(zoomed.zoom).toBe(4);
+    const stillUnderCursor = projectWorldPoint(geographic.longitude, geographic.latitude, width, height, 1, zoomed);
+    expect(stillUnderCursor.x).toBeCloseTo(cursor.x, 6);
+    expect(stillUnderCursor.y).toBeCloseTo(cursor.y, 6);
+
+    const nearby = [
+      venue({ mic: "WEST", longitude: -20, latitude: 20 }),
+      venue({ mic: "EAST", longitude: -18, latitude: 20 }),
+    ];
+    expect(clusterWorldVenues(nearby, 80, 24)).toHaveLength(1);
+    expect(clusterWorldVenues(nearby, 80, 24, 1, {
+      zoom: 10,
+      centerLongitude: 0,
+      centerLatitude: DEFAULT_WORLD_MAP_VIEWPORT.centerLatitude,
+    })).toHaveLength(2);
+
+    const panned = panWorldMapViewport(zoomed, width, height, 40, 0);
+    expect(panned.centerLongitude).toBeLessThan(zoomed.centerLongitude);
+    expect(panWorldMapViewport(DEFAULT_WORLD_MAP_VIEWPORT, width, height, 40, 0)).toEqual(DEFAULT_WORLD_MAP_VIEWPORT);
+    expect(zoomWorldMapViewport(zoomed, width, height, cursor, 0.01)).toEqual(DEFAULT_WORLD_MAP_VIEWPORT);
   });
 });

--- a/src/plugins/builtin/world-venue-map/model.ts
+++ b/src/plugins/builtin/world-venue-map/model.ts
@@ -11,8 +11,49 @@ export interface WorldVenueCluster extends WorldMapPoint {
   isOpen: boolean;
 }
 
+export interface WorldMapViewport {
+  zoom: number;
+  centerLongitude: number;
+  centerLatitude: number;
+}
+
 const MAX_LATITUDE = 85;
 const MIN_LATITUDE = -60;
+const LONGITUDE_SPAN = 360;
+export const MAX_WORLD_MAP_ZOOM = 18;
+
+export const DEFAULT_WORLD_MAP_VIEWPORT: WorldMapViewport = {
+  zoom: 1,
+  centerLongitude: 0,
+  centerLatitude: (MAX_LATITUDE + MIN_LATITUDE) / 2,
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function mapExtent(width: number, height: number, yUnitAspect = 1) {
+  const availableWidth = Math.max(width - 1, 0);
+  const availableHeight = Math.max(height - 1, 0);
+  const unitAspect = Math.max(yUnitAspect, Number.EPSILON);
+  const effectiveHeight = availableHeight * unitAspect;
+  const latitudeSpan = MAX_LATITUDE - MIN_LATITUDE;
+  return { availableWidth, availableHeight, unitAspect, effectiveHeight, latitudeSpan };
+}
+
+function fittedWorldMapScale(width: number, height: number, yUnitAspect = 1): number {
+  const { availableWidth, effectiveHeight, latitudeSpan } = mapExtent(width, height, yUnitAspect);
+  return Math.min(availableWidth / LONGITUDE_SPAN, effectiveHeight / latitudeSpan);
+}
+
+function worldMapScale(
+  width: number,
+  height: number,
+  yUnitAspect: number,
+  viewport: WorldMapViewport,
+): number {
+  return fittedWorldMapScale(width, height, yUnitAspect) * Math.max(viewport.zoom, 1);
+}
 
 export function projectWorldPoint(
   longitude: number,
@@ -20,21 +61,100 @@ export function projectWorldPoint(
   width: number,
   height: number,
   yUnitAspect = 1,
+  viewport: WorldMapViewport = DEFAULT_WORLD_MAP_VIEWPORT,
 ): WorldMapPoint {
-  const availableWidth = Math.max(width - 1, 0);
-  const availableHeight = Math.max(height - 1, 0);
-  const unitAspect = Math.max(yUnitAspect, Number.EPSILON);
-  const effectiveHeight = availableHeight * unitAspect;
-  const latitudeSpan = MAX_LATITUDE - MIN_LATITUDE;
-  const scale = Math.min(availableWidth / 360, effectiveHeight / latitudeSpan);
-  const mapWidth = 360 * scale;
-  const mapHeight = latitudeSpan * scale;
-  const clampedLatitude = Math.max(MIN_LATITUDE, Math.min(MAX_LATITUDE, latitude));
+  const { availableWidth, unitAspect, effectiveHeight } = mapExtent(width, height, yUnitAspect);
+  const scale = worldMapScale(width, height, yUnitAspect, viewport);
+  const clampedLatitude = clamp(latitude, MIN_LATITUDE, MAX_LATITUDE);
 
   return {
-    x: (availableWidth - mapWidth) / 2 + (longitude + 180) * scale,
-    y: ((effectiveHeight - mapHeight) / 2 + (MAX_LATITUDE - clampedLatitude) * scale) / unitAspect,
+    x: availableWidth / 2 + (longitude - viewport.centerLongitude) * scale,
+    y: (effectiveHeight / 2 - (clampedLatitude - viewport.centerLatitude) * scale) / unitAspect,
   };
+}
+
+export function unprojectWorldPoint(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  yUnitAspect = 1,
+  viewport: WorldMapViewport = DEFAULT_WORLD_MAP_VIEWPORT,
+): { longitude: number; latitude: number } {
+  const { availableWidth, unitAspect, effectiveHeight } = mapExtent(width, height, yUnitAspect);
+  const scale = worldMapScale(width, height, yUnitAspect, viewport);
+  return {
+    longitude: viewport.centerLongitude + (x - availableWidth / 2) / scale,
+    latitude: viewport.centerLatitude - (y * unitAspect - effectiveHeight / 2) / scale,
+  };
+}
+
+export function clampWorldMapViewport(
+  viewport: WorldMapViewport,
+  width: number,
+  height: number,
+  yUnitAspect = 1,
+): WorldMapViewport {
+  const zoom = clamp(viewport.zoom, 1, MAX_WORLD_MAP_ZOOM);
+  if (zoom <= 1) return DEFAULT_WORLD_MAP_VIEWPORT;
+
+  const { availableWidth, effectiveHeight, latitudeSpan } = mapExtent(width, height, yUnitAspect);
+  const scale = fittedWorldMapScale(width, height, yUnitAspect) * zoom;
+  const halfLongitude = availableWidth / (2 * scale);
+  const halfLatitude = effectiveHeight / (2 * scale);
+  const minLongitude = -180 + halfLongitude;
+  const maxLongitude = 180 - halfLongitude;
+  const minLatitude = MIN_LATITUDE + halfLatitude;
+  const maxLatitude = MAX_LATITUDE - halfLatitude;
+
+  return {
+    zoom,
+    centerLongitude: minLongitude < maxLongitude
+      ? clamp(viewport.centerLongitude, minLongitude, maxLongitude)
+      : DEFAULT_WORLD_MAP_VIEWPORT.centerLongitude,
+    centerLatitude: halfLatitude < latitudeSpan / 2
+      ? clamp(viewport.centerLatitude, minLatitude, maxLatitude)
+      : DEFAULT_WORLD_MAP_VIEWPORT.centerLatitude,
+  };
+}
+
+export function zoomWorldMapViewport(
+  viewport: WorldMapViewport,
+  width: number,
+  height: number,
+  point: WorldMapPoint,
+  zoomFactor: number,
+  yUnitAspect = 1,
+): WorldMapViewport {
+  const nextZoom = clamp(viewport.zoom * zoomFactor, 1, MAX_WORLD_MAP_ZOOM);
+  if (nextZoom <= 1) return DEFAULT_WORLD_MAP_VIEWPORT;
+
+  const geographic = unprojectWorldPoint(point.x, point.y, width, height, yUnitAspect, viewport);
+  const { availableWidth, unitAspect, effectiveHeight } = mapExtent(width, height, yUnitAspect);
+  const scale = fittedWorldMapScale(width, height, yUnitAspect) * nextZoom;
+  return clampWorldMapViewport({
+    zoom: nextZoom,
+    centerLongitude: geographic.longitude - (point.x - availableWidth / 2) / scale,
+    centerLatitude: geographic.latitude + (point.y * unitAspect - effectiveHeight / 2) / scale,
+  }, width, height, yUnitAspect);
+}
+
+export function panWorldMapViewport(
+  viewport: WorldMapViewport,
+  width: number,
+  height: number,
+  deltaX: number,
+  deltaY: number,
+  yUnitAspect = 1,
+): WorldMapViewport {
+  if (viewport.zoom <= 1) return DEFAULT_WORLD_MAP_VIEWPORT;
+  const scale = worldMapScale(width, height, yUnitAspect, viewport);
+  const unitAspect = Math.max(yUnitAspect, Number.EPSILON);
+  return clampWorldMapViewport({
+    zoom: viewport.zoom,
+    centerLongitude: viewport.centerLongitude - deltaX / scale,
+    centerLatitude: viewport.centerLatitude + (deltaY * unitAspect) / scale,
+  }, width, height, yUnitAspect);
 }
 
 export function clusterWorldVenues(
@@ -42,13 +162,14 @@ export function clusterWorldVenues(
   width: number,
   height: number,
   yUnitAspect = 1,
+  viewport: WorldMapViewport = DEFAULT_WORLD_MAP_VIEWPORT,
 ): WorldVenueCluster[] {
   const buckets = new Map<string, CloudWorldVenuePayload[]>();
   const cellWidth = Math.max(4, Math.round(width / 18));
   const cellHeight = Math.max(2, Math.round(height / 12));
 
   for (const venue of venues) {
-    const point = projectWorldPoint(venue.longitude, venue.latitude, width, height, yUnitAspect);
+    const point = projectWorldPoint(venue.longitude, venue.latitude, width, height, yUnitAspect, viewport);
     const key = `${Math.floor(point.x / cellWidth)}:${Math.floor(point.y / cellHeight)}`;
     const bucket = buckets.get(key) ?? [];
     bucket.push(venue);
@@ -58,7 +179,7 @@ export function clusterWorldVenues(
   return [...buckets.entries()].map(([id, grouped]) => {
     const point = grouped.reduce(
       (sum, venue) => {
-        const projected = projectWorldPoint(venue.longitude, venue.latitude, width, height, yUnitAspect);
+        const projected = projectWorldPoint(venue.longitude, venue.latitude, width, height, yUnitAspect, viewport);
         return { x: sum.x + projected.x, y: sum.y + projected.y };
       },
       { x: 0, y: 0 },


### PR DESCRIPTION
The desktop/web world venue map now zooms toward the pointer (wheel or pinch), pans by dragging, and zooms in on double-click. Nearby venues uncluster as you zoom in; scrolling back out restores the world view.