### PR TITLE
Stop sharing react-dom with plugin bundles

### DIFF
--- a/src/plugins/bundle.ts
+++ b/src/plugins/bundle.ts
@@ -25,12 +25,16 @@ export const PLUGIN_HOST_GLOBAL = "__GLOOM_PLUGIN_HOST__";
 /**
  * Specifiers a plugin may import that must resolve to the host's copy. Anything
  * else is a plugin's own dependency and gets bundled normally.
+ *
+ * Deliberately no `react-dom`: it is a renderer package, and plugins are
+ * required to be renderer-neutral so the same code runs in the terminal. A
+ * plugin reaching for it should fail to bundle rather than quietly work on the
+ * desktop and break in the TUI.
  */
 export const SHARED_SPECIFIERS = [
   "react",
   "react/jsx-runtime",
   "react/jsx-dev-runtime",
-  "react-dom",
   "gloomberb/types/plugin",
   "gloomberb/types/persistence",
   "gloomberb/ui",

--- a/src/plugins/host-modules.ts
+++ b/src/plugins/host-modules.ts
@@ -16,7 +16,6 @@ export async function installPluginHostModules(): Promise<void> {
   const [
     react,
     jsxRuntime,
-    reactDom,
     typesPlugin,
     typesPersistence,
     ui,
@@ -28,7 +27,6 @@ export async function installPluginHostModules(): Promise<void> {
   ] = await Promise.all([
     import("react"),
     import("react/jsx-runtime"),
-    import("react-dom"),
     // Type-only modules still need an entry: a plugin may import a runtime
     // value from them, and a missing key throws a clearer error than undefined.
     import("../types/plugin"),
@@ -45,7 +43,6 @@ export async function installPluginHostModules(): Promise<void> {
     "react": react,
     "react/jsx-runtime": jsxRuntime,
     "react/jsx-dev-runtime": jsxRuntime,
-    "react-dom": reactDom,
     "gloomberb/types/plugin": typesPlugin,
     "gloomberb/types/persistence": typesPersistence,
     "gloomberb/ui": ui,


### PR DESCRIPTION
Follow-up to #667, which I merged past a red build — that was my mistake and this is the fix.

`src/architecture/import-boundaries.test.ts` failed because `host-modules.ts` imported `react-dom` outside a renderer adapter. The test was right, and not just about file layout: `react-dom` is a renderer package, and PLUGINS.md requires plugins to be renderer-neutral so the same plugin runs in the terminal, on the desktop, and in the browser.

Sharing it would have let a plugin import `react-dom`, work on the desktop, and break in the TUI. It now fails to bundle instead, which is the contract we want. No plugin needs it — the Hacker News bundle shares only `react`, `react/jsx-*`, and `gloomberb/*`.

Full suite green: 2414 pass, all six typecheck targets clean.