### PR TITLE
Let the ASKG protocol describe server executed tools

### DIFF
--- a/src/plugins/builtin/cloud/askg/protocol.test.ts
+++ b/src/plugins/builtin/cloud/askg/protocol.test.ts
@@ -7,6 +7,7 @@ import {
   type ASKGSessionStartRequest,
   type ASKGSessionStartResponse,
   type ASKGSseEvent,
+  type ClientToolManifest,
   type ToolManifest,
   type ToolResultPayload,
 } from "./protocol";
@@ -17,7 +18,7 @@ function jsonRoundTrip<T>(value: T): T {
 
 function projectHeadlessDefinition(
   definition: HeadlessPaneDefinition,
-): ToolManifest {
+): ClientToolManifest {
   const options = definition.options.map(({ settingKey: _settingKey, pluginState: _pluginState, ...option }) => option);
   const columns = definition.columns?.map(({ format: _format, ...column }) => column);
   return {
@@ -37,7 +38,7 @@ function projectHeadlessDefinition(
 
 describe("ASKG protocol", () => {
   test("round-trips session negotiation, a manifest, every event, and a tool result", () => {
-    const manifest: ToolManifest = {
+    const manifest: ClientToolManifest = {
       name: "layout.place_pane",
       source: "remote-op",
       title: "Place pane",

--- a/src/plugins/builtin/cloud/askg/protocol.ts
+++ b/src/plugins/builtin/cloud/askg/protocol.ts
@@ -37,7 +37,16 @@ export type WriteTier = RemoteWriteTier;
 export type ASKGClientKind = "tui" | "desktop" | "web";
 
 /** Origin of an advertised client tool. */
-export type ToolManifestSource = "headless" | "remote-op";
+/**
+ * Origin of a tool. This client only ever advertises "headless" and
+ * "remote-op"; "server" describes the tools the platform runs itself and
+ * reports back in `serverTools`, so a session response can describe its whole
+ * tool surface.
+ */
+export type ToolManifestSource = "headless" | "remote-op" | "server";
+
+/** The subset this client is allowed to advertise at session start. */
+export type ClientToolManifestSource = Exclude<ToolManifestSource, "server">;
 
 /** Headless result shapes supported by the tool timeline. */
 export type ToolManifestShape = HeadlessPaneShape;
@@ -67,6 +76,8 @@ export type ToolInputSchemaType = RemoteJsonSchemaType;
 export type ToolInputSchema = RemoteJsonSchema;
 
 /** Client or server tool metadata negotiated when a session starts. */
+export type ClientToolManifest = ToolManifest & { source: ClientToolManifestSource };
+
 export interface ToolManifest {
   /** Lowercase stable identifier matching TOOL_NAME_PATTERN. */
   name: string;
@@ -102,7 +113,8 @@ export interface ASKGSessionStartRequest {
   protocolVersion: typeof ASKG_PROTOCOL_VERSION;
   client: ASKGClientDescriptor;
   context: ASKGSessionContext;
-  tools: ToolManifest[];
+  /** A client may only advertise tools it executes itself. */
+  tools: ClientToolManifest[];
   manifestHash: string;
 }
 
@@ -196,7 +208,7 @@ export interface ASKGToolExecutedEvent extends ASKGEventBase {
   turnId: string;
   toolCallId: string;
   name: string;
-  source: ToolManifestSource | "server";
+  source: ToolManifestSource;
   status: ToolResultStatus;
   summary: ToolExecutionSummary;
 }


### PR DESCRIPTION
## Why

The session start response reports the tools the platform executes itself in `serverTools: ToolManifest[]`, but `ToolManifestSource` was `"headless" | "remote-op"`, so a server tool could not describe its own origin. The tool executed event had already worked around this with an inline `| "server"`. The server tools task hit the same gap and flagged it.

## What

- `ToolManifestSource` gains `"server"`, and the inline widening on the tool executed event goes away.
- `ClientToolManifestSource` and `ClientToolManifest` exclude it, and the session start request accepts client manifests only, so a client cannot advertise itself as the server.
- The platform mirror gets the identical change in `server/src/services/askg/types.ts`.

## Verify

`bun test src/plugins/builtin/cloud` passes (18 tests) and the typecheck is clean. On the platform, `bun test server/src/services/askg` passes (21 tests).