### PR TITLE
Install plugins by name

### DIFF
--- a/src/cli/commands/plugins.ts
+++ b/src/cli/commands/plugins.ts
@@ -51,8 +51,45 @@ function parseGitHubRef(rawRef: string): { url: string; name: string } {
   throw new Error(`Invalid plugin reference: ${ref}. Use user/repo or a GitHub URL.`);
 }
 
-export async function installPlugin(ref: string) {
+const PLUGIN_ID_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+/**
+ * Resolves a bare plugin id through the registry, so `gloomberb install
+ * hackernews` works alongside `gloomberb install owner/repo`. Anything already
+ * shaped like a repo reference is left alone, and a registry lookup failure
+ * falls through to the normal parse error rather than inventing a repo name.
+ */
+async function resolveRegistryRef(rawRef: string): Promise<string> {
+  if (rawRef.includes("/") || rawRef.includes(":") || !PLUGIN_ID_PATTERN.test(rawRef)) return rawRef;
+
+  try {
+    const response = await fetch(`https://plugins.gloom.sh/plugins/${rawRef}.json`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) return rawRef;
+    const entry = await response.json() as { repo?: string; bundled?: boolean; name?: string };
+
+    if (entry.bundled) {
+      fail(
+        `"${entry.name ?? rawRef}" ships with Gloomberb.`,
+        `Enable it from the plugin marketplace (PL) instead.`,
+      );
+    }
+    if (typeof entry.repo === "string" && entry.repo.length > 0) {
+      console.log(cliStyles.muted(`Resolved "${rawRef}" to ${entry.repo}`));
+      return entry.repo;
+    }
+  } catch {
+    // Offline or registry down: fall through so the plain parse error explains
+    // the accepted formats rather than blaming the network.
+  }
+  return rawRef;
+}
+
+export async function installPlugin(rawRef: string) {
   ensurePluginsDir();
+  const ref = await resolveRegistryRef(rawRef);
   const { url, name } = parseGitHubRef(ref);
   const targetDir = join(PLUGINS_DIR, name);
 


### PR DESCRIPTION
`gloomberb install hackernews` now resolves through plugins.gloom.sh, alongside the existing `owner/repo` and URL forms.

- A reference that already contains `/` or `:` is passed straight through, so nothing about the existing syntax changes.
- Asking for a bundled plugin explains that it ships with Gloomberb and points at `PL`, rather than failing to clone a repo that does not exist.
- A registry lookup failure falls through to the normal parse error, so an offline user is told which formats are accepted instead of being shown a network problem.

Verified end to end in an isolated HOME: resolve, clone, dependency install, host link, and load with the pane registered.