### PR TITLE
Reserve a right offset on the composite chart and mark the last price

### DIFF
--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -31,6 +31,7 @@ import {
   buildCompositeNavigationFrame,
   zoomCompositeViewport,
 } from "./interactions";
+import { COMPOSITE_RIGHT_OFFSET_RATIO } from "./time-scale";
 import { getThemeColors, syncTheme } from "../../../theme/colors";
 import { ThemeProvider } from "../../../theme/theme-context";
 import { DEFAULT_THEME } from "../../../theme/themes";
@@ -1493,7 +1494,9 @@ describe("CompositeChart", () => {
       frame,
       viewport,
       1 + 4 * 0.04,
-      pointerX / Math.max(plotWidth - 1, 1),
+      // The pointer reads in plot space, which is wider than the viewport by
+      // the reserved right offset.
+      pointerX / Math.max(plotWidth - 1, 1) * (1 + COMPOSITE_RIGHT_OFFSET_RATIO),
     );
 
     await act(async () => {

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -92,7 +92,11 @@ import {
   type ChartToolDrag,
   type ChartToolKind,
 } from "./tools";
-import { unprojectCompositeTimestamp } from "./time-scale";
+import {
+  COMPOSITE_RIGHT_OFFSET_RATIO,
+  compositeRightOffsetRatio,
+  unprojectCompositeTimestamp,
+} from "./time-scale";
 import {
   allocateCompositePanelHeights,
   applyCompositeChartCursor,
@@ -139,12 +143,17 @@ interface PanGesture {
   positionsPerCell: number;
 }
 
-/** A drag pans in the frame it started in; see `CompositeNavigationFrame`. */
+/**
+ * A drag pans in the frame it started in; see `CompositeNavigationFrame`. The
+ * plot covers the viewport plus its reserved right offset, so a cell is worth
+ * that much time and the bars keep pace with the pointer.
+ */
 function startPanGesture(
   frame: CompositeNavigationFrame,
   viewport: CompositeViewportRange,
   plotWidth: number,
   globalX: number,
+  plotSpanFactor: number,
 ): PanGesture {
   const positions = compositeViewportPositions(frame, viewport);
   const span = positions ? Math.max(positions.end - positions.start, Number.EPSILON) : 1;
@@ -153,7 +162,7 @@ function startPanGesture(
     startGlobalX: globalX,
     frame,
     startViewport: viewport,
-    positionsPerCell: span / Math.max(plotWidth, 1),
+    positionsPerCell: span * plotSpanFactor / Math.max(plotWidth, 1),
   };
 }
 
@@ -740,6 +749,9 @@ function CompositePanelSurface({
   >(null);
   const [toolDrag, setToolDrag] = useState<ChartToolDrag | null>(null);
   const plotAspect = (plotWidth * cellWidthPx) / Math.max(panel.height * cellHeightPx, 1);
+  // The plot is wider than the viewport by the reserved right offset. Gestures
+  // read the pointer in plot space, so they convert through this.
+  const plotSpanFactor = 1 + compositeRightOffsetRatio(scene.timeScale);
   const bitmapSize = useStaticChartBitmapSize(plotWidth, panel.height);
   const bitmap = useCompositePanelBitmap({ panel, bitmapSize, colors, isDesktopWeb });
   const columnLayout = useMemo(() => buildCompositeColumnLayout(panel), [panel]);
@@ -924,20 +936,37 @@ function CompositePanelSurface({
     // anchor the drag started from.
     if (!toolDrag || toolDrag.kind === "zoom" || !toolReadout?.startValueLabel) return null;
     return {
+      side: null,
       yRatio: toolDrag.startYRatio,
       label: toolReadout.startValueLabel,
       color: toolReadout.direction === "down" ? colors.negative : themeColors.positive,
     };
   }, [colors.negative, toolDrag, toolReadout]);
+  const lastPriceMarker = useMemo(() => {
+    const marker = panel.lastPrice;
+    const domain = marker ? panel.axes[marker.axis] : undefined;
+    if (!marker || !domain) return null;
+    return {
+      side: marker.axis,
+      yRatio: marker.yRatio,
+      label: formatAxisValue
+        ? formatAxisValue(marker.value, domain)
+        : formatCompositeCursorValue(marker.value, domain),
+      color: marker.color,
+    };
+  }, [formatAxisValue, panel]);
   const buildAxisMarkers = (side: "left" | "right") => {
-    if (!axisMarkers || !panel.axes[side]) return undefined;
-    const row = Math.round(axisMarkers.yRatio * Math.max(panel.height - 1, 0));
-    return [{
-      row,
-      pixelY: axisMarkers.yRatio * Math.max(panel.height * cellHeightPx - 1, 0),
-      label: axisMarkers.label,
-      color: axisMarkers.color,
-    }];
+    if (!panel.axes[side]) return undefined;
+    const markers = [lastPriceMarker, axisMarkers].flatMap((marker) => (
+      marker && (marker.side === null || marker.side === side) ? [marker] : []
+    ));
+    if (markers.length === 0) return undefined;
+    return markers.map((marker) => ({
+      row: Math.round(marker.yRatio * Math.max(panel.height - 1, 0)),
+      pixelY: marker.yRatio * Math.max(panel.height * cellHeightPx - 1, 0),
+      label: marker.label,
+      color: marker.color,
+    }));
   };
   const leftAxisMarkers = buildAxisMarkers("left");
   const rightAxisMarkers = buildAxisMarkers("right");
@@ -1013,7 +1042,13 @@ function CompositePanelSurface({
       return;
     }
     if (!updateCursor(event)) return;
-    dragRef.current = startPanGesture(frame, viewport, plotWidth, getGlobalMouseX(event, renderer));
+    dragRef.current = startPanGesture(
+      frame,
+      viewport,
+      plotWidth,
+      getGlobalMouseX(event, renderer),
+      plotSpanFactor,
+    );
   }, [
     armedTool,
     drawings,
@@ -1022,6 +1057,7 @@ function CompositePanelSurface({
     onSelectDrawing,
     panel,
     plotAspect,
+    plotSpanFactor,
     plotWidth,
     pointerRatios,
     renderer,
@@ -1067,7 +1103,7 @@ function CompositePanelSurface({
     if (drag.frame !== frame) {
       // Data refreshed mid-drag. The new frame maps positions differently, so
       // continue from where the plot is now instead of replaying the drag.
-      Object.assign(drag, startPanGesture(frame, viewport, plotWidth, globalX));
+      Object.assign(drag, startPanGesture(frame, viewport, plotWidth, globalX, plotSpanFactor));
     }
     onPanViewport(
       (globalX - drag.startGlobalX) * drag.positionsPerCell,
@@ -1078,6 +1114,7 @@ function CompositePanelSurface({
     onEditDrawing,
     onPanViewport,
     panel,
+    plotSpanFactor,
     plotWidth,
     pointerRatios,
     renderer,
@@ -1117,8 +1154,8 @@ function CompositePanelSurface({
   // absorbs every event that arrived since the last one.
   const pendingWheelRef = useRef<PendingWheel | null>(null);
   const wheelFrameRef = useRef<number | null>(null);
-  const latestWheelStateRef = useRef({ frame, viewport, onPanViewport, onZoomViewport });
-  latestWheelStateRef.current = { frame, viewport, onPanViewport, onZoomViewport };
+  const latestWheelStateRef = useRef({ frame, viewport, onPanViewport, onZoomViewport, plotSpanFactor });
+  latestWheelStateRef.current = { frame, viewport, onPanViewport, onZoomViewport, plotSpanFactor };
   const flushWheel = useCallback(() => {
     wheelFrameRef.current = null;
     const pending = pendingWheelRef.current;
@@ -1128,7 +1165,7 @@ function CompositePanelSurface({
     if (pending.panRatio !== 0) {
       const positions = compositeViewportPositions(latest.frame, latest.viewport);
       const span = positions ? Math.max(positions.end - positions.start, Number.EPSILON) : 0;
-      latest.onPanViewport(pending.panRatio * span);
+      latest.onPanViewport(pending.panRatio * span * latest.plotSpanFactor);
     }
     if (pending.zoomLog !== 0) {
       latest.onZoomViewport(Math.exp(pending.zoomLog), pending.anchorRatio);
@@ -1152,7 +1189,12 @@ function CompositePanelSurface({
     const pending = pendingWheelRef.current ?? { panRatio: 0, zoomLog: 0, anchorRatio: 0.5 };
     if (event.modifiers.ctrl && pointer && isVerticalWheelDirection(scroll.direction)) {
       pending.zoomLog += Math.log(resolveCompositeWheelZoom(scroll));
-      pending.anchorRatio = pointer.cellX / Math.max(plotWidth - 1, 1);
+      // The anchor is a fraction of the viewport, so a pointer over the empty
+      // right offset anchors on the newest observation instead of past it.
+      pending.anchorRatio = Math.min(
+        1,
+        pointer.cellX / Math.max(plotWidth - 1, 1) * plotSpanFactor,
+      );
     } else {
       pending.panRatio += resolveCompositeWheelPan(scroll, plotWidth * cellWidthPx);
     }
@@ -1164,7 +1206,16 @@ function CompositePanelSurface({
     if (wheelFrameRef.current === null) {
       wheelFrameRef.current = webFrame.requestAnimationFrame(flushWheel);
     }
-  }, [cellWidthPx, flushWheel, isDesktopWeb, onActivate, plotWidth, renderer, updateCursor]);
+  }, [
+    cellWidthPx,
+    flushWheel,
+    isDesktopWeb,
+    onActivate,
+    plotSpanFactor,
+    plotWidth,
+    renderer,
+    updateCursor,
+  ]);
 
   return (
     <Box
@@ -1767,6 +1818,9 @@ export function CompositeChart({
     textDim: colors?.textDim ?? activeThemeColors.textDim,
     negative: colors?.negative ?? activeThemeColors.negative,
   }), [activeThemeColors, colors]);
+  // A custom x axis means x is not time: a tenor, a fraction, a return. Its
+  // last observation belongs at the right edge, under its own label.
+  const rightOffsetRatio = xAxis ? 0 : COMPOSITE_RIGHT_OFFSET_RATIO;
   const projectedScene = useMemo(() => {
     // lastTickKey busts this memo when a live tick mutates series identity in place.
     void lastTickKey;
@@ -1775,8 +1829,17 @@ export function CompositeChart({
       height: Math.max(panelCount, 1),
       viewport: effectiveViewport ?? undefined,
       timelineSeries: marketTimelineSeries,
+      rightOffsetRatio,
     });
-  }, [effectiveViewport, lastTickKey, marketTimelineSeries, panelCount, panelSeries, panels]);
+  }, [
+    effectiveViewport,
+    lastTickKey,
+    marketTimelineSeries,
+    panelCount,
+    panelSeries,
+    panels,
+    rightOffsetRatio,
+  ]);
   // Gutters follow the axes the scene actually built. Reading the series list
   // instead drops a gutter the moment its series has no observation in view,
   // which is exactly what a zoom does, taking the axis labels with it.

--- a/src/components/chart/composite/rasterizer.ts
+++ b/src/components/chart/composite/rasterizer.ts
@@ -29,6 +29,11 @@ interface RenderCompositePanelBitmapOptions {
 
 const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
 
+/** Dash geometry of the last price level, in bitmap pixels. */
+const LAST_PRICE_DASH_PIXELS = 6;
+const LAST_PRICE_GAP_PIXELS = 5;
+const LAST_PRICE_OPACITY = 0.9;
+
 function pixelPoint(point: CompositeProjectedPoint, width: number, height: number): { x: number; y: number } {
   return {
     x: clamp(point.xRatio * Math.max(width - 1, 0), 0, Math.max(width - 1, 0)),
@@ -288,6 +293,30 @@ function drawOhlc(
   }
 }
 
+function drawLastPriceLevel(
+  data: Uint8Array,
+  width: number,
+  height: number,
+  yRatio: number,
+  color: RgbaColor,
+): void {
+  const y = Math.round(clamp(yRatio * Math.max(height - 1, 0), 0, Math.max(height - 1, 0)));
+  const period = LAST_PRICE_DASH_PIXELS + LAST_PRICE_GAP_PIXELS;
+  for (let x = 0; x < width; x += period) {
+    fillRect(
+      data,
+      width,
+      height,
+      x,
+      y,
+      Math.min(x + LAST_PRICE_DASH_PIXELS - 1, width - 1),
+      y,
+      color,
+      LAST_PRICE_OPACITY,
+    );
+  }
+}
+
 export function renderCompositePanelBitmap(
   panel: CompositePanelScene,
   options: RenderCompositePanelBitmapOptions,
@@ -360,6 +389,10 @@ export function renderCompositePanelBitmap(
         drawConnectedSeries(data, width, height, series, domain, color, false);
         break;
     }
+  }
+
+  if (panel.lastPrice) {
+    drawLastPriceLevel(data, width, height, panel.lastPrice.yRatio, parseHex(panel.lastPrice.color));
   }
 
   return { width, height, pixels: data };

--- a/src/components/chart/composite/renderers.test.ts
+++ b/src/components/chart/composite/renderers.test.ts
@@ -71,8 +71,8 @@ describe("composite chart renderers", () => {
 
     const rows = renderCompositePanelText(scene.panels[0]!, scene.width, null, null);
     expect(rows[7]!.slice(0, 2)).toBe("██");
-    expect(rows[7]!.slice(15, 17)).toBe("██");
-    expect(rows[7]!.slice(-2)).toBe("██");
+    expect(rows[7]!.slice(14, 16)).toBe("██");
+    expect(rows[7]!.slice(28, 30)).toBe("██");
   });
 
   test("rasterizes same-date columns as separate colored bars", () => {
@@ -401,7 +401,7 @@ describe("composite chart renderers", () => {
     const rows = renderCompositePanelText(scene.panels[0]!, scene.width, null, null);
     const occupied = [...rows[7]!]
       .flatMap((cell, index) => cell === "█" ? [index] : []);
-    expect(occupied).toEqual([0, 15, 30]);
+    expect(occupied).toEqual([0, 14, 28]);
   });
 
   test("does not group columns across independent axes or panels", () => {
@@ -732,10 +732,57 @@ describe("composite chart renderers", () => {
       else runs.push([x]);
     }
 
+    const widths = runs.map((run) => run.length);
     expect(runs).toHaveLength(3);
-    expect(runs.map((run) => run.length)).toEqual([13, 13, 13]);
+    expect(Math.min(...widths)).toBeGreaterThanOrEqual(13);
+    // Fractional centers cost a body at most one pixel of rounding.
+    expect(Math.max(...widths) - Math.min(...widths)).toBeLessThanOrEqual(1);
     expect(runs[0]?.[0]).toBe(0);
+    // Three bars leave less reserved space than half a body, so the clamp is
+    // still what keeps the newest one whole.
     expect(runs.at(-1)?.at(-1)).toBe(bitmap.width - 1);
+  });
+
+  test("leaves the reserved right offset empty after the newest candle", () => {
+    const candles = series("price", "candles", [], "left", "#00ff66");
+    candles.points = Array.from({ length: 40 }, (_, index) => ({
+      ...point(`2025-02-${String(index + 1).padStart(2, "0")}`, 10),
+      open: 8,
+      high: 13,
+      low: 7,
+      close: 10,
+    }));
+    const scene = buildCompositeChartScene(
+      [candles],
+      [{ id: "main" }],
+      { width: 81, height: 9 },
+    )!;
+    const panel = scene.panels[0]!;
+    const bitmap = renderCompositePanelBitmap(panel, {
+      pixelWidth: 400,
+      pixelHeight: 51,
+      colors: {
+        background: "#000000",
+        grid: "#202020",
+        crosshair: "#ffffff",
+        text: "#eeeeee",
+        textDim: "#999999",
+        negative: "#ff0000",
+      },
+    });
+    const domain = panel.axes.left!;
+    const bodyY = Math.round(
+      (projectCompositeValue(8, domain)! + projectCompositeValue(10, domain)!) / 2
+      * (bitmap.height - 1),
+    );
+    const painted = Array.from({ length: bitmap.width }, (_, x) => x).filter((x) => {
+      const offset = (bodyY * bitmap.width + x) * 4;
+      return bitmap.pixels[offset + 1]! > 220;
+    });
+    const slotWidth = (bitmap.width - 1) / 40;
+
+    // The newest body ends short of the axis, with whole bar slots of air.
+    expect(bitmap.width - 1 - painted.at(-1)!).toBeGreaterThan(slotWidth);
   });
 
   test("marks a standalone line observation without extending it through time", () => {

--- a/src/components/chart/composite/scene.test.ts
+++ b/src/components/chart/composite/scene.test.ts
@@ -9,6 +9,10 @@ import {
   unprojectCompositeValue,
 } from "./scene";
 import { buildCompositeColumnLayout } from "./column-layout";
+import { COMPOSITE_RIGHT_OFFSET_RATIO } from "./time-scale";
+
+/** Ratio the newest observation lands on once the right offset is reserved. */
+const NEWEST_X_RATIO = 1 / (1 + COMPOSITE_RIGHT_OFFSET_RATIO);
 
 function point(date: string, value: number): TimeSeriesPoint {
   const observedAt = new Date(`${date}T00:00:00.000Z`);
@@ -278,8 +282,83 @@ describe("composite chart scene", () => {
     );
 
     expect(scene).not.toBeNull();
-    expect(scene?.panels[0]?.series[0]?.points.map(({ xRatio }) => xRatio)).toEqual([0, 1]);
+    const stepPoints = scene?.panels[0]?.series[0]?.points ?? [];
+    expect(stepPoints).toHaveLength(2);
+    expect(stepPoints[0]?.xRatio).toBe(0);
+    // The level runs to the viewport end and stops: the reserved right offset
+    // never carries a projected value.
+    expect(stepPoints[1]?.xRatio).toBeCloseTo(NEWEST_X_RATIO, 10);
     expect(scene?.cursorValues[0]?.value).toBe(90);
+  });
+
+  test("reserves empty space after the newest observation on both time scales", () => {
+    const calendar = series({
+      id: "calendar",
+      points: [point("2025-01-01", 10), point("2025-01-11", 20), point("2025-01-21", 30)],
+    });
+    const market = series({
+      ...calendar,
+      id: "market",
+      timeBasis: { kind: "market", timeZone: "America/New_York" },
+    });
+
+    for (const entry of [calendar, market]) {
+      const scene = buildCompositeChartScene([entry], [{ id: "main" }], { width: 101, height: 10 })!;
+      const points = scene.panels[0]!.series[0]!.points;
+
+      expect(points.at(-1)?.xRatio).toBeCloseTo(NEWEST_X_RATIO, 10);
+      // The empty tail is the plot's, not the viewport's: navigation still ends
+      // on the newest observation.
+      expect(scene.endTime).toBe(new Date("2025-01-21T00:00:00.000Z").getTime());
+      // A pointer over the reserved space still reads the newest bar.
+      expect(resolveCompositeCursorDate(scene, 100)?.toISOString())
+        .toBe("2025-01-21T00:00:00.000Z");
+    }
+  });
+
+  test("marks the newest close of the primary price series, skipping studies and volume", () => {
+    const timeBasis = { kind: "market", timeZone: "America/New_York" } as const;
+    const price = series({
+      id: "price",
+      unitGroup: "price:USD",
+      dataShape: "ohlcv",
+      style: "candles",
+      timeBasis,
+      points: ["2025-01-02", "2025-01-03"].map((date, index) => ({
+        ...point(date, 100 + index),
+        open: 90 + index,
+        high: 110 + index,
+        low: 80 + index,
+        close: 101 + index,
+      })),
+    });
+    const average = series({
+      id: "sma",
+      unitGroup: "price:USD",
+      timeBasis,
+      points: [point("2025-01-02", 40), point("2025-01-03", 41)],
+    });
+    const volume = series({
+      id: "volume",
+      unitGroup: "volume",
+      style: "columns",
+      panelId: "volume",
+      timeBasis,
+      points: [point("2025-01-02", 5_000), point("2025-01-03", 6_000)],
+    });
+    const scene = buildCompositeChartScene(
+      [price, average, volume],
+      [{ id: "main" }, { id: "volume" }],
+      { width: 101, height: 12 },
+    )!;
+    const [main, volumePanel] = scene.panels;
+
+    expect(main?.lastPrice?.seriesId).toBe("price");
+    expect(main?.lastPrice?.value).toBe(102);
+    expect(main?.lastPrice?.color).toBe(price.color);
+    expect(main?.lastPrice?.yRatio)
+      .toBe(projectCompositeValue(102, main!.axes.left!));
+    expect(volumePanel?.lastPrice).toBeUndefined();
   });
 
   test("uses as-of values across mixed-frequency dates without looking ahead", () => {
@@ -473,7 +552,11 @@ describe("composite chart scene", () => {
     );
 
     expect(scene?.timeScale).toMatchObject({ kind: "market", anchorSeriesId: "price" });
-    expect(scene?.panels[0]?.series[0]?.points.map(({ xRatio }) => xRatio)).toEqual([0, 0.5, 1]);
+    const ratios = scene?.panels[0]?.series[0]?.points.map(({ xRatio }) => xRatio) ?? [];
+    expect(ratios).toHaveLength(3);
+    expect(ratios[0]).toBe(0);
+    expect(ratios[1]).toBeCloseTo(0.5 * NEWEST_X_RATIO, 10);
+    expect(ratios[2]).toBeCloseTo(NEWEST_X_RATIO, 10);
   });
 
   test("retains the authored primary market scale when its plotted series is hidden", () => {

--- a/src/components/chart/composite/scene.ts
+++ b/src/components/chart/composite/scene.ts
@@ -16,9 +16,11 @@ import type {
 } from "./types";
 import {
   buildCompositeTimeScale,
+  COMPOSITE_RIGHT_OFFSET_RATIO,
   projectCompositeTimestamp,
+  unprojectCompositeTimestamp,
 } from "./time-scale";
-import type { CompositeTimeScale } from "./types";
+import type { CompositeLastPriceMarker, CompositeTimeScale } from "./types";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -331,7 +333,8 @@ function projectSeries(
   series: ResolvedSeries,
   domain: CompositeAxisDomain,
   startTime: number,
-  endTime: number,
+  /** Where a step series holds its last level to, never past the newest bar. */
+  stepEndTime: number,
   timeScale: CompositeTimeScale,
 ): CompositeProjectedPoint[] {
   const projected: CompositeProjectedPoint[] = [];
@@ -372,14 +375,72 @@ function projectSeries(
   if (stepSeries && projected.length > 0) {
     const last = projected.at(-1)!;
     const trailingGap = normalizedSourcePoints(series, timeScale).some(({ timestamp, value }) => (
-      timestamp > last.timestamp && timestamp <= endTime
+      timestamp > last.timestamp && timestamp <= stepEndTime
       && (value === null || projectCompositeValue(value, domain) === null)
     ));
-    if (last.timestamp < endTime && !trailingGap) {
-      projected.push({ ...last, timestamp: endTime, xRatio: 1, breakBefore: false });
+    // The synthetic tail is a level, not an observation, so it lands on its own
+    // timestamp rather than snapping forward to the next trading slot.
+    const trailingRatio = projectCompositeTimestamp(timeScale, stepEndTime)?.ratio;
+    if (last.timestamp < stepEndTime && !trailingGap && trailingRatio !== undefined) {
+      projected.push({
+        ...last,
+        timestamp: stepEndTime,
+        xRatio: Math.min(trailingRatio, 1),
+        xSlot: undefined,
+        breakBefore: false,
+      });
     }
   }
   return projected;
+}
+
+/**
+ * Unit groups a price can wear, raw or transformed. Volume, oscillators and
+ * other derived study outputs are deliberately absent: a level line there
+ * would mark a quantity that has no last price to read.
+ */
+const PRICE_UNIT_GROUPS = /^(?:price|currency|percent|index|log)(?::|$)/;
+
+/**
+ * The chart's primary price series: the first exchange-traded price, in
+ * authored order. Study outputs are appended after the series they derive
+ * from, so an overlay indicator never wins over the price it follows.
+ */
+function primaryPriceSeries(series: readonly ResolvedSeries[]): ResolvedSeries | null {
+  return series.find((entry) => (
+    entry.timeBasis?.kind === "market"
+    && PRICE_UNIT_GROUPS.test(entry.unitGroup.toLowerCase())
+  )) ?? null;
+}
+
+function lastCloseOf(points: readonly CompositeProjectedPoint[]): number | null {
+  const last = points.at(-1);
+  if (!last) return null;
+  return finiteNumber(last.point.close) ? last.point.close : last.value;
+}
+
+/** Marks the newest close of the primary price series on the panel that draws it. */
+function attachLastPriceMarker(
+  panels: CompositePanelScene[],
+  series: readonly ResolvedSeries[],
+): void {
+  const primary = primaryPriceSeries(series);
+  if (!primary) return;
+  const panel = panels.find((entry) => entry.id === primary.panelId);
+  const projected = panel?.series.find((entry) => entry.source.id === primary.id);
+  const domain = panel?.axes[primary.axis];
+  if (!panel || !projected || !domain) return;
+  const value = lastCloseOf(projected.points);
+  if (value === null) return;
+  const yRatio = projectCompositeValue(value, domain);
+  if (yRatio === null) return;
+  panel.lastPrice = {
+    seriesId: primary.id,
+    color: primary.color,
+    axis: primary.axis,
+    value,
+    yRatio,
+  };
 }
 
 function nearestDate(dates: Date[], requested: Date): Date | null {
@@ -483,7 +544,16 @@ export function buildCompositeChartScene(
     timelineSeries,
     startTime,
     endTime,
+    options.rightOffsetRatio ?? COMPOSITE_RIGHT_OFFSET_RATIO,
   );
+  // The plot reaches past the viewport by the reserved right offset. Panned
+  // back into history that space holds real observations, so navigation and
+  // the cursor follow the drawn edge rather than the viewport end.
+  const plotEndTime = Math.max(endTime, unprojectCompositeTimestamp(timeScale, 1));
+  // A step holds its level to the newest observation and no further: the space
+  // reserved after it stays empty. With data still ahead of the window, the
+  // level runs to the drawn edge instead.
+  const stepTrailingTime = Math.min(plotEndTime, Math.max(lastTime, endTime));
   const scopedSeries = viewport
     ? dataSeries.flatMap((entry) => scopeSeriesToViewport(entry, startTime, endTime, timeScale) ?? [])
     : dataSeries;
@@ -493,11 +563,11 @@ export function buildCompositeChartScene(
   const usableSeries = emptyRange
     ? dataSeries.map((entry) => ({ ...entry, points: [] }))
     : scopedSeries;
-  const visibleTimes = uniqueTimes.filter((time) => time >= startTime && time <= endTime);
+  const visibleTimes = uniqueTimes.filter((time) => time >= startTime && time <= plotEndTime);
   const marketTimes = timeScale.kind === "market"
     ? timeScale.anchors
       .map(({ timestamp }) => timestamp)
-      .filter((time) => time >= startTime && time <= endTime)
+      .filter((time) => time >= startTime && time <= plotEndTime)
     : [];
   const cursorTimes = timeScale.kind === "market" ? marketTimes : visibleTimes;
   const dates = (cursorTimes.length > 0
@@ -540,11 +610,15 @@ export function buildCompositeChartScene(
       series: panelSeries.flatMap((entry) => {
         const domain = axes[entry.axis];
         return domain
-          ? [{ source: entry, points: projectSeries(entry, domain, startTime, endTime, timeScale) }]
+          ? [{
+            source: entry,
+            points: projectSeries(entry, domain, startTime, stepTrailingTime, timeScale),
+          }]
           : [];
       }),
     };
   });
+  attachLastPriceMarker(panelScenes, usableSeries);
 
   return {
     width: Math.max(1, Math.floor(options.width)),

--- a/src/components/chart/composite/text-renderer.ts
+++ b/src/components/chart/composite/text-renderer.ts
@@ -251,6 +251,19 @@ export function renderCompositePanelText(
     }
   }
 
+  // Blank cells only, so the dashed level reads as if it ran under the marks.
+  if (panel.lastPrice) {
+    const row = clamp(
+      Math.round(panel.lastPrice.yRatio * Math.max(height - 1, 0)),
+      0,
+      Math.max(height - 1, 0),
+    );
+    for (let x = 0; x < plotWidth; x += 1) {
+      const current = rows[row]?.[x];
+      if (current === " " || current === "·") setCell(rows, x, row, "╌");
+    }
+  }
+
   if (cursorXRatio !== null) {
     const cursorX = clamp(Math.round(cursorXRatio * Math.max(plotWidth - 1, 0)), 0, Math.max(plotWidth - 1, 0));
     for (let y = 0; y < height; y += 1) {

--- a/src/components/chart/composite/time-scale.ts
+++ b/src/components/chart/composite/time-scale.ts
@@ -3,6 +3,14 @@ import type { CompositeTimeScale } from "./types";
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
 const QUARTER_HOUR_MS = 15 * 60 * 1_000;
+/**
+ * Empty space kept after the newest observation, as a fraction of the visible
+ * span, so the last bar is drawn whole with air after it instead of hugging the
+ * value axis. Six percent is three to five bar slots on the windows these
+ * charts show, and because it scales with the plot it reads the same in a
+ * narrow terminal pane and at desktop pixel widths.
+ */
+export const COMPOSITE_RIGHT_OFFSET_RATIO = 0.06;
 const MINIMUM_SLOT_FRACTION = 0.25;
 const dateFormatters = new Map<string, Intl.DateTimeFormat>();
 // Session dates are looked up once per quarter hour, not once per bar: a day
@@ -202,11 +210,13 @@ export function buildCompositeTimeScale(
   timelineSeries: readonly ResolvedSeries[],
   startTime: number,
   endTime: number,
+  rightOffsetRatio = 0,
 ): CompositeTimeScale {
+  const offset = Number.isFinite(rightOffsetRatio) && rightOffsetRatio > 0 ? rightOffsetRatio : 0;
   const anchorSeries = timelineSeries.find((series) => series.timeBasis?.kind === "market");
   const resolved = anchorSeries ? resolveMarketAnchors(anchorSeries) : null;
   if (!anchorSeries || !resolved || resolved.anchors.length === 0) {
-    return { kind: "calendar", startTime, endTime };
+    return { kind: "calendar", startTime, endTime, rightOffsetRatio: offset };
   }
   const { cadenceMs, anchors } = resolved;
   const startPosition = positionForTimestamp({ anchors, cadenceMs }, startTime);
@@ -220,7 +230,22 @@ export function buildCompositeTimeScale(
     anchors,
     startPosition,
     endPosition: endPosition > startPosition ? endPosition : startPosition + 1,
+    rightOffsetRatio: offset,
   };
+}
+
+/** Fraction of the visible span held empty after the newest observation. */
+export function compositeRightOffsetRatio(scale: CompositeTimeScale): number {
+  const ratio = scale.rightOffsetRatio ?? 0;
+  return Number.isFinite(ratio) && ratio > 0 ? ratio : 0;
+}
+
+/** Span the plot's full width covers, viewport plus reserved right offset. */
+function projectionSpan(scale: CompositeTimeScale): number {
+  const viewportSpan = scale.kind === "calendar"
+    ? Math.max(scale.endTime - scale.startTime, 1)
+    : Math.max(scale.endPosition - scale.startPosition, Number.EPSILON);
+  return viewportSpan * (1 + compositeRightOffsetRatio(scale));
 }
 
 /** Slot position of a timestamp on a market scale, or wall-clock time on a calendar scale. */
@@ -261,8 +286,7 @@ export function projectCompositeTimestamp(
 ): { ratio: number; xSlot?: number } | null {
   if (!Number.isFinite(timestamp)) return null;
   if (scale.kind === "calendar") {
-    const span = Math.max(scale.endTime - scale.startTime, 1);
-    return { ratio: (timestamp - scale.startTime) / span };
+    return { ratio: (timestamp - scale.startTime) / projectionSpan(scale) };
   }
 
   let position: number;
@@ -279,8 +303,7 @@ export function projectCompositeTimestamp(
     position = positionForTimestamp(scale, timestamp);
     if (exact?.timestamp === timestamp) xSlot = index;
   }
-  const span = Math.max(scale.endPosition - scale.startPosition, Number.EPSILON);
-  return { ratio: (position - scale.startPosition) / span, xSlot };
+  return { ratio: (position - scale.startPosition) / projectionSpan(scale), xSlot };
 }
 
 export function unprojectCompositeTimestamp(
@@ -289,10 +312,7 @@ export function unprojectCompositeTimestamp(
 ): number {
   const safeRatio = Math.max(0, Math.min(1, ratio));
   if (scale.kind === "calendar") {
-    return scale.startTime + (scale.endTime - scale.startTime) * safeRatio;
+    return scale.startTime + projectionSpan(scale) * safeRatio;
   }
-  return compositeTimeAtPosition(
-    scale,
-    scale.startPosition + (scale.endPosition - scale.startPosition) * safeRatio,
-  );
+  return compositeTimeAtPosition(scale, scale.startPosition + projectionSpan(scale) * safeRatio);
 }

--- a/src/components/chart/composite/types.ts
+++ b/src/components/chart/composite/types.ts
@@ -43,6 +43,12 @@ export interface CompositeCalendarTimeScale {
   kind: "calendar";
   startTime: number;
   endTime: number;
+  /**
+   * Empty space reserved after `endTime`, as a fraction of the visible span.
+   * The 0..1 projection covers `startTime` to `endTime` plus that space, so
+   * the newest observation is drawn whole with air after it. Absent means none.
+   */
+  rightOffsetRatio?: number;
 }
 
 export interface CompositeMarketTimeScale {
@@ -56,7 +62,10 @@ export interface CompositeMarketTimeScale {
     position: number;
   }>;
   startPosition: number;
+  /** Slot of `endTime`; the reserved right offset extends past it. */
   endPosition: number;
+  /** Empty slots reserved after `endPosition`, as a fraction of the visible span. */
+  rightOffsetRatio?: number;
 }
 
 export type CompositeTimeScale = CompositeCalendarTimeScale | CompositeMarketTimeScale;
@@ -66,6 +75,15 @@ export interface CompositeProjectedSeries {
   points: CompositeProjectedPoint[];
 }
 
+/** Level line at the newest close of the chart's primary price series. */
+export interface CompositeLastPriceMarker {
+  seriesId: string;
+  color: string;
+  axis: CompositeAxisSide;
+  value: number;
+  yRatio: number;
+}
+
 export interface CompositePanelScene {
   id: string;
   label?: string;
@@ -73,6 +91,8 @@ export interface CompositePanelScene {
   scale: PanelScale;
   axes: Partial<Record<CompositeAxisSide, CompositeAxisDomain>>;
   series: CompositeProjectedSeries[];
+  /** Present only on the panel that holds the primary price series. */
+  lastPrice?: CompositeLastPriceMarker;
 }
 
 export interface CompositeCursorValue {
@@ -109,6 +129,12 @@ export interface BuildCompositeChartSceneOptions {
   };
   /** Authored series order retained even when the primary anchor is hidden. */
   timelineSeries?: ResolvedSeries[];
+  /**
+   * Empty space kept after the newest observation, as a fraction of the visible
+   * span. Defaults to `COMPOSITE_RIGHT_OFFSET_RATIO`; pass 0 for charts whose x
+   * is not time, where the last observation belongs at the right edge.
+   */
+  rightOffsetRatio?: number;
 }
 
 export interface CompositeChartXMarker {


### PR DESCRIPTION
## Why

The composite chart projected the last observation to x ratio 1, so the newest bar was pinned against the value axis: candles were clamped flush to the edge, column bars lost half their width, and the day a chart is usually about (an earnings gap, a -17% close) was the hardest one to read. There was also no way to read the current level off the plot without hovering.

## What

**Right offset.** `buildCompositeTimeScale` now takes a right offset and both scale kinds project the viewport plus that reserved space onto 0..1:

- `COMPOSITE_RIGHT_OFFSET_RATIO = 0.06` in `src/components/chart/composite/time-scale.ts`, a single constant expressed as a fraction of the visible span. Six percent is roughly three to five bar slots on the windows these charts show (3.8 bars on a 3M daily window), it is what TradingView reserves, and because it scales with the plot it reads the same at 60 terminal cells and at 1200 desktop pixels. Bar counts would break on dense windows and pixels would break in the terminal.
- Market scales reserve slots, calendar scales reserve time, and the same ratio drives both, so range presets, explicit viewports and the no-viewport default all get it.
- Panned back into history the reserved space holds real observations, exactly like TradingView's scroll model, so `dates` and `dateRatios` now run to the drawn edge and the cursor can still snap to bars there. Panning right still stops at the newest observation: `clampPositions` was already the hard edge, so nothing scrolls past the offset.
- Drag pan, wheel pan and wheel zoom convert the pointer through the plot span, so bars keep pace with the pointer and a zoom anchored over the empty space anchors on the newest bar.
- Step series hold their level to the newest observation instead of the plot edge, and never into the reserved space.
- Charts with a custom `xAxis` (yield curve tenors, Kelly fractions, scatter returns) opt out with ratio 0: their last observation belongs under its own label at the right edge.

**Last price marker.** The scene attaches a `lastPrice` marker to the panel that draws the chart's primary price series, that is the first exchange traded series whose unit group is a price, raw or transformed. Study outputs are appended after the series they derive from, so an overlay indicator never wins, and volume, oscillator and derived panels have no marker at all.

- Desktop and browser: the canvas bitmap rasterizer draws a real dashed pixel line, no cell characters.
- Terminal: the kitty path uses the same bitmap; the text fallback fills blank cells with `╌` so the level reads as if it ran under the marks.
- The label goes in the gutter of the axis the series actually uses, in the series colour. Gloomberb puts the price axis on the left, so a hardcoded right gutter would have drawn the label into a zero-width axis.

Legend, ticks, cursor readouts and drawings are untouched. Drawings are stored as timestamps and reprojected, so they stay anchored to their bars.

## Verify

`bun test` (2497 pass) and `bun run typecheck` are green. Tests extended in `scene.test.ts` and `renderers.test.ts` for the reserved offset on both scale kinds, cursor snapping inside it, the step tail stopping at the newest observation, and the marker value equalling the last close.

Desktop, `gloomberb shot --theme tokyo`. Images are in `artifacts/chart-right-offset/` (gitignored) and `/tmp/gbshots/`:

| Shot | Before | After |
| --- | --- | --- |
| `GP VSXY --rangePreset 3M` | `artifacts/chart-right-offset/before-vsxy.png` | `artifacts/chart-right-offset/after-vsxy.png` |
| `CMP AVGO,NVDA,MRVL --rangePreset 3M` | `artifacts/chart-right-offset/before-cmp.png` | `artifacts/chart-right-offset/after-cmp.png` |
| `GP NVDA --rangePreset 1Y` | `artifacts/chart-right-offset/before-nvda.png` | `artifacts/chart-right-offset/after-nvda.png` |
| `GP VSXY --rangePreset 5Y` | `artifacts/chart-right-offset/before-5y.png` | `artifacts/chart-right-offset/after-5y.png` |
| `GC` (unchanged, x is not time) | | `artifacts/chart-right-offset/after-gc.png` |

Each after shot shows the newest bar whole with air after it, the dashed level at the last close, and the label in the series colour.

Terminal, `GP VSXY` in tmux at 160x45: the last candle and the last volume bar sit about four cells short of the axis, the dashed row runs the width with `73.6` on its axis row, keyboard cursor lands on `2026-08-31` rather than the empty space, and panning right eight times does not move the newest bar past the offset. Session killed, leak sweep clean.

## Open questions

- Every time based composite chart gets the margin, including the small static ones (Fear and Greed history, dividend yield, econ detail). That is consistent and matches the no-viewport default the brief asked for, but it does cost those sparklines about 6 percent of plot width. Happy to gate it to navigable charts if you would rather keep them full bleed.
- Under about six visible bars, half a candle is wider than 6 percent of the span, so the newest body still ends flush against the axis, held inside only by the rasterizer clamp. Fixing that needs a second term (at least three quarters of a bar slot) rather than a single ratio; it seemed worse than the wart.
- The time axis end label stays right aligned on the viewport end while the bar it names now sits a little to its left. That was already true before this change; the extra room means one more interior tick can fit on long ranges (the 5Y shot gains a `Jan 2026`).
