### PR TITLE
Stop showing delayed daily moves as after-hours trades

### DIFF
--- a/src/market-data/quotes/contributions.ts
+++ b/src/market-data/quotes/contributions.ts
@@ -38,7 +38,9 @@ function normalizeListingExchange(
 }
 
 function shouldProjectSessionPrice(quote: Quote | QuoteContribution): boolean {
-  return quote.sessionConfidence === "explicit" || quote.dataSource === "live";
+  // An explicit market state identifies the session, not which session supplied
+  // the last trade. Delayed snapshots can still contain the regular close.
+  return quote.dataSource === "live";
 }
 
 export function finalizeSessionFields(

--- a/src/market-data/quotes/resolution.test.ts
+++ b/src/market-data/quotes/resolution.test.ts
@@ -5,6 +5,7 @@ import {
   resolveTickerFinancialsQuoteState,
   upsertQuoteContributionMap,
 } from "./resolution";
+import { normalizeQuoteContribution } from "./contributions";
 
 describe("quote-resolution", () => {
   test("resolves price, session, listing venue, and route from separate providers", () => {
@@ -359,6 +360,49 @@ describe("quote-resolution", () => {
     expect(quote?.preMarketPrice).toBeUndefined();
     expect(quote?.preMarketChange).toBeUndefined();
     expect(quote?.preMarketChangePercent).toBeUndefined();
+  });
+
+  test("explicit session state does not turn a delayed or unclassified regular close into extended-hours trades", () => {
+    for (const marketState of ["PRE", "POST"] as const) {
+      for (const dataSource of ["delayed", undefined] as const) {
+        const contribution = normalizeQuoteContribution({
+          symbol: "ASML", providerId: "gloomberb-cloud", listingExchangeName: "AMS",
+          price: 1472.8, currency: "EUR", previousClose: 1497.6,
+          change: -24.8, changePercent: -1.65598,
+          lastUpdated: Date.parse("2026-09-10T15:29:00Z"),
+          marketState, sessionConfidence: "explicit", dataSource,
+        })!;
+        const canonical = resolveCanonicalQuote({ "gloomberb-cloud": contribution }, contribution.lastUpdated).quote;
+        for (const quote of [contribution, canonical]) {
+          expect(quote?.price).toBe(1472.8);
+          expect(quote?.marketState).toBe(marketState);
+          expect(quote?.preMarketPrice).toBeUndefined();
+          expect(quote?.preMarketChange).toBeUndefined();
+          expect(quote?.preMarketChangePercent).toBeUndefined();
+          expect(quote?.postMarketPrice).toBeUndefined();
+          expect(quote?.postMarketChange).toBeUndefined();
+          expect(quote?.postMarketChangePercent).toBeUndefined();
+        }
+      }
+    }
+  });
+
+  test("preserves reported delayed after-hours fields without filling missing changes from the daily move", () => {
+    const base = {
+      symbol: "ASML", providerId: "gloomberb-cloud", listingExchangeName: "AMS",
+      price: 1472.8, currency: "EUR", previousClose: 1497.6,
+      change: -24.8, changePercent: -1.65598, lastUpdated: Date.parse("2026-09-10T16:00:00Z"),
+      marketState: "POST" as const, sessionConfidence: "explicit" as const, dataSource: "delayed" as const,
+      postMarketPrice: 1475,
+    };
+    const priceOnly = normalizeQuoteContribution(base)!;
+    expect(priceOnly.postMarketPrice).toBe(1475);
+    expect(priceOnly.postMarketChange).toBeUndefined();
+    expect(priceOnly.postMarketChangePercent).toBeUndefined();
+    const reported = normalizeQuoteContribution({ ...base, postMarketChange: 2.2, postMarketChangePercent: 0.1494 })!;
+    expect(resolveCanonicalQuote({ "gloomberb-cloud": reported }, reported.lastUpdated).quote).toMatchObject({
+      postMarketPrice: 1475, postMarketChange: 2.2, postMarketChangePercent: 0.1494,
+    });
   });
 
   test("ignores stale cloud price contributions when a fresh yahoo quote exists", () => {


### PR DESCRIPTION
ASML Amsterdam returned a delayed regular-session quote of €1,472.80, down €24.80 for the day, with an explicit POST market status but no after-hours quote. Quote normalization copied those daily values into a second “After-Hours” row, presenting a daily loss as a separate extended-session move.

Only live prices may now be projected into session fields. Delayed and unclassified snapshots retain the market-status label while their actual extended-hours fields remain optional; explicitly supplied extended-hours data is preserved.

Validation: 36 focused tests / 191 assertions passed, browser typecheck and web bundle audit passed. Chromium at 1600×1000 and native tmux both show ASML’s EUR regular-session values without the fabricated row. Regression cases cover delayed/unspecified PRE and POST snapshots, canonical resolution, supplied post-market fields and existing live behavior. Follow-up to the research sweep in #752 and #753. No version bump or GitHub release.

Final validation: all 2,772 app tests / 10,120 assertions and all six runtime typechecks passed in CI. [Production deployment 34501847389](https://github.com/gloom-sh/gloomberb/actions/runs/34501847389) succeeded at main 2c787a7a54dfe7bddfa48dd0154ef644a3e99079. The production browser retest showed ASML.AS EUR 1,472.80 and -1.66% daily, with zero After-Hours value labels. Latest release remains v0.13.3 published September 8; no release was created.
