### PR TITLE
Race ticker search sources instead of chaining them

### DIFF
--- a/src/components/command-bar/routes/root/provider-search.ts
+++ b/src/components/command-bar/routes/root/provider-search.ts
@@ -105,14 +105,29 @@ export function useRootProviderSearch(options: {
     const requestId = ++rootSearchRequestIdRef.current;
     rootSearchTimerRef.current = setTimeout(async () => {
       try {
+        const publish = (candidates: TickerSearchCandidate[]) => {
+          setRootProviderResults(mergeTickerSearchResultItems(
+            searchQuery,
+            buildTickerSearchResultItems(candidates, searchQuery),
+            localTickerSearchResultItems(searchQuery, { limit: 6 }),
+          ));
+          setRootProviderResultsQuery(searchQuery);
+        };
         const combined = await searchTickerCandidates({
           query: searchQuery,
           tickers,
           dataProvider,
           searchContext: {
             preferBroker: true,
+            interactive: true,
             brokerId: activeSearchPortfolio?.brokerId,
             brokerInstanceId: activeSearchPortfolio?.brokerInstanceId,
+          },
+          // A broker that answers after the cloud upgrades the rows in place
+          // rather than being dropped because the list was already drawn.
+          onPartial: (candidates) => {
+            if (requestId !== rootSearchRequestIdRef.current) return;
+            publish(candidates);
           },
           ...QUICK_LOOK_TICKER_SEARCH_OPTIONS,
         });
@@ -123,12 +138,7 @@ export function useRootProviderSearch(options: {
           activeSearchPortfolio?.brokerId,
           activeSearchPortfolio?.brokerInstanceId,
         );
-        setRootProviderResults(mergeTickerSearchResultItems(
-          searchQuery,
-          buildTickerSearchResultItems(combined, searchQuery),
-          localTickerSearchResultItems(searchQuery, { limit: 6 }),
-        ));
-        setRootProviderResultsQuery(searchQuery);
+        publish(combined);
       } catch {
         if (requestId !== rootSearchRequestIdRef.current) return;
         setRootProviderResults([{

--- a/src/components/command-bar/routes/ticker-search/route.ts
+++ b/src/components/command-bar/routes/ticker-search/route.ts
@@ -95,6 +95,7 @@ export function useTickerSearchRouteResults(options: {
           dataProvider,
           searchContext: {
             preferBroker: true,
+            interactive: true,
             brokerId: brokerId ?? undefined,
             brokerInstanceId: brokerInstanceId ?? undefined,
           },

--- a/src/components/command-bar/workflow/tickers.ts
+++ b/src/components/command-bar/workflow/tickers.ts
@@ -36,6 +36,7 @@ function getTickerSearchContext(state: AppState, collectionId: string | null) {
   const activePortfolio = state.config.portfolios.find((portfolio) => portfolio.id === collectionId);
   return {
     preferBroker: true,
+    interactive: true,
     brokerId: activePortfolio?.brokerId,
     brokerInstanceId: activePortfolio?.brokerInstanceId,
   };

--- a/src/sources/provider-router/search.test.ts
+++ b/src/sources/provider-router/search.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import type { DataProvider, SearchRequestContext } from "../../types/data-provider";
+import type { InstrumentSearchResult } from "../../types/instrument";
+import { ProviderRouterSearchRoutes } from "./search";
+
+function result(symbol: string, extra: Partial<InstrumentSearchResult> = {}): InstrumentSearchResult {
+  return { symbol, name: symbol, exchange: "NASDAQ", type: "EQUITY", ...extra };
+}
+
+function provider(
+  id: string,
+  items: InstrumentSearchResult[],
+  delayMs = 0,
+): DataProvider {
+  return {
+    id,
+    search: async () => {
+      if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+      return items;
+    },
+  } as unknown as DataProvider;
+}
+
+function broker(
+  id: string,
+  items: InstrumentSearchResult[] | null,
+  delayMs = 0,
+) {
+  return {
+    brokerId: id,
+    brokerInstanceId: `${id}-1`,
+    brokerLabel: id,
+    instance: {},
+    broker: {
+      searchInstruments: async () => {
+        if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+        if (!items) throw new Error("broker down");
+        return items;
+      },
+    },
+  };
+}
+
+function makeRoutes(options: {
+  brokers?: ReturnType<typeof broker>[];
+  providers?: DataProvider[];
+}) {
+  return new ProviderRouterSearchRoutes({
+    getBrokerCandidates: () => (options.brokers ?? []) as never,
+    providersInPriorityOrder: () => options.providers ?? [],
+    logProviderError: () => {},
+  });
+}
+
+describe("provider search racing", () => {
+  /**
+   * The reason this exists: brokers used to be awaited one at a time before the
+   * cloud was asked at all, so a single unreachable broker delayed every ticker
+   * lookup in the app by its full timeout.
+   */
+  test("a hanging broker does not delay a provider that can answer", async () => {
+    const routes = makeRoutes({
+      brokers: [broker("dead", [result("NVDA")], 5_000)],
+      providers: [provider("cloud", [result("NVDA")])],
+    });
+
+    const started = Date.now();
+    const results = await routes.search("nvidia", { preferBroker: true, interactive: true });
+
+    expect(results.map((item) => item.symbol)).toEqual(["NVDA"]);
+    // Sequentially this waited on the broker's timeout first.
+    expect(Date.now() - started).toBeLessThan(400);
+  });
+
+  test("interactive lookups abandon a stalled source in well under a second", async () => {
+    const routes = makeRoutes({ providers: [provider("slow", [result("AAPL")], 5_000)] });
+
+    const started = Date.now();
+    const results = await routes.search("apple", { interactive: true });
+
+    expect(results).toEqual([]);
+    expect(Date.now() - started).toBeLessThan(1_500);
+  });
+
+  test("a broker that answers after the cloud upgrades the row in place", async () => {
+    const partials: InstrumentSearchResult[][] = [];
+    const routes = makeRoutes({
+      brokers: [broker("ibkr", [result("NVDA", { brokerContract: { brokerId: "ibkr" } as never })], 60)],
+      providers: [provider("cloud", [result("NVDA")])],
+    });
+
+    const first = await routes.search("nvidia", {
+      preferBroker: true,
+      interactive: true,
+      onPartial: (items) => partials.push(items),
+    });
+
+    // The cloud answers immediately and that is what the caller renders.
+    expect(first.map((item) => item.symbol)).toEqual(["NVDA"]);
+    expect(first[0]?.brokerContract).toBeUndefined();
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // The broker's richer copy replaces it without duplicating the symbol.
+    expect(partials).toHaveLength(1);
+    expect(partials[0]).toHaveLength(1);
+    expect(partials[0]?.[0]?.brokerContract).toBeDefined();
+  });
+
+  /**
+   * Racing everything would bill a metered fallback on every keystroke for an
+   * answer already in hand, so the second tier only runs when the first found
+   * nothing.
+   */
+  test("a fallback provider is not asked when the preferred one answers", async () => {
+    let fallbackCalls = 0;
+    const fallback = {
+      id: "fallback",
+      search: async () => {
+        fallbackCalls += 1;
+        return [result("WRONG")];
+      },
+    } as unknown as DataProvider;
+    const routes = makeRoutes({ providers: [provider("preferred", [result("NVDA")]), fallback] });
+
+    const results = await routes.search("nvidia", { interactive: true });
+
+    expect(results.map((item) => item.symbol)).toEqual(["NVDA"]);
+    expect(fallbackCalls).toBe(0);
+  });
+
+  test("a fallback provider is asked when the preferred one finds nothing", async () => {
+    let fallbackCalls = 0;
+    const fallback = {
+      id: "fallback",
+      search: async () => {
+        fallbackCalls += 1;
+        return [result("NVDA")];
+      },
+    } as unknown as DataProvider;
+    const routes = makeRoutes({ providers: [provider("preferred", []), fallback] });
+
+    const results = await routes.search("nvidia", { interactive: true });
+
+    expect(results.map((item) => item.symbol)).toEqual(["NVDA"]);
+    expect(fallbackCalls).toBe(1);
+  });
+
+  test("a failing broker leaves the provider result intact", async () => {
+    const routes = makeRoutes({
+      brokers: [broker("dead", null)],
+      providers: [provider("cloud", [result("MSFT")])],
+    });
+
+    const results = await routes.search("microsoft", { preferBroker: true });
+    expect(results.map((item) => item.symbol)).toEqual(["MSFT"]);
+  });
+
+  test("concurrent identical queries share one run", async () => {
+    let calls = 0;
+    const counting = {
+      id: "cloud",
+      search: async () => {
+        calls += 1;
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        return [result("TSLA")];
+      },
+    } as unknown as DataProvider;
+    const routes = makeRoutes({ providers: [counting] });
+
+    const [a, b] = await Promise.all([routes.search("tesla"), routes.search("tesla")]);
+
+    expect(a.map((item) => item.symbol)).toEqual(["TSLA"]);
+    expect(b.map((item) => item.symbol)).toEqual(["TSLA"]);
+    expect(calls).toBe(1);
+  });
+
+  test("results returned to one caller are not mutated by a later source", async () => {
+    const routes = makeRoutes({
+      brokers: [broker("late", [result("AMD")], 50)],
+      providers: [provider("cloud", [result("NVDA")])],
+    });
+
+    const first = await routes.search("chips", { preferBroker: true } as SearchRequestContext);
+    expect(first).toHaveLength(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    // The array handed back stays the answer that was handed back.
+    expect(first).toHaveLength(1);
+  });
+});

--- a/src/sources/provider-router/search.ts
+++ b/src/sources/provider-router/search.ts
@@ -7,6 +7,12 @@ const SEARCH_CACHE_TTL_MS = 30_000;
 const SEARCH_CACHE_MAX_ENTRIES = 100;
 
 const SEARCH_PROVIDER_TIMEOUT_MS = 5_000;
+/**
+ * A keystroke path cannot wait the batch budget on a source that is failing
+ * slowly. A broker whose gateway is down is the common case, and five seconds
+ * of it is indistinguishable from the feature being broken.
+ */
+const INTERACTIVE_SEARCH_TIMEOUT_MS = 800;
 
 interface BrokerSearchCandidate {
   brokerId: string;
@@ -14,9 +20,9 @@ interface BrokerSearchCandidate {
   brokerLabel: string;
 }
 
-function withSearchTimeout<T>(promise: Promise<T>): Promise<T | null> {
+function withSearchTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | null> {
   return new Promise<T | null>((resolve) => {
-    const timer = setTimeout(() => resolve(null), SEARCH_PROVIDER_TIMEOUT_MS);
+    const timer = setTimeout(() => resolve(null), timeoutMs);
     promise.then(
       (value) => { clearTimeout(timer); resolve(value); },
       () => { clearTimeout(timer); resolve(null); },
@@ -93,72 +99,119 @@ export class ProviderRouterSearchRoutes {
     const inFlight = this.searchInFlight.get(cacheKey);
     if (inFlight) return inFlight;
 
-    const task = this.fetchSearchResults(query, context, cacheKey).finally(() => {
+    const { first, settled } = this.fetchSearchResults(query, context, cacheKey);
+    // Held until every source settles, not until the first answer, so a repeat
+    // of the same query joins this run instead of starting a second one.
+    this.searchInFlight.set(cacheKey, first);
+    void settled.finally(() => {
       this.searchInFlight.delete(cacheKey);
     });
-
-    this.searchInFlight.set(cacheKey, task);
-    return task;
+    return first;
   }
 
-  private async fetchSearchResults(
+  /**
+   * Brokers and the preferred provider run at once, rather than each being
+   * awaited in turn. The old order tried brokers one at a time before the
+   * preferred provider was asked at all, so one unreachable broker delayed
+   * every lookup by its full timeout.
+   *
+   * Fallback providers stay a fallback: they are only asked when that first
+   * round found nothing, because they are metered upstreams and racing them on
+   * every keystroke would bill for answers already in hand.
+   *
+   * Ordering still matters, it just no longer costs latency: `mergeSearchResults`
+   * keeps the richest entry per symbol, so a broker arriving after the cloud
+   * still upgrades the row, and `onPartial` hands that upgrade to the caller.
+   */
+  private fetchSearchResults(
     query: string,
     context: SearchRequestContext | undefined,
     cacheKey: string,
-  ): Promise<InstrumentSearchResult[]> {
+  ): { first: Promise<InstrumentSearchResult[]>; settled: Promise<void> } {
     const results: InstrumentSearchResult[] = [];
     const resultIndexByKey = new Map<string, number>();
+    const timeoutMs = context?.interactive
+      ? INTERACTIVE_SEARCH_TIMEOUT_MS
+      : SEARCH_PROVIDER_TIMEOUT_MS;
+
     const cacheResults = (ttl = SEARCH_CACHE_TTL_MS) => {
       this.searchCache.set(cacheKey, {
         expiresAt: Date.now() + ttl,
-        results,
+        results: [...results],
       });
       if (this.searchCache.size > SEARCH_CACHE_MAX_ENTRIES) {
         this.searchCache.delete(this.searchCache.keys().next().value!);
       }
     };
-    const push = (items: InstrumentSearchResult[]) => {
+
+    let resolveFirst!: (value: InstrumentSearchResult[]) => void;
+    const first = new Promise<InstrumentSearchResult[]>((resolve) => {
+      resolveFirst = resolve;
+    });
+    let answered = false;
+
+    const record = (items: InstrumentSearchResult[] | null) => {
+      if (!items?.length) return;
       mergeSearchResults(results, resultIndexByKey, items, context);
+      cacheResults();
+      if (!answered) {
+        answered = true;
+        resolveFirst([...results]);
+        return;
+      }
+      // The caller already has an answer, so a later, richer source is handed
+      // over rather than silently dropped into the cache.
+      context?.onPartial?.([...results]);
     };
 
-    if (context?.preferBroker !== false) {
-      for (const candidate of this.deps.getBrokerCandidates(
-        context?.brokerInstanceId,
-        context?.brokerId,
-      )) {
-        if (!candidate.broker.searchInstruments) continue;
-        try {
-          const items = await withSearchTimeout(candidate.broker.searchInstruments(query, candidate.instance));
-          if (!items) continue;
-          push(annotateBrokerSearchResults(items, candidate));
-          if (results.length > 0) {
-            cacheResults();
-            return results;
-          }
-        } catch {
-          // continue through broker candidates
-        }
-      }
-    }
-
-    for (const provider of this.deps.providersInPriorityOrder()) {
+    const searchBroker = (candidate: BrokerCandidate) => (async () => {
       try {
-        const items = await withSearchTimeout(provider.search(query, context));
-        if (!items) continue;
-        push(items);
-        if (results.length > 0) {
-          cacheResults();
-          return results;
-        }
+        const items = await withSearchTimeout(
+          candidate.broker.searchInstruments!(query, candidate.instance),
+          timeoutMs,
+        );
+        record(items && annotateBrokerSearchResults(items, candidate));
+      } catch {
+        // A broker that cannot answer must not hold up the ones that can.
+      }
+    })();
+
+    const searchProvider = (provider: DataProvider) => (async () => {
+      try {
+        record(await withSearchTimeout(provider.search(query, context), timeoutMs));
       } catch (error) {
         if (shouldLogProviderError(error)) {
           this.deps.logProviderError(`${provider.id} failed: ${error}`);
         }
       }
-    }
+    })();
 
-    cacheResults(Math.min(SEARCH_CACHE_TTL_MS, 5_000));
-    return results;
+    const brokers = context?.preferBroker === false
+      ? []
+      : this.deps
+        .getBrokerCandidates(context?.brokerInstanceId, context?.brokerId)
+        .filter((candidate) => candidate.broker.searchInstruments);
+    const [preferred, ...fallbacks] = this.deps.providersInPriorityOrder();
+
+    const settled = (async () => {
+      await Promise.allSettled([
+        ...brokers.map(searchBroker),
+        ...(preferred ? [searchProvider(preferred)] : []),
+      ]);
+      if (results.length === 0) {
+        await Promise.allSettled(fallbacks.map(searchProvider));
+      }
+    })().then(() => {
+      if (!answered) {
+        answered = true;
+        // Nothing matched anywhere, so hold the empty answer briefly rather
+        // than asking every source again on the next keystroke.
+        cacheResults(Math.min(SEARCH_CACHE_TTL_MS, 5_000));
+        resolveFirst([]);
+      }
+    });
+
+    return { first, settled };
   }
 }
 

--- a/src/tickers/search/index.ts
+++ b/src/tickers/search/index.ts
@@ -117,6 +117,7 @@ export async function searchTickerCandidates({
   localLimit = 6,
   totalLimit = 8,
   includeOptionContracts = true,
+  onPartial,
 }: {
   query: string;
   tickers: ReadonlyMap<string, TickerRecord>;
@@ -125,15 +126,23 @@ export async function searchTickerCandidates({
   localLimit?: number;
   totalLimit?: number;
   includeOptionContracts?: boolean;
+  /** Called when a slower, richer source improves results already returned. */
+  onPartial?: (candidates: TickerSearchCandidate[]) => void;
 }): Promise<TickerSearchCandidate[]> {
-  return buildTickerSearchCandidates({
+  const assemble = (providerResults: InstrumentSearchResult[]) => buildTickerSearchCandidates({
     query,
     tickers,
-    providerResults: await searchProviderResults(dataProvider, query, searchContext),
+    providerResults,
     localLimit,
     totalLimit,
     includeOptionContracts,
   });
+  return assemble(await searchProviderResults(
+    dataProvider,
+    query,
+    searchContext,
+    onPartial ? (results) => onPartial(assemble(results)) : undefined,
+  ));
 }
 
 export function buildTickerSearchCandidates({
@@ -233,27 +242,43 @@ async function searchProviderResults(
   dataProvider: DataProvider,
   query: string,
   searchContext?: SearchRequestContext,
+  onPartial?: (results: InstrumentSearchResult[]) => void,
 ): Promise<InstrumentSearchResult[]> {
-  const merged: InstrumentSearchResult[] = [];
-  const seen = new Set<string>();
-
-  for (const searchQuery of buildProviderSearchQueries(query)) {
-    let results: InstrumentSearchResult[] = [];
-    try {
-      results = await dataProvider.search(searchQuery, searchContext);
-    } catch {
-      results = [];
-    }
-
+  // A Map rather than a list plus a seen set, because a later source can send
+  // back a richer version of a symbol already recorded. Overwriting a key keeps
+  // its original position, so an upgrade does not reorder the list.
+  const byKey = new Map<string, InstrumentSearchResult>();
+  const add = (results: InstrumentSearchResult[], upgrade = false) => {
     for (const result of results) {
       const key = buildProviderSearchResultKey(result);
-      if (seen.has(key)) continue;
-      seen.add(key);
-      merged.push(result);
+      if (!upgrade && byKey.has(key)) continue;
+      byKey.set(key, result);
     }
-  }
+  };
 
-  return merged;
+  // The variants are independent lookups of the same words, so they run
+  // together. Awaited in turn they multiplied every per-source timeout by the
+  // number of spellings tried.
+  await Promise.all(buildProviderSearchQueries(query).map(async (searchQuery) => {
+    try {
+      const results = await dataProvider.search(searchQuery, {
+        ...searchContext,
+        ...(onPartial
+          ? {
+            onPartial: (upgraded: InstrumentSearchResult[]) => {
+              add(upgraded, true);
+              onPartial([...byKey.values()]);
+            },
+          }
+          : {}),
+      });
+      add(results);
+    } catch {
+      // One spelling failing must not lose the others.
+    }
+  }));
+
+  return [...byKey.values()];
 }
 
 function buildProviderSearchQueries(query: string): string[] {

--- a/src/types/data-provider.ts
+++ b/src/types/data-provider.ts
@@ -93,6 +93,17 @@ export interface SearchRequestContext {
   preferBroker?: boolean;
   brokerId?: string;
   brokerInstanceId?: string;
+  /**
+   * A person is waiting on this result, so a slow source should be abandoned in
+   * well under a second rather than given the batch budget.
+   */
+  interactive?: boolean;
+  /**
+   * Called when a later source improves the result the search already returned,
+   * typically a broker adding contract detail to a symbol the cloud found
+   * first. Receives the full merged list, not a delta.
+   */
+  onPartial?: (results: InstrumentSearchResult[]) => void;
 }
 
 export interface QuoteSubscriptionTarget {


### PR DESCRIPTION
## The bug

Typing a company name showed document hits before ticker hits, even though tickers start **150ms earlier** (200ms debounce against 350ms). The reason is that `ProviderRouterSearchRoutes.search` asked every source in turn:

```ts
for (const candidate of getBrokerCandidates(...)) {
  const items = await withSearchTimeout(candidate.broker.searchInstruments(...))
  ...
}
for (const provider of providersInPriorityOrder()) {
  const items = await withSearchTimeout(provider.search(query, context))
```

Each broker is awaited on its own before the preferred provider is asked at all, and `SEARCH_PROVIDER_TIMEOUT_MS` was **5000ms** per step. So one unreachable broker delayed every ticker lookup in the app by five seconds. A failing IBKR Gateway is the ordinary way to reach that state.

`searchProviderResults` in `src/tickers/search/index.ts` had the same shape one level up: it awaited each query variant in turn, multiplying the per-source timeout by the number of spellings tried.

Measured against production, documents are steady where tickers are not:

| | cold | warm |
|---|---|---|
| `/cloud/search` (documents) | 94ms | 88ms |
| `/market/search` (tickers) | 130-315ms | 82-96ms |

## The change

- Brokers and the preferred provider run **together**; the first useful answer returns.
- **Fallback providers stay a fallback**, only asked when that round found nothing. They are metered upstreams and racing them on every keystroke would bill for answers already in hand. An existing test (`AssetDataRouter > does not search fallback providers when the preferred provider returns results`) caught the first version of this change, which raced everything.
- Ordering still decides what is shown: the merge keeps the richest entry per symbol, so a broker answering after the cloud **upgrades the row in place** rather than duplicating it. That upgrade reaches the caller through a new optional `onPartial`, and the command bar re-renders on it.
- Interactive lookups get an **800ms** budget instead of 5s.
- Query variants run concurrently.

## Verification

`bun run typecheck` clean across six projects; `bun test` 2385 passing, 0 failing.

Eight new tests in `src/sources/provider-router/search.test.ts`. Three of them fail against the previous implementation with exactly the reported symptom, at **5001ms**:

```
(fail) a hanging broker does not delay a provider that can answer   [5001.59ms]
(fail) interactive lookups abandon a stalled source in well under a second [5001.00ms]
(fail) a broker that answers after the cloud upgrades the row in place
```

They also cover the two fallback cases in both directions, that a failing broker leaves the provider result intact, that concurrent identical queries share one run, and that an array already handed to a caller is not mutated when a later source lands.

## Risk

This is on the path of every ticker lookup in the app, which is why it is separate from #678 rather than folded into it. The behaviour that changed deliberately is concurrency and the interactive timeout; result ordering, richness preference, caching and in-flight de-duplication are unchanged and covered.