### PR TITLE
Let ASKG name a tool after any terminal shortcut

### DIFF
--- a/src/plugins/builtin/cloud/askg/manifest.test.ts
+++ b/src/plugins/builtin/cloud/askg/manifest.test.ts
@@ -132,15 +132,20 @@ describe("ASKG client manifest", () => {
 
   test("skips illegal and ambiguous names instead of rewriting them", () => {
     const catalog = registry([
+      // Short and digit leading tokens are legal: the terminal's own shortcuts
+      // include N, SI and 13F, and a tool the model cannot name is a tool the
+      // model cannot use.
       template("short", "pane-short", "N", { kind: "none" }),
+      template("numeric", "pane-numeric", "13F", { kind: "none" }),
       template("bad", "pane-bad", "BAD/TOKEN", { kind: "none" }),
       template("first", "pane-first", "VAL", { kind: "none" }),
       template("second", "pane-second", "val", { kind: "none" }),
     ]);
     const { tools, skipped } = buildASKGToolManifests(catalog);
 
-    expect(tools.filter(({ source }) => source === "headless")).toEqual([]);
-    expect(skipped.map(({ token }) => token)).toEqual(["BAD/TOKEN", "N", "VAL", "val"]);
+    expect(tools.filter(({ source }) => source === "headless").map(({ name }) => name))
+      .toEqual(["13f", "n"]);
+    expect(skipped.map(({ token }) => token)).toEqual(["BAD/TOKEN", "VAL", "val"]);
     expect(skipped.filter(({ token }) => token.toLowerCase() === "val").every(({ reason }) => (
       reason.includes("Duplicate tool name")
     ))).toBe(true);

--- a/src/plugins/builtin/cloud/askg/protocol.ts
+++ b/src/plugins/builtin/cloud/askg/protocol.ts
@@ -19,7 +19,7 @@ export const ASKG_PROTOCOL_VERSION = 1;
 export const MAX_TOOL_RESULT_BYTES = 262_144;
 
 /** Source form for valid tool names advertised to ASKG. */
-export const TOOL_NAME_PATTERN = "^[a-z][a-z0-9_.]{2,48}$";
+export const TOOL_NAME_PATTERN = "^[a-z0-9][a-z0-9_.]{0,47}$";
 
 /** JSON value accepted on the ASKG wire. */
 export type JsonValue =


### PR DESCRIPTION
## Why

`TOOL_NAME_PATTERN` was `^[a-z][a-z0-9_.]{2,48}$`, requiring three characters and a leading letter. The client manifest builder therefore skipped nine panes: `13F`, `SI`, `CG`, `CN`, `EE`, `GC`, `N`, `PM` and `BI`. Those are among the shortcuts a user is most likely to ask about, and several are exactly what the publisher and an assistant need (congress trades, short interest, institutional holdings, earnings estimates).

## What

The pattern becomes `^[a-z0-9][a-z0-9_.]{0,47}$`: a name may start with a digit and may be one character. Tool names stay identical to the terminal shortcut and to the token accepted by `gloomberb fn`, so there is one vocabulary rather than two. Duplicate and illegal names are still skipped with a reason.

The platform mirror in `server/src/services/askg/types.ts` carries the same pattern.

## Verify

`bun test src/plugins/builtin/cloud` passes (28 tests); the manifest test now asserts `13f` and `n` are advertised rather than skipped.