### PR TITLE
Wrap and scroll the earnings call transcript reader

### DIFF
--- a/src/plugins/builtin/earnings-calls/pane.tsx
+++ b/src/plugins/builtin/earnings-calls/pane.tsx
@@ -11,10 +11,11 @@ import {
   type DataTableRootKeyContext,
   type PaneFooterSegment,
 } from "../../../components";
+import { useShortcut } from "../../../react/input";
 import { CloudAuthNotice } from "../cloud/auth-actions";
 import { useCloudPlanAction, useCloudUpgradeAction } from "../shared/cloud-upgrade";
 import { colors } from "../../../theme/colors";
-import { Box, Text, type InputRenderable } from "../../../ui";
+import { Box, Text, type InputRenderable, type ScrollBoxRenderable } from "../../../ui";
 import { isPlainKey } from "../../../utils/keyboard";
 import { isPlainArrowUp, stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
 import { useBoundTicker as useSymbolBinding } from "../shared/ticker-request";
@@ -148,6 +149,7 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
   const [searchFocused, setSearchFocused] = useState(false);
   const [searchFocusToken, setSearchFocusToken] = useState(0);
   const searchInputRef = useRef<InputRenderable | null>(null);
+  const transcriptScrollRef = useRef<ScrollBoxRenderable | null>(null);
 
   const focusSearch = useCallback(() => {
     setSearchFocused(true);
@@ -243,6 +245,19 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
     };
   }, [detailOpen, selected]);
 
+  const scrollTranscriptBy = useCallback((delta: number) => {
+    const scrollBox = transcriptScrollRef.current;
+    if (!scrollBox?.viewport) return;
+    const maxScrollTop = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height);
+    scrollBox.scrollTop = Math.max(0, Math.min(maxScrollTop, scrollBox.scrollTop + delta));
+  }, []);
+
+  // A new call or a narrowed transcript should start at the top.
+  useEffect(() => {
+    const scrollBox = transcriptScrollRef.current;
+    if (scrollBox) scrollBox.scrollTop = 0;
+  }, [selectedId, detailOpen, qaOnly, searchQuery]);
+
   const signInRequired = !access.signedIn || listError?.status === 401;
   const verificationRequired =
     !signInRequired && (!access.emailVerified || listError?.status === 403);
@@ -277,21 +292,47 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
     [fetchCalls, focusSearch],
   );
 
+  // `q` is the app's quit key, handled ahead of pane handlers. The reader
+  // claims it first while it is open, the same way other panes take keys
+  // that clash with global ones.
+  useShortcut(
+    (event) => {
+      if (!isPlainKey(event, "q")) return;
+      stopSearchFocusNavigation(event);
+      setQaOnly((current) => !current);
+    },
+    {
+      enabled: focused && detailOpen && !searchFocused,
+      phase: "before",
+      scope: "earnings-calls:reader",
+    },
+  );
+
   const handleDetailKey = useCallback(
     (event: DataTableKeyEvent) => {
-      if (isPlainKey(event, "q")) {
-        stopSearchFocusNavigation(event);
-        setQaOnly((current) => !current);
-        return true;
-      }
       if (isPlainKey(event, "/")) {
         stopSearchFocusNavigation(event);
         focusSearch();
         return true;
       }
+      if (isPlainKey(event, "j", "down")) {
+        stopSearchFocusNavigation(event);
+        scrollTranscriptBy(1);
+        return true;
+      }
+      if (isPlainArrowUp(event) || isPlainKey(event, "k")) {
+        stopSearchFocusNavigation(event);
+        // Like the list: pressing up at the top moves into the search field.
+        if ((transcriptScrollRef.current?.scrollTop ?? 0) <= 0 && isPlainArrowUp(event)) {
+          focusSearch();
+          return true;
+        }
+        scrollTranscriptBy(-1);
+        return true;
+      }
       return false;
     },
-    [focusSearch],
+    [focusSearch, scrollTranscriptBy],
   );
 
   usePaneFooter(
@@ -420,7 +461,7 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
   ) : (
     // The reader gets its own search bar: a transcript runs to thousands of
     // words, so finding a topic matters as much as filtering the call list.
-    <Box flexDirection="column" flexGrow={1}>
+    <Box flexDirection="column" flexGrow={1} flexShrink={1} flexBasis={0} minHeight={0} overflow="hidden">
       <InputSearchBar
         value={searchQuery}
         focused={focused && detailOpen}
@@ -442,6 +483,7 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
         qaOnly={qaOnly}
         query={searchQuery}
         width={width}
+        scrollRef={transcriptScrollRef}
       />
     </Box>
   );

--- a/src/plugins/builtin/earnings-calls/transcript-view.tsx
+++ b/src/plugins/builtin/earnings-calls/transcript-view.tsx
@@ -1,7 +1,15 @@
-import { useMemo } from "react";
+import { useMemo, type RefObject } from "react";
 import { Spinner } from "../../../components";
 import { colors } from "../../../theme/colors";
-import { Box, ScrollBox, Text, TextAttributes } from "../../../ui";
+import {
+  Box,
+  ScrollBox,
+  Text,
+  TextAttributes,
+  useUiCapabilities,
+  type ScrollBoxRenderable,
+} from "../../../ui";
+import { wrapTextLines } from "../../../utils/text-wrap";
 import type {
   CloudEarningsTranscriptPayload,
   CloudTranscriptTurnPayload,
@@ -14,14 +22,67 @@ function speakerColor(turn: CloudTranscriptTurnPayload): string {
   return colors.textBright;
 }
 
-function Section({ title, body }: { title: string; body: string }) {
+/** Role and firm after the name; "Operator" is not repeated as its own role. */
+function turnDetail(turn: CloudTranscriptTurnPayload): string {
+  const role = turn.role && turn.role !== turn.speaker ? turn.role : null;
+  return [role, turn.company].filter(Boolean).join(", ");
+}
+
+const NATIVE_STRETCH_STYLE = { minWidth: 0 };
+const NATIVE_TEXT_STYLE = { display: "block" };
+
+/**
+ * The terminal renderer does not wrap text on its own, so long paragraphs are
+ * pre-wrapped into one fixed-height row per line. Desktop chrome wraps natively.
+ */
+function TextLines({
+  text,
+  width,
+  color,
+  attributes,
+  nativePaneChrome,
+}: {
+  text: string | undefined;
+  width: number;
+  color: string;
+  attributes?: number;
+  nativePaneChrome: boolean;
+}) {
+  if (!text?.trim()) return null;
+  if (nativePaneChrome) {
+    return (
+      <Text fg={color} attributes={attributes} wrapText width="100%" style={NATIVE_TEXT_STYLE}>
+        {text}
+      </Text>
+    );
+  }
+  return wrapTextLines(text, width).map((line, index) => (
+    <Box key={index} height={1}>
+      <Text fg={color} attributes={attributes}>{line}</Text>
+    </Box>
+  ));
+}
+
+function Section({
+  title,
+  body,
+  width,
+  nativePaneChrome,
+}: {
+  title: string;
+  body: string;
+  width: number;
+  nativePaneChrome: boolean;
+}) {
   if (!body.trim()) return null;
   return (
     <Box flexDirection="column" marginTop={1}>
-      <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
-        {title}
-      </Text>
-      <Text fg={colors.text}>{body}</Text>
+      <Box height={1}>
+        <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
+          {title}
+        </Text>
+      </Box>
+      <TextLines text={body} width={width} color={colors.text} nativePaneChrome={nativePaneChrome} />
     </Box>
   );
 }
@@ -33,6 +94,7 @@ export function TranscriptView({
   qaOnly,
   query,
   width,
+  scrollRef,
 }: {
   transcript: CloudEarningsTranscriptPayload | null;
   loading: boolean;
@@ -41,7 +103,12 @@ export function TranscriptView({
   /** Free-text filter applied to the turns, for finding a topic in a long call. */
   query?: string;
   width: number;
+  /** Lets the owning pane drive keyboard scrolling. */
+  scrollRef?: RefObject<ScrollBoxRenderable | null>;
 }) {
+  const { nativePaneChrome } = useUiCapabilities();
+  const isNative = nativePaneChrome === true;
+
   const turns = useMemo(() => {
     const all = transcript?.turns ?? [];
     const scoped = qaOnly ? all.filter((turn) => turn.isQa) : all;
@@ -80,65 +147,93 @@ export function TranscriptView({
     .filter(Boolean)
     .join("  ·  ");
 
-  const bodyWidth = Math.max(20, width - 2);
+  // One column of padding each side inside the scroll box.
+  const bodyWidth = Math.max(12, width - 2);
+  const contentWidth = isNative ? "100%" : bodyWidth;
+  const contentStyle = isNative ? NATIVE_STRETCH_STYLE : undefined;
 
   return (
-    <ScrollBox scrollY flexGrow={1} paddingX={1}>
-      <Box flexDirection="column" width={bodyWidth}>
-        <Text fg={colors.textDim}>{meta}</Text>
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      flexShrink={1}
+      flexBasis={0}
+      minHeight={0}
+      overflow="hidden"
+    >
+      <ScrollBox
+        ref={scrollRef}
+        flexGrow={1}
+        flexShrink={1}
+        flexBasis={0}
+        minHeight={0}
+        scrollY
+        focusable={false}
+        paddingX={1}
+      >
+        <Box flexDirection="column" width={contentWidth} style={contentStyle}>
+          <TextLines text={meta} width={bodyWidth} color={colors.textDim} nativePaneChrome={isNative} />
 
-        <Section title="SUMMARY" body={transcript.summary ?? ""} />
-        <Section title="WHAT STOOD OUT" body={transcript.notable ?? ""} />
-        <Section title="ANALYSTS PRESSED ON" body={transcript.analystFocus ?? ""} />
-        <Section title="GUIDANCE" body={transcript.guidance ?? ""} />
-        <Section title="RISKS" body={transcript.riskFactors ?? ""} />
+          <Section title="SUMMARY" body={transcript.summary ?? ""} width={bodyWidth} nativePaneChrome={isNative} />
+          <Section title="WHAT STOOD OUT" body={transcript.notable ?? ""} width={bodyWidth} nativePaneChrome={isNative} />
+          <Section title="ANALYSTS PRESSED ON" body={transcript.analystFocus ?? ""} width={bodyWidth} nativePaneChrome={isNative} />
+          <Section title="GUIDANCE" body={transcript.guidance ?? ""} width={bodyWidth} nativePaneChrome={isNative} />
+          <Section title="RISKS" body={transcript.riskFactors ?? ""} width={bodyWidth} nativePaneChrome={isNative} />
 
-        {transcript.participants.length > 0 && (
-          <Box flexDirection="column" marginTop={1}>
-            <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
-              PARTICIPANTS
-            </Text>
-            {transcript.participants.map((participant) => (
-              <Text key={participant.name} fg={colors.text}>
-                {[participant.name, participant.role, participant.company]
-                  .filter(Boolean)
-                  .join("  ·  ")}
-              </Text>
-            ))}
-          </Box>
-        )}
-
-        <Box flexDirection="column" marginTop={1}>
-          <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
-            {qaOnly ? "QUESTION AND ANSWER" : "TRANSCRIPT"}
-          </Text>
-        </Box>
-
-        {turns.map((turn, index) => (
-          <Box key={`${turn.startSeconds}-${index}`} flexDirection="column" marginTop={1}>
-            <Box flexDirection="row" gap={1}>
-              <Text fg={colors.textDim}>{formatTimestamp(turn.startSeconds)}</Text>
-              <Text fg={speakerColor(turn)} attributes={TextAttributes.BOLD}>
-                {turn.speaker}
-              </Text>
-              {(turn.role || turn.company) && (
-                <Text fg={colors.textDim}>
-                  {[turn.role, turn.company].filter(Boolean).join(", ")}
+          {transcript.participants.length > 0 && (
+            <Box flexDirection="column" marginTop={1}>
+              <Box height={1}>
+                <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
+                  PARTICIPANTS
                 </Text>
-              )}
+              </Box>
+              {transcript.participants.map((participant) => (
+                <TextLines
+                  key={participant.name}
+                  text={[participant.name, participant.role, participant.company]
+                    .filter(Boolean)
+                    .join("  ·  ")}
+                  width={bodyWidth}
+                  color={colors.text}
+                  nativePaneChrome={isNative}
+                />
+              ))}
             </Box>
-            <Text fg={colors.text}>{turn.text}</Text>
-          </Box>
-        ))}
+          )}
 
-        {turns.length === 0 && (
-          <Text fg={colors.textDim}>
-            {query?.trim()
-              ? `Nothing matching "${query.trim()}" in this call.`
-              : "No question and answer section in this call."}
-          </Text>
-        )}
-      </Box>
-    </ScrollBox>
+          <Box height={1} marginTop={1}>
+            <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
+              {qaOnly ? "QUESTION AND ANSWER" : "TRANSCRIPT"}
+            </Text>
+          </Box>
+
+          {turns.map((turn, index) => (
+            <Box key={`${turn.startSeconds}-${index}`} flexDirection="column" marginTop={1}>
+              <Box height={1} flexDirection="row" gap={1} overflow="hidden">
+                <Text fg={colors.textDim}>{formatTimestamp(turn.startSeconds)}</Text>
+                <Text fg={speakerColor(turn)} attributes={TextAttributes.BOLD}>
+                  {turn.speaker}
+                </Text>
+                {turnDetail(turn) && <Text fg={colors.textDim}>{turnDetail(turn)}</Text>}
+              </Box>
+              <TextLines text={turn.text} width={bodyWidth} color={colors.text} nativePaneChrome={isNative} />
+            </Box>
+          ))}
+
+          {turns.length === 0 && (
+            <TextLines
+              text={
+                query?.trim()
+                  ? `Nothing matching "${query.trim()}" in this call.`
+                  : "No question and answer section in this call."
+              }
+              width={bodyWidth}
+              color={colors.textDim}
+              nativePaneChrome={isNative}
+            />
+          )}
+        </Box>
+      </ScrollBox>
+    </Box>
   );
 }


### PR DESCRIPTION
## Problems

- Transcript text ran off the right edge: `<Text>` does not wrap in the terminal renderer.
- Arrows / j/k / PageUp / PageDown did nothing in the reader. The `ScrollBox` had no `flexBasis`/`minHeight`, so it grew to fit the whole call and never had anything to scroll.
- Pressing `q` in the reader (the advertised `[q]&A only` hint) quit the app: the global quit key runs in the `before` phase ahead of the pane's detail handler.

## Changes

`transcript-view.tsx`
- Pre-wraps every paragraph with `wrapTextLines` into fixed-height rows (terminal) or `wrapText` (desktop chrome), the same pattern as the news reader.
- Scroll box is now `flexGrow flexBasis={0} minHeight={0}` inside an `overflow="hidden"` column, so the shared pane scroll controller (PageUp/PageDown/Home/End) also works.
- Accepts a `scrollRef` so the pane can drive keyboard scrolling.
- Turn header no longer prints "Operator Operator" when the role repeats the name.

`pane.tsx`
- j/k and arrows scroll the reader one line, matching the other detail readers. Up at the top moves focus into the find field, mirroring the list.
- Scroll resets to top when the call, Q&A filter, or query changes.
- `q` is claimed with a scoped `before`-phase `useShortcut` while the reader is open and the find field is not focused, so it toggles Q&A instead of quitting.

Tested in tmux at 120x40: wrapping, arrows, j/k, Home/End/PageDown, up-to-search, `q` toggle, and the warning scan is clean.

Backend side (discovery coverage and speaker attribution) is in gloomberb-platform#157.
