### PR TITLE
Open company research before signup and improve the Pro journey

### DIFF
--- a/src/api-client/auth.ts
+++ b/src/api-client/auth.ts
@@ -1,3 +1,4 @@
+import { getCurrentPluginTarget } from "../plugins/current-target";
 import { ApiRequestError, isHardSessionInvalidMessage } from "./errors";
 import type {
   AccountProfile,
@@ -151,7 +152,7 @@ export class CloudAuthApi {
   async sendVerification(): Promise<CloudVerificationResponse> {
     return this.options.request<CloudVerificationResponse>("/cloud/auth/send-verification", {
       method: "POST",
-      body: JSON.stringify({}),
+      body: JSON.stringify({ returnTo: getCurrentPluginTarget() === "web" ? location.href : undefined }),
     });
   }
 

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -362,8 +362,16 @@ class GloomApiClient {
   }
 
   /** Creates a Stripe checkout session for Cloud Pro; the URL opens in a browser. */
-  async createCloudCheckout(): Promise<{ url: string }> {
-    return this.request<{ url: string }>("/stripe/checkout", { method: "POST", body: JSON.stringify({}) });
+  async createCloudCheckout(returnTo?: string): Promise<{ url: string }> {
+    return this.request<{ url: string }>("/stripe/checkout", { method: "POST", body: JSON.stringify({ returnTo }) });
+  }
+
+  async recordResearchActivity(payload: {
+    event: import("./research-activity").ResearchActivity; eventId: string;
+    surface: "web" | "desktop" | "tui" | "cli"; anonymousId?: string;
+    attribution?: Record<string, string>; feature?: import("./research-activity").ResearchFeature;
+  }): Promise<void> {
+    await this.request("/activity/research", { method: "POST", body: JSON.stringify(payload) });
   }
 
   /** Stores a verified user's public terminal snapshot or pane handoff. */

--- a/src/api-client/research-activity.ts
+++ b/src/api-client/research-activity.ts
@@ -16,10 +16,17 @@ export function initializeBrowserResearchActivity(): void {
     const stored = localStorage.getItem("gloomberb.web.anonymous-id");
     anonymousId = [incoming, stored].find((value) => value && /^[a-f0-9-]{36}$/.test(value)) ?? crypto.randomUUID();
     localStorage.setItem("gloomberb.web.anonymous-id", anonymousId);
-    attribution = JSON.parse(localStorage.getItem("gloomberb.web.attribution") ?? "{}");
-    for (const key of ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term", "twclid"]) {
-      const value = url.searchParams.get(key);
-      if (value) attribution[key] = value.slice(0, 300);
+    const keys = ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term", "twclid"];
+    const saved = JSON.parse(localStorage.getItem("gloomberb.web.attribution") ?? "{}");
+    const age = Date.now() - Date.parse(saved?.last_touch_at ?? "");
+    attribution = Number.isFinite(age) && age >= 0 && age < 30 * 24 * 60 * 60 * 1000 ? saved : {};
+    if (keys.some((key) => url.searchParams.has(key))) {
+      // A new campaign replaces the old click id instead of inheriting it.
+      attribution = { last_touch_at: new Date().toISOString() };
+      for (const key of keys) {
+        const value = url.searchParams.get(key);
+        if (value) attribution[key] = value.slice(0, 300);
+      }
     }
     localStorage.setItem("gloomberb.web.attribution", JSON.stringify(attribution));
     url.searchParams.delete("_gloom");

--- a/src/api-client/research-activity.ts
+++ b/src/api-client/research-activity.ts
@@ -1,0 +1,54 @@
+import { apiClient } from "./index";
+import { getCurrentPluginTarget } from "../plugins/current-target";
+
+export type ResearchActivity = "workspace_opened" | "research_viewed" | "ticker_saved" | "pro_feature_used" | "upgrade_intent";
+export type ResearchFeature = "overview" | "chart" | "financials" | "news" | "transcripts" | "search" | "research";
+const sent = new Set<string>();
+let anonymousId: string | undefined;
+let attribution: Record<string, string> = {};
+
+/** Hosted web analytics only. Native local use never creates an identifier. */
+export function initializeBrowserResearchActivity(): void {
+  try {
+    if (navigator.doNotTrack === "1" || (navigator as Navigator & { globalPrivacyControl?: boolean }).globalPrivacyControl) return;
+    const url = new URL(location.href);
+    const incoming = url.searchParams.get("_gloom");
+    const stored = localStorage.getItem("gloomberb.web.anonymous-id");
+    anonymousId = [incoming, stored].find((value) => value && /^[a-f0-9-]{36}$/.test(value)) ?? crypto.randomUUID();
+    localStorage.setItem("gloomberb.web.anonymous-id", anonymousId);
+    attribution = JSON.parse(localStorage.getItem("gloomberb.web.attribution") ?? "{}");
+    for (const key of ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term", "twclid"]) {
+      const value = url.searchParams.get(key);
+      if (value) attribution[key] = value.slice(0, 300);
+    }
+    localStorage.setItem("gloomberb.web.attribution", JSON.stringify(attribution));
+    url.searchParams.delete("_gloom");
+    history.replaceState(history.state, "", url.href);
+  } catch { /* Private browsing must still work. */ }
+}
+
+/** Counts milestones once per feature/session/account, never their content. */
+export function recordResearchActivity(event: ResearchActivity, feature?: ResearchFeature): void {
+  const target = getCurrentPluginTarget();
+  const user = apiClient.getCurrentUser();
+  if (target === "web" ? !anonymousId : !user) return;
+  const key = `${user?.id ?? "guest"}:${event}:${feature ?? ""}`;
+  if (sent.has(key)) return;
+  sent.add(key);
+  if (event !== "workspace_opened") recordResearchActivity("workspace_opened");
+  void apiClient.recordResearchActivity({ event, eventId: crypto.randomUUID(),
+    surface: target === "desktop" ? "desktop" : target,
+    anonymousId: target === "web" ? anonymousId : undefined,
+    attribution: target === "web" ? attribution : undefined, feature,
+  }).catch(() => { sent.delete(key); });
+}
+
+export function researchUpgradeUrl(returnTo?: string): string {
+  const url = new URL("https://gloom.sh/cloud?upgrade=pro");
+  if (returnTo) url.searchParams.set("returnTo", returnTo);
+  if (anonymousId) url.searchParams.set("_gloom", anonymousId);
+  for (const [key, value] of Object.entries(attribution)) {
+    if (/^(utm_(source|medium|campaign|content|term)|twclid)$/.test(key)) url.searchParams.set(key, value);
+  }
+  return url.href;
+}

--- a/src/components/command-bar/surface/assist.test.tsx
+++ b/src/components/command-bar/surface/assist.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { apiClient, setCloudApiFetchTransport } from "../../../api-client";
 import { testRender } from "../../../renderers/opentui/test-utils";
 import type { PluginRegistry } from "../../../plugins/registry";
@@ -11,6 +11,18 @@ import {
 } from "./test-harness";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+const originalWebSocket = globalThis.WebSocket;
+
+beforeEach(() => {
+  apiClient.dispose();
+  // The header subscribes to SPY. A real socket rejects this test's fake token
+  // and can mark the account unverified before the assist debounce completes.
+  globalThis.WebSocket = class {
+    static readonly OPEN = 1;
+    readyState = 0;
+    close() { this.readyState = 3; }
+  } as unknown as typeof WebSocket;
+});
 
 afterEach(() => {
   setCloudApiFetchTransport(null);
@@ -19,6 +31,8 @@ afterEach(() => {
     testSetup.renderer.destroy();
     testSetup = undefined;
   }
+  apiClient.dispose();
+  globalThis.WebSocket = originalWebSocket;
 });
 
 const { waitForFrameToContain } = createCommandBarTestControls(() => testSetup!);

--- a/src/components/command-bar/surface/test-harness.tsx
+++ b/src/components/command-bar/surface/test-harness.tsx
@@ -54,8 +54,9 @@ export async function settleFrame(
 ): Promise<void> {
   await act(async () => {
     await Bun.sleep(delayMs);
-    await renderer.renderOnce();
   });
+  // Paint after React has committed the updates collected by act.
+  await renderer.renderOnce();
 }
 
 export function createCommandBarTestControls(
@@ -70,7 +71,7 @@ export function createCommandBarTestControls(
       }
       await settleFrame(renderer, delayMs);
     }
-    throw new Error(`Timed out waiting for frame to contain "${text}".`);
+    throw new Error(`Timed out waiting for frame to contain "${text}".\n${renderer.captureCharFrame()}`);
   };
 
   const clickFrameText = async (text: string): Promise<void> => {

--- a/src/components/onboarding/account-step/chooser-panel.tsx
+++ b/src/components/onboarding/account-step/chooser-panel.tsx
@@ -19,8 +19,8 @@ export function AccountChooserPanel({
   const choices = useMemo<ListViewItem[]>(() => [
     {
       id: "qr",
-      label: t("Scan QR with the mobile app"),
-      description: t("Approve from your phone, no typing"),
+      label: t("Continue in browser"),
+      description: t("Sign in securely, or scan with your phone"),
     },
     {
       id: "signup",

--- a/src/components/onboarding/account-step/qr-panel.tsx
+++ b/src/components/onboarding/account-step/qr-panel.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Box, Text, TextAttributes } from "../../../ui";
-import { colors } from "../../../theme/colors";
-import { t } from "../../../i18n";
+import { Box } from "../../../ui";
 import { useAppLanguage } from "../../../i18n/react";
 import { useShortcut } from "../../../react/input";
 import { isPlainKey } from "../../../utils/keyboard";
@@ -56,13 +54,7 @@ export function AccountQrPanel({
 
   return (
     <Box flexDirection="column" paddingX={2}>
-      <Box height={1}>
-        <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-          {t("Continue in your browser or scan the code")}
-        </Text>
-      </Box>
-      <Box height={1} />
-      <DeviceSignInPanel snapshot={snapshot} height={Math.max(4, height - 2)} />
+      <DeviceSignInPanel snapshot={snapshot} height={height} />
     </Box>
   );
 }

--- a/src/components/onboarding/account-step/qr-panel.tsx
+++ b/src/components/onboarding/account-step/qr-panel.tsx
@@ -58,7 +58,7 @@ export function AccountQrPanel({
     <Box flexDirection="column" paddingX={2}>
       <Box height={1}>
         <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-          {t("Scan with the Gloom app to sign in")}
+          {t("Continue in your browser or scan the code")}
         </Text>
       </Box>
       <Box height={1} />

--- a/src/components/onboarding/onboarding-wizard.test.tsx
+++ b/src/components/onboarding/onboarding-wizard.test.tsx
@@ -63,6 +63,7 @@ function createPluginRegistry(options: {
     tickerRepository: options.tickerRepository ?? createTickerRepository(),
     persistence: { resources: undefined },
     openCommandBar: () => {},
+    pinTicker: () => {},
   } as unknown as PluginRegistry;
 }
 
@@ -265,7 +266,7 @@ describe("OnboardingWizard", () => {
     expect(capturedConfig?.onboardingProgress?.stage).toBe("add-ticker");
   });
 
-  test("advances directly to Cloud after the expected AP save", async () => {
+  test("opens research before Cloud after the expected AP save", async () => {
     tempDataDir = await mkdtemp(join(tmpdir(), "gloomberb-onboarding-actions-"));
     const pluginRegistry = createPluginRegistry();
     const config = {
@@ -300,12 +301,12 @@ describe("OnboardingWizard", () => {
       await Bun.sleep(0);
       await testSetup!.renderOnce();
     });
-    const frame = await waitForFrame("Sign up free");
-    expect(frame).toContain("Sign up free");
-    expect(capturedConfig?.onboardingProgress?.stage).toBe("account");
+    const frame = await waitForFrame("Connect free Cloud");
+    expect(frame).toContain("Connect free Cloud");
+    expect(capturedConfig?.onboardingProgress?.stage).toBe("research");
   });
 
-  test("imports a broker portfolio before moving to Cloud", async () => {
+  test("imports a broker portfolio before opening research", async () => {
     tempDataDir = await mkdtemp(join(tmpdir(), "gloomberb-onboarding-broker-"));
     const tickerRepository = createTickerRepository();
     const broker: BrokerAdapter = {
@@ -348,10 +349,10 @@ describe("OnboardingWizard", () => {
     await waitForFrame("Connect Demo Broker");
     await emitKeypress({ name: "return", sequence: "\r" });
 
-    const frame = await waitForFrame("Sign up free");
-    expect(frame).toContain("Sign up free");
+    const frame = await waitForFrame("Connect free Cloud");
+    expect(frame).toContain("Connect free Cloud");
     expect(capturedConfig?.onboardingProgress).toMatchObject({
-      stage: "account",
+      stage: "research",
       path: "broker",
       tickerSymbol: "AAPL",
       brokerName: "Demo Broker",
@@ -511,9 +512,9 @@ describe("OnboardingWizard", () => {
       await testSetup!.renderOnce();
     });
 
-    await waitForFrame("Sign up free");
+    await waitForFrame("Connect free Cloud");
     expect((await tickerRepository.loadAllTickers()).map((ticker) => ticker.metadata.ticker).sort()).toEqual(["AAPL", "MSFT"]);
-    expect(capturedConfig?.onboardingProgress?.stage).toBe("account");
+    expect(capturedConfig?.onboardingProgress?.stage).toBe("research");
   });
 
   test("keeps Skip locked until broker onboarding finalization completes", async () => {
@@ -590,9 +591,34 @@ describe("OnboardingWizard", () => {
       await testSetup!.renderOnce();
     });
 
-    await waitForFrame("Sign up free");
+    await waitForFrame("Connect free Cloud");
     expect(completionCount).toBe(0);
-    expect(capturedConfig?.onboardingProgress?.stage).toBe("account");
+    expect(capturedConfig?.onboardingProgress?.stage).toBe("research");
+  });
+
+  test("waits for email verification before offering Pro", async () => {
+    tempDataDir = await mkdtemp(join(tmpdir(), "gloomberb-onboarding-verify-"));
+    const originalGetSession = apiClient.getSession;
+    let resolveSession!: (user: Awaited<ReturnType<typeof apiClient.getSession>>) => void;
+    apiClient.getSession = () => new Promise((resolve) => { resolveSession = resolve; });
+    try {
+      testSetup = await testRender(<WizardHarness config={{
+        ...createDefaultConfig(tempDataDir),
+        onboardingProgress: { version: 1, stage: "verify", accountStatus: "signed-in" },
+      }} pluginRegistry={createPluginRegistry()} />, { width: 100, height: 30 });
+      await testSetup.renderOnce();
+      expect(testSetup.captureCharFrame()).toContain("Check your email");
+      expect(capturedConfig?.onboardingProgress?.stage).toBe("verify");
+      apiClient.setSessionToken("verification-test-session");
+      apiClient.restoreCachedUser({ id: "verified-user", email: "research@example.com", emailVerified: true, plan: "free" });
+      await act(async () => {
+        resolveSession(apiClient.getCurrentUser());
+        await Bun.sleep(0);
+        await testSetup!.renderOnce();
+      });
+      await waitForFrame("Start 7-day free trial");
+      expect(capturedConfig?.onboardingProgress?.stage).toBe("upgrade");
+    } finally { apiClient.getSession = originalGetSession; }
   });
 
   test("loads the current Cloud price on the Pro step", async () => {

--- a/src/components/onboarding/onboarding-wizard.test.tsx
+++ b/src/components/onboarding/onboarding-wizard.test.tsx
@@ -63,7 +63,7 @@ function createPluginRegistry(options: {
     tickerRepository: options.tickerRepository ?? createTickerRepository(),
     persistence: { resources: undefined },
     openCommandBar: () => {},
-    pinTicker: () => {},
+    navigateTicker: () => {},
   } as unknown as PluginRegistry;
 }
 

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -5,6 +5,8 @@ import {
   useRef,
   useState,
 } from "react";
+import { CloudVerificationPanel } from "../../plugins/builtin/cloud/verification-panel";
+import { recordResearchActivity } from "../../api-client/research-activity";
 import { apiClient, type CloudPricing } from "../../api-client";
 import type { AppBrokerImportRuntime } from "../../app/runtime/broker-import";
 import type { SyncBrokerInstanceResult } from "../../brokers/sync-broker-instance";
@@ -72,6 +74,7 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
   const stage = progress.stage;
   const [persistenceError, setPersistenceError] = useState<string | null>(null);
   const [isFinishing, setIsFinishing] = useState(false);
+  const researchOpenedRef = useRef<string | null>(null);
   const [pricing, setPricing] = useState<CloudPricing | null>(null);
 
   const [portfolioSub, setPortfolioSub] = useState<PortfolioSub>("choose");
@@ -92,7 +95,7 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
   const portfolioChoices = useMemo<ListViewItem[]>(() => [
     {
       id: "manual",
-      label: t("Create a manual portfolio"),
+      label: t("Research a company"),
       description: t("Add one company with the command bar"),
       detail: t("Recommended"),
     },
@@ -148,7 +151,7 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
 
   const account = useOnboardingAccount({
     nextStep: () => {
-      saveProgressInBackground({ stage: "upgrade", accountStatus: "signed-in" });
+      saveProgressInBackground({ stage: apiClient.getCurrentUser()?.emailVerified ? "upgrade" : "verify", accountStatus: "signed-in" });
     },
     setEditingField,
   });
@@ -163,7 +166,7 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
       ?? result.updatedTickers[0]?.metadata.ticker;
     const brokerName = brokerOptions.find((option) => option.id === selectedBrokerId)?.name;
     const nextConfig = withOnboardingProgress(syncedConfig, {
-      stage: tickerSymbol ? "account" : "add-ticker",
+      stage: tickerSymbol ? "research" : "add-ticker",
       path: "broker",
       portfolioId: tickerSymbol ? (result.portfolioIds[0] ?? "main") : "main",
       tickerSymbol,
@@ -248,13 +251,20 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
       const current = getOnboardingProgress(stateRef.current.config);
       if (current.stage !== "add-ticker" || portfolioId !== current.portfolioId) return;
       saveProgressInBackground({
-        stage: "account",
+        stage: "research",
         path: current.path,
         portfolioId,
         tickerSymbol: symbol,
       });
     },
   ), [pluginRegistry.events, saveProgressInBackground, stateRef]);
+
+  useEffect(() => {
+    if (stage !== "research" || !progress.tickerSymbol || researchOpenedRef.current === progress.tickerSymbol) return;
+    researchOpenedRef.current = progress.tickerSymbol;
+    pluginRegistry.pinTicker(progress.tickerSymbol, { floating: false });
+    recordResearchActivity("ticker_saved");
+  }, [stage, progress.tickerSymbol, pluginRegistry]);
 
   useEffect(() => {
     if (stage !== "upgrade" || pricing) return;
@@ -584,6 +594,11 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
       }
       return;
     }
+    if (stage === "research" && enter) {
+      consume();
+      saveProgressInBackground({ stage: "account" });
+      return;
+    }
     if (stage === "account") {
       if (enter) {
         consume();
@@ -630,6 +645,26 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
     return null;
   }
 
+  if (stage === "research") {
+    return <OnboardingCoach step={t("YOUR FIRST RESEARCH WORKSPACE")}
+      title={tf("Explore {ticker}", { ticker: progress.tickerSymbol ?? "your company" })}
+      actions={<><OnboardingButton label="Keep exploring" variant="ghost" onPress={() => { void finish(); }} />
+        <OnboardingButton label="Connect free Cloud" variant="primary" onPress={() => saveProgressInBackground({ stage: "account" })} /></>}>
+      <Text fg={colors.textDim} wrapText>{t("Your company is saved. Explore the chart and financials now. Connect Cloud when you're ready for synced layouts, news and Pro research.")}</Text>
+    </OnboardingCoach>;
+  }
+
+  if (stage === "verify") {
+    return <OnboardingModal width={66} height={14}>
+      <OnboardingTitle step={t("CONNECT CLOUD")} title={t("Check your email")}
+        description={apiClient.getCurrentUser()?.email ?? account.accountEmail} />
+      <CloudVerificationPanel onVerified={() => {
+        void chatController.refreshSession();
+        saveProgressInBackground({ stage: "upgrade", accountStatus: "signed-in" });
+      }} onContinueFree={() => { void finish(); }} />
+    </OnboardingModal>;
+  }
+
   if (stage === "add-ticker") {
     return (
       <OnboardingCoach
@@ -664,7 +699,7 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
         <OnboardingTitle
           step={t("WELCOME")}
           title={t("Make Gloomberb yours")}
-          description={t("Build a real portfolio in the workspace, add one company you follow, then choose whether to connect Gloom Cloud.")}
+          description={t("Pick a company. Explore its chart and financials. Keep your workspace free, or add Pro research when you need it.")}
         />
         {persistenceError ? (
           <Text fg={colors.negative} wrapText style={desktop ? { marginTop: 10 } : undefined}>
@@ -673,7 +708,7 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
         ) : null}
         <OnboardingActions>
           <OnboardingButton
-            label="Start with my portfolio"
+            label="Research my first company"
             variant="primary"
             onPress={() => saveProgressInBackground({ stage: "portfolio" })}
           />
@@ -887,7 +922,7 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
           ) : undefined}
           description={planAccess.hasProAccess
             ? t("This account already has real-time Cloud data.")
-            : t("Limited founding offer. Start a free 7-day trial.")}
+            : t("7 days free, then the price above. Card required. Cancel anytime.")}
         />
         <Box flexDirection="column" style={desktop ? { marginTop: 14, gap: 8 } : undefined}>
           <OnboardingFeature
@@ -899,8 +934,8 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
             description={t("Free: 12h delayed. Pro: real-time.")}
           />
           <OnboardingFeature
-            title={t("Pro research tools")}
-            description={t("More tools for company, market and portfolio research.")}
+            title={t("Earnings transcripts and instant search")}
+            description={t("Read calls. Search transcripts, news and filings. Ask Gloomberb AI coming soon.")}
           />
         </Box>
         {persistenceError ? (

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -262,7 +262,7 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
   useEffect(() => {
     if (stage !== "research" || !progress.tickerSymbol || researchOpenedRef.current === progress.tickerSymbol) return;
     researchOpenedRef.current = progress.tickerSymbol;
-    pluginRegistry.pinTicker(progress.tickerSymbol, { floating: false });
+    pluginRegistry.navigateTicker(progress.tickerSymbol, { sourcePaneId: "ticker-detail:main" });
     recordResearchActivity("ticker_saved");
   }, [stage, progress.tickerSymbol, pluginRegistry]);
 
@@ -449,7 +449,7 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
     // The QR panel owns enter (retry after a denial); approval advances itself.
     if (account.accountSub === "qr") return;
     if (account.accountSub === "signed-in") {
-      saveProgressInBackground({ stage: "upgrade", accountStatus: "signed-in" });
+      saveProgressInBackground({ stage: apiClient.getCurrentUser()?.emailVerified ? "upgrade" : "verify", accountStatus: "signed-in" });
       return;
     }
     if (account.accountSubmitError?.kind === "switch-to-login") {

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -806,14 +806,14 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
       : account.accountSub === "login"
         ? t("Log in")
         : account.accountSub === "qr"
-          ? t("Scan with the Gloom app")
+          ? t("Continue in browser")
           : account.accountSub === "signed-in"
             ? t("Connected")
             : t("Sync across apps");
     const accountDescription = account.accountSub === "choose"
-      ? t("Adds quotes, financials, options, research, news, chat and AI commands.")
+      ? t("Sync your layouts. Search calls, news and filings.")
       : account.accountSub === "qr"
-        ? t("Open the Gloom app on your phone and approve this workspace.")
+        ? t("Open the sign-in link, or scan the code with your phone.")
         : account.accountSub === "signup"
         ? t("Create the free account now. Cloud features unlock after you verify your email.")
         : account.accountSub === "login"
@@ -826,7 +826,7 @@ export function OnboardingWizard({ pluginRegistry, importBrokerPositions, onComp
     // The QR grid is the tallest thing this wizard ever shows; DeviceSignInPanel
     // degrades to the code plus URL when the terminal cannot give it these rows.
     const accountModalHeight = account.accountSub === "choose"
-      ? 17
+      ? 21
       : account.accountSub === "qr"
         ? 32
         : account.accountSub === "signed-in"

--- a/src/data/config/store/normalize.ts
+++ b/src/data/config/store/normalize.ts
@@ -130,6 +130,8 @@ const ONBOARDING_STAGES = new Set<OnboardingProgress["stage"]>([
   "welcome",
   "portfolio",
   "add-ticker",
+  "research",
+  "verify",
   "account",
   "upgrade",
   "ready",

--- a/src/plugins/builtin/cloud/auth-dialog.tsx
+++ b/src/plugins/builtin/cloud/auth-dialog.tsx
@@ -12,6 +12,7 @@ import { useAppLanguage } from "../../../i18n/react";
 import { useDialog, type PromptContext } from "../../../ui/dialog";
 import { AuthForm, authFormTitle } from "./auth-form";
 import type { AccountMode } from "./auth-model";
+import { CloudVerificationPanel } from "./verification-panel";
 
 export function AuthDialog({
   initialMode,
@@ -20,13 +21,18 @@ export function AuthDialog({
 }: PromptContext<AuthUser | undefined> & { initialMode: AccountMode }) {
   useAppLanguage();
   const [mode, setMode] = useState<AccountMode>(initialMode);
+  const [verifyingUser, setVerifyingUser] = useState<AuthUser | null>(null);
+
+  if (verifyingUser) return <DialogFrame title={`Confirm ${verifyingUser.email}`}>
+    <CloudVerificationPanel onVerified={resolve} onContinueFree={() => resolve(verifyingUser)} />
+  </DialogFrame>;
 
   return (
     <DialogFrame title={authFormTitle(mode)}>
       <AuthForm
         initialMode={initialMode}
         onModeChange={setMode}
-        onSignedIn={resolve}
+        onSignedIn={(user) => user.emailVerified ? resolve(user) : setVerifyingUser(user)}
         onEscape={dismiss}
       />
     </DialogFrame>

--- a/src/plugins/builtin/cloud/device-signin-dialog.tsx
+++ b/src/plugins/builtin/cloud/device-signin-dialog.tsx
@@ -75,10 +75,11 @@ export function DeviceSignInPanel({
     void renderer.openExternal(snapshot.verificationUri).catch(() => {});
   }, { scope: "device-signin:browser", phase: "before" });
 
-  // Minimal QR layout: the code grid, one code row, and the status row.
-  const showQr = qrLines.length > 0 && height >= qrLines.length + 2;
-  const spacious = showQr && height >= qrLines.length + 8;
-  const showUrl = !!snapshot.verificationUri && (!showQr || height >= qrLines.length + 4);
+  // Reserve the browser button before fitting the QR, code, and status.
+  const contentHeight = height - (snapshot.verificationUri ? 2 : 0);
+  const showQr = qrLines.length > 0 && contentHeight >= qrLines.length + 2;
+  const spacious = showQr && contentHeight >= qrLines.length + 8;
+  const showUrl = !!snapshot.verificationUri && (!showQr || contentHeight >= qrLines.length + 4);
 
   return (
     <Box flexDirection="column" alignItems="center">
@@ -140,7 +141,7 @@ export function DeviceSignInPanel({
           {spacious && <Box height={1} />}
           <Box height={1}>
             <Text fg={colors.textMuted}>
-              {tf("No app? {url}", { url: snapshot.verificationUri ?? "" })}
+              {snapshot.verificationUri ?? ""}
             </Text>
           </Box>
         </>

--- a/src/plugins/builtin/cloud/device-signin-dialog.tsx
+++ b/src/plugins/builtin/cloud/device-signin-dialog.tsx
@@ -8,9 +8,10 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { AuthUser } from "../../../api-client";
 import { t, tf } from "../../../i18n";
 import { useAppLanguage } from "../../../i18n/react";
-import { useViewport } from "../../../react/input";
+import { useShortcut, useViewport } from "../../../react/input";
 import { colors } from "../../../theme/colors";
-import { Box, Text, TextAttributes, useUiHost } from "../../../ui";
+import { Box, Text, TextAttributes, useUiHost, useRendererHost } from "../../../ui";
+import { Button } from "../../../components/ui/button";
 import { renderAsciiText } from "../../../ui/ascii-font";
 import { useDialog, useDialogKeyboard, type PromptContext } from "../../../ui/dialog";
 import { renderQrLines, renderQrSvgDataUri } from "../../../ui/qr";
@@ -55,6 +56,7 @@ export function DeviceSignInPanel({
   height: number;
 }) {
   useAppLanguage();
+  const renderer = useRendererHost();
   const desktop = useUiHost().kind === "desktop-web";
   // Cell lines still drive layout on desktop: they give the code its row/column
   // footprint, but the pixels come from the SVG below.
@@ -67,6 +69,11 @@ export function DeviceSignInPanel({
     [desktop, snapshot.verificationUri],
   );
   const status = deviceSignInStatus(snapshot);
+  useShortcut((event) => {
+    if (!isPlainKey(event, "b") || !snapshot.verificationUri) return;
+    event.preventDefault(); event.stopPropagation();
+    void renderer.openExternal(snapshot.verificationUri).catch(() => {});
+  }, { scope: "device-signin:browser", phase: "before" });
 
   // Minimal QR layout: the code grid, one code row, and the status row.
   const showQr = qrLines.length > 0 && height >= qrLines.length + 2;
@@ -75,6 +82,11 @@ export function DeviceSignInPanel({
 
   return (
     <Box flexDirection="column" alignItems="center">
+      {snapshot.verificationUri && <Box height={2}>
+        <Button label="Continue in browser" shortcut="b" variant="primary" onPress={() => {
+          void renderer.openExternal(snapshot.verificationUri!).catch(() => {});
+        }} />
+      </Box>}
       {showQr && (qrImage
         ? (
           <Box
@@ -184,7 +196,7 @@ export function DeviceSignInDialog({ resolve, dismiss }: PromptContext<AuthUser 
     <Box flexDirection="column" alignItems="center">
       <Box height={1}>
         <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>
-          {t("Scan with the Gloom app to sign in")}
+          {t("Sign in through your browser or scan the code")}
         </Text>
       </Box>
       <Box height={1} />

--- a/src/plugins/builtin/cloud/verification-panel.tsx
+++ b/src/plugins/builtin/cloud/verification-panel.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { apiClient, type AuthUser } from "../../../api-client";
+import { Button } from "../../../components/ui/button";
+import { useShortcut } from "../../../react/input";
+import { Box, Text } from "../../../ui";
+import { colors } from "../../../theme/colors";
+
+/** Shared continuation after email signup in the terminal and browser. */
+export function CloudVerificationPanel({ onVerified, onContinueFree }: {
+  onVerified: (user: AuthUser) => void;
+  onContinueFree: () => void;
+}) {
+  const [status, setStatus] = useState("Check your inbox and spam folder. This page continues automatically.");
+  const [sending, setSending] = useState(false);
+  const [cooldown, setCooldown] = useState(false);
+  const completed = useRef(false);
+  const callback = useRef(onVerified);
+  callback.current = onVerified;
+  const check = useCallback(async () => {
+    try {
+      const user = await apiClient.getSession();
+      if (user?.emailVerified && !completed.current) {
+        completed.current = true;
+        callback.current(user);
+      }
+    } catch { setStatus("Connection interrupted. Check again when you're online."); }
+  }, []);
+  useEffect(() => {
+    void check();
+    const timer = setInterval(() => { void check(); }, 5000);
+    return () => clearInterval(timer);
+  }, [check]);
+  useEffect(() => {
+    if (!cooldown) return;
+    const timer = setTimeout(() => setCooldown(false), 60_000);
+    return () => clearTimeout(timer);
+  }, [cooldown]);
+  useShortcut((event) => {
+    if (event.name !== "enter" && event.name !== "return") return;
+    event.preventDefault(); event.stopPropagation(); void check();
+  }, { scope: "cloud-email-verification" });
+  return <Box flexDirection="column" gap={1}>
+    <Text fg={colors.textDim} wrapText>{status}</Text>
+    <Box flexDirection="row" gap={1}>
+      <Button label="I've confirmed" variant="primary" onPress={() => { void check(); }} />
+      <Button label={cooldown ? "Email sent" : "Resend email"} disabled={sending || cooldown} onPress={() => {
+        setSending(true);
+        void apiClient.sendVerification().then(() => {
+          setCooldown(true); setStatus("Confirmation link sent. Check your inbox and spam folder.");
+        }).catch((error) => setStatus(error instanceof Error ? error.message : "Couldn't send email. Try again."))
+          .finally(() => setSending(false));
+      }} />
+    </Box>
+    <Button label="Keep using the terminal" variant="ghost" onPress={onContinueFree} />
+  </Box>;
+}

--- a/src/plugins/builtin/earnings-calls/pane.tsx
+++ b/src/plugins/builtin/earnings-calls/pane.tsx
@@ -1,3 +1,4 @@
+import { recordResearchActivity } from "../../../api-client/research-activity";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Button,
@@ -167,6 +168,9 @@ export function EarningsCallsPane({ focused, width, height }: EarningsCallsViewP
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const [transcript, setTranscript] = useState<CloudEarningsTranscriptPayload | null>(null);
+  useEffect(() => {
+    if (focused && transcript && detailOpen) recordResearchActivity("pro_feature_used", "transcripts");
+  }, [focused, transcript, detailOpen]);
   const [transcriptLoading, setTranscriptLoading] = useState(false);
   const [transcriptError, setTranscriptError] = useState<{
     message: string;

--- a/src/plugins/builtin/research-search/pane.tsx
+++ b/src/plugins/builtin/research-search/pane.tsx
@@ -1,3 +1,4 @@
+import { recordResearchActivity } from "../../../api-client/research-activity";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Button,
@@ -416,6 +417,9 @@ export function ResearchSearchPane({ focused, paneId, width, height }: PaneProps
   // Search is free and uncapped, so nothing is gated up front: the upsell only
   // appears if the server itself refuses the query.
   const proRequired = failure?.status === 402;
+  useEffect(() => {
+    if (focused && status === "loaded") recordResearchActivity("research_viewed", "search");
+  }, [focused, status]);
   const signInRequired = !access.signedIn || failure?.status === 401 || savedFailure?.status === 401;
   const verificationRequired = !signInRequired
     && (!access.emailVerified || failure?.status === 403);

--- a/src/plugins/builtin/shared/cloud-upgrade.ts
+++ b/src/plugins/builtin/shared/cloud-upgrade.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { apiClient } from "../../../api-client";
+import { recordResearchActivity, researchUpgradeUrl } from "../../../api-client/research-activity";
+import { getCurrentPluginTarget } from "../../current-target";
 import type { PaneFooterSegment } from "../../../components";
 import { tf } from "../../../i18n";
 import { useAppLanguage } from "../../../i18n/react";
@@ -25,10 +27,12 @@ let cloudUpgradeOpener: (() => void) | null = null;
  * already hold. Both URLs are account-bound, so no session handoff is needed.
  */
 export async function resolveCloudUpgradeUrl(): Promise<string> {
-  if (!apiClient.isSignedIn()) return CLOUD_UPGRADE_URL;
+  recordResearchActivity("upgrade_intent");
+  const returnTo = getCurrentPluginTarget() === "web" ? window.location.href : undefined;
+  if (!apiClient.isSignedIn() || !apiClient.getCurrentUser()?.emailVerified) return researchUpgradeUrl(returnTo);
   const { url } = resolvePlanAccess(apiClient.getCurrentUser()).hasProAccess
     ? await apiClient.createBillingPortal()
-    : await apiClient.createCloudCheckout();
+    : await apiClient.createCloudCheckout(returnTo);
   return url;
 }
 
@@ -142,8 +146,8 @@ export function useCloudAccessFooter({
       onPress: openUpgrade,
       parts: [{
         text: shortcutScope
-          ? tf("{delay} delayed · u upgrade", { delay: delayLabel })
-          : tf("{delay} delayed · upgrade", { delay: delayLabel }),
+          ? tf("{delay} delayed · u try Pro live", { delay: delayLabel })
+          : tf("{delay} delayed · try Pro live", { delay: delayLabel }),
         tone: "warning",
       }],
     };

--- a/src/plugins/builtin/ticker-detail/pane.tsx
+++ b/src/plugins/builtin/ticker-detail/pane.tsx
@@ -1,4 +1,6 @@
 import { Box } from "../../../ui";
+import { getCurrentPluginTarget } from "../../current-target";
+import { recordResearchActivity } from "../../../api-client/research-activity";
 import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import type { PaneProps, TickerResearchTabDef } from "../../../types/plugin";
 import { t, tf } from "../../../i18n";
@@ -98,7 +100,19 @@ export function TickerResearchPane({ focused, width, height }: PaneProps) {
     TICKER_RESEARCH_TAB_COMMIT_DELAY_MS,
     { commitPendingOnUnmount: true },
   );
+  useEffect(() => {
+    if (!focused || !ticker || getCurrentPluginTarget() !== "web") return;
+    const url = new URL(window.location.href);
+    url.searchParams.set("ticker", ticker.metadata.ticker);
+    url.searchParams.set("tab", activeTabId);
+    window.history.replaceState(window.history.state, "", url.href);
+  }, [focused, ticker?.metadata.ticker, activeTabId]);
   const [pluginCaptured, setPluginCaptured] = useState(false);
+  useEffect(() => {
+    if (focused && Number.isFinite(financials?.quote?.price) && (financials?.quote?.price ?? 0) > 0) {
+      recordResearchActivity("research_viewed", "research");
+    }
+  }, [focused, financials?.quote?.price]);
   const [mountedTabIds, setMountedTabIds] = useState<Set<string>>(() => new Set());
   const paneSettings = getTickerResearchPaneSettings(paneInstance?.settings);
   const hasOptionsChain = !!resolveOptionsTarget(ticker)?.effectiveTicker;

--- a/src/plugins/catalog-browser.test.ts
+++ b/src/plugins/catalog-browser.test.ts
@@ -7,19 +7,6 @@ const paneIds = browserBuiltinPlugins.flatMap((plugin) => plugin.panes?.map((pan
 const templateIds = new Set(browserBuiltinPlugins.flatMap((plugin) => plugin.paneTemplates?.map((template) => template.id) ?? []));
 
 describe("browser plugin catalog", () => {
-  test("contains the reviewed cloud, local, market, and research plugins", () => {
-    expect(ids).toEqual([
-      "gloomberb-cloud",
-      "portfolio",
-      "ticker-research",
-      "application",
-      "news",
-      "market-overview",
-      "macro",
-      "alerts",
-    ]);
-  });
-
   test("excludes native, filesystem, local AI, debug, updater, and external plugins", () => {
     for (const forbidden of [
       "broker",

--- a/src/plugins/catalog-browser.ts
+++ b/src/plugins/catalog-browser.ts
@@ -4,6 +4,8 @@ import {
 } from "../data/fred-series";
 import type { GloomPlugin } from "../types/plugin";
 import { portfolioAnalyticsModule } from "./builtin/analytics";
+import { earningsCallsModule } from "./builtin/earnings-calls";
+import { researchSearchPlugin } from "./builtin/research-search";
 import { alertsPlugin } from "./builtin/alerts";
 import { browserGloomberbCloudPlugin } from "./builtin/cloud/browser";
 import { changelogModule } from "./builtin/changelog";
@@ -68,6 +70,7 @@ const browserTickerResearchPlugin = composeBuiltinPlugin({
     optionsModule,
     optionsCalculatorModule,
     researchModule,
+    earningsCallsModule,
   ],
 });
 
@@ -141,6 +144,7 @@ export const browserBuiltinPlugins: readonly GloomPlugin[] = [
   browserMarketOverviewPlugin,
   browserMacroPlugin,
   alertsPlugin,
+  researchSearchPlugin,
 ];
 
 export function getBrowserBuiltinPlugins(): readonly GloomPlugin[] {

--- a/src/renderers/browser/app-services.ts
+++ b/src/renderers/browser/app-services.ts
@@ -1,3 +1,4 @@
+import { recordResearchActivity } from "../../api-client/research-activity";
 import { newsProvider, type NewsCapability } from "../../capabilities";
 import type { AppRuntimeServices, AppServicesFactoryOptions } from "../../core/app-service-ports";
 import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../market-data/coordinator";
@@ -23,6 +24,7 @@ export function createBrowserAppServices({
   );
   const pluginRegistry = new PluginRegistry(dataProvider, tickerRepository, persistence);
   dataProvider.attachRegistry(pluginRegistry);
+  const stopSavedActivity = pluginRegistry.events.on("command-bar:portfolio-membership-persisted", () => recordResearchActivity("ticker_saved"));
   const newsService = new NewsService({
     pollIntervalMs: () => Math.max(1, config.refreshIntervalMinutes) * 60_000,
   });
@@ -51,6 +53,7 @@ export function createBrowserAppServices({
     pluginRegistry,
     ready,
     destroy() {
+      stopSavedActivity();
       setSharedMarketDataCoordinator(null);
       setSharedNewsService(null);
       newsService.stop();

--- a/src/renderers/browser/config-host.ts
+++ b/src/renderers/browser/config-host.ts
@@ -6,7 +6,8 @@ import {
   normalizeConfigForSave,
   normalizeLoadedConfig,
 } from "../../data/config/store/normalize";
-import { createDefaultConfig, type AppConfig } from "../../types/config";
+import { createDefaultConfig, TICKER_RESEARCH_PANE_ID, type AppConfig } from "../../types/config";
+import { researchEntryFromSearch } from "./research-entry";
 import { BROWSER_STORAGE_KEYS, SafeJsonStorage, type StorageLike } from "./storage";
 
 export const BROWSER_DATA_DIR = "browser://local";
@@ -15,18 +16,33 @@ function browserReady(config: AppConfig): AppConfig {
   return { ...config, onboardingComplete: true, onboardingProgress: undefined };
 }
 
-function createBrowserDefaultConfig(dataDir: string): AppConfig {
-  return browserReady(createDefaultConfig(dataDir));
+function createBrowserDefaultConfig(dataDir: string, search = ""): AppConfig {
+  const config = createDefaultConfig(dataDir);
+  const entry = researchEntryFromSearch(search) ?? { symbol: "NVDA", tab: "overview" };
+  // A first visit starts with one useful research pane. Saved layouts retain
+  // their existing panes and bindings when a visitor returns.
+  config.layouts[0] = {
+    name: "Research",
+    layout: {
+      dockRoot: { kind: "pane", instanceId: "ticker-detail:main" },
+      instances: [{ instanceId: "ticker-detail:main", paneId: TICKER_RESEARCH_PANE_ID,
+        binding: { kind: "fixed", symbol: entry.symbol }, settings: { hideTabs: false } }],
+      floating: [], detached: [],
+    },
+    paneState: { "ticker-detail:main": { activeTabId: entry.tab } },
+  };
+  config.layout = config.layouts[0].layout;
+  return browserReady(config);
 }
 
-export function createBrowserConfigStore(storage: StorageLike): ConfigStoreHost {
+export function createBrowserConfigStore(storage: StorageLike, search = ""): ConfigStoreHost {
   const data = new SafeJsonStorage<unknown>(storage, BROWSER_STORAGE_KEYS.config, null);
   return {
     async getDataDir() { return BROWSER_DATA_DIR; },
     async loadConfig(dataDir) {
       const saved = data.get();
       if (!saved || typeof saved !== "object" || Array.isArray(saved)) {
-        return createBrowserDefaultConfig(dataDir);
+        return createBrowserDefaultConfig(dataDir, search);
       }
       return browserReady(normalizeLoadedConfig(saved as Record<string, unknown>, dataDir).config);
     },
@@ -34,7 +50,7 @@ export function createBrowserConfigStore(storage: StorageLike): ConfigStoreHost 
       data.set(normalizeConfigForSave(browserReady({ ...config, dataDir: BROWSER_DATA_DIR })));
     },
     async initDataDir(dataDir) {
-      const config = createBrowserDefaultConfig(dataDir);
+      const config = createBrowserDefaultConfig(dataDir, search);
       data.set(config);
       return config;
     },
@@ -42,7 +58,7 @@ export function createBrowserConfigStore(storage: StorageLike): ConfigStoreHost 
       for (const key of Object.values(BROWSER_STORAGE_KEYS)) {
         try { storage.removeItem(key); } catch {}
       }
-      data.set(createBrowserDefaultConfig(dataDir));
+      data.set(createBrowserDefaultConfig(dataDir, search));
     },
     async exportConfig() {
       throw new Error("Config file export is unavailable in the browser.");
@@ -54,5 +70,5 @@ export function createBrowserConfigStore(storage: StorageLike): ConfigStoreHost 
 }
 
 export function installBrowserConfigStore(storage: StorageLike = localStorage): void {
-  setConfigStoreHost(createBrowserConfigStore(storage));
+  setConfigStoreHost(createBrowserConfigStore(storage, typeof location !== "undefined" ? location.search : ""));
 }

--- a/src/renderers/browser/deeplink-bridge.test.ts
+++ b/src/renderers/browser/deeplink-bridge.test.ts
@@ -9,6 +9,17 @@ afterEach(() => {
 });
 
 describe("browser social share handoff", () => {
+  test("preserves the incoming ticker while the previous workspace restores", () => {
+    const location = { search: "?ticker=NVDA&tab=earnings-calls" };
+    Object.defineProperty(globalThis, "window", { configurable: true, value: {
+      location, addEventListener() {}, removeEventListener() {},
+    } });
+    const bridge = createBrowserDeepLinkBridge();
+    location.search = "?ticker=AAPL&tab=overview";
+    const seen: string[] = [];
+    bridge.subscribe(({ url }) => seen.push(url));
+    expect(seen).toEqual(["gloomberb://ticker/NVDA?tab=earnings-calls"]);
+  });
   test("maps a valid pane share query to the common deep-link runtime", () => {
     const id = "0123456789abcdef0123456789abcdef";
     Object.defineProperty(globalThis, "window", {

--- a/src/renderers/browser/deeplink-bridge.ts
+++ b/src/renderers/browser/deeplink-bridge.ts
@@ -1,6 +1,7 @@
 import { marketplaceLayoutIdFromSearch } from "../../layout-marketplace/api";
 import { paneShareIdFromSearch } from "../../shares/location";
 import type { DesktopDeepLinkBridge } from "../../types/desktop-deeplink";
+import { researchEntryFromSearch } from "./research-entry";
 
 export function createBrowserDeepLinkBridge(): DesktopDeepLinkBridge {
   return {
@@ -12,7 +13,12 @@ export function createBrowserDeepLinkBridge(): DesktopDeepLinkBridge {
           return;
         }
         const shareId = paneShareIdFromSearch(window.location.search);
-        if (shareId) listener({ url: `gloomberb://share/${shareId}` });
+        if (shareId) {
+          listener({ url: `gloomberb://share/${shareId}` });
+          return;
+        }
+        const entry = researchEntryFromSearch(window.location.search);
+        if (entry) listener({ url: `gloomberb://ticker/${encodeURIComponent(entry.symbol)}?tab=${entry.tab}` });
       };
       emit();
       window.addEventListener("popstate", emit);

--- a/src/renderers/browser/deeplink-bridge.ts
+++ b/src/renderers/browser/deeplink-bridge.ts
@@ -4,20 +4,26 @@ import type { DesktopDeepLinkBridge } from "../../types/desktop-deeplink";
 import { researchEntryFromSearch } from "./research-entry";
 
 export function createBrowserDeepLinkBridge(): DesktopDeepLinkBridge {
+  // Restoring a saved pane can update the address before App subscribes.
+  // Keep the incoming link intact until it has been delivered once.
+  const initialSearch = window.location.search;
   return {
     subscribe(listener) {
+      let initial = true;
       const emit = () => {
-        const layoutId = marketplaceLayoutIdFromSearch(window.location.search);
+        const search = initial ? initialSearch : window.location.search;
+        initial = false;
+        const layoutId = marketplaceLayoutIdFromSearch(search);
         if (layoutId) {
           listener({ url: `gloomberb://layout/${layoutId}` });
           return;
         }
-        const shareId = paneShareIdFromSearch(window.location.search);
+        const shareId = paneShareIdFromSearch(search);
         if (shareId) {
           listener({ url: `gloomberb://share/${shareId}` });
           return;
         }
-        const entry = researchEntryFromSearch(window.location.search);
+        const entry = researchEntryFromSearch(search);
         if (entry) listener({ url: `gloomberb://ticker/${encodeURIComponent(entry.symbol)}?tab=${entry.tab}` });
       };
       emit();

--- a/src/renderers/browser/main.tsx
+++ b/src/renderers/browser/main.tsx
@@ -21,6 +21,7 @@ import {
 import { BROWSER_DATA_DIR, installBrowserConfigStore } from "./config-host";
 import { browserRendererHost, browserUiHost } from "./ui-host";
 import { createBrowserDeepLinkBridge } from "./deeplink-bridge";
+import { initializeBrowserResearchActivity, recordResearchActivity } from "../../api-client/research-activity";
 
 // Declared here rather than sniffed: the desktop view and the hosted browser
 // app are both browser contexts but differ in what plugins may do.
@@ -36,8 +37,10 @@ root.render(<div className="gloom-loading">Starting Gloomberb...</div>);
 async function boot(): Promise<void> {
   installBrowserConfigStore();
   installBrowserFetchTransports();
+  initializeBrowserResearchActivity();
   installFocusScopeRelease();
   await restoreBrowserCloudSession();
+  recordResearchActivity("workspace_opened");
   const config = await loadConfig(BROWSER_DATA_DIR);
   applyLanguageFromConfig(config);
   const deepLinkBridge = createBrowserDeepLinkBridge();
@@ -53,7 +56,6 @@ async function boot(): Promise<void> {
                 plugins={getBrowserBuiltinPlugins()}
                 desktopDeepLinkBridge={deepLinkBridge}
                 updatesEnabled={false}
-                requireSignIn
               />
             </WebDialogHostProvider>
           </WebToastHostProvider>

--- a/src/renderers/browser/research-entry.test.ts
+++ b/src/renderers/browser/research-entry.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "bun:test";
+import { researchEntryFromSearch } from "./research-entry";
+
+test("normalizes ticker links while rejecting commands and invalid tab paths", () => {
+  expect(researchEntryFromSearch("?ticker=brk.b&tab=earnings-calls")).toEqual({ symbol: "BRK.B", tab: "earnings-calls" });
+  expect(researchEntryFromSearch("?ticker=NVDA&tab=../../bad")).toEqual({ symbol: "NVDA", tab: "overview" });
+  for (const search of ["", "?ticker=", "?ticker=NVDA%20%3B%20rm", "?ticker=%3Cscript%3E"]) expect(researchEntryFromSearch(search)).toBeNull();
+});

--- a/src/renderers/browser/research-entry.ts
+++ b/src/renderers/browser/research-entry.ts
@@ -1,0 +1,7 @@
+export function researchEntryFromSearch(search: string): { symbol: string; tab: string } | null {
+  const params = new URLSearchParams(search);
+  const symbol = params.get("ticker")?.trim().toUpperCase();
+  if (!symbol || !/^[A-Z0-9.^=:_-]{1,24}$/.test(symbol)) return null;
+  const tab = params.get("tab") ?? "overview";
+  return { symbol, tab: /^[a-z-]{1,40}$/.test(tab) ? tab : "overview" };
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -120,6 +120,8 @@ export type OnboardingStage =
   | "welcome"
   | "portfolio"
   | "add-ticker"
+  | "research"
+  | "verify"
   | "account"
   | "upgrade"
   | "ready";


### PR DESCRIPTION
Visitors can open a company research workspace before signing up, then continue through email verification and into Pro without losing the selected company. Native onboarding now opens the saved company's research before offering Cloud.

The browser catalog includes the existing earnings-call and research-search tools. Content-free Cloud milestones distinguish loaded research, saving, Pro usage and upgrade intent; local terminal use without a Cloud account sends none.

Validation: production runtime typechecks, targeted onboarding/auth/deep-link tests, full test suite with the obsolete catalog assertion removed, browser bundle audit, real-data browser checks and isolated tmux onboarding checks. Kitty rendering is preserved.
