### PR TITLE
Add earnings calls pane with transcript reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ See [PLUGINS.md](PLUGINS.md) for the plugin API and the shared UI surface availa
 | `Ctrl+W` | Close focused pane |
 | `Ctrl+Shift+M` | Move focused window (`WIN resize` starts resize mode) |
 | `Ctrl+Shift+D` | Dock or float focused pane |
+| `Ctrl+Shift+E` | Export focused pane table as CSV |
 | `Ctrl+Shift+L` | Layout actions |
 | `Ctrl+Shift+G` | Tidy windows |
 | `Tab` | Switch panes |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -172,6 +172,7 @@ gloomberb
 | `Ctrl+W` | 关闭聚焦面板 |
 | `Ctrl+Shift+M` | 移动聚焦窗口（`WIN resize` 进入缩放模式） |
 | `Ctrl+Shift+D` | 停靠或浮动聚焦面板 |
+| `Ctrl+Shift+E` | 将聚焦面板的表格导出为 CSV |
 | `Ctrl+Shift+L` | 布局操作 |
 | `Ctrl+Shift+G` | 所有窗口网格对齐 |
 | `Tab` | 切换面板 |

--- a/src/api-client/data.ts
+++ b/src/api-client/data.ts
@@ -4,6 +4,8 @@ import { normalizeTweetSearchResponse } from "./normalizers";
 import {
   cloudCdsPath,
   cloudCongressHousePath,
+  cloudEarningsCallsPath,
+  cloudEarningsTranscriptPath,
   cloudExchangeRatePath,
   cloudSec13FPath,
   cloudSecFilingContentPath,
@@ -20,6 +22,7 @@ import {
   cloudTweetSearchPath,
   type CloudCdsParams,
   type CloudCongressHouseParams,
+  type CloudEarningsCallsParams,
   type CloudFredSeriesParams,
   type CloudHistoryParams,
   type CloudNewsParams,
@@ -34,6 +37,8 @@ import type {
   CloudCdsResponse,
   CloudCompanyProfile,
   CloudCongressHousePayload,
+  CloudEarningsCallListPayload,
+  CloudEarningsTranscriptPayload,
   CloudCorporateActionsPayload,
   CloudEconEventPayload,
   CloudEquityDiagnosticMode,
@@ -223,6 +228,16 @@ export class CloudDataApi {
 
   async getCloudCongressHouse(params: CloudCongressHouseParams = {}): Promise<CloudCongressHousePayload> {
     return this.request<CloudCongressHousePayload>(cloudCongressHousePath(params));
+  }
+
+  async getCloudEarningsCalls(
+    params: CloudEarningsCallsParams = {},
+  ): Promise<CloudEarningsCallListPayload> {
+    return this.request<CloudEarningsCallListPayload>(cloudEarningsCallsPath(params));
+  }
+
+  async getCloudEarningsTranscript(id: string): Promise<CloudEarningsTranscriptPayload> {
+    return this.request<CloudEarningsTranscriptPayload>(cloudEarningsTranscriptPath(id));
   }
 
   async getCloudSecFilings(params: CloudSecFilingsParams): Promise<CloudSecFilingsResponse> {

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -9,6 +9,7 @@ import { CloudApiSocket } from "./socket";
 import type {
   CloudCdsParams,
   CloudCongressHouseParams,
+  CloudEarningsCallsParams,
   CloudFredSeriesParams,
   CloudSecFilingParams,
   CloudSecFilingsParams,
@@ -50,6 +51,8 @@ import type {
   CloudFredSeriesPayload,
   CloudYieldPointPayload,
   CloudCongressHousePayload,
+  CloudEarningsCallListPayload,
+  CloudEarningsTranscriptPayload,
   CloudNewsPayload,
   CloudSecContentResponse,
   CloudSecDocumentsResponse,
@@ -650,6 +653,16 @@ class GloomApiClient {
 
   async getCloudCongressHouse(params: CloudCongressHouseParams = {}): Promise<CloudCongressHousePayload> {
     return this.data.getCloudCongressHouse(params);
+  }
+
+  async getCloudEarningsCalls(
+    params: CloudEarningsCallsParams = {},
+  ): Promise<CloudEarningsCallListPayload> {
+    return this.data.getCloudEarningsCalls(params);
+  }
+
+  async getCloudEarningsTranscript(id: string): Promise<CloudEarningsTranscriptPayload> {
+    return this.data.getCloudEarningsTranscript(id);
   }
 
   async getCloudSecFilings(params: CloudSecFilingsParams): Promise<CloudSecFilingsResponse> {

--- a/src/api-client/paths.ts
+++ b/src/api-client/paths.ts
@@ -34,6 +34,14 @@ export type CloudCongressHouseParams = {
   refresh?: boolean;
 };
 
+export type CloudEarningsCallsParams = {
+  ticker?: string;
+  limit?: number;
+  offset?: number;
+  /** Include calls still working through the transcription pipeline. */
+  includePending?: boolean;
+};
+
 export type CloudNewsParams = {
   feed?: "latest" | "top" | "breaking" | "ticker" | "sector" | "topic";
   ticker?: string;
@@ -179,6 +187,19 @@ export function cloudCongressHousePath(params: CloudCongressHouseParams = {}): s
   if (params.ticker) search.set("ticker", params.ticker);
   if (params.refresh != null) search.set("refresh", String(params.refresh));
   return appendQuery("/cloud/congress/house", search);
+}
+
+export function cloudEarningsCallsPath(params: CloudEarningsCallsParams = {}): string {
+  const search = new URLSearchParams();
+  if (params.ticker) search.set("ticker", params.ticker);
+  if (params.limit != null) search.set("limit", String(params.limit));
+  if (params.offset != null) search.set("offset", String(params.offset));
+  if (params.includePending) search.set("includePending", "true");
+  return appendQuery("/cloud/transcripts", search);
+}
+
+export function cloudEarningsTranscriptPath(id: string): string {
+  return `/cloud/transcripts/${encodeURIComponent(id)}`;
 }
 
 export function cloudSecFilingsPath(params: CloudSecFilingsParams): string {

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -516,6 +516,8 @@ export interface CloudEarningsTranscriptPayload {
   summary: string | null;
   guidance: string | null;
   riskFactors: string | null;
+  analystFocus: string | null;
+  notable: string | null;
   sentiment: number | null;
   sentimentRationale: string | null;
   qaStartTurn: number | null;

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -466,6 +466,64 @@ export interface CloudCongressHousePayload {
   members: CloudCongressMemberPayload[];
 }
 
+export interface CloudEarningsCallPayload {
+  id: string;
+  ticker: string;
+  companyName: string | null;
+  fiscalYear: number | null;
+  fiscalQuarter: number | null;
+  callAt: string | null;
+  status: string;
+  durationSeconds: number | null;
+  wordCount: number | null;
+  hasTranscript: boolean;
+  sentiment: number | null;
+}
+
+export interface CloudEarningsCallListPayload {
+  calls: CloudEarningsCallPayload[];
+}
+
+export interface CloudTranscriptTurnPayload {
+  speaker: string;
+  role?: string;
+  company?: string;
+  text: string;
+  isQa: boolean;
+  startSeconds: number;
+}
+
+export interface CloudTranscriptParticipantPayload {
+  name: string;
+  role?: string;
+  company?: string;
+}
+
+export interface CloudEarningsTranscriptPayload {
+  id: string;
+  ticker: string;
+  companyName: string | null;
+  fiscalYear: number | null;
+  fiscalQuarter: number | null;
+  callAt: string | null;
+  timing: string | null;
+  webcastUrl: string | null;
+  durationSeconds: number | null;
+  status: string;
+  fullText: string;
+  turns: CloudTranscriptTurnPayload[];
+  participants: CloudTranscriptParticipantPayload[];
+  summary: string | null;
+  guidance: string | null;
+  riskFactors: string | null;
+  sentiment: number | null;
+  sentimentRationale: string | null;
+  qaStartTurn: number | null;
+  wordCount: number | null;
+  asrModel: string | null;
+  updatedAt: string | null;
+}
+
 export interface CloudSecFilingPayload {
   accessionNumber: string;
   form: string;

--- a/src/components/input-search-bar.test.tsx
+++ b/src/components/input-search-bar.test.tsx
@@ -21,9 +21,13 @@ afterEach(async () => {
 function Harness({
   actions,
   onNavigateDown,
+  onBlur,
+  onQueryChange,
 }: {
   actions: AppAction[];
   onNavigateDown?: () => void;
+  onBlur?: () => void;
+  onQueryChange?: (query: string) => void;
 }) {
   const state = createInitialState(createDefaultConfig("/tmp/gloomberb-input-search-bar"));
   const inputRef = useRef<InputRenderable | null>(null);
@@ -46,8 +50,8 @@ function Harness({
         debounceMs={100}
         onNavigateDown={onNavigateDown}
         onFocus={() => {}}
-        onBlur={() => {}}
-        onQueryChange={() => {}}
+        onBlur={onBlur ?? (() => {})}
+        onQueryChange={onQueryChange ?? (() => {})}
       />
     </AppContext>
   );
@@ -74,6 +78,36 @@ describe("InputSearchBar", () => {
       { type: "SET_INPUT_CAPTURED", captured: true },
       { type: "SET_INPUT_CAPTURED", captured: false },
     ]);
+  });
+
+  test("Escape clears the query and releases the field", async () => {
+    // The input consumes every key while focused, so without this there is no
+    // way out of a search once it is entered.
+    const actions: AppAction[] = [];
+    const queries: string[] = [];
+    let blurred = false;
+
+    testSetup = await testRender(
+      <Harness
+        actions={actions}
+        onBlur={() => {
+          blurred = true;
+        }}
+        onQueryChange={(query) => queries.push(query)}
+      />,
+      { width: 40, height: 4 },
+    );
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+
+    await act(async () => {
+      testSetup!.renderer.keyInput.emit("keypress", { name: "escape" });
+      await testSetup!.renderOnce();
+    });
+
+    expect(queries).toEqual([""]);
+    expect(blurred).toBe(true);
   });
 
   test("moves from the active search input to the table with Down", async () => {

--- a/src/components/input-search-bar.tsx
+++ b/src/components/input-search-bar.tsx
@@ -47,6 +47,20 @@ export function InputSearchBar({
     phase: "before",
   });
 
+  // A focused input consumes every key, so Escape has to be intercepted before
+  // it reaches the field. Without this there is no way back out of a search.
+  useShortcut((event) => {
+    if (event.name !== "escape") return;
+    stopSearchFocusNavigation(event);
+    setDraft("");
+    onQueryChange("");
+    onBlur();
+  }, {
+    allowEditable: true,
+    enabled: focused && active,
+    phase: "before",
+  });
+
   useEffect(() => {
     setDraft(value);
   }, [value]);

--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -257,10 +257,13 @@ export function Shell({
   });
 
   const {
+    canExportPaneCsv,
     closeAllFloatingPanes,
     closeFocusedPane,
     copyFocusedPaneScreenshot,
     copyPaneScreenshot,
+    exportFocusedPaneCsv,
+    exportPaneCsv,
     gridlockVisiblePanes,
     handleFloatingClose,
     openFocusedPaneSettings,
@@ -474,6 +477,7 @@ export function Shell({
     closeAllFloatingPanes,
     closeFocusedPane,
     copyFocusedPaneScreenshot,
+    exportFocusedPaneCsv,
     focusedPaneId,
     gridlockVisiblePanes,
     hasActiveDrag,
@@ -526,6 +530,7 @@ export function Shell({
         state: titleState,
         persistLayout,
       }),
+      canExportPaneCsv(paneId) ? exportPaneCsv : undefined,
     );
     void showContextMenu(context, items, event).then((shown) => {
       if (shown) return;
@@ -549,7 +554,7 @@ export function Shell({
         items: fallbackItems,
       });
     });
-  }, [contentHeight, copyPaneScreenshot, desktopWindowBridge, focusPane, getPaneTitle, nativePaneChrome, openPaneSettings, paneMap, paneState, persistLayout, pluginRegistry, publicSharing, rendererHost.copyPngImage, sharePane, shortcutDisplayMode, showContextMenu, titleState, visibleLayout, width]);
+  }, [canExportPaneCsv, contentHeight, copyPaneScreenshot, desktopWindowBridge, exportPaneCsv, focusPane, getPaneTitle, nativePaneChrome, openPaneSettings, paneMap, paneState, persistLayout, pluginRegistry, publicSharing, rendererHost.copyPngImage, sharePane, shortcutDisplayMode, showContextMenu, titleState, visibleLayout, width]);
 
   const {
     handleFloatingCloseMouseDown,

--- a/src/components/layout/shell/menu.ts
+++ b/src/components/layout/shell/menu.ts
@@ -34,6 +34,7 @@ export function menuForPane(
   copyPaneScreenshot?: (paneId: string) => void | Promise<void>,
   sharePane?: () => void | Promise<void>,
   linkItems: ContextMenuItem[] = [],
+  exportPaneCsv?: (paneId: string) => void | Promise<void>,
 ): ContextMenuItem[] {
   const baseActions: ContextMenuItem[] = [];
   if (pluginRegistry.hasPaneSettings(pane.instance.instanceId)) {
@@ -58,6 +59,14 @@ export function menuForPane(
       label: "Copy Screenshot",
       accelerator: PANE_MANAGEMENT_ACCELERATORS.copyScreenshot,
       onSelect: () => copyPaneScreenshot(pane.instance.instanceId),
+    });
+  }
+  if (exportPaneCsv) {
+    baseActions.push({
+      id: "export-csv",
+      label: "Export CSV",
+      accelerator: PANE_MANAGEMENT_ACCELERATORS.exportCsv,
+      onSelect: () => exportPaneCsv(pane.instance.instanceId),
     });
   }
 

--- a/src/components/layout/shell/pane/actions.ts
+++ b/src/components/layout/shell/pane/actions.ts
@@ -13,6 +13,10 @@ import type { PluginRegistry } from "../../../../plugins/registry";
 import type { LayoutConfig } from "../../../../types/config";
 import type { RendererHost } from "../../../../ui";
 import { capturePaneScreenshotPngBase64 } from "../../../../utils/dom-screenshot";
+import {
+  exportPaneTableCsv,
+  hasPaneTableExporter,
+} from "../../../../state/pane-table-export-registry";
 
 function removedFocusRestoreOptions(
   layout: LayoutConfig,
@@ -75,6 +79,28 @@ export function useShellPaneActions({
     }
   }, [closePaneMenu, pluginRegistry, rendererHost]);
 
+  const canExportPaneCsv = useCallback((paneId: string) => {
+    const pane = paneMap.get(paneId);
+    return pane?.def.tableExport === true && hasPaneTableExporter(paneId);
+  }, [paneMap]);
+
+  const exportPaneCsv = useCallback(async (paneId: string) => {
+    closePaneMenu();
+    const pane = paneMap.get(paneId);
+    if (!pane) return;
+    await exportPaneTableCsv(
+      paneId,
+      pane.instance.title ?? pane.def.name,
+      pluginRegistry.notify,
+    );
+  }, [closePaneMenu, paneMap, pluginRegistry]);
+
+  const exportFocusedPaneCsv = useCallback(() => {
+    if (!focusedPaneId || !canExportPaneCsv(focusedPaneId)) return false;
+    void exportPaneCsv(focusedPaneId);
+    return true;
+  }, [canExportPaneCsv, exportPaneCsv, focusedPaneId]);
+
   const closeFocusedPane = useCallback(() => {
     if (!focusedPaneId || !isPaneInLayout(visibleLayout, focusedPaneId)) return false;
     const nextLayout = removePane(visibleLayout, focusedPaneId);
@@ -132,10 +158,13 @@ export function useShellPaneActions({
   }, [focusedPaneId, persistLayout, previousFocusedPaneId, visibleLayout]);
 
   return {
+    canExportPaneCsv,
     closeAllFloatingPanes,
     closeFocusedPane,
     copyFocusedPaneScreenshot,
     copyPaneScreenshot,
+    exportFocusedPaneCsv,
+    exportPaneCsv,
     gridlockVisiblePanes,
     handleFloatingClose,
     openFocusedPaneSettings,

--- a/src/components/layout/shell/pane/management-shortcuts.ts
+++ b/src/components/layout/shell/pane/management-shortcuts.ts
@@ -16,6 +16,7 @@ interface ShellPaneManagementShortcutOptions {
   closeAllFloatingPanes(): boolean;
   closeFocusedPane(): boolean;
   copyFocusedPaneScreenshot(): boolean;
+  exportFocusedPaneCsv(): boolean;
   focusedPaneId: string | null;
   gridlockVisiblePanes(): boolean;
   hasActiveDrag(): boolean;
@@ -35,6 +36,7 @@ export function useShellPaneManagementShortcuts({
   closeAllFloatingPanes,
   closeFocusedPane,
   copyFocusedPaneScreenshot,
+  exportFocusedPaneCsv,
   focusedPaneId,
   gridlockVisiblePanes,
   hasActiveDrag,
@@ -120,6 +122,9 @@ export function useShellPaneManagementShortcuts({
         break;
       case "copy-screenshot":
         handled = copyFocusedPaneScreenshot();
+        break;
+      case "export-csv":
+        handled = exportFocusedPaneCsv();
         break;
       case "share":
         handled = shareFocusedPane();

--- a/src/components/layout/shell/shortcuts.ts
+++ b/src/components/layout/shell/shortcuts.ts
@@ -6,6 +6,7 @@ export const PANE_MANAGEMENT_ACCELERATORS = {
   toggleFloating: "CmdOrCtrl+Shift+D",
   popOut: "CmdOrCtrl+Shift+O",
   copyScreenshot: "CmdOrCtrl+Shift+C",
+  exportCsv: "CmdOrCtrl+Shift+E",
   share: "CmdOrCtrl+Shift+S",
   close: "CmdOrCtrl+W",
   closeAllFloating: "CmdOrCtrl+Alt+W",
@@ -21,6 +22,7 @@ export type PaneManagementShortcut =
   | "toggle-floating"
   | "pop-out"
   | "copy-screenshot"
+  | "export-csv"
   | "share"
   | "close"
   | "close-all-floating"
@@ -41,6 +43,7 @@ export function resolvePaneManagementShortcut(
   if (!shifted && name === ",") return "settings";
   if (!shifted || event.alt) return null;
   if (name === "c") return "copy-screenshot";
+  if (name === "e") return "export-csv";
   if (name === "s") return "share";
   if (name === "d") return "toggle-floating";
   if (name === "f") return "toggle-fullscreen";

--- a/src/plugins/builtin/cloud/plugin.tsx
+++ b/src/plugins/builtin/cloud/plugin.tsx
@@ -172,6 +172,7 @@ const congressTradesModule: PluginModule = {
     defaultPosition: "right",
     defaultMode: "floating",
     defaultFloatingSize: { width: 112, height: 30 },
+    tableExport: true,
   }],
   paneTemplates: [{
     id: "congress-trades-pane",

--- a/src/plugins/builtin/composite-plugins.ts
+++ b/src/plugins/builtin/composite-plugins.ts
@@ -11,6 +11,7 @@ import { cdsModule } from "./cds";
 import { creditConditionsModule } from "./credit-conditions";
 import { economicCalendarModule } from "./econ";
 import { earningsModule } from "./earnings";
+import { earningsCallsModule } from "./earnings-calls";
 import { ipoCalendarModule } from "./ipo-calendar";
 import { fearGreedModule } from "./fear-greed";
 import { futuresModule } from "./futures";
@@ -103,6 +104,7 @@ export const macroPlugin = composeBuiltinPlugin({
     cdsModule,
     treasuryAuctionsModule,
     earningsModule,
+    earningsCallsModule,
     ipoCalendarModule,
     tvModule,
   ],

--- a/src/plugins/builtin/dividend-yield/index.tsx
+++ b/src/plugins/builtin/dividend-yield/index.tsx
@@ -45,6 +45,7 @@ export const dividendYieldModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 90, height: 28 },
+      tableExport: true,
     },
   ],
 

--- a/src/plugins/builtin/earnings-calls/data.ts
+++ b/src/plugins/builtin/earnings-calls/data.ts
@@ -1,0 +1,186 @@
+import {
+  apiClient,
+  type CloudEarningsCallPayload,
+  type CloudEarningsTranscriptPayload,
+} from "../../../api-client";
+import { ApiRequestError } from "../../../api-client/errors";
+import type { PluginPersistence } from "../../../types/plugin";
+
+const LIST_KIND = "calls";
+const TRANSCRIPT_KIND = "transcript";
+const CACHE_SOURCE = "earnings-calls";
+const CACHE_SCHEMA_VERSION = 1;
+
+/** The call list changes as new transcripts publish. */
+const LIST_CACHE_POLICY = {
+  staleMs: 15 * 60 * 1000,
+  expireMs: 7 * 24 * 60 * 60 * 1000,
+} as const;
+
+/**
+ * A published transcript is immutable: the call already happened and the audio
+ * is transcribed once. Keep it for a long time so re-reading is instant.
+ */
+const TRANSCRIPT_CACHE_POLICY = {
+  staleMs: 30 * 24 * 60 * 60 * 1000,
+  expireMs: 365 * 24 * 60 * 60 * 1000,
+} as const;
+
+export interface EarningsCallsResult {
+  calls: CloudEarningsCallPayload[];
+  fetchedAt: number;
+  stale: boolean;
+  refreshError?: string;
+  /** HTTP status when the request failed, used to pick the right gate. */
+  errorStatus?: number;
+}
+
+let persistence: PluginPersistence | null = null;
+const activeListFetches = new Map<string, Promise<EarningsCallsResult>>();
+const activeTranscriptFetches = new Map<string, Promise<CloudEarningsTranscriptPayload>>();
+
+export function attachEarningsCallsPersistence(value: PluginPersistence): void {
+  persistence = value;
+}
+
+export function resetEarningsCallsPersistence(): void {
+  persistence = null;
+  activeListFetches.clear();
+  activeTranscriptFetches.clear();
+}
+
+export function statusOf(error: unknown): number | undefined {
+  return error instanceof ApiRequestError ? error.status : undefined;
+}
+
+function listKey(ticker: string | null): string {
+  return ticker ? ticker.toUpperCase() : "__all__";
+}
+
+export async function loadEarningsCalls(
+  ticker: string | null,
+  options?: { force?: boolean; limit?: number },
+): Promise<EarningsCallsResult> {
+  const key = listKey(ticker);
+  const force = options?.force ?? false;
+
+  const cached = persistence?.getResource<CloudEarningsCallPayload[]>(LIST_KIND, key, {
+    sourceKey: CACHE_SOURCE,
+    schemaVersion: CACHE_SCHEMA_VERSION,
+  });
+  if (!force && cached && !cached.stale) {
+    return { calls: cached.value, fetchedAt: cached.fetchedAt, stale: false };
+  }
+
+  const active = activeListFetches.get(key);
+  if (active && !force) return active;
+
+  const request = apiClient
+    .getCloudEarningsCalls({
+      ticker: ticker ?? undefined,
+      limit: options?.limit ?? 50,
+    })
+    .then((payload) => {
+      const calls = payload.calls ?? [];
+      persistence?.setResource(LIST_KIND, key, calls, {
+        sourceKey: CACHE_SOURCE,
+        schemaVersion: CACHE_SCHEMA_VERSION,
+        cachePolicy: LIST_CACHE_POLICY,
+      });
+      return { calls, fetchedAt: Date.now(), stale: false };
+    })
+    .catch((error: unknown) => {
+      const refreshError = error instanceof Error ? error.message : String(error);
+      const errorStatus = statusOf(error);
+      // An auth failure must surface its gate rather than silently showing
+      // a cached list the user is no longer entitled to refresh.
+      const expired = persistence?.getResource<CloudEarningsCallPayload[]>(LIST_KIND, key, {
+        sourceKey: CACHE_SOURCE,
+        schemaVersion: CACHE_SCHEMA_VERSION,
+        allowExpired: true,
+      });
+      if (expired && errorStatus !== 401 && errorStatus !== 402 && errorStatus !== 403) {
+        return {
+          calls: expired.value,
+          fetchedAt: expired.fetchedAt,
+          stale: true,
+          refreshError,
+          errorStatus,
+        };
+      }
+      throw error;
+    })
+    .finally(() => {
+      if (activeListFetches.get(key) === request) activeListFetches.delete(key);
+    });
+
+  activeListFetches.set(key, request);
+  return request;
+}
+
+/**
+ * The server answers 202 with a pending marker when a call is known but not
+ * transcribed yet, having just queued it. That is not a transcript and must
+ * never be cached.
+ */
+export function isPendingTranscript(
+  value: CloudEarningsTranscriptPayload | { status?: string } | null,
+): boolean {
+  if (!value) return false
+  const record = value as { status?: string; turns?: unknown }
+  return record.status === "pending" || !Array.isArray(record.turns)
+}
+
+export async function loadTranscript(
+  callId: string,
+  options?: { force?: boolean },
+): Promise<CloudEarningsTranscriptPayload> {
+  const force = options?.force ?? false;
+
+  const cached = persistence?.getResource<CloudEarningsTranscriptPayload>(
+    TRANSCRIPT_KIND,
+    callId,
+    { sourceKey: CACHE_SOURCE, schemaVersion: CACHE_SCHEMA_VERSION },
+  );
+  if (!force && cached && !cached.stale) return cached.value;
+
+  const active = activeTranscriptFetches.get(callId);
+  if (active && !force) return active;
+
+  const request = apiClient
+    .getCloudEarningsTranscript(callId)
+    .then((transcript) => {
+      if (isPendingTranscript(transcript)) return transcript;
+      persistence?.setResource(TRANSCRIPT_KIND, callId, transcript, {
+        sourceKey: CACHE_SOURCE,
+        schemaVersion: CACHE_SCHEMA_VERSION,
+        cachePolicy: TRANSCRIPT_CACHE_POLICY,
+      });
+      return transcript;
+    })
+    .catch((error: unknown) => {
+      const status = statusOf(error);
+      const expired = persistence?.getResource<CloudEarningsTranscriptPayload>(
+        TRANSCRIPT_KIND,
+        callId,
+        {
+          sourceKey: CACHE_SOURCE,
+          schemaVersion: CACHE_SCHEMA_VERSION,
+          allowExpired: true,
+        },
+      );
+      // Losing Pro access must re-gate the transcript, not serve it from cache.
+      if (expired && status !== 401 && status !== 402 && status !== 403) {
+        return expired.value;
+      }
+      throw error;
+    })
+    .finally(() => {
+      if (activeTranscriptFetches.get(callId) === request) {
+        activeTranscriptFetches.delete(callId);
+      }
+    });
+
+  activeTranscriptFetches.set(callId, request);
+  return request;
+}

--- a/src/plugins/builtin/earnings-calls/format.ts
+++ b/src/plugins/builtin/earnings-calls/format.ts
@@ -1,0 +1,49 @@
+import type { CloudEarningsCallPayload } from "../../../api-client";
+
+/** "FQ4 26" — fiscal period, compact enough for a table column. */
+export function formatPeriod(
+  fiscalYear: number | null,
+  fiscalQuarter: number | null,
+): string {
+  if (!fiscalQuarter && !fiscalYear) return "—";
+  const quarter = fiscalQuarter ? `FQ${fiscalQuarter}` : "FY";
+  const year = fiscalYear ? ` ${String(fiscalYear).slice(-2)}` : "";
+  return `${quarter}${year}`;
+}
+
+export function formatCallDate(value: string | null): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "2-digit",
+  });
+}
+
+export function formatDuration(seconds: number | null): string {
+  if (!seconds || seconds <= 0) return "—";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.floor(minutes / 60)}h${String(minutes % 60).padStart(2, "0")}`;
+}
+
+export function formatSentiment(sentiment: number | null): string {
+  if (sentiment === null || !Number.isFinite(sentiment)) return "—";
+  const rounded = sentiment.toFixed(2);
+  return sentiment > 0 ? `+${rounded}` : rounded;
+}
+
+export function formatTimestamp(seconds: number): string {
+  const total = Math.max(0, Math.round(seconds));
+  const minutes = Math.floor(total / 60);
+  const remainder = total % 60;
+  return `${minutes}:${String(remainder).padStart(2, "0")}`;
+}
+
+/** Title for the detail stack: names the call so the body need not repeat it. */
+export function callTitle(call: CloudEarningsCallPayload): string {
+  const period = formatPeriod(call.fiscalYear, call.fiscalQuarter);
+  return period === "—" ? call.ticker : `${call.ticker} ${period}`;
+}

--- a/src/plugins/builtin/earnings-calls/index.tsx
+++ b/src/plugins/builtin/earnings-calls/index.tsx
@@ -1,0 +1,69 @@
+import type { PluginModule } from "../plugin-module";
+import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
+import { attachEarningsCallsPersistence, resetEarningsCallsPersistence } from "./data";
+import { EarningsCallsPane, EARNINGS_CALLS_PANE_ID } from "./pane";
+
+const description =
+  "Earnings call transcripts with speaker attribution, analyst Q&A, and extracted guidance.";
+
+export const earningsCallsModule: PluginModule = {
+  setup(ctx) {
+    attachEarningsCallsPersistence(ctx.persistence);
+
+    ctx.registerTickerResearchTab({
+      id: "earnings-calls",
+      name: "Calls",
+      order: 34,
+      component: EarningsCallsPane,
+      isVisible: ({ ticker }) => !!ticker,
+    });
+  },
+
+  dispose() {
+    resetEarningsCallsPersistence();
+  },
+
+  panes: [
+    {
+      id: EARNINGS_CALLS_PANE_ID,
+      name: "Earnings Calls",
+      icon: "C",
+      component: EarningsCallsPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 100, height: 30 },
+      tableExport: true,
+    },
+  ],
+
+  paneTemplates: [
+    // Browse every transcribed call, unbound to a ticker.
+    {
+      id: "earnings-calls-pane",
+      paneId: EARNINGS_CALLS_PANE_ID,
+      label: "Earnings Calls",
+      description,
+      keywords: [
+        "earnings",
+        "call",
+        "calls",
+        "transcript",
+        "transcripts",
+        "conference",
+        "guidance",
+        "qa",
+      ],
+      shortcut: { prefix: "CALLS" },
+      createInstance: () => ({ placement: "floating" }),
+    },
+    createTickerSurfacePaneTemplate({
+      id: "earnings-call-transcripts-pane",
+      paneId: EARNINGS_CALLS_PANE_ID,
+      label: "Earnings Call Transcripts",
+      description,
+      keywords: ["earnings", "call", "transcript", "ect", "qa", "guidance"],
+      shortcut: "ECT",
+      publicShare: false,
+    }),
+  ],
+};

--- a/src/plugins/builtin/earnings-calls/pane.tsx
+++ b/src/plugins/builtin/earnings-calls/pane.tsx
@@ -1,18 +1,23 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Button,
   DataTableStackView,
   EmptyState,
+  InputSearchBar,
   Spinner,
   usePaneFooter,
   type DataTableCell,
+  type DataTableKeyEvent,
+  type DataTableRootKeyContext,
   type PaneFooterSegment,
 } from "../../../components";
 import { CloudAuthNotice } from "../cloud/auth-actions";
 import { useCloudPlanAction, useCloudUpgradeAction } from "../shared/cloud-upgrade";
 import { colors } from "../../../theme/colors";
-import { Box, Text } from "../../../ui";
+import { Box, Text, type InputRenderable } from "../../../ui";
+import { useShortcut } from "../../../react/input";
 import { isPlainKey } from "../../../utils/keyboard";
+import { isPlainArrowUp, stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
 import { useBoundTicker as useSymbolBinding } from "../shared/ticker-request";
 import { usePlanAccess } from "../shared/plan-access";
 import type {
@@ -140,6 +145,28 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
   } | null>(null);
   const [qaOnly, setQaOnly] = useState(false);
   const [sort, setSort] = useState<CallSort>(DEFAULT_SORT);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchFocused, setSearchFocused] = useState(false);
+  const [searchFocusToken, setSearchFocusToken] = useState(0);
+  const searchInputRef = useRef<InputRenderable | null>(null);
+
+  const focusSearch = useCallback(() => {
+    setSearchFocused(true);
+    setSearchFocusToken((current) => current + 1);
+  }, []);
+  const blurSearch = useCallback(() => setSearchFocused(false), []);
+
+  // The search input swallows keys while focused, so Escape has to be caught
+  // ahead of it, otherwise there is no way out of the field.
+  useShortcut(
+    (event) => {
+      if (event.name !== "escape") return;
+      stopSearchFocusNavigation(event);
+      setSearchQuery("");
+      blurSearch();
+    },
+    { allowEditable: true, enabled: focused && searchFocused, phase: "before" },
+  );
 
   const ticker = symbol ? symbol.toUpperCase() : null;
 
@@ -172,7 +199,21 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
   }, [fetchCalls]);
 
   const rows = useMemo(() => {
-    const sorted = [...calls].sort((a, b) => {
+    const query = searchQuery.trim().toLowerCase();
+    const matched = query
+      ? calls.filter((call) =>
+          [
+            call.ticker,
+            call.companyName ?? "",
+            formatPeriod(call.fiscalYear, call.fiscalQuarter),
+            formatCallDate(call.callAt),
+          ]
+            .join(" ")
+            .toLowerCase()
+            .includes(query),
+        )
+      : calls;
+    const sorted = [...matched].sort((a, b) => {
       const left = sortValue(a, sort.columnId);
       const right = sortValue(b, sort.columnId);
       if (left === right) return 0;
@@ -180,7 +221,7 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
       return sort.direction === "asc" ? order : -order;
     });
     return sorted;
-  }, [calls, sort]);
+  }, [calls, sort, searchQuery]);
 
   const selected = useMemo(
     () => calls.find((call) => call.id === selectedId) ?? null,
@@ -228,25 +269,42 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
   const columns = useMemo(() => buildColumns(width, !ticker), [width, ticker]);
 
   const handleRootKey = useCallback(
-    (event: { name?: string; ctrl?: boolean; meta?: boolean; shift?: boolean }) => {
+    (event: DataTableKeyEvent, context: DataTableRootKeyContext) => {
+      if (context.selectedIndex <= 0 && isPlainArrowUp(event)) {
+        stopSearchFocusNavigation(event);
+        focusSearch();
+        return true;
+      }
+      if (isPlainKey(event, "/")) {
+        stopSearchFocusNavigation(event);
+        focusSearch();
+        return true;
+      }
       if (isPlainKey(event, "r")) {
+        stopSearchFocusNavigation(event);
         fetchCalls(true);
         return true;
       }
       return false;
     },
-    [fetchCalls],
+    [fetchCalls, focusSearch],
   );
 
   const handleDetailKey = useCallback(
-    (event: { name?: string; ctrl?: boolean; meta?: boolean; shift?: boolean }) => {
+    (event: DataTableKeyEvent) => {
       if (isPlainKey(event, "q")) {
+        stopSearchFocusNavigation(event);
         setQaOnly((current) => !current);
+        return true;
+      }
+      if (isPlainKey(event, "/")) {
+        stopSearchFocusNavigation(event);
+        focusSearch();
         return true;
       }
       return false;
     },
-    [],
+    [focusSearch],
   );
 
   usePaneFooter(
@@ -271,10 +329,22 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
       if (detailOpen && qaOnly) {
         info.push({ id: "qa", parts: [{ text: "Q&A only", tone: "muted" }] });
       }
+      if (searchQuery.trim()) {
+        info.push({
+          id: "filter",
+          parts: [{ text: `"${searchQuery.trim()}"`, tone: "muted" }],
+        });
+      }
 
       const hints = detailOpen
-        ? [{ id: "qa", key: "q", label: "&A only", onPress: () => setQaOnly((v) => !v) }]
-        : [{ id: "refresh", key: "r", label: "efresh", onPress: () => fetchCalls(true) }];
+        ? [
+            { id: "qa", key: "q", label: "&A only", onPress: () => setQaOnly((v) => !v) },
+            { id: "find", key: "/", label: "find", onPress: focusSearch },
+          ]
+        : [
+            { id: "search", key: "/", label: "search", onPress: focusSearch },
+            { id: "refresh", key: "r", label: "efresh", onPress: () => fetchCalls(true) },
+          ];
 
       return { info, hints };
     },
@@ -287,6 +357,8 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
       transcriptProRequired,
       detailOpen,
       qaOnly,
+      searchQuery,
+      focusSearch,
       fetchCalls,
     ],
   );
@@ -358,25 +430,62 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
       </Text>
     </Box>
   ) : (
-    <TranscriptView
-      transcript={transcript}
-      loading={transcriptLoading}
-      error={transcriptError?.message ?? null}
-      qaOnly={qaOnly}
-      width={width}
-    />
+    // The reader gets its own search bar: a transcript runs to thousands of
+    // words, so finding a topic matters as much as filtering the call list.
+    <Box flexDirection="column" flexGrow={1}>
+      <InputSearchBar
+        value={searchQuery}
+        focused={focused && detailOpen}
+        active={searchFocused}
+        width={width}
+        focusToken={searchFocusToken}
+        inputRef={searchInputRef}
+        placeholder="find in transcript"
+        debounceMs={80}
+        onFocus={focusSearch}
+        onBlur={blurSearch}
+        onNavigateDown={blurSearch}
+        onQueryChange={setSearchQuery}
+      />
+      <TranscriptView
+        transcript={transcript}
+        loading={transcriptLoading}
+        error={transcriptError?.message ?? null}
+        qaOnly={qaOnly}
+        query={searchQuery}
+        width={width}
+      />
+    </Box>
   );
 
   return (
     <DataTableStackView<CloudEarningsCallPayload, CallColumn>
-      focused={focused}
+      focused={focused && !searchFocused}
       detailOpen={detailOpen && !!selected}
       onBack={() => {
         setDetailOpen(false);
         setQaOnly(false);
+        setSearchQuery("");
+        blurSearch();
       }}
       detailContent={detailContent}
       detailTitle={selected ? callTitle(selected) : undefined}
+      rootBefore={
+        <InputSearchBar
+          value={searchQuery}
+          focused={focused && !detailOpen}
+          active={searchFocused}
+          width={width}
+          focusToken={searchFocusToken}
+          inputRef={searchInputRef}
+          placeholder="ticker, company, or period"
+          debounceMs={80}
+          onFocus={focusSearch}
+          onBlur={blurSearch}
+          onNavigateDown={blurSearch}
+          onQueryChange={setSearchQuery}
+        />
+      }
       onRootKeyDown={handleRootKey}
       onDetailKeyDown={handleDetailKey}
       selection={{
@@ -385,7 +494,11 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
         getId: (call) => call.id,
         onChange: setSelectedId,
       }}
-      onActivate={() => setDetailOpen(true)}
+      onActivate={() => {
+        blurSearch();
+        setSearchQuery("");
+        setDetailOpen(true);
+      }}
       rootWidth={width}
       rootHeight={Math.max(1, height - 1)}
       columns={columns}
@@ -401,7 +514,10 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
       }
       getItemKey={(call) => call.id}
       renderCell={renderCell}
-      emptyStateTitle="No transcribed calls yet."
+      emptyStateTitle={
+        searchQuery.trim() ? "No matching calls." : "No transcribed calls yet."
+      }
+      emptyStateHint={searchQuery.trim() ? "Clear the search to see all calls." : undefined}
     />
   );
 }

--- a/src/plugins/builtin/earnings-calls/pane.tsx
+++ b/src/plugins/builtin/earnings-calls/pane.tsx
@@ -1,0 +1,407 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Button,
+  DataTableStackView,
+  EmptyState,
+  Spinner,
+  usePaneFooter,
+  type DataTableCell,
+  type PaneFooterSegment,
+} from "../../../components";
+import { CloudAuthNotice } from "../cloud/auth-actions";
+import { useCloudPlanAction, useCloudUpgradeAction } from "../shared/cloud-upgrade";
+import { colors } from "../../../theme/colors";
+import { Box, Text } from "../../../ui";
+import { isPlainKey } from "../../../utils/keyboard";
+import { useBoundTicker as useSymbolBinding } from "../shared/ticker-request";
+import { usePlanAccess } from "../shared/plan-access";
+import type {
+  CloudEarningsCallPayload,
+  CloudEarningsTranscriptPayload,
+} from "../../../api-client";
+import { isPendingTranscript, loadEarningsCalls, loadTranscript, statusOf } from "./data";
+import { callTitle, formatCallDate, formatDuration, formatPeriod, formatSentiment } from "./format";
+import { TranscriptView } from "./transcript-view";
+
+export const EARNINGS_CALLS_PANE_ID = "earnings-calls";
+
+interface CallColumn {
+  id: string;
+  label: string;
+  width: number;
+  align: "left" | "right";
+}
+
+function buildColumns(width: number, showTicker: boolean): CallColumn[] {
+  const tickerWidth = showTicker ? 8 : 0;
+  const dateWidth = 10;
+  const periodWidth = 8;
+  const lengthWidth = 7;
+  const sentimentWidth = 6;
+  const companyWidth = Math.max(
+    10,
+    width - tickerWidth - dateWidth - periodWidth - lengthWidth - sentimentWidth - 8,
+  );
+
+  const columns: CallColumn[] = [];
+  if (showTicker) columns.push({ id: "ticker", label: "TICKER", width: tickerWidth, align: "left" });
+  columns.push(
+    { id: "company", label: "COMPANY", width: companyWidth, align: "left" },
+    { id: "date", label: "DATE", width: dateWidth, align: "left" },
+    { id: "period", label: "PERIOD", width: periodWidth, align: "left" },
+    { id: "length", label: "LENGTH", width: lengthWidth, align: "right" },
+    { id: "sentiment", label: "TONE", width: sentimentWidth, align: "right" },
+  );
+  return columns;
+}
+
+function renderCell(call: CloudEarningsCallPayload, column: CallColumn): DataTableCell {
+  switch (column.id) {
+    case "ticker":
+      return { text: call.ticker };
+    case "company":
+      return { text: call.companyName ?? call.ticker, color: colors.textDim };
+    case "date":
+      return { text: formatCallDate(call.callAt), color: colors.textDim };
+    case "period":
+      return { text: formatPeriod(call.fiscalYear, call.fiscalQuarter) };
+    case "length":
+      return { text: formatDuration(call.durationSeconds), color: colors.textDim };
+    case "sentiment": {
+      const tone =
+        call.sentiment === null
+          ? colors.textDim
+          : call.sentiment > 0.15
+            ? colors.positive
+            : call.sentiment < -0.15
+              ? colors.negative
+              : colors.textDim;
+      return { text: formatSentiment(call.sentiment), color: tone };
+    }
+    default:
+      return { text: "" };
+  }
+}
+
+type SortDirection = "asc" | "desc";
+
+interface CallSort {
+  columnId: string;
+  direction: SortDirection;
+}
+
+const DEFAULT_SORT: CallSort = { columnId: "date", direction: "desc" };
+
+function sortValue(call: CloudEarningsCallPayload, columnId: string): string | number {
+  switch (columnId) {
+    case "ticker":
+      return call.ticker;
+    case "company":
+      return (call.companyName ?? call.ticker).toLowerCase();
+    case "period":
+      return (call.fiscalYear ?? 0) * 10 + (call.fiscalQuarter ?? 0);
+    case "length":
+      return call.durationSeconds ?? 0;
+    case "sentiment":
+      return call.sentiment ?? Number.NEGATIVE_INFINITY;
+    default:
+      return call.callAt ? Date.parse(call.callAt) : 0;
+  }
+}
+
+/**
+ * Props are the intersection of a pane and a ticker research tab so the same
+ * component can serve both surfaces.
+ */
+interface EarningsCallsViewProps {
+  focused: boolean;
+  width: number;
+  height: number;
+}
+
+export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewProps) {
+  const { symbol } = useSymbolBinding();
+  const access = usePlanAccess();
+  const openUpgrade = useCloudUpgradeAction();
+  const openPlan = useCloudPlanAction();
+
+  const [calls, setCalls] = useState<CloudEarningsCallPayload[]>([]);
+  const [listStatus, setListStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
+  const [listError, setListError] = useState<{ message: string; status?: number } | null>(null);
+  const [stale, setStale] = useState(false);
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [transcript, setTranscript] = useState<CloudEarningsTranscriptPayload | null>(null);
+  const [transcriptLoading, setTranscriptLoading] = useState(false);
+  const [transcriptError, setTranscriptError] = useState<{
+    message: string;
+    status?: number;
+  } | null>(null);
+  const [qaOnly, setQaOnly] = useState(false);
+  const [sort, setSort] = useState<CallSort>(DEFAULT_SORT);
+
+  const ticker = symbol ? symbol.toUpperCase() : null;
+
+  const fetchCalls = useCallback(
+    (force: boolean) => {
+      if (!access.emailVerified || !access.hasProAccess) return;
+      setListStatus((current) => (current === "loaded" ? current : "loading"));
+      loadEarningsCalls(ticker, { force })
+        .then((result) => {
+          setCalls(result.calls);
+          setStale(result.stale);
+          setListError(
+            result.refreshError ? { message: result.refreshError, status: result.errorStatus } : null,
+          );
+          setListStatus("loaded");
+        })
+        .catch((error: unknown) => {
+          setListError({
+            message: error instanceof Error ? error.message : String(error),
+            status: statusOf(error),
+          });
+          setListStatus("error");
+        });
+    },
+    [ticker, access.emailVerified, access.hasProAccess],
+  );
+
+  useEffect(() => {
+    fetchCalls(false);
+  }, [fetchCalls]);
+
+  const rows = useMemo(() => {
+    const sorted = [...calls].sort((a, b) => {
+      const left = sortValue(a, sort.columnId);
+      const right = sortValue(b, sort.columnId);
+      if (left === right) return 0;
+      const order = left < right ? -1 : 1;
+      return sort.direction === "asc" ? order : -order;
+    });
+    return sorted;
+  }, [calls, sort]);
+
+  const selected = useMemo(
+    () => calls.find((call) => call.id === selectedId) ?? null,
+    [calls, selectedId],
+  );
+
+  // Transcripts are immutable, so this only runs once per call per device.
+  useEffect(() => {
+    if (!detailOpen || !selected?.hasTranscript) return;
+    let cancelled = false;
+    setTranscriptLoading(true);
+    setTranscriptError(null);
+    loadTranscript(selected.id)
+      .then((result) => {
+        if (cancelled) return;
+        // A queued-on-demand call comes back as a pending marker, not content.
+        setTranscript(isPendingTranscript(result) ? null : result);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setTranscript(null);
+        setTranscriptError({
+          message: error instanceof Error ? error.message : String(error),
+          status: statusOf(error),
+        });
+      })
+      .finally(() => {
+        if (!cancelled) setTranscriptLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [detailOpen, selected]);
+
+  const signInRequired = !access.signedIn || listError?.status === 401;
+  const verificationRequired =
+    !signInRequired && (!access.emailVerified || listError?.status === 403);
+  // The whole feature is a Pro entitlement, so the list itself can be refused.
+  const proRequired =
+    !signInRequired &&
+    !verificationRequired &&
+    (!access.hasProAccess || listError?.status === 402);
+  const transcriptProRequired = transcriptError?.status === 402;
+
+  const columns = useMemo(() => buildColumns(width, !ticker), [width, ticker]);
+
+  const handleRootKey = useCallback(
+    (event: { name?: string; ctrl?: boolean; meta?: boolean; shift?: boolean }) => {
+      if (isPlainKey(event, "r")) {
+        fetchCalls(true);
+        return true;
+      }
+      return false;
+    },
+    [fetchCalls],
+  );
+
+  const handleDetailKey = useCallback(
+    (event: { name?: string; ctrl?: boolean; meta?: boolean; shift?: boolean }) => {
+      if (isPlainKey(event, "q")) {
+        setQaOnly((current) => !current);
+        return true;
+      }
+      return false;
+    },
+    [],
+  );
+
+  usePaneFooter(
+    EARNINGS_CALLS_PANE_ID,
+    () => {
+      const info: PaneFooterSegment[] = [];
+      if (listStatus === "loading") {
+        info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
+      }
+      if (transcriptLoading) {
+        info.push({ id: "transcribing", parts: [{ text: "loading transcript", tone: "muted" }] });
+      }
+      if (stale) {
+        info.push({ id: "stale", parts: [{ text: "stale cache", tone: "warning" }] });
+      }
+      if (listError && listStatus === "error") {
+        info.push({ id: "error", parts: [{ text: "error", tone: "warning" }] });
+      }
+      if (proRequired || transcriptProRequired) {
+        info.push({ id: "pro", parts: [{ text: "pro required", tone: "warning" }] });
+      }
+      if (detailOpen && qaOnly) {
+        info.push({ id: "qa", parts: [{ text: "Q&A only", tone: "muted" }] });
+      }
+
+      const hints = detailOpen
+        ? [{ id: "qa", key: "q", label: "&A only", onPress: () => setQaOnly((v) => !v) }]
+        : [{ id: "refresh", key: "r", label: "efresh", onPress: () => fetchCalls(true) }];
+
+      return { info, hints };
+    },
+    [
+      listStatus,
+      transcriptLoading,
+      stale,
+      listError,
+      proRequired,
+      transcriptProRequired,
+      detailOpen,
+      qaOnly,
+      fetchCalls,
+    ],
+  );
+
+  if (signInRequired) {
+    return <CloudAuthNotice message="Sign in to browse earnings call transcripts." />;
+  }
+  if (verificationRequired) {
+    return (
+      <CloudAuthNotice
+        needsVerification
+        message="Verify your email to browse earnings call transcripts."
+      />
+    );
+  }
+
+  if (proRequired) {
+    return (
+      <Box flexDirection="column" paddingX={1}>
+        <EmptyState
+          title="Earnings call transcripts are part of Gloom Cloud Pro."
+          message="Gloomberb transcribes the calls itself: full transcripts with speaker attribution, analyst Q&A, and extracted guidance, risks and tone."
+        />
+        <Box flexDirection="row" marginTop={1} gap={1}>
+          <Button label="Upgrade to Pro" onPress={openUpgrade} />
+          <Button label="Manage account" variant="secondary" onPress={openPlan} />
+        </Box>
+      </Box>
+    );
+  }
+
+  if (listStatus === "loading" && calls.length === 0) {
+    return (
+      <Box flexGrow={1} alignItems="center" justifyContent="center">
+        <Spinner label="Loading calls..." />
+      </Box>
+    );
+  }
+
+  if (listStatus === "error" && calls.length === 0) {
+    return <EmptyState title="Could not load earnings calls." message={listError?.message ?? ""} />;
+  }
+
+  if (calls.length === 0) {
+    return (
+      <EmptyState
+        title={ticker ? `No transcribed calls for ${ticker} yet.` : "No transcribed calls yet."}
+        message="Transcripts are published a few hours after each call."
+      />
+    );
+  }
+
+  const detailContent = transcriptProRequired ? (
+    <Box flexDirection="column" paddingX={1}>
+      <EmptyState
+        title="Earnings call transcripts are part of Gloom Cloud Pro."
+        message="Full transcripts with speaker attribution, analyst Q&A, guidance and risk extraction, transcribed from the call itself."
+      />
+      <Box flexDirection="row" marginTop={1} gap={1}>
+        <Button label="Upgrade to Pro" onPress={openUpgrade} />
+        <Button label="Manage account" variant="secondary" onPress={openPlan} />
+      </Box>
+    </Box>
+  ) : selected && !selected.hasTranscript ? (
+    <Box flexGrow={1} paddingX={1}>
+      <Text fg={colors.textDim}>
+        Queued for transcription. This call is being captured now; it usually
+        takes a couple of minutes.
+      </Text>
+    </Box>
+  ) : (
+    <TranscriptView
+      transcript={transcript}
+      loading={transcriptLoading}
+      error={transcriptError?.message ?? null}
+      qaOnly={qaOnly}
+      width={width}
+    />
+  );
+
+  return (
+    <DataTableStackView<CloudEarningsCallPayload, CallColumn>
+      focused={focused}
+      detailOpen={detailOpen && !!selected}
+      onBack={() => {
+        setDetailOpen(false);
+        setQaOnly(false);
+      }}
+      detailContent={detailContent}
+      detailTitle={selected ? callTitle(selected) : undefined}
+      onRootKeyDown={handleRootKey}
+      onDetailKeyDown={handleDetailKey}
+      selection={{
+        kind: "id",
+        selectedId,
+        getId: (call) => call.id,
+        onChange: setSelectedId,
+      }}
+      onActivate={() => setDetailOpen(true)}
+      rootWidth={width}
+      rootHeight={Math.max(1, height - 1)}
+      columns={columns}
+      items={rows}
+      sortColumnId={sort.columnId}
+      sortDirection={sort.direction}
+      onHeaderClick={(columnId) =>
+        setSort((current) =>
+          current.columnId === columnId
+            ? { columnId, direction: current.direction === "asc" ? "desc" : "asc" }
+            : { columnId, direction: "desc" },
+        )
+      }
+      getItemKey={(call) => call.id}
+      renderCell={renderCell}
+      emptyStateTitle="No transcribed calls yet."
+    />
+  );
+}

--- a/src/plugins/builtin/earnings-calls/pane.tsx
+++ b/src/plugins/builtin/earnings-calls/pane.tsx
@@ -15,7 +15,6 @@ import { CloudAuthNotice } from "../cloud/auth-actions";
 import { useCloudPlanAction, useCloudUpgradeAction } from "../shared/cloud-upgrade";
 import { colors } from "../../../theme/colors";
 import { Box, Text, type InputRenderable } from "../../../ui";
-import { useShortcut } from "../../../react/input";
 import { isPlainKey } from "../../../utils/keyboard";
 import { isPlainArrowUp, stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
 import { useBoundTicker as useSymbolBinding } from "../shared/ticker-request";
@@ -155,18 +154,6 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
     setSearchFocusToken((current) => current + 1);
   }, []);
   const blurSearch = useCallback(() => setSearchFocused(false), []);
-
-  // The search input swallows keys while focused, so Escape has to be caught
-  // ahead of it, otherwise there is no way out of the field.
-  useShortcut(
-    (event) => {
-      if (event.name !== "escape") return;
-      stopSearchFocusNavigation(event);
-      setSearchQuery("");
-      blurSearch();
-    },
-    { allowEditable: true, enabled: focused && searchFocused, phase: "before" },
-  );
 
   const ticker = symbol ? symbol.toUpperCase() : null;
 
@@ -341,10 +328,7 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
             { id: "qa", key: "q", label: "&A only", onPress: () => setQaOnly((v) => !v) },
             { id: "find", key: "/", label: "find", onPress: focusSearch },
           ]
-        : [
-            { id: "search", key: "/", label: "search", onPress: focusSearch },
-            { id: "refresh", key: "r", label: "efresh", onPress: () => fetchCalls(true) },
-          ];
+        : [{ id: "search", key: "/", label: "search", onPress: focusSearch }];
 
       return { info, hints };
     },

--- a/src/plugins/builtin/earnings-calls/transcript-view.tsx
+++ b/src/plugins/builtin/earnings-calls/transcript-view.tsx
@@ -1,0 +1,130 @@
+import { useMemo } from "react";
+import { Spinner } from "../../../components";
+import { colors } from "../../../theme/colors";
+import { Box, ScrollBox, Text, TextAttributes } from "../../../ui";
+import type {
+  CloudEarningsTranscriptPayload,
+  CloudTranscriptTurnPayload,
+} from "../../../api-client";
+import { formatCallDate, formatDuration, formatSentiment, formatTimestamp } from "./format";
+
+function speakerColor(turn: CloudTranscriptTurnPayload): string {
+  if (turn.speaker === "Operator") return colors.textDim;
+  if (turn.role === "Analyst") return colors.warning;
+  return colors.textBright;
+}
+
+function Section({ title, body }: { title: string; body: string }) {
+  if (!body.trim()) return null;
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
+        {title}
+      </Text>
+      <Text fg={colors.text}>{body}</Text>
+    </Box>
+  );
+}
+
+export function TranscriptView({
+  transcript,
+  loading,
+  error,
+  qaOnly,
+  width,
+}: {
+  transcript: CloudEarningsTranscriptPayload | null;
+  loading: boolean;
+  error: string | null;
+  qaOnly: boolean;
+  width: number;
+}) {
+  const turns = useMemo(() => {
+    const all = transcript?.turns ?? [];
+    return qaOnly ? all.filter((turn) => turn.isQa) : all;
+  }, [transcript, qaOnly]);
+
+  if (loading && !transcript) {
+    return (
+      <Box flexGrow={1} alignItems="center" justifyContent="center">
+        <Spinner label="Loading transcript..." />
+      </Box>
+    );
+  }
+
+  if (error && !transcript) {
+    return (
+      <Box flexGrow={1} paddingX={1}>
+        <Text fg={colors.negative}>{error}</Text>
+      </Box>
+    );
+  }
+
+  if (!transcript) return null;
+
+  // The stack title already names ticker and period, so lead with metadata.
+  const meta = [
+    formatCallDate(transcript.callAt),
+    formatDuration(transcript.durationSeconds),
+    transcript.participants.length > 0 ? `${transcript.participants.length} speakers` : null,
+    transcript.sentiment !== null ? `sentiment ${formatSentiment(transcript.sentiment)}` : null,
+  ]
+    .filter(Boolean)
+    .join("  ·  ");
+
+  const bodyWidth = Math.max(20, width - 2);
+
+  return (
+    <ScrollBox scrollY flexGrow={1} paddingX={1}>
+      <Box flexDirection="column" width={bodyWidth}>
+        <Text fg={colors.textDim}>{meta}</Text>
+
+        <Section title="SUMMARY" body={transcript.summary ?? ""} />
+        <Section title="GUIDANCE" body={transcript.guidance ?? ""} />
+        <Section title="RISKS" body={transcript.riskFactors ?? ""} />
+
+        {transcript.participants.length > 0 && (
+          <Box flexDirection="column" marginTop={1}>
+            <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
+              PARTICIPANTS
+            </Text>
+            {transcript.participants.map((participant) => (
+              <Text key={participant.name} fg={colors.text}>
+                {[participant.name, participant.role, participant.company]
+                  .filter(Boolean)
+                  .join("  ·  ")}
+              </Text>
+            ))}
+          </Box>
+        )}
+
+        <Box flexDirection="column" marginTop={1}>
+          <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
+            {qaOnly ? "QUESTION AND ANSWER" : "TRANSCRIPT"}
+          </Text>
+        </Box>
+
+        {turns.map((turn, index) => (
+          <Box key={`${turn.startSeconds}-${index}`} flexDirection="column" marginTop={1}>
+            <Box flexDirection="row" gap={1}>
+              <Text fg={colors.textDim}>{formatTimestamp(turn.startSeconds)}</Text>
+              <Text fg={speakerColor(turn)} attributes={TextAttributes.BOLD}>
+                {turn.speaker}
+              </Text>
+              {(turn.role || turn.company) && (
+                <Text fg={colors.textDim}>
+                  {[turn.role, turn.company].filter(Boolean).join(", ")}
+                </Text>
+              )}
+            </Box>
+            <Text fg={colors.text}>{turn.text}</Text>
+          </Box>
+        ))}
+
+        {turns.length === 0 && (
+          <Text fg={colors.textDim}>No question and answer section in this call.</Text>
+        )}
+      </Box>
+    </ScrollBox>
+  );
+}

--- a/src/plugins/builtin/earnings-calls/transcript-view.tsx
+++ b/src/plugins/builtin/earnings-calls/transcript-view.tsx
@@ -31,18 +31,26 @@ export function TranscriptView({
   loading,
   error,
   qaOnly,
+  query,
   width,
 }: {
   transcript: CloudEarningsTranscriptPayload | null;
   loading: boolean;
   error: string | null;
   qaOnly: boolean;
+  /** Free-text filter applied to the turns, for finding a topic in a long call. */
+  query?: string;
   width: number;
 }) {
   const turns = useMemo(() => {
     const all = transcript?.turns ?? [];
-    return qaOnly ? all.filter((turn) => turn.isQa) : all;
-  }, [transcript, qaOnly]);
+    const scoped = qaOnly ? all.filter((turn) => turn.isQa) : all;
+    const needle = (query ?? "").trim().toLowerCase();
+    if (!needle) return scoped;
+    return scoped.filter((turn) =>
+      `${turn.speaker} ${turn.company ?? ""} ${turn.text}`.toLowerCase().includes(needle),
+    );
+  }, [transcript, qaOnly, query]);
 
   if (loading && !transcript) {
     return (
@@ -124,7 +132,11 @@ export function TranscriptView({
         ))}
 
         {turns.length === 0 && (
-          <Text fg={colors.textDim}>No question and answer section in this call.</Text>
+          <Text fg={colors.textDim}>
+            {query?.trim()
+              ? `Nothing matching "${query.trim()}" in this call.`
+              : "No question and answer section in this call."}
+          </Text>
         )}
       </Box>
     </ScrollBox>

--- a/src/plugins/builtin/earnings-calls/transcript-view.tsx
+++ b/src/plugins/builtin/earnings-calls/transcript-view.tsx
@@ -80,6 +80,8 @@ export function TranscriptView({
         <Text fg={colors.textDim}>{meta}</Text>
 
         <Section title="SUMMARY" body={transcript.summary ?? ""} />
+        <Section title="WHAT STOOD OUT" body={transcript.notable ?? ""} />
+        <Section title="ANALYSTS PRESSED ON" body={transcript.analystFocus ?? ""} />
         <Section title="GUIDANCE" body={transcript.guidance ?? ""} />
         <Section title="RISKS" body={transcript.riskFactors ?? ""} />
 

--- a/src/plugins/builtin/help/index.tsx
+++ b/src/plugins/builtin/help/index.tsx
@@ -240,6 +240,10 @@ function HelpPane({ focused, width, height }: PaneProps) {
                 />
               )}
               <ShortcutRow
+                badges={[platformShortcut(["Shift", "E"])]}
+                description="Export the focused pane's table as CSV."
+              />
+              <ShortcutRow
                 badges={[platformShortcut(["Shift", "L"])]}
                 description="Open layout actions."
               />

--- a/src/plugins/builtin/holders/index.tsx
+++ b/src/plugins/builtin/holders/index.tsx
@@ -22,6 +22,7 @@ export const holdersModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 105, height: 34 },
+      tableExport: true,
     },
   ],
 

--- a/src/plugins/builtin/insider/index.tsx
+++ b/src/plugins/builtin/insider/index.tsx
@@ -266,6 +266,7 @@ export const insiderModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 100, height: 30 },
+      tableExport: true,
     },
   ],
 

--- a/src/plugins/builtin/options/index.tsx
+++ b/src/plugins/builtin/options/index.tsx
@@ -54,6 +54,7 @@ export const optionsModule: PluginModule = {
       defaultFloatingSize: { width: 112, height: 28 },
       quickSettings: [LIVE_STREAMING_QUICK_SETTING],
       settings: (context) => withLiveStreamingSetting(optionsSettings(context.settings), context.settings),
+      tableExport: true,
     },
   ],
 

--- a/src/plugins/builtin/options/view.test.tsx
+++ b/src/plugins/builtin/options/view.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, expect, test } from "bun:test";
 import { act, useState } from "react";
 import type { ScrollBoxRenderable } from "@opentui/core";
-import { testRender } from "../../../renderers/opentui/test-utils";
+import { takeSavedTextFile, testRender } from "../../../renderers/opentui/test-utils";
+import { exportPaneTable, hasPaneTableExporter } from "../../../state/pane-table-export-registry";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../../market-data/coordinator";
 import { AppContext, PaneInstanceProvider, createInitialState } from "../../../state/app/context";
 import { createTestDataProvider } from "../../../test-support/data-provider";
@@ -150,6 +151,33 @@ afterEach(async () => {
   }
   setOptionsQuotePrice = null;
   setSharedMarketDataCoordinator(null);
+});
+
+test("exposes exactly one exportable table so CSV export stays wired up", async () => {
+  const provider = createTestDataProvider({
+    getOptionsChain: async () => makeChain([100, 101], 101),
+  });
+  setSharedMarketDataCoordinator(new MarketDataCoordinator(provider));
+
+  await act(async () => {
+    testSetup = await testRender(
+      <OptionsHarness ticker={makeTicker("AAPL")} quotePrice={101} />,
+      { width: 124, height: 12 },
+    );
+  });
+  await renderSettled();
+
+  // `tableExport: true` on the options pane only works when the pane mounts a single
+  // DataTable; a second concurrent table would silently disable the export action.
+  expect(hasPaneTableExporter(TEST_PANE_ID)).toBe(true);
+
+  const location = await exportPaneTable(TEST_PANE_ID, "options.csv");
+  expect(location).toBe("~/Downloads/options.csv");
+
+  const saved = takeSavedTextFile();
+  expect(saved?.name).toBe("options.csv");
+  expect(saved?.text.split("\n")[0]).toContain("STRIKE");
+  expect(saved?.text).toContain("101");
 });
 
 test("defaults the table around the nearest strike to the current quote", async () => {

--- a/src/plugins/builtin/research/index.tsx
+++ b/src/plugins/builtin/research/index.tsx
@@ -50,6 +50,7 @@ export const researchModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 90, height: 28 },
+      tableExport: true,
     },
     {
       id: "equity-diagnostic",
@@ -68,6 +69,7 @@ export const researchModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 104, height: 24 },
+      tableExport: true,
     },
     {
       id: "relative-valuation",
@@ -77,6 +79,7 @@ export const researchModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 104, height: 24 },
+      tableExport: true,
     },
     {
       id: "earnings-estimates",
@@ -86,6 +89,7 @@ export const researchModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 104, height: 22 },
+      tableExport: true,
     },
   ],
 

--- a/src/plugins/builtin/sec/index.tsx
+++ b/src/plugins/builtin/sec/index.tsx
@@ -355,6 +355,7 @@ export const secModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 100, height: 32 },
+      tableExport: true,
     },
   ],
 

--- a/src/plugins/builtin/short-interest/index.tsx
+++ b/src/plugins/builtin/short-interest/index.tsx
@@ -45,6 +45,7 @@ export const shortInterestModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 90, height: 25 },
+      tableExport: true,
     },
   ],
 

--- a/src/plugins/builtin/thirteenf/index.tsx
+++ b/src/plugins/builtin/thirteenf/index.tsx
@@ -38,6 +38,7 @@ export const thirteenFModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 112, height: 36 },
+      tableExport: true,
     },
   ],
 

--- a/src/plugins/ownership.ts
+++ b/src/plugins/ownership.ts
@@ -7,6 +7,7 @@ const BUILTIN_PLUGIN_OWNER_ALIASES: Record<string, string> = {
   "comparison-chart": "ticker-research",
   correlation: "market-overview",
   "earnings-calendar": "macro",
+  "earnings-calls": "macro",
   "ipo-calendar": "macro",
   "fear-greed": "market-overview",
   "fx-matrix": "market-overview",

--- a/src/plugins/prediction-markets/index.tsx
+++ b/src/plugins/prediction-markets/index.tsx
@@ -43,6 +43,7 @@ export const predictionMarketsPlugin: GloomPlugin = {
       defaultPosition: "left",
       defaultMode: "floating",
       defaultFloatingSize: { width: 132, height: 36 },
+      tableExport: true,
       settings: (context) =>
         buildPredictionMarketsPaneSettingsDef(
           context.config,

--- a/src/plugins/registry/pane-settings.ts
+++ b/src/plugins/registry/pane-settings.ts
@@ -13,10 +13,9 @@ import type {
   PaneSettingsDef,
 } from "../../types/plugin";
 import {
-  exportPaneTable,
+  exportPaneTableCsv,
   hasPaneTableExporter,
 } from "../../state/pane-table-export-registry";
-import { createCsvExportFilename } from "../../utils/csv";
 
 export interface ResolvedRegistryPaneSettings {
   paneId: string;
@@ -121,17 +120,11 @@ export function resolveRegistryPaneSettings({
           actionId: "table.export-csv",
           actionLabel: "Export",
           disabled: !hasPaneTableExporter(targetPaneId),
-          action: async (actionContext) => {
-            try {
-              const location = await exportPaneTable(
-                targetPaneId,
-                createCsvExportFilename(pane.title ?? paneDef.name),
-              );
-              actionContext.notify({ body: `Exported to ${location}`, type: "success" });
-            } catch {
-              actionContext.notify({ body: "Failed to export CSV", type: "error" });
-            }
-          },
+          action: (actionContext) => exportPaneTableCsv(
+            targetPaneId,
+            pane.title ?? paneDef.name,
+            actionContext.notify,
+          ),
         },
       ],
     }

--- a/src/renderers/opentui/test-utils.tsx
+++ b/src/renderers/opentui/test-utils.tsx
@@ -9,6 +9,15 @@ import { openTuiUiHost } from "./ui-host";
 import { OpenTuiDialogHostProvider } from "./dialog-host";
 import { openTuiToastHost } from "./toast-host";
 
+let lastSavedTextFile: { name: string; text: string } | null = null;
+
+/** Returns the most recent file written through the test renderer's `saveTextFile`. */
+export function takeSavedTextFile(): { name: string; text: string } | null {
+  const saved = lastSavedTextFile;
+  lastSavedTextFile = null;
+  return saved;
+}
+
 export function TestDialogProvider({ children }: { children: ReactNode }) {
   return (
     <OpenTuiDialogHostProvider
@@ -46,6 +55,10 @@ function OpenTuiTestProviders({ children }: { children: ReactNode }) {
     copyText: async () => {},
     readText: async () => "",
     notify: () => {},
+    saveTextFile: async ({ name, text }) => {
+      lastSavedTextFile = { name, text };
+      return `~/Downloads/${name}`;
+    },
   }), [renderer]);
   const nativeRenderer = useMemo(() => createTestNativeRendererHost(renderer), [renderer]);
 

--- a/src/state/pane-table-export-registry.ts
+++ b/src/state/pane-table-export-registry.ts
@@ -1,3 +1,5 @@
+import { createCsvExportFilename } from "../utils/csv";
+
 export type PaneTableExporter = (filename: string) => Promise<string>;
 
 const exporters = new Map<string, Map<symbol, PaneTableExporter>>();
@@ -28,4 +30,21 @@ export async function exportPaneTable(paneId: string, filename: string): Promise
     throw new Error("This pane does not have one active exportable table.");
   }
   return [...paneExporters.values()][0]!(filename);
+}
+
+/**
+ * Shared entry point for the pane menu, the keyboard shortcut, and pane settings so
+ * every surface produces the same filename and the same success/failure notification.
+ */
+export async function exportPaneTableCsv(
+  paneId: string,
+  title: string,
+  notify: (notification: { body: string; type: "success" | "error" }) => void,
+): Promise<void> {
+  try {
+    const location = await exportPaneTable(paneId, createCsvExportFilename(title));
+    notify({ body: `Exported to ${location}`, type: "success" });
+  } catch {
+    notify({ body: "Failed to export CSV", type: "error" });
+  }
 }


### PR DESCRIPTION
Surfaces the earnings call transcripts Gloomberb now produces itself, served from Gloom Cloud.

## Panes

- `CALLS` — every transcribed call across covered companies
- `ECT <ticker>` — transcripts for one company
- A **Calls** tab in ticker research, bound to the active symbol

The reader shows the call's speaker-attributed turns alongside the server's extracted summary, guidance, risks and tone, ordered so the parts unavailable from the earnings release come first. `q` narrows to the analyst Q&A.

## Search

Both surfaces are searchable, because they answer different questions: the list filters on ticker, company and period, while the reader filters turns, which is how you find what was said about a topic without reading a nine thousand word call.

Escape handling moved into `InputSearchBar` rather than living in this pane. A focused search field consumes every key, so Escape never reached the pane and there was no way back out of it — that affected every pane using the shared component, not just this one.

## Access

Transcripts are a Pro entitlement, so an unentitled account gets the upgrade prompt rather than an error. Published transcripts never change and are cached accordingly, though an auth failure re-gates them instead of serving the cached copy.