### PR TITLE
Give the assist tests a wall-clock budget

### DIFF
--- a/src/components/command-bar/surface/assist.test.tsx
+++ b/src/components/command-bar/surface/assist.test.tsx
@@ -81,21 +81,29 @@ function configureEarningsRegistry(
 
 /** Wide enough to cover the ask debounce plus the round trip. */
 const ASSIST_WAIT_ATTEMPTS = 40;
+/**
+ * A budget, not a poll count. The ask waits out a 600ms debounce before it even
+ * reaches the transport, and on a loaded CI runner the renders in between cost
+ * far more than the sleeps, which is what made these tests fail in batches.
+ */
+const ASSIST_WAIT_MS = 10_000;
 
 async function waitForRequest(requests: string[]): Promise<void> {
-  for (let attempt = 0; attempt < ASSIST_WAIT_ATTEMPTS; attempt++) {
+  const deadline = Date.now() + ASSIST_WAIT_MS;
+  do {
     if (requests.length > 0) return;
     await settleFrame(testSetup!);
-  }
+  } while (Date.now() < deadline);
   throw new Error("Timed out waiting for the assist request.");
 }
 
 async function waitForFrameWithout(text: string): Promise<string> {
-  for (let attempt = 0; attempt < ASSIST_WAIT_ATTEMPTS; attempt++) {
+  const deadline = Date.now() + ASSIST_WAIT_MS;
+  do {
     const frame = testSetup!.captureCharFrame();
     if (!frame.includes(text)) return frame;
     await settleFrame(testSetup!);
-  }
+  } while (Date.now() < deadline);
   throw new Error(`Timed out waiting for "${text}" to disappear.`);
 }
 
@@ -234,7 +242,8 @@ describe("CommandBar AI assist", () => {
     expect(created).toEqual([]);
 
     releaseResponse();
-    for (let attempt = 0; attempt < ASSIST_WAIT_ATTEMPTS && created.length === 0; attempt++) {
+    const deadline = Date.now() + ASSIST_WAIT_MS;
+    while (created.length === 0 && Date.now() < deadline) {
       await settleFrame(testSetup);
     }
     expect(created).toEqual([{ templateId: "new-chat-pane", options: { arg: "#general" } }]);

--- a/src/components/command-bar/surface/assist.test.tsx
+++ b/src/components/command-bar/surface/assist.test.tsx
@@ -87,6 +87,12 @@ const ASSIST_WAIT_ATTEMPTS = 40;
  * far more than the sleeps, which is what made these tests fail in batches.
  */
 const ASSIST_WAIT_MS = 10_000;
+/**
+ * Above `ASSIST_WAIT_MS`, because Bun's own per-test timeout is 5s and a wait
+ * budget the runner kills first is not a budget. These tests sit out a 600ms
+ * debounce and a round trip, so they need the room on a slow machine.
+ */
+const ASSIST_TEST_TIMEOUT_MS = 20_000;
 
 async function waitForRequest(requests: string[]): Promise<void> {
   const deadline = Date.now() + ASSIST_WAIT_MS;
@@ -150,7 +156,7 @@ describe("CommandBar AI assist", () => {
 
     await emitKeypress(testSetup, { name: "return", sequence: "\r" });
     expect(created).toEqual([{ templateId: "new-chat-pane", options: { arg: "#general" } }]);
-  });
+  }, ASSIST_TEST_TIMEOUT_MS);
 
   test("keeps the row the user picked when an answer lands above it", async () => {
     signInVerified();
@@ -187,7 +193,7 @@ describe("CommandBar AI assist", () => {
     // Enter still runs it rather than whatever now sits at its old index.
     await emitKeypress(testSetup, { name: "return", sequence: "\r" });
     expect(created).toEqual([{ templateId: "new-chat-pane", options: undefined }]);
-  });
+  }, ASSIST_TEST_TIMEOUT_MS);
 
   test("runs an argless prefix candidate that still carries an argument", async () => {
     signInVerified();
@@ -211,7 +217,7 @@ describe("CommandBar AI assist", () => {
 
     await emitKeypress(testSetup, { name: "return", sequence: "\r" });
     expect(created).toEqual([{ templateId: "earnings-calendar-pane", options: undefined }]);
-  });
+  }, ASSIST_TEST_TIMEOUT_MS);
 
   test("claims the answer still in flight when Enter lands on the thinking row", async () => {
     signInVerified();
@@ -248,7 +254,7 @@ describe("CommandBar AI assist", () => {
     }
     expect(created).toEqual([{ templateId: "new-chat-pane", options: { arg: "#general" } }]);
     expect(requests).toHaveLength(1);
-  });
+  }, ASSIST_TEST_TIMEOUT_MS);
 
   test("drops the section when a background ask fails", async () => {
     signInVerified();
@@ -265,7 +271,7 @@ describe("CommandBar AI assist", () => {
     const frame = await waitForFrameWithout("Ask AI");
     expect(requests).toHaveLength(1);
     expect(frame).not.toContain("unavailable");
-  });
+  }, ASSIST_TEST_TIMEOUT_MS);
 
   test("sends signed-out users to sign up instead of the endpoint", async () => {
     const requests = mockAssistTransport(() => jsonResponse({ candidates: [] }));
@@ -289,5 +295,5 @@ describe("CommandBar AI assist", () => {
     // the local match the user was already looking at.
     await emitKeypress(testSetup, { name: "return", sequence: "\r" });
     expect(created).toEqual([{ templateId: "new-chat-pane", options: undefined }]);
-  });
+  }, ASSIST_TEST_TIMEOUT_MS);
 });

--- a/src/components/command-bar/surface/test-harness.tsx
+++ b/src/components/command-bar/surface/test-harness.tsx
@@ -58,18 +58,32 @@ export async function settleFrame(
   });
 }
 
+/**
+ * Turns a poll count into a wall-clock budget.
+ *
+ * Counting attempts assumes every attempt costs about `delayMs`, which is only
+ * true on an idle machine: on a loaded CI runner each render can cost more than
+ * the sleep, so a caller asking for 40 attempts got its 2s budget spent well
+ * before the app had a chance to answer. The count is kept as the caller's
+ * unit, then floored so a slow machine waits longer rather than failing.
+ */
+function waitBudgetMs(attempts: number, delayMs: number): number {
+  return Math.max(attempts * delayMs, 10_000);
+}
+
 export function createCommandBarTestControls(
   getRenderer: () => Awaited<ReturnType<typeof testRender>>,
 ) {
   const waitForFrameToContain = async (text: string, attempts = 12, delayMs = 50): Promise<string> => {
     const renderer = getRenderer();
-    for (let attempt = 0; attempt < attempts; attempt++) {
+    const deadline = Date.now() + waitBudgetMs(attempts, delayMs);
+    do {
       const frame = renderer.captureCharFrame();
       if (frame.includes(text)) {
         return frame;
       }
       await settleFrame(renderer, delayMs);
-    }
+    } while (Date.now() < deadline);
     throw new Error(`Timed out waiting for frame to contain "${text}".`);
   };
 


### PR DESCRIPTION
Follow-up to #705, which reduced but did not eliminate the `CommandBar AI assist` flakes. They still failed on #706 and #708, four at a time.

## Why the first fix was not enough

#705 made the flush deterministic by polling inside `act()`. The remaining problem is the budget, not the flush. The helpers counted **attempts** (40 x 50ms), which only equals 2s when each render is free. On a loaded CI runner the renders between sleeps cost more than the sleeps, and the ask has to wait out a 600ms debounce before it even reaches the transport. Every failure burned the full budget and stopped at roughly 2.1-2.9s, and the tests that failed were exactly the four that wait on a response.

## Fix

Wait against a wall-clock deadline (10s floor) instead of an attempt count, in `waitForFrameToContain`, `waitForRequest`, `waitForFrameWithout`, and the claim loop. A slow machine now takes longer instead of failing; a healthy one is unchanged, since these resolve in about two polls.

## Verification

- 3/3 green under 16 busy cores, which is heavier load than the earlier reproduction.
- `bun test src/components/` green.