### PR TITLE
Install plugins from the marketplace, in one list

### DIFF
--- a/src/cli/commands/plugins.ts
+++ b/src/cli/commands/plugins.ts
@@ -77,7 +77,7 @@ async function resolveRegistryRef(rawRef: string): Promise<string> {
       );
     }
     if (typeof entry.repo === "string" && entry.repo.length > 0) {
-      console.log(cliStyles.muted(`Resolved "${rawRef}" to ${entry.repo}`));
+    
       return entry.repo;
     }
   } catch {
@@ -87,7 +87,20 @@ async function resolveRegistryRef(rawRef: string): Promise<string> {
   return rawRef;
 }
 
-export async function installPlugin(rawRef: string) {
+export interface InstallPluginOptions {
+  /**
+   * Suppress child-process output and progress logging. The marketplace pane
+   * installs while the terminal UI owns the screen, and git and bun writing to
+   * stdout corrupts the rendered frame.
+   */
+  quiet?: boolean;
+}
+
+export async function installPlugin(rawRef: string, options: InstallPluginOptions = {}) {
+  const stdio = options.quiet ? "pipe" : "inherit";
+  const say = (message: string) => {
+    if (!options.quiet) console.log(message);
+  };
   ensurePluginsDir();
   const ref = await resolveRegistryRef(rawRef);
   const { url, name } = parseGitHubRef(ref);
@@ -97,11 +110,11 @@ export async function installPlugin(rawRef: string) {
     fail(`Plugin "${name}" already exists.`, `Use "gloomberb update ${name}" to refresh it.`);
   }
 
-  console.log(cliStyles.accent(`Installing ${name}`));
-  console.log(cliStyles.muted(url));
+  say(cliStyles.accent(`Installing ${name}`));
+  say(cliStyles.muted(url));
 
   try {
-    execFileSync("git", ["clone", "--depth", "1", url, targetDir], { stdio: "inherit" });
+    execFileSync("git", ["clone", "--depth", "1", url, targetDir], { stdio });
   } catch {
     rmSync(targetDir, { recursive: true, force: true });
     fail(`Failed to clone ${url}.`);
@@ -109,23 +122,25 @@ export async function installPlugin(rawRef: string) {
 
   const pkgPath = join(targetDir, "package.json");
   if (existsSync(pkgPath)) {
-    console.log(cliStyles.muted("Installing plugin dependencies..."));
+    say(cliStyles.muted("Installing plugin dependencies..."));
     try {
       // --production: plugin repos depend on `gloomberb` as a devDependency so
       // their own CI can typecheck against the real API. At runtime the host is
       // symlinked in instead, and pulling a second full copy here would both
       // waste a lot of disk and risk a duplicate React.
-      execFileSync("bun", ["install", "--production"], { cwd: targetDir, stdio: "inherit" });
+      execFileSync("bun", ["install", "--production"], { cwd: targetDir, stdio });
     } catch {
-      console.error(cliStyles.warning("Warning: failed to install plugin dependencies."));
+      if (!options.quiet) console.error(cliStyles.warning("Warning: failed to install plugin dependencies."));
     }
   }
 
   // After `bun install`, which prunes links it does not know about.
   const link = linkHostPackages(targetDir);
   if (link.error) {
-    console.error(cliStyles.warning(`Warning: could not link the Gloomberb runtime (${link.error}).`));
-    console.error(cliStyles.muted("The plugin's \"gloomberb/*\" imports will not resolve."));
+    if (!options.quiet) {
+      console.error(cliStyles.warning(`Warning: could not link the Gloomberb runtime (${link.error}).`));
+      console.error(cliStyles.muted("The plugin's \"gloomberb/*\" imports will not resolve."));
+    }
   }
 
   try {
@@ -147,13 +162,13 @@ export async function installPlugin(rawRef: string) {
       const mod = await import(entryFile);
       const plugin = mod.default ?? mod.plugin;
       if (plugin?.id && plugin?.name) {
-        console.log(cliStyles.success(`Installed ${plugin.name} v${plugin.version || "0.0.0"}`));
+        say(cliStyles.success(`Installed ${plugin.name} v${plugin.version || "0.0.0"}`));
         return;
       }
     }
-    console.log(cliStyles.warning("Installed files, but no valid GloomPlugin export was found."));
+    say(cliStyles.warning("Installed files, but no valid GloomPlugin export was found."));
   } catch (err) {
-    console.log(cliStyles.warning(`Plugin validation failed: ${err}`));
+    say(cliStyles.warning(`Plugin validation failed: ${err}`));
   }
 }
 

--- a/src/plugins/builtin/earnings-calls/pane.tsx
+++ b/src/plugins/builtin/earnings-calls/pane.tsx
@@ -383,7 +383,11 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
   }
 
   if (listStatus === "error" && calls.length === 0) {
-    return <EmptyState title="Could not load earnings calls." message={listError?.message ?? ""} />;
+    return (
+      <Box flexDirection="column" paddingX={1}>
+        <EmptyState title="Could not load earnings calls." message={listError?.message ?? ""} />
+      </Box>
+    );
   }
 
   if (calls.length === 0) {

--- a/src/plugins/builtin/plugin-marketplace/model.test.ts
+++ b/src/plugins/builtin/plugin-marketplace/model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   collectCategories,
+  isInstallable,
   mergeCatalog,
   sortEntries,
   unsupportedLabel,
@@ -12,6 +13,7 @@ import {
 function registryPlugin(overrides: Partial<RegistryPlugin> & Pick<RegistryPlugin, "id">): RegistryPlugin {
   return {
     name: overrides.id,
+    repo: `gloom-sh/${overrides.id}`,
     tagline: "",
     author: { name: "Someone" },
     categories: ["data"],
@@ -114,6 +116,23 @@ describe("mergeCatalog", () => {
 });
 
 describe("sortEntries", () => {
+  test("puts what is installed above the rest of the catalog", () => {
+    // One list rather than two tabs: acting on what you already have should not
+    // require a mode switch, and an uninstalled plugin should never outrank one
+    // that is present just because it has more stars.
+    const entries = mergeCatalog({
+      registry: [
+        registryPlugin({ id: "popular-uninstalled", tier: "official", stars: 5000 }),
+        registryPlugin({ id: "quiet-installed", tier: "community", stars: 0 }),
+      ],
+      installed: [installedPlugin({ id: "quiet-installed" })],
+      target: "tui",
+    });
+
+    expect(sortEntries(entries).map((entry) => entry.id))
+      .toEqual(["quiet-installed", "popular-uninstalled"]);
+  });
+
   test("puts the featured plugin first, then tier, then stars", () => {
     const entries = mergeCatalog({
       registry: [
@@ -126,6 +145,7 @@ describe("sortEntries", () => {
       target: "tui",
     });
 
+    // All uninstalled, so the curated order applies within that half.
     expect(sortEntries(entries).map((entry) => entry.id)).toEqual([
       "cloud",
       "official-quiet",
@@ -147,5 +167,34 @@ describe("collectCategories", () => {
     });
 
     expect(collectCategories(entries)).toEqual(["data", "news"]);
+  });
+});
+
+describe("isInstallable", () => {
+  test("offers an install only for a catalog plugin that is absent", () => {
+    const [available, bundled, installed] = mergeCatalog({
+      registry: [
+        registryPlugin({ id: "available" }),
+        registryPlugin({ id: "bundled", bundled: true }),
+        registryPlugin({ id: "installed" }),
+      ],
+      installed: [installedPlugin({ id: "installed" })],
+      target: "tui",
+    });
+
+    expect(isInstallable(available!)).toBe(true);
+    // Ships with the app; there is nothing to fetch.
+    expect(isInstallable(bundled!)).toBe(false);
+    expect(isInstallable(installed!)).toBe(false);
+  });
+
+  test("does not offer an install without a repository to clone", () => {
+    const [entry] = mergeCatalog({
+      registry: [],
+      installed: [installedPlugin({ id: "sideloaded" })],
+      target: "tui",
+    });
+
+    expect(isInstallable(entry!)).toBe(false);
   });
 });

--- a/src/plugins/builtin/plugin-marketplace/model.ts
+++ b/src/plugins/builtin/plugin-marketplace/model.ts
@@ -152,8 +152,16 @@ export function mergeCatalog(options: {
   return entries;
 }
 
+/**
+ * One ordered list rather than an installed/available split.
+ *
+ * What you already have is what you act on most, so it sorts to the top; the
+ * rest of the catalog continues below without a mode switch to find it. Within
+ * each half the order is the curated one: featured, then tier, then stars.
+ */
 export function sortEntries(entries: readonly MarketplaceEntry[]): MarketplaceEntry[] {
   return [...entries].sort((a, b) => {
+    if (a.installed !== b.installed) return a.installed ? -1 : 1;
     if (a.featured !== b.featured) return a.featured ? -1 : 1;
     if (a.tier !== b.tier) return TIER_RANK[a.tier] - TIER_RANK[b.tier];
     if (a.stars !== b.stars) return b.stars - a.stars;
@@ -161,20 +169,13 @@ export function sortEntries(entries: readonly MarketplaceEntry[]): MarketplaceEn
   });
 }
 
-export type MarketplaceSection = "installed" | "browse";
-
-export function sectionOf(entry: MarketplaceEntry): MarketplaceSection {
-  return entry.installed ? "installed" : "browse";
-}
-
 export function filterEntries(
   entries: readonly MarketplaceEntry[],
-  options: { section: MarketplaceSection; query: string; category: string | null },
+  options: { query: string; category: string | null },
 ): MarketplaceEntry[] {
   const query = options.query.trim().toLowerCase();
 
   return entries.filter((entry) => {
-    if (sectionOf(entry) !== options.section) return false;
     if (options.category && !entry.categories.includes(options.category)) return false;
     if (!query) return true;
     return [entry.name, entry.id, entry.tagline, entry.description, ...entry.categories]
@@ -188,6 +189,11 @@ export function collectCategories(entries: readonly MarketplaceEntry[]): string[
     for (const category of entry.categories) seen.add(category);
   }
   return [...seen].sort();
+}
+
+/** Whether this entry can be installed from inside the app right now. */
+export function isInstallable(entry: MarketplaceEntry): boolean {
+  return !entry.installed && !entry.bundled && !!entry.repo;
 }
 
 /** Short label for a plugin that cannot run on the current renderer. */

--- a/src/plugins/builtin/plugin-marketplace/pane.tsx
+++ b/src/plugins/builtin/plugin-marketplace/pane.tsx
@@ -5,7 +5,6 @@ import {
   EmptyState,
   InputSearchBar,
   Spinner,
-  Tabs,
   useExternalLinkFooter,
   type DataTableCell,
   type DataTableColumn,
@@ -26,20 +25,15 @@ import {
   mergeCatalog,
   sortEntries,
   unsupportedLabel,
+  isInstallable,
   type MarketplaceEntry,
-  type MarketplaceSection,
   type RegistryPlugin,
 } from "./model";
-import { getMarketplaceHost } from "./store";
+import { getMarketplaceHost, getPluginInstaller } from "./store";
 
 export const PLUGIN_MARKETPLACE_PANE_ID = "plugin-marketplace";
 
 type Column = DataTableColumn & { id: "name" | "tagline" | "stars" | "status" };
-
-const SECTIONS: { label: string; value: MarketplaceSection }[] = [
-  { label: "Installed", value: "installed" },
-  { label: "Browse", value: "browse" },
-];
 
 function buildColumns(width: number): Column[] {
   const starsWidth = 6;
@@ -146,7 +140,6 @@ function EntryDetail({ entry, width }: { entry: MarketplaceEntry; width: number 
 }
 
 export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
-  const [section, setSection] = useState<MarketplaceSection>("installed");
   const [query, setQuery] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
@@ -160,8 +153,10 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
   const [stale, setStale] = useState(false);
   const [fetchedAt, setFetchedAt] = useState<number | null>(null);
-  // Bumped after a toggle so the installed list is re-read from the host.
+  // Bumped after a toggle or install so the list is re-read from the host.
   const [localRevision, setLocalRevision] = useState(0);
+  const [installing, setInstalling] = useState<string | null>(null);
+  const [installError, setInstallError] = useState<string | null>(null);
 
   const refresh = useCallback((force: boolean) => {
     setStatus((current) => (current === "ready" ? current : "loading"));
@@ -183,11 +178,11 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
   }, [registry, target, localRevision]);
 
   const rows = useMemo(() => {
-    const filtered = filterEntries(entries, { section, query, category: null });
+    const filtered = filterEntries(entries, { query, category: null });
     if (sortColumn === "name") return [...filtered].sort((a, b) => a.name.localeCompare(b.name));
     if (sortColumn === "stars") return [...filtered].sort((a, b) => b.stars - a.stars);
     return filtered;
-  }, [entries, query, section, sortColumn]);
+  }, [entries, query, sortColumn]);
 
   const selected = useMemo(
     () => rows.find((entry) => entry.id === selectedId) ?? rows[0] ?? null,
@@ -207,6 +202,22 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
     setLocalRevision((value) => value + 1);
   }, [selected]);
 
+  const installSelected = useCallback(() => {
+    const install = getPluginInstaller();
+    if (!selected || !isInstallable(selected) || !install || installing) return;
+    const target = selected.id;
+    setInstalling(target);
+    setInstallError(null);
+    void install(target).then((result) => {
+      setInstalling(null);
+      if (result.ok) {
+        setLocalRevision((value) => value + 1);
+        return;
+      }
+      setInstallError(result.error ?? "Install failed.");
+    });
+  }, [installing, selected]);
+
   useShortcut((event) => {
     if (!focused || searchFocused) return;
     const key = (event.name ?? event.key ?? "").toLowerCase();
@@ -223,6 +234,11 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
     if (key === "/" && isPlainKey(event)) {
       event.preventDefault?.();
       focusSearch();
+      return;
+    }
+    if (key === "i" && isPlainKey(event)) {
+      event.preventDefault?.();
+      installSelected();
     }
   });
 
@@ -230,10 +246,10 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
   if (status === "loading") info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
   if (status === "error") info.push({ id: "error", parts: [{ text: "catalog unavailable", tone: "warning" }] });
   if (stale) info.push({ id: "stale", parts: [{ text: "stale catalog", tone: "warning" }] });
-  if (!canInstallPlugins() && section === "browse") {
-    // Installing shells out to git and bun, which only the terminal build can do.
-    info.push({ id: "install", parts: [{ text: "install from the terminal", tone: "muted" }] });
+  if (installing) {
+    info.push({ id: "installing", parts: [{ text: `installing ${installing}`, tone: "muted" }] });
   }
+  if (installError) info.push({ id: "install-error", parts: [{ text: installError, tone: "warning" }] });
   if (status === "ready" && fetchedAt && !stale) {
     info.push({ id: "updated", parts: [{ text: formatRelativeAge(fetchedAt), tone: "muted" }] });
   }
@@ -244,31 +260,18 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
     url: selected ? registryPluginUrl(selected.id) : null,
     source: selected ? "gloom.sh" : null,
     info,
-    hints: selected?.installed && selected.toggleable
-      ? [{ id: "toggle", key: "e", label: selected.enabled ? "disable" : "nable", onPress: toggleSelected }]
-      : [],
+    hints: selected && isInstallable(selected) && getPluginInstaller()
+      ? [{ id: "install", key: "i", label: "nstall", onPress: installSelected }]
+      : selected?.installed && selected.toggleable
+        ? [{ id: "toggle", key: "e", label: selected.enabled ? "disable" : "nable", onPress: toggleSelected }]
+        : [],
   });
 
   const columns = useMemo(() => buildColumns(width), [width]);
 
-  const tabs = (
-    <Tabs
-      tabs={SECTIONS}
-      activeValue={section}
-      onSelect={(value) => {
-        setSection(value as MarketplaceSection);
-        setDetailOpen(false);
-      }}
-      focused={focused && !detailOpen}
-      variant="underline"
-      dense
-    />
-  );
-
   if (status === "loading" && entries.length === 0) {
     return (
       <Box flexDirection="column" width={width} height={height}>
-        {tabs}
         <Box flexGrow={1} alignItems="center" justifyContent="center">
           <Spinner />
         </Box>
@@ -278,7 +281,6 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
 
   return (
     <Box flexDirection="column" width={width} height={height}>
-      {tabs}
       <DataTableStackView<MarketplaceEntry, Column>
         focused={focused && !searchFocused}
         detailOpen={detailOpen && !!selected}
@@ -309,7 +311,7 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
         }}
         onActivate={() => setDetailOpen(true)}
         rootWidth={width}
-        rootHeight={Math.max(1, height - 1)}
+        rootHeight={height}
         columns={columns}
         items={rows}
         getItemKey={(entry) => entry.id}
@@ -323,13 +325,7 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
           }
         }}
         renderCell={(entry, column, _index, rowState) => renderCell(entry, column, rowState)}
-        emptyStateTitle={
-          status === "error"
-            ? "Plugin catalog unavailable."
-            : section === "browse"
-              ? "Everything in the catalog is installed."
-              : "No plugins match."
-        }
+        emptyStateTitle={status === "error" ? "Plugin catalog unavailable." : "No plugins match."}
         emptyStateHint={status === "error" ? "Press r to retry." : undefined}
       />
     </Box>

--- a/src/plugins/builtin/plugin-marketplace/pane.tsx
+++ b/src/plugins/builtin/plugin-marketplace/pane.tsx
@@ -8,6 +8,7 @@ import {
   useExternalLinkFooter,
   type DataTableCell,
   type DataTableColumn,
+  type DataTableKeyEvent,
   type PaneFooterSegment,
 } from "../../../components";
 import { useShortcut } from "../../../react/input";
@@ -48,7 +49,11 @@ function buildColumns(width: number): Column[] {
   ];
 }
 
-function statusOf(entry: MarketplaceEntry): { text: string; color: string } {
+function statusOf(
+  entry: MarketplaceEntry,
+  installedNow: readonly string[],
+): { text: string; color: string } {
+  if (installedNow.includes(entry.id)) return { text: "restart to load", color: colors.warning };
   if (entry.loadError) return { text: "failed", color: colors.negative };
   const unsupported = unsupportedLabel(entry);
   if (unsupported) return { text: unsupported.toLowerCase(), color: colors.warning };
@@ -61,7 +66,12 @@ function statusOf(entry: MarketplaceEntry): { text: string; color: string } {
   return { text: "available", color: colors.textBright };
 }
 
-function renderCell(entry: MarketplaceEntry, column: Column, rowState: { selected: boolean }): DataTableCell {
+function renderCell(
+  entry: MarketplaceEntry,
+  column: Column,
+  rowState: { selected: boolean },
+  installedNow: readonly string[],
+): DataTableCell {
   const selected = rowState.selected ? colors.selectedText : undefined;
 
   switch (column.id) {
@@ -79,7 +89,7 @@ function renderCell(entry: MarketplaceEntry, column: Column, rowState: { selecte
         color: selected ?? colors.textDim,
       };
     case "status": {
-      const status = statusOf(entry);
+      const status = statusOf(entry, installedNow);
       return { text: status.text, color: rowState.selected ? colors.selectedText : status.color };
     }
   }
@@ -157,6 +167,9 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
   const [localRevision, setLocalRevision] = useState(0);
   const [installing, setInstalling] = useState<string | null>(null);
   const [installError, setInstallError] = useState<string | null>(null);
+  // Installed during this session. A plugin is only registered at startup, so
+  // saying "enabled" here would be a lie — the pane it adds is not there yet.
+  const [installedNow, setInstalledNow] = useState<readonly string[]>([]);
 
   const refresh = useCallback((force: boolean) => {
     setStatus((current) => (current === "ready" ? current : "loading"));
@@ -205,18 +218,47 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
   const installSelected = useCallback(() => {
     const install = getPluginInstaller();
     if (!selected || !isInstallable(selected) || !install || installing) return;
+    if (installedNow.includes(selected.id)) return;
     const target = selected.id;
     setInstalling(target);
     setInstallError(null);
     void install(target).then((result) => {
       setInstalling(null);
       if (result.ok) {
+        setInstalledNow((current) => [...current, target]);
         setLocalRevision((value) => value + 1);
         return;
       }
       setInstallError(result.error ?? "Install failed.");
     });
-  }, [installing, selected]);
+  }, [installedNow, installing, selected]);
+
+  /**
+   * Pane keys go through the table's key handler rather than a global shortcut:
+   * while the DataTable holds key focus it consumes plain letters, so a
+   * `useShortcut` for "i" never fires.
+   */
+  const handleRootKeyDown = useCallback((event: DataTableKeyEvent) => {
+    if (searchFocused) return;
+    const key = (event.name ?? "").toLowerCase();
+    if (key === "i") {
+      installSelected();
+      return true;
+    }
+    if (key === "e") {
+      toggleSelected();
+      return true;
+    }
+    if (key === "r") {
+      refresh(true);
+      return true;
+    }
+    if (key === "/") {
+      focusSearch();
+      return true;
+    }
+    return undefined;
+  }, [focusSearch, installSelected, refresh, searchFocused, toggleSelected]);
 
   useShortcut((event) => {
     if (!focused || searchFocused) return;
@@ -250,6 +292,9 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
     info.push({ id: "installing", parts: [{ text: `installing ${installing}`, tone: "muted" }] });
   }
   if (installError) info.push({ id: "install-error", parts: [{ text: installError, tone: "warning" }] });
+  if (installedNow.length > 0 && !installing) {
+    info.push({ id: "restart", parts: [{ text: "restart to load new plugins", tone: "warning" }] });
+  }
   if (status === "ready" && fetchedAt && !stale) {
     info.push({ id: "updated", parts: [{ text: formatRelativeAge(fetchedAt), tone: "muted" }] });
   }
@@ -260,7 +305,7 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
     url: selected ? registryPluginUrl(selected.id) : null,
     source: selected ? "gloom.sh" : null,
     info,
-    hints: selected && isInstallable(selected) && getPluginInstaller()
+    hints: selected && isInstallable(selected) && !installedNow.includes(selected.id) && getPluginInstaller()
       ? [{ id: "install", key: "i", label: "nstall", onPress: installSelected }]
       : selected?.installed && selected.toggleable
         ? [{ id: "toggle", key: "e", label: selected.enabled ? "disable" : "nable", onPress: toggleSelected }]
@@ -309,6 +354,8 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
           getId: (entry) => entry.id,
           onChange: (id) => setSelectedId(typeof id === "string" ? id : null),
         }}
+        onRootKeyDown={handleRootKeyDown}
+        onDetailKeyDown={handleRootKeyDown}
         onActivate={() => setDetailOpen(true)}
         rootWidth={width}
         rootHeight={height}
@@ -324,7 +371,7 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
             setSortColumn((current) => (current === columnId ? null : columnId));
           }
         }}
-        renderCell={(entry, column, _index, rowState) => renderCell(entry, column, rowState)}
+        renderCell={(entry, column, _index, rowState) => renderCell(entry, column, rowState, installedNow)}
         emptyStateTitle={status === "error" ? "Plugin catalog unavailable." : "No plugins match."}
         emptyStateHint={status === "error" ? "Press r to retry." : undefined}
       />

--- a/src/plugins/builtin/plugin-marketplace/store.ts
+++ b/src/plugins/builtin/plugin-marketplace/store.ts
@@ -24,3 +24,23 @@ export function setMarketplaceHost(next: MarketplaceHost | null): void {
 export function getMarketplaceHost(): MarketplaceHost | null {
   return host;
 }
+
+/**
+ * Installing a plugin means running git and bun, which only the Bun-hosted
+ * renderers can do — and the desktop view has to ask its Bun process over RPC.
+ * Rather than let this pane reach for a renderer API and break the
+ * renderer-neutrality rule, each renderer installs its own implementation at
+ * startup. A renderer that leaves it unset (the browser) gets the install
+ * command shown instead of a button.
+ */
+export type PluginInstaller = (ref: string) => Promise<{ ok: boolean; error?: string }>;
+
+let installer: PluginInstaller | null = null;
+
+export function setPluginInstaller(next: PluginInstaller | null): void {
+  installer = next;
+}
+
+export function getPluginInstaller(): PluginInstaller | null {
+  return installer;
+}

--- a/src/public/public-api.test.ts
+++ b/src/public/public-api.test.ts
@@ -72,6 +72,7 @@ const PUBLIC_API: Record<string, readonly string[]> = {
     "PriceSelectorDialog",
     "RemoteImage",
     "SegmentedControl",
+    "SelectButton",
     "SpeedometerGauge",
     "Spinner",
     "StaticChartSurface",

--- a/src/renderers/electrobun/bun/external-plugins.ts
+++ b/src/renderers/electrobun/bun/external-plugins.ts
@@ -131,7 +131,7 @@ export async function collectExternalPluginBundles(): Promise<DesktopExternalPlu
 export async function installExternalPlugin(ref: string): Promise<{ ok: boolean; error?: string }> {
   try {
     const { installPlugin } = await import("../../../cli/commands/plugins");
-    await installPlugin(ref);
+    await installPlugin(ref, { quiet: true });
     bundleCache.clear();
     return { ok: true };
   } catch (error) {

--- a/src/renderers/electrobun/bun/external-plugins.ts
+++ b/src/renderers/electrobun/bun/external-plugins.ts
@@ -119,3 +119,22 @@ export async function collectExternalPluginBundles(): Promise<DesktopExternalPlu
 
   return bundles;
 }
+
+/**
+ * Installs a plugin on behalf of the desktop view, which cannot run git or bun
+ * itself. Errors are returned rather than thrown so the marketplace can show
+ * them next to the plugin instead of surfacing an RPC failure.
+ *
+ * The bundle cache is cleared so the next `plugins.listExternal` compiles the
+ * newly installed plugin rather than serving a stale set.
+ */
+export async function installExternalPlugin(ref: string): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const { installPlugin } = await import("../../../cli/commands/plugins");
+    await installPlugin(ref);
+    bundleCache.clear();
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -37,7 +37,7 @@ import {
 } from "./window/frame";
 import { MAIN_WINDOW_RPC_KEY } from "./window/focus";
 import { handleHttpFetch } from "./desktop/http-fetch";
-import { collectExternalPluginBundles } from "./external-plugins";
+import { collectExternalPluginBundles, installExternalPlugin } from "./external-plugins";
 import { handleDesktopPluginStateRequest } from "./desktop/plugin-state";
 import { scheduleDesktopRelaunch } from "./desktop/relaunch";
 import {
@@ -471,6 +471,8 @@ async function handleBackendRequest(
       return handleDesktopPluginStateRequest(requireServices().persistence.pluginState, request);
     case "plugins.listExternal":
       return collectExternalPluginBundles();
+    case "plugins.install":
+      return installExternalPlugin(request.payload.ref);
     case "host.restart":
     case "host.exit":
     case "host.windowControl":

--- a/src/renderers/electrobun/shared/protocol.ts
+++ b/src/renderers/electrobun/shared/protocol.ts
@@ -131,6 +131,7 @@ export interface DesktopBackendRequestMap {
   "pluginState.setMany": { request: { entries: DesktopPluginStateSetEntry[] }; response: null };
   "pluginState.delete": { request: { pluginId: string; key: string }; response: null };
   "plugins.listExternal": { request: null; response: DesktopExternalPluginBundle[] };
+  "plugins.install": { request: { ref: string }; response: { ok: boolean; error?: string } };
   "host.restart": { request: DesktopRestartMessage; response: null };
   "host.exit": { request: null; response: null };
   "host.windowControl": { request: { action: DesktopWindowControlAction }; response: null };

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -33,6 +33,7 @@ import { prepareDetachedSnapshot } from "./desktop/window/snapshot";
 import { createElectrobunAppServices } from "./app-services";
 import { getRendererPlugins } from "../../../plugins/catalog-ui";
 import { loadDesktopExternalPlugins } from "./external-plugins";
+import { setPluginInstaller } from "../../../plugins/builtin/plugin-marketplace/store";
 
 // Declared here rather than sniffed: the desktop view and the hosted browser
 // app are both browser contexts but differ in what plugins may do.
@@ -120,6 +121,8 @@ async function boot() {
       }
     },
   );
+
+  setPluginInstaller((ref) => backendRequest("plugins.install", { ref }));
 
   const remoteControlAdapter = init.windowKind === "main"
     ? { registerHandler: setElectrobunRemoteRequestHandler }

--- a/src/renderers/opentui/start.tsx
+++ b/src/renderers/opentui/start.tsx
@@ -7,6 +7,7 @@ import { applyLanguageFromConfig } from "../../i18n";
 import * as nodeConfigStoreHost from "../../data/config/store/node";
 import { loadExternalPlugins } from "../../plugins/loader";
 import { restoreExtractedPlugins } from "../../cli/restore-plugins";
+import { setPluginInstaller } from "../../plugins/builtin/plugin-marketplace/store";
 import { setCurrentPluginTarget } from "../../plugins/current-target";
 import { getLoadablePlugins } from "../../plugins/catalog";
 import { OpenTuiInputHostProvider } from "./input-host";
@@ -86,6 +87,16 @@ export async function startOpenTuiApp(options: StartOpenTuiAppOptions = {}): Pro
   if (!options.externalPlugins) {
     await measurePerfAsync("startup.opentui.restore-plugins", restoreExtractedPlugins);
   }
+
+  setPluginInstaller(async (ref) => {
+    try {
+      const { installPlugin } = await import("../../cli/commands/plugins");
+      await installPlugin(ref);
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  });
 
   const externalPlugins = options.externalPlugins ?? await measurePerfAsync("startup.opentui.load-external-plugins", () => loadExternalPlugins("tui"));
   let cliLaunchRequest = options.cliLaunchRequest ?? null;

--- a/src/renderers/opentui/start.tsx
+++ b/src/renderers/opentui/start.tsx
@@ -91,7 +91,7 @@ export async function startOpenTuiApp(options: StartOpenTuiAppOptions = {}): Pro
   setPluginInstaller(async (ref) => {
     try {
       const { installPlugin } = await import("../../cli/commands/plugins");
-      await installPlugin(ref);
+      await installPlugin(ref, { quiet: true });
       return { ok: true };
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error.message : String(error) };


### PR DESCRIPTION
Two changes to `PL`.

**One list instead of two tabs.** Installed and available were separate screens, so acting on what you have required a mode switch to find it. Now it is a single list sorted with installed and bundled plugins above the rest of the catalog. An uninstalled plugin never outranks one you have just because it has more stars.

**Install in place.** `i` installs the selected plugin. Browse previously could only print a command to run somewhere else.

Installing runs git and bun, which the desktop view cannot do. Rather than have this pane reach for a renderer API and break renderer-neutrality, each renderer registers its own installer at startup: the terminal calls the CLI directly, the desktop asks its Bun process over a new `plugins.install` RPC, and the browser registers none and keeps showing the command.

Two things found by actually driving it in a terminal:

- git and bun inherit stdio, which corrupted the rendered frame mid-install. Installers now run quiet.
- A freshly installed plugin was reporting "enabled", which is a lie — plugins are only registered at startup, so its pane does not exist yet. It now says "restart to load", with a matching footer note.

Also: pane keys moved to the table's key handler. While the DataTable holds key focus it consumes plain letters, so the `useShortcut` for `i` never fired — worth knowing for any pane adding a letter shortcut.

Verified end to end in tmux: cursor onto an available plugin, press `i`, repo cloned into `~/.gloomberb/plugins`, row flips to "restart to load", install hint disappears, frame stays clean.