### PR TITLE
Publish an Intel macOS terminal build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
         include:
           - os: macos-latest
             asset: gloomberb-darwin-arm64
+          # Intel Macs only get the terminal build. GitHub retires this runner
+          # image in 2027; the desktop app stays Apple Silicon only.
+          - os: macos-15-intel
+            asset: gloomberb-darwin-x64
           - os: ubuntu-latest
             asset: gloomberb-linux-x64
           - os: ubuntu-24.04-arm

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ curl -fsSL gloom.sh/install | bash
 
 Both install `Gloomberb.app` and a `gloomberb` command that runs the TUI through the app bundle, so the bundled runtime is stored once.
 
-macOS builds are Apple Silicon (arm64) only. Intel Macs are not supported: the install script and the Homebrew cask stop with an error instead of installing an app that cannot launch. Run [term.gloom.sh](https://term.gloom.sh) in the browser there, and follow [issue #539](https://github.com/gloom-sh/gloomberb/issues/539) for Intel support.
+`Gloomberb.app` is Apple Silicon (arm64) only. On an Intel Mac the install script installs the standalone `gloomberb` terminal app instead, and the Homebrew cask refuses to install rather than leaving an app that cannot launch.
 
 Prefer a direct download?
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -19,6 +19,7 @@ interface BuildTarget {
 
 const targets: BuildTarget[] = [
   { os: "darwin", arch: "arm64", bunOs: "darwin", extension: "", nativePackageName: "@opentui/core-darwin-arm64" },
+  { os: "darwin", arch: "x64", bunOs: "darwin", extension: "", nativePackageName: "@opentui/core-darwin-x64" },
   { os: "linux", arch: "x64", bunOs: "linux", extension: "", nativePackageName: "@opentui/core-linux-x64" },
   { os: "linux", arch: "arm64", bunOs: "linux", extension: "", nativePackageName: "@opentui/core-linux-arm64" },
   { os: "windows", arch: "x64", bunOs: "windows", extension: ".exe", nativePackageName: "@opentui/core-win32-x64" },

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,22 +27,14 @@ case "$ARCH" in
     ;;
 esac
 
-# Apple Silicon shells under Rosetta report x86_64. Genuine Intel Macs cannot
-# run the arm64 app and must fail instead of downloading a bad binary.
+# Apple Silicon shells under Rosetta report x86_64, and they still want the
+# arm64 build. Genuine Intel Macs keep x64 and get the terminal app, because
+# the desktop app bundle is published for Apple Silicon only.
 if [ "$os" = "darwin" ] && [ "$arch" = "x64" ]; then
   translated="$(sysctl -n sysctl.proc_translated 2>/dev/null || true)"
   has_arm64="$(sysctl -n hw.optional.arm64 2>/dev/null || true)"
   if [ "$translated" = "1" ] || [ "$has_arm64" = "1" ]; then
     arch="arm64"
-  else
-    echo "Gloomberb does not support Intel Macs yet, so nothing was installed." >&2
-    echo "" >&2
-    echo "The macOS build is Apple Silicon (arm64) only. Installing it on this machine" >&2
-    echo "would fail at launch with 'Bad CPU type in executable'." >&2
-    echo "" >&2
-    echo "In the meantime you can run Gloomberb in the browser: https://term.gloom.sh" >&2
-    echo "Intel support is tracked at https://github.com/gloom-sh/gloomberb/issues/539" >&2
-    exit 1
   fi
 fi
 
@@ -150,7 +142,16 @@ install_standalone_cli() {
   # Download
   TMP="$(mktemp)"
   echo "Downloading ${ASSET}..."
-  download_file "$DOWNLOAD_URL" "$TMP"
+  if ! download_file "$DOWNLOAD_URL" "$TMP"; then
+    rm -f "$TMP"
+    echo "Error: ${ASSET} is not available in the latest release." >&2
+    if [ "$os" = "darwin" ] && [ "$arch" = "x64" ]; then
+      echo "Intel Macs need a release that ships ${ASSET}." >&2
+      echo "Run Gloomberb in the browser meanwhile: https://term.gloom.sh" >&2
+      echo "Intel support: https://github.com/gloom-sh/gloomberb/issues/539" >&2
+    fi
+    exit 1
+  fi
 
   # Decompress
   echo "Extracting..."
@@ -162,9 +163,13 @@ install_standalone_cli() {
   echo "Installed gloomberb to ${INSTALL_DIR}/gloomberb"
 }
 
-if [ "$os" = "darwin" ]; then
+if [ "$os" = "darwin" ] && [ "$arch" = "arm64" ]; then
   install_macos_app
 else
+  if [ "$os" = "darwin" ]; then
+    echo "Intel Mac detected. Gloomberb.app is Apple Silicon only, so this installs"
+    echo "the terminal app instead."
+  fi
   install_standalone_cli
 fi
 

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -119,17 +119,26 @@ async function runInstall(machine: FakeMachine): Promise<InstallRun> {
 describe("install.sh architecture detection", () => {
   // https://github.com/gloom-sh/gloomberb/issues/539: an Intel Mac used to get
   // the arm64 app and only found out at launch, with "Bad CPU type in
-  // executable".
-  test("refuses to install anything on a genuine Intel Mac", async () => {
+  // executable". It now gets the x64 terminal build, never the app bundle.
+  test("installs the x64 terminal build on a genuine Intel Mac", async () => {
+    const run = await runInstall({
+      unameSystem: "Darwin",
+      unameMachine: "x86_64",
+    });
+
+    expect(run.downloadLog).toContain("gloomberb-darwin-x64.gz");
+    expect(run.downloadLog).not.toContain("stable-macos-arm64");
+  });
+
+  test("explains itself when a release ships no Intel asset", async () => {
     const run = await runInstall({
       unameSystem: "Darwin",
       unameMachine: "x86_64",
     });
 
     expect(run.exitCode).not.toBe(0);
-    expect(run.stderr).toContain("does not support Intel Macs");
+    expect(run.stderr).toContain("gloomberb-darwin-x64.gz is not available");
     expect(run.stderr).toContain("https://term.gloom.sh");
-    expect(run.downloadLog).toBe("");
   });
 
   test("installs the arm64 app from an x86_64 shell translated by Rosetta", async () => {


### PR DESCRIPTION
## Why

#539: Intel Macs have no working install path. The desktop app bundle is Apple Silicon only, so #732 could only make the installer refuse them politely. The TUI has no such constraint.

## What

- `scripts/build.ts` gains a `darwin-x64` target using `@opentui/core-darwin-x64`, which is already an optional dep of `@opentui/core`.
- Release matrix builds `gloomberb-darwin-x64` on `macos-15-intel`, so the binary is compiled and smoke tested natively on Intel rather than cross-compiled blind. GitHub retires that image around Aug 2027, which is the horizon for native Intel CI either way.
- `install.sh` keeps Rosetta-translated shells on arm64 and routes genuine Intel Macs to `install_standalone_cli` instead of the app bundle.
- The standalone path now reports a missing asset clearly (with the browser app and #539) instead of failing with a bare curl error. That covers the window between merging this and the first release that carries the asset.
- README: the app bundle is Apple Silicon only, Intel Macs get the terminal app.

The desktop `.app` stays Apple Silicon only, and the Homebrew cask keeps `depends_on arch: :arm64` from #732. The updater already resolves `gloomberb-darwin-x64` after #732, so Intel installs self-update correctly.

## Tests

`scripts/install.test.ts` covers the new routing: an Intel Mac downloads `gloomberb-darwin-x64.gz` and never the app zip, a release without the asset produces an explanatory error, Rosetta shells and Apple Silicon still get the arm64 app, Linux is unchanged.

`bun test` (2588 pass) and `bun run typecheck:scripts` are green. The Intel matrix row can only be exercised by a tagged release.

Closes #539