### PR TITLE
Render pane screenshots from the routed provider

### DIFF
--- a/src/cli/desktop-pane-shot.ts
+++ b/src/cli/desktop-pane-shot.ts
@@ -56,6 +56,33 @@ export interface DesktopPaneShotApiProxy {
   sessionToken: string | null;
 }
 
+/**
+ * The page renders panes that fetch their own data. Left alone it can only
+ * reach the cloud API, so a pane whose values come from a provider the router
+ * merges in (analyst price targets, Yahoo dividends) rendered thinner than the
+ * same pane in the terminal. The bridge lets the page ask the Bun process to
+ * run those requests through the real provider router instead.
+ */
+export interface DesktopPaneShotBridge {
+  marketData(operation: string, args: unknown[]): Promise<unknown>;
+  httpFetch(request: DesktopPaneShotHttpRequest): Promise<DesktopPaneShotHttpResponse>;
+}
+
+export interface DesktopPaneShotHttpRequest {
+  url: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+export interface DesktopPaneShotHttpResponse {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  setCookie: string[];
+  body: string;
+}
+
 export interface DesktopPaneShotRenderedCell {
   columnId?: string;
   columnLabel: string;
@@ -109,13 +136,15 @@ const SHOT_READY_TIMEOUT_MS = 45_000;
 const CDP_CALL_TIMEOUT_MS = 10_000;
 const DEFAULT_DEVICE_SCALE_FACTOR = 2;
 const SHOT_API_PROXY_PREFIX = "/__gloom_cli_api__";
+export const SHOT_MARKET_BRIDGE_PATH = "/__gloom_cli_market__";
+export const SHOT_HTTP_BRIDGE_PATH = "/__gloom_cli_http__";
 const SESSION_COOKIE_NAMES = ["__Secure-gloomberb.session_token", "gloomberb.session_token"] as const;
 
 export async function renderDesktopPaneScreenshot(
   payload: DesktopPaneShotPayload,
   outputPath: string,
   apiProxy: DesktopPaneShotApiProxy,
-  options: { captureImage?: boolean } = {},
+  options: { captureImage?: boolean; bridge?: DesktopPaneShotBridge } = {},
 ): Promise<DesktopPaneShotRenderResult> {
   const tempDir = await mkdtemp(join(tmpdir(), "gloom-pane-shot-"));
   let server: ReturnType<typeof Bun.serve> | null = null;
@@ -123,7 +152,7 @@ export async function renderDesktopPaneScreenshot(
     const outdir = join(tempDir, "assets");
     await mkdir(outdir, { recursive: true });
     await buildShotPage(outdir, payload);
-    server = serveShotPage(outdir, apiProxy);
+    server = serveShotPage(outdir, apiProxy, options.bridge ?? null);
     const chrome = await findChromeExecutable();
     return await capturePageScreenshot({
       chrome,
@@ -183,6 +212,7 @@ async function buildShotPage(outdir: string, payload: DesktopPaneShotPayload): P
 function serveShotPage(
   outdir: string,
   apiProxy: DesktopPaneShotApiProxy,
+  bridge: DesktopPaneShotBridge | null,
 ): ReturnType<typeof Bun.serve> {
   const staticRoot = resolve(outdir);
   return Bun.serve({
@@ -194,9 +224,49 @@ function serveShotPage(
       if (url.pathname.startsWith(`${SHOT_API_PROXY_PREFIX}/`)) {
         return proxyShotApiRequest(request, url, apiProxy);
       }
+      if (url.pathname === SHOT_MARKET_BRIDGE_PATH) {
+        return runShotMarketBridge(request, bridge);
+      }
+      if (url.pathname === SHOT_HTTP_BRIDGE_PATH) {
+        return runShotHttpBridge(request, bridge);
+      }
       return serveShotAsset(url, staticRoot);
     },
   });
+}
+
+async function runShotMarketBridge(
+  request: Request,
+  bridge: DesktopPaneShotBridge | null,
+): Promise<Response> {
+  if (!bridge) return Response.json({ ok: false, error: "No market bridge" }, { status: 404 });
+  try {
+    const payload = await request.json() as { operation?: unknown; args?: unknown };
+    const operation = typeof payload.operation === "string" ? payload.operation : "";
+    const args = Array.isArray(payload.args) ? payload.args : [];
+    const data = await bridge.marketData(operation, args);
+    return Response.json({ ok: true, data });
+  } catch (error) {
+    return Response.json({ ok: false, error: errorMessage(error) });
+  }
+}
+
+async function runShotHttpBridge(
+  request: Request,
+  bridge: DesktopPaneShotBridge | null,
+): Promise<Response> {
+  if (!bridge) return Response.json({ ok: false, error: "No HTTP bridge" }, { status: 404 });
+  try {
+    const payload = await request.json() as DesktopPaneShotHttpRequest;
+    const data = await bridge.httpFetch(payload);
+    return Response.json({ ok: true, data });
+  } catch (error) {
+    return Response.json({ ok: false, error: errorMessage(error) });
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 async function serveShotAsset(url: URL, staticRoot: string): Promise<Response> {

--- a/src/cli/pane-functions/screenshot.test.ts
+++ b/src/cli/pane-functions/screenshot.test.ts
@@ -3,6 +3,7 @@ import type { RemoteUiNodeSnapshot } from "../../remote/types";
 import {
   chartSeriesEvidenceWithinRange,
   chartEvidenceMismatchesFor,
+  createDesktopShotBridge,
   isPaneScreenshotUsable,
   missingActiveTabSelections,
   resolveDesktopShotApiProxy,
@@ -91,6 +92,32 @@ describe("pane screenshot payload credentials", () => {
       paneState: { pane: { pluginState: { service: { tab: "latest" } } } },
     });
     expect(JSON.stringify(payload)).not.toContain("private-");
+  });
+});
+
+describe("pane screenshot market bridge", () => {
+  /**
+   * The page can only reach the cloud API on its own, and the cloud carries no
+   * per-rating price targets. Serving research requests from the router is what
+   * keeps a screenshot showing the same values as `gloomberb fn`.
+   */
+  test("answers research requests from the routed provider and refuses anything else", async () => {
+    const calls: Array<[string, unknown[]]> = [];
+    const bridge = createDesktopShotBridge({
+      dataProvider: {
+        getAnalystResearch: (...args: unknown[]) => {
+          calls.push(["getAnalystResearch", args]);
+          return Promise.resolve({ symbol: "NKE", ratings: [{ currentPriceTarget: 42 }] });
+        },
+      } as any,
+    });
+
+    expect(await bridge.marketData("getAnalystResearch", ["NKE", "NYSE"])).toEqual({
+      symbol: "NKE",
+      ratings: [{ currentPriceTarget: 42 }],
+    });
+    expect(calls).toEqual([["getAnalystResearch", ["NKE", "NYSE"]]]);
+    await expect(bridge.marketData("getOptionsChain", ["NKE"])).rejects.toThrow(/does not serve/);
   });
 });
 

--- a/src/cli/pane-functions/screenshot.ts
+++ b/src/cli/pane-functions/screenshot.ts
@@ -11,6 +11,9 @@ const DEFAULT_SHOT_DEVICE_SCALE_FACTOR = 2;
 import {
   renderDesktopPaneScreenshot,
   type DesktopPaneShotApiProxy,
+  type DesktopPaneShotBridge,
+  type DesktopPaneShotHttpRequest,
+  type DesktopPaneShotHttpResponse,
   type DesktopPaneShotIntradayHistory,
   type DesktopPaneShotPayload,
   type DesktopPaneShotRenderResult,
@@ -136,6 +139,82 @@ export function resolveDesktopShotApiProxy(
   return {
     baseUrl: getCloudApiBaseUrl(),
     sessionToken: resolvePersistedCloudSessionToken(context),
+  };
+}
+
+/**
+ * Data the page may request while it renders. The cloud API is only one of the
+ * router's sources, so calling it directly from the page dropped whatever
+ * another provider contributes: analyst rating price targets came back empty
+ * and corporate actions vanished whenever the cloud leg failed. Quotes are
+ * here for board panes that list symbols the payload was never built for.
+ * These run on the Bun side through the same router `gloomberb fn` uses.
+ */
+const SHOT_BRIDGE_MARKET_OPERATIONS = new Set([
+  "getAnalystResearch",
+  "getCorporateActions",
+  "getEarningsCalendar",
+  "getHolders",
+  "getPriceHistory",
+  "getQuote",
+  "getQuotesBatch",
+  "getSecFilings",
+]);
+
+const SHOT_BRIDGE_HTTP_TIMEOUT_MS = 20_000;
+
+export function createDesktopShotBridge(
+  context: Pick<MarketContext, "dataProvider">,
+): DesktopPaneShotBridge {
+  return {
+    async marketData(operation, args) {
+      if (!SHOT_BRIDGE_MARKET_OPERATIONS.has(operation)) {
+        throw new Error(`Screenshot market bridge does not serve "${operation}".`);
+      }
+      const provider = context.dataProvider as unknown as Record<string, unknown>;
+      const handler = provider[operation];
+      if (typeof handler !== "function") {
+        throw new Error(`No provider available for ${operation}.`);
+      }
+      return await (handler as (...values: unknown[]) => Promise<unknown>).apply(
+        context.dataProvider,
+        args,
+      );
+    },
+    httpFetch: (request) => runDesktopShotHttpFetch(request),
+  };
+}
+
+/**
+ * Panes such as DVD fetch a third-party API directly. A browser cannot: the
+ * request is cross-origin and dies in CORS, so the pane reported that the
+ * ticker pays no dividend. The desktop renderer already proxies these through
+ * its native half; the screenshot page gets the same treatment.
+ */
+async function runDesktopShotHttpFetch(
+  request: DesktopPaneShotHttpRequest,
+): Promise<DesktopPaneShotHttpResponse> {
+  const target = new URL(request.url);
+  if (target.protocol !== "http:" && target.protocol !== "https:") {
+    throw new Error(`Screenshot HTTP bridge refuses ${target.protocol} requests.`);
+  }
+  const response = await fetch(request.url, {
+    method: request.method ?? "GET",
+    headers: request.headers,
+    body: request.body,
+    redirect: "follow",
+    signal: AbortSignal.timeout(SHOT_BRIDGE_HTTP_TIMEOUT_MS),
+  });
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, name) => {
+    headers[name] = value;
+  });
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+    setCookie: response.headers.getSetCookie?.() ?? [],
+    body: await response.text(),
   };
 }
 
@@ -617,7 +696,10 @@ export async function renderDesktopShot({
       scale ?? 1,
       watermark ?? null,
     );
-    render = await renderDesktopPaneScreenshot(payload, outputPath, apiProxy, { captureImage });
+    render = await renderDesktopPaneScreenshot(payload, outputPath, apiProxy, {
+      captureImage,
+      bridge: createDesktopShotBridge(context),
+    });
   } finally {
     apiClient.setSessionToken(previousSessionToken);
   }

--- a/src/plugins/builtin/earnings/index.tsx
+++ b/src/plugins/builtin/earnings/index.tsx
@@ -7,8 +7,11 @@ import { useAppSelector, usePaneInstance } from "../../../state/app/context";
 import { parseTickerListInput, formatTickerListInput } from "../../../tickers/list";
 import { useAssetData, usePluginPaneState, usePluginTickerActions } from "../../runtime";
 import { useAutoRefresh } from "../shared/auto-refresh";
-import type { PaneSettingsContext, PaneSettingsDef } from "../../../types/plugin";
-import { formatTickerListInput as formatTickers } from "../../../tickers/list";
+import type {
+  PaneSettingsContext,
+  PaneSettingsDef,
+  PaneTemplateCreateOptions,
+} from "../../../types/plugin";
 import {
   attachEarningsCalendarPersistence,
   loadEarningsCalendar,
@@ -188,6 +191,18 @@ function EarningsCalendarPane({ focused, width, height }: PaneProps) {
   );
 }
 
+/** Tickers named on the command bar or the CLI win over the active collection. */
+function earningsScopeSymbols(options: PaneTemplateCreateOptions | undefined): string[] {
+  if (options?.symbols && options.symbols.length > 0) return options.symbols;
+  const raw = options?.arg?.trim() ?? "";
+  if (!raw) return [];
+  try {
+    return parseTickerListInput(raw);
+  } catch {
+    return [];
+  }
+}
+
 /** The monitor's scope lives in pane settings, so it has to be editable there too. */
 function earningsSettings(context: PaneSettingsContext): PaneSettingsDef {
   const collections = [
@@ -197,7 +212,7 @@ function earningsSettings(context: PaneSettingsContext): PaneSettingsDef {
   const symbols = scopedSymbolsFromSettings(context.settings);
   return {
     title: "Earnings Scope",
-    values: { symbolsText: symbols.length > 0 ? formatTickers(symbols) : "" },
+    values: { symbolsText: symbols.length > 0 ? formatTickerListInput(symbols) : "" },
     fields: [
       {
         key: "symbolsText",
@@ -266,13 +281,22 @@ export const earningsModule: PluginModule = {
       label: "Earnings Calendar",
       description: "Upcoming earnings dates and estimates for your tickers.",
       keywords: ["earn", "earnings", "calendar", "eps", "revenue", "quarterly"],
-      shortcut: { prefix: "ERN" },
+      shortcut: { prefix: "ERN", argPlaceholder: "tickers", argKind: "ticker-list" },
       headless: earningsCalendarHeadless,
-      createInstance: (context) => ({
-        settings: context.activeCollectionId
-          ? { collectionId: context.activeCollectionId }
-          : undefined,
-      }),
+      // The shortcut takes tickers, so honor them the way the report does.
+      // Ignoring them left `ERN NKE` scoped to the active collection, which
+      // rendered "No tickers in scope" while the report listed NKE's earnings.
+      createInstance: (context, options) => {
+        const symbols = earningsScopeSymbols(options);
+        return {
+          title: symbols.length > 0 ? `ERN ${formatTickerListInput(symbols)}` : undefined,
+          settings: symbols.length > 0
+            ? { symbols, symbolsText: formatTickerListInput(symbols) }
+            : context.activeCollectionId
+              ? { collectionId: context.activeCollectionId }
+              : undefined,
+        };
+      },
     },
     {
       id: "earnings-monitor-pane",

--- a/src/plugins/builtin/earnings/model.test.ts
+++ b/src/plugins/builtin/earnings/model.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import type { TickerRecord } from "../../../types/ticker";
-import { groupEarningsByRelativeDate, resolveEarningsCollectionId, trackedEarningsSymbols } from "./model";
+import type { PaneTemplateContext } from "../../../types/plugin";
+import { earningsModule } from "./index";
+import {
+  groupEarningsByRelativeDate,
+  resolveEarningsCollectionId,
+  scopedSymbolsFromSettings,
+  trackedEarningsSymbols,
+} from "./model";
 
 function ticker(
   symbol: string,
@@ -21,6 +28,27 @@ function ticker(
     },
   };
 }
+
+describe("ERN pane scope", () => {
+  /**
+   * The shortcut takes tickers, but the template used to drop them and follow
+   * the active collection instead, so `ERN NKE` opened a pane that reported no
+   * tickers in scope while the same argument produced a report.
+   */
+  test("scopes the pane to the tickers the shortcut was given", async () => {
+    const template = earningsModule.paneTemplates?.find(
+      (candidate) => candidate.id === "earnings-calendar-pane",
+    );
+    const context = { activeCollectionId: "main" } as unknown as PaneTemplateContext;
+
+    const scoped = await template?.createInstance?.(context, { arg: "nke, msft" });
+    expect(scopedSymbolsFromSettings(scoped?.settings)).toEqual(["NKE", "MSFT"]);
+
+    const unscoped = await template?.createInstance?.(context, undefined);
+    expect(scopedSymbolsFromSettings(unscoped?.settings)).toEqual([]);
+    expect(unscoped?.settings?.collectionId).toBe("main");
+  });
+});
 
 describe("trackedEarningsSymbols", () => {
   test("gives settings-less legacy panes one stable collection scope", () => {

--- a/src/plugins/builtin/research/analyst-pane.test.tsx
+++ b/src/plugins/builtin/research/analyst-pane.test.tsx
@@ -1,0 +1,145 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { AppContext, PaneInstanceProvider, createInitialState } from "../../../state/app/context";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
+import { cloneLayout, createDefaultConfig } from "../../../types/config";
+import type { AnalystResearchData } from "../../../types/financials";
+import type { DataProvider } from "../../../types/data-provider";
+import type { TickerRecord } from "../../../types/ticker";
+import { Box } from "../../../ui";
+import { PluginRenderProvider } from "../../runtime";
+import { AnalystResearchView } from "./analyst-pane";
+
+const TEST_PANE_ID = "analyst-research:NKE";
+const WIDTH = 96;
+const HEIGHT = 20;
+
+let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+const research: AnalystResearchData = {
+  providerId: "test",
+  symbol: "NKE",
+  currency: "USD",
+  priceTarget: { current: 38.4, average: 50.46, low: 23, median: 46.5, high: 94, currency: "USD" },
+  recommendationRating: 6.1,
+  recommendations: [],
+  ratings: [
+    {
+      date: "2026-08-26",
+      firm: "Truist Securities",
+      action: "Downgrade",
+      current: "Hold",
+      prior: "Buy",
+      currentPriceTarget: 42,
+      priorPriceTarget: 47,
+    },
+    {
+      date: "2026-08-25",
+      firm: "Solo Target",
+      action: "Initiates",
+      current: "Buy",
+      currentPriceTarget: 61,
+    },
+    {
+      date: "2026-08-24",
+      firm: "No Target",
+      action: "Reiterates",
+      current: "Buy",
+      prior: "Buy",
+    },
+  ],
+  earningsEstimates: [],
+  revenueEstimates: [],
+};
+
+function makeTicker(symbol: string): TickerRecord {
+  return {
+    metadata: {
+      ticker: symbol,
+      exchange: "NYSE",
+      currency: "USD",
+      name: symbol,
+      portfolios: [],
+      watchlists: [],
+      positions: [],
+      custom: {},
+      tags: [],
+    },
+  };
+}
+
+function AnalystHarness({ provider }: { provider: DataProvider }) {
+  const config = createDefaultConfig("/tmp/gloomberb-analyst-pane-test");
+  config.layout = {
+    dockRoot: { kind: "pane", instanceId: TEST_PANE_ID },
+    instances: [{
+      instanceId: TEST_PANE_ID,
+      paneId: "analyst-research",
+      binding: { kind: "fixed", symbol: "NKE" },
+    }],
+    floating: [],
+    detached: [],
+  };
+  config.layouts = [{ name: "Default", layout: cloneLayout(config.layout) }];
+
+  const state = createInitialState(config);
+  state.focusedPaneId = TEST_PANE_ID;
+  state.tickers = new Map([["NKE", makeTicker("NKE")]]);
+
+  return (
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <PaneInstanceProvider paneId={TEST_PANE_ID}>
+        <PluginRenderProvider
+          pluginId="ticker-research"
+          runtime={createTestPluginRuntime({ getMarketData: () => provider })}
+        >
+          <Box flexDirection="column" width={WIDTH} height={HEIGHT}>
+            <AnalystResearchView width={WIDTH} height={HEIGHT} focused />
+          </Box>
+        </PluginRenderProvider>
+      </PaneInstanceProvider>
+    </AppContext>
+  );
+}
+
+async function renderHarness(provider: DataProvider): Promise<void> {
+  await act(async () => {
+    testSetup = await testRender(<AnalystHarness provider={provider} />, { width: WIDTH, height: HEIGHT });
+  });
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    await act(async () => {
+      await Bun.sleep(1);
+      await testSetup!.renderOnce();
+    });
+  }
+}
+
+afterEach(async () => {
+  if (testSetup) {
+    await act(async () => testSetup!.renderer.destroy());
+    testSetup = undefined;
+  }
+});
+
+/**
+ * The pane used to reach a source that carries the aggregate price target but
+ * no per-rating targets, so every TARGET cell rendered as a dash under a
+ * header that advertised an average target.
+ */
+test("renders each rating's price target and only dashes the rows without one", async () => {
+  await renderHarness({
+    id: "test",
+    name: "Test",
+    getAnalystResearch: async () => research,
+  } as unknown as DataProvider);
+
+  const frame = testSetup!.captureCharFrame();
+  expect(frame).toContain("$50.46 avg target");
+  expect(frame).toContain("$47 → $42");
+  expect(frame).toContain("$61");
+  const noTargetRow = frame.split("\n").find((line) => line.includes("No Target"));
+  expect(noTargetRow).toBeDefined();
+  expect(noTargetRow).not.toMatch(/\$\d/);
+  expect(noTargetRow).toContain("-");
+});

--- a/src/plugins/builtin/research/corporate-actions-pane.tsx
+++ b/src/plugins/builtin/research/corporate-actions-pane.tsx
@@ -34,7 +34,12 @@ import {
   buildInlineFilingContentTargets,
   useSecFilingContentCache,
 } from "../sec/filing-content";
-import { buildEventRows, type EventRow, type EventStatus } from "./event-model";
+import {
+  buildEventRows,
+  eventSourceNotice,
+  type EventRow,
+  type EventStatus,
+} from "./event-model";
 
 export { buildEventRows } from "./event-model";
 
@@ -284,6 +289,18 @@ export function CorporateActionsView({
       : allRows
   ), [allRows, variant]);
   const columns = useMemo(() => buildEventColumns(), []);
+  const sourceNotice = useMemo(() => (
+    actionsLoading || analystLoading
+      ? null
+      : eventSourceNotice({
+        variant,
+        symbol: symbol ?? "this ticker",
+        actions: actionsData,
+        actionsError,
+        estimates: analystData,
+        estimatesError: analystError,
+      })
+  ), [actionsData, actionsError, actionsLoading, analystData, analystError, analystLoading, symbol, variant]);
   const [selectedIdx, setSelectedIdx] = useState(0);
   const [openRowId, setOpenRowId] = useState<string | null>(null);
   const detailScrollRef = useRef<ScrollBoxRenderable>(null);
@@ -480,6 +497,15 @@ export function CorporateActionsView({
       }}
       onActivate={(row) => setOpenRowId(row.id)}
       onDetailKeyDown={handleDetailKeyDown}
+      rootBefore={sourceNotice && rows.length > 0 ? (
+        <Box
+          height={1}
+          paddingX={1}
+          {...(sourceNotice.failed ? { "data-gloom-status": "error" } : {})}
+        >
+          <Text fg={sourceNotice.failed ? colors.negative : colors.textDim}>{sourceNotice.text}</Text>
+        </Box>
+      ) : undefined}
       rootWidth={width}
       rootHeight={height}
       onRootKeyDown={handleKeyDown}

--- a/src/plugins/builtin/research/event-model.ts
+++ b/src/plugins/builtin/research/event-model.ts
@@ -243,3 +243,59 @@ export function buildEventRows(
     || left.period.localeCompare(right.period)
   ));
 }
+
+export interface EventSourceState {
+  variant: "corporate-actions" | "earnings-estimates";
+  symbol: string;
+  actions: CorporateActionsData | null;
+  actionsError: string | null;
+  estimates: AnalystResearchData | null;
+  estimatesError: string | null;
+}
+
+export interface EventSourceNotice {
+  text: string;
+  /** True when a source failed, as opposed to a source that had nothing. */
+  failed: boolean;
+}
+
+/**
+ * The table can still show a TTM line built from statements while both event
+ * sources returned nothing, which used to read as a working pane that happens
+ * to be almost empty. This says which source is missing so a thin pane
+ * explains itself instead of looking broken.
+ */
+export function eventSourceNotice(state: EventSourceState): EventSourceNotice | null {
+  const actionsLabel = state.variant === "earnings-estimates"
+    ? "Reported earnings"
+    : "Corporate actions";
+  const notices: string[] = [];
+
+  if (state.actionsError) {
+    notices.push(`${actionsLabel} unavailable: ${state.actionsError}`);
+  } else if (state.actions && !hasCorporateActionRows(state.actions)) {
+    notices.push(state.variant === "earnings-estimates"
+      ? `No reported earnings for ${state.symbol}`
+      : `No dividends, splits, or reported earnings for ${state.symbol}`);
+  }
+
+  if (state.estimatesError) {
+    notices.push(`Analyst estimates unavailable: ${state.estimatesError}`);
+  } else if (state.estimates && !hasAnalystEstimates(state.estimates)) {
+    notices.push(`No analyst estimates for ${state.symbol}`);
+  }
+
+  if (notices.length === 0) return null;
+  return {
+    text: notices.join("   "),
+    failed: !!state.actionsError || !!state.estimatesError,
+  };
+}
+
+function hasCorporateActionRows(data: CorporateActionsData): boolean {
+  return data.dividends.length > 0 || data.splits.length > 0 || data.earnings.length > 0;
+}
+
+function hasAnalystEstimates(data: AnalystResearchData): boolean {
+  return data.earningsEstimates.length > 0 || data.revenueEstimates.length > 0;
+}

--- a/src/plugins/builtin/research/index.test.ts
+++ b/src/plugins/builtin/research/index.test.ts
@@ -9,6 +9,7 @@ import {
   type RatingSortPreference,
 } from "./analyst-pane";
 import { buildEventRows, matchEarningsSecFiling } from "./corporate-actions-pane";
+import { eventSourceNotice } from "./event-model";
 
 const ratings: AnalystRatingRecord[] = [
   {
@@ -360,5 +361,47 @@ describe("event rows", () => {
     ];
 
     expect(matchEarningsSecFiling(row, filings)?.accessionNumber).toBe("0000320193-26-000009");
+  });
+});
+
+describe("event source notice", () => {
+  const loaded = {
+    variant: "corporate-actions" as const,
+    symbol: "DBK",
+    actions: { symbol: "DBK", dividends: [{ exDate: "2026-05-29", amount: 1 }], splits: [], earnings: [] },
+    actionsError: null,
+    estimates: {
+      symbol: "DBK",
+      recommendations: [],
+      ratings: [],
+      earningsEstimates: [{ date: "2026-12-31", period: "current_year", average: 3.3, analysts: 10 }],
+      revenueEstimates: [],
+    } satisfies AnalystResearchData,
+    estimatesError: null,
+  };
+
+  test("stays quiet when both sources delivered", () => {
+    expect(eventSourceNotice(loaded)).toBeNull();
+  });
+
+  /**
+   * A failed corporate-actions request left the table showing only estimate and
+   * TTM rows, which reads as a working pane for a company with no events.
+   */
+  test("names a failed source and marks it as a failure", () => {
+    expect(eventSourceNotice({ ...loaded, actions: null, actionsError: "Cloud request failed" })).toEqual({
+      text: "Corporate actions unavailable: Cloud request failed",
+      failed: true,
+    });
+  });
+
+  test("reports genuinely empty data without calling it a failure", () => {
+    expect(eventSourceNotice({
+      ...loaded,
+      actions: { symbol: "DBK", dividends: [], splits: [], earnings: [] },
+    })).toEqual({
+      text: "No dividends, splits, or reported earnings for DBK",
+      failed: false,
+    });
   });
 });

--- a/src/plugins/builtin/short-interest/model.ts
+++ b/src/plugins/builtin/short-interest/model.ts
@@ -97,17 +97,28 @@ export function nextSortPreference(
   return { columnId: columnId as ShortInterestColumnId, direction: "desc" };
 }
 
-export function buildColumns(width: number): ShortInterestColumn[] {
+/**
+ * FINRA settlement history carries no float, so percent of float is null for
+ * every row on that route. Keeping the column drew a header over a column of
+ * dashes, which reads as missing data rather than data the source never had.
+ */
+export function buildColumns(
+  width: number,
+  records: readonly ShortInterestRecord[] = [],
+): ShortInterestColumn[] {
+  const hasPercentFloat = records.some((record) => record.shortPercentFloat != null);
   const dateWidth = 12;
   const sharesWidth = 12;
   const ratioWidth = 12;
-  const advWidth = Math.max(12, width - 2 - dateWidth - sharesWidth - ratioWidth - 12);
-  const percentWidth = 10;
+  const percentWidth = hasPercentFloat ? 10 : 0;
+  const advWidth = Math.max(12, width - 2 - dateWidth - sharesWidth - ratioWidth - (hasPercentFloat ? 12 : 2));
   return [
     { id: "settlementDate", label: "DATE", width: dateWidth, align: "left" },
     { id: "sharesShort", label: "SHARES SHORT", width: sharesWidth, align: "right" },
     { id: "shortRatio", label: "DAYS TO COVER", width: ratioWidth, align: "right" },
     { id: "averageDailyVolume", label: "AVG DAILY VOL", width: advWidth, align: "right" },
-    { id: "shortPercentFloat", label: "% FLOAT", width: percentWidth, align: "right" },
+    ...(hasPercentFloat
+      ? [{ id: "shortPercentFloat" as const, label: "% FLOAT", width: percentWidth, align: "right" as const }]
+      : []),
   ];
 }

--- a/src/plugins/builtin/short-interest/pane.tsx
+++ b/src/plugins/builtin/short-interest/pane.tsx
@@ -71,7 +71,7 @@ function ShortInterestView({ width, height, focused }: { width: number; height: 
 
   const rows = useMemo(() => buildRows(records), [records]);
   const sortedRows = useMemo(() => sortRows(rows, sortPreference), [rows, sortPreference]);
-  const columns = useMemo(() => buildColumns(width), [width]);
+  const columns = useMemo(() => buildColumns(width, records), [records, width]);
   const chartPoints = useMemo(() => recordsToChartPoints(records), [records]);
 
   const boundedSelectedIdx = sortedRows.length > 0

--- a/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
+++ b/src/renderers/electrobun/view/cli-pane-shot-entry.tsx
@@ -35,8 +35,24 @@ import type {
   AppTickerRepositoryPort,
 } from "../../../core/app-service-ports";
 import type { CachedResourceRecord, ResourceCacheKey, SetResourceOptions } from "../../../data/resource-store";
-import type { CachedFinancialsTarget, DataProvider, QuoteSubscriptionTarget } from "../../../types/data-provider";
-import type { OptionsChain, PricePoint, TickerFinancials } from "../../../types/financials";
+import type {
+  CachedFinancialsTarget,
+  DataProvider,
+  EarningsEvent,
+  QuoteBatchResult,
+  QuoteSubscriptionTarget,
+  SecFilingItem,
+} from "../../../types/data-provider";
+import type {
+  AnalystResearchData,
+  CorporateActionsData,
+  HolderData,
+  OptionsChain,
+  PricePoint,
+  Quote,
+  TickerFinancials,
+} from "../../../types/financials";
+import { setHttpFetchTransport } from "../../../utils/http-transport";
 import type { TickerRecord } from "../../../types/ticker";
 import type { AppState, PaneRuntimeState } from "../../../core/state/app/state";
 import type { PaneDef } from "../../../types/plugin";
@@ -100,6 +116,9 @@ const SHOT_READY_STABLE_FRAMES = 10;
 // headline) wait forever and time out.
 const SHOT_LOADING_SELECTOR = "[data-gloom-status=\"loading\"]";
 const SHOT_API_PROXY_PREFIX = "/__gloom_cli_api__";
+// Served by the Bun process that owns this page, see src/cli/desktop-pane-shot.ts.
+const SHOT_MARKET_BRIDGE_PATH = "/__gloom_cli_market__";
+const SHOT_HTTP_BRIDGE_PATH = "/__gloom_cli_http__";
 const TRACKED_RESPONSE_METHODS = new Set<PropertyKey>([
   "arrayBuffer",
   "blob",
@@ -183,12 +202,119 @@ function installShotCloudApiTransport(): void {
   });
 }
 
+/**
+ * Panes such as DVD and SI call a third-party API through httpFetch. A browser
+ * cannot do that cross-origin, so those requests died in CORS and the panes
+ * reported the ticker as having no data. The desktop renderer proxies the same
+ * calls through its native half; here the Bun process that serves this page
+ * runs them and returns the response, cookies included so the Yahoo crumb
+ * handshake still works.
+ */
+function installShotHttpFetchTransport(): void {
+  setHttpFetchTransport(async (url, init = {}) => {
+    const headers: Record<string, string> = {};
+    new Headers(init.headers).forEach((value, name) => {
+      headers[name] = value;
+    });
+    const response = await window.fetch(SHOT_HTTP_BRIDGE_PATH, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        url,
+        method: init.method,
+        headers,
+        body: typeof init.body === "string" ? init.body : undefined,
+      }),
+    });
+    const result = await response.json() as {
+      ok: boolean;
+      error?: string;
+      data?: {
+        status: number;
+        statusText: string;
+        headers: Record<string, string>;
+        setCookie: string[];
+        body: string;
+      };
+    };
+    if (!result.ok || !result.data) throw new Error(result.error ?? `Request failed: ${url}`);
+    return createShotHttpResponse(result.data);
+  });
+}
+
+function createShotHttpResponse(payload: {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  setCookie: string[];
+  body: string;
+}): Response {
+  // Yahoo's crumb handshake reads set-cookie, which fetch hides from a page.
+  const headers = new Headers(payload.headers);
+  const originalGet = headers.get.bind(headers);
+  headers.get = ((name: string) => (
+    name.toLowerCase() === "set-cookie" ? payload.setCookie[0] ?? null : originalGet(name)
+  )) as Headers["get"];
+  (headers as Headers & { getSetCookie?: () => string[] }).getSetCookie = () => [...payload.setCookie];
+  const response = new Response(payload.body, {
+    status: payload.status,
+    statusText: payload.statusText,
+  });
+  Object.defineProperty(response, "headers", { value: headers, configurable: true });
+  return response;
+}
+
 async function restoreShotCloudSession(): Promise<void> {
   await apiClient.getSession().catch(() => null);
 }
 
 function resolveShotWork<T>(value: T): Promise<T> {
   return trackShotWork(Promise.resolve(value));
+}
+
+/**
+ * Runs an asset-data request in the Bun process so the page sees exactly what
+ * `gloomberb fn` sees. The page can only reach the cloud API on its own, and
+ * the cloud is one source among several: analyst rating price targets and part
+ * of the corporate action history come from providers the router merges in.
+ */
+async function requestShotMarketData<T>(operation: string, args: unknown[]): Promise<T> {
+  const response = await window.fetch(SHOT_MARKET_BRIDGE_PATH, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ operation, args }),
+  });
+  const result = await response.json() as { ok: boolean; data?: T; error?: string };
+  if (!result.ok) throw new Error(result.error ?? `Screenshot data request failed: ${operation}`);
+  return result.data as T;
+}
+
+/** JSON has no Date, so every bridged date arrives as a string. */
+function reviveDate(value: unknown): Date | undefined {
+  if (value instanceof Date) return value;
+  if (typeof value !== "string" && typeof value !== "number") return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function reviveSecFilings(filings: SecFilingItem[]): SecFilingItem[] {
+  return filings.map((filing) => ({
+    ...filing,
+    filingDate: reviveDate(filing.filingDate) ?? new Date(0),
+    ...(filing.acceptedAt ? { acceptedAt: reviveDate(filing.acceptedAt) } : {}),
+  }));
+}
+
+function revivePricePoints(points: PricePoint[]): PricePoint[] {
+  return points.map((point) => ({ ...point, date: reviveDate(point.date) ?? new Date(0) }));
+}
+
+function reviveEarningsEvents(events: EarningsEvent[]): EarningsEvent[] {
+  return events.map((event) => ({
+    ...event,
+    earningsDate: reviveDate(event.earningsDate) ?? new Date(0),
+    ...(event.earningsCallDate ? { earningsCallDate: reviveDate(event.earningsCallDate) ?? null } : {}),
+  }));
 }
 
 function isShotLoadingTextVisible(): boolean {
@@ -301,9 +427,13 @@ function createShotDataProvider(payload: CliPaneShotPayload): DataProvider {
     if (!instrument.exchange) optionsChains.set(normalizeSymbol(instrument.symbol), data);
   }
 
+  const findFinancials = (symbol: string, exchange?: string) => (
+    financials.get(canonicalTickerKey(symbol, exchange))
+      ?? financials.get(normalizeSymbol(symbol))
+  );
+
   const getFinancials = (symbol: string, exchange?: string) => {
-    const data = financials.get(canonicalTickerKey(symbol, exchange))
-      ?? financials.get(normalizeSymbol(symbol));
+    const data = findFinancials(symbol, exchange);
     if (!data) throw new Error(`No screenshot market data available for ${symbol}.`);
     return data;
   };
@@ -323,18 +453,26 @@ function createShotDataProvider(payload: CliPaneShotPayload): DataProvider {
       })));
     },
     getQuote(ticker, exchange) {
-      return trackShotWork(Promise.resolve().then(() => {
-        const quote = getFinancials(ticker, exchange).quote;
-        if (!quote) throw new Error(`No screenshot quote data available for ${ticker}.`);
-        return quote;
-      }));
+      const quote = findFinancials(ticker, exchange)?.quote;
+      if (quote) return resolveShotWork(quote);
+      return requestShotMarketData<Quote>("getQuote", [ticker, exchange]);
     },
+    // Board panes such as WEI, MOST, and BI quote symbols the shot payload was
+    // never built for, and returning null for those drew a full table of
+    // dashes. The payload still wins wherever it has the symbol, so mapped
+    // capabilities keep rendering exactly the data their evidence checks use.
     getQuotesBatch(targets: QuoteSubscriptionTarget[]) {
-      return resolveShotWork(targets.map((target) => ({
-        target,
-        quote: (financials.get(canonicalTickerKey(target.symbol, target.exchange))
-          ?? financials.get(normalizeSymbol(target.symbol)))?.quote ?? null,
-      })));
+      const resolved: QuoteBatchResult[] = [];
+      const missing: QuoteSubscriptionTarget[] = [];
+      for (const target of targets) {
+        const quote = findFinancials(target.symbol, target.exchange)?.quote;
+        if (quote) resolved.push({ target, quote });
+        else missing.push(target);
+      }
+      if (missing.length === 0) return resolveShotWork(resolved);
+      return requestShotMarketData<QuoteBatchResult[]>("getQuotesBatch", [missing])
+        .then((results) => [...resolved, ...results])
+        .catch(() => [...resolved, ...missing.map((target) => ({ target, quote: null }))]);
     },
     getExchangeRate(fromCurrency: string) {
       // Returning 1 for every currency used to render the FX matrix as a grid
@@ -373,13 +511,18 @@ function createShotDataProvider(payload: CliPaneShotPayload): DataProvider {
       return resolveShotWork(null);
     },
     getPriceHistory(ticker, exchange, range) {
+      const intraday = intradayHistory(ticker, exchange);
+      const local = intraday ? intraday.points : findFinancials(ticker, exchange)?.priceHistory;
+      // Sector and board panes chart symbols the payload does not carry, and
+      // an empty series turned their trailing-return columns into dashes.
+      if (!intraday && !local) {
+        return requestShotMarketData<PricePoint[]>("getPriceHistory", [ticker, exchange, range])
+          .then(revivePricePoints)
+          .catch(() => []);
+      }
       return trackShotWork(Promise.resolve().then(() => {
-        const intraday = intradayHistory(ticker, exchange);
         if (intraday?.unavailableReason) throw new Error(intraday.unavailableReason);
-        return clipPriceHistoryToRange(
-          intraday ? intraday.points : getFinancials(ticker, exchange).priceHistory ?? [],
-          range,
-        );
+        return clipPriceHistoryToRange(local ?? [], range);
       }));
     },
     getPriceHistoryForResolution(ticker, exchange, bufferRange, resolution) {
@@ -409,6 +552,23 @@ function createShotDataProvider(payload: CliPaneShotPayload): DataProvider {
     },
     getChartResolutionSupport() {
       return resolveShotWork(SHOT_CHART_RESOLUTION_SUPPORT);
+    },
+    getAnalystResearch(ticker, exchange) {
+      return requestShotMarketData<AnalystResearchData>("getAnalystResearch", [ticker, exchange]);
+    },
+    getCorporateActions(ticker, exchange) {
+      return requestShotMarketData<CorporateActionsData>("getCorporateActions", [ticker, exchange]);
+    },
+    getHolders(ticker, exchange) {
+      return requestShotMarketData<HolderData>("getHolders", [ticker, exchange]);
+    },
+    getSecFilings(ticker, count, exchange) {
+      return requestShotMarketData<SecFilingItem[]>("getSecFilings", [ticker, count, exchange])
+        .then(reviveSecFilings);
+    },
+    getEarningsCalendar(symbols) {
+      return requestShotMarketData<EarningsEvent[]>("getEarningsCalendar", [symbols])
+        .then(reviveEarningsEvents);
     },
     subscribeQuotes() {
       return () => {};
@@ -684,6 +844,7 @@ async function render() {
   revivePayloadDates(payload);
   installShotFetchTracker();
   installShotCloudApiTransport();
+  installShotHttpFetchTransport();
   hydrateFredSeries(payload.fredSeries ?? []);
   hydrateValuationSeries(payload.valuationSeries ?? []);
   statsCache.hydrate(payload.statSeries ?? []);


### PR DESCRIPTION
## Why

Two data bugs reached a public post, and both came from the same place: a pane screenshot renders in a browser page that could only talk to the cloud API, while the terminal and `gloomberb fn` run the same request through the provider router. Anything a second provider contributes was missing from the image.

- `shot ANR NKE` printed `$50.46 avg target` in the header and a dash in every one of the 20 `TARGET` cells. The cloud analyst payload carries the aggregate price target but no per-rating targets, and only the router falls back to the source that has them. `fn ANR NKE --json` had `currentPriceTarget` on every row the whole time.
- `shot EVT DBK` rendered estimates plus a lone TTM row and 90 percent empty space. Deutsche Bank does have corporate actions; the cloud leg failed for that request, the page had nothing to fall back to, and the pane silently dropped every dividend and earnings row without saying so. The screenshot still reported `usable: true`.

## What

- The screenshot page asks the Bun process to run research, quote, and price-history requests through the same `AssetDataRouter` that `fn` uses (`getAnalystResearch`, `getCorporateActions`, `getEarningsCalendar`, `getHolders`, `getSecFilings`, `getQuote`, `getQuotesBatch`, `getPriceHistory`). The injected payload still wins wherever it has the symbol, so the mapped chart capabilities keep rendering exactly the series their evidence checks compare against.
- Third-party HTTP from a pane is proxied through the same local server, the way the desktop renderer already proxies it through its native half. A browser cannot fetch Yahoo cross-origin, which is why `shot DVD NKE` claimed the ticker pays no dividend.
- The events pane (`EVT`, `EE`) names a source that failed or came back empty above the table, and marks the failure case with the shared error status so a partial screenshot is no longer reported as usable.
- `ERN` scopes the pane to the tickers the shortcut was given instead of ignoring them and following the active collection.
- `SI` drops the `% FLOAT` column when the settlement source never fills it, instead of drawing a header over a column of dashes.

## Verify

`fn` JSON and the rendered image now agree for every fixed pane, and each one was reopened in the TUI (tmux, session killed afterwards): ANR, EVT, ERN, SI and DVD render correctly with no React or listener warnings in the log.

Before and after, `shot ANR NKE --theme tokyo --width 1200 --height 675 --scale 1.5`:

| Before | After |
| --- | --- |
| ![ANR before](https://raw.githubusercontent.com/gloom-sh/gloomberb/assets/pane-empty-columns/pane-empty-columns/anr-before.png) | ![ANR after](https://raw.githubusercontent.com/gloom-sh/gloomberb/assets/pane-empty-columns/pane-empty-columns/anr-after.png) |

`shot EVT DBK`, same flags:

| Before | After |
| --- | --- |
| ![EVT before](https://raw.githubusercontent.com/gloom-sh/gloomberb/assets/pane-empty-columns/pane-empty-columns/evt-before.png) | ![EVT after](https://raw.githubusercontent.com/gloom-sh/gloomberb/assets/pane-empty-columns/pane-empty-columns/evt-after.png) |

Forcing the corporate-actions request to fail now renders `Corporate actions unavailable: ...` above the remaining rows and reports `usable=false, unusableReason="The pane rendered an error state."` instead of a clean-looking near-empty pane.

Tests: `bun test` (2583 pass), `bun test src/cli/pane-functions`, `bun run typecheck`.

## Audit

Every pane was checked by comparing `fn <TOKEN> --json` against the cells in `shot <TOKEN> --json`, looking for columns that are entirely empty or entirely `-` while the model has values.

| Pane | Before | After |
| --- | --- | --- |
| ANR | `TARGET` empty in all 20 rows | targets and `prior → current` arrows render |
| EVT | dividends and earnings dropped when the cloud leg failed, no explanation | rows match `fn`; a failed or empty source is named and marks the shot unusable |
| EE | same source as EVT | same fix |
| DVD | "No dividend data found for NKE" while `fn` returned 51 payments | metrics, yield chart and payment history render |
| ERN | "No tickers in scope" while `fn ERN NKE` returned the NKE row | pane scopes to the argument |
| SI | `% FLOAT` header over an all-dash column | column hidden when the source has no float |
| HDS | opens on the treemap, no table rows | unchanged, matches the TUI default view |
| INS | matched `fn` | unchanged |
| SEC | matched `fn` | unchanged |
| CG | matched `fn` | unchanged |
| 13F | matched `fn` | unchanged |
| WEI | `LAST`, `CHG`, `CHG%`, `TIME` empty for all 19 indices | quotes render |
| BI | `RETURN 1M`, `RETURN 1Y` empty | returns render |
| MOST | `VOL RATIO`, `RANGE`, `MKT CAP` empty | price and change now render; the three remaining columns come from a best-effort metadata leg with a 1.5s timeout that a cold screenshot page loses, left as is |
| CALLS, ECT, HP, FA, RV, QQ, CORR, GR, VAL, VIX, HILO, N, CN, IPO, PM, AUCT, CDS, CRD, GC, ECST, FNG | no column with data in the model and dashes in the render | unchanged |
