### PR TITLE
Look up any company from the earnings shelf and produce calls on request

### DIFF
--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -504,6 +504,10 @@ export interface CloudEarningsCallPayload {
 
 export interface CloudEarningsCallListPayload {
   calls: CloudEarningsCallPayload[];
+  /** Set when asking about a company started a search that is still running. */
+  pending?: boolean;
+  /** Set when the requested symbol is not one the SEC knows. */
+  unknownTicker?: boolean;
 }
 
 export interface CloudTranscriptTurnPayload {

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -500,6 +500,8 @@ export interface CloudEarningsCallPayload {
   wordCount: number | null;
   hasTranscript: boolean;
   sentiment: number | null;
+  /** The replay or event page the transcript came from. */
+  webcastUrl?: string | null;
 }
 
 export interface CloudEarningsCallListPayload {

--- a/src/plugins/builtin/earnings-calls/data.ts
+++ b/src/plugins/builtin/earnings-calls/data.ts
@@ -33,6 +33,32 @@ export interface EarningsCallsResult {
   refreshError?: string;
   /** HTTP status when the request failed, used to pick the right gate. */
   errorStatus?: number;
+  /** The server has just started looking for this company's calls. */
+  pending?: boolean;
+  /** The symbol is not one the SEC knows, so there is nothing to look for. */
+  unknownTicker?: boolean;
+}
+
+/** A call that has been found but whose transcript is not produced yet. */
+export function isShelved(call: CloudEarningsCallPayload): boolean {
+  return !call.hasTranscript;
+}
+
+/** Short label for the state of a call without a transcript. */
+export function callStatusLabel(call: CloudEarningsCallPayload): string {
+  switch (call.status) {
+    case "available":
+      return "on request";
+    case "capturing":
+    case "transcribing":
+    case "enriching":
+      return "in progress";
+    case "discovered":
+    case "failed":
+      return "queued";
+    default:
+      return "";
+  }
 }
 
 let persistence: PluginPersistence | null = null;
@@ -82,12 +108,23 @@ export async function loadEarningsCalls(
     })
     .then((payload) => {
       const calls = payload.calls ?? [];
-      persistence?.setResource(LIST_KIND, key, calls, {
-        sourceKey: CACHE_SOURCE,
-        schemaVersion: CACHE_SCHEMA_VERSION,
-        cachePolicy: LIST_CACHE_POLICY,
-      });
-      return { calls, fetchedAt: Date.now(), stale: false };
+      // A list with calls still being produced changes by the minute, so it
+      // is not worth keeping; a list of finished transcripts is.
+      const settled = calls.every((call) => call.hasTranscript);
+      if (settled) {
+        persistence?.setResource(LIST_KIND, key, calls, {
+          sourceKey: CACHE_SOURCE,
+          schemaVersion: CACHE_SCHEMA_VERSION,
+          cachePolicy: LIST_CACHE_POLICY,
+        });
+      }
+      return {
+        calls,
+        fetchedAt: Date.now(),
+        stale: false,
+        pending: payload.pending === true,
+        unknownTicker: payload.unknownTicker === true,
+      };
     })
     .catch((error: unknown) => {
       const refreshError = error instanceof Error ? error.message : String(error);

--- a/src/plugins/builtin/earnings-calls/pane.tsx
+++ b/src/plugins/builtin/earnings-calls/pane.tsx
@@ -24,7 +24,13 @@ import type {
   CloudEarningsCallPayload,
   CloudEarningsTranscriptPayload,
 } from "../../../api-client";
-import { isPendingTranscript, loadEarningsCalls, loadTranscript, statusOf } from "./data";
+import {
+  callStatusLabel,
+  isPendingTranscript,
+  loadEarningsCalls,
+  loadTranscript,
+  statusOf,
+} from "./data";
 import { callTitle, formatCallDate, formatDuration, formatPeriod, formatSentiment } from "./format";
 import { TranscriptView } from "./transcript-view";
 
@@ -42,7 +48,8 @@ function buildColumns(width: number, showTicker: boolean): CallColumn[] {
   const dateWidth = 10;
   const periodWidth = 8;
   const lengthWidth = 7;
-  const sentimentWidth = 6;
+  // Wide enough for a state such as "in progress" on calls not yet produced.
+  const sentimentWidth = 11;
   const companyWidth = Math.max(
     10,
     width - tickerWidth - dateWidth - periodWidth - lengthWidth - sentimentWidth - 8,
@@ -73,6 +80,7 @@ function renderCell(call: CloudEarningsCallPayload, column: CallColumn): DataTab
     case "length":
       return { text: formatDuration(call.durationSeconds), color: colors.textDim };
     case "sentiment": {
+      if (!call.hasTranscript) return { text: callStatusLabel(call), color: colors.textDim };
       const tone =
         call.sentiment === null
           ? colors.textDim
@@ -96,6 +104,21 @@ interface CallSort {
 }
 
 const DEFAULT_SORT: CallSort = { columnId: "date", direction: "desc" };
+
+/** "AVGO", "BRK-B", "brk.b": something worth asking the server about. */
+const TICKER_PATTERN = /^[A-Z]{1,5}(?:[.-][A-Z]{1,2})?$/;
+
+/** How often to ask again while a transcript is being produced. */
+const PRODUCE_POLL_MS = 15_000;
+/** How often to ask again while the server is still finding a company's calls. */
+const LOOKUP_POLL_MS = 20_000;
+
+interface TickerLookup {
+  ticker: string;
+  /** "none": a real company, but no reachable call. "unknown": not a listed symbol. */
+  status: "found" | "pending" | "none" | "unknown" | "error";
+  calls: CloudEarningsCallPayload[];
+}
 
 function sortValue(call: CloudEarningsCallPayload, columnId: string): string | number {
   switch (columnId) {
@@ -151,6 +174,13 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
   const searchInputRef = useRef<InputRenderable | null>(null);
   const transcriptScrollRef = useRef<ScrollBoxRenderable | null>(null);
 
+  // Typing a symbol the shelf does not have asks the server for that company.
+  const [lookup, setLookup] = useState<TickerLookup | null>(null);
+  // Set while a call opened without a transcript is being produced.
+  const [producing, setProducing] = useState(false);
+  // The list answered "pending": the server is still searching for calls.
+  const [listPending, setListPending] = useState(false);
+
   const focusSearch = useCallback(() => {
     setSearchFocused(true);
     setSearchFocusToken((current) => current + 1);
@@ -167,6 +197,7 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
         .then((result) => {
           setCalls(result.calls);
           setStale(result.stale);
+          setListPending(result.pending === true && result.calls.length === 0);
           setListError(
             result.refreshError ? { message: result.refreshError, status: result.errorStatus } : null,
           );
@@ -187,10 +218,74 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
     fetchCalls(false);
   }, [fetchCalls]);
 
+  // A research tab whose company is still being searched checks back until
+  // the calls appear.
+  useEffect(() => {
+    if (!listPending) return;
+    const timer = setTimeout(() => fetchCalls(true), LOOKUP_POLL_MS);
+    return () => clearTimeout(timer);
+  }, [listPending, fetchCalls, calls.length]);
+
+  // On the shelf, a query that looks like a symbol we do not have becomes a
+  // request for that company's calls.
+  const lookupTicker = useMemo(() => {
+    if (ticker || detailOpen) return null;
+    const candidate = searchQuery.trim().toUpperCase();
+    if (!TICKER_PATTERN.test(candidate)) return null;
+    if (calls.some((call) => call.ticker === candidate)) return null;
+    return candidate;
+  }, [ticker, detailOpen, searchQuery, calls]);
+
+  // Answered for the current query, or still waiting on the server.
+  const lookupState: TickerLookup["status"] | "loading" | null = !lookupTicker
+    ? null
+    : lookup?.ticker === lookupTicker
+      ? lookup.status
+      : "loading";
+
+  useEffect(() => {
+    if (!lookupTicker) return;
+    const answered = lookup?.ticker === lookupTicker;
+    if (answered && lookup.status !== "pending") return;
+    let cancelled = false;
+    // Debounce typing; while the server is still searching, check back slowly.
+    const delay = answered ? LOOKUP_POLL_MS : 500;
+    const timer = setTimeout(() => {
+      loadEarningsCalls(lookupTicker, { force: true })
+        .then((result) => {
+          if (cancelled) return;
+          setLookup({
+            ticker: lookupTicker,
+            status: result.unknownTicker
+              ? "unknown"
+              : result.calls.length > 0
+                ? "found"
+                : result.pending
+                  ? "pending"
+                  : "none",
+            calls: result.calls,
+          });
+        })
+        .catch(() => {
+          if (!cancelled) setLookup({ ticker: lookupTicker, status: "error", calls: [] });
+        });
+    }, delay);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [lookupTicker, lookup]);
+
+  const allCalls = useMemo(() => {
+    if (!lookup || lookup.calls.length === 0) return calls;
+    const known = new Set(calls.map((call) => call.id));
+    return [...calls, ...lookup.calls.filter((call) => !known.has(call.id))];
+  }, [calls, lookup]);
+
   const rows = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
     const matched = query
-      ? calls.filter((call) =>
+      ? allCalls.filter((call) =>
           [
             call.ticker,
             call.companyName ?? "",
@@ -201,7 +296,7 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
             .toLowerCase()
             .includes(query),
         )
-      : calls;
+      : allCalls;
     const sorted = [...matched].sort((a, b) => {
       const left = sortValue(a, sort.columnId);
       const right = sortValue(b, sort.columnId);
@@ -210,40 +305,75 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
       return sort.direction === "asc" ? order : -order;
     });
     return sorted;
-  }, [calls, sort, searchQuery]);
+  }, [allCalls, sort, searchQuery]);
 
   const selected = useMemo(
-    () => calls.find((call) => call.id === selectedId) ?? null,
-    [calls, selectedId],
+    () => allCalls.find((call) => call.id === selectedId) ?? null,
+    [allCalls, selectedId],
   );
+  const selectedCallId = selected?.id ?? null;
+  const selectedHasTranscript = selected?.hasTranscript ?? false;
 
-  // Transcripts are immutable, so this only runs once per call per device.
+  // Marks a call as transcribed in whichever list holds it, once it is.
+  const markTranscribed = useCallback((callId: string) => {
+    const update = (list: CloudEarningsCallPayload[]) =>
+      list.map((call) =>
+        call.id === callId ? { ...call, hasTranscript: true, status: "published" } : call,
+      );
+    setCalls(update);
+    setLookup((current) => (current ? { ...current, calls: update(current.calls) } : current));
+  }, []);
+
+  // A published transcript is immutable, so it loads once per call. Opening
+  // a call that has none asks the server to produce it, then checks back
+  // until it arrives.
   useEffect(() => {
-    if (!detailOpen || !selected?.hasTranscript) return;
+    if (!detailOpen || !selectedCallId) return;
     let cancelled = false;
-    setTranscriptLoading(true);
+    let timer: ReturnType<typeof setTimeout> | null = null;
     setTranscriptError(null);
-    loadTranscript(selected.id)
-      .then((result) => {
-        if (cancelled) return;
-        // A queued-on-demand call comes back as a pending marker, not content.
-        setTranscript(isPendingTranscript(result) ? null : result);
-      })
-      .catch((error: unknown) => {
-        if (cancelled) return;
-        setTranscript(null);
-        setTranscriptError({
-          message: error instanceof Error ? error.message : String(error),
-          status: statusOf(error),
+
+    const attempt = (force: boolean) => {
+      setTranscriptLoading(true);
+      loadTranscript(selectedCallId, { force })
+        .then((result) => {
+          if (cancelled) return;
+          if (isPendingTranscript(result)) {
+            setTranscript(null);
+            setProducing(true);
+            timer = setTimeout(() => attempt(true), PRODUCE_POLL_MS);
+            return;
+          }
+          setTranscript(result);
+          setProducing(false);
+          if (!selectedHasTranscript) {
+            markTranscribed(selectedCallId);
+            fetchCalls(true);
+          }
+        })
+        .catch((error: unknown) => {
+          if (cancelled) return;
+          setTranscript(null);
+          setProducing(false);
+          setTranscriptError({
+            message: error instanceof Error ? error.message : String(error),
+            status: statusOf(error),
+          });
+        })
+        .finally(() => {
+          if (!cancelled) setTranscriptLoading(false);
         });
-      })
-      .finally(() => {
-        if (!cancelled) setTranscriptLoading(false);
-      });
+    };
+    attempt(!selectedHasTranscript);
+
     return () => {
       cancelled = true;
+      if (timer) clearTimeout(timer);
+      setProducing(false);
     };
-  }, [detailOpen, selected]);
+    // The call's identity is what matters; list refreshes must not restart this.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detailOpen, selectedCallId]);
 
   const scrollTranscriptBy = useCallback((delta: number) => {
     const scrollBox = transcriptScrollRef.current;
@@ -342,8 +472,22 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
       if (listStatus === "loading") {
         info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
       }
-      if (transcriptLoading) {
+      if (producing) {
+        info.push({ id: "producing", parts: [{ text: "producing transcript", tone: "muted" }] });
+      } else if (transcriptLoading) {
         info.push({ id: "transcribing", parts: [{ text: "loading transcript", tone: "muted" }] });
+      }
+      if (listPending) {
+        info.push({ id: "searching", parts: [{ text: "searching for calls", tone: "muted" }] });
+      }
+      if (lookupTicker && lookupState) {
+        if (lookupState === "loading" || lookupState === "pending") {
+          info.push({ id: "lookup", parts: [{ text: `looking up ${lookupTicker}`, tone: "muted" }] });
+        } else if (lookupState === "unknown" || lookupState === "none") {
+          info.push({ id: "lookup", parts: [{ text: `${lookupTicker} not found`, tone: "warning" }] });
+        } else if (lookupState === "error") {
+          info.push({ id: "lookup", parts: [{ text: `${lookupTicker} lookup failed`, tone: "warning" }] });
+        }
       }
       if (stale) {
         info.push({ id: "stale", parts: [{ text: "stale cache", tone: "warning" }] });
@@ -376,6 +520,10 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
     [
       listStatus,
       transcriptLoading,
+      producing,
+      listPending,
+      lookupState,
+      lookupTicker,
       stale,
       listError,
       proRequired,
@@ -431,11 +579,17 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
     );
   }
 
-  if (calls.length === 0) {
-    return (
+  // A research tab with nothing yet: either the server is still searching
+  // for the company, or it has nothing to search for.
+  if (ticker && calls.length === 0) {
+    return listPending ? (
+      <Box flexGrow={1} alignItems="center" justifyContent="center">
+        <Spinner label={`Looking for ${ticker}'s earnings calls...`} />
+      </Box>
+    ) : (
       <EmptyState
-        title={ticker ? `No transcribed calls for ${ticker} yet.` : "No transcribed calls yet."}
-        message="Transcripts are published a few hours after each call."
+        title={`No earnings calls found for ${ticker}.`}
+        message="Calls appear here once the company's investor site or filings list a webcast."
       />
     );
   }
@@ -451,14 +605,19 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
         <Button label="Manage account" variant="secondary" onPress={openPlan} />
       </Box>
     </Box>
-  ) : selected && !selected.hasTranscript ? (
-    <Box flexGrow={1} paddingX={1}>
-      <Text fg={colors.textDim}>
-        Queued for transcription. This call is being captured now; it usually
-        takes a couple of minutes.
-      </Text>
+  ) : selected && !transcript && (producing || (!selected.hasTranscript && !transcriptError)) ? (
+    <Box flexDirection="column" flexGrow={1} paddingX={1} gap={1}>
+      <Box height={1}>
+        <Text fg={colors.textDim}>
+          {[formatCallDate(selected.callAt), formatPeriod(selected.fiscalYear, selected.fiscalQuarter)]
+            .filter(Boolean)
+            .join("  ·  ")}
+        </Text>
+      </Box>
+      <Spinner label="Producing the transcript. This usually takes two to three minutes." />
     </Box>
   ) : (
+
     // The reader gets its own search bar: a transcript runs to thousands of
     // words, so finding a topic matters as much as filtering the call list.
     <Box flexDirection="column" flexGrow={1} flexShrink={1} flexBasis={0} minHeight={0} overflow="hidden">
@@ -545,7 +704,17 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
       getItemKey={(call) => call.id}
       renderCell={renderCell}
       emptyStateTitle={
-        searchQuery.trim() ? "No matching calls." : "No transcribed calls yet."
+        lookupTicker && lookupState
+          ? lookupState === "unknown"
+            ? `${lookupTicker} is not a listed company.`
+            : lookupState === "none"
+              ? `No reachable earnings call for ${lookupTicker} yet.`
+              : lookupState === "error"
+                ? `Could not look up ${lookupTicker}.`
+                : `Looking up ${lookupTicker}...`
+          : searchQuery.trim()
+            ? "No matching calls."
+            : "No calls yet."
       }
       emptyStateHint={searchQuery.trim() ? "Clear the search to see all calls." : undefined}
     />

--- a/src/plugins/builtin/earnings-calls/pane.tsx
+++ b/src/plugins/builtin/earnings-calls/pane.tsx
@@ -15,7 +15,13 @@ import { useShortcut } from "../../../react/input";
 import { CloudAuthNotice } from "../cloud/auth-actions";
 import { useCloudPlanAction, useCloudUpgradeAction } from "../shared/cloud-upgrade";
 import { colors } from "../../../theme/colors";
-import { Box, Text, type InputRenderable, type ScrollBoxRenderable } from "../../../ui";
+import {
+  Box,
+  Text,
+  useRendererHost,
+  type InputRenderable,
+  type ScrollBoxRenderable,
+} from "../../../ui";
 import { isPlainKey } from "../../../utils/keyboard";
 import { isPlainArrowUp, stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
 import { useBoundTicker as useSymbolBinding } from "../shared/ticker-request";
@@ -32,7 +38,7 @@ import {
   statusOf,
 } from "./data";
 import { callTitle, formatCallDate, formatDuration, formatPeriod, formatSentiment } from "./format";
-import { TranscriptView } from "./transcript-view";
+import { TranscriptView, type ReaderTab } from "./transcript-view";
 
 export const EARNINGS_CALLS_PANE_ID = "earnings-calls";
 
@@ -166,7 +172,7 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
     message: string;
     status?: number;
   } | null>(null);
-  const [qaOnly, setQaOnly] = useState(false);
+  const [readerTab, setReaderTab] = useState<ReaderTab>("summary");
   const [sort, setSort] = useState<CallSort>(DEFAULT_SORT);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchFocused, setSearchFocused] = useState(false);
@@ -386,7 +392,17 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
   useEffect(() => {
     const scrollBox = transcriptScrollRef.current;
     if (scrollBox) scrollBox.scrollTop = 0;
-  }, [selectedId, detailOpen, qaOnly, searchQuery]);
+  }, [selectedId, detailOpen, readerTab, searchQuery]);
+
+  // The find field filters turns, so typing in it moves off the summary.
+  useEffect(() => {
+    if (detailOpen && searchQuery.trim() && readerTab === "summary") setReaderTab("transcript");
+  }, [detailOpen, searchQuery, readerTab]);
+
+  const rendererHost = useRendererHost();
+  const openSource = useCallback(() => {
+    if (selected?.webcastUrl) void rendererHost.openExternal(selected.webcastUrl);
+  }, [rendererHost, selected]);
 
   const signInRequired = !access.signedIn || listError?.status === 401;
   const verificationRequired =
@@ -429,7 +445,7 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
     (event) => {
       if (!isPlainKey(event, "q")) return;
       stopSearchFocusNavigation(event);
-      setQaOnly((current) => !current);
+      setReaderTab("qa");
     },
     {
       enabled: focused && detailOpen && !searchFocused,
@@ -443,6 +459,21 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
       if (isPlainKey(event, "/")) {
         stopSearchFocusNavigation(event);
         focusSearch();
+        return true;
+      }
+      if (isPlainKey(event, "s")) {
+        stopSearchFocusNavigation(event);
+        setReaderTab("summary");
+        return true;
+      }
+      if (isPlainKey(event, "t")) {
+        stopSearchFocusNavigation(event);
+        setReaderTab("transcript");
+        return true;
+      }
+      if (isPlainKey(event, "o")) {
+        stopSearchFocusNavigation(event);
+        openSource();
         return true;
       }
       if (isPlainKey(event, "j", "down")) {
@@ -462,7 +493,7 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
       }
       return false;
     },
-    [focusSearch, scrollTranscriptBy],
+    [focusSearch, scrollTranscriptBy, openSource],
   );
 
   usePaneFooter(
@@ -498,9 +529,6 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
       if (proRequired || transcriptProRequired) {
         info.push({ id: "pro", parts: [{ text: "pro required", tone: "warning" }] });
       }
-      if (detailOpen && qaOnly) {
-        info.push({ id: "qa", parts: [{ text: "Q&A only", tone: "muted" }] });
-      }
       if (searchQuery.trim()) {
         info.push({
           id: "filter",
@@ -510,7 +538,9 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
 
       const hints = detailOpen
         ? [
-            { id: "qa", key: "q", label: "&A only", onPress: () => setQaOnly((v) => !v) },
+            ...(selected?.webcastUrl
+              ? [{ id: "open", key: "o", label: "pen source", onPress: openSource }]
+              : []),
             { id: "find", key: "/", label: "find", onPress: focusSearch },
           ]
         : [{ id: "search", key: "/", label: "search", onPress: focusSearch }];
@@ -529,9 +559,10 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
       proRequired,
       transcriptProRequired,
       detailOpen,
-      qaOnly,
+      selected,
       searchQuery,
       focusSearch,
+      openSource,
       fetchCalls,
     ],
   );
@@ -639,7 +670,9 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
         transcript={transcript}
         loading={transcriptLoading}
         error={transcriptError?.message ?? null}
-        qaOnly={qaOnly}
+        tab={readerTab}
+        onTabChange={setReaderTab}
+        tabsFocused={focused && detailOpen && !searchFocused}
         query={searchQuery}
         width={width}
         scrollRef={transcriptScrollRef}
@@ -653,7 +686,7 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
       detailOpen={detailOpen && !!selected}
       onBack={() => {
         setDetailOpen(false);
-        setQaOnly(false);
+        setReaderTab("summary");
         setSearchQuery("");
         blurSearch();
       }}
@@ -689,7 +722,8 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
         setDetailOpen(true);
       }}
       rootWidth={width}
-      rootHeight={Math.max(1, height - 1)}
+      // The search bar sits inside the frame, so the frame takes the full height.
+      rootHeight={Math.max(2, height)}
       columns={columns}
       items={rows}
       sortColumnId={sort.columnId}

--- a/src/plugins/builtin/earnings-calls/prose.test.ts
+++ b/src/plugins/builtin/earnings-calls/prose.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { splitFigures, splitSentences } from "./prose";
+
+describe("splitFigures", () => {
+  test("picks out money, percentages and quantities, leaves years and labels", () => {
+    const runs = splitFigures(
+      "Revenue grew 20% to $1.2 billion in 2026, or 150 bps above Q2 guidance of $900 million to $1 billion, with 2,500 hires.",
+    );
+    expect(runs.filter((run) => run.figure).map((run) => run.text)).toEqual([
+      "20%",
+      "$1.2 billion",
+      "150 bps",
+      "$900 million",
+      "$1 billion",
+      "2,500",
+    ]);
+    // Everything is accounted for, nothing dropped or duplicated.
+    expect(runs.map((run) => run.text).join("")).toBe(
+      "Revenue grew 20% to $1.2 billion in 2026, or 150 bps above Q2 guidance of $900 million to $1 billion, with 2,500 hires.",
+    );
+  });
+});
+
+describe("splitSentences", () => {
+  test("splits on sentence ends but not on abbreviations or decimals", () => {
+    expect(
+      splitSentences(
+        "The U.S. business grew. Margins were 27.8% vs. 25% last year. Acme Inc. expects $5 million and under; management sees this as transferable.",
+      ),
+    ).toEqual([
+      "The U.S. business grew.",
+      "Margins were 27.8% vs. 25% last year.",
+      "Acme Inc. expects $5 million and under; management sees this as transferable.",
+    ]);
+  });
+});

--- a/src/plugins/builtin/earnings-calls/prose.ts
+++ b/src/plugins/builtin/earnings-calls/prose.ts
@@ -1,0 +1,59 @@
+/**
+ * Text shaping for the call reader. Model summaries arrive as dense
+ * paragraphs; on a wide pane they are a wall. Splitting them into one point
+ * per sentence and setting the figures in bold is what makes them scannable.
+ */
+
+export interface ProseRun {
+  text: string;
+  /** A number the eye should land on: money, percentages, quantities. */
+  figure: boolean;
+}
+
+/**
+ * Money, percentages and quantities with a unit, plus bare numbers except
+ * years. Ordinals and fiscal labels (Q2, FY26, 2Q) are left alone.
+ */
+const FIGURE_PATTERN =
+  /[$€£¥]\s?\d[\d,]*(?:\.\d+)?(?:\s?(?:trillion|billion|million|thousand|bn|mn|k|m|b)\b)?|\b\d[\d,]*(?:\.\d+)?\s?(?:%|percent(?:age points?)?|bps|basis points|x\b|trillion|billion|million|thousand)|\b\d[\d,]*(?:\.\d+)?\b/gi;
+
+const YEAR_PATTERN = /^(?:19|20)\d{2}$/;
+
+export function splitFigures(text: string): ProseRun[] {
+  const runs: ProseRun[] = [];
+  let last = 0;
+  for (const match of text.matchAll(FIGURE_PATTERN)) {
+    const start = match.index ?? 0;
+    const value = match[0];
+    if (YEAR_PATTERN.test(value)) continue;
+    if (start > last) runs.push({ text: text.slice(last, start), figure: false });
+    runs.push({ text: value, figure: true });
+    last = start + value.length;
+  }
+  if (last < text.length) runs.push({ text: text.slice(last), figure: false });
+  return runs;
+}
+
+/**
+ * Sentence boundaries, minus the periods inside abbreviations ("U.S.",
+ * "Inc.", "vs.") and figures ("$27.8 million").
+ */
+const SENTENCE_BOUNDARY =
+  /(?<!\b(?:[A-Z]|Inc|Ltd|Co|Corp|vs|Mr|Ms|Mrs|Dr|No|St|Jr|Sr|U\.S|e\.g|i\.e|approx))[.!?]["”')]?\s+(?=["“(]?[A-Z0-9$])/;
+
+export function splitSentences(text: string): string[] {
+  const out: string[] = [];
+  let rest = text.trim();
+  while (rest.length > 0) {
+    const match = SENTENCE_BOUNDARY.exec(rest);
+    if (!match) {
+      out.push(rest);
+      break;
+    }
+    // Keep the closing punctuation, drop the whitespace that followed it.
+    const cut = match.index + match[0].trimEnd().length;
+    out.push(rest.slice(0, cut).trim());
+    rest = rest.slice(match.index + match[0].length);
+  }
+  return out.filter(Boolean);
+}

--- a/src/plugins/builtin/earnings-calls/transcript-view.tsx
+++ b/src/plugins/builtin/earnings-calls/transcript-view.tsx
@@ -1,9 +1,11 @@
 import { useMemo, type RefObject } from "react";
 import { Spinner } from "../../../components";
+import { Tabs } from "../../../components/ui/tabs";
 import { colors } from "../../../theme/colors";
 import {
   Box,
   ScrollBox,
+  StyledText,
   Text,
   TextAttributes,
   useUiCapabilities,
@@ -15,6 +17,21 @@ import type {
   CloudTranscriptTurnPayload,
 } from "../../../api-client";
 import { formatCallDate, formatDuration, formatSentiment, formatTimestamp } from "./format";
+import { splitFigures, splitSentences } from "./prose";
+
+export type ReaderTab = "summary" | "transcript" | "qa";
+
+export const READER_TABS: Array<{ label: string; value: ReaderTab }> = [
+  { label: "Summary", value: "summary" },
+  { label: "Transcript", value: "transcript" },
+  { label: "Q&A", value: "qa" },
+];
+
+/**
+ * Prose is capped at a comfortable measure. On a wide pane a full-width line
+ * is over two hundred characters, which the eye loses on the way back.
+ */
+const MAX_PROSE_WIDTH = 100;
 
 function speakerColor(turn: CloudTranscriptTurnPayload): string {
   if (turn.speaker === "Operator") return colors.textDim;
@@ -31,38 +48,75 @@ function turnDetail(turn: CloudTranscriptTurnPayload): string {
 const NATIVE_STRETCH_STYLE = { minWidth: 0 };
 const NATIVE_TEXT_STYLE = { display: "block" };
 
+/** Figures set in bold, the rest in the given colour. */
+function styledRuns(text: string, color: string, attributes = 0): StyledText {
+  return new StyledText(
+    splitFigures(text).map((run) => ({
+      text: run.text,
+      fg: run.figure ? colors.textBright : color,
+      attributes: run.figure ? attributes | TextAttributes.BOLD : attributes,
+    })),
+  );
+}
+
 /**
- * The terminal renderer does not wrap text on its own, so long paragraphs are
- * pre-wrapped into one fixed-height row per line. Desktop chrome wraps natively.
+ * A paragraph with figures in bold. The terminal renderer does not wrap on
+ * its own, so lines are pre-wrapped and styled one at a time; desktop
+ * chrome wraps the styled paragraph itself. `indent` is applied to every
+ * line after the first, for bullets.
  */
-function TextLines({
+function Prose({
   text,
   width,
   color,
-  attributes,
   nativePaneChrome,
+  prefix = "",
 }: {
-  text: string | undefined;
+  text: string;
   width: number;
   color: string;
-  attributes?: number;
   nativePaneChrome: boolean;
+  /** Put before the first line; later lines are indented by its width. */
+  prefix?: string;
 }) {
-  if (!text?.trim()) return null;
+  if (!text.trim()) return null;
   if (nativePaneChrome) {
     return (
-      <Text fg={color} attributes={attributes} wrapText width="100%" style={NATIVE_TEXT_STYLE}>
-        {text}
-      </Text>
+      <Box flexDirection="row" width="100%" style={NATIVE_STRETCH_STYLE}>
+        {prefix ? <Text fg={colors.textDim}>{prefix}</Text> : null}
+        <Text
+          wrapText
+          width="100%"
+          style={NATIVE_TEXT_STYLE}
+          content={styledRuns(text, color)}
+        />
+      </Box>
     );
   }
-  return wrapTextLines(text, width).map((line, index) => (
-    <Box key={index} height={1}>
-      <Text fg={color} attributes={attributes}>{line}</Text>
+  const indent = " ".repeat(prefix.length);
+  return wrapTextLines(text, Math.max(8, width - prefix.length)).map((line, index) => (
+    <Box key={index} height={1} flexDirection="row">
+      {prefix ? (
+        <Text fg={colors.textDim} flexShrink={0}>
+          {index === 0 ? prefix : indent}
+        </Text>
+      ) : null}
+      <Text content={styledRuns(line, color)} />
     </Box>
   ));
 }
 
+function SectionHeading({ title }: { title: string }) {
+  return (
+    <Box height={1} marginTop={1}>
+      <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
+        {title}
+      </Text>
+    </Box>
+  );
+}
+
+/** A summary section as one point per sentence. */
 function Section({
   title,
   body,
@@ -76,13 +130,42 @@ function Section({
 }) {
   if (!body.trim()) return null;
   return (
+    <Box flexDirection="column">
+      <SectionHeading title={title} />
+      {splitSentences(body).map((sentence, index) => (
+        <Prose
+          key={index}
+          text={sentence}
+          width={width}
+          color={colors.text}
+          nativePaneChrome={nativePaneChrome}
+          prefix="• "
+        />
+      ))}
+    </Box>
+  );
+}
+
+function TurnView({
+  turn,
+  width,
+  nativePaneChrome,
+}: {
+  turn: CloudTranscriptTurnPayload;
+  width: number;
+  nativePaneChrome: boolean;
+}) {
+  const detail = turnDetail(turn);
+  return (
     <Box flexDirection="column" marginTop={1}>
-      <Box height={1}>
-        <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
-          {title}
+      <Box height={1} flexDirection="row" gap={1} overflow="hidden">
+        <Text fg={colors.textDim}>{formatTimestamp(turn.startSeconds)}</Text>
+        <Text fg={speakerColor(turn)} attributes={TextAttributes.BOLD}>
+          {turn.speaker}
         </Text>
+        {detail ? <Text fg={colors.textDim}>{detail}</Text> : null}
       </Box>
-      <TextLines text={body} width={width} color={colors.text} nativePaneChrome={nativePaneChrome} />
+      <Prose text={turn.text} width={width} color={colors.text} nativePaneChrome={nativePaneChrome} />
     </Box>
   );
 }
@@ -91,7 +174,9 @@ export function TranscriptView({
   transcript,
   loading,
   error,
-  qaOnly,
+  tab,
+  onTabChange,
+  tabsFocused,
   query,
   width,
   scrollRef,
@@ -99,7 +184,10 @@ export function TranscriptView({
   transcript: CloudEarningsTranscriptPayload | null;
   loading: boolean;
   error: string | null;
-  qaOnly: boolean;
+  tab: ReaderTab;
+  onTabChange: (tab: ReaderTab) => void;
+  /** Whether left/right should move between tabs. */
+  tabsFocused: boolean;
   /** Free-text filter applied to the turns, for finding a topic in a long call. */
   query?: string;
   width: number;
@@ -111,13 +199,13 @@ export function TranscriptView({
 
   const turns = useMemo(() => {
     const all = transcript?.turns ?? [];
-    const scoped = qaOnly ? all.filter((turn) => turn.isQa) : all;
+    const scoped = tab === "qa" ? all.filter((turn) => turn.isQa) : all;
     const needle = (query ?? "").trim().toLowerCase();
     if (!needle) return scoped;
     return scoped.filter((turn) =>
       `${turn.speaker} ${turn.company ?? ""} ${turn.text}`.toLowerCase().includes(needle),
     );
-  }, [transcript, qaOnly, query]);
+  }, [transcript, tab, query]);
 
   if (loading && !transcript) {
     return (
@@ -149,8 +237,10 @@ export function TranscriptView({
 
   // One column of padding each side inside the scroll box.
   const bodyWidth = Math.max(12, width - 2);
+  const proseWidth = Math.min(bodyWidth, MAX_PROSE_WIDTH);
   const contentWidth = isNative ? "100%" : bodyWidth;
   const contentStyle = isNative ? NATIVE_STRETCH_STYLE : undefined;
+  const hasQa = (transcript.turns ?? []).some((turn) => turn.isQa);
 
   return (
     <Box
@@ -161,6 +251,20 @@ export function TranscriptView({
       minHeight={0}
       overflow="hidden"
     >
+      <Box height={1} flexShrink={0} paddingX={1} overflow="hidden">
+        <Tabs
+          tabs={READER_TABS.map((entry) => ({
+            label: entry.label,
+            value: entry.value,
+            disabled: entry.value === "qa" && !hasQa,
+          }))}
+          activeValue={tab}
+          onSelect={(value) => onTabChange(value as ReaderTab)}
+          compact
+          variant="bare"
+          focused={tabsFocused}
+        />
+      </Box>
       <ScrollBox
         ref={scrollRef}
         flexGrow={1}
@@ -172,65 +276,56 @@ export function TranscriptView({
         paddingX={1}
       >
         <Box flexDirection="column" width={contentWidth} style={contentStyle}>
-          <TextLines text={meta} width={bodyWidth} color={colors.textDim} nativePaneChrome={isNative} />
-
-          <Section title="SUMMARY" body={transcript.summary ?? ""} width={bodyWidth} nativePaneChrome={isNative} />
-          <Section title="WHAT STOOD OUT" body={transcript.notable ?? ""} width={bodyWidth} nativePaneChrome={isNative} />
-          <Section title="ANALYSTS PRESSED ON" body={transcript.analystFocus ?? ""} width={bodyWidth} nativePaneChrome={isNative} />
-          <Section title="GUIDANCE" body={transcript.guidance ?? ""} width={bodyWidth} nativePaneChrome={isNative} />
-          <Section title="RISKS" body={transcript.riskFactors ?? ""} width={bodyWidth} nativePaneChrome={isNative} />
-
-          {transcript.participants.length > 0 && (
-            <Box flexDirection="column" marginTop={1}>
-              <Box height={1}>
-                <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
-                  PARTICIPANTS
-                </Text>
-              </Box>
-              {transcript.participants.map((participant) => (
-                <TextLines
-                  key={participant.name}
-                  text={[participant.name, participant.role, participant.company]
-                    .filter(Boolean)
-                    .join("  ·  ")}
-                  width={bodyWidth}
-                  color={colors.text}
+          {tab === "summary" ? (
+            <>
+              <Prose text={meta} width={proseWidth} color={colors.textDim} nativePaneChrome={isNative} />
+              <Section title="SUMMARY" body={transcript.summary ?? ""} width={proseWidth} nativePaneChrome={isNative} />
+              <Section title="WHAT STOOD OUT" body={transcript.notable ?? ""} width={proseWidth} nativePaneChrome={isNative} />
+              <Section title="ANALYSTS PRESSED ON" body={transcript.analystFocus ?? ""} width={proseWidth} nativePaneChrome={isNative} />
+              <Section title="GUIDANCE" body={transcript.guidance ?? ""} width={proseWidth} nativePaneChrome={isNative} />
+              <Section title="RISKS" body={transcript.riskFactors ?? ""} width={proseWidth} nativePaneChrome={isNative} />
+              {transcript.participants.length > 0 && (
+                <Box flexDirection="column">
+                  <SectionHeading title="PARTICIPANTS" />
+                  {transcript.participants.map((participant) => (
+                    <Prose
+                      key={participant.name}
+                      text={[participant.name, participant.role, participant.company]
+                        .filter(Boolean)
+                        .join("  ·  ")}
+                      width={proseWidth}
+                      color={colors.text}
+                      nativePaneChrome={isNative}
+                    />
+                  ))}
+                </Box>
+              )}
+            </>
+          ) : (
+            <>
+              {turns.map((turn, index) => (
+                <TurnView
+                  key={`${turn.startSeconds}-${index}`}
+                  turn={turn}
+                  width={proseWidth}
                   nativePaneChrome={isNative}
                 />
               ))}
-            </Box>
-          )}
-
-          <Box height={1} marginTop={1}>
-            <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
-              {qaOnly ? "QUESTION AND ANSWER" : "TRANSCRIPT"}
-            </Text>
-          </Box>
-
-          {turns.map((turn, index) => (
-            <Box key={`${turn.startSeconds}-${index}`} flexDirection="column" marginTop={1}>
-              <Box height={1} flexDirection="row" gap={1} overflow="hidden">
-                <Text fg={colors.textDim}>{formatTimestamp(turn.startSeconds)}</Text>
-                <Text fg={speakerColor(turn)} attributes={TextAttributes.BOLD}>
-                  {turn.speaker}
-                </Text>
-                {turnDetail(turn) && <Text fg={colors.textDim}>{turnDetail(turn)}</Text>}
-              </Box>
-              <TextLines text={turn.text} width={bodyWidth} color={colors.text} nativePaneChrome={isNative} />
-            </Box>
-          ))}
-
-          {turns.length === 0 && (
-            <TextLines
-              text={
-                query?.trim()
-                  ? `Nothing matching "${query.trim()}" in this call.`
-                  : "No question and answer section in this call."
-              }
-              width={bodyWidth}
-              color={colors.textDim}
-              nativePaneChrome={isNative}
-            />
+              {turns.length === 0 && (
+                <Box marginTop={1}>
+                  <Prose
+                    text={
+                      query?.trim()
+                        ? `Nothing matching "${query.trim()}" in this call.`
+                        : "No question and answer section in this call."
+                    }
+                    width={proseWidth}
+                    color={colors.textDim}
+                    nativePaneChrome={isNative}
+                  />
+                </Box>
+              )}
+            </>
           )}
         </Box>
       </ScrollBox>


### PR DESCRIPTION
## What

The shelf can now reach any company, and calls that exist but are not transcribed yet can be produced from the reader.

- **Ticker lookup from the search bar.** On the shelf, a query that looks like a symbol we do not have (`AVGO`, `BRK-B`) asks the server for that company after a short debounce. Results merge into the list; the footer shows `looking up AVGO` / `AVGO not found`, and the empty state distinguishes "not a listed company" from "no reachable call yet". While the server is still searching (`pending`), the lookup checks back every 20s.
- **Calls without a transcript are listed** with their state in the TONE column: `on request` (found, shelved), `queued`, `in progress`. Column widened from 6 to 11 to fit.
- **Open to produce.** Opening a call without a transcript now calls the transcript endpoint (which promotes it server-side), shows "Producing the transcript..." with a spinner and the call's date/period, and polls every 15s until the transcript arrives, then swaps to the reader and marks the row transcribed. Before, opening such a call showed a static "queued" note and never requested anything.
- A research tab whose company is still being searched shows a spinner and polls the list instead of an empty shelf.
- Lists containing unfinished calls are not cached (they change by the minute); finished lists keep the 15 min policy.

`CloudEarningsCallListPayload` gains optional `pending` / `unknownTicker` (already returned by the API).

## Tested

In tmux against production: typed `NVDA` on the shelf, got the row back in under 2s marked `queued`, opened it, watched the producing state, and the reader appeared on its own once the server published (32 turns, 11 speakers via the Q4 caption route). Typecheck clean.

Backend counterparts: gloomberb-platform #160 (shelved calls, on-request), #161 (Q4 feed + sources), #162 (S&P 500 coverage), #163 (queue order on promote), #164 (model order).

## Update: reader rework

- **Tabs**: Summary | Transcript | Q&A (shared `Tabs`, bare variant). `s` / `t` / `q` jump, left/right arrows move between tabs, Q&A is disabled when the call has none. Typing in the find field moves off Summary since it filters turns.
- **Readability**: summary sections are one sentence per bullet with a hanging indent; prose measure capped at 100 columns; **figures in bold** (money, percentages, bps, quantities with units, bare numbers except years) via `StyledText` chunks, so it works on both the terminal and desktop renderers. Applies to transcript turns too.
- **`o` opens the source** (webcast page / recording) via `rendererHost.openExternal`; the API now returns `webcastUrl` with each call (platform #167).
- **Dead row** at the bottom of the list: the frame height was `height - 1` for a search bar that is already inside the frame.

Tested in tmux (isolated layout via remote control, deleted after): tabs, keys, wrapping, bold escape codes present, warning scan clean.
