### PR TITLE
fix(macro): research Treasury curves by historical date

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -105,7 +105,7 @@ The toolbar controls preset or exact date ranges, intervals from one minute thro
 | `FUT` | Front-month futures across index, rates, energy, metals, grains, and FX |
 | `ECO` | Economic events and releases |
 | `ECST [statistic]` | Economic statistics: inflation, labour, growth, consumer, housing, rates |
-| `GC` | Yield curve |
+| `GC [YYYY-MM-DD]` | Treasury yield curve for the latest session or a historical date; CLI also accepts `--date YYYY-MM-DD` |
 | `AUCT` | Treasury auction results: high rate, bid-to-cover, indirect share, and size |
 | `VIX` | VIX 30-day/3-month implied-volatility curve |
 | `CRD` | Credit spreads |

--- a/src/plugins/builtin/econ-statistics/view.test.ts
+++ b/src/plugins/builtin/econ-statistics/view.test.ts
@@ -14,3 +14,14 @@ test("1Y ago matches calendar periods even when an intermediate month is missing
   const missingBase = points.filter((point) => point.date !== "2025-07-01");
   expect(projectStat({ stat: findStat("cpi-yoy"), points: missingBase, trend: fitTrend(missingBase) }, "5Y").yearAgo).toBeNull();
 });
+
+
+test("daily 1Y ago clamps February 29 to February 28 instead of looking forward into March", () => {
+  const points = [
+    { date: "2023-02-27", value: 4.1 }, { date: "2023-02-28", value: 4.2 },
+    { date: "2023-03-01", value: 4.3 }, { date: "2024-02-28", value: 4.4 },
+    { date: "2024-02-29", value: 4.5 },
+  ];
+  const view = projectStat({ stat: findStat("ten-year"), points, trend: fitTrend(points) }, "5Y");
+  expect(view.yearAgo).toEqual({ date: "2023-02-28", value: 4.2 });
+});

--- a/src/plugins/builtin/econ-statistics/view.ts
+++ b/src/plugins/builtin/econ-statistics/view.ts
@@ -60,7 +60,10 @@ export function projectStat(
   const nowMs = opts.nowMs ?? Date.now();
   const perYear = periodsPerYear(points.map((point) => ({ date: point.date, value: point.value })));
   const yearEarlier = new Date(latest.date);
-  yearEarlier.setUTCFullYear(yearEarlier.getUTCFullYear() - 1);
+  const year = yearEarlier.getUTCFullYear() - 1;
+  const month = yearEarlier.getUTCMonth();
+  const day = Math.min(yearEarlier.getUTCDate(), new Date(Date.UTC(year, month + 1, 0)).getUTCDate());
+  yearEarlier.setTime(Date.UTC(year, month, day));
   const target = yearEarlier.toISOString().slice(0, 10);
   // Monthly/quarterly releases are calendar periods. Daily series can use the
   // nearest preceding business day, but never an arbitrary row count.

--- a/src/plugins/builtin/yield-curve/headless.test.ts
+++ b/src/plugins/builtin/yield-curve/headless.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
 import { createYieldCurveHeadless } from "./headless";
+import { TREASURY_MATURITIES } from "./treasury-data";
 
 const args: HeadlessPaneLoadArgs = { rawArgument: "", argument: null, symbols: [], options: {} };
 
 describe("yield curve headless model", () => {
-  test("does not calculate a spread across different observation dates", async () => {
+  test("marks a partial, mixed-date curve incomplete and does not calculate a spread", async () => {
     const headless = createYieldCurveHeadless({
       load: async () => [
         { maturity: "10Y", maturityYears: 10, yield: 4.1, asOf: "2026-09-03" },
@@ -13,14 +14,27 @@ describe("yield curve headless model", () => {
       ],
     });
     const result = await headless.load(args, {} as HeadlessPaneContext);
-
-    expect(result.rows.map((row) => row.maturity)).toEqual(["2Y", "10Y"]);
-    expect(result.metadata).toEqual({
-      asOf: null,
-      inverted: null,
-      spread2Y10YBasisPoints: null,
-      missingTenors: [],
-      stale: false,
+    expect(result.rows).toHaveLength(10);
+    expect(result.metadata).toMatchObject({
+      requestedDate: null, asOf: null, inverted: null, spread2Y10YBasisPoints: null,
+      missingTenors: ["1M", "3M", "6M", "1Y", "5Y", "7Y", "20Y", "30Y"], stale: false,
     });
+    expect(result.errors).toHaveLength(2);
+  });
+
+  test("date options call bounded series history, preserve observation dates and flag stale sources", async () => {
+    const calls: string[] = [];
+    const context = { apiClient: { getCloudFredSeries: async (id: string, options: { endDate: string }) => {
+      calls.push(`${id}:${options.endDate}`);
+      return {
+        info: { units: "Percent", frequency: "Daily" },
+        observations: [{ date: "2024-03-01", value: id === "DGS2" ? 4.54 : 4.19 }],
+        stale: id === "DGS30",
+      };
+    } } } as unknown as HeadlessPaneContext;
+    const result = await createYieldCurveHeadless().load({ ...args, options: { date: "2024-03-02" } }, context);
+    expect(calls).toEqual(TREASURY_MATURITIES.map(({ seriesId }) => `${seriesId}:2024-03-02`));
+    expect(result.metadata).toMatchObject({ requestedDate: "2024-03-02", asOf: "2024-03-01", spread2Y10YBasisPoints: -35, missingTenors: [], stale: true });
+    expect(result.errors).toEqual(["Some Treasury sources are stale cached data."]);
   });
 });

--- a/src/plugins/builtin/yield-curve/headless.ts
+++ b/src/plugins/builtin/yield-curve/headless.ts
@@ -10,6 +10,7 @@ import {
   type YieldCurveLoader,
   type YieldPoint,
 } from "./treasury-data";
+import { completeYieldCurve, loadHistoricalYieldCurve, yieldCurveDate } from "./history";
 
 const COLUMNS = [
   { key: "maturity", header: "Maturity" },
@@ -41,23 +42,35 @@ export function createYieldCurveHeadless(
 ): HeadlessPaneDefinition<"rows"> {
   return {
     shape: "rows",
-    argument: { kind: "none" },
-    options: [],
+    argument: { kind: "free-text", optional: true, placeholder: "YYYY-MM-DD", description: "Historical as-of date; omit for latest." },
+    options: [{ key: "date", type: "string", description: "Historical as-of date (YYYY-MM-DD); uses the latest observation on or before it." }],
     columns: COLUMNS,
     describe: "US Treasury Yield Curve",
     async load(args, ctx) {
-      const points = await dependencies.load(
+      const requestedDate = yieldCurveDate(args.options.date ?? args.argument);
+      const points = completeYieldCurve(await dependencies.load(
         args,
-        () => ctx.apiClient.getCloudYieldCurve(),
-      );
+        requestedDate
+          ? () => loadHistoricalYieldCurve(requestedDate, (id, options) => ctx.apiClient.getCloudFredSeries(id, options))
+          : () => ctx.apiClient.getCloudYieldCurve(),
+      ));
       const rows = [...points].sort((a, b) => a.maturityYears - b.maturityYears);
+      const missingTenors = points.filter((point) => point.yield == null).map((point) => point.maturity);
       return {
         rows: rows.map((point) => ({ ...point })),
+        errors: [
+          ...(missingTenors.length ? [`Treasury tenors unavailable: ${missingTenors.join(", ")}`] : []),
+          ...(!curveAsOf(points) ? ["Curve has mixed or unknown observation dates."] : []),
+          ...(points.some((point) => point.stale) ? ["Some Treasury sources are stale cached data."] : []),
+        ],
         metadata: {
+          source: "FRED / US Treasury constant maturity rates",
+          units: "Percent",
+          requestedDate: requestedDate || null,
           asOf: curveAsOf(points),
           inverted: isInverted(points),
           spread2Y10YBasisPoints: spreadBasisPoints(points),
-          missingTenors: points.filter((point) => point.yield == null).map((point) => point.maturity),
+          missingTenors,
           stale: points.some((point) => point.stale),
         },
       };

--- a/src/plugins/builtin/yield-curve/history.test.ts
+++ b/src/plugins/builtin/yield-curve/history.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import type { CloudFredSeriesPayload } from "../../../api-client";
+import { completeYieldCurve, loadHistoricalYieldCurve, yieldCurveDate } from "./history";
+import { curveAsOf, spreadBasisPoints } from "./treasury-data";
+
+function payload(observations: CloudFredSeriesPayload["observations"]): CloudFredSeriesPayload {
+  return {
+    observations,
+    info: { id: "", title: "Treasury", units: "Percent", frequency: "Daily", seasonalAdjustment: "Not Seasonally Adjusted", source: "FRED", notes: "" },
+    fetchedAt: "2026-09-10T12:00:00Z",
+    stale: false,
+  };
+}
+
+describe("historical Treasury curves", () => {
+  test("uses one preceding business date for a weekend and keeps the requested bounds", async () => {
+    const requests: unknown[] = [];
+    const points = await loadHistoricalYieldCurve("2024-03-02", async (id, options) => {
+      requests.push(options);
+      return payload([
+        { date: "2024-03-04", value: 99 }, // An upstream over-fetch must not leak into the selected curve.
+        { date: "2024-03-02", value: null },
+        { date: "2024-03-01", value: id === "DGS2" ? 4.54 : 4.19 },
+        { date: "2024-02-29", value: 4.25 },
+      ]);
+    });
+    expect(requests).toHaveLength(10);
+    expect(requests[0]).toEqual({ startDate: "2024-02-21", endDate: "2024-03-02", limit: 10, sortOrder: "desc" });
+    expect(points).toHaveLength(10);
+    expect(curveAsOf(points)).toBe("2024-03-01");
+    expect(spreadBasisPoints(points)).toBe(-35);
+    expect(points.every((point) => point.asOf === "2024-03-01")).toBe(true);
+  });
+
+  test("partial failures and lagging tenors never carry older values into a newer curve", async () => {
+    const points = await loadHistoricalYieldCurve("2024-02-29", async (id) => {
+      if (id === "DGS30") throw new Error("provider unavailable");
+      if (id === "DGS2") return payload([{ date: "2024-02-28", value: 4.64 }]);
+      if (id === "DGS20") return { ...payload([{ date: "2024-02-29", value: 450 }]), info: { ...payload([]).info!, units: "Basis Points" } };
+      if (id === "DGS6MO") return { ...payload([{ date: "2024-02-29", value: -0.2 }]), info: null };
+      return { ...payload([{ date: "2024-02-29", value: id === "DGS1" ? 0 : -0.1 }]), stale: true };
+    });
+    expect(curveAsOf(points)).toBe("2024-02-29");
+    expect(spreadBasisPoints(points)).toBeNull();
+    expect(points.filter((point) => point.yield == null).map((point) => point.maturity)).toEqual(["2Y", "20Y", "30Y"]);
+    expect(points.find((point) => point.maturity === "1Y")?.yield).toBe(0);
+    expect(points[0]?.yield).toBe(-0.1);
+    expect(points[0]?.stale).toBe(true);
+    expect(points[0]?.fetchedAt).toBe("2026-09-10T12:00:00Z");
+    expect(points.find((point) => point.maturity === "6M")?.yield).toBe(-0.2);
+  });
+
+  test("does not return a fabricated empty curve when every series fails", async () => {
+    await expect(loadHistoricalYieldCurve("2024-02-29", async () => { throw new Error("offline"); })).rejects.toThrow("No Treasury observations");
+    await expect(loadHistoricalYieldCurve("2024-02-29", async () => payload([{ date: "2024-02-01", value: 4 }]))).rejects.toThrow("No Treasury observations");
+  });
+
+  test("validates real calendar dates before requesting history", async () => {
+    const now = new Date("2026-09-10T12:00:00Z");
+    expect(yieldCurveDate("2024-02-29", now)).toBe("2024-02-29");
+    expect(yieldCurveDate(" latest ", now)).toBe("");
+    for (const date of ["2023-02-29", "2024-02-30", "2024-2-1", "2024-01-01T00:00:00Z", 2024]) {
+      expect(() => yieldCurveDate(date, now)).toThrow("YYYY-MM-DD");
+    }
+    expect(() => yieldCurveDate("2026-09-11", now)).toThrow("future date");
+    let calls = 0;
+    await expect(loadHistoricalYieldCurve("2023-02-29", async () => { calls++; return payload([]); })).rejects.toThrow("YYYY-MM-DD");
+    expect(calls).toBe(0);
+  });
+
+  test("exposes omitted and invalid latest tenors as missing", () => {
+    const points = completeYieldCurve([
+      { maturity: "2Y", maturityYears: 2, yield: Number.NaN, asOf: "2024-02-29" },
+      { maturity: "10Y", maturityYears: 100, yield: 0, asOf: "2024-02-29" },
+    ]);
+    expect(points).toHaveLength(10);
+    expect(points.find((point) => point.maturity === "2Y")).toMatchObject({ yield: null, asOf: null });
+    expect(points.find((point) => point.maturity === "10Y")).toMatchObject({ yield: 0, maturityYears: 10 });
+  });
+});

--- a/src/plugins/builtin/yield-curve/history.ts
+++ b/src/plugins/builtin/yield-curve/history.ts
@@ -1,0 +1,72 @@
+import { apiClient, type CloudFredSeriesPayload } from "../../../api-client";
+import { TREASURY_MATURITIES, type YieldPoint } from "./treasury-data";
+
+const DAY_MS = 86_400_000;
+export type TreasurySeriesLoader = (seriesId: string, options: {
+  startDate: string;
+  endDate: string;
+  limit: number;
+  sortOrder: "desc";
+}) => Promise<CloudFredSeriesPayload>;
+
+export function yieldCurveDate(value: unknown, now = new Date()): string {
+  if (value == null) return "";
+  const date = typeof value === "string" ? value.trim() : "";
+  if (typeof value === "string" && (date === "" || date.toLowerCase() === "latest")) return "";
+  const timestamp = Date.parse(date);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !Number.isFinite(timestamp)
+    || new Date(timestamp).toISOString().slice(0, 10) !== date) {
+    throw new Error("Use an as-of date in YYYY-MM-DD format, or latest.");
+  }
+  if (date > now.toISOString().slice(0, 10)) throw new Error("A Treasury curve cannot use a future date.");
+  return date;
+}
+
+export function completeYieldCurve(points: readonly YieldPoint[]): YieldPoint[] {
+  return TREASURY_MATURITIES.map(({ maturity, years }) => {
+    const found = points.find((point) => point.maturity === maturity);
+    return found && found.yield != null && Number.isFinite(found.yield)
+      ? { ...found, maturityYears: years }
+      : { ...found, maturity, maturityYears: years, yield: null, asOf: null };
+  });
+}
+
+/** Pick one published session on/before the requested date. A lagging tenor is
+ * unavailable for that curve, never silently carried from a different session. */
+export async function loadHistoricalYieldCurve(
+  requestedDate: string,
+  loader: TreasurySeriesLoader = (id, options) => apiClient.getCloudFredSeries(id, options),
+): Promise<YieldPoint[]> {
+  const endDate = yieldCurveDate(requestedDate);
+  if (!endDate) throw new Error("A historical curve requires a date.");
+  const startDate = new Date(Date.parse(endDate) - 10 * DAY_MS).toISOString().slice(0, 10);
+  const results = await Promise.allSettled(TREASURY_MATURITIES.map(async ({ seriesId }) => {
+    const payload = await loader(seriesId, { startDate, endDate, limit: 10, sortOrder: "desc" });
+    // These fixed DGS series are daily percentages. A metadata endpoint outage
+    // can retain usable observations; contradictory metadata must not be used.
+    if (payload.info && (payload.info.units?.toLowerCase() !== "percent" || payload.info.frequency?.toLowerCase() !== "daily")) {
+      throw new Error(`${seriesId}: unexpected Treasury units or frequency`);
+    }
+    const observations = payload.observations.filter((point): point is { date: string; value: number } =>
+      /^\d{4}-\d{2}-\d{2}$/.test(point.date) && point.date >= startDate && point.date <= endDate
+      && point.value != null && Number.isFinite(point.value));
+    return { payload, observations };
+  }));
+  const dates = results.flatMap((result) => result.status === "fulfilled"
+    ? result.value.observations.map((point) => point.date) : []);
+  const asOf = dates.sort().at(-1);
+  if (!asOf) throw new Error(`No Treasury observations available on or within 10 days before ${endDate}.`);
+  return TREASURY_MATURITIES.map(({ maturity, years }, index) => {
+    const result = results[index]!;
+    const data = result.status === "fulfilled" ? result.value : null;
+    const point = data?.observations.find((entry) => entry.date === asOf);
+    return {
+      maturity,
+      maturityYears: years,
+      yield: point?.value ?? null,
+      asOf: point ? asOf : null,
+      stale: data?.payload.stale ?? false,
+      fetchedAt: data?.payload.fetchedAt,
+    };
+  });
+}

--- a/src/plugins/builtin/yield-curve/index.tsx
+++ b/src/plugins/builtin/yield-curve/index.tsx
@@ -1,18 +1,19 @@
-import { useMemo } from "react";
-import { EmptyState, PaneStatusBody, StaticChartSurface, type PaneFooterSegment } from "../../../components";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Button, DataTableView, Notice, PaneStatusBody, StaticChartSurface, TextField, type PaneFooterSegment } from "../../../components";
 import type { ProjectedChartPoint } from "../../../components/chart/core/data";
 import { resolveChartPalette } from "../../../components/chart/core/palette";
 import { useAsyncResource } from "../../../react/async-resource";
 import { useShortcut } from "../../../react/input";
+import { usePaneSettingValue } from "../../../state/app/context";
 import { colors } from "../../../theme/colors";
 import type { PaneProps } from "../../../types/plugin";
-import { Box, ScrollBox, Text } from "../../../ui";
+import { Box, ScrollBox, Text, type InputRenderable } from "../../../ui";
 import type { PluginModule } from "../plugin-module";
 import { useAutoRefresh, useUpdatedAgo } from "../shared/auto-refresh";
 import { usePaneStatusFooter } from "../shared/pane-footer";
 import { yieldCurveHeadless } from "./headless";
+import { completeYieldCurve, loadHistoricalYieldCurve, yieldCurveDate } from "./history";
 import {
-  TREASURY_MATURITIES,
   curveAsOf,
   isInverted,
   loadYieldCurve,
@@ -23,8 +24,12 @@ import {
 
 export { yieldCurveHeadless } from "./headless";
 
-const loadCurve = () => loadYieldCurve();
 const EMPTY_POINTS: YieldPoint[] = [];
+const TABLE_COLUMNS = [
+  { id: "maturity", label: "Maturity", width: 9, align: "left" as const },
+  { id: "yield", label: "Yield", width: 8, align: "right" as const },
+  { id: "asOf", label: "As of", width: 11, align: "left" as const },
+];
 
 function formatYield(y: number | null): string {
   if (y == null) return "—";
@@ -35,16 +40,51 @@ function formatYieldAxis(value: number): string {
   return `${value.toFixed(2)}%`;
 }
 
-function YieldCurvePane({ focused, width, height }: PaneProps) {
+export function YieldCurvePane({ focused, width, height }: PaneProps) {
+  const [requestedDate, setRequestedDate] = usePaneSettingValue<string>("asOfDate", "");
+  const [draftDate, setDraftDate] = useState(requestedDate);
+  const [dateError, setDateError] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
+  const dateInput = useRef<InputRenderable>(null);
+  useEffect(() => { setDraftDate(requestedDate); }, [requestedDate]);
+  const loadCurve = useCallback(async () => ({
+    requestedDate,
+    points: completeYieldCurve(requestedDate
+      ? await loadHistoricalYieldCurve(requestedDate)
+      : await loadYieldCurve()),
+  }), [requestedDate]);
   const { data, loading, error, updatedAt: lastUpdated, load } = useAsyncResource(loadCurve);
-  const points = data ?? EMPTY_POINTS;
-  useAutoRefresh(lastUpdated, load);
-  const updatedAgo = useUpdatedAgo(lastUpdated);
+  // A pending date change must never relabel the previous curve as the new one.
+  const points = data?.requestedDate === requestedDate ? data.points : EMPTY_POINTS;
+  const refreshLatest = useCallback(() => { if (!requestedDate) void load(); }, [requestedDate, load]);
+  useAutoRefresh(lastUpdated, refreshLatest);
+  const updatedAgo = useUpdatedAgo(points.length ? lastUpdated : null);
+  const selectDate = (value: string) => {
+    try {
+      const nextDate = yieldCurveDate(value);
+      setRequestedDate(nextDate);
+      setDraftDate(nextDate);
+      setDateError(null);
+      setEditing(false);
+      if (dateInput.current?.setCursorOffset) dateInput.current.setCursorOffset(0);
+      else if (dateInput.current) dateInput.current.cursorOffset = 0;
+      dateInput.current?.blur?.();
+      if (nextDate === requestedDate) void load();
+    } catch (error) {
+      setDateError(error instanceof Error ? error.message : String(error));
+    }
+  };
 
   useShortcut((ev) => {
-    if (!focused) return;
-    if (ev.name === "r") {
-      load();
+    if (!focused || editing) return;
+    if (ev.name === "d") {
+      ev.preventDefault();
+      setEditing(true);
+      dateInput.current?.focus?.();
+    } else if (ev.name === "r") {
+      void load();
+    } else if (ev.name === "l") {
+      selectDate("");
     }
   });
 
@@ -58,11 +98,12 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
       ...(inverted ? [{ id: "inverted", parts: [{ text: "INVERTED", tone: "warning" as const, bold: true }] }] : []),
       ...(bp != null ? [{ id: "spread", parts: [{ text: `10Y − 2Y ${bp >= 0 ? "+" : ""}${bp}bp`, tone: bp < 0 ? "warning" as const : "muted" as const }] }] : []),
       ...(asOf ? [{ id: "as-of", parts: [{ text: `as of ${asOf}`, tone: "muted" as const }] }] : []),
+      ...(requestedDate && asOf && requestedDate !== asOf ? [{ id: "requested", parts: [{ text: `requested ${requestedDate} · prior published session`, tone: "muted" as const }] }] : []),
       ...(!asOf && points.length ? [{ id: "mixed-dates", parts: [{ text: "Mixed or unknown observation dates", tone: "warning" as const }] }] : []),
       ...(points.some((point) => point.yield == null) ? [{ id: "missing", parts: [{ text: "Some tenors unavailable", tone: "warning" as const }] }] : []),
       ...(points.some((point) => point.stale) ? [{ id: "stale", parts: [{ text: "Cached source · refresh failed", tone: "warning" as const }] }] : []),
       ...(updatedAgo ? [{ id: "updated", parts: [{ text: `updated ${updatedAgo}`, tone: "muted" as const }] }] : []),
-  ], [asOf, bp, inverted, updatedAgo, points]);
+  ], [asOf, bp, inverted, updatedAgo, points, requestedDate]);
   usePaneStatusFooter({
     registrationId: "yield-curve",
     loading,
@@ -70,26 +111,10 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
     info: yieldStatus,
   });
 
-  if (loading && points.length === 0) {
-    return (
-      <Box flexDirection="column" width={width} height={height}>
-        <PaneStatusBody loading align="center" loadingLabel="Loading yield curve..." />
-      </Box>
-    );
-  }
-
-  if (error && points.length === 0) {
-    return (
-      <Box flexDirection="column" width={width} height={height} padding={1} gap={1}>
-        <EmptyState status={error ? "error" : "empty"} title="Yield curve unavailable." message={error} />
-      </Box>
-    );
-  }
-
-  const validPoints = parseYieldPoints(points);
+  const validPoints = asOf ? parseYieldPoints(points) : [];
 
   const chartWidth = Math.max(10, width - 2);
-  const chartHeight = Math.min(18, Math.max(8, height - 5));
+  const chartHeight = Math.min(12, Math.max(6, height - 18));
 
   const palette = resolveChartPalette(colors, "positive");
 
@@ -103,16 +128,25 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
     volume: 0,
   }));
 
-  // Build maturity label row and yield value row for the table
-  const colWidth = Math.max(6, Math.floor((width - 2) / TREASURY_MATURITIES.length));
-  const maturityLabels = TREASURY_MATURITIES.map((m) => m.maturity.padEnd(colWidth)).join("").trimEnd();
-  const yieldValues = TREASURY_MATURITIES.map((m) => {
-    const pt = points.find((p) => p.maturity === m.maturity);
-    return formatYield(pt?.yield ?? null).padEnd(colWidth);
-  }).join("").trimEnd();
-
   return (
     <Box flexDirection="column" width={width} height={height}>
+      <Box flexDirection="row" paddingX={1} gap={1} alignItems="flex-end" flexShrink={0}>
+        <TextField label="As-of date" type="date" value={draftDate} width={12}
+          placeholder="YYYY-MM-DD" inputRef={dateInput} focused={focused && editing}
+          onChange={setDraftDate} onSubmit={selectDate}
+          onMouseDown={() => setEditing(true)} onBlur={() => setEditing(false)}
+          onKeyDown={(event) => {
+            if (event.name === "escape") { setEditing(false); dateInput.current?.blur?.(); }
+          }} />
+        <Button label="View" onPress={() => selectDate(draftDate)} compact />
+        <Button label="Latest" shortcut="l" onPress={() => selectDate("")} compact />
+        <Button label="Edit date" displayLabel="Date" shortcut="d" compact onPress={() => {
+          setEditing(true); dateInput.current?.focus?.();
+        }} />
+      </Box>
+      {dateError ? <Notice tone="negative">{dateError}</Notice> : null}
+      <PaneStatusBody loading={loading && points.length === 0} error={points.length === 0 ? error : null}
+        loadingLabel="Loading yield curve..." subject="yield curve">
       {/* Scrollable chart + table */}
       <ScrollBox flexGrow={1} scrollY focusable={false}>
         <Box flexDirection="column">
@@ -132,19 +166,20 @@ function YieldCurvePane({ focused, width, height }: PaneProps) {
             </Box>
           ) : (
             <Box paddingX={1} marginTop={1}>
-              <Text fg={colors.textMuted}>Not enough data for chart</Text>
+              <Text fg={colors.textMuted}>{points.length && !asOf ? "A curve requires matching observation dates" : "Not enough data for chart"}</Text>
             </Box>
           )}
 
-          {/* Maturity table */}
-          <Box paddingX={1} marginTop={1} height={1}>
-            <Text fg={colors.textDim}>{maturityLabels}</Text>
-          </Box>
-          <Box paddingX={1} height={1}>
-            <Text fg={colors.text}>{yieldValues}</Text>
+          <Box marginTop={1} height={12}>
+            <DataTableView columns={TABLE_COLUMNS} items={points} selection={{ kind: "none" }}
+              focused={focused && !editing} sortColumnId={null} sortDirection="asc" onHeaderClick={() => {}}
+              getItemKey={(point) => point.maturity} rootHeight={12} emptyStateTitle="No Treasury observations"
+              renderCell={(point, column) => ({ text: column.id === "yield" ? formatYield(point.yield)
+                : column.id === "asOf" ? point.asOf ?? "—" : point.maturity })} />
           </Box>
         </Box>
       </ScrollBox>
+      </PaneStatusBody>
     </Box>
   );
 }
@@ -157,7 +192,7 @@ export const yieldCurveModule: PluginModule = {
     component: YieldCurvePane,
     defaultPosition: "right",
     defaultMode: "floating",
-    defaultFloatingSize: { width: 80, height: 20 },
+    defaultFloatingSize: { width: 80, height: 28 },
   }],
   paneTemplates: [{
     id: "yield-curve-pane",
@@ -165,7 +200,8 @@ export const yieldCurveModule: PluginModule = {
     label: "Yield Curve",
     description: "US Treasury yield curve charted from FRED data.",
     keywords: ["yield", "curve", "treasury", "bonds", "rates", "gc", "interest"],
-    shortcut: { prefix: "GC" },
+    shortcut: { prefix: "GC", argPlaceholder: "YYYY-MM-DD", argKind: "text", argOptional: true },
     headless: yieldCurveHeadless,
+    createInstance: (_context, options) => ({ settings: { asOfDate: yieldCurveDate(options?.arg) } }),
   }],
 };

--- a/src/plugins/builtin/yield-curve/pane.test.tsx
+++ b/src/plugins/builtin/yield-curve/pane.test.tsx
@@ -1,0 +1,64 @@
+import { afterEach, expect, spyOn, test } from "bun:test";
+import { act, useReducer } from "react";
+import { apiClient } from "../../../api-client";
+import { emitKeypress, testRender } from "../../../renderers/opentui/test-utils";
+import { AppContext, PaneInstanceProvider, appReducer, createInitialState } from "../../../state/app/context";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
+import { cloneLayout, createDefaultConfig } from "../../../types/config";
+import { PluginRenderProvider } from "../../runtime";
+import { YieldCurvePane } from "./index";
+import { TREASURY_MATURITIES } from "./treasury-data";
+
+const id = "yield-curve:test";
+let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+let latestSpy: ReturnType<typeof spyOn> | undefined;
+let historySpy: ReturnType<typeof spyOn> | undefined;
+
+function Harness() {
+  const config = createDefaultConfig("/tmp/gloom-curve-test");
+  config.layout = { dockRoot: { kind: "pane", instanceId: id }, instances: [{ instanceId: id, paneId: "yield-curve", binding: { kind: "none" } }], floating: [], detached: [] };
+  config.layouts = [{ name: "Default", layout: cloneLayout(config.layout) }];
+  const initial = createInitialState(config);
+  initial.focusedPaneId = id;
+  const [state, dispatch] = useReducer(appReducer, initial);
+  return <AppContext value={{state, dispatch}}><PaneInstanceProvider paneId={id}>
+    <PluginRenderProvider pluginId="macro" runtime={createTestPluginRuntime()}>
+      <YieldCurvePane paneId={id} paneType="yield-curve" focused width={70} height={30} />
+    </PluginRenderProvider>
+  </PaneInstanceProvider></AppContext>;
+}
+
+async function frame() {
+  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); await setup!.renderOnce(); });
+}
+
+afterEach(async () => {
+  if (setup) await act(async () => { setup!.renderer.destroy(); });
+  setup = undefined;
+  latestSpy?.mockRestore(); historySpy?.mockRestore();
+});
+
+test("date submission hides the previous curve while pending and keeps controls available after failure", async () => {
+  latestSpy = spyOn(apiClient, "getCloudYieldCurve").mockResolvedValue(TREASURY_MATURITIES.map(({ maturity, years }) => ({ maturity, maturityYears: years, yield: 4.5, asOf: "2026-09-08" })));
+  let rejectHistory!: (error: Error) => void;
+  const pending = new Promise<never>((_resolve, reject) => { rejectHistory = reject; });
+  historySpy = spyOn(apiClient, "getCloudFredSeries").mockImplementation(() => pending);
+  await act(async () => { setup = await testRender(<Harness />, { width: 70, height: 30 }); });
+  await frame(); await frame();
+  expect(setup!.captureCharFrame()).toContain("2026-09-08");
+  await emitKeypress(setup!, { name: "d" });
+  await act(async () => { await setup!.mockInput.typeText("2024-03-02"); setup!.mockInput.pressEnter(); });
+  await frame();
+  expect(historySpy).toHaveBeenCalledTimes(10);
+  expect(setup!.captureCharFrame()).toContain("2024-03-02");
+  expect(setup!.captureCharFrame()).toContain("Loading yield curve");
+  expect(setup!.captureCharFrame()).not.toContain("2026-09-08");
+  await act(async () => { rejectHistory(new Error("offline")); });
+  await frame();
+  expect(setup!.captureCharFrame()).toContain("No Treasury observations");
+  expect(setup!.captureCharFrame()).toContain("As-of date");
+  expect(setup!.captureCharFrame()).toContain("Latest");
+  await emitKeypress(setup!, { name: "l" });
+  await frame();
+  expect(setup!.captureCharFrame()).toContain("2026-09-08");
+});


### PR DESCRIPTION
Researchers could only open the latest Treasury curve, and `GC --date` was rejected despite historical FRED observations being available. Add a persisted as-of date selector and `GC [YYYY-MM-DD]` / `--date` support using the existing FRED API. A request for Saturday 2024-03-02 now shows Friday 2024-03-01, with 2Y 4.54%, 10Y 4.19%, and a −35 bp spread.

Choose one observation date across tenors, retain missing maturities as unavailable, and mark partial/stale CLI results incomplete. Hide the previous curve during date changes, keep controls usable after errors, and retain the last good curve after a failed refresh of the same date. The table exposes every tenor's observation date. Also clamp daily “1Y ago” comparisons from February 29 to February 28, and preserve the first digit of a submitted date in the terminal input.

Validation: 15 focused tests / 60 assertions, browser and OpenTUI TypeScript checks, and `git diff --check` pass. Live CLI and Chrome checks matched all ten FRED observations for 2024-02-29 and the 2024-03-02 weekend request; terminal keyboard selection was exercised in tmux. Chrome checked at 1280×900 and 390×844, with no relevant console errors after interactions. Local development-server restarts caused expected WebSocket reconnect warnings.

Historical results use current FRED observation history, not release vintages. Missing-tenor, metadata failure, and stale-source cases are regression fixtures; production failures were not induced. Source convention: [FRED DGS10](https://fred.stlouisfed.org/series/DGS10). No backend changes or release are required.
