### PR TITLE
Respect bar cadence when checking chart history freshness

### DIFF
--- a/src/sources/provider-router/cache.ts
+++ b/src/sources/provider-router/cache.ts
@@ -67,8 +67,8 @@ export function isIntradayRange(range: TimeRange): boolean {
   return range === "1D" || range === "1W" || range === "1M" || range === "3M";
 }
 
-export function isStaleIntradayHistory(points: PricePoint[], enabled: boolean, exchange?: string): boolean {
-  return enabled && isPriceHistoryStaleForCurrentWindow(points, Date.now(), { exchange });
+export function isStaleIntradayHistory(points: PricePoint[], enabled: boolean, exchange?: string, intervalMs?: number | null): boolean {
+  return enabled && isPriceHistoryStaleForCurrentWindow(points, Date.now(), { exchange, intervalMs });
 }
 
 export function isCurrentHistoryWindow(endDate?: Date): boolean {

--- a/src/sources/provider-router/history.test.ts
+++ b/src/sources/provider-router/history.test.ts
@@ -18,6 +18,43 @@ afterEach(() => {
 });
 
 describe("AssetDataRouter chart history", () => {
+  test("uses requested bar cadence for fetched and cached charts and infers generic daily data", async () => {
+    const originalNow = Date.now;
+    Date.now = () => Date.parse("2026-09-10T19:39:09Z");
+    const persistence = new AppPersistence(createTempDbPath("bar-cadence-freshness"));
+    const intraday = ["2026-09-10T18:45:00Z", "2026-09-10T19:00:00Z"].map((date) => ({ date: new Date(date), close: 709 }));
+    const daily = ["2026-09-04T00:00:00Z", "2026-09-08T00:00:00Z", "2026-09-09T00:00:00Z"].map((date) => ({ date: new Date(date), close: 716.31 }));
+    const weekly = [{ date: new Date("2026-09-07T00:00:00Z"), close: 716.31 }];
+    const calls = { generic: 0, resolution: 0, detailed: 0 };
+    const router = new AssetDataRouter({
+      ...fallbackProvider,
+      async getPriceHistory() { calls.generic++; return daily; },
+      async getPriceHistoryForResolution() { calls.resolution++; return intraday; },
+      async getDetailedPriceHistory(_ticker, _exchange, _start, _end, barSize) {
+        calls.detailed++;
+        return barSize === "1wk" ? weekly : intraday;
+      },
+    }, [], persistence.resources);
+    const start = new Date("2026-08-10T19:39:09Z");
+    const end = new Date(Date.now());
+    try {
+      for (let attempt = 0; attempt < 2; attempt++) {
+        // Persistence serializes Date labels; values and timestamps must survive.
+        expect(JSON.stringify(await router.getPriceHistory("QQQ", "NASDAQ", "1M"))).toBe(JSON.stringify(daily));
+        expect(JSON.stringify(await router.getPriceHistoryForResolution("QQQ", "NASDAQ", "1M", "15m"))).toBe(JSON.stringify(intraday));
+        expect(JSON.stringify(await router.getDetailedPriceHistory("QQQ", "NASDAQ", start, end, "15m"))).toBe(JSON.stringify(intraday));
+        expect(JSON.stringify(await router.getDetailedPriceHistory("QQQ", "NASDAQ", start, end, "1wk"))).toBe(JSON.stringify(weekly));
+      }
+      expect(calls).toEqual({ generic: 1, resolution: 1, detailed: 2 });
+      await expect(router.getPriceHistoryForResolution("QQQ", "NASDAQ", "1M", "1m")).rejects.toThrow("No resolution-aware history provider");
+      Date.now = () => Date.parse("2026-09-11T19:39:09Z");
+      await expect(router.getPriceHistoryForResolution("QQQ", "NASDAQ", "1M", "15m")).rejects.toThrow("No resolution-aware history provider");
+    } finally {
+      persistence.close();
+      Date.now = originalNow;
+    }
+  });
+
   test("does not log expected provider misses for missing chart data", async () => {
     const noisyProvider: DataProvider = {
       ...fallbackProvider,

--- a/src/sources/provider-router/history.ts
+++ b/src/sources/provider-router/history.ts
@@ -14,7 +14,7 @@ import { clipPriceHistoryToRange } from "../../time-series/history-window";
 import { repairIsolatedIntradayOhlcOutliers } from "../../time-series/history-quality";
 import { canonicalExchange } from "../../utils/exchanges";
 import { resolvePriceHistoryCurrencyUnit } from "../../utils/currency-units";
-import { isPriceHistoryStaleForCurrentWindow, normalizePriceHistory } from "../../utils/price-history";
+import { isPriceHistoryStaleForCurrentWindow, normalizePriceHistory, priceHistoryIntervalMs } from "../../utils/price-history";
 import { shouldLogProviderError } from "../provider-errors";
 import {
   buildVariantKey,
@@ -192,6 +192,7 @@ export class ProviderRouterHistoryRoutes {
       fallbackVariantParts: [["range", bufferRange], ["resolution", resolution]],
     });
     const intraday = isIntradayResolution(resolution);
+    const intervalMs = priceHistoryIntervalMs(resolution);
     return this.executeHistoryRequest({
       ...identity,
       cacheVariantKeys: expandedHistoryCacheVariantKeys(this.deps, {
@@ -205,8 +206,8 @@ export class ProviderRouterHistoryRoutes {
       context,
       cachePolicyKey: intraday ? "priceHistoryIntraday" : "priceHistoryDaily",
       missingProviderError: `No resolution-aware history provider available for ${ticker}`,
-      isCachedValueStale: (value) => isStaleIntradayHistory(value, intraday, exchange),
-      isFetchedValueStale: (value) => isStaleIntradayHistory(value, intraday, exchange),
+      isCachedValueStale: (value) => isStaleIntradayHistory(value, intraday, exchange, intervalMs),
+      isFetchedValueStale: (value) => isStaleIntradayHistory(value, intraday, exchange, intervalMs),
       fetchBroker: async (candidate) => candidate.broker.getPriceHistoryForResolution
         ? candidate.broker.getPriceHistoryForResolution(
           ticker,
@@ -302,14 +303,15 @@ export class ProviderRouterHistoryRoutes {
       fallbackVariantParts: fallbackParts,
     });
     const currentWindowAtLookup = isCurrentHistoryWindow(endDate);
+    const intervalMs = priceHistoryIntervalMs(barSize);
     return this.executeHistoryRequest({
       ...identity,
       context,
-      cachePolicyKey: "priceHistoryIntraday",
+      cachePolicyKey: intervalMs != null && intervalMs >= 24 * 60 * 60 * 1000 ? "priceHistoryDaily" : "priceHistoryIntraday",
       isCachedValueStale: (value) => currentWindowAtLookup
-        && isPriceHistoryStaleForCurrentWindow(value, Date.now(), { exchange }),
+        && isPriceHistoryStaleForCurrentWindow(value, Date.now(), { exchange, intervalMs }),
       isFetchedValueStale: (value) => isCurrentHistoryWindow(endDate)
-        && isPriceHistoryStaleForCurrentWindow(value, Date.now(), { exchange }),
+        && isPriceHistoryStaleForCurrentWindow(value, Date.now(), { exchange, intervalMs }),
       fetchBroker: async (candidate) => candidate.broker.getDetailedPriceHistory
         ? candidate.broker.getDetailedPriceHistory(
           ticker,

--- a/src/utils/price-history.test.ts
+++ b/src/utils/price-history.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, test } from "bun:test";
-import { isPriceHistoryStaleForCurrentWindow, normalizePriceHistory } from "./price-history";
+import { isPriceHistoryStaleForCurrentWindow, normalizePriceHistory, priceHistoryIntervalMs } from "./price-history";
+
+describe("history freshness follows bar cadence", () => {
+  const now = Date.parse("2026-09-10T19:39:09Z");
+  const points = (dates: string[]) => dates.map((date) => ({ date: new Date(date), close: 709 }));
+
+  test("allows delayed completed bars without relaxing one-minute freshness", () => {
+    const history = points(["2026-09-10T18:45:00Z", "2026-09-10T19:00:00Z"]);
+    expect(isPriceHistoryStaleForCurrentWindow(history, now, { exchange: "NASDAQ", intervalMs: priceHistoryIntervalMs("15m") })).toBe(false);
+    expect(isPriceHistoryStaleForCurrentWindow(history, now, { exchange: "NASDAQ", intervalMs: priceHistoryIntervalMs("1m") })).toBe(true);
+    expect(isPriceHistoryStaleForCurrentWindow(history, now, { exchange: "NASDAQ", intervalMs: priceHistoryIntervalMs("5min") })).toBe(true);
+    expect(isPriceHistoryStaleForCurrentWindow(history, Date.parse("2026-09-10T19:46:00Z"), { exchange: "NASDAQ", intervalMs: priceHistoryIntervalMs("15m") })).toBe(true);
+    expect(isPriceHistoryStaleForCurrentWindow(points(["2026-09-10T17:30:00Z"]), now,
+      { exchange: "NASDAQ", intervalMs: priceHistoryIntervalMs("1h") })).toBe(false);
+  });
+
+  test("infers generic daily history across weekends and holidays, not a sparse intraday pair", () => {
+    const daily = points(["2026-09-04T00:00:00Z", "2026-09-08T00:00:00Z", "2026-09-09T00:00:00Z"]);
+    expect(isPriceHistoryStaleForCurrentWindow(daily, now, { exchange: "NASDAQ" })).toBe(false);
+    expect(isPriceHistoryStaleForCurrentWindow(daily, now, { exchange: "NASDAQ", intervalMs: priceHistoryIntervalMs("15m") })).toBe(true);
+    const sparse = points(["2026-09-09T19:00:00Z", "2026-09-10T19:00:00Z"]);
+    expect(isPriceHistoryStaleForCurrentWindow(sparse, now, { exchange: "NASDAQ" })).toBe(true);
+  });
+
+  test("keeps explicit weekly labels usable and still rejects prior-session intraday bars", () => {
+    expect(isPriceHistoryStaleForCurrentWindow(points(["2026-09-07T00:00:00Z"]), now,
+      { exchange: "NASDAQ", intervalMs: priceHistoryIntervalMs("1week") })).toBe(false);
+    const previousSession = points(["2026-09-09T18:45:00Z", "2026-09-09T19:00:00Z"]);
+    expect(isPriceHistoryStaleForCurrentWindow(previousSession, now,
+      { exchange: "NASDAQ", intervalMs: priceHistoryIntervalMs("15min") })).toBe(true);
+    expect(isPriceHistoryStaleForCurrentWindow(points(["2026-09-11T19:00:00Z"]), Date.parse("2026-09-13T19:39:09Z"),
+      { exchange: "NASDAQ", intervalMs: priceHistoryIntervalMs("15min") })).toBe(false);
+  });
+});
 
 describe("normalizePriceHistory", () => {
   test("drops poisoned cached history when every timestamp collapses to the same value", () => {

--- a/src/utils/price-history.ts
+++ b/src/utils/price-history.ts
@@ -4,9 +4,40 @@ import { isTimestampStaleForExchangeSession } from "../market-data/market/freshn
 
 const MAX_CURRENT_INTRADAY_HISTORY_LAG_MS = 18 * 60 * 60 * 1000;
 const MAX_SAME_SESSION_HISTORY_LAG_MS = 30 * 60 * 1000;
+const DELAYED_HISTORY_ALLOWANCE_MS = 15 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 interface PriceHistoryFreshnessOptions {
   exchange?: string;
+  intervalMs?: number | null;
+}
+
+export function priceHistoryIntervalMs(interval: string): number | null {
+  const match = /^(\d+)\s*(m|min|mins|minute|minutes|h|hr|hour|hours|d|day|days|w|wk|week|weeks|mo|month|months)$/i.exec(interval.trim());
+  if (!match) return null;
+  const count = Number(match[1]);
+  const unit = match[2]!.toLowerCase();
+  const step = /^(mo|month)/.test(unit) ? 30 * DAY_MS
+    : /^(w|wk|week)/.test(unit) ? 7 * DAY_MS
+    : /^(d|day)/.test(unit) ? DAY_MS
+    : /^(h|hr|hour)/.test(unit) ? 60 * 60 * 1000
+    : 60 * 1000;
+  return count > 0 && Number.isFinite(count * step) ? count * step : null;
+}
+
+function inferredHistoryIntervalMs(points: PricePoint[]): number | null {
+  const times = [...new Set(points.slice(-20).map(getPricePointTimestamp))];
+  const gaps = times.slice(1).map((time, index) => time - times[index]!);
+  const shortest = Math.min(...gaps);
+  if (shortest > 0 && shortest <= 60 * 60 * 1000) return shortest;
+  // A generic range does not specify bar size. Multiple daily labels can
+  // establish daily cadence; a single overnight gap between sparse intraday
+  // observations cannot. One-hour drift allows daily exchange opens over DST.
+  if (times.length >= 3 && shortest >= 20 * 60 * 60 * 1000) {
+    const clockTimes = times.map((time) => time % DAY_MS);
+    if (Math.max(...clockTimes) - Math.min(...clockTimes) <= 60 * 60 * 1000) return DAY_MS;
+  }
+  return null;
 }
 
 export function getPricePointTimestamp(point: PricePoint): number {
@@ -78,10 +109,20 @@ export function isPriceHistoryStaleForCurrentWindow(
   const latest = normalized.at(-1);
   if (!latest) return false;
 
+  const intervalMs = options.intervalMs ?? inferredHistoryIntervalMs(normalized);
+  // Daily/weekly/monthly labels are period starts, not live observation times.
+  // Their cache policy controls refresh; an intraday lag test is inapplicable.
+  if (intervalMs != null && intervalMs >= DAY_MS) return false;
+
   const latestTime = getPricePointTimestamp(latest);
   if (!Number.isFinite(latestTime)) return false;
   const age = now - latestTime;
-  if (age <= MAX_SAME_SESSION_HISTORY_LAG_MS) return false;
+  // Completed bars are timestamped at their opening time. Before the next
+  // completed bar is delivered, the newest bar may be almost two intervals
+  // plus the feed delay old. Keep the existing tolerance for finer bars.
+  const allowedLag = Math.max(MAX_SAME_SESSION_HISTORY_LAG_MS,
+    intervalMs != null ? 2 * intervalMs + DELAYED_HISTORY_ALLOWANCE_MS : 0);
+  if (age <= allowedLag) return false;
   const exchange = options.exchange || "NASDAQ";
   if (
     resolveExchangeTimeZone(exchange)


### PR DESCRIPTION
Valid chart history could disappear as “No history provider available.” In the browser at 19:39 UTC, successful QQQ responses contained 1,398 delayed 15-minute bars ending at 19:00 and 22 daily bars ending September 9. Both were rejected by a 30-minute freshness check applied to the bars' opening timestamps.

Freshness now accounts for the requested bar interval and completed-bar delivery delay, while preserving the existing one-minute/five-minute tolerance and prior-session intraday rejection. Generic histories infer daily cadence only from multiple consistent observations, so a sparse overnight pair cannot masquerade as daily data. Detailed daily/weekly/monthly requests use the daily cache policy and do not apply an intraday age test.

Validation:

- 27 focused tests / 64 assertions cover delayed 15-minute/hourly bars, stale one-minute data, explicit versus inferred cadence, daily holiday/weekend gaps, weekly labels, and fetched/cached router behavior.
- Replaying the exact captured HTTP 200 payloads through the old router reproduces both errors; the patched router returns all 1,398 intraday and 22 daily points with their timestamps unchanged.
- All six runtime typechecks and the full CI build-and-test workflow pass. Independent review found no concrete blocker.
- Live combined browser preview at 1280×900 and 900×700: QQQ/TQQQ/SQQQ 1M settles to August 10–September 10 with all three traces populated and no loading/error state; screenshots and snapshots visually checked.

Limits: accepting delayed bars does not make them live. Daily/coarser refresh remains governed by cache age. The history contract has no exchange holiday calendar or market-state metadata; existing prior-session intraday behavior on exchange holidays remains unchanged. The captured-data replay and anonymous browser verification do not establish authenticated Pro coverage. A brief initial cached range before final resolution remains a separate chart-seed investigation.
