### PR TITLE
Fix native chart editor arrow keys when background input retains focus

### DIFF
--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -16,6 +16,8 @@ export interface SegmentedControlProps {
   value: string;
   onChange?: (value: string) => void;
   focused?: boolean;
+  /** For controls whose owning dialog tracks focus independently of native text inputs. */
+  allowEditable?: boolean;
   shortcutScope?: string;
   width?: number | "100%";
   wrap?: boolean;
@@ -26,6 +28,7 @@ export function SegmentedControl({
   value,
   onChange,
   focused = false,
+  allowEditable = false,
   shortcutScope,
   width,
   wrap = false,
@@ -67,6 +70,7 @@ export function SegmentedControl({
     enabled: ui.kind !== "desktop-web" && focused && !!onChange,
     phase: "before",
     scope: shortcutScope,
+    allowEditable,
   });
 
   if (HostSegmentedControl) {

--- a/src/plugins/builtin/chart-composer/editor.test.tsx
+++ b/src/plugins/builtin/chart-composer/editor.test.tsx
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { act } from "react";
-import { testRender } from "../../../renderers/opentui/test-utils";
+import { emitKeypress, testRender } from "../../../renderers/opentui/test-utils";
+import { useShortcut } from "../../../react/input";
+import { Input, type InputRenderable } from "../../../ui";
 import { SeriesEditorDialog } from "./editor";
 import {
   appendChartSeries,
@@ -16,28 +18,7 @@ async function emitKey(
   sequence: string,
   overrides: Partial<{ shift: boolean }> = {},
 ) {
-  await act(async () => {
-    (testSetup!.renderer as any).keyInput.emit("keypress", {
-      name,
-      sequence,
-      ctrl: false,
-      meta: false,
-      super: false,
-      option: false,
-      shift: overrides.shift ?? false,
-      eventType: "press",
-      repeated: false,
-      defaultPrevented: false,
-      propagationStopped: false,
-      preventDefault() {
-        this.defaultPrevented = true;
-      },
-      stopPropagation() {
-        this.propagationStopped = true;
-      },
-    });
-    await testSetup!.renderOnce();
-  });
+  await emitKeypress(testSetup!, { name, sequence, shift: overrides.shift ?? false }, { trackPropagation: true });
 }
 
 async function waitForFrameToContain(text: string, attempts = 12): Promise<string> {
@@ -274,6 +255,34 @@ describe("chart composer series editor", () => {
       .map((row) => row.trimEnd())
       .filter((row) => row.length > contentWidth);
     expect(overflowRows).toEqual([]);
+  });
+
+  test("logical editor focus owns arrows when another native text editor retains focus", async () => {
+    let background: InputRenderable | null = null;
+    let resolved: ReturnType<typeof buildPriceChartPreset> | null | undefined;
+    let globalArrows = 0;
+    function Harness() {
+      useShortcut((event) => {
+        if (event.name === "left" || event.name === "right") globalArrows += 1;
+      }, { phase: "after", allowEditable: true });
+      return <>
+        <Input ref={(input) => { background = input; }} value="unchanged" />
+        <SeriesEditorDialog dialogId="retained-editor-focus" initialSpec={buildPriceChartPreset("QQQ")}
+          dismiss={() => {}} resolve={(next) => { resolved = next; }} />
+      </>;
+    }
+    testSetup = await testRender(<Harness />, { width: 92, height: 48 });
+    for (let index = 0; index < 4; index += 1) await emitKey("tab", "\t");
+    // The full terminal can still identify an underlying input as its focused
+    // editor after the dialog has moved its own logical focus to a selector.
+    await act(async () => { background!.focus(); await testSetup!.renderOnce(); });
+    await emitKey("right", "\u001b[C");
+    await emitKey("left", "\u001b[D");
+    await emitKey("right", "\u001b[C");
+    await emitKey("enter", "\r");
+    expect(resolved?.series[0]).toMatchObject({ transform: "percent", style: "line" });
+    expect(background!.editBuffer.getText()).toBe("unchanged");
+    expect(globalArrows).toBe(0);
   });
 
   test("edits every segmented series setting with Tab and arrow keys", async () => {

--- a/src/plugins/builtin/chart-composer/editor/opentui-view.tsx
+++ b/src/plugins/builtin/chart-composer/editor/opentui-view.tsx
@@ -65,6 +65,7 @@ export function OpenTuiSeriesEditorFields({
                     value={field.value}
                     onChange={field.onChange}
                     focused={focused}
+                    allowEditable={focused}
                     shortcutScope={dialogId}
                     width="100%"
                     wrap
@@ -78,6 +79,7 @@ export function OpenTuiSeriesEditorFields({
                 value={field.value}
                 onChange={field.onChange}
                 focused={focused}
+                allowEditable={focused}
                 shortcutScope={dialogId}
                 width="100%"
                 wrap


### PR DESCRIPTION
The native chart series editor could highlight Transform but ignore Left/Right when a background text input retained native focus. This blocked changing a multi-security comparison from raw prices to percentages.

Allow the logically focused, dialog-scoped segmented controls to handle arrows in that condition. The shared control retains its default protection for text inputs, and only the native chart editor opts in.

Validation:
- Regression reproduces retained background input focus: Right/Left/Right saves percent with line style, leaves background text unchanged, and does not trigger global arrow shortcuts. It fails before the fix.
- Chart editor and model tests: 10 passed, 35 assertions.
- OpenTUI and browser typechecks pass.
- Actual native terminal: edited QQQ, TQQQ, and SQQQ to percentage transforms, then verified settled 5Y → 1M → 1Y ranges. The 1M axis covers Aug 10–Sep 10; 1Y covers Sep 10, 2025–Sep 10, 2026. Test session closed.
