### PR TITLE
fix(financials): separate annual SEC periods and income concepts

### DIFF
--- a/src/sources/provider-router/cache.test.ts
+++ b/src/sources/provider-router/cache.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, expect, test } from "bun:test";
+import { AppPersistence } from "../../data/app-persistence";
+import { cacheRouterResource, listCachedResources } from "./cache";
+import { cleanupProviderRouterTestFiles, createTempDbPath, makeFinancials, makeQuote } from "./test-support";
+
+afterEach(cleanupProviderRouterTestFiles);
+
+test("refreshes legacy SEC annual caches without discarding unrelated data and accepts repaired writes", () => {
+  const persistence = new AppPersistence(createTempDbPath("sec-annual-cache-version"));
+  const key = { namespace: "market", kind: "financials", entityKey: "COST", variantKey: "exchange=NASDAQ", sourceKey: "provider:yahoo" };
+  const cachePolicy = { staleMs: 60_000, expireMs: 120_000 };
+  const legacy = makeFinancials({ annualStatements: [{ date: "2017-09-03", netIncome: 919_000_000, fieldAvailability: { netIncome: "2017-10-18" } }] });
+  persistence.resources.set(key, legacy, { cachePolicy });
+  persistence.resources.set({ ...key, sourceKey: "provider:gloomberb-cloud" }, makeFinancials({ annualStatements: [{ date: "2025-08-31", netIncome: 8_099_000_000 }] }), { cachePolicy });
+  persistence.resources.set({ ...key, kind: "quote" }, makeQuote({ symbol: "COST" }), { cachePolicy });
+  const read = (kind: string) => listCachedResources(persistence.resources, kind, "COST", ["exchange=NASDAQ"], ["provider:yahoo", "provider:gloomberb-cloud"], true);
+  expect(read("financials").map((row) => row.sourceKey)).toEqual(["provider:gloomberb-cloud"]);
+  expect(read("quote")).toHaveLength(1);
+
+  const repaired = makeFinancials({ annualStatements: [{ date: "2017-09-03", netIncome: 2_679_000_000, fieldAvailability: { netIncome: "2017-10-18" } }] });
+  cacheRouterResource(persistence.resources, "financials", "COST", key.variantKey, key.sourceKey, repaired, cachePolicy);
+  expect(read("financials").find((row) => row.sourceKey === "provider:yahoo")?.value).toEqual(repaired);
+  persistence.close();
+});

--- a/src/sources/provider-router/cache.ts
+++ b/src/sources/provider-router/cache.ts
@@ -1,12 +1,13 @@
 import type { CachedResourceRecord, ResourceStore } from "../../data/resource-store";
 import type { TimeRange } from "../../time-series/range";
 import type { BrokerContractRef } from "../../types/instrument";
-import type { PricePoint } from "../../types/financials";
+import type { PricePoint, TickerFinancials } from "../../types/financials";
 import type { CachePolicy, CachePolicyMap } from "../../types/persistence";
 import { canonicalExchange } from "../../utils/exchanges";
 import { isPriceHistoryStaleForCurrentWindow } from "../../utils/price-history";
 
 const MARKET_NAMESPACE = "market";
+const FINANCIALS_SCHEMA_VERSION = 2;
 
 const DEFAULT_CACHE_POLICIES = {
   brokerQuote: { staleMs: 15_000, expireMs: 15 * 60_000 },
@@ -103,6 +104,7 @@ export function cacheRouterResource<T>(
     value,
     {
       cachePolicy,
+      ...(kind === "financials" ? { schemaVersion: FINANCIALS_SCHEMA_VERSION } : {}),
     },
   );
 }
@@ -142,6 +144,13 @@ export function listCachedResources<T>(
     variantKeys,
     sourceKeys,
     allowExpired,
+  }).filter((record) => {
+    if (kind !== "financials" || record.schemaVersion >= FINANCIALS_SCHEMA_VERSION) return true;
+    // Legacy SEC-supplemented annuals mixed quarter facts and fallback
+    // concepts. Their period durations cannot be reconstructed from cache.
+    // Refresh those records; unrelated quote/history/company caches remain usable.
+    const value = record.value as TickerFinancials;
+    return !value.annualStatements?.some((row) => row.availableAt || Object.keys(row.fieldAvailability ?? {}).length > 0);
   });
   if (records.length === 0) return [];
 

--- a/src/sources/sec-edgar.test.ts
+++ b/src/sources/sec-edgar.test.ts
@@ -133,6 +133,57 @@ describe("parseFilingDocuments", () => {
 });
 
 describe("parseCompanyFactsFinancialStatements", () => {
+  test("keeps preferred income concept and its restatements separate from consolidated fallback income", () => {
+    const period = { start: "2017-09-04", end: "2018-09-02", form: "10-K", fp: "FY" };
+    const statements = parseCompanyFactsFinancialStatements({ facts: { "us-gaap": {
+      NetIncomeLoss: { units: { USD: [
+        { ...period, val: 3_134_000_000, filed: "2018-10-26" },
+        { ...period, val: 3_134_000_000, filed: "2019-10-11" },
+        { ...period, val: 3_140_000_000, filed: "2020-10-07" },
+      ] } },
+      ProfitLoss: { units: { USD: [
+        { ...period, val: 3_179_000_000, filed: "2018-10-26" },
+        { ...period, val: 3_179_000_000, filed: "2021-10-06" },
+        { ...period, start: "2016-08-29", end: "2017-09-03", val: 2_714_000_000, filed: "2018-10-26" },
+      ] } },
+    } } });
+    expect(statements.annualStatements.map(({ date, netIncome, fieldAvailability }) => ({ date, netIncome, availableAt: fieldAvailability?.netIncome }))).toEqual([
+      { date: "2017-09-03", netIncome: 2_714_000_000, availableAt: "2018-10-26" },
+      { date: "2018-09-02", netIncome: 3_140_000_000, availableAt: "2020-10-07" },
+    ]);
+  });
+
+  test("separates annual facts from quarter disclosures in the same 10-K and fiscal-year label", () => {
+    const fact = (rows: unknown[]) => ({ units: { USD: rows } });
+    const filing = { form: "10-K", fp: "FY", fy: 2017, filed: "2017-10-18" };
+    const statements = parseCompanyFactsFinancialStatements({ facts: { "us-gaap": {
+      NetIncomeLoss: fact([
+        { ...filing, start: "2016-08-29", end: "2017-09-03", val: 2_679_000_000 },
+        { ...filing, start: "2017-05-08", end: "2017-09-03", val: 919_000_000, frame: "CY2017Q3" },
+        { ...filing, start: "2016-11-21", end: "2017-02-12", val: 521_000_000, frame: "CY2017Q1" },
+        // A later quarterly comparative must not overwrite the annual amount.
+        { ...filing, filed: "2018-10-26", start: "2017-05-08", end: "2017-09-03", val: 919_000_000, frame: "CY2017Q3" },
+        // Filing fp can be Q4 even when the fact itself spans the full year.
+        { ...filing, filed: "2018-10-26", fp: "Q4", start: "2017-09-04", end: "2018-09-02", val: 3_179_000_000 },
+      ]),
+      Assets: fact([
+        { ...filing, end: "2017-09-03", val: 36_347_000_000 },
+        { ...filing, end: "2017-02-12", val: 33_000_000_000, frame: "CY2017Q1I" },
+      ]),
+      GrossProfit: fact([
+        { ...filing, end: "2017-09-03", val: 1 }, // Unknown duration stays unknown.
+        { ...filing, start: "2017-01-01", end: "2017-09-03", val: 2 }, // YTD, not annual.
+      ]),
+    } } });
+    expect(statements.annualStatements.map(({ date, netIncome, totalAssets, grossProfit }) => ({ date, netIncome, totalAssets, grossProfit }))).toEqual([
+      { date: "2017-09-03", netIncome: 2_679_000_000, totalAssets: 36_347_000_000, grossProfit: undefined },
+      { date: "2018-09-02", netIncome: 3_179_000_000, totalAssets: undefined, grossProfit: undefined },
+    ]);
+    expect(statements.quarterlyStatements.find((row) => row.date === "2017-09-03")?.netIncome).toBe(919_000_000);
+    expect(statements.quarterlyStatements.find((row) => row.date === "2017-02-12")).toMatchObject({ netIncome: 521_000_000, totalAssets: 33_000_000_000 });
+    expect(statements.annualStatements[0]?.fieldAvailability?.netIncome).toBe("2017-10-18");
+  });
+
   test("maps SEC company facts into deeper annual and quarterly statement rows", () => {
     const fact = (tag: string, unit: string, rows: unknown[]) => ({
       [tag]: {

--- a/src/sources/sec-edgar.ts
+++ b/src/sources/sec-edgar.ts
@@ -56,6 +56,7 @@ type LookupEntry = {
 };
 
 type CompanyFactsEntry = {
+  tagPriority?: number;
   start?: string;
   end?: string;
   val?: number;
@@ -443,6 +444,11 @@ function shouldReplaceCompanyFact(
   if (!selected) return true;
   const left = candidate;
   const right = selected;
+  // Ordered tags are fallback concepts, not interchangeable restatements.
+  // For example ProfitLoss includes noncontrolling interests while the
+  // preferred NetIncomeLoss reports income attributable to the parent.
+  const priorityDiff = (left.tagPriority ?? 0) - (right.tagPriority ?? 0);
+  if (priorityDiff !== 0) return priorityDiff < 0;
   const leftFiled = companyFactsFiledRank(left.filed);
   const rightFiled = companyFactsFiledRank(right.filed);
   const filedDiff = leftFiled - rightFiled;
@@ -468,9 +474,20 @@ function compareCompanyFactsChronologically(
     || String(left.frame ?? "").localeCompare(String(right.frame ?? ""));
 }
 
-function isAnnualCompanyFact(entry: CompanyFactsEntry): boolean {
+function isAnnualFiling(entry: CompanyFactsEntry): boolean {
   const form = normalize(entry.form);
-  return (form === "10-K" || form === "10-K/A") && normalize(entry.fp ?? undefined) === "FY";
+  return form === "10-K" || form === "10-K/A";
+}
+
+function isAnnualDurationFact(entry: CompanyFactsEntry): boolean {
+  if (!isAnnualFiling(entry)) return false;
+  const start = entry.start ? Date.parse(`${entry.start}T00:00:00Z`) : Number.NaN;
+  const end = entry.end ? Date.parse(`${entry.end}T00:00:00Z`) : Number.NaN;
+  const days = (end - start) / 86_400_000;
+  // `fp` describes the filing, not each fact in it. A 10-K also repeats
+  // quarterly results. SEC annual frames allow 365 +/- 30 days, including
+  // 52/53-week fiscal years; shorter transition periods remain unclassified.
+  return Number.isFinite(days) && days >= 335 && days <= 395;
 }
 
 function isQuarterlyCompanyFact(entry: CompanyFactsEntry, periodType: "duration" | "instant"): boolean {
@@ -528,11 +545,14 @@ function fillCompanyFactsStatementRows(
   entries: CompanyFactsEntry[],
   field: CompanyFactsStatementField,
   period: "annual" | "quarterly",
+  annualPeriodEnds: ReadonlySet<string>,
 ): void {
   for (const entry of [...entries].sort(compareCompanyFactsChronologically)) {
     if (!entry.end || typeof entry.val !== "number") continue;
     const matchesPeriod = period === "annual"
-      ? isAnnualCompanyFact(entry)
+      ? field.periodType === "duration"
+        ? isAnnualDurationFact(entry)
+        : isAnnualFiling(entry) && annualPeriodEnds.has(entry.end)
       : isQuarterlyCompanyFact(entry, field.periodType);
     if (!matchesPeriod) continue;
     setCompanyFactValue(
@@ -577,12 +597,21 @@ export function parseCompanyFactsFinancialStatements(payload: unknown): SecCompa
   const quarterlyRows = new Map<string, FinancialStatement>();
   const annualSelectedFacts = new Map<string, CompanyFactsEntry>();
   const quarterlySelectedFacts = new Map<string, CompanyFactsEntry>();
+  const fieldEntries = COMPANY_FACTS_STATEMENT_FIELDS.map((field) => ({
+    field,
+    entries: field.tags.flatMap((tag, tagPriority) => companyFactsEntries(payload, tag, field.units)
+      .map((entry) => ({ ...entry, tagPriority }))),
+  }));
+  // Balance-sheet facts have no duration. Anchor their dates to actual annual
+  // periods, so quarterly comparative snapshots in a 10-K stay quarterly.
+  const annualPeriodEnds = new Set(fieldEntries.flatMap(({ field, entries }) => field.periodType === "duration"
+    ? entries.filter(isAnnualDurationFact).map((entry) => entry.end!)
+    : []));
 
-  for (const field of COMPANY_FACTS_STATEMENT_FIELDS) {
-    const entries = field.tags.flatMap((tag) => companyFactsEntries(payload, tag, field.units));
+  for (const { field, entries } of fieldEntries) {
     if (entries.length === 0) continue;
-    fillCompanyFactsStatementRows(annualRows, annualSelectedFacts, entries, field, "annual");
-    fillCompanyFactsStatementRows(quarterlyRows, quarterlySelectedFacts, entries, field, "quarterly");
+    fillCompanyFactsStatementRows(annualRows, annualSelectedFacts, entries, field, "annual", annualPeriodEnds);
+    fillCompanyFactsStatementRows(quarterlyRows, quarterlySelectedFacts, entries, field, "quarterly", annualPeriodEnds);
   }
 
   return {


### PR DESCRIPTION
SEC annual history could include quarterly facts repeated in a 10-K. Costco's 2017 annual net income became its $919 million fourth quarter instead of $2.679 billion for the year. Classify flow facts by their actual start/end duration and anchor annual balance snapshots to proven annual period ends, including 52/53-week fiscal years.

Preserve each metric's declared concept preference for a given date. Parent net income no longer alternates with consolidated profit including noncontrolling interests as though the different concepts were restatements; genuine newer restatements within the preferred concept still apply. Refresh legacy cached financial records with SEC annual provenance because their missing source durations cannot be repaired locally. Unrelated caches remain usable.

Validation:

- 77 focused SEC mapper, Yahoo integration, and financial cache/router tests passed (232 assertions).
- Browser and OpenTUI typechecks passed.
- Actual SEC companyfacts confirms Costco's annual/quarter distinction and parent/consolidated income distinction. Native FA and GF Costco journeys retain the correct fiscal dates after refresh.

Cloud-only provider dates remain a separate limitation: Yahoo's raw Costco timeseries currently uses month-end labels. This change repairs SEC supplementation; it does not infer exact fiscal dates from those provider labels. Short transition periods without a normal annual duration remain unclassified.

No release created.
