### PR TITLE
Fix duplicate command bar assist requests

### DIFF
--- a/src/components/command-bar/assist/runtime.ts
+++ b/src/components/command-bar/assist/runtime.ts
@@ -42,17 +42,21 @@ export function useCommandBarAssist({
   askAssist: () => void;
   resetAssist: () => boolean;
 } {
-  const [assistState, setAssistState] = useState<AssistRequestState>({ status: "idle" });
+  const [assistState, setRenderedAssistState] = useState<AssistRequestState>({ status: "idle" });
   const assistStateRef = useRef(assistState);
-  assistStateRef.current = assistState;
+  /**
+   * Event handlers can run again before React commits the state they just
+   * queued. Keep their read model current synchronously so repeated Enter
+   * claims one request instead of aborting it and starting another.
+   */
+  const updateAssistState = useCallback((next: AssistRequestState) => {
+    assistStateRef.current = next;
+    setRenderedAssistState(next);
+  }, []);
   const abortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const answersRef = useRef(new Map<string, AssistCommandCandidate[]>());
-  /**
-   * The query the runtime has already acted on, updated the moment a request
-   * starts. Rendered state lags a tick behind, and reading it instead would let
-   * a re-render slip a second debounce past an ask that is already in flight.
-   */
+  /** Query the runtime has already acted on, updated when a request starts. */
   const handledQueryRef = useRef<string | null>(null);
   /** Query the user dismissed with Esc; the section stays gone until it changes. */
   const dismissedQueryRef = useRef<string | null>(null);
@@ -65,12 +69,13 @@ export function useCommandBarAssist({
   getInventoryRef.current = getInventory;
 
   const cancelPending = useCallback(() => {
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-      debounceRef.current = null;
-    }
-    abortRef.current?.abort();
+    const debounce = debounceRef.current;
+    debounceRef.current = null;
+    if (debounce !== null) clearTimeout(debounce);
+
+    const controller = abortRef.current;
     abortRef.current = null;
+    controller?.abort();
   }, []);
 
   const resetAssist = useCallback((): boolean => {
@@ -79,9 +84,9 @@ export function useCommandBarAssist({
     if (active.status === "idle" || active.source === "auto") return false;
     cancelPending();
     dismissedQueryRef.current = active.query;
-    setAssistState({ status: "idle" });
+    updateAssistState({ status: "idle" });
     return true;
-  }, [cancelPending]);
+  }, [cancelPending, updateAssistState]);
 
   const runAssist = useCallback((query: string, source: AssistRequestSource) => {
     const trimmed = query.trim();
@@ -96,35 +101,35 @@ export function useCommandBarAssist({
 
     const cached = answersRef.current.get(trimmed);
     if (cached) {
-      setAssistState({ status: "answered", query: trimmed, source: resolveSource(), candidates: cached });
+      updateAssistState({ status: "answered", query: trimmed, source: resolveSource(), candidates: cached });
       return;
     }
 
     const controller = new AbortController();
     abortRef.current = controller;
-    setAssistState({ status: "loading", query: trimmed, source: resolveSource() });
+    updateAssistState({ status: "loading", query: trimmed, source: resolveSource() });
 
     void (async () => {
       try {
         const response = await apiClient.assistCommand(trimmed, getInventoryRef.current(), {
           signal: controller.signal,
         });
-        if (controller.signal.aborted) return;
+        if (controller.signal.aborted || abortRef.current !== controller) return;
         const candidates = response?.candidates ?? [];
         answersRef.current.set(trimmed, candidates);
-        setAssistState({ status: "answered", query: trimmed, source: resolveSource(), candidates });
+        updateAssistState({ status: "answered", query: trimmed, source: resolveSource(), candidates });
       } catch (error) {
-        if (controller.signal.aborted) return;
+        if (controller.signal.aborted || abortRef.current !== controller) return;
         const kind = classifyAssistError(error);
         if (kind === "rate-limited") {
           rateLimitedUntilRef.current = Date.now() + ASSIST_RATE_LIMIT_BACKOFF_MS;
         }
-        setAssistState({ status: "error", query: trimmed, source: resolveSource(), kind });
+        updateAssistState({ status: "error", query: trimmed, source: resolveSource(), kind });
       } finally {
         if (abortRef.current === controller) abortRef.current = null;
       }
     })();
-  }, [cancelPending]);
+  }, [cancelPending, updateAssistState]);
 
   const askAssist = useCallback(() => {
     const trimmed = rootQueryRef.current.trim();
@@ -134,17 +139,17 @@ export function useCommandBarAssist({
     // The background ask already on the wire asks this exact question; asking
     // again would only abort it and start the wait over.
     if (active.status === "loading" && active.query === trimmed) {
-      setAssistState({ ...active, source: "explicit" });
+      updateAssistState({ ...active, source: "explicit" });
       return;
     }
     runAssist(trimmed, "explicit");
-  }, [runAssist]);
+  }, [runAssist, updateAssistState]);
 
   useEffect(() => {
     const trimmed = rootQuery.trim();
     const active = assistStateRef.current;
     if (active.status !== "idle" && active.query !== trimmed) {
-      setAssistState({ status: "idle" });
+      updateAssistState({ status: "idle" });
     }
     if (handledQueryRef.current !== null && handledQueryRef.current !== trimmed) {
       // Whatever is in flight describes text the user has already moved past.
@@ -158,21 +163,24 @@ export function useCommandBarAssist({
     const cached = answersRef.current.get(trimmed);
     if (cached) {
       handledQueryRef.current = trimmed;
-      setAssistState({ status: "answered", query: trimmed, source: "auto", candidates: cached });
+      updateAssistState({ status: "answered", query: trimmed, source: "auto", candidates: cached });
       return;
     }
     if (Date.now() < rateLimitedUntilRef.current) return;
 
-    debounceRef.current = setTimeout(() => {
+    const debounce = setTimeout(() => {
+      // A cleared timer can already be queued. Only the timer still owned by
+      // this effect may start a request.
+      if (debounceRef.current !== debounce) return;
       debounceRef.current = null;
       runAssist(trimmed, "auto");
     }, ASSIST_DEBOUNCE_MS);
+    debounceRef.current = debounce;
     return () => {
-      if (!debounceRef.current) return;
-      clearTimeout(debounceRef.current);
-      debounceRef.current = null;
+      clearTimeout(debounce);
+      if (debounceRef.current === debounce) debounceRef.current = null;
     };
-  }, [autoAsk, cancelPending, rootQuery, runAssist]);
+  }, [autoAsk, cancelPending, rootQuery, runAssist, updateAssistState]);
 
   useEffect(() => cancelPending, [cancelPending]);
 

--- a/src/components/command-bar/surface/assist.test.tsx
+++ b/src/components/command-bar/surface/assist.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
 import { apiClient, setCloudApiFetchTransport } from "../../../api-client";
 import { testRender } from "../../../renderers/opentui/test-utils";
 import type { PluginRegistry } from "../../../plugins/registry";
@@ -253,6 +254,48 @@ describe("CommandBar AI assist", () => {
     }
     expect(created).toEqual([{ templateId: "new-chat-pane", options: { arg: "#general" } }]);
     expect(requests).toHaveLength(1);
+  });
+
+  test("does not restart an ask when Enter repeats before loading renders", async () => {
+    signInVerified();
+    let releaseResponse = () => {};
+    const held = new Promise<void>((resolve) => { releaseResponse = resolve; });
+    const requests = mockAssistTransport(async () => {
+      await held;
+      return jsonResponse({
+        candidates: [{ input: "CHAT #general", title: "Open the general channel", prefix: "CHAT", confidence: 0.9 }],
+      });
+    });
+
+    testSetup = await testRender(
+      <CommandBarHarness query="new chat pane" />,
+      { width: 120, height: 20 },
+    );
+
+    await testSetup.renderOnce();
+    expect(testSetup.captureCharFrame()).toContain("Thinking…");
+
+    await act(async () => {
+      for (let press = 0; press < 2; press += 1) {
+        testSetup!.renderer.keyInput.emit("keypress", {
+          ctrl: false,
+          meta: false,
+          option: false,
+          shift: false,
+          eventType: "press",
+          name: "return",
+          sequence: "\r",
+          repeated: press > 0,
+          stopPropagation: () => {},
+          preventDefault: () => {},
+        } as any);
+      }
+      await testSetup!.renderOnce();
+    });
+
+    expect(requests).toHaveLength(1);
+    releaseResponse();
+    await waitForFrameToContain("#general · Open the general channel", ASSIST_WAIT_ATTEMPTS);
   });
 
   test("drops the section when a background ask fails", async () => {


### PR DESCRIPTION
## Why

Command Bar AI assist event handlers could run again before React committed the loading state. A repeated Enter in that window still observed `idle`, aborted the request already in flight, and started a duplicate. Under CI load, the wider scheduling window made this nondeterministic race easier to hit.

## What

- synchronize the assist state ref before scheduling each React state update
- let repeated Enter claim the matching in-flight request instead of restarting it
- make debounce cleanup ownership-safe when an expired timer is already queued
- ignore stale request completions by checking abort-controller ownership
- add a regression that emits two Enter events before the loading render commits

## Verify

- regression against parent commit, 50 consecutive runs: 0 passed, 50 failed
- regression with fix, 50 consecutive runs: 50 passed, 0 failed
- concurrent regression load, 50 runs: 50 passed, 0 failed
- `bun test src/components/command-bar`: 173 passed
- `bun run typecheck`: passed
- `bun test`: 2547 passed
- isolated tmux smoke check: command bar rendered with no runtime warnings
