### PR TITLE
Add an Exec tab: the named executives and what they were paid

### DIFF
--- a/src/api-client/data.ts
+++ b/src/api-client/data.ts
@@ -11,6 +11,8 @@ import {
   cloudCongressHousePath,
   cloudEarningsCallsPath,
   cloudEarningsTranscriptPath,
+  publicProxyStatementPath,
+  publicProxyStatementsPath,
   cloudExchangeRatePath,
   cloudSec13FPath,
   cloudSecFilingContentPath,
@@ -51,6 +53,8 @@ import type {
   CloudCongressHousePayload,
   CloudEarningsCallListPayload,
   CloudEarningsTranscriptPayload,
+  CloudProxyStatementListPayload,
+  CloudProxyStatementPayload,
   CloudCorporateActionsPayload,
   CloudEconEventPayload,
   CloudEquityDiagnosticMode,
@@ -90,8 +94,14 @@ type CloudApiRequest = <T>(path: string, options?: RequestInit) => Promise<T>;
 export class CloudDataApi {
   constructor(private readonly request: CloudApiRequest) {}
 
-  private requestMarketSymbol<T>(path: string, symbol: string, exchange?: string): Promise<CloudMarketResponse<T>> {
-    return this.request<CloudMarketResponse<T>>(cloudMarketSymbolPath(path, symbol, exchange));
+  private requestMarketSymbol<T>(
+    path: string,
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<T>> {
+    return this.request<CloudMarketResponse<T>>(
+      cloudMarketSymbolPath(path, symbol, exchange),
+    );
   }
 
   private postMarketBatch<T>(
@@ -105,12 +115,20 @@ export class CloudDataApi {
     });
   }
 
-  async searchInstruments(query: string, limit = 10): Promise<InstrumentSearchResult[]> {
-    const response = await this.request<CloudMarketResponse<InstrumentSearchResult[]>>(cloudMarketSearchPath(query, limit));
+  async searchInstruments(
+    query: string,
+    limit = 10,
+  ): Promise<InstrumentSearchResult[]> {
+    const response = await this.request<
+      CloudMarketResponse<InstrumentSearchResult[]>
+    >(cloudMarketSearchPath(query, limit));
     return response.data ?? [];
   }
 
-  async getCloudQuote(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudQuotePayload>> {
+  async getCloudQuote(
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<CloudQuotePayload>> {
     return this.requestMarketSymbol("/market/quote", symbol, exchange);
   }
 
@@ -121,8 +139,12 @@ export class CloudDataApi {
     return this.postMarketBatch("/market/quotes/batch", targets, mode);
   }
 
-  async getCloudWorldVenues(): Promise<CloudMarketResponse<CloudWorldVenueMapPayload>> {
-    return this.request<CloudMarketResponse<CloudWorldVenueMapPayload>>("/market/venues");
+  async getCloudWorldVenues(): Promise<
+    CloudMarketResponse<CloudWorldVenueMapPayload>
+  > {
+    return this.request<CloudMarketResponse<CloudWorldVenueMapPayload>>(
+      "/market/venues",
+    );
   }
 
   async getCloudMarketScreener(
@@ -146,18 +168,29 @@ export class CloudDataApi {
     exchange?: string,
     expirationDate?: number,
   ): Promise<CloudMarketResponse<CloudOptionsChainPayload>> {
-    return this.request<CloudMarketResponse<CloudOptionsChainPayload>>(cloudOptionsChainPath(symbol, exchange, expirationDate));
+    return this.request<CloudMarketResponse<CloudOptionsChainPayload>>(
+      cloudOptionsChainPath(symbol, exchange, expirationDate),
+    );
   }
 
-  async getCloudProfile(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudCompanyProfile>> {
+  async getCloudProfile(
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<CloudCompanyProfile>> {
     return this.requestMarketSymbol("/market/profile", symbol, exchange);
   }
 
-  async getCloudFundamentals(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudFundamentals>> {
+  async getCloudFundamentals(
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<CloudFundamentals>> {
     return this.requestMarketSymbol("/market/fundamentals", symbol, exchange);
   }
 
-  async getCloudFinancials(symbol: string, exchange?: string): Promise<CloudMarketResponse<TickerFinancials>> {
+  async getCloudFinancials(
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<TickerFinancials>> {
     return this.requestMarketSymbol("/market/financials", symbol, exchange);
   }
 
@@ -168,32 +201,56 @@ export class CloudDataApi {
     return this.postMarketBatch("/market/financials/batch", targets, mode);
   }
 
-  async getCloudHolders(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudHoldersPayload>> {
+  async getCloudHolders(
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<CloudHoldersPayload>> {
     return this.requestMarketSymbol("/market/holders", symbol, exchange);
   }
 
-  async getCloudAnalystResearch(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudAnalystResearchPayload>> {
+  async getCloudAnalystResearch(
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<CloudAnalystResearchPayload>> {
     return this.requestMarketSymbol("/market/analyst", symbol, exchange);
   }
 
-  async getCloudShortInterest(symbol: string, years?: number): Promise<CloudMarketResponse<CloudShortInterestPayload>> {
+  async getCloudShortInterest(
+    symbol: string,
+    years?: number,
+  ): Promise<CloudMarketResponse<CloudShortInterestPayload>> {
     const params = new URLSearchParams({ symbol: symbol.toUpperCase() });
     if (years != null) params.set("years", String(years));
-    return this.request<CloudMarketResponse<CloudShortInterestPayload>>(`/market/short-interest?${params}`);
+    return this.request<CloudMarketResponse<CloudShortInterestPayload>>(
+      `/market/short-interest?${params}`,
+    );
   }
 
-  async getCloudCorporateActions(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudCorporateActionsPayload>> {
-    return this.requestMarketSymbol("/market/corporate-actions", symbol, exchange);
+  async getCloudCorporateActions(
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<CloudCorporateActionsPayload>> {
+    return this.requestMarketSymbol(
+      "/market/corporate-actions",
+      symbol,
+      exchange,
+    );
   }
 
   async getCloudStatements(
     symbol: string,
     exchange?: string,
     period: "annual" | "quarterly" | "both" = "both",
-  ): Promise<CloudMarketResponse<Pick<TickerFinancials, "annualStatements" | "quarterlyStatements">>> {
-    return this.request<CloudMarketResponse<Pick<TickerFinancials, "annualStatements" | "quarterlyStatements">>>(
-      cloudStatementsPath(symbol, exchange, period),
-    );
+  ): Promise<
+    CloudMarketResponse<
+      Pick<TickerFinancials, "annualStatements" | "quarterlyStatements">
+    >
+  > {
+    return this.request<
+      CloudMarketResponse<
+        Pick<TickerFinancials, "annualStatements" | "quarterlyStatements">
+      >
+    >(cloudStatementsPath(symbol, exchange, period));
   }
 
   async getCloudHistory(
@@ -201,11 +258,17 @@ export class CloudDataApi {
     exchange: string,
     params: CloudHistoryParams = {},
   ): Promise<CloudMarketResponse<CloudPricePointPayload[]>> {
-    return this.request<CloudMarketResponse<CloudPricePointPayload[]>>(cloudHistoryPath(symbol, exchange, params));
+    return this.request<CloudMarketResponse<CloudPricePointPayload[]>>(
+      cloudHistoryPath(symbol, exchange, params),
+    );
   }
 
-  async getCloudExchangeRate(fromCurrency: string): Promise<CloudMarketResponse<{ rate: number }>> {
-    return this.request<CloudMarketResponse<{ rate: number }>>(cloudExchangeRatePath(fromCurrency));
+  async getCloudExchangeRate(
+    fromCurrency: string,
+  ): Promise<CloudMarketResponse<{ rate: number }>> {
+    return this.request<CloudMarketResponse<{ rate: number }>>(
+      cloudExchangeRatePath(fromCurrency),
+    );
   }
 
   /**
@@ -218,14 +281,17 @@ export class CloudDataApi {
     exchange?: string,
     mode: CloudEquityDiagnosticMode = "cache-first",
   ): Promise<CloudEquityDiagnosticResult> {
-    return this.request<CloudEquityDiagnosticResult>("/research/equity-diagnostic", {
-      method: "POST",
-      body: JSON.stringify({
-        symbol: symbol.trim().toUpperCase(),
-        ...(exchange ? { exchange } : {}),
-        mode,
-      }),
-    });
+    return this.request<CloudEquityDiagnosticResult>(
+      "/research/equity-diagnostic",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          symbol: symbol.trim().toUpperCase(),
+          ...(exchange ? { exchange } : {}),
+          mode,
+        }),
+      },
+    );
   }
 
   async getCloudEconomicCalendar(): Promise<CloudEconEventPayload[]> {
@@ -236,7 +302,9 @@ export class CloudDataApi {
     seriesId: string,
     params: CloudFredSeriesParams = {},
   ): Promise<CloudFredSeriesPayload> {
-    return this.request<CloudFredSeriesPayload>(cloudFredSeriesPath(seriesId, params));
+    return this.request<CloudFredSeriesPayload>(
+      cloudFredSeriesPath(seriesId, params),
+    );
   }
 
   async getCloudShiller(): Promise<CloudShillerPayload> {
@@ -251,33 +319,73 @@ export class CloudDataApi {
     return this.request<CloudCdsResponse>(cloudCdsPath(params));
   }
 
-  async getCloudCongressHouse(params: CloudCongressHouseParams = {}): Promise<CloudCongressHousePayload> {
-    return this.request<CloudCongressHousePayload>(cloudCongressHousePath(params));
+  async getCloudCongressHouse(
+    params: CloudCongressHouseParams = {},
+  ): Promise<CloudCongressHousePayload> {
+    return this.request<CloudCongressHousePayload>(
+      cloudCongressHousePath(params),
+    );
   }
 
   async getCloudEarningsCalls(
     params: CloudEarningsCallsParams = {},
   ): Promise<CloudEarningsCallListPayload> {
-    return this.request<CloudEarningsCallListPayload>(cloudEarningsCallsPath(params));
+    return this.request<CloudEarningsCallListPayload>(
+      cloudEarningsCallsPath(params),
+    );
   }
 
-  async getCloudEarningsTranscript(id: string): Promise<CloudEarningsTranscriptPayload> {
-    return this.request<CloudEarningsTranscriptPayload>(cloudEarningsTranscriptPath(id));
+  async getCloudEarningsTranscript(
+    id: string,
+  ): Promise<CloudEarningsTranscriptPayload> {
+    return this.request<CloudEarningsTranscriptPayload>(
+      cloudEarningsTranscriptPath(id),
+    );
   }
 
-  async getCloudSecFilings(params: CloudSecFilingsParams): Promise<CloudSecFilingsResponse> {
+  async getProxyStatements(
+    ticker: string,
+  ): Promise<CloudProxyStatementListPayload> {
+    return this.request<CloudProxyStatementListPayload>(
+      publicProxyStatementsPath(ticker),
+    );
+  }
+
+  async getProxyStatement(
+    ticker: string,
+    year: number,
+  ): Promise<CloudProxyStatementPayload> {
+    return this.request<CloudProxyStatementPayload>(
+      publicProxyStatementPath(ticker, year),
+    );
+  }
+
+  async getCloudSecFilings(
+    params: CloudSecFilingsParams,
+  ): Promise<CloudSecFilingsResponse> {
     return this.request<CloudSecFilingsResponse>(cloudSecFilingsPath(params));
   }
 
-  async getCloudSecFilingDocuments(params: CloudSecFilingParams): Promise<CloudSecDocumentsResponse> {
-    return this.request<CloudSecDocumentsResponse>(cloudSecFilingDocumentsPath(params));
+  async getCloudSecFilingDocuments(
+    params: CloudSecFilingParams,
+  ): Promise<CloudSecDocumentsResponse> {
+    return this.request<CloudSecDocumentsResponse>(
+      cloudSecFilingDocumentsPath(params),
+    );
   }
 
-  async getCloudSecFilingContent(params: CloudSecFilingParams): Promise<CloudSecContentResponse> {
-    return this.request<CloudSecContentResponse>(cloudSecFilingContentPath(params));
+  async getCloudSecFilingContent(
+    params: CloudSecFilingParams,
+  ): Promise<CloudSecContentResponse> {
+    return this.request<CloudSecContentResponse>(
+      cloudSecFilingContentPath(params),
+    );
   }
 
-  async getCloudSec13F(path: string, params: Record<string, string | number | undefined> = {}): Promise<unknown> {
+  async getCloudSec13F(
+    path: string,
+    params: Record<string, string | number | undefined> = {},
+  ): Promise<unknown> {
     return this.request<unknown>(cloudSec13FPath(path, params));
   }
 
@@ -290,7 +398,9 @@ export class CloudDataApi {
     options?: { signal?: AbortSignal },
   ): Promise<CloudSearchResponse> {
     return normalizeSearchResponse(
-      await this.request<CloudSearchResponse>(cloudSearchPath(params), { signal: options?.signal }),
+      await this.request<CloudSearchResponse>(cloudSearchPath(params), {
+        signal: options?.signal,
+      }),
     );
   }
 
@@ -306,28 +416,39 @@ export class CloudDataApi {
     return response.document;
   }
 
-  async getCloudSavedSearches(options?: { signal?: AbortSignal }): Promise<CloudSavedSearch[]> {
-    const response = await this.request<CloudSavedSearchListResponse>(cloudSavedSearchesPath(), {
-      signal: options?.signal,
-    });
+  async getCloudSavedSearches(options?: {
+    signal?: AbortSignal;
+  }): Promise<CloudSavedSearch[]> {
+    const response = await this.request<CloudSavedSearchListResponse>(
+      cloudSavedSearchesPath(),
+      {
+        signal: options?.signal,
+      },
+    );
     return response.searches ?? [];
   }
 
-  async createCloudSavedSearch(input: CloudSavedSearchInput): Promise<CloudSavedSearch> {
-    return normalizeSavedSearchResponse(await this.request<unknown>(cloudSavedSearchesPath(), {
-      method: "POST",
-      body: JSON.stringify(input),
-    }));
+  async createCloudSavedSearch(
+    input: CloudSavedSearchInput,
+  ): Promise<CloudSavedSearch> {
+    return normalizeSavedSearchResponse(
+      await this.request<unknown>(cloudSavedSearchesPath(), {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    );
   }
 
   async updateCloudSavedSearch(
     id: string,
     update: Partial<CloudSavedSearchInput>,
   ): Promise<CloudSavedSearch> {
-    return normalizeSavedSearchResponse(await this.request<unknown>(cloudSavedSearchPath(id), {
-      method: "PATCH",
-      body: JSON.stringify(update),
-    }));
+    return normalizeSavedSearchResponse(
+      await this.request<unknown>(cloudSavedSearchPath(id), {
+        method: "PATCH",
+        body: JSON.stringify(update),
+      }),
+    );
   }
 
   async deleteCloudSavedSearch(id: string): Promise<void> {
@@ -338,26 +459,40 @@ export class CloudDataApi {
     id: string,
     options?: { signal?: AbortSignal },
   ): Promise<CloudSearchHit[]> {
-    return normalizeSavedSearchHits(await this.request<unknown>(cloudSavedSearchHitsPath(id), {
-      signal: options?.signal,
-    }));
+    return normalizeSavedSearchHits(
+      await this.request<unknown>(cloudSavedSearchHitsPath(id), {
+        signal: options?.signal,
+      }),
+    );
   }
 
-  async getCloudNews(params: CloudNewsParams = {}): Promise<CloudNewsListResponse> {
+  async getCloudNews(
+    params: CloudNewsParams = {},
+  ): Promise<CloudNewsListResponse> {
     return this.request<CloudNewsListResponse>(cloudNewsPath(params));
   }
 
   async getCloudNewsStory(storyId: string): Promise<CloudNewsPayload> {
-    return this.request<CloudNewsPayload>(`/news/${encodeURIComponent(storyId)}`);
+    return this.request<CloudNewsPayload>(
+      `/news/${encodeURIComponent(storyId)}`,
+    );
   }
 
-  async getCloudTickerTweets(params: CloudTickerTweetsParams): Promise<CloudTweetSearchResponse> {
-    const response = await this.request<CloudTweetSearchResponse>(cloudTickerTweetsPath(params));
+  async getCloudTickerTweets(
+    params: CloudTickerTweetsParams,
+  ): Promise<CloudTweetSearchResponse> {
+    const response = await this.request<CloudTweetSearchResponse>(
+      cloudTickerTweetsPath(params),
+    );
     return normalizeTweetSearchResponse(response);
   }
 
-  async searchCloudTweets(params: CloudTweetSearchParams): Promise<CloudTweetSearchResponse> {
-    const response = await this.request<CloudTweetSearchResponse>(cloudTweetSearchPath(params));
+  async searchCloudTweets(
+    params: CloudTweetSearchParams,
+  ): Promise<CloudTweetSearchResponse> {
+    const response = await this.request<CloudTweetSearchResponse>(
+      cloudTweetSearchPath(params),
+    );
     return normalizeTweetSearchResponse(response);
   }
 }

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -56,6 +56,8 @@ import type {
   CloudCongressHousePayload,
   CloudEarningsCallListPayload,
   CloudEarningsTranscriptPayload,
+  CloudProxyStatementListPayload,
+  CloudProxyStatementPayload,
   CloudNewsPayload,
   CloudSavedSearch,
   CloudSavedSearchInput,
@@ -108,7 +110,12 @@ class GloomApiClient {
   private currentUser: AuthUser | null = null;
   private sessionChecked = false;
   /** Last few session transitions, content-free, for app://auth. */
-  private authTrace: Array<{ at: number; event: string; token: boolean; user: string }> = [];
+  private authTrace: Array<{
+    at: number;
+    event: string;
+    token: boolean;
+    user: string;
+  }> = [];
   private sessionRequest: Promise<AuthUser | null> | null = null;
   private readonly currentUserListeners = new Set<() => void>();
   private readonly transport = new CloudApiRequestTransport();
@@ -135,7 +142,8 @@ class GloomApiClient {
       hasSessionCredential: () => this.transport.hasSessionCredential(),
       hasVerifiedUser: () => this.currentUser?.emailVerified === true,
       isUsingWebSocketToken: () => !!this.transport.getWebSocketToken(),
-      clearWebSocketTokenForFallback: () => this.transport.clearWebSocketTokenForFallback(),
+      clearWebSocketTokenForFallback: () =>
+        this.transport.clearWebSocketTokenForFallback(),
       markCurrentUserUnverified: () => {
         if (this.currentUser) {
           this.currentUser = { ...this.currentUser, emailVerified: false };
@@ -152,7 +160,9 @@ class GloomApiClient {
       request: (path, options) => this.request(path, options),
       socket: this.socket,
     });
-    this.data = new CloudDataApi((path, options) => this.request(path, options));
+    this.data = new CloudDataApi((path, options) =>
+      this.request(path, options),
+    );
     this.askg = new CloudASKGApi({
       request: (path, options) => this.request(path, options),
       openStream: (path, options) => this.transport.openStream(path, options),
@@ -177,7 +187,9 @@ class GloomApiClient {
     const changed = this.transport.getSessionToken() !== token;
     this.sessionChecked = false;
     this.transport.setSessionToken(token);
-    this.traceAuth(changed ? "setSessionToken:changed" : "setSessionToken:same");
+    this.traceAuth(
+      changed ? "setSessionToken:changed" : "setSessionToken:same",
+    );
     if (!token) {
       this.currentUser = null;
       this.emitCurrentUserChange();
@@ -217,7 +229,9 @@ class GloomApiClient {
   }
 
   isVerified(): boolean {
-    return this.transport.hasSessionCredential() && !!this.currentUser?.emailVerified;
+    return (
+      this.transport.hasSessionCredential() && !!this.currentUser?.emailVerified
+    );
   }
 
   /**
@@ -249,17 +263,20 @@ class GloomApiClient {
       trace: [...this.authTrace],
       currentUser: user
         ? {
-          id: user.id,
-          emailVerified: user.emailVerified === true,
-          plan: user.plan ?? null,
-          effectivePlan: user.effectivePlan ?? null,
-          trialEndsAt: user.trialEndsAt ?? null,
-        }
+            id: user.id,
+            emailVerified: user.emailVerified === true,
+            plan: user.plan ?? null,
+            effectivePlan: user.effectivePlan ?? null,
+            trialEndsAt: user.trialEndsAt ?? null,
+          }
         : null,
     };
   }
 
-  private traceAuth(event: string, user: AuthUser | null = this.currentUser): void {
+  private traceAuth(
+    event: string,
+    user: AuthUser | null = this.currentUser,
+  ): void {
     this.authTrace.push({
       at: Date.now(),
       event,
@@ -270,7 +287,9 @@ class GloomApiClient {
   }
 
   private setCurrentUser(user: AuthUser | null): void {
-    const changed = this.socketEntitlementKey(this.currentUser) !== this.socketEntitlementKey(user);
+    const changed =
+      this.socketEntitlementKey(this.currentUser) !==
+      this.socketEntitlementKey(user);
     this.traceAuth("setCurrentUser", user);
     this.currentUser = user;
     this.socket.syncAuthState({ reconnect: changed });
@@ -318,7 +337,12 @@ class GloomApiClient {
     return this.currentUser?.emailVerified ? this.currentUser : null;
   }
 
-  async signUp(email: string, username: string, name: string, password: string): Promise<AuthUser> {
+  async signUp(
+    email: string,
+    username: string,
+    name: string,
+    password: string,
+  ): Promise<AuthUser> {
     return this.auth.signUp(email, username, name, password);
   }
 
@@ -326,7 +350,10 @@ class GloomApiClient {
     return this.auth.signIn(email, password);
   }
 
-  async startDeviceSignIn(body: { clientName?: string; clientPlatform?: string }): Promise<DeviceAuthStartResponse> {
+  async startDeviceSignIn(body: {
+    clientName?: string;
+    clientPlatform?: string;
+  }): Promise<DeviceAuthStartResponse> {
     return this.auth.startDeviceSignIn(body);
   }
 
@@ -351,7 +378,9 @@ class GloomApiClient {
       this.traceAuth("getSession:done", user);
       return user;
     } catch (error) {
-      this.traceAuth(`getSession:error:${error instanceof Error ? error.message.slice(0, 60) : "unknown"}`);
+      this.traceAuth(
+        `getSession:error:${error instanceof Error ? error.message.slice(0, 60) : "unknown"}`,
+      );
       throw error;
     } finally {
       this.sessionRequest = null;
@@ -372,19 +401,30 @@ class GloomApiClient {
 
   /** Creates a Stripe checkout session for Cloud Pro; the URL opens in a browser. */
   async createCloudCheckout(returnTo?: string): Promise<{ url: string }> {
-    return this.request<{ url: string }>("/stripe/checkout", { method: "POST", body: JSON.stringify({ returnTo }) });
+    return this.request<{ url: string }>("/stripe/checkout", {
+      method: "POST",
+      body: JSON.stringify({ returnTo }),
+    });
   }
 
   async recordResearchActivity(payload: {
-    event: import("./research-activity").ResearchActivity; eventId: string;
-    surface: "web" | "desktop" | "tui" | "cli"; anonymousId?: string;
-    attribution?: Record<string, string>; feature?: import("./research-activity").ResearchFeature;
+    event: import("./research-activity").ResearchActivity;
+    eventId: string;
+    surface: "web" | "desktop" | "tui" | "cli";
+    anonymousId?: string;
+    attribution?: Record<string, string>;
+    feature?: import("./research-activity").ResearchFeature;
   }): Promise<void> {
-    await this.request("/activity/research", { method: "POST", body: JSON.stringify(payload) });
+    await this.request("/activity/research", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
   }
 
   /** Stores a verified user's public terminal snapshot or pane handoff. */
-  async createTerminalShare(payload: unknown): Promise<{ id: string; expiresAt: string }> {
+  async createTerminalShare(
+    payload: unknown,
+  ): Promise<{ id: string; expiresAt: string }> {
     return this.request<{ id: string; expiresAt: string }>("/shares", {
       method: "POST",
       body: JSON.stringify(payload),
@@ -393,7 +433,10 @@ class GloomApiClient {
 
   /** Stripe billing portal for an account that already has a subscription. */
   async createBillingPortal(): Promise<{ url: string }> {
-    return this.request<{ url: string }>("/stripe/portal", { method: "POST", body: JSON.stringify({}) });
+    return this.request<{ url: string }>("/stripe/portal", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
   }
 
   async getAccountProfile(): Promise<AccountProfile> {
@@ -412,15 +455,22 @@ class GloomApiClient {
     return this.auth.getBuildoutToken();
   }
 
-  async updateAccountProfile(update: AccountProfileUpdate): Promise<AccountProfile> {
+  async updateAccountProfile(
+    update: AccountProfileUpdate,
+  ): Promise<AccountProfile> {
     return this.auth.updateAccountProfile(update);
   }
 
   async getSyncSnapshot(): Promise<CloudSyncSnapshotResponse> {
-    return this.request<CloudSyncSnapshotResponse>("/sync/snapshot", { method: "GET" });
+    return this.request<CloudSyncSnapshotResponse>("/sync/snapshot", {
+      method: "GET",
+    });
   }
 
-  async putSyncSnapshot(snapshot: SyncSnapshot, options?: { baseRevision?: number | null }): Promise<CloudSyncPushResponse> {
+  async putSyncSnapshot(
+    snapshot: SyncSnapshot,
+    options?: { baseRevision?: number | null },
+  ): Promise<CloudSyncPushResponse> {
     return this.request<CloudSyncPushResponse>("/sync/snapshot", {
       method: "PUT",
       body: JSON.stringify({
@@ -436,22 +486,29 @@ class GloomApiClient {
   ): Promise<LayoutMarketplaceEntry | null> {
     if (!isMarketplaceLayoutId(id)) return null;
     try {
-      return parseMarketplaceLayoutEntry(await this.request<unknown>(`/layouts/${encodeURIComponent(id)}`, {
-        method: "GET",
-        signal: options?.signal,
-      }));
+      return parseMarketplaceLayoutEntry(
+        await this.request<unknown>(`/layouts/${encodeURIComponent(id)}`, {
+          method: "GET",
+          signal: options?.signal,
+        }),
+      );
     } catch (error) {
       if (error instanceof ApiRequestError && error.status === 404) return null;
       throw error;
     }
   }
 
-  async listMarketplaceLayouts(options?: { signal?: AbortSignal }): Promise<LayoutMarketplaceEntry[]> {
-    const items = parseMarketplaceLayoutList(await this.request<unknown>("/layouts", {
-      method: "GET",
-      signal: options?.signal,
-    }));
-    if (!items) throw new Error("The layout marketplace returned invalid data.");
+  async listMarketplaceLayouts(options?: {
+    signal?: AbortSignal;
+  }): Promise<LayoutMarketplaceEntry[]> {
+    const items = parseMarketplaceLayoutList(
+      await this.request<unknown>("/layouts", {
+        method: "GET",
+        signal: options?.signal,
+      }),
+    );
+    if (!items)
+      throw new Error("The layout marketplace returned invalid data.");
     return items;
   }
 
@@ -460,20 +517,27 @@ class GloomApiClient {
     payload: LayoutMarketplacePayload,
     options?: { signal?: AbortSignal },
   ): Promise<LayoutMarketplaceEntry> {
-    const item = parseMarketplaceLayoutEntry(await this.request<unknown>("/layouts", {
-      method: "POST",
-      body: JSON.stringify({ name: name.trim(), ...payload }),
-      signal: options?.signal,
-    }));
+    const item = parseMarketplaceLayoutEntry(
+      await this.request<unknown>("/layouts", {
+        method: "POST",
+        body: JSON.stringify({ name: name.trim(), ...payload }),
+        signal: options?.signal,
+      }),
+    );
     if (!item) throw new Error("The layout marketplace returned invalid data.");
     return item;
   }
 
-  async updateSyncSettings(update: Partial<SyncSettings>): Promise<SyncSettings> {
-    const result = await this.request<{ settings: SyncSettings }>("/sync/settings", {
-      method: "PATCH",
-      body: JSON.stringify(update),
-    });
+  async updateSyncSettings(
+    update: Partial<SyncSettings>,
+  ): Promise<SyncSettings> {
+    const result = await this.request<{ settings: SyncSettings }>(
+      "/sync/settings",
+      {
+        method: "PATCH",
+        body: JSON.stringify(update),
+      },
+    );
     if (this.currentUser) {
       this.currentUser = {
         ...this.currentUser,
@@ -481,21 +545,32 @@ class GloomApiClient {
         weeklyRoundupEnabled: result.settings.weeklyRoundupEnabled,
         positionAlertsEnabled: result.settings.positionAlertsEnabled,
         lastSyncAt: result.settings.lastSyncAt ?? this.currentUser.lastSyncAt,
-        lastRoundupEmailAt: result.settings.lastRoundupEmailAt ?? this.currentUser.lastRoundupEmailAt,
+        lastRoundupEmailAt:
+          result.settings.lastRoundupEmailAt ??
+          this.currentUser.lastRoundupEmailAt,
       };
     }
     return result.settings;
   }
 
   async getRoundupPreview(): Promise<CloudRoundupPreviewResponse> {
-    return this.request<CloudRoundupPreviewResponse>("/sync/roundup/preview", { method: "POST", body: JSON.stringify({}) });
+    return this.request<CloudRoundupPreviewResponse>("/sync/roundup/preview", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
   }
 
   async sendRoundupTestEmail(): Promise<CloudRoundupPreviewResponse> {
-    return this.request<CloudRoundupPreviewResponse>("/sync/roundup/test-email", { method: "POST", body: JSON.stringify({}) });
+    return this.request<CloudRoundupPreviewResponse>(
+      "/sync/roundup/test-email",
+      { method: "POST", body: JSON.stringify({}) },
+    );
   }
 
-  async changePassword(currentPassword: string, newPassword: string): Promise<void> {
+  async changePassword(
+    currentPassword: string,
+    newPassword: string,
+  ): Promise<void> {
     return this.auth.changePassword(currentPassword, newPassword);
   }
 
@@ -562,15 +637,24 @@ class GloomApiClient {
     return this.chat.updateChannelState(channelId, body);
   }
 
-  async markChatNotificationsDelivered(notificationIds: string[]): Promise<{ delivered: number }> {
+  async markChatNotificationsDelivered(
+    notificationIds: string[],
+  ): Promise<{ delivered: number }> {
     return this.chat.markNotificationsDelivered(notificationIds);
   }
 
-  async openDirectChannel(target: { userId?: string; username?: string }): Promise<ChatChannel> {
+  async openDirectChannel(target: {
+    userId?: string;
+    username?: string;
+  }): Promise<ChatChannel> {
     return this.chat.openDirectChannel(target);
   }
 
-  async openGroupChannel(body: { userIds?: string[]; usernames?: string[]; name?: string }): Promise<ChatChannel> {
+  async openGroupChannel(body: {
+    userIds?: string[];
+    usernames?: string[];
+    name?: string;
+  }): Promise<ChatChannel> {
     return this.chat.openGroupChannel(body);
   }
 
@@ -581,11 +665,25 @@ class GloomApiClient {
     return this.chat.getMessages(channelId, opts);
   }
 
-  async sendMessage(channelId: string, content: string, replyToId?: string, clientMessageId?: string): Promise<ChatMessage> {
-    return this.chat.sendMessage(channelId, content, replyToId, clientMessageId);
+  async sendMessage(
+    channelId: string,
+    content: string,
+    replyToId?: string,
+    clientMessageId?: string,
+  ): Promise<ChatMessage> {
+    return this.chat.sendMessage(
+      channelId,
+      content,
+      replyToId,
+      clientMessageId,
+    );
   }
 
-  async editMessage(channelId: string, messageId: string, content: string): Promise<ChatMessage> {
+  async editMessage(
+    channelId: string,
+    messageId: string,
+    content: string,
+  ): Promise<ChatMessage> {
     return this.chat.editMessage(channelId, messageId, content);
   }
 
@@ -593,11 +691,20 @@ class GloomApiClient {
     channelId: string,
     onMessage: (msg: ChatMessage) => void,
     onError?: (err: string) => void,
-  ): { send: (content: string, replyToId?: string, clientMessageId?: string) => Promise<ChatMessage>; close: () => void } {
+  ): {
+    send: (
+      content: string,
+      replyToId?: string,
+      clientMessageId?: string,
+    ) => Promise<ChatMessage>;
+    close: () => void;
+  } {
     return this.chat.connectChannel(channelId, onMessage, onError);
   }
 
-  subscribeChatNotifications(listener: (notification: ChatNotification) => void): () => void {
+  subscribeChatNotifications(
+    listener: (notification: ChatNotification) => void,
+  ): () => void {
     return this.chat.subscribeNotifications(listener);
   }
 
@@ -613,7 +720,10 @@ class GloomApiClient {
   }
 
   /** Subscribes to a shared scanner feed; all panes of one kind share one upstream subscription. */
-  subscribeScanner(scanner: ScannerKind, listener: (event: ScannerFeedEvent) => void): () => void {
+  subscribeScanner(
+    scanner: ScannerKind,
+    listener: (event: ScannerFeedEvent) => void,
+  ): () => void {
     return this.socket.subscribeScanner(scanner, listener);
   }
 
@@ -621,11 +731,17 @@ class GloomApiClient {
     this.socket.dispose();
   }
 
-  async searchInstruments(query: string, limit = 10): Promise<InstrumentSearchResult[]> {
+  async searchInstruments(
+    query: string,
+    limit = 10,
+  ): Promise<InstrumentSearchResult[]> {
     return this.data.searchInstruments(query, limit);
   }
 
-  async getCloudQuote(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudQuotePayload>> {
+  async getCloudQuote(
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<CloudQuotePayload>> {
     return this.data.getCloudQuote(symbol, exchange);
   }
 
@@ -636,7 +752,9 @@ class GloomApiClient {
     return this.data.getCloudQuotesBatch(targets, mode);
   }
 
-  async getCloudWorldVenues(): Promise<CloudMarketResponse<CloudWorldVenueMapPayload>> {
+  async getCloudWorldVenues(): Promise<
+    CloudMarketResponse<CloudWorldVenueMapPayload>
+  > {
     return this.data.getCloudWorldVenues();
   }
 
@@ -656,15 +774,24 @@ class GloomApiClient {
     return this.data.getCloudOptionsChain(symbol, exchange, expirationDate);
   }
 
-  async getCloudProfile(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudCompanyProfile>> {
+  async getCloudProfile(
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<CloudCompanyProfile>> {
     return this.data.getCloudProfile(symbol, exchange);
   }
 
-  async getCloudFundamentals(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudFundamentals>> {
+  async getCloudFundamentals(
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<CloudFundamentals>> {
     return this.data.getCloudFundamentals(symbol, exchange);
   }
 
-  async getCloudFinancials(symbol: string, exchange?: string): Promise<CloudMarketResponse<TickerFinancials>> {
+  async getCloudFinancials(
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<TickerFinancials>> {
     return this.data.getCloudFinancials(symbol, exchange);
   }
 
@@ -675,19 +802,31 @@ class GloomApiClient {
     return this.data.getCloudFinancialsBatch(targets, mode);
   }
 
-  async getCloudHolders(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudHoldersPayload>> {
+  async getCloudHolders(
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<CloudHoldersPayload>> {
     return this.data.getCloudHolders(symbol, exchange);
   }
 
-  async getCloudShortInterest(symbol: string, years?: number): Promise<CloudMarketResponse<CloudShortInterestPayload>> {
+  async getCloudShortInterest(
+    symbol: string,
+    years?: number,
+  ): Promise<CloudMarketResponse<CloudShortInterestPayload>> {
     return this.data.getCloudShortInterest(symbol, years);
   }
 
-  async getCloudAnalystResearch(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudAnalystResearchPayload>> {
+  async getCloudAnalystResearch(
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<CloudAnalystResearchPayload>> {
     return this.data.getCloudAnalystResearch(symbol, exchange);
   }
 
-  async getCloudCorporateActions(symbol: string, exchange?: string): Promise<CloudMarketResponse<CloudCorporateActionsPayload>> {
+  async getCloudCorporateActions(
+    symbol: string,
+    exchange?: string,
+  ): Promise<CloudMarketResponse<CloudCorporateActionsPayload>> {
     return this.data.getCloudCorporateActions(symbol, exchange);
   }
 
@@ -695,7 +834,11 @@ class GloomApiClient {
     symbol: string,
     exchange?: string,
     period: "annual" | "quarterly" | "both" = "both",
-  ): Promise<CloudMarketResponse<Pick<TickerFinancials, "annualStatements" | "quarterlyStatements">>> {
+  ): Promise<
+    CloudMarketResponse<
+      Pick<TickerFinancials, "annualStatements" | "quarterlyStatements">
+    >
+  > {
     return this.data.getCloudStatements(symbol, exchange, period);
   }
 
@@ -707,7 +850,9 @@ class GloomApiClient {
     return this.data.getCloudHistory(symbol, exchange, params);
   }
 
-  async getCloudExchangeRate(fromCurrency: string): Promise<CloudMarketResponse<{ rate: number }>> {
+  async getCloudExchangeRate(
+    fromCurrency: string,
+  ): Promise<CloudMarketResponse<{ rate: number }>> {
     return this.data.getCloudExchangeRate(fromCurrency);
   }
 
@@ -742,7 +887,9 @@ class GloomApiClient {
     return this.data.getCloudCds(params);
   }
 
-  async getCloudCongressHouse(params: CloudCongressHouseParams = {}): Promise<CloudCongressHousePayload> {
+  async getCloudCongressHouse(
+    params: CloudCongressHouseParams = {},
+  ): Promise<CloudCongressHousePayload> {
     return this.data.getCloudCongressHouse(params);
   }
 
@@ -752,23 +899,47 @@ class GloomApiClient {
     return this.data.getCloudEarningsCalls(params);
   }
 
-  async getCloudEarningsTranscript(id: string): Promise<CloudEarningsTranscriptPayload> {
+  async getCloudEarningsTranscript(
+    id: string,
+  ): Promise<CloudEarningsTranscriptPayload> {
     return this.data.getCloudEarningsTranscript(id);
   }
 
-  async getCloudSecFilings(params: CloudSecFilingsParams): Promise<CloudSecFilingsResponse> {
+  async getProxyStatements(
+    ticker: string,
+  ): Promise<CloudProxyStatementListPayload> {
+    return this.data.getProxyStatements(ticker);
+  }
+
+  async getProxyStatement(
+    ticker: string,
+    year: number,
+  ): Promise<CloudProxyStatementPayload> {
+    return this.data.getProxyStatement(ticker, year);
+  }
+
+  async getCloudSecFilings(
+    params: CloudSecFilingsParams,
+  ): Promise<CloudSecFilingsResponse> {
     return this.data.getCloudSecFilings(params);
   }
 
-  async getCloudSecFilingDocuments(params: CloudSecFilingParams): Promise<CloudSecDocumentsResponse> {
+  async getCloudSecFilingDocuments(
+    params: CloudSecFilingParams,
+  ): Promise<CloudSecDocumentsResponse> {
     return this.data.getCloudSecFilingDocuments(params);
   }
 
-  async getCloudSecFilingContent(params: CloudSecFilingParams): Promise<CloudSecContentResponse> {
+  async getCloudSecFilingContent(
+    params: CloudSecFilingParams,
+  ): Promise<CloudSecContentResponse> {
     return this.data.getCloudSecFilingContent(params);
   }
 
-  async getCloudSec13F(path: string, params: Record<string, string | number | undefined> = {}): Promise<unknown> {
+  async getCloudSec13F(
+    path: string,
+    params: Record<string, string | number | undefined> = {},
+  ): Promise<unknown> {
     return this.data.getCloudSec13F(path, params);
   }
 
@@ -787,11 +958,15 @@ class GloomApiClient {
     return this.data.getCloudSearchDocument(docType, sourceId, options);
   }
 
-  async getCloudSavedSearches(options?: { signal?: AbortSignal }): Promise<CloudSavedSearch[]> {
+  async getCloudSavedSearches(options?: {
+    signal?: AbortSignal;
+  }): Promise<CloudSavedSearch[]> {
     return this.data.getCloudSavedSearches(options);
   }
 
-  async createCloudSavedSearch(input: CloudSavedSearchInput): Promise<CloudSavedSearch> {
+  async createCloudSavedSearch(
+    input: CloudSavedSearchInput,
+  ): Promise<CloudSavedSearch> {
     return this.data.createCloudSavedSearch(input);
   }
 
@@ -813,7 +988,9 @@ class GloomApiClient {
     return this.data.getCloudSavedSearchHits(id, options);
   }
 
-  async getCloudNews(params: CloudNewsParams = {}): Promise<CloudNewsListResponse> {
+  async getCloudNews(
+    params: CloudNewsParams = {},
+  ): Promise<CloudNewsListResponse> {
     return this.data.getCloudNews(params);
   }
 
@@ -821,11 +998,15 @@ class GloomApiClient {
     return this.data.getCloudNewsStory(storyId);
   }
 
-  async getCloudTickerTweets(params: CloudTickerTweetsParams): Promise<CloudTweetSearchResponse> {
+  async getCloudTickerTweets(
+    params: CloudTickerTweetsParams,
+  ): Promise<CloudTweetSearchResponse> {
     return this.data.getCloudTickerTweets(params);
   }
 
-  async searchCloudTweets(params: CloudTweetSearchParams): Promise<CloudTweetSearchResponse> {
+  async searchCloudTweets(
+    params: CloudTweetSearchParams,
+  ): Promise<CloudTweetSearchResponse> {
     return this.data.searchCloudTweets(params);
   }
 }

--- a/src/api-client/paths.ts
+++ b/src/api-client/paths.ts
@@ -1,4 +1,8 @@
-import type { CloudSearchDocType, CloudSearchSort, CloudTweetQueryType } from "./types";
+import type {
+  CloudSearchDocType,
+  CloudSearchSort,
+  CloudTweetQueryType,
+} from "./types";
 import { normalizeSymbol, publicTickerKey } from "../utils/exchanges";
 
 export type CloudHistoryParams = {
@@ -82,13 +86,19 @@ const CRYPTO_QUOTE = /[-/](USD|USDT|USDC|EUR|GBP|BTC)$/;
 
 export type CloudLogoKind = "ticker" | "crypto";
 
-export function normalizeCloudLogoSymbol(kind: CloudLogoKind, symbol: string): string | null {
+export function normalizeCloudLogoSymbol(
+  kind: CloudLogoKind,
+  symbol: string,
+): string | null {
   let normalized = symbol.trim().toUpperCase();
   if (kind === "crypto") normalized = normalized.replace(CRYPTO_QUOTE, "");
   return LOGO_SYMBOL_RE.test(normalized) ? normalized : null;
 }
 
-export function cloudLogoPath(kind: CloudLogoKind, symbol: string): string | null {
+export function cloudLogoPath(
+  kind: CloudLogoKind,
+  symbol: string,
+): string | null {
   const normalized = normalizeCloudLogoSymbol(kind, symbol);
   if (!normalized) return null;
   return `/cloud/logos/${kind}/${encodeURIComponent(normalized)}`;
@@ -100,22 +110,34 @@ function appendQuery(path: string, search: URLSearchParams): string {
 }
 
 export function cloudMarketSearchPath(query: string, limit: number): string {
-  return appendQuery("/market/search", new URLSearchParams({
-    q: query,
-    limit: String(limit),
-  }));
+  return appendQuery(
+    "/market/search",
+    new URLSearchParams({
+      q: query,
+      limit: String(limit),
+    }),
+  );
 }
 
-export function cloudMarketSymbolPath(path: string, symbol: string, exchange?: string): string {
+export function cloudMarketSymbolPath(
+  path: string,
+  symbol: string,
+  exchange?: string,
+): string {
   const search = new URLSearchParams({ symbol });
   if (exchange) search.set("exchange", exchange);
   return appendQuery(path, search);
 }
 
-export function cloudOptionsChainPath(symbol: string, exchange?: string, expirationDate?: number): string {
+export function cloudOptionsChainPath(
+  symbol: string,
+  exchange?: string,
+  expirationDate?: number,
+): string {
   const search = new URLSearchParams({ symbol });
   if (exchange) search.set("exchange", exchange);
-  if (expirationDate != null) search.set("expirationDate", String(expirationDate));
+  if (expirationDate != null)
+    search.set("expirationDate", String(expirationDate));
   return appendQuery("/market/options", search);
 }
 
@@ -129,10 +151,15 @@ export function cloudStatementsPath(
   return appendQuery("/market/statements", search);
 }
 
-export function cloudHistoryPath(symbol: string, exchange: string, params: CloudHistoryParams = {}): string {
+export function cloudHistoryPath(
+  symbol: string,
+  exchange: string,
+  params: CloudHistoryParams = {},
+): string {
   const search = new URLSearchParams({ symbol, exchange });
   if (params.interval) search.set("interval", params.interval);
-  if (params.outputsize != null) search.set("outputsize", String(params.outputsize));
+  if (params.outputsize != null)
+    search.set("outputsize", String(params.outputsize));
   if (params.startDate) search.set("startDate", params.startDate);
   if (params.endDate) search.set("endDate", params.endDate);
   if (params.rangeKey) search.set("rangeKey", params.rangeKey);
@@ -144,16 +171,25 @@ export function cloudShillerPath(): string {
 }
 
 export function cloudExchangeRatePath(fromCurrency: string): string {
-  return appendQuery("/market/exchange-rate", new URLSearchParams({ fromCurrency }));
+  return appendQuery(
+    "/market/exchange-rate",
+    new URLSearchParams({ fromCurrency }),
+  );
 }
 
-export function cloudFredSeriesPath(seriesId: string, params: CloudFredSeriesParams = {}): string {
+export function cloudFredSeriesPath(
+  seriesId: string,
+  params: CloudFredSeriesParams = {},
+): string {
   const search = new URLSearchParams();
   if (params.startDate) search.set("startDate", params.startDate);
   if (params.endDate) search.set("endDate", params.endDate);
   if (params.limit != null) search.set("limit", String(params.limit));
   if (params.sortOrder) search.set("sortOrder", params.sortOrder);
-  return appendQuery(`/cloud/econ/series/${encodeURIComponent(seriesId)}`, search);
+  return appendQuery(
+    `/cloud/econ/series/${encodeURIComponent(seriesId)}`,
+    search,
+  );
 }
 
 export function cloudCdsPath(params: CloudCdsParams = {}): string {
@@ -180,20 +216,26 @@ export type CloudSecFilingParams = {
   filingUrl?: string;
 };
 
-export function cloudCongressHousePath(params: CloudCongressHouseParams = {}): string {
+export function cloudCongressHousePath(
+  params: CloudCongressHouseParams = {},
+): string {
   const search = new URLSearchParams();
   if (params.year != null) search.set("year", String(params.year));
   if (params.limit != null) search.set("limit", String(params.limit));
   if (params.offset != null) search.set("offset", String(params.offset));
-  if (params.filingLimit != null) search.set("filingLimit", String(params.filingLimit));
-  if (params.filingOffset != null) search.set("filingOffset", String(params.filingOffset));
+  if (params.filingLimit != null)
+    search.set("filingLimit", String(params.filingLimit));
+  if (params.filingOffset != null)
+    search.set("filingOffset", String(params.filingOffset));
   if (params.member) search.set("member", params.member);
   if (params.ticker) search.set("ticker", params.ticker);
   if (params.refresh != null) search.set("refresh", String(params.refresh));
   return appendQuery("/cloud/congress/house", search);
 }
 
-export function cloudEarningsCallsPath(params: CloudEarningsCallsParams = {}): string {
+export function cloudEarningsCallsPath(
+  params: CloudEarningsCallsParams = {},
+): string {
   const search = new URLSearchParams();
   if (params.ticker) search.set("ticker", params.ticker);
   if (params.limit != null) search.set("limit", String(params.limit));
@@ -206,6 +248,15 @@ export function cloudEarningsTranscriptPath(id: string): string {
   return `/cloud/transcripts/${encodeURIComponent(id)}`;
 }
 
+/** Executive compensation reads are open: no account, no plan. */
+export function publicProxyStatementsPath(ticker: string): string {
+  return `/public/proxies/${encodeURIComponent(ticker.toUpperCase())}`;
+}
+
+export function publicProxyStatementPath(ticker: string, year: number): string {
+  return `/public/proxies/${encodeURIComponent(ticker.toUpperCase())}/${year}`;
+}
+
 export function cloudSecFilingsPath(params: CloudSecFilingsParams): string {
   const search = new URLSearchParams({ ticker: params.ticker });
   if (params.limit != null) search.set("limit", String(params.limit));
@@ -213,28 +264,38 @@ export function cloudSecFilingsPath(params: CloudSecFilingsParams): string {
   return appendQuery("/cloud/sec/filings", search);
 }
 
-export function cloudSecFilingDocumentsPath(params: CloudSecFilingParams): string {
+export function cloudSecFilingDocumentsPath(
+  params: CloudSecFilingParams,
+): string {
   const search = new URLSearchParams();
   if (params.cik) search.set("cik", params.cik);
   if (params.accession) search.set("accession", params.accession);
   if (params.form) search.set("form", params.form);
-  if (params.primaryDocument) search.set("primaryDocument", params.primaryDocument);
+  if (params.primaryDocument)
+    search.set("primaryDocument", params.primaryDocument);
   if (params.filingUrl) search.set("filingUrl", params.filingUrl);
   return appendQuery("/cloud/sec/filing/documents", search);
 }
 
-export function cloudSecFilingContentPath(params: CloudSecFilingParams): string {
+export function cloudSecFilingContentPath(
+  params: CloudSecFilingParams,
+): string {
   const search = new URLSearchParams();
   if (params.cik) search.set("cik", params.cik);
   if (params.accession) search.set("accession", params.accession);
   if (params.form) search.set("form", params.form);
-  if (params.primaryDocument) search.set("primaryDocument", params.primaryDocument);
-  if (params.primaryDocumentUrl) search.set("primaryDocumentUrl", params.primaryDocumentUrl);
+  if (params.primaryDocument)
+    search.set("primaryDocument", params.primaryDocument);
+  if (params.primaryDocumentUrl)
+    search.set("primaryDocumentUrl", params.primaryDocumentUrl);
   if (params.filingUrl) search.set("filingUrl", params.filingUrl);
   return appendQuery("/cloud/sec/filing/content", search);
 }
 
-export function cloudSec13FPath(path: string, params: Record<string, string | number | undefined> = {}): string {
+export function cloudSec13FPath(
+  path: string,
+  params: Record<string, string | number | undefined> = {},
+): string {
   const search = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
     if (value !== undefined) search.set(key, String(value));
@@ -262,7 +323,9 @@ export type CloudSearchParams = {
 
 function csvParam(values: readonly string[] | undefined): string | null {
   if (!values) return null;
-  const cleaned = values.map((value) => value.trim()).filter((value) => value.length > 0);
+  const cleaned = values
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
   return cleaned.length > 0 ? cleaned.join(",") : null;
 }
 
@@ -286,7 +349,10 @@ export function cloudSearchPath(params: CloudSearchParams): string {
   return appendQuery("/cloud/search", search);
 }
 
-export function cloudSearchDocumentPath(docType: CloudSearchDocType, sourceId: string): string {
+export function cloudSearchDocumentPath(
+  docType: CloudSearchDocType,
+  sourceId: string,
+): string {
   return `/cloud/search/documents/${encodeURIComponent(docType)}/${encodeURIComponent(sourceId)}`;
 }
 
@@ -312,16 +378,21 @@ export function cloudNewsPath(params: CloudNewsParams = {}): string {
     search.set("tickers", tickerFilter);
   }
   if (params.tickerTier) search.set("tickerTier", params.tickerTier);
-  if (params.tickerRelations?.length) search.set("tickerRelations", params.tickerRelations.join(","));
+  if (params.tickerRelations?.length)
+    search.set("tickerRelations", params.tickerRelations.join(","));
   if (params.limit != null) search.set("limit", String(params.limit));
   if (params.topics?.length) search.set("topics", params.topics.join(","));
-  if (params.categories?.length) search.set("categories", params.categories.join(","));
+  if (params.categories?.length)
+    search.set("categories", params.categories.join(","));
   if (params.sectors?.length) search.set("sectors", params.sectors.join(","));
   if (params.sources?.length) search.set("sources", params.sources.join(","));
-  if (params.excludeSources?.length) search.set("excludeSources", params.excludeSources.join(","));
+  if (params.excludeSources?.length)
+    search.set("excludeSources", params.excludeSources.join(","));
   if (params.sentiment) search.set("sentiment", params.sentiment);
-  if (params.minImportance != null) search.set("minImportance", String(params.minImportance));
-  if (params.minUrgency != null) search.set("minUrgency", String(params.minUrgency));
+  if (params.minImportance != null)
+    search.set("minImportance", String(params.minImportance));
+  if (params.minUrgency != null)
+    search.set("minUrgency", String(params.minUrgency));
   if (params.breaking != null) search.set("breaking", String(params.breaking));
   if (params.since) search.set("since", params.since.toISOString());
   if (params.until) search.set("until", params.until.toISOString());
@@ -333,7 +404,8 @@ export function cloudTickerTweetsPath(params: CloudTickerTweetsParams): string {
   const search = new URLSearchParams({ ticker: params.ticker });
   if (params.limit != null) search.set("limit", String(params.limit));
   if (params.hours != null) search.set("hours", String(params.hours));
-  if (params.includeReplies != null) search.set("includeReplies", String(params.includeReplies));
+  if (params.includeReplies != null)
+    search.set("includeReplies", String(params.includeReplies));
   return appendQuery("/news/tweets", search);
 }
 

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -513,6 +513,64 @@ export interface CloudEarningsCallListPayload {
   unknownTicker?: boolean;
 }
 
+/** One row of a proxy statement's Summary Compensation Table, in dollars. */
+export interface CloudExecutiveRowPayload {
+  name: string;
+  title: string;
+  salary: number | null;
+  bonus: number | null;
+  stockAwards: number | null;
+  optionAwards: number | null;
+  nonEquityIncentive: number | null;
+  pensionAndDeferred: number | null;
+  allOther: number | null;
+  total: number | null;
+}
+
+export interface CloudProxyStatementSummaryPayload {
+  id: string;
+  ticker: string;
+  company: {
+    ticker: string;
+    cik: string | null;
+    name: string;
+    shortName: string;
+  };
+  /** Year of the filing date: what people call "the 2026 proxy". */
+  proxyYear: number;
+  fiscalYear: number | null;
+  fiscalYearLabel: string | null;
+  filedAt: string;
+  meetingDate: string | null;
+  updatedAt: string;
+  ceoName: string | null;
+  ceoTitle: string | null;
+  ceoTotal: number | null;
+  ceoPriorYearTotal: number | null;
+  payRatio: number | null;
+  medianEmployeePay: number | null;
+}
+
+export interface CloudProxyStatementPayload extends CloudProxyStatementSummaryPayload {
+  docUrl: string;
+  ceo: (CloudExecutiveRowPayload & { priorYearTotal: number | null }) | null;
+  namedExecutives: CloudExecutiveRowPayload[];
+  sayOnPayPriorSupport: number | null;
+  highlights: string | null;
+  keyFigures: CloudTranscriptKeyFigurePayload[];
+  otherYears: CloudProxyStatementSummaryPayload[];
+}
+
+export interface CloudProxyStatementListPayload {
+  company: {
+    ticker: string;
+    cik: string | null;
+    name: string;
+    shortName: string;
+  };
+  proxies: CloudProxyStatementSummaryPayload[];
+}
+
 export interface CloudTranscriptTurnPayload {
   speaker: string;
   role?: string;

--- a/src/plugins/builtin/earnings-calls/transcript-view.tsx
+++ b/src/plugins/builtin/earnings-calls/transcript-view.tsx
@@ -72,7 +72,7 @@ function styledRuns(text: string, color: string, attributes = 0): StyledText {
  * chrome wraps the styled paragraph itself. `indent` is applied to every
  * line after the first, for bullets.
  */
-function Prose({
+export function Prose({
   text,
   width,
   color,
@@ -125,7 +125,7 @@ function Prose({
   );
 }
 
-function SectionHeading({ title }: { title: string }) {
+export function SectionHeading({ title }: { title: string }) {
   return (
     <Box height={1} marginTop={1}>
       <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>

--- a/src/plugins/builtin/executives/data.ts
+++ b/src/plugins/builtin/executives/data.ts
@@ -1,0 +1,139 @@
+import {
+  apiClient,
+  type CloudProxyStatementListPayload,
+  type CloudProxyStatementPayload,
+} from "../../../api-client";
+import type { PluginPersistence } from "../../../types/plugin";
+
+/**
+ * Executive compensation comes from Gloom Cloud's open proxy-statement
+ * reads. A proxy is filed once a year and the extraction does not change
+ * after it is verified, so a statement is kept for a long time; the list
+ * of years is refreshed more often, since a new filing adds one.
+ */
+
+const LIST_KIND = "proxies";
+const STATEMENT_KIND = "proxy";
+const CACHE_SOURCE = "executives";
+const CACHE_SCHEMA_VERSION = 1;
+
+const LIST_CACHE_POLICY = {
+  staleMs: 6 * 60 * 60 * 1000,
+  expireMs: 30 * 24 * 60 * 60 * 1000,
+} as const;
+
+const STATEMENT_CACHE_POLICY = {
+  staleMs: 7 * 24 * 60 * 60 * 1000,
+  expireMs: 365 * 24 * 60 * 60 * 1000,
+} as const;
+
+let persistence: PluginPersistence | null = null;
+const activeListFetches = new Map<
+  string,
+  Promise<CloudProxyStatementListPayload>
+>();
+const activeStatementFetches = new Map<
+  string,
+  Promise<CloudProxyStatementPayload>
+>();
+
+export function attachExecutivesPersistence(value: PluginPersistence): void {
+  persistence = value;
+}
+
+export function resetExecutivesPersistence(): void {
+  persistence = null;
+  activeListFetches.clear();
+  activeStatementFetches.clear();
+}
+
+function cached<T>(kind: string, key: string, allowExpired = false) {
+  return persistence?.getResource<T>(kind, key, {
+    sourceKey: CACHE_SOURCE,
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    allowExpired,
+  });
+}
+
+function remember<T>(
+  kind: string,
+  key: string,
+  value: T,
+  policy: { staleMs: number; expireMs: number },
+) {
+  persistence?.setResource(kind, key, value, {
+    sourceKey: CACHE_SOURCE,
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    cachePolicy: policy,
+  });
+}
+
+export async function loadProxyStatements(
+  ticker: string,
+  options?: { force?: boolean },
+): Promise<CloudProxyStatementListPayload> {
+  const key = ticker.toUpperCase();
+  const force = options?.force ?? false;
+  const hit = cached<CloudProxyStatementListPayload>(LIST_KIND, key);
+  if (!force && hit && !hit.stale) return hit.value;
+
+  const active = activeListFetches.get(key);
+  if (active && !force) return active;
+
+  const request = apiClient
+    .getProxyStatements(key)
+    .then((payload) => {
+      remember(LIST_KIND, key, payload, LIST_CACHE_POLICY);
+      return payload;
+    })
+    .catch((error: unknown) => {
+      const expired = cached<CloudProxyStatementListPayload>(
+        LIST_KIND,
+        key,
+        true,
+      );
+      if (expired) return expired.value;
+      throw error;
+    })
+    .finally(() => {
+      if (activeListFetches.get(key) === request) activeListFetches.delete(key);
+    });
+  activeListFetches.set(key, request);
+  return request;
+}
+
+export async function loadProxyStatement(
+  ticker: string,
+  year: number,
+  options?: { force?: boolean },
+): Promise<CloudProxyStatementPayload> {
+  const key = `${ticker.toUpperCase()}:${year}`;
+  const force = options?.force ?? false;
+  const hit = cached<CloudProxyStatementPayload>(STATEMENT_KIND, key);
+  if (!force && hit && !hit.stale) return hit.value;
+
+  const active = activeStatementFetches.get(key);
+  if (active && !force) return active;
+
+  const request = apiClient
+    .getProxyStatement(ticker, year)
+    .then((payload) => {
+      remember(STATEMENT_KIND, key, payload, STATEMENT_CACHE_POLICY);
+      return payload;
+    })
+    .catch((error: unknown) => {
+      const expired = cached<CloudProxyStatementPayload>(
+        STATEMENT_KIND,
+        key,
+        true,
+      );
+      if (expired) return expired.value;
+      throw error;
+    })
+    .finally(() => {
+      if (activeStatementFetches.get(key) === request)
+        activeStatementFetches.delete(key);
+    });
+  activeStatementFetches.set(key, request);
+  return request;
+}

--- a/src/plugins/builtin/executives/format.ts
+++ b/src/plugins/builtin/executives/format.ts
@@ -1,0 +1,53 @@
+import type { CloudExecutiveRowPayload } from "../../../api-client";
+
+/** "$36.3M", "$282K", "$50,000". */
+export function formatPay(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value))
+    return "—";
+  const abs = Math.abs(value);
+  if (abs >= 1e9) return `$${(value / 1e9).toFixed(2).replace(/\.?0+$/, "")}B`;
+  if (abs >= 1e6) return `$${(value / 1e6).toFixed(1).replace(/\.0$/, "")}M`;
+  if (abs >= 1e5) return `$${Math.round(value / 1e3)}K`;
+  return `$${Math.round(value).toLocaleString("en-US")}`;
+}
+
+export function formatRatio(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "—";
+  return `${Math.round(value)}:1`;
+}
+
+/** "+17%" or "-27%"; empty when either year is missing. */
+export function formatChange(
+  current: number | null,
+  prior: number | null,
+): string {
+  if (!current || !prior || prior <= 0) return "";
+  const change = Math.round(((current - prior) / prior) * 100);
+  return `${change > 0 ? "+" : ""}${change}%`;
+}
+
+export function formatFiled(value: string | null): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+  });
+}
+
+/** Share of a row's total that was stock and option awards, as "82%". */
+export function equityShare(row: CloudExecutiveRowPayload): string {
+  if (!row.total) return "";
+  const equity = (row.stockAwards ?? 0) + (row.optionAwards ?? 0);
+  if (equity <= 0) return "";
+  return `${Math.round((equity / row.total) * 100)}%`;
+}
+
+/** "President and CEO" trimmed to fit a column. */
+export function shortTitle(title: string, max: number): string {
+  const cleaned = title.replace(/\s+/g, " ").trim();
+  if (cleaned.length <= max) return cleaned;
+  return `${cleaned.slice(0, Math.max(1, max - 1)).trimEnd()}…`;
+}

--- a/src/plugins/builtin/executives/index.tsx
+++ b/src/plugins/builtin/executives/index.tsx
@@ -1,0 +1,61 @@
+import type { PluginModule } from "../plugin-module";
+import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
+import {
+  attachExecutivesPersistence,
+  resetExecutivesPersistence,
+} from "./data";
+import { EXECUTIVES_PANE_ID, ExecutivesPane } from "./pane";
+
+const description =
+  "Named executive officers and what they were paid, read from the company's proxy statement and checked against the filing.";
+
+export const executivesModule: PluginModule = {
+  setup(ctx) {
+    attachExecutivesPersistence(ctx.persistence);
+    ctx.registerTickerResearchTab({
+      id: "executives",
+      name: "Exec",
+      order: 35,
+      component: ExecutivesPane,
+      isVisible: ({ ticker }) => !!ticker,
+    });
+  },
+
+  dispose() {
+    resetExecutivesPersistence();
+  },
+
+  panes: [
+    {
+      id: EXECUTIVES_PANE_ID,
+      name: "Executives",
+      icon: "X",
+      component: ExecutivesPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 100, height: 30 },
+    },
+  ],
+
+  paneTemplates: [
+    createTickerSurfacePaneTemplate({
+      id: "executives-pane",
+      paneId: EXECUTIVES_PANE_ID,
+      label: "Executives",
+      description,
+      keywords: [
+        "executive",
+        "executives",
+        "exec",
+        "ceo",
+        "compensation",
+        "pay",
+        "proxy",
+        "def 14a",
+        "salary",
+      ],
+      shortcut: "EXEC",
+      publicShare: false,
+    }),
+  ],
+};

--- a/src/plugins/builtin/executives/pane.tsx
+++ b/src/plugins/builtin/executives/pane.tsx
@@ -1,0 +1,429 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  CloudExecutiveRowPayload,
+  CloudProxyStatementPayload,
+  CloudProxyStatementSummaryPayload,
+} from "../../../api-client";
+import {
+  EmptyState,
+  Spinner,
+  Tabs,
+  usePaneFooter,
+  type PaneFooterSegment,
+} from "../../../components";
+import { useShortcut } from "../../../react/input";
+import { colors } from "../../../theme/colors";
+import {
+  Box,
+  ScrollBox,
+  Text,
+  TextAttributes,
+  useRendererHost,
+  useUiCapabilities,
+  type ScrollBoxRenderable,
+} from "../../../ui";
+import { isPlainKey } from "../../../utils/keyboard";
+import { Prose, SectionHeading } from "../earnings-calls/transcript-view";
+import { useBoundTicker } from "../shared/ticker-request";
+import { loadProxyStatement, loadProxyStatements } from "./data";
+import {
+  equityShare,
+  formatChange,
+  formatFiled,
+  formatPay,
+  formatRatio,
+  shortTitle,
+} from "./format";
+
+export const EXECUTIVES_PANE_ID = "executives";
+
+const MAX_PROSE_WIDTH = 100;
+
+/** A figure and what it is, value first so the column of numbers is what the eye reads. */
+function FigureLine({
+  value,
+  label,
+  note,
+  width,
+  valueWidth,
+  nativePaneChrome,
+}: {
+  value: string;
+  label: string;
+  note?: string;
+  width: number;
+  valueWidth: number;
+  nativePaneChrome: boolean;
+}) {
+  const text = [label, note].filter(Boolean).join(", ");
+  return (
+    <Prose
+      text={text}
+      width={width}
+      color={colors.textDim}
+      nativePaneChrome={nativePaneChrome}
+      prefix={`${value.padEnd(valueWidth)}  `}
+      prefixColor={colors.textBright}
+    />
+  );
+}
+
+function ExecutiveRows({
+  rows,
+  width,
+  nativePaneChrome,
+}: {
+  rows: CloudExecutiveRowPayload[];
+  width: number;
+  nativePaneChrome: boolean;
+}) {
+  // Name, title, equity share, total. The title takes whatever is left.
+  const totalWidth = 9;
+  const equityWidth = 5;
+  const nameWidth = Math.min(
+    24,
+    Math.max(10, ...rows.map((row) => row.name.length)),
+  );
+  const titleWidth = Math.max(
+    8,
+    width - nameWidth - equityWidth - totalWidth - 6,
+  );
+  return (
+    <Box flexDirection="column">
+      <Box height={1} flexDirection="row">
+        <Text fg={colors.textDim}>
+          {"NAME".padEnd(nameWidth)} {"TITLE".padEnd(titleWidth)}{" "}
+          {"EQ%".padStart(equityWidth)} {"TOTAL".padStart(totalWidth)}
+        </Text>
+      </Box>
+      {rows.map((row) => (
+        <Box key={`${row.name}-${row.total}`} height={1} flexDirection="row">
+          <Text fg={colors.textBright}>
+            {shortTitle(row.name, nameWidth).padEnd(nameWidth)}
+          </Text>
+          <Text fg={colors.textDim}>
+            {" "}
+            {shortTitle(row.title, titleWidth).padEnd(titleWidth)}{" "}
+          </Text>
+          <Text fg={colors.textDim}>
+            {equityShare(row).padStart(equityWidth)}{" "}
+          </Text>
+          <Text fg={colors.text} attributes={TextAttributes.BOLD}>
+            {formatPay(row.total).padStart(totalWidth)}
+          </Text>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+function figuresOf(statement: CloudProxyStatementPayload) {
+  const figures: Array<{ value: string; label: string; note?: string }> = [];
+  const ceo = statement.ceo;
+  if (ceo?.total) {
+    const change = formatChange(ceo.total, ceo.priorYearTotal);
+    figures.push({
+      value: formatPay(ceo.total),
+      label: `${ceo.name} total pay`,
+      note: change
+        ? `${change} vs prior year`
+        : (statement.fiscalYearLabel ?? undefined),
+    });
+  }
+  if (statement.payRatio !== null) {
+    figures.push({
+      value: formatRatio(statement.payRatio),
+      label: "CEO to median employee",
+      note: statement.medianEmployeePay
+        ? `median ${formatPay(statement.medianEmployeePay)}`
+        : undefined,
+    });
+  }
+  if (ceo) {
+    const share = equityShare(ceo);
+    if (share) figures.push({ value: share, label: "CEO pay in equity" });
+  }
+  if (statement.sayOnPayPriorSupport !== null) {
+    figures.push({
+      value: `${Math.round(statement.sayOnPayPriorSupport)}%`,
+      label: "prior say-on-pay support",
+    });
+  }
+  const seen = new Set(figures.map((figure) => figure.label.toLowerCase()));
+  for (const figure of statement.keyFigures ?? []) {
+    if (figures.length >= 8) break;
+    if (seen.has(figure.label.toLowerCase())) continue;
+    figures.push({
+      value: figure.value,
+      label: figure.label,
+      note: figure.note || undefined,
+    });
+  }
+  return figures;
+}
+
+export function ExecutivesPane({
+  focused,
+  width,
+}: {
+  focused: boolean;
+  width: number;
+  height: number;
+}) {
+  const { symbol } = useBoundTicker();
+  const ticker = symbol ? symbol.toUpperCase() : null;
+  const nativePaneChrome = useUiCapabilities().nativePaneChrome === true;
+  const rendererHost = useRendererHost();
+
+  const [years, setYears] = useState<CloudProxyStatementSummaryPayload[]>([]);
+  const [year, setYear] = useState<number | null>(null);
+  const [statement, setStatement] = useState<CloudProxyStatementPayload | null>(
+    null,
+  );
+  const [status, setStatus] = useState<
+    "idle" | "loading" | "loaded" | "none" | "error"
+  >("idle");
+  const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null);
+
+  useEffect(() => {
+    if (!ticker) return;
+    let cancelled = false;
+    setStatus("loading");
+    setStatement(null);
+    loadProxyStatements(ticker)
+      .then((payload) => {
+        if (cancelled) return;
+        setYears(payload.proxies);
+        setYear(payload.proxies[0]?.proxyYear ?? null);
+        setStatus(payload.proxies.length > 0 ? "loaded" : "none");
+      })
+      .catch((caught: unknown) => {
+        if (cancelled) return;
+        // No proxy on file answers 404, which is not an error worth a message.
+        const message =
+          caught instanceof Error ? caught.message : String(caught);
+        if (/404|not found|no proxy/i.test(message)) {
+          setYears([]);
+          setStatus("none");
+          return;
+        }
+        setError(message);
+        setStatus("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ticker]);
+
+  useEffect(() => {
+    if (!ticker || year === null) return;
+    let cancelled = false;
+    loadProxyStatement(ticker, year)
+      .then((payload) => {
+        if (!cancelled) setStatement(payload);
+      })
+      .catch((caught: unknown) => {
+        if (!cancelled)
+          setError(caught instanceof Error ? caught.message : String(caught));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ticker, year]);
+
+  useEffect(() => {
+    const scrollBox = scrollRef.current;
+    if (scrollBox) scrollBox.scrollTop = 0;
+  }, [year]);
+
+  const openFiling = useCallback(() => {
+    if (statement?.docUrl) void rendererHost.openExternal(statement.docUrl);
+  }, [rendererHost, statement]);
+
+  const scrollBy = useCallback((delta: number) => {
+    const scrollBox = scrollRef.current;
+    if (!scrollBox?.viewport) return;
+    const max = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height);
+    scrollBox.scrollTop = Math.max(
+      0,
+      Math.min(max, scrollBox.scrollTop + delta),
+    );
+  }, []);
+
+  useShortcut(
+    (event) => {
+      if (isPlainKey(event, "o")) {
+        openFiling();
+      } else if (isPlainKey(event, "j", "down")) {
+        scrollBy(1);
+      } else if (isPlainKey(event, "k", "up")) {
+        scrollBy(-1);
+      }
+    },
+    { enabled: focused, scope: "executives" },
+  );
+
+  usePaneFooter(EXECUTIVES_PANE_ID, () => {
+    const info: PaneFooterSegment[] = [];
+    if (status === "loading")
+      info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
+    if (statement) {
+      info.push({
+        id: "filed",
+        parts: [
+          { text: `filed ${formatFiled(statement.filedAt)}`, tone: "muted" },
+        ],
+      });
+    }
+    const hints = statement
+      ? [{ id: "open", key: "o", label: "pen filing", onPress: openFiling }]
+      : [];
+    return { info, hints };
+  }, [status, statement, openFiling]);
+
+  const figures = useMemo(
+    () => (statement ? figuresOf(statement) : []),
+    [statement],
+  );
+  const bodyWidth = Math.max(12, width - 2);
+  const proseWidth = Math.min(bodyWidth, MAX_PROSE_WIDTH);
+  const valueWidth = Math.min(
+    14,
+    Math.max(4, ...figures.map((figure) => figure.value.length)),
+  );
+
+  if (!ticker)
+    return <EmptyState title="Pick a ticker to see its executives." />;
+  if (status === "loading" && !statement) {
+    return (
+      <Box flexGrow={1} alignItems="center" justifyContent="center">
+        <Spinner label="Loading proxy statement..." />
+      </Box>
+    );
+  }
+  if (status === "none") {
+    return (
+      <EmptyState
+        title={`No proxy statement on file for ${ticker}.`}
+        message="Executive pay comes from the annual DEF 14A. Funds, SPACs and foreign filers do not file one with a compensation table."
+      />
+    );
+  }
+  if (status === "error") {
+    return (
+      <EmptyState
+        title="Could not load executive compensation."
+        message={error ?? ""}
+      />
+    );
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      flexShrink={1}
+      flexBasis={0}
+      minHeight={0}
+      overflow="hidden"
+    >
+      {years.length > 1 && (
+        <Box height={1} flexShrink={0} paddingX={1} overflow="hidden">
+          <Tabs
+            tabs={years.map((entry) => ({
+              label: `${entry.proxyYear} proxy`,
+              value: String(entry.proxyYear),
+            }))}
+            activeValue={year === null ? "" : String(year)}
+            onSelect={(value) => setYear(Number(value))}
+            compact
+            variant="bare"
+            focused={focused}
+          />
+        </Box>
+      )}
+      <ScrollBox
+        ref={scrollRef}
+        flexGrow={1}
+        flexShrink={1}
+        flexBasis={0}
+        minHeight={0}
+        paddingX={1}
+      >
+        {statement ? (
+          <Box
+            flexDirection="column"
+            width={nativePaneChrome ? "100%" : bodyWidth}
+          >
+            <Prose
+              text={[
+                `${statement.proxyYear} proxy statement`,
+                statement.fiscalYearLabel
+                  ? `pay for ${statement.fiscalYearLabel.replace(/^Fiscal/, "fiscal")}`
+                  : null,
+                statement.meetingDate
+                  ? `meeting ${formatFiled(statement.meetingDate)}`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join("  ·  ")}
+              width={proseWidth}
+              color={colors.textDim}
+              nativePaneChrome={nativePaneChrome}
+            />
+            {figures.length > 0 && (
+              <Box flexDirection="column">
+                <SectionHeading title="KEY FIGURES" />
+                {figures.map((figure) => (
+                  <FigureLine
+                    key={`${figure.label}-${figure.value}`}
+                    value={figure.value}
+                    label={figure.label}
+                    note={figure.note}
+                    width={proseWidth}
+                    valueWidth={valueWidth}
+                    nativePaneChrome={nativePaneChrome}
+                  />
+                ))}
+              </Box>
+            )}
+            {statement.namedExecutives.length > 0 && (
+              <Box flexDirection="column">
+                <SectionHeading title="NAMED EXECUTIVE OFFICERS" />
+                <ExecutiveRows
+                  rows={statement.namedExecutives}
+                  width={proseWidth}
+                  nativePaneChrome={nativePaneChrome}
+                />
+              </Box>
+            )}
+            {statement.highlights && (
+              <Box flexDirection="column">
+                <SectionHeading title="WHAT CHANGED" />
+                {statement.highlights.split("\n").map((point) => (
+                  <Prose
+                    key={point}
+                    text={point}
+                    width={proseWidth}
+                    color={colors.text}
+                    nativePaneChrome={nativePaneChrome}
+                    prefix="• "
+                  />
+                ))}
+              </Box>
+            )}
+            <Box height={1} marginTop={1}>
+              <Text fg={colors.textDim}>
+                Read from the DEF 14A and checked against the filing. Equity
+                valued at grant. Press o to open the filing.
+              </Text>
+            </Box>
+          </Box>
+        ) : (
+          <Spinner label="Loading..." />
+        )}
+      </ScrollBox>
+    </Box>
+  );
+}

--- a/src/plugins/builtin/executives/pane.tsx
+++ b/src/plugins/builtin/executives/pane.tsx
@@ -12,7 +12,7 @@ import {
   type PaneFooterSegment,
 } from "../../../components";
 import { useShortcut } from "../../../react/input";
-import { colors } from "../../../theme/colors";
+import { colors, getChartIndicatorColor } from "../../../theme/colors";
 import {
   Box,
   ScrollBox,
@@ -65,6 +65,70 @@ function FigureLine({
       prefix={`${value.padEnd(valueWidth)}  `}
       prefixColor={colors.textBright}
     />
+  );
+}
+
+const PAY_PARTS: Array<{ key: keyof CloudExecutiveRowPayload; label: string }> =
+  [
+    { key: "salary", label: "Salary" },
+    { key: "bonus", label: "Bonus" },
+    { key: "stockAwards", label: "Stock" },
+    { key: "optionAwards", label: "Options" },
+    { key: "nonEquityIncentive", label: "Incentive" },
+    { key: "pensionAndDeferred", label: "Pension" },
+    { key: "allOther", label: "Other" },
+  ];
+
+/**
+ * How the chief executive's pay was made up, as one bar of blocks. Salary
+ * is usually a sliver and equity most of it; seeing that beats the table.
+ * Every piece gets at least one cell so a small one still shows.
+ */
+function PayMixBar({
+  row,
+  width,
+}: {
+  row: CloudExecutiveRowPayload;
+  width: number;
+}) {
+  const parts = PAY_PARTS.map((part, index) => ({
+    ...part,
+    value: (row[part.key] as number | null) ?? 0,
+    color: getChartIndicatorColor(index),
+  })).filter((part) => part.value > 0);
+  const sum = parts.reduce((total, part) => total + part.value, 0);
+  if (sum <= 0) return null;
+  const barWidth = Math.max(10, Math.min(width, 60));
+  let cells = parts.map((part) =>
+    Math.max(1, Math.round((part.value / sum) * barWidth)),
+  );
+  // Rounding and the one-cell floor can overshoot; trim the largest piece.
+  while (cells.reduce((a, b) => a + b, 0) > barWidth) {
+    const largest = cells.indexOf(Math.max(...cells));
+    cells[largest] = cells[largest]! - 1;
+  }
+  cells = cells.map((count) => Math.max(1, count));
+  return (
+    <Box flexDirection="column">
+      <Box height={1} flexDirection="row">
+        {parts.map((part, index) => (
+          <Text key={part.key} fg={part.color}>
+            {"█".repeat(cells[index]!)}
+          </Text>
+        ))}
+      </Box>
+      <Box flexDirection="row" flexWrap="wrap">
+        {parts.map((part) => (
+          <Box key={part.key} flexDirection="row" marginRight={2}>
+            <Text fg={part.color}>■ </Text>
+            <Text fg={colors.textDim}>{part.label} </Text>
+            <Text fg={colors.text}>
+              {Math.round((part.value / sum) * 100)}%
+            </Text>
+          </Box>
+        ))}
+      </Box>
+    </Box>
   );
 }
 
@@ -386,6 +450,14 @@ export function ExecutivesPane({
                     nativePaneChrome={nativePaneChrome}
                   />
                 ))}
+              </Box>
+            )}
+            {statement.ceo && (
+              <Box flexDirection="column">
+                <SectionHeading
+                  title={`HOW ${statement.ceo.name.split(" ").pop()?.toUpperCase() ?? "THE CEO"} WAS PAID`}
+                />
+                <PayMixBar row={statement.ceo} width={proseWidth} />
               </Box>
             )}
             {statement.namedExecutives.length > 0 && (

--- a/src/plugins/builtin/ticker-research-plugin.ts
+++ b/src/plugins/builtin/ticker-research-plugin.ts
@@ -1,5 +1,6 @@
 import { chartComposerModule } from "./chart-composer";
 import { dividendYieldModule } from "./dividend-yield";
+import { executivesModule } from "./executives";
 import { holdersModule } from "./holders";
 import { insiderModule } from "./insider";
 import { optionsModule } from "./options";
@@ -29,5 +30,6 @@ export const tickerResearchPlugin = composeBuiltinPlugin({
     thirteenFModule,
     secModule,
     insiderModule,
+    executivesModule,
   ],
 });

--- a/src/plugins/catalog-browser.ts
+++ b/src/plugins/catalog-browser.ts
@@ -5,6 +5,7 @@ import {
 import type { GloomPlugin } from "../types/plugin";
 import { portfolioAnalyticsModule } from "./builtin/analytics";
 import { earningsCallsModule } from "./builtin/earnings-calls";
+import { executivesModule } from "./builtin/executives";
 import { researchSearchPlugin } from "./builtin/research-search";
 import { alertsPlugin } from "./builtin/alerts";
 import { browserGloomberbCloudPlugin } from "./builtin/cloud/browser";
@@ -71,6 +72,7 @@ const browserTickerResearchPlugin = composeBuiltinPlugin({
     optionsCalculatorModule,
     researchModule,
     earningsCallsModule,
+    executivesModule,
   ],
 });
 

--- a/src/plugins/ownership.ts
+++ b/src/plugins/ownership.ts
@@ -15,6 +15,7 @@ const BUILTIN_PLUGIN_OWNER_ALIASES: Record<string, string> = {
   holders: "ticker-research",
   insider: "ticker-research",
   "dividend-yield": "ticker-research",
+  executives: "ticker-research",
   "short-interest": "ticker-research",
   "kelly-sizer": "portfolio",
   "layout-manager": "application",


### PR DESCRIPTION
Adds an `Exec` research tab (order 35, beside Calls) and an `EXEC <ticker>` pane, reading Gloom Cloud's open `/public/proxies` endpoints. Key figures value first, the named executive officers table (name, title, equity share, total), what changed, a year switcher, and `o` to open the DEF 14A.

Deep link: `term.gloom.sh/?ticker=PAYX&tab=executives`. The proxy pages on gloom.sh point here.

No plan gate: the data is open on the API and on the site.