### PR TITLE
Show the resolved fund name when opening 13F holdings by CIK

### DIFF
--- a/src/plugins/builtin/thirteenf/pane.tsx
+++ b/src/plugins/builtin/thirteenf/pane.tsx
@@ -559,6 +559,9 @@ function FundDetailView({
 
   return (
     <Box flexDirection="column" width={width} flexGrow={1} overflow="hidden">
+      {data?.name && data.name !== seed.name ? (
+        <Box paddingX={1}><Text fg={colors.text}>{data.name}</Text></Box>
+      ) : null}
       <Box height={1}>
         <Tabs
           tabs={FUND_DETAIL_TABS}


### PR DESCRIPTION
Opening a 13F manager directly by CIK showed only the numeric identifier even after the filing resolved its company name. Show the reported manager name above both detail tabs when it differs from the lookup text, so users can confirm the fund before interpreting its holdings.

Validated Scion CIK 1649339 in native tmux: manager name, reporting/comparison dates, option-notional explanation and holdings remain visible. All 22 13F tests passed; diff check passed. Follow-up to #752; no version bump or GitHub release.
