### PR TITLE
Decouple the IBKR broker adapter from the Gateway

### DIFF
--- a/src/plugins/ibkr/broker-adapter.ts
+++ b/src/plugins/ibkr/broker-adapter.ts
@@ -10,8 +10,13 @@ import {
 } from "./config";
 import { getIbkrAccountCachePolicy, getIbkrAccountCacheSourceKey } from "./account-cache";
 import { loadFlexStatement, parseFlexAccounts, parseFlexPositions } from "./flex";
-import { ibkrGatewayManager } from "./gateway/service";
-import { refreshGatewayData } from "./gateway/helpers";
+import {
+  GATEWAY_UNAVAILABLE_MESSAGE,
+  gatewayServiceFor,
+  gatewayUnavailableStatus,
+  getIbkrGatewayBridge,
+  requireGatewayBridge,
+} from "./gateway-bridge";
 import { getIbkrPortfolioPerformance } from "./portfolio-performance";
 
 async function importFlexPositions(config: FlexQueryConfig): Promise<BrokerPosition[]> {
@@ -26,16 +31,18 @@ export const ibkrBroker: BrokerAdapter = {
 
   async validate(instance) {
     const normalized = normalizeIbkrConfig(instance.config);
-    return normalized.connectionMode === "gateway"
-      ? isGatewayConfigured(instance.config)
-      : isFlexConfigured(instance.config);
+    if (normalized.connectionMode !== "gateway") return isFlexConfigured(instance.config);
+    // Without the Gateway plugin the profile is well-formed but unusable, so it
+    // fails validation rather than silently importing nothing.
+    return !!getIbkrGatewayBridge() && isGatewayConfigured(instance.config);
   },
 
   async importPositions(instance) {
     const normalized = normalizeIbkrConfig(instance.config);
     if (normalized.connectionMode === "gateway") {
-      await refreshGatewayData(instance);
-      return ibkrGatewayManager.getService(instance.id).getPositions(normalized.gateway);
+      const gateway = requireGatewayBridge();
+      await gateway.refresh(instance);
+      return gateway.getService(instance.id).getPositions(normalized.gateway);
     }
     return importFlexPositions(normalized.flex);
   },
@@ -43,11 +50,11 @@ export const ibkrBroker: BrokerAdapter = {
   async importPortfolioSnapshot(instance) {
     const normalized = normalizeIbkrConfig(instance.config);
     if (normalized.connectionMode === "gateway") {
-      const service = ibkrGatewayManager.getService(instance.id);
-      await refreshGatewayData(instance);
+      const gateway = requireGatewayBridge();
+      await gateway.refresh(instance);
       const [accounts, positions] = await Promise.all([
-        service.getAccounts(normalized.gateway),
-        service.getPositions(normalized.gateway),
+        gateway.getService(instance.id).getAccounts(normalized.gateway),
+        gateway.getService(instance.id).getPositions(normalized.gateway),
       ]);
       return { accounts, positions };
     }
@@ -62,11 +69,11 @@ export const ibkrBroker: BrokerAdapter = {
   async connect(instance) {
     const normalized = normalizeIbkrConfig(instance.config);
     if (normalized.connectionMode !== "gateway") return;
-    await ibkrGatewayManager.getService(instance.id).connect(normalized.gateway);
+    await requireGatewayBridge().getService(instance.id).connect(normalized.gateway);
   },
 
   async disconnect(instance) {
-    await ibkrGatewayManager.removeInstance(instance.id);
+    await getIbkrGatewayBridge()?.removeInstance(instance.id);
   },
 
   getStatus(instance) {
@@ -79,17 +86,21 @@ export const ibkrBroker: BrokerAdapter = {
         updatedAt: 0,
       };
     }
-    return { ...ibkrGatewayManager.getSnapshot(instance.id).status, mode: "gateway" };
+    const gateway = getIbkrGatewayBridge();
+    if (!gateway) return { ...gatewayUnavailableStatus(), mode: "gateway" };
+    return { ...gateway.getStatus(instance.id), mode: "gateway" };
   },
 
   subscribeStatus(instance, listener) {
-    return ibkrGatewayManager.subscribe(instance.id, listener);
+    const gateway = getIbkrGatewayBridge();
+    if (!gateway) return () => {};
+    return gateway.subscribeStatus(instance.id, listener);
   },
 
   getPersistedConfigUpdate(instance) {
     const normalized = normalizeIbkrConfig(instance.config);
     if (normalized.connectionMode !== "gateway") return null;
-    const resolved = ibkrGatewayManager.getService(instance.id).getResolvedConnection();
+    const resolved = gatewayServiceFor(instance.id)?.getResolvedConnection() ?? null;
     return resolved ? buildPersistedIbkrGatewayConfig(instance.config, resolved) : null;
   },
 
@@ -102,8 +113,10 @@ export const ibkrBroker: BrokerAdapter = {
       id: "ibkr-console",
       label: "IBKR Console",
       paneId: "ibkr-trading",
-      disabled: normalized.connectionMode !== "gateway",
-      disabledReason: "IBKR Console is available for Gateway / TWS profiles.",
+      disabled: normalized.connectionMode !== "gateway" || !getIbkrGatewayBridge(),
+      disabledReason: getIbkrGatewayBridge()
+        ? "IBKR Console is available for Gateway / TWS profiles."
+        : GATEWAY_UNAVAILABLE_MESSAGE,
     }];
   },
 
@@ -141,7 +154,7 @@ export const ibkrBroker: BrokerAdapter = {
   async listAccounts(instance) {
     const normalized = normalizeIbkrConfig(instance.config);
     if (normalized.connectionMode === "gateway") {
-      return ibkrGatewayManager.getService(instance.id).getAccounts(normalized.gateway);
+      return requireGatewayBridge().getService(instance.id).getAccounts(normalized.gateway);
     }
     const xml = await loadFlexStatement(normalized.flex);
     return parseFlexAccounts(xml);
@@ -154,7 +167,7 @@ export const ibkrBroker: BrokerAdapter = {
   async searchInstruments(query, instance) {
     const normalized = normalizeIbkrConfig(instance.config);
     if (normalized.connectionMode !== "gateway") return [];
-    return (await ibkrGatewayManager.getService(instance.id).searchInstruments(query, normalized.gateway)).map((result) => ({
+    return (await requireGatewayBridge().getService(instance.id).searchInstruments(query, normalized.gateway)).map((result) => ({
       ...result,
       brokerInstanceId: result.brokerInstanceId ?? instance.id,
       brokerLabel: result.brokerLabel ?? instance.label,
@@ -169,7 +182,7 @@ export const ibkrBroker: BrokerAdapter = {
     if (normalized.connectionMode !== "gateway") {
       throw new Error("Gateway mode is required for broker market data");
     }
-    return ibkrGatewayManager.getService(instance.id).getTickerFinancials(ticker, normalized.gateway, exchange, instrument);
+    return requireGatewayBridge().getService(instance.id).getTickerFinancials(ticker, normalized.gateway, exchange, instrument);
   },
 
   async getQuote(ticker, instance, exchange, instrument) {
@@ -177,7 +190,7 @@ export const ibkrBroker: BrokerAdapter = {
     if (normalized.connectionMode !== "gateway") {
       throw new Error("Gateway mode is required for broker quotes");
     }
-    return ibkrGatewayManager.getService(instance.id).getQuote(ticker, normalized.gateway, exchange, instrument);
+    return requireGatewayBridge().getService(instance.id).getQuote(ticker, normalized.gateway, exchange, instrument);
   },
 
   async getPriceHistory(ticker, instance, exchange, range, instrument) {
@@ -185,7 +198,7 @@ export const ibkrBroker: BrokerAdapter = {
     if (normalized.connectionMode !== "gateway") {
       throw new Error("Gateway mode is required for broker history");
     }
-    return ibkrGatewayManager.getService(instance.id).getPriceHistory(ticker, normalized.gateway, exchange, range, instrument);
+    return requireGatewayBridge().getService(instance.id).getPriceHistory(ticker, normalized.gateway, exchange, range, instrument);
   },
 
   getChartResolutionSupport(ticker, instance, exchange, instrument) {
@@ -193,7 +206,7 @@ export const ibkrBroker: BrokerAdapter = {
     if (normalized.connectionMode !== "gateway") {
       throw new Error("Gateway mode is required for broker history");
     }
-    return ibkrGatewayManager.getService(instance.id).getChartResolutionSupport(
+    return requireGatewayBridge().getService(instance.id).getChartResolutionSupport(
       ticker,
       normalized.gateway,
       exchange,
@@ -206,7 +219,7 @@ export const ibkrBroker: BrokerAdapter = {
     if (normalized.connectionMode !== "gateway") {
       throw new Error("Gateway mode is required for broker history");
     }
-    return ibkrGatewayManager.getService(instance.id).getPriceHistoryForResolution(
+    return requireGatewayBridge().getService(instance.id).getPriceHistoryForResolution(
       ticker,
       normalized.gateway,
       exchange,
@@ -221,7 +234,7 @@ export const ibkrBroker: BrokerAdapter = {
     if (normalized.connectionMode !== "gateway") {
       throw new Error("Gateway mode is required for broker history");
     }
-    return ibkrGatewayManager.getService(instance.id).getDetailedPriceHistory(
+    return requireGatewayBridge().getService(instance.id).getDetailedPriceHistory(
       ticker,
       normalized.gateway,
       exchange,
@@ -237,19 +250,19 @@ export const ibkrBroker: BrokerAdapter = {
     if (normalized.connectionMode !== "gateway") {
       return () => {};
     }
-    return ibkrGatewayManager.getService(instance.id).subscribeQuotes(normalized.gateway, targets, onQuote);
+    return requireGatewayBridge().getService(instance.id).subscribeQuotes(normalized.gateway, targets, onQuote);
   },
 
   async listOpenOrders(instance) {
     const normalized = normalizeIbkrConfig(instance.config);
     if (normalized.connectionMode !== "gateway") return [];
-    return ibkrGatewayManager.getService(instance.id).listOpenOrders(normalized.gateway);
+    return requireGatewayBridge().getService(instance.id).listOpenOrders(normalized.gateway);
   },
 
   async listExecutions(instance) {
     const normalized = normalizeIbkrConfig(instance.config);
     if (normalized.connectionMode !== "gateway") return [];
-    return ibkrGatewayManager.getService(instance.id).listExecutions(normalized.gateway);
+    return requireGatewayBridge().getService(instance.id).listExecutions(normalized.gateway);
   },
 
   async previewOrder(instance, request) {
@@ -257,7 +270,7 @@ export const ibkrBroker: BrokerAdapter = {
     if (normalized.connectionMode !== "gateway") {
       throw new Error("Gateway mode is required for order preview");
     }
-    return ibkrGatewayManager.getService(instance.id).previewOrder(normalized.gateway, request);
+    return requireGatewayBridge().getService(instance.id).previewOrder(normalized.gateway, request);
   },
 
   async placeOrder(instance, request) {
@@ -265,7 +278,7 @@ export const ibkrBroker: BrokerAdapter = {
     if (normalized.connectionMode !== "gateway") {
       throw new Error("Gateway mode is required for trading");
     }
-    return ibkrGatewayManager.getService(instance.id).placeOrder(normalized.gateway, request);
+    return requireGatewayBridge().getService(instance.id).placeOrder(normalized.gateway, request);
   },
 
   async modifyOrder(instance, orderId, request) {
@@ -273,7 +286,7 @@ export const ibkrBroker: BrokerAdapter = {
     if (normalized.connectionMode !== "gateway") {
       throw new Error("Gateway mode is required for trading");
     }
-    return ibkrGatewayManager.getService(instance.id).modifyOrder(normalized.gateway, orderId, request);
+    return requireGatewayBridge().getService(instance.id).modifyOrder(normalized.gateway, orderId, request);
   },
 
   async cancelOrder(instance, orderId) {
@@ -281,6 +294,6 @@ export const ibkrBroker: BrokerAdapter = {
     if (normalized.connectionMode !== "gateway") {
       throw new Error("Gateway mode is required for trading");
     }
-    return ibkrGatewayManager.getService(instance.id).cancelOrder(normalized.gateway, orderId);
+    return requireGatewayBridge().getService(instance.id).cancelOrder(normalized.gateway, orderId);
   },
 };

--- a/src/plugins/ibkr/gateway-bridge.test.ts
+++ b/src/plugins/ibkr/gateway-bridge.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { ibkrBroker } from "./broker-adapter";
+import {
+  GATEWAY_UNAVAILABLE_MESSAGE,
+  setIbkrGatewayBridge,
+  type IbkrGatewayBridge,
+} from "./gateway-bridge";
+import type { BrokerInstanceConfig } from "../../types/config";
+
+/**
+ * Flex and Gateway are one broker with two connection modes, and they are about
+ * to become two plugins. The property that has to hold is that a user with
+ * Gateway uninstalled keeps a working Flex profile and gets a direct explanation
+ * on a Gateway one — not a crash, and not a profile that silently imports
+ * nothing while looking healthy.
+ *
+ * These run against the real adapter with the bridge unset, which is exactly the
+ * state a Flex-only install will be in.
+ */
+
+function instance(config: Record<string, unknown>): BrokerInstanceConfig {
+  return { id: "inst-1", brokerType: "ibkr", label: "IBKR", config } as BrokerInstanceConfig;
+}
+
+const flexProfile = instance({
+  connectionMode: "flex",
+  flex: { token: "t", queryId: "q" },
+  token: "t",
+  queryId: "q",
+});
+
+const gatewayProfile = instance({
+  connectionMode: "gateway",
+  gateway: { host: "127.0.0.1", port: 4001, clientId: 1 },
+  host: "127.0.0.1",
+  port: 4001,
+  clientId: 1,
+});
+
+afterEach(() => {
+  setIbkrGatewayBridge(null);
+});
+
+describe("without the Gateway plugin", () => {
+  test("a Gateway profile fails validation rather than importing nothing", async () => {
+    setIbkrGatewayBridge(null);
+
+    expect(await ibkrBroker.validate!(gatewayProfile)).toBe(false);
+  });
+
+  test("a Flex profile still validates", async () => {
+    setIbkrGatewayBridge(null);
+
+    expect(await ibkrBroker.validate!(flexProfile)).toBe(true);
+  });
+
+  test("status explains what is missing instead of reporting disconnected", () => {
+    setIbkrGatewayBridge(null);
+
+    const status = ibkrBroker.getStatus!(gatewayProfile);
+    expect(status.state).toBe("error");
+    expect(status.message).toBe(GATEWAY_UNAVAILABLE_MESSAGE);
+  });
+
+  test("importing from a Gateway profile throws a directed error", async () => {
+    setIbkrGatewayBridge(null);
+
+    await expect(ibkrBroker.importPositions!(gatewayProfile))
+      .rejects.toThrow(GATEWAY_UNAVAILABLE_MESSAGE);
+  });
+
+  test("disconnect and status subscription stay safe no-ops", async () => {
+    setIbkrGatewayBridge(null);
+
+    await ibkrBroker.disconnect!(gatewayProfile);
+    const unsubscribe = ibkrBroker.subscribeStatus!(gatewayProfile, () => {});
+    expect(typeof unsubscribe).toBe("function");
+    unsubscribe();
+  });
+
+  test("the console profile action is disabled with the reason", () => {
+    setIbkrGatewayBridge(null);
+
+    const [action] = ibkrBroker.getProfileActions!(gatewayProfile);
+    expect(action?.disabled).toBe(true);
+    expect(action?.disabledReason).toBe(GATEWAY_UNAVAILABLE_MESSAGE);
+  });
+});
+
+describe("with the Gateway plugin registered", () => {
+  test("gateway work routes through the bridge", async () => {
+    const calls: string[] = [];
+    const bridge = {
+      refresh: async () => { calls.push("refresh"); },
+      getService: () => ({
+        getPositions: async () => { calls.push("getPositions"); return []; },
+      }),
+      removeInstance: async () => { calls.push("removeInstance"); },
+      getStatus: () => ({ state: "connected", message: "", updatedAt: 1 }),
+      subscribeStatus: () => () => {},
+    } as unknown as IbkrGatewayBridge;
+    setIbkrGatewayBridge(bridge);
+
+    expect(await ibkrBroker.validate!(gatewayProfile)).toBe(true);
+    await ibkrBroker.importPositions!(gatewayProfile);
+    expect(calls).toEqual(["refresh", "getPositions"]);
+    expect(ibkrBroker.getStatus!(gatewayProfile).state).toBe("connected");
+  });
+});

--- a/src/plugins/ibkr/gateway-bridge.ts
+++ b/src/plugins/ibkr/gateway-bridge.ts
@@ -1,0 +1,62 @@
+import type { BrokerConnectionStatus } from "../../types/broker";
+import type { BrokerInstanceConfig } from "../../types/config";
+import type { IbkrGatewayServiceFacade } from "./gateway/service";
+
+/**
+ * The seam between IBKR Flex and IBKR Gateway.
+ *
+ * Flex talks to a hosted HTTPS statement service and runs anywhere. Gateway
+ * opens a raw TCP socket to a local TWS instance, so it can never run in a
+ * browser. They are separate plugins for that reason, but they are one broker:
+ * a user has a single "Interactive Brokers" profile whose `connectionMode`
+ * decides which side services it.
+ *
+ * Splitting them across two broker ids would orphan every saved broker instance
+ * and its stored credentials, so instead the Flex plugin owns the broker id and
+ * Gateway registers itself here when installed. With no Gateway plugin present,
+ * a Gateway-mode profile reports why it is inert rather than failing obscurely.
+ *
+ * The bridge hands back the gateway service rather than mirroring its ~20
+ * methods: the adapter's gateway calls stay exactly as they were, and the two
+ * plugins share one type instead of a hand-copied interface that drifts.
+ */
+
+export interface IbkrGatewayBridge {
+  refresh(instance: BrokerInstanceConfig): Promise<void>;
+  getService(instanceId: string): IbkrGatewayServiceFacade;
+  removeInstance(instanceId: string): Promise<void>;
+  getStatus(instanceId: string): BrokerConnectionStatus;
+  subscribeStatus(instanceId: string, listener: () => void): () => void;
+}
+
+let bridge: IbkrGatewayBridge | null = null;
+
+export function setIbkrGatewayBridge(next: IbkrGatewayBridge | null): void {
+  bridge = next;
+}
+
+export function getIbkrGatewayBridge(): IbkrGatewayBridge | null {
+  return bridge;
+}
+
+export const GATEWAY_UNAVAILABLE_MESSAGE =
+  "Install the IBKR Gateway plugin to use a Gateway or TWS profile.";
+
+/** Status shown for a Gateway profile when the Gateway plugin is not installed. */
+export function gatewayUnavailableStatus(): BrokerConnectionStatus {
+  return {
+    state: "error",
+    message: GATEWAY_UNAVAILABLE_MESSAGE,
+    updatedAt: Date.now(),
+  };
+}
+
+export function requireGatewayBridge(): IbkrGatewayBridge {
+  if (!bridge) throw new Error(GATEWAY_UNAVAILABLE_MESSAGE);
+  return bridge;
+}
+
+/** The gateway service for an instance, or `null` when Gateway is not installed. */
+export function gatewayServiceFor(instanceId: string): IbkrGatewayServiceFacade | null {
+  return bridge?.getService(instanceId) ?? null;
+}

--- a/src/plugins/ibkr/gateway/service/index.ts
+++ b/src/plugins/ibkr/gateway/service/index.ts
@@ -22,6 +22,7 @@ import {
   type NativeGatewayModule,
 } from "./native-loader";
 
+export type { IbkrGatewayServiceFacade };
 export type {
   IbkrGatewayConfig,
   ResolvedIbkrGatewayConnection,

--- a/src/plugins/ibkr/index.tsx
+++ b/src/plugins/ibkr/index.tsx
@@ -1,5 +1,7 @@
 import type { GloomPlugin, GloomPluginContext } from "../../types/plugin";
 import { ibkrBroker } from "./broker-adapter";
+import { setIbkrGatewayBridge } from "./gateway-bridge";
+import { refreshGatewayData } from "./gateway/helpers";
 import { buildPersistedIbkrGatewayConfig } from "./config";
 import { ibkrGatewayManager, setResolvedIbkrGatewayListener } from "./gateway/service";
 import {
@@ -62,6 +64,17 @@ export const ibkrPlugin: GloomPlugin = {
 
   setup(ctx) {
     ctx.log.info("IBKR plugin initializing");
+
+    // In-repo both halves ship together, so Gateway registers itself here. Once
+    // Gateway is its own plugin this call moves to its setup, and the Flex
+    // adapter degrades on its own when it is absent.
+    setIbkrGatewayBridge({
+      refresh: refreshGatewayData,
+      getService: (instanceId) => ibkrGatewayManager.getService(instanceId),
+      removeInstance: (instanceId) => ibkrGatewayManager.removeInstance(instanceId),
+      getStatus: (instanceId) => ibkrGatewayManager.getSnapshot(instanceId).status,
+      subscribeStatus: (instanceId, listener) => ibkrGatewayManager.subscribe(instanceId, listener),
+    });
     setResolvedIbkrGatewayListener(async (instanceId, resolved) => {
       if (!instanceId) return;
       const instance = ctx.getConfig().brokerInstances.find((entry) => entry.id === instanceId);


### PR DESCRIPTION
Second step toward splitting IBKR. Flex and Gateway are one broker with two connection modes, but only Gateway opens a TCP socket — so Flex can run where Gateway cannot, and they need to be separate plugins.

They cannot be separate *brokers*: splitting across two broker ids would orphan every saved IBKR profile and its stored Flex token and Gateway settings. So Flex keeps broker id `ibkr`, and the adapter reaches Gateway through a bridge that the Gateway side registers on setup.

The bridge hands back the gateway service rather than mirroring its ~20 market-data and trading methods. The adapter's calls are unchanged, and the two plugins will share one type instead of a hand-copied interface that drifts apart.

**The state worth testing** is a Flex-only install, which is what everyone will have once Gateway is a separate optional plugin. With no bridge registered, a Gateway profile:

- fails validation rather than importing nothing while looking healthy
- reports "Install the IBKR Gateway plugin…" in its connection status instead of "disconnected"
- throws that same message on import
- disables the IBKR Console action with the reason
- leaves disconnect and status subscription as safe no-ops

All six of those are covered against the real adapter.

No behaviour change today — in-repo both halves still ship together, so the bridge is registered in IBKR's own setup. That registration moves to the Gateway plugin when it splits out.

2425 tests, all typecheck targets, desktop view build.