### PR TITLE
Load external plugins in the desktop app

### DIFF
--- a/src/plugins/catalog-ui.ts
+++ b/src/plugins/catalog-ui.ts
@@ -1,4 +1,5 @@
 import type { GloomPlugin } from "../types/plugin";
+import type { LoadedExternalPlugin } from "./loader";
 import { newsPlugin } from "./builtin/news";
 import { notesPlugin } from "./builtin/notes";
 import { substackPlugin } from "./builtin/substack";
@@ -43,4 +44,21 @@ export const uiBuiltinPlugins: GloomPlugin[] = [
 
 export function getRendererBuiltinPlugins(): GloomPlugin[] {
   return uiBuiltinPlugins;
+}
+
+/**
+ * The plugin list for a UI renderer: the built-ins it ships with, plus any
+ * external plugins that loaded and support this renderer.
+ *
+ * Deliberately not `getLoadablePlugins`, which is the CLI catalog and also
+ * carries the Yahoo fallback provider and the debug plugin. Routing the desktop
+ * through it would quietly change which plugins the app runs.
+ */
+export function getRendererPlugins(externalPlugins: readonly LoadedExternalPlugin[] = []): GloomPlugin[] {
+  return [
+    ...uiBuiltinPlugins,
+    ...externalPlugins
+      .filter((entry) => !entry.error && !entry.unsupportedTarget)
+      .map((entry) => entry.plugin),
+  ];
 }

--- a/src/renderers/electrobun/bun/external-plugins.ts
+++ b/src/renderers/electrobun/bun/external-plugins.ts
@@ -1,0 +1,121 @@
+import { readdir, stat } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+
+import type { DesktopExternalPluginBundle } from "../shared/protocol";
+import { bundleExternalPlugin, pluginBundleCacheDir } from "../../../plugins/bundle";
+import { linkHostPackages } from "../../../plugins/host-link";
+import { getPluginsDir, resolvePluginEntry } from "../../../plugins/loader";
+import type { GloomPlugin } from "../../../types/plugin";
+import { debugLog } from "../../../utils/debug-log";
+
+const log = debugLog.createLogger("desktop-plugins");
+
+/**
+ * Prepares external plugins for the desktop view.
+ *
+ * The view is a browser context and cannot read `~/.gloomberb/plugins`, so the
+ * Bun process does both halves here: it imports each plugin natively to read
+ * its metadata, and compiles it to an ES module the view can evaluate.
+ *
+ * Bundling is cached against the newest mtime in the plugin directory. Without
+ * that, every window open would recompile every plugin, which is slow enough to
+ * be visible at startup.
+ */
+
+interface CacheEntry {
+  mtimeMs: number;
+  code: string;
+}
+
+const bundleCache = new Map<string, CacheEntry>();
+
+async function newestMtime(dir: string): Promise<number> {
+  let newest = 0;
+  const walk = async (current: string, depth: number): Promise<void> => {
+    if (depth > 6) return;
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name === ".git") continue;
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full, depth + 1);
+        continue;
+      }
+      const info = await stat(full);
+      if (info.mtimeMs > newest) newest = info.mtimeMs;
+    }
+  };
+  await walk(dir, 0);
+  return newest;
+}
+
+async function readPluginMetadata(entryFile: string): Promise<GloomPlugin | null> {
+  try {
+    const mod = await import(entryFile);
+    const plugin: GloomPlugin = mod.default ?? mod.plugin;
+    return plugin?.id && plugin?.name ? plugin : null;
+  } catch (error) {
+    log.error(`Metadata read failed for ${entryFile}: ${error}`);
+    return null;
+  }
+}
+
+export async function collectExternalPluginBundles(): Promise<DesktopExternalPluginBundle[]> {
+  const pluginsDir = getPluginsDir();
+  if (!existsSync(pluginsDir)) return [];
+
+  const outDir = pluginBundleCacheDir(join(pluginsDir, ".cache"));
+  const bundles: DesktopExternalPluginBundle[] = [];
+
+  for (const entry of await readdir(pluginsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
+    const pluginDir = join(pluginsDir, entry.name);
+
+    const entryFile = await resolvePluginEntry(pluginDir);
+    if (!entryFile) continue;
+
+    linkHostPackages(pluginDir);
+
+    const plugin = await readPluginMetadata(entryFile);
+    const base = {
+      id: plugin?.id ?? entry.name,
+      name: plugin?.name ?? entry.name,
+      version: plugin?.version ?? "0.0.0",
+      path: pluginDir,
+      ...(plugin?.targets ? { targets: plugin.targets } : {}),
+    };
+
+    if (!plugin) {
+      bundles.push({ ...base, error: "Plugin did not export a valid GloomPlugin." });
+      continue;
+    }
+
+    // Skip compiling something the desktop cannot run anyway; the marketplace
+    // still lists it, explaining why it is inert.
+    if (plugin.targets && !plugin.targets.includes("desktop")) {
+      bundles.push({ ...base, error: `${plugin.name} does not support the desktop app.` });
+      continue;
+    }
+
+    try {
+      const mtimeMs = await newestMtime(pluginDir);
+      const cached = bundleCache.get(pluginDir);
+      if (cached && cached.mtimeMs === mtimeMs) {
+        bundles.push({ ...base, code: cached.code });
+        continue;
+      }
+
+      const result = await bundleExternalPlugin(pluginDir, join(outDir, entry.name));
+      const code = await Bun.file(result.outputPath).text();
+      bundleCache.set(pluginDir, { mtimeMs, code });
+      log.info(`Bundled ${plugin.id} (${Math.round(code.length / 1024)}KB, shared: ${result.shared.join(", ")})`);
+      bundles.push({ ...base, code });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.error(`Bundling ${plugin.id} failed: ${message}`);
+      bundles.push({ ...base, error: message });
+    }
+  }
+
+  return bundles;
+}

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -37,6 +37,7 @@ import {
 } from "./window/frame";
 import { MAIN_WINDOW_RPC_KEY } from "./window/focus";
 import { handleHttpFetch } from "./desktop/http-fetch";
+import { collectExternalPluginBundles } from "./external-plugins";
 import { handleDesktopPluginStateRequest } from "./desktop/plugin-state";
 import { scheduleDesktopRelaunch } from "./desktop/relaunch";
 import {
@@ -468,6 +469,8 @@ async function handleBackendRequest(
     case "pluginState.setMany":
     case "pluginState.delete":
       return handleDesktopPluginStateRequest(requireServices().persistence.pluginState, request);
+    case "plugins.listExternal":
+      return collectExternalPluginBundles();
     case "host.restart":
     case "host.exit":
     case "host.windowControl":

--- a/src/renderers/electrobun/shared/protocol.ts
+++ b/src/renderers/electrobun/shared/protocol.ts
@@ -83,6 +83,25 @@ export interface DesktopCapabilitySubscribeRequest extends DesktopCapabilityInvo
   subscriptionId: string;
 }
 
+/**
+ * One external plugin, compiled for the view.
+ *
+ * The Bun process owns the filesystem, so it reads and bundles the plugin and
+ * hands the view executable module text. `error` is carried rather than thrown
+ * so a single broken plugin surfaces in the marketplace instead of taking down
+ * the renderer.
+ */
+export interface DesktopExternalPluginBundle {
+  id: string;
+  name: string;
+  version: string;
+  path: string;
+  /** ES module source, absent when `error` is set. */
+  code?: string;
+  targets?: readonly ("cli" | "tui" | "desktop" | "web")[];
+  error?: string;
+}
+
 export interface DesktopBackendRequestMap {
   init: {
     request: { kind?: "main" | "detached"; paneId?: string };
@@ -111,6 +130,7 @@ export interface DesktopBackendRequestMap {
   "pluginState.set": { request: DesktopPluginStateSetEntry; response: null };
   "pluginState.setMany": { request: { entries: DesktopPluginStateSetEntry[] }; response: null };
   "pluginState.delete": { request: { pluginId: string; key: string }; response: null };
+  "plugins.listExternal": { request: null; response: DesktopExternalPluginBundle[] };
   "host.restart": { request: DesktopRestartMessage; response: null };
   "host.exit": { request: null; response: null };
   "host.windowControl": { request: { action: DesktopWindowControlAction }; response: null };

--- a/src/renderers/electrobun/view/external-plugins.test.ts
+++ b/src/renderers/electrobun/view/external-plugins.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import { loadDesktopExternalPlugins } from "./external-plugins";
+import type { DesktopExternalPluginBundle } from "../shared/protocol";
+
+/**
+ * The guarantee under test is containment: a plugin that fails to compile, ships
+ * no bundle, or exports the wrong shape must surface as a broken entry the
+ * marketplace can explain, never as an exception that stops the desktop app from
+ * starting. Every case here is one a user can hit by installing a bad plugin.
+ */
+function bundle(overrides: Partial<DesktopExternalPluginBundle>): DesktopExternalPluginBundle {
+  return { id: "x", name: "X", version: "1.0.0", path: "/tmp/x", ...overrides };
+}
+
+describe("loadDesktopExternalPlugins", () => {
+  test("does nothing when there is nothing to load", async () => {
+    expect(await loadDesktopExternalPlugins([])).toEqual([]);
+  });
+
+  test("carries a compile error through instead of throwing", async () => {
+    const [entry] = await loadDesktopExternalPlugins([
+      bundle({ id: "broken", error: "Could not resolve ./nope" }),
+    ]);
+
+    expect(entry?.error).toBe("Could not resolve ./nope");
+    expect(entry?.plugin.id).toBe("broken");
+  });
+
+  test("reports a bundle that arrived without code", async () => {
+    const [entry] = await loadDesktopExternalPlugins([bundle({ id: "empty" })]);
+
+    expect(entry?.error).toContain("no bundle");
+  });
+
+  test("keeps loading the rest after one plugin fails", async () => {
+    const entries = await loadDesktopExternalPlugins([
+      bundle({ id: "first", error: "boom" }),
+      bundle({ id: "second", error: "also boom" }),
+    ]);
+
+    expect(entries.map((entry) => entry.plugin.id)).toEqual(["first", "second"]);
+    expect(entries.every((entry) => entry.error)).toBe(true);
+  });
+});

--- a/src/renderers/electrobun/view/external-plugins.ts
+++ b/src/renderers/electrobun/view/external-plugins.ts
@@ -1,0 +1,63 @@
+import type { DesktopExternalPluginBundle } from "../shared/protocol";
+import { installPluginHostModules } from "../../../plugins/host-modules";
+import type { LoadedExternalPlugin } from "../../../plugins/loader";
+import type { GloomPlugin } from "../../../types/plugin";
+import { debugLog } from "../../../utils/debug-log";
+
+const log = debugLog.createLogger("desktop-plugins");
+
+/**
+ * Evaluates the plugin bundles the Bun process compiled for this view.
+ *
+ * The host's shared modules have to be published before any bundle is imported:
+ * a compiled plugin's `react` and `gloomberb/*` imports read from that registry
+ * rather than carrying their own copies (see `plugins/bundle.ts`).
+ *
+ * Bundles are imported from blob URLs. The desktop view has no origin to fetch
+ * from and no filesystem, and writing them to a served directory would mean
+ * managing a cache the renderer cannot clean up reliably.
+ */
+export async function loadDesktopExternalPlugins(
+  bundles: readonly DesktopExternalPluginBundle[],
+): Promise<LoadedExternalPlugin[]> {
+  if (bundles.length === 0) return [];
+
+  await installPluginHostModules();
+
+  const loaded: LoadedExternalPlugin[] = [];
+
+  for (const bundle of bundles) {
+    const fallback = {
+      plugin: { id: bundle.id, name: bundle.name, version: bundle.version } as GloomPlugin,
+      path: bundle.path,
+    };
+
+    if (bundle.error || !bundle.code) {
+      loaded.push({ ...fallback, error: bundle.error ?? "Plugin produced no bundle." });
+      continue;
+    }
+
+    let objectUrl: string | null = null;
+    try {
+      objectUrl = URL.createObjectURL(new Blob([bundle.code], { type: "text/javascript" }));
+      const mod = await import(/* @vite-ignore */ objectUrl);
+      const plugin: GloomPlugin = mod.default ?? mod.plugin;
+      if (!plugin?.id || !plugin?.name) {
+        loaded.push({ ...fallback, error: "Bundle did not export a valid GloomPlugin." });
+        continue;
+      }
+      log.info(`Loaded external plugin: ${plugin.id} v${plugin.version ?? "0.0.0"}`);
+      loaded.push({ plugin, path: bundle.path });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.error(`Evaluating ${bundle.id} failed: ${message}`);
+      loaded.push({ ...fallback, error: message });
+    } finally {
+      // The module graph keeps its own reference once imported, so the URL can
+      // be released immediately; leaving it would leak for the session.
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    }
+  }
+
+  return loaded;
+}

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -31,7 +31,8 @@ import { createDesktopDeepLinkBridge } from "./desktop-deeplink-bridge";
 import { createDesktopWindowBridge } from "./desktop/window/bridge";
 import { prepareDetachedSnapshot } from "./desktop/window/snapshot";
 import { createElectrobunAppServices } from "./app-services";
-import { getRendererBuiltinPlugins } from "../../../plugins/catalog-ui";
+import { getRendererPlugins } from "../../../plugins/catalog-ui";
+import { loadDesktopExternalPlugins } from "./external-plugins";
 
 // Declared here rather than sniffed: the desktop view and the hosted browser
 // app are both browser contexts but differ in what plugins may do.
@@ -105,6 +106,21 @@ async function boot() {
   const desktopApplicationMenuBridge = createApplicationMenuBridge();
   const desktopDeepLinkBridge = createDesktopDeepLinkBridge();
   const webUiHost = createWebUiHost(init.desktopPlatform);
+  // Compiled by the Bun process, which owns the filesystem. A failure here must
+  // not stop the app from starting: the marketplace reports broken plugins, and
+  // the built-in catalog is enough to run on.
+  const externalPlugins = await measurePerfAsync(
+    "startup.electrobun.load-external-plugins",
+    async () => {
+      try {
+        return await loadDesktopExternalPlugins(await backendRequest("plugins.listExternal"));
+      } catch (error) {
+        debugLog.createLogger("desktop-plugins").error(`External plugin load failed: ${error}`);
+        return [];
+      }
+    },
+  );
+
   const remoteControlAdapter = init.windowKind === "main"
     ? { registerHandler: setElectrobunRemoteRequestHandler }
     : undefined;
@@ -118,7 +134,8 @@ async function boot() {
                 <App
                   config={config}
                   servicesFactory={createElectrobunAppServices}
-                  plugins={getRendererBuiltinPlugins()}
+                  externalPlugins={externalPlugins}
+                  plugins={getRendererPlugins(externalPlugins)}
                   desktopWindowBridge={desktopWindowBridge}
                   desktopApplicationMenuBridge={desktopApplicationMenuBridge}
                   desktopDeepLinkBridge={desktopDeepLinkBridge}


### PR DESCRIPTION
Closes the gap that made the extractions unsafe: `catalog-ui.ts` returned built-ins only, so a plugin installed with `gloomberb install` worked in the terminal and silently did nothing on the desktop.

The Bun process owns the filesystem, so it does both halves — imports each plugin natively for its metadata, and compiles it with the bundler from #667 into a module the view can evaluate. Bundles cache against the newest mtime in the plugin directory; recompiling every plugin on every window open is visible at startup.

The view publishes the host's shared modules, then imports each bundle from a blob URL. It has no origin to fetch from and no filesystem to serve one.

Containment is the property worth checking: a plugin that fails to compile, ships no bundle, or exports the wrong shape becomes a broken entry the marketplace explains, never an exception that stops the app booting. That is what the new tests cover.

One subtlety worth calling out: renderer plugin assembly goes through a new `getRendererPlugins` rather than `getLoadablePlugins`. The latter is the CLI catalog and also carries the Yahoo fallback provider and the debug plugin, so routing the desktop through it would have quietly changed which plugins the app runs.

Desktop view build succeeds; full suite green.