### PR TITLE
Add headless data for filings and research panes

### DIFF
--- a/src/plugins/builtin/cloud/plugin.tsx
+++ b/src/plugins/builtin/cloud/plugin.tsx
@@ -17,6 +17,7 @@ import {
   CONGRESS_TRADES_PANE_ID,
   CongressTradesPane,
 } from "../congress-trades/pane";
+import { congressHeadless } from "../congress-trades/headless";
 import { registerTwitterFeedFeature } from "../cloud-tweets/registration";
 import { composeBuiltinPlugin, type PluginModule } from "../plugin-module";
 import { registerCloudAuthCommands } from "./auth-commands";
@@ -181,6 +182,7 @@ const congressTradesModule: PluginModule = {
     description: "Track newly disclosed House periodic transaction reports.",
     keywords: ["congress", "house", "trades", "ptr", "stock", "disclosures"],
     shortcut: { prefix: "CG" },
+    headless: congressHeadless,
     createInstance: () => ({ placement: "floating" }),
     publicShare: createPublicPaneShare("Congress Trades"),
   }],

--- a/src/plugins/builtin/congress-trades/client.ts
+++ b/src/plugins/builtin/congress-trades/client.ts
@@ -1,0 +1,11 @@
+import { apiClient } from "../../../api-client";
+import type { CloudCongressHousePayload } from "../../../api-client";
+import type { CloudCongressHouseParams } from "../../../api-client/paths";
+import type { HeadlessPaneApiClient } from "../../../types/plugin";
+
+export function loadCongressHouse(
+  params: CloudCongressHouseParams = {},
+  client: Pick<HeadlessPaneApiClient, "getCloudCongressHouse"> = apiClient,
+): Promise<CloudCongressHousePayload> {
+  return client.getCloudCongressHouse(params);
+}

--- a/src/plugins/builtin/congress-trades/detail.tsx
+++ b/src/plugins/builtin/congress-trades/detail.tsx
@@ -15,7 +15,6 @@ import type {
   CloudCongressMemberPayload,
   CloudCongressTradePayload,
 } from "../../../api-client";
-import { apiClient } from "../../../api-client";
 import {
   CONGRESS_MEMBER_FILING_LIMIT,
   CONGRESS_MEMBER_TRADE_LIMIT,
@@ -34,6 +33,7 @@ import {
   type TradeColumnId,
 } from "./model";
 import { renderCongressTradeCell } from "./table";
+import { loadCongressHouse } from "./client";
 
 function DetailLine({
   label,
@@ -133,7 +133,7 @@ export function MemberTradesDetail({
     const gen = fetchGenRef.current;
     setStatus("loading");
     setError(null);
-    apiClient.getCloudCongressHouse({
+    loadCongressHouse({
       member: member.memberName,
       limit: CONGRESS_MEMBER_TRADE_LIMIT,
       filingLimit: Math.max(CONGRESS_MEMBER_FILING_LIMIT, filingLimit),
@@ -162,7 +162,7 @@ export function MemberTradesDetail({
     if (!nextRequest) return;
     const gen = fetchGenRef.current;
     setLoadingMore(true);
-    apiClient.getCloudCongressHouse({
+    loadCongressHouse({
       ...nextRequest,
       member: member.memberName,
       limit: CONGRESS_MEMBER_TRADE_LIMIT,

--- a/src/plugins/builtin/congress-trades/headless.test.ts
+++ b/src/plugins/builtin/congress-trades/headless.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import type { CloudCongressHousePayload } from "../../../api-client";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { createDefaultConfig } from "../../../types/config";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createCongressHeadless } from "./headless";
+
+const payload: CloudCongressHousePayload = {
+  asOf: "2026-09-04T12:00:00.000Z",
+  chamber: "house",
+  source: "house-clerk",
+  year: 2026,
+  indexUpdatedAt: "2026-09-04T11:00:00.000Z",
+  filingsScanned: 2,
+  filingCount: 2,
+  trades: [
+    {
+      id: "trade-1",
+      chamber: "house",
+      filingId: "filing-1",
+      docId: "doc-1",
+      memberName: "Nancy Pelosi",
+      stateDistrict: "CA-11",
+      filingDate: "2026-09-03",
+      transactionDate: "2026-08-20",
+      notificationDate: null,
+      lagDays: 14,
+      side: "BUY",
+      transactionType: "Purchase",
+      ticker: "NVDA",
+      assetName: "NVIDIA Corporation",
+      assetType: "Stock",
+      owner: "SP",
+      rawOwner: "Spouse",
+      amount: "$1,000,001 - $5,000,000",
+      amountLow: 1_000_001,
+      amountHigh: 5_000_000,
+      capGainsOver200: null,
+      filingStatus: null,
+      subholdingOf: null,
+      description: null,
+      sourceUrl: "https://disclosures-clerk.house.gov/filing-1",
+    },
+  ],
+  members: [
+    {
+      id: "member-1",
+      memberName: "Nancy Pelosi",
+      stateDistrict: "CA-11",
+      tradeCount: 12,
+      buyCount: 8,
+      sellCount: 4,
+      exchangeCount: 0,
+      otherCount: 0,
+      estimatedLow: 2_000_000,
+      estimatedHigh: 8_000_000,
+      lastFilingDate: "2026-09-03",
+      avgLagDays: 18,
+    },
+  ],
+};
+
+function context(): HeadlessPaneContext {
+  return {
+    marketData: createTestDataProvider(),
+    apiClient: {} as HeadlessPaneContext["apiClient"],
+    config: createDefaultConfig("/tmp/gloomberb-headless-congress"),
+    signal: new AbortController().signal,
+  };
+}
+
+function args(tab: "trades" | "members", limit = 50): HeadlessPaneLoadArgs {
+  return { rawArgument: "", argument: null, symbols: [], options: { tab, year: 2026, limit } };
+}
+
+describe("congress headless model", () => {
+  test("projects the active tab and applies its row limit", async () => {
+    const headless = createCongressHeadless({ loadHouse: async () => payload });
+
+    const trades = await headless.load(args("trades", 1), context());
+    expect(trades.rows).toMatchObject([{
+      memberName: "Nancy Pelosi",
+      side: "BUY",
+      ticker: "NVDA",
+      amountLow: 1_000_001,
+      amountHigh: 5_000_000,
+    }]);
+    expect(trades.columns?.map((column) => column.key)).toContain("ticker");
+
+    const members = await headless.load(args("members", 1), context());
+    expect(members.rows).toMatchObject([{
+      memberName: "Nancy Pelosi",
+      tradeCount: 12,
+      buyCount: 8,
+    }]);
+    expect(members.columns?.map((column) => column.key)).toContain("tradeCount");
+  });
+});

--- a/src/plugins/builtin/congress-trades/headless.ts
+++ b/src/plugins/builtin/congress-trades/headless.ts
@@ -1,0 +1,145 @@
+import type {
+  HeadlessPaneColumn,
+  HeadlessPaneContext,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import type { CloudCongressHousePayload } from "../../../api-client";
+import { loadCongressHouse } from "./client";
+import {
+  CONGRESS_FILING_LIMIT,
+  CONGRESS_TRADE_LIMIT,
+  formatAmountRange,
+  formatLag,
+  formatShortDate,
+  sortedMembers,
+  sortedTrades,
+} from "./model";
+
+const TRADE_COLUMNS: HeadlessPaneColumn[] = [
+  { key: "filingDate", header: "Filed", format: (value) => formatShortDate(typeof value === "string" ? value : null) },
+  { key: "transactionDate", header: "Tx", format: (value) => formatShortDate(typeof value === "string" ? value : null) },
+  { key: "lagDays", header: "Lag", align: "right", format: (value) => formatLag(typeof value === "number" ? value : null) },
+  { key: "memberName", header: "Member" },
+  { key: "side", header: "Side" },
+  { key: "ticker", header: "Ticker" },
+  {
+    key: "amountLow",
+    header: "Amount",
+    align: "right",
+    format: (value, row) => formatAmountRange(
+      typeof value === "number" ? value : null,
+      typeof row.amountHigh === "number" ? row.amountHigh : null,
+      typeof row.amount === "string" ? row.amount : undefined,
+    ),
+  },
+  { key: "owner", header: "Owner" },
+];
+
+const MEMBER_COLUMNS: HeadlessPaneColumn[] = [
+  { key: "memberName", header: "Member" },
+  { key: "stateDistrict", header: "Dist" },
+  { key: "tradeCount", header: "Trades", align: "right" },
+  { key: "buyCount", header: "Buy", align: "right" },
+  { key: "sellCount", header: "Sell", align: "right" },
+  {
+    key: "estimatedLow",
+    header: "Est Range",
+    align: "right",
+    format: (value, row) => formatAmountRange(
+      typeof value === "number" ? value : null,
+      typeof row.estimatedHigh === "number" ? row.estimatedHigh : null,
+    ),
+  },
+  { key: "lastFilingDate", header: "Last", format: (value) => formatShortDate(typeof value === "string" ? value : null) },
+  { key: "avgLagDays", header: "Avg", align: "right", format: (value) => formatLag(typeof value === "number" ? value : null) },
+];
+
+export interface CongressHeadlessDependencies {
+  loadHouse(
+    args: HeadlessPaneLoadArgs,
+    ctx: HeadlessPaneContext,
+  ): Promise<CloudCongressHousePayload>;
+}
+
+const defaultDependencies: CongressHeadlessDependencies = {
+  loadHouse: (args, ctx) => loadCongressHouse({
+    year: Number(args.options.year),
+    limit: CONGRESS_TRADE_LIMIT,
+    filingLimit: CONGRESS_FILING_LIMIT,
+  }, ctx.apiClient),
+};
+
+export function createCongressHeadless(
+  dependencies: CongressHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "none",
+      description: "The House PTR feed does not require an argument.",
+    },
+    options: [
+      {
+        key: "tab",
+        description: "Congress pane tab.",
+        type: "enum",
+        values: [{ value: "trades" }, { value: "members" }],
+        defaultValue: "trades",
+        pluginState: { pluginId: "gloomberb-cloud", key: "activeTab" },
+      },
+      {
+        key: "year",
+        description: "House disclosure year.",
+        type: "integer",
+        defaultValue: new Date().getUTCFullYear(),
+        minimum: 2008,
+        maximum: 2100,
+      },
+      {
+        key: "limit",
+        aliases: ["count", "rows"],
+        description: "Maximum rows.",
+        type: "integer",
+        defaultValue: 50,
+        minimum: 1,
+        maximum: 200,
+      },
+    ],
+    describe: (args) => `Congress Trades | ${args.options.tab === "members" ? "Members" : "Trades"}`,
+    async load(args, ctx) {
+      const payload = await dependencies.loadHouse(args, ctx);
+      const limit = Number(args.options.limit);
+      if (args.options.tab === "members") {
+        const rows = sortedMembers(payload.members, { columnId: "trades", direction: "desc" })
+          .slice(0, limit)
+          .map((member) => ({ ...member }));
+        return {
+          columns: MEMBER_COLUMNS,
+          rows,
+          metadata: {
+            asOf: payload.asOf,
+            chamber: payload.chamber,
+            source: payload.source,
+            year: payload.year,
+          },
+        };
+      }
+      const rows = sortedTrades(payload.trades, { columnId: "filed", direction: "desc" })
+        .slice(0, limit)
+        .map((trade) => ({ ...trade }));
+      return {
+        columns: TRADE_COLUMNS,
+        rows,
+        metadata: {
+          asOf: payload.asOf,
+          chamber: payload.chamber,
+          source: payload.source,
+          year: payload.year,
+        },
+      };
+    },
+  };
+}
+
+export const congressHeadless = createCongressHeadless();

--- a/src/plugins/builtin/congress-trades/pane.tsx
+++ b/src/plugins/builtin/congress-trades/pane.tsx
@@ -10,7 +10,6 @@ import { useDebouncedPluginPaneState, usePluginPaneState } from "../../runtime";
 import { useAutoRefresh } from "../shared/auto-refresh";
 import { useInlineTickerOpener } from "../../../state/hooks/inline-tickers";
 import {
-  apiClient,
   type CloudCongressHousePayload,
   type CloudCongressMemberPayload,
   type CloudCongressTradePayload,
@@ -46,6 +45,7 @@ import {
   renderCongressMemberCell,
   renderCongressTradeCell,
 } from "./table";
+import { loadCongressHouse } from "./client";
 
 export { CONGRESS_TRADES_PANE_ID } from "./model";
 
@@ -77,7 +77,7 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
     setStatus((current) => (current === "loaded" && !refresh ? "loaded" : "loading"));
     setError(null);
     setLoadingMore(false);
-    apiClient.getCloudCongressHouse({
+    loadCongressHouse({
       limit: CONGRESS_TRADE_LIMIT,
       filingLimit: CONGRESS_FILING_LIMIT,
       refresh,
@@ -103,7 +103,7 @@ export function CongressTradesPane({ focused, width, height }: PaneProps) {
     if (!nextRequest) return;
     const gen = fetchGenRef.current;
     setLoadingMore(true);
-    apiClient.getCloudCongressHouse({
+    loadCongressHouse({
       ...nextRequest,
       limit: CONGRESS_TRADE_LIMIT,
       filingLimit: CONGRESS_FILING_LIMIT,

--- a/src/plugins/builtin/holders/client.ts
+++ b/src/plugins/builtin/holders/client.ts
@@ -1,0 +1,29 @@
+import type { DataProvider, MarketDataRequestContext } from "../../../types/data-provider";
+import type { HolderData } from "../../../types/financials";
+
+export async function loadHolderData(
+  provider: DataProvider,
+  symbol: string,
+  exchange = "",
+  context?: MarketDataRequestContext,
+): Promise<HolderData> {
+  if (!provider.getHolders) throw new Error("Holder data unavailable");
+  return provider.getHolders(symbol, exchange, context);
+}
+
+export async function loadHolderSnapshot(
+  provider: DataProvider,
+  symbol: string,
+  exchange = "",
+): Promise<{ data: HolderData; marketCap?: number }> {
+  const [data, financials] = await Promise.all([
+    loadHolderData(provider, symbol, exchange),
+    provider.getTickerFinancials(symbol, exchange).catch(() => null),
+  ]);
+  const quoteMarketCap = financials?.quote?.marketCap;
+  const marketCap = financials?.quote?.currency && data.currency
+    && financials.quote.currency !== data.currency
+    ? undefined
+    : quoteMarketCap;
+  return { data, marketCap };
+}

--- a/src/plugins/builtin/holders/headless.test.ts
+++ b/src/plugins/builtin/holders/headless.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { createDefaultConfig } from "../../../types/config";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createHoldersHeadless } from "./headless";
+
+function context(): HeadlessPaneContext {
+  return {
+    marketData: createTestDataProvider(),
+    apiClient: {} as HeadlessPaneContext["apiClient"],
+    config: createDefaultConfig("/tmp/gloomberb-headless-holders"),
+    signal: new AbortController().signal,
+  };
+}
+
+function args(overrides: Partial<HeadlessPaneLoadArgs["options"]> = {}): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: "NVDA",
+    argument: "NVDA",
+    symbols: ["NVDA"],
+    options: { sort: "value", order: "desc", limit: 25, ...overrides },
+  };
+}
+
+describe("holders headless model", () => {
+  test("projects holder values and applies sorting and limits", async () => {
+    const headless = createHoldersHeadless({
+      loadSnapshot: async () => ({
+        marketCap: 1_000,
+        data: {
+          symbol: "NVDA",
+          currency: "USD",
+          asOf: "2026-06-30",
+          holders: [
+            { ownerType: "institution", name: "Small Fund", value: 100, shares: 4, reportDate: "2026-06-30" },
+            { ownerType: "fund", name: "Large Fund", value: 300, shares: 8, changeShares: 2, reportDate: "2026-06-30" },
+          ],
+        },
+      }),
+    });
+
+    const byValue = await headless.load(args({ limit: 1 }), context());
+    expect(byValue.rows).toEqual([{
+      name: "Large Fund",
+      ownerType: "fund",
+      value: 300,
+      shares: 8,
+      changeShares: 2,
+      changePercent: null,
+      percentHeld: 0.3,
+      reportDate: "2026-06-30",
+      currency: "USD",
+    }]);
+
+    const byName = await headless.load(args({ sort: "holder", order: "asc", limit: 2 }), context());
+    expect(byName.rows.map((row) => row.name)).toEqual(["Large Fund", "Small Fund"]);
+  });
+});

--- a/src/plugins/builtin/holders/headless.ts
+++ b/src/plugins/builtin/holders/headless.ts
@@ -1,0 +1,162 @@
+import type {
+  HeadlessPaneColumn,
+  HeadlessPaneContext,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import { formatCompact } from "../../../utils/format";
+import { loadHolderSnapshot } from "./client";
+import {
+  displayDate,
+  formatHolderOwnershipPercent,
+  formatMaybePercent,
+  formatMoneyCompact,
+  formatSignedCompact,
+  resolveHolderOwnershipPercent,
+} from "./format";
+import { buildRows, sortRows } from "./table-model";
+import type { HolderData } from "../../../types/financials";
+import type { HolderColumnId } from "./types";
+
+const HOLDER_COLUMNS: HeadlessPaneColumn[] = [
+  { key: "name", header: "Holder" },
+  { key: "ownerType", header: "Type" },
+  {
+    key: "value",
+    header: "Value",
+    align: "right",
+    format: (value, row) => formatMoneyCompact(
+      value == null ? undefined : Number(value),
+      String(row.currency ?? "USD"),
+    ),
+  },
+  {
+    key: "shares",
+    header: "Amount",
+    align: "right",
+    format: (value) => value == null ? "-" : formatCompact(Number(value)),
+  },
+  {
+    key: "changeShares",
+    header: "Chg",
+    align: "right",
+    format: (value) => formatSignedCompact(value == null ? undefined : Number(value)),
+  },
+  {
+    key: "changePercent",
+    header: "Chg%",
+    align: "right",
+    format: (value) => formatMaybePercent(value == null ? undefined : Number(value)),
+  },
+  {
+    key: "percentHeld",
+    header: "Held",
+    align: "right",
+    format: (value) => formatHolderOwnershipPercent(value == null ? undefined : Number(value)),
+  },
+  {
+    key: "reportDate",
+    header: "Date",
+    format: (value) => displayDate(typeof value === "string" ? value : undefined),
+  },
+];
+
+const SORT_COLUMNS: Record<string, HolderColumnId> = {
+  holder: "holder",
+  value: "value",
+  shares: "shares",
+  change: "changeShares",
+  "change-percent": "changePercent",
+  held: "percentHeld",
+  date: "reportDate",
+};
+
+interface HolderSnapshot {
+  data: HolderData;
+  marketCap?: number;
+}
+
+export interface HoldersHeadlessDependencies {
+  loadSnapshot(
+    symbol: string,
+    args: HeadlessPaneLoadArgs,
+    ctx: HeadlessPaneContext,
+  ): Promise<HolderSnapshot>;
+}
+
+const defaultDependencies: HoldersHeadlessDependencies = {
+  loadSnapshot: (symbol, _args, ctx) => loadHolderSnapshot(ctx.marketData, symbol),
+};
+
+export function createHoldersHeadless(
+  dependencies: HoldersHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "ticker",
+      placeholder: "ticker",
+      description: "Ticker whose institutional holders should be loaded.",
+    },
+    options: [
+      {
+        key: "sort",
+        description: "Column used to sort holder rows.",
+        type: "enum",
+        values: Object.keys(SORT_COLUMNS).map((value) => ({ value })),
+        defaultValue: "value",
+      },
+      {
+        key: "order",
+        description: "Sort direction.",
+        type: "enum",
+        values: [{ value: "desc" }, { value: "asc" }],
+        defaultValue: "desc",
+      },
+      {
+        key: "limit",
+        aliases: ["count", "rows"],
+        description: "Maximum holder rows.",
+        type: "integer",
+        defaultValue: 25,
+        minimum: 1,
+        maximum: 200,
+      },
+    ],
+    columns: HOLDER_COLUMNS,
+    describe: (args) => `Holders | ${args.symbols[0]}`,
+    async load(args, ctx) {
+      const symbol = args.symbols[0]!;
+      const { data, marketCap } = await dependencies.loadSnapshot(symbol, args, ctx);
+      const currency = data.currency ?? "USD";
+      const rows = sortRows(buildRows(data), {
+        columnId: SORT_COLUMNS[String(args.options.sort)] ?? "value",
+        direction: args.options.order === "asc" ? "asc" : "desc",
+      }, marketCap)
+        .slice(0, Number(args.options.limit))
+        .map((row) => ({
+          name: row.name,
+          ownerType: row.ownerType,
+          value: row.value ?? null,
+          shares: row.shares ?? null,
+          changeShares: row.changeShares ?? null,
+          changePercent: row.changePercent ?? null,
+          percentHeld: resolveHolderOwnershipPercent(row, marketCap) ?? null,
+          reportDate: row.reportDate ?? null,
+          currency,
+        }));
+      return {
+        rows,
+        metadata: {
+          symbol: data.symbol || symbol,
+          name: data.name ?? null,
+          currency,
+          asOf: data.asOf ?? null,
+          summary: data.summary ?? null,
+        },
+      };
+    },
+  };
+}
+
+export const holdersHeadless = createHoldersHeadless();

--- a/src/plugins/builtin/holders/index.tsx
+++ b/src/plugins/builtin/holders/index.tsx
@@ -1,6 +1,9 @@
 import type { PluginModule } from "../plugin-module";
 import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
+import { holdersHeadless } from "./headless";
 import { HoldersView } from "./pane";
+
+export { holdersHeadless } from "./headless";
 
 export const holdersModule: PluginModule = {
   setup(ctx) {
@@ -27,13 +30,16 @@ export const holdersModule: PluginModule = {
   ],
 
   paneTemplates: [
-    createTickerSurfacePaneTemplate({
-      id: "holders-pane",
-      paneId: "holders",
-      label: "Holders",
-      description: "Institutional holders for the selected ticker.",
-      keywords: ["holders", "ownership", "institutional", "owners", "hds"],
-      shortcut: "HDS",
-    }),
+    {
+      ...createTickerSurfacePaneTemplate({
+        id: "holders-pane",
+        paneId: "holders",
+        label: "Holders",
+        description: "Institutional holders for the selected ticker.",
+        keywords: ["holders", "ownership", "institutional", "owners", "hds"],
+        shortcut: "HDS",
+      }),
+      headless: holdersHeadless,
+    },
   ],
 };

--- a/src/plugins/builtin/holders/pane.tsx
+++ b/src/plugins/builtin/holders/pane.tsx
@@ -31,6 +31,7 @@ import {
   sortRows,
   VIEW_TABS,
 } from "./table-model";
+import { loadHolderData } from "./client";
 import { HoldersTreemap } from "./treemap";
 import type { HolderColumn, HolderRow, SortPreference, ViewMode } from "./types";
 import { loadHolder13FMatches, type Holder13FMatch } from "./thirteenf-match";
@@ -77,7 +78,12 @@ export function HoldersView({ focused, width, height }: { focused: boolean; widt
     setError(null);
 
     try {
-      const nextData = await dataProvider.getHolders(symbol, exchange, forceRefresh ? { cacheMode: "refresh" } : undefined);
+      const nextData = await loadHolderData(
+        dataProvider,
+        symbol,
+        exchange,
+        forceRefresh ? { cacheMode: "refresh" } : undefined,
+      );
       if (fetchGenRef.current !== gen) return;
       setData(nextData);
       setSelectedId(null);

--- a/src/plugins/builtin/insider/client.ts
+++ b/src/plugins/builtin/insider/client.ts
@@ -1,0 +1,50 @@
+import type { DataProvider, SecFilingItem } from "../../../types/data-provider";
+import { parseForm4Xml } from "./insider-data";
+import type { ParsedInsiderFiling } from "./model";
+
+export async function loadInsiderFilings(
+  provider: DataProvider,
+  symbol: string,
+  count: number,
+  exchange = "",
+): Promise<SecFilingItem[]> {
+  if (!provider.getSecFilings) throw new Error("Insider filing data unavailable");
+  const filings = await provider.getSecFilings(symbol, count, exchange);
+  return filings.filter((filing) => filing.form.trim() === "4");
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) return;
+  throw signal.reason instanceof Error ? signal.reason : new Error("Insider filing load was aborted.");
+}
+
+export async function loadParsedInsiderFilings(
+  provider: DataProvider,
+  symbol: string,
+  options: { limit: number; exchange?: string; signal?: AbortSignal },
+): Promise<ParsedInsiderFiling[]> {
+  if (!provider.getSecFilingContent) throw new Error("Insider filing content unavailable");
+  const filings = (await loadInsiderFilings(
+    provider,
+    symbol,
+    20_000,
+    options.exchange,
+  )).slice(0, options.limit);
+
+  const parsed: ParsedInsiderFiling[] = [];
+  for (const filing of filings) {
+    throwIfAborted(options.signal);
+    try {
+      const content = await provider.getSecFilingContent(filing);
+      parsed.push({
+        filing,
+        transaction: content ? parseForm4Xml(content) : null,
+        isLoading: false,
+      });
+    } catch {
+      throwIfAborted(options.signal);
+      parsed.push({ filing, transaction: null, isLoading: false });
+    }
+  }
+  return parsed;
+}

--- a/src/plugins/builtin/insider/headless.test.ts
+++ b/src/plugins/builtin/insider/headless.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { createDefaultConfig } from "../../../types/config";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { loadParsedInsiderFilings } from "./client";
+import { createInsiderHeadless } from "./headless";
+import type { ParsedInsiderFiling } from "./model";
+
+const parsed: ParsedInsiderFiling[] = [
+  {
+    filing: {
+      accessionNumber: "one",
+      form: "4",
+      filingDate: new Date("2026-08-26T00:00:00.000Z"),
+      cik: "0000002488",
+      filingUrl: "https://www.sec.gov/one",
+    },
+    transaction: {
+      filingDate: new Date("2026-08-25T00:00:00.000Z"),
+      reportedName: "SU LISA T",
+      title: "Chief Executive Officer",
+      transactionType: "P",
+      shares: 25_000,
+      pricePerShare: 150,
+      totalValue: 3_750_000,
+      sharesOwned: 4_000_000,
+      form: "4",
+    },
+    isLoading: false,
+  },
+  {
+    filing: {
+      accessionNumber: "two",
+      form: "4",
+      filingDate: new Date("2026-08-24T00:00:00.000Z"),
+      cik: "0000002488",
+      filingUrl: "https://www.sec.gov/two",
+    },
+    transaction: {
+      filingDate: new Date("2026-08-23T00:00:00.000Z"),
+      reportedName: "OTHER OFFICER",
+      title: "Officer",
+      transactionType: "S",
+      shares: 1_000,
+      pricePerShare: 155,
+      totalValue: 155_000,
+      sharesOwned: 20_000,
+      form: "4",
+    },
+    isLoading: false,
+  },
+];
+
+function context(): HeadlessPaneContext {
+  return {
+    marketData: createTestDataProvider(),
+    apiClient: {} as HeadlessPaneContext["apiClient"],
+    config: createDefaultConfig("/tmp/gloomberb-headless-insider"),
+    signal: new AbortController().signal,
+  };
+}
+
+function args(name = "", limit = 20): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: "AMD",
+    argument: "AMD",
+    symbols: ["AMD"],
+    options: { name, limit },
+  };
+}
+
+describe("insider client", () => {
+  test("scans Form 4 filings and loads their content sequentially", async () => {
+    let activeContentLoads = 0;
+    let maxActiveContentLoads = 0;
+    const filingRequests: Array<{ symbol: string; count: number; exchange: string | undefined }> = [];
+    const provider = createTestDataProvider({
+      getSecFilings: async (symbol, count, exchange) => {
+        filingRequests.push({ symbol, count, exchange });
+        return parsed.map(({ filing }) => filing);
+      },
+      getSecFilingContent: async () => {
+        activeContentLoads += 1;
+        maxActiveContentLoads = Math.max(maxActiveContentLoads, activeContentLoads);
+        await Bun.sleep(1);
+        activeContentLoads -= 1;
+        return null;
+      },
+    });
+
+    const result = await loadParsedInsiderFilings(provider, "NVDA", { limit: 2 });
+
+    expect(filingRequests).toEqual([{ symbol: "NVDA", count: 20_000, exchange: "" }]);
+    expect(result).toHaveLength(2);
+    expect(maxActiveContentLoads).toBe(1);
+  });
+});
+
+describe("insider headless model", () => {
+  test("projects parsed Form 4 values and applies the owner filter", async () => {
+    const requestedLimits: number[] = [];
+    const headless = createInsiderHeadless({
+      loadParsed: async (_symbol, limit) => {
+        requestedLimits.push(limit);
+        return parsed.slice(0, limit);
+      },
+    });
+
+    const all = await headless.load(args("", 2), context());
+    expect(all.rows[0]).toMatchObject({
+      insider: "SU LISA T",
+      side: "BUY",
+      shares: 25_000,
+      totalValue: 3_750_000,
+    });
+
+    const filtered = await headless.load(args("other officer", 2), context());
+    expect(filtered.rows).toHaveLength(1);
+    expect(filtered.rows[0]).toMatchObject({ insider: "OTHER OFFICER", side: "SELL" });
+    expect(requestedLimits).toEqual([2, 2]);
+  });
+});

--- a/src/plugins/builtin/insider/headless.ts
+++ b/src/plugins/builtin/insider/headless.ts
@@ -1,0 +1,117 @@
+import type {
+  HeadlessPaneColumn,
+  HeadlessPaneContext,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import { formatCompact, formatCurrency } from "../../../utils/format";
+import { loadParsedInsiderFilings } from "./client";
+import {
+  buildInsiderRows,
+  buildInsiderSummary,
+  type ParsedInsiderFiling,
+} from "./model";
+
+const INSIDER_COLUMNS: HeadlessPaneColumn[] = [
+  {
+    key: "filingDate",
+    header: "Filed",
+    format: (value) => typeof value === "string" ? value.slice(0, 10) : "-",
+  },
+  {
+    key: "transactionDate",
+    header: "Tx",
+    format: (value) => typeof value === "string" ? value.slice(0, 10) : "-",
+  },
+  { key: "insider", header: "Insider" },
+  { key: "title", header: "Title" },
+  { key: "side", header: "Side" },
+  {
+    key: "shares",
+    header: "Shares",
+    align: "right",
+    format: (value) => value == null ? "-" : formatCompact(Number(value)),
+  },
+  {
+    key: "pricePerShare",
+    header: "Price",
+    align: "right",
+    format: (value) => value == null ? "-" : formatCurrency(Number(value)),
+  },
+  {
+    key: "totalValue",
+    header: "Value",
+    align: "right",
+    format: (value) => value == null ? "-" : formatCurrency(Number(value)),
+  },
+];
+
+export interface InsiderHeadlessDependencies {
+  loadParsed(
+    symbol: string,
+    limit: number,
+    args: HeadlessPaneLoadArgs,
+    ctx: HeadlessPaneContext,
+  ): Promise<ParsedInsiderFiling[]>;
+}
+
+const defaultDependencies: InsiderHeadlessDependencies = {
+  loadParsed: (symbol, limit, _args, ctx) => loadParsedInsiderFilings(ctx.marketData, symbol, {
+    limit,
+    signal: ctx.signal,
+  }),
+};
+
+export function createInsiderHeadless(
+  dependencies: InsiderHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "ticker",
+      placeholder: "ticker",
+      description: "US equity ticker.",
+    },
+    options: [
+      {
+        key: "name",
+        description: "Exact reporting owner name.",
+        type: "string",
+        defaultValue: "",
+        pluginState: { pluginId: "ticker-research", key: "nameFilter" },
+      },
+      {
+        key: "limit",
+        aliases: ["count", "rows"],
+        description: "Maximum Form 4 filings to parse.",
+        type: "integer",
+        defaultValue: 20,
+        minimum: 1,
+        maximum: 100,
+      },
+    ],
+    columns: INSIDER_COLUMNS,
+    describe: (args) => `Insider Transactions | ${args.symbols[0]}`,
+    async load(args, ctx) {
+      const symbol = args.symbols[0]!;
+      const limit = Number(args.options.limit);
+      const parsed = await dependencies.loadParsed(symbol, limit, args, ctx);
+      const name = String(args.options.name ?? "").trim().toLocaleLowerCase();
+      const filtered = name
+        ? parsed.filter(({ transaction }) => transaction?.reportedName.toLocaleLowerCase() === name)
+        : parsed;
+      return {
+        rows: buildInsiderRows(filtered),
+        metadata: {
+          symbol,
+          summary: buildInsiderSummary(parsed),
+          parsed: parsed.filter(({ transaction }) => transaction != null).length,
+          requested: limit,
+          name: name || null,
+        },
+      };
+    },
+  };
+}
+
+export const insiderHeadless = createInsiderHeadless();

--- a/src/plugins/builtin/insider/index.tsx
+++ b/src/plugins/builtin/insider/index.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PluginModule } from "../plugin-module";
-import type { SecFilingItem } from "../../../types/data-provider";
 import {
   useResolvedEntryValue,
   useSecFilingsQuery,
@@ -11,9 +10,8 @@ import type { ScrollBoxRenderable } from "../../../ui";
 import { EmptyState, FeedDataTableStackView, Spinner, useExternalLinkFooter, useTableLoadMore, type FeedDataTableItem } from "../../../components";
 import { usePluginPaneState } from "../../runtime";
 import { isUsEquityTicker } from "../../../utils/sec";
-import { formatCompact, formatCurrency } from "../../../utils/format";
 import { truncateWithEllipsis as truncateText } from "../../../utils/text-wrap";
-import { parseForm4Xml, type InsiderTransaction } from "./insider-data";
+import { parseForm4Xml } from "./insider-data";
 import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
 import {
   buildInsiderTransactionDetailBody,
@@ -23,48 +21,18 @@ import {
   renderFilingNotice,
 } from "../sec/filing-display";
 import { useSecFilingContentCache } from "../sec/filing-content";
+import {
+  buildInsiderSummary,
+  type ParsedInsiderFiling as ParsedFiling,
+} from "./model";
+import { insiderHeadless } from "./headless";
+
+export { insiderHeadless } from "./headless";
 
 const FORM4_PAGE_SIZE = 20;
 // Recent EDGAR dumps cap at 1,000 mixed forms. Older archives are fetched
 // until this many filings or company history ends.
 const SEC_FILING_SCAN_LIMIT = 20_000;
-const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
-
-interface ParsedFiling {
-  filing: SecFilingItem;
-  transaction: InsiderTransaction | null;
-  isLoading: boolean;
-}
-
-/** Null while filings are still parsing, so the pane never claims "no activity" early. */
-function buildSummary(parsed: ParsedFiling[]): string | null {
-  if (parsed.some(({ isLoading }) => isLoading)) return null;
-  const cutoff = new Date(Date.now() - NINETY_DAYS_MS);
-  let buyShares = 0;
-  let sellShares = 0;
-  let buyValue = 0;
-  let sellValue = 0;
-
-  for (const { transaction } of parsed) {
-    if (!transaction) continue;
-    const txDate = transaction.filingDate instanceof Date ? transaction.filingDate : new Date(transaction.filingDate);
-    if (isNaN(txDate.getTime()) || txDate < cutoff) continue;
-    if (transaction.transactionType === "P") {
-      buyShares += transaction.shares;
-      buyValue += transaction.totalValue ?? 0;
-    } else if (transaction.transactionType === "S") {
-      sellShares += transaction.shares;
-      sellValue += transaction.totalValue ?? 0;
-    }
-  }
-
-  if (buyShares === 0 && sellShares === 0) return "No buy/sell activity in last 90 days.";
-
-  const parts: string[] = [];
-  if (buyShares > 0) parts.push(`Bought ${formatCompact(buyShares)} shares (${formatCurrency(buyValue)})`);
-  if (sellShares > 0) parts.push(`Sold ${formatCompact(sellShares)} shares (${formatCurrency(sellValue)})`);
-  return parts.join("  |  ");
-}
 
 function toFeedItems(parsed: ParsedFiling[]): FeedDataTableItem[] {
   return parsed.map(({ filing, transaction, isLoading }) => {
@@ -165,7 +133,7 @@ function InsiderView({ width, height, focused }: { width: number; height: number
       : allParsed
   ), [allParsed, nameFilter]);
   const feedItems = useMemo(() => toFeedItems(parsed), [parsed]);
-  const summary = useMemo(() => buildSummary(allParsed), [allParsed]);
+  const summary = useMemo(() => buildInsiderSummary(allParsed), [allParsed]);
   const selectedTransaction = parsed[selectedIdx]?.transaction ?? null;
   const openFiling = openItemId
     ? parsed.find(({ filing }) => filing.accessionNumber === openItemId)?.filing ?? null
@@ -271,15 +239,18 @@ export const insiderModule: PluginModule = {
   ],
 
   paneTemplates: [
-    createTickerSurfacePaneTemplate({
-      id: "insider-pane",
-      paneId: "insider",
-      label: "Insider",
-      description: "Insider transaction activity for the selected ticker.",
-      keywords: ["insider", "form 4", "ownership", "transactions", "ins"],
-      shortcut: "INS",
-      canCreate: (_context, options) => !options?.ticker || isUsEquityTicker(options.ticker),
-    }),
+    {
+      ...createTickerSurfacePaneTemplate({
+        id: "insider-pane",
+        paneId: "insider",
+        label: "Insider",
+        description: "Insider transaction activity for the selected ticker.",
+        keywords: ["insider", "form 4", "ownership", "transactions", "ins"],
+        shortcut: "INS",
+        canCreate: (_context, options) => !options?.ticker || isUsEquityTicker(options.ticker),
+      }),
+      headless: insiderHeadless,
+    },
   ],
 
   setup(ctx) {

--- a/src/plugins/builtin/insider/insider-data.ts
+++ b/src/plugins/builtin/insider/insider-data.ts
@@ -45,6 +45,6 @@ export function transactionTypeLabel(type: InsiderTransaction["transactionType"]
     case "S": return "SELL";
     case "A": return "AWARD";
     case "D": return "DISPOSE";
-    default: return "—";
+    default: return "-";
   }
 }

--- a/src/plugins/builtin/insider/model.ts
+++ b/src/plugins/builtin/insider/model.ts
@@ -1,0 +1,72 @@
+import type { SecFilingItem } from "../../../types/data-provider";
+import { formatCompact, formatCurrency } from "../../../utils/format";
+import {
+  transactionTypeLabel,
+  type InsiderTransaction,
+} from "./insider-data";
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+export interface ParsedInsiderFiling {
+  filing: SecFilingItem;
+  transaction: InsiderTransaction | null;
+  isLoading: boolean;
+}
+
+/** Null while filings are still parsing, so the pane never claims no activity early. */
+export function buildInsiderSummary(
+  parsed: ParsedInsiderFiling[],
+  now = Date.now(),
+): string | null {
+  if (parsed.some(({ isLoading }) => isLoading)) return null;
+  const cutoff = new Date(now - NINETY_DAYS_MS);
+  let buyShares = 0;
+  let sellShares = 0;
+  let buyValue = 0;
+  let sellValue = 0;
+
+  for (const { transaction } of parsed) {
+    if (!transaction) continue;
+    const txDate = transaction.filingDate instanceof Date
+      ? transaction.filingDate
+      : new Date(transaction.filingDate);
+    if (Number.isNaN(txDate.getTime()) || txDate < cutoff) continue;
+    if (transaction.transactionType === "P") {
+      buyShares += transaction.shares;
+      buyValue += transaction.totalValue ?? 0;
+    } else if (transaction.transactionType === "S") {
+      sellShares += transaction.shares;
+      sellValue += transaction.totalValue ?? 0;
+    }
+  }
+
+  if (buyShares === 0 && sellShares === 0) return "No buy/sell activity in last 90 days.";
+
+  const parts: string[] = [];
+  if (buyShares > 0) parts.push(`Bought ${formatCompact(buyShares)} shares (${formatCurrency(buyValue)})`);
+  if (sellShares > 0) parts.push(`Sold ${formatCompact(sellShares)} shares (${formatCurrency(sellValue)})`);
+  return parts.join("  |  ");
+}
+
+export function buildInsiderRows(parsed: readonly ParsedInsiderFiling[]) {
+  return parsed.map(({ filing, transaction, isLoading }) => ({
+    filingDate: filing.filingDate instanceof Date
+      ? filing.filingDate.toISOString()
+      : String(filing.filingDate),
+    transactionDate: transaction?.filingDate instanceof Date
+      ? transaction.filingDate.toISOString()
+      : transaction?.filingDate ? String(transaction.filingDate) : null,
+    insider: transaction?.reportedName ?? null,
+    title: transaction?.title ?? null,
+    side: transaction ? transactionTypeLabel(transaction.transactionType) : null,
+    transactionCode: transaction?.transactionType ?? null,
+    shares: transaction?.shares ?? null,
+    pricePerShare: transaction?.pricePerShare ?? null,
+    totalValue: transaction?.totalValue ?? null,
+    sharesOwnedAfter: transaction?.sharesOwned ?? null,
+    form: filing.form,
+    accessionNumber: filing.accessionNumber,
+    url: filing.filingUrl,
+    status: isLoading ? "loading" : transaction ? "parsed" : "unavailable",
+  }));
+}

--- a/src/plugins/builtin/research/analyst-headless.test.ts
+++ b/src/plugins/builtin/research/analyst-headless.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { createDefaultConfig } from "../../../types/config";
+import type { AnalystResearchData } from "../../../types/financials";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createAnalystResearchHeadless } from "./analyst-headless";
+
+const data: AnalystResearchData = {
+  symbol: "AMD",
+  currency: "USD",
+  priceTarget: { current: 150, average: 180, low: 120, median: 175, high: 230 },
+  recommendationRating: 8.4,
+  recommendations: [{ period: "current month", strongBuy: 10, buy: 8, hold: 4, sell: 1 }],
+  ratings: [
+    { date: "2026-08-20", firm: "Beta", action: "Maintains", current: "Buy", currentPriceTarget: 190 },
+    { date: "2026-08-25", firm: "Alpha", action: "Raises", current: "Buy", prior: "Hold", currentPriceTarget: 210, priorPriceTarget: 180 },
+  ],
+  earningsEstimates: [],
+  revenueEstimates: [],
+};
+
+function context(): HeadlessPaneContext {
+  return {
+    marketData: createTestDataProvider(),
+    apiClient: {} as HeadlessPaneContext["apiClient"],
+    config: createDefaultConfig("/tmp/gloomberb-headless-analyst"),
+    signal: new AbortController().signal,
+  };
+}
+
+function args(overrides: Partial<HeadlessPaneLoadArgs["options"]> = {}): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: "AMD",
+    argument: "AMD",
+    symbols: ["AMD"],
+    options: { sort: "date", order: "desc", limit: 25, ...overrides },
+  };
+}
+
+describe("analyst research headless model", () => {
+  test("projects summary and ratings while applying sort and limit", async () => {
+    const headless = createAnalystResearchHeadless({ loadData: async () => data });
+
+    const latest = await headless.load(args({ limit: 1 }), context());
+    expect(latest.sections[0]?.title).toBe("Summary");
+    const entries = "entries" in latest.sections[0]! ? latest.sections[0]!.entries : [];
+    expect(entries.slice(0, 2)).toMatchObject([
+      { label: "Average target", value: 180 },
+      { label: "Target upside", value: 0.2 },
+    ]);
+    expect(latest.sections[1]).toMatchObject({
+      title: "Recent analyst actions",
+      rows: [{ firm: "Alpha", currentPriceTarget: 210, priorPriceTarget: 180 }],
+    });
+
+    const byFirm = await headless.load(args({ sort: "firm", order: "desc", limit: 2 }), context());
+    const ratings = "rows" in byFirm.sections[1]! ? byFirm.sections[1]!.rows : [];
+    expect(ratings.map((row) => row.firm)).toEqual(["Beta", "Alpha"]);
+  });
+});

--- a/src/plugins/builtin/research/analyst-headless.ts
+++ b/src/plugins/builtin/research/analyst-headless.ts
@@ -1,0 +1,172 @@
+import type {
+  HeadlessBundleSection,
+  HeadlessPaneColumn,
+  HeadlessPaneContext,
+  HeadlessPaneDefinition,
+  HeadlessPaneEntry,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import type { AnalystResearchData } from "../../../types/financials";
+import { formatCurrency, formatPercent } from "../../../utils/format";
+import { loadAnalystResearch } from "./client";
+import {
+  formatRatingLabel,
+  formatRatingTarget,
+  latestRecommendation,
+  recommendationTotal,
+  sortRatingRows,
+  targetUpside,
+  type RatingColumnId,
+} from "./analyst-model";
+
+const RATING_COLUMNS: HeadlessPaneColumn[] = [
+  { key: "date", header: "Date" },
+  { key: "firm", header: "Firm" },
+  { key: "action", header: "Action" },
+  { key: "current", header: "Rating" },
+  {
+    key: "target",
+    header: "Target",
+    format: (_value, row) => formatRatingTarget(
+      row as unknown as AnalystResearchData["ratings"][number],
+      String(row.currency ?? "USD"),
+    ).trim(),
+  },
+  { key: "prior", header: "Prior" },
+];
+
+const SORT_COLUMNS: Record<string, RatingColumnId> = {
+  date: "date",
+  firm: "firm",
+  action: "action",
+  rating: "current",
+  target: "target",
+};
+
+function overviewEntries(data: AnalystResearchData): HeadlessPaneEntry[] {
+  const target = data.priceTarget;
+  const currency = target?.currency ?? data.currency ?? "USD";
+  const recommendation = latestRecommendation(data);
+  const upside = targetUpside(target);
+  return [
+    {
+      label: "Average target",
+      value: target?.average ?? null,
+      formatted: target?.average == null ? "-" : formatCurrency(target.average, currency),
+    },
+    {
+      label: "Target upside",
+      value: upside ?? null,
+      formatted: upside == null ? "-" : formatPercent(upside),
+    },
+    {
+      label: "Target range",
+      value: target ? { low: target.low, median: target.median, high: target.high } : null,
+      formatted: target
+        ? [target.low, target.median, target.high]
+          .map((value) => value == null ? "-" : formatCurrency(value, currency))
+          .join(" / ")
+        : "-",
+    },
+    {
+      label: "Recommendation rating",
+      value: data.recommendationRating ?? null,
+      formatted: formatRatingLabel(data.recommendationRating),
+    },
+    { label: "Analysts", value: recommendationTotal(data) },
+    {
+      label: "Recommendation mix",
+      value: recommendation ? {
+        period: recommendation.period,
+        strongBuy: recommendation.strongBuy ?? 0,
+        buy: recommendation.buy ?? 0,
+        hold: recommendation.hold ?? 0,
+        sell: recommendation.sell ?? 0,
+        strongSell: recommendation.strongSell ?? 0,
+      } : null,
+      formatted: recommendation
+        ? `SB ${recommendation.strongBuy ?? 0}  B ${recommendation.buy ?? 0}  H ${recommendation.hold ?? 0}  S ${(recommendation.sell ?? 0) + (recommendation.strongSell ?? 0)}`
+        : "-",
+    },
+  ];
+}
+
+export interface AnalystResearchHeadlessDependencies {
+  loadData(
+    symbol: string,
+    args: HeadlessPaneLoadArgs,
+    ctx: HeadlessPaneContext,
+  ): Promise<AnalystResearchData>;
+}
+
+const defaultDependencies: AnalystResearchHeadlessDependencies = {
+  loadData: (symbol, _args, ctx) => loadAnalystResearch(ctx.marketData, symbol),
+};
+
+export function createAnalystResearchHeadless(
+  dependencies: AnalystResearchHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"bundle"> {
+  return {
+    shape: "bundle",
+    argument: {
+      kind: "ticker",
+      placeholder: "ticker",
+      description: "Ticker whose analyst research should be loaded.",
+    },
+    options: [
+      {
+        key: "sort",
+        description: "Column used to sort analyst actions.",
+        type: "enum",
+        values: Object.keys(SORT_COLUMNS).map((value) => ({ value })),
+        defaultValue: "date",
+      },
+      {
+        key: "order",
+        description: "Sort direction.",
+        type: "enum",
+        values: [{ value: "desc" }, { value: "asc" }],
+        defaultValue: "desc",
+      },
+      {
+        key: "limit",
+        aliases: ["count", "rows"],
+        description: "Maximum analyst action rows.",
+        type: "integer",
+        defaultValue: 25,
+        minimum: 1,
+        maximum: 100,
+      },
+    ],
+    describe: (args) => `Analyst Research | ${args.symbols[0]}`,
+    async load(args, ctx) {
+      const symbol = args.symbols[0]!;
+      const data = await dependencies.loadData(symbol, args, ctx);
+      const currency = data.priceTarget?.currency ?? data.currency ?? "USD";
+      const ratings = sortRatingRows(data.ratings, {
+        columnId: SORT_COLUMNS[String(args.options.sort)] ?? "date",
+        direction: args.options.order === "asc" ? "asc" : "desc",
+      })
+        .slice(0, Number(args.options.limit))
+        .map((rating) => ({
+          ...rating,
+          target: rating.currentPriceTarget ?? rating.priorPriceTarget ?? null,
+          currency,
+        }));
+      const sections: HeadlessBundleSection[] = [
+        { title: "Summary", entries: overviewEntries(data) },
+        { title: "Recent analyst actions", columns: RATING_COLUMNS, rows: ratings },
+      ];
+      return {
+        sections,
+        metadata: {
+          symbol: data.symbol || symbol,
+          name: data.name ?? null,
+          currency,
+        },
+      };
+    },
+  };
+}
+
+export const analystResearchHeadless = createAnalystResearchHeadless();

--- a/src/plugins/builtin/research/analyst-model.ts
+++ b/src/plugins/builtin/research/analyst-model.ts
@@ -1,0 +1,219 @@
+import type { DataTableColumn } from "../../../components";
+import type { AnalystRatingRecord, AnalystResearchData } from "../../../types/financials";
+import { formatCurrency, formatNumber } from "../../../utils/format";
+import { compareSortValues, type SortDirection } from "../../../utils/sort-values";
+
+function compactPeriod(period: string): string {
+  return period
+    .replace("current ", "")
+    .replace("previous ", "prev ")
+    .replace("next_", "next ")
+    .replace(/_/g, " ");
+}
+
+export function targetUpside(target: AnalystResearchData["priceTarget"]): number | undefined {
+  if (!target?.average || !target.current) return undefined;
+  return (target.average - target.current) / target.current;
+}
+
+export function latestRecommendation(data: AnalystResearchData | null) {
+  return data?.recommendations[0] ?? null;
+}
+
+export function recommendationTotal(data: AnalystResearchData | null): number {
+  const rec = latestRecommendation(data);
+  if (!rec) return 0;
+  return (rec.strongBuy ?? 0) + (rec.buy ?? 0) + (rec.hold ?? 0) + (rec.sell ?? 0) + (rec.strongSell ?? 0);
+}
+
+export function formatRatingLabel(value: number | undefined): string {
+  return value == null ? "-" : `${formatNumber(value, 1)}/10`;
+}
+
+export function formatPriceTarget(value: number | undefined, currency: string): string {
+  if (value == null) return "-";
+  return formatCurrency(value, currency)
+    .replace(/\.00\b/, "")
+    .replace(/(\.\d)0\b/, "$1");
+}
+
+const TARGET_SEPARATOR = " → ";
+
+export interface RatingTargetColumnSizing {
+  targetPriorWidth: number;
+  targetCurrentWidth: number;
+}
+
+export function formatRatingTarget(
+  row: AnalystResearchData["ratings"][number],
+  currency: string,
+  sizing?: Partial<RatingTargetColumnSizing>,
+): string {
+  const current = row.currentPriceTarget;
+  const prior = row.priorPriceTarget;
+  if (current == null && prior == null) return "-";
+  if (current == null) return ` ${formatPriceTarget(prior, currency)}`;
+  if (prior == null) return ` ${formatPriceTarget(current, currency)}`;
+
+  const priorText = formatPriceTarget(prior, currency).padStart(sizing?.targetPriorWidth ?? 0);
+  const currentText = formatPriceTarget(current, currency).padEnd(sizing?.targetCurrentWidth ?? 0);
+  return ` ${priorText}${TARGET_SEPARATOR}${currentText}`;
+}
+
+export function ratingTargetDelta(row: AnalystResearchData["ratings"][number]): number | null {
+  if (row.currentPriceTarget == null || row.priorPriceTarget == null) return null;
+  return row.currentPriceTarget - row.priorPriceTarget;
+}
+
+export type RatingColumnId = "date" | "firm" | "action" | "current" | "target" | "prior";
+export type RatingColumn = DataTableColumn & { id: RatingColumnId } & Partial<RatingTargetColumnSizing>;
+
+export interface RatingSortPreference {
+  columnId: RatingColumnId;
+  direction: SortDirection;
+}
+
+export const DEFAULT_RATING_SORT: RatingSortPreference = {
+  columnId: "date",
+  direction: "desc",
+};
+
+const DEFAULT_RATING_SORT_DIRECTIONS: Record<RatingColumnId, SortDirection> = {
+  date: "desc",
+  firm: "asc",
+  action: "asc",
+  current: "asc",
+  target: "desc",
+  prior: "asc",
+};
+
+const BASE_RATING_COLUMNS: RatingColumn[] = [
+  { id: "date", label: "DATE", width: 10, align: "left" },
+  { id: "firm", label: "FIRM", width: 20, align: "left" },
+  { id: "action", label: "ACTION", width: 10, align: "left" },
+  { id: "current", label: "RATING", width: 13, align: "left" },
+  { id: "target", label: "TARGET", width: 13, align: "left" },
+  { id: "prior", label: "PRIOR", width: 13, align: "left" },
+];
+
+export function buildRatingColumns(
+  rows: readonly AnalystRatingRecord[],
+  currency: string,
+): RatingColumn[] {
+  const targetSizing = rows.reduce<RatingTargetColumnSizing>(
+    (sizing, row) => ({
+      targetPriorWidth: Math.max(
+        sizing.targetPriorWidth,
+        row.priorPriceTarget == null ? 0 : formatPriceTarget(row.priorPriceTarget, currency).length,
+      ),
+      targetCurrentWidth: Math.max(
+        sizing.targetCurrentWidth,
+        row.currentPriceTarget == null ? 0 : formatPriceTarget(row.currentPriceTarget, currency).length,
+      ),
+    }),
+    { targetPriorWidth: 0, targetCurrentWidth: 0 },
+  );
+  const targetWidth = rows.reduce(
+    (width, row) => Math.max(width, formatRatingTarget(row, currency, targetSizing).length),
+    BASE_RATING_COLUMNS.find((column) => column.id === "target")?.width ?? 13,
+  );
+
+  return BASE_RATING_COLUMNS.map((column) => {
+    return column.id === "target" ? { ...column, ...targetSizing, width: targetWidth } : column;
+  });
+}
+
+function normalizedText(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toLocaleLowerCase() : null;
+}
+
+function ratingTargetSortValue(row: AnalystRatingRecord): number | null {
+  return row.currentPriceTarget ?? row.priorPriceTarget ?? null;
+}
+
+function ratingSortValue(row: AnalystRatingRecord, columnId: RatingColumnId): string | number | null {
+  switch (columnId) {
+    case "date":
+      return normalizedText(row.date);
+    case "firm":
+      return normalizedText(row.firm);
+    case "action":
+      return normalizedText(row.action);
+    case "current":
+      return normalizedText(row.current);
+    case "target":
+      return ratingTargetSortValue(row);
+    case "prior":
+      return normalizedText(row.prior);
+  }
+}
+
+export function sortRatingRows<T extends AnalystRatingRecord>(
+  rows: readonly T[],
+  preference: RatingSortPreference,
+): T[] {
+  return rows
+    .map((row, index) => ({ row, index }))
+    .sort((left, right) => {
+      const primary = compareSortValues(
+        ratingSortValue(left.row, preference.columnId),
+        ratingSortValue(right.row, preference.columnId),
+        preference.direction,
+      );
+      if (primary !== 0) return primary;
+
+      const dateTieBreak = preference.columnId === "date"
+        ? 0
+        : compareSortValues(
+          ratingSortValue(left.row, "date"),
+          ratingSortValue(right.row, "date"),
+          "desc",
+        );
+      if (dateTieBreak !== 0) return dateTieBreak;
+
+      return left.index - right.index;
+    })
+    .map((entry) => entry.row);
+}
+
+export function nextRatingSortPreference(
+  current: RatingSortPreference,
+  columnId: string,
+): RatingSortPreference {
+  const typedColumnId = columnId as RatingColumnId;
+  if (current.columnId !== typedColumnId) {
+    return {
+      columnId: typedColumnId,
+      direction: DEFAULT_RATING_SORT_DIRECTIONS[typedColumnId] ?? "asc",
+    };
+  }
+  return {
+    columnId: typedColumnId,
+    direction: current.direction === "asc" ? "desc" : "asc",
+  };
+}
+
+export function buildAnalystSummaryLines(data: AnalystResearchData | null): string[] {
+  if (!data) return [];
+
+  const target = data.priceTarget;
+  const currency = target?.currency ?? data.currency ?? "USD";
+  const price = (value: number | undefined) => value != null ? formatCurrency(value, currency) : "-";
+  const rec = latestRecommendation(data);
+  const total = recommendationTotal(data);
+  const lines: string[] = [];
+
+  if (target) {
+    lines.push(`low ${price(target.low)}   med ${price(target.median)}   high ${price(target.high)}`);
+  }
+  if (data.recommendationRating != null || rec || total > 0) {
+    lines.push([
+      data.recommendationRating != null ? `rating ${formatRatingLabel(data.recommendationRating)}` : null,
+      rec ? `SB ${rec.strongBuy ?? 0}  B ${rec.buy ?? 0}  H ${rec.hold ?? 0}  S ${(rec.sell ?? 0) + (rec.strongSell ?? 0)}` : null,
+      total > 0 ? `${total} analysts${rec?.period ? ` (${compactPeriod(rec.period)})` : ""}` : null,
+    ].filter(Boolean).join("   "));
+  }
+
+  return lines;
+}

--- a/src/plugins/builtin/research/analyst-pane.tsx
+++ b/src/plugins/builtin/research/analyst-pane.tsx
@@ -4,84 +4,42 @@ import {
   DataTableView,
   usePaneFooter,
   type DataTableCell,
-  type DataTableColumn,
   type DataTableKeyEvent,
 } from "../../../components";
-import type { AnalystRatingRecord, AnalystResearchData } from "../../../types/financials";
+import type { AnalystResearchData } from "../../../types/financials";
 import { blendHex, colors, priceColor } from "../../../theme/colors";
-import { formatCurrency, formatNumber, formatPercent } from "../../../utils/format";
-import { compareSortValues, type SortDirection } from "../../../utils/sort-values";
+import { formatCurrency, formatPercent } from "../../../utils/format";
 import { useAssetData } from "../../runtime";
 import { handleRefreshKey, loadingErrorFooterInfo } from "../shared/table-pane";
 import { useBoundTicker as useSymbolBinding, useTickerRequest } from "../shared/ticker-request";
+import { loadAnalystResearch } from "./client";
+import {
+  DEFAULT_RATING_SORT,
+  buildAnalystSummaryLines,
+  buildRatingColumns,
+  formatRatingTarget,
+  nextRatingSortPreference,
+  ratingTargetDelta,
+  sortRatingRows,
+  targetUpside,
+  type RatingColumn,
+  type RatingSortPreference,
+} from "./analyst-model";
 
-function compactPeriod(period: string): string {
-  return period
-    .replace("current ", "")
-    .replace("previous ", "prev ")
-    .replace("next_", "next ")
-    .replace(/_/g, " ");
-}
-
-function targetUpside(target: AnalystResearchData["priceTarget"]): number | undefined {
-  if (!target?.average || !target.current) return undefined;
-  return (target.average - target.current) / target.current;
-}
-
-function latestRecommendation(data: AnalystResearchData | null) {
-  return data?.recommendations[0] ?? null;
-}
-
-function recommendationTotal(data: AnalystResearchData | null): number {
-  const rec = latestRecommendation(data);
-  if (!rec) return 0;
-  return (rec.strongBuy ?? 0) + (rec.buy ?? 0) + (rec.hold ?? 0) + (rec.sell ?? 0) + (rec.strongSell ?? 0);
-}
-
-function formatRatingLabel(value: number | undefined): string {
-  return value == null ? "-" : `${formatNumber(value, 1)}/10`;
-}
+export {
+  buildAnalystSummaryLines,
+  buildRatingColumns,
+  formatRatingTarget,
+  nextRatingSortPreference,
+  sortRatingRows,
+  type RatingSortPreference,
+} from "./analyst-model";
 
 function ratingActionColor(action: string | undefined): string {
   const normalized = action?.toLowerCase() ?? "";
   if (normalized.includes("upgrade")) return colors.positive;
   if (normalized.includes("downgrade")) return colors.negative;
   return colors.textDim;
-}
-
-function formatPriceTarget(value: number | undefined, currency: string): string {
-  if (value == null) return "-";
-  return formatCurrency(value, currency)
-    .replace(/\.00\b/, "")
-    .replace(/(\.\d)0\b/, "$1");
-}
-
-const TARGET_SEPARATOR = " → ";
-
-interface RatingTargetColumnSizing {
-  targetPriorWidth: number;
-  targetCurrentWidth: number;
-}
-
-export function formatRatingTarget(
-  row: AnalystResearchData["ratings"][number],
-  currency: string,
-  sizing?: Partial<RatingTargetColumnSizing>,
-): string {
-  const current = row.currentPriceTarget;
-  const prior = row.priorPriceTarget;
-  if (current == null && prior == null) return "-";
-  if (current == null) return ` ${formatPriceTarget(prior, currency)}`;
-  if (prior == null) return ` ${formatPriceTarget(current, currency)}`;
-
-  const priorText = formatPriceTarget(prior, currency).padStart(sizing?.targetPriorWidth ?? 0);
-  const currentText = formatPriceTarget(current, currency).padEnd(sizing?.targetCurrentWidth ?? 0);
-  return ` ${priorText}${TARGET_SEPARATOR}${currentText}`;
-}
-
-function ratingTargetDelta(row: AnalystResearchData["ratings"][number]): number | null {
-  if (row.currentPriceTarget == null || row.priorPriceTarget == null) return null;
-  return row.currentPriceTarget - row.priorPriceTarget;
 }
 
 function ratingTargetBackground(delta: number | null): string | undefined {
@@ -93,30 +51,6 @@ function ratingTargetBackground(delta: number | null): string | undefined {
  * Price targets and the recommendation mix are pane content, not status, so the
  * summary block owns them and the footer stays empty unless something changed.
  */
-export function buildAnalystSummaryLines(data: AnalystResearchData | null): string[] {
-  if (!data) return [];
-
-  const target = data.priceTarget;
-  const currency = target?.currency ?? data.currency ?? "USD";
-  const price = (value: number | undefined) => value != null ? formatCurrency(value, currency) : "-";
-  const rec = latestRecommendation(data);
-  const total = recommendationTotal(data);
-  const lines: string[] = [];
-
-  if (target) {
-    lines.push(`low ${price(target.low)}   med ${price(target.median)}   high ${price(target.high)}`);
-  }
-  if (data.recommendationRating != null || rec || total > 0) {
-    lines.push([
-      data.recommendationRating != null ? `rating ${formatRatingLabel(data.recommendationRating)}` : null,
-      rec ? `SB ${rec.strongBuy ?? 0}  B ${rec.buy ?? 0}  H ${rec.hold ?? 0}  S ${(rec.sell ?? 0) + (rec.strongSell ?? 0)}` : null,
-      total > 0 ? `${total} analysts${rec?.period ? ` (${compactPeriod(rec.period)})` : ""}` : null,
-    ].filter(Boolean).join("   "));
-  }
-
-  return lines;
-}
-
 function AnalystSummary({ data }: { data: AnalystResearchData | null }) {
   const target = data?.priceTarget;
   const upside = targetUpside(target);
@@ -147,142 +81,18 @@ function AnalystSummary({ data }: { data: AnalystResearchData | null }) {
   );
 }
 
-type RatingColumnId = "date" | "firm" | "action" | "current" | "target" | "prior";
-type RatingColumn = DataTableColumn & { id: RatingColumnId } & Partial<RatingTargetColumnSizing>;
-
-export interface RatingSortPreference {
-  columnId: RatingColumnId;
-  direction: SortDirection;
-}
-
-const DEFAULT_RATING_SORT: RatingSortPreference = {
-  columnId: "date",
-  direction: "desc",
-};
-
-const DEFAULT_RATING_SORT_DIRECTIONS: Record<RatingColumnId, SortDirection> = {
-  date: "desc",
-  firm: "asc",
-  action: "asc",
-  current: "asc",
-  target: "desc",
-  prior: "asc",
-};
-
-const BASE_RATING_COLUMNS: RatingColumn[] = [
-  { id: "date", label: "DATE", width: 10, align: "left" },
-  { id: "firm", label: "FIRM", width: 20, align: "left" },
-  { id: "action", label: "ACTION", width: 10, align: "left" },
-  { id: "current", label: "RATING", width: 13, align: "left" },
-  { id: "target", label: "TARGET", width: 13, align: "left" },
-  { id: "prior", label: "PRIOR", width: 13, align: "left" },
-];
-
-export function buildRatingColumns(
-  rows: readonly AnalystRatingRecord[],
-  currency: string,
-): RatingColumn[] {
-  const targetSizing = rows.reduce<RatingTargetColumnSizing>(
-    (sizing, row) => ({
-      targetPriorWidth: Math.max(
-        sizing.targetPriorWidth,
-        row.priorPriceTarget == null ? 0 : formatPriceTarget(row.priorPriceTarget, currency).length,
-      ),
-      targetCurrentWidth: Math.max(
-        sizing.targetCurrentWidth,
-        row.currentPriceTarget == null ? 0 : formatPriceTarget(row.currentPriceTarget, currency).length,
-      ),
-    }),
-    { targetPriorWidth: 0, targetCurrentWidth: 0 },
-  );
-  const targetWidth = rows.reduce(
-    (width, row) => Math.max(width, formatRatingTarget(row, currency, targetSizing).length),
-    BASE_RATING_COLUMNS.find((column) => column.id === "target")?.width ?? 13,
-  );
-
-  return BASE_RATING_COLUMNS.map((column) => {
-    return column.id === "target" ? { ...column, ...targetSizing, width: targetWidth } : column;
-  });
-}
-
-function normalizedText(value: string | undefined): string | null {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed.toLocaleLowerCase() : null;
-}
-
-function ratingTargetSortValue(row: AnalystRatingRecord): number | null {
-  return row.currentPriceTarget ?? row.priorPriceTarget ?? null;
-}
-
-function ratingSortValue(row: AnalystRatingRecord, columnId: RatingColumnId): string | number | null {
-  switch (columnId) {
-    case "date":
-      return normalizedText(row.date);
-    case "firm":
-      return normalizedText(row.firm);
-    case "action":
-      return normalizedText(row.action);
-    case "current":
-      return normalizedText(row.current);
-    case "target":
-      return ratingTargetSortValue(row);
-    case "prior":
-      return normalizedText(row.prior);
-  }
-}
-
-export function sortRatingRows<T extends AnalystRatingRecord>(
-  rows: readonly T[],
-  preference: RatingSortPreference,
-): T[] {
-  return rows
-    .map((row, index) => ({ row, index }))
-    .sort((left, right) => {
-      const primary = compareSortValues(
-        ratingSortValue(left.row, preference.columnId),
-        ratingSortValue(right.row, preference.columnId),
-        preference.direction,
-      );
-      if (primary !== 0) return primary;
-
-      const dateTieBreak = preference.columnId === "date"
-        ? 0
-        : compareSortValues(
-          ratingSortValue(left.row, "date"),
-          ratingSortValue(right.row, "date"),
-          "desc",
-        );
-      if (dateTieBreak !== 0) return dateTieBreak;
-
-      return left.index - right.index;
-    })
-    .map((entry) => entry.row);
-}
-
-export function nextRatingSortPreference(
-  current: RatingSortPreference,
-  columnId: string,
-): RatingSortPreference {
-  const typedColumnId = columnId as RatingColumnId;
-  if (current.columnId !== typedColumnId) {
-    return {
-      columnId: typedColumnId,
-      direction: DEFAULT_RATING_SORT_DIRECTIONS[typedColumnId] ?? "asc",
-    };
-  }
-  return {
-    columnId: typedColumnId,
-    direction: current.direction === "asc" ? "desc" : "asc",
-  };
-}
-
 export function AnalystResearchView({ focused, width, height }: { focused: boolean; width: number; height: number }) {
   const dataProvider = useAssetData();
   const { symbol, exchange } = useSymbolBinding();
   const [sortPreference, setSortPreference] = useState<RatingSortPreference>(DEFAULT_RATING_SORT);
   const loader = useCallback((nextSymbol: string, nextExchange: string, forceRefresh: boolean) => {
-    if (!dataProvider?.getAnalystResearch) throw new Error("Analyst data unavailable");
-    return dataProvider.getAnalystResearch(nextSymbol, nextExchange, forceRefresh ? { cacheMode: "refresh" } : undefined);
+    if (!dataProvider) throw new Error("Analyst data unavailable");
+    return loadAnalystResearch(
+      dataProvider,
+      nextSymbol,
+      nextExchange,
+      forceRefresh ? { cacheMode: "refresh" } : undefined,
+    );
   }, [dataProvider]);
   const { data, loading, error, reload } = useTickerRequest<AnalystResearchData>(loader, symbol, exchange);
   const rows = useMemo(() => sortRatingRows(data?.ratings ?? [], sortPreference), [data?.ratings, sortPreference]);

--- a/src/plugins/builtin/research/client.ts
+++ b/src/plugins/builtin/research/client.ts
@@ -1,0 +1,12 @@
+import type { DataProvider, MarketDataRequestContext } from "../../../types/data-provider";
+import type { AnalystResearchData } from "../../../types/financials";
+
+export async function loadAnalystResearch(
+  provider: DataProvider,
+  symbol: string,
+  exchange = "",
+  context?: MarketDataRequestContext,
+): Promise<AnalystResearchData> {
+  if (!provider.getAnalystResearch) throw new Error("Analyst data unavailable");
+  return provider.getAnalystResearch(symbol, exchange, context);
+}

--- a/src/plugins/builtin/research/index.tsx
+++ b/src/plugins/builtin/research/index.tsx
@@ -5,10 +5,13 @@ import { AnalystResearchView } from "./analyst-pane";
 import { CorporateActionsView } from "./corporate-actions-pane";
 import { EquityDiagnosticView } from "./equity-diagnostic-pane";
 import { RelativeValuationPane } from "./relative-valuation-pane";
+import { analystResearchHeadless } from "./analyst-headless";
 import { eventsHeadless } from "./events-headless";
 import { earningsEstimatesHeadless } from "./headless";
 
+export { analystResearchHeadless } from "./analyst-headless";
 export { eventsHeadless } from "./events-headless";
+export { earningsEstimatesHeadless } from "./headless";
 
 function EarningsEstimatesPane(props: { focused: boolean; width: number; height: number }) {
   return (
@@ -99,15 +102,18 @@ export const researchModule: PluginModule = {
   ],
 
   paneTemplates: [
-    createTickerSurfacePaneTemplate({
-      id: "analyst-research-pane",
-      paneId: "analyst-research",
-      label: "Analyst Research",
-      description: "Price targets, recommendations, and recent analyst actions.",
-      keywords: ["analyst", "research", "ratings", "target", "anr"],
-      shortcut: "ANR",
-      publicShare: true,
-    }),
+    {
+      ...createTickerSurfacePaneTemplate({
+        id: "analyst-research-pane",
+        paneId: "analyst-research",
+        label: "Analyst Research",
+        description: "Price targets, recommendations, and recent analyst actions.",
+        keywords: ["analyst", "research", "ratings", "target", "anr"],
+        shortcut: "ANR",
+        publicShare: true,
+      }),
+      headless: analystResearchHeadless,
+    },
     createTickerSurfacePaneTemplate({
       id: "equity-diagnostic-pane",
       paneId: "equity-diagnostic",

--- a/src/plugins/builtin/sec/client.ts
+++ b/src/plugins/builtin/sec/client.ts
@@ -1,0 +1,16 @@
+import type {
+  DataProvider,
+  MarketDataRequestContext,
+  SecFilingItem,
+} from "../../../types/data-provider";
+
+export async function loadSecFilings(
+  provider: DataProvider,
+  symbol: string,
+  count: number,
+  exchange = "",
+  context?: MarketDataRequestContext,
+): Promise<SecFilingItem[]> {
+  if (!provider.getSecFilings) throw new Error("SEC filing data unavailable");
+  return provider.getSecFilings(symbol, count, exchange, context);
+}

--- a/src/plugins/builtin/sec/headless.test.ts
+++ b/src/plugins/builtin/sec/headless.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { createDefaultConfig } from "../../../types/config";
+import type { SecFilingItem } from "../../../types/data-provider";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createSecHeadless } from "./headless";
+
+const filings: SecFilingItem[] = [
+  {
+    accessionNumber: "0000320193-26-000100",
+    form: "8-K",
+    filingDate: new Date("2026-08-25T00:00:00.000Z"),
+    primaryDocDescription: "8-K Results of Operations",
+    items: "2.02,9.01",
+    cik: "0000320193",
+    filingUrl: "https://www.sec.gov/filing/one",
+  },
+  {
+    accessionNumber: "0000320193-26-000099",
+    form: "10-Q",
+    filingDate: new Date("2026-08-20T00:00:00.000Z"),
+    cik: "0000320193",
+    filingUrl: "https://www.sec.gov/filing/two",
+  },
+];
+
+function context(): HeadlessPaneContext {
+  return {
+    marketData: createTestDataProvider(),
+    apiClient: {} as HeadlessPaneContext["apiClient"],
+    config: createDefaultConfig("/tmp/gloomberb-headless-sec"),
+    signal: new AbortController().signal,
+  };
+}
+
+function args(limit: number): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: "AAPL",
+    argument: "AAPL",
+    symbols: ["AAPL"],
+    options: { limit },
+  };
+}
+
+describe("SEC headless model", () => {
+  test("projects filing rows and honors the page limit", async () => {
+    const requestedLimits: number[] = [];
+    const headless = createSecHeadless({
+      loadFilings: async (_symbol, limit) => {
+        requestedLimits.push(limit);
+        return filings;
+      },
+    });
+
+    const first = await headless.load(args(1), context());
+    expect(first.rows).toEqual([{
+      filedAt: "2026-08-25T00:00:00.000Z",
+      acceptedAt: null,
+      form: "8-K",
+      filing: "8-K | Results of Operations | Current Report",
+      items: "2.02,9.01",
+      accessionNumber: "0000320193-26-000100",
+      primaryDocument: null,
+      cik: "0000320193",
+      url: "https://www.sec.gov/filing/one",
+    }]);
+
+    const both = await headless.load(args(2), context());
+    expect(both.rows).toHaveLength(2);
+    expect(requestedLimits).toEqual([1, 2]);
+  });
+});

--- a/src/plugins/builtin/sec/headless.ts
+++ b/src/plugins/builtin/sec/headless.ts
@@ -1,0 +1,69 @@
+import type {
+  HeadlessPaneColumn,
+  HeadlessPaneContext,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import type { SecFilingItem } from "../../../types/data-provider";
+import { loadSecFilings } from "./client";
+import { buildSecFilingRows } from "./model";
+
+const SEC_COLUMNS: HeadlessPaneColumn[] = [
+  {
+    key: "filedAt",
+    header: "Filed",
+    format: (value) => typeof value === "string" ? value.slice(0, 10) : "-",
+  },
+  { key: "form", header: "Form" },
+  { key: "filing", header: "Filing" },
+  { key: "items", header: "Items" },
+  { key: "accessionNumber", header: "Accession" },
+];
+
+export interface SecHeadlessDependencies {
+  loadFilings(
+    symbol: string,
+    limit: number,
+    args: HeadlessPaneLoadArgs,
+    ctx: HeadlessPaneContext,
+  ): Promise<SecFilingItem[]>;
+}
+
+const defaultDependencies: SecHeadlessDependencies = {
+  loadFilings: (symbol, limit, _args, ctx) => loadSecFilings(ctx.marketData, symbol, limit),
+};
+
+export function createSecHeadless(
+  dependencies: SecHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "ticker",
+      placeholder: "ticker",
+      description: "US equity ticker.",
+    },
+    options: [{
+      key: "limit",
+      aliases: ["count", "rows"],
+      description: "Maximum recent filings.",
+      type: "integer",
+      defaultValue: 50,
+      minimum: 1,
+      maximum: 200,
+    }],
+    columns: SEC_COLUMNS,
+    describe: (args) => `SEC Filings | ${args.symbols[0]}`,
+    async load(args, ctx) {
+      const symbol = args.symbols[0]!;
+      const limit = Number(args.options.limit);
+      const filings = await dependencies.loadFilings(symbol, limit, args, ctx);
+      return {
+        rows: buildSecFilingRows(filings).slice(0, limit),
+        metadata: { symbol, returned: Math.min(filings.length, limit) },
+      };
+    },
+  };
+}
+
+export const secHeadless = createSecHeadless();

--- a/src/plugins/builtin/sec/index.tsx
+++ b/src/plugins/builtin/sec/index.tsx
@@ -27,53 +27,18 @@ import {
   useSecFilingContentCache,
 } from "./filing-content";
 import { usePaneStatusLinkFooter } from "../shared/pane-footer";
+import { secHeadless } from "./headless";
+import {
+  getFilingDisplayTitle,
+  getFormDescription,
+  getMeaningfulPrimaryDescription,
+} from "./model";
+
+export { secHeadless } from "./headless";
 
 const SEC_FILING_FETCH_LIMIT = 20_000;
 const SEC_FILING_PAGE_SIZE = 50;
 const OWNERSHIP_FORMS = new Set(["3", "4", "5"]);
-
-function getDisplayFormLabel(form: string): string {
-  const trimmed = form.trim();
-  return /^\d+(?:\/[A-Z])?$/i.test(trimmed)
-    ? `FORM ${trimmed}`
-    : trimmed;
-}
-
-function normalizeComparableText(value: string): string {
-  return value
-    .toUpperCase()
-    .replace(/\bFORM\b/g, "")
-    .replace(/[^A-Z0-9]+/g, "");
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function stripRedundantFormPrefix(form: string, description: string): string {
-  const pattern = escapeRegExp(form.trim()).replace(/\s+/g, "\\s+");
-  return description
-    .trim()
-    .replace(new RegExp(`^(?:FORM\\s+)?${pattern}(?:\\s*[:|-]\\s*|\\s+)`, "i"), "")
-    .trim();
-}
-
-function getMeaningfulPrimaryDescription(filing: SecFilingItem): string | undefined {
-  const description = filing.primaryDocDescription?.trim();
-  if (!description) return undefined;
-  if (normalizeComparableText(description) === normalizeComparableText(filing.form)) return undefined;
-
-  const stripped = stripRedundantFormPrefix(filing.form, description);
-  if (!stripped) return undefined;
-  if (normalizeComparableText(stripped) === normalizeComparableText(filing.form)) return undefined;
-  return stripped;
-}
-
-function getFilingDisplayTitle(filing: SecFilingItem): string {
-  const description = getMeaningfulPrimaryDescription(filing);
-  const formLabel = getDisplayFormLabel(filing.form);
-  return description ? `${formLabel} | ${description}` : formLabel;
-}
 
 function formatFiledAt(filing: SecFilingItem): string {
   return formatFilingMetaDate(filing.filingDate);
@@ -159,29 +124,6 @@ function buildForm4Detail(content: string | null, filing: SecFilingItem): string
   if (tx.totalValue != null) lines.push(`Total Value: ${formatCurrency(tx.totalValue)}`);
   if (tx.sharesOwned != null) lines.push(`Shares Owned After: ${formatCompact(tx.sharesOwned)}`);
   return lines.join("\n");
-}
-
-function getFormDescription(form: string): string {
-  const f = form.trim().toUpperCase();
-  switch (f) {
-    case "10-K": return "Annual Report";
-    case "10-K/A": return "Annual Report (Amended)";
-    case "10-Q": return "Quarterly Report";
-    case "10-Q/A": return "Quarterly Report (Amended)";
-    case "8-K": return "Current Report";
-    case "8-K/A": return "Current Report (Amended)";
-    case "4": return "Insider Transaction";
-    case "3": return "Initial Insider Ownership";
-    case "5": return "Annual Insider Ownership";
-    case "SC 13G": return "Beneficial Ownership (Passive)";
-    case "SC 13G/A": return "Beneficial Ownership (Amended)";
-    case "SC 13D": return "Beneficial Ownership (Active)";
-    case "SC 13D/A": return "Beneficial Ownership (Amended)";
-    case "DEF 14A": return "Proxy Statement";
-    case "S-1": return "Registration Statement";
-    case "20-F": return "Annual Report (Foreign)";
-    default: return "";
-  }
 }
 
 function toFeedItems(
@@ -360,15 +302,18 @@ export const secModule: PluginModule = {
   ],
 
   paneTemplates: [
-    createTickerSurfacePaneTemplate({
-      id: "sec-pane",
-      paneId: "sec",
-      label: "SEC",
-      description: "Recent SEC filings for the selected ticker.",
-      keywords: ["sec", "filings", "10-k", "10-q", "8-k"],
-      shortcut: "SEC",
-      canCreate: (_context, options) => !options?.ticker || isUsEquityTicker(options.ticker),
-    }),
+    {
+      ...createTickerSurfacePaneTemplate({
+        id: "sec-pane",
+        paneId: "sec",
+        label: "SEC",
+        description: "Recent SEC filings for the selected ticker.",
+        keywords: ["sec", "filings", "10-k", "10-q", "8-k"],
+        shortcut: "SEC",
+        canCreate: (_context, options) => !options?.ticker || isUsEquityTicker(options.ticker),
+      }),
+      headless: secHeadless,
+    },
   ],
 
   setup(ctx) {

--- a/src/plugins/builtin/sec/model.ts
+++ b/src/plugins/builtin/sec/model.ts
@@ -1,0 +1,89 @@
+import type { SecFilingItem } from "../../../types/data-provider";
+
+export function getDisplayFormLabel(form: string): string {
+  const trimmed = form.trim();
+  return /^\d+(?:\/[A-Z])?$/i.test(trimmed)
+    ? `FORM ${trimmed}`
+    : trimmed;
+}
+
+function normalizeComparableText(value: string): string {
+  return value
+    .toUpperCase()
+    .replace(/\bFORM\b/g, "")
+    .replace(/[^A-Z0-9]+/g, "");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function stripRedundantFormPrefix(form: string, description: string): string {
+  const pattern = escapeRegExp(form.trim()).replace(/\s+/g, "\\s+");
+  return description
+    .trim()
+    .replace(new RegExp(`^(?:FORM\\s+)?${pattern}(?:\\s*[:|-]\\s*|\\s+)`, "i"), "")
+    .trim();
+}
+
+export function getMeaningfulPrimaryDescription(filing: SecFilingItem): string | undefined {
+  const description = filing.primaryDocDescription?.trim();
+  if (!description) return undefined;
+  if (normalizeComparableText(description) === normalizeComparableText(filing.form)) return undefined;
+
+  const stripped = stripRedundantFormPrefix(filing.form, description);
+  if (!stripped) return undefined;
+  if (normalizeComparableText(stripped) === normalizeComparableText(filing.form)) return undefined;
+  return stripped;
+}
+
+export function getFilingDisplayTitle(filing: SecFilingItem): string {
+  const description = getMeaningfulPrimaryDescription(filing);
+  const formLabel = getDisplayFormLabel(filing.form);
+  return description ? `${formLabel} | ${description}` : formLabel;
+}
+
+export function getFormDescription(form: string): string {
+  const normalized = form.trim().toUpperCase();
+  switch (normalized) {
+    case "10-K": return "Annual Report";
+    case "10-K/A": return "Annual Report (Amended)";
+    case "10-Q": return "Quarterly Report";
+    case "10-Q/A": return "Quarterly Report (Amended)";
+    case "8-K": return "Current Report";
+    case "8-K/A": return "Current Report (Amended)";
+    case "4": return "Insider Transaction";
+    case "3": return "Initial Insider Ownership";
+    case "5": return "Annual Insider Ownership";
+    case "SC 13G": return "Beneficial Ownership (Passive)";
+    case "SC 13G/A": return "Beneficial Ownership (Amended)";
+    case "SC 13D": return "Beneficial Ownership (Active)";
+    case "SC 13D/A": return "Beneficial Ownership (Amended)";
+    case "DEF 14A": return "Proxy Statement";
+    case "S-1": return "Registration Statement";
+    case "20-F": return "Annual Report (Foreign)";
+    default: return "";
+  }
+}
+
+export function buildSecFilingRows(filings: readonly SecFilingItem[]) {
+  return filings.map((filing) => {
+    const displayTitle = getFilingDisplayTitle(filing);
+    const formDescription = getFormDescription(filing.form);
+    return {
+      filedAt: filing.filingDate instanceof Date
+        ? filing.filingDate.toISOString()
+        : String(filing.filingDate),
+      acceptedAt: filing.acceptedAt instanceof Date
+        ? filing.acceptedAt.toISOString()
+        : filing.acceptedAt ? String(filing.acceptedAt) : null,
+      form: filing.form,
+      filing: formDescription ? `${displayTitle} | ${formDescription}` : displayTitle,
+      items: filing.items ?? null,
+      accessionNumber: filing.accessionNumber,
+      primaryDocument: filing.primaryDocument ?? null,
+      cik: filing.cik,
+      url: filing.filingUrl,
+    };
+  });
+}

--- a/src/plugins/builtin/short-interest/client.ts
+++ b/src/plugins/builtin/short-interest/client.ts
@@ -110,9 +110,12 @@ function normalizeCloudRecords(payload: CloudShortInterestPayload): ShortInteres
  * Yahoo carries the current and prior settlement plus percent of float, so it
  * stays as the fallback when the cloud route is unavailable.
  */
-export async function fetchShortInterest(symbol: string): Promise<ShortInterestRecord[]> {
+export async function fetchShortInterest(
+  symbol: string,
+  cloudClient: Pick<typeof apiClient, "getCloudShortInterest"> = apiClient,
+): Promise<ShortInterestRecord[]> {
   try {
-    const response = await apiClient.getCloudShortInterest(symbol);
+    const response = await cloudClient.getCloudShortInterest(symbol);
     const records = response.status === "success" && response.data
       ? normalizeCloudRecords(response.data)
       : [];

--- a/src/plugins/builtin/short-interest/headless.test.ts
+++ b/src/plugins/builtin/short-interest/headless.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { CloudDataApi } from "../../../api-client/data";
+import type { CloudMarketResponse, CloudShortInterestPayload } from "../../../api-client/types";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { createDefaultConfig } from "../../../types/config";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { fetchShortInterest } from "./client";
+import { createShortInterestHeadless } from "./headless";
+
+const records = [
+  {
+    settlementDate: new Date("2026-08-15T00:00:00.000Z"),
+    sharesShort: 12_000_000,
+    shortRatio: 2.5,
+    averageDailyVolume: 4_800_000,
+    shortPercentFloat: 3.2,
+  },
+  {
+    settlementDate: new Date("2026-08-31T00:00:00.000Z"),
+    sharesShort: 15_000_000,
+    shortRatio: 3,
+    averageDailyVolume: 5_000_000,
+    shortPercentFloat: 4.1,
+  },
+];
+
+function context(): HeadlessPaneContext {
+  return {
+    marketData: createTestDataProvider(),
+    apiClient: {} as HeadlessPaneContext["apiClient"],
+    config: createDefaultConfig("/tmp/gloomberb-headless-short-interest"),
+    signal: new AbortController().signal,
+  };
+}
+
+function args(overrides: Partial<HeadlessPaneLoadArgs["options"]> = {}): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: "AMD",
+    argument: "AMD",
+    symbols: ["AMD"],
+    options: { order: "newest", limit: 24, ...overrides },
+  };
+}
+
+describe("short interest client", () => {
+  test("uses the served market route for FINRA history", async () => {
+    const paths: string[] = [];
+    const dataApi = new CloudDataApi(async <T>(path: string): Promise<T> => {
+      paths.push(path);
+      return {
+        status: "success",
+        data: {
+          symbol: "AAPL",
+          issueName: "Apple Inc.",
+          points: [{
+            settlementDate: "2026-08-31",
+            sharesShort: 15_000_000,
+            previousSharesShort: 12_000_000,
+            averageDailyVolume: 5_000_000,
+            daysToCover: 3,
+            changePercent: 25,
+            revised: false,
+          }],
+        },
+      } as CloudMarketResponse<CloudShortInterestPayload> as T;
+    });
+
+    const result = await fetchShortInterest("aapl", dataApi);
+
+    expect(paths).toEqual(["/market/short-interest?symbol=AAPL"]);
+    expect(result[0]).toMatchObject({ sharesShort: 15_000_000, shortRatio: 3 });
+  });
+});
+
+describe("short interest headless model", () => {
+  test("projects raw settlement values and applies order and limit", async () => {
+    const headless = createShortInterestHeadless({
+      loadRecords: async () => records,
+    });
+
+    const newest = await headless.load(args({ limit: 1 }), context());
+    expect(newest.rows).toEqual([{
+      settlementDate: "2026-08-31",
+      sharesShort: 15_000_000,
+      daysToCover: 3,
+      averageDailyVolume: 5_000_000,
+      shortPercentFloat: 4.1,
+    }]);
+
+    const oldest = await headless.load(args({ order: "oldest", limit: 1 }), context());
+    expect(oldest.rows[0]).toMatchObject({
+      settlementDate: "2026-08-15",
+      sharesShort: 12_000_000,
+    });
+  });
+});

--- a/src/plugins/builtin/short-interest/headless.ts
+++ b/src/plugins/builtin/short-interest/headless.ts
@@ -1,0 +1,111 @@
+import type {
+  HeadlessPaneColumn,
+  HeadlessPaneContext,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import { formatCompact, formatNumber } from "../../../utils/format";
+import { fetchShortInterest } from "./client";
+import {
+  buildRows,
+  sortRows,
+  type SortPreference,
+} from "./model";
+import type { ShortInterestRecord } from "./types";
+
+const SHORT_INTEREST_COLUMNS: HeadlessPaneColumn[] = [
+  { key: "settlementDate", header: "Date" },
+  {
+    key: "sharesShort",
+    header: "Shares Short",
+    align: "right",
+    format: (value) => formatCompact(Number(value)),
+  },
+  {
+    key: "daysToCover",
+    header: "Days to Cover",
+    align: "right",
+    format: (value) => value == null ? "-" : formatNumber(Number(value), 2),
+  },
+  {
+    key: "averageDailyVolume",
+    header: "Avg Daily Vol",
+    align: "right",
+    format: (value) => value == null ? "-" : formatCompact(Number(value)),
+  },
+  {
+    key: "shortPercentFloat",
+    header: "% Float",
+    align: "right",
+    format: (value) => value == null ? "-" : `${formatNumber(Number(value), 2)}%`,
+  },
+];
+
+export interface ShortInterestHeadlessDependencies {
+  loadRecords(
+    symbol: string,
+    args: HeadlessPaneLoadArgs,
+    ctx: HeadlessPaneContext,
+  ): Promise<ShortInterestRecord[]>;
+}
+
+const defaultDependencies: ShortInterestHeadlessDependencies = {
+  loadRecords: (symbol, _args, ctx) => fetchShortInterest(symbol, ctx.apiClient),
+};
+
+export function createShortInterestHeadless(
+  dependencies: ShortInterestHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "ticker",
+      placeholder: "ticker",
+      description: "US equity ticker.",
+    },
+    options: [
+      {
+        key: "order",
+        description: "Settlement date order.",
+        type: "enum",
+        values: [{ value: "newest" }, { value: "oldest" }],
+        defaultValue: "newest",
+      },
+      {
+        key: "limit",
+        aliases: ["count", "rows"],
+        description: "Maximum settlement rows.",
+        type: "integer",
+        defaultValue: 24,
+        minimum: 1,
+        maximum: 100,
+      },
+    ],
+    columns: SHORT_INTEREST_COLUMNS,
+    describe: (args) => `Short Interest | ${args.symbols[0]}`,
+    async load(args, ctx) {
+      const symbol = args.symbols[0]!;
+      const records = await dependencies.loadRecords(symbol, args, ctx);
+      const preference: SortPreference = {
+        columnId: "settlementDate",
+        direction: args.options.order === "oldest" ? "asc" : "desc",
+      };
+      const limit = Number(args.options.limit);
+      const rows = sortRows(buildRows(records), preference)
+        .slice(0, limit)
+        .map((row) => ({
+          settlementDate: row.settlementDate,
+          sharesShort: row.record.sharesShort,
+          daysToCover: row.record.shortRatio,
+          averageDailyVolume: row.record.averageDailyVolume,
+          shortPercentFloat: row.record.shortPercentFloat,
+        }));
+      return {
+        rows,
+        metadata: { symbol, order: args.options.order },
+      };
+    },
+  };
+}
+
+export const shortInterestHeadless = createShortInterestHeadless();

--- a/src/plugins/builtin/short-interest/index.tsx
+++ b/src/plugins/builtin/short-interest/index.tsx
@@ -5,7 +5,10 @@ import {
   resetShortInterestHealth,
   YAHOO_SHORT_INTEREST_CONNECTION_ID,
 } from "./client";
+import { shortInterestHeadless } from "./headless";
 import { ShortInterestView } from "./pane";
+
+export { shortInterestHeadless } from "./headless";
 
 let disposeConnection: (() => void) | null = null;
 
@@ -50,14 +53,17 @@ export const shortInterestModule: PluginModule = {
   ],
 
   paneTemplates: [
-    createTickerSurfacePaneTemplate({
-      id: "short-interest-pane",
-      paneId: "short-interest",
-      label: "Short Interest",
-      // Yahoo's key-statistics module only carries the current and prior settlement dates.
-      description: "Bi-monthly short interest settlements from FINRA with days to cover and average daily volume.",
-      keywords: ["short", "interest", "si", "shorts", "borrow", "days", "cover"],
-      shortcut: "SI",
-    }),
+    {
+      ...createTickerSurfacePaneTemplate({
+        id: "short-interest-pane",
+        paneId: "short-interest",
+        label: "Short Interest",
+        // Yahoo's key-statistics module only carries the current and prior settlement dates.
+        description: "Bi-monthly short interest settlements from FINRA with days to cover and average daily volume.",
+        keywords: ["short", "interest", "si", "shorts", "borrow", "days", "cover"],
+        shortcut: "SI",
+      }),
+      headless: shortInterestHeadless,
+    },
   ],
 };

--- a/src/plugins/builtin/thirteenf/data.ts
+++ b/src/plugins/builtin/thirteenf/data.ts
@@ -45,35 +45,37 @@ export async function loadBrowserRows(
   tab: ThirteenFBrowserTab,
   query: string,
   signal?: AbortSignal,
-  options: { forceRefresh?: boolean; offset?: number } = {},
+  options: { forceRefresh?: boolean; offset?: number; limit?: number } = {},
 ): Promise<BrowserLoadResult> {
   const now = new Date();
   const from = dateYearsAgo(2, now);
   const to = todayIso(now);
   const quarter = latestLikely13FQuarter(now);
   const offset = Math.max(0, options.offset ?? 0);
+  const browserLimit = Math.max(1, options.limit ?? BROWSER_PAGE_LIMIT);
+  const latestLimit = Math.max(1, options.limit ?? LATEST_FILINGS_PAGE_LIMIT);
   const apiOptions = { forceRefresh: options.forceRefresh };
   const pageApiOptions = { forceRefresh: options.forceRefresh, offset };
 
   if (tab === "performance") {
-    const topFunds = await listTopThirteenFFunds(quarter, BROWSER_PAGE_LIMIT, signal, pageApiOptions);
+    const topFunds = await listTopThirteenFFunds(quarter, browserLimit, signal, pageApiOptions);
     const funds: ThirteenFFund[] = topFunds.map((fund) => ({ cik: fund.cik, name: fund.name }));
-    const forms = await loadLatestFormsForFunds(funds.slice(0, FORM_ENRICHMENT_LIMIT), { from, to, signal, concurrency: 5, forceRefresh: options.forceRefresh });
+    const forms = await loadLatestFormsForFunds(funds.slice(0, Math.min(browserLimit, FORM_ENRICHMENT_LIMIT)), { from, to, signal, concurrency: 5, forceRefresh: options.forceRefresh });
     return {
       rows: buildBrowserRows({ topFunds, forms, source: "performance" }),
       quarter,
       period: topFunds[0]?.periodOfReport,
-      hasMore: topFunds.length >= BROWSER_PAGE_LIMIT,
+      hasMore: topFunds.length >= browserLimit,
       nextOffset: offset + topFunds.length,
     };
   }
 
   if (tab === "latest") {
-    const filings = await listThirteenFFilings(recentIso(21, now), to, LATEST_FILINGS_PAGE_LIMIT, signal, pageApiOptions);
+    const filings = await listThirteenFFilings(recentIso(21, now), to, latestLimit, signal, pageApiOptions);
     return {
       rows: buildBrowserRows({ latestFilings: filings, source: "latest" }),
       period: filings[0]?.periodOfReport,
-      hasMore: filings.length >= LATEST_FILINGS_PAGE_LIMIT,
+      hasMore: filings.length >= latestLimit,
       nextOffset: offset + filings.length,
     };
   }
@@ -97,7 +99,7 @@ export async function loadBrowserRows(
     try {
       const holders = await lookupThirteenFHoldersByCusip(cusip, periodOfReport, signal, apiOptions);
       const forms = new Map<string, ThirteenFFormSummary>();
-      const pageCiks = holders.ciks.slice(offset, offset + BROWSER_PAGE_LIMIT);
+      const pageCiks = holders.ciks.slice(offset, offset + browserLimit);
       const funds = await Promise.all(pageCiks.map(async (cik): Promise<ThirteenFFund> => {
         const fundForms = await listThirteenFForms(cik, from, to, 1, signal, apiOptions);
         if (fundForms[0]) forms.set(cik, fundForms[0]);
@@ -136,10 +138,10 @@ export async function loadBrowserRows(
       nextOffset: offset + 1,
     };
   }
-  const funds = await searchThirteenFFunds(trimmed, BROWSER_PAGE_LIMIT, signal, pageApiOptions);
+  const funds = await searchThirteenFFunds(trimmed, browserLimit, signal, pageApiOptions);
   const [forms, topFunds] = await Promise.all([
-    loadLatestFormsForFunds(funds.slice(0, FORM_ENRICHMENT_LIMIT), { from, to, signal, concurrency: 5, forceRefresh: options.forceRefresh }),
-    listTopThirteenFFunds(quarter, BROWSER_PAGE_LIMIT, signal, { forceRefresh: options.forceRefresh }).catch(() => []),
+    loadLatestFormsForFunds(funds.slice(0, Math.min(browserLimit, FORM_ENRICHMENT_LIMIT)), { from, to, signal, concurrency: 5, forceRefresh: options.forceRefresh }),
+    listTopThirteenFFunds(quarter, browserLimit, signal, { forceRefresh: options.forceRefresh }).catch(() => []),
   ]);
   const topByCik = new Map(topFunds.map((fund) => [fund.cik, fund]));
   const matchedTopFunds = funds
@@ -153,7 +155,7 @@ export async function loadBrowserRows(
       source: "funds",
     }),
     quarter,
-    hasMore: funds.length >= BROWSER_PAGE_LIMIT,
+    hasMore: funds.length >= browserLimit,
     nextOffset: offset + funds.length,
   };
 }

--- a/src/plugins/builtin/thirteenf/headless.test.ts
+++ b/src/plugins/builtin/thirteenf/headless.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { createDefaultConfig } from "../../../types/config";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createThirteenFHeadless } from "./headless";
+import type { FundDetailData } from "./types";
+
+const detail: FundDetailData = {
+  cik: "0001067983",
+  name: "Berkshire Hathaway",
+  forms: [
+    {
+      url: "https://www.sec.gov/latest",
+      accessionNumber: "latest",
+      submissionType: "13F-HR",
+      periodOfReport: "2026-06-30",
+      filedAsOfDate: "2026-08-14",
+      cik: "0001067983",
+      companyName: "Berkshire Hathaway",
+      tableValueTotal: 300,
+      tableEntryTotal: 2,
+      isAmendment: false,
+    },
+    {
+      url: "https://www.sec.gov/previous",
+      accessionNumber: "previous",
+      submissionType: "13F-HR",
+      periodOfReport: "2026-03-31",
+      filedAsOfDate: "2026-05-15",
+      cik: "0001067983",
+      companyName: "Berkshire Hathaway",
+      tableValueTotal: 200,
+      tableEntryTotal: 1,
+      isAmendment: false,
+    },
+  ],
+  latestForm: null,
+  previousForm: null,
+  latestHoldings: [],
+  previousHoldings: [],
+};
+detail.latestForm = detail.forms[0]!;
+detail.previousForm = detail.forms[1]!;
+detail.latestHoldings = [
+  {
+    accessionNumber: "latest",
+    cik: detail.cik,
+    issuer: "Apple Inc",
+    titleOfClass: "COM",
+    cusip: "037833100",
+    ticker: "AAPL",
+    value: 300,
+    shares: 3,
+    shareType: "SH",
+    investmentDiscretion: "DFND",
+    votingAuthoritySole: 3,
+    votingAuthorityShared: 0,
+    votingAuthorityNone: 0,
+    putCall: "",
+  },
+];
+detail.previousHoldings = [{ ...detail.latestHoldings[0]!, accessionNumber: "previous", value: 200, shares: 2 }];
+
+function context(): HeadlessPaneContext {
+  return {
+    marketData: createTestDataProvider(),
+    apiClient: {} as HeadlessPaneContext["apiClient"],
+    config: createDefaultConfig("/tmp/gloomberb-headless-thirteenf"),
+    signal: new AbortController().signal,
+  };
+}
+
+function args(view: string, limit = 50): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: "1067983",
+    argument: "1067983",
+    symbols: [],
+    options: { view, limit },
+  };
+}
+
+describe("13F headless model", () => {
+  test("projects browser rows and switches to fund holdings", async () => {
+    const headless = createThirteenFHeadless({
+      loadBrowser: async () => ({
+        rows: [
+          { id: "one", cik: detail.cik, name: detail.name, estQuarterReturn: 8.2, source: "performance" },
+          { id: "two", cik: "0000000002", name: "Second Fund", estQuarterReturn: 4.1, source: "performance" },
+        ],
+        quarter: "2026Q2",
+      }),
+      loadDetail: async () => detail,
+    });
+
+    const browser = await headless.load(args("performance", 1), context());
+    expect(browser.rows).toEqual([expect.objectContaining({
+      cik: detail.cik,
+      name: detail.name,
+      estQuarterReturn: 8.2,
+    })]);
+
+    const holdings = await headless.load(args("holdings", 5), context());
+    expect(holdings.rows).toEqual([expect.objectContaining({
+      ticker: "AAPL",
+      value: 300,
+      sharesChange: 1,
+      action: "add",
+      actionLabel: "Add",
+    })]);
+    expect(holdings.metadata).toMatchObject({ view: "holdings", fund: detail.name });
+  });
+});

--- a/src/plugins/builtin/thirteenf/headless.ts
+++ b/src/plugins/builtin/thirteenf/headless.ts
@@ -1,0 +1,286 @@
+import type {
+  HeadlessPaneColumn,
+  HeadlessPaneContext,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import { normalizeCik } from "./api";
+import {
+  loadBrowserRows,
+  loadFundDetail,
+  type BrowserLoadResult,
+} from "./data";
+import {
+  DEFAULT_BROWSER_SORT,
+  DEFAULT_HOLDING_SORT,
+  DEFAULT_TIMELINE_SORT,
+  buildFundHoldingRows,
+  buildTimelineRows,
+  inferBrowserTabFromQuery,
+  isCikQuery,
+  positionType,
+  sortBrowserRows,
+  sortHoldingRows,
+  sortTimelineRows,
+} from "./model";
+import {
+  actionLabel,
+  formatChangeShares,
+  formatMoneyCompact,
+  formatPercentMaybe,
+  formatRawPercentMaybe,
+  formatShares,
+  formatShortDate,
+} from "./format";
+import type {
+  FundDetailData,
+  ThirteenFBrowserTab,
+} from "./types";
+
+const BROWSER_COLUMNS: HeadlessPaneColumn[] = [
+  { key: "name", header: "Fund" },
+  { key: "cik", header: "CIK" },
+  { key: "periodOfReport", header: "Period" },
+  {
+    key: "estQuarterReturn",
+    header: "Est 13F",
+    align: "right",
+    format: (value) => formatRawPercentMaybe(value == null ? null : Number(value)),
+  },
+  {
+    key: "tableValueTotal",
+    header: "Value",
+    align: "right",
+    format: (value) => formatMoneyCompact(value == null ? null : Number(value)),
+  },
+  { key: "tableEntryTotal", header: "Rows", align: "right" },
+  {
+    key: "filedAsOfDate",
+    header: "Filed",
+    format: (value) => formatShortDate(typeof value === "string" ? value : null),
+  },
+];
+
+const HOLDING_COLUMNS: HeadlessPaneColumn[] = [
+  { key: "ticker", header: "Ticker" },
+  { key: "type", header: "Type" },
+  { key: "issuer", header: "Issuer" },
+  {
+    key: "value",
+    header: "Value",
+    align: "right",
+    format: (value) => formatMoneyCompact(value == null ? null : Number(value)),
+  },
+  {
+    key: "estimatedPnl",
+    header: "Est P&L",
+    align: "right",
+    format: (value) => formatMoneyCompact(value == null ? null : Number(value)),
+  },
+  {
+    key: "weight",
+    header: "Weight",
+    align: "right",
+    format: (value) => formatPercentMaybe(value == null ? null : Number(value)),
+  },
+  {
+    key: "shares",
+    header: "Shares",
+    align: "right",
+    format: (value) => formatShares(value == null ? null : Number(value)),
+  },
+  {
+    key: "sharesChange",
+    header: "QoQ",
+    align: "right",
+    format: (value) => formatChangeShares(value == null ? null : Number(value)),
+  },
+  { key: "actionLabel", header: "Action" },
+];
+
+const FILING_COLUMNS: HeadlessPaneColumn[] = [
+  { key: "periodOfReport", header: "Period" },
+  {
+    key: "filedAsOfDate",
+    header: "Filed",
+    format: (value) => formatShortDate(typeof value === "string" ? value : null),
+  },
+  {
+    key: "tableValueTotal",
+    header: "Value",
+    align: "right",
+    format: (value) => formatMoneyCompact(value == null ? null : Number(value)),
+  },
+  { key: "tableEntryTotal", header: "Rows", align: "right" },
+  {
+    key: "valueChangePercent",
+    header: "Value%",
+    align: "right",
+    format: (value) => formatPercentMaybe(value == null ? null : Number(value)),
+  },
+  { key: "submissionType", header: "Form" },
+];
+
+type HeadlessThirteenFView =
+  | "auto"
+  | "performance"
+  | "funds"
+  | "by-ticker"
+  | "latest"
+  | "holdings"
+  | "filings";
+
+export interface ThirteenFHeadlessDependencies {
+  loadBrowser(
+    tab: ThirteenFBrowserTab,
+    query: string,
+    limit: number,
+    args: HeadlessPaneLoadArgs,
+    ctx: HeadlessPaneContext,
+  ): Promise<BrowserLoadResult>;
+  loadDetail(
+    cik: string,
+    name: string,
+    args: HeadlessPaneLoadArgs,
+    ctx: HeadlessPaneContext,
+  ): Promise<FundDetailData>;
+}
+
+const defaultDependencies: ThirteenFHeadlessDependencies = {
+  loadBrowser: (tab, query, limit, _args, ctx) => loadBrowserRows(
+    tab,
+    query,
+    ctx.signal,
+    { limit },
+  ),
+  loadDetail: (cik, name, _args, ctx) => loadFundDetail(cik, name, ctx.signal),
+};
+
+function browserTab(view: HeadlessThirteenFView, query: string): ThirteenFBrowserTab {
+  if (view === "performance" || view === "funds" || view === "latest") return view;
+  if (view === "by-ticker") return "byTicker";
+  return inferBrowserTabFromQuery(query);
+}
+
+async function resolveFund(
+  query: string,
+  limit: number,
+  args: HeadlessPaneLoadArgs,
+  ctx: HeadlessPaneContext,
+  dependencies: ThirteenFHeadlessDependencies,
+): Promise<{ cik: string; name: string }> {
+  if (!query) throw new Error("13F holdings and filings require a fund name or CIK.");
+  if (isCikQuery(query)) return { cik: normalizeCik(query), name: query };
+  const result = await dependencies.loadBrowser("funds", query, Math.min(limit, 25), args, ctx);
+  const exact = result.rows.find((row) => row.name.toLocaleLowerCase() === query.toLocaleLowerCase());
+  const fund = exact ?? result.rows[0];
+  if (!fund) throw new Error(`No 13F fund found for "${query}".`);
+  return { cik: fund.cik, name: fund.name };
+}
+
+export function createThirteenFHeadless(
+  dependencies: ThirteenFHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "free-text",
+      placeholder: "fund, ticker, or CIK",
+      description: "Optional fund name, ticker, CIK, or latest keyword.",
+      optional: true,
+    },
+    options: [
+      {
+        key: "view",
+        description: "Fund browser mode or detail tab.",
+        type: "enum",
+        values: [
+          { value: "auto" },
+          { value: "performance" },
+          { value: "funds" },
+          { value: "by-ticker", aliases: ["ticker", "byTicker"] },
+          { value: "latest" },
+          { value: "holdings" },
+          { value: "filings" },
+        ],
+        defaultValue: "auto",
+      },
+      {
+        key: "limit",
+        aliases: ["count", "rows"],
+        description: "Maximum rows.",
+        type: "integer",
+        defaultValue: 50,
+        minimum: 1,
+        maximum: 200,
+      },
+    ],
+    describe: (args) => `13F Funds | ${String(args.options.view)}`,
+    async load(args, ctx) {
+      const query = typeof args.argument === "string" ? args.argument.trim() : "";
+      const requestedView = String(args.options.view) as HeadlessThirteenFView;
+      const view = requestedView === "auto" && isCikQuery(query) ? "holdings" : requestedView;
+      const limit = Number(args.options.limit);
+
+      if (view === "holdings" || view === "filings") {
+        const fund = await resolveFund(query, limit, args, ctx, dependencies);
+        const detail = await dependencies.loadDetail(fund.cik, fund.name, args, ctx);
+        if (view === "filings") {
+          const rows = sortTimelineRows(buildTimelineRows(detail.forms), DEFAULT_TIMELINE_SORT)
+            .slice(0, limit)
+            .map((row) => ({ ...row }));
+          return {
+            columns: FILING_COLUMNS,
+            rows,
+            metadata: {
+              view,
+              cik: detail.cik,
+              fund: detail.name,
+              latestPeriod: detail.latestForm?.periodOfReport ?? null,
+            },
+          };
+        }
+        const rows = sortHoldingRows(
+          buildFundHoldingRows(detail).filter((row) => row.value != null),
+          DEFAULT_HOLDING_SORT,
+        )
+          .slice(0, limit)
+          .map((row) => ({
+            ...row,
+            type: positionType(row),
+            actionLabel: actionLabel(row.action),
+          }));
+        return {
+          columns: HOLDING_COLUMNS,
+          rows,
+          metadata: {
+            view,
+            cik: detail.cik,
+            fund: detail.name,
+            latestPeriod: detail.latestForm?.periodOfReport ?? null,
+            previousPeriod: detail.previousForm?.periodOfReport ?? null,
+          },
+        };
+      }
+
+      const tab = browserTab(view, query);
+      const result = await dependencies.loadBrowser(tab, query, limit, args, ctx);
+      return {
+        columns: BROWSER_COLUMNS,
+        rows: sortBrowserRows(result.rows, DEFAULT_BROWSER_SORT)
+          .slice(0, limit)
+          .map((row) => ({ ...row })),
+        ...(result.warning ? { errors: [result.warning] } : {}),
+        metadata: {
+          view: tab,
+          query: query || null,
+          period: result.period ?? null,
+          quarter: result.quarter ?? null,
+          hasMore: result.hasMore ?? false,
+        },
+      };
+    },
+  };
+}
+
+export const thirteenFHeadless = createThirteenFHeadless();

--- a/src/plugins/builtin/thirteenf/index.tsx
+++ b/src/plugins/builtin/thirteenf/index.tsx
@@ -11,6 +11,9 @@ import {
   attachThirteenFApiPersistence,
   resetThirteenFApiPersistence,
 } from "./api";
+import { thirteenFHeadless } from "./headless";
+
+export { thirteenFHeadless } from "./headless";
 
 function queryFromOptions(options?: PaneTemplateCreateOptions): string {
   return (options?.arg ?? options?.values?.query ?? "").trim();
@@ -55,6 +58,7 @@ export const thirteenFModule: PluginModule = {
         argKind: "text",
         argOptional: true,
       },
+      headless: thirteenFHeadless,
       createInstance(_context: PaneTemplateContext, options?: PaneTemplateCreateOptions) {
         const query = queryFromOptions(options);
         const browserMode = inferBrowserTabFromQuery(query);

--- a/src/plugins/builtin/thirteenf/model.ts
+++ b/src/plugins/builtin/thirteenf/model.ts
@@ -615,6 +615,19 @@ export function selectedIndexById<T extends { id: string }>(rows: T[], selectedI
   return index >= 0 ? index : rows.length > 0 ? 0 : -1;
 }
 
+export function positionType(row: {
+  putCall: string;
+  titleOfClass: string;
+  shareType: string;
+}): string {
+  const putCall = row.putCall.trim().toUpperCase();
+  if (putCall === "PUT" || putCall === "CALL") return putCall;
+  const title = row.titleOfClass.trim().toUpperCase();
+  if (title) return title;
+  const shareType = row.shareType.trim().toUpperCase();
+  return shareType || "--";
+}
+
 export function isCikQuery(query: string): boolean {
   return CIK_RE.test(query.trim());
 }

--- a/src/plugins/builtin/thirteenf/table.ts
+++ b/src/plugins/builtin/thirteenf/table.ts
@@ -12,6 +12,7 @@ import {
   formatShares,
   formatShortDate,
 } from "./format";
+import { positionType } from "./model";
 import type {
   FilingPositionColumn,
   FilingPositionRow,
@@ -82,7 +83,7 @@ export function renderHoldingCell(
         attributes: TextAttributes.BOLD,
       };
     case "type":
-      return { text: formatPositionType(row), color: selectedColor ?? colors.textDim };
+      return { text: positionType(row), color: selectedColor ?? colors.textDim };
     case "issuer":
       return { text: row.issuer, color: selectedColor ?? colors.text };
     case "value":
@@ -136,7 +137,7 @@ export function renderFilingPositionCell(
         attributes: TextAttributes.BOLD,
       };
     case "type":
-      return { text: formatPositionType(row), color: selectedColor ?? colors.textDim };
+      return { text: positionType(row), color: selectedColor ?? colors.textDim };
     case "issuer":
       return { text: row.issuer, color: selectedColor ?? colors.text };
     case "value":
@@ -183,19 +184,6 @@ export function renderTimelineCell(
         color: selectedColor ?? (row.isAmendment ? colors.warning : colors.textDim),
       };
   }
-}
-
-function formatPositionType(row: {
-  putCall: string;
-  titleOfClass: string;
-  shareType: string;
-}): string {
-  const putCall = row.putCall.trim().toUpperCase();
-  if (putCall === "PUT" || putCall === "CALL") return putCall;
-  const title = row.titleOfClass.trim().toUpperCase();
-  if (title) return title;
-  const shareType = row.shareType.trim().toUpperCase();
-  return shareType || "--";
 }
 
 function actionColor(action: FundHoldingRow["action"]): string {


### PR DESCRIPTION
## Summary

- Add shared headless definitions for `CG`, `INS`, `SI`, `13F`, `SEC`, `HDS`, and `ANR`.
- Reuse the pane data providers, clients, parsing, sorting, and projection models instead of maintaining separate report implementations.
- Expose pane-specific options for tabs, views, filters, sorting, year, and row limits. `count` and `rows` are aliases for pane row limits because `--limit` is also a global CLI option.
- Register every pane as a report-ready catalog entry with structured rows or bundle output.
- Keep Form 4 content loading sequential, matching the pane cache behavior and avoiding a burst against SEC document endpoints.
- Use main's existing `withPersistedCloudSession` report wrapper. This branch adds no second session mechanism and writes no session data.

## Data source state

- **CG: blocked upstream.** `loadCongressHouse` calls `apiClient.getCloudCongressHouse({ year, filingLimit: 60, offset: 0, limit: 200 })`, which requests `/cloud/congress/house`. Production currently fails in `runMistralOcr` with HTTP 402 because the Mistral subscription needs attention. The migration is covered by an injected fixture and does not add a workaround.
- **SI: cloud access rejection followed by a browser fallback failure, not a wrong path or empty data.** The pane calls `fetchShortInterest("AAPL")`, then `apiClient.getCloudShortInterest("AAPL")`, which issues `GET /market/short-interest?symbol=AAPL` with no explicit `years` value. With persisted session restoration active, the rendered view still ends unavailable. A fresh proxied trace showed the session cookie present and this endpoint responding 401. `fetchShortInterest` intentionally catches that response and tries Yahoo; the browser request then fails, so the pane surfaces unavailable rather than the plain `Unauthorized` returned by entitlement-gated CALLS and ECT. The Bun pane and Bun headless loader can use the existing Yahoo fallback and return rows. A focused regression test verifies the served `/market/short-interest` path. No current SI call emits `/cloud/sec/short-interest`, so the production 404 is from another client.
- **INS: client-side cloud verification gate, not empty SEC data.** The pane starts with `useSecFilingsQuery({ instrument: { symbol: "NVDA" }, count: 20000 })`, which resolves to `dataProvider.getSecFilings("NVDA", 20000, "", context)`. The cloud implementation calls `apiClient.getCloudSecFilings({ ticker: "NVDA", limit: 20000, offset: 0 })`, or `GET /cloud/sec/filings?ticker=NVDA&limit=20000&offset=0`, then loads each Form 4 with `getSecFilingContent` through `/cloud/sec/filing/content` using CIK, accession, form, and document URL parameters. The rendered-only cloud provider applies `requireVerifiedSession` before those requests. The normal Bun provider path returns and parses live Form 4 rows. Also, `gloomberb insider` queries holder ownership categories, not Form 4 filings, so its empty table is not an INS upstream check.
- **SEC: client-side cloud verification gate, not a path, parameter, or upstream-data problem.** The pane makes the same `useSecFilingsQuery` request with ticker `AAPL` and count `20000`. The served request is `GET /cloud/sec/filings?ticker=AAPL&limit=20000&offset=0`. A direct check returned HTTP 200 with 2,246 filings, while the rendered cloud provider still reported unavailable after persisted session restoration because `requireVerifiedSession` stopped the provider before the public SEC request. The new headless loader uses the same normal market-data provider as the terminal pane, where SEC fallback data is available, and returns live rows.

No SI, INS, or SEC pane call in the current worktree targets an unserved route, so there was no in-scope route string to rewrite. Their rendered `fn` failures are also distinct from the plain `Unauthorized` entitlement response observed for CALLS and ECT. Selecting these headless definitions before the DOM fallback returns structured data while preserving the pane data paths.

## Output samples

All successful live JSON checks below returned `source: "headless"`.

```text
CG fixture, live blocked: 2026-02-15 | Pelosi, Nancy | BUY | NVDA | $15,001-$50,000
INS AAPL: 2026-09-03 | Newstead Jennifer | SELL | 1,439 | $317.01 | $456,177.39
SI AAPL: 2026-08-14 | 116,327,753 short | 2.19 days to cover | 0.80% float
13F 1067983 --view holdings: AAPL | APPLE INC | $65,950,296,923 | 227,917,808 shares | 22.04%
SEC AAPL: 2026-09-03 | FORM 4 | 0001140361-26-035636
HDS AAPL: Blackrock Inc. | $372,124,131,991 | 1,162,996,939 shares | 7.97%
ANR AAPL: Average target $323.86 | upside +1.22% | Morgan Stanley Overweight | target $360
```

Source checks after the final rebase:

```text
SI:  source=headless rows=1 complete=true
INS: source=headless rows=1 complete=true
13F: source=headless rows=1 complete=true
SEC: source=headless rows=1 complete=true
HDS: source=headless rows=1 complete=true
ANR: source=headless rows=7 complete=true
```

`CG` reaches its headless loader but returns the upstream Mistral 402 before a result envelope can carry a source field. Its catalog capability is `ready` with `rows` output.

## Verification

- `bun run typecheck`
- `bun test src/plugins/builtin/congress-trades src/plugins/builtin/insider src/plugins/builtin/short-interest src/plugins/builtin/thirteenf src/plugins/builtin/sec src/plugins/builtin/holders src/plugins/builtin/research` (77 pass)
- `bun test src/cli/pane-functions` (48 pass)
- Live text and JSON smoke checks for INS, SI, 13F, SEC, HDS, and ANR
- Fixture-backed CG headless test plus live confirmation of the known Mistral 402
- tmux render checks after rebase for `SI AAPL` and `SEC AAPL`, with live rows and no React, listener, or hook warnings
