### PR TITLE
Run Linux verify on PRs and main, Windows on main only

### DIFF
--- a/.github/workflows/verify-windows.yml
+++ b/.github/workflows/verify-windows.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "**"
+      - main
 
 concurrency:
   group: verify-windows-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,7 +2,11 @@ name: Verify
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Linux `Verify` now runs on pull requests targeting `main` and on pushes to `main`, not on every feature-branch push. That removes the duplicate push+PR pair.
- `Verify Windows` now runs on `main` and `workflow_dispatch` only. Feature-branch pushes were starting two `windows-latest` jobs (~10 minutes each) on every commit.

Release still builds Windows on tags. Homebrew desktop verify stays manual.

## Test plan
- [ ] Open this PR and confirm Linux `Verify` still runs
- [ ] Confirm `Verify Windows` does **not** start on this branch
- [ ] After merge, confirm a `main` push still starts both workflows