### PR TITLE
Run plugin restore on the path the app actually starts from

### DIFF
--- a/src/cli/entry.ts
+++ b/src/cli/entry.ts
@@ -1,7 +1,6 @@
 import { dispatchCli } from "./index";
 import { fail, inferCliErrorOptions, printCliError } from "./errors";
 import { loadExternalPlugins } from "../plugins/loader";
-import { restoreExtractedPlugins } from "./restore-plugins";
 import type { CliLaunchRequest } from "../types/plugin";
 import {
   OPEN_TUI_NATIVE_SMOKE_COMMAND,
@@ -36,10 +35,6 @@ export async function runCliEntrypoint(rawArgs = process.argv.slice(2)): Promise
     await smokeOpenTuiRuntime();
     process.exit(0);
   }
-
-  // Restores plugins that used to ship inside Gloomberb, before the catalog is
-  // read, so an upgrade does not silently drop a feature the user was relying on.
-  await restoreExtractedPlugins();
 
   const externalPlugins = await loadExternalPlugins();
 

--- a/src/renderers/opentui/start.tsx
+++ b/src/renderers/opentui/start.tsx
@@ -6,6 +6,7 @@ import { getDataDir, initDataDir, setConfigStoreHost } from "../../data/config/s
 import { applyLanguageFromConfig } from "../../i18n";
 import * as nodeConfigStoreHost from "../../data/config/store/node";
 import { loadExternalPlugins } from "../../plugins/loader";
+import { restoreExtractedPlugins } from "../../cli/restore-plugins";
 import { setCurrentPluginTarget } from "../../plugins/current-target";
 import { getLoadablePlugins } from "../../plugins/catalog";
 import { OpenTuiInputHostProvider } from "./input-host";
@@ -78,6 +79,14 @@ export async function startOpenTuiApp(options: StartOpenTuiAppOptions = {}): Pro
   };
 
   const cliArgs = options.cliArgs ?? process.argv.slice(2);
+  // Before the catalog is read, so a plugin that moved out of this repository is
+  // available in the same session rather than only after a restart. Placed here
+  // rather than in the CLI entry because `src/index.tsx` starts the app directly
+  // and would otherwise skip it.
+  if (!options.externalPlugins) {
+    await measurePerfAsync("startup.opentui.restore-plugins", restoreExtractedPlugins);
+  }
+
   const externalPlugins = options.externalPlugins ?? await measurePerfAsync("startup.opentui.load-external-plugins", () => loadExternalPlugins("tui"));
   let cliLaunchRequest = options.cliLaunchRequest ?? null;
   if (!options.skipCliDispatch && cliArgs.length > 0) {


### PR DESCRIPTION
Follow-up to #670. The seeding hook was in `src/cli/entry.ts`, but `src/index.tsx` calls `startOpenTuiApp` directly — so the migration that restores Substack never ran for anyone starting the app normally. Extracting a plugin without this working is exactly the silent feature loss the seeding was meant to prevent.

Moved into `startOpenTuiApp`, which both entry points reach.

Verified with a config carried over from a previous version: the plugin is fetched during startup and shows as **enabled** in `PL` in the same session, with the directory present on disk. A genuinely fresh install still restores nothing, since there is nothing to migrate — a new user sees Substack under Browse like any other plugin.