### PR TITLE
Continue the website visitor into term.gloom.sh and the desktop app

### DIFF
--- a/src/api-client/research-activity.test.ts
+++ b/src/api-client/research-activity.test.ts
@@ -1,8 +1,24 @@
 import { describe, expect, test } from "bun:test";
-import { resolveBrowserAttribution } from "./research-activity";
+import {
+  adoptDesktopHandoff,
+  carriesHandoff,
+  observeDesktopDeepLinks,
+  readStoredAttribution,
+  resolveBrowserAttribution,
+} from "./research-activity";
 
 const NOW = Date.parse("2026-09-10T12:00:00.000Z");
 const DAY = 24 * 60 * 60 * 1000;
+const ANON = "0f1e2d3c-4b5a-4968-8776-655443322110";
+
+function memoryStorage(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    map,
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => void map.set(key, value),
+  };
+}
 
 describe("resolveBrowserAttribution", () => {
   test("a direct visit still records a first touch", () => {
@@ -144,6 +160,64 @@ describe("resolveBrowserAttribution", () => {
     expect(result.first_touch_landing_page).toBe("/");
   });
 
+  test("a first touch forwarded by the website is adopted over inventing one", () => {
+    const result = resolveBrowserAttribution({
+      href:
+        "https://term.gloom.sh/?ticker=NVDA&_gloom=" +
+        ANON +
+        "&first_touch_at=2026-09-08T09:00:00.000Z&first_touch_landing_page=%2Fcloud&first_touch_referrer=https%3A%2F%2Ft.co%2Fabc&first_touch_utm_source=x&first_touch_twclid=click_9",
+      now: NOW,
+      referrer: "https://gloom.sh/cloud",
+      stored: null,
+    });
+    expect(result).toEqual({
+      first_touch_at: "2026-09-08T09:00:00.000Z",
+      first_touch_landing_page: "/cloud",
+      first_touch_referrer: "https://t.co/abc",
+      first_touch_utm_source: "x",
+      first_touch_twclid: "click_9",
+    });
+  });
+
+  test("a forwarded first touch never overrides a fresh stored one", () => {
+    const stored = resolveBrowserAttribution({
+      href: "https://term.gloom.sh/",
+      now: NOW - 2 * DAY,
+      referrer: "https://news.ycombinator.com/",
+      stored: null,
+    });
+    const result = resolveBrowserAttribution({
+      href: "https://term.gloom.sh/?first_touch_at=2026-09-09T09:00:00.000Z&first_touch_landing_page=%2F&first_touch_referrer=https%3A%2F%2Ft.co%2Fabc",
+      now: NOW,
+      referrer: "https://gloom.sh/",
+      stored: JSON.stringify(stored),
+    });
+    expect(result).toEqual(stored);
+  });
+
+  test("a stale, future, or malformed forwarded first touch is ignored", () => {
+    for (const at of ["2026-07-01T00:00:00.000Z", "2026-09-11T00:00:00.000Z", "yesterday", ""]) {
+      const result = resolveBrowserAttribution({
+        href: `https://term.gloom.sh/?first_touch_at=${encodeURIComponent(at)}&first_touch_referrer=https%3A%2F%2Ft.co%2Fabc`,
+        now: NOW,
+        referrer: "",
+        stored: null,
+      });
+      expect(result.first_touch_at).toBe("2026-09-10T12:00:00.000Z");
+      expect(result.first_touch_referrer).toBeUndefined();
+    }
+  });
+
+  test("a forwarded first touch a minute ahead of this clock is still fresh", () => {
+    const result = resolveBrowserAttribution({
+      href: "https://term.gloom.sh/?first_touch_at=2026-09-10T12:01:00.000Z&first_touch_landing_page=%2Fcloud",
+      now: NOW,
+      referrer: "",
+      stored: null,
+    });
+    expect(result.first_touch_landing_page).toBe("/cloud");
+  });
+
   test("corrupt storage and junk values are ignored", () => {
     const result = resolveBrowserAttribution({
       href: "https://term.gloom.sh/?utm_source=" + "x".repeat(400) + "&twclid=%20%20",
@@ -154,5 +228,89 @@ describe("resolveBrowserAttribution", () => {
     expect(result.utm_source).toHaveLength(300);
     expect(result.twclid).toBeUndefined();
     expect(result.first_touch_referrer).toBeUndefined();
+  });
+});
+
+describe("readStoredAttribution", () => {
+  test("returns only touches inside their windows and never invents one", () => {
+    expect(readStoredAttribution(null, NOW)).toEqual({});
+    expect(
+      readStoredAttribution(
+        JSON.stringify({
+          first_touch_at: new Date(NOW - 40 * DAY).toISOString(),
+          first_touch_referrer: "https://t.co/old",
+          last_touch_at: new Date(NOW - DAY).toISOString(),
+          twclid: "click_recent",
+        }),
+        NOW,
+      ),
+    ).toEqual({
+      last_touch_at: new Date(NOW - DAY).toISOString(),
+      twclid: "click_recent",
+    });
+  });
+});
+
+describe("desktop handoff", () => {
+  test("carriesHandoff recognises ids, campaigns, and first touches only", () => {
+    expect(carriesHandoff("gloomberb://ticker/NVDA?tab=earnings-calls")).toBe(false);
+    expect(carriesHandoff(`gloomberb://cloud/success?_gloom=${ANON}`)).toBe(true);
+    expect(carriesHandoff("gloomberb://ticker/NVDA?utm_source=x")).toBe(true);
+    expect(carriesHandoff("gloomberb://ticker/NVDA?first_touch_at=2026-09-10T11:00:00.000Z")).toBe(true);
+    expect(carriesHandoff("not a url")).toBe(false);
+  });
+
+  test("a plain deep link leaves storage untouched", () => {
+    const storage = memoryStorage();
+    expect(adoptDesktopHandoff("gloomberb://ticker/NVDA?tab=chart", storage, NOW)).toBe(false);
+    expect(storage.map.size).toBe(0);
+  });
+
+  test("a website link persists the visitor id and touches for later sign-in", () => {
+    const storage = memoryStorage();
+    const href =
+      `gloomberb://cloud/success?_gloom=${ANON}` +
+      "&utm_source=x&utm_campaign=c1&twclid=click_1" +
+      "&first_touch_at=2026-09-08T09:00:00.000Z&first_touch_landing_page=%2F&first_touch_referrer=https%3A%2F%2Ft.co%2Fabc";
+    expect(adoptDesktopHandoff(href, storage, NOW)).toBe(true);
+    expect(storage.getItem("gloomberb.web.anonymous-id")).toBe(ANON);
+    expect(JSON.parse(storage.getItem("gloomberb.web.attribution")!)).toEqual({
+      first_touch_at: "2026-09-08T09:00:00.000Z",
+      first_touch_landing_page: "/",
+      first_touch_referrer: "https://t.co/abc",
+      last_touch_at: "2026-09-10T12:00:00.000Z",
+      utm_source: "x",
+      utm_campaign: "c1",
+      twclid: "click_1",
+    });
+  });
+
+  test("a campaign-only link without a forwarded first touch records the link as the first touch", () => {
+    const storage = memoryStorage();
+    adoptDesktopHandoff("gloomberb://cloud/success?utm_source=x&twclid=click_1", storage, NOW);
+    const saved = JSON.parse(storage.getItem("gloomberb.web.attribution")!);
+    expect(saved.first_touch_landing_page).toBe("cloud/success");
+    expect(saved.first_touch_twclid).toBe("click_1");
+    expect(saved.first_touch_referrer).toBeUndefined();
+  });
+
+  test("observeDesktopDeepLinks inspects every link and still delivers it to the app", () => {
+    const storage = memoryStorage();
+    const listeners = new Set<(link: { url: string }) => void>();
+    const pending = [{ url: `gloomberb://cloud/success?_gloom=${ANON}&utm_source=x` }];
+    const bridge = {
+      subscribe(listener: (link: { url: string }) => void) {
+        listeners.add(listener);
+        for (const link of pending.splice(0)) listener(link);
+        return () => void listeners.delete(listener);
+      },
+    };
+    const seen: string[] = [];
+    const unsubscribe = observeDesktopDeepLinks(bridge, storage).subscribe((link) => seen.push(link.url));
+    for (const listener of listeners) listener({ url: "gloomberb://ticker/NVDA" });
+    expect(seen).toEqual([`gloomberb://cloud/success?_gloom=${ANON}&utm_source=x`, "gloomberb://ticker/NVDA"]);
+    expect(storage.getItem("gloomberb.web.anonymous-id")).toBe(ANON);
+    unsubscribe();
+    expect(listeners.size).toBe(0);
   });
 });

--- a/src/api-client/research-activity.ts
+++ b/src/api-client/research-activity.ts
@@ -1,5 +1,6 @@
 import { apiClient } from "./index";
 import { getCurrentPluginTarget } from "../plugins/current-target";
+import type { DesktopDeepLinkBridge } from "../types/desktop-deeplink";
 
 export type ResearchActivity =
   | "workspace_opened"
@@ -21,7 +22,11 @@ let attribution: Record<string, string> = {};
 
 const ATTRIBUTION_STORAGE_KEY = "gloomberb.web.attribution";
 const ANONYMOUS_ID_STORAGE_KEY = "gloomberb.web.anonymous-id";
+const HANDOFF_ID_KEY = "_gloom";
 const ATTRIBUTION_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+/** Another device's clock may run slightly ahead; a touch from a minute in the future is still fresh. */
+const CLOCK_SKEW_MS = 5 * 60 * 1000;
+const ANONYMOUS_ID = /^[a-f0-9-]{36}$/;
 const CAMPAIGN_KEYS = [
   "utm_source",
   "utm_medium",
@@ -37,25 +42,105 @@ const FIRST_TOUCH_KEYS = [
   ...CAMPAIGN_KEYS.map((key) => `first_touch_${key}` as const),
 ] as const;
 
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
 function cleanValue(value: unknown, maxLength = 300): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed ? trimmed.slice(0, maxLength) : undefined;
 }
 
+function maxLengthFor(key: string): number {
+  return key.includes("referrer") || key.includes("landing") ? 500 : key.endsWith("_at") ? 40 : 300;
+}
+
 function isFresh(at: string | undefined, now: number): boolean {
   const age = now - Date.parse(at ?? "");
-  return Number.isFinite(age) && age >= 0 && age < ATTRIBUTION_WINDOW_MS;
+  return Number.isFinite(age) && age >= -CLOCK_SKEW_MS && age < ATTRIBUTION_WINDOW_MS;
+}
+
+function cleanUrlValue(value: unknown): string | undefined {
+  const cleaned = cleanValue(value, 500);
+  if (!cleaned) return undefined;
+  try {
+    new URL(cleaned);
+    return cleaned;
+  } catch {
+    return undefined;
+  }
 }
 
 /** A referrer only counts when it is another site; our own pages are not a source. */
 function externalReferrer(referrer: string | undefined, href: string): string | undefined {
-  const value = cleanValue(referrer, 500);
+  const value = cleanUrlValue(referrer);
   if (!value) return undefined;
+  return new URL(value).origin === new URL(href).origin ? undefined : value;
+}
+
+/** `gloomberb://cloud/success` has no meaningful pathname on its own; keep the host. */
+function landingPageOf(url: URL): string {
+  return url.protocol === "http:" || url.protocol === "https:" ? url.pathname : `${url.host}${url.pathname}`;
+}
+
+/** The stored touches that are still inside their windows; nothing is invented here. */
+export function readStoredAttribution(stored: string | null, now = Date.now()): Record<string, string> {
+  let saved: Record<string, unknown> = {};
   try {
-    return new URL(value).origin === new URL(href).origin ? undefined : value;
+    const parsed: unknown = JSON.parse(stored ?? "{}");
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) saved = parsed as Record<string, unknown>;
   } catch {
-    return undefined;
+    /* Corrupt storage is the same as no storage. */
+  }
+
+  const next: Record<string, string> = {};
+  if (isFresh(cleanValue(saved.first_touch_at, 40), now)) {
+    for (const key of FIRST_TOUCH_KEYS) {
+      const value = cleanValue(saved[key], maxLengthFor(key));
+      if (value) next[key] = value;
+    }
+  }
+  if (isFresh(cleanValue(saved.last_touch_at, 40), now)) {
+    next.last_touch_at = cleanValue(saved.last_touch_at, 40)!;
+    for (const key of CAMPAIGN_KEYS) {
+      const value = cleanValue(saved[key]);
+      if (value) next[key] = value;
+    }
+  }
+  return next;
+}
+
+/**
+ * The website forwards the first touch it recorded when it sends a visitor to
+ * term.gloom.sh or into the desktop app, so the earliest touch survives the
+ * hop. It is only trusted when it is well formed and still inside the window.
+ */
+function incomingFirstTouch(url: URL, now: number): Record<string, string> | null {
+  const at = cleanValue(url.searchParams.get("first_touch_at"), 40);
+  if (!at || !isFresh(at, now)) return null;
+  const touch: Record<string, string> = { first_touch_at: at };
+  for (const key of FIRST_TOUCH_KEYS) {
+    if (key === "first_touch_at") continue;
+    const raw = url.searchParams.get(key);
+    const value = key === "first_touch_referrer" ? cleanUrlValue(raw) : cleanValue(raw, maxLengthFor(key));
+    if (value) touch[key] = value;
+  }
+  return touch;
+}
+
+/** Whether a URL carries anything the website hands over: an id, a campaign, or a first touch. */
+export function carriesHandoff(href: string): boolean {
+  try {
+    const params = new URL(href).searchParams;
+    return (
+      params.has(HANDOFF_ID_KEY) ||
+      CAMPAIGN_KEYS.some((key) => params.has(key)) ||
+      FIRST_TOUCH_KEYS.some((key) => params.has(key))
+    );
+  } catch {
+    return false;
   }
 }
 
@@ -63,8 +148,9 @@ function externalReferrer(referrer: string | undefined, href: string): string | 
  * Merges what this page load reveals into the stored attribution. The first
  * touch (landing page, external referrer, and any campaign on it) is written
  * once and kept for 30 days so a signup on a later visit still knows how the
- * visitor originally arrived. Campaign fields track the most recent click: a
- * new campaign replaces the old click id instead of inheriting it. Both parts
+ * visitor originally arrived; a first touch forwarded by the website wins over
+ * inventing one here. Campaign fields track the most recent click: a new
+ * campaign replaces the old click id instead of inheriting it. Both parts
  * expire independently.
  */
 export function resolveBrowserAttribution({
@@ -79,28 +165,7 @@ export function resolveBrowserAttribution({
   stored: string | null;
 }): Record<string, string> {
   const url = new URL(href);
-  let saved: Record<string, unknown> = {};
-  try {
-    const parsed: unknown = JSON.parse(stored ?? "{}");
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) saved = parsed as Record<string, unknown>;
-  } catch {
-    /* Corrupt storage is the same as no storage. */
-  }
-
-  const next: Record<string, string> = {};
-  if (isFresh(cleanValue(saved.first_touch_at, 40), now)) {
-    for (const key of FIRST_TOUCH_KEYS) {
-      const value = cleanValue(saved[key], key.includes("referrer") || key.includes("landing") ? 500 : 300);
-      if (value) next[key] = value;
-    }
-  }
-  if (isFresh(cleanValue(saved.last_touch_at, 40), now)) {
-    next.last_touch_at = cleanValue(saved.last_touch_at, 40)!;
-    for (const key of CAMPAIGN_KEYS) {
-      const value = cleanValue(saved[key]);
-      if (value) next[key] = value;
-    }
-  }
+  const next = readStoredAttribution(stored, now);
 
   const campaign: Partial<Record<(typeof CAMPAIGN_KEYS)[number], string>> = {};
   for (const key of CAMPAIGN_KEYS) {
@@ -115,8 +180,12 @@ export function resolveBrowserAttribution({
   }
 
   if (!next.first_touch_at) {
+    const forwarded = incomingFirstTouch(url, now);
+    if (forwarded) Object.assign(next, forwarded);
+  }
+  if (!next.first_touch_at) {
     next.first_touch_at = capturedAt;
-    next.first_touch_landing_page = url.pathname;
+    next.first_touch_landing_page = landingPageOf(url);
     const source = externalReferrer(referrer, href);
     if (source) next.first_touch_referrer = source;
     for (const key of CAMPAIGN_KEYS) {
@@ -126,6 +195,16 @@ export function resolveBrowserAttribution({
   }
 
   return next;
+}
+
+function readHandoffId(url: URL): string | undefined {
+  const value = url.searchParams.get(HANDOFF_ID_KEY);
+  return value && ANONYMOUS_ID.test(value) ? value : undefined;
+}
+
+function stripHandoffParams(url: URL): void {
+  url.searchParams.delete(HANDOFF_ID_KEY);
+  for (const key of FIRST_TOUCH_KEYS) url.searchParams.delete(key);
 }
 
 /** Hosted web analytics only. Native local use never creates an identifier. */
@@ -138,11 +217,11 @@ export function initializeBrowserResearchActivity(): void {
     )
       return;
     const url = new URL(location.href);
-    const incoming = url.searchParams.get("_gloom");
+    const incoming = readHandoffId(url);
     const stored = localStorage.getItem(ANONYMOUS_ID_STORAGE_KEY);
     anonymousId =
       [incoming, stored].find(
-        (value) => value && /^[a-f0-9-]{36}$/.test(value),
+        (value) => value && ANONYMOUS_ID.test(value),
       ) ?? crypto.randomUUID();
     localStorage.setItem(ANONYMOUS_ID_STORAGE_KEY, anonymousId);
     attribution = resolveBrowserAttribution({
@@ -151,17 +230,76 @@ export function initializeBrowserResearchActivity(): void {
       stored: localStorage.getItem(ATTRIBUTION_STORAGE_KEY),
     });
     localStorage.setItem(ATTRIBUTION_STORAGE_KEY, JSON.stringify(attribution));
-    url.searchParams.delete("_gloom");
+    stripHandoffParams(url);
     history.replaceState(history.state, "", url.href);
   } catch {
     /* Private browsing must still work. */
   }
 }
 
+/**
+ * The desktop app never mints an identifier or invents a touch of its own. It
+ * only continues what the website handed over in a gloomberb:// link, so a
+ * visitor who read gloom.sh, installed the app, and signed up inside it is one
+ * person in analytics instead of two.
+ */
+export function initializeDesktopResearchActivity(storage: StorageLike = localStorage): void {
+  try {
+    const stored = storage.getItem(ANONYMOUS_ID_STORAGE_KEY);
+    anonymousId = stored && ANONYMOUS_ID.test(stored) ? stored : undefined;
+    attribution = readStoredAttribution(storage.getItem(ATTRIBUTION_STORAGE_KEY));
+  } catch {
+    /* A read-only profile still runs the app. */
+  }
+}
+
+export function adoptDesktopHandoff(href: string, storage: StorageLike = localStorage, now = Date.now()): boolean {
+  if (!carriesHandoff(href)) return false;
+  try {
+    const url = new URL(href);
+    const incoming = readHandoffId(url);
+    if (incoming) {
+      anonymousId = incoming;
+      storage.setItem(ANONYMOUS_ID_STORAGE_KEY, incoming);
+    }
+    attribution = resolveBrowserAttribution({
+      href,
+      now,
+      stored: storage.getItem(ATTRIBUTION_STORAGE_KEY),
+    });
+    storage.setItem(ATTRIBUTION_STORAGE_KEY, JSON.stringify(attribution));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Wraps the deep-link bridge so every link the app receives is inspected for a
+ * website handoff before the app acts on it. Wrapping, rather than subscribing
+ * separately, matters: the bridge flushes links queued during startup to the
+ * first subscriber only, and that subscriber must stay the app.
+ */
+export function observeDesktopDeepLinks(
+  bridge: DesktopDeepLinkBridge,
+  storage: StorageLike = localStorage,
+): DesktopDeepLinkBridge {
+  return {
+    subscribe(listener) {
+      return bridge.subscribe((deeplink) => {
+        adoptDesktopHandoff(deeplink.url, storage);
+        listener(deeplink);
+      });
+    },
+  };
+}
+
 /** What the server stores against the account: stored touches plus the product marker. */
 function attributionPayload(): Record<string, string> | undefined {
-  if (getCurrentPluginTarget() !== "web") return undefined;
-  return { product: "gloomberb", ...attribution };
+  const target = getCurrentPluginTarget();
+  if (target === "web") return { product: "gloomberb", ...attribution };
+  if (target === "desktop" && Object.keys(attribution).length > 0) return { product: "gloomberb", ...attribution };
+  return undefined;
 }
 
 /** Counts milestones once per feature/session/account, never their content. */
@@ -181,7 +319,7 @@ export function recordResearchActivity(
       event,
       eventId: crypto.randomUUID(),
       surface: target === "desktop" ? "desktop" : target,
-      anonymousId: target === "web" ? anonymousId : undefined,
+      anonymousId: target === "web" || target === "desktop" ? anonymousId : undefined,
       attribution: attributionPayload(),
       feature,
     })
@@ -207,7 +345,7 @@ export function identifyResearchUser(): void {
 export function researchUpgradeUrl(returnTo?: string): string {
   const url = new URL("https://gloom.sh/cloud?upgrade=pro");
   if (returnTo) url.searchParams.set("returnTo", returnTo);
-  if (anonymousId) url.searchParams.set("_gloom", anonymousId);
+  if (anonymousId) url.searchParams.set(HANDOFF_ID_KEY, anonymousId);
   for (const [key, value] of Object.entries(attribution)) {
     if (/^(utm_(source|medium|campaign|content|term)|twclid)$/.test(key))
       url.searchParams.set(key, value);

--- a/src/app/runtime/desktop-deeplink.test.ts
+++ b/src/app/runtime/desktop-deeplink.test.ts
@@ -26,6 +26,20 @@ describe("desktop deeplinks", () => {
     });
   });
 
+  test("ignores the website's analytics handoff parameters", () => {
+    const handoff =
+      "_gloom=0f1e2d3c-4b5a-4968-8776-655443322110&utm_source=x&twclid=click_1&first_touch_at=2026-09-10T11:00:00.000Z&first_touch_referrer=https%3A%2F%2Ft.co%2Fabc";
+    expect(resolveDesktopDeepLinkAction(`gloomberb://cloud/success?${handoff}`)).toEqual(
+      resolveDesktopDeepLinkAction("gloomberb://cloud/success"),
+    );
+    expect(resolveDesktopDeepLinkAction(`gloomberb://ticker/NVDA?tab=chart&${handoff}`)).toEqual(
+      resolveDesktopDeepLinkAction("gloomberb://ticker/NVDA?tab=chart"),
+    );
+    expect(resolveDesktopDeepLinkAction(`gloomberb://cloud/roundup?week=2026-07-03&${handoff}`)).toEqual(
+      resolveDesktopDeepLinkAction("gloomberb://cloud/roundup?week=2026-07-03"),
+    );
+  });
+
   test("routes ticker links with arbitrary registered tab ids", () => {
     expect(resolveDesktopDeepLinkAction("gloomberb://ticker/NVDA?tab=analyst-research")).toEqual({
       type: "open-ticker",

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -28,6 +28,10 @@ import { WebToastHostProvider } from "./toast-host";
 import { createWebUiHost, webRendererHost } from "./ui-host";
 import { createApplicationMenuBridge } from "./application-menu-bridge";
 import { createDesktopDeepLinkBridge } from "./desktop-deeplink-bridge";
+import {
+  initializeDesktopResearchActivity,
+  observeDesktopDeepLinks,
+} from "../../../api-client/research-activity";
 import { createDesktopWindowBridge } from "./desktop/window/bridge";
 import { prepareDetachedSnapshot } from "./desktop/window/snapshot";
 import { createElectrobunAppServices } from "./app-services";
@@ -105,7 +109,8 @@ async function boot() {
   applyLanguageFromConfig(config);
   const desktopWindowBridge = createDesktopWindowBridge(init.windowKind, init.paneId);
   const desktopApplicationMenuBridge = createApplicationMenuBridge();
-  const desktopDeepLinkBridge = createDesktopDeepLinkBridge();
+  initializeDesktopResearchActivity();
+  const desktopDeepLinkBridge = observeDesktopDeepLinks(createDesktopDeepLinkBridge());
   const webUiHost = createWebUiHost(init.desktopPlatform);
   // Compiled by the Bun process, which owns the filesystem. A failure here must
   // not stop the app from starting: the marketplace reports broken plugins, and


### PR DESCRIPTION
Stacked on #747 (base is that branch; GitHub retargets to `main` once it merges). Pairs with the platform PR that adds the sending side.

## Why

Two gaps remained after #747:

- The gloom.sh to term.gloom.sh hop forwarded only the anonymous id and the last-click campaign. An organic visitor who read gloom.sh first showed up on term with `first_touch_referrer: https://gloom.sh/`, so the real source was lost.
- The desktop app had no way to continue a website visitor at all. 53% of signups happen inside the app.

## What changes

**term.gloom.sh**
- `resolveBrowserAttribution` adopts a forwarded `first_touch_*` set from the URL when it has no fresh first touch of its own. It never overrides a stored one, rejects stale/future/malformed timestamps, and tolerates a forwarding clock up to 5 minutes ahead.
- Handoff parameters (`_gloom`, `first_touch_*`) are stripped from the address bar after reading, like `_gloom` was already.

**Desktop**
- `initializeDesktopResearchActivity` loads a previously persisted id and touches from the view's storage. It never mints an id or invents a touch.
- `observeDesktopDeepLinks` wraps the deep-link bridge the App subscribes to and calls `adoptDesktopHandoff` on every link. Wrapping matters: `onDesktopDeepLink` flushes links queued during startup to the first subscriber only, so a separate subscription would have swallowed the launch link.
- Plain `gloomberb://ticker/NVDA` links leave storage untouched (`carriesHandoff` gate). Website links carrying `_gloom`, a campaign, or a first touch are persisted, and the first milestone after sign-in (already wired by #747) sends them with `anonymousId` so the server aliases the web visitor onto the account.
- `attributionPayload` sends `product` plus touches on desktop only when something was handed over. TUI/CLI unchanged.

## Verification

- `src/api-client/research-activity.test.ts`: 18 cases (10 new: forwarded first touch adopted / not overriding / rejected when stale, future, malformed / accepted 1 min ahead; `readStoredAttribution` never invents; `carriesHandoff`; plain link no-op; website link persisted; campaign-only link; bridge wrapper delivers every link and unsubscribes).
- `src/app/runtime/desktop-deeplink.test.ts`: new case proving the resolver output is identical with and without handoff parameters on `cloud/success`, `ticker`, and `cloud/roundup`.
- 242 tests pass across `api-client`, `plugins/builtin/cloud`, `renderers`, `app/runtime`; `typecheck:browser`, `typecheck:electrobun-view`, `typecheck:opentui` clean.

## Not covered

- The download-then-install path (gloom.sh -> DMG -> in-app signup) has no deep link today, so it is still unattributed. I checked whether macOS carries the browser's "Where from" metadata through a DMG install so the app could read its own origin; no app on the Mac carries it, so I did not build on it. A post-download "Open Gloomberb" step on gloom.sh would close this and is a product decision.