### PR TITLE
Require known cash and debt for enterprise value multiples

### DIFF
--- a/src/components/data-table/view.test.tsx
+++ b/src/components/data-table/view.test.tsx
@@ -175,10 +175,14 @@ function DeferredScrollHarness({ onScroll, initialRows = [], initialIndex = 500,
 }
 
 async function renderSettled() {
-  await act(async () => {
-    await testSetup!.renderOnce();
-    await testSetup!.renderOnce();
-  });
+  // Commit React's measurement/scroll effects between native frames, then
+  // paint the resulting viewport. One act around every frame can leave the
+  // numeric scroll offset updated while the captured frame is still old.
+  for (let phase = 0; phase < 3; phase += 1) {
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+  }
 }
 
 const emitKeypress = (event: TestKeyEvent) => emitTuiKeypress(testSetup!, event);

--- a/src/time-series/fundamentals.test.ts
+++ b/src/time-series/fundamentals.test.ts
@@ -462,6 +462,34 @@ describe("fundamental series extraction", () => {
     });
   });
 
+  test("enterprise-value multiples require known debt and cash, while explicit zeros remain valid", () => {
+    const statement: FinancialStatement = {
+      date: "2024-12-31",
+      availableAt: "2025-02-01",
+      totalRevenue: 100,
+      ebitda: 25,
+      basicShares: 10,
+      totalDebt: 0,
+      cashAndCashEquivalents: 0,
+    };
+    const snapshot = (row: FinancialStatement): TickerFinancials => ({
+      ...financials([], [row], [{ date: new Date("2025-01-31T00:00:00Z"), close: 100 }]),
+      quote: { symbol: "TEST", price: 100, currency: "USD", change: 0, changePercent: 0,
+        lastUpdated: Date.parse("2025-03-01T16:00:00Z") },
+    });
+    for (const [field, expected] of [["valuation.evSales", 10], ["valuation.evEbitda", 40]] as const) {
+      const known = extractFundamentalSeries(snapshot(statement), source(field, "annual"));
+      expect(known.map((point) => point.value)).toEqual([expected, expected]);
+      for (const missing of ["totalDebt", "cashAndCashEquivalents"] as const) {
+        expect(extractFundamentalSeries(snapshot({ ...statement, [missing]: undefined }), source(field, "annual"))).toEqual([]);
+        expect(extractFundamentalSeries(snapshot({ ...statement, [missing]: Number.NaN }), source(field, "annual"))).toEqual([]);
+      }
+    }
+    // Missing EV inputs must not disable a market-cap-based ratio.
+    expect(extractFundamentalSeries(snapshot({ ...statement, totalDebt: undefined }), source("valuation.priceSales", "annual"))
+      .map((point) => point.value)).toEqual([10, 10]);
+  });
+
   test("tracks the selected share and cash alternatives for enterprise value", () => {
     const points = extractFundamentalSeries(
       financials([], [{

--- a/src/time-series/fundamentals.ts
+++ b/src/time-series/fundamentals.ts
@@ -523,7 +523,7 @@ function metricDependencies(metric: string, statement: FinancialStatement): Nume
     return uniqueDependencies([
       "totalRevenue",
       selectedShares(statement)?.field,
-      finiteNumber(statement.totalDebt) ? "totalDebt" : undefined,
+      "totalDebt",
       selectedCash(statement)?.field,
     ]);
   }
@@ -531,7 +531,7 @@ function metricDependencies(metric: string, statement: FinancialStatement): Nume
     return uniqueDependencies([
       "ebitda",
       selectedShares(statement)?.field,
-      finiteNumber(statement.totalDebt) ? "totalDebt" : undefined,
+      "totalDebt",
       selectedCash(statement)?.field,
     ]);
   }
@@ -649,10 +649,12 @@ function valuationAtPrice(
 ): number | null {
   const shares = selectedShares(statement);
   const marketCap = shares ? price * shares.value : null;
-  const cash = selectedCash(statement)?.value ?? 0;
-  const debt = finiteNumber(statement.totalDebt) ? statement.totalDebt : 0;
-  const enterpriseValue = marketCap !== null
-    ? marketCap + debt - (finiteNumber(cash) ? cash : 0)
+  const cash = selectedCash(statement)?.value;
+  const debt = statement.totalDebt;
+  // Unknown balance-sheet inputs are not zero balances. Avoid manufacturing
+  // an EV multiple from market capitalization alone when coverage is sparse.
+  const enterpriseValue = marketCap !== null && finiteNumber(debt) && finiteNumber(cash)
+    ? marketCap + debt - cash
     : null;
   if (metric === "trailingPE") {
     const eps = selectedEps(statement)?.value;


### PR DESCRIPTION
Historical and current EV/Sales and EV/EBITDA charts treated missing cash or debt as zero, so incomplete statements could produce plausible but unsupported valuation multiples.

Require finite reported cash and debt before deriving enterprise value. Explicit zero balances remain valid, the existing preferred cash field is retained, and market-cap-based ratios remain available independently.

Validation: a regression fixture failed before by producing EV/Sales 10× despite unknown debt. Afterward, 60 focused fundamental/resolver tests passed (230 assertions), covering missing and non-finite inputs, zero balances, both historical/current points, and unaffected Price/Sales. No version bump or release.
