### PR TITLE
Shorten README and move reference material into guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,23 @@ bun dev
 ## Building plugins
 
 See [PLUGINS.md](PLUGINS.md) for a guide on building your own plugins.
+
+## Browser development
+
+```bash
+bun run web:build
+bunx wrangler dev
+```
+
+Validate the public artifacts with `bun run web:audit` and `bun run cloudflare:dry-run`. `wrangler.jsonc` is the local configuration. After verification passes on `main`, GitHub Actions deploys `term.gloom.sh` with `wrangler.production.jsonc`. The private Gloom Cloud API is deployed separately.
+
+Cloud REST and WebSocket traffic uses the same-origin `/api` path, which the Worker forwards only to `https://api.gloom.sh`; it is not an arbitrary network proxy. Public shares open under `/s/:id` in a separate slim bundle. Share creation and owner deletion use the signed-in Gloom Cloud session through the same API path; public reads require no account.
+
+See the [browser guide](docs/browser.md) for account requirements and supported features.
+
+## Localization
+
+- Locale dictionaries live in [src/i18n](src/i18n), keyed by the original English UI text. Missing entries safely fall back to English.
+- Shared render sinks call `t()` / `tf()` / `tc()` for pane titles, the command bar, menus, settings, tabs, help, and onboarding.
+- Finance abbreviations such as BID, ASK, and CHG% intentionally remain in English for terminal conventions and fixed-width alignment.
+- CJK wide characters and grapheme clusters are measured by [src/utils/format.ts](src/utils/format.ts) using terminal display-cell widths.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Desktop app for macOS and Windows. Terminal UI for macOS, Linux, and Windows.
 &nbsp;&middot;&nbsp;
 <a href="#install"><strong>Install the TUI</strong></a>
 &nbsp;&middot;&nbsp;
+<a href="https://term.gloom.sh"><strong>Open in browser</strong></a>
+&nbsp;&middot;&nbsp;
 <a href="README.zh-CN.md">简体中文</a>
 
 <br />
@@ -21,349 +23,80 @@ Desktop app for macOS and Windows. Terminal UI for macOS, Linux, and Windows.
 
 </div>
 
-## Desktop App or TUI?
+- **Research companies:** quotes, charts, financials, filings, options, and analyst ratings.
+- **Follow markets:** news, global indices, FX, economic events, and market scanners.
+- **Manage your workspace:** portfolios, watchlists, broker connections, alerts, notes, and AI tools.
 
-Gloomberb has two ways in:
-
-| Surface | Best for | How it runs |
-|---------|----------|-------------|
-| Desktop app | A polished app window, pop-out panes, OS shortcuts, and built-in updates | Published for macOS and Windows. It also installs a `gloomberb` terminal command for the TUI. |
-| Terminal UI | Fast keyboard workflows inside your terminal, SSH/dev boxes, Linux machines, and script-friendly setups | Runs with `gloomberb` on macOS, Linux, and Windows. |
-| Browser app | The shared DOM interface without an install | Open [term.gloom.sh](https://term.gloom.sh). |
-
-The desktop app and TUI share the full command language and plugin system. The browser app uses the same official DOM renderer and layout with a reviewed browser plugin catalog.
-
-## Browser App
-
-[term.gloom.sh](https://term.gloom.sh) requires a free Gloom Cloud account. The workspace loads behind a sign-in panel that cannot be dismissed, and a session opens it; configuration, tickers, layouts, session state, and plugin state are stored in the browser. Free accounts receive rate-limited, 15-minute-delayed Gloom Cloud market data and read-only chat until the email is verified; Pro accounts receive realtime market data. Public share pages stay open to everyone with no account. Cloud REST and WebSocket traffic uses the same-origin `/api` path, which the Worker forwards only to `https://api.gloom.sh`; it is not an arbitrary network proxy.
-
-The browser build intentionally omits brokers and native integrations, filesystem notes, local AI, external plugins, updater/debug tools, application menus, native window controls, pop-out native windows, and native context menus. Modules that still depend on desktop-only or CORS-blocked feeds are also absent for now: RSS/Substack, prediction markets and polls, market halts/heatmap/movers, dividend/ownership/SEC panes, earnings/IPO, and TV. Public shares open under `/s/:id` in a separate slim bundle. Share creation and owner deletion use the signed-in Gloom Cloud session through the same fixed API path; public reads require no account.
-
-Local browser development:
-
-```bash
-bun run web:build
-bunx wrangler dev
-```
-
-Validate the public artifacts with `bun run web:audit` and `bun run cloudflare:dry-run`. `wrangler.jsonc` remains generic for local checks. After verification passes on `main`, GitHub Actions deploys `term.gloom.sh` with `wrangler.production.jsonc`. The private Gloom Cloud API is deployed separately.
+The desktop app and TUI share the command language and plugin system. The [browser app](https://term.gloom.sh) offers a smaller feature set and requires a free Gloom Cloud account: free market data is rate-limited and delayed by 15 minutes; Pro provides realtime data. See [browser features and limits](docs/browser.md).
 
 ## Install
 
-### macOS
+### Desktop
 
-Install the desktop app and the `gloomberb` terminal command:
+On **macOS (Apple Silicon)**:
 
 ```bash
 brew install --cask vincelwt/tap/gloomberb
-# or
-curl -fsSL gloom.sh/install | bash
 ```
 
-Both install `Gloomberb.app` and a `gloomberb` command that runs the TUI through the app bundle, so the bundled runtime is stored once.
+On **Windows 11**, [download the installer](https://github.com/gloom-sh/gloomberb/releases/latest/download/stable-win-x64-GloomberbSetup.exe). It supports x64, and ARM64 through x64 emulation.
 
-`Gloomberb.app` is Apple Silicon (arm64) only. On an Intel Mac the install script installs the standalone `gloomberb` terminal app instead, and the Homebrew cask refuses to install rather than leaving an app that cannot launch.
+Both desktop installers include the `gloomberb` terminal command.
 
-Prefer a direct download?
+### Terminal
 
-- [Download Gloomberb for Mac](https://gloom.sh/download/desktop)
-
-### Linux
-
-Install the standalone TUI binary:
+On **macOS or Linux**:
 
 ```bash
 curl -fsSL gloom.sh/install | bash
 ```
 
-This installs `gloomberb` to `~/.local/bin` by default. A Linux desktop package is not published yet.
+On Apple Silicon Macs, this installs the desktop app and TUI. On Intel Macs and Linux, it installs the standalone TUI.
 
-### Windows
-
-Install the desktop app:
-
-- [Download GloomberbSetup.exe for Windows](https://github.com/gloom-sh/gloomberb/releases/latest/download/stable-win-x64-GloomberbSetup.exe)
-
-The installer supports Windows 11 on x64 and ARM64. On ARM64, the desktop app and its bundled `gloomberb` terminal command use Windows' built-in x64 emulation.
-
-For a terminal-only setup on x64, install Bun and use the package:
-
-```powershell
-bun install -g gloomberb
-```
-
-### Terminal Package
-
-Already have Bun installed on any supported OS?
+Or install with [Bun](https://bun.sh) on macOS, Linux, or Windows x64:
 
 ```bash
 bun install -g gloomberb
 ```
 
-Then run:
-
-```bash
-gloomberb
-```
-
-On macOS and Windows, desktop updates replace the installed app in place and keep the terminal command pointing at the updated runtime. Homebrew users can also update through `brew upgrade --cask gloomberb`.
-
-For the best terminal experience, use a [Kitty](https://sw.kovidgoyal.net/kitty/)-compatible terminal such as Ghostty, Kitty, or WezTerm.
-
-Install [TV](https://github.com/gloom-sh/gloomberb-tv) with `gloomberb install gloom-sh/gloomberb-tv`. Existing installations restore it once after upgrading. Live TV in the terminal also requires `mpv` with Kitty video output. Gloomberb resolves the stream in JavaScript and runs `mpv` with its `yt-dlp` integration disabled, so `yt-dlp` is not required.
+Run `gloomberb` to launch. For graphics, use a Kitty-compatible terminal such as Ghostty, Kitty, or WezTerm. See the [installation guide](docs/installation.md) for direct downloads, install locations, and updates.
 
 ## Start
 
-Open command mode with `Ctrl+P`, then type a command. Press `` ` `` to open ticker search directly.
+Press `Ctrl+P` to open the command bar, or press `` ` `` to search for a ticker. Desktop also supports `Cmd/Ctrl+K`.
 
 | Try | Opens |
 |-----|-------|
-| `DES AAPL` | Security details |
+| `DES AAPL` | Company details |
 | `GP NVDA` | Price chart |
-| `G AAPL:price, MSFT:revenue` | Mixed-series chart |
-| `TOP` | Ranked market stories |
-| `HM` | Market heatmap |
-| `MOST` | Market movers |
-| `HILO` | New highs and new lows |
+| `TOP` | Market stories |
 | `PF` | Portfolios and watchlists |
-| `KELLY AAPL` | Position sizing |
-| `HELP` | Full in-app shortcut list |
+| `HELP` | Commands and keyboard shortcuts |
 
-## What It Does
-
-- Research companies with quotes, charts, financials, filings, holders, insiders, options, analyst ratings, events, and relative valuation.
-- Follow markets with top stories, breaking news, sector feeds, Substack subscriptions, global indices, futures, FX, macro events, yield curves, Treasury auctions, market movers, new-high/new-low and options-flow scanners, and fear/greed.
-- Track portfolios and watchlists, connect brokers, set alerts, keep notes, run AI screens, browse prediction markets, and use Gloom Cloud chat.
-
-### Broker position sync
-
-Use **New Portfolio** or **Add Broker Account** to connect a broker. Gloomberb can import positions from Interactive Brokers, Public, Robinhood, and SimpleFIN.
-
-Each broker is a plugin with its own repository, installed on first launch and updatable on its own. Manage them from the plugin directory, or with `gloomberb install gloom-sh/gloomberb-public` and friends.
-
-- Robinhood opens a browser sign-in page. Gloomberb uses only the read-only account and equity-position tools from the Robinhood Trading MCP server.
-- Public needs an API secret from Public API settings. Gloomberb creates a short-lived access token and uses only the account and portfolio endpoints.
-- SimpleFIN needs a one-time setup token from SimpleFIN Bridge. Gloomberb exchanges the token and imports only accounts that contain holdings.
-
-Gloomberb saves the connection data on the local device. It does not include this data in Gloom Cloud synchronization. A later position sync updates the managed portfolios and removes positions that the broker no longer reports.
+Use `Tab` to switch panes and `j` / `k` to navigate lists. The [user guide](docs/usage.md) covers charts, broker setup, keyboard shortcuts, and the full command reference.
 
 ## CLI
 
-Running `gloomberb` with no arguments launches the terminal UI. Normal commands run through a headless CLI path; use `gloomberb launch-ui` when a script should explicitly open the UI.
+Run commands directly from your shell:
 
-Human-readable output is the default. Automation can opt into structured output with `--json`, `--csv`, or `--ndjson`. JSON output favors the richest fetched model available and includes display-column metadata when a command has table columns; CSV and NDJSON use the command's tabular row view. Common global flags include `--limit`, `--refresh`, `--quiet`, `--no-color`, `--dry-run`, and `--yes`.
-
-| Command | Use |
-|---------|-----|
-| `gloomberb` | Launch the terminal UI |
-| `gloomberb launch-ui` | Explicitly launch the terminal UI |
-| `gloomberb help` | Show all CLI commands |
-| `gloomberb api list|get|invoke|subscribe` | Inspect and call plugin capabilities directly |
-| `gloomberb quote <symbols>` | Fetch current quotes |
-| `gloomberb search <query>` / `provider-search <query>` | Search tickers and provider symbols |
-| `gloomberb ticker <symbol>` | Show quote, ownership, and financials |
-| `gloomberb history|financials|fundamentals|options <symbol>` | Fetch research data |
-| `gloomberb news|filings|holders|insider|13f|analyst|events|valuation <symbol>` | Fetch company research feeds |
-| `gloomberb movers|indices|sectors|fx|fear-greed|earnings` | Fetch market overview data |
-| `gloomberb econ|fred|yield-curve` | Fetch macro data |
-| `gloomberb compare|correlation|relationship <symbols>` | Compare securities |
-| `gloomberb portfolio [action]` | Manage manual portfolios |
-| `gloomberb watchlist [action]` | Manage watchlists |
-| `gloomberb notes|alerts [action]` | Manage local notes and alerts |
-| `gloomberb broker|ibkr [action]` | Inspect broker profiles |
-| `gloomberb ai providers|ask` | Use configured AI providers |
-| `gloomberb rss fetch <url>` | Fetch an RSS feed |
-| `gloomberb provider status` | Inspect enabled data providers |
-| `gloomberb config|cache|plugin|layout|pane|debug|doctor|version|changelog` | Inspect and manage local app state |
-| `gloomberb fn [...]` | Run a pane-backed report command |
-| `gloomberb shot [...]` | Capture a pane-backed screenshot |
-| `gloomberb predictions [...]` | Launch Prediction Markets |
-| `gloomberb plugins` | List installed plugins |
-| `gloomberb install <user/repo>` | Install a plugin from GitHub |
-| `gloomberb remove <name>` | Remove an installed plugin |
-| `gloomberb update [name]` | Update plugins |
-
-## Plugins
-
-Everything from the portfolio list to broker integrations is a plugin. Plugins can add panes, tabs, columns, command bar commands, CLI commands, status bar widgets, and data providers.
-
-Core plugin areas include:
-
-- Portfolios, watchlists, manual entry, and broker connections
-- Ticker details, quotes, charts, options, filings, holders, insiders, and research
-- News, Substack reader feeds, market movers, global indices, sectors, FX, earnings, macro data, and yield curves
-- Prediction markets, alerts, notes, chat, AI screeners, and external plugins
-
-See [PLUGINS.md](PLUGINS.md) for the plugin API and the shared UI surface available through `gloomberb/components`.
-
-## Keyboard
-
-| Key | Action |
-|-----|--------|
-| `Ctrl+P` | Open command mode |
-| `` ` `` | Open ticker search |
-| `Ctrl+,` | Open focused pane settings |
-| `Ctrl+W` | Close focused pane |
-| `Ctrl+Shift+M` | Move focused window (`WIN resize` starts resize mode) |
-| `Ctrl+Shift+D` | Dock or float focused pane |
-| `Ctrl+Shift+E` | Export focused pane table as CSV |
-| `Ctrl+Shift+L` | Layout actions |
-| `Ctrl+Shift+G` | Tidy windows |
-| `Tab` | Switch panes |
-| `j` / `k` | Navigate lists |
-| `h` / `l` | Switch tabs |
-| `m` | Cycle chart mode |
-| `q` | Quit |
-
-Desktop builds also accept `Cmd/Ctrl+K` for the command bar, the matching `Cmd` shortcuts on macOS, `Cmd/Ctrl+Shift+O` to pop out a pane, and `Cmd/Ctrl+Shift+C` to copy a focused pane screenshot.
-
-## Command Reference
-
-Use `HELP` inside Gloomberb for the live shortcut list. The common command-bar prefixes are listed here for quick scanning.
-
-### Company Research
-
-| Shortcut | Function |
-|----------|----------|
-| `DES <ticker>` / `T <ticker>` | Security details for a ticker |
-| `FA <ticker>` | Financial statement view |
-| `G <series>` | Custom chart composer |
-| `CAT [query]` | Browse and search chartable series |
-| `GP <ticker>` | Price chart |
-| `GIP <ticker>` | Intraday price chart |
-| `HP <ticker>` | Historical OHLCV prices |
-| `GF <tickers>` | Fundamental statement graph |
-| `GE <tickers>` | Valuation multiple graph |
-| `GR <tickers>` | Security relationship graph |
-| `EE <ticker>` | Events view with earnings and revenue estimates |
-| `EM [tickers]` | Earnings monitor |
-| `SRCH [query]` | Full-text search across earnings call transcripts, news, and SEC filings |
-| `QQ <tickers>` | Ticker quote monitor |
-| `CMP <tickers>` | Normalized price comparison |
-| `CORR <tickers>` | Ticker return correlations |
-| `ANR <ticker>` | Analyst targets and ratings |
-| `DIAG <ticker>` | Equity Diagnostic with cited flags and anomalies |
-| `SEC <ticker>` | SEC filings and company disclosures |
-| `OMON <ticker>` | Options monitor |
-| `OVME` | Black-Scholes option calculator with Greeks and implied volatility |
-| `HDS <ticker>` | Institutional holders |
-| `DVD <ticker>` | Dividend yield and history |
-| `SI <ticker>` | Short interest |
-| `13F [fund/ticker/CIK]` | 13F fund filings and holdings |
-| `INS <ticker>` | Insider activity |
-| `EVT <ticker>` | Corporate actions, earnings, and estimates |
-| `RV <tickers>` | Relative valuation |
-
-### Chart Composer
-
-`G`, `GP`, `GIP`, `CMP`, `GF`, and `GE` all open the same chart composer with different starting presets. `CAT` opens a searchable catalog of those chartable series so you can graph one without typing the expression. A custom expression can mix unrelated data sources on one synchronized timeline:
-
-```text
-G AAPL:price, MSFT:revenue, FRED:CPIAUCSL
+```bash
+gloomberb quote AAPL
+gloomberb quote AAPL --json
+gloomberb help
 ```
 
-Open **Series** to add, remove, reorder, or hide series and choose each series' field, chart style, transform, axis, panel, period, and panel scale. Price data supports candles, OHLC, HLC, line, and area; scalar data supports its compatible line, area, step, column, and point modes. Panels can use independent left/right axes and linear or logarithmic scales.
+Output is human-readable by default; use `--json`, `--csv`, or `--ndjson` for scripts. See the [CLI reference](docs/usage.md#cli) for commands and flags.
 
-The toolbar controls preset or exact date ranges, intervals from one minute through monthly, the primary chart mode, technical indicators, and pair formulas. Indicators include volume, SMA, EMA, Bollinger Bands, RSI, and MACD; formulas include ratio, spread, and rolling correlation. Mixed-frequency values use as-of alignment: fundamentals use filing dates when available, sparse series carry forward only after becoming available, and missing publication dates are called out in the chart status.
+## Plugins and contributing
 
-### Markets, News, and Macro
+Plugins add panes, data providers, broker connections, and commands. Install one from GitHub:
 
-| Shortcut | Function |
-|----------|----------|
-| `TOP` | Ranked market stories |
-| `HM` | Market heatmap for large US stocks and ETFs |
-| `MOST` | Top gainers, losers, most active, and trending tickers |
-| `HILO` | Session new highs and new lows with 30s/1m/5m momentum |
-| `FLOW` | Unusual options activity: sweeps, blocks, and large premium |
-| `PM <query>` | Polymarket and Kalshi prediction data |
-| `N` | News feed |
-| `CN <ticker>` | Ticker news |
-| `NI` | Sector news |
-| `SUB` | Authenticated Substack reader feed |
-| `FIRST` | Breaking news |
-| `TWIT <query>` | Ticker-related market posts |
-| `TBO` | TheBuildout infrastructure intelligence |
-| `CG` | Congress trading disclosures |
-| `WEI` | Global equity indices |
-| `MAP` | Live world venue map with local market status and clocks |
-| `FUT` | Front-month futures across index, rates, energy, metals, grains, and FX |
-| `ECO` | Economic events and releases |
-| `ECST [statistic]` | Economic statistics: inflation, labour, growth, consumer, housing, rates |
-| `GC` | Yield curve |
-| `AUCT` | Treasury auction results: high rate, bid-to-cover, indirect share, and size |
-| `VIX` | VIX 30-day/3-month implied-volatility curve |
-| `CRD` | Credit spreads |
-| `VAL [indicator]` | Whole-market valuation: Buffett, CAPE, excess CAPE yield, Tobin Q, investor equity allocation, dividend yield, margin debt, cap/profits, cap/M2 |
-| `CDS [ticker]` | Single-name corporate CDS activity: most-active issuers, or one issuer's trades |
-| `ERN` | Earnings calendar |
-| `IPO` | Upcoming and recent IPOs |
-| `HALT` | US trading halts with reason and resumption times |
-| `TV` | Live Bloomberg, CNBC, and Yahoo Finance television ([TV plugin](https://github.com/gloom-sh/gloomberb-tv)) |
-| `BI` / `SP` | S&P 500 sector performance |
-| `FXC` | Major FX cross rates |
-| `FNG` | Fear and greed market gauge |
+```bash
+gloomberb install gloom-sh/gloomberb-tv
+```
 
-### Workspace and App Controls
+See the [plugin development guide](PLUGINS.md), [TV setup](docs/usage.md#live-tv), or [contributing guide](CONTRIBUTING.md) to get started.
 
-| Shortcut | Function |
-|----------|----------|
-| `PF` | Portfolio and watchlist workspace |
-| `PORT` | Portfolio risk and sector exposure |
-| `ALRT` | Price alerts |
-| `SA <symbol condition price>` | Create a price alert |
-| `AI <prompt>` | AI screener |
-| `AGENT` | Local AI research workspace |
-| `CHAT [channel]` | Gloom Cloud chat |
-| `DM @user [@user...]` | Open or start a direct or group chat |
-| `ACM` | Gloom Cloud account settings |
-| `NOTE` | Notes |
-| `IBKR` | IBKR trading pane |
-| `BR` | Broker connections |
-| `CHG` | Changelog |
-| `HELP` | Open shortcut and layout help |
-| `AW` / `AP <ticker>` | Add a ticker to the active watchlist or portfolio |
-| `RW` / `RP <ticker>` | Remove a ticker from the active watchlist or portfolio |
-| `PS` | Open focused pane settings |
-| `LAY` | Open the layout browser to switch, publish, or add layouts |
-| `LMA <query>` | Layout and pane arrangement actions |
-| `WIN move\|resize` | Move or resize the focused window |
-| `GL` | Tidy all windows |
-| `SB` | Toggle the status bar |
-| `VF` | Toggle quote value flashing |
-| `TH <theme>` | Change color theme |
-| `FONT+` / `FONT-` | Increase or decrease desktop font size |
-| `CONN` | Connection health |
-| `POLL` | Prediction-market polls |
-| `UPGRADE` | Account upgrade |
-| `CR` | Cycle chart renderer |
-| `LANG <locale>` | Change interface language (`auto`, `en`, `es`, `zh-CN`, `zh-TW`, `ja`, or `ko`) |
-| `PL <plugin>` | Manage plugins |
+Available in English, Spanish, Simplified Chinese, Traditional Chinese, Japanese, and Korean. Use `LANG` in the command bar to switch; see [language settings](docs/usage.md#localized-interface).
 
-Published layouts preserve portable pane setup and state, including searches, chart viewport, and drawings. Credentials, accounts, portfolios, and pane fields marked private stay local. Publishing copies a durable `term.gloom.sh/l/...` link for social sharing.
-
-## Gloom Cloud sign-in
-
-Sign in with email and password, or pick `Log In with QR Code` from the command bar and scan the code with the Gloomberb mobile companion app to sign the terminal in without typing. The onboarding wizard offers the same QR option as the recommended path, with email and password as the alternative.
-
-## Localized interface
-
-Gloomberb includes English, Spanish, Simplified Chinese, Traditional Chinese, Japanese, and Korean UI support. English remains the default fallback language.
-
-- **Automatic detection:** supported `LANG` / `LC_ALL` and desktop system locales select the matching interface automatically.
-- **Command switching:** enter `LANG` in the command bar (Ctrl+P) to cycle languages, or use `LANG auto`, `LANG en`, `LANG es`, `LANG zh-CN`, `LANG zh-TW`, `LANG ja`, or `LANG ko`. The choice is persisted in `config.json`.
-- **One-run override:** `GLOOMBERB_LANG=ja gloomberb` (or another supported locale) takes highest priority in environments that expose process locale variables.
-
-Implementation notes:
-
-- Locale dictionaries live in [src/i18n](src/i18n), keyed by the original English UI text. Missing entries safely fall back to English.
-- Shared render sinks call `t()` / `tf()` / `tc()` for pane titles, the command bar, menus, settings, tabs, help, and onboarding.
-- Finance abbreviations such as BID, ASK, and CHG% intentionally remain in English for terminal conventions and fixed-width alignment.
-- CJK wide characters and grapheme clusters are measured by [src/utils/format.ts](src/utils/format.ts) using terminal display-cell widths.
-
-## License
-
-MIT
-
-## Credits
-
-- [OpenTUI](https://opentui.com/) for the layout engine
+[MIT licensed](LICENSE). Built with [OpenTUI](https://opentui.com/).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://gloom.sh/gloomberb-logo-grayscale.svg" alt="Gloomberb logo" width="76" />
+<img src="https://gloom.sh/gloomberb-logo-grayscale.svg" alt="Gloomberb 标志" width="76" />
 
 # Gloomberb
 
@@ -10,9 +10,11 @@
 
 <a href="https://gloom.sh/download/desktop"><strong>下载桌面版</strong></a>
 &nbsp;&middot;&nbsp;
-<a href="#安装">安装 TUI</a>
+<a href="#安装"><strong>安装 TUI</strong></a>
 &nbsp;&middot;&nbsp;
-<a href="README.md"><strong>English</strong></a>
+<a href="https://term.gloom.sh"><strong>在浏览器中打开</strong></a>
+&nbsp;&middot;&nbsp;
+<a href="README.md">English</a>
 
 <br />
 <br />
@@ -23,274 +25,80 @@
 
 > 本文档为社区维护的简体中文翻译。若与 [英文原版 README](README.md) 有出入，以英文版为准。
 
-## 桌面版还是 TUI？
+- **公司研究**：行情、图表、财务报表、监管文件、期权与分析师评级。
+- **市场追踪**：新闻、全球股指、外汇、经济事件与市场扫描工具。
+- **工作区管理**：投资组合、自选列表、券商连接、提醒、笔记与 AI 工具。
 
-Gloomberb 有两种使用方式：
-
-| 形态 | 适合场景 | 运行方式 |
-|---------|----------|-------------|
-| 桌面应用 | 精美的应用窗口、可弹出面板、系统级快捷键、内置更新 | 发布支持 macOS 和 Windows，同时会安装 `gloomberb` 终端命令用于运行 TUI |
-| 终端界面 (TUI) | 终端内的高速键盘操作、SSH/开发机、Linux 主机、脚本友好的场景 | 在 macOS、Linux、Windows 上通过 `gloomberb` 运行 |
-
-两者共享同一套命令语言、插件系统、市场数据界面、投资组合、自选列表、提醒、笔记与 AI 工具。
+桌面版和 TUI 共享同一套命令语言与插件系统。[浏览器版](https://term.gloom.sh) 提供部分功能，需要免费 Gloom Cloud 账户：免费行情有请求频率限制，并延迟 15 分钟；Pro 提供实时行情。详见[浏览器版功能与限制（英文）](docs/browser.md)。
 
 ## 安装
 
-### macOS
+### 桌面版
 
-安装桌面应用和 `gloomberb` 终端命令：
+在 **macOS（Apple Silicon）** 上：
 
 ```bash
 brew install --cask vincelwt/tap/gloomberb
-# 或
-curl -fsSL gloom.sh/install | bash
 ```
 
-两种方式都会安装 `Gloomberb.app`，以及一个通过应用内置运行时执行 TUI 的 `gloomberb` 命令，运行时只会存储一份。
+在 **Windows 11** 上，[下载安装程序](https://github.com/gloom-sh/gloomberb/releases/latest/download/stable-win-x64-GloomberbSetup.exe)。支持 x64，也可通过 x64 仿真在 ARM64 上运行。
 
-想直接下载？
+两个平台的桌面安装程序均包含 `gloomberb` 终端命令。
 
-- [下载 Gloomberb（Mac 版）](https://gloom.sh/download/desktop)
+### 终端版
 
-### Linux
-
-安装独立的 TUI 可执行文件：
+在 **macOS 或 Linux** 上：
 
 ```bash
 curl -fsSL gloom.sh/install | bash
 ```
 
-默认会将 `gloomberb` 安装到 `~/.local/bin`。Linux 桌面安装包暂未发布。
+在 Apple Silicon Mac 上，此脚本会安装桌面版和 TUI；在 Intel Mac 和 Linux 上，会安装独立的 TUI。
 
-### Windows
-
-安装桌面应用：
-
-- [下载 GloomberbSetup.exe（Windows x64）](https://github.com/gloom-sh/gloomberb/releases/latest/download/stable-win-x64-GloomberbSetup.exe)
-
-安装程序会添加应用本体和 `gloomberb` 终端命令。如果只需要终端版本，安装 Bun 后使用该包即可：
-
-```powershell
-bun install -g gloomberb
-```
-
-### 终端安装包
-
-已经装好 Bun？在任意受支持的系统上执行：
+也可在 macOS、Linux 或 Windows x64 上通过 [Bun](https://bun.sh) 安装：
 
 ```bash
 bun install -g gloomberb
 ```
 
-然后运行：
-
-```bash
-gloomberb
-```
-
-在 macOS 和 Windows 上，桌面版更新会原地替换已安装的应用，并让终端命令继续指向更新后的运行时。Homebrew 用户也可以通过 `brew upgrade --cask gloomberb` 更新。
-
-为获得最佳终端体验，请使用兼容 [Kitty](https://sw.kovidgoyal.net/kitty/) 图形协议的终端，例如 Ghostty、Kitty 或 WezTerm。
+运行 `gloomberb` 即可启动。要显示图形，请使用兼容 Kitty 图形协议的终端，例如 Ghostty、Kitty 或 WezTerm。直接下载、安装位置与更新方式详见[安装指南（英文）](docs/installation.md)。
 
 ## 开始使用
 
-按 `Ctrl+P` 打开命令模式，然后输入命令。按 `` ` `` 可直接打开股票搜索。
+按 `Ctrl+P` 打开命令栏，或按 `` ` `` 搜索股票代码。桌面版也支持 `Cmd/Ctrl+K`。
 
 | 试试 | 打开 |
 |-----|-------|
-| `DES AAPL` | 证券详情 |
+| `DES AAPL` | 公司详情 |
 | `GP NVDA` | 价格图表 |
-| `TOP` | 排名市场头条 |
-| `HM` | 市场热力图 |
-| `MOST` | 市场异动 |
+| `TOP` | 市场新闻 |
 | `PF` | 投资组合与自选列表 |
-| `KELLY AAPL` | 仓位计算 |
-| `HELP` | 完整的应用内快捷键列表 |
+| `HELP` | 命令与键盘快捷键 |
 
-## 功能概览
+使用 `Tab` 切换面板，`j` / `k` 浏览列表。[使用指南（英文）](docs/usage.md) 包含图表、券商配置、键盘快捷键与完整命令参考。
 
-- **公司研究**：行情、图表、财务报表、监管文件、股东、内部人交易、期权、分析师评级、事件与相对估值。
-- **市场追踪**：头条新闻、突发新闻、板块新闻、Substack 订阅、全球股指、外汇、宏观事件、收益率曲线、市场异动与恐惧贪婪指数。
-- **组合管理**：跟踪投资组合与自选列表、连接券商、设置提醒、记笔记、运行 AI 选股、浏览预测市场，并使用 Gloom Cloud 聊天。
+## 命令行（CLI）
 
-## 命令行 (CLI)
+直接在 shell 中运行命令：
 
-不带参数运行 `gloomberb` 会启动终端界面。普通命令走无界面（headless）的 CLI 路径；脚本若需要显式打开 UI，使用 `gloomberb launch-ui`。
+```bash
+gloomberb quote AAPL
+gloomberb quote AAPL --json
+gloomberb help
+```
 
-默认输出为易读的人类可读格式。自动化场景可通过 `--json`、`--csv` 或 `--ndjson` 选择结构化输出。JSON 输出会使用能获取到的最丰富的数据模型，并在命令带有表格列时附带列元数据；CSV 和 NDJSON 则使用命令的表格行视图。常用全局参数包括 `--limit`、`--refresh`、`--quiet`、`--no-color`、`--dry-run` 和 `--yes`。
+默认输出便于阅读；脚本可使用 `--json`、`--csv` 或 `--ndjson` 获取结构化输出。命令与参数详见 [CLI 参考（英文）](docs/usage.md#cli)。
 
-| 命令 | 用途 |
-|---------|-----|
-| `gloomberb` | 启动终端界面 |
-| `gloomberb launch-ui` | 显式启动终端界面 |
-| `gloomberb help` | 显示全部 CLI 命令 |
-| `gloomberb api list\|get\|invoke\|subscribe` | 直接查看和调用插件能力 |
-| `gloomberb quote <symbols>` | 获取实时行情 |
-| `gloomberb search <query>` / `provider-search <query>` | 搜索股票代码与数据源符号 |
-| `gloomberb ticker <symbol>` | 显示行情、持股结构与财务数据 |
-| `gloomberb history\|financials\|fundamentals\|options <symbol>` | 获取研究数据 |
-| `gloomberb news\|filings\|holders\|insider\|13f\|analyst\|events\|valuation <symbol>` | 获取公司研究信息流 |
-| `gloomberb movers\|indices\|sectors\|fx\|fear-greed\|earnings` | 获取市场概览数据 |
-| `gloomberb econ\|fred\|yield-curve` | 获取宏观数据 |
-| `gloomberb compare\|correlation\|relationship <symbols>` | 对比证券 |
-| `gloomberb portfolio [action]` | 管理手动投资组合 |
-| `gloomberb watchlist [action]` | 管理自选列表 |
-| `gloomberb notes\|alerts [action]` | 管理本地笔记与提醒 |
-| `gloomberb broker\|ibkr [action]` | 查看券商配置 |
-| `gloomberb ai providers\|ask` | 使用已配置的 AI 服务商 |
-| `gloomberb rss fetch <url>` | 抓取 RSS 订阅源 |
-| `gloomberb provider status` | 查看已启用的数据源 |
-| `gloomberb config\|cache\|plugin\|layout\|pane\|debug\|doctor\|version\|changelog` | 查看和管理本地应用状态 |
-| `gloomberb fn [...]` | 运行基于面板的报告命令 |
-| `gloomberb shot [...]` | 捕获基于面板的截图 |
-| `gloomberb predictions [...]` | 启动预测市场 |
-| `gloomberb plugins` | 列出已安装插件 |
-| `gloomberb install <user/repo>` | 从 GitHub 安装插件 |
-| `gloomberb remove <name>` | 移除已安装插件 |
-| `gloomberb update [name]` | 更新插件 |
+## 插件与贡献
 
-## 插件
+插件可添加面板、数据源、券商连接与命令。从 GitHub 安装插件：
 
-从投资组合列表到券商集成，一切皆为插件。插件可以添加面板、页签、列、命令栏命令、CLI 命令、状态栏组件与数据源。
+```bash
+gloomberb install gloom-sh/gloomberb-tv
+```
 
-核心插件领域包括：
+详见[插件开发指南（英文）](PLUGINS.md)、[直播电视配置（英文）](docs/usage.md#live-tv)或[贡献指南（英文）](CONTRIBUTING.md)。
 
-- 投资组合、自选列表、手动录入与券商连接
-- 股票详情、行情、图表、期权、监管文件、股东、内部人交易与研究
-- 新闻、Substack 阅读订阅、市场异动、全球股指、板块、外汇、财报、宏观数据与收益率曲线
-- 预测市场、提醒、笔记、聊天、AI 选股器与外部插件
+界面支持英语、西班牙语、简体中文、繁体中文、日语与韩语。在命令栏中输入 `LANG` 即可切换，详见[语言设置（英文）](docs/usage.md#localized-interface)。
 
-插件 API 以及通过 `gloomberb/components` 提供的共享 UI 界面，详见 [PLUGINS.md](PLUGINS.md)。
-
-## 键盘快捷键
-
-| 按键 | 操作 |
-|-----|--------|
-| `Ctrl+P` | 打开命令模式 |
-| `` ` `` | 打开股票搜索 |
-| `Ctrl+,` | 打开聚焦面板的设置 |
-| `Ctrl+W` | 关闭聚焦面板 |
-| `Ctrl+Shift+M` | 移动聚焦窗口（`WIN resize` 进入缩放模式） |
-| `Ctrl+Shift+D` | 停靠或浮动聚焦面板 |
-| `Ctrl+Shift+E` | 将聚焦面板的表格导出为 CSV |
-| `Ctrl+Shift+L` | 布局操作 |
-| `Ctrl+Shift+G` | 所有窗口网格对齐 |
-| `Tab` | 切换面板 |
-| `j` / `k` | 列表导航 |
-| `h` / `l` | 切换页签 |
-| `m` | 循环切换图表模式 |
-| `q` | 退出 |
-
-桌面版还支持 `Cmd/Ctrl+K` 打开命令栏、macOS 上对应的 `Cmd` 快捷键、`Cmd/Ctrl+Shift+O` 弹出面板为独立窗口，以及 `Cmd/Ctrl+Shift+C` 复制聚焦面板截图。
-
-## 命令参考
-
-在 Gloomberb 内输入 `HELP` 可查看实时快捷键列表。以下列出常用命令栏前缀，方便快速查阅。
-
-### 公司研究
-
-| 快捷指令 | 功能 |
-|----------|----------|
-| `DES <ticker>` / `T <ticker>` | 股票的证券详情 |
-| `FA <ticker>` | 财务报表视图 |
-| `GP <ticker>` | 价格图表 |
-| `GIP <ticker>` | 盘中价格图表 |
-| `HP <ticker>` | 历史 OHLCV 价格 |
-| `GF <tickers>` | 基本面报表图表 |
-| `GE <tickers>` | 估值倍数图表 |
-| `GR <tickers>` | 证券关系图 |
-| `EE <ticker>` | 含 EPS 与营收预估的事件视图 |
-| `EM [tickers]` | 财报监控 |
-| `SRCH [query]` | 跨财报电话会记录、新闻与 SEC 文件的全文检索 |
-| `QQ <tickers>` | 股票行情监控 |
-| `CMP <tickers>` | 股票图表对比 |
-| `CORR <tickers>` | 股票收益率相关性 |
-| `ANR <ticker>` | 分析师目标价与评级 |
-| `SEC <ticker>` | SEC 申报文件与公司披露 |
-| `OMON <ticker>` | 期权监控 |
-| `HDS <ticker>` | 机构股东 |
-| `13F [fund/ticker/CIK]` | 13F 基金申报与持仓 |
-| `INS <ticker>` | 内部人交易动态 |
-| `EVT <ticker>` | 公司行动、财报与预估 |
-| `RV <tickers>` | 相对估值 |
-
-### 市场、新闻与宏观
-
-| 快捷指令 | 功能 |
-|----------|----------|
-| `TOP` | 排名市场头条 |
-| `HM` | 美股大盘股与 ETF 市场热力图 |
-| `MOST` | 涨幅榜、跌幅榜、成交活跃与热门股票 |
-| `PM <query>` | Polymarket 与 Kalshi 预测数据 |
-| `N` | 新闻源 |
-| `CN <ticker>` | 个股新闻 |
-| `NI` | 板块新闻 |
-| `SUB` | 已登录的 Substack 阅读订阅源 |
-| `FIRST` | 突发新闻 |
-| `TWIT <query>` | 与股票相关的市场动态帖子 |
-| `TBO` | TheBuildout 基础设施情报 |
-| `CG` | 国会交易披露 |
-| `WEI` | 全球股指 |
-| `ECO` | 经济事件与数据发布 |
-| `ECST [统计指标]` | 经济统计：通胀、就业、增长、消费、住房、利率 |
-| `GC` | 收益率曲线 |
-| `ERN` | 财报日历 |
-| `BI` / `SP` | 标普 500 板块表现 |
-| `FXC` | 主要外汇交叉汇率 |
-| `FNG` | 恐惧与贪婪市场指数 |
-
-### 工作区与应用控制
-
-| 快捷指令 | 功能 |
-|----------|----------|
-| `PF` | 投资组合与自选列表工作区 |
-| `PORT` | 投资组合风险与板块敞口 |
-| `ALRT` | 价格提醒 |
-| `SA <symbol condition price>` | 创建价格提醒 |
-| `AI <prompt>` | AI 选股器 |
-| `CHAT [channel]` | Gloom Cloud 聊天 |
-| `DM @user [@user...]` | 打开或发起私信/群聊 |
-| `ACM` | Gloom Cloud 账户设置 |
-| `NOTE` | 笔记 |
-| `IBKR` | IBKR 交易面板 |
-| `BR` | 券商连接 |
-| `CHG` | 更新日志 |
-| `HELP` | 打开快捷键与布局帮助 |
-| `AW` / `AP <ticker>` | 将股票添加到活动自选列表或投资组合 |
-| `RW` / `RP <ticker>` | 从活动自选列表或投资组合中移除股票 |
-| `PS` | 打开聚焦面板的设置 |
-| `LAY` | 打开布局浏览器以切换、发布或添加布局 |
-| `LMA <query>` | 布局与面板排列操作 |
-| `WIN move\|resize` | 移动或缩放聚焦窗口 |
-| `GL` | 所有可见面板网格对齐 |
-| `SB` | 切换状态栏 |
-| `VF` | 切换行情数值闪烁 |
-| `TH <theme>` | 更换配色主题 |
-| `CR` | 切换图表渲染器 |
-| `LANG <locale>` | 切换界面语言（`auto`、`en`、`es`、`zh-CN`、`zh-TW`、`ja` 或 `ko`） |
-| `PL <plugin>` | 管理插件 |
-
-发布的布局会保留可移植的面板设置与状态，包括搜索条件、图表视窗和绘图；凭据、账户、投资组合以及标记为私密的字段始终保留在本地。发布后会自动复制一个长期有效的 `term.gloom.sh/l/...` 社交分享链接。
-
-## 本地化界面
-
-Gloomberb 内置 English、简体中文、繁體中文、日本語和한국어界面支持；英文仍是默认回退语言。
-
-- **自动检测**：终端 `LANG` / `LC_ALL` 与桌面系统语言会自动选择受支持的界面语言。
-- **命令切换**：在命令栏（Ctrl+P）输入 `LANG` 可循环切换，也可直接输入 `LANG auto`、`LANG en`、`LANG es`、`LANG zh-CN`、`LANG zh-TW`、`LANG ja` 或 `LANG ko`。选择会保存到 `config.json`。
-- **单次覆盖**：在可读取进程语言变量的环境中，可用 `GLOOMBERB_LANG=ja gloomberb`（或其他受支持的语言代码）进行最高优先级覆盖。
-
-实现说明：
-
-- 各语言词典位于 [src/i18n](src/i18n)，以英文原文为键；查不到的词条自动回退英文，因此可以增量补充翻译，不影响任何功能。
-- 渲染出口统一经过 `t()`（[src/i18n/index.ts](src/i18n/index.ts)），面板标题、命令栏、右键菜单、设置对话框、页签、帮助与引导页均已接入。
-- 表格列头（BID/ASK/CHG% 等金融缩写）刻意保留英文，符合行情终端惯例并保证定宽列对齐。
-- 中日韩宽字符和字素簇的截断与排版由 [src/utils/format.ts](src/utils/format.ts) 按终端单元格宽度处理。
-
-## 许可证
-
-MIT
-
-## 致谢
-
-- [OpenTUI](https://opentui.com/) 提供布局引擎
+采用 [MIT 许可证](LICENSE)。基于 [OpenTUI](https://opentui.com/) 构建。

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -1,0 +1,21 @@
+# Browser app
+
+[Back to README](../README.md) · [User guide](usage.md)
+
+Open [term.gloom.sh](https://term.gloom.sh) and sign in with a free Gloom Cloud account. The browser app uses the same DOM renderer and layout as the desktop app, with a reviewed browser plugin catalog.
+
+## Accounts and data
+
+- A Gloom Cloud session is required to open the workspace.
+- Free accounts receive rate-limited, 15-minute-delayed Gloom Cloud market data. Pro accounts receive realtime data.
+- Chat is read-only until the account's email is verified.
+- Configuration, tickers, layouts, session state, and plugin state are stored in the browser.
+- Public share pages require no account. Creating a share or deleting one you own requires sign-in.
+
+## Feature limits
+
+The browser build omits brokers and native integrations, filesystem notes, local AI, external plugins, updater/debug tools, application menus, native window controls, pop-out native windows, and native context menus.
+
+Modules that depend on desktop-only or CORS-blocked feeds are also unavailable: RSS/Substack, prediction markets and polls, market halts/heatmap/movers, dividend/ownership/SEC panes, earnings/IPO, and TV.
+
+For local development, validation, and deployment details, see [Contributing](../CONTRIBUTING.md#browser-development).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,63 @@
+# Installation
+
+[Back to README](../README.md)
+
+## macOS
+
+Install the desktop app and the `gloomberb` terminal command:
+
+```bash
+brew install --cask vincelwt/tap/gloomberb
+# or
+curl -fsSL gloom.sh/install | bash
+```
+
+Both install `Gloomberb.app` and a `gloomberb` command that runs the TUI through the app bundle, so the bundled runtime is stored once.
+
+`Gloomberb.app` is Apple Silicon (arm64) only. On an Intel Mac the install script installs the standalone `gloomberb` terminal app instead, and the Homebrew cask refuses to install rather than leaving an app that cannot launch.
+
+Prefer a direct download?
+
+- [Download Gloomberb for Mac](https://gloom.sh/download/desktop)
+
+## Linux
+
+Install the standalone TUI binary:
+
+```bash
+curl -fsSL gloom.sh/install | bash
+```
+
+This installs `gloomberb` to `~/.local/bin` by default. A Linux desktop package is not published yet.
+
+## Windows
+
+Install the desktop app:
+
+- [Download GloomberbSetup.exe for Windows](https://github.com/gloom-sh/gloomberb/releases/latest/download/stable-win-x64-GloomberbSetup.exe)
+
+The installer supports Windows 11 on x64 and ARM64. On ARM64, the desktop app and its bundled `gloomberb` terminal command use Windows' built-in x64 emulation.
+
+For a terminal-only setup on x64, install Bun and use the package:
+
+```powershell
+bun install -g gloomberb
+```
+
+## Terminal Package
+
+Already have Bun installed on any supported OS?
+
+```bash
+bun install -g gloomberb
+```
+
+Then run:
+
+```bash
+gloomberb
+```
+
+On macOS and Windows, desktop updates replace the installed app in place and keep the terminal command pointing at the updated runtime. Homebrew users can also update through `brew upgrade --cask gloomberb`.
+
+For the best terminal experience, use a [Kitty](https://sw.kovidgoyal.net/kitty/)-compatible terminal such as Ghostty, Kitty, or WezTerm.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,222 @@
+# User guide
+
+[Back to README](../README.md) · [Installation](installation.md) · [Browser app](browser.md)
+
+- [Keyboard shortcuts](#keyboard)
+- [Command reference and chart composer](#command-reference)
+- [CLI commands and output formats](#cli)
+- [Broker position sync](#broker-position-sync)
+- [Gloom Cloud sign-in](#gloom-cloud-sign-in)
+- [Interface language](#localized-interface)
+- [Live TV](#live-tv)
+
+The desktop app and TUI share the command language and plugin system. The [browser app](browser.md) offers a smaller feature set. Use `HELP` in the app or `gloomberb help` in your shell for the commands available in your installation.
+
+## Keyboard
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+P` | Open command mode |
+| `` ` `` | Open ticker search |
+| `Ctrl+,` | Open focused pane settings |
+| `Ctrl+W` | Close focused pane |
+| `Ctrl+Shift+M` | Move focused window (`WIN resize` starts resize mode) |
+| `Ctrl+Shift+D` | Dock or float focused pane |
+| `Ctrl+Shift+E` | Export focused pane table as CSV |
+| `Ctrl+Shift+L` | Layout actions |
+| `Ctrl+Shift+G` | Tidy windows |
+| `Tab` | Switch panes |
+| `j` / `k` | Navigate lists |
+| `h` / `l` | Switch tabs |
+| `m` | Cycle chart mode |
+| `q` | Quit |
+
+Desktop builds also accept `Cmd/Ctrl+K` for the command bar, the matching `Cmd` shortcuts on macOS, `Cmd/Ctrl+Shift+O` to pop out a pane, and `Cmd/Ctrl+Shift+C` to copy a focused pane screenshot.
+
+## Command Reference
+
+Use `HELP` inside Gloomberb for the live shortcut list. The common command-bar prefixes are listed here for quick scanning.
+
+### Company Research
+
+| Shortcut | Function |
+|----------|----------|
+| `DES <ticker>` / `T <ticker>` | Security details for a ticker |
+| `FA <ticker>` | Financial statement view |
+| `G <series>` | Custom chart composer |
+| `CAT [query]` | Browse and search chartable series |
+| `GP <ticker>` | Price chart |
+| `GIP <ticker>` | Intraday price chart |
+| `HP <ticker>` | Historical OHLCV prices |
+| `GF <tickers>` | Fundamental statement graph |
+| `GE <tickers>` | Valuation multiple graph |
+| `GR <tickers>` | Security relationship graph |
+| `EE <ticker>` | Events view with earnings and revenue estimates |
+| `EM [tickers]` | Earnings monitor |
+| `SRCH [query]` | Full-text search across earnings call transcripts, news, and SEC filings |
+| `QQ <tickers>` | Ticker quote monitor |
+| `CMP <tickers>` | Normalized price comparison |
+| `CORR <tickers>` | Ticker return correlations |
+| `ANR <ticker>` | Analyst targets and ratings |
+| `DIAG <ticker>` | Equity Diagnostic with cited flags and anomalies |
+| `SEC <ticker>` | SEC filings and company disclosures |
+| `OMON <ticker>` | Options monitor |
+| `OVME` | Black-Scholes option calculator with Greeks and implied volatility |
+| `HDS <ticker>` | Institutional holders |
+| `DVD <ticker>` | Dividend yield and history |
+| `SI <ticker>` | Short interest |
+| `13F [fund/ticker/CIK]` | 13F fund filings and holdings |
+| `INS <ticker>` | Insider activity |
+| `EVT <ticker>` | Corporate actions, earnings, and estimates |
+| `RV <tickers>` | Relative valuation |
+
+### Chart Composer
+
+`G`, `GP`, `GIP`, `CMP`, `GF`, and `GE` all open the same chart composer with different starting presets. `CAT` opens a searchable catalog of those chartable series so you can graph one without typing the expression. A custom expression can mix unrelated data sources on one synchronized timeline:
+
+```text
+G AAPL:price, MSFT:revenue, FRED:CPIAUCSL
+```
+
+Open **Series** to add, remove, reorder, or hide series and choose each series' field, chart style, transform, axis, panel, period, and panel scale. Price data supports candles, OHLC, HLC, line, and area; scalar data supports its compatible line, area, step, column, and point modes. Panels can use independent left/right axes and linear or logarithmic scales.
+
+The toolbar controls preset or exact date ranges, intervals from one minute through monthly, the primary chart mode, technical indicators, and pair formulas. Indicators include volume, SMA, EMA, Bollinger Bands, RSI, and MACD; formulas include ratio, spread, and rolling correlation. Mixed-frequency values use as-of alignment: fundamentals use filing dates when available, sparse series carry forward only after becoming available, and missing publication dates are called out in the chart status.
+
+### Markets, News, and Macro
+
+| Shortcut | Function |
+|----------|----------|
+| `TOP` | Ranked market stories |
+| `HM` | Market heatmap for large US stocks and ETFs |
+| `MOST` | Top gainers, losers, most active, and trending tickers |
+| `HILO` | Session new highs and new lows with 30s/1m/5m momentum |
+| `FLOW` | Unusual options activity: sweeps, blocks, and large premium |
+| `PM <query>` | Polymarket and Kalshi prediction data |
+| `N` | News feed |
+| `CN <ticker>` | Ticker news |
+| `NI` | Sector news |
+| `SUB` | Authenticated Substack reader feed |
+| `FIRST` | Breaking news |
+| `TWIT <query>` | Ticker-related market posts |
+| `TBO` | TheBuildout infrastructure intelligence |
+| `CG` | Congress trading disclosures |
+| `WEI` | Global equity indices |
+| `MAP` | Live world venue map with local market status and clocks |
+| `FUT` | Front-month futures across index, rates, energy, metals, grains, and FX |
+| `ECO` | Economic events and releases |
+| `ECST [statistic]` | Economic statistics: inflation, labour, growth, consumer, housing, rates |
+| `GC` | Yield curve |
+| `AUCT` | Treasury auction results: high rate, bid-to-cover, indirect share, and size |
+| `VIX` | VIX 30-day/3-month implied-volatility curve |
+| `CRD` | Credit spreads |
+| `VAL [indicator]` | Whole-market valuation: Buffett, CAPE, excess CAPE yield, Tobin Q, investor equity allocation, dividend yield, margin debt, cap/profits, cap/M2 |
+| `CDS [ticker]` | Single-name corporate CDS activity: most-active issuers, or one issuer's trades |
+| `ERN` | Earnings calendar |
+| `IPO` | Upcoming and recent IPOs |
+| `HALT` | US trading halts with reason and resumption times |
+| `TV` | Live Bloomberg, CNBC, and Yahoo Finance television ([TV plugin](https://github.com/gloom-sh/gloomberb-tv)) |
+| `BI` / `SP` | S&P 500 sector performance |
+| `FXC` | Major FX cross rates |
+| `FNG` | Fear and greed market gauge |
+
+### Workspace and App Controls
+
+| Shortcut | Function |
+|----------|----------|
+| `PF` | Portfolio and watchlist workspace |
+| `PORT` | Portfolio risk and sector exposure |
+| `ALRT` | Price alerts |
+| `SA <symbol condition price>` | Create a price alert |
+| `AI <prompt>` | AI screener |
+| `AGENT` | Local AI research workspace |
+| `CHAT [channel]` | Gloom Cloud chat |
+| `DM @user [@user...]` | Open or start a direct or group chat |
+| `ACM` | Gloom Cloud account settings |
+| `NOTE` | Notes |
+| `IBKR` | IBKR trading pane |
+| `BR` | Broker connections |
+| `CHG` | Changelog |
+| `HELP` | Open shortcut and layout help |
+| `AW` / `AP <ticker>` | Add a ticker to the active watchlist or portfolio |
+| `RW` / `RP <ticker>` | Remove a ticker from the active watchlist or portfolio |
+| `PS` | Open focused pane settings |
+| `LAY` | Open the layout browser to switch, publish, or add layouts |
+| `LMA <query>` | Layout and pane arrangement actions |
+| `WIN move\|resize` | Move or resize the focused window |
+| `GL` | Tidy all windows |
+| `SB` | Toggle the status bar |
+| `VF` | Toggle quote value flashing |
+| `TH <theme>` | Change color theme |
+| `FONT+` / `FONT-` | Increase or decrease desktop font size |
+| `CONN` | Connection health |
+| `POLL` | Prediction-market polls |
+| `UPGRADE` | Account upgrade |
+| `CR` | Cycle chart renderer |
+| `LANG <locale>` | Change interface language (`auto`, `en`, `es`, `zh-CN`, `zh-TW`, `ja`, or `ko`) |
+| `PL <plugin>` | Manage plugins |
+
+Published layouts preserve portable pane setup and state, including searches, chart viewport, and drawings. Credentials, accounts, portfolios, and pane fields marked private stay local. Publishing copies a durable `term.gloom.sh/l/...` link for social sharing.
+
+## CLI
+
+Running `gloomberb` with no arguments launches the terminal UI. Normal commands run through a headless CLI path; use `gloomberb launch-ui` when a script should explicitly open the UI.
+
+Human-readable output is the default. Automation can opt into structured output with `--json`, `--csv`, or `--ndjson`. JSON output favors the richest fetched model available and includes display-column metadata when a command has table columns; CSV and NDJSON use the command's tabular row view. Common global flags include `--limit`, `--refresh`, `--quiet`, `--no-color`, `--dry-run`, and `--yes`.
+
+| Command | Use |
+|---------|-----|
+| `gloomberb` | Launch the terminal UI |
+| `gloomberb launch-ui` | Explicitly launch the terminal UI |
+| `gloomberb help` | Show all CLI commands |
+| `gloomberb api list\|get\|invoke\|subscribe` | Inspect and call plugin capabilities directly |
+| `gloomberb quote <symbols>` | Fetch current quotes |
+| `gloomberb search <query>` / `provider-search <query>` | Search tickers and provider symbols |
+| `gloomberb ticker <symbol>` | Show quote, ownership, and financials |
+| `gloomberb history\|financials\|fundamentals\|options <symbol>` | Fetch research data |
+| `gloomberb news\|filings\|holders\|insider\|13f\|analyst\|events\|valuation <symbol>` | Fetch company research feeds |
+| `gloomberb movers\|indices\|sectors\|fx\|fear-greed\|earnings` | Fetch market overview data |
+| `gloomberb econ\|fred\|yield-curve` | Fetch macro data |
+| `gloomberb compare\|correlation\|relationship <symbols>` | Compare securities |
+| `gloomberb portfolio [action]` | Manage manual portfolios |
+| `gloomberb watchlist [action]` | Manage watchlists |
+| `gloomberb notes\|alerts [action]` | Manage local notes and alerts |
+| `gloomberb broker\|ibkr [action]` | Inspect broker profiles |
+| `gloomberb ai providers\|ask` | Use configured AI providers |
+| `gloomberb rss fetch <url>` | Fetch an RSS feed |
+| `gloomberb provider status` | Inspect enabled data providers |
+| `gloomberb config\|cache\|plugin\|layout\|pane\|debug\|doctor\|version\|changelog` | Inspect and manage local app state |
+| `gloomberb fn [...]` | Run a pane-backed report command |
+| `gloomberb shot [...]` | Capture a pane-backed screenshot |
+| `gloomberb predictions [...]` | Launch Prediction Markets |
+| `gloomberb plugins` | List installed plugins |
+| `gloomberb install <user/repo>` | Install a plugin from GitHub |
+| `gloomberb remove <name>` | Remove an installed plugin |
+| `gloomberb update [name]` | Update plugins |
+
+## Broker position sync
+
+Use **New Portfolio** or **Add Broker Account** to connect a broker. Gloomberb can import positions from Interactive Brokers, Public, Robinhood, and SimpleFIN.
+
+Each broker is a plugin with its own repository, installed on first launch and updatable on its own. Manage them from the plugin directory, or with `gloomberb install gloom-sh/gloomberb-public` and friends.
+
+- Robinhood opens a browser sign-in page. Gloomberb uses only the read-only account and equity-position tools from the Robinhood Trading MCP server.
+- Public needs an API secret from Public API settings. Gloomberb creates a short-lived access token and uses only the account and portfolio endpoints.
+- SimpleFIN needs a one-time setup token from SimpleFIN Bridge. Gloomberb exchanges the token and imports only accounts that contain holdings.
+
+Gloomberb saves the connection data on the local device. It does not include this data in Gloom Cloud synchronization. A later position sync updates the managed portfolios and removes positions that the broker no longer reports.
+
+## Gloom Cloud sign-in
+
+Sign in with email and password, or pick `Log In with QR Code` from the command bar and scan the code with the Gloomberb mobile companion app to sign the terminal in without typing. The onboarding wizard offers the same QR option as the recommended path, with email and password as the alternative.
+
+## Localized interface
+
+Gloomberb includes English, Spanish, Simplified Chinese, Traditional Chinese, Japanese, and Korean UI support. English remains the default fallback language.
+
+- **Automatic detection:** supported `LANG` / `LC_ALL` and desktop system locales select the matching interface automatically.
+- **Command switching:** enter `LANG` in the command bar (Ctrl+P) to cycle languages, or use `LANG auto`, `LANG en`, `LANG es`, `LANG zh-CN`, `LANG zh-TW`, `LANG ja`, or `LANG ko`. The choice is persisted in `config.json`.
+- **One-run override:** `GLOOMBERB_LANG=ja gloomberb` (or another supported locale) takes highest priority in environments that expose process locale variables.
+
+## Live TV
+
+Install [TV](https://github.com/gloom-sh/gloomberb-tv) with `gloomberb install gloom-sh/gloomberb-tv`. Existing installations restore it once after upgrading. Live TV in the terminal also requires `mpv` with Kitty video output. Gloomberb resolves the stream in JavaScript and runs `mpv` with its `yt-dlp` integration disabled, so `yt-dlp` is not required.


### PR DESCRIPTION
The README had grown to 369 lines, mixing installation and first-use guidance with full command tables and implementation details. Shorten it to 102 lines and align the Chinese README with the same structure.

Move installation details, command references, and browser limitations into linked guides. Keep browser development and localization implementation notes in CONTRIBUTING.md, and fix escaped pipes in the CLI table.

Validation: all 42 local links and anchors, Markdown table structure, code fences, and matching English/Chinese command examples pass; git diff --check passes. Documentation only.
