### PR TITLE
Add an 8-K tab: the company's current reports, classified and read

### DIFF
--- a/src/api-client/data.ts
+++ b/src/api-client/data.ts
@@ -12,6 +12,7 @@ import {
   cloudEarningsCallsPath,
   cloudEarningsTranscriptPath,
   publicProxyStatementPath,
+  publicFilingEventsPath,
   publicRiskReportPath,
   publicRiskReportsPath,
   publicProxyStatementsPath,
@@ -57,6 +58,7 @@ import type {
   CloudEarningsTranscriptPayload,
   CloudProxyStatementListPayload,
   CloudProxyStatementPayload,
+  CloudFilingEventPayload,
   CloudRiskReportListPayload,
   CloudRiskReportPayload,
   CloudCorporateActionsPayload,
@@ -361,6 +363,15 @@ export class CloudDataApi {
   ): Promise<CloudProxyStatementPayload> {
     return this.request<CloudProxyStatementPayload>(
       publicProxyStatementPath(ticker, year),
+    );
+  }
+
+  async getFilingEvents(
+    ticker: string,
+    limit?: number,
+  ): Promise<{ ticker: string; events: CloudFilingEventPayload[] }> {
+    return this.request<{ ticker: string; events: CloudFilingEventPayload[] }>(
+      publicFilingEventsPath(ticker, limit),
     );
   }
 

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -58,6 +58,7 @@ import type {
   CloudEarningsTranscriptPayload,
   CloudProxyStatementListPayload,
   CloudProxyStatementPayload,
+  CloudFilingEventPayload,
   CloudRiskReportListPayload,
   CloudRiskReportPayload,
   CloudNewsPayload,
@@ -918,6 +919,13 @@ class GloomApiClient {
     year: number,
   ): Promise<CloudProxyStatementPayload> {
     return this.data.getProxyStatement(ticker, year);
+  }
+
+  async getFilingEvents(
+    ticker: string,
+    limit?: number,
+  ): Promise<{ ticker: string; events: CloudFilingEventPayload[] }> {
+    return this.data.getFilingEvents(ticker, limit);
   }
 
   async getRiskReports(ticker: string): Promise<CloudRiskReportListPayload> {

--- a/src/api-client/paths.ts
+++ b/src/api-client/paths.ts
@@ -253,6 +253,15 @@ export function publicProxyStatementsPath(ticker: string): string {
   return `/public/proxies/${encodeURIComponent(ticker.toUpperCase())}`;
 }
 
+export function publicFilingEventsPath(ticker: string, limit?: number): string {
+  const search = new URLSearchParams();
+  if (limit != null) search.set("limit", String(limit));
+  return appendQuery(
+    `/public/events/${encodeURIComponent(ticker.toUpperCase())}`,
+    search,
+  );
+}
+
 export function publicRiskReportsPath(ticker: string): string {
   return `/public/risks/${encodeURIComponent(ticker.toUpperCase())}`;
 }

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -631,6 +631,36 @@ export interface CloudRiskReportListPayload {
   reports: CloudRiskReportSummaryPayload[];
 }
 
+export interface CloudFilingPersonPayload {
+  name: string;
+  role: string;
+  action: string;
+  effective: string | null;
+}
+
+/** An 8-K, classified by its items and, when it carried news, read. */
+export interface CloudFilingEventPayload {
+  id: string;
+  ticker: string;
+  company: {
+    ticker: string;
+    cik: string | null;
+    name: string;
+    shortName: string;
+  };
+  filedAt: string;
+  docUrl: string;
+  items: string[];
+  labels: string[];
+  kinds: string[];
+  material: boolean;
+  headline: string | null;
+  summary: string | null;
+  people: CloudFilingPersonPayload[];
+  /** True when the headline and points are the model's reading rather than the item labels. */
+  read: boolean;
+}
+
 export interface CloudProxyStatementListPayload {
   company: {
     ticker: string;

--- a/src/plugins/builtin/filing-events/index.tsx
+++ b/src/plugins/builtin/filing-events/index.tsx
@@ -1,0 +1,51 @@
+import type { PluginModule } from "../plugin-module";
+import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
+import { FILING_EVENTS_PANE_ID, FilingEventsPane } from "./pane";
+
+const description =
+  "The company's 8-K filings, classified by item and read: agreements, executive changes, auditor changes, restructurings, and what each said.";
+
+export const filingEventsModule: PluginModule = {
+  setup(ctx) {
+    ctx.registerTickerResearchTab({
+      id: "filing-events",
+      name: "8-K",
+      order: 37,
+      component: FilingEventsPane,
+      isVisible: ({ ticker }) => !!ticker,
+    });
+  },
+
+  panes: [
+    {
+      id: FILING_EVENTS_PANE_ID,
+      name: "8-K Filings",
+      icon: "K",
+      component: FilingEventsPane,
+      defaultPosition: "right",
+      defaultMode: "floating",
+      defaultFloatingSize: { width: 100, height: 30 },
+      tableExport: true,
+    },
+  ],
+
+  paneTemplates: [
+    createTickerSurfacePaneTemplate({
+      id: "filing-events-pane",
+      paneId: FILING_EVENTS_PANE_ID,
+      label: "8-K Filings",
+      description,
+      keywords: [
+        "8-k",
+        "8k",
+        "current report",
+        "events",
+        "material",
+        "filings",
+        "executive change",
+      ],
+      shortcut: "EK",
+      publicShare: false,
+    }),
+  ],
+};

--- a/src/plugins/builtin/filing-events/pane.tsx
+++ b/src/plugins/builtin/filing-events/pane.tsx
@@ -1,0 +1,295 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { CloudFilingEventPayload } from "../../../api-client";
+import { apiClient } from "../../../api-client";
+import {
+  DataTableStackView,
+  EmptyState,
+  Spinner,
+  usePaneFooter,
+  type DataTableCell,
+  type DataTableKeyEvent,
+  type PaneFooterSegment,
+} from "../../../components";
+import { colors } from "../../../theme/colors";
+import { Box, Text, useRendererHost, useUiCapabilities } from "../../../ui";
+import { isPlainKey } from "../../../utils/keyboard";
+import { Prose, SectionHeading } from "../earnings-calls/transcript-view";
+import { useBoundTicker } from "../shared/ticker-request";
+
+export const FILING_EVENTS_PANE_ID = "filing-events";
+
+interface EventColumn {
+  id: string;
+  label: string;
+  width: number;
+  align: "left" | "right";
+}
+
+function buildColumns(width: number): EventColumn[] {
+  const dateWidth = 9;
+  const itemsWidth = 11;
+  const headlineWidth = Math.max(16, width - dateWidth - itemsWidth - 6);
+  return [
+    { id: "date", label: "FILED", width: dateWidth, align: "left" },
+    { id: "items", label: "ITEMS", width: itemsWidth, align: "left" },
+    {
+      id: "headline",
+      label: "WHAT HAPPENED",
+      width: headlineWidth,
+      align: "left",
+    },
+  ];
+}
+
+function formatFiled(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "2-digit",
+  });
+}
+
+/** The items that say something; exhibits are on every filing. */
+function itemCodes(event: CloudFilingEventPayload): string {
+  return event.items.filter((code) => code !== "9.01").join(" ") || "—";
+}
+
+function renderCell(
+  event: CloudFilingEventPayload,
+  column: EventColumn,
+): DataTableCell {
+  switch (column.id) {
+    case "date":
+      return { text: formatFiled(event.filedAt), color: colors.textDim };
+    case "items":
+      return {
+        text: itemCodes(event),
+        color: event.material ? colors.warning : colors.textDim,
+      };
+    case "headline":
+      return {
+        text: event.headline ?? event.labels.join(", "),
+        color: event.read ? colors.textBright : colors.text,
+      };
+    default:
+      return { text: "" };
+  }
+}
+
+export function FilingEventsPane({
+  focused,
+  width,
+  height,
+}: {
+  focused: boolean;
+  width: number;
+  height: number;
+}) {
+  const { symbol } = useBoundTicker();
+  const ticker = symbol ? symbol.toUpperCase() : null;
+  const nativePaneChrome = useUiCapabilities().nativePaneChrome === true;
+  const rendererHost = useRendererHost();
+
+  const [events, setEvents] = useState<CloudFilingEventPayload[]>([]);
+  const [status, setStatus] = useState<"idle" | "loading" | "loaded" | "error">(
+    "idle",
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+
+  useEffect(() => {
+    if (!ticker) return;
+    let cancelled = false;
+    setStatus("loading");
+    apiClient
+      .getFilingEvents(ticker, 100)
+      .then((payload) => {
+        if (cancelled) return;
+        setEvents(payload.events);
+        setStatus("loaded");
+      })
+      .catch((caught: unknown) => {
+        if (cancelled) return;
+        setError(caught instanceof Error ? caught.message : String(caught));
+        setStatus("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ticker]);
+
+  const selected = useMemo(
+    () => events.find((event) => event.id === selectedId) ?? null,
+    [events, selectedId],
+  );
+  const columns = useMemo(() => buildColumns(width), [width]);
+
+  const openFiling = useCallback(() => {
+    if (selected?.docUrl) void rendererHost.openExternal(selected.docUrl);
+  }, [rendererHost, selected]);
+
+  const handleKey = useCallback(
+    (event: DataTableKeyEvent) => {
+      if (isPlainKey(event, "o")) {
+        openFiling();
+        return true;
+      }
+      return false;
+    },
+    [openFiling],
+  );
+
+  usePaneFooter(FILING_EVENTS_PANE_ID, () => {
+    const info: PaneFooterSegment[] = [];
+    if (status === "loading")
+      info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
+    const material = events.filter((event) => event.material).length;
+    if (events.length > 0) {
+      info.push({
+        id: "count",
+        parts: [
+          {
+            text: `${events.length} filings, ${material} with news`,
+            tone: "muted",
+          },
+        ],
+      });
+    }
+    const hints = selected
+      ? [{ id: "open", key: "o", label: "pen filing", onPress: openFiling }]
+      : [];
+    return { info, hints };
+  }, [status, events, selected, openFiling]);
+
+  if (!ticker)
+    return <EmptyState title="Pick a ticker to see its 8-K filings." />;
+  if (status === "loading" && events.length === 0) {
+    return (
+      <Box flexGrow={1} alignItems="center" justifyContent="center">
+        <Spinner label="Loading 8-Ks..." />
+      </Box>
+    );
+  }
+  if (status === "error")
+    return (
+      <EmptyState title="Could not load 8-K filings." message={error ?? ""} />
+    );
+  if (status === "loaded" && events.length === 0) {
+    return (
+      <EmptyState
+        title={`No 8-K on file for ${ticker} in the last six months.`}
+      />
+    );
+  }
+
+  const proseWidth = Math.min(Math.max(12, width - 2), 100);
+  const detail = selected ? (
+    <Box flexDirection="column" flexGrow={1} paddingX={1}>
+      <Prose
+        text={[
+          formatFiled(selected.filedAt),
+          ...selected.labels.filter((label) => label !== "Exhibits"),
+        ].join("  ·  ")}
+        width={proseWidth}
+        color={colors.textDim}
+        nativePaneChrome={nativePaneChrome}
+      />
+      {selected.headline ? (
+        <Box marginTop={1}>
+          <Prose
+            text={selected.headline}
+            width={proseWidth}
+            color={colors.textBright}
+            nativePaneChrome={nativePaneChrome}
+          />
+        </Box>
+      ) : null}
+      {selected.summary ? (
+        <Box flexDirection="column" marginTop={1}>
+          {selected.summary.split("\n").map((point) => (
+            <Prose
+              key={point}
+              text={point}
+              width={proseWidth}
+              color={colors.text}
+              nativePaneChrome={nativePaneChrome}
+              prefix="• "
+            />
+          ))}
+        </Box>
+      ) : null}
+      {selected.people.length > 0 ? (
+        <Box flexDirection="column">
+          <SectionHeading title="PEOPLE" />
+          {selected.people.map((person) => (
+            <Prose
+              key={`${person.name}-${person.action}`}
+              text={[
+                person.role,
+                person.action,
+                person.effective ? `effective ${person.effective}` : null,
+              ]
+                .filter(Boolean)
+                .join(", ")}
+              width={proseWidth}
+              color={colors.textDim}
+              nativePaneChrome={nativePaneChrome}
+              prefix={`${person.name}  `}
+              prefixColor={colors.textBright}
+            />
+          ))}
+        </Box>
+      ) : null}
+      {!selected.read ? (
+        <Box marginTop={1}>
+          <Text fg={colors.textDim}>
+            Routine filing; the headline is the item label. Press o to read it.
+          </Text>
+        </Box>
+      ) : (
+        <Box marginTop={1}>
+          <Text fg={colors.textDim}>
+            Read from the filing by a model; names checked against the text.
+            Press o to open it.
+          </Text>
+        </Box>
+      )}
+    </Box>
+  ) : null;
+
+  return (
+    <DataTableStackView<CloudFilingEventPayload, EventColumn>
+      focused={focused}
+      detailOpen={detailOpen && !!selected}
+      onBack={() => setDetailOpen(false)}
+      detailContent={detail}
+      detailTitle={
+        selected
+          ? `${formatFiled(selected.filedAt)}  ${itemCodes(selected)}`
+          : undefined
+      }
+      onRootKeyDown={handleKey}
+      onDetailKeyDown={handleKey}
+      selection={{
+        kind: "id",
+        selectedId,
+        getId: (event) => event.id,
+        onChange: setSelectedId,
+      }}
+      onActivate={() => setDetailOpen(true)}
+      rootWidth={width}
+      rootHeight={Math.max(2, height)}
+      columns={columns}
+      items={events}
+      sortColumnId="date"
+      sortDirection="desc"
+      onHeaderClick={() => {}}
+      getItemKey={(event) => event.id}
+      renderCell={renderCell}
+      emptyStateTitle="No filings."
+    />
+  );
+}

--- a/src/plugins/builtin/ticker-research-plugin.ts
+++ b/src/plugins/builtin/ticker-research-plugin.ts
@@ -1,6 +1,7 @@
 import { chartComposerModule } from "./chart-composer";
 import { dividendYieldModule } from "./dividend-yield";
 import { executivesModule } from "./executives";
+import { filingEventsModule } from "./filing-events";
 import { holdersModule } from "./holders";
 import { insiderModule } from "./insider";
 import { optionsModule } from "./options";
@@ -33,5 +34,6 @@ export const tickerResearchPlugin = composeBuiltinPlugin({
     insiderModule,
     executivesModule,
     riskFactorsModule,
+    filingEventsModule,
   ],
 });

--- a/src/plugins/catalog-browser.ts
+++ b/src/plugins/catalog-browser.ts
@@ -6,6 +6,7 @@ import type { GloomPlugin } from "../types/plugin";
 import { portfolioAnalyticsModule } from "./builtin/analytics";
 import { earningsCallsModule } from "./builtin/earnings-calls";
 import { executivesModule } from "./builtin/executives";
+import { filingEventsModule } from "./builtin/filing-events";
 import { riskFactorsModule } from "./builtin/risk-factors";
 import { researchSearchPlugin } from "./builtin/research-search";
 import { alertsPlugin } from "./builtin/alerts";
@@ -75,6 +76,7 @@ const browserTickerResearchPlugin = composeBuiltinPlugin({
     earningsCallsModule,
     executivesModule,
     riskFactorsModule,
+    filingEventsModule,
   ],
 });
 

--- a/src/plugins/ownership.ts
+++ b/src/plugins/ownership.ts
@@ -16,6 +16,7 @@ const BUILTIN_PLUGIN_OWNER_ALIASES: Record<string, string> = {
   insider: "ticker-research",
   "dividend-yield": "ticker-research",
   executives: "ticker-research",
+  "filing-events": "ticker-research",
   "risk-factors": "ticker-research",
   "short-interest": "ticker-research",
   "kelly-sizer": "portfolio",


### PR DESCRIPTION
Stacked on #739. Adds an `8-K` research tab (order 37) and `EK <ticker>` pane reading Gloom Cloud's open `/public/events/:ticker`: a table of filed date, item codes (material ones highlighted), and headline; the detail carries the model's points, the people named on executive changes, and `o` to open the filing.

Deep link: `term.gloom.sh/?ticker=IRT&tab=filing-events`.