### PR TITLE
Give breaking news notifications scope, sector mutes, and snooze

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -160,6 +160,13 @@ function AppInner({
     renderToast: (notification) => {
       const type = notification.type ?? "info";
       let toastId: string | number | undefined;
+      const dismissAfter = (run: () => void) => () => {
+        try {
+          run();
+        } finally {
+          if (toastId != null) toast.dismiss(toastId);
+        }
+      };
       const options = {
         title: notification.title,
         subtitle: notification.subtitle,
@@ -167,13 +174,13 @@ function AppInner({
         action: notification.action
           ? {
             label: notification.action.label,
-            onClick: () => {
-              try {
-                notification.action?.onClick();
-              } finally {
-                if (toastId != null) toast.dismiss(toastId);
-              }
-            },
+            onClick: dismissAfter(() => notification.action?.onClick()),
+          }
+          : undefined,
+        secondaryAction: notification.secondaryAction
+          ? {
+            label: notification.secondaryAction.label,
+            onClick: dismissAfter(() => notification.secondaryAction?.onClick()),
           }
           : undefined,
       };

--- a/src/plugins/builtin/news/wire/breaking/filters.test.ts
+++ b/src/plugins/builtin/news/wire/breaking/filters.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import type { MarketNewsItem } from "../../../../../types/news-source";
+import {
+  isSectorMuted,
+  parseBreakingScope,
+  parseMutedSectors,
+  selectNotifiableArticles,
+} from "./filters";
+
+function article(overrides: Partial<MarketNewsItem> = {}): MarketNewsItem {
+  return {
+    id: "1",
+    title: "Headline",
+    url: "https://example.com/1",
+    source: "Reuters",
+    publishedAt: new Date("2026-09-01T12:00:00Z"),
+    topic: "general",
+    topics: [],
+    sectors: [],
+    categories: [],
+    tickers: [],
+    scores: { importance: 80, urgency: 80, marketImpact: 80, novelty: 50, confidence: 90 },
+    isBreaking: true,
+    isDeveloping: false,
+    importance: 80,
+    ...overrides,
+  };
+}
+
+const watched = new Set(["AAPL", "MSFT"]);
+
+describe("breaking notification scope", () => {
+  const macro = article({ id: "macro", tickers: [] });
+  const held = article({ id: "held", tickers: ["AAPL"] });
+  const unrelated = article({ id: "unrelated", tickers: ["XOM"] });
+  const all = [macro, held, unrelated];
+
+  const idsFor = (scope: string) =>
+    selectNotifiableArticles(all, {
+      scope: parseBreakingScope(scope),
+      mutedSectors: new Set(),
+      watchedSymbols: watched,
+    }).map((item) => item.id);
+
+  test("watchlist-macro keeps tracked tickers and market-wide stories", () => {
+    expect(idsFor("watchlist-macro")).toEqual(["macro", "held"]);
+  });
+
+  test("watchlist drops market-wide stories", () => {
+    expect(idsFor("watchlist")).toEqual(["held"]);
+  });
+
+  test("macro drops every ticker-linked story", () => {
+    expect(idsFor("macro")).toEqual(["macro"]);
+  });
+
+  test("all keeps everything", () => {
+    expect(idsFor("all")).toEqual(["macro", "held", "unrelated"]);
+  });
+
+  test("unknown or missing scope falls back to watchlist-macro", () => {
+    expect(parseBreakingScope(undefined)).toBe("watchlist-macro");
+    expect(parseBreakingScope("nonsense")).toBe("watchlist-macro");
+  });
+});
+
+describe("muted sectors", () => {
+  const muted = new Set(["health_care"]);
+
+  test("mutes a story confined to a muted sector", () => {
+    expect(isSectorMuted(article({ sectors: ["health_care"] }), muted)).toBe(true);
+  });
+
+  test("keeps a story that also spans an unmuted sector", () => {
+    expect(isSectorMuted(article({ sectors: ["health_care", "energy"] }), muted)).toBe(false);
+  });
+
+  test("keeps stories with no sector attribution", () => {
+    expect(isSectorMuted(article({ sectors: [] }), muted)).toBe(false);
+  });
+
+  test("ignores malformed stored values", () => {
+    expect(parseMutedSectors(undefined).size).toBe(0);
+    expect(parseMutedSectors(["energy", 3, ""]).has("energy")).toBe(true);
+    expect(parseMutedSectors(["energy", 3, ""]).size).toBe(1);
+  });
+});
+
+describe("scope and mute combined", () => {
+  test("a muted sector suppresses an otherwise in-scope watchlist story", () => {
+    const pharma = article({ id: "pharma", tickers: ["AAPL"], sectors: ["health_care"] });
+    const kept = selectNotifiableArticles([pharma], {
+      scope: "watchlist-macro",
+      mutedSectors: new Set(["health_care"]),
+      watchedSymbols: watched,
+    });
+    expect(kept).toEqual([]);
+  });
+});

--- a/src/plugins/builtin/news/wire/breaking/filters.ts
+++ b/src/plugins/builtin/news/wire/breaking/filters.ts
@@ -1,0 +1,110 @@
+import type { MarketNewsItem } from "../../../../../types/news-source";
+import { SECTOR_NEWS_SECTORS, sectorNewsLabel } from "../news/query-presets";
+
+export const BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY = "breakingNewsNotificationsEnabled";
+export const BREAKING_NEWS_SCOPE_KEY = "breakingNewsScope";
+export const BREAKING_NEWS_MUTED_SECTORS_KEY = "breakingNewsMutedSectors";
+
+export const BREAKING_SCOPES = [
+  "watchlist-macro",
+  "watchlist",
+  "macro",
+  "all",
+] as const;
+
+export type BreakingScope = (typeof BREAKING_SCOPES)[number];
+
+export const DEFAULT_BREAKING_SCOPE: BreakingScope = "watchlist-macro";
+
+export const BREAKING_SCOPE_OPTIONS = [
+  {
+    value: "watchlist-macro",
+    label: "Watchlist + macro",
+    description: "Stories about tickers you track, plus market-wide events.",
+  },
+  {
+    value: "watchlist",
+    label: "Watchlist only",
+    description: "Only stories linked to a ticker you watch or hold.",
+  },
+  {
+    value: "macro",
+    label: "Macro only",
+    description: "Only market-wide events with no single ticker.",
+  },
+  { value: "all", label: "Everything", description: "Every breaking story." },
+];
+
+export const BREAKING_MUTED_SECTOR_OPTIONS = SECTOR_NEWS_SECTORS.map((sector) => ({
+  value: sector,
+  label: sectorNewsLabel(sector),
+}));
+
+export function parseBreakingScope(value: unknown): BreakingScope {
+  return BREAKING_SCOPES.includes(value as BreakingScope)
+    ? (value as BreakingScope)
+    : DEFAULT_BREAKING_SCOPE;
+}
+
+export function parseMutedSectors(value: unknown): Set<string> {
+  if (!Array.isArray(value)) return new Set();
+  return new Set(
+    value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0),
+  );
+}
+
+/**
+ * A story with no ticker links is market-wide: policy, geopolitics, or market
+ * structure. The server never attributes those to a symbol, so absence of
+ * tickers is the signal.
+ */
+export function isMacroArticle(article: MarketNewsItem): boolean {
+  return article.tickers.length === 0;
+}
+
+export function matchesWatchlist(
+  article: MarketNewsItem,
+  watchedSymbols: ReadonlySet<string>,
+): boolean {
+  return article.tickers.some((ticker) => watchedSymbols.has(ticker.toUpperCase()));
+}
+
+export function matchesScope(
+  article: MarketNewsItem,
+  scope: BreakingScope,
+  watchedSymbols: ReadonlySet<string>,
+): boolean {
+  if (scope === "all") return true;
+  if (scope === "macro") return isMacroArticle(article);
+  if (scope === "watchlist") return matchesWatchlist(article, watchedSymbols);
+  return isMacroArticle(article) || matchesWatchlist(article, watchedSymbols);
+}
+
+/**
+ * Muted only when every sector is muted. A story spanning a muted and an
+ * unmuted sector still matters, so partial overlap is deliberately kept.
+ */
+export function isSectorMuted(
+  article: MarketNewsItem,
+  mutedSectors: ReadonlySet<string>,
+): boolean {
+  if (mutedSectors.size === 0 || article.sectors.length === 0) return false;
+  return article.sectors.every((sector) => mutedSectors.has(sector));
+}
+
+export interface BreakingNotificationFilter {
+  scope: BreakingScope;
+  mutedSectors: ReadonlySet<string>;
+  watchedSymbols: ReadonlySet<string>;
+}
+
+export function selectNotifiableArticles(
+  articles: MarketNewsItem[],
+  filter: BreakingNotificationFilter,
+): MarketNewsItem[] {
+  return articles.filter(
+    (article) =>
+      matchesScope(article, filter.scope, filter.watchedSymbols) &&
+      !isSectorMuted(article, filter.mutedSectors),
+  );
+}

--- a/src/plugins/builtin/news/wire/breaking/notifications.test.ts
+++ b/src/plugins/builtin/news/wire/breaking/notifications.test.ts
@@ -2,11 +2,19 @@ import { describe, expect, test } from "bun:test";
 import type { AppNotificationRequest, GloomPluginContext } from "../../../../../types/plugin";
 import type { MarketNewsItem, NewsQueryState } from "../../../../../types/news-source";
 import {
+  BREAKING_NEWS_MUTED_SECTORS_KEY,
+  BREAKING_NEWS_SCOPE_KEY,
+} from "./filters";
+import {
   BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY,
   setupBreakingNewsNotifications,
 } from "./notifications";
 
-function article(id: string, title = id): MarketNewsItem {
+function article(
+  id: string,
+  title = id,
+  overrides: Partial<MarketNewsItem> = {},
+): MarketNewsItem {
   return {
     id,
     title,
@@ -18,16 +26,11 @@ function article(id: string, title = id): MarketNewsItem {
     sectors: [],
     categories: ["general"],
     tickers: ["AAPL"],
-    scores: {
-      importance: 90,
-      urgency: 90,
-      marketImpact: 80,
-      novelty: 80,
-      confidence: 90,
-    },
+    scores: { importance: 90, urgency: 90, marketImpact: 80, novelty: 80, confidence: 90 },
     importance: 90,
     isBreaking: true,
     isDeveloping: false,
+    ...overrides,
   };
 }
 
@@ -43,58 +46,159 @@ function ready(articles: MarketNewsItem[]): NewsQueryState {
   };
 }
 
+interface Harness {
+  ctx: GloomPluginContext;
+  notifications: AppNotificationRequest[];
+  shownPanes: string[];
+  state: Map<string, unknown>;
+  emit(articles: MarketNewsItem[]): void;
+  isWatching(): boolean;
+}
+
+function harness(options: {
+  settings?: Record<string, unknown>;
+  watchedSymbols?: string[];
+} = {}): Harness {
+  let listener: ((state: NewsQueryState) => void) | null = null;
+  const notifications: AppNotificationRequest[] = [];
+  const shownPanes: string[] = [];
+  const state = new Map<string, unknown>();
+  const settings: Record<string, unknown> = {
+    [BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY]: true,
+    ...options.settings,
+  };
+  const watched = options.watchedSymbols ?? ["AAPL"];
+
+  const ctx = {
+    configState: { get: (key: string) => settings[key] ?? null },
+    persistence: {
+      getState: (key: string) => state.get(key) ?? null,
+      setState: (key: string, value: unknown) => void state.set(key, value),
+    },
+    tickerRepository: {
+      loadAllTickers: async () =>
+        watched.map((symbol) => ({
+          metadata: { ticker: symbol, watchlists: ["default"], portfolios: [], positions: [] },
+        })),
+    },
+    watchNewsQuery: (_query: unknown, next: (state: NewsQueryState) => void) => {
+      listener = next;
+      return () => {
+        listener = null;
+      };
+    },
+    on: () => () => {},
+    notify: (notification: AppNotificationRequest) => void notifications.push(notification),
+    showPane: (paneId: string) => void shownPanes.push(paneId),
+    log: { warn: () => {} },
+  } as unknown as GloomPluginContext;
+
+  return {
+    ctx,
+    notifications,
+    shownPanes,
+    state,
+    emit: (articles) => listener?.(ready(articles)),
+    isWatching: () => listener !== null,
+  };
+}
+
+/** Lets the async watchlist load settle before articles arrive. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 describe("breaking news notifications", () => {
-  test("primes on the first ready batch and notifies for later unseen articles", () => {
-    let enabled = true;
-    let listener: ((state: NewsQueryState) => void) | null = null;
-    const notifications: AppNotificationRequest[] = [];
-    const shownPanes: string[] = [];
+  test("primes on the first ready batch and notifies for later unseen articles", async () => {
+    const h = harness();
+    const dispose = setupBreakingNewsNotifications(h.ctx);
+    await settle();
 
-    const ctx = {
-      configState: {
-        get: (key: string) => key === BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY ? enabled : null,
-      },
-      watchNewsQuery: (_query: unknown, nextListener: (state: NewsQueryState) => void) => {
-        listener = nextListener;
-        return () => {
-          listener = null;
-        };
-      },
-      on: (_event: string, _handler: unknown) => () => {},
-      notify: (notification: AppNotificationRequest) => {
-        notifications.push(notification);
-      },
-      showPane: (paneId: string) => {
-        shownPanes.push(paneId);
-      },
-      log: {
-        warn: () => {},
-      },
-    } as unknown as GloomPluginContext;
+    const old = article("old", "Old headline");
+    const fresh = article("new", "New headline");
 
-    const dispose = setupBreakingNewsNotifications(ctx);
-    const oldArticle = article("old", "Old headline");
-    const newArticle = article("new", "New headline");
+    h.emit([old]);
+    h.emit([fresh, old]);
 
-    listener?.(ready([oldArticle]));
-    listener?.(ready([newArticle, oldArticle]));
-
-    expect(notifications).toHaveLength(1);
-    expect(notifications[0]).toMatchObject({
+    expect(h.notifications).toHaveLength(1);
+    expect(h.notifications[0]).toMatchObject({
       title: "Breaking News",
       body: "New headline",
       desktop: "always",
-      persistent: true,
     });
+    // Breaking toasts must expire on their own; persistent ones stacked up.
+    expect(h.notifications[0]?.persistent).toBeUndefined();
+    expect(h.notifications[0]?.duration).toBeGreaterThan(0);
 
-    notifications[0]!.action?.onClick();
-    expect(shownPanes).toEqual(["news-breaking"]);
-
-    enabled = false;
-    listener?.(ready([article("newer", "Newer headline"), newArticle, oldArticle]));
-    expect(notifications).toHaveLength(1);
+    h.notifications[0]!.action?.onClick();
+    expect(h.shownPanes).toEqual(["news-breaking"]);
 
     dispose();
-    expect(listener).toBeNull();
+    expect(h.isWatching()).toBe(false);
+  });
+
+  test("default scope drops stories about tickers the user does not track", async () => {
+    const h = harness({ watchedSymbols: ["AAPL"] });
+    setupBreakingNewsNotifications(h.ctx);
+    await settle();
+
+    h.emit([article("seed")]);
+    h.emit([
+      article("unrelated", "Unrelated ticker", { tickers: ["XOM"] }),
+      article("seed"),
+    ]);
+    expect(h.notifications).toHaveLength(0);
+
+    h.emit([article("macro", "Market-wide event", { tickers: [] }), article("seed")]);
+    expect(h.notifications).toHaveLength(1);
+    expect(h.notifications[0]?.body).toBe("Market-wide event");
+  });
+
+  test("muted sectors suppress otherwise in-scope stories", async () => {
+    const h = harness({
+      settings: { [BREAKING_NEWS_MUTED_SECTORS_KEY]: ["health_care"] },
+    });
+    setupBreakingNewsNotifications(h.ctx);
+    await settle();
+
+    h.emit([article("seed")]);
+    h.emit([
+      article("pharma", "Pharma story", { sectors: ["health_care"] }),
+      article("seed"),
+    ]);
+    expect(h.notifications).toHaveLength(0);
+  });
+
+  test("filtered-out articles are still marked seen so relaxing a filter replays nothing", async () => {
+    const h = harness({ settings: { [BREAKING_NEWS_SCOPE_KEY]: "watchlist" } });
+    setupBreakingNewsNotifications(h.ctx);
+    await settle();
+
+    h.emit([article("seed")]);
+    const macro = article("macro", "Market-wide event", { tickers: [] });
+    h.emit([macro, article("seed")]);
+    expect(h.notifications).toHaveLength(0);
+
+    // Same article arriving again must not notify once it has been observed.
+    h.emit([macro, article("seed")]);
+    expect(h.notifications).toHaveLength(0);
+  });
+
+  test("snoozing suppresses notifications until the window passes", async () => {
+    const h = harness();
+    setupBreakingNewsNotifications(h.ctx);
+    await settle();
+
+    h.emit([article("seed")]);
+    h.emit([article("first", "First"), article("seed")]);
+    expect(h.notifications).toHaveLength(1);
+
+    h.notifications[0]!.secondaryAction?.onClick();
+    const confirmation = h.notifications.length;
+
+    h.emit([article("second", "Second"), article("seed")]);
+    expect(h.notifications).toHaveLength(confirmation);
+
+    h.state.set("breaking-news-snooze-until", Date.now() - 1);
+    h.emit([article("third", "Third"), article("seed")]);
+    expect(h.notifications.at(-1)?.body).toBe("Third");
   });
 });

--- a/src/plugins/builtin/news/wire/breaking/notifications.ts
+++ b/src/plugins/builtin/news/wire/breaking/notifications.ts
@@ -1,10 +1,22 @@
 import type { GloomPluginContext } from "../../../../../types/plugin";
 import type { MarketNewsItem, NewsQueryState } from "../../../../../types/news-source";
 import { NEWS_QUERY_PRESETS } from "../news/query-presets";
+import {
+  BREAKING_NEWS_MUTED_SECTORS_KEY,
+  BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY,
+  BREAKING_NEWS_SCOPE_KEY,
+  parseBreakingScope,
+  parseMutedSectors,
+  selectNotifiableArticles,
+} from "./filters";
 
-export const BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY = "breakingNewsNotificationsEnabled";
+export { BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY };
 
 const MAX_SEEN_ARTICLE_IDS = 500;
+/** Long enough to read a stacked burst, short enough to clear itself. */
+const BREAKING_TOAST_DURATION_MS = 20_000;
+const SNOOZE_DURATION_MS = 60 * 60_000;
+const SNOOZE_STATE_KEY = "breaking-news-snooze-until";
 
 function isReadyState(state: NewsQueryState): boolean {
   return state.phase === "ready" || state.phase === "refreshing";
@@ -35,31 +47,69 @@ function notificationSubtitle(article: MarketNewsItem): string {
   return tickers ? `${article.source} ${tickers}` : article.source;
 }
 
-function notifyNewBreakingArticles(ctx: GloomPluginContext, articles: MarketNewsItem[]): void {
-  const latest = [...articles].sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime())[0];
-  if (!latest) return;
-
-  const extraCount = articles.length - 1;
-  ctx.notify({
-    title: "Breaking News",
-    subtitle: notificationSubtitle(latest),
-    body: extraCount > 0 ? `${latest.title} (+${extraCount} more)` : latest.title,
-    type: "info",
-    desktop: "always",
-    persistent: true,
-    action: {
-      label: "Open",
-      onClick: () => ctx.showPane("news-breaking"),
-    },
-  });
-}
-
 export function setupBreakingNewsNotifications(ctx: GloomPluginContext): () => void {
   let disposeWatch: (() => void) | null = null;
   let primed = false;
   let seenArticleIds = new Set<string>();
+  let watchedSymbols = new Set<string>();
 
   const enabled = () => ctx.configState.get<boolean>(BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY) === true;
+
+  // Snooze is intentionally local: it is short-lived and must not race the
+  // cloud sync snapshot across devices.
+  const snoozedUntil = () => ctx.persistence.getState<number>(SNOOZE_STATE_KEY) ?? 0;
+  const isSnoozed = () => snoozedUntil() > Date.now();
+  const snooze = () => {
+    ctx.persistence.setState(SNOOZE_STATE_KEY, Date.now() + SNOOZE_DURATION_MS);
+    ctx.notify({
+      body: "Breaking news snoozed for 1 hour.",
+      type: "info",
+      desktop: "never",
+    });
+  };
+
+  const refreshWatchedSymbols = async () => {
+    try {
+      const tickers = await ctx.tickerRepository.loadAllTickers();
+      const next = new Set<string>();
+      for (const ticker of tickers) {
+        const metadata = ticker.metadata;
+        const tracked =
+          (metadata.watchlists?.length ?? 0) > 0 ||
+          (metadata.portfolios?.length ?? 0) > 0 ||
+          (metadata.positions?.length ?? 0) > 0;
+        if (tracked) next.add(metadata.ticker.toUpperCase());
+      }
+      watchedSymbols = next;
+    } catch (error) {
+      ctx.log.warn(`breaking notifications could not load watched tickers: ${error}`);
+    }
+  };
+
+  const notifyNewBreakingArticles = (articles: MarketNewsItem[]): void => {
+    const latest = [...articles].sort(
+      (a, b) => b.publishedAt.getTime() - a.publishedAt.getTime(),
+    )[0];
+    if (!latest) return;
+
+    const extraCount = articles.length - 1;
+    ctx.notify({
+      title: "Breaking News",
+      subtitle: notificationSubtitle(latest),
+      body: extraCount > 0 ? `${latest.title} (+${extraCount} more)` : latest.title,
+      type: "info",
+      desktop: "always",
+      duration: BREAKING_TOAST_DURATION_MS,
+      action: {
+        label: "Open",
+        onClick: () => ctx.showPane("news-breaking"),
+      },
+      secondaryAction: {
+        label: "Snooze 1h",
+        onClick: snooze,
+      },
+    });
+  };
 
   const handleState = (state: NewsQueryState) => {
     if (!isReadyState(state)) return;
@@ -71,12 +121,20 @@ export function setupBreakingNewsNotifications(ctx: GloomPluginContext): () => v
     }
 
     const freshArticles = state.articles.filter((article) => !seenArticleIds.has(article.id));
-    if (freshArticles.length === 0) return;
-
+    // Mark everything seen regardless of filtering, so relaxing a filter later
+    // does not replay a backlog of old stories as if they just broke.
     seenArticleIds = rememberArticleIds(seenArticleIds, state.articles);
-    if (enabled()) {
-      notifyNewBreakingArticles(ctx, freshArticles);
-    }
+    if (freshArticles.length === 0) return;
+    if (!enabled() || isSnoozed()) return;
+
+    const notifiable = selectNotifiableArticles(freshArticles, {
+      scope: parseBreakingScope(ctx.configState.get(BREAKING_NEWS_SCOPE_KEY)),
+      mutedSectors: parseMutedSectors(ctx.configState.get(BREAKING_NEWS_MUTED_SECTORS_KEY)),
+      watchedSymbols,
+    });
+    if (notifiable.length === 0) return;
+
+    notifyNewBreakingArticles(notifiable);
   };
 
   const stop = () => {
@@ -92,6 +150,7 @@ export function setupBreakingNewsNotifications(ctx: GloomPluginContext): () => v
       ctx.log.warn("breaking notifications unavailable: news query watcher missing");
       return;
     }
+    void refreshWatchedSymbols();
     disposeWatch = ctx.watchNewsQuery(NEWS_QUERY_PRESETS.breaking, handleState);
   };
 
@@ -100,11 +159,18 @@ export function setupBreakingNewsNotifications(ctx: GloomPluginContext): () => v
     else stop();
   };
 
-  const disposeConfigListener = ctx.on("config:changed", sync);
+  const disposeConfigListener = ctx.on("config:changed", () => {
+    void refreshWatchedSymbols();
+    sync();
+  });
+  const disposeTickerAdded = ctx.on("ticker:added", () => void refreshWatchedSymbols());
+  const disposeTickerRemoved = ctx.on("ticker:removed", () => void refreshWatchedSymbols());
   sync();
 
   return () => {
     disposeConfigListener();
+    disposeTickerAdded();
+    disposeTickerRemoved();
     stop();
   };
 }

--- a/src/plugins/builtin/news/wire/index.tsx
+++ b/src/plugins/builtin/news/wire/index.tsx
@@ -7,6 +7,12 @@ import {
   setupBreakingNewsNotifications,
 } from "./breaking/notifications";
 import {
+  BREAKING_MUTED_SECTOR_OPTIONS,
+  BREAKING_NEWS_MUTED_SECTORS_KEY,
+  BREAKING_NEWS_SCOPE_KEY,
+  BREAKING_SCOPE_OPTIONS,
+} from "./breaking/filters";
+import {
   addUserNewsFeed,
   getEnabledNewsFeeds,
   loadNewsFeedSettings,
@@ -77,13 +83,31 @@ export const newsWireModule: PluginModule = {
       defaultFloatingSize: { width: 85, height: 20 },
       settings: {
         title: "Breaking News Settings",
-        fields: [{
-          key: BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY,
-          label: "Notifications",
-          description: "Notify when new breaking stories arrive, even while this pane is closed.",
-          type: "toggle",
-          storage: "plugin",
-        }],
+        fields: [
+          {
+            key: BREAKING_NEWS_NOTIFICATIONS_ENABLED_KEY,
+            label: "Notifications",
+            description: "Notify when new breaking stories arrive, even while this pane is closed.",
+            type: "toggle",
+            storage: "plugin",
+          },
+          {
+            key: BREAKING_NEWS_SCOPE_KEY,
+            label: "Notify About",
+            description: "Which breaking stories are worth interrupting you for.",
+            type: "select",
+            storage: "plugin",
+            options: BREAKING_SCOPE_OPTIONS,
+          },
+          {
+            key: BREAKING_NEWS_MUTED_SECTORS_KEY,
+            label: "Muted Sectors",
+            description: "Never notify about stories confined to these sectors.",
+            type: "multi-select",
+            storage: "plugin",
+            options: BREAKING_MUTED_SECTOR_OPTIONS,
+          },
+        ],
       },
     },
   ],

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -504,6 +504,11 @@ body.gloom-dragging [data-gloom-role="chart-surface"] {
   border-radius: 4px;
   color: var(--gloom-text-bright);
 }
+/* Secondary reads as the quieter option next to the primary action. */
+.gloom-toast-action-secondary {
+  border-color: var(--gloom-border);
+  color: var(--gloom-text-dim);
+}
 .gloom-toast-dismiss {
   display: grid;
   width: 22px;

--- a/src/renderers/electrobun/view/toast-host.tsx
+++ b/src/renderers/electrobun/view/toast-host.tsx
@@ -11,6 +11,7 @@ interface ToastEntry {
   title?: string;
   subtitle?: string;
   action?: ToastOptions["action"];
+  secondaryAction?: ToastOptions["secondaryAction"];
 }
 
 let nextToastId = 1;
@@ -31,6 +32,7 @@ export function WebToastHostProvider({ children }: { children: ReactNode }) {
       title: options?.title,
       subtitle: options?.subtitle,
       action: options?.action,
+      secondaryAction: options?.secondaryAction,
     }]);
     if (options?.duration !== 0) {
       setTimeout(() => dismiss(id), options?.duration ?? 4500);
@@ -80,6 +82,22 @@ export function WebToastHostProvider({ children }: { children: ReactNode }) {
                       }}
                     >
                       {toast.action.label}
+                    </button>
+                  )}
+                  {toast.secondaryAction && (
+                    <button
+                      type="button"
+                      className="gloom-toast-action gloom-toast-action-secondary"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        try {
+                          toast.secondaryAction?.onClick();
+                        } finally {
+                          dismiss(toast.id);
+                        }
+                      }}
+                    >
+                      {toast.secondaryAction.label}
                     </button>
                   )}
                   <button

--- a/src/renderers/opentui/toast-host.tsx
+++ b/src/renderers/opentui/toast-host.tsx
@@ -13,6 +13,10 @@ interface ToastRecord {
   options?: ToastOptions;
 }
 
+const MAX_VISIBLE_TOASTS = 4;
+/** Small buffer above the visible cap so a dismissal can reveal a recent toast. */
+const MAX_RETAINED_TOASTS = 8;
+
 let nextToastId = 1;
 let toasts: ToastRecord[] = [];
 const listeners = new Set<() => void>();
@@ -36,7 +40,16 @@ function dismissToast(id: string | number): void {
 
 function addToast(tone: ToastTone, body: string, options?: ToastOptions): number {
   const id = nextToastId++;
-  toasts = [...toasts, { id, body, tone, options }];
+  // Only the newest MAX_VISIBLE_TOASTS render, so anything past the cap is
+  // unreachable. Keeping it would let a dismissal resurface a stale toast.
+  const kept = [...toasts, { id, body, tone, options }].slice(-MAX_RETAINED_TOASTS);
+  for (const dropped of toasts) {
+    if (kept.some((toast) => toast.id === dropped.id)) continue;
+    const timer = timers.get(dropped.id);
+    if (timer) clearTimeout(timer);
+    timers.delete(dropped.id);
+  }
+  toasts = kept;
   publish();
   const duration = options?.duration ?? 4_000;
   if (Number.isFinite(duration) && duration > 0) {
@@ -89,7 +102,7 @@ function ToastViewport({ position = "bottom-right" }: { position?: string }) {
       flexDirection="column"
       gap={1}
     >
-      {visibleToasts.slice(-4).map((toast) => (
+      {visibleToasts.slice(-MAX_VISIBLE_TOASTS).map((toast) => (
         <box
           key={toast.id}
           width="100%"
@@ -113,6 +126,17 @@ function ToastViewport({ position = "bottom-right" }: { position?: string }) {
               }}
             >
               {`[${toast.options.action.label}]`}
+            </text>
+          )}
+          {toast.options?.secondaryAction && (
+            <text
+              fg={colors.textMuted}
+              onMouseDown={(event) => {
+                event.stopPropagation();
+                toast.options?.secondaryAction?.onClick();
+              }}
+            >
+              {`[${toast.options.secondaryAction.label}]`}
             </text>
           )}
           <text

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -508,6 +508,11 @@ export interface AppNotificationRequest {
     label: string;
     onClick: () => void;
   };
+  /** Rendered next to `action`. Use for a dismissing counterpart such as snooze. */
+  secondaryAction?: {
+    label: string;
+    onClick: () => void;
+  };
 }
 
 export interface BrokerInstanceUpdateOptions {

--- a/src/ui/toast.tsx
+++ b/src/ui/toast.tsx
@@ -1,13 +1,17 @@
 import { createContext, useContext, type ComponentType, type ReactNode } from "react";
 
+export interface ToastAction {
+  label: string;
+  onClick(): void;
+}
+
 export interface ToastOptions {
   title?: string;
   subtitle?: string;
   duration?: number;
-  action?: {
-    label: string;
-    onClick(): void;
-  };
+  action?: ToastAction;
+  /** Rendered next to `action`. Use for a dismissing counterpart such as snooze. */
+  secondaryAction?: ToastAction;
 }
 
 export interface ToastHost {


### PR DESCRIPTION
## Problem

Breaking notifications were all-or-nothing. The watcher sent the global feed with no filtering:

```ts
breaking: { feed: "breaking", breaking: true, limit: 50 }
```

No topics, sectors, tickers, or thresholds, even though `NewsQuery` supports all of them. Every result became a `persistent: true` toast that never expired, so a burst stacked up until dismissed by hand. The only control was one on/off toggle, so a user who did not care about pharma had to choose between every breaking story and none.

## Controls

All plugin-scoped, so they ride the existing cloud sync snapshot via `pluginConfig` and apply across desktop and TUI with no sync work.

**Notify About** (select): `watchlist + macro` (default), `watchlist only`, `macro only`, `everything`.

A story with no ticker links is treated as macro, which is how the server represents policy and geopolitical events. This matters: a pure watchlist scope would have silently dropped the Iran/oil headlines that prompted this. Mobile's existing watchlist-only push has that blind spot; this does not copy it.

**Muted Sectors** (multi-select): reuses the existing `SECTOR_NEWS_SECTORS` taxonomy and `sectorNewsLabel`. A story is muted only when *every* sector is muted, so one spanning a muted and an unmuted sector still comes through. Conservative on purpose; over-muting is worse than under-muting.

**Snooze 1h**: a secondary toast action. Deliberately stored in local plugin state, not synced config, since it is short-lived and should not race the sync snapshot across devices.

## Delivery fixes

- Breaking toasts expire after 20s instead of `persistent: true`. The persistent flag was the real amplifier behind the reported spam.
- The OpenTUI host retained every toast forever while rendering only the last four, so dismissing one could resurface a stale toast. Now caps retention and clears timers for dropped toasts.
- `AppNotificationRequest` and `ToastOptions` gained `secondaryAction`, rendered by both the terminal and desktop hosts. Generic, reusable by other plugins.

## Subtlety worth noting

Articles are marked seen even when filtered out. Otherwise relaxing a filter would replay a backlog of old stories as though they just broke.

## Testing

- `filters.test.ts`: scope matrix, sector-mute boundary (including the partial-overlap case), malformed stored values.
- `notifications.test.ts`: rewritten. Covers priming, scope filtering end to end, sector muting, snooze suppression and expiry, and the seen-while-filtered behavior above. The old mock context lacked `persistence` and `tickerRepository`, and asserted `persistent: true`.
- Not tested: the settings dialog rendering, which is existing generic infrastructure already used by chart-composer and portfolio-list.
- Full suite: 2373 pass, 0 fail. All six typecheck targets clean.
- tmux smoke on an isolated `HOME`: all three fields register with the correct control types, no React warnings or errors in the log or final capture.

## Follow-ups (not in this PR)

- Sensitivity presets mapping to `minImportance` / `minUrgency`.
- Server-side parity so `mobile-alerts.ts` honours the same synced sector mutes and gains the macro scope.