### PR TITLE
Fix truncated CLI research reports when piping output

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -74,6 +74,11 @@ async function captureConsole<T>(fn: () => Promise<T> | T): Promise<{ result: T;
   const originalLog = console.log;
   const originalError = console.error;
 
+  const stdout = spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    logs.push(String(chunk).replace(/\n$/, ""));
+    return true;
+  });
+
   console.log = (...args: unknown[]) => {
     logs.push(args.map(String).join(" "));
   };
@@ -91,6 +96,7 @@ async function captureConsole<T>(fn: () => Promise<T> | T): Promise<{ result: T;
   } finally {
     console.log = originalLog;
     console.error = originalError;
+    stdout.mockRestore();
   }
 }
 
@@ -100,6 +106,11 @@ async function captureConsoleFailure(fn: () => Promise<unknown> | unknown): Prom
   const originalLog = console.log;
   const originalError = console.error;
   const originalExitCode = process.exitCode;
+
+  const stdout = spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    logs.push(String(chunk).replace(/\n$/, ""));
+    return true;
+  });
 
   console.log = (...args: unknown[]) => {
     logs.push(args.map(String).join(" "));
@@ -123,6 +134,7 @@ async function captureConsoleFailure(fn: () => Promise<unknown> | unknown): Prom
     console.log = originalLog;
     console.error = originalError;
     process.exitCode = originalExitCode ?? 0;
+    stdout.mockRestore();
   }
 }
 

--- a/src/cli/registry.test.ts
+++ b/src/cli/registry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdtemp, rm } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -34,6 +34,11 @@ async function captureConsole<T>(fn: () => Promise<T> | T): Promise<{ result: T;
   const originalLog = console.log;
   const originalError = console.error;
 
+  const stdout = spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    logs.push(String(chunk).replace(/\n$/, ""));
+    return true;
+  });
+
   console.log = (...args: unknown[]) => {
     logs.push(args.map(String).join(" "));
   };
@@ -51,6 +56,7 @@ async function captureConsole<T>(fn: () => Promise<T> | T): Promise<{ result: T;
   } finally {
     console.log = originalLog;
     console.error = originalError;
+    stdout.mockRestore();
   }
 }
 

--- a/src/cli/result.test.ts
+++ b/src/cli/result.test.ts
@@ -80,3 +80,21 @@ describe("serializeCliError", () => {
     });
   });
 });
+
+test("large research reports remain complete through a pipe after stdout initialization", async () => {
+  const child = Bun.spawn([process.execPath, "-e", `
+    import { printCliResult } from ${JSON.stringify(new URL("./result.ts", import.meta.url).pathname)};
+    import { DEFAULT_CLI_OPTIONS } from ${JSON.stringify(new URL("./options.ts", import.meta.url).pathname)};
+    // CLI color/terminal detection initializes the stream before reports print.
+    void process.stdout;
+    printCliResult({ data: { rows: Array.from({ length: 6000 }, (_, id) => ({ id, name: "東京 — research report" })) } },
+      { ...DEFAULT_CLI_OPTIONS, format: "json" });
+  `], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, status] = await Promise.all([
+    new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited,
+  ]);
+  expect({ status, stderr }).toEqual({ status: 0, stderr: "" });
+  const report = JSON.parse(stdout);
+  expect(report.data.rows).toHaveLength(6000);
+  expect(report.data.rows.at(-1)).toEqual({ id: 5999, name: "東京 — research report" });
+});

--- a/src/cli/result.ts
+++ b/src/cli/result.ts
@@ -135,7 +135,9 @@ export function printCliResult<T, Row extends Record<string, unknown> = Record<s
 ): void {
   if (options.quiet && options.format === "text") return;
   const output = serializeCliResult(result, options, renderOptions);
-  if (output) console.log(output);
+  // Bun's console writer can truncate a large pipe write after stdout has been
+  // initialized. The stream queues the remaining bytes until the reader drains.
+  if (output) process.stdout.write(`${output}\n`);
 }
 
 export function serializeCliError(error: CliErrorObject, options: CliGlobalOptions): string {


### PR DESCRIPTION
Large research reports could exit successfully after writing only 65,536 bytes to a pipe. For example, the quarterly Intel cash-flow JSON report was cut off mid-field once CLI terminal detection initialized stdout.

Write serialized reports through the stdout stream so pending bytes drain correctly. A subprocess regression reproduces the original truncation with a 6,000-row Unicode report; command tests also capture stream output.

Validation: 26 focused CLI tests / 97 assertions passed. The live Intel report now produces 74,445 bytes of valid JSON through Python subprocess capture, versus 65,536 invalid bytes before. No release or version change.
