### PR TITLE
Fix GIP screenshots with real intraday bars

### DIFF
--- a/src/cli/desktop-pane-shot.ts
+++ b/src/cli/desktop-pane-shot.ts
@@ -3,7 +3,8 @@ import { tmpdir } from "os";
 import { join, resolve, sep } from "path";
 import type { AppConfig } from "../types/config";
 import type { ResolvedSeries } from "../time-series/types";
-import type { OptionsChain, TickerFinancials } from "../types/financials";
+import type { OptionsChain, PricePoint, TickerFinancials } from "../types/financials";
+import type { ManualChartResolution } from "../time-series/resolution";
 import type { TickerRecord } from "../types/ticker";
 import type { PaneRuntimeState } from "../core/state/app/state";
 import type { RemoteUiNodeSnapshot } from "../remote/types";
@@ -13,6 +14,19 @@ import {
   electrobunViewPath,
   writeElectrobunViewPage,
 } from "../renderers/electrobun/view/build-assets";
+
+export interface DesktopPaneShotIntradayHistory {
+  symbol: string;
+  exchange: string;
+  rangePreset: "1D" | "1W";
+  resolution: ManualChartResolution;
+  requestedSession: string | null;
+  sessionDates: string[];
+  points: PricePoint[];
+  start: string | null;
+  end: string | null;
+  unavailableReason: string | null;
+}
 
 export interface DesktopPaneShotPayload {
   config: AppConfig;
@@ -27,6 +41,7 @@ export interface DesktopPaneShotPayload {
   watermark?: string | null;
   tickers: TickerRecord[];
   financials: Array<[string, TickerFinancials]>;
+  intradayHistories: DesktopPaneShotIntradayHistory[];
   optionsChains: Array<[string, OptionsChain]>;
   fredSeries: Array<[string, FredSeriesCacheEntry]>;
   valuationSeries: Array<[string, DatedObservation[]]>;

--- a/src/cli/pane-functions/capabilities.ts
+++ b/src/cli/pane-functions/capabilities.ts
@@ -376,10 +376,32 @@ const CAPABILITIES: Record<string, PaneFunctionCapability> = {
     intents: ["chart intraday security prices"],
     outputKind: "price-history",
     reportReadiness: "ready",
-    screenshotReadiness: "partial",
+    screenshotReadiness: "ready",
     dataRequirements: ["intraday price history"],
-    limitations: ["Intraday availability depends on the selected market-data provider."],
-    options: [],
+    limitations: ["Intraday availability and historical retention depend on the selected market-data provider."],
+    options: [
+      {
+        key: "rangePreset",
+        description: "Session window. 1D selects the latest session and 1W selects the latest five sessions.",
+        type: "enum",
+        aliases: ["range"],
+        values: RANGE_VALUES.filter(({ value }) => value === "1D" || value === "1W"),
+        defaultValue: "1D",
+      },
+      {
+        key: "chartResolution",
+        description: "Intraday sampling interval. Auto uses 1m for 1D and 5m for 1W.",
+        type: "enum",
+        aliases: ["resolution"],
+        values: ["auto", "5m", "15m", "1h"].map((value) => ({ value })),
+        defaultValue: "auto",
+      },
+      {
+        key: "session",
+        description: "Specific exchange-local session in YYYY-MM-DD form. Overrides the session window.",
+        type: "string",
+      },
+    ],
   },
 };
 

--- a/src/cli/pane-functions/index.ts
+++ b/src/cli/pane-functions/index.ts
@@ -106,16 +106,14 @@ export async function runPaneScreenshot(args: string[], ctx: CliCommandContext) 
       });
       if (parsed.requireBotSafe && !result.usable) {
         throw new Error(
-          `${resolved.token} did not produce a usable bot-safe screenshot: `
-          + `${result.empty ? "empty render" : ""}${result.empty && !result.complete ? ", " : ""}`
-          + `${!result.complete ? `missing data for ${result.unavailableSymbols.join(", ")}` : ""}`
-          + `${result.semanticMismatch ? `${(result.empty || !result.complete) ? ", " : ""}rendered content did not match the requested capability` : ""}`,
+          `${resolved.token} did not produce a usable bot-safe screenshot: ${result.unusableReason ?? "unknown reason"}`,
         );
       }
       ctx.printResult({ data: result }, {
         text: (data) => [
           `Saved screenshot to ${data.outputPath}`,
           `Result: ${data.rowCount} semantic rows; empty=${data.empty}; complete=${data.complete}; mismatch=${data.semanticMismatch}; usable=${data.usable}`,
+          ...(data.unusableReason ? [`Unusable reason: ${data.unusableReason}`] : []),
           ...(data.unavailableSymbols.length > 0
             ? [`Unavailable symbols: ${data.unavailableSymbols.join(", ")}`]
             : []),

--- a/src/cli/pane-functions/intraday-shot.test.ts
+++ b/src/cli/pane-functions/intraday-shot.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, test } from "bun:test";
+import { CHART_COMPOSER_PANE_ID, createDefaultConfig } from "../../types/config";
+import type { DataProvider } from "../../types/data-provider";
+import type { PricePoint, TickerFinancials } from "../../types/financials";
+import {
+  buildIntradayPriceChartPreset,
+  buildPriceChartPreset,
+} from "../../plugins/builtin/chart-composer/presets";
+import type { MarketContext } from "../types";
+import {
+  buildDesktopShotPayload,
+  intradayChartEvidenceMismatchesFor,
+  shotUnusableReasonFor,
+} from "./screenshot";
+import type { ResolvedPaneFunction } from "./resolver";
+import {
+  resolveShotIntradaySessionWindow,
+  resolveShotIntradayRequest,
+} from "./intraday-shot";
+
+function sessionBars(date: string, base: number): PricePoint[] {
+  return [
+    {
+      date: new Date(`${date}T13:30:00.000Z`),
+      open: base,
+      high: base + 1,
+      low: base - 1,
+      close: base + 0.25,
+      volume: 100,
+    },
+    {
+      date: new Date(`${date}T13:35:00.000Z`),
+      open: base + 0.25,
+      high: base + 1.25,
+      low: base,
+      close: base + 0.5,
+      volume: 200,
+    },
+  ];
+}
+
+function financials(priceHistory: PricePoint[] = []): TickerFinancials {
+  return {
+    quote: {
+      symbol: "AAPL",
+      price: 108,
+      currency: "USD",
+      change: 1,
+      changePercent: 1,
+      lastUpdated: Date.parse("2026-09-03T20:00:00.000Z"),
+      listingExchangeName: "NASDAQ",
+    },
+    annualStatements: [],
+    quarterlyStatements: [],
+    priceHistory,
+  };
+}
+
+function contextWithProvider(provider: DataProvider): MarketContext {
+  return {
+    config: createDefaultConfig("/tmp/gloomberb-shot-test"),
+    dataDir: "/tmp/gloomberb-shot-test",
+    persistence: {
+      pluginState: { get: () => null },
+    },
+    store: {
+      loadTicker: async () => ({
+        metadata: {
+          ticker: "AAPL",
+          exchange: "NASDAQ",
+          currency: "USD",
+          name: "Apple",
+          portfolios: [],
+          watchlists: [],
+          positions: [],
+          custom: {},
+          tags: [],
+        },
+      }),
+    },
+    dataProvider: provider,
+  } as unknown as MarketContext;
+}
+
+function resolvedChart(
+  capabilityId: "intraday-price-chart" | "price-chart",
+  spec: ReturnType<typeof buildIntradayPriceChartPreset>,
+  options: Record<string, string>,
+): ResolvedPaneFunction {
+  return {
+    pane: { id: CHART_COMPOSER_PANE_ID },
+    capability: { id: capabilityId, options: [] },
+    options,
+    instance: {
+      instanceId: `${capabilityId}:test`,
+      paneId: CHART_COMPOSER_PANE_ID,
+      title: "AAPL",
+      binding: { kind: "fixed", symbol: "AAPL" },
+      settings: { chartSpec: spec },
+    },
+    createOptions: { symbol: "AAPL" },
+  } as unknown as ResolvedPaneFunction;
+}
+
+async function payloadFor(
+  resolved: ResolvedPaneFunction,
+  provider: DataProvider,
+) {
+  return buildDesktopShotPayload(
+    resolved,
+    contextWithProvider(provider),
+    "AAPL",
+    {},
+    1200,
+    675,
+    "tokyo",
+    1.5,
+    null,
+  );
+}
+
+describe("GIP session windows", () => {
+  const history = [
+    ...sessionBars("2026-08-27", 100),
+    ...sessionBars("2026-08-28", 101),
+    ...sessionBars("2026-08-31", 102),
+    ...sessionBars("2026-09-01", 103),
+    ...sessionBars("2026-09-02", 104),
+    ...sessionBars("2026-09-03", 105),
+  ];
+
+  test("resolves the latest session, latest five sessions, and an explicit session", () => {
+    const latest = resolveShotIntradaySessionWindow(history, {
+      rangePreset: "1D",
+      timeZone: "America/New_York",
+    });
+    expect(latest.sessionDates).toEqual(["2026-09-03"]);
+    expect(latest.points).toHaveLength(2);
+
+    const week = resolveShotIntradaySessionWindow(history, {
+      rangePreset: "1W",
+      timeZone: "America/New_York",
+    });
+    expect(week.sessionDates).toEqual([
+      "2026-08-28",
+      "2026-08-31",
+      "2026-09-01",
+      "2026-09-02",
+      "2026-09-03",
+    ]);
+    expect(week.points).toHaveLength(10);
+
+    const explicit = resolveShotIntradaySessionWindow(history, {
+      rangePreset: "1W",
+      session: "2026-09-01",
+      timeZone: "America/New_York",
+    });
+    expect(explicit.sessionDates).toEqual(["2026-09-01"]);
+    expect(explicit.points.map((point) => point.close)).toEqual([103.25, 103.5]);
+  });
+
+  test("maps Auto to the preset interval and validates explicit dates", () => {
+    expect(resolveShotIntradayRequest({ rangePreset: "1D", chartResolution: "auto" }))
+      .toEqual({ rangePreset: "1D", resolution: "1m", session: null });
+    expect(resolveShotIntradayRequest({ rangePreset: "1W", chartResolution: "auto" }))
+      .toEqual({ rangePreset: "1W", resolution: "5m", session: null });
+    expect(resolveShotIntradayRequest({
+      rangePreset: "1W",
+      chartResolution: "15m",
+      session: "2026-09-02",
+    })).toEqual({ rangePreset: "1D", resolution: "15m", session: "2026-09-02" });
+    expect(() => resolveShotIntradayRequest({ session: "2026-02-30" }))
+      .toThrow("real calendar date");
+  });
+});
+
+describe("GIP screenshot payload", () => {
+  test("injects resolution-aware intraday bars for GIP", async () => {
+    const calls: Array<{ range: string; resolution: string }> = [];
+    const history = [
+      ...sessionBars("2026-09-02", 100),
+      ...sessionBars("2026-09-03", 105),
+    ];
+    const provider = {
+      id: "test",
+      name: "Test",
+      getTickerFinancials: async () => financials([
+        { date: new Date("2026-09-03T00:00:00.000Z"), close: 105 },
+      ]),
+      getPriceHistory: async () => [],
+      getPriceHistoryForResolution: async (_symbol, _exchange, range, resolution) => {
+        calls.push({ range, resolution });
+        return history;
+      },
+      getDetailedPriceHistory: async () => [],
+    } as DataProvider;
+    const spec = buildIntradayPriceChartPreset("AAPL");
+    spec.viewport.resolution = "auto";
+    const payload = await payloadFor(
+      resolvedChart("intraday-price-chart", spec, {
+        rangePreset: "1D",
+        chartResolution: "auto",
+      }),
+      provider,
+    );
+
+    expect(calls).toEqual([{ range: "1W", resolution: "1m" }]);
+    expect(payload.intradayHistories).toHaveLength(1);
+    expect(payload.intradayHistories[0]).toMatchObject({
+      symbol: "AAPL",
+      exchange: "NASDAQ",
+      rangePreset: "1D",
+      resolution: "1m",
+      requestedSession: null,
+      sessionDates: ["2026-09-03"],
+      unavailableReason: null,
+    });
+    expect(payload.intradayHistories[0]?.points).toHaveLength(2);
+    expect(payload.financials[0]?.[1].priceHistory).toHaveLength(2);
+
+    const renderedEvidence = [{
+      role: "chart-data",
+      metadata: {
+        kind: "chart-composer",
+        projectedPointCount: 2,
+        baseSeries: [{
+          pointCount: 2,
+          first: { date: "2026-09-03T13:30:00.000Z", value: 105.25 },
+          last: { date: "2026-09-03T13:35:00.000Z", value: 105.5 },
+        }],
+      },
+    }];
+    const resolved = resolvedChart("intraday-price-chart", spec, {
+      rangePreset: "1D",
+      chartResolution: "auto",
+    });
+    expect(intradayChartEvidenceMismatchesFor(resolved, payload, renderedEvidence as never))
+      .toEqual([]);
+    renderedEvidence[0]!.metadata.baseSeries[0]!.pointCount = 1;
+    expect(intradayChartEvidenceMismatchesFor(resolved, payload, renderedEvidence as never))
+      .toContain("rendered intraday point count does not match");
+  });
+
+  test("keeps GP on daily history without an intraday payload", async () => {
+    let intradayCalls = 0;
+    const daily = [
+      { date: new Date("2026-09-02T00:00:00.000Z"), close: 100 },
+      { date: new Date("2026-09-03T00:00:00.000Z"), close: 105 },
+    ];
+    const provider = {
+      id: "test",
+      name: "Test",
+      getTickerFinancials: async () => financials(),
+      getPriceHistory: async () => daily,
+      getPriceHistoryForResolution: async () => {
+        intradayCalls += 1;
+        return [];
+      },
+    } as DataProvider;
+    const payload = await payloadFor(
+      resolvedChart("price-chart", buildPriceChartPreset("AAPL"), { rangePreset: "3M" }),
+      provider,
+    );
+
+    expect(intradayCalls).toBe(0);
+    expect(payload.intradayHistories).toEqual([]);
+    expect(payload.financials[0]?.[1].priceHistory).toEqual(daily);
+  });
+
+  test("records an explicit unusable reason when no intraday bars exist", async () => {
+    const provider = {
+      id: "test",
+      name: "Test",
+      getTickerFinancials: async () => financials([
+        { date: new Date("2026-09-03T00:00:00.000Z"), close: 105 },
+      ]),
+      getPriceHistory: async () => [],
+      getPriceHistoryForResolution: async () => [],
+      getDetailedPriceHistory: async () => [],
+    } as DataProvider;
+    const spec = buildIntradayPriceChartPreset("AAPL");
+    spec.viewport.resolution = "auto";
+    const resolved = resolvedChart("intraday-price-chart", spec, {
+      rangePreset: "1D",
+      chartResolution: "auto",
+      session: "2020-01-02",
+    });
+    const payload = await payloadFor(resolved, provider);
+
+    expect(payload.intradayHistories[0]?.points).toEqual([]);
+    expect(payload.intradayHistories[0]?.start).toBe("2020-01-02T05:00:00.000Z");
+    expect(payload.intradayHistories[0]?.end).toBe("2020-01-03T05:00:00.000Z");
+    expect(payload.intradayHistories[0]?.unavailableReason)
+      .toBe("No intraday price history is available for AAPL for session 2020-01-02.");
+    expect(shotUnusableReasonFor(
+      resolved,
+      payload,
+      {
+        loadingStateDetected: false,
+        errorStateDetected: false,
+        emptyStateDetected: true,
+      },
+      ["AAPL"],
+      false,
+    )).toBe("No intraday price history is available for AAPL for session 2020-01-02.");
+  });
+});

--- a/src/cli/pane-functions/intraday-shot.ts
+++ b/src/cli/pane-functions/intraday-shot.ts
@@ -1,0 +1,334 @@
+import type { DataProvider } from "../../types/data-provider";
+import type { PricePoint } from "../../types/financials";
+import type { TimeRange } from "../../time-series/range";
+import {
+  getPresetResolution,
+  isIntradayResolution,
+  type ManualChartResolution,
+} from "../../time-series/resolution";
+import { resolveExchangeTimeZone } from "../../utils/exchanges";
+import { getPricePointTimestamp } from "../../utils/price-history";
+import { zonedWallClockToUtcMs } from "../../utils/zoned-date-time";
+
+export type ShotIntradayRangePreset = "1D" | "1W";
+
+export interface ShotIntradayRequest {
+  rangePreset: ShotIntradayRangePreset;
+  resolution: ManualChartResolution;
+  session: string | null;
+}
+
+export interface ShotIntradayWindow {
+  points: PricePoint[];
+  sessionDates: string[];
+  start: Date | null;
+  end: Date | null;
+}
+
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const HISTORICAL_RETRY_DELAY_MS = 61 * 60_000;
+const DAY_MS = 24 * 60 * 60_000;
+
+function sessionDateFormatter(timeZone: string): Intl.DateTimeFormat {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
+function sessionDate(timestamp: number, timeZone: string): string {
+  const parts = new Map(
+    sessionDateFormatter(timeZone)
+      .formatToParts(new Date(timestamp))
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  );
+  return `${parts.get("year")}-${parts.get("month")}-${parts.get("day")}`;
+}
+
+export function parseShotSessionDate(value: string): {
+  year: number;
+  month: number;
+  day: number;
+} {
+  const match = DATE_ONLY_PATTERN.exec(value.trim());
+  if (!match) throw new Error(`Invalid --session value "${value}". Use YYYY-MM-DD.`);
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const candidate = new Date(Date.UTC(year, month - 1, day));
+  if (
+    candidate.getUTCFullYear() !== year
+    || candidate.getUTCMonth() !== month - 1
+    || candidate.getUTCDate() !== day
+  ) {
+    throw new Error(`Invalid --session value "${value}". Use a real calendar date.`);
+  }
+  return { year, month, day };
+}
+
+export function shotSessionUtcBounds(value: string, timeZone: string): {
+  start: Date;
+  end: Date;
+} {
+  const parsed = parseShotSessionDate(value);
+  const next = new Date(Date.UTC(parsed.year, parsed.month - 1, parsed.day + 1));
+  return {
+    start: new Date(zonedWallClockToUtcMs(
+      timeZone,
+      parsed.year,
+      parsed.month,
+      parsed.day,
+      0,
+      0,
+      0,
+    )),
+    end: new Date(zonedWallClockToUtcMs(
+      timeZone,
+      next.getUTCFullYear(),
+      next.getUTCMonth() + 1,
+      next.getUTCDate(),
+      0,
+      0,
+      0,
+    )),
+  };
+}
+
+function normalizedPoints(points: readonly PricePoint[]): PricePoint[] {
+  const byTimestamp = new Map<number, PricePoint>();
+  for (const point of points) {
+    const timestamp = getPricePointTimestamp(point);
+    if (!Number.isFinite(timestamp) || !Number.isFinite(point.close) || point.close <= 0) continue;
+    byTimestamp.set(timestamp, {
+      ...point,
+      date: point.date instanceof Date ? point.date : new Date(timestamp),
+    });
+  }
+  return [...byTimestamp.values()].sort(
+    (left, right) => getPricePointTimestamp(left) - getPricePointTimestamp(right),
+  );
+}
+
+export function resolveShotIntradaySessionWindow(
+  points: readonly PricePoint[],
+  options: {
+    rangePreset: ShotIntradayRangePreset;
+    session?: string | null;
+    timeZone?: string | null;
+  },
+): ShotIntradayWindow {
+  const timeZone = options.timeZone || "UTC";
+  const normalized = normalizedPoints(points);
+  const bySession = new Map<string, PricePoint[]>();
+  for (const point of normalized) {
+    const date = sessionDate(getPricePointTimestamp(point), timeZone);
+    const sessionPoints = bySession.get(date) ?? [];
+    sessionPoints.push(point);
+    bySession.set(date, sessionPoints);
+  }
+
+  const requestedSession = options.session?.trim() || null;
+  if (requestedSession) parseShotSessionDate(requestedSession);
+  const availableSessions = [...bySession.keys()].sort();
+  const selectedSessions = requestedSession
+    ? availableSessions.filter((date) => date === requestedSession)
+    : options.rangePreset === "1D"
+      ? availableSessions.slice(-1)
+      : availableSessions.slice(-5);
+  const selected = selectedSessions.flatMap((date) => bySession.get(date) ?? []);
+  const startTime = selected.length > 0 ? getPricePointTimestamp(selected[0]!) : Number.NaN;
+  const endTime = selected.length > 0 ? getPricePointTimestamp(selected.at(-1)!) : Number.NaN;
+  return {
+    points: selected,
+    sessionDates: selectedSessions,
+    start: Number.isFinite(startTime) ? new Date(startTime) : null,
+    end: Number.isFinite(endTime) ? new Date(endTime) : null,
+  };
+}
+
+export function hasIntradayBars(window: ShotIntradayWindow, timeZone = "UTC"): boolean {
+  if (window.points.length < 2) return false;
+  const pointsBySession = new Map<string, number[]>();
+  for (const point of window.points) {
+    const timestamp = getPricePointTimestamp(point);
+    const date = sessionDate(timestamp, timeZone);
+    const timestamps = pointsBySession.get(date) ?? [];
+    timestamps.push(timestamp);
+    pointsBySession.set(date, timestamps);
+  }
+  return [...pointsBySession.values()].some((timestamps) => (
+    timestamps.length >= 2
+    && timestamps.some((timestamp, index) => index > 0 && timestamp - timestamps[index - 1]! < DAY_MS)
+  ));
+}
+
+export function resolveShotIntradayRequest(options: {
+  rangePreset?: unknown;
+  chartResolution?: unknown;
+  session?: unknown;
+}): ShotIntradayRequest {
+  const session = typeof options.session === "string" && options.session.trim()
+    ? options.session.trim()
+    : null;
+  if (session) parseShotSessionDate(session);
+  const rangePreset = session
+    ? "1D"
+    : options.rangePreset === "1W" ? "1W" : "1D";
+  const requestedResolution = typeof options.chartResolution === "string"
+    ? options.chartResolution
+    : "auto";
+  const resolution = requestedResolution === "auto"
+    ? getPresetResolution(rangePreset)
+    : requestedResolution as ManualChartResolution;
+  if (!isIntradayResolution(resolution)) {
+    throw new Error(`GIP requires an intraday chart resolution, got "${requestedResolution}".`);
+  }
+  return { rangePreset, resolution, session };
+}
+
+function unavailableReason(symbol: string, request: ShotIntradayRequest, kind: "empty" | "not-intraday"): string {
+  const window = request.session
+    ? `session ${request.session}`
+    : request.rangePreset === "1W" ? "the latest five sessions" : "the latest session";
+  return kind === "not-intraday"
+    ? `The market-data provider did not return intraday bars for ${symbol} for ${window}.`
+    : `No intraday price history is available for ${symbol} for ${window}.`;
+}
+
+async function loadTrailingHistory(
+  provider: DataProvider,
+  symbol: string,
+  exchange: string,
+  request: ShotIntradayRequest,
+): Promise<PricePoint[]> {
+  if (!provider.getPriceHistoryForResolution) return [];
+  const fetchRange: TimeRange = request.rangePreset === "1W" && request.resolution !== "1m"
+    ? "1M"
+    : "1W";
+  try {
+    return await provider.getPriceHistoryForResolution(
+      symbol,
+      exchange,
+      fetchRange,
+      request.resolution,
+    );
+  } catch {
+    return [];
+  }
+}
+
+async function loadHistoricalFallback(
+  provider: DataProvider,
+  symbol: string,
+  exchange: string,
+  request: ShotIntradayRequest,
+  now: Date,
+): Promise<PricePoint[]> {
+  if (!provider.getDetailedPriceHistory) return [];
+  if (request.session) {
+    const timeZone = resolveExchangeTimeZone(exchange) ?? "UTC";
+    const bounds = shotSessionUtcBounds(request.session, timeZone);
+    return provider.getDetailedPriceHistory(
+      symbol,
+      exchange,
+      bounds.start,
+      bounds.end,
+      request.resolution,
+    ).catch(() => []);
+  }
+  const end = new Date(now.getTime() - HISTORICAL_RETRY_DELAY_MS);
+  const lookbackDays = request.rangePreset === "1W" ? 35 : 8;
+  const start = new Date(end.getTime() - lookbackDays * DAY_MS);
+  return provider.getDetailedPriceHistory(
+    symbol,
+    exchange,
+    start,
+    end,
+    request.resolution,
+  ).catch(() => []);
+}
+
+export async function loadShotIntradayWindow(options: {
+  provider: DataProvider;
+  symbol: string;
+  exchange: string;
+  request: ShotIntradayRequest;
+  now?: Date;
+}): Promise<ShotIntradayWindow & { unavailableReason: string | null }> {
+  const timeZone = resolveExchangeTimeZone(options.exchange) ?? "UTC";
+  let raw = options.request.session
+    ? await loadHistoricalFallback(
+        options.provider,
+        options.symbol,
+        options.exchange,
+        options.request,
+        options.now ?? new Date(),
+      )
+    : await loadTrailingHistory(
+        options.provider,
+        options.symbol,
+        options.exchange,
+        options.request,
+      );
+  let window = resolveShotIntradaySessionWindow(raw, {
+    rangePreset: options.request.rangePreset,
+    session: options.request.session,
+    timeZone,
+  });
+  let sawNonIntradayData = window.points.length > 0 && !hasIntradayBars(window, timeZone);
+
+  if (!hasIntradayBars(window, timeZone)) {
+    raw = options.request.session
+      ? await loadTrailingHistory(
+          options.provider,
+          options.symbol,
+          options.exchange,
+          options.request,
+        )
+      : await loadHistoricalFallback(
+          options.provider,
+          options.symbol,
+          options.exchange,
+          options.request,
+          options.now ?? new Date(),
+        );
+    window = resolveShotIntradaySessionWindow(raw, {
+      rangePreset: options.request.rangePreset,
+      session: options.request.session,
+      timeZone,
+    });
+    sawNonIntradayData ||= window.points.length > 0 && !hasIntradayBars(window, timeZone);
+  }
+
+  if (window.points.length === 0) {
+    const requestedWindow = options.request.session
+      ? shotSessionUtcBounds(options.request.session, timeZone)
+      : null;
+    return {
+      ...window,
+      start: requestedWindow?.start ?? window.start,
+      end: requestedWindow?.end ?? window.end,
+      unavailableReason: unavailableReason(
+        options.symbol,
+        options.request,
+        sawNonIntradayData ? "not-intraday" : "empty",
+      ),
+    };
+  }
+  if (!hasIntradayBars(window, timeZone)) {
+    const requestedWindow = options.request.session
+      ? shotSessionUtcBounds(options.request.session, timeZone)
+      : null;
+    return {
+      points: [],
+      sessionDates: window.sessionDates,
+      start: requestedWindow?.start ?? null,
+      end: requestedWindow?.end ?? null,
+      unavailableReason: unavailableReason(options.symbol, options.request, "not-intraday"),
+    };
+  }
+  return { ...window, unavailableReason: null };
+}

--- a/src/cli/pane-functions/screenshot.ts
+++ b/src/cli/pane-functions/screenshot.ts
@@ -11,6 +11,7 @@ const DEFAULT_SHOT_DEVICE_SCALE_FACTOR = 2;
 import {
   renderDesktopPaneScreenshot,
   type DesktopPaneShotApiProxy,
+  type DesktopPaneShotIntradayHistory,
   type DesktopPaneShotPayload,
   type DesktopPaneShotRenderResult,
 } from "../desktop-pane-shot";
@@ -65,6 +66,10 @@ import {
   isFinancialAnalysisFunction,
   withShotPriceHistory,
 } from "./data";
+import {
+  loadShotIntradayWindow,
+  resolveShotIntradayRequest,
+} from "./intraday-shot";
 
 const DESKTOP_CELL_WIDTH_PX = 8;
 const DESKTOP_CELL_HEIGHT_PX = 18;
@@ -289,6 +294,8 @@ export interface PaneScreenshotPriceSeriesEvidence {
   pointCount: number;
   first: PaneScreenshotChartPointEvidence;
   last: PaneScreenshotChartPointEvidence;
+  resolution?: string;
+  sessionDates?: string[];
 }
 
 export interface PaneScreenshotFundamentalSeriesEvidence {
@@ -362,6 +369,7 @@ export interface PaneScreenshotResult {
   unavailableSymbols: string[];
   semanticMismatch: boolean;
   usable: boolean;
+  unusableReason: string | null;
   dataEvidence: PaneScreenshotDataEvidence | null;
   outputPath: string;
   render: DesktopPaneShotRenderResult & {
@@ -379,7 +387,7 @@ export function defaultScreenshotPath(resolved: ResolvedPaneFunction, rawArg: st
   return resolve(process.cwd(), `gloomberb-${suffix}.png`);
 }
 
-async function buildDesktopShotPayload(
+export async function buildDesktopShotPayload(
   resolved: ResolvedPaneFunction,
   context: MarketContext,
   rawArg: string,
@@ -414,9 +422,10 @@ async function buildDesktopShotPayload(
   const paneState = stripDesktopShotCredentials<Record<string, PaneRuntimeState>>({
     [resolved.instance.instanceId]: initialPaneState,
   });
+  let shotInstance = stripDesktopShotCredentials<typeof resolved.instance>(resolved.instance);
   const layout = {
     dockRoot: null,
-    instances: [resolved.instance],
+    instances: [shotInstance],
     floating: [{
       instanceId: resolved.instance.instanceId,
       x: 0,
@@ -444,6 +453,7 @@ async function buildDesktopShotPayload(
 
   const tickers: TickerRecord[] = [];
   const financials: Array<[string, TickerFinancials]> = [];
+  const intradayHistories: DesktopPaneShotIntradayHistory[] = [];
   const optionsChains: Array<[string, OptionsChain]> = [];
   const [fredSeries, capabilitySeries, valuationSeries, statSeries] = await Promise.all([
     collectShotFredSeries(resolved),
@@ -452,16 +462,64 @@ async function buildDesktopShotPayload(
     collectShotStatSeries(resolved),
   ]);
   const includeOptionsChains = resolved.pane.id === OPTIONS_PANE_ID || resolved.template?.paneId === OPTIONS_PANE_ID;
+  const shotNow = new Date();
   for (const symbol of collectShotSymbols(resolved, rawArg)) {
     const entry = await fetchTickerFinancials(context, symbol);
     const requestedRange = shotPriceHistoryRange(resolved);
     let data = entry.financials;
-    if (requestedRange) {
-      const exchange = entry.instrument.exchange
-        ?? entry.tickerFile?.metadata.exchange
-        ?? data.quote?.listingExchangeName
-        ?? data.quote?.exchangeName
-        ?? "";
+    const exchange = entry.instrument.exchange
+      ?? entry.tickerFile?.metadata.exchange
+      ?? data.quote?.listingExchangeName
+      ?? data.quote?.exchangeName
+      ?? "";
+    if (resolved.capability.id === "intraday-price-chart") {
+      const request = resolveShotIntradayRequest(resolved.options);
+      const intraday = await loadShotIntradayWindow({
+        provider: context.dataProvider,
+        symbol: entry.instrument.symbol,
+        exchange,
+        request,
+        now: shotNow,
+      });
+      data = { ...data, priceHistory: intraday.points };
+      intradayHistories.push({
+        symbol: entry.instrument.symbol,
+        exchange,
+        rangePreset: request.rangePreset,
+        resolution: request.resolution,
+        requestedSession: request.session,
+        sessionDates: intraday.sessionDates,
+        points: intraday.points,
+        start: intraday.start?.toISOString() ?? null,
+        end: intraday.end?.toISOString() ?? null,
+        unavailableReason: intraday.unavailableReason,
+      });
+      const presetStart = subtractTimeRange(shotNow, request.rangePreset);
+      const needsExplicitWindow = request.session !== null
+        || (intraday.start !== null && intraday.start.getTime() < presetStart.getTime())
+        || (intraday.end !== null && intraday.end.getTime() > shotNow.getTime());
+      if (needsExplicitWindow && intraday.start && intraday.end) {
+        const chartSpec = parseChartSpec(shotInstance.settings?.chartSpec);
+        if (chartSpec) {
+          shotInstance = {
+            ...shotInstance,
+            settings: {
+              ...shotInstance.settings,
+              chartSpec: {
+                ...chartSpec,
+                viewport: {
+                  ...chartSpec.viewport,
+                  dateWindow: {
+                    start: intraday.start.toISOString(),
+                    end: intraday.end.toISOString(),
+                  },
+                },
+              },
+            },
+          };
+        }
+      }
+    } else if (requestedRange) {
       try {
         const priceHistory = await context.dataProvider.getPriceHistory(entry.instrument.symbol, exchange, requestedRange);
         data = { ...data, priceHistory: clipPriceHistoryToRange(priceHistory, requestedRange) };
@@ -472,15 +530,13 @@ async function buildDesktopShotPayload(
     tickers.push(entry.tickerFile ?? createFallbackTicker(symbol, data, context));
     financials.push([symbol, data]);
     if (includeOptionsChains && context.dataProvider.getOptionsChain) {
-      const exchange = entry.instrument.exchange
-        ?? entry.tickerFile?.metadata.exchange
-        ?? data.quote?.listingExchangeName
-        ?? data.quote?.exchangeName
-        ?? "";
       const chain = await context.dataProvider.getOptionsChain(entry.instrument.symbol, exchange);
       optionsChains.push([symbol, chain]);
     }
   }
+  layout.instances[0] = shotInstance;
+  config.layout.instances[0] = shotInstance;
+  if (config.layouts[0]) config.layouts[0].layout.instances[0] = shotInstance;
 
   return {
     config,
@@ -493,6 +549,7 @@ async function buildDesktopShotPayload(
     watermark,
     tickers,
     financials,
+    intradayHistories,
     optionsChains,
     fredSeries,
     valuationSeries,
@@ -525,7 +582,7 @@ export function shotPriceHistoryRange(resolved: ResolvedPaneFunction): TimeRange
     case "return-correlation":
       return (resolved.options.rangePreset ?? "1Y") as TimeRange;
     case "intraday-price-chart":
-      return "1D";
+      return (resolved.options.rangePreset ?? "1D") as TimeRange;
     case "historical-prices":
     case "security-relationship":
       return (resolved.options.range ?? "1Y") as TimeRange;
@@ -598,9 +655,10 @@ export async function renderDesktopShot({
   );
   const expectedChart = shotExpectedChart(resolved, payload);
   const dataEvidence = shotDataEvidenceFor(resolved, payload);
-  const chartEvidenceMismatches = expectedChart
-    ? chartEvidenceMismatchesFor(render.semanticUi, expectedChart)
-    : [];
+  const chartEvidenceMismatches = [
+    ...(expectedChart ? chartEvidenceMismatchesFor(render.semanticUi, expectedChart) : []),
+    ...intradayChartEvidenceMismatchesFor(resolved, payload, render.semanticUi),
+  ];
   const semanticMismatch = missingExpectedText.length > 0
     || missingExpectedSelections.length > 0
     || chartEvidenceMismatches.length > 0;
@@ -619,6 +677,9 @@ export async function renderDesktopShot({
     requiresStructuredDataEvidence: requiresStructuredDataEvidence(resolved),
     hasStructuredDataEvidence: dataEvidence !== null,
   });
+  const unusableReason = usable
+    ? null
+    : shotUnusableReasonFor(resolved, payload, render, unavailableSymbols, semanticMismatch);
   return {
     kind: "pane-screenshot",
     target: resolved.token,
@@ -637,6 +698,7 @@ export async function renderDesktopShot({
     unavailableSymbols,
     semanticMismatch,
     usable,
+    unusableReason,
     dataEvidence,
     outputPath,
     render: {
@@ -652,8 +714,37 @@ export async function renderDesktopShot({
 }
 
 function requiresStructuredDataEvidence(resolved: ResolvedPaneFunction): boolean {
-  return ["price-chart", "price-comparison", "fundamental-series", "financial-statements"]
-    .includes(resolved.capability.id);
+  return [
+    "price-chart",
+    "intraday-price-chart",
+    "price-comparison",
+    "fundamental-series",
+    "financial-statements",
+  ].includes(resolved.capability.id);
+}
+
+export function shotUnusableReasonFor(
+  resolved: ResolvedPaneFunction,
+  payload: DesktopPaneShotPayload,
+  render: Pick<DesktopPaneShotRenderResult, "loadingStateDetected" | "errorStateDetected" | "emptyStateDetected">,
+  unavailableSymbols: string[],
+  semanticMismatch: boolean,
+): string {
+  if (resolved.capability.id === "intraday-price-chart") {
+    const intraday = payload.intradayHistories[0];
+    if (intraday?.unavailableReason) return intraday.unavailableReason;
+    if (intraday && intraday.points.length > 0) {
+      return `Intraday bars were loaded for ${intraday.symbol}, but the chart did not render them.`;
+    }
+    const symbol = payload.financials[0]?.[0] ?? resolved.createOptions?.symbol ?? "the ticker";
+    return `No intraday price history is available for ${symbol} for the requested session window.`;
+  }
+  if (render.loadingStateDetected) return "The pane was still loading when the screenshot was captured.";
+  if (render.errorStateDetected) return "The pane rendered an error state.";
+  if (render.emptyStateDetected) return "The pane rendered an empty state.";
+  if (unavailableSymbols.length > 0) return `Data is unavailable for ${unavailableSymbols.join(", ")}.`;
+  if (semanticMismatch) return "The rendered content did not match the requested capability.";
+  return "The pane did not produce verifiable screenshot evidence.";
 }
 
 const STATEMENT_EVIDENCE_KEYS: Record<string, ReadonlySet<string>> = {
@@ -685,6 +776,23 @@ export function shotDataEvidenceFor(
   resolved: ResolvedPaneFunction,
   payload: DesktopPaneShotPayload,
 ): PaneScreenshotDataEvidence | null {
+  if (resolved.capability.id === "intraday-price-chart") {
+    const intraday = payload.intradayHistories[0];
+    if (!intraday || intraday.points.length === 0) return null;
+    const evidence = chartSeriesEvidence(intraday.symbol, intraday.points);
+    if (!evidence.first || !evidence.last) return null;
+    return {
+      kind: "price-series",
+      symbol: intraday.symbol,
+      range: intraday.rangePreset,
+      pointCount: evidence.pointCount,
+      first: evidence.first,
+      last: evidence.last,
+      resolution: intraday.resolution,
+      sessionDates: intraday.sessionDates,
+    };
+  }
+
   if (resolved.capability.id === "price-chart") {
     const range = String(resolved.options.rangePreset ?? "5Y") as TimeRange;
     const [symbol, financials] = payload.financials[0] ?? [];
@@ -1140,6 +1248,48 @@ export function chartEvidenceMismatchesFor(
   return mismatches;
 }
 
+export function intradayChartEvidenceMismatchesFor(
+  resolved: ResolvedPaneFunction,
+  payload: DesktopPaneShotPayload,
+  semanticUi: RemoteUiNodeSnapshot[],
+): string[] {
+  if (resolved.capability.id !== "intraday-price-chart") return [];
+  const intraday = payload.intradayHistories[0];
+  if (!intraday || intraday.points.length === 0) return [];
+  const metadata = semanticUi.find((node) => (
+    node.role === "chart-data" && node.metadata?.kind === "chart-composer"
+  ))?.metadata;
+  if (!metadata) return ["rendered intraday chart-data semantic evidence is missing"];
+  const baseSeries = Array.isArray(metadata.baseSeries) ? metadata.baseSeries : [];
+  const actual = baseSeries[0];
+  if (!isRecord(actual)) return ["rendered intraday base series is missing"];
+
+  const expected = chartSeriesEvidence(intraday.symbol, intraday.points);
+  const mismatches: string[] = [];
+  if (actual.pointCount !== expected.pointCount) {
+    mismatches.push("rendered intraday point count does not match");
+  }
+  if (metadata.projectedPointCount !== expected.pointCount) {
+    mismatches.push("rendered intraday projection point count does not match");
+  }
+  const pointMatches = (
+    actualPoint: unknown,
+    expectedPoint: PaneScreenshotChartPointEvidence | null,
+  ): boolean => {
+    if (!isRecord(actualPoint) || !expectedPoint) return false;
+    return actualPoint.date === expectedPoint.date
+      && typeof actualPoint.value === "number"
+      && closeEnough(actualPoint.value, expectedPoint.close);
+  };
+  if (!pointMatches(actual.first, expected.first)) {
+    mismatches.push("rendered intraday first bar does not match");
+  }
+  if (!pointMatches(actual.last, expected.last)) {
+    mismatches.push("rendered intraday last bar does not match");
+  }
+  return mismatches;
+}
+
 export function shotUnavailableSymbols(
   resolved: ResolvedPaneFunction,
   payload: DesktopPaneShotPayload,
@@ -1162,6 +1312,16 @@ export function shotUnavailableSymbols(
       return [];
     });
   }
+  if (resolved.capability.id === "intraday-price-chart") {
+    const symbol = payload.intradayHistories[0]?.symbol ?? payload.financials[0]?.[0];
+    const metadata = semanticUi.find((node) => (
+      node.role === "chart-data" && node.metadata?.kind === "chart-composer"
+    ))?.metadata;
+    const renderedPoints = typeof metadata?.projectedPointCount === "number"
+      ? metadata.projectedPointCount
+      : 0;
+    return symbol && renderedPoints <= 0 ? [symbol] : [];
+  }
   const graphKind = shotGraphKind(resolved);
   if (graphKind) {
     const metric = resolved.options.metric as GraphMetricKey;
@@ -1174,7 +1334,7 @@ export function shotUnavailableSymbols(
       ).length === 0 ? [symbol] : []
     ));
   }
-  if (["price-chart", "intraday-price-chart", "historical-prices"].includes(resolved.capability.id)) {
+  if (["price-chart", "historical-prices"].includes(resolved.capability.id)) {
     return payload.financials.flatMap(([symbol, financials]) => financials.priceHistory.length > 0 ? [] : [symbol]);
   }
   if (["price-comparison", "return-correlation", "security-relationship"].includes(resolved.capability.id)) {
@@ -1211,6 +1371,14 @@ export function shotSemanticRowCount(
       count + (isRecord(entry) && typeof entry.pointCount === "number" ? Math.max(0, entry.pointCount) : 0)
     ), 0);
   }
+  if (resolved.capability.id === "intraday-price-chart") {
+    const metadata = semanticUi.find((node) => (
+      node.role === "chart-data" && node.metadata?.kind === "chart-composer"
+    ))?.metadata;
+    return typeof metadata?.projectedPointCount === "number"
+      ? Math.max(0, metadata.projectedPointCount)
+      : 0;
+  }
   const graphKind = shotGraphKind(resolved);
   if (graphKind) {
     const metric = resolved.options.metric as GraphMetricKey;
@@ -1223,7 +1391,7 @@ export function shotSemanticRowCount(
       ).length
     ), 0);
   }
-  if (["price-chart", "intraday-price-chart", "historical-prices"].includes(resolved.capability.id)) {
+  if (["price-chart", "historical-prices"].includes(resolved.capability.id)) {
     return payload.financials[0]?.[1].priceHistory.length ?? 0;
   }
   if (["price-comparison", "return-correlation", "security-relationship"].includes(resolved.capability.id)) {

--- a/src/plugins/builtin/chart-composer/cli-options.ts
+++ b/src/plugins/builtin/chart-composer/cli-options.ts
@@ -45,7 +45,10 @@ export function applyChartComposerCapabilityOptions(
   options: NormalizedPaneFunctionOptions,
 ): ChartSpec {
   let next = spec;
-  const range = chartRange(options);
+  const selectedRange = chartRange(options);
+  const range = capabilityId === "intraday-price-chart" && typeof options.session === "string"
+    ? "1D"
+    : selectedRange;
   const resolution = chartResolution(options);
   if (range || resolution) {
     next = {

--- a/src/plugins/builtin/chart-composer/index.tsx
+++ b/src/plugins/builtin/chart-composer/index.tsx
@@ -279,7 +279,7 @@ const chartComposerTemplates: PaneTemplateDef[] = [
     id: "graph-intraday-price-pane",
     prefix: "GIP",
     label: "Intraday Price Graph",
-    description: "Open a one-minute intraday price chart.",
+    description: "Open an intraday price chart for one or five sessions.",
     argKind: "ticker",
     minimumSymbols: 1,
     build: (symbols) => buildIntradayPriceChartPreset(symbols[0]!),

--- a/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
+++ b/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
@@ -26,6 +26,7 @@ import {
   getPresetResolution,
   normalizeChartResolutionSupport,
   TIME_RANGE_ORDER,
+  type ManualChartResolution,
 } from "../../../time-series/resolution";
 import type { TimeRange } from "../../../components/chart/core/types";
 import type { AppConfig } from "../../../types/config";
@@ -35,7 +36,7 @@ import type {
 } from "../../../core/app-service-ports";
 import type { CachedResourceRecord, ResourceCacheKey, SetResourceOptions } from "../../../data/resource-store";
 import type { CachedFinancialsTarget, DataProvider, QuoteSubscriptionTarget } from "../../../types/data-provider";
-import type { OptionsChain, TickerFinancials } from "../../../types/financials";
+import type { OptionsChain, PricePoint, TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 import type { AppState, PaneRuntimeState } from "../../../core/state/app/state";
 import type { PaneDef } from "../../../types/plugin";
@@ -50,6 +51,19 @@ import { chartSeriesSourceKey } from "../../../capabilities";
 import { apiClient, setCloudApiFetchTransport } from "../../../api-client";
 import { createGloomberbCloudProvider } from "../../../sources/gloomberb-cloud";
 
+interface CliPaneShotIntradayHistory {
+  symbol: string;
+  exchange: string;
+  rangePreset: "1D" | "1W";
+  resolution: ManualChartResolution;
+  requestedSession: string | null;
+  sessionDates: string[];
+  points: PricePoint[];
+  start: string | null;
+  end: string | null;
+  unavailableReason: string | null;
+}
+
 interface CliPaneShotPayload {
   config: AppConfig;
   paneId: string;
@@ -57,6 +71,7 @@ interface CliPaneShotPayload {
   heightCells: number;
   tickers: TickerRecord[];
   financials: Array<[string, TickerFinancials]>;
+  intradayHistories: CliPaneShotIntradayHistory[];
   optionsChains: Array<[string, OptionsChain]>;
   fredSeries: Array<[string, FredSeriesCacheEntry]>;
   valuationSeries: Array<[string, DatedObservation[]]>;
@@ -187,8 +202,11 @@ function isShotLoadingTextVisible(): boolean {
  * price presets passed.
  */
 function revivePayloadDates(payload: CliPaneShotPayload): void {
-  for (const [, data] of payload.financials) {
-    const history = data.priceHistory;
+  const histories = [
+    ...payload.financials.map(([, data]) => data.priceHistory),
+    ...(payload.intradayHistories ?? []).map((entry) => entry.points),
+  ];
+  for (const history of histories) {
     if (!Array.isArray(history)) continue;
     for (const point of history) {
       if (!(point.date instanceof Date)) point.date = new Date(point.date as unknown as string);
@@ -266,6 +284,16 @@ function createShotDataProvider(payload: CliPaneShotPayload): DataProvider {
     financials.set(canonicalTickerKey(instrument.symbol, instrument.exchange), data);
     if (!instrument.exchange) financials.set(normalizeSymbol(instrument.symbol), data);
   }
+  const intradayHistories = new Map<string, CliPaneShotIntradayHistory>();
+  for (const entry of payload.intradayHistories ?? []) {
+    intradayHistories.set(canonicalTickerKey(entry.symbol, entry.exchange), entry);
+    intradayHistories.set(normalizeSymbol(entry.symbol), entry);
+  }
+  const intradayHistory = (symbol: string, exchange?: string) => (
+    intradayHistories.get(canonicalTickerKey(symbol, exchange))
+      ?? intradayHistories.get(normalizeSymbol(symbol))
+  );
+
   const optionsChains = new Map<string, OptionsChain>();
   for (const [key, data] of payload.optionsChains ?? []) {
     const instrument = parsePublicTickerKey(key);
@@ -345,14 +373,39 @@ function createShotDataProvider(payload: CliPaneShotPayload): DataProvider {
       return resolveShotWork(null);
     },
     getPriceHistory(ticker, exchange, range) {
-      return trackShotWork(Promise.resolve().then(() => (
-        clipPriceHistoryToRange(getFinancials(ticker, exchange).priceHistory ?? [], range)
-      )));
+      return trackShotWork(Promise.resolve().then(() => {
+        const intraday = intradayHistory(ticker, exchange);
+        if (intraday?.unavailableReason) throw new Error(intraday.unavailableReason);
+        return clipPriceHistoryToRange(
+          intraday ? intraday.points : getFinancials(ticker, exchange).priceHistory ?? [],
+          range,
+        );
+      }));
     },
-    getPriceHistoryForResolution(ticker, exchange, bufferRange) {
-      return trackShotWork(Promise.resolve().then(() => (
-        clipPriceHistoryToRange(getFinancials(ticker, exchange).priceHistory ?? [], bufferRange)
-      )));
+    getPriceHistoryForResolution(ticker, exchange, bufferRange, resolution) {
+      return trackShotWork(Promise.resolve().then(() => {
+        const intraday = intradayHistory(ticker, exchange);
+        if (intraday?.unavailableReason) throw new Error(intraday.unavailableReason);
+        if (intraday && intraday.resolution !== resolution) return [];
+        return clipPriceHistoryToRange(
+          intraday ? intraday.points : getFinancials(ticker, exchange).priceHistory ?? [],
+          bufferRange,
+        );
+      }));
+    },
+    getDetailedPriceHistory(ticker, exchange, startDate, endDate, resolution) {
+      return trackShotWork(Promise.resolve().then(() => {
+        const intraday = intradayHistory(ticker, exchange);
+        if (intraday?.unavailableReason) throw new Error(intraday.unavailableReason);
+        if (intraday && intraday.resolution !== resolution) return [];
+        const start = startDate.getTime();
+        const end = endDate.getTime();
+        const points = intraday?.points ?? getFinancials(ticker, exchange).priceHistory ?? [];
+        return points.filter((point) => {
+          const timestamp = point.date.getTime();
+          return timestamp >= start && timestamp < end;
+        });
+      }));
     },
     getChartResolutionSupport() {
       return resolveShotWork(SHOT_CHART_RESOLUTION_SUPPORT);


### PR DESCRIPTION
## Summary

- fetch resolution-aware intraday history before launching the headless screenshot view
- support `--rangePreset 1D`, `--rangePreset 1W`, and exchange-local `--session YYYY-MM-DD` windows for GIP
- inject the selected bars into the screenshot data provider and verify the rendered semantic bar count plus first and last values
- return and render a specific `unusableReason` when intraday history is empty or daily-only
- keep GP and CMP on their existing daily-history paths

## Verification

- `bun test src/cli/pane-functions` (44 passed)
- `bun run typecheck`
- rebased on `origin/main` at `936aab2e`

### GIP readiness output

```json
{"case":"GIP AAPL 1D","rowCount":389,"complete":true,"semanticMismatch":false,"usable":true,"unusableReason":null,"resolution":"1m","sessionDates":["2026-09-03"],"pointCount":389}
{"case":"GIP AAPL 1W","rowCount":390,"complete":true,"semanticMismatch":false,"usable":true,"unusableReason":null,"resolution":"5m","sessionDates":["2026-08-28","2026-08-31","2026-09-01","2026-09-02","2026-09-03"],"pointCount":390}
{"case":"GIP VSXY 1W","rowCount":390,"complete":true,"semanticMismatch":false,"usable":true,"unusableReason":null,"resolution":"5m","sessionDates":["2026-08-28","2026-08-31","2026-09-01","2026-09-02","2026-09-03"],"pointCount":390}
{"case":"GIP AAPL unavailable session","rowCount":0,"complete":false,"semanticMismatch":true,"usable":false,"unusableReason":"No intraday price history is available for AAPL for session 2020-01-02."}
```

For each successful case, the semantic chart metadata reported the same `projectedPointCount`, first timestamp/value, and last timestamp/value as `dataEvidence`. The VSXY image shows the Sep 3 price gap.

### Screenshot artifacts

- AAPL 1D: `/tmp/gip-aapl-1d-final.png`, `/tmp/gip-aapl-1d-final.json`
- AAPL 1W: `/tmp/gip-aapl-1w-final.png`, `/tmp/gip-aapl-1w-final.json`
- VSXY 1W after rebase: `/tmp/gip-vsxy-1w-post-rebase.png`, `/tmp/gip-vsxy-1w-post-rebase.json`
- AAPL explicit session: `/tmp/gip-after-aapl-session.png`, `/tmp/gip-after-aapl-session.json`
- Unavailable session: `/tmp/gip-after-aapl-unavailable-v2.png`, `/tmp/gip-after-aapl-unavailable-v2.json`

### Regression checks

```json
{"case":"GP AAPL 3M","rowCount":261,"complete":true,"semanticMismatch":false,"usable":true}
{"case":"CMP AVGO,NVDA 1M","rowCount":2,"complete":true,"semanticMismatch":false,"usable":true}
```

- GP: `/tmp/gp-aapl-3m-final.png`, `/tmp/gp-aapl-3m-final.json`
- CMP: `/tmp/cmp-avgo-nvda-1m-final.png`, `/tmp/cmp-avgo-nvda-1m-final.json`
