### PR TITLE
Show fiscal date sources in financial tables and exports

### DIFF
--- a/src/plugins/builtin/ticker-detail/financials/model.ts
+++ b/src/plugins/builtin/ticker-detail/financials/model.ts
@@ -124,9 +124,19 @@ export function formatFinancialValue(
   return formatWithDivisor(value, row.divisor);
 }
 
-export function formatFinancialHeader(date: string, currency?: string): string {
+export function formatFinancialHeader(date: string, currency?: string, dateSource?: FinancialStatement["dateSource"], compact = false): string {
   const period = date === "TTM" ? "TTM" : date.slice(0, 10);
-  return currency ? `${period} ${currency}` : period;
+  const label = currency ? `${period} ${currency}` : period;
+  if (date === "TTM") return label;
+  return `${label} ${compact ? (dateSource === "sec" ? "S" : "P") : (dateSource === "sec" ? "(SEC date)" : "(provider date)")}`;
+}
+
+export function financialStatementDateNotice(statements: readonly FinancialStatement[]): string {
+  const dated = statements.filter(({ date }) => date !== "TTM");
+  return [
+    dated.some(({ dateSource }) => dateSource !== "sec") ? "P: provider period date; may be approximate." : "",
+    dated.some(({ dateSource }) => dateSource === "sec") ? "S: SEC fiscal date; filing evidence identifies the period, not every metric's publication date." : "",
+  ].filter(Boolean).join(" ");
 }
 
 export function financialStatementCurrency(

--- a/src/plugins/builtin/ticker-detail/financials/tab.tsx
+++ b/src/plugins/builtin/ticker-detail/financials/tab.tsx
@@ -28,6 +28,7 @@ import {
   formatFinancialCell,
   formatFinancialHeader,
   financialStatementCurrency,
+  financialStatementDateNotice,
   financialStatementLimitations,
   formatFinancialValue,
   resolveFinancialPeriod,
@@ -259,7 +260,7 @@ export function ResolvedFinancialsTab({
       id: `statement:${statement.date}:${index}`,
       kind: "statement",
       statement,
-      label: padTo(formatFinancialHeader(statement.date, statement.currency ?? financialStatementCurrency(financials, displayStatements)), FINANCIAL_COL_W, "center"),
+      label: padTo(formatFinancialHeader(statement.date, statement.currency ?? financialStatementCurrency(financials, displayStatements), statement.dateSource, true), FINANCIAL_COL_W, "center"),
       width: FINANCIAL_COL_W,
       align: "right",
       headerColor: statement.date === "TTM" ? colors.textBright : colors.textDim,
@@ -400,6 +401,7 @@ export function ResolvedFinancialsTab({
         rootBefore={(
           <>
             {financialStatementLimitations(financials).map((limitation) => <Notice key={limitation} tone="muted">{limitation}</Notice>)}
+            {financialStatementDateNotice(displayStatements) && <Notice tone="muted">{financialStatementDateNotice(displayStatements)}</Notice>}
             <Box flexDirection="row" height={1}>
               <Box width={FINANCIAL_SUB_TABS_WIDTH} height={1}>
                 <Tabs

--- a/src/plugins/builtin/ticker-detail/headless.test.ts
+++ b/src/plugins/builtin/ticker-detail/headless.test.ts
@@ -39,6 +39,25 @@ test("financial statements keep raw values, dated growth cells, and formatted co
   expect((shares.cells as Array<{ growth: number }>)[0]!.growth).toBeCloseTo(0.2);
 });
 
+test("financial exports distinguish provider dates from SEC period evidence and derived TTM", async () => {
+  const dateEvidence = { accessionNumber: "0000909832-24-000049", filed: "2024-10-09", startDate: "2023-09-04" };
+  const ctx = { marketData: createTestDataProvider({ async getTickerFinancials() {
+    return { annualStatements: [
+      { date: "2023-08-31", currency: "USD", dateSource: "provider" as const, totalRevenue: 100 },
+      { date: "2024-09-01", currency: "USD", dateSource: "sec" as const, providerDate: "2024-08-31", dateEvidence, totalRevenue: 120 },
+    ], quarterlyStatements: ["2025-03-31", "2025-06-30", "2025-09-30", "2025-12-31"].map((date) => ({
+      date, currency: "USD", dateSource: "sec" as const, dateEvidence, totalRevenue: 40,
+    })), priceHistory: [] };
+  } }) } as HeadlessPaneContext;
+  const result = await financialStatementsHeadless.load(args(["COST"], { period: "annual", statement: "income" }), ctx);
+  const columns = result.metadata!.columns as Array<Record<string, unknown>>;
+  expect(columns.find(({ date }) => date === "2024-09-01")).toMatchObject({ dateSource: "sec", providerDate: "2024-08-31", dateEvidence, label: "2024-09-01 USD (SEC date)" });
+  expect(columns.find(({ date }) => date === "2023-08-31")).toMatchObject({ dateSource: "provider", dateEvidence: null, label: "2023-08-31 USD (provider date)" });
+  expect(columns.find(({ date }) => date === "TTM")).toMatchObject({ dateSource: "derived", dateEvidence: null, providerDate: null });
+  expect(columns.every((column) => !("availableAt" in column))).toBe(true);
+  expect(result.columns?.find(({ key }) => key === "2023-08-31")?.header).toContain("provider date");
+});
+
 test("quote comparison retains successful exchange-qualified inputs when a peer fails", async () => {
   const ctx = {
     signal: new AbortController().signal,

--- a/src/plugins/builtin/ticker-detail/headless.ts
+++ b/src/plugins/builtin/ticker-detail/headless.ts
@@ -1,7 +1,7 @@
 import type { HeadlessPaneColumn, HeadlessPaneDefinition } from "../../../types/headless";
 import type { TimeRange } from "../../../time-series/range";
 import { formatCurrency, formatNumber, formatPercentRaw } from "../../../utils/format";
-import { buildFinancialTableModel, financialStatementCurrency, financialStatementLimitations, formatFinancialHeader } from "./financials/model";
+import { buildFinancialTableModel, financialStatementCurrency, financialStatementDateNotice, financialStatementLimitations, formatFinancialHeader } from "./financials/model";
 import { paneSchemas } from "./headless-schema";
 import {
   loadHeadlessFinancials, loadHeadlessPriceHistory, loadHeadlessSymbols, resolveHeadlessInstrument,
@@ -20,9 +20,12 @@ export const financialStatementsHeadless: HeadlessPaneDefinition<"rows"> = {
       expandAll: true,
     });
     const statementCurrency = financialStatementCurrency(financials, table?.statements ?? []);
-    const dates = table?.statements.map(({ date, currency }) => ({
+    const dates = table?.statements.map(({ date, currency, dateSource, providerDate, dateEvidence }) => ({
       date, currency: currency ?? statementCurrency ?? null,
-      label: formatFinancialHeader(date, currency ?? statementCurrency).trim(),
+      dateSource: date === "TTM" ? "derived" : dateSource ?? "provider",
+      providerDate: date === "TTM" ? null : providerDate ?? null,
+      dateEvidence: date === "TTM" || dateSource !== "sec" ? null : dateEvidence ?? null,
+      label: formatFinancialHeader(date, currency ?? statementCurrency, dateSource).trim(),
     })) ?? [];
     const rows = table?.rows.map((row) => ({
       id: row.id, kind: row.kind, metric: row.unitLabel,
@@ -49,6 +52,7 @@ export const financialStatementsHeadless: HeadlessPaneDefinition<"rows"> = {
         statement: table?.subTab.key ?? options.statement, statementLabel: table?.subTab.name ?? null,
         period: table?.period ?? options.period, growthBasis: table?.period === "quarterly" ? "QoQ" : "YoY", columns: dates,
         limitations: financialStatementLimitations(financials),
+        dateProvenance: financialStatementDateNotice(table?.statements ?? []),
       },
     };
   },

--- a/src/sources/sec-edgar.test.ts
+++ b/src/sources/sec-edgar.test.ts
@@ -133,6 +133,16 @@ describe("parseFilingDocuments", () => {
 });
 
 describe("parseCompanyFactsFinancialStatements", () => {
+  test("keeps the fiscal period accession separate from later metric publication dates", () => {
+    const earlier = { start: "2023-09-04", end: "2024-09-01", form: "10-K", fp: "FY", accn: "0000909832-24-000049", filed: "2024-10-09", val: 100 };
+    const statements = parseCompanyFactsFinancialStatements({ facts: { "us-gaap": {
+      Revenues: { units: { USD: [earlier] } },
+      NetIncomeLoss: { units: { USD: [{ ...earlier, accn: "0000909832-24-000050", filed: "2024-10-20", val: 10 }] } },
+    } } });
+    expect(statements.annualStatements[0]).toMatchObject({ date: "2024-09-01", dateSource: "sec",
+      dateEvidence: { accessionNumber: earlier.accn, filed: earlier.filed, startDate: earlier.start },
+      availableAt: "2024-10-20", fieldAvailability: { totalRevenue: "2024-10-09", netIncome: "2024-10-20" } });
+  });
   test("keeps preferred income concept and its restatements separate from consolidated fallback income", () => {
     const period = { start: "2017-09-04", end: "2018-09-02", form: "10-K", fp: "FY" };
     const statements = parseCompanyFactsFinancialStatements({ facts: { "us-gaap": {
@@ -240,6 +250,7 @@ describe("parseCompanyFactsFinancialStatements", () => {
 
     expect(statements.annualStatements).toEqual([{
       date: "2020-12-31",
+      dateSource: "sec",
       availableAt: "2020-12-31",
       fieldAvailability: {
         totalRevenue: "2020-12-31",
@@ -259,6 +270,7 @@ describe("parseCompanyFactsFinancialStatements", () => {
     expect(statements.quarterlyStatements).toEqual([
       {
         date: "2021-03-31",
+        dateSource: "sec",
         availableAt: "2021-03-31",
         fieldAvailability: {
           totalRevenue: "2021-03-31",
@@ -277,6 +289,7 @@ describe("parseCompanyFactsFinancialStatements", () => {
       },
       {
         date: "2021-06-30",
+        dateSource: "sec",
         availableAt: "2021-06-30",
         fieldAvailability: { totalRevenue: "2021-06-30" },
         totalRevenue: 40,
@@ -325,6 +338,7 @@ describe("parseCompanyFactsFinancialStatements", () => {
 
     expect(parseCompanyFactsFinancialStatements(payload).quarterlyStatements).toEqual([{
       date: "2025-03-29",
+      dateSource: "sec",
       availableAt: "2025-05-02",
       fieldAvailability: { totalRevenue: "2025-05-02" },
       totalRevenue: 95_359,
@@ -452,6 +466,7 @@ describe("parseCompanyFactsFinancialStatements", () => {
     expect(statements.quarterlyStatements).toEqual([
       {
         date: "2025-03-31",
+        dateSource: "sec",
         availableAt: "2025-03-31",
         fieldAvailability: { totalRevenue: "2025-03-31", grossProfit: "2025-03-31" },
         totalRevenue: 100,
@@ -459,6 +474,7 @@ describe("parseCompanyFactsFinancialStatements", () => {
       },
       {
         date: "2026-03-31",
+        dateSource: "sec",
         availableAt: "2026-03-31",
         fieldAvailability: { totalRevenue: "2026-03-31", grossProfit: "2026-03-31" },
         totalRevenue: 200,

--- a/src/sources/sec-edgar.ts
+++ b/src/sources/sec-edgar.ts
@@ -57,6 +57,7 @@ type LookupEntry = {
 
 type CompanyFactsEntry = {
   tagPriority?: number;
+  accn?: string;
   start?: string;
   end?: string;
   val?: number;
@@ -403,6 +404,7 @@ function companyFactsEntries(payload: unknown, tag: string, units: string[]): Co
       .map((entry) => companyFactsRecord(entry))
       .filter((entry): entry is Record<string, unknown> => !!entry)
       .map((entry) => ({
+        accn: typeof entry.accn === "string" ? entry.accn : undefined,
         start: typeof entry.start === "string" ? entry.start : undefined,
         end: typeof entry.end === "string" ? entry.end : undefined,
         val: typeof entry.val === "number" ? entry.val : undefined,
@@ -522,7 +524,7 @@ function setCompanyFactValue(
 ): void {
   const selectionKey = `${date}:${String(field)}`;
   if (!shouldReplaceCompanyFact(entry, selectedFacts.get(selectionKey))) return;
-  const row = rows.get(date) ?? { date };
+  const row = rows.get(date) ?? { date, dateSource: "sec" };
   (row as unknown as Record<string, unknown>)[field] = value;
   if (entry.filed) {
     row.fieldAvailability = {
@@ -566,9 +568,17 @@ function fillCompanyFactsStatementRows(
   }
 }
 
-function finalizeCompanyFactsStatements(rows: Map<string, FinancialStatement>): FinancialStatement[] {
+function finalizeCompanyFactsStatements(rows: Map<string, FinancialStatement>, selectedFacts: Map<string, CompanyFactsEntry>): FinancialStatement[] {
   const statements = Array.from(rows.values()).sort((left, right) => left.date.localeCompare(right.date));
   for (const statement of statements) {
+    // A selected duration fact identifies the fiscal period. Its accession and
+    // filing date are evidence for that identity, never row-wide availability.
+    const anchor = [...selectedFacts.entries()]
+      .filter(([key, entry]) => key.startsWith(`${statement.date}:`) && entry.start && entry.accn
+        && /^\d{10}-\d{2}-\d{6}$/.test(entry.accn) && entry.filed && entry.filed >= statement.date)
+      .map(([, entry]) => entry)
+      .sort((left, right) => left.filed!.localeCompare(right.filed!) || left.accn!.localeCompare(right.accn!))[0];
+    if (anchor) statement.dateEvidence = { accessionNumber: anchor.accn!, filed: anchor.filed!, startDate: anchor.start! };
     if (
       typeof statement.freeCashFlow !== "number"
       && typeof statement.operatingCashFlow === "number"
@@ -615,8 +625,8 @@ export function parseCompanyFactsFinancialStatements(payload: unknown): SecCompa
   }
 
   return {
-    annualStatements: finalizeCompanyFactsStatements(annualRows),
-    quarterlyStatements: finalizeCompanyFactsStatements(quarterlyRows),
+    annualStatements: finalizeCompanyFactsStatements(annualRows, annualSelectedFacts),
+    quarterlyStatements: finalizeCompanyFactsStatements(quarterlyRows, quarterlySelectedFacts),
   };
 }
 

--- a/src/types/financials.ts
+++ b/src/types/financials.ts
@@ -248,6 +248,16 @@ export interface CompanyProfile {
 
 export interface FinancialStatement {
   date: string;
+  /** Source of the fiscal period date; does not establish metric publication dates. */
+  dateSource?: "sec" | "provider";
+  /** Original vendor period date when independent filing evidence changes it. */
+  providerDate?: string;
+  /** Filing evidence for the period identity only, not availability of every field. */
+  dateEvidence?: {
+    accessionNumber: string;
+    filed: string;
+    startDate: string;
+  };
   /** Reporting currency for monetary statement fields (per-share values use reported shares). */
   currency?: string;
   /** Earliest date on which the complete row was publicly available, when known. */

--- a/src/utils/financial-statements.test.ts
+++ b/src/utils/financial-statements.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, test } from "bun:test";
 import { coalesceFinancialPeriodAliases, mergeFinancialStatementRows } from "./financial-statements";
 import { computeTTM } from "../plugins/builtin/ticker-detail/financials/aggregation";
+import type { FinancialStatement } from "../types/financials";
+
+test("period evidence follows the selected fiscal date without inventing field availability", () => {
+  const dateEvidence = { accessionNumber: "0000909832-26-000050", filed: "2026-06-04", startDate: "2026-02-16" };
+  const fiscal: FinancialStatement = { date: "2026-05-10", currency: "USD", dateSource: "sec", dateEvidence, totalRevenue: 70527, netIncome: 2192, totalAssets: 81639 };
+  const provider: FinancialStatement = { ...fiscal, date: "2026-05-31", dateSource: "provider", dateEvidence: undefined };
+  for (const [primary, fallback] of [[provider, fiscal], [fiscal, provider]] as const) {
+    const [merged] = mergeFinancialStatementRows([primary], [fallback]);
+    expect(merged).toMatchObject({ date: fiscal.date, dateSource: "sec", dateEvidence });
+    expect(merged?.availableAt).toBeUndefined();
+    expect(merged?.fieldAvailability).toBeUndefined();
+  }
+  const sameDate = mergeFinancialStatementRows([{ ...provider, date: fiscal.date }], [fiscal])[0]!;
+  expect(sameDate.dateEvidence).toEqual(dateEvidence);
+  const different = mergeFinancialStatementRows([{ ...provider, date: "2026-05-09", totalRevenue: 1 }], [{ ...fiscal, availableAt: "2026-06-04" }])[0]!;
+  expect(different.date).toBe("2026-05-09");
+  expect(different.dateSource).toBe("provider");
+  expect(different.dateEvidence).toBeUndefined();
+});
 
 describe("mergeFinancialStatementRows", () => {
   test("preserves per-field availability across providers", () => {

--- a/src/utils/financial-statements.ts
+++ b/src/utils/financial-statements.ts
@@ -1,6 +1,6 @@
 import type { FinancialStatement } from "../types/financials";
 
-const STATEMENT_METADATA_KEYS = new Set(["date", "currency", "availableAt", "fieldAvailability"]);
+const STATEMENT_METADATA_KEYS = new Set(["date", "dateSource", "providerDate", "dateEvidence", "currency", "availableAt", "fieldAvailability"]);
 const NEARBY_PERIOD_END_MS = 7 * 24 * 60 * 60 * 1_000;
 
 function metricKeys(...rows: Array<FinancialStatement | undefined>): string[] {
@@ -25,6 +25,8 @@ function canonicalStatementDate(
   fallback: FinancialStatement | undefined,
 ): string {
   if (!fallback) return primary.date;
+  if (primary.dateSource === "sec") return primary.date;
+  if (fallback.dateSource === "sec") return hasMatchingFinancialValues(primary, fallback) ? fallback.date : primary.date;
   if (isVerifiedCalendarAlias(primary, fallback)) return [primary.date, fallback.date].sort()[0]!;
   return hasAvailabilityEvidence(fallback) && !hasAvailabilityEvidence(primary)
     ? fallback.date
@@ -62,7 +64,7 @@ function isVerifiedCalendarAlias(left: FinancialStatement, right: FinancialState
   };
   if (monthEnd(left) === monthEnd(right)) return false;
   const fiscal = monthEnd(left) ? right : left;
-  if (!hasAvailabilityEvidence(fiscal)) return false;
+  if (fiscal.dateSource !== "sec" && !hasAvailabilityEvidence(fiscal)) return false;
   // A month-end approximation can be weeks away for a 52/53-week issuer.
   // Require corroborating values, not just proximity or common zero fields.
   return hasMatchingFinancialValues(left, right);
@@ -121,6 +123,15 @@ export function mergeFinancialStatementRows(
       // otherwise retain their primary provider's period identity.
       date: canonicalStatementDate(row, fallback),
     } as FinancialStatement;
+    // Period provenance belongs to the selected date. It must not leak from a
+    // different fallback period or become publication evidence for any value.
+    const dateOwner = [row, fallback].find((candidate) => candidate?.date === merged.date && candidate.dateSource === "sec")
+      ?? (row.date === merged.date ? row : fallback);
+    for (const key of ["dateSource", "providerDate", "dateEvidence"] as const) delete merged[key];
+    if (dateOwner?.dateSource) merged.dateSource = dateOwner.dateSource;
+    if (dateOwner?.providerDate) merged.providerDate = dateOwner.providerDate;
+    if (dateOwner?.dateEvidence) merged.dateEvidence = dateOwner.dateEvidence;
+    if (merged.dateSource === "sec" && row.date !== merged.date && !merged.providerDate) merged.providerDate = row.date;
     const fieldAvailability: Record<string, string> = {};
     const keys = metricKeys(row, fallback);
 


### PR DESCRIPTION
Financial tables previously presented vendor month-end approximations as exact fiscal dates. COST's vendor 2024-08-31 label, for example, represents the SEC fiscal period ending 2024-09-01. The financial table now distinguishes provider period dates (P, possibly approximate) from SEC fiscal dates (S), with a visible explanation. FA text/CSV headers use full source labels; JSON columns retain the original provider date and accession, filing date, and period start when supplied.

The additive contract matches backend PR226. Native SEC statements also retain period provenance. Merges bind evidence to the selected date, require corroborating values before replacing a provider date, and keep period evidence separate from field publication dates. TTM is labelled derived and never inherits one filing's evidence. Older cached rows without source metadata remain unverified until refreshed.

Validation: 79 focused tests / 229 assertions; browser and OpenTUI typechecks; production web build; diff check. Actual native FA COST output and local browser used live current data to verify unverified date labels. An OpenTUI tmux run used the saved public COST SEC companyfacts payload to verify exact fiscal dates and accession output. Browser replay of the immutable backend226 result verified mixed SEC/provider quarter labels and annual views; no application errors (one WebSocket reconnect warning during reload). The SEC replay is fixture validation, not a claim that backend226 is already deployed.

Primary source: https://www.sec.gov/search-filings/edgar-application-programming-interfaces
