### PR TITLE
Fix 13F amendments and disclosed holding comparisons

### DIFF
--- a/src/components/data-table/view.test.tsx
+++ b/src/components/data-table/view.test.tsx
@@ -175,10 +175,14 @@ function DeferredScrollHarness({ onScroll, initialRows = [], initialIndex = 500,
 }
 
 async function renderSettled() {
-  await act(async () => {
-    await testSetup!.renderOnce();
-    await testSetup!.renderOnce();
-  });
+  // Commit React's measurement/scroll effects between native frames, then
+  // paint the resulting viewport. One act around every frame can leave the
+  // numeric scroll offset updated while the captured frame is still old.
+  for (let phase = 0; phase < 3; phase += 1) {
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+  }
 }
 
 const emitKeypress = (event: TestKeyEvent) => emitTuiKeypress(testSetup!, event);

--- a/src/plugins/builtin/thirteenf/data.test.ts
+++ b/src/plugins/builtin/thirteenf/data.test.ts
@@ -5,7 +5,8 @@ import {
   attachThirteenFApiPersistence,
   resetThirteenFApiPersistence,
 } from "./api";
-import { loadBrowserRows } from "./data";
+import { loadBrowserRows, loadFundDetail } from "./data";
+import { buildFundHoldingRows, hasComparable13FQuarter } from "./model";
 
 afterEach(() => {
   setHttpFetchTransport(null);
@@ -13,6 +14,38 @@ afterEach(() => {
 });
 
 describe("13F data cache", () => {
+  test("loads all additive filings, uses their combined denominator, and detects truncated holdings", async () => {
+    const fetched: string[] = [];
+    const forms = [
+      { accession_number: "base", period_of_report: "2026-06-30", table_value_total: 100,
+        table_entry_total: 1, filed_as_of_date: "2026-08-14", submission_type: "13F-HR" },
+      { accession_number: "addition", period_of_report: "2026-06-30", table_value_total: 50,
+        table_entry_total: 1, filed_as_of_date: "2026-08-20", submission_type: "13F-HR/A", amendment_type: "NEW HOLDINGS" },
+      { accession_number: "previous", period_of_report: "2026-03-31", table_value_total: 120,
+        table_entry_total: 1, filed_as_of_date: "2026-05-14", submission_type: "13F-HR" },
+    ];
+    setHttpFetchTransport(async (url) => {
+      const parsed = new URL(String(url));
+      if (parsed.pathname.endsWith("/forms")) return json(forms.map((form) => ({ ...form, cik: "1067983" })));
+      const accession = parsed.searchParams.get("accession_number")!;
+      fetched.push(accession);
+      return json([{ accession_number: accession, cik: "1067983", cusip: accession === "addition" ? "222222222" : "111111111",
+        ticker: accession === "addition" ? "NEW" : "OLD", value: accession === "addition" ? 50 : 100, ssh_prnamt: 10 }]);
+    });
+    const detail = await loadFundDetail("1067983", "Fund");
+    expect(fetched.sort()).toEqual(["addition", "base", "previous"]);
+    expect(detail.forms).toHaveLength(3);
+    expect(detail.latestReport).toMatchObject({ complete: true, tableValueTotal: 150 });
+    expect(hasComparable13FQuarter(detail)).toBe(true);
+    expect(buildFundHoldingRows(detail).find((row) => row.ticker === "NEW"))
+      .toMatchObject({ weight: 1 / 3, value: 50, action: "new" });
+    forms[0]!.table_entry_total = 2;
+    const partial = await loadFundDetail("1067983", "Fund", undefined, { forceRefresh: true });
+    expect(partial.warnings?.[0]).toContain("loaded 1 of 2");
+    expect(hasComparable13FQuarter(partial)).toBe(false);
+    expect(buildFundHoldingRows(partial).every((row) => row.action === "unknown" && row.weight === null)).toBe(true);
+  });
+
   test("reuses the built-in plugin resource cache across browser row loads", async () => {
     attachThirteenFApiPersistence(new MemoryPluginPersistence());
     let requestCount = 0;

--- a/src/plugins/builtin/thirteenf/data.ts
+++ b/src/plugins/builtin/thirteenf/data.ts
@@ -15,7 +15,7 @@ import {
   dateYearsAgo,
   latestLikely13FQuarter,
   recentIso,
-  selectLatestFormsByPeriod,
+  buildPeriodReports,
   todayIso,
 } from "./model";
 import type {
@@ -26,6 +26,7 @@ import type {
   ThirteenFFund,
   ThirteenFHoldingRecord,
   ThirteenFTopFund,
+  ThirteenFPeriodReport,
 } from "./types";
 
 const BROWSER_PAGE_LIMIT = 75;
@@ -169,19 +170,39 @@ export async function loadFundDetail(
   const now = new Date();
   const apiOptions = { forceRefresh: options.forceRefresh };
 
-  const forms = selectLatestFormsByPeriod(await listThirteenFForms(
+  const forms = await listThirteenFForms(
     cik,
     dateYearsAgo(4, now),
     todayIso(now),
-    20,
+    100,
     signal,
     apiOptions,
-  ));
-  const latestForm = forms[0] ?? null;
-  const previousForm = forms[1] ?? null;
+  );
+  const reports = buildPeriodReports(forms);
+  const latestReport = reports[0];
+  const previousReport = reports[1];
+  const latestForm = latestReport?.filings.at(-1) ?? null;
+  const previousForm = previousReport?.filings.at(-1) ?? null;
+  const warnings: string[] = [];
+  async function loadReport(report: ThirteenFPeriodReport | undefined): Promise<ThirteenFHoldingRecord[]> {
+    if (!report) return [];
+    const holdings: ThirteenFHoldingRecord[] = [];
+    for (const form of report.filings) {
+      const rows = await listThirteenFFormHoldings(cik, form.accessionNumber, signal, apiOptions);
+      holdings.push(...rows);
+      if (form.tableEntryTotal != null && rows.length !== form.tableEntryTotal) {
+        report.complete = false;
+        warnings.push(`${report.periodOfReport}: loaded ${rows.length} of ${form.tableEntryTotal} disclosed entries for ${form.accessionNumber}.`);
+      }
+    }
+    if (!report.complete && !warnings.some((warning) => warning.startsWith(report.periodOfReport))) {
+      warnings.push(`${report.periodOfReport}: amendment type or original report unavailable; disclosed entries cannot be reconciled into a full report.`);
+    }
+    return holdings;
+  }
   const [latestHoldings, previousHoldings] = await Promise.all([
-    latestForm ? listThirteenFFormHoldings(cik, latestForm.accessionNumber, signal, apiOptions) : Promise.resolve([]),
-    previousForm ? listThirteenFFormHoldings(cik, previousForm.accessionNumber, signal, apiOptions) : Promise.resolve([]),
+    loadReport(latestReport),
+    loadReport(previousReport),
   ]);
   return {
     cik: normalizeCik(cik),
@@ -191,6 +212,9 @@ export async function loadFundDetail(
     previousForm,
     latestHoldings,
     previousHoldings,
+    latestReport,
+    previousReport,
+    warnings,
   };
 }
 

--- a/src/plugins/builtin/thirteenf/headless.test.ts
+++ b/src/plugins/builtin/thirteenf/headless.test.ts
@@ -80,6 +80,21 @@ function args(view: string, limit = 50): HeadlessPaneLoadArgs {
 }
 
 describe("13F headless model", () => {
+  test("retains prior-quarter positions omitted from the current disclosed report", async () => {
+    const headless = createThirteenFHeadless({
+      loadBrowser: async () => ({ rows: [] }),
+      loadDetail: async () => ({ ...detail, previousHoldings: [
+        ...detail.previousHoldings,
+        { ...detail.previousHoldings[0]!, cusip: "21036P108", ticker: "STZ", shares: 632890, value: 94933500 },
+      ] }),
+    });
+    const result = await headless.load(args("holdings"), context());
+    expect(result.rows.find((row) => row.ticker === "STZ")).toMatchObject({
+      action: "exit", previousShares: 632890, sharesChange: -632890,
+      shares: null, value: null, estimatedPnl: null,
+    });
+  });
+
   test("requires an unambiguous manager even when the requested output has only one row", async () => {
     const lookups: number[] = [];
     let loaded = false;

--- a/src/plugins/builtin/thirteenf/headless.ts
+++ b/src/plugins/builtin/thirteenf/headless.ts
@@ -122,6 +122,7 @@ const FILING_COLUMNS: HeadlessPaneColumn[] = [
     format: (value) => formatPercentMaybe(value == null ? null : Number(value)),
   },
   { key: "submissionType", header: "Form" },
+  { key: "amendmentType", header: "Amendment" },
 ];
 
 type HeadlessThirteenFView =
@@ -250,7 +251,7 @@ export function createThirteenFHeadless(
           };
         }
         const rows = sortHoldingRows(
-          buildFundHoldingRows(detail).filter((row) => row.value != null),
+          buildFundHoldingRows(detail),
           DEFAULT_HOLDING_SORT,
         )
           .slice(0, limit)
@@ -262,6 +263,7 @@ export function createThirteenFHeadless(
         return {
           columns: HOLDING_COLUMNS,
           rows,
+          ...(detail.warnings?.length ? { errors: detail.warnings } : {}),
           metadata: {
             view,
             cik: detail.cik,
@@ -269,6 +271,10 @@ export function createThirteenFHeadless(
             latestPeriod: detail.latestForm?.periodOfReport ?? null,
             previousPeriod: detail.previousForm?.periodOfReport ?? null,
             comparisonAvailable: hasComparable13FQuarter(detail),
+            currentFilings: detail.latestReport?.filings.map((form) => form.accessionNumber) ?? [],
+            previousFilings: detail.previousReport?.filings.map((form) => form.accessionNumber) ?? [],
+            currentReportedValue: detail.latestReport?.complete ? detail.latestReport.tableValueTotal : null,
+            changeBasis: "Changes compare disclosed quarter-end positions, not trades. Omitted or confidential holdings can affect apparent entries and exits.",
             valueBasis: THIRTEENF_OPTIONS_NOTE,
             estimatedPnlBasis: "Quarter-end unit-value change on overlapping reported shares; excludes options, trading costs and dividends; not actual fund P&L.",
           },

--- a/src/plugins/builtin/thirteenf/model.test.ts
+++ b/src/plugins/builtin/thirteenf/model.test.ts
@@ -5,7 +5,7 @@ import {
   buildTimelineRows,
   inferBrowserTabFromQuery,
   latestLikely13FQuarter,
-  selectLatestFormsByPeriod,
+  buildPeriodReports,
   sortFilingPositionRows,
 } from "./model";
 import type { FundDetailData, ThirteenFFormSummary, ThirteenFHoldingRecord } from "./types";
@@ -61,29 +61,32 @@ describe("13F model", () => {
     expect(latestLikely13FQuarter(new Date("2026-02-20T00:00:00Z"))).toBe("2025Q4");
   });
 
-  test("selects the latest filing for each period", () => {
-    const selected = selectLatestFormsByPeriod([
-      form({ accessionNumber: "old", periodOfReport: "2025-12-31", filedAsOfDate: "2026-02-14" }),
-      form({ accessionNumber: "amended", periodOfReport: "2025-12-31", filedAsOfDate: "2026-02-20", isAmendment: true }),
-      form({ accessionNumber: "new", periodOfReport: "2026-03-31", filedAsOfDate: "2026-05-15" }),
-    ]);
-    expect(selected.map((entry) => entry.accessionNumber)).toEqual(["new", "amended"]);
+  test("reconciles additions and smaller full restatements without losing filing history", () => {
+    const original = form({ accessionNumber: "original", tableEntryTotal: 110, tableValueTotal: 258701144516 });
+    const addition = form({ accessionNumber: "addition", filedAsOfDate: "2026-05-20", isAmendment: true,
+      amendmentType: "NEW HOLDINGS", tableEntryTotal: 4, tableValueTotal: 1106550356 });
+    const reports = buildPeriodReports([addition, original, addition]);
+    expect(reports[0]).toMatchObject({ complete: true, tableEntryTotal: 114, tableValueTotal: 259807694872 });
+    expect(reports[0]?.filings.map((entry) => entry.accessionNumber)).toEqual(["original", "addition"]);
+    const restatement = form({ accessionNumber: "restated", filedAsOfDate: "2026-06-01", isAmendment: true,
+      amendmentType: "RESTATEMENT", tableEntryTotal: 1, tableValueTotal: 20 });
+    const extra = { ...addition, accessionNumber: "extra", filedAsOfDate: "2026-06-02" };
+    const revised = buildPeriodReports([extra, original, restatement, addition])[0];
+    expect(revised?.filings.map((entry) => entry.accessionNumber)).toEqual(["restated", "extra"]);
+    expect(revised).toMatchObject({ complete: true, tableEntryTotal: 5, tableValueTotal: 1106550376 });
+    expect(buildTimelineRows([original, addition, restatement, extra]).map((row) => row.id))
+      .toEqual(["extra", "restated", "addition", "original"]);
+    expect(buildTimelineRows([original, addition]).every((row) => row.valueChangePercent === null)).toBe(true);
   });
 
-  test("does not replace a full period filing with a supplemental amendment", () => {
-    const selected = selectLatestFormsByPeriod([
-      form({ accessionNumber: "full", periodOfReport: "2025-03-31", filedAsOfDate: "2025-05-15", tableEntryTotal: 110 }),
-      form({
-        accessionNumber: "supplemental",
-        submissionType: "13F-HR/A",
-        periodOfReport: "2025-03-31",
-        filedAsOfDate: "2025-06-03",
-        tableEntryTotal: 4,
-        isAmendment: true,
-        amendmentType: "NEW HOLDINGS",
-      }),
-    ]);
-    expect(selected.map((entry) => entry.accessionNumber)).toEqual(["full"]);
+  test("does not infer a full report from a standalone or untyped amendment", () => {
+    const original = form({ accessionNumber: "original" });
+    for (const amendmentType of [undefined, "NEW HOLDINGS"]) {
+      const amendment = form({ accessionNumber: "amendment", isAmendment: true, amendmentType,
+        filedAsOfDate: "2026-05-20" });
+      expect(buildPeriodReports([amendment])[0]).toMatchObject({ complete: false, tableValueTotal: null });
+      if (!amendmentType) expect(buildPeriodReports([original, amendment])[0]?.complete).toBe(false);
+    }
   });
 
   test("aggregates current and prior holdings into change rows", () => {
@@ -180,10 +183,34 @@ describe("13F model", () => {
     }
   });
 
+  test("missing amounts stay unknown through aggregation and incomplete reports do not fabricate exits", () => {
+    const latest = form({});
+    const previous = form({ accessionNumber: "previous", periodOfReport: "2025-12-31" });
+    const data: FundDetailData = { cik: latest.cik, name: "Fund", forms: [latest, previous],
+      latestForm: latest, previousForm: previous,
+      latestHoldings: [holding({ value: 20, shares: 2 }), holding({ value: null, shares: null })],
+      previousHoldings: [holding({ value: 50, shares: 5 }), holding({ cusip: "123456789" })] };
+    const rows = buildFundHoldingRows(data);
+    expect(rows[0]).toMatchObject({ value: null, shares: null, sharesChange: null,
+      valueChange: null, weight: null, estimatedPnl: null, action: "unknown" });
+    const report = buildPeriodReports([latest])[0]!;
+    report.complete = false;
+    expect(buildFundHoldingRows({ ...data, latestReport: report })).toHaveLength(1);
+    expect(buildFilingPositionRows([holding({ value: 20 })], null)[0]?.weight).toBeNull();
+  });
+
+  test("filing value changes do not bridge a missing quarter", () => {
+    const rows = buildTimelineRows([
+      form({ accessionNumber: "current", periodOfReport: "2026-03-31" }),
+      form({ accessionNumber: "old", periodOfReport: "2025-09-30" }),
+    ]);
+    expect(rows[0]?.valueChangePercent).toBeNull();
+  });
+
   test("timeline rows include period-over-period value changes", () => {
     const rows = buildTimelineRows([
-      form({ periodOfReport: "2026-03-31", tableValueTotal: 120, amendmentType: "RESTATEMENT" }),
-      form({ periodOfReport: "2025-12-31", tableValueTotal: 100 }),
+      form({ accessionNumber: "latest", periodOfReport: "2026-03-31", tableValueTotal: 120, amendmentType: "RESTATEMENT" }),
+      form({ accessionNumber: "previous", periodOfReport: "2025-12-31", tableValueTotal: 100 }),
     ]);
     expect(rows[0]?.valueChangePercent).toBeCloseTo(0.2);
     expect(rows[0]).toMatchObject({

--- a/src/plugins/builtin/thirteenf/model.ts
+++ b/src/plugins/builtin/thirteenf/model.ts
@@ -22,6 +22,7 @@ import type {
   ThirteenFFund,
   ThirteenFHoldingRecord,
   ThirteenFTopFund,
+  ThirteenFPeriodReport,
 } from "./types";
 
 export const THIRTEENF_PANE_ID = "thirteenf-funds";
@@ -151,36 +152,37 @@ export function dedupeLatestForms(forms: ThirteenFFormSummary[]): ThirteenFFormS
   return [...byCik.values()].sort((left, right) => compareFormRecency(right, left));
 }
 
-export function selectLatestFormsByPeriod(forms: ThirteenFFormSummary[]): ThirteenFFormSummary[] {
-  const byPeriod = new Map<string, ThirteenFFormSummary>();
-  for (const form of forms) {
-    const current = byPeriod.get(form.periodOfReport);
-    if (!current || shouldReplacePeriodForm(current, form)) {
-      byPeriod.set(form.periodOfReport, form);
+/** SEC Form 13F special instruction 3: restatements replace the report;
+ * NEW HOLDINGS filings add entries to the existing public report. Row counts
+ * cannot establish which kind of amendment a filer submitted. */
+export function buildPeriodReports(forms: ThirteenFFormSummary[]): ThirteenFPeriodReport[] {
+  const byPeriod = new Map<string, ThirteenFPeriodReport>();
+  const unique = [...new Map(forms.map((form) => [form.accessionNumber, form])).values()];
+  for (const form of unique.sort(compareFormRecency)) {
+    let report = byPeriod.get(form.periodOfReport);
+    const amendmentType = form.amendmentType?.trim().toUpperCase();
+    if (!form.isAmendment || amendmentType === "RESTATEMENT") {
+      report = { periodOfReport: form.periodOfReport, filings: [form], complete: true,
+        tableValueTotal: form.tableValueTotal, tableEntryTotal: form.tableEntryTotal };
+    } else if (amendmentType === "NEW HOLDINGS") {
+      report = report ?? { periodOfReport: form.periodOfReport, filings: [], complete: false,
+        tableValueTotal: null, tableEntryTotal: null };
+      report.filings.push(form);
+      report.tableValueTotal = addKnown(report.tableValueTotal, form.tableValueTotal);
+      report.tableEntryTotal = addKnown(report.tableEntryTotal, form.tableEntryTotal);
+    } else {
+      // An untyped amendment could replace or supplement the report. Display
+      // its disclosed entries without inventing a reconciled full portfolio.
+      report = { periodOfReport: form.periodOfReport, filings: [form], complete: false,
+        tableValueTotal: null, tableEntryTotal: null };
     }
+    byPeriod.set(form.periodOfReport, report);
   }
-  return [...byPeriod.values()].sort((left, right) => compareFormPeriod(right, left));
+  return [...byPeriod.values()].sort((left, right) => right.periodOfReport.localeCompare(left.periodOfReport));
 }
 
-function isSupplementalAmendment(form: ThirteenFFormSummary): boolean {
-  if (!form.isAmendment) return false;
-  const amendmentType = form.amendmentType?.toUpperCase() ?? "";
-  return amendmentType.length > 0 && amendmentType !== "RESTATEMENT";
-}
-
-function shouldReplacePeriodForm(current: ThirteenFFormSummary, candidate: ThirteenFFormSummary): boolean {
-  if (isSupplementalAmendment(candidate) && !isSupplementalAmendment(current)) return false;
-  if (!isSupplementalAmendment(candidate) && isSupplementalAmendment(current)) return true;
-  if (candidate.isAmendment && !current.isAmendment) {
-    const candidateRows = candidate.tableEntryTotal ?? 0;
-    const currentRows = current.tableEntryTotal ?? 0;
-    if (currentRows > 0 && candidateRows < currentRows * 0.75) return false;
-  }
-  return compareFormRecency(candidate, current) > 0;
-}
-
-function compareFormPeriod(left: ThirteenFFormSummary, right: ThirteenFFormSummary): number {
-  return left.periodOfReport.localeCompare(right.periodOfReport);
+function addKnown(left: number | null, right: number | null): number | null {
+  return left != null && right != null ? left + right : null;
 }
 
 function compareFormRecency(left: ThirteenFFormSummary, right: ThirteenFFormSummary): number {
@@ -199,8 +201,8 @@ interface HoldingAggregate {
   titleOfClass: string;
   putCall: string;
   shareType: string;
-  value: number;
-  shares: number;
+  value: number | null;
+  shares: number | null;
   accessionNumber: string;
 }
 
@@ -217,11 +219,11 @@ function aggregateHoldings(holdings: ThirteenFHoldingRecord[]): Map<string, Hold
   for (const holding of holdings) {
     const id = holdingKey(holding);
     const current = aggregates.get(id);
-    const value = holding.value ?? 0;
-    const shares = holding.shares ?? 0;
+    const value = holding.value;
+    const shares = holding.shares;
     if (current) {
-      current.value += value;
-      current.shares += shares;
+      current.value = addKnown(current.value, value);
+      current.shares = addKnown(current.shares, shares);
       if (!current.ticker && holding.ticker) current.ticker = holding.ticker;
       continue;
     }
@@ -245,6 +247,7 @@ function resolveAction(current: HoldingAggregate | undefined, previous: HoldingA
   if (current && !previous) return "new";
   if (!current && previous) return "exit";
   if (!current || !previous) return "held";
+  if (current.shares == null || previous.shares == null) return "unknown";
   const delta = current.shares - previous.shares;
   if (delta > 0) return "add";
   if (delta < 0) return "trim";
@@ -259,8 +262,8 @@ function estimateHoldingPnl(
   // A 13F option value is underlying notional. Its change cannot price the
   // option, and the filing does not identify strike, expiry or premium.
   if (current.putCall || previous.putCall) return null;
-  if (current.value <= 0 || previous.value <= 0) return null;
-  if (current.shares <= 0 || previous.shares <= 0) return null;
+  if (current.value == null || previous.value == null || current.value <= 0 || previous.value <= 0) return null;
+  if (current.shares == null || previous.shares == null || current.shares <= 0 || previous.shares <= 0) return null;
 
   const currentPrice = current.value / current.shares;
   const previousPrice = previous.value / previous.shares;
@@ -269,8 +272,13 @@ function estimateHoldingPnl(
 }
 
 export function hasComparable13FQuarter(data: FundDetailData): boolean {
+  if (data.latestReport?.complete === false || data.previousReport?.complete === false) return false;
   const current = data.latestForm?.periodOfReport;
   const previous = data.previousForm?.periodOfReport;
+  return adjacentQuarterPeriods(current, previous);
+}
+
+function adjacentQuarterPeriods(current: string | undefined, previous: string | undefined): boolean {
   if (!current || !previous) return false;
   const date = new Date(`${current}T00:00:00Z`);
   if (!Number.isFinite(date.getTime())) return false;
@@ -284,8 +292,9 @@ export function buildFundHoldingRows(data: FundDetailData | null): FundHoldingRo
   const comparable = hasComparable13FQuarter(data);
   const previous = aggregateHoldings(comparable ? data.previousHoldings : []);
   const allKeys = new Set([...current.keys(), ...previous.keys()]);
-  const totalValue = data.latestForm.tableValueTotal
-    ?? [...current.values()].reduce((sum, item) => sum + item.value, 0);
+  const totalValue = data.latestReport
+    ? data.latestReport.complete ? data.latestReport.tableValueTotal : null
+    : data.latestForm.tableValueTotal;
 
   return [...allKeys].map((id) => {
     const currentHolding = current.get(id);
@@ -295,10 +304,10 @@ export function buildFundHoldingRows(data: FundDetailData | null): FundHoldingRo
     const shares = currentHolding?.shares ?? null;
     const previousValue = previousHolding?.value ?? null;
     const previousShares = previousHolding?.shares ?? null;
-    const valueChange = comparable && (value != null || previousValue != null)
+    const valueChange = comparable && (!currentHolding || value != null) && (!previousHolding || previousValue != null)
       ? (value ?? 0) - (previousValue ?? 0)
       : null;
-    const sharesChange = comparable && (shares != null || previousShares != null)
+    const sharesChange = comparable && (!currentHolding || shares != null) && (!previousHolding || previousShares != null)
       ? (shares ?? 0) - (previousShares ?? 0)
       : null;
     const sharesChangePercent = sharesChange != null && previousShares && previousShares !== 0
@@ -331,8 +340,8 @@ export function buildFilingPositionRows(
   holdings: ThirteenFHoldingRecord[],
   reportedTotalValue?: number | null,
 ): FilingPositionRow[] {
-  const computedTotalValue = holdings.reduce((sum, holding) => sum + (holding.value ?? 0), 0);
-  const totalValue = reportedTotalValue ?? computedTotalValue;
+  // Filing details are paginated; the loaded page cannot supply a full-report denominator.
+  const totalValue = reportedTotalValue;
   return holdings.map((holding, index) => ({
     id: [
       holding.accessionNumber,
@@ -361,12 +370,20 @@ export function buildFilingPositionRows(
 }
 
 export function buildTimelineRows(forms: ThirteenFFormSummary[]): FundTimelineRow[] {
-  const selected = selectLatestFormsByPeriod(forms);
-  return selected.map((form, index) => {
-    const previous = selected[index + 1];
-    const valueChangePercent = form.tableValueTotal != null
-      && previous?.tableValueTotal != null
-      && previous.tableValueTotal !== 0
+  const reports = buildPeriodReports(forms);
+  const selected = [...new Map(forms.map((form) => [form.accessionNumber, form])).values()]
+    .sort((left, right) => compareFormRecency(right, left));
+  return selected.map((form) => {
+    const index = reports.findIndex((report) => report.periodOfReport === form.periodOfReport);
+    const report = reports[index];
+    const previous = reports[index + 1];
+    // A single filing's value is not the combined value of an amended period.
+    // Keep every source filing visible, and compare only full adjacent reports.
+    const comparable = report?.complete && report.filings.length === 1
+      && report.filings[0]?.accessionNumber === form.accessionNumber
+      && previous?.complete && adjacentQuarterPeriods(form.periodOfReport, previous.periodOfReport);
+    const valueChangePercent = comparable && form.tableValueTotal != null
+      && previous.tableValueTotal != null && previous.tableValueTotal !== 0
       ? (form.tableValueTotal - previous.tableValueTotal) / previous.tableValueTotal
       : null;
     return {

--- a/src/plugins/builtin/thirteenf/pane.test.tsx
+++ b/src/plugins/builtin/thirteenf/pane.test.tsx
@@ -266,7 +266,7 @@ describe("ThirteenFPane", () => {
 
     const filingsFrame = testSetup!.captureCharFrame();
     expect(filingsFrame).toContain("PERIOD");
-    expect(filingsFrame).toContain("13F-HR/A");
+    expect(filingsFrame).toContain("Restatement");
     expect(filingsFrame).toContain("Back Alpha Capital");
     expect(filingsFrame).not.toContain("Accession");
   });

--- a/src/plugins/builtin/thirteenf/pane.tsx
+++ b/src/plugins/builtin/thirteenf/pane.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   DataTableStackView,
   DataTableView,
-  EmptyState, InputSearchBar, KeyValueRow, PaneStatusBody, Tabs, useTableLoadMore, type DataTableKeyEvent,
+  EmptyState, Notice, InputSearchBar, KeyValueRow, PaneStatusBody, Tabs, useTableLoadMore, type DataTableKeyEvent,
   type DataTableRootKeyContext, type PaneFooterSegment
 } from "../../../components";
 import { useShortcut } from "../../../react/input";
@@ -424,7 +424,7 @@ function FundDetailView({
 
   const holdingRows = useMemo(() => buildFundHoldingRows(data), [data]);
   const visibleHoldingRows = useMemo(() => (
-    sortHoldingRows(holdingRows.filter((row) => row.value != null), holdingSort)
+    sortHoldingRows(holdingRows, holdingSort)
   ), [holdingRows, holdingSort]);
   const filingRows = useMemo(() => sortTimelineRows(buildTimelineRows(data?.forms ?? []), filingSort), [data?.forms, filingSort]);
   const selectedHoldingIndex = selectedIndexById(visibleHoldingRows, holdingSelectedId);
@@ -447,7 +447,7 @@ function FundDetailView({
       : selectedFiling;
   const currentSourceUrl = activeTab === "filings"
     ? openFiling?.url ?? selectedFiling?.url
-    : latestForm?.url;
+    : selectedHoldingFiling?.url ?? latestForm?.url;
   const statusFiling = openFiling ?? latestForm;
   useEffect(() => {
     if (holdingSelectedId && visibleHoldingRows.some((row) => row.id === holdingSelectedId)) return;
@@ -626,6 +626,10 @@ function FundDetailView({
             <Box flexDirection="column" paddingX={1}>
               <KeyValueRow label="Reported" value={data?.latestForm?.periodOfReport ?? "--"} detail={`Filed ${data?.latestForm?.filedAsOfDate || "--"}`} width={Math.max(1, width - 2)} />
               <KeyValueRow label="Compared with" value={data && hasComparable13FQuarter(data) ? data.previousForm!.periodOfReport : "Prior quarter unavailable"} width={Math.max(1, width - 2)} />
+              {data?.latestReport && data.latestReport.filings.length > 1 ? (
+                <KeyValueRow label="Public report" value={`${data.latestReport.filings.length} filings combined`} width={Math.max(1, width - 2)} />
+              ) : null}
+              {data?.warnings?.map((warning) => <Notice key={warning} tone="warning">{warning}</Notice>)}
               {visibleHoldingRows.some((row) => !!row.putCall) ? (
                 <Text fg={colors.textMuted}>{THIRTEENF_OPTIONS_NOTE}</Text>
               ) : null}

--- a/src/plugins/builtin/thirteenf/table.ts
+++ b/src/plugins/builtin/thirteenf/table.ts
@@ -180,7 +180,7 @@ export function renderTimelineCell(
       };
     case "form":
       return {
-        text: row.isAmendment ? `${row.submissionType} amended` : row.submissionType,
+        text: row.isAmendment ? row.amendmentType?.toUpperCase() === "RESTATEMENT" ? "Restatement" : row.amendmentType?.toUpperCase() === "NEW HOLDINGS" ? "New holdings" : "Amendment (unknown)" : row.submissionType,
         color: selectedColor ?? (row.isAmendment ? colors.warning : colors.textDim),
       };
   }

--- a/src/plugins/builtin/thirteenf/types.ts
+++ b/src/plugins/builtin/thirteenf/types.ts
@@ -90,6 +90,18 @@ export interface FundDetailData {
   previousForm: ThirteenFFormSummary | null;
   latestHoldings: ThirteenFHoldingRecord[];
   previousHoldings: ThirteenFHoldingRecord[];
+  latestReport?: ThirteenFPeriodReport;
+  previousReport?: ThirteenFPeriodReport;
+  warnings?: string[];
+}
+
+/** The public report for one period, after applying known amendment types. */
+export interface ThirteenFPeriodReport {
+  periodOfReport: string;
+  filings: ThirteenFFormSummary[];
+  complete: boolean;
+  tableValueTotal: number | null;
+  tableEntryTotal: number | null;
 }
 
 export type HoldingAction = "held" | "new" | "add" | "trim" | "exit" | "unknown";


### PR DESCRIPTION
13F research omitted fully exited positions and discarded amendments that add holdings. Berkshire's 2026 Q2 comparison hid the STZ exit, and its March 2025 supplemental filing with four entries and $1.10655B of disclosed value was absent from the filing history.

Reconcile each period using the declared amendment type: restatements replace the report, while subsequent NEW HOLDINGS filings add entries and their reported totals. Keep every source filing accessible, retain exits, and suppress comparisons/weights when amendment coverage or loaded entry counts are incomplete. Unknown amounts remain unknown, and paginated filing details no longer derive weights from a partial page.

Validation: 33 focused tests / 110 assertions; browser and OpenTUI typechecks. Live CLI and native tmux journeys verified Berkshire's adjacent quarters and supplemental filing, plus Scion option underlying-notional values, against actual SEC XML. Algert's full restatement was also checked against both SEC filings. Amendment semantics follow [SEC Form 13F special instruction 3](https://www.sec.gov/pdf/form13f.pdf). The native table regression harness now commits React effects between render phases before capturing the frame; its scroll-position and visual assertions remain intact. No release.
