### PR TITLE
Let headless callers authenticate with GLOOMBERB_SESSION_TOKEN

### DIFF
--- a/src/cli/pane-functions/cloud-session.test.ts
+++ b/src/cli/pane-functions/cloud-session.test.ts
@@ -52,3 +52,26 @@ describe("pane function Cloud session", () => {
     }
   });
 });
+
+describe("cloud session token from the environment", () => {
+  test("prefers GLOOMBERB_SESSION_TOKEN over persisted state so containers can authenticate", () => {
+    const context = {
+      persistence: {
+        pluginState: {
+          get: () => ({ value: { sessionToken: "persisted-token" } }),
+        },
+      },
+    } as unknown as Parameters<typeof resolvePersistedCloudSessionToken>[0];
+
+    const previous = process.env.GLOOMBERB_SESSION_TOKEN;
+    try {
+      process.env.GLOOMBERB_SESSION_TOKEN = "env-token";
+      expect(resolvePersistedCloudSessionToken(context)).toBe("env-token");
+      delete process.env.GLOOMBERB_SESSION_TOKEN;
+      expect(resolvePersistedCloudSessionToken(context)).toBe("persisted-token");
+    } finally {
+      if (previous === undefined) delete process.env.GLOOMBERB_SESSION_TOKEN;
+      else process.env.GLOOMBERB_SESSION_TOKEN = previous;
+    }
+  });
+});

--- a/src/cli/pane-functions/cloud-session.ts
+++ b/src/cli/pane-functions/cloud-session.ts
@@ -8,9 +8,18 @@ interface PersistedCloudSession {
   sessionToken?: unknown;
 }
 
+/**
+ * A container has no local plugin state, so a bot or a CI job has no way to
+ * reach Pro gated panes. `GLOOMBERB_SESSION_TOKEN` gives headless callers the
+ * same session the desktop app persists after signing in, and it wins over the
+ * stored one so a service account can be pointed somewhere else without
+ * touching the user's own state.
+ */
 export function resolvePersistedCloudSessionToken(
   context: Pick<MarketContext, "persistence">,
 ): string | null {
+  const fromEnv = process.env.GLOOMBERB_SESSION_TOKEN?.trim();
+  if (fromEnv) return fromEnv;
   for (const key of CLOUD_SESSION_KEYS) {
     const value = context.persistence.pluginState.get<PersistedCloudSession>(
       CLOUD_PLUGIN_ID,


### PR DESCRIPTION
## Why

`gloomberb fn CALLS AAPL` and `fn ECT AAPL` answer `Unauthorized` anywhere without a signed in desktop, because the only source of a Cloud session is local plugin state written by the app. That blocks the social publisher container from earnings transcripts, and it would block any CI job or service account.

## What

`resolvePersistedCloudSessionToken` reads `GLOOMBERB_SESSION_TOKEN` first and falls back to the persisted session. Nothing else changes: `withPersistedCloudSession` still restores the previous token afterwards, and no token is written to disk.

## Verify

With a Pro service account token exported, `gloomberb fn CALLS AAPL --json` returns `source: "headless"` with 2 rows, where it previously returned `Unauthorized`. `bun test src/cli/pane-functions` passes (49 tests). Note the pre-existing `TS2769` in `cloud-session.test.ts` line 48 is on `main` already and unrelated.