### PR TITLE
Fix investor research data across income, events, 13F and options

### DIFF
--- a/src/app/runtime/desktop-deeplink.test.ts
+++ b/src/app/runtime/desktop-deeplink.test.ts
@@ -1,7 +1,36 @@
 import { describe, expect, test } from "bun:test";
-import { resolveDesktopDeepLinkAction } from "./desktop-deeplink";
+import { handleDesktopDeepLink, resolveDesktopDeepLinkAction } from "./desktop-deeplink";
+import type { PluginRegistry } from "../../plugins/registry";
+import type { AppState } from "../../state/app/context";
 
 describe("desktop deeplinks", () => {
+  test("opens a valid ticker on overview when a requested tab is unavailable, preserving registered tabs and rejected links", () => {
+    const pinned: Array<{ symbol: string; options: unknown }> = [];
+    const notices: Array<{ body: string; type: string }> = [];
+    const panes = new Map([["ticker-research", {}]]);
+    const registry = {
+      panes,
+      getTickerResearchTabPluginId: (id: string) => ["overview", "corporate-actions"].includes(id) ? "research" : undefined,
+      pinTicker: (symbol: string, options: unknown) => { pinned.push({ symbol, options }); },
+      notify: (notice: { body: string; type: string }) => { notices.push(notice); },
+    } as unknown as PluginRegistry;
+    const options = { pluginRegistry: registry, dispatch: () => {}, stateRef: { current: {} as AppState } };
+
+    handleDesktopDeepLink("gloomberb://ticker/RIVN?tab=events", options);
+    expect(pinned).toEqual([{ symbol: "RIVN", options: { floating: true, paneType: "ticker-research", tabId: "overview" } }]);
+    expect(notices.at(-1)).toEqual({ body: 'Ticker tab "events" is unavailable. Opening RIVN overview.', type: "info" });
+
+    handleDesktopDeepLink("gloomberb://ticker/RIVN?tab=corporate-actions", options);
+    expect(pinned.at(-1)?.options).toMatchObject({ tabId: "corporate-actions" });
+    handleDesktopDeepLink("gloomberb://ticker?tab=events", options);
+    expect(pinned).toHaveLength(2);
+    expect(notices.at(-1)?.type).toBe("error");
+    panes.clear();
+    handleDesktopDeepLink("gloomberb://ticker/RIVN?tab=events", options);
+    expect(pinned).toHaveLength(2);
+    expect(notices.at(-1)?.body).toBe("Ticker research is unavailable.");
+  });
+
   test("routes cloud roundup links to account management", () => {
     expect(resolveDesktopDeepLinkAction("gloomberb://cloud/roundup?week=2026-07-03")).toEqual({
       type: "open-account-management",

--- a/src/app/runtime/desktop-deeplink.ts
+++ b/src/app/runtime/desktop-deeplink.ts
@@ -373,17 +373,19 @@ function handleOpenTicker(
   pluginRegistry: PluginRegistry,
 ): void {
   if (!requirePane(pluginRegistry, TICKER_RESEARCH_PANE_ID, "Ticker research is unavailable.")) return;
-  if (action.tabId && !pluginRegistry.getTickerResearchTabPluginId(action.tabId)) {
-    notifyError(pluginRegistry, `Ticker tab "${action.tabId}" is unavailable.`);
-    return;
-  }
+  const unavailableTab = action.tabId && !pluginRegistry.getTickerResearchTabPluginId(action.tabId);
+  const tabId = unavailableTab ? "overview" : action.tabId;
 
   pluginRegistry.pinTicker(action.symbol, {
     floating: true,
     paneType: TICKER_RESEARCH_PANE_ID,
-    tabId: action.tabId ?? undefined,
+    tabId: tabId ?? undefined,
   });
-  notifySuccess(pluginRegistry, action.message);
+  if (unavailableTab) {
+    pluginRegistry.notify({ body: `Ticker tab "${action.tabId}" is unavailable. Opening ${action.symbol} overview.`, type: "info" });
+  } else {
+    notifySuccess(pluginRegistry, action.message);
+  }
 }
 
 function handleOpenCollection(

--- a/src/cli/pane-functions/index.test.ts
+++ b/src/cli/pane-functions/index.test.ts
@@ -5,6 +5,8 @@ import { paneSchemas as researchSchemas } from "../../plugins/builtin/research/h
 import type { HeadlessPaneDefinition } from "../../types/headless";
 import { describe, expect, test } from "bun:test";
 import { paneFunctionTestInternals } from "./index";
+import { parseCliGlobalArgs } from "../options";
+import { thirteenFHeadless } from "../../plugins/builtin/thirteenf/headless";
 
 const {
   parsePaneFunctionArgs,
@@ -42,6 +44,18 @@ function capabilityFor(templateId: string) {
 }
 
 describe("pane function CLI args", () => {
+  test("passes global limits through the pane schema instead of silently using its default", () => {
+    const capability = getPaneFunctionCapability({
+      id: "funds", paneId: dummyPane.id, label: "Funds", description: "Funds", headless: thirteenFHeadless,
+    }, dummyPane);
+    for (const flags of [["--limit", "15"], ["--limit=15"]]) {
+      const global = parseCliGlobalArgs(["fn", "13F", "1067983", ...flags, "--json"]);
+      const parsed = parsePaneFunctionArgs(global.args.slice(1), global.options);
+      expect(normalizeCapabilityOptions(capability, parsed.options, { strict: true }).limit).toBe(15);
+    }
+    const parsed = parsePaneFunctionArgs(["13F", "1067983"], { limit: 201 });
+    expect(() => normalizeCapabilityOptions(capability, parsed.options, { strict: true })).toThrow();
+  });
   test("inline options do not consume the next positional instrument", () => {
     expect(parsePaneFunctionArgs(["GP", "--range=1M", "ES=F"])).toMatchObject({
       target: "GP", arg: "ES=F", options: { range: "1M" },

--- a/src/cli/pane-functions/index.ts
+++ b/src/cli/pane-functions/index.ts
@@ -41,7 +41,7 @@ async function withPaneRuntime<T>(
   }) => Promise<T>,
   settings: { strictHeadlessOptions?: boolean } = {},
 ): Promise<T> {
-  const parsed = parsePaneFunctionArgs(args);
+  const parsed = parsePaneFunctionArgs(args, ctx.cliOptions);
   return withMarketData(ctx, async (context) => {
     const registry = await createPaneCatalog(context, ctx.plugins);
     try {

--- a/src/cli/pane-functions/options.ts
+++ b/src/cli/pane-functions/options.ts
@@ -62,7 +62,7 @@ export function parseArgumentsOption(value: string): Record<string, string> {
   return pairs;
 }
 
-export function parsePaneFunctionArgs(args: string[]): ParsedPaneFunctionArgs {
+export function parsePaneFunctionArgs(args: string[], globalOptions: { limit?: number } = {}): ParsedPaneFunctionArgs {
   const positionals: string[] = [];
   const options: Record<string, string | true> = {};
   let outputPath: string | null = null;
@@ -122,6 +122,9 @@ export function parsePaneFunctionArgs(args: string[]): ParsedPaneFunctionArgs {
 
   const target = positionals[0]?.trim() ?? "";
   const arg = positionals.slice(1).join(" ").trim();
+  // The outer CLI parser consumes --limit before fn/shot sees its arguments.
+  // Restore it for the pane's own schema and loader, including bounds checks.
+  if (globalOptions.limit != null) options.limit = String(globalOptions.limit);
   return { target, arg, options, outputPath, width, height, theme, scale, watermark, requireBotSafe };
 }
 

--- a/src/plugins/builtin/ai/screener/results.test.ts
+++ b/src/plugins/builtin/ai/screener/results.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, expect, test } from "bun:test";
+import { JsonTickerRepository } from "../../../../data/json-ticker-repository";
+import { createTestDataProvider } from "../../../../test-support/data-provider";
+import type { InstrumentSearchResult } from "../../../../types/instrument";
+import { type PluginRegistry, setSharedRegistryForTests } from "../../../registry";
+import { validateScreenerResults } from "./results";
+
+afterEach(() => setSharedRegistryForTests(undefined));
+
+function setup() {
+  const values = new Map<string, string>();
+  const tickerRepository = new JsonTickerRepository({
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
+  });
+  setSharedRegistryForTests({ tickerRepository, events: { emit() {} } } as unknown as PluginRegistry);
+  return tickerRepository;
+}
+
+function result(symbol: string, exchange: string): InstrumentSearchResult {
+  return { providerId: "cloud", symbol, exchange, currency: exchange === "LSE" ? "GBP" : "USD", name: symbol, type: "ETF" };
+}
+
+test("AI screener preserves dotted share classes and venue aliases instead of stripping their identity", async () => {
+  const repository = setup();
+  const dataProvider = createTestDataProvider({ search: async () => [result("BRK.B", "NYSE"), result("VWRL", "LSE")] });
+  const validated = await validateScreenerResults([
+    { symbol: "BRK.B", exchange: "NYSE", reason: "Class B" },
+    { symbol: "VWRL.L", exchange: "LSE", reason: "Distributing UK listing" },
+  ], new Map(), () => {}, dataProvider);
+  expect(validated.results.map((entry) => [entry.symbol, entry.exchange])).toEqual([["BRK.B", "NYSE"], ["VWRL", "LSE"]]);
+  expect(validated.warning).toBeNull();
+  expect((await repository.loadAllTickers()).map((ticker) => ticker.metadata.ticker).sort()).toEqual(["BRK.B", "VWRL"]);
+});
+
+test("AI screener refuses a wrong-exchange ADR and distinguishes saved listings in the same result set", async () => {
+  const repository = setup();
+  const onlyAdr = createTestDataProvider({ search: async () => [result("VOD", "NASDAQ")] });
+  const rejected = await validateScreenerResults([{ symbol: "VOD", exchange: "XLON", reason: "UK income" }], new Map(), () => {}, onlyAdr);
+  expect(rejected.results).toEqual([]);
+  expect(rejected.warning).toContain("Could not resolve 1: VOD");
+  expect(await repository.loadAllTickers()).toEqual([]);
+
+  const bothListings = createTestDataProvider({ search: async () => [result("VOD", "NASDAQ"), result("VOD", "LSE")] });
+  const validated = await validateScreenerResults([
+    { symbol: "VOD", exchange: "NASDAQ", reason: "ADR" },
+    { symbol: "VOD", exchange: "LSE", reason: "UK ordinary" },
+  ], new Map(), () => {}, bothListings);
+  expect(validated.results.map((entry) => [entry.symbol, entry.exchange])).toEqual([["VOD", "NASDAQ"], ["VOD:XLON", "LSE"]]);
+
+  const saved = await repository.loadTicker("VOD:XLON");
+  const reused = await validateScreenerResults([{ symbol: "VOD", exchange: "XLON", reason: "UK income" }],
+    new Map([["VOD:XLON", saved!]]), () => {}, createTestDataProvider({ search: async () => { throw new Error("Should use saved listing"); } }));
+  expect(reused.results[0]?.symbol).toBe("VOD:XLON");
+});

--- a/src/plugins/builtin/ai/screener/results.ts
+++ b/src/plugins/builtin/ai/screener/results.ts
@@ -5,9 +5,9 @@ import type { TickerFinancials } from "../../../../types/financials";
 import type { InstrumentSearchResult } from "../../../../types/instrument";
 import type { TickerRecord } from "../../../../types/ticker";
 import type { AppAction } from "../../../../state/app/context";
-import { canonicalExchange } from "../../../../utils/exchanges";
+import { canonicalExchange, parsePublicTickerKey } from "../../../../utils/exchanges";
 import { compareSortValues } from "../../../../utils/sort-values";
-import { upsertTickerFromSearchResult } from "../../../../tickers/search";
+import { findExactTickerSearchMatch, upsertTickerFromSearchResult } from "../../../../tickers/search";
 import { getSharedRegistry } from "../../../registry";
 import { getSortValue, type ColumnContext } from "../../portfolio-list/metrics";
 import type { ScreenerSortPreference } from "./model";
@@ -24,10 +24,6 @@ function summarizeWarning(unresolved: string[], duplicateCount: number): string 
   return parts.length > 0 ? parts.join(" ") : null;
 }
 
-function resolveResultSymbol(result: InstrumentSearchResult): string {
-  return (result.brokerContract?.localSymbol || result.symbol.split(".")[0] || "").trim().toUpperCase();
-}
-
 function matchesExchange(result: InstrumentSearchResult, exchange: string): boolean {
   if (!exchange) return true;
   const normalized = canonicalExchange(exchange);
@@ -35,6 +31,18 @@ function matchesExchange(result: InstrumentSearchResult, exchange: string): bool
     || canonicalExchange(result.primaryExchange) === normalized
     || canonicalExchange(result.brokerContract?.exchange) === normalized
     || canonicalExchange(result.brokerContract?.primaryExchange) === normalized;
+}
+
+function matchesCandidate(result: InstrumentSearchResult, candidate: { symbol: string; exchange: string }): boolean {
+  const requested = parsePublicTickerKey(candidate.symbol);
+  const parsedResult = parsePublicTickerKey(result.brokerContract?.localSymbol || result.symbol);
+  const resultExchange = parsedResult.exchange || result.exchange;
+  if (!matchesExchange({ ...result, exchange: resultExchange }, requested.exchange || candidate.exchange)) return false;
+  return findExactTickerSearchMatch([{
+    label: parsedResult.symbol,
+    exchangeLabel: resultExchange,
+    primaryExchangeLabel: result.primaryExchange || result.brokerContract?.primaryExchange,
+  }], candidate.symbol) != null;
 }
 
 async function resolveCandidateTicker(
@@ -48,8 +56,12 @@ async function resolveCandidateTicker(
     throw new Error("AI screener could not access the ticker repository.");
   }
 
-  const localTicker = localTickers.get(candidate.symbol);
-  if (localTicker && (!candidate.exchange || localTicker.metadata.exchange.toUpperCase() === candidate.exchange)) {
+  const localTicker = [...localTickers.values()].find((ticker) => matchesCandidate({
+    providerId: "saved", symbol: ticker.metadata.ticker, exchange: ticker.metadata.exchange,
+    name: ticker.metadata.name, currency: ticker.metadata.currency, type: ticker.metadata.assetCategory || "",
+    brokerContract: ticker.metadata.broker_contracts?.[0],
+  }, candidate));
+  if (localTicker) {
     return {
       symbol: localTicker.metadata.ticker,
       exchange: localTicker.metadata.exchange,
@@ -59,10 +71,7 @@ async function resolveCandidateTicker(
   }
 
   const searchResults = await dataProvider.search(candidate.symbol);
-  const matches = searchResults.filter((result) => resolveResultSymbol(result) === candidate.symbol);
-  const selected = matches.find((result) => matchesExchange(result, candidate.exchange))
-    ?? matches[0]
-    ?? null;
+  const selected = searchResults.find((result) => matchesCandidate(result, candidate)) ?? null;
   if (!selected) return null;
 
   const { ticker, created } = await upsertTickerFromSearchResult(registry.tickerRepository, selected);

--- a/src/plugins/builtin/dividend-yield/calendar.ts
+++ b/src/plugins/builtin/dividend-yield/calendar.ts
@@ -1,0 +1,9 @@
+/** Preserve the UTC month and clamp February 29 to February 28 in non-leap years. */
+export function calendarYearsBefore(date: Date, years: number): Date {
+  const result = new Date(date);
+  const year = date.getUTCFullYear() - years;
+  const month = date.getUTCMonth();
+  const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  result.setUTCFullYear(year, month, Math.min(date.getUTCDate(), lastDay));
+  return result;
+}

--- a/src/plugins/builtin/dividend-yield/client.test.ts
+++ b/src/plugins/builtin/dividend-yield/client.test.ts
@@ -1,5 +1,16 @@
-import { describe, expect, test } from "bun:test";
-import { extractDividendFields } from "./client";
+import { afterEach, describe, expect, test } from "bun:test";
+import { buildDividendMetrics, dividendReferencePrice, extractDividendFields, fetchDividendData, repriceDividendMetrics, toDividendPayment } from "./client";
+import type { DividendPayment } from "./types";
+import type { HeadlessPaneContext } from "../../../types/plugin";
+import { setHttpFetchTransport } from "../../../utils/http-transport";
+import { createDividendYieldHeadless } from "./headless";
+
+afterEach(() => setHttpFetchTransport(null));
+
+const now = new Date("2026-09-10T12:00:00Z");
+function payment(date: string, amount = 0.5, currency = "USD"): DividendPayment {
+  return toDividendPayment(date, amount, currency)!;
+}
 
 describe("extractDividendFields", () => {
   test("reads dividend modules from quoteSummary.result[0], not the response root", () => {
@@ -54,5 +65,97 @@ describe("extractDividendFields", () => {
 
     expect(fields.forwardAnnualDividendRate).toBe(1.08);
     expect(fields.payoutRatio).toBe(0.1204);
+  });
+});
+
+describe("cash distribution calculations", () => {
+  test("initial loading and headless yields only use external prices with matching explicit currency", async () => {
+    const timestamp = Math.floor((Date.now() - 86_400_000) / 1000);
+    setHttpFetchTransport(async (url) => {
+      if (url.includes("fc.yahoo.com")) return new Response("", { headers: { "set-cookie": "test=fixture" } });
+      if (url.includes("getcrumb")) return new Response("fixture-crumb");
+      if (url.includes("/chart/")) return Response.json({ chart: { result: [{
+        meta: { currency: "EUR", regularMarketPrice: 80 }, timestamp: [timestamp],
+        indicators: { quote: [{ close: [80] }] }, events: { dividends: { [timestamp]: { date: timestamp, amount: 4 } } },
+      }] } });
+      if (url.includes("/quoteSummary/")) return Response.json({ quoteSummary: { result: [{ summaryDetail: { currency: "EUR" } }] } });
+      throw new Error(`Unexpected fixture URL: ${url}`);
+    });
+
+    for (const [quoteCurrency, expectedPrice] of [["USD", 80], [undefined, 80], ["EUR", 100]] as const) {
+      const data = await fetchDividendData("ASML.AS", 100, "AMS", quoteCurrency);
+      expect(data.price).toBe(expectedPrice);
+      expect(data.metrics.trailingYield).toBeCloseTo(4 / expectedPrice, 12);
+      const result = await createDividendYieldHeadless().load({
+        rawArgument: "ASML.AS", argument: "ASML.AS", symbols: ["ASML.AS"], options: {},
+      }, {
+        resolveInstrument: async () => ({ symbol: "ASML", exchange: "AMS" }),
+        marketData: { getQuote: async () => ({ price: 100, currency: quoteCurrency }) },
+      } as unknown as HeadlessPaneContext);
+      expect(result.sections[0]?.entries?.find((entry) => entry.label === "Trailing yield")?.value).toBeCloseTo(4 / expectedPrice, 12);
+    }
+    expect(dividendReferencePrice(200, "GBp", "GBP")).toBe(2);
+    expect(dividendReferencePrice(2, "GBP", "GBP")).toBe(2);
+    expect(dividendReferencePrice(200, "USD", "GBP")).toBeNull();
+  });
+
+  test("leap-day trailing cash and growth retain March 1 payments inside the prior calendar year", () => {
+    const metrics = buildDividendMetrics([
+      payment("2019-02-01", 1), payment("2020-03-01", 1), payment("2021-03-01", 2),
+      payment("2022-03-01", 3), payment("2023-03-01", 4),
+    ], null, 100, { now: new Date("2024-02-29T12:00:00Z") });
+    expect(metrics.trailingRate).toBe(4);
+    expect(metrics.trailingYield).toBe(0.04);
+    expect(metrics.growth1Y).toBeCloseTo(4 / 3 - 1, 12);
+    expect(metrics.growth3Y).toBeCloseTo(Math.pow(4, 1 / 3) - 1, 12);
+  });
+
+  test("uses reported cash history over zero ETF summary fields, with calendar cutoffs and no future cash", () => {
+    const payments = Array.from({ length: 12 }, (_, month) => payment(new Date(Date.UTC(2025, 9 + month, 1)).toISOString().slice(0, 10)));
+    payments.push(payment("2026-10-01", 10), payment("2025-09-10", 20));
+    const fields = extractDividendFields({ quoteSummary: { result: [{ summaryDetail: {
+      trailingAnnualDividendRate: { raw: 0 }, trailingAnnualDividendYield: { raw: 0 },
+    } }] } });
+    const metrics = buildDividendMetrics(payments, fields, 60, { now });
+    expect(metrics.trailingRate).toBe(6);
+    expect(metrics.trailingYield).toBeCloseTo(0.1, 12);
+    expect(repriceDividendMetrics(metrics, 120).trailingYield).toBeCloseTo(0.05, 12);
+    expect(repriceDividendMetrics(metrics, NaN).trailingYield).toBeNull();
+  });
+
+  test("normalizes pence cash into pounds and suppresses unverifiable summary rate units", () => {
+    const payments = [payment("2026-06-04", 2.0301435, "GBp"), payment("2025-11-20", 1.9512, "GBp")];
+    const fields = extractDividendFields({ quoteSummary: { result: [{ summaryDetail: {
+      currency: "GBp", trailingAnnualDividendRate: { raw: 0.046 }, forwardAnnualDividendRate: { raw: 0.04 },
+    } }] } });
+    const metrics = buildDividendMetrics(payments, fields, 1.28725, { now, summaryRatesComparable: false });
+    expect(payments[0]).toMatchObject({ currency: "GBP", amount: 0.020301435 });
+    expect(metrics.trailingRate).toBeCloseTo(0.039813435, 12);
+    expect(metrics.trailingYield).toBeCloseTo(0.0309290619, 9);
+    expect(metrics.forwardRate).toBeNull();
+    expect(metrics.forwardYield).toBeNull();
+  });
+
+  test("distinguishes no reported cash from unavailable history and does not advertise past payment dates", () => {
+    const fields = extractDividendFields({ quoteSummary: { result: [{ summaryDetail: {
+      dividendDate: { raw: Date.parse("2026-08-31") / 1000 },
+    } }] } });
+    expect(buildDividendMetrics([], fields, 100, { now }).trailingYield).toBe(0);
+    const unavailable = buildDividendMetrics([], fields, 100, { now, historyAvailable: false });
+    expect(unavailable.trailingYield).toBeNull();
+    expect(unavailable.nextPayDate).toBeNull();
+  });
+
+  test("does not compare a new fund's partial first year with a full recent year", () => {
+    const payments = Array.from({ length: 14 }, (_, month) => payment(new Date(Date.UTC(2025, 7 + month, 1)).toISOString().slice(0, 10)));
+    const metrics = buildDividendMetrics(payments, null, 60, { now });
+    expect(metrics.growth1Y).toBeNull();
+    expect(metrics.growth3Y).toBeNull();
+    const mature = buildDividendMetrics([
+      payment("2022-08-01", 1), payment("2023-08-01", 1), payment("2024-08-01", 1.1),
+      payment("2025-08-01", 1.21), payment("2026-08-01", 1.331),
+    ], null, 60, { now });
+    expect(mature.growth1Y).toBeCloseTo(0.1, 12);
+    expect(mature.growth3Y).toBeCloseTo(0.1, 12);
   });
 });

--- a/src/plugins/builtin/dividend-yield/client.ts
+++ b/src/plugins/builtin/dividend-yield/client.ts
@@ -5,9 +5,10 @@ import { fetchYahooChart } from "../../../sources/yahoo-finance/requests";
 import { getYahooSymbolsToTry } from "../../../sources/yahoo-finance/symbols";
 import type { QuoteSummaryResponse } from "../../../sources/yahoo-finance/types";
 import type { DividendMetrics, DividendPayment } from "./types";
+import { resolveCurrencyUnit } from "../../../utils/currency-units";
+import { calendarYearsBefore } from "./calendar";
 
 export const YAHOO_DIVIDENDS_CONNECTION_ID = "yahoo-dividends";
-const DAY_MS = 24 * 60 * 60 * 1000;
 const yahoo = new YahooHttpClient();
 
 let connectionHealth: ConnectionHealthRegistry | null = null;
@@ -74,12 +75,13 @@ export function extractDividendFields(payload: unknown): QuoteSummaryDividendFie
   };
 }
 
-function toDividendPayment(
+export function toDividendPayment(
   exDate: string,
   amount: number,
   currency: string,
 ): DividendPayment | null {
-  if (amount <= 0) return null;
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+  const unit = resolveCurrencyUnit(currency);
   const parsed = new Date(`${exDate}T00:00:00.000Z`);
   if (Number.isNaN(parsed.getTime())) return null;
   return {
@@ -87,8 +89,8 @@ function toDividendPayment(
     recordDate: null,
     paymentDate: null,
     declarationDate: null,
-    amount,
-    currency,
+    amount: amount / unit.divisor,
+    currency: unit.currency,
     type: "cash",
   };
 }
@@ -97,18 +99,21 @@ export interface DividendData {
   payments: DividendPayment[];
   metrics: DividendMetrics;
   price: number | null;
+  currency?: string;
+  historyAvailable?: boolean;
 }
 
 export async function fetchDividendData(
   symbol: string,
   currentPrice: number | null,
   exchange = "",
+  currentPriceCurrency?: string,
 ): Promise<DividendData> {
   const symbols = exchange ? getYahooSymbolsToTry(symbol, exchange) : [symbol];
   let lastError: unknown;
   for (const yahooSymbol of symbols) {
     try {
-      return await fetchDividendDataForSymbol(yahooSymbol, currentPrice);
+      return await fetchDividendDataForSymbol(yahooSymbol, currentPrice, currentPriceCurrency);
     } catch (error) {
       lastError = error;
     }
@@ -119,6 +124,7 @@ export async function fetchDividendData(
 async function fetchDividendDataForSymbol(
   symbol: string,
   currentPrice: number | null,
+  currentPriceCurrency?: string,
 ): Promise<DividendData> {
   const quoteUrl =
     `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(symbol)}`
@@ -137,58 +143,61 @@ async function fetchDividendDataForSymbol(
     ? extractDividendFields(quoteResult.value)
     : null;
 
-  const currency = quoteFields?.currency
-    ?? (chartResult.status === "fulfilled" ? chartResult.value.meta.currency ?? null : null)
-    ?? "USD";
+  const rawCurrency = (chartResult.status === "fulfilled" ? chartResult.value.meta.currency ?? null : null)
+    ?? quoteFields?.currency ?? "USD";
+  const { currency, divisor } = resolveCurrencyUnit(rawCurrency);
 
   const payments: DividendPayment[] = [];
   if (chartResult.status === "fulfilled") {
     for (const dividend of mapYahooDividends(chartResult.value.events)) {
-      const payment = toDividendPayment(dividend.exDate, dividend.amount, currency);
+      const payment = toDividendPayment(dividend.exDate, dividend.amount, rawCurrency);
       if (payment) payments.push(payment);
     }
     payments.sort((a, b) => b.exDate.getTime() - a.exDate.getTime());
   }
 
-  const resolvedPrice = currentPrice
-    ?? (chartResult.status === "fulfilled" ? chartResult.value.meta.regularMarketPrice ?? null : null)
-    ?? null;
+  const chartPrice = chartResult.status === "fulfilled" ? chartResult.value.meta.regularMarketPrice : null;
+  const resolvedPrice = dividendReferencePrice(currentPrice, currentPriceCurrency, currency)
+    ?? (chartPrice != null && Number.isFinite(chartPrice) && chartPrice > 0 ? chartPrice / divisor : null);
 
-  const metrics = buildMetrics(payments, quoteFields, resolvedPrice);
+  const historyAvailable = chartResult.status === "fulfilled";
+  // Yahoo annual-rate fields can use a different denomination from its pence
+  // charts (VOD.L is one example). Cash history has explicit chart units.
+  const summaryUnit = resolveCurrencyUnit(quoteFields?.currency);
+  const summaryRatesComparable = divisor === 1
+    && (!quoteFields?.currency || (summaryUnit.currency === currency && summaryUnit.divisor === 1));
+  const metrics = buildDividendMetrics(payments, quoteFields, resolvedPrice, { historyAvailable, summaryRatesComparable });
 
-  if (payments.length === 0 && !quoteFields?.trailingAnnualDividendRate) {
+  if (!historyAvailable && metrics.trailingRate == null && metrics.forwardRate == null) {
     throw new Error(`No dividend data found for ${symbol}`);
   }
 
-  return { payments, metrics, price: resolvedPrice };
+  return { payments, metrics, price: resolvedPrice, currency, historyAvailable };
 }
 
-function buildMetrics(
+/** A quote from another listing/currency cannot price this cash distribution series. */
+export function dividendReferencePrice(price: number | null, priceCurrency: string | undefined, cashCurrency: string): number | null {
+  if (price == null || !Number.isFinite(price) || price <= 0) return null;
+  const unit = resolveCurrencyUnit(priceCurrency);
+  if (!unit.currency || unit.currency !== resolveCurrencyUnit(cashCurrency).currency) return null;
+  return price / unit.divisor;
+}
+
+export function buildDividendMetrics(
   payments: DividendPayment[],
   quoteFields: QuoteSummaryDividendFields | null,
   currentPrice: number | null,
+  options: { historyAvailable?: boolean; summaryRatesComparable?: boolean; now?: Date } = {},
 ): DividendMetrics {
-  const trailingRate = quoteFields?.trailingAnnualDividendRate
-    ?? (payments.length > 0
-      ? payments
-        .filter((p) => p.exDate >= new Date(Date.now() - 365 * DAY_MS))
-        .reduce((sum, p) => sum + p.amount, 0)
-      : null);
-
-  const forwardRate = quoteFields?.forwardAnnualDividendRate ?? null;
-
-  const trailingYield = quoteFields?.trailingAnnualDividendYield != null
-    ? quoteFields.trailingAnnualDividendYield
-    : trailingRate != null && currentPrice != null && currentPrice > 0
-      ? trailingRate / currentPrice
-      : null;
-
-  const forwardYield = forwardRate != null && currentPrice != null && currentPrice > 0
-    ? forwardRate / currentPrice
-    : null;
-
-  const growth1Y = payments.length >= 2 ? computeGrowth1Y(payments) : null;
-  const growth3Y = payments.length >= 4 ? computeGrowth3Y(payments) : null;
+  const now = options.now ?? new Date();
+  const eligible = payments.filter((payment) => payment.exDate <= now && Number.isFinite(payment.amount) && payment.amount > 0);
+  const cutoff = calendarYearsBefore(now, 1);
+  const trailingRate = options.historyAvailable !== false
+    ? eligible.filter((payment) => payment.exDate > cutoff).reduce((sum, payment) => sum + payment.amount, 0)
+    : options.summaryRatesComparable !== false ? quoteFields?.trailingAnnualDividendRate ?? null : null;
+  const forwardRate = options.summaryRatesComparable !== false ? quoteFields?.forwardAnnualDividendRate ?? null : null;
+  const growth1Y = computeGrowth(eligible, 1, now);
+  const growth3Y = computeGrowth(eligible, 3, now);
 
   const exDividendDate = quoteFields?.exDividendDate != null
     ? new Date(quoteFields.exDividendDate * 1000)
@@ -196,62 +205,44 @@ function buildMetrics(
       ? payments[0]!.exDate
       : null;
 
-  const nextPayDate = quoteFields?.dividendDate != null
-    ? new Date(quoteFields.dividendDate * 1000)
-    : null;
+  const reportedPayDate = quoteFields?.dividendDate != null ? new Date(quoteFields.dividendDate * 1000) : null;
+  const today = new Date(now.toISOString().slice(0, 10));
+  const nextPayDate = reportedPayDate && reportedPayDate >= today ? reportedPayDate : null;
 
-  return {
-    trailingYield,
-    forwardYield,
+  return repriceDividendMetrics({
+    trailingYield: null,
+    forwardYield: null,
     trailingRate,
     forwardRate,
     payoutRatio: quoteFields?.payoutRatio ?? null,
     growth1Y,
     growth3Y,
-    paymentFrequency: inferFrequency(payments),
+    paymentFrequency: inferFrequency(eligible),
     exDividendDate,
     nextPayDate,
+  }, currentPrice);
+}
+
+export function repriceDividendMetrics(metrics: DividendMetrics, price: number | null): DividendMetrics {
+  const validPrice = price != null && Number.isFinite(price) && price > 0;
+  return {
+    ...metrics,
+    trailingYield: validPrice && metrics.trailingRate != null ? metrics.trailingRate / price : null,
+    forwardYield: validPrice && metrics.forwardRate != null ? metrics.forwardRate / price : null,
   };
 }
 
 const DAY = 24 * 60 * 60 * 1000;
 
-function computeGrowth1Y(payments: DividendPayment[]): number | null {
-  const now = new Date();
-  const recentCutoff = new Date(now.getTime() - 365 * DAY);
-  const priorCutoff = new Date(now.getTime() - 2 * 365 * DAY);
-  const recent = payments
-    .filter((p) => p.exDate >= recentCutoff && p.exDate <= now)
-    .reduce((sum, p) => sum + p.amount, 0);
-  const prior = payments
-    .filter((p) => p.exDate >= priorCutoff && p.exDate < recentCutoff)
-    .reduce((sum, p) => sum + p.amount, 0);
-  if (prior <= 0) return null;
-  return (recent - prior) / prior;
-}
-
-function computeGrowth3Y(payments: DividendPayment[]): number | null {
-  const regular = payments.filter((p) => p.type === "cash" || p.type === "unknown");
-  if (regular.length < 4) return null;
-  const freq = inferFrequency(regular);
-  if (!freq || freq === "irregular") return null;
-  const annualCount = freq === "monthly" ? 12 : freq === "quarterly" ? 4 : freq === "semi-annual" ? 2 : 1;
-
-  const now = new Date();
-  const recentStart = new Date(now.getTime() - 365 * DAY);
-  const threeYearsAgo = new Date(now.getTime() - 3 * 365 * DAY);
-  const priorStart = new Date(now.getTime() - 4 * 365 * DAY);
-
-  const sorted = [...regular].sort((a, b) => a.exDate.getTime() - b.exDate.getTime());
-  const recentAvg = sorted
-    .filter((p) => p.exDate >= recentStart && p.exDate <= now)
-    .reduce((sum, p) => sum + p.amount, 0) / annualCount;
-  const priorAvg = sorted
-    .filter((p) => p.exDate >= priorStart && p.exDate <= threeYearsAgo)
-    .reduce((sum, p) => sum + p.amount, 0) / annualCount;
-
-  if (priorAvg <= 0 || recentAvg <= 0) return null;
-  return Math.pow(recentAvg / priorAvg, 1 / 3) - 1;
+function computeGrowth(payments: DividendPayment[], years: number, now: Date): number | null {
+  const recentStart = calendarYearsBefore(now, 1);
+  const priorEnd = calendarYearsBefore(now, years);
+  const priorStart = calendarYearsBefore(priorEnd, 1);
+  // A new fund's partial first year is not a full-year growth baseline.
+  if (!payments.some((payment) => payment.exDate <= priorStart)) return null;
+  const recent = payments.filter((p) => p.exDate > recentStart && p.exDate <= now).reduce((sum, p) => sum + p.amount, 0);
+  const prior = payments.filter((p) => p.exDate > priorStart && p.exDate <= priorEnd).reduce((sum, p) => sum + p.amount, 0);
+  return prior > 0 && recent > 0 ? Math.pow(recent / prior, 1 / years) - 1 : null;
 }
 
 function inferFrequency(payments: DividendPayment[]): DividendMetrics["paymentFrequency"] {

--- a/src/plugins/builtin/dividend-yield/headless.test.ts
+++ b/src/plugins/builtin/dividend-yield/headless.test.ts
@@ -61,7 +61,7 @@ describe("dividend yield headless", () => {
     expect(result.sections[0]).toMatchObject({
       title: "Dividend metrics",
       entries: expect.arrayContaining([
-        { label: "Trailing yield", value: 0.005 },
+        { label: "Trailing yield", value: 0.005, formatted: "0.50%" },
         { label: "Frequency", value: "quarterly" },
       ]),
     });

--- a/src/plugins/builtin/dividend-yield/headless.ts
+++ b/src/plugins/builtin/dividend-yield/headless.ts
@@ -6,7 +6,8 @@ import type {
 } from "../../../types/plugin";
 import { fetchDividendData, type DividendData } from "./client";
 import type { DividendPayment } from "./types";
-import { toDividendRows } from "./view";
+import { formatDividendYield, toDividendRows } from "./view";
+import { formatDistributionAmount } from "../../../utils/format";
 
 const PAYMENT_COLUMNS = [
   { key: "exDate", header: "Ex-date" },
@@ -22,12 +23,17 @@ export interface DividendYieldHeadlessDependencies {
 const defaultDependencies: DividendYieldHeadlessDependencies = {
   async loadData(symbol, context) {
     let currentPrice: number | null = null;
+    let currentPriceCurrency: string | undefined;
+    const instrument = await context.resolveInstrument?.(symbol);
+    const exchange = instrument?.exchange ?? "";
     try {
-      currentPrice = (await context.marketData.getQuote(symbol, "")).price ?? null;
+      const quote = await context.marketData.getQuote(symbol, exchange);
+      currentPrice = quote.price ?? null;
+      currentPriceCurrency = quote.currency;
     } catch {
       currentPrice = null;
     }
-    return fetchDividendData(symbol, currentPrice);
+    return fetchDividendData(symbol, currentPrice, exchange, currentPriceCurrency);
   },
 };
 
@@ -54,6 +60,7 @@ export function projectDividendYieldHeadless(
     };
   });
   const metrics = data.metrics;
+  const currency = data.currency ?? data.payments[0]?.currency ?? "USD";
 
   return {
     sections: [
@@ -61,10 +68,10 @@ export function projectDividendYieldHeadless(
         title: "Dividend metrics",
         entries: [
           { label: "Price", value: data.price },
-          { label: "Trailing yield", value: metrics.trailingYield },
-          { label: "Forward yield", value: metrics.forwardYield },
-          { label: "Trailing rate", value: metrics.trailingRate },
-          { label: "Forward rate", value: metrics.forwardRate },
+          { label: "Trailing yield", value: metrics.trailingYield, formatted: formatDividendYield(metrics.trailingYield) },
+          { label: "Forward yield", value: metrics.forwardYield, formatted: formatDividendYield(metrics.forwardYield) },
+          { label: "Trailing rate", value: metrics.trailingRate, formatted: formatDistributionAmount(metrics.trailingRate ?? undefined, currency) },
+          { label: "Forward rate", value: metrics.forwardRate, formatted: formatDistributionAmount(metrics.forwardRate ?? undefined, currency) },
           { label: "Payout ratio", value: metrics.payoutRatio },
           { label: "1Y growth", value: metrics.growth1Y },
           { label: "3Y growth", value: metrics.growth3Y },
@@ -84,6 +91,10 @@ export function projectDividendYieldHeadless(
       returnedPayments: rows.length,
       truncated: rows.length < matching.length,
       type,
+      currency: data.currency ?? data.payments[0]?.currency ?? null,
+      historyAvailable: data.historyAvailable ?? true,
+      yieldMethod: "Cash distributions with ex-dates in the preceding 12 months divided by the reference share price; excludes reinvestment and is not SEC yield or total return.",
+      forwardRateMethod: "Provider indicated annual cash rate, only when its currency units are comparable with the share price.",
     },
   };
 }

--- a/src/plugins/builtin/dividend-yield/pane.tsx
+++ b/src/plugins/builtin/dividend-yield/pane.tsx
@@ -12,9 +12,11 @@ import { resolveChartPalette } from "../../../components/chart/core/palette";
 import { useAsyncResource } from "../../../react/async-resource";
 import { colors, priceColor } from "../../../theme/colors";
 import { Box, Text, TextAttributes } from "../../../ui";
-import { formatCurrency, formatNumber, formatPercentRaw } from "../../../utils/format";
+import { formatDistributionAmount, formatPercentRaw } from "../../../utils/format";
+import { resolveCurrencyUnit } from "../../../utils/currency-units";
 import { handleRefreshKey, loadingErrorFooterInfo } from "../shared/table-pane";
-import { fetchDividendData } from "./client";
+import { dividendReferencePrice, fetchDividendData, repriceDividendMetrics } from "./client";
+import { buildTrailingCashChartPoints, formatDividendYield } from "./view";
 import {
   DEFAULT_SORT_PREFERENCE,
   buildDividendColumns,
@@ -25,16 +27,11 @@ import {
   type DividendRow,
   type DividendSortPreference,
 } from "./model";
-import type { DividendMetrics, DividendPayment } from "./types";
-
-function formatYield(value: number | null): string {
-  if (value == null) return "—";
-  return `${(value * 100).toFixed(2)}%`;
-}
+import type { DividendMetrics } from "./types";
 
 function formatRate(value: number | null, currency: string): string {
   if (value == null) return "—";
-  return formatCurrency(value, currency);
+  return formatDistributionAmount(value, currency);
 }
 
 function formatGrowth(value: number | null): string {
@@ -67,42 +64,17 @@ interface MetricRow {
 
 function buildMetricRows(metrics: DividendMetrics, currency: string): MetricRow[] {
   return [
-    { label: "Trailing Yield", value: formatYield(metrics.trailingYield), color: priceColor(metrics.trailingYield ?? 0), bold: true },
-    { label: "Forward Yield", value: formatYield(metrics.forwardYield), color: priceColor(metrics.forwardYield ?? 0) },
-    { label: "Trailing Rate", value: formatRate(metrics.trailingRate, currency) },
-    { label: "Forward Rate", value: formatRate(metrics.forwardRate, currency) },
-    { label: "1Y Growth", value: formatGrowth(metrics.growth1Y), color: priceColor(metrics.growth1Y ?? 0) },
-    { label: "3Y Growth", value: formatGrowth(metrics.growth3Y), color: priceColor(metrics.growth3Y ?? 0) },
-    { label: "Payout Ratio", value: metrics.payoutRatio != null ? `${(metrics.payoutRatio * 100).toFixed(1)}%` : "—" },
+    { label: "TTM Cash Yield", value: formatDividendYield(metrics.trailingYield), color: priceColor(metrics.trailingYield ?? 0), bold: true },
+    { label: "Forward Yield", value: formatDividendYield(metrics.forwardYield), color: priceColor(metrics.forwardYield ?? 0) },
+    { label: "TTM Cash/Share", value: formatRate(metrics.trailingRate, currency) },
+    { label: "Forward/Share", value: formatRate(metrics.forwardRate, currency) },
+    { label: "1Y Cash Growth", value: formatGrowth(metrics.growth1Y), color: priceColor(metrics.growth1Y ?? 0) },
+    { label: "3Y Cash CAGR", value: formatGrowth(metrics.growth3Y), color: priceColor(metrics.growth3Y ?? 0) },
+    { label: "Earnings Payout", value: metrics.payoutRatio != null ? `${(metrics.payoutRatio * 100).toFixed(1)}%` : "—" },
     { label: "Frequency", value: formatFrequency(metrics.paymentFrequency) },
     { label: "Ex-Dividend", value: formatDate(metrics.exDividendDate) },
     { label: "Next Pay", value: formatDate(metrics.nextPayDate) },
   ];
-}
-
-function buildYieldChartPoints(payments: DividendPayment[], currentPrice: number | null): ProjectedChartPoint[] {
-  if (payments.length === 0 || currentPrice == null || currentPrice <= 0) return [];
-  const sorted = [...payments].sort((a, b) => a.exDate.getTime() - b.exDate.getTime());
-  const DAY = 24 * 60 * 60 * 1000;
-  const points: ProjectedChartPoint[] = [];
-
-  for (const payment of sorted) {
-    const trailingCutoff = new Date(payment.exDate.getTime() - 365 * DAY);
-    const trailingSum = sorted
-      .filter((p) => p.exDate >= trailingCutoff && p.exDate <= payment.exDate)
-      .reduce((sum, p) => sum + p.amount, 0);
-    const yieldPct = (trailingSum / currentPrice) * 100;
-    points.push({
-      date: payment.exDate,
-      open: yieldPct,
-      high: yieldPct,
-      low: yieldPct,
-      close: yieldPct,
-      volume: 0,
-    });
-  }
-
-  return points;
 }
 
 function renderMetricCell(row: MetricRow, width: number) {
@@ -164,9 +136,9 @@ function DividendSummary({
             height={chartHeight}
             mode="line"
             colors={palette}
-            yAxisLabel="Yield %"
+            yAxisLabel="TTM cash/share"
             yAxisColor={colors.textDim}
-            formatYAxisValue={(value) => `${value.toFixed(2)}%`}
+            formatYAxisValue={(value) => formatRate(value, currency)}
           />
         </Box>
       )}
@@ -186,7 +158,7 @@ function renderCell(
       return { text: row.exDate, color: selectedColor ?? colors.textDim };
     case "amount":
       return {
-        text: formatNumber(row.amount, 4),
+        text: formatDistributionAmount(row.amount, row.currency),
         color: selectedColor ?? colors.textBright,
         attributes: TextAttributes.BOLD,
       };
@@ -197,7 +169,7 @@ function renderCell(
 
 export function DividendYieldPane({ focused, width, height }: { focused: boolean; width: number; height: number }) {
   const { symbol, ticker, financials } = usePaneTicker();
-  const currency = ticker?.metadata.currency ?? "USD";
+  const quoteCurrency = financials?.quote?.currency;
   const exchange = ticker?.metadata.exchange ?? "";
   const quotePrice = financials?.quote?.price ?? null;
 
@@ -205,10 +177,10 @@ export function DividendYieldPane({ focused, width, height }: { focused: boolean
   const [selectedIdx, setSelectedIdx] = useState(0);
   // Ten years of history must not be refetched on every live price tick, so the
   // quote is read through a ref instead of being an effect dependency.
-  const quotePriceRef = useRef(quotePrice);
-  quotePriceRef.current = quotePrice;
+  const quoteRef = useRef({ price: quotePrice, currency: quoteCurrency });
+  quoteRef.current = { price: quotePrice, currency: quoteCurrency };
 
-  const request = useCallback(() => fetchDividendData(symbol!, quotePriceRef.current, exchange), [exchange, symbol]);
+  const request = useCallback(() => fetchDividendData(symbol!, quoteRef.current.price, exchange, quoteRef.current.currency), [exchange, symbol]);
   const { data, loading, error, updatedAt, reload: refresh } = useAsyncResource(symbol ? request : null, { clearOnError: true });
   useEffect(() => { if (updatedAt !== null) setSelectedIdx(0); }, [updatedAt]);
 
@@ -217,13 +189,15 @@ export function DividendYieldPane({ focused, width, height }: { focused: boolean
   }), [error, loading]);
 
   const payments = data?.payments ?? [];
-  const metrics = data?.metrics;
+  const currency = data?.currency ?? payments[0]?.currency ?? resolveCurrencyUnit(ticker?.metadata.currency).currency;
+  const currentPrice = dividendReferencePrice(quotePrice, quoteCurrency, currency) ?? data?.price ?? null;
+  const metrics = data?.metrics ? repriceDividendMetrics(data.metrics, currentPrice) : undefined;
   const rows = useMemo(() => toDividendRows(payments), [payments]);
   const sortedRows = useMemo(() => sortRows(rows, sortPreference), [rows, sortPreference]);
   const columns = useMemo(() => buildDividendColumns(width), [width]);
   const chartPoints = useMemo(
-    () => buildYieldChartPoints(payments, data?.price ?? quotePrice),
-    [data?.price, payments, quotePrice],
+    () => buildTrailingCashChartPoints(payments),
+    [payments],
   );
 
   const handleHeaderClick = useCallback((columnId: string) => {
@@ -238,7 +212,7 @@ export function DividendYieldPane({ focused, width, height }: { focused: boolean
     ? "No ticker selected."
     : loading
       ? "Loading dividends..."
-      : error ?? "No dividend history";
+      : error ?? (data?.historyAvailable ? "No cash distributions reported." : "Dividend history unavailable.");
 
   return (
     <DataTableView<DividendRow, DividendColumn>
@@ -255,7 +229,7 @@ export function DividendYieldPane({ focused, width, height }: { focused: boolean
       rootBefore={metrics ? (
         <DividendSummary
           metrics={metrics}
-          currency={payments[0]?.currency ?? currency}
+          currency={currency}
           width={width}
           chartPoints={chartPoints}
         />

--- a/src/plugins/builtin/dividend-yield/view.test.ts
+++ b/src/plugins/builtin/dividend-yield/view.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { toDividendPayment } from "./client";
+import { buildTrailingCashChartPoints } from "./view";
+
+test("cash chart uses complete calendar-year cash totals without inventing historical price yields", () => {
+  const payments = Array.from({ length: 25 }, (_, month) => toDividendPayment(
+    new Date(Date.UTC(2024, 1 + month, 1)).toISOString().slice(0, 10), 0.5, "USD",
+  )!);
+  payments.push(toDividendPayment("2027-02-01", 50, "USD")!);
+  const points = buildTrailingCashChartPoints(payments.reverse(), new Date("2026-09-10"));
+  expect(points).toHaveLength(13);
+  expect(points[0]?.date.toISOString().slice(0, 10)).toBe("2025-02-01");
+  expect(points.every((point) => point.close === 6)).toBe(true);
+  expect(buildTrailingCashChartPoints(payments.slice(1, 3), new Date("2026-09-10"))).toEqual([]);
+});
+
+test("leap-day cash chart retains payments after the clamped February 28 cutoff", () => {
+  const points = buildTrailingCashChartPoints([
+    toDividendPayment("2022-02-28", 1, "USD")!,
+    toDividendPayment("2023-03-01", 4, "USD")!,
+    toDividendPayment("2024-02-29", 1, "USD")!,
+  ], new Date("2024-02-29T12:00:00Z"));
+  expect(points.at(-1)?.close).toBe(5);
+});

--- a/src/plugins/builtin/dividend-yield/view.ts
+++ b/src/plugins/builtin/dividend-yield/view.ts
@@ -1,4 +1,28 @@
 import type { DividendPayment } from "./types";
+import type { ProjectedChartPoint } from "../../../components/chart/core/data";
+import { calendarYearsBefore } from "./calendar";
+
+export function formatDividendYield(value: number | null): string {
+  return value != null && Number.isFinite(value) ? `${(value * 100).toFixed(2)}%` : "—";
+}
+
+/** Cash history does not contain historical share prices, so cannot establish historical yields. */
+export function buildTrailingCashChartPoints(payments: DividendPayment[], now = new Date()): ProjectedChartPoint[] {
+  const sorted = payments.filter((payment) => payment.exDate <= now && Number.isFinite(payment.amount) && payment.amount > 0)
+    .sort((a, b) => a.exDate.getTime() - b.exDate.getTime());
+  const firstDate = sorted[0]?.exDate;
+  if (!firstDate) return [];
+  const points: ProjectedChartPoint[] = [];
+  for (const payment of sorted) {
+    const cutoff = calendarYearsBefore(payment.exDate, 1);
+    // Avoid drawing the first partial year of a fund's history as a full-year cash rate.
+    if (cutoff < firstDate) continue;
+    const cash = sorted.filter((p) => p.exDate > cutoff && p.exDate <= payment.exDate)
+      .reduce((sum, p) => sum + p.amount, 0);
+    points.push({ date: payment.exDate, open: cash, high: cash, low: cash, close: cash, volume: 0 });
+  }
+  return points;
+}
 
 export interface DividendRow {
   key: string;

--- a/src/plugins/builtin/earnings-calls/headless.test.ts
+++ b/src/plugins/builtin/earnings-calls/headless.test.ts
@@ -9,6 +9,7 @@ import {
   createEarningsTranscriptHeadless,
   type EarningsCallsHeadlessDependencies,
 } from "./headless";
+import { buildTranscriptSegments, findCallForQuarter } from "./model";
 
 const calls: CloudEarningsCallPayload[] = [
   {
@@ -138,6 +139,19 @@ describe("earnings calls headless", () => {
 });
 
 describe("earnings transcript headless", () => {
+  test("full-text fallback searches return matching paragraphs rather than the entire call", () => {
+    const fallback = { ...transcript, turns: [], fullText: "Welcome to the quarterly call.\n\nMembership renewal rates increased.\n\nThank you for joining us." };
+    expect(buildTranscriptSegments(fallback, "transcript", { search: "RENEWAL" }).map((row) => row.text)).toEqual(["Membership renewal rates increased."]);
+    expect(buildTranscriptSegments(fallback, "transcript", { search: "missing" })).toEqual([]);
+    expect(buildTranscriptSegments(fallback, "transcript", { speaker: "CFO", search: "renewal" })).toEqual([]);
+  });
+
+  test("non-calendar fiscal quarter selection uses reported fiscal identity, not announcement month", () => {
+    const cost = [{ ...calls[0]!, id: "cost-fq4", ticker: "COST", fiscalYear: 2025, fiscalQuarter: 4, callAt: "2025-09-25T21:00:00Z" },
+      { ...calls[1]!, id: "cost-fq1", ticker: "COST", fiscalYear: 2026, fiscalQuarter: 1, callAt: "2025-12-11T21:00:00Z" }];
+    expect(findCallForQuarter(cost, "FQ4-2025")?.id).toBe("cost-fq4");
+    expect(findCallForQuarter(cost, "FY2026")?.id).toBe("cost-fq1");
+  });
   test("selects a quarter and filters speakers by role acronym", async () => {
     const definition = createEarningsTranscriptHeadless(dependencies());
 

--- a/src/plugins/builtin/earnings-calls/model.ts
+++ b/src/plugins/builtin/earnings-calls/model.ts
@@ -133,6 +133,7 @@ export function buildTranscriptSegments(
       const search = options.search?.trim().toLowerCase() ?? "";
       if (!options.speaker?.trim() && (!search || transcript.fullText.toLowerCase().includes(search))) {
         for (const paragraph of transcript.fullText.split(/\n{2,}/)) {
+          if (search && !paragraph.toLowerCase().includes(search)) continue;
           for (const text of chunks(paragraph)) {
             withoutIndexes.push({
               section,

--- a/src/plugins/builtin/options-calculator/model.test.ts
+++ b/src/plugins/builtin/options-calculator/model.test.ts
@@ -54,6 +54,22 @@ describe("valueOption", () => {
       .toBeCloseTo(100 - 100 * Math.exp(-0.05), 6);
   });
 
+  test("zero-volatility theta and rho agree with changes in the discounted payoff", () => {
+    for (const side of ["call", "put"] as const) {
+      const draft = { ...CANONICAL, side, spot: side === "call" ? 120 : 80, volatility: 0, dividendYield: 0.02 };
+      const value = valueOption(draft);
+      const dayStep = 0.001;
+      const rateStep = 0.000001;
+      const theta = (valueOption({ ...draft, daysToExpiry: draft.daysToExpiry - dayStep }).price
+        - valueOption({ ...draft, daysToExpiry: draft.daysToExpiry + dayStep }).price) / (2 * dayStep);
+      const rho = (valueOption({ ...draft, rate: draft.rate + rateStep }).price
+        - valueOption({ ...draft, rate: draft.rate - rateStep }).price) / (2 * rateStep * 100);
+      expect(value.thetaPerDay).toBeCloseTo(theta, 7);
+      expect(value.rhoPerPoint).toBeCloseTo(rho, 7);
+      expect(valueOption({ ...draft, daysToExpiry: 0 }).rhoPerPoint).toBe(0);
+    }
+  });
+
   test("never returns NaN or Infinity for impossible inputs", () => {
     const broken: OptionCalcDraft[] = [
       { ...CANONICAL, spot: 0 },

--- a/src/plugins/builtin/options-calculator/model.ts
+++ b/src/plugins/builtin/options-calculator/model.ts
@@ -86,10 +86,18 @@ function intrinsicValuation(
   const price = side === "call"
     ? Math.max(0, discountedSpot - discountedStrike)
     : Math.max(0, discountedStrike - discountedSpot);
+  const direction = side === "call" ? 1 : -1;
   return {
     ...ZERO_GREEKS,
     price,
     delta: inTheMoney ? (side === "call" ? Math.exp(-dividendYield * years) : -Math.exp(-dividendYield * years)) : 0,
+    // Zero volatility removes uncertainty, but discounting still changes the
+    // forward payoff as time and interest rates change. At expiry only the
+    // terminal payoff remains.
+    thetaPerDay: inTheMoney && years > 0
+      ? direction * (dividendYield * discountedSpot - rate * discountedStrike) / DAYS_PER_YEAR
+      : 0,
+    rhoPerPoint: inTheMoney && years > 0 ? direction * years * discountedStrike / 100 : 0,
   };
 }
 

--- a/src/plugins/builtin/options-calculator/pane.test.tsx
+++ b/src/plugins/builtin/options-calculator/pane.test.tsx
@@ -106,12 +106,10 @@ test("prices the seeded contract and solves its implied volatility", async () =>
   expect(frame).toContain("European exercise");
 });
 
-test("opens on defaults with no seed and leaves implied volatility empty", async () => {
-  await render();
-
+test("shows the remaining fraction of a day for a live near-expiry contract", async () => {
+  await render({ days: "0.25" });
   const frame = testSetup!.captureCharFrame();
-  expect(frame).toContain("Spot");
-  expect(frame).toContain("Market");
+  expect(frame).toMatch(/Days\s+0\.25\s*d/);
   expect(frame).toMatch(/Implied IV\s+—/);
 });
 

--- a/src/plugins/builtin/options-calculator/pane.tsx
+++ b/src/plugins/builtin/options-calculator/pane.tsx
@@ -38,8 +38,13 @@ export function OptionsCalculatorPane({ focused, width, height }: PaneProps) {
       id: "days",
       label: "Days",
       value: draft.daysToExpiry,
-      // Whole days read better than the shared 2-decimal number format.
-      valueText: String(Math.round(draft.daysToExpiry)),
+      // Keep intraday expiry visible; rounding six hours to "0 d" makes a
+      // live contract appear expired while its time value is still priced.
+      valueText: Number.isInteger(draft.daysToExpiry)
+        ? String(draft.daysToExpiry)
+        : draft.daysToExpiry > 0 && draft.daysToExpiry < 0.0001
+          ? "<0.0001"
+          : String(Number(draft.daysToExpiry.toFixed(4))),
       suffix: "d",
       onValue: (value) => updateDraft({ daysToExpiry: Math.max(0, value) }),
     },

--- a/src/plugins/builtin/research/analyst-headless.test.ts
+++ b/src/plugins/builtin/research/analyst-headless.test.ts
@@ -38,6 +38,17 @@ function args(overrides: Partial<HeadlessPaneLoadArgs["options"]> = {}): Headles
 }
 
 describe("analyst research headless model", () => {
+  test("keeps an explicit zero target distinct from missing data and exposes stale reference prices", async () => {
+    const headless = createAnalystResearchHeadless({ loadData: async () => ({ ...data,
+      stale: true, fetchedAt: "2026-09-09T16:00:00Z", priceTarget: { average: 0, current: 2, currency: "USD" },
+    }) });
+    const result = await headless.load(args(), context());
+    expect(result.sections[0]?.entries?.slice(0, 3)).toMatchObject([
+      { label: "Average target", value: 0 }, { label: "Target upside", value: -1 }, { label: "Upside reference price", value: 2 },
+    ]);
+    expect(result.errors).toEqual(["Analyst research is stale"]);
+    expect(result.metadata).toMatchObject({ stale: true, fetchedAt: "2026-09-09T16:00:00Z" });
+  });
   test("projects summary and ratings while applying sort and limit", async () => {
     const headless = createAnalystResearchHeadless({ loadData: async () => data });
 

--- a/src/plugins/builtin/research/analyst-headless.ts
+++ b/src/plugins/builtin/research/analyst-headless.ts
@@ -60,6 +60,11 @@ function overviewEntries(data: AnalystResearchData): HeadlessPaneEntry[] {
       formatted: upside == null ? "-" : formatPercent(upside),
     },
     {
+      label: "Upside reference price",
+      value: target?.current ?? null,
+      formatted: target?.current == null ? "-" : formatCurrency(target.current, currency),
+    },
+    {
       label: "Target range",
       value: target ? { low: target.low, median: target.median, high: target.high } : null,
       formatted: target
@@ -159,10 +164,13 @@ export function createAnalystResearchHeadless(
       ];
       return {
         sections,
+        errors: data.stale ? ["Analyst research is stale"] : undefined,
         metadata: {
           symbol: data.symbol || symbol,
           name: data.name ?? null,
           currency,
+          fetchedAt: data.fetchedAt,
+          stale: data.stale,
         },
       };
     },

--- a/src/plugins/builtin/research/analyst-model.ts
+++ b/src/plugins/builtin/research/analyst-model.ts
@@ -12,7 +12,9 @@ function compactPeriod(period: string): string {
 }
 
 export function targetUpside(target: AnalystResearchData["priceTarget"]): number | undefined {
-  if (!target?.average || !target.current) return undefined;
+  if (target?.average == null || target.current == null
+    || !Number.isFinite(target.average) || !Number.isFinite(target.current)
+    || target.average < 0 || target.current <= 0) return undefined;
   return (target.average - target.current) / target.current;
 }
 
@@ -206,7 +208,10 @@ export function buildAnalystSummaryLines(data: AnalystResearchData | null): stri
 
   if (target) {
     lines.push(`low ${price(target.low)}   med ${price(target.median)}   high ${price(target.high)}`);
+    if (target.current != null) lines.push(`Upside reference price ${price(target.current)}`);
   }
+
+  if (data.fetchedAt || data.stale) lines.push(`${data.stale ? "Stale data" : "Fetched"}${data.fetchedAt ? ` ${data.fetchedAt}` : ""}`);
   if (data.recommendationRating != null || rec || total > 0) {
     lines.push([
       data.recommendationRating != null ? `rating ${formatRatingLabel(data.recommendationRating)}` : null,

--- a/src/plugins/builtin/research/corporate-actions-pane.tsx
+++ b/src/plugins/builtin/research/corporate-actions-pane.tsx
@@ -113,8 +113,8 @@ function scoreFilingForEarnings(filing: SecFilingItem, earningsDate: string): nu
   return score;
 }
 
-export function matchEarningsSecFiling(row: { status: string; date: string } | null | undefined, filings: readonly SecFilingItem[]): SecFilingItem | null {
-  if (!row || row.status !== "Earnings") return null;
+export function matchEarningsSecFiling(row: { status: string; date: string; dateType?: EventRow["dateType"] } | null | undefined, filings: readonly SecFilingItem[]): SecFilingItem | null {
+  if (!row || row.status !== "Earnings" || row.dateType === "fiscal-period-end") return null;
   let best: { filing: SecFilingItem; score: number } | null = null;
   for (const filing of filings) {
     const score = scoreFilingForEarnings(filing, row.date);
@@ -189,6 +189,10 @@ function buildEventDetailBody({
   }
 
   lines.push("", "SEC Filing");
+  if (row.dateType === "fiscal-period-end") {
+    lines.push("The source supplies a fiscal period end, not an announcement date. Open SEC filings to locate the earnings release.");
+    return lines.join("\n");
+  }
   if (secFilingsLoading && !filing) {
     lines.push("Loading recent SEC filings...");
     return lines.join("\n");

--- a/src/plugins/builtin/research/event-model.test.ts
+++ b/src/plugins/builtin/research/event-model.test.ts
@@ -1,13 +1,55 @@
 import { expect, test } from "bun:test";
-import { buildEventRows, formatEventMetric } from "./event-model";
+import { buildEventRows, eventSourceNotice, formatEventMetric } from "./event-model";
 
 test("ADR reported EPS and company revenue keep their distinct currencies", () => {
   const rows = buildEventRows({ symbol: "TSM", currency: "USD", dividends: [], splits: [],
-    earnings: [{ date: "2026-01-15", epsActual: 2.5 }],
+    earnings: [{ date: "2026-01-15", epsActual: 2.5, currency: "USD" }],
   }, null, { financialCurrency: "TWD", quarterlyStatements: [
     { date: "2025-12-31", currency: "TWD", totalRevenue: 1000000000000, eps: 15 },
   ] }, "USD");
   expect(rows[0]).toMatchObject({ qEps: 2.5, qRevenue: 1000000000000, epsCurrency: "USD", revenueCurrency: "TWD" });
   expect(formatEventMetric(rows[0]?.qEps, rows[0]?.epsCurrency, "eps")).toBe("2.50 USD");
   expect(formatEventMetric(rows[0]?.qRevenue, rows[0]?.revenueCurrency, "revenue")).toBe("1T TWD");
+});
+
+test("pending RIVN earnings show consensus without borrowing prior-quarter actuals", () => {
+  const [row] = buildEventRows({ symbol: "RIVN", currency: "USD", dividends: [], splits: [],
+    earnings: [{ date: "2026-11-03", dateType: "announcement", epsEstimate: -0.73, currency: "USD", time: "AMC" }],
+  }, null, { quarterlyStatements: [{ date: "2026-06-30", currency: "USD", eps: -0.63, totalRevenue: 1_658_000_000 }] }, "USD");
+  expect(row).toMatchObject({ date: "2026-11-03", period: "AMC", detail: "Pending", qEps: -0.73, epsCurrency: "USD" });
+  expect(row?.qRevenue).toBeUndefined();
+  expect(row?.revenueCurrency).toBeUndefined();
+});
+
+test("ADRs keep independent consensus EPS and revenue currencies and never infer missing ones", () => {
+  const rows = buildEventRows(null, { symbol: "TSM", currency: "USD", recommendations: [], ratings: [],
+    earningsEstimates: [{ date: "2026-09-30", period: "current_quarter", average: 4.46, currency: "USD" }],
+    revenueEstimates: [{ date: "2026-09-30", period: "current_quarter", average: 1.454e12, currency: "TWD" },
+      { date: "2026-12-31", period: "next_quarter", average: 1.6e12 }],
+  }, null, "USD");
+  expect(rows.find((row) => row.date === "2026-09-30")).toMatchObject({ epsCurrency: "USD", revenueCurrency: "TWD" });
+  expect(rows.find((row) => row.date === "2026-12-31")?.revenueCurrency).toBeUndefined();
+});
+
+test("split direction and fractional historical dividends remain faithful to the event", () => {
+  const rows = buildEventRows({ symbol: "NVDA", currency: "USD", earnings: [],
+    dividends: [{ exDate: "2024-03-05", amount: 0.004 }],
+    splits: [{ date: "2024-06-10", fromFactor: 1, toFactor: 10 }, { date: "2023-01-01", fromFactor: 20, toFactor: 1 }],
+  }, null, null, "USD");
+  expect(rows.map((row) => row.value)).toEqual(["10:1", "$0.004", "1:20"]);
+});
+
+test("fiscal period ends stay labeled and unknown EPS currency stays unknown", () => {
+  const [row] = buildEventRows({ symbol: "COST", currency: "USD", dividends: [], splits: [],
+    earnings: [{ date: "2026-05-31", dateType: "fiscal-period-end", epsActual: 4.93, difference: 0.01 }],
+  }, null, null, "USD");
+  expect(row).toMatchObject({ dateType: "fiscal-period-end", detail: "Period end; diff 0.01" });
+  expect(row?.epsCurrency).toBeUndefined();
+});
+
+test("partial and stale corporate data are not described as an empty event history", () => {
+  const notice = eventSourceNotice({ variant: "corporate-actions", symbol: "RIVN", actionsError: null, estimatesError: null, estimates: null,
+    actions: { symbol: "RIVN", dividends: [], splits: [], earnings: [], coverage: { earnings: "unavailable", dividends: "available" }, stale: true },
+  });
+  expect(notice).toEqual({ text: "Unavailable: earnings   Corporate actions stale", failed: true });
 });

--- a/src/plugins/builtin/research/event-model.ts
+++ b/src/plugins/builtin/research/event-model.ts
@@ -6,7 +6,7 @@ import type {
   TickerFinancials,
 } from "../../../types/financials";
 import {
-  formatCurrency,
+  formatDistributionAmount,
   formatCompact,
   formatNumber,
   formatPercent,
@@ -19,6 +19,7 @@ export type EventStatus = "Earnings" | "Q Est" | "FY Est" | "TTM" | "Dividend" |
 export interface EventRow {
   id: string;
   date: string;
+  dateType?: "announcement" | "fiscal-period-end";
   status: EventStatus;
   period: string;
   detail: string;
@@ -158,8 +159,8 @@ function ttmRow(quarterlyStatements: readonly FinancialStatement[], financialCur
 
 function earningsDetail(earning: CorporateActionsData["earnings"][number]): string {
   if (earning.epsActual == null) return "Pending";
-  if (earning.difference == null) return "Reported";
-  return `diff ${formatNumber(earning.difference, 2)}`;
+  const detail = earning.difference == null ? "Reported" : `diff ${formatNumber(earning.difference, 2)}`;
+  return earning.dateType === "fiscal-period-end" ? `Period end; ${detail}` : detail;
 }
 
 function eventSortRank(status: EventStatus): number {
@@ -185,17 +186,18 @@ export function buildEventRows(
   if (ttm) rows.push(ttm);
 
   for (const earning of data?.earnings ?? []) {
-    const statement = statementForEarningsDate(quarterlyStatements, earning.date);
+    // A pending announcement must never inherit the previous report's actuals.
+    const statement = earning.epsActual == null ? undefined : statementForEarningsDate(quarterlyStatements, earning.date);
     rows.push({
       id: `earn:${earning.date}`,
       date: earning.date,
+      dateType: earning.dateType,
       status: "Earnings",
       period: statement ? quarterLabel(statement) : earning.time?.trim() || "-",
       detail: earningsDetail(earning),
-      epsCurrency: earning.epsActual != null || (statement?.eps == null && earning.epsEstimate != null)
-        ? data?.currency ?? currency : statement?.currency ?? financials?.financialCurrency,
-      revenueCurrency: statement?.currency ?? financials?.financialCurrency,
-      qEps: earning.epsActual ?? statement?.eps ?? earning.epsEstimate,
+      epsCurrency: earning.currency,
+      revenueCurrency: statement ? statement.currency ?? financials?.financialCurrency : undefined,
+      qEps: earning.epsActual ?? earning.epsEstimate,
       qRevenue: statement?.totalRevenue,
       value: earning.surprisePercent != null ? formatPercentRaw(earning.surprisePercent) : "-",
       tone: earning.surprisePercent == null ? "muted" : earning.surprisePercent >= 0 ? "positive" : "negative",
@@ -210,8 +212,8 @@ export function buildEventRows(
       status: isFiscal ? "FY Est" : "Q Est",
       period: formatPeriod(pair.period),
       detail: formatEstimateDetail(pair),
-      epsCurrency: estimates?.currency,
-      revenueCurrency: estimates?.currency,
+      epsCurrency: pair.eps?.currency,
+      revenueCurrency: pair.revenue?.currency,
       qEps: isFiscal ? undefined : pair.eps?.average,
       qRevenue: isFiscal ? undefined : pair.revenue?.average,
       annualEps: isFiscal ? pair.eps?.average : undefined,
@@ -228,7 +230,7 @@ export function buildEventRows(
       status: "Dividend",
       period: "-",
       detail: "Ex-date",
-      value: formatCurrency(dividend.amount, currency),
+      value: formatDistributionAmount(dividend.amount, data?.currency ?? currency),
       tone: "positive",
     });
   }
@@ -241,7 +243,7 @@ export function buildEventRows(
       period: "-",
       detail: split.description ?? "Split",
       value: split.fromFactor && split.toFactor
-        ? `${split.fromFactor}:${split.toFactor}`
+        ? `${split.toFactor}:${split.fromFactor}`
         : formatNumber(split.ratio, 4),
       tone: "muted",
     });
@@ -280,14 +282,22 @@ export function eventSourceNotice(state: EventSourceState): EventSourceNotice | 
     ? "Reported earnings"
     : "Corporate actions";
   const notices: string[] = [];
+  const unavailableSections = Object.entries(state.actions?.coverage ?? {})
+    .filter(([section, status]) => status === "unavailable" && (state.variant !== "earnings-estimates" || section === "earnings"))
+    .map(([section]) => section);
 
   if (state.actionsError) {
     notices.push(`${actionsLabel} unavailable: ${state.actionsError}`);
+  } else if (unavailableSections.length > 0) {
+    notices.push(`Unavailable: ${unavailableSections.join(", ")}`);
   } else if (state.actions && !hasCorporateActionRows(state.actions)) {
     notices.push(state.variant === "earnings-estimates"
       ? `No reported earnings for ${state.symbol}`
       : `No dividends, splits, or reported earnings for ${state.symbol}`);
   }
+
+  if (state.actions?.stale) notices.push(`Corporate actions stale${state.actions.fetchedAt ? ` (fetched ${state.actions.fetchedAt})` : ""}`);
+  if (state.estimates?.stale) notices.push(`Analyst estimates stale${state.estimates.fetchedAt ? ` (fetched ${state.estimates.fetchedAt})` : ""}`);
 
   if (state.estimatesError) {
     notices.push(`Analyst estimates unavailable: ${state.estimatesError}`);
@@ -298,7 +308,7 @@ export function eventSourceNotice(state: EventSourceState): EventSourceNotice | 
   if (notices.length === 0) return null;
   return {
     text: notices.join("   "),
-    failed: !!state.actionsError || !!state.estimatesError,
+    failed: !!state.actionsError || !!state.estimatesError || unavailableSections.length > 0 || !!state.actions?.stale || !!state.estimates?.stale,
   };
 }
 

--- a/src/plugins/builtin/research/events-headless.test.ts
+++ b/src/plugins/builtin/research/events-headless.test.ts
@@ -1,12 +1,23 @@
 import { describe, expect, test } from "bun:test";
 import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
 import { createEventsHeadless } from "./events-headless";
+import { createTestDataProvider } from "../../../test-support/data-provider";
 
 const args: HeadlessPaneLoadArgs = {
   rawArgument: "AAPL", argument: "AAPL", symbols: ["AAPL"], options: {},
 };
 
 describe("corporate actions headless model", () => {
+  test("keeps successful events while reporting failed estimates and statements", async () => {
+    const marketData = createTestDataProvider({
+      getCorporateActions: async () => ({ symbol: "NVDA", currency: "USD", dividends: [{ exDate: "2024-03-05", amount: 0.004 }], splits: [], earnings: [] }),
+      getAnalystResearch: async () => { throw new Error("Analyst source timed out"); },
+      getTickerFinancials: async () => { throw new Error("Financials source timed out"); },
+    });
+    const result = await createEventsHeadless().load(args, { marketData } as HeadlessPaneContext);
+    expect(result.rows[0]).toMatchObject({ status: "Dividend", value: "$0.004" });
+    expect(result.errors).toEqual(["Analyst estimates unavailable: Analyst source timed out", "Financial statements unavailable: Financials source timed out"]);
+  });
   test("maps corporate actions through the same event projection as the pane", async () => {
     const headless = createEventsHeadless({
       load: async () => ({

--- a/src/plugins/builtin/research/events-headless.ts
+++ b/src/plugins/builtin/research/events-headless.ts
@@ -8,7 +8,7 @@ import type {
   HeadlessPaneDefinition,
   HeadlessPaneLoadArgs,
 } from "../../../types/plugin";
-import { formatEventMetric, buildEventRows } from "./event-model";
+import { formatEventMetric, buildEventRows, eventSourceNotice } from "./event-model";
 
 const COLUMNS = [
   { key: "date", header: "Date" },
@@ -27,6 +27,9 @@ export interface EventHeadlessData {
   estimates: AnalystResearchData | null;
   financials: TickerFinancials | null;
   currency: string;
+  actionsError?: string | null;
+  estimatesError?: string | null;
+  financialsError?: string | null;
 }
 
 export interface EventsHeadlessDependencies {
@@ -39,21 +42,25 @@ export interface EventsHeadlessDependencies {
 
 const defaultDependencies: EventsHeadlessDependencies = {
   async load(_args, symbol, provider) {
-    if (!provider.getCorporateActions) {
-      throw new Error("Corporate actions source unavailable");
-    }
-    const [actions, estimates, financials] = await Promise.all([
-      provider.getCorporateActions(symbol, ""),
+    const [actions, estimates, financials] = await Promise.allSettled([
+      provider.getCorporateActions ? provider.getCorporateActions(symbol, "") : Promise.reject(new Error("Corporate actions source unavailable")),
       provider.getAnalystResearch
-        ? provider.getAnalystResearch(symbol, "").catch(() => null)
-        : null,
-      provider.getTickerFinancials(symbol, "").catch(() => null),
+        ? provider.getAnalystResearch(symbol, "")
+        : Promise.reject(new Error("Analyst estimates source unavailable")),
+      provider.getTickerFinancials(symbol, ""),
     ]);
+    const actionsData = actions.status === "fulfilled" ? actions.value : null;
+    const estimatesData = estimates.status === "fulfilled" ? estimates.value : null;
+    const financialsData = financials.status === "fulfilled" ? financials.value : null;
+    const error = (result: PromiseSettledResult<unknown>) => result.status === "rejected" ? String(result.reason instanceof Error ? result.reason.message : result.reason) : null;
     return {
-      actions,
-      estimates,
-      financials,
-      currency: actions.currency ?? estimates?.currency ?? financials?.quote?.currency ?? "USD",
+      actions: actionsData,
+      estimates: estimatesData,
+      financials: financialsData,
+      actionsError: error(actions),
+      estimatesError: error(estimates),
+      financialsError: error(financials),
+      currency: actionsData?.currency ?? estimatesData?.currency ?? financialsData?.quote?.currency ?? "USD",
     };
   },
 };
@@ -74,10 +81,20 @@ export function createEventsHeadless(
     async load(args, ctx) {
       const symbol = args.symbols[0]!;
       const data = await dependencies.load(args, symbol, ctx.marketData);
+      const notice = eventSourceNotice({ variant: "corporate-actions", symbol,
+        actions: data.actions, actionsError: data.actionsError ?? null,
+        estimates: data.estimates, estimatesError: data.estimatesError ?? null });
+      const errors = [notice?.failed ? notice.text : null,
+        data.financialsError ? `Financial statements unavailable: ${data.financialsError}` : null,
+      ].filter((error): error is string => !!error);
       return {
         rows: buildEventRows(data.actions, data.estimates, data.financials, data.currency)
           .map((row) => ({ ...row })),
-        metadata: { symbol, currency: data.currency },
+        errors: errors.length > 0 ? errors : undefined,
+        metadata: { symbol, currency: data.currency, coverage: data.actions?.coverage,
+          actionsFetchedAt: data.actions?.fetchedAt, estimatesFetchedAt: data.estimates?.fetchedAt,
+          ...(notice ? { notice: notice.text } : {}),
+        },
       };
     },
   };

--- a/src/plugins/builtin/research/index.test.ts
+++ b/src/plugins/builtin/research/index.test.ts
@@ -175,7 +175,8 @@ describe("analyst summary", () => {
     } satisfies AnalystResearchData);
 
     expect(lines[0]).toBe("low $225.00   med $482.50   high $625.00");
-    expect(lines[1]).toBe("rating 8.8/10   SB 12  B 18  H 4  S 1   35 analysts (month)");
+    expect(lines[1]).toBe("Upside reference price $467.50");
+    expect(lines[2]).toBe("rating 8.8/10   SB 12  B 18  H 4  S 1   35 analysts (month)");
   });
 });
 
@@ -326,7 +327,7 @@ describe("event rows", () => {
     expect(rows).toMatchObject([
       { id: "div:2026-02-10", status: "Dividend", value: "$0.26" },
       { id: "earn:2026-01-30", status: "Earnings" },
-      { id: "split:2025-12-01:4-for-1 split", status: "Split", value: "1:4" },
+      { id: "split:2025-12-01:4-for-1 split", status: "Split", value: "4:1" },
     ]);
     expect(rows[0]?.qEps).toBeUndefined();
     expect(rows[0]?.annualEps).toBeUndefined();
@@ -361,6 +362,7 @@ describe("event rows", () => {
     ];
 
     expect(matchEarningsSecFiling(row, filings)?.accessionNumber).toBe("0000320193-26-000009");
+    expect(matchEarningsSecFiling({ ...row!, dateType: "fiscal-period-end" }, filings)).toBeNull();
   });
 });
 

--- a/src/plugins/builtin/sectors/client.test.ts
+++ b/src/plugins/builtin/sectors/client.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import type { DataProvider } from "../../../types/data-provider";
+import type { PricePoint, Quote } from "../../../types/financials";
+import { loadSectorRows } from "./client";
+
+const sectors = [
+  { name: "Technology", etf: "XLK" },
+  { name: "Financials", etf: "XLF" },
+];
+const quote = (symbol: string): Quote => ({
+  symbol, price: 105, change: 5, changePercent: 5, currency: "USD", lastUpdated: 1,
+});
+const history = [
+  { date: "2025-09-10", close: 80 },
+  { date: "2026-08-10", close: 90 },
+  { date: "2026-09-10", close: 100 },
+] as PricePoint[];
+
+describe("sector quote recovery", () => {
+  test("retries missing batch items without refetching successful quotes", async () => {
+    const retried: string[] = [];
+    const provider = {
+      getQuotesBatch: async () => [{ target: { symbol: "XLK", exchange: "" }, quote: quote("XLK") }],
+      getQuote: async (symbol: string) => { retried.push(symbol); return quote(symbol); },
+      getPriceHistory: async () => history,
+    } as unknown as DataProvider;
+    const rows = await loadSectorRows(sectors, provider);
+    expect(retried).toEqual(["XLF"]);
+    expect(rows.map(({ row }) => [row?.price, row?.changePercent, row?.quoteUnavailable]))
+      .toEqual([[105, 5, false], [105, 5, false]]);
+  });
+
+  test("keeps historical returns while leaving unavailable current quotes blank", async () => {
+    const provider = {
+      getQuotesBatch: async () => { throw new Error("batch unavailable"); },
+      getQuote: async () => { throw new Error("quote unavailable"); },
+      getPriceHistory: async () => history,
+    } as unknown as DataProvider;
+    const [result] = await loadSectorRows(sectors.slice(0, 1), provider);
+    expect(result?.row).toMatchObject({ price: null, changePercent: null, quoteUnavailable: true });
+    expect(result?.row?.return1Y).toBeCloseTo(25);
+    expect(result?.row?.return1M).toBeCloseTo(11.111111);
+  });
+});

--- a/src/plugins/builtin/sectors/client.ts
+++ b/src/plugins/builtin/sectors/client.ts
@@ -3,7 +3,6 @@ import type { PricePoint, Quote } from "../../../types/financials";
 import type { SectorDef } from "./sector-data";
 import {
   computeTrailingReturn,
-  latestHistoryClose,
   ONE_MONTH_DAYS,
   ONE_YEAR_DAYS,
   type SectorRow,
@@ -24,26 +23,28 @@ export async function loadSectorRows(
       sectors.map((sector) => ({ symbol: sector.etf, exchange: "" })),
     ).catch(() => []);
     for (const result of results) quotes.set(result.target.symbol, result.quote ?? null);
-  } else {
-    await Promise.all(sectors.map(async (sector) => {
-      try {
-        quotes.set(sector.etf, await provider.getQuote(sector.etf, ""));
-      } catch {
-        quotes.set(sector.etf, null);
-      }
-    }));
   }
+  // A partial batch must not silently replace a live quote with yesterday's
+  // history close. Retry only the missing instruments through the normal route.
+  await Promise.all(sectors.filter((sector) => !quotes.get(sector.etf)).map(async (sector) => {
+    try {
+      quotes.set(sector.etf, await provider.getQuote(sector.etf, ""));
+    } catch {
+      quotes.set(sector.etf, null);
+    }
+  }));
 
   return Promise.all(sectors.map(async (sector) => {
     const history: PricePoint[] = await provider.getPriceHistory(sector.etf, "", "1Y")
       .catch(() => []);
     const quote = quotes.get(sector.etf) ?? null;
     if (!quote && history.length === 0) return { etf: sector.etf, row: null };
-    const price = quote?.price ?? latestHistoryClose(history);
+    const price = quote?.price ?? null;
     return {
       etf: sector.etf,
       row: {
         price,
+        quoteUnavailable: !quote,
         changePercent: quote?.changePercent ?? null,
         return1M: computeTrailingReturn(history, ONE_MONTH_DAYS, price),
         return1Y: computeTrailingReturn(history, ONE_YEAR_DAYS, price),

--- a/src/plugins/builtin/sectors/headless.test.ts
+++ b/src/plugins/builtin/sectors/headless.test.ts
@@ -7,6 +7,18 @@ function args(collection: string): HeadlessPaneLoadArgs {
 }
 
 describe("sectors headless model", () => {
+  test("reports incomplete quotes even when historical returns remain available", async () => {
+    const headless = createSectorsHeadless({
+      load: async (_args, definitions) => definitions.map((definition) => ({
+        etf: definition.etf,
+        row: { price: null, changePercent: null, return1Y: 10, quoteUnavailable: true },
+      })),
+    });
+    const result = await headless.load(args("sectors"), {} as HeadlessPaneContext);
+    expect(result.unavailableSymbols).toContain("XLK");
+    expect(result.rows.find((row) => row.etf === "XLK")?.return1Y).toBe(10);
+  });
+
   test("changes the loaded ETF universe with the collection option", async () => {
     const requested: string[][] = [];
     const headless = createSectorsHeadless({

--- a/src/plugins/builtin/sectors/headless.ts
+++ b/src/plugins/builtin/sectors/headless.ts
@@ -30,6 +30,7 @@ export function projectSectorRows(
     return1Y: byEtf.get(definition.etf)?.return1Y ?? null,
     currency: byEtf.get(definition.etf)?.currency ?? "USD",
     loading: false,
+    quoteUnavailable: !byEtf.get(definition.etf) || byEtf.get(definition.etf)?.quoteUnavailable === true,
   })), DEFAULT_SORT_PREFERENCE);
 }
 
@@ -65,12 +66,15 @@ export function createSectorsHeadless(
       const definitions = getSectorCollection(collectionId).items;
       const outcomes = await dependencies.load(args, definitions, ctx.marketData);
       const rows = projectSectorRows(definitions, outcomes);
+      const unavailableQuotes = rows.filter((row) => row.quoteUnavailable).map((row) => row.etf);
       return {
+        unavailableSymbols: unavailableQuotes.length > 0 ? unavailableQuotes : undefined,
         rows: rows.map((row) => ({ ...row })),
         metadata: {
           collection: collectionId,
           available: outcomes.filter((outcome) => outcome.row).length,
           requested: definitions.length,
+          unavailableQuotes,
         },
       };
     },

--- a/src/plugins/builtin/sectors/index.tsx
+++ b/src/plugins/builtin/sectors/index.tsx
@@ -108,11 +108,12 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
       if (fetchGenRef.current !== gen) return;
       const loadedByEtf = new Map(outcomes.map((outcome) => [outcome.etf, outcome.row]));
       setRowsByCollection((prev) => updateRowsForCollection(prev, collectionId, sectorDefs, (rows) => (
-        rows.map((row) => ({ ...row, ...(loadedByEtf.get(row.etf) ?? {}), loading: false }))
+        rows.map((row) => ({ ...row, ...(loadedByEtf.get(row.etf) ?? { price: null, changePercent: null, quoteUnavailable: true }), loading: false }))
       )));
 
       const loadedCount = outcomes.filter((outcome) => outcome.row).length;
-      setLoadError(loadedCount === 0 ? "Sector data unavailable" : null);
+      const missingQuotes = outcomes.filter((outcome) => !outcome.row || outcome.row.quoteUnavailable).length;
+      setLoadError(loadedCount === 0 ? "Sector data unavailable" : missingQuotes > 0 ? `${missingQuotes} quotes unavailable` : null);
       // A refresh that returned nothing must not claim the board is current.
       if (loadedCount === 0) return;
       setLastRefreshByCollection((prev) => ({ ...prev, [collectionId]: Date.now() }));

--- a/src/plugins/builtin/sectors/sector-model.ts
+++ b/src/plugins/builtin/sectors/sector-model.ts
@@ -20,6 +20,7 @@ export interface SectorRow extends SectorDef {
   return1Y: number | null;
   currency: string;
   loading: boolean;
+  quoteUnavailable?: boolean;
 }
 
 type SectorColumnId = "name" | "etf" | "price" | "changePercent" | "return1M" | "return1Y" | "bar";
@@ -83,6 +84,7 @@ export function normalizeRowsForCollection(
       return1Y: existing?.return1Y ?? null,
       currency: existing?.currency ?? "USD",
       loading: existing?.loading ?? true,
+      quoteUnavailable: existing?.quoteUnavailable ?? false,
     };
   });
 }

--- a/src/plugins/builtin/thirteenf/format.ts
+++ b/src/plugins/builtin/thirteenf/format.ts
@@ -45,6 +45,8 @@ export function actionLabel(action: HoldingAction): string {
       return "Exit";
     case "held":
       return "Held";
+    case "unknown":
+      return "--";
   }
 }
 

--- a/src/plugins/builtin/thirteenf/headless.test.ts
+++ b/src/plugins/builtin/thirteenf/headless.test.ts
@@ -80,6 +80,27 @@ function args(view: string, limit = 50): HeadlessPaneLoadArgs {
 }
 
 describe("13F headless model", () => {
+  test("requires an unambiguous manager even when the requested output has only one row", async () => {
+    const lookups: number[] = [];
+    let loaded = false;
+    const headless = createThirteenFHeadless({
+      loadBrowser: async (_tab, _query, limit) => {
+        lookups.push(limit);
+        return { rows: [
+          { id: "asset", cik: "0000949012", name: "Berkshire Asset Management", source: "funds" },
+          { id: "hathaway", cik: detail.cik, name: detail.name, source: "funds" },
+        ] };
+      },
+      loadDetail: async () => { loaded = true; return detail; },
+    });
+    await expect(headless.load({ ...args("holdings", 1), argument: "Berkshire" }, context()))
+      .rejects.toThrow(/Ambiguous 13F fund.*0001067983/);
+    expect(loaded).toBe(false);
+    expect(lookups).toEqual([25]);
+    const exact = await headless.load({ ...args("holdings", 1), argument: "Berkshire Hathaway" }, context());
+    expect(exact.metadata?.cik).toBe(detail.cik);
+  });
+
   test("projects browser rows and switches to fund holdings", async () => {
     const headless = createThirteenFHeadless({
       loadBrowser: async () => ({

--- a/src/plugins/builtin/thirteenf/headless.ts
+++ b/src/plugins/builtin/thirteenf/headless.ts
@@ -17,6 +17,8 @@ import {
   buildFundHoldingRows,
   buildTimelineRows,
   inferBrowserTabFromQuery,
+  hasComparable13FQuarter,
+  THIRTEENF_OPTIONS_NOTE,
   isCikQuery,
   positionType,
   sortBrowserRows,
@@ -79,7 +81,8 @@ const HOLDING_COLUMNS: HeadlessPaneColumn[] = [
   },
   {
     key: "weight",
-    header: "Weight",
+    header: "13F %",
+    description: "Share of the filing's reported value, including underlying notional for options; not portfolio allocation.",
     align: "right",
     format: (value) => formatPercentMaybe(value == null ? null : Number(value)),
   },
@@ -164,17 +167,23 @@ function browserTab(view: HeadlessThirteenFView, query: string): ThirteenFBrowse
 
 async function resolveFund(
   query: string,
-  limit: number,
   args: HeadlessPaneLoadArgs,
   ctx: HeadlessPaneContext,
   dependencies: ThirteenFHeadlessDependencies,
 ): Promise<{ cik: string; name: string }> {
   if (!query) throw new Error("13F holdings and filings require a fund name or CIK.");
   if (isCikQuery(query)) return { cik: normalizeCik(query), name: query };
-  const result = await dependencies.loadBrowser("funds", query, Math.min(limit, 25), args, ctx);
-  const exact = result.rows.find((row) => row.name.toLocaleLowerCase() === query.toLocaleLowerCase());
-  const fund = exact ?? result.rows[0];
-  if (!fund) throw new Error(`No 13F fund found for "${query}".`);
+  // A small output limit must not hide other matching managers during lookup.
+  const result = await dependencies.loadBrowser("funds", query, 25, args, ctx);
+  const candidates = [...new Map(result.rows.map((row) => [row.cik, row])).values()];
+  const exact = candidates.filter((row) => row.name.toLocaleLowerCase() === query.toLocaleLowerCase());
+  const fund = exact.length === 1 ? exact[0]
+    : candidates.length === 1 && !result.hasMore ? candidates[0] : undefined;
+  if (candidates.length === 0) throw new Error(`No 13F fund found for "${query}".`);
+  if (!fund) {
+    const choices = candidates.slice(0, 5).map((row) => `${row.name} (${row.cik})`).join("; ");
+    throw new Error(`Ambiguous 13F fund "${query}". Use an exact fund name or CIK: ${choices}.`);
+  }
   return { cik: fund.cik, name: fund.name };
 }
 
@@ -223,7 +232,7 @@ export function createThirteenFHeadless(
       const limit = Number(args.options.limit);
 
       if (view === "holdings" || view === "filings") {
-        const fund = await resolveFund(query, limit, args, ctx, dependencies);
+        const fund = await resolveFund(query, args, ctx, dependencies);
         const detail = await dependencies.loadDetail(fund.cik, fund.name, args, ctx);
         if (view === "filings") {
           const rows = sortTimelineRows(buildTimelineRows(detail.forms), DEFAULT_TIMELINE_SORT)
@@ -259,6 +268,9 @@ export function createThirteenFHeadless(
             fund: detail.name,
             latestPeriod: detail.latestForm?.periodOfReport ?? null,
             previousPeriod: detail.previousForm?.periodOfReport ?? null,
+            comparisonAvailable: hasComparable13FQuarter(detail),
+            valueBasis: THIRTEENF_OPTIONS_NOTE,
+            estimatedPnlBasis: "Quarter-end unit-value change on overlapping reported shares; excludes options, trading costs and dividends; not actual fund P&L.",
           },
         };
       }

--- a/src/plugins/builtin/thirteenf/model.test.ts
+++ b/src/plugins/builtin/thirteenf/model.test.ts
@@ -57,6 +57,8 @@ describe("13F model", () => {
   test("uses the latest plausibly filed 13F quarter", () => {
     expect(latestLikely13FQuarter(new Date("2026-05-24T00:00:00Z"))).toBe("2026Q1");
     expect(latestLikely13FQuarter(new Date("2026-04-20T00:00:00Z"))).toBe("2025Q4");
+    expect(latestLikely13FQuarter(new Date("2026-01-15T00:00:00Z"))).toBe("2025Q3");
+    expect(latestLikely13FQuarter(new Date("2026-02-20T00:00:00Z"))).toBe("2025Q4");
   });
 
   test("selects the latest filing for each period", () => {
@@ -139,6 +141,43 @@ describe("13F model", () => {
       investmentDiscretion: "SOLE",
     });
     expect(sortFilingPositionRows(rows, { columnId: "value", direction: "desc" }).map((row) => row.ticker)).toEqual(["BBB", "AAA"]);
+  });
+
+  test("uses CUSIP and security type across ticker and class-label changes, and excludes option P&L", () => {
+    const current = [
+      holding({ ticker: "NEW", titleOfClass: "ORDINARY", value: 120, shares: 10 }),
+      holding({ ticker: "NEW", putCall: "PUT", value: 120, shares: 10 }),
+      holding({ ticker: "NEW", shareType: "PRN", value: 500, shares: 500 }),
+    ];
+    const rows = buildFundHoldingRows({
+      cik: "0001067983", name: "Fund", forms: [],
+      latestForm: form({}), previousForm: form({ periodOfReport: "2025-12-31" }),
+      latestHoldings: current,
+      previousHoldings: [
+        holding({ ticker: "OLD", titleOfClass: "COM", value: 100, shares: 10 }),
+        holding({ ticker: "OLD", putCall: "PUT", value: 100, shares: 10 }),
+      ],
+    });
+    expect(rows).toHaveLength(3);
+    expect(rows.find((row) => row.shareType === "SH" && !row.putCall))
+      .toMatchObject({ ticker: "NEW", action: "held", sharesChange: 0, estimatedPnl: 20 });
+    expect(rows.find((row) => row.putCall === "PUT"))
+      .toMatchObject({ estimatedPnl: null, shares: 10, action: "held" });
+    expect(rows.find((row) => row.shareType === "PRN")?.shares).toBe(500);
+  });
+
+  test("does not call a first filing or a missing-quarter comparison new buying", () => {
+    for (const previousForm of [null, form({ periodOfReport: "2025-09-30" })]) {
+      const rows = buildFundHoldingRows({
+        cik: "0001067983", name: "Fund", forms: [], latestForm: form({}), previousForm,
+        latestHoldings: [holding({ value: 120, shares: 10 })],
+        previousHoldings: previousForm ? [holding({ value: 100, shares: 9 })] : [],
+      });
+      expect(rows[0]).toMatchObject({
+        value: 120, shares: 10, previousValue: null, sharesChange: null,
+        sharesChangePercent: null, valueChange: null, estimatedPnl: null, action: "unknown",
+      });
+    }
   });
 
   test("timeline rows include period-over-period value changes", () => {

--- a/src/plugins/builtin/thirteenf/model.ts
+++ b/src/plugins/builtin/thirteenf/model.ts
@@ -26,6 +26,7 @@ import type {
 
 export const THIRTEENF_PANE_ID = "thirteenf-funds";
 export const THIRTEENF_TEMPLATE_ID = "thirteenf-funds-pane";
+export const THIRTEENF_OPTIONS_NOTE = "Option values and shares refer to the underlying; 13F % is share of reported value.";
 
 export const FUND_DETAIL_TABS: Array<{ label: string; value: ThirteenFDetailTab }> = [
   { label: "Holdings", value: "holdings" },
@@ -72,19 +73,14 @@ export function normalizeQuarterDate(value: Date): string {
 }
 
 export function latestLikely13FQuarter(now = new Date()): string {
-  const year = now.getUTCFullYear();
-  const quarterEnds = [
-    Date.UTC(year - 1, 11, 31),
-    Date.UTC(year, 2, 31),
-    Date.UTC(year, 5, 30),
-    Date.UTC(year, 8, 30),
-    Date.UTC(year, 11, 31),
-  ];
-  const availableAt = quarterEnds
-    .map((timestamp) => timestamp + 50 * 24 * 60 * 60_000)
-    .filter((timestamp) => timestamp <= now.getTime())
-    .at(-1) ?? quarterEnds[0]!;
-  return normalizeQuarterDate(new Date(availableAt - 50 * 24 * 60 * 60_000));
+  const currentQuarterStart = Math.floor(now.getUTCMonth() / 3) * 3;
+  // Allow the provider's existing 50-day reporting buffer, including January
+  // when the latest broadly available filing period is the previous Q3.
+  for (let offset = 0; offset < 8; offset += 1) {
+    const end = new Date(Date.UTC(now.getUTCFullYear(), currentQuarterStart - offset * 3, 0));
+    if (end.getTime() + 50 * 86_400_000 <= now.getTime()) return normalizeQuarterDate(end);
+  }
+  return "";
 }
 
 export function dateYearsAgo(years: number, now = new Date()): string {
@@ -210,10 +206,9 @@ interface HoldingAggregate {
 
 function holdingKey(holding: ThirteenFHoldingRecord): string {
   return [
-    holding.ticker || "NO-TICKER",
-    holding.cusip,
-    holding.putCall || "",
-    holding.titleOfClass || "",
+    holding.cusip.trim().toUpperCase(),
+    holding.putCall.trim().toUpperCase(),
+    holding.shareType.trim().toUpperCase(),
   ].join("|");
 }
 
@@ -261,6 +256,9 @@ function estimateHoldingPnl(
   previous: HoldingAggregate | undefined,
 ): number | null {
   if (!current || !previous) return null;
+  // A 13F option value is underlying notional. Its change cannot price the
+  // option, and the filing does not identify strike, expiry or premium.
+  if (current.putCall || previous.putCall) return null;
   if (current.value <= 0 || previous.value <= 0) return null;
   if (current.shares <= 0 || previous.shares <= 0) return null;
 
@@ -270,10 +268,21 @@ function estimateHoldingPnl(
   return (currentPrice - previousPrice) * overlappingShares;
 }
 
+export function hasComparable13FQuarter(data: FundDetailData): boolean {
+  const current = data.latestForm?.periodOfReport;
+  const previous = data.previousForm?.periodOfReport;
+  if (!current || !previous) return false;
+  const date = new Date(`${current}T00:00:00Z`);
+  if (!Number.isFinite(date.getTime())) return false;
+  const priorEnd = new Date(Date.UTC(date.getUTCFullYear(), Math.floor(date.getUTCMonth() / 3) * 3, 0));
+  return previous === priorEnd.toISOString().slice(0, 10);
+}
+
 export function buildFundHoldingRows(data: FundDetailData | null): FundHoldingRow[] {
   if (!data?.latestForm) return [];
   const current = aggregateHoldings(data.latestHoldings);
-  const previous = aggregateHoldings(data.previousHoldings);
+  const comparable = hasComparable13FQuarter(data);
+  const previous = aggregateHoldings(comparable ? data.previousHoldings : []);
   const allKeys = new Set([...current.keys(), ...previous.keys()]);
   const totalValue = data.latestForm.tableValueTotal
     ?? [...current.values()].reduce((sum, item) => sum + item.value, 0);
@@ -286,10 +295,10 @@ export function buildFundHoldingRows(data: FundDetailData | null): FundHoldingRo
     const shares = currentHolding?.shares ?? null;
     const previousValue = previousHolding?.value ?? null;
     const previousShares = previousHolding?.shares ?? null;
-    const valueChange = value != null || previousValue != null
+    const valueChange = comparable && (value != null || previousValue != null)
       ? (value ?? 0) - (previousValue ?? 0)
       : null;
-    const sharesChange = shares != null || previousShares != null
+    const sharesChange = comparable && (shares != null || previousShares != null)
       ? (shares ?? 0) - (previousShares ?? 0)
       : null;
     const sharesChangePercent = sharesChange != null && previousShares && previousShares !== 0
@@ -312,7 +321,7 @@ export function buildFundHoldingRows(data: FundDetailData | null): FundHoldingRo
       estimatedPnl: estimateHoldingPnl(currentHolding, previousHolding),
       sharesChange,
       sharesChangePercent,
-      action: resolveAction(currentHolding, previousHolding),
+      action: comparable ? resolveAction(currentHolding, previousHolding) : "unknown",
       accessionNumber: display.accessionNumber,
     };
   });
@@ -562,7 +571,7 @@ export function buildFilingPositionColumns(width: number): FilingPositionColumn[
     { id: "type", label: "TYPE", width: typeWidth, align: "left" },
     { id: "issuer", label: "ISSUER", width: issuerWidth, align: "left" },
     { id: "value", label: "VALUE", width: valueWidth, align: "right" },
-    { id: "weight", label: "WEIGHT", width: weightWidth, align: "right" },
+    { id: "weight", label: "13F %", width: weightWidth, align: "right" },
     { id: "shares", label: "SHARES", width: sharesWidth, align: "right" },
     { id: "cusip", label: "CUSIP", width: cusipWidth, align: "left" },
     { id: "discretion", label: "DISCR", width: discretionWidth, align: "left" },
@@ -586,7 +595,7 @@ export function buildHoldingColumns(width: number): FundHoldingColumn[] {
     { id: "issuer", label: "ISSUER", width: issuerWidth, align: "left" },
     { id: "value", label: "VALUE", width: valueWidth, align: "right" },
     { id: "estimatedPnl", label: "EST P&L", width: pnlWidth, align: "right" },
-    { id: "weight", label: "WEIGHT", width: weightWidth, align: "right" },
+    { id: "weight", label: "13F %", width: weightWidth, align: "right" },
     { id: "shares", label: "SHARES", width: sharesWidth, align: "right" },
     { id: "sharesChange", label: "QOQ", width: changeWidth, align: "right" },
     { id: "action", label: "ACTION", width: actionWidth, align: "left" },

--- a/src/plugins/builtin/thirteenf/pane.tsx
+++ b/src/plugins/builtin/thirteenf/pane.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   DataTableStackView,
   DataTableView,
-  EmptyState, InputSearchBar, PaneStatusBody, Tabs, useTableLoadMore, type DataTableKeyEvent,
+  EmptyState, InputSearchBar, KeyValueRow, PaneStatusBody, Tabs, useTableLoadMore, type DataTableKeyEvent,
   type DataTableRootKeyContext, type PaneFooterSegment
 } from "../../../components";
 import { useShortcut } from "../../../react/input";
@@ -31,6 +31,8 @@ import {
   DEFAULT_TIMELINE_SORT,
   FUND_DETAIL_TABS,
   THIRTEENF_PANE_ID,
+  THIRTEENF_OPTIONS_NOTE,
+  hasComparable13FQuarter,
   buildBrowserColumns,
   buildFilingPositionColumns,
   buildFilingPositionRows,
@@ -617,6 +619,15 @@ function FundDetailView({
             onChange: (id) => setHoldingSelectedId(id),
           }}
           rootWidth={width}
+          rootBefore={(
+            <Box flexDirection="column" paddingX={1}>
+              <KeyValueRow label="Reported" value={data?.latestForm?.periodOfReport ?? "--"} detail={`Filed ${data?.latestForm?.filedAsOfDate || "--"}`} width={Math.max(1, width - 2)} />
+              <KeyValueRow label="Compared with" value={data && hasComparable13FQuarter(data) ? data.previousForm!.periodOfReport : "Prior quarter unavailable"} width={Math.max(1, width - 2)} />
+              {visibleHoldingRows.some((row) => !!row.putCall) ? (
+                <Text fg={colors.textMuted}>{THIRTEENF_OPTIONS_NOTE}</Text>
+              ) : null}
+            </Box>
+          )}
           columns={buildHoldingColumns(width)}
           items={visibleHoldingRows}
           sortColumnId={holdingSort.columnId}
@@ -774,6 +785,7 @@ function FilingDetailView({
           <Text fg={colors.text}>{value}</Text>
         </Box>
       ))}
+      {holdings.some((row) => !!row.putCall) ? <Text fg={colors.textMuted}>{THIRTEENF_OPTIONS_NOTE}</Text> : null}
     </Box>
   );
   const emptyTitle = status === "loading" || status === "idle"

--- a/src/plugins/builtin/thirteenf/table.ts
+++ b/src/plugins/builtin/thirteenf/table.ts
@@ -195,6 +195,7 @@ function actionColor(action: FundHoldingRow["action"]): string {
     case "exit":
       return colors.negative;
     case "held":
+    case "unknown":
       return colors.textDim;
   }
 }

--- a/src/plugins/builtin/thirteenf/types.ts
+++ b/src/plugins/builtin/thirteenf/types.ts
@@ -92,7 +92,7 @@ export interface FundDetailData {
   previousHoldings: ThirteenFHoldingRecord[];
 }
 
-export type HoldingAction = "held" | "new" | "add" | "trim" | "exit";
+export type HoldingAction = "held" | "new" | "add" | "trim" | "exit" | "unknown";
 
 export interface FundHoldingRow {
   id: string;

--- a/src/sources/provider-router/cached-routes.test.ts
+++ b/src/sources/provider-router/cached-routes.test.ts
@@ -15,6 +15,28 @@ function deferred<T>() {
 }
 
 describe("shared cached market queries", () => {
+  test("retries partial corporate actions and invalidates cached estimates without reporting currency", async () => {
+    const persistence = new AppPersistence(":memory:");
+    let actionCalls = 0;
+    let analystCalls = 0;
+    const provider = createTestDataProvider({ id: "research",
+      getCorporateActions: async () => ({ symbol: "BABA", dividends: [], splits: [], earnings: [],
+        coverage: { earnings: ++actionCalls === 1 ? "unavailable" as const : "available" as const } }),
+      getAnalystResearch: async () => { analystCalls++; return { symbol: "BABA", recommendations: [], ratings: [],
+        earningsEstimates: [{ date: "2026-09-30", period: "current quarter", currency: "CNY", average: 10.97 }], revenueEstimates: [] }; },
+    });
+    persistence.resources.set({ namespace: "market", kind: "analystResearch", entityKey: "BABA", sourceKey: "provider:research" },
+      { symbol: "BABA", currency: "USD", recommendations: [], ratings: [], earningsEstimates: [{ date: "2026-09-30", period: "current quarter", average: 10.97 }], revenueEstimates: [] },
+      { cachePolicy: { staleMs: 86400000, expireMs: 86400000 } });
+    const router = new AssetDataRouter(provider, [], persistence.resources);
+    try {
+      expect((await router.getAnalystResearch("BABA")).earningsEstimates[0]?.currency).toBe("CNY");
+      expect(analystCalls).toBe(1);
+      expect((await router.getCorporateActions("BABA")).coverage?.earnings).toBe("unavailable");
+      expect((await router.getCorporateActions("BABA")).coverage?.earnings).toBe("available");
+      expect(actionCalls).toBe(2);
+    } finally { persistence.close(); }
+  });
   test("preserves stale FX age, shares refreshes, notifies consumers, and unsubscribes on destroy", async () => {
     const persistence = new AppPersistence(":memory:");
     const pending = deferred<number>();

--- a/src/sources/provider-router/cached-routes.ts
+++ b/src/sources/provider-router/cached-routes.ts
@@ -155,14 +155,15 @@ export class ProviderRouterCachedRoutes {
         error: `No holder data provider available for ${ticker}`,
       };
       case "getAnalystResearch": return {
-        ...tickerRoute("analystResearch", "analystResearch"), request: (provider, force) => provider.getAnalystResearch?.(ticker, exchange, force ? { ...extra, cacheMode: "refresh" } : extra),
-        rank: (data: AnalystResearchData) => !hasAnalystResearchValue(data) ? 0 : isAnalystResearchMissingRatingTargets(data) ? 1 : 2,
-        acceptCached: (data: AnalystResearchData) => !isAnalystResearchMissingRatingTargets(data), throwLastError: true,
+        ...tickerRoute("analystResearch-v2", "analystResearch"), request: (provider, force) => provider.getAnalystResearch?.(ticker, exchange, force ? { ...extra, cacheMode: "refresh" } : extra),
+        rank: (data: AnalystResearchData) => !hasAnalystResearchValue(data) ? 0 : data.stale || isAnalystResearchMissingRatingTargets(data) ? 1 : 2,
+        acceptCached: (data: AnalystResearchData) => !data.stale && !isAnalystResearchMissingRatingTargets(data), throwLastError: true,
         error: `No analyst research provider available for ${ticker}`,
       };
       case "getCorporateActions": return {
-        ...tickerRoute("corporateActions", "corporateActions"), request: (provider, force) => provider.getCorporateActions?.(ticker, exchange, force ? { ...extra, cacheMode: "refresh" } : extra),
-        rank: (data: CorporateActionsData) => hasCorporateActionsValue(data) ? 2 : 0, throwLastError: true,
+        ...tickerRoute("corporateActions-v2", "corporateActions"), request: (provider, force) => provider.getCorporateActions?.(ticker, exchange, force ? { ...extra, cacheMode: "refresh" } : extra),
+        rank: (data: CorporateActionsData) => !hasCorporateActionsValue(data) ? 0 : data.stale || Object.values(data.coverage ?? {}).includes("unavailable") ? 1 : 2,
+        acceptCached: (data: CorporateActionsData) => !data.stale && !Object.values(data.coverage ?? {}).includes("unavailable"), throwLastError: true,
         error: `No corporate actions provider available for ${ticker}`,
       };
       case "getOptionsChain": return {

--- a/src/sources/yahoo-finance/mappers.test.ts
+++ b/src/sources/yahoo-finance/mappers.test.ts
@@ -1,8 +1,53 @@
 import { describe, expect, test } from "bun:test";
-import { extractExtendedHoursPrices } from "./mappers";
+import { extractExtendedHoursPrices, mapYahooAnalystResearchResponse, mapYahooCalendarEarnings, mapYahooEarningsHistory } from "./mappers";
+import { loadYahooCorporateActions } from "./quote-summary";
 import type { ChartResult } from "./types";
 
 describe("Yahoo mappers", () => {
+  test("normalizes London price targets without converting USD earnings estimates", () => {
+    const data = mapYahooAnalystResearchResponse({ price: { currency: "GBp" },
+      financialData: { targetMeanPrice: 3812.312, currentPrice: 3533.5 },
+      upgradeDowngradeHistory: { history: [{ epochGradeDate: 1_700_000_000, firm: "Analyst", currentPriceTarget: 3900, priorPriceTarget: 3600 }] },
+      earningsTrend: { trend: [{ period: "0q", endDate: "2026-09-30", earningsEstimate: { avg: 1.39667, earningsCurrency: "USD", numberOfAnalysts: 10 } }] },
+    }, "SHEL.L");
+    expect(data).toMatchObject({ currency: "GBP", priceTarget: { currency: "GBP", average: 38.12312, current: 35.335 },
+      ratings: [{ currentPriceTarget: 39, priorPriceTarget: 36 }], earningsEstimates: [{ average: 1.39667, currency: "USD" }] });
+  });
+
+  test("preserves TSM reporting currency and drops Yahoo no-coverage zeros while keeping break-even consensus", () => {
+    const data = mapYahooAnalystResearchResponse({ price: { currency: "USD" }, earningsTrend: { trend: [
+      { period: "0q", endDate: "2026-09-30", earningsEstimate: { avg: 4.4614, earningsCurrency: "USD" }, revenueEstimate: { avg: 1.454e12, revenueCurrency: "TWD" } },
+      { period: "+1q", earningsEstimate: { avg: 0, low: 0, high: 0, numberOfAnalysts: 2, earningsCurrency: "USD" }, revenueEstimate: { avg: 0, low: 0, high: 0, numberOfAnalysts: 0 } },
+    ] } }, "TSM");
+    expect(data.earningsEstimates.map((row) => [row.average, row.currency])).toEqual([[4.4614, "USD"], [0, "USD"]]);
+    expect(data.revenueEstimates).toHaveLength(1);
+    expect(data.revenueEstimates[0]).toMatchObject({ average: 1.454e12, currency: "TWD" });
+  });
+
+  test("distinguishes announcement dates from Yahoo fiscal period ends", () => {
+    expect(mapYahooCalendarEarnings({ calendarEvents: { earnings: { earningsDate: [{ fmt: "2026-09-24" }] } } })[0]?.dateType).toBe("announcement");
+    const [history] = mapYahooEarningsHistory({ earningsHistory: { history: [{ quarter: "2026-05-31", currency: "CNY", epsActual: -0.63, epsEstimate: -0.78, surprisePercent: 0.1885 }] } });
+    expect(history).toMatchObject({ date: "2026-05-31", dateType: "fiscal-period-end", currency: "CNY", epsActual: -0.63, surprisePercent: 18.85 });
+  });
+
+  test("omits grade-only zero placeholders but retains explicitly cut-to-zero analyst targets", () => {
+    const data = mapYahooAnalystResearchResponse({ upgradeDowngradeHistory: { history: [
+      { epochGradeDate: 1_700_000_000, firm: "Freedom Capital Markets", action: "down", priceTargetAction: "", currentPriceTarget: 0, priorPriceTarget: 0 },
+      { epochGradeDate: 1_700_000_000, firm: "Distressed analyst", action: "down", priceTargetAction: "Lowers", currentPriceTarget: 0, priorPriceTarget: 2 },
+    ] } }, "BABA");
+    expect(data.ratings[0]?.currentPriceTarget).toBeUndefined();
+    expect(data.ratings[0]?.priorPriceTarget).toBeUndefined();
+    expect(data.ratings[1]).toMatchObject({ currentPriceTarget: 0, priorPriceTarget: 2 });
+  });
+
+  test("retains London dividends when the independent earnings endpoint fails", async () => {
+    const data = await loadYahooCorporateActions({ ticker: "VOD.L", providerId: "yahoo",
+      fetchChart: async () => ({ meta: { currency: "GBp" }, events: { dividends: { one: { date: 1_700_000_000, amount: 2.0301435 } } } }),
+      fetchJsonWithCrumb: async () => { throw new Error("Earnings unavailable"); },
+    });
+    expect(data).toMatchObject({ currency: "GBP", coverage: { dividends: "available", splits: "available", earnings: "unavailable" } });
+    expect(data.dividends[0]?.amount).toBeCloseTo(0.020301435, 9);
+  });
   test("derives premarket change from the prior regular close", () => {
     const meta: NonNullable<ChartResult["meta"]> = {
       regularMarketPrice: 39.47,

--- a/src/sources/yahoo-finance/mappers.ts
+++ b/src/sources/yahoo-finance/mappers.ts
@@ -102,18 +102,21 @@ export function mapYahooAnalystResearchResponse(
   fallbackSymbol: string,
 ): AnalystResearchData {
   const financialData = result.financialData;
-  const targetHigh = financeRawNumber(financialData?.targetHighPrice);
-  const targetLow = financeRawNumber(financialData?.targetLowPrice);
-  const targetMean = financeRawNumber(financialData?.targetMeanPrice);
-  const targetMedian = financeRawNumber(financialData?.targetMedianPrice);
-  const currentPrice = financeRawNumber(financialData?.currentPrice);
+  const unit = resolveCurrencyUnit(result.price?.currency);
+  const priceValue = (value: unknown) => normalizeMarketValue(financeRawNumber(value), unit.divisor);
+  const targetHigh = priceValue(financialData?.targetHighPrice);
+  const targetLow = priceValue(financialData?.targetLowPrice);
+  const targetMean = priceValue(financialData?.targetMeanPrice);
+  const targetMedian = priceValue(financialData?.targetMedianPrice);
+  const currentPrice = priceValue(financialData?.currentPrice);
   const trend = result.earningsTrend?.trend ?? [];
 
   return {
     providerId: "yahoo",
+    fetchedAt: new Date().toISOString(),
     symbol: result.price?.symbol ?? fallbackSymbol,
     name: result.price?.shortName ?? result.price?.longName,
-    currency: result.price?.currency,
+    currency: unit.currency || undefined,
     exchange: result.price?.exchangeName,
     priceTarget: targetHigh != null || targetLow != null || targetMean != null || targetMedian != null
       ? {
@@ -122,7 +125,7 @@ export function mapYahooAnalystResearchResponse(
           low: targetLow,
           average: targetMean,
           current: currentPrice,
-          currency: result.price?.currency,
+          currency: unit.currency || undefined,
         }
       : undefined,
     recommendationRating: yahooRecommendationMeanToRating(financeRawNumber(financialData?.recommendationMean)),
@@ -146,16 +149,18 @@ export function mapYahooAnalystResearchResponse(
         const action = normalizeYahooRatingAction(rating.action, rating.priceTargetAction);
         const current = rating.toGrade?.trim();
         const prior = rating.fromGrade?.trim();
-        const currentPriceTarget = financeRawNumber(rating.currentPriceTarget);
-        const priorPriceTarget = financeRawNumber(rating.priorPriceTarget);
+        const currentPriceTarget = priceValue(rating.currentPriceTarget);
+        const priorPriceTarget = priceValue(rating.priorPriceTarget);
+        // A grade-only action uses two zero sentinels, not an explicit $0 target.
+        const emptyTargets = currentPriceTarget === 0 && priorPriceTarget === 0 && !rating.priceTargetAction?.trim();
         return {
           date,
           firm,
           ...(action ? { action } : {}),
           ...(current ? { current } : {}),
           ...(prior ? { prior } : {}),
-          ...(currentPriceTarget != null ? { currentPriceTarget } : {}),
-          ...(priorPriceTarget != null ? { priorPriceTarget } : {}),
+          ...(!emptyTargets && currentPriceTarget != null ? { currentPriceTarget } : {}),
+          ...(!emptyTargets && priorPriceTarget != null ? { priorPriceTarget } : {}),
         };
       })
       .filter((rating): rating is AnalystResearchData["ratings"][number] => rating !== null)
@@ -205,6 +210,7 @@ export function mapYahooCalendarEarnings(result: YahooQuoteSummaryResult): Earni
   const timestamp = yahooRawDateTime(rawDate);
   return [{
     date,
+    dateType: "announcement",
     time: timestamp ? inferEarningsTiming(timestamp) : undefined,
     epsEstimate: financeRawNumber(result.calendarEvents?.earnings?.earningsAverage),
   }];
@@ -216,11 +222,15 @@ export function mapYahooEarningsHistory(result: YahooQuoteSummaryResult): Earnin
       const date = yahooRawDate(earning.quarter);
       if (!date) return null;
       const surprisePercent = financeRawNumber(earning.surprisePercent);
+      const unit = resolveCurrencyUnit(earning.currency);
+      const monetaryValue = (value: unknown) => normalizeMarketValue(financeRawNumber(value), unit.divisor);
       return {
         date,
-        epsEstimate: financeRawNumber(earning.epsEstimate),
-        epsActual: financeRawNumber(earning.epsActual),
-        difference: financeRawNumber(earning.epsDifference),
+        dateType: "fiscal-period-end",
+        currency: unit.currency || undefined,
+        epsEstimate: monetaryValue(earning.epsEstimate),
+        epsActual: monetaryValue(earning.epsActual),
+        difference: monetaryValue(earning.epsDifference),
         surprisePercent: surprisePercent == null ? undefined : surprisePercent * 100,
       };
     })
@@ -369,12 +379,17 @@ function mapYahooEstimate(
 ): AnalystEstimateRecord | null {
   if (!estimate || typeof estimate !== "object") return null;
   const record = estimate as Record<string, unknown>;
-  const average = financeRawNumber(record.avg);
-  const low = financeRawNumber(record.low);
-  const high = financeRawNumber(record.high);
+  const rawCurrency = record[yearAgoKey === "yearAgoEps" ? "earningsCurrency" : "revenueCurrency"];
+  const unit = resolveCurrencyUnit(typeof rawCurrency === "string" ? rawCurrency : undefined);
+  const monetaryValue = (value: unknown) => normalizeMarketValue(financeRawNumber(value), unit.divisor);
+  const average = monetaryValue(record.avg);
+  const low = monetaryValue(record.low);
+  const high = monetaryValue(record.high);
   const analysts = financeRawNumber(record.numberOfAnalysts);
-  const yearAgo = financeRawNumber(record[yearAgoKey]);
+  const yearAgo = monetaryValue(record[yearAgoKey]);
   const growth = financeRawNumber(record.growth);
+  // Yahoo emits all-zero placeholders for periods with no analyst coverage.
+  if (analysts === 0 && [average, low, high, yearAgo, growth].every((value) => value == null || value === 0)) return null;
   if (
     average == null
     && low == null
@@ -387,6 +402,7 @@ function mapYahooEstimate(
   }
   return {
     date: trend.endDate ?? "",
+    currency: unit.currency || undefined,
     period: normalizeYahooRecommendationPeriod(trend.period),
     analysts,
     average,

--- a/src/sources/yahoo-finance/quote-summary.ts
+++ b/src/sources/yahoo-finance/quote-summary.ts
@@ -5,6 +5,7 @@ import type {
   HolderRecord,
 } from "../../types/financials";
 import type { EarningsEvent } from "../../types/data-provider";
+import { resolveCurrencyUnit } from "../../utils/currency-units";
 import {
   deriveShareChange,
   financeRawNumber,
@@ -146,26 +147,36 @@ export async function loadYahooCorporateActions({
 
   for (const symbol of symbolsToTry) {
     try {
-      const chart = await fetchChart(symbol, "5y", "1d");
       const params = new URLSearchParams({
         modules: "price,quoteType,calendarEvents,earningsHistory",
       });
       const url = `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(symbol)}?${params}`;
-      const data = await fetchJsonWithCrumb<QuoteSummaryResponse>(url);
-      const result = data.quoteSummary?.result?.[0];
-      if (!result) throw new Error(`No corporate actions for ${symbol}`);
+      const [chartResult, summaryResult] = await Promise.allSettled([
+        fetchChart(symbol, "5y", "1d"),
+        fetchJsonWithCrumb<QuoteSummaryResponse>(url).then((data) => {
+          const result = data.quoteSummary?.result?.[0];
+          if (!result) throw new Error(`No corporate actions for ${symbol}`);
+          return result;
+        }),
+      ]);
+      if (chartResult.status === "rejected" && summaryResult.status === "rejected") throw summaryResult.reason;
+      const chart = chartResult.status === "fulfilled" ? chartResult.value : undefined;
+      const result = summaryResult.status === "fulfilled" ? summaryResult.value : undefined;
+      const dividendUnit = resolveCurrencyUnit(chart?.meta.currency);
 
       const actions: CorporateActionsData = {
         providerId,
-        symbol: result.price?.symbol ?? symbol,
-        name: result.price?.shortName ?? result.price?.longName,
-        currency: result.price?.currency ?? chart.meta.currency,
-        exchange: result.price?.exchangeName ?? result.quoteType?.exchange,
-        dividends: mapYahooDividends(chart.events),
-        splits: mapYahooSplits(chart.events),
+        fetchedAt: new Date().toISOString(),
+        coverage: { dividends: chart ? "available" : "unavailable", splits: chart ? "available" : "unavailable", earnings: result?.calendarEvents || result?.earningsHistory ? "available" : "unavailable" },
+        symbol: result?.price?.symbol ?? symbol,
+        name: result?.price?.shortName ?? result?.price?.longName,
+        currency: dividendUnit.currency || undefined,
+        exchange: result?.price?.exchangeName ?? result?.quoteType?.exchange,
+        dividends: mapYahooDividends(chart?.events).map((dividend) => ({ ...dividend, amount: dividend.amount / dividendUnit.divisor })),
+        splits: mapYahooSplits(chart?.events),
         earnings: [
-          ...mapYahooCalendarEarnings(result),
-          ...mapYahooEarningsHistory(result),
+          ...mapYahooCalendarEarnings(result ?? {}),
+          ...mapYahooEarningsHistory(result ?? {}),
         ],
       };
 

--- a/src/sources/yahoo-finance/types.ts
+++ b/src/sources/yahoo-finance/types.ts
@@ -78,6 +78,7 @@ export type QuoteSummaryResponse = {
           period?: string;
           endDate?: string;
           earningsEstimate?: {
+            earningsCurrency?: string;
             avg?: { raw?: number } | number | null;
             low?: { raw?: number } | number | null;
             high?: { raw?: number } | number | null;
@@ -86,6 +87,7 @@ export type QuoteSummaryResponse = {
             growth?: { raw?: number } | number | null;
           };
           revenueEstimate?: {
+            revenueCurrency?: string;
             avg?: { raw?: number } | number | null;
             low?: { raw?: number } | number | null;
             high?: { raw?: number } | number | null;
@@ -121,6 +123,7 @@ export type QuoteSummaryResponse = {
       };
       earningsHistory?: {
         history?: Array<{
+          currency?: string;
           epsActual?: { raw?: number } | number | null;
           epsEstimate?: { raw?: number } | number | null;
           epsDifference?: { raw?: number } | number | null;

--- a/src/types/financials.ts
+++ b/src/types/financials.ts
@@ -74,8 +74,9 @@ export type QuoteContributionMap = Record<string, QuoteContribution>;
 export interface Fundamentals {
   /** Currency of reported revenue, income, and cash flows; may differ from the listing. */
   financialCurrency?: string;
-  /** Provider-reported issuer market cap in the quote currency; never inferred from share counts. */
+  /** Provider-reported issuer market cap; marketCapCurrency identifies its units when known. */
   marketCap?: number;
+  marketCapCurrency?: string;
   trailingPE?: number;
   forwardPE?: number;
   pegRatio?: number;
@@ -159,6 +160,8 @@ export interface AnalystRatingRecord {
 export interface AnalystEstimateRecord {
   date: string;
   period: string;
+  /** Explicit currency for these estimates; independent of the listing currency. */
+  currency?: string;
   analysts?: number;
   average?: number;
   low?: number;
@@ -169,6 +172,8 @@ export interface AnalystEstimateRecord {
 
 export interface AnalystResearchData {
   providerId?: string;
+  fetchedAt?: string;
+  stale?: boolean;
   symbol: string;
   name?: string;
   currency?: string;
@@ -191,13 +196,18 @@ export interface DividendAction {
 export interface SplitAction {
   date: string;
   description?: string;
+  /** New shares per old share, e.g. 10 for a ten-for-one forward split. */
   ratio?: number;
+  /** Old shares surrendered. */
   fromFactor?: number;
+  /** New shares received. */
   toFactor?: number;
 }
 
 export interface EarningsAction {
   date: string;
+  dateType?: "announcement" | "fiscal-period-end";
+  currency?: string;
   time?: string;
   epsEstimate?: number;
   epsActual?: number;
@@ -207,6 +217,9 @@ export interface EarningsAction {
 
 export interface CorporateActionsData {
   providerId?: string;
+  fetchedAt?: string;
+  stale?: boolean;
+  coverage?: Partial<Record<"dividends" | "splits" | "earnings", "available" | "unavailable">>;
   symbol: string;
   name?: string;
   currency?: string;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -3,16 +3,17 @@ import { toTimestampMillis } from "./timestamp";
 const currencyFormatters = new Map<string, Intl.NumberFormat>();
 const numberFormatters = new Map<number, Intl.NumberFormat>();
 
-function getCurrencyFormatter(currency: string): Intl.NumberFormat {
-  let formatter = currencyFormatters.get(currency);
+function getCurrencyFormatter(currency: string, maximumFractionDigits = 2): Intl.NumberFormat {
+  const key = `${currency}:${maximumFractionDigits}`;
+  let formatter = currencyFormatters.get(key);
   if (!formatter) {
     formatter = new Intl.NumberFormat("en-US", {
       style: "currency",
       currency,
       minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
+      maximumFractionDigits,
     });
-    currencyFormatters.set(currency, formatter);
+    currencyFormatters.set(key, formatter);
   }
   return formatter;
 }
@@ -33,6 +34,12 @@ function getNumberFormatter(decimals: number): Intl.NumberFormat {
 export function formatCurrency(value: number | undefined, currency = "USD"): string {
   if (value == null || !Number.isFinite(value)) return "—";
   return getCurrencyFormatter(currency).format(value);
+}
+
+/** Preserve fractional per-share distributions, including split-adjusted history. */
+export function formatDistributionAmount(value: number | undefined, currency = "USD"): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return getCurrencyFormatter(currency, 6).format(value);
 }
 
 /** Format a number as percentage (e.g., +1.23%) */


### PR DESCRIPTION
Real research workflows exposed misleading cash yields, currencies, event history and 13F comparisons. This change corrects those values across the terminal, browser and headless reports, and keeps partial-data failures visible.

| Scenario | Reproduction and corrected behavior |
| --- | --- |
| Income and credit investor | JEPQ, SGOV, BND, HYG, SCHD and O distributions; JEPQ reported 0% despite $6.765 trailing cash/share. Compute trailing cash yield from reported distributions and a matching-currency reference price. |
| UK and UCITS investor | VOD.L pence payments now normalize to GBP (about 3.09% at the observed quote). VWRA.L correctly has zero cash distributions; VWRL.L has distributing cash history. Preserve small payments, suppress unverifiable forward-rate units and past next-pay dates. |
| Income history | Replace historical “yield” computed using today's price with trailing cash/share. Guard incomplete growth baselines and February 29 boundaries. A EUR cash series cannot use a USD reference quote. |
| Earnings and ADR researcher | RIVN/COST pending earnings no longer borrow prior-quarter revenue. Preserve BABA CNY estimates and TSM USD EPS/TWD revenue. Mark fiscal-period dates and stop matching them to nearby announcement filings. |
| Analyst and corporate actions | Normalize Shell pence targets into pounds; omit grade-only zero-target placeholders; display NVIDIA 10:1 and $0.004 historical distributions. Surface unavailable sections, stale sources and retrieval dates. |
| Institutional holdings researcher | “Berkshire” now requires an exact manager or CIK instead of silently selecting Berkshire Asset Management. Show reporting/comparison dates, suppress nonadjacent-quarter comparisons, keep CUSIP identity across renames and distinguish SH/PRN and options. |
| 13F options interpretation | Label weights as share of reported 13F value; explain underlying notional and suppress estimated option P&L. See [SEC Form 13F, Special Instruction 10](https://www.sec.gov/files/form13f.pdf). |
| Near-expiry options | Display 0.25 days correctly and calculate zero-volatility theta/rho; finite-difference regressions cover call/put signs and units. |
| Sector rotation | Retry missing batch quotes individually. Historical closes no longer masquerade as current quotes; incomplete headless results identify unavailable symbols. |
| Research automation | Preserve share classes and requested exchanges in AI screener results; forward global --limit into pane schemas; transcript fallback search returns matching paragraphs; unavailable research tabs open the requested ticker's overview. |

Validation: **2,770 tests passed, 0 failed, 10,053 assertions** across 482 files. All six runtime typechecks passed. Final web bundle audit passed, desktop view build passed, and built-in manifest is current. Required CI passed, including desktop/core builds, Cloudflare dry run and global-upgrade smoke testing. The web terminal deployed successfully in [Verify run 34499787643](https://github.com/gloom-sh/gloomberb/actions/runs/34499787643); #753 carries the final small name-display follow-up.

Manual QA used the production terminal and a local Worker at http://127.0.0.1:8798, Chromium 1600×1000, plus native tmux sessions with isolated storage. Browser checks covered RIVN research/chart, sector/industry switching, fractional-expiry/zero-volatility options and missing-tab deep links. Native checks covered RIVN events, JEPQ/VOD.L/VWRA.L income panes and Scion 13F holdings with reporting dates and option-value semantics. Direct-CIK manager identification was additionally fixed in #753. CLI reports covered the income universe, BABA/Shell/NVIDIA events and Berkshire/Scion 13F holdings. Evidence snapshots and screenshots remain in /tmp; no production account state was edited.

Backend fixes are tracked in [platform PR223](https://github.com/vincelwt/gloomberb-platform/pull/223) and [PR224](https://github.com/vincelwt/gloomberb-platform/pull/224), including provider currencies, adjusted split history and the discovered ASML.AS/MC.PA + EURONEXT listing mismatch.

Coverage limits: authenticated browser dividend/13F/analyst/event routes and live COST transcripts were access-gated in this environment; corresponding behavior was checked through public native providers and representative fixtures. Broker execution was outside this research sweep. Some ETF fundamental fields are unavailable upstream. Cash yield is not SEC yield or total return, and 13F comparisons remain filing-based estimates.

No version bump or GitHub release. Merge deploys the web terminal through the existing workflow; native release remains held for user validation.

Production browser retest on term.gloom.sh confirmed 0.25d, fair value 0.0027, theta -0.0110/day and rho +0.0007/rate point at spot/strike 100, rate 4%, zero volatility. No application errors appeared in this check; navigation occasionally logged a canceled WebSocket connection.

Final backend deployment [34500362042](https://github.com/vincelwt/gloomberb-platform/actions/runs/34500362042) passed. Production ASML.AS + EURONEXT now returns Amsterdam EUR 1,472.80 versus Nasdaq ASML USD 1,705.60; MC.PA + EURONEXT returns LVMH EUR 407.90 rather than US Moelis MC USD 65.69. SAP.DE and SHOP.TO retained EUR and CAD. Vodafone statistics recovered through an unexpired compatible cache with matching GBP 29.73B capitalization; unverified capitalization remains omitted where upstream data is unavailable.

The last rendered ASML check found a regular-session loss duplicated as an after-hours move despite absent extended-hours fields. #754 prevents that projection for delayed/unspecified sources and preserves supplied extended-hours data. Browser and native follow-up checks passed.

Final sweep status: #752, #753 and #754 are merged and deployed. App total after the follow-ups: **2,772 tests / 10,120 assertions**, all six typechecks and required CI builds/checks passed. [Final terminal deployment](https://github.com/gloom-sh/gloomberb/actions/runs/34501847389) succeeded; production ASML after-hours rendering was rechecked. Backend PR223/224 are deployed with **172 focused tests / 639 assertions** passing. Test browser/tmux sessions and local Workers were closed. No GitHub release was created.
