### PR TITLE
Recover from expired cloud sessions

### DIFF
--- a/src/api-client/index.test.ts
+++ b/src/api-client/index.test.ts
@@ -264,6 +264,40 @@ describe("apiClient auth cookies", () => {
     ]);
   });
 
+  test("ignores a stale response cookie after the session credential changes", async () => {
+    let releaseResponse: (() => void) | null = null;
+    let markRequestStarted: (() => void) | null = null;
+    const requestStarted = new Promise<void>((resolve) => {
+      markRequestStarted = resolve;
+    });
+
+    apiClient.setSessionToken("old-session.value");
+    setCloudApiFetchTransport(async () => {
+      markRequestStarted?.();
+      await new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+      });
+      return createResponse({
+        channels: [],
+        onlineCount: 0,
+        channelStates: [],
+        notifications: [],
+      }, {
+        cookies: [
+          "__Secure-gloomberb.session_token=old-session.value; Path=/; HttpOnly; Secure; SameSite=None",
+        ],
+      });
+    });
+
+    const staleRequest = apiClient.getChatState();
+    await requestStarted;
+    apiClient.setSessionToken("new-session.value");
+    releaseResponse?.();
+    await staleRequest;
+
+    expect(apiClient.getSessionToken()).toBe("new-session.value");
+  });
+
   test("uses an installed cloud API fetch transport for auth cookie capture", async () => {
     const seenCookies: Array<string | null> = [];
     globalThis.fetch = mockFetch(async () => {

--- a/src/api-client/request.ts
+++ b/src/api-client/request.ts
@@ -141,6 +141,7 @@ export class CloudApiRequestTransport {
       headers.set("Content-Type", "application/json");
     }
     this.setSessionCookieHeader(headers);
+    const sessionTokenAtRequestStart = this.sessionToken;
     headers.set("Origin", this.baseUrl);
 
     const operation = `${options?.method ?? "GET"} ${path.split("?")[0]}`;
@@ -151,7 +152,9 @@ export class CloudApiRequestTransport {
         credentials: "include",
       });
       throwIfRequestAborted(options?.signal);
-      this.extractSessionCookie(res);
+      if (this.sessionToken === sessionTokenAtRequestStart) {
+        this.extractSessionCookie(res);
+      }
       const text = await res.text();
       throwIfRequestAborted(options?.signal);
 

--- a/src/plugins/builtin/chat/controller.test.ts
+++ b/src/plugins/builtin/chat/controller.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { AppNotificationRequest } from "../../../types/plugin";
 import { MemoryPluginPersistence as MemoryPersistence } from "../../../test-support/plugin-persistence";
-import { apiClient, type ChatChannel, type ChatMessage, type ChatNotification } from "../../../api-client";
+import {
+  apiClient,
+  type ChatChannel,
+  type ChatMessage,
+  type ChatNotification,
+  type ChatStateResponse,
+} from "../../../api-client";
+import { ApiRequestError } from "../../../api-client/errors";
 import { ChatController } from "./controller";
 
 const TRANSCRIPT_KIND = "channel-transcript";
@@ -14,6 +21,7 @@ const originalGetMessages = apiClient.getMessages.bind(apiClient);
 const originalGetChannels = apiClient.getChannels.bind(apiClient);
 const originalGetChatPresence = apiClient.getChatPresence.bind(apiClient);
 const originalGetChatState = apiClient.getChatState.bind(apiClient);
+const originalGetAccountProfile = apiClient.getAccountProfile.bind(apiClient);
 const originalUpdateChatChannelState = apiClient.updateChatChannelState.bind(apiClient);
 const originalMarkChatNotificationsDelivered = apiClient.markChatNotificationsDelivered.bind(apiClient);
 const originalSubscribeChatNotifications = apiClient.subscribeChatNotifications.bind(apiClient);
@@ -100,6 +108,7 @@ afterEach(() => {
   apiClient.getChannels = originalGetChannels;
   apiClient.getChatPresence = originalGetChatPresence;
   apiClient.getChatState = originalGetChatState;
+  apiClient.getAccountProfile = originalGetAccountProfile;
   apiClient.updateChatChannelState = originalUpdateChatChannelState;
   apiClient.markChatNotificationsDelivered = originalMarkChatNotificationsDelivered;
   apiClient.subscribeChatNotifications = originalSubscribeChatNotifications;
@@ -453,9 +462,15 @@ describe("ChatController", () => {
     }
   });
 
-  test("keeps a persisted native session when get-session returns no user", async () => {
+  test("validates a persisted native session through protected chat state", async () => {
     const persistence = new MemoryPersistence();
     const controller = new ChatController();
+    const directChannel: ChatChannel = {
+      id: "dm:u2",
+      name: "u2",
+      kind: "direct",
+      created_at: "2026-03-28T00:00:00.000Z",
+    };
 
     persistence.setState("session", {
       sessionToken: "token-123",
@@ -463,11 +478,22 @@ describe("ChatController", () => {
     }, { schemaVersion: 1 });
 
     controller.attachPersistence(persistence);
-    apiClient.getSession = async () => null;
+    apiClient.getSession = async () => {
+      apiClient.restoreCachedUser(null);
+      return null;
+    };
+    apiClient.getChatState = async () => ({
+      channels: [...SERVER_CHAT_CHANNELS, directChannel],
+      onlineCount: 0,
+      channelStates: [],
+      notifications: [],
+    });
 
     await controller.refreshSession();
 
     expect(apiClient.getSessionToken()).toBe("token-123");
+    expect(apiClient.getCurrentUser()?.id).toBe("u1");
+    expect(controller.getChannels()).toContainEqual(directChannel);
     expect(persistence.getState<{
       sessionToken: string;
       user: { id: string; username: string; emailVerified: boolean };
@@ -480,6 +506,219 @@ describe("ChatController", () => {
       username: "vince",
       emailVerified: true,
     });
+    controller.dispose();
+  });
+
+  test("clears an expired persisted session when protected chat rejects it", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+
+    persistence.setState("session", {
+      sessionToken: "expired-token",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+
+    controller.attachPersistence(persistence);
+    apiClient.getSession = async () => {
+      apiClient.restoreCachedUser(null);
+      return null;
+    };
+    apiClient.getChatState = async () => {
+      throw new ApiRequestError("Unauthorized", 401);
+    };
+
+    await controller.refreshSession();
+
+    expect(apiClient.getSessionToken()).toBeNull();
+    expect(apiClient.getCurrentUser()).toBeNull();
+    expect(controller.getSnapshot().user).toBeNull();
+    expect(persistence.getState("session", { schemaVersion: 1 })).toEqual({
+      sessionToken: null,
+      user: null,
+    });
+    controller.dispose();
+  });
+
+  test("clears an expired persisted session for an unverified user", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    let profileRequests = 0;
+
+    persistence.setState("session", {
+      sessionToken: "expired-token",
+      user: { id: "u1", username: "vince", emailVerified: false },
+    }, { schemaVersion: 1 });
+
+    controller.attachPersistence(persistence);
+    apiClient.getSession = async () => {
+      apiClient.restoreCachedUser(null);
+      return null;
+    };
+    apiClient.getAccountProfile = async () => {
+      profileRequests += 1;
+      throw new ApiRequestError("Unauthorized", 401);
+    };
+
+    await controller.refreshSession();
+
+    expect(profileRequests).toBe(1);
+    expect(apiClient.getSessionToken()).toBeNull();
+    expect(apiClient.getCurrentUser()).toBeNull();
+    expect(controller.getSnapshot().user).toBeNull();
+    controller.dispose();
+  });
+
+  test("downgrades stale verification state when protected chat rejects it", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+
+    controller.attachPersistence(persistence);
+    apiClient.getSession = async () => {
+      apiClient.restoreCachedUser(null);
+      return null;
+    };
+    apiClient.getChatState = async () => {
+      throw new ApiRequestError("Email verification required", 403);
+    };
+
+    await controller.refreshSession();
+
+    expect(apiClient.getSessionToken()).toBe("token-123");
+    expect(apiClient.getCurrentUser()?.emailVerified).toBe(false);
+    expect(controller.getSnapshot().user?.emailVerified).toBe(false);
+    expect(persistence.getState<{
+      sessionToken: string;
+      user: { id: string; username: string; emailVerified: boolean };
+    }>("session", { schemaVersion: 1 })?.user.emailVerified).toBe(false);
+    controller.dispose();
+  });
+
+  test("does not let a stale validation failure clear a replacement session", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    let rejectProbe: ((error: Error) => void) | null = null;
+    let markProbeStarted: (() => void) | null = null;
+    const probeStarted = new Promise<void>((resolve) => {
+      markProbeStarted = resolve;
+    });
+
+    persistence.setState("session", {
+      sessionToken: "old-token",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+
+    controller.attachPersistence(persistence);
+    apiClient.getSession = async () => {
+      apiClient.restoreCachedUser(null);
+      return null;
+    };
+    apiClient.getChatState = () => new Promise((_, reject) => {
+      rejectProbe = reject;
+      markProbeStarted?.();
+    });
+
+    const refresh = controller.refreshSession();
+    await probeStarted;
+    controller.adoptSession("new-token", {
+      id: "u2",
+      username: "mara",
+      emailVerified: true,
+    });
+    rejectProbe?.(new ApiRequestError("Unauthorized", 401));
+    await refresh;
+
+    expect(apiClient.getSessionToken()).toBe("new-token");
+    expect(apiClient.getCurrentUser()?.id).toBe("u2");
+    expect(controller.getSnapshot().user?.id).toBe("u2");
+    expect(persistence.getState<{
+      sessionToken: string;
+      user: { id: string };
+    }>("session", { schemaVersion: 1 })).toMatchObject({
+      sessionToken: "new-token",
+      user: { id: "u2" },
+    });
+    controller.dispose();
+  });
+
+  test("does not apply stale chat state after a replacement session", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+    let resolveProbe: ((state: ChatStateResponse) => void) | null = null;
+    let markProbeStarted: (() => void) | null = null;
+    const probeStarted = new Promise<void>((resolve) => {
+      markProbeStarted = resolve;
+    });
+    const oldDirectChannel: ChatChannel = {
+      id: "dm:old-account",
+      name: "old-account",
+      kind: "direct",
+      created_at: "2026-03-28T00:00:00.000Z",
+    };
+
+    persistence.setState("session", {
+      sessionToken: "old-token",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+
+    controller.attachPersistence(persistence);
+    apiClient.getSession = async () => {
+      apiClient.restoreCachedUser(null);
+      return null;
+    };
+    apiClient.getChatState = () => new Promise<ChatStateResponse>((resolve) => {
+      resolveProbe = resolve;
+      markProbeStarted?.();
+    });
+
+    const refresh = controller.refreshSession();
+    await probeStarted;
+    controller.adoptSession("new-token", {
+      id: "u2",
+      username: "mara",
+      emailVerified: true,
+    });
+    resolveProbe?.({
+      channels: [...SERVER_CHAT_CHANNELS, oldDirectChannel],
+      onlineCount: 0,
+      channelStates: [],
+      notifications: [],
+    });
+    await refresh;
+
+    expect(apiClient.getSessionToken()).toBe("new-token");
+    expect(controller.getSnapshot().user?.id).toBe("u2");
+    expect(controller.getChannels()).not.toContainEqual(oldDirectChannel);
+    controller.dispose();
+  });
+
+  test("keeps a persisted session when the protected validation probe is offline", async () => {
+    const persistence = new MemoryPersistence();
+    const controller = new ChatController();
+
+    persistence.setState("session", {
+      sessionToken: "token-123",
+      user: { id: "u1", username: "vince", emailVerified: true },
+    }, { schemaVersion: 1 });
+
+    controller.attachPersistence(persistence);
+    apiClient.getSession = async () => {
+      apiClient.restoreCachedUser(null);
+      return null;
+    };
+    apiClient.getChatState = async () => {
+      throw new Error("network down");
+    };
+
+    await controller.refreshSession();
+
+    expect(apiClient.getSessionToken()).toBe("token-123");
+    expect(apiClient.getCurrentUser()?.id).toBe("u1");
+    expect(controller.getSnapshot().user?.id).toBe("u1");
     controller.dispose();
   });
 

--- a/src/plugins/builtin/chat/controller/channels.ts
+++ b/src/plugins/builtin/chat/controller/channels.ts
@@ -104,12 +104,13 @@ export class ChatControllerChannels {
     return request;
   }
 
-  async refreshChatState(): Promise<void> {
+  async refreshChatState(isCurrent: () => boolean = () => true): Promise<void> {
     if (!this.options.canLoadPrivateState()) {
       await this.refreshPresence();
       return;
     }
     const state = await apiClient.getChatState();
+    if (!isCurrent()) return;
     this.channels = normalizeChannels(state.channels);
     this.onlineCount = state.onlineCount;
     for (const entry of state.channelStates) {

--- a/src/plugins/builtin/chat/controller/index.ts
+++ b/src/plugins/builtin/chat/controller/index.ts
@@ -215,7 +215,7 @@ export class ChatController {
       ensureRealtimeSubscriptions: () => this.realtime.ensureRealtimeSubscriptions(),
       persistChannelState: (channelId) => this.storage.persistChannelState(channelId),
       persistSession: (sessionToken, user) => this.storage.persistSession(sessionToken, user),
-      refreshChatState: () => this.refreshChatState(),
+      refreshChatState: (isCurrent) => this.channelCatalog.refreshChatState(isCurrent),
       session: this.session,
       stopRealtimeSubscriptions: () => {
         this.realtime.stopRealtimeSubscriptions();

--- a/src/plugins/builtin/chat/controller/session-runtime.ts
+++ b/src/plugins/builtin/chat/controller/session-runtime.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "../../../../api-client";
+import { ApiRequestError } from "../../../../api-client/errors";
 import {
   DEFAULT_CHAT_CHANNEL_ID,
   type ChannelRuntimeState,
@@ -93,7 +94,7 @@ interface RefreshChatControllerSessionOptions {
   ensureRealtimeSubscriptions: () => void;
   persistChannelState: (channelId: string) => void;
   persistSession: (sessionToken: string | null, user: ChatSessionUser | null) => void;
-  refreshChatState: () => Promise<void>;
+  refreshChatState: (isCurrent?: () => boolean) => Promise<void>;
   session: ChatControllerSessionState;
   stopRealtimeSubscriptions: () => void;
   stopSafetyRefresh: () => void;
@@ -119,20 +120,83 @@ export async function refreshChatControllerSession({
   session.sessionToken = apiClient.getSessionToken();
   const apiSession = await apiClient.getSession();
   if (!apiSession) {
-    const persistedToken = apiClient.getSessionToken() || session.sessionToken;
-    // A 200 with no user is what /auth/get-session returns when no cookie
-    // reached the server. Desktop's backend process used to treat that as a
-    // real sign-out and persist a wiped token, so the next launch was logged
-    // out. Keep a captured native session; hard account-missing responses
-    // already clear the token inside getSession().
+    const persistedToken = apiClient.getSessionToken();
+    // A 200 with no user used to mean the desktop backend had not received the
+    // restored cookie yet, so do not discard a captured native session on that
+    // response alone. Probe another authenticated endpoint: success validates
+    // the token, a 401 proves it expired, and a transient failure keeps offline
+    // startup from signing the user out.
     if (persistedToken) {
       session.sessionToken = persistedToken;
       session.user = session.user ?? normalizeSessionUser(apiClient.getCurrentUser());
+      // getSession() clears the API client's cached user when the endpoint
+      // answers null. Keep both session views aligned while the protected
+      // request validates the preserved native credential.
+      apiClient.restoreCachedUser(session.user);
       session.sessionChecked = true;
       persistSession(session.sessionToken, session.user);
       emit();
+
+      const credentialIsCurrent = () =>
+        apiClient.getSessionToken() === persistedToken && session.sessionToken === persistedToken;
+      const handleValidationError = (error: unknown) => {
+        if (!(error instanceof ApiRequestError) || !credentialIsCurrent()) return;
+        if (error.status === 401) {
+          apiClient.setSessionToken(null);
+          session.sessionToken = null;
+          applySignedOut();
+          return;
+        }
+        if (error.status === 403 && session.user) {
+          session.user = { ...session.user, emailVerified: false };
+          apiClient.restoreCachedUser(session.user);
+          persistSession(session.sessionToken, session.user);
+          emit();
+          syncVerificationPolling();
+          stopSafetyRefresh();
+          stopRealtimeSubscriptions();
+        }
+      };
+
+      if (!session.user?.emailVerified) {
+        try {
+          const profile = await apiClient.getAccountProfile();
+          if (!credentialIsCurrent()) return;
+          const persistedProfile = {
+            ...profile,
+            updatedAt: profile.updatedAt ?? undefined,
+          };
+          session.user = normalizeSessionUser(persistedProfile);
+          apiClient.restoreCachedUser(persistedProfile);
+          persistSession(session.sessionToken, session.user);
+          emit();
+        } catch (error) {
+          handleValidationError(error);
+          return;
+        }
+
+        if (!session.user?.emailVerified) {
+          syncVerificationPolling();
+          stopSafetyRefresh();
+          stopRealtimeSubscriptions();
+          return;
+        }
+      }
+
+      try {
+        await refreshChatState(credentialIsCurrent);
+      } catch (error) {
+        handleValidationError(error);
+        return;
+      }
+      if (!credentialIsCurrent()) return;
+
+      stopVerificationPolling();
+      ensureRealtimeSubscriptions();
+      ensureOpenChannelConnections();
       return;
     }
+    session.sessionToken = null;
     applySignedOut();
     return;
   }


### PR DESCRIPTION
## Summary
- validate cached native sessions when `/auth/get-session` returns no user
- clear persisted sessions on a definitive 401 so the desktop shows signed-out state
- retain cached sessions through transient and offline failures
- validate expired unverified sessions and reconcile stale verification state
- prevent delayed validation failures, chat state, and response cookies from affecting a replacement login
- keep the controller and API client user caches aligned

## Why
An expired persisted desktop session left the cached user visible while private chat state failed with 401, producing an expanded but empty DMs section.

## Tests
- `bun test src/api-client/index.test.ts src/plugins/builtin/chat/controller.test.ts`
- `bun run typecheck`