### PR TITLE
Restore extracted plugins on desktop, move the bundle cache out of the plugins dir

### DIFF
--- a/src/cli/commands/plugins.ts
+++ b/src/cli/commands/plugins.ts
@@ -1,7 +1,7 @@
 import { join } from "path";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from "fs";
 import { execFileSync } from "child_process";
-import { getPluginsDir } from "../../plugins/loader";
+import { getPluginsDir, isPluginDirectory } from "../../plugins/loader";
 import { linkHostPackages } from "../../plugins/host-link";
 import {
   cliStyles,
@@ -149,7 +149,7 @@ export async function updatePlugins(name?: string) {
   const dirs = name
     ? [validatePluginDirectoryName(name)]
     : readdirSync(PLUGINS_DIR, { withFileTypes: true })
-        .filter((entry) => entry.isDirectory())
+        .filter((entry) => entry.isDirectory() && isPluginDirectory(entry.name))
         .map((entry) => entry.name);
 
   if (dirs.length === 0) {
@@ -179,7 +179,8 @@ export async function updatePlugins(name?: string) {
 
 export function listPlugins() {
   ensurePluginsDir();
-  const entries = readdirSync(PLUGINS_DIR, { withFileTypes: true }).filter((entry) => entry.isDirectory());
+  const entries = readdirSync(PLUGINS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && isPluginDirectory(entry.name));
 
   if (entries.length === 0) {
     console.log(cliStyles.muted("No plugins installed."));

--- a/src/cli/restore-plugins.ts
+++ b/src/cli/restore-plugins.ts
@@ -11,24 +11,31 @@ const log = debugLog.createLogger("plugin-seed");
  * Runs before the plugin catalog is read so a restored plugin is available in
  * the same session, and stays quiet on failure: an offline launch should start
  * normally and try again next time, not block on a network request.
+ *
+ * Returns the seeded ids so a caller that already holds the config in memory
+ * can adopt them. The desktop loads its config before restoring, and without
+ * this it would keep an object whose `seededPlugins` is one launch stale and
+ * overwrite the record on the next save.
  */
-export async function restoreExtractedPlugins(): Promise<void> {
+export async function restoreExtractedPlugins(): Promise<string[] | null> {
   try {
     const config = await loadCliConfigIfAvailable();
     // No data directory yet means a first run: there is nothing to restore.
-    if (!config) return;
+    if (!config) return null;
     const { installPlugin } = await import("./commands/plugins");
     const result = await seedExtractedPlugins(config, installPlugin);
 
     const seeded = [...new Set(result.seeded)].sort();
     const existing = [...new Set(config.seededPlugins ?? [])].sort();
-    if (seeded.join() === existing.join()) return;
+    if (seeded.join() === existing.join()) return seeded;
 
     await saveConfig({ ...config, seededPlugins: seeded });
     if (result.installed.length > 0) {
       log.info(`Restored ${result.installed.join(", ")} into ~/.gloomberb/plugins`);
     }
+    return seeded;
   } catch (error) {
     log.error(`Plugin restore skipped: ${error}`);
+    return null;
   }
 }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -9,6 +9,11 @@ import { linkHostPackages } from "./host-link";
 const loaderLog = debugLog.createLogger("plugin-loader");
 
 const PLUGINS_DIR = join(process.env.HOME || homedir(), ".gloomberb", "plugins");
+/**
+ * Host-owned scratch space for plugins, kept beside the plugins folder rather
+ * than inside it so nothing the host writes can be mistaken for an install.
+ */
+const PLUGIN_CACHE_DIR = join(process.env.HOME || homedir(), ".gloomberb", "plugin-cache");
 
 export interface LoadedExternalPlugin {
   plugin: GloomPlugin;
@@ -20,6 +25,23 @@ export interface LoadedExternalPlugin {
 
 export function getPluginsDir(): string {
   return PLUGINS_DIR;
+}
+
+export function getPluginCacheDir(): string {
+  return PLUGIN_CACHE_DIR;
+}
+
+/**
+ * Whether a directory inside the plugins folder is a plugin at all.
+ *
+ * Dot-directories are bookkeeping, not plugins: the desktop bundle cache used
+ * to be written to `plugins/.cache`, and it showed up in `gloomberb plugins`
+ * as an installed plugin and in `gloomberb update` as a repo to pull. The
+ * cache has moved out, but old installs still have that directory, so this
+ * stays as the single rule every reader shares.
+ */
+export function isPluginDirectory(name: string): boolean {
+  return !name.startsWith(".");
 }
 
 /** Resolves a plugin directory's entry file the way `bun install` would. */
@@ -55,7 +77,7 @@ export async function loadExternalPlugins(target: PluginTarget = "cli"): Promise
   const entries = await readdir(PLUGINS_DIR, { withFileTypes: true });
 
   for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
+    if (!entry.isDirectory() || !isPluginDirectory(entry.name)) continue;
     const pluginDir = join(PLUGINS_DIR, entry.name);
 
     const entryFile = await resolvePluginEntry(pluginDir);

--- a/src/renderers/electrobun/bun/desktop/initialization.ts
+++ b/src/renderers/electrobun/bun/desktop/initialization.ts
@@ -3,6 +3,7 @@ import { homedir } from "os";
 import { join } from "path";
 import { createAppServices, type AppServices } from "../../../../core/app-services";
 import { loadDesktopBackendPlugins } from "../../../../plugins/catalog-backend";
+import { restoreExtractedPlugins } from "../../../../cli/restore-plugins";
 import type { AppSessionSnapshot } from "../../../../core/state/session-persistence";
 import {
   getDataDir,
@@ -133,7 +134,13 @@ export async function initializeDesktopBackend<TRpc>(
     });
   }
 
-  options.setCurrentConfig(await initDataDir(await resolveDesktopDataDir()));
+  const initialConfig = await initDataDir(await resolveDesktopDataDir());
+  // Restore plugins that moved into their own repositories before the catalog
+  // is read, the same as the terminal does at startup. Without it a
+  // desktop-only user silently loses a feature the day it is extracted, since
+  // nothing else installs it for them.
+  const seededPlugins = await restoreExtractedPlugins();
+  options.setCurrentConfig(seededPlugins ? { ...initialConfig, seededPlugins } : initialConfig);
   const config = options.getCurrentConfig();
   if (!config) throw new Error("Desktop config failed to initialize.");
 

--- a/src/renderers/electrobun/bun/external-plugins.ts
+++ b/src/renderers/electrobun/bun/external-plugins.ts
@@ -1,11 +1,11 @@
-import { readdir, stat } from "fs/promises";
+import { readdir, rm, stat } from "fs/promises";
 import { existsSync } from "fs";
 import { join } from "path";
 
 import type { DesktopExternalPluginBundle } from "../shared/protocol";
 import { bundleExternalPlugin, pluginBundleCacheDir } from "../../../plugins/bundle";
 import { linkHostPackages } from "../../../plugins/host-link";
-import { getPluginsDir, resolvePluginEntry } from "../../../plugins/loader";
+import { getPluginCacheDir, getPluginsDir, isPluginDirectory, resolvePluginEntry } from "../../../plugins/loader";
 import type { GloomPlugin } from "../../../types/plugin";
 import { debugLog } from "../../../utils/debug-log";
 
@@ -60,15 +60,31 @@ async function readPluginMetadata(entryFile: string): Promise<GloomPlugin | null
   }
 }
 
+/**
+ * Bundles used to be cached inside the plugins folder, where the CLI listed
+ * `.cache` as an installed plugin and tried to `git pull` it. It is only a
+ * cache, so the old copy is dropped rather than migrated.
+ */
+async function removeLegacyBundleCache(pluginsDir: string): Promise<void> {
+  const legacy = join(pluginsDir, ".cache");
+  if (!existsSync(legacy)) return;
+  try {
+    await rm(legacy, { recursive: true, force: true });
+  } catch (error) {
+    log.error(`Could not remove the legacy bundle cache: ${error}`);
+  }
+}
+
 export async function collectExternalPluginBundles(): Promise<DesktopExternalPluginBundle[]> {
   const pluginsDir = getPluginsDir();
   if (!existsSync(pluginsDir)) return [];
 
-  const outDir = pluginBundleCacheDir(join(pluginsDir, ".cache"));
+  await removeLegacyBundleCache(pluginsDir);
+  const outDir = pluginBundleCacheDir(getPluginCacheDir());
   const bundles: DesktopExternalPluginBundle[] = [];
 
   for (const entry of await readdir(pluginsDir, { withFileTypes: true })) {
-    if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
+    if (!entry.isDirectory() || !isPluginDirectory(entry.name)) continue;
     const pluginDir = join(pluginsDir, entry.name);
 
     const entryFile = await resolvePluginEntry(pluginDir);


### PR DESCRIPTION
Groundwork for extracting the remaining built-in brokers. Verified the install path end-to-end on both renderers first and found three things wrong with it.

## 1. The desktop never restored extracted plugins

`restoreExtractedPlugins()` ran only in the OpenTUI startup path. The desktop backend went straight to `loadDesktopBackendPlugins()`, so a desktop-only user never got a plugin that moved out of this repo. That is already true today for `substack`, `ibkr`, and `ibkr-gateway`, and it would silently take away a working broker the day we extract `public`, `robinhood`, or `simplefin`.

The desktop now restores before it reads the catalog, like the terminal does.

Because the desktop loads its config *before* restoring, `restoreExtractedPlugins()` now returns the seeded ids and the desktop adopts them into the in-memory config. Otherwise it would hold a config whose `seededPlugins` is one launch stale and overwrite the record on the next save, re-running the seed forever.

## 2. The desktop bundle cache was listed as an installed plugin

The desktop wrote its bundle cache to `~/.gloomberb/plugins/.cache`, i.e. inside the plugins folder. After any desktop launch:

```
$ gloomberb plugins
gloomberb-hackernews    0.1.0    Hacker News front page in Gloomberb
...
.cache                  —        —          <-- not a plugin
```

`gloomberb update` also tried to `git pull` it.

The cache moved to `~/.gloomberb/plugin-cache/bundles`, and the stale `.cache` directory is deleted on the next bundle collection since it is only a cache.

## 3. Three readers disagreed on what a plugin directory is

`collectExternalPluginBundles` skipped dot-directories, but `loadExternalPlugins`, `listPlugins`, and `updatePlugins` did not. Added `isPluginDirectory()` in the loader as the single shared rule so a stray dot-directory (including the legacy `.cache` on existing installs) can never be mistaken for an install again.

## Verification

Ran against a sandboxed `HOME` so nothing touched the real plugins directory.

- Terminal install: `gloomberb install gloom-sh/gloomberb-hackernews` clones, installs deps, links the host, and reports `Installed Hacker News v0.1.0`.
- Terminal load: launched the TUI in tmux, and the plugin is live. `Ctrl+P` -> "hacker" lists the `HN` pane, and opening it renders the real front page.
- Seeding: a fresh sandbox home auto-restored `substack`, `ibkr`, and `ibkr-gateway`.
- Desktop bundling: `collectExternalPluginBundles()` compiles hackernews, ibkr, and substack, and correctly reports `ibkr-gateway` as unsupported on desktop.
- Cache relocation confirmed: `plugins/.cache` is gone, `plugin-cache/bundles` is populated, and `gloomberb plugins` no longer lists it.
- `bun test`: 2507 pass, 0 fail. `bun run typecheck`: clean.
