### PR TITLE
Keep a study's panel in place while its data loads

### DIFF
--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -304,6 +304,70 @@ describe("CompositeChart", () => {
     expect(testSetup.captureCharFrame()).toContain("ACME Price $110 +10.65%");
   });
 
+  test("holds a lower panel's rows while its series has no observations in view", async () => {
+    const price: ResolvedSeries = {
+      ...series("price", "main", "left", "USD", []),
+      points: [
+        point("2025-01-01", 100),
+        point("2025-01-02", 103),
+        point("2025-01-03", 101),
+        point("2025-01-04", 104),
+        point("2025-01-05", 102),
+      ],
+    };
+    const volume: ResolvedSeries = {
+      ...series("volume", "volume", "left", "shares", []),
+      label: "Volume",
+      unitGroup: "volume",
+      style: "columns",
+      points: [point("2025-01-01", 4_000), point("2025-01-02", 6_000)],
+    };
+    const panels = [{ id: "main", height: 3 }, { id: "volume", height: 1 }];
+    const renderChart = async (
+      volumeSeries: ResolvedSeries,
+      viewport?: { start: Date; end: Date },
+    ) => {
+      testSetup = await testRender(
+        <CompositeChart
+          width={78}
+          height={18}
+          series={[price, volumeSeries]}
+          panels={panels}
+          viewport={viewport}
+        />,
+        { width: 80, height: 20 },
+      );
+      await act(async () => {
+        await testSetup!.renderOnce();
+        await testSetup!.renderOnce();
+      });
+      const frame = testSetup!.captureCharFrame();
+      await act(async () => testSetup!.renderer.destroy());
+      testSetup = undefined;
+      return frame;
+    };
+    // The lowest price-axis label sits on the boundary between the two panels,
+    // so it moves down the moment the lower panel gives up its rows.
+    const priceAxisFloor = (frame: string) => frame
+      .split("\n")
+      .reduce((row, line, index) => line.includes("$") ? index : row, -1);
+
+    const loaded = await renderChart(volume);
+    // Panned to a window the upper panel covers and the lower panel has no bars in.
+    const panned = await renderChart(volume, {
+      start: new Date("2025-01-03T00:00:00.000Z"),
+      end: new Date("2025-01-05T00:00:00.000Z"),
+    });
+    // The same chart before the lower panel's data has loaded at all.
+    const loading = await renderChart({ ...volume, points: [] });
+
+    expect(priceAxisFloor(loaded)).toBeGreaterThan(0);
+    expect(priceAxisFloor(panned)).toBe(priceAxisFloor(loaded));
+    expect(priceAxisFloor(loading)).toBe(priceAxisFloor(loaded));
+    // A panel with loaded history keeps its axis while the window holds no bars.
+    expect(panned).toMatch(/\dK/);
+  });
+
   test("lays out mixed panels with one shared legend and time axis", async () => {
     testSetup = await testRender(
       <CompositeChart

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -1611,6 +1611,9 @@ export function CompositeChart({
   const stableSeries = reuseResolvedSeriesList(seriesIdentityRef.current, series);
   seriesIdentityRef.current = stableSeries;
   const visibleSeries = useMemo(() => stableSeries.filter((entry) => entry.points.length > 0), [stableSeries]);
+  // Panel layout follows the authored series so a panel keeps its height while
+  // its data loads; only the marks inside it wait for observations.
+  const panelSeries = useMemo(() => stableSeries.filter((entry) => !entry.hidden), [stableSeries]);
   const marketTimelineSeries = useMemo(() => {
     const supplied = timelineSeries?.filter((entry) => entry.points.length > 0) ?? [];
     return supplied.some((entry) => entry.timeBasis?.kind === "market")
@@ -1749,7 +1752,7 @@ export function CompositeChart({
   const timeAxisRows = showTimeAxis ? 1 : 0;
   const xMarkers = xAxis?.markers ?? NO_X_MARKERS;
   const xMarkerRows = xMarkers.some((marker) => marker.label) ? 1 : 0;
-  const panelCount = new Set(visibleSeries.map((entry) => entry.panelId)).size;
+  const panelCount = new Set(panelSeries.map((entry) => entry.panelId)).size;
   const lastTickKey = visibleSeries.map((entry) => {
     const last = entry.points.at(-1);
     if (!last) return entry.id;
@@ -1767,13 +1770,13 @@ export function CompositeChart({
   const projectedScene = useMemo(() => {
     // lastTickKey busts this memo when a live tick mutates series identity in place.
     void lastTickKey;
-    return buildCompositeChartScene(visibleSeries, panels, {
+    return buildCompositeChartScene(panelSeries, panels, {
       width: 1,
       height: Math.max(panelCount, 1),
       viewport: effectiveViewport ?? undefined,
       timelineSeries: marketTimelineSeries,
     });
-  }, [effectiveViewport, lastTickKey, marketTimelineSeries, panelCount, panels, visibleSeries]);
+  }, [effectiveViewport, lastTickKey, marketTimelineSeries, panelCount, panelSeries, panels]);
   // Gutters follow the axes the scene actually built. Reading the series list
   // instead drops a gutter the moment its series has no observation in view,
   // which is exactly what a zoom does, taking the axis labels with it.

--- a/src/components/chart/composite/scene.test.ts
+++ b/src/components/chart/composite/scene.test.ts
@@ -37,6 +37,49 @@ function series(overrides: Partial<ResolvedSeries> & Pick<ResolvedSeries, "id" |
 }
 
 describe("composite chart scene", () => {
+  test("keeps a panel and its height while its series has no observations in view", () => {
+    const price = series({
+      id: "price",
+      points: [point("2025-01-01", 90), point("2025-01-02", 95), point("2025-01-03", 110)],
+    });
+    const volume = series({
+      id: "volume",
+      panelId: "volume",
+      style: "columns",
+      unit: "shares",
+      unitGroup: "volume",
+      points: [point("2025-01-01", 1_000), point("2025-01-02", 1_200), point("2025-01-03", 1_400)],
+    });
+    const panels = [{ id: "main" }, { id: "volume", height: 0.25 }];
+    const options = { width: 10, height: 8 };
+
+    const loaded = buildCompositeChartScene([price, volume], panels, {
+      ...options,
+      viewport: { start: new Date("2025-01-01T00:00:00.000Z"), end: new Date("2025-01-03T00:00:00.000Z") },
+    });
+    // The same window, with the lower panel's data not yet loaded.
+    const loading = buildCompositeChartScene([price, { ...volume, points: [] }], panels, {
+      ...options,
+      viewport: { start: new Date("2025-01-01T00:00:00.000Z"), end: new Date("2025-01-03T00:00:00.000Z") },
+    });
+    // A window the upper panel covers and the lower panel has no bars in.
+    const partial = buildCompositeChartScene([price, {
+      ...volume,
+      points: [point("2025-01-01", 1_000)],
+    }], panels, {
+      ...options,
+      viewport: { start: new Date("2025-01-02T00:00:00.000Z"), end: new Date("2025-01-03T00:00:00.000Z") },
+    });
+
+    const layout = (scene: typeof loaded) => scene?.panels.map((panel) => [panel.id, panel.height]);
+    expect(layout(loaded)).toEqual([["main", 6], ["volume", 2]]);
+    expect(layout(loading)).toEqual(layout(loaded));
+    expect(layout(partial)).toEqual(layout(loaded));
+    expect(loading?.panels[1]?.series).toEqual([]);
+    // The axis still reads the loaded history, so the gutter does not jump either.
+    expect(partial?.panels[1]?.axes.left?.max).toBeGreaterThan(0);
+  });
+
   test("keeps panels synchronized while preserving independent dual-axis domains", () => {
     const price = series({
       id: "price",

--- a/src/components/chart/composite/scene.ts
+++ b/src/components/chart/composite/scene.ts
@@ -514,22 +514,24 @@ export function buildCompositeChartScene(
   const cursorXRatio = cursorDate
     ? projectCompositeTimestamp(timeScale, cursorDate.getTime())?.ratio ?? null
     : null;
-  const orderedPanels = panelSpecsForSeries(usableSeries, panels);
+  // Panels belong to the authored series, not to whichever of them happen to
+  // hold observations right now. A panel that disappears while its data loads
+  // reflows every other panel, and the chart jumps again when it comes back.
+  const orderedPanels = panelSpecsForSeries(series, panels);
   const panelHeights = allocateCompositePanelHeights(orderedPanels, options.height);
 
-  const panelScenes: CompositePanelScene[] = orderedPanels.flatMap((panel) => {
+  const panelScenes: CompositePanelScene[] = orderedPanels.map((panel) => {
     const panelSeries = usableSeries.filter((entry) => entry.panelId === panel.id);
-    if (panelSeries.length === 0) return [];
     const scale = panel.scale ?? "linear";
-    // An empty range has no in-view values, so scale its axes to the loaded
-    // history rather than the meaningless 0..1 fallback.
-    const domainSeries = emptyRange
+    // With no in-view values, scale the axes to the loaded history rather than
+    // the meaningless 0..1 fallback, so the panel keeps its gutter and grid.
+    const domainSeries = emptyRange || panelSeries.length === 0
       ? dataSeries.filter((entry) => entry.panelId === panel.id)
       : panelSeries;
     const left = buildAxisDomain("left", domainSeries, scale);
     const right = buildAxisDomain("right", domainSeries, scale);
     const axes: Partial<Record<CompositeAxisSide, CompositeAxisDomain>> = { left, right };
-    return [{
+    return {
       id: panel.id,
       label: panel.label,
       height: panelHeights.get(panel.id) ?? 1,
@@ -541,7 +543,7 @@ export function buildCompositeChartScene(
           ? [{ source: entry, points: projectSeries(entry, domain, startTime, endTime, timeScale) }]
           : [];
       }),
-    }];
+    };
   });
 
   return {

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -3,7 +3,12 @@ import type { FredSeriesData, FredSeriesLoadResult } from "../data/fred-series";
 import { createTestDataProvider } from "../test-support/data-provider";
 import type { TickerFinancials } from "../types/financials";
 import { CHART_SPEC_VERSION, type ChartSpec } from "./types";
-import { ChartResolveCache, mergePriceHistoryWindows, resolveChartSpecData } from "./resolve";
+import {
+  ChartResolveCache,
+  mergePriceHistoryWindows,
+  resolveChartSpecData,
+  seedChartResolutionResult,
+} from "./resolve";
 import { chartQuoteOverrideKeyForSource } from "./live-quotes";
 import { chartSeriesSourceKey } from "../capabilities";
 import { buildCustomChartPreset } from "../plugins/builtin/chart-composer/presets";
@@ -26,6 +31,118 @@ const fredLoad = (
 });
 
 describe("resolveChartSpecData", () => {
+  test("seeds study series so their panels survive the wait for real data", async () => {
+    const date = new Date("2026-01-05T00:00:00.000Z");
+    const seeded = seedChartResolutionResult(
+      {
+        version: CHART_SPEC_VERSION,
+        viewport: { range: "1M", resolution: "auto" },
+        panels: [{ id: "main" }, { id: "volume" }],
+        series: [{
+          id: "price",
+          source: {
+            kind: "security",
+            instrument: { symbol: "TEST", exchange: "NASDAQ" },
+            fieldId: "market.ohlcv",
+          },
+          style: "candles",
+          transform: "raw",
+          axis: "left",
+          panelId: "main",
+          interpolation: "none",
+        }],
+        studies: [{
+          id: "volume",
+          kind: "volume",
+          inputSeriesIds: ["price"],
+          parameters: {},
+          panelId: "volume",
+          axis: "left",
+        }],
+      },
+      new Map([[
+        chartQuoteOverrideKeyForSource({
+          kind: "security",
+          instrument: { symbol: "TEST", exchange: "NASDAQ" },
+          fieldId: "market.ohlcv",
+        }),
+        [{ date, open: 10, high: 12, low: 9, close: 11, volume: 5_000 }],
+      ]]),
+    );
+
+    const volume = seeded?.series.find((entry) => entry.panelId === "volume");
+    expect(volume?.points.map((point) => point.value)).toEqual([5_000]);
+    expect(seeded?.bufferedSeries).toBe(seeded?.series);
+  });
+
+  test("keeps study output over the whole buffered history its base series carries", async () => {
+    const history = Array.from({ length: 900 }, (_, day) => {
+      const date = new Date(Date.UTC(2024, 0, 1) + day * 86_400_000);
+      return date.getUTCDay() === 0 || date.getUTCDay() === 6
+        ? null
+        : { date, open: 100, high: 101, low: 99, close: 100 + (day % 7), volume: 1_000 + day };
+    }).filter((point): point is NonNullable<typeof point> => point !== null);
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => emptyFinancials(),
+      getChartResolutionSupport: () => [{ resolution: "1d", maxRange: "ALL" }],
+      getPriceHistoryForResolution: async () => history,
+      getDetailedPriceHistory: async () => history,
+    });
+    const spec: ChartSpec = {
+      version: CHART_SPEC_VERSION,
+      viewport: { range: "1Y", resolution: "1d" },
+      panels: [{ id: "main" }, { id: "volume", label: "Volume", height: 0.24 }],
+      series: [{
+        id: "price",
+        source: {
+          kind: "security",
+          instrument: { symbol: "TEST", exchange: "NASDAQ" },
+          fieldId: "market.close",
+        },
+        style: "line",
+        transform: "raw",
+        axis: "left",
+        panelId: "main",
+        interpolation: "none",
+      }],
+      studies: [{
+        id: "volume",
+        kind: "volume",
+        inputSeriesIds: ["price"],
+        parameters: {},
+        panelId: "volume",
+        axis: "left",
+      }],
+    };
+    const sources = {
+      dataProvider: provider,
+      now: new Date("2026-06-15T00:00:00.000Z"),
+      loadFredSeries: async () => fredLoad(),
+    };
+    const cache = new ChartResolveCache();
+
+    await resolveChartSpecData(spec, sources, cache);
+    // Panning back accumulates older bars into the buffer. The study has to
+    // follow, or it empties out wherever the base series has already been.
+    const panned = await resolveChartSpecData(spec, sources, cache, {
+      requestViewport: {
+        start: new Date("2024-02-01T00:00:00.000Z"),
+        end: new Date("2024-08-01T00:00:00.000Z"),
+      },
+    });
+
+    const span = (id: string) => {
+      const entry = panned.bufferedSeries?.find((candidate) => candidate.id === id);
+      return entry && entry.points.length > 0
+        ? {
+            first: entry.points[0]!.date.toISOString(),
+            last: entry.points.at(-1)!.date.toISOString(),
+          }
+        : null;
+    };
+    expect(span("volume")).toEqual(span("price"));
+  });
+
   test("routes futures and Treasury aliases through the existing market and FRED pipelines", async () => {
     const marketRequests: string[] = [];
     const fredRequests: string[] = [];

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -384,10 +384,16 @@ export function seedChartResolutionResult(
     if (resolved?.points.length) series.push(resolved);
   });
   if (series.length === 0) return null;
+  // Studies ride along with the seed. Without them the chart briefly drops to
+  // base series alone whenever it falls back here, and every panel a study
+  // owns loses its rows until the first real resolve lands.
+  const seeded = spec.studies.length > 0
+    ? [...series, ...resolveStudies(series, spec.studies).series]
+    : series;
   return {
-    series,
-    legendSeries: series,
-    bufferedSeries: series,
+    series: seeded,
+    legendSeries: seeded,
+    bufferedSeries: seeded,
     loading: false,
     errors: [],
     warnings: [],
@@ -805,13 +811,6 @@ function prepareBaseSeriesForStudies(
   );
 }
 
-function rawCalculationSeries(series: ResolvedSeries, bounds: DateBounds): ResolvedSeries {
-  if (bounds.start !== null && bounds.end !== null) {
-    return clipSeriesToWindow(series, new Date(bounds.start), new Date(bounds.end));
-  }
-  return { ...series, points: filterPoints(series.points, bounds) };
-}
-
 function scalarBaseline(series: ResolvedSeries, bounds: DateBounds): number | null {
   const points = filterPoints(series.points, bounds);
   for (const point of points) {
@@ -1148,15 +1147,14 @@ export async function resolveChartSpecData(
     ? requestVisibleBounds
     : followLatestMarketObservation(initialVisibleBounds, rawSeries);
   const resolution = initialResolution;
-  const studyBounds = bounds.end !== null
-      && initialCalculationBounds.end !== null
-      && bounds.end > initialCalculationBounds.end
-    ? { ...initialCalculationBounds, end: bounds.end }
-    : initialCalculationBounds;
   const baseSeries = rawSeries
     .filter((entry) => visibleSeriesIds.has(entry.id))
     .map((entry) => prepareBaseSeriesForStudies(entry, bounds, false, requestVisibleBounds));
-  const calculationSeries = rawSeries.map((entry) => rawCalculationSeries(entry, studyBounds));
+  // Studies run over the same loaded history their base series carries. Clipping
+  // them to the requested window instead left a study with no observations
+  // wherever the accumulated buffer had already been panned past, so a study's
+  // panel emptied out mid-pan and only refilled once the next fetch landed.
+  const calculationSeries = rawSeries;
   let resolved = baseSeries;
 
   // Study outputs are appended by the pure engine before the final viewport clip.


### PR DESCRIPTION
The volume panel disappears while panning and comes back a moment later, reflowing the rest of the chart each way. Three independent causes, all of which let a panel's rows depend on whether its series happened to hold observations at that instant.

## Studies did not cover their base series

Study outputs were computed over the requested window, while base series keep the whole accumulated buffer. Panning back through history and forward again left the price line drawn over ground the volume study no longer covered, so the panel emptied until the next fetch landed. Studies now run over the same loaded history their base series carries.

## The seeded fallback dropped every study

The chart falls back to a seeded result whenever a resolve returns nothing renderable, and that seed carried base series only. Every panel owned by a study lost its rows for as long as the fallback was in effect, which is what made a range switch visibly reflow the chart. The seed now resolves the spec's studies over its own history, so panels stay put and the bars come from the seeded history instead of being blank.

## Panels followed in-view data

Panels were assembled from whichever series currently had points inside the viewport, so a panel vanished the moment its data left the window. Panels now follow the authored series. One with no observations in view keeps its rows and grid, and takes its axis from the loaded history so the gutter does not jump either.

## Verification

- `bun test`: 2498 pass. Typecheck clean for opentui, electrobun-view and browser.
- Three regression tests, each confirmed to fail without its fix: study span against the buffered base series, studies present in the seed, and panel rows held at the scene and component levels.
- Terminal probe on a price-and-volume chart, sampling the panel boundary across seven range switches and forty rapid pan reversals. The volume panel lost its rows in 35 of 168 sampled frames before this change and 0 of 168 after.

## Tradeoff

Studies now scale with the accumulated buffer rather than the request window. Measured at roughly 6 ms for three studies over 10k bars and 24 ms over 50k, on a debounced resolve rather than per frame. Provider resolution caps keep realistic buffers in the low thousands of bars.
