### PR TITLE
Publish a versioned plugin API so plugins can live outside this repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,19 @@
   "description": "Market research and portfolio tracker for the terminal",
   "module": "src/index.tsx",
   "type": "module",
+  "exports": {
+    ".": "./src/index.tsx",
+    "./types/plugin": "./src/types/plugin.ts",
+    "./types/persistence": "./src/types/persistence.ts",
+    "./ui": "./src/ui/index.tsx",
+    "./components": "./src/components/index.ts",
+    "./theme": "./src/theme/colors.ts",
+    "./capabilities": "./src/capabilities/index.ts",
+    "./utils": "./src/public/utils.ts",
+    "./react": "./src/public/react.ts",
+    "./test-support": "./src/public/test-support.ts",
+    "./package.json": "./package.json"
+  },
   "bin": {
     "gloomberb": "bin/gloomberb"
   },

--- a/src/cli/commands/plugins.ts
+++ b/src/cli/commands/plugins.ts
@@ -2,6 +2,7 @@ import { join } from "path";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from "fs";
 import { execFileSync } from "child_process";
 import { getPluginsDir } from "../../plugins/loader";
+import { linkHostPackages } from "../../plugins/host-link";
 import {
   cliStyles,
   renderSection,
@@ -79,6 +80,13 @@ export async function installPlugin(ref: string) {
     }
   }
 
+  // After `bun install`, which prunes links it does not know about.
+  const link = linkHostPackages(targetDir);
+  if (link.error) {
+    console.error(cliStyles.warning(`Warning: could not link the Gloomberb runtime (${link.error}).`));
+    console.error(cliStyles.muted("The plugin's \"gloomberb/*\" imports will not resolve."));
+  }
+
   try {
     let entryFile: string | null = null;
     if (existsSync(pkgPath)) {
@@ -143,6 +151,7 @@ export async function updatePlugins(name?: string) {
       if (existsSync(pkgPath)) {
         execFileSync("bun", ["install"], { cwd: targetDir, stdio: "inherit" });
       }
+      linkHostPackages(targetDir);
     } catch {
       console.error(cliStyles.danger(`Failed to update ${dir}.`));
     }

--- a/src/cli/commands/plugins.ts
+++ b/src/cli/commands/plugins.ts
@@ -74,7 +74,11 @@ export async function installPlugin(ref: string) {
   if (existsSync(pkgPath)) {
     console.log(cliStyles.muted("Installing plugin dependencies..."));
     try {
-      execFileSync("bun", ["install"], { cwd: targetDir, stdio: "inherit" });
+      // --production: plugin repos depend on `gloomberb` as a devDependency so
+      // their own CI can typecheck against the real API. At runtime the host is
+      // symlinked in instead, and pulling a second full copy here would both
+      // waste a lot of disk and risk a duplicate React.
+      execFileSync("bun", ["install", "--production"], { cwd: targetDir, stdio: "inherit" });
     } catch {
       console.error(cliStyles.warning("Warning: failed to install plugin dependencies."));
     }
@@ -149,7 +153,7 @@ export async function updatePlugins(name?: string) {
       execFileSync("git", ["pull", "--ff-only"], { cwd: targetDir, stdio: "inherit" });
       const pkgPath = join(targetDir, "package.json");
       if (existsSync(pkgPath)) {
-        execFileSync("bun", ["install"], { cwd: targetDir, stdio: "inherit" });
+        execFileSync("bun", ["install", "--production"], { cwd: targetDir, stdio: "inherit" });
       }
       linkHostPackages(targetDir);
     } catch {

--- a/src/plugins/builtin/plugin-module.ts
+++ b/src/plugins/builtin/plugin-module.ts
@@ -4,7 +4,15 @@ import type {
   GloomPluginContext,
 } from "../../types/plugin";
 
-type PluginMetadataKey = "id" | "name" | "version" | "description" | "toggleable" | "order";
+type PluginMetadataKey =
+  | "id"
+  | "name"
+  | "version"
+  | "description"
+  | "toggleable"
+  | "order"
+  | "targets"
+  | "homepage";
 type PluginMetadata = Pick<GloomPlugin, PluginMetadataKey>;
 
 export type PluginModule = Omit<GloomPlugin, PluginMetadataKey>;

--- a/src/plugins/catalog.ts
+++ b/src/plugins/catalog.ts
@@ -1,4 +1,4 @@
-import type { GloomPlugin } from "../types/plugin";
+import type { GloomPlugin, PluginTarget } from "../types/plugin";
 import type { LoadedExternalPlugin } from "./loader";
 import { debugPlugin } from "./builtin/debug";
 import { yahooPlugin } from "./builtin/yahoo";
@@ -9,6 +9,12 @@ export interface PluginCatalogEntry {
   source: "builtin" | "external";
   path?: string;
   error?: string;
+  /**
+   * Set when the plugin installed cleanly but cannot run here — IBKR Gateway on
+   * the web build, for example. The catalog still lists it so the marketplace
+   * can explain why it is inert instead of leaving the user wondering.
+   */
+  unsupportedTarget?: PluginTarget;
 }
 
 const builtinPlugins: GloomPlugin[] = [
@@ -28,12 +34,13 @@ export function getPluginCatalog(externalPlugins: LoadedExternalPlugin[] = []): 
       source: "external" as const,
       path: entry.path,
       error: entry.error,
+      unsupportedTarget: entry.unsupportedTarget,
     })),
   ];
 }
 
 export function getLoadablePlugins(externalPlugins: LoadedExternalPlugin[] = []): GloomPlugin[] {
   return getPluginCatalog(externalPlugins)
-    .filter((entry) => !entry.error)
+    .filter((entry) => !entry.error && !entry.unsupportedTarget)
     .map((entry) => entry.plugin);
 }

--- a/src/plugins/host-link.ts
+++ b/src/plugins/host-link.ts
@@ -1,0 +1,109 @@
+import { existsSync, lstatSync, mkdirSync, readlinkSync, rmSync, symlinkSync } from "fs";
+import { dirname, join, resolve } from "path";
+
+/**
+ * External plugins live in `~/.gloomberb/plugins/<name>/`, outside any
+ * `node_modules` chain that could reach the running Gloomberb install. Left
+ * alone, `import { Box } from "gloomberb/ui"` does not resolve, and a plugin
+ * that lists `react` as a real dependency gets its *own* copy — two React
+ * instances in one process, which throws on the first hook.
+ *
+ * So the host links itself and its React into each plugin's `node_modules`.
+ * Plugins declare both as peer dependencies and never install them. This keeps
+ * one module instance per process and makes plugin imports resolve exactly the
+ * way they do for first-party code.
+ *
+ * Links are rebuilt after every install and update, because `bun install`
+ * prunes entries it does not know about, and repaired at load time so a plugin
+ * copied in by hand still works.
+ */
+
+const LINKED_PACKAGES = ["gloomberb", "react", "react-dom"] as const;
+
+let cachedHostRoot: string | null | undefined;
+
+/** Walks up from this module to the directory holding the `gloomberb` package.json. */
+export function findHostPackageRoot(startDir: string = import.meta.dir): string | null {
+  if (cachedHostRoot !== undefined && startDir === import.meta.dir) return cachedHostRoot;
+  let dir = resolve(startDir);
+  for (let depth = 0; depth < 12; depth += 1) {
+    const pkgPath = join(dir, "package.json");
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(require("fs").readFileSync(pkgPath, "utf-8")) as { name?: string };
+        if (pkg.name === "gloomberb") {
+          if (startDir === import.meta.dir) cachedHostRoot = dir;
+          return dir;
+        }
+      } catch {
+        // Unreadable package.json — keep walking rather than giving up.
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  if (startDir === import.meta.dir) cachedHostRoot = null;
+  return null;
+}
+
+function linkTarget(hostRoot: string, pkg: string): string | null {
+  if (pkg === "gloomberb") return hostRoot;
+  const candidate = join(hostRoot, "node_modules", pkg);
+  return existsSync(candidate) ? candidate : null;
+}
+
+/** True when `path` is already a symlink pointing at `target`. */
+function alreadyLinked(path: string, target: string): boolean {
+  try {
+    return lstatSync(path).isSymbolicLink() && resolve(dirname(path), readlinkSync(path)) === resolve(target);
+  } catch {
+    return false;
+  }
+}
+
+export interface HostLinkResult {
+  linked: string[];
+  skipped: string[];
+  error?: string;
+}
+
+/**
+ * Points `<pluginDir>/node_modules/{gloomberb,react,react-dom}` at the running
+ * install. Safe to call repeatedly.
+ */
+export function linkHostPackages(pluginDir: string, hostRoot = findHostPackageRoot()): HostLinkResult {
+  if (!hostRoot) return { linked: [], skipped: [...LINKED_PACKAGES], error: "Could not locate the Gloomberb install." };
+
+  const modulesDir = join(pluginDir, "node_modules");
+  const linked: string[] = [];
+  const skipped: string[] = [];
+
+  for (const pkg of LINKED_PACKAGES) {
+    const target = linkTarget(hostRoot, pkg);
+    if (!target) {
+      skipped.push(pkg);
+      continue;
+    }
+    const linkPath = join(modulesDir, pkg);
+    if (alreadyLinked(linkPath, target)) {
+      linked.push(pkg);
+      continue;
+    }
+    try {
+      mkdirSync(modulesDir, { recursive: true });
+      // A real directory here means `bun install` fetched a second copy; replacing
+      // it is the whole point, otherwise the plugin runs against a duplicate React.
+      if (existsSync(linkPath) || lstatSync(linkPath, { throwIfNoEntry: false })) {
+        rmSync(linkPath, { recursive: true, force: true });
+      }
+      symlinkSync(target, linkPath, "dir");
+      linked.push(pkg);
+    } catch (err) {
+      skipped.push(pkg);
+      if (pkg === "gloomberb") return { linked, skipped, error: String(err) };
+    }
+  }
+
+  return { linked, skipped };
+}

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2,8 +2,9 @@ import { readdir } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
 import { homedir } from "os";
-import type { GloomPlugin } from "../types/plugin";
+import type { GloomPlugin, PluginTarget } from "../types/plugin";
 import { debugLog } from "../utils/debug-log";
+import { linkHostPackages } from "./host-link";
 
 const loaderLog = debugLog.createLogger("plugin-loader");
 
@@ -13,13 +14,41 @@ export interface LoadedExternalPlugin {
   plugin: GloomPlugin;
   path: string;
   error?: string;
+  /** Set when the plugin loaded but does not support the running renderer. */
+  unsupportedTarget?: PluginTarget;
 }
 
 export function getPluginsDir(): string {
   return PLUGINS_DIR;
 }
 
-export async function loadExternalPlugins(): Promise<LoadedExternalPlugin[]> {
+/** Resolves a plugin directory's entry file the way `bun install` would. */
+export async function resolvePluginEntry(pluginDir: string): Promise<string | null> {
+  const pkgPath = join(pluginDir, "package.json");
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(await Bun.file(pkgPath).text());
+      if (pkg.main) {
+        const main = join(pluginDir, pkg.main);
+        if (existsSync(main)) return main;
+      }
+    } catch {
+      // Malformed package.json falls through to the index candidates.
+    }
+  }
+  for (const candidate of ["index.ts", "index.tsx", "index.js"]) {
+    const path = join(pluginDir, candidate);
+    if (existsSync(path)) return path;
+  }
+  return null;
+}
+
+export function pluginSupportsTarget(plugin: GloomPlugin, target: PluginTarget): boolean {
+  // No declaration means "everywhere"; the registry fills this in for listed plugins.
+  return !plugin.targets || plugin.targets.length === 0 || plugin.targets.includes(target);
+}
+
+export async function loadExternalPlugins(target: PluginTarget = "cli"): Promise<LoadedExternalPlugin[]> {
   if (!existsSync(PLUGINS_DIR)) return [];
 
   const results: LoadedExternalPlugin[] = [];
@@ -29,32 +58,22 @@ export async function loadExternalPlugins(): Promise<LoadedExternalPlugin[]> {
     if (!entry.isDirectory()) continue;
     const pluginDir = join(PLUGINS_DIR, entry.name);
 
-    // Look for entry file
-    let entryFile: string | null = null;
-
-    // Check package.json first
-    const pkgPath = join(pluginDir, "package.json");
-    if (existsSync(pkgPath)) {
-      try {
-        const pkg = JSON.parse(await Bun.file(pkgPath).text());
-        if (pkg.main) entryFile = join(pluginDir, pkg.main);
-      } catch { /* ignore malformed package.json */ }
-    }
-
-    // Fall back to index files
-    if (!entryFile) {
-      for (const candidate of ["index.ts", "index.tsx", "index.js"]) {
-        const p = join(pluginDir, candidate);
-        if (existsSync(p)) { entryFile = p; break; }
-      }
-    }
-
+    const entryFile = await resolvePluginEntry(pluginDir);
     if (!entryFile) continue;
+
+    // Repairs `gloomberb`/`react` links for plugins copied in by hand or left
+    // behind by a `bun install` that pruned them.
+    linkHostPackages(pluginDir);
 
     try {
       const mod = await import(entryFile);
       const plugin: GloomPlugin = mod.default ?? mod.plugin;
       if (plugin && plugin.id && plugin.name) {
+        if (!pluginSupportsTarget(plugin, target)) {
+          loaderLog.info(`Skipped ${plugin.id}: does not support "${target}"`);
+          results.push({ plugin, path: pluginDir, unsupportedTarget: target });
+          continue;
+        }
         loaderLog.info(`Loaded external plugin: ${plugin.id} v${plugin.version ?? "0.0.0"}`);
         results.push({ plugin, path: pluginDir });
       }

--- a/src/public/public-api.test.ts
+++ b/src/public/public-api.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+
+import * as capabilities from "../capabilities";
+import * as components from "../components";
+import * as theme from "../theme/colors";
+import * as ui from "../ui";
+import * as pluginReact from "./react";
+import * as testSupport from "./test-support";
+import * as utils from "./utils";
+
+/**
+ * The public plugin API is a compatibility boundary: plugins in other
+ * repositories (gloom-sh/gloomberb-substack, -ibkr, -hackernews, and any
+ * community plugin) import these subpaths, and a rename here breaks them
+ * silently at their next install rather than in this repo's CI.
+ *
+ * Adding an export is deliberate — update the list below in the same commit.
+ * Removing or renaming one is a breaking change for every installed plugin and
+ * needs a major version plus a migration note in PLUGINS.md.
+ */
+const PUBLIC_API: Record<string, readonly string[]> = {
+  "ui": [
+    "AsciiText",
+    "Box",
+    "ChartSurface",
+    "ContextMenuProvider",
+    "ImageSurface",
+    "Input",
+    "MediaSurface",
+    "RGBA",
+    "ScrollBox",
+    "Span",
+    "SpinnerMark",
+    "Strong",
+    "StyledText",
+    "Text",
+    "TextAttributes",
+    "Textarea",
+    "UiHostProvider",
+    "Underline",
+    "compactContextMenuItems",
+    "contextMenuDivider",
+    "editableTextContextMenuItems",
+    "linkContextMenuItems",
+    "tickerContextMenuItems",
+    "useContextMenu",
+    "useNativeRenderer",
+    "useRendererHost",
+    "useSyntaxStyleFactory",
+    "useTickerContextMenu",
+    "useUiCapabilities",
+    "useUiHost",
+  ],
+  "components": [
+    "Button",
+    "Checkbox",
+    "ChoiceDialog",
+    "ConfirmDialog",
+    "DataTableStackView",
+    "DataTableView",
+    "EmptyState",
+    "FeedDataTableStackView",
+    "InputSearchBar",
+    "MessageComposer",
+    "MetricTreemapSurface",
+    "NumberField",
+    "PaneFooterScope",
+    "PaneSidebar",
+    "PaneSidebarAction",
+    "PaneSidebarRow",
+    "PaneStatusBody",
+    "PriceSelectorDialog",
+    "SegmentedControl",
+    "SpeedometerGauge",
+    "Spinner",
+    "StaticChartSurface",
+    "Tabs",
+    "TextField",
+    "TickerBadgeList",
+    "TickerListTableView",
+    "activeStackIndex",
+    "buildMetricTreemapNavigationTiles",
+    "findMetricTreemapNeighbor",
+    "getMessageComposerBlockHeight",
+    "getPaneSidebarWidth",
+    "isTableScrollNearEnd",
+    "loadingText",
+    "shouldShowPaneSidebar",
+    "sortStackItems",
+    "unavailableText",
+    "useExternalLinkFooter",
+    "usePaneFooter",
+    "usePaneTicker",
+    "useTableLoadMore",
+  ],
+  "theme": [
+    "applyTheme",
+    "blendHex",
+    "clearTransientThemePreview",
+    "colors",
+    "commandBarAccentText",
+    "commandBarBg",
+    "commandBarHeadingText",
+    "commandBarHoverBg",
+    "commandBarInputBg",
+    "commandBarPanelBg",
+    "commandBarSelectedBg",
+    "commandBarSelectedText",
+    "commandBarSubtleText",
+    "commandBarText",
+    "floatingPaneBg",
+    "floatingPaneTitleBg",
+    "getChartIndicatorColor",
+    "getCurrentThemeId",
+    "getThemeColors",
+    "hoverBg",
+    "paneBg",
+    "paneTitleBg",
+    "paneTitleText",
+    "previewTheme",
+    "priceColor",
+    "syncTheme",
+  ],
+  "capabilities": [
+    "AI_RUNNER_CAPABILITY_ID",
+    "BROKER_CAPABILITY_ID",
+    "CHART_SERIES_CAPABILITY_KIND",
+    "CapabilityRegistry",
+    "MAX_CHART_SERIES_CATALOG_ITEMS",
+    "MAX_CHART_SERIES_POINTS",
+    "NOTES_FILES_CAPABILITY_ID",
+    "assetDataProvider",
+    "chartSeriesCapabilityManifests",
+    "chartSeriesCatalogOutputSchema",
+    "chartSeriesCatalogRequestSchema",
+    "chartSeriesProvider",
+    "chartSeriesResolveOutputSchema",
+    "chartSeriesResolveRequestSchema",
+    "chartSeriesSourceKey",
+    "createChartSeriesResolver",
+    "isValidChartCapabilityId",
+    "isValidChartSeriesId",
+    "newsProvider",
+    "recordSchema",
+    "searchChartSeriesCapabilities",
+  ],
+  "utils": [
+    "createThrottledFetch",
+    "decodeHtmlEntities",
+    "displayWidth",
+    "formatCompact",
+    "formatCompactCurrency",
+    "formatCurrency",
+    "formatGrowthShort",
+    "formatNumber",
+    "formatPercent",
+    "formatPercentRaw",
+    "formatWithDivisor",
+    "isPlainKey",
+    "isPlainKeyboardEvent",
+    "normalizedHttpUrl",
+    "padTo",
+    "pickUnit",
+    "truncateToDisplayWidth",
+  ],
+  "react": [
+    "deletePluginPaneStateValue",
+    "getPluginPaneStateValue",
+    "setPluginPaneStateValue",
+    "useAssetData",
+    "useCapabilityInvoker",
+    "useConnectionHealth",
+    "useDebouncedPluginPaneState",
+    "useInlineTickerOpener",
+    "useInlineTickers",
+    "useMarketData",
+    "usePluginAppActions",
+    "usePluginBrokerActions",
+    "usePluginConfigState",
+    "usePluginPaneActions",
+    "usePluginPaneState",
+    "usePluginState",
+    "usePluginTickerActions",
+    "useSetPluginConfigStates",
+  ],
+  "test-support": [
+    "MemoryPluginPersistence",
+  ],
+};
+
+const MODULES: Record<string, Record<string, unknown>> = {
+  ui,
+  components,
+  theme,
+  capabilities,
+  utils,
+  react: pluginReact,
+  "test-support": testSupport,
+};
+
+describe("public plugin API", () => {
+  for (const [name, expected] of Object.entries(PUBLIC_API)) {
+    test(`gloomberb/${name} exports exactly its documented surface`, () => {
+      const actual = Object.keys(MODULES[name]!)
+        .filter((key) => key !== "default")
+        .sort();
+      expect(actual).toEqual([...expected]);
+    });
+  }
+
+  test("every exports subpath in package.json resolves", async () => {
+    const pkg = JSON.parse(await Bun.file(new URL("../../package.json", import.meta.url)).text());
+    const subpaths = Object.entries(pkg.exports as Record<string, string>);
+    expect(subpaths.length).toBeGreaterThan(0);
+    for (const [subpath, target] of subpaths) {
+      if (subpath === "./package.json") continue;
+      const file = Bun.file(new URL(`../../${target.replace(/^\.\//, "")}`, import.meta.url));
+      expect(await file.exists(), `${subpath} -> ${target}`).toBe(true);
+    }
+  });
+});

--- a/src/public/public-api.test.ts
+++ b/src/public/public-api.test.ts
@@ -155,6 +155,7 @@ const PUBLIC_API: Record<string, readonly string[]> = {
     "formatNumber",
     "formatPercent",
     "formatPercentRaw",
+    "formatRelativeAge",
     "formatWithDivisor",
     "isPlainKey",
     "isPlainKeyboardEvent",

--- a/src/public/react.ts
+++ b/src/public/react.ts
@@ -1,0 +1,34 @@
+/**
+ * Public React runtime surface for external plugins (`gloomberb/react`).
+ *
+ * These hooks are the renderer-neutral way for plugin panes to reach app
+ * services. Plugin render code must use them instead of importing OpenTUI,
+ * Electrobun, or DOM APIs directly — the renderer decides how each one is
+ * fulfilled, which is what lets the same plugin run in the terminal, on the
+ * desktop, and (for web-capable plugins) in the browser.
+ *
+ * Compatibility commitment: see the note in `./utils.ts`.
+ */
+
+export {
+  deletePluginPaneStateValue,
+  getPluginPaneStateValue,
+  setPluginPaneStateValue,
+  useCapabilityInvoker,
+  useAssetData,
+  useConnectionHealth,
+  useDebouncedPluginPaneState,
+  useMarketData,
+  usePluginAppActions,
+  usePluginBrokerActions,
+  usePluginConfigState,
+  usePluginPaneActions,
+  usePluginPaneState,
+  usePluginState,
+  usePluginTickerActions,
+  useSetPluginConfigStates,
+} from "../plugins/runtime";
+export type { PluginRuntimeAccess } from "../plugins/runtime";
+
+export { useInlineTickerOpener, useInlineTickers } from "../state/hooks/inline-tickers";
+export type { InlineTickerCatalogEntry, UseInlineTickersOptions } from "../state/hooks/inline-tickers";

--- a/src/public/test-support.ts
+++ b/src/public/test-support.ts
@@ -1,0 +1,9 @@
+/**
+ * Test helpers for external plugin repositories (`gloomberb/test-support`).
+ *
+ * Plugins live in their own repos and run their own `bun test`, so the fakes
+ * they need to exercise persistence-backed logic have to ship with the host
+ * rather than being copied per plugin and drifting.
+ */
+
+export { MemoryPluginPersistence } from "../test-support/plugin-persistence";

--- a/src/public/utils.ts
+++ b/src/public/utils.ts
@@ -1,0 +1,41 @@
+/**
+ * Public utility surface for external plugins (`gloomberb/utils`).
+ *
+ * Everything re-exported here is a compatibility commitment: plugins in other
+ * repositories import it, so removing or changing a signature is a breaking
+ * change for them. Internal helpers stay internal — add to this barrel only
+ * when a real plugin needs it, and prefer widening later over exporting
+ * speculatively.
+ *
+ * `scripts/check-public-api.ts` pins the exported names so the surface cannot
+ * grow by accident during an unrelated refactor.
+ */
+
+export { createThrottledFetch } from "../utils/throttled-fetch";
+export type {
+  ThrottledFetchClient,
+  ThrottledFetchOptions,
+  ThrottledFetchTransport,
+} from "../utils/throttled-fetch";
+
+export { normalizedHttpUrl } from "../utils/url";
+
+export { decodeHtmlEntities } from "../utils/html-entities";
+
+export { isPlainKey, isPlainKeyboardEvent } from "../utils/keyboard";
+export type { KeyboardModifierEventLike } from "../utils/keyboard";
+
+export {
+  displayWidth,
+  formatCompact,
+  formatCompactCurrency,
+  formatCurrency,
+  formatGrowthShort,
+  formatNumber,
+  formatPercent,
+  formatPercentRaw,
+  formatWithDivisor,
+  padTo,
+  pickUnit,
+  truncateToDisplayWidth,
+} from "../utils/format";

--- a/src/public/utils.ts
+++ b/src/public/utils.ts
@@ -20,6 +20,8 @@ export type {
 
 export { normalizedHttpUrl } from "../utils/url";
 
+export { formatRelativeAge } from "../utils/relative-time";
+
 export { decodeHtmlEntities } from "../utils/html-entities";
 
 export { isPlainKey, isPlainKeyboardEvent } from "../utils/keyboard";

--- a/src/renderers/opentui/start.tsx
+++ b/src/renderers/opentui/start.tsx
@@ -73,7 +73,7 @@ export async function startOpenTuiApp(options: StartOpenTuiAppOptions = {}): Pro
   };
 
   const cliArgs = options.cliArgs ?? process.argv.slice(2);
-  const externalPlugins = options.externalPlugins ?? await measurePerfAsync("startup.opentui.load-external-plugins", () => loadExternalPlugins());
+  const externalPlugins = options.externalPlugins ?? await measurePerfAsync("startup.opentui.load-external-plugins", () => loadExternalPlugins("tui"));
   let cliLaunchRequest = options.cliLaunchRequest ?? null;
   if (!options.skipCliDispatch && cliArgs.length > 0) {
     const dispatchResult = await dispatchCli(cliArgs, { externalPlugins });

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -577,6 +577,21 @@ export interface GloomPluginContext {
   notify(notification: AppNotificationRequest): AppNotificationDelivery | void;
 }
 
+/**
+ * Where a plugin can actually run.
+ *
+ * `cli` and `tui` run in Bun and may use Node APIs. `desktop` runs in the
+ * Electrobun view. `web` runs in the browser at term.gloom.sh, which rules out
+ * Node builtins entirely — a plugin opening a TCP socket (IBKR Gateway) can
+ * never be web-capable, no matter what it declares.
+ *
+ * Plugins may declare this, but the registry derives it from a static import
+ * scan and overwrites the declaration. Treat an author-supplied value as a hint.
+ */
+export type PluginTarget = "cli" | "tui" | "desktop" | "web";
+
+export const ALL_PLUGIN_TARGETS: readonly PluginTarget[] = ["cli", "tui", "desktop", "web"];
+
 export interface GloomPlugin {
   id: string;
   name: string;
@@ -585,6 +600,10 @@ export interface GloomPlugin {
   toggleable?: boolean;
   order?: number;
   cliCommands?: CliCommandDef[];
+  /** Defaults to every target when omitted. */
+  targets?: readonly PluginTarget[];
+  /** Shown in the marketplace pane and on the website. */
+  homepage?: string;
 
   setup?(ctx: GloomPluginContext): void | Promise<void>;
   dispose?(): void;


### PR DESCRIPTION
External plugins could not actually be written against the documented API.

`package.json` had no `exports` map, so every `gloomberb/ui`, `gloomberb/components`, and `gloomberb/types/plugin` import in PLUGINS.md resolved nowhere — those specifiers appeared only in the docs, never in code. And because plugins install to `~/.gloomberb/plugins/`, outside any node_modules chain reaching the running install, a plugin listing `react` as a dependency would load a second React instance and throw on its first hook.

This adds:

- An `exports` map over curated barrels (`gloomberb/ui`, `/components`, `/react`, `/utils`, `/theme`, `/capabilities`, `/types/*`, `/test-support`). The surface was derived from what the Substack plugin actually reaches for, not guessed.
- `src/public/public-api.test.ts`, which freezes the exported names. The boundary is a compatibility commitment to plugins in other repos, where a rename breaks them silently at their next install rather than in this repo's CI.
- `src/plugins/host-link.ts`, which symlinks the running `gloomberb`, `react`, and `react-dom` into each plugin directory on install, update, and load. One module instance per process, and plugin imports resolve the way first-party ones do.
- `GloomPlugin.targets`, so a renderer skips a plugin it cannot run. The catalog keeps unsupported entries visible so the marketplace can explain why one is inert.
- `bun install --production` for plugins, so a repo can depend on `gloomberb` for typechecking without shipping a second copy at runtime.

Verified end to end: a plugin in `~/.gloomberb/plugins` importing only `gloomberb/*` links, loads, registers its pane, and reports its targets.

No behaviour change for built-in plugins.