### PR TITLE
fix(insider): preserve all Form 4 transactions and SEC eligibility

### DIFF
--- a/src/plugins/builtin/insider/client.ts
+++ b/src/plugins/builtin/insider/client.ts
@@ -1,6 +1,5 @@
 import type { DataProvider, SecFilingItem } from "../../../types/data-provider";
-import { parseForm4Xml } from "./insider-data";
-import type { ParsedInsiderFiling } from "./model";
+import { parseInsiderFiling, type ParsedInsiderFiling } from "./model";
 
 export async function loadInsiderFilings(
   provider: DataProvider,
@@ -36,11 +35,7 @@ export async function loadParsedInsiderFilings(
     throwIfAborted(options.signal);
     try {
       const content = await provider.getSecFilingContent(filing);
-      parsed.push({
-        filing,
-        transaction: content ? parseForm4Xml(content) : null,
-        isLoading: false,
-      });
+      parsed.push(...parseInsiderFiling(filing, content));
     } catch {
       throwIfAborted(options.signal);
       parsed.push({ filing, transaction: null, isLoading: false });

--- a/src/plugins/builtin/insider/headless.test.ts
+++ b/src/plugins/builtin/insider/headless.test.ts
@@ -94,6 +94,20 @@ describe("insider client", () => {
     expect(result).toHaveLength(2);
     expect(maxActiveContentLoads).toBe(1);
   });
+
+  test("filing limit expands every transaction and reports failed content even with an owner filter", async () => {
+    const tx = (shares: number) => `<nonDerivativeTransaction><securityTitle><value>Class A</value></securityTitle><transactionDate><value>2026-08-20</value></transactionDate><transactionCoding><transactionCode>G</transactionCode></transactionCoding><transactionAmounts><transactionShares><value>${shares}</value></transactionShares></transactionAmounts></nonDerivativeTransaction>`;
+    const provider = createTestDataProvider({
+      getSecFilings: async () => parsed.map(({ filing }) => filing),
+      getSecFilingContent: async (filing) => filing.accessionNumber === "one"
+        ? `<ownershipDocument><reportingOwner><reportingOwnerId><rptOwnerName>SU LISA T</rptOwnerName></reportingOwnerId></reportingOwner>${tx(55)}${tx(294)}</ownershipDocument>`
+        : null,
+    });
+    const result = await createInsiderHeadless().load(args("su lisa t", 2), { ...context(), marketData: provider });
+    expect(result.rows.map((row) => [row.id, row.shares, row.side])).toEqual([["one:0", 55, "GIFT"], ["one:1", 294, "GIFT"]]);
+    expect(result.metadata).toMatchObject({ parsed: 1, transactions: 2, requested: 2 });
+    expect(result.errors).toEqual(["two: Form 4 transactions are unavailable or incomplete."]);
+  });
 });
 
 describe("insider headless model", () => {

--- a/src/plugins/builtin/insider/headless.ts
+++ b/src/plugins/builtin/insider/headless.ts
@@ -25,6 +25,8 @@ const INSIDER_COLUMNS: HeadlessPaneColumn[] = [
   },
   { key: "insider", header: "Insider" },
   { key: "title", header: "Title" },
+  { key: "security", header: "Security" },
+  { key: "isDerivative", header: "Derivative" },
   { key: "side", header: "Side" },
   {
     key: "shares",
@@ -98,16 +100,23 @@ export function createInsiderHeadless(
       const parsed = await dependencies.loadParsed(symbol, limit, args, ctx);
       const name = String(args.options.name ?? "").trim().toLocaleLowerCase();
       const filtered = name
-        ? parsed.filter(({ transaction }) => transaction?.reportedName.toLocaleLowerCase() === name)
+        ? parsed.filter(({ transaction }) => transaction?.reportedName.toLocaleLowerCase() === name
+          || transaction?.reportingOwners?.some((owner) => owner.name.toLocaleLowerCase() === name))
         : parsed;
+      const incomplete = [...new Set(buildInsiderRows(parsed)
+        .filter((row) => row.status !== "parsed")
+        .map((row) => row.accessionNumber))];
       return {
         rows: buildInsiderRows(filtered),
+        errors: incomplete.map((accessionNumber) => `${accessionNumber}: Form 4 transactions are unavailable or incomplete.`),
         metadata: {
           symbol,
-          summary: buildInsiderSummary(parsed),
-          parsed: parsed.filter(({ transaction }) => transaction != null).length,
+          summary: buildInsiderSummary(filtered),
+          parsed: new Set(parsed.filter(({ transaction }) => transaction != null).map(({ filing }) => filing.accessionNumber)).size,
+          transactions: filtered.filter(({ transaction }) => transaction != null).length,
           requested: limit,
           name: name || null,
+          limitations: ["Only loaded Form 4 filings are summarized; amendments are not reconciled."],
         },
       };
     },

--- a/src/plugins/builtin/insider/index.tsx
+++ b/src/plugins/builtin/insider/index.tsx
@@ -11,7 +11,6 @@ import { EmptyState, FeedDataTableStackView, Spinner, useExternalLinkFooter, use
 import { usePluginPaneState } from "../../runtime";
 import { isUsEquityTicker } from "../../../utils/sec";
 import { truncateWithEllipsis as truncateText } from "../../../utils/text-wrap";
-import { parseForm4Xml } from "./insider-data";
 import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
 import {
   buildInsiderTransactionDetailBody,
@@ -23,6 +22,8 @@ import {
 import { useSecFilingContentCache } from "../sec/filing-content";
 import {
   buildInsiderSummary,
+  insiderTransactionId,
+  parseInsiderFiling,
   type ParsedInsiderFiling as ParsedFiling,
 } from "./model";
 import { insiderHeadless } from "./headless";
@@ -35,7 +36,9 @@ const FORM4_PAGE_SIZE = 20;
 const SEC_FILING_SCAN_LIMIT = 20_000;
 
 function toFeedItems(parsed: ParsedFiling[]): FeedDataTableItem[] {
-  return parsed.map(({ filing, transaction, isLoading }) => {
+  return parsed.map((entry) => {
+    const { filing, transaction, isLoading } = entry;
+    const id = insiderTransactionId(entry);
     const filingMeta = [
       `Filed ${formatFilingShortDate(filing.filingDate)}`,
       `Accession ${filing.accessionNumber}`,
@@ -44,7 +47,7 @@ function toFeedItems(parsed: ParsedFiling[]): FeedDataTableItem[] {
 
     if (!transaction) {
       return {
-        id: filing.accessionNumber,
+        id,
         eyebrow: formatFilingFormLabel(filing.form),
         title: isLoading ? "Loading Form 4 filing..." : "Form 4 transaction unavailable",
         timestamp: filing.filingDate,
@@ -57,10 +60,10 @@ function toFeedItems(parsed: ParsedFiling[]): FeedDataTableItem[] {
     }
 
     return {
-      id: filing.accessionNumber,
+      id,
       eyebrow: transaction.reportedName,
       title: buildInsiderTransactionTitle(transaction),
-      timestamp: transaction.filingDate,
+      timestamp: transaction.filingDate ?? filing.filingDate,
       detailTitle: transaction.reportedName,
       detailMeta: [
         ...(transaction.title ? [transaction.title] : []),
@@ -116,14 +119,10 @@ function InsiderView({ width, height, focused }: { width: number; height: number
     targets: visibleForm4Filings,
   });
 
-  const allParsed: ParsedFiling[] = useMemo(() => visibleForm4Filings.map((filing) => {
+  const allParsed: ParsedFiling[] = useMemo(() => visibleForm4Filings.flatMap((filing) => {
     const hasContent = contentMap.has(filing.accessionNumber);
     const xml = contentMap.get(filing.accessionNumber) ?? null;
-    return {
-      filing,
-      transaction: xml ? parseForm4Xml(xml) : null,
-      isLoading: !hasContent,
-    };
+    return parseInsiderFiling(filing, xml, !hasContent);
   }), [contentMap, visibleForm4Filings]);
 
   // Apply name filter
@@ -133,10 +132,10 @@ function InsiderView({ width, height, focused }: { width: number; height: number
       : allParsed
   ), [allParsed, nameFilter]);
   const feedItems = useMemo(() => toFeedItems(parsed), [parsed]);
-  const summary = useMemo(() => buildInsiderSummary(allParsed), [allParsed]);
+  const summary = useMemo(() => buildInsiderSummary(parsed), [parsed]);
   const selectedTransaction = parsed[selectedIdx]?.transaction ?? null;
   const openFiling = openItemId
-    ? parsed.find(({ filing }) => filing.accessionNumber === openItemId)?.filing ?? null
+    ? parsed.find((entry) => insiderTransactionId(entry) === openItemId)?.filing ?? null
     : null;
 
   const toggleNameFilter = useCallback((reportedName: string) => {

--- a/src/plugins/builtin/insider/insider-data.test.ts
+++ b/src/plugins/builtin/insider/insider-data.test.ts
@@ -1,45 +1,58 @@
 import { describe, expect, test } from "bun:test";
 import { parseForm4Xml } from "./insider-data";
+import { buildInsiderRows, buildInsiderSummary, parseInsiderFiling } from "./model";
+import type { SecFilingItem } from "../../../types/data-provider";
 
-const SAMPLE_FORM4 = `<?xml version="1.0"?>
-<ownershipDocument>
-  <reportingOwner>
-    <reportingOwnerId><rptOwnerName>COOK TIMOTHY D</rptOwnerName></reportingOwnerId>
-    <reportingOwnerRelationship>
-      <isOfficer>1</isOfficer>
-      <officerTitle>Chief Executive Officer</officerTitle>
-    </reportingOwnerRelationship>
-  </reportingOwner>
-  <nonDerivativeTable>
-    <nonDerivativeTransaction>
-      <transactionDate><value>2024-04-01</value></transactionDate>
-      <transactionCoding><transactionCode>S</transactionCode></transactionCoding>
-      <transactionAmounts>
-        <transactionShares><value>50000</value></transactionShares>
-        <transactionPricePerShare><value>171.50</value></transactionPricePerShare>
-      </transactionAmounts>
-      <postTransactionAmounts>
-        <sharesOwnedFollowingTransaction><value>3500000</value></sharesOwnedFollowingTransaction>
-      </postTransactionAmounts>
-    </nonDerivativeTransaction>
-  </nonDerivativeTable>
-</ownershipDocument>`;
+const owner = `<reportingOwner><reportingOwnerId><rptOwnerName>OWNER &amp; CO</rptOwnerName><rptOwnerCik>123</rptOwnerCik></reportingOwnerId><reportingOwnerRelationship><officerTitle>CEO</officerTitle></reportingOwnerRelationship></reportingOwner>`;
+function transaction(code: string, security: string, shares: string, price: string, date = "2026-08-20", derivative = false) {
+  const tag = derivative ? "derivativeTransaction" : "nonDerivativeTransaction";
+  return `<${tag}>
+    <securityTitle><value>${security}</value></securityTitle>
+    <transactionDate><value>${date}</value></transactionDate>
+    <transactionCoding><transactionCode>${code}</transactionCode></transactionCoding>
+    <transactionAmounts><transactionShares><value>${shares}</value><footnoteId id="F1"/></transactionShares><transactionPricePerShare><value>${price}</value></transactionPricePerShare><transactionAcquiredDisposedCode><value>D</value></transactionAcquiredDisposedCode></transactionAmounts>
+    <postTransactionAmounts><sharesOwnedFollowingTransaction><value>292786</value></sharesOwnedFollowingTransaction></postTransactionAmounts>
+    <ownershipNature><directOrIndirectOwnership><value>I</value></directOrIndirectOwnership><natureOfOwnership><value>Family trust</value></natureOfOwnership></ownershipNature>
+  </${tag}>`;
+}
+const filing: SecFilingItem = { accessionNumber: "one", form: "4", filingDate: new Date("2026-08-24"), cik: "123", filingUrl: "https://www.sec.gov/one" };
 
-describe("parseForm4Xml", () => {
-  test("parses insider sale from Form 4 XML", () => {
-    const result = parseForm4Xml(SAMPLE_FORM4);
-    expect(result).not.toBeNull();
-    expect(result!.reportedName).toBe("COOK TIMOTHY D");
-    expect(result!.title).toBe("Chief Executive Officer");
-    expect(result!.transactionType).toBe("S");
-    expect(result!.shares).toBe(50000);
-    expect(result!.pricePerShare).toBe(171.50);
-    expect(result!.totalValue).toBe(50000 * 171.50);
-    expect(result!.sharesOwned).toBe(3500000);
+describe("Form 4 transaction parsing", () => {
+  test("keeps all gift, conversion and derivative rows with their own dates, security and ownership", () => {
+    const xml = `<ownershipDocument>${owner}<nonDerivativeTable>
+      <nonDerivativeHolding><securityTitle><value>Unrelated holding</value></securityTitle><postTransactionAmounts><sharesOwnedFollowingTransaction><value>999999</value></sharesOwnedFollowingTransaction></postTransactionAmounts></nonDerivativeHolding>
+      ${transaction("G", "Class A Common Stock", "55498", "0", "2026-08-10")}
+      ${transaction("G", "Class A Common Stock", "294502", "0", "2026-08-11")}
+      ${transaction("C", "Class B Common Stock", "402348", "")}
+      </nonDerivativeTable><derivativeTable>${transaction("M", "Restricted Stock Units", "877500", "0", "2026-08-20", true)}</derivativeTable></ownershipDocument>`;
+    const rows = parseForm4Xml(xml);
+    expect(rows).toHaveLength(4);
+    expect(rows.map((row) => [row.transactionType, row.shares, row.pricePerShare, row.filingDate?.toISOString().slice(0, 10), row.isDerivative])).toEqual([
+      ["G", 55498, 0, "2026-08-10", false], ["G", 294502, 0, "2026-08-11", false],
+      ["C", 402348, null, "2026-08-20", false], ["M", 877500, 0, "2026-08-20", true],
+    ]);
+    expect(rows[0]).toMatchObject({ reportedName: "OWNER & CO", securityTitle: "Class A Common Stock", acquiredDisposed: "D", ownershipType: "I", ownershipNature: "Family trust", sharesOwned: 292786, totalValue: 0 });
+    expect(rows[2]?.totalValue).toBeNull();
+    const projected = buildInsiderRows(parseInsiderFiling(filing, xml));
+    expect(new Set(projected.map((row) => row.id)).size).toBe(4);
+    expect(projected[1]).toMatchObject({ filingDate: "2026-08-24T00:00:00.000Z", transactionDate: "2026-08-11T00:00:00.000Z", side: "GIFT", transactionCode: "G", reportingOwners: [{ name: "OWNER & CO", cik: "123", title: "CEO" }] });
   });
 
-  test("returns null for non-Form-4 XML", () => {
-    expect(parseForm4Xml("<html>not a form</html>")).toBeNull();
-    expect(parseForm4Xml("")).toBeNull();
+  test("missing amounts and invalid dates remain unknown rather than becoming zero or today", () => {
+    const rows = parseForm4Xml(`<ownershipDocument>${owner}${transaction("F", "Class A", "", "", "2026-02-31")}</ownershipDocument>`);
+    expect(rows[0]).toMatchObject({ filingDate: null, shares: null, pricePerShare: null, totalValue: null, transactionType: "F" });
+    expect(parseForm4Xml("<html>not a filing</html>")).toEqual([]);
+    expect(buildInsiderRows(parseInsiderFiling(filing, "<ownershipDocument/>"))[0]?.status).toBe("unavailable");
+  });
+
+  test("summary excludes exercises and gifts, separates securities, and exposes missing sale prices", () => {
+    const xml = `<ownershipDocument>${owner}
+      ${transaction("S", "Class A", "100", "10")}${transaction("S", "Class A", "25", "")}
+      ${transaction("S", "Class B", "50", "20")}${transaction("S", "Options", "9000", "1", "2026-08-20", true)}
+      ${transaction("G", "Class A", "8000", "0")}${transaction("M", "Class A", "7000", "0")}
+      ${transaction("S", "Class A", "6000", "1", "2025-01-01")}
+      </ownershipDocument>`;
+    const summary = buildInsiderSummary(parseInsiderFiling(filing, xml), new Date("2026-09-10").getTime());
+    expect(summary).toBe("Loaded filings, last 90 days: Class A: Sold 125 shares (value unavailable) | Class B: Sold 50 shares ($1,000.00)");
   });
 });

--- a/src/plugins/builtin/insider/insider-data.ts
+++ b/src/plugins/builtin/insider/insider-data.ts
@@ -1,50 +1,80 @@
+import { decodeHtmlEntities } from "../../../utils/html-entities";
 
 export interface InsiderTransaction {
-  filingDate: Date;
+  /** Transaction date, distinct from the enclosing SEC filing date. */
+  filingDate: Date | null;
   reportedName: string;
   title: string;
-  transactionType: "P" | "S" | "A" | "D" | "";
-  shares: number;
+  transactionType: string;
+  shares: number | null;
   pricePerShare: number | null;
   totalValue: number | null;
   sharesOwned: number | null;
   form: string;
+  transactionIndex?: number;
+  securityTitle?: string;
+  isDerivative?: boolean;
+  acquiredDisposed?: string;
+  ownershipType?: string;
+  ownershipNature?: string;
+  reportingOwners?: Array<{ name: string; cik: string; title: string }>;
 }
 
-export function parseForm4Xml(xml: string): InsiderTransaction | null {
-  const nameMatch = xml.match(/<rptOwnerName>([^<]+)<\/rptOwnerName>/);
-  if (!nameMatch) return null;
+function tagContent(xml: string, tag: string): string | undefined {
+  return xml.match(new RegExp(`<(?:[\\w.-]+:)?${tag}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/(?:[\\w.-]+:)?${tag}\\s*>`, "i"))?.[1];
+}
 
-  const titleMatch = xml.match(/<officerTitle>([^<]+)<\/officerTitle>/);
-  const codeMatch = xml.match(/<transactionCode>([^<]+)<\/transactionCode>/);
-  const sharesMatch = xml.match(/<transactionShares>[\s\S]*?<value>([^<]+)<\/value>/);
-  const priceMatch = xml.match(/<transactionPricePerShare>[\s\S]*?<value>([^<]+)<\/value>/);
-  const ownedMatch = xml.match(/<sharesOwnedFollowingTransaction>[\s\S]*?<value>([^<]+)<\/value>/);
-  const dateMatch = xml.match(/<transactionDate>[\s\S]*?<value>([^<]+)<\/value>/);
+function tagText(xml: string, tag: string): string {
+  return decodeHtmlEntities((tagContent(xml, tag) ?? "").replace(/<[^>]*>/g, "").trim());
+}
 
-  const shares = sharesMatch ? parseFloat(sharesMatch[1]!) : 0;
-  const price = priceMatch ? parseFloat(priceMatch[1]!) : null;
-  const code = codeMatch?.[1] ?? "";
+function numberValue(xml: string, tag: string): number | null {
+  const raw = tagText(tagContent(xml, tag) ?? "", "value");
+  if (!raw) return null;
+  const value = Number(raw.replace(/,/g, ""));
+  return Number.isFinite(value) ? value : null;
+}
 
-  return {
-    filingDate: dateMatch ? new Date(dateMatch[1]!) : new Date(),
-    reportedName: nameMatch[1]!.trim(),
-    title: titleMatch?.[1]?.trim() ?? "",
-    transactionType: (code === "P" || code === "S" || code === "A" || code === "D") ? code : "",
-    shares: isNaN(shares) ? 0 : shares,
-    pricePerShare: price !== null && !isNaN(price) ? price : null,
-    totalValue: price !== null && !isNaN(price) && !isNaN(shares) ? shares * price : null,
-    sharesOwned: ownedMatch ? parseFloat(ownedMatch[1]!) : null,
-    form: "4",
-  };
+export function parseForm4Xml(xml: string): InsiderTransaction[] {
+  const owners = [...xml.matchAll(/<(?:[\w.-]+:)?reportingOwner(?:\s[^>]*)?>([\s\S]*?)<\/(?:[\w.-]+:)?reportingOwner\s*>/gi)]
+    .map((match) => ({ name: tagText(match[1]!, "rptOwnerName"), cik: tagText(match[1]!, "rptOwnerCik"), title: tagText(match[1]!, "officerTitle") }))
+    .filter((owner) => owner.name);
+  if (!owners.length) return [];
+  const blocks = [...xml.matchAll(/<(?:[\w.-]+:)?(nonDerivativeTransaction|derivativeTransaction)(?:\s[^>]*)?>([\s\S]*?)<\/(?:[\w.-]+:)?\1\s*>/gi)];
+  return blocks.map((match, transactionIndex) => {
+    const block = match[2]!;
+    const amounts = tagContent(block, "transactionAmounts") ?? "";
+    const shares = numberValue(amounts, "transactionShares");
+    const price = numberValue(amounts, "transactionPricePerShare");
+    const dateText = tagText(tagContent(block, "transactionDate") ?? "", "value");
+    const date = /^\d{4}-\d{2}-\d{2}$/.test(dateText) ? new Date(`${dateText}T00:00:00Z`) : null;
+    return {
+      filingDate: date && Number.isFinite(date.getTime()) && date.toISOString().slice(0, 10) === dateText ? date : null,
+      reportedName: owners.map(({ name }) => name).join("; "),
+      title: [...new Set(owners.map(({ title }) => title).filter(Boolean))].join("; "),
+      reportingOwners: owners,
+      transactionType: tagText(tagContent(block, "transactionCoding") ?? "", "transactionCode"),
+      securityTitle: tagText(tagContent(block, "securityTitle") ?? "", "value"),
+      isDerivative: match[1]!.toLowerCase() === "derivativetransaction",
+      transactionIndex,
+      shares,
+      pricePerShare: price,
+      totalValue: shares != null && price != null ? shares * price : null,
+      sharesOwned: numberValue(tagContent(block, "postTransactionAmounts") ?? "", "sharesOwnedFollowingTransaction"),
+      acquiredDisposed: tagText(tagContent(amounts, "transactionAcquiredDisposedCode") ?? "", "value"),
+      ownershipType: tagText(tagContent(tagContent(block, "ownershipNature") ?? "", "directOrIndirectOwnership") ?? "", "value"),
+      ownershipNature: tagText(tagContent(tagContent(block, "ownershipNature") ?? "", "natureOfOwnership") ?? "", "value"),
+      form: tagText(xml, "documentType") || "4",
+    };
+  });
 }
 
 export function transactionTypeLabel(type: InsiderTransaction["transactionType"]): string {
-  switch (type) {
-    case "P": return "BUY";
-    case "S": return "SELL";
-    case "A": return "AWARD";
-    case "D": return "DISPOSE";
-    default: return "-";
-  }
+  const labels: Record<string, string> = {
+    P: "BUY", S: "SELL", A: "AWARD", D: "DISPOSE", M: "EXERCISE", C: "CONVERT",
+    F: "TAX/EXERCISE PAYMENT", G: "GIFT", X: "EXERCISE", O: "OUT-OF-MONEY EXERCISE",
+    E: "EXPIRATION", H: "CANCELLATION", I: "DISCRETIONARY", J: "OTHER", K: "SWAP",
+    L: "SMALL ACQUISITION", U: "TENDER", W: "INHERITANCE", Z: "TRUST TRANSFER",
+  };
+  return labels[type] ?? (type || "—");
 }

--- a/src/plugins/builtin/insider/model.ts
+++ b/src/plugins/builtin/insider/model.ts
@@ -1,9 +1,6 @@
 import type { SecFilingItem } from "../../../types/data-provider";
 import { formatCompact, formatCurrency } from "../../../utils/format";
-import {
-  transactionTypeLabel,
-  type InsiderTransaction,
-} from "./insider-data";
+import { parseForm4Xml, transactionTypeLabel, type InsiderTransaction } from "./insider-data";
 
 const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
 
@@ -13,60 +10,67 @@ export interface ParsedInsiderFiling {
   isLoading: boolean;
 }
 
-/** Null while filings are still parsing, so the pane never claims no activity early. */
-export function buildInsiderSummary(
-  parsed: ParsedInsiderFiling[],
-  now = Date.now(),
-): string | null {
+export function parseInsiderFiling(filing: SecFilingItem, content: string | null, isLoading = false): ParsedInsiderFiling[] {
+  const transactions = content ? parseForm4Xml(content) : [];
+  return transactions.length
+    ? transactions.map((transaction) => ({ filing, transaction, isLoading: false }))
+    : [{ filing, transaction: null, isLoading }];
+}
+
+export function insiderTransactionId({ filing, transaction }: ParsedInsiderFiling): string {
+  return `${filing.accessionNumber}:${transaction?.transactionIndex ?? 0}`;
+}
+
+/** Summarize only loaded non-derivative buys/sales, grouped by security. */
+export function buildInsiderSummary(parsed: ParsedInsiderFiling[], now = Date.now()): string | null {
   if (parsed.some(({ isLoading }) => isLoading)) return null;
-  const cutoff = new Date(now - NINETY_DAYS_MS);
-  let buyShares = 0;
-  let sellShares = 0;
-  let buyValue = 0;
-  let sellValue = 0;
-
+  const incomplete = parsed.some(({ transaction }) => !transaction?.filingDate || transaction.shares == null || !transaction.transactionType || !transaction.securityTitle);
+  const cutoff = now - NINETY_DAYS_MS;
+  const totals = new Map<string, { security: string; side: string; shares: number; value: number; knownValue: boolean }>();
   for (const { transaction } of parsed) {
-    if (!transaction) continue;
-    const txDate = transaction.filingDate instanceof Date
-      ? transaction.filingDate
-      : new Date(transaction.filingDate);
-    if (Number.isNaN(txDate.getTime()) || txDate < cutoff) continue;
-    if (transaction.transactionType === "P") {
-      buyShares += transaction.shares;
-      buyValue += transaction.totalValue ?? 0;
-    } else if (transaction.transactionType === "S") {
-      sellShares += transaction.shares;
-      sellValue += transaction.totalValue ?? 0;
-    }
+    if (!transaction || transaction.isDerivative || transaction.shares == null || !transaction.securityTitle) continue;
+    const date = transaction.filingDate?.getTime();
+    if (date == null || !Number.isFinite(date) || date < cutoff || date > now) continue;
+    if (transaction.transactionType !== "P" && transaction.transactionType !== "S") continue;
+    const security = transaction.securityTitle;
+    const key = `${security}:${transaction.transactionType}`;
+    const total = totals.get(key) ?? { security, side: transaction.transactionType, shares: 0, value: 0, knownValue: true };
+    total.shares += transaction.shares;
+    total.knownValue &&= transaction.totalValue != null;
+    total.value += transaction.totalValue ?? 0;
+    totals.set(key, total);
   }
-
-  if (buyShares === 0 && sellShares === 0) return "No buy/sell activity in last 90 days.";
-
-  const parts: string[] = [];
-  if (buyShares > 0) parts.push(`Bought ${formatCompact(buyShares)} shares (${formatCurrency(buyValue)})`);
-  if (sellShares > 0) parts.push(`Sold ${formatCompact(sellShares)} shares (${formatCurrency(sellValue)})`);
-  return parts.join("  |  ");
+  const prefix = "Loaded filings, last 90 days: ";
+  const coverage = incomplete ? " | Some transactions unavailable or incomplete." : "";
+  if (totals.size === 0) return `${prefix}no parsed non-derivative buys/sales.${coverage}`;
+  return prefix + [...totals.values()].map((total) => `${total.security}: ${total.side === "P" ? "Bought" : "Sold"} ${formatCompact(total.shares)} shares (${total.knownValue ? formatCurrency(total.value) : "value unavailable"})`).join(" | ") + coverage;
 }
 
 export function buildInsiderRows(parsed: readonly ParsedInsiderFiling[]) {
-  return parsed.map(({ filing, transaction, isLoading }) => ({
-    filingDate: filing.filingDate instanceof Date
-      ? filing.filingDate.toISOString()
-      : String(filing.filingDate),
-    transactionDate: transaction?.filingDate instanceof Date
-      ? transaction.filingDate.toISOString()
-      : transaction?.filingDate ? String(transaction.filingDate) : null,
-    insider: transaction?.reportedName ?? null,
-    title: transaction?.title ?? null,
-    side: transaction ? transactionTypeLabel(transaction.transactionType) : null,
-    transactionCode: transaction?.transactionType ?? null,
-    shares: transaction?.shares ?? null,
-    pricePerShare: transaction?.pricePerShare ?? null,
-    totalValue: transaction?.totalValue ?? null,
-    sharesOwnedAfter: transaction?.sharesOwned ?? null,
-    form: filing.form,
-    accessionNumber: filing.accessionNumber,
-    url: filing.filingUrl,
-    status: isLoading ? "loading" : transaction ? "parsed" : "unavailable",
-  }));
+  return parsed.map((entry) => {
+    const { filing, transaction, isLoading } = entry;
+    return {
+      id: insiderTransactionId(entry),
+      filingDate: filing.filingDate instanceof Date ? filing.filingDate.toISOString() : String(filing.filingDate),
+      transactionDate: transaction?.filingDate?.toISOString() ?? null,
+      insider: transaction?.reportedName ?? null,
+      reportingOwners: transaction?.reportingOwners ?? [],
+      title: transaction?.title ?? null,
+      security: transaction?.securityTitle ?? null,
+      isDerivative: transaction?.isDerivative ?? null,
+      side: transaction ? transactionTypeLabel(transaction.transactionType) : null,
+      transactionCode: transaction?.transactionType ?? null,
+      acquiredDisposed: transaction?.acquiredDisposed ?? null,
+      ownershipType: transaction?.ownershipType ?? null,
+      ownershipNature: transaction?.ownershipNature ?? null,
+      shares: transaction?.shares ?? null,
+      pricePerShare: transaction?.pricePerShare ?? null,
+      totalValue: transaction?.totalValue ?? null,
+      sharesOwnedAfter: transaction?.sharesOwned ?? null,
+      form: filing.form,
+      accessionNumber: filing.accessionNumber,
+      url: filing.filingUrl,
+      status: isLoading ? "loading" : !transaction ? "unavailable" : transaction.filingDate && transaction.shares != null && transaction.transactionType && transaction.securityTitle ? "parsed" : "partial",
+    };
+  });
 }

--- a/src/plugins/builtin/sec/filing-display.tsx
+++ b/src/plugins/builtin/sec/filing-display.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "../../../ui";
 import { colors } from "../../../theme/colors";
-import { formatCompact, formatCurrency } from "../../../utils/format";
+import { formatCompact, formatCurrency, formatNumber } from "../../../utils/format";
 import { transactionTypeLabel, type InsiderTransaction } from "../insider/insider-data";
 
 const MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] as const;
@@ -8,7 +8,7 @@ const MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Se
 export function formatFilingShortDate(value: Date | string | number): string {
   const date = value instanceof Date ? value : new Date(value);
   if (isNaN(date.getTime())) return "—";
-  return `${MONTH_NAMES[date.getMonth()]} ${String(date.getDate()).padStart(2, " ")} ${date.getFullYear()}`;
+  return `${MONTH_NAMES[date.getUTCMonth()]} ${String(date.getUTCDate()).padStart(2, " ")} ${date.getUTCFullYear()}`;
 }
 
 export function formatFilingMetaDate(value: Date): string {
@@ -16,6 +16,7 @@ export function formatFilingMetaDate(value: Date): string {
     month: "short",
     day: "numeric",
     year: "numeric",
+    timeZone: "UTC",
   });
 }
 
@@ -45,17 +46,22 @@ export function buildInsiderTransactionTitle(transaction: InsiderTransaction): s
   const value = transaction.totalValue != null
     ? ` | ${formatCurrency(transaction.totalValue)}`
     : "";
-  return `${type} ${formatCompact(transaction.shares)} shares${price}${value}`;
+  const shares = transaction.shares != null ? formatCompact(transaction.shares) : "—";
+  const security = transaction.securityTitle || "shares";
+  return `${type} ${shares} ${security}${transaction.isDerivative ? " (derivative)" : ""}${price}${value}`;
 }
 
 export function buildInsiderTransactionDetailBody(transaction: InsiderTransaction): string {
   const lines = [
-    `Transaction: ${transactionTypeLabel(transaction.transactionType)}`,
-    `Date: ${formatFilingShortDate(transaction.filingDate)}`,
-    `Shares: ${formatCompact(transaction.shares)}`,
+    `Transaction: ${transactionTypeLabel(transaction.transactionType)}${transaction.transactionType ? ` (${transaction.transactionType})` : ""}`,
+    `Transaction Date: ${transaction.filingDate ? formatFilingShortDate(transaction.filingDate) : "—"}`,
+    `Security: ${transaction.securityTitle || "—"}${transaction.isDerivative ? " (derivative)" : ""}`,
+    `Acquired/Disposed: ${transaction.acquiredDisposed === "A" ? "Acquired" : transaction.acquiredDisposed === "D" ? "Disposed" : transaction.acquiredDisposed || "—"}`,
+    `Shares: ${transaction.shares != null ? formatNumber(transaction.shares, Number.isInteger(transaction.shares) ? 0 : 4) : "—"}`,
     `Price/Share: ${transaction.pricePerShare != null ? formatCurrency(transaction.pricePerShare) : "—"}`,
     `Total Value: ${transaction.totalValue != null ? formatCurrency(transaction.totalValue) : "—"}`,
-    `Shares Owned After: ${transaction.sharesOwned != null ? formatCompact(transaction.sharesOwned) : "—"}`,
+    `Shares Owned After: ${transaction.sharesOwned != null ? formatNumber(transaction.sharesOwned, Number.isInteger(transaction.sharesOwned) ? 0 : 4) : "—"}`,
+    `Ownership: ${transaction.ownershipType === "D" ? "Direct" : transaction.ownershipType === "I" ? "Indirect" : transaction.ownershipType || "—"}${transaction.ownershipNature ? ` — ${transaction.ownershipNature}` : ""}`,
   ];
   return lines.join("\n");
 }

--- a/src/plugins/builtin/sec/index.tsx
+++ b/src/plugins/builtin/sec/index.tsx
@@ -9,10 +9,11 @@ import type { ScrollBoxRenderable } from "../../../ui";
 import { EmptyState, FeedDataTableStackView, Spinner, useTableLoadMore, type FeedDataTableItem } from "../../../components";
 import { isUsEquityTicker } from "../../../utils/sec";
 import { parseForm4Xml, transactionTypeLabel } from "../insider/insider-data";
-import { formatCompact, formatCurrency } from "../../../utils/format";
 import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
 import {
   formatFilingMetaDate,
+  buildInsiderTransactionTitle,
+  buildInsiderTransactionDetailBody,
   renderFilingNotice,
 } from "./filing-display";
 import {
@@ -102,27 +103,27 @@ function buildDetailBodyWithDocuments({
 
 function buildForm4Preview(content: string | null): string | null {
   if (!content) return null;
-  const tx = parseForm4Xml(content);
+  const transactions = parseForm4Xml(content);
+  const tx = transactions[0];
   if (!tx) return null;
-  const type = transactionTypeLabel(tx.transactionType);
-  const shares = formatCompact(tx.shares);
-  const price = tx.pricePerShare != null ? ` @ ${formatCurrency(tx.pricePerShare)}` : "";
-  return `${tx.reportedName} — ${type} ${shares} shares${price}`;
+  if (transactions.length === 1) return `${tx.reportedName} — ${buildInsiderTransactionTitle(tx)}`;
+  const types = [...new Set(transactions.map((transaction) => transactionTypeLabel(transaction.transactionType)))];
+  return `${tx.reportedName} — ${transactions.length} transactions: ${types.join(", ")}`;
 }
 
 function buildForm4Detail(content: string | null, filing: SecFilingItem): string {
   if (!content) return buildDetailBody(filing);
-  const tx = parseForm4Xml(content);
+  const transactions = parseForm4Xml(content);
+  const tx = transactions[0];
   if (!tx) return buildDetailBody(filing);
 
   const lines: string[] = [];
   lines.push(`Insider: ${tx.reportedName}`);
   if (tx.title) lines.push(`Title: ${tx.title}`);
-  lines.push(`Transaction: ${transactionTypeLabel(tx.transactionType)}`);
-  lines.push(`Shares: ${formatCompact(tx.shares)}`);
-  if (tx.pricePerShare != null) lines.push(`Price/Share: ${formatCurrency(tx.pricePerShare)}`);
-  if (tx.totalValue != null) lines.push(`Total Value: ${formatCurrency(tx.totalValue)}`);
-  if (tx.sharesOwned != null) lines.push(`Shares Owned After: ${formatCompact(tx.sharesOwned)}`);
+  for (const [index, transaction] of transactions.entries()) {
+    if (transactions.length > 1) lines.push("", `Transaction ${index + 1}`);
+    lines.push(buildInsiderTransactionDetailBody(transaction));
+  }
   return lines.join("\n");
 }
 

--- a/src/utils/sec.test.ts
+++ b/src/utils/sec.test.ts
@@ -35,15 +35,17 @@ describe("isUsEquityTicker", () => {
     }))).toBe(true);
   });
 
-  test("accepts US-listed ADRs", () => {
-    expect(isUsEquityTicker(makeTicker({
-      assetCategory: "ADR",
-    }))).toBe(true);
-  });
-
-  test("rejects non-equity instruments", () => {
-    expect(isUsEquityTicker(makeTicker({
-      assetCategory: "OPT",
-    }))).toBe(false);
+  test("accepts catalogue common stocks and depositary receipts without admitting funds or foreign listings", () => {
+    for (const assetCategory of ["ADR", "Common Stock", "Depositary Receipt"]) {
+      expect(isUsEquityTicker(makeTicker({ assetCategory }))).toBe(true);
+      expect(isUsEquityTicker(makeTicker({ assetCategory, exchange: "LSE" }))).toBe(false);
+      expect(isUsEquityTicker(makeTicker({ assetCategory, currency: "CAD" }))).toBe(false);
+    }
+    for (const exchange of ["XNAS", "NGM", "NCM", "XNYS", "XASE"]) {
+      expect(isUsEquityTicker(makeTicker({ assetCategory: "Common Stock", exchange }))).toBe(true);
+    }
+    for (const assetCategory of ["OPT", "ETF", "Mutual Fund", "Preferred Stock"]) {
+      expect(isUsEquityTicker(makeTicker({ assetCategory }))).toBe(false);
+    }
   });
 });

--- a/src/utils/sec.ts
+++ b/src/utils/sec.ts
@@ -1,4 +1,5 @@
 import type { TickerRecord } from "../types/ticker";
+import { canonicalExchange } from "./exchanges";
 
 const US_EQUITY_EXCHANGES = new Set([
   "AMEX",
@@ -19,12 +20,12 @@ function normalize(value?: string): string {
 }
 
 function isUsExchange(value?: string): boolean {
-  return US_EQUITY_EXCHANGES.has(normalize(value));
+  return US_EQUITY_EXCHANGES.has(canonicalExchange(value));
 }
 
 function isEquityType(value?: string): boolean {
-  const normalized = normalize(value);
-  return normalized.length === 0 || normalized === "STK" || normalized === "EQUITY" || normalized === "ADR";
+  const normalized = normalize(value).replace(/[\s_-]/g, "");
+  return normalized.length === 0 || ["STK", "EQUITY", "ADR", "COMMONSTOCK", "DEPOSITARYRECEIPT"].includes(normalized);
 }
 
 export function isUsEquityTicker(ticker: TickerRecord | null | undefined): boolean {


### PR DESCRIPTION
Form 4 research returned only the first transaction in each filing and erased gifts, exercises, and conversions. The same five Palantir filings now produce 31 transactions, each with its own date, security, transaction code, acquisition/disposition, and ownership. Insider lists, filing details, and exports use distinct transaction IDs; summaries cover loaded non-derivative purchases/sales by security and disclose incomplete filings and unreconciled amendments.

Newly searched US common stocks and depositary receipts also open SEC research correctly. Their provider type names and known US exchange aliases previously failed the equity eligibility check.

Validation:

- 11 focused parser, client, SEC, eligibility, and cache-loading tests passed (45 assertions).
- Browser and OpenTUI typechecks passed.
- Live `INS PLTR --limit 5 --json` returned 31 rows. Independent SEC XML parsing matched all 18 Karp transactions and both Sankar gifts; Karp sales total 492,348 Class A shares.
- Actual terminal list and detail navigation verified separate transaction/filing dates, exact shares, and ownership. Test session closed.

No release created.
