### PR TITLE
Fix hidden pane restoration and persistence

### DIFF
--- a/src/app/pane-runtime/index.tsx
+++ b/src/app/pane-runtime/index.tsx
@@ -20,7 +20,6 @@ import {
 import { scheduleConfigSave } from "../../state/config-save-scheduler";
 import {
   createPaneInstance,
-  findPaneInstance,
   isTickerPaneId,
   normalizePaneId,
   normalizePaneLayout,
@@ -37,6 +36,7 @@ import type {
 import type { DialogApi } from "../../ui/dialog";
 import {
   resolvePanelForPane,
+  resolvePaneShowTarget,
   resolvePaneTarget as resolvePaneTargetInLayout,
   selectEdgeAnchor,
 } from "./layout-placement";
@@ -209,26 +209,23 @@ export function useAppPaneRuntime({
   ]);
 
   const showPane = useCallback((paneId: string) => {
-    const normalizedPaneId = normalizePaneId(paneId);
-    const paneDef = pluginRegistry.panes.get(normalizedPaneId);
+    const target = resolvePaneShowTarget(state.config.layout, paneId);
+    const paneDef = pluginRegistry.panes.get(target.paneType);
     if (!paneDef) return;
 
-    if (normalizedPaneId === TICKER_RESEARCH_PANE_ID) {
+    if (target.paneType === TICKER_RESEARCH_PANE_ID) {
       showTickerResearchPane();
       return;
     }
 
-    const existingInstanceId = resolvePaneTarget(normalizedPaneId);
-    if (existingInstanceId && isPaneInLayout(state.config.layout, existingInstanceId)) {
-      pluginRegistry.focusPaneFn(existingInstanceId);
+    if (target.instance && isPaneInLayout(state.config.layout, target.instance.instanceId)) {
+      pluginRegistry.focusPaneFn(target.instance.instanceId);
       return;
     }
 
-    const instance = existingInstanceId
-      ? findPaneInstance(state.config.layout, existingInstanceId)
-      : buildPaneInstance(normalizedPaneId);
+    const instance = target.instance ?? buildPaneInstance(target.paneType);
     if (!instance) {
-      if (isTickerPaneId(paneId)) {
+      if (isTickerPaneId(target.paneType)) {
         notify("Open a ticker or collection context first.");
       }
       return;
@@ -239,7 +236,6 @@ export function useAppPaneRuntime({
     notify,
     placePaneInstance,
     pluginRegistry,
-    resolvePaneTarget,
     showTickerResearchPane,
     state.config.layout,
   ]);

--- a/src/app/pane-runtime/layout-placement.test.ts
+++ b/src/app/pane-runtime/layout-placement.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import type { LayoutConfig } from "../../types/config";
+import { resolvePaneShowTarget } from "./layout-placement";
+
+describe("resolvePaneShowTarget", () => {
+  test("resolves a hidden pane by its exact instance id", () => {
+    const hiddenPane = {
+      instanceId: "news-top:stored",
+      paneId: "news-top",
+      binding: { kind: "none" as const },
+      placementMemory: {
+        floating: { x: 12, y: 4, width: 90, height: 30 },
+      },
+    };
+    const layout: LayoutConfig = {
+      dockRoot: null,
+      instances: [hiddenPane],
+      floating: [],
+      detached: [],
+    };
+
+    expect(resolvePaneShowTarget(layout, hiddenPane.instanceId)).toEqual({
+      paneType: "news-top",
+      instance: hiddenPane,
+    });
+  });
+});

--- a/src/app/pane-runtime/layout-placement.ts
+++ b/src/app/pane-runtime/layout-placement.ts
@@ -28,6 +28,19 @@ export function resolvePaneTarget(layout: LayoutConfig, paneId: string): string 
     ?? null;
 }
 
+/** Resolve an instance id before looking up its registered pane type. */
+export function resolvePaneShowTarget(
+  layout: LayoutConfig,
+  paneId: string,
+): { paneType: string; instance: PaneInstanceConfig | null } {
+  const instanceId = resolvePaneTarget(layout, paneId);
+  const instance = instanceId ? findPaneInstance(layout, instanceId) ?? null : null;
+  return {
+    paneType: normalizePaneId(instance?.paneId ?? paneId),
+    instance,
+  };
+}
+
 export function resolvePanelForPane({
   layout,
   paneId,

--- a/src/data/config/layout.ts
+++ b/src/data/config/layout.ts
@@ -10,8 +10,10 @@ import {
   cloneLayout,
   clonePaneSettings,
   createPaneInstanceId,
+  getPlacedPaneInstanceIds,
   normalizePaneLayout,
   normalizePaneId,
+  removeUnreachablePaneInstances,
 } from "../../types/config";
 import {
   migrateChartPaneSettings,
@@ -155,11 +157,14 @@ function sanitizePaneInstances(
         placementMemory: sanitizePlacementMemory(entry.placementMemory),
       };
     });
-  return instances.length > 0 ? instances : cloneLayout(fallback).instances;
+  return instances;
 }
 
-function getDefaultFollowSourceInstanceId(instances: PaneInstanceConfig[]): string | null {
-  return instances.find((instance) => instance.paneId === "portfolio-list")?.instanceId ?? null;
+function getDefaultFollowSourceInstanceId(layout: LayoutConfig): string | null {
+  const placedPaneIds = new Set(getPlacedPaneInstanceIds(layout));
+  return layout.instances.find((instance) => (
+    instance.paneId === "portfolio-list" && placedPaneIds.has(instance.instanceId)
+  ))?.instanceId ?? null;
 }
 
 function sanitizeFloatingEntries(value: unknown, validInstanceIds: Set<string>): LayoutConfig["floating"] {
@@ -219,7 +224,7 @@ export function sanitizeLayout(
   if (!Array.isArray((value as LayoutConfig & { instances?: unknown }).instances)) {
     const layout = cloneLayout(fallback);
     return normalizePaneLayout(layout, {
-      defaultFollowSourceInstanceId: getDefaultFollowSourceInstanceId(layout.instances),
+      defaultFollowSourceInstanceId: getDefaultFollowSourceInstanceId(layout),
       resolveOrphanSymbol: () => null,
     });
   }
@@ -241,8 +246,9 @@ export function sanitizeLayout(
     detached,
   };
 
-  return normalizePaneLayout(layout, {
-    defaultFollowSourceInstanceId: getDefaultFollowSourceInstanceId(layout.instances),
+  const normalized = normalizePaneLayout(layout, {
+    defaultFollowSourceInstanceId: getDefaultFollowSourceInstanceId(layout),
     resolveOrphanSymbol: () => null,
   });
+  return removeUnreachablePaneInstances(normalized);
 }

--- a/src/data/config/store/index.test.ts
+++ b/src/data/config/store/index.test.ts
@@ -49,6 +49,50 @@ async function writeConfigJson(dataDir: string, config: Record<string, unknown>)
 }
 
 describe("sanitizeLayout", () => {
+  test("preserves an intentionally blank layout", () => {
+    expect(sanitizeLayout({
+      dockRoot: null,
+      instances: [],
+      floating: [],
+      detached: [],
+    }, DEFAULT_LAYOUT)).toEqual({
+      dockRoot: null,
+      instances: [],
+      floating: [],
+      detached: [],
+    });
+  });
+
+  test("prunes abandoned panes while retaining a hidden follow source", () => {
+    const layout = sanitizeLayout({
+      dockRoot: { kind: "pane", instanceId: "ticker-research:visible" },
+      instances: [
+        {
+          instanceId: "portfolio-list:source",
+          paneId: "portfolio-list",
+          binding: { kind: "none" },
+        },
+        {
+          instanceId: "ticker-research:visible",
+          paneId: "ticker-research",
+          binding: { kind: "follow", sourceInstanceId: "portfolio-list:source" },
+        },
+        {
+          instanceId: "ticker-research:closed",
+          paneId: "ticker-research",
+          binding: { kind: "fixed", symbol: "NVDA" },
+        },
+      ],
+      floating: [],
+      detached: [],
+    }, DEFAULT_LAYOUT);
+
+    expect(layout.instances.map((instance) => instance.instanceId)).toEqual([
+      "portfolio-list:source",
+      "ticker-research:visible",
+    ]);
+  });
+
   test("ships a focused Home layout with portfolio, chat, and following research", () => {
     expect(DEFAULT_LAYOUT.instances.map((instance) => instance.instanceId)).toEqual([
       "portfolio-list:main",
@@ -318,6 +362,59 @@ describe("sanitizeLayout", () => {
 });
 
 describe("loadConfig", () => {
+  test("migrates unreachable pane instances and their saved state", async () => {
+    const dataDir = await createTempConfigDir();
+    const hiddenPaneId = "ticker-research:closed";
+    const legacyLayout = {
+      ...DEFAULT_LAYOUT,
+      instances: [
+        ...DEFAULT_LAYOUT.instances.map((instance) => instance.instanceId === "chat:main"
+          ? {
+            ...instance,
+            placementMemory: {
+              docked: {
+                anchorInstanceId: hiddenPaneId,
+                position: "right" as const,
+              },
+            },
+          }
+          : instance),
+        {
+          instanceId: hiddenPaneId,
+          paneId: "ticker-research",
+          binding: { kind: "fixed" as const, symbol: "NVDA" },
+          placementMemory: { floating: { x: 12, y: 4, width: 90, height: 30 } },
+        },
+      ],
+    };
+    await writeConfigJson(dataDir, createSavedConfig({
+      configVersion: 21,
+      layout: legacyLayout,
+      layouts: [{
+        name: "Default",
+        layout: legacyLayout,
+        paneState: {
+          "chat:main": { draft: "keep" },
+          [hiddenPaneId]: { activeTabId: "overview" },
+        },
+        focusedPaneId: hiddenPaneId,
+      }],
+    }));
+
+    const config = await loadConfig(dataDir);
+
+    expect(config.configVersion).toBe(CURRENT_CONFIG_VERSION);
+    expect(config.layout.instances.some((instance) => instance.instanceId === hiddenPaneId)).toBe(false);
+    expect(config.layouts[0]?.layout.instances.some((instance) => instance.instanceId === hiddenPaneId)).toBe(false);
+    expect(config.layouts[0]?.paneState).toEqual({ "chat:main": { draft: "keep" } });
+    expect(config.layouts[0]?.focusedPaneId).toBeNull();
+    expect(findPaneInstance(config.layout, "chat:main")?.placementMemory?.docked).toEqual({
+      anchorInstanceId: undefined,
+      path: undefined,
+      position: "right",
+    });
+  });
+
   test("folds saved graph plugin state into composer specs and removes only chart-owned state", async () => {
     const dataDir = await createTempConfigDir();
     const legacyLayout = {

--- a/src/data/config/store/migrations.ts
+++ b/src/data/config/store/migrations.ts
@@ -4,6 +4,7 @@ import {
   CURRENT_CONFIG_VERSION,
   DEFAULT_COLUMNS,
   DEFAULT_PORTFOLIO_COLUMN_IDS,
+  getPlacedPaneInstanceIds,
   type LayoutConfig,
 } from "../../../types/config";
 import {
@@ -24,6 +25,7 @@ const CLOUD_MACRO_SPLIT_CONFIG_VERSION = 15;
 const PORTFOLIO_DEFAULT_COLUMNS_CONFIG_VERSION = 17;
 const BUILTIN_OWNERSHIP_AND_CHART_CONFIG_VERSION = 20;
 const ONBOARDING_BACKFILL_CONFIG_VERSION = 21;
+const UNREACHABLE_PANE_CLEANUP_CONFIG_VERSION = 22;
 
 const LEGACY_MAIN_PORTFOLIO_COLUMN_IDS = DEFAULT_COLUMNS.map((column) => column.id);
 const PRE_SPARKLINE_PORTFOLIO_COLUMN_IDS = [
@@ -85,6 +87,11 @@ const CONFIG_MIGRATIONS: readonly ConfigMigration[] = [
     toVersion: ONBOARDING_BACKFILL_CONFIG_VERSION,
     migrate: migrateOnboardingComplete,
   },
+  {
+    name: "prune-unreachable-pane-instances",
+    toVersion: UNREACHABLE_PANE_CLEANUP_CONFIG_VERSION,
+    migrate: migrateUnreachablePaneInstances,
+  },
 ];
 
 export function migrateSavedConfig(saved: Record<string, unknown>, dataDir: string): ConfigMigrationResult {
@@ -136,6 +143,40 @@ function migrateOnboardingComplete(saved: Record<string, unknown>): Record<strin
     ...saved,
     onboardingComplete: true,
     onboardingProgress: undefined,
+  };
+}
+
+function migrateUnreachablePaneInstances(
+  saved: Record<string, unknown>,
+  dataDir: string,
+): Record<string, unknown> {
+  const defaults = createDefaultConfig(dataDir);
+  const layout = sanitizeLayout(saved.layout, defaults.layout);
+  const layouts = Array.isArray(saved.layouts)
+    ? saved.layouts.map((entry) => {
+      if (!isPlainRecord(entry) || typeof entry.name !== "string") return entry;
+      const entryLayout = sanitizeLayout(entry.layout, layout);
+      const instanceIds = new Set(entryLayout.instances.map((instance) => instance.instanceId));
+      const placedIds = new Set(getPlacedPaneInstanceIds(entryLayout));
+      const paneState = isPlainRecord(entry.paneState)
+        ? Object.fromEntries(Object.entries(entry.paneState).filter(([instanceId]) => instanceIds.has(instanceId)))
+        : entry.paneState;
+      const focusedPaneId = typeof entry.focusedPaneId === "string" && !placedIds.has(entry.focusedPaneId)
+        ? null
+        : entry.focusedPaneId;
+      return {
+        ...entry,
+        layout: entryLayout,
+        paneState,
+        focusedPaneId,
+      };
+    })
+    : saved.layouts;
+
+  return {
+    ...saved,
+    layout,
+    layouts,
   };
 }
 

--- a/src/data/config/store/normalize.ts
+++ b/src/data/config/store/normalize.ts
@@ -10,6 +10,7 @@ import {
   cloneLayout,
   createDefaultConfig,
   CURRENT_CONFIG_VERSION,
+  getPlacedPaneInstanceIds,
 } from "../../../types/config";
 import type { Portfolio, Watchlist } from "../../../types/ticker";
 import { isLanguagePreference } from "../../../i18n/languages";
@@ -305,15 +306,16 @@ function sanitizeSavedLayouts(
     )
     .map((entry) => {
       const layout = sanitizeLayout(entry.layout, fallbackLayout);
+      const placedPaneIds = new Set(getPlacedPaneInstanceIds(layout));
       const paneState = sanitizeSavedPaneState((entry as { paneState?: unknown }).paneState, layout);
       return {
         id: typeof entry.id === "string" ? entry.id : undefined,
         name: entry.name,
         layout,
         paneState,
-        focusedPaneId: typeof entry.focusedPaneId === "string" || entry.focusedPaneId === null
-          ? entry.focusedPaneId
-          : undefined,
+        focusedPaneId: typeof entry.focusedPaneId === "string"
+          ? placedPaneIds.has(entry.focusedPaneId) ? entry.focusedPaneId : null
+          : entry.focusedPaneId === null ? null : undefined,
         activePanel: entry.activePanel === "right" || entry.activePanel === "left"
           ? entry.activePanel
           : undefined,

--- a/src/remote/layout-helpers.ts
+++ b/src/remote/layout-helpers.ts
@@ -1,7 +1,9 @@
 import {
-  getDockedPaneIds,
-} from "../plugins/pane-manager";
-import type { DockLayoutNode, LayoutConfig, PaneInstanceConfig } from "../types/config";
+  getPlacedPaneInstanceIds,
+  type DockLayoutNode,
+  type LayoutConfig,
+  type PaneInstanceConfig,
+} from "../types/config";
 
 export function requirePaneInstance(layout: LayoutConfig, paneId: string): PaneInstanceConfig {
   const instance = layout.instances.find((entry) => entry.instanceId === paneId)
@@ -27,11 +29,7 @@ export function buildGridDockRoot(paneIds: string[], columns?: number): DockLayo
 }
 
 export function visiblePaneIds(layout: LayoutConfig): string[] {
-  const ids = new Set<string>();
-  getDockedPaneIds(layout).forEach((id) => ids.add(id));
-  layout.floating.forEach((entry) => ids.add(entry.instanceId));
-  (layout.detached ?? []).forEach((entry) => ids.add(entry.instanceId));
-  return [...ids];
+  return getPlacedPaneInstanceIds(layout);
 }
 
 export function regionToDockPosition(region: string): "left" | "right" | "above" | "below" {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,7 +1,7 @@
 import type { Portfolio, Watchlist } from "./ticker";
 import type { LanguagePreference } from "../i18n/languages";
 
-export const CURRENT_CONFIG_VERSION = 21;
+export const CURRENT_CONFIG_VERSION = 22;
 
 type ChartRendererPreference = "auto" | "kitty" | "braille";
 
@@ -457,6 +457,14 @@ function getDockedPaneIdsFromNode(node: DockLayoutNode | null, result: string[] 
   return result;
 }
 
+export function getPlacedPaneInstanceIds(layout: LayoutConfig): string[] {
+  return [...new Set([
+    ...getDockedPaneIdsFromNode(layout.dockRoot),
+    ...layout.floating.map((entry) => entry.instanceId),
+    ...(layout.detached ?? []).map((entry) => entry.instanceId),
+  ])];
+}
+
 export function createPaneInstanceId(paneId: string): string {
   nextPaneInstanceSeq += 1;
   return `${paneId}:${Date.now().toString(36)}${nextPaneInstanceSeq.toString(36)}`;
@@ -560,8 +568,24 @@ export function removePaneInstances(layout: LayoutConfig, instanceIds: Iterable<
   const removedIds = new Set(instanceIds);
   if (removedIds.size === 0) return layout;
 
-  const instances = layout.instances.filter((instance) => !removedIds.has(instance.instanceId));
-  const validInstanceIds = new Set(instances.map((instance) => instance.instanceId));
+  const retainedInstances = layout.instances.filter((instance) => !removedIds.has(instance.instanceId));
+  const validInstanceIds = new Set(retainedInstances.map((instance) => instance.instanceId));
+  const instances = retainedInstances
+    .map((instance) => {
+      const memory = clonePlacementMemory(instance.placementMemory);
+      if (!memory?.docked?.anchorInstanceId || validInstanceIds.has(memory.docked.anchorInstanceId)) {
+        return instance;
+      }
+      const docked = {
+        ...memory.docked,
+        anchorInstanceId: undefined,
+      };
+      const nextDocked = docked.path || docked.position ? docked : undefined;
+      const placementMemory = nextDocked || memory.floating || memory.detached
+        ? { ...memory, docked: nextDocked }
+        : undefined;
+      return { ...instance, placementMemory };
+    });
   const dockRoot = normalizeDockNode(layout.dockRoot, validInstanceIds, new Set<string>());
   const dockedPaneIds = new Set(getDockedPaneIdsFromNode(dockRoot));
   const detached = layout.detached ?? [];
@@ -572,6 +596,28 @@ export function removePaneInstances(layout: LayoutConfig, instanceIds: Iterable<
     floating: layout.floating.filter((entry) => !removedIds.has(entry.instanceId) && !dockedPaneIds.has(entry.instanceId)),
     detached: detached.filter((entry) => !removedIds.has(entry.instanceId) && !dockedPaneIds.has(entry.instanceId)),
   };
+}
+
+export function removeUnreachablePaneInstances(layout: LayoutConfig): LayoutConfig {
+  const instancesById = new Map(layout.instances.map((instance) => [instance.instanceId, instance] as const));
+  const reachableIds = new Set(getPlacedPaneInstanceIds(layout));
+  const pendingIds = [...reachableIds];
+
+  for (let index = 0; index < pendingIds.length; index += 1) {
+    const instance = instancesById.get(pendingIds[index]!);
+    if (instance?.binding?.kind !== "follow") continue;
+    const sourceId = instance.binding.sourceInstanceId;
+    if (!instancesById.has(sourceId) || reachableIds.has(sourceId)) continue;
+    reachableIds.add(sourceId);
+    pendingIds.push(sourceId);
+  }
+
+  return removePaneInstances(
+    layout,
+    layout.instances
+      .filter((instance) => !reachableIds.has(instance.instanceId))
+      .map((instance) => instance.instanceId),
+  );
 }
 
 export function normalizePaneLayout(


### PR DESCRIPTION
Summary:
- restore an existing unplaced pane when its command shortcut is used
- migrate persisted layouts to remove unreachable pane instances and matching state
- preserve follow-source dependencies and intentionally blank layouts
- enforce placed-pane focus metadata and reuse shared placement lookup

Validation:
- bun test: 2,522 passed
- bun run typecheck
- bun run desktop:view:build
- bun run build
- isolated tmux TUI smoke: TOP opened Top News with live rows