### PR TITLE
Attribute browser signups without a campaign click

### DIFF
--- a/src/api-client/research-activity.test.ts
+++ b/src/api-client/research-activity.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import { resolveBrowserAttribution } from "./research-activity";
+
+const NOW = Date.parse("2026-09-10T12:00:00.000Z");
+const DAY = 24 * 60 * 60 * 1000;
+
+describe("resolveBrowserAttribution", () => {
+  test("a direct visit still records a first touch", () => {
+    const result = resolveBrowserAttribution({
+      href: "https://term.gloom.sh/",
+      now: NOW,
+      referrer: "",
+      stored: null,
+    });
+    expect(result).toEqual({
+      first_touch_at: "2026-09-10T12:00:00.000Z",
+      first_touch_landing_page: "/",
+    });
+  });
+
+  test("an external referrer is kept, our own origin is not", () => {
+    expect(
+      resolveBrowserAttribution({
+        href: "https://term.gloom.sh/?ticker=NVDA",
+        now: NOW,
+        referrer: "https://t.co/abc123",
+        stored: null,
+      }).first_touch_referrer,
+    ).toBe("https://t.co/abc123");
+    expect(
+      resolveBrowserAttribution({
+        href: "https://term.gloom.sh/s/share-id",
+        now: NOW,
+        referrer: "https://term.gloom.sh/",
+        stored: null,
+      }).first_touch_referrer,
+    ).toBeUndefined();
+  });
+
+  test("a campaign on the first visit lands in both first touch and last touch", () => {
+    const result = resolveBrowserAttribution({
+      href: "https://term.gloom.sh/?utm_source=x&utm_medium=paid_social&utm_campaign=c1&twclid=click_1",
+      now: NOW,
+      referrer: "https://t.co/xyz",
+      stored: null,
+    });
+    expect(result).toEqual({
+      first_touch_at: "2026-09-10T12:00:00.000Z",
+      first_touch_landing_page: "/",
+      first_touch_referrer: "https://t.co/xyz",
+      first_touch_utm_source: "x",
+      first_touch_utm_medium: "paid_social",
+      first_touch_utm_campaign: "c1",
+      first_touch_twclid: "click_1",
+      last_touch_at: "2026-09-10T12:00:00.000Z",
+      utm_source: "x",
+      utm_medium: "paid_social",
+      utm_campaign: "c1",
+      twclid: "click_1",
+    });
+  });
+
+  test("a later campaign replaces the click id but keeps the first touch", () => {
+    const first = resolveBrowserAttribution({
+      href: "https://term.gloom.sh/?utm_source=x&utm_campaign=c1&twclid=click_1",
+      now: NOW - 3 * DAY,
+      referrer: "https://t.co/xyz",
+      stored: null,
+    });
+    const later = resolveBrowserAttribution({
+      href: "https://term.gloom.sh/?utm_source=newsletter&utm_campaign=c2",
+      now: NOW,
+      referrer: "",
+      stored: JSON.stringify(first),
+    });
+    expect(later.first_touch_twclid).toBe("click_1");
+    expect(later.first_touch_utm_campaign).toBe("c1");
+    expect(later.first_touch_referrer).toBe("https://t.co/xyz");
+    expect(later.twclid).toBeUndefined();
+    expect(later.utm_source).toBe("newsletter");
+    expect(later.utm_campaign).toBe("c2");
+    expect(later.last_touch_at).toBe("2026-09-10T12:00:00.000Z");
+  });
+
+  test("a return visit without params reuses the stored touches", () => {
+    const first = resolveBrowserAttribution({
+      href: "https://term.gloom.sh/?utm_source=x&twclid=click_1",
+      now: NOW - 5 * DAY,
+      referrer: "https://t.co/xyz",
+      stored: null,
+    });
+    const back = resolveBrowserAttribution({
+      href: "https://term.gloom.sh/",
+      now: NOW,
+      referrer: "",
+      stored: JSON.stringify(first),
+    });
+    expect(back).toEqual(first);
+  });
+
+  test("first touch and campaign expire independently after 30 days", () => {
+    const first = resolveBrowserAttribution({
+      href: "https://term.gloom.sh/",
+      now: NOW - 35 * DAY,
+      referrer: "https://news.ycombinator.com/",
+      stored: null,
+    });
+    const campaign = resolveBrowserAttribution({
+      href: "https://term.gloom.sh/?utm_source=x&twclid=click_1",
+      now: NOW - 10 * DAY,
+      referrer: "",
+      stored: JSON.stringify(first),
+    });
+    expect(campaign.first_touch_referrer).toBe("https://news.ycombinator.com/");
+
+    const now = resolveBrowserAttribution({
+      href: "https://term.gloom.sh/",
+      now: NOW,
+      referrer: "",
+      stored: JSON.stringify(campaign),
+    });
+    expect(now.first_touch_at).toBe("2026-09-10T12:00:00.000Z");
+    expect(now.first_touch_referrer).toBeUndefined();
+    expect(now.twclid).toBe("click_1");
+    expect(now.last_touch_at).toBe(campaign.last_touch_at);
+  });
+
+  test("legacy storage without a first touch is upgraded in place", () => {
+    const legacy = JSON.stringify({
+      last_touch_at: new Date(NOW - 2 * DAY).toISOString(),
+      utm_source: "x",
+      utm_content: "homepage_hero_v1",
+      twclid: "click_legacy",
+    });
+    const result = resolveBrowserAttribution({
+      href: "https://term.gloom.sh/",
+      now: NOW,
+      referrer: "",
+      stored: legacy,
+    });
+    expect(result.twclid).toBe("click_legacy");
+    expect(result.utm_content).toBe("homepage_hero_v1");
+    expect(result.first_touch_at).toBe("2026-09-10T12:00:00.000Z");
+    expect(result.first_touch_landing_page).toBe("/");
+  });
+
+  test("corrupt storage and junk values are ignored", () => {
+    const result = resolveBrowserAttribution({
+      href: "https://term.gloom.sh/?utm_source=" + "x".repeat(400) + "&twclid=%20%20",
+      now: NOW,
+      referrer: "not a url",
+      stored: "{not json",
+    });
+    expect(result.utm_source).toHaveLength(300);
+    expect(result.twclid).toBeUndefined();
+    expect(result.first_touch_referrer).toBeUndefined();
+  });
+});

--- a/src/api-client/research-activity.ts
+++ b/src/api-client/research-activity.ts
@@ -19,6 +19,115 @@ const sent = new Set<string>();
 let anonymousId: string | undefined;
 let attribution: Record<string, string> = {};
 
+const ATTRIBUTION_STORAGE_KEY = "gloomberb.web.attribution";
+const ANONYMOUS_ID_STORAGE_KEY = "gloomberb.web.anonymous-id";
+const ATTRIBUTION_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+const CAMPAIGN_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "twclid",
+] as const;
+const FIRST_TOUCH_KEYS = [
+  "first_touch_at",
+  "first_touch_landing_page",
+  "first_touch_referrer",
+  ...CAMPAIGN_KEYS.map((key) => `first_touch_${key}` as const),
+] as const;
+
+function cleanValue(value: unknown, maxLength = 300): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, maxLength) : undefined;
+}
+
+function isFresh(at: string | undefined, now: number): boolean {
+  const age = now - Date.parse(at ?? "");
+  return Number.isFinite(age) && age >= 0 && age < ATTRIBUTION_WINDOW_MS;
+}
+
+/** A referrer only counts when it is another site; our own pages are not a source. */
+function externalReferrer(referrer: string | undefined, href: string): string | undefined {
+  const value = cleanValue(referrer, 500);
+  if (!value) return undefined;
+  try {
+    return new URL(value).origin === new URL(href).origin ? undefined : value;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Merges what this page load reveals into the stored attribution. The first
+ * touch (landing page, external referrer, and any campaign on it) is written
+ * once and kept for 30 days so a signup on a later visit still knows how the
+ * visitor originally arrived. Campaign fields track the most recent click: a
+ * new campaign replaces the old click id instead of inheriting it. Both parts
+ * expire independently.
+ */
+export function resolveBrowserAttribution({
+  href,
+  now = Date.now(),
+  referrer,
+  stored,
+}: {
+  href: string;
+  now?: number;
+  referrer?: string;
+  stored: string | null;
+}): Record<string, string> {
+  const url = new URL(href);
+  let saved: Record<string, unknown> = {};
+  try {
+    const parsed: unknown = JSON.parse(stored ?? "{}");
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) saved = parsed as Record<string, unknown>;
+  } catch {
+    /* Corrupt storage is the same as no storage. */
+  }
+
+  const next: Record<string, string> = {};
+  if (isFresh(cleanValue(saved.first_touch_at, 40), now)) {
+    for (const key of FIRST_TOUCH_KEYS) {
+      const value = cleanValue(saved[key], key.includes("referrer") || key.includes("landing") ? 500 : 300);
+      if (value) next[key] = value;
+    }
+  }
+  if (isFresh(cleanValue(saved.last_touch_at, 40), now)) {
+    next.last_touch_at = cleanValue(saved.last_touch_at, 40)!;
+    for (const key of CAMPAIGN_KEYS) {
+      const value = cleanValue(saved[key]);
+      if (value) next[key] = value;
+    }
+  }
+
+  const campaign: Partial<Record<(typeof CAMPAIGN_KEYS)[number], string>> = {};
+  for (const key of CAMPAIGN_KEYS) {
+    const value = cleanValue(url.searchParams.get(key));
+    if (value) campaign[key] = value;
+  }
+  const capturedAt = new Date(now).toISOString();
+  if (Object.keys(campaign).length > 0) {
+    for (const key of CAMPAIGN_KEYS) delete next[key];
+    next.last_touch_at = capturedAt;
+    Object.assign(next, campaign);
+  }
+
+  if (!next.first_touch_at) {
+    next.first_touch_at = capturedAt;
+    next.first_touch_landing_page = url.pathname;
+    const source = externalReferrer(referrer, href);
+    if (source) next.first_touch_referrer = source;
+    for (const key of CAMPAIGN_KEYS) {
+      const value = campaign[key];
+      if (value) next[`first_touch_${key}`] = value;
+    }
+  }
+
+  return next;
+}
+
 /** Hosted web analytics only. Native local use never creates an identifier. */
 export function initializeBrowserResearchActivity(): void {
   try {
@@ -30,45 +139,29 @@ export function initializeBrowserResearchActivity(): void {
       return;
     const url = new URL(location.href);
     const incoming = url.searchParams.get("_gloom");
-    const stored = localStorage.getItem("gloomberb.web.anonymous-id");
+    const stored = localStorage.getItem(ANONYMOUS_ID_STORAGE_KEY);
     anonymousId =
       [incoming, stored].find(
         (value) => value && /^[a-f0-9-]{36}$/.test(value),
       ) ?? crypto.randomUUID();
-    localStorage.setItem("gloomberb.web.anonymous-id", anonymousId);
-    const keys = [
-      "utm_source",
-      "utm_medium",
-      "utm_campaign",
-      "utm_content",
-      "utm_term",
-      "twclid",
-    ];
-    const saved = JSON.parse(
-      localStorage.getItem("gloomberb.web.attribution") ?? "{}",
-    );
-    const age = Date.now() - Date.parse(saved?.last_touch_at ?? "");
-    attribution =
-      Number.isFinite(age) && age >= 0 && age < 30 * 24 * 60 * 60 * 1000
-        ? saved
-        : {};
-    if (keys.some((key) => url.searchParams.has(key))) {
-      // A new campaign replaces the old click id instead of inheriting it.
-      attribution = { last_touch_at: new Date().toISOString() };
-      for (const key of keys) {
-        const value = url.searchParams.get(key);
-        if (value) attribution[key] = value.slice(0, 300);
-      }
-    }
-    localStorage.setItem(
-      "gloomberb.web.attribution",
-      JSON.stringify(attribution),
-    );
+    localStorage.setItem(ANONYMOUS_ID_STORAGE_KEY, anonymousId);
+    attribution = resolveBrowserAttribution({
+      href: url.href,
+      referrer: document.referrer,
+      stored: localStorage.getItem(ATTRIBUTION_STORAGE_KEY),
+    });
+    localStorage.setItem(ATTRIBUTION_STORAGE_KEY, JSON.stringify(attribution));
     url.searchParams.delete("_gloom");
     history.replaceState(history.state, "", url.href);
   } catch {
     /* Private browsing must still work. */
   }
+}
+
+/** What the server stores against the account: stored touches plus the product marker. */
+function attributionPayload(): Record<string, string> | undefined {
+  if (getCurrentPluginTarget() !== "web") return undefined;
+  return { product: "gloomberb", ...attribution };
 }
 
 /** Counts milestones once per feature/session/account, never their content. */
@@ -89,12 +182,26 @@ export function recordResearchActivity(
       eventId: crypto.randomUUID(),
       surface: target === "desktop" ? "desktop" : target,
       anonymousId: target === "web" ? anonymousId : undefined,
-      attribution: target === "web" ? attribution : undefined,
+      attribution: attributionPayload(),
       feature,
     })
     .catch(() => {
       sent.delete(key);
     });
+}
+
+/**
+ * Ties the visitor to the account right after sign-up or sign-in. Milestones
+ * are keyed by account, so the first one under the new user id carries the
+ * stored attribution and the anonymous id to the server; without this call a
+ * visitor who signs up and leaves is never attributed.
+ */
+export function identifyResearchUser(): void {
+  try {
+    recordResearchActivity("workspace_opened");
+  } catch {
+    /* Analytics never blocks sign-in. */
+  }
 }
 
 export function researchUpgradeUrl(returnTo?: string): string {

--- a/src/plugins/builtin/cloud/auth-model.ts
+++ b/src/plugins/builtin/cloud/auth-model.ts
@@ -5,6 +5,7 @@
  * without rendering.
  */
 import { apiClient, type AuthUser } from "../../../api-client";
+import { identifyResearchUser } from "../../../api-client/research-activity";
 import { t } from "../../../i18n";
 import { chatController } from "../chat/controller";
 
@@ -130,6 +131,7 @@ export async function performEmailAuth(mode: AccountMode, email: string, passwor
   if (sessionToken) {
     chatController.adoptSession(sessionToken, user);
   }
+  identifyResearchUser();
   await chatController.refreshSession().catch(() => {});
   return user;
 }


### PR DESCRIPTION
## Why

Production check on 10 Sep: of 176 browser signups in the last 30 days, 128 carry no marketing attribution at all. Every gloom.sh signup writes at least `product` + `current_path`, so those 128 came through term.gloom.sh, where:

- `initializeBrowserResearchActivity` stored only utm/twclid from the URL. A visitor from t.co, Google or Hacker News with no params produced `{}`.
- Nothing fired at sign-up or sign-in. Attribution only reached the server piggybacked on a later research milestone, and the server drops empty objects. A campaign visitor who signed up and left was lost too.

## What changes

- `resolveBrowserAttribution` (pure, tested) records a first touch: landing page, external referrer (own origin excluded), and any campaign present on that visit. It is written once and kept for 30 days. Last-click campaign fields keep today's behaviour (a new campaign replaces the old click id). Both parts expire independently. Existing localStorage entries are upgraded in place.
- Web milestones now always carry `product: "gloomberb"` plus the stored touches, so the server has something to save for every web account.
- `performEmailAuth` calls `identifyResearchUser()` right after the session is adopted, which sends the first milestone under the new user id with the attribution and anonymous id. Wrapped so analytics can never break sign-in. Desktop and TUI keep sending no attribution, as before.

No server change needed: `cleanMarketingAttribution` already accepts `product`, `first_touch_*`, `last_touch_at`, `utm_*`, `twclid`, and the merge preserves existing `first_touch_*` values.

## Verification

- `bun test src/api-client/research-activity.test.ts`: 8 cases covering direct visit, external vs own referrer, campaign on first visit, later campaign replacing click id, return visit reuse, independent expiry, legacy storage upgrade, junk input.
- `bun test src/api-client src/plugins/builtin/cloud src/renderers/browser`: 124 pass.
- `typecheck:browser`, `typecheck:opentui`, `typecheck:electrobun-view` clean.

## Follow-ups (not in this PR)

- gloom.sh -> term.gloom.sh hop forwards utm/twclid but not the original referrer, so an organic X visitor who lands on gloom.sh first still shows `first_touch_referrer: https://gloom.sh/`. Small change in the platform's `researchWorkspaceUrl`.
- term.gloom.sh deploys from the platform repo's `terminal/gloomberb-ref` pin; bump it after merge.
- `session.ipAddress` stores Cloudflare edge IPs (api.gloom.sh is behind CF); unrelated, noted while investigating.