### PR TITLE
Show transcript turns as paragraphs

### DIFF
--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -517,6 +517,8 @@ export interface CloudTranscriptTurnPayload {
   role?: string;
   company?: string;
   text: string;
+  /** `text` cut where the speaker paused or changed topic; absent on older transcripts. */
+  paragraphs?: string[];
   isQa: boolean;
   /** Offset into the recording; null when the company published the transcript as a document. */
   startSeconds: number | null;

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -98,7 +98,8 @@ export interface AuthUser {
   updatedAt: string;
 }
 
-export type PersistedAuthUser = Pick<AuthUser, "id" | "emailVerified"> & Partial<AuthUser>;
+export type PersistedAuthUser = Pick<AuthUser, "id" | "emailVerified"> &
+  Partial<AuthUser>;
 
 export interface AccountProfile {
   id: string;
@@ -524,6 +525,15 @@ export interface CloudTranscriptTurnPayload {
   startSeconds: number | null;
 }
 
+export interface CloudTranscriptKeyFigurePayload {
+  /** What the number is, e.g. "Q3 revenue guidance". */
+  label: string;
+  /** As management said it, e.g. "$108B ± 2%". */
+  value: string;
+  /** Comparison or qualifier, e.g. "vs $96B in Q2". */
+  note?: string;
+}
+
 export interface CloudTranscriptParticipantPayload {
   name: string;
   role?: string;
@@ -544,6 +554,8 @@ export interface CloudEarningsTranscriptPayload {
   fullText: string;
   turns: CloudTranscriptTurnPayload[];
   participants: CloudTranscriptParticipantPayload[];
+  /** The numbers management gave, picked for a card; empty on older transcripts. */
+  keyFigures?: CloudTranscriptKeyFigurePayload[];
   summary: string | null;
   guidance: string | null;
   riskFactors: string | null;
@@ -933,7 +945,8 @@ export interface CloudMarketScreenerPayload {
 /** Cache reuse policy for one Equity Diagnostic request. */
 export type CloudEquityDiagnosticMode = "cache-first" | "refresh";
 
-export type CloudEquityDiagnosticFindingKind = "red_flag" | "green_flag" | "anomaly";
+export type CloudEquityDiagnosticFindingKind =
+  "red_flag" | "green_flag" | "anomaly";
 
 /** 3 is the most severe. */
 export type CloudEquityDiagnosticSeverity = 1 | 2 | 3;
@@ -1000,8 +1013,7 @@ export interface CloudEquityDiagnosticResponse {
 }
 
 export type CloudEquityDiagnosticResult =
-  | CloudEquityDiagnosticPending
-  | CloudEquityDiagnosticResponse;
+  CloudEquityDiagnosticPending | CloudEquityDiagnosticResponse;
 
 export interface CloudVerificationResponse {
   sent: boolean;
@@ -1098,13 +1110,20 @@ export type ScannerPayload = ScannerHiloPayload | ScannerFlowPayload;
 
 /** What a scanner subscriber receives: data, or the entitlement refusal. */
 export type ScannerFeedEvent<T extends ScannerPayload = ScannerPayload> =
-  | { type: "data"; payload: T }
-  | { type: "denied"; reason: string };
+  { type: "data"; payload: T } | { type: "denied"; reason: string };
 
 export interface QuoteStreamTarget {
   symbol: string;
   exchange?: string;
-  surface?: "portfolio" | "watchlist" | "detail" | "monitor" | "inline" | "options" | "screener" | "unknown";
+  surface?:
+    | "portfolio"
+    | "watchlist"
+    | "detail"
+    | "monitor"
+    | "inline"
+    | "options"
+    | "screener"
+    | "unknown";
   visible?: boolean;
   selected?: boolean;
   weight?: number;

--- a/src/plugins/builtin/earnings-calls/prose.test.ts
+++ b/src/plugins/builtin/earnings-calls/prose.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { splitFigures, splitSentences } from "./prose";
+import { splitFigures, splitParagraphs, splitSentences } from "./prose";
 
 describe("splitFigures", () => {
   test("picks out money, percentages and quantities, leaves years and labels", () => {
@@ -18,6 +18,20 @@ describe("splitFigures", () => {
     expect(runs.map((run) => run.text).join("")).toBe(
       "Revenue grew 20% to $1.2 billion in 2026, or 150 bps above Q2 guidance of $900 million to $1 billion, with 2,500 hires.",
     );
+  });
+});
+
+describe("splitParagraphs", () => {
+  test("groups sentences to about the target and breaks on a topic shift", () => {
+    const sentence = (n: number) => `Sentence number ${n} has exactly seven words.`;
+    const text = `${sentence(1)} ${sentence(2)} ${sentence(3)} Turning to margins, they rose. ${sentence(4)}`;
+    const paragraphs = splitParagraphs(text, 40);
+    expect(paragraphs[1]).toMatch(/^Turning to margins/);
+    expect(paragraphs.join(" ")).toBe(text);
+  });
+
+  test("short text stays one paragraph", () => {
+    expect(splitParagraphs("Thank you. Good morning.")).toEqual(["Thank you. Good morning."]);
   });
 });
 

--- a/src/plugins/builtin/earnings-calls/prose.ts
+++ b/src/plugins/builtin/earnings-calls/prose.ts
@@ -41,6 +41,39 @@ export function splitFigures(text: string): ProseRun[] {
 const SENTENCE_BOUNDARY =
   /(?<!\b(?:[A-Z]|Inc|Ltd|Co|Corp|vs|Mr|Ms|Mrs|Dr|No|St|Jr|Sr|U\.S|e\.g|i\.e|approx))[.!?]["”')]?\s+(?=["“(]?[A-Z0-9$])/;
 
+/**
+ * Phrases a speaker uses to start a new topic; a paragraph break before one
+ * lands where an editor would put it.
+ */
+const TOPIC_SHIFT =
+  /^(?:Turning to|Moving (?:on )?to|Now,? (?:let me|let's|turning|moving|I'll|I want)|Let me (?:now |also |briefly )?(?:turn|move|shift|start|close|wrap|touch)|With that|Next,|Finally,|In (?:summary|closing)|Before I|Looking (?:ahead|forward)|Lastly,|First,|Second,|Third,|Fourth,|As for|Regarding|Switching to|Shifting to|To (?:wrap|close|summarize))/;
+
+/**
+ * A speaking turn as paragraphs of about `targetWords`, for transcripts the
+ * server produced before it cut paragraphs itself. Sentences are grouped and
+ * the group closes early where the speaker changes topic.
+ */
+export function splitParagraphs(text: string, targetWords = 80): string[] {
+  const paragraphs: string[] = [];
+  let current: string[] = [];
+  let words = 0;
+  const flush = () => {
+    if (current.length > 0) paragraphs.push(current.join(" "));
+    current = [];
+    words = 0;
+  };
+  for (const sentence of splitSentences(text)) {
+    const count = sentence.split(/\s+/).length;
+    if (words >= targetWords * 0.4 && TOPIC_SHIFT.test(sentence)) flush();
+    if (words > 0 && words + count > targetWords * 1.25) flush();
+    current.push(sentence);
+    words += count;
+    if (words >= targetWords) flush();
+  }
+  flush();
+  return paragraphs;
+}
+
 export function splitSentences(text: string): string[] {
   const out: string[] = [];
   let rest = text.trim();

--- a/src/plugins/builtin/earnings-calls/transcript-view.tsx
+++ b/src/plugins/builtin/earnings-calls/transcript-view.tsx
@@ -17,7 +17,7 @@ import type {
   CloudTranscriptTurnPayload,
 } from "../../../api-client";
 import { formatCallDate, formatDuration, formatSentiment, formatTimestamp } from "./format";
-import { splitFigures, splitSentences } from "./prose";
+import { splitFigures, splitParagraphs, splitSentences } from "./prose";
 import { filterTranscriptTurns } from "./model";
 
 export type ReaderTab = "summary" | "transcript" | "qa";
@@ -157,6 +157,10 @@ function TurnView({
   nativePaneChrome: boolean;
 }) {
   const detail = turnDetail(turn);
+  // The server cuts paragraphs where the speaker paused on the recording.
+  // A transcript from before that is one block, so it is cut here by length.
+  const paragraphs =
+    turn.paragraphs && turn.paragraphs.length > 0 ? turn.paragraphs : splitParagraphs(turn.text);
   return (
     <Box flexDirection="column" marginTop={1}>
       <Box height={1} flexDirection="row" gap={1} overflow="hidden">
@@ -169,7 +173,11 @@ function TurnView({
         </Text>
         {detail ? <Text fg={colors.textDim}>{detail}</Text> : null}
       </Box>
-      <Prose text={turn.text} width={width} color={colors.text} nativePaneChrome={nativePaneChrome} />
+      {paragraphs.map((paragraph, index) => (
+        <Box key={index} flexDirection="column" marginTop={index === 0 ? 0 : 1}>
+          <Prose text={paragraph} width={width} color={colors.text} nativePaneChrome={nativePaneChrome} />
+        </Box>
+      ))}
     </Box>
   );
 }

--- a/src/plugins/builtin/earnings-calls/transcript-view.tsx
+++ b/src/plugins/builtin/earnings-calls/transcript-view.tsx
@@ -14,9 +14,15 @@ import {
 import { wrapTextLines } from "../../../utils/text-wrap";
 import type {
   CloudEarningsTranscriptPayload,
+  CloudTranscriptKeyFigurePayload,
   CloudTranscriptTurnPayload,
 } from "../../../api-client";
-import { formatCallDate, formatDuration, formatSentiment, formatTimestamp } from "./format";
+import {
+  formatCallDate,
+  formatDuration,
+  formatSentiment,
+  formatTimestamp,
+} from "./format";
 import { splitFigures, splitParagraphs, splitSentences } from "./prose";
 import { filterTranscriptTurns } from "./model";
 
@@ -72,6 +78,7 @@ function Prose({
   color,
   nativePaneChrome,
   prefix = "",
+  prefixColor = colors.textDim,
 }: {
   text: string;
   width: number;
@@ -79,12 +86,17 @@ function Prose({
   nativePaneChrome: boolean;
   /** Put before the first line; later lines are indented by its width. */
   prefix?: string;
+  prefixColor?: string;
 }) {
   if (!text.trim()) return null;
   if (nativePaneChrome) {
     return (
       <Box flexDirection="row" width="100%" style={NATIVE_STRETCH_STYLE}>
-        {prefix ? <Text fg={colors.textDim}>{prefix}</Text> : null}
+        {prefix ? (
+          <Text fg={prefixColor} attributes={TextAttributes.BOLD}>
+            {prefix}
+          </Text>
+        ) : null}
         <Text
           wrapText
           width="100%"
@@ -95,16 +107,22 @@ function Prose({
     );
   }
   const indent = " ".repeat(prefix.length);
-  return wrapTextLines(text, Math.max(8, width - prefix.length)).map((line, index) => (
-    <Box key={index} height={1} flexDirection="row">
-      {prefix ? (
-        <Text fg={colors.textDim} flexShrink={0}>
-          {index === 0 ? prefix : indent}
-        </Text>
-      ) : null}
-      <Text content={styledRuns(line, color)} />
-    </Box>
-  ));
+  return wrapTextLines(text, Math.max(8, width - prefix.length)).map(
+    (line, index) => (
+      <Box key={index} height={1} flexDirection="row">
+        {prefix ? (
+          <Text
+            fg={prefixColor}
+            attributes={TextAttributes.BOLD}
+            flexShrink={0}
+          >
+            {index === 0 ? prefix : indent}
+          </Text>
+        ) : null}
+        <Text content={styledRuns(line, color)} />
+      </Box>
+    ),
+  );
 }
 
 function SectionHeading({ title }: { title: string }) {
@@ -147,6 +165,49 @@ function Section({
   );
 }
 
+/**
+ * The numbers management gave, one per line with the value first so the
+ * column of figures is what the eye lands on.
+ */
+function KeyFigures({
+  figures,
+  width,
+  nativePaneChrome,
+}: {
+  figures: CloudTranscriptKeyFigurePayload[];
+  width: number;
+  nativePaneChrome: boolean;
+}) {
+  if (figures.length === 0) return null;
+  const valueWidth = Math.min(
+    18,
+    Math.max(...figures.map((figure) => figure.value.length)),
+  );
+  return (
+    <Box flexDirection="column">
+      <SectionHeading title="KEY FIGURES" />
+      {figures.map((figure) => {
+        const value =
+          figure.value.length > valueWidth
+            ? figure.value
+            : figure.value.padEnd(valueWidth);
+        const rest = [figure.label, figure.note].filter(Boolean).join(", ");
+        return (
+          <Prose
+            key={`${figure.label}-${figure.value}`}
+            text={rest}
+            width={width}
+            color={colors.textDim}
+            nativePaneChrome={nativePaneChrome}
+            prefix={`${value}  `}
+            prefixColor={colors.textBright}
+          />
+        );
+      })}
+    </Box>
+  );
+}
+
 function TurnView({
   turn,
   width,
@@ -160,7 +221,9 @@ function TurnView({
   // The server cuts paragraphs where the speaker paused on the recording.
   // A transcript from before that is one block, so it is cut here by length.
   const paragraphs =
-    turn.paragraphs && turn.paragraphs.length > 0 ? turn.paragraphs : splitParagraphs(turn.text);
+    turn.paragraphs && turn.paragraphs.length > 0
+      ? turn.paragraphs
+      : splitParagraphs(turn.text);
   return (
     <Box flexDirection="column" marginTop={1}>
       <Box height={1} flexDirection="row" gap={1} overflow="hidden">
@@ -175,7 +238,12 @@ function TurnView({
       </Box>
       {paragraphs.map((paragraph, index) => (
         <Box key={index} flexDirection="column" marginTop={index === 0 ? 0 : 1}>
-          <Prose text={paragraph} width={width} color={colors.text} nativePaneChrome={nativePaneChrome} />
+          <Prose
+            text={paragraph}
+            width={width}
+            color={colors.text}
+            nativePaneChrome={nativePaneChrome}
+          />
         </Box>
       ))}
     </Box>
@@ -209,13 +277,14 @@ export function TranscriptView({
   const { nativePaneChrome } = useUiCapabilities();
   const isNative = nativePaneChrome === true;
 
-  const turns = useMemo(() => filterTranscriptTurns(
-    transcript?.turns ?? [],
-    {
-      section: tab === "qa" ? "qa" : "transcript",
-      search: query,
-    },
-  ), [transcript, tab, query]);
+  const turns = useMemo(
+    () =>
+      filterTranscriptTurns(transcript?.turns ?? [], {
+        section: tab === "qa" ? "qa" : "transcript",
+        search: query,
+      }),
+    [transcript, tab, query],
+  );
 
   if (loading && !transcript) {
     return (
@@ -239,8 +308,12 @@ export function TranscriptView({
   const meta = [
     formatCallDate(transcript.callAt),
     formatDuration(transcript.durationSeconds),
-    transcript.participants.length > 0 ? `${transcript.participants.length} speakers` : null,
-    transcript.sentiment !== null ? `sentiment ${formatSentiment(transcript.sentiment)}` : null,
+    transcript.participants.length > 0
+      ? `${transcript.participants.length} speakers`
+      : null,
+    transcript.sentiment !== null
+      ? `sentiment ${formatSentiment(transcript.sentiment)}`
+      : null,
   ]
     .filter(Boolean)
     .join("  ·  ");
@@ -288,19 +361,58 @@ export function TranscriptView({
         <Box flexDirection="column" width={contentWidth} style={contentStyle}>
           {tab === "summary" ? (
             <>
-              <Prose text={meta} width={proseWidth} color={colors.textDim} nativePaneChrome={isNative} />
-              <Section title="SUMMARY" body={transcript.summary ?? ""} width={proseWidth} nativePaneChrome={isNative} />
-              <Section title="WHAT STOOD OUT" body={transcript.notable ?? ""} width={proseWidth} nativePaneChrome={isNative} />
-              <Section title="ANALYSTS PRESSED ON" body={transcript.analystFocus ?? ""} width={proseWidth} nativePaneChrome={isNative} />
-              <Section title="GUIDANCE" body={transcript.guidance ?? ""} width={proseWidth} nativePaneChrome={isNative} />
-              <Section title="RISKS" body={transcript.riskFactors ?? ""} width={proseWidth} nativePaneChrome={isNative} />
+              <Prose
+                text={meta}
+                width={proseWidth}
+                color={colors.textDim}
+                nativePaneChrome={isNative}
+              />
+              <KeyFigures
+                figures={transcript.keyFigures ?? []}
+                width={proseWidth}
+                nativePaneChrome={isNative}
+              />
+              <Section
+                title="SUMMARY"
+                body={transcript.summary ?? ""}
+                width={proseWidth}
+                nativePaneChrome={isNative}
+              />
+              <Section
+                title="WHAT STOOD OUT"
+                body={transcript.notable ?? ""}
+                width={proseWidth}
+                nativePaneChrome={isNative}
+              />
+              <Section
+                title="ANALYSTS PRESSED ON"
+                body={transcript.analystFocus ?? ""}
+                width={proseWidth}
+                nativePaneChrome={isNative}
+              />
+              <Section
+                title="GUIDANCE"
+                body={transcript.guidance ?? ""}
+                width={proseWidth}
+                nativePaneChrome={isNative}
+              />
+              <Section
+                title="RISKS"
+                body={transcript.riskFactors ?? ""}
+                width={proseWidth}
+                nativePaneChrome={isNative}
+              />
               {transcript.participants.length > 0 && (
                 <Box flexDirection="column">
                   <SectionHeading title="PARTICIPANTS" />
                   {transcript.participants.map((participant) => (
                     <Prose
                       key={participant.name}
-                      text={[participant.name, participant.role, participant.company]
+                      text={[
+                        participant.name,
+                        participant.role,
+                        participant.company,
+                      ]
                         .filter(Boolean)
                         .join("  ·  ")}
                       width={proseWidth}


### PR DESCRIPTION
Gloom Cloud now cuts each speaking turn into paragraphs where the speaker paused on the recording or changed topic (`paragraphs` on each turn), and picks the numbers management stated as `keyFigures` (label, value, note). The call reader renders the paragraphs with a blank line between and opens the summary tab with the key figures, value first.

Older transcripts arrive without `paragraphs` and are cut client-side by sentence and topic (`splitParagraphs`), so a fifteen-hundred-word set of prepared remarks is never one block. Transcripts without `keyFigures` show no figures section.

Pairs with the platform change that adds both to the transcript payload and re-enriches existing transcripts.