### PR TITLE
Require owner/repo for plugin installs

### DIFF
--- a/src/cli/commands/plugins.ts
+++ b/src/cli/commands/plugins.ts
@@ -51,42 +51,6 @@ function parseGitHubRef(rawRef: string): { url: string; name: string } {
   throw new Error(`Invalid plugin reference: ${ref}. Use user/repo or a GitHub URL.`);
 }
 
-const PLUGIN_ID_PATTERN = /^[a-z][a-z0-9-]*$/;
-
-/**
- * Resolves a bare plugin id through the registry, so `gloomberb install
- * hackernews` works alongside `gloomberb install owner/repo`. Anything already
- * shaped like a repo reference is left alone, and a registry lookup failure
- * falls through to the normal parse error rather than inventing a repo name.
- */
-async function resolveRegistryRef(rawRef: string): Promise<string> {
-  if (rawRef.includes("/") || rawRef.includes(":") || !PLUGIN_ID_PATTERN.test(rawRef)) return rawRef;
-
-  try {
-    const response = await fetch(`https://plugins.gloom.sh/plugins/${rawRef}.json`, {
-      headers: { Accept: "application/json" },
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!response.ok) return rawRef;
-    const entry = await response.json() as { repo?: string; bundled?: boolean; name?: string };
-
-    if (entry.bundled) {
-      fail(
-        `"${entry.name ?? rawRef}" ships with Gloomberb.`,
-        `Enable it from the plugin marketplace (PL) instead.`,
-      );
-    }
-    if (typeof entry.repo === "string" && entry.repo.length > 0) {
-    
-      return entry.repo;
-    }
-  } catch {
-    // Offline or registry down: fall through so the plain parse error explains
-    // the accepted formats rather than blaming the network.
-  }
-  return rawRef;
-}
-
 export interface InstallPluginOptions {
   /**
    * Suppress child-process output and progress logging. The marketplace pane
@@ -96,13 +60,12 @@ export interface InstallPluginOptions {
   quiet?: boolean;
 }
 
-export async function installPlugin(rawRef: string, options: InstallPluginOptions = {}) {
+export async function installPlugin(ref: string, options: InstallPluginOptions = {}) {
   const stdio = options.quiet ? "pipe" : "inherit";
   const say = (message: string) => {
     if (!options.quiet) console.log(message);
   };
   ensurePluginsDir();
-  const ref = await resolveRegistryRef(rawRef);
   const { url, name } = parseGitHubRef(ref);
   const targetDir = join(PLUGINS_DIR, name);
 

--- a/src/plugins/builtin/plugin-marketplace/pane.tsx
+++ b/src/plugins/builtin/plugin-marketplace/pane.tsx
@@ -130,19 +130,20 @@ function EntryDetail({ entry, width }: { entry: MarketplaceEntry; width: number 
 
       <Box paddingTop={1} flexDirection="column">
         {contributes.length > 0 ? <DetailRow label="Adds" value={contributes.join(", ")} /> : null}
-        {/* Shown before install, because it is the one thing a user should weigh. */}
-        <DetailRow
-          label="Network"
-          value={entry.hosts.length > 0 ? entry.hosts.join(", ") : "no third-party requests"}
-        />
+        {/*
+          * Declared by the plugin author and not enforced: plugins are not
+          * sandboxed, so this is a hint about intent, not a limit. Labelled
+          * "Declares" rather than "Network" so it does not read as a guarantee.
+          */}
+        {entry.hosts.length > 0 ? <DetailRow label="Declares" value={entry.hosts.join(", ")} /> : null}
         {entry.repo ? <DetailRow label="Source" value={`github.com/${entry.repo}`} /> : null}
         {entry.loadError ? <DetailRow label="Error" value={entry.loadError} /> : null}
       </Box>
 
-      {!entry.installed && !entry.bundled ? (
+      {!entry.installed && !entry.bundled && entry.repo ? (
         <Box paddingTop={1} flexDirection="column">
-          <Text fg={colors.textDim}>Install with</Text>
-          <Text fg={colors.textBright}>{`gloomberb install ${entry.id}`}</Text>
+          <Text fg={colors.textDim}>Runs with your full permissions. Read the source first.</Text>
+          <Text fg={colors.textBright}>{`gloomberb install ${entry.repo}`}</Text>
         </Box>
       ) : null}
     </ScrollBox>
@@ -219,10 +220,14 @@ export function PluginMarketplacePane({ focused, width, height }: PaneProps) {
     const install = getPluginInstaller();
     if (!selected || !isInstallable(selected) || !install || installing) return;
     if (installedNow.includes(selected.id)) return;
+    // Installs address the repository, not the plugin id: there is no central
+    // name resolution, so owner/repo is the only unambiguous reference.
+    const repo = selected.repo;
+    if (!repo) return;
     const target = selected.id;
     setInstalling(target);
     setInstallError(null);
-    void install(target).then((result) => {
+    void install(repo).then((result) => {
       setInstalling(null);
       if (result.ok) {
         setInstalledNow((current) => [...current, target]);


### PR DESCRIPTION
`gloomberb install substack` resolved short names through plugins.gloom.sh. That made the registry look like it governed installs, and it never did.

Two things make that concrete:

- `plugins.ts` passes any reference containing `/` straight through, so `gloomberb install anyone/anything` has always worked without touching the registry.
- Duplicate and reserved plugin ids are rejected by the **runtime** (`registry/index.ts:513` and `:515`), not by the registry feed. The registry's uniqueness check was duplicating a guarantee the app already enforces at load.

So the short-name lookup was the only place the storefront and the install path were entangled, for a convenience that implied a gate that does not exist. Installs now take `owner/repo` or a GitHub URL, which is also what the docs already documented.

**Second change, same theme.** The detail view labelled the author-declared host list "Network" and said "no third-party requests" when empty. Nothing enforces that. Plugins are not sandboxed and run with the user's full permissions, so the field is a statement of intent that we do not verify, and presenting it as a network boundary is a false assurance I introduced. It now reads "Declares", is omitted entirely when empty rather than asserting an absence, and sits under "Runs with your full permissions. Read the source first."

The marketplace still installs in place; it just passes the repository instead of the id.

Verified: `owner/repo` installs and loads, a bare short name is rejected with the format hint rather than silently resolving. 2373 tests, six typecheck targets.

Not merging this myself since it changes pane copy.