### PR TITLE
Compile external plugins for the desktop and browser renderers

### DIFF
--- a/src/plugins/bundle.test.ts
+++ b/src/plugins/bundle.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  bundleExternalPlugin,
+  buildSharedModuleSource,
+  PLUGIN_HOST_GLOBAL,
+} from "./bundle";
+
+/**
+ * This is the seam that lets a plugin on disk run inside the desktop and
+ * browser renderers, and the failure it prevents is nasty: if `react` or a
+ * `gloomberb/*` module gets bundled into the plugin instead of shared with the
+ * host, the plugin loads fine and then throws on its first hook, or silently
+ * renders against a second copy of the theme. That is worth pinning down.
+ */
+
+function scratchPlugin(source: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "gloom-bundle-"));
+  writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "scratch", main: "index.tsx" }));
+  writeFileSync(join(dir, "index.tsx"), source);
+  return dir;
+}
+
+const fakeExports = async (specifier: string) => (
+  specifier === "gloomberb/ui" ? ["Box", "Text"] : specifier === "react" ? ["useState"] : []
+);
+
+describe("buildSharedModuleSource", () => {
+  test("re-exports each name from the host registry", () => {
+    const source = buildSharedModuleSource("gloomberb/ui", ["Box", "Text"]);
+
+    expect(source).toContain(PLUGIN_HOST_GLOBAL);
+    expect(source).toContain('export const Box = mod["Box"];');
+    expect(source).toContain('export const Text = mod["Text"];');
+  });
+
+  test("throws a directed error when the host registry is missing", () => {
+    // A plugin bundle loaded before the host installs its modules should say so,
+    // not fail later with an undefined property read deep in a render.
+    const source = buildSharedModuleSource("gloomberb/ui", []);
+    expect(source).toContain("was not installed before this plugin loaded");
+  });
+
+  test("skips a default export, which the module already provides", () => {
+    expect(buildSharedModuleSource("react", ["default", "useState"]))
+      .not.toContain("export const default");
+  });
+});
+
+describe("bundleExternalPlugin", () => {
+  test("shares react and gloomberb modules instead of bundling them", async () => {
+    const dir = scratchPlugin(`
+      import { useState } from "react";
+      import { Box } from "gloomberb/ui";
+      export default { id: "scratch", name: "Scratch", version: "1.0.0", useState, Box };
+    `);
+    const out = join(dir, "out");
+    try {
+      const result = await bundleExternalPlugin(dir, out, { exportNamesFor: fakeExports });
+      const code = await Bun.file(result.outputPath).text();
+
+      expect(result.shared).toEqual(["gloomberb/ui", "react"]);
+      expect(code).toContain(PLUGIN_HOST_GLOBAL);
+      // The giveaway that React got inlined rather than shared.
+      expect(code).not.toContain("react-dom/client");
+      expect(code).not.toContain("Invalid hook call");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("bundles a plugin's own dependencies rather than sharing them", async () => {
+    const dir = scratchPlugin(`
+      import { double } from "./helper";
+      export default { id: "scratch", name: "Scratch", version: "1.0.0", value: double(21) };
+    `);
+    writeFileSync(join(dir, "helper.ts"), "export function double(n: number) { return n * 2; }");
+    const out = join(dir, "out");
+    try {
+      const result = await bundleExternalPlugin(dir, out, { exportNamesFor: fakeExports });
+      const code = await Bun.file(result.outputPath).text();
+
+      expect(result.shared).toEqual([]);
+      expect(code).toContain("* 2");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports a compile error against the plugin instead of throwing something opaque", async () => {
+    const dir = scratchPlugin(`import { missing } from "./nope"; export default missing;`);
+    try {
+      await expect(bundleExternalPlugin(dir, join(dir, "out"), { exportNamesFor: fakeExports }))
+        .rejects.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a directory with no entry file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gloom-bundle-empty-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    try {
+      await expect(bundleExternalPlugin(dir, join(dir, "out"))).rejects.toThrow("No plugin entry file");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/plugins/bundle.ts
+++ b/src/plugins/bundle.ts
@@ -1,0 +1,159 @@
+import { mkdir } from "fs/promises";
+import { join } from "path";
+
+import { resolvePluginEntry } from "./loader";
+
+/**
+ * Compiles an external plugin for a renderer that cannot read the filesystem.
+ *
+ * The terminal renderer runs in Bun and can `import()` a plugin directly from
+ * `~/.gloomberb/plugins`. The desktop view and the hosted browser app cannot:
+ * they are browser contexts running a sealed bundle, so plugin source has to be
+ * compiled to an ES module they can fetch.
+ *
+ * The hard part is not compiling, it is *sharing*. A plugin bundle that carries
+ * its own React would give the process a second React instance and throw on the
+ * first hook, and it has no way to reach the host's `gloomberb/*` modules at
+ * all. So those specifiers are not bundled — they are rewritten to read from a
+ * registry the host publishes on `globalThis` before it loads any plugin. One
+ * instance of every shared module, exactly as on the terminal side where the
+ * host is symlinked in.
+ */
+
+export const PLUGIN_HOST_GLOBAL = "__GLOOM_PLUGIN_HOST__";
+
+/**
+ * Specifiers a plugin may import that must resolve to the host's copy. Anything
+ * else is a plugin's own dependency and gets bundled normally.
+ */
+export const SHARED_SPECIFIERS = [
+  "react",
+  "react/jsx-runtime",
+  "react/jsx-dev-runtime",
+  "react-dom",
+  "gloomberb/types/plugin",
+  "gloomberb/types/persistence",
+  "gloomberb/ui",
+  "gloomberb/components",
+  "gloomberb/theme",
+  "gloomberb/capabilities",
+  "gloomberb/utils",
+  "gloomberb/react",
+] as const;
+
+export type SharedSpecifier = (typeof SHARED_SPECIFIERS)[number];
+
+/**
+ * Source for a module that re-exports one shared specifier from the host
+ * registry. Named exports have to be listed statically — `export *` cannot
+ * forward from a runtime object — so the caller passes the names it found by
+ * importing the real module.
+ */
+export function buildSharedModuleSource(specifier: string, exportNames: readonly string[]): string {
+  const lines = [
+    `const mod = globalThis[${JSON.stringify(PLUGIN_HOST_GLOBAL)}]?.[${JSON.stringify(specifier)}];`,
+    `if (!mod) throw new Error(${JSON.stringify(`Gloomberb host module "${specifier}" is unavailable. The plugin host was not installed before this plugin loaded.`)});`,
+    "export default mod;",
+  ];
+  for (const name of exportNames) {
+    if (name === "default") continue;
+    // Not `export const`: a getter keeps live bindings working and avoids
+    // capturing a value the host may replace on a theme or locale change.
+    lines.push(`export const ${name} = mod[${JSON.stringify(name)}];`);
+  }
+  return lines.join("\n");
+}
+
+export interface BundlePluginResult {
+  /** Absolute path of the emitted ES module. */
+  outputPath: string;
+  /** Shared specifiers this plugin actually imported. */
+  shared: string[];
+  warnings: string[];
+}
+
+/**
+ * Bun plugin that redirects the shared specifiers to generated modules.
+ *
+ * `exportNamesFor` is injected so this stays testable and so the caller decides
+ * how names are discovered — the bundler runs in Bun and can simply import the
+ * real module, but a test should not have to.
+ */
+export function createSharedModuleResolver(
+  exportNamesFor: (specifier: string) => Promise<readonly string[]>,
+  onShared?: (specifier: string) => void,
+): import("bun").BunPlugin {
+  const namespace = "gloom-host";
+  const shared = new Set<string>(SHARED_SPECIFIERS);
+
+  return {
+    name: "gloomberb-host-modules",
+    setup(build) {
+      build.onResolve({ filter: /.*/ }, (args) => {
+        if (!shared.has(args.path)) return undefined;
+        onShared?.(args.path);
+        return { path: args.path, namespace };
+      });
+
+      build.onLoad({ filter: /.*/, namespace }, async (args) => ({
+        contents: buildSharedModuleSource(args.path, await exportNamesFor(args.path)),
+        loader: "js",
+      }));
+    },
+  };
+}
+
+async function hostExportNames(specifier: string): Promise<readonly string[]> {
+  const mod = await import(specifier);
+  return Object.keys(mod).sort();
+}
+
+/**
+ * Bundles one plugin directory to `outDir`, returning the emitted module path.
+ * Throws on a compile error so the caller can surface it against the plugin
+ * rather than failing the whole renderer.
+ */
+export async function bundleExternalPlugin(
+  pluginDir: string,
+  outDir: string,
+  options: { exportNamesFor?: (specifier: string) => Promise<readonly string[]> } = {},
+): Promise<BundlePluginResult> {
+  const entry = await resolvePluginEntry(pluginDir);
+  if (!entry) throw new Error(`No plugin entry file in ${pluginDir}`);
+
+  await mkdir(outDir, { recursive: true });
+
+  const shared = new Set<string>();
+  const result = await Bun.build({
+    entrypoints: [entry],
+    outdir: outDir,
+    target: "browser",
+    format: "esm",
+    splitting: false,
+    minify: false,
+    sourcemap: "none",
+    plugins: [
+      createSharedModuleResolver(
+        options.exportNamesFor ?? hostExportNames,
+        (specifier) => shared.add(specifier),
+      ),
+    ],
+  });
+
+  if (!result.success) {
+    throw new Error(result.logs.map((log) => log.message).join("\n"));
+  }
+
+  const output = result.outputs.find((entryOutput) => entryOutput.kind === "entry-point");
+  if (!output) throw new Error(`Bundling ${pluginDir} produced no entry point`);
+
+  return {
+    outputPath: output.path,
+    shared: [...shared].sort(),
+    warnings: result.logs.filter((log) => log.level === "warning").map((log) => log.message),
+  };
+}
+
+export function pluginBundleCacheDir(baseDir: string): string {
+  return join(baseDir, "bundles");
+}

--- a/src/plugins/host-modules.ts
+++ b/src/plugins/host-modules.ts
@@ -1,0 +1,64 @@
+import { PLUGIN_HOST_GLOBAL, SHARED_SPECIFIERS } from "./bundle";
+
+/**
+ * Publishes the host's shared modules for compiled plugin bundles to read.
+ *
+ * Browser-context renderers load plugins as separate ES modules, so the bundler
+ * rewrites their `react` and `gloomberb/*` imports to read from this registry
+ * (see `bundle.ts`). This must run before any plugin bundle is imported, and
+ * the modules here must be the same instances the app itself uses — importing
+ * them normally is what guarantees that.
+ */
+export async function installPluginHostModules(): Promise<void> {
+  const globals = globalThis as Record<string, unknown>;
+  if (globals[PLUGIN_HOST_GLOBAL]) return;
+
+  const [
+    react,
+    jsxRuntime,
+    reactDom,
+    typesPlugin,
+    typesPersistence,
+    ui,
+    components,
+    theme,
+    capabilities,
+    utils,
+    pluginReact,
+  ] = await Promise.all([
+    import("react"),
+    import("react/jsx-runtime"),
+    import("react-dom"),
+    // Type-only modules still need an entry: a plugin may import a runtime
+    // value from them, and a missing key throws a clearer error than undefined.
+    import("../types/plugin"),
+    import("../types/persistence"),
+    import("../ui"),
+    import("../components"),
+    import("../theme/colors"),
+    import("../capabilities"),
+    import("../public/utils"),
+    import("../public/react"),
+  ]);
+
+  const registry: Record<string, unknown> = {
+    "react": react,
+    "react/jsx-runtime": jsxRuntime,
+    "react/jsx-dev-runtime": jsxRuntime,
+    "react-dom": reactDom,
+    "gloomberb/types/plugin": typesPlugin,
+    "gloomberb/types/persistence": typesPersistence,
+    "gloomberb/ui": ui,
+    "gloomberb/components": components,
+    "gloomberb/theme": theme,
+    "gloomberb/capabilities": capabilities,
+    "gloomberb/utils": utils,
+    "gloomberb/react": pluginReact,
+  };
+
+  for (const specifier of SHARED_SPECIFIERS) {
+    if (!registry[specifier]) throw new Error(`Plugin host registry is missing "${specifier}"`);
+  }
+
+  globals[PLUGIN_HOST_GLOBAL] = registry;
+}


### PR DESCRIPTION
The desktop app has only ever loaded built-in plugins (`catalog-ui.ts:44`). That is the blocker for moving IBKR and Substack into their own repos — extracting either one today would drop it from the desktop build.

The terminal renderer imports a plugin directly from `~/.gloomberb/plugins` because it runs in Bun. The Electrobun view and term.gloom.sh are browser contexts running a sealed bundle, so plugin source has to be compiled to an ES module they can fetch.

Compiling is the easy half. The half that matters is **sharing**: a plugin bundle carrying its own React gives the process a second React instance and throws on the first hook, and it has no route to the host's `gloomberb/*` modules at all. So those specifiers are never bundled — a Bun resolver rewrites them to read from a registry the host publishes on `globalThis` before any plugin loads. One instance of every shared module, matching what the symlink already does on the terminal side.

Verified against the real Hacker News plugin: a 22KB bundle (small precisely because react and `gloomberb/*` stay shared), importing to the same React instance as the host with its pane component intact.

Scope: this is the loading mechanism and its tests. Wiring it into the Electrobun view — bun-side bundling on startup plus view-side import — is the next change, and is what actually unblocks the two extractions.