### PR TITLE
Allow the plugin registry origin on the hosted build

### DIFF
--- a/src/plugins/builtin/plugin-marketplace/feed.ts
+++ b/src/plugins/builtin/plugin-marketplace/feed.ts
@@ -2,14 +2,13 @@ import { createThrottledFetch } from "../../../utils/throttled-fetch";
 import type { RegistryFeed, RegistryPlugin } from "./model";
 
 /**
- * The custom domain is canonical. The workers.dev origin is the same Worker and
- * is tried only if the first request fails, which covers a DNS or certificate
- * problem on the custom hostname without taking the marketplace down.
+ * Exported so the hosted build's CSP can be checked against it. The browser
+ * renderer can only reach origins listed in `connect-src`, and a blocked fetch
+ * shows up as an empty catalog rather than an error, so the two are pinned
+ * together by a test.
  */
-const REGISTRY_URLS = [
-  "https://plugins.gloom.sh/registry.json",
-  "https://gloomberb-plugins.lyser.workers.dev/registry.json",
-] as const;
+export const REGISTRY_ORIGIN = "https://plugins.gloom.sh";
+const REGISTRY_URL = `${REGISTRY_ORIGIN}/registry.json`;
 const FRESH_MS = 15 * 60_000;
 
 const registryFetch = createThrottledFetch({
@@ -55,17 +54,9 @@ export async function loadRegistry(options: { force?: boolean } = {}): Promise<F
 
   if (!inFlight) {
     inFlight = (async () => {
-      let lastError: unknown = new Error("No registry endpoint configured");
-      for (const url of REGISTRY_URLS) {
-        try {
-          const response = await registryFetch.fetch(url);
-          if (!response.ok) throw new Error(`Registry request failed (${response.status})`);
-          return parseFeed(await response.json());
-        } catch (error) {
-          lastError = error;
-        }
-      }
-      throw lastError;
+      const response = await registryFetch.fetch(REGISTRY_URL);
+      if (!response.ok) throw new Error(`Registry request failed (${response.status})`);
+      return parseFeed(await response.json());
     })().finally(() => {
       inFlight = null;
     });

--- a/src/renderers/cloudflare/worker.test.ts
+++ b/src/renderers/cloudflare/worker.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { handleRequest, SECURITY_HEADERS, type WorkerEnv } from "./worker";
+import { REGISTRY_ORIGIN } from "../../plugins/builtin/plugin-marketplace/feed";
 
 function fixture() {
   const requests: Request[] = [];
@@ -132,5 +133,23 @@ describe("static Cloudflare host", () => {
     }), env);
     expect(response.status).toBe(405);
     expect(requests).toHaveLength(0);
+  });
+});
+
+/**
+ * The hosted build can only reach origins listed in `connect-src`. A blocked
+ * fetch is not an error the user can act on: the plugin marketplace just shows
+ * an empty catalog. This shipped that way once, because the pane was verified
+ * on the terminal and desktop but not on the web build, so the two values are
+ * pinned to each other here.
+ */
+describe("content security policy", () => {
+  test("allows the plugin registry the marketplace fetches", () => {
+    const connectSrc = SECURITY_HEADERS["content-security-policy"]
+      .split(";")
+      .map((directive) => directive.trim())
+      .find((directive) => directive.startsWith("connect-src"));
+
+    expect(connectSrc).toContain(REGISTRY_ORIGIN);
   });
 });

--- a/src/renderers/cloudflare/worker.ts
+++ b/src/renderers/cloudflare/worker.ts
@@ -39,7 +39,7 @@ const API_METHODS = new Set(["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "O
 type ApiFetch = (request: Request) => Promise<Response>;
 
 export const SECURITY_HEADERS = {
-  "content-security-policy": "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; media-src 'self' https:; connect-src 'self' https://api.github.com https://api.fiscaldata.treasury.gov; form-action 'self'; upgrade-insecure-requests",
+  "content-security-policy": "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; media-src 'self' https:; connect-src 'self' https://api.github.com https://api.fiscaldata.treasury.gov https://plugins.gloom.sh; form-action 'self'; upgrade-insecure-requests",
   "cross-origin-opener-policy": "same-origin",
   "cross-origin-resource-policy": "same-origin",
   "permissions-policy": "camera=(), geolocation=(), microphone=(), payment=(), usb=()",


### PR DESCRIPTION
The plugin marketplace does not work on term.gloom.sh. It fetches `plugins.gloom.sh`, which is not in the hosted build's `connect-src`, so the browse list is empty and the footer reads "catalog unavailable".

Confirmed against the deployed header:

```
connect-src 'self' https://api.github.com https://api.fiscaldata.treasury.gov
```

I verified that pane in the terminal and on the desktop and never on the web build, which is how it shipped.

The failure mode is why this needs a test rather than just a fix: a CSP-blocked fetch surfaces as an empty catalog, not as an error anyone can act on. `connect-src` and the origin the marketplace actually requests are now pinned to each other, with the origin exported from `feed.ts` so there is one value rather than two copies. Confirmed the test fails when the entry is removed.

Also drops the workers.dev fallback URL. It pointed at the standalone Worker that served this feed before it moved to the website, so since that Worker was deleted every failure spent an extra request on a hostname that no longer resolves.