### PR TITLE
feat: make fn fall back to rendered pane data

### DIFF
--- a/src/cli/desktop-pane-shot.ts
+++ b/src/cli/desktop-pane-shot.ts
@@ -73,6 +73,8 @@ export interface DesktopPaneShotRenderedRow {
 export interface DesktopPaneShotRenderResult {
   visibleText: string;
   rows: DesktopPaneShotRenderedRow[];
+  truncated: boolean;
+  truncationReasons: string[];
   loadingStateDetected: boolean;
   errorStateDetected: boolean;
   errorStateMarkers: string[];
@@ -113,6 +115,7 @@ export async function renderDesktopPaneScreenshot(
   payload: DesktopPaneShotPayload,
   outputPath: string,
   apiProxy: DesktopPaneShotApiProxy,
+  options: { captureImage?: boolean } = {},
 ): Promise<DesktopPaneShotRenderResult> {
   const tempDir = await mkdtemp(join(tmpdir(), "gloom-pane-shot-"));
   let server: ReturnType<typeof Bun.serve> | null = null;
@@ -130,6 +133,7 @@ export async function renderDesktopPaneScreenshot(
       heightPx: payload.heightPx,
       deviceScaleFactor: payload.deviceScaleFactor ?? DEFAULT_DEVICE_SCALE_FACTOR,
       userDataDir: join(tempDir, "chrome-profile"),
+      captureImage: options.captureImage !== false,
     });
   } finally {
     server?.stop(true);
@@ -311,6 +315,7 @@ async function capturePageScreenshot({
   heightPx,
   deviceScaleFactor,
   userDataDir,
+  captureImage,
 }: {
   chrome: string;
   url: string;
@@ -319,6 +324,7 @@ async function capturePageScreenshot({
   heightPx: number;
   deviceScaleFactor: number;
   userDataDir: string;
+  captureImage: boolean;
 }): Promise<DesktopPaneShotRenderResult> {
   await mkdir(userDataDir, { recursive: true });
   const port = 43000 + Math.floor(Math.random() * 10000);
@@ -359,13 +365,15 @@ async function capturePageScreenshot({
     });
     await waitForShotReady(session);
     const rendered = await readRenderedPaneState(session);
-    const screenshot = await session.send("Page.captureScreenshot", {
-      format: "png",
-      fromSurface: true,
-      captureBeyondViewport: false,
-    }) as { data?: string };
-    if (!screenshot.data) throw new Error("Chrome did not return screenshot data.");
-    await writeFile(outputPath, Uint8Array.from(Buffer.from(screenshot.data, "base64")));
+    if (captureImage) {
+      const screenshot = await session.send("Page.captureScreenshot", {
+        format: "png",
+        fromSurface: true,
+        captureBeyondViewport: false,
+      }) as { data?: string };
+      if (!screenshot.data) throw new Error("Chrome did not return screenshot data.");
+      await writeFile(outputPath, Uint8Array.from(Buffer.from(screenshot.data, "base64")));
+    }
     return rendered;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -388,6 +396,7 @@ const ERROR_STATE_PATTERNS = [
   /\bCould not load\b/gi,
   /\bSign in to\b/gi,
   /\bVerify your email\b/gi,
+  /\brequires signup and email verification\b/gi,
   /\bpart of Gloom Cloud Pro\b/gi,
   /\bCloud API request failed\b/gi,
 ];
@@ -431,6 +440,25 @@ async function readRenderedPaneState(session: CdpSession): Promise<DesktopPaneSh
       };
       const semanticTables = semanticUi.filter((node) => node && node.role === "table");
       const rows = [];
+      const truncationReasons = new Set();
+      const markScrollTruncation = (element) => {
+        if (!(element instanceof HTMLElement) || !isVisible(element)) return;
+        if (
+          element.getAttribute("data-gloom-scrollbar-y") === "visible"
+          || element.scrollHeight > element.clientHeight + 1
+        ) {
+          truncationReasons.add("rows extend below the rendered viewport");
+        }
+        if (
+          element.getAttribute("data-gloom-scrollbar-x") === "visible"
+          || element.scrollWidth > element.clientWidth + 1
+        ) {
+          truncationReasons.add("columns extend beyond the rendered viewport");
+        }
+      };
+      [...root.querySelectorAll(
+        '[data-gloom-scrollbar-x="visible"], [data-gloom-scrollbar-y="visible"], [data-gloom-role="data-table-body-scroll"]',
+      )].forEach(markScrollTruncation);
       [...root.querySelectorAll('[data-gloom-role="data-table"]')]
         .filter(isVisible)
         .forEach((table, tableIndex) => {
@@ -448,12 +476,24 @@ async function readRenderedPaneState(session: CdpSession): Promise<DesktopPaneSh
             const semanticRow = semanticRows[rowIndex] || {};
             const cells = values.map((cell, cellIndex) => {
               const semanticColumn = semanticColumns[cellIndex] || {};
+              const text = normalize(cell.innerText || cell.textContent);
+              const textNodes = [cell, ...cell.querySelectorAll('*')];
+              if (
+                /\\u2026|\\.\\.\\./.test(text)
+                || textNodes.some((node) => (
+                  node instanceof HTMLElement
+                  && isVisible(node)
+                  && node.scrollWidth > node.clientWidth + 1
+                ))
+              ) {
+                truncationReasons.add("one or more cells are visibly clipped");
+              }
               return {
                 ...(typeof semanticColumn.id === "string" ? { columnId: semanticColumn.id } : {}),
                 columnLabel: typeof semanticColumn.label === "string"
                   ? semanticColumn.label
                   : headers[cellIndex] || (values.length === 1 ? "Row" : String(cellIndex + 1)),
-                text: normalize(cell.innerText || cell.textContent),
+                text,
               };
             }).filter((cell) => cell.text.length > 0);
             if (cells.length === 0) return;
@@ -487,6 +527,8 @@ async function readRenderedPaneState(session: CdpSession): Promise<DesktopPaneSh
         errorStateDetected: root.querySelector('[data-gloom-status="error"]') !== null,
         emptyStateDetected: root.querySelector('[data-gloom-status="empty"]') !== null,
         rows,
+        truncated: truncationReasons.size > 0,
+        truncationReasons: [...truncationReasons],
         semanticUi,
       };
     })()`,
@@ -500,6 +542,8 @@ async function readRenderedPaneState(session: CdpSession): Promise<DesktopPaneSh
         errorStateDetected?: boolean;
         emptyStateDetected?: boolean;
         rows?: DesktopPaneShotRenderedRow[];
+        truncated?: boolean;
+        truncationReasons?: string[];
         semanticUi?: RemoteUiNodeSnapshot[];
       };
     };
@@ -510,9 +554,19 @@ async function readRenderedPaneState(session: CdpSession): Promise<DesktopPaneSh
   const loadingStateMarkers = stateMarkers(visibleText, LOADING_STATE_PATTERNS);
   const errorStateMarkers = stateMarkers(visibleText, ERROR_STATE_PATTERNS);
   const emptyStateMarkers = stateMarkers(visibleText, EMPTY_STATE_PATTERNS);
+  const rows = Array.isArray(value?.rows) ? value.rows : [];
+  const textShowsEllipsis = rows.some((row) => row.cells.some((cell) => /\u2026|\.\.\./.test(cell.text)));
+  const truncationReasons = Array.isArray(value?.truncationReasons)
+    ? value.truncationReasons.filter((reason): reason is string => typeof reason === "string")
+    : [];
+  if (textShowsEllipsis && !truncationReasons.includes("one or more cells are visibly clipped")) {
+    truncationReasons.push("one or more cells are visibly clipped");
+  }
   return {
     visibleText,
-    rows: Array.isArray(value?.rows) ? value.rows : [],
+    rows,
+    truncated: value?.truncated === true || textShowsEllipsis,
+    truncationReasons,
     loadingStateDetected: value?.loadingStateDetected === true || loadingStateMarkers.length > 0,
     errorStateDetected: value?.errorStateDetected === true || errorStateMarkers.length > 0,
     errorStateMarkers,

--- a/src/cli/pane-functions/capabilities.ts
+++ b/src/cli/pane-functions/capabilities.ts
@@ -9,8 +9,8 @@ import type {
   PaneTemplateDef,
 } from "../../types/plugin";
 
-export type PaneFunctionReadiness = "ready" | "partial" | "unsupported";
-export type PaneFunctionScreenshotReadiness = PaneFunctionReadiness | "live-dom";
+export type PaneFunctionReadiness = "ready" | "partial" | "live-dom" | "unsupported";
+export type PaneFunctionScreenshotReadiness = PaneFunctionReadiness;
 export type PaneFunctionTickerCardinality = "none" | "one" | "one-or-more" | "two-or-more" | "one-or-two";
 export type PaneFunctionOptionType = HeadlessPaneOptionType;
 export type PaneFunctionOptionValue = HeadlessPaneOptionValue;
@@ -405,21 +405,51 @@ const CAPABILITIES: Record<string, PaneFunctionCapability> = {
   },
 };
 
-const UNSUPPORTED_CAPABILITY: PaneFunctionCapability = {
-  id: "unverified-pane",
-  botSafe: false,
-  tickerCardinality: "none",
-  aliases: [],
-  intents: [],
-  outputKind: "pane",
-  reportReadiness: "unsupported",
-  screenshotReadiness: "live-dom",
-  dataRequirements: [],
-  limitations: [
-    "Reports are not verified for automation. Screenshots render live and derive evidence from visible DOM rows.",
-  ],
-  options: [],
-};
+const NON_DATA_PANE_IDS = new Set([
+  "account-management",
+  "brokers",
+  "changelog",
+  "chat",
+  "connections",
+  "data-catalog",
+  "debug",
+  "help",
+  "ibkr-trading",
+  "layout-marketplace",
+  "local-agent-workspace",
+  "macro-tv",
+  "plugin-marketplace",
+  "world-venue-map",
+]);
+
+const RENDERED_VIEW_LIMITATION =
+  "Reports contain only values exposed by the rendered view and may omit clipped or off-screen data.";
+
+function fallbackCapability(
+  template: PaneTemplateDef | undefined,
+  pane: PaneDef,
+): PaneFunctionCapability {
+  const dataPane = isDataPaneForDomFallback(pane);
+  return {
+    id: template?.id ?? pane.id,
+    botSafe: false,
+    tickerCardinality: "none",
+    aliases: [],
+    intents: [],
+    outputKind: dataPane ? "rendered-view" : "pane",
+    reportReadiness: dataPane ? "live-dom" : "unsupported",
+    screenshotReadiness: "live-dom",
+    dataRequirements: [],
+    limitations: [dataPane
+      ? RENDERED_VIEW_LIMITATION
+      : "This pane is an interactive surface and does not expose a data report."],
+    options: [],
+  };
+}
+
+export function isDataPaneForDomFallback(pane: Pick<PaneDef, "id">): boolean {
+  return !NON_DATA_PANE_IDS.has(pane.id);
+}
 
 function optionToken(value: string): string {
   return value.trim().toLowerCase().replace(/[\s_.-]+/g, "");
@@ -453,13 +483,14 @@ export function getPaneFunctionCapability(
   template: PaneTemplateDef | undefined,
   pane: PaneDef,
 ): PaneFunctionCapability {
-  const existing = template ? CAPABILITIES[template.id] ?? UNSUPPORTED_CAPABILITY : UNSUPPORTED_CAPABILITY;
+  const fallback = fallbackCapability(template, pane);
+  const existing = template ? CAPABILITIES[template.id] ?? fallback : fallback;
   const headless = getHeadlessPaneDefinition(template, pane);
   if (!headless) return existing;
 
-  const hasExistingCapability = existing !== UNSUPPORTED_CAPABILITY;
+  const hasExistingCapability = existing !== fallback;
   return {
-    ...(hasExistingCapability ? existing : UNSUPPORTED_CAPABILITY),
+    ...(hasExistingCapability ? existing : fallback),
     id: hasExistingCapability ? existing.id : template?.id ?? pane.id,
     botSafe: true,
     tickerCardinality: headlessTickerCardinality(headless.argument),

--- a/src/cli/pane-functions/dom.test.ts
+++ b/src/cli/pane-functions/dom.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import type { ResolvedPaneFunction } from "./resolver";
+import type { PaneScreenshotResult } from "./screenshot";
+import { buildDomPaneReportFromRender } from "./dom";
+
+test("marks rendered reports as truncated when a visible cell contains an ellipsis", () => {
+  const resolved = {
+    token: "INS",
+    label: "Insider",
+    capability: { id: "insider-pane" },
+    options: {},
+  } as unknown as ResolvedPaneFunction;
+  const screenshot = {
+    symbols: ["AVGO"],
+    render: {
+      visibleText: "NVIDIA Corporati…",
+      rows: [{
+        tableIndex: 0,
+        rowIndex: 0,
+        selected: false,
+        cells: [{ columnLabel: "Issuer", text: "NVIDIA Corporati…" }],
+      }],
+      truncated: false,
+      truncationReasons: [],
+      loadingStateDetected: false,
+      errorStateDetected: false,
+      errorStateMarkers: [],
+      emptyStateDetected: false,
+      emptyStateMarkers: [],
+    },
+  } as unknown as PaneScreenshotResult;
+
+  const report = buildDomPaneReportFromRender(resolved, screenshot);
+  expect(report.data).toMatchObject({
+    kind: "rendered-view",
+    rowCount: 1,
+    truncated: true,
+    complete: false,
+    limitation: expect.stringContaining("visible"),
+  });
+});

--- a/src/cli/pane-functions/dom.ts
+++ b/src/cli/pane-functions/dom.ts
@@ -1,0 +1,199 @@
+import type { DesktopPaneShotRenderedRow } from "../desktop-pane-shot";
+import { renderSection, renderTable } from "../../utils/cli-output";
+import type { MarketContext } from "../types";
+import type { PaneFunctionReport } from "./report";
+import type { ResolvedPaneFunction } from "./resolver";
+import { collectShotSymbols } from "./data";
+import { renderDesktopShot, type PaneScreenshotResult } from "./screenshot";
+
+const DOM_REPORT_WIDTH = 1280;
+const DOM_REPORT_HEIGHT = 720;
+const DOM_LIMITATION =
+  "Only values visible in the rendered pane are returned; clipped or off-screen data may be omitted.";
+
+function rowsContainEllipsis(rows: DesktopPaneShotRenderedRow[]): boolean {
+  return rows.some((row) => row.cells.some((cell) => /\u2026|\.\.\./.test(cell.text)));
+}
+
+export function isDomReportTruncated(
+  render: Pick<PaneScreenshotResult["render"], "rows" | "truncated">,
+): boolean {
+  return render.truncated || rowsContainEllipsis(render.rows);
+}
+
+function renderDomTables(rows: DesktopPaneShotRenderedRow[]): string[] {
+  const byTable = new Map<number, DesktopPaneShotRenderedRow[]>();
+  for (const row of rows) {
+    const tableRows = byTable.get(row.tableIndex) ?? [];
+    tableRows.push(row);
+    byTable.set(row.tableIndex, tableRows);
+  }
+
+  return [...byTable.entries()].flatMap(([tableIndex, tableRows], index) => {
+    const columnCount = Math.max(0, ...tableRows.map((row) => row.cells.length));
+    const columns = Array.from({ length: columnCount }, (_, columnIndex) => ({
+      header: tableRows.find((row) => row.cells[columnIndex])?.cells[columnIndex]?.columnLabel
+        ?? `Column ${columnIndex + 1}`,
+    }));
+    const output = renderTable(
+      columns,
+      tableRows.map((row) => columns.map((_column, columnIndex) => row.cells[columnIndex]?.text ?? "")),
+    );
+    return [
+      ...(index > 0 ? [""] : []),
+      ...(byTable.size > 1 ? [renderSection(`Rendered table ${tableIndex + 1}`)] : []),
+      output,
+    ];
+  });
+}
+
+function renderedFailureReason(
+  result: PaneScreenshotResult,
+  rows: DesktopPaneShotRenderedRow[],
+): string | null {
+  if (result.render.loadingStateDetected) return "The rendered pane was still loading.";
+  if (result.render.errorStateDetected) {
+    const marker = result.render.errorStateMarkers[0];
+    return marker ? `The rendered pane reported: ${marker}` : "The rendered pane reported an error.";
+  }
+  if (result.render.emptyStateDetected) {
+    const marker = result.render.emptyStateMarkers[0];
+    return marker ? `The rendered pane reported: ${marker}` : "The rendered pane reported an empty state.";
+  }
+  if (rows.length === 0) return "The rendered pane exposed no structured rows or visible text.";
+  return null;
+}
+
+function reportRows(result: PaneScreenshotResult): DesktopPaneShotRenderedRow[] {
+  if (result.render.rows.length > 0) return result.render.rows;
+  if (
+    result.render.loadingStateDetected
+    || result.render.errorStateDetected
+    || result.render.emptyStateDetected
+    || !result.render.visibleText
+  ) {
+    return [];
+  }
+  return [{
+    tableIndex: 0,
+    rowIndex: 0,
+    selected: false,
+    cells: [{ columnLabel: "Rendered view", text: result.render.visibleText }],
+  }];
+}
+
+export function buildDomPaneReportFromRender(
+  resolved: ResolvedPaneFunction,
+  result: PaneScreenshotResult,
+): PaneFunctionReport {
+  const rows = reportRows(result);
+  const hasStructuredRows = result.render.rows.length > 0;
+  const truncated = isDomReportTruncated({ ...result.render, rows });
+  const truncationReasons = [...result.render.truncationReasons];
+  if (rowsContainEllipsis(rows) && !truncationReasons.includes("one or more cells are visibly clipped")) {
+    truncationReasons.push("one or more cells are visibly clipped");
+  }
+  const failureReason = renderedFailureReason(result, rows);
+  const unavailableSymbols = failureReason && result.symbols.length > 0 ? result.symbols : [];
+  const textLines = [resolved.label, ""];
+  if (hasStructuredRows) {
+    textLines.push(...renderDomTables(rows));
+  } else if (result.render.visibleText) {
+    textLines.push(result.render.visibleText);
+  } else {
+    textLines.push(failureReason ?? "No rendered values were available.");
+  }
+  if (failureReason && rows.length > 0) textLines.push("", failureReason);
+
+  return {
+    data: {
+      kind: "rendered-view",
+      target: resolved.token,
+      capabilityId: resolved.capability.id,
+      symbols: result.symbols,
+      options: resolved.options,
+      rowCount: rows.length,
+      empty: rows.length === 0,
+      complete: failureReason === null && !truncated,
+      unavailableSymbols,
+      rows,
+      visibleText: result.render.visibleText,
+      truncated,
+      truncationReasons,
+      limitation: DOM_LIMITATION,
+      ...(failureReason ? { reason: failureReason } : {}),
+    },
+    text: textLines.join("\n").trimEnd(),
+  };
+}
+
+export function appendDomReportFooter(
+  text: string,
+  elapsedMs: number,
+  truncated: boolean,
+): string {
+  const clipping = truncated ? "The rendered view is clipped." : "The rendered view may be clipped.";
+  return [
+    text,
+    "",
+    `Rendered view: values come from the visible pane. ${clipping} Render time: ${elapsedMs} ms.`,
+  ].join("\n");
+}
+
+function failedDomReport(
+  resolved: ResolvedPaneFunction,
+  rawArg: string,
+  error: unknown,
+): PaneFunctionReport {
+  const message = (error instanceof Error ? error.message : String(error))
+    .split("\n")[0]!
+    .replace(/^Error:\s*/, "")
+    .trim();
+  const reason = `The rendered view could not be read: ${message || "unknown renderer error"}`;
+  const symbols = collectShotSymbols(resolved, rawArg);
+  return {
+    data: {
+      kind: "rendered-view",
+      target: resolved.token,
+      capabilityId: resolved.capability.id,
+      symbols,
+      options: resolved.options,
+      rowCount: 0,
+      empty: true,
+      complete: false,
+      unavailableSymbols: symbols,
+      rows: [],
+      visibleText: "",
+      truncated: false,
+      truncationReasons: [],
+      limitation: DOM_LIMITATION,
+      reason,
+    },
+    text: [resolved.label, "", reason].join("\n"),
+  };
+}
+
+export async function buildDomFunctionReport(
+  resolved: ResolvedPaneFunction,
+  context: MarketContext,
+  rawArg: string,
+): Promise<PaneFunctionReport> {
+  try {
+    const result = await renderDesktopShot({
+      resolved,
+      context,
+      rawArg,
+      outputPath: "",
+      width: DOM_REPORT_WIDTH,
+      height: DOM_REPORT_HEIGHT,
+      theme: null,
+      scale: 1,
+      watermark: null,
+      options: {},
+      captureImage: false,
+    });
+    return buildDomPaneReportFromRender(resolved, result);
+  } catch (error) {
+    return failedDomReport(resolved, rawArg, error);
+  }
+}

--- a/src/cli/pane-functions/index.test.ts
+++ b/src/cli/pane-functions/index.test.ts
@@ -10,6 +10,7 @@ const {
   filterPaneCatalogEntries,
   renderPaneCatalogReport,
   getPaneFunctionCapability,
+  isDataPaneForDomFallback,
   normalizeCapabilityOptions,
   capabilityPluginState,
 } = paneFunctionTestInternals;
@@ -208,13 +209,23 @@ describe("pane function CLI args", () => {
     });
   });
 
-  test("enables live DOM screenshots without claiming report support for unmapped panes", () => {
+  test("maps data panes to rendered reports and keeps interactive panes unsupported", () => {
     expect(capabilityFor("new-api-pane")).toMatchObject({
-      id: "unverified-pane",
+      id: "new-api-pane",
       botSafe: false,
+      outputKind: "rendered-view",
+      reportReadiness: "live-dom",
+      screenshotReadiness: "live-dom",
+    });
+
+    const helpPane = { ...dummyPane, id: "help" };
+    expect(getPaneFunctionCapability(undefined, helpPane)).toMatchObject({
+      id: "help",
       reportReadiness: "unsupported",
       screenshotReadiness: "live-dom",
     });
+    expect(isDataPaneForDomFallback(dummyPane)).toBe(true);
+    expect(isDataPaneForDomFallback(helpPane)).toBe(false);
   });
 
   test("rejects financial statement options on a price comparison", () => {

--- a/src/cli/pane-functions/index.ts
+++ b/src/cli/pane-functions/index.ts
@@ -25,6 +25,7 @@ import {
 import {
   capabilityPluginState,
   getPaneFunctionCapability,
+  isDataPaneForDomFallback,
   normalizeCapabilityOptions,
 } from "./capabilities";
 
@@ -178,6 +179,7 @@ export const paneFunctionTestInternals = {
   filterPaneCatalogEntries,
   renderPaneCatalogReport,
   getPaneFunctionCapability,
+  isDataPaneForDomFallback,
   normalizeCapabilityOptions,
   capabilityPluginState,
 };

--- a/src/cli/pane-functions/report.test.ts
+++ b/src/cli/pane-functions/report.test.ts
@@ -3,7 +3,10 @@ import { createDefaultConfig } from "../../types/config";
 import { CHART_SPEC_VERSION, type ChartSpec } from "../../time-series/types";
 import { createTestDataProvider } from "../../test-support/data-provider";
 import { setSharedRegistryForTests } from "../../plugins/registry";
-import { buildFunctionReport } from "./report";
+import {
+  buildFunctionReport,
+  resolvePaneFunctionReportSource,
+} from "./report";
 import type { ResolvedPaneFunction } from "./resolver";
 import type { MarketContext } from "../types";
 
@@ -24,6 +27,31 @@ const spec: ChartSpec = {
 };
 
 afterEach(() => setSharedRegistryForTests(undefined));
+
+test("selects headless before legacy reports and rendered DOM fallback", () => {
+  const base = {
+    pane: { id: "market-data", name: "Market Data" },
+    template: undefined,
+    instance: {},
+    capability: { id: "market-data", reportReadiness: "live-dom" },
+  } as unknown as ResolvedPaneFunction;
+
+  expect(resolvePaneFunctionReportSource(base)).toBe("dom");
+  expect(resolvePaneFunctionReportSource({
+    ...base,
+    capability: { ...base.capability, id: "quote-comparison" },
+  })).toBe("report");
+  expect(resolvePaneFunctionReportSource({
+    ...base,
+    capability: { ...base.capability, id: "quote-comparison" },
+    headless: {
+      shape: "rows",
+      argument: { kind: "none" },
+      options: [],
+      load: () => ({ rows: [] }),
+    },
+  })).toBe("headless");
+});
 
 test("chart composer reports accept capability-backed series", async () => {
   const date = new Date(Date.now() - 24 * 60 * 60 * 1_000);

--- a/src/cli/pane-functions/report.ts
+++ b/src/cli/pane-functions/report.ts
@@ -45,9 +45,19 @@ import {
 } from "./data";
 import type { ResolvedPaneFunction } from "./resolver";
 import { buildHeadlessFunctionReport } from "./headless";
+import {
+  appendDomReportFooter,
+  buildDomFunctionReport,
+} from "./dom";
+
+export type PaneFunctionReportSource = "headless" | "report" | "dom";
 
 export interface PaneFunctionReportData {
   kind: string;
+  /** Added by buildFunctionReport after the selected loader completes. */
+  source?: PaneFunctionReportSource;
+  /** Added by buildFunctionReport for every successful report. */
+  elapsedMs?: number;
   target: string;
   capabilityId: string;
   symbols: string[];
@@ -746,14 +756,40 @@ async function buildRelationshipReport(
   };
 }
 
-export async function buildFunctionReport(
+const LEGACY_REPORT_CAPABILITY_IDS = new Set([
+  "chart-composer",
+  "financial-statements",
+  "fundamental-series",
+  "historical-prices",
+  "intraday-price-chart",
+  "price-chart",
+  "price-comparison",
+  "quote-comparison",
+  "relative-valuation",
+  "return-correlation",
+  "security-relationship",
+  "valuation-series",
+]);
+
+export function resolvePaneFunctionReportSource(
+  resolved: Pick<ResolvedPaneFunction, "headless" | "capability" | "pane" | "template" | "instance">,
+): PaneFunctionReportSource | null {
+  if (resolved.headless) return "headless";
+  if (
+    isFinancialAnalysisFunction(resolved as ResolvedPaneFunction)
+    || LEGACY_REPORT_CAPABILITY_IDS.has(resolved.capability.id)
+  ) {
+    return "report";
+  }
+  if (resolved.capability.reportReadiness === "live-dom") return "dom";
+  return null;
+}
+
+async function buildLegacyFunctionReport(
   resolved: ResolvedPaneFunction,
   context: MarketContext,
   rawArg: string,
 ): Promise<PaneFunctionReport> {
-  if (resolved.headless) {
-    return buildHeadlessFunctionReport(resolved, context, rawArg);
-  }
   if (isFinancialAnalysisFunction(resolved)) {
     return buildFinancialStatementReport(resolved, context, rawArg);
   }
@@ -785,12 +821,37 @@ export async function buildFunctionReport(
       return buildCorrelationReport(resolved, context);
     case "security-relationship":
       return buildRelationshipReport(resolved, context);
+    default:
+      throw new Error(`No structured report builder is registered for ${resolved.token}.`);
+  }
+}
+
+export async function buildFunctionReport(
+  resolved: ResolvedPaneFunction,
+  context: MarketContext,
+  rawArg: string,
+): Promise<PaneFunctionReport> {
+  const startedAt = performance.now();
+  const source = resolvePaneFunctionReportSource(resolved);
+  if (!source) {
+    throw new Error(`${resolved.token} is an interactive pane and does not expose a data report.`);
   }
 
-  if (resolved.capability.reportReadiness === "unsupported") {
-    return buildLegacyPaneReport(resolved, context, rawArg);
+  const report = source === "headless"
+    ? await buildHeadlessFunctionReport(resolved, context, rawArg)
+    : source === "report"
+      ? await buildLegacyFunctionReport(resolved, context, rawArg)
+      : await buildDomFunctionReport(resolved, context, rawArg);
+  const elapsedMs = Math.max(0, Math.round(performance.now() - startedAt));
+  report.data = { ...report.data, source, elapsedMs };
+  if (source === "dom") {
+    report.text = appendDomReportFooter(
+      report.text,
+      elapsedMs,
+      report.data.truncated === true,
+    );
   }
-  throw new Error(`No structured report builder is registered for ${resolved.token}.`);
+  return report;
 }
 
 async function buildLegacyPaneReport(

--- a/src/cli/pane-functions/screenshot.ts
+++ b/src/cli/pane-functions/screenshot.ts
@@ -602,6 +602,7 @@ export async function renderDesktopShot({
   scale,
   watermark,
   options,
+  captureImage = true,
 }: {
   resolved: ResolvedPaneFunction;
   context: MarketContext;
@@ -613,8 +614,9 @@ export async function renderDesktopShot({
   scale?: number;
   watermark?: string | null;
   options: Record<string, string | true>;
+  captureImage?: boolean;
 }): Promise<PaneScreenshotResult> {
-  await mkdir(dirname(outputPath), { recursive: true });
+  if (captureImage) await mkdir(dirname(outputPath), { recursive: true });
   const apiProxy = resolveDesktopShotApiProxy(context);
   const previousSessionToken = apiClient.getSessionToken();
   let payload: DesktopPaneShotPayload;
@@ -632,7 +634,7 @@ export async function renderDesktopShot({
       scale ?? 1,
       watermark ?? null,
     );
-    render = await renderDesktopPaneScreenshot(payload, outputPath, apiProxy);
+    render = await renderDesktopPaneScreenshot(payload, outputPath, apiProxy, { captureImage });
   } finally {
     apiClient.setSessionToken(previousSessionToken);
   }


### PR DESCRIPTION
## Why

Only 14 of 83 catalog entries answered `gloomberb fn`. The other 69 returned a pane description or refused the request even when `gloomberb shot` could render live data for that pane.

## What

- Selects report sources in this order: native `headless`, legacy structured `report`, then rendered `dom`.
- Reuses the existing desktop shot harness for DOM reports. Data-only renders skip `Page.captureScreenshot` and PNG encoding.
- Adds `source` and `elapsedMs` to every successful JSON report.
- Adds `truncated`, `truncationReasons`, and a one-line `limitation` to DOM results.
- Detects clipped cells, horizontal overflow, and vertical scroll regions in the rendered view.
- Marks 55 data panes as `reportReadiness: "live-dom"`. The 14 interactive, non-data panes remain `unsupported`.
- Keeps `--require-bot-safe` unchanged. DOM fallback reports remain unverified and are not bot-safe.

## Verify

- Before: 14 ready, 69 unsupported.
- After: 14 ready, 55 live-dom, 14 unsupported.
- Full catalog run: 45 entries returned rows, 24 returned a clear rendered reason, and 14 non-data panes were rejected as expected.
- Sources: 2 headless, 12 report, 55 DOM.
- The run returned 990 rows. Median DOM render time was 1,708 ms.
- Native checks stayed on their existing path: VAL headless (17 rows), ECST headless (41), FA report (27), CMP report (2).
- `bun test src/cli/pane-functions`: 46 pass.
- `bun run typecheck`: pass.
- A normal `shot WEI` still produced a PNG after adding data-only mode.

The coverage script queried every entry from `gloomberb catalog --json --all`. It used AVGO for ticker panes, AVGO and NVDA for ticker lists, SPY for intraday, and representative text for text panes.

### Coverage

| Token | Readiness | Source | Result | Rows | Elapsed ms | Reason |
|---|---|---:|---:|---:|---:|---|
| 13F | live-dom | dom | ok | 6 | 1738 |  |
| ACM | unsupported | - | failed | 0 | 0 | ACM is an interactive pane and does not expose a data report. |
| AGENT | unsupported | - | failed | 0 | 0 | AGENT is an interactive pane and does not expose a data report. |
| AI | live-dom | dom | ok | 1 | 1364 |  |
| ALRT | live-dom | dom | ok | 3 | 1377 |  |
| ANR | live-dom | dom | reason | 0 | 1388 | The rendered pane reported: requires signup and email verification |
| AUCT | live-dom | dom | reason | 0 | 2037 | The rendered pane reported: Treasury Auctions All Bills Notes Bonds Treasury auctions unavailable. |
| BI | live-dom | dom | ok | 11 | 1454 |  |
| BR | unsupported | - | failed | 0 | 0 | BR is an interactive pane and does not expose a data report. |
| CALLS | live-dom | dom | reason | 0 | 1638 | The rendered pane reported: Sign in to |
| CAT | unsupported | - | failed | 0 | 0 | CAT is an interactive pane and does not expose a data report. |
| CDS | live-dom | dom | ok | 37 | 2141 |  |
| CG | live-dom | dom | reason | 0 | 1802 | The rendered pane reported: Congress Trades Members House PTR filings unavailable. |
| CHAT | unsupported | - | failed | 0 | 0 | CHAT is an interactive pane and does not expose a data report. |
| CHG | unsupported | - | failed | 0 | 0 | CHG is an interactive pane and does not expose a data report. |
| CMP | ready | report | ok | 2 | 12 |  |
| CN | live-dom | dom | reason | 0 | 1780 | The rendered pane reported an empty state. |
| CONN | unsupported | - | failed | 0 | 0 | CONN is an interactive pane and does not expose a data report. |
| CORR | ready | report | ok | 1 | 12 |  |
| CRD | live-dom | dom | ok | 6 | 1977 |  |
| debug | unsupported | - | failed | 0 | 0 | debug is an interactive pane and does not expose a data report. |
| DIAG | live-dom | dom | reason | 0 | 1667 | The rendered pane reported: Sign in to |
| DVD | live-dom | dom | ok | 1 | 1854 |  |
| earnings-monitor-pane | live-dom | dom | ok | 1 | 1424 |  |
| ECO | live-dom | dom | ok | 37 | 1829 |  |
| ECST | ready | headless | ok | 41 | 392 |  |
| ECT | live-dom | dom | reason | 0 | 1805 | The rendered pane reported: Sign in to |
| EE | live-dom | dom | ok | 1 | 1864 |  |
| ERN | live-dom | dom | ok | 1 | 1607 |  |
| EVT | live-dom | dom | ok | 1 | 1828 |  |
| FA | ready | report | ok | 27 | 171 |  |
| FIRST | live-dom | dom | reason | 0 | 1595 | The rendered pane reported an empty state. |
| FLOW | live-dom | dom | reason | 0 | 1799 | The rendered pane reported: Sign in to |
| FNG | live-dom | dom | ok | 1 | 1489 |  |
| FUT | live-dom | dom | ok | 37 | 1671 |  |
| FXC | live-dom | dom | ok | 8 | 1628 |  |
| G | ready | report | ok | 257 | 16 |  |
| GC | live-dom | dom | ok | 1 | 1655 |  |
| GE | ready | report | ok | 10 | 210 |  |
| GF | ready | report | ok | 8 | 263 |  |
| GIP | ready | report | ok | 79 | 342 |  |
| GP | ready | report | ok | 61 | 6 |  |
| GR | ready | report | ok | 11 | 7 |  |
| HALT | live-dom | dom | reason | 0 | 1943 | The rendered pane reported: Market Halts All Active Resumed Trading halts unavailable. |
| HDS | live-dom | dom | reason | 0 | 1670 | The rendered pane reported: requires signup and email verification |
| help | unsupported | - | failed | 0 | 0 | help is an interactive pane and does not expose a data report. |
| HILO | live-dom | dom | ok | 1 | 2080 |  |
| HM | live-dom | dom | ok | 1 | 2023 |  |
| HN | live-dom | dom | reason | 0 | 1504 | The rendered view could not be read: Pane hackernews is not registered in the desktop renderer. |
| HP | ready | report | ok | 206 | 5 |  |
| IBKR | unsupported | - | failed | 0 | 0 | IBKR is an interactive pane and does not expose a data report. |
| INS | live-dom | dom | reason | 0 | 1830 | The rendered pane reported: INS AVGO Insider filings unavailable. |
| IPO | live-dom | dom | reason | 0 | 2006 | The rendered pane reported: IPO Calendar / IPO calendar unavailable. |
| KELLY | live-dom | dom | ok | 1 | 1852 |  |
| layout-marketplace | unsupported | - | failed | 0 | 0 | layout-marketplace is an interactive pane and does not expose a data report. |
| MAP | unsupported | - | failed | 0 | 0 | MAP is an interactive pane and does not expose a data report. |
| MOST | live-dom | dom | ok | 1 | 2001 |  |
| N | live-dom | dom | reason | 0 | 1631 | The rendered pane reported an empty state. |
| new-portfolio-pane | live-dom | dom | ok | 1 | 1727 |  |
| new-watchlist-pane | live-dom | dom | ok | 1 | 1607 |  |
| NI | live-dom | dom | reason | 0 | 1708 | The rendered pane reported an empty state. |
| NOTE | live-dom | dom | ok | 1 | 1615 |  |
| OMON | live-dom | dom | ok | 35 | 1988 |  |
| OVME | live-dom | dom | ok | 1 | 1700 |  |
| PF | live-dom | dom | ok | 1 | 1700 |  |
| PL | unsupported | - | failed | 0 | 0 | PL is an interactive pane and does not expose a data report. |
| PM | live-dom | dom | ok | 6 | 2653 |  |
| POLL | live-dom | dom | reason | 0 | 4893 | The rendered pane reported: Polls Approval Favorability Generic Senate Governor House Polls unavailable. |
| PORT | live-dom | dom | ok | 1 | 1583 |  |
| QQ | ready | report | ok | 2 | 243 |  |
| RV | ready | report | ok | 2 | 8 |  |
| SEC | live-dom | dom | reason | 0 | 1609 | The rendered pane reported: SEC AVGO SEC filings unavailable. |
| SI | live-dom | dom | reason | 0 | 1900 | The rendered pane reported: SI AVGO Short interest unavailable. |
| SRCH | live-dom | dom | reason | 0 | 1594 | The rendered pane reported: Sign in to |
| SUB | live-dom | dom | reason | 0 | 1169 | The rendered view could not be read: Pane substack is not registered in the desktop renderer. |
| T | live-dom | dom | reason | 0 | 1615 | The rendered pane reported an empty state. |
| TBO | live-dom | dom | ok | 37 | 2087 |  |
| TOP | live-dom | dom | reason | 0 | 1436 | The rendered pane reported an empty state. |
| TV | unsupported | - | failed | 0 | 0 | TV is an interactive pane and does not expose a data report. |
| twitter-feed-pane | live-dom | dom | reason | 0 | 1531 | The rendered pane reported an empty state. |
| VAL | ready | headless | ok | 17 | 1405 |  |
| VIX | live-dom | dom | ok | 2 | 1746 |  |
| WEI | live-dom | dom | ok | 23 | 1722 |  |

### Expected unsupported panes

ACM, AGENT, BR, CAT, CHAT, CHG, CONN, debug, help, IBKR, layout-marketplace, MAP, PL, and TV are interactive surfaces rather than data panes.

### Clear runtime reasons

Several live DOM panes reported current auth, upstream API, or empty-state reasons. HN and SUB are installed external plugins and are not registered in the desktop shot bundle, so they return that precise limitation instead of failing the whole `fn` command.
