### PR TITLE
Stop hiding closed-market and delayed quotes as too old

### DIFF
--- a/src/market-data/quotes/freshness.ts
+++ b/src/market-data/quotes/freshness.ts
@@ -4,7 +4,7 @@ import { isTimestampStaleForExchangeSession } from "../market/freshness";
 
 const EXTENDED_HOURS_EXCHANGES = new Set(["NASDAQ", "NYSE", "AMEX", "ARCA", "BATS"]);
 
-function isExtendedHoursExchange(quote: Quote): boolean {
+export function isExtendedHoursExchange(quote: Quote): boolean {
   return EXTENDED_HOURS_EXCHANGES.has(canonicalExchange(quote.listingExchangeName || quote.exchangeName));
 }
 

--- a/src/sources/provider-router/financials.test.ts
+++ b/src/sources/provider-router/financials.test.ts
@@ -36,6 +36,43 @@ describe("provider-router financial quote usability", () => {
     ).toBe(true);
   });
 
+  test("keeps a delayed quote the server cache has aged past twenty minutes", () => {
+    expect(isProviderQuoteUsableForCurrentSession(makeQuote({
+      dataSource: "delayed",
+      listingExchangeName: "NASDAQ",
+      marketState: "REGULAR",
+      lastUpdated: Date.now() - 25 * 60_000,
+    }), "NASDAQ")).toBe(true);
+  });
+
+  test("still rejects a delayed quote the provider stopped updating", () => {
+    expect(isProviderQuoteUsableForCurrentSession(makeQuote({
+      dataSource: "delayed",
+      listingExchangeName: "NASDAQ",
+      marketState: "REGULAR",
+      lastUpdated: Date.now() - 35 * 60_000,
+    }), "NASDAQ")).toBe(false);
+  });
+
+  test("keeps a closed Asian index that Yahoo still labels POST hours after the close", () => {
+    expect(isProviderQuoteUsableForCurrentSession(makeQuote({
+      symbol: "^N225",
+      dataSource: "delayed",
+      listingExchangeName: "OSAKA",
+      marketState: "POST",
+      lastUpdated: Date.now() - 6 * 60 * 60_000,
+    }), "OSAKA")).toBe(true);
+  });
+
+  test("still ages out a US after-hours quote the provider stopped updating", () => {
+    expect(isProviderQuoteUsableForCurrentSession(makeQuote({
+      listingExchangeName: "NASDAQ",
+      marketState: "POST",
+      postMarketPrice: 101,
+      lastUpdated: Date.now() - 15 * 60_000,
+    }), "NASDAQ")).toBe(false);
+  });
+
   test("rejects empty zero provider quotes", () => {
     expect(isProviderQuoteUsableForCurrentSession(makeQuote({
       price: 0,

--- a/src/sources/provider-router/financials.ts
+++ b/src/sources/provider-router/financials.ts
@@ -3,7 +3,7 @@ import type { AnalystResearchData, CorporateActionsData, FinancialStatement, Quo
 import { hasLikelyQuoteUnitMismatch } from "../../utils/currency-units";
 import { mergeFinancialStatementRows } from "../../utils/financial-statements";
 import { normalizePriceHistory, normalizeTickerFinancialsPriceHistory } from "../../utils/price-history";
-import { isQuoteStaleForCurrentSession } from "../../market-data/quotes/freshness";
+import { isExtendedHoursExchange, isQuoteStaleForCurrentSession } from "../../market-data/quotes/freshness";
 import {
   mergeQuoteContributionMaps,
   resolveCanonicalQuote,
@@ -82,11 +82,25 @@ function finitePositiveNumber(value: unknown): value is number {
 }
 
 const ACTIVE_PROVIDER_QUOTE_MAX_AGE_MS = 10 * 60_000;
-const ACTIVE_DELAYED_PROVIDER_QUOTE_MAX_AGE_MS = 20 * 60_000;
-const ACTIVE_QUOTE_MARKET_STATES = new Set(["PRE", "REGULAR", "POST"]);
+// A delayed quote is built from the last completed one-minute bar fifteen
+// minutes back, so a fresh one is already sixteen minutes old; leave room for
+// the server cache on top of that before calling the provider stuck.
+const ACTIVE_DELAYED_PROVIDER_QUOTE_MAX_AGE_MS = 30 * 60_000;
+
+/**
+ * PRE and POST are live sessions only where the exchange trades outside
+ * regular hours. Yahoo reports POST for Tokyo or Sydney for hours after the
+ * close, and that closing quote is exactly what a world board should show.
+ */
+function isQuoteInActiveSession(quote: Quote): boolean {
+  const state = quote.marketState ?? "";
+  if (state === "REGULAR") return true;
+  if (state === "PRE" || state === "POST") return isExtendedHoursExchange(quote);
+  return false;
+}
 
 function isActiveProviderQuoteTooOld(quote: Quote, now = Date.now()): boolean {
-  if (!ACTIVE_QUOTE_MARKET_STATES.has(quote.marketState ?? "")) return false;
+  if (!isQuoteInActiveSession(quote)) return false;
   if (!Number.isFinite(quote.lastUpdated)) return false;
   const maxAge =
     quote.dataSource === "delayed"


### PR DESCRIPTION
World Indices showed dashes for every Asia-Pacific index all day, and for US and European rows on and off (`11 unavailable` in the footer). The batch endpoint returns all 19 quotes with prices; two client rules in `isProviderQuoteUsableForCurrentSession` were dropping them.

1. Yahoo labels Tokyo, Hong Kong, Shanghai, Seoul, Sydney and Mumbai `POST` for hours after their close. `isActiveProviderQuoteTooOld` treated POST as a live session and rejected their closing quotes for being older than 20 minutes. PRE and POST now only count as live where the exchange trades outside regular hours (the existing `isExtendedHoursExchange` set), so US after-hours quotes still age out and closed foreign markets keep their close.

2. A delayed quote is synthesized server-side from the last completed one-minute bar 15 minutes back (`SYNTHETIC_DELAY_MS`), so a fresh one is already 16 minutes old. The client's 20-minute limit left about four minutes for the server cache, and rows crossed it at different moments. The delayed limit is now 30 minutes; the 10-minute limit for live quotes is unchanged.

Tests cover: delayed quote at 25 min kept, at 35 min rejected, Nikkei in POST six hours after close kept, US after-hours quote at 15 min still rejected. Verified against production data in a local `wrangler dev`: all 17 index rows populate, footer no longer says unavailable.