### PR TITLE
Fix chart session data and research workflow state

### DIFF
--- a/src/components/data-table/view.test.tsx
+++ b/src/components/data-table/view.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { act, useState } from "react";
+import type { ScrollBoxRenderable } from "@opentui/core";
 import { emitKeypress as emitTuiKeypress, testRender, type TestKeyEvent } from "../../renderers/opentui/test-utils";
 import {
   AppContext,
@@ -132,6 +133,47 @@ function LargeSelectionHarness({
   );
 }
 
+let setDeferredRows: ((rows: Row[]) => void) | undefined;
+let setRequestedIndex: ((index: number) => void) | undefined;
+
+function DeferredScrollHarness({ onScroll, initialRows = [], initialIndex = 500, controlSelection = false }: {
+  onScroll?: (source?: "programmatic" | "user") => void;
+  initialRows?: Row[];
+  initialIndex?: number;
+  controlSelection?: boolean;
+}) {
+  const [items, setItems] = useState<Row[]>(initialRows);
+  const [requestedIndex, requestIndex] = useState(initialIndex);
+  setDeferredRows = setItems;
+  setRequestedIndex = requestIndex;
+  const state = createInitialState(createDefaultConfig("/tmp/gloomberb-table-deferred-scroll"));
+  return (
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <PaneInstanceProvider paneId="deferred-scroll-test">
+        <DataTableView<Row, Column>
+          focused
+          selection={controlSelection
+            ? { kind: "index", selectedIndex: requestedIndex, onChange: requestIndex }
+            : { kind: "none" }}
+          columns={columns}
+          items={items}
+          sortColumnId={null}
+          sortDirection="asc"
+          onHeaderClick={() => {}}
+          getItemKey={(row) => row.id}
+          renderCell={(row) => ({ text: row.title })}
+          emptyStateTitle="Loading rows"
+          bodyScrollId="deferred-scroll-body"
+          scrollToIndex={requestedIndex}
+          scrollToIndexAlign="center"
+          resetScrollKey="contract-chain"
+          onBodyScrollActivity={onScroll}
+        />
+      </PaneInstanceProvider>
+    </AppContext>
+  );
+}
+
 async function renderSettled() {
   await act(async () => {
     await testSetup!.renderOnce();
@@ -244,4 +286,40 @@ describe("DataTableView", () => {
 
     expect(renderedCells - beforeNavigation).toBeLessThanOrEqual(4);
   });
+});
+
+test("fulfills a center request after rows are laid out and then leaves manual scrolling alone", async () => {
+  const scrollSources: Array<"programmatic" | "user" | undefined> = [];
+  testSetup = await testRender(
+    <DeferredScrollHarness onScroll={(source) => scrollSources.push(source)} />,
+    { width: 60, height: 12 },
+  );
+  await renderSettled();
+  await act(async () => { setDeferredRows!(largeRows); });
+  await renderSettled();
+  const body = testSetup.renderer.root.findDescendantById("deferred-scroll-body") as ScrollBoxRenderable;
+  expect(body.scrollTop).toBe(500 - Math.floor(body.viewport.height / 2));
+  expect(testSetup.captureCharFrame()).toContain("Row 500");
+  expect(scrollSources.at(-1)).toBe("programmatic");
+
+  await act(async () => { body.scrollTo(50); });
+  await renderSettled();
+  await act(async () => { setDeferredRows!([...largeRows, { type: "row", id: "new", title: "New row" }]); });
+  await renderSettled();
+  expect(body.scrollTop).toBe(50);
+  expect(scrollSources.at(-1)).toBe("user");
+});
+
+
+test("an external selection and scroll request cannot be reversed by the previous cursor", async () => {
+  testSetup = await testRender(
+    <DeferredScrollHarness initialRows={largeRows} initialIndex={0} controlSelection />,
+    { width: 60, height: 12 },
+  );
+  await renderSettled();
+  await act(async () => { setRequestedIndex!(500); });
+  await renderSettled();
+  const body = testSetup.renderer.root.findDescendantById("deferred-scroll-body") as ScrollBoxRenderable;
+  expect(body.scrollTop).toBe(500 - Math.floor(body.viewport.height / 2));
+  expect(testSetup.captureCharFrame()).toContain("Row 500");
 });

--- a/src/components/data-table/view.tsx
+++ b/src/components/data-table/view.tsx
@@ -318,10 +318,14 @@ export function DataTableView<
       || previous.key !== current.key;
     const selectedRowAppeared = !previous?.resolved && current.resolved;
     if (selectionChanged || selectedRowAppeared) {
-      requestSelectionScroll(effectiveSelectedIndex);
+      // An external selection renders before the optimistic cursor's syncing
+      // effect commits. Scroll to the new selection, retaining an immediate
+      // cursor only while a keyboard navigation commit is still pending.
+      requestSelectionScroll(pendingCommitRef.current ? effectiveSelectedIndex : defaultCursorIndex);
     }
   }, [
     clearSelectionScrollTarget,
+    defaultCursorIndex,
     effectiveSelectedIndex,
     requestSelectionScroll,
     scrollToIndex,

--- a/src/components/ui/data-table/opentui/index.tsx
+++ b/src/components/ui/data-table/opentui/index.tsx
@@ -8,6 +8,7 @@ import { measurePerf } from "../../../../utils/perf-marks";
 import { useDoubleClickActivation } from "../../../use-double-click-activation";
 import { useScrollBoxScrollActivity } from "../../../table-view-shared";
 import { EmptyState } from "../../status";
+import { observeScrollBoxContentSize } from "../../../../renderers/opentui/scrollbox-layout";
 import {
   expandTableColumns,
   fitTableCellText,
@@ -235,6 +236,7 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
   const nativeRenderer = useNativeRenderer();
   const [scrollVersion, setScrollVersion] = useState(0);
   const lastAppliedScrollRequestRef = useRef<string | null>(null);
+  const controlledScrollTopRef = useRef<number | null>(null);
   const lastVisibleRangeRef = useRef<{
     key: string | number | undefined;
     range: DataTableVisibleRange;
@@ -323,10 +325,15 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
     if (virtualize) {
       setScrollVersion((current) => current + 1);
     }
-    onBodyScrollActivity();
+    const controlledTop = controlledScrollTopRef.current;
+    controlledScrollTopRef.current = null;
+    const source = controlledTop !== null && scrollRef.current?.scrollTop === controlledTop
+      ? "programmatic"
+      : "user";
+    onBodyScrollActivity(source);
     emitVisibleRange();
     nativeRenderer.requestRender();
-  }, [emitVisibleRange, nativeRenderer, onBodyScrollActivity, virtualize]);
+  }, [emitVisibleRange, nativeRenderer, onBodyScrollActivity, scrollRef, virtualize]);
   useScrollBoxScrollActivity({
     scrollRef,
     onVerticalScroll: handleBodyScrollActivity,
@@ -334,11 +341,11 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
   });
   const handleBodySizeChange = useCallback(() => {
     measureContentWidth();
-    if (virtualize) {
-      setScrollVersion((current) => current + 1);
-    }
+    setScrollVersion((current) => current + 1);
     queueMicrotask(emitVisibleRange);
-  }, [emitVisibleRange, measureContentWidth, virtualize]);
+  }, [emitVisibleRange, measureContentWidth]);
+
+  useEffect(() => observeScrollBoxContentSize(scrollRef.current, handleBodySizeChange), [handleBodySizeChange, scrollRef]);
 
   useEffect(() => {
     emitVisibleRange();
@@ -350,9 +357,14 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
   }, [dispatch, paneInstanceId]);
 
   const applyScrollToIndex = useCallback(() => {
-    if (scrollToIndex == null || items.length === 0) return true;
+    if (scrollToIndex == null) return true;
+    if (items.length === 0) return false;
     const scrollBox = scrollRef.current;
-    if (!scrollBox?.viewport) return false;
+    // An empty or unmeasured body clamps scrollTo to zero. Keep the request
+    // pending until the rows and viewport have completed native layout.
+    if (!scrollBox?.viewport
+      || scrollBox.viewport.height <= 0
+      || scrollBox.scrollHeight < items.length) return false;
 
     const targetIndex = Math.max(0, Math.min(scrollToIndex, items.length - 1));
     const visibleHeight = Math.max(
@@ -370,6 +382,7 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
 
     if (nextTop === currentTop) return true;
     scrollBox.scrollTo(nextTop);
+    controlledScrollTopRef.current = scrollBox.scrollTop;
     return scrollBox.scrollTop === nextTop;
   }, [
     appViewport.height,
@@ -414,6 +427,7 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
     const scrollRequestKey = [
       scrollToIndex,
       scrollToIndexVersion,
+      scrollToIndexAlign,
       measuredViewportHeight ?? "pending",
     ].join(":");
     if (lastAppliedScrollRequestRef.current === scrollRequestKey) return;
@@ -422,22 +436,15 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
       lastAppliedScrollRequestRef.current = scrollRequestKey;
       return;
     }
-    let cancelled = false;
-    const retry = () => {
-      if (cancelled) return;
-      if (applyScrollToIndex()) {
-        lastAppliedScrollRequestRef.current = scrollRequestKey;
-      }
-    };
-    process.nextTick(retry);
-    return () => {
-      cancelled = true;
-    };
+    // Body/content size events retry a pending request after measurement;
+    // completed requests remain consumed while users scroll or rows append.
   }, [
     applyScrollToIndex,
     measuredViewportHeight,
     scrollToIndex,
+    scrollToIndexAlign,
     scrollToIndexVersion,
+    scrollVersion,
   ]);
 
   return (

--- a/src/plugins/builtin/dividend-yield/pane.tsx
+++ b/src/plugins/builtin/dividend-yield/pane.tsx
@@ -195,7 +195,7 @@ export function DividendYieldPane({ focused, width, height, loadData = fetchDivi
   quoteRef.current = { price: quotePrice, currency: quoteCurrency };
 
   const request = useCallback(() => loadData(symbol!, quoteRef.current.price, exchange, quoteRef.current.currency), [exchange, loadData, symbol]);
-  const { data, loading, error, updatedAt, reload: refresh } = useAsyncResource(symbol ? request : null, { clearOnError: true });
+  const { data, loading, error, updatedAt, reload: refresh } = useAsyncResource(symbol ? request : null);
   useEffect(() => { if (updatedAt !== null) setSelectedIdx(0); }, [updatedAt]);
 
   usePaneFooter("dividend-yield", () => ({

--- a/src/plugins/builtin/options/view.test.tsx
+++ b/src/plugins/builtin/options/view.test.tsx
@@ -233,7 +233,9 @@ test("streams live quotes without resetting manual scroll", async () => {
   });
   await renderSettled();
 
-  const targets = subscriptions.at(-1) ?? [];
+  const subscribedTargets = subscriptions.at(-1) ?? [];
+  expect(subscribedTargets.some((target) => target.symbol === "AAPL" && target.exchange !== "OPTIONS")).toBe(true);
+  const targets = subscribedTargets.filter((target) => target.exchange === "OPTIONS");
   expect(targets.length).toBeGreaterThan(16);
   expect(targets.length).toBeLessThanOrEqual(80);
   expect(targets.filter((target) => target.visible === true).length).toBeGreaterThan(16);
@@ -291,6 +293,32 @@ test("streams live quotes without resetting manual scroll", async () => {
   });
   await renderSettled();
   expect(bodyScroll.scrollTop).toBe(0);
+});
+
+test("a standalone chain subscribes to its underlying and resolves ATM without a research pane", async () => {
+  let targets: QuoteSubscriptionTarget[] = [];
+  let emit: ((target: QuoteSubscriptionTarget, quote: Quote) => void) | undefined;
+  const provider = createTestDataProvider({
+    getTickerFinancials: async () => ({ annualStatements: [], quarterlyStatements: [], priceHistory: [] }),
+    getOptionsChain: async () => makeChain(Array.from({ length: 100 }, (_, index) => 50 + index), 120),
+    subscribeQuotes: (nextTargets, onQuote) => {
+      targets = nextTargets;
+      emit = onQuote;
+      return () => {};
+    },
+  });
+  setSharedMarketDataCoordinator(new MarketDataCoordinator(provider));
+  await act(async () => {
+    testSetup = await testRender(<OptionsHarness ticker={makeTicker("AAPL")} />, { width: 124, height: 16 });
+  });
+  await renderSettled();
+  const underlying = targets.find((target) => target.symbol === "AAPL");
+  expect(underlying).toBeDefined();
+  await act(async () => { emit!(underlying!, makeFinancials(120.2).quote!); });
+  await renderSettled();
+  const scrollBox = testSetup!.renderer.root.findDescendantById("options-table-body-scroll") as ScrollBoxRenderable;
+  expect(scrollBox.scrollTop).toBeGreaterThan(0);
+  expect(testSetup!.captureCharFrame()).toContain("ATM IV 20.0%");
 });
 
 test("lets the expiration tab row use the full available width", async () => {

--- a/src/plugins/builtin/options/view.tsx
+++ b/src/plugins/builtin/options/view.tsx
@@ -15,7 +15,8 @@ import {
   type DataTableVisibleRange,
 } from "../../../components";
 import { useShortcut } from "../../../react/input";
-import { useLiveQuoteEntries } from "../../../state/hooks/quote-streaming";
+import { useLiveQuoteEntries, useQuoteUpdates } from "../../../state/hooks/quote-streaming";
+import { quoteSubscriptionTargetFromTicker } from "../../../market-data/request-types";
 import { usePluginAppActions } from "../../runtime";
 import {
   OPTIONS_CALCULATOR_TEMPLATE_ID,
@@ -107,6 +108,14 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
   const parsed = target?.parsedOption ?? null;
   const effectiveTicker = target?.effectiveTicker ?? "";
   const effectiveExchange = target?.effectiveExchange ?? "";
+  const underlyingQuoteTarget = isOpt
+    ? effectiveTicker ? { symbol: effectiveTicker, exchange: effectiveExchange, route: "provider" as const } : null
+    : quoteSubscriptionTargetFromTicker(ticker, effectiveTicker, "provider");
+  // A standalone chain has no parent research pane to subscribe to its stock.
+  // Its spot, ATM selection and Greeks must update independently of other panes.
+  useQuoteUpdates(underlyingQuoteTarget ? [{
+    ...underlyingQuoteTarget, surface: "options", visible: true, selected: true, weight: 100,
+  }] : [], { liveStreaming });
   const underlyingFinancials = useTickerFinancials(isOpt ? effectiveTicker : null, null);
   const underlying = isOpt ? underlyingFinancials : financials;
   const spot = underlying?.quote?.price;

--- a/src/react/async-resource.test.tsx
+++ b/src/react/async-resource.test.tsx
@@ -57,9 +57,12 @@ test("changing, disabling, and unmounting a resource invalidate pending work", a
 });
 
 test.each([false, true])("refresh failure clears data only when configured: %s", async (clearOnError) => {
-  await mount(async () => "cached", clearOnError);
+  await mount(async (force) => {
+    if (force) throw new Error("");
+    return "cached";
+  }, clearOnError);
   await act(async () => {
-    changeLoader(() => { throw new Error(""); });
+    await resource.reload();
   });
   expect(resource).toMatchObject({
     data: clearOnError ? null : "cached",
@@ -67,4 +70,14 @@ test.each([false, true])("refresh failure clears data only when configured: %s",
     error: "",
     status: "error",
   });
+});
+
+test("a new security cannot display the previous security's loaded data while pending or failed", async () => {
+  await mount(async () => "AAPL history");
+  expect(resource.data).toBe("AAPL history");
+  const next = Promise.withResolvers<string>();
+  await act(async () => { changeLoader(() => next.promise); });
+  expect(resource).toMatchObject({ data: null, updatedAt: null, loading: true, error: null });
+  await act(async () => { next.reject(new Error("MSFT unavailable")); });
+  expect(resource).toMatchObject({ data: null, updatedAt: null, loading: false, error: "MSFT unavailable" });
 });

--- a/src/react/async-resource.ts
+++ b/src/react/async-resource.ts
@@ -12,7 +12,8 @@ export function useAsyncResource<T>(
   loader: ((force: boolean) => Promise<T>) | null,
   options: { initialData?: () => T | null; clearOnError?: boolean } = {},
 ) {
-  const [state, setState] = useState<ResourceState<T>>(() => ({
+  const [state, setState] = useState<ResourceState<T> & { owner: typeof loader }>(() => ({
+    owner: loader,
     data: options.initialData?.() ?? null,
     loading: !!loader,
     error: null,
@@ -23,14 +24,16 @@ export function useAsyncResource<T>(
   const load = useCallback(async (force = false) => {
     const currentGeneration = ++generation.current;
     if (!loader) {
-      setState({ data: null, loading: false, error: null, updatedAt: null });
+      setState({ owner: loader, data: null, loading: false, error: null, updatedAt: null });
       return;
     }
-    setState((current) => ({ ...current, loading: true, error: null }));
+    setState((current) => current.owner === loader
+      ? { ...current, loading: true, error: null }
+      : { owner: loader, data: null, loading: true, error: null, updatedAt: null });
     try {
       const data = await loader(force);
       if (generation.current === currentGeneration) {
-        setState({ data, loading: false, error: null, updatedAt: Date.now() });
+        setState({ owner: loader, data, loading: false, error: null, updatedAt: Date.now() });
       }
     } catch (error) {
       if (generation.current === currentGeneration) {
@@ -50,6 +53,10 @@ export function useAsyncResource<T>(
   }, [load]);
 
   const reload = useCallback(() => load(true), [load]);
-  const status = state.error !== null ? "error" : state.data !== null ? "loaded" : state.loading ? "loading" : "idle";
-  return { ...state, status, load, reload };
+  // Hide a previous resource during the render before the new loader's effect
+  // runs, as well as throughout a failed request for the new security.
+  const { data, loading, error, updatedAt } = state.owner === loader ? state
+    : { data: null, loading: !!loader, error: null, updatedAt: null };
+  const status = error !== null ? "error" : data !== null ? "loaded" : loading ? "loading" : "idle";
+  return { data, loading, error, updatedAt, status, load, reload };
 }

--- a/src/renderers/opentui/scrollbox-layout.ts
+++ b/src/renderers/opentui/scrollbox-layout.ts
@@ -1,0 +1,24 @@
+import type { ScrollBoxRenderable as NativeScrollBoxRenderable } from "@opentui/core";
+import type { ScrollBoxRenderable } from "../../ui/host";
+
+/** Observe computed native content layout after ScrollBox updates its range. */
+export function observeScrollBoxContentSize(
+  scrollBox: ScrollBoxRenderable | null,
+  onSizeChange: () => void,
+): (() => void) | undefined {
+  const content = (scrollBox as NativeScrollBoxRenderable | null)?.content;
+  if (!content) return;
+  // Computed layout invokes onSizeChange, not the explicit resize event.
+  // Preserve the internal handler that recalculates the scrollbars.
+  const previousSizeChange = content.onSizeChange;
+  const handleContentSizeChange = () => {
+    previousSizeChange?.call(content);
+    onSizeChange();
+  };
+  content.onSizeChange = handleContentSizeChange;
+  return () => {
+    if (content.onSizeChange === handleContentSizeChange) {
+      content.onSizeChange = previousSizeChange;
+    }
+  };
+}

--- a/src/time-series/chart-data.test.ts
+++ b/src/time-series/chart-data.test.ts
@@ -17,6 +17,38 @@ function quoteFixture(overrides: Partial<Quote> = {}): Quote {
 }
 
 describe("appendLiveQuotePoint", () => {
+  test("merges daily quote updates by session for date labels and opening timestamps", () => {
+    const now = Date.parse("2026-09-10T18:44:00Z");
+    const quote = quoteFixture({ price: 39.75, lastUpdated: now });
+    for (const date of ["2026-09-10T00:00:00Z", "2026-09-10T13:30:00Z"]) {
+      const history = [{ date: new Date(date), open: 40, high: 41, low: 39, close: 39.77, volume: 1000 }];
+      const updated = appendLiveQuotePoint(history, quote, { now, mode: "ohlc", resolution: "1d" });
+      expect(updated).toHaveLength(1);
+      expect(updated[0]).toMatchObject({ close: 39.75, open: 40, high: 41, low: 39, volume: 1000 });
+      expect(history[0]?.close).toBe(39.77);
+    }
+  });
+
+  test("does not merge the next premarket into yesterday's daily bar within 24 hours", () => {
+    const now = Date.parse("2026-09-11T12:00:00Z");
+    const history = [{ date: new Date("2026-09-10T13:30:00Z"), close: 100 }];
+    const updated = appendLiveQuotePoint(history, quoteFixture({
+      price: 100, preMarketPrice: 105, marketState: "PRE", lastUpdated: now,
+    }), { now, mode: "ohlc", resolution: "1d" });
+    expect(updated).toHaveLength(2);
+    expect(updated[0]?.close).toBe(100);
+    expect(updated[1]?.close).toBe(105);
+  });
+
+  test("keeps an after-hours quote in its exchange session across UTC midnight", () => {
+    const now = Date.parse("2026-09-11T00:01:00Z");
+    const updated = appendLiveQuotePoint([{ date: new Date("2026-09-10T00:00:00Z"), close: 100 }],
+      quoteFixture({ price: 100, postMarketPrice: 105, marketState: "POST", lastUpdated: now - 60_000 }),
+      { now, mode: "ohlc", resolution: "1d" });
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.close).toBe(105);
+  });
+
   test("extends coarse chart histories with a fresh quote tail", () => {
     const history: PricePoint[] = [
       { date: new Date("2026-05-04T00:00:00Z"), close: 56 },
@@ -172,7 +204,7 @@ describe("appendLiveQuotePoint", () => {
         price: 346.27,
         lastUpdated: Date.parse("2026-07-22T18:52:00Z"),
       }),
-      Date.parse("2026-07-22T18:53:00Z"),
+      { now: Date.parse("2026-07-22T18:53:00Z") },
     );
 
     expect(extended).toBe(history);

--- a/src/time-series/chart-data.ts
+++ b/src/time-series/chart-data.ts
@@ -1,6 +1,7 @@
 import type { PricePoint, Quote } from "../types/financials";
 import { isQuoteStaleForCurrentSession } from "../market-data/quotes/freshness";
 import { hasLikelyQuoteUnitMismatch } from "../utils/currency-units";
+import { resolveExchangeTimeZone } from "../utils/exchanges";
 import {
   CHART_RESOLUTION_STEP_MS,
   type ManualChartResolution,
@@ -20,6 +21,7 @@ export type AppendLiveQuotePointOptions =
     now?: number;
     mode: "ohlc";
     resolution: ManualChartResolution;
+    exchange?: string;
   };
 
 function coerceDate(value: Date | string | number): Date {
@@ -44,13 +46,27 @@ function quoteBelongsToLatestBar(
   latestTime: number,
   quoteTime: number,
   resolution: ManualChartResolution,
+  exchange?: string,
 ): boolean {
   if (quoteTime < latestTime) return false;
-  if (resolution === "1mo") {
-    const latestDate = new Date(latestTime);
-    const quoteDate = new Date(quoteTime);
-    return latestDate.getUTCFullYear() === quoteDate.getUTCFullYear()
-      && latestDate.getUTCMonth() === quoteDate.getUTCMonth();
+  if (resolution === "1d" || resolution === "1wk" || resolution === "1mo") {
+    const zone = resolveExchangeTimeZone(exchange) ?? "UTC";
+    // Vendors use both UTC date labels and actual session-opening timestamps.
+    // A daily bar belongs to a calendar session, not the next rolling 24 hours.
+    const key = (timestamp: number, dateLabel: boolean) => {
+      const day = dateLabel ? new Date(timestamp).toISOString().slice(0, 10) :
+        new Intl.DateTimeFormat("en-CA", {
+          timeZone: zone, year: "numeric", month: "2-digit", day: "2-digit",
+        }).format(new Date(timestamp));
+      if (resolution === "1mo") return day.slice(0, 7);
+      if (resolution === "1wk") {
+        const monday = new Date(`${day}T00:00:00Z`);
+        monday.setUTCDate(monday.getUTCDate() - (monday.getUTCDay() + 6) % 7);
+        return monday.toISOString().slice(0, 10);
+      }
+      return day;
+    };
+    return key(latestTime, latestTime % 86_400_000 === 0) === key(quoteTime, false);
   }
   return quoteTime - latestTime < CHART_RESOLUTION_STEP_MS[resolution];
 }
@@ -117,7 +133,7 @@ export function appendLiveQuotePoint(
   }
 
   if (options.mode === "ohlc") {
-    if (quoteBelongsToLatestBar(latestTime, quoteTime, options.resolution)) {
+    if (quoteBelongsToLatestBar(latestTime, quoteTime, options.resolution, options.exchange || quote.listingExchangeName || quote.exchangeName)) {
       const merged = mergeQuoteIntoLatestBar(latest, quotePrice);
       return [...points.slice(0, -1), merged];
     }

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -1459,6 +1459,51 @@ describe("resolveChartSpecData", () => {
     expect(sma?.points.at(-1)?.date.getTime()).toBe(quoteTime);
   });
 
+  test.each(["line", "candles"] as const)("keeps one daily bar when a live quote updates a %s chart", async (style) => {
+    const now = Date.parse("2026-09-10T18:44:00Z");
+    const source = { kind: "security" as const, instrument: { symbol: "SQQQ", exchange: "NASDAQ" }, fieldId: "market.close" };
+    const provider = createTestDataProvider({
+      getPriceHistoryForResolution: async () => [{
+        date: new Date("2026-09-10T13:30:00Z"), open: 40, high: 41, low: 39, close: 39.77, volume: 1000,
+      }],
+    });
+    const result = await resolveChartSpecData(chartSpec({
+      viewport: { range: "1M", resolution: "1d" },
+      series: [{ id: "price", source, style, transform: "raw", axis: "left", panelId: "main", interpolation: "none" }],
+    }), {
+      dataProvider: provider,
+      now: new Date(now),
+      quoteOverrides: new Map([[chartQuoteOverrideKeyForSource(source), {
+        symbol: "SQQQ", price: 39.75, currency: "USD", change: 0, changePercent: 0,
+        lastUpdated: now, listingExchangeName: "NASDAQ", marketState: "REGULAR",
+      }]]),
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.series[0]?.points).toHaveLength(1);
+    expect(result.series[0]?.points[0]).toMatchObject({ value: 39.75, open: 40, high: 41, low: 39, volume: 1000 });
+  });
+
+  test("retains the known listing session when the quote omits exchange metadata", async () => {
+    const now = Date.parse("2026-09-11T00:01:00Z");
+    const source = { kind: "security" as const, instrument: { symbol: "SQQQ", exchange: "NASDAQ" }, fieldId: "market.close" };
+    const result = await resolveChartSpecData(chartSpec({
+      viewport: { range: "1M", resolution: "1d" },
+      series: [{ id: "price", source, style: "line", transform: "raw", axis: "left", panelId: "main", interpolation: "none" }],
+    }), {
+      dataProvider: createTestDataProvider({ getPriceHistoryForResolution: async () => [
+        { date: new Date("2026-09-10T00:00:00Z"), close: 100 },
+      ] }),
+      now: new Date(now),
+      quoteOverrides: new Map([[chartQuoteOverrideKeyForSource(source), {
+        symbol: "SQQQ", price: 100, postMarketPrice: 105, currency: "USD", change: 0, changePercent: 0,
+        lastUpdated: now - 60_000, marketState: "POST",
+      }]]),
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.series[0]?.points).toHaveLength(1);
+    expect(result.series[0]?.points[0]?.value).toBe(105);
+  });
+
   test("reuses raw source loads while live quotes recompute the chart tail", async () => {
     const now = Date.parse("2026-05-15T20:30:00Z");
     const source = {

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -40,7 +40,6 @@ import {
   maxStudyWarmupPoints,
   resolveStudies,
 } from "./studies";
-import { isOhlcSeriesStyle } from "./spec";
 import { applyResolvedSeriesTransform } from "./transforms";
 import { clipSeriesToWindow } from "./alignment";
 import { chartQuoteOverrideKeyForSource } from "./live-quotes";
@@ -556,11 +555,12 @@ function mergeHistory(
   quoteOverride: Quote | undefined,
   now: number,
   liveBarResolution?: ManualChartResolution,
+  exchange?: string,
 ): TickerFinancials {
   const base = financials ?? emptyFinancials();
   const quote = latestQuote(base.quote, quoteOverride);
   const priceHistory = appendLiveQuotePoint(history, quote, liveBarResolution
-    ? { now, mode: "ohlc", resolution: liveBarResolution }
+    ? { now, mode: "ohlc", resolution: liveBarResolution, exchange }
     : { now });
   return { ...base, quote, priceHistory };
 }
@@ -1112,9 +1112,11 @@ export async function resolveChartSpecData(
         ]);
         resolvedSource = sourceWithResolvedExchange(source, financials);
       }
-      const liveBarResolution = isOhlcSeriesStyle(seriesSpec.style) ? initialResolution : undefined;
+      // Display style does not change the sampling interval: line and candle
+      // charts must merge a live quote into the same active price bar.
+      const liveBarResolution = initialResolution;
       const merged = history
-        ? mergeHistory(financials, history, quoteOverride, referenceNow.getTime(), liveBarResolution)
+        ? mergeHistory(financials, history, quoteOverride, referenceNow.getTime(), liveBarResolution, resolvedSource.instrument.exchange)
         : quoteOverride && financials
           ? { ...financials, quote: latestQuote(financials.quote, quoteOverride) }
           : financials;

--- a/src/time-series/transforms.test.ts
+++ b/src/time-series/transforms.test.ts
@@ -33,6 +33,20 @@ function series(id: string, points: TimeSeriesPoint[], interpolation: ResolvedSe
 }
 
 describe("series transformations", () => {
+  test("price display transforms preserve supporting share volume", () => {
+    const points = [
+      { ...point("2024-01-01", 10), open: 9, high: 11, low: 8, close: 10, volume: 1000 },
+      { ...point("2024-01-02", 15), open: 12, high: 16, low: 11, close: 15, volume: 2000 },
+    ];
+    for (const transform of ["percent", "index100", "log", "yoy"] as const) {
+      const transformed = applySeriesTransform(points, transform);
+      expect(transformed.map(({ volume }) => volume)).toEqual([1000, 2000]);
+    }
+    expect(applySeriesTransform(points, "percent")[1]).toMatchObject({ value: 50, close: 50, open: 20 });
+    const volumes = points.map((point) => ({ ...point, value: point.volume }));
+    expect(applySeriesTransform(volumes, "percent").map(({ value }) => value)).toEqual([0, 100]);
+  });
+
   test("normalizes to percent and index 100 from the first nonzero observation", () => {
     const points = [point("2024-01-01", 10), point("2024-02-01", 15), point("2024-03-01", 20)];
     expect(applySeriesTransform(points, "percent").map(({ value }) => value)).toEqual([0, 50, 100]);

--- a/src/time-series/transforms.ts
+++ b/src/time-series/transforms.ts
@@ -1,7 +1,9 @@
 import type { ResolvedSeries, SeriesTransform, TimeSeriesPoint } from "./types";
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
-const NUMERIC_POINT_FIELDS = ["value", "open", "high", "low", "close", "volume"] as const;
+// Volume is separate supporting data, not another price. A volume series has
+// its primary measurement in `value`, which still receives the transform.
+const NUMERIC_POINT_FIELDS = ["value", "open", "high", "low", "close"] as const;
 
 function finiteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);


### PR DESCRIPTION
Research comparisons could add a second observation for the current session and apply price normalization to share volume. A ticker change could also display the previous security's data while loading or after failure, and a standalone options chain could remain without its underlying quote or open far from the relevant strike.

This change merges live prices into calendar/session bars independently of line/candle style, preserves supporting volume, isolates async data by resource, and preserves valid dividend history during refresh errors. Standalone options subscribe to their underlying; native tables fulfill selection scrolling after layout and preserve subsequent manual scrolling.

Validation:
- Full suite: 2,809 tests passed, 10,281 assertions. All six runtime TypeScript checks and web build passed; OpenTUI checks rerun after moving layout observation into the renderer adapter.
- Regression tests cover daily/weekly/monthly boundaries, exchange-local sessions, missing quote venue metadata, normalized volume, ticker request ownership, late underlying quotes, delayed native layout and manual scrolling.
- Live QQQ/TQQQ/SQQQ 1M CLI comparison now has 22 observations and 22 unique dates per series, with original integer share volumes. Before, SQQQ had a duplicate current-session point and transformed volume.
- Fresh native OMON NVDA session independently loads its stock quote and ATM/Greeks; relevant strike is visible after cold and warm loads, and manual scrolling survives updates.
- Browser desktop/narrow checks exposed an additional range-selection/seed-data problem: the selected 1M tab could still show decades of cached history. This is being investigated separately; this PR does not claim that workflow passes. Browser plugin unavailable; Playwriter headless Chrome used. Authenticated dividend refresh behavior covered by isolated tests; anonymous browser correctly shows the account requirement.

No version bump or GitHub release.
