### PR TITLE
Keep Windows smoke cleanup from failing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-latest
@@ -157,6 +158,7 @@ jobs:
       - build
       - desktop-macos
       - desktop-windows
+    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -165,6 +167,18 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+
+      - name: Check release assets
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(dist/*.dmg dist/*.exe dist/*.gz dist/*.json dist/*.zip dist/*.zst)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No release artifacts were produced."
+            exit 1
+          fi
+          printf 'Uploading %s release artifacts:\n' "${#files[@]}"
+          printf '  %s\n' "${files[@]}"
 
       - name: Upload assets to GitHub release
         uses: softprops/action-gh-release@v2
@@ -193,6 +207,10 @@ jobs:
 
           VERSION="${GITHUB_REF_NAME#v}"
           ZIP_PATH="dist/stable-macos-arm64-Gloomberb.app.zip"
+          if [ ! -f "$ZIP_PATH" ]; then
+            echo "macOS desktop zip is missing; skipping Homebrew tap update."
+            exit 0
+          fi
           SHA256="$(sha256sum "$ZIP_PATH" | awk '{print $1}')"
           TAP_DIR="$RUNNER_TEMP/homebrew-tap"
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -82,6 +82,28 @@ function canRunTarget(os: string, arch: string): boolean {
   return hostOs === os && hostArch === arch;
 }
 
+function isRetryableCleanupError(error: unknown): boolean {
+  if (!error || typeof error !== "object" || !("code" in error)) return false;
+  const code = String(error.code);
+  return code === "EBUSY" || code === "EPERM" || code === "ENOTEMPTY";
+}
+
+async function removeSmokeDir(smokeDir: string) {
+  const delaysMs = process.platform === "win32" ? [0, 100, 250, 500, 1000] : [0];
+  let lastError: unknown;
+  for (const delayMs of delaysMs) {
+    if (delayMs > 0) await Bun.sleep(delayMs);
+    try {
+      rmSync(smokeDir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableCleanupError(error)) throw error;
+    }
+  }
+  console.warn(`Could not remove smoke test directory ${smokeDir}:`, lastError);
+}
+
 async function smokeTestBinary(outfile: string, os: string, arch: string) {
   if (!canRunTarget(os, arch)) {
     console.log(`Skipping smoke test for ${os}-${arch} on ${process.platform}-${process.arch}`);
@@ -124,7 +146,7 @@ async function smokeTestBinary(outfile: string, os: string, arch: string) {
       }
     }
   } finally {
-    rmSync(smokeDir, { recursive: true, force: true });
+    await removeSmokeDir(smokeDir);
   }
 
   if (failureMessage) {


### PR DESCRIPTION
## Summary
- v0.13.2 shipped with no GitHub assets because the Windows CLI smoke test passed, then `rmSync` of the temp copy hit `EBUSY` and failed the whole Release workflow ([run](https://github.com/gloom-sh/gloomberb/actions/runs/33991815504), #727).
- Retry that cleanup on Windows and warn instead of failing the build if the directory stays locked.
- Keep uploading whatever artifacts a tag build did produce, so one platform flake cannot blank the GitHub release.

## Test plan
- [ ] Confirm `scripts/build.ts` still smoke-tests the packaged binary, then gzips `dist/`.
- [ ] On the next tag release, a Windows `EBUSY` during smoke cleanup should not skip asset upload, Homebrew, or npm.