### PR TITLE
Let a plugin ship a browser entry

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -69,9 +69,42 @@ For external plugins, create a directory in `~/.gloomberb/plugins/`:
 
 ```
 ~/.gloomberb/plugins/my-plugin/
-  index.ts        # export default myPlugin
-  package.json    # optional, for dependencies
+  index.ts          # export default myPlugin
+  index.browser.ts  # optional, see below
+  package.json      # optional, for dependencies
+  icon.svg          # optional, 64x64, shown in the plugin directory
 ```
+
+### Plugins with a native half
+
+The terminal imports a plugin straight into Bun, so `node:net`, `node:dns`, and
+the filesystem are all available. The desktop view and the hosted browser app
+are browser contexts: their copy of the plugin is compiled with Bun's browser
+target, which **rejects `node:*` imports even behind a dynamic `import()`**. A
+plugin that opens a socket or resolves DNS therefore fails to compile for the
+view, and the marketplace shows it as broken.
+
+Ship a second, renderer-safe entry for that case:
+
+```json
+{
+  "main": "index.ts",
+  "browser": "index.browser.ts"
+}
+```
+
+The browser entry exports the same plugin identity, and the same broker
+`configSchema` and form conversions, but leaves out anything native. Nothing is
+lost on the desktop: the broker's network calls are executed by the Bun process
+and reach the view over RPC, so the renderer only needs the metadata and the UI.
+
+`index.browser.ts` is picked up automatically if the `browser` field is absent.
+A plugin with no browser entry falls back to `main`, which is correct for the
+majority that only use `fetch`.
+
+If a plugin genuinely cannot work on a renderer, declare `targets` instead
+(`["cli", "tui"]`, for example) so the marketplace explains why it is inert
+rather than reporting a compile error.
 
 ## What plugins can do
 

--- a/src/plugins/bundle.test.ts
+++ b/src/plugins/bundle.test.ts
@@ -97,6 +97,37 @@ describe("bundleExternalPlugin", () => {
     }
   });
 
+  test("compiles the browser entry so a plugin with a native half still loads", async () => {
+    // Bun's browser target rejects `node:*` imports even behind a dynamic
+    // import, so without this a broker that opens a socket or resolves DNS
+    // could not ship to the desktop view at all.
+    const dir = mkdtempSync(join(tmpdir(), "gloom-bundle-browser-"));
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "scratch", main: "index.ts", browser: "index.browser.ts" }),
+    );
+    writeFileSync(join(dir, "native.ts"), `
+      import { Socket } from "node:net";
+      export const connect = () => new Socket();
+    `);
+    writeFileSync(join(dir, "index.ts"), `
+      export default { id: "scratch", name: "Scratch", version: "1.0.0", load: () => import("./native") };
+    `);
+    writeFileSync(join(dir, "index.browser.ts"), `
+      export default { id: "scratch", name: "Scratch", version: "1.0.0" };
+    `);
+    const out = join(dir, "out");
+    try {
+      const result = await bundleExternalPlugin(dir, out, { exportNamesFor: fakeExports });
+      const code = await Bun.file(result.outputPath).text();
+
+      expect(code).toContain("Scratch");
+      expect(code).not.toContain("node:net");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("rejects a directory with no entry file", async () => {
     const dir = mkdtempSync(join(tmpdir(), "gloom-bundle-empty-"));
     mkdirSync(join(dir, "src"), { recursive: true });

--- a/src/plugins/bundle.test.ts
+++ b/src/plugins/bundle.test.ts
@@ -22,7 +22,13 @@ function scratchPlugin(source: string): string {
 }
 
 const fakeExports = async (specifier: string) => (
-  specifier === "gloomberb/ui" ? ["Box", "Text"] : specifier === "react" ? ["useState"] : []
+  specifier === "gloomberb/ui"
+    ? ["Box", "Text"]
+    : specifier === "react"
+      ? ["useState"]
+      : specifier === "gloomberb/broker"
+        ? ["PRESERVED_PASSWORD_HINT", "getBrokerRemoteClient"]
+        : []
 );
 
 describe("buildSharedModuleSource", () => {
@@ -92,6 +98,26 @@ describe("bundleExternalPlugin", () => {
     try {
       await expect(bundleExternalPlugin(dir, join(dir, "out"), { exportNamesFor: fakeExports }))
         .rejects.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("shares gloomberb/broker rather than bundling the host's copy", async () => {
+    // That module owns the remote broker client the desktop view installs at
+    // startup. A plugin carrying its own copy reads an empty one and reports
+    // that the broker host is unavailable, which looks like a broken broker
+    // rather than a bundling mistake.
+    const dir = scratchPlugin(`
+      import { PRESERVED_PASSWORD_HINT } from "gloomberb/broker";
+      export default { id: "scratch", name: "Scratch", version: "1.0.0", hint: PRESERVED_PASSWORD_HINT };
+    `);
+    try {
+      const result = await bundleExternalPlugin(dir, join(dir, "out"), { exportNamesFor: fakeExports });
+      const code = await Bun.file(result.outputPath).text();
+
+      expect(result.shared).toEqual(["gloomberb/broker"]);
+      expect(code).toContain(PLUGIN_HOST_GLOBAL);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/plugins/bundle.ts
+++ b/src/plugins/bundle.ts
@@ -1,7 +1,7 @@
 import { mkdir } from "fs/promises";
 import { join } from "path";
 
-import { resolvePluginEntry } from "./loader";
+import { resolvePluginBrowserEntry } from "./loader";
 import { PLUGIN_HOST_GLOBAL, SHARED_SPECIFIERS } from "./host-contract";
 
 /**
@@ -98,7 +98,9 @@ export async function bundleExternalPlugin(
   outDir: string,
   options: { exportNamesFor?: (specifier: string) => Promise<readonly string[]> } = {},
 ): Promise<BundlePluginResult> {
-  const entry = await resolvePluginEntry(pluginDir);
+  // The browser entry when the plugin ships one, so a plugin with a native
+  // half can still present its UI and metadata in the view.
+  const entry = await resolvePluginBrowserEntry(pluginDir);
   if (!entry) throw new Error(`No plugin entry file in ${pluginDir}`);
 
   await mkdir(outDir, { recursive: true });

--- a/src/plugins/host-contract.ts
+++ b/src/plugins/host-contract.ts
@@ -32,6 +32,15 @@ export const SHARED_SPECIFIERS = [
   "gloomberb/capabilities",
   "gloomberb/utils",
   "gloomberb/react",
+  // Modules below hold state or reach the host's services, so a bundled copy
+  // is worse than a missing one. `gloomberb/broker` is the clearest case: it
+  // owns the remote broker client the desktop view sets at startup, and a
+  // plugin carrying its own copy reads an empty one and reports that the
+  // broker host is unavailable.
+  "gloomberb/broker",
+  "gloomberb/dialog",
+  "gloomberb/market-data",
+  "gloomberb/time-series",
 ] as const;
 
 export type SharedSpecifier = (typeof SHARED_SPECIFIERS)[number];

--- a/src/plugins/host-modules.ts
+++ b/src/plugins/host-modules.ts
@@ -24,6 +24,10 @@ export async function installPluginHostModules(): Promise<void> {
     capabilities,
     utils,
     pluginReact,
+    broker,
+    dialog,
+    marketData,
+    timeSeries,
   ] = await Promise.all([
     import("react"),
     import("react/jsx-runtime"),
@@ -37,6 +41,10 @@ export async function installPluginHostModules(): Promise<void> {
     import("../capabilities"),
     import("../public/utils"),
     import("../public/react"),
+    import("../public/broker"),
+    import("../ui/dialog"),
+    import("../public/market-data"),
+    import("../public/time-series"),
   ]);
 
   const registry: Record<string, unknown> = {
@@ -51,6 +59,10 @@ export async function installPluginHostModules(): Promise<void> {
     "gloomberb/capabilities": capabilities,
     "gloomberb/utils": utils,
     "gloomberb/react": pluginReact,
+    "gloomberb/broker": broker,
+    "gloomberb/dialog": dialog,
+    "gloomberb/market-data": marketData,
+    "gloomberb/time-series": timeSeries,
   };
 
   for (const specifier of SHARED_SPECIFIERS) {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -44,25 +44,51 @@ export function isPluginDirectory(name: string): boolean {
   return !name.startsWith(".");
 }
 
-/** Resolves a plugin directory's entry file the way `bun install` would. */
-export async function resolvePluginEntry(pluginDir: string): Promise<string | null> {
+async function readPluginPackageField(pluginDir: string, field: string): Promise<string | null> {
   const pkgPath = join(pluginDir, "package.json");
-  if (existsSync(pkgPath)) {
-    try {
-      const pkg = JSON.parse(await Bun.file(pkgPath).text());
-      if (pkg.main) {
-        const main = join(pluginDir, pkg.main);
-        if (existsSync(main)) return main;
-      }
-    } catch {
-      // Malformed package.json falls through to the index candidates.
-    }
+  if (!existsSync(pkgPath)) return null;
+  try {
+    const pkg = JSON.parse(await Bun.file(pkgPath).text());
+    const value = pkg[field];
+    if (typeof value !== "string" || !value) return null;
+    const resolved = join(pluginDir, value);
+    return existsSync(resolved) ? resolved : null;
+  } catch {
+    // Malformed package.json falls through to the index candidates.
+    return null;
   }
-  for (const candidate of ["index.ts", "index.tsx", "index.js"]) {
-    const path = join(pluginDir, candidate);
+}
+
+function resolveIndexCandidate(pluginDir: string, prefix: string): string | null {
+  for (const extension of ["ts", "tsx", "js"]) {
+    const path = join(pluginDir, `${prefix}.${extension}`);
     if (existsSync(path)) return path;
   }
   return null;
+}
+
+/** Resolves a plugin directory's entry file the way `bun install` would. */
+export async function resolvePluginEntry(pluginDir: string): Promise<string | null> {
+  return await readPluginPackageField(pluginDir, "main")
+    ?? resolveIndexCandidate(pluginDir, "index");
+}
+
+/**
+ * Resolves the entry to compile for a browser renderer, preferring the standard
+ * `browser` field and falling back to the native entry.
+ *
+ * A plugin that touches sockets, DNS, or the filesystem cannot be compiled for
+ * the desktop view: Bun's browser target rejects `node:*` imports even behind a
+ * dynamic import. The app solves this for its own build with private alias
+ * rules that swap in stubs, which a plugin in its own repository cannot reach.
+ * The `browser` field is that same escape hatch, published: ship a
+ * renderer-safe module with the same plugin metadata and let the native half
+ * run in the Bun process, where the desktop calls it over RPC anyway.
+ */
+export async function resolvePluginBrowserEntry(pluginDir: string): Promise<string | null> {
+  return await readPluginPackageField(pluginDir, "browser")
+    ?? resolveIndexCandidate(pluginDir, "index.browser")
+    ?? await resolvePluginEntry(pluginDir);
 }
 
 export function pluginSupportsTarget(plugin: GloomPlugin, target: PluginTarget): boolean {

--- a/src/public/broker.ts
+++ b/src/public/broker.ts
@@ -7,6 +7,12 @@
  * from the view, since the renderer cannot open sockets itself.
  */
 export { getBrokerRemoteClient, setBrokerRemoteClient } from "../brokers/remote-broker-adapter";
+/**
+ * Placeholder a broker shows instead of a stored secret, so an edited profile
+ * can tell "unchanged" from "cleared". Broker plugins that persist a derived
+ * credential need the host's exact string for the round trip to work.
+ */
+export { PRESERVED_PASSWORD_HINT } from "../brokers/profile-form";
 export type { BrokerRemoteClient } from "../brokers/remote-broker-adapter";
 export type { ResourceStore } from "../data/resource-store";
 export { resolveTickerFinancialsForInstrument } from "../market-data/coordinator";


### PR DESCRIPTION
Stacked on #706. Required before `robinhood` and `simplefin` can move to their own repositories.

## The blocker

Bun's browser target rejects `node:*` imports **even behind a dynamic `import()`**. A plugin that opens a socket or resolves DNS fails to compile for the desktop view:

```
error: Browser polyfill for module "node:http" doesn't have a matching export named "createServer"
```

The app dodges this for its own build with private alias rules in `src/renderers/electrobun/view/build-assets.ts`:

```ts
["./native-loader", "plugins/broker-sync/robinhood.ts", "native-stubs/broker-sync-native-loader.ts"],
["./native-loader", "plugins/broker-sync/simplefin.ts", "native-stubs/broker-sync-native-loader.ts"],
```

Those rules are keyed to in-repo paths, so a plugin in its own repository cannot use them. Extracting Robinhood or SimpleFIN today would produce a plugin that works in the terminal and shows up broken on the desktop.

## The fix

Publish that escape hatch as the standard `browser` field:

```json
{ "main": "index.ts", "browser": "index.browser.ts" }
```

- `resolvePluginEntry()` keeps resolving `main`, which is what the terminal and the Bun backend import.
- New `resolvePluginBrowserEntry()` prefers `browser`, then `index.browser.*`, then falls back to `main`.
- `bundleExternalPlugin()` compiles the browser entry.

Nothing is lost on the desktop: the broker's network calls run in the Bun process and reach the view over RPC, so the renderer only ever needs the metadata, the `configSchema`, and the UI.

Plugins without a browser entry are unaffected and still resolve through `main`.

Also exports `PRESERVED_PASSWORD_HINT` on `gloomberb/broker`. SimpleFIN needs the host's exact placeholder string to tell "unchanged" from "cleared" when an edited profile round-trips a stored credential, and it is currently reachable only via a private import.

## Verification

- New test in `bundle.test.ts` compiles a plugin whose native module imports `node:net`. It fails without this change (`7 pass, 1 fail`) and passes with it, asserting the output contains the plugin and no `node:net`.
- Checked against a real install: a probe plugin with a `node:http` / `node:net` / `node:dns` module fails to bundle before, and bundles to 468 bytes with no node builtins after.
- Fallback confirmed against the installed hackernews plugin, which has no `browser` field and still resolves `index.tsx`.
- `bun test`: 2508 pass, 0 fail. `bun run typecheck`: clean.
- PLUGINS.md documents the field, the icon convention, and when to use `targets` instead.
