### PR TITLE
Retry cloud session validation after outages

### DIFF
--- a/src/plugins/builtin/chat/controller.test.ts
+++ b/src/plugins/builtin/chat/controller.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
 import type { AppNotificationRequest } from "../../../types/plugin";
 import { MemoryPluginPersistence as MemoryPersistence } from "../../../test-support/plugin-persistence";
 import {
@@ -10,6 +10,7 @@ import {
 } from "../../../api-client";
 import { ApiRequestError } from "../../../api-client/errors";
 import { ChatController } from "./controller";
+import { SESSION_RETRY_MS } from "./controller/state";
 
 const TRANSCRIPT_KIND = "channel-transcript";
 const TRANSCRIPT_KEY = "everyone";
@@ -99,6 +100,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  jest.useRealTimers();
   apiClient.dispose();
   apiClient.setSessionToken(null);
   apiClient.setCookieSessionMode(false);
@@ -696,7 +698,8 @@ describe("ChatController", () => {
     controller.dispose();
   });
 
-  test("keeps a persisted session when the protected validation probe is offline", async () => {
+  test("revalidates a persisted session after an offline validation probe", async () => {
+    jest.useFakeTimers();
     const persistence = new MemoryPersistence();
     const controller = new ChatController();
 
@@ -719,7 +722,19 @@ describe("ChatController", () => {
     expect(apiClient.getSessionToken()).toBe("token-123");
     expect(apiClient.getCurrentUser()?.id).toBe("u1");
     expect(controller.getSnapshot().user?.id).toBe("u1");
+    expect((controller as any).realtime.sessionRetryTimer).not.toBeNull();
+
+    apiClient.getChatState = async () => {
+      throw new ApiRequestError("Unauthorized", 401);
+    };
+    jest.advanceTimersByTime(SESSION_RETRY_MS);
+    await controller.refreshSession();
+
+    expect(apiClient.getSessionToken()).toBeNull();
+    expect(controller.getSnapshot().user).toBeNull();
+    expect((controller as any).realtime.sessionRetryTimer).toBeNull();
     controller.dispose();
+    jest.useRealTimers();
   });
 
   test("signs out when get-session returns no user and no token is stored", async () => {
@@ -769,6 +784,8 @@ describe("ChatController", () => {
       username: "vince",
       emailVerified: true,
     });
+    expect((controller as any).realtime.sessionRetryTimer).not.toBeNull();
+    controller.dispose();
   });
 
   test("refreshes the public transcript without requiring a session", async () => {

--- a/src/plugins/builtin/chat/controller/index.ts
+++ b/src/plugins/builtin/chat/controller/index.ts
@@ -197,9 +197,15 @@ export class ChatController {
   /** Single-flight: every open chat pane calls this on mount. */
   async refreshSession(): Promise<void> {
     if (this.sessionRefreshPromise) return this.sessionRefreshPromise;
-    const request = this.runSessionRefresh().finally(() => {
-      this.sessionRefreshPromise = null;
-    });
+    this.realtime.stopSessionRetry();
+    const request = this.runSessionRefresh()
+      .catch((error) => {
+        this.realtime.scheduleSessionRetry();
+        throw error;
+      })
+      .finally(() => {
+        this.sessionRefreshPromise = null;
+      });
     this.sessionRefreshPromise = request;
     return request;
   }
@@ -216,6 +222,7 @@ export class ChatController {
       persistChannelState: (channelId) => this.storage.persistChannelState(channelId),
       persistSession: (sessionToken, user) => this.storage.persistSession(sessionToken, user),
       refreshChatState: (isCurrent) => this.channelCatalog.refreshChatState(isCurrent),
+      scheduleSessionRetry: () => this.realtime.scheduleSessionRetry(),
       session: this.session,
       stopRealtimeSubscriptions: () => {
         this.realtime.stopRealtimeSubscriptions();
@@ -337,11 +344,12 @@ export class ChatController {
     this.appActive = appActive;
     if (!appActive) {
       this.realtime.stopVerificationPolling();
+      this.realtime.stopSessionRetry();
       return;
     }
     this.markFocusedViewsViewed();
     this.realtime.syncVerificationPolling();
-    void this.refreshChatState()
+    void this.refreshSession()
       .then(() => this.markFocusedViewsViewed())
       .catch(() => {});
   }

--- a/src/plugins/builtin/chat/controller/realtime.ts
+++ b/src/plugins/builtin/chat/controller/realtime.ts
@@ -1,6 +1,7 @@
 import { apiClient, type ChatNotification } from "../../../../api-client";
 import {
   SAFETY_REFRESH_MS,
+  SESSION_RETRY_MS,
   VERIFICATION_POLL_MS,
 } from "./state";
 
@@ -18,6 +19,7 @@ interface ChatControllerRealtimeOptions {
 
 export class ChatControllerRealtime {
   private verificationPollTimer: ReturnType<typeof setInterval> | null = null;
+  private sessionRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private safetyRefreshTimer: ReturnType<typeof setInterval> | null = null;
   private chatNotificationUnsubscribe: (() => void) | null = null;
   private chatPresenceUnsubscribe: (() => void) | null = null;
@@ -34,6 +36,27 @@ export class ChatControllerRealtime {
     this.verificationPollTimer = setInterval(() => {
       void this.options.refreshSession().catch(() => {});
     }, VERIFICATION_POLL_MS);
+  }
+
+  scheduleSessionRetry(): void {
+    if (
+      this.sessionRetryTimer
+      || !this.options.getAppActive()
+      || !this.options.hasSession()
+    ) {
+      return;
+    }
+    this.sessionRetryTimer = setTimeout(() => {
+      this.sessionRetryTimer = null;
+      void this.options.refreshSession().catch(() => {});
+    }, SESSION_RETRY_MS);
+    this.sessionRetryTimer.unref?.();
+  }
+
+  stopSessionRetry(): void {
+    if (!this.sessionRetryTimer) return;
+    clearTimeout(this.sessionRetryTimer);
+    this.sessionRetryTimer = null;
   }
 
   ensureRealtimeSubscriptions(): void {
@@ -85,6 +108,7 @@ export class ChatControllerRealtime {
 
   stopAll(): void {
     this.stopVerificationPolling();
+    this.stopSessionRetry();
     this.stopSafetyRefresh();
     this.stopRealtimeSubscriptions();
   }

--- a/src/plugins/builtin/chat/controller/session-runtime.ts
+++ b/src/plugins/builtin/chat/controller/session-runtime.ts
@@ -95,6 +95,7 @@ interface RefreshChatControllerSessionOptions {
   persistChannelState: (channelId: string) => void;
   persistSession: (sessionToken: string | null, user: ChatSessionUser | null) => void;
   refreshChatState: (isCurrent?: () => boolean) => Promise<void>;
+  scheduleSessionRetry: () => void;
   session: ChatControllerSessionState;
   stopRealtimeSubscriptions: () => void;
   stopSafetyRefresh: () => void;
@@ -111,6 +112,7 @@ export async function refreshChatControllerSession({
   persistChannelState,
   persistSession,
   refreshChatState,
+  scheduleSessionRetry,
   session,
   stopRealtimeSubscriptions,
   stopSafetyRefresh,
@@ -140,14 +142,14 @@ export async function refreshChatControllerSession({
       const credentialIsCurrent = () =>
         apiClient.getSessionToken() === persistedToken && session.sessionToken === persistedToken;
       const handleValidationError = (error: unknown) => {
-        if (!(error instanceof ApiRequestError) || !credentialIsCurrent()) return;
-        if (error.status === 401) {
+        if (!credentialIsCurrent()) return;
+        if (error instanceof ApiRequestError && error.status === 401) {
           apiClient.setSessionToken(null);
           session.sessionToken = null;
           applySignedOut();
           return;
         }
-        if (error.status === 403 && session.user) {
+        if (error instanceof ApiRequestError && error.status === 403 && session.user) {
           session.user = { ...session.user, emailVerified: false };
           apiClient.restoreCachedUser(session.user);
           persistSession(session.sessionToken, session.user);
@@ -155,7 +157,9 @@ export async function refreshChatControllerSession({
           syncVerificationPolling();
           stopSafetyRefresh();
           stopRealtimeSubscriptions();
+          return;
         }
+        scheduleSessionRetry();
       };
 
       if (!session.user?.emailVerified) {
@@ -216,7 +220,7 @@ export async function refreshChatControllerSession({
   if (nextUser?.emailVerified) {
     stopVerificationPolling();
     ensureRealtimeSubscriptions();
-    await refreshChatState().catch(() => {});
+    await refreshChatState().catch(() => scheduleSessionRetry());
     ensureOpenChannelConnections();
     return;
   }

--- a/src/plugins/builtin/chat/controller/state.ts
+++ b/src/plugins/builtin/chat/controller/state.ts
@@ -21,6 +21,7 @@ export const TRANSCRIPT_CACHE_POLICY = {
 };
 export const DRAFT_SYNC_DEBOUNCE_MS = 250;
 export const VERIFICATION_POLL_MS = 5_000;
+export const SESSION_RETRY_MS = 30_000;
 export const SAFETY_REFRESH_MS = 30_000;
 export const PENDING_RECONCILE_WINDOW_MS = 2 * 60_000;
 


### PR DESCRIPTION
## Summary
- schedule a session validation retry after transient profile or chat-state failures
- retry every 30 seconds while the app remains active and a cached session exists
- validate the session again when the app returns to the foreground
- cancel pending retries when backgrounded, reset, signed out, or disposed

## Why
The expired-session fix intentionally retained cached credentials during outages, but a verified user had no later validation timer. If connectivity returned without remounting the chat UI, the empty DM state could persist.

## Tests
- `bun test src/plugins/builtin/chat/controller.test.ts src/api-client/index.test.ts`
- `bun run typecheck`