### PR TITLE
Fix sector comparison calendar return windows

### DIFF
--- a/src/plugins/builtin/correlation/headless.ts
+++ b/src/plugins/builtin/correlation/headless.ts
@@ -39,9 +39,11 @@ export const correlationHeadless: HeadlessPaneDefinition<"rows"> = {
       metadata: {
         range,
         unavailablePairs,
-        returnAlignment: "Close-to-close returns between shared UTC dates; exchange closing times may differ.",
+        returnAlignment: "Local-price close-to-close returns between shared UTC dates; no FX conversion, and exchange closing times may differ.",
         availability: symbols.map((symbol) => ({
           symbol, status: bySymbol.get(symbol)?.status ?? "error", observationCount: bySymbol.get(symbol)?.observationCount ?? 0,
+          firstDate: bySymbol.get(symbol)?.prices.at(0)?.dateKey ?? null,
+          lastDate: bySymbol.get(symbol)?.prices.at(-1)?.dateKey ?? null,
         })),
       },
     };

--- a/src/plugins/builtin/correlation/index.tsx
+++ b/src/plugins/builtin/correlation/index.tsx
@@ -1,6 +1,6 @@
 import { Box, ScrollBox, Text, type InputRenderable } from "../../../ui";
 import { useCallback, useMemo, useRef, useState } from "react";
-import { InputSearchBar, SegmentedControl, usePaneFooter } from "../../../components";
+import { Notice, InputSearchBar, SegmentedControl, usePaneFooter } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
@@ -186,6 +186,8 @@ function CorrelationMatrixPane({ focused, width, height }: PaneProps) {
           shortcutScope="correlation:range"
         />
       </Box>
+
+      <Box height={1} paddingX={1}><Notice tone="muted">Local-price returns; shared dates, market closes differ.</Notice></Box>
 
       {/* Column header row */}
       <Box flexDirection="row" paddingX={1} height={1} width={matrixRowWidth} backgroundColor={headerBg}>

--- a/src/plugins/builtin/sectors/client.test.ts
+++ b/src/plugins/builtin/sectors/client.test.ts
@@ -8,7 +8,7 @@ const sectors = [
   { name: "Financials", etf: "XLF" },
 ];
 const quote = (symbol: string): Quote => ({
-  symbol, price: 105, change: 5, changePercent: 5, currency: "USD", lastUpdated: 1,
+  symbol, price: 105, change: 5, changePercent: 5, currency: "USD", lastUpdated: Date.parse("2026-09-10T18:00:00Z"), changeSessionDate: "2026-09-10",
 });
 const history = [
   { date: "2025-09-10", close: 80 },
@@ -41,4 +41,53 @@ describe("sector quote recovery", () => {
     expect(result?.row?.return1Y).toBeCloseTo(25);
     expect(result?.row?.return1M).toBeCloseTo(11.111111);
   });
+});
+
+
+test("uses one session for live returns and rejects short or outdated histories", async () => {
+  const provider = {
+    getQuotesBatch: async () => [{ target: { symbol: "XLK" }, quote: quote("XLK") }],
+    getQuote: async () => null,
+    getPriceHistory: async (symbol: string) => symbol === "XLK"
+      ? [{ date: new Date("2026-08-10"), close: 90 }, { date: new Date("2026-09-09"), close: 100 }]
+      : [{ date: new Date("2025-09-10"), close: 80 }, { date: new Date("2026-08-10"), close: 90 }, { date: new Date("2026-09-09"), close: 100 }],
+  } as unknown as DataProvider;
+  const rows = await loadSectorRows(sectors, provider);
+  expect(rows[0]?.row?.return1M).toBeCloseTo(16.6666667);
+  expect(rows[0]?.row).toMatchObject({ return1Y: null, returnAsOfDate: "2026-09-10", return1MStartDate: "2026-08-10" });
+  expect(rows[1]?.row).toMatchObject({ return1M: null, return1Y: null, quoteUnavailable: true });
+});
+
+test("requests a boundary buffer when the prior-year date falls on a holiday", async () => {
+  let requestedStart: string | null = null;
+  const sessionQuote = { ...quote("XLK"), changeSessionDate: "2026-10-12", lastUpdated: Date.parse("2026-10-12T18:00:00Z") };
+  const provider = {
+    getQuote: async () => sessionQuote,
+    getPriceHistory: async () => [{ date: new Date("2025-10-13"), close: 101 }, { date: new Date("2026-10-12"), close: 104 }],
+    getDetailedPriceHistory: async (_symbol: string, _exchange: string, start: Date) => {
+      requestedStart = start.toISOString().slice(0, 10);
+      return [{ date: new Date("2025-10-10"), close: 100 }];
+    },
+  } as unknown as DataProvider;
+  const [result] = await loadSectorRows(sectors.slice(0, 1), provider);
+  expect(requestedStart).toBe("2025-10-05");
+  expect(result?.row?.return1Y).toBeCloseTo(5);
+  expect(result?.row?.return1YStartDate).toBe("2025-10-10");
+});
+
+
+test("one missing baseline bar cannot change a fund's comparison window", async () => {
+  const provider = {
+    getQuote: async (symbol: string) => quote(symbol),
+    getPriceHistory: async (symbol: string) => [
+      { date: new Date("2025-09-10"), close: 80 },
+      { date: new Date("2026-08-07"), close: 85 },
+      ...(symbol === "XLK" ? [{ date: new Date("2026-08-10"), close: 90 }] : []),
+      { date: new Date("2026-09-10"), close: 100 },
+    ],
+  } as unknown as DataProvider;
+  const outcomes = await loadSectorRows(sectors, provider);
+  expect(outcomes[0]?.row?.return1M).toBeCloseTo(16.6666667);
+  expect(outcomes[1]?.row?.return1M).toBeNull();
+  expect(outcomes.map(({ row }) => row?.return1Y)).toEqual([31.25, 31.25]);
 });

--- a/src/plugins/builtin/sectors/client.ts
+++ b/src/plugins/builtin/sectors/client.ts
@@ -3,8 +3,8 @@ import type { PricePoint, Quote } from "../../../types/financials";
 import type { SectorDef } from "./sector-data";
 import {
   computeTrailingReturn,
-  ONE_MONTH_DAYS,
-  ONE_YEAR_DAYS,
+  latestHistoryDate,
+  sectorReturnTargetDate,
   type SectorRow,
 } from "./sector-model";
 
@@ -34,22 +34,68 @@ export async function loadSectorRows(
     }
   }));
 
-  return Promise.all(sectors.map(async (sector) => {
-    const history: PricePoint[] = await provider.getPriceHistory(sector.etf, "", "1Y")
-      .catch(() => []);
+  const histories = new Map(await Promise.all(sectors.map(async (sector) => [
+    sector.etf,
+    await provider.getPriceHistory(sector.etf, "", "1Y").catch(() => []),
+  ] as const)));
+  const quoteDates = new Map([...quotes].map(([symbol, quote]) => [symbol, quote ? quoteSessionDate(quote) : null]));
+  const asOfDate = [...quoteDates.values(), ...[...histories.values()].map(latestHistoryDate)]
+    .filter((date): date is string => date != null).sort().at(-1) ?? null;
+
+  const outcomes = await Promise.all(sectors.map(async (sector) => {
+    let history: PricePoint[] = histories.get(sector.etf) ?? [];
     const quote = quotes.get(sector.etf) ?? null;
     if (!quote && history.length === 0) return { etf: sector.etf, row: null };
-    const price = quote?.price ?? null;
+    const price = quote && Number.isFinite(quote.price) && quote.price > 0 ? quote.price : null;
+    const currentPrice = quoteDates.get(sector.etf) === asOfDate ? price : null;
+    // A strict trailing request may begin after the prior year's weekend or
+    // holiday. Ask for a small boundary buffer when the provider supports it.
+    if (asOfDate && !computeTrailingReturn(history, "1Y", currentPrice, asOfDate)
+      && provider.getDetailedPriceHistory) {
+      const start = new Date(`${sectorReturnTargetDate(asOfDate, "1Y")}T00:00:00Z`);
+      start.setUTCDate(start.getUTCDate() - 7);
+      const end = new Date(`${asOfDate}T00:00:00Z`);
+      end.setUTCDate(end.getUTCDate() + 1);
+      const extended = await provider.getDetailedPriceHistory(sector.etf, "", start, end, "1d").catch(() => []);
+      if (extended.length > 0) history = [...history, ...extended];
+    }
+    const month = computeTrailingReturn(history, "1M", currentPrice, asOfDate);
+    const year = computeTrailingReturn(history, "1Y", currentPrice, asOfDate);
     return {
       etf: sector.etf,
       row: {
         price,
-        quoteUnavailable: !quote,
+        quoteUnavailable: price == null,
         changePercent: quote?.changePercent ?? null,
-        return1M: computeTrailingReturn(history, ONE_MONTH_DAYS, price),
-        return1Y: computeTrailingReturn(history, ONE_YEAR_DAYS, price),
+        return1M: month?.value ?? null,
+        return1Y: year?.value ?? null,
+        returnAsOfDate: asOfDate,
+        return1MStartDate: month?.startDate ?? null,
+        return1YStartDate: year?.startDate ?? null,
         currency: quote?.currency ?? "USD",
       },
     };
   }));
+  // These ETFs share a market calendar. A missing observation for one fund
+  // must not silently give it an earlier baseline than its peers.
+  const monthStartDate = outcomes.map(({ row }) => row?.return1MStartDate).filter((date): date is string => !!date).sort().at(-1);
+  const yearStartDate = outcomes.map(({ row }) => row?.return1YStartDate).filter((date): date is string => !!date).sort().at(-1);
+  for (const { row } of outcomes) {
+    if (!row) continue;
+    if (row.return1MStartDate !== monthStartDate) { row.return1M = null; row.return1MStartDate = null; }
+    if (row.return1YStartDate !== yearStartDate) { row.return1Y = null; row.return1YStartDate = null; }
+  }
+  return outcomes;
+}
+
+function quoteSessionDate(quote: Quote): string | null {
+  const declared = quote.changeSessionDate;
+  if (typeof declared === "string" && /^\d{4}-\d{2}-\d{2}$/.test(declared)
+    && Number.isFinite(Date.parse(declared)) && new Date(declared).toISOString().slice(0, 10) === declared) return declared;
+  if (!Number.isFinite(quote.lastUpdated) || quote.lastUpdated <= 0) return null;
+  // Every instrument in these collections is a US-listed ETF. quote.price is
+  // the regular-session price; prefer its declared session when supplied.
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/New_York", year: "numeric", month: "2-digit", day: "2-digit",
+  }).format(new Date(quote.lastUpdated));
 }

--- a/src/plugins/builtin/sectors/headless.test.ts
+++ b/src/plugins/builtin/sectors/headless.test.ts
@@ -38,3 +38,17 @@ describe("sectors headless model", () => {
     expect(requested[0]).not.toEqual(requested[1]);
   });
 });
+
+
+test("an available quote does not make an unavailable annual window complete", async () => {
+  const headless = createSectorsHeadless({
+    load: async (_args, definitions) => definitions.map((definition) => ({
+      etf: definition.etf,
+      row: { price: 100, changePercent: 1, return1M: 2, return1Y: null, quoteUnavailable: false, returnAsOfDate: "2026-09-10" },
+    })),
+  });
+  const result = await headless.load(args("sectors"), {} as HeadlessPaneContext);
+  expect(result.unavailableSymbols).toContain("XLK");
+  expect(result.errors?.some((error) => error.startsWith("XLK:"))).toBe(true);
+  expect(result.rows.find((row) => row.etf === "XLK")).toMatchObject({ price: 100, return1M: 2, return1Y: null });
+});

--- a/src/plugins/builtin/sectors/headless.ts
+++ b/src/plugins/builtin/sectors/headless.ts
@@ -31,6 +31,9 @@ export function projectSectorRows(
     currency: byEtf.get(definition.etf)?.currency ?? "USD",
     loading: false,
     quoteUnavailable: !byEtf.get(definition.etf) || byEtf.get(definition.etf)?.quoteUnavailable === true,
+    returnAsOfDate: byEtf.get(definition.etf)?.returnAsOfDate ?? null,
+    return1MStartDate: byEtf.get(definition.etf)?.return1MStartDate ?? null,
+    return1YStartDate: byEtf.get(definition.etf)?.return1YStartDate ?? null,
   })), DEFAULT_SORT_PREFERENCE);
 }
 
@@ -67,14 +70,20 @@ export function createSectorsHeadless(
       const outcomes = await dependencies.load(args, definitions, ctx.marketData);
       const rows = projectSectorRows(definitions, outcomes);
       const unavailableQuotes = rows.filter((row) => row.quoteUnavailable).map((row) => row.etf);
+      const unavailableReturns = rows.filter((row) => row.return1M == null || row.return1Y == null).map((row) => row.etf);
+      const unavailableSymbols = [...new Set([...unavailableQuotes, ...unavailableReturns])];
       return {
-        unavailableSymbols: unavailableQuotes.length > 0 ? unavailableQuotes : undefined,
+        unavailableSymbols: unavailableSymbols.length > 0 ? unavailableSymbols : undefined,
+        errors: unavailableReturns.map((symbol) => `${symbol}: price history does not cover one or more requested calendar windows.`),
         rows: rows.map((row) => ({ ...row })),
         metadata: {
           collection: collectionId,
           available: outcomes.filter((outcome) => outcome.row).length,
           requested: definitions.length,
           unavailableQuotes,
+          unavailableReturns,
+          returnDefinition: "ETF price returns in listing currency; cash distributions are not reinvested. Shared ending session and calendar-month/year boundaries; prior close used for holidays.",
+          returnWindows: rows.map((row) => ({ symbol: row.etf, asOfDate: row.returnAsOfDate, monthStartDate: row.return1MStartDate, yearStartDate: row.return1YStartDate })),
         },
       };
     },

--- a/src/plugins/builtin/sectors/index.tsx
+++ b/src/plugins/builtin/sectors/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box } from "../../../ui";
-import { DataTableView, Tabs, usePaneFooter, type DataTableCell, type DataTableKeyEvent, type PaneFooterSegment } from "../../../components";
+import { DataTableView, Notice, Tabs, usePaneFooter, type DataTableCell, type DataTableKeyEvent, type PaneFooterSegment } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import { usePaneSettingValue } from "../../../state/app/context";
@@ -58,7 +58,7 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
     [activeCollection.id, savedIndustryEtfs, savedSectorEtfs],
   );
   const [rowsByCollection, setRowsByCollection] = useDebouncedPluginPaneState<SectorRowsByCollection>(
-    "rowsByCollection:v1",
+    "rowsByCollection:v2",
     INITIAL_ROWS_BY_COLLECTION,
   );
   const [lastRefreshByCollection, setLastRefreshByCollection] = useDebouncedPluginPaneState<SectorRefreshByCollection>(
@@ -108,12 +108,17 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
       if (fetchGenRef.current !== gen) return;
       const loadedByEtf = new Map(outcomes.map((outcome) => [outcome.etf, outcome.row]));
       setRowsByCollection((prev) => updateRowsForCollection(prev, collectionId, sectorDefs, (rows) => (
-        rows.map((row) => ({ ...row, ...(loadedByEtf.get(row.etf) ?? { price: null, changePercent: null, quoteUnavailable: true }), loading: false }))
+        rows.map((row) => ({ ...row, ...(loadedByEtf.get(row.etf) ?? { price: null, changePercent: null, return1M: null, return1Y: null, returnAsOfDate: null, return1MStartDate: null, return1YStartDate: null, quoteUnavailable: true }), loading: false }))
       )));
 
       const loadedCount = outcomes.filter((outcome) => outcome.row).length;
       const missingQuotes = outcomes.filter((outcome) => !outcome.row || outcome.row.quoteUnavailable).length;
-      setLoadError(loadedCount === 0 ? "Sector data unavailable" : missingQuotes > 0 ? `${missingQuotes} quotes unavailable` : null);
+      const missingReturns = outcomes.filter((outcome) => outcome.row && (outcome.row.return1M == null || outcome.row.return1Y == null)).length;
+      const warnings = [
+        ...(missingQuotes > 0 ? [`${missingQuotes} quotes unavailable`] : []),
+        ...(missingReturns > 0 ? [`${missingReturns} return windows incomplete`] : []),
+      ];
+      setLoadError(loadedCount === 0 ? "Sector data unavailable" : warnings.join(" · ") || null);
       // A refresh that returned nothing must not claim the board is current.
       if (loadedCount === 0) return;
       setLastRefreshByCollection((prev) => ({ ...prev, [collectionId]: Date.now() }));
@@ -206,17 +211,19 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
   }, []);
 
   const updatedAgo = useUpdatedAgo(lastRefreshMs);
+  const returnAsOfDate = rows.map((row) => row.returnAsOfDate).filter((date): date is string => !!date).sort().at(-1);
 
   usePaneFooter("sectors", () => {
     const info: PaneFooterSegment[] = [];
     if (loading) info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
     if (loadError) info.push({ id: "error", parts: [{ text: loadError, tone: "warning" }] });
+    if (returnAsOfDate) info.push({ id: "return-as-of", parts: [{ text: `returns as of ${returnAsOfDate}`, tone: "muted" }] });
     if (updatedAgo) info.push({ id: "updated", parts: [{ text: `updated ${updatedAgo}`, tone: "muted" }] });
     return { info };
-  }, [loadError, loading, updatedAgo]);
+  }, [loadError, loading, returnAsOfDate, updatedAgo]);
 
   const rootBefore = (
-    <Box height={1} paddingX={1}>
+    <Box height={2} paddingX={1} flexDirection="column">
       <Tabs
         tabs={tabs}
         activeValue={activeCollection.id}
@@ -229,6 +236,7 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
         variant="bare"
         focused={focused}
       />
+      <Notice tone="muted">ETF price returns; cash distributions excluded.</Notice>
     </Box>
   );
 

--- a/src/plugins/builtin/sectors/sector-model.test.ts
+++ b/src/plugins/builtin/sectors/sector-model.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import type { PricePoint } from "../../../types/financials";
+import { computeTrailingReturn, sectorReturnTargetDate, sortRows, type SectorRow } from "./sector-model";
+
+const point = (date: string, close: number): PricePoint => ({ date: new Date(date), close });
+
+describe("sector calendar price returns", () => {
+  test("a shorter history cannot stand in for the requested year", () => {
+    const history = [point("2026-06-01", 195.76), point("2026-09-09", 187.87)];
+    expect(computeTrailingReturn(history, "1Y")).toBeNull();
+  });
+
+  test("uses the shared as-of date rather than each history's final bar", () => {
+    const history = [point("2026-08-10", 90), point("2026-08-11", 100), point("2026-09-09", 100)];
+    const current = [...history, point("2026-09-10", 104)];
+    for (const source of [history, current]) {
+      const result = computeTrailingReturn(source, "1M", 105, "2026-09-10");
+      expect(result?.value).toBeCloseTo(16.6666667);
+      expect(result?.startDate).toBe("2026-08-10");
+      expect(result?.endDate).toBe("2026-09-10");
+    }
+    // Without a quote for that session, yesterday's close cannot replace it.
+    expect(computeTrailingReturn(history, "1M", null, "2026-09-10")).toBeNull();
+  });
+
+  test("clamps month ends and leap years, allowing a nearby preceding holiday close", () => {
+    expect(sectorReturnTargetDate("2024-02-29", "1Y")).toBe("2023-02-28");
+    expect(sectorReturnTargetDate("2026-03-31", "1M")).toBe("2026-02-28");
+    const result = computeTrailingReturn([point("2026-02-27", 100), point("2026-03-31", 110)], "1M");
+    expect(result).toMatchObject({ startDate: "2026-02-27", endDate: "2026-03-31" });
+    expect(result?.value).toBeCloseTo(10);
+    expect(computeTrailingReturn([point("2026-02-01", 100), point("2026-03-31", 110)], "1M")).toBeNull();
+  });
+
+  test.each(["asc", "desc"] as const)("keeps unavailable window returns last when sorting %s", (direction) => {
+    const rows = [{ etf: "missing", return1Y: null }, { etf: "loss", return1Y: -5 }, { etf: "gain", return1Y: 10 }] as SectorRow[];
+    expect(sortRows(rows, { columnId: "return1Y", direction }).at(-1)?.etf).toBe("missing");
+  });
+});

--- a/src/plugins/builtin/sectors/sector-model.ts
+++ b/src/plugins/builtin/sectors/sector-model.ts
@@ -9,8 +9,6 @@ import {
 } from "./sector-data";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-export const ONE_MONTH_DAYS = 30;
-export const ONE_YEAR_DAYS = 365;
 export const DEFAULT_COLLECTION_ID: SectorCollectionId = "sectors";
 
 export interface SectorRow extends SectorDef {
@@ -21,6 +19,9 @@ export interface SectorRow extends SectorDef {
   currency: string;
   loading: boolean;
   quoteUnavailable?: boolean;
+  returnAsOfDate?: string | null;
+  return1MStartDate?: string | null;
+  return1YStartDate?: string | null;
 }
 
 type SectorColumnId = "name" | "etf" | "price" | "changePercent" | "return1M" | "return1Y" | "bar";
@@ -85,6 +86,9 @@ export function normalizeRowsForCollection(
       currency: existing?.currency ?? "USD",
       loading: existing?.loading ?? true,
       quoteUnavailable: existing?.quoteUnavailable ?? false,
+      returnAsOfDate: existing?.returnAsOfDate ?? null,
+      return1MStartDate: existing?.return1MStartDate ?? null,
+      return1YStartDate: existing?.return1YStartDate ?? null,
     };
   });
 }
@@ -116,27 +120,45 @@ export function latestHistoryClose(history: readonly PricePoint[]): number | nul
   return getSortedHistory(history).at(-1)?.point.close ?? null;
 }
 
+export function latestHistoryDate(history: readonly PricePoint[]): string | null {
+  const latest = getSortedHistory(history).at(-1);
+  return latest ? new Date(latest.timestamp).toISOString().slice(0, 10) : null;
+}
+
+export type SectorReturnRange = "1M" | "1Y";
+
+/** Clamp calendar subtraction so March 31 maps to February's final day. */
+export function sectorReturnTargetDate(asOfDate: string, range: SectorReturnRange): string {
+  const shifted = new Date(`${asOfDate}T00:00:00Z`);
+  const day = shifted.getUTCDate();
+  shifted.setUTCDate(1);
+  shifted.setUTCMonth(shifted.getUTCMonth() - (range === "1M" ? 1 : 12));
+  const lastDay = new Date(Date.UTC(shifted.getUTCFullYear(), shifted.getUTCMonth() + 1, 0)).getUTCDate();
+  shifted.setUTCDate(Math.min(day, lastDay));
+  return shifted.toISOString().slice(0, 10);
+}
+
 export function computeTrailingReturn(
   history: readonly PricePoint[],
-  days: number,
+  range: SectorReturnRange,
   latestPrice?: number | null,
-): number | null {
+  asOfDate = latestHistoryDate(history),
+): { value: number; startDate: string; endDate: string } | null {
+  if (!asOfDate) return null;
   const points = getSortedHistory(history);
-  if (points.length < 2) return null;
-
-  const latest = points.at(-1)!;
+  const target = sectorReturnTargetDate(asOfDate, range);
+  // Use the last close on/before the calendar boundary, allowing a weekend or
+  // exchange holiday. A shorter history or a long source gap is not 1M/1Y.
+  const baseline = points.findLast(({ timestamp }) => new Date(timestamp).toISOString().slice(0, 10) <= target);
+  if (!baseline) return null;
+  const startDate = new Date(baseline.timestamp).toISOString().slice(0, 10);
+  if (Date.parse(target) - Date.parse(startDate) > 7 * DAY_MS) return null;
+  const end = points.findLast(({ timestamp }) => new Date(timestamp).toISOString().slice(0, 10) === asOfDate);
   const endPrice = latestPrice != null && Number.isFinite(latestPrice) && latestPrice > 0
     ? latestPrice
-    : latest.point.close;
-  const targetTimestamp = latest.timestamp - days * DAY_MS;
-  let baseline = points[0]!;
-  for (const point of points) {
-    if (point.timestamp > targetTimestamp) break;
-    baseline = point;
-  }
-  const baselinePrice = baseline.point.close;
-  if (!Number.isFinite(endPrice) || !Number.isFinite(baselinePrice) || baselinePrice <= 0) return null;
-  return (endPrice / baselinePrice - 1) * 100;
+    : end?.point.close;
+  if (endPrice == null || !Number.isFinite(endPrice) || endPrice <= 0) return null;
+  return { value: (endPrice / baseline.point.close - 1) * 100, startDate, endDate: asOfDate };
 }
 
 export function buildSectorColumns(width: number): SectorColumn[] {


### PR DESCRIPTION
Sector and industry ETF boards could label a short history as a full-year return and compare funds using different dates. A controlled truncation of captured XLK history to June–September still produced a 1Y return of -4.03%.

This change uses a shared ending session and calendar month/year boundaries, requests a small historical boundary buffer when supported, and leaves a return unavailable when the required endpoint or common baseline is missing. The table identifies these as price returns excluding cash distributions, exposes the return as-of date, and reports incomplete windows in CLI output. Correlation now explicitly identifies local-price returns without FX conversion and includes each input's available date range.

Validation:

- 30 focused tests / 343 assertions covering short history, different ending sessions, missing baseline bars, month ends, leap years, prior-year holidays, and incomplete CLI results.
- Live CLI: all 11 sector ETFs loaded; all 22 displayed month/year returns matched independent calculations exactly. All 18 industry ETFs also loaded with matching window dates.
- Native terminal: sector and industry tables, collection switching, dates, and method notices verified with isolated configuration. Live SPY/Tokyo-listed Toyota correlation matched independent shared-date return calculations to floating-point precision, including US/Japan holiday gaps.
- Plugin manifest check passes. Runtime typechecks and CI recorded in checks.

The broader leveraged-fund comparison and sector research scenarios remain partial while separate chart-window work continues. Authenticated Pro access is not claimed by this validation.
