### PR TITLE
Add ASKG client tool layer

### DIFF
--- a/src/plugins/builtin/cloud/askg/executor.test.ts
+++ b/src/plugins/builtin/cloud/askg/executor.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import type { MarketContext } from "../../../../cli/types";
+import type { PaneFunctionCatalog } from "../../../../cli/pane-functions/catalog";
+import type { RemoteControlResponse } from "../../../../remote/types";
+import {
+  MAX_TOOL_RESULT_BYTES,
+  type ASKGToolCallEvent,
+  type ClientToolManifest,
+} from "./protocol";
+import { createASKGToolExecutor } from "./executor";
+
+const emptyRegistry: PaneFunctionCatalog = {
+  panes: new Map(),
+  paneTemplates: new Map(),
+  destroy() {},
+};
+const emptyContext = {} as MarketContext;
+
+const headlessManifest: ClientToolManifest = {
+  name: "val",
+  source: "headless",
+  title: "Valuation",
+  description: "Read valuation data.",
+  writeTier: "read",
+  shape: "rows",
+  argument: { kind: "none" },
+  options: [],
+  confirm: "never",
+  timeoutMs: 30_000,
+};
+
+const resourceManifest: ClientToolManifest = {
+  name: "app.get_resource",
+  source: "remote-op",
+  title: "App: Get resource",
+  description: "Read an app resource.",
+  writeTier: "read",
+  inputSchema: { type: "object" },
+  confirm: "never",
+  timeoutMs: 10_000,
+};
+
+function call(
+  manifest: ClientToolManifest,
+  overrides: Partial<ASKGToolCallEvent> = {},
+): ASKGToolCallEvent {
+  return {
+    seq: 1,
+    type: "tool-call",
+    turnId: "turn-1",
+    toolCallId: "tool-1",
+    name: manifest.name,
+    args: {},
+    writeTier: manifest.writeTier,
+    requiresConfirmation: false,
+    preview: null,
+    timeoutMs: 1_000,
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    ...overrides,
+  };
+}
+
+function executor(options: {
+  manifests?: ClientToolManifest[];
+  remoteHandler?: (request: unknown) => Promise<RemoteControlResponse>;
+  headlessExecutor?: Parameters<typeof createASKGToolExecutor>[0]["headlessExecutor"];
+}) {
+  return createASKGToolExecutor({
+    manifests: options.manifests ?? [headlessManifest],
+    registry: emptyRegistry,
+    context: emptyContext,
+    remoteHandler: options.remoteHandler ?? (async () => ({ ok: true, data: {} })),
+    ...(options.headlessExecutor ? { headlessExecutor: options.headlessExecutor } : {}),
+  });
+}
+
+describe("ASKG delegated tool executor", () => {
+  test("denies a server tier that does not match the advertised tier", async () => {
+    let executions = 0;
+    const tools = executor({
+      headlessExecutor: async () => {
+        executions += 1;
+        return { result: { rows: [] }, rowCount: 0 };
+      },
+    });
+
+    const result = await tools.execute(call(headlessManifest, { writeTier: "ui-write" }));
+
+    expect(result.status).toBe("denied");
+    expect(result.note).toContain("tier mismatch");
+    expect(executions).toBe(0);
+  });
+
+  test("returns timeout without waiting for a stalled loader", async () => {
+    const tools = executor({
+      headlessExecutor: async () => new Promise(() => {}),
+    });
+
+    const result = await tools.execute(call(headlessManifest, { timeoutMs: 5 }));
+
+    expect(result.status).toBe("timeout");
+    expect(result.elapsedMs).toBeLessThan(500);
+  });
+
+  test("cancels an in-flight delegated load", async () => {
+    const started = Promise.withResolvers<void>();
+    const tools = executor({
+      headlessExecutor: async () => {
+        started.resolve();
+        return new Promise(() => {});
+      },
+    });
+    const controller = new AbortController();
+    const pending = tools.execute(call(headlessManifest), { signal: controller.signal });
+    await started.promise;
+    controller.abort();
+
+    const result = await pending;
+
+    expect(result.status).toBe("cancelled");
+  });
+
+  test("truncates the complete wire payload under the byte cap", async () => {
+    const tools = executor({
+      manifests: [resourceManifest],
+      remoteHandler: async () => ({ ok: true, data: { rows: [{ text: "x".repeat(MAX_TOOL_RESULT_BYTES * 2) }] } }),
+    });
+
+    const result = await tools.execute(call(resourceManifest, {
+      args: { resource: "app://snapshot" },
+    }));
+
+    expect(result.status).toBe("partial");
+    expect(result.truncated).toBe(true);
+    expect(result.rowCount).toBe(1);
+    expect(new TextEncoder().encode(JSON.stringify(result)).byteLength).toBeLessThanOrEqual(MAX_TOOL_RESULT_BYTES);
+    expect(result.result).toMatchObject({ originalBytes: expect.any(Number) });
+  });
+
+  test("returns remote failures as error values", async () => {
+    const tools = executor({
+      manifests: [resourceManifest],
+      remoteHandler: async () => ({
+        ok: false,
+        error: { code: "upstream_unavailable", message: "Upstream source is unavailable." },
+      }),
+    });
+
+    const result = await tools.execute(call(resourceManifest, {
+      args: { resource: "app://snapshot" },
+    }));
+
+    expect(result).toMatchObject({
+      status: "error",
+      result: { code: "upstream_unavailable" },
+      note: "Upstream source is unavailable.",
+      truncated: false,
+    });
+  });
+});

--- a/src/plugins/builtin/cloud/askg/executor.ts
+++ b/src/plugins/builtin/cloud/askg/executor.ts
@@ -1,0 +1,429 @@
+import type { MarketContext } from "../../../../cli/types";
+import type { PaneFunctionCatalog } from "../../../../cli/pane-functions/catalog";
+import { withPersistedCloudSession } from "../../../../cli/pane-functions/cloud-session";
+import {
+  loadResolvedHeadlessPaneModel,
+  serializeHeadlessPaneResult,
+} from "../../../../cli/pane-functions/headless";
+import { resolvePaneFunction } from "../../../../cli/pane-functions/resolver";
+import { stableStringify } from "../../../../remote/revision";
+import type {
+  HeadlessBundleResult,
+  HeadlessPaneDefinition,
+  HeadlessPaneResult,
+  HeadlessSeriesResult,
+  HeadlessSnapshotResult,
+} from "../../../../types/headless";
+import {
+  MAX_TOOL_RESULT_BYTES,
+  type ASKGToolCallEvent,
+  type ClientToolManifest,
+  type JsonValue,
+  type ToolResultPayload,
+  type ToolResultStatus,
+} from "./protocol";
+import {
+  remoteRequestForTool,
+  resolveRemoteToolBinding,
+} from "./manifest";
+import {
+  ASKGUndoManager,
+  type AppliedUndo,
+  type InProcessRemoteControlHandler,
+} from "./undo";
+
+interface HeadlessExecution {
+  result: unknown;
+  rowCount: number;
+  errors?: string[];
+}
+
+export interface HeadlessToolCall {
+  name: string;
+  args: Record<string, JsonValue>;
+  manifest: ClientToolManifest;
+  signal: AbortSignal;
+}
+
+export type HeadlessToolExecutor = (call: HeadlessToolCall) => Promise<HeadlessExecution>;
+
+export interface ASKGToolExecutorDependencies {
+  manifests: readonly ClientToolManifest[];
+  registry: PaneFunctionCatalog;
+  context: MarketContext;
+  remoteHandler: InProcessRemoteControlHandler;
+  headlessExecutor?: HeadlessToolExecutor;
+  undoManager?: ASKGUndoManager;
+  now?: () => number;
+}
+
+export interface ASKGToolExecutionOptions {
+  signal?: AbortSignal;
+  confirmed?: boolean;
+}
+
+export interface ASKGToolExecutor {
+  execute(
+    call: ASKGToolCallEvent,
+    options?: ASKGToolExecutionOptions,
+  ): Promise<ToolResultPayload>;
+  undo(token: string, signal?: AbortSignal): Promise<AppliedUndo>;
+}
+
+interface ExecutionValue {
+  status: ToolResultStatus;
+  result?: unknown;
+  rowCount?: number;
+  truncated?: boolean;
+  note?: string;
+  rev?: string;
+  undoToken?: string;
+}
+
+const ARGUMENT_KEYS = new Set(["symbol", "symbols", "text"]);
+
+class ToolTimeoutError extends Error {}
+class ToolCancelledError extends Error {}
+
+function shortReason(error: unknown): string {
+  const text = error instanceof Error ? error.message : String(error);
+  return text.replace(/\s+/g, " ").trim().slice(0, 320) || "Unknown error.";
+}
+
+function appendNote(current: string | undefined, next: string): string {
+  return current ? `${current} ${next}` : next;
+}
+
+function normalizeJson(value: unknown, seen = new WeakSet<object>()): JsonValue {
+  if (value == null) return null;
+  if (typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "bigint") return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Error) return { name: value.name, message: value.message };
+  if (typeof value !== "object") return String(value);
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const result = value.map((entry) => normalizeJson(entry, seen));
+    seen.delete(value);
+    return result;
+  }
+  const result: Record<string, JsonValue> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    result[key] = normalizeJson((value as Record<string, unknown>)[key], seen);
+  }
+  seen.delete(value);
+  return result;
+}
+
+function encodedSize(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}
+
+function withBoundedPayload(payload: ToolResultPayload): ToolResultPayload {
+  if (encodedSize(payload) <= MAX_TOOL_RESULT_BYTES) return payload;
+
+  const resultText = stableStringify(payload.result ?? null);
+  const originalBytes = encodedSize(payload.result ?? null);
+  const note = appendNote(
+    payload.note,
+    `Result exceeded ${MAX_TOOL_RESULT_BYTES} bytes. result.jsonPreview contains a canonical JSON prefix.`,
+  );
+  const status = payload.status === "ok" ? "partial" : payload.status;
+  let low = 0;
+  let high = resultText.length;
+  let best: ToolResultPayload = {
+    ...payload,
+    status,
+    result: { jsonPreview: "", originalBytes },
+    truncated: true,
+    note,
+  };
+
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const candidate: ToolResultPayload = {
+      ...best,
+      result: { jsonPreview: resultText.slice(0, middle), originalBytes },
+    };
+    if (encodedSize(candidate) <= MAX_TOOL_RESULT_BYTES) {
+      best = candidate;
+      low = middle + 1;
+    } else {
+      high = middle - 1;
+    }
+  }
+
+  if (encodedSize(best) <= MAX_TOOL_RESULT_BYTES) return best;
+  const withoutResult: ToolResultPayload = {
+    turnId: payload.turnId,
+    toolCallId: payload.toolCallId,
+    status,
+    rowCount: payload.rowCount,
+    truncated: true,
+    elapsedMs: payload.elapsedMs,
+    note: "Result exceeded the client payload limit and was omitted.",
+    ...(payload.rev ? { rev: payload.rev } : {}),
+    ...(payload.undoToken ? { undoToken: payload.undoToken } : {}),
+  };
+  return withoutResult;
+}
+
+function rawArgumentFor(manifest: ClientToolManifest, args: Record<string, JsonValue>): string {
+  switch (manifest.argument?.kind) {
+    case "none":
+    case undefined:
+      return "";
+    case "ticker": {
+      const symbol = args.symbol;
+      if (symbol == null && manifest.argument.optional) return "";
+      if (typeof symbol !== "string") throw new Error(`${manifest.name} requires a symbol string.`);
+      return symbol;
+    }
+    case "tickers":
+    case "symbol-list": {
+      const symbols = args.symbols;
+      if (symbols == null && manifest.argument.optional) return "";
+      if (!Array.isArray(symbols) || !symbols.every((symbol) => typeof symbol === "string")) {
+        throw new Error(`${manifest.name} requires a symbols array.`);
+      }
+      return symbols.join(",");
+    }
+    case "free-text": {
+      const text = args.text;
+      if (text == null && manifest.argument.optional) return "";
+      if (typeof text !== "string") throw new Error(`${manifest.name} requires a text string.`);
+      return text;
+    }
+  }
+}
+
+function optionArgsFor(manifest: ClientToolManifest, args: Record<string, JsonValue>): Record<string, string | true> {
+  const declared = new Set(manifest.options?.map(({ key }) => key) ?? []);
+  const options: Record<string, string | true> = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (ARGUMENT_KEYS.has(key)) continue;
+    if (!declared.has(key)) throw new Error(`Unknown option "${key}" for ${manifest.name}.`);
+    if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {
+      throw new Error(`Option "${key}" for ${manifest.name} must be a scalar value.`);
+    }
+    options[key] = value === true ? true : String(value);
+  }
+  return options;
+}
+
+function headlessRowCount(definition: HeadlessPaneDefinition, result: HeadlessPaneResult): number {
+  switch (definition.shape) {
+    case "rows":
+      return (result as { rows: unknown[] }).rows.length;
+    case "bundle":
+      return (result as HeadlessBundleResult).sections.reduce((count, section) => (
+        count + ("rows" in section && section.rows ? section.rows.length : section.entries.length)
+      ), 0);
+    case "series":
+      return (result as HeadlessSeriesResult).series.reduce(
+        (count, series) => count + series.points.length,
+        0,
+      );
+    case "snapshot":
+      return (result as HeadlessSnapshotResult).items.length;
+  }
+}
+
+function inferRemoteRowCount(value: unknown): number | undefined {
+  if (Array.isArray(value)) return value.length;
+  if (value == null || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  for (const key of ["rows", "items", "panes", "sections", "series", "results"]) {
+    if (Array.isArray(record[key])) return record[key].length;
+  }
+  return 1;
+}
+
+function effectiveTimeoutMs(call: ASKGToolCallEvent, now: number): number {
+  const declared = Math.max(0, call.timeoutMs);
+  const expiresAt = Date.parse(call.expiresAt);
+  if (!Number.isFinite(expiresAt)) return declared;
+  return Math.max(0, Math.min(declared, expiresAt - now));
+}
+
+async function runWithDeadline<T>(
+  run: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  externalSignal?: AbortSignal,
+): Promise<T> {
+  if (externalSignal?.aborted) throw new ToolCancelledError("Tool call was cancelled.");
+  if (timeoutMs <= 0) throw new ToolTimeoutError("Tool call timed out.");
+
+  const controller = new AbortController();
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  let removeAbortListener: (() => void) | undefined;
+  const gate = new Promise<never>((_resolve, reject) => {
+    timeoutHandle = setTimeout(() => {
+      const error = new ToolTimeoutError("Tool call timed out.");
+      controller.abort(error);
+      reject(error);
+    }, timeoutMs);
+    if (externalSignal) {
+      const onAbort = () => {
+        const error = new ToolCancelledError("Tool call was cancelled.");
+        controller.abort(error);
+        reject(error);
+      };
+      externalSignal.addEventListener("abort", onAbort, { once: true });
+      removeAbortListener = () => externalSignal.removeEventListener("abort", onAbort);
+    }
+  });
+
+  try {
+    return await Promise.race([run(controller.signal), gate]);
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+    removeAbortListener?.();
+  }
+}
+
+function defaultHeadlessExecutor(
+  registry: PaneFunctionCatalog,
+  context: MarketContext,
+): HeadlessToolExecutor {
+  return async ({ name, args, manifest, signal }) => {
+    const rawArgument = rawArgumentFor(manifest, args);
+    const resolved = await resolvePaneFunction(registry, context, {
+      target: name,
+      arg: rawArgument,
+      options: optionArgsFor(manifest, args),
+      outputPath: null,
+      width: 1280,
+      height: 720,
+      theme: null,
+      scale: 1,
+      watermark: null,
+      requireBotSafe: false,
+    }, { strictHeadlessOptions: true });
+    const loaded = await withPersistedCloudSession(
+      context,
+      () => loadResolvedHeadlessPaneModel(resolved, context, rawArgument, signal),
+    );
+    return {
+      result: serializeHeadlessPaneResult(loaded.definition, loaded.result),
+      rowCount: headlessRowCount(loaded.definition, loaded.result),
+      ...(loaded.result.errors?.length ? { errors: loaded.result.errors } : {}),
+    };
+  };
+}
+
+export function createASKGToolExecutor(
+  dependencies: ASKGToolExecutorDependencies,
+): ASKGToolExecutor {
+  const manifests = new Map(dependencies.manifests.map((manifest) => [manifest.name, manifest]));
+  const now = dependencies.now ?? Date.now;
+  const executeHeadless = dependencies.headlessExecutor
+    ?? defaultHeadlessExecutor(dependencies.registry, dependencies.context);
+  const undoManager = dependencies.undoManager ?? new ASKGUndoManager(dependencies.remoteHandler);
+
+  const execute = async (
+    call: ASKGToolCallEvent,
+    options: ASKGToolExecutionOptions = {},
+  ): Promise<ToolResultPayload> => {
+    const startedAt = now();
+    const base = (value: ExecutionValue): ToolResultPayload => withBoundedPayload({
+      turnId: call.turnId,
+      toolCallId: call.toolCallId,
+      status: value.status,
+      ...(value.result !== undefined ? { result: normalizeJson(value.result) } : {}),
+      ...(value.rowCount !== undefined ? { rowCount: value.rowCount } : {}),
+      truncated: value.truncated ?? false,
+      elapsedMs: Math.max(0, now() - startedAt),
+      ...(value.note ? { note: value.note } : {}),
+      ...(value.rev ? { rev: value.rev } : {}),
+      ...(value.undoToken ? { undoToken: value.undoToken } : {}),
+    });
+
+    const manifest = manifests.get(call.name);
+    if (!manifest) {
+      return base({ status: "denied", note: `Tool "${call.name}" was not advertised by this client.` });
+    }
+    if (call.writeTier !== manifest.writeTier) {
+      return base({
+        status: "denied",
+        note: `Tool tier mismatch: advertised ${manifest.writeTier}, received ${call.writeTier}.`,
+      });
+    }
+    if ((manifest.confirm === "always" || call.requiresConfirmation) && !options.confirmed) {
+      return base({ status: "denied", note: "This tool call requires local confirmation." });
+    }
+
+    const timeoutMs = Math.min(manifest.timeoutMs, effectiveTimeoutMs(call, now()));
+    try {
+      const value = await runWithDeadline(async (signal): Promise<ExecutionValue> => {
+        if (manifest.source === "headless") {
+          const loaded = await executeHeadless({ name: call.name, args: call.args, manifest, signal });
+          const errors = loaded.errors?.filter(Boolean) ?? [];
+          return {
+            status: errors.length > 0 ? (loaded.rowCount > 0 ? "partial" : "error") : "ok",
+            result: loaded.result,
+            rowCount: loaded.rowCount,
+            ...(errors.length > 0 ? {
+              truncated: loaded.rowCount > 0,
+              note: errors.map(shortReason).join(" "),
+            } : {}),
+          };
+        }
+
+        const binding = resolveRemoteToolBinding(call.name);
+        if (!binding) throw new Error(`Remote tool "${call.name}" has no in-process binding.`);
+        let preparedUndo: Awaited<ReturnType<ASKGUndoManager["prepare"]>> = null;
+        let undoNote: string | undefined;
+        if (manifest.writeTier === "ui-write" && binding.kind === "operation") {
+          try {
+            preparedUndo = await undoManager.prepare(binding.operation, call.args, signal);
+          } catch (error) {
+            undoNote = `Undo is unavailable: ${shortReason(error)}`;
+          }
+        }
+
+        const response = await dependencies.remoteHandler(remoteRequestForTool(binding, call.args));
+        if (!response.ok) {
+          return {
+            status: "error",
+            result: { code: response.error.code, ...(response.error.details !== undefined ? { details: response.error.details } : {}) },
+            note: shortReason(response.error.message),
+          };
+        }
+
+        let undoToken: string | undefined;
+        if (preparedUndo) {
+          try {
+            undoToken = await undoManager.commit(preparedUndo, signal) ?? undefined;
+          } catch (error) {
+            undoNote = `Undo is unavailable: ${shortReason(error)}`;
+          }
+        }
+        return {
+          status: "ok",
+          result: response.data,
+          rowCount: inferRemoteRowCount(response.data),
+          ...(undoNote ? { note: undoNote } : {}),
+          ...(response.rev ? { rev: response.rev } : response.state?.rev ? { rev: response.state.rev } : {}),
+          ...(undoToken ? { undoToken } : {}),
+        };
+      }, timeoutMs, options.signal);
+      return base(value);
+    } catch (error) {
+      if (error instanceof ToolTimeoutError) {
+        return base({ status: "timeout", note: "Tool call timed out." });
+      }
+      if (error instanceof ToolCancelledError || options.signal?.aborted) {
+        return base({ status: "cancelled", note: "Tool call was cancelled." });
+      }
+      return base({ status: "error", note: shortReason(error) });
+    }
+  };
+
+  return {
+    execute,
+    undo: (token, signal) => undoManager.undo(token, signal),
+  };
+}

--- a/src/plugins/builtin/cloud/askg/manifest.test.ts
+++ b/src/plugins/builtin/cloud/askg/manifest.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import type { PaneFunctionCatalog } from "../../../../cli/pane-functions/catalog";
+import type {
+  HeadlessPaneArgumentDef,
+  HeadlessPaneDefinition,
+  PaneDef,
+  PaneTemplateDef,
+} from "../../../../types/plugin";
+import {
+  buildASKGToolManifests,
+  hashASKGToolManifests,
+} from "./manifest";
+import type { ClientToolManifest } from "./protocol";
+
+function headless(argument: HeadlessPaneArgumentDef): HeadlessPaneDefinition<"rows"> {
+  return {
+    shape: "rows",
+    argument,
+    options: [{
+      key: "limit",
+      description: "Maximum rows.",
+      type: "integer",
+      minimum: 1,
+      maximum: 100,
+      defaultValue: 10,
+      settingKey: "limit",
+      pluginState: { pluginId: "test" },
+    }],
+    columns: [{ key: "value", header: "Value", format: String }],
+    load: () => ({ rows: [] }),
+  };
+}
+
+function pane(id: string): PaneDef {
+  return {
+    id,
+    name: id,
+    component: () => null,
+    defaultPosition: "left",
+  };
+}
+
+function template(
+  id: string,
+  paneId: string,
+  prefix: string,
+  argument: HeadlessPaneArgumentDef,
+): PaneTemplateDef {
+  return {
+    id,
+    paneId,
+    label: id,
+    description: `Read ${id}.`,
+    shortcut: { prefix, argKind: "text" },
+    headless: headless(argument),
+  };
+}
+
+function registry(templates: PaneTemplateDef[]): PaneFunctionCatalog {
+  return {
+    panes: new Map(templates.map(({ paneId }) => [paneId, pane(paneId)])),
+    paneTemplates: new Map(templates.map((entry) => [entry.id, entry])),
+    destroy() {},
+  };
+}
+
+function headlessTools(catalog: PaneFunctionCatalog): ClientToolManifest[] {
+  return buildASKGToolManifests(catalog).tools.filter(({ source }) => source === "headless");
+}
+
+describe("ASKG client manifest", () => {
+  test("projects every headless argument kind and strips renderer-only fields", () => {
+    const tools = headlessTools(registry([
+      template("none", "pane-none", "NON", { kind: "none" }),
+      template("ticker", "pane-ticker", "TIK", { kind: "ticker", placeholder: "symbol" }),
+      template("tickers", "pane-tickers", "TKS", { kind: "tickers", minimum: 2, maximum: 4 }),
+      template("symbols", "pane-symbols", "SYM", { kind: "symbol-list", optional: true }),
+      template("text", "pane-text", "TXT", { kind: "free-text", description: "Search phrase." }),
+    ]));
+
+    expect(tools.map(({ name, argument }) => [name, argument?.kind])).toEqual([
+      ["non", "none"],
+      ["sym", "symbol-list"],
+      ["tik", "ticker"],
+      ["tks", "tickers"],
+      ["txt", "free-text"],
+    ]);
+    expect(tools[0]?.options?.[0]).toEqual({
+      key: "limit",
+      description: "Maximum rows.",
+      type: "integer",
+      minimum: 1,
+      maximum: 100,
+      defaultValue: 10,
+    });
+    expect(tools[0]?.columns).toEqual([{ key: "value", header: "Value" }]);
+    expect(tools.every(({ writeTier, confirm }) => writeTier === "read" && confirm === "never")).toBe(true);
+  });
+
+  test("projects remote operation schemas and confirmation tiers", () => {
+    const { tools } = buildASKGToolManifests(registry([]));
+    const notify = tools.find(({ name }) => name === "app.notify");
+    const deleteLayout = tools.find(({ name }) => name === "layout.delete");
+
+    expect(notify).toMatchObject({
+      source: "remote-op",
+      writeTier: "ui-write",
+      confirm: "never",
+      inputSchema: { required: ["body"] },
+    });
+    expect(deleteLayout).toMatchObject({
+      source: "remote-op",
+      writeTier: "user-data",
+      confirm: "always",
+      inputSchema: { required: ["index"] },
+    });
+  });
+
+  test("hash is order-independent and changes with the surface", async () => {
+    const tools = headlessTools(registry([
+      template("valuation", "pane-valuation", "VAL", { kind: "none" }),
+      template("fear", "pane-fear", "FNG", { kind: "none" }),
+    ]));
+    const reversed = [...tools].reverse();
+    const changed = tools.map((tool, index) => index === 0
+      ? { ...tool, description: `${tool.description} Changed.` }
+      : tool);
+
+    expect(await hashASKGToolManifests(tools)).toBe(await hashASKGToolManifests(reversed));
+    expect(await hashASKGToolManifests(changed)).not.toBe(await hashASKGToolManifests(tools));
+  });
+
+  test("skips illegal and ambiguous names instead of rewriting them", () => {
+    const catalog = registry([
+      template("short", "pane-short", "N", { kind: "none" }),
+      template("bad", "pane-bad", "BAD/TOKEN", { kind: "none" }),
+      template("first", "pane-first", "VAL", { kind: "none" }),
+      template("second", "pane-second", "val", { kind: "none" }),
+    ]);
+    const { tools, skipped } = buildASKGToolManifests(catalog);
+
+    expect(tools.filter(({ source }) => source === "headless")).toEqual([]);
+    expect(skipped.map(({ token }) => token)).toEqual(["BAD/TOKEN", "N", "VAL", "val"]);
+    expect(skipped.filter(({ token }) => token.toLowerCase() === "val").every(({ reason }) => (
+      reason.includes("Duplicate tool name")
+    ))).toBe(true);
+  });
+});

--- a/src/plugins/builtin/cloud/askg/manifest.ts
+++ b/src/plugins/builtin/cloud/askg/manifest.ts
@@ -1,0 +1,314 @@
+import type { PaneFunctionCatalog } from "../../../../cli/pane-functions/catalog";
+import { stableStringify } from "../../../../remote/revision";
+import {
+  REMOTE_OPERATIONS,
+  REMOTE_RESOURCES,
+  remoteOperationDescriptors,
+  remoteOperationToolName,
+} from "../../../../remote/schema";
+import type { RemoteControlRequest } from "../../../../remote/types";
+import type {
+  HeadlessPaneDefinition,
+  PaneDef,
+  PaneTemplateDef,
+} from "../../../../types/plugin";
+import {
+  TOOL_NAME_PATTERN,
+  type ClientToolManifest,
+  type ClientToolManifestSource,
+  type JsonValue,
+  type ToolManifestArgument,
+  type ToolManifestColumn,
+  type ToolManifestOption,
+} from "./protocol";
+
+export const HEADLESS_TOOL_TIMEOUT_MS = 30_000;
+export const REMOTE_TOOL_TIMEOUT_MS = 10_000;
+export const REMOTE_RESOURCE_TOOL_NAME = "app.get_resource";
+
+const TOOL_NAME_REGEX = new RegExp(TOOL_NAME_PATTERN);
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export interface SkippedToolManifest {
+  source: ClientToolManifestSource;
+  token: string;
+  reason: string;
+}
+
+export interface ASKGClientManifest {
+  tools: ClientToolManifest[];
+  manifestHash: string;
+  skipped: SkippedToolManifest[];
+}
+
+interface ManifestCandidate {
+  token: string;
+  identity: string;
+  manifest: ClientToolManifest;
+}
+
+export type RemoteToolBinding =
+  | { kind: "operation"; operation: string }
+  | { kind: "resource" };
+
+function projectArgument(argument: HeadlessPaneDefinition["argument"]): ToolManifestArgument {
+  return { ...argument };
+}
+
+function projectOptions(options: HeadlessPaneDefinition["options"]): ToolManifestOption[] {
+  return options.map(({
+    settingKey: _settingKey,
+    pluginState: _pluginState,
+    values,
+    aliases,
+    ...option
+  }) => ({
+    ...option,
+    ...(aliases ? { aliases: [...aliases] } : {}),
+    ...(values ? {
+      values: values.map((value) => ({
+        ...value,
+        ...(value.aliases ? { aliases: [...value.aliases] } : {}),
+      })),
+    } : {}),
+  }));
+}
+
+function projectColumns(columns: HeadlessPaneDefinition["columns"]): ToolManifestColumn[] | undefined {
+  if (!columns) return undefined;
+  return columns.map(({ format: _format, ...column }) => ({ ...column }));
+}
+
+function headlessManifest(
+  token: string,
+  title: string,
+  description: string,
+  definition: HeadlessPaneDefinition,
+): ClientToolManifest {
+  const columns = projectColumns(definition.columns);
+  return {
+    name: token.toLowerCase(),
+    source: "headless",
+    title,
+    description,
+    writeTier: "read",
+    shape: definition.shape,
+    argument: projectArgument(definition.argument),
+    options: projectOptions(definition.options),
+    ...(columns ? { columns } : {}),
+    confirm: "never",
+    timeoutMs: HEADLESS_TOOL_TIMEOUT_MS,
+  };
+}
+
+function definitionFor(template: PaneTemplateDef, pane: PaneDef): HeadlessPaneDefinition | undefined {
+  return template.headless ?? pane.headless;
+}
+
+function headlessCandidates(registry: PaneFunctionCatalog): ManifestCandidate[] {
+  const candidates: ManifestCandidate[] = [];
+  const templatedPaneIds = new Set<string>();
+
+  const templates = [...registry.paneTemplates.values()]
+    .sort((left, right) => compareText(left.id, right.id));
+  for (const template of templates) {
+    const pane = registry.panes.get(template.paneId);
+    if (!pane) continue;
+    templatedPaneIds.add(pane.id);
+    const definition = definitionFor(template, pane);
+    if (!definition) continue;
+    const token = template.shortcut?.prefix ?? template.id;
+    candidates.push({
+      token,
+      identity: `template:${template.id}`,
+      manifest: headlessManifest(token, template.label, template.description, definition),
+    });
+  }
+
+  const panes = [...registry.panes.values()]
+    .sort((left, right) => compareText(left.id, right.id));
+  for (const pane of panes) {
+    if (templatedPaneIds.has(pane.id) || !pane.headless) continue;
+    candidates.push({
+      token: pane.id,
+      identity: `pane:${pane.id}`,
+      manifest: headlessManifest(
+        pane.id,
+        pane.name,
+        `Read data from the ${pane.name} pane.`,
+        pane.headless,
+      ),
+    });
+  }
+
+  return candidates;
+}
+
+function remoteCandidates(): ManifestCandidate[] {
+  const descriptors = remoteOperationDescriptors();
+  const operationsByName = new Map(
+    REMOTE_OPERATIONS.map((operation) => [remoteOperationToolName(operation.id), operation]),
+  );
+  const candidates = descriptors.map((descriptor): ManifestCandidate => ({
+    token: descriptor.name,
+    identity: `operation:${operationsByName.get(descriptor.name)?.id ?? descriptor.name}`,
+    manifest: {
+      name: descriptor.name,
+      source: "remote-op",
+      title: descriptor.title,
+      description: descriptor.description,
+      writeTier: descriptor.writeTier,
+      inputSchema: descriptor.inputSchema,
+      confirm: descriptor.writeTier === "user-data" || descriptor.writeTier === "broker"
+        ? "always"
+        : "never",
+      timeoutMs: REMOTE_TOOL_TIMEOUT_MS,
+    },
+  }));
+
+  candidates.push({
+    token: REMOTE_RESOURCE_TOOL_NAME,
+    identity: "resource:get",
+    manifest: {
+      name: REMOTE_RESOURCE_TOOL_NAME,
+      source: "remote-op",
+      title: "App: Get resource",
+      description: `Read a registered in-process app resource. Available resources: ${REMOTE_RESOURCES.map(({ uri }) => uri).join(", ")}.`,
+      writeTier: "read",
+      inputSchema: {
+        type: "object",
+        properties: {
+          resource: {
+            type: "string",
+            minLength: 1,
+            description: "Registered resource URI, such as app://snapshot or app://pane-state/{paneId}.",
+          },
+        },
+        required: ["resource"],
+        additionalProperties: false,
+      },
+      confirm: "never",
+      timeoutMs: REMOTE_TOOL_TIMEOUT_MS,
+    },
+  });
+
+  return candidates;
+}
+
+function compareManifests(left: ClientToolManifest, right: ClientToolManifest): number {
+  return compareText(left.name, right.name) || compareText(left.source, right.source);
+}
+
+function filterCandidates(candidates: ManifestCandidate[]): {
+  tools: ClientToolManifest[];
+  skipped: SkippedToolManifest[];
+} {
+  const skipped: SkippedToolManifest[] = [];
+  const valid: ManifestCandidate[] = [];
+
+  for (const candidate of candidates.sort((left, right) => (
+    compareText(left.manifest.name, right.manifest.name)
+    || compareText(left.identity, right.identity)
+  ))) {
+    if (!TOOL_NAME_REGEX.test(candidate.manifest.name)) {
+      skipped.push({
+        source: candidate.manifest.source,
+        token: candidate.token,
+        reason: `Lowercased token "${candidate.manifest.name}" does not match ${TOOL_NAME_PATTERN}.`,
+      });
+      continue;
+    }
+    valid.push(candidate);
+  }
+
+  const counts = new Map<string, number>();
+  for (const candidate of valid) {
+    counts.set(candidate.manifest.name, (counts.get(candidate.manifest.name) ?? 0) + 1);
+  }
+
+  const tools: ClientToolManifest[] = [];
+  for (const candidate of valid) {
+    if ((counts.get(candidate.manifest.name) ?? 0) > 1) {
+      skipped.push({
+        source: candidate.manifest.source,
+        token: candidate.token,
+        reason: `Duplicate tool name "${candidate.manifest.name}" from ${candidate.identity}.`,
+      });
+      continue;
+    }
+    tools.push(candidate.manifest);
+  }
+
+  return {
+    tools: tools.sort(compareManifests),
+    skipped: skipped.sort((left, right) => (
+      compareText(left.token, right.token) || compareText(left.source, right.source)
+    )),
+  };
+}
+
+export function buildASKGToolManifests(registry: PaneFunctionCatalog): {
+  tools: ClientToolManifest[];
+  skipped: SkippedToolManifest[];
+} {
+  return filterCandidates([
+    ...headlessCandidates(registry),
+    ...remoteCandidates(),
+  ]);
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export async function hashASKGToolManifests(tools: readonly ClientToolManifest[]): Promise<string> {
+  const sorted = [...tools].sort(compareManifests);
+  const digest = await globalThis.crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(stableStringify(sorted)),
+  );
+  return `sha256:${bytesToHex(new Uint8Array(digest))}`;
+}
+
+export async function buildASKGClientManifest(
+  registry: PaneFunctionCatalog,
+): Promise<ASKGClientManifest> {
+  const { tools, skipped } = buildASKGToolManifests(registry);
+  return {
+    tools,
+    manifestHash: await hashASKGToolManifests(tools),
+    skipped,
+  };
+}
+
+export function resolveRemoteToolBinding(name: string): RemoteToolBinding | null {
+  if (name === REMOTE_RESOURCE_TOOL_NAME) return { kind: "resource" };
+  const operation = REMOTE_OPERATIONS.find((entry) => remoteOperationToolName(entry.id) === name);
+  return operation ? { kind: "operation", operation: operation.id } : null;
+}
+
+function resourcePatternMatches(pattern: string, value: string): boolean {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`^${escaped.replace(/\\\{[^}]+\\\}/g, "[^/]+")}$`);
+  return regex.test(value);
+}
+
+export function remoteRequestForTool(
+  binding: RemoteToolBinding,
+  args: Record<string, JsonValue>,
+): RemoteControlRequest {
+  if (binding.kind === "operation") {
+    return { type: "call", operation: binding.operation, input: args };
+  }
+  const resource = args.resource;
+  if (typeof resource !== "string" || resource.length === 0) {
+    throw new Error(`${REMOTE_RESOURCE_TOOL_NAME} requires a resource URI.`);
+  }
+  if (!REMOTE_RESOURCES.some(({ uri }) => resourcePatternMatches(uri, resource))) {
+    throw new Error(`Unknown remote resource "${resource}".`);
+  }
+  return { type: "get", resource };
+}

--- a/src/plugins/builtin/cloud/askg/undo.test.ts
+++ b/src/plugins/builtin/cloud/askg/undo.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+import { applyJsonPatch } from "../../../../remote/json-patch";
+import { revisionFor } from "../../../../remote/revision";
+import type { RemoteControlResponse } from "../../../../remote/types";
+import type { JsonValue } from "./protocol";
+import { ASKGUndoManager, type InProcessRemoteControlHandler } from "./undo";
+
+test("restores reversible pane state only when it has not changed again", async () => {
+  const resource = "app://pane-state/chart%3Amain";
+  const values = new Map<string, JsonValue>([[resource, { cursor: 1, mode: "price" }]]);
+  const handler: InProcessRemoteControlHandler = async (request): Promise<RemoteControlResponse> => {
+    if (request.type === "get") {
+      const value = values.get(request.resource) ?? {};
+      return { ok: true, data: value, rev: revisionFor(value) };
+    }
+    if (request.type === "patch") {
+      const current = values.get(request.resource) ?? {};
+      if (request.expectRev && request.expectRev !== revisionFor(current)) {
+        return { ok: false, error: { code: "revision_mismatch", message: "Revision mismatch." } };
+      }
+      const next = applyJsonPatch(current, request.patch) as JsonValue;
+      values.set(request.resource, next);
+      return { ok: true, data: next, rev: revisionFor(next) };
+    }
+    return { ok: false, error: { code: "unsupported", message: "Unsupported request." } };
+  };
+  const undo = new ASKGUndoManager(handler, { tokenFactory: () => "undo-1" });
+  const prepared = await undo.prepare("pane.setState", { paneId: "chart:main", patch: { cursor: 2 } });
+  expect(prepared).not.toBeNull();
+  values.set(resource, { cursor: 2, mode: "price", transient: true });
+  const token = await undo.commit(prepared!);
+
+  expect(token).toBe("undo-1");
+  expect((await undo.undo(token!)).status).toBe("ok");
+  expect(values.get(resource)).toEqual({ cursor: 1, mode: "price" });
+
+  const second = await undo.prepare("pane.setState", { paneId: "chart:main", patch: { cursor: 3 } });
+  values.set(resource, { cursor: 3, mode: "price" });
+  const secondToken = await undo.commit(second!);
+  values.set(resource, { cursor: 4, mode: "price" });
+  const denied = await undo.undo(secondToken!);
+  expect(denied.status).toBe("denied");
+  expect(denied.note).toContain("changed after the tool call");
+});

--- a/src/plugins/builtin/cloud/askg/undo.ts
+++ b/src/plugins/builtin/cloud/askg/undo.ts
@@ -1,0 +1,277 @@
+import { stableStringify } from "../../../../remote/revision";
+import type {
+  RemoteControlRequest,
+  RemoteControlResponse,
+  RemoteJsonPatchOperation,
+} from "../../../../remote/types";
+import type { JsonValue, ToolResultStatus } from "./protocol";
+
+export type InProcessRemoteControlHandler = (
+  request: RemoteControlRequest,
+) => Promise<RemoteControlResponse>;
+
+interface UndoResourceSnapshot {
+  resource: string;
+  value: JsonValue;
+}
+
+interface StoredUndoResource extends UndoResourceSnapshot {
+  expectedRev: string;
+}
+
+interface StoredUndo {
+  createdAt: number;
+  resources: StoredUndoResource[];
+}
+
+export interface PreparedUndo {
+  resources: UndoResourceSnapshot[];
+}
+
+export interface AppliedUndo {
+  status: Extract<ToolResultStatus, "ok" | "error" | "denied" | "cancelled">;
+  elapsedMs: number;
+  note?: string;
+}
+
+export interface ASKGUndoManagerOptions {
+  maxEntries?: number;
+  ttlMs?: number;
+  now?: () => number;
+  tokenFactory?: () => string;
+}
+
+const DEFAULT_MAX_ENTRIES = 50;
+const DEFAULT_TTL_MS = 10 * 60_000;
+
+const LAYOUT_UNDO_OPERATIONS = new Set([
+  "pane.setSetting",
+  "layout.gridlock",
+  "layout.closeFloating",
+  "layout.placePane",
+  "layout.setGrid",
+]);
+
+function shortReason(error: unknown): string {
+  const text = error instanceof Error ? error.message : String(error);
+  return text.replace(/\s+/g, " ").trim().slice(0, 240) || "Unknown error.";
+}
+
+function normalizeJson(value: unknown, seen = new WeakSet<object>()): JsonValue {
+  if (value == null) return null;
+  if (typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "bigint") return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value !== "object") return String(value);
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const result = value.map((entry) => normalizeJson(entry, seen));
+    seen.delete(value);
+    return result;
+  }
+  const result: Record<string, JsonValue> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    result[key] = normalizeJson((value as Record<string, unknown>)[key], seen);
+  }
+  seen.delete(value);
+  return result;
+}
+
+function paneStateResource(args: Record<string, JsonValue>): string | null {
+  const paneId = args.paneId;
+  return typeof paneId === "string" && paneId.length > 0
+    ? `app://pane-state/${encodeURIComponent(paneId)}`
+    : null;
+}
+
+function resourcesForOperation(
+  operation: string,
+  args: Record<string, JsonValue>,
+): string[] | null {
+  if (operation === "pane.setState") {
+    const resource = paneStateResource(args);
+    return resource ? [resource] : null;
+  }
+  if (LAYOUT_UNDO_OPERATIONS.has(operation)) return ["app://layout/current"];
+  return null;
+}
+
+function pointerSegment(value: string): string {
+  return value.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+function isObject(value: JsonValue): value is Record<string, JsonValue> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function replacementPatch(current: JsonValue, target: JsonValue): RemoteJsonPatchOperation[] | null {
+  if (!isObject(current) || !isObject(target)) return null;
+  const patch: RemoteJsonPatchOperation[] = [];
+  const currentKeys = Object.keys(current).sort();
+  const targetKeys = Object.keys(target).sort();
+  for (const key of currentKeys) {
+    if (!(key in target)) patch.push({ op: "remove", path: `/${pointerSegment(key)}` });
+  }
+  for (const key of targetKeys) {
+    const path = `/${pointerSegment(key)}`;
+    if (!(key in current)) {
+      patch.push({ op: "add", path, value: target[key] });
+    } else if (stableStringify(current[key]) !== stableStringify(target[key])) {
+      patch.push({ op: "replace", path, value: target[key] });
+    }
+  }
+  return patch;
+}
+
+function throwIfCancelled(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  throw signal.reason instanceof Error ? signal.reason : new Error("Undo was cancelled.");
+}
+
+function randomToken(): string {
+  return globalThis.crypto.randomUUID();
+}
+
+export class ASKGUndoManager {
+  private readonly entries = new Map<string, StoredUndo>();
+  private readonly maxEntries: number;
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+  private readonly tokenFactory: () => string;
+
+  constructor(
+    private readonly remoteHandler: InProcessRemoteControlHandler,
+    options: ASKGUndoManagerOptions = {},
+  ) {
+    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.now = options.now ?? Date.now;
+    this.tokenFactory = options.tokenFactory ?? randomToken;
+  }
+
+  async prepare(
+    operation: string,
+    args: Record<string, JsonValue>,
+    signal?: AbortSignal,
+  ): Promise<PreparedUndo | null> {
+    const resources = resourcesForOperation(operation, args);
+    if (!resources) return null;
+    const snapshots: UndoResourceSnapshot[] = [];
+    for (const resource of resources) {
+      throwIfCancelled(signal);
+      const response = await this.remoteHandler({ type: "get", resource });
+      if (!response.ok) throw new Error(response.error.message);
+      snapshots.push({ resource, value: normalizeJson(response.data) });
+    }
+    return { resources: snapshots };
+  }
+
+  async commit(prepared: PreparedUndo, signal?: AbortSignal): Promise<string | null> {
+    const resources: StoredUndoResource[] = [];
+    let changed = false;
+    for (const before of prepared.resources) {
+      throwIfCancelled(signal);
+      const response = await this.remoteHandler({ type: "get", resource: before.resource });
+      if (!response.ok) throw new Error(response.error.message);
+      if (!response.rev) throw new Error(`Resource "${before.resource}" did not return a revision.`);
+      const current = normalizeJson(response.data);
+      if (stableStringify(current) !== stableStringify(before.value)) changed = true;
+      resources.push({ ...before, expectedRev: response.rev });
+    }
+    if (!changed) return null;
+
+    this.prune();
+    const token = this.tokenFactory();
+    this.entries.set(token, { createdAt: this.now(), resources });
+    while (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value as string | undefined;
+      if (!oldest) break;
+      this.entries.delete(oldest);
+    }
+    return token;
+  }
+
+  async undo(token: string, signal?: AbortSignal): Promise<AppliedUndo> {
+    const startedAt = this.now();
+    this.prune();
+    const entry = this.entries.get(token);
+    if (!entry) {
+      return {
+        status: "denied",
+        elapsedMs: Math.max(0, this.now() - startedAt),
+        note: "Undo token is unknown or expired.",
+      };
+    }
+
+    try {
+      const currentResources: Array<{
+        snapshot: StoredUndoResource;
+        value: JsonValue;
+        rev: string;
+        patch: RemoteJsonPatchOperation[];
+      }> = [];
+      for (const snapshot of entry.resources) {
+        throwIfCancelled(signal);
+        const response = await this.remoteHandler({ type: "get", resource: snapshot.resource });
+        if (!response.ok) throw new Error(response.error.message);
+        if (!response.rev) throw new Error(`Resource "${snapshot.resource}" did not return a revision.`);
+        if (response.rev !== snapshot.expectedRev) {
+          return {
+            status: "denied",
+            elapsedMs: Math.max(0, this.now() - startedAt),
+            note: `Cannot undo because "${snapshot.resource}" changed after the tool call.`,
+          };
+        }
+        const value = normalizeJson(response.data);
+        const patch = replacementPatch(value, snapshot.value);
+        if (!patch) {
+          return {
+            status: "denied",
+            elapsedMs: Math.max(0, this.now() - startedAt),
+            note: `Cannot safely restore non-object resource "${snapshot.resource}".`,
+          };
+        }
+        currentResources.push({ snapshot, value, rev: response.rev, patch });
+      }
+
+      for (const current of currentResources) {
+        throwIfCancelled(signal);
+        if (current.patch.length === 0) continue;
+        const response = await this.remoteHandler({
+          type: "patch",
+          resource: current.snapshot.resource,
+          patch: current.patch,
+          expectRev: current.rev,
+        });
+        if (!response.ok) throw new Error(response.error.message);
+      }
+      this.entries.delete(token);
+      return {
+        status: "ok",
+        elapsedMs: Math.max(0, this.now() - startedAt),
+      };
+    } catch (error) {
+      if (signal?.aborted) {
+        return {
+          status: "cancelled",
+          elapsedMs: Math.max(0, this.now() - startedAt),
+          note: "Undo was cancelled.",
+        };
+      }
+      return {
+        status: "error",
+        elapsedMs: Math.max(0, this.now() - startedAt),
+        note: shortReason(error),
+      };
+    }
+  }
+
+  private prune(): void {
+    const cutoff = this.now() - this.ttlMs;
+    for (const [token, entry] of this.entries) {
+      if (entry.createdAt < cutoff) this.entries.delete(token);
+    }
+  }
+}

--- a/src/plugins/builtin/cloud/askg/verify.ts
+++ b/src/plugins/builtin/cloud/askg/verify.ts
@@ -1,0 +1,130 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createAppServices } from "../../../../core/app-services";
+import {
+  appReducer,
+  createInitialState,
+  type AppAction,
+} from "../../../../core/state/app/state";
+import { getLoadablePlugins } from "../../../catalog";
+import { createAppRemoteController } from "../../../../remote/controller";
+import type { RemoteUiRegistry } from "../../../../remote/semantic-tree";
+import { createDefaultConfig } from "../../../../types/config";
+import type { ASKGToolCallEvent, ClientToolManifest } from "./protocol";
+import { createASKGToolExecutor } from "./executor";
+import { buildASKGClientManifest, REMOTE_RESOURCE_TOOL_NAME } from "./manifest";
+
+function toolCall(tool: ClientToolManifest, args: ASKGToolCallEvent["args"]): ASKGToolCallEvent {
+  return {
+    seq: 1,
+    type: "tool-call",
+    turnId: "verify-turn",
+    toolCallId: `verify-${tool.name}`,
+    name: tool.name,
+    args,
+    writeTier: tool.writeTier,
+    requiresConfirmation: false,
+    preview: null,
+    timeoutMs: tool.timeoutMs,
+    expiresAt: new Date(Date.now() + tool.timeoutMs).toISOString(),
+  };
+}
+
+function resultShape(value: unknown): string {
+  if (Array.isArray(value)) return "array";
+  if (value == null) return String(value);
+  if (typeof value !== "object") return typeof value;
+  return Object.keys(value as Record<string, unknown>).sort().join(",") || "object";
+}
+
+async function verify() {
+  const dataDir = mkdtempSync(join(tmpdir(), "gloomberb-askg-client-"));
+  const config = { ...createDefaultConfig(dataDir), onboardingComplete: true };
+  const services = createAppServices({ config, plugins: getLoadablePlugins() });
+  try {
+    await services.ready;
+    let state = createInitialState(config);
+    const dispatch = (action: AppAction) => {
+      state = appReducer(state, action);
+    };
+    services.pluginRegistry.getConfigFn = () => state.config;
+    services.pluginRegistry.getLayoutFn = () => state.config.layout;
+    services.pluginRegistry.updateLayoutFn = (layout) => dispatch({ type: "UPDATE_LAYOUT", layout });
+
+    const uiRegistry: RemoteUiRegistry = {
+      register() {},
+      unregister() {},
+      snapshot: () => [],
+      invoke: async () => null,
+    };
+    const remote = createAppRemoteController({
+      dispatch,
+      getState: () => state,
+      pluginRegistry: services.pluginRegistry,
+      uiRegistry,
+    });
+    const built = await buildASKGClientManifest(services.pluginRegistry);
+    const sources = { headless: 0, "remote-op": 0 };
+    const tiers = { read: 0, "ui-write": 0, "user-data": 0, broker: 0 };
+    for (const tool of built.tools) {
+      sources[tool.source] += 1;
+      tiers[tool.writeTier] += 1;
+    }
+
+    console.log(JSON.stringify({
+      totalTools: built.tools.length,
+      sources,
+      tiers,
+      headlessNames: built.tools.filter(({ source }) => source === "headless").map(({ name }) => name),
+      manifestHash: built.manifestHash,
+      skipped: built.skipped,
+    }, null, 2));
+
+    const executor = createASKGToolExecutor({
+      manifests: built.tools,
+      registry: services.pluginRegistry,
+      context: {
+        config,
+        dataDir,
+        persistence: services.persistence,
+        store: services.tickerRepository,
+        dataProvider: services.providerRouter,
+      },
+      remoteHandler: remote.handle,
+    });
+    const headless = built.tools.find(({ source, name, argument }) => (
+      source === "headless" && name === "val" && (argument?.kind === "none" || argument?.optional)
+    )) ?? built.tools.find(({ source, argument }) => (
+      source === "headless" && (argument?.kind === "none" || argument?.optional)
+    ));
+    const resource = built.tools.find(({ name }) => name === REMOTE_RESOURCE_TOOL_NAME);
+    if (!headless || !resource) throw new Error("Verification tools are missing from the manifest.");
+
+    const headlessResult = await executor.execute(toolCall(headless, {}));
+    const remoteResult = await executor.execute(toolCall(resource, { resource: "app://snapshot" }));
+    console.log(JSON.stringify({
+      headless: {
+        name: headless.name,
+        status: headlessResult.status,
+        resultShape: resultShape(headlessResult.result),
+        rowCount: headlessResult.rowCount,
+        elapsedMs: headlessResult.elapsedMs,
+      },
+      remote: {
+        name: resource.name,
+        status: remoteResult.status,
+        resultShape: resultShape(remoteResult.result),
+        rowCount: remoteResult.rowCount,
+        elapsedMs: remoteResult.elapsedMs,
+      },
+    }, null, 2));
+  } finally {
+    services.destroy();
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+}
+
+if (import.meta.main) {
+  await verify();
+}


### PR DESCRIPTION
## Why

ASKG runs its model loop on Gloom Cloud, but terminal-local data and UI operations need a negotiated client tool surface and an in-process executor. The client also needs to enforce its own safety boundaries rather than trusting a delegated call from the server.

## What

- Build deterministic client manifests from live headless pane exports and remote-control operation descriptors.
- Add `app.get_resource` for read-only access to registered remote resources such as `app://snapshot`.
- Hash the sorted manifest surface with SHA-256 and report invalid or ambiguous names instead of rewriting them.
- Execute headless calls through `loadResolvedHeadlessPaneModel` and its existing serializer, including persisted Cloud session handling.
- Execute remote calls through an injected in-process `RemoteControlHost` handler, with no loopback HTTP dependency.
- Recheck write tiers and local confirmation, enforce deadlines and cancellation, bound the full wire payload, and return failures as protocol values.
- Capture conservative undo snapshots for reversible UI writes. Undo is only offered when the affected layout or pane-state resource can be restored safely at the expected revision.
- Add a real-registry verification script at `src/plugins/builtin/cloud/askg/verify.ts`.

The next transport task should call:

- `buildASKGClientManifest(pluginRegistry)` during session negotiation.
- `createASKGToolExecutor(...)` once with the same in-process handler registered by `RemoteControlHost`.
- `executor.execute(toolCallEvent, { signal, confirmed })` for delegated SSE calls.
- `executor.undo(undoToken, signal)` for the UI undo action.

## Verify

```text
bun test src/plugins/builtin/cloud
28 pass, 0 fail

bun run typecheck
opentui, electrobun-bun, electrobun-view, browser, cloudflare, scripts passed

bun run src/plugins/builtin/cloud/askg/verify.ts
57 total tools
20 headless
37 remote-op
write tiers: 21 read, 34 ui-write, 1 user-data, 1 broker
```

End-to-end calls, with no server:

```text
val: ok, shape errors/metadata/sections, 17 rows, 1015 ms
app.get_resource app://snapshot: ok, 3 panes, 1 ms
```

The manifest hash was `sha256:354bfd01fb0c9ae9f5f8f0c8e87c1d30e1d7a81b03611688239aa2b58ca823ba`.

Nine headless shortcuts are skipped because the v1 protocol pattern requires at least three characters and a leading letter: `13F`, `BI`, `CG`, `CN`, `EE`, `GC`, `N`, `PM`, `SI`. They are reported with reasons and never silently renamed. Complete shortcut coverage needs a protocol decision to relax the pattern or define explicit stable aliases.

Remote-control handlers do not currently accept an `AbortSignal`. The executor stops waiting and reports cancellation or timeout, but an already-started remote operation can still finish in-process. Headless loaders receive the signal directly.
