### PR TITLE
Say where plugins run on the web marketplace

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -106,6 +106,23 @@ If a plugin genuinely cannot work on a renderer, declare `targets` instead
 (`["cli", "tui"]`, for example) so the marketplace explains why it is inert
 rather than reporting a compile error.
 
+### Where plugins run
+
+Plugins run in the terminal and in the desktop app. The hosted web app at
+term.gloom.sh ships only the built-ins compiled into it (`catalog-browser.ts`)
+and does not load plugins from outside the build.
+
+That is a product decision rather than a gap. Third-party code on the web
+would run on the origin that holds the user's session, and there is no
+sandbox that can contain a plugin written as a React component sharing the
+host's module registry. The desktop app and the terminal run on the user's own
+machine, where installing a plugin is an explicit choice with a bounded blast
+radius.
+
+The marketplace still lists every plugin on the web, labelled with where it
+runs, so the web app works as a storefront. Listing `"web"` in `targets` is
+harmless but has no effect today.
+
 ## What plugins can do
 
 Use `setup()` for interactive runtime registration, `capabilities` for reusable headless services, and `cliCommands` for root-level CLI commands that should be discoverable without rendering panes. Capability operations can still declare `cli` manifests (`summary`, input/output shape, formats, safety notes, side-effect level) for `gloomberb api list`.

--- a/src/plugins/builtin/plugin-marketplace/model.test.ts
+++ b/src/plugins/builtin/plugin-marketplace/model.test.ts
@@ -90,18 +90,50 @@ describe("mergeCatalog", () => {
 
     expect(entry?.installed).toBe(true);
     expect(entry?.unsupportedHere).toBe(true);
-    expect(unsupportedLabel(entry!)).toBe("Desktop only");
+    expect(unsupportedLabel(entry!)).toBe("Desktop and terminal");
+  });
+
+  test("names the one renderer a plugin is limited to", () => {
+    const [desktopOnly, terminalOnly] = mergeCatalog({
+      registry: [
+        registryPlugin({ id: "native-charts", targets: ["desktop"] }),
+        registryPlugin({ id: "ibkr-gateway", targets: ["cli", "tui"] }),
+      ],
+      installed: [],
+      target: "web",
+    });
+
+    expect(unsupportedLabel(desktopOnly!)).toBe("Desktop only");
+    expect(unsupportedLabel(terminalOnly!)).toBe("Terminal only");
   });
 
   test("does not flag a plugin that supports the current renderer", () => {
     const [entry] = mergeCatalog({
       registry: [registryPlugin({ id: "hackernews" })],
       installed: [],
-      target: "web",
+      target: "desktop",
     });
 
     expect(entry?.unsupportedHere).toBe(false);
     expect(unsupportedLabel(entry!)).toBeNull();
+  });
+
+  test("flags every external plugin on the web, whatever it declares", () => {
+    // term.gloom.sh loads only the built-ins compiled into it. A plugin that
+    // lists "web" in its targets is describing where its code could run, not
+    // where the web app will load it from, so it must not look installable.
+    const [external, bundled] = mergeCatalog({
+      registry: [
+        registryPlugin({ id: "hackernews", targets: ["cli", "tui", "desktop", "web"] }),
+        registryPlugin({ id: "portfolio", bundled: true, targets: ["cli", "tui", "desktop", "web"] }),
+      ],
+      installed: [],
+      target: "web",
+    });
+
+    expect(external?.unsupportedHere).toBe(true);
+    expect(unsupportedLabel(external!)).toBe("Desktop and terminal");
+    expect(bundled?.unsupportedHere).toBe(false);
   });
 
   test("surfaces a load error so a broken install is visible rather than missing", () => {

--- a/src/plugins/builtin/plugin-marketplace/model.ts
+++ b/src/plugins/builtin/plugin-marketplace/model.ts
@@ -1,4 +1,5 @@
 import type { PluginTarget } from "../../../types/plugin";
+import { runsExternalPlugins } from "../../current-target";
 
 export type PluginTier = "official" | "verified" | "community";
 
@@ -121,7 +122,12 @@ export function mergeCatalog(options: {
       availableVersion: plugin.ref,
       contributes: plugin.contributes,
       loadError: local?.loadError,
-      unsupportedHere: !plugin.targets.includes(target),
+      // A bundled plugin is part of the build and runs wherever the build
+      // does. Anything else needs a renderer that loads external code, which
+      // the web app does not, whatever the plugin declares.
+      unsupportedHere: plugin.bundled
+        ? !plugin.targets.includes(target)
+        : !runsExternalPlugins(target) || !plugin.targets.includes(target),
     });
   }
 
@@ -200,5 +206,8 @@ export function isInstallable(entry: MarketplaceEntry): boolean {
 export function unsupportedLabel(entry: MarketplaceEntry): string | null {
   if (!entry.unsupportedHere) return null;
   if (entry.targets.length === 0) return "Unavailable here";
-  return entry.targets.includes("desktop") ? "Desktop only" : "Terminal only";
+  const desktop = entry.targets.includes("desktop");
+  const terminal = entry.targets.includes("cli") || entry.targets.includes("tui");
+  if (desktop && terminal) return "Desktop and terminal";
+  return desktop ? "Desktop only" : "Terminal only";
 }

--- a/src/plugins/builtin/plugin-marketplace/pane.tsx
+++ b/src/plugins/builtin/plugin-marketplace/pane.tsx
@@ -18,7 +18,7 @@ import { Box, ScrollBox, Text, TextAttributes, type InputRenderable } from "../.
 import { formatCompact } from "../../../utils/format";
 import { isPlainKey } from "../../../utils/keyboard";
 import { formatRelativeAge } from "../../../utils/relative-time";
-import { canInstallPlugins, getCurrentPluginTarget } from "../../current-target";
+import { canInstallPlugins, getCurrentPluginTarget, runsExternalPlugins } from "../../current-target";
 import { loadRegistry, registryPluginUrl } from "./feed";
 import {
   collectCategories,
@@ -141,10 +141,19 @@ function EntryDetail({ entry, width }: { entry: MarketplaceEntry; width: number 
       </Box>
 
       {!entry.installed && !entry.bundled && entry.repo ? (
-        <Box paddingTop={1} flexDirection="column">
-          <Text fg={colors.textDim}>Runs with your full permissions. Read the source first.</Text>
-          <Text fg={colors.textBright}>{`gloomberb install ${entry.repo}`}</Text>
-        </Box>
+        runsExternalPlugins() ? (
+          <Box paddingTop={1} flexDirection="column">
+            <Text fg={colors.textDim}>Runs with your full permissions. Read the source first.</Text>
+            <Text fg={colors.textBright}>{`gloomberb install ${entry.repo}`}</Text>
+          </Box>
+        ) : (
+          // No shell here, so the install command would be a dead end. Say
+          // where plugins run instead: the web app is the storefront.
+          <Box paddingTop={1} flexDirection="column">
+            <Text fg={colors.textDim}>Plugins run in the desktop app and the terminal.</Text>
+            <Text fg={colors.textBright}>gloom.sh</Text>
+          </Box>
+        )
       ) : null}
     </ScrollBox>
   );

--- a/src/plugins/current-target.ts
+++ b/src/plugins/current-target.ts
@@ -26,3 +26,16 @@ export function getCurrentPluginTarget(): PluginTarget {
 export function canInstallPlugins(): boolean {
   return currentTarget === "cli" || currentTarget === "tui";
 }
+
+/**
+ * Whether this renderer runs plugins from outside the build at all.
+ *
+ * term.gloom.sh ships only the curated built-ins in `catalog-browser.ts`.
+ * Third-party code there would run on the origin that holds the session, so
+ * it is a product decision, not a missing feature: plugins live in the desktop
+ * app and the terminal. The marketplace still lists them on the web so it
+ * works as a storefront, but it says where they run instead of how to install.
+ */
+export function runsExternalPlugins(target: PluginTarget = currentTarget): boolean {
+  return target !== "web";
+}


### PR DESCRIPTION
Follow-up to the decision in #710 (closed): term.gloom.sh is the built-in experience, and plugins live in the desktop app and the terminal.

## Before

On the web, the marketplace treated every plugin as installable. A plugin declaring `"web"` in its `targets` (most of them, via the template default) showed no label at all, and the detail pane printed:

```
Runs with your full permissions. Read the source first.
gloomberb install gloom-sh/gloomberb-hackernews
```

There is no shell on term.gloom.sh to run that in, and the web app never loads external code anyway (`src/renderers/browser/main.tsx` uses `getBrowserBuiltinPlugins()` only).

## After

- `runsExternalPlugins()` in `current-target.ts` states the rule in one place. The web target returns false.
- `mergeCatalog` marks every non-bundled plugin unsupported on the web, whatever its `targets` say. Bundled plugins are unaffected.
- The label now reads **Desktop and terminal** for the common case. Previously a plugin that ran on `cli`, `tui`, and `desktop` was labelled "Desktop only", which was wrong. "Desktop only" and "Terminal only" are kept for plugins genuinely limited to one.
- The detail pane on the web says where plugins run and points at gloom.sh, instead of the install command.
- PLUGINS.md documents the decision and the reasoning, so it reads as intentional rather than as a gap.

## Verification

- `bun test src/plugins/`: 1063 pass. Three new model tests, one of which replaces a test that encoded the old behaviour (hackernews "not flagged" on web).
- `bun run typecheck` clean.

Small and non-visual apart from the marketplace copy, so I will merge once CI is green unless you want to look at the wording.