### PR TITLE
Let built-in plugins declare an icon for the directory

### DIFF
--- a/plugin-icons/gloomberb-cloud.svg
+++ b/plugin-icons/gloomberb-cloud.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Gloom Cloud">
+  <rect width="64" height="64" fill="#0B0B0B"/>
+  <rect x="0.75" y="0.75" width="62.5" height="62.5" fill="none" stroke="#2E2E2E" stroke-width="1.5"/>
+  <path d="M20 44 h24 a9 9 0 0 0 1-18 a13 13 0 0 0-24-5 a9.5 9.5 0 0 0-1 23 z" fill="#FFFFFF"/>
+  <rect x="24" y="30" width="3" height="10" fill="#0B0B0B"/>
+  <rect x="30.5" y="25" width="3" height="15" fill="#0B0B0B"/>
+  <rect x="37" y="33" width="3" height="7" fill="#0B0B0B"/>
+</svg>

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -89,6 +89,7 @@
       ],
       "toggleable": true,
       "featured": true,
+      "icon": "plugin-icons/gloomberb-cloud.svg",
       "contributes": {
         "panes": [
           "account-management",

--- a/scripts/generate-plugin-manifest.ts
+++ b/scripts/generate-plugin-manifest.ts
@@ -20,6 +20,27 @@ if (manifest.uncategorised.length > 0) {
   process.exit(1);
 }
 
+// A declared icon that is not in the repo resolves to a 404 in the directory,
+// which renders as a broken tile rather than falling back to a glyph.
+const missingIcons = await Promise.all(
+  manifest.plugins
+    .map((plugin) => plugin.icon)
+    .filter((icon): icon is string => !!icon)
+    .map(async (icon) => ({
+      icon,
+      exists: await Bun.file(new URL(`../${icon}`, import.meta.url)).exists(),
+    })),
+).then((results) => results.filter((result) => !result.exists));
+
+if (missingIcons.length > 0) {
+  console.error(
+    `Plugin icons declared in EDITORIAL but missing from the repo: ${missingIcons
+      .map((result) => result.icon)
+      .join(", ")}`,
+  );
+  process.exit(1);
+}
+
 const { uncategorised: _drop, ...published } = manifest;
 const next = `${JSON.stringify(published, null, 2)}\n`;
 

--- a/src/plugins/catalog-manifest.test.ts
+++ b/src/plugins/catalog-manifest.test.ts
@@ -34,6 +34,21 @@ describe("built-in plugin manifest", () => {
     expect(featured.map((plugin) => plugin.id)).toEqual(["gloomberb-cloud"]);
   });
 
+  test("every declared icon exists in the repo", async () => {
+    // The directory resolves these against this repo's HEAD, so a wrong path
+    // is a broken image in the plugin grid rather than a missing file here.
+    const icons = buildBuiltinManifest()
+      .plugins.map((plugin) => plugin.icon)
+      .filter((icon): icon is string => !!icon);
+
+    expect(icons.length).toBeGreaterThan(0);
+
+    for (const icon of icons) {
+      const file = Bun.file(new URL(`../../${icon}`, import.meta.url));
+      expect(await file.exists()).toBe(true);
+    }
+  });
+
   test("describes what each plugin contributes, which is what the directory renders", () => {
     const cloud = buildBuiltinManifest().plugins.find((plugin) => plugin.id === "gloomberb-cloud");
 

--- a/src/plugins/catalog-manifest.ts
+++ b/src/plugins/catalog-manifest.ts
@@ -18,6 +18,8 @@ export interface BuiltinPluginManifestEntry {
   categories: string[];
   toggleable: boolean;
   featured?: true;
+  /** Path to artwork in this repo, resolved by the directory against HEAD. */
+  icon?: string;
   contributes: {
     panes: string[];
     capabilities: string[];
@@ -30,8 +32,15 @@ export interface BuiltinPluginManifestEntry {
  * is reported by `generate-plugin-manifest.ts` rather than silently defaulted,
  * so a new built-in cannot slip into the directory uncategorised.
  */
-const EDITORIAL: Record<string, { categories: string[]; featured?: true }> = {
-  "gloomberb-cloud": { categories: ["data", "cloud"], featured: true },
+const EDITORIAL: Record<
+  string,
+  { categories: string[]; featured?: true; icon?: string }
+> = {
+  "gloomberb-cloud": {
+    categories: ["data", "cloud"],
+    featured: true,
+    icon: "plugin-icons/gloomberb-cloud.svg",
+  },
   ai: { categories: ["ai"] },
   alerts: { categories: ["alerts"] },
   application: { categories: ["core"] },
@@ -74,6 +83,7 @@ export function buildBuiltinManifest(): BuiltinManifest {
         categories: editorial?.categories ?? [],
         toggleable: plugin.toggleable === true,
         ...(editorial?.featured ? { featured: true as const } : {}),
+        ...(editorial?.icon ? { icon: editorial.icon } : {}),
         contributes: {
           panes: (plugin.panes ?? []).map((pane) => pane.id).sort(),
           capabilities: (plugin.capabilities ?? [])


### PR DESCRIPTION
`BuiltinPluginManifestEntry` gains `icon`, a path inside this repo that the plugin directory resolves against the default branch. Gloom Cloud ships the first one at `plugin-icons/gloomberb-cloud.svg`; the rest keep the directory's generic category glyph.

`bun run plugins:manifest` and the manifest test both fail when a declared icon is missing from the repo, so a typo cannot ship as a broken image on gloom.sh/plugins.