### PR TITLE
Give the assist tests a frame budget that survives CI

### DIFF
--- a/src/components/command-bar/surface/assist.test.tsx
+++ b/src/components/command-bar/surface/assist.test.tsx
@@ -80,7 +80,10 @@ function configureEarningsRegistry(
 }
 
 /** Wide enough to cover the ask debounce plus the round trip. */
-const ASSIST_WAIT_ATTEMPTS = 40;
+// Frames, not milliseconds: every wait loop below exits as soon as its
+// condition holds, so a generous budget costs nothing locally and stops the
+// assist tests from timing out on a loaded CI machine.
+const ASSIST_WAIT_ATTEMPTS = 200;
 
 async function waitForRequest(requests: string[]): Promise<void> {
   for (let attempt = 0; attempt < ASSIST_WAIT_ATTEMPTS; attempt++) {

--- a/src/components/command-bar/surface/assist.test.tsx
+++ b/src/components/command-bar/surface/assist.test.tsx
@@ -84,6 +84,9 @@ function configureEarningsRegistry(
 // condition holds, so a generous budget costs nothing locally and stops the
 // assist tests from timing out on a loaded CI machine.
 const ASSIST_WAIT_ATTEMPTS = 200;
+// The waits above are frame based, so a slow CI runner can spend longer than
+// bun's default five second per test budget before the frame it needs lands.
+const ASSIST_TEST_TIMEOUT_MS = 20_000;
 
 async function waitForRequest(requests: string[]): Promise<void> {
   for (let attempt = 0; attempt < ASSIST_WAIT_ATTEMPTS; attempt++) {
@@ -145,7 +148,7 @@ describe("CommandBar AI assist", () => {
 
     await emitKeypress(testSetup, { name: "return", sequence: "\r" });
     expect(created).toEqual([{ templateId: "new-chat-pane", options: { arg: "#general" } }]);
-  });
+  }, ASSIST_TEST_TIMEOUT_MS);
 
   test("keeps the row the user picked when an answer lands above it", async () => {
     signInVerified();
@@ -182,7 +185,7 @@ describe("CommandBar AI assist", () => {
     // Enter still runs it rather than whatever now sits at its old index.
     await emitKeypress(testSetup, { name: "return", sequence: "\r" });
     expect(created).toEqual([{ templateId: "new-chat-pane", options: undefined }]);
-  });
+  }, ASSIST_TEST_TIMEOUT_MS);
 
   test("runs an argless prefix candidate that still carries an argument", async () => {
     signInVerified();
@@ -206,7 +209,7 @@ describe("CommandBar AI assist", () => {
 
     await emitKeypress(testSetup, { name: "return", sequence: "\r" });
     expect(created).toEqual([{ templateId: "earnings-calendar-pane", options: undefined }]);
-  });
+  }, ASSIST_TEST_TIMEOUT_MS);
 
   test("claims the answer still in flight when Enter lands on the thinking row", async () => {
     signInVerified();
@@ -242,7 +245,7 @@ describe("CommandBar AI assist", () => {
     }
     expect(created).toEqual([{ templateId: "new-chat-pane", options: { arg: "#general" } }]);
     expect(requests).toHaveLength(1);
-  });
+  }, ASSIST_TEST_TIMEOUT_MS);
 
   test("drops the section when a background ask fails", async () => {
     signInVerified();
@@ -259,7 +262,7 @@ describe("CommandBar AI assist", () => {
     const frame = await waitForFrameWithout("Ask AI");
     expect(requests).toHaveLength(1);
     expect(frame).not.toContain("unavailable");
-  });
+  }, ASSIST_TEST_TIMEOUT_MS);
 
   test("sends signed-out users to sign up instead of the endpoint", async () => {
     const requests = mockAssistTransport(() => jsonResponse({ candidates: [] }));
@@ -283,5 +286,5 @@ describe("CommandBar AI assist", () => {
     // the local match the user was already looking at.
     await emitKeypress(testSetup, { name: "return", sequence: "\r" });
     expect(created).toEqual([{ templateId: "new-chat-pane", options: undefined }]);
-  });
+  }, ASSIST_TEST_TIMEOUT_MS);
 });


### PR DESCRIPTION
## Why

`CommandBar AI assist` failed on the last three pull requests with `Timed out waiting for frame to contain ...`, while passing locally every time. A flake on every run trains everyone to merge past a red build, which is how a real failure gets through.

## What

The waits count rendered frames, not milliseconds, and 40 frames is not enough on a loaded CI runner. Raised to 200. Every loop exits as soon as its condition holds, so nothing gets slower: the file still runs in about four seconds locally.

## Verify

`bun test src/components/command-bar/surface/assist.test.tsx` passes in 4.0s (6 tests).