### PR TITLE
Give the header its columns back in fullscreen, fix pane scrolling, and read the 8-K feed

### DIFF
--- a/src/components/command-bar/panel/layout.test.ts
+++ b/src/components/command-bar/panel/layout.test.ts
@@ -14,6 +14,7 @@ const BASE = {
   themePickerActive: false,
   themePickerRowCount: 0,
   titleBarOverlay: undefined as boolean | undefined,
+  windowFullscreen: false,
 };
 
 const DESKTOP = {
@@ -67,6 +68,37 @@ describe("command bar sheet geometry", () => {
     expect(desktop.panelBounds.x).toBe(desktopPrompt.left);
     expect(desktop.panelBounds.width).toBe(desktopPrompt.width);
     expect(desktop.panelBounds.y).toBeCloseTo(28 / 18, 6);
+  });
+
+  /**
+   * macOS takes the traffic lights away in fullscreen, so the columns the
+   * header held for them have to go back to the prompt, and the sheet has to
+   * follow it there rather than hang off its old left edge.
+   */
+  test("gives the traffic-light columns back in fullscreen", () => {
+    const windowed = resolveHeaderPromptGeometry({
+      nativePaneChrome: true,
+      nativeWindowChrome: true,
+      platform: "macOS",
+      termWidth: 200,
+      titleBarOverlay: true,
+    });
+    const fullscreen = resolveHeaderPromptGeometry({
+      nativePaneChrome: true,
+      nativeWindowChrome: true,
+      platform: "macOS",
+      termWidth: 200,
+      titleBarOverlay: true,
+      windowFullscreen: true,
+    });
+    expect(windowed.left).toBe(9);
+    expect(fullscreen.left).toBe(1);
+
+    // Wide enough and the prompt is already at its cap, so the columns only
+    // show up as width on a window that was short of them.
+    const narrow = { nativePaneChrome: true, nativeWindowChrome: true, platform: "macOS", termWidth: 60, titleBarOverlay: true };
+    expect(resolveHeaderPromptGeometry({ ...narrow, windowFullscreen: true }).width)
+      .toBeGreaterThan(resolveHeaderPromptGeometry(narrow).width);
   });
 
   /**

--- a/src/components/command-bar/panel/layout.ts
+++ b/src/components/command-bar/panel/layout.ts
@@ -51,6 +51,7 @@ export function resolveCommandBarPanelLayout({
   themePickerActive,
   themePickerRowCount,
   titleBarOverlay,
+  windowFullscreen,
 }: {
   cellHeightPx: number;
   cellWidthPx: number;
@@ -66,8 +67,15 @@ export function resolveCommandBarPanelLayout({
   themePickerActive: boolean;
   themePickerRowCount: number;
   titleBarOverlay: boolean | undefined;
+  windowFullscreen: boolean;
 }): CommandBarPanelLayout {
-  const prompt = resolveHeaderPromptGeometry({ nativePaneChrome, nativeWindowChrome, termWidth, titleBarOverlay });
+  const prompt = resolveHeaderPromptGeometry({
+    nativePaneChrome,
+    nativeWindowChrome,
+    termWidth,
+    titleBarOverlay,
+    windowFullscreen,
+  });
   const barWidth = prompt.width;
   const contentPadding = nativePaneChrome ? 1 : 3;
   const nativePanelPaddingColumns = nativePaneChrome

--- a/src/components/command-bar/panel/state.ts
+++ b/src/components/command-bar/panel/state.ts
@@ -9,6 +9,7 @@ import {
 import {
   resolveCommandBarPanelLayout,
 } from "./layout";
+import { useWindowFullscreen } from "../../layout/window-fullscreen";
 import { matchThemeOptions } from "../theme-picker";
 import type { CommandBarRoute } from "../workflow/types";
 
@@ -52,6 +53,9 @@ export function useCommandBarPanelState({
   visibleListStateRef,
 }: UseCommandBarPanelStateOptions) {
   visibleListStateRef.current = routeListState;
+  // The sheet drops out of the header prompt, so it has to follow the prompt
+  // off the traffic lights when the window goes fullscreen.
+  const windowFullscreen = useWindowFullscreen();
 
   useEffect(() => {
     const listState = routeListState;
@@ -122,6 +126,7 @@ export function useCommandBarPanelState({
     themePickerActive,
     themePickerRowCount,
     titleBarOverlay,
+    windowFullscreen,
   }), [
     cellHeightPx,
     cellWidthPx,
@@ -137,6 +142,7 @@ export function useCommandBarPanelState({
     themePickerActive,
     themePickerRowCount,
     titleBarOverlay,
+    windowFullscreen,
   ]);
   const selectedListRowIndex = visibleListState
     ? listRowIndexByGlobalIndex.get(visibleListState.selectedIdx) ?? -1

--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -14,6 +14,7 @@ import { PaneContent } from "./pane/content";
 import { resolvePaneBodyFrame, shouldReservePaneFooter } from "./pane/sizing";
 import { getPaneDisplayTitle } from "./pane/title";
 import { TITLEBAR_OVERLAY_HEIGHT_PX, getTitlebarLeadingInset } from "./titlebar-overlay";
+import { useWindowFullscreen } from "./window-fullscreen";
 import { WindowControls, WINDOWS_CONTROL_GROUP_WIDTH_PX } from "./window-controls";
 import {
   createDoubleEscapeCloseState,
@@ -60,7 +61,10 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
     windowControls,
   } = useUiCapabilities();
   const showWindowControls = nativeWindowChrome && windowControls === "windows";
-  const titlebarLeadingInset = titleBarOverlay && nativeWindowChrome ? getTitlebarLeadingInset() : 0;
+  const windowFullscreen = useWindowFullscreen();
+  const titlebarLeadingInset = titleBarOverlay && nativeWindowChrome
+    ? getTitlebarLeadingInset({ windowFullscreen })
+    : 0;
   const instance = useAppSelector((state) => findPaneInstance(state.config.layout, desktopWindowBridge.paneId) ?? null);
   const paneDef = instance ? pluginRegistry.panes.get(instance.paneId) ?? null : null;
   const hasPaneSettings = !!instance && pluginRegistry.hasPaneSettings(instance.instanceId);

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -37,6 +37,7 @@ import { truncateToDisplayWidth } from "../../utils/format";
 import { formatCommandBarShortcut, getShortcutDisplayMode } from "../../utils/shortcut-labels";
 import { resolveMarketSummaryFit, useMarketSummary } from "./market-summary";
 import { resolveHeaderPromptGeometry } from "./shell/chrome";
+import { useWindowFullscreen } from "./window-fullscreen";
 import { WindowControls, WINDOWS_CONTROL_GROUP_WIDTH_PX } from "./window-controls";
 
 const UPDATE_NOTICE_DURATION_MS = 5_000;
@@ -377,11 +378,13 @@ export function Header({
   const uiKind = useUiHost().kind;
   const { nativePaneChrome = false, titleBarOverlay, nativeWindowChrome = titleBarOverlay, windowControls } = useUiCapabilities();
   const showWindowControls = nativeWindowChrome && windowControls === "windows";
+  const windowFullscreen = useWindowFullscreen();
   const prompt = resolveHeaderPromptGeometry({
     nativePaneChrome,
     nativeWindowChrome,
     termWidth,
     titleBarOverlay,
+    windowFullscreen,
   });
   const shortcutLabel = formatCommandBarShortcut(getShortcutDisplayMode(uiKind));
   // Desktop has its own window chrome to sit on; the terminal has none, so the

--- a/src/components/layout/shell/chrome.ts
+++ b/src/components/layout/shell/chrome.ts
@@ -84,11 +84,16 @@ export function resolveHeaderPromptGeometry(options: {
   termWidth: number;
   nativePaneChrome?: boolean;
   nativeWindowChrome?: boolean;
+  /** Sniffed from the host when absent. */
+  platform?: string;
   titleBarOverlay?: boolean;
+  windowFullscreen?: boolean;
 }): HeaderPromptGeometry {
-  const { nativePaneChrome, termWidth, titleBarOverlay } = options;
+  const { nativePaneChrome, platform, termWidth, titleBarOverlay, windowFullscreen } = options;
   const nativeWindowChrome = options.nativeWindowChrome ?? titleBarOverlay;
-  const leadingInset = titleBarOverlay && nativeWindowChrome ? getTitlebarLeadingInset() : 0;
+  const leadingInset = titleBarOverlay && nativeWindowChrome
+    ? getTitlebarLeadingInset({ platform, windowFullscreen })
+    : 0;
   const left = leadingInset + 1;
   const updateColumns = headerPromptUpdateColumns(termWidth);
   const marketColumns = headerMarketColumns(termWidth, left, updateColumns);

--- a/src/components/layout/titlebar-overlay.ts
+++ b/src/components/layout/titlebar-overlay.ts
@@ -13,6 +13,16 @@ function currentPlatform(): string {
     ?? "";
 }
 
-export function getTitlebarLeadingInset(platform = currentPlatform()): number {
+/**
+ * Columns the header leaves free before its first content. macOS parks the
+ * traffic lights over them, but takes them away in fullscreen, where the space
+ * would just be a gap the eye has to cross.
+ */
+export function getTitlebarLeadingInset(options: {
+  platform?: string;
+  windowFullscreen?: boolean;
+} = {}): number {
+  if (options.windowFullscreen) return 0;
+  const platform = options.platform ?? currentPlatform();
   return /mac/i.test(platform) ? TITLEBAR_TRAFFIC_LIGHT_WIDTH : 0;
 }

--- a/src/components/layout/window-fullscreen.ts
+++ b/src/components/layout/window-fullscreen.ts
@@ -1,0 +1,32 @@
+import { useSyncExternalStore } from "react";
+
+let windowFullscreen = false;
+const listeners = new Set<() => void>();
+
+/**
+ * Whether the window hosting this view is in the platform's own fullscreen,
+ * which is not the same as a pane being maximized inside the workspace. Only
+ * the desktop host knows: a webview cannot see its window's style mask, and
+ * macOS hides the traffic lights there, so the header has to stop holding
+ * columns for controls that are no longer on screen.
+ */
+export function setWindowFullscreen(next: boolean): void {
+  if (windowFullscreen === next) return;
+  windowFullscreen = next;
+  for (const listener of [...listeners]) listener();
+}
+
+export function isWindowFullscreen(): boolean {
+  return windowFullscreen;
+}
+
+function subscribeWindowFullscreen(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function useWindowFullscreen(): boolean {
+  return useSyncExternalStore(subscribeWindowFullscreen, isWindowFullscreen, () => false);
+}

--- a/src/plugins/builtin/filing-events/feed.test.ts
+++ b/src/plugins/builtin/filing-events/feed.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import type { CloudFilingEventPayload } from "../../../api-client";
+import { buildFilingEventsFeed, resolveFeedScrollTop } from "./feed";
+
+function filingEvent(overrides: Partial<CloudFilingEventPayload> = {}): CloudFilingEventPayload {
+  return {
+    id: "id",
+    ticker: "ACME",
+    company: { ticker: "ACME", cik: "1", name: "Acme Inc.", shortName: "Acme" },
+    filedAt: "2026-04-02T00:00:00.000Z",
+    docUrl: "https://sec.gov/acme.htm",
+    items: ["2.02", "9.01"],
+    labels: ["Results of operations", "Exhibits"],
+    kinds: ["results"],
+    material: false,
+    headline: null,
+    summary: null,
+    people: [],
+    read: false,
+    ...overrides,
+  };
+}
+
+describe("buildFilingEventsFeed", () => {
+  test("puts what a model read first and leaves the rest below", () => {
+    const feed = buildFilingEventsFeed([
+      filingEvent({ id: "routine", filedAt: "2026-07-22T00:00:00.000Z" }),
+      filingEvent({
+        id: "news",
+        filedAt: "2026-06-05T00:00:00.000Z",
+        labels: ["Executive or director change"],
+        material: true,
+        read: true,
+        headline: "Chief financial officer steps down",
+        summary: "Departure effective June 30, 2026.",
+      }),
+    ], 60);
+
+    expect(feed.sections.map((section) => section.id)).toEqual(["news", "also"]);
+    expect(feed.entries.map((entry) => entry.id)).toEqual(["news", "routine"]);
+    expect(feed.summaryLine).toBe("2 filings since Jun 05, 26  ·  1 carries news");
+  });
+
+  test("keeps the exhibits label only when the filing has no other", () => {
+    const feed = buildFilingEventsFeed([
+      filingEvent({ id: "results" }),
+      filingEvent({ id: "exhibits-only", labels: ["Exhibits"] }),
+      filingEvent({ id: "unclassified", items: [], labels: [] }),
+    ], 60);
+
+    expect(feed.entries.map((entry) => entry.itemsLabel)).toEqual([
+      "Results of operations",
+      "Exhibits",
+      "No item listed",
+    ]);
+  });
+
+  test("measures an entry from the lines its read actually takes", () => {
+    const headingLines = 2;
+    const feed = buildFilingEventsFeed([
+      filingEvent({
+        id: "news",
+        read: true,
+        headline: "A headline long enough to wrap onto a second line",
+        summary: "One point.\nAnother point.",
+        people: [{ name: "Ada Lovelace", role: "Chair", action: "joined", effective: null }],
+      }),
+      filingEvent({ id: "routine" }),
+    ], 40);
+
+    const news = feed.entries[0]!;
+    // A blank row and the filed row, two headline lines, a line per point, and
+    // a line for the person.
+    expect(news.top).toBe(headingLines);
+    expect(news.lines).toBe(2 + 2 + 2 + 1);
+
+    // The second section pays for its own heading before its first entry.
+    expect(feed.entries[1]!.top).toBe(news.top + news.lines + headingLines);
+    expect(feed.entries[1]!.lines).toBe(2);
+  });
+});
+
+describe("resolveFeedScrollTop", () => {
+  const entry = { top: 20, lines: 6 } as Parameters<typeof resolveFeedScrollTop>[0]["entry"];
+
+  test("leaves an entry already in view alone", () => {
+    expect(resolveFeedScrollTop({ entry, scrollTop: 18, viewportHeight: 20 })).toBe(18);
+  });
+
+  test("scrolls up to an entry above the viewport", () => {
+    expect(resolveFeedScrollTop({ entry, scrollTop: 30, viewportHeight: 20 })).toBe(20);
+  });
+
+  test("scrolls down just far enough to finish an entry below the viewport", () => {
+    expect(resolveFeedScrollTop({ entry, scrollTop: 0, viewportHeight: 10 })).toBe(16);
+  });
+
+  test("pins an entry taller than the viewport to its own top", () => {
+    const tall = { top: 20, lines: 40 } as typeof entry;
+    expect(resolveFeedScrollTop({ entry: tall, scrollTop: 0, viewportHeight: 10 })).toBe(20);
+  });
+});

--- a/src/plugins/builtin/filing-events/feed.ts
+++ b/src/plugins/builtin/filing-events/feed.ts
@@ -1,0 +1,176 @@
+import type { CloudFilingEventPayload } from "../../../api-client";
+import { wrapTextLines } from "../../../utils/text-wrap";
+
+/** Every 8-K carries exhibits, so the label says nothing beside another one. */
+const EXHIBITS_LABEL = "Exhibits";
+/** Shown for a filing whose items EDGAR did not report. */
+const UNCLASSIFIED_LABEL = "No item listed";
+const BULLET_PREFIX = "• ";
+
+export interface FilingEventPerson {
+  name: string;
+  detail: string;
+}
+
+export interface FilingEventEntry {
+  id: string;
+  filedLabel: string;
+  itemsLabel: string;
+  docUrl: string;
+  material: boolean;
+  headline: string | null;
+  points: string[];
+  people: FilingEventPerson[];
+  /** Lines the entry occupies in the feed, its leading blank row included. */
+  lines: number;
+  /** First line of the entry in the feed, its leading blank row included. */
+  top: number;
+}
+
+export interface FilingEventsSection {
+  id: "news" | "also";
+  title: string;
+  entries: FilingEventEntry[];
+}
+
+export interface FilingEventsFeed {
+  summaryLine: string;
+  sections: FilingEventsSection[];
+  /** Every entry in the order the selection walks them. */
+  entries: FilingEventEntry[];
+}
+
+function formatFiled(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "2-digit",
+  });
+}
+
+function itemsLabel(event: CloudFilingEventPayload): string {
+  const named = event.labels.filter((label) => label !== EXHIBITS_LABEL);
+  const labels = named.length > 0 ? named : event.labels;
+  return labels.join(" · ") || UNCLASSIFIED_LABEL;
+}
+
+function personDetail(person: CloudFilingEventPayload["people"][number]): string {
+  return [
+    person.role,
+    person.action,
+    person.effective ? `effective ${formatFiled(person.effective)}` : null,
+  ].filter(Boolean).join(", ");
+}
+
+/** A filing the model read and had something to say about. */
+function carriesNews(event: CloudFilingEventPayload): boolean {
+  return event.read && (!!event.headline || !!event.summary);
+}
+
+function proseLines(text: string, width: number, prefix = ""): number {
+  return wrapTextLines(text, Math.max(8, width - prefix.length)).length;
+}
+
+function buildEntry(
+  event: CloudFilingEventPayload,
+  proseWidth: number,
+  detailed: boolean,
+): Omit<FilingEventEntry, "top"> {
+  const headline = detailed ? event.headline : null;
+  const points = detailed && event.summary
+    ? event.summary.split("\n").map((point) => point.trim()).filter(Boolean)
+    : [];
+  const people = detailed
+    ? event.people.map((person) => ({ name: person.name, detail: personDetail(person) }))
+    : [];
+  // One blank row above, then the filed-and-items row, then whatever was read.
+  let lines = 2;
+  if (headline) lines += proseLines(headline, proseWidth);
+  for (const point of points) lines += proseLines(point, proseWidth, BULLET_PREFIX);
+  for (const person of people) lines += proseLines(person.detail, proseWidth, `${person.name}  `);
+  return {
+    id: event.id,
+    filedLabel: formatFiled(event.filedAt),
+    itemsLabel: itemsLabel(event),
+    docUrl: event.docUrl,
+    material: event.material,
+    headline,
+    points,
+    people,
+    lines,
+  };
+}
+
+function summaryLine(events: CloudFilingEventPayload[], newsCount: number): string {
+  const oldest = events[events.length - 1];
+  const since = oldest ? ` since ${formatFiled(oldest.filedAt)}` : "";
+  const news = newsCount === 0
+    ? "none carry news"
+    : newsCount === 1
+      ? "1 carries news"
+      : `${newsCount} carry news`;
+  return `${events.length} filing${events.length === 1 ? "" : "s"}${since}  ·  ${news}`;
+}
+
+/**
+ * Splits the filings into the ones a model read and the rest, and measures each
+ * entry so a moving selection can be scrolled into view. Filings arrive newest
+ * first and stay in that order inside each group.
+ */
+export function buildFilingEventsFeed(
+  events: CloudFilingEventPayload[],
+  proseWidth: number,
+): FilingEventsFeed {
+  const news: Omit<FilingEventEntry, "top">[] = [];
+  const also: Omit<FilingEventEntry, "top">[] = [];
+  for (const event of events) {
+    const detailed = carriesNews(event);
+    (detailed ? news : also).push(buildEntry(event, proseWidth, detailed));
+  }
+
+  const sections: FilingEventsSection[] = [];
+  const entries: FilingEventEntry[] = [];
+  let top = 0;
+  for (const [id, title, group] of [
+    ["news", "WHAT HAPPENED", news],
+    ["also", "ALSO FILED", also],
+  ] as const) {
+    if (group.length === 0) continue;
+    // The heading sits on its own row under a blank one, matching an entry.
+    top += 2;
+    const placed = group.map((entry) => {
+      const positioned = { ...entry, top };
+      top += entry.lines;
+      return positioned;
+    });
+    sections.push({ id, title, entries: placed });
+    entries.push(...placed);
+  }
+
+  return { summaryLine: summaryLine(events, news.length), sections, entries };
+}
+
+/**
+ * Scroll offset that brings an entry into view, mirroring how the shared list
+ * follows its selection. An entry taller than the viewport is pinned to its
+ * own top rather than its bottom, so its filed date stays readable.
+ */
+export function resolveFeedScrollTop({
+  entry,
+  scrollTop,
+  viewportHeight,
+}: {
+  entry: FilingEventEntry | null;
+  scrollTop: number;
+  viewportHeight: number;
+}): number {
+  if (!entry || viewportHeight <= 0) return scrollTop;
+  if (entry.top < scrollTop) return entry.top;
+  const bottom = entry.top + entry.lines;
+  if (bottom > scrollTop + viewportHeight) {
+    return Math.min(entry.top, bottom - viewportHeight);
+  }
+  return scrollTop;
+}

--- a/src/plugins/builtin/filing-events/index.tsx
+++ b/src/plugins/builtin/filing-events/index.tsx
@@ -25,7 +25,6 @@ export const filingEventsModule: PluginModule = {
       defaultPosition: "right",
       defaultMode: "floating",
       defaultFloatingSize: { width: 100, height: 30 },
-      tableExport: true,
     },
   ],
 

--- a/src/plugins/builtin/filing-events/pane.tsx
+++ b/src/plugins/builtin/filing-events/pane.tsx
@@ -1,84 +1,108 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CloudFilingEventPayload } from "../../../api-client";
 import { apiClient } from "../../../api-client";
 import {
-  DataTableStackView,
-  EmptyState, PaneStatusBody, Prose, SectionHeading, usePaneFooter,
-  type DataTableCell,
-  type DataTableKeyEvent,
-  type PaneFooterSegment
+  EmptyState,
+  ExternalLinkText,
+  PaneStatusBody,
+  Prose,
+  SectionHeading,
+  usePaneFooter,
+  type PaneFooterSegment,
 } from "../../../components";
-import { colors } from "../../../theme/colors";
-import { Box, Text, useRendererHost } from "../../../ui";
+import { useShortcut } from "../../../react/input";
+import { colors, hoverBg } from "../../../theme/colors";
+import {
+  Box,
+  ScrollBox,
+  Text,
+  useRendererHost,
+  useUiCapabilities,
+  type ScrollBoxRenderable,
+} from "../../../ui";
+import { truncateToDisplayWidth } from "../../../utils/format";
 import { isPlainKey } from "../../../utils/keyboard";
 import { useBoundTicker } from "../shared/ticker-request";
+import {
+  buildFilingEventsFeed,
+  resolveFeedScrollTop,
+  type FilingEventEntry,
+} from "./feed";
 
 export const FILING_EVENTS_PANE_ID = "filing-events";
 
-interface EventColumn {
-  id: string;
-  label: string;
-  width: number;
-  align: "left" | "right";
-}
+const MAX_PROSE_WIDTH = 100;
 
-function buildColumns(width: number): EventColumn[] {
-  const dateWidth = 9;
-  const itemsWidth = 11;
-  const headlineWidth = Math.max(16, width - dateWidth - itemsWidth - 6);
-  return [
-    { id: "date", label: "FILED", width: dateWidth, align: "left" },
-    { id: "items", label: "ITEMS", width: itemsWidth, align: "left" },
-    {
-      id: "headline",
-      label: "WHAT HAPPENED",
-      width: headlineWidth,
-      align: "left",
-    },
-  ];
-}
-
-function formatFiled(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "—";
-  return date.toLocaleDateString("en-US", {
-    month: "short",
-    day: "2-digit",
-    year: "2-digit",
-  });
-}
-
-/** The items that say something; exhibits are on every filing. */
-function itemCodes(event: CloudFilingEventPayload): string {
-  return event.items.filter((code) => code !== "9.01").join(" ") || "—";
-}
-
-function renderCell(
-  event: CloudFilingEventPayload,
-  column: EventColumn,
-): DataTableCell {
-  switch (column.id) {
-    case "date":
-      return { text: formatFiled(event.filedAt), color: colors.textDim };
-    case "items":
-      return {
-        text: itemCodes(event),
-        color: event.material ? colors.warning : colors.textDim,
-      };
-    case "headline":
-      return {
-        text: event.headline ?? event.labels.join(", "),
-        color: event.read ? colors.textBright : colors.text,
-      };
-    default:
-      return { text: "" };
-  }
+/** One filing: when it was filed, what it was about, and what it said. */
+function FilingEntry({
+  entry,
+  nativePaneChrome,
+  onOpen,
+  onSelect,
+  proseWidth,
+  selected,
+}: {
+  entry: FilingEventEntry;
+  nativePaneChrome: boolean;
+  onOpen: () => void;
+  onSelect: () => void;
+  proseWidth: number;
+  selected: boolean;
+}) {
+  // Desktop chrome clips the row itself; the terminal has to be told where the
+  // row ends, or a third item label runs off it mid-word.
+  const items = nativePaneChrome
+    ? entry.itemsLabel
+    : truncateToDisplayWidth(entry.itemsLabel, Math.max(4, proseWidth - entry.filedLabel.length - 2));
+  return (
+    <Box
+      flexDirection="column"
+      marginTop={1}
+      backgroundColor={selected ? hoverBg(colors) : undefined}
+      data-gloom-role="filing-event"
+      data-gloom-interactive="true"
+      onMouseDown={onSelect}
+    >
+      <Box height={1} width="100%" flexDirection="row" gap={2} overflow="hidden">
+        <ExternalLinkText
+          url={entry.docUrl}
+          label={entry.filedLabel}
+          color={selected ? colors.selectedText : colors.textDim}
+          onOpen={onOpen}
+        />
+        <Text fg={selected ? colors.selectedText : entry.material ? colors.warning : colors.textDim}>
+          {items}
+        </Text>
+      </Box>
+      {entry.headline ? (
+        <Prose text={entry.headline} width={proseWidth} color={colors.textBright} />
+      ) : null}
+      {entry.points.map((point) => (
+        <Prose
+          key={point}
+          text={point}
+          width={proseWidth}
+          color={colors.text}
+          prefix="• "
+        />
+      ))}
+      {entry.people.map((person) => (
+        <Prose
+          key={`${person.name}-${person.detail}`}
+          text={person.detail}
+          width={proseWidth}
+          color={colors.textDim}
+          prefix={`${person.name}  `}
+          prefixColor={colors.textBright}
+        />
+      ))}
+    </Box>
+  );
 }
 
 export function FilingEventsPane({
   focused,
   width,
-  height,
 }: {
   focused: boolean;
   width: number;
@@ -86,15 +110,14 @@ export function FilingEventsPane({
 }) {
   const { symbol } = useBoundTicker();
   const ticker = symbol ? symbol.toUpperCase() : null;
+  const nativePaneChrome = useUiCapabilities().nativePaneChrome === true;
   const rendererHost = useRendererHost();
 
   const [events, setEvents] = useState<CloudFilingEventPayload[]>([]);
-  const [status, setStatus] = useState<"idle" | "loading" | "loaded" | "error">(
-    "idle",
-  );
+  const [status, setStatus] = useState<"idle" | "loading" | "loaded" | "error">("idle");
   const [error, setError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [detailOpen, setDetailOpen] = useState(false);
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null);
 
   useEffect(() => {
     if (!ticker) return;
@@ -105,6 +128,9 @@ export function FilingEventsPane({
       .then((payload) => {
         if (cancelled) return;
         setEvents(payload.events);
+        // The feed leads with what was read rather than what was filed last,
+        // so the opening selection is resolved against it, not this order.
+        setSelectedId(null);
         setStatus("loaded");
       })
       .catch((caught: unknown) => {
@@ -117,169 +143,138 @@ export function FilingEventsPane({
     };
   }, [ticker]);
 
-  const selected = useMemo(
-    () => events.find((event) => event.id === selectedId) ?? null,
-    [events, selectedId],
+  useEffect(() => {
+    const scrollBox = scrollRef.current;
+    if (scrollBox) scrollBox.scrollTop = 0;
+  }, [ticker]);
+
+  const bodyWidth = Math.max(12, width - 2);
+  const proseWidth = Math.min(bodyWidth, MAX_PROSE_WIDTH);
+  // Desktop chrome wraps the paragraphs itself, across the whole pane; the
+  // terminal wraps at the reading width. Measuring against whichever is in use
+  // keeps the entry offsets on the lines the reader actually sees.
+  const feed = useMemo(
+    () => buildFilingEventsFeed(events, nativePaneChrome ? bodyWidth : proseWidth),
+    [bodyWidth, events, nativePaneChrome, proseWidth],
   );
-  const columns = useMemo(() => buildColumns(width), [width]);
+  const selectedIndex = Math.max(
+    0,
+    feed.entries.findIndex((entry) => entry.id === selectedId),
+  );
+  const selected = feed.entries[selectedIndex] ?? null;
+
+  useEffect(() => {
+    const scrollBox = scrollRef.current;
+    if (!scrollBox?.viewport || !selected) return;
+    scrollBox.scrollTop = resolveFeedScrollTop({
+      entry: selected,
+      scrollTop: scrollBox.scrollTop,
+      viewportHeight: scrollBox.viewport.height,
+    });
+  }, [selected]);
 
   const openFiling = useCallback(() => {
     if (selected?.docUrl) void rendererHost.openExternal(selected.docUrl);
   }, [rendererHost, selected]);
 
-  const handleKey = useCallback(
-    (event: DataTableKeyEvent) => {
-      if (isPlainKey(event, "o")) {
-        openFiling();
-        return true;
-      }
-      return false;
+  const moveSelection = useCallback((delta: number) => {
+    const entries = feed.entries;
+    if (entries.length === 0) return;
+    const next = Math.max(0, Math.min(entries.length - 1, selectedIndex + delta));
+    setSelectedId(entries[next]?.id ?? null);
+  }, [feed.entries, selectedIndex]);
+
+  useShortcut(
+    (event) => {
+      if (isPlainKey(event, "o")) openFiling();
+      else if (isPlainKey(event, "j", "down")) moveSelection(1);
+      else if (isPlainKey(event, "k", "up")) moveSelection(-1);
     },
-    [openFiling],
+    { enabled: focused, scope: FILING_EVENTS_PANE_ID },
   );
 
   usePaneFooter(FILING_EVENTS_PANE_ID, () => {
     const info: PaneFooterSegment[] = [];
-    if (status === "loading")
+    if (status === "loading") {
       info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
-    const material = events.filter((event) => event.material).length;
-    if (events.length > 0) {
-      info.push({
-        id: "count",
-        parts: [
-          {
-            text: `${events.length} filings, ${material} with news`,
-            tone: "muted",
-          },
-        ],
-      });
     }
     const hints = selected
       ? [{ id: "open", key: "o", label: "pen filing", onPress: openFiling }]
       : [];
     return { info, hints };
-  }, [status, events, selected, openFiling]);
+  }, [status, selected, openFiling]);
 
-  if (!ticker)
-    return <EmptyState title="Pick a ticker to see its 8-K filings." />;
+  if (!ticker) return <EmptyState title="Pick a ticker to see its 8-K filings." />;
   if (status === "loading" && events.length === 0) {
+    return <PaneStatusBody loading align="center" loadingLabel="Loading 8-Ks..." />;
+  }
+  if (status === "error") {
     return (
-      <PaneStatusBody loading align="center" loadingLabel="Loading 8-Ks..." />
+      <PaneStatusBody
+        error={error ?? "Could not load 8-K filings."}
+        errorTitle="Could not load 8-K filings."
+      />
     );
   }
-  if (status === "error")
-    return (
-      <PaneStatusBody error={error ?? "Could not load 8-K filings."} errorTitle="Could not load 8-K filings." />
-    );
   if (status === "loaded" && events.length === 0) {
     return (
-      <EmptyState
-        title={`No 8-K on file for ${ticker} in the last six months.`}
-      />
+      <EmptyState title={`No 8-K on file for ${ticker} in the last six months.`} />
     );
   }
 
-  const proseWidth = Math.min(Math.max(12, width - 2), 100);
-  const detail = selected ? (
-    <Box flexDirection="column" flexGrow={1} paddingX={1}>
-      <Prose
-        text={[
-          formatFiled(selected.filedAt),
-          ...selected.labels.filter((label) => label !== "Exhibits"),
-        ].join("  ·  ")}
-        width={proseWidth}
-        color={colors.textDim}
-      />
-      {selected.headline ? (
-        <Box marginTop={1}>
-          <Prose
-            text={selected.headline}
-            width={proseWidth}
-            color={colors.textBright}
-          />
-        </Box>
-      ) : null}
-      {selected.summary ? (
-        <Box flexDirection="column" marginTop={1}>
-          {selected.summary.split("\n").map((point) => (
-            <Prose
-              key={point}
-              text={point}
-              width={proseWidth}
-              color={colors.text}
-              prefix="• "
-            />
-          ))}
-        </Box>
-      ) : null}
-      {selected.people.length > 0 ? (
-        <Box flexDirection="column">
-          <SectionHeading marginTop={1} title="PEOPLE" />
-          {selected.people.map((person) => (
-            <Prose
-              key={`${person.name}-${person.action}`}
-              text={[
-                person.role,
-                person.action,
-                person.effective ? `effective ${person.effective}` : null,
-              ]
-                .filter(Boolean)
-                .join(", ")}
-              width={proseWidth}
-              color={colors.textDim}
-              prefix={`${person.name}  `}
-              prefixColor={colors.textBright}
-            />
-          ))}
-        </Box>
-      ) : null}
-      {!selected.read ? (
-        <Box marginTop={1}>
-          <Text fg={colors.textDim}>
-            Routine filing; the headline is the item label. Press o to read it.
-          </Text>
-        </Box>
-      ) : (
-        <Box marginTop={1}>
-          <Text fg={colors.textDim}>
-            Read from the filing by a model; names checked against the text.
-            Press o to open it.
-          </Text>
-        </Box>
-      )}
-    </Box>
-  ) : null;
-
   return (
-    <DataTableStackView<CloudFilingEventPayload, EventColumn>
-      focused={focused}
-      detailOpen={detailOpen && !!selected}
-      onBack={() => setDetailOpen(false)}
-      detailContent={detail}
-      detailTitle={
-        selected
-          ? `${formatFiled(selected.filedAt)}  ${itemCodes(selected)}`
-          : undefined
-      }
-      onRootKeyDown={handleKey}
-      onDetailKeyDown={handleKey}
-      selection={{
-        kind: "id",
-        selectedId,
-        getId: (event) => event.id,
-        onChange: setSelectedId,
-      }}
-      onActivate={() => setDetailOpen(true)}
-      rootWidth={width}
-      rootHeight={Math.max(2, height)}
-      columns={columns}
-      items={events}
-      sortColumnId="date"
-      sortDirection="desc"
-      onHeaderClick={() => {}}
-      getItemKey={(event) => event.id}
-      renderCell={renderCell}
-      emptyStateTitle="No filings."
-    />
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      flexShrink={1}
+      flexBasis={0}
+      minHeight={0}
+      overflow="hidden"
+    >
+      <Box height={1} flexShrink={0} paddingX={1} overflow="hidden">
+        <Text fg={colors.textDim}>{feed.summaryLine}</Text>
+      </Box>
+      <ScrollBox
+        ref={scrollRef}
+        flexGrow={1}
+        flexShrink={1}
+        flexBasis={0}
+        minHeight={0}
+        scrollY
+        focusable={false}
+        paddingX={1}
+      >
+        <Box
+          flexDirection="column"
+          width={nativePaneChrome ? "100%" : bodyWidth}
+        >
+          {feed.sections.map((section) => (
+            <Box key={section.id} flexDirection="column">
+              <SectionHeading marginTop={1} title={section.title} />
+              {section.entries.map((entry) => (
+                <FilingEntry
+                  key={entry.id}
+                  entry={entry}
+                  nativePaneChrome={nativePaneChrome}
+                  onOpen={() => {
+                    setSelectedId(entry.id);
+                    void rendererHost.openExternal(entry.docUrl);
+                  }}
+                  onSelect={() => setSelectedId(entry.id)}
+                  proseWidth={proseWidth}
+                  selected={entry.id === selected?.id}
+                />
+              ))}
+            </Box>
+          ))}
+          <Box height={1} marginTop={1}>
+            <Text fg={colors.textDim}>
+              Headlines and points are read from the filing by a model; names are
+              checked against its text.
+            </Text>
+          </Box>
+        </Box>
+      </ScrollBox>
+    </Box>
   );
 }

--- a/src/renderers/electrobun/bun/desktop/host-requests.ts
+++ b/src/renderers/electrobun/bun/desktop/host-requests.ts
@@ -19,6 +19,7 @@ interface DesktopHostRequestOptions<TRpc> {
   focusWindowForRpcKey: (windowKey: string) => void;
   getMainWindow: () => BrowserWindow | null;
   getRpcWindowKey: (rpc: TRpc) => string | undefined;
+  isWindowFullscreenForRpcKey: (windowKey: string | undefined) => boolean;
   request: DesktopHostRequest;
   restartDesktopApp: (message?: DesktopRestartMessage) => void;
   rpc: TRpc;
@@ -59,6 +60,7 @@ export async function handleDesktopHostRequest<TRpc>({
   focusWindowForRpcKey,
   getMainWindow,
   getRpcWindowKey,
+  isWindowFullscreenForRpcKey,
   request,
   restartDesktopApp,
   rpc,
@@ -104,6 +106,8 @@ export async function handleDesktopHostRequest<TRpc>({
       }
       return null;
     }
+    case "host.windowFullscreen":
+      return isWindowFullscreenForRpcKey(getRpcWindowKey(rpc));
     case "host.openExternal": {
       if (typeof request.payload.url !== "string") {
         throw new Error("host.openExternal requires a URL.");

--- a/src/renderers/electrobun/bun/index.ts
+++ b/src/renderers/electrobun/bun/index.ts
@@ -378,10 +378,27 @@ function quitDesktopApp(): void {
   Utils.quit();
 }
 
-function controlWindowForRpcKey(windowKey: string | undefined, action: DesktopWindowControlAction): boolean {
-  const targetWindow = windowKey === MAIN_WINDOW_RPC_KEY
+function windowForRpcKey(windowKey: string | undefined): BrowserWindow | null {
+  return windowKey === MAIN_WINDOW_RPC_KEY
     ? mainWindow
     : detachedWindowManager.getWindowForRpcKey(windowKey);
+}
+
+/**
+ * Electrobun has no fullscreen event, so the view asks after every resize.
+ * A runtime whose native library cannot answer reports windowed, which is the
+ * layout the header held before it could ask at all.
+ */
+function isWindowFullscreenForRpcKey(windowKey: string | undefined): boolean {
+  try {
+    return windowForRpcKey(windowKey)?.isFullScreen?.() === true;
+  } catch {
+    return false;
+  }
+}
+
+function controlWindowForRpcKey(windowKey: string | undefined, action: DesktopWindowControlAction): boolean {
+  const targetWindow = windowForRpcKey(windowKey);
   if (!targetWindow) return false;
   if (action !== "close") {
     detachedWindowManager.suppressAutoDockForRpcKey(windowKey);
@@ -471,6 +488,7 @@ async function handleBackendRequest(
     case "host.restart":
     case "host.exit":
     case "host.windowControl":
+    case "host.windowFullscreen":
     case "host.openExternal":
     case "host.copyText":
     case "host.focusWindow":
@@ -487,6 +505,7 @@ async function handleBackendRequest(
         focusWindowForRpcKey: (windowKey) => detachedWindowManager.focusWindowForRpcKey(windowKey),
         getMainWindow: () => mainWindow,
         getRpcWindowKey,
+        isWindowFullscreenForRpcKey,
         request,
         restartDesktopApp,
         rpc,

--- a/src/renderers/electrobun/shared/protocol.ts
+++ b/src/renderers/electrobun/shared/protocol.ts
@@ -133,6 +133,7 @@ export interface DesktopBackendRequestMap {
   "host.restart": { request: DesktopRestartMessage; response: null };
   "host.exit": { request: null; response: null };
   "host.windowControl": { request: { action: DesktopWindowControlAction }; response: null };
+  "host.windowFullscreen": { request: null; response: boolean };
   "host.openExternal": { request: { url: string }; response: null };
   "host.copyText": { request: { text: string }; response: null };
   "host.focusWindow": { request: null; response: null };

--- a/src/renderers/electrobun/view/host/scroll-box.desktop.test.tsx
+++ b/src/renderers/electrobun/view/host/scroll-box.desktop.test.tsx
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { createDomTestHarness } from "../test-utils";
+import { WebScrollBox } from "./scroll-box";
+
+const { render } = createDomTestHarness();
+
+/**
+ * OpenTUI's ScrollBox scrolls vertically unless told otherwise. When the web
+ * one did not, a pane that rendered a bare ScrollBox came out unscrollable in
+ * the desktop app and only its own arrow-key handler could move it.
+ */
+test("scrolls vertically by default and only sideways for a one-row strip", async () => {
+  const container = await render(
+    <>
+      <WebScrollBox data-testid="body"><span>body</span></WebScrollBox>
+      <WebScrollBox data-testid="off" scrollY={false}><span>clipped</span></WebScrollBox>
+      <WebScrollBox data-testid="strip" scrollX height={1}><span>tabs</span></WebScrollBox>
+    </>,
+  );
+  const styleOf = (id: string) => (container.querySelector(`[data-testid="${id}"]`) as HTMLElement).style;
+
+  expect(styleOf("body").overflowY).toBe("auto");
+  expect(styleOf("off").overflowY).toBe("hidden");
+  expect(styleOf("strip").overflowX).toBe("auto");
+  expect(styleOf("strip").overflowY).toBe("hidden");
+});

--- a/src/renderers/electrobun/view/host/scroll-box.tsx
+++ b/src/renderers/electrobun/view/host/scroll-box.tsx
@@ -21,11 +21,19 @@ export const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unkno
   function WebScrollBox({ children, ...props }, ref) {
     const elementRef = useRef<HTMLDivElement | null>(null);
     const isHeaderLikeScroller = props.scrollX === true && props.scrollY !== true && props.height === 1;
+    /**
+     * OpenTUI's ScrollBox scrolls vertically unless told otherwise, so this one
+     * has to as well: a pane that renders a ScrollBox and nothing more expects
+     * the wheel to work, and used to get an unscrollable box that only its own
+     * arrow-key handler could move. The one-row horizontal strips (tab bars,
+     * table headers, chart legends) are the exception and scroll on their axis.
+     */
+    const scrollYEnabled = props.scrollY !== false && !isHeaderLikeScroller;
     const [horizontalScrollBarVisible, setHorizontalScrollBarVisible] = useState(
       () => props.scrollX === true && !isHeaderLikeScroller,
     );
     const [verticalScrollBarVisible, setVerticalScrollBarVisible] = useState(
-      () => props.scrollY === true,
+      () => scrollYEnabled,
     );
     const horizontalScrollBarVisibleRef = useRef(horizontalScrollBarVisible);
     const verticalScrollBarVisibleRef = useRef(verticalScrollBarVisible);
@@ -92,10 +100,10 @@ export const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unkno
     }, [horizontalScrollBar, props.scrollX]);
 
     useEffect(() => {
-      if (props.scrollY !== true) {
+      if (!scrollYEnabled) {
         verticalScrollBar.visible = false;
       }
-    }, [props.scrollY, verticalScrollBar]);
+    }, [scrollYEnabled, verticalScrollBar]);
 
     useEffect(() => () => {
       if (scrollFrameRef.current != null) {
@@ -226,9 +234,9 @@ export const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unkno
       verticalScrollBar,
     ]);
 
-    const scrollable = props.scrollX === true || props.scrollY === true;
+    const scrollable = props.scrollX === true || scrollYEnabled;
     const overflowX = props.scrollX === true ? "auto" : "hidden";
-    const overflowY = props.scrollY === true ? "auto" : "hidden";
+    const overflowY = scrollYEnabled ? "auto" : "hidden";
     const handleScroll = useCallback(() => {
       emitScrollPositionChanges();
       markScrollbarActive();
@@ -251,7 +259,7 @@ export const WebScrollBox = forwardRef<ScrollBoxRenderable, Record<string, unkno
         {...cleanDomProps(props)}
         ref={elementRef}
         data-gloom-scrollbar-x={props.scrollX === true ? (horizontalScrollBarVisible ? "visible" : "hidden") : undefined}
-        data-gloom-scrollbar-y={props.scrollY === true ? (verticalScrollBarVisible ? "visible" : "hidden") : undefined}
+        data-gloom-scrollbar-y={scrollYEnabled ? (verticalScrollBarVisible ? "visible" : "hidden") : undefined}
         data-gloom-scrollbar-active={scrollbarActive ? "true" : undefined}
         onMouseDown={(event) => callMouseHandler(props.onMouseDown, event, "down")}
         onMouseMove={(event) => callMouseHandler(props.onMouseMove, event, "move")}

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -21,6 +21,7 @@ import {
   installElectrobunHttpFetchTransport,
 } from "./http-fetch";
 import { installElectrobunUpdateHost } from "./update-host";
+import { installElectrobunWindowFullscreenTracking } from "./window-fullscreen";
 import { DesktopFatalScreen, ElectrobunErrorBoundary } from "./fatal-screen";
 import { WebInputHostProvider } from "./input-host";
 import { webNativeRenderer } from "./native-renderer";
@@ -102,6 +103,7 @@ async function boot() {
   const init = await measurePerfAsync("startup.electrobun.backend-init", () => backendInitPromise);
   installElectrobunAiHost();
   installFocusScopeRelease();
+  installElectrobunWindowFullscreenTracking();
   const desktopSnapshot = init.windowKind === "detached" && init.paneId && init.desktopSnapshot
     ? prepareDetachedSnapshot(init.desktopSnapshot, init.paneId)
     : init.desktopSnapshot;

--- a/src/renderers/electrobun/view/window-fullscreen.ts
+++ b/src/renderers/electrobun/view/window-fullscreen.ts
@@ -1,0 +1,57 @@
+import { setWindowFullscreen } from "../../../components/layout/window-fullscreen";
+import { backendRequest } from "./backend-rpc";
+
+/**
+ * Long enough that dragging a window edge does not ask the host on every
+ * frame, short enough that the header has moved by the time the fullscreen
+ * animation finishes.
+ */
+const RESIZE_SETTLE_MS = 120;
+
+/**
+ * Keeps the view's idea of its window's fullscreen state current. Electrobun
+ * emits no fullscreen event and a webview cannot see its window's style mask,
+ * but entering and leaving fullscreen always resizes the window, so the host
+ * is asked every time the size settles.
+ */
+export function installElectrobunWindowFullscreenTracking(): () => void {
+  let settleTimer: ReturnType<typeof setTimeout> | null = null;
+  let reading = false;
+  let readAgain = false;
+
+  const read = async (): Promise<void> => {
+    if (reading) {
+      readAgain = true;
+      return;
+    }
+    reading = true;
+    try {
+      setWindowFullscreen(await backendRequest("host.windowFullscreen") === true);
+    } catch {
+      // A host too old to answer has the window chrome the header already
+      // assumes, so leaving the last known state alone is the safe read.
+    } finally {
+      reading = false;
+      if (readAgain) {
+        readAgain = false;
+        void read();
+      }
+    }
+  };
+
+  const scheduleRead = (): void => {
+    if (settleTimer) clearTimeout(settleTimer);
+    settleTimer = setTimeout(() => {
+      settleTimer = null;
+      void read();
+    }, RESIZE_SETTLE_MS);
+  };
+
+  window.addEventListener("resize", scheduleRead);
+  void read();
+
+  return () => {
+    window.removeEventListener("resize", scheduleRead);
+    if (settleTimer) clearTimeout(settleTimer);
+  };
+}


### PR DESCRIPTION
Three desktop reports from the Mac app.

## The header keeps room for traffic lights that are not there

`getTitlebarLeadingInset()` returned a flat eight columns on macOS, and nothing in the view knew the window was in fullscreen, where macOS takes the traffic lights away. The command prompt and the sheet that drops out of it stayed indented into an empty corner.

Electrobun emits no fullscreen event and a webview cannot see its window's style mask, so the view asks the host over a new `host.windowFullscreen` request every time the window settles at a new size — entering and leaving fullscreen always resizes. The answer lands in a small store the header, the detached pane shell and the command sheet read, and a runtime whose native library cannot answer reports windowed, which is the layout the header held before.

## Panes that would not scroll under the mouse

Renderer parity bug. OpenTUI's `ScrollBox` scrolls vertically unless told otherwise; the web one only set `overflowY: auto` when a caller passed `scrollY`. The Risks tab, the Exec tab and the marketplace detail render a bare `ScrollBox`, so in the desktop app they were unscrollable boxes that only their own arrow-key handlers could move, while `scrollTop` still worked programmatically — which is why the arrows felt fine.

The web `ScrollBox` now matches upstream. The one-row horizontal strips — tab bars, table headers, chart legends — are the exception and keep their own axis.

## The 8-K pane did not say much

It was a table of raw SEC item codes (`2.02`, `1.01 3.03 5…`, clipped) with the headline beside them, and the model's reading of each filing — the points, the people named — behind Enter. On a company that files three 8-Ks in six months it was three rows of "Results of operations" in an otherwise empty pane.

It reads as a feed now, like the Risks and Exec tabs that shipped beside it: what happened first, each filing with its plain-English items, its headline, its points and the people it names; the routine filings gathered under them. The count moved out of the footer into a summary line, `o` still opens the selected filing, the filed date is a link, and `j`/`k` walk the filings with the feed following.

## Verification

- `bun run typecheck`, `bun test` (2689 pass), `bun run plugins:manifest:check`, `bun run desktop:view:build`, `bun run web:audit`
- 8-K feed rendered through `gloomberb shot EK` for a company with one newsworthy filing and one with seven
- 8-K feed, selection and scroll-into-view driven in the terminal under tmux
- New tests cover the feed's grouping and measurement, the scroll target, the fullscreen prompt geometry, and the ScrollBox default

🤖 Generated with [Claude Code](https://claude.com/claude-code)