### PR TITLE
Fix the desktop view crashing on load

### DIFF
--- a/src/architecture/browser-entry-graph.test.ts
+++ b/src/architecture/browser-entry-graph.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "fs";
+import { dirname, join, relative, resolve } from "path";
+
+const SOURCE_ROOT = process.cwd();
+const IMPORT_PATTERN = /\b(?:import|export)\s+(?:[^'"]*?\s+from\s+)?["']([^"']+)["']|import\(["']([^"']+)["']\)/g;
+const TYPE_ONLY_PATTERN = /\b(?:import|export)\s+type\s/;
+
+/**
+ * Entry points that run in a browser context: the Electrobun desktop view and
+ * the hosted web app. Neither has `process`, a filesystem, or a Bun runtime.
+ */
+const BROWSER_ENTRIES = [
+  "src/renderers/electrobun/view/main.tsx",
+  "src/renderers/browser/main.tsx",
+];
+
+/**
+ * Modules that only work under Bun. Each reads the filesystem or the process
+ * environment at module scope, so merely importing one from a browser bundle
+ * throws on load — the bundle still builds, which is exactly what makes this
+ * worth a test.
+ *
+ * `plugins/loader` reaching the desktop view through `plugins/bundle` shipped a
+ * broken desktop build: the view crashed with "Can't find variable: process"
+ * before rendering anything, while `desktop:view:build` reported success.
+ */
+const BUN_ONLY_MODULES = [
+  "src/plugins/loader.ts",
+  "src/plugins/bundle.ts",
+  "src/plugins/seed.ts",
+  "src/plugins/host-link.ts",
+  "src/cli/restore-plugins.ts",
+];
+
+const EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"];
+
+function resolveSpecifier(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith(".")) return null;
+  const base = resolve(dirname(fromFile), specifier);
+  for (const candidate of [base, ...EXTENSIONS.map((ext) => `${base}${ext}`), ...EXTENSIONS.map((ext) => join(base, `index${ext}`))]) {
+    if (existsSync(candidate) && !candidate.endsWith("/")) {
+      try {
+        if (Bun.file(candidate).size >= 0 && !candidate.match(/\/$/)) return candidate;
+      } catch {
+        // Directory or unreadable entry: keep trying the other candidates.
+      }
+    }
+  }
+  return null;
+}
+
+/** Walks runtime imports only; `import type` is erased and cannot pull code in. */
+async function reachableFrom(entry: string): Promise<Map<string, string[]>> {
+  const seen = new Map<string, string[]>();
+  const queue: Array<{ file: string; path: string[] }> = [{ file: resolve(SOURCE_ROOT, entry), path: [entry] }];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const key = relative(SOURCE_ROOT, current.file);
+    if (seen.has(key)) continue;
+    seen.set(key, current.path);
+
+    let source: string;
+    try {
+      source = await Bun.file(current.file).text();
+    } catch {
+      continue;
+    }
+
+    for (const line of source.split("\n")) {
+      if (TYPE_ONLY_PATTERN.test(line)) continue;
+      for (const match of line.matchAll(IMPORT_PATTERN)) {
+        const specifier = match[1] ?? match[2] ?? "";
+        const resolved = resolveSpecifier(current.file, specifier);
+        if (resolved) queue.push({ file: resolved, path: [...current.path, relative(SOURCE_ROOT, resolved)] });
+      }
+    }
+  }
+
+  return seen;
+}
+
+describe("browser entry import graph", () => {
+  for (const entry of BROWSER_ENTRIES) {
+    test(`${entry} does not reach a Bun-only module`, async () => {
+      const reachable = await reachableFrom(entry);
+
+      const violations = BUN_ONLY_MODULES
+        .filter((module) => reachable.has(module))
+        .map((module) => `${module} via ${reachable.get(module)!.slice(-3).join(" -> ")}`);
+
+      expect(violations).toEqual([]);
+    });
+  }
+});

--- a/src/plugins/bundle.test.ts
+++ b/src/plugins/bundle.test.ts
@@ -3,11 +3,8 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import {
-  bundleExternalPlugin,
-  buildSharedModuleSource,
-  PLUGIN_HOST_GLOBAL,
-} from "./bundle";
+import { bundleExternalPlugin, buildSharedModuleSource } from "./bundle";
+import { PLUGIN_HOST_GLOBAL } from "./host-contract";
 
 /**
  * This is the seam that lets a plugin on disk run inside the desktop and

--- a/src/plugins/bundle.ts
+++ b/src/plugins/bundle.ts
@@ -2,6 +2,7 @@ import { mkdir } from "fs/promises";
 import { join } from "path";
 
 import { resolvePluginEntry } from "./loader";
+import { PLUGIN_HOST_GLOBAL, SHARED_SPECIFIERS } from "./host-contract";
 
 /**
  * Compiles an external plugin for a renderer that cannot read the filesystem.
@@ -20,32 +21,7 @@ import { resolvePluginEntry } from "./loader";
  * host is symlinked in.
  */
 
-export const PLUGIN_HOST_GLOBAL = "__GLOOM_PLUGIN_HOST__";
 
-/**
- * Specifiers a plugin may import that must resolve to the host's copy. Anything
- * else is a plugin's own dependency and gets bundled normally.
- *
- * Deliberately no `react-dom`: it is a renderer package, and plugins are
- * required to be renderer-neutral so the same code runs in the terminal. A
- * plugin reaching for it should fail to bundle rather than quietly work on the
- * desktop and break in the TUI.
- */
-export const SHARED_SPECIFIERS = [
-  "react",
-  "react/jsx-runtime",
-  "react/jsx-dev-runtime",
-  "gloomberb/types/plugin",
-  "gloomberb/types/persistence",
-  "gloomberb/ui",
-  "gloomberb/components",
-  "gloomberb/theme",
-  "gloomberb/capabilities",
-  "gloomberb/utils",
-  "gloomberb/react",
-] as const;
-
-export type SharedSpecifier = (typeof SHARED_SPECIFIERS)[number];
 
 /**
  * Source for a module that re-exports one shared specifier from the host

--- a/src/plugins/host-contract.ts
+++ b/src/plugins/host-contract.ts
@@ -1,0 +1,37 @@
+/**
+ * The contract shared between the plugin bundler and the renderers that load
+ * its output.
+ *
+ * Kept in its own module with no imports on purpose. The bundler runs in Bun
+ * and reaches the filesystem; the renderers that consume it are browser
+ * contexts. Pulling these two constants from `bundle.ts` dragged the whole
+ * bundler — and through it `plugins/loader.ts`, which reads `process.env.HOME`
+ * at module scope — into the desktop view, where it threw on load.
+ */
+
+export const PLUGIN_HOST_GLOBAL = "__GLOOM_PLUGIN_HOST__";
+
+/**
+ * Specifiers a plugin may import that must resolve to the host's copy. Anything
+ * else is a plugin's own dependency and gets bundled normally.
+ *
+ * Deliberately no `react-dom`: it is a renderer package, and plugins are
+ * required to be renderer-neutral so the same code runs in the terminal. A
+ * plugin reaching for it should fail to bundle rather than quietly work on the
+ * desktop and break in the TUI.
+ */
+export const SHARED_SPECIFIERS = [
+  "react",
+  "react/jsx-runtime",
+  "react/jsx-dev-runtime",
+  "gloomberb/types/plugin",
+  "gloomberb/types/persistence",
+  "gloomberb/ui",
+  "gloomberb/components",
+  "gloomberb/theme",
+  "gloomberb/capabilities",
+  "gloomberb/utils",
+  "gloomberb/react",
+] as const;
+
+export type SharedSpecifier = (typeof SHARED_SPECIFIERS)[number];

--- a/src/plugins/host-modules.ts
+++ b/src/plugins/host-modules.ts
@@ -1,4 +1,4 @@
-import { PLUGIN_HOST_GLOBAL, SHARED_SPECIFIERS } from "./bundle";
+import { PLUGIN_HOST_GLOBAL, SHARED_SPECIFIERS } from "./host-contract";
 
 /**
  * Publishes the host's shared modules for compiled plugin bundles to read.


### PR DESCRIPTION
The desktop app died on startup with `Can't find variable: process`. My bug, from #669.

The chain: `view/external-plugins.ts` → `plugins/host-modules.ts` → `plugins/bundle.ts` → `plugins/loader.ts`, which evaluates `process.env.HOME` at module scope. In a browser context that throws before anything renders.

`host-modules.ts` only wanted two constants from the bundler. They are the contract between the bundler and the renderers that load its output, so they move to `plugins/host-contract.ts`, which imports nothing. The mechanism is otherwise unchanged.

**The part worth fixing properly.** `desktop:view:build` reported success throughout — bundling Node code for a browser is legal, it just explodes at runtime, so nothing in CI could see it. This adds a transitive import-graph walk from both browser entry points asserting neither reaches a Bun-only module. The existing `import-boundaries` test only inspects direct imports, which is exactly why a three-hop chain got through.

Verified the new test fails on the old code, reporting the precise chain. And verified against a real desktop build this time, not just a successful bundle: the app starts clean, and its Bun process compiled an installed plugin to a 22KB bundle in the cache.