### PR TITLE
Render any cloud-backed pane in shot with a session proxy and DOM evidence

### DIFF
--- a/src/cli/desktop-pane-shot.ts
+++ b/src/cli/desktop-pane-shot.ts
@@ -1,7 +1,6 @@
 import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
-import { join } from "path";
-import { pathToFileURL } from "url";
+import { join, resolve, sep } from "path";
 import type { AppConfig } from "../types/config";
 import type { ResolvedSeries } from "../time-series/types";
 import type { OptionsChain, TickerFinancials } from "../types/financials";
@@ -36,8 +35,32 @@ export interface DesktopPaneShotPayload {
   paneState: Record<string, PaneRuntimeState>;
 }
 
+/** Kept in Bun memory and never serialized into the browser page or CLI result. */
+export interface DesktopPaneShotApiProxy {
+  baseUrl: string;
+  sessionToken: string | null;
+}
+
+export interface DesktopPaneShotRenderedCell {
+  columnId?: string;
+  columnLabel: string;
+  text: string;
+}
+
+export interface DesktopPaneShotRenderedRow {
+  tableIndex: number;
+  rowIndex: number;
+  key?: string;
+  selected: boolean;
+  cells: DesktopPaneShotRenderedCell[];
+}
+
 export interface DesktopPaneShotRenderResult {
   visibleText: string;
+  rows: DesktopPaneShotRenderedRow[];
+  loadingStateDetected: boolean;
+  errorStateDetected: boolean;
+  errorStateMarkers: string[];
   emptyStateDetected: boolean;
   emptyStateMarkers: string[];
   semanticUi: RemoteUiNodeSnapshot[];
@@ -65,23 +88,28 @@ const SHOT_MODE_CSS = [
   + " pointer-events: none; z-index: 1000; }";
 
 const CHROME_POLL_ATTEMPTS = 80;
-const SHOT_READY_TIMEOUT_MS = 10_000;
+const SHOT_READY_TIMEOUT_MS = 45_000;
 const CDP_CALL_TIMEOUT_MS = 10_000;
 const DEFAULT_DEVICE_SCALE_FACTOR = 2;
+const SHOT_API_PROXY_PREFIX = "/__gloom_cli_api__";
+const SESSION_COOKIE_NAMES = ["__Secure-gloomberb.session_token", "gloomberb.session_token"] as const;
 
 export async function renderDesktopPaneScreenshot(
   payload: DesktopPaneShotPayload,
   outputPath: string,
+  apiProxy: DesktopPaneShotApiProxy,
 ): Promise<DesktopPaneShotRenderResult> {
   const tempDir = await mkdtemp(join(tmpdir(), "gloom-pane-shot-"));
+  let server: ReturnType<typeof Bun.serve> | null = null;
   try {
     const outdir = join(tempDir, "assets");
     await mkdir(outdir, { recursive: true });
-    const htmlPath = await buildShotPage(outdir, payload);
+    await buildShotPage(outdir, payload);
+    server = serveShotPage(outdir, apiProxy);
     const chrome = await findChromeExecutable();
     return await capturePageScreenshot({
       chrome,
-      url: pathToFileURL(htmlPath).href,
+      url: new URL("/", server.url).href,
       outputPath,
       widthPx: payload.widthPx,
       heightPx: payload.heightPx,
@@ -89,6 +117,7 @@ export async function renderDesktopPaneScreenshot(
       userDataDir: join(tempDir, "chrome-profile"),
     });
   } finally {
+    server?.stop(true);
     await rm(tempDir, { recursive: true, force: true });
   }
 }
@@ -130,6 +159,116 @@ async function buildShotPage(outdir: string, payload: DesktopPaneShotPayload): P
       });
 `,
   });
+}
+
+function serveShotPage(
+  outdir: string,
+  apiProxy: DesktopPaneShotApiProxy,
+): ReturnType<typeof Bun.serve> {
+  const staticRoot = resolve(outdir);
+  return Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    idleTimeout: 60,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname.startsWith(`${SHOT_API_PROXY_PREFIX}/`)) {
+        return proxyShotApiRequest(request, url, apiProxy);
+      }
+      return serveShotAsset(url, staticRoot);
+    },
+  });
+}
+
+async function serveShotAsset(url: URL, staticRoot: string): Promise<Response> {
+  let pathname: string;
+  try {
+    pathname = decodeURIComponent(url.pathname);
+  } catch {
+    return new Response("Bad request", { status: 400 });
+  }
+  const relativePath = pathname === "/" ? "index.html" : pathname.replace(/^\/+/, "");
+  const filePath = resolve(staticRoot, relativePath);
+  if (filePath !== staticRoot && !filePath.startsWith(`${staticRoot}${sep}`)) {
+    return new Response("Not found", { status: 404 });
+  }
+  const file = Bun.file(filePath);
+  if (!(await file.exists())) return new Response("Not found", { status: 404 });
+  return new Response(file);
+}
+
+async function proxyShotApiRequest(
+  request: Request,
+  requestUrl: URL,
+  apiProxy: DesktopPaneShotApiProxy,
+): Promise<Response> {
+  const baseUrl = new URL(apiProxy.baseUrl);
+  const proxiedPath = requestUrl.pathname.slice(SHOT_API_PROXY_PREFIX.length) || "/";
+  const target = new URL(baseUrl);
+  const basePath = baseUrl.pathname.replace(/\/+$/, "");
+  target.pathname = `${basePath}${proxiedPath.startsWith("/") ? proxiedPath : `/${proxiedPath}`}`;
+  target.search = requestUrl.search;
+  target.hash = "";
+  const headers = new Headers(request.headers);
+  for (const name of [
+    "authorization",
+    "connection",
+    "content-length",
+    "cookie",
+    "host",
+    "origin",
+    "proxy-authorization",
+    "referer",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+  ]) {
+    headers.delete(name);
+  }
+  const browserOwnedHeaders: string[] = [];
+  headers.forEach((_value, name) => {
+    if (name.startsWith("sec-") || name === "accept-encoding") browserOwnedHeaders.push(name);
+  });
+  for (const name of browserOwnedHeaders) headers.delete(name);
+  headers.set("Origin", baseUrl.origin);
+  if (apiProxy.sessionToken) {
+    headers.set(
+      "Cookie",
+      SESSION_COOKIE_NAMES.map((name) => `${name}=${apiProxy.sessionToken}`).join("; "),
+    );
+  }
+
+  try {
+    const response = await fetch(target, {
+      method: request.method,
+      headers,
+      body: request.method === "GET" || request.method === "HEAD" ? undefined : request.body,
+      redirect: "follow",
+    });
+    const responseHeaders = new Headers(response.headers);
+    for (const name of [
+      "access-control-allow-credentials",
+      "access-control-allow-origin",
+      "content-encoding",
+      "content-length",
+      "set-cookie",
+      "transfer-encoding",
+    ]) {
+      responseHeaders.delete(name);
+    }
+    responseHeaders.set("Cache-Control", "no-store");
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    });
+  } catch {
+    return Response.json({ error: "Cloud API request failed." }, { status: 502 });
+  }
 }
 
 async function findChromeExecutable(): Promise<string> {
@@ -223,6 +362,21 @@ async function capturePageScreenshot({
   }
 }
 
+const LOADING_STATE_PATTERNS = [
+  /\bLoading(?: [^.]{0,80})?\.{3}/gi,
+  /\bRendering pane\.{3}/gi,
+];
+
+const ERROR_STATE_PATTERNS = [
+  /\b[^.]{1,100} unavailable\./gi,
+  /\bFailed to fetch\b/gi,
+  /\bCould not load\b/gi,
+  /\bSign in to\b/gi,
+  /\bVerify your email\b/gi,
+  /\bpart of Gloom Cloud Pro\b/gi,
+  /\bCloud API request failed\b/gi,
+];
+
 const EMPTY_STATE_PATTERNS = [
   /\bNo chart data\b/gi,
   /\bNo graph data\b/gi,
@@ -231,21 +385,94 @@ const EMPTY_STATE_PATTERNS = [
   /\bNo comparison tickers configured\b/gi,
   /\bNo relationship tickers configured\b/gi,
   /\bNo overlapping price history\b/gi,
-  /\bLoading chart\.{0,3}\b/gi,
-  /\bRendering pane\.{0,3}\b/gi,
-  /\bNo tickers selected\b/gi,
-  /\bMarket data unavailable\b/gi,
+  /\bNo tickers? selected\b/gi,
   /\bNo data(?: available)?\b/gi,
+  /\bNothing to show yet\b/gi,
+  /\bNo transcribed calls(?: for [^.]+)? yet\b/gi,
+  /\bNo short interest (?:data|found)\b/gi,
+  /\bNo (?:House PTR |insider )?(?:trades|members|transactions|filings)\b/gi,
 ];
+
+function stateMarkers(text: string, patterns: RegExp[]): string[] {
+  return [...new Set(patterns.flatMap((pattern) => (
+    [...text.matchAll(pattern)].map((match) => match[0])
+  )))];
+}
 
 async function readRenderedPaneState(session: CdpSession): Promise<DesktopPaneShotRenderResult> {
   const result = await session.send("Runtime.evaluate", {
     expression: `(() => {
       const root = document.getElementById("root") || document.body;
+      const semanticUi = window.__GLOOM_CLI_SHOT_SEMANTIC_UI__ || [];
+      const normalize = (value) => String(value || "").replace(/\\s+/g, " ").trim();
+      const isVisible = (element) => {
+        if (!(element instanceof HTMLElement)) return false;
+        const style = getComputedStyle(element);
+        if (style.display === "none" || style.visibility === "hidden" || style.opacity === "0") return false;
+        const rect = element.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0
+          && rect.right > 0 && rect.bottom > 0
+          && rect.left < window.innerWidth && rect.top < window.innerHeight;
+      };
+      const semanticTables = semanticUi.filter((node) => node && node.role === "table");
+      const rows = [];
+      [...root.querySelectorAll('[data-gloom-role="data-table"]')]
+        .filter(isVisible)
+        .forEach((table, tableIndex) => {
+          const tableMetadata = semanticTables[tableIndex] && semanticTables[tableIndex].metadata || {};
+          const semanticColumns = Array.isArray(tableMetadata.columns) ? tableMetadata.columns : [];
+          const semanticRows = Array.isArray(tableMetadata.rows) ? tableMetadata.rows : [];
+          const headers = [...table.querySelectorAll('[data-gloom-role="data-table-header-cell"]')]
+            .map((cell) => normalize(cell.innerText || cell.textContent));
+          const rowElements = [...table.querySelectorAll(
+            '[data-gloom-role="data-table-row"], [data-gloom-role="data-table-section-header"]',
+          )].filter(isVisible);
+          rowElements.forEach((row, rowIndex) => {
+            const cellElements = [...row.querySelectorAll('[data-gloom-role="data-table-cell"]')];
+            const values = cellElements.length > 0 ? cellElements : [row];
+            const semanticRow = semanticRows[rowIndex] || {};
+            const cells = values.map((cell, cellIndex) => {
+              const semanticColumn = semanticColumns[cellIndex] || {};
+              return {
+                ...(typeof semanticColumn.id === "string" ? { columnId: semanticColumn.id } : {}),
+                columnLabel: typeof semanticColumn.label === "string"
+                  ? semanticColumn.label
+                  : headers[cellIndex] || (values.length === 1 ? "Row" : String(cellIndex + 1)),
+                text: normalize(cell.innerText || cell.textContent),
+              };
+            }).filter((cell) => cell.text.length > 0);
+            if (cells.length === 0) return;
+            rows.push({
+              tableIndex,
+              rowIndex,
+              ...(typeof semanticRow.key === "string" ? { key: semanticRow.key } : {}),
+              selected: row.getAttribute("data-selected") === "true" || semanticRow.selected === true,
+              cells,
+            });
+          });
+        });
+      if (rows.length === 0) {
+        [...root.querySelectorAll('[data-gloom-role="desktop-list-row"]')]
+          .filter(isVisible)
+          .forEach((row, rowIndex) => {
+            const text = normalize(row.innerText || row.textContent);
+            if (!text) return;
+            rows.push({
+              tableIndex: 0,
+              rowIndex,
+              selected: row.getAttribute("data-selected") === "true",
+              cells: [{ columnLabel: "Row", text }],
+            });
+          });
+      }
       return {
         visibleText: root.innerText || root.textContent || "",
         error: window.__GLOOM_CLI_SHOT_ERROR__ || "",
-        semanticUi: window.__GLOOM_CLI_SHOT_SEMANTIC_UI__ || [],
+        loadingStateDetected: root.querySelector('[data-gloom-status="loading"]') !== null,
+        errorStateDetected: root.querySelector('[data-gloom-status="error"]') !== null,
+        emptyStateDetected: root.querySelector('[data-gloom-status="empty"]') !== null,
+        rows,
+        semanticUi,
       };
     })()`,
     returnByValue: true,
@@ -254,6 +481,10 @@ async function readRenderedPaneState(session: CdpSession): Promise<DesktopPaneSh
       value?: {
         visibleText?: string;
         error?: string;
+        loadingStateDetected?: boolean;
+        errorStateDetected?: boolean;
+        emptyStateDetected?: boolean;
+        rows?: DesktopPaneShotRenderedRow[];
         semanticUi?: RemoteUiNodeSnapshot[];
       };
     };
@@ -261,12 +492,16 @@ async function readRenderedPaneState(session: CdpSession): Promise<DesktopPaneSh
   const value = result.result?.value;
   if (value?.error) throw new Error(value.error);
   const visibleText = (value?.visibleText ?? "").replace(/\s+/g, " ").trim();
-  const emptyStateMarkers = [...new Set(EMPTY_STATE_PATTERNS.flatMap((pattern) => (
-    [...visibleText.matchAll(pattern)].map((match) => match[0])
-  )))];
+  const loadingStateMarkers = stateMarkers(visibleText, LOADING_STATE_PATTERNS);
+  const errorStateMarkers = stateMarkers(visibleText, ERROR_STATE_PATTERNS);
+  const emptyStateMarkers = stateMarkers(visibleText, EMPTY_STATE_PATTERNS);
   return {
     visibleText,
-    emptyStateDetected: emptyStateMarkers.length > 0,
+    rows: Array.isArray(value?.rows) ? value.rows : [],
+    loadingStateDetected: value?.loadingStateDetected === true || loadingStateMarkers.length > 0,
+    errorStateDetected: value?.errorStateDetected === true || errorStateMarkers.length > 0,
+    errorStateMarkers,
+    emptyStateDetected: value?.emptyStateDetected === true || emptyStateMarkers.length > 0,
     emptyStateMarkers,
     semanticUi: Array.isArray(value?.semanticUi) ? value.semanticUi : [],
   };

--- a/src/cli/pane-functions/capabilities.ts
+++ b/src/cli/pane-functions/capabilities.ts
@@ -10,6 +10,7 @@ import type {
 } from "../../types/plugin";
 
 export type PaneFunctionReadiness = "ready" | "partial" | "unsupported";
+export type PaneFunctionScreenshotReadiness = PaneFunctionReadiness | "live-dom";
 export type PaneFunctionTickerCardinality = "none" | "one" | "one-or-more" | "two-or-more" | "one-or-two";
 export type PaneFunctionOptionType = HeadlessPaneOptionType;
 export type PaneFunctionOptionValue = HeadlessPaneOptionValue;
@@ -24,7 +25,7 @@ export interface PaneFunctionCapability {
   intents: string[];
   outputKind: string;
   reportReadiness: PaneFunctionReadiness;
-  screenshotReadiness: PaneFunctionReadiness;
+  screenshotReadiness: PaneFunctionScreenshotReadiness;
   dataRequirements: string[];
   limitations: string[];
   options: PaneFunctionOptionDef[];
@@ -390,9 +391,11 @@ const UNSUPPORTED_CAPABILITY: PaneFunctionCapability = {
   intents: [],
   outputKind: "pane",
   reportReadiness: "unsupported",
-  screenshotReadiness: "unsupported",
+  screenshotReadiness: "live-dom",
   dataRequirements: [],
-  limitations: ["This UI pane has not been verified as a deterministic CLI or bot capability."],
+  limitations: [
+    "Reports are not verified for automation. Screenshots render live and derive evidence from visible DOM rows.",
+  ],
   options: [],
 };
 

--- a/src/cli/pane-functions/index.test.ts
+++ b/src/cli/pane-functions/index.test.ts
@@ -208,6 +208,15 @@ describe("pane function CLI args", () => {
     });
   });
 
+  test("enables live DOM screenshots without claiming report support for unmapped panes", () => {
+    expect(capabilityFor("new-api-pane")).toMatchObject({
+      id: "unverified-pane",
+      botSafe: false,
+      reportReadiness: "unsupported",
+      screenshotReadiness: "live-dom",
+    });
+  });
+
   test("rejects financial statement options on a price comparison", () => {
     const capability = capabilityFor("comparison-chart-pane");
     expect(() => normalizeCapabilityOptions(capability, {

--- a/src/cli/pane-functions/resolver.ts
+++ b/src/cli/pane-functions/resolver.ts
@@ -150,7 +150,7 @@ export async function resolvePaneFunction(
     capability,
     options: normalizedOptions,
   };
-  resolved.instance = await buildPaneInstance(resolved, context, args.arg || pane.id);
+  resolved.instance = await buildPaneInstance(resolved, context, args.arg);
   return resolved;
 }
 

--- a/src/cli/pane-functions/screenshot.test.ts
+++ b/src/cli/pane-functions/screenshot.test.ts
@@ -3,12 +3,15 @@ import type { RemoteUiNodeSnapshot } from "../../remote/types";
 import {
   chartSeriesEvidenceWithinRange,
   chartEvidenceMismatchesFor,
+  isPaneScreenshotUsable,
   missingActiveTabSelections,
+  resolveDesktopShotApiProxy,
   shotDataEvidenceFor,
   shotExpectedText,
   shotPriceHistoryRange,
   shotSemanticRowCount,
   shotUnavailableSymbols,
+  stripDesktopShotCredentials,
   type PaneScreenshotExpectedChartEvidence,
   type PaneScreenshotExpectedSelection,
 } from "./screenshot";
@@ -17,6 +20,79 @@ import type { DesktopPaneShotPayload } from "../desktop-pane-shot";
 import type { ResolvedPaneFunction } from "./resolver";
 import { buildCustomChartPreset } from "../../plugins/builtin/chart-composer/presets";
 import { CHART_COMPOSER_PANE_ID } from "../../types/config";
+
+describe("pane screenshot rendered readiness", () => {
+  const rendered = {
+    rowCount: 2,
+    loadingStateDetected: false,
+    errorStateDetected: false,
+    emptyStateDetected: false,
+    complete: true,
+    semanticMismatch: false,
+    requiresStructuredDataEvidence: false,
+    hasStructuredDataEvidence: false,
+  };
+
+  test("requires rows without loading, error, or empty states", () => {
+    expect(isPaneScreenshotUsable(rendered)).toBe(true);
+    expect(isPaneScreenshotUsable({ ...rendered, rowCount: 0 })).toBe(false);
+    expect(isPaneScreenshotUsable({ ...rendered, loadingStateDetected: true })).toBe(false);
+    expect(isPaneScreenshotUsable({ ...rendered, errorStateDetected: true })).toBe(false);
+    expect(isPaneScreenshotUsable({ ...rendered, emptyStateDetected: true })).toBe(false);
+  });
+
+  test("preserves mapped capability completeness and evidence checks", () => {
+    expect(isPaneScreenshotUsable({ ...rendered, complete: false })).toBe(false);
+    expect(isPaneScreenshotUsable({ ...rendered, semanticMismatch: true })).toBe(false);
+    expect(isPaneScreenshotUsable({
+      ...rendered,
+      requiresStructuredDataEvidence: true,
+    })).toBe(false);
+    expect(isPaneScreenshotUsable({
+      ...rendered,
+      requiresStructuredDataEvidence: true,
+      hasStructuredDataEvidence: true,
+    })).toBe(true);
+  });
+});
+
+describe("pane screenshot payload credentials", () => {
+  test("keeps the restored session in the proxy and strips credential fields from page data", () => {
+    const sessionToken = "private-shot-session";
+    const proxy = resolveDesktopShotApiProxy({
+      persistence: {
+        pluginState: {
+          get: (_pluginId: string, key: string) => key === "resume:session"
+            ? { value: { sessionToken }, schemaVersion: 1, updatedAt: 1 }
+            : null,
+        },
+      },
+    } as any);
+    const payload = stripDesktopShotCredentials({
+      config: {
+        theme: "tokyo",
+        pluginConfig: {
+          service: { apiKey: "private-api-key", display: "compact" },
+        },
+        brokerInstances: [{ config: { password: "private-password", region: "US" } }],
+      },
+      paneState: {
+        pane: { pluginState: { service: { accessToken: "private-access", tab: "latest" } } },
+      },
+    });
+
+    expect(proxy.sessionToken).toBe(sessionToken);
+    expect(payload).toEqual({
+      config: {
+        theme: "tokyo",
+        pluginConfig: { service: { display: "compact" } },
+        brokerInstances: [{ config: { region: "US" } }],
+      },
+      paneState: { pane: { pluginState: { service: { tab: "latest" } } } },
+    });
+    expect(JSON.stringify(payload)).not.toContain("private-");
+  });
+});
 
 describe("pane screenshot active-state verification", () => {
   const expected: PaneScreenshotExpectedSelection[] = [

--- a/src/cli/pane-functions/screenshot.ts
+++ b/src/cli/pane-functions/screenshot.ts
@@ -1,7 +1,7 @@
 import { dirname, resolve } from "path";
 import { mkdir } from "fs/promises";
 import type { PaneRuntimeState } from "../../core/state/app/state";
-import { CHART_COMPOSER_PANE_ID } from "../../types/config";
+import { CHART_COMPOSER_PANE_ID, type AppConfig } from "../../types/config";
 import type { OptionsChain, PricePoint, TickerFinancials } from "../../types/financials";
 import type { TickerRecord } from "../../types/ticker";
 import { slugifyName } from "../../utils/slugify";
@@ -10,6 +10,7 @@ import { getTheme, getThemeIds } from "../../theme/themes";
 const DEFAULT_SHOT_DEVICE_SCALE_FACTOR = 2;
 import {
   renderDesktopPaneScreenshot,
+  type DesktopPaneShotApiProxy,
   type DesktopPaneShotPayload,
   type DesktopPaneShotRenderResult,
 } from "../desktop-pane-shot";
@@ -51,6 +52,7 @@ import { defaultStatLoader } from "../../plugins/builtin/econ-statistics/client"
 import { STATS } from "../../plugins/builtin/econ-statistics/stats";
 import { publicTickerKey } from "../../utils/exchanges";
 import { apiClient } from "../../api-client";
+import { getCloudApiBaseUrl } from "../../api-client/request";
 import type { FredSeriesCacheEntry } from "../../data/fred-series";
 import type { ResolvedSeries } from "../../time-series/types";
 import { chartSeriesSourceKey, createChartSeriesResolver } from "../../capabilities";
@@ -69,6 +71,85 @@ const DESKTOP_CELL_HEIGHT_PX = 18;
 const OPTIONS_PANE_ID = "options";
 const MARKET_VALUATION_PANE_ID = "market-valuation";
 const ECON_STATISTICS_PANE_ID = "econ-statistics";
+const CLOUD_PLUGIN_ID = "gloomberb-cloud";
+const CLOUD_SESSION_KEYS = ["resume:session", "session"] as const;
+const CREDENTIAL_FIELD_NAMES = new Set([
+  "accesstoken",
+  "accessurl",
+  "apikey",
+  "apisecret",
+  "authorization",
+  "cookie",
+  "credentials",
+  "oauth",
+  "passphrase",
+  "password",
+  "privatekey",
+  "refreshtoken",
+  "secret",
+  "sessiontoken",
+  "token",
+]);
+
+interface PersistedShotCloudSession {
+  sessionToken?: unknown;
+}
+
+/**
+ * The proxy receives the desktop session out of band. Keeping this separate
+ * from DesktopPaneShotPayload prevents the token from entering the page,
+ * semantic evidence, or JSON CLI output.
+ */
+function isCredentialField(key: string): boolean {
+  const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+  return CREDENTIAL_FIELD_NAMES.has(normalized)
+    || normalized.endsWith("password")
+    || normalized.endsWith("passphrase")
+    || normalized.endsWith("secret")
+    || normalized.endsWith("token")
+    || normalized.endsWith("credential")
+    || normalized.endsWith("cookie")
+    || normalized.endsWith("apikey")
+    || normalized.endsWith("accesskey")
+    || normalized.endsWith("privatekey")
+    || normalized.endsWith("authorization")
+    || normalized.endsWith("accessurl");
+}
+
+/** Removes credential-shaped object fields before data enters the page or JSON output. */
+export function stripDesktopShotCredentials<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stripDesktopShotCredentials(entry)) as T;
+  }
+  if (!value || typeof value !== "object" || value instanceof Date) return value;
+  const clean: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (isCredentialField(key)) continue;
+    clean[key] = stripDesktopShotCredentials(entry);
+  }
+  return clean as T;
+}
+
+export function resolveDesktopShotApiProxy(
+  context: Pick<MarketContext, "persistence">,
+): DesktopPaneShotApiProxy {
+  let sessionToken: string | null = null;
+  for (const key of CLOUD_SESSION_KEYS) {
+    const value = context.persistence.pluginState.get<PersistedShotCloudSession>(
+      CLOUD_PLUGIN_ID,
+      key,
+      1,
+    )?.value;
+    if (typeof value?.sessionToken === "string" && value.sessionToken.length > 0) {
+      sessionToken = value.sessionToken;
+      break;
+    }
+  }
+  return {
+    baseUrl: getCloudApiBaseUrl(),
+    sessionToken,
+  };
+}
 
 /** Same reason as the valuation legs: the renderer cannot fill its own cache. */
 async function collectShotStatSeries(
@@ -242,6 +323,27 @@ export type PaneScreenshotDataEvidence =
   | PaneScreenshotFundamentalSeriesEvidence
   | PaneScreenshotFinancialStatementEvidence;
 
+export interface PaneScreenshotReadinessSignals {
+  rowCount: number;
+  loadingStateDetected: boolean;
+  errorStateDetected: boolean;
+  emptyStateDetected: boolean;
+  complete: boolean;
+  semanticMismatch: boolean;
+  requiresStructuredDataEvidence: boolean;
+  hasStructuredDataEvidence: boolean;
+}
+
+export function isPaneScreenshotUsable(signals: PaneScreenshotReadinessSignals): boolean {
+  return signals.rowCount > 0
+    && !signals.loadingStateDetected
+    && !signals.errorStateDetected
+    && !signals.emptyStateDetected
+    && signals.complete
+    && !signals.semanticMismatch
+    && (!signals.requiresStructuredDataEvidence || signals.hasStructuredDataEvidence);
+}
+
 export interface PaneScreenshotResult {
   kind: "pane-screenshot";
   target: string;
@@ -309,9 +411,9 @@ async function buildDesktopShotPayload(
   if (isFinancialAnalysisFunction(resolved) && !initialPaneState.activeTabId) {
     initialPaneState.activeTabId = "financials";
   }
-  const paneState: Record<string, PaneRuntimeState> = {
+  const paneState = stripDesktopShotCredentials<Record<string, PaneRuntimeState>>({
     [resolved.instance.instanceId]: initialPaneState,
-  };
+  });
   const layout = {
     dockRoot: null,
     instances: [resolved.instance],
@@ -325,7 +427,7 @@ async function buildDesktopShotPayload(
     }],
     detached: [],
   };
-  const config = {
+  const config = stripDesktopShotCredentials<AppConfig>({
     ...context.config,
     ...(theme ? { theme: resolveShotTheme(theme) } : {}),
     layout,
@@ -338,7 +440,7 @@ async function buildDesktopShotPayload(
     }],
     activeLayoutIndex: 0,
     onboardingComplete: true,
-  };
+  });
 
   const tickers: TickerRecord[] = [];
   const financials: Array<[string, TickerFinancials]> = [];
@@ -456,21 +558,35 @@ export async function renderDesktopShot({
   options: Record<string, string | true>;
 }): Promise<PaneScreenshotResult> {
   await mkdir(dirname(outputPath), { recursive: true });
-  const payload = await buildDesktopShotPayload(
-    resolved,
-    context,
-    rawArg,
-    options,
-    width,
-    height,
-    theme ?? null,
-    scale ?? 1,
-    watermark ?? null,
-  );
-  const render = await renderDesktopPaneScreenshot(payload, outputPath);
+  const apiProxy = resolveDesktopShotApiProxy(context);
+  const previousSessionToken = apiClient.getSessionToken();
+  let payload: DesktopPaneShotPayload;
+  let render: DesktopPaneShotRenderResult;
+  apiClient.setSessionToken(apiProxy.sessionToken);
+  try {
+    payload = await buildDesktopShotPayload(
+      resolved,
+      context,
+      rawArg,
+      options,
+      width,
+      height,
+      theme ?? null,
+      scale ?? 1,
+      watermark ?? null,
+    );
+    render = await renderDesktopPaneScreenshot(payload, outputPath, apiProxy);
+  } finally {
+    apiClient.setSessionToken(previousSessionToken);
+  }
   const symbols = payload.financials.map(([symbol]) => symbol);
-  const rowCount = shotSemanticRowCount(resolved, payload, render.semanticUi);
-  const unavailableSymbols = shotUnavailableSymbols(resolved, payload, render.semanticUi);
+  const usesLiveDomEvidence = resolved.capability.screenshotReadiness === "live-dom";
+  const rowCount = usesLiveDomEvidence
+    ? render.rows.length
+    : shotSemanticRowCount(resolved, payload, render.semanticUi);
+  const unavailableSymbols = usesLiveDomEvidence
+    ? []
+    : shotUnavailableSymbols(resolved, payload, render.semanticUi);
   const complete = unavailableSymbols.length === 0;
   const expectedText = shotExpectedText(resolved, symbols, payload);
   const normalizedVisibleText = render.visibleText.toLowerCase();
@@ -488,12 +604,21 @@ export async function renderDesktopShot({
   const semanticMismatch = missingExpectedText.length > 0
     || missingExpectedSelections.length > 0
     || chartEvidenceMismatches.length > 0;
-  const empty = render.emptyStateDetected || rowCount === 0 || semanticMismatch;
-  const usable = resolved.capability.botSafe
-    && resolved.capability.screenshotReadiness === "ready"
-    && !empty
-    && complete
-    && (!requiresStructuredDataEvidence(resolved) || dataEvidence !== null);
+  const empty = render.loadingStateDetected
+    || render.errorStateDetected
+    || render.emptyStateDetected
+    || rowCount === 0
+    || semanticMismatch;
+  const usable = isPaneScreenshotUsable({
+    rowCount,
+    loadingStateDetected: render.loadingStateDetected,
+    errorStateDetected: render.errorStateDetected,
+    emptyStateDetected: render.emptyStateDetected,
+    complete,
+    semanticMismatch,
+    requiresStructuredDataEvidence: requiresStructuredDataEvidence(resolved),
+    hasStructuredDataEvidence: dataEvidence !== null,
+  });
   return {
     kind: "pane-screenshot",
     target: resolved.token,
@@ -505,7 +630,7 @@ export async function renderDesktopShot({
       screenshotReadiness: resolved.capability.screenshotReadiness,
     },
     symbols,
-    options: resolved.options,
+    options: stripDesktopShotCredentials(resolved.options),
     rowCount,
     empty,
     complete,
@@ -515,7 +640,7 @@ export async function renderDesktopShot({
     dataEvidence,
     outputPath,
     render: {
-      ...render,
+      ...stripDesktopShotCredentials(render),
       expectedText,
       missingExpectedText,
       expectedSelections,

--- a/src/components/ui/status.tsx
+++ b/src/components/ui/status.tsx
@@ -70,7 +70,7 @@ export function PaneStatusBody({
 }: PaneStatusBodyProps) {
   if (error) {
     return (
-      <Box paddingX={1} paddingY={1}>
+      <Box paddingX={1} paddingY={1} data-gloom-status="error">
         <EmptyState
           title={subject ? unavailableText(subject) : error}
           message={subject ? error : undefined}
@@ -89,7 +89,7 @@ export function PaneStatusBody({
   }
   if (empty) {
     return (
-      <Box paddingX={1} paddingY={1}>
+      <Box paddingX={1} paddingY={1} data-gloom-status="empty">
         <EmptyState
           title={emptyTitle ?? t("Nothing to show yet.")}
           message={emptyMessage}

--- a/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
+++ b/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
@@ -47,6 +47,8 @@ import type { DatedObservation } from "../../../plugins/builtin/market-valuation
 import { clipPriceHistoryToRange } from "../../../time-series/history-window";
 import type { ResolvedSeries } from "../../../time-series/types";
 import { chartSeriesSourceKey } from "../../../capabilities";
+import { apiClient, setCloudApiFetchTransport } from "../../../api-client";
+import { createGloomberbCloudProvider } from "../../../sources/gloomberb-cloud";
 
 interface CliPaneShotPayload {
   config: AppConfig;
@@ -82,6 +84,7 @@ const SHOT_READY_STABLE_FRAMES = 10;
 // content contains the word "loading" (a changelog release note, a news
 // headline) wait forever and time out.
 const SHOT_LOADING_SELECTOR = "[data-gloom-status=\"loading\"]";
+const SHOT_API_PROXY_PREFIX = "/__gloom_cli_api__";
 const TRACKED_RESPONSE_METHODS = new Set<PropertyKey>([
   "arrayBuffer",
   "blob",
@@ -144,6 +147,29 @@ function installShotFetchTracker(): void {
   window.fetch = ((...args: Parameters<typeof fetch>) => (
     trackShotWork(fetchOriginal(...args)).then(wrapTrackedResponse)
   )) as typeof fetch;
+}
+
+function installShotCloudApiTransport(): void {
+  apiClient.setCookieSessionMode(true);
+  setCloudApiFetchTransport((url, init = {}) => {
+    const upstream = new URL(url);
+    const proxyUrl = new URL(`${SHOT_API_PROXY_PREFIX}${upstream.pathname}`, window.location.origin);
+    proxyUrl.search = upstream.search;
+    const headers = new Headers(init.headers);
+    // Bun owns the real session cookie. The browser only talks to the local
+    // same-origin proxy and never receives or serializes the credential.
+    headers.delete("Cookie");
+    headers.delete("Origin");
+    return window.fetch(proxyUrl, {
+      ...init,
+      headers,
+      credentials: "same-origin",
+    });
+  });
+}
+
+async function restoreShotCloudSession(): Promise<void> {
+  await apiClient.getSession().catch(() => null);
 }
 
 function resolveShotWork<T>(value: T): Promise<T> {
@@ -254,7 +280,7 @@ function createShotDataProvider(payload: CliPaneShotPayload): DataProvider {
     return data;
   };
 
-  return {
+  const injectedProvider: DataProvider = {
     id: "cli-shot",
     name: "CLI screenshot data",
     getTickerFinancials(ticker, exchange) {
@@ -335,6 +361,19 @@ function createShotDataProvider(payload: CliPaneShotPayload): DataProvider {
       return () => {};
     },
   };
+
+  // Keep deterministic payload data for the mapped screenshot capabilities,
+  // then fall through to the authenticated cloud provider for operations such
+  // as SEC filings that live panes request through market-data hooks.
+  const cloudProvider = createGloomberbCloudProvider();
+  return new Proxy(injectedProvider, {
+    get(target, property, receiver) {
+      const local = Reflect.get(target, property, receiver);
+      if (local !== undefined) return local;
+      const cloud = Reflect.get(cloudProvider, property, cloudProvider);
+      return typeof cloud === "function" ? cloud.bind(cloudProvider) : cloud;
+    },
+  });
 }
 
 function installShotMarketData(payload: CliPaneShotPayload): void {
@@ -591,6 +630,7 @@ async function render() {
   if (!payload) throw new Error("Missing CLI pane screenshot payload.");
   revivePayloadDates(payload);
   installShotFetchTracker();
+  installShotCloudApiTransport();
   hydrateFredSeries(payload.fredSeries ?? []);
   hydrateValuationSeries(payload.valuationSeries ?? []);
   statsCache.hydrate(payload.statSeries ?? []);
@@ -598,6 +638,9 @@ async function render() {
   // Panes contributed from an async setup() only exist once every plugin has
   // finished registering, so the tree cannot mount before that resolves.
   await installShotPluginRegistry(payload);
+  // Plugin setup hydrates its in-memory persistence and may reset apiClient.
+  // Restore the proxied cloud session only after registration is complete.
+  await restoreShotCloudSession();
 
   const rootElement = document.getElementById("root");
   if (!rootElement) throw new Error("Missing root element.");


### PR DESCRIPTION
## Why

`gloomberb shot` only produced usable images for the 12 panes with a bespoke report builder. Every other pane fetches inside the component through the cloud API and failed in headless Chrome (`shot CG` rendered "House PTR filings unavailable. Failed to fetch") because the page had no base URL and no session. Readiness also came from the capability map, so a pane that rendered rows still reported `usable: false`.

## What

- The CLI serves the harness from a local Bun server bound to `127.0.0.1` (random port) and proxies cloud API calls under `/__gloom_cli_api__`. The session cookie is attached on the Bun side; the page never receives or serializes the credential. The payload strips api keys, passwords and access tokens before injection.
- The harness routes `apiClient` through the proxy (`setCloudApiFetchTransport`) and restores the session before mounting. Mapped panes keep their deterministic injected data and fall through to the authenticated cloud provider for everything else.
- Evidence comes from the DOM: table and list rows with semantic column metadata, plus loading, error and empty detection from `data-gloom-status` markers (added to the shared status components).
- `usable` is decided from what rendered: rows present, no error, empty or loading state. The catalog reports such panes as `live-dom` (71 panes) next to `ready` (7) and `partial` (5). Field shape is unchanged for gloombot.

## Verify

```
gloomberb shot CG --theme tokyo --width 1200 --height 675 --scale 1.5 --watermark gloom.sh --json
gloomberb shot SI AAPL ... --json     # usable true, 13 rows
gloomberb shot INS NVDA ... --json    # usable true, 20 rows
gloomberb shot VAL ... --json         # usable true, 9 rows
gloomberb shot FA AVGO ... --json     # unchanged, readiness ready
```

Requires a signed-in CLI session for private panes; without one the pane shows its own error state and `usable` is false.

Tests: `bun test src/cli/pane-functions` (32 tests) covers credential stripping, proxy resolution and the readiness decision. `bun run typecheck` clean.