### PR TITLE
Preserve broker identity across cloud sync

### DIFF
--- a/src/sync/core-contributors.test.ts
+++ b/src/sync/core-contributors.test.ts
@@ -129,6 +129,99 @@ describe("core sync contributors", () => {
     }
   });
 
+  test("preserves local broker identity when applying sanitized portfolios", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-sync-broker-identity-test");
+    config.portfolios = [{
+      id: "broker:demo-live:ACCOUNT-1",
+      name: "Primary",
+      currency: "USD",
+      brokerId: "demo",
+      brokerInstanceId: "demo-live",
+      brokerAccountId: "ACCOUNT-1",
+      lastSyncedAt: 100,
+    }];
+
+    const collected = __syncContributorInternalsForTests.collectCoreConfigPayload(config) as {
+      portfolios: Array<Record<string, unknown>>;
+    };
+    expect(collected.portfolios[0]).not.toHaveProperty("brokerInstanceId");
+    expect(collected.portfolios[0]).not.toHaveProperty("brokerAccountId");
+
+    const merged = __syncContributorInternalsForTests.mergeConfigPayload(config, {
+      portfolios: [{
+        id: "broker:demo-live:ACCOUNT-1",
+        name: "Primary",
+        currency: "USD",
+        brokerId: "demo",
+        lastSyncedAt: 200,
+      }],
+    });
+
+    expect(merged?.portfolios).toEqual([{
+      id: "broker:demo-live:ACCOUNT-1",
+      name: "Primary",
+      currency: "USD",
+      brokerId: "demo",
+      brokerInstanceId: "demo-live",
+      brokerAccountId: "ACCOUNT-1",
+      lastSyncedAt: 200,
+    }]);
+  });
+
+  test("does not reintroduce older unlinked broker portfolios from cloud", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-sync-broker-identity-test");
+    config.portfolios = [
+      {
+        id: "main",
+        name: "Main",
+        currency: "USD",
+      },
+      {
+        id: "broker:demo-live:ACCOUNT-1",
+        name: "Primary",
+        currency: "USD",
+        brokerId: "demo",
+        brokerInstanceId: "demo-live",
+        brokerAccountId: "ACCOUNT-1",
+        lastSyncedAt: 200,
+      },
+      {
+        id: "broker:demo-live:ACCOUNT-2",
+        name: "Secondary",
+        currency: "USD",
+        brokerId: "demo",
+        brokerInstanceId: "demo-live",
+        brokerAccountId: "ACCOUNT-2",
+        lastSyncedAt: 200,
+      },
+    ];
+
+    const merged = __syncContributorInternalsForTests.mergeConfigPayload(config, {
+      portfolios: [
+        { id: "main", name: "Main", currency: "USD" },
+        { id: "broker:demo-live:ACCOUNT-1", name: "Primary", currency: "USD", brokerId: "demo", lastSyncedAt: 200 },
+        { id: "broker:demo-live:ACCOUNT-2", name: "Secondary", currency: "USD", brokerId: "demo", lastSyncedAt: 200 },
+        { id: "broker:demo-old:ACCOUNT-1", name: "Primary", currency: "USD", brokerId: "demo", lastSyncedAt: 100 },
+        { id: "broker:demo-old:ACCOUNT-2", name: "Secondary", currency: "USD", brokerId: "demo", lastSyncedAt: 100 },
+        { id: "broker:demo-old:REMOVED", name: "Removed", currency: "USD", brokerId: "demo", lastSyncedAt: 100 },
+        { id: "broker:demo-other:ACCOUNT-3", name: "Remote", currency: "USD", brokerId: "demo", lastSyncedAt: 300 },
+      ],
+    });
+
+    expect(merged?.portfolios).toEqual([
+      config.portfolios[0],
+      config.portfolios[1],
+      config.portfolios[2],
+      {
+        id: "broker:demo-other:ACCOUNT-3",
+        name: "Remote",
+        currency: "USD",
+        brokerId: "demo",
+        lastSyncedAt: 300,
+      },
+    ]);
+  });
+
   test("keeps resumable onboarding local until the guide is complete", async () => {
     const config = createDefaultConfig("/tmp/gloomberb-sync-test");
     config.onboardingComplete = false;
@@ -258,6 +351,24 @@ describe("core sync contributors", () => {
     expect((payload as any).tickers[0].quote.weekReferencePrice).toBe(125);
     expect((payload as any).tickers[0].quote.weekChangePercent).toBe(20);
     expect((payload as any).analyticsByPortfolio.main.oneYearReturn).toBe(0.42);
+
+    const saved: TickerRecord[] = [];
+    const sanitizedTickerPayload = { tickers: (payload as any).tickers };
+    await coreCollectionsSyncContributor.apply?.(sanitizedTickerPayload, {
+      baselinePayload: sanitizedTickerPayload,
+      baselineState: state,
+      state,
+      getState: () => state,
+      isCurrent: () => true,
+      dispatch: () => {},
+      tickerRepository: { saveTicker: async (record: TickerRecord) => { saved.push(record); } },
+    } as unknown as Parameters<NonNullable<typeof coreCollectionsSyncContributor.apply>>[1]);
+
+    expect(saved[0]?.metadata.positions[0]).toMatchObject({
+      brokerInstanceId: "broker-id",
+      brokerAccountId: "account-id",
+      brokerContractId: 42,
+    });
   });
 
   test("keeps a position written while the app was closed", async () => {

--- a/src/sync/core-contributors.ts
+++ b/src/sync/core-contributors.ts
@@ -58,6 +58,116 @@ function sanitizePortfolio(portfolio: Portfolio): Portfolio {
   };
 }
 
+function brokerAccountIdFromPortfolioId(portfolioId: string): string | undefined {
+  const [kind, instanceId, ...accountParts] = portfolioId.split(":");
+  if (kind !== "broker" || !instanceId) return undefined;
+  const accountId = accountParts.join(":").trim();
+  return accountId && accountId !== "default" ? accountId : undefined;
+}
+
+function brokerPortfolioKey(brokerId: string | undefined, accountId: string | undefined): string | undefined {
+  if (!brokerId || !accountId) return undefined;
+  return [brokerId, accountId].join("\u0000");
+}
+
+function portfolioSyncTimestamp(portfolio: Portfolio): number {
+  return typeof portfolio.lastSyncedAt === "number" && Number.isFinite(portfolio.lastSyncedAt)
+    ? portfolio.lastSyncedAt
+    : 0;
+}
+
+function latestBrokerSyncByType(portfolios: Portfolio[], linkedOnly: boolean): Map<string, number> {
+  const latest = new Map<string, number>();
+  for (const portfolio of portfolios) {
+    if (!portfolio.brokerId || (linkedOnly && !portfolio.brokerInstanceId)) continue;
+    const timestamp = portfolioSyncTimestamp(portfolio);
+    latest.set(portfolio.brokerId, Math.max(latest.get(portfolio.brokerId) ?? 0, timestamp));
+  }
+  return latest;
+}
+
+/**
+ * Broker identity is deliberately excluded from cloud payloads, but it is
+ * still local state that must survive applying a sanitized portfolio back to
+ * this device. Match by the stable portfolio ID first, then by the account
+ * suffix in that stable ID. A newer local broker snapshot also wins over old
+ * unlinked records left in a cloud snapshot from before a reset.
+ */
+function mergeLocalBrokerPortfolioIdentity(
+  localPortfolios: Portfolio[],
+  syncedPortfolios: Portfolio[],
+): Portfolio[] {
+  const localById = new Map(localPortfolios.map((portfolio) => [portfolio.id, portfolio] as const));
+  const localByBrokerAccount = new Map<string, Portfolio[]>();
+  for (const portfolio of localPortfolios) {
+    if (!portfolio.brokerInstanceId) continue;
+    const key = brokerPortfolioKey(portfolio.brokerId, portfolio.brokerAccountId);
+    if (!key) continue;
+    const entries = localByBrokerAccount.get(key) ?? [];
+    entries.push(portfolio);
+    localByBrokerAccount.set(key, entries);
+  }
+
+  const exactIncomingIds = new Set(
+    syncedPortfolios
+      .map((portfolio) => portfolio.id)
+      .filter((portfolioId) => localById.has(portfolioId)),
+  );
+  const localLatestByBroker = latestBrokerSyncByType(localPortfolios, true);
+  const syncedLatestByBroker = latestBrokerSyncByType(syncedPortfolios, false);
+  const merged: Portfolio[] = [];
+  const seenIds = new Set<string>();
+
+  for (const portfolio of syncedPortfolios) {
+    const localByStableId = localById.get(portfolio.id);
+    const accountId = brokerAccountIdFromPortfolioId(portfolio.id);
+    const accountCandidates = localByBrokerAccount.get(brokerPortfolioKey(portfolio.brokerId, accountId) ?? "");
+    const local = localByStableId?.brokerInstanceId && localByStableId.brokerId === portfolio.brokerId
+      ? localByStableId
+      : accountCandidates?.length === 1
+        ? accountCandidates[0]
+        : undefined;
+
+    if (local) {
+      // Prefer an exact stable-ID entry when an older duplicate appears first
+      // in the remote array.
+      if (portfolio.id !== local.id && exactIncomingIds.has(local.id)) continue;
+      if (seenIds.has(local.id)) continue;
+
+      const localIsNewer = portfolioSyncTimestamp(local) > portfolioSyncTimestamp(portfolio);
+      merged.push(localIsNewer
+        ? local
+        : {
+          ...portfolio,
+          id: local.id,
+          brokerInstanceId: local.brokerInstanceId,
+          brokerAccountId: local.brokerAccountId,
+        });
+      seenIds.add(local.id);
+      continue;
+    }
+
+    const localLatest = portfolio.brokerId ? localLatestByBroker.get(portfolio.brokerId) : undefined;
+    if (localLatest !== undefined && localLatest > portfolioSyncTimestamp(portfolio)) continue;
+    merged.push(portfolio);
+    seenIds.add(portfolio.id);
+  }
+
+  // If the newer local broker snapshot is absent from the cloud array
+  // altogether, keep it instead of treating the older array as authoritative.
+  for (const portfolio of localPortfolios) {
+    if (!portfolio.brokerInstanceId || seenIds.has(portfolio.id)) continue;
+    const localLatest = portfolio.brokerId ? localLatestByBroker.get(portfolio.brokerId) : undefined;
+    const syncedLatest = portfolio.brokerId ? syncedLatestByBroker.get(portfolio.brokerId) ?? 0 : 0;
+    if (localLatest !== undefined && localLatest > syncedLatest) {
+      merged.push(portfolio);
+      seenIds.add(portfolio.id);
+    }
+  }
+
+  return merged;
+}
+
 function sanitizeWatchlist(watchlist: Watchlist): Watchlist {
   return {
     id: watchlist.id,
@@ -91,6 +201,38 @@ function sanitizePosition(position: TickerPosition): TickerPosition {
     multiplier: position.multiplier,
     markPrice: position.markPrice,
   };
+}
+
+function brokerPositionKey(position: Pick<TickerPosition, "portfolio" | "broker" | "side">): string {
+  return [position.portfolio, position.broker, position.side ?? ""].join("\u0000");
+}
+
+/** Keep broker position identity local while applying public cloud fields. */
+function mergeLocalBrokerPositionIdentity(
+  localPositions: TickerPosition[],
+  syncedPositions: TickerPosition[],
+): TickerPosition[] {
+  const localByKey = new Map<string, TickerPosition[]>();
+  for (const position of localPositions) {
+    if (!position.brokerInstanceId) continue;
+    const key = brokerPositionKey(position);
+    const entries = localByKey.get(key) ?? [];
+    entries.push(position);
+    localByKey.set(key, entries);
+  }
+
+  return syncedPositions.map((position) => {
+    const entries = localByKey.get(brokerPositionKey(position));
+    const local = entries?.shift();
+    if (!local) return position;
+
+    return {
+      ...position,
+      brokerInstanceId: local.brokerInstanceId,
+      brokerAccountId: local.brokerAccountId,
+      brokerContractId: local.brokerContractId,
+    };
+  });
 }
 
 function pricePointTime(point: { date: Date | string | number }): number {
@@ -405,7 +547,12 @@ function mergeConfigPayload(
 
   assign("baseCurrency");
   assign("refreshIntervalMinutes");
-  assign("portfolios");
+  if ("portfolios" in payload && canApply("portfolios")) {
+    const syncedPortfolios = payload.portfolios;
+    next.portfolios = Array.isArray(syncedPortfolios)
+      ? mergeLocalBrokerPortfolioIdentity(config.portfolios, syncedPortfolios as Portfolio[])
+      : syncedPortfolios as AppConfig["portfolios"];
+  }
   assign("watchlists");
   assign("disabledSources");
   assign("theme");
@@ -532,9 +679,16 @@ export const coreCollectionsSyncContributor: SyncContributor = {
       // Local edits the cloud has never seen (CLI positions, offline changes)
       // win here and are uploaded by the push that follows this pull.
       if (tickerChangedSinceLastSync(current, lastSyncedTickers)) continue;
+      const syncedPositions = Array.isArray(rawTicker.positions)
+        ? mergeLocalBrokerPositionIdentity(
+          current?.metadata.positions ?? [],
+          rawTicker.positions as TickerPosition[],
+        )
+        : current?.metadata.positions ?? [];
       const metadata = hydrateTickerMetadata({
         ...current?.metadata,
         ...rawTicker,
+        positions: syncedPositions,
         broker_contracts: current?.metadata.broker_contracts ?? [],
       });
       const record: TickerRecord = { metadata };


### PR DESCRIPTION
Fixes #697

## Problem

Gloom Cloud payloads intentionally omit local broker instance/account fields. The config pull path then replaced local portfolios wholesale, so a later broker sync could not match the managed portfolios and created duplicates. Sanitized ticker payloads could also lose broker position identity. A stale cloud snapshot could additionally reintroduce older unlinked broker rows after a reset.

## Fix

- preserve the existing cloud redaction boundary
- restore local portfolio broker identity by stable portfolio ID
- reconcile sanitized rows by the account suffix in the stable broker portfolio ID when safe
- prefer a newer local broker snapshot over older unlinked cloud rows, while retaining newer remote rows
- restore local position instance, account, and contract identity by portfolio/broker/side
- keep the local-edit guard ahead of broker identity merging
- add regression coverage for portfolio and position round trips and stale cloud rows

## Verification

- `bun run typecheck` passes
- `bun test src/sync/core-contributors.test.ts` passes (14 tests)
- `bun run build` passes, including packaged-binary smoke tests
- `git diff --check` passes
- Full `bun test`: 2,494 passed and 2 unrelated existing onboarding timing tests failed; the same onboarding failure reproduces on the clean baseline
- Live sanitized-state simulation: clean local `15 total / 14 linked` plus stale remote `29 total` merges to `15 total / 14 linked / 0 unlinked`

No credentials or local broker configuration are added to cloud payloads.