### PR TITLE
Add --theme, --scale and --watermark to shot and hide interaction chrome

### DIFF
--- a/src/cli/desktop-pane-shot.ts
+++ b/src/cli/desktop-pane-shot.ts
@@ -22,6 +22,10 @@ export interface DesktopPaneShotPayload {
   heightCells: number;
   widthPx: number;
   heightPx: number;
+  /** Chrome device scale factor; 2 keeps text crisp, higher values zoom the layout. */
+  deviceScaleFactor?: number;
+  /** Label drawn at the right edge of the pane title bar; null draws nothing. */
+  watermark?: string | null;
   tickers: TickerRecord[];
   financials: Array<[string, TickerFinancials]>;
   optionsChains: Array<[string, OptionsChain]>;
@@ -54,12 +58,16 @@ const SHOT_MODE_CSS = [
   "[data-gloom-role='composite-chart-toolbar']",
   "[data-gloom-role='chart-series-quick-add']",
   "[data-gloom-role='pane-close']",
-].join(", ") + " { display: none !important; }";
+].join(", ") + " { display: none !important; }\n"
+  // Sits where the hidden close button was: one cell high, right-aligned in the title bar.
+  + "[data-gloom-role='shot-watermark'] { position: fixed; top: 1px; right: 10px; height: var(--cell-h);"
+  + " line-height: var(--cell-h); font-size: 12px; letter-spacing: 0.02em; color: var(--gloom-text-dim, #888);"
+  + " pointer-events: none; z-index: 1000; }";
 
 const CHROME_POLL_ATTEMPTS = 80;
 const SHOT_READY_TIMEOUT_MS = 10_000;
 const CDP_CALL_TIMEOUT_MS = 10_000;
-const SHOT_DEVICE_SCALE_FACTOR = 2;
+const DEFAULT_DEVICE_SCALE_FACTOR = 2;
 
 export async function renderDesktopPaneScreenshot(
   payload: DesktopPaneShotPayload,
@@ -77,6 +85,7 @@ export async function renderDesktopPaneScreenshot(
       outputPath,
       widthPx: payload.widthPx,
       heightPx: payload.heightPx,
+      deviceScaleFactor: payload.deviceScaleFactor ?? DEFAULT_DEVICE_SCALE_FACTOR,
       userDataDir: join(tempDir, "chrome-profile"),
     });
   } finally {
@@ -105,6 +114,13 @@ async function buildShotPage(outdir: string, payload: DesktopPaneShotPayload): P
         const style = document.createElement("style");
         style.textContent = ${JSON.stringify(SHOT_MODE_CSS)};
         document.head.appendChild(style);
+        const watermark = ${JSON.stringify(payload.watermark ?? null)};
+        if (watermark) {
+          const mark = document.createElement("div");
+          mark.setAttribute("data-gloom-role", "shot-watermark");
+          mark.textContent = watermark;
+          document.addEventListener("DOMContentLoaded", () => document.body.appendChild(mark));
+        }
       })();
       window.addEventListener("error", (event) => {
         window.__GLOOM_CLI_SHOT_ERROR__ = event.error && event.error.stack ? event.error.stack : String(event.error || event.message);
@@ -139,6 +155,7 @@ async function capturePageScreenshot({
   outputPath,
   widthPx,
   heightPx,
+  deviceScaleFactor,
   userDataDir,
 }: {
   chrome: string;
@@ -146,6 +163,7 @@ async function capturePageScreenshot({
   outputPath: string;
   widthPx: number;
   heightPx: number;
+  deviceScaleFactor: number;
   userDataDir: string;
 }): Promise<DesktopPaneShotRenderResult> {
   await mkdir(userDataDir, { recursive: true });
@@ -182,7 +200,7 @@ async function capturePageScreenshot({
     await session.send("Emulation.setDeviceMetricsOverride", {
       width: widthPx,
       height: heightPx,
-      deviceScaleFactor: SHOT_DEVICE_SCALE_FACTOR,
+      deviceScaleFactor,
       mobile: false,
     });
     await waitForShotReady(session);

--- a/src/cli/desktop-pane-shot.ts
+++ b/src/cli/desktop-pane-shot.ts
@@ -50,6 +50,12 @@ type PendingCdpCall = {
   reject: (error: Error) => void;
 };
 
+const SHOT_MODE_CSS = [
+  "[data-gloom-role='composite-chart-toolbar']",
+  "[data-gloom-role='chart-series-quick-add']",
+  "[data-gloom-role='pane-close']",
+].join(", ") + " { display: none !important; }";
+
 const CHROME_POLL_ATTEMPTS = 80;
 const SHOT_READY_TIMEOUT_MS = 10_000;
 const CDP_CALL_TIMEOUT_MS = 10_000;
@@ -93,6 +99,13 @@ async function buildShotPage(outdir: string, payload: DesktopPaneShotPayload): P
     loadingText: "Rendering pane...",
     bootstrapScript: `
       window.__GLOOM_CLI_SHOT_PAYLOAD__ = ${payloadJson};
+      (() => {
+        // A screenshot cannot be interacted with, so drawing tools, the
+        // quick-add input and the close button only add noise to the image.
+        const style = document.createElement("style");
+        style.textContent = ${JSON.stringify(SHOT_MODE_CSS)};
+        document.head.appendChild(style);
+      })();
       window.addEventListener("error", (event) => {
         window.__GLOOM_CLI_SHOT_ERROR__ = event.error && event.error.stack ? event.error.stack : String(event.error || event.message);
       });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -121,7 +121,7 @@ function createCoreCliCommands(
       aliases: ["screenshot"],
       description: "Render a desktop-style screenshot for a pane-backed market function",
       help: {
-        usage: ["shot <function-or-pane> [argument] [--output path] [--width px] [--height px] [--key value]"],
+        usage: ["shot <function-or-pane> [argument] [--output path] [--width px] [--height px] [--theme id] [--key value]"],
       },
       execute: async (args, ctx) => {
         await runPaneScreenshot(args, ctx);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -121,7 +121,7 @@ function createCoreCliCommands(
       aliases: ["screenshot"],
       description: "Render a desktop-style screenshot for a pane-backed market function",
       help: {
-        usage: ["shot <function-or-pane> [argument] [--output path] [--width px] [--height px] [--theme id] [--key value]"],
+        usage: ["shot <function-or-pane> [argument] [--output path] [--width px] [--height px] [--theme id] [--scale n] [--watermark text] [--key value]"],
       },
       execute: async (args, ctx) => {
         await runPaneScreenshot(args, ctx);

--- a/src/cli/pane-functions/index.ts
+++ b/src/cli/pane-functions/index.ts
@@ -98,6 +98,7 @@ export async function runPaneScreenshot(args: string[], ctx: CliCommandContext) 
         outputPath,
         width: parsed.width,
         height: parsed.height,
+        theme: parsed.theme,
         options: parsed.options,
       });
       if (parsed.requireBotSafe && !result.usable) {

--- a/src/cli/pane-functions/index.ts
+++ b/src/cli/pane-functions/index.ts
@@ -99,6 +99,8 @@ export async function runPaneScreenshot(args: string[], ctx: CliCommandContext) 
         width: parsed.width,
         height: parsed.height,
         theme: parsed.theme,
+        scale: parsed.scale,
+        watermark: parsed.watermark,
         options: parsed.options,
       });
       if (parsed.requireBotSafe && !result.usable) {

--- a/src/cli/pane-functions/options.ts
+++ b/src/cli/pane-functions/options.ts
@@ -23,6 +23,8 @@ export interface ParsedPaneFunctionArgs {
   outputPath: string | null;
   width: number;
   height: number;
+  /** Theme id override for screenshots; null keeps the configured theme. */
+  theme: string | null;
   requireBotSafe: boolean;
 }
 
@@ -62,6 +64,7 @@ export function parsePaneFunctionArgs(args: string[]): ParsedPaneFunctionArgs {
   let outputPath: string | null = null;
   let width = DEFAULT_SHOT_WIDTH;
   let height = DEFAULT_SHOT_HEIGHT;
+  let theme: string | null = null;
   let requireBotSafe = false;
 
   for (let index = 0; index < args.length; index += 1) {
@@ -98,6 +101,8 @@ export function parsePaneFunctionArgs(args: string[]): ParsedPaneFunctionArgs {
       if (Number.isFinite(parsedHeight)) {
         height = Math.max(MIN_SHOT_HEIGHT, Math.min(MAX_SHOT_HEIGHT, Math.round(parsedHeight)));
       }
+    } else if (normalizedKey === "theme" && value !== true) {
+      theme = value.trim() || null;
     } else if (normalizedKey === "arguments" && value !== true) {
       Object.assign(options, parseArgumentsOption(value));
     } else {
@@ -107,7 +112,7 @@ export function parsePaneFunctionArgs(args: string[]): ParsedPaneFunctionArgs {
 
   const target = positionals[0]?.trim() ?? "";
   const arg = positionals.slice(1).join(" ").trim();
-  return { target, arg, options, outputPath, width, height, requireBotSafe };
+  return { target, arg, options, outputPath, width, height, theme, requireBotSafe };
 }
 
 export function parsePaneCatalogArgs(args: string[]): ParsedPaneCatalogArgs {
@@ -165,7 +170,7 @@ export function optionString(options: PaneOptionValues, key: string): string | u
   return value === true || value === undefined ? undefined : String(value);
 }
 
-const RESERVED_OPTION_KEYS = new Set(["output", "out", "o", "width", "height", "arguments", "state"]);
+const RESERVED_OPTION_KEYS = new Set(["output", "out", "o", "width", "height", "theme", "arguments", "state"]);
 
 export function optionSettings(options: Record<string, string | true>): Record<string, unknown> {
   const settings: Record<string, unknown> = {};

--- a/src/cli/pane-functions/options.ts
+++ b/src/cli/pane-functions/options.ts
@@ -25,6 +25,10 @@ export interface ParsedPaneFunctionArgs {
   height: number;
   /** Theme id override for screenshots; null keeps the configured theme. */
   theme: string | null;
+  /** Render scale: 1.5 renders two thirds as many cells at 1.5x size, so text reads larger at the same pixel size. */
+  scale: number;
+  /** Small label drawn in the pane title bar, e.g. a domain; null draws nothing. */
+  watermark: string | null;
   requireBotSafe: boolean;
 }
 
@@ -65,6 +69,8 @@ export function parsePaneFunctionArgs(args: string[]): ParsedPaneFunctionArgs {
   let width = DEFAULT_SHOT_WIDTH;
   let height = DEFAULT_SHOT_HEIGHT;
   let theme: string | null = null;
+  let scale = 1;
+  let watermark: string | null = null;
   let requireBotSafe = false;
 
   for (let index = 0; index < args.length; index += 1) {
@@ -103,6 +109,10 @@ export function parsePaneFunctionArgs(args: string[]): ParsedPaneFunctionArgs {
       }
     } else if (normalizedKey === "theme" && value !== true) {
       theme = value.trim() || null;
+    } else if (normalizedKey === "scale" && value !== true) {
+      scale = parseScale(value);
+    } else if (normalizedKey === "watermark" && value !== true) {
+      watermark = value.trim() || null;
     } else if (normalizedKey === "arguments" && value !== true) {
       Object.assign(options, parseArgumentsOption(value));
     } else {
@@ -112,7 +122,7 @@ export function parsePaneFunctionArgs(args: string[]): ParsedPaneFunctionArgs {
 
   const target = positionals[0]?.trim() ?? "";
   const arg = positionals.slice(1).join(" ").trim();
-  return { target, arg, options, outputPath, width, height, theme, requireBotSafe };
+  return { target, arg, options, outputPath, width, height, theme, scale, watermark, requireBotSafe };
 }
 
 export function parsePaneCatalogArgs(args: string[]): ParsedPaneCatalogArgs {
@@ -170,7 +180,17 @@ export function optionString(options: PaneOptionValues, key: string): string | u
   return value === true || value === undefined ? undefined : String(value);
 }
 
-const RESERVED_OPTION_KEYS = new Set(["output", "out", "o", "width", "height", "theme", "arguments", "state"]);
+const RESERVED_OPTION_KEYS = new Set([
+  "output", "out", "o", "width", "height", "theme", "scale", "watermark", "arguments", "state",
+]);
+
+function parseScale(value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed < 0.5 || parsed > 4) {
+    throw new Error(`--scale must be a number between 0.5 and 4, got "${value}".`);
+  }
+  return parsed;
+}
 
 export function optionSettings(options: Record<string, string | true>): Record<string, unknown> {
   const settings: Record<string, unknown> = {};

--- a/src/cli/pane-functions/screenshot.ts
+++ b/src/cli/pane-functions/screenshot.ts
@@ -6,6 +6,8 @@ import type { OptionsChain, PricePoint, TickerFinancials } from "../../types/fin
 import type { TickerRecord } from "../../types/ticker";
 import { slugifyName } from "../../utils/slugify";
 import { getTheme, getThemeIds } from "../../theme/themes";
+
+const DEFAULT_SHOT_DEVICE_SCALE_FACTOR = 2;
 import {
   renderDesktopPaneScreenshot,
   type DesktopPaneShotPayload,
@@ -283,13 +285,19 @@ async function buildDesktopShotPayload(
   widthPx: number,
   heightPx: number,
   theme: string | null,
+  scale: number,
+  watermark: string | null,
 ): Promise<DesktopPaneShotPayload> {
-  // Snap the viewport to whole cells. Rounding up used to make the pane a few
-  // pixels taller than the capture, which clipped the bottom axis of charts.
-  const widthCells = Math.max(1, Math.floor(widthPx / DESKTOP_CELL_WIDTH_PX));
-  const heightCells = Math.max(1, Math.floor(heightPx / DESKTOP_CELL_HEIGHT_PX));
+  // The requested size is the output size. Scale shrinks the CSS viewport and
+  // raises the device scale factor by the same factor, so a 1200px wide shot at
+  // scale 1.5 lays out 100 cells instead of 150 and every glyph is 1.5x larger.
+  // Snap to whole cells: rounding up used to make the pane a few pixels taller
+  // than the capture, which clipped the bottom axis of charts.
+  const widthCells = Math.max(1, Math.floor(widthPx / scale / DESKTOP_CELL_WIDTH_PX));
+  const heightCells = Math.max(1, Math.floor(heightPx / scale / DESKTOP_CELL_HEIGHT_PX));
   widthPx = widthCells * DESKTOP_CELL_WIDTH_PX;
   heightPx = heightCells * DESKTOP_CELL_HEIGHT_PX;
+  const deviceScaleFactor = DEFAULT_SHOT_DEVICE_SCALE_FACTOR * scale;
   const initialPaneState = optionPaneState(resolved.options);
   const pluginState = capabilityPluginState(resolved.capability, resolved.options);
   if (Object.keys(pluginState).length > 0) {
@@ -379,6 +387,8 @@ async function buildDesktopShotPayload(
     heightCells,
     widthPx,
     heightPx,
+    deviceScaleFactor,
+    watermark,
     tickers,
     financials,
     optionsChains,
@@ -430,6 +440,8 @@ export async function renderDesktopShot({
   width,
   height,
   theme,
+  scale,
+  watermark,
   options,
 }: {
   resolved: ResolvedPaneFunction;
@@ -439,10 +451,22 @@ export async function renderDesktopShot({
   width: number;
   height: number;
   theme?: string | null;
+  scale?: number;
+  watermark?: string | null;
   options: Record<string, string | true>;
 }): Promise<PaneScreenshotResult> {
   await mkdir(dirname(outputPath), { recursive: true });
-  const payload = await buildDesktopShotPayload(resolved, context, rawArg, options, width, height, theme ?? null);
+  const payload = await buildDesktopShotPayload(
+    resolved,
+    context,
+    rawArg,
+    options,
+    width,
+    height,
+    theme ?? null,
+    scale ?? 1,
+    watermark ?? null,
+  );
   const render = await renderDesktopPaneScreenshot(payload, outputPath);
   const symbols = payload.financials.map(([symbol]) => symbol);
   const rowCount = shotSemanticRowCount(resolved, payload, render.semanticUi);

--- a/src/cli/pane-functions/screenshot.ts
+++ b/src/cli/pane-functions/screenshot.ts
@@ -5,6 +5,7 @@ import { CHART_COMPOSER_PANE_ID } from "../../types/config";
 import type { OptionsChain, PricePoint, TickerFinancials } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
 import { slugifyName } from "../../utils/slugify";
+import { getTheme, getThemeIds } from "../../theme/themes";
 import {
   renderDesktopPaneScreenshot,
   type DesktopPaneShotPayload,
@@ -281,9 +282,14 @@ async function buildDesktopShotPayload(
   options: Record<string, string | true>,
   widthPx: number,
   heightPx: number,
+  theme: string | null,
 ): Promise<DesktopPaneShotPayload> {
-  const widthCells = Math.max(1, Math.round(widthPx / DESKTOP_CELL_WIDTH_PX));
-  const heightCells = Math.max(1, Math.round(heightPx / DESKTOP_CELL_HEIGHT_PX));
+  // Snap the viewport to whole cells. Rounding up used to make the pane a few
+  // pixels taller than the capture, which clipped the bottom axis of charts.
+  const widthCells = Math.max(1, Math.floor(widthPx / DESKTOP_CELL_WIDTH_PX));
+  const heightCells = Math.max(1, Math.floor(heightPx / DESKTOP_CELL_HEIGHT_PX));
+  widthPx = widthCells * DESKTOP_CELL_WIDTH_PX;
+  heightPx = heightCells * DESKTOP_CELL_HEIGHT_PX;
   const initialPaneState = optionPaneState(resolved.options);
   const pluginState = capabilityPluginState(resolved.capability, resolved.options);
   if (Object.keys(pluginState).length > 0) {
@@ -313,6 +319,7 @@ async function buildDesktopShotPayload(
   };
   const config = {
     ...context.config,
+    ...(theme ? { theme: resolveShotTheme(theme) } : {}),
     layout,
     layouts: [{
       name: "CLI Shot",
@@ -383,6 +390,17 @@ async function buildDesktopShotPayload(
   };
 }
 
+function resolveShotTheme(requested: string): string {
+  const normalized = requested.trim().toLowerCase().replace(/[\s_]+/g, "-");
+  const ids = getThemeIds();
+  const match = ids.find((id) => id.toLowerCase() === normalized)
+    ?? ids.find((id) => getTheme(id).name.toLowerCase().replace(/[\s_]+/g, "-") === normalized);
+  if (!match) {
+    throw new Error(`Unknown theme "${requested}". Available themes: ${ids.join(", ")}`);
+  }
+  return match;
+}
+
 export function shotPriceHistoryRange(resolved: ResolvedPaneFunction): TimeRange | null {
   switch (resolved.capability.id) {
     case "chart-composer":
@@ -411,6 +429,7 @@ export async function renderDesktopShot({
   outputPath,
   width,
   height,
+  theme,
   options,
 }: {
   resolved: ResolvedPaneFunction;
@@ -419,10 +438,11 @@ export async function renderDesktopShot({
   outputPath: string;
   width: number;
   height: number;
+  theme?: string | null;
   options: Record<string, string | true>;
 }): Promise<PaneScreenshotResult> {
   await mkdir(dirname(outputPath), { recursive: true });
-  const payload = await buildDesktopShotPayload(resolved, context, rawArg, options, width, height);
+  const payload = await buildDesktopShotPayload(resolved, context, rawArg, options, width, height, theme ?? null);
   const render = await renderDesktopPaneScreenshot(payload, outputPath);
   const symbols = payload.financials.map(([symbol]) => symbol);
   const rowCount = shotSemanticRowCount(resolved, payload, render.semanticUi);


### PR DESCRIPTION
## Why

Social/bot screenshots inherited whatever theme the local config had (here `github-light`), the capture viewport rounded up to a cell count taller than the image (clipping the bottom axis), the 12px grid was too small to read on a phone, and drawing tools, the add-series input and the close button showed up in every image.

## What

- `--theme <id>` overrides the theme for one render. Unknown ids fail with the list of available themes.
- `--scale <n>` (0.5 to 4) lays out fewer cells at a higher device scale factor. Output pixel size is unchanged, glyphs are n times larger and still crisp.
- `--watermark <text>` draws a dim label at the right of the title bar where the close button was.
- Viewport snaps to whole 8x18 cells so the pane always fits the capture.
- Shot mode hides `composite-chart-toolbar`, `chart-series-quick-add` and `pane-close` via injected CSS.

## Verify

```
gloomberb shot CMP AVGO,NVDA,MRVL --rangePreset 3M --theme tokyo --width 1200 --height 675 --scale 1.5 --watermark gloom.sh --output /tmp/cmp.png
gloomberb shot FA AVGO --theme tokyo --width 1200 --height 675 --scale 1.5 --watermark gloom.sh --output /tmp/fa.png
```

Note for callers: the comparison chart rebases on the first visible bar, so a different cell count can shift the base day and the legend percentages. Anything that writes copy from a render must read `render.visibleText`, not the manifest's `returnPercent`.

Tests: `bun test src/cli/pane-functions` passes (28 tests). `theme`, `scale` and `watermark` are reserved keys and never enter pane options, so gloombot manifest validation is unaffected.