### PR TITLE
Open the browser first visit as a three-pane research workspace

### DIFF
--- a/src/renderers/browser/config-host.test.ts
+++ b/src/renderers/browser/config-host.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+import { getDockedPaneIds } from "../../plugins/pane-manager/dock-tree";
+import {
+  BROWSER_RESEARCH_CHART_ID,
+  BROWSER_RESEARCH_NEWS_ID,
+  BROWSER_RESEARCH_PANE_ID,
+  createBrowserConfigStore,
+} from "./config-host";
+import type { StorageLike } from "./storage";
+
+function memoryStorage(): StorageLike {
+  const map = new Map<string, string>();
+  return {
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => { map.set(key, value); },
+    removeItem: (key) => { map.delete(key); },
+  };
+}
+
+test("a first visit opens one company across research, chart, and news panes", async () => {
+  const store = createBrowserConfigStore(memoryStorage(), "?ticker=aapl&tab=financials");
+  const config = await store.loadConfig("browser://local");
+
+  expect(config.layouts[0]?.name).toBe("Research");
+  expect(getDockedPaneIds(config.layout)).toEqual([
+    BROWSER_RESEARCH_PANE_ID,
+    BROWSER_RESEARCH_CHART_ID,
+    BROWSER_RESEARCH_NEWS_ID,
+  ]);
+
+  const byId = new Map(config.layout.instances.map((instance) => [instance.instanceId, instance]));
+  expect(byId.get(BROWSER_RESEARCH_PANE_ID)?.binding).toEqual({ kind: "fixed", symbol: "AAPL" });
+  expect(byId.get(BROWSER_RESEARCH_CHART_ID)?.binding).toEqual({
+    kind: "follow",
+    sourceInstanceId: BROWSER_RESEARCH_PANE_ID,
+  });
+  expect(byId.get(BROWSER_RESEARCH_NEWS_ID)?.binding).toEqual({
+    kind: "follow",
+    sourceInstanceId: BROWSER_RESEARCH_PANE_ID,
+  });
+  expect(config.layouts[0]?.paneState?.[BROWSER_RESEARCH_PANE_ID]).toEqual({ activeTabId: "financials" });
+  expect(config.onboardingComplete).toBe(true);
+});
+
+test("a visit without a research link still opens NVDA", async () => {
+  const store = createBrowserConfigStore(memoryStorage());
+  const config = await store.loadConfig("browser://local");
+  const research = config.layout.instances.find((instance) => instance.instanceId === BROWSER_RESEARCH_PANE_ID);
+  expect(research?.binding).toEqual({ kind: "fixed", symbol: "NVDA" });
+});
+
+test("a returning visitor keeps the saved layout", async () => {
+  const storage = memoryStorage();
+  const first = createBrowserConfigStore(storage, "?ticker=NVDA");
+  await first.saveConfig(await first.loadConfig("browser://local"));
+
+  const second = createBrowserConfigStore(storage, "?ticker=MSFT");
+  const restored = await second.loadConfig("browser://local");
+  const research = restored.layout.instances.find((instance) => instance.instanceId === BROWSER_RESEARCH_PANE_ID);
+  expect(research?.binding).toEqual({ kind: "fixed", symbol: "NVDA" });
+  expect(getDockedPaneIds(restored.layout)).toHaveLength(3);
+});

--- a/src/renderers/browser/config-host.ts
+++ b/src/renderers/browser/config-host.ts
@@ -6,7 +6,13 @@ import {
   normalizeConfigForSave,
   normalizeLoadedConfig,
 } from "../../data/config/store/normalize";
-import { createDefaultConfig, TICKER_RESEARCH_PANE_ID, type AppConfig } from "../../types/config";
+import {
+  CHART_COMPOSER_PANE_ID,
+  createDefaultConfig,
+  TICKER_RESEARCH_PANE_ID,
+  type AppConfig,
+  type LayoutConfig,
+} from "../../types/config";
 import { researchEntryFromSearch } from "./research-entry";
 import { BROWSER_STORAGE_KEYS, SafeJsonStorage, type StorageLike } from "./storage";
 
@@ -16,20 +22,63 @@ function browserReady(config: AppConfig): AppConfig {
   return { ...config, onboardingComplete: true, onboardingProgress: undefined };
 }
 
+export const BROWSER_RESEARCH_PANE_ID = "ticker-detail:main";
+export const BROWSER_RESEARCH_CHART_ID = "chart-composer:research";
+export const BROWSER_RESEARCH_NEWS_ID = "ticker-news:research";
+
+/**
+ * The first-visit workspace: one company across three panes. The research
+ * pane owns the symbol; the chart and news panes follow it, so typing a new
+ * ticker while the research pane is focused swaps the whole screen.
+ */
+export function createBrowserResearchLayout(symbol: string): LayoutConfig {
+  return {
+    dockRoot: {
+      kind: "split",
+      axis: "horizontal",
+      ratio: 0.58,
+      first: { kind: "pane", instanceId: BROWSER_RESEARCH_PANE_ID },
+      second: {
+        kind: "split",
+        axis: "vertical",
+        ratio: 0.52,
+        first: { kind: "pane", instanceId: BROWSER_RESEARCH_CHART_ID },
+        second: { kind: "pane", instanceId: BROWSER_RESEARCH_NEWS_ID },
+      },
+    },
+    instances: [
+      {
+        instanceId: BROWSER_RESEARCH_PANE_ID,
+        paneId: TICKER_RESEARCH_PANE_ID,
+        binding: { kind: "fixed", symbol },
+        settings: { hideTabs: false },
+      },
+      {
+        instanceId: BROWSER_RESEARCH_CHART_ID,
+        paneId: CHART_COMPOSER_PANE_ID,
+        binding: { kind: "follow", sourceInstanceId: BROWSER_RESEARCH_PANE_ID },
+      },
+      {
+        instanceId: BROWSER_RESEARCH_NEWS_ID,
+        paneId: "ticker-news",
+        binding: { kind: "follow", sourceInstanceId: BROWSER_RESEARCH_PANE_ID },
+      },
+    ],
+    floating: [],
+    detached: [],
+  };
+}
+
 function createBrowserDefaultConfig(dataDir: string, search = ""): AppConfig {
   const config = createDefaultConfig(dataDir);
   const entry = researchEntryFromSearch(search) ?? { symbol: "NVDA", tab: "overview" };
-  // A first visit starts with one useful research pane. Saved layouts retain
-  // their existing panes and bindings when a visitor returns.
+  // A first visit starts with a research workspace for one company. Saved
+  // layouts retain their existing panes and bindings when a visitor returns.
   config.layouts[0] = {
     name: "Research",
-    layout: {
-      dockRoot: { kind: "pane", instanceId: "ticker-detail:main" },
-      instances: [{ instanceId: "ticker-detail:main", paneId: TICKER_RESEARCH_PANE_ID,
-        binding: { kind: "fixed", symbol: entry.symbol }, settings: { hideTabs: false } }],
-      floating: [], detached: [],
-    },
-    paneState: { "ticker-detail:main": { activeTabId: entry.tab } },
+    layout: createBrowserResearchLayout(entry.symbol),
+    paneState: { [BROWSER_RESEARCH_PANE_ID]: { activeTabId: entry.tab } },
+    focusedPaneId: BROWSER_RESEARCH_PANE_ID,
   };
   config.layout = config.layouts[0].layout;
   return browserReady(config);


### PR DESCRIPTION
The first visit to term.gloom.sh showed a single company pane. At a normal desktop width that reads as a stock quote page with a lot of empty space, not a research terminal, and the homepage preview captured from it looked the same.

This builds the browser `Research` layout as three panes on one company: research overview (58%), with a price chart and ticker news stacked on the right. The chart and news panes use a `follow` binding on the research pane, so typing a new ticker while the research pane is focused swaps all three. The deep link still resolves to the existing fixed pane, so `?ticker=NVDA` does not open a duplicate.

Returning visitors keep their saved layout, as before.

Validation: new `config-host.test.ts` covers the layout shape, bindings, the NVDA fallback, and saved-layout precedence. `bun test src/renderers/browser` and `typecheck:browser` pass. Previewed locally with `wrangler dev` at 1440x900.

Follow-up in gloomberb-platform: bump `terminal/gloomberb-ref` and capture the homepage screenshot from this layout.