### PR TITLE
Add headless reports for macro and market panes

### DIFF
--- a/src/plugins/builtin/cds/client.test.ts
+++ b/src/plugins/builtin/cds/client.test.ts
@@ -41,6 +41,26 @@ describe("loadCdsActivity", () => {
     expect(activity.issuer).toBe("Oracle Corporation");
   });
 
+  test("prefers the primary US common stock when exchanges reuse a ticker", async () => {
+    const cedear = {
+      ...result("ORCL", "Oracle Corp. - CEDEAR"),
+      exchange: "BYMA",
+      primaryExchange: "BYMA",
+      type: "Depositary Receipt",
+      currency: "ARS",
+    };
+    const primary = {
+      ...result("ORCL", "Oracle Corporation"),
+      currency: "USD",
+      primaryExchange: "NYSE",
+    };
+    const calls = spy([cedear, primary]);
+
+    await loadCdsActivity("ORCL", calls.fetchCds, calls.searchInstruments);
+
+    expect(calls.requested).toEqual(["Oracle Corporation"]);
+  });
+
   test("falls back to the first result when no symbol matches exactly", async () => {
     const calls = spy([result("AVGO", "Broadcom Inc."), result("AVGOP", "Broadcom Preferred")]);
 

--- a/src/plugins/builtin/cds/client.ts
+++ b/src/plugins/builtin/cds/client.ts
@@ -16,14 +16,23 @@ export interface CdsActivity {
 
 export type CdsActivityLoader = (issuer: string | null) => Promise<CdsActivity>;
 
-type CdsFetch = (params: { issuer?: string; days?: number; limit?: number }) => Promise<CloudCdsResponse>;
-type InstrumentSearch = (query: string, limit?: number) => Promise<InstrumentSearchResult[]>;
+export type CdsFetch = (params: { issuer?: string; days?: number; limit?: number }) => Promise<CloudCdsResponse>;
+export type InstrumentSearch = (query: string, limit?: number) => Promise<InstrumentSearchResult[]>;
 
 /**
  * A bare ticker with normal symbol punctuation and no spaces. Anything longer or
  * containing a space is already a company name and is sent to the backend as-is.
  */
 const TICKER_LIKE = /^[A-Za-z0-9][A-Za-z0-9.^:-]{0,11}$/;
+const US_PRIMARY_EXCHANGES = new Set(["AMEX", "NASDAQ", "NYSE", "NYSEAMERICAN", "NYSEARCA"]);
+
+function isPrimaryUsCommonStock(result: InstrumentSearchResult): boolean {
+  const exchange = (result.primaryExchange || result.exchange).toUpperCase().replace(/[^A-Z]/g, "");
+  const type = result.type.toLowerCase();
+  return result.currency === "USD"
+    && US_PRIMARY_EXCHANGES.has(exchange)
+    && (type === "stk" || type === "equity" || type.includes("common stock"));
+}
 
 /**
  * The backend matches DTCC issuer names, so a ticker has to become a company
@@ -40,7 +49,8 @@ export async function resolveIssuerName(
   try {
     const results = await searchInstruments(issuer);
     const symbol = issuer.toUpperCase();
-    const match = results.find((result) => result.symbol.toUpperCase() === symbol) ?? results[0];
+    const exactMatches = results.filter((result) => result.symbol.toUpperCase() === symbol);
+    const match = exactMatches.find(isPrimaryUsCommonStock) ?? exactMatches[0] ?? results[0];
     return match?.name?.trim() || issuer;
   } catch {
     return issuer;

--- a/src/plugins/builtin/cds/headless.test.ts
+++ b/src/plugins/builtin/cds/headless.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createCdsHeadless } from "./headless";
+import type { CdsActivity } from "./client";
+
+const activity: CdsActivity = {
+  source: "DTCC",
+  asOf: "2026-09-04T12:00:00Z",
+  issuer: "Oracle Corporation",
+  trades: [{
+    id: "1", issuer: "Oracle Corporation", issuerKey: "oracle", eventAt: 100,
+    maturity: "2031-06-20", notional: 5_000_000, notionalCapped: false,
+    currency: "USD", couponBp: 100, spreadBp: 45, upfront: null, upfrontCurrency: null,
+  }],
+};
+
+function args(argument: string | null): HeadlessPaneLoadArgs {
+  return { rawArgument: argument ?? "", argument, symbols: argument ? [argument] : [], options: {} };
+}
+
+describe("CDS headless model", () => {
+  test("switches from issuer summaries to trade rows for a ticker argument", async () => {
+    const headless = createCdsHeadless({ load: async () => activity });
+    const market = await headless.load(args(null), {} as HeadlessPaneContext);
+    const ticker = await headless.load(args("ORCL"), {} as HeadlessPaneContext);
+
+    expect(market.rows).toEqual([expect.objectContaining({ issuer: "Oracle Corporation", trades: 1 })]);
+    expect(ticker.rows).toEqual([expect.objectContaining({ id: "1", spreadBp: 45 })]);
+  });
+});

--- a/src/plugins/builtin/cds/headless.ts
+++ b/src/plugins/builtin/cds/headless.ts
@@ -1,0 +1,113 @@
+import type {
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+  HeadlessRowsResult,
+} from "../../../types/plugin";
+import {
+  loadCdsActivity,
+  type CdsActivity,
+  type CdsFetch,
+  type InstrumentSearch,
+} from "./client";
+import {
+  DEFAULT_ISSUER_SORT,
+  DEFAULT_TRADE_SORT,
+  formatBp,
+  formatEventTime,
+  formatNotional,
+  formatUpfront,
+  sortIssuers,
+  sortTrades,
+  summarizeIssuers,
+  type CdsTrade,
+} from "./model";
+
+const ISSUER_COLUMNS = [
+  { key: "issuer", header: "Issuer" },
+  { key: "trades", header: "Trades", align: "right" as const },
+  { key: "lastTradeAt", header: "Last UTC", format: (value: unknown) => formatEventTime(Number(value)) },
+  { key: "latestSpreadBp", header: "Spread", align: "right" as const, format: (value: unknown) => formatBp(value as number | null) },
+];
+
+function tradeForFormatting(row: Record<string, unknown>): CdsTrade {
+  return row as unknown as CdsTrade;
+}
+
+const TRADE_COLUMNS = [
+  { key: "eventAt", header: "Time UTC", format: (value: unknown) => formatEventTime(Number(value)) },
+  { key: "issuer", header: "Issuer" },
+  { key: "maturity", header: "Maturity" },
+  {
+    key: "notional",
+    header: "Notional",
+    align: "right" as const,
+    format: (_value: unknown, row: Record<string, unknown>) => formatNotional(tradeForFormatting(row)),
+  },
+  { key: "currency", header: "CCY" },
+  { key: "couponBp", header: "Coupon", align: "right" as const, format: (value: unknown) => formatBp(value as number | null) },
+  { key: "spreadBp", header: "Spread", align: "right" as const, format: (value: unknown) => formatBp(value as number | null) },
+  {
+    key: "upfront",
+    header: "Upfront",
+    align: "right" as const,
+    format: (_value: unknown, row: Record<string, unknown>) => formatUpfront(tradeForFormatting(row)),
+  },
+];
+
+export function projectCdsHeadless(activity: CdsActivity, issuer: string | null): HeadlessRowsResult {
+  if (issuer) {
+    return {
+      columns: TRADE_COLUMNS,
+      rows: sortTrades(activity.trades, DEFAULT_TRADE_SORT).map((trade) => ({ ...trade })),
+      metadata: { source: activity.source, asOf: activity.asOf, issuer: activity.issuer },
+    };
+  }
+  return {
+    columns: ISSUER_COLUMNS,
+    rows: sortIssuers(summarizeIssuers(activity.trades), DEFAULT_ISSUER_SORT).map((issuerRow) => ({ ...issuerRow })),
+    metadata: { source: activity.source, asOf: activity.asOf, issuer: null },
+  };
+}
+
+export interface CdsHeadlessDependencies {
+  load(
+    args: HeadlessPaneLoadArgs,
+    issuer: string | null,
+    fetchCds: CdsFetch,
+    searchInstruments: InstrumentSearch,
+  ): Promise<CdsActivity>;
+}
+
+const defaultDependencies: CdsHeadlessDependencies = {
+  load: (_args, issuer, fetchCds, searchInstruments) => (
+    loadCdsActivity(issuer, fetchCds, searchInstruments)
+  ),
+};
+
+export function createCdsHeadless(
+  dependencies: CdsHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "free-text",
+      placeholder: "ticker or issuer",
+      description: "Optional ticker or issuer. Omit for the most-active issuer view.",
+      optional: true,
+    },
+    options: [],
+    describe: (args) => typeof args.argument === "string" ? `CDS | ${args.argument}` : "Single-Name CDS",
+    async load(args, ctx) {
+      const issuer = typeof args.argument === "string" ? args.argument : null;
+      const activity = await dependencies.load(
+        args,
+        issuer,
+        (params) => ctx.apiClient.getCloudCds(params),
+        (query, limit) => ctx.apiClient.searchInstruments(query, limit),
+      );
+      return projectCdsHeadless(activity, issuer);
+    },
+  };
+}
+
+export const cdsHeadless = createCdsHeadless();

--- a/src/plugins/builtin/cds/index.tsx
+++ b/src/plugins/builtin/cds/index.tsx
@@ -2,6 +2,9 @@ import type { PaneTemplateCreateOptions } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import { CDS_PANE_ID } from "./model";
 import { CdsPane } from "./pane";
+import { cdsHeadless } from "./headless";
+
+export { cdsHeadless } from "./headless";
 
 /** Only an explicit argument binds a ticker; bare `CDS` stays market-wide. */
 function explicitSymbol(options?: PaneTemplateCreateOptions): string | null {
@@ -26,6 +29,7 @@ export const cdsModule: PluginModule = {
     description: "Single-name corporate CDS trade activity from DTCC public dissemination.",
     keywords: ["cds", "credit", "default", "swap", "single name", "issuer", "dtcc", "protection"],
     shortcut: { prefix: "CDS", argPlaceholder: "ticker", argKind: "ticker", argOptional: true },
+    headless: cdsHeadless,
     createInstance: (_context, options) => {
       const symbol = explicitSymbol(options);
       return symbol

--- a/src/plugins/builtin/credit-conditions/client.ts
+++ b/src/plugins/builtin/credit-conditions/client.ts
@@ -19,7 +19,7 @@ export interface CreditConditionsLoadResult {
 
 const HISTORY_LIMIT = 45;
 
-type CreditSeriesLoader = (
+export type CreditSeriesLoader = (
   seriesId: CreditSeriesId,
   options: { limit: number; sortOrder: "desc" },
 ) => Promise<CloudFredSeriesPayload>;

--- a/src/plugins/builtin/credit-conditions/headless.test.ts
+++ b/src/plugins/builtin/credit-conditions/headless.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createCreditConditionsHeadless } from "./headless";
+
+const args: HeadlessPaneLoadArgs = { rawArgument: "", argument: null, symbols: [], options: {} };
+
+describe("credit conditions headless model", () => {
+  test("returns normalized spread rows and partial errors", async () => {
+    const headless = createCreditConditionsHeadless({
+      load: async () => ({
+        rows: [{
+          seriesId: "BAMLC0A0CM",
+          label: "US IG",
+          title: "US Corporate Option-Adjusted Spread",
+          units: "Percent",
+          frequency: "Daily",
+          oasBp: 82.4,
+          dailyChangeBp: 1.2,
+          date: "2026-09-03",
+          stale: false,
+        }],
+        stale: false,
+        errors: ["one series unavailable"],
+      }),
+    });
+    const result = await headless.load(args, {} as HeadlessPaneContext);
+
+    expect(result.rows).toEqual([expect.objectContaining({ label: "US IG", oasBp: 82.4 })]);
+    expect(result.errors).toEqual(["one series unavailable"]);
+  });
+});

--- a/src/plugins/builtin/credit-conditions/headless.ts
+++ b/src/plugins/builtin/credit-conditions/headless.ts
@@ -1,0 +1,55 @@
+import type {
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import {
+  loadCreditConditions,
+  type CreditConditionsLoadResult,
+  type CreditSeriesLoader,
+} from "./client";
+
+const COLUMNS = [
+  { key: "label", header: "Index" },
+  { key: "seriesId", header: "FRED series" },
+  { key: "oasBp", header: "OAS", align: "right" as const, format: (value: unknown) => `${Number(value).toFixed(1)}bp` },
+  {
+    key: "dailyChangeBp",
+    header: "1D",
+    align: "right" as const,
+    format: (value: unknown) => value == null ? "-" : `${Number(value) > 0 ? "+" : ""}${Number(value).toFixed(1)}bp`,
+  },
+  { key: "date", header: "As of" },
+];
+
+export interface CreditConditionsHeadlessDependencies {
+  load(args: HeadlessPaneLoadArgs, loader: CreditSeriesLoader): Promise<CreditConditionsLoadResult>;
+}
+
+const defaultDependencies: CreditConditionsHeadlessDependencies = {
+  load: (_args, loader) => loadCreditConditions(false, loader),
+};
+
+export function createCreditConditionsHeadless(
+  dependencies: CreditConditionsHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: { kind: "none" },
+    options: [],
+    columns: COLUMNS,
+    describe: "Credit Spreads",
+    async load(args, ctx) {
+      const result = await dependencies.load(
+        args,
+        (seriesId, options) => ctx.apiClient.getCloudFredSeries(seriesId, options),
+      );
+      return {
+        rows: result.rows.map((row) => ({ ...row })),
+        errors: result.errors,
+        metadata: { stale: result.stale },
+      };
+    },
+  };
+}
+
+export const creditConditionsHeadless = createCreditConditionsHeadless();

--- a/src/plugins/builtin/credit-conditions/index.tsx
+++ b/src/plugins/builtin/credit-conditions/index.tsx
@@ -16,11 +16,14 @@ import type { PaneProps } from "../../../types/plugin";
 import { colors } from "../../../theme/colors";
 import type { PluginModule } from "../plugin-module";
 import { getCachedCreditConditions, loadCreditConditions } from "./client";
+import { creditConditionsHeadless } from "./headless";
 import {
   CREDIT_SERIES,
   type CreditConditionRow,
   type CreditSeriesId,
 } from "./model";
+
+export { creditConditionsHeadless } from "./headless";
 
 type SortId = "label" | "oas" | "change";
 interface Column extends DataTableColumn { id: SortId }
@@ -204,5 +207,6 @@ export const creditConditionsModule: PluginModule = {
     description: "ICE BofA US corporate option-adjusted spreads from FRED.",
     keywords: ["credit", "spread", "oas", "corporate", "high yield", "investment grade", "macro"],
     shortcut: { prefix: "CRD" },
+    headless: creditConditionsHeadless,
   }],
 };

--- a/src/plugins/builtin/fear-greed/headless.test.ts
+++ b/src/plugins/builtin/fear-greed/headless.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createFearGreedHeadless } from "./headless";
+import type { FearGreedData } from "./data";
+
+const args: HeadlessPaneLoadArgs = { rawArgument: "", argument: null, symbols: [], options: {} };
+
+const data: FearGreedData = {
+  overall: {
+    score: 63,
+    rating: "greed",
+    updatedAt: new Date("2026-09-04T12:00:00Z"),
+    previousClose: 58,
+    previousWeek: 41,
+    previousMonth: 35,
+    previousYear: 52,
+    history: [],
+  },
+  indicators: [{
+    definition: {
+      id: "market-volatility",
+      title: "Market Volatility",
+      subtitle: "VIX and its 50-day moving average",
+      primaryKey: "market_volatility_vix",
+      primaryLabel: "VIX",
+      secondaryKey: "market_volatility_vix_50",
+      secondaryLabel: "50-day moving average",
+      valueFormat: "number",
+    },
+    score: 72,
+    rating: "greed",
+    updatedAt: new Date("2026-09-04T12:00:00Z"),
+    points: [],
+    secondaryPoints: [],
+    latestValue: 14.25,
+    latestSecondaryValue: 17.5,
+  }],
+};
+
+describe("fear and greed headless model", () => {
+  test("maps the loaded index and indicators into shared sections", async () => {
+    const headless = createFearGreedHeadless({
+      load: async () => ({ data, fetchedAt: 123, stale: false }),
+    });
+    const result = await headless.load(args, {} as HeadlessPaneContext);
+
+    expect(result.sections[0]?.title).toBe("Fear & Greed Index");
+    expect(result.sections[0]?.entries?.[0]).toMatchObject({ label: "Score", value: 63 });
+    expect(result.sections[1]?.rows?.[0]).toMatchObject({
+      id: "market-volatility", latestValue: 14.25, secondaryValue: 17.5,
+    });
+  });
+});

--- a/src/plugins/builtin/fear-greed/headless.ts
+++ b/src/plugins/builtin/fear-greed/headless.ts
@@ -1,0 +1,84 @@
+import type {
+  HeadlessBundleResult,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import { loadFearGreed, type FearGreedLoadResult } from "./cache";
+import { fetchFearGreedData, type FearGreedData } from "./data";
+import { formatIndicatorValue, formatScore, ratingLabel } from "./format";
+
+export function projectFearGreedHeadless(data: FearGreedData): HeadlessBundleResult {
+  return {
+    sections: [
+      {
+        title: "Fear & Greed Index",
+        entries: [
+          { label: "Score", value: data.overall.score, formatted: formatScore(data.overall.score) },
+          { label: "Rating", value: data.overall.rating, formatted: ratingLabel(data.overall.rating) },
+          { label: "Previous close", value: data.overall.previousClose, formatted: formatScore(data.overall.previousClose) },
+          { label: "1 week ago", value: data.overall.previousWeek, formatted: formatScore(data.overall.previousWeek) },
+          { label: "1 month ago", value: data.overall.previousMonth, formatted: formatScore(data.overall.previousMonth) },
+          { label: "1 year ago", value: data.overall.previousYear, formatted: formatScore(data.overall.previousYear) },
+          { label: "Updated at", value: data.overall.updatedAt?.toISOString() ?? null },
+        ],
+      },
+      {
+        title: "Indicators",
+        columns: [
+          { key: "indicator", header: "Indicator" },
+          { key: "score", header: "Score", align: "right", format: (value) => formatScore(value as number | null) },
+          { key: "rating", header: "Rating" },
+          { key: "latest", header: "Latest", align: "right" },
+          { key: "secondary", header: "Comparison", align: "right" },
+          { key: "updatedAt", header: "Updated at" },
+        ],
+        rows: data.indicators.map((indicator) => ({
+          id: indicator.definition.id,
+          indicator: indicator.definition.title,
+          description: indicator.definition.subtitle,
+          score: indicator.score,
+          rating: indicator.rating,
+          latestValue: indicator.latestValue,
+          latest: formatIndicatorValue(indicator.latestValue, indicator.definition.valueFormat),
+          secondaryValue: indicator.latestSecondaryValue,
+          secondary: indicator.definition.secondaryLabel && indicator.latestSecondaryValue != null
+            ? `${indicator.definition.secondaryLabel}: ${formatIndicatorValue(indicator.latestSecondaryValue, indicator.definition.valueFormat)}`
+            : "-",
+          updatedAt: indicator.updatedAt?.toISOString() ?? null,
+        })),
+      },
+    ],
+  };
+}
+
+export interface FearGreedHeadlessDependencies {
+  load(args: HeadlessPaneLoadArgs, signal: AbortSignal): Promise<FearGreedLoadResult>;
+}
+
+const defaultDependencies: FearGreedHeadlessDependencies = {
+  load: (_args, signal) => loadFearGreed(false, () => fetchFearGreedData({
+    fetcher: ((input, init) => fetch(input, { ...init, signal })) as typeof fetch,
+  })),
+};
+
+export function createFearGreedHeadless(
+  dependencies: FearGreedHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"bundle"> {
+  return {
+    shape: "bundle",
+    argument: { kind: "none" },
+    options: [],
+    describe: "Fear & Greed",
+    async load(args, ctx) {
+      const result = await dependencies.load(args, ctx.signal);
+      const projected = projectFearGreedHeadless(result.data);
+      return {
+        ...projected,
+        ...(result.refreshError ? { errors: [result.refreshError] } : {}),
+        metadata: { fetchedAt: result.fetchedAt, stale: result.stale },
+      };
+    },
+  };
+}
+
+export const fearGreedHeadless = createFearGreedHeadless();

--- a/src/plugins/builtin/fear-greed/index.tsx
+++ b/src/plugins/builtin/fear-greed/index.tsx
@@ -4,6 +4,9 @@ import {
   resetFearGreedPersistence,
 } from "./cache";
 import { FearGreedPane } from "./pane";
+import { fearGreedHeadless } from "./headless";
+
+export { fearGreedHeadless } from "./headless";
 
 export const fearGreedModule: PluginModule = {
   setup(ctx) {
@@ -34,6 +37,7 @@ export const fearGreedModule: PluginModule = {
       description: "CNN Fear & Greed sentiment gauge with the seven indicator charts.",
       keywords: ["fear", "greed", "sentiment", "cnn", "market", "indicators", "gauge"],
       shortcut: { prefix: "FNG" },
+      headless: fearGreedHeadless,
     },
   ],
 };

--- a/src/plugins/builtin/market-movers/client.ts
+++ b/src/plugins/builtin/market-movers/client.ts
@@ -1,0 +1,76 @@
+import type { DataProvider } from "../../../types/data-provider";
+import { CATEGORY_MAP, screenerQuoteFromQuote, type TabId } from "./model";
+import {
+  fetchPreferredMarketMovers,
+  fetchTrending,
+  type MarketMoversResult,
+  type ScreenerQuote,
+  type TrendingSymbol,
+} from "./screener";
+
+export interface MarketMoverTabResult extends MarketMoversResult {
+  tab: TabId;
+}
+
+export interface MarketMoverTabDependencies {
+  fetchPreferred(
+    category: "day_gainers" | "day_losers" | "most_actives",
+    count: number,
+    options?: { forceRefresh?: boolean },
+  ): Promise<MarketMoversResult>;
+  fetchTrending(count: number, options?: { forceRefresh?: boolean }): Promise<TrendingSymbol[]>;
+}
+
+const defaultDependencies: MarketMoverTabDependencies = {
+  fetchPreferred: (category, count, options) => fetchPreferredMarketMovers(category, count, options),
+  fetchTrending: (count, options) => fetchTrending(count, undefined, options),
+};
+
+async function hydrateTrending(
+  trending: readonly TrendingSymbol[],
+  provider: DataProvider | null,
+): Promise<ScreenerQuote[]> {
+  const symbols = trending.slice(0, 25).map(({ symbol }) => symbol);
+  const bySymbol = new Map<string, ScreenerQuote>();
+  if (!provider) return [];
+  if (provider.getQuotesBatch) {
+    const results = await provider.getQuotesBatch(
+      symbols.map((symbol) => ({ symbol, exchange: "" })),
+    ).catch(() => []);
+    for (const result of results) {
+      if (result.quote) bySymbol.set(result.target.symbol, screenerQuoteFromQuote(result.target.symbol, result.quote));
+    }
+  } else {
+    await Promise.all(symbols.map(async (symbol) => {
+      try {
+        const quote = await provider.getQuote(symbol, "");
+        bySymbol.set(symbol, screenerQuoteFromQuote(symbol, quote));
+      } catch {
+        // Missing quotes are omitted from a ranked list.
+      }
+    }));
+  }
+  return symbols.flatMap((symbol) => {
+    const quote = bySymbol.get(symbol);
+    return quote ? [quote] : [];
+  });
+}
+
+export async function loadMarketMoverTab(
+  tab: TabId,
+  provider: DataProvider | null,
+  options?: { forceRefresh?: boolean },
+  dependencies: MarketMoverTabDependencies = defaultDependencies,
+): Promise<MarketMoverTabResult> {
+  if (tab === "trending") {
+    const trending = await dependencies.fetchTrending(25, options);
+    return {
+      tab,
+      quotes: await hydrateTrending(trending, provider),
+      source: "yahoo",
+      stale: false,
+    };
+  }
+  const result = await dependencies.fetchPreferred(CATEGORY_MAP[tab], 25, options);
+  return { ...result, tab };
+}

--- a/src/plugins/builtin/market-movers/headless.test.ts
+++ b/src/plugins/builtin/market-movers/headless.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createMarketMoversHeadless } from "./headless";
+
+function args(list: string): HeadlessPaneLoadArgs {
+  return { rawArgument: "", argument: null, symbols: [], options: { list } };
+}
+
+describe("market movers headless model", () => {
+  test("loads the selected list and computes each quote's 52-week position", async () => {
+    const loaded: string[] = [];
+    const headless = createMarketMoversHeadless({
+      load: async (_args, tab) => {
+        loaded.push(tab);
+        return {
+          tab,
+          source: "cloud",
+          stale: false,
+          quotes: [{
+            symbol: "NVDA", name: "NVIDIA", price: 150, change: 5, changePercent: 3.4,
+            volume: 100, avgVolume: 50, volumeRatio: 2, marketCap: 1_000,
+            currency: "USD", fiftyTwoWeekHigh: 200, fiftyTwoWeekLow: 100,
+            dayHigh: 151, dayLow: 142, exchange: "NASDAQ",
+          }],
+        };
+      },
+    });
+
+    const gainers = await headless.load(args("gainers"), {} as HeadlessPaneContext);
+    await headless.load(args("actives"), {} as HeadlessPaneContext);
+    expect(loaded).toEqual(["gainers", "actives"]);
+    expect(gainers.rows).toEqual([expect.objectContaining({ rank: 1, rangePositionPercent: 50 })]);
+  });
+});

--- a/src/plugins/builtin/market-movers/headless.ts
+++ b/src/plugins/builtin/market-movers/headless.ts
@@ -1,0 +1,73 @@
+import type { DataProvider } from "../../../types/data-provider";
+import type {
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import { formatCompact, formatCurrency, formatNumber, formatPercentRaw } from "../../../utils/format";
+import { loadMarketMoverTab, type MarketMoverTabResult } from "./client";
+import { createRows, fiftyTwoWeekPositionPercent, type TabId } from "./model";
+
+const COLUMNS = [
+  { key: "rank", header: "Rank", align: "right" as const },
+  { key: "symbol", header: "Symbol" },
+  { key: "name", header: "Name" },
+  { key: "price", header: "Last", align: "right" as const, format: (value: unknown, row: Record<string, unknown>) => formatCurrency(Number(value), String(row.currency)) },
+  { key: "changePercent", header: "Change %", align: "right" as const, format: (value: unknown) => formatPercentRaw(Number(value)) },
+  { key: "volume", header: "Volume", align: "right" as const, format: (value: unknown) => formatCompact(Number(value)) },
+  { key: "volumeRatio", header: "Vol / Avg", align: "right" as const, format: (value: unknown) => formatNumber(Number(value), 1) },
+  { key: "rangePositionPercent", header: "52W pos", align: "right" as const, format: (value: unknown) => value == null ? "-" : formatPercentRaw(Number(value)) },
+  { key: "marketCap", header: "Market cap", align: "right" as const, format: (value: unknown) => value == null ? "-" : formatCompact(Number(value)) },
+];
+
+export interface MarketMoversHeadlessDependencies {
+  load(
+    args: HeadlessPaneLoadArgs,
+    tab: TabId,
+    provider: DataProvider,
+  ): Promise<MarketMoverTabResult>;
+}
+
+const defaultDependencies: MarketMoversHeadlessDependencies = {
+  load: (_args, tab, provider) => loadMarketMoverTab(tab, provider),
+};
+
+export function createMarketMoversHeadless(
+  dependencies: MarketMoversHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: { kind: "none" },
+    options: [{
+      key: "list",
+      description: "Market movers list.",
+      type: "enum",
+      values: [
+        { value: "gainers" },
+        { value: "losers" },
+        { value: "actives", aliases: ["active", "most-active"] },
+        { value: "trending" },
+      ],
+      defaultValue: "actives",
+    }],
+    columns: COLUMNS,
+    describe: (args) => `Market Movers | ${String(args.options.list)}`,
+    async load(args, ctx) {
+      const tab = args.options.list as TabId;
+      const result = await dependencies.load(args, tab, ctx.marketData);
+      const rows = createRows(result.quotes).map((row) => ({
+        ...row,
+        rangePositionPercent: fiftyTwoWeekPositionPercent(
+          row.price,
+          row.fiftyTwoWeekLow,
+          row.fiftyTwoWeekHigh,
+        ),
+      }));
+      return {
+        rows,
+        metadata: { list: tab, source: result.source, stale: result.stale },
+      };
+    },
+  };
+}
+
+export const marketMoversHeadless = createMarketMoversHeadless();

--- a/src/plugins/builtin/market-movers/index.tsx
+++ b/src/plugins/builtin/market-movers/index.tsx
@@ -13,15 +13,12 @@ import { useAutoRefresh } from "../shared/auto-refresh";
 import { useQuoteBoard } from "../shared/use-quote-board";
 import {
   attachMarketMoversPersistence,
-  fetchPreferredMarketMovers,
-  fetchTrending,
   MARKET_SUMMARY_SYMBOLS,
   resetMarketMoversPersistence,
   type ScreenerQuote,
   type MarketSummaryQuote,
 } from "./screener";
 import {
-  CATEGORY_MAP,
   DEFAULT_SORT_PREFERENCE,
   INDEX_SHORT,
   TABS,
@@ -29,7 +26,6 @@ import {
   nextSortPreference,
   resolveSummarySymbols,
   resolveTabs,
-  screenerQuoteFromQuote,
   sortRows,
   summaryQuoteFromQuote,
   type MarketMoverColumn,
@@ -37,6 +33,8 @@ import {
   type MarketMoverSortPreference,
   type TabId,
 } from "./model";
+import { loadMarketMoverTab } from "./client";
+import { marketMoversHeadless } from "./headless";
 import { buildMarketMoverColumns, renderMarketMoverCell } from "./table";
 import {
   LIVE_STREAMING_QUICK_SETTING,
@@ -48,6 +46,8 @@ import {
   overlayScreenerQuoteEntries,
   resolveScreenerQuoteFeedStatus,
 } from "../shared/screener-live-quotes";
+
+export { marketMoversHeadless } from "./headless";
 
 /** Stable identity: a fresh literal here would reload the board every render. */
 const NO_SAVED_SELECTION: string[] = [];
@@ -138,54 +138,13 @@ function MarketMoversPane({ focused, width, height }: PaneProps) {
     }
 
     try {
-      let data: ScreenerQuote[];
+      const result = await loadMarketMoverTab(tab, dataProvider, {
+        forceRefresh: options?.forceRefresh,
+      });
+      if (fetchGenRef.current !== gen) return;
 
-      if (tab === "trending") {
-        const trending = await fetchTrending(25, undefined, {
-          forceRefresh: options?.forceRefresh,
-        });
-        if (fetchGenRef.current !== gen) return;
-
-        const resolved: ScreenerQuote[] = [];
-
-        if (dataProvider) {
-          const targets = trending.slice(0, 25).map(({ symbol }) => ({ symbol, exchange: "" }));
-          if (dataProvider.getQuotesBatch) {
-            const batchResults = await dataProvider.getQuotesBatch(targets).catch(() => []);
-            for (const result of batchResults) {
-              if (fetchGenRef.current !== gen) return;
-              if (result.quote) {
-                resolved.push(screenerQuoteFromQuote(result.target.symbol, result.quote));
-              }
-            }
-          } else {
-            await Promise.allSettled(targets.map(async ({ symbol }) => {
-              try {
-                const q = await dataProvider.getQuote(symbol, "");
-                if (fetchGenRef.current !== gen) return;
-                if (q) {
-                  resolved.push(screenerQuoteFromQuote(symbol, q));
-                }
-              } catch { /* skip */ }
-            }));
-          }
-        }
-
-        if (fetchGenRef.current !== gen) return;
-        data = trending
-          .map((t) => resolved.find((r) => r.symbol === t.symbol))
-          .filter((r): r is ScreenerQuote => r !== undefined);
-        setMoversStale(false);
-      } else {
-        const result = await fetchPreferredMarketMovers(CATEGORY_MAP[tab], 25, {
-          forceRefresh: options?.forceRefresh,
-        });
-        if (fetchGenRef.current !== gen) return;
-        data = result.quotes;
-        setMoversStale(result.stale);
-      }
-
-      setQuotes(data);
+      setQuotes(result.quotes);
+      setMoversStale(result.stale);
       if (!options?.background) setSelectedSymbol(null);
       setLoadError(null);
       setLastLoadedAt(Date.now());
@@ -361,6 +320,7 @@ export const marketMoversModule: PluginModule = {
       description: "Top gainers, losers, most active, and trending tickers.",
       keywords: ["movers", "gainers", "losers", "active", "trending", "screener", "top"],
       shortcut: { prefix: "MOST" },
+      headless: marketMoversHeadless,
     },
   ],
 };

--- a/src/plugins/builtin/research/corporate-actions-pane.tsx
+++ b/src/plugins/builtin/research/corporate-actions-pane.tsx
@@ -9,21 +9,17 @@ import {
 } from "../../../components";
 import type { SecFilingDocument, SecFilingItem } from "../../../types/data-provider";
 import type {
-  AnalystEstimateRecord,
   AnalystResearchData,
   CorporateActionsData,
-  FinancialStatement,
-  TickerFinancials,
 } from "../../../types/financials";
 import { blendHex, colors } from "../../../theme/colors";
-import { formatCompact, formatCurrency, formatNumber, formatPercent, formatPercentRaw } from "../../../utils/format";
+import { formatCompact, formatNumber } from "../../../utils/format";
 import { isPlainKey } from "../../../utils/keyboard";
 import { wrapTextLines } from "../../../utils/text-wrap";
 import { useResolvedEntryValue, useSecFilingDocuments, useSecFilingsQuery } from "../../../market-data/hooks";
 import { instrumentFromTicker } from "../../../market-data/request-types";
 import { usePaneTicker } from "../../../state/app/context";
 import { isUsEquityTicker } from "../../../utils/sec";
-import { computeTTM } from "../ticker-detail/financials/aggregation";
 import { useAssetData } from "../../runtime";
 import { handleRefreshKey, loadingErrorFooterInfo } from "../shared/table-pane";
 import { useBoundTicker as useSymbolBinding, useTickerRequest } from "../shared/ticker-request";
@@ -38,32 +34,12 @@ import {
   buildInlineFilingContentTargets,
   useSecFilingContentCache,
 } from "../sec/filing-content";
+import { buildEventRows, type EventRow, type EventStatus } from "./event-model";
 
-type EventStatus = "Earnings" | "Q Est" | "FY Est" | "TTM" | "Dividend" | "Split";
-
-type EventRow = {
-  id: string;
-  date: string;
-  status: EventStatus;
-  period: string;
-  detail: string;
-  qEps?: number;
-  qRevenue?: number;
-  annualEps?: number;
-  annualRevenue?: number;
-  value: string;
-  tone: "positive" | "negative" | "muted" | "text";
-};
+export { buildEventRows } from "./event-model";
 
 type EventColumnId = "date" | "status" | "period" | "qEps" | "qRevenue" | "annualEps" | "annualRevenue" | "value" | "detail";
 type EventColumn = DataTableColumn & { id: EventColumnId };
-
-type EstimatePair = {
-  date: string;
-  period: string;
-  eps?: AnalystEstimateRecord;
-  revenue?: AnalystEstimateRecord;
-};
 
 const SEC_EVENT_FILING_LIMIT = 50;
 const SEC_EVENT_MATCH_WINDOW_DAYS = 7;
@@ -74,36 +50,6 @@ function todayDateKey(): string {
   const month = String(now.getMonth() + 1).padStart(2, "0");
   const day = String(now.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
-}
-
-function formatPeriod(period: string): string {
-  const label = period.replace(/_/g, " ");
-  return label
-    .replace(/\bcurrent\b/g, "cur")
-    .replace(/\bquarter\b/g, "qtr")
-    .replace(/\byear\b/g, "yr")
-    || "-";
-}
-
-function isFiscalEstimatePeriod(period: string): boolean {
-  return /\byear\b|^current_year$|^next_year$|^next_5y$/i.test(period);
-}
-
-function sortedQuarterlyStatements(financials: Pick<TickerFinancials, "quarterlyStatements"> | null): FinancialStatement[] {
-  return [...(financials?.quarterlyStatements ?? [])]
-    .filter((statement) => statement.date)
-    .sort((left, right) => left.date.localeCompare(right.date));
-}
-
-function quarterLabel(statement: FinancialStatement | undefined): string {
-  return statement?.date ? `Q${statement.date.slice(2)}` : "-";
-}
-
-function daysBetween(leftDate: string, rightDate: string): number {
-  const left = new Date(`${leftDate}T00:00:00Z`).getTime();
-  const right = new Date(`${rightDate}T00:00:00Z`).getTime();
-  if (!Number.isFinite(left) || !Number.isFinite(right)) return Number.POSITIVE_INFINITY;
-  return Math.abs(left - right) / 86_400_000;
 }
 
 function dateKeyToEpochDay(dateKey: string): number | null {
@@ -173,186 +119,6 @@ export function matchEarningsSecFiling(row: { status: string; date: string } | n
     }
   }
   return best?.filing ?? null;
-}
-
-function statementForEarningsDate(
-  quarterlyStatements: readonly FinancialStatement[],
-  earningsDate: string,
-): FinancialStatement | undefined {
-  let best: FinancialStatement | undefined;
-  for (const statement of quarterlyStatements) {
-    if (statement.date > earningsDate) continue;
-    if (!best || statement.date > best.date) best = statement;
-  }
-  return best && daysBetween(best.date, earningsDate) <= 140 ? best : undefined;
-}
-
-function estimateKey(estimate: AnalystEstimateRecord): string {
-  return `${estimate.date}|${estimate.period}`;
-}
-
-function hasEstimateValue(estimate: AnalystEstimateRecord | undefined): boolean {
-  return estimate?.average != null
-    || estimate?.low != null
-    || estimate?.high != null
-    || estimate?.yearAgo != null
-    || estimate?.growth != null
-    || estimate?.analysts != null;
-}
-
-function buildEstimatePairs(data: AnalystResearchData | null): EstimatePair[] {
-  const pairs = new Map<string, EstimatePair>();
-  const ensurePair = (estimate: AnalystEstimateRecord): EstimatePair => {
-    const key = estimateKey(estimate);
-    const existing = pairs.get(key);
-    if (existing) return existing;
-    const pair: EstimatePair = { date: estimate.date, period: estimate.period };
-    pairs.set(key, pair);
-    return pair;
-  };
-
-  for (const estimate of data?.earningsEstimates ?? []) {
-    if (hasEstimateValue(estimate)) ensurePair(estimate).eps = estimate;
-  }
-  for (const estimate of data?.revenueEstimates ?? []) {
-    if (hasEstimateValue(estimate)) ensurePair(estimate).revenue = estimate;
-  }
-
-  return [...pairs.values()];
-}
-
-function formatEstimateDetail(pair: EstimatePair): string {
-  const analystCounts: string[] = [];
-  if (pair.eps?.analysts != null) analystCounts.push(`${pair.eps.analysts}E`);
-  if (pair.revenue?.analysts != null) analystCounts.push(`${pair.revenue.analysts}R`);
-  if (analystCounts.length) return analystCounts.join("/");
-  return "Consensus";
-}
-
-function estimateTone(pair: EstimatePair): EventRow["tone"] {
-  const growth = pair.eps?.growth ?? pair.revenue?.growth;
-  if (growth == null) return "muted";
-  return growth >= 0 ? "positive" : "negative";
-}
-
-function estimateValue(pair: EstimatePair): string {
-  const growth = pair.eps?.growth ?? pair.revenue?.growth;
-  return growth == null ? "-" : formatPercent(growth);
-}
-
-function ttmRow(quarterlyStatements: readonly FinancialStatement[]): EventRow | null {
-  const latestFour = quarterlyStatements.slice(-4);
-  const ttm = computeTTM([...quarterlyStatements]);
-  if (!ttm || (ttm.totalRevenue == null && ttm.eps == null)) return null;
-  const latest = latestFour.at(-1);
-  return {
-    id: `ttm:${latest?.date ?? ""}`,
-    date: latest?.date ?? "",
-    status: "TTM",
-    period: "4 qtrs",
-    detail: "sum",
-    annualEps: ttm.eps,
-    annualRevenue: ttm.totalRevenue,
-    value: "-",
-    tone: "muted",
-  };
-}
-
-function earningsDetail(earning: CorporateActionsData["earnings"][number]): string {
-  if (earning.epsActual == null) return "Pending";
-  if (earning.difference == null) return "Reported";
-  return `diff ${formatNumber(earning.difference, 2)}`;
-}
-
-function eventSortRank(status: EventStatus): number {
-  switch (status) {
-    case "Q Est":
-      return 0;
-    case "FY Est":
-      return 1;
-    case "Earnings":
-      return 2;
-    case "TTM":
-      return 3;
-    case "Dividend":
-      return 4;
-    case "Split":
-      return 5;
-  }
-}
-
-export function buildEventRows(
-  data: CorporateActionsData | null,
-  estimates: AnalystResearchData | null,
-  financials: Pick<TickerFinancials, "quarterlyStatements"> | null,
-  currency: string,
-): EventRow[] {
-  const rows: EventRow[] = [];
-  const quarterlyStatements = sortedQuarterlyStatements(financials);
-  const ttm = ttmRow(quarterlyStatements);
-  if (ttm) rows.push(ttm);
-
-  for (const earning of data?.earnings ?? []) {
-    const statement = statementForEarningsDate(quarterlyStatements, earning.date);
-    rows.push({
-      id: `earn:${earning.date}`,
-      date: earning.date,
-      status: "Earnings",
-      period: statement ? quarterLabel(statement) : earning.time?.trim() || "-",
-      detail: earningsDetail(earning),
-      qEps: earning.epsActual ?? statement?.eps ?? earning.epsEstimate,
-      qRevenue: statement?.totalRevenue,
-      value: earning.surprisePercent != null ? formatPercentRaw(earning.surprisePercent) : "-",
-      tone: earning.surprisePercent == null ? "muted" : earning.surprisePercent >= 0 ? "positive" : "negative",
-    });
-  }
-
-  for (const pair of buildEstimatePairs(estimates)) {
-    const isFiscal = isFiscalEstimatePeriod(pair.period);
-    rows.push({
-      id: `estimate:${pair.date}:${pair.period}`,
-      date: pair.date,
-      status: isFiscal ? "FY Est" : "Q Est",
-      period: formatPeriod(pair.period),
-      detail: formatEstimateDetail(pair),
-      qEps: isFiscal ? undefined : pair.eps?.average,
-      qRevenue: isFiscal ? undefined : pair.revenue?.average,
-      annualEps: isFiscal ? pair.eps?.average : undefined,
-      annualRevenue: isFiscal ? pair.revenue?.average : undefined,
-      value: estimateValue(pair),
-      tone: estimateTone(pair),
-    });
-  }
-
-  for (const dividend of data?.dividends ?? []) {
-    rows.push({
-      id: `div:${dividend.exDate}`,
-      date: dividend.exDate,
-      status: "Dividend",
-      period: "-",
-      detail: "Ex-date",
-      value: formatCurrency(dividend.amount, currency),
-      tone: "positive",
-    });
-  }
-
-  for (const split of data?.splits ?? []) {
-    rows.push({
-      id: `split:${split.date}:${split.description ?? ""}`,
-      date: split.date,
-      status: "Split",
-      period: "-",
-      detail: split.description ?? "Split",
-      value: split.fromFactor && split.toFactor ? `${split.fromFactor}:${split.toFactor}` : formatNumber(split.ratio, 4),
-      tone: "muted",
-    });
-  }
-
-  return rows.sort((left, right) => (
-    right.date.localeCompare(left.date)
-    || eventSortRank(left.status) - eventSortRank(right.status)
-    || left.period.localeCompare(right.period)
-  ));
 }
 
 function buildEventColumns(): EventColumn[] {

--- a/src/plugins/builtin/research/event-model.ts
+++ b/src/plugins/builtin/research/event-model.ts
@@ -1,0 +1,245 @@
+import type {
+  AnalystEstimateRecord,
+  AnalystResearchData,
+  CorporateActionsData,
+  FinancialStatement,
+  TickerFinancials,
+} from "../../../types/financials";
+import {
+  formatCurrency,
+  formatNumber,
+  formatPercent,
+  formatPercentRaw,
+} from "../../../utils/format";
+import { computeTTM } from "../ticker-detail/financials/aggregation";
+
+export type EventStatus = "Earnings" | "Q Est" | "FY Est" | "TTM" | "Dividend" | "Split";
+
+export interface EventRow {
+  id: string;
+  date: string;
+  status: EventStatus;
+  period: string;
+  detail: string;
+  qEps?: number;
+  qRevenue?: number;
+  annualEps?: number;
+  annualRevenue?: number;
+  value: string;
+  tone: "positive" | "negative" | "muted" | "text";
+}
+
+interface EstimatePair {
+  date: string;
+  period: string;
+  eps?: AnalystEstimateRecord;
+  revenue?: AnalystEstimateRecord;
+}
+
+function formatPeriod(period: string): string {
+  const label = period.replace(/_/g, " ");
+  return label
+    .replace(/\bcurrent\b/g, "cur")
+    .replace(/\bquarter\b/g, "qtr")
+    .replace(/\byear\b/g, "yr")
+    || "-";
+}
+
+function isFiscalEstimatePeriod(period: string): boolean {
+  return /\byear\b|^current_year$|^next_year$|^next_5y$/i.test(period);
+}
+
+function sortedQuarterlyStatements(
+  financials: Pick<TickerFinancials, "quarterlyStatements"> | null,
+): FinancialStatement[] {
+  return [...(financials?.quarterlyStatements ?? [])]
+    .filter((statement) => statement.date)
+    .sort((left, right) => left.date.localeCompare(right.date));
+}
+
+function quarterLabel(statement: FinancialStatement | undefined): string {
+  return statement?.date ? `Q${statement.date.slice(2)}` : "-";
+}
+
+function daysBetween(leftDate: string, rightDate: string): number {
+  const left = new Date(`${leftDate}T00:00:00Z`).getTime();
+  const right = new Date(`${rightDate}T00:00:00Z`).getTime();
+  if (!Number.isFinite(left) || !Number.isFinite(right)) return Number.POSITIVE_INFINITY;
+  return Math.abs(left - right) / 86_400_000;
+}
+
+function statementForEarningsDate(
+  quarterlyStatements: readonly FinancialStatement[],
+  earningsDate: string,
+): FinancialStatement | undefined {
+  let best: FinancialStatement | undefined;
+  for (const statement of quarterlyStatements) {
+    if (statement.date > earningsDate) continue;
+    if (!best || statement.date > best.date) best = statement;
+  }
+  return best && daysBetween(best.date, earningsDate) <= 140 ? best : undefined;
+}
+
+function estimateKey(estimate: AnalystEstimateRecord): string {
+  return `${estimate.date}|${estimate.period}`;
+}
+
+function hasEstimateValue(estimate: AnalystEstimateRecord | undefined): boolean {
+  return estimate?.average != null
+    || estimate?.low != null
+    || estimate?.high != null
+    || estimate?.yearAgo != null
+    || estimate?.growth != null
+    || estimate?.analysts != null;
+}
+
+function buildEstimatePairs(data: AnalystResearchData | null): EstimatePair[] {
+  const pairs = new Map<string, EstimatePair>();
+  const ensurePair = (estimate: AnalystEstimateRecord): EstimatePair => {
+    const key = estimateKey(estimate);
+    const existing = pairs.get(key);
+    if (existing) return existing;
+    const pair: EstimatePair = { date: estimate.date, period: estimate.period };
+    pairs.set(key, pair);
+    return pair;
+  };
+
+  for (const estimate of data?.earningsEstimates ?? []) {
+    if (hasEstimateValue(estimate)) ensurePair(estimate).eps = estimate;
+  }
+  for (const estimate of data?.revenueEstimates ?? []) {
+    if (hasEstimateValue(estimate)) ensurePair(estimate).revenue = estimate;
+  }
+
+  return [...pairs.values()];
+}
+
+function formatEstimateDetail(pair: EstimatePair): string {
+  const analystCounts: string[] = [];
+  if (pair.eps?.analysts != null) analystCounts.push(`${pair.eps.analysts}E`);
+  if (pair.revenue?.analysts != null) analystCounts.push(`${pair.revenue.analysts}R`);
+  if (analystCounts.length) return analystCounts.join("/");
+  return "Consensus";
+}
+
+function estimateTone(pair: EstimatePair): EventRow["tone"] {
+  const growth = pair.eps?.growth ?? pair.revenue?.growth;
+  if (growth == null) return "muted";
+  return growth >= 0 ? "positive" : "negative";
+}
+
+function estimateValue(pair: EstimatePair): string {
+  const growth = pair.eps?.growth ?? pair.revenue?.growth;
+  return growth == null ? "-" : formatPercent(growth);
+}
+
+function ttmRow(quarterlyStatements: readonly FinancialStatement[]): EventRow | null {
+  const latestFour = quarterlyStatements.slice(-4);
+  const ttm = computeTTM([...quarterlyStatements]);
+  if (!ttm || (ttm.totalRevenue == null && ttm.eps == null)) return null;
+  const latest = latestFour.at(-1);
+  return {
+    id: `ttm:${latest?.date ?? ""}`,
+    date: latest?.date ?? "",
+    status: "TTM",
+    period: "4 qtrs",
+    detail: "sum",
+    annualEps: ttm.eps,
+    annualRevenue: ttm.totalRevenue,
+    value: "-",
+    tone: "muted",
+  };
+}
+
+function earningsDetail(earning: CorporateActionsData["earnings"][number]): string {
+  if (earning.epsActual == null) return "Pending";
+  if (earning.difference == null) return "Reported";
+  return `diff ${formatNumber(earning.difference, 2)}`;
+}
+
+function eventSortRank(status: EventStatus): number {
+  switch (status) {
+    case "Q Est": return 0;
+    case "FY Est": return 1;
+    case "Earnings": return 2;
+    case "TTM": return 3;
+    case "Dividend": return 4;
+    case "Split": return 5;
+  }
+}
+
+export function buildEventRows(
+  data: CorporateActionsData | null,
+  estimates: AnalystResearchData | null,
+  financials: Pick<TickerFinancials, "quarterlyStatements"> | null,
+  currency: string,
+): EventRow[] {
+  const rows: EventRow[] = [];
+  const quarterlyStatements = sortedQuarterlyStatements(financials);
+  const ttm = ttmRow(quarterlyStatements);
+  if (ttm) rows.push(ttm);
+
+  for (const earning of data?.earnings ?? []) {
+    const statement = statementForEarningsDate(quarterlyStatements, earning.date);
+    rows.push({
+      id: `earn:${earning.date}`,
+      date: earning.date,
+      status: "Earnings",
+      period: statement ? quarterLabel(statement) : earning.time?.trim() || "-",
+      detail: earningsDetail(earning),
+      qEps: earning.epsActual ?? statement?.eps ?? earning.epsEstimate,
+      qRevenue: statement?.totalRevenue,
+      value: earning.surprisePercent != null ? formatPercentRaw(earning.surprisePercent) : "-",
+      tone: earning.surprisePercent == null ? "muted" : earning.surprisePercent >= 0 ? "positive" : "negative",
+    });
+  }
+
+  for (const pair of buildEstimatePairs(estimates)) {
+    const isFiscal = isFiscalEstimatePeriod(pair.period);
+    rows.push({
+      id: `estimate:${pair.date}:${pair.period}`,
+      date: pair.date,
+      status: isFiscal ? "FY Est" : "Q Est",
+      period: formatPeriod(pair.period),
+      detail: formatEstimateDetail(pair),
+      qEps: isFiscal ? undefined : pair.eps?.average,
+      qRevenue: isFiscal ? undefined : pair.revenue?.average,
+      annualEps: isFiscal ? pair.eps?.average : undefined,
+      annualRevenue: isFiscal ? pair.revenue?.average : undefined,
+      value: estimateValue(pair),
+      tone: estimateTone(pair),
+    });
+  }
+
+  for (const dividend of data?.dividends ?? []) {
+    rows.push({
+      id: `div:${dividend.exDate}`,
+      date: dividend.exDate,
+      status: "Dividend",
+      period: "-",
+      detail: "Ex-date",
+      value: formatCurrency(dividend.amount, currency),
+      tone: "positive",
+    });
+  }
+
+  for (const split of data?.splits ?? []) {
+    rows.push({
+      id: `split:${split.date}:${split.description ?? ""}`,
+      date: split.date,
+      status: "Split",
+      period: "-",
+      detail: split.description ?? "Split",
+      value: split.fromFactor && split.toFactor
+        ? `${split.fromFactor}:${split.toFactor}`
+        : formatNumber(split.ratio, 4),
+      tone: "muted",
+    });
+  }
+
+  return rows.sort((left, right) => (
+    right.date.localeCompare(left.date)
+    || eventSortRank(left.status) - eventSortRank(right.status)
+    || left.period.localeCompare(right.period)
+  ));
+}

--- a/src/plugins/builtin/research/events-headless.test.ts
+++ b/src/plugins/builtin/research/events-headless.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createEventsHeadless } from "./events-headless";
+
+const args: HeadlessPaneLoadArgs = {
+  rawArgument: "AAPL", argument: "AAPL", symbols: ["AAPL"], options: {},
+};
+
+describe("corporate actions headless model", () => {
+  test("maps corporate actions through the same event projection as the pane", async () => {
+    const headless = createEventsHeadless({
+      load: async () => ({
+        actions: {
+          symbol: "AAPL",
+          currency: "USD",
+          dividends: [{ exDate: "2026-08-08", amount: 0.26 }],
+          splits: [],
+          earnings: [{ date: "2026-07-31", epsActual: 1.57, surprisePercent: 5.4 }],
+        },
+        estimates: null,
+        financials: null,
+        currency: "USD",
+      }),
+    });
+    const result = await headless.load(args, {} as HeadlessPaneContext);
+
+    expect(result.rows).toEqual([
+      expect.objectContaining({ status: "Dividend", value: "$0.26" }),
+      expect.objectContaining({ status: "Earnings", qEps: 1.57, value: "+5.40%" }),
+    ]);
+  });
+});

--- a/src/plugins/builtin/research/events-headless.ts
+++ b/src/plugins/builtin/research/events-headless.ts
@@ -1,0 +1,87 @@
+import type { DataProvider } from "../../../types/data-provider";
+import type {
+  AnalystResearchData,
+  CorporateActionsData,
+  TickerFinancials,
+} from "../../../types/financials";
+import type {
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import { formatCompact, formatNumber } from "../../../utils/format";
+import { buildEventRows } from "./event-model";
+
+const COLUMNS = [
+  { key: "date", header: "Date" },
+  { key: "status", header: "Event" },
+  { key: "period", header: "Period" },
+  { key: "qEps", header: "Q EPS", align: "right" as const, format: (value: unknown) => value == null ? "-" : formatNumber(Number(value), 2) },
+  { key: "qRevenue", header: "Q revenue", align: "right" as const, format: (value: unknown) => value == null ? "-" : formatCompact(Number(value)) },
+  { key: "annualEps", header: "Annual EPS", align: "right" as const, format: (value: unknown) => value == null ? "-" : formatNumber(Number(value), 2) },
+  { key: "annualRevenue", header: "Annual revenue", align: "right" as const, format: (value: unknown) => value == null ? "-" : formatCompact(Number(value)) },
+  { key: "value", header: "Value", align: "right" as const },
+  { key: "detail", header: "Detail" },
+];
+
+export interface EventHeadlessData {
+  actions: CorporateActionsData | null;
+  estimates: AnalystResearchData | null;
+  financials: TickerFinancials | null;
+  currency: string;
+}
+
+export interface EventsHeadlessDependencies {
+  load(
+    args: HeadlessPaneLoadArgs,
+    symbol: string,
+    provider: DataProvider,
+  ): Promise<EventHeadlessData>;
+}
+
+const defaultDependencies: EventsHeadlessDependencies = {
+  async load(_args, symbol, provider) {
+    if (!provider.getCorporateActions) {
+      throw new Error("Corporate actions source unavailable");
+    }
+    const [actions, estimates, financials] = await Promise.all([
+      provider.getCorporateActions(symbol, ""),
+      provider.getAnalystResearch
+        ? provider.getAnalystResearch(symbol, "").catch(() => null)
+        : null,
+      provider.getTickerFinancials(symbol, "").catch(() => null),
+    ]);
+    return {
+      actions,
+      estimates,
+      financials,
+      currency: actions.currency ?? estimates?.currency ?? financials?.quote?.currency ?? "USD",
+    };
+  },
+};
+
+export function createEventsHeadless(
+  dependencies: EventsHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "ticker",
+      placeholder: "ticker",
+      description: "Ticker whose corporate actions and estimates should be returned.",
+    },
+    options: [],
+    columns: COLUMNS,
+    describe: (args) => `Corporate Actions | ${String(args.argument)}`,
+    async load(args, ctx) {
+      const symbol = args.symbols[0]!;
+      const data = await dependencies.load(args, symbol, ctx.marketData);
+      return {
+        rows: buildEventRows(data.actions, data.estimates, data.financials, data.currency)
+          .map((row) => ({ ...row })),
+        metadata: { symbol, currency: data.currency },
+      };
+    },
+  };
+}
+
+export const eventsHeadless = createEventsHeadless();

--- a/src/plugins/builtin/research/index.tsx
+++ b/src/plugins/builtin/research/index.tsx
@@ -5,6 +5,9 @@ import { AnalystResearchView } from "./analyst-pane";
 import { CorporateActionsView } from "./corporate-actions-pane";
 import { EquityDiagnosticView } from "./equity-diagnostic-pane";
 import { RelativeValuationPane } from "./relative-valuation-pane";
+import { eventsHeadless } from "./events-headless";
+
+export { eventsHeadless } from "./events-headless";
 
 function EarningsEstimatesPane(props: { focused: boolean; width: number; height: number }) {
   return (
@@ -70,6 +73,7 @@ export const researchModule: PluginModule = {
       defaultMode: "floating",
       defaultFloatingSize: { width: 104, height: 24 },
       tableExport: true,
+      headless: eventsHeadless,
     },
     {
       id: "relative-valuation",

--- a/src/plugins/builtin/scanner/headless.test.ts
+++ b/src/plugins/builtin/scanner/headless.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import type { ScannerHiloPayload } from "../../../api-client";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createHiloHeadless, loadHiloSnapshot } from "./headless";
+
+const payload: ScannerHiloPayload = {
+  status: "live",
+  asOf: 123,
+  access: "realtime",
+  delayMinutes: 0,
+  windows: { s30: { highs: 1, lows: 1 }, m1: { highs: 2, lows: 2 }, m5: { highs: 3, lows: 3 } },
+  lows: [
+    { symbol: "PENNY", price: 0.5, count: 10, at: 10 },
+    { symbol: "LOW", price: 10, count: 2, at: 20 },
+  ],
+  highs: [{ symbol: "HIGH", price: 20, count: 5, at: 30 }],
+};
+
+function args(minPrice: string, sort: string): HeadlessPaneLoadArgs {
+  return { rawArgument: "", argument: null, symbols: [], options: { minPrice, sort } };
+}
+
+describe("highs and lows headless model", () => {
+  test("waits for scanner data beyond the connecting snapshot", async () => {
+    let unsubscribed = 0;
+    const result = await loadHiloSnapshot({
+      subscribeScanner(_scanner, listener) {
+        listener({ type: "data", payload: { ...payload, status: "starting" } });
+        listener({ type: "data", payload });
+        return () => { unsubscribed += 1; };
+      },
+    }, new AbortController().signal);
+
+    expect(result.status).toBe("live");
+    expect(unsubscribed).toBe(1);
+  });
+
+  test("reports a degraded stream as partial data", async () => {
+    const headless = createHiloHeadless({
+      load: async () => ({ ...payload, status: "degraded" }),
+    });
+
+    const result = await headless.load(args("1", "recent"), {} as HeadlessPaneContext);
+
+    expect(result.errors).toEqual(["Scanner feed degraded"]);
+  });
+
+  test("applies the pane price and sort options to a stream snapshot", async () => {
+    const headless = createHiloHeadless({ load: async () => payload });
+    const filtered = await headless.load(args("1", "recent"), {} as HeadlessPaneContext);
+    const unfiltered = await headless.load(args("off", "count"), {} as HeadlessPaneContext);
+
+    expect(filtered.items.map((row) => row.symbol)).toEqual(["LOW", "HIGH"]);
+    expect(unfiltered.items.map((row) => row.symbol)).toEqual(["PENNY", "LOW", "HIGH"]);
+    expect((filtered.metadata?.windows as Array<Record<string, unknown>>)[0]).toMatchObject({
+      key: "m5", highs: 3, lows: 3,
+    });
+  });
+});

--- a/src/plugins/builtin/scanner/headless.ts
+++ b/src/plugins/builtin/scanner/headless.ts
@@ -1,0 +1,125 @@
+import type { ScannerFeedEvent, ScannerHiloPayload } from "../../../api-client";
+import type {
+  HeadlessPaneApiClient,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+  HeadlessSnapshotResult,
+} from "../../../types/plugin";
+import { buildHiloBarRows, filterHiloRows, type HiloMinPrice, type HiloSort } from "./hilo-model";
+
+export function loadHiloSnapshot(
+  client: Pick<HeadlessPaneApiClient, "subscribeScanner">,
+  signal: AbortSignal,
+  timeoutMs = 10_000,
+): Promise<ScannerHiloPayload> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let unsubscribe: (() => void) | null = null;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      unsubscribe?.();
+      callback();
+    };
+    const onAbort = () => finish(() => reject(signal.reason instanceof Error
+      ? signal.reason
+      : new Error("Highs and lows snapshot aborted")));
+    const timer = setTimeout(() => finish(() => reject(new Error("Highs and lows snapshot timed out"))), timeoutMs);
+    signal.addEventListener("abort", onAbort, { once: true });
+    unsubscribe = client.subscribeScanner("hilo", (event: ScannerFeedEvent) => {
+      if (event.type === "denied") {
+        finish(() => reject(new Error(event.reason === "pro_required" ? "Pro access required" : "Sign in required")));
+        return;
+      }
+      if (event.payload.status === "starting") return;
+      finish(() => resolve(event.payload as ScannerHiloPayload));
+    });
+    if (settled) unsubscribe();
+  });
+}
+
+export function projectHiloSnapshot(
+  payload: ScannerHiloPayload,
+  minPrice: HiloMinPrice,
+  sort: HiloSort,
+): HeadlessSnapshotResult {
+  const lows = filterHiloRows(payload.lows, minPrice, sort).map((row) => ({ side: "low", ...row }));
+  const highs = filterHiloRows(payload.highs, minPrice, sort).map((row) => ({ side: "high", ...row }));
+  return {
+    asOf: new Date(payload.asOf).toISOString(),
+    items: [...lows, ...highs],
+    ...(payload.status === "degraded" ? { errors: ["Scanner feed degraded"] } : {}),
+    metadata: {
+      status: payload.status,
+      access: payload.access,
+      delayMinutes: payload.delayMinutes,
+      windows: buildHiloBarRows(payload.windows),
+      minPrice,
+      sort,
+    },
+  };
+}
+
+export interface HiloHeadlessDependencies {
+  load(
+    args: HeadlessPaneLoadArgs,
+    client: Pick<HeadlessPaneApiClient, "subscribeScanner">,
+    signal: AbortSignal,
+  ): Promise<ScannerHiloPayload>;
+}
+
+const defaultDependencies: HiloHeadlessDependencies = {
+  load: (_args, client, signal) => loadHiloSnapshot(client, signal),
+};
+
+export function createHiloHeadless(
+  dependencies: HiloHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"snapshot"> {
+  return {
+    shape: "snapshot",
+    argument: { kind: "none" },
+    options: [
+      {
+        key: "minPrice",
+        aliases: ["min-price"],
+        settingKey: "minPrice",
+        description: "Minimum stock price.",
+        type: "enum",
+        values: [{ value: "off" }, { value: "1" }, { value: "5" }],
+        defaultValue: "1",
+      },
+      {
+        key: "sort",
+        settingKey: "sort",
+        description: "Extreme ordering.",
+        type: "enum",
+        values: [{ value: "recent" }, { value: "count" }],
+        defaultValue: "recent",
+      },
+    ],
+    columns: [
+      { key: "side", header: "Side" },
+      { key: "symbol", header: "Symbol" },
+      { key: "price", header: "Price", align: "right" },
+      { key: "count", header: "Count", align: "right" },
+      {
+        key: "at",
+        header: "Observed at",
+        format: (value: unknown) => new Date(Number(value)).toISOString(),
+      },
+    ],
+    describe: "New Highs / Lows",
+    async load(args, ctx) {
+      const payload = await dependencies.load(args, ctx.apiClient, ctx.signal);
+      return projectHiloSnapshot(
+        payload,
+        args.options.minPrice as HiloMinPrice,
+        args.options.sort as HiloSort,
+      );
+    },
+  };
+}
+
+export const hiloHeadless = createHiloHeadless();

--- a/src/plugins/builtin/scanner/index.ts
+++ b/src/plugins/builtin/scanner/index.ts
@@ -3,6 +3,9 @@ import type { PluginModule } from "../plugin-module";
 import { DEFAULT_FLOW_FILTERS, FLOW_FILTER_OPTIONS } from "./flow-model";
 import FlowPane from "./flow-pane";
 import HiloPane from "./hilo-pane";
+import { hiloHeadless } from "./headless";
+
+export { hiloHeadless } from "./headless";
 
 export const HILO_PANE_ID = "scanner-hilo";
 export const FLOW_PANE_ID = "scanner-flow";
@@ -96,6 +99,7 @@ export const scannerModule: PluginModule = {
       description: "Session new-high and new-low momentum with 30s/1m/5m counts.",
       keywords: ["hilo", "highs", "lows", "new", "momentum", "breakout", "scanner"],
       shortcut: { prefix: "HILO" },
+      headless: hiloHeadless,
       createInstance: () => ({ settings: { minPrice: "1", sort: "recent" } }),
     },
     {

--- a/src/plugins/builtin/sectors/client.ts
+++ b/src/plugins/builtin/sectors/client.ts
@@ -1,0 +1,54 @@
+import type { DataProvider } from "../../../types/data-provider";
+import type { PricePoint, Quote } from "../../../types/financials";
+import type { SectorDef } from "./sector-data";
+import {
+  computeTrailingReturn,
+  latestHistoryClose,
+  ONE_MONTH_DAYS,
+  ONE_YEAR_DAYS,
+  type SectorRow,
+} from "./sector-model";
+
+export interface SectorRowOutcome {
+  etf: string;
+  row: Partial<SectorRow> | null;
+}
+
+export async function loadSectorRows(
+  sectors: readonly SectorDef[],
+  provider: DataProvider,
+): Promise<SectorRowOutcome[]> {
+  const quotes = new Map<string, Quote | null>();
+  if (provider.getQuotesBatch) {
+    const results = await provider.getQuotesBatch(
+      sectors.map((sector) => ({ symbol: sector.etf, exchange: "" })),
+    ).catch(() => []);
+    for (const result of results) quotes.set(result.target.symbol, result.quote ?? null);
+  } else {
+    await Promise.all(sectors.map(async (sector) => {
+      try {
+        quotes.set(sector.etf, await provider.getQuote(sector.etf, ""));
+      } catch {
+        quotes.set(sector.etf, null);
+      }
+    }));
+  }
+
+  return Promise.all(sectors.map(async (sector) => {
+    const history: PricePoint[] = await provider.getPriceHistory(sector.etf, "", "1Y")
+      .catch(() => []);
+    const quote = quotes.get(sector.etf) ?? null;
+    if (!quote && history.length === 0) return { etf: sector.etf, row: null };
+    const price = quote?.price ?? latestHistoryClose(history);
+    return {
+      etf: sector.etf,
+      row: {
+        price,
+        changePercent: quote?.changePercent ?? null,
+        return1M: computeTrailingReturn(history, ONE_MONTH_DAYS, price),
+        return1Y: computeTrailingReturn(history, ONE_YEAR_DAYS, price),
+        currency: quote?.currency ?? "USD",
+      },
+    };
+  }));
+}

--- a/src/plugins/builtin/sectors/headless.test.ts
+++ b/src/plugins/builtin/sectors/headless.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createSectorsHeadless } from "./headless";
+
+function args(collection: string): HeadlessPaneLoadArgs {
+  return { rawArgument: "", argument: null, symbols: [], options: { collection } };
+}
+
+describe("sectors headless model", () => {
+  test("changes the loaded ETF universe with the collection option", async () => {
+    const requested: string[][] = [];
+    const headless = createSectorsHeadless({
+      load: async (_args, definitions) => {
+        requested.push(definitions.map(({ etf }) => etf));
+        return definitions.map((definition, index) => ({
+          etf: definition.etf,
+          row: { price: 100, changePercent: index, return1M: index + 1, return1Y: index + 2, currency: "USD" },
+        }));
+      },
+    });
+
+    const sectors = await headless.load(args("sectors"), {} as HeadlessPaneContext);
+    const industries = await headless.load(args("industries"), {} as HeadlessPaneContext);
+    expect(sectors.rows.some((row) => row.etf === "XLK")).toBe(true);
+    expect(industries.rows.some((row) => row.etf === "SMH")).toBe(true);
+    expect(requested[0]).not.toEqual(requested[1]);
+  });
+});

--- a/src/plugins/builtin/sectors/headless.ts
+++ b/src/plugins/builtin/sectors/headless.ts
@@ -1,0 +1,80 @@
+import type { DataProvider } from "../../../types/data-provider";
+import type {
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import { formatCurrency, formatPercentRaw } from "../../../utils/format";
+import { loadSectorRows, type SectorRowOutcome } from "./client";
+import { getSectorCollection, type SectorCollectionId, type SectorDef } from "./sector-data";
+import { DEFAULT_SORT_PREFERENCE, sortRows, type SectorRow } from "./sector-model";
+
+const COLUMNS = [
+  { key: "name", header: "Sector" },
+  { key: "etf", header: "ETF" },
+  { key: "price", header: "Last", align: "right" as const, format: (value: unknown, row: Record<string, unknown>) => value == null ? "-" : formatCurrency(Number(value), String(row.currency)) },
+  { key: "changePercent", header: "1D", align: "right" as const, format: (value: unknown) => value == null ? "-" : formatPercentRaw(Number(value)) },
+  { key: "return1M", header: "1M", align: "right" as const, format: (value: unknown) => value == null ? "-" : formatPercentRaw(Number(value)) },
+  { key: "return1Y", header: "1Y", align: "right" as const, format: (value: unknown) => value == null ? "-" : formatPercentRaw(Number(value)) },
+];
+
+export function projectSectorRows(
+  definitions: readonly SectorDef[],
+  outcomes: readonly SectorRowOutcome[],
+): SectorRow[] {
+  const byEtf = new Map(outcomes.map((outcome) => [outcome.etf, outcome.row]));
+  return sortRows(definitions.map((definition) => ({
+    ...definition,
+    price: byEtf.get(definition.etf)?.price ?? null,
+    changePercent: byEtf.get(definition.etf)?.changePercent ?? null,
+    return1M: byEtf.get(definition.etf)?.return1M ?? null,
+    return1Y: byEtf.get(definition.etf)?.return1Y ?? null,
+    currency: byEtf.get(definition.etf)?.currency ?? "USD",
+    loading: false,
+  })), DEFAULT_SORT_PREFERENCE);
+}
+
+export interface SectorsHeadlessDependencies {
+  load(
+    args: HeadlessPaneLoadArgs,
+    definitions: readonly SectorDef[],
+    provider: DataProvider,
+  ): Promise<SectorRowOutcome[]>;
+}
+
+const defaultDependencies: SectorsHeadlessDependencies = {
+  load: (_args, definitions, provider) => loadSectorRows(definitions, provider),
+};
+
+export function createSectorsHeadless(
+  dependencies: SectorsHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: { kind: "none" },
+    options: [{
+      key: "collection",
+      description: "Sector or industry ETF collection.",
+      type: "enum",
+      values: [{ value: "sectors" }, { value: "industries" }],
+      defaultValue: "sectors",
+    }],
+    columns: COLUMNS,
+    describe: (args) => `Sector Performance | ${String(args.options.collection)}`,
+    async load(args, ctx) {
+      const collectionId = args.options.collection as SectorCollectionId;
+      const definitions = getSectorCollection(collectionId).items;
+      const outcomes = await dependencies.load(args, definitions, ctx.marketData);
+      const rows = projectSectorRows(definitions, outcomes);
+      return {
+        rows: rows.map((row) => ({ ...row })),
+        metadata: {
+          collection: collectionId,
+          available: outcomes.filter((outcome) => outcome.row).length,
+          requested: definitions.length,
+        },
+      };
+    },
+  };
+}
+
+export const sectorsHeadless = createSectorsHeadless();

--- a/src/plugins/builtin/sectors/index.tsx
+++ b/src/plugins/builtin/sectors/index.tsx
@@ -3,7 +3,6 @@ import { Box } from "../../../ui";
 import { DataTableView, Tabs, usePaneFooter, type DataTableCell, type DataTableKeyEvent, type PaneFooterSegment } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
-import type { PricePoint, Quote } from "../../../types/financials";
 import { usePaneSettingValue } from "../../../state/app/context";
 import { colors, priceColor } from "../../../theme/colors";
 import { formatCurrency, formatPercentRaw } from "../../../utils/format";
@@ -22,11 +21,7 @@ import {
   DEFAULT_SORT_PREFERENCE,
   INITIAL_REFRESH_BY_COLLECTION,
   INITIAL_ROWS_BY_COLLECTION,
-  ONE_MONTH_DAYS,
-  ONE_YEAR_DAYS,
   buildSectorColumns,
-  computeTrailingReturn,
-  latestHistoryClose,
   nextSortPreference,
   normalizeRowsForCollection,
   sortRows,
@@ -37,6 +32,10 @@ import {
   type SectorRowsByCollection,
   type SectorSortPreference,
 } from "./sector-model";
+import { loadSectorRows } from "./client";
+import { sectorsHeadless } from "./headless";
+
+export { sectorsHeadless } from "./headless";
 
 /** Stable identity: a fresh literal here would refetch the board every render. */
 const NO_SAVED_ETFS: string[] = [];
@@ -105,52 +104,7 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
       rows.map((row) => ({ ...row, loading: true }))
     )));
 
-    const loadQuotes = async (): Promise<Map<string, Quote | null>> => {
-      const quotes = new Map<string, Quote | null>();
-      if (dataProvider.getQuotesBatch) {
-        // A failed batch leaves every quote missing, which the row outcome below
-        // reports as unavailable instead of stamping the pane as fresh.
-        const results = await dataProvider.getQuotesBatch(
-          sectorDefs.map((sector) => ({ symbol: sector.etf, exchange: "" })),
-        ).catch(() => []);
-        for (const result of results) {
-          quotes.set(result.target.symbol, result.quote ?? null);
-        }
-        return quotes;
-      }
-
-      await Promise.all(sectorDefs.map(async (sector) => {
-        try {
-          quotes.set(sector.etf, await dataProvider.getQuote(sector.etf, ""));
-        } catch {
-          quotes.set(sector.etf, null);
-        }
-      }));
-      return quotes;
-    };
-
-    const loadRows = async (): Promise<Array<{ etf: string; row: Partial<SectorRow> | null }>> => {
-      const quotesByEtf = await loadQuotes();
-      return Promise.all(sectorDefs.map(async (sector) => {
-        const history: PricePoint[] = await dataProvider.getPriceHistory(sector.etf, "", "1Y")
-          .catch(() => []);
-        const quote = quotesByEtf.get(sector.etf) ?? null;
-        if (!quote && history.length === 0) return { etf: sector.etf, row: null };
-        const price = quote?.price ?? latestHistoryClose(history);
-        return {
-          etf: sector.etf,
-          row: {
-            price,
-            changePercent: quote?.changePercent ?? null,
-            return1M: computeTrailingReturn(history, ONE_MONTH_DAYS, price),
-            return1Y: computeTrailingReturn(history, ONE_YEAR_DAYS, price),
-            currency: quote?.currency ?? "USD",
-          },
-        };
-      }));
-    };
-
-    loadRows().then((outcomes) => {
+    loadSectorRows(sectorDefs, dataProvider).then((outcomes) => {
       if (fetchGenRef.current !== gen) return;
       const loadedByEtf = new Map(outcomes.map((outcome) => [outcome.etf, outcome.row]));
       setRowsByCollection((prev) => updateRowsForCollection(prev, collectionId, sectorDefs, (rows) => (
@@ -365,6 +319,7 @@ export const sectorsModule: PluginModule = {
       description: "S&P 500 sector and industry performance sorted by daily change.",
       keywords: ["sector", "sectors", "industry", "semis", "defense", "food", "leisure", "etf", "xlk", "xlv", "xlf", "performance", "spdr"],
       shortcut: { prefix: "BI" },
+      headless: sectorsHeadless,
     },
   ],
 };

--- a/src/plugins/builtin/treasury-auctions/headless.test.ts
+++ b/src/plugins/builtin/treasury-auctions/headless.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createTreasuryAuctionsHeadless } from "./headless";
+import type { TreasuryAuction } from "./types";
+
+const bill: TreasuryAuction = {
+  id: "bill", cusip: "A", secType: "Bill", securityTerm: "4-Week", auctionDate: "2026-09-03",
+  highInvestmentRate: 4.1, highYield: null, avgMedYield: null, highPrice: null, lowPrice: null,
+  avgMedPrice: null, bidToCoverRatio: 2.8, competitiveAccepted: 80, indirectAccepted: 20,
+  primaryDealerAccepted: 10, totalAccepted: 100, offeringAmount: 100,
+};
+const bond: TreasuryAuction = { ...bill, id: "bond", cusip: "B", secType: "Bond", securityTerm: "30-Year" };
+
+function args(filter: string): HeadlessPaneLoadArgs {
+  return { rawArgument: "", argument: null, symbols: [], options: { historyDays: "90", filter } };
+}
+
+describe("treasury auctions headless model", () => {
+  test("applies history and security filters to derived auction rows", async () => {
+    const requested: number[] = [];
+    const headless = createTreasuryAuctionsHeadless({
+      load: async (_args, historyDays) => {
+        requested.push(historyDays);
+        return { auctions: [bill, bond], fetchedAt: 123, stale: false };
+      },
+    });
+
+    const all = await headless.load(args("all"), {} as HeadlessPaneContext);
+    const bonds = await headless.load(args("bond"), {} as HeadlessPaneContext);
+    expect(all.rows).toHaveLength(2);
+    expect(bonds.rows).toEqual([expect.objectContaining({ id: "bond", rate: 4.1, indirectPercent: 20 })]);
+    expect(requested).toEqual([90, 90]);
+  });
+});

--- a/src/plugins/builtin/treasury-auctions/headless.ts
+++ b/src/plugins/builtin/treasury-auctions/headless.ts
@@ -1,0 +1,95 @@
+import type {
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import { formatCompact } from "../../../utils/format";
+import { fetchTreasuryAuctions } from "./client";
+import { loadTreasuryAuctions, type TreasuryAuctionsResult } from "./cache";
+import {
+  auctionSize,
+  DEFAULT_AUCTION_SORT,
+  indirectPct,
+  rateValue,
+  visibleAuctions,
+  type AuctionFilter,
+} from "./model";
+
+const COLUMNS = [
+  { key: "auctionDate", header: "Date" },
+  { key: "secType", header: "Type" },
+  { key: "securityTerm", header: "Term" },
+  { key: "rate", header: "Rate", align: "right" as const, format: (value: unknown) => value == null ? "-" : `${Number(value).toFixed(3)}%` },
+  { key: "bidToCoverRatio", header: "B/C", align: "right" as const, format: (value: unknown) => value == null ? "-" : Number(value).toFixed(2) },
+  { key: "indirectPercent", header: "Indirect", align: "right" as const, format: (value: unknown) => value == null ? "-" : `${Number(value).toFixed(1)}%` },
+  { key: "size", header: "Size", align: "right" as const, format: (value: unknown) => value == null ? "-" : `$${formatCompact(Number(value))}` },
+  { key: "cusip", header: "CUSIP" },
+];
+
+export interface TreasuryAuctionsHeadlessDependencies {
+  load(args: HeadlessPaneLoadArgs, historyDays: number): Promise<TreasuryAuctionsResult>;
+}
+
+const defaultDependencies: TreasuryAuctionsHeadlessDependencies = {
+  load: (_args, historyDays) => loadTreasuryAuctions(false, fetchTreasuryAuctions, historyDays),
+};
+
+export function createTreasuryAuctionsHeadless(
+  dependencies: TreasuryAuctionsHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "free-text",
+      placeholder: "search",
+      description: "Optional security type, term, or auction date filter.",
+      optional: true,
+    },
+    options: [
+      {
+        key: "historyDays",
+        aliases: ["history"],
+        settingKey: "historyDays",
+        description: "Auction history window in days.",
+        type: "enum",
+        values: [{ value: "30" }, { value: "90" }, { value: "120" }, { value: "365" }],
+        defaultValue: "120",
+      },
+      {
+        key: "filter",
+        description: "Security type group.",
+        type: "enum",
+        values: [{ value: "all" }, { value: "bill" }, { value: "note" }, { value: "bond" }],
+        defaultValue: "all",
+      },
+    ],
+    columns: COLUMNS,
+    describe: (args) => `Treasury Auctions | ${String(args.options.historyDays)} days | ${String(args.options.filter)}`,
+    async load(args) {
+      const historyDays = Number(args.options.historyDays);
+      const filter = args.options.filter as AuctionFilter;
+      const result = await dependencies.load(args, historyDays);
+      const query = typeof args.argument === "string" ? args.argument : "";
+      const auctions = visibleAuctions(result.auctions, {
+        filter,
+        query,
+        sort: DEFAULT_AUCTION_SORT,
+      });
+      return {
+        rows: auctions.map((auction) => ({
+          ...auction,
+          rate: rateValue(auction),
+          indirectPercent: indirectPct(auction),
+          size: auctionSize(auction),
+        })),
+        metadata: {
+          fetchedAt: result.fetchedAt,
+          stale: result.stale,
+          historyDays,
+          filter,
+        },
+      };
+    },
+  };
+}
+
+export const treasuryAuctionsHeadless = createTreasuryAuctionsHeadless();

--- a/src/plugins/builtin/treasury-auctions/index.tsx
+++ b/src/plugins/builtin/treasury-auctions/index.tsx
@@ -8,6 +8,9 @@ import {
 import { TreasuryAuctionsPane } from "./pane";
 import { TREASURY_AUCTIONS_PANE_ID } from "./types";
 import { createPublicPaneShare } from "../shared/public-pane";
+import { treasuryAuctionsHeadless } from "./headless";
+
+export { treasuryAuctionsHeadless } from "./headless";
 
 let disposeConnection: (() => void) | null = null;
 
@@ -86,6 +89,7 @@ export const treasuryAuctionsModule: PluginModule = {
         "issuance",
       ],
       shortcut: { prefix: "AUCT" },
+      headless: treasuryAuctionsHeadless,
       createInstance: () => ({ placement: "floating" }),
       publicShare: createPublicPaneShare("Treasury Auctions"),
     },

--- a/src/plugins/builtin/volatility/client.ts
+++ b/src/plugins/builtin/volatility/client.ts
@@ -21,6 +21,11 @@ export interface VolatilityLoadResult {
 
 const HISTORY_LIMIT = 120;
 
+export type VolatilitySeriesLoader = (
+  seriesId: VolatilitySeriesId,
+  options: { limit?: number; sortOrder?: "asc" | "desc" },
+) => Promise<VolatilitySeriesInput>;
+
 function requestFor(seriesId: VolatilitySeriesId): FredSeriesRequest {
   return { seriesId, limit: HISTORY_LIMIT, sortOrder: "desc" };
 }
@@ -48,11 +53,12 @@ export function getCachedVolatilityData(): VolatilityLoadResult | null {
 async function loadSeries(
   seriesId: VolatilitySeriesId,
   force: boolean,
+  loader: VolatilitySeriesLoader,
 ): Promise<FredSeriesLoadResult> {
   const request = requestFor(seriesId);
   return loadCachedFredSeries(
     request,
-    async () => toInput({ data: await apiClient.getCloudFredSeries(seriesId, {
+    async () => toInput({ data: await loader(seriesId, {
       limit: request.limit,
       sortOrder: request.sortOrder,
     }) }),
@@ -60,9 +66,16 @@ async function loadSeries(
   );
 }
 
-export async function loadVolatilityData(force = false): Promise<VolatilityLoadResult> {
+const defaultSeriesLoader: VolatilitySeriesLoader = (seriesId, options) => (
+  apiClient.getCloudFredSeries(seriesId, options)
+);
+
+export async function loadVolatilityData(
+  force = false,
+  loader: VolatilitySeriesLoader = defaultSeriesLoader,
+): Promise<VolatilityLoadResult> {
   const settled = await Promise.allSettled(
-    VOLATILITY_SERIES.map(({ seriesId }) => loadSeries(seriesId, force)),
+    VOLATILITY_SERIES.map(({ seriesId }) => loadSeries(seriesId, force, loader)),
   );
   const inputs: Partial<Record<VolatilitySeriesId, VolatilitySeriesInput>> = {};
   const errors: string[] = [];

--- a/src/plugins/builtin/volatility/headless.test.ts
+++ b/src/plugins/builtin/volatility/headless.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createVolatilityHeadless } from "./headless";
+
+const args: HeadlessPaneLoadArgs = { rawArgument: "", argument: null, symbols: [], options: {} };
+
+describe("volatility headless model", () => {
+  test("projects aligned tenors and the derived curve state", async () => {
+    const headless = createVolatilityHeadless({
+      load: async () => ({
+        data: {
+          metrics: [
+            { seriesId: "VIXCLS", label: "VIX", tenor: "30D", title: "VIX", value: 18, date: "2026-09-03", history: [] },
+            { seriesId: "VXVCLS", label: "VIX 3M", tenor: "3M", title: "VIX 3M", value: 21, date: "2026-09-03", history: [] },
+          ],
+          termPoints: [],
+          termDate: "2026-09-03",
+          ratio: 21 / 18,
+          slope: 3,
+          ratioHistory: [],
+          termState: "normal",
+        },
+        stale: false,
+        errors: [],
+      }),
+    });
+    const result = await headless.load(args, {} as HeadlessPaneContext);
+
+    expect(result.sections[0]?.entries?.slice(0, 2)).toEqual([
+      { label: "State", value: "normal" },
+      { label: "As of", value: "2026-09-03" },
+    ]);
+    expect(result.sections[1]?.rows?.[0]).toMatchObject({ label: "VIX", value: 18 });
+  });
+});

--- a/src/plugins/builtin/volatility/headless.ts
+++ b/src/plugins/builtin/volatility/headless.ts
@@ -1,0 +1,75 @@
+import type {
+  HeadlessBundleResult,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import {
+  loadVolatilityData,
+  type VolatilityLoadResult,
+  type VolatilitySeriesLoader,
+} from "./client";
+import type { VolatilityData } from "./model";
+
+function formattedValue(value: number | null, digits = 2): string {
+  return value == null ? "-" : value.toFixed(digits);
+}
+
+export function projectVolatilityHeadless(data: VolatilityData): HeadlessBundleResult {
+  return {
+    sections: [
+      {
+        title: "Term structure",
+        entries: [
+          { label: "State", value: data.termState },
+          { label: "As of", value: data.termDate },
+          { label: "3M / 30D", value: data.ratio, formatted: formattedValue(data.ratio) },
+          { label: "3M spread", value: data.slope, formatted: data.slope == null ? "-" : `${data.slope > 0 ? "+" : ""}${data.slope.toFixed(2)} pts` },
+        ],
+      },
+      {
+        title: "Volatility tenors",
+        columns: [
+          { key: "label", header: "Index" },
+          { key: "tenor", header: "Tenor" },
+          { key: "value", header: "Close", align: "right", format: (value) => formattedValue(value as number | null) },
+          { key: "date", header: "As of" },
+          { key: "title", header: "Series" },
+        ],
+        rows: data.metrics.map((metric) => ({ ...metric })),
+      },
+    ],
+  };
+}
+
+export interface VolatilityHeadlessDependencies {
+  load(args: HeadlessPaneLoadArgs, loader: VolatilitySeriesLoader): Promise<VolatilityLoadResult>;
+}
+
+const defaultDependencies: VolatilityHeadlessDependencies = {
+  load: (_args, loader) => loadVolatilityData(false, loader),
+};
+
+export function createVolatilityHeadless(
+  dependencies: VolatilityHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"bundle"> {
+  return {
+    shape: "bundle",
+    argument: { kind: "none" },
+    options: [],
+    describe: "VIX 30D/3M Curve",
+    async load(args, ctx) {
+      const result = await dependencies.load(
+        args,
+        (seriesId, options) => ctx.apiClient.getCloudFredSeries(seriesId, options),
+      );
+      const projected = projectVolatilityHeadless(result.data);
+      return {
+        ...projected,
+        errors: result.errors,
+        metadata: { stale: result.stale },
+      };
+    },
+  };
+}
+
+export const volatilityHeadless = createVolatilityHeadless();

--- a/src/plugins/builtin/volatility/index.tsx
+++ b/src/plugins/builtin/volatility/index.tsx
@@ -18,6 +18,9 @@ import { colors } from "../../../theme/colors";
 import type { PluginModule } from "../plugin-module";
 import { getCachedVolatilityData, loadVolatilityData } from "./client";
 import type { TermState, VolatilityData } from "./model";
+import { volatilityHeadless } from "./headless";
+
+export { volatilityHeadless } from "./headless";
 
 function formatValue(value: number | null, suffix = ""): string {
   return value == null || !Number.isFinite(value) ? "--" : `${value.toFixed(2)}${suffix}`;
@@ -189,5 +192,6 @@ export const volatilityModule: PluginModule = {
     description: "Aligned daily 30-day and three-month VIX implied-volatility closes from FRED.",
     keywords: ["vix", "volatility", "implied volatility", "curve", "slope", "normal", "inverted", "macro"],
     shortcut: { prefix: "VIX" },
+    headless: volatilityHeadless,
   }],
 };

--- a/src/plugins/builtin/world-indices/client.ts
+++ b/src/plugins/builtin/world-indices/client.ts
@@ -1,0 +1,43 @@
+import type { DataProvider } from "../../../types/data-provider";
+import type { Quote } from "../../../types/financials";
+import type { IndexEntry } from "./indices";
+
+export interface WorldIndexQuoteResult {
+  quotes: Map<string, Quote | null>;
+  errors: string[];
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function loadWorldIndexQuotes(
+  entries: readonly IndexEntry[],
+  provider: DataProvider,
+): Promise<WorldIndexQuoteResult> {
+  const quotes = new Map<string, Quote | null>();
+  const errors: string[] = [];
+  if (provider.getQuotesBatch) {
+    const results = await provider.getQuotesBatch(
+      entries.map((entry) => ({ symbol: entry.symbol, exchange: "" })),
+    );
+    const bySymbol = new Map(results.map((result) => [result.target.symbol, result]));
+    for (const entry of entries) {
+      const result = bySymbol.get(entry.symbol);
+      quotes.set(entry.symbol, result?.quote ?? null);
+      if (result?.error) errors.push(`${entry.symbol}: ${errorMessage(result.error)}`);
+      else if (!result?.quote) errors.push(`${entry.symbol}: quote unavailable`);
+    }
+    return { quotes, errors };
+  }
+
+  await Promise.all(entries.map(async (entry) => {
+    try {
+      quotes.set(entry.symbol, await provider.getQuote(entry.symbol, ""));
+    } catch (error) {
+      quotes.set(entry.symbol, null);
+      errors.push(`${entry.symbol}: ${errorMessage(error)}`);
+    }
+  }));
+  return { quotes, errors };
+}

--- a/src/plugins/builtin/world-indices/headless.test.ts
+++ b/src/plugins/builtin/world-indices/headless.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createWorldIndicesHeadless } from "./headless";
+
+const args: HeadlessPaneLoadArgs = { rawArgument: "", argument: null, symbols: [], options: {} };
+
+describe("world indices headless model", () => {
+  test("groups quote rows by the same world regions as the pane", async () => {
+    const headless = createWorldIndicesHeadless({
+      load: async (_args, entries) => ({
+        quotes: new Map(entries.map((entry) => [entry.symbol, {
+          symbol: entry.symbol,
+          price: entry.symbol === "^GSPC" ? 6_800 : 100,
+          currency: "USD",
+          change: 10,
+          changePercent: 0.5,
+          lastUpdated: 1_700_000_000_000,
+          marketState: "REGULAR" as const,
+        }])),
+        errors: [],
+      }),
+    });
+    const result = await headless.load(args, {} as HeadlessPaneContext);
+
+    expect(result.sections.map((section) => section.title)).toEqual([
+      "Americas", "Europe", "Asia-Pacific", "Other",
+    ]);
+    expect(result.sections[0]?.rows?.[0]).toMatchObject({
+      symbol: "^GSPC", shortName: "SPX", price: 6_800,
+    });
+  });
+});

--- a/src/plugins/builtin/world-indices/headless.ts
+++ b/src/plugins/builtin/world-indices/headless.ts
@@ -1,0 +1,109 @@
+import type { DataProvider } from "../../../types/data-provider";
+import type {
+  HeadlessBundleResult,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import { formatCurrency, formatNumber, formatPercentRaw } from "../../../utils/format";
+import { loadWorldIndexQuotes, type WorldIndexQuoteResult } from "./client";
+import {
+  getIndicesByRegion,
+  REGION_LABELS,
+  REGION_ORDER,
+  WORLD_INDICES,
+  type IndexEntry,
+} from "./indices";
+
+const COLUMNS = [
+  { key: "shortName", header: "Index" },
+  { key: "name", header: "Name" },
+  {
+    key: "price",
+    header: "Last",
+    align: "right" as const,
+    format: (value: unknown, row: Record<string, unknown>) => value == null
+      ? "-"
+      : formatCurrency(Number(value), String(row.currency ?? "USD")),
+  },
+  {
+    key: "change",
+    header: "Change",
+    align: "right" as const,
+    format: (value: unknown) => value == null ? "-" : `${Number(value) >= 0 ? "+" : ""}${formatNumber(Number(value), 2)}`,
+  },
+  {
+    key: "changePercent",
+    header: "Change %",
+    align: "right" as const,
+    format: (value: unknown) => value == null ? "-" : formatPercentRaw(Number(value)),
+  },
+  { key: "marketState", header: "Session" },
+  {
+    key: "lastUpdated",
+    header: "Updated",
+    format: (value: unknown) => value == null ? "-" : new Date(Number(value)).toISOString(),
+  },
+];
+
+export function projectWorldIndicesHeadless(
+  entries: readonly IndexEntry[],
+  loaded: WorldIndexQuoteResult,
+): HeadlessBundleResult {
+  const grouped = getIndicesByRegion(entries);
+  return {
+    sections: REGION_ORDER.flatMap((region) => {
+      const regionEntries = grouped.get(region) ?? [];
+      if (regionEntries.length === 0) return [];
+      return [{
+        title: REGION_LABELS[region],
+        columns: COLUMNS,
+        rows: regionEntries.map((entry) => {
+          const quote = loaded.quotes.get(entry.symbol);
+          return {
+            ...entry,
+            price: quote?.price ?? null,
+            currency: quote?.currency ?? null,
+            change: quote?.change ?? null,
+            changePercent: quote?.changePercent ?? null,
+            marketState: quote?.marketState ?? null,
+            lastUpdated: quote?.lastUpdated ?? null,
+          };
+        }),
+      }];
+    }),
+    errors: loaded.errors,
+    metadata: {
+      requested: entries.length,
+      available: [...loaded.quotes.values()].filter(Boolean).length,
+    },
+  };
+}
+
+export interface WorldIndicesHeadlessDependencies {
+  load(
+    args: HeadlessPaneLoadArgs,
+    entries: readonly IndexEntry[],
+    provider: DataProvider,
+  ): Promise<WorldIndexQuoteResult>;
+}
+
+const defaultDependencies: WorldIndicesHeadlessDependencies = {
+  load: (_args, entries, provider) => loadWorldIndexQuotes(entries, provider),
+};
+
+export function createWorldIndicesHeadless(
+  dependencies: WorldIndicesHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"bundle"> {
+  return {
+    shape: "bundle",
+    argument: { kind: "none" },
+    options: [],
+    describe: "World Equity Indices",
+    async load(args, ctx) {
+      const loaded = await dependencies.load(args, WORLD_INDICES, ctx.marketData);
+      return projectWorldIndicesHeadless(WORLD_INDICES, loaded);
+    },
+  };
+}
+
+export const worldIndicesHeadless = createWorldIndicesHeadless();

--- a/src/plugins/builtin/world-indices/index.tsx
+++ b/src/plugins/builtin/world-indices/index.tsx
@@ -9,6 +9,7 @@ import { useQuoteBoard } from "../shared/use-quote-board";
 import { WORLD_INDICES, REGION_LABELS, getIndicesByRegion, resolveIndexEntries } from "./indices";
 import { useWorldIndicesFooter } from "./footer";
 import { createPublicPaneShare } from "../shared/public-pane";
+import { worldIndicesHeadless } from "./headless";
 import {
   buildFlatRows,
   DEFAULT_SORT_PREFERENCE,
@@ -22,6 +23,8 @@ import {
   usesSessionText,
   type WorldIndexColumn,
 } from "./table";
+
+export { worldIndicesHeadless } from "./headless";
 
 /** Stable identity: a fresh literal here would remount the board every render. */
 const NO_SAVED_SYMBOLS: string[] = [];
@@ -160,6 +163,7 @@ export const worldIndicesModule: PluginModule = {
       description: "Monitor global equity indices grouped by region.",
       keywords: ["world", "indices", "global", "equity", "markets", "international"],
       shortcut: { prefix: "WEI" },
+      headless: worldIndicesHeadless,
       publicShare: createPublicPaneShare("World Equity Indices"),
     },
   ],

--- a/src/plugins/builtin/yield-curve/headless.test.ts
+++ b/src/plugins/builtin/yield-curve/headless.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createYieldCurveHeadless } from "./headless";
+
+const args: HeadlessPaneLoadArgs = { rawArgument: "", argument: null, symbols: [], options: {} };
+
+describe("yield curve headless model", () => {
+  test("returns ordered maturities and the shared 2Y to 10Y spread", async () => {
+    const headless = createYieldCurveHeadless({
+      load: async () => [
+        { maturity: "10Y", maturityYears: 10, yield: 4.1, asOf: "2026-09-03" },
+        { maturity: "2Y", maturityYears: 2, yield: 4.35, asOf: "2026-09-04" },
+      ],
+    });
+    const result = await headless.load(args, {} as HeadlessPaneContext);
+
+    expect(result.rows.map((row) => row.maturity)).toEqual(["2Y", "10Y"]);
+    expect(result.metadata).toEqual({
+      asOf: "2026-09-04",
+      inverted: true,
+      spread2Y10YBasisPoints: -25,
+    });
+  });
+});

--- a/src/plugins/builtin/yield-curve/headless.ts
+++ b/src/plugins/builtin/yield-curve/headless.ts
@@ -1,0 +1,67 @@
+import type {
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import {
+  curveAsOf,
+  isInverted,
+  loadYieldCurve,
+  parseYieldPoints,
+  spreadBasisPoints,
+  type YieldCurveLoader,
+  type YieldPoint,
+} from "./treasury-data";
+
+const COLUMNS = [
+  { key: "maturity", header: "Maturity" },
+  {
+    key: "maturityYears",
+    header: "Years",
+    align: "right" as const,
+    format: (value: unknown) => Number(value).toFixed(2).replace(/\.00$/, ""),
+  },
+  {
+    key: "yield",
+    header: "Yield",
+    align: "right" as const,
+    format: (value: unknown) => value == null ? "-" : `${Number(value).toFixed(2)}%`,
+  },
+  { key: "asOf", header: "As of" },
+];
+
+export interface YieldCurveHeadlessDependencies {
+  load(args: HeadlessPaneLoadArgs, loader: YieldCurveLoader): Promise<YieldPoint[]>;
+}
+
+const defaultDependencies: YieldCurveHeadlessDependencies = {
+  load: (_args, loader) => loadYieldCurve(loader),
+};
+
+export function createYieldCurveHeadless(
+  dependencies: YieldCurveHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: { kind: "none" },
+    options: [],
+    columns: COLUMNS,
+    describe: "US Treasury Yield Curve",
+    async load(args, ctx) {
+      const points = await dependencies.load(
+        args,
+        () => ctx.apiClient.getCloudYieldCurve(),
+      );
+      const rows = parseYieldPoints(points);
+      return {
+        rows: rows.map((point) => ({ ...point })),
+        metadata: {
+          asOf: curveAsOf(points),
+          inverted: isInverted(points),
+          spread2Y10YBasisPoints: spreadBasisPoints(points),
+        },
+      };
+    },
+  };
+}
+
+export const yieldCurveHeadless = createYieldCurveHeadless();

--- a/src/plugins/builtin/yield-curve/index.tsx
+++ b/src/plugins/builtin/yield-curve/index.tsx
@@ -12,11 +12,15 @@ import {
   loadYieldCurve,
   parseYieldPoints,
   isInverted,
+  spreadBasisPoints,
   TREASURY_MATURITIES,
   type YieldPoint,
 } from "./treasury-data";
 import { usePaneStatusFooter } from "../shared/pane-footer";
 import { useAutoRefresh, useUpdatedAgo } from "../shared/auto-refresh";
+import { yieldCurveHeadless } from "./headless";
+
+export { yieldCurveHeadless } from "./headless";
 
 function formatYield(y: number | null): string {
   if (y == null) return "—";
@@ -25,13 +29,6 @@ function formatYield(y: number | null): string {
 
 function formatYieldAxis(value: number): string {
   return `${value.toFixed(2)}%`;
-}
-
-function spreadBp(points: YieldPoint[]): number | null {
-  const y2 = points.find((p) => p.maturity === "2Y")?.yield;
-  const y10 = points.find((p) => p.maturity === "10Y")?.yield;
-  if (y2 == null || y10 == null) return null;
-  return Math.round((y10 - y2) * 100);
 }
 
 function YieldCurvePane({ focused, width, height }: PaneProps) {
@@ -75,7 +72,7 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
   });
 
   const inverted = isInverted(points);
-  const bp = spreadBp(points);
+  const bp = spreadBasisPoints(points);
   // Treasury series are daily closes, so which session the curve represents is
   // status the user needs; "updated Xm ago" only says when we last fetched it.
   const asOf = curveAsOf(points);
@@ -191,5 +188,6 @@ export const yieldCurveModule: PluginModule = {
     description: "US Treasury yield curve charted from FRED data.",
     keywords: ["yield", "curve", "treasury", "bonds", "rates", "gc", "interest"],
     shortcut: { prefix: "GC" },
+    headless: yieldCurveHeadless,
   }],
 };

--- a/src/plugins/builtin/yield-curve/treasury-data.ts
+++ b/src/plugins/builtin/yield-curve/treasury-data.ts
@@ -20,8 +20,12 @@ export const TREASURY_MATURITIES: Array<{ maturity: string; years: number; serie
   { maturity: "30Y", years: 30,    seriesId: "DGS30" },
 ];
 
-export async function loadYieldCurve(): Promise<YieldPoint[]> {
-  return apiClient.getCloudYieldCurve();
+export type YieldCurveLoader = () => Promise<YieldPoint[]>;
+
+export async function loadYieldCurve(
+  loader: YieldCurveLoader = () => apiClient.getCloudYieldCurve(),
+): Promise<YieldPoint[]> {
+  return loader();
 }
 
 export function parseYieldPoints(points: YieldPoint[]): YieldPoint[] {
@@ -45,8 +49,14 @@ export function curveAsOf(points: readonly YieldPoint[]): string | null {
   return latest;
 }
 
-export function isInverted(points: YieldPoint[]): boolean {
-  const y2 = points.find((p) => p.maturity === "2Y")?.yield;
-  const y10 = points.find((p) => p.maturity === "10Y")?.yield;
-  return y2 != null && y10 != null && y2 > y10;
+export function spreadBasisPoints(points: readonly YieldPoint[]): number | null {
+  const y2 = points.find((point) => point.maturity === "2Y")?.yield;
+  const y10 = points.find((point) => point.maturity === "10Y")?.yield;
+  if (y2 == null || y10 == null) return null;
+  return Math.round((y10 - y2) * 100);
+}
+
+export function isInverted(points: readonly YieldPoint[]): boolean {
+  const spread = spreadBasisPoints(points);
+  return spread != null && spread < 0;
 }


### PR DESCRIPTION
## Why

Macro, rates, and market-state panes need renderer-independent data contracts so `gloomberb fn`, ASKG tools, and the publisher can consume the same facts shown in the terminal.

## What

- Added headless contracts for every requested existing token: `FNG`, `GC`, `CRD`, `VIX`, `WEI`, `AUCT`, `CDS`, `BI`, `EVT`, `HILO`, and `MOST`.
- Kept the catalog's real mappings: `GC` is US Treasury Yield Curve, `WEI` is World Equity Indices, `BI` is Sector Performance, and `EVT` is Corporate Actions.
- Shared pane loaders and derived models for yield spreads, credit OAS, VIX curve state, auction metrics, CDS activity, sector returns, corporate events, scanner filters, and mover rankings.
- Added options for auction history and type, sector or industry collection, HILO price and sort filters, and market-mover list selection.
- Made CDS accept either a ticker or literal issuer, with primary US listing preference when exchanges reuse a ticker.
- Made HILO wait past the connecting snapshot and report degraded feeds as partial data.
- No requested tokens were skipped.

## Live output

Text and `--json` were run for every token on 2026-09-04. Trimmed results:

| Token | Command arguments | Real result |
| --- | --- | --- |
| `FNG` | default | bundle, 14 records, score `41.8571` formatted as `42`, rating `FEAR` |
| `GC` | default | 10 maturities; 1M `3.83%`, 10Y `4.77%`, 2Y to 10Y spread `+43bp` |
| `CRD` | default | 6 rows; US IG OAS `81.0bp`, 1D `0.0bp`, as of `2026-09-03` |
| `VIX` | default | bundle, state `normal`, 3M/30D `1.22`, spread `+3.10 pts` |
| `WEI` | default | 19 rows requested, 15 available; COMP `26,506.99`, `-0.29%`; four unavailable quotes reported as partial errors |
| `AUCT` | `--history 30 --filter note` | 8 notes; 7Y `4.512%`, B/C `2.50`, indirect `53.7%`, size `$49.66B` |
| `CDS` | `ORCL` | 30 Oracle Corporation trades; first row notional `$3M`, coupon `100bp`, upfront `+$145.37K USD` |
| `BI` | `--collection industries` | 18 rows; Semiconductors/SMH `565.79`, 1D `+2.39%`, 1Y `+97.53%` |
| `EVT` | `AAPL` | 30 rows; next-year FY estimate EPS `9.53289`, revenue `525248157290`, growth `+8.17%` |
| `HILO` | `--min-price 5 --sort count` | snapshot received; after-hours feed was degraded with zero extremes and returned `complete: false` plus `Scanner feed degraded` |
| `MOST` | `--list gainers` | 25 rows; BLTE rank 1 at `193.61`, change `+13.16%`, 52-week position `95.27%` |

`catalog --json --all` reports all 11 capabilities as `ready`, with `bundle`, `rows`, or `snapshot` output and the declared options.

## Verify

- `bun test` across the 11 affected plugin directories: 149 passed.
- Focused headless, CDS client, and pane-function suite after rebasing: 64 passed.
- `bun run typecheck`: all OpenTUI, Electrobun, browser, Cloudflare, and scripts targets passed.
- Full terminal smoke in named tmux session: opened FNG and AUCT together, confirmed score and auction facts rendered, scanned for React/runtime warnings, killed the session, and completed the process leak sweep.
