### PR TITLE
Share panes from the terminal, including news panes

### DIFF
--- a/src/layout-marketplace/payload.test.ts
+++ b/src/layout-marketplace/payload.test.ts
@@ -157,6 +157,23 @@ describe("layout marketplace payloads", () => {
     expect(JSON.stringify(pane)).not.toContain("secret");
   });
 
+  test("drops cache-sized pane state instead of failing the share", () => {
+    const pane = publishableMarketplacePane({
+      instanceId: "news-top:main",
+      paneId: "prediction-markets",
+      binding: { kind: "none" },
+    }, {
+      sort: { columnId: "time", direction: "desc" },
+      "news-top:articles": Array.from({ length: 400 }, (_, index) => ({
+        id: `article-${index}`,
+        title: "x".repeat(200),
+        publishedAt: "2026-08-26T00:00:00.000Z",
+      })),
+    }, panes);
+
+    expect(pane.paneState.p1).toEqual({ sort: { columnId: "time", direction: "desc" } });
+  });
+
   test("shares portable pane setup and state while redacting private data", () => {
     const fixture = portableFixture();
     const payload = publishableMarketplaceLayout(fixture.layout, fixture.paneState, panes);

--- a/src/layout-marketplace/payload.ts
+++ b/src/layout-marketplace/payload.ts
@@ -12,6 +12,10 @@ import type {
 } from "../types/plugin";
 
 const MAX_LAYOUT_BYTES = 128 * 1024;
+// Pane runtime state doubles as a cache (news panes keep six figures of bytes of
+// article backlog), so bulky fields drop out of the share rather than failing
+// the whole publish.
+const MAX_PANE_STATE_FIELD_BYTES = 16 * 1024;
 const MAX_INSTANCES = 40;
 const MAX_DOCK_DEPTH = 20;
 const MAX_ID_LENGTH = 160;
@@ -493,14 +497,45 @@ function publishableLayout(
       height,
     })),
   };
-  const parsed = parseMarketplaceLayoutPayload({
-    schemaVersion: 2,
-    sourceConfigVersion: CURRENT_CONFIG_VERSION,
-    layout: projected,
-    paneState: projectedState,
-  });
+  let publishableState = Object.fromEntries(
+    Object.entries(projectedState).flatMap(([id, state]) => {
+      const trimmed = withoutCacheFields(state);
+      return Object.keys(trimmed).length > 0 ? [[id, trimmed] as const] : [];
+    }),
+  );
+  let parsed = parsePublishablePayload(projected, publishableState);
+  while (!parsed && Object.keys(publishableState).length > 0) {
+    publishableState = withoutLargestState(publishableState);
+    parsed = parsePublishablePayload(projected, publishableState);
+  }
   if (!parsed) throw new Error("This layout cannot be published safely.");
   return parsed;
+}
+
+function parsePublishablePayload(
+  layout: LayoutConfig,
+  paneState: Record<string, PaneRuntimeState>,
+): LayoutMarketplacePayload | null {
+  return parseMarketplaceLayoutPayload({
+    schemaVersion: 2,
+    sourceConfigVersion: CURRENT_CONFIG_VERSION,
+    layout,
+    paneState,
+  });
+}
+
+function withoutCacheFields(state: PaneRuntimeState): PaneRuntimeState {
+  return Object.fromEntries(
+    Object.entries(state).filter(([, value]) => encodedSize(value) <= MAX_PANE_STATE_FIELD_BYTES),
+  ) as PaneRuntimeState;
+}
+
+function withoutLargestState(
+  paneState: Record<string, PaneRuntimeState>,
+): Record<string, PaneRuntimeState> {
+  const largest = Object.entries(paneState)
+    .reduce((worst, entry) => (encodedSize(entry[1]) > encodedSize(worst[1]) ? entry : worst));
+  return Object.fromEntries(Object.entries(paneState).filter(([id]) => id !== largest[0]));
 }
 
 export function publishableMarketplaceLayout(

--- a/src/renderers/opentui/ui-host.tsx
+++ b/src/renderers/opentui/ui-host.tsx
@@ -109,6 +109,7 @@ export const openTuiUiHost: UiHost = {
   kind: "opentui",
   capabilities: {
     nativeCharts: true,
+    publicSharing: true,
   },
   Box: OpenTuiBox as UiHost["Box"],
   Text: OpenTuiText as UiHost["Text"],


### PR DESCRIPTION
The OpenTUI host never advertised the `publicSharing` capability, so the terminal had no **Share Pane** context-menu action, no `Ctrl+Shift+S`, and no `y` share hint on charts or news, even though the share flow only needs `copyText` (OSC 52/pbcopy) and the terminal share API.

While verifying it, news panes still had no share action: `usePersistedNewsArticles` keeps up to 200 serialized articles in pane state (138 KB for `news-top` in a real config), which exceeded the 128 KB marketplace payload cap, so `publishableMarketplacePane` threw, `buildPaneSharePayload` returned null, and the menu item silently disappeared. The same cap also blocked publishing any layout containing a news pane.

- `src/renderers/opentui/ui-host.tsx`: advertise `publicSharing`.
- `src/layout-marketplace/payload.ts`: drop cache-sized pane-state fields (>16 KB) from the published projection, and fall back to dropping whole state entries if the payload still exceeds the cap, instead of failing the publish.

Verified in tmux: **Share Pane / Ctrl+Shift+S** now appears on chart and news panes, the chart footer shows the `y` share hint, and selecting it returns "Share link copied to clipboard" against the live API.

Full suite: 2519 pass, 0 fail. `typecheck:opentui` clean.