### PR TITLE
Preserve listing identity and requested tabs in research links

### DIFF
--- a/src/app/pane-runtime/ticker-open-runtime.test.tsx
+++ b/src/app/pane-runtime/ticker-open-runtime.test.tsx
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../../renderers/opentui/test-utils";
+import { createTestDataProvider } from "../../test-support/data-provider";
+import { createBrowserResearchLayout, BROWSER_RESEARCH_PANE_ID } from "../../renderers/browser/config-host";
+import { createInitialState, type AppAction } from "../../state/app/context";
+import { createDefaultConfig, createPaneInstance, TICKER_RESEARCH_PANE_ID } from "../../types/config";
+import type { TickerRecord } from "../../types/ticker";
+import { useAppTickerOpenRuntime } from "./ticker-open-runtime";
+
+test("a slow linked ticker applies its tab to the reused or new pane after hydration", async () => {
+  for (const reusePane of [true, false]) {
+    const config = createDefaultConfig(":memory:");
+    config.layout = createBrowserResearchLayout(reusePane ? "VOD:XLON" : "NVDA");
+    const stateRef = { current: createInitialState(config) };
+    const actions: AppAction[] = [];
+    const focused: string[] = [];
+    let layouts = 0;
+    let releaseSearch!: () => void;
+    const pendingSearch = new Promise<void>((resolve) => { releaseSearch = resolve; });
+    let runtime!: ReturnType<typeof useAppTickerOpenRuntime>;
+    function Harness() {
+      runtime = useAppTickerOpenRuntime({
+        stateRef,
+        dataProvider: createTestDataProvider({ search: async () => {
+          await pendingSearch;
+          return [{ providerId: "cloud", symbol: "VOD", name: "Vodafone", exchange: "LSE", currency: "GBP", type: "EQUITY" }];
+        } }),
+        tickerRepository: {
+          loadTicker: async () => null,
+          createTicker: async (metadata: TickerRecord["metadata"]) => ({ metadata }),
+        } as any,
+        dispatch: (action) => { actions.push(action); },
+        pluginRegistry: {
+          panes: new Map([[TICKER_RESEARCH_PANE_ID, { id: TICKER_RESEARCH_PANE_ID }]]),
+          events: { emit() {} }, notify() {}, getTermSizeFn: () => ({ width: 120, height: 40 }),
+        } as any,
+        buildPaneInstance: (paneId, options) => createPaneInstance(paneId, { ...options, instanceId: "ticker-detail:linked" }),
+        persistLayout: (layout) => { layouts++; stateRef.current.config.layout = layout; },
+        activatePane: (paneId) => { focused.push(paneId); },
+        focusVisiblePane: (paneId) => { focused.push(paneId); },
+      });
+      return <text>Research</text>;
+    }
+    const rendered = await testRender(<Harness />, { width: 20, height: 2 });
+    try {
+      await act(async () => { await rendered.renderOnce(); });
+      const opening = runtime.openPinnedTicker("VOD:XLON", { tabId: "financials", floating: true });
+      // Focus may change while the provider is still resolving the linked listing.
+      stateRef.current.focusedPaneId = "world-indices:main";
+      expect(actions).toEqual([]);
+      releaseSearch();
+      await act(async () => { await opening; });
+      const paneId = reusePane ? BROWSER_RESEARCH_PANE_ID : "ticker-detail:linked";
+      expect(actions).toContainEqual({ type: "UPDATE_PANE_STATE", paneId, patch: { activeTabId: "financials" } });
+      expect(actions.filter((action) => action.type === "UPDATE_PANE_STATE")).toHaveLength(1);
+      expect(actions.find((action) => action.type === "UPDATE_TICKER")).toMatchObject({ ticker: { metadata: { ticker: "VOD:XLON", exchange: "LSE" } } });
+      expect(stateRef.current.config.layout.instances.find((pane) => pane.instanceId === paneId)?.binding)
+        .toEqual({ kind: "fixed", symbol: "VOD:XLON" });
+      expect(focused).toEqual([paneId]);
+      expect(layouts).toBe(reusePane ? 0 : 1);
+    } finally {
+      await act(async () => { rendered.renderer.destroy(); });
+    }
+  }
+});

--- a/src/app/pane-runtime/ticker-open-runtime.ts
+++ b/src/app/pane-runtime/ticker-open-runtime.ts
@@ -93,6 +93,9 @@ export function useAppTickerOpenRuntime({
       ? null
       : findFixedTickerPaneForSymbol(currentLayout, paneType, symbol);
     if (existing) {
+      if (paneType === TICKER_RESEARCH_PANE_ID && options?.tabId) {
+        dispatch({ type: "UPDATE_PANE_STATE", paneId: existing.instanceId, patch: { activeTabId: options.tabId } });
+      }
       focusVisiblePane(existing.instanceId, currentLayout);
       return;
     }
@@ -118,10 +121,14 @@ export function useAppTickerOpenRuntime({
         },
       );
     persistLayout(nextLayout);
+    if (paneType === TICKER_RESEARCH_PANE_ID && options?.tabId) {
+      dispatch({ type: "UPDATE_PANE_STATE", paneId: instance.instanceId, patch: { activeTabId: options.tabId } });
+    }
     activatePane(instance.instanceId, nextLayout);
   }, [
     activatePane,
     buildPaneInstance,
+    dispatch,
     focusVisiblePane,
     persistLayout,
     pluginRegistry,

--- a/src/app/runtime/desktop-deeplink.ts
+++ b/src/app/runtime/desktop-deeplink.ts
@@ -381,13 +381,8 @@ function handleOpenTicker(
   pluginRegistry.pinTicker(action.symbol, {
     floating: true,
     paneType: TICKER_RESEARCH_PANE_ID,
+    tabId: action.tabId ?? undefined,
   });
-
-  if (action.tabId) {
-    globalThis.setTimeout(() => {
-      pluginRegistry.switchTab(action.tabId!);
-    }, 80);
-  }
   notifySuccess(pluginRegistry, action.message);
 }
 

--- a/src/sources/gloomberb-cloud/index.test.ts
+++ b/src/sources/gloomberb-cloud/index.test.ts
@@ -3,6 +3,7 @@ import { createGloomberbCloudCapabilities, GloomberbCloudProvider } from "./inde
 import { getRangeStartDate, toHistoryRequest } from "./normalizers";
 import type { NewsCapability } from "../../capabilities";
 import { apiClient, type AuthUser, type CloudNewsPayload } from "../../api-client";
+import { cloudNewsParams } from "./news";
 
 const verifiedUser: AuthUser = {
   id: "user-1",
@@ -39,6 +40,17 @@ test("requests fifty years of cloud history for the ALL range", () => {
     outputsize: 600,
     rangeKey: "ALL",
   });
+});
+
+test("news lookup shares the canonical listing across public and Yahoo deep-link aliases", () => {
+  for (const ticker of ["VOD:XLON", "VOD.L"]) {
+    expect(cloudNewsParams({ scope: "ticker", ticker, exchange: "LSE" }))
+      .toMatchObject({ ticker: "VOD", exchange: "XLON" });
+  }
+  expect(cloudNewsParams({ scope: "ticker", ticker: "BRK.B", exchange: "NYSE" }))
+    .toMatchObject({ ticker: "BRK.B", exchange: "XNYS" });
+  expect(cloudNewsParams({ scope: "ticker", ticker: "VOD.L", exchange: "NASDAQ" }))
+    .toMatchObject({ ticker: "VOD.L", exchange: "XNAS" });
 });
 
 function makeCloudNewsPayload(overrides: Partial<CloudNewsPayload> = {}): CloudNewsPayload {

--- a/src/sources/gloomberb-cloud/news.ts
+++ b/src/sources/gloomberb-cloud/news.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../api-client";
 import type { CloudNewsParams } from "../../api-client/paths";
 import { parsePublicTickerKey, publicExchange } from "../../utils/exchanges";
+import { getYahooSymbol, tickerHasYahooSuffix } from "../yahoo-finance/symbols";
 
 function normalizeStringArray(value: unknown): string[] {
   return Array.isArray(value)
@@ -93,10 +94,16 @@ export function mapCloudNewsArticle(
 export function cloudNewsParams(query: NewsQuery): CloudNewsParams {
   const feed = query.feed ?? (query.scope === "ticker" ? "ticker" : "latest");
   const ticker = query.ticker ? parsePublicTickerKey(query.ticker) : undefined;
+  const exchange = ticker?.exchange ?? query.exchange;
+  let symbol = ticker?.symbol;
+  if (symbol && exchange && tickerHasYahooSuffix(symbol)) {
+    const baseSymbol = symbol.slice(0, symbol.lastIndexOf("."));
+    if (getYahooSymbol(baseSymbol, exchange) === symbol) symbol = baseSymbol;
+  }
   return {
     feed,
-    ticker: feed === "ticker" ? ticker?.symbol : undefined,
-    exchange: feed === "ticker" ? publicExchange(ticker?.exchange ?? query.exchange) : undefined,
+    ticker: feed === "ticker" ? symbol : undefined,
+    exchange: feed === "ticker" ? publicExchange(exchange) : undefined,
     tickerTier:
       feed === "ticker" ? query.tickerTier ?? "primary" : query.tickerTier,
     tickerRelations: query.tickerRelations,

--- a/src/tickers/open-target.test.ts
+++ b/src/tickers/open-target.test.ts
@@ -43,17 +43,24 @@ test("opening an ordinary query keeps the provider ticker instead of persisting 
   expect(await tickerRepository.loadTicker("BRKB")).toBeNull();
 });
 
-test("quote-only hydration rejects a conflicting reported listing exchange", async () => {
+test("quote-only hydration verifies the returned symbol and listing before preserving a qualified key", async () => {
   for (const query of ["VOD:XLON", "VOD.L"]) {
-    for (const exchange of ["NASDAQ", "LSE"]) {
+    for (const [symbol, exchange, valid] of [
+      ["VOD", "NASDAQ", false],
+      ["BARC", "LSE", false],
+      ["VOD", undefined, false],
+      ["VOD.L", "NASDAQ", false],
+      ["VOD", "LSE", true],
+      ["VOD.L", "LSE", true],
+    ] as const) {
       const tickerRepository = repository();
       const target = await resolveTickerOpenTarget({
         query, tickerRepository, tickers: new Map(),
         dataProvider: createTestDataProvider({ getQuote: async () => ({
-          symbol: "VOD", exchangeName: exchange, price: 1.25, currency: "GBP", lastUpdated: 1, change: 0, changePercent: 0,
+          symbol, exchangeName: exchange, price: 1.25, currency: "GBP", lastUpdated: 1, change: 0, changePercent: 0,
         }) }),
       });
-      if (exchange === "NASDAQ") {
+      if (!valid) {
         expect(target).toBeNull();
         expect(await tickerRepository.loadAllTickers()).toEqual([]);
       } else {

--- a/src/tickers/open-target.test.ts
+++ b/src/tickers/open-target.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test";
+import { JsonTickerRepository } from "../data/json-ticker-repository";
+import { createTestDataProvider } from "../test-support/data-provider";
+import { resolveTickerOpenTarget } from "./open-target";
+
+function repository() {
+  const values = new Map<string, string>();
+  return new JsonTickerRepository({
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
+  });
+}
+
+test("opening validated venue links hydrates their exact key without changing another listing's holdings", async () => {
+  for (const query of ["VOD:XLON", "VOD.L"]) {
+    for (const savedExchange of [null, "NASDAQ", "LSE"]) {
+      const tickerRepository = repository();
+      const saved = savedExchange ? await tickerRepository.createTicker({
+        ticker: "VOD", exchange: savedExchange, currency: savedExchange === "LSE" ? "GBP" : "USD", name: "Vodafone",
+        portfolios: ["retirement"], watchlists: [], positions: [{ portfolio: "retirement", shares: 10, avgCost: 20, broker: "manual", currency: "USD" }], custom: {}, tags: [],
+      }) : null;
+      const before = await tickerRepository.loadTicker("VOD");
+      const target = await resolveTickerOpenTarget({
+        query, tickerRepository, tickers: new Map(saved ? [["VOD", saved]] : []),
+        dataProvider: createTestDataProvider({ search: async () => [{ providerId: "cloud", symbol: "VOD", exchange: "LSE", currency: "GBp", name: "Vodafone Group", type: "EQUITY" }] }),
+      });
+      expect(target?.symbol).toBe(query);
+      expect(target?.ticker.metadata).toMatchObject({ ticker: query, exchange: "LSE", positions: [], portfolios: [] });
+      expect(await tickerRepository.loadTicker(query)).not.toBeNull();
+      expect(await tickerRepository.loadTicker("VOD")).toEqual(before);
+    }
+  }
+});
+
+test("opening an ordinary query keeps the provider ticker instead of persisting search text", async () => {
+  const tickerRepository = repository();
+  const target = await resolveTickerOpenTarget({
+    query: "brkb", tickerRepository, tickers: new Map(),
+    dataProvider: createTestDataProvider({ search: async () => [{ providerId: "cloud", symbol: "BRK.B", exchange: "NYSE", currency: "USD", name: "Berkshire Hathaway", type: "EQUITY" }] }),
+  });
+  expect(target?.symbol).toBe("BRK.B");
+  expect(await tickerRepository.loadTicker("BRKB")).toBeNull();
+});
+
+test("quote-only hydration rejects a conflicting reported listing exchange", async () => {
+  for (const query of ["VOD:XLON", "VOD.L"]) {
+    for (const exchange of ["NASDAQ", "LSE"]) {
+      const tickerRepository = repository();
+      const target = await resolveTickerOpenTarget({
+        query, tickerRepository, tickers: new Map(),
+        dataProvider: createTestDataProvider({ getQuote: async () => ({
+          symbol: "VOD", exchangeName: exchange, price: 1.25, currency: "GBP", lastUpdated: 1, change: 0, changePercent: 0,
+        }) }),
+      });
+      if (exchange === "NASDAQ") {
+        expect(target).toBeNull();
+        expect(await tickerRepository.loadAllTickers()).toEqual([]);
+      } else {
+        expect(target?.ticker.metadata).toMatchObject({ ticker: query, exchange: "LSE", currency: "GBP" });
+      }
+    }
+  }
+});

--- a/src/tickers/open-target.ts
+++ b/src/tickers/open-target.ts
@@ -3,11 +3,14 @@ import type { SearchRequestContext, DataProvider } from "../types/data-provider"
 import type { TickerRecord } from "../types/ticker";
 import {
   normalizeTickerInput,
+  findExactTickerSearchMatch,
   resolveTickerSearch,
   upsertTickerFromSearchResult,
 } from "./search";
 import { normalizeTickerSymbol } from "./search/ranking";
 import type { TickerOpenTarget } from "./search/types";
+import { parsePublicTickerKey } from "../utils/exchanges";
+import { tickerHasYahooSuffix } from "../sources/yahoo-finance/symbols";
 
 export type { TickerOpenTarget } from "./search/types";
 
@@ -26,6 +29,8 @@ export async function resolveTickerOpenTarget({
 }): Promise<TickerOpenTarget | null> {
   const symbol = normalizeTickerInput(null, query);
   if (!symbol) return null;
+  const requested = parsePublicTickerKey(symbol);
+  const preserveListingKey = !!requested.exchange || tickerHasYahooSuffix(symbol);
 
   let resolved: Awaited<ReturnType<typeof resolveTickerSearch>> | null = null;
   try {
@@ -41,17 +46,39 @@ export async function resolveTickerOpenTarget({
   }
 
   if (resolved?.kind === "local") {
+    if (preserveListingKey && resolved.symbol !== symbol) {
+      const metadata = resolved.ticker.metadata;
+      const { ticker, created } = await upsertTickerFromSearchResult(tickerRepository, {
+        providerId: dataProvider.id,
+        symbol: resolved.symbol,
+        exchange: metadata.exchange,
+        currency: metadata.currency,
+        name: metadata.name,
+        type: metadata.assetCategory || "",
+        brokerContract: metadata.broker_contracts?.[0],
+      }, { tickerSymbol: symbol });
+      return { symbol: ticker.metadata.ticker, ticker, created };
+    }
     return { symbol: resolved.symbol, ticker: resolved.ticker, created: false };
   }
 
   if (resolved?.kind === "provider") {
-    const { ticker, created } = await upsertTickerFromSearchResult(tickerRepository, resolved.result);
+    // Search validates the listing, but its provider symbol may omit the venue.
+    // Keep the explicit key that an incoming layout and its followers reference.
+    const { ticker, created } = await upsertTickerFromSearchResult(tickerRepository, resolved.result, {
+      tickerSymbol: preserveListingKey ? symbol : undefined,
+    });
     return { symbol: ticker.metadata.ticker, ticker, created };
   }
 
   try {
     const quote = await dataProvider.getQuote(symbol, "");
-    const quoteSymbol = normalizeTickerSymbol(quote.symbol || symbol);
+    const quoteExchange = quote.listingExchangeName ?? quote.exchangeName;
+    if (preserveListingKey && quoteExchange) {
+      const baseSymbol = requested.exchange ? requested.symbol : symbol.slice(0, symbol.lastIndexOf("."));
+      if (!findExactTickerSearchMatch([{ label: baseSymbol, right: quoteExchange }], symbol)) return null;
+    }
+    const quoteSymbol = preserveListingKey ? symbol : normalizeTickerSymbol(quote.symbol || symbol);
     const existing = await tickerRepository.loadTicker(quoteSymbol);
     if (existing) {
       return { symbol: existing.metadata.ticker, ticker: existing, created: false };
@@ -59,7 +86,7 @@ export async function resolveTickerOpenTarget({
 
     const ticker = await tickerRepository.createTicker({
       ticker: quoteSymbol,
-      exchange: quote.listingExchangeName ?? quote.exchangeName ?? "",
+      exchange: requested.exchange ?? quote.listingExchangeName ?? quote.exchangeName ?? "",
       currency: quote.currency || "USD",
       name: quote.name || quoteSymbol,
       assetCategory: undefined,

--- a/src/tickers/open-target.ts
+++ b/src/tickers/open-target.ts
@@ -10,7 +10,7 @@ import {
 import { normalizeTickerSymbol } from "./search/ranking";
 import type { TickerOpenTarget } from "./search/types";
 import { parsePublicTickerKey } from "../utils/exchanges";
-import { tickerHasYahooSuffix } from "../sources/yahoo-finance/symbols";
+import { getYahooSymbol, tickerHasYahooSuffix } from "../sources/yahoo-finance/symbols";
 
 export type { TickerOpenTarget } from "./search/types";
 
@@ -77,6 +77,11 @@ export async function resolveTickerOpenTarget({
     if (preserveListingKey && quoteExchange) {
       const baseSymbol = requested.exchange ? requested.symbol : symbol.slice(0, symbol.lastIndexOf("."));
       if (!findExactTickerSearchMatch([{ label: baseSymbol, right: quoteExchange }], symbol)) return null;
+    }
+    if (preserveListingKey) {
+      const yahooAlias = requested.exchange ? getYahooSymbol(requested.symbol, requested.exchange) : symbol;
+      const explicitAliasMatches = tickerHasYahooSuffix(yahooAlias) && normalizeTickerSymbol(quote.symbol) === yahooAlias;
+      if (!explicitAliasMatches && !findExactTickerSearchMatch([{ label: quote.symbol, right: quoteExchange }], symbol)) return null;
     }
     const quoteSymbol = preserveListingKey ? symbol : normalizeTickerSymbol(quote.symbol || symbol);
     const existing = await tickerRepository.loadTicker(quoteSymbol);

--- a/src/tickers/search/upsert.ts
+++ b/src/tickers/search/upsert.ts
@@ -13,8 +13,9 @@ import { canonicalExchange, parsePublicTickerKey, publicTickerKey } from "../../
 export async function upsertTickerFromSearchResult(
   tickerRepository: AppTickerRepositoryPort,
   result: InstrumentSearchResult,
+  options: { tickerSymbol?: string } = {},
 ): Promise<{ ticker: TickerRecord; created: boolean }> {
-  let symbol = getSearchResultSymbol(result);
+  let symbol = options.tickerSymbol ?? getSearchResultSymbol(result);
   let ticker = await tickerRepository.loadTicker(symbol);
   const selectedExchange = canonicalExchange(
     result.exchange === "SMART" ? result.primaryExchange : result.exchange || result.primaryExchange,

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -602,6 +602,8 @@ export interface PinTickerOptions {
   floating?: boolean;
   paneType?: string;
   forceNewPane?: boolean;
+  /** Select this research tab once the requested ticker has resolved. */
+  tabId?: string;
 }
 
 export interface GloomPluginContext {


### PR DESCRIPTION
Cold research links such as `?ticker=VOD%3AXLON&tab=financials` and `?ticker=VOD.L&tab=financials` could save the provider's bare `VOD` symbol while the initial research workspace still referenced the qualified key. The original research and news panes stayed empty, a separate floating pane opened, and the requested tab was lost.

Preserve explicit, validated listing keys when resolving an opening target without changing an existing listing's positions. Apply the requested tab to the actual opened or reused pane after ticker resolution, replacing the timer that could change an unrelated focused pane. Normalize matching Yahoo venue suffixes in news requests while preserving share-class punctuation, and reject quote-only fallbacks whose symbol or exchange does not establish the requested listing.

Validation: focused ticker, deep-link, pane-runtime and cloud regression tests pass; all six production TypeScript configurations pass. Fresh browser workspaces retain both `VOD:XLON` and `VOD.L`, load their London quotes and EUR financial statements, keep `tab=financials`, and reuse the initial research pane. Deferred-resolution tests cover focus changes, new panes, reused panes and unchanged saved holdings.
