### PR TITLE
Stop macOS installs from handing Intel Macs an arm64 build

### DIFF
--- a/.github/workflows/verify-desktop-homebrew.yml
+++ b/.github/workflows/verify-desktop-homebrew.yml
@@ -111,6 +111,7 @@ jobs:
 
           ruby -c "$tap_dir/Casks/gloomberb.rb"
           grep -q 'stable-macos-arm64-Gloomberb.app.zip' "$tap_dir/Casks/gloomberb.rb"
+          grep -q 'depends_on arch: :arm64' "$tap_dir/Casks/gloomberb.rb"
           grep -q 'binary "#{appdir}/Gloomberb.app/Contents/Resources/gloomberb", target: "gloomberb"' "$tap_dir/Casks/gloomberb.rb"
 
           cd "$tap_dir"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ curl -fsSL gloom.sh/install | bash
 
 Both install `Gloomberb.app` and a `gloomberb` command that runs the TUI through the app bundle, so the bundled runtime is stored once.
 
+macOS builds are Apple Silicon (arm64) only. Intel Macs are not supported: the install script and the Homebrew cask stop with an error instead of installing an app that cannot launch. Run [term.gloom.sh](https://term.gloom.sh) in the browser there, and follow [issue #539](https://github.com/gloom-sh/gloomberb/issues/539) for Intel support.
+
 Prefer a direct download?
 
 - [Download Gloomberb for Mac](https://gloom.sh/download/desktop)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,7 +13,7 @@ case "$OS" in
   Darwin) os="darwin" ;;
   Linux)  os="linux" ;;
   *)
-    echo "Unsupported OS: $OS"
+    echo "Unsupported OS: $OS" >&2
     exit 1
     ;;
 esac
@@ -22,7 +22,7 @@ case "$ARCH" in
   arm64|aarch64) arch="arm64" ;;
   x86_64|amd64)  arch="x64" ;;
   *)
-    echo "Unsupported architecture: $ARCH"
+    echo "Unsupported architecture: $ARCH" >&2
     exit 1
     ;;
 esac
@@ -35,7 +35,13 @@ if [ "$os" = "darwin" ] && [ "$arch" = "x64" ]; then
   if [ "$translated" = "1" ] || [ "$has_arm64" = "1" ]; then
     arch="arm64"
   else
-    echo "Intel Macs are not supported. Gloomberb currently ships Apple Silicon (arm64) only."
+    echo "Gloomberb does not support Intel Macs yet, so nothing was installed." >&2
+    echo "" >&2
+    echo "The macOS build is Apple Silicon (arm64) only. Installing it on this machine" >&2
+    echo "would fail at launch with 'Bad CPU type in executable'." >&2
+    echo "" >&2
+    echo "In the meantime you can run Gloomberb in the browser: https://term.gloom.sh" >&2
+    echo "Intel support is tracked at https://github.com/gloom-sh/gloomberb/issues/539" >&2
     exit 1
   fi
 fi
@@ -48,7 +54,7 @@ download_file() {
   elif command -v wget >/dev/null 2>&1; then
     wget -q --show-progress "$url" -O "$dest"
   else
-    echo "Error: curl or wget required"
+    echo "Error: curl or wget required" >&2
     exit 1
   fi
 }
@@ -106,7 +112,7 @@ install_macos_app() {
   fi
 
   if [ ! -d "$APP_PATH" ]; then
-    echo "Error: ${ASSET} did not contain Gloomberb.app"
+    echo "Error: ${ASSET} did not contain Gloomberb.app" >&2
     exit 1
   fi
 
@@ -123,7 +129,7 @@ install_macos_app() {
 
   APP_CLI="${DEST_APP}/Contents/Resources/gloomberb"
   if [ ! -x "$APP_CLI" ]; then
-    echo "Error: installed app is missing the gloomberb terminal shim"
+    echo "Error: installed app is missing the gloomberb terminal shim" >&2
     exit 1
   fi
 

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const installScript = join(import.meta.dir, "install.sh");
+
+interface FakeMachine {
+  /** What `uname -s` reports. */
+  unameSystem: string;
+  /** What `uname -m` reports. */
+  unameMachine: string;
+  /** `sysctl -n sysctl.proc_translated`, unset when the key does not exist. */
+  procTranslated?: string;
+  /** `sysctl -n hw.optional.arm64`, unset when the key does not exist. */
+  hardwareArm64?: string;
+}
+
+interface InstallRun {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  /** Every argument passed to the stubbed downloader, one per line. */
+  downloadLog: string;
+}
+
+let workDir = "";
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), "gloomberb-install-"));
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+function writeStub(binDir: string, name: string, body: string) {
+  const path = join(binDir, name);
+  writeFileSync(path, `#!/bin/sh\n${body}`);
+  chmodSync(path, 0o755);
+}
+
+/**
+ * Runs the real install script against a fake machine. Downloads are stubbed
+ * out and always fail, so the script never touches the network and the test
+ * can assert on which asset it asked for.
+ */
+async function runInstall(machine: FakeMachine): Promise<InstallRun> {
+  const binDir = join(workDir, "bin");
+  const installDir = join(workDir, "install");
+  const appDir = join(workDir, "Applications");
+  const downloadLog = join(workDir, "downloads.log");
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(installDir, { recursive: true });
+  mkdirSync(appDir, { recursive: true });
+
+  writeStub(binDir, "uname", [
+    'case "$1" in',
+    '  -m) printf "%s\\n" "$FAKE_UNAME_MACHINE" ;;',
+    '  *) printf "%s\\n" "$FAKE_UNAME_SYSTEM" ;;',
+    "esac",
+  ].join("\n"));
+
+  writeStub(binDir, "sysctl", [
+    '# Only -n <key> is used by the installer.',
+    'case "$2" in',
+    '  sysctl.proc_translated) value="$FAKE_PROC_TRANSLATED" ;;',
+    '  hw.optional.arm64) value="$FAKE_HW_ARM64" ;;',
+    '  *) value="" ;;',
+    "esac",
+    'if [ -z "$value" ]; then',
+    '  echo "sysctl: unknown oid \'$2\'" >&2',
+    "  exit 1",
+    "fi",
+    'printf "%s\\n" "$value"',
+  ].join("\n"));
+
+  writeStub(binDir, "curl", [
+    'for arg in "$@"; do printf "%s\\n" "$arg" >> "$FAKE_DOWNLOAD_LOG"; done',
+    "exit 22",
+  ].join("\n"));
+
+  writeStub(binDir, "wget", [
+    'for arg in "$@"; do printf "%s\\n" "$arg" >> "$FAKE_DOWNLOAD_LOG"; done',
+    "exit 8",
+  ].join("\n"));
+
+  const proc = Bun.spawn(["sh", installScript], {
+    cwd: workDir,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      GLOOMBERB_INSTALL_DIR: installDir,
+      GLOOMBERB_APP_DIR: appDir,
+      FAKE_UNAME_SYSTEM: machine.unameSystem,
+      FAKE_UNAME_MACHINE: machine.unameMachine,
+      FAKE_PROC_TRANSLATED: machine.procTranslated ?? "",
+      FAKE_HW_ARM64: machine.hardwareArm64 ?? "",
+      FAKE_DOWNLOAD_LOG: downloadLog,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return {
+    exitCode,
+    stdout,
+    stderr,
+    downloadLog: existsSync(downloadLog) ? readFileSync(downloadLog, "utf8") : "",
+  };
+}
+
+describe("install.sh architecture detection", () => {
+  // https://github.com/gloom-sh/gloomberb/issues/539: an Intel Mac used to get
+  // the arm64 app and only found out at launch, with "Bad CPU type in
+  // executable".
+  test("refuses to install anything on a genuine Intel Mac", async () => {
+    const run = await runInstall({
+      unameSystem: "Darwin",
+      unameMachine: "x86_64",
+    });
+
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("does not support Intel Macs");
+    expect(run.stderr).toContain("https://term.gloom.sh");
+    expect(run.downloadLog).toBe("");
+  });
+
+  test("installs the arm64 app from an x86_64 shell translated by Rosetta", async () => {
+    const run = await runInstall({
+      unameSystem: "Darwin",
+      unameMachine: "x86_64",
+      procTranslated: "1",
+    });
+
+    expect(run.downloadLog).toContain("stable-macos-arm64-Gloomberb.app.zip");
+    expect(run.stderr).not.toContain("does not support Intel Macs");
+  });
+
+  test("installs the arm64 app on an Apple Silicon Mac", async () => {
+    const run = await runInstall({
+      unameSystem: "Darwin",
+      unameMachine: "arm64",
+      hardwareArm64: "1",
+    });
+
+    expect(run.downloadLog).toContain("stable-macos-arm64-Gloomberb.app.zip");
+  });
+
+  test("installs the x64 binary on Linux", async () => {
+    const run = await runInstall({
+      unameSystem: "Linux",
+      unameMachine: "x86_64",
+    });
+
+    expect(run.downloadLog).toContain("gloomberb-linux-x64.gz");
+  });
+
+  test("installs the arm64 binary on Linux", async () => {
+    const run = await runInstall({
+      unameSystem: "Linux",
+      unameMachine: "aarch64",
+    });
+
+    expect(run.downloadLog).toContain("gloomberb-linux-arm64.gz");
+  });
+
+  test("rejects an unsupported operating system", async () => {
+    const run = await runInstall({
+      unameSystem: "FreeBSD",
+      unameMachine: "x86_64",
+    });
+
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr).toContain("Unsupported OS: FreeBSD");
+    expect(run.downloadLog).toBe("");
+  });
+});

--- a/scripts/write-homebrew-cask.test.ts
+++ b/scripts/write-homebrew-cask.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const caskScript = join(import.meta.dir, "write-homebrew-cask.ts");
+
+let workDir = "";
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), "gloomberb-cask-"));
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+async function renderCask(): Promise<string> {
+  const output = join(workDir, "gloomberb.rb");
+  const proc = Bun.spawn([
+    "bun",
+    "run",
+    caskScript,
+    "--version",
+    "1.2.3",
+    "--sha256",
+    "a".repeat(64),
+    "--output",
+    output,
+  ], { stdout: "pipe", stderr: "pipe" });
+
+  const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+
+  return readFileSync(output, "utf8");
+}
+
+describe("write-homebrew-cask", () => {
+  // The cask points at an Apple Silicon app bundle, so Homebrew has to refuse
+  // Intel Macs instead of installing something that cannot launch.
+  // https://github.com/gloom-sh/gloomberb/issues/539
+  test("declares the cask as Apple Silicon only", async () => {
+    expect(await renderCask()).toContain("depends_on arch: :arm64");
+  });
+
+  test("keeps the app bundle and terminal command wiring", async () => {
+    const cask = await renderCask();
+
+    expect(cask).toContain(
+      'url "https://github.com/gloom-sh/gloomberb/releases/download/v#{version}/stable-macos-arm64-Gloomberb.app.zip"',
+    );
+    expect(cask).toContain('app "Gloomberb.app"');
+    expect(cask).toContain(
+      'binary "#{appdir}/Gloomberb.app/Contents/Resources/gloomberb", target: "gloomberb"',
+    );
+  });
+});

--- a/scripts/write-homebrew-cask.ts
+++ b/scripts/write-homebrew-cask.ts
@@ -66,6 +66,10 @@ function renderCask({ version, sha256 }: Pick<Options, "version" | "sha256">): s
 
   auto_updates true
 
+  # The published app bundle is Apple Silicon only. Without this, Homebrew
+  # installs an app on Intel Macs that dies with "Bad CPU type in executable".
+  depends_on arch: :arm64
+
   app "Gloomberb.app"
   binary "#{appdir}/Gloomberb.app/Contents/Resources/gloomberb", target: "gloomberb"
 

--- a/src/updater.test.ts
+++ b/src/updater.test.ts
@@ -25,7 +25,7 @@ afterEach(() => {
 
 function expectedAssetName(compressed = false): string {
   const os = process.platform === "darwin" ? "darwin" : process.platform === "win32" ? "windows" : "linux";
-  const arch = os === "darwin" || process.arch === "arm64" ? "arm64" : "x64";
+  const arch = process.arch === "arm64" ? "arm64" : "x64";
   const extension = os === "windows" ? ".exe" : "";
   return compressed ? `gloomberb-${os}-${arch}${extension}.gz` : `gloomberb-${os}-${arch}${extension}`;
 }
@@ -36,6 +36,22 @@ describe("getAssetBaseNameForRuntime", () => {
       platform: "win32",
       arch: "x64",
     })).toBe("gloomberb-windows-x64.exe");
+  });
+
+  test("keeps macOS arm64 runtimes on the arm64 asset", () => {
+    expect(getAssetBaseNameForRuntime({
+      platform: "darwin",
+      arch: "arm64",
+    })).toBe("gloomberb-darwin-arm64");
+  });
+
+  // An arm64 asset cannot run on an x64 macOS runtime, so it must never be
+  // offered as that runtime's update.
+  test("asks for an x64 asset on an x64 macOS runtime", () => {
+    expect(getAssetBaseNameForRuntime({
+      platform: "darwin",
+      arch: "x64",
+    })).toBe("gloomberb-darwin-x64");
   });
 });
 

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -62,8 +62,10 @@ export function getAssetBaseNameForRuntime(
     : runtimeProcess?.platform === "win32"
       ? "windows"
       : "linux";
-  // macOS x64 uses arm64 binary (runs via Rosetta 2)
-  const arch = os === "darwin" || runtimeProcess?.arch === "arm64" ? "arm64" : "x64";
+  // Always update to the architecture the current runtime actually is. macOS
+  // only publishes arm64 today, so an x64 macOS runtime resolves no asset and
+  // reports that instead of overwriting itself with an unrunnable binary.
+  const arch = runtimeProcess?.arch === "arm64" ? "arm64" : "x64";
   const extension = os === "windows" ? ".exe" : "";
   return `gloomberb-${os}-${arch}${extension}`;
 }


### PR DESCRIPTION
## Why

`install.sh` learned to refuse genuine Intel Macs in #642, but the other macOS install paths still hand Intel users an Apple Silicon build that only fails at launch with `Bad CPU type in executable` (#539).

## What

- **Homebrew cask**: generated cask now declares `depends_on arch: :arm64`, so `brew install --cask vincelwt/tap/gloomberb` refuses Intel Macs up front instead of installing an app that cannot launch. The desktop/homebrew verify workflow asserts the guard.
- **Self-updater**: `getAssetBaseNameForRuntime` mapped *every* darwin runtime to the arm64 asset. It now uses the running architecture, so an x64 macOS runtime reports "no compatible release asset" instead of replacing a working install with an unrunnable binary. This is also the piece that would silently break if a `darwin-x64` build ever ships.
- **Installer message**: the Intel branch now says nothing was installed, explains why, points at https://term.gloom.sh, and links #539. Installer errors go to stderr.
- **README**: the macOS section states Apple Silicon only.

## Tests

- `scripts/install.test.ts` runs the real script against fake `uname`/`sysctl`/`curl`: genuine Intel Mac installs nothing and exits non-zero, Rosetta-translated shells and Apple Silicon still get the arm64 app, Linux x64/arm64 still resolve their assets. Verified it fails if the Intel guard is reverted.
- `scripts/write-homebrew-cask.test.ts` covers the arch guard and the app/binary wiring.
- `src/updater.test.ts` covers darwin arm64 vs x64 asset resolution.

`bun test` (2587 pass) and `bun run typecheck:scripts` are green.

## Not in this PR

Whether to publish an actual `darwin-x64` build is a product/release call. Groundwork exists (`@opentui/core-darwin-x64` is already an optional dep of `@opentui/core` and `bun build --compile --target=bun-darwin-x64` is supported), so the TUI binary is a small matrix addition. The Electrobun `.app` is the expensive half.

Refs #539