### PR TITLE
Publish the built-in plugin catalog from this repository

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Typecheck production runtimes
         run: bun run typecheck
 
+      # Fails when a built-in plugin changes without regenerating the published
+      # manifest, which is what the plugin directory renders for built-ins.
+      - name: Check the built-in plugin manifest
+        run: bun run plugins:manifest:check
+
   build-and-test:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "desktop:release": "electrobun build --env=stable",
     "desktop:release:windows": "electrobun build --env=stable --targets=win-x64",
     "i18n:audit": "bun run scripts/i18n-audit.ts",
+    "plugins:manifest": "bun run scripts/generate-plugin-manifest.ts",
+    "plugins:manifest:check": "bun run scripts/generate-plugin-manifest.ts --check",
     "typecheck": "bun run typecheck:opentui && bun run typecheck:electrobun-bun && bun run typecheck:electrobun-view && bun run typecheck:browser && bun run typecheck:cloudflare && bun run typecheck:scripts",
     "typecheck:opentui": "tsc --project tsconfig.opentui.json",
     "typecheck:electrobun-bun": "tsc --project tsconfig.electrobun-bun.json",

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -1,0 +1,340 @@
+{
+  "version": 1,
+  "plugins": [
+    {
+      "id": "ai",
+      "name": "AI",
+      "description": "Use AI providers with your financial data.",
+      "categories": [
+        "ai"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [],
+        "capabilities": [],
+        "broker": false
+      }
+    },
+    {
+      "id": "alerts",
+      "name": "Alerts",
+      "description": "Price trigger alerts with desktop notifications",
+      "categories": [
+        "alerts"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [],
+        "capabilities": [],
+        "broker": false
+      }
+    },
+    {
+      "id": "application",
+      "name": "Application",
+      "description": "Core layout, help, and release information.",
+      "categories": [
+        "core"
+      ],
+      "toggleable": false,
+      "contributes": {
+        "panes": [
+          "changelog",
+          "connections",
+          "help",
+          "layout-marketplace",
+          "plugin-marketplace"
+        ],
+        "capabilities": [],
+        "broker": false
+      }
+    },
+    {
+      "id": "broker",
+      "name": "Broker",
+      "description": "Broker profiles, account sync, and connection status.",
+      "categories": [
+        "broker"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [
+          "brokers"
+        ],
+        "capabilities": [],
+        "broker": false
+      }
+    },
+    {
+      "id": "debug",
+      "name": "Debug",
+      "description": "View and export debug logs",
+      "categories": [
+        "developer"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [],
+        "capabilities": [],
+        "broker": false
+      }
+    },
+    {
+      "id": "gloomberb-cloud",
+      "name": "Gloom Cloud",
+      "description": "Free market, macro, and chat services. Chat requires signup.",
+      "categories": [
+        "data",
+        "cloud"
+      ],
+      "toggleable": true,
+      "featured": true,
+      "contributes": {
+        "panes": [
+          "account-management",
+          "buildout",
+          "chat",
+          "congress-trades"
+        ],
+        "capabilities": [
+          "asset-data.gloomberb-cloud",
+          "news.gloomberb-cloud"
+        ],
+        "broker": false
+      }
+    },
+    {
+      "id": "macro",
+      "name": "Macro",
+      "description": "Economic calendar, rates, volatility, credit spreads, single-name CDS, Treasury auctions, earnings, IPOs, and live financial TV.",
+      "categories": [
+        "macro"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [
+          "cds",
+          "credit-conditions",
+          "earnings-calendar",
+          "earnings-calls",
+          "econ-calendar",
+          "ipo-calendar",
+          "macro-tv",
+          "treasury-auctions",
+          "volatility-term-structure",
+          "yield-curve"
+        ],
+        "capabilities": [],
+        "broker": false
+      }
+    },
+    {
+      "id": "market-overview",
+      "name": "Market Overview",
+      "description": "Global indices, movers, scanners, sectors, FX, futures, sentiment, and correlations.",
+      "categories": [
+        "markets"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [
+          "correlation",
+          "fear-greed",
+          "futures",
+          "fx-matrix",
+          "market-halts",
+          "market-heatmap",
+          "market-movers",
+          "relationship-graph",
+          "scanner-flow",
+          "scanner-hilo",
+          "sectors",
+          "world-indices",
+          "world-venue-map"
+        ],
+        "capabilities": [],
+        "broker": false
+      }
+    },
+    {
+      "id": "news",
+      "name": "News",
+      "description": "View latest news for each ticker",
+      "categories": [
+        "news"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [
+          "news-breaking",
+          "news-feed",
+          "news-industry",
+          "news-top",
+          "ticker-news"
+        ],
+        "capabilities": [],
+        "broker": false
+      }
+    },
+    {
+      "id": "notes",
+      "name": "Notes",
+      "description": "Add markdown notes to your tickers.",
+      "categories": [
+        "productivity"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [],
+        "capabilities": [],
+        "broker": false
+      }
+    },
+    {
+      "id": "polls",
+      "name": "Polls",
+      "description": "Political polls from VoteHub (CC BY 4.0)",
+      "categories": [
+        "data"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [
+          "polls"
+        ],
+        "capabilities": [],
+        "broker": false
+      }
+    },
+    {
+      "id": "portfolio",
+      "name": "Portfolio",
+      "description": "Portfolio and watchlist management, analytics, and position sizing.",
+      "categories": [
+        "portfolio"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [
+          "analytics",
+          "kelly-sizer",
+          "portfolio-list"
+        ],
+        "capabilities": [],
+        "broker": false
+      }
+    },
+    {
+      "id": "prediction-markets",
+      "name": "Prediction Markets",
+      "description": "Browse prediction markets (Polymarket and Kalshi).",
+      "categories": [
+        "markets"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [
+          "prediction-markets"
+        ],
+        "capabilities": [
+          "prediction-markets.series"
+        ],
+        "broker": false
+      }
+    },
+    {
+      "id": "public",
+      "name": "Public",
+      "description": "Read-only account and position sync for Public.",
+      "categories": [
+        "broker"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [],
+        "capabilities": [],
+        "broker": true
+      }
+    },
+    {
+      "id": "robinhood",
+      "name": "Robinhood",
+      "description": "Read-only account and position sync through Robinhood Trading MCP.",
+      "categories": [
+        "broker"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [],
+        "capabilities": [],
+        "broker": true
+      }
+    },
+    {
+      "id": "simplefin",
+      "name": "SimpleFIN",
+      "description": "Read-only investment position sync through SimpleFIN Bridge.",
+      "categories": [
+        "broker"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [],
+        "capabilities": [],
+        "broker": true
+      }
+    },
+    {
+      "id": "ticker-research",
+      "name": "Ticker Research",
+      "description": "Company research workspace: overview, charts, financials, filings, ownership, options, analyst research, and events.",
+      "categories": [
+        "research"
+      ],
+      "toggleable": true,
+      "contributes": {
+        "panes": [
+          "analyst-research",
+          "chart-composer",
+          "corporate-actions",
+          "data-catalog",
+          "dividend-yield",
+          "earnings-estimates",
+          "equity-diagnostic",
+          "financial-analysis",
+          "historical-prices",
+          "holders",
+          "insider",
+          "options",
+          "options-calculator",
+          "provider-search-results",
+          "quote-monitor",
+          "relative-valuation",
+          "sec",
+          "short-interest",
+          "thirteenf-funds",
+          "ticker-research"
+        ],
+        "capabilities": [],
+        "broker": false
+      }
+    },
+    {
+      "id": "yahoo",
+      "name": "Yahoo Fallback",
+      "description": "Built-in delayed fallback for quotes, fundamentals, charts, and unsupported cloud data.",
+      "categories": [
+        "data"
+      ],
+      "toggleable": false,
+      "contributes": {
+        "panes": [],
+        "capabilities": [
+          "asset-data.yahoo",
+          "news.yahoo"
+        ],
+        "broker": false
+      }
+    }
+  ]
+}

--- a/scripts/generate-plugin-manifest.ts
+++ b/scripts/generate-plugin-manifest.ts
@@ -1,0 +1,39 @@
+import { buildBuiltinManifest } from "../src/plugins/catalog-manifest";
+
+/**
+ * Writes `plugin-manifest.json`, the published description of Gloomberb's
+ * built-in plugins. The plugin directory reads it so the built-in half of the
+ * catalog comes from this repository rather than a hand-kept copy elsewhere.
+ *
+ * Run with --check in CI to fail when the committed file no longer matches the
+ * live catalog.
+ */
+const OUT = new URL("../plugin-manifest.json", import.meta.url);
+
+const manifest = buildBuiltinManifest();
+
+if (manifest.uncategorised.length > 0) {
+  console.error(
+    `Built-in plugins missing editorial metadata: ${manifest.uncategorised.join(", ")}\n` +
+      "Add them to EDITORIAL in src/plugins/catalog-manifest.ts so they are not listed uncategorised.",
+  );
+  process.exit(1);
+}
+
+const { uncategorised: _drop, ...published } = manifest;
+const next = `${JSON.stringify(published, null, 2)}\n`;
+
+if (process.argv.includes("--check")) {
+  const current = await Bun.file(OUT).text().catch(() => "");
+  if (current !== next) {
+    console.error(
+      "plugin-manifest.json is out of date with the plugin catalog.\n" +
+        "Run: bun run plugins:manifest",
+    );
+    process.exit(1);
+  }
+  console.log(`plugin-manifest.json is current (${published.plugins.length} built-in plugins).`);
+} else {
+  await Bun.write(OUT, next);
+  console.log(`Wrote plugin-manifest.json (${published.plugins.length} built-in plugins).`);
+}

--- a/src/plugins/catalog-manifest.test.ts
+++ b/src/plugins/catalog-manifest.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildBuiltinManifest } from "./catalog-manifest";
+
+/**
+ * The published manifest is the built-in half of the plugin directory. It used
+ * to be hand-maintained in a separate repository, where it drifted from the
+ * real catalog with nothing to catch it: a built-in could rename itself, gain a
+ * pane, or be added outright, and the directory would keep showing the old
+ * description indefinitely.
+ *
+ * These tests exist so that cannot recur. Drift now fails here rather than
+ * being discovered by a user reading a stale listing.
+ */
+describe("built-in plugin manifest", () => {
+  test("matches the committed file, so the directory cannot serve a stale catalog", async () => {
+    const committed = JSON.parse(
+      await Bun.file(new URL("../../plugin-manifest.json", import.meta.url)).text(),
+    );
+    const { uncategorised: _drop, ...generated } = buildBuiltinManifest();
+
+    expect(generated).toEqual(committed);
+  });
+
+  test("every built-in has editorial metadata", () => {
+    // A new built-in with no categories would appear unfiltered and
+    // uncategorised in the directory, so generation refuses instead.
+    expect(buildBuiltinManifest().uncategorised).toEqual([]);
+  });
+
+  test("exactly one plugin is featured", () => {
+    const featured = buildBuiltinManifest().plugins.filter((plugin) => plugin.featured);
+
+    expect(featured.map((plugin) => plugin.id)).toEqual(["gloomberb-cloud"]);
+  });
+
+  test("describes what each plugin contributes, which is what the directory renders", () => {
+    const cloud = buildBuiltinManifest().plugins.find((plugin) => plugin.id === "gloomberb-cloud");
+
+    expect(cloud?.contributes.panes).toContain("chat");
+    expect(cloud?.contributes.capabilities.length).toBeGreaterThan(0);
+  });
+});

--- a/src/plugins/catalog-manifest.ts
+++ b/src/plugins/catalog-manifest.ts
@@ -1,0 +1,91 @@
+import { getPluginCatalog } from "./catalog";
+
+/**
+ * The public description of the plugins that ship inside Gloomberb.
+ *
+ * The plugin directory has to list built-ins alongside installable ones, but a
+ * built-in has no repository to read metadata from. Hand-maintaining that half
+ * elsewhere meant it silently drifted every time a built-in changed its panes
+ * or description, so it is derived from the live catalog here instead and
+ * checked against a committed snapshot in CI.
+ */
+
+export interface BuiltinPluginManifestEntry {
+  id: string;
+  name: string;
+  description: string;
+  /** Curated, since the catalog has no notion of categories. */
+  categories: string[];
+  toggleable: boolean;
+  featured?: true;
+  contributes: {
+    panes: string[];
+    capabilities: string[];
+    broker: boolean;
+  };
+}
+
+/**
+ * Editorial metadata the runtime catalog does not carry. Anything missing here
+ * is reported by `generate-plugin-manifest.ts` rather than silently defaulted,
+ * so a new built-in cannot slip into the directory uncategorised.
+ */
+const EDITORIAL: Record<string, { categories: string[]; featured?: true }> = {
+  "gloomberb-cloud": { categories: ["data", "cloud"], featured: true },
+  ai: { categories: ["ai"] },
+  alerts: { categories: ["alerts"] },
+  application: { categories: ["core"] },
+  broker: { categories: ["broker"] },
+  debug: { categories: ["developer"] },
+  macro: { categories: ["macro"] },
+  "market-overview": { categories: ["markets"] },
+  news: { categories: ["news"] },
+  notes: { categories: ["productivity"] },
+  polls: { categories: ["data"] },
+  portfolio: { categories: ["portfolio"] },
+  "prediction-markets": { categories: ["markets"] },
+  public: { categories: ["broker"] },
+  robinhood: { categories: ["broker"] },
+  simplefin: { categories: ["broker"] },
+  "ticker-research": { categories: ["research"] },
+  yahoo: { categories: ["data"] },
+};
+
+export interface BuiltinManifest {
+  version: 1;
+  plugins: BuiltinPluginManifestEntry[];
+  /** Built-in ids with no editorial entry; a non-empty list fails generation. */
+  uncategorised: string[];
+}
+
+export function buildBuiltinManifest(): BuiltinManifest {
+  const uncategorised: string[] = [];
+
+  const plugins = getPluginCatalog()
+    .map(({ plugin }) => {
+      const editorial = EDITORIAL[plugin.id];
+      if (!editorial) uncategorised.push(plugin.id);
+
+      return {
+        id: plugin.id,
+        name: plugin.name,
+        description: plugin.description ?? "",
+        categories: editorial?.categories ?? [],
+        toggleable: plugin.toggleable === true,
+        ...(editorial?.featured ? { featured: true as const } : {}),
+        contributes: {
+          panes: (plugin.panes ?? []).map((pane) => pane.id).sort(),
+          capabilities: (plugin.capabilities ?? [])
+            .map((capability) => {
+              const value = capability as { id?: string; kind?: string };
+              return value.id ?? value.kind ?? "capability";
+            })
+            .sort(),
+          broker: !!plugin.broker,
+        },
+      };
+    })
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+  return { version: 1, plugins, uncategorised: uncategorised.sort() };
+}


### PR DESCRIPTION
First half of removing `gloom-sh/plugins`.

That repo holds 22 entries. **18 are built-ins with no repository at all** - a snapshot of this repo's plugin catalog that I generated once and which has drifted ever since with nothing to detect it. A built-in could rename itself, gain a pane, or be added outright, and the directory would keep serving the old description indefinitely.

Built-in metadata now comes from `getPluginCatalog()` into a committed `plugin-manifest.json`, with a test and a `verify` step that fail when the two disagree. I confirmed the test bites by editing the manifest by hand.

Categories and the featured flag are editorial and have no runtime equivalent, so they sit next to the generator. Generation **refuses** when a built-in has no editorial entry, rather than defaulting it, so a new built-in cannot slip into the directory uncategorised.

No runtime behaviour changes; this only adds a published artifact and the check that keeps it honest.

Next, and not in this PR: discover installable plugins by the `gloomberb-plugin` GitHub topic (already applied to the four repos, search returns all four), build the merged feed from that plus this manifest, and retire the registry repo and its Worker.