### PR TITLE
Add a Risks tab: the 10-K risk factors and what changed

### DIFF
--- a/src/api-client/askg.test.ts
+++ b/src/api-client/askg.test.ts
@@ -27,7 +27,7 @@ describe("createSseDecoder", () => {
     const decoder = createSseDecoder();
     expect(decoder.push("id: 1\nevent: text-delta\nda")).toEqual([]);
     expect(decoder.push('ta: {"a":1}\n')).toEqual([]);
-    const frames = decoder.push("\n: keep-alive\n\nid: 2\ndata: {\"b\":2}\n\n");
+    const frames = decoder.push('\n: keep-alive\n\nid: 2\ndata: {"b":2}\n\n');
     expect(frames).toEqual([
       { id: "1", event: "text-delta", data: '{"a":1}' },
       { id: "2", data: '{"b":2}' },
@@ -36,7 +36,9 @@ describe("createSseDecoder", () => {
 
   test("keeps multi-line data and \\r\\n line endings", () => {
     const decoder = createSseDecoder();
-    expect(decoder.push("data: one\r\ndata: two\r\n\r\n")).toEqual([{ data: "one\ntwo" }]);
+    expect(decoder.push("data: one\r\ndata: two\r\n\r\n")).toEqual([
+      { data: "one\ntwo" },
+    ]);
   });
 });
 
@@ -52,7 +54,11 @@ describe("readASKGEventStream", () => {
       { onEvent: (event) => events.push(event) },
     );
 
-    expect(events.map((event) => event.type)).toEqual(["text-delta", "text-delta", "done"]);
+    expect(events.map((event) => event.type)).toEqual([
+      "text-delta",
+      "text-delta",
+      "done",
+    ]);
     expect(outcome).toEqual({ lastSeq: 3, done: "complete" });
   });
 
@@ -78,7 +84,16 @@ describe("readASKGEventStream", () => {
   test("ignores frames that are not protocol events", async () => {
     const events: ASKGSseEvent[] = [];
     await readASKGEventStream(
-      streamOf(["data: not json\n\n", 'data: {"hello":true}\n\n', frame({ seq: 4, type: "tool-result-ack", turnId: "t1", toolCallId: "c1" })]),
+      streamOf([
+        "data: not json\n\n",
+        'data: {"hello":true}\n\n',
+        frame({
+          seq: 4,
+          type: "tool-result-ack",
+          turnId: "t1",
+          toolCallId: "c1",
+        }),
+      ]),
       { onEvent: (event) => events.push(event) },
     );
     expect(events).toHaveLength(1);
@@ -86,10 +101,12 @@ describe("readASKGEventStream", () => {
   });
 });
 
-function transportFor(open: (init: RequestInit | undefined) => Promise<Response>) {
+function transportFor(
+  open: (init: RequestInit | undefined) => Promise<Response>,
+) {
   const requests: Array<{ path: string; init?: RequestInit }> = [];
   const api = new CloudASKGApi({
-    request: async <T,>(path: string, init?: RequestInit) => {
+    request: async <T>(path: string, init?: RequestInit) => {
       requests.push({ path, init });
       return undefined as T;
     },
@@ -108,37 +125,81 @@ describe("CloudASKGApi.streamTurn", () => {
     let attempt = 0;
     const { api, requests } = transportFor(async () => {
       attempt += 1;
-      return new Response(streamOf(attempt === 1
-        ? [frame({ seq: 1, type: "text-delta", turnId: "t1", delta: "half " })]
-        : [
-          frame({ seq: 1, type: "text-delta", turnId: "t1", delta: "half " }),
-          frame({ seq: 2, type: "text-delta", turnId: "t1", delta: "answer" }),
-          frame({ seq: 3, type: "done", turnId: "t1", reason: "complete" }),
-        ]));
+      return new Response(
+        streamOf(
+          attempt === 1
+            ? [
+                frame({
+                  seq: 1,
+                  type: "text-delta",
+                  turnId: "t1",
+                  delta: "half ",
+                }),
+              ]
+            : [
+                frame({
+                  seq: 1,
+                  type: "text-delta",
+                  turnId: "t1",
+                  delta: "half ",
+                }),
+                frame({
+                  seq: 2,
+                  type: "text-delta",
+                  turnId: "t1",
+                  delta: "answer",
+                }),
+                frame({
+                  seq: 3,
+                  type: "done",
+                  turnId: "t1",
+                  reason: "complete",
+                }),
+              ],
+        ),
+      );
     });
 
     const deltas: string[] = [];
-    const reason = await api.streamTurn("s1", { turnId: "t1", input: "hi" }, {
-      onEvent: (event) => {
-        if (event.type === "text-delta") deltas.push(event.delta);
+    const reason = await api.streamTurn(
+      "s1",
+      { turnId: "t1", input: "hi" },
+      {
+        onEvent: (event) => {
+          if (event.type === "text-delta") deltas.push(event.delta);
+        },
       },
-    });
+    );
 
     expect(reason).toBe("complete");
     // The replayed first event is dropped, so the answer is not doubled.
     expect(deltas.join("")).toBe("half answer");
-    expect(new Headers(requests[0]?.init?.headers).get("Last-Event-ID")).toBeNull();
-    expect(new Headers(requests[1]?.init?.headers).get("Last-Event-ID")).toBe("1");
+    expect(
+      new Headers(requests[0]?.init?.headers).get("Last-Event-ID"),
+    ).toBeNull();
+    expect(new Headers(requests[1]?.init?.headers).get("Last-Event-ID")).toBe(
+      "1",
+    );
     // The same turn id re-attaches instead of asking again.
     expect(JSON.parse(String(requests[1]?.init?.body)).turnId).toBe("t1");
   });
 
   test("gives up with a retryable network error when the stream keeps dropping", async () => {
-    const { api } = transportFor(async () => (
-      new Response(streamOf([frame({ seq: 1, type: "text-delta", turnId: "t1", delta: "x" })]))
-    ));
-    await expect(api.streamTurn("s1", { turnId: "t1", input: "hi" }, { onEvent: () => {} }))
-      .rejects.toMatchObject({ code: "network", retryable: true });
+    const { api } = transportFor(
+      async () =>
+        new Response(
+          streamOf([
+            frame({ seq: 1, type: "text-delta", turnId: "t1", delta: "x" }),
+          ]),
+        ),
+    );
+    await expect(
+      api.streamTurn(
+        "s1",
+        { turnId: "t1", input: "hi" },
+        { onEvent: () => {} },
+      ),
+    ).rejects.toMatchObject({ code: "network", retryable: true });
   });
 });
 
@@ -154,7 +215,9 @@ describe("CloudASKGApi.postToolResult", () => {
   test("sends the tool call id as the idempotency key", async () => {
     const { api, requests } = transportFor(async () => new Response(""));
     expect(await api.postToolResult("s1", payload)).toBe("accepted");
-    expect(new Headers(requests[0]?.init?.headers).get("Idempotency-Key")).toBe("call-1");
+    expect(new Headers(requests[0]?.init?.headers).get("Idempotency-Key")).toBe(
+      "call-1",
+    );
   });
 
   test("reports a closed result window instead of failing the turn", async () => {
@@ -171,16 +234,23 @@ describe("CloudASKGApi.postToolResult", () => {
 
 describe("classifyASKGRequestError", () => {
   test("maps the documented statuses onto handled codes", () => {
-    expect(classifyASKGRequestError(new ApiRequestError("pro required", 402)).code)
-      .toBe("tier_required");
-    expect(classifyASKGRequestError(new ApiRequestError("old protocol", 426)).code)
-      .toBe("protocol");
-    expect(classifyASKGRequestError(new ApiRequestError("disabled", 503)).code)
-      .toBe("model_unavailable");
-    const limited = classifyASKGRequestError(new ApiRequestError("too many", 429, 42_000));
+    expect(
+      classifyASKGRequestError(new ApiRequestError("pro required", 402)).code,
+    ).toBe("tier_required");
+    expect(
+      classifyASKGRequestError(new ApiRequestError("old protocol", 426)).code,
+    ).toBe("protocol");
+    expect(
+      classifyASKGRequestError(new ApiRequestError("disabled", 503)).code,
+    ).toBe("model_unavailable");
+    const limited = classifyASKGRequestError(
+      new ApiRequestError("too many", 429, 42_000),
+    );
     expect(limited.code).toBe("rate_limited");
     expect(limited.retryAfterMs).toBe(42_000);
-    expect(classifyASKGRequestError(new ApiRequestError("daily cap reached", 429)).code)
-      .toBe("daily_turn_cap");
+    expect(
+      classifyASKGRequestError(new ApiRequestError("daily cap reached", 429))
+        .code,
+    ).toBe("daily_turn_cap");
   });
 });

--- a/src/api-client/askg.ts
+++ b/src/api-client/askg.ts
@@ -25,17 +25,17 @@ export type ASKGClientErrorCode =
  * what the user sees: the turn already continued with a synthetic timeout.
  */
 export type ASKGToolResultOutcome =
-  | "accepted"
-  | "unknown-call"
-  | "too-late"
-  | "too-large"
-  | "already-recorded";
+  "accepted" | "unknown-call" | "too-late" | "too-large" | "already-recorded";
 
 export class ASKGTransportError extends Error {
   constructor(
     readonly code: ASKGClientErrorCode,
     message: string,
-    readonly options: { retryable?: boolean; retryAfterMs?: number; status?: number } = {},
+    readonly options: {
+      retryable?: boolean;
+      retryAfterMs?: number;
+      status?: number;
+    } = {},
   ) {
     super(message);
     this.name = "ASKGTransportError";
@@ -102,7 +102,8 @@ export function createSseDecoder(): {
   let event: string | undefined;
 
   const takeFrame = (): SseFrame | null => {
-    if (dataLines.length === 0 && event === undefined && id === undefined) return null;
+    if (dataLines.length === 0 && event === undefined && id === undefined)
+      return null;
     const frame: SseFrame = {
       data: dataLines.join("\n"),
       ...(id !== undefined ? { id } : {}),
@@ -161,7 +162,9 @@ export function createSseDecoder(): {
 function isAskgEvent(value: unknown): value is ASKGSseEvent {
   if (value == null || typeof value !== "object") return false;
   const candidate = value as { type?: unknown; seq?: unknown };
-  return typeof candidate.type === "string" && typeof candidate.seq === "number";
+  return (
+    typeof candidate.type === "string" && typeof candidate.seq === "number"
+  );
 }
 
 /** Parses one frame payload, ignoring keep-alives and unknown shapes. */
@@ -242,12 +245,17 @@ const MAX_STREAM_RESUMES = 2;
 const RESUME_BACKOFF_MS = 250;
 
 function isAbortError(error: unknown): boolean {
-  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
+  return (
+    error instanceof Error &&
+    (error.name === "AbortError" || error.name === "TimeoutError")
+  );
 }
 
 /** A 429 covers both the per-minute limit and the daily cap. */
 function rateLimitCode(message: string): "rate_limited" | "daily_turn_cap" {
-  return /\bdaily\b|\bday\b|daily_turn_cap/i.test(message) ? "daily_turn_cap" : "rate_limited";
+  return /\bdaily\b|\bday\b|daily_turn_cap/i.test(message)
+    ? "daily_turn_cap"
+    : "rate_limited";
 }
 
 /** Maps an HTTP failure onto the same codes the stream itself reports. */
@@ -261,9 +269,13 @@ export function classifyASKGRequestError(error: unknown): ASKGTransportError {
       );
     }
     if (error.status === 401 || error.status === 403) {
-      return new ASKGTransportError("unauthorized", "Sign in to Gloom Cloud to ask Gloom.", {
-        status: error.status,
-      });
+      return new ASKGTransportError(
+        "unauthorized",
+        "Sign in to Gloom Cloud to ask Gloom.",
+        {
+          status: error.status,
+        },
+      );
     }
     if (error.status === 429) {
       return new ASKGTransportError(
@@ -271,7 +283,9 @@ export function classifyASKGRequestError(error: unknown): ASKGTransportError {
         error.message || "Too many requests.",
         {
           retryable: true,
-          ...(error.retryAfterMs !== undefined ? { retryAfterMs: error.retryAfterMs } : {}),
+          ...(error.retryAfterMs !== undefined
+            ? { retryAfterMs: error.retryAfterMs }
+            : {}),
           status: error.status,
         },
       );
@@ -291,21 +305,31 @@ export function classifyASKGRequestError(error: unknown): ASKGTransportError {
       );
     }
     if (error.status === 503) {
-      return new ASKGTransportError("model_unavailable", error.message || "Ask Gloom is unavailable.", {
-        retryable: true,
-        status: error.status,
-      });
+      return new ASKGTransportError(
+        "model_unavailable",
+        error.message || "Ask Gloom is unavailable.",
+        {
+          retryable: true,
+          status: error.status,
+        },
+      );
     }
-    return new ASKGTransportError("internal", error.message || "Ask Gloom failed.", {
-      status: error.status,
-    });
+    return new ASKGTransportError(
+      "internal",
+      error.message || "Ask Gloom failed.",
+      {
+        status: error.status,
+      },
+    );
   }
   if (isAbortError(error)) {
     return new ASKGTransportError("network", "Ask Gloom was cancelled.");
   }
   return new ASKGTransportError(
     "network",
-    error instanceof Error ? error.message : "Ask Gloom could not reach the server.",
+    error instanceof Error
+      ? error.message
+      : "Ask Gloom could not reach the server.",
     { retryable: true },
   );
 }
@@ -355,11 +379,14 @@ export class CloudASKGApi implements ASKGTransport {
     options: { signal?: AbortSignal } = {},
   ): Promise<ASKGSessionStartResponse> {
     try {
-      const response = await this.options.request<ASKGSessionStartResponse>("/askg/session", {
-        method: "POST",
-        body: JSON.stringify(request),
-        signal: options.signal,
-      });
+      const response = await this.options.request<ASKGSessionStartResponse>(
+        "/askg/session",
+        {
+          method: "POST",
+          body: JSON.stringify(request),
+          signal: options.signal,
+        },
+      );
       if (response?.protocolVersion !== ASKG_PROTOCOL_VERSION) {
         throw new ASKGTransportError(
           "protocol",
@@ -398,19 +425,23 @@ export class CloudASKGApi implements ASKGTransport {
           `/askg/session/${encodeURIComponent(sessionId)}/turn`,
           {
             method: "POST",
-            body: JSON.stringify({ protocolVersion: ASKG_PROTOCOL_VERSION, ...request }),
+            body: JSON.stringify({
+              protocolVersion: ASKG_PROTOCOL_VERSION,
+              ...request,
+            }),
             signal: options.signal,
-            headers: lastSeq > 0 ? { "Last-Event-ID": String(lastSeq) } : undefined,
+            headers:
+              lastSeq > 0 ? { "Last-Event-ID": String(lastSeq) } : undefined,
           },
         );
       } catch (error) {
         const transportError = classifyASKGRequestError(error);
         // Only a dropped connection is worth reopening; a refusal is final.
         if (
-          transportError.code !== "network"
-          || attempt >= MAX_STREAM_RESUMES
-          || options.signal?.aborted
-          || lastSeq === 0
+          transportError.code !== "network" ||
+          attempt >= MAX_STREAM_RESUMES ||
+          options.signal?.aborted ||
+          lastSeq === 0
         ) {
           throw transportError;
         }

--- a/src/api-client/auth.ts
+++ b/src/api-client/auth.ts
@@ -37,32 +37,47 @@ export class CloudAuthApi {
     }
     this.options.setCurrentUser({
       id: user.id,
-      name: typeof user.name === "string" && user.name.length > 0
-        ? user.name
-        : user.username ?? "User",
+      name:
+        typeof user.name === "string" && user.name.length > 0
+          ? user.name
+          : (user.username ?? "User"),
       email: typeof user.email === "string" ? user.email : "",
       username: typeof user.username === "string" ? user.username : null,
       emailVerified: user.emailVerified === true,
       image: typeof user.image === "string" ? user.image : null,
       plan: user.plan,
-      trialEndsAt: typeof user.trialEndsAt === "string" ? user.trialEndsAt : null,
+      trialEndsAt:
+        typeof user.trialEndsAt === "string" ? user.trialEndsAt : null,
       effectivePlan: user.effectivePlan,
       syncEnabled: user.syncEnabled === false ? false : true,
       weeklyRoundupEnabled: user.weeklyRoundupEnabled === false ? false : true,
-      positionAlertsEnabled: user.positionAlertsEnabled === false ? false : true,
-      chatEmailNotificationsEnabled: user.chatEmailNotificationsEnabled === false ? false : true,
+      positionAlertsEnabled:
+        user.positionAlertsEnabled === false ? false : true,
+      chatEmailNotificationsEnabled:
+        user.chatEmailNotificationsEnabled === false ? false : true,
       lastSyncAt: typeof user.lastSyncAt === "string" ? user.lastSyncAt : null,
-      lastRoundupEmailAt: typeof user.lastRoundupEmailAt === "string" ? user.lastRoundupEmailAt : null,
+      lastRoundupEmailAt:
+        typeof user.lastRoundupEmailAt === "string"
+          ? user.lastRoundupEmailAt
+          : null,
       createdAt: typeof user.createdAt === "string" ? user.createdAt : "",
       updatedAt: typeof user.updatedAt === "string" ? user.updatedAt : "",
     });
   }
 
-  async signUp(email: string, username: string, name: string, password: string): Promise<AuthUser> {
-    const result = await this.options.request<{ user: AuthUser }>("/auth/sign-up/email", {
-      method: "POST",
-      body: JSON.stringify({ email, username, name, password }),
-    });
+  async signUp(
+    email: string,
+    username: string,
+    name: string,
+    password: string,
+  ): Promise<AuthUser> {
+    const result = await this.options.request<{ user: AuthUser }>(
+      "/auth/sign-up/email",
+      {
+        method: "POST",
+        body: JSON.stringify({ email, username, name, password }),
+      },
+    );
     this.options.requireCapturedSession(
       "Account created, but Gloomberb could not save the login session. Please try logging in again.",
     );
@@ -71,10 +86,13 @@ export class CloudAuthApi {
   }
 
   async signIn(email: string, password: string): Promise<AuthUser> {
-    const result = await this.options.request<{ user: AuthUser }>("/auth/sign-in/email", {
-      method: "POST",
-      body: JSON.stringify({ email, password }),
-    });
+    const result = await this.options.request<{ user: AuthUser }>(
+      "/auth/sign-in/email",
+      {
+        method: "POST",
+        body: JSON.stringify({ email, password }),
+      },
+    );
     this.options.requireCapturedSession(
       "Logged in, but Gloomberb could not save the login session. Please try again.",
     );
@@ -83,7 +101,10 @@ export class CloudAuthApi {
   }
 
   /** Starts a QR / device sign-in; the mobile app approves the returned user code. */
-  async startDeviceSignIn(body: { clientName?: string; clientPlatform?: string }): Promise<DeviceAuthStartResponse> {
+  async startDeviceSignIn(body: {
+    clientName?: string;
+    clientPlatform?: string;
+  }): Promise<DeviceAuthStartResponse> {
     return this.options.request<DeviceAuthStartResponse>("/auth/device/start", {
       method: "POST",
       body: JSON.stringify(body),
@@ -118,18 +139,25 @@ export class CloudAuthApi {
     // credential that exists now instead of trusting an answer about one that
     // no longer does.
     const credential = this.options.getSessionToken();
-    const credentialChanged = () => this.options.getSessionToken() !== credential;
+    const credentialChanged = () =>
+      this.options.getSessionToken() !== credential;
     try {
-      const result = await this.options.request<{ user: AuthUser }>("/auth/get-session", {
-        method: "GET",
-      });
+      const result = await this.options.request<{ user: AuthUser }>(
+        "/auth/get-session",
+        {
+          method: "GET",
+        },
+      );
       if (credentialChanged()) return this.getSession();
       const user = result?.user ?? null;
       this.options.setCurrentUser(user);
       return user;
     } catch (error) {
       if (credentialChanged()) return this.getSession();
-      if (error instanceof ApiRequestError && isHardSessionInvalidMessage(error.message)) {
+      if (
+        error instanceof ApiRequestError &&
+        isHardSessionInvalidMessage(error.message)
+      ) {
         this.options.setSessionToken(null);
         return null;
       }
@@ -150,10 +178,16 @@ export class CloudAuthApi {
   }
 
   async sendVerification(): Promise<CloudVerificationResponse> {
-    return this.options.request<CloudVerificationResponse>("/cloud/auth/send-verification", {
-      method: "POST",
-      body: JSON.stringify({ returnTo: getCurrentPluginTarget() === "web" ? location.href : undefined }),
-    });
+    return this.options.request<CloudVerificationResponse>(
+      "/cloud/auth/send-verification",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          returnTo:
+            getCurrentPluginTarget() === "web" ? location.href : undefined,
+        }),
+      },
+    );
   }
 
   /**
@@ -161,16 +195,22 @@ export class CloudAuthApi {
    * The server deliberately returns an opaque one-time URL, never the session cookie.
    */
   async createBrowserHandoff(): Promise<CloudBrowserHandoffResponse> {
-    return this.options.request<CloudBrowserHandoffResponse>("/cloud/auth/browser-handoff", {
-      method: "POST",
-      body: JSON.stringify({}),
-    });
+    return this.options.request<CloudBrowserHandoffResponse>(
+      "/cloud/auth/browser-handoff",
+      {
+        method: "POST",
+        body: JSON.stringify({}),
+      },
+    );
   }
 
   async getAccountProfile(): Promise<AccountProfile> {
-    const result = await this.options.request<{ profile: AccountProfile }>("/account/profile", {
-      method: "GET",
-    });
+    const result = await this.options.request<{ profile: AccountProfile }>(
+      "/account/profile",
+      {
+        method: "GET",
+      },
+    );
     return result.profile;
   }
 
@@ -186,17 +226,25 @@ export class CloudAuthApi {
   }
 
   async getBuildoutToken(): Promise<BuildoutTokenResponse> {
-    return this.options.request<BuildoutTokenResponse>("/account/buildout/token", {
-      method: "POST",
-      body: JSON.stringify({}),
-    });
+    return this.options.request<BuildoutTokenResponse>(
+      "/account/buildout/token",
+      {
+        method: "POST",
+        body: JSON.stringify({}),
+      },
+    );
   }
 
-  async updateAccountProfile(update: AccountProfileUpdate): Promise<AccountProfile> {
-    const result = await this.options.request<{ profile: AccountProfile }>("/account/profile", {
-      method: "PATCH",
-      body: JSON.stringify(update),
-    });
+  async updateAccountProfile(
+    update: AccountProfileUpdate,
+  ): Promise<AccountProfile> {
+    const result = await this.options.request<{ profile: AccountProfile }>(
+      "/account/profile",
+      {
+        method: "PATCH",
+        body: JSON.stringify(update),
+      },
+    );
     const profile = result.profile;
     if (this.options.getCurrentUser()?.id === profile.id) {
       this.options.updateCurrentUser((currentUser) => ({
@@ -225,7 +273,10 @@ export class CloudAuthApi {
     return profile;
   }
 
-  async changePassword(currentPassword: string, newPassword: string): Promise<void> {
+  async changePassword(
+    currentPassword: string,
+    newPassword: string,
+  ): Promise<void> {
     await this.options.request("/auth/change-password", {
       method: "POST",
       body: JSON.stringify({

--- a/src/api-client/chat.ts
+++ b/src/api-client/chat.ts
@@ -26,7 +26,8 @@ export class CloudChatApi {
   constructor(private readonly options: CloudChatApiOptions) {}
 
   async getChannels(): Promise<ChatChannel[]> {
-    const channels = await this.options.request<ChatChannel[]>("/chat/channels");
+    const channels =
+      await this.options.request<ChatChannel[]>("/chat/channels");
     return channels.map((channel) => normalizeChatChannel(channel));
   }
 
@@ -43,20 +44,31 @@ export class CloudChatApi {
     channelId: string,
     body: { notificationsEnabled?: boolean; readThroughMessageId?: string },
   ): Promise<ChatChannelState> {
-    return this.options.request<ChatChannelState>(`/chat/channels/${channelId}/state`, {
-      method: "PATCH",
-      body: JSON.stringify(body),
-    });
+    return this.options.request<ChatChannelState>(
+      `/chat/channels/${channelId}/state`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      },
+    );
   }
 
-  async markNotificationsDelivered(notificationIds: string[]): Promise<{ delivered: number }> {
-    return this.options.request<{ delivered: number }>("/chat/notifications/delivered", {
-      method: "POST",
-      body: JSON.stringify({ notificationIds }),
-    });
+  async markNotificationsDelivered(
+    notificationIds: string[],
+  ): Promise<{ delivered: number }> {
+    return this.options.request<{ delivered: number }>(
+      "/chat/notifications/delivered",
+      {
+        method: "POST",
+        body: JSON.stringify({ notificationIds }),
+      },
+    );
   }
 
-  async openDirectChannel(target: { userId?: string; username?: string }): Promise<ChatChannel> {
+  async openDirectChannel(target: {
+    userId?: string;
+    username?: string;
+  }): Promise<ChatChannel> {
     const channel = await this.options.request<ChatChannel>("/chat/direct", {
       method: "POST",
       body: JSON.stringify(target),
@@ -64,7 +76,11 @@ export class CloudChatApi {
     return normalizeChatChannel(channel, "direct");
   }
 
-  async openGroupChannel(body: { userIds?: string[]; usernames?: string[]; name?: string }): Promise<ChatChannel> {
+  async openGroupChannel(body: {
+    userIds?: string[];
+    usernames?: string[];
+    name?: string;
+  }): Promise<ChatChannel> {
     const channel = await this.options.request<ChatChannel>("/chat/groups", {
       method: "POST",
       body: JSON.stringify(body),
@@ -81,23 +97,40 @@ export class CloudChatApi {
     if (opts?.before) params.set("before", opts.before);
     if (opts?.limit) params.set("limit", String(opts.limit));
     const qs = params.toString();
-    const messages = await this.options.request<ChatMessage[]>(`/chat/channels/${channelId}/messages${qs ? `?${qs}` : ""}`);
+    const messages = await this.options.request<ChatMessage[]>(
+      `/chat/channels/${channelId}/messages${qs ? `?${qs}` : ""}`,
+    );
     return normalizeChatMessages(messages);
   }
 
-  async sendMessage(channelId: string, content: string, replyToId?: string, clientMessageId?: string): Promise<ChatMessage> {
-    const message = await this.options.request<ChatMessage>(`/chat/channels/${channelId}/messages`, {
-      method: "POST",
-      body: JSON.stringify({ content, replyToId, clientMessageId }),
-    });
+  async sendMessage(
+    channelId: string,
+    content: string,
+    replyToId?: string,
+    clientMessageId?: string,
+  ): Promise<ChatMessage> {
+    const message = await this.options.request<ChatMessage>(
+      `/chat/channels/${channelId}/messages`,
+      {
+        method: "POST",
+        body: JSON.stringify({ content, replyToId, clientMessageId }),
+      },
+    );
     return normalizeChatMessage(message);
   }
 
-  async editMessage(channelId: string, messageId: string, content: string): Promise<ChatMessage> {
-    const message = await this.options.request<ChatMessage>(`/chat/channels/${channelId}/messages/${messageId}`, {
-      method: "PATCH",
-      body: JSON.stringify({ content }),
-    });
+  async editMessage(
+    channelId: string,
+    messageId: string,
+    content: string,
+  ): Promise<ChatMessage> {
+    const message = await this.options.request<ChatMessage>(
+      `/chat/channels/${channelId}/messages/${messageId}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify({ content }),
+      },
+    );
     return normalizeChatMessage(message);
   }
 
@@ -110,7 +143,8 @@ export class CloudChatApi {
       channelId,
       onMessage,
       onError,
-      (content, replyToId, clientMessageId) => this.sendMessage(channelId, content, replyToId, clientMessageId),
+      (content, replyToId, clientMessageId) =>
+        this.sendMessage(channelId, content, replyToId, clientMessageId),
     );
   }
 

--- a/src/api-client/data.ts
+++ b/src/api-client/data.ts
@@ -12,6 +12,8 @@ import {
   cloudEarningsCallsPath,
   cloudEarningsTranscriptPath,
   publicProxyStatementPath,
+  publicRiskReportPath,
+  publicRiskReportsPath,
   publicProxyStatementsPath,
   cloudExchangeRatePath,
   cloudSec13FPath,
@@ -55,6 +57,8 @@ import type {
   CloudEarningsTranscriptPayload,
   CloudProxyStatementListPayload,
   CloudProxyStatementPayload,
+  CloudRiskReportListPayload,
+  CloudRiskReportPayload,
   CloudCorporateActionsPayload,
   CloudEconEventPayload,
   CloudEquityDiagnosticMode,
@@ -357,6 +361,21 @@ export class CloudDataApi {
   ): Promise<CloudProxyStatementPayload> {
     return this.request<CloudProxyStatementPayload>(
       publicProxyStatementPath(ticker, year),
+    );
+  }
+
+  async getRiskReports(ticker: string): Promise<CloudRiskReportListPayload> {
+    return this.request<CloudRiskReportListPayload>(
+      publicRiskReportsPath(ticker),
+    );
+  }
+
+  async getRiskReport(
+    ticker: string,
+    year: number,
+  ): Promise<CloudRiskReportPayload> {
+    return this.request<CloudRiskReportPayload>(
+      publicRiskReportPath(ticker, year),
     );
   }
 

--- a/src/api-client/errors.ts
+++ b/src/api-client/errors.ts
@@ -17,7 +17,10 @@ export class ApiRequestError extends Error {
 }
 
 /** Reads `Retry-After` as milliseconds, accepting seconds or an HTTP date. */
-export function parseRetryAfterMs(header: string | null, now = Date.now()): number | undefined {
+export function parseRetryAfterMs(
+  header: string | null,
+  now = Date.now(),
+): number | undefined {
   if (!header) return undefined;
   const trimmed = header.trim();
   if (/^\d+$/.test(trimmed)) return Number(trimmed) * 1000;
@@ -29,8 +32,15 @@ export function parseRetryAfterMs(header: string | null, now = Date.now()): numb
 export function parseApiErrorMessage(body: string): string {
   try {
     const parsed = JSON.parse(body) as Record<string, unknown>;
-    const parts = [parsed.message, parsed.error, parsed.code, parsed.reason]
-      .filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+    const parts = [
+      parsed.message,
+      parsed.error,
+      parsed.code,
+      parsed.reason,
+    ].filter(
+      (value): value is string =>
+        typeof value === "string" && value.trim().length > 0,
+    );
     return parts.join(" ") || body;
   } catch {
     return body;
@@ -39,5 +49,7 @@ export function parseApiErrorMessage(body: string): string {
 
 export function isHardSessionInvalidMessage(message: string): boolean {
   const normalized = message.replace(/[_-]+/g, " ");
-  return HARD_SESSION_INVALID_PATTERNS.some((pattern) => pattern.test(normalized));
+  return HARD_SESSION_INVALID_PATTERNS.some((pattern) =>
+    pattern.test(normalized),
+  );
 }

--- a/src/api-client/index.test.ts
+++ b/src/api-client/index.test.ts
@@ -19,7 +19,10 @@ const verifiedUser: AuthUser = {
   updatedAt: "2026-03-30T00:00:00.000Z",
 };
 
-function createResponse(body: unknown, options: { status?: number; cookies?: string[] } = {}): Response {
+function createResponse(
+  body: unknown,
+  options: { status?: number; cookies?: string[] } = {},
+): Response {
   const headers = {
     getSetCookie: () => options.cookies ?? [],
     get: (name: string) => {
@@ -36,7 +39,12 @@ function createResponse(body: unknown, options: { status?: number; cookies?: str
   } as Response;
 }
 
-function mockFetch(handler: (input: Request | string | URL, init?: RequestInit) => Response | Promise<Response>): typeof fetch {
+function mockFetch(
+  handler: (
+    input: Request | string | URL,
+    init?: RequestInit,
+  ) => Response | Promise<Response>,
+): typeof fetch {
   return handler as unknown as typeof fetch;
 }
 
@@ -114,12 +122,17 @@ afterEach(() => {
 describe("apiClient layout marketplace", () => {
   test("lists and publishes validated layouts through authenticated transport", async () => {
     const config = createDefaultConfig("/tmp/api-layout-marketplace-test");
-    const panes = new Map(config.layout.instances.map((instance) => [instance.paneId, {
-      id: instance.paneId,
-      name: instance.paneId,
-      component: () => null,
-      defaultPosition: "right" as const,
-    } satisfies PaneDef]));
+    const panes = new Map(
+      config.layout.instances.map((instance) => [
+        instance.paneId,
+        {
+          id: instance.paneId,
+          name: instance.paneId,
+          component: () => null,
+          defaultPosition: "right" as const,
+        } satisfies PaneDef,
+      ]),
+    );
     const payload = publishableMarketplaceLayout(config.layout, {}, panes);
     const entry = {
       id: "0123456789abcdef0123456789abcdef",
@@ -134,40 +147,60 @@ describe("apiClient layout marketplace", () => {
       calls.push({
         url,
         method: init?.method ?? "GET",
-        ...(typeof init?.body === "string" ? { body: JSON.parse(init.body) } : {}),
+        ...(typeof init?.body === "string"
+          ? { body: JSON.parse(init.body) }
+          : {}),
       });
       const path = new URL(url).pathname;
-      return createResponse(path === `/layouts/${entry.id}` || init?.method === "POST"
-        ? entry
-        : { items: [entry] });
+      return createResponse(
+        path === `/layouts/${entry.id}` || init?.method === "POST"
+          ? entry
+          : { items: [entry] },
+      );
     });
 
     await expect(apiClient.listMarketplaceLayouts()).resolves.toEqual([entry]);
-    await expect(apiClient.getMarketplaceLayout(entry.id)).resolves.toEqual(entry);
-    await expect(apiClient.publishMarketplaceLayout(entry.name, payload)).resolves.toEqual(entry);
+    await expect(apiClient.getMarketplaceLayout(entry.id)).resolves.toEqual(
+      entry,
+    );
+    await expect(
+      apiClient.publishMarketplaceLayout(entry.name, payload),
+    ).resolves.toEqual(entry);
 
-    expect(calls.map((call) => [new URL(call.url).pathname, call.method])).toEqual([
+    expect(
+      calls.map((call) => [new URL(call.url).pathname, call.method]),
+    ).toEqual([
       ["/layouts", "GET"],
       [`/layouts/${entry.id}`, "GET"],
       ["/layouts", "POST"],
     ]);
-    expect(calls[2]?.body).toMatchObject({ name: "Research Desk", schemaVersion: 2, paneState: {} });
+    expect(calls[2]?.body).toMatchObject({
+      name: "Research Desk",
+      schemaVersion: 2,
+      paneState: {},
+    });
   });
 });
 
 describe("apiClient auth cookies", () => {
   test("accepts a browser-managed api.gloom.sh cookie without exposing its value", async () => {
     apiClient.setCookieSessionMode(true);
-    setCloudApiFetchTransport(mockFetch(() => createResponse({ user: verifiedUser })));
+    setCloudApiFetchTransport(
+      mockFetch(() => createResponse({ user: verifiedUser })),
+    );
 
-    await expect(apiClient.signIn("test@example.com", "password")).resolves.toEqual(verifiedUser);
+    await expect(
+      apiClient.signIn("test@example.com", "password"),
+    ).resolves.toEqual(verifiedUser);
     expect(apiClient.getSessionToken()).toBeNull();
     expect(apiClient.isVerified()).toBe(true);
   });
 
   test("reports signed-in from the restored user when the cookie hides the raw token", async () => {
     apiClient.setCookieSessionMode(true);
-    setCloudApiFetchTransport(mockFetch(() => createResponse({ user: verifiedUser })));
+    setCloudApiFetchTransport(
+      mockFetch(() => createResponse({ user: verifiedUser })),
+    );
 
     expect(apiClient.isSignedIn()).toBe(false);
     await apiClient.signIn("test@example.com", "password");
@@ -181,7 +214,9 @@ describe("apiClient auth cookies", () => {
     let finishRequest!: () => void;
     setCloudApiFetchTransport(async () => {
       requests += 1;
-      await new Promise<void>((resolve) => { finishRequest = resolve; });
+      await new Promise<void>((resolve) => {
+        finishRequest = resolve;
+      });
       return createResponse({ user: null });
     });
 
@@ -211,7 +246,9 @@ describe("apiClient auth cookies", () => {
       const cookie = new Headers(init?.headers).get("cookie");
       seen.push(cookie);
       if (seen.length === 1) {
-        await new Promise<void>((resolve) => { releaseFirst = resolve; });
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
         return createResponse({ user: null });
       }
       return createResponse({ user: verifiedUser });
@@ -239,19 +276,25 @@ describe("apiClient auth cookies", () => {
   test("captures secure session cookies after login and reuses them on session refresh", async () => {
     const seenCookies: Array<string | null> = [];
 
-    globalThis.fetch = mockFetch(async (_input: Request | string | URL, init?: RequestInit) => {
-      const headers = new Headers(init?.headers);
-      seenCookies.push(headers.get("Cookie"));
+    globalThis.fetch = mockFetch(
+      async (_input: Request | string | URL, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        seenCookies.push(headers.get("Cookie"));
 
-      if (seenCookies.length === 1) {
-        return createResponse(
-          { token: "ws-token", user: verifiedUser },
-          { cookies: ["__Secure-gloomberb.session_token=signed-token.value; Path=/; HttpOnly; Secure; SameSite=Lax"] },
-        );
-      }
+        if (seenCookies.length === 1) {
+          return createResponse(
+            { token: "ws-token", user: verifiedUser },
+            {
+              cookies: [
+                "__Secure-gloomberb.session_token=signed-token.value; Path=/; HttpOnly; Secure; SameSite=Lax",
+              ],
+            },
+          );
+        }
 
-      return createResponse({ user: verifiedUser });
-    });
+        return createResponse({ user: verifiedUser });
+      },
+    );
 
     await apiClient.signIn("test@example.com", "password");
     await apiClient.getSession();
@@ -277,16 +320,19 @@ describe("apiClient auth cookies", () => {
       await new Promise<void>((resolve) => {
         releaseResponse = resolve;
       });
-      return createResponse({
-        channels: [],
-        onlineCount: 0,
-        channelStates: [],
-        notifications: [],
-      }, {
-        cookies: [
-          "__Secure-gloomberb.session_token=old-session.value; Path=/; HttpOnly; Secure; SameSite=None",
-        ],
-      });
+      return createResponse(
+        {
+          channels: [],
+          onlineCount: 0,
+          channelStates: [],
+          notifications: [],
+        },
+        {
+          cookies: [
+            "__Secure-gloomberb.session_token=old-session.value; Path=/; HttpOnly; Secure; SameSite=None",
+          ],
+        },
+      );
     });
 
     const staleRequest = apiClient.getChatState();
@@ -308,7 +354,11 @@ describe("apiClient auth cookies", () => {
       seenCookies.push(headers.get("Cookie"));
       return createResponse(
         { token: "ws-token", user: verifiedUser },
-        { cookies: ["gloomberb.session_token=signed-token.value; Path=/; HttpOnly; SameSite=Lax"] },
+        {
+          cookies: [
+            "gloomberb.session_token=signed-token.value; Path=/; HttpOnly; SameSite=Lax",
+          ],
+        },
       );
     });
 
@@ -320,11 +370,13 @@ describe("apiClient auth cookies", () => {
   });
 
   test("rejects login success without a captured session cookie", async () => {
-    globalThis.fetch = mockFetch(async () => createResponse({ token: "raw-session-token", user: verifiedUser }));
-
-    await expect(apiClient.signIn("test@example.com", "password")).rejects.toThrow(
-      "could not save the login session",
+    globalThis.fetch = mockFetch(async () =>
+      createResponse({ token: "raw-session-token", user: verifiedUser }),
     );
+
+    await expect(
+      apiClient.signIn("test@example.com", "password"),
+    ).rejects.toThrow("could not save the login session");
     expect(apiClient.getSessionToken()).toBeNull();
     expect(apiClient.getWebSocketToken()).toBeNull();
     expect(apiClient.getCurrentUser()).toBeNull();
@@ -334,11 +386,13 @@ describe("apiClient auth cookies", () => {
     const seenCookies: Array<string | null> = [];
     apiClient.setSessionToken("persisted-token.value");
 
-    globalThis.fetch = mockFetch(async (_input: Request | string | URL, init?: RequestInit) => {
-      const headers = new Headers(init?.headers);
-      seenCookies.push(headers.get("Cookie"));
-      return createResponse({ user: verifiedUser });
-    });
+    globalThis.fetch = mockFetch(
+      async (_input: Request | string | URL, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        seenCookies.push(headers.get("Cookie"));
+        return createResponse({ user: verifiedUser });
+      },
+    );
 
     await apiClient.getSession();
 
@@ -351,13 +405,15 @@ describe("apiClient auth cookies", () => {
     let requestedUrl = "";
     let requestedCookie: string | null = null;
     apiClient.setSessionToken("desktop-session-token");
-    globalThis.fetch = mockFetch(async (input: Request | string | URL, init?: RequestInit) => {
-      requestedUrl = String(input);
-      requestedCookie = new Headers(init?.headers).get("Cookie");
-      return createResponse({
-        url: "https://api.gloom.sh/cloud/auth/browser-handoff?token=opaque-one-time-token",
-      });
-    });
+    globalThis.fetch = mockFetch(
+      async (input: Request | string | URL, init?: RequestInit) => {
+        requestedUrl = String(input);
+        requestedCookie = new Headers(init?.headers).get("Cookie");
+        return createResponse({
+          url: "https://api.gloom.sh/cloud/auth/browser-handoff?token=opaque-one-time-token",
+        });
+      },
+    );
 
     const handoff = await apiClient.createBrowserHandoff();
 
@@ -373,7 +429,9 @@ describe("apiClient auth cookies", () => {
     apiClient.setSessionToken("persisted-token.value");
     apiClient.restoreCachedUser(verifiedUser);
 
-    globalThis.fetch = mockFetch(async () => createResponse({ message: "Unauthorized" }, { status: 401 }));
+    globalThis.fetch = mockFetch(async () =>
+      createResponse({ message: "Unauthorized" }, { status: 401 }),
+    );
 
     await expect(apiClient.getSession()).rejects.toThrow("Unauthorized");
     expect(apiClient.getSessionToken()).toBe("persisted-token.value");
@@ -389,7 +447,9 @@ describe("apiClient auth cookies", () => {
     apiClient.setWebSocketToken("ws-token");
     apiClient.restoreCachedUser(verifiedUser);
 
-    globalThis.fetch = mockFetch(async () => createResponse({ code: "USER_NOT_FOUND" }, { status: 403 }));
+    globalThis.fetch = mockFetch(async () =>
+      createResponse({ code: "USER_NOT_FOUND" }, { status: 403 }),
+    );
 
     await expect(apiClient.getSession()).resolves.toBeNull();
     expect(apiClient.getSessionToken()).toBeNull();
@@ -402,7 +462,9 @@ describe("apiClient auth cookies", () => {
     apiClient.setWebSocketToken("ws-token");
     apiClient.restoreCachedUser(verifiedUser);
 
-    globalThis.fetch = mockFetch(async () => createResponse({ message: "server unavailable" }, { status: 503 }));
+    globalThis.fetch = mockFetch(async () =>
+      createResponse({ message: "server unavailable" }, { status: 503 }),
+    );
 
     await expect(apiClient.signOut()).rejects.toThrow("server unavailable");
     expect(apiClient.getSessionToken()).toBeNull();
@@ -418,7 +480,10 @@ describe("apiClient quote socket", () => {
     apiClient.setWebSocketToken("stale-ws-token");
     apiClient.restoreCachedUser(verifiedUser);
 
-    const unsubscribe = apiClient.subscribeQuotes([{ symbol: "AAPL" }], () => {});
+    const unsubscribe = apiClient.subscribeQuotes(
+      [{ symbol: "AAPL" }],
+      () => {},
+    );
 
     expect(sockets).toHaveLength(1);
     expect(sockets[0]!.url).toContain("token=stale-ws-token");
@@ -434,28 +499,35 @@ describe("apiClient quote socket", () => {
   test("opens an anonymous market websocket and sends quote priority hints", () => {
     const sockets = installTestWebSocket();
 
-    const unsubscribe = apiClient.subscribeQuotes([{
-      symbol: "AAPL",
-      exchange: "NASDAQ",
-      surface: "portfolio",
-      visible: true,
-      selected: true,
-      weight: 100,
-    }], () => {});
+    const unsubscribe = apiClient.subscribeQuotes(
+      [
+        {
+          symbol: "AAPL",
+          exchange: "NASDAQ",
+          surface: "portfolio",
+          visible: true,
+          selected: true,
+          weight: 100,
+        },
+      ],
+      () => {},
+    );
     sockets[0]!.open();
 
     expect(sockets).toHaveLength(1);
     expect(sockets[0]!.url).toBe("wss://api.gloom.sh/cloud/ws");
     expect(sockets[0]!.sent).toContainEqual({
       type: "market.subscribe",
-      symbols: [{
-        symbol: "AAPL",
-        exchange: "NASDAQ",
-        surface: "portfolio",
-        visible: true,
-        selected: true,
-        weight: 100,
-      }],
+      symbols: [
+        {
+          symbol: "AAPL",
+          exchange: "NASDAQ",
+          surface: "portfolio",
+          visible: true,
+          selected: true,
+          weight: 100,
+        },
+      ],
     });
 
     unsubscribe();
@@ -584,7 +656,10 @@ describe("apiClient quote socket", () => {
   test("does not invent quote priority hints when opening a socket", () => {
     const sockets = installTestWebSocket();
 
-    const unsubscribe = apiClient.subscribeQuotes([{ symbol: "AAPL", exchange: "NASDAQ" }], () => {});
+    const unsubscribe = apiClient.subscribeQuotes(
+      [{ symbol: "AAPL", exchange: "NASDAQ" }],
+      () => {},
+    );
     sockets[0]!.open();
 
     expect(sockets[0]!.sent).toContainEqual({
@@ -599,41 +674,53 @@ describe("apiClient quote socket", () => {
     jest.useFakeTimers();
     const sockets = installTestWebSocket();
     const deliveredSurfaces: string[] = [];
-    const unsubscribeInline = apiClient.subscribeQuotes([{
-      symbol: "AAPL",
-      exchange: "NASDAQ",
-      surface: "inline",
-      weight: 1,
-    }], (target) => {
-      deliveredSurfaces.push(target.surface ?? "unknown");
-    });
+    const unsubscribeInline = apiClient.subscribeQuotes(
+      [
+        {
+          symbol: "AAPL",
+          exchange: "NASDAQ",
+          surface: "inline",
+          weight: 1,
+        },
+      ],
+      (target) => {
+        deliveredSurfaces.push(target.surface ?? "unknown");
+      },
+    );
     const socket = sockets[0]!;
     socket.open();
     flushQuoteSubscriptionUpdates();
     socket.sent.length = 0;
 
-    const unsubscribeDetail = apiClient.subscribeQuotes([{
-      symbol: "AAPL",
-      exchange: "NASDAQ",
-      surface: "detail",
-      visible: true,
-      selected: true,
-      weight: 50,
-    }], (target) => {
-      deliveredSurfaces.push(target.surface ?? "unknown");
-    });
+    const unsubscribeDetail = apiClient.subscribeQuotes(
+      [
+        {
+          symbol: "AAPL",
+          exchange: "NASDAQ",
+          surface: "detail",
+          visible: true,
+          selected: true,
+          weight: 50,
+        },
+      ],
+      (target) => {
+        deliveredSurfaces.push(target.surface ?? "unknown");
+      },
+    );
     flushQuoteSubscriptionUpdates();
 
     expect(socket.sent.at(-1)).toEqual({
       type: "market.subscribe",
-      symbols: [{
-        symbol: "AAPL",
-        exchange: "NASDAQ",
-        surface: "detail",
-        visible: true,
-        selected: true,
-        weight: 50,
-      }],
+      symbols: [
+        {
+          symbol: "AAPL",
+          exchange: "NASDAQ",
+          surface: "detail",
+          visible: true,
+          selected: true,
+          weight: 50,
+        },
+      ],
     });
 
     socket.receive({
@@ -648,12 +735,14 @@ describe("apiClient quote socket", () => {
     flushQuoteSubscriptionUpdates();
     expect(socket.sent.at(-1)).toEqual({
       type: "market.subscribe",
-      symbols: [{
-        symbol: "AAPL",
-        exchange: "NASDAQ",
-        surface: "inline",
-        weight: 1,
-      }],
+      symbols: [
+        {
+          symbol: "AAPL",
+          exchange: "NASDAQ",
+          surface: "inline",
+          weight: 1,
+        },
+      ],
     });
 
     unsubscribeInline();
@@ -662,40 +751,59 @@ describe("apiClient quote socket", () => {
   test("unsubscribes a server-side quote when queued priority updates are removed", () => {
     jest.useFakeTimers();
     const sockets = installTestWebSocket();
-    const unsubscribeMsft = apiClient.subscribeQuotes([{ symbol: "MSFT", exchange: "NASDAQ" }], () => {});
+    const unsubscribeMsft = apiClient.subscribeQuotes(
+      [{ symbol: "MSFT", exchange: "NASDAQ" }],
+      () => {},
+    );
     const socket = sockets[0]!;
     socket.open();
     flushQuoteSubscriptionUpdates();
 
-    const unsubscribeInline = apiClient.subscribeQuotes([{
-      symbol: "AAPL",
-      exchange: "NASDAQ",
-      surface: "inline",
-      weight: 1,
-    }], () => {});
+    const unsubscribeInline = apiClient.subscribeQuotes(
+      [
+        {
+          symbol: "AAPL",
+          exchange: "NASDAQ",
+          surface: "inline",
+          weight: 1,
+        },
+      ],
+      () => {},
+    );
     flushQuoteSubscriptionUpdates();
     expect(socket.sent.at(-1)).toEqual({
       type: "market.subscribe",
-      symbols: [{ symbol: "AAPL", exchange: "NASDAQ", surface: "inline", weight: 1 }],
+      symbols: [
+        { symbol: "AAPL", exchange: "NASDAQ", surface: "inline", weight: 1 },
+      ],
     });
 
     socket.sent.length = 0;
-    const unsubscribeDetail = apiClient.subscribeQuotes([{
-      symbol: "AAPL",
-      exchange: "NASDAQ",
-      surface: "detail",
-      visible: true,
-      selected: true,
-      weight: 50,
-    }], () => {});
+    const unsubscribeDetail = apiClient.subscribeQuotes(
+      [
+        {
+          symbol: "AAPL",
+          exchange: "NASDAQ",
+          surface: "detail",
+          visible: true,
+          selected: true,
+          weight: 50,
+        },
+      ],
+      () => {},
+    );
     unsubscribeDetail();
     unsubscribeInline();
     flushQuoteSubscriptionUpdates();
 
-    expect(socket.sent).toEqual([{
-      type: "market.unsubscribe",
-      symbols: [{ symbol: "AAPL", exchange: "NASDAQ", surface: "inline", weight: 1 }],
-    }]);
+    expect(socket.sent).toEqual([
+      {
+        type: "market.unsubscribe",
+        symbols: [
+          { symbol: "AAPL", exchange: "NASDAQ", surface: "inline", weight: 1 },
+        ],
+      },
+    ]);
     unsubscribeMsft();
   });
 
@@ -720,10 +828,9 @@ describe("apiClient quote socket", () => {
     unsubscribeOld();
     flushQuoteSubscriptionUpdates();
 
-    expect(socket.sent.map((message) => (message as { type: string }).type)).toEqual([
-      "market.unsubscribe",
-      "market.subscribe",
-    ]);
+    expect(
+      socket.sent.map((message) => (message as { type: string }).type),
+    ).toEqual(["market.unsubscribe", "market.subscribe"]);
     expect(socket.sent[0]).toMatchObject({
       symbols: [{ symbol: "OPT0" }, { symbol: "OPT1" }],
     });
@@ -738,9 +845,12 @@ describe("apiClient quote socket", () => {
     const seenPrices: number[] = [];
     const sockets = installTestWebSocket();
 
-    const unsubscribe = apiClient.subscribeQuotes([{ symbol: "AAPL" }], (_target, quote) => {
-      seenPrices.push(quote.price);
-    });
+    const unsubscribe = apiClient.subscribeQuotes(
+      [{ symbol: "AAPL" }],
+      (_target, quote) => {
+        seenPrices.push(quote.price);
+      },
+    );
     const socket = sockets[0]!;
     socket.open();
     socket.receive({ type: "auth.unverified" });
@@ -773,15 +883,24 @@ describe("apiClient scanner subscriptions", () => {
     const first: unknown[] = [];
     const second: unknown[] = [];
 
-    const unsubscribeFirst = apiClient.subscribeScanner("hilo", (event) => first.push(event));
+    const unsubscribeFirst = apiClient.subscribeScanner("hilo", (event) =>
+      first.push(event),
+    );
     const socket = sockets[0]!;
     socket.open();
-    expect(socket.sent).toContainEqual({ type: "scanner.subscribe", scanner: "hilo" });
+    expect(socket.sent).toContainEqual({
+      type: "scanner.subscribe",
+      scanner: "hilo",
+    });
 
     const payload = {
       status: "live",
       asOf: 1,
-      windows: { s30: { highs: 1, lows: 0 }, m1: { highs: 2, lows: 1 }, m5: { highs: 3, lows: 2 } },
+      windows: {
+        s30: { highs: 1, lows: 0 },
+        m1: { highs: 2, lows: 1 },
+        m5: { highs: 3, lows: 2 },
+      },
       highs: [],
       lows: [],
     };
@@ -789,9 +908,13 @@ describe("apiClient scanner subscriptions", () => {
 
     // A second pane must not open a second upstream subscription, and must not
     // wait a tick for its first frame.
-    const subscribeCount = () => socket.sent.filter((message: any) => message.type === "scanner.subscribe").length;
+    const subscribeCount = () =>
+      socket.sent.filter((message: any) => message.type === "scanner.subscribe")
+        .length;
     const before = subscribeCount();
-    const unsubscribeSecond = apiClient.subscribeScanner("hilo", (event) => second.push(event));
+    const unsubscribeSecond = apiClient.subscribeScanner("hilo", (event) =>
+      second.push(event),
+    );
     expect(subscribeCount()).toBe(before);
     expect(second).toEqual([{ type: "data", payload }]);
 
@@ -800,19 +923,31 @@ describe("apiClient scanner subscriptions", () => {
     expect(second).toHaveLength(2);
 
     unsubscribeFirst();
-    expect(socket.sent).not.toContainEqual({ type: "scanner.unsubscribe", scanner: "hilo" });
+    expect(socket.sent).not.toContainEqual({
+      type: "scanner.unsubscribe",
+      scanner: "hilo",
+    });
     unsubscribeSecond();
-    expect(socket.sent).toContainEqual({ type: "scanner.unsubscribe", scanner: "hilo" });
+    expect(socket.sent).toContainEqual({
+      type: "scanner.unsubscribe",
+      scanner: "hilo",
+    });
   });
 
   test("replays scanner subscriptions after a reconnect and surfaces denials", () => {
     const sockets = installTestWebSocket();
     const seen: unknown[] = [];
-    const unsubscribe = apiClient.subscribeScanner("flow", (event) => seen.push(event));
+    const unsubscribe = apiClient.subscribeScanner("flow", (event) =>
+      seen.push(event),
+    );
 
     const socket = sockets[0]!;
     socket.open();
-    socket.receive({ type: "scanner.denied", scanner: "flow", reason: "pro_required" });
+    socket.receive({
+      type: "scanner.denied",
+      scanner: "flow",
+      reason: "pro_required",
+    });
     expect(seen).toEqual([{ type: "denied", reason: "pro_required" }]);
 
     jest.useFakeTimers();
@@ -820,7 +955,10 @@ describe("apiClient scanner subscriptions", () => {
     jest.runAllTimers();
     const reconnected = sockets[1]!;
     reconnected.open();
-    expect(reconnected.sent).toContainEqual({ type: "scanner.subscribe", scanner: "flow" });
+    expect(reconnected.sent).toContainEqual({
+      type: "scanner.subscribe",
+      scanner: "flow",
+    });
 
     unsubscribe();
   });
@@ -844,15 +982,17 @@ describe("apiClient chat timestamps", () => {
 
   test("normalizes transcript and send-response timestamps to UTC ISO strings", async () => {
     const responses = [
-      createResponse([{
-        id: "m1",
-        channelId: "everyone",
-        content: "older",
-        replyToId: null,
-        createdAt: "2026-04-08 07:28:27.625",
-        user: { id: "u1", username: "alice", displayName: "Alice" },
-        replyTo: null,
-      }]),
+      createResponse([
+        {
+          id: "m1",
+          channelId: "everyone",
+          content: "older",
+          replyToId: null,
+          createdAt: "2026-04-08 07:28:27.625",
+          user: { id: "u1", username: "alice", displayName: "Alice" },
+          replyTo: null,
+        },
+      ]),
       createResponse({
         id: "m2",
         channelId: "everyone",
@@ -875,31 +1015,39 @@ describe("apiClient chat timestamps", () => {
 
   test("edits a chat message and normalizes the edit timestamp", async () => {
     const requests: Array<{ path: string; method: string; body: unknown }> = [];
-    globalThis.fetch = mockFetch(async (input: Request | string | URL, init?: RequestInit) => {
-      requests.push({
-        path: new URL(String(input)).pathname,
-        method: init?.method ?? "GET",
-        body: init?.body ? JSON.parse(String(init.body)) : null,
-      });
-      return createResponse({
-        id: "m2",
-        channelId: "everyone",
-        content: "hello edited",
-        replyToId: null,
-        createdAt: "2026-04-08 07:29:27.625",
-        editedAt: "2026-04-08 07:30:27.625",
-        user: { id: "u1", username: "alice", displayName: "Alice" },
-        replyTo: null,
-      });
-    });
+    globalThis.fetch = mockFetch(
+      async (input: Request | string | URL, init?: RequestInit) => {
+        requests.push({
+          path: new URL(String(input)).pathname,
+          method: init?.method ?? "GET",
+          body: init?.body ? JSON.parse(String(init.body)) : null,
+        });
+        return createResponse({
+          id: "m2",
+          channelId: "everyone",
+          content: "hello edited",
+          replyToId: null,
+          createdAt: "2026-04-08 07:29:27.625",
+          editedAt: "2026-04-08 07:30:27.625",
+          user: { id: "u1", username: "alice", displayName: "Alice" },
+          replyTo: null,
+        });
+      },
+    );
 
-    const editedMessage = await apiClient.editMessage("everyone", "m2", "hello edited");
+    const editedMessage = await apiClient.editMessage(
+      "everyone",
+      "m2",
+      "hello edited",
+    );
 
-    expect(requests).toEqual([{
-      path: "/chat/channels/everyone/messages/m2",
-      method: "PATCH",
-      body: { content: "hello edited" },
-    }]);
+    expect(requests).toEqual([
+      {
+        path: "/chat/channels/everyone/messages/m2",
+        method: "PATCH",
+        body: { content: "hello edited" },
+      },
+    ]);
     expect(editedMessage.editedAt).toBe("2026-04-08T07:30:27.625Z");
   });
 
@@ -909,19 +1057,21 @@ describe("apiClient chat timestamps", () => {
       seenCreatedAts.push(message.createdAt);
     });
 
-    await (apiClient as any).socket.handleSocketMessage(JSON.stringify({
-      type: "chat.message",
-      channelId: "everyone",
-      data: {
-        id: "m1",
+    await (apiClient as any).socket.handleSocketMessage(
+      JSON.stringify({
+        type: "chat.message",
         channelId: "everyone",
-        content: "hello",
-        replyToId: null,
-        createdAt: "2026-04-08 07:28:27.625",
-        user: { id: "u1", username: "alice", displayName: "Alice" },
-        replyTo: null,
-      },
-    }));
+        data: {
+          id: "m1",
+          channelId: "everyone",
+          content: "hello",
+          replyToId: null,
+          createdAt: "2026-04-08 07:28:27.625",
+          user: { id: "u1", username: "alice", displayName: "Alice" },
+          replyTo: null,
+        },
+      }),
+    );
 
     expect(seenCreatedAts).toEqual(["2026-04-08T07:28:27.625Z"]);
     channel.close();
@@ -932,30 +1082,43 @@ describe("apiClient chat timestamps", () => {
     globalThis.fetch = mockFetch(async (input: Request | string | URL) => {
       requestedUrl = String(input);
       return createResponse({
-        channels: [{ id: "everyone", name: "everyone", created_at: "2026-04-08T07:00:00.000Z" }],
-        onlineCount: 2,
-        channelStates: [{
-          channelId: "everyone",
-          notificationsEnabled: true,
-          lastReadMessageId: "m1",
-          unreadCount: 1,
-        }],
-        notifications: [{
-          id: "n1",
-          type: "reply",
-          channelId: "everyone",
-          messageId: "m2",
-          createdAt: "2026-04-08 07:30:00.000",
-          message: {
-            id: "m2",
-            channelId: "everyone",
-            content: "reply",
-            replyToId: "m1",
-            createdAt: "2026-04-08 07:29:00.000",
-            user: { id: "u2", username: "bob", displayName: "Bob" },
-            replyTo: { content: "parent", user: { id: "u1", username: "vince" } },
+        channels: [
+          {
+            id: "everyone",
+            name: "everyone",
+            created_at: "2026-04-08T07:00:00.000Z",
           },
-        }],
+        ],
+        onlineCount: 2,
+        channelStates: [
+          {
+            channelId: "everyone",
+            notificationsEnabled: true,
+            lastReadMessageId: "m1",
+            unreadCount: 1,
+          },
+        ],
+        notifications: [
+          {
+            id: "n1",
+            type: "reply",
+            channelId: "everyone",
+            messageId: "m2",
+            createdAt: "2026-04-08 07:30:00.000",
+            message: {
+              id: "m2",
+              channelId: "everyone",
+              content: "reply",
+              replyToId: "m1",
+              createdAt: "2026-04-08 07:29:00.000",
+              user: { id: "u2", username: "bob", displayName: "Bob" },
+              replyTo: {
+                content: "parent",
+                user: { id: "u1", username: "vince" },
+              },
+            },
+          },
+        ],
       });
     });
 
@@ -964,7 +1127,9 @@ describe("apiClient chat timestamps", () => {
     expect(new URL(requestedUrl).pathname).toBe("/chat/state");
     expect(state.onlineCount).toBe(2);
     expect(state.notifications[0]?.createdAt).toBe("2026-04-08T07:30:00.000Z");
-    expect(state.notifications[0]?.message.createdAt).toBe("2026-04-08T07:29:00.000Z");
+    expect(state.notifications[0]?.message.createdAt).toBe(
+      "2026-04-08T07:29:00.000Z",
+    );
   });
 
   test("updates chat channel state and marks notifications delivered", async () => {
@@ -979,14 +1144,16 @@ describe("apiClient chat timestamps", () => {
       createResponse({ delivered: 2 }),
       createResponse({ onlineCount: 4 }),
     ];
-    globalThis.fetch = mockFetch(async (input: Request | string | URL, init?: RequestInit) => {
-      requests.push({
-        path: new URL(String(input)).pathname,
-        method: init?.method ?? "GET",
-        body: init?.body ? JSON.parse(String(init.body)) : null,
-      });
-      return responses.shift() as Response;
-    });
+    globalThis.fetch = mockFetch(
+      async (input: Request | string | URL, init?: RequestInit) => {
+        requests.push({
+          path: new URL(String(input)).pathname,
+          method: init?.method ?? "GET",
+          body: init?.body ? JSON.parse(String(init.body)) : null,
+        });
+        return responses.shift() as Response;
+      },
+    );
 
     await apiClient.updateChatChannelState("everyone", {
       notificationsEnabled: true,
@@ -1018,36 +1185,49 @@ describe("apiClient chat timestamps", () => {
   test("emits websocket chat presence and notification events", async () => {
     const seenPresence: number[] = [];
     const seenNotifications: string[] = [];
-    const unsubscribePresence = apiClient.subscribeChatPresence((onlineCount) => {
-      seenPresence.push(onlineCount);
-    });
-    const unsubscribeNotifications = apiClient.subscribeChatNotifications((notification) => {
-      seenNotifications.push(`${notification.id}:${notification.message.createdAt}`);
-    });
-
-    await (apiClient as any).socket.handleSocketMessage(JSON.stringify({
-      type: "chat.presence",
-      onlineCount: 5,
-    }));
-    await (apiClient as any).socket.handleSocketMessage(JSON.stringify({
-      type: "chat.notification",
-      data: {
-        id: "n1",
-        type: "reply",
-        channelId: "everyone",
-        messageId: "m2",
-        createdAt: "2026-04-08 07:30:00.000",
-        message: {
-          id: "m2",
-          channelId: "everyone",
-          content: "reply",
-          replyToId: "m1",
-          createdAt: "2026-04-08 07:29:00.000",
-          user: { id: "u2", username: "bob", displayName: "Bob" },
-          replyTo: { content: "parent", user: { id: "u1", username: "vince" } },
-        },
+    const unsubscribePresence = apiClient.subscribeChatPresence(
+      (onlineCount) => {
+        seenPresence.push(onlineCount);
       },
-    }));
+    );
+    const unsubscribeNotifications = apiClient.subscribeChatNotifications(
+      (notification) => {
+        seenNotifications.push(
+          `${notification.id}:${notification.message.createdAt}`,
+        );
+      },
+    );
+
+    await (apiClient as any).socket.handleSocketMessage(
+      JSON.stringify({
+        type: "chat.presence",
+        onlineCount: 5,
+      }),
+    );
+    await (apiClient as any).socket.handleSocketMessage(
+      JSON.stringify({
+        type: "chat.notification",
+        data: {
+          id: "n1",
+          type: "reply",
+          channelId: "everyone",
+          messageId: "m2",
+          createdAt: "2026-04-08 07:30:00.000",
+          message: {
+            id: "m2",
+            channelId: "everyone",
+            content: "reply",
+            replyToId: "m1",
+            createdAt: "2026-04-08 07:29:00.000",
+            user: { id: "u2", username: "bob", displayName: "Bob" },
+            replyTo: {
+              content: "parent",
+              user: { id: "u1", username: "vince" },
+            },
+          },
+        },
+      }),
+    );
 
     expect(seenPresence).toEqual([5]);
     expect(seenNotifications).toEqual(["n1:2026-04-08T07:29:00.000Z"]);
@@ -1062,30 +1242,32 @@ describe("apiClient account profile", () => {
     let requestedBody = "";
     apiClient.setSessionToken("session-token");
     apiClient.restoreCachedUser(verifiedUser);
-    globalThis.fetch = mockFetch(async (input: Request | string | URL, init?: RequestInit) => {
-      requestedUrl = String(input);
-      requestedBody = String(init?.body ?? "");
-      return createResponse({
-        profile: {
-          id: verifiedUser.id,
-          email: verifiedUser.email,
-          emailVerified: true,
-          plan: "pro",
-          username: "renamed",
-          name: "Renamed User",
-          company: "Gloomberb",
-          title: "Founder",
-          bio: "Markets.",
-          profilePublic: true,
-          publicEmail: "public@example.com",
-          xAccount: "vincelwt",
-          sharedPortfolioId: "main",
-          acceptUnknownDms: true,
-          chatEmailNotificationsEnabled: false,
-          updatedAt: "2026-04-01T00:00:00.000Z",
-        },
-      });
-    });
+    globalThis.fetch = mockFetch(
+      async (input: Request | string | URL, init?: RequestInit) => {
+        requestedUrl = String(input);
+        requestedBody = String(init?.body ?? "");
+        return createResponse({
+          profile: {
+            id: verifiedUser.id,
+            email: verifiedUser.email,
+            emailVerified: true,
+            plan: "pro",
+            username: "renamed",
+            name: "Renamed User",
+            company: "Gloomberb",
+            title: "Founder",
+            bio: "Markets.",
+            profilePublic: true,
+            publicEmail: "public@example.com",
+            xAccount: "vincelwt",
+            sharedPortfolioId: "main",
+            acceptUnknownDms: true,
+            chatEmailNotificationsEnabled: false,
+            updatedAt: "2026-04-01T00:00:00.000Z",
+          },
+        });
+      },
+    );
 
     const profile = await apiClient.updateAccountProfile({
       username: "renamed",
@@ -1108,18 +1290,22 @@ describe("apiClient account profile", () => {
     expect(profile.username).toBe("renamed");
     expect(apiClient.getCurrentUser()?.username).toBe("renamed");
     expect(apiClient.getCurrentUser()?.plan).toBe("pro");
-    expect(apiClient.getCurrentUser()?.chatEmailNotificationsEnabled).toBe(false);
+    expect(apiClient.getCurrentUser()?.chatEmailNotificationsEnabled).toBe(
+      false,
+    );
   });
 
   test("changes password through Better Auth", async () => {
     let requestedUrl = "";
     let requestedBody = "";
     apiClient.setSessionToken("session-token");
-    globalThis.fetch = mockFetch(async (input: Request | string | URL, init?: RequestInit) => {
-      requestedUrl = String(input);
-      requestedBody = String(init?.body ?? "");
-      return createResponse({ status: true });
-    });
+    globalThis.fetch = mockFetch(
+      async (input: Request | string | URL, init?: RequestInit) => {
+        requestedUrl = String(input);
+        requestedBody = String(init?.body ?? "");
+        return createResponse({ status: true });
+      },
+    );
 
     await apiClient.changePassword("old-password", "new-password");
 
@@ -1206,11 +1392,13 @@ describe("apiClient equity diagnostic", () => {
   test("posts the symbol, exchange, and cache mode to the research route", async () => {
     let seenUrl = "";
     let seenInit: RequestInit | undefined;
-    globalThis.fetch = mockFetch(async (input: Request | string | URL, init?: RequestInit) => {
-      seenUrl = String(input);
-      seenInit = init;
-      return createResponse({ symbol: "AAPL", status: "complete" });
-    });
+    globalThis.fetch = mockFetch(
+      async (input: Request | string | URL, init?: RequestInit) => {
+        seenUrl = String(input);
+        seenInit = init;
+        return createResponse({ symbol: "AAPL", status: "complete" });
+      },
+    );
 
     await apiClient.getCloudEquityDiagnostic(" aapl ", "NASDAQ", "refresh");
 
@@ -1225,14 +1413,19 @@ describe("apiClient equity diagnostic", () => {
 
   test("omits an unknown exchange and defaults to the cached answer", async () => {
     let seenInit: RequestInit | undefined;
-    globalThis.fetch = mockFetch(async (_input: Request | string | URL, init?: RequestInit) => {
-      seenInit = init;
-      return createResponse({ symbol: "AAPL", status: "complete" });
-    });
+    globalThis.fetch = mockFetch(
+      async (_input: Request | string | URL, init?: RequestInit) => {
+        seenInit = init;
+        return createResponse({ symbol: "AAPL", status: "complete" });
+      },
+    );
 
     await apiClient.getCloudEquityDiagnostic("AAPL");
 
-    expect(JSON.parse(String(seenInit?.body))).toEqual({ symbol: "AAPL", mode: "cache-first" });
+    expect(JSON.parse(String(seenInit?.body))).toEqual({
+      symbol: "AAPL",
+      mode: "cache-first",
+    });
   });
 });
 
@@ -1277,7 +1470,11 @@ describe("apiClient document search", () => {
     // Counting is the server default, so only opting out travels.
     expect(url.searchParams.has("count")).toBe(false);
 
-    await apiClient.searchCloudDocuments({ query: "margin", limit: 3, count: false });
+    await apiClient.searchCloudDocuments({
+      query: "margin",
+      limit: 3,
+      count: false,
+    });
     expect(new URL(seenUrl).searchParams.get("count")).toBe("false");
   });
 
@@ -1288,7 +1485,10 @@ describe("apiClient document search", () => {
       return createResponse({ document: { chunks: [] } });
     });
 
-    await apiClient.getCloudSearchDocument("filing", "0000320193-26-000042/a b");
+    await apiClient.getCloudSearchDocument(
+      "filing",
+      "0000320193-26-000042/a b",
+    );
 
     expect(new URL(seenUrl).pathname).toBe(
       "/cloud/search/documents/filing/0000320193-26-000042%2Fa%20b",
@@ -1309,18 +1509,30 @@ describe("apiClient document search", () => {
       createdAt: "2026-05-01T00:00:00.000Z",
     };
 
-    globalThis.fetch = mockFetch(async () => createResponse({ search: record }));
-    expect((await apiClient.createCloudSavedSearch({
-      name: record.name,
-      query: record.query,
-    })).id).toBe("saved-1");
+    globalThis.fetch = mockFetch(async () =>
+      createResponse({ search: record }),
+    );
+    expect(
+      (
+        await apiClient.createCloudSavedSearch({
+          name: record.name,
+          query: record.query,
+        })
+      ).id,
+    ).toBe("saved-1");
 
     globalThis.fetch = mockFetch(async () => createResponse(record));
-    expect((await apiClient.updateCloudSavedSearch("saved-1", { alertEnabled: false })).id)
-      .toBe("saved-1");
+    expect(
+      (
+        await apiClient.updateCloudSavedSearch("saved-1", {
+          alertEnabled: false,
+        })
+      ).id,
+    ).toBe("saved-1");
 
     globalThis.fetch = mockFetch(async () => createResponse({}));
-    await expect(apiClient.updateCloudSavedSearch("saved-1", { alertEnabled: false }))
-      .rejects.toThrow("missing a record");
+    await expect(
+      apiClient.updateCloudSavedSearch("saved-1", { alertEnabled: false }),
+    ).rejects.toThrow("missing a record");
   });
 });

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -58,6 +58,8 @@ import type {
   CloudEarningsTranscriptPayload,
   CloudProxyStatementListPayload,
   CloudProxyStatementPayload,
+  CloudRiskReportListPayload,
+  CloudRiskReportPayload,
   CloudNewsPayload,
   CloudSavedSearch,
   CloudSavedSearchInput,
@@ -916,6 +918,17 @@ class GloomApiClient {
     year: number,
   ): Promise<CloudProxyStatementPayload> {
     return this.data.getProxyStatement(ticker, year);
+  }
+
+  async getRiskReports(ticker: string): Promise<CloudRiskReportListPayload> {
+    return this.data.getRiskReports(ticker);
+  }
+
+  async getRiskReport(
+    ticker: string,
+    year: number,
+  ): Promise<CloudRiskReportPayload> {
+    return this.data.getRiskReport(ticker, year);
   }
 
   async getCloudSecFilings(

--- a/src/api-client/normalizers.ts
+++ b/src/api-client/normalizers.ts
@@ -16,18 +16,25 @@ import { normalizeTimestamp } from "../utils/timestamp";
  * Both shapes are accepted so a server-side envelope change cannot silently
  * hand the pane an object with no `id`.
  */
-export function normalizeSavedSearchResponse(response: unknown): CloudSavedSearch {
-  const envelope = response as { search?: CloudSavedSearch } | CloudSavedSearch | null;
-  const search = envelope && "search" in envelope && envelope.search
-    ? envelope.search
-    : envelope as CloudSavedSearch | null;
-  if (!search?.id) throw new Error("The saved search response was missing a record.");
+export function normalizeSavedSearchResponse(
+  response: unknown,
+): CloudSavedSearch {
+  const envelope = response as
+    { search?: CloudSavedSearch } | CloudSavedSearch | null;
+  const search =
+    envelope && "search" in envelope && envelope.search
+      ? envelope.search
+      : (envelope as CloudSavedSearch | null);
+  if (!search?.id)
+    throw new Error("The saved search response was missing a record.");
   return search;
 }
 
 export function normalizeSavedSearchHits(response: unknown): CloudSearchHit[] {
   const hits = (response as { hits?: unknown } | null)?.hits;
-  return Array.isArray(hits) ? (hits as CloudSearchHit[]).map(normalizeSearchHit) : [];
+  return Array.isArray(hits)
+    ? (hits as CloudSearchHit[]).map(normalizeSearchHit)
+    : [];
 }
 
 /**
@@ -41,7 +48,9 @@ export function normalizeSearchHit(hit: CloudSearchHit): CloudSearchHit {
   return hit.ticker ? hit : { ...hit, ticker: "" };
 }
 
-export function normalizeSearchResponse(response: CloudSearchResponse): CloudSearchResponse {
+export function normalizeSearchResponse(
+  response: CloudSearchResponse,
+): CloudSearchResponse {
   const hits = response.hits;
   if (!Array.isArray(hits)) return { ...response, hits: [] };
   return { ...response, hits: hits.map(normalizeSearchHit) };
@@ -51,7 +60,9 @@ export function normalizeChatMessage(message: ChatMessage): ChatMessage {
   return {
     ...message,
     createdAt: normalizeTimestamp(message.createdAt),
-    ...(message.editedAt ? { editedAt: normalizeTimestamp(message.editedAt) } : {}),
+    ...(message.editedAt
+      ? { editedAt: normalizeTimestamp(message.editedAt) }
+      : {}),
   };
 }
 
@@ -59,7 +70,9 @@ export function normalizeChatMessages(messages: ChatMessage[]): ChatMessage[] {
   return messages.map((message) => normalizeChatMessage(message));
 }
 
-export function normalizeChatNotification(notification: ChatNotification): ChatNotification {
+export function normalizeChatNotification(
+  notification: ChatNotification,
+): ChatNotification {
   return {
     ...notification,
     createdAt: normalizeTimestamp(notification.createdAt),
@@ -67,7 +80,10 @@ export function normalizeChatNotification(notification: ChatNotification): ChatN
   };
 }
 
-export function normalizeChatChannel(channel: ChatChannel, fallbackKind: ChatChannel["kind"] = "public"): ChatChannel {
+export function normalizeChatChannel(
+  channel: ChatChannel,
+  fallbackKind: ChatChannel["kind"] = "public",
+): ChatChannel {
   return {
     ...channel,
     kind: channel.kind ?? fallbackKind,
@@ -75,7 +91,9 @@ export function normalizeChatChannel(channel: ChatChannel, fallbackKind: ChatCha
   };
 }
 
-export function normalizeChatState(response: ChatStateResponse): ChatStateResponse {
+export function normalizeChatState(
+  response: ChatStateResponse,
+): ChatStateResponse {
   return {
     ...response,
     channels: response.channels.map((channel) => normalizeChatChannel(channel)),
@@ -90,7 +108,9 @@ function normalizeTweet(tweet: CloudTweetPayload): CloudTweetPayload {
   };
 }
 
-export function normalizeTweetSearchResponse(response: CloudTweetSearchResponse): CloudTweetSearchResponse {
+export function normalizeTweetSearchResponse(
+  response: CloudTweetSearchResponse,
+): CloudTweetSearchResponse {
   return {
     ...response,
     since: normalizeTimestamp(response.since),

--- a/src/api-client/paths.ts
+++ b/src/api-client/paths.ts
@@ -253,6 +253,14 @@ export function publicProxyStatementsPath(ticker: string): string {
   return `/public/proxies/${encodeURIComponent(ticker.toUpperCase())}`;
 }
 
+export function publicRiskReportsPath(ticker: string): string {
+  return `/public/risks/${encodeURIComponent(ticker.toUpperCase())}`;
+}
+
+export function publicRiskReportPath(ticker: string, year: number): string {
+  return `/public/risks/${encodeURIComponent(ticker.toUpperCase())}/${year}`;
+}
+
 export function publicProxyStatementPath(ticker: string, year: number): string {
   return `/public/proxies/${encodeURIComponent(ticker.toUpperCase())}/${year}`;
 }

--- a/src/api-client/request.test.ts
+++ b/src/api-client/request.test.ts
@@ -20,19 +20,34 @@ describe("CloudApiRequestTransport connection reporting", () => {
     const dispose = registerGloomCloudConnectionSources(health);
     const transport = new CloudApiRequestTransport({
       connectionHealth: health,
-      fetchTransport: async () => responseWithBody(async () => JSON.stringify({ observations: [], info: null })),
+      fetchTransport: async () =>
+        responseWithBody(async () =>
+          JSON.stringify({ observations: [], info: null }),
+        ),
     });
 
-    await transport.request("/cloud/econ/series/VIXCLS?limit=120&sortOrder=desc");
+    await transport.request(
+      "/cloud/econ/series/VIXCLS?limit=120&sortOrder=desc",
+    );
 
-    expect(health.getSnapshot().sources.map((source) => ({
-      id: source.id,
-      status: source.status,
-      operation: source.lastOperation,
-    }))).toEqual([
-      { id: "gloom-cloud-http", status: "connected", operation: "GET /cloud/econ/series/VIXCLS" },
+    expect(
+      health.getSnapshot().sources.map((source) => ({
+        id: source.id,
+        status: source.status,
+        operation: source.lastOperation,
+      })),
+    ).toEqual([
+      {
+        id: "gloom-cloud-http",
+        status: "connected",
+        operation: "GET /cloud/econ/series/VIXCLS",
+      },
       { id: "gloom-cloud-socket", status: "idle", operation: null },
-      { id: "gloom-cloud-fred", status: "connected", operation: "GET /cloud/econ/series/VIXCLS" },
+      {
+        id: "gloom-cloud-fred",
+        status: "connected",
+        operation: "GET /cloud/econ/series/VIXCLS",
+      },
     ]);
 
     dispose();
@@ -51,9 +66,9 @@ describe("CloudApiRequestTransport market deadlines", () => {
       },
     });
 
-    await expect(transport.request("/market/quote?symbol=AAPL")).rejects.toThrow(
-      "Cloud market request timed out after 10ms",
-    );
+    await expect(
+      transport.request("/market/quote?symbol=AAPL"),
+    ).rejects.toThrow("Cloud market request timed out after 10ms");
     expect(signal?.aborted).toBe(true);
   });
 
@@ -67,9 +82,9 @@ describe("CloudApiRequestTransport market deadlines", () => {
       },
     });
 
-    await expect(transport.request("/market/history?symbol=AAPL")).rejects.toThrow(
-      "Cloud market request timed out after 10ms",
-    );
+    await expect(
+      transport.request("/market/history?symbol=AAPL"),
+    ).rejects.toThrow("Cloud market request timed out after 10ms");
     expect(signal?.aborted).toBe(true);
   });
 
@@ -85,9 +100,11 @@ describe("CloudApiRequestTransport market deadlines", () => {
       },
     });
 
-    await expect(transport.request("/market/quote?symbol=AAPL", {
-      signal: controller.signal,
-    })).rejects.toThrow("cancelled by caller");
+    await expect(
+      transport.request("/market/quote?symbol=AAPL", {
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("cancelled by caller");
     expect(fetchCalls).toBe(0);
   });
 });

--- a/src/api-client/request.ts
+++ b/src/api-client/request.ts
@@ -1,6 +1,10 @@
 import { httpFetch, isHttpFetchStreaming } from "../utils/http-transport";
 import { withDeadline } from "../utils/async-deadline";
-import { ApiRequestError, parseApiErrorMessage, parseRetryAfterMs } from "./errors";
+import {
+  ApiRequestError,
+  parseApiErrorMessage,
+  parseRetryAfterMs,
+} from "./errors";
 import {
   connectionHealth,
   GLOOM_CLOUD_FRED_CONNECTION_ID,
@@ -12,11 +16,20 @@ const DEFAULT_API_URL = "https://api.gloom.sh";
 const DEFAULT_MARKET_REQUEST_TIMEOUT_MS = 10_000;
 /** Local status for "this runtime cannot stream", never returned by the server. */
 export const STREAMING_UNSUPPORTED_STATUS = 0;
-const SESSION_COOKIE_NAMES = ["__Secure-gloomberb.session_token", "gloomberb.session_token"] as const;
+const SESSION_COOKIE_NAMES = [
+  "__Secure-gloomberb.session_token",
+  "gloomberb.session_token",
+] as const;
 
 type CloudApiResponse = Pick<Response, "ok" | "status" | "headers" | "text">;
-type CloudApiFetchTransport = (url: string, init?: RequestInit) => Promise<CloudApiResponse>;
-type CloudApiStreamFetch = (url: string, init?: RequestInit) => Promise<Response>;
+type CloudApiFetchTransport = (
+  url: string,
+  init?: RequestInit,
+) => Promise<CloudApiResponse>;
+type CloudApiStreamFetch = (
+  url: string,
+  init?: RequestInit,
+) => Promise<Response>;
 type SessionCookieName = (typeof SESSION_COOKIE_NAMES)[number];
 
 export interface CloudApiFetchTransportOptions {
@@ -39,7 +52,7 @@ export function setCloudApiFetchTransport(
 ): void {
   cloudApiFetchTransport = transport ?? httpFetch;
   cloudApiTransportInstalled = !!transport;
-  cloudApiFetchStreaming = transport ? options.streaming ?? false : true;
+  cloudApiFetchStreaming = transport ? (options.streaming ?? false) : true;
 }
 
 /**
@@ -49,7 +62,9 @@ export function setCloudApiFetchTransport(
 export function getCloudApiStreamFetch(): CloudApiStreamFetch | null {
   if (cloudApiTransportInstalled) {
     // A transport that declares streaming returns a real Response.
-    return cloudApiFetchStreaming ? cloudApiFetchTransport as CloudApiStreamFetch : null;
+    return cloudApiFetchStreaming
+      ? (cloudApiFetchTransport as CloudApiStreamFetch)
+      : null;
   }
   return isHttpFetchStreaming() ? httpFetch : null;
 }
@@ -58,7 +73,8 @@ declare const __GLOOMBERB_API_URL__: string | undefined;
 
 export function getCloudApiBaseUrl(): string {
   // Browser bundles have no `process`; the build replaces this with a literal.
-  const bundled = typeof __GLOOMBERB_API_URL__ === "string" ? __GLOOMBERB_API_URL__ : "";
+  const bundled =
+    typeof __GLOOMBERB_API_URL__ === "string" ? __GLOOMBERB_API_URL__ : "";
   if (bundled) {
     return typeof location !== "undefined" && bundled === location.origin
       ? `${bundled}/api`
@@ -72,7 +88,10 @@ export function getCloudApiBaseUrl(): string {
 
 function throwIfRequestAborted(signal: AbortSignal | null | undefined): void {
   if (!signal?.aborted) return;
-  throw signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+  throw (
+    signal.reason ??
+    new DOMException("The operation was aborted.", "AbortError")
+  );
 }
 
 export class CloudApiRequestTransport {
@@ -86,13 +105,16 @@ export class CloudApiRequestTransport {
 
   readonly baseUrl = getCloudApiBaseUrl();
 
-  constructor(options: {
-    fetchTransport?: CloudApiFetchTransport;
-    marketRequestTimeoutMs?: number;
-    connectionHealth?: ConnectionHealthRegistry;
-  } = {}) {
+  constructor(
+    options: {
+      fetchTransport?: CloudApiFetchTransport;
+      marketRequestTimeoutMs?: number;
+      connectionHealth?: ConnectionHealthRegistry;
+    } = {},
+  ) {
     this.fetchTransport = options.fetchTransport ?? null;
-    this.marketRequestTimeoutMs = options.marketRequestTimeoutMs ?? DEFAULT_MARKET_REQUEST_TIMEOUT_MS;
+    this.marketRequestTimeoutMs =
+      options.marketRequestTimeoutMs ?? DEFAULT_MARKET_REQUEST_TIMEOUT_MS;
     this.connectionHealth = options.connectionHealth ?? connectionHealth;
   }
 
@@ -155,7 +177,11 @@ export class CloudApiRequestTransport {
       );
     }
     const headers = new Headers(options.headers);
-    if (!headers.has("Content-Type") && options.method && options.method !== "GET") {
+    if (
+      !headers.has("Content-Type") &&
+      options.method &&
+      options.method !== "GET"
+    ) {
       headers.set("Content-Type", "application/json");
     }
     if (!headers.has("Accept")) headers.set("Accept", "text/event-stream");
@@ -163,23 +189,27 @@ export class CloudApiRequestTransport {
     headers.set("Origin", this.baseUrl);
 
     const operation = `${options.method ?? "GET"} ${path.split("?")[0]}`;
-    return this.connectionHealth.track(GLOOM_CLOUD_HTTP_CONNECTION_ID, operation, async () => {
-      const response = await streamFetch(`${this.baseUrl}${path}`, {
-        ...options,
-        headers,
-        credentials: "include",
-      });
-      throwIfRequestAborted(options.signal);
-      if (!response.ok) {
-        const text = await response.text().catch(() => "");
-        throw new ApiRequestError(
-          parseApiErrorMessage(text),
-          response.status,
-          parseRetryAfterMs(response.headers.get("Retry-After")),
-        );
-      }
-      return response;
-    });
+    return this.connectionHealth.track(
+      GLOOM_CLOUD_HTTP_CONNECTION_ID,
+      operation,
+      async () => {
+        const response = await streamFetch(`${this.baseUrl}${path}`, {
+          ...options,
+          headers,
+          credentials: "include",
+        });
+        throwIfRequestAborted(options.signal);
+        if (!response.ok) {
+          const text = await response.text().catch(() => "");
+          throw new ApiRequestError(
+            parseApiErrorMessage(text),
+            response.status,
+            parseRetryAfterMs(response.headers.get("Retry-After")),
+          );
+        }
+        return response;
+      },
+    );
   }
 
   async request<T>(path: string, options?: RequestInit): Promise<T> {
@@ -212,10 +242,17 @@ export class CloudApiRequestTransport {
     }
   }
 
-  private async performRequest<T>(path: string, options?: RequestInit): Promise<T> {
+  private async performRequest<T>(
+    path: string,
+    options?: RequestInit,
+  ): Promise<T> {
     throwIfRequestAborted(options?.signal);
     const headers = new Headers(options?.headers);
-    if (!headers.has("Content-Type") && options?.method && options.method !== "GET") {
+    if (
+      !headers.has("Content-Type") &&
+      options?.method &&
+      options.method !== "GET"
+    ) {
       headers.set("Content-Type", "application/json");
     }
     this.setSessionCookieHeader(headers);
@@ -224,11 +261,14 @@ export class CloudApiRequestTransport {
 
     const operation = `${options?.method ?? "GET"} ${path.split("?")[0]}`;
     const request = async () => {
-      const res = await (this.fetchTransport ?? cloudApiFetchTransport)(`${this.baseUrl}${path}`, {
-        ...options,
-        headers,
-        credentials: "include",
-      });
+      const res = await (this.fetchTransport ?? cloudApiFetchTransport)(
+        `${this.baseUrl}${path}`,
+        {
+          ...options,
+          headers,
+          credentials: "include",
+        },
+      );
       throwIfRequestAborted(options?.signal);
       if (this.sessionToken === sessionTokenAtRequestStart) {
         this.extractSessionCookie(res);
@@ -238,7 +278,11 @@ export class CloudApiRequestTransport {
 
       if (!res.ok) {
         const msg = parseApiErrorMessage(text);
-        throw new ApiRequestError(msg, res.status, parseRetryAfterMs(res.headers.get("Retry-After")));
+        throw new ApiRequestError(
+          msg,
+          res.status,
+          parseRetryAfterMs(res.headers.get("Retry-After")),
+        );
       }
 
       if (!text) return undefined as T;
@@ -251,9 +295,14 @@ export class CloudApiRequestTransport {
     return this.connectionHealth.track(
       GLOOM_CLOUD_HTTP_CONNECTION_ID,
       operation,
-      () => path.startsWith("/cloud/econ/series/")
-        ? this.connectionHealth.track(GLOOM_CLOUD_FRED_CONNECTION_ID, operation, request)
-        : request(),
+      () =>
+        path.startsWith("/cloud/econ/series/")
+          ? this.connectionHealth.track(
+              GLOOM_CLOUD_FRED_CONNECTION_ID,
+              operation,
+              request,
+            )
+          : request(),
     );
   }
 
@@ -265,7 +314,10 @@ export class CloudApiRequestTransport {
     }
     for (const cookie of setCookie) {
       for (const cookieName of SESSION_COOKIE_NAMES) {
-        const escapedCookieName = cookieName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const escapedCookieName = cookieName.replace(
+          /[.*+?^${}()|[\]\\]/g,
+          "\\$&",
+        );
         const match = cookie.match(new RegExp(`${escapedCookieName}=([^;]+)`));
         if (!match) continue;
         this.sessionToken = match[1] ?? null;
@@ -277,8 +329,12 @@ export class CloudApiRequestTransport {
 
   private buildSessionCookieHeader(): string | null {
     if (!this.sessionToken) return null;
-    const cookieNames = this.sessionCookieName ? [this.sessionCookieName] : SESSION_COOKIE_NAMES;
-    return cookieNames.map((cookieName) => `${cookieName}=${this.sessionToken}`).join("; ");
+    const cookieNames = this.sessionCookieName
+      ? [this.sessionCookieName]
+      : SESSION_COOKIE_NAMES;
+    return cookieNames
+      .map((cookieName) => `${cookieName}=${this.sessionToken}`)
+      .join("; ");
   }
 
   private setSessionCookieHeader(headers: Headers): void {

--- a/src/api-client/research-activity.ts
+++ b/src/api-client/research-activity.ts
@@ -1,8 +1,20 @@
 import { apiClient } from "./index";
 import { getCurrentPluginTarget } from "../plugins/current-target";
 
-export type ResearchActivity = "workspace_opened" | "research_viewed" | "ticker_saved" | "pro_feature_used" | "upgrade_intent";
-export type ResearchFeature = "overview" | "chart" | "financials" | "news" | "transcripts" | "search" | "research";
+export type ResearchActivity =
+  | "workspace_opened"
+  | "research_viewed"
+  | "ticker_saved"
+  | "pro_feature_used"
+  | "upgrade_intent";
+export type ResearchFeature =
+  | "overview"
+  | "chart"
+  | "financials"
+  | "news"
+  | "transcripts"
+  | "search"
+  | "research";
 const sent = new Set<string>();
 let anonymousId: string | undefined;
 let attribution: Record<string, string> = {};
@@ -10,16 +22,36 @@ let attribution: Record<string, string> = {};
 /** Hosted web analytics only. Native local use never creates an identifier. */
 export function initializeBrowserResearchActivity(): void {
   try {
-    if (navigator.doNotTrack === "1" || (navigator as Navigator & { globalPrivacyControl?: boolean }).globalPrivacyControl) return;
+    if (
+      navigator.doNotTrack === "1" ||
+      (navigator as Navigator & { globalPrivacyControl?: boolean })
+        .globalPrivacyControl
+    )
+      return;
     const url = new URL(location.href);
     const incoming = url.searchParams.get("_gloom");
     const stored = localStorage.getItem("gloomberb.web.anonymous-id");
-    anonymousId = [incoming, stored].find((value) => value && /^[a-f0-9-]{36}$/.test(value)) ?? crypto.randomUUID();
+    anonymousId =
+      [incoming, stored].find(
+        (value) => value && /^[a-f0-9-]{36}$/.test(value),
+      ) ?? crypto.randomUUID();
     localStorage.setItem("gloomberb.web.anonymous-id", anonymousId);
-    const keys = ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term", "twclid"];
-    const saved = JSON.parse(localStorage.getItem("gloomberb.web.attribution") ?? "{}");
+    const keys = [
+      "utm_source",
+      "utm_medium",
+      "utm_campaign",
+      "utm_content",
+      "utm_term",
+      "twclid",
+    ];
+    const saved = JSON.parse(
+      localStorage.getItem("gloomberb.web.attribution") ?? "{}",
+    );
     const age = Date.now() - Date.parse(saved?.last_touch_at ?? "");
-    attribution = Number.isFinite(age) && age >= 0 && age < 30 * 24 * 60 * 60 * 1000 ? saved : {};
+    attribution =
+      Number.isFinite(age) && age >= 0 && age < 30 * 24 * 60 * 60 * 1000
+        ? saved
+        : {};
     if (keys.some((key) => url.searchParams.has(key))) {
       // A new campaign replaces the old click id instead of inheriting it.
       attribution = { last_touch_at: new Date().toISOString() };
@@ -28,14 +60,22 @@ export function initializeBrowserResearchActivity(): void {
         if (value) attribution[key] = value.slice(0, 300);
       }
     }
-    localStorage.setItem("gloomberb.web.attribution", JSON.stringify(attribution));
+    localStorage.setItem(
+      "gloomberb.web.attribution",
+      JSON.stringify(attribution),
+    );
     url.searchParams.delete("_gloom");
     history.replaceState(history.state, "", url.href);
-  } catch { /* Private browsing must still work. */ }
+  } catch {
+    /* Private browsing must still work. */
+  }
 }
 
 /** Counts milestones once per feature/session/account, never their content. */
-export function recordResearchActivity(event: ResearchActivity, feature?: ResearchFeature): void {
+export function recordResearchActivity(
+  event: ResearchActivity,
+  feature?: ResearchFeature,
+): void {
   const target = getCurrentPluginTarget();
   const user = apiClient.getCurrentUser();
   if (target === "web" ? !anonymousId : !user) return;
@@ -43,11 +83,18 @@ export function recordResearchActivity(event: ResearchActivity, feature?: Resear
   if (sent.has(key)) return;
   sent.add(key);
   if (event !== "workspace_opened") recordResearchActivity("workspace_opened");
-  void apiClient.recordResearchActivity({ event, eventId: crypto.randomUUID(),
-    surface: target === "desktop" ? "desktop" : target,
-    anonymousId: target === "web" ? anonymousId : undefined,
-    attribution: target === "web" ? attribution : undefined, feature,
-  }).catch(() => { sent.delete(key); });
+  void apiClient
+    .recordResearchActivity({
+      event,
+      eventId: crypto.randomUUID(),
+      surface: target === "desktop" ? "desktop" : target,
+      anonymousId: target === "web" ? anonymousId : undefined,
+      attribution: target === "web" ? attribution : undefined,
+      feature,
+    })
+    .catch(() => {
+      sent.delete(key);
+    });
 }
 
 export function researchUpgradeUrl(returnTo?: string): string {
@@ -55,7 +102,8 @@ export function researchUpgradeUrl(returnTo?: string): string {
   if (returnTo) url.searchParams.set("returnTo", returnTo);
   if (anonymousId) url.searchParams.set("_gloom", anonymousId);
   for (const [key, value] of Object.entries(attribution)) {
-    if (/^(utm_(source|medium|campaign|content|term)|twclid)$/.test(key)) url.searchParams.set(key, value);
+    if (/^(utm_(source|medium|campaign|content|term)|twclid)$/.test(key))
+      url.searchParams.set(key, value);
   }
   return url.href;
 }

--- a/src/api-client/socket-health.test.ts
+++ b/src/api-client/socket-health.test.ts
@@ -10,7 +10,8 @@ function waitForStatus(
   health: ConnectionHealthRegistry,
   status: ConnectionHealthStatus,
 ): Promise<void> {
-  if (health.getSnapshot().sources[0]?.status === status) return Promise.resolve();
+  if (health.getSnapshot().sources[0]?.status === status)
+    return Promise.resolve();
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       unsubscribe();
@@ -32,7 +33,9 @@ describe("CloudApiSocket connection health", () => {
       hostname: "127.0.0.1",
       port: 0,
       fetch(request, server) {
-        return server.upgrade(request) ? undefined : new Response("Upgrade required", { status: 426 });
+        return server.upgrade(request)
+          ? undefined
+          : new Response("Upgrade required", { status: 426 });
       },
       websocket: {
         open(socket) {
@@ -47,16 +50,19 @@ describe("CloudApiSocket connection health", () => {
       name: "Gloom Cloud Stream",
       kind: "websocket",
     });
-    const socket = new CloudApiSocket({
-      getBaseUrl: () => `http://127.0.0.1:${server.port}`,
-      getSocketAuthToken: () => null,
-      hasSessionCredential: () => false,
-      hasVerifiedUser: () => false,
-      isUsingWebSocketToken: () => false,
-      clearWebSocketTokenForFallback: () => false,
-      markCurrentUserUnverified: () => {},
-      updateCurrentUserFromSocket: () => {},
-    }, health);
+    const socket = new CloudApiSocket(
+      {
+        getBaseUrl: () => `http://127.0.0.1:${server.port}`,
+        getSocketAuthToken: () => null,
+        hasSessionCredential: () => false,
+        hasVerifiedUser: () => false,
+        isUsingWebSocketToken: () => false,
+        clearWebSocketTokenForFallback: () => false,
+        markCurrentUserUnverified: () => {},
+        updateCurrentUserFromSocket: () => {},
+      },
+      health,
+    );
 
     try {
       socket.subscribeQuotes([{ symbol: "AAPL" }], () => {});

--- a/src/api-client/socket.ts
+++ b/src/api-client/socket.ts
@@ -7,10 +7,7 @@ import type {
   ScannerFeedEvent,
   ScannerKind,
 } from "./types";
-import {
-  normalizeChatMessage,
-  normalizeChatNotification,
-} from "./normalizers";
+import { normalizeChatMessage, normalizeChatNotification } from "./normalizers";
 import { debugLog } from "../utils/debug-log";
 import { canonicalExchange, normalizeSymbol } from "../utils/exchanges";
 import { mergeQuoteSubscriptionTargets } from "../market-data/quote-subscription-target";
@@ -26,7 +23,10 @@ const cloudApiLog = debugLog.createLogger("cloud-api");
 type ChannelListener = (message: ChatMessage) => void;
 type ChatNotificationListener = (notification: ChatNotification) => void;
 type ChatPresenceListener = (onlineCount: number) => void;
-type QuoteListener = (target: QuoteStreamTarget, quote: CloudQuotePayload) => void;
+type QuoteListener = (
+  target: QuoteStreamTarget,
+  quote: CloudQuotePayload,
+) => void;
 type QuoteSubscription = {
   target: QuoteStreamTarget;
   listener: QuoteListener;
@@ -58,14 +58,20 @@ type CloudApiSocketDelegate = {
 };
 
 type ChatChannelConnection = {
-  send: (content: string, replyToId?: string, clientMessageId?: string) => Promise<ChatMessage>;
+  send: (
+    content: string,
+    replyToId?: string,
+    clientMessageId?: string,
+  ) => Promise<ChatMessage>;
   close: () => void;
 };
 
 function marketKey(symbol: string, exchange?: string): string {
   const normalizedSymbolValue = normalizeSymbol(symbol);
   const normalizedExchangeValue = canonicalExchange(exchange);
-  return normalizedExchangeValue ? `${normalizedSymbolValue}:${normalizedExchangeValue}` : normalizedSymbolValue;
+  return normalizedExchangeValue
+    ? `${normalizedSymbolValue}:${normalizedExchangeValue}`
+    : normalizedSymbolValue;
 }
 
 export class CloudApiSocket {
@@ -74,15 +80,29 @@ export class CloudApiSocket {
   private reconnectDelayMs = 1000;
 
   private readonly channelListeners = new Map<string, Set<ChannelListener>>();
-  private readonly chatNotificationListeners = new Set<ChatNotificationListener>();
+  private readonly chatNotificationListeners =
+    new Set<ChatNotificationListener>();
   private readonly chatPresenceListeners = new Set<ChatPresenceListener>();
   private nextQuoteSubscriptionId = 1;
-  private readonly quoteSubscriptions = new Map<string, Map<number, QuoteSubscription>>();
+  private readonly quoteSubscriptions = new Map<
+    string,
+    Map<number, QuoteSubscription>
+  >();
   private readonly quoteTargets = new Map<string, QuoteStreamTarget>();
-  private readonly pendingQuoteSubscribes = new Map<string, QuoteStreamTarget>();
-  private readonly pendingQuoteUnsubscribes = new Map<string, QuoteStreamTarget>();
-  private quoteSubscriptionFlushTimer: ReturnType<typeof setTimeout> | null = null;
-  private readonly scannerListeners = new Map<ScannerKind, Set<ScannerListener>>();
+  private readonly pendingQuoteSubscribes = new Map<
+    string,
+    QuoteStreamTarget
+  >();
+  private readonly pendingQuoteUnsubscribes = new Map<
+    string,
+    QuoteStreamTarget
+  >();
+  private quoteSubscriptionFlushTimer: ReturnType<typeof setTimeout> | null =
+    null;
+  private readonly scannerListeners = new Map<
+    ScannerKind,
+    Set<ScannerListener>
+  >();
   /** Latest fan-out payload, so a pane opened mid-stream does not wait for the next tick. */
   private readonly scannerSnapshots = new Map<ScannerKind, ScannerFeedEvent>();
 
@@ -111,7 +131,11 @@ export class CloudApiSocket {
     this.ws = null;
     if (ws) {
       cloudApiLog.info("teardown websocket");
-      this.health.reportSocketState(GLOOM_CLOUD_SOCKET_CONNECTION_ID, "idle", "Socket closed locally");
+      this.health.reportSocketState(
+        GLOOM_CLOUD_SOCKET_CONNECTION_ID,
+        "idle",
+        "Socket closed locally",
+      );
     }
     try {
       ws?.close();
@@ -124,7 +148,11 @@ export class CloudApiSocket {
     channelId: string,
     onMessage: (msg: ChatMessage) => void,
     onError: ((err: string) => void) | undefined,
-    sendMessage: (content: string, replyToId?: string, clientMessageId?: string) => Promise<ChatMessage>,
+    sendMessage: (
+      content: string,
+      replyToId?: string,
+      clientMessageId?: string,
+    ) => Promise<ChatMessage>,
   ): ChatChannelConnection {
     if (!channelId) {
       return {
@@ -135,7 +163,8 @@ export class CloudApiSocket {
       };
     }
 
-    const listeners = this.channelListeners.get(channelId) ?? new Set<ChannelListener>();
+    const listeners =
+      this.channelListeners.get(channelId) ?? new Set<ChannelListener>();
     const firstListener = listeners.size === 0;
     listeners.add(onMessage);
     this.channelListeners.set(channelId, listeners);
@@ -145,9 +174,17 @@ export class CloudApiSocket {
     }
 
     return {
-      send: async (content: string, replyToId?: string, clientMessageId?: string) => {
+      send: async (
+        content: string,
+        replyToId?: string,
+        clientMessageId?: string,
+      ) => {
         try {
-          const message = await sendMessage(content, replyToId, clientMessageId);
+          const message = await sendMessage(
+            content,
+            replyToId,
+            clientMessageId,
+          );
           onMessage(message);
           return message;
         } catch (error) {
@@ -188,8 +225,12 @@ export class CloudApiSocket {
    * Subscribes to a shared server-computed scanner. Every open pane of the same
    * kind shares one upstream subscription; the socket fans the payload out.
    */
-  subscribeScanner(scanner: ScannerKind, listener: ScannerListener): () => void {
-    const listeners = this.scannerListeners.get(scanner) ?? new Set<ScannerListener>();
+  subscribeScanner(
+    scanner: ScannerKind,
+    listener: ScannerListener,
+  ): () => void {
+    const listeners =
+      this.scannerListeners.get(scanner) ?? new Set<ScannerListener>();
     const firstListener = listeners.size === 0;
     listeners.add(listener);
     this.scannerListeners.set(scanner, listeners);
@@ -220,34 +261,48 @@ export class CloudApiSocket {
     onQuote: (target: QuoteStreamTarget, quote: CloudQuotePayload) => void,
   ): () => void {
     const subscriptionId = this.nextQuoteSubscriptionId++;
-    const uniqueTargets = [...new Map(
-      targets
-        .filter((target) => typeof target.symbol === "string" && target.symbol.trim().length > 0)
-        .map((target) => {
-          const normalized = {
-            symbol: normalizeSymbol(target.symbol),
-            exchange: canonicalExchange(target.exchange),
-            surface: target.surface,
-            visible: target.visible,
-            selected: target.selected,
-            weight: target.weight,
-          } satisfies QuoteStreamTarget;
-          return [marketKey(normalized.symbol, normalized.exchange), normalized] as const;
-        }),
-    ).values()];
+    const uniqueTargets = [
+      ...new Map(
+        targets
+          .filter(
+            (target) =>
+              typeof target.symbol === "string" &&
+              target.symbol.trim().length > 0,
+          )
+          .map((target) => {
+            const normalized = {
+              symbol: normalizeSymbol(target.symbol),
+              exchange: canonicalExchange(target.exchange),
+              surface: target.surface,
+              visible: target.visible,
+              selected: target.selected,
+              weight: target.weight,
+            } satisfies QuoteStreamTarget;
+            return [
+              marketKey(normalized.symbol, normalized.exchange),
+              normalized,
+            ] as const;
+          }),
+      ).values(),
+    ];
 
     const newSubscriptions: QuoteStreamTarget[] = [];
     const updatedSubscriptions: QuoteStreamTarget[] = [];
     for (const target of uniqueTargets) {
       const key = marketKey(target.symbol, target.exchange);
-      const subscriptions = this.quoteSubscriptions.get(key) ?? new Map<number, QuoteSubscription>();
+      const subscriptions =
+        this.quoteSubscriptions.get(key) ??
+        new Map<number, QuoteSubscription>();
       const previousTarget = this.quoteTargets.get(key);
       subscriptions.set(subscriptionId, { target, listener: onQuote });
       this.quoteSubscriptions.set(key, subscriptions);
-      const mergedTarget = mergeQuoteStreamSubscriptions(subscriptions.values()) ?? target;
+      const mergedTarget =
+        mergeQuoteStreamSubscriptions(subscriptions.values()) ?? target;
       if (!previousTarget) {
         newSubscriptions.push(target);
-      } else if (!this.areQuoteStreamTargetsEquivalent(previousTarget, mergedTarget)) {
+      } else if (
+        !this.areQuoteStreamTargetsEquivalent(previousTarget, mergedTarget)
+      ) {
         updatedSubscriptions.push(mergedTarget);
       }
       this.quoteTargets.set(key, mergedTarget);
@@ -258,7 +313,9 @@ export class CloudApiSocket {
     if (subscriptionsToSend.length > 0) {
       cloudApiLog.info("register quote listeners", {
         count: subscriptionsToSend.length,
-        symbols: subscriptionsToSend.map((target) => marketKey(target.symbol, target.exchange)),
+        symbols: subscriptionsToSend.map((target) =>
+          marketKey(target.symbol, target.exchange),
+        ),
       });
       this.queueQuoteSubscribes(subscriptionsToSend);
     }
@@ -278,10 +335,15 @@ export class CloudApiSocket {
           this.quoteTargets.delete(key);
           continue;
         }
-        const mergedTarget = mergeQuoteStreamSubscriptions(subscriptions.values());
+        const mergedTarget = mergeQuoteStreamSubscriptions(
+          subscriptions.values(),
+        );
         if (!mergedTarget) continue;
         this.quoteTargets.set(key, mergedTarget);
-        if (previousTarget && !this.areQuoteStreamTargetsEquivalent(previousTarget, mergedTarget)) {
+        if (
+          previousTarget &&
+          !this.areQuoteStreamTargetsEquivalent(previousTarget, mergedTarget)
+        ) {
           updatedTargets.push(mergedTarget);
         }
       }
@@ -293,7 +355,9 @@ export class CloudApiSocket {
       if (removedTargets.length > 0) {
         cloudApiLog.info("remove quote listeners", {
           count: removedTargets.length,
-          symbols: removedTargets.map((target) => marketKey(target.symbol, target.exchange)),
+          symbols: removedTargets.map((target) =>
+            marketKey(target.symbol, target.exchange),
+          ),
         });
         this.queueQuoteUnsubscribes(removedTargets);
       }
@@ -335,16 +399,25 @@ export class CloudApiSocket {
     }
 
     if (parsed?.type === "ready" && parsed.user) {
-      cloudApiLog.info("websocket ready", { emailVerified: parsed.user.emailVerified === true });
-      this.delegate.updateCurrentUserFromSocket(parsed.user as Partial<AuthUser>);
+      cloudApiLog.info("websocket ready", {
+        emailVerified: parsed.user.emailVerified === true,
+      });
+      this.delegate.updateCurrentUserFromSocket(
+        parsed.user as Partial<AuthUser>,
+      );
       return;
     }
 
     if (parsed?.type === "auth.unverified") {
       cloudApiLog.warn("websocket marked unverified");
-      if (this.delegate.isUsingWebSocketToken() && this.delegate.clearWebSocketTokenForFallback()) {
+      if (
+        this.delegate.isUsingWebSocketToken() &&
+        this.delegate.clearWebSocketTokenForFallback()
+      ) {
         this.reconnectDelayMs = 1000;
-        cloudApiLog.warn("cleared websocket token after auth rejection; falling back to session token");
+        cloudApiLog.warn(
+          "cleared websocket token after auth rejection; falling back to session token",
+        );
         this.teardown();
         this.scheduleReconnect();
         return;
@@ -357,30 +430,43 @@ export class CloudApiSocket {
       return;
     }
 
-    if (parsed?.type === "chat.message" && typeof parsed.channelId === "string" && parsed.data) {
+    if (
+      parsed?.type === "chat.message" &&
+      typeof parsed.channelId === "string" &&
+      parsed.data
+    ) {
       const message = normalizeChatMessage(parsed.data as ChatMessage);
-      for (const listener of this.channelListeners.get(parsed.channelId) ?? []) {
+      for (const listener of this.channelListeners.get(parsed.channelId) ??
+        []) {
         listener(message);
       }
       return;
     }
 
     if (parsed?.type === "chat.notification" && parsed.data) {
-      const notification = normalizeChatNotification(parsed.data as ChatNotification);
+      const notification = normalizeChatNotification(
+        parsed.data as ChatNotification,
+      );
       for (const listener of this.chatNotificationListeners) {
         listener(notification);
       }
       return;
     }
 
-    if (parsed?.type === "chat.presence" && typeof parsed.onlineCount === "number") {
+    if (
+      parsed?.type === "chat.presence" &&
+      typeof parsed.onlineCount === "number"
+    ) {
       for (const listener of this.chatPresenceListeners) {
         listener(parsed.onlineCount);
       }
       return;
     }
 
-    const scannerKind = typeof parsed?.type === "string" ? SCANNER_MESSAGE_KINDS[parsed.type] : undefined;
+    const scannerKind =
+      typeof parsed?.type === "string"
+        ? SCANNER_MESSAGE_KINDS[parsed.type]
+        : undefined;
     if (scannerKind) {
       const { type: _type, ...payload } = parsed;
       this.emitScannerEvent(scannerKind, { type: "data", payload });
@@ -392,13 +478,18 @@ export class CloudApiSocket {
       if (denied) {
         this.emitScannerEvent(denied, {
           type: "denied",
-          reason: typeof parsed.reason === "string" ? parsed.reason : "pro_required",
+          reason:
+            typeof parsed.reason === "string" ? parsed.reason : "pro_required",
         });
       }
       return;
     }
 
-    if (parsed?.type === "market.quote" && parsed.quote && typeof parsed.symbol === "string") {
+    if (
+      parsed?.type === "market.quote" &&
+      parsed.quote &&
+      typeof parsed.symbol === "string"
+    ) {
       const key = marketKey(parsed.symbol, parsed.exchange);
       const quote: CloudQuotePayload = {
         ...(parsed.quote as CloudQuotePayload),
@@ -407,7 +498,8 @@ export class CloudApiSocket {
           : {}),
         ...(typeof parsed.stale === "boolean" ? { stale: parsed.stale } : {}),
       };
-      for (const subscription of this.quoteSubscriptions.get(key)?.values() ?? []) {
+      for (const subscription of this.quoteSubscriptions.get(key)?.values() ??
+        []) {
         subscription.listener(subscription.target, quote);
       }
     }
@@ -419,7 +511,10 @@ export class CloudApiSocket {
     return baseUrl.replace(/^https?/, wsProtocol);
   }
 
-  private emitScannerEvent(scanner: ScannerKind, event: ScannerFeedEvent): void {
+  private emitScannerEvent(
+    scanner: ScannerKind,
+    event: ScannerFeedEvent,
+  ): void {
     this.scannerSnapshots.set(scanner, event);
     for (const listener of this.scannerListeners.get(scanner) ?? []) {
       listener(event);
@@ -427,10 +522,13 @@ export class CloudApiSocket {
   }
 
   private shouldKeepSocketOpen(): boolean {
-    if (this.quoteTargets.size > 0 || this.scannerListeners.size > 0) return true;
-    return this.delegate.hasSessionCredential()
-      && this.delegate.hasVerifiedUser()
-      && this.channelListeners.size > 0;
+    if (this.quoteTargets.size > 0 || this.scannerListeners.size > 0)
+      return true;
+    return (
+      this.delegate.hasSessionCredential() &&
+      this.delegate.hasVerifiedUser() &&
+      this.channelListeners.size > 0
+    );
   }
 
   private ensureSocket(): void {
@@ -447,7 +545,11 @@ export class CloudApiSocket {
       quoteTargets: this.quoteTargets.size,
       channelTargets: this.channelListeners.size,
     });
-    this.health.reportSocketState(GLOOM_CLOUD_SOCKET_CONNECTION_ID, "connecting", this.getWebSocketBaseUrl());
+    this.health.reportSocketState(
+      GLOOM_CLOUD_SOCKET_CONNECTION_ID,
+      "connecting",
+      this.getWebSocketBaseUrl(),
+    );
     let ws: WebSocket;
     try {
       ws = new WebSocket(url);
@@ -464,7 +566,11 @@ export class CloudApiSocket {
     ws.onopen = () => {
       if (this.ws !== ws) return;
       cloudApiLog.info("websocket open");
-      this.health.reportSocketState(GLOOM_CLOUD_SOCKET_CONNECTION_ID, "open", this.getWebSocketBaseUrl());
+      this.health.reportSocketState(
+        GLOOM_CLOUD_SOCKET_CONNECTION_ID,
+        "open",
+        this.getWebSocketBaseUrl(),
+      );
       this.reconnectDelayMs = 1000;
       this.flushSubscriptions();
     };
@@ -490,11 +596,17 @@ export class CloudApiSocket {
       this.health.reportSocketState(
         GLOOM_CLOUD_SOCKET_CONNECTION_ID,
         "closed",
-        closeEvent?.reason || (closeEvent?.code ? `Closed (${closeEvent.code})` : "Socket closed"),
+        closeEvent?.reason ||
+          (closeEvent?.code ? `Closed (${closeEvent.code})` : "Socket closed"),
       );
-      if (usingWebSocketToken && this.delegate.clearWebSocketTokenForFallback()) {
+      if (
+        usingWebSocketToken &&
+        this.delegate.clearWebSocketTokenForFallback()
+      ) {
         this.reconnectDelayMs = 1000;
-        cloudApiLog.warn("cleared websocket token after socket close; falling back to session token");
+        cloudApiLog.warn(
+          "cleared websocket token after socket close; falling back to session token",
+        );
       }
       if (!this.shouldKeepSocketOpen()) return;
       this.scheduleReconnect();
@@ -502,7 +614,11 @@ export class CloudApiSocket {
 
     ws.onerror = () => {
       if (this.ws !== ws) return;
-      this.health.reportSocketState(GLOOM_CLOUD_SOCKET_CONNECTION_ID, "error", "WebSocket error");
+      this.health.reportSocketState(
+        GLOOM_CLOUD_SOCKET_CONNECTION_ID,
+        "error",
+        "WebSocket error",
+      );
       // Reconnect is handled by onclose.
     };
   }
@@ -519,15 +635,19 @@ export class CloudApiSocket {
 
   private sendSocketMessage(payload: unknown): void {
     if (this.ws?.readyState !== WebSocket.OPEN) return;
-    if (payload && typeof payload === "object" && "type" in (payload as Record<string, unknown>)) {
+    if (
+      payload &&
+      typeof payload === "object" &&
+      "type" in (payload as Record<string, unknown>)
+    ) {
       const type = (payload as Record<string, unknown>).type;
       if (
-        type === "market.subscribe"
-        || type === "market.unsubscribe"
-        || type === "chat.subscribe"
-        || type === "chat.unsubscribe"
-        || type === "scanner.subscribe"
-        || type === "scanner.unsubscribe"
+        type === "market.subscribe" ||
+        type === "market.unsubscribe" ||
+        type === "chat.subscribe" ||
+        type === "chat.unsubscribe" ||
+        type === "scanner.subscribe" ||
+        type === "scanner.unsubscribe"
       ) {
         cloudApiLog.info("send websocket message", payload);
       }
@@ -549,7 +669,9 @@ export class CloudApiSocket {
     if (this.quoteTargets.size > 0) {
       this.sendSocketMessage({
         type: "market.subscribe",
-        symbols: [...this.quoteTargets.values()].map((target) => this.serializeQuoteStreamTarget(target)),
+        symbols: [...this.quoteTargets.values()].map((target) =>
+          this.serializeQuoteStreamTarget(target),
+        ),
       });
     }
   }
@@ -593,18 +715,24 @@ export class CloudApiSocket {
     if (unsubscribes.length > 0) {
       this.sendSocketMessage({
         type: "market.unsubscribe",
-        symbols: unsubscribes.map((target) => this.serializeQuoteStreamTarget(target)),
+        symbols: unsubscribes.map((target) =>
+          this.serializeQuoteStreamTarget(target),
+        ),
       });
     }
     if (subscribes.length > 0) {
       this.sendSocketMessage({
         type: "market.subscribe",
-        symbols: subscribes.map((target) => this.serializeQuoteStreamTarget(target)),
+        symbols: subscribes.map((target) =>
+          this.serializeQuoteStreamTarget(target),
+        ),
       });
     }
   }
 
-  private serializeQuoteStreamTarget(target: QuoteStreamTarget): QuoteStreamTarget {
+  private serializeQuoteStreamTarget(
+    target: QuoteStreamTarget,
+  ): QuoteStreamTarget {
     return {
       symbol: target.symbol,
       exchange: target.exchange ?? "",
@@ -615,8 +743,13 @@ export class CloudApiSocket {
     };
   }
 
-  private areQuoteStreamTargetsEquivalent(left: QuoteStreamTarget, right: QuoteStreamTarget): boolean {
-    return JSON.stringify(this.serializeQuoteStreamTarget(left))
-      === JSON.stringify(this.serializeQuoteStreamTarget(right));
+  private areQuoteStreamTargetsEquivalent(
+    left: QuoteStreamTarget,
+    right: QuoteStreamTarget,
+  ): boolean {
+    return (
+      JSON.stringify(this.serializeQuoteStreamTarget(left)) ===
+      JSON.stringify(this.serializeQuoteStreamTarget(right))
+    );
   }
 }

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -561,6 +561,76 @@ export interface CloudProxyStatementPayload extends CloudProxyStatementSummaryPa
   otherYears: CloudProxyStatementSummaryPayload[];
 }
 
+export interface CloudRiskFactorPayload {
+  heading: string;
+  group: string | null;
+  excerpt: string;
+  words: number;
+}
+
+export interface CloudRiskNotePayload {
+  /** Position of the risk in `risks` (or in the prior year's list, for removed). */
+  index: number;
+  text: string;
+}
+
+export interface CloudRiskReportSummaryPayload {
+  id: string;
+  ticker: string;
+  company: {
+    ticker: string;
+    cik: string | null;
+    name: string;
+    shortName: string;
+  };
+  /** Year of the filing date: "the 2026 10-K". */
+  reportYear: number;
+  filedAt: string;
+  updatedAt: string;
+  riskCount: number;
+  groupCount: number;
+  wordCount: number;
+  addedCount: number | null;
+  removedCount: number | null;
+  rewordedCount: number | null;
+  overview: string | null;
+}
+
+export interface CloudRiskReportPayload extends CloudRiskReportSummaryPayload {
+  docUrl: string;
+  groups: string[];
+  risks: CloudRiskFactorPayload[];
+  diff: {
+    added: number[];
+    removed: Array<{ heading: string; group: string | null; excerpt: string }>;
+    reworded: Array<{
+      index: number;
+      similarity: number;
+      headingChanged: boolean;
+      priorHeading: string | null;
+    }>;
+    matched: number;
+    priorRiskCount: number;
+  } | null;
+  notes: {
+    added: CloudRiskNotePayload[];
+    removed: CloudRiskNotePayload[];
+    reworded: CloudRiskNotePayload[];
+    top: CloudRiskNotePayload[];
+  };
+  otherYears: CloudRiskReportSummaryPayload[];
+}
+
+export interface CloudRiskReportListPayload {
+  company: {
+    ticker: string;
+    cik: string | null;
+    name: string;
+    shortName: string;
+  };
+  reports: CloudRiskReportSummaryPayload[];
+}
+
 export interface CloudProxyStatementListPayload {
   company: {
     ticker: string;

--- a/src/plugins/builtin/risk-factors/data.ts
+++ b/src/plugins/builtin/risk-factors/data.ts
@@ -1,0 +1,122 @@
+import {
+  apiClient,
+  type CloudRiskReportListPayload,
+  type CloudRiskReportPayload,
+} from "../../../api-client";
+import type { PluginPersistence } from "../../../types/plugin";
+
+/**
+ * Risk factor reports come from Gloom Cloud's open reads. A report is built
+ * once per 10-K and does not change, so it is kept a long time; the list of
+ * years gains one a year.
+ */
+
+const LIST_KIND = "reports";
+const REPORT_KIND = "report";
+const CACHE_SOURCE = "risk-factors";
+const CACHE_SCHEMA_VERSION = 1;
+
+const LIST_CACHE_POLICY = {
+  staleMs: 6 * 60 * 60 * 1000,
+  expireMs: 30 * 24 * 60 * 60 * 1000,
+} as const;
+const REPORT_CACHE_POLICY = {
+  staleMs: 7 * 24 * 60 * 60 * 1000,
+  expireMs: 365 * 24 * 60 * 60 * 1000,
+} as const;
+
+let persistence: PluginPersistence | null = null;
+const activeListFetches = new Map<
+  string,
+  Promise<CloudRiskReportListPayload>
+>();
+const activeReportFetches = new Map<string, Promise<CloudRiskReportPayload>>();
+
+export function attachRiskFactorsPersistence(value: PluginPersistence): void {
+  persistence = value;
+}
+
+export function resetRiskFactorsPersistence(): void {
+  persistence = null;
+  activeListFetches.clear();
+  activeReportFetches.clear();
+}
+
+function cached<T>(kind: string, key: string, allowExpired = false) {
+  return persistence?.getResource<T>(kind, key, {
+    sourceKey: CACHE_SOURCE,
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    allowExpired,
+  });
+}
+
+function remember<T>(
+  kind: string,
+  key: string,
+  value: T,
+  policy: { staleMs: number; expireMs: number },
+) {
+  persistence?.setResource(kind, key, value, {
+    sourceKey: CACHE_SOURCE,
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    cachePolicy: policy,
+  });
+}
+
+export async function loadRiskReports(
+  ticker: string,
+  options?: { force?: boolean },
+): Promise<CloudRiskReportListPayload> {
+  const key = ticker.toUpperCase();
+  const force = options?.force ?? false;
+  const hit = cached<CloudRiskReportListPayload>(LIST_KIND, key);
+  if (!force && hit && !hit.stale) return hit.value;
+  const active = activeListFetches.get(key);
+  if (active && !force) return active;
+  const request = apiClient
+    .getRiskReports(key)
+    .then((payload) => {
+      remember(LIST_KIND, key, payload, LIST_CACHE_POLICY);
+      return payload;
+    })
+    .catch((error: unknown) => {
+      const expired = cached<CloudRiskReportListPayload>(LIST_KIND, key, true);
+      if (expired) return expired.value;
+      throw error;
+    })
+    .finally(() => {
+      if (activeListFetches.get(key) === request) activeListFetches.delete(key);
+    });
+  activeListFetches.set(key, request);
+  return request;
+}
+
+export async function loadRiskReport(
+  ticker: string,
+  year: number,
+  options?: { force?: boolean },
+): Promise<CloudRiskReportPayload> {
+  const key = `${ticker.toUpperCase()}:${year}`;
+  const force = options?.force ?? false;
+  const hit = cached<CloudRiskReportPayload>(REPORT_KIND, key);
+  if (!force && hit && !hit.stale) return hit.value;
+  const active = activeReportFetches.get(key);
+  if (active && !force) return active;
+  const request = apiClient
+    .getRiskReport(ticker, year)
+    .then((payload) => {
+      remember(REPORT_KIND, key, payload, REPORT_CACHE_POLICY);
+      return payload;
+    })
+    .catch((error: unknown) => {
+      const expired = cached<CloudRiskReportPayload>(REPORT_KIND, key, true);
+      if (expired) return expired.value;
+      throw error;
+    })
+    .finally(() => {
+      if (activeReportFetches.get(key) === request)
+        activeReportFetches.delete(key);
+    });
+  activeReportFetches.set(key, request);
+  return request;
+}

--- a/src/plugins/builtin/risk-factors/index.tsx
+++ b/src/plugins/builtin/risk-factors/index.tsx
@@ -1,0 +1,58 @@
+import type { PluginModule } from "../plugin-module";
+import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
+import {
+  attachRiskFactorsPersistence,
+  resetRiskFactorsPersistence,
+} from "./data";
+import { RISK_FACTORS_PANE_ID, RiskFactorsPane } from "./pane";
+
+const description =
+  "The company's 10-K risk factors, and what was added, dropped, or rewritten since the prior year.";
+
+export const riskFactorsModule: PluginModule = {
+  setup(ctx) {
+    attachRiskFactorsPersistence(ctx.persistence);
+    ctx.registerTickerResearchTab({
+      id: "risk-factors",
+      name: "Risks",
+      order: 36,
+      component: RiskFactorsPane,
+      isVisible: ({ ticker }) => !!ticker,
+    });
+  },
+
+  dispose() {
+    resetRiskFactorsPersistence();
+  },
+
+  panes: [
+    {
+      id: RISK_FACTORS_PANE_ID,
+      name: "Risk Factors",
+      icon: "R",
+      component: RiskFactorsPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 100, height: 30 },
+    },
+  ],
+
+  paneTemplates: [
+    createTickerSurfacePaneTemplate({
+      id: "risk-factors-pane",
+      paneId: RISK_FACTORS_PANE_ID,
+      label: "Risk Factors",
+      description,
+      keywords: [
+        "risk",
+        "risks",
+        "risk factors",
+        "10-k",
+        "annual report",
+        "item 1a",
+      ],
+      shortcut: "RISK",
+      publicShare: false,
+    }),
+  ],
+};

--- a/src/plugins/builtin/risk-factors/pane.tsx
+++ b/src/plugins/builtin/risk-factors/pane.tsx
@@ -1,0 +1,376 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  CloudRiskNotePayload,
+  CloudRiskReportPayload,
+  CloudRiskReportSummaryPayload,
+} from "../../../api-client";
+import {
+  EmptyState,
+  Spinner,
+  Tabs,
+  usePaneFooter,
+  type PaneFooterSegment,
+} from "../../../components";
+import { useShortcut } from "../../../react/input";
+import { colors } from "../../../theme/colors";
+import {
+  Box,
+  ScrollBox,
+  Text,
+  useRendererHost,
+  useUiCapabilities,
+  type ScrollBoxRenderable,
+} from "../../../ui";
+import { isPlainKey } from "../../../utils/keyboard";
+import { Prose, SectionHeading } from "../earnings-calls/transcript-view";
+import { useBoundTicker } from "../shared/ticker-request";
+import { loadRiskReport, loadRiskReports } from "./data";
+
+export const RISK_FACTORS_PANE_ID = "risk-factors";
+
+const MAX_PROSE_WIDTH = 100;
+
+function noteFor(
+  notes: CloudRiskNotePayload[],
+  index: number,
+): string | undefined {
+  return notes.find((note) => note.index === index)?.text;
+}
+
+/** A risk heading, its group, and the model's line under it. */
+function RiskLine({
+  tag,
+  group,
+  heading,
+  note,
+  width,
+  nativePaneChrome,
+}: {
+  tag: string;
+  group: string | null;
+  heading: string;
+  note?: string;
+  width: number;
+  nativePaneChrome: boolean;
+}) {
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Box height={1} flexDirection="row" gap={1} overflow="hidden">
+        <Text fg={colors.textBright}>{tag}</Text>
+        {group ? <Text fg={colors.textDim}>{group}</Text> : null}
+      </Box>
+      <Prose
+        text={heading}
+        width={width}
+        color={colors.text}
+        nativePaneChrome={nativePaneChrome}
+      />
+      {note ? (
+        <Prose
+          text={note}
+          width={width}
+          color={colors.textDim}
+          nativePaneChrome={nativePaneChrome}
+          prefix="  "
+        />
+      ) : null}
+    </Box>
+  );
+}
+
+export function RiskFactorsPane({
+  focused,
+  width,
+}: {
+  focused: boolean;
+  width: number;
+  height: number;
+}) {
+  const { symbol } = useBoundTicker();
+  const ticker = symbol ? symbol.toUpperCase() : null;
+  const nativePaneChrome = useUiCapabilities().nativePaneChrome === true;
+  const rendererHost = useRendererHost();
+
+  const [years, setYears] = useState<CloudRiskReportSummaryPayload[]>([]);
+  const [year, setYear] = useState<number | null>(null);
+  const [report, setReport] = useState<CloudRiskReportPayload | null>(null);
+  const [status, setStatus] = useState<
+    "idle" | "loading" | "loaded" | "none" | "error"
+  >("idle");
+  const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null);
+
+  useEffect(() => {
+    if (!ticker) return;
+    let cancelled = false;
+    setStatus("loading");
+    setReport(null);
+    loadRiskReports(ticker)
+      .then((payload) => {
+        if (cancelled) return;
+        setYears(payload.reports);
+        setYear(payload.reports[0]?.reportYear ?? null);
+        setStatus(payload.reports.length > 0 ? "loaded" : "none");
+      })
+      .catch((caught: unknown) => {
+        if (cancelled) return;
+        const message =
+          caught instanceof Error ? caught.message : String(caught);
+        if (/404|not found|no risk/i.test(message)) {
+          setYears([]);
+          setStatus("none");
+          return;
+        }
+        setError(message);
+        setStatus("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ticker]);
+
+  useEffect(() => {
+    if (!ticker || year === null) return;
+    let cancelled = false;
+    loadRiskReport(ticker, year)
+      .then((payload) => {
+        if (!cancelled) setReport(payload);
+      })
+      .catch((caught: unknown) => {
+        if (!cancelled)
+          setError(caught instanceof Error ? caught.message : String(caught));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ticker, year]);
+
+  useEffect(() => {
+    const scrollBox = scrollRef.current;
+    if (scrollBox) scrollBox.scrollTop = 0;
+  }, [year]);
+
+  const openFiling = useCallback(() => {
+    if (report?.docUrl) void rendererHost.openExternal(report.docUrl);
+  }, [rendererHost, report]);
+
+  const scrollBy = useCallback((delta: number) => {
+    const scrollBox = scrollRef.current;
+    if (!scrollBox?.viewport) return;
+    const max = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height);
+    scrollBox.scrollTop = Math.max(
+      0,
+      Math.min(max, scrollBox.scrollTop + delta),
+    );
+  }, []);
+
+  useShortcut(
+    (event) => {
+      if (isPlainKey(event, "o")) openFiling();
+      else if (isPlainKey(event, "j", "down")) scrollBy(1);
+      else if (isPlainKey(event, "k", "up")) scrollBy(-1);
+    },
+    { enabled: focused, scope: "risk-factors" },
+  );
+
+  usePaneFooter(RISK_FACTORS_PANE_ID, () => {
+    const info: PaneFooterSegment[] = [];
+    if (status === "loading")
+      info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
+    if (report) {
+      info.push({
+        id: "count",
+        parts: [{ text: `${report.riskCount} risks`, tone: "muted" }],
+      });
+    }
+    const hints = report
+      ? [{ id: "open", key: "o", label: "pen filing", onPress: openFiling }]
+      : [];
+    return { info, hints };
+  }, [status, report, openFiling]);
+
+  const bodyWidth = Math.max(12, width - 2);
+  const proseWidth = Math.min(bodyWidth, MAX_PROSE_WIDTH);
+
+  if (!ticker)
+    return <EmptyState title="Pick a ticker to see its risk factors." />;
+  if (status === "loading" && !report) {
+    return (
+      <Box flexGrow={1} alignItems="center" justifyContent="center">
+        <Spinner label="Loading risk factors..." />
+      </Box>
+    );
+  }
+  if (status === "none") {
+    return (
+      <EmptyState
+        title={`No 10-K risk factors on file for ${ticker}.`}
+        message="Reports are built from Item 1A of each annual report on Form 10-K. Foreign filers report on Form 20-F and are not covered yet."
+      />
+    );
+  }
+  if (status === "error")
+    return (
+      <EmptyState title="Could not load risk factors." message={error ?? ""} />
+    );
+
+  const diff = report?.diff ?? null;
+  const summaryLine = report
+    ? [
+        `${report.reportYear} 10-K`,
+        `${report.riskCount} risks in ${report.groupCount} groups`,
+        diff
+          ? `${diff.added.length} new, ${diff.removed.length} dropped, ${diff.reworded.length} reworded vs prior year`
+          : "no prior year on file",
+      ].join("  ·  ")
+    : "";
+
+  return (
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      flexShrink={1}
+      flexBasis={0}
+      minHeight={0}
+      overflow="hidden"
+    >
+      {years.length > 1 && (
+        <Box height={1} flexShrink={0} paddingX={1} overflow="hidden">
+          <Tabs
+            tabs={years.map((entry) => ({
+              label: `${entry.reportYear} 10-K`,
+              value: String(entry.reportYear),
+            }))}
+            activeValue={year === null ? "" : String(year)}
+            onSelect={(value) => setYear(Number(value))}
+            compact
+            variant="bare"
+            focused={focused}
+          />
+        </Box>
+      )}
+      <ScrollBox
+        ref={scrollRef}
+        flexGrow={1}
+        flexShrink={1}
+        flexBasis={0}
+        minHeight={0}
+        paddingX={1}
+      >
+        {report ? (
+          <Box
+            flexDirection="column"
+            width={nativePaneChrome ? "100%" : bodyWidth}
+          >
+            <Prose
+              text={summaryLine}
+              width={proseWidth}
+              color={colors.textDim}
+              nativePaneChrome={nativePaneChrome}
+            />
+            {report.overview ? (
+              <Box flexDirection="column">
+                <SectionHeading
+                  title={diff ? "WHAT THE CHANGES SAY" : "WHAT DOMINATES"}
+                />
+                {report.overview.split("\n").map((point) => (
+                  <Prose
+                    key={point}
+                    text={point}
+                    width={proseWidth}
+                    color={colors.text}
+                    nativePaneChrome={nativePaneChrome}
+                    prefix="• "
+                  />
+                ))}
+              </Box>
+            ) : null}
+            {diff ? (
+              <Box flexDirection="column">
+                <SectionHeading title="WHAT CHANGED" />
+                {diff.added.length === 0 &&
+                diff.removed.length === 0 &&
+                diff.reworded.length === 0 ? (
+                  <Prose
+                    text="Every risk carried over with its text substantially unchanged."
+                    width={proseWidth}
+                    color={colors.textDim}
+                    nativePaneChrome={nativePaneChrome}
+                  />
+                ) : null}
+                {diff.added.map((index) => (
+                  <RiskLine
+                    key={`new-${index}`}
+                    tag="NEW"
+                    group={report.risks[index]?.group ?? null}
+                    heading={report.risks[index]?.heading ?? ""}
+                    note={noteFor(report.notes.added, index)}
+                    width={proseWidth}
+                    nativePaneChrome={nativePaneChrome}
+                  />
+                ))}
+                {diff.removed.map((risk, index) => (
+                  <RiskLine
+                    key={`dropped-${risk.heading}`}
+                    tag="DROPPED"
+                    group={risk.group}
+                    heading={risk.heading}
+                    note={noteFor(report.notes.removed, index)}
+                    width={proseWidth}
+                    nativePaneChrome={nativePaneChrome}
+                  />
+                ))}
+                {diff.reworded.map((item) => (
+                  <RiskLine
+                    key={`reworded-${item.index}`}
+                    tag={`${Math.round((1 - item.similarity) * 100)}% REWRITTEN`}
+                    group={report.risks[item.index]?.group ?? null}
+                    heading={report.risks[item.index]?.heading ?? ""}
+                    note={noteFor(report.notes.reworded, item.index)}
+                    width={proseWidth}
+                    nativePaneChrome={nativePaneChrome}
+                  />
+                ))}
+              </Box>
+            ) : report.notes.top.length > 0 ? (
+              <Box flexDirection="column">
+                <SectionHeading title="MOST SPECIFIC TO THE COMPANY" />
+                {report.notes.top.map((note) => (
+                  <RiskLine
+                    key={`top-${note.index}`}
+                    tag={String(note.index + 1).padStart(2, "0")}
+                    group={report.risks[note.index]?.group ?? null}
+                    heading={report.risks[note.index]?.heading ?? ""}
+                    note={note.text}
+                    width={proseWidth}
+                    nativePaneChrome={nativePaneChrome}
+                  />
+                ))}
+              </Box>
+            ) : null}
+            <Box flexDirection="column">
+              <SectionHeading title={`ALL ${report.riskCount} RISK FACTORS`} />
+              {report.risks.map((risk, index) => (
+                <Prose
+                  key={`${index}-${risk.heading}`}
+                  text={risk.heading}
+                  width={proseWidth}
+                  color={colors.text}
+                  nativePaneChrome={nativePaneChrome}
+                  prefix={`${String(index + 1).padStart(2, "0")} `}
+                />
+              ))}
+            </Box>
+            <Box height={1} marginTop={1}>
+              <Text fg={colors.textDim}>
+                Headings are the filing's own. Press o to open the 10-K.
+              </Text>
+            </Box>
+          </Box>
+        ) : (
+          <Spinner label="Loading..." />
+        )}
+      </ScrollBox>
+    </Box>
+  );
+}

--- a/src/plugins/builtin/ticker-research-plugin.ts
+++ b/src/plugins/builtin/ticker-research-plugin.ts
@@ -7,6 +7,7 @@ import { optionsModule } from "./options";
 import { optionsCalculatorModule } from "./options-calculator";
 import { composeBuiltinPlugin } from "./plugin-module";
 import { researchModule } from "./research";
+import { riskFactorsModule } from "./risk-factors";
 import { secModule } from "./sec";
 import { shortInterestModule } from "./short-interest";
 import { thirteenFModule } from "./thirteenf";
@@ -31,5 +32,6 @@ export const tickerResearchPlugin = composeBuiltinPlugin({
     secModule,
     insiderModule,
     executivesModule,
+    riskFactorsModule,
   ],
 });

--- a/src/plugins/catalog-browser.ts
+++ b/src/plugins/catalog-browser.ts
@@ -6,6 +6,7 @@ import type { GloomPlugin } from "../types/plugin";
 import { portfolioAnalyticsModule } from "./builtin/analytics";
 import { earningsCallsModule } from "./builtin/earnings-calls";
 import { executivesModule } from "./builtin/executives";
+import { riskFactorsModule } from "./builtin/risk-factors";
 import { researchSearchPlugin } from "./builtin/research-search";
 import { alertsPlugin } from "./builtin/alerts";
 import { browserGloomberbCloudPlugin } from "./builtin/cloud/browser";
@@ -73,6 +74,7 @@ const browserTickerResearchPlugin = composeBuiltinPlugin({
     researchModule,
     earningsCallsModule,
     executivesModule,
+    riskFactorsModule,
   ],
 });
 

--- a/src/plugins/ownership.ts
+++ b/src/plugins/ownership.ts
@@ -16,6 +16,7 @@ const BUILTIN_PLUGIN_OWNER_ALIASES: Record<string, string> = {
   insider: "ticker-research",
   "dividend-yield": "ticker-research",
   executives: "ticker-research",
+  "risk-factors": "ticker-research",
   "short-interest": "ticker-research",
   "kelly-sizer": "portfolio",
   "layout-manager": "application",


### PR DESCRIPTION
Stacked on #738. Adds a `Risks` research tab (order 36) and `RISK <ticker>` pane reading Gloom Cloud's open `/public/risks` endpoints: counts, what the changes say, new / dropped / rewritten risks with the model's one-line reading, and every heading in filing order. Year switcher, `o` opens the 10-K.

Deep link: `term.gloom.sh/?ticker=PAYX&tab=risk-factors`; the risk factor pages on gloom.sh point here.