### PR TITLE
Flush command bar test polls inside act

### DIFF
--- a/src/components/command-bar/surface/assist.test.tsx
+++ b/src/components/command-bar/surface/assist.test.tsx
@@ -7,6 +7,7 @@ import {
   CommandBarHarness,
   createCommandBarTestControls,
   emitKeypress,
+  settleFrame,
 } from "./test-harness";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
@@ -84,8 +85,7 @@ const ASSIST_WAIT_ATTEMPTS = 40;
 async function waitForRequest(requests: string[]): Promise<void> {
   for (let attempt = 0; attempt < ASSIST_WAIT_ATTEMPTS; attempt++) {
     if (requests.length > 0) return;
-    await Bun.sleep(50);
-    await testSetup!.renderOnce();
+    await settleFrame(testSetup!);
   }
   throw new Error("Timed out waiting for the assist request.");
 }
@@ -94,8 +94,7 @@ async function waitForFrameWithout(text: string): Promise<string> {
   for (let attempt = 0; attempt < ASSIST_WAIT_ATTEMPTS; attempt++) {
     const frame = testSetup!.captureCharFrame();
     if (!frame.includes(text)) return frame;
-    await Bun.sleep(50);
-    await testSetup!.renderOnce();
+    await settleFrame(testSetup!);
   }
   throw new Error(`Timed out waiting for "${text}" to disappear.`);
 }
@@ -236,8 +235,7 @@ describe("CommandBar AI assist", () => {
 
     releaseResponse();
     for (let attempt = 0; attempt < ASSIST_WAIT_ATTEMPTS && created.length === 0; attempt++) {
-      await Bun.sleep(50);
-      await testSetup.renderOnce();
+      await settleFrame(testSetup);
     }
     expect(created).toEqual([{ templateId: "new-chat-pane", options: { arg: "#general" } }]);
     expect(requests).toHaveLength(1);
@@ -275,8 +273,7 @@ describe("CommandBar AI assist", () => {
     await testSetup.renderOnce();
     expect(testSetup.captureCharFrame()).toContain("Ask AI — sign up to enable");
 
-    await Bun.sleep(700);
-    await testSetup.renderOnce();
+    await settleFrame(testSetup, 700);
     expect(requests).toEqual([]);
 
     // The offer sits under the list and never takes the Enter that belongs to

--- a/src/components/command-bar/surface/test-harness.tsx
+++ b/src/components/command-bar/surface/test-harness.tsx
@@ -41,6 +41,23 @@ export async function emitKeypress(
   });
 }
 
+/**
+ * Advances one polling step: sleeps, then renders. Both happen inside `act` so
+ * that anything a resolving promise queued during the sleep is flushed before
+ * the next frame is captured. Polling outside `act` leaves the update to
+ * React's scheduler, which is why a loaded CI box could time out waiting for a
+ * frame the app had already produced.
+ */
+export async function settleFrame(
+  renderer: Awaited<ReturnType<typeof testRender>>,
+  delayMs = 50,
+): Promise<void> {
+  await act(async () => {
+    await Bun.sleep(delayMs);
+    await renderer.renderOnce();
+  });
+}
+
 export function createCommandBarTestControls(
   getRenderer: () => Awaited<ReturnType<typeof testRender>>,
 ) {
@@ -51,8 +68,7 @@ export function createCommandBarTestControls(
       if (frame.includes(text)) {
         return frame;
       }
-      await Bun.sleep(delayMs);
-      await renderer.renderOnce();
+      await settleFrame(renderer, delayMs);
     }
     throw new Error(`Timed out waiting for frame to contain "${text}".`);
   };
@@ -76,7 +92,9 @@ export function createCommandBarTestControls(
   const renderFrames = async (count = 2): Promise<void> => {
     const renderer = getRenderer();
     for (let index = 0; index < count; index += 1) {
-      await renderer.renderOnce();
+      await act(async () => {
+        await renderer.renderOnce();
+      });
     }
   };
 


### PR DESCRIPTION
## Why

`CommandBar AI assist > keeps the row the user picked when an answer lands above it` has been failing intermittently on CI, including on `main` (runs 33871703503, 33877647308). It blocked #702 and needed an admin merge.

## Root cause

The poll helpers advanced with a bare `await Bun.sleep(50)` + `renderOnce()`, both outside `act()`. That leaves the state update from the resolved assist ask to React's scheduler instead of flushing it. On a loaded CI runner the update landed *after* the 2s budget, so the helper threw while the app had already produced the frame. The giveaway in the CI log is `An update to CommandBar inside a test was not wrapped in act(...)` printed immediately after the timeout error.

## Fix

Added `settleFrame()`, which does the sleep and the render inside `act()`, and routed the polling helpers through it (`waitForFrameToContain`, `renderFrames`, and the assist-local `waitForRequest` / `waitForFrameWithout`).

The test is kept, not deleted: it guards real behavior, namely that the selection stays on the row the user picked when async AI rows insert above it.

## Verification

- `bun test src/components/` gives 486 pass, 0 fail
- `bun run typecheck` clean
- Instrumented the poll loop and re-ran under 14 busy cores: the answer is now found **after 2 polls**, where the old loop exhausted all 40 on CI. 5/5 loaded runs green.
