### PR TITLE
Omit the timestamp on transcripts published as documents

### DIFF
--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -518,7 +518,8 @@ export interface CloudTranscriptTurnPayload {
   company?: string;
   text: string;
   isQa: boolean;
-  startSeconds: number;
+  /** Offset into the recording; null when the company published the transcript as a document. */
+  startSeconds: number | null;
 }
 
 export interface CloudTranscriptParticipantPayload {

--- a/src/plugins/builtin/earnings-calls/transcript-view.tsx
+++ b/src/plugins/builtin/earnings-calls/transcript-view.tsx
@@ -159,7 +159,10 @@ function TurnView({
   return (
     <Box flexDirection="column" marginTop={1}>
       <Box height={1} flexDirection="row" gap={1} overflow="hidden">
-        <Text fg={colors.textDim}>{formatTimestamp(turn.startSeconds)}</Text>
+        {/* A transcript the company published as a document has no timings. */}
+        {turn.startSeconds !== null && (
+          <Text fg={colors.textDim}>{formatTimestamp(turn.startSeconds)}</Text>
+        )}
         <Text fg={speakerColor(turn)} attributes={TextAttributes.BOLD}>
           {turn.speaker}
         </Text>
@@ -305,7 +308,7 @@ export function TranscriptView({
             <>
               {turns.map((turn, index) => (
                 <TurnView
-                  key={`${turn.startSeconds}-${index}`}
+                  key={`${turn.startSeconds ?? "doc"}-${index}`}
                   turn={turn}
                   width={proseWidth}
                   nativePaneChrome={isNative}


### PR DESCRIPTION
Backend counterpart: gloomberb-platform#182.

When a company attaches the full transcript to its investor events feed, the pipeline now builds the transcript from that document instead of the recording. Those turns have no timestamps, so `startSeconds` is nullable and the reader omits the column for them instead of printing 0:00 on every turn.

Typecheck clean; no other reader behaviour changes.