### PR TITLE
Fix table navigation hot paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "typecheck:cloudflare": "tsc --project tsconfig.cloudflare.json",
     "typecheck:scripts": "tsc --project tsconfig.scripts.json",
     "test": "bun test",
+    "benchmark:tui:navigation": "bun run scripts/benchmark-tui-navigation.ts",
     "test:global-upgrade": "bun run scripts/smoke-global-upgrade.ts",
     "release": "./scripts/release.sh"
   },

--- a/scripts/benchmark-tui-navigation.ts
+++ b/scripts/benchmark-tui-navigation.ts
@@ -1,0 +1,275 @@
+import { Database } from "bun:sqlite";
+import { existsSync } from "fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+import { createDefaultConfig } from "../src/types/config";
+import { SqliteDatabase } from "../src/data/sqlite/database";
+import { sendRemoteControlRequest } from "../src/remote/client";
+import {
+  summarizeInteractionPerformance,
+  type InteractionPerformanceSample,
+} from "../src/renderers/opentui/interaction-performance";
+
+interface Options {
+  command: string;
+  count: number;
+  intervalMs: number;
+  output: string;
+  width: number;
+  height: number;
+}
+
+interface CachedSeriesRow {
+  namespace: string;
+  kind: string;
+  entity_key: string;
+  variant_key: string;
+  source_key: string;
+  schema_version: number;
+  payload: string;
+  provenance: string | null;
+  fetched_at: number;
+  stale_at: number;
+  expires_at: number;
+  last_accessed_at: number;
+  size_bytes: number;
+}
+
+const root = resolve(import.meta.dir, "..");
+const options = parseOptions(process.argv.slice(2));
+const session = `gloomberb-nav-${process.pid}`;
+const sandbox = await mkdtemp(join(tmpdir(), "gloomberb-nav-"));
+const sandboxHome = join(sandbox, "home");
+const dataDir = join(sandboxHome, ".gloomberb");
+const appLog = join(sandbox, "app.log");
+
+try {
+  if (!Bun.which("tmux")) throw new Error("tmux is required for the TUI navigation benchmark.");
+  await rm(options.output, { force: true });
+  await seedSandbox(dataDir);
+  await runTmux(["kill-session", "-t", session], false);
+  await runTmux([
+    "new-session",
+    "-d",
+    "-s",
+    session,
+    "-x",
+    String(options.width),
+    "-y",
+    String(options.height),
+    "-c",
+    root,
+    `env HOME=${shellQuote(sandboxHome)} GLOOMBERB_INTERACTION_PERF=${shellQuote(options.output)} bun src/index.tsx`,
+  ]);
+  await runTmux(["pipe-pane", "-o", "-t", session, `cat > ${shellQuote(appLog)}`]);
+
+  await waitForFile(join(dataDir, "remote-control.tui.json"), 15_000);
+  await Bun.sleep(500);
+  await runTmux(["send-keys", "-t", session, "C-p"]);
+  await Bun.sleep(100);
+  await runTmux(["send-keys", "-t", session, "-l", options.command]);
+  await runTmux(["send-keys", "-t", session, "Enter"]);
+  await waitForPopulatedTable(dataDir, 15_000);
+  await Bun.sleep(500);
+
+  await sendNavigation("Down", 2, 35);
+  await sendNavigation("Up", 2, 35);
+  await Bun.sleep(250);
+  await sendNavigation("Down", options.count, options.intervalMs);
+  await Bun.sleep(250);
+  await sendNavigation("Up", options.count, options.intervalMs);
+  await Bun.sleep(500);
+
+  await runTmux(["send-keys", "-t", session, "C-c"]);
+  await waitForFile(options.output, 3_000);
+
+  const report = JSON.parse(await readFile(options.output, "utf8")) as {
+    samples: InteractionPerformanceSample[];
+  };
+  const allNavigationSamples = report.samples
+    .filter((sample) => sample.key === "up" || sample.key === "down");
+  const expectedSampleCount = options.count * 2 + 4;
+  if (allNavigationSamples.length !== expectedSampleCount) {
+    throw new Error(
+      `Expected ${expectedSampleCount} framed navigation inputs, received ${allNavigationSamples.length}.`,
+    );
+  }
+  const navigation = allNavigationSamples.slice(4);
+  if (navigation.every((sample) => sample.cellsUpdated === 0)) {
+    throw new Error("Navigation inputs produced no rendered cell updates.");
+  }
+  const summary = summarizeInteractionPerformance(navigation);
+  const peakRssBytes = navigation.reduce((maximum, sample) => Math.max(maximum, sample.rssBytes), 0);
+  const cells = navigation.map((sample) => sample.cellsUpdated).sort((left, right) => left - right);
+  const medianCellsUpdated = cells.length === 0
+    ? 0
+    : cells.length % 2 === 0
+      ? (cells[cells.length / 2 - 1]! + cells[cells.length / 2]!) / 2
+      : cells[Math.floor(cells.length / 2)]!;
+  console.log(JSON.stringify({
+    command: options.command,
+    dimensions: { width: options.width, height: options.height },
+    intervalMs: options.intervalMs,
+    medianCellsUpdated,
+    output: options.output,
+    peakRssMiB: Math.round((peakRssBytes / 1024 / 1024) * 10) / 10,
+    summary,
+  }, null, 2));
+} finally {
+  await runTmux(["kill-session", "-t", session], false);
+  await rm(sandbox, { recursive: true, force: true });
+}
+
+async function sendNavigation(key: "Up" | "Down", count: number, intervalMs: number) {
+  for (let index = 0; index < count; index += 1) {
+    await runTmux(["send-keys", "-t", session, key]);
+    if (index < count - 1) await Bun.sleep(intervalMs);
+  }
+}
+
+async function seedSandbox(targetDataDir: string): Promise<void> {
+  await mkdir(targetDataDir, { recursive: true });
+  const config = {
+    ...createDefaultConfig(targetDataDir),
+    onboardingComplete: true,
+  };
+  await writeFile(join(targetDataDir, "config.json"), `${JSON.stringify(config, null, 2)}\n`, "utf8");
+
+  const target = new SqliteDatabase(join(targetDataDir, ".gloomberb-cache.db"));
+  try {
+    const sourcePath = await currentDatabasePath();
+    if (!sourcePath || !existsSync(sourcePath)) return;
+    const source = new Database(sourcePath, { readonly: true });
+    try {
+      const rows = source.query(`
+        SELECT namespace, kind, entity_key, variant_key, source_key,
+               schema_version, payload, provenance, fetched_at, stale_at,
+               expires_at, last_accessed_at, size_bytes
+        FROM resource_cache
+        WHERE kind = 'econ-statistics-series'
+      `).all() as CachedSeriesRow[];
+      const insert = target.connection.prepare(`
+        INSERT OR REPLACE INTO resource_cache (
+          namespace, kind, entity_key, variant_key, source_key,
+          schema_version, payload, provenance, fetched_at, stale_at,
+          expires_at, last_accessed_at, size_bytes
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      target.connection.transaction((entries: typeof rows) => {
+        for (const row of entries) {
+          insert.run(
+            row.namespace,
+            row.kind,
+            row.entity_key,
+            row.variant_key,
+            row.source_key,
+            row.schema_version,
+            row.payload,
+            row.provenance,
+            row.fetched_at,
+            row.stale_at,
+            row.expires_at,
+            row.last_accessed_at,
+            row.size_bytes,
+          );
+        }
+      })(rows);
+    } finally {
+      source.close();
+    }
+  } finally {
+    target.close();
+  }
+}
+
+async function currentDatabasePath(): Promise<string | null> {
+  const home = process.env.HOME;
+  if (!home) return null;
+  try {
+    const globalConfig = JSON.parse(await readFile(join(home, ".gloomberb", "config.json"), "utf8")) as {
+      dataDir?: string;
+    };
+    return join(globalConfig.dataDir || join(home, ".gloomberb"), ".gloomberb-cache.db");
+  } catch {
+    return join(home, ".gloomberb", ".gloomberb-cache.db");
+  }
+}
+
+async function runTmux(args: string[], check = true): Promise<void> {
+  const process = Bun.spawn(["tmux", ...args], { stdout: "pipe", stderr: "pipe" });
+  const [exitCode, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stderr).text(),
+  ]);
+  if (check && exitCode !== 0) {
+    throw new Error(`tmux ${args[0]} failed: ${stderr.trim() || `exit ${exitCode}`}`);
+  }
+}
+
+async function waitForFile(path: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) return;
+    await Bun.sleep(50);
+  }
+  throw new Error(`Benchmark report was not written: ${path}`);
+}
+
+async function waitForPopulatedTable(targetDataDir: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await sendRemoteControlRequest(
+        { type: "get", resource: "ui://tree" },
+        { dataDir: targetDataDir, appKind: "tui" },
+      );
+      if (response.ok && Array.isArray(response.data)) {
+        const ready = response.data.some((node: unknown) => {
+          if (!node || typeof node !== "object") return false;
+          const candidate = node as { role?: unknown; metadata?: { rowCount?: unknown } };
+          return candidate.role === "table"
+            && typeof candidate.metadata?.rowCount === "number"
+            && candidate.metadata.rowCount > 1;
+        });
+        if (ready) return;
+      }
+    } catch {
+      // The app may still be replacing its command-bar surface.
+    }
+    await Bun.sleep(50);
+  }
+  throw new Error(`Command ${options.command} did not render a populated table.`);
+}
+
+function parseOptions(args: string[]): Options {
+  const output = takeOption(args, "--output")
+    ?? join(tmpdir(), `gloomberb-navigation-${Date.now()}.json`);
+  return {
+    command: takeOption(args, "--command") ?? "ECST",
+    count: positiveInteger(takeOption(args, "--count"), 12, "count"),
+    intervalMs: positiveInteger(takeOption(args, "--interval"), 25, "interval"),
+    output: resolve(output),
+    width: positiveInteger(takeOption(args, "--width"), 140, "width"),
+    height: positiveInteger(takeOption(args, "--height"), 45, "height"),
+  };
+}
+
+function takeOption(args: string[], name: string): string | undefined {
+  const equals = args.find((argument) => argument.startsWith(`${name}=`));
+  if (equals) return equals.slice(name.length + 1);
+  const index = args.indexOf(name);
+  if (index < 0) return undefined;
+  return args[index + 1];
+}
+
+function positiveInteger(raw: string | undefined, fallback: number, label: string): number {
+  if (raw == null) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) throw new Error(`${label} must be a positive integer.`);
+  return value;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}

--- a/scripts/benchmark-tui-navigation.ts
+++ b/scripts/benchmark-tui-navigation.ts
@@ -14,6 +14,7 @@ import {
 interface Options {
   command: string;
   count: number;
+  expectedPaneId: string;
   intervalMs: number;
   output: string;
   width: number;
@@ -70,7 +71,7 @@ try {
   await Bun.sleep(100);
   await runTmux(["send-keys", "-t", session, "-l", options.command]);
   await runTmux(["send-keys", "-t", session, "Enter"]);
-  await waitForPopulatedTable(dataDir, 15_000);
+  await waitForPopulatedTable(dataDir, options.expectedPaneId, 15_000);
   await Bun.sleep(500);
 
   await sendNavigation("Down", 2, 35);
@@ -96,12 +97,20 @@ try {
     );
   }
   const navigation = allNavigationSamples.slice(4);
-  if (navigation.every((sample) => sample.cellsUpdated === 0)) {
+  const navigationFrames = [...new Map(
+    navigation.map((sample) => [sample.frameId, sample]),
+  ).values()];
+  if (navigationFrames.every((sample) => sample.cellsUpdated === 0)) {
     throw new Error("Navigation inputs produced no rendered cell updates.");
   }
   const summary = summarizeInteractionPerformance(navigation);
-  const peakRssBytes = navigation.reduce((maximum, sample) => Math.max(maximum, sample.rssBytes), 0);
-  const cells = navigation.map((sample) => sample.cellsUpdated).sort((left, right) => left - right);
+  const peakRssBytes = navigationFrames.reduce(
+    (maximum, sample) => Math.max(maximum, sample.rssBytes),
+    0,
+  );
+  const cells = navigationFrames
+    .map((sample) => sample.cellsUpdated)
+    .sort((left, right) => left - right);
   const medianCellsUpdated = cells.length === 0
     ? 0
     : cells.length % 2 === 0
@@ -216,39 +225,77 @@ async function waitForFile(path: string, timeoutMs: number): Promise<void> {
   throw new Error(`Benchmark report was not written: ${path}`);
 }
 
-async function waitForPopulatedTable(targetDataDir: string, timeoutMs: number): Promise<void> {
+async function waitForPopulatedTable(
+  targetDataDir: string,
+  expectedPaneId: string,
+  timeoutMs: number,
+): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
       const response = await sendRemoteControlRequest(
-        { type: "get", resource: "ui://tree" },
+        { type: "get", resource: "app://snapshot" },
         { dataDir: targetDataDir, appKind: "tui" },
       );
-      if (response.ok && Array.isArray(response.data)) {
-        const ready = response.data.some((node: unknown) => {
-          if (!node || typeof node !== "object") return false;
-          const candidate = node as { role?: unknown; metadata?: { rowCount?: unknown } };
-          return candidate.role === "table"
-            && typeof candidate.metadata?.rowCount === "number"
-            && candidate.metadata.rowCount > 1;
+      if (response.ok && response.data && typeof response.data === "object") {
+        const snapshot = response.data as {
+          app?: { commandBarOpen?: unknown; focusedPaneId?: unknown };
+          panes?: Array<{ instanceId?: unknown; paneId?: unknown; focused?: unknown }>;
+          ui?: Array<{
+            role?: unknown;
+            metadata?: { paneInstanceId?: unknown; rowCount?: unknown };
+          }>;
+        };
+        const focusedPane = snapshot.panes?.find((pane) => (
+          pane.focused === true
+          || pane.instanceId === snapshot.app?.focusedPaneId
+        ));
+        const hasPopulatedTable = snapshot.ui?.some((node) => {
+          const metadata = node.metadata;
+          if (!metadata) return false;
+          return node.role === "table"
+            && metadata.paneInstanceId === focusedPane?.instanceId
+            && typeof metadata.rowCount === "number"
+            && metadata.rowCount > 1;
         });
-        if (ready) return;
+        if (
+          snapshot.app?.commandBarOpen === false
+          && focusedPane?.paneId === expectedPaneId
+          && hasPopulatedTable
+        ) return;
       }
     } catch {
       // The app may still be replacing its command-bar surface.
     }
     await Bun.sleep(50);
   }
-  throw new Error(`Command ${options.command} did not render a populated table.`);
+  throw new Error(
+    `Command ${options.command} did not focus pane ${expectedPaneId} with a populated table.`,
+  );
 }
 
 function parseOptions(args: string[]): Options {
   const output = takeOption(args, "--output")
     ?? join(tmpdir(), `gloomberb-navigation-${Date.now()}.json`);
+  const command = takeOption(args, "--command") ?? "ECST";
+  const expectedPaneId = takeOption(args, "--pane-id")
+    ?? (command.trim().split(/\s+/, 1)[0]?.toUpperCase() === "ECST" ? "econ-statistics" : null);
+  if (!expectedPaneId) {
+    throw new Error("--pane-id is required when benchmarking a command other than ECST.");
+  }
   return {
-    command: takeOption(args, "--command") ?? "ECST",
-    count: positiveInteger(takeOption(args, "--count"), 12, "count"),
-    intervalMs: positiveInteger(takeOption(args, "--interval"), 25, "interval"),
+    command,
+    count: positiveInteger(
+      takeOption(args, "--count") ?? takeOption(args, "--keys"),
+      12,
+      "count",
+    ),
+    expectedPaneId,
+    intervalMs: positiveInteger(
+      takeOption(args, "--interval") ?? takeOption(args, "--interval-ms"),
+      25,
+      "interval",
+    ),
     output: resolve(output),
     width: positiveInteger(takeOption(args, "--width"), 140, "width"),
     height: positiveInteger(takeOption(args, "--height"), 45, "height"),

--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -54,7 +54,13 @@ function assignRef(ref: ForwardedRef<any>, value: any) {
   else if (ref) ref.current = value;
 }
 
-function CaptureChartSurfaceProvider({ children }: { children: ReactNode }) {
+function CaptureChartSurfaceProvider({
+  children,
+  canvasCharts = false,
+}: {
+  children: ReactNode;
+  canvasCharts?: boolean;
+}) {
   const baseUi = useUiHost();
   const renderer = useRendererHost();
   const nativeRenderer = useNativeRenderer();
@@ -72,8 +78,14 @@ function CaptureChartSurfaceProvider({ children }: { children: ReactNode }) {
     });
   }, [baseUi]);
   const ui = useMemo(
-    () => ({ ...baseUi, ChartSurface: CapturingChartSurface }),
-    [CapturingChartSurface, baseUi],
+    () => ({
+      ...baseUi,
+      ChartSurface: CapturingChartSurface,
+      capabilities: canvasCharts
+        ? { ...baseUi.capabilities, canvasCharts: true, nativeCharts: false }
+        : baseUi.capabilities,
+    }),
+    [CapturingChartSurface, baseUi, canvasCharts],
   );
   return (
     <UiHostProvider ui={ui} renderer={renderer} nativeRenderer={nativeRenderer}>
@@ -245,6 +257,31 @@ describe("CompositeChart", () => {
     const expectedBackground = getThemeColors(nextThemeId).bg;
     const expectedRgb = [1, 3, 5].map((offset) => parseInt(expectedBackground.slice(offset, offset + 2), 16));
     expect(Array.from(bitmap.pixels.slice(0, 3))).toEqual(expectedRgb);
+  });
+
+  test("does not allocate a native raster when braille rendering is forced", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-composite-braille");
+    config.chartPreferences.renderer = "braille";
+
+    testSetup = await testRender(
+      <AppContext value={{ state: createInitialState(config), dispatch: () => {} }}>
+        <CaptureChartSurfaceProvider>
+          <CompositeChart
+            width={60}
+            height={12}
+            series={[series("price", "main", "left", "USD", [100, 101, 102])]}
+            panels={[{ id: "main" }]}
+          />
+        </CaptureChartSurfaceProvider>
+      </AppContext>,
+      { width: 62, height: 14 },
+    );
+    await act(async () => {
+      await testSetup!.renderOnce();
+      await testSetup!.renderOnce();
+    });
+
+    expect(capturedSurfaceProps!.bitmaps).toBeNull();
   });
 
   test("shows the regular-session move beside the latest intraday value", async () => {
@@ -1575,7 +1612,7 @@ describe("CompositeChart", () => {
       testSetup = await testRender(
         <AppContext value={{ state: createInitialState(config), dispatch: () => {} }}>
           <PaneInstanceProvider paneId="chart:test">
-            <CaptureChartSurfaceProvider>
+            <CaptureChartSurfaceProvider canvasCharts>
               <CompositeChart
                 width={60}
                 height={12}

--- a/src/components/chart/static/chart/bitmap.ts
+++ b/src/components/chart/static/chart/bitmap.ts
@@ -1,6 +1,9 @@
 import { useMemo } from "react";
 import { useNativeRenderer, useUiCapabilities } from "../../../../ui";
+import { useOptionalAppSelector } from "../../../../state/app/context";
+import type { ChartRendererPreference } from "../../core/types";
 import { resolveNativeBitmapSize, shouldRenderNativeBitmap } from "../../native/bitmap-support";
+import { useResolvedChartRendererState } from "../../native/renderer-selection";
 
 export interface StaticChartBitmapSize {
   pixelWidth: number;
@@ -16,13 +19,22 @@ export function useStaticChartBitmapSize(width: number, height: number): StaticC
     pixelRatio = 1,
   } = useUiCapabilities();
   const nativeRenderer = useNativeRenderer();
+  const preferredRenderer = useOptionalAppSelector<ChartRendererPreference | null>(
+    (state) => state.config.chartPreferences.renderer,
+    null,
+  );
+  const rendererState = useResolvedChartRendererState(
+    nativeCharts === true ? preferredRenderer ?? "auto" : "braille",
+    nativeRenderer,
+  );
   const rendererCapabilities = nativeRenderer.capabilities;
   const rendererResolution = nativeRenderer.resolution;
   const rendererTerminalWidth = nativeRenderer.terminalWidth;
   const rendererTerminalHeight = nativeRenderer.terminalHeight;
 
   return useMemo(() => {
-    if (shouldRenderNativeBitmap(nativeRenderer, nativeCharts === true)) {
+    const nativeRendererActive = preferredRenderer === null || rendererState.renderer === "kitty";
+    if (nativeRendererActive && shouldRenderNativeBitmap(nativeRenderer, nativeCharts === true)) {
       return resolveNativeBitmapSize({
         width,
         height,
@@ -48,8 +60,10 @@ export function useStaticChartBitmapSize(width: number, height: number): StaticC
     nativeCharts,
     nativeRenderer,
     pixelRatio,
+    preferredRenderer,
     rendererCapabilities,
     rendererResolution,
+    rendererState.renderer,
     rendererTerminalHeight,
     rendererTerminalWidth,
     width,

--- a/src/components/data-table/view.test.tsx
+++ b/src/components/data-table/view.test.tsx
@@ -43,7 +43,7 @@ afterEach(async () => {
   testSetup = undefined;
 });
 
-function Harness() {
+function Harness({ onCursor = () => {} }: { onCursor?: () => void }) {
   const [selectedIndex, setSelectedIndex] = useState(1);
   const [cursorIndex, setCursorIndex] = useState(1);
   const [activatedTitle, setActivatedTitle] = useState("");
@@ -64,7 +64,10 @@ function Harness() {
             selectedIndex,
             onChange: (index) => setSelectedIndex(index),
           }}
-          onCursorChange={(_row, index) => setCursorIndex(index)}
+          onCursorChange={(_row, index) => {
+            onCursor();
+            setCursorIndex(index);
+          }}
           onActivate={(row) => {
             if (row.type === "row") setActivatedTitle(row.title);
           }}
@@ -122,6 +125,7 @@ function LargeSelectionHarness({
             return { text: row.title + (index === 500 ? "" : "") };
           }}
           emptyStateTitle="No rows"
+          scrollToIndex={500}
         />
       </PaneInstanceProvider>
     </AppContext>
@@ -228,6 +232,20 @@ describe("DataTableView", () => {
     expect(testSetup.captureCharFrame()).toContain("cursor=Second row selected=First row activated=First row");
   });
 
+  test("does no cursor or scroll work when navigation is already at an edge", async () => {
+    let cursorChanges = 0;
+    testSetup = await testRender(
+      <Harness onCursor={() => { cursorChanges += 1; }} />,
+      { width: 60, height: 12 },
+    );
+
+    await renderSettled();
+    await emitKeypress({ name: "up", sequence: "\u001B[A" });
+    await renderSettled();
+
+    expect(cursorChanges).toBe(0);
+  });
+
   test("keeps selection current across repeated keypresses before the next render", async () => {
     testSetup = await testRender(<Harness />, { width: 60, height: 12 });
 
@@ -242,19 +260,40 @@ describe("DataTableView", () => {
     expect(testSetup.captureCharFrame()).toContain("selected=Third row activated=Third row");
   });
 
-  test("does not scan every row when the selected index is explicit", async () => {
-    let isSelectedCalls = 0;
+  test("keeps the immediate cursor visible while a controlled selection is deferred", async () => {
+    testSetup = await testRender(
+      <LargeSelectionHarness onIsSelected={() => {}} />,
+      { width: 60, height: 12 },
+    );
+
+    await renderSettled();
+    await emitKeypressBatch(Array.from({ length: 30 }, () => ({
+      name: "down",
+      sequence: "\u001B[B",
+    })));
+    await renderSettled();
+
+    expect(testSetup.captureCharFrame()).toContain("Row 530");
+  });
+
+  test("renders only the visible rows and the rows changed by navigation", async () => {
+    let renderedCells = 0;
     testSetup = await testRender(
       <LargeSelectionHarness
         onIsSelected={() => {
-          isSelectedCalls += 1;
+          renderedCells += 1;
         }}
       />,
       { width: 60, height: 12 },
     );
 
     await renderSettled();
+    expect(renderedCells).toBeLessThan(150);
 
-    expect(isSelectedCalls).toBeLessThan(150);
+    const beforeNavigation = renderedCells;
+    await emitKeypress({ name: "down", sequence: "\u001B[B" });
+    await renderSettled();
+
+    expect(renderedCells - beforeNavigation).toBeLessThanOrEqual(4);
   });
 });

--- a/src/components/data-table/view.tsx
+++ b/src/components/data-table/view.tsx
@@ -80,6 +80,11 @@ export interface DataTableViewProps<
   focused?: boolean;
   selection: DataTableSelection<T>;
   onActivate?: (item: T, index: number) => void;
+  /**
+   * Fires immediately as the lightweight visual cursor moves. Expensive detail
+   * work and persisted selection belong in selection.onChange, which is
+   * coalesced across keyboard repeats.
+   */
   onCursorChange?: (
     item: T,
     index: number,
@@ -198,20 +203,39 @@ export function DataTableView<
   effectiveSelectedIndexRef.current = effectiveSelectedIndex;
   const [selectionScrollVersion, setSelectionScrollVersion] = useState(0);
   const [selectionScrollTarget, setSelectionScrollTarget] = useState<number | null>(null);
+  const selectionScrollTargetRef = useRef<number | null>(null);
   const lastExternalSelectionScrollRef = useRef<{
     kind: DataTableSelection<T>["kind"];
     key: string | number | null;
     resolved: boolean;
   } | null>(null);
-  const effectiveScrollToIndex = scrollToIndex !== undefined
-    ? scrollToIndex
-    : selectionScrollTarget;
+  const effectiveScrollToIndex = selectionScrollTarget ?? scrollToIndex;
 
   const requestSelectionScroll = useCallback((index: number) => {
-    if (scrollToIndex !== undefined || index < 0) return;
+    if (index < 0 || selectionScrollTargetRef.current === index) return;
+    const scrollBox = effectiveScrollRef.current;
+    const viewportHeight = scrollBox?.viewport?.height;
+    const scrollTop = scrollBox?.scrollTop;
+    if (
+      typeof viewportHeight === "number"
+      && typeof scrollTop === "number"
+      && index >= Math.floor(scrollTop)
+      && index < Math.floor(scrollTop) + Math.max(1, Math.floor(viewportHeight))
+    ) return;
+    selectionScrollTargetRef.current = index;
     setSelectionScrollTarget(index);
     setSelectionScrollVersion((current) => current + 1);
-  }, [scrollToIndex]);
+  }, [effectiveScrollRef]);
+  const clearSelectionScrollTarget = useCallback(() => {
+    if (selectionScrollTargetRef.current === null) return;
+    selectionScrollTargetRef.current = null;
+    setSelectionScrollTarget(null);
+  }, []);
+
+  useEffect(() => {
+    if (scrollToIndex === undefined) return;
+    clearSelectionScrollTarget();
+  }, [clearSelectionScrollTarget, scrollToIndex, scrollToIndexVersion]);
 
   const clearPendingCommit = useCallback(() => {
     if (pendingCommitTimerRef.current) {
@@ -220,7 +244,8 @@ export function DataTableView<
     }
     pendingCommitRef.current = false;
     pendingCommitTargetRef.current = null;
-  }, []);
+    clearSelectionScrollTarget();
+  }, [clearSelectionScrollTarget]);
 
   useEffect(() => {
     if (selection.kind === "none") {
@@ -268,7 +293,7 @@ export function DataTableView<
     lastExternalSelectionScrollRef.current = current;
 
     if (selection.kind === "none") {
-      if (scrollToIndex === undefined) setSelectionScrollTarget(null);
+      clearSelectionScrollTarget();
       return;
     }
     if (effectiveSelectedIndex < 0) return;
@@ -281,6 +306,7 @@ export function DataTableView<
       requestSelectionScroll(effectiveSelectedIndex);
     }
   }, [
+    clearSelectionScrollTarget,
     effectiveSelectedIndex,
     requestSelectionScroll,
     scrollToIndex,
@@ -360,9 +386,10 @@ export function DataTableView<
       pendingCommitRef.current = false;
       const pendingTarget = pendingCommitTargetRef.current;
       pendingCommitTargetRef.current = null;
+      clearSelectionScrollTarget();
       commitTarget(pendingTarget, "keyboard");
     }, DATA_TABLE_SELECTION_COMMIT_DELAY_MS);
-  }, [commitTarget, getCommitTarget, selection.kind]);
+  }, [clearSelectionScrollTarget, commitTarget, getCommitTarget, selection.kind]);
 
   const updateCursorIndex = useCallback((
     index: number,
@@ -375,13 +402,17 @@ export function DataTableView<
     if (index < 0 || index >= tableProps.items.length) return;
     const item = tableProps.items[index]!;
     if (isNavigable && !isNavigable(item, index)) return;
-    effectiveSelectedIndexRef.current = index;
-    setCursorIndex(index);
     const reason = options.reason ?? (options.commit === "deferred"
       ? "keyboard"
       : options.commit === "immediate"
         ? "pointer"
         : "keyboard");
+    if (effectiveSelectedIndexRef.current === index) {
+      if (options.commit === "immediate") commitIndexImmediately(index, reason);
+      return;
+    }
+    effectiveSelectedIndexRef.current = index;
+    setCursorIndex(index);
     onCursorChange?.(item, index, reason);
     if (options.commit === "deferred") {
       requestSelectionScroll(index);

--- a/src/components/data-table/view.tsx
+++ b/src/components/data-table/view.tsx
@@ -209,7 +209,18 @@ export function DataTableView<
     key: string | number | null;
     resolved: boolean;
   } | null>(null);
-  const effectiveScrollToIndex = selectionScrollTarget ?? scrollToIndex;
+  const lastControlledScrollRequestRef = useRef({
+    index: scrollToIndex,
+    version: scrollToIndexVersion,
+  });
+  const controlledScrollRequestChanged = scrollToIndex !== undefined
+    && (
+      lastControlledScrollRequestRef.current.index !== scrollToIndex
+      || lastControlledScrollRequestRef.current.version !== scrollToIndexVersion
+    );
+  const effectiveScrollToIndex = controlledScrollRequestChanged
+    ? scrollToIndex
+    : selectionScrollTarget ?? scrollToIndex;
 
   const requestSelectionScroll = useCallback((index: number) => {
     if (index < 0 || selectionScrollTargetRef.current === index) return;
@@ -233,6 +244,10 @@ export function DataTableView<
   }, []);
 
   useEffect(() => {
+    lastControlledScrollRequestRef.current = {
+      index: scrollToIndex,
+      version: scrollToIndexVersion,
+    };
     if (scrollToIndex === undefined) return;
     clearSelectionScrollTarget();
   }, [clearSelectionScrollTarget, scrollToIndex, scrollToIndexVersion]);

--- a/src/components/ui/data-table/index.tsx
+++ b/src/components/ui/data-table/index.tsx
@@ -82,7 +82,7 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>(
         props.onBodyScrollActivity();
       },
     },
-    metadata: {
+    getMetadata: () => ({
       sortColumnId: props.sortColumnId,
       sortDirection: props.sortDirection,
       columns: props.columns.map((column) => ({ id: column.id, label: column.label })),
@@ -92,7 +92,7 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>(
         selected: props.isSelected(item, index),
       })),
       rowCount: props.items.length,
-    },
+    }),
   });
   const HostDataTable = useUiHost().DataTable as
     | ComponentType<DataTableProps<T, C>>

--- a/src/components/ui/data-table/index.tsx
+++ b/src/components/ui/data-table/index.tsx
@@ -83,6 +83,7 @@ export function DataTable<T, C extends DataTableColumn = DataTableColumn>(
       },
     },
     getMetadata: () => ({
+      paneInstanceId: paneId,
       sortColumnId: props.sortColumnId,
       sortDirection: props.sortDirection,
       columns: props.columns.map((column) => ({ id: column.id, label: column.label })),

--- a/src/components/ui/data-table/opentui/index.tsx
+++ b/src/components/ui/data-table/opentui/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, ScrollBox, Text, TextAttributes, useNativeRenderer } from "../../../../ui";
 import { hoverBg } from "../../../../theme/colors";
 import { useThemeColors } from "../../../../theme/theme-context";
@@ -47,6 +47,147 @@ function setScrollBarVisible(scrollBar: unknown, visible: boolean): void {
   }
   bar.visible = visible;
 }
+
+function OpenTuiDataTableRowInner<
+  T,
+  C extends DataTableColumn,
+>({
+  colors,
+  columnGap,
+  contentWidth,
+  displayColumns,
+  focusPane,
+  getRowBackgroundColor,
+  handleRowMouseDown,
+  horizontalPadding,
+  index,
+  item,
+  itemKey,
+  onRowContextMenu,
+  onRowMouseDown,
+  onTableMouseDown,
+  renderCell,
+  renderSectionHeader,
+  rowContextMenuSurface,
+  selected,
+}: {
+  colors: ReturnType<typeof useThemeColors>;
+  columnGap: number;
+  contentWidth: number;
+  displayColumns: C[];
+  focusPane: () => void;
+  getRowBackgroundColor?: DataTableProps<T, C>["getRowBackgroundColor"];
+  handleRowMouseDown: (
+    targetKey: string,
+    value: DataTableRowPointerTarget<T>,
+    event?: { detail?: number },
+  ) => void;
+  horizontalPadding: number;
+  index: number;
+  item: T;
+  itemKey: string;
+  onRowContextMenu?: DataTableProps<T, C>["onRowContextMenu"];
+  onRowMouseDown?: DataTableProps<T, C>["onRowMouseDown"];
+  onTableMouseDown?: DataTableProps<T, C>["onTableMouseDown"];
+  renderCell: DataTableProps<T, C>["renderCell"];
+  renderSectionHeader?: DataTableProps<T, C>["renderSectionHeader"];
+  rowContextMenuSurface: boolean;
+  selected: boolean;
+}) {
+  const sectionHeader = renderSectionHeader?.(item, index) ?? null;
+
+  if (sectionHeader) {
+    return (
+      <Box
+        flexDirection="row"
+        height={1}
+        {...tableContentWidthProps(contentWidth)}
+        paddingX={horizontalPadding}
+        backgroundColor={sectionHeader.backgroundColor ?? colors.bg}
+        onMouseDown={(event: any) => {
+          focusPane();
+          onTableMouseDown?.(event);
+          sectionHeader.onMouseDown?.(event);
+          event.preventDefault();
+        }}
+      >
+        <Text
+          attributes={sectionHeader.attributes ?? TextAttributes.BOLD}
+          fg={sectionHeader.color ?? colors.textBright}
+        >
+          {sectionHeader.text}
+        </Text>
+      </Box>
+    );
+  }
+
+  const rowState = { selected };
+  const rowBackgroundColor = getRowBackgroundColor?.(item, index, rowState);
+  const rowBg = selected ? colors.selected : rowBackgroundColor ?? colors.bg;
+  const rowHoverBg = selected ? undefined : hoverBg(colors);
+
+  return (
+    <Box
+      flexDirection="row"
+      height={1}
+      {...tableContentWidthProps(contentWidth)}
+      paddingX={horizontalPadding}
+      backgroundColor={rowBg}
+      hoverBackgroundColor={rowHoverBg}
+      data-gloom-context-menu-surface={rowContextMenuSurface ? "true" : undefined}
+      onMouseDown={(event: any) => {
+        focusPane();
+        onTableMouseDown?.(event);
+        if (onRowMouseDown?.(item, index, event) === true) return;
+        event.preventDefault();
+        handleRowMouseDown(itemKey, { item, index }, event);
+      }}
+      onContextMenu={(event: any) => {
+        focusPane();
+        onRowContextMenu?.(item, index, event);
+      }}
+    >
+      {displayColumns.map((column) => {
+        const cell = renderCell(item, column, index, rowState);
+        return (
+          <Box
+            key={column.id}
+            width={column.width + columnGap}
+            backgroundColor={cell.backgroundColor ?? rowBg}
+            onMouseDown={(event: any) => {
+              focusPane();
+              onTableMouseDown?.(event);
+              if (cell.onMouseDown) {
+                cell.onMouseDown(event);
+                return;
+              }
+              if (onRowMouseDown?.(item, index, event) === true) {
+                event.stopPropagation?.();
+                return;
+              }
+              event.preventDefault();
+              event.stopPropagation?.();
+              handleRowMouseDown(itemKey, { item, index }, event);
+            }}
+          >
+            {cell.content !== undefined ? (
+              cell.content
+            ) : (
+              <Text
+                attributes={cell.attributes ?? TextAttributes.NONE}
+                fg={cell.color ?? (selected ? colors.selectedText : colors.text)}
+              >
+                {fitTableCellText(cell.text, column.width, column.align)}
+              </Text>
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+const OpenTuiDataTableRow = memo(OpenTuiDataTableRowInner) as typeof OpenTuiDataTableRowInner;
 
 export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>({
   columns,
@@ -229,22 +370,13 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
 
     if (nextTop === currentTop) return true;
     scrollBox.scrollTo(nextTop);
-    if (scrollBox.scrollTop !== nextTop) return false;
-    if (virtualize) {
-      setScrollVersion((current) => current + 1);
-    }
-    syncHeaderScroll();
-    queueMicrotask(emitVisibleRange);
-    return true;
+    return scrollBox.scrollTop === nextTop;
   }, [
     appViewport.height,
     items.length,
     scrollRef,
     scrollToIndex,
     scrollToIndexAlign,
-    emitVisibleRange,
-    syncHeaderScroll,
-    virtualize,
   ]);
 
   useEffect(() => {
@@ -400,116 +532,29 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
               "data-table.render-visible-rows",
               () => visibleItems.map((item, visibleIndex) => {
                 const index = startIndex + visibleIndex;
-                const sectionHeader = renderSectionHeader?.(item, index) ?? null;
-
-                if (sectionHeader) {
-                  return (
-                    <Box
-                      key={getItemKey(item, index)}
-                      flexDirection="row"
-                      height={1}
-                      {...tableContentWidthProps(contentWidth)}
-                      paddingX={horizontalPadding}
-                      backgroundColor={sectionHeader.backgroundColor ?? colors.bg}
-                      onMouseDown={(event: any) => {
-                        focusPane();
-                        onTableMouseDown?.(event);
-                        sectionHeader.onMouseDown?.(event);
-                        event.preventDefault();
-                      }}
-                    >
-                      <Text
-                        attributes={sectionHeader.attributes ?? TextAttributes.BOLD}
-                        fg={sectionHeader.color ?? colors.textBright}
-                      >
-                        {sectionHeader.text}
-                      </Text>
-                    </Box>
-                  );
-                }
-
-                const selected = isSelected(item, index);
-                const rowState = { selected };
-                const rowBackgroundColor = getRowBackgroundColor?.(
-                  item,
-                  index,
-                  rowState,
-                );
-                const rowBg = selected
-                  ? colors.selected
-                  : rowBackgroundColor ?? colors.bg;
-                const rowHoverBg = selected ? undefined : hoverBg(colors);
-
+                const itemKey = getItemKey(item, index);
                 return (
-                  <Box
-                    key={getItemKey(item, index)}
-                    flexDirection="row"
-                    height={1}
-                    {...tableContentWidthProps(contentWidth)}
-                    paddingX={horizontalPadding}
-                    backgroundColor={rowBg}
-                    hoverBackgroundColor={rowHoverBg}
-                    data-gloom-context-menu-surface={rowContextMenuSurface ? "true" : undefined}
-                    onMouseDown={(event: any) => {
-                      focusPane();
-                      onTableMouseDown?.(event);
-                      if (onRowMouseDown?.(item, index, event) === true) {
-                        return;
-                      }
-                      event.preventDefault();
-                      handleRowMouseDown(getItemKey(item, index), {
-                        item,
-                        index,
-                      }, event);
-                    }}
-                    onContextMenu={(event: any) => {
-                      focusPane();
-                      onRowContextMenu?.(item, index, event);
-                    }}
-                  >
-                    {displayColumns.map((column) => {
-                      const cell = renderCell(item, column, index, rowState);
-                      return (
-                        <Box
-                          key={column.id}
-                          width={column.width + columnGap}
-                          backgroundColor={cell.backgroundColor ?? rowBg}
-                          onMouseDown={(event: any) => {
-                            focusPane();
-                            onTableMouseDown?.(event);
-                            if (cell.onMouseDown) {
-                              cell.onMouseDown(event);
-                              return;
-                            }
-                            if (onRowMouseDown?.(item, index, event) === true) {
-                              event.stopPropagation?.();
-                              return;
-                            }
-                            event.preventDefault();
-                            event.stopPropagation?.();
-                            handleRowMouseDown(getItemKey(item, index), {
-                              item,
-                              index,
-                            }, event);
-                          }}
-                        >
-                          {cell.content !== undefined ? (
-                            cell.content
-                          ) : (
-                            <Text
-                              attributes={cell.attributes ?? TextAttributes.NONE}
-                              fg={
-                                cell.color ??
-                                (selected ? colors.selectedText : colors.text)
-                              }
-                            >
-                              {fitTableCellText(cell.text, column.width, column.align)}
-                            </Text>
-                          )}
-                        </Box>
-                      );
-                    })}
-                  </Box>
+                  <OpenTuiDataTableRow<T, C>
+                    key={itemKey}
+                    colors={colors}
+                    columnGap={columnGap}
+                    contentWidth={contentWidth}
+                    displayColumns={displayColumns}
+                    focusPane={focusPane}
+                    getRowBackgroundColor={getRowBackgroundColor}
+                    handleRowMouseDown={handleRowMouseDown}
+                    horizontalPadding={horizontalPadding}
+                    index={index}
+                    item={item}
+                    itemKey={itemKey}
+                    onRowContextMenu={onRowContextMenu}
+                    onRowMouseDown={onRowMouseDown}
+                    onTableMouseDown={onTableMouseDown}
+                    renderCell={renderCell}
+                    renderSectionHeader={renderSectionHeader}
+                    rowContextMenuSurface={rowContextMenuSurface}
+                    selected={isSelected(item, index)}
+                  />
                 );
               }),
               {

--- a/src/components/ui/table-layout.ts
+++ b/src/components/ui/table-layout.ts
@@ -177,7 +177,7 @@ export function useMeasuredTableContentWidth(
     queueMicrotask(measureContentWidth);
   }, [measureContentWidth]);
 
-  useEffect(scheduleContentWidthMeasure);
+  useEffect(scheduleContentWidthMeasure, [scheduleContentWidthMeasure]);
 
   return {
     contentWidth: Math.max(tableWidth, viewportWidth),

--- a/src/components/use-double-click-activation.ts
+++ b/src/components/use-double-click-activation.ts
@@ -16,21 +16,25 @@ export function useDoubleClickActivation<T>({
   onActivate?: (value: T) => void;
 }) {
   const lastClickRef = useRef<LastClickState | null>(null);
+  const onSelectRef = useRef(onSelect);
+  const onActivateRef = useRef(onActivate);
+  onSelectRef.current = onSelect;
+  onActivateRef.current = onActivate;
 
   return useCallback((targetKey: string, value: T, event?: ClickEventLike) => {
     const lastClick = lastClickRef.current;
 
-    onSelect?.(value);
+    onSelectRef.current?.(value);
 
     if ((typeof event?.detail === "number" && event.detail >= 2)
         || (lastClick && lastClick.targetKey === targetKey)) {
       lastClickRef.current = null;
-      onActivate?.(value);
+      onActivateRef.current?.(value);
       return;
     }
 
     lastClickRef.current = {
       targetKey,
     };
-  }, [onActivate, onSelect]);
+  }, []);
 }

--- a/src/market-data/coordinator/index.ts
+++ b/src/market-data/coordinator/index.ts
@@ -55,7 +55,8 @@ import {
   loadQuoteBatchEntries,
   loadQuoteEntry,
   QuoteSubscriptionManager,
-  type QuoteSubscriptionPriority,
+  type QuoteSubscriptionHandle,
+  type QuoteSubscriptionRequest,
 } from "./quotes";
 
 export class MarketDataCoordinator {
@@ -361,7 +362,7 @@ export class MarketDataCoordinator {
     });
   }
 
-  subscribeQuotes(targets: Array<{ instrument: InstrumentRef; priority?: QuoteSubscriptionPriority }>): () => void {
+  subscribeQuotes(targets: QuoteSubscriptionRequest[]): QuoteSubscriptionHandle {
     return this.quoteSubscriptionManager.subscribe(targets);
   }
 

--- a/src/market-data/coordinator/quotes.ts
+++ b/src/market-data/coordinator/quotes.ts
@@ -19,6 +19,21 @@ import {
 
 export type QuoteSubscriptionPriority = Pick<QuoteSubscriptionTarget, "route" | "surface" | "visible" | "selected" | "weight">;
 
+export interface QuoteSubscriptionRequest {
+  instrument: InstrumentRef;
+  priority?: QuoteSubscriptionPriority;
+}
+
+/**
+ * Remains callable for compatibility with the original disposer API. Updating
+ * the handle lets long-lived consumers change priorities without unregistering
+ * their whole target set first.
+ */
+export interface QuoteSubscriptionHandle {
+  (): void;
+  update(targets: QuoteSubscriptionRequest[]): void;
+}
+
 export interface QuoteSubscriptionEntry {
   target: QuoteSubscriptionTarget;
   targets: Map<number, QuoteSubscriptionTarget>;
@@ -30,7 +45,8 @@ interface PendingStreamQuote {
   quote: Quote;
 }
 
-const QUOTE_SUBSCRIPTION_REMOVE_GRACE_MS = 250;
+export const QUOTE_SUBSCRIPTION_REMOVE_GRACE_MS = 250;
+export const QUOTE_SUBSCRIPTION_PRIORITY_UPDATE_DELAY_MS = 100;
 
 const STREAM_QUOTE_FIELDS: Array<keyof Quote> = [
   "symbol",
@@ -198,101 +214,192 @@ export class QuoteSubscriptionManager {
   private readonly pendingStreamQuotes = new Map<string, PendingStreamQuote>();
   private lastStreamQuoteBatchAppliedAt: number | null = null;
   private pendingStreamQuoteTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingPriorityUpdateTimer: ReturnType<typeof setTimeout> | null = null;
   private nextQuoteSubscriptionId = 1;
   private quoteSubscriptionDispose: (() => void) | null = null;
   private quoteSubscriptionSignature = "";
+  private quoteSubscriptionRoutingSignature = "";
 
   constructor(
     private readonly dataProvider: DataProvider,
     private readonly applyQuote: (instrument: InstrumentRef, quote: Quote) => void,
   ) {}
 
-  subscribe(targets: Array<{ instrument: InstrumentRef; priority?: QuoteSubscriptionPriority }>): () => void {
-    if (!this.dataProvider.subscribeQuotes || targets.length === 0) {
-      return () => {};
+  subscribe(targets: QuoteSubscriptionRequest[]): QuoteSubscriptionHandle {
+    if (!this.dataProvider.subscribeQuotes) {
+      return this.createNoopSubscription();
     }
 
     const subscriptionId = this.nextQuoteSubscriptionId++;
-    const subscribedKeys = new Set<string>();
-    for (const { instrument, priority } of targets) {
-      const key = buildQuoteKey(instrument);
-      subscribedKeys.add(key);
-      const target = quoteTargetFromInstrument(instrument, priority);
-      const existing = this.quoteSubscriptions.get(key);
-      if (existing) {
-        existing.targets.set(subscriptionId, target);
-        existing.target = mergeQuoteSubscriptionTargets(existing.targets.values()) ?? target;
-        if (existing.removeTimer) {
-          clearTimeout(existing.removeTimer);
-          existing.removeTimer = null;
-        }
-        continue;
-      }
-      this.quoteSubscriptions.set(key, {
-        target,
-        targets: new Map([[subscriptionId, target]]),
-        removeTimer: null,
-      });
-    }
-    this.flush();
-
-    return () => {
-      for (const key of subscribedKeys) {
-        const existing = this.quoteSubscriptions.get(key);
-        if (!existing) continue;
-        existing.targets.delete(subscriptionId);
-        const mergedTarget = mergeQuoteSubscriptionTargets(existing.targets.values());
-        if (mergedTarget) {
-          existing.target = mergedTarget;
-          this.flush();
-          continue;
-        }
-        if (existing.removeTimer) continue;
-        this.clearPendingStreamQuote(key);
-        existing.removeTimer = setTimeout(() => {
-          const current = this.quoteSubscriptions.get(key);
-          if (!current || current.targets.size > 0) return;
-          this.quoteSubscriptions.delete(key);
-          this.clearPendingStreamQuote(key);
-          this.flush();
-        }, QUOTE_SUBSCRIPTION_REMOVE_GRACE_MS);
-      }
+    let subscribedKeys = new Set<string>();
+    let disposed = false;
+    const update = (nextTargets: QuoteSubscriptionRequest[]) => {
+      if (disposed) return;
+      subscribedKeys = this.updateSubscriptionTargets(subscriptionId, subscribedKeys, nextTargets);
     };
+    const dispose = (() => {
+      if (disposed) return;
+      disposed = true;
+      subscribedKeys = this.updateSubscriptionTargets(subscriptionId, subscribedKeys, []);
+    }) as QuoteSubscriptionHandle;
+    dispose.update = update;
+    update(targets);
+    return dispose;
   }
 
-  private flush(): void {
+  private createNoopSubscription(): QuoteSubscriptionHandle {
+    const dispose = (() => {}) as QuoteSubscriptionHandle;
+    dispose.update = () => {};
+    return dispose;
+  }
+
+  private updateSubscriptionTargets(
+    subscriptionId: number,
+    subscribedKeys: Set<string>,
+    targets: QuoteSubscriptionRequest[],
+  ): Set<string> {
+    const nextTargets = new Map<string, QuoteSubscriptionTarget>();
+    for (const { instrument, priority } of targets) {
+      const key = buildQuoteKey(instrument);
+      const target = quoteTargetFromInstrument(instrument, priority);
+      const duplicate = nextTargets.get(key);
+      nextTargets.set(
+        key,
+        duplicate
+          ? mergeQuoteSubscriptionTargets([duplicate, target]) ?? target
+          : target,
+      );
+    }
+
+    const nextKeys = new Set(nextTargets.keys());
+    const affectedKeys = new Set([...subscribedKeys, ...nextKeys]);
+    let shouldFlush = false;
+    for (const key of affectedKeys) {
+      const nextTarget = nextTargets.get(key);
+      let entry = this.quoteSubscriptions.get(key);
+      if (nextTarget) {
+        if (!entry) {
+          entry = {
+            target: nextTarget,
+            targets: new Map(),
+            removeTimer: null,
+          };
+          this.quoteSubscriptions.set(key, entry);
+        }
+        entry.targets.set(subscriptionId, nextTarget);
+        if (entry.removeTimer) {
+          clearTimeout(entry.removeTimer);
+          entry.removeTimer = null;
+        }
+      } else if (entry) {
+        entry.targets.delete(subscriptionId);
+      }
+      if (!entry) continue;
+
+      const mergedTarget = mergeQuoteSubscriptionTargets(entry.targets.values());
+      if (mergedTarget) {
+        entry.target = mergedTarget;
+        shouldFlush = true;
+        continue;
+      }
+      this.scheduleSubscriptionRemoval(key, entry);
+    }
+    if (shouldFlush) {
+      this.flush();
+    } else if (![...this.quoteSubscriptions.values()].some((entry) => entry.targets.size > 0)) {
+      this.cancelPendingPriorityUpdate();
+    }
+    return nextKeys;
+  }
+
+  private scheduleSubscriptionRemoval(key: string, entry: QuoteSubscriptionEntry): void {
+    if (entry.removeTimer) return;
+    this.clearPendingStreamQuote(key);
+    entry.removeTimer = setTimeout(() => {
+      const current = this.quoteSubscriptions.get(key);
+      if (!current || current.targets.size > 0) return;
+      this.quoteSubscriptions.delete(key);
+      this.clearPendingStreamQuote(key);
+      this.flush();
+    }, QUOTE_SUBSCRIPTION_REMOVE_GRACE_MS);
+  }
+
+  private flush({
+    coalescePriorityChanges = true,
+    requireStableRouting = false,
+  }: {
+    coalescePriorityChanges?: boolean;
+    requireStableRouting?: boolean;
+  } = {}): void {
     if (!this.dataProvider.subscribeQuotes) return;
 
     const activeEntries = [...this.quoteSubscriptions.entries()]
       .filter(([, entry]) => entry.targets.size > 0)
       .sort(([left], [right]) => left.localeCompare(right));
-    const nextSignature = activeEntries.map(([key, entry]) => [
+    const nextRoutingSignature = JSON.stringify(activeEntries.map(([key, entry]) => [
       key,
-      entry.target.route ?? "",
+      entry.target.route ?? "auto",
+    ]));
+    const nextSignature = JSON.stringify(activeEntries.map(([key, entry]) => [
+      key,
+      entry.target.route ?? "auto",
       entry.target.surface ?? "",
-      entry.target.visible ? "visible" : "",
-      entry.target.selected ? "selected" : "",
-      Number.isFinite(entry.target.weight) ? entry.target.weight : "",
-    ].join(":")).join("|");
-    if (nextSignature === this.quoteSubscriptionSignature) return;
+      entry.target.visible === true,
+      entry.target.selected === true,
+      Number.isFinite(entry.target.weight) ? entry.target.weight : null,
+    ]));
+    if (nextSignature === this.quoteSubscriptionSignature) {
+      this.cancelPendingPriorityUpdate();
+      return;
+    }
+    if (requireStableRouting && nextRoutingSignature !== this.quoteSubscriptionRoutingSignature) {
+      return;
+    }
 
-    this.quoteSubscriptionDispose?.();
-    this.quoteSubscriptionDispose = null;
-    this.quoteSubscriptionSignature = nextSignature;
+    const priorityOnlyChange = this.quoteSubscriptionSignature.length > 0
+      && nextRoutingSignature === this.quoteSubscriptionRoutingSignature;
+    if (coalescePriorityChanges && priorityOnlyChange) {
+      this.schedulePriorityUpdate();
+      return;
+    }
+    this.cancelPendingPriorityUpdate();
 
     const targets = activeEntries.map(([, entry]) => entry.target);
-    if (targets.length === 0) return;
+    const nextDispose = targets.length > 0
+      ? this.dataProvider.subscribeQuotes(targets, (target, quote) => {
+          const instrument: InstrumentRef = {
+            symbol: target.symbol,
+            exchange: target.exchange ?? "",
+            brokerId: target.context?.brokerId,
+            brokerInstanceId: target.context?.brokerInstanceId,
+            instrument: target.context?.instrument ?? null,
+          };
+          this.enqueueStreamQuote(instrument, quote);
+        })
+      : null;
+    // Register first so the cloud socket and desktop registries can merge the
+    // overlapping listeners without observing a zero-listener disconnect.
+    const previousDispose = this.quoteSubscriptionDispose;
+    this.quoteSubscriptionDispose = nextDispose;
+    this.quoteSubscriptionSignature = nextSignature;
+    this.quoteSubscriptionRoutingSignature = nextRoutingSignature;
+    previousDispose?.();
+  }
 
-    this.quoteSubscriptionDispose = this.dataProvider.subscribeQuotes(targets, (target, quote) => {
-      const instrument: InstrumentRef = {
-        symbol: target.symbol,
-        exchange: target.exchange ?? "",
-        brokerId: target.context?.brokerId,
-        brokerInstanceId: target.context?.brokerInstanceId,
-        instrument: target.context?.instrument ?? null,
-      };
-      this.enqueueStreamQuote(instrument, quote);
-    });
+  private schedulePriorityUpdate(): void {
+    // Do not reset this timer. Continuous navigation must still publish the
+    // latest priorities instead of postponing them indefinitely.
+    if (this.pendingPriorityUpdateTimer !== null) return;
+    this.pendingPriorityUpdateTimer = setTimeout(() => {
+      this.pendingPriorityUpdateTimer = null;
+      this.flush({ coalescePriorityChanges: false, requireStableRouting: true });
+    }, QUOTE_SUBSCRIPTION_PRIORITY_UPDATE_DELAY_MS);
+  }
+
+  private cancelPendingPriorityUpdate(): void {
+    if (this.pendingPriorityUpdateTimer === null) return;
+    clearTimeout(this.pendingPriorityUpdateTimer);
+    this.pendingPriorityUpdateTimer = null;
   }
 
   private enqueueStreamQuote(instrument: InstrumentRef, quote: Quote): void {

--- a/src/market-data/coordinator/subscriptions.test.ts
+++ b/src/market-data/coordinator/subscriptions.test.ts
@@ -5,6 +5,11 @@ import { QUOTE_STREAM_UPDATE_THROTTLE_MS } from "../quotes/cadence";
 import { createTestDataProvider } from "../../test-support/data-provider";
 import type { Quote } from "../../types/financials";
 import type { DataProvider, QuoteSubscriptionTarget } from "../../types/data-provider";
+import {
+  QUOTE_SUBSCRIPTION_PRIORITY_UPDATE_DELAY_MS,
+  QUOTE_SUBSCRIPTION_REMOVE_GRACE_MS,
+  type QuoteSubscriptionRequest,
+} from "./quotes";
 
 function createProvider(): {
   provider: DataProvider;
@@ -75,47 +80,220 @@ describe("MarketDataCoordinator key subscriptions", () => {
   });
 
   test("keeps the highest-priority target when duplicate surfaces subscribe", () => {
-    const subscriptions: QuoteSubscriptionTarget[][] = [];
-    let disposals = 0;
-    const provider = createTestDataProvider({
-      id: "test-provider",
-      subscribeQuotes: (targets) => {
-        subscriptions.push(targets);
-        return () => {
-          disposals += 1;
-        };
-      },
-    });
-    const coordinator = new MarketDataCoordinator(provider);
-    const instrument = { symbol: "AAPL", exchange: "NASDAQ" };
+    jest.useFakeTimers();
+    try {
+      const subscriptions: QuoteSubscriptionTarget[][] = [];
+      let disposals = 0;
+      const provider = createTestDataProvider({
+        id: "test-provider",
+        subscribeQuotes: (targets) => {
+          subscriptions.push(targets);
+          return () => {
+            disposals += 1;
+          };
+        },
+      });
+      const coordinator = new MarketDataCoordinator(provider);
+      const instrument = { symbol: "AAPL", exchange: "NASDAQ" };
 
-    const unsubscribeDetail = coordinator.subscribeQuotes([{
-      instrument,
-      priority: { surface: "detail", visible: true, selected: true, weight: 100 },
-    }]);
-    coordinator.subscribeQuotes([{
-      instrument,
-      priority: { surface: "portfolio", visible: false, selected: false, weight: 10 },
-    }]);
+      const unsubscribeDetail = coordinator.subscribeQuotes([{
+        instrument,
+        priority: { surface: "detail", visible: true, selected: true, weight: 100 },
+      }]);
+      const unsubscribePortfolio = coordinator.subscribeQuotes([{
+        instrument,
+        priority: { surface: "portfolio", visible: false, selected: false, weight: 10 },
+      }]);
 
-    expect(subscriptions).toHaveLength(1);
-    expect(subscriptions[0]?.[0]).toMatchObject({
-      surface: "detail",
-      visible: true,
-      selected: true,
-      weight: 100,
-    });
+      expect(subscriptions).toHaveLength(1);
+      expect(subscriptions[0]?.[0]).toMatchObject({
+        surface: "detail",
+        visible: true,
+        selected: true,
+        weight: 100,
+      });
 
-    unsubscribeDetail();
+      unsubscribeDetail();
+      expect(subscriptions).toHaveLength(1);
 
-    expect(subscriptions).toHaveLength(2);
-    expect(disposals).toBe(1);
-    expect(subscriptions[1]?.[0]).toMatchObject({
-      surface: "portfolio",
-      visible: false,
-      selected: false,
-      weight: 10,
-    });
+      jest.advanceTimersByTime(QUOTE_SUBSCRIPTION_PRIORITY_UPDATE_DELAY_MS);
+      expect(subscriptions).toHaveLength(2);
+      expect(disposals).toBe(1);
+      expect(subscriptions[1]?.[0]).toMatchObject({
+        surface: "portfolio",
+        visible: false,
+        selected: false,
+        weight: 10,
+      });
+
+      unsubscribePortfolio();
+      jest.runAllTimers();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("coalesces priority updates and overlaps the upstream replacement", () => {
+    jest.useFakeTimers();
+    try {
+      const events: string[] = [];
+      const subscriptions: QuoteSubscriptionTarget[][] = [];
+      const provider = createTestDataProvider({
+        id: "test-provider",
+        subscribeQuotes: (targets) => {
+          const subscriptionId = subscriptions.length + 1;
+          subscriptions.push(targets);
+          events.push(`subscribe:${subscriptionId}`);
+          return () => events.push(`dispose:${subscriptionId}`);
+        },
+      });
+      const coordinator = new MarketDataCoordinator(provider);
+      const instruments = ["AAPL", "MSFT", "NVDA"].map((symbol) => ({
+        symbol,
+        exchange: "NASDAQ",
+      }));
+      const requests = (
+        selectedSymbol: string,
+        selectedSurface: "portfolio" | "detail" = "portfolio",
+      ): QuoteSubscriptionRequest[] => instruments.map((instrument) => ({
+        instrument,
+        priority: {
+          surface: instrument.symbol === selectedSymbol ? selectedSurface : "portfolio",
+          visible: instrument.symbol === selectedSymbol,
+          selected: instrument.symbol === selectedSymbol,
+          weight: instrument.symbol === selectedSymbol ? 100 : 10,
+        },
+      }));
+
+      const subscription = coordinator.subscribeQuotes(requests("AAPL"));
+      subscription.update(requests("MSFT"));
+      subscription.update(requests("NVDA", "detail"));
+
+      jest.advanceTimersByTime(QUOTE_SUBSCRIPTION_PRIORITY_UPDATE_DELAY_MS - 1);
+      expect(subscriptions).toHaveLength(1);
+      expect(events).toEqual(["subscribe:1"]);
+
+      jest.advanceTimersByTime(1);
+      expect(subscriptions).toHaveLength(2);
+      expect(subscriptions[1]?.find((target) => target.symbol === "NVDA")).toMatchObject({
+        surface: "detail",
+        visible: true,
+        selected: true,
+        weight: 100,
+      });
+      expect(events).toEqual(["subscribe:1", "subscribe:2", "dispose:1"]);
+
+      subscription();
+      jest.runAllTimers();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("applies membership and routing changes immediately", () => {
+    jest.useFakeTimers();
+    try {
+      const subscriptions: QuoteSubscriptionTarget[][] = [];
+      let disposals = 0;
+      const provider = createTestDataProvider({
+        id: "test-provider",
+        subscribeQuotes: (targets) => {
+          subscriptions.push(targets);
+          return () => { disposals += 1; };
+        },
+      });
+      const coordinator = new MarketDataCoordinator(provider);
+      const aapl = {
+        symbol: "AAPL",
+        exchange: "NASDAQ",
+        brokerId: "ibkr",
+        brokerInstanceId: "ibkr-work",
+        instrument: {
+          brokerId: "ibkr",
+          brokerInstanceId: "ibkr-work",
+          conId: 1001,
+          symbol: "AAPL",
+        },
+      };
+      const msft = { symbol: "MSFT", exchange: "NASDAQ" };
+      const subscription = coordinator.subscribeQuotes([{
+        instrument: aapl,
+        priority: { route: "provider", surface: "portfolio" },
+      }]);
+
+      subscription.update([
+        { instrument: aapl, priority: { route: "provider", surface: "portfolio" } },
+        { instrument: msft, priority: { route: "provider", surface: "portfolio" } },
+      ]);
+      expect(subscriptions).toHaveLength(2);
+      expect(disposals).toBe(1);
+      expect(subscriptions[1]?.map((target) => target.symbol).sort()).toEqual(["AAPL", "MSFT"]);
+
+      subscription.update([
+        { instrument: aapl, priority: { route: "broker", surface: "detail" } },
+        { instrument: msft, priority: { route: "provider", surface: "portfolio" } },
+      ]);
+      expect(subscriptions).toHaveLength(3);
+      expect(disposals).toBe(2);
+      expect(subscriptions[2]?.find((target) => target.symbol === "AAPL")).toMatchObject({
+        route: "broker",
+        surface: "detail",
+        context: {
+          brokerId: "ibkr",
+          brokerInstanceId: "ibkr-work",
+          instrument: { brokerId: "ibkr", conId: 1001, symbol: "AAPL" },
+        },
+      });
+
+      subscription();
+      jest.runAllTimers();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("keeps an updated handle callable and honors removal grace on dispose", () => {
+    jest.useFakeTimers();
+    try {
+      const subscriptions: QuoteSubscriptionTarget[][] = [];
+      let disposals = 0;
+      const provider = createTestDataProvider({
+        id: "test-provider",
+        subscribeQuotes: (targets) => {
+          subscriptions.push(targets);
+          return () => { disposals += 1; };
+        },
+      });
+      const coordinator = new MarketDataCoordinator(provider);
+      const instrument = { symbol: "AAPL", exchange: "NASDAQ" };
+      const subscription = coordinator.subscribeQuotes([{
+        instrument,
+        priority: { surface: "portfolio", selected: false, weight: 10 },
+      }]);
+
+      expect(typeof subscription).toBe("function");
+      expect(typeof subscription.update).toBe("function");
+      subscription.update([{
+        instrument,
+        priority: { surface: "detail", selected: true, weight: 100 },
+      }]);
+      jest.advanceTimersByTime(QUOTE_SUBSCRIPTION_PRIORITY_UPDATE_DELAY_MS);
+      expect(subscriptions).toHaveLength(2);
+      expect(disposals).toBe(1);
+
+      subscription();
+      subscription.update([{ instrument: { symbol: "MSFT", exchange: "NASDAQ" } }]);
+      subscription();
+      jest.advanceTimersByTime(QUOTE_SUBSCRIPTION_REMOVE_GRACE_MS - 1);
+      expect(subscriptions).toHaveLength(2);
+      expect(disposals).toBe(1);
+
+      jest.advanceTimersByTime(1);
+      expect(subscriptions).toHaveLength(2);
+      expect(disposals).toBe(2);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test("replaces a capped target window without retaining pending removals", () => {

--- a/src/pane-settings.ts
+++ b/src/pane-settings.ts
@@ -52,7 +52,7 @@ export function setPaneSetting(
   value: unknown,
 ): LayoutConfig {
   const current = findPaneInstance(layout, paneId);
-  if (!current) return layout;
+  if (!current || Object.is(current.settings?.[key], value)) return layout;
   return setPaneSettings(layout, paneId, {
     ...(current.settings ?? {}),
     [key]: value,

--- a/src/plugins/builtin/credit-conditions/index.test.tsx
+++ b/src/plugins/builtin/credit-conditions/index.test.tsx
@@ -14,8 +14,8 @@ import {
   PaneInstanceProvider,
 } from "../../../state/app/context";
 import { createDefaultConfig } from "../../../types/config";
-import { CREDIT_SERIES, type CreditConditionRow } from "./model";
-import { CreditConditionsPane, moveCreditSelection } from "./index";
+import { CREDIT_SERIES } from "./model";
+import { CreditConditionsPane } from "./index";
 
 let setup: Awaited<ReturnType<typeof testRender>> | undefined;
 
@@ -80,9 +80,6 @@ afterEach(async () => {
 
 describe("CreditConditionsPane", () => {
   test("selects credit rows with keyboard and mouse", async () => {
-    const keyboardRows = CREDIT_SERIES.map((definition) => ({ ...definition }) as CreditConditionRow);
-    expect(moveCreditSelection(keyboardRows, CREDIT_SERIES[5].seriesId, -1)).toBe(CREDIT_SERIES[4].seriesId);
-
     const state = createInitialState(createDefaultConfig("/tmp/gloomberb-credit-test"));
     setup = await testRender(
       <AppContext value={{ state, dispatch: () => {} }}>
@@ -98,13 +95,22 @@ describe("CreditConditionsPane", () => {
 
     expect(setup.captureCharFrame()).toContain(`${CREDIT_SERIES[0].seriesId} Option-Adjusted Spread`);
 
+    await act(async () => {
+      setup!.mockInput.pressArrow("up");
+      setup!.mockInput.pressEnter();
+      await setup!.renderOnce();
+    });
+    await settle();
+    const keyboardTitle = `${CREDIT_SERIES[5].seriesId} Option-Adjusted Spread`;
+    expect(setup.captureCharFrame()).toContain(keyboardTitle);
+
     let mouseSelected = false;
     for (let row = 3; row < 9 && !mouseSelected; row += 1) {
       await act(async () => {
         await setup!.mockMouse.click(2, row);
         await setup!.renderOnce();
       });
-      mouseSelected = !setup.captureCharFrame().includes(`${CREDIT_SERIES[0].seriesId} Option-Adjusted Spread`);
+      mouseSelected = !setup.captureCharFrame().includes(keyboardTitle);
     }
     expect(mouseSelected).toBe(true);
   });

--- a/src/plugins/builtin/credit-conditions/index.tsx
+++ b/src/plugins/builtin/credit-conditions/index.tsx
@@ -47,16 +47,6 @@ function sortRows(rows: CreditConditionRow[], id: SortId, descending: boolean): 
   });
 }
 
-export function moveCreditSelection(
-  rows: CreditConditionRow[],
-  selectedId: CreditSeriesId | null,
-  offset: -1 | 1,
-): CreditSeriesId | null {
-  if (rows.length === 0) return null;
-  const current = Math.max(0, rows.findIndex((row) => row.seriesId === selectedId));
-  return rows[Math.max(0, Math.min(current + offset, rows.length - 1))]!.seriesId;
-}
-
 function renderCell(
   row: CreditConditionRow,
   column: Column,
@@ -131,16 +121,8 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
     onMouseDown: () => setSelectedId(row.seriesId),
   }), []);
   useShortcut((event) => {
-    if (!focused) return;
-    if (event.name === "r") {
-      if (loading) return;
-      reload();
-    } else if (["up", "k", "down", "j"].includes(event.name ?? "")) {
-      const offset = event.name === "up" || event.name === "k" ? -1 : 1;
-      setSelectedId(moveCreditSelection(sorted, selectedId, offset));
-    } else {
-      return;
-    }
+    if (!focused || event.name !== "r" || loading) return;
+    reload();
     event.preventDefault?.();
     event.stopPropagation?.();
   });
@@ -190,7 +172,6 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
         getId: (row) => row.seriesId,
         onChange: (id) => setSelectedId(id as CreditSeriesId),
       }}
-      onCursorChange={(row) => setSelectedId(row.seriesId)}
       columns={columns}
       items={sorted}
       sortColumnId={sort.id}

--- a/src/plugins/builtin/econ-statistics/pane.tsx
+++ b/src/plugins/builtin/econ-statistics/pane.tsx
@@ -310,9 +310,6 @@ export function EconStatisticsPane({ focused, width, height }: PaneProps) {
                 getId: (row) => row.id,
                 onChange: (id, _item, _index, reason) => chooseStat(String(id), reason),
               }}
-              onCursorChange={(row, _index, reason) => {
-                if (row.kind === "stat") chooseStat(row.view.stat.id, reason);
-              }}
               isNavigable={(row) => row.kind === "stat"}
               onHeaderClick={() => {}}
               onRootKeyDown={handlePaneKey}

--- a/src/plugins/builtin/market-valuation/pane.tsx
+++ b/src/plugins/builtin/market-valuation/pane.tsx
@@ -295,7 +295,6 @@ export function MarketValuationPane({ focused, width, height }: PaneProps) {
             getId: (view) => view.indicator.id,
             onChange: (id, _item, _index, reason) => chooseIndicator(String(id), reason),
           }}
-          onCursorChange={(view, _index, reason) => chooseIndicator(view.indicator.id, reason)}
           onHeaderClick={() => {}}
           onRootKeyDown={handlePaneKey}
           getItemKey={(view) => view.indicator.id}

--- a/src/plugins/builtin/options/view.tsx
+++ b/src/plugins/builtin/options/view.tsx
@@ -423,25 +423,6 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
       return true;
     }
 
-    if (isPlainKey(event, "j", "down")) {
-      if (strikes.length === 0) return true;
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      userSelectedStrikeRef.current = true;
-      setScrollToIndexAlign("nearest");
-      setStrikeIdx((i) => Math.min(i + 1, strikes.length - 1));
-      return true;
-    }
-    if (isPlainKey(event, "k", "up")) {
-      if (strikes.length === 0) return true;
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      userSelectedStrikeRef.current = true;
-      setScrollToIndexAlign("nearest");
-      setStrikeIdx((i) => Math.max(i - 1, 0));
-      return true;
-    }
-
     return false;
   }, [
     calcParams,
@@ -450,7 +431,6 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     interactive,
     openCalculator,
     selectAdjacentExpiration,
-    strikes.length,
   ]);
 
   if (!ticker) {
@@ -522,11 +502,10 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
             setStrikeIdx(index);
           },
         }}
-        onCursorChange={(_row, index) => {
+        onCursorChange={() => {
           userSelectedStrikeRef.current = true;
           setScrollToIndexAlign("nearest");
           enterInteractive();
-          setStrikeIdx(index);
         }}
         onRootKeyDown={handleTableKeyDown}
         headerScrollId="options-table-header-scroll"

--- a/src/remote/semantic-tree.test.tsx
+++ b/src/remote/semantic-tree.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, expect, test } from "bun:test";
+import { act, useState } from "react";
+import { testRender } from "../renderers/opentui/test-utils";
+import {
+  RemoteUiRegistryProvider,
+  createRemoteUiRegistry,
+  useRemoteUiNode,
+} from "./semantic-tree";
+
+let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+let setValue: ((value: number) => void) | null = null;
+let metadataReads = 0;
+
+afterEach(async () => {
+  if (!setup) return;
+  await act(async () => setup?.renderer.destroy());
+  setup = undefined;
+  setValue = null;
+  metadataReads = 0;
+});
+
+function LazyMetadataNode() {
+  useRemoteUiNode({
+    role: "table",
+    getMetadata: () => {
+      metadataReads += 1;
+      return { rowCount: 200 };
+    },
+  });
+  return <text>table</text>;
+}
+
+function DynamicNode() {
+  const [value, updateValue] = useState(1);
+  setValue = updateValue;
+  useRemoteUiNode({
+    role: "button",
+    label: `Value ${value}`,
+    actions: { read: () => value },
+    metadata: { value },
+  });
+  return <text>{value}</text>;
+}
+
+test("semantic registry rejects non-function actions consistently", async () => {
+  const registry = createRemoteUiRegistry();
+  registry.register("invalid", {
+    role: "button",
+    actions: { broken: "not-a-function" as unknown as () => void },
+  });
+
+  expect(registry.snapshot()[0]?.actions).toEqual([]);
+  await expect(registry.invoke("invalid", "broken")).rejects.toThrow(
+    'UI node "invalid" does not expose action "broken".',
+  );
+});
+
+test("semantic metadata is projected only when a remote snapshot requests it", async () => {
+  const registry = createRemoteUiRegistry();
+  setup = await testRender(
+    <RemoteUiRegistryProvider registry={registry}>
+      <LazyMetadataNode />
+    </RemoteUiRegistryProvider>,
+    { width: 20, height: 4 },
+  );
+  await setup.renderOnce();
+
+  expect(metadataReads).toBe(0);
+  expect(registry.snapshot()[0]?.metadata).toEqual({ rowCount: 200 });
+  expect(metadataReads).toBe(1);
+});
+
+test("semantic nodes keep current behavior without re-registering on every render", async () => {
+  const registry = createRemoteUiRegistry();
+  const register = registry.register.bind(registry);
+  let registrations = 0;
+  registry.register = (id, registration) => {
+    registrations += 1;
+    register(id, registration);
+  };
+
+  setup = await testRender(
+    <RemoteUiRegistryProvider registry={registry}>
+      <DynamicNode />
+    </RemoteUiRegistryProvider>,
+    { width: 20, height: 4 },
+  );
+  await setup.renderOnce();
+
+  const nodeId = registry.snapshot()[0]!.id;
+  expect(registrations).toBe(1);
+  expect(await registry.invoke(nodeId, "read")).toBe(1);
+
+  await act(async () => {
+    setValue?.(2);
+    await setup!.renderOnce();
+  });
+
+  expect(registrations).toBe(1);
+  expect(registry.snapshot()[0]).toMatchObject({
+    label: "Value 2",
+    metadata: { value: 2 },
+  });
+  expect(await registry.invoke(nodeId, "read")).toBe(2);
+});

--- a/src/remote/semantic-tree.tsx
+++ b/src/remote/semantic-tree.tsx
@@ -17,11 +17,13 @@ export interface RemoteUiNodeRegistration {
   disabled?: boolean;
   actions?: Record<string, RemoteUiAction | undefined>;
   metadata?: Record<string, unknown>;
+  /** Defers expensive metadata projection until a remote snapshot requests it. */
+  getMetadata?: () => Record<string, unknown>;
 }
 
-interface RegisteredRemoteUiNode extends RemoteUiNodeRegistration {
+interface RegisteredRemoteUiNode {
   id: string;
-  actions: Record<string, RemoteUiAction>;
+  registration: RemoteUiNodeRegistration;
 }
 
 export interface RemoteUiRegistry {
@@ -33,46 +35,54 @@ export interface RemoteUiRegistry {
 
 const RemoteUiRegistryContext = createContext<RemoteUiRegistry | null>(null);
 
-function createRemoteUiRegistry(): RemoteUiRegistry {
+export function createRemoteUiRegistry(): RemoteUiRegistry {
   const nodes = new Map<string, RegisteredRemoteUiNode>();
 
   return {
     register(id, registration) {
-      nodes.set(id, {
-        ...registration,
-        id,
-        actions: Object.fromEntries(
-          Object.entries(registration.actions ?? {})
-            .filter((entry): entry is [string, RemoteUiAction] => typeof entry[1] === "function"),
-        ),
-      });
+      nodes.set(id, { id, registration });
     },
     unregister(id) {
       nodes.delete(id);
     },
     snapshot() {
-      return [...nodes.values()].map((node) => ({
-        id: node.id,
-        role: node.role,
-        label: node.label,
-        disabled: node.disabled,
-        actions: Object.keys(node.actions).sort(),
-        metadata: node.metadata,
-      }));
+      return [...nodes.values()].map((node) => {
+        const registration = node.registration;
+        return {
+          id: node.id,
+          role: registration.role,
+          label: registration.label,
+          disabled: registration.disabled,
+          actions: Object.entries(registration.actions ?? {})
+            .filter((entry): entry is [string, RemoteUiAction] => typeof entry[1] === "function")
+            .map(([action]) => action)
+            .sort(),
+          metadata: registration.getMetadata?.() ?? registration.metadata,
+        };
+      });
     },
     async invoke(nodeId, action, input) {
       const node = nodes.get(nodeId);
       if (!node) throw new Error(`Unknown UI node "${nodeId}".`);
-      if (node.disabled) throw new Error(`UI node "${nodeId}" is disabled.`);
-      const handler = node.actions[action];
-      if (!handler) throw new Error(`UI node "${nodeId}" does not expose action "${action}".`);
+      const registration = node.registration;
+      if (registration.disabled) throw new Error(`UI node "${nodeId}" is disabled.`);
+      const handler = registration.actions?.[action];
+      if (typeof handler !== "function") {
+        throw new Error(`UI node "${nodeId}" does not expose action "${action}".`);
+      }
       return await handler(input);
     },
   };
 }
 
-export function RemoteUiRegistryProvider({ children }: { children: ReactNode }) {
-  const registryRef = useRef<RemoteUiRegistry | null>(null);
+export function RemoteUiRegistryProvider({
+  children,
+  registry,
+}: {
+  children: ReactNode;
+  registry?: RemoteUiRegistry;
+}) {
+  const registryRef = useRef<RemoteUiRegistry | null>(registry ?? null);
   if (!registryRef.current) {
     registryRef.current = createRemoteUiRegistry();
   }
@@ -91,22 +101,30 @@ export function useRemoteUiNode(registration: RemoteUiNodeRegistration | null | 
   const registry = useRemoteUiRegistry();
   const generatedId = useId();
   const nodeId = useMemo(() => `ui:${generatedId.replace(/:/g, "")}`, [generatedId]);
+  const registrationRef = useRef(registration);
+  registrationRef.current = registration;
+  const dynamicRegistrationRef = useRef<RemoteUiNodeRegistration | null>(null);
+  if (!dynamicRegistrationRef.current) {
+    dynamicRegistrationRef.current = {
+      get role() { return registrationRef.current?.role ?? "unknown"; },
+      get label() { return registrationRef.current?.label; },
+      get disabled() { return registrationRef.current?.disabled; },
+      get actions() { return registrationRef.current?.actions; },
+      get metadata() { return registrationRef.current?.metadata; },
+      get getMetadata() { return registrationRef.current?.getMetadata; },
+    };
+  }
+  const registered = registration != null;
 
   useEffect(() => {
     if (!registry) return;
-    if (!registration) {
+    if (!registered) {
       registry.unregister(nodeId);
       return;
     }
-    registry.register(nodeId, registration);
-  });
+    registry.register(nodeId, dynamicRegistrationRef.current!);
+    return () => registry.unregister(nodeId);
+  }, [nodeId, registered, registry]);
 
-  useEffect(() => {
-    return () => registry?.unregister(nodeId);
-  }, [
-    nodeId,
-    registry,
-  ]);
-
-  return registry && registration ? nodeId : null;
+  return registry && registered ? nodeId : null;
 }

--- a/src/renderers/opentui/host.tsx
+++ b/src/renderers/opentui/host.tsx
@@ -1,6 +1,6 @@
 import { createCliRenderer, type CliRenderer } from "@opentui/core";
 import { createRoot, useKeyboard, useTerminalDimensions } from "@opentui/react";
-import type { ReactNode } from "react";
+import { Profiler, type ReactNode } from "react";
 import { resetTerminalInputState } from "../../utils/terminal-input-reset";
 import type { KeyEventLike } from "../../react/input";
 import type { NativeRendererHost, PixelResolution, RendererHost } from "../../ui/host";
@@ -248,7 +248,18 @@ export async function createOpenTuiHost(): Promise<OpenTuiHost> {
     renderer,
     rendererHost,
     nativeRenderer,
-    render: (node) => root.render(node),
+    render: (node) => root.render(
+      stopInteractionPerformanceRecorder.enabled
+        ? (
+            <Profiler
+              id="interaction-performance"
+              onRender={stopInteractionPerformanceRecorder.markCommit}
+            >
+              {node}
+            </Profiler>
+          )
+        : node,
+    ),
     destroy: () => renderer.destroy(),
   };
 }

--- a/src/renderers/opentui/host.tsx
+++ b/src/renderers/opentui/host.tsx
@@ -8,6 +8,7 @@ import { colors } from "../../theme/colors";
 import { safeExternalUrl } from "../../utils/external-url";
 import { createTerminalMediaReaper, terminalMediaStateFile } from "./terminal-media";
 import { saveTextFileToDownloads } from "../../utils/save-text-file";
+import { installInteractionPerformanceRecorder } from "./interaction-performance";
 
 export { useKeyboard, useTerminalDimensions };
 
@@ -97,6 +98,8 @@ export async function createOpenTuiHost(): Promise<OpenTuiHost> {
   });
   const root = createRoot(renderer);
   installResolutionEventBridge(renderer);
+  const stopInteractionPerformanceRecorder = installInteractionPerformanceRecorder(renderer);
+  renderer.once("destroy", stopInteractionPerformanceRecorder);
 
   const rendererHost: RendererHost = {
     requestExit: () => renderer.destroy(),

--- a/src/renderers/opentui/interaction-performance.test.ts
+++ b/src/renderers/opentui/interaction-performance.test.ts
@@ -1,14 +1,29 @@
-import { expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
+import { EventEmitter } from "events";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { CliRenderer } from "@opentui/core";
 import {
+  installInteractionPerformanceRecorder,
   summarizeInteractionPerformance,
   type InteractionPerformanceSample,
 } from "./interaction-performance";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
 
 function sample(latencyMs: number): InteractionPerformanceSample {
   return {
     id: latencyMs,
     key: "down",
     frameId: 1,
+    inputsInFrame: 1,
     latencyMs,
     frameCallbackMs: 0,
     cellsUpdated: 0,
@@ -24,4 +39,41 @@ test("summarizes key-to-frame latency with nearest-rank percentiles", () => {
     p95Ms: 19,
     maxMs: 20,
   });
+});
+
+test("waits for the key's React commit before attributing a renderer frame", () => {
+  const directory = mkdtempSync(join(tmpdir(), "gloomberb-interaction-performance-"));
+  temporaryDirectories.push(directory);
+  const output = join(directory, "report.json");
+  const rendererEvents = new EventEmitter();
+  const keyInput = new EventEmitter();
+  const renderer = Object.assign(rendererEvents, {
+    keyInput,
+    setGatherStats: () => {},
+    getStats: () => ({ frameCallbackTime: 1.25, cellsUpdated: 42 }),
+  }) as unknown as CliRenderer;
+  const recorder = installInteractionPerformanceRecorder(renderer, output);
+
+  keyInput.emit("keypress", { name: "down" });
+  keyInput.emit("keypress", { name: "up" });
+  rendererEvents.emit("frame", { frameId: 10 });
+  recorder.markCommit();
+  rendererEvents.emit("frame", { frameId: 11 });
+  recorder();
+
+  const report = JSON.parse(readFileSync(output, "utf8")) as {
+    unframedInputCount: number;
+    samples: InteractionPerformanceSample[];
+  };
+  expect(report.unframedInputCount).toBe(0);
+  expect(report.samples).toHaveLength(2);
+  expect(report.samples.map((entry) => entry.key)).toEqual(["down", "up"]);
+  for (const entry of report.samples) {
+    expect(entry).toMatchObject({
+      frameId: 11,
+      inputsInFrame: 2,
+      frameCallbackMs: 1.25,
+      cellsUpdated: 42,
+    });
+  }
 });

--- a/src/renderers/opentui/interaction-performance.test.ts
+++ b/src/renderers/opentui/interaction-performance.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import {
+  summarizeInteractionPerformance,
+  type InteractionPerformanceSample,
+} from "./interaction-performance";
+
+function sample(latencyMs: number): InteractionPerformanceSample {
+  return {
+    id: latencyMs,
+    key: "down",
+    frameId: 1,
+    latencyMs,
+    frameCallbackMs: 0,
+    cellsUpdated: 0,
+    rssBytes: 0,
+  };
+}
+
+test("summarizes key-to-frame latency with nearest-rank percentiles", () => {
+  const samples = Array.from({ length: 20 }, (_, index) => sample(index + 1));
+  expect(summarizeInteractionPerformance(samples)).toEqual({
+    count: 20,
+    p50Ms: 10,
+    p95Ms: 19,
+    maxMs: 20,
+  });
+});

--- a/src/renderers/opentui/interaction-performance.ts
+++ b/src/renderers/opentui/interaction-performance.ts
@@ -27,8 +27,10 @@ export interface InteractionPerformanceSample {
   id: number;
   key: string;
   frameId: number;
+  inputsInFrame: number;
   latencyMs: number;
   frameCallbackMs: number;
+  /** Renderer-wide count shared by every input completed in this frame. */
   cellsUpdated: number;
   rssBytes: number;
 }
@@ -38,6 +40,12 @@ export interface InteractionPerformanceSummary {
   p50Ms: number;
   p95Ms: number;
   maxMs: number;
+}
+
+export interface InteractionPerformanceRecorder {
+  (): void;
+  readonly enabled: boolean;
+  markCommit(): void;
 }
 
 function round(value: number): number {
@@ -91,12 +99,20 @@ function statsForFrame(renderer: CliRenderer): CliRendererStats {
 export function installInteractionPerformanceRecorder(
   renderer: CliRenderer,
   outputPath = process.env.GLOOMBERB_INTERACTION_PERF,
-): () => void {
-  if (!outputPath) return () => {};
+): InteractionPerformanceRecorder {
+  if (!outputPath) {
+    const stop = (() => {}) as InteractionPerformanceRecorder;
+    Object.defineProperties(stop, {
+      enabled: { value: false },
+      markCommit: { value: () => {} },
+    });
+    return stop;
+  }
 
   const startedAt = new Date().toISOString();
   const pending: PendingInteraction[] = [];
   const samples: InteractionPerformanceSample[] = [];
+  let committedCount = 0;
   let nextId = 1;
   let stopped = false;
 
@@ -108,15 +124,18 @@ export function installInteractionPerformanceRecorder(
     pending.push({ id: nextId++, key, startedAtMs: performance.now() });
   };
   const onFrame = (event: { frameId: number }) => {
-    if (pending.length === 0) return;
+    if (committedCount === 0) return;
     const completedAtMs = performance.now();
     const stats = statsForFrame(renderer);
     const rssBytes = process.memoryUsage.rss();
-    for (const interaction of pending.splice(0)) {
+    const completed = pending.splice(0, committedCount);
+    committedCount = 0;
+    for (const interaction of completed) {
       samples.push({
         id: interaction.id,
         key: interaction.key,
         frameId: event.frameId,
+        inputsInFrame: completed.length,
         latencyMs: round(completedAtMs - interaction.startedAtMs),
         frameCallbackMs: round(stats.frameCallbackTime),
         cellsUpdated: stats.cellsUpdated,
@@ -128,7 +147,7 @@ export function installInteractionPerformanceRecorder(
   renderer.keyInput.on("keypress", onKeypress);
   renderer.on("frame", onFrame);
 
-  return () => {
+  const stop = (() => {
     if (stopped) return;
     stopped = true;
     renderer.keyInput.off("keypress", onKeypress);
@@ -143,7 +162,7 @@ export function installInteractionPerformanceRecorder(
         ]),
     );
     const report = {
-      version: 1,
+      version: 2,
       startedAt,
       endedAt: new Date().toISOString(),
       summary: summarizeInteractionPerformance(samples),
@@ -154,5 +173,16 @@ export function installInteractionPerformanceRecorder(
     const target = resolve(outputPath);
     mkdirSync(dirname(target), { recursive: true });
     writeFileSync(target, `${JSON.stringify(report, null, 2)}\n`, "utf8");
-  };
+  }) as InteractionPerformanceRecorder;
+  Object.defineProperties(stop, {
+    enabled: { value: true },
+    markCommit: {
+      value: () => {
+        // A React Profiler callback runs after host mutations commit. Only
+        // inputs present by then may be completed by the following frame.
+        committedCount = pending.length;
+      },
+    },
+  });
+  return stop;
 }

--- a/src/renderers/opentui/interaction-performance.ts
+++ b/src/renderers/opentui/interaction-performance.ts
@@ -1,0 +1,158 @@
+import { mkdirSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
+import type { CliRenderer, CliRendererStats } from "@opentui/core";
+
+const SAFE_INTERACTION_KEYS = new Set([
+  "up",
+  "down",
+  "left",
+  "right",
+  "pageup",
+  "pagedown",
+  "home",
+  "end",
+  "enter",
+  "return",
+  "tab",
+  "escape",
+]);
+
+interface PendingInteraction {
+  id: number;
+  key: string;
+  startedAtMs: number;
+}
+
+export interface InteractionPerformanceSample {
+  id: number;
+  key: string;
+  frameId: number;
+  latencyMs: number;
+  frameCallbackMs: number;
+  cellsUpdated: number;
+  rssBytes: number;
+}
+
+export interface InteractionPerformanceSummary {
+  count: number;
+  p50Ms: number;
+  p95Ms: number;
+  maxMs: number;
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function percentile(sorted: readonly number[], quantile: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.max(0, Math.ceil(sorted.length * quantile) - 1);
+  return sorted[Math.min(index, sorted.length - 1)]!;
+}
+
+export function summarizeInteractionPerformance(
+  samples: readonly InteractionPerformanceSample[],
+): InteractionPerformanceSummary {
+  const latencies = samples.map((sample) => sample.latencyMs).sort((left, right) => left - right);
+  return {
+    count: latencies.length,
+    p50Ms: round(percentile(latencies, 0.5)),
+    p95Ms: round(percentile(latencies, 0.95)),
+    maxMs: round(latencies.at(-1) ?? 0),
+  };
+}
+
+function statsForFrame(renderer: CliRenderer): CliRendererStats {
+  try {
+    return renderer.getStats();
+  } catch {
+    return {
+      fps: 0,
+      frameCount: 0,
+      frameTimes: [],
+      averageFrameTime: 0,
+      minFrameTime: 0,
+      maxFrameTime: 0,
+      frameCallbackTime: 0,
+      nativeLastFrameTime: 0,
+      nativeAverageFrameTime: 0,
+      nativeFrameCount: 0,
+      cellsUpdated: 0,
+      averageCellsUpdated: 0,
+    };
+  }
+}
+
+/**
+ * Opt-in key-to-frame telemetry for repeatable tmux benchmarks. The recorder
+ * ignores printable keys, buffers in memory, and writes once during renderer
+ * shutdown so measurement does not add filesystem work to the hot path.
+ */
+export function installInteractionPerformanceRecorder(
+  renderer: CliRenderer,
+  outputPath = process.env.GLOOMBERB_INTERACTION_PERF,
+): () => void {
+  if (!outputPath) return () => {};
+
+  const startedAt = new Date().toISOString();
+  const pending: PendingInteraction[] = [];
+  const samples: InteractionPerformanceSample[] = [];
+  let nextId = 1;
+  let stopped = false;
+
+  renderer.setGatherStats(true);
+
+  const onKeypress = (event: { name?: string }) => {
+    const key = event.name?.toLowerCase() ?? "";
+    if (!SAFE_INTERACTION_KEYS.has(key)) return;
+    pending.push({ id: nextId++, key, startedAtMs: performance.now() });
+  };
+  const onFrame = (event: { frameId: number }) => {
+    if (pending.length === 0) return;
+    const completedAtMs = performance.now();
+    const stats = statsForFrame(renderer);
+    const rssBytes = process.memoryUsage.rss();
+    for (const interaction of pending.splice(0)) {
+      samples.push({
+        id: interaction.id,
+        key: interaction.key,
+        frameId: event.frameId,
+        latencyMs: round(completedAtMs - interaction.startedAtMs),
+        frameCallbackMs: round(stats.frameCallbackTime),
+        cellsUpdated: stats.cellsUpdated,
+        rssBytes,
+      });
+    }
+  };
+
+  renderer.keyInput.on("keypress", onKeypress);
+  renderer.on("frame", onFrame);
+
+  return () => {
+    if (stopped) return;
+    stopped = true;
+    renderer.keyInput.off("keypress", onKeypress);
+    renderer.off("frame", onFrame);
+
+    const byKey = Object.fromEntries(
+      [...new Set(samples.map((sample) => sample.key))]
+        .sort()
+        .map((key) => [
+          key,
+          summarizeInteractionPerformance(samples.filter((sample) => sample.key === key)),
+        ]),
+    );
+    const report = {
+      version: 1,
+      startedAt,
+      endedAt: new Date().toISOString(),
+      summary: summarizeInteractionPerformance(samples),
+      byKey,
+      unframedInputCount: pending.length,
+      samples,
+    };
+    const target = resolve(outputPath);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  };
+}

--- a/src/state/app/context/index.tsx
+++ b/src/state/app/context/index.tsx
@@ -287,6 +287,7 @@ export function usePaneStateValue<T>(key: string, fallback: T, paneId?: string):
     const resolved = typeof nextValue === "function"
       ? (nextValue as (previousValue: T) => T)(currentValue)
       : nextValue;
+    if (Object.is(currentValue, resolved)) return;
     dispatch({ type: "UPDATE_PANE_STATE", paneId: scopedPaneId, patch: { [key]: resolved } });
   }, [dispatch, key, scopedPaneId, stateRef]);
   return [value, setValue];
@@ -309,6 +310,7 @@ export function usePaneSettingValue<T>(
     const resolved = typeof nextValue === "function"
       ? (nextValue as (previousValue: T) => T)(currentValue)
       : nextValue;
+    if (Object.is(currentValue, resolved)) return;
     const layout = setPaneSetting(currentState.config.layout, scopedPaneId, key, resolved);
     const nextConfig = syncConfigActiveLayoutState(
       { ...currentState.config, layout },

--- a/src/state/app/context/selector.test.tsx
+++ b/src/state/app/context/selector.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { act, useRef, type Dispatch } from "react";
 import { testRender } from "../../../renderers/opentui/test-utils";
-import { AppProvider, PaneInstanceProvider, useAppDispatch, useAppSelector, usePaneTicker, type AppAction } from "./index";
+import { AppProvider, PaneInstanceProvider, useAppDispatch, useAppSelector, usePaneSettingValue, usePaneTicker, type AppAction } from "./index";
 import { cloneLayout, createDefaultConfig, type AppConfig } from "../../../types/config";
 import { applyTheme } from "../../../theme/colors";
 import { useThemeId } from "../../../theme/theme-context";
@@ -11,6 +11,7 @@ const TEST_PANE_ID = "ticker-detail:test";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let capturedDispatch: Dispatch<AppAction> | null = null;
+let capturedPaneSetting: ((value: string) => void) | null = null;
 
 function createTickerDetailConfig(symbol: string): AppConfig {
   const config = createDefaultConfig("/tmp/gloomberb-test");
@@ -42,6 +43,14 @@ function PaneTickerHarness() {
   renderCountRef.current += 1;
   const { symbol } = usePaneTicker();
   return <text>{`${symbol ?? "none"}:${renderCountRef.current}`}</text>;
+}
+
+function PaneSettingHarness() {
+  const renderCountRef = useRef(0);
+  renderCountRef.current += 1;
+  const [value, setValue] = usePaneSettingValue("mode", "table");
+  capturedPaneSetting = setValue;
+  return <text>{`${value}:${renderCountRef.current}`}</text>;
 }
 
 function ThemeSelectorHarness() {
@@ -99,6 +108,7 @@ describe("pane selectors", () => {
     }
     testSetup = undefined;
     capturedDispatch = null;
+    capturedPaneSetting = null;
     applyTheme("amber");
   });
 
@@ -123,6 +133,28 @@ describe("pane selectors", () => {
     await testSetup.renderOnce();
     await testSetup.renderOnce();
     expect(testSetup.captureCharFrame()).toContain("AAPL:1");
+  });
+
+  test("does not dispatch or rerender when a pane setting keeps its effective value", async () => {
+    testSetup = await testRender(
+      <AppProvider config={createTickerDetailConfig("AAPL")}>
+        <PaneInstanceProvider paneId={TEST_PANE_ID}>
+          <PaneSettingHarness />
+        </PaneInstanceProvider>
+      </AppProvider>,
+      { width: 24, height: 4 },
+    );
+
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain("table:1");
+
+    await act(() => {
+      capturedPaneSetting?.("table");
+    });
+    await testSetup.renderOnce();
+    await testSetup.renderOnce();
+
+    expect(testSetup.captureCharFrame()).toContain("table:1");
   });
 
   test("rerenders theme hook consumers when the theme changes", async () => {

--- a/src/state/hooks/quote-streaming.test.tsx
+++ b/src/state/hooks/quote-streaming.test.tsx
@@ -10,6 +10,7 @@ import { useLiveQuoteEntries, useQuoteStreaming, useQuoteUpdates } from "./quote
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let bumpHarness: (() => void) | null = null;
+let toggleStreamingPriority: (() => void) | null = null;
 let togglePollingPriority: (() => void) | null = null;
 let updateLiveTargets: ((symbol: string) => void) | null = null;
 let updateFreshnessScope: ((scope: string) => void) | null = null;
@@ -25,6 +26,31 @@ function QuoteStreamingHarness() {
   }]);
 
   return <text>{String(tick)}</text>;
+}
+
+function QuoteStreamingPriorityHarness() {
+  const [selected, setSelected] = useState(false);
+  toggleStreamingPriority = () => setSelected((current) => !current);
+  useQuoteStreaming([{
+    symbol: "AAPL",
+    exchange: "NASDAQ",
+    context: {
+      brokerId: "ibkr",
+      brokerInstanceId: "ibkr-work",
+      instrument: {
+        brokerId: "ibkr",
+        brokerInstanceId: "ibkr-work",
+        conId: 1001,
+        symbol: "AAPL",
+      },
+    },
+    route: "provider",
+    surface: selected ? "detail" : "portfolio",
+    visible: true,
+    selected,
+    weight: selected ? 100 : 10,
+  }]);
+  return <text>{selected ? "selected" : "idle"}</text>;
 }
 
 function QuotePollingHarness() {
@@ -82,6 +108,7 @@ afterEach(async () => {
     testSetup = undefined;
   }
   bumpHarness = null;
+  toggleStreamingPriority = null;
   togglePollingPriority = null;
   updateLiveTargets = null;
   updateFreshnessScope = null;
@@ -125,6 +152,72 @@ describe("useQuoteStreaming", () => {
 
     expect(subscribeCalls).toBe(1);
     expect(unsubscribeCalls).toBe(0);
+  });
+
+  test("updates priorities without replacing the hook subscription", async () => {
+    type CoordinatorTargets = Parameters<MarketDataCoordinator["subscribeQuotes"]>[0];
+    const initialTargets: CoordinatorTargets[] = [];
+    const updates: CoordinatorTargets[] = [];
+    let unsubscribeCalls = 0;
+    const coordinator = {
+      subscribeQuotes: (targets: CoordinatorTargets) => {
+        initialTargets.push(targets);
+        return Object.assign(
+          () => { unsubscribeCalls += 1; },
+          { update: (nextTargets: CoordinatorTargets) => updates.push(nextTargets) },
+        );
+      },
+    };
+    setSharedMarketDataCoordinator(coordinator as unknown as MarketDataCoordinator);
+
+    testSetup = await testRender(<QuoteStreamingPriorityHarness />, {
+      width: 20,
+      height: 1,
+    });
+    await act(async () => testSetup!.renderOnce());
+
+    expect(initialTargets).toHaveLength(1);
+    expect(initialTargets[0]?.[0]).toMatchObject({
+      instrument: {
+        symbol: "AAPL",
+        exchange: "NASDAQ",
+        brokerId: "ibkr",
+        brokerInstanceId: "ibkr-work",
+        instrument: { conId: 1001, symbol: "AAPL" },
+      },
+      priority: {
+        route: "provider",
+        surface: "portfolio",
+        visible: true,
+        selected: false,
+        weight: 10,
+      },
+    });
+
+    await act(async () => {
+      toggleStreamingPriority?.();
+      await Promise.resolve();
+      await testSetup!.renderOnce();
+    });
+
+    expect(initialTargets).toHaveLength(1);
+    expect(unsubscribeCalls).toBe(0);
+    expect(updates).toHaveLength(1);
+    expect(updates[0]?.[0]).toMatchObject({
+      instrument: {
+        symbol: "AAPL",
+        brokerId: "ibkr",
+        brokerInstanceId: "ibkr-work",
+        instrument: { conId: 1001 },
+      },
+      priority: {
+        route: "provider",
+        surface: "detail",
+        visible: true,
+        selected: true,
+        weight: 100,
+      },
+    });
   });
 
   test("uses forced polling instead of a subscription when live streaming is disabled", async () => {

--- a/src/state/hooks/quote-streaming.ts
+++ b/src/state/hooks/quote-streaming.ts
@@ -4,7 +4,7 @@ import type { QuoteSubscriptionTarget } from "../../types/data-provider";
 import type { Quote } from "../../types/financials";
 import { debugLog } from "../../utils/debug-log";
 import { normalizeSymbol } from "../../utils/exchanges";
-import { getSharedMarketDataCoordinator } from "../../market-data/coordinator";
+import { getSharedMarketDataCoordinator, type MarketDataCoordinator } from "../../market-data/coordinator";
 import { useQuoteEntries } from "../../market-data/hooks";
 import type { InstrumentRef } from "../../market-data/request-types";
 import type { QueryEntry } from "../../market-data/result-types";
@@ -33,12 +33,11 @@ export function normalizeQuoteStreamSubscriptionTarget(target: QuoteSubscription
   };
 }
 
-export function buildQuoteStreamSubscriptionKey(target: QuoteSubscriptionTarget): string {
+export function buildQuoteStreamSubscriptionIdentityKey(target: QuoteSubscriptionTarget): string {
   const contractKey = target.context?.instrument?.conId
     ?? target.context?.instrument?.localSymbol
     ?? target.context?.instrument?.symbol
     ?? "";
-  const weight = Number.isFinite(target.weight) ? String(target.weight) : "";
   return [
     target.symbol,
     target.exchange ?? "",
@@ -46,11 +45,49 @@ export function buildQuoteStreamSubscriptionKey(target: QuoteSubscriptionTarget)
     target.context?.brokerInstanceId ?? "",
     contractKey,
     target.route ?? "auto",
+  ].join("|");
+}
+
+export function buildQuoteStreamSubscriptionKey(target: QuoteSubscriptionTarget): string {
+  const weight = Number.isFinite(target.weight) ? String(target.weight) : "";
+  return [
+    buildQuoteStreamSubscriptionIdentityKey(target),
     target.surface ?? "",
     target.visible ? "visible" : "",
     target.selected ? "selected" : "",
     weight,
   ].join("|");
+}
+
+type CoordinatorQuoteTargets = Parameters<MarketDataCoordinator["subscribeQuotes"]>[0];
+type UpdateableQuoteSubscription = (() => void) & {
+  update?: (targets: CoordinatorQuoteTargets) => void;
+};
+
+interface ActiveQuoteSubscription {
+  identityKey: string;
+  subscriptionKey: string;
+  count: number;
+  dispose: UpdateableQuoteSubscription;
+}
+
+function toCoordinatorQuoteTargets(targets: QuoteSubscriptionTarget[]): CoordinatorQuoteTargets {
+  return targets.map((target) => ({
+    instrument: {
+      symbol: target.symbol,
+      exchange: target.exchange,
+      brokerId: target.context?.brokerId,
+      brokerInstanceId: target.context?.brokerInstanceId,
+      instrument: target.context?.instrument ?? null,
+    },
+    priority: {
+      route: target.route,
+      surface: target.surface,
+      visible: target.visible,
+      selected: target.selected,
+      weight: target.weight,
+    },
+  }));
 }
 
 export function useQuoteStreaming(
@@ -70,48 +107,86 @@ export function useQuoteStreaming(
   const sortedEntries = [...normalizedEntries.entries()].sort(([left], [right]) => left.localeCompare(right));
   const normalizedTargets = sortedEntries.map(([, target]) => target);
   const subscriptionKey = sortedEntries.map(([key]) => key).join("|");
+  const identityKey = [...new Set(normalizedTargets.map(buildQuoteStreamSubscriptionIdentityKey))]
+    .sort()
+    .join("\u001f");
+  const coordinatorTargets = toCoordinatorQuoteTargets(normalizedTargets);
+  const latestSubscriptionRef = useRef({
+    identityKey,
+    subscriptionKey,
+    targets: coordinatorTargets,
+  });
+  latestSubscriptionRef.current = {
+    identityKey,
+    subscriptionKey,
+    targets: coordinatorTargets,
+  };
+  const activeSubscriptionRef = useRef<ActiveQuoteSubscription | null>(null);
 
   useEffect(() => {
+    const latest = latestSubscriptionRef.current;
     if (!enabled || !appActive) {
-      if (normalizedTargets.length > 0) {
+      if (latest.targets.length > 0) {
         quoteStreamLog.info("skipping subscription", {
           reason: enabled ? "inactive" : "disabled",
-          targets: subscriptionKey,
+          targets: latest.subscriptionKey,
         });
       }
       return;
     }
-    if (!coordinator || normalizedTargets.length === 0) return;
+    if (!coordinator || latest.targets.length === 0) return;
     quoteStreamLog.info("subscribe", {
       providerId: "market-data",
-      count: normalizedTargets.length,
-      targets: subscriptionKey,
+      count: latest.targets.length,
+      targets: latest.subscriptionKey,
     });
-    const unsubscribe = coordinator.subscribeQuotes(normalizedTargets.map((target) => ({
-      instrument: {
-        symbol: target.symbol,
-        exchange: target.exchange,
-        brokerId: target.context?.brokerId,
-        brokerInstanceId: target.context?.brokerInstanceId,
-        instrument: target.context?.instrument ?? null,
-      },
-      priority: {
-        route: target.route,
-        surface: target.surface,
-        visible: target.visible,
-        selected: target.selected,
-        weight: target.weight,
-      },
-    })));
+    const active: ActiveQuoteSubscription = {
+      identityKey: latest.identityKey,
+      subscriptionKey: latest.subscriptionKey,
+      count: latest.targets.length,
+      dispose: coordinator.subscribeQuotes(latest.targets) as UpdateableQuoteSubscription,
+    };
+    activeSubscriptionRef.current = active;
     return () => {
+      if (activeSubscriptionRef.current === active) {
+        activeSubscriptionRef.current = null;
+      }
       quoteStreamLog.info("unsubscribe", {
         providerId: "market-data",
-        count: normalizedTargets.length,
-        targets: subscriptionKey,
+        count: active.count,
+        targets: active.subscriptionKey,
       });
-      unsubscribe?.();
+      active.dispose();
     };
-  }, [appActive, coordinator, enabled, subscriptionKey]);
+  }, [appActive, coordinator, enabled, identityKey]);
+
+  useEffect(() => {
+    if (!enabled || !appActive || !coordinator) return;
+    const active = activeSubscriptionRef.current;
+    const latest = latestSubscriptionRef.current;
+    if (
+      !active
+      || active.identityKey !== latest.identityKey
+      || active.subscriptionKey === latest.subscriptionKey
+    ) {
+      return;
+    }
+
+    quoteStreamLog.info("update subscription", {
+      providerId: "market-data",
+      count: latest.targets.length,
+      targets: latest.subscriptionKey,
+    });
+    if (typeof active.dispose.update === "function") {
+      active.dispose.update(latest.targets);
+    } else {
+      const previousDispose = active.dispose;
+      active.dispose = coordinator.subscribeQuotes(latest.targets) as UpdateableQuoteSubscription;
+      previousDispose();
+    }
+    active.subscriptionKey = latest.subscriptionKey;
+    active.count = latest.targets.length;
+  }, [appActive, coordinator, enabled, identityKey, subscriptionKey]);
 }
 
 export function useQuoteUpdates(
@@ -195,8 +270,9 @@ export function useLiveQuoteEntries(
     const normalized = normalizeQuoteStreamSubscriptionTarget(target);
     return normalized ? [normalized] : [];
   });
-  const targetKey = normalizedTargets
-    .map((target) => buildQuoteStreamSubscriptionKey(target))
+  const targetKey = [...new Set(
+    normalizedTargets.map((target) => buildQuoteStreamSubscriptionIdentityKey(target)),
+  )]
     .sort()
     .join("\u001f");
   const liveStreaming = options.liveStreaming !== false;


### PR DESCRIPTION
## Summary

- decouple immediate table cursor movement from persisted pane selection so linked detail charts and app config do not rebuild on every key repeat
- cut shared table render work with row-level memoization, stable event callbacks, lazy remote metadata, and native-bitmap gating when braille rendering is active
- retain quote subscription handles across priority changes, coalesce priority-only upstream updates, and keep membership/routing changes immediate
- add opt-in key-to-frame telemetry and a deterministic tmux navigation benchmark

## ECST benchmark

Sandboxed 140x45 tmux session, 12 down and 12 up keys at 50 ms intervals, populated table verified through `ui://tree`.

| Metric | Baseline | After (median of 3 runs) | Change |
| --- | ---: | ---: | ---: |
| key-to-frame p50 | 40.53 ms | 3.79 ms | -90.6% |
| key-to-frame p95 | 45.67 ms | 4.21 ms | -90.8% |
| cells updated per frame | 557.5 | 88 | -84.2% |
| peak RSS | 680.2 MiB | 584.6 MiB | -14.1% |

Both baseline and after measurements use post-commit frame correlation. The three after runs stayed within 3.73-3.88 ms p50 and 4.06-4.72 ms p95.

## Validation

- `bun test` (2518 passed)
- `bun run typecheck`
- `bun run build`
- `bun run benchmark:tui:navigation -- --keys 12 --interval-ms 50`
