### PR TITLE
Load external plugins in desktop backend

### DIFF
--- a/src/plugins/catalog-backend.test.ts
+++ b/src/plugins/catalog-backend.test.ts
@@ -18,4 +18,30 @@ describe("desktop backend plugin catalog", () => {
       expect(plugin?.slots).toBeUndefined();
     }
   });
+
+  test("includes compatible external plugins in the native desktop backend", () => {
+    const externalPlugin = {
+      id: "external-broker",
+      name: "External broker",
+      version: "1.0.0",
+      targets: ["cli", "tui", "desktop"] as const,
+    };
+    const backendPlugins = getDesktopBackendPlugins([
+      { plugin: externalPlugin, path: "/plugins/external-broker" },
+      {
+        plugin: { id: "broken", name: "Broken", version: "1.0.0" },
+        path: "/plugins/broken",
+        error: "load failed",
+      },
+      {
+        plugin: { id: "web-only", name: "Web only", version: "1.0.0" },
+        path: "/plugins/web-only",
+        unsupportedTarget: "desktop",
+      },
+    ]);
+
+    expect(backendPlugins).toContain(externalPlugin);
+    expect(backendPlugins.some((plugin) => plugin.id === "broken")).toBe(false);
+    expect(backendPlugins.some((plugin) => plugin.id === "web-only")).toBe(false);
+  });
 });

--- a/src/plugins/catalog-backend.ts
+++ b/src/plugins/catalog-backend.ts
@@ -1,12 +1,19 @@
 import type { GloomPlugin } from "../types/plugin";
 import { tickerResearchBackendPlugin } from "./builtin/ticker-research-backend-plugin";
 import { getLoadablePlugins } from "./catalog";
+import { loadExternalPlugins, type LoadedExternalPlugin } from "./loader";
 import { predictionMarketsBackendPlugin } from "./prediction-markets/backend-plugin";
 
-export function getDesktopBackendPlugins(): GloomPlugin[] {
-  return getLoadablePlugins().map((plugin) => {
+export function getDesktopBackendPlugins(
+  externalPlugins: LoadedExternalPlugin[] = [],
+): GloomPlugin[] {
+  return getLoadablePlugins(externalPlugins).map((plugin) => {
     if (plugin.id === "ticker-research") return tickerResearchBackendPlugin;
     if (plugin.id === "prediction-markets") return predictionMarketsBackendPlugin;
     return plugin;
   });
+}
+
+export async function loadDesktopBackendPlugins(): Promise<GloomPlugin[]> {
+  return getDesktopBackendPlugins(await loadExternalPlugins("desktop"));
 }

--- a/src/renderers/electrobun/bun/desktop/backend-requests.ts
+++ b/src/renderers/electrobun/bun/desktop/backend-requests.ts
@@ -1,5 +1,5 @@
 import { createAppServices, type AppServices } from "../../../../core/app-services";
-import { getDesktopBackendPlugins } from "../../../../plugins/catalog-backend";
+import { loadDesktopBackendPlugins } from "../../../../plugins/catalog-backend";
 import type { AppSessionSnapshot } from "../../../../core/state/session-persistence";
 import {
   exportConfig,
@@ -63,7 +63,7 @@ async function importDesktopConfig({
   setCurrentConfig(await importConfig(payload.dataDir, payload.srcPath));
   setServices(createAppServices({
     config: getConfig(),
-    plugins: getDesktopBackendPlugins(),
+    plugins: await loadDesktopBackendPlugins(),
   }));
   syncConfigAccessors();
   registerCoreCapabilities();

--- a/src/renderers/electrobun/bun/desktop/initialization.ts
+++ b/src/renderers/electrobun/bun/desktop/initialization.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 import { createAppServices, type AppServices } from "../../../../core/app-services";
-import { getDesktopBackendPlugins } from "../../../../plugins/catalog-backend";
+import { loadDesktopBackendPlugins } from "../../../../plugins/catalog-backend";
 import type { AppSessionSnapshot } from "../../../../core/state/session-persistence";
 import {
   getDataDir,
@@ -139,7 +139,7 @@ export async function initializeDesktopBackend<TRpc>(
 
   const services = createAppServices({
     config,
-    plugins: getDesktopBackendPlugins(),
+    plugins: await loadDesktopBackendPlugins(),
   });
   options.setServices(services);
   await services.ready;


### PR DESCRIPTION
## Summary

- load installed desktop-compatible external plugins into the native backend catalog
- reuse that catalog during startup and configuration import
- keep failed and unsupported-target plugins filtered out

## Why

The desktop view already discovers and bundles external plugins, but the native backend initialized only the built-in catalog. Renderer registrations could therefore exist without their native broker or capability handlers.

## Verification

- `bun test src/plugins/catalog-backend.test.ts`
- `bun run typecheck:electrobun-bun`
- `bun test`
- `bun run desktop:build`