### PR TITLE
Define ASKG protocol and remote write tiers

### DIFF
--- a/src/plugins/builtin/cloud/askg/protocol.test.ts
+++ b/src/plugins/builtin/cloud/askg/protocol.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 import type { HeadlessPaneDefinition } from "../../../../types/headless";
 import { marketValuationHeadless } from "../../market-valuation/headless";
 import {
+  ASKG_PROTOCOL_VERSION,
   TOOL_NAME_PATTERN,
+  type ASKGSessionStartRequest,
+  type ASKGSessionStartResponse,
   type ASKGSseEvent,
   type ToolManifest,
   type ToolResultPayload,
@@ -33,7 +36,7 @@ function projectHeadlessDefinition(
 }
 
 describe("ASKG protocol", () => {
-  test("round-trips a manifest, every event, and a tool result", () => {
+  test("round-trips session negotiation, a manifest, every event, and a tool result", () => {
     const manifest: ToolManifest = {
       name: "layout.place_pane",
       source: "remote-op",
@@ -51,6 +54,38 @@ describe("ASKG protocol", () => {
       },
       confirm: "never",
       timeoutMs: 10_000,
+    };
+    const sessionRequest: ASKGSessionStartRequest = {
+      protocolVersion: ASKG_PROTOCOL_VERSION,
+      client: { kind: "tui", version: "0.8.0" },
+      context: {
+        query: "Compare NVDA valuation",
+        symbol: "NVDA",
+        paneId: "ticker:main",
+        layout: { id: "layout-1" },
+      },
+      tools: [manifest],
+      manifestHash: "sha256:manifest-1",
+    };
+    const sessionResponse: ASKGSessionStartResponse = {
+      protocolVersion: ASKG_PROTOCOL_VERSION,
+      sessionId: "session-1",
+      manifestHash: sessionRequest.manifestHash,
+      serverTools: [],
+      acceptedTools: [manifest.name],
+      rejectedTools: [{ name: "invalid.tool", reason: "Unknown source" }],
+      limits: {
+        requestsPerMinute: 20,
+        turnsPerDay: 300,
+        turnsRemainingToday: 299,
+        maxToolCallsPerTurn: 25,
+        turnWallClockMs: 90_000,
+        clientToolTimeoutMs: 10_000,
+      },
+      tier: "pro",
+      model: "gpt-5.6-luna",
+      promptVersion: "2026-09-04",
+      expiresAt: "2026-09-04T21:30:00.000Z",
     };
     const events: ASKGSseEvent[] = [
       {
@@ -126,6 +161,8 @@ describe("ASKG protocol", () => {
 
     expect(new RegExp(TOOL_NAME_PATTERN).test(manifest.name)).toBe(true);
     expect(jsonRoundTrip(manifest)).toEqual(manifest);
+    expect(jsonRoundTrip(sessionRequest)).toEqual(sessionRequest);
+    expect(jsonRoundTrip(sessionResponse)).toEqual(sessionResponse);
     expect(events.map(jsonRoundTrip)).toEqual(events);
     expect(jsonRoundTrip(result)).toEqual(result);
   });

--- a/src/plugins/builtin/cloud/askg/protocol.test.ts
+++ b/src/plugins/builtin/cloud/askg/protocol.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneDefinition } from "../../../../types/headless";
+import { marketValuationHeadless } from "../../market-valuation/headless";
+import {
+  TOOL_NAME_PATTERN,
+  type ASKGSseEvent,
+  type ToolManifest,
+  type ToolResultPayload,
+} from "./protocol";
+
+function jsonRoundTrip<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function projectHeadlessDefinition(
+  definition: HeadlessPaneDefinition,
+): ToolManifest {
+  const options = definition.options.map(({ settingKey: _settingKey, pluginState: _pluginState, ...option }) => option);
+  const columns = definition.columns?.map(({ format: _format, ...column }) => column);
+  return {
+    name: "market.valuation",
+    source: "headless",
+    title: "Market valuation",
+    description: "Compare whole-market valuation ratios with their history.",
+    writeTier: "read",
+    shape: definition.shape,
+    argument: definition.argument,
+    options,
+    ...(columns ? { columns } : {}),
+    confirm: "never",
+    timeoutMs: 30_000,
+  };
+}
+
+describe("ASKG protocol", () => {
+  test("round-trips a manifest, every event, and a tool result", () => {
+    const manifest: ToolManifest = {
+      name: "layout.place_pane",
+      source: "remote-op",
+      title: "Place pane",
+      description: "Move a pane to a layout region.",
+      writeTier: "ui-write",
+      inputSchema: {
+        type: "object",
+        properties: {
+          paneId: { type: "string" },
+          region: { type: "string", enum: ["left", "right", "floating"] },
+        },
+        required: ["paneId", "region"],
+        additionalProperties: false,
+      },
+      confirm: "never",
+      timeoutMs: 10_000,
+    };
+    const events: ASKGSseEvent[] = [
+      {
+        type: "session",
+        seq: 1,
+        sessionId: "session-1",
+        turnId: "turn-1",
+        model: "gpt-5.6-luna",
+        promptVersion: "2026-09-04",
+      },
+      { type: "text-delta", seq: 2, turnId: "turn-1", delta: "NVDA" },
+      {
+        type: "tool-call",
+        seq: 3,
+        turnId: "turn-1",
+        toolCallId: "call-1",
+        name: manifest.name,
+        args: { paneId: "chart:main", region: "right" },
+        writeTier: "ui-write",
+        requiresConfirmation: false,
+        preview: { paneId: "chart:main", region: "right", dryRun: true },
+        timeoutMs: 10_000,
+        expiresAt: "2026-09-04T21:00:10.000Z",
+      },
+      {
+        type: "tool-executed",
+        seq: 4,
+        turnId: "turn-1",
+        toolCallId: "call-server-1",
+        name: "market.quote",
+        source: "server",
+        status: "ok",
+        summary: {
+          rowCount: 1,
+          elapsedMs: 24,
+          truncated: false,
+          note: "Fresh quote",
+          sample: { symbol: "NVDA", price: 180 },
+        },
+      },
+      { type: "tool-result-ack", seq: 5, turnId: "turn-1", toolCallId: "call-1" },
+      {
+        type: "error",
+        seq: 6,
+        turnId: "turn-1",
+        code: "rate_limited",
+        message: "Try again shortly.",
+        retryable: true,
+        retryAfterMs: 1_000,
+      },
+      {
+        type: "usage",
+        seq: 7,
+        turnId: "turn-1",
+        inputTokens: 120,
+        outputTokens: 30,
+        totalTokens: 150,
+        estimated: false,
+      },
+      { type: "done", seq: 8, turnId: "turn-1", reason: "complete" },
+    ];
+    const result: ToolResultPayload = {
+      turnId: "turn-1",
+      toolCallId: "call-1",
+      status: "ok",
+      result: { moved: true },
+      rowCount: 1,
+      truncated: false,
+      elapsedMs: 12,
+      rev: "rev-2",
+      undoToken: "undo-1",
+    };
+
+    expect(new RegExp(TOOL_NAME_PATTERN).test(manifest.name)).toBe(true);
+    expect(jsonRoundTrip(manifest)).toEqual(manifest);
+    expect(events.map(jsonRoundTrip)).toEqual(events);
+    expect(jsonRoundTrip(result)).toEqual(result);
+  });
+
+  test("projects a migrated headless definition without executable fields", () => {
+    const manifest = projectHeadlessDefinition(marketValuationHeadless);
+    const serialized = JSON.stringify(manifest);
+
+    expect(new RegExp(TOOL_NAME_PATTERN).test(manifest.name)).toBe(true);
+    expect(manifest).toMatchObject({
+      source: "headless",
+      writeTier: "read",
+      shape: marketValuationHeadless.shape,
+      argument: marketValuationHeadless.argument,
+      confirm: "never",
+    });
+    expect(manifest.options).toHaveLength(marketValuationHeadless.options.length);
+    expect(serialized).not.toContain("load");
+    expect(serialized).not.toContain("settingKey");
+    expect(serialized).not.toContain("pluginState");
+    expect(serialized).not.toContain("format");
+    expect(jsonRoundTrip(manifest)).toEqual(manifest);
+  });
+});

--- a/src/plugins/builtin/cloud/askg/protocol.ts
+++ b/src/plugins/builtin/cloud/askg/protocol.ts
@@ -1,0 +1,274 @@
+// Wire declarations are mirrored in gloomberb-platform/server/src/services/askg/types.ts.
+import type {
+  HeadlessPaneArgumentDef,
+  HeadlessPaneColumn,
+  HeadlessPaneOptionDef,
+  HeadlessPaneOptionValue,
+  HeadlessPaneShape,
+} from "../../../../types/headless";
+import type {
+  RemoteJsonSchema,
+  RemoteJsonSchemaType,
+  RemoteWriteTier,
+} from "../../../../remote/types";
+
+/** Major version of the ASKG client and server wire contract. */
+export const ASKG_PROTOCOL_VERSION = 1;
+
+/** Maximum accepted JSON-encoded client tool result size. */
+export const MAX_TOOL_RESULT_BYTES = 262_144;
+
+/** Source form for valid tool names advertised to ASKG. */
+export const TOOL_NAME_PATTERN = "^[a-z][a-z0-9_.]{2,48}$";
+
+/** JSON value accepted on the ASKG wire. */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/** Safety tier applied before a client tool is executed. */
+export type WriteTier = RemoteWriteTier;
+
+/** Runtime that opened an ASKG session. */
+export type ASKGClientKind = "tui" | "desktop" | "web";
+
+/** Origin of an advertised client tool. */
+export type ToolManifestSource = "headless" | "remote-op";
+
+/** Headless result shapes supported by the tool timeline. */
+export type ToolManifestShape = HeadlessPaneShape;
+
+/** Headless argument kinds understood by the manifest compiler. */
+export type ToolManifestArgumentKind = HeadlessPaneArgumentDef["kind"];
+
+/** Serializable headless argument declaration. */
+export type ToolManifestArgument = HeadlessPaneArgumentDef;
+
+/** Values accepted by a headless enum option. */
+export type ToolManifestOptionValue = HeadlessPaneOptionValue;
+
+/** Headless option types understood by the manifest compiler. */
+export type ToolManifestOptionType = HeadlessPaneOptionDef["type"];
+
+/** Serializable headless option declaration. */
+export type ToolManifestOption = Omit<HeadlessPaneOptionDef, "settingKey" | "pluginState">;
+
+/** Serializable headless column declaration. */
+export type ToolManifestColumn = Omit<HeadlessPaneColumn, "format">;
+
+/** JSON Schema primitive types accepted for remote operation inputs. */
+export type ToolInputSchemaType = RemoteJsonSchemaType;
+
+/** JSON Schema accepted by a remote operation tool. */
+export type ToolInputSchema = RemoteJsonSchema;
+
+/** Client or server tool metadata negotiated when a session starts. */
+export interface ToolManifest {
+  /** Lowercase stable identifier matching TOOL_NAME_PATTERN. */
+  name: string;
+  source: ToolManifestSource;
+  title: string;
+  description: string;
+  writeTier: WriteTier;
+  shape?: ToolManifestShape;
+  argument?: ToolManifestArgument;
+  options?: ToolManifestOption[];
+  columns?: ToolManifestColumn[];
+  inputSchema?: ToolInputSchema;
+  confirm: "never" | "always";
+  timeoutMs: number;
+}
+
+/** Client identity included in a session negotiation. */
+export interface ASKGClientDescriptor {
+  kind: ASKGClientKind;
+  version: string;
+}
+
+/** Terminal context supplied to the model at session start. */
+export interface ASKGSessionContext {
+  query?: string;
+  symbol?: string;
+  paneId?: string;
+  layout?: JsonValue;
+}
+
+/** Request used to negotiate tools and limits for an ASKG session. */
+export interface ASKGSessionStartRequest {
+  protocolVersion: typeof ASKG_PROTOCOL_VERSION;
+  client: ASKGClientDescriptor;
+  context: ASKGSessionContext;
+  tools: ToolManifest[];
+  manifestHash: string;
+}
+
+/** Per-user and per-turn limits returned by the platform. */
+export interface ASKGLimits {
+  requestsPerMinute: number;
+  turnsPerDay: number;
+  turnsRemainingToday: number;
+  maxToolCallsPerTurn: number;
+  turnWallClockMs: number;
+  clientToolTimeoutMs: number;
+}
+
+/** Client tool rejected during session negotiation. */
+export interface ASKGRejectedTool {
+  name: string;
+  reason: string;
+}
+
+/** Successful ASKG session negotiation response. */
+export interface ASKGSessionStartResponse {
+  protocolVersion: typeof ASKG_PROTOCOL_VERSION;
+  sessionId: string;
+  manifestHash: string;
+  serverTools: ToolManifest[];
+  acceptedTools: string[];
+  rejectedTools: ASKGRejectedTool[];
+  limits: ASKGLimits;
+  tier: string;
+  model: string;
+  promptVersion: string;
+  expiresAt: string;
+}
+
+/** Shared fields carried by every turn stream event. */
+export interface ASKGEventBase {
+  seq: number;
+}
+
+/** Announces the session and turn attached to this stream. */
+export interface ASKGSessionEvent extends ASKGEventBase {
+  type: "session";
+  sessionId: string;
+  turnId: string;
+  model: string;
+  promptVersion: string;
+}
+
+/** Appends model text to the visible answer. */
+export interface ASKGTextDeltaEvent extends ASKGEventBase {
+  type: "text-delta";
+  turnId: string;
+  delta: string;
+}
+
+/** Delegates one negotiated tool call to the client. */
+export interface ASKGToolCallEvent extends ASKGEventBase {
+  type: "tool-call";
+  turnId: string;
+  toolCallId: string;
+  name: string;
+  args: Record<string, JsonValue>;
+  writeTier: WriteTier;
+  requiresConfirmation: boolean;
+  preview: JsonValue;
+  timeoutMs: number;
+  expiresAt: string;
+}
+
+/** Compact result information suitable for the tool timeline. */
+export interface ToolExecutionSummary {
+  rowCount?: number;
+  elapsedMs: number;
+  truncated: boolean;
+  note?: string;
+  sample?: JsonValue;
+}
+
+/** Status returned by either a server or client tool execution. */
+export type ToolResultStatus =
+  | "ok"
+  | "error"
+  | "denied"
+  | "timeout"
+  | "partial"
+  | "cancelled";
+
+/** Reports a completed server tool or an accepted client execution. */
+export interface ASKGToolExecutedEvent extends ASKGEventBase {
+  type: "tool-executed";
+  turnId: string;
+  toolCallId: string;
+  name: string;
+  source: ToolManifestSource | "server";
+  status: ToolResultStatus;
+  summary: ToolExecutionSummary;
+}
+
+/** Confirms that one client tool result was accepted by the turn loop. */
+export interface ASKGToolResultAckEvent extends ASKGEventBase {
+  type: "tool-result-ack";
+  turnId: string;
+  toolCallId: string;
+}
+
+/** Stable error codes that clients can handle without parsing text. */
+export type ASKGErrorCode =
+  | "rate_limited"
+  | "daily_turn_cap"
+  | "tool_budget_exhausted"
+  | "turn_timeout"
+  | "model_usage_limit"
+  | "model_unavailable"
+  | "internal";
+
+/** Reports a recoverable or terminal session or turn failure. */
+export interface ASKGErrorEvent extends ASKGEventBase {
+  type: "error";
+  turnId?: string;
+  code: ASKGErrorCode;
+  message: string;
+  retryable: boolean;
+  retryAfterMs?: number;
+}
+
+/** Token accounting emitted when the model provider supplies it. */
+export interface ASKGUsageEvent extends ASKGEventBase {
+  type: "usage";
+  turnId: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  estimated: boolean;
+}
+
+/** Reason a turn stream stopped. */
+export type ASKGDoneReason = "complete" | "cancelled" | "error" | "timeout";
+
+/** Terminates a turn stream. */
+export interface ASKGDoneEvent extends ASKGEventBase {
+  type: "done";
+  turnId: string;
+  reason: ASKGDoneReason;
+}
+
+/** Event payloads emitted over the ASKG turn SSE stream. */
+export type ASKGSseEvent =
+  | ASKGSessionEvent
+  | ASKGTextDeltaEvent
+  | ASKGToolCallEvent
+  | ASKGToolExecutedEvent
+  | ASKGToolResultAckEvent
+  | ASKGErrorEvent
+  | ASKGUsageEvent
+  | ASKGDoneEvent;
+
+/** Client result posted for one delegated tool call. */
+export interface ToolResultPayload {
+  turnId: string;
+  toolCallId: string;
+  status: ToolResultStatus;
+  result?: JsonValue;
+  rowCount?: number;
+  truncated: boolean;
+  elapsedMs: number;
+  note?: string;
+  rev?: string;
+  undoToken?: string;
+}

--- a/src/remote/schema.test.ts
+++ b/src/remote/schema.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import {
+  REMOTE_OPERATIONS,
+  remoteOperationDescriptors,
+  writeTierForSideEffectLevel,
+} from "./schema";
+
+function jsonRoundTrip<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+describe("remote operation schema", () => {
+  test("publishes stable input schemas and write tiers", () => {
+    expect(REMOTE_OPERATIONS.length).toBeGreaterThan(0);
+
+    for (const operation of REMOTE_OPERATIONS) {
+      expect(operation.title.length).toBeGreaterThan(0);
+      expect(operation.inputSchema.type).toBe("object");
+      const mappedTier = writeTierForSideEffectLevel(operation.sideEffectLevel);
+      if (operation.id === "layout.delete") {
+        expect(operation.sideEffectLevel).toBe("local-write");
+        expect(operation.writeTier).toBe("user-data");
+      } else {
+        expect(operation.writeTier).toBe(mappedTier);
+      }
+      expect(jsonRoundTrip(operation.inputSchema)).toEqual(operation.inputSchema);
+    }
+
+    expect(writeTierForSideEffectLevel("none")).toBe("read");
+    expect(writeTierForSideEffectLevel("network-write")).toBe("user-data");
+    expect(writeTierForSideEffectLevel("external-trade")).toBe("broker");
+    expect(REMOTE_OPERATIONS.find(({ id }) => id === "layout.delete")?.writeTier)
+      .toBe("user-data");
+    expect(REMOTE_OPERATIONS.find(({ id }) => id === "capability.invoke")?.writeTier)
+      .toBe("broker");
+    expect(REMOTE_OPERATIONS.find(({ id }) => id === "layout.placePane")?.inputSchema)
+      .toMatchObject({
+        required: ["paneId", "region"],
+        properties: {
+          region: { enum: ["left", "right", "top", "bottom", "floating"] },
+        },
+      });
+  });
+
+  test("serializes operation descriptors without losing fields", () => {
+    const descriptors = remoteOperationDescriptors();
+
+    expect(jsonRoundTrip(descriptors)).toEqual(descriptors);
+    expect(descriptors).toHaveLength(REMOTE_OPERATIONS.length);
+    expect(descriptors[0]).toEqual({
+      name: REMOTE_OPERATIONS[0]!.id,
+      title: REMOTE_OPERATIONS[0]!.title,
+      description: REMOTE_OPERATIONS[0]!.description,
+      writeTier: REMOTE_OPERATIONS[0]!.writeTier,
+      inputSchema: REMOTE_OPERATIONS[0]!.inputSchema,
+    });
+  });
+});

--- a/src/remote/schema.test.ts
+++ b/src/remote/schema.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { TOOL_NAME_PATTERN } from "../plugins/builtin/cloud/askg/protocol";
 import {
   REMOTE_OPERATIONS,
   remoteOperationDescriptors,
+  remoteOperationToolName,
   writeTierForSideEffectLevel,
 } from "./schema";
 
@@ -47,8 +49,13 @@ describe("remote operation schema", () => {
 
     expect(jsonRoundTrip(descriptors)).toEqual(descriptors);
     expect(descriptors).toHaveLength(REMOTE_OPERATIONS.length);
+    expect(new Set(descriptors.map(({ name }) => name)).size).toBe(descriptors.length);
+    expect(descriptors.every(({ name }) => new RegExp(TOOL_NAME_PATTERN).test(name)))
+      .toBe(true);
+    expect(remoteOperationToolName("commandBar.activateResult"))
+      .toBe("command_bar.activate_result");
     expect(descriptors[0]).toEqual({
-      name: REMOTE_OPERATIONS[0]!.id,
+      name: remoteOperationToolName(REMOTE_OPERATIONS[0]!.id),
       title: REMOTE_OPERATIONS[0]!.title,
       description: REMOTE_OPERATIONS[0]!.description,
       writeTier: REMOTE_OPERATIONS[0]!.writeTier,

--- a/src/remote/schema.ts
+++ b/src/remote/schema.ts
@@ -379,12 +379,18 @@ export function writeTierForSideEffectLevel(
 
 export function remoteOperationDescriptors(): RemoteOperationDescriptor[] {
   return REMOTE_OPERATIONS.map(({ id, title, description, writeTier, inputSchema }) => ({
-    name: id,
+    name: remoteOperationToolName(id),
     title,
     description,
     writeTier,
     inputSchema,
   }));
+}
+
+export function remoteOperationToolName(id: string): string {
+  return id
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase();
 }
 
 function operationTitle(id: string): string {

--- a/src/remote/schema.ts
+++ b/src/remote/schema.ts
@@ -1,4 +1,12 @@
-import type { RemoteControlSchema, RemoteOperationSchema, RemoteResourceSchema } from "./types";
+import type {
+  RemoteControlSchema,
+  RemoteJsonSchema,
+  RemoteOperationDescriptor,
+  RemoteOperationSchema,
+  RemoteResourceSchema,
+  RemoteSideEffectLevel,
+  RemoteWriteTier,
+} from "./types";
 
 export const REMOTE_RESOURCES: RemoteResourceSchema[] = [
   { uri: "app://snapshot", description: "Current app snapshot including layout, focus, panes, command bar, and plugin/capability catalogs." },
@@ -19,43 +27,262 @@ export const REMOTE_RESOURCES: RemoteResourceSchema[] = [
   { uri: "ui://tree", description: "Live semantic UI node tree populated by shared controls and interactive primitives." },
 ];
 
+const stringSchema = { type: "string" } satisfies RemoteJsonSchema;
+const requiredStringSchema = { type: "string", minLength: 1 } satisfies RemoteJsonSchema;
+const booleanSchema = { type: "boolean" } satisfies RemoteJsonSchema;
+const indexSchema = { type: "integer", minimum: 0 } satisfies RemoteJsonSchema;
+const openObjectSchema = { type: "object", additionalProperties: true } satisfies RemoteJsonSchema;
+const anySchema = {} satisfies RemoteJsonSchema;
+
+function objectSchema(
+  properties: Record<string, RemoteJsonSchema> = {},
+  required: string[] = [],
+): RemoteJsonSchema {
+  return {
+    type: "object",
+    properties,
+    ...(required.length > 0 ? { required } : {}),
+    additionalProperties: false,
+  };
+}
+
+const paneIdInput = objectSchema({ paneId: requiredStringSchema }, ["paneId"]);
+
 export const REMOTE_OPERATIONS: RemoteOperationSchema[] = [
-  op("app.openCommandBar", "Open the command bar with an optional query and optional mode.", "{ query?: string, mode?: 'command' | 'ticker' }", "local-write"),
-  op("app.closeCommandBar", "Close the command bar.", "{}", "local-write"),
-  op("app.setCommandBarQuery", "Set the command bar query.", "{ query: string }", "local-write"),
-  op("app.search", "Open command-bar search without requiring UI prefix syntax.", "{ mode: 'command' | 'ticker', query?: string }", "local-write"),
-  op("app.switchPanel", "Switch the active panel.", "{ panel: 'left' | 'right' }", "local-write"),
-  op("app.notify", "Show an in-app notification.", "{ body: string, type?: string }", "local-write"),
-  op("commandBar.activateResult", "Activate a visible command-bar result by zero-based index, node id, item id, or label.", "{ index?: number, nodeId?: string, itemId?: string, label?: string }", "local-write"),
-  op("pane.show", "Show or focus a pane type.", "{ paneId: string }", "local-write"),
-  op("pane.focus", "Focus a pane instance or pane type.", "{ paneId: string }", "local-write"),
-  op("pane.close", "Close a pane instance or pane type.", "{ paneId: string }", "local-write"),
-  op("pane.createFromTemplate", "Create a pane from a registered template.", "{ templateId: string, options?: object }", "local-write"),
-  op("pane.setState", "Patch pane runtime state.", "{ paneId: string, patch: object }", "local-write"),
-  op("pane.setSetting", "Set one pane setting using the pane's registered setting field when available.", "{ paneId: string, key: string, value: any }", "local-write"),
-  op("ticker.navigate", "Navigate a ticker into the best available ticker research target.", "{ symbol: string, sourcePaneId?: string }", "local-write"),
-  op("ticker.pin", "Open or focus a fixed ticker research pane.", "{ symbol: string, floating?: boolean, forceNewPane?: boolean, paneType?: string }", "local-write"),
-  op("ticker.select", "Select a ticker in a target pane.", "{ symbol: string, paneId?: string }", "local-write"),
-  op("ticker.switchTab", "Switch ticker research tab.", "{ tabId: string, paneId?: string }", "local-write"),
-  op("layout.switch", "Switch active layout by index.", "{ index: number }", "local-write"),
-  op("layout.new", "Create a new blank layout.", "{ name: string }", "local-write"),
-  op("layout.rename", "Rename a layout.", "{ index: number, name: string }", "local-write"),
-  op("layout.duplicate", "Duplicate a layout.", "{ index: number }", "local-write"),
-  op("layout.delete", "Delete a layout.", "{ index: number }", "local-write"),
-  op("layout.undo", "Undo last layout change.", "{}", "local-write"),
-  op("layout.redo", "Redo last layout change.", "{}", "local-write"),
-  op("layout.gridlock", "Tidy all panes into a dense layout.", "{}", "local-write"),
-  op("layout.closeFloating", "Close all floating panes in the active layout.", "{}", "local-write"),
-  op("layout.placePane", "Move a pane to a layout region.", "{ paneId: string, region: 'left' | 'right' | 'top' | 'bottom' | 'floating', relativeTo?: string }", "local-write"),
-  op("layout.focusRegion", "Focus a pane by visual layout region.", "{ region: 'left' | 'right' | 'top' | 'bottom' | 'center' }", "local-write"),
-  op("layout.setGrid", "Dock visible or specified panes into a simple grid.", "{ paneIds?: string[], columns?: number }", "local-write"),
-  op("desktop.popOutPane", "Pop a pane into a detached desktop window.", "{ paneId: string }", "local-write"),
-  op("desktop.dockPane", "Dock a detached desktop pane.", "{ paneId: string }", "local-write"),
-  op("desktop.closeDetachedPane", "Close a detached desktop pane.", "{ paneId: string }", "local-write"),
-  op("desktop.focusDetachedPane", "Focus a detached desktop pane.", "{ paneId: string }", "local-write"),
-  op("capability.invoke", "Invoke a registered plugin capability operation.", "{ capabilityId: string, operationId: string, payload?: object }", "local-write"),
-  op("ui.invoke", "Invoke an action on a live semantic UI node.", "{ nodeId: string, action?: string, input?: any }", "local-write"),
-  op("ui.invokeMatching", "Invoke an action on the first semantic UI node matching role, label, index, or metadata.", "{ role?: string, label?: string, contains?: string, index?: number, action?: string, input?: any, metadata?: object }", "local-write"),
+  op(
+    "app.openCommandBar",
+    "Open the command bar with an optional query and optional mode.",
+    "{ query?: string, mode?: 'command' | 'ticker' | 'default' }",
+    "local-write",
+    objectSchema({
+      query: stringSchema,
+      mode: { type: "string", enum: ["command", "ticker", "default"] },
+    }),
+  ),
+  op("app.closeCommandBar", "Close the command bar.", "{}", "local-write", objectSchema()),
+  op(
+    "app.setCommandBarQuery",
+    "Set the command bar query.",
+    "{ query: string }",
+    "local-write",
+    objectSchema({ query: requiredStringSchema }, ["query"]),
+  ),
+  op(
+    "app.search",
+    "Open command-bar search without requiring UI prefix syntax.",
+    "{ mode?: 'command' | 'ticker' | 'default', query?: string }",
+    "local-write",
+    objectSchema({
+      mode: { type: "string", enum: ["command", "ticker", "default"] },
+      query: stringSchema,
+    }),
+  ),
+  op(
+    "app.switchPanel",
+    "Switch the active panel.",
+    "{ panel: 'left' | 'right' }",
+    "local-write",
+    objectSchema({ panel: { type: "string", enum: ["left", "right"] } }, ["panel"]),
+  ),
+  op(
+    "app.notify",
+    "Show an in-app notification.",
+    "{ body: string, type?: 'info' | 'success' | 'error' }",
+    "local-write",
+    objectSchema({
+      body: requiredStringSchema,
+      type: { type: "string", enum: ["info", "success", "error"] },
+    }, ["body"]),
+  ),
+  op(
+    "commandBar.activateResult",
+    "Activate a visible command-bar result by zero-based index, node id, item id, or label.",
+    "{ index?: number, nodeId?: string, itemId?: string, label?: string }",
+    "local-write",
+    objectSchema({ index: indexSchema, nodeId: stringSchema, itemId: stringSchema, label: stringSchema }),
+  ),
+  op("pane.show", "Show or focus a pane type.", "{ paneId: string }", "local-write", paneIdInput),
+  op("pane.focus", "Focus a pane instance or pane type.", "{ paneId: string }", "local-write", paneIdInput),
+  op("pane.close", "Close a pane instance or pane type.", "{ paneId: string }", "local-write", paneIdInput),
+  op(
+    "pane.createFromTemplate",
+    "Create a pane from a registered template.",
+    "{ templateId: string, options?: object }",
+    "local-write",
+    objectSchema({ templateId: requiredStringSchema, options: openObjectSchema }, ["templateId"]),
+  ),
+  op(
+    "pane.setState",
+    "Patch pane runtime state.",
+    "{ paneId: string, patch: object }",
+    "local-write",
+    objectSchema({ paneId: requiredStringSchema, patch: openObjectSchema }, ["paneId", "patch"]),
+  ),
+  op(
+    "pane.setSetting",
+    "Set one pane setting using the pane's registered setting field when available.",
+    "{ paneId: string, key: string, value: any }",
+    "local-write",
+    objectSchema({ paneId: requiredStringSchema, key: requiredStringSchema, value: anySchema }, ["paneId", "key", "value"]),
+  ),
+  op(
+    "ticker.navigate",
+    "Navigate a ticker into the best available ticker research target.",
+    "{ symbol: string, sourcePaneId?: string }",
+    "local-write",
+    objectSchema({ symbol: requiredStringSchema, sourcePaneId: stringSchema }, ["symbol"]),
+  ),
+  op(
+    "ticker.pin",
+    "Open or focus a fixed ticker research pane.",
+    "{ symbol: string, floating?: boolean, forceNewPane?: boolean, paneType?: string }",
+    "local-write",
+    objectSchema({
+      symbol: requiredStringSchema,
+      floating: booleanSchema,
+      forceNewPane: booleanSchema,
+      paneType: stringSchema,
+    }, ["symbol"]),
+  ),
+  op(
+    "ticker.select",
+    "Select a ticker in a target pane.",
+    "{ symbol: string, paneId?: string }",
+    "local-write",
+    objectSchema({ symbol: requiredStringSchema, paneId: stringSchema }, ["symbol"]),
+  ),
+  op(
+    "ticker.switchTab",
+    "Switch ticker research tab.",
+    "{ tabId: string, paneId?: string }",
+    "local-write",
+    objectSchema({ tabId: requiredStringSchema, paneId: stringSchema }, ["tabId"]),
+  ),
+  op(
+    "layout.switch",
+    "Switch active layout by index.",
+    "{ index: number }",
+    "local-write",
+    objectSchema({ index: indexSchema }, ["index"]),
+  ),
+  op(
+    "layout.new",
+    "Create a new blank layout.",
+    "{ name: string }",
+    "local-write",
+    objectSchema({ name: requiredStringSchema }, ["name"]),
+  ),
+  op(
+    "layout.rename",
+    "Rename a layout.",
+    "{ index: number, name: string }",
+    "local-write",
+    objectSchema({ index: indexSchema, name: requiredStringSchema }, ["index", "name"]),
+  ),
+  op(
+    "layout.duplicate",
+    "Duplicate a layout.",
+    "{ index: number }",
+    "local-write",
+    objectSchema({ index: indexSchema }, ["index"]),
+  ),
+  op(
+    "layout.delete",
+    "Delete a layout.",
+    "{ index: number }",
+    "local-write",
+    objectSchema({ index: indexSchema }, ["index"]),
+    "user-data",
+  ),
+  op("layout.undo", "Undo last layout change.", "{}", "local-write", objectSchema()),
+  op("layout.redo", "Redo last layout change.", "{}", "local-write", objectSchema()),
+  op("layout.gridlock", "Tidy all panes into a dense layout.", "{}", "local-write", objectSchema()),
+  op(
+    "layout.closeFloating",
+    "Close all floating panes in the active layout.",
+    "{}",
+    "local-write",
+    objectSchema(),
+  ),
+  op(
+    "layout.placePane",
+    "Move a pane to a layout region.",
+    "{ paneId: string, region: 'left' | 'right' | 'top' | 'bottom' | 'floating', relativeTo?: string }",
+    "local-write",
+    objectSchema({
+      paneId: requiredStringSchema,
+      region: { type: "string", enum: ["left", "right", "top", "bottom", "floating"] },
+      relativeTo: stringSchema,
+    }, ["paneId", "region"]),
+  ),
+  op(
+    "layout.focusRegion",
+    "Focus a pane by visual layout region.",
+    "{ region: 'left' | 'right' | 'top' | 'bottom' | 'center' }",
+    "local-write",
+    objectSchema({
+      region: { type: "string", enum: ["left", "right", "top", "bottom", "center"] },
+    }, ["region"]),
+  ),
+  op(
+    "layout.setGrid",
+    "Dock visible or specified panes into a simple grid.",
+    "{ paneIds?: string[], columns?: number }",
+    "local-write",
+    objectSchema({
+      paneIds: { type: "array", items: requiredStringSchema },
+      columns: { type: "integer", minimum: 1 },
+    }),
+  ),
+  op("desktop.popOutPane", "Pop a pane into a detached desktop window.", "{ paneId: string }", "local-write", paneIdInput),
+  op("desktop.dockPane", "Dock a detached desktop pane.", "{ paneId: string }", "local-write", paneIdInput),
+  op(
+    "desktop.closeDetachedPane",
+    "Close a detached desktop pane.",
+    "{ paneId: string }",
+    "local-write",
+    paneIdInput,
+  ),
+  op(
+    "desktop.focusDetachedPane",
+    "Focus a detached desktop pane.",
+    "{ paneId: string }",
+    "local-write",
+    paneIdInput,
+  ),
+  op(
+    "capability.invoke",
+    "Invoke a registered plugin capability operation.",
+    "{ capabilityId: string, operationId: string, payload?: object }",
+    "external-side-effect",
+    objectSchema({
+      capabilityId: requiredStringSchema,
+      operationId: requiredStringSchema,
+      payload: openObjectSchema,
+    }, ["capabilityId", "operationId"]),
+  ),
+  op(
+    "ui.invoke",
+    "Invoke an action on a live semantic UI node.",
+    "{ nodeId: string, action?: string, input?: any }",
+    "local-write",
+    objectSchema({ nodeId: requiredStringSchema, action: stringSchema, input: anySchema }, ["nodeId"]),
+  ),
+  op(
+    "ui.invokeMatching",
+    "Invoke an action on the first semantic UI node matching role, label, index, or metadata.",
+    "{ role?: string, label?: string, contains?: string, index?: number, action?: string, input?: any, metadata?: object }",
+    "local-write",
+    objectSchema({
+      role: stringSchema,
+      label: stringSchema,
+      contains: stringSchema,
+      index: indexSchema,
+      action: stringSchema,
+      input: anySchema,
+      metadata: openObjectSchema,
+    }),
+  ),
 ];
 
 export const REMOTE_AGENT_HELP = {
@@ -134,11 +361,61 @@ export function remoteControlSchema(): RemoteControlSchema {
   };
 }
 
+export function writeTierForSideEffectLevel(
+  sideEffectLevel: RemoteSideEffectLevel,
+): RemoteWriteTier {
+  switch (sideEffectLevel) {
+    case "none":
+      return "read";
+    case "local-write":
+      return "ui-write";
+    case "network-write":
+      return "user-data";
+    case "external-side-effect":
+    case "external-trade":
+      return "broker";
+  }
+}
+
+export function remoteOperationDescriptors(): RemoteOperationDescriptor[] {
+  return REMOTE_OPERATIONS.map(({ id, title, description, writeTier, inputSchema }) => ({
+    name: id,
+    title,
+    description,
+    writeTier,
+    inputSchema,
+  }));
+}
+
+function operationTitle(id: string): string {
+  const [scope = "", action = ""] = id.split(".");
+  return `${humanizeIdentifier(scope)}: ${humanizeIdentifier(action)}`;
+}
+
+function humanizeIdentifier(value: string): string {
+  if (value === "ui") return "UI";
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/^./, (character) => character.toUpperCase());
+}
+
 function op(
   id: string,
   description: string,
   inputShape: string,
-  sideEffectLevel: RemoteOperationSchema["sideEffectLevel"],
+  sideEffectLevel: RemoteSideEffectLevel,
+  inputSchema: RemoteJsonSchema,
+  writeTier = writeTierForSideEffectLevel(sideEffectLevel),
 ): RemoteOperationSchema {
-  return { id, description, inputShape, sideEffectLevel, dryRun: sideEffectLevel !== "none" };
+  return {
+    id,
+    title: operationTitle(id),
+    description,
+    inputShape,
+    inputSchema,
+    sideEffectLevel,
+    writeTier,
+    requiresConfirmation: writeTier === "user-data" || writeTier === "broker",
+    dryRun: sideEffectLevel !== "none",
+  };
 }

--- a/src/remote/types.ts
+++ b/src/remote/types.ts
@@ -100,17 +100,64 @@ export interface RemoteResourceSchema {
   patchable?: boolean;
 }
 
+export type RemoteSideEffectLevel =
+  | "none"
+  | "local-write"
+  | "network-write"
+  | "external-side-effect"
+  | "external-trade";
+
+export type RemoteWriteTier = "read" | "ui-write" | "user-data" | "broker";
+
+export type RemoteJsonSchemaType =
+  | "object"
+  | "array"
+  | "string"
+  | "number"
+  | "integer"
+  | "boolean"
+  | "null";
+
+/** Serializable subset of JSON Schema used for remote operation inputs. */
+export interface RemoteJsonSchema {
+  type?: RemoteJsonSchemaType | RemoteJsonSchemaType[];
+  description?: string;
+  properties?: Record<string, RemoteJsonSchema>;
+  required?: string[];
+  additionalProperties?: boolean;
+  items?: RemoteJsonSchema;
+  enum?: Array<string | number | boolean | null>;
+  minimum?: number;
+  maximum?: number;
+  minItems?: number;
+  maxItems?: number;
+  minLength?: number;
+  maxLength?: number;
+}
+
 export interface RemoteOperationSchema {
   id: string;
+  title: string;
   description: string;
-  inputShape?: string;
+  inputShape: string;
+  inputSchema: RemoteJsonSchema;
   outputShape?: string;
   returns?: string;
   recommendedNextReads?: string[];
   examples?: unknown[];
-  sideEffectLevel: "none" | "local-write" | "network-write" | "external-side-effect" | "external-trade";
+  sideEffectLevel: RemoteSideEffectLevel;
+  writeTier: RemoteWriteTier;
   requiresConfirmation?: boolean;
   dryRun?: boolean;
+}
+
+/** Stable operation metadata suitable for advertising outside the process. */
+export interface RemoteOperationDescriptor {
+  name: string;
+  title: string;
+  description: string;
+  writeTier: RemoteWriteTier;
+  inputSchema: RemoteJsonSchema;
 }
 
 export interface RemoteControlSchema {


### PR DESCRIPTION
## Why

ASKG needs a stable client tool contract before the hosted loop or terminal executor can be built. Remote operations also need machine-readable arguments and safety tiers instead of prose-only inputs.

Companion platform PR: https://github.com/vincelwt/gloomberb-platform/pull/183

## What

- add JSON Schema inputs, titles, and write tiers to every registered remote operation
- derive normal tiers from existing side-effect levels, with an explicit user-data override for layout deletion and a conservative broker tier for generic capability invocation
- expose serializable remote operation descriptors with unique, protocol-safe snake_case names
- define ASKG protocol v1 manifests, session negotiation, SSE events, limits, and tool results
- tie headless manifest fields directly to the existing headless pane types

## Verify

- `bun test src/remote/schema.test.ts src/plugins/builtin/cloud/askg/protocol.test.ts`
- `bun test` (2,524 pass)
- `bun run typecheck`

## CI note

The branch is rebased onto current `main`. Earlier GitHub attempts reproduced `main`'s pre-existing command-bar assist timeouts and Windows blank onboarding screenshot failure; Verify retries passed. Deploy jobs remain skipped.
