### PR TITLE
Add the ASKG assistant pane, streaming transport and command bar entry

### DIFF
--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -93,6 +93,7 @@
       "contributes": {
         "panes": [
           "account-management",
+          "askg",
           "buildout",
           "chat",
           "congress-trades"

--- a/scripts/mock-askg-server.ts
+++ b/scripts/mock-askg-server.ts
@@ -7,11 +7,16 @@
  *   bun run scripts/mock-askg-server.ts &
  *   GLOOMBERB_API_URL=http://localhost:8792 bun run dev
  *
- * The reply depends on the prompt: "val" runs a headless pane tool, "layout"
- * asks for a user-data confirmation, "error" reports a rate limit, and "drop"
- * closes the stream mid answer so the client has to resume with Last-Event-ID.
+ * The reply depends on the input: "val" runs a headless pane tool, "layout"
+ * asks for a user-data confirmation, "error" reports a rate limit, "drop"
+ * closes the stream mid answer so the client has to resume with Last-Event-ID,
+ * and "late" refuses the tool result with 410 the way a lapsed window does.
+ *
+ * Pass --free to answer the session with 402, which is how the platform tells a
+ * free verified account that Ask Gloom needs a paid plan.
  */
 const PORT = Number(process.env.MOCK_ASKG_PORT ?? 8792);
+const FREE_TIER = process.argv.includes("--free");
 
 const USER = {
   id: "mock-user",
@@ -25,8 +30,10 @@ const USER = {
 };
 
 const toolResults = new Map<string, unknown>();
-let turnCounter = 0;
-let openTurnId = "turn-0";
+/** Tool calls whose result window has closed, answered with 410. */
+const lateToolCalls = new Set<string>();
+/** Streams already opened for a turn id, so a resume re-attaches. */
+const seenTurns = new Set<string>();
 
 function json(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -56,7 +63,14 @@ async function waitForToolResult(toolCallId: string, timeoutMs = 30_000): Promis
 interface TurnPlanStep {
   kind: "text" | "tool" | "server-tool" | "error" | "drop";
   text?: string;
-  tool?: { name: string; args: Record<string, unknown>; writeTier: string; preview?: unknown };
+  tool?: {
+    name: string;
+    args: Record<string, unknown>;
+    writeTier: string;
+    preview?: unknown;
+    /** Closes the result window immediately, so the post is answered with 410. */
+    late?: boolean;
+  };
   server?: { name: string; rowCount: number; note: string };
 }
 
@@ -86,6 +100,21 @@ function planFor(prompt: string): TurnPlanStep[] {
         },
       },
       { kind: "text", text: "Nothing else to do." },
+    ];
+  }
+  if (lower.includes("late")) {
+    return [
+      { kind: "text", text: "Reading the workspace, but not waiting for it.\n\n" },
+      {
+        kind: "tool",
+        tool: {
+          name: "app.get_resource",
+          args: { resource: "app://panes" },
+          writeTier: "read",
+          late: true,
+        },
+      },
+      { kind: "text", text: "Answered without the tool." },
     ];
   }
   if (lower.includes("drop") || lower.includes("resume")) {
@@ -143,6 +172,9 @@ function turnStream(
       };
 
       send({ type: "session", sessionId, turnId, model: "gloom-1", promptVersion: "2024-06-01" });
+      // The real stream pings every 15s; one up front proves the client's
+      // decoder ignores comment frames.
+      controller.enqueue(encoder.encode(": keep-alive\n\n"));
 
       for (const step of planFor(prompt)) {
         if (step.kind === "drop" && lastEventId === 0) {
@@ -190,6 +222,7 @@ function turnStream(
         }
         if (step.kind === "tool" && step.tool) {
           const toolCallId = `call-${seq + 1}`;
+          if (step.tool.late) lateToolCalls.add(toolCallId);
           send({
             type: "tool-call",
             turnId,
@@ -202,6 +235,19 @@ function turnStream(
             timeoutMs: 30_000,
             expiresAt: new Date(Date.now() + 30_000).toISOString(),
           });
+          if (step.tool.late) {
+            // The turn continues with the synthetic timeout the route records.
+            send({
+              type: "tool-executed",
+              turnId,
+              toolCallId,
+              name: step.tool.name,
+              source: "remote-op",
+              status: "timeout",
+              summary: { elapsedMs: 0, truncated: false, note: "No result inside the window." },
+            });
+            continue;
+          }
           const result = await waitForToolResult(toolCallId) as {
             status?: string;
             rowCount?: number;
@@ -264,6 +310,9 @@ Bun.serve({
     if (path === "/auth/sign-in" || path === "/auth/sign-up") return json({ user: USER });
 
     if (path === "/askg/session" && request.method === "POST") {
+      if (FREE_TIER) {
+        return json({ message: "Ask Gloom is included with Pro." }, { status: 402 });
+      }
       const body = await request.json() as { tools?: unknown[]; manifestHash?: string };
       const tools = body.tools ?? [];
       console.log(`[askg] session start: ${tools.length} tools, hash ${body.manifestHash}`);
@@ -301,27 +350,43 @@ Bun.serve({
 
     const turnMatch = path.match(/^\/askg\/session\/([^/]+)\/turn$/);
     if (turnMatch && request.method === "POST") {
-      const body = await request.json() as { prompt?: string };
+      const body = await request.json() as {
+        turnId?: string;
+        input?: string;
+        history?: Array<{ role: string; text: string }>;
+      };
       const lastEventId = Number(request.headers.get("Last-Event-ID") ?? "0") || 0;
-      // A resumed turn keeps the id it started with.
-      if (lastEventId === 0) openTurnId = `turn-${++turnCounter}`;
-      console.log(`[askg] turn: "${body.prompt}" lastEventId=${lastEventId} turn=${openTurnId}`);
-      return turnStream(body.prompt ?? "", turnMatch[1] ?? "mock-session", lastEventId, openTurnId);
+      const turnId = body.turnId ?? "turn-0";
+      const reattached = seenTurns.has(turnId);
+      seenTurns.add(turnId);
+      console.log(
+        `[askg] turn ${turnId}${reattached ? " (re-attach)" : ""}: "${body.input}" lastEventId=${lastEventId} history=${body.history?.length ?? 0}`,
+      );
+      return turnStream(body.input ?? "", turnMatch[1] ?? "mock-session", lastEventId, turnId);
     }
 
     const resultMatch = path.match(/^\/askg\/session\/([^/]+)\/tool-result$/);
     if (resultMatch && request.method === "POST") {
       const payload = await request.json() as { toolCallId: string; status: string; rowCount?: number };
+      const key = request.headers.get("Idempotency-Key");
       console.log(
-        `[askg] tool-result ${payload.toolCallId} ${payload.status} rows=${payload.rowCount ?? "-"} key=${request.headers.get("Idempotency-Key")}`,
+        `[askg] tool-result ${payload.toolCallId} ${payload.status} rows=${payload.rowCount ?? "-"} key=${key}`,
       );
+      if (key !== payload.toolCallId) {
+        return json({ error: "idempotency key must equal toolCallId" }, { status: 400 });
+      }
+      if (lateToolCalls.has(payload.toolCallId)) {
+        return json({ error: "result window closed" }, { status: 410 });
+      }
+      if (toolResults.has(payload.toolCallId)) return json({ status: "duplicate" }, { status: 202 });
       toolResults.set(payload.toolCallId, payload);
-      return json({ ok: true });
+      return json({ status: "accepted" });
     }
 
     if (/^\/askg\/session\/[^/]+\/cancel$/.test(path)) {
-      console.log("[askg] cancel");
-      return json({ ok: true });
+      const body = await request.json().catch(() => ({})) as { turnId?: string };
+      console.log(`[askg] cancel ${body.turnId ?? "-"}`);
+      return json({ status: "cancelling" }, { status: 202 });
     }
 
     return json({ error: "not found", path }, { status: 404 });

--- a/scripts/mock-askg-server.ts
+++ b/scripts/mock-askg-server.ts
@@ -1,0 +1,331 @@
+/**
+ * Dev-only stand-in for the ASKG platform endpoints, so the assistant pane can
+ * be built and smoke-tested before the server branch lands. Never imported by
+ * app code.
+ *
+ * Usage:
+ *   bun run scripts/mock-askg-server.ts &
+ *   GLOOMBERB_API_URL=http://localhost:8792 bun run dev
+ *
+ * The reply depends on the prompt: "val" runs a headless pane tool, "layout"
+ * asks for a user-data confirmation, "error" reports a rate limit, and "drop"
+ * closes the stream mid answer so the client has to resume with Last-Event-ID.
+ */
+const PORT = Number(process.env.MOCK_ASKG_PORT ?? 8792);
+
+const USER = {
+  id: "mock-user",
+  email: "mock@gloom.sh",
+  username: "mock",
+  name: "Mock Account",
+  emailVerified: true,
+  plan: "pro",
+  effectivePlan: "pro",
+  trialEndsAt: null,
+};
+
+const toolResults = new Map<string, unknown>();
+let turnCounter = 0;
+let openTurnId = "turn-0";
+
+function json(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+      "Set-Cookie": "gloomberb.session_token=mock-session-token; Path=/",
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+async function waitForToolResult(toolCallId: string, timeoutMs = 30_000): Promise<unknown> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = toolResults.get(toolCallId);
+    if (result) {
+      toolResults.delete(toolCallId);
+      return result;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return null;
+}
+
+interface TurnPlanStep {
+  kind: "text" | "tool" | "server-tool" | "error" | "drop";
+  text?: string;
+  tool?: { name: string; args: Record<string, unknown>; writeTier: string; preview?: unknown };
+  server?: { name: string; rowCount: number; note: string };
+}
+
+function planFor(prompt: string): TurnPlanStep[] {
+  const lower = prompt.toLowerCase();
+  if (lower.includes("error") || lower.includes("limit")) {
+    return [
+      { kind: "text", text: "Checking the model budget" },
+      { kind: "error" },
+    ];
+  }
+  if (lower.includes("layout") || lower.includes("delete")) {
+    return [
+      { kind: "text", text: "That removes a saved layout, so it needs your approval.\n\n" },
+      {
+        kind: "tool",
+        tool: {
+          name: "layout.delete",
+          args: { index: 1 },
+          writeTier: "user-data",
+          preview: {
+            operation: "layout.delete",
+            layout: "Research",
+            panes: 4,
+            reversible: "no",
+          },
+        },
+      },
+      { kind: "text", text: "Nothing else to do." },
+    ];
+  }
+  if (lower.includes("drop") || lower.includes("resume")) {
+    return [
+      { kind: "text", text: "Starting the answer, " },
+      { kind: "drop" },
+      { kind: "text", text: "and finishing it after the stream was resumed." },
+    ];
+  }
+  if (lower.includes("val") || lower.includes("valuation") || lower.includes("market")) {
+    return [
+      { kind: "text", text: "Reading market valuation.\n\n" },
+      { kind: "tool", tool: { name: "val", args: {}, writeTier: "read" } },
+      { kind: "server-tool", server: { name: "news.search", rowCount: 6, note: "6 wire stories" } },
+      {
+        kind: "text",
+        text: "Long horizon valuation is rich against history. **NVDA** and **AAPL** carry the index multiple.",
+      },
+    ];
+  }
+  return [
+    { kind: "text", text: "Looking at your workspace.\n\n" },
+    {
+      kind: "tool",
+      tool: { name: "app.get_resource", args: { resource: "app://panes" }, writeTier: "read" },
+    },
+    { kind: "server-tool", server: { name: "market.quote", rowCount: 3, note: "3 quotes" } },
+    {
+      kind: "text",
+      text: "Your layout is open and reachable. Ask about a ticker such as **NVDA** for a deeper read.",
+    },
+  ];
+}
+
+function sseChunk(event: Record<string, unknown>): string {
+  return `id: ${event.seq}\nevent: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
+}
+
+function turnStream(
+  prompt: string,
+  sessionId: string,
+  lastEventId: number,
+  turnId: string,
+): Response {
+  const encoder = new TextEncoder();
+  let seq = 0;
+
+  const body = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (event: Record<string, unknown>) => {
+        seq += 1;
+        // A resumed stream replays nothing the client already applied.
+        if (seq <= lastEventId) return;
+        controller.enqueue(encoder.encode(sseChunk({ ...event, seq })));
+      };
+
+      send({ type: "session", sessionId, turnId, model: "gloom-1", promptVersion: "2024-06-01" });
+
+      for (const step of planFor(prompt)) {
+        if (step.kind === "drop" && lastEventId === 0) {
+          // Close without `done`, which is what a proxy timeout looks like.
+          controller.close();
+          return;
+        }
+        if (step.kind === "text" && step.text) {
+          for (const word of step.text.split(/(\s+)/)) {
+            if (!word) continue;
+            send({ type: "text-delta", turnId, delta: word });
+            await new Promise((resolve) => setTimeout(resolve, 25));
+          }
+          continue;
+        }
+        if (step.kind === "error") {
+          send({
+            type: "error",
+            turnId,
+            code: "rate_limited",
+            message: "You have asked 20 questions this minute.",
+            retryable: true,
+            retryAfterMs: 42_000,
+          });
+          send({ type: "done", turnId, reason: "error" });
+          controller.close();
+          return;
+        }
+        if (step.kind === "server-tool" && step.server) {
+          send({
+            type: "tool-executed",
+            turnId,
+            toolCallId: `server-${step.server.name}`,
+            name: step.server.name,
+            source: "server",
+            status: "ok",
+            summary: {
+              rowCount: step.server.rowCount,
+              elapsedMs: 180,
+              truncated: false,
+              note: step.server.note,
+            },
+          });
+          continue;
+        }
+        if (step.kind === "tool" && step.tool) {
+          const toolCallId = `call-${seq + 1}`;
+          send({
+            type: "tool-call",
+            turnId,
+            toolCallId,
+            name: step.tool.name,
+            args: step.tool.args,
+            writeTier: step.tool.writeTier,
+            requiresConfirmation: step.tool.writeTier !== "read",
+            preview: step.tool.preview ?? null,
+            timeoutMs: 30_000,
+            expiresAt: new Date(Date.now() + 30_000).toISOString(),
+          });
+          const result = await waitForToolResult(toolCallId) as {
+            status?: string;
+            rowCount?: number;
+            elapsedMs?: number;
+            note?: string;
+          } | null;
+          send({ type: "tool-result-ack", turnId, toolCallId });
+          send({
+            type: "tool-executed",
+            turnId,
+            toolCallId,
+            name: step.tool.name,
+            source: step.tool.name.includes(".") ? "remote-op" : "headless",
+            status: result?.status ?? "timeout",
+            summary: {
+              ...(result?.rowCount !== undefined ? { rowCount: result.rowCount } : {}),
+              elapsedMs: result?.elapsedMs ?? 0,
+              truncated: false,
+              ...(result?.note ? { note: result.note } : {}),
+            },
+          });
+          if (result?.status === "denied") {
+            send({ type: "text-delta", turnId, delta: "\n\nLeft the layout alone." });
+          }
+          continue;
+        }
+      }
+
+      send({
+        type: "usage",
+        turnId,
+        inputTokens: 1_200,
+        outputTokens: 320,
+        totalTokens: 1_520,
+        estimated: false,
+      });
+      send({ type: "done", turnId, reason: "complete" });
+      controller.close();
+    },
+  });
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+Bun.serve({
+  port: PORT,
+  idleTimeout: 0,
+  async fetch(request) {
+    const url = new URL(request.url);
+    const path = url.pathname;
+
+    if (path === "/auth/get-session") return json({ user: USER });
+    if (path === "/auth/sign-in" || path === "/auth/sign-up") return json({ user: USER });
+
+    if (path === "/askg/session" && request.method === "POST") {
+      const body = await request.json() as { tools?: unknown[]; manifestHash?: string };
+      const tools = body.tools ?? [];
+      console.log(`[askg] session start: ${tools.length} tools, hash ${body.manifestHash}`);
+      return json({
+        protocolVersion: 1,
+        sessionId: "mock-session",
+        manifestHash: body.manifestHash ?? "sha256:mock",
+        serverTools: [
+          {
+            name: "news.search",
+            source: "server",
+            title: "News: Search",
+            description: "Search the wire.",
+            writeTier: "read",
+            confirm: "never",
+            timeoutMs: 15_000,
+          },
+        ],
+        acceptedTools: (tools as Array<{ name: string }>).map((tool) => tool.name),
+        rejectedTools: [],
+        limits: {
+          requestsPerMinute: 20,
+          turnsPerDay: 100,
+          turnsRemainingToday: 97,
+          maxToolCallsPerTurn: 8,
+          turnWallClockMs: 120_000,
+          clientToolTimeoutMs: 30_000,
+        },
+        tier: "pro",
+        model: "gloom-1",
+        promptVersion: "2024-06-01",
+        expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      });
+    }
+
+    const turnMatch = path.match(/^\/askg\/session\/([^/]+)\/turn$/);
+    if (turnMatch && request.method === "POST") {
+      const body = await request.json() as { prompt?: string };
+      const lastEventId = Number(request.headers.get("Last-Event-ID") ?? "0") || 0;
+      // A resumed turn keeps the id it started with.
+      if (lastEventId === 0) openTurnId = `turn-${++turnCounter}`;
+      console.log(`[askg] turn: "${body.prompt}" lastEventId=${lastEventId} turn=${openTurnId}`);
+      return turnStream(body.prompt ?? "", turnMatch[1] ?? "mock-session", lastEventId, openTurnId);
+    }
+
+    const resultMatch = path.match(/^\/askg\/session\/([^/]+)\/tool-result$/);
+    if (resultMatch && request.method === "POST") {
+      const payload = await request.json() as { toolCallId: string; status: string; rowCount?: number };
+      console.log(
+        `[askg] tool-result ${payload.toolCallId} ${payload.status} rows=${payload.rowCount ?? "-"} key=${request.headers.get("Idempotency-Key")}`,
+      );
+      toolResults.set(payload.toolCallId, payload);
+      return json({ ok: true });
+    }
+
+    if (/^\/askg\/session\/[^/]+\/cancel$/.test(path)) {
+      console.log("[askg] cancel");
+      return json({ ok: true });
+    }
+
+    return json({ error: "not found", path }, { status: 404 });
+  },
+});
+
+console.log(`Mock ASKG server on http://localhost:${PORT}`);

--- a/scripts/seed-mock-cloud-session.ts
+++ b/scripts/seed-mock-cloud-session.ts
@@ -1,0 +1,37 @@
+/**
+ * Dev-only helper that plants a signed-in Gloom Cloud session in a throwaway
+ * data directory, so a TUI smoke test against scripts/mock-askg-server.ts
+ * starts already verified. Never imported by app code.
+ *
+ * Usage:
+ *   bun run scripts/seed-mock-cloud-session.ts /tmp/gloomberb-askg
+ */
+import { AppPersistence } from "../src/data/app-persistence";
+import { join } from "node:path";
+import { mkdirSync } from "node:fs";
+
+const dataDir = process.argv[2];
+if (!dataDir) {
+  console.error("Usage: bun run scripts/seed-mock-cloud-session.ts <dataDir>");
+  process.exit(1);
+}
+
+mkdirSync(dataDir, { recursive: true });
+const persistence = new AppPersistence(join(dataDir, ".gloomberb-cache.db"));
+const value = {
+  sessionToken: "mock-session-token",
+  user: {
+    id: "mock-user",
+    username: "mock",
+    emailVerified: true,
+    plan: "pro" as const,
+    effectivePlan: "pro" as const,
+    trialEndsAt: null,
+  },
+};
+
+for (const key of ["session", "resume:session"]) {
+  persistence.pluginState.set("gloomberb-cloud", key, value, 1);
+}
+persistence.close();
+console.log(`Seeded a verified mock cloud session in ${dataDir}`);

--- a/src/api-client/askg.test.ts
+++ b/src/api-client/askg.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "bun:test";
+import {
+  classifyASKGRequestError,
+  createSseDecoder,
+  readASKGEventStream,
+  CloudASKGApi,
+} from "./askg";
+import { ApiRequestError } from "./errors";
+import type { ASKGSseEvent } from "../plugins/builtin/cloud/askg/protocol";
+
+function streamOf(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+function frame(event: Record<string, unknown>): string {
+  return `id: ${event.seq}\nevent: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
+}
+
+describe("createSseDecoder", () => {
+  test("joins frames split across chunks and drops keep-alive comments", () => {
+    const decoder = createSseDecoder();
+    expect(decoder.push("id: 1\nevent: text-delta\nda")).toEqual([]);
+    expect(decoder.push('ta: {"a":1}\n')).toEqual([]);
+    const frames = decoder.push("\n: keep-alive\n\nid: 2\ndata: {\"b\":2}\n\n");
+    expect(frames).toEqual([
+      { id: "1", event: "text-delta", data: '{"a":1}' },
+      { id: "2", data: '{"b":2}' },
+    ]);
+  });
+
+  test("keeps multi-line data and \\r\\n line endings", () => {
+    const decoder = createSseDecoder();
+    expect(decoder.push("data: one\r\ndata: two\r\n\r\n")).toEqual([{ data: "one\ntwo" }]);
+  });
+});
+
+describe("readASKGEventStream", () => {
+  test("emits typed events in order and reports the terminal reason", async () => {
+    const events: ASKGSseEvent[] = [];
+    const outcome = await readASKGEventStream(
+      streamOf([
+        frame({ seq: 1, type: "text-delta", turnId: "t1", delta: "he" }),
+        frame({ seq: 2, type: "text-delta", turnId: "t1", delta: "llo" }),
+        frame({ seq: 3, type: "done", turnId: "t1", reason: "complete" }),
+      ]),
+      { onEvent: (event) => events.push(event) },
+    );
+
+    expect(events.map((event) => event.type)).toEqual(["text-delta", "text-delta", "done"]);
+    expect(outcome).toEqual({ lastSeq: 3, done: "complete" });
+  });
+
+  test("skips events a resumed stream replays", async () => {
+    const deltas: string[] = [];
+    const outcome = await readASKGEventStream(
+      streamOf([
+        frame({ seq: 1, type: "text-delta", turnId: "t1", delta: "old" }),
+        frame({ seq: 2, type: "text-delta", turnId: "t1", delta: "new" }),
+      ]),
+      {
+        lastSeq: 1,
+        onEvent: (event) => {
+          if (event.type === "text-delta") deltas.push(event.delta);
+        },
+      },
+    );
+
+    expect(deltas).toEqual(["new"]);
+    expect(outcome.done).toBeNull();
+  });
+
+  test("ignores frames that are not protocol events", async () => {
+    const events: ASKGSseEvent[] = [];
+    await readASKGEventStream(
+      streamOf(["data: not json\n\n", 'data: {"hello":true}\n\n', frame({ seq: 4, type: "tool-result-ack", turnId: "t1", toolCallId: "c1" })]),
+      { onEvent: (event) => events.push(event) },
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe("tool-result-ack");
+  });
+});
+
+function transportFor(open: (init: RequestInit | undefined) => Promise<Response>) {
+  const requests: Array<{ path: string; init?: RequestInit }> = [];
+  const api = new CloudASKGApi({
+    request: async <T,>(path: string, init?: RequestInit) => {
+      requests.push({ path, init });
+      return undefined as T;
+    },
+    openStream: (path, init) => {
+      requests.push({ path, init });
+      return open(init);
+    },
+    isStreamingSupported: () => true,
+    delay: async () => {},
+  });
+  return { api, requests };
+}
+
+describe("CloudASKGApi.streamTurn", () => {
+  test("resumes a dropped stream with Last-Event-ID and finishes the answer", async () => {
+    let attempt = 0;
+    const { api, requests } = transportFor(async () => {
+      attempt += 1;
+      return new Response(streamOf(attempt === 1
+        ? [frame({ seq: 1, type: "text-delta", turnId: "t1", delta: "half " })]
+        : [
+          frame({ seq: 1, type: "text-delta", turnId: "t1", delta: "half " }),
+          frame({ seq: 2, type: "text-delta", turnId: "t1", delta: "answer" }),
+          frame({ seq: 3, type: "done", turnId: "t1", reason: "complete" }),
+        ]));
+    });
+
+    const deltas: string[] = [];
+    const reason = await api.streamTurn("s1", { turnId: "t1", input: "hi" }, {
+      onEvent: (event) => {
+        if (event.type === "text-delta") deltas.push(event.delta);
+      },
+    });
+
+    expect(reason).toBe("complete");
+    // The replayed first event is dropped, so the answer is not doubled.
+    expect(deltas.join("")).toBe("half answer");
+    expect(new Headers(requests[0]?.init?.headers).get("Last-Event-ID")).toBeNull();
+    expect(new Headers(requests[1]?.init?.headers).get("Last-Event-ID")).toBe("1");
+    // The same turn id re-attaches instead of asking again.
+    expect(JSON.parse(String(requests[1]?.init?.body)).turnId).toBe("t1");
+  });
+
+  test("gives up with a retryable network error when the stream keeps dropping", async () => {
+    const { api } = transportFor(async () => (
+      new Response(streamOf([frame({ seq: 1, type: "text-delta", turnId: "t1", delta: "x" })]))
+    ));
+    await expect(api.streamTurn("s1", { turnId: "t1", input: "hi" }, { onEvent: () => {} }))
+      .rejects.toMatchObject({ code: "network", retryable: true });
+  });
+});
+
+describe("CloudASKGApi.postToolResult", () => {
+  const payload = {
+    turnId: "t1",
+    toolCallId: "call-1",
+    status: "ok" as const,
+    truncated: false,
+    elapsedMs: 12,
+  };
+
+  test("sends the tool call id as the idempotency key", async () => {
+    const { api, requests } = transportFor(async () => new Response(""));
+    expect(await api.postToolResult("s1", payload)).toBe("accepted");
+    expect(new Headers(requests[0]?.init?.headers).get("Idempotency-Key")).toBe("call-1");
+  });
+
+  test("reports a closed result window instead of failing the turn", async () => {
+    const api = new CloudASKGApi({
+      request: async () => {
+        throw new ApiRequestError("result window closed", 410);
+      },
+      openStream: async () => new Response(""),
+      isStreamingSupported: () => true,
+    });
+    expect(await api.postToolResult("s1", payload)).toBe("too-late");
+  });
+});
+
+describe("classifyASKGRequestError", () => {
+  test("maps the documented statuses onto handled codes", () => {
+    expect(classifyASKGRequestError(new ApiRequestError("pro required", 402)).code)
+      .toBe("tier_required");
+    expect(classifyASKGRequestError(new ApiRequestError("old protocol", 426)).code)
+      .toBe("protocol");
+    expect(classifyASKGRequestError(new ApiRequestError("disabled", 503)).code)
+      .toBe("model_unavailable");
+    const limited = classifyASKGRequestError(new ApiRequestError("too many", 429, 42_000));
+    expect(limited.code).toBe("rate_limited");
+    expect(limited.retryAfterMs).toBe(42_000);
+    expect(classifyASKGRequestError(new ApiRequestError("daily cap reached", 429)).code)
+      .toBe("daily_turn_cap");
+  });
+});

--- a/src/api-client/askg.ts
+++ b/src/api-client/askg.ts
@@ -2,28 +2,34 @@ import {
   ASKG_PROTOCOL_VERSION,
   type ASKGDoneReason,
   type ASKGErrorCode,
-  type ASKGSessionContext,
   type ASKGSessionStartRequest,
   type ASKGSessionStartResponse,
   type ASKGSseEvent,
+  type ASKGTurnRequest,
   type ToolResultPayload,
 } from "../plugins/builtin/cloud/askg/protocol";
 import { ApiRequestError } from "./errors";
 import { STREAMING_UNSUPPORTED_STATUS } from "./request";
 
-/** Turn body posted to `/askg/session/{id}/turn`; mirrored by the platform. */
-export interface ASKGTurnRequest {
-  prompt: string;
-  context?: ASKGSessionContext;
-}
-
 /** Client-side failure codes, layered on top of the wire error codes. */
 export type ASKGClientErrorCode =
   | ASKGErrorCode
   | "transport_unsupported"
+  | "tier_required"
   | "unauthorized"
   | "network"
   | "protocol";
+
+/**
+ * What the tool-result route made of a posted result. Only `too-late` changes
+ * what the user sees: the turn already continued with a synthetic timeout.
+ */
+export type ASKGToolResultOutcome =
+  | "accepted"
+  | "unknown-call"
+  | "too-late"
+  | "too-large"
+  | "already-recorded";
 
 export class ASKGTransportError extends Error {
   constructor(
@@ -65,8 +71,8 @@ export interface ASKGTransport {
   postToolResult(
     sessionId: string,
     payload: ToolResultPayload,
-    options: { idempotencyKey: string; signal?: AbortSignal },
-  ): Promise<void>;
+    options?: { signal?: AbortSignal },
+  ): Promise<ASKGToolResultOutcome>;
   cancelTurn(
     sessionId: string,
     turnId: string,
@@ -239,10 +245,9 @@ function isAbortError(error: unknown): boolean {
   return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }
 
-function retryAfterMsFromError(error: ApiRequestError): number | undefined {
-  const match = error.message.match(/(\d+)\s*(seconds|second|s)\b/i);
-  if (!match?.[1]) return undefined;
-  return Number(match[1]) * 1000;
+/** A 429 covers both the per-minute limit and the daily cap. */
+function rateLimitCode(message: string): "rate_limited" | "daily_turn_cap" {
+  return /\bdaily\b|\bday\b|daily_turn_cap/i.test(message) ? "daily_turn_cap" : "rate_limited";
 }
 
 /** Maps an HTTP failure onto the same codes the stream itself reports. */
@@ -261,16 +266,29 @@ export function classifyASKGRequestError(error: unknown): ASKGTransportError {
       });
     }
     if (error.status === 429) {
-      return new ASKGTransportError("rate_limited", error.message || "Too many requests.", {
-        retryable: true,
-        retryAfterMs: retryAfterMsFromError(error),
-        status: error.status,
-      });
+      return new ASKGTransportError(
+        rateLimitCode(error.message),
+        error.message || "Too many requests.",
+        {
+          retryable: true,
+          ...(error.retryAfterMs !== undefined ? { retryAfterMs: error.retryAfterMs } : {}),
+          status: error.status,
+        },
+      );
     }
     if (error.status === 402) {
-      return new ASKGTransportError("daily_turn_cap", error.message || "Daily limit reached.", {
-        status: error.status,
-      });
+      return new ASKGTransportError(
+        "tier_required",
+        error.message || "Ask Gloom is part of a paid plan.",
+        { status: error.status },
+      );
+    }
+    if (error.status === 426) {
+      return new ASKGTransportError(
+        "protocol",
+        `Ask Gloom no longer speaks protocol v${ASKG_PROTOCOL_VERSION}. Update Gloomberb.`,
+        { status: error.status },
+      );
     }
     if (error.status === 503) {
       return new ASKGTransportError("model_unavailable", error.message || "Ask Gloom is unavailable.", {
@@ -355,9 +373,9 @@ export class CloudASKGApi implements ASKGTransport {
   }
 
   /**
-   * Reads one turn. A stream that drops before `done` is reopened with
-   * `Last-Event-ID` set to the highest applied `seq`, so the answer continues
-   * instead of restarting.
+   * Reads one turn. A stream that drops before `done` is reopened with the same
+   * `turnId` and `Last-Event-ID` set to the highest applied `seq`, which
+   * re-attaches to the running turn instead of starting another one.
    */
   async streamTurn(
     sessionId: string,
@@ -380,7 +398,7 @@ export class CloudASKGApi implements ASKGTransport {
           `/askg/session/${encodeURIComponent(sessionId)}/turn`,
           {
             method: "POST",
-            body: JSON.stringify(request),
+            body: JSON.stringify({ protocolVersion: ASKG_PROTOCOL_VERSION, ...request }),
             signal: options.signal,
             headers: lastSeq > 0 ? { "Last-Event-ID": String(lastSeq) } : undefined,
           },
@@ -439,25 +457,37 @@ export class CloudASKGApi implements ASKGTransport {
   }
 
   /**
-   * Posts one client tool result. The key makes a redelivered result a no-op
-   * on the server after a resume replays the same tool call.
+   * Posts one client tool result. The idempotency key is the tool call id, so a
+   * result redelivered after a resume is recorded once. Refusals that describe
+   * the call rather than the connection are returned instead of thrown: the
+   * turn is still running and the timeline says what happened to the row.
    */
   async postToolResult(
     sessionId: string,
     payload: ToolResultPayload,
-    options: { idempotencyKey: string; signal?: AbortSignal },
-  ): Promise<void> {
+    options: { signal?: AbortSignal } = {},
+  ): Promise<ASKGToolResultOutcome> {
     try {
       await this.options.request<void>(
         `/askg/session/${encodeURIComponent(sessionId)}/tool-result`,
         {
           method: "POST",
           body: JSON.stringify(payload),
-          headers: { "Idempotency-Key": options.idempotencyKey },
+          // The route requires the header and the body to name the same call.
+          headers: { "Idempotency-Key": payload.toolCallId },
           signal: options.signal,
         },
       );
+      // 200 and 202 both mean the turn has the result; the buffered request
+      // path does not surface which one answered.
+      return "accepted";
     } catch (error) {
+      if (error instanceof ApiRequestError) {
+        if (error.status === 404) return "unknown-call";
+        if (error.status === 410) return "too-late";
+        if (error.status === 413) return "too-large";
+        if (error.status === 409) return "already-recorded";
+      }
       throw classifyASKGRequestError(error);
     }
   }

--- a/src/api-client/askg.ts
+++ b/src/api-client/askg.ts
@@ -1,0 +1,483 @@
+import {
+  ASKG_PROTOCOL_VERSION,
+  type ASKGDoneReason,
+  type ASKGErrorCode,
+  type ASKGSessionContext,
+  type ASKGSessionStartRequest,
+  type ASKGSessionStartResponse,
+  type ASKGSseEvent,
+  type ToolResultPayload,
+} from "../plugins/builtin/cloud/askg/protocol";
+import { ApiRequestError } from "./errors";
+import { STREAMING_UNSUPPORTED_STATUS } from "./request";
+
+/** Turn body posted to `/askg/session/{id}/turn`; mirrored by the platform. */
+export interface ASKGTurnRequest {
+  prompt: string;
+  context?: ASKGSessionContext;
+}
+
+/** Client-side failure codes, layered on top of the wire error codes. */
+export type ASKGClientErrorCode =
+  | ASKGErrorCode
+  | "transport_unsupported"
+  | "unauthorized"
+  | "network"
+  | "protocol";
+
+export class ASKGTransportError extends Error {
+  constructor(
+    readonly code: ASKGClientErrorCode,
+    message: string,
+    readonly options: { retryable?: boolean; retryAfterMs?: number; status?: number } = {},
+  ) {
+    super(message);
+    this.name = "ASKGTransportError";
+  }
+
+  get retryable(): boolean {
+    return this.options.retryable ?? false;
+  }
+
+  get retryAfterMs(): number | undefined {
+    return this.options.retryAfterMs;
+  }
+}
+
+export interface ASKGStreamOptions {
+  signal?: AbortSignal;
+  onEvent(event: ASKGSseEvent): void;
+  /** Highest `seq` already applied, so a resumed stream skips what was seen. */
+  lastEventId?: number;
+}
+
+export interface ASKGTransport {
+  isStreamingSupported(): boolean;
+  startSession(
+    request: ASKGSessionStartRequest,
+    options?: { signal?: AbortSignal },
+  ): Promise<ASKGSessionStartResponse>;
+  streamTurn(
+    sessionId: string,
+    request: ASKGTurnRequest,
+    options: ASKGStreamOptions,
+  ): Promise<ASKGDoneReason | null>;
+  postToolResult(
+    sessionId: string,
+    payload: ToolResultPayload,
+    options: { idempotencyKey: string; signal?: AbortSignal },
+  ): Promise<void>;
+  cancelTurn(
+    sessionId: string,
+    turnId: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<void>;
+}
+
+/** One decoded server-sent event frame. */
+export interface SseFrame {
+  id?: string;
+  event?: string;
+  data: string;
+}
+
+/**
+ * Incremental server-sent events decoder. Chunk boundaries never line up with
+ * frame boundaries, so the trailing partial line is held until more bytes
+ * arrive and only a blank line dispatches a frame.
+ */
+export function createSseDecoder(): {
+  push(chunk: string): SseFrame[];
+  flush(): SseFrame[];
+} {
+  let buffer = "";
+  let dataLines: string[] = [];
+  let id: string | undefined;
+  let event: string | undefined;
+
+  const takeFrame = (): SseFrame | null => {
+    if (dataLines.length === 0 && event === undefined && id === undefined) return null;
+    const frame: SseFrame = {
+      data: dataLines.join("\n"),
+      ...(id !== undefined ? { id } : {}),
+      ...(event !== undefined ? { event } : {}),
+    };
+    dataLines = [];
+    event = undefined;
+    id = undefined;
+    return frame.data ? frame : null;
+  };
+
+  const consumeLine = (line: string, frames: SseFrame[]): void => {
+    if (line === "") {
+      const frame = takeFrame();
+      if (frame) frames.push(frame);
+      return;
+    }
+    // A leading colon is a comment, used for keep-alive pings.
+    if (line.startsWith(":")) return;
+    const colon = line.indexOf(":");
+    const field = colon === -1 ? line : line.slice(0, colon);
+    const rawValue = colon === -1 ? "" : line.slice(colon + 1);
+    const value = rawValue.startsWith(" ") ? rawValue.slice(1) : rawValue;
+    if (field === "data") dataLines.push(value);
+    else if (field === "event") event = value;
+    else if (field === "id") id = value;
+  };
+
+  return {
+    push(chunk) {
+      const frames: SseFrame[] = [];
+      buffer += chunk;
+      // \r\n, \n, and \r are all valid SSE line terminators.
+      let match = buffer.match(/\r\n|\n|\r/);
+      while (match?.index !== undefined) {
+        const line = buffer.slice(0, match.index);
+        buffer = buffer.slice(match.index + match[0].length);
+        consumeLine(line, frames);
+        match = buffer.match(/\r\n|\n|\r/);
+      }
+      return frames;
+    },
+    flush() {
+      const frames: SseFrame[] = [];
+      if (buffer) {
+        consumeLine(buffer, frames);
+        buffer = "";
+      }
+      const frame = takeFrame();
+      if (frame) frames.push(frame);
+      return frames;
+    },
+  };
+}
+
+function isAskgEvent(value: unknown): value is ASKGSseEvent {
+  if (value == null || typeof value !== "object") return false;
+  const candidate = value as { type?: unknown; seq?: unknown };
+  return typeof candidate.type === "string" && typeof candidate.seq === "number";
+}
+
+/** Parses one frame payload, ignoring keep-alives and unknown shapes. */
+export function parseASKGFrame(frame: SseFrame): ASKGSseEvent | null {
+  const data = frame.data.trim();
+  if (!data || data === "[DONE]") return null;
+  try {
+    const parsed: unknown = JSON.parse(data);
+    return isAskgEvent(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface ReadASKGStreamOptions {
+  onEvent(event: ASKGSseEvent): void;
+  /** Events at or below this `seq` were already applied before a resume. */
+  lastSeq?: number;
+  signal?: AbortSignal;
+}
+
+export interface ASKGStreamOutcome {
+  /** Highest applied `seq`, used as `Last-Event-ID` when resuming. */
+  lastSeq: number;
+  /** Set when the stream carried a terminal `done` event. */
+  done: ASKGDoneReason | null;
+}
+
+/**
+ * Drains one SSE body into typed events. Duplicate and replayed events are
+ * dropped by `seq` so a resumed stream is idempotent for the caller.
+ */
+export async function readASKGEventStream(
+  body: ReadableStream<Uint8Array>,
+  options: ReadASKGStreamOptions,
+): Promise<ASKGStreamOutcome> {
+  const decoder = new TextDecoder();
+  const sse = createSseDecoder();
+  const reader = body.getReader();
+  let lastSeq = options.lastSeq ?? 0;
+  let done: ASKGDoneReason | null = null;
+
+  const applyFrames = (frames: SseFrame[]): void => {
+    for (const frame of frames) {
+      const event = parseASKGFrame(frame);
+      if (!event || event.seq <= lastSeq) continue;
+      lastSeq = event.seq;
+      if (event.type === "done") done = event.reason;
+      options.onEvent(event);
+    }
+  };
+
+  const abort = () => {
+    void reader.cancel().catch(() => {});
+  };
+  options.signal?.addEventListener("abort", abort, { once: true });
+  try {
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      applyFrames(sse.push(decoder.decode(chunk.value, { stream: true })));
+      if (done) break;
+    }
+    if (!done) applyFrames(sse.flush());
+    return { lastSeq, done };
+  } finally {
+    options.signal?.removeEventListener("abort", abort);
+    try {
+      reader.releaseLock?.();
+    } catch {
+      // A reader cancelled mid-read cannot release its lock; nothing to undo.
+    }
+  }
+}
+
+/** Number of times a dropped stream is reopened with `Last-Event-ID`. */
+const MAX_STREAM_RESUMES = 2;
+const RESUME_BACKOFF_MS = 250;
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
+}
+
+function retryAfterMsFromError(error: ApiRequestError): number | undefined {
+  const match = error.message.match(/(\d+)\s*(seconds|second|s)\b/i);
+  if (!match?.[1]) return undefined;
+  return Number(match[1]) * 1000;
+}
+
+/** Maps an HTTP failure onto the same codes the stream itself reports. */
+export function classifyASKGRequestError(error: unknown): ASKGTransportError {
+  if (error instanceof ASKGTransportError) return error;
+  if (error instanceof ApiRequestError) {
+    if (error.status === STREAMING_UNSUPPORTED_STATUS) {
+      return new ASKGTransportError(
+        "transport_unsupported",
+        "Ask Gloom needs a streaming connection, which this window cannot open.",
+      );
+    }
+    if (error.status === 401 || error.status === 403) {
+      return new ASKGTransportError("unauthorized", "Sign in to Gloom Cloud to ask Gloom.", {
+        status: error.status,
+      });
+    }
+    if (error.status === 429) {
+      return new ASKGTransportError("rate_limited", error.message || "Too many requests.", {
+        retryable: true,
+        retryAfterMs: retryAfterMsFromError(error),
+        status: error.status,
+      });
+    }
+    if (error.status === 402) {
+      return new ASKGTransportError("daily_turn_cap", error.message || "Daily limit reached.", {
+        status: error.status,
+      });
+    }
+    if (error.status === 503) {
+      return new ASKGTransportError("model_unavailable", error.message || "Ask Gloom is unavailable.", {
+        retryable: true,
+        status: error.status,
+      });
+    }
+    return new ASKGTransportError("internal", error.message || "Ask Gloom failed.", {
+      status: error.status,
+    });
+  }
+  if (isAbortError(error)) {
+    return new ASKGTransportError("network", "Ask Gloom was cancelled.");
+  }
+  return new ASKGTransportError(
+    "network",
+    error instanceof Error ? error.message : "Ask Gloom could not reach the server.",
+    { retryable: true },
+  );
+}
+
+interface CloudASKGApiOptions {
+  request<T>(path: string, options?: RequestInit): Promise<T>;
+  openStream(path: string, options?: RequestInit): Promise<Response>;
+  isStreamingSupported(): boolean;
+  /** Overridable so tests do not wait on real backoff. */
+  delay?(ms: number, signal?: AbortSignal): Promise<void>;
+}
+
+async function defaultDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal?.aborted) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Streaming client for the ASKG turn protocol. `apiClient.request` buffers and
+ * JSON-parses every response, so the turn stream takes its own path and keeps
+ * the body live; the session, tool result, and cancel calls stay on the normal
+ * request path.
+ */
+export class CloudASKGApi implements ASKGTransport {
+  private readonly delay: (ms: number, signal?: AbortSignal) => Promise<void>;
+
+  constructor(private readonly options: CloudASKGApiOptions) {
+    this.delay = options.delay ?? defaultDelay;
+  }
+
+  isStreamingSupported(): boolean {
+    return this.options.isStreamingSupported();
+  }
+
+  async startSession(
+    request: ASKGSessionStartRequest,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<ASKGSessionStartResponse> {
+    try {
+      const response = await this.options.request<ASKGSessionStartResponse>("/askg/session", {
+        method: "POST",
+        body: JSON.stringify(request),
+        signal: options.signal,
+      });
+      if (response?.protocolVersion !== ASKG_PROTOCOL_VERSION) {
+        throw new ASKGTransportError(
+          "protocol",
+          `Ask Gloom speaks protocol v${response?.protocolVersion ?? "?"}, this build speaks v${ASKG_PROTOCOL_VERSION}. Update Gloomberb.`,
+        );
+      }
+      return response;
+    } catch (error) {
+      throw classifyASKGRequestError(error);
+    }
+  }
+
+  /**
+   * Reads one turn. A stream that drops before `done` is reopened with
+   * `Last-Event-ID` set to the highest applied `seq`, so the answer continues
+   * instead of restarting.
+   */
+  async streamTurn(
+    sessionId: string,
+    request: ASKGTurnRequest,
+    options: ASKGStreamOptions,
+  ): Promise<ASKGDoneReason | null> {
+    if (!this.isStreamingSupported()) {
+      throw new ASKGTransportError(
+        "transport_unsupported",
+        "Ask Gloom needs a streaming connection, which this window cannot open.",
+      );
+    }
+
+    let lastSeq = options.lastEventId ?? 0;
+    let attempt = 0;
+    for (;;) {
+      let response: Response;
+      try {
+        response = await this.options.openStream(
+          `/askg/session/${encodeURIComponent(sessionId)}/turn`,
+          {
+            method: "POST",
+            body: JSON.stringify(request),
+            signal: options.signal,
+            headers: lastSeq > 0 ? { "Last-Event-ID": String(lastSeq) } : undefined,
+          },
+        );
+      } catch (error) {
+        const transportError = classifyASKGRequestError(error);
+        // Only a dropped connection is worth reopening; a refusal is final.
+        if (
+          transportError.code !== "network"
+          || attempt >= MAX_STREAM_RESUMES
+          || options.signal?.aborted
+          || lastSeq === 0
+        ) {
+          throw transportError;
+        }
+        attempt += 1;
+        await this.delay(RESUME_BACKOFF_MS * attempt, options.signal);
+        continue;
+      }
+
+      if (!response.body) {
+        throw new ASKGTransportError(
+          "transport_unsupported",
+          "Ask Gloom needs a streaming connection, which this window cannot open.",
+        );
+      }
+
+      try {
+        const outcome = await readASKGEventStream(response.body, {
+          onEvent: options.onEvent,
+          lastSeq,
+          signal: options.signal,
+        });
+        if (outcome.done) return outcome.done;
+        lastSeq = outcome.lastSeq;
+      } catch (error) {
+        if (isAbortError(error) || options.signal?.aborted) return null;
+        const outcomeError = classifyASKGRequestError(error);
+        if (attempt >= MAX_STREAM_RESUMES) throw outcomeError;
+        attempt += 1;
+        await this.delay(RESUME_BACKOFF_MS * attempt, options.signal);
+        continue;
+      }
+
+      if (options.signal?.aborted) return null;
+      if (attempt >= MAX_STREAM_RESUMES) {
+        throw new ASKGTransportError(
+          "network",
+          "The answer stream ended before it finished.",
+          { retryable: true },
+        );
+      }
+      attempt += 1;
+      await this.delay(RESUME_BACKOFF_MS * attempt, options.signal);
+    }
+  }
+
+  /**
+   * Posts one client tool result. The key makes a redelivered result a no-op
+   * on the server after a resume replays the same tool call.
+   */
+  async postToolResult(
+    sessionId: string,
+    payload: ToolResultPayload,
+    options: { idempotencyKey: string; signal?: AbortSignal },
+  ): Promise<void> {
+    try {
+      await this.options.request<void>(
+        `/askg/session/${encodeURIComponent(sessionId)}/tool-result`,
+        {
+          method: "POST",
+          body: JSON.stringify(payload),
+          headers: { "Idempotency-Key": options.idempotencyKey },
+          signal: options.signal,
+        },
+      );
+    } catch (error) {
+      throw classifyASKGRequestError(error);
+    }
+  }
+
+  async cancelTurn(
+    sessionId: string,
+    turnId: string,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<void> {
+    try {
+      await this.options.request<void>(
+        `/askg/session/${encodeURIComponent(sessionId)}/cancel`,
+        {
+          method: "POST",
+          body: JSON.stringify({ turnId }),
+          signal: options.signal,
+        },
+      );
+    } catch (error) {
+      throw classifyASKGRequestError(error);
+    }
+  }
+}

--- a/src/api-client/errors.ts
+++ b/src/api-client/errors.ts
@@ -5,10 +5,25 @@ const HARD_SESSION_INVALID_PATTERNS = [
 ];
 
 export class ApiRequestError extends Error {
-  constructor(message: string, readonly status?: number) {
+  constructor(
+    message: string,
+    readonly status?: number,
+    /** `Retry-After` in milliseconds when the server sent one. */
+    readonly retryAfterMs?: number,
+  ) {
     super(message);
     this.name = "ApiRequestError";
   }
+}
+
+/** Reads `Retry-After` as milliseconds, accepting seconds or an HTTP date. */
+export function parseRetryAfterMs(header: string | null, now = Date.now()): number | undefined {
+  if (!header) return undefined;
+  const trimmed = header.trim();
+  if (/^\d+$/.test(trimmed)) return Number(trimmed) * 1000;
+  const at = Date.parse(trimmed);
+  if (Number.isNaN(at)) return undefined;
+  return Math.max(0, at - now);
 }
 
 export function parseApiErrorMessage(body: string): string {

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -97,7 +97,7 @@ import {
 export type * from "./types";
 export { setCloudApiFetchTransport } from "./request";
 export { ASKGTransportError } from "./askg";
-export type { ASKGTransport, ASKGTurnRequest } from "./askg";
+export type { ASKGTransport, ASKGToolResultOutcome } from "./askg";
 
 /** Server-side caps for `/assist/command`; enforced here so a 422 is never sent. */
 const ASSIST_QUERY_MAX_LENGTH = 200;

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -1,5 +1,6 @@
 import type { TickerFinancials } from "../types/financials";
 import type { InstrumentSearchResult } from "../types/instrument";
+import { CloudASKGApi } from "./askg";
 import { CloudAuthApi } from "./auth";
 import { CloudChatApi } from "./chat";
 import { CloudDataApi } from "./data";
@@ -95,6 +96,8 @@ import {
 
 export type * from "./types";
 export { setCloudApiFetchTransport } from "./request";
+export { ASKGTransportError } from "./askg";
+export type { ASKGTransport, ASKGTurnRequest } from "./askg";
 
 /** Server-side caps for `/assist/command`; enforced here so a 422 is never sent. */
 const ASSIST_QUERY_MAX_LENGTH = 200;
@@ -113,6 +116,7 @@ class GloomApiClient {
   private readonly socket: CloudApiSocket;
   private readonly chat: CloudChatApi;
   private readonly data: CloudDataApi;
+  readonly askg: CloudASKGApi;
 
   constructor() {
     this.auth = new CloudAuthApi({
@@ -149,6 +153,11 @@ class GloomApiClient {
       socket: this.socket,
     });
     this.data = new CloudDataApi((path, options) => this.request(path, options));
+    this.askg = new CloudASKGApi({
+      request: (path, options) => this.request(path, options),
+      openStream: (path, options) => this.transport.openStream(path, options),
+      isStreamingSupported: () => this.transport.isStreamingSupported(),
+    });
   }
 
   getSessionToken(): string | null {

--- a/src/api-client/request.ts
+++ b/src/api-client/request.ts
@@ -1,4 +1,4 @@
-import { httpFetch } from "../utils/http-transport";
+import { httpFetch, isHttpFetchStreaming } from "../utils/http-transport";
 import { withDeadline } from "../utils/async-deadline";
 import { ApiRequestError, parseApiErrorMessage } from "./errors";
 import {
@@ -10,16 +10,48 @@ import {
 
 const DEFAULT_API_URL = "https://api.gloom.sh";
 const DEFAULT_MARKET_REQUEST_TIMEOUT_MS = 10_000;
+/** Local status for "this runtime cannot stream", never returned by the server. */
+export const STREAMING_UNSUPPORTED_STATUS = 0;
 const SESSION_COOKIE_NAMES = ["__Secure-gloomberb.session_token", "gloomberb.session_token"] as const;
 
 type CloudApiResponse = Pick<Response, "ok" | "status" | "headers" | "text">;
 type CloudApiFetchTransport = (url: string, init?: RequestInit) => Promise<CloudApiResponse>;
+type CloudApiStreamFetch = (url: string, init?: RequestInit) => Promise<Response>;
 type SessionCookieName = (typeof SESSION_COOKIE_NAMES)[number];
 
-let cloudApiFetchTransport: CloudApiFetchTransport = httpFetch;
+export interface CloudApiFetchTransportOptions {
+  /**
+   * Whether the transport resolves once headers arrive and exposes a live
+   * `response.body`. The desktop transport proxies over RPC and returns the
+   * whole payload as a string, so it must stay false: a caller that waits for
+   * server-sent events on it would never see a first token.
+   */
+  streaming?: boolean;
+}
 
-export function setCloudApiFetchTransport(transport: CloudApiFetchTransport | null): void {
+let cloudApiFetchTransport: CloudApiFetchTransport = httpFetch;
+let cloudApiTransportInstalled = false;
+let cloudApiFetchStreaming = true;
+
+export function setCloudApiFetchTransport(
+  transport: CloudApiFetchTransport | null,
+  options: CloudApiFetchTransportOptions = {},
+): void {
   cloudApiFetchTransport = transport ?? httpFetch;
+  cloudApiTransportInstalled = !!transport;
+  cloudApiFetchStreaming = transport ? options.streaming ?? false : true;
+}
+
+/**
+ * The fetch to use for a response that must be read while it arrives, or null
+ * when the installed transport buffers whole responses.
+ */
+export function getCloudApiStreamFetch(): CloudApiStreamFetch | null {
+  if (cloudApiTransportInstalled) {
+    // A transport that declares streaming returns a real Response.
+    return cloudApiFetchStreaming ? cloudApiFetchTransport as CloudApiStreamFetch : null;
+  }
+  return isHttpFetchStreaming() ? httpFetch : null;
 }
 
 declare const __GLOOMBERB_API_URL__: string | undefined;
@@ -102,6 +134,48 @@ export class CloudApiRequestTransport {
     if (!this.websocketToken || !this.sessionToken) return false;
     this.websocketToken = null;
     return true;
+  }
+
+  /** False when this transport buffers whole responses, e.g. the desktop view. */
+  isStreamingSupported(): boolean {
+    return !this.fetchTransport && !!getCloudApiStreamFetch();
+  }
+
+  /**
+   * Opens a response that the caller reads incrementally. Unlike `request`,
+   * nothing is buffered or JSON-parsed here, so the body stays a live stream.
+   */
+  async openStream(path: string, options: RequestInit = {}): Promise<Response> {
+    throwIfRequestAborted(options.signal);
+    const streamFetch = this.fetchTransport ? null : getCloudApiStreamFetch();
+    if (!streamFetch) {
+      throw new ApiRequestError(
+        "This client cannot read streaming responses.",
+        STREAMING_UNSUPPORTED_STATUS,
+      );
+    }
+    const headers = new Headers(options.headers);
+    if (!headers.has("Content-Type") && options.method && options.method !== "GET") {
+      headers.set("Content-Type", "application/json");
+    }
+    if (!headers.has("Accept")) headers.set("Accept", "text/event-stream");
+    this.setSessionCookieHeader(headers);
+    headers.set("Origin", this.baseUrl);
+
+    const operation = `${options.method ?? "GET"} ${path.split("?")[0]}`;
+    return this.connectionHealth.track(GLOOM_CLOUD_HTTP_CONNECTION_ID, operation, async () => {
+      const response = await streamFetch(`${this.baseUrl}${path}`, {
+        ...options,
+        headers,
+        credentials: "include",
+      });
+      throwIfRequestAborted(options.signal);
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new ApiRequestError(parseApiErrorMessage(text), response.status);
+      }
+      return response;
+    });
   }
 
   async request<T>(path: string, options?: RequestInit): Promise<T> {

--- a/src/api-client/request.ts
+++ b/src/api-client/request.ts
@@ -1,6 +1,6 @@
 import { httpFetch, isHttpFetchStreaming } from "../utils/http-transport";
 import { withDeadline } from "../utils/async-deadline";
-import { ApiRequestError, parseApiErrorMessage } from "./errors";
+import { ApiRequestError, parseApiErrorMessage, parseRetryAfterMs } from "./errors";
 import {
   connectionHealth,
   GLOOM_CLOUD_FRED_CONNECTION_ID,
@@ -172,7 +172,11 @@ export class CloudApiRequestTransport {
       throwIfRequestAborted(options.signal);
       if (!response.ok) {
         const text = await response.text().catch(() => "");
-        throw new ApiRequestError(parseApiErrorMessage(text), response.status);
+        throw new ApiRequestError(
+          parseApiErrorMessage(text),
+          response.status,
+          parseRetryAfterMs(response.headers.get("Retry-After")),
+        );
       }
       return response;
     });
@@ -234,7 +238,7 @@ export class CloudApiRequestTransport {
 
       if (!res.ok) {
         const msg = parseApiErrorMessage(text);
-        throw new ApiRequestError(msg, res.status);
+        throw new ApiRequestError(msg, res.status, parseRetryAfterMs(res.headers.get("Retry-After")));
       }
 
       if (!text) return undefined as T;

--- a/src/components/command-bar/assist/model.test.ts
+++ b/src/components/command-bar/assist/model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildAssistResultItems,
   formatAssistCandidateLabel,
+  isQuestionLike,
   shouldAutoAskAssist,
   shouldShowAssistRow,
   type AssistRequestState,
@@ -34,6 +35,18 @@ describe("shouldAutoAskAssist", () => {
     expect(shouldAutoAskAssist({ query: "T NVDA", hasShortcutIntent: true })).toBe(false);
     expect(shouldAutoAskAssist({ query: "gg", hasShortcutIntent: false })).toBe(false);
     expect(shouldAutoAskAssist({ query: "   ", hasShortcutIntent: false })).toBe(false);
+  });
+});
+
+describe("isQuestionLike", () => {
+  test("reads a question mark or a leading question word as a question", () => {
+    expect(isQuestionLike("why is NVDA down")).toBe(true);
+    expect(isQuestionLike("chart nvidia vs amd?")).toBe(true);
+    expect(isQuestionLike("compare NVDA and AMD")).toBe(true);
+    // A single word is a prefix search, even when it reads like a question word.
+    expect(isQuestionLike("is")).toBe(false);
+    expect(isQuestionLike("chart nvidia vs amd")).toBe(false);
+    expect(isQuestionLike("  ")).toBe(false);
   });
 });
 
@@ -105,6 +118,59 @@ describe("buildAssistResultItems", () => {
     expect(items[0]?.accent).toBe(true);
     items[0]?.action();
     expect(runs).toEqual([["G NVDA AMD", "G"]]);
+  });
+
+  test("offers the assistant pane for a question, without taking Enter from a command", () => {
+    const asked: string[] = [];
+    const items = buildAssistResultItems({
+      ...handlers,
+      onAskGloom: (question) => asked.push(question),
+      query: "why is NVDA down?",
+      enabled: true,
+      auto: true,
+      state: {
+        status: "answered",
+        query: "why is NVDA down?",
+        source: "auto",
+        candidates: [{ input: "DES NVDA", title: "Open security details for NVDA", prefix: "DES", confidence: 0.8 }],
+      },
+    });
+
+    expect(items.map((item) => item.label)).toEqual([
+      "NVDA \u00b7 Open security details",
+      "why is NVDA down? \u00b7 Ask Gloom",
+    ]);
+    expect(items[1]?.badge).toBe("ASKG");
+    expect(items[1]?.defaultSelectable).toBe(false);
+    items[1]?.action();
+    expect(asked).toEqual(["why is NVDA down?"]);
+  });
+
+  test("replaces the dead-end row when no command fits the query", () => {
+    const items = buildAssistResultItems({
+      ...handlers,
+      onAskGloom: () => {},
+      query: "tell me about the bond market",
+      enabled: true,
+      auto: true,
+      state: {
+        status: "answered",
+        query: "tell me about the bond market",
+        source: "auto",
+        candidates: [],
+      },
+    });
+
+    expect(items.map((item) => item.label)).toEqual(["tell me about the bond market \u00b7 Ask Gloom"]);
+    // Nothing local fits, so Enter belongs to the assistant.
+    expect(items[0]?.defaultSelectable).toBe(true);
+  });
+
+  test("leaves the row out when the assistant pane is unavailable", () => {
+    expect(labels(
+      { status: "answered", query: "why is NVDA down?", source: "auto", candidates: [] },
+      { query: "why is NVDA down?" },
+    )).toEqual(["No command found — try HELP"]);
   });
 
   test("ignores an answer that belongs to an earlier query", () => {

--- a/src/components/command-bar/assist/model.ts
+++ b/src/components/command-bar/assist/model.ts
@@ -31,6 +31,53 @@ export interface AssistRowHandlers {
   onAsk: () => void;
   onSignUp: () => void;
   onRunCandidate: (input: string, prefix?: string) => void;
+  /**
+   * Opens the assistant pane with the typed question. Omitted when the ASKG
+   * pane is unavailable, which keeps the row out of the list entirely.
+   */
+  onAskGloom?: (query: string) => void;
+}
+
+/** Prefix the assistant pane is reached by, shown in the row's badge column. */
+const ASKG_PREFIX = "ASKG";
+
+const QUESTION_WORDS = new Set([
+  "what", "whats", "why", "how", "when", "where", "who", "which", "whose",
+  "is", "are", "was", "were", "do", "does", "did", "can", "could", "should",
+  "would", "will", "has", "have", "explain", "compare", "summarize", "summarise",
+]);
+
+/**
+ * Whether the text reads as a question rather than a command. A question mark
+ * settles it; otherwise a leading question word only counts in a phrase, so
+ * "is" on its own stays a prefix search.
+ */
+export function isQuestionLike(query: string): boolean {
+  const trimmed = query.trim();
+  if (!trimmed) return false;
+  if (trimmed.endsWith("?")) return true;
+  if (!/\s/.test(trimmed)) return false;
+  const first = trimmed.split(/\s+/)[0]?.toLowerCase().replace(/[^a-z]/g, "") ?? "";
+  return QUESTION_WORDS.has(first);
+}
+
+/**
+ * Whether the assistant pane is worth offering: the user asked a question, or
+ * the command translation came back without a command that fits.
+ */
+export function shouldOfferAskGloom({
+  query,
+  state,
+}: {
+  query: string;
+  state: AssistRequestState;
+}): boolean {
+  const trimmed = query.trim();
+  if (!trimmed) return false;
+  if (isQuestionLike(trimmed)) return true;
+  return state.status === "answered"
+    && state.query === trimmed
+    && state.candidates.length === 0;
 }
 
 /**
@@ -136,6 +183,7 @@ export function buildAssistResultItems({
   onAsk,
   onSignUp,
   onRunCandidate,
+  onAskGloom,
 }: AssistRowHandlers & { query: string }): ResultItem[] {
   const trimmed = query.trim();
   if (!trimmed) return [];
@@ -155,31 +203,55 @@ export function buildAssistResultItems({
   // A response only describes the query it was asked about.
   const active = state.status !== "idle" && state.query === trimmed ? state : null;
 
+  const askGloomRow = (defaultSelectable: boolean): ResultItem | null => (
+    onAskGloom && shouldOfferAskGloom({ query: trimmed, state })
+      ? assistRow({
+        id: "assist:ask-gloom",
+        label: `${trimmed} · ${t("Ask Gloom")}`,
+        badge: ASKG_PREFIX,
+        kind: "action",
+        action: () => onAskGloom(trimmed),
+        defaultSelectable,
+      })
+      : null
+  );
+
   if (!active) {
-    if (!auto) return [];
+    const askGloom = askGloomRow(false);
+    if (!auto) return askGloom ? [askGloom] : [];
     // Still inside the debounce window; activating the row skips the wait.
-    return [assistRow({ id: "assist:pending", label: t("Thinking…"), kind: "info", action: onAsk })];
+    const pending = assistRow({ id: "assist:pending", label: t("Thinking…"), kind: "info", action: onAsk });
+    return askGloom ? [pending, askGloom] : [pending];
   }
 
   if (active.status === "loading") {
     // Selectable so that Enter on it means something: it claims the answer
     // that is already on the wire.
-    return [assistRow({ id: "assist:loading", label: t("Thinking…"), kind: "info", action: onAsk })];
+    const loading = assistRow({ id: "assist:loading", label: t("Thinking…"), kind: "info", action: onAsk });
+    const askGloom = askGloomRow(false);
+    return askGloom ? [loading, askGloom] : [loading];
   }
 
   if (active.status === "error") {
+    // The assistant pane does not depend on the command translation, so a
+    // failed translation still leaves the question answerable.
+    const askGloom = askGloomRow(true);
     // A background failure is not worth a row the user never asked for.
-    if (active.source === "auto") return [];
-    return [assistRow({
+    if (active.source === "auto") return askGloom ? [askGloom] : [];
+    const error = assistRow({
       id: "assist:error",
       label: assistErrorLabel(active.kind),
       kind: "info",
       action: onAsk,
       defaultSelectable: false,
-    })];
+    });
+    return askGloom ? [error, askGloom] : [error];
   }
 
   if (active.candidates.length === 0) {
+    // Nothing local fits, so the assistant is the answer rather than a dead end.
+    const askGloom = askGloomRow(true);
+    if (askGloom) return [askGloom];
     return [assistRow({
       id: "assist:no-command",
       label: t("No command found — try HELP"),
@@ -190,11 +262,14 @@ export function buildAssistResultItems({
   // The prefix in the badge column and the argument leading the label: the
   // row doubles as a lesson in the prefix language, laid out like every
   // other row.
-  return active.candidates.map((candidate, index) => assistRow({
+  const candidateRows = active.candidates.map((candidate, index) => assistRow({
     id: `assist:candidate:${index}:${candidate.input}`,
     label: formatAssistCandidateLabel(candidate),
     badge: candidate.prefix.trim() || undefined,
     kind: "action",
     action: () => onRunCandidate(candidate.input, candidate.prefix),
   }));
+  // A resolved command is the faster answer, so it keeps the default selection.
+  const askGloom = askGloomRow(false);
+  return askGloom ? [...candidateRows, askGloom] : candidateRows;
 }

--- a/src/components/command-bar/surface/index.tsx
+++ b/src/components/command-bar/surface/index.tsx
@@ -7,6 +7,9 @@ import { usePlanAccess } from "../../../plugins/builtin/shared/plan-access";
 import { buildAssistCommandInventory } from "../assist/inventory";
 import { useCommandBarAssist } from "../assist/runtime";
 import { shouldAutoAskAssist, type AssistRowHandlers } from "../assist/model";
+
+/** Command-bar prefix of the assistant pane. */
+const ASKG_SHORTCUT_PREFIX = "ASKG";
 import {
   getAvailableCommandBarSearchProviders,
   useCommandBarSearchProviders,
@@ -243,6 +246,13 @@ export function CommandBar({
     }
     setRootQuery("Sign Up");
   }, [getAvailablePluginCommands, openPluginCommandWorkflow, setRootQuery]);
+  // The assistant pane ships with the cloud plugin, so the row only exists
+  // while that pane template is registered.
+  const askGloomTemplate = useMemo(() => (
+    getAvailablePaneTemplates(undefined, { includePromptableTickerTemplates: true })
+      .find((template) => template.shortcut?.prefix?.toUpperCase() === ASKG_SHORTCUT_PREFIX)
+      ?? null
+  ), [getAvailablePaneTemplates]);
   const assist = useMemo<AssistRowHandlers>(() => ({
     enabled: planAccess.emailVerified,
     auto: assistAutoAsk && assistActive,
@@ -253,7 +263,16 @@ export function CommandBar({
       input,
       prefix ? { fallbackPrefix: prefix } : undefined,
     ),
-  }), [askAssistNow, assistActive, assistAutoAsk, assistState, planAccess.emailVerified, startAssistSignUp]);
+    // Runs through the same submit path as typing the shortcut by hand.
+    ...(askGloomTemplate
+      ? {
+        onAskGloom: (question: string) => runRootQueryRef.current?.(
+          `${ASKG_SHORTCUT_PREFIX} ${question}`,
+          { fallbackPrefix: ASKG_SHORTCUT_PREFIX },
+        ),
+      }
+      : {}),
+  }), [askAssistNow, askGloomTemplate, assistActive, assistAutoAsk, assistState, planAccess.emailVerified, startAssistSignUp]);
 
   const searchProviders = useMemo(
     () => getAvailableCommandBarSearchProviders(pluginRegistry, state.config.disabledPlugins),

--- a/src/plugins/builtin/cloud/askg/controller.test.ts
+++ b/src/plugins/builtin/cloud/askg/controller.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  ASKGStreamOptions,
+  ASKGToolResultOutcome,
+  ASKGTransport,
+} from "../../../../api-client/askg";
+import { ASKGSessionController } from "./controller";
+import type { ASKGToolExecutor } from "./executor";
+import { pendingConfirmation } from "./model";
+import type {
+  ASKGSessionStartRequest,
+  ASKGSessionStartResponse,
+  ASKGSseEvent,
+  ASKGTurnRequest,
+  ClientToolManifest,
+  ToolResultPayload,
+} from "./protocol";
+
+const READ_TOOL: ClientToolManifest = {
+  name: "app.get_resource",
+  source: "remote-op",
+  title: "App: Get resource",
+  description: "Read an app resource.",
+  writeTier: "read",
+  confirm: "never",
+  timeoutMs: 10_000,
+};
+
+const WRITE_TOOL: ClientToolManifest = {
+  ...READ_TOOL,
+  name: "layout.delete",
+  title: "Layout: Delete",
+  writeTier: "user-data",
+  confirm: "always",
+};
+
+const MANIFEST = { tools: [READ_TOOL, WRITE_TOOL], manifestHash: "sha256:test" };
+
+function sessionResponse(): ASKGSessionStartResponse {
+  return {
+    protocolVersion: 1,
+    sessionId: "s1",
+    manifestHash: MANIFEST.manifestHash,
+    serverTools: [],
+    acceptedTools: MANIFEST.tools.map((tool) => tool.name),
+    rejectedTools: [],
+    limits: {
+      requestsPerMinute: 20,
+      turnsPerDay: 100,
+      turnsRemainingToday: 99,
+      maxToolCallsPerTurn: 8,
+      turnWallClockMs: 60_000,
+      clientToolTimeoutMs: 10_000,
+    },
+    tier: "pro",
+    model: "gloom-1",
+    promptVersion: "v1",
+    expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+  };
+}
+
+function toolCallEvent(seq: number, tool: ClientToolManifest): ASKGSseEvent {
+  return {
+    seq,
+    type: "tool-call",
+    turnId: "turn-1",
+    toolCallId: `call-${seq}`,
+    name: tool.name,
+    args: { resource: "app://panes" },
+    writeTier: tool.writeTier,
+    requiresConfirmation: tool.confirm === "always",
+    preview: { operation: tool.name },
+    timeoutMs: tool.timeoutMs,
+    expiresAt: new Date(Date.now() + tool.timeoutMs).toISOString(),
+  };
+}
+
+interface Harness {
+  controller: ASKGSessionController;
+  posted: ToolResultPayload[];
+  sessionRequests: ASKGSessionStartRequest[];
+  turnRequests: ASKGTurnRequest[];
+  emit(event: ASKGSseEvent): void;
+  streamed: Promise<void>;
+}
+
+function createHarness(options: {
+  script: ASKGSseEvent[];
+  executor?: ASKGToolExecutor;
+  toolResultOutcome?: ASKGToolResultOutcome;
+} ): Harness {
+  const posted: ToolResultPayload[] = [];
+  const sessionRequests: ASKGSessionStartRequest[] = [];
+  const turnRequests: ASKGTurnRequest[] = [];
+  let emit: (event: ASKGSseEvent) => void = () => {};
+  let finishStream: (() => void) | null = null;
+
+  const transport: ASKGTransport = {
+    isStreamingSupported: () => true,
+    async startSession(request) {
+      sessionRequests.push(request);
+      return sessionResponse();
+    },
+    async streamTurn(_sessionId: string, request: ASKGTurnRequest, streamOptions: ASKGStreamOptions) {
+      turnRequests.push(request);
+      emit = (event) => streamOptions.onEvent(event);
+      await new Promise<void>((resolve) => {
+        finishStream = resolve;
+      });
+      return "complete";
+    },
+    async postToolResult(_sessionId: string, payload: ToolResultPayload) {
+      posted.push(payload);
+      return options.toolResultOutcome ?? "accepted";
+    },
+    async cancelTurn() {},
+  };
+
+  const controller = new ASKGSessionController({
+    transport,
+    loadManifest: async () => MANIFEST,
+    getExecutor: () => options.executor ?? null,
+    client: { kind: "tui", version: "1" },
+    createId: () => "turn-1",
+  });
+
+  const streamed = controller.ask("what is open").then(() => {});
+  return {
+    controller,
+    posted,
+    sessionRequests,
+    turnRequests,
+    streamed,
+    emit: (event) => {
+      emit(event);
+      if (event.type === "done") finishStream?.();
+    },
+  };
+}
+
+function executorReturning(payload: Partial<ToolResultPayload>): {
+  executor: ASKGToolExecutor;
+  calls: Array<{ name: string; confirmed: boolean | undefined }>;
+} {
+  const calls: Array<{ name: string; confirmed: boolean | undefined }> = [];
+  return {
+    calls,
+    executor: {
+      async execute(call, executeOptions) {
+        calls.push({ name: call.name, confirmed: executeOptions?.confirmed });
+        return {
+          turnId: call.turnId,
+          toolCallId: call.toolCallId,
+          status: "ok",
+          truncated: false,
+          elapsedMs: 5,
+          ...payload,
+        };
+      },
+      async undo() {
+        return { status: "ok", elapsedMs: 1 };
+      },
+    },
+  };
+}
+
+async function settle(): Promise<void> {
+  for (let index = 0; index < 8; index += 1) await Promise.resolve();
+}
+
+describe("ASKGSessionController", () => {
+  test("runs a read tool through the executor and posts the result back", async () => {
+    const { executor, calls } = executorReturning({ rowCount: 6, result: { rows: [] } });
+    const harness = createHarness({ script: [], executor });
+    await settle();
+
+    harness.emit(toolCallEvent(1, READ_TOOL));
+    await settle();
+
+    expect(calls).toEqual([{ name: "app.get_resource", confirmed: true }]);
+    expect(harness.posted).toHaveLength(1);
+    expect(harness.posted[0]).toMatchObject({
+      toolCallId: "call-1",
+      status: "ok",
+      rowCount: 6,
+    });
+
+    const row = harness.controller.getState().turns[0]?.tools[0];
+    expect(row).toMatchObject({ name: "app.get_resource", status: "ok", rowCount: 6 });
+
+    harness.emit({ seq: 2, type: "done", turnId: "turn-1", reason: "complete" });
+    await harness.streamed;
+  });
+
+  test("sends the client turn id and the negotiated manifest", async () => {
+    const harness = createHarness({ script: [] });
+    await settle();
+    expect(harness.sessionRequests[0]).toMatchObject({
+      protocolVersion: 1,
+      manifestHash: MANIFEST.manifestHash,
+    });
+    expect(harness.turnRequests[0]).toMatchObject({ turnId: "turn-1", input: "what is open" });
+    harness.emit({ seq: 1, type: "done", turnId: "turn-1", reason: "complete" });
+    await harness.streamed;
+  });
+
+  test("holds a user-data tool until it is approved, and declines without running it", async () => {
+    const { executor, calls } = executorReturning({});
+    const harness = createHarness({ script: [], executor });
+    await settle();
+
+    harness.emit(toolCallEvent(1, WRITE_TOOL));
+    await settle();
+
+    expect(calls).toHaveLength(0);
+    const waiting = pendingConfirmation(harness.controller.getState());
+    expect(waiting).toMatchObject({ toolCallId: "call-1", status: "awaiting-confirmation" });
+
+    harness.controller.resolveConfirmation("call-1", false);
+    await settle();
+
+    expect(calls).toHaveLength(0);
+    expect(harness.posted[0]).toMatchObject({ status: "denied" });
+    expect(harness.controller.getState().turns[0]?.tools[0]?.status).toBe("denied");
+
+    harness.emit({ seq: 2, type: "done", turnId: "turn-1", reason: "complete" });
+    await harness.streamed;
+  });
+
+  test("runs a user-data tool once approved", async () => {
+    const { executor, calls } = executorReturning({});
+    const harness = createHarness({ script: [], executor });
+    await settle();
+
+    harness.emit(toolCallEvent(1, WRITE_TOOL));
+    await settle();
+    harness.controller.resolveConfirmation("call-1", true);
+    await settle();
+
+    expect(calls).toEqual([{ name: "layout.delete", confirmed: true }]);
+    expect(harness.posted[0]).toMatchObject({ status: "ok" });
+
+    harness.emit({ seq: 2, type: "done", turnId: "turn-1", reason: "complete" });
+    await harness.streamed;
+  });
+
+  test("shows a result the server refused as too late as a timed out tool", async () => {
+    const { executor } = executorReturning({ rowCount: 2 });
+    const harness = createHarness({ script: [], executor, toolResultOutcome: "too-late" });
+    await settle();
+
+    harness.emit(toolCallEvent(1, READ_TOOL));
+    await settle();
+
+    const row = harness.controller.getState().turns[0]?.tools[0];
+    expect(row?.status).toBe("timeout");
+    expect(row?.note).toContain("Gloom answered without it");
+
+    harness.emit({ seq: 2, type: "done", turnId: "turn-1", reason: "complete" });
+    await harness.streamed;
+  });
+
+  test("never leaves a tool row running when the turn ends", async () => {
+    const harness = createHarness({ script: [] });
+    await settle();
+    harness.emit(toolCallEvent(1, WRITE_TOOL));
+    await settle();
+    harness.emit({ seq: 2, type: "done", turnId: "turn-1", reason: "cancelled" });
+    await harness.streamed;
+
+    const turn = harness.controller.getState().turns[0];
+    expect(turn?.status).toBe("cancelled");
+    expect(turn?.tools[0]?.status).toBe("cancelled");
+  });
+});

--- a/src/plugins/builtin/cloud/askg/controller.ts
+++ b/src/plugins/builtin/cloud/askg/controller.ts
@@ -1,5 +1,6 @@
 import {
   ASKGTransportError,
+  type ASKGToolResultOutcome,
   type ASKGTransport,
 } from "../../../../api-client/askg";
 import type { ASKGToolExecutor } from "./executor";
@@ -21,9 +22,13 @@ import {
   type ASKGSessionStartResponse,
   type ASKGSseEvent,
   type ASKGToolCallEvent,
+  type ASKGTurnRequest,
   type ClientToolManifest,
   type ToolResultPayload,
 } from "./protocol";
+
+/** Turns kept as context for the next question. */
+const MAX_HISTORY_TURNS = 8;
 
 /** Ceiling used until the server states its own turn budget. */
 const DEFAULT_TURN_WALL_CLOCK_MS = 120_000;
@@ -44,6 +49,32 @@ export interface ASKGControllerOptions {
   getContext?(): ASKGSessionContext;
   now?(): number;
   createId?(): string;
+}
+
+/**
+ * How a refused delivery reads in the timeline. A result that misses its window
+ * is a timed out tool, because the turn already continued with a synthetic
+ * timeout for it; the other refusals describe a call the turn cannot use.
+ */
+function refusedResult(
+  payload: ToolResultPayload,
+  outcome: ASKGToolResultOutcome,
+): ToolResultPayload | null {
+  switch (outcome) {
+    case "accepted":
+    case "already-recorded":
+      return null;
+    case "too-late":
+      return {
+        ...payload,
+        status: "timeout",
+        note: "Took too long, so Gloom answered without it.",
+      };
+    case "too-large":
+      return { ...payload, status: "error", note: "Result was too large to send." };
+    case "unknown-call":
+      return { ...payload, status: "error", note: "Gloom no longer has this tool call." };
+  }
 }
 
 function errorState(error: unknown): ASKGErrorState {
@@ -74,6 +105,8 @@ export class ASKGSessionController {
   private sessionRequest: Promise<ASKGSessionStartResponse> | null = null;
   private manifest: ASKGControllerManifest | null = null;
   private readonly confirmations = new Map<string, (approved: boolean) => void>();
+  /** Calls whose turn ended while they were still waiting to be approved. */
+  private readonly abandonedCalls = new Set<string>();
   private readonly toolTasks = new Set<Promise<void>>();
   private turnAbort: AbortController | null = null;
   private disposed = false;
@@ -126,6 +159,7 @@ export class ASKGSessionController {
         sessionId: session.sessionId,
         model: session.model,
         limits: session.limits,
+        acceptedTools: session.acceptedTools,
       });
       return session;
     })();
@@ -138,12 +172,26 @@ export class ASKGSessionController {
     }
   }
 
+  /** Prior questions and answers, oldest first, for the next turn's context. */
+  private history(): ASKGTurnRequest["history"] {
+    return this.state.turns
+      .filter((turn) => turn.answer.trim().length > 0)
+      .slice(-MAX_HISTORY_TURNS)
+      .flatMap((turn) => ([
+        { role: "user" as const, text: turn.prompt },
+        { role: "assistant" as const, text: turn.answer },
+      ]));
+  }
+
   /** Asks one question and streams the answer until the turn ends. */
   async ask(prompt: string): Promise<void> {
     const trimmed = prompt.trim();
     if (!trimmed || this.disposed || isTurnRunning(this.state)) return;
 
+    // The turn id is the client's: a reconnect reuses it verbatim and
+    // re-attaches to the same turn instead of asking again.
     const turnId = this.createId();
+    const history = this.history();
     this.dispatch({ type: "prompt", turnId, prompt: trimmed, at: this.now() });
 
     const abort = new AbortController();
@@ -165,13 +213,16 @@ export class ASKGSessionController {
             retryable: true,
           },
         });
-        this.rejectPendingConfirmations();
+        this.abandonPendingConfirmations();
         abort.abort();
       }, wallClockMs);
 
       await this.options.transport.streamTurn(session.sessionId, {
-        prompt: trimmed,
+        protocolVersion: ASKG_PROTOCOL_VERSION,
+        turnId,
+        input: trimmed,
         ...(this.options.getContext ? { context: this.options.getContext() } : {}),
+        ...(history && history.length > 0 ? { history } : {}),
       }, {
         signal: abort.signal,
         onEvent: (event) => this.handleEvent(event),
@@ -182,7 +233,7 @@ export class ASKGSessionController {
       if (!abort.signal.aborted) {
         this.dispatch({ type: "turn-failed", turnId, error: errorState(error) });
       }
-      this.rejectPendingConfirmations();
+      this.abandonPendingConfirmations();
     } finally {
       if (deadline) clearTimeout(deadline);
       if (this.turnAbort === abort) this.turnAbort = null;
@@ -204,6 +255,11 @@ export class ASKGSessionController {
 
   private handleEvent(event: ASKGSseEvent): void {
     this.dispatch({ type: "event", event });
+    if (event.type === "done") {
+      // Nothing is worth approving once the turn is over.
+      this.abandonPendingConfirmations();
+      return;
+    }
     if (event.type !== "tool-call") return;
     const task = this.runToolCall(event).finally(() => {
       this.toolTasks.delete(task);
@@ -223,6 +279,19 @@ export class ASKGSessionController {
       note,
     });
 
+    const accepted = this.state.acceptedTools;
+    if (accepted.length > 0 && !accepted.includes(call.name)) {
+      await this.deliver({
+        turnId: call.turnId,
+        toolCallId: call.toolCallId,
+        status: "denied",
+        truncated: false,
+        elapsedMs: 0,
+        note: `"${call.name}" was not accepted by this session.`,
+      });
+      return;
+    }
+
     try {
       let confirmed = false;
       if (requiresLocalConfirmation(call)) {
@@ -230,6 +299,7 @@ export class ASKGSessionController {
         confirmed = await new Promise<boolean>((resolve) => {
           this.confirmations.set(call.toolCallId, resolve);
         });
+        if (this.abandonedCalls.delete(call.toolCallId)) return;
         if (!confirmed) {
           await this.deliver({
             turnId: call.turnId,
@@ -271,11 +341,11 @@ export class ASKGSessionController {
     const sessionId = this.session?.sessionId;
     if (!sessionId) return;
     try {
-      await this.options.transport.postToolResult(sessionId, payload, {
-        // Same call, same key: a replayed tool call after a resume is a no-op.
-        idempotencyKey: `${sessionId}:${payload.toolCallId}`,
+      const outcome = await this.options.transport.postToolResult(sessionId, payload, {
         ...(this.turnAbort ? { signal: this.turnAbort.signal } : {}),
       });
+      const refused = refusedResult(payload, outcome);
+      if (refused) this.dispatch({ type: "tool-result", payload: refused });
     } catch (error) {
       const note = `${payload.note ? `${payload.note} ` : ""}Result could not be delivered: ${describeASKGError(errorState(error))}`;
       this.dispatch({ type: "tool-result", payload: { ...payload, note } });
@@ -295,6 +365,12 @@ export class ASKGSessionController {
       this.confirmations.delete(toolCallId);
       resolve(false);
     }
+  }
+
+  /** Drops confirmations whose answer can no longer reach the turn. */
+  private abandonPendingConfirmations(): void {
+    for (const toolCallId of this.confirmations.keys()) this.abandonedCalls.add(toolCallId);
+    this.rejectPendingConfirmations();
   }
 
   setExpanded(toolCallId: string, expanded: boolean): void {
@@ -343,7 +419,7 @@ export class ASKGSessionController {
   /** Stops the current turn locally and tells the server to stop too. */
   cancel(): void {
     const turn = activeTurn(this.state);
-    this.rejectPendingConfirmations();
+    this.abandonPendingConfirmations();
     this.turnAbort?.abort();
     this.turnAbort = null;
     if (turn) this.dispatch({ type: "turn-cancelled", turnId: turn.id });
@@ -356,7 +432,7 @@ export class ASKGSessionController {
 
   dispose(): void {
     this.disposed = true;
-    this.rejectPendingConfirmations();
+    this.abandonPendingConfirmations();
     this.turnAbort?.abort();
     this.turnAbort = null;
     this.listeners.clear();

--- a/src/plugins/builtin/cloud/askg/controller.ts
+++ b/src/plugins/builtin/cloud/askg/controller.ts
@@ -1,0 +1,364 @@
+import {
+  ASKGTransportError,
+  type ASKGTransport,
+} from "../../../../api-client/askg";
+import type { ASKGToolExecutor } from "./executor";
+import {
+  activeTurn,
+  askgReducer,
+  describeASKGError,
+  EMPTY_ASKG_CONVERSATION,
+  isTurnRunning,
+  requiresLocalConfirmation,
+  type ASKGAction,
+  type ASKGConversationState,
+  type ASKGErrorState,
+} from "./model";
+import {
+  ASKG_PROTOCOL_VERSION,
+  type ASKGClientDescriptor,
+  type ASKGSessionContext,
+  type ASKGSessionStartResponse,
+  type ASKGSseEvent,
+  type ASKGToolCallEvent,
+  type ClientToolManifest,
+  type ToolResultPayload,
+} from "./protocol";
+
+/** Ceiling used until the server states its own turn budget. */
+const DEFAULT_TURN_WALL_CLOCK_MS = 120_000;
+/** Sessions are renegotiated a little before they expire. */
+const SESSION_EXPIRY_GRACE_MS = 5_000;
+
+export interface ASKGControllerManifest {
+  tools: ClientToolManifest[];
+  manifestHash: string;
+}
+
+export interface ASKGControllerOptions {
+  transport: ASKGTransport;
+  loadManifest(): Promise<ASKGControllerManifest>;
+  /** Null when this runtime cannot run delegated tools. */
+  getExecutor(manifest: ASKGControllerManifest): ASKGToolExecutor | null;
+  client: ASKGClientDescriptor;
+  getContext?(): ASKGSessionContext;
+  now?(): number;
+  createId?(): string;
+}
+
+function errorState(error: unknown): ASKGErrorState {
+  if (error instanceof ASKGTransportError) {
+    return {
+      code: error.code,
+      message: error.message,
+      retryable: error.retryable,
+      ...(error.retryAfterMs !== undefined ? { retryAfterMs: error.retryAfterMs } : {}),
+    };
+  }
+  return {
+    code: "internal",
+    message: error instanceof Error ? error.message : "Ask Gloom failed.",
+    retryable: true,
+  };
+}
+
+/**
+ * Runs one ASKG conversation: negotiates the session, reads the turn stream,
+ * executes delegated tool calls locally, and posts their results back. It owns
+ * no rendering, so the pane only subscribes and dispatches user intent.
+ */
+export class ASKGSessionController {
+  private state: ASKGConversationState = EMPTY_ASKG_CONVERSATION;
+  private readonly listeners = new Set<() => void>();
+  private session: ASKGSessionStartResponse | null = null;
+  private sessionRequest: Promise<ASKGSessionStartResponse> | null = null;
+  private manifest: ASKGControllerManifest | null = null;
+  private readonly confirmations = new Map<string, (approved: boolean) => void>();
+  private readonly toolTasks = new Set<Promise<void>>();
+  private turnAbort: AbortController | null = null;
+  private disposed = false;
+  private readonly now: () => number;
+  private readonly createId: () => string;
+
+  constructor(private readonly options: ASKGControllerOptions) {
+    this.now = options.now ?? Date.now;
+    this.createId = options.createId ?? (() => globalThis.crypto.randomUUID());
+  }
+
+  getState(): ASKGConversationState {
+    return this.state;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private dispatch(action: ASKGAction): void {
+    const next = askgReducer(this.state, action);
+    if (next === this.state) return;
+    this.state = next;
+    for (const listener of this.listeners) listener();
+  }
+
+  private async ensureSession(signal: AbortSignal): Promise<ASKGSessionStartResponse> {
+    const current = this.session;
+    if (current && Date.parse(current.expiresAt) - SESSION_EXPIRY_GRACE_MS > this.now()) {
+      return current;
+    }
+    if (this.sessionRequest) return this.sessionRequest;
+
+    const request = (async () => {
+      const manifest = this.manifest ?? await this.options.loadManifest();
+      this.manifest = manifest;
+      const session = await this.options.transport.startSession({
+        protocolVersion: ASKG_PROTOCOL_VERSION,
+        client: this.options.client,
+        context: this.options.getContext?.() ?? {},
+        tools: manifest.tools,
+        manifestHash: manifest.manifestHash,
+      }, { signal });
+      this.session = session;
+      this.dispatch({
+        type: "session-started",
+        sessionId: session.sessionId,
+        model: session.model,
+        limits: session.limits,
+      });
+      return session;
+    })();
+
+    this.sessionRequest = request;
+    try {
+      return await request;
+    } finally {
+      if (this.sessionRequest === request) this.sessionRequest = null;
+    }
+  }
+
+  /** Asks one question and streams the answer until the turn ends. */
+  async ask(prompt: string): Promise<void> {
+    const trimmed = prompt.trim();
+    if (!trimmed || this.disposed || isTurnRunning(this.state)) return;
+
+    const turnId = this.createId();
+    this.dispatch({ type: "prompt", turnId, prompt: trimmed, at: this.now() });
+
+    const abort = new AbortController();
+    this.turnAbort = abort;
+    let deadline: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const session = await this.ensureSession(abort.signal);
+      // A stalled stream must fail visibly rather than spin forever.
+      const wallClockMs = session.limits.turnWallClockMs > 0
+        ? session.limits.turnWallClockMs
+        : DEFAULT_TURN_WALL_CLOCK_MS;
+      deadline = setTimeout(() => {
+        this.dispatch({
+          type: "turn-failed",
+          turnId,
+          error: {
+            code: "turn_timeout",
+            message: "Gloom stopped responding before the answer finished.",
+            retryable: true,
+          },
+        });
+        this.rejectPendingConfirmations();
+        abort.abort();
+      }, wallClockMs);
+
+      await this.options.transport.streamTurn(session.sessionId, {
+        prompt: trimmed,
+        ...(this.options.getContext ? { context: this.options.getContext() } : {}),
+      }, {
+        signal: abort.signal,
+        onEvent: (event) => this.handleEvent(event),
+      });
+      // Tool calls delivered late in the stream may still be running.
+      await Promise.allSettled([...this.toolTasks]);
+    } catch (error) {
+      if (!abort.signal.aborted) {
+        this.dispatch({ type: "turn-failed", turnId, error: errorState(error) });
+      }
+      this.rejectPendingConfirmations();
+    } finally {
+      if (deadline) clearTimeout(deadline);
+      if (this.turnAbort === abort) this.turnAbort = null;
+      const turn = activeTurn(this.state);
+      // The stream can end without a `done` event after a resume gives up.
+      if (turn?.id === turnId && turn.status === "streaming") {
+        this.dispatch({
+          type: "turn-failed",
+          turnId,
+          error: {
+            code: "network",
+            message: "The answer stream ended before it finished.",
+            retryable: true,
+          },
+        });
+      }
+    }
+  }
+
+  private handleEvent(event: ASKGSseEvent): void {
+    this.dispatch({ type: "event", event });
+    if (event.type !== "tool-call") return;
+    const task = this.runToolCall(event).finally(() => {
+      this.toolTasks.delete(task);
+    });
+    this.toolTasks.add(task);
+  }
+
+  private async runToolCall(call: ASKGToolCallEvent): Promise<void> {
+    const signal = this.turnAbort?.signal;
+    const startedAt = this.now();
+    const failure = (note: string): ToolResultPayload => ({
+      turnId: call.turnId,
+      toolCallId: call.toolCallId,
+      status: "error",
+      truncated: false,
+      elapsedMs: Math.max(0, this.now() - startedAt),
+      note,
+    });
+
+    try {
+      let confirmed = false;
+      if (requiresLocalConfirmation(call)) {
+        this.dispatch({ type: "tool-awaiting-confirmation", toolCallId: call.toolCallId });
+        confirmed = await new Promise<boolean>((resolve) => {
+          this.confirmations.set(call.toolCallId, resolve);
+        });
+        if (!confirmed) {
+          await this.deliver({
+            turnId: call.turnId,
+            toolCallId: call.toolCallId,
+            status: "denied",
+            truncated: false,
+            elapsedMs: Math.max(0, this.now() - startedAt),
+            note: "You declined this action.",
+          });
+          return;
+        }
+      }
+
+      this.dispatch({ type: "tool-running", toolCallId: call.toolCallId });
+      const manifest = this.manifest ?? await this.options.loadManifest();
+      this.manifest = manifest;
+      const executor = this.options.getExecutor(manifest);
+      if (!executor) {
+        await this.deliver(failure("This window cannot run Gloomberb tools."));
+        return;
+      }
+      const payload = await executor.execute(call, {
+        confirmed: confirmed || !requiresLocalConfirmation(call),
+        ...(signal ? { signal } : {}),
+      });
+      await this.deliver(payload);
+    } catch (error) {
+      await this.deliver(failure(
+        error instanceof Error ? error.message : "The tool call failed locally.",
+      ));
+    } finally {
+      this.confirmations.delete(call.toolCallId);
+    }
+  }
+
+  /** Records a tool result locally, then posts it to the turn loop. */
+  private async deliver(payload: ToolResultPayload): Promise<void> {
+    this.dispatch({ type: "tool-result", payload });
+    const sessionId = this.session?.sessionId;
+    if (!sessionId) return;
+    try {
+      await this.options.transport.postToolResult(sessionId, payload, {
+        // Same call, same key: a replayed tool call after a resume is a no-op.
+        idempotencyKey: `${sessionId}:${payload.toolCallId}`,
+        ...(this.turnAbort ? { signal: this.turnAbort.signal } : {}),
+      });
+    } catch (error) {
+      const note = `${payload.note ? `${payload.note} ` : ""}Result could not be delivered: ${describeASKGError(errorState(error))}`;
+      this.dispatch({ type: "tool-result", payload: { ...payload, note } });
+    }
+  }
+
+  /** Answers a `user-data` or `broker` confirmation prompt. */
+  resolveConfirmation(toolCallId: string, approved: boolean): void {
+    const resolve = this.confirmations.get(toolCallId);
+    if (!resolve) return;
+    this.confirmations.delete(toolCallId);
+    resolve(approved);
+  }
+
+  private rejectPendingConfirmations(): void {
+    for (const [toolCallId, resolve] of [...this.confirmations]) {
+      this.confirmations.delete(toolCallId);
+      resolve(false);
+    }
+  }
+
+  setExpanded(toolCallId: string, expanded: boolean): void {
+    this.dispatch({ type: "tool-expanded", toolCallId, expanded });
+  }
+
+  /** Reverts a `ui-write` tool call through the undo token it returned. */
+  async undo(toolCallId: string): Promise<void> {
+    const row = this.state.turns
+      .flatMap((turn) => turn.tools)
+      .find((entry) => entry.toolCallId === toolCallId);
+    if (!row?.undoToken || row.undo?.status === "running") return;
+    const manifest = this.manifest ?? await this.options.loadManifest();
+    this.manifest = manifest;
+    const executor = this.options.getExecutor(manifest);
+    if (!executor) {
+      this.dispatch({
+        type: "undo",
+        toolCallId,
+        undo: { status: "failed", note: "This window cannot undo tool calls." },
+      });
+      return;
+    }
+    this.dispatch({ type: "undo", toolCallId, undo: { status: "running" } });
+    try {
+      const applied = await executor.undo(row.undoToken);
+      this.dispatch({
+        type: "undo",
+        toolCallId,
+        undo: applied.status === "ok"
+          ? { status: "done" }
+          : { status: "failed", ...(applied.note ? { note: applied.note } : {}) },
+      });
+    } catch (error) {
+      this.dispatch({
+        type: "undo",
+        toolCallId,
+        undo: {
+          status: "failed",
+          note: error instanceof Error ? error.message : "Undo failed.",
+        },
+      });
+    }
+  }
+
+  /** Stops the current turn locally and tells the server to stop too. */
+  cancel(): void {
+    const turn = activeTurn(this.state);
+    this.rejectPendingConfirmations();
+    this.turnAbort?.abort();
+    this.turnAbort = null;
+    if (turn) this.dispatch({ type: "turn-cancelled", turnId: turn.id });
+    const sessionId = this.session?.sessionId;
+    const remoteTurnId = turn?.remoteTurnId;
+    if (sessionId && remoteTurnId) {
+      void this.options.transport.cancelTurn(sessionId, remoteTurnId).catch(() => {});
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.rejectPendingConfirmations();
+    this.turnAbort?.abort();
+    this.turnAbort = null;
+    this.listeners.clear();
+  }
+}

--- a/src/plugins/builtin/cloud/askg/host.ts
+++ b/src/plugins/builtin/cloud/askg/host.ts
@@ -1,0 +1,87 @@
+import type { AppPersistence } from "../../../../data/app-persistence";
+import type { TickerRepository } from "../../../../data/ticker-repository";
+import type { AssetDataRouter } from "../../../../sources/provider-router";
+import type { MarketContext } from "../../../../cli/types";
+import type { AppConfig } from "../../../../types/config";
+import { getSharedRegistry } from "../../../registry";
+import type { PluginRegistry } from "../../../registry";
+import { createASKGToolExecutor, type ASKGToolExecutor } from "./executor";
+import { buildASKGClientManifest, type ASKGClientManifest } from "./manifest";
+import type { InProcessRemoteControlHandler } from "./undo";
+
+/**
+ * Headless loaders only read `config` and `dataProvider`, and the persisted
+ * cloud session only reads plugin state, so the registry's runtime ports carry
+ * everything a delegated tool needs. The casts stay here rather than widening
+ * the executor's contract for one renderer.
+ */
+function marketContextFromRegistry(registry: PluginRegistry, config: AppConfig): MarketContext {
+  return {
+    config,
+    dataDir: config.dataDir,
+    persistence: registry.persistence as unknown as AppPersistence,
+    store: registry.tickerRepository as unknown as TickerRepository,
+    dataProvider: registry.marketData as unknown as AssetDataRouter,
+  };
+}
+
+let manifestCache: { registry: PluginRegistry; manifest: Promise<ASKGClientManifest> } | null = null;
+
+/** The tools this client advertises, rebuilt when the registry changes. */
+export function loadASKGClientManifest(): Promise<ASKGClientManifest> {
+  const registry = getSharedRegistry();
+  if (!registry) return Promise.reject(new Error("The plugin registry is not available."));
+  if (manifestCache?.registry === registry) return manifestCache.manifest;
+  const manifest = buildASKGClientManifest(registry);
+  manifestCache = { registry, manifest };
+  return manifest;
+}
+
+export function resetASKGClientManifestCache(): void {
+  manifestCache = null;
+}
+
+export interface ASKGToolExecutorOptions {
+  config: AppConfig;
+  remoteHandler: InProcessRemoteControlHandler;
+  manifest: ASKGClientManifest;
+}
+
+export function createASKGRendererToolExecutor({
+  config,
+  remoteHandler,
+  manifest,
+}: ASKGToolExecutorOptions): ASKGToolExecutor | null {
+  const registry = getSharedRegistry();
+  if (!registry) return null;
+  return createASKGToolExecutor({
+    manifests: manifest.tools,
+    registry,
+    context: marketContextFromRegistry(registry, config),
+    remoteHandler,
+  });
+}
+
+export interface ASKGPaneTarget {
+  templateId?: string;
+  paneId: string;
+  label: string;
+}
+
+/**
+ * Reverses the manifest's naming so a timeline row can open the pane the tool
+ * read from. Tool names come from a template shortcut prefix or a pane id,
+ * lowercased, which is what `buildASKGToolManifests` advertised.
+ */
+export function resolveToolPaneTarget(toolName: string): ASKGPaneTarget | null {
+  const registry = getSharedRegistry();
+  if (!registry) return null;
+  const normalized = toolName.toLowerCase();
+  for (const template of registry.paneTemplates.values()) {
+    const token = (template.shortcut?.prefix ?? template.id).toLowerCase();
+    if (token !== normalized) continue;
+    return { templateId: template.id, paneId: template.paneId, label: template.label };
+  }
+  const pane = registry.panes.get(toolName);
+  return pane ? { paneId: pane.id, label: pane.name } : null;
+}

--- a/src/plugins/builtin/cloud/askg/model.test.ts
+++ b/src/plugins/builtin/cloud/askg/model.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from "bun:test";
+import {
+  askgReducer,
+  describeToolStatus,
+  EMPTY_ASKG_CONVERSATION,
+  requiresLocalConfirmation,
+  rowSymbol,
+  summarizeToolArguments,
+  toolResultTables,
+  type ASKGConversationState,
+} from "./model";
+import type { ASKGSseEvent } from "./protocol";
+
+function withTurn(): ASKGConversationState {
+  return askgReducer(EMPTY_ASKG_CONVERSATION, {
+    type: "prompt",
+    turnId: "turn-1",
+    prompt: "what is open",
+    at: 0,
+  });
+}
+
+function apply(state: ASKGConversationState, ...events: ASKGSseEvent[]): ASKGConversationState {
+  return events.reduce((current, event) => askgReducer(current, { type: "event", event }), state);
+}
+
+describe("askgReducer", () => {
+  test("builds the answer and one timeline row per tool call", () => {
+    const state = apply(
+      withTurn(),
+      { seq: 1, type: "session", sessionId: "s1", turnId: "turn-1", model: "gloom-1", promptVersion: "v1" },
+      { seq: 2, type: "text-delta", turnId: "turn-1", delta: "Reading " },
+      {
+        seq: 3,
+        type: "tool-call",
+        turnId: "turn-1",
+        toolCallId: "call-1",
+        name: "val",
+        args: { range: "20Y" },
+        writeTier: "read",
+        requiresConfirmation: false,
+        preview: null,
+        timeoutMs: 30_000,
+        expiresAt: new Date().toISOString(),
+      },
+      { seq: 4, type: "text-delta", turnId: "turn-1", delta: "the market." },
+    );
+
+    const turn = state.turns[0]!;
+    expect(turn.answer).toBe("Reading the market.");
+    expect(turn.tools).toHaveLength(1);
+    expect(turn.tools[0]).toMatchObject({
+      name: "val",
+      origin: "client",
+      status: "pending",
+      argumentSummary: "range=20Y",
+    });
+  });
+
+  test("keeps a server tool in the same timeline, marked as run by Gloom", () => {
+    const state = apply(withTurn(), {
+      seq: 1,
+      type: "tool-executed",
+      turnId: "turn-1",
+      toolCallId: "server-1",
+      name: "news.search",
+      source: "server",
+      status: "ok",
+      summary: { rowCount: 6, elapsedMs: 120, truncated: false, note: "6 wire stories" },
+    });
+
+    expect(state.turns[0]?.tools[0]).toMatchObject({
+      name: "news.search",
+      origin: "server",
+      status: "ok",
+      rowCount: 6,
+    });
+  });
+
+  test("drops events a resumed stream replays", () => {
+    const streamed = apply(
+      withTurn(),
+      { seq: 1, type: "text-delta", turnId: "turn-1", delta: "half " },
+      { seq: 2, type: "text-delta", turnId: "turn-1", delta: "answer" },
+    );
+    const resumed = apply(streamed, { seq: 2, type: "text-delta", turnId: "turn-1", delta: "answer" });
+    expect(resumed.turns[0]?.answer).toBe("half answer");
+  });
+
+  test("a reused server turn id lands on the newest turn", () => {
+    const first = apply(withTurn(), { seq: 1, type: "done", turnId: "turn-1", reason: "complete" });
+    const second = askgReducer(first, { type: "prompt", turnId: "turn-1", prompt: "again", at: 1 });
+    const streamed = apply(second, { seq: 1, type: "text-delta", turnId: "turn-1", delta: "new" });
+
+    expect(streamed.turns[0]?.answer).toBe("");
+    expect(streamed.turns[1]?.answer).toBe("new");
+  });
+
+  test("a local tool result fills in the row and offers undo when one exists", () => {
+    const called = apply(withTurn(), {
+      seq: 1,
+      type: "tool-call",
+      turnId: "turn-1",
+      toolCallId: "call-1",
+      name: "pane.set_setting",
+      args: { paneId: "chart:main", key: "range", value: "5Y" },
+      writeTier: "ui-write",
+      requiresConfirmation: false,
+      preview: null,
+      timeoutMs: 10_000,
+      expiresAt: new Date().toISOString(),
+    });
+    const state = askgReducer(called, {
+      type: "tool-result",
+      payload: {
+        turnId: "turn-1",
+        toolCallId: "call-1",
+        status: "ok",
+        truncated: false,
+        elapsedMs: 8,
+        rowCount: 1,
+        undoToken: "undo-1",
+      },
+    });
+
+    expect(state.turns[0]?.tools[0]).toMatchObject({
+      status: "ok",
+      rowCount: 1,
+      undoToken: "undo-1",
+      undo: { status: "available" },
+    });
+  });
+
+  test("an error event describes the turn instead of leaving it streaming", () => {
+    const state = apply(withTurn(), {
+      seq: 1,
+      type: "error",
+      turnId: "turn-1",
+      code: "rate_limited",
+      message: "Too many questions.",
+      retryable: true,
+      retryAfterMs: 42_000,
+    });
+    expect(state.turns[0]).toMatchObject({
+      status: "error",
+      error: { code: "rate_limited", retryAfterMs: 42_000 },
+    });
+  });
+});
+
+describe("requiresLocalConfirmation", () => {
+  test("stops account and broker writes, and lets reads and layout writes run", () => {
+    expect(requiresLocalConfirmation({ writeTier: "read", requiresConfirmation: false })).toBe(false);
+    expect(requiresLocalConfirmation({ writeTier: "ui-write", requiresConfirmation: false })).toBe(false);
+    expect(requiresLocalConfirmation({ writeTier: "user-data", requiresConfirmation: false })).toBe(true);
+    expect(requiresLocalConfirmation({ writeTier: "broker", requiresConfirmation: false })).toBe(true);
+    // The server can ask for a confirmation on any tier.
+    expect(requiresLocalConfirmation({ writeTier: "ui-write", requiresConfirmation: true })).toBe(true);
+  });
+});
+
+describe("toolResultTables", () => {
+  test("uses the columns a headless rows result declares", () => {
+    const tables = toolResultTables({
+      columns: [{ key: "symbol", header: "Ticker" }, { key: "last", header: "Last", align: "right" }],
+      rows: [{ symbol: "NVDA", last: 120.5 }],
+    });
+    expect(tables).toHaveLength(1);
+    expect(tables[0]?.columns).toEqual([
+      { key: "symbol", header: "Ticker" },
+      { key: "last", header: "Last", align: "right" },
+    ]);
+    expect(tables[0]?.rows).toHaveLength(1);
+  });
+
+  test("splits a bundle into one table per section, including entry sections", () => {
+    const tables = toolResultTables({
+      sections: [
+        { title: "Multiples", rows: [{ metric: "P/E", value: 22 }] },
+        { title: "Summary", entries: [{ label: "Median", value: 18, formatted: "18.0x" }] },
+      ],
+    });
+    expect(tables.map((table) => table.title)).toEqual(["Multiples", "Summary"]);
+    expect(tables[1]?.rows).toEqual([{ label: "Median", value: "18.0x" }]);
+  });
+
+  test("describes a plain remote operation result as fields", () => {
+    const tables = toolResultTables({ paneId: "chart:main", ok: true });
+    expect(tables[0]?.rows).toEqual([
+      { label: "paneId", value: "chart:main" },
+      { label: "ok", value: true },
+    ]);
+  });
+});
+
+describe("timeline row helpers", () => {
+  test("summarizes arguments with the subject first", () => {
+    expect(summarizeToolArguments({ range: "5Y", symbol: "NVDA" })).toBe("NVDA · range=5Y");
+    expect(summarizeToolArguments({ resource: "app://panes" })).toBe("app://panes");
+  });
+
+  test("reads the row count into the status once a tool returns", () => {
+    const base = {
+      toolCallId: "call-1",
+      name: "val",
+      argumentSummary: "",
+      writeTier: "read" as const,
+      origin: "client" as const,
+      requiresConfirmation: false,
+      expanded: false,
+    };
+    expect(describeToolStatus({ ...base, status: "running" })).toBe("running");
+    expect(describeToolStatus({ ...base, status: "ok", rowCount: 1 })).toBe("1 row");
+    expect(describeToolStatus({ ...base, status: "ok", rowCount: 12 })).toBe("12 rows");
+    expect(describeToolStatus({ ...base, status: "timeout" })).toBe("timed out");
+  });
+
+  test("finds the symbol a result row is about", () => {
+    expect(rowSymbol({ ticker: "aapl", note: "x" })).toBe("AAPL");
+    expect(rowSymbol({ name: "Apple Inc" })).toBeNull();
+  });
+});

--- a/src/plugins/builtin/cloud/askg/model.ts
+++ b/src/plugins/builtin/cloud/askg/model.ts
@@ -1,0 +1,605 @@
+import type {
+  ASKGErrorCode,
+  ASKGLimits,
+  ASKGSseEvent,
+  ASKGToolCallEvent,
+  JsonValue,
+  ToolManifestSource,
+  ToolResultPayload,
+  ToolResultStatus,
+  WriteTier,
+} from "./protocol";
+
+/** Lifecycle of one row in the tool timeline. */
+export type ASKGToolRowStatus =
+  | ToolResultStatus
+  | "pending"
+  | "awaiting-confirmation"
+  | "running";
+
+export type ASKGUndoStatus = "available" | "running" | "done" | "failed";
+
+export interface ASKGUndoState {
+  status: ASKGUndoStatus;
+  note?: string;
+}
+
+export interface ASKGToolRow {
+  toolCallId: string;
+  name: string;
+  /** One line rendering of the call arguments, e.g. `NVDA · range=5Y`. */
+  argumentSummary: string;
+  writeTier: WriteTier;
+  /** Server tools are executed by the platform and marked as run by Gloom. */
+  origin: "client" | "server";
+  source?: ToolManifestSource;
+  status: ASKGToolRowStatus;
+  requiresConfirmation: boolean;
+  /** Dry run description shown before a `user-data` or `broker` call runs. */
+  preview?: JsonValue;
+  rowCount?: number;
+  elapsedMs?: number;
+  truncated?: boolean;
+  note?: string;
+  /** Rows returned locally; server tools only report a sample. */
+  result?: JsonValue;
+  undoToken?: string;
+  undo?: ASKGUndoState;
+  expanded: boolean;
+}
+
+export type ASKGTurnStatus =
+  | "streaming"
+  | "complete"
+  | "cancelled"
+  | "error";
+
+export interface ASKGErrorState {
+  code: ASKGErrorCode | "transport_unsupported" | "unauthorized" | "network" | "protocol";
+  message: string;
+  retryable: boolean;
+  retryAfterMs?: number;
+}
+
+export interface ASKGTurn {
+  id: string;
+  /** Server turn id, known once the stream announces itself. */
+  remoteTurnId: string | null;
+  prompt: string;
+  answer: string;
+  tools: ASKGToolRow[];
+  status: ASKGTurnStatus;
+  error: ASKGErrorState | null;
+  startedAt: number;
+}
+
+export interface ASKGConversationState {
+  sessionId: string | null;
+  model: string | null;
+  limits: ASKGLimits | null;
+  turns: ASKGTurn[];
+  /** Highest applied `seq`, so a resumed stream skips replayed events. */
+  lastSeq: number;
+}
+
+export const EMPTY_ASKG_CONVERSATION: ASKGConversationState = {
+  sessionId: null,
+  model: null,
+  limits: null,
+  turns: [],
+  lastSeq: 0,
+};
+
+export type ASKGAction =
+  | { type: "session-started"; sessionId: string; model: string; limits: ASKGLimits }
+  | { type: "prompt"; turnId: string; prompt: string; at: number }
+  | { type: "event"; event: ASKGSseEvent }
+  | { type: "tool-awaiting-confirmation"; toolCallId: string }
+  | { type: "tool-running"; toolCallId: string }
+  | { type: "tool-result"; payload: ToolResultPayload }
+  | { type: "tool-expanded"; toolCallId: string; expanded: boolean }
+  | { type: "undo"; toolCallId: string; undo: ASKGUndoState }
+  | { type: "turn-failed"; turnId: string; error: ASKGErrorState }
+  | { type: "turn-cancelled"; turnId: string }
+  | { type: "reset" };
+
+/**
+ * Tiers that never run without the user saying so. `read` is silent and
+ * `ui-write` is reversible, so only account and broker writes stop the turn.
+ */
+export function requiresLocalConfirmation(call: {
+  writeTier: WriteTier;
+  requiresConfirmation: boolean;
+}): boolean {
+  return call.requiresConfirmation
+    || call.writeTier === "user-data"
+    || call.writeTier === "broker";
+}
+
+function scalarText(value: JsonValue): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) return value.map(scalarText).filter(Boolean).join(",");
+  return JSON.stringify(value);
+}
+
+/** Compact single line form of a tool call's arguments for the timeline. */
+export function summarizeToolArguments(args: Record<string, JsonValue>): string {
+  const parts: string[] = [];
+  const leading = ["symbol", "symbols", "text", "query", "paneId", "resource"];
+  const seen = new Set<string>();
+  for (const key of leading) {
+    if (!(key in args)) continue;
+    seen.add(key);
+    const text = scalarText(args[key] as JsonValue);
+    if (text) parts.push(text);
+  }
+  for (const key of Object.keys(args).sort()) {
+    if (seen.has(key)) continue;
+    const text = scalarText(args[key] as JsonValue);
+    if (!text) continue;
+    parts.push(`${key}=${text}`);
+  }
+  return parts.join(" · ");
+}
+
+function rowFromToolCall(event: ASKGToolCallEvent): ASKGToolRow {
+  return {
+    toolCallId: event.toolCallId,
+    name: event.name,
+    argumentSummary: summarizeToolArguments(event.args),
+    writeTier: event.writeTier,
+    origin: "client",
+    status: requiresLocalConfirmation(event) ? "awaiting-confirmation" : "pending",
+    requiresConfirmation: requiresLocalConfirmation(event),
+    ...(event.preview !== undefined && event.preview !== null ? { preview: event.preview } : {}),
+    expanded: false,
+  };
+}
+
+function patchTurn(
+  state: ASKGConversationState,
+  turnId: string | null,
+  patch: (turn: ASKGTurn) => ASKGTurn,
+): ASKGConversationState {
+  // Newest first: a server that reuses a turn id must not reopen an old turn.
+  const index = turnId
+    ? state.turns.findLastIndex((turn) => turn.id === turnId || turn.remoteTurnId === turnId)
+    : state.turns.length - 1;
+  if (index < 0) return state;
+  const turns = [...state.turns];
+  const current = turns[index];
+  if (!current) return state;
+  turns[index] = patch(current);
+  return { ...state, turns };
+}
+
+/** Applies a change to whichever turn owns the tool call. */
+function patchToolRow(
+  state: ASKGConversationState,
+  toolCallId: string,
+  patch: (row: ASKGToolRow) => ASKGToolRow,
+): ASKGConversationState {
+  const index = state.turns.findLastIndex((turn) => (
+    turn.tools.some((row) => row.toolCallId === toolCallId)
+  ));
+  if (index < 0) return state;
+  const turns = [...state.turns];
+  const turn = turns[index];
+  if (!turn) return state;
+  turns[index] = {
+    ...turn,
+    tools: turn.tools.map((row) => (row.toolCallId === toolCallId ? patch(row) : row)),
+  };
+  return { ...state, turns };
+}
+
+function appendToolRow(turn: ASKGTurn, row: ASKGToolRow): ASKGTurn {
+  const existing = turn.tools.findIndex((entry) => entry.toolCallId === row.toolCallId);
+  if (existing < 0) return { ...turn, tools: [...turn.tools, row] };
+  const tools = [...turn.tools];
+  tools[existing] = { ...tools[existing], ...row } as ASKGToolRow;
+  return { ...turn, tools };
+}
+
+function applyEvent(
+  state: ASKGConversationState,
+  event: ASKGSseEvent,
+): ASKGConversationState {
+  // Resumed streams replay what the client already applied.
+  if (event.seq <= state.lastSeq) return state;
+  const next = { ...state, lastSeq: event.seq };
+
+  switch (event.type) {
+    case "session":
+      return patchTurn(
+        { ...next, sessionId: event.sessionId, model: event.model },
+        null,
+        (turn) => (turn.remoteTurnId ? turn : { ...turn, remoteTurnId: event.turnId }),
+      );
+    case "text-delta":
+      return patchTurn(next, event.turnId, (turn) => ({
+        ...turn,
+        remoteTurnId: turn.remoteTurnId ?? event.turnId,
+        answer: turn.answer + event.delta,
+      }));
+    case "tool-call":
+      return patchTurn(next, event.turnId, (turn) => appendToolRow(turn, rowFromToolCall(event)));
+    case "tool-executed": {
+      if (event.source === "server") {
+        return patchTurn(next, event.turnId, (turn) => appendToolRow(turn, {
+          toolCallId: event.toolCallId,
+          name: event.name,
+          argumentSummary: event.summary.note ?? "",
+          writeTier: "read",
+          origin: "server",
+          source: event.source,
+          status: event.status,
+          requiresConfirmation: false,
+          ...(event.summary.rowCount !== undefined ? { rowCount: event.summary.rowCount } : {}),
+          elapsedMs: event.summary.elapsedMs,
+          truncated: event.summary.truncated,
+          ...(event.summary.note ? { note: event.summary.note } : {}),
+          ...(event.summary.sample !== undefined ? { result: event.summary.sample } : {}),
+          expanded: false,
+        }));
+      }
+      // The client already holds the full result for its own tools; the server
+      // echo only confirms the status it recorded.
+      return patchToolRow(next, event.toolCallId, (row) => ({
+        ...row,
+        source: event.source,
+        status: row.status === "running" || row.status === "pending" ? event.status : row.status,
+        elapsedMs: row.elapsedMs ?? event.summary.elapsedMs,
+      }));
+    }
+    case "tool-result-ack":
+      return next;
+    case "error":
+      return patchTurn(next, event.turnId ?? null, (turn) => ({
+        ...turn,
+        status: "error",
+        error: {
+          code: event.code,
+          message: event.message,
+          retryable: event.retryable,
+          ...(event.retryAfterMs !== undefined ? { retryAfterMs: event.retryAfterMs } : {}),
+        },
+      }));
+    case "usage":
+      return next;
+    case "done":
+      return patchTurn(next, event.turnId, (turn) => ({
+        ...turn,
+        status: event.reason === "complete"
+          ? "complete"
+          : event.reason === "cancelled"
+            ? "cancelled"
+            : turn.error
+              ? "error"
+              : event.reason === "timeout"
+                ? "error"
+                : "complete",
+        error: turn.error ?? (event.reason === "timeout"
+          ? {
+            code: "turn_timeout",
+            message: "Gloom ran out of time answering this question.",
+            retryable: true,
+          }
+          : null),
+        // A stream that stops mid tool call must not leave a row spinning.
+        tools: turn.tools.map((row) => (
+          row.status === "pending" || row.status === "running" || row.status === "awaiting-confirmation"
+            ? { ...row, status: "cancelled" as const }
+            : row
+        )),
+      }));
+  }
+}
+
+export function askgReducer(
+  state: ASKGConversationState,
+  action: ASKGAction,
+): ASKGConversationState {
+  switch (action.type) {
+    case "session-started":
+      return {
+        ...state,
+        sessionId: action.sessionId,
+        model: action.model,
+        limits: action.limits,
+      };
+    case "prompt":
+      return {
+        ...state,
+        // Each turn is its own stream, so sequence numbers restart with it.
+        lastSeq: 0,
+        turns: [...state.turns, {
+          id: action.turnId,
+          remoteTurnId: null,
+          prompt: action.prompt,
+          answer: "",
+          tools: [],
+          status: "streaming",
+          error: null,
+          startedAt: action.at,
+        }],
+      };
+    case "event":
+      return applyEvent(state, action.event);
+    case "tool-awaiting-confirmation":
+      return patchToolRow(state, action.toolCallId, (row) => ({
+        ...row,
+        status: "awaiting-confirmation",
+      }));
+    case "tool-running":
+      return patchToolRow(state, action.toolCallId, (row) => ({ ...row, status: "running" }));
+    case "tool-result":
+      return patchToolRow(state, action.payload.toolCallId, (row) => ({
+        ...row,
+        status: action.payload.status,
+        ...(action.payload.rowCount !== undefined ? { rowCount: action.payload.rowCount } : {}),
+        elapsedMs: action.payload.elapsedMs,
+        truncated: action.payload.truncated,
+        ...(action.payload.note ? { note: action.payload.note } : {}),
+        ...(action.payload.result !== undefined ? { result: action.payload.result } : {}),
+        ...(action.payload.undoToken
+          ? { undoToken: action.payload.undoToken, undo: { status: "available" as const } }
+          : {}),
+      }));
+    case "tool-expanded":
+      return patchToolRow(state, action.toolCallId, (row) => ({
+        ...row,
+        expanded: action.expanded,
+      }));
+    case "undo":
+      return patchToolRow(state, action.toolCallId, (row) => ({ ...row, undo: action.undo }));
+    case "turn-failed":
+      return patchTurn(state, action.turnId, (turn) => ({
+        ...turn,
+        status: "error",
+        error: action.error,
+        tools: turn.tools.map((row) => (
+          row.status === "pending" || row.status === "running" || row.status === "awaiting-confirmation"
+            ? { ...row, status: "cancelled" as const }
+            : row
+        )),
+      }));
+    case "turn-cancelled":
+      return patchTurn(state, action.turnId, (turn) => ({
+        ...turn,
+        status: turn.status === "streaming" ? "cancelled" : turn.status,
+        tools: turn.tools.map((row) => (
+          row.status === "pending" || row.status === "running" || row.status === "awaiting-confirmation"
+            ? { ...row, status: "cancelled" as const }
+            : row
+        )),
+      }));
+    case "reset":
+      return { ...EMPTY_ASKG_CONVERSATION, sessionId: state.sessionId, model: state.model, limits: state.limits };
+  }
+}
+
+/** The tool call the pane is currently blocking on, if any. */
+export function pendingConfirmation(state: ASKGConversationState): ASKGToolRow | null {
+  for (const turn of state.turns) {
+    for (const row of turn.tools) {
+      if (row.status === "awaiting-confirmation") return row;
+    }
+  }
+  return null;
+}
+
+export function activeTurn(state: ASKGConversationState): ASKGTurn | null {
+  const turn = state.turns[state.turns.length - 1];
+  return turn ?? null;
+}
+
+export function isTurnRunning(state: ASKGConversationState): boolean {
+  return activeTurn(state)?.status === "streaming";
+}
+
+export interface ASKGResultColumn {
+  key: string;
+  header: string;
+  align?: "left" | "right" | "center";
+  width?: number;
+}
+
+export interface ASKGResultTable {
+  title?: string;
+  columns: ASKGResultColumn[];
+  rows: Record<string, JsonValue>[];
+}
+
+function isRecord(value: JsonValue | undefined): value is Record<string, JsonValue> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function columnsFromRows(
+  rows: Record<string, JsonValue>[],
+  declared: JsonValue | undefined,
+): ASKGResultColumn[] {
+  if (Array.isArray(declared)) {
+    const columns = declared
+      .filter(isRecord)
+      .map((column) => ({
+        key: String(column.key ?? ""),
+        header: String(column.header ?? column.key ?? ""),
+        ...(typeof column.align === "string"
+          ? { align: column.align as ASKGResultColumn["align"] }
+          : {}),
+        ...(typeof column.width === "number" ? { width: column.width } : {}),
+      }))
+      .filter((column) => column.key);
+    if (columns.length > 0) return columns;
+  }
+  const keys: string[] = [];
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (!keys.includes(key)) keys.push(key);
+    }
+  }
+  return keys.map((key) => ({ key, header: key }));
+}
+
+function rowRecords(value: JsonValue | undefined): Record<string, JsonValue>[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.map((entry, index) => (
+    isRecord(entry) ? entry : { "#": index + 1, value: entry as JsonValue }
+  ));
+}
+
+/**
+ * Projects a tool result onto tables the shared data table can render. Headless
+ * results already carry columns; anything else is described by its own keys so
+ * a remote operation result is still readable.
+ */
+export function toolResultTables(result: JsonValue | undefined): ASKGResultTable[] {
+  if (result === undefined || result === null) return [];
+  if (Array.isArray(result)) {
+    const rows = rowRecords(result) ?? [];
+    return rows.length > 0 ? [{ columns: columnsFromRows(rows, undefined), rows }] : [];
+  }
+  if (!isRecord(result)) return [];
+
+  const rows = rowRecords(result.rows) ?? rowRecords(result.items);
+  if (rows) {
+    return [{ columns: columnsFromRows(rows, result.columns), rows }];
+  }
+
+  if (Array.isArray(result.sections)) {
+    const tables: ASKGResultTable[] = [];
+    for (const section of result.sections) {
+      if (!isRecord(section)) continue;
+      const title = typeof section.title === "string" ? section.title : undefined;
+      const sectionRows = rowRecords(section.rows);
+      if (sectionRows) {
+        tables.push({
+          ...(title ? { title } : {}),
+          columns: columnsFromRows(sectionRows, section.columns),
+          rows: sectionRows,
+        });
+        continue;
+      }
+      const entries = Array.isArray(section.entries) ? section.entries.filter(isRecord) : [];
+      if (entries.length === 0) continue;
+      tables.push({
+        ...(title ? { title } : {}),
+        columns: [{ key: "label", header: "Item" }, { key: "value", header: "Value" }],
+        rows: entries.map((entry) => ({
+          label: (entry.label ?? entry.key ?? "") as JsonValue,
+          value: (entry.formatted ?? entry.value ?? null) as JsonValue,
+        })),
+      });
+    }
+    return tables;
+  }
+
+  if (Array.isArray(result.series)) {
+    const rows = result.series.filter(isRecord).map((series) => {
+      const points = Array.isArray(series.points) ? series.points : [];
+      const last = points[points.length - 1];
+      return {
+        series: (series.label ?? series.id ?? "") as JsonValue,
+        points: points.length,
+        last: isRecord(last) ? (last.value ?? last.close ?? null) : null,
+      } satisfies Record<string, JsonValue>;
+    });
+    return rows.length > 0
+      ? [{
+        columns: [
+          { key: "series", header: "Series" },
+          { key: "points", header: "Points", align: "right" },
+          { key: "last", header: "Last", align: "right" },
+        ],
+        rows,
+      }]
+      : [];
+  }
+
+  // A plain object result reads best as label and value pairs.
+  const entries = Object.entries(result).filter(([, value]) => value !== undefined);
+  if (entries.length === 0) return [];
+  return [{
+    columns: [{ key: "label", header: "Field" }, { key: "value", header: "Value" }],
+    rows: entries.map(([label, value]) => ({
+      label,
+      value: isRecord(value) || Array.isArray(value) ? JSON.stringify(value) : value,
+    })),
+  }];
+}
+
+/** Symbol a result row points at, used to open the ticker it describes. */
+export function rowSymbol(row: Record<string, JsonValue>): string | null {
+  for (const key of ["symbol", "ticker", "Symbol", "Ticker"]) {
+    const value = row[key];
+    if (typeof value === "string" && /^[A-Za-z0-9.\-^]{1,12}$/.test(value.trim())) {
+      return value.trim().toUpperCase();
+    }
+  }
+  return null;
+}
+
+export function formatCellValue(value: JsonValue | undefined): string {
+  if (value == null) return "-";
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? String(value) : value.toFixed(2);
+  }
+  if (typeof value === "boolean") return value ? "yes" : "no";
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+const ERROR_TITLES: Record<string, string> = {
+  rate_limited: "Rate limited",
+  daily_turn_cap: "Daily question limit reached",
+  tool_budget_exhausted: "Tool budget used up",
+  turn_timeout: "Answer timed out",
+  model_usage_limit: "Model usage limit reached",
+  model_unavailable: "Model unavailable",
+  transport_unsupported: "Streaming unavailable",
+  unauthorized: "Sign in required",
+  network: "Connection lost",
+  protocol: "Version mismatch",
+  internal: "Ask Gloom failed",
+};
+
+/** Specific, actionable one line description of a failure. */
+export function describeASKGError(error: ASKGErrorState): string {
+  const title = ERROR_TITLES[error.code] ?? "Ask Gloom failed";
+  const retry = error.retryAfterMs && error.retryAfterMs > 0
+    ? ` Try again in ${Math.max(1, Math.round(error.retryAfterMs / 1000))}s.`
+    : "";
+  const detail = error.message.trim();
+  return detail && detail.toLowerCase() !== title.toLowerCase()
+    ? `${title}: ${detail}${retry}`
+    : `${title}.${retry}`;
+}
+
+/** Wording for the tool row status column. */
+export function describeToolStatus(row: ASKGToolRow): string {
+  switch (row.status) {
+    case "pending":
+      return "queued";
+    case "awaiting-confirmation":
+      return "needs approval";
+    case "running":
+      return "running";
+    case "ok":
+      return row.rowCount === undefined
+        ? "done"
+        : `${row.rowCount} ${row.rowCount === 1 ? "row" : "rows"}`;
+    case "partial":
+      return row.rowCount === undefined ? "partial" : `${row.rowCount} rows · partial`;
+    case "denied":
+      return "declined";
+    case "timeout":
+      return "timed out";
+    case "cancelled":
+      return "cancelled";
+    case "error":
+      return "failed";
+  }
+}

--- a/src/plugins/builtin/cloud/askg/model.ts
+++ b/src/plugins/builtin/cloud/askg/model.ts
@@ -1,5 +1,5 @@
+import type { ASKGClientErrorCode } from "../../../../api-client/askg";
 import type {
-  ASKGErrorCode,
   ASKGLimits,
   ASKGSseEvent,
   ASKGToolCallEvent,
@@ -55,7 +55,7 @@ export type ASKGTurnStatus =
   | "error";
 
 export interface ASKGErrorState {
-  code: ASKGErrorCode | "transport_unsupported" | "unauthorized" | "network" | "protocol";
+  code: ASKGClientErrorCode;
   message: string;
   retryable: boolean;
   retryAfterMs?: number;
@@ -77,6 +77,8 @@ export interface ASKGConversationState {
   sessionId: string | null;
   model: string | null;
   limits: ASKGLimits | null;
+  /** Tool names the session negotiated; anything else is refused locally. */
+  acceptedTools: string[];
   turns: ASKGTurn[];
   /** Highest applied `seq`, so a resumed stream skips replayed events. */
   lastSeq: number;
@@ -86,12 +88,19 @@ export const EMPTY_ASKG_CONVERSATION: ASKGConversationState = {
   sessionId: null,
   model: null,
   limits: null,
+  acceptedTools: [],
   turns: [],
   lastSeq: 0,
 };
 
 export type ASKGAction =
-  | { type: "session-started"; sessionId: string; model: string; limits: ASKGLimits }
+  | {
+    type: "session-started";
+    sessionId: string;
+    model: string;
+    limits: ASKGLimits;
+    acceptedTools: string[];
+  }
   | { type: "prompt"; turnId: string; prompt: string; at: number }
   | { type: "event"; event: ASKGSseEvent }
   | { type: "tool-awaiting-confirmation"; toolCallId: string }
@@ -309,6 +318,7 @@ export function askgReducer(
         sessionId: action.sessionId,
         model: action.model,
         limits: action.limits,
+        acceptedTools: action.acceptedTools,
       };
     case "prompt":
       return {
@@ -377,7 +387,13 @@ export function askgReducer(
         )),
       }));
     case "reset":
-      return { ...EMPTY_ASKG_CONVERSATION, sessionId: state.sessionId, model: state.model, limits: state.limits };
+      return {
+        ...EMPTY_ASKG_CONVERSATION,
+        sessionId: state.sessionId,
+        model: state.model,
+        limits: state.limits,
+        acceptedTools: state.acceptedTools,
+      };
   }
 }
 
@@ -552,14 +568,16 @@ export function formatCellValue(value: JsonValue | undefined): string {
   return JSON.stringify(value);
 }
 
-const ERROR_TITLES: Record<string, string> = {
+const ERROR_TITLES: Record<ASKGClientErrorCode, string> = {
   rate_limited: "Rate limited",
   daily_turn_cap: "Daily question limit reached",
   tool_budget_exhausted: "Tool budget used up",
   turn_timeout: "Answer timed out",
   model_usage_limit: "Model usage limit reached",
   model_unavailable: "Model unavailable",
+  turn_already_recorded: "Turn already answered",
   transport_unsupported: "Streaming unavailable",
+  tier_required: "Ask Gloom needs a paid plan",
   unauthorized: "Sign in required",
   network: "Connection lost",
   protocol: "Version mismatch",

--- a/src/plugins/builtin/cloud/askg/pane.tsx
+++ b/src/plugins/builtin/cloud/askg/pane.tsx
@@ -32,7 +32,6 @@ import { useShortcut } from "../../../../react/input";
 import {
   useAppDispatch,
   useAppSelector,
-  usePaneInstance,
 } from "../../../../state/app/context";
 import { useInlineTickers } from "../../../../state/hooks/inline-tickers";
 import { useRemoteControlHandler } from "../../../../remote/app-host";
@@ -47,6 +46,7 @@ import {
   loadASKGClientManifest,
   resolveToolPaneTarget,
 } from "./host";
+import { subscribeASKGQuestions } from "./pending-question";
 import {
   activeTurn,
   describeASKGError,
@@ -357,6 +357,7 @@ function TurnView({
   onSelectTool,
   onToggleTool,
   onUndo,
+  onUpgrade,
 }: {
   turn: ASKGTurn;
   width: number;
@@ -367,6 +368,7 @@ function TurnView({
   onSelectTool: (toolCallId: string) => void;
   onToggleTool: (toolCallId: string) => void;
   onUndo: (toolCallId: string) => void;
+  onUpgrade: () => void;
 }) {
   return (
     <Box flexDirection="column" paddingTop={1}>
@@ -401,8 +403,13 @@ function TurnView({
         <Box paddingTop={1}><Spinner label="Gloom is thinking…" /></Box>
       ) : null}
       {turn.error ? (
-        <Box paddingTop={1}>
+        <Box flexDirection="column" paddingTop={1}>
           <Text fg={colors.negative}>{describeASKGError(turn.error)}</Text>
+          {turn.error.code === "tier_required" ? (
+            <Box paddingTop={1}>
+              <Button label="Upgrade to Pro" variant="primary" onPress={onUpgrade} />
+            </Box>
+          ) : null}
         </Box>
       ) : null}
     </Box>
@@ -412,7 +419,6 @@ function TurnView({
 export function ASKGPane({ paneId, focused, width, height }: PaneProps) {
   const { nativePaneChrome } = useUiCapabilities();
   const dispatch = useAppDispatch();
-  const paneInstance = usePaneInstance();
   const planAccess = usePlanAccess();
   const remoteHandler = useRemoteControlHandler();
   const config = useAppSelector((state) => state.config);
@@ -464,7 +470,7 @@ export function ASKGPane({ paneId, focused, width, height }: PaneProps) {
   const [expandedToolCallId, setExpandedToolCallId] = useState<string | null>(null);
   const inputRef = useRef<TextareaRenderable | null>(null);
   const scrollRef = useRef<ScrollBoxRenderable | null>(null);
-  const askedParamsRef = useRef<string | null>(null);
+  const [queuedQuestion, setQueuedQuestion] = useState<string | null>(null);
 
   const running = isTurnRunning(state);
   const confirmation = pendingConfirmation(state);
@@ -502,19 +508,17 @@ export function ASKGPane({ paneId, focused, width, height }: PaneProps) {
     dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
   }, [dispatch]);
 
-  // A question from the ASKG shortcut runs once, including when the shortcut
-  // reuses this pane for a second question.
-  const seededQuestion = typeof paneInstance?.params?.question === "string"
-    ? paneInstance.params.question.trim()
-    : "";
-  const seededAt = paneInstance?.params?.askedAt ?? "";
+  // A question typed at the command bar, either opening this pane or landing
+  // in the conversation already open here.
+  useEffect(() => subscribeASKGQuestions(setQueuedQuestion), []);
+
   useEffect(() => {
-    if (!seededQuestion) return;
-    const key = `${seededAt}:${seededQuestion}`;
-    if (askedParamsRef.current === key) return;
-    askedParamsRef.current = key;
-    if (planAccess.emailVerified) ask(seededQuestion);
-  }, [ask, planAccess.emailVerified, seededAt, seededQuestion]);
+    // The restored cloud session arrives after the first render, so a question
+    // that beat it waits instead of being dropped.
+    if (!queuedQuestion || !planAccess.emailVerified) return;
+    setQueuedQuestion(null);
+    ask(queuedQuestion);
+  }, [ask, planAccess.emailVerified, queuedQuestion]);
 
   useEffect(() => {
     const scroll = scrollRef.current;
@@ -561,12 +565,14 @@ export function ASKGPane({ paneId, focused, width, height }: PaneProps) {
     pinTicker(symbol, { floating: true });
   }, [pinTicker]);
 
+  // A write waiting on the user owns the keyboard, so the answer never gets
+  // typed into the composer instead.
+  useEffect(() => {
+    if (confirmation && inputFocused) blurInput();
+  }, [blurInput, confirmation, inputFocused]);
+
   useShortcut((event) => {
     if (!focused) return;
-    if (inputFocused) {
-      if (event.name === "escape") blurInput();
-      return;
-    }
     if (confirmation) {
       if (event.name === "y") {
         controller.resolveConfirmation(confirmation.toolCallId, true);
@@ -576,6 +582,10 @@ export function ASKGPane({ paneId, focused, width, height }: PaneProps) {
         controller.resolveConfirmation(confirmation.toolCallId, false);
         return;
       }
+    }
+    if (inputFocused) {
+      if (event.name === "escape") blurInput();
+      return;
     }
     if (event.name === "enter" || event.name === "return") {
       focusInput();
@@ -698,6 +708,7 @@ export function ASKGPane({ paneId, focused, width, height }: PaneProps) {
             onSelectTool={setSelectedToolCallId}
             onToggleTool={toggleExpanded}
             onUndo={(toolCallId) => void controller.undo(toolCallId)}
+            onUpgrade={() => openCommandBar("Upgrade to Pro")}
           />
         ))}
       </ScrollBox>

--- a/src/plugins/builtin/cloud/askg/pane.tsx
+++ b/src/plugins/builtin/cloud/askg/pane.tsx
@@ -1,0 +1,745 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { apiClient } from "../../../../api-client";
+import {
+  Box,
+  ScrollBox,
+  Text,
+  TextAttributes,
+  useUiCapabilities,
+  type ScrollBoxRenderable,
+  type TextareaRenderable,
+} from "../../../../ui";
+import {
+  Button,
+  DataTableView,
+  EmptyState,
+  MessageComposer,
+  SegmentedControl,
+  Spinner,
+  usePaneFooter,
+  type DataTableCell,
+  type DataTableColumn,
+} from "../../../../components";
+import { MarkdownText } from "../../../../components/markdown-text";
+import { useShortcut } from "../../../../react/input";
+import {
+  useAppDispatch,
+  useAppSelector,
+  usePaneInstance,
+} from "../../../../state/app/context";
+import { useInlineTickers } from "../../../../state/hooks/inline-tickers";
+import { useRemoteControlHandler } from "../../../../remote/app-host";
+import { colors } from "../../../../theme/colors";
+import type { PaneProps } from "../../../../types/plugin";
+import { truncateWithEllipsis } from "../../../../utils/text-wrap";
+import { usePluginAppActions, usePluginTickerActions } from "../../../runtime";
+import { usePlanAccess } from "../../shared/plan-access";
+import { ASKGSessionController, type ASKGControllerManifest } from "./controller";
+import {
+  createASKGRendererToolExecutor,
+  loadASKGClientManifest,
+  resolveToolPaneTarget,
+} from "./host";
+import {
+  activeTurn,
+  describeASKGError,
+  describeToolStatus,
+  formatCellValue,
+  isTurnRunning,
+  pendingConfirmation,
+  rowSymbol,
+  toolResultTables,
+  type ASKGConversationState,
+  type ASKGResultTable,
+  type ASKGToolRow,
+  type ASKGTurn,
+} from "./model";
+import type { JsonValue } from "./protocol";
+
+export const ASKG_PANE_ID = "askg";
+
+const CLIENT_VERSION = "1";
+const MIN_DETAIL_HEIGHT = 8;
+
+function clientKind(nativePaneChrome: boolean): "tui" | "desktop" | "web" {
+  if (!nativePaneChrome) return "tui";
+  return typeof location !== "undefined" && location.protocol.startsWith("http") ? "web" : "desktop";
+}
+
+function tierLabel(row: ASKGToolRow): string | null {
+  if (row.writeTier === "read") return null;
+  if (row.writeTier === "ui-write") return "layout";
+  if (row.writeTier === "user-data") return "your data";
+  return "broker";
+}
+
+function statusColor(row: ASKGToolRow): string {
+  switch (row.status) {
+    case "ok":
+      return colors.textDim;
+    case "partial":
+    case "awaiting-confirmation":
+      return colors.warning;
+    case "error":
+    case "timeout":
+      return colors.negative;
+    case "denied":
+    case "cancelled":
+      return colors.textMuted;
+    default:
+      return colors.textDim;
+  }
+}
+
+function previewLines(preview: JsonValue | undefined): string[] {
+  if (preview == null) return [];
+  if (typeof preview === "string") return preview.split("\n");
+  if (typeof preview === "number" || typeof preview === "boolean") return [String(preview)];
+  if (Array.isArray(preview)) return preview.map((entry) => formatCellValue(entry));
+  return Object.entries(preview).map(([key, value]) => `${key}: ${formatCellValue(value)}`);
+}
+
+function ToolTimelineRow({
+  row,
+  width,
+  selected,
+  expanded,
+  onSelect,
+  onToggle,
+  onUndo,
+}: {
+  row: ASKGToolRow;
+  width: number;
+  selected: boolean;
+  expanded: boolean;
+  onSelect: () => void;
+  onToggle: () => void;
+  onUndo: () => void;
+}) {
+  const hasRows = row.result !== undefined;
+  const marker = hasRows ? (expanded ? "▾" : "▸") : "·";
+  const tier = tierLabel(row);
+  const status = describeToolStatus(row);
+  const undoLabel = row.undo?.status === "running"
+    ? "undoing…"
+    : row.undo?.status === "done"
+      ? "undone"
+      : row.undo?.status === "failed"
+        ? "undo failed"
+        : row.undoToken
+          ? "undo"
+          : null;
+  const trailing = ` ${status}${row.origin === "server" ? " · Gloom" : ""}`;
+  const summaryWidth = Math.max(
+    6,
+    width - marker.length - row.name.length - trailing.length - (tier ? tier.length + 3 : 0) - 4,
+  );
+
+  return (
+    <Box flexDirection="column">
+      <Box
+        flexDirection="row"
+        height={1}
+        backgroundColor={selected ? colors.panel : undefined}
+        onMouseDown={() => {
+          onSelect();
+          onToggle();
+        }}
+        style={{ cursor: "pointer" }}
+      >
+        <Text fg={selected ? colors.textBright : colors.textDim}>{`${marker} `}</Text>
+        <Text fg={colors.textBright}>{row.name}</Text>
+        {row.argumentSummary ? (
+          <Text fg={colors.textDim}>{`  ${truncateWithEllipsis(row.argumentSummary, summaryWidth)}`}</Text>
+        ) : null}
+        <Box flexGrow={1} />
+        {tier ? <Text fg={colors.warning}>{`${tier}  `}</Text> : null}
+        {row.status === "running" || row.status === "pending" ? (
+          <Spinner label={status} />
+        ) : (
+          <Text fg={statusColor(row)}>{status}</Text>
+        )}
+        {row.origin === "server" ? <Text fg={colors.textMuted}> · Gloom</Text> : null}
+      </Box>
+      {undoLabel ? (
+        <Box flexDirection="row" height={1} paddingLeft={2}>
+          <Text
+            fg={row.undo?.status === "failed" ? colors.negative : colors.textBright}
+            onMouseDown={() => {
+              if (row.undo?.status === "available" || !row.undo) onUndo();
+            }}
+            style={{ cursor: "pointer" }}
+          >
+            {undoLabel}
+          </Text>
+          {row.undo?.note ? <Text fg={colors.textMuted}>{`  ${row.undo.note}`}</Text> : null}
+        </Box>
+      ) : null}
+      {row.note && row.status !== "ok" ? (
+        <Box paddingLeft={2}>
+          <Text fg={statusColor(row)}>{truncateWithEllipsis(row.note, Math.max(10, width - 3))}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+/** Rows the confirmation block reserves for the dry run preview. */
+const MAX_PREVIEW_LINES = 4;
+
+export function confirmationBlockHeight(row: ASKGToolRow): number {
+  return 3 + Math.min(MAX_PREVIEW_LINES, previewLines(row.preview).length);
+}
+
+function ConfirmationPrompt({
+  row,
+  width,
+  onApprove,
+  onDecline,
+}: {
+  row: ASKGToolRow;
+  width: number;
+  onApprove: () => void;
+  onDecline: () => void;
+}) {
+  const lines = previewLines(row.preview).slice(0, MAX_PREVIEW_LINES);
+  return (
+    <Box
+      flexDirection="column"
+      flexShrink={0}
+      paddingX={1}
+      height={confirmationBlockHeight(row)}
+      backgroundColor={colors.panel}
+    >
+      <Box flexDirection="row" height={1}>
+        <Text fg={colors.warning} attributes={TextAttributes.BOLD}>{`Approve ${row.name}?`}</Text>
+        <Text fg={colors.textDim}>
+          {`  writes ${tierLabel(row) ?? "data"}${row.argumentSummary ? ` · ${row.argumentSummary}` : ""}`}
+        </Text>
+      </Box>
+      {lines.map((line, index) => (
+        <Box key={index} height={1}>
+          <Text fg={colors.text}>{truncateWithEllipsis(line, Math.max(10, width - 2))}</Text>
+        </Box>
+      ))}
+      <Box flexDirection="row" height={2} paddingTop={1}>
+        <Button label="Approve" variant="primary" shortcut="y" onPress={onApprove} />
+        <Box width={2} />
+        <Button label="Decline" shortcut="n" onPress={onDecline} />
+      </Box>
+    </Box>
+  );
+}
+
+function ToolResultDetail({
+  row,
+  width,
+  height,
+  focused,
+  onOpenSymbol,
+  onOpenPane,
+}: {
+  row: ASKGToolRow;
+  width: number;
+  height: number;
+  focused: boolean;
+  onOpenSymbol: (symbol: string) => void;
+  onOpenPane: () => void;
+}) {
+  const tables = useMemo<ASKGResultTable[]>(() => toolResultTables(row.result), [row.result]);
+  const [tableIndex, setTableIndex] = useState(0);
+  useEffect(() => {
+    setTableIndex(0);
+  }, [row.toolCallId]);
+  const table = tables[Math.min(tableIndex, tables.length - 1)] ?? null;
+  const paneTarget = useMemo(() => resolveToolPaneTarget(row.name), [row.name]);
+
+  const columns = useMemo<DataTableColumn[]>(() => (
+    (table?.columns ?? []).map((column) => ({
+      id: column.key,
+      label: column.header,
+      width: column.width ?? Math.max(column.header.length + 2, 10),
+      align: column.align === "right" ? "right" : "left",
+      flexGrow: 1,
+    }))
+  ), [table]);
+
+  const renderCell = useCallback((
+    item: Record<string, JsonValue>,
+    column: DataTableColumn,
+  ): DataTableCell => {
+    const value = formatCellValue(item[column.id]);
+    const symbol = rowSymbol(item);
+    return {
+      text: value,
+      color: symbol && (column.id === "symbol" || column.id === "ticker")
+        ? colors.textBright
+        : colors.text,
+    };
+  }, []);
+
+  const headerHeight = 1 + (tables.length > 1 ? 1 : 0);
+  // The timeline row above already names the tool and its arguments, so the
+  // detail header carries what the row cannot: shape, size, and cost.
+  const metadata = [
+    table?.title,
+    row.rowCount !== undefined ? `${row.rowCount} ${row.rowCount === 1 ? "row" : "rows"}` : null,
+    row.elapsedMs !== undefined ? `${row.elapsedMs}ms` : null,
+    row.truncated ? "truncated" : null,
+  ].filter(Boolean).join(" · ");
+  return (
+    <Box flexDirection="column" flexShrink={0} width={width} height={height}>
+      <Box flexDirection="row" height={1} paddingX={1}>
+        <Text fg={colors.textDim}>
+          {truncateWithEllipsis(metadata, Math.max(10, width - 16))}
+        </Text>
+        <Box flexGrow={1} />
+        {paneTarget ? (
+          <Text fg={colors.textBright} onMouseDown={onOpenPane} style={{ cursor: "pointer" }}>
+            open pane
+          </Text>
+        ) : null}
+      </Box>
+      {tables.length > 1 ? (
+        <Box height={1} paddingX={1}>
+          <SegmentedControl
+            options={tables.map((entry, index) => ({
+              value: String(index),
+              label: entry.title ?? `Section ${index + 1}`,
+            }))}
+            value={String(tableIndex)}
+            onChange={(value) => setTableIndex(Number(value))}
+          />
+        </Box>
+      ) : null}
+      {table && table.rows.length > 0 ? (
+        <DataTableView<Record<string, JsonValue>>
+          focused={focused}
+          selection={{ kind: "none" }}
+          rootWidth={width}
+          rootHeight={Math.max(3, height - headerHeight)}
+          columns={columns}
+          items={table.rows}
+          sortColumnId={null}
+          sortDirection="asc"
+          onHeaderClick={() => {}}
+          getItemKey={(_item, index) => String(index)}
+          renderCell={renderCell}
+          onActivate={(item) => {
+            const symbol = rowSymbol(item);
+            if (symbol) onOpenSymbol(symbol);
+          }}
+          emptyStateTitle="No rows returned"
+        />
+      ) : (
+        <Box paddingX={1}>
+          <Text fg={colors.textMuted}>{row.note ?? "This tool returned no rows."}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function TurnView({
+  turn,
+  width,
+  selectedToolCallId,
+  expandedToolCallId,
+  catalog,
+  openTicker,
+  onSelectTool,
+  onToggleTool,
+  onUndo,
+}: {
+  turn: ASKGTurn;
+  width: number;
+  selectedToolCallId: string | null;
+  expandedToolCallId: string | null;
+  catalog: ReturnType<typeof useInlineTickers>["catalog"];
+  openTicker: (symbol: string) => void;
+  onSelectTool: (toolCallId: string) => void;
+  onToggleTool: (toolCallId: string) => void;
+  onUndo: (toolCallId: string) => void;
+}) {
+  return (
+    <Box flexDirection="column" paddingTop={1}>
+      <Text fg={colors.textBright} attributes={TextAttributes.BOLD}>{turn.prompt}</Text>
+      {turn.tools.length > 0 ? (
+        <Box flexDirection="column" paddingTop={1}>
+          {turn.tools.map((row) => (
+            <ToolTimelineRow
+              key={row.toolCallId}
+              row={row}
+              width={width}
+              selected={row.toolCallId === selectedToolCallId}
+              expanded={row.toolCallId === expandedToolCallId}
+              onSelect={() => onSelectTool(row.toolCallId)}
+              onToggle={() => onToggleTool(row.toolCallId)}
+              onUndo={() => onUndo(row.toolCallId)}
+            />
+          ))}
+        </Box>
+      ) : null}
+      {turn.answer ? (
+        <Box paddingTop={1}>
+          <MarkdownText
+            text={turn.answer}
+            lineWidth={width}
+            catalog={catalog}
+            textColor={colors.text}
+            openTicker={openTicker}
+          />
+        </Box>
+      ) : turn.status === "streaming" && turn.tools.length === 0 ? (
+        <Box paddingTop={1}><Spinner label="Gloom is thinking…" /></Box>
+      ) : null}
+      {turn.error ? (
+        <Box paddingTop={1}>
+          <Text fg={colors.negative}>{describeASKGError(turn.error)}</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+export function ASKGPane({ paneId, focused, width, height }: PaneProps) {
+  const { nativePaneChrome } = useUiCapabilities();
+  const dispatch = useAppDispatch();
+  const paneInstance = usePaneInstance();
+  const planAccess = usePlanAccess();
+  const remoteHandler = useRemoteControlHandler();
+  const config = useAppSelector((state) => state.config);
+  const activeSymbol = useAppSelector((state) => state.recentTickers[0] ?? null);
+  const { pinTicker } = usePluginTickerActions();
+  const { createPaneFromTemplate, showPane, openCommandBar } = usePluginAppActions();
+
+  const configRef = useRef(config);
+  configRef.current = config;
+  const remoteHandlerRef = useRef(remoteHandler);
+  remoteHandlerRef.current = remoteHandler;
+  const contextRef = useRef({ symbol: activeSymbol, paneId });
+  contextRef.current = { symbol: activeSymbol, paneId };
+
+  const controller = useMemo(() => new ASKGSessionController({
+    transport: apiClient.askg,
+    loadManifest: () => loadASKGClientManifest(),
+    getExecutor: (manifest: ASKGControllerManifest) => {
+      const handler = remoteHandlerRef.current;
+      if (!handler) return null;
+      return createASKGRendererToolExecutor({
+        config: configRef.current,
+        remoteHandler: handler,
+        manifest: {
+          tools: manifest.tools,
+          manifestHash: manifest.manifestHash,
+          skipped: [],
+        },
+      });
+    },
+    client: { kind: clientKind(!!nativePaneChrome), version: CLIENT_VERSION },
+    getContext: () => ({
+      ...(contextRef.current.symbol ? { symbol: contextRef.current.symbol } : {}),
+      paneId: contextRef.current.paneId,
+    }),
+  }), [nativePaneChrome]);
+
+  useEffect(() => () => controller.dispose(), [controller]);
+
+  const state: ASKGConversationState = useSyncExternalStore(
+    useCallback((listener) => controller.subscribe(listener), [controller]),
+    useCallback(() => controller.getState(), [controller]),
+    useCallback(() => controller.getState(), [controller]),
+  );
+
+  const [inputValue, setInputValue] = useState("");
+  const [inputFocused, setInputFocused] = useState(false);
+  const [selectedToolCallId, setSelectedToolCallId] = useState<string | null>(null);
+  const [expandedToolCallId, setExpandedToolCallId] = useState<string | null>(null);
+  const inputRef = useRef<TextareaRenderable | null>(null);
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null);
+  const askedParamsRef = useRef<string | null>(null);
+
+  const running = isTurnRunning(state);
+  const confirmation = pendingConfirmation(state);
+  const timelineRows = useMemo(
+    () => state.turns.flatMap((turn) => turn.tools),
+    [state.turns],
+  );
+  const expandedRow = useMemo(
+    () => timelineRows.find((row) => row.toolCallId === expandedToolCallId) ?? null,
+    [expandedToolCallId, timelineRows],
+  );
+
+  const ask = useCallback((question: string) => {
+    const trimmed = question.trim();
+    if (!trimmed) return;
+    void controller.ask(trimmed);
+  }, [controller]);
+
+  const focusInput = useCallback(() => {
+    setInputFocused(true);
+    dispatch({ type: "SET_INPUT_CAPTURED", captured: true });
+    inputRef.current?.focus?.();
+  }, [dispatch]);
+
+  const blurInput = useCallback(() => {
+    setInputFocused(false);
+    dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (!focused && inputFocused) blurInput();
+  }, [blurInput, focused, inputFocused]);
+
+  useEffect(() => () => {
+    dispatch({ type: "SET_INPUT_CAPTURED", captured: false });
+  }, [dispatch]);
+
+  // A question from the ASKG shortcut runs once, including when the shortcut
+  // reuses this pane for a second question.
+  const seededQuestion = typeof paneInstance?.params?.question === "string"
+    ? paneInstance.params.question.trim()
+    : "";
+  const seededAt = paneInstance?.params?.askedAt ?? "";
+  useEffect(() => {
+    if (!seededQuestion) return;
+    const key = `${seededAt}:${seededQuestion}`;
+    if (askedParamsRef.current === key) return;
+    askedParamsRef.current = key;
+    if (planAccess.emailVerified) ask(seededQuestion);
+  }, [ask, planAccess.emailVerified, seededAt, seededQuestion]);
+
+  useEffect(() => {
+    const scroll = scrollRef.current;
+    if (!scroll?.viewport) return;
+    scroll.scrollTo({ x: 0, y: Math.max(0, scroll.scrollHeight - scroll.viewport.height) });
+  }, [state.turns]);
+
+  const submitInput = useCallback(() => {
+    const value = inputRef.current?.editBuffer.getText() ?? inputValue;
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    setInputValue("");
+    inputRef.current?.editBuffer.setText?.("");
+    ask(trimmed);
+  }, [ask, inputValue]);
+
+  const toggleExpanded = useCallback((toolCallId: string) => {
+    setExpandedToolCallId((current) => (current === toolCallId ? null : toolCallId));
+  }, []);
+
+  const moveSelection = useCallback((direction: -1 | 1) => {
+    if (timelineRows.length === 0) return;
+    const index = timelineRows.findIndex((row) => row.toolCallId === selectedToolCallId);
+    // Selection starts at the newest row: that is the answer being read.
+    const nextIndex = index < 0
+      ? timelineRows.length - 1
+      : (index + direction + timelineRows.length) % timelineRows.length;
+    setSelectedToolCallId(timelineRows[nextIndex]?.toolCallId ?? null);
+  }, [selectedToolCallId, timelineRows]);
+
+  const openPaneForTool = useCallback((row: ASKGToolRow) => {
+    const target = resolveToolPaneTarget(row.name);
+    if (!target) return;
+    if (target.templateId) {
+      createPaneFromTemplate(target.templateId, row.argumentSummary
+        ? { arg: row.argumentSummary.split(" · ")[0] }
+        : undefined);
+      return;
+    }
+    showPane(target.paneId);
+  }, [createPaneFromTemplate, showPane]);
+
+  const openSymbol = useCallback((symbol: string) => {
+    pinTicker(symbol, { floating: true });
+  }, [pinTicker]);
+
+  useShortcut((event) => {
+    if (!focused) return;
+    if (inputFocused) {
+      if (event.name === "escape") blurInput();
+      return;
+    }
+    if (confirmation) {
+      if (event.name === "y") {
+        controller.resolveConfirmation(confirmation.toolCallId, true);
+        return;
+      }
+      if (event.name === "n" || event.name === "escape") {
+        controller.resolveConfirmation(confirmation.toolCallId, false);
+        return;
+      }
+    }
+    if (event.name === "enter" || event.name === "return") {
+      focusInput();
+      return;
+    }
+    if (event.name === "j" || event.name === "down") {
+      moveSelection(1);
+      return;
+    }
+    if (event.name === "k" || event.name === "up") {
+      moveSelection(-1);
+      return;
+    }
+    const selected = timelineRows.find((row) => row.toolCallId === selectedToolCallId) ?? null;
+    if (event.name === "x" && selected) {
+      toggleExpanded(selected.toolCallId);
+      return;
+    }
+    if (event.name === "o" && selected) {
+      openPaneForTool(selected);
+      return;
+    }
+    if (event.name === "u" && selected?.undoToken) {
+      void controller.undo(selected.toolCallId);
+      return;
+    }
+    if (event.name === "c" && running) controller.cancel();
+  }, { allowEditable: true });
+
+  const answerTexts = useMemo(
+    () => state.turns.map((turn) => turn.answer).filter(Boolean),
+    [state.turns],
+  );
+  const { catalog, openTicker } = useInlineTickers(answerTexts);
+
+  usePaneFooter(`askg:${paneId}`, () => ({
+    info: [
+      ...(running
+        ? [{ id: "streaming", parts: [{ text: "Streaming", tone: "positive" as const, bold: true }] }]
+        : []),
+      ...(confirmation
+        ? [{ id: "confirm", parts: [{ text: "Waiting for approval", tone: "warning" as const }] }]
+        : []),
+      ...(state.limits && state.limits.turnsRemainingToday >= 0 && !running
+        ? [{
+          id: "quota",
+          parts: [{
+            text: `${state.limits.turnsRemainingToday} questions left today`,
+            tone: "muted" as const,
+          }],
+        }]
+        : []),
+    ],
+    hints: [
+      ...(confirmation
+        ? [
+          { id: "approve", key: "y", label: "es approve", onPress: () => controller.resolveConfirmation(confirmation.toolCallId, true) },
+          { id: "decline", key: "n", label: "o decline", onPress: () => controller.resolveConfirmation(confirmation.toolCallId, false) },
+        ]
+        : []),
+      ...(running
+        ? [{ id: "cancel", key: "c", label: "ancel", onPress: () => controller.cancel() }]
+        : []),
+      ...(selectedToolCallId
+        ? [{ id: "expand", key: "x", label: "pand rows", onPress: () => toggleExpanded(selectedToolCallId) }]
+        : []),
+    ],
+  }), [confirmation, controller, running, selectedToolCallId, state.limits, toggleExpanded]);
+
+  if (!planAccess.emailVerified) {
+    return (
+      <Box flexDirection="column" paddingX={1} paddingTop={1}>
+        <EmptyState
+          title="Ask Gloom needs a verified Gloom Cloud account."
+          hint="Sign in, then ask questions about any pane in the terminal."
+        />
+        <Box paddingTop={1}>
+          <Button
+            label="Sign in"
+            variant="primary"
+            shortcut="s"
+            onPress={() => openCommandBar("Sign In")}
+          />
+        </Box>
+      </Box>
+    );
+  }
+
+  const contentWidth = Math.max(24, width - (nativePaneChrome ? 2 : 4));
+  const composerHeight = nativePaneChrome ? 3 : 2;
+  const confirmationHeight = confirmation ? confirmationBlockHeight(confirmation) : 0;
+  // The conversation keeps a readable slice no matter what else is open.
+  const detailBudget = height - composerHeight - confirmationHeight - 6;
+  const detailHeight = expandedRow && detailBudget >= MIN_DETAIL_HEIGHT
+    ? Math.min(Math.floor(height / 2), detailBudget)
+    : 0;
+
+  return (
+    <Box
+      flexDirection="column"
+      width={nativePaneChrome ? "100%" : width}
+      height={nativePaneChrome ? "100%" : height}
+      overflow="hidden"
+    >
+      <ScrollBox ref={scrollRef} flexGrow={1} minHeight={0} scrollY focusable={false} paddingX={1}>
+        {state.turns.length === 0 ? (
+          <EmptyState
+            title="Ask about anything on screen."
+            hint="Gloom reads your panes to answer, and shows every tool it used."
+          />
+        ) : state.turns.map((turn) => (
+          <TurnView
+            key={turn.id}
+            turn={turn}
+            width={contentWidth}
+            selectedToolCallId={selectedToolCallId}
+            expandedToolCallId={expandedToolCallId}
+            catalog={catalog}
+            openTicker={openTicker}
+            onSelectTool={setSelectedToolCallId}
+            onToggleTool={toggleExpanded}
+            onUndo={(toolCallId) => void controller.undo(toolCallId)}
+          />
+        ))}
+      </ScrollBox>
+
+      {confirmation ? (
+        <ConfirmationPrompt
+          row={confirmation}
+          width={contentWidth}
+          onApprove={() => controller.resolveConfirmation(confirmation.toolCallId, true)}
+          onDecline={() => controller.resolveConfirmation(confirmation.toolCallId, false)}
+        />
+      ) : null}
+
+      {expandedRow && detailHeight > 0 ? (
+        <ToolResultDetail
+          row={expandedRow}
+          width={nativePaneChrome ? width : width - 2}
+          height={detailHeight}
+          focused={focused && !inputFocused}
+          onOpenSymbol={openSymbol}
+          onOpenPane={() => openPaneForTool(expandedRow)}
+        />
+      ) : null}
+
+      <MessageComposer
+        inputRef={inputRef}
+        initialValue={inputValue}
+        focused={inputFocused && focused}
+        placeholder={activeTurn(state) && running ? "Gloom is answering…" : "Ask Gloom a question…"}
+        width="100%"
+        height={composerHeight}
+        terminalPrefix=" > "
+        terminalBottomInset={nativePaneChrome ? 0 : 1}
+        onFocusRequest={focusInput}
+        onInput={setInputValue}
+        keyBindings={[
+          { name: "return", action: "submit" },
+          { name: "linefeed", action: "submit" },
+        ]}
+        onSubmit={submitInput}
+        wrapText
+      />
+    </Box>
+  );
+}

--- a/src/plugins/builtin/cloud/askg/pending-question.ts
+++ b/src/plugins/builtin/cloud/askg/pending-question.ts
@@ -1,0 +1,38 @@
+/**
+ * Hand-off for a question typed at the command bar. The ASKG shortcut can both
+ * open the pane and reuse the one already open, so the question travels here
+ * rather than through pane params: a param would be persisted with the layout
+ * and replayed on the next launch, and a conversation is not layout.
+ */
+type PendingQuestionListener = (question: string) => void;
+
+const listeners = new Set<PendingQuestionListener>();
+/** Held only until the pane the shortcut just opened finishes mounting. */
+let pendingQuestion: string | null = null;
+
+export function askGloomQuestion(question: string): void {
+  const trimmed = question.trim();
+  if (!trimmed) return;
+  if (listeners.size === 0) {
+    pendingQuestion = trimmed;
+    return;
+  }
+  for (const listener of listeners) listener(trimmed);
+}
+
+export function subscribeASKGQuestions(listener: PendingQuestionListener): () => void {
+  listeners.add(listener);
+  const queued = pendingQuestion;
+  if (queued !== null) {
+    pendingQuestion = null;
+    listener(queued);
+  }
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Test helper: drops a question no pane ever claimed. */
+export function clearPendingASKGQuestion(): void {
+  pendingQuestion = null;
+}

--- a/src/plugins/builtin/cloud/askg/protocol.ts
+++ b/src/plugins/builtin/cloud/askg/protocol.ts
@@ -149,6 +149,16 @@ export interface ASKGSessionStartResponse {
   expiresAt: string;
 }
 
+/** Request body for one turn on an open session. */
+export interface ASKGTurnRequest {
+  protocolVersion?: typeof ASKG_PROTOCOL_VERSION;
+  /** Client generated id, reused verbatim to re-attach to a running turn. */
+  turnId: string;
+  input: string;
+  context?: ASKGSessionContext;
+  history?: Array<{ role: "user" | "assistant"; text: string }>;
+}
+
 /** Shared fields carried by every turn stream event. */
 export interface ASKGEventBase {
   seq: number;
@@ -228,6 +238,7 @@ export type ASKGErrorCode =
   | "turn_timeout"
   | "model_usage_limit"
   | "model_unavailable"
+  | "turn_already_recorded"
   | "internal";
 
 /** Reports a recoverable or terminal session or turn failure. */

--- a/src/plugins/builtin/cloud/plugin.tsx
+++ b/src/plugins/builtin/cloud/plugin.tsx
@@ -20,6 +20,7 @@ import {
 import { congressHeadless } from "../congress-trades/headless";
 import { registerTwitterFeedFeature } from "../cloud-tweets/registration";
 import { composeBuiltinPlugin, type PluginModule } from "../plugin-module";
+import { ASKG_PANE_ID, ASKGPane } from "./askg/pane";
 import { registerCloudAuthCommands } from "./auth-commands";
 import { registerCloudUpgradeCommand } from "./upgrade-command";
 import { CloudUpgradeStatusWidget } from "./upgrade-status-widget";
@@ -164,6 +165,41 @@ const accountModule: PluginModule = {
   },
 };
 
+const askgModule: PluginModule = {
+  panes: [{
+    id: ASKG_PANE_ID,
+    name: "Ask Gloom",
+    icon: "K",
+    component: ASKGPane,
+    defaultPosition: "right",
+    defaultMode: "floating",
+    defaultFloatingSize: { width: 96, height: 32 },
+    portableShare: {
+      // A conversation and the panes it read are personal to the account.
+      private: { title: true, params: true, settings: true, state: true },
+    },
+  }],
+  paneTemplates: [{
+    id: "askg-pane",
+    paneId: ASKG_PANE_ID,
+    label: "Ask Gloom",
+    description: "Ask a question about your panes and watch the tools Gloom runs",
+    keywords: ["ask", "gloom", "assistant", "ai", "question", "askg"],
+    shortcut: { prefix: "ASKG", argPlaceholder: "question", argKind: "text" },
+    createInstance: (_context, options) => {
+      const question = options?.arg?.trim() ?? "";
+      return {
+        placement: "floating",
+        // One assistant: a second question focuses the open conversation and
+        // asks there instead of stacking another pane. `askedAt` keeps the
+        // same question asked twice a real change to the pane's params.
+        instanceId: "askg:main",
+        ...(question ? { params: { question, askedAt: String(Date.now()) } } : {}),
+      };
+    },
+  }],
+};
+
 const congressTradesModule: PluginModule = {
   panes: [{
     id: CONGRESS_TRADES_PANE_ID,
@@ -208,6 +244,7 @@ export function createGloomberbCloudPlugin({
       createCloudDataModule(),
       createChatModule(ChatPane, ChatStatusWidget),
       accountModule,
+      askgModule,
       ...extraModules,
       congressTradesModule,
       twitterModule,

--- a/src/plugins/builtin/cloud/plugin.tsx
+++ b/src/plugins/builtin/cloud/plugin.tsx
@@ -21,6 +21,7 @@ import { congressHeadless } from "../congress-trades/headless";
 import { registerTwitterFeedFeature } from "../cloud-tweets/registration";
 import { composeBuiltinPlugin, type PluginModule } from "../plugin-module";
 import { ASKG_PANE_ID, ASKGPane } from "./askg/pane";
+import { askGloomQuestion } from "./askg/pending-question";
 import { registerCloudAuthCommands } from "./auth-commands";
 import { registerCloudUpgradeCommand } from "./upgrade-command";
 import { CloudUpgradeStatusWidget } from "./upgrade-status-widget";
@@ -187,15 +188,12 @@ const askgModule: PluginModule = {
     keywords: ["ask", "gloom", "assistant", "ai", "question", "askg"],
     shortcut: { prefix: "ASKG", argPlaceholder: "question", argKind: "text" },
     createInstance: (_context, options) => {
-      const question = options?.arg?.trim() ?? "";
-      return {
-        placement: "floating",
-        // One assistant: a second question focuses the open conversation and
-        // asks there instead of stacking another pane. `askedAt` keeps the
-        // same question asked twice a real change to the pane's params.
-        instanceId: "askg:main",
-        ...(question ? { params: { question, askedAt: String(Date.now()) } } : {}),
-      };
+      // The question is handed to the pane directly, so it is never persisted
+      // with the layout and never replayed on the next launch.
+      askGloomQuestion(options?.arg ?? "");
+      // One assistant: a second question focuses the conversation already open
+      // and asks there instead of stacking another pane.
+      return { placement: "floating", instanceId: "askg:main" };
     },
   }],
 };

--- a/src/remote/app-host.tsx
+++ b/src/remote/app-host.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { createContext, useContext, useEffect, useMemo } from "react";
 import type { Dispatch, ReactNode } from "react";
 import type { PluginRegistry } from "../plugins/registry";
 import type { AppAction, AppState } from "../state/app/context";
@@ -8,6 +8,17 @@ import { useRemoteUiRegistry } from "./semantic-tree";
 import type { RemoteControlRequest, RemoteControlResponse } from "./types";
 
 export type RemoteControlHandler = (request: RemoteControlRequest) => Promise<RemoteControlResponse>;
+
+const RemoteControlHandlerContext = createContext<RemoteControlHandler | null>(null);
+
+/**
+ * The in-process handler for app operations and resources, or null outside a
+ * remote control host. Panes use it to run the same operations a remote client
+ * would, instead of opening a second controller.
+ */
+export function useRemoteControlHandler(): RemoteControlHandler | null {
+  return useContext(RemoteControlHandlerContext);
+}
 
 export interface RemoteControlAdapter {
   startServer?(options: { dataDir: string; handle: RemoteControlHandler }): void | (() => void | Promise<void>);
@@ -75,5 +86,9 @@ export function RemoteControlHost({
     };
   }, [adapter, controller]);
 
-  return children;
+  return (
+    <RemoteControlHandlerContext value={controller.handle}>
+      {children}
+    </RemoteControlHandlerContext>
+  );
 }

--- a/src/renderers/browser/cloud-transport.ts
+++ b/src/renderers/browser/cloud-transport.ts
@@ -31,8 +31,9 @@ export function browserCredentialedFetch(url: string, init: RequestInit = {}): P
 
 export function installBrowserFetchTransports(): void {
   apiClient.setCookieSessionMode(true);
-  setCloudApiFetchTransport(browserCredentialedFetch);
-  setHttpFetchTransport((url, init) => fetch(url, init));
+  // Both are native fetch, so a response body can be read while it arrives.
+  setCloudApiFetchTransport(browserCredentialedFetch, { streaming: true });
+  setHttpFetchTransport((url, init) => fetch(url, init), { streaming: true });
 }
 
 export async function restoreBrowserCloudSession(budgetMs = 5_000): Promise<void> {

--- a/src/utils/http-transport.ts
+++ b/src/utils/http-transport.ts
@@ -1,9 +1,29 @@
 export type HttpFetchTransport = (url: string, init?: RequestInit) => Promise<Response>;
 
-let httpFetchTransport: HttpFetchTransport | null = null;
+export interface HttpFetchTransportOptions {
+  /**
+   * Whether the transport resolves as soon as headers arrive and exposes a
+   * live `response.body`. A transport that proxies over RPC and returns the
+   * whole payload as a string must leave this false so long-lived reads such
+   * as server-sent events degrade instead of hanging.
+   */
+  streaming?: boolean;
+}
 
-export function setHttpFetchTransport(transport: HttpFetchTransport | null): void {
+let httpFetchTransport: HttpFetchTransport | null = null;
+let httpFetchStreaming = true;
+
+export function setHttpFetchTransport(
+  transport: HttpFetchTransport | null,
+  options: HttpFetchTransportOptions = {},
+): void {
   httpFetchTransport = transport;
+  httpFetchStreaming = transport ? options.streaming ?? false : true;
+}
+
+/** False when the installed transport buffers whole responses. */
+export function isHttpFetchStreaming(): boolean {
+  return httpFetchStreaming;
 }
 
 export function httpFetch(url: string, init?: RequestInit): Promise<Response> {


### PR DESCRIPTION
## Why

ASKG had a protocol, a session layer, server tools and a client tool executor, but nothing a user could talk to. This adds the pane, the streaming transport and the way in.

## What

- `src/api-client/askg.ts`: session start, the SSE turn stream with `Last-Event-ID` resume, tool-result POST with an idempotency key, and cancel. The desktop renderer buffers whole responses and cannot stream, so it degrades with a clear message instead of hanging.
- `src/plugins/builtin/cloud/askg/`: controller, model, pane and the pending question hand off. Streamed answer, a tool timeline that separates client executed calls from ones Gloom ran server side, expandable rows, write tier confirmations backed by the existing undo capture, and specific error states for rate limits, the daily cap and model outages.
- Command bar: an "Ask Gloom" row when the input is a question or nothing matches. DeepSeek command translation is untouched, and the assist runtime's invariants from the recent race fix are preserved.

## Verify

Against `scripts/mock-askg-server.ts` in tmux: the answer streams, the limit envelope renders ("97 questions left today"), and a question that triggers tools shows

```
▸ app.get_resource  app://panes                8 rows
· market.quote      3 quotes           3 rows · Gloom
```

`bun test src/plugins/builtin/cloud src/api-client/askg.test.ts` passes (57), full cloud plus command bar suite 234, typecheck clean.

Still needs the live server: real model streaming, the 402 and 429 paths, and desktop once a push channel exists.