### PR TITLE
Keep cached chart data within its selected research window

### DIFF
--- a/src/components/data-table/view.test.tsx
+++ b/src/components/data-table/view.test.tsx
@@ -175,10 +175,14 @@ function DeferredScrollHarness({ onScroll, initialRows = [], initialIndex = 500,
 }
 
 async function renderSettled() {
-  await act(async () => {
-    await testSetup!.renderOnce();
-    await testSetup!.renderOnce();
-  });
+  // Commit React's measurement/scroll effects between native frames, then
+  // paint the resulting viewport. One act around every frame can leave the
+  // numeric scroll offset updated while the captured frame is still old.
+  for (let phase = 0; phase < 3; phase += 1) {
+    await act(async () => {
+      await testSetup!.renderOnce();
+    });
+  }
 }
 
 const emitKeypress = (event: TestKeyEvent) => emitTuiKeypress(testSetup!, event);

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -74,7 +74,49 @@ describe("resolveChartSpecData", () => {
 
     const volume = seeded?.series.find((entry) => entry.panelId === "volume");
     expect(volume?.points.map((point) => point.value)).toEqual([5_000]);
-    expect(seeded?.bufferedSeries).toBe(seeded?.series);
+    expect(seeded?.bufferedSeries?.find((entry) => entry.panelId === "volume")?.points).toHaveLength(1);
+  });
+
+  test("cached history honors the visible date range before the network resolves", () => {
+    const source = { kind: "security" as const, instrument: { symbol: "TEST", exchange: "NASDAQ" }, fieldId: "market.close" };
+    const history = ["2021-01-01", "2026-08-01", "2026-08-15", "2026-09-10"].map((day, i) => ({
+      date: new Date(`${day}T00:00:00Z`), close: 100 + i, volume: 1_000 + i,
+    }));
+    const seeded = seedChartResolutionResult(chartSpec({
+      viewport: { range: "1M", resolution: "auto" },
+      series: [chartSeries({ source, transform: "percent" })],
+    }), new Map([[chartQuoteOverrideKeyForSource(source), history]]));
+    expect(seeded?.viewport?.start.toISOString()).toBe("2026-08-10T00:00:00.000Z");
+    expect(seeded?.viewport?.end.toISOString()).toBe("2026-09-10T00:00:00.000Z");
+    expect(seeded?.series[0]?.points.map((p) => p.date.toISOString().slice(0, 10))).toEqual(["2026-08-15", "2026-09-10"]);
+    expect(seeded?.series[0]?.points[0]?.value).toBe(0);
+    expect(seeded?.bufferedSeries?.[0]?.points).toHaveLength(4);
+  });
+
+  test("a point-limited seed exposes a viewport only for an explicit date window", () => {
+    const source = { kind: "security" as const, instrument: { symbol: "TEST", exchange: "NASDAQ" }, fieldId: "market.close" };
+    const history = ["2026-08-01", "2026-08-15", "2026-09-10"].map((day, index) => ({
+      date: new Date(`${day}T00:00:00Z`), close: 100 + index,
+    }));
+    const cached = new Map([[chartQuoteOverrideKeyForSource(source), history]]);
+    const spec = chartSpec({ viewport: { range: "1Y", resolution: "auto", maxPoints: 2 }, series: [chartSeries({ source })] });
+    const seed = seedChartResolutionResult(spec, cached);
+    expect(seed?.series[0]?.points).toHaveLength(2);
+    expect(seed?.viewport).toBeUndefined();
+    expect(seed?.bufferedSeries).toBeUndefined();
+    const explicit = seedChartResolutionResult({ ...spec, viewport: {
+      ...spec.viewport, dateWindow: { start: "2026-08-01", end: "2026-09-10" },
+    } }, cached);
+    expect(explicit?.viewport?.start.toISOString()).toBe("2026-08-01T00:00:00.000Z");
+    expect(explicit?.viewport?.end.toISOString()).toBe("2026-09-10T23:59:59.999Z");
+  });
+
+  test("stale cached observations cannot move a current preset window into the past", () => {
+    const source = { kind: "security" as const, instrument: { symbol: "TEST" }, fieldId: "market.close" };
+    const cached = new Map([[chartQuoteOverrideKeyForSource(source), [{ date: new Date("2026-08-31T00:00:00Z"), close: 100 }]]]);
+    const result = seedChartResolutionResult(chartSpec({ viewport: { range: "1M", resolution: "auto" },
+      series: [chartSeries({ source })] }), cached, new Date("2026-09-10T18:00:00Z"));
+    expect(result?.viewport).toEqual({ start: new Date("2026-08-10T18:00:00Z"), end: new Date("2026-09-10T18:00:00Z") });
   });
 
   test("keeps study output over the whole buffered history its base series carries", async () => {

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -374,6 +374,7 @@ function emptyFinancials(priceHistory: TickerFinancials["priceHistory"] = []): T
 export function seedChartResolutionResult(
   spec: ChartSpec,
   historyByInstrument: ReadonlyMap<string, TickerFinancials["priceHistory"]>,
+  referenceNow?: Date,
 ): ChartResolutionResult | null {
   const series: ResolvedSeries[] = [];
   spec.series.forEach((seriesSpec, index) => {
@@ -385,19 +386,36 @@ export function seedChartResolutionResult(
     if (resolved?.points.length) series.push(resolved);
   });
   if (series.length === 0) return null;
-  // Studies ride along with the seed. Without them the chart briefly drops to
-  // base series alone whenever it falls back here, and every panel a study
-  // owns loses its rows until the first real resolve lands.
-  const seeded = spec.studies.length > 0
-    ? [...series, ...resolveStudies(series, spec.studies).series]
-    : series;
+  let latest = Number.NEGATIVE_INFINITY;
+  for (const entry of series) {
+    for (const point of entry.points) latest = Math.max(latest, point.date.getTime());
+  }
+  const bounds = requestedBounds(spec, referenceNow ?? new Date(latest));
+  const baseSeries = series.map((entry) => prepareBaseSeriesForStudies(entry, bounds));
+  // Calculate studies from raw buffered inputs, then use the same presentation
+  // and visible-window rules as the network result.
+  const studies = resolveStudies(series, spec.studies);
+  const bufferedSeries = [
+    ...baseSeries,
+    ...applyStudyPresentationTransforms(studies.series, spec.studies, series, bounds),
+  ];
+  const visible = bufferedSeries.map((entry) => {
+    const clipped = bounds.start !== null && bounds.end !== null
+      ? clipSeriesToWindow(entry, new Date(bounds.start), new Date(bounds.end))
+      : { ...entry, points: filterPoints(entry.points, bounds) };
+    return spec.viewport.maxPoints === undefined ? clipped
+      : { ...clipped, points: clipped.points.slice(-spec.viewport.maxPoints) };
+  });
   return {
-    series: seeded,
-    legendSeries: seeded,
-    bufferedSeries: seeded,
-    loading: false,
-    errors: [],
-    warnings: [],
+    series: visible,
+    legendSeries: visible,
+    ...(spec.viewport.maxPoints === undefined ? { bufferedSeries } : {}),
+    ...((explicitBounds(spec) !== null || spec.viewport.maxPoints === undefined)
+      && bounds.start !== null && bounds.end !== null
+      ? { viewport: { start: new Date(bounds.start), end: new Date(bounds.end) } } : {}),
+    loading: true,
+    errors: studies.errors,
+    warnings: studies.warnings,
     resolution: spec.viewport.resolution === "auto"
       ? getPresetResolution(spec.viewport.range)
       : spec.viewport.resolution,

--- a/src/time-series/use-chart-resolution.test.tsx
+++ b/src/time-series/use-chart-resolution.test.tsx
@@ -447,13 +447,81 @@ describe("useChartResolution", () => {
     });
 
     expect(latestResult?.series[0]?.points.length).toBe(2);
-    expect(latestResult?.loading).toBe(false);
+    expect(latestResult?.loading).toBe(true);
 
     await act(async () => {
       history.resolve(INITIAL_HISTORY);
       await testSetup!.renderOnce();
     });
     await waitFor(() => latestResult?.loading === false);
+  });
+
+  test("a settled history failure is not replaced by an indefinitely loading cached seed", async () => {
+    const history = deferred<PricePoint[]>();
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => EMPTY_FINANCIALS,
+      getPriceHistoryForResolution: async () => history.promise,
+      getPriceHistory: async () => { throw new Error("Selected history unavailable"); },
+    });
+    setSharedMarketDataCoordinator({
+      subscribe: () => () => {}, getVersion: () => 1,
+      getChartEntry: () => ({ ...createIdleEntry<PricePoint[]>(), phase: "ready",
+        data: INITIAL_HISTORY, lastGoodData: INITIAL_HISTORY, source: "test", fetchedAt: Date.now() }),
+    } as never);
+    testSetup = await testRender(<ResolutionHarness sources={sourcesFor(provider)} />, { width: 24, height: 1 });
+    expect(latestResult?.loading).toBe(true);
+    expect(latestResult?.series[0]?.points.length).toBe(2);
+    history.reject(new Error("Selected history unavailable"));
+    await waitFor(() => latestResult?.loading === false);
+    expect(latestResult?.errors.join(" ")).toContain("Selected history unavailable");
+    await flushEffects(3);
+    expect(latestResult?.loading).toBe(false);
+  });
+
+  test("identical hydrated specs preserve one pending resolution during quote-driven renders", async () => {
+    const history = deferred<PricePoint[]>();
+    let historyCalls = 0;
+    let resolvedInputs = 0;
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => EMPTY_FINANCIALS,
+      getPriceHistoryForResolution: async () => { historyCalls += 1; return history.promise; },
+      getPriceHistory: async () => [],
+    });
+    const sources = { ...sourcesFor(provider), onSecurityData: () => { resolvedInputs += 1; } };
+    testSetup = await testRender(<MutableSpecHarness sources={sources} />, { width: 24, height: 1 });
+    await waitFor(() => historyCalls === 1);
+    for (let index = 0; index < 3; index += 1) {
+      await act(async () => { setChartSpec?.(JSON.parse(JSON.stringify(SPEC))); });
+      await flushEffects(2);
+    }
+    history.resolve(INITIAL_HISTORY);
+    await waitFor(() => latestResult?.loading === false);
+    expect(historyCalls).toBe(1);
+    expect(resolvedInputs).toBe(1);
+    expect(latestResult?.series[0]?.points).toHaveLength(2);
+  });
+
+  test("changing a security cannot retain its predecessor's chart after a failed request", async () => {
+    const other = deferred<PricePoint[]>();
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => EMPTY_FINANCIALS,
+      getPriceHistoryForResolution: async (symbol) => symbol === "OTHER" ? other.promise : INITIAL_HISTORY,
+      getPriceHistory: async () => { throw new Error("OTHER unavailable"); },
+    });
+    testSetup = await testRender(<MutableSpecHarness sources={sourcesFor(provider)} />, { width: 24, height: 1 });
+    await waitFor(() => latestResult?.loading === false && latestResult.series[0]?.points.length === 2);
+    await act(async () => {
+      setChartSpec?.({ ...SPEC, series: [{ ...SPEC.series[0]!, source: {
+        kind: "security", instrument: { symbol: "OTHER", exchange: "NASDAQ" }, fieldId: "market.ohlcv",
+      } }] });
+      await testSetup!.renderOnce();
+    });
+    expect(latestResult?.series.flatMap((entry) => entry.points)).toEqual([]);
+    expect(latestResult?.loading).toBe(true);
+    other.reject(new Error("OTHER unavailable"));
+    await waitFor(() => latestResult?.loading === false);
+    expect(latestResult?.series.flatMap((entry) => entry.points)).toEqual([]);
+    expect(latestResult?.errors.join(" ")).toContain("OTHER unavailable");
   });
 
   test("reuses cached history when the spec object identity changes", async () => {

--- a/src/time-series/use-chart-resolution.ts
+++ b/src/time-series/use-chart-resolution.ts
@@ -101,10 +101,18 @@ export function useChartResolution(
 ): UseChartResolutionResult {
   const snapshot = options.snapshot;
   const coordinator = getSharedMarketDataCoordinator();
-  const [result, setResult] = useState<ChartResolutionResult>(
-    () => snapshot ?? seedChartResolutionResult(spec, collectSeedHistory(spec)) ?? EMPTY_RESULT,
-  );
-  const needsSeed = !snapshot && !hasRenderableData(result);
+  const specKey = JSON.stringify(spec);
+  const [state, setState] = useState(() => ({
+    key: specKey,
+    result: snapshot ?? seedChartResolutionResult(spec, collectSeedHistory(spec), sources.now ?? new Date()) ?? EMPTY_RESULT,
+  }));
+  // A selected range, listing or transform owns its displayed data. A pending
+  // request must not keep another specification's result under the new controls.
+  const result = state.key === specKey ? state.result : EMPTY_RESULT;
+  // A seed bridges an in-flight request. Once that request settles, an empty
+  // or failed result must not be replaced with a fresh loading seed forever.
+  const needsSeed = !snapshot && !hasRenderableData(result)
+    && (state.key !== specKey || result.loading);
   const subscribeSeed = useCallback((listener: () => void) => {
     if (!needsSeed || !coordinator) return () => {};
     return coordinator.subscribe(listener);
@@ -115,7 +123,7 @@ export function useChartResolution(
   }, [coordinator, needsSeed]);
   useSyncExternalStore(subscribeSeed, getSeedSnapshot, () => 0);
   const seeded = needsSeed
-    ? seedChartResolutionResult(spec, collectSeedHistory(spec))
+    ? seedChartResolutionResult(spec, collectSeedHistory(spec), sources.now ?? new Date())
     : null;
   const displayed = hasRenderableData(result) ? result : (seeded ?? result);
   const resultRef = useRef(displayed);
@@ -175,9 +183,9 @@ export function useChartResolution(
     cacheIdentityRef.current = { spec, sources, revision };
     const cache = resolveCacheRef.current;
     const current = resultRef.current;
-    const backgroundRefresh = hasRenderableData(current) && !isExplicitReload;
+    const backgroundRefresh = state.key === specKey && hasRenderableData(current) && !current.loading && !isExplicitReload;
     if (!backgroundRefresh) {
-      setResult((currentResult) => ({ ...currentResult, loading: true, errors: [] }));
+      setState({ key: specKey, result: { ...current, loading: true, errors: [] } });
     }
     resolveChartSpecData(
       spec,
@@ -188,17 +196,16 @@ export function useChartResolution(
       .then((next) => {
         if (generationRef.current !== generation) return;
         if (backgroundRefresh && !hasRenderableData(next)) return;
-        setResult(next);
+        setState({ key: specKey, result: next });
       })
       .catch((error) => {
         if (generationRef.current !== generation) return;
         if (backgroundRefresh) return;
-        setResult({
-          series: [],
+        setState({ key: specKey, result: {
+          ...current,
           loading: false,
           errors: [error instanceof Error ? error.message : String(error)],
-          warnings: [],
-        });
+        } });
       });
     return () => {
       if (generationRef.current === generation) generationRef.current += 1;
@@ -212,7 +219,7 @@ export function useChartResolution(
     requestViewportStart,
     revision,
     sources,
-    spec,
+    specKey,
   ]);
 
   const liveTargetSignature = liveChartQuoteTargetSignature(spec);
@@ -242,24 +249,30 @@ export function useChartResolution(
             liveSubscriptionGenerationRef.current === subscriptionGeneration
             && generationRef.current === generation
           ) {
-            setResult((current) => (
-              (request.options.autoViewport || request.options.requestViewport)
-              && !current.loading
-              && hasRenderableData(current)
+            const requestKey = JSON.stringify(request.spec);
+            setState((current) => ({ key: requestKey, result:
+              current.key === requestKey
+              && (request.options.autoViewport || request.options.requestViewport)
+              && !current.result.loading
+              && hasRenderableData(current.result)
               && !hasRenderableData(next)
-                ? current
-                : next
-            ));
+                ? current.result
+                : next,
+            }));
           }
         } catch (error) {
           if (
             liveSubscriptionGenerationRef.current !== subscriptionGeneration
             || generationRef.current !== generation
           ) return;
-          setResult((current) => ({
+          const requestKey = JSON.stringify(request.spec);
+          setState((current) => current.key !== requestKey ? current : ({
             ...current,
-            loading: false,
-            errors: [error instanceof Error ? error.message : String(error)],
+            result: {
+              ...current.result,
+              loading: false,
+              errors: [error instanceof Error ? error.message : String(error)],
+            },
           }));
         }
       },


### PR DESCRIPTION
Changing a custom chart from 5Y to 1M could leave five years of cached prices under the selected 1M control. Cached observations also skipped presentation transforms, and a failed request could keep resurrecting a loading seed indefinitely.

Apply the requested date window and transforms to cached chart data, keeping raw buffers for study calculations. Scope loaded data to the chart specification, use semantic specification identity so quote-driven hydration does not repeatedly cancel pending work, and stop seeding once a request settles. Current presets remain anchored to the requested reference time even when cached observations are older; capped and explicit-window exports retain the resolver's viewport rules.

Validation:
- Full suite: 2,826 tests / 10,372 assertions passed before the final one-test reference-time addition; the final focused resolver/hook suite has 48 tests / 212 assertions passing. Browser and OpenTUI TypeScript checks and web build pass.
- Before/after regressions cover cached date clipping, percent normalization, stale cache reference dates, unchanged-spec rerenders, security changes during failed requests, and failure-to-loading loops. Independent review reproduced the latter failures against prior behavior.
- Browser (Playwriter headless, Browser plugin unavailable): production G QQQ,TQQQ,SQQQ kept 2021–2026 under 1M; patched build shows the selected period. 1Y displays Sep10 2025–Sep10 2026. Checked at1280×720 and900×700. Startup/restart WebSocket warnings were observed; no framework overlay.
- A separate existing freshness bug rejects valid delayed/coarse cloud bars on 1M. This patch exposes that failure instead of displaying another period or loading forever; interval-aware freshness is a separate followup.
- Actual native tmux journey switched the custom chart through 5Y, 1M, and 1Y with matching axes. Percent-mode keyboard interaction exposed a separate editor focus bug and is being fixed separately.
- After the companion freshness fix, live browser 1M settles to Aug10–Sep10 for all three ETFs at1280×900 and900×700. A brief loading seed initially showedJul31–Aug31 before resolution completed; that transient anchor behavior remains uncharacterized.
- Includes the already reviewed native table test harness adjustment to flush React layout commits before checking painted rows.

No version bump or GitHub release.
