### PR TITLE
Add headless reports for earnings and event panes

### DIFF
--- a/src/cli/pane-functions/cloud-session.test.ts
+++ b/src/cli/pane-functions/cloud-session.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { apiClient } from "../../api-client";
+import type { MarketContext } from "../types";
+import {
+  resolvePersistedCloudSessionToken,
+  withPersistedCloudSession,
+} from "./cloud-session";
+
+function contextWithSession(
+  key: string,
+  sessionToken: string,
+): Pick<MarketContext, "persistence"> {
+  return {
+    persistence: {
+      pluginState: {
+        get: (_pluginId: string, candidate: string) => candidate === key
+          ? { value: { sessionToken }, schemaVersion: 1, updatedAt: 1 }
+          : null,
+      },
+    },
+  } as Pick<MarketContext, "persistence">;
+}
+
+describe("pane function Cloud session", () => {
+  test("restores the current and legacy persisted session keys", () => {
+    expect(resolvePersistedCloudSessionToken(
+      contextWithSession("resume:session", "current-session"),
+    )).toBe("current-session");
+    expect(resolvePersistedCloudSessionToken(
+      contextWithSession("session", "legacy-session"),
+    )).toBe("legacy-session");
+  });
+
+  test("scopes the persisted session to one report load", async () => {
+    const initial = apiClient.getSessionToken();
+    apiClient.setSessionToken("previous-session");
+    try {
+      let activeSession: string | null = null;
+      const result = await withPersistedCloudSession(
+        contextWithSession("resume:session", "report-session"),
+        async () => {
+          activeSession = apiClient.getSessionToken();
+          return 42;
+        },
+      );
+
+      expect(result).toBe(42);
+      expect(activeSession).toBe("report-session");
+      expect(apiClient.getSessionToken()).toBe("previous-session");
+    } finally {
+      apiClient.setSessionToken(initial);
+    }
+  });
+});

--- a/src/cli/pane-functions/cloud-session.ts
+++ b/src/cli/pane-functions/cloud-session.ts
@@ -1,0 +1,38 @@
+import { apiClient } from "../../api-client";
+import type { MarketContext } from "../types";
+
+const CLOUD_PLUGIN_ID = "gloomberb-cloud";
+const CLOUD_SESSION_KEYS = ["resume:session", "session"] as const;
+
+interface PersistedCloudSession {
+  sessionToken?: unknown;
+}
+
+export function resolvePersistedCloudSessionToken(
+  context: Pick<MarketContext, "persistence">,
+): string | null {
+  for (const key of CLOUD_SESSION_KEYS) {
+    const value = context.persistence.pluginState.get<PersistedCloudSession>(
+      CLOUD_PLUGIN_ID,
+      key,
+      1,
+    )?.value;
+    if (typeof value?.sessionToken === "string" && value.sessionToken.length > 0) {
+      return value.sessionToken;
+    }
+  }
+  return null;
+}
+
+export async function withPersistedCloudSession<T>(
+  context: Pick<MarketContext, "persistence">,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previousSessionToken = apiClient.getSessionToken();
+  apiClient.setSessionToken(resolvePersistedCloudSessionToken(context));
+  try {
+    return await run();
+  } finally {
+    apiClient.setSessionToken(previousSessionToken);
+  }
+}

--- a/src/cli/pane-functions/index.ts
+++ b/src/cli/pane-functions/index.ts
@@ -28,6 +28,7 @@ import {
   isDataPaneForDomFallback,
   normalizeCapabilityOptions,
 } from "./capabilities";
+import { withPersistedCloudSession } from "./cloud-session";
 
 async function withPaneRuntime<T>(
   ctx: CliCommandContext,
@@ -63,7 +64,10 @@ export async function runPaneFunction(args: string[], ctx: CliCommandContext) {
           + `Use "gloomberb catalog ${resolved.token}" to inspect readiness.`,
         );
       }
-      const report = await buildFunctionReport(resolved, context, parsed.arg);
+      const report = await withPersistedCloudSession(
+        context,
+        () => buildFunctionReport(resolved, context, parsed.arg),
+      );
       if (parsed.requireBotSafe && (report.data.empty || !report.data.complete)) {
         const unavailable = report.data.unavailableSymbols.length > 0
           ? ` Missing data for ${report.data.unavailableSymbols.join(", ")}.`

--- a/src/cli/pane-functions/screenshot.ts
+++ b/src/cli/pane-functions/screenshot.ts
@@ -19,6 +19,7 @@ import { optionPaneState } from "./options";
 import type { ResolvedPaneFunction } from "./resolver";
 import type { MarketContext } from "../types";
 import { capabilityPluginState } from "./capabilities";
+import { resolvePersistedCloudSessionToken } from "./cloud-session";
 import type { RemoteUiNodeSnapshot } from "../../remote/types";
 import {
   graphRowsForFinancials,
@@ -76,8 +77,6 @@ const DESKTOP_CELL_HEIGHT_PX = 18;
 const OPTIONS_PANE_ID = "options";
 const MARKET_VALUATION_PANE_ID = "market-valuation";
 const ECON_STATISTICS_PANE_ID = "econ-statistics";
-const CLOUD_PLUGIN_ID = "gloomberb-cloud";
-const CLOUD_SESSION_KEYS = ["resume:session", "session"] as const;
 const CREDENTIAL_FIELD_NAMES = new Set([
   "accesstoken",
   "accessurl",
@@ -95,10 +94,6 @@ const CREDENTIAL_FIELD_NAMES = new Set([
   "sessiontoken",
   "token",
 ]);
-
-interface PersistedShotCloudSession {
-  sessionToken?: unknown;
-}
 
 /**
  * The proxy receives the desktop session out of band. Keeping this separate
@@ -138,21 +133,9 @@ export function stripDesktopShotCredentials<T>(value: T): T {
 export function resolveDesktopShotApiProxy(
   context: Pick<MarketContext, "persistence">,
 ): DesktopPaneShotApiProxy {
-  let sessionToken: string | null = null;
-  for (const key of CLOUD_SESSION_KEYS) {
-    const value = context.persistence.pluginState.get<PersistedShotCloudSession>(
-      CLOUD_PLUGIN_ID,
-      key,
-      1,
-    )?.value;
-    if (typeof value?.sessionToken === "string" && value.sessionToken.length > 0) {
-      sessionToken = value.sessionToken;
-      break;
-    }
-  }
   return {
     baseUrl: getCloudApiBaseUrl(),
-    sessionToken,
+    sessionToken: resolvePersistedCloudSessionToken(context),
   };
 }
 

--- a/src/news/types.ts
+++ b/src/news/types.ts
@@ -38,6 +38,7 @@ export interface NewsArticle {
   scores: NewsScores;
   isBreaking: boolean;
   isDeveloping: boolean;
+  sourceCount?: number;
   items?: NewsStoryItem[];
 
   // Compatibility aliases for RSS/Yahoo panes and existing table columns.

--- a/src/plugins/builtin/dividend-yield/headless.test.ts
+++ b/src/plugins/builtin/dividend-yield/headless.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import type { DividendData } from "./client";
+import { createDividendYieldHeadless } from "./headless";
+
+const fixture: DividendData = {
+  price: 200,
+  metrics: {
+    trailingYield: 0.005,
+    forwardYield: 0.0052,
+    trailingRate: 1,
+    forwardRate: 1.04,
+    payoutRatio: 0.14,
+    growth1Y: 0.04,
+    growth3Y: 0.03,
+    paymentFrequency: "quarterly",
+    exDividendDate: new Date("2026-08-10T00:00:00.000Z"),
+    nextPayDate: new Date("2026-08-17T00:00:00.000Z"),
+  },
+  payments: [
+    {
+      exDate: new Date("2026-08-10T00:00:00.000Z"),
+      recordDate: null,
+      paymentDate: null,
+      declarationDate: null,
+      amount: 0.26,
+      currency: "USD",
+      type: "cash",
+    },
+    {
+      exDate: new Date("2026-05-11T00:00:00.000Z"),
+      recordDate: null,
+      paymentDate: null,
+      declarationDate: null,
+      amount: 0.24,
+      currency: "USD",
+      type: "special",
+    },
+  ],
+};
+
+function args(options: Record<string, string | number | boolean>): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: "AAPL",
+    argument: "AAPL",
+    symbols: ["AAPL"],
+    options,
+  };
+}
+
+const context = {} as HeadlessPaneContext;
+
+describe("dividend yield headless", () => {
+  test("maps metrics and payment rows", async () => {
+    const definition = createDividendYieldHeadless({
+      loadData: async () => fixture,
+    });
+
+    const result = await definition.load(args({ type: "all", limit: 40 }), context);
+
+    expect(result.sections[0]).toMatchObject({
+      title: "Dividend metrics",
+      entries: expect.arrayContaining([
+        { label: "Trailing yield", value: 0.005 },
+        { label: "Frequency", value: "quarterly" },
+      ]),
+    });
+    expect(result.sections[1]).toMatchObject({
+      title: "Dividend history",
+      rows: [
+        expect.objectContaining({ exDate: "2026-08-10", amount: 0.26, type: "cash" }),
+        expect.objectContaining({ exDate: "2026-05-11", amount: 0.24, type: "special" }),
+      ],
+    });
+  });
+
+  test("applies type and limit options", async () => {
+    const definition = createDividendYieldHeadless({ loadData: async () => fixture });
+
+    const result = await definition.load(args({ type: "cash", limit: 1 }), context);
+    const history = result.sections[1];
+
+    expect(history).toMatchObject({
+      rows: [expect.objectContaining({ type: "cash" })],
+    });
+    expect(result.metadata).toMatchObject({ totalPayments: 1, returnedPayments: 1 });
+  });
+});

--- a/src/plugins/builtin/dividend-yield/headless.ts
+++ b/src/plugins/builtin/dividend-yield/headless.ts
@@ -1,0 +1,135 @@
+import type {
+  HeadlessBundleResult,
+  HeadlessPaneContext,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+} from "../../../types/plugin";
+import { fetchDividendData, type DividendData } from "./client";
+import type { DividendPayment } from "./types";
+import { toDividendRows } from "./view";
+
+const PAYMENT_COLUMNS = [
+  { key: "exDate", header: "Ex-date" },
+  { key: "amount", header: "Amount", align: "right" as const },
+  { key: "currency", header: "CCY" },
+  { key: "type", header: "Type" },
+];
+
+export interface DividendYieldHeadlessDependencies {
+  loadData(symbol: string, context: HeadlessPaneContext): Promise<DividendData>;
+}
+
+const defaultDependencies: DividendYieldHeadlessDependencies = {
+  async loadData(symbol, context) {
+    let currentPrice: number | null = null;
+    try {
+      currentPrice = (await context.marketData.getQuote(symbol, "")).price ?? null;
+    } catch {
+      currentPrice = null;
+    }
+    return fetchDividendData(symbol, currentPrice);
+  },
+};
+
+function matchesType(payment: DividendPayment, type: string): boolean {
+  return type === "all" || payment.type === type;
+}
+
+export function projectDividendYieldHeadless(
+  data: DividendData,
+  args: HeadlessPaneLoadArgs,
+): HeadlessBundleResult {
+  const type = String(args.options.type ?? "all");
+  const limit = Number(args.options.limit ?? 40);
+  const matching = data.payments.filter((payment) => matchesType(payment, type));
+  const selectedPayments = matching.slice(0, limit);
+  const rows = toDividendRows(selectedPayments).map((row, index) => {
+    const payment = selectedPayments[index];
+    return {
+      ...row,
+      recordDate: payment?.recordDate?.toISOString() ?? null,
+      paymentDate: payment?.paymentDate?.toISOString() ?? null,
+      declarationDate: payment?.declarationDate?.toISOString() ?? null,
+      type: payment?.type ?? null,
+    };
+  });
+  const metrics = data.metrics;
+
+  return {
+    sections: [
+      {
+        title: "Dividend metrics",
+        entries: [
+          { label: "Price", value: data.price },
+          { label: "Trailing yield", value: metrics.trailingYield },
+          { label: "Forward yield", value: metrics.forwardYield },
+          { label: "Trailing rate", value: metrics.trailingRate },
+          { label: "Forward rate", value: metrics.forwardRate },
+          { label: "Payout ratio", value: metrics.payoutRatio },
+          { label: "1Y growth", value: metrics.growth1Y },
+          { label: "3Y growth", value: metrics.growth3Y },
+          { label: "Frequency", value: metrics.paymentFrequency },
+          { label: "Ex-dividend", value: metrics.exDividendDate },
+          { label: "Next pay", value: metrics.nextPayDate },
+        ],
+      },
+      {
+        title: "Dividend history",
+        columns: PAYMENT_COLUMNS,
+        rows,
+      },
+    ],
+    metadata: {
+      totalPayments: matching.length,
+      returnedPayments: rows.length,
+      truncated: rows.length < matching.length,
+      type,
+    },
+  };
+}
+
+export function createDividendYieldHeadless(
+  dependencies: DividendYieldHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"bundle"> {
+  return {
+    shape: "bundle",
+    argument: {
+      kind: "ticker",
+      placeholder: "ticker",
+      description: "Company symbol.",
+    },
+    options: [
+      {
+        key: "type",
+        description: "Dividend payment type to include.",
+        type: "enum",
+        values: [
+          { value: "all" },
+          { value: "cash" },
+          { value: "special" },
+          { value: "stock" },
+          { value: "unknown" },
+        ],
+        defaultValue: "all",
+      },
+      {
+        key: "limit",
+        description: "Maximum historical payments to return.",
+        type: "integer",
+        defaultValue: 40,
+        minimum: 1,
+        maximum: 200,
+      },
+    ],
+    describe: (args) => `Dividend Yield | ${String(args.argument)}`,
+    async load(args, context) {
+      const symbol = String(args.argument);
+      return projectDividendYieldHeadless(
+        await dependencies.loadData(symbol, context),
+        args,
+      );
+    },
+  };
+}
+
+export const dividendYieldHeadless = createDividendYieldHeadless();

--- a/src/plugins/builtin/dividend-yield/index.tsx
+++ b/src/plugins/builtin/dividend-yield/index.tsx
@@ -6,6 +6,7 @@ import {
   YAHOO_DIVIDENDS_CONNECTION_ID,
 } from "./client";
 import { DividendYieldPane } from "./pane";
+import { dividendYieldHeadless } from "./headless";
 
 let disposeConnection: (() => void) | null = null;
 
@@ -50,13 +51,16 @@ export const dividendYieldModule: PluginModule = {
   ],
 
   paneTemplates: [
-    createTickerSurfacePaneTemplate({
-      id: "dividend-yield-pane",
-      paneId: "dividend-yield",
-      label: "Dividend Yield",
-      description: "Dividend history, trailing/forward yield, growth rates, and payment schedule.",
-      keywords: ["dividend", "yield", "dvd", "income", "payout", "ex-date", "distribution"],
-      shortcut: "DVD",
-    }),
+    {
+      ...createTickerSurfacePaneTemplate({
+        id: "dividend-yield-pane",
+        paneId: "dividend-yield",
+        label: "Dividend Yield",
+        description: "Dividend history, trailing/forward yield, growth rates, and payment schedule.",
+        keywords: ["dividend", "yield", "dvd", "income", "payout", "ex-date", "distribution"],
+        shortcut: "DVD",
+      }),
+      headless: dividendYieldHeadless,
+    },
   ],
 };

--- a/src/plugins/builtin/dividend-yield/model.ts
+++ b/src/plugins/builtin/dividend-yield/model.ts
@@ -1,16 +1,12 @@
 import type { DataTableColumn } from "../../../components";
 import { compareSortValues, type SortDirection } from "../../../utils/sort-values";
-import type { DividendPayment } from "./types";
+import type { DividendRow } from "./view";
+
+export { toDividendRows } from "./view";
+export type { DividendRow } from "./view";
 
 export type DividendColumnId = "exDate" | "amount" | "currency";
 export type DividendColumn = DataTableColumn & { id: DividendColumnId };
-
-export interface DividendRow {
-  key: string;
-  exDate: string;
-  amount: number;
-  currency: string;
-}
 
 export interface DividendSortPreference {
   columnId: DividendColumnId | null;
@@ -66,18 +62,4 @@ export function nextSortPreference(
     return { columnId: typedColumnId, direction: "asc" };
   }
   return DEFAULT_SORT_PREFERENCE;
-}
-
-export function toDividendRows(payments: DividendPayment[]): DividendRow[] {
-  return payments.map((p, i) => ({
-    key: `${p.exDate.toISOString()}:${i}`,
-    exDate: formatDate(p.exDate),
-    amount: p.amount,
-    currency: p.currency,
-  }));
-}
-
-function formatDate(date: Date): string {
-  const iso = date.toISOString();
-  return iso.slice(0, 10);
 }

--- a/src/plugins/builtin/dividend-yield/view.ts
+++ b/src/plugins/builtin/dividend-yield/view.ts
@@ -1,0 +1,17 @@
+import type { DividendPayment } from "./types";
+
+export interface DividendRow {
+  key: string;
+  exDate: string;
+  amount: number;
+  currency: string;
+}
+
+export function toDividendRows(payments: DividendPayment[]): DividendRow[] {
+  return payments.map((payment, index) => ({
+    key: `${payment.exDate.toISOString()}:${index}`,
+    exDate: payment.exDate.toISOString().slice(0, 10),
+    amount: payment.amount,
+    currency: payment.currency,
+  }));
+}

--- a/src/plugins/builtin/earnings-calls/data.ts
+++ b/src/plugins/builtin/earnings-calls/data.ts
@@ -4,7 +4,12 @@ import {
   type CloudEarningsTranscriptPayload,
 } from "../../../api-client";
 import { ApiRequestError } from "../../../api-client/errors";
-import type { PluginPersistence } from "../../../types/plugin";
+import type { HeadlessPaneApiClient, PluginPersistence } from "../../../types/plugin";
+
+type EarningsCallsApiClient = Pick<
+  HeadlessPaneApiClient,
+  "getCloudEarningsCalls" | "getCloudEarningsTranscript"
+>;
 
 const LIST_KIND = "calls";
 const TRANSCRIPT_KIND = "transcript";
@@ -83,7 +88,8 @@ function listKey(ticker: string | null): string {
   return ticker ? ticker.toUpperCase() : "__all__";
 }
 
-export async function loadEarningsCalls(
+export async function loadEarningsCallsWithClient(
+  client: EarningsCallsApiClient,
   ticker: string | null,
   options?: { force?: boolean; limit?: number },
 ): Promise<EarningsCallsResult> {
@@ -101,7 +107,7 @@ export async function loadEarningsCalls(
   const active = activeListFetches.get(key);
   if (active && !force) return active;
 
-  const request = apiClient
+  const request = client
     .getCloudEarningsCalls({
       ticker: ticker ?? undefined,
       limit: options?.limit ?? 50,
@@ -155,6 +161,13 @@ export async function loadEarningsCalls(
   return request;
 }
 
+export function loadEarningsCalls(
+  ticker: string | null,
+  options?: { force?: boolean; limit?: number },
+): Promise<EarningsCallsResult> {
+  return loadEarningsCallsWithClient(apiClient, ticker, options);
+}
+
 /**
  * The server answers 202 with a pending marker when a call is known but not
  * transcribed yet, having just queued it. That is not a transcript and must
@@ -163,12 +176,13 @@ export async function loadEarningsCalls(
 export function isPendingTranscript(
   value: CloudEarningsTranscriptPayload | { status?: string } | null,
 ): boolean {
-  if (!value) return false
-  const record = value as { status?: string; turns?: unknown }
-  return record.status === "pending" || !Array.isArray(record.turns)
+  if (!value) return false;
+  const record = value as { status?: string; turns?: unknown };
+  return record.status === "pending" || !Array.isArray(record.turns);
 }
 
-export async function loadTranscript(
+export async function loadTranscriptWithClient(
+  client: EarningsCallsApiClient,
   callId: string,
   options?: { force?: boolean },
 ): Promise<CloudEarningsTranscriptPayload> {
@@ -184,7 +198,7 @@ export async function loadTranscript(
   const active = activeTranscriptFetches.get(callId);
   if (active && !force) return active;
 
-  const request = apiClient
+  const request = client
     .getCloudEarningsTranscript(callId)
     .then((transcript) => {
       if (isPendingTranscript(transcript)) return transcript;
@@ -220,4 +234,11 @@ export async function loadTranscript(
 
   activeTranscriptFetches.set(callId, request);
   return request;
+}
+
+export function loadTranscript(
+  callId: string,
+  options?: { force?: boolean },
+): Promise<CloudEarningsTranscriptPayload> {
+  return loadTranscriptWithClient(apiClient, callId, options);
 }

--- a/src/plugins/builtin/earnings-calls/headless.test.ts
+++ b/src/plugins/builtin/earnings-calls/headless.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  CloudEarningsCallPayload,
+  CloudEarningsTranscriptPayload,
+} from "../../../api-client";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import {
+  createEarningsCallsHeadless,
+  createEarningsTranscriptHeadless,
+  type EarningsCallsHeadlessDependencies,
+} from "./headless";
+
+const calls: CloudEarningsCallPayload[] = [
+  {
+    id: "amd-fq2-2026",
+    ticker: "AMD",
+    companyName: "Advanced Micro Devices",
+    fiscalYear: 2026,
+    fiscalQuarter: 2,
+    callAt: "2026-07-29T21:00:00.000Z",
+    status: "published",
+    durationSeconds: 3_600,
+    wordCount: 12_000,
+    hasTranscript: true,
+    sentiment: 0.2,
+  },
+  {
+    id: "amd-fq1-2026",
+    ticker: "AMD",
+    companyName: "Advanced Micro Devices",
+    fiscalYear: 2026,
+    fiscalQuarter: 1,
+    callAt: "2026-04-29T21:00:00.000Z",
+    status: "discovered",
+    durationSeconds: null,
+    wordCount: null,
+    hasTranscript: false,
+    sentiment: null,
+  },
+];
+
+const transcript: CloudEarningsTranscriptPayload = {
+  id: "amd-fq2-2026",
+  ticker: "AMD",
+  companyName: "Advanced Micro Devices",
+  fiscalYear: 2026,
+  fiscalQuarter: 2,
+  callAt: "2026-07-29T21:00:00.000Z",
+  timing: "AMC",
+  webcastUrl: "https://example.com/call",
+  durationSeconds: 3_600,
+  status: "published",
+  fullText: "",
+  turns: [
+    {
+      speaker: "Jean Hu",
+      role: "Chief Financial Officer",
+      company: "AMD",
+      text: `Gross margin expanded. ${"Margin discipline remained strong. ".repeat(80)}`,
+      isQa: false,
+      startSeconds: 120,
+    },
+    {
+      speaker: "Analyst One",
+      role: "Analyst",
+      company: "Research Firm",
+      text: "What should investors expect from the CFO on data center margins?",
+      isQa: true,
+      startSeconds: 2_400,
+    },
+  ],
+  participants: [
+    { name: "Jean Hu", role: "Chief Financial Officer", company: "AMD" },
+  ],
+  summary: "Revenue grew while gross margin expanded.",
+  guidance: "Management expects sequential growth.",
+  riskFactors: "Supply remains constrained.",
+  analystFocus: "Analysts focused on data center margins.",
+  notable: "Management raised its annual outlook.",
+  sentiment: 0.2,
+  sentimentRationale: "Constructive outlook.",
+  qaStartTurn: 1,
+  wordCount: 12_000,
+  asrModel: "test",
+  updatedAt: "2026-07-30T00:00:00.000Z",
+};
+
+function callArgs(options: Record<string, string | number | boolean>): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: "",
+    argument: null,
+    symbols: [],
+    options,
+  };
+}
+
+function transcriptArgs(options: Record<string, string | number | boolean>): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: "AMD",
+    argument: "AMD",
+    symbols: ["AMD"],
+    options,
+  };
+}
+
+function dependencies(): EarningsCallsHeadlessDependencies {
+  return {
+    loadCalls: async () => ({
+      calls,
+      fetchedAt: 123,
+      stale: false,
+    }),
+    loadTranscript: async () => transcript,
+  };
+}
+
+const context = {} as HeadlessPaneContext;
+
+describe("earnings calls headless", () => {
+  test("maps call shelf rows and applies availability", async () => {
+    const definition = createEarningsCallsHeadless(dependencies());
+
+    const result = await definition.load(
+      callArgs({ availability: "pending", limit: 1 }),
+      context,
+    );
+
+    expect(result.rows).toEqual([
+      expect.objectContaining({
+        id: "amd-fq1-2026",
+        ticker: "AMD",
+        status: "queued",
+        hasTranscript: false,
+      }),
+    ]);
+    expect(result.metadata).toMatchObject({ availability: "pending", returned: 1 });
+  });
+});
+
+describe("earnings transcript headless", () => {
+  test("selects a quarter and filters speakers by role acronym", async () => {
+    const definition = createEarningsTranscriptHeadless(dependencies());
+
+    const result = await definition.load(transcriptArgs({
+      section: "transcript",
+      quarter: "FQ2-2026",
+      speaker: "CFO",
+      search: "margin",
+      offset: 0,
+      limit: 20,
+    }), context);
+
+    expect(result.rows.length).toBeGreaterThan(0);
+    expect(result.rows.every((row) => row.speaker === "Jean Hu")).toBe(true);
+    expect(result.metadata).toMatchObject({
+      fiscalYear: 2026,
+      fiscalQuarter: 2,
+      section: "transcript",
+      speaker: "CFO",
+    });
+  });
+
+  test("pages bounded transcript segments and reports truncation", async () => {
+    const definition = createEarningsTranscriptHeadless(dependencies());
+    const first = await definition.load(transcriptArgs({
+      section: "transcript",
+      quarter: "latest",
+      speaker: "CFO",
+      search: "",
+      offset: 0,
+      limit: 1,
+    }), context);
+    const second = await definition.load(transcriptArgs({
+      section: "transcript",
+      quarter: "latest",
+      speaker: "CFO",
+      search: "",
+      offset: 1,
+      limit: 1,
+    }), context);
+
+    expect(first.rows).toHaveLength(1);
+    expect(first.metadata).toMatchObject({
+      returnedSegments: 1,
+      truncated: true,
+      hasMore: true,
+      nextOffset: 1,
+    });
+    expect(second.rows).toHaveLength(1);
+    expect(second.rows[0]?.index).toBe(1);
+  });
+});

--- a/src/plugins/builtin/earnings-calls/headless.ts
+++ b/src/plugins/builtin/earnings-calls/headless.ts
@@ -1,0 +1,300 @@
+import type {
+  CloudEarningsCallPayload,
+  CloudEarningsTranscriptPayload,
+} from "../../../api-client";
+import type {
+  HeadlessPaneContext,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+  HeadlessRowsResult,
+} from "../../../types/plugin";
+import {
+  callStatusLabel,
+  isPendingTranscript,
+  loadEarningsCallsWithClient,
+  loadTranscriptWithClient,
+  type EarningsCallsResult,
+} from "./data";
+import {
+  buildTranscriptSegments,
+  findCallForQuarter,
+  sortCallsNewest,
+  type TranscriptSection,
+} from "./model";
+
+const CALL_COLUMNS = [
+  { key: "ticker", header: "Ticker" },
+  { key: "company", header: "Company" },
+  { key: "callAt", header: "Call date" },
+  { key: "fiscalYear", header: "FY", align: "right" as const },
+  { key: "fiscalQuarter", header: "FQ", align: "right" as const },
+  { key: "status", header: "Status" },
+  { key: "durationSeconds", header: "Seconds", align: "right" as const },
+  { key: "wordCount", header: "Words", align: "right" as const },
+  { key: "sentiment", header: "Tone", align: "right" as const },
+];
+
+const TRANSCRIPT_COLUMNS = [
+  { key: "index", header: "#", align: "right" as const },
+  { key: "section", header: "Section" },
+  { key: "startSeconds", header: "Start", align: "right" as const },
+  { key: "speaker", header: "Speaker" },
+  { key: "role", header: "Role" },
+  { key: "isQa", header: "Q&A" },
+  { key: "text", header: "Text" },
+];
+
+export interface EarningsCallsHeadlessDependencies {
+  loadCalls(
+    ticker: string | null,
+    limit: number,
+    context: HeadlessPaneContext,
+  ): Promise<EarningsCallsResult>;
+  loadTranscript(
+    callId: string,
+    context: HeadlessPaneContext,
+  ): Promise<CloudEarningsTranscriptPayload>;
+}
+
+const defaultDependencies: EarningsCallsHeadlessDependencies = {
+  loadCalls: (ticker, limit, context) => loadEarningsCallsWithClient(
+    context.apiClient,
+    ticker,
+    { limit },
+  ),
+  loadTranscript: (callId, context) => loadTranscriptWithClient(context.apiClient, callId),
+};
+
+function callRow(call: CloudEarningsCallPayload) {
+  return {
+    id: call.id,
+    ticker: call.ticker,
+    company: call.companyName,
+    callAt: call.callAt,
+    fiscalYear: call.fiscalYear,
+    fiscalQuarter: call.fiscalQuarter,
+    status: call.hasTranscript ? "transcribed" : callStatusLabel(call) || call.status,
+    durationSeconds: call.durationSeconds,
+    wordCount: call.wordCount,
+    hasTranscript: call.hasTranscript,
+    sentiment: call.sentiment,
+    webcastUrl: call.webcastUrl ?? null,
+  };
+}
+
+function availabilityMatches(call: CloudEarningsCallPayload, availability: string): boolean {
+  if (availability === "all") return true;
+  return availability === "transcribed" ? call.hasTranscript : !call.hasTranscript;
+}
+
+export function projectEarningsCallsHeadless(
+  result: EarningsCallsResult,
+  args: HeadlessPaneLoadArgs,
+): HeadlessRowsResult {
+  const availability = String(args.options.availability ?? "all");
+  const limit = Number(args.options.limit ?? 50);
+  const matching = sortCallsNewest(result.calls)
+    .filter((call) => availabilityMatches(call, availability));
+  const rows = matching.slice(0, limit).map(callRow);
+
+  return {
+    columns: CALL_COLUMNS,
+    rows,
+    errors: result.refreshError ? [result.refreshError] : undefined,
+    metadata: {
+      fetchedAt: result.fetchedAt,
+      stale: result.stale,
+      pending: result.pending ?? false,
+      unknownTicker: result.unknownTicker ?? false,
+      availability,
+      total: matching.length,
+      returned: rows.length,
+      truncated: rows.length < matching.length,
+    },
+  };
+}
+
+function selectedSection(args: HeadlessPaneLoadArgs): TranscriptSection {
+  return String(args.options.section ?? "overview") as TranscriptSection;
+}
+
+function transcriptResult(
+  transcript: CloudEarningsTranscriptPayload,
+  call: CloudEarningsCallPayload,
+  args: HeadlessPaneLoadArgs,
+): HeadlessRowsResult {
+  const section = selectedSection(args);
+  const speaker = String(args.options.speaker ?? "").trim();
+  const search = String(args.options.search ?? "").trim();
+  const offset = Number(args.options.offset ?? 0);
+  const limit = Number(args.options.limit ?? 20);
+  const segments = buildTranscriptSegments(transcript, section, { speaker, search });
+  const rows = segments.slice(offset, offset + limit).map((segment) => ({ ...segment }));
+  const hasMore = offset + rows.length < segments.length;
+
+  return {
+    columns: TRANSCRIPT_COLUMNS,
+    rows,
+    metadata: {
+      callId: call.id,
+      ticker: transcript.ticker,
+      company: transcript.companyName,
+      fiscalYear: transcript.fiscalYear,
+      fiscalQuarter: transcript.fiscalQuarter,
+      callAt: transcript.callAt,
+      durationSeconds: transcript.durationSeconds,
+      wordCount: transcript.wordCount,
+      sentiment: transcript.sentiment,
+      updatedAt: transcript.updatedAt,
+      section,
+      speaker: speaker || null,
+      search: search || null,
+      offset,
+      limit,
+      totalSegments: segments.length,
+      returnedSegments: rows.length,
+      truncated: offset > 0 || hasMore,
+      hasMore,
+      nextOffset: hasMore ? offset + rows.length : null,
+    },
+  };
+}
+
+function transcriptOptions() {
+  return [
+    {
+      key: "section",
+      description: "Transcript section to return.",
+      type: "enum" as const,
+      values: [
+        { value: "overview" },
+        { value: "summary" },
+        { value: "transcript" },
+        { value: "qa", aliases: ["q&a"] },
+        { value: "guidance" },
+        { value: "risks" },
+        { value: "notable" },
+        { value: "analyst-focus", aliases: ["analyst"] },
+        { value: "participants", aliases: ["speakers"] },
+      ],
+      defaultValue: "overview",
+    },
+    {
+      key: "quarter",
+      description: "Fiscal quarter such as latest, FQ2-2026, or FY2026.",
+      type: "string" as const,
+      defaultValue: "latest",
+    },
+    {
+      key: "speaker",
+      description: "Speaker name, role, or role acronym such as CFO.",
+      type: "string" as const,
+      defaultValue: "",
+    },
+    {
+      key: "search",
+      description: "Text to find in transcript turns.",
+      type: "string" as const,
+      defaultValue: "",
+    },
+    {
+      key: "offset",
+      description: "Transcript segment offset for paging.",
+      type: "integer" as const,
+      defaultValue: 0,
+      minimum: 0,
+      maximum: 100_000,
+    },
+    {
+      key: "limit",
+      description: "Maximum transcript segments to return.",
+      type: "integer" as const,
+      defaultValue: 20,
+      minimum: 1,
+      maximum: 200,
+    },
+  ];
+}
+
+export function createEarningsCallsHeadless(
+  dependencies: EarningsCallsHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "ticker",
+      placeholder: "ticker",
+      description: "Optional company symbol. Omit it to browse all calls.",
+      optional: true,
+    },
+    options: [
+      {
+        key: "availability",
+        description: "Transcript availability to include.",
+        type: "enum",
+        values: [
+          { value: "all" },
+          { value: "transcribed" },
+          { value: "pending" },
+        ],
+        defaultValue: "all",
+      },
+      {
+        key: "limit",
+        description: "Maximum calls to return.",
+        type: "integer",
+        defaultValue: 50,
+        minimum: 1,
+        maximum: 200,
+      },
+    ],
+    columns: CALL_COLUMNS,
+    describe: (args) => args.argument
+      ? `Earnings Calls | ${String(args.argument)}`
+      : "Earnings Calls",
+    async load(args, context) {
+      const ticker = typeof args.argument === "string" ? args.argument : null;
+      return projectEarningsCallsHeadless(
+        await dependencies.loadCalls(ticker, 200, context),
+        args,
+      );
+    },
+  };
+}
+
+export function createEarningsTranscriptHeadless(
+  dependencies: EarningsCallsHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "ticker",
+      placeholder: "ticker",
+      description: "Company symbol.",
+    },
+    options: transcriptOptions(),
+    columns: TRANSCRIPT_COLUMNS,
+    describe: (args) => (
+      `Earnings Call Transcript | ${String(args.argument)} | ${String(args.options.quarter)}`
+    ),
+    async load(args, context) {
+      const ticker = String(args.argument);
+      const calls = await dependencies.loadCalls(ticker, 200, context);
+      const quarter = String(args.options.quarter ?? "latest");
+      const selected = findCallForQuarter(calls.calls, quarter);
+      if (!selected) {
+        if (calls.unknownTicker) throw new Error(`${ticker} is not a known listed company.`);
+        if (calls.pending) throw new Error(`Earnings call discovery for ${ticker} is still pending.`);
+        throw new Error(`No ${quarter} earnings call found for ${ticker}.`);
+      }
+      const transcript = await dependencies.loadTranscript(selected.id, context);
+      if (isPendingTranscript(transcript)) {
+        throw new Error(`Transcript for ${ticker} ${quarter} is still being produced.`);
+      }
+      return transcriptResult(transcript, selected, args);
+    },
+  };
+}
+
+export const earningsCallsHeadless = createEarningsCallsHeadless();
+export const earningsTranscriptHeadless = createEarningsTranscriptHeadless();

--- a/src/plugins/builtin/earnings-calls/index.tsx
+++ b/src/plugins/builtin/earnings-calls/index.tsx
@@ -2,6 +2,12 @@ import type { PluginModule } from "../plugin-module";
 import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
 import { attachEarningsCallsPersistence, resetEarningsCallsPersistence } from "./data";
 import { EarningsCallsPane, EARNINGS_CALLS_PANE_ID } from "./pane";
+import {
+  earningsCallsHeadless,
+  earningsTranscriptHeadless,
+} from "./headless";
+
+export { earningsCallsHeadless, earningsTranscriptHeadless } from "./headless";
 
 const description =
   "Earnings call transcripts with speaker attribution, analyst Q&A, and extracted guidance.";
@@ -54,16 +60,20 @@ export const earningsCallsModule: PluginModule = {
         "qa",
       ],
       shortcut: { prefix: "CALLS" },
+      headless: earningsCallsHeadless,
       createInstance: () => ({ placement: "floating" }),
     },
-    createTickerSurfacePaneTemplate({
-      id: "earnings-call-transcripts-pane",
-      paneId: EARNINGS_CALLS_PANE_ID,
-      label: "Earnings Call Transcripts",
-      description,
-      keywords: ["earnings", "call", "transcript", "ect", "qa", "guidance"],
-      shortcut: "ECT",
-      publicShare: false,
-    }),
+    {
+      ...createTickerSurfacePaneTemplate({
+        id: "earnings-call-transcripts-pane",
+        paneId: EARNINGS_CALLS_PANE_ID,
+        label: "Earnings Call Transcripts",
+        description,
+        keywords: ["earnings", "call", "transcript", "ect", "qa", "guidance"],
+        shortcut: "ECT",
+        publicShare: false,
+      }),
+      headless: earningsTranscriptHeadless,
+    },
   ],
 };

--- a/src/plugins/builtin/earnings-calls/model.ts
+++ b/src/plugins/builtin/earnings-calls/model.ts
@@ -1,0 +1,238 @@
+import type {
+  CloudEarningsCallPayload,
+  CloudEarningsTranscriptPayload,
+  CloudTranscriptTurnPayload,
+} from "../../../api-client";
+
+export type TranscriptSection =
+  | "overview"
+  | "summary"
+  | "transcript"
+  | "qa"
+  | "guidance"
+  | "risks"
+  | "notable"
+  | "analyst-focus"
+  | "participants";
+
+export interface TranscriptFilter {
+  section: "transcript" | "qa";
+  speaker?: string;
+  search?: string;
+}
+
+export interface TranscriptSegment {
+  index: number;
+  section: string;
+  startSeconds: number | null;
+  speaker: string | null;
+  role: string | null;
+  company: string | null;
+  isQa: boolean;
+  text: string;
+}
+
+const MAX_SEGMENT_CHARS = 1_600;
+
+function roleAcronym(value: string): string {
+  return value
+    .split(/\s+/)
+    .filter((word) => /^[A-Za-z]/.test(word))
+    .map((word) => word[0])
+    .join("");
+}
+
+function turnSpeakerText(turn: CloudTranscriptTurnPayload): string {
+  const role = turn.role ?? "";
+  return [
+    turn.speaker,
+    role,
+    roleAcronym(role),
+    turn.company ?? "",
+  ].join(" ").toLowerCase();
+}
+
+function turnSearchText(turn: CloudTranscriptTurnPayload): string {
+  return `${turnSpeakerText(turn)} ${turn.text}`.toLowerCase();
+}
+
+export function filterTranscriptTurns(
+  turns: CloudTranscriptTurnPayload[],
+  filter: TranscriptFilter,
+): CloudTranscriptTurnPayload[] {
+  const speaker = filter.speaker?.trim().toLowerCase() ?? "";
+  const search = filter.search?.trim().toLowerCase() ?? "";
+  return turns.filter((turn) => {
+    if (filter.section === "qa" && !turn.isQa) return false;
+    if (speaker && !turnSpeakerText(turn).includes(speaker)) return false;
+    return !search || turnSearchText(turn).includes(search);
+  });
+}
+
+function chunks(text: string): string[] {
+  const normalized = text.trim();
+  if (!normalized) return [];
+  const result: string[] = [];
+  let remaining = normalized;
+  while (remaining.length > MAX_SEGMENT_CHARS) {
+    const breakAt = Math.max(
+      remaining.lastIndexOf(" ", MAX_SEGMENT_CHARS),
+      remaining.lastIndexOf("\n", MAX_SEGMENT_CHARS),
+    );
+    const cut = breakAt > MAX_SEGMENT_CHARS / 2 ? breakAt : MAX_SEGMENT_CHARS;
+    result.push(remaining.slice(0, cut).trim());
+    remaining = remaining.slice(cut).trim();
+  }
+  if (remaining) result.push(remaining);
+  return result;
+}
+
+function summaryFields(
+  transcript: CloudEarningsTranscriptPayload,
+  section: TranscriptSection,
+): Array<{ section: string; text: string }> {
+  const fields = [
+    { section: "summary", text: transcript.summary ?? "" },
+    { section: "notable", text: transcript.notable ?? "" },
+    { section: "analyst-focus", text: transcript.analystFocus ?? "" },
+    { section: "guidance", text: transcript.guidance ?? "" },
+    { section: "risks", text: transcript.riskFactors ?? "" },
+  ];
+  return section === "overview"
+    ? fields.filter((field) => field.text.trim())
+    : fields.filter((field) => field.section === section && field.text.trim());
+}
+
+export function buildTranscriptSegments(
+  transcript: CloudEarningsTranscriptPayload,
+  section: TranscriptSection,
+  options: { speaker?: string; search?: string } = {},
+): TranscriptSegment[] {
+  const withoutIndexes: Array<Omit<TranscriptSegment, "index">> = [];
+
+  if (section === "transcript" || section === "qa") {
+    const turns = filterTranscriptTurns(transcript.turns ?? [], {
+      section,
+      speaker: options.speaker,
+      search: options.search,
+    });
+    for (const turn of turns) {
+      for (const text of chunks(turn.text)) {
+        withoutIndexes.push({
+          section,
+          startSeconds: turn.startSeconds,
+          speaker: turn.speaker,
+          role: turn.role ?? null,
+          company: turn.company ?? null,
+          isQa: turn.isQa,
+          text,
+        });
+      }
+    }
+    if (withoutIndexes.length === 0 && section === "transcript" && transcript.fullText.trim()) {
+      const search = options.search?.trim().toLowerCase() ?? "";
+      if (!options.speaker?.trim() && (!search || transcript.fullText.toLowerCase().includes(search))) {
+        for (const paragraph of transcript.fullText.split(/\n{2,}/)) {
+          for (const text of chunks(paragraph)) {
+            withoutIndexes.push({
+              section,
+              startSeconds: null,
+              speaker: null,
+              role: null,
+              company: null,
+              isQa: false,
+              text,
+            });
+          }
+        }
+      }
+    }
+  } else if (section === "participants") {
+    const speaker = options.speaker?.trim().toLowerCase() ?? "";
+    for (const participant of transcript.participants) {
+      const haystack = [
+        participant.name,
+        participant.role ?? "",
+        roleAcronym(participant.role ?? ""),
+        participant.company ?? "",
+      ].join(" ").toLowerCase();
+      if (speaker && !haystack.includes(speaker)) continue;
+      withoutIndexes.push({
+        section,
+        startSeconds: null,
+        speaker: participant.name,
+        role: participant.role ?? null,
+        company: participant.company ?? null,
+        isQa: false,
+        text: [participant.role, participant.company].filter(Boolean).join(", "),
+      });
+    }
+  } else {
+    for (const field of summaryFields(transcript, section)) {
+      for (const text of chunks(field.text)) {
+        withoutIndexes.push({
+          section: field.section,
+          startSeconds: null,
+          speaker: null,
+          role: null,
+          company: null,
+          isQa: false,
+          text,
+        });
+      }
+    }
+  }
+
+  return withoutIndexes.map((segment, index) => ({ index, ...segment }));
+}
+
+function callTime(call: CloudEarningsCallPayload): number {
+  const timestamp = call.callAt ? Date.parse(call.callAt) : Number.NaN;
+  if (Number.isFinite(timestamp)) return timestamp;
+  return (call.fiscalYear ?? 0) * 10 + (call.fiscalQuarter ?? 0);
+}
+
+export function sortCallsNewest(calls: CloudEarningsCallPayload[]): CloudEarningsCallPayload[] {
+  return [...calls].sort((left, right) => callTime(right) - callTime(left));
+}
+
+function sameYear(actual: number | null, requested: number | null): boolean {
+  if (requested == null) return true;
+  if (actual == null) return false;
+  return requested < 100 ? actual % 100 === requested : actual === requested;
+}
+
+export function findCallForQuarter(
+  calls: CloudEarningsCallPayload[],
+  requestedQuarter: string,
+): CloudEarningsCallPayload | null {
+  const sorted = sortCallsNewest(calls);
+  const token = requestedQuarter.trim().toUpperCase().replace(/[\s_-]+/g, "");
+  if (!token || token === "LATEST") return sorted[0] ?? null;
+
+  const quarterFirst = token.match(/^(?:F?Q)?([1-4])(?:\/?(\d{2}|\d{4}))?$/);
+  if (quarterFirst) {
+    const quarter = Number(quarterFirst[1]);
+    const year = quarterFirst[2] ? Number(quarterFirst[2]) : null;
+    return sorted.find((call) => (
+      call.fiscalQuarter === quarter && sameYear(call.fiscalYear, year)
+    )) ?? null;
+  }
+
+  const yearFirst = token.match(/^(\d{2}|\d{4})(?:\/?F?Q)([1-4])$/);
+  if (yearFirst) {
+    const year = Number(yearFirst[1]);
+    const quarter = Number(yearFirst[2]);
+    return sorted.find((call) => (
+      call.fiscalQuarter === quarter && sameYear(call.fiscalYear, year)
+    )) ?? null;
+  }
+
+  const fiscalYear = token.match(/^(?:FY)?(\d{2}|\d{4})$/);
+  if (fiscalYear) {
+    const year = Number(fiscalYear[1]);
+    return sorted.find((call) => sameYear(call.fiscalYear, year)) ?? null;
+  }
+
+  return null;
+}

--- a/src/plugins/builtin/earnings-calls/transcript-view.tsx
+++ b/src/plugins/builtin/earnings-calls/transcript-view.tsx
@@ -18,6 +18,7 @@ import type {
 } from "../../../api-client";
 import { formatCallDate, formatDuration, formatSentiment, formatTimestamp } from "./format";
 import { splitFigures, splitSentences } from "./prose";
+import { filterTranscriptTurns } from "./model";
 
 export type ReaderTab = "summary" | "transcript" | "qa";
 
@@ -200,15 +201,13 @@ export function TranscriptView({
   const { nativePaneChrome } = useUiCapabilities();
   const isNative = nativePaneChrome === true;
 
-  const turns = useMemo(() => {
-    const all = transcript?.turns ?? [];
-    const scoped = tab === "qa" ? all.filter((turn) => turn.isQa) : all;
-    const needle = (query ?? "").trim().toLowerCase();
-    if (!needle) return scoped;
-    return scoped.filter((turn) =>
-      `${turn.speaker} ${turn.company ?? ""} ${turn.text}`.toLowerCase().includes(needle),
-    );
-  }, [transcript, tab, query]);
+  const turns = useMemo(() => filterTranscriptTurns(
+    transcript?.turns ?? [],
+    {
+      section: tab === "qa" ? "qa" : "transcript",
+      search: query,
+    },
+  ), [transcript, tab, query]);
 
   if (loading && !transcript) {
     return (

--- a/src/plugins/builtin/earnings/headless.test.ts
+++ b/src/plugins/builtin/earnings/headless.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import type { EarningsEvent } from "../../../types/data-provider";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createEarningsCalendarHeadless } from "./headless";
+
+const events: EarningsEvent[] = [
+  {
+    symbol: "MSFT",
+    name: "Microsoft",
+    earningsDate: new Date("2026-09-08T20:00:00.000Z"),
+    earningsCallDate: new Date("2026-09-08T21:00:00.000Z"),
+    isDateEstimate: false,
+    epsEstimate: 3.67,
+    epsLow: 3.5,
+    epsHigh: 3.8,
+    epsGrowth: 0.12,
+    epsTrend30dAgo: 3.55,
+    epsRevisionUp30d: 8,
+    epsRevisionDown30d: 2,
+    epsActual: null,
+    revenueEstimate: 74_000_000_000,
+    revenueLow: 72_000_000_000,
+    revenueHigh: 76_000_000_000,
+    revenueGrowth: 0.16,
+    revenueActual: null,
+    surprise: null,
+    timing: "AMC",
+  },
+  {
+    symbol: "AAPL",
+    name: "Apple",
+    earningsDate: new Date("2026-09-07T12:00:00.000Z"),
+    epsEstimate: 1.5,
+    epsActual: null,
+    revenueEstimate: 95_000_000_000,
+    revenueActual: null,
+    surprise: null,
+    timing: "BMO",
+  },
+];
+
+function args(options: Record<string, string | number | boolean>): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: "AAPL,MSFT",
+    argument: ["AAPL", "MSFT"],
+    symbols: ["AAPL", "MSFT"],
+    options,
+  };
+}
+
+const context = {} as HeadlessPaneContext;
+
+describe("earnings calendar headless", () => {
+  test("maps provider events into date-ordered rows", async () => {
+    const definition = createEarningsCalendarHeadless({
+      loadCalendar: async () => ({ events, fetchedAt: 123, stale: false }),
+    });
+
+    const result = await definition.load(args({ timing: "all", limit: 50 }), context);
+
+    expect(result.rows.map((row) => row.symbol)).toEqual(["AAPL", "MSFT"]);
+    expect(result.rows[1]).toMatchObject({
+      date: "2026-09-08T20:00:00.000Z",
+      timing: "AMC",
+      dateStatus: "confirmed",
+      epsEstimate: 3.67,
+      revenueEstimate: 74_000_000_000,
+    });
+  });
+
+  test("applies timing and limit options", async () => {
+    const definition = createEarningsCalendarHeadless({
+      loadCalendar: async () => ({ events, fetchedAt: 123, stale: false }),
+    });
+
+    const result = await definition.load(args({ timing: "AMC", limit: 1 }), context);
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.symbol).toBe("MSFT");
+    expect(result.metadata).toMatchObject({ timing: "AMC", returned: 1 });
+  });
+});

--- a/src/plugins/builtin/earnings/headless.ts
+++ b/src/plugins/builtin/earnings/headless.ts
@@ -1,0 +1,162 @@
+import type { EarningsEvent } from "../../../types/data-provider";
+import type {
+  HeadlessPaneContext,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+  HeadlessRowsResult,
+} from "../../../types/plugin";
+import {
+  loadEarningsCalendar,
+  type EarningsCalendarResult,
+} from "./data/cache";
+
+const EARNINGS_COLUMNS = [
+  { key: "date", header: "Date" },
+  { key: "timing", header: "When" },
+  { key: "dateStatus", header: "Status" },
+  { key: "symbol", header: "Ticker" },
+  { key: "name", header: "Name" },
+  { key: "epsEstimate", header: "EPS est", align: "right" as const },
+  { key: "epsLow", header: "EPS low", align: "right" as const },
+  { key: "epsHigh", header: "EPS high", align: "right" as const },
+  { key: "epsGrowth", header: "EPS growth", align: "right" as const },
+  { key: "epsTrend30dAgo", header: "EPS 30D ago", align: "right" as const },
+  { key: "epsRevisionUp30d", header: "Rev up", align: "right" as const },
+  { key: "epsRevisionDown30d", header: "Rev down", align: "right" as const },
+  { key: "revenueEstimate", header: "Sales est", align: "right" as const },
+  { key: "revenueLow", header: "Sales low", align: "right" as const },
+  { key: "revenueHigh", header: "Sales high", align: "right" as const },
+  { key: "revenueGrowth", header: "Sales growth", align: "right" as const },
+  { key: "epsAnalysts", header: "EPS analysts", align: "right" as const },
+  { key: "revenueAnalysts", header: "Sales analysts", align: "right" as const },
+];
+
+export interface EarningsCalendarHeadlessDependencies {
+  loadCalendar(
+    symbols: string[],
+    context: HeadlessPaneContext,
+  ): Promise<EarningsCalendarResult>;
+}
+
+const defaultDependencies: EarningsCalendarHeadlessDependencies = {
+  loadCalendar: (symbols, context) => loadEarningsCalendar(context.marketData, symbols),
+};
+
+function timingMatches(event: EarningsEvent, timing: string): boolean {
+  if (timing === "all") return true;
+  if (timing === "unknown") return !event.timing;
+  return event.timing?.toUpperCase() === timing;
+}
+
+function eventRow(event: EarningsEvent) {
+  return {
+    date: event.earningsDate.toISOString(),
+    earningsCallDate: event.earningsCallDate?.toISOString() ?? null,
+    timing: event.timing || null,
+    dateStatus: event.isDateEstimate == null
+      ? null
+      : event.isDateEstimate
+        ? "estimated"
+        : "confirmed",
+    symbol: event.symbol,
+    name: event.name,
+    epsEstimate: event.epsEstimate ?? null,
+    epsLow: event.epsLow ?? null,
+    epsHigh: event.epsHigh ?? null,
+    epsYearAgo: event.epsYearAgo ?? null,
+    epsGrowth: event.epsGrowth ?? null,
+    epsAnalysts: event.epsAnalysts ?? null,
+    epsTrend7dAgo: event.epsTrend7dAgo ?? null,
+    epsTrend30dAgo: event.epsTrend30dAgo ?? null,
+    epsRevisionUp7d: event.epsRevisionUp7d ?? null,
+    epsRevisionUp30d: event.epsRevisionUp30d ?? null,
+    epsRevisionDown7d: event.epsRevisionDown7d ?? null,
+    epsRevisionDown30d: event.epsRevisionDown30d ?? null,
+    epsActual: event.epsActual ?? null,
+    revenueEstimate: event.revenueEstimate ?? null,
+    revenueLow: event.revenueLow ?? null,
+    revenueHigh: event.revenueHigh ?? null,
+    revenueYearAgo: event.revenueYearAgo ?? null,
+    revenueGrowth: event.revenueGrowth ?? null,
+    revenueAnalysts: event.revenueAnalysts ?? null,
+    revenueActual: event.revenueActual ?? null,
+    surprise: event.surprise ?? null,
+  };
+}
+
+export function projectEarningsCalendarHeadless(
+  result: EarningsCalendarResult,
+  args: HeadlessPaneLoadArgs,
+): HeadlessRowsResult {
+  const timing = String(args.options.timing ?? "all").toUpperCase();
+  const normalizedTiming = timing === "ALL" || timing === "UNKNOWN"
+    ? timing.toLowerCase()
+    : timing;
+  const limit = Number(args.options.limit ?? 50);
+  const matching = result.events
+    .filter((event) => timingMatches(event, normalizedTiming))
+    .sort((left, right) => left.earningsDate.getTime() - right.earningsDate.getTime());
+  const rows = matching.slice(0, limit).map(eventRow);
+
+  return {
+    columns: EARNINGS_COLUMNS,
+    rows,
+    errors: result.refreshError ? [result.refreshError] : undefined,
+    metadata: {
+      fetchedAt: result.fetchedAt,
+      stale: result.stale,
+      timing: normalizedTiming,
+      total: matching.length,
+      returned: rows.length,
+      truncated: rows.length < matching.length,
+    },
+  };
+}
+
+export function createEarningsCalendarHeadless(
+  dependencies: EarningsCalendarHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "symbol-list",
+      placeholder: "tickers",
+      description: "Comma-separated company symbols.",
+      minimum: 1,
+      maximum: 100,
+    },
+    options: [
+      {
+        key: "timing",
+        description: "Release timing to include.",
+        type: "enum",
+        values: [
+          { value: "all" },
+          { value: "BMO" },
+          { value: "AMC" },
+          { value: "TNS" },
+          { value: "unknown" },
+        ],
+        defaultValue: "all",
+      },
+      {
+        key: "limit",
+        description: "Maximum earnings rows to return.",
+        type: "integer",
+        defaultValue: 50,
+        minimum: 1,
+        maximum: 200,
+      },
+    ],
+    columns: EARNINGS_COLUMNS,
+    describe: (args) => `Earnings Calendar | ${args.symbols.join(", ")}`,
+    async load(args, context) {
+      return projectEarningsCalendarHeadless(
+        await dependencies.loadCalendar(args.symbols, context),
+        args,
+      );
+    },
+  };
+}
+
+export const earningsCalendarHeadless = createEarningsCalendarHeadless();

--- a/src/plugins/builtin/earnings/index.tsx
+++ b/src/plugins/builtin/earnings/index.tsx
@@ -23,6 +23,7 @@ import {
   type EarningsDisplayRow,
   type EarningsEventDisplayRow,
 } from "./model";
+import { earningsCalendarHeadless } from "./headless";
 import {
   buildEarningsColumns,
   renderEarningsCell,
@@ -266,6 +267,7 @@ export const earningsModule: PluginModule = {
       description: "Upcoming earnings dates and estimates for your tickers.",
       keywords: ["earn", "earnings", "calendar", "eps", "revenue", "quarterly"],
       shortcut: { prefix: "ERN" },
+      headless: earningsCalendarHeadless,
       createInstance: (context) => ({
         settings: context.activeCollectionId
           ? { collectionId: context.activeCollectionId }

--- a/src/plugins/builtin/ipo-calendar/client.ts
+++ b/src/plugins/builtin/ipo-calendar/client.ts
@@ -256,6 +256,21 @@ async function fetchUpcomingIpos(): Promise<IPORecord[]> {
   return parseCalendarRecords(flat);
 }
 
+export function formatIpoDate(date: Date): string {
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${date.getUTCFullYear()}-${month}-${day}`;
+}
+
+export function matchesIpoRecord(record: IPORecord, query: string): boolean {
+  if (!query) return true;
+  const normalized = query.toLowerCase();
+  return record.ticker.toLowerCase().includes(normalized)
+    || record.companyName.toLowerCase().includes(normalized)
+    || (record.exchange?.toLowerCase().includes(normalized) ?? false)
+    || record.status.includes(normalized);
+}
+
 function dedupeAndSort(records: IPORecord[]): IPORecord[] {
   const byTicker = new Map<string, IPORecord>();
   const statusOrder: Record<IPOStatus, number> = { upcoming: 0, priced: 1, trading: 2 };

--- a/src/plugins/builtin/ipo-calendar/headless.test.ts
+++ b/src/plugins/builtin/ipo-calendar/headless.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import { createIpoCalendarHeadless } from "./headless";
+import type { IPORecord } from "./types";
+
+const records: IPORecord[] = [
+  {
+    ticker: "ALFA",
+    companyName: "Alpha Labs",
+    date: new Date("2026-09-10T00:00:00.000Z"),
+    status: "upcoming",
+    exchange: "NASDAQ",
+    offerSize: 120_000_000,
+    priceRange: [18, 20],
+    pricedPrice: null,
+    shares: 6_000_000,
+    closePrice: null,
+    change1D: null,
+  },
+  {
+    ticker: "BETA",
+    companyName: "Beta Systems",
+    date: new Date("2026-09-03T00:00:00.000Z"),
+    status: "trading",
+    exchange: "NYSE",
+    offerSize: null,
+    priceRange: null,
+    pricedPrice: 24,
+    shares: null,
+    closePrice: 30,
+    change1D: 25,
+  },
+];
+
+function args(
+  argument: string | null = null,
+  options: Record<string, string | number | boolean> = { status: "all", limit: 50 },
+): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: argument ?? "",
+    argument,
+    symbols: [],
+    options,
+  };
+}
+
+const context = {} as HeadlessPaneContext;
+
+describe("IPO calendar headless", () => {
+  test("maps IPO records into structured rows", async () => {
+    const definition = createIpoCalendarHeadless({
+      loadCalendar: async () => ({
+        records,
+        fetchedAt: 123,
+        stale: false,
+        errors: [],
+      }),
+    });
+
+    const result = await definition.load(args("alpha"), context);
+
+    expect(result.rows).toEqual([{
+      ticker: "ALFA",
+      company: "Alpha Labs",
+      date: "2026-09-10",
+      status: "upcoming",
+      exchange: "NASDAQ",
+      offerSize: 120_000_000,
+      priceLow: 18,
+      priceHigh: 20,
+      pricedPrice: null,
+      shares: 6_000_000,
+      closePrice: null,
+      change1D: null,
+    }]);
+    expect(result.metadata).toMatchObject({ total: 1, returned: 1, truncated: false });
+  });
+
+  test("applies status and limit options", async () => {
+    const definition = createIpoCalendarHeadless({
+      loadCalendar: async () => ({ records, fetchedAt: 123, stale: false, errors: [] }),
+    });
+
+    const result = await definition.load(args(null, { status: "trading", limit: 1 }), context);
+
+    expect(result.rows.map((row) => row.ticker)).toEqual(["BETA"]);
+    expect(result.metadata).toMatchObject({ status: "trading", returned: 1 });
+  });
+});

--- a/src/plugins/builtin/ipo-calendar/headless.ts
+++ b/src/plugins/builtin/ipo-calendar/headless.ts
@@ -1,0 +1,127 @@
+import type {
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+  HeadlessRowsResult,
+} from "../../../types/plugin";
+import { formatIpoDate, matchesIpoRecord } from "./client";
+import { loadIpoCalendar, type IpoCalendarResult } from "./cache";
+import type { IPORecord, IPOStatus } from "./types";
+
+const IPO_COLUMNS = [
+  { key: "ticker", header: "Ticker" },
+  { key: "company", header: "Company" },
+  { key: "date", header: "Date" },
+  { key: "status", header: "Status" },
+  { key: "exchange", header: "Exchange" },
+  { key: "offerSize", header: "Offer", align: "right" as const },
+  { key: "priceLow", header: "Price low", align: "right" as const },
+  { key: "priceHigh", header: "Price high", align: "right" as const },
+  { key: "pricedPrice", header: "Priced", align: "right" as const },
+  { key: "shares", header: "Shares", align: "right" as const },
+  { key: "closePrice", header: "Close", align: "right" as const },
+  { key: "change1D", header: "1D %", align: "right" as const },
+];
+
+export interface IpoCalendarHeadlessDependencies {
+  loadCalendar(): Promise<IpoCalendarResult>;
+}
+
+const defaultDependencies: IpoCalendarHeadlessDependencies = {
+  loadCalendar: () => loadIpoCalendar(false),
+};
+
+function statusOption(args: HeadlessPaneLoadArgs): IPOStatus | "all" {
+  return String(args.options.status ?? "all") as IPOStatus | "all";
+}
+
+function toHeadlessRow(record: IPORecord) {
+  return {
+    ticker: record.ticker,
+    company: record.companyName,
+    date: formatIpoDate(record.date),
+    status: record.status,
+    exchange: record.exchange,
+    offerSize: record.offerSize,
+    priceLow: record.priceRange?.[0] ?? null,
+    priceHigh: record.priceRange?.[1] ?? null,
+    pricedPrice: record.pricedPrice,
+    shares: record.shares,
+    closePrice: record.closePrice,
+    change1D: record.change1D,
+  };
+}
+
+export function projectIpoCalendarHeadless(
+  result: IpoCalendarResult,
+  args: HeadlessPaneLoadArgs,
+): HeadlessRowsResult {
+  const query = typeof args.argument === "string" ? args.argument.trim() : "";
+  const status = statusOption(args);
+  const limit = Number(args.options.limit ?? 50);
+  const matching = result.records.filter((record) => (
+    matchesIpoRecord(record, query)
+    && (status === "all" || record.status === status)
+  ));
+  const rows = matching.slice(0, limit).map(toHeadlessRow);
+
+  return {
+    columns: IPO_COLUMNS,
+    rows,
+    errors: result.errors.length > 0 ? result.errors : undefined,
+    metadata: {
+      fetchedAt: result.fetchedAt,
+      stale: result.stale,
+      total: matching.length,
+      returned: rows.length,
+      truncated: rows.length < matching.length,
+      query: query || null,
+      status,
+    },
+  };
+}
+
+export function createIpoCalendarHeadless(
+  dependencies: IpoCalendarHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "free-text",
+      placeholder: "company or ticker",
+      description: "Optional company, ticker, exchange, or status filter.",
+      optional: true,
+    },
+    options: [
+      {
+        key: "status",
+        description: "IPO stage to include.",
+        type: "enum",
+        values: [
+          { value: "all" },
+          { value: "upcoming" },
+          { value: "priced" },
+          { value: "trading" },
+        ],
+        defaultValue: "all",
+      },
+      {
+        key: "limit",
+        description: "Maximum IPO rows to return.",
+        type: "integer",
+        defaultValue: 50,
+        minimum: 1,
+        maximum: 200,
+      },
+    ],
+    columns: IPO_COLUMNS,
+    describe: (args) => {
+      const status = statusOption(args);
+      return status === "all" ? "IPO Calendar" : `IPO Calendar | ${status}`;
+    },
+    async load(args) {
+      return projectIpoCalendarHeadless(await dependencies.loadCalendar(), args);
+    },
+  };
+}
+
+export const ipoCalendarHeadless = createIpoCalendarHeadless();

--- a/src/plugins/builtin/ipo-calendar/index.tsx
+++ b/src/plugins/builtin/ipo-calendar/index.tsx
@@ -6,6 +6,7 @@ import {
 } from "./client";
 import { attachIpoCalendarPersistence, resetIpoCalendarPersistence } from "./cache";
 import { IPOCalendarPane } from "./pane";
+import { ipoCalendarHeadless } from "./headless";
 import { IPO_CALENDAR_PANE_ID } from "./types";
 
 let disposeConnection: (() => void) | null = null;
@@ -60,6 +61,7 @@ export const ipoCalendarModule: PluginModule = {
         "debut",
       ],
       shortcut: { prefix: "IPO" },
+      headless: ipoCalendarHeadless,
       createInstance: () => ({ placement: "floating" }),
     },
   ],

--- a/src/plugins/builtin/ipo-calendar/model.ts
+++ b/src/plugins/builtin/ipo-calendar/model.ts
@@ -2,6 +2,7 @@ import type { DataTableColumn } from "../../../components";
 import { colors } from "../../../theme/colors";
 import { compareSortValues, type SortDirection } from "../../../utils/sort-values";
 import type { IPORecord, IPOStatus } from "./types";
+import { formatIpoDate, matchesIpoRecord } from "./client";
 
 type IPOColumnId =
   | "ticker"
@@ -37,11 +38,7 @@ export function statusColor(status: IPOStatus): string {
   }
 }
 
-export function formatDate(date: Date): string {
-  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(date.getUTCDate()).padStart(2, "0");
-  return `${date.getUTCFullYear()}-${month}-${day}`;
-}
+export const formatDate = formatIpoDate;
 
 export function formatOfferSize(value: number | null): string {
   if (value == null) return "—";
@@ -133,13 +130,4 @@ export function nextSortPreference(current: IPOSortPreference, columnId: string)
   return DEFAULT_SORT_PREFERENCE;
 }
 
-export function matchesSearch(record: IPORecord, query: string): boolean {
-  if (!query) return true;
-  const q = query.toLowerCase();
-  return (
-    record.ticker.toLowerCase().includes(q)
-    || record.companyName.toLowerCase().includes(q)
-    || (record.exchange?.toLowerCase().includes(q) ?? false)
-    || record.status.includes(q)
-  );
-}
+export const matchesSearch = matchesIpoRecord;

--- a/src/plugins/builtin/news/headless.test.ts
+++ b/src/plugins/builtin/news/headless.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import type { CloudNewsPayload } from "../../../api-client";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import type { NewsQuery } from "../../../news/types";
+import {
+  createNewsFeedHeadless,
+  createTickerNewsHeadless,
+  type NewsHeadlessDependencies,
+} from "./headless";
+
+function story(
+  id: string,
+  sentiment: CloudNewsPayload["sentiment"],
+  importance: number,
+  publishedAt: string,
+): CloudNewsPayload {
+  return {
+    id,
+    headline: `${id} headline`,
+    summary: `${id} summary`,
+    category: "markets",
+    sentiment,
+    sectors: ["technology"],
+    firstPublishedAt: publishedAt,
+    lastPublishedAt: publishedAt,
+    firstSeenAt: publishedAt,
+    lastSeenAt: publishedAt,
+    primaryUrl: `https://example.com/${id}`,
+    primarySource: "Example Wire",
+    scores: {
+      importance,
+      urgency: importance - 1,
+      marketImpact: importance - 2,
+      novelty: 7,
+      confidence: 90,
+    },
+    flags: { breaking: importance > 80 },
+    variantCount: 1,
+    sourceCount: 1,
+    sources: ["Example Wire"],
+    entities: [],
+    tickerLinks: [{
+      symbol: "AMD",
+      exchange: "NASDAQ",
+      canonicalTicker: "AMD",
+      relationType: "issuer",
+      displayTier: "primary",
+      confidence: 1,
+      relevanceScore: 1,
+    }],
+  };
+}
+
+const stories = [
+  story("newer", "positive", 95, "2026-09-04T20:00:00.000Z"),
+  story("older", "negative", 70, "2026-09-04T18:00:00.000Z"),
+];
+
+function args(
+  symbol: string | null,
+  options: Record<string, string | number | boolean>,
+): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: symbol ?? "",
+    argument: symbol,
+    symbols: symbol ? [symbol] : [],
+    options,
+  };
+}
+
+const context = {} as HeadlessPaneContext;
+
+function dependencies(seen: NewsQuery[]): NewsHeadlessDependencies {
+  return {
+    loadNews: async (query) => {
+      seen.push(query);
+      return { items: stories, nextCursor: "page-2" };
+    },
+    now: () => new Date("2026-09-04T21:00:00.000Z"),
+  };
+}
+
+describe("news feed headless", () => {
+  test("maps cloud stories into a point-in-time snapshot", async () => {
+    const seen: NewsQuery[] = [];
+    const definition = createNewsFeedHeadless(dependencies(seen));
+
+    const result = await definition.load(
+      args(null, { sentiment: "any", minImportance: 0, limit: 50 }),
+      context,
+    );
+
+    expect(result.asOf).toBe("2026-09-04T21:00:00.000Z");
+    expect(result.items[0]).toMatchObject({
+      id: "newer",
+      headline: "newer headline",
+      tickers: ["AMD"],
+      sentiment: "positive",
+      importance: 95,
+      breaking: true,
+      sourceCount: 1,
+    });
+    expect(seen[0]).toMatchObject({ feed: "latest", limit: 50 });
+  });
+
+  test("applies sentiment and importance options", async () => {
+    const definition = createNewsFeedHeadless(dependencies([]));
+
+    const result = await definition.load(
+      args(null, { sentiment: "positive", minImportance: 90, limit: 50 }),
+      context,
+    );
+
+    expect(result.items.map((item) => item.id)).toEqual(["newer"]);
+  });
+});
+
+describe("ticker news headless", () => {
+  test("requests the ticker feed and applies the row limit", async () => {
+    const seen: NewsQuery[] = [];
+    const definition = createTickerNewsHeadless(dependencies(seen));
+
+    const result = await definition.load(
+      args("AMD:XNAS", { sentiment: "any", minImportance: 0, limit: 1 }),
+      context,
+    );
+
+    expect(seen[0]).toMatchObject({
+      feed: "ticker",
+      ticker: "AMD",
+      exchange: "NASDAQ",
+      tickerTier: "primary",
+      limit: 1,
+    });
+    expect(result.items).toHaveLength(1);
+    expect(result.metadata).toMatchObject({ truncated: true });
+  });
+});

--- a/src/plugins/builtin/news/headless.ts
+++ b/src/plugins/builtin/news/headless.ts
@@ -1,0 +1,190 @@
+import type { CloudNewsListResponse } from "../../../api-client";
+import type {
+  HeadlessPaneContext,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+  HeadlessSnapshotResult,
+} from "../../../types/plugin";
+import type { NewsArticle, NewsQuery } from "../../../news/types";
+import {
+  cloudNewsParams,
+  mapCloudNewsArticle,
+} from "../../../sources/gloomberb-cloud/news";
+import { parsePublicTickerKey } from "../../../utils/exchanges";
+
+const NEWS_COLUMNS = [
+  { key: "publishedAt", header: "Published" },
+  { key: "source", header: "Source" },
+  { key: "headline", header: "Headline" },
+  { key: "tickers", header: "Tickers" },
+  { key: "sentiment", header: "Sentiment" },
+  { key: "importance", header: "Score", align: "right" as const },
+];
+
+export interface NewsHeadlessDependencies {
+  loadNews(
+    query: NewsQuery,
+    context: HeadlessPaneContext,
+  ): Promise<CloudNewsListResponse>;
+  now(): Date;
+}
+
+const defaultDependencies: NewsHeadlessDependencies = {
+  loadNews: (query, context) => context.apiClient.getCloudNews(cloudNewsParams(query)),
+  now: () => new Date(),
+};
+
+function newsRow(article: NewsArticle) {
+  return {
+    id: article.id,
+    publishedAt: article.publishedAt.toISOString(),
+    source: article.source,
+    headline: article.title,
+    summary: article.summary ?? null,
+    topic: article.topic,
+    topics: article.topics,
+    sectors: article.sectors,
+    categories: article.categories,
+    tickers: article.tickers,
+    sentiment: article.sentiment ?? null,
+    importance: article.scores.importance,
+    urgency: article.scores.urgency,
+    marketImpact: article.scores.marketImpact,
+    novelty: article.scores.novelty,
+    confidence: article.scores.confidence,
+    breaking: article.isBreaking,
+    developing: article.isDeveloping,
+    sourceCount: article.sourceCount ?? article.items?.length ?? 0,
+    url: article.url,
+  };
+}
+
+function selectedSentiment(args: HeadlessPaneLoadArgs): string {
+  return String(args.options.sentiment ?? "any");
+}
+
+export function projectNewsHeadless(
+  response: CloudNewsListResponse,
+  args: HeadlessPaneLoadArgs,
+  now: Date,
+): HeadlessSnapshotResult {
+  const sentiment = selectedSentiment(args);
+  const minImportance = Number(args.options.minImportance ?? 0);
+  const limit = Number(args.options.limit ?? 50);
+  const matching = response.items
+    .map((item) => mapCloudNewsArticle(item, args.symbols[0]))
+    .filter((article) => sentiment === "any" || article.sentiment === sentiment)
+    .filter((article) => article.importance >= minImportance)
+    .sort((left, right) => right.publishedAt.getTime() - left.publishedAt.getTime());
+  const items = matching.slice(0, limit).map(newsRow);
+
+  return {
+    asOf: now.toISOString(),
+    items,
+    metadata: {
+      nextCursor: response.nextCursor,
+      sentiment,
+      minImportance,
+      total: matching.length,
+      returned: items.length,
+      truncated: items.length < matching.length || response.nextCursor != null,
+    },
+  };
+}
+
+function newsOptions() {
+  return [
+    {
+      key: "sentiment",
+      description: "Story sentiment to include.",
+      type: "enum" as const,
+      values: [
+        { value: "any" },
+        { value: "positive" },
+        { value: "neutral" },
+        { value: "negative" },
+      ],
+      defaultValue: "any",
+    },
+    {
+      key: "minImportance",
+      aliases: ["importance"],
+      description: "Minimum importance score.",
+      type: "integer" as const,
+      defaultValue: 0,
+      minimum: 0,
+      maximum: 100,
+    },
+    {
+      key: "limit",
+      description: "Maximum stories to return.",
+      type: "integer" as const,
+      defaultValue: 50,
+      minimum: 1,
+      maximum: 200,
+    },
+  ];
+}
+
+function queryFor(args: HeadlessPaneLoadArgs, feed: "latest" | "ticker"): NewsQuery {
+  const sentiment = selectedSentiment(args);
+  const ticker = args.symbols[0] ? parsePublicTickerKey(args.symbols[0]) : null;
+  return {
+    feed,
+    ...(feed === "ticker"
+      ? {
+          ticker: ticker?.symbol,
+          exchange: ticker?.exchange,
+          tickerTier: "primary" as const,
+        }
+      : {}),
+    ...(sentiment === "any" ? {} : { sentiment: sentiment as "positive" | "neutral" | "negative" }),
+    minImportance: Number(args.options.minImportance ?? 0),
+    limit: Number(args.options.limit ?? 50),
+  };
+}
+
+export function createNewsFeedHeadless(
+  dependencies: NewsHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"snapshot"> {
+  return {
+    shape: "snapshot",
+    argument: { kind: "none" },
+    options: newsOptions(),
+    columns: NEWS_COLUMNS,
+    describe: "News Feed",
+    async load(args, context) {
+      return projectNewsHeadless(
+        await dependencies.loadNews(queryFor(args, "latest"), context),
+        args,
+        dependencies.now(),
+      );
+    },
+  };
+}
+
+export function createTickerNewsHeadless(
+  dependencies: NewsHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"snapshot"> {
+  return {
+    shape: "snapshot",
+    argument: {
+      kind: "ticker",
+      placeholder: "ticker",
+      description: "Company symbol, optionally qualified as SYMBOL:EXCHANGE.",
+    },
+    options: newsOptions(),
+    columns: NEWS_COLUMNS,
+    describe: (args) => `Ticker News | ${String(args.argument)}`,
+    async load(args, context) {
+      return projectNewsHeadless(
+        await dependencies.loadNews(queryFor(args, "ticker"), context),
+        args,
+        dependencies.now(),
+      );
+    },
+  };
+}
+
+export const newsFeedHeadless = createNewsFeedHeadless();
+export const tickerNewsHeadless = createTickerNewsHeadless();

--- a/src/plugins/builtin/news/index.tsx
+++ b/src/plugins/builtin/news/index.tsx
@@ -17,6 +17,7 @@ import { useNewsArticleFooter } from "./wire/news/footer";
 import { usePersistedNewsArticles } from "./wire/persisted-articles";
 import { useNewsReadState } from "./wire/read-state";
 import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
+import { tickerNewsHeadless } from "./headless";
 
 const NEWS_ITEM_LIMIT = 50;
 const DEFAULT_SORT: NewsSortPreference = { columnId: "time", direction: "desc" };
@@ -140,15 +141,18 @@ export const tickerNewsModule: PluginModule = {
   ],
 
   paneTemplates: [
-    createTickerSurfacePaneTemplate({
-      id: "ticker-news-pane",
-      paneId: "ticker-news",
-      label: "Ticker News",
-      description: "Company news for the selected ticker.",
-      keywords: ["company", "ticker", "news", "headlines", "cn"],
-      shortcut: "CN",
-      publicShare: true,
-    }),
+    {
+      ...createTickerSurfacePaneTemplate({
+        id: "ticker-news-pane",
+        paneId: "ticker-news",
+        label: "Ticker News",
+        description: "Company news for the selected ticker.",
+        keywords: ["company", "ticker", "news", "headlines", "cn"],
+        shortcut: "CN",
+        publicShare: true,
+      }),
+      headless: tickerNewsHeadless,
+    },
   ],
 
   setup(ctx) {

--- a/src/plugins/builtin/news/wire/index.tsx
+++ b/src/plugins/builtin/news/wire/index.tsx
@@ -23,6 +23,7 @@ import { NewsPresetPane } from "./news/preset-pane";
 import { NEWS_QUERY_PRESETS } from "./news/query-presets";
 import type { NewsColumnId, NewsSortPreference } from "./news/table";
 import { createRssNewsCapability } from "./rss/source";
+import { newsFeedHeadless } from "../headless";
 
 interface NewsPresetPaneConfig {
   paneKey: string;
@@ -107,7 +108,7 @@ export const newsWireModule: PluginModule = {
   ],
   paneTemplates: [
     { id: "news-top-pane", paneId: "news-top", label: "Top News", description: "Curated top market stories ranked by importance", keywords: ["top", "news", "headlines", "stories"], shortcut: { prefix: "TOP" } },
-    { id: "news-feed-pane", paneId: "news-feed", label: "News Feed", description: "Chronological market news firehose", keywords: ["news", "feed", "firehose", "wire", "stream"], shortcut: { prefix: "N" } },
+    { id: "news-feed-pane", paneId: "news-feed", label: "News Feed", description: "Chronological market news firehose", keywords: ["news", "feed", "firehose", "wire", "stream"], shortcut: { prefix: "N" }, headless: newsFeedHeadless },
     { id: "news-industry-pane", paneId: "news-industry", label: "Sector News", description: "Market news filtered by sector", keywords: ["news", "industry", "sector", "ni", "filter"], shortcut: { prefix: "NI" } },
     { id: "news-breaking-pane", paneId: "news-breaking", label: "Breaking News", description: "Breaking and urgent market news", keywords: ["first", "breaking", "urgent", "alert", "flash"], shortcut: { prefix: "FIRST" } },
   ],

--- a/src/plugins/builtin/research/headless.test.ts
+++ b/src/plugins/builtin/research/headless.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
+import {
+  createEarningsEstimatesHeadless,
+  type EarningsEstimateSources,
+} from "./headless";
+
+const sources: EarningsEstimateSources = {
+  currency: "USD",
+  actions: {
+    symbol: "AMD",
+    currency: "USD",
+    dividends: [],
+    splits: [],
+    earnings: [{
+      date: "2026-07-28",
+      epsEstimate: 0.45,
+      epsActual: 0.48,
+      difference: 0.03,
+      surprisePercent: 6.67,
+    }],
+  },
+  estimates: {
+    symbol: "AMD",
+    currency: "USD",
+    recommendations: [],
+    ratings: [],
+    earningsEstimates: [
+      { date: "2026-09-30", period: "next_quarter", average: 1.2, analysts: 30 },
+      { date: "2026-12-31", period: "current_year", average: 4.8, analysts: 32 },
+    ],
+    revenueEstimates: [
+      { date: "2026-09-30", period: "next_quarter", average: 9_000_000_000, analysts: 28 },
+      { date: "2026-12-31", period: "current_year", average: 35_000_000_000, analysts: 29 },
+    ],
+  },
+  financials: {
+    annualStatements: [],
+    quarterlyStatements: [],
+    priceHistory: [],
+  },
+};
+
+function args(options: Record<string, string | number | boolean>): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: "AMD",
+    argument: "AMD",
+    symbols: ["AMD"],
+    options,
+  };
+}
+
+const context = {} as HeadlessPaneContext;
+
+describe("earnings estimates headless", () => {
+  test("maps the shared event model into estimate rows", async () => {
+    const definition = createEarningsEstimatesHeadless({
+      loadSources: async () => sources,
+    });
+
+    const result = await definition.load(args({ kind: "all", limit: 50 }), context);
+
+    expect(result.rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        status: "Q Est",
+        period: "next qtr",
+        qEps: 1.2,
+        qRevenue: 9_000_000_000,
+        detail: "30E/28R",
+      }),
+      expect.objectContaining({
+        status: "FY Est",
+        annualEps: 4.8,
+        annualRevenue: 35_000_000_000,
+      }),
+      expect.objectContaining({
+        status: "Earnings",
+        qEps: 0.48,
+        value: "+6.67%",
+      }),
+    ]));
+  });
+
+  test("applies kind and limit options", async () => {
+    const definition = createEarningsEstimatesHeadless({ loadSources: async () => sources });
+
+    const result = await definition.load(args({ kind: "estimates", limit: 1 }), context);
+
+    expect(result.rows).toHaveLength(1);
+    expect(["Q Est", "FY Est"]).toContain(result.rows[0]?.status);
+    expect(result.metadata).toMatchObject({ kind: "estimates", total: 2, truncated: true });
+  });
+});

--- a/src/plugins/builtin/research/headless.ts
+++ b/src/plugins/builtin/research/headless.ts
@@ -1,0 +1,161 @@
+import type {
+  AnalystResearchData,
+  CorporateActionsData,
+  TickerFinancials,
+} from "../../../types/financials";
+import type {
+  HeadlessPaneContext,
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+  HeadlessRowsResult,
+} from "../../../types/plugin";
+import { buildEventRows, type EventRow } from "./event-model";
+
+const ESTIMATE_COLUMNS = [
+  { key: "date", header: "Date" },
+  { key: "status", header: "Event" },
+  { key: "period", header: "Period" },
+  { key: "qEps", header: "Q EPS", align: "right" as const },
+  { key: "qRevenue", header: "Q revenue", align: "right" as const },
+  { key: "annualEps", header: "Annual EPS", align: "right" as const },
+  { key: "annualRevenue", header: "Annual revenue", align: "right" as const },
+  { key: "value", header: "Value", align: "right" as const },
+  { key: "detail", header: "Detail" },
+];
+
+export interface EarningsEstimateSources {
+  actions: CorporateActionsData | null;
+  estimates: AnalystResearchData | null;
+  financials: TickerFinancials | null;
+  currency: string;
+  errors?: string[];
+}
+
+export interface EarningsEstimatesHeadlessDependencies {
+  loadSources(
+    symbol: string,
+    context: HeadlessPaneContext,
+  ): Promise<EarningsEstimateSources>;
+}
+
+async function settledValue<T>(
+  promise: Promise<T> | null,
+  errors: string[],
+  label: string,
+): Promise<T | null> {
+  if (!promise) return null;
+  try {
+    return await promise;
+  } catch (error) {
+    errors.push(`${label}: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+}
+
+const defaultDependencies: EarningsEstimatesHeadlessDependencies = {
+  async loadSources(symbol, context) {
+    const errors: string[] = [];
+    const provider = context.marketData;
+    const [actions, estimates, financials] = await Promise.all([
+      settledValue(
+        provider.getCorporateActions?.(symbol, "") ?? null,
+        errors,
+        "corporate actions",
+      ),
+      settledValue(
+        provider.getAnalystResearch?.(symbol, "") ?? null,
+        errors,
+        "analyst estimates",
+      ),
+      settledValue(provider.getTickerFinancials(symbol, ""), errors, "financials"),
+    ]);
+    if (!actions && !estimates && !financials && errors.length > 0) {
+      throw new Error(errors.join("; "));
+    }
+    return {
+      actions,
+      estimates,
+      financials,
+      currency: actions?.currency ?? estimates?.currency ?? financials?.quote?.currency ?? "USD",
+      errors,
+    };
+  },
+};
+
+function matchesKind(row: EventRow, kind: string): boolean {
+  if (kind === "all") return true;
+  if (kind === "estimates") return row.status === "Q Est" || row.status === "FY Est";
+  return row.status === "Earnings" || row.status === "TTM";
+}
+
+export function projectEarningsEstimatesHeadless(
+  sources: EarningsEstimateSources,
+  args: HeadlessPaneLoadArgs,
+): HeadlessRowsResult {
+  const kind = String(args.options.kind ?? "all");
+  const limit = Number(args.options.limit ?? 50);
+  const matching = buildEventRows(
+    sources.actions,
+    sources.estimates,
+    sources.financials,
+    sources.currency,
+  ).filter((row) => matchesKind(row, kind));
+  const rows = matching.slice(0, limit).map((row) => ({ ...row }));
+
+  return {
+    columns: ESTIMATE_COLUMNS,
+    rows,
+    errors: sources.errors?.length ? sources.errors : undefined,
+    metadata: {
+      currency: sources.currency,
+      kind,
+      total: matching.length,
+      returned: rows.length,
+      truncated: rows.length < matching.length,
+    },
+  };
+}
+
+export function createEarningsEstimatesHeadless(
+  dependencies: EarningsEstimatesHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "ticker",
+      placeholder: "ticker",
+      description: "Company symbol.",
+    },
+    options: [
+      {
+        key: "kind",
+        description: "Estimate or reported rows to include.",
+        type: "enum",
+        values: [
+          { value: "all" },
+          { value: "estimates" },
+          { value: "reported" },
+        ],
+        defaultValue: "all",
+      },
+      {
+        key: "limit",
+        description: "Maximum rows to return.",
+        type: "integer",
+        defaultValue: 50,
+        minimum: 1,
+        maximum: 200,
+      },
+    ],
+    columns: ESTIMATE_COLUMNS,
+    describe: (args) => `Earnings Estimates | ${String(args.argument)}`,
+    async load(args, context) {
+      return projectEarningsEstimatesHeadless(
+        await dependencies.loadSources(String(args.argument), context),
+        args,
+      );
+    },
+  };
+}
+
+export const earningsEstimatesHeadless = createEarningsEstimatesHeadless();

--- a/src/plugins/builtin/research/index.tsx
+++ b/src/plugins/builtin/research/index.tsx
@@ -6,6 +6,7 @@ import { CorporateActionsView } from "./corporate-actions-pane";
 import { EquityDiagnosticView } from "./equity-diagnostic-pane";
 import { RelativeValuationPane } from "./relative-valuation-pane";
 import { eventsHeadless } from "./events-headless";
+import { earningsEstimatesHeadless } from "./headless";
 
 export { eventsHeadless } from "./events-headless";
 
@@ -125,15 +126,18 @@ export const researchModule: PluginModule = {
       shortcut: "EVT",
       publicShare: true,
     }),
-    createTickerSurfacePaneTemplate({
-      id: "earnings-estimates-pane",
-      paneId: "earnings-estimates",
-      label: "Earnings Estimates",
-      description: "EPS and revenue estimates with reported earnings.",
-      keywords: ["earnings", "estimates", "ee", "analyst", "eps", "revenue", "events"],
-      shortcut: "EE",
-      publicShare: true,
-    }),
+    {
+      ...createTickerSurfacePaneTemplate({
+        id: "earnings-estimates-pane",
+        paneId: "earnings-estimates",
+        label: "Earnings Estimates",
+        description: "EPS and revenue estimates with reported earnings.",
+        keywords: ["earnings", "estimates", "ee", "analyst", "eps", "revenue", "events"],
+        shortcut: "EE",
+        publicShare: true,
+      }),
+      headless: earningsEstimatesHeadless,
+    },
     {
       id: "relative-valuation-pane",
       paneId: "relative-valuation",

--- a/src/plugins/prediction-markets/headless.test.ts
+++ b/src/plugins/prediction-markets/headless.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../types/plugin";
+import {
+  createPredictionMarketsHeadless,
+  type PredictionMarketsHeadlessDependencies,
+} from "./headless";
+import type { PredictionMarketSummary, PredictionVenue } from "./types";
+
+function market(
+  key: string,
+  venue: PredictionVenue,
+  title: string,
+  volume24h: number,
+  endsAt: string,
+): PredictionMarketSummary {
+  return {
+    key,
+    venue,
+    marketId: `${key}-id`,
+    title,
+    marketLabel: "Yes",
+    eventLabel: title,
+    category: title.includes("Fed") ? "Economics" : "Politics",
+    tags: [],
+    status: "open",
+    url: `https://example.com/${key}`,
+    description: `${title} market`,
+    endsAt,
+    updatedAt: "2026-09-04T20:00:00.000Z",
+    yesPrice: 0.62,
+    noPrice: 0.38,
+    yesBid: 0.61,
+    yesAsk: 0.63,
+    noBid: 0.37,
+    noAsk: 0.39,
+    spread: 0.02,
+    lastTradePrice: 0.62,
+    volume24h,
+    volume24hUnit: "usd",
+    totalVolume: volume24h * 10,
+    totalVolumeUnit: "usd",
+    openInterest: volume24h / 2,
+    openInterestUnit: venue === "kalshi" ? "contracts" : "usd",
+    liquidity: volume24h / 4,
+    liquidityUnit: "usd",
+  };
+}
+
+const markets = [
+  market("poly-fed", "polymarket", "Will the Fed cut rates?", 2_000_000, "2026-10-01T00:00:00.000Z"),
+  market("kalshi-election", "kalshi", "Will the incumbent win?", 500_000, "2026-11-01T00:00:00.000Z"),
+];
+
+function args(
+  argument: string | null,
+  options: Record<string, string | number | boolean>,
+): HeadlessPaneLoadArgs {
+  return {
+    rawArgument: argument ?? "",
+    argument,
+    symbols: [],
+    options,
+  };
+}
+
+const context = {} as HeadlessPaneContext;
+
+function dependencies(seen: string[]): PredictionMarketsHeadlessDependencies {
+  return {
+    loadPolymarket: async (query) => {
+      seen.push(`polymarket:${query}`);
+      return markets.filter((entry) => entry.venue === "polymarket");
+    },
+    loadKalshi: async (query) => {
+      seen.push(`kalshi:${query}`);
+      return markets.filter((entry) => entry.venue === "kalshi");
+    },
+    now: () => new Date("2026-09-04T21:00:00.000Z"),
+  };
+}
+
+describe("prediction markets headless", () => {
+  test("projects venue data through the pane's shared row ordering", async () => {
+    const definition = createPredictionMarketsHeadless(dependencies([]));
+
+    const result = await definition.load(args(null, {
+      venue: "all",
+      category: "all",
+      tab: "top",
+      limit: 1,
+    }), context);
+
+    expect(result.rows).toEqual([
+      expect.objectContaining({
+        key: "poly-fed",
+        venue: "polymarket",
+        yesProbability: 0.62,
+        volume24h: 2_000_000,
+      }),
+    ]);
+    expect(result.metadata).toMatchObject({ total: 2, returned: 1, truncated: true });
+  });
+
+  test("uses the shortcut venue prefix without querying the other venue", async () => {
+    const seen: string[] = [];
+    const definition = createPredictionMarketsHeadless(dependencies(seen));
+
+    const result = await definition.load(args("polymarket:fed", {
+      venue: "all",
+      category: "macro",
+      tab: "ending",
+      limit: 20,
+    }), context);
+
+    expect(seen).toEqual(["polymarket:fed"]);
+    expect(result.rows.map((row) => row.key)).toEqual(["poly-fed"]);
+    expect(result.metadata).toMatchObject({ venue: "polymarket", query: "fed" });
+  });
+});

--- a/src/plugins/prediction-markets/headless.ts
+++ b/src/plugins/prediction-markets/headless.ts
@@ -1,0 +1,255 @@
+import type {
+  HeadlessPaneDefinition,
+  HeadlessPaneLoadArgs,
+  HeadlessRowsResult,
+} from "../../types/plugin";
+import { PREDICTION_CATEGORY_OPTIONS } from "./categories";
+import {
+  filterPredictionMarkets,
+  getDefaultPredictionSort,
+  sortPredictionMarkets,
+} from "./metrics";
+import { parsePredictionSearchShortcut } from "./navigation";
+import { buildPredictionListRows } from "./rows";
+import { loadKalshiCatalog } from "./services/kalshi/adapter";
+import { loadPolymarketCatalog } from "./services/polymarket/adapter";
+import type {
+  PredictionBrowseTab,
+  PredictionCategoryId,
+  PredictionListRow,
+  PredictionMarketSummary,
+  PredictionVenueScope,
+} from "./types";
+
+const PREDICTION_COLUMNS = [
+  { key: "venue", header: "Venue" },
+  { key: "title", header: "Market" },
+  { key: "target", header: "Target" },
+  { key: "yesProbability", header: "Yes", align: "right" as const },
+  { key: "spread", header: "Spread", align: "right" as const },
+  { key: "volume24h", header: "24h volume", align: "right" as const },
+  { key: "openInterest", header: "Open interest", align: "right" as const },
+  { key: "endsAt", header: "Ends" },
+  { key: "status", header: "Status" },
+  { key: "category", header: "Category" },
+];
+
+export interface PredictionMarketsHeadlessDependencies {
+  loadPolymarket(
+    query: string,
+    category: PredictionCategoryId,
+    limit: number,
+  ): Promise<PredictionMarketSummary[]>;
+  loadKalshi(
+    query: string,
+    category: PredictionCategoryId,
+    limit: number,
+  ): Promise<PredictionMarketSummary[]>;
+  now(): Date;
+}
+
+const defaultDependencies: PredictionMarketsHeadlessDependencies = {
+  loadPolymarket: (query, category, limit) => loadPolymarketCatalog(
+    query,
+    category,
+    { limit },
+  ),
+  loadKalshi: (query, category, limit) => loadKalshiCatalog(
+    query,
+    category,
+    { limit },
+  ),
+  now: () => new Date(),
+};
+
+interface PredictionSelection {
+  query: string;
+  venue: PredictionVenueScope;
+  category: PredictionCategoryId;
+  tab: PredictionBrowseTab;
+  limit: number;
+}
+
+function selectionFor(args: HeadlessPaneLoadArgs): PredictionSelection {
+  const parsed = parsePredictionSearchShortcut(
+    typeof args.argument === "string" ? args.argument : "",
+  );
+  const optionVenue = String(args.options.venue ?? "all") as PredictionVenueScope;
+  return {
+    query: parsed.searchQuery,
+    venue: optionVenue === "all" ? parsed.venueScope : optionVenue,
+    category: String(args.options.category ?? "all") as PredictionCategoryId,
+    tab: String(args.options.tab ?? "top") as PredictionBrowseTab,
+    limit: Number(args.options.limit ?? 50),
+  };
+}
+
+function rowForHeadless(row: PredictionListRow) {
+  const focusMarket = row.markets.find((market) => market.key === row.focusMarketKey)
+    ?? row.representative;
+  return {
+    key: row.key,
+    kind: row.kind,
+    venue: row.venue,
+    title: row.title,
+    target: row.focusMarketLabel,
+    yesProbability: row.focusYesPrice,
+    noProbability: focusMarket.noPrice,
+    targetMarketId: focusMarket.marketId,
+    marketId: row.marketId,
+    event: row.eventLabel,
+    category: row.category ?? null,
+    tags: row.tags ?? [],
+    status: row.status,
+    url: row.url,
+    description: row.description,
+    endsAt: row.endsAt,
+    updatedAt: row.updatedAt,
+    spread: row.spread,
+    lastTradePrice: row.lastTradePrice,
+    volume24h: row.volume24h,
+    volume24hUnit: row.volume24hUnit,
+    totalVolume: row.totalVolume,
+    totalVolumeUnit: row.totalVolumeUnit,
+    openInterest: row.openInterest,
+    openInterestUnit: row.openInterestUnit,
+    liquidity: row.liquidity,
+    liquidityUnit: row.liquidityUnit,
+    marketCount: row.kind === "group" ? row.marketCount : 1,
+    yesProbabilityLow: row.kind === "group" ? row.yesPriceLow : row.yesPrice,
+    yesProbabilityHigh: row.kind === "group" ? row.yesPriceHigh : row.yesPrice,
+  };
+}
+
+export function projectPredictionMarketsHeadless(
+  markets: PredictionMarketSummary[],
+  errors: string[],
+  args: HeadlessPaneLoadArgs,
+  now: Date,
+): HeadlessRowsResult {
+  const selection = selectionFor(args);
+  const rows = sortPredictionMarkets(
+    filterPredictionMarkets(
+      buildPredictionListRows(markets),
+      selection.tab,
+      selection.venue,
+      selection.category,
+      selection.query,
+      new Set(),
+    ),
+    getDefaultPredictionSort(selection.tab),
+  );
+  const selectedRows = rows.slice(0, selection.limit).map(rowForHeadless);
+
+  return {
+    columns: PREDICTION_COLUMNS,
+    rows: selectedRows,
+    errors: errors.length > 0 ? errors : undefined,
+    metadata: {
+      fetchedAt: now.toISOString(),
+      query: selection.query || null,
+      venue: selection.venue,
+      category: selection.category,
+      tab: selection.tab,
+      sourceMarkets: markets.length,
+      total: rows.length,
+      returned: selectedRows.length,
+      truncated: selectedRows.length < rows.length,
+    },
+  };
+}
+
+export function createPredictionMarketsHeadless(
+  dependencies: PredictionMarketsHeadlessDependencies = defaultDependencies,
+): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument: {
+      kind: "free-text",
+      placeholder: "query",
+      description: "Optional market query, including polymarket: or kalshi: shorthand.",
+      optional: true,
+    },
+    options: [
+      {
+        key: "venue",
+        description: "Prediction venue to include.",
+        type: "enum",
+        values: [
+          { value: "all" },
+          { value: "polymarket" },
+          { value: "kalshi" },
+        ],
+        defaultValue: "all",
+      },
+      {
+        key: "category",
+        description: "Market category to include.",
+        type: "enum",
+        values: PREDICTION_CATEGORY_OPTIONS.map((option) => ({ value: option.id })),
+        defaultValue: "all",
+      },
+      {
+        key: "tab",
+        description: "Browse ordering to apply.",
+        type: "enum",
+        values: [
+          { value: "top" },
+          { value: "ending" },
+          { value: "new" },
+        ],
+        defaultValue: "top",
+      },
+      {
+        key: "limit",
+        description: "Maximum market rows to return.",
+        type: "integer",
+        defaultValue: 50,
+        minimum: 1,
+        maximum: 200,
+      },
+    ],
+    columns: PREDICTION_COLUMNS,
+    describe: (args) => {
+      const selection = selectionFor(args);
+      return selection.query
+        ? `Prediction Markets | ${selection.query}`
+        : "Prediction Markets";
+    },
+    async load(args) {
+      const selection = selectionFor(args);
+      const requested: Array<{
+        venue: "polymarket" | "kalshi";
+        load: Promise<PredictionMarketSummary[]>;
+      }> = [];
+      if (selection.venue !== "kalshi") {
+        requested.push({
+          venue: "polymarket",
+          load: dependencies.loadPolymarket(selection.query, selection.category, 200),
+        });
+      }
+      if (selection.venue !== "polymarket") {
+        requested.push({
+          venue: "kalshi",
+          load: dependencies.loadKalshi(selection.query, selection.category, 200),
+        });
+      }
+      const settled = await Promise.allSettled(requested.map((request) => request.load));
+      const markets: PredictionMarketSummary[] = [];
+      const errors: string[] = [];
+      for (const [index, result] of settled.entries()) {
+        if (result.status === "fulfilled") {
+          markets.push(...result.value);
+        } else {
+          const message = result.reason instanceof Error
+            ? result.reason.message
+            : String(result.reason);
+          errors.push(`${requested[index]?.venue ?? "venue"}: ${message}`);
+        }
+      }
+      return projectPredictionMarketsHeadless(markets, errors, args, dependencies.now());
+    },
+  };
+}
+
+export const predictionMarketsHeadless = createPredictionMarketsHeadless();

--- a/src/plugins/prediction-markets/index.tsx
+++ b/src/plugins/prediction-markets/index.tsx
@@ -5,6 +5,7 @@ import { PredictionMarketsPane } from "./pane";
 import { attachPredictionMarketsPersistence, resetPredictionMarketsPersistence } from "./services/fetch";
 import { predictionMarketsCliCommand } from "./cli";
 import { predictionChartSeriesCapability } from "./capability";
+import { predictionMarketsHeadless } from "./headless";
 import {
   buildPredictionMarketsPaneSettingsDef,
   createPredictionMarketsPaneSettings,
@@ -59,6 +60,7 @@ export const predictionMarketsPlugin: GloomPlugin = {
       description: "Open a new prediction markets browser pane",
       keywords: ["prediction", "markets", "polymarket", "kalshi", "events"],
       shortcut: { prefix: "PM", argPlaceholder: "query", argKind: "text" },
+      headless: predictionMarketsHeadless,
       createInstance: (_context, options) => {
         const parsed = parsePredictionSearchShortcut(options?.arg ?? "");
         return {

--- a/src/sources/gloomberb-cloud/news.ts
+++ b/src/sources/gloomberb-cloud/news.ts
@@ -85,6 +85,7 @@ export function mapCloudNewsArticle(
     importance: scores.importance,
     isBreaking: !!item.flags?.breaking,
     isDeveloping: !!item.flags?.developing,
+    sourceCount: item.sourceCount,
     items: item.items?.map(mapCloudNewsStoryItem) ?? [],
   };
 }


### PR DESCRIPTION
## Summary

- add shared headless models for `CALLS`, `ECT`, `EE`, `ERN`, `IPO`, `DVD`, `PM`, `N`, and `CN`
- keep raw values structured while reusing pane projections for earnings events, dividend rows, IPO filters, transcript filters, news normalization, and prediction market grouping and ordering
- add bounded transcript sections with quarter selection, speaker and text filters, offsets, limits, truncation state, and next offsets
- restore the persisted Gloomberb Cloud session while a CLI report loads, using the same credential source as pane screenshots
- add focused fixture coverage for each migrated report and the Cloud session boundary

## Catalog verification

All requested tokens report `reportReadiness: ready`:

```text
CALLS rows      availability,limit
ECT   rows      section,quarter,speaker,search,offset,limit
EE    rows      kind,limit
ERN   rows      timing,limit
IPO   rows      status,limit
DVD   bundle    type,limit
PM    rows      venue,category,tab,limit
N     snapshot  sentiment,minImportance,limit
CN    snapshot  sentiment,minImportance,limit
```

## Live CLI samples

The commands below used real providers and `--arguments limit=1` so the pane-level limit is not consumed as the global CLI limit.

```text
EE AMD       { kind: "rows", rowCount: 1, status: "FY Est", annualEps: 15.45073 }
ERN AAPL,... { kind: "rows", rowCount: 1, symbol: "MSFT", timing: "AMC", epsEstimate: 4.72455 }
IPO          { kind: "rows", rowCount: 1, ticker: "PTT", status: "upcoming", priceLow: 7 }
DVD AAPL     { kind: "bundle", trailingYield: 0.0031991713, exDate: "2026-08-10", amount: 0.27 }
PM fed       { kind: "rows", rowCount: 1, venue: "polymarket", title: "Fed Decision in September?" }
N            { kind: "snapshot", rowCount: 1, sentiment: "negative", sourceCount: 8 }
CN AMD:XNAS  { kind: "snapshot", rowCount: 1, tickers: ["AMD", "NVDA", "SPCX"] }
CALLS AAPL   { ok: false, error: { message: "Unauthorized" } }
ECT AAPL     { ok: false, error: { message: "Unauthorized" } }
```

`CALLS` and `ECT` reached the live Cloud endpoint, but the local persisted Pro session had expired. The CLI now restores that session instead of always making anonymous requests. Their authenticated row mapping, transcript selection, filtering, chunk bounds, and paging are covered with injected Cloud fixtures.

## Verification

- `bun test`: 2544 passed, 0 failed
- `bun run typecheck`
- `bun run plugins:manifest:check`
- live text and JSON checks for every token
- final catalog check for readiness and options
- tmux smoke checks for `EE AMD` and `DVD AAPL`, including runtime warning scan and session cleanup
