### PR TITLE
Give the web app a plugin HTTP proxy

### DIFF
--- a/src/renderers/browser/cloud-transport.ts
+++ b/src/renderers/browser/cloud-transport.ts
@@ -1,5 +1,6 @@
 import { apiClient, setCloudApiFetchTransport } from "../../api-client";
 import { setHttpFetchTransport } from "../../utils/http-transport";
+import { createBrowserHttpProxyTransport } from "./http-proxy-transport";
 
 const SESSION_COOKIE_NAMES = ["__Secure-gloomberb.session_token", "gloomberb.session_token"] as const;
 
@@ -32,7 +33,9 @@ export function browserCredentialedFetch(url: string, init: RequestInit = {}): P
 export function installBrowserFetchTransports(): void {
   apiClient.setCookieSessionMode(true);
   setCloudApiFetchTransport(browserCredentialedFetch);
-  setHttpFetchTransport((url, init) => fetch(url, init));
+  // Cross-origin plugin requests go through the worker, which can set the
+  // headers a browser will not and reach APIs that send no CORS headers.
+  setHttpFetchTransport(createBrowserHttpProxyTransport());
 }
 
 export async function restoreBrowserCloudSession(budgetMs = 5_000): Promise<void> {

--- a/src/renderers/browser/http-proxy-transport.test.ts
+++ b/src/renderers/browser/http-proxy-transport.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createBrowserHttpProxyTransport } from "./http-proxy-transport";
+
+const originalLocation = Reflect.get(globalThis, "location");
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, "location", {
+    value: { href: "https://term.gloom.sh/", origin: "https://term.gloom.sh", protocol: "https:" },
+    configurable: true,
+  });
+});
+
+afterAll(() => {
+  if (originalLocation === undefined) {
+    Reflect.deleteProperty(globalThis, "location");
+    return;
+  }
+  Object.defineProperty(globalThis, "location", { value: originalLocation, configurable: true });
+});
+
+describe("browser plugin transport", () => {
+  test("sends a cross-origin request to the proxy as an envelope", async () => {
+    // `Cookie` cannot be set on a browser fetch, so it has to travel in the
+    // body rather than as a header on the request to the worker.
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const transport = createBrowserHttpProxyTransport((async (url: string, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return Response.json({
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        setCookie: ["substack.sid=granted; Path=/"],
+        body: "{\"ok\":true}",
+      });
+    }) as unknown as typeof fetch);
+
+    const response = await transport("https://substack.com/api/v1/reader/feed", {
+      headers: { cookie: "substack.sid=stored" },
+    });
+
+    expect(calls[0]?.url).toBe("/http-proxy");
+    expect(calls[0]?.init?.method).toBe("POST");
+    expect(JSON.parse(String(calls[0]?.init?.body))).toMatchObject({
+      url: "https://substack.com/api/v1/reader/feed",
+      init: { headers: { cookie: "substack.sid=stored" } },
+    });
+    expect(await response.json()).toEqual({ ok: true });
+  });
+
+  test("restores set-cookie so a plugin can complete a login", async () => {
+    const transport = createBrowserHttpProxyTransport((async () => Response.json({
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      setCookie: ["substack.sid=granted; Path=/", "other=1"],
+      body: "{}",
+    })) as unknown as typeof fetch);
+
+    const response = await transport("https://substack.com/api/v1/login");
+
+    expect(response.headers.get("set-cookie")).toContain("substack.sid=granted");
+    expect(response.headers.getSetCookie()).toHaveLength(2);
+  });
+
+  test("leaves same-origin and CORS-friendly hosts on the direct path", async () => {
+    // The marketplace feed and the public data sources already work from a
+    // browser. Routing them through the proxy would cost a round trip and the
+    // worker would refuse them, since they are not on the allowlist.
+    const calls: string[] = [];
+    const transport = createBrowserHttpProxyTransport((async (url: string) => {
+      calls.push(String(url));
+      return new Response("ok");
+    }) as unknown as typeof fetch);
+
+    await transport("/api/portfolio");
+    await transport("https://plugins.gloom.sh/registry.json");
+    await transport("https://api.fiscaldata.treasury.gov/services/api/v1/auctions");
+
+    expect(calls).toEqual([
+      "/api/portfolio",
+      "https://plugins.gloom.sh/registry.json",
+      "https://api.fiscaldata.treasury.gov/services/api/v1/auctions",
+    ]);
+  });
+
+  test("surfaces a refusal from the proxy instead of returning it as a response", async () => {
+    const transport = createBrowserHttpProxyTransport((async () => Response.json(
+      { error: "Sign in to use plugin requests." },
+      { status: 401 },
+    )) as unknown as typeof fetch);
+
+    await expect(transport("https://substack.com/api/v1/reader/feed")).rejects.toThrow("refused (401)");
+  });
+});

--- a/src/renderers/browser/http-proxy-transport.ts
+++ b/src/renderers/browser/http-proxy-transport.ts
@@ -1,0 +1,82 @@
+import { createProxyResponse, type HttpProxyResponseEnvelope } from "../../utils/http-proxy-response";
+import type { HttpFetchTransport } from "../../utils/http-transport";
+import { isProxiedHost } from "../../utils/plugin-proxy-hosts";
+
+/**
+ * Client half of the plugin HTTP transport for the hosted web app.
+ *
+ * A plugin calling `httpFetch` in the terminal reaches the API directly, and on
+ * the desktop it goes to the Bun process. In a browser tab neither is possible:
+ * most third-party APIs send no CORS headers, and headers like `Cookie` belong
+ * to the browser and are dropped from anything script sets. Requests that need
+ * either are posted to the worker's `/http-proxy` route instead.
+ *
+ * Only hosts on the shared allowlist are routed. Everything else, including
+ * same-origin calls and the CORS-friendly APIs the marketplace and the data
+ * sources already use, goes out as a direct fetch exactly as before. Sending
+ * those through the proxy would cost a round trip, lose streaming, and be
+ * refused by the worker anyway.
+ */
+export const HTTP_PROXY_PATH = "/http-proxy";
+
+function needsProxy(url: string): boolean {
+  try {
+    const target = new URL(url, typeof location === "undefined" ? undefined : location.href);
+    if (typeof location !== "undefined" && target.origin === location.origin) return false;
+    return isProxiedHost(target.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function headersToRecord(headers: HeadersInit | undefined): Record<string, string> {
+  const record: Record<string, string> = {};
+  if (!headers) return record;
+  if (headers instanceof Headers) {
+    headers.forEach((value, key) => {
+      record[key] = value;
+    });
+    return record;
+  }
+  if (Array.isArray(headers)) {
+    for (const [key, value] of headers) record[key] = value;
+    return record;
+  }
+  return { ...headers };
+}
+
+async function serializeBody(body: BodyInit | null | undefined): Promise<string | undefined> {
+  if (body == null) return undefined;
+  if (typeof body === "string") return body;
+  return new Response(body).text();
+}
+
+export function createBrowserHttpProxyTransport(
+  send: typeof fetch = fetch,
+): HttpFetchTransport {
+  return async function proxiedFetch(url: string, init?: RequestInit): Promise<Response> {
+    if (!needsProxy(url)) return send(url, init);
+
+    const proxied = await send(HTTP_PROXY_PATH, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      credentials: "include",
+      signal: init?.signal ?? null,
+      body: JSON.stringify({
+        url,
+        init: {
+          method: init?.method,
+          headers: headersToRecord(init?.headers),
+          body: await serializeBody(init?.body),
+          redirect: init?.redirect,
+        },
+      }),
+    });
+
+    if (!proxied.ok) {
+      const detail = await proxied.text().catch(() => "");
+      throw new Error(`Plugin request was refused (${proxied.status}). ${detail}`.trim());
+    }
+    return createProxyResponse(await proxied.json() as HttpProxyResponseEnvelope);
+  };
+}

--- a/src/renderers/cloudflare/http-proxy.test.ts
+++ b/src/renderers/cloudflare/http-proxy.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { handleHttpProxy, validateProxyTarget } from "./http-proxy";
+
+const SESSION_COOKIE = "__Secure-gloomberb.session_token=abc123";
+
+function proxyRequest(body: unknown, init: RequestInit = {}): Request {
+  return new Request("https://term.gloom.sh/http-proxy", {
+    method: "POST",
+    headers: { cookie: SESSION_COOKIE, ...(init.headers as Record<string, string> ?? {}) },
+    body: JSON.stringify(body),
+    ...init,
+  });
+}
+
+describe("proxy target validation", () => {
+  test("allows an allowlisted host and its subdomains", () => {
+    expect(validateProxyTarget("https://substack.com/api/v1/reader/feed")).toHaveProperty("url");
+    expect(validateProxyTarget("https://example.substack.com/api/v1/posts")).toHaveProperty("url");
+  });
+
+  test("refuses a host that merely ends with an allowlisted name", () => {
+    // "evilsubstack.com" ends with "substack.com" as a string but is a
+    // different registrable domain, so suffix matching has to be on a label.
+    expect(validateProxyTarget("https://evilsubstack.com/x")).toMatchObject({ status: 403 });
+  });
+
+  test.each([
+    ["http://substack.com/x", "plain http"],
+    ["https://user:pass@substack.com/x", "credentials in the URL"],
+    ["https://substack.com:8443/x", "a non-default port"],
+    ["https://169.254.169.254/latest/meta-data", "an IP literal"],
+    ["https://localhost/x", "localhost"],
+    ["https://api.github.com/x", "a host that is not allowlisted"],
+  ])("refuses %s (%s)", (url) => {
+    const result = validateProxyTarget(url);
+
+    expect(result).not.toHaveProperty("url");
+    expect((result as { status: number }).status).toBeGreaterThanOrEqual(400);
+  });
+});
+
+describe("proxy request handling", () => {
+  test("forwards only the envelope, never the caller's session cookie", async () => {
+    // The browser attaches the Gloomberb session to this same-origin POST.
+    // Passing it upstream would hand a third party the user's session.
+    let seen: Request | undefined;
+    const response = await handleHttpProxy(
+      proxyRequest({
+        url: "https://substack.com/api/v1/reader/feed",
+        init: { headers: { cookie: "substack.sid=plugin-owned", "user-agent": "Gloomberb" } },
+      }),
+      (async (input: Request | string | URL, init?: RequestInit) => {
+        seen = new Request(input as never, init);
+        return new Response("[]", { status: 200, headers: { "content-type": "application/json" } });
+      }) as typeof fetch,
+    );
+
+    expect(response.status).toBe(200);
+    expect(seen?.headers.get("cookie")).toBe("substack.sid=plugin-owned");
+    expect(seen?.headers.get("cookie")).not.toContain("gloomberb.session_token");
+    expect(seen?.headers.get("user-agent")).toBe("Gloomberb");
+  });
+
+  test("returns set-cookie in the envelope instead of as a header", async () => {
+    // A real Set-Cookie here would let a third party set cookies on the
+    // Gloomberb origin.
+    const response = await handleHttpProxy(
+      proxyRequest({ url: "https://substack.com/api/v1/login", init: { method: "POST", body: "{}" } }),
+      (async () => new Response("{}", {
+        status: 200,
+        headers: { "set-cookie": "substack.sid=granted; Path=/; HttpOnly" },
+      })) as typeof fetch,
+    );
+    const envelope = await response.json() as { setCookie: string[]; headers: Record<string, string> };
+
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(envelope.setCookie[0]).toContain("substack.sid=granted");
+    expect(envelope.headers["set-cookie"]).toBeUndefined();
+  });
+
+  test("requires a session cookie", async () => {
+    const response = await handleHttpProxy(
+      new Request("https://term.gloom.sh/http-proxy", {
+        method: "POST",
+        body: JSON.stringify({ url: "https://substack.com/x" }),
+      }),
+      (async () => new Response("nope")) as typeof fetch,
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  test("refuses a cross-origin caller", async () => {
+    const response = await handleHttpProxy(
+      proxyRequest({ url: "https://substack.com/x" }, { headers: { origin: "https://evil.example" } }),
+      (async () => new Response("nope")) as typeof fetch,
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  test("reports an upstream timeout as a gateway error rather than throwing", async () => {
+    const response = await handleHttpProxy(
+      proxyRequest({ url: "https://substack.com/slow" }),
+      (async () => {
+        throw Object.assign(new Error("timed out"), { name: "TimeoutError" });
+      }) as typeof fetch,
+    );
+
+    expect(response.status).toBe(504);
+    expect(await response.json()).toMatchObject({ error: expect.stringContaining("timed out") });
+  });
+});

--- a/src/renderers/cloudflare/http-proxy.ts
+++ b/src/renderers/cloudflare/http-proxy.ts
@@ -1,0 +1,193 @@
+/**
+ * Server half of the plugin HTTP transport for the hosted web app.
+ *
+ * The terminal reaches third-party APIs directly, and the desktop forwards
+ * them to its Bun process (`http.fetch`). The web build has neither: it runs
+ * on a real origin, so a plugin's request is subject to CORS, and it cannot
+ * set `Cookie` because browsers own that header. This route is the web's
+ * equivalent of the desktop backend, using the same envelope so the client
+ * side of both transports behaves identically.
+ *
+ * The desktop version deliberately has no allowlist: it runs on the user's own
+ * machine, reaching only what that machine could already reach. This one is
+ * on the public internet, so an unrestricted copy would be an open proxy
+ * running on our bandwidth and our IP reputation. Everything below exists to
+ * keep that from happening.
+ */
+import { isProxiedHost } from "../../utils/plugin-proxy-hosts";
+
+const PROXY_METHODS = new Set(["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"]);
+const SESSION_COOKIE_NAMES = ["__Secure-gloomberb.session_token", "gloomberb.session_token"];
+/** Set by the caller's browser or meaningful only to the hop it came from. */
+const STRIPPED_REQUEST_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+const MAX_BODY_BYTES = 5 * 1024 * 1024;
+const MAX_TIMEOUT_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+export interface HttpProxyEnvelope {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  setCookie: string[];
+  body: string;
+}
+
+/**
+ * Rejects anything that is not a plain https host on the allowlist.
+ *
+ * IP literals are refused outright rather than range-checked: no allowlisted
+ * host needs one, and it removes the entire class of "does this address point
+ * somewhere internal" bugs, including the decimal and IPv6-mapped spellings
+ * that defeat naive checks.
+ */
+export function validateProxyTarget(rawUrl: unknown): { url: URL } | { error: string; status: number } {
+  if (typeof rawUrl !== "string" || rawUrl.length > 2_048) {
+    return { error: "A target URL is required.", status: 400 };
+  }
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return { error: "The target URL is not valid.", status: 400 };
+  }
+  if (url.protocol !== "https:") {
+    return { error: "Only https targets are allowed.", status: 400 };
+  }
+  if (url.username || url.password) {
+    return { error: "Credentials in the URL are not allowed.", status: 400 };
+  }
+  if (url.port && url.port !== "443") {
+    return { error: "Only the default https port is allowed.", status: 400 };
+  }
+  if (/^\d|^\[|:/.test(url.hostname) || url.hostname === "localhost") {
+    return { error: "The target host is not allowed.", status: 403 };
+  }
+  if (!isProxiedHost(url.hostname)) {
+    return { error: "The target host is not on the plugin allowlist.", status: 403 };
+  }
+  return { url };
+}
+
+function hasSessionCookie(request: Request): boolean {
+  const cookie = request.headers.get("cookie") ?? "";
+  return SESSION_COOKIE_NAMES.some((name) => new RegExp(`(?:^|;\\s*)${name}=[^;]`).test(cookie));
+}
+
+function upstreamHeaders(raw: unknown): Headers {
+  const headers = new Headers();
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return headers;
+  for (const [name, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value !== "string") continue;
+    if (STRIPPED_REQUEST_HEADERS.has(name.toLowerCase())) continue;
+    try {
+      headers.set(name, value);
+    } catch {
+      // A header name the runtime refuses is dropped rather than failing the
+      // whole request, matching how a browser treats an unsettable header.
+    }
+  }
+  return headers;
+}
+
+function clampTimeout(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.min(value, MAX_TIMEOUT_MS)
+    : DEFAULT_TIMEOUT_MS;
+}
+
+function proxyError(message: string, status: number): Response {
+  return Response.json({ error: message }, { status, headers: { "cache-control": "no-store" } });
+}
+
+/**
+ * Note the upstream request is built only from the envelope. Forwarding the
+ * incoming request's headers would hand the caller's Gloomberb session cookie
+ * to a third party, which is the opposite of what this exists to do.
+ */
+export async function handleHttpProxy(
+  request: Request,
+  fetchUpstream: typeof fetch = fetch,
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return proxyError("Method not allowed", 405);
+  }
+  const origin = request.headers.get("origin");
+  if (origin && origin !== new URL(request.url).origin) {
+    return proxyError("Origin not allowed", 403);
+  }
+  if (!hasSessionCookie(request)) {
+    return proxyError("Sign in to use plugin requests.", 401);
+  }
+
+  let payload: { url?: unknown; init?: unknown };
+  try {
+    payload = await request.json() as { url?: unknown; init?: unknown };
+  } catch {
+    return proxyError("The request body is not valid JSON.", 400);
+  }
+
+  const target = validateProxyTarget(payload.url);
+  if ("error" in target) return proxyError(target.error, target.status);
+
+  const init = payload.init && typeof payload.init === "object" && !Array.isArray(payload.init)
+    ? payload.init as Record<string, unknown>
+    : {};
+  const method = typeof init.method === "string" && init.method.trim()
+    ? init.method.trim().toUpperCase()
+    : "GET";
+  if (!PROXY_METHODS.has(method)) {
+    return proxyError("Method not allowed", 405);
+  }
+  const body = typeof init.body === "string" && method !== "GET" && method !== "HEAD"
+    ? init.body
+    : undefined;
+
+  let response: Response;
+  try {
+    response = await fetchUpstream(target.url, {
+      method,
+      headers: upstreamHeaders(init.headers),
+      body,
+      redirect: init.redirect === "manual" || init.redirect === "error" ? init.redirect : "follow",
+      signal: AbortSignal.timeout(clampTimeout(init.timeoutMs)),
+    });
+  } catch (error) {
+    const timedOut = error instanceof Error && error.name === "TimeoutError";
+    return proxyError(timedOut ? "The upstream request timed out." : "The upstream request failed.", 504);
+  }
+
+  const text = await response.text();
+  if (text.length > MAX_BODY_BYTES) {
+    return proxyError("The upstream response is too large.", 502);
+  }
+
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    // Carried in `setCookie` instead. Emitting it here would let a third party
+    // set cookies on the Gloomberb origin.
+    if (key.toLowerCase() === "set-cookie") return;
+    headers[key] = value;
+  });
+  const setCookie = [...(response.headers.getSetCookie?.() ?? [])];
+  const singleSetCookie = response.headers.get("set-cookie");
+  if (setCookie.length === 0 && singleSetCookie) setCookie.push(singleSetCookie);
+
+  const envelope: HttpProxyEnvelope = {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+    setCookie,
+    body: text,
+  };
+  return Response.json(envelope, { headers: { "cache-control": "no-store" } });
+}

--- a/src/renderers/cloudflare/worker.ts
+++ b/src/renderers/cloudflare/worker.ts
@@ -1,3 +1,5 @@
+import { handleHttpProxy } from "./http-proxy";
+
 interface StaticAssetsBinding {
   fetch(request: Request): Promise<Response>;
 }
@@ -9,6 +11,7 @@ export interface WorkerEnv {
 const SHARE_PATH = /^\/s\/[a-f0-9]{32}\/?$/;
 const LAYOUT_SHARE_PATH = /^\/l\/[a-f0-9]{32}\/?$/;
 const API_PATH = /^\/api(?:\/|$)/;
+const HTTP_PROXY_PATH = "/http-proxy";
 const APPLE_APP_SITE_ASSOCIATION_PATH = "/.well-known/apple-app-site-association";
 
 /**
@@ -78,6 +81,10 @@ async function proxyApi(request: Request, fetchApi: ApiFetch): Promise<Response>
 export async function handleRequest(request: Request, env: WorkerEnv, fetchApi: ApiFetch = fetch): Promise<Response> {
   const url = new URL(request.url);
   if (API_PATH.test(url.pathname)) return proxyApi(request, fetchApi);
+  // Before the GET/HEAD gate below, since plugin requests arrive as POST.
+  if (url.pathname === HTTP_PROXY_PATH) {
+    return withSecurityHeaders(await handleHttpProxy(request));
+  }
 
   if (request.method !== "GET" && request.method !== "HEAD") {
     return withSecurityHeaders(Response.json({ error: "Method not allowed" }, {

--- a/src/renderers/electrobun/view/http-fetch.ts
+++ b/src/renderers/electrobun/view/http-fetch.ts
@@ -1,4 +1,5 @@
 import { setCloudApiFetchTransport } from "../../../api-client";
+import { createProxyResponseHeaders } from "../../../utils/http-proxy-response";
 import { setHttpFetchTransport } from "../../../utils/http-transport";
 import type { DesktopHttpFetchResponse } from "../shared/protocol";
 import { backendRequest } from "./backend-rpc";
@@ -55,7 +56,7 @@ async function electrobunHttpFetch(url: string, init?: RequestInit): Promise<Res
   const requestPromise = requestBackendHttpFetch(url, init);
 
   const response = await withAbort(requestPromise, init?.signal);
-  const headers = createResponseHeaders(response.headers, response.setCookie);
+  const headers = createProxyResponseHeaders(response.headers, response.setCookie);
   const fetchResponse = new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
@@ -86,18 +87,6 @@ async function requestBackendHttpFetch(
   });
 }
 
-function createResponseHeaders(headers: Record<string, string>, setCookie: string[] = []): Headers {
-  const responseHeaders = new Headers(headers);
-  if (setCookie.length === 0) return responseHeaders;
-
-  const originalGet = responseHeaders.get.bind(responseHeaders);
-  responseHeaders.get = ((name: string) => (
-    name.toLowerCase() === "set-cookie" ? setCookie[0] ?? null : originalGet(name)
-  )) as Headers["get"];
-  (responseHeaders as Headers & { getSetCookie?: () => string[] }).getSetCookie = () => [...setCookie];
-  return responseHeaders;
-}
-
 async function electrobunCloudApiFetch(url: string, init?: RequestInit): Promise<Response> {
   if (init?.signal?.aborted) {
     throw createAbortError();
@@ -111,7 +100,7 @@ async function electrobunCloudApiFetch(url: string, init?: RequestInit): Promise
     ok: response.status >= 200 && response.status < 300,
     status: response.status,
     statusText: response.statusText,
-    headers: createResponseHeaders(response.headers, response.setCookie),
+    headers: createProxyResponseHeaders(response.headers, response.setCookie),
     text: async () => response.body,
   } as Response;
 }

--- a/src/utils/http-proxy-response.ts
+++ b/src/utils/http-proxy-response.ts
@@ -1,0 +1,44 @@
+/**
+ * Rebuilds a `Response` from a proxied envelope.
+ *
+ * Both proxying transports (desktop's Bun backend, the web app's worker route)
+ * return `set-cookie` alongside the other headers rather than inside them,
+ * because a `Headers` object built in a renderer cannot hold multiple cookies
+ * and the browser strips the header anyway. Callers that read cookies, like a
+ * plugin completing a login, need `get("set-cookie")` and `getSetCookie()` to
+ * work, so those are restored here.
+ */
+export interface HttpProxyResponseEnvelope {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  setCookie?: string[];
+  body: string;
+}
+
+export function createProxyResponseHeaders(
+  headers: Record<string, string>,
+  setCookie: string[] = [],
+): Headers {
+  const responseHeaders = new Headers(headers);
+  if (setCookie.length === 0) return responseHeaders;
+
+  const originalGet = responseHeaders.get.bind(responseHeaders);
+  responseHeaders.get = ((name: string) => (
+    name.toLowerCase() === "set-cookie" ? setCookie[0] ?? null : originalGet(name)
+  )) as Headers["get"];
+  (responseHeaders as Headers & { getSetCookie?: () => string[] }).getSetCookie = () => [...setCookie];
+  return responseHeaders;
+}
+
+export function createProxyResponse(envelope: HttpProxyResponseEnvelope): Response {
+  const headers = createProxyResponseHeaders(envelope.headers, envelope.setCookie ?? []);
+  const response = new Response(envelope.body, {
+    status: envelope.status,
+    statusText: envelope.statusText,
+    headers,
+  });
+  // `new Response` copies the headers, which drops the accessors above.
+  Object.defineProperty(response, "headers", { value: headers, configurable: true });
+  return response;
+}

--- a/src/utils/plugin-proxy-hosts.ts
+++ b/src/utils/plugin-proxy-hosts.ts
@@ -1,0 +1,25 @@
+/**
+ * Hosts the hosted web app is allowed to reach through the worker proxy.
+ *
+ * Shared by both halves on purpose. The worker uses it to refuse anything else,
+ * so it cannot be turned into an open proxy, and the browser uses it to decide
+ * what to route: everything not listed here keeps going out as a direct fetch,
+ * which is what the marketplace feed and the CORS-friendly data sources already
+ * rely on. If the two lists disagreed, the client would send requests the
+ * server rejects, or quietly bypass the allowlist.
+ *
+ * Add a host only when a plugin genuinely cannot reach it from a browser, and
+ * remember that anything listed can then be reached with our IP and our
+ * bandwidth.
+ */
+export const PROXY_ALLOWED_HOSTS = [
+  // Substack sends no CORS headers at all, and its session lives in a `Cookie`
+  // header that a browser will not let script set.
+  "substack.com",
+] as const;
+
+/** Matches a host exactly, or as a subdomain of an allowed parent. */
+export function isProxiedHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return PROXY_ALLOWED_HOSTS.some((allowed) => host === allowed || host.endsWith(`.${allowed}`));
+}


### PR DESCRIPTION
Gives the hosted web app the same plugin HTTP escape hatch the desktop already has, so a plugin that cannot be reached from a browser (no CORS headers, or auth that lives in a `Cookie`) can work on term.gloom.sh.

## Background

`src/utils/http-transport.ts` is already the seam every plugin uses, since `createThrottledFetch` defaults to it. Each renderer binds it:

| Renderer | Transport | Result |
|---|---|---|
| CLI / TUI | none, falls back to `globalThis.fetch` in Bun | no CORS |
| Desktop | `http.fetch` RPC into the Bun process | arbitrary headers, `set-cookie` plumbed back |
| Web (before) | `setHttpFetchTransport((url, init) => fetch(url, init))` | plain browser fetch, so CORS |

Only the web binding was missing a server to forward to. This adds it.

## What is here

- `src/renderers/cloudflare/http-proxy.ts`, a `POST /http-proxy` route using the same envelope as the desktop backend, so both clients decode identically.
- `src/renderers/browser/http-proxy-transport.ts`, the client half.
- `src/utils/plugin-proxy-hosts.ts`, one allowlist shared by both, currently just `substack.com`.
- `src/utils/http-proxy-response.ts`, the envelope-to-`Response` rebuild, now shared with the desktop view instead of duplicated.

## Guardrails

The desktop proxy deliberately has none: it runs on the user's machine and reaches only what that machine already could. A copy of it on the edge would be an open proxy on our bandwidth and IP reputation, so this one adds:

- **Allowlist**, matched per label, so `evilsubstack.com` does not pass as a suffix of `substack.com`.
- **https only**, no URL credentials, no non-default port.
- **IP literals refused outright** rather than range-checked. No allowlisted host needs one, and it kills the whole "is this address internal" class, including the decimal and IPv6-mapped spellings that beat naive checks. (`169.254.169.254` is covered by a test.)
- **Envelope-only forwarding.** The upstream request is built from the body, never from the incoming request's headers. The browser attaches the Gloomberb session cookie to this same-origin POST, and forwarding it would hand a third party the user's session. Tested.
- **`set-cookie` returned in the envelope, never as a header**, so a third party cannot set cookies on the Gloomberb origin. Tested.
- Session cookie required, same-origin check, method allowlist, 5MB body cap, 30s timeout cap.

## One regression caught during review

My first version routed *every* cross-origin request through the proxy, which would have broken the marketplace feed, the Treasury API, and the other CORS-friendly sources that work in the browser today, since the worker would refuse them as not allowlisted. Only allowlisted hosts are routed now; everything else takes the direct path exactly as before. There is a test covering it.

## Verification

- `bun test`: 2518 pass, 0 fail, including 13 new tests for the guardrails and the transport.
- `bun run typecheck` clean across all five projects, `tsconfig.cloudflare.json` included.
- `bun run web:build` and `bun run cloudflare:dry-run` both succeed. Worker bundle is 9.42 KiB.

## What this does not do

Substack still cannot run on the web, because external plugins cannot be delivered there at all: `src/renderers/browser/main.tsx:53` loads `getBrowserBuiltinPlugins()` only. That is the next piece, written up separately. This PR is the transport half, and it is useful on its own for any built-in that needs a non-CORS origin.

Worth a decision before Substack ships on web: proxying means a user's `substack.sid` transits our edge. Today it never leaves their machine.
