### PR TITLE
Add a headless pane model convention

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -77,6 +77,112 @@ For external plugins, create a directory in `~/.gloomberb/plugins/`:
 
 Use `setup()` for interactive runtime registration, `capabilities` for reusable headless services, and `cliCommands` for root-level CLI commands that should be discoverable without rendering panes. Capability operations can still declare `cli` manifests (`summary`, input/output shape, formats, safety notes, side-effect level) for `gloomberb api list`.
 
+## Headless pane models
+
+A data pane should expose the renderer-neutral model that sits behind its component. Add a `headless` definition to the `PaneDef` and export the definition from the plugin module so server processes can invoke the same loader later. If one pane has multiple templates with different data contracts, put `headless` on each `PaneTemplateDef` instead. A template-level definition takes precedence over the pane-level definition.
+
+```typescript
+import type {
+  GloomPlugin,
+  HeadlessPaneDefinition,
+} from "gloomberb/types/plugin";
+
+export const statsHeadless = {
+  shape: "bundle",
+  argument: {
+    kind: "free-text",
+    placeholder: "statistic",
+    optional: true,
+    description: "Optional statistic id or label.",
+  },
+  options: [{
+    key: "range",
+    description: "History window.",
+    type: "enum",
+    values: [{ value: "5Y" }, { value: "20Y" }, { value: "ALL" }],
+    defaultValue: "20Y",
+  }],
+  describe: (args) => `Statistics | ${String(args.options.range)}`,
+  async load(args, ctx) {
+    const bundle = await loadStatsBundle(ctx.apiClient, ctx.signal);
+    return projectStatsView(bundle, args.argument, args.options.range);
+  },
+} satisfies HeadlessPaneDefinition<"bundle">;
+
+export default {
+  id: "stats",
+  name: "Statistics",
+  version: "1.0.0",
+  panes: [{
+    id: "stats",
+    name: "Statistics",
+    component: StatisticsPane,
+    defaultPosition: "right",
+    headless: statsHeadless,
+  }],
+} satisfies GloomPlugin;
+```
+
+A pane with `headless` automatically gets:
+
+- `gloomberb fn <TOKEN>` text output with shared aligned tables and section headings
+- `gloomberb fn <TOKEN> --json` through the normal `{ ok, data }` result envelope
+- `reportReadiness: "ready"` plus its declared options in `gloomberb catalog`
+- strict option validation for `fn`, including allowed enum values and numeric bounds
+
+If a pane still has an entry in the legacy pane capability map, `headless` wins for reports. Its old report builder and screenshot behavior stay available until they are migrated separately.
+
+### Definition contract
+
+```typescript
+interface HeadlessPaneDefinition<Shape extends HeadlessPaneShape> {
+  shape: Shape;
+  argument: HeadlessPaneArgumentDef;
+  options: HeadlessPaneOptionDef[];
+  columns?: HeadlessPaneColumn[];
+  describe?: string | ((args: HeadlessPaneLoadArgs) => string);
+  load(
+    args: HeadlessPaneLoadArgs,
+    ctx: HeadlessPaneContext,
+  ): HeadlessPaneResultByShape[Shape] | Promise<HeadlessPaneResultByShape[Shape]>;
+}
+```
+
+`argument.kind` is one of `none`, `ticker`, `tickers`, `symbol-list`, or `free-text`. Use `optional`, `minimum`, and `maximum` to describe cardinality. The adapter normalizes ticker arguments and supplies both `args.argument` and `args.symbols`.
+
+Options use the existing pane-function schema: `key`, `type`, `description`, optional aliases, enum `values`, `defaultValue`, and optional integer bounds. Keep option names aligned with pane settings when possible so the same flag can drive a later screenshot model without translation.
+
+`ctx` contains:
+
+- `marketData`: the active plugin-aware market data provider
+- `apiClient`: the Gloom Cloud client
+- `config`: the loaded app configuration
+- `signal`: the abort signal for this invocation
+
+Headless loaders must stay isomorphic. Do not import React, DOM APIs, Electrobun, OpenTUI, or renderer state. Pass dependencies through `ctx` and keep fetching in `client.ts`.
+
+### Result shapes
+
+The four supported shapes cover the pane catalog:
+
+- `rows`: `{ columns?, rows }` for one table
+- `bundle`: `{ sections: [{ title, columns?, rows } | { title, entries }] }` for dashboards such as VAL and ECST
+- `series`: `{ series: [{ id, label, points }], stats? }` for charts and derived statistics
+- `snapshot`: `{ asOf, items }` for a point-in-time view of a stream
+
+All shapes may include `errors` and `metadata`. Rows and items should contain raw structured values. Put display formatting in column `format` callbacks, or use an entry's `formatted` field, so JSON keeps the raw value while text stays readable.
+
+### Migration checklist
+
+For a pane that currently fetches inside its component:
+
+1. Move API calls and cache access into `client.ts`. Accept injected clients or providers where practical.
+2. Move filtering, grouping, derived values, and row construction into pure functions in `view.ts` or `model.ts`.
+3. Make the React pane call those same client and projection functions.
+4. Export a typed `headless` definition and attach it to the pane registration, or to each template when one pane has multiple contracts.
+5. Declare every supported argument and option. Do not read pane or renderer state from `load`.
+6. Verify text, JSON, option errors, and catalog readiness with `gloomberb fn` and `gloomberb catalog`.
+
 ## Renderer-neutral UI
 
 Plugins should treat Gloomberb's UI APIs as the renderer contract. Official plugins may render panes, Ticker Research tabs, and slot widgets with React, but plugin UI should import shared Gloom APIs such as `gloomberb/ui`, `gloomberb/react`, or the plugin runtime hooks instead of importing OpenTUI, Electrobun, DOM, or terminal renderer packages directly. Renderer-specific details like terminal keyboard events, kitty images, DOM pointer behavior, dialogs, and notifications belong in the renderer adapters.

--- a/src/cli/pane-functions/capabilities.ts
+++ b/src/cli/pane-functions/capabilities.ts
@@ -1,31 +1,20 @@
 import { CHART_RESOLUTIONS } from "../../time-series/range";
-import type { PaneDef, PaneTemplateDef } from "../../types/plugin";
+import type {
+  HeadlessPaneArgumentDef,
+  HeadlessPaneDefinition,
+  HeadlessPaneOptionDef,
+  HeadlessPaneOptionType,
+  HeadlessPaneOptionValue,
+  PaneDef,
+  PaneTemplateDef,
+} from "../../types/plugin";
 
 export type PaneFunctionReadiness = "ready" | "partial" | "unsupported";
 export type PaneFunctionTickerCardinality = "none" | "one" | "one-or-more" | "two-or-more" | "one-or-two";
-export type PaneFunctionOptionType = "enum" | "integer" | "string" | "boolean";
+export type PaneFunctionOptionType = HeadlessPaneOptionType;
+export type PaneFunctionOptionValue = HeadlessPaneOptionValue;
+export type PaneFunctionOptionDef = HeadlessPaneOptionDef;
 export type NormalizedPaneFunctionOptions = Record<string, string | number | boolean>;
-
-export interface PaneFunctionOptionValue {
-  value: string;
-  aliases?: string[];
-}
-
-export interface PaneFunctionOptionDef {
-  key: string;
-  description: string;
-  type: PaneFunctionOptionType;
-  aliases?: string[];
-  values?: PaneFunctionOptionValue[];
-  defaultValue?: string | number | boolean;
-  minimum?: number;
-  maximum?: number;
-  settingKey?: string;
-  pluginState?: {
-    pluginId: string;
-    key?: string;
-  };
-}
 
 export interface PaneFunctionCapability {
   id: string;
@@ -411,11 +400,49 @@ function optionToken(value: string): string {
   return value.trim().toLowerCase().replace(/[\s_.-]+/g, "");
 }
 
+function headlessTickerCardinality(argument: HeadlessPaneArgumentDef): PaneFunctionTickerCardinality {
+  switch (argument.kind) {
+    case "ticker":
+      return "one";
+    case "tickers":
+    case "symbol-list":
+      return (argument.minimum ?? 1) >= 2 ? "two-or-more" : "one-or-more";
+    case "none":
+    case "free-text":
+      return "none";
+    default: {
+      const _exhaustive: never = argument.kind;
+      return _exhaustive;
+    }
+  }
+}
+
+export function getHeadlessPaneDefinition(
+  template: PaneTemplateDef | undefined,
+  pane: PaneDef,
+): HeadlessPaneDefinition | undefined {
+  return template?.headless ?? pane.headless;
+}
+
 export function getPaneFunctionCapability(
   template: PaneTemplateDef | undefined,
-  _pane: PaneDef,
+  pane: PaneDef,
 ): PaneFunctionCapability {
-  return template ? CAPABILITIES[template.id] ?? UNSUPPORTED_CAPABILITY : UNSUPPORTED_CAPABILITY;
+  const existing = template ? CAPABILITIES[template.id] ?? UNSUPPORTED_CAPABILITY : UNSUPPORTED_CAPABILITY;
+  const headless = getHeadlessPaneDefinition(template, pane);
+  if (!headless) return existing;
+
+  const hasExistingCapability = existing !== UNSUPPORTED_CAPABILITY;
+  return {
+    ...(hasExistingCapability ? existing : UNSUPPORTED_CAPABILITY),
+    id: hasExistingCapability ? existing.id : template?.id ?? pane.id,
+    botSafe: true,
+    tickerCardinality: headlessTickerCardinality(headless.argument),
+    outputKind: headless.shape,
+    reportReadiness: "ready",
+    options: [...headless.options],
+    ...(hasExistingCapability ? {} : { limitations: [] }),
+  };
 }
 
 function resolveOptionDef(

--- a/src/cli/pane-functions/catalog.ts
+++ b/src/cli/pane-functions/catalog.ts
@@ -7,6 +7,7 @@ import {
 } from "./options";
 import {
   capabilityOptionSummary,
+  getHeadlessPaneDefinition,
   getPaneFunctionCapability,
   type PaneFunctionCapability,
 } from "./capabilities";
@@ -120,6 +121,7 @@ async function buildTemplateCatalogEntry(
     }
   }
 
+  const headless = getHeadlessPaneDefinition(template, pane);
   return {
     token: template.shortcut?.prefix ?? template.id,
     label: template.label,
@@ -128,8 +130,8 @@ async function buildTemplateCatalogEntry(
     paneName: pane.name,
     templateId: template.id,
     shortcut: template.shortcut?.prefix,
-    argKind: template.shortcut?.argKind,
-    argPlaceholder: template.shortcut?.argPlaceholder,
+    argKind: headless?.argument.kind ?? template.shortcut?.argKind,
+    argPlaceholder: headless?.argument.placeholder ?? template.shortcut?.argPlaceholder,
     keywords: template.keywords ?? [],
     defaultSettings,
     capability: getPaneFunctionCapability(template, pane),
@@ -158,6 +160,8 @@ export async function buildPaneCatalogEntries(
       description: `Open the ${pane.name} pane.`,
       paneId: pane.id,
       paneName: pane.name,
+      argKind: pane.headless?.argument.kind,
+      argPlaceholder: pane.headless?.argument.placeholder,
       keywords: [],
       defaultSettings: {},
       capability: getPaneFunctionCapability(undefined, pane),
@@ -251,7 +255,13 @@ export function renderPaneCatalogReport(entries: PaneCatalogEntry[], args: Parse
   }
 
   for (const entry of shown) {
-    const arg = entry.argPlaceholder ? `<${entry.argPlaceholder}>` : entry.argKind ? `<${entry.argKind}>` : "[argument]";
+    const arg = entry.argKind === "none"
+      ? ""
+      : entry.argPlaceholder
+        ? `<${entry.argPlaceholder}>`
+        : entry.argKind
+          ? `<${entry.argKind}>`
+          : "[argument]";
     lines.push(`${entry.token} | ${entry.label}`);
     lines.push(`  Description: ${entry.description}`);
     lines.push(`  Pane: ${entry.paneId} (${entry.paneName})`);
@@ -273,7 +283,9 @@ export function renderPaneCatalogReport(entries: PaneCatalogEntry[], args: Parse
       lines.push(`  Limitations: ${entry.capability.limitations.join(" ")}`);
     }
     lines.push(`  Defaults: ${formatCatalogSettings(entry.defaultSettings)}`);
-    lines.push(`  Examples: gloomberb fn ${entry.token} ${arg} | gloomberb shot ${entry.token} ${arg} --output /tmp/${entry.token.toLowerCase()}.png`);
+    const fnExample = `gloomberb fn ${entry.token}${arg ? ` ${arg}` : ""}`;
+    const shotExample = `gloomberb shot ${entry.token}${arg ? ` ${arg}` : ""} --output /tmp/${entry.token.toLowerCase()}.png`;
+    lines.push(`  Examples: ${fnExample} | ${shotExample}`);
     lines.push("");
   }
 

--- a/src/cli/pane-functions/headless.test.ts
+++ b/src/cli/pane-functions/headless.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_CLI_OPTIONS } from "../options";
+import { serializeCliResult } from "../result";
+import type {
+  HeadlessBundleResult,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+  HeadlessRowsResult,
+  HeadlessSeriesResult,
+  HeadlessSnapshotResult,
+  PaneDef,
+  PaneTemplateDef,
+} from "../../types/plugin";
+import { getPaneFunctionCapability, normalizeCapabilityOptions } from "./capabilities";
+import {
+  buildHeadlessPaneLoadArgs,
+  renderHeadlessPaneText,
+  serializeHeadlessPaneResult,
+} from "./headless";
+
+const args: HeadlessPaneLoadArgs = {
+  rawArgument: "",
+  argument: null,
+  symbols: [],
+  options: {},
+};
+
+function jsonData(
+  definition: HeadlessPaneDefinition,
+  result: HeadlessRowsResult | HeadlessBundleResult | HeadlessSeriesResult | HeadlessSnapshotResult,
+): Record<string, unknown> {
+  const output = serializeCliResult(
+    { data: serializeHeadlessPaneResult(definition, result) },
+    { ...DEFAULT_CLI_OPTIONS, format: "json" },
+  );
+  return JSON.parse(output) as Record<string, unknown>;
+}
+
+describe("headless pane printer", () => {
+  test("renders rows as aligned text and preserves raw values in JSON", () => {
+    const definition: HeadlessPaneDefinition<"rows"> = {
+      shape: "rows",
+      argument: { kind: "none" },
+      options: [],
+      columns: [
+        { key: "name", header: "Name" },
+        {
+          key: "value",
+          header: "Value",
+          align: "right",
+          format: (value) => `${Number(value).toFixed(1)}%`,
+        },
+      ],
+      load: () => ({ rows: [] }),
+    };
+    const result: HeadlessRowsResult = { rows: [{ name: "CPI", value: 2.45 }] };
+
+    const text = renderHeadlessPaneText(definition, result, args, "Statistics");
+    expect(text).toContain("NAME");
+    expect(text).toContain("2.5%");
+    expect(jsonData(definition, result)).toMatchObject({
+      ok: true,
+      data: {
+        columns: [{ key: "name", header: "Name" }, { key: "value", header: "Value" }],
+        rows: [{ name: "CPI", value: 2.45 }],
+      },
+    });
+  });
+
+  test("renders bundle row and entry sections", () => {
+    const definition: HeadlessPaneDefinition<"bundle"> = {
+      shape: "bundle",
+      argument: { kind: "none" },
+      options: [],
+      load: () => ({ sections: [] }),
+    };
+    const result: HeadlessBundleResult = {
+      sections: [
+        {
+          title: "Inflation",
+          columns: [{ key: "name", header: "Indicator" }],
+          rows: [{ name: "CPI" }],
+        },
+        {
+          title: "CPI detail",
+          entries: [{ label: "Latest", value: 2.45, formatted: "2.5%" }],
+        },
+      ],
+    };
+
+    const text = renderHeadlessPaneText(definition, result, args, "Statistics");
+    expect(text).toContain("Inflation");
+    expect(text).toContain("CPI detail");
+    expect(text).toContain("2.5%");
+    expect(jsonData(definition, result)).toMatchObject({
+      ok: true,
+      data: {
+        sections: [
+          { title: "Inflation", rows: [{ name: "CPI" }] },
+          { title: "CPI detail", entries: [{ label: "Latest", value: 2.45 }] },
+        ],
+      },
+    });
+  });
+
+  test("renders series summaries and structured stats", () => {
+    const definition: HeadlessPaneDefinition<"series"> = {
+      shape: "series",
+      argument: { kind: "ticker" },
+      options: [],
+      load: () => ({ series: [] }),
+    };
+    const result: HeadlessSeriesResult = {
+      series: [{
+        id: "price",
+        label: "Price",
+        points: [
+          { date: "2026-09-01", value: 100 },
+          { date: "2026-09-02", value: 102 },
+        ],
+      }],
+      stats: { return: 0.02 },
+    };
+
+    const text = renderHeadlessPaneText(definition, result, args, "Price");
+    expect(text).toContain("2026-09-02");
+    expect(text).toContain("Statistics");
+    expect(jsonData(definition, result)).toMatchObject({
+      ok: true,
+      data: {
+        series: [{ id: "price", points: [{ value: 100 }, { value: 102 }] }],
+        stats: { return: 0.02 },
+      },
+    });
+  });
+
+  test("renders snapshot time and items", () => {
+    const definition: HeadlessPaneDefinition<"snapshot"> = {
+      shape: "snapshot",
+      argument: { kind: "none" },
+      options: [],
+      columns: [{ key: "headline", header: "Headline" }],
+      load: () => ({ asOf: "", items: [] }),
+    };
+    const result: HeadlessSnapshotResult = {
+      asOf: "2026-09-03T12:00:00Z",
+      items: [{ headline: "Markets open" }],
+    };
+
+    const text = renderHeadlessPaneText(definition, result, args, "News");
+    expect(text).toContain("As of: 2026-09-03T12:00:00Z");
+    expect(text).toContain("Markets open");
+    expect(jsonData(definition, result)).toMatchObject({
+      ok: true,
+      data: {
+        asOf: "2026-09-03T12:00:00Z",
+        items: [{ headline: "Markets open" }],
+      },
+    });
+  });
+});
+
+describe("headless pane arguments and options", () => {
+  test("normalizes symbol lists and enforces their declared minimum", () => {
+    const definition: HeadlessPaneDefinition<"rows"> = {
+      shape: "rows",
+      argument: { kind: "tickers", placeholder: "tickers", minimum: 2 },
+      options: [],
+      load: () => ({ rows: [] }),
+    };
+
+    expect(buildHeadlessPaneLoadArgs(definition, "CMP", "$aapl, msft, AAPL", {})).toMatchObject({
+      argument: ["AAPL", "MSFT"],
+      symbols: ["AAPL", "MSFT"],
+    });
+    expect(() => buildHeadlessPaneLoadArgs(definition, "CMP", "AAPL", {}))
+      .toThrow("CMP requires at least 2 symbols");
+  });
+
+  test("derives ready catalog capability and validates enum values", () => {
+    const definition: HeadlessPaneDefinition<"rows"> = {
+      shape: "rows",
+      argument: { kind: "none" },
+      options: [{
+        key: "mode",
+        description: "Display mode.",
+        type: "enum",
+        values: [{ value: "summary" }, { value: "detail" }],
+        defaultValue: "summary",
+      }],
+      load: () => ({ rows: [] }),
+    };
+    const pane: PaneDef = {
+      id: "example",
+      name: "Example",
+      component: () => null,
+      defaultPosition: "right",
+      headless: definition,
+    };
+    const capability = getPaneFunctionCapability(undefined, pane);
+
+    expect(capability).toMatchObject({
+      id: "example",
+      botSafe: true,
+      reportReadiness: "ready",
+      outputKind: "rows",
+    });
+    expect(normalizeCapabilityOptions(capability, {})).toEqual({ mode: "summary" });
+    expect(() => normalizeCapabilityOptions(capability, { mode: "wide" }))
+      .toThrow('Invalid --mode value "wide". Use one of: summary, detail.');
+  });
+
+  test("prefers a template model when one pane exposes multiple contracts", () => {
+    const paneModel: HeadlessPaneDefinition<"rows"> = {
+      shape: "rows",
+      argument: { kind: "none" },
+      options: [],
+      load: () => ({ rows: [] }),
+    };
+    const templateModel: HeadlessPaneDefinition<"series"> = {
+      shape: "series",
+      argument: { kind: "ticker" },
+      options: [],
+      load: () => ({ series: [] }),
+    };
+    const pane: PaneDef = {
+      id: "chart",
+      name: "Chart",
+      component: () => null,
+      defaultPosition: "right",
+      headless: paneModel,
+    };
+    const template: PaneTemplateDef = {
+      id: "price-chart",
+      paneId: pane.id,
+      label: "Price",
+      description: "Price chart.",
+      headless: templateModel,
+    };
+
+    expect(getPaneFunctionCapability(template, pane)).toMatchObject({
+      outputKind: "series",
+      tickerCardinality: "one",
+      reportReadiness: "ready",
+    });
+  });
+});

--- a/src/cli/pane-functions/headless.ts
+++ b/src/cli/pane-functions/headless.ts
@@ -1,0 +1,423 @@
+import { apiClient } from "../../api-client";
+import type { MarketContext } from "../types";
+import type {
+  HeadlessBundleResult,
+  HeadlessBundleSection,
+  HeadlessPaneColumn,
+  HeadlessPaneContext,
+  HeadlessPaneDefinition,
+  HeadlessPaneEntry,
+  HeadlessPaneLoadArgs,
+  HeadlessPaneOptionValues,
+  HeadlessPaneResult,
+  HeadlessPaneRow,
+  HeadlessSeriesResult,
+  HeadlessSnapshotResult,
+} from "../../types/plugin";
+import { renderSection, renderTable } from "../../utils/cli-output";
+import type { PaneFunctionReport } from "./report";
+import type { ResolvedPaneFunction } from "./resolver";
+
+interface SerializableHeadlessColumn {
+  key: string;
+  header: string;
+  align?: "left" | "right" | "center";
+  width?: number;
+  description?: string;
+}
+
+export interface LoadedHeadlessPaneModel {
+  definition: HeadlessPaneDefinition;
+  args: HeadlessPaneLoadArgs;
+  result: HeadlessPaneResult;
+}
+
+function argumentName(definition: HeadlessPaneDefinition): string {
+  return definition.argument.placeholder
+    ?? (definition.argument.kind === "free-text" ? "text" : "symbol");
+}
+
+function requiredArgumentError(definition: HeadlessPaneDefinition, token: string): Error {
+  return new Error(`Usage: gloomberb fn ${token} <${argumentName(definition)}>`);
+}
+
+function normalizeSymbol(value: string): string {
+  return value.trim().replace(/^\$+/, "").toUpperCase();
+}
+
+function normalizeSymbolList(value: string): string[] {
+  const symbols: string[] = [];
+  const seen = new Set<string>();
+  for (const part of value.split(/[,\n]/)) {
+    const symbol = normalizeSymbol(part);
+    if (!symbol || seen.has(symbol)) continue;
+    seen.add(symbol);
+    symbols.push(symbol);
+  }
+  return symbols;
+}
+
+function validateSymbolCount(
+  definition: HeadlessPaneDefinition,
+  token: string,
+  symbols: string[],
+): void {
+  const minimum = definition.argument.minimum
+    ?? (definition.argument.optional ? 0 : 1);
+  const maximum = definition.argument.maximum;
+  if (symbols.length < minimum) {
+    if (minimum <= 1) throw requiredArgumentError(definition, token);
+    throw new Error(`${token} requires at least ${minimum} symbols.`);
+  }
+  if (maximum != null && symbols.length > maximum) {
+    throw new Error(`${token} accepts at most ${maximum} symbols.`);
+  }
+}
+
+export function buildHeadlessPaneLoadArgs(
+  definition: HeadlessPaneDefinition,
+  token: string,
+  rawArgument: string,
+  options: HeadlessPaneOptionValues,
+): HeadlessPaneLoadArgs {
+  const raw = rawArgument.trim();
+  switch (definition.argument.kind) {
+    case "none":
+      if (raw) throw new Error(`${token} does not accept an argument.`);
+      return { rawArgument: raw, argument: null, symbols: [], options };
+    case "free-text":
+      if (!raw && !definition.argument.optional) throw requiredArgumentError(definition, token);
+      return { rawArgument: raw, argument: raw || null, symbols: [], options };
+    case "ticker": {
+      const symbol = normalizeSymbol(raw);
+      const symbols = symbol ? [symbol] : [];
+      validateSymbolCount(definition, token, symbols);
+      return {
+        rawArgument: raw,
+        argument: symbol || null,
+        symbols,
+        options,
+      };
+    }
+    case "tickers":
+    case "symbol-list": {
+      const symbols = normalizeSymbolList(raw);
+      validateSymbolCount(definition, token, symbols);
+      return {
+        rawArgument: raw,
+        argument: symbols.length > 0 ? symbols : null,
+        symbols,
+        options,
+      };
+    }
+    default: {
+      const _exhaustive: never = definition.argument.kind;
+      return _exhaustive;
+    }
+  }
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (!signal.aborted) return;
+  throw signal.reason instanceof Error
+    ? signal.reason
+    : new Error("Headless pane load was aborted.");
+}
+
+export async function loadHeadlessPaneModel(
+  definition: HeadlessPaneDefinition,
+  args: HeadlessPaneLoadArgs,
+  context: HeadlessPaneContext,
+): Promise<HeadlessPaneResult> {
+  throwIfAborted(context.signal);
+  const result = await definition.load(args, context);
+  throwIfAborted(context.signal);
+  validateHeadlessResult(definition.shape, result);
+  return result;
+}
+
+/**
+ * Loads the same renderer-neutral model used by `fn`.
+ * A future screenshot payload can call this function instead of adding another fetch path.
+ */
+export async function loadResolvedHeadlessPaneModel(
+  resolved: ResolvedPaneFunction,
+  context: MarketContext,
+  rawArgument: string,
+  signal: AbortSignal = new AbortController().signal,
+): Promise<LoadedHeadlessPaneModel> {
+  const definition = resolved.headless;
+  if (!definition) throw new Error(`${resolved.token} has no headless pane model.`);
+  const args = buildHeadlessPaneLoadArgs(definition, resolved.token, rawArgument, resolved.options);
+  const headlessContext: HeadlessPaneContext = {
+    marketData: context.dataProvider,
+    apiClient,
+    config: context.config,
+    signal,
+  };
+  const result = await loadHeadlessPaneModel(definition, args, headlessContext);
+  return { definition, args, result };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function validateHeadlessResult(shape: HeadlessPaneDefinition["shape"], result: unknown): void {
+  if (!isRecord(result)) throw new Error(`Headless ${shape} loader returned an invalid result.`);
+  const valid = shape === "rows"
+    ? Array.isArray(result.rows)
+    : shape === "bundle"
+      ? Array.isArray(result.sections)
+      : shape === "series"
+        ? Array.isArray(result.series)
+        : Array.isArray(result.items) && result.asOf != null;
+  if (!valid) throw new Error(`Headless ${shape} loader returned an invalid result.`);
+}
+
+function serializableColumns(columns: HeadlessPaneColumn[]): SerializableHeadlessColumn[] {
+  return columns.map((column) => ({
+    key: column.key,
+    header: column.header,
+    ...(column.align ? { align: column.align } : {}),
+    ...(column.width != null ? { width: column.width } : {}),
+    ...(column.description ? { description: column.description } : {}),
+  }));
+}
+
+function inferColumns(rows: HeadlessPaneRow[]): HeadlessPaneColumn[] {
+  const keys = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) keys.add(key);
+  }
+  return [...keys].map((key) => ({ key, header: key }));
+}
+
+function columnsFor(
+  rows: HeadlessPaneRow[],
+  ownColumns: HeadlessPaneColumn[] | undefined,
+  fallbackColumns: HeadlessPaneColumn[] | undefined,
+): HeadlessPaneColumn[] {
+  return ownColumns ?? fallbackColumns ?? inferColumns(rows);
+}
+
+function serializeBundleSection(
+  section: HeadlessBundleSection,
+  fallbackColumns: HeadlessPaneColumn[] | undefined,
+): Record<string, unknown> {
+  if ("rows" in section && section.rows) {
+    const columns = columnsFor(section.rows, section.columns, fallbackColumns);
+    return {
+      title: section.title,
+      columns: serializableColumns(columns),
+      rows: section.rows,
+    };
+  }
+  return { title: section.title, entries: section.entries };
+}
+
+export function serializeHeadlessPaneResult(
+  definition: HeadlessPaneDefinition,
+  result: HeadlessPaneResult,
+): Record<string, unknown> {
+  const common = {
+    ...(result.errors ? { errors: result.errors } : {}),
+    ...(result.metadata ? { metadata: result.metadata } : {}),
+  };
+  switch (definition.shape) {
+    case "rows": {
+      const rowsResult = result as HeadlessPaneResult & { rows: HeadlessPaneRow[]; columns?: HeadlessPaneColumn[] };
+      const columns = columnsFor(rowsResult.rows, rowsResult.columns, definition.columns);
+      return { ...common, columns: serializableColumns(columns), rows: rowsResult.rows };
+    }
+    case "bundle": {
+      const bundle = result as HeadlessBundleResult;
+      return {
+        ...common,
+        sections: bundle.sections.map((section) => serializeBundleSection(section, definition.columns)),
+      };
+    }
+    case "series": {
+      const series = result as HeadlessSeriesResult;
+      return { ...common, series: series.series, ...(series.stats ? { stats: series.stats } : {}) };
+    }
+    case "snapshot": {
+      const snapshot = result as HeadlessSnapshotResult;
+      const columns = columnsFor(snapshot.items, undefined, definition.columns);
+      return {
+        ...common,
+        asOf: snapshot.asOf,
+        columns: serializableColumns(columns),
+        items: snapshot.items,
+      };
+    }
+    default: {
+      const _exhaustive: never = definition.shape;
+      return _exhaustive;
+    }
+  }
+}
+
+function displayValue(value: unknown): string {
+  if (value == null) return "-";
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function renderRows(
+  rows: HeadlessPaneRow[],
+  ownColumns: HeadlessPaneColumn[] | undefined,
+  fallbackColumns: HeadlessPaneColumn[] | undefined,
+): string {
+  if (rows.length === 0) return "No data.";
+  const columns = columnsFor(rows, ownColumns, fallbackColumns);
+  return renderTable(
+    columns.map((column) => ({
+      header: column.header.toUpperCase(),
+      align: column.align,
+      width: column.width,
+    })),
+    rows.map((row) => columns.map((column) => {
+      const value = row[column.key];
+      return column.format ? column.format(value, row) : displayValue(value);
+    })),
+  );
+}
+
+function renderEntries(entries: HeadlessPaneEntry[]): string {
+  if (entries.length === 0) return "No data.";
+  return renderTable(
+    [{ header: "METRIC" }, { header: "VALUE" }],
+    entries.map((entry) => [entry.label, entry.formatted ?? displayValue(entry.value)]),
+  );
+}
+
+function renderBundle(
+  definition: HeadlessPaneDefinition,
+  result: HeadlessBundleResult,
+): string[] {
+  return result.sections.flatMap((section, index) => [
+    ...(index > 0 ? [""] : []),
+    renderSection(section.title),
+    "rows" in section && section.rows
+      ? renderRows(section.rows, section.columns, definition.columns)
+      : renderEntries(section.entries),
+  ]);
+}
+
+function renderSeries(result: HeadlessSeriesResult): string[] {
+  const rows = result.series.map((series) => {
+    const latest = [...series.points].reverse().find((point) => (
+      point.value != null || point.close != null
+    ));
+    return {
+      series: series.label,
+      latest: latest ? displayValue(latest.date) : "-",
+      value: latest?.value ?? latest?.close ?? null,
+      points: series.points.length,
+    };
+  });
+  const columns: HeadlessPaneColumn[] = [
+    { key: "series", header: "Series" },
+    { key: "latest", header: "Latest" },
+    { key: "value", header: "Value", align: "right" },
+    { key: "points", header: "Points", align: "right" },
+  ];
+  const lines = [renderRows(rows, columns, undefined)];
+  if (result.stats) {
+    const entries = Array.isArray(result.stats)
+      ? result.stats
+      : Object.entries(result.stats).map(([label, value]) => ({ label, value }));
+    lines.push("", renderSection("Statistics"), renderEntries(entries));
+  }
+  return lines;
+}
+
+function reportTitle(definition: HeadlessPaneDefinition, args: HeadlessPaneLoadArgs, fallback: string): string {
+  if (typeof definition.describe === "function") return definition.describe(args);
+  return definition.describe ?? fallback;
+}
+
+export function renderHeadlessPaneText(
+  definition: HeadlessPaneDefinition,
+  result: HeadlessPaneResult,
+  args: HeadlessPaneLoadArgs,
+  fallbackTitle: string,
+): string {
+  const lines = [reportTitle(definition, args, fallbackTitle), ""];
+  switch (definition.shape) {
+    case "rows": {
+      const rowsResult = result as HeadlessPaneResult & { rows: HeadlessPaneRow[]; columns?: HeadlessPaneColumn[] };
+      lines.push(renderRows(rowsResult.rows, rowsResult.columns, definition.columns));
+      break;
+    }
+    case "bundle":
+      lines.push(...renderBundle(definition, result as HeadlessBundleResult));
+      break;
+    case "series":
+      lines.push(...renderSeries(result as HeadlessSeriesResult));
+      break;
+    case "snapshot": {
+      const snapshot = result as HeadlessSnapshotResult;
+      lines.push(`As of: ${displayValue(snapshot.asOf)}`, "", renderRows(snapshot.items, undefined, definition.columns));
+      break;
+    }
+    default: {
+      const _exhaustive: never = definition.shape;
+      return _exhaustive;
+    }
+  }
+  if (result.errors?.length) lines.push("", `Errors: ${result.errors.join(" ")}`);
+  return lines.join("\n").trimEnd();
+}
+
+function resultRowCount(definition: HeadlessPaneDefinition, result: HeadlessPaneResult): number {
+  switch (definition.shape) {
+    case "rows":
+      return (result as { rows: HeadlessPaneRow[] }).rows.length;
+    case "bundle":
+      return (result as HeadlessBundleResult).sections.reduce((count, section) => (
+        count + ("rows" in section && section.rows ? section.rows.length : section.entries.length)
+      ), 0);
+    case "series":
+      return (result as HeadlessSeriesResult).series.reduce((count, series) => count + series.points.length, 0);
+    case "snapshot":
+      return (result as HeadlessSnapshotResult).items.length;
+    default: {
+      const _exhaustive: never = definition.shape;
+      return _exhaustive;
+    }
+  }
+}
+
+export async function buildHeadlessFunctionReport(
+  resolved: ResolvedPaneFunction,
+  context: MarketContext,
+  rawArgument: string,
+): Promise<PaneFunctionReport> {
+  const loaded = await loadResolvedHeadlessPaneModel(resolved, context, rawArgument);
+  const rowCount = resultRowCount(loaded.definition, loaded.result);
+  const unavailableSymbols = rowCount === 0 ? loaded.args.symbols : [];
+  const serialized = serializeHeadlessPaneResult(loaded.definition, loaded.result);
+  return {
+    data: {
+      kind: loaded.definition.shape,
+      target: resolved.token,
+      capabilityId: resolved.capability.id,
+      symbols: loaded.args.symbols,
+      options: resolved.options,
+      rowCount,
+      empty: rowCount === 0,
+      complete: unavailableSymbols.length === 0 && !loaded.result.errors?.length,
+      unavailableSymbols,
+      ...serialized,
+    },
+    text: renderHeadlessPaneText(
+      loaded.definition,
+      loaded.result,
+      loaded.args,
+      resolved.label,
+    ),
+  };
+}

--- a/src/cli/pane-functions/index.ts
+++ b/src/cli/pane-functions/index.ts
@@ -37,12 +37,13 @@ async function withPaneRuntime<T>(
     registry: PaneFunctionCatalog;
     resolved: ResolvedPaneFunction;
   }) => Promise<T>,
+  settings: { strictHeadlessOptions?: boolean } = {},
 ): Promise<T> {
   const parsed = parsePaneFunctionArgs(args);
   return withMarketData(ctx, async (context) => {
     const registry = await createPaneCatalog(context, ctx.plugins);
     try {
-      const resolved = await resolvePaneFunction(registry, context, parsed);
+      const resolved = await resolvePaneFunction(registry, context, parsed, settings);
       return await run({ parsed, context, registry, resolved });
     } finally {
       registry.destroy();
@@ -73,7 +74,7 @@ export async function runPaneFunction(args: string[], ctx: CliCommandContext) {
       ctx.printResult({ data: report.data }, {
         text: () => report.text,
       });
-    });
+    }, { strictHeadlessOptions: true });
   });
 }
 

--- a/src/cli/pane-functions/report.ts
+++ b/src/cli/pane-functions/report.ts
@@ -44,6 +44,7 @@ import {
   withShotPriceHistory,
 } from "./data";
 import type { ResolvedPaneFunction } from "./resolver";
+import { buildHeadlessFunctionReport } from "./headless";
 
 export interface PaneFunctionReportData {
   kind: string;
@@ -750,6 +751,9 @@ export async function buildFunctionReport(
   context: MarketContext,
   rawArg: string,
 ): Promise<PaneFunctionReport> {
+  if (resolved.headless) {
+    return buildHeadlessFunctionReport(resolved, context, rawArg);
+  }
   if (isFinancialAnalysisFunction(resolved)) {
     return buildFinancialStatementReport(resolved, context, rawArg);
   }

--- a/src/cli/pane-functions/resolver.ts
+++ b/src/cli/pane-functions/resolver.ts
@@ -1,6 +1,11 @@
 import type { PaneInstanceConfig } from "../../types/config";
 import { CHART_COMPOSER_PANE_ID } from "../../types/config";
-import type { PaneDef, PaneTemplateCreateOptions, PaneTemplateDef } from "../../types/plugin";
+import type {
+  HeadlessPaneDefinition,
+  PaneDef,
+  PaneTemplateCreateOptions,
+  PaneTemplateDef,
+} from "../../types/plugin";
 import { applyChartComposerCapabilityOptions } from "../../plugins/builtin/chart-composer/cli-options";
 import { parseChartSpec } from "../../plugins/builtin/chart-composer/chart-spec";
 import { normalizeTickerInput } from "../../tickers/search";
@@ -20,6 +25,7 @@ import {
 } from "./options";
 import {
   capabilityPaneSettings,
+  getHeadlessPaneDefinition,
   getPaneFunctionCapability,
   normalizeCapabilityOptions,
   type NormalizedPaneFunctionOptions,
@@ -33,6 +39,7 @@ export interface ResolvedPaneFunction {
   shortcut?: string;
   pane: PaneDef;
   template?: PaneTemplateDef;
+  headless?: HeadlessPaneDefinition;
   instance: PaneInstanceConfig;
   createOptions: PaneTemplateCreateOptions | undefined;
   optionSettings: Record<string, unknown>;
@@ -41,16 +48,24 @@ export interface ResolvedPaneFunction {
 }
 
 async function buildPaneInstance(
-  resolved: Pick<ResolvedPaneFunction, "pane" | "template" | "createOptions" | "optionSettings" | "capability" | "options">,
+  resolved: Pick<ResolvedPaneFunction, "pane" | "template" | "headless" | "createOptions" | "optionSettings" | "capability" | "options">,
   context: MarketContext,
   target: string,
 ): Promise<PaneInstanceConfig> {
-  // A text argument is a phrase, not a symbol: uppercasing it and binding it as
-  // a ticker makes the pane look for a provider for "HIGH GROWTH SOFTWARE".
-  const argKind = resolved.template?.shortcut?.argKind;
+  // Free text is a phrase, not a symbol. Treating it as a ticker makes the
+  // pane look for a provider for values such as "HIGH GROWTH SOFTWARE".
+  const shortcutArgKind = resolved.template?.shortcut?.argKind;
+  const headlessArgKind = resolved.headless?.argument.kind;
+  const fallbackSymbol = headlessArgKind === "free-text" || headlessArgKind === "none"
+    ? null
+    : headlessArgKind === "tickers" || headlessArgKind === "symbol-list"
+      ? normalizeTickerInput(null, cleanTickerInput(target.split(/[,\n]/)[0] ?? ""))
+      : shortcutArgKind === "text"
+        ? null
+        : normalizeTickerInput(null, cleanTickerInput(target));
   const primarySymbol = resolved.createOptions?.symbol
     ?? resolved.createOptions?.symbols?.[0]
-    ?? (argKind === "text" ? null : normalizeTickerInput(null, cleanTickerInput(target)));
+    ?? fallbackSymbol;
   const templateContext = buildTemplateContext(context, primarySymbol ?? null);
   const spec = await resolved.template?.createInstance?.(templateContext, resolved.createOptions) ?? {};
   const instanceId = `${resolved.pane.id}:cli-${slugifyName(target || resolved.pane.id, "pane")}`;
@@ -83,6 +98,7 @@ export async function resolvePaneFunction(
   registry: PaneFunctionCatalog,
   context: MarketContext,
   args: ParsedPaneFunctionArgs,
+  resolutionSettings: { strictHeadlessOptions?: boolean } = {},
 ): Promise<ResolvedPaneFunction> {
   if (!args.target) {
     throw new Error("Usage: gloomberb fn <function-or-pane> [argument] [--key value]");
@@ -106,9 +122,10 @@ export async function resolvePaneFunction(
     throw new Error(`Template "${template?.id}" points at missing pane "${template?.paneId}".`);
   }
   const createOptions = buildCreateOptions(template, args.arg);
+  const headless = getHeadlessPaneDefinition(template, pane);
   const capability = getPaneFunctionCapability(template, pane);
   const normalizedOptions = normalizeCapabilityOptions(capability, args.options, {
-    strict: args.requireBotSafe,
+    strict: args.requireBotSafe || (!!headless && resolutionSettings.strictHeadlessOptions === true),
   });
   const settings = capability.botSafe
     ? {
@@ -126,6 +143,7 @@ export async function resolvePaneFunction(
     shortcut: template?.shortcut?.prefix,
     pane,
     template,
+    ...(headless ? { headless } : {}),
     instance: {} as PaneInstanceConfig,
     createOptions,
     optionSettings: settings,

--- a/src/plugins/builtin/econ-statistics/client.ts
+++ b/src/plugins/builtin/econ-statistics/client.ts
@@ -20,16 +20,20 @@ export interface StatsBundle {
   fetchedAt: number;
 }
 
-const cloudLoader: StatSeriesLoader = async (def) => {
-  const data = await apiClient.getCloudFredSeries(def.seriesId, {
-    limit: def.limit,
-    sortOrder: "desc",
-  });
-  return data.observations;
-};
+export type StatsCloudClient = Pick<typeof apiClient, "getCloudFredSeries">;
 
-export const defaultStatLoader: StatSeriesLoader = (def) =>
-  statsCache.load(def.seriesId, () => cloudLoader(def));
+export function createStatSeriesLoader(client: StatsCloudClient): StatSeriesLoader {
+  const cloudLoader: StatSeriesLoader = async (def) => {
+    const data = await client.getCloudFredSeries(def.seriesId, {
+      limit: def.limit,
+      sortOrder: "desc",
+    });
+    return data.observations;
+  };
+  return (def) => statsCache.load(def.seriesId, () => cloudLoader(def));
+}
+
+export const defaultStatLoader = createStatSeriesLoader(apiClient);
 
 function build(def: StatDef, observations: DatedObservation[]): StatBuild | null {
   const scale = def.scale ?? 1;

--- a/src/plugins/builtin/econ-statistics/headless.test.ts
+++ b/src/plugins/builtin/econ-statistics/headless.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { createDefaultConfig } from "../../../types/config";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { statsCache } from "./cache";
+import { econStatisticsHeadless } from "./headless";
+
+beforeEach(() => statsCache.reset());
+afterEach(() => statsCache.reset());
+
+function monthlyCpi() {
+  return Array.from({ length: 25 }, (_, index) => {
+    const year = 2024 + Math.floor(index / 12);
+    const month = (index % 12) + 1;
+    return {
+      date: `${year}-${String(month).padStart(2, "0")}-01`,
+      value: 300 + index,
+    };
+  });
+}
+
+const args: HeadlessPaneLoadArgs = {
+  rawArgument: "cpi",
+  argument: "cpi",
+  symbols: [],
+  options: { range: "5Y" },
+};
+
+describe("economic statistics headless model", () => {
+  test("loads through the injected cloud client and produces category sections", async () => {
+    const requested: string[] = [];
+    const apiClient = {
+      getCloudFredSeries: async (seriesId: string) => {
+        requested.push(seriesId);
+        return { seriesId, observations: monthlyCpi() };
+      },
+    } as unknown as HeadlessPaneContext["apiClient"];
+    const context: HeadlessPaneContext = {
+      marketData: createTestDataProvider(),
+      apiClient,
+      config: createDefaultConfig("/tmp/gloomberb-headless-econ"),
+      signal: new AbortController().signal,
+    };
+
+    const result = await econStatisticsHeadless.load(args, context);
+
+    expect(requested).toEqual(["CPIAUCSL"]);
+    expect(result.sections.map(({ title }) => title)).toEqual(["Inflation", "CPI"]);
+    expect(result.sections[0]).toMatchObject({
+      rows: [{ id: "cpi-yoy", indicator: "CPI y/y" }],
+    });
+    expect(result.metadata).toMatchObject({ range: "5Y", selected: "cpi-yoy" });
+  });
+});

--- a/src/plugins/builtin/econ-statistics/headless.ts
+++ b/src/plugins/builtin/econ-statistics/headless.ts
@@ -1,0 +1,171 @@
+import type {
+  HeadlessBundleResult,
+  HeadlessPaneDefinition,
+  HeadlessPaneEntry,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import { formatNumber } from "../../../utils/format";
+import {
+  createStatSeriesLoader,
+  loadStatsBundle,
+  type StatSeriesLoader,
+  type StatsBundle,
+} from "./client";
+import { STAT_CATEGORIES } from "./defs";
+import { DEFAULT_STAT_ID, resolveStatArg, STATS } from "./stats";
+import { selectStatViews, type StatRangeId, type StatViewModel } from "./view";
+
+function signedSigma(value: number): string {
+  return `${value > 0 ? "+" : ""}${formatNumber(value, 1)}σ`;
+}
+
+function detailEntries(view: StatViewModel): HeadlessPaneEntry[] {
+  const format = view.stat.formatValue;
+  return [
+    { label: "Latest", value: view.latest.value, formatted: format(view.latest.value) },
+    {
+      label: "Previous",
+      value: view.previous?.value ?? null,
+      formatted: view.previous ? format(view.previous.value) : "-",
+    },
+    {
+      label: "1Y ago",
+      value: view.yearAgo?.value ?? null,
+      formatted: view.yearAgo ? format(view.yearAgo.value) : "-",
+    },
+    { label: "Mean", value: view.mean, formatted: format(view.mean) },
+    {
+      label: "Historical percentile",
+      value: view.percentile,
+      formatted: formatNumber(view.percentile, 0),
+    },
+    {
+      label: "Trend deviation",
+      value: view.sigmaVsTrend,
+      formatted: signedSigma(view.sigmaVsTrend),
+    },
+    {
+      label: "High",
+      value: view.high,
+      formatted: `${format(view.high.value)} ${view.high.date}`,
+    },
+    {
+      label: "Low",
+      value: view.low,
+      formatted: `${format(view.low.value)} ${view.low.date}`,
+    },
+    { label: "As of", value: view.latest.date },
+    { label: "Source", value: `FRED ${view.stat.seriesId}` },
+  ];
+}
+
+export function projectStatsHeadlessBundle(
+  bundle: StatsBundle,
+  range: StatRangeId,
+  selectedId: string,
+): HeadlessBundleResult {
+  const views = selectStatViews(bundle.builds, range);
+  const selected = views.find((view) => view.stat.id === selectedId) ?? views[0] ?? null;
+  const sections = STAT_CATEGORIES.flatMap((category) => {
+    const categoryViews = views.filter((view) => view.stat.category === category.id);
+    if (categoryViews.length === 0) return [];
+    return [{
+      title: category.label,
+      columns: [
+        { key: "indicator", header: "Indicator" },
+        {
+          key: "latest",
+          header: "Latest",
+          align: "right" as const,
+          format: (_value: unknown, row: Record<string, unknown>) => String(row.formattedLatest),
+        },
+        {
+          key: "previous",
+          header: "Previous",
+          align: "right" as const,
+          format: (_value: unknown, row: Record<string, unknown>) => String(row.formattedPrevious),
+        },
+        {
+          key: "percentile",
+          header: "%ile",
+          align: "right" as const,
+          format: (value: unknown) => formatNumber(Number(value), 0),
+        },
+        { key: "asOf", header: "As of" },
+      ],
+      rows: categoryViews.map((view) => ({
+        id: view.stat.id,
+        indicator: view.stat.shortLabel,
+        latest: view.latest.value,
+        formattedLatest: view.stat.formatValue(view.latest.value),
+        previous: view.previous?.value ?? null,
+        formattedPrevious: view.previous ? view.stat.formatValue(view.previous.value) : "-",
+        percentile: view.percentile,
+        asOf: view.latest.date,
+        stale: view.observationStale,
+      })),
+    }];
+  });
+
+  return {
+    sections: [
+      ...sections,
+      ...(selected ? [{ title: selected.stat.label, entries: detailEntries(selected) }] : []),
+    ],
+    errors: bundle.errors,
+    metadata: {
+      fetchedAt: bundle.fetchedAt,
+      range,
+      selected: selected?.stat.id ?? null,
+    },
+  };
+}
+
+export interface EconStatisticsHeadlessDependencies {
+  loadBundle(args: HeadlessPaneLoadArgs, loader: StatSeriesLoader): Promise<StatsBundle>;
+}
+
+const defaultDependencies: EconStatisticsHeadlessDependencies = {
+  loadBundle: (args, loader) => {
+    const requested = typeof args.argument === "string" ? resolveStatArg(args.argument) : null;
+    return loadStatsBundle({
+      loader,
+      ...(requested ? { stats: [requested] } : {}),
+    });
+  },
+};
+
+export function createEconStatisticsHeadless(
+  dependencies: EconStatisticsHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"bundle"> {
+  return {
+    shape: "bundle",
+    argument: {
+      kind: "free-text",
+      placeholder: "statistic",
+      description: "Optional statistic id, FRED series id, label, or prefix.",
+      optional: true,
+    },
+    options: [{
+      key: "range",
+      description: "History window used by the selected statistic view.",
+      type: "enum",
+      values: [{ value: "5Y" }, { value: "20Y" }, { value: "ALL", aliases: ["all"] }],
+      defaultValue: "20Y",
+    }],
+    describe: (args) => `Economic Statistics | ${String(args.options.range)}`,
+    async load(args, ctx) {
+      const requested = typeof args.argument === "string" ? resolveStatArg(args.argument) : null;
+      if (args.argument && !requested) {
+        throw new Error(
+          `Unknown economic statistic "${String(args.argument)}". Use one of: ${STATS.map(({ id }) => id).join(", ")}.`,
+        );
+      }
+      const range = args.options.range as StatRangeId;
+      const bundle = await dependencies.loadBundle(args, createStatSeriesLoader(ctx.apiClient));
+      return projectStatsHeadlessBundle(bundle, range, requested?.id ?? DEFAULT_STAT_ID);
+    },
+  };
+}
+
+export const econStatisticsHeadless = createEconStatisticsHeadless();

--- a/src/plugins/builtin/econ-statistics/index.tsx
+++ b/src/plugins/builtin/econ-statistics/index.tsx
@@ -1,8 +1,11 @@
 import type { PluginModule } from "../plugin-module";
 import { statsCache } from "./cache";
 import { STAT_CATEGORIES } from "./defs";
+import { econStatisticsHeadless } from "./headless";
 import { EconStatisticsPane } from "./pane";
 import { resolveStatArg, STATS, DEFAULT_STAT_ID } from "./stats";
+
+export { econStatisticsHeadless } from "./headless";
 
 const ECON_STATISTICS_PANE_ID = "econ-statistics";
 
@@ -36,6 +39,7 @@ export const econStatisticsModule: PluginModule = {
       argKind: "text",
       argOptional: true,
     },
+    headless: econStatisticsHeadless,
     canCreate: () => true,
     createInstance: (_context, options) => ({
       settings: { stat: resolveStatArg(options?.arg)?.id ?? DEFAULT_STAT_ID },

--- a/src/plugins/builtin/market-valuation/client.ts
+++ b/src/plugins/builtin/market-valuation/client.ts
@@ -3,7 +3,12 @@ import { getCachedSeries, loadCachedSeries } from "./cache";
 import { indicatorSeries, type IndicatorDef, type SeriesDef } from "./defs";
 import { INDICATORS } from "./indicators";
 import type { DatedSeries } from "./series";
-import { cloudSourceDeps, createSourceLoader, provenanceFor } from "./sources";
+import {
+  cloudSourceDeps,
+  createSourceLoader,
+  provenanceFor,
+  type ValuationSourceDeps,
+} from "./sources";
 import { fitIndicatorTrend } from "./trend";
 import type { IndicatorBuild, ValuationBundle } from "./view";
 
@@ -22,14 +27,17 @@ export function requiredSeries(
   return [...seen.values()];
 }
 
-const cloudLoader = createSourceLoader(cloudSourceDeps);
-
 /** Cache-first around the cloud sources; exported so Bun-side tooling can reuse it. */
-export const defaultValuationSeriesLoader: ValuationSeriesLoader = async (def) => ({
-  seriesId: def.key,
-  observations: await loadCachedSeries(def.key, async () => (await cloudLoader(def)).observations),
-  provenance: provenanceFor(def),
-});
+export function createValuationSeriesLoader(deps: ValuationSourceDeps): ValuationSeriesLoader {
+  const cloudLoader = createSourceLoader(deps);
+  return async (def) => ({
+    seriesId: def.key,
+    observations: await loadCachedSeries(def.key, async () => (await cloudLoader(def)).observations),
+    provenance: provenanceFor(def),
+  });
+}
+
+export const defaultValuationSeriesLoader = createValuationSeriesLoader(cloudSourceDeps);
 
 /** Builds whatever the on-disk cache can already answer, for an instant first paint. */
 export function getCachedValuationBundle(

--- a/src/plugins/builtin/market-valuation/headless.test.ts
+++ b/src/plugins/builtin/market-valuation/headless.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { createDefaultConfig } from "../../../types/config";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { resetValuationPersistence } from "./cache";
+import { marketValuationHeadless } from "./headless";
+
+beforeEach(resetValuationPersistence);
+afterEach(resetValuationPersistence);
+
+function loadArgs(): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: "cape",
+    argument: "cape",
+    symbols: [],
+    options: { range: "10Y" },
+  };
+}
+
+describe("market valuation headless model", () => {
+  test("loads through the injected cloud client and produces bundle sections", async () => {
+    let shillerCalls = 0;
+    const apiClient = {
+      getCloudFredSeries: async () => { throw new Error("unexpected FRED request"); },
+      getCloudHistory: async () => { throw new Error("unexpected history request"); },
+      getCloudShiller: async () => {
+        shillerCalls += 1;
+        return {
+          observations: [
+            { date: "2024-01-01", price: 4800, dividend: 70, earnings: 180, cpi: 310, longRate: 4, cape: 32, excessCapeYield: 0.02 },
+            { date: "2025-01-01", price: 5900, dividend: 76, earnings: 200, cpi: 320, longRate: 4.2, cape: 36, excessCapeYield: 0.015 },
+            { date: "2026-01-01", price: 6300, dividend: 80, earnings: 220, cpi: 330, longRate: 4.4, cape: 39, excessCapeYield: 0.01 },
+          ],
+          sourceUrl: "https://example.test/shiller.xls",
+          fetchedAt: "2026-01-02T00:00:00Z",
+        };
+      },
+    } as unknown as HeadlessPaneContext["apiClient"];
+    const context: HeadlessPaneContext = {
+      marketData: createTestDataProvider(),
+      apiClient,
+      config: createDefaultConfig("/tmp/gloomberb-headless-valuation"),
+      signal: new AbortController().signal,
+    };
+
+    const result = await marketValuationHeadless.load(loadArgs(), context);
+
+    expect(shillerCalls).toBe(1);
+    expect(result.sections.map(({ title }) => title)).toEqual([
+      "Market valuation",
+      "Shiller CAPE",
+    ]);
+    expect(result.sections[0]).toMatchObject({
+      rows: [{ id: "shiller-cape", value: 39, formattedValue: "39.0" }],
+    });
+    expect(result.metadata).toMatchObject({ range: "10Y", selected: "shiller-cape" });
+  });
+});

--- a/src/plugins/builtin/market-valuation/headless.ts
+++ b/src/plugins/builtin/market-valuation/headless.ts
@@ -1,0 +1,170 @@
+import type {
+  HeadlessBundleResult,
+  HeadlessPaneDefinition,
+  HeadlessPaneEntry,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import { formatNumber } from "../../../utils/format";
+import {
+  createValuationSeriesLoader,
+  loadValuationBundle,
+  type ValuationSeriesLoader,
+} from "./client";
+import type { ValuationRangeId } from "./defs";
+import { DEFAULT_INDICATOR_ID, INDICATORS, resolveIndicatorArg } from "./indicators";
+import { createCloudSourceDeps } from "./sources";
+import {
+  formatSigma,
+  selectValuationViews,
+  type IndicatorViewModel,
+  type ValuationBundle,
+} from "./view";
+
+function detailEntries(view: IndicatorViewModel): HeadlessPaneEntry[] {
+  const format = view.indicator.formatValue;
+  return [
+    { label: "Current", value: view.current.ratio, formatted: format(view.current.ratio) },
+    {
+      label: "1Y ago",
+      value: view.ratioOneYearAgo,
+      formatted: view.ratioOneYearAgo == null ? "-" : format(view.ratioOneYearAgo),
+    },
+    { label: "Mean", value: view.mean, formatted: format(view.mean) },
+    {
+      label: "Rich percentile",
+      value: view.richPercentile,
+      formatted: formatNumber(view.richPercentile, 0),
+    },
+    {
+      label: "Trend deviation",
+      value: view.richSigma,
+      formatted: formatSigma(view.richSigma),
+    },
+    {
+      label: "All-time high",
+      value: { value: view.allTimeHigh.ratio, date: view.allTimeHigh.date },
+      formatted: `${format(view.allTimeHigh.ratio)} ${view.allTimeHigh.date}`,
+    },
+    {
+      label: "All-time low",
+      value: { value: view.allTimeLow.ratio, date: view.allTimeLow.date },
+      formatted: `${format(view.allTimeLow.ratio)} ${view.allTimeLow.date}`,
+    },
+    { label: "As of", value: view.asOf },
+  ];
+}
+
+export function projectValuationHeadlessBundle(
+  bundle: ValuationBundle,
+  range: ValuationRangeId,
+  selectedId: string,
+): HeadlessBundleResult {
+  const views = selectValuationViews(bundle, range);
+  const selected = views.find((view) => view.indicator.id === selectedId) ?? views[0] ?? null;
+  const rows = views.map((view) => ({
+    id: view.indicator.id,
+    indicator: view.indicator.label,
+    value: view.current.ratio,
+    formattedValue: view.indicator.formatValue(view.current.ratio),
+    zone: view.zone.label,
+    richPercentile: view.richPercentile,
+    richSigma: view.richSigma,
+    asOf: view.asOf,
+    stale: view.observationStale,
+  }));
+
+  return {
+    sections: [
+      {
+        title: "Market valuation",
+        columns: [
+          { key: "indicator", header: "Indicator" },
+          {
+            key: "value",
+            header: "Value",
+            align: "right",
+            format: (_value, row) => String(row.formattedValue),
+          },
+          { key: "zone", header: "Zone" },
+          {
+            key: "richPercentile",
+            header: "Rich %ile",
+            align: "right",
+            format: (value) => formatNumber(Number(value), 0),
+          },
+          {
+            key: "richSigma",
+            header: "Trend",
+            align: "right",
+            format: (value) => formatSigma(Number(value)),
+          },
+          { key: "asOf", header: "As of" },
+        ],
+        rows,
+      },
+      ...(selected
+        ? [{ title: selected.indicator.label, entries: detailEntries(selected) }]
+        : []),
+    ],
+    errors: bundle.errors,
+    metadata: {
+      fetchedAt: bundle.fetchedAt,
+      range,
+      selected: selected?.indicator.id ?? null,
+    },
+  };
+}
+
+export interface MarketValuationHeadlessDependencies {
+  loadBundle(args: HeadlessPaneLoadArgs, loader: ValuationSeriesLoader): Promise<ValuationBundle>;
+}
+
+const defaultDependencies: MarketValuationHeadlessDependencies = {
+  loadBundle: (args, loader) => {
+    const requested = typeof args.argument === "string" ? resolveIndicatorArg(args.argument) : null;
+    return loadValuationBundle({
+      loader,
+      ...(requested ? { indicators: [requested] } : {}),
+    });
+  },
+};
+
+export function createMarketValuationHeadless(
+  dependencies: MarketValuationHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"bundle"> {
+  return {
+    shape: "bundle",
+    argument: {
+      kind: "free-text",
+      placeholder: "indicator",
+      description: "Optional valuation indicator id, label, or prefix.",
+      optional: true,
+    },
+    options: [{
+      key: "range",
+      description: "History window used by the selected indicator view.",
+      type: "enum",
+      values: [{ value: "10Y" }, { value: "25Y" }, { value: "ALL", aliases: ["all"] }],
+      defaultValue: "25Y",
+    }],
+    describe: (args) => `Market Valuation | ${String(args.options.range)}`,
+    async load(args, ctx) {
+      const requested = typeof args.argument === "string" ? resolveIndicatorArg(args.argument) : null;
+      if (args.argument && !requested) {
+        throw new Error(
+          `Unknown valuation indicator "${String(args.argument)}". Use one of: ${INDICATORS.map(({ id }) => id).join(", ")}.`,
+        );
+      }
+      const range = args.options.range as ValuationRangeId;
+      const loader = createValuationSeriesLoader(createCloudSourceDeps(ctx.apiClient));
+      const bundle = await dependencies.loadBundle(args, loader);
+      return projectValuationHeadlessBundle(
+        bundle,
+        range,
+        requested?.id ?? DEFAULT_INDICATOR_ID,
+      );
+    },
+  };
+}
+
+export const marketValuationHeadless = createMarketValuationHeadless();

--- a/src/plugins/builtin/market-valuation/index.tsx
+++ b/src/plugins/builtin/market-valuation/index.tsx
@@ -1,8 +1,11 @@
 import type { PluginModule } from "../plugin-module";
 import { createValuationChartSeriesCapability } from "./chart-series";
 import { INDICATORS, resolveIndicatorArg } from "./indicators";
+import { marketValuationHeadless } from "./headless";
 import { MarketValuationPane } from "./pane";
 import { buildValuationSettingsDef, VALUATION_DEFAULTS } from "./settings";
+
+export { marketValuationHeadless } from "./headless";
 
 const MARKET_VALUATION_PANE_ID = "market-valuation";
 
@@ -47,6 +50,7 @@ export const marketValuationModule: PluginModule = {
       argKind: "text",
       argOptional: true,
     },
+    headless: marketValuationHeadless,
     // No wizard: VAL opens straight into the pane, where the summary rows swap
     // indicators with the cursor. The argument form stays for deep links.
     canCreate: () => true,

--- a/src/plugins/builtin/market-valuation/pane.tsx
+++ b/src/plugins/builtin/market-valuation/pane.tsx
@@ -25,7 +25,12 @@ import { getCachedValuationBundle, loadValuationBundle } from "./client";
 import { shortZoneLabel, type ValuationRangeId } from "./defs";
 import { IndicatorDetail } from "./detail";
 import { RANGE_OPTIONS, VALUATION_DEFAULTS } from "./settings";
-import { selectValuationViews, type IndicatorViewModel, type ValuationBundle } from "./view";
+import {
+  formatSigma,
+  selectValuationViews,
+  type IndicatorViewModel,
+  type ValuationBundle,
+} from "./view";
 
 /** Below this the detail sits under the table instead of beside it. */
 const SPLIT_MIN_WIDTH = 108;
@@ -59,10 +64,6 @@ function bundleOf(state: LoadState): ValuationBundle | null {
 function initialLoadState(): LoadState {
   const cached = getCachedValuationBundle();
   return cached ? { status: "ready", bundle: cached } : { status: "idle" };
-}
-
-function formatSigma(sigma: number): string {
-  return `${sigma > 0 ? "+" : ""}${formatNumber(sigma, 1)}σ`;
 }
 
 function matchesQuery(view: IndicatorViewModel, query: string): boolean {

--- a/src/plugins/builtin/market-valuation/sources.ts
+++ b/src/plugins/builtin/market-valuation/sources.ts
@@ -105,17 +105,26 @@ export function createSourceLoader(deps: ValuationSourceDeps) {
   };
 }
 
-export const cloudSourceDeps: ValuationSourceDeps = {
-  loadFred: async (seriesId, limit) => {
-    const data = await apiClient.getCloudFredSeries(seriesId, { limit, sortOrder: "desc" });
-    return data.observations;
-  },
-  loadMarketHistory: async (symbol, exchange, startDate) => {
-    const response = await apiClient.getCloudHistory(symbol, exchange, {
-      interval: "1d",
-      startDate,
-    });
-    return historyToObservations(response.data ?? []);
-  },
-  loadShiller: () => apiClient.getCloudShiller(),
-};
+export type ValuationCloudClient = Pick<
+  typeof apiClient,
+  "getCloudFredSeries" | "getCloudHistory" | "getCloudShiller"
+>;
+
+export function createCloudSourceDeps(client: ValuationCloudClient): ValuationSourceDeps {
+  return {
+    loadFred: async (seriesId, limit) => {
+      const data = await client.getCloudFredSeries(seriesId, { limit, sortOrder: "desc" });
+      return data.observations;
+    },
+    loadMarketHistory: async (symbol, exchange, startDate) => {
+      const response = await client.getCloudHistory(symbol, exchange, {
+        interval: "1d",
+        startDate,
+      });
+      return historyToObservations(response.data ?? []);
+    },
+    loadShiller: () => client.getCloudShiller(),
+  };
+}
+
+export const cloudSourceDeps: ValuationSourceDeps = createCloudSourceDeps(apiClient);

--- a/src/plugins/builtin/market-valuation/view.ts
+++ b/src/plugins/builtin/market-valuation/view.ts
@@ -9,6 +9,7 @@ import {
   type ZoneHit,
 } from "./defs";
 import { sigmaVsTrend, trendAt, type TrendFit } from "./trend";
+import { formatNumber } from "../../../utils/format";
 
 const MS_PER_DAY = 86_400_000;
 
@@ -27,6 +28,10 @@ export interface ValuationBundle {
   builds: IndicatorBuild[];
   errors: string[];
   fetchedAt: number;
+}
+
+export function formatSigma(sigma: number): string {
+  return `${sigma > 0 ? "+" : ""}${formatNumber(sigma, 1)}σ`;
 }
 
 export interface IndicatorViewModel {

--- a/src/types/headless.ts
+++ b/src/types/headless.ts
@@ -1,0 +1,161 @@
+import type { AppConfig } from "./config";
+import type { DataProvider } from "./data-provider";
+
+type GloomApiClientInstance = typeof import("../api-client").apiClient;
+
+/** Public methods of the shared cloud client, expressed structurally for alternate executors. */
+export type HeadlessPaneApiClient = Pick<GloomApiClientInstance, keyof GloomApiClientInstance>;
+
+export type HeadlessPaneShape = "rows" | "bundle" | "series" | "snapshot";
+export type HeadlessPaneArgumentKind =
+  | "none"
+  | "ticker"
+  | "tickers"
+  | "symbol-list"
+  | "free-text";
+export type HeadlessPaneOptionType = "enum" | "integer" | "string" | "boolean";
+export type HeadlessPaneOptionValues = Record<string, string | number | boolean>;
+
+export interface HeadlessPaneArgumentDef {
+  kind: HeadlessPaneArgumentKind;
+  placeholder?: string;
+  description?: string;
+  optional?: boolean;
+  /** Minimum item count for ticker and symbol list arguments. */
+  minimum?: number;
+  /** Maximum item count for ticker and symbol list arguments. */
+  maximum?: number;
+}
+
+export interface HeadlessPaneOptionValue {
+  value: string;
+  aliases?: string[];
+}
+
+/**
+ * Declarative option schema shared by headless panes and the pane function CLI.
+ * `settingKey` and `pluginState` keep existing screenshot state wiring compatible.
+ */
+export interface HeadlessPaneOptionDef {
+  key: string;
+  description: string;
+  type: HeadlessPaneOptionType;
+  aliases?: string[];
+  values?: HeadlessPaneOptionValue[];
+  defaultValue?: string | number | boolean;
+  minimum?: number;
+  maximum?: number;
+  settingKey?: string;
+  pluginState?: {
+    pluginId: string;
+    key?: string;
+  };
+}
+
+export interface HeadlessPaneLoadArgs {
+  rawArgument: string;
+  argument: string | string[] | null;
+  symbols: string[];
+  options: HeadlessPaneOptionValues;
+}
+
+export interface HeadlessPaneContext {
+  marketData: DataProvider;
+  apiClient: HeadlessPaneApiClient;
+  config: AppConfig;
+  signal: AbortSignal;
+}
+
+export type HeadlessPaneRow = Record<string, unknown>;
+
+export interface HeadlessPaneColumn {
+  key: string;
+  header: string;
+  align?: "left" | "right" | "center";
+  width?: number;
+  description?: string;
+  format?: (value: unknown, row: HeadlessPaneRow) => string;
+}
+
+export interface HeadlessPaneEntry {
+  key?: string;
+  label: string;
+  value: unknown;
+  /** Human-readable form used by text output while JSON retains `value`. */
+  formatted?: string;
+}
+
+interface HeadlessPaneResultBase {
+  errors?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface HeadlessRowsResult extends HeadlessPaneResultBase {
+  columns?: HeadlessPaneColumn[];
+  rows: HeadlessPaneRow[];
+}
+
+export type HeadlessBundleSection =
+  | {
+    title: string;
+    columns?: HeadlessPaneColumn[];
+    rows: HeadlessPaneRow[];
+    entries?: never;
+  }
+  | {
+    title: string;
+    entries: HeadlessPaneEntry[];
+    columns?: never;
+    rows?: never;
+  };
+
+export interface HeadlessBundleResult extends HeadlessPaneResultBase {
+  sections: HeadlessBundleSection[];
+}
+
+export interface HeadlessSeriesPoint extends HeadlessPaneRow {
+  date: string | number | Date;
+  value?: number | null;
+  open?: number | null;
+  high?: number | null;
+  low?: number | null;
+  close?: number | null;
+  volume?: number | null;
+}
+
+export interface HeadlessSeries {
+  id: string;
+  label: string;
+  points: HeadlessSeriesPoint[];
+}
+
+export interface HeadlessSeriesResult extends HeadlessPaneResultBase {
+  series: HeadlessSeries[];
+  stats?: Record<string, unknown> | HeadlessPaneEntry[];
+}
+
+export interface HeadlessSnapshotResult extends HeadlessPaneResultBase {
+  asOf: string | number | Date;
+  items: HeadlessPaneRow[];
+}
+
+export interface HeadlessPaneResultByShape {
+  rows: HeadlessRowsResult;
+  bundle: HeadlessBundleResult;
+  series: HeadlessSeriesResult;
+  snapshot: HeadlessSnapshotResult;
+}
+
+export interface HeadlessPaneDefinition<Shape extends HeadlessPaneShape = HeadlessPaneShape> {
+  shape: Shape;
+  argument: HeadlessPaneArgumentDef;
+  options: HeadlessPaneOptionDef[];
+  columns?: HeadlessPaneColumn[];
+  describe?: string | ((args: HeadlessPaneLoadArgs) => string);
+  load(
+    args: HeadlessPaneLoadArgs,
+    ctx: HeadlessPaneContext,
+  ): HeadlessPaneResultByShape[Shape] | Promise<HeadlessPaneResultByShape[Shape]>;
+}
+
+export type HeadlessPaneResult = HeadlessPaneResultByShape[HeadlessPaneShape];

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,5 +1,32 @@
 import type { ReactNode } from "react";
 import type { AppTickerRepositoryPort } from "../core/app-service-ports";
+import type { HeadlessPaneDefinition } from "./headless";
+
+export type {
+  HeadlessBundleResult,
+  HeadlessBundleSection,
+  HeadlessPaneApiClient,
+  HeadlessPaneArgumentDef,
+  HeadlessPaneArgumentKind,
+  HeadlessPaneColumn,
+  HeadlessPaneContext,
+  HeadlessPaneDefinition,
+  HeadlessPaneEntry,
+  HeadlessPaneLoadArgs,
+  HeadlessPaneOptionDef,
+  HeadlessPaneOptionType,
+  HeadlessPaneOptionValue,
+  HeadlessPaneOptionValues,
+  HeadlessPaneResult,
+  HeadlessPaneResultByShape,
+  HeadlessPaneRow,
+  HeadlessPaneShape,
+  HeadlessRowsResult,
+  HeadlessSeries,
+  HeadlessSeriesPoint,
+  HeadlessSeriesResult,
+  HeadlessSnapshotResult,
+} from "./headless";
 import type { ConnectionHealthRegistry } from "../core/connection-health";
 import type { PluginEvents } from "../plugins/event-bus";
 import type { PluginLogger } from "../utils/debug-log";
@@ -67,6 +94,8 @@ export interface PaneDef {
   defaultMode?: "docked" | "floating";
   /** Pane publishes its selected symbol as pane-state `cursorSymbol`, so ticker panes can follow it. */
   tickerSource?: boolean;
+  /** Renderer-neutral data model used by CLI functions, automation, and hosted tools. */
+  headless?: HeadlessPaneDefinition;
   /** Add an Excel-compatible CSV action for the pane's single active DataTable. */
   tableExport?: true;
   settings?: PaneSettingsDef | ((context: PaneSettingsContext) => PaneSettingsDef | null);
@@ -233,6 +262,8 @@ export interface PaneTemplateDef {
   description: string;
   keywords?: string[];
   shortcut?: PaneTemplateShortcut;
+  /** Template-specific headless model. Takes precedence over the pane-level model. */
+  headless?: HeadlessPaneDefinition;
   wizard?: WizardStep[];
   canCreate?: (context: PaneTemplateContext, options?: PaneTemplateCreateOptions) => boolean;
   createInstance?: (


### PR DESCRIPTION
## Why

The pane function CLI only had structured reports for 12 hand-maintained capabilities. Data panes outside that map fell back to a pane description or ticker summary, even when the pane already had reusable client and projection code. This duplicated data logic and prevented the catalog from exposing new panes as reliable automation tools.

## What

- Adds a typed `headless` model to pane and pane-template definitions, with template models taking precedence when one pane has multiple contracts.
- Supports `rows`, `bundle`, `series`, and `snapshot` result shapes.
- Adds declarative arguments and options, normalized ticker inputs, strict `fn` option validation, and clear enum errors.
- Adds one generic text and JSON adapter with aligned tables, section headers, raw JSON values, metadata, and completeness fields.
- Derives catalog report readiness, output shape, argument kind, and options from the headless definition.
- Keeps the 12 existing report builders as fallbacks. A headless definition takes precedence when both exist.
- Exports the shared model loader for future screenshot payload reuse without changing the screenshot harness in this PR.
- Migrates VAL and ECST as bundle references using their existing clients and pure view projections.
- Documents the convention and migration checklist in `PLUGINS.md`.

## Sample output

```text
$ gloomberb fn VAL cape --range 10Y
Market Valuation | 10Y

Market valuation
----------------
INDICATOR     VALUE  ZONE                      RICH %ILE  TREND  AS OF
------------  -----  ------------------------  ---------  -----  ----------
Shiller CAPE   40.6  Significantly Overvalued         99  +1.5σ  2026-09-01
```

```text
$ gloomberb fn ECST cpi --range 5Y
Economic Statistics | 5Y

Inflation
------------
INDICATOR  LATEST  PREVIOUS  %ILE  AS OF
---------  ------  --------  ----  ----------
CPI y/y      3.5%      3.7%    64  2026-07-01
```

`gloomberb catalog ECST --json` now includes:

```json
{
  "token": "ECST",
  "argKind": "free-text",
  "capability": {
    "outputKind": "bundle",
    "reportReadiness": "ready",
    "options": [{ "key": "range", "defaultValue": "20Y" }]
  }
}
```

## Verify

- `bun test src/cli/pane-functions src/plugins/builtin/market-valuation src/plugins/builtin/econ-statistics` (91 pass)
- `bunx tsc --noEmit -p tsconfig.opentui.json`
- `bunx tsc --noEmit -p tsconfig.browser.json`
- `bunx tsc --noEmit -p tsconfig.electrobun-view.json`
- Ran `bunx tsc --noEmit -p tsconfig.json`. It still reports 175 existing errors outside the touched files and no errors in touched files.
- Ran VAL and ECST in text and JSON modes, with and without `--range`.
- Confirmed invalid range values list `10Y, 25Y, ALL` or `5Y, 20Y, ALL`.
- Ran catalog in text and JSON modes and confirmed VAL and ECST are ready with range options.
- Ran `gloomberb fn FA AVGO` and `gloomberb fn CMP AVGO,NVDA` to confirm the legacy report paths are unchanged.
