### PR TITLE
Clarify corporate action factors and SEC issuer and publication timing

### DIFF
--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -846,6 +846,8 @@ export interface CloudSecFilingPayload {
   form: string;
   filingDate: string;
   acceptedAt?: string;
+  /** Unmodified SEC acceptanceDateTime; a missing timezone is not inferred. */
+  acceptedAtRaw?: string;
   primaryDocument?: string;
   primaryDocDescription?: string;
   items?: string;

--- a/src/plugins/builtin/research/corporate-actions-pane.tsx
+++ b/src/plugins/builtin/research/corporate-actions-pane.tsx
@@ -36,6 +36,7 @@ import {
 } from "../sec/filing-content";
 import {
   buildEventRows,
+  CORPORATE_ACTION_COVERAGE,
   eventSourceNotice,
   formatEventMetric,
   type EventRow,
@@ -139,7 +140,7 @@ function buildEventColumns(): EventColumn[] {
     { id: "qRevenue", label: "Q REV", width: 12, align: "right" },
     { id: "annualEps", label: "ANN EPS", width: 12, align: "right" },
     { id: "annualRevenue", label: "ANN REV", width: 12, align: "right" },
-    { id: "value", label: "VALUE", width: 8, align: "right" },
+    { id: "value", label: "VALUE", width: 11, align: "right" },
     { id: "detail", label: "DETAIL", width: 9, align: "left", flexGrow: 1 },
   ];
 }
@@ -194,6 +195,11 @@ export function buildEventDetailBody({
   primaryContentLoading: boolean;
 }): string {
   const lines: string[] = ["Summary", eventSummaryLine(row)];
+  if (row.status === "Factor") {
+    lines.push("", "Provider split/adjustment factor",
+      "This factor can encode a stock split or a spinoff price adjustment. It does not establish shares received, distribution terms, or the legal effective date. Verify those terms in issuer filings.",
+      ...(row.providerDescription ? [`Provider description: ${row.providerDescription}`] : []));
+  }
   if (row.status !== "Earnings") {
     return lines.join("\n");
   }
@@ -532,6 +538,7 @@ export function CorporateActionsView({
           </Box>}
           {rows.some((row) => row.status === "Earnings") && <Prose width={width - 2} color={colors.textDim}
             text="Event EPS and consensus use an unspecified accounting basis; TTM uses statements. Period ends are not announcement dates. Open a row for source details." />}
+          {variant === "corporate-actions" && <Prose text={CORPORATE_ACTION_COVERAGE} width={Math.max(width - 2, 12)} color={colors.textDim} />}
         </Box>
       ) : undefined}
       rootWidth={width}

--- a/src/plugins/builtin/research/event-model.test.ts
+++ b/src/plugins/builtin/research/event-model.test.ts
@@ -75,3 +75,13 @@ test("missing or ambiguous fiscal periods and announcements cannot borrow a prev
     expect(buildEventRows(actions, null, { quarterlyStatements: statements }, "USD").every((row) => row.qRevenue == null)).toBe(true);
   }
 });
+
+test("spinoff adjustment factors are not presented as verified share splits", () => {
+  const [row] = buildEventRows({ symbol: "GE", earnings: [], dividends: [],
+    splits: [{ date: "2024-04-02", fromFactor: 1000, toFactor: 1253, description: "1253:1000 split" }],
+  }, null, null, "USD");
+  expect(row).toMatchObject({ status: "Factor", value: "1253:1000", adjustmentFactor: 1.253,
+    detail: "Provider split/adjustment", providerDescription: "1253:1000 split" });
+  expect(row?.qEps).toBeUndefined();
+
+});

--- a/src/plugins/builtin/research/event-model.ts
+++ b/src/plugins/builtin/research/event-model.ts
@@ -14,7 +14,9 @@ import {
 } from "../../../utils/format";
 import { computeTTM } from "../ticker-detail/financials/aggregation";
 
-export type EventStatus = "Earnings" | "Q Est" | "FY Est" | "TTM" | "Dividend" | "Split";
+export const CORPORATE_ACTION_COVERAGE = "Split-feed factors may include spinoff price adjustments. Merger terms, spinoff distributions, and security conversions are not covered.";
+
+export type EventStatus = "Earnings" | "Q Est" | "FY Est" | "TTM" | "Dividend" | "Factor";
 
 export interface EventRow {
   id: string;
@@ -25,6 +27,9 @@ export interface EventRow {
   detail: string;
   epsCurrency?: string;
   revenueCurrency?: string;
+  /** Raw provider split-feed description; does not verify a legal share split. */
+  providerDescription?: string;
+  adjustmentFactor?: number;
   qEps?: number;
   qRevenue?: number;
   earningsState?: "pending" | "reported";
@@ -174,7 +179,7 @@ function eventSortRank(status: EventStatus): number {
     case "Earnings": return 2;
     case "TTM": return 3;
     case "Dividend": return 4;
-    case "Split": return 5;
+    case "Factor": return 5;
   }
 }
 
@@ -255,9 +260,11 @@ export function buildEventRows(
     rows.push({
       id: `split:${split.date}:${split.description ?? ""}`,
       date: split.date,
-      status: "Split",
+      status: "Factor",
       period: "-",
-      detail: split.description ?? "Split",
+      detail: "Provider split/adjustment",
+      providerDescription: split.description,
+      adjustmentFactor: split.fromFactor && split.toFactor ? split.toFactor / split.fromFactor : split.ratio,
       value: split.fromFactor && split.toFactor
         ? `${split.toFactor}:${split.fromFactor}`
         : formatNumber(split.ratio, 4),

--- a/src/plugins/builtin/research/events-headless.ts
+++ b/src/plugins/builtin/research/events-headless.ts
@@ -8,7 +8,7 @@ import type {
   HeadlessPaneDefinition,
   HeadlessPaneLoadArgs,
 } from "../../../types/plugin";
-import { formatEventMetric, buildEventRows, eventSourceNotice } from "./event-model";
+import { formatEventMetric, buildEventRows, eventSourceNotice, CORPORATE_ACTION_COVERAGE } from "./event-model";
 
 const COLUMNS = [
   { key: "date", header: "Date" },
@@ -92,6 +92,7 @@ export function createEventsHeadless(
           .map((row) => ({ ...row })),
         errors: errors.length > 0 ? errors : undefined,
         metadata: { symbol, currency: data.currency, coverage: data.actions?.coverage,
+          coverageNote: CORPORATE_ACTION_COVERAGE,
           actionsFetchedAt: data.actions?.fetchedAt, estimatesFetchedAt: data.estimates?.fetchedAt,
           ...(notice ? { notice: notice.text } : {}),
         },

--- a/src/plugins/builtin/research/index.test.ts
+++ b/src/plugins/builtin/research/index.test.ts
@@ -327,7 +327,7 @@ describe("event rows", () => {
     expect(rows).toMatchObject([
       { id: "div:2026-02-10", status: "Dividend", value: "$0.26" },
       { id: "earn:2026-01-30", status: "Earnings" },
-      { id: "split:2025-12-01:4-for-1 split", status: "Split", value: "4:1" },
+      { id: "split:2025-12-01:4-for-1 split", status: "Factor", value: "4:1" },
     ]);
     expect(rows[0]?.qEps).toBeUndefined();
     expect(rows[0]?.annualEps).toBeUndefined();

--- a/src/plugins/builtin/sec/filing-content.test.ts
+++ b/src/plugins/builtin/sec/filing-content.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { extractFilingContent } from "../../../sources/sec-edgar/content";
+import { filingPreviewTruncated } from "./filing-documents";
 import type { SecFilingDocument, SecFilingItem } from "../../../types/data-provider";
 import {
   buildInlineFilingContentTargets,
@@ -38,4 +40,18 @@ describe("SEC filing content cache", () => {
     expect(buildInlineFilingContentTargets(selected, documents).map((target) => target.accessionNumber))
       .toEqual(["selected:exhibit.htm"]);
   });
+});
+
+test("preview coverage follows the extracted primary and inline exhibits, not unrelated cached documents", () => {
+  const selected = filing("selected");
+  const documents: SecFilingDocument[] = [{ document: "release.htm", type: "EX-99.1", url: "https://example.com/release.htm", isPrimary: false }];
+  const complete = extractFilingContent("<html><body><p>Complete terms.</p></body></html>", "text/html", { form: "8-K" });
+  const truncated = extractFilingContent(`<html><body><p>${"Important merger consideration. ".repeat(1000)}</p></body></html>`, "text/html", { form: "8-K" });
+  const cache = new Map([["selected", complete], ["unrelated", truncated]]);
+  expect(filingPreviewTruncated(selected, documents, cache)).toBe(false);
+  cache.set("selected:release.htm", truncated);
+  expect(filingPreviewTruncated(selected, documents, cache)).toBe(true);
+  cache.set("selected:release.htm", complete);
+  cache.set("selected", truncated);
+  expect(filingPreviewTruncated(selected, [], cache)).toBe(true);
 });

--- a/src/plugins/builtin/sec/filing-documents.ts
+++ b/src/plugins/builtin/sec/filing-documents.ts
@@ -53,3 +53,13 @@ export function isDefaultVisibleFilingDocument(document: SecFilingDocument): boo
   if (isInlineExhibitDocument(document)) return true;
   return !SEC_SUPPORT_DOCUMENT_TYPE_RE.test(document.type.trim());
 }
+
+/** A primary preview or a rendered exhibit can independently hit the extraction limit. */
+export function filingPreviewTruncated(
+  filing: SecFilingItem,
+  documents: readonly SecFilingDocument[],
+  contentCache: ReadonlyMap<string, string | null>,
+): boolean {
+  const keys = [filing.accessionNumber, ...documents.filter(isInlineExhibitDocument).map((document) => documentContentKey(filing, document))];
+  return keys.some((key) => contentCache.get(key)?.trimEnd().endsWith("[truncated]"));
+}

--- a/src/plugins/builtin/sec/headless.test.ts
+++ b/src/plugins/builtin/sec/headless.test.ts
@@ -62,6 +62,7 @@ describe("SEC headless model", () => {
       accessionNumber: "0000320193-26-000100",
       primaryDocument: null,
       cik: "0000320193",
+      companyName: null,
       url: "https://www.sec.gov/filing/one",
     }]);
 
@@ -69,4 +70,14 @@ describe("SEC headless model", () => {
     expect(both.rows).toHaveLength(2);
     expect(requestedLimits).toEqual([1, 2]);
   });
+});
+
+
+test("ticker reuse preserves the actual filing issuer rather than the requested ticker's former company", async () => {
+  const headless = createSecHeadless({ loadFilings: async () => [{
+    ...filings[0]!, cik: "0001826011", companyName: "Banzai International, Inc."
+  }] });
+  const result = await headless.load({ ...args(1), argument: "PARA", symbols: ["PARA"] }, context());
+  expect(result.rows[0]).toMatchObject({ cik: "0001826011", companyName: "Banzai International, Inc." });
+  expect(result.metadata?.issuers).toEqual([{ cik: "0001826011", companyName: "Banzai International, Inc." }]);
 });

--- a/src/plugins/builtin/sec/headless.test.ts
+++ b/src/plugins/builtin/sec/headless.test.ts
@@ -91,6 +91,9 @@ test("accepted timestamps survive persisted JSON rows and invalid cached values 
   expect(buildSecFilingRows([restored])[0]?.acceptedAt).toBe("2025-03-20T20:10:11.000Z");
   const compact = { ...restored, acceptedAt: undefined, acceptedAtRaw: "20250320161011" };
   expect(buildSecFilingRows([compact])[0]).toMatchObject({ acceptedAt: null, acceptedAtRaw: "20250320161011", acceptanceReported: "20250320161011 (timezone unspecified)" });
+  expect(secAcceptanceTimestamp("2025-03-20T16:10:11")).toBeNull();
+  const naive = JSON.parse(JSON.stringify({ ...filing, acceptedAt: "2025-03-20T16:10:11" })) as SecFilingItem;
+  expect(buildSecFilingRows([naive])[0]).toMatchObject({ acceptedAt: null, acceptanceReported: "2025-03-20T16:10:11 (timezone unspecified)" });
   expect(secAcceptanceTimestamp("invalid")).toBeNull();
   expect(secAcceptanceTimestamp(undefined)).toBeNull();
 });

--- a/src/plugins/builtin/sec/headless.test.ts
+++ b/src/plugins/builtin/sec/headless.test.ts
@@ -4,6 +4,7 @@ import { createDefaultConfig } from "../../../types/config";
 import type { SecFilingItem } from "../../../types/data-provider";
 import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
 import { createSecHeadless } from "./headless";
+import { buildSecFilingRows, secAcceptanceTimestamp } from "./model";
 
 const filings: SecFilingItem[] = [
   {
@@ -56,6 +57,8 @@ describe("SEC headless model", () => {
     expect(first.rows).toEqual([{
       filedAt: "2026-08-25T00:00:00.000Z",
       acceptedAt: null,
+      acceptedAtRaw: null,
+      acceptanceReported: null,
       form: "8-K",
       filing: "8-K | Results of Operations | Current Report",
       items: "2.02,9.01",
@@ -72,7 +75,6 @@ describe("SEC headless model", () => {
   });
 });
 
-
 test("ticker reuse preserves the actual filing issuer rather than the requested ticker's former company", async () => {
   const headless = createSecHeadless({ loadFilings: async () => [{
     ...filings[0]!, cik: "0001826011", companyName: "Banzai International, Inc."
@@ -80,4 +82,15 @@ test("ticker reuse preserves the actual filing issuer rather than the requested 
   const result = await headless.load({ ...args(1), argument: "PARA", symbols: ["PARA"] }, context());
   expect(result.rows[0]).toMatchObject({ cik: "0001826011", companyName: "Banzai International, Inc." });
   expect(result.metadata?.issuers).toEqual([{ cik: "0001826011", companyName: "Banzai International, Inc." }]);
+});
+
+test("accepted timestamps survive persisted JSON rows and invalid cached values remain unknown", () => {
+  const filing = { ...filings[0]!, acceptedAt: new Date("2025-03-20T20:10:11.000Z") };
+  const restored = JSON.parse(JSON.stringify(filing)) as SecFilingItem;
+  expect(secAcceptanceTimestamp(restored.acceptedAt)).toBe("2025-03-20T20:10:11.000Z");
+  expect(buildSecFilingRows([restored])[0]?.acceptedAt).toBe("2025-03-20T20:10:11.000Z");
+  const compact = { ...restored, acceptedAt: undefined, acceptedAtRaw: "20250320161011" };
+  expect(buildSecFilingRows([compact])[0]).toMatchObject({ acceptedAt: null, acceptedAtRaw: "20250320161011", acceptanceReported: "20250320161011 (timezone unspecified)" });
+  expect(secAcceptanceTimestamp("invalid")).toBeNull();
+  expect(secAcceptanceTimestamp(undefined)).toBeNull();
 });

--- a/src/plugins/builtin/sec/headless.ts
+++ b/src/plugins/builtin/sec/headless.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../../types/plugin";
 import type { SecFilingItem } from "../../../types/data-provider";
 import { loadSecFilings } from "./client";
-import { buildSecFilingRows } from "./model";
+import { buildSecFilingRows, secFilingIssuers } from "./model";
 
 const SEC_COLUMNS: HeadlessPaneColumn[] = [
   {
@@ -14,7 +14,9 @@ const SEC_COLUMNS: HeadlessPaneColumn[] = [
     header: "Filed",
     format: (value) => typeof value === "string" ? value.slice(0, 10) : "-",
   },
+  { key: "acceptedAt", header: "Accepted UTC" },
   { key: "form", header: "Form" },
+  { key: "companyName", header: "Issuer" },
   { key: "filing", header: "Filing" },
   { key: "items", header: "Items" },
   { key: "accessionNumber", header: "Accession" },
@@ -60,7 +62,7 @@ export function createSecHeadless(
       const filings = await dependencies.loadFilings(symbol, limit, args, ctx);
       return {
         rows: buildSecFilingRows(filings).slice(0, limit),
-        metadata: { symbol, returned: Math.min(filings.length, limit) },
+        metadata: { symbol, returned: Math.min(filings.length, limit), issuers: secFilingIssuers(filings.slice(0, limit)) },
       };
     },
   };

--- a/src/plugins/builtin/sec/headless.ts
+++ b/src/plugins/builtin/sec/headless.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../../types/plugin";
 import type { SecFilingItem } from "../../../types/data-provider";
 import { loadSecFilings } from "./client";
-import { buildSecFilingRows, secFilingIssuers } from "./model";
+import { buildSecFilingRows, secFilingIssuers, SEC_ACCEPTANCE_NOTE } from "./model";
 
 const SEC_COLUMNS: HeadlessPaneColumn[] = [
   {
@@ -14,7 +14,7 @@ const SEC_COLUMNS: HeadlessPaneColumn[] = [
     header: "Filed",
     format: (value) => typeof value === "string" ? value.slice(0, 10) : "-",
   },
-  { key: "acceptedAt", header: "Accepted UTC" },
+  { key: "acceptanceReported", header: "SEC-reported acceptance" },
   { key: "form", header: "Form" },
   { key: "companyName", header: "Issuer" },
   { key: "filing", header: "Filing" },
@@ -62,7 +62,7 @@ export function createSecHeadless(
       const filings = await dependencies.loadFilings(symbol, limit, args, ctx);
       return {
         rows: buildSecFilingRows(filings).slice(0, limit),
-        metadata: { symbol, returned: Math.min(filings.length, limit), issuers: secFilingIssuers(filings.slice(0, limit)) },
+        metadata: { acceptanceNote: SEC_ACCEPTANCE_NOTE, symbol, returned: Math.min(filings.length, limit), issuers: secFilingIssuers(filings.slice(0, limit)) },
       };
     },
   };

--- a/src/plugins/builtin/sec/index.tsx
+++ b/src/plugins/builtin/sec/index.tsx
@@ -22,6 +22,7 @@ import {
   formatCompactDocumentLabel,
   isDefaultVisibleFilingDocument,
   isInlineExhibitDocument,
+  filingPreviewTruncated,
 } from "./filing-documents";
 import {
   buildInlineFilingContentTargets,
@@ -35,6 +36,8 @@ import {
   getMeaningfulPrimaryDescription,
   secFilingIssuers,
   secIssuerLabel,
+  secReportedAcceptance,
+  SEC_ACCEPTANCE_NOTE,
 } from "./model";
 
 export { secHeadless } from "./headless";
@@ -139,6 +142,7 @@ function toFeedItems(
 ): FeedDataTableItem[] {
   return filings.map((filing) => {
     const displayTitle = getFilingDisplayTitle(filing);
+    const acceptedAt = secReportedAcceptance(filing);
     const formDesc = getFormDescription(filing.form);
     const hasFetchedContent = contentCache.has(filing.accessionNumber);
     const fetchedContent = contentCache.get(filing.accessionNumber);
@@ -181,9 +185,11 @@ function toFeedItems(
       detailMeta: [
         secIssuerLabel(filing),
         `Filed ${formatFiledAt(filing)}`,
-        ...(filing.acceptedAt ? [`Accepted ${filing.acceptedAt.toISOString()} (UTC)`] : []),
+        ...(acceptedAt ? [`SEC-reported acceptance ${acceptedAt}`, SEC_ACCEPTANCE_NOTE] : []),
         `Accession ${filing.accessionNumber}`,
         ...(filing.items ? [`Items ${filing.items}`] : []),
+        ...(filingPreviewTruncated(filing, selected ? selectedDocuments : [], contentCache)
+          ? ["Preview truncated. Open the SEC filing for the complete documents and terms."] : []),
       ],
       detailBody,
     };

--- a/src/plugins/builtin/sec/index.tsx
+++ b/src/plugins/builtin/sec/index.tsx
@@ -5,8 +5,8 @@ import { useResolvedEntryValue, useSecFilingDocuments, useSecFilingsQuery } from
 import { instrumentFromTicker } from "../../../market-data/request-types";
 import { useDebouncedPluginPaneState } from "../../runtime";
 import { usePaneTicker } from "../../../state/app/context";
-import type { ScrollBoxRenderable } from "../../../ui";
-import { EmptyState, FeedDataTableStackView, Spinner, useTableLoadMore, type FeedDataTableItem } from "../../../components";
+import { Box, type ScrollBoxRenderable } from "../../../ui";
+import { EmptyState, FeedDataTableStackView, Prose, Spinner, useTableLoadMore, type FeedDataTableItem } from "../../../components";
 import { isUsEquityTicker } from "../../../utils/sec";
 import { parseForm4Xml, transactionTypeLabel } from "../insider/insider-data";
 import { createTickerSurfacePaneTemplate } from "../shared/ticker-surface";
@@ -33,6 +33,8 @@ import {
   getFilingDisplayTitle,
   getFormDescription,
   getMeaningfulPrimaryDescription,
+  secFilingIssuers,
+  secIssuerLabel,
 } from "./model";
 
 export { secHeadless } from "./headless";
@@ -177,7 +179,9 @@ function toFeedItems(
       timestamp: filing.filingDate,
       detailTitle: enrichedTitle,
       detailMeta: [
+        secIssuerLabel(filing),
         `Filed ${formatFiledAt(filing)}`,
+        ...(filing.acceptedAt ? [`Accepted ${filing.acceptedAt.toISOString()} (UTC)`] : []),
         `Accession ${filing.accessionNumber}`,
         ...(filing.items ? [`Items ${filing.items}`] : []),
       ],
@@ -279,6 +283,9 @@ function SecView({ width, height, focused }: { width: number; height: number; fo
       selectedIdx={selectedIdx}
       onSelect={setSelectedIdx}
       onOpenItemIdChange={setOpenItemId}
+      rootBefore={<Box flexDirection="column" paddingX={1}>
+        {secFilingIssuers(filings).map((issuer) => <Prose key={issuer.cik} text={secIssuerLabel(issuer)} width={Math.max(width - 2, 12)} />)}
+      </Box>}
       sourceLabel="Form"
       titleLabel="Filing"
       emptyStateTitle="No SEC filings."

--- a/src/plugins/builtin/sec/model.ts
+++ b/src/plugins/builtin/sec/model.ts
@@ -52,6 +52,9 @@ export function getFormDescription(form: string): string {
     case "10-Q/A": return "Quarterly Report (Amended)";
     case "8-K": return "Current Report";
     case "8-K/A": return "Current Report (Amended)";
+    case "8-K12B": return "Successor Issuer Current Report";
+    case "S-4": return "Business Combination or Exchange Offer Registration";
+    case "S-4/A": return "Business Combination or Exchange Offer Registration (Amended)";
     case "4": return "Insider Transaction";
     case "3": return "Initial Insider Ownership";
     case "5": return "Annual Insider Ownership";
@@ -83,7 +86,24 @@ export function buildSecFilingRows(filings: readonly SecFilingItem[]) {
       accessionNumber: filing.accessionNumber,
       primaryDocument: filing.primaryDocument ?? null,
       cik: filing.cik,
+      companyName: filing.companyName ?? null,
       url: filing.filingUrl,
     };
   });
+}
+
+
+export function secFilingIssuers(filings: readonly SecFilingItem[]) {
+  const issuers = new Map<string, { cik: string; companyName: string | null }>();
+  for (const filing of filings) {
+    const previous = issuers.get(filing.cik);
+    if (!previous || (!previous.companyName && filing.companyName)) {
+      issuers.set(filing.cik, { cik: filing.cik, companyName: filing.companyName ?? null });
+    }
+  }
+  return [...issuers.values()];
+}
+
+export function secIssuerLabel(issuer: { cik: string; companyName?: string | null }): string {
+  return `${issuer.companyName || "Issuer name unavailable"} · CIK ${issuer.cik}`;
 }

--- a/src/plugins/builtin/sec/model.ts
+++ b/src/plugins/builtin/sec/model.ts
@@ -77,9 +77,9 @@ export function buildSecFilingRows(filings: readonly SecFilingItem[]) {
       filedAt: filing.filingDate instanceof Date
         ? filing.filingDate.toISOString()
         : String(filing.filingDate),
-      acceptedAt: filing.acceptedAt instanceof Date
-        ? filing.acceptedAt.toISOString()
-        : filing.acceptedAt ? String(filing.acceptedAt) : null,
+      acceptedAt: secAcceptanceTimestamp(filing.acceptedAt),
+      acceptedAtRaw: filing.acceptedAtRaw ?? null,
+      acceptanceReported: secReportedAcceptance(filing),
       form: filing.form,
       filing: formDescription ? `${displayTitle} | ${formDescription}` : displayTitle,
       items: filing.items ?? null,
@@ -91,7 +91,6 @@ export function buildSecFilingRows(filings: readonly SecFilingItem[]) {
     };
   });
 }
-
 
 export function secFilingIssuers(filings: readonly SecFilingItem[]) {
   const issuers = new Map<string, { cik: string; companyName: string | null }>();
@@ -107,3 +106,20 @@ export function secFilingIssuers(filings: readonly SecFilingItem[]) {
 export function secIssuerLabel(issuer: { cik: string; companyName?: string | null }): string {
   return `${issuer.companyName || "Issuer name unavailable"} · CIK ${issuer.cik}`;
 }
+
+/** Persistence may return timestamps as strings even when the network model uses Date. */
+export function secAcceptanceTimestamp(value: unknown): string | null {
+  if (!(value instanceof Date) && typeof value !== "string") return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+
+export function secReportedAcceptance(filing: SecFilingItem): string | null {
+  const raw = filing.acceptedAtRaw?.trim();
+  if (raw) return /^\d{14}$/.test(raw) || !/(?:Z|[+-]\d{2}:\d{2})$/.test(raw)
+    ? `${raw} (timezone unspecified)`
+    : raw;
+  return secAcceptanceTimestamp(filing.acceptedAt);
+}
+
+export const SEC_ACCEPTANCE_NOTE = "SEC-reported acceptance is not verified public availability or an announcement time. Source timestamps without a timezone remain unconverted.";

--- a/src/plugins/builtin/sec/model.ts
+++ b/src/plugins/builtin/sec/model.ts
@@ -110,12 +110,14 @@ export function secIssuerLabel(issuer: { cik: string; companyName?: string | nul
 /** Persistence may return timestamps as strings even when the network model uses Date. */
 export function secAcceptanceTimestamp(value: unknown): string | null {
   if (!(value instanceof Date) && typeof value !== "string") return null;
+  if (typeof value === "string" && !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/.test(value)) return null;
   const date = value instanceof Date ? value : new Date(value);
   return Number.isFinite(date.getTime()) ? date.toISOString() : null;
 }
 
 export function secReportedAcceptance(filing: SecFilingItem): string | null {
-  const raw = filing.acceptedAtRaw?.trim();
+  const persistedValue: unknown = filing.acceptedAt;
+  const raw = filing.acceptedAtRaw?.trim() || (typeof persistedValue === "string" ? persistedValue.trim() : undefined);
   if (raw) return /^\d{14}$/.test(raw) || !/(?:Z|[+-]\d{2}:\d{2})$/.test(raw)
     ? `${raw} (timezone unspecified)`
     : raw;

--- a/src/sources/gloomberb-cloud/index.test.ts
+++ b/src/sources/gloomberb-cloud/index.test.ts
@@ -17,6 +17,7 @@ const verifiedUser: AuthUser = {
 };
 
 const originalEnsureVerifiedSession = apiClient.ensureVerifiedSession.bind(apiClient);
+const originalGetCloudSecFilings = apiClient.getCloudSecFilings.bind(apiClient);
 const originalGetCloudHistory = apiClient.getCloudHistory.bind(apiClient);
 const originalGetCloudQuote = apiClient.getCloudQuote.bind(apiClient);
 const originalGetCloudFinancials = apiClient.getCloudFinancials.bind(apiClient);
@@ -102,6 +103,7 @@ function makeCloudNewsPayload(overrides: Partial<CloudNewsPayload> = {}): CloudN
 
 afterEach(() => {
   apiClient.ensureVerifiedSession = originalEnsureVerifiedSession;
+  apiClient.getCloudSecFilings = originalGetCloudSecFilings;
   apiClient.getCloudHistory = originalGetCloudHistory;
   apiClient.getCloudQuote = originalGetCloudQuote;
   apiClient.getCloudFinancials = originalGetCloudFinancials;
@@ -902,4 +904,16 @@ describe("GloomberbCloudProvider", () => {
     expect(story?.items?.map((item) => item.id)).toEqual(["item-2", "item-1"]);
     expect(story?.items?.[0]?.publishedAt).toEqual(new Date("2026-04-01T10:05:00.000Z"));
   });
+});
+
+test("cloud SEC acceptance keeps timezone-free source values without using the machine timezone", async () => {
+  apiClient.ensureVerifiedSession = async () => verifiedUser;
+  const values = ["2025-03-20T20:10:11.000Z", "2025-03-20T16:10:11", "20250320161011"];
+  apiClient.getCloudSecFilings = async () => ({ filings: values.map((acceptedAt, index) => ({
+    accessionNumber: String(index), form: "8-K", filingDate: "2025-03-20", acceptedAt,
+    cik: "0001048911", filingUrl: "https://www.sec.gov/filing",
+  })) });
+  const rows = await new GloomberbCloudProvider().getSecFilings("FDX");
+  expect(rows.map((row) => row.acceptedAtRaw)).toEqual(values);
+  expect(rows.map((row) => row.acceptedAt?.toISOString())).toEqual([values[0], undefined, undefined]);
 });

--- a/src/sources/gloomberb-cloud/index.ts
+++ b/src/sources/gloomberb-cloud/index.ts
@@ -87,8 +87,9 @@ function mapCloudSecFiling(item: {
     accessionNumber: item.accessionNumber,
     form: item.form,
     filingDate: new Date(`${item.filingDate}T00:00:00Z`),
-    acceptedAt: item.acceptedAt ? new Date(item.acceptedAt) : undefined,
-    acceptedAtRaw: item.acceptedAtRaw,
+    acceptedAt: item.acceptedAt && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/.test(item.acceptedAt)
+      ? new Date(item.acceptedAt) : undefined,
+    acceptedAtRaw: item.acceptedAtRaw ?? item.acceptedAt,
     primaryDocument: item.primaryDocument,
     primaryDocDescription: item.primaryDocDescription,
     items: item.items,

--- a/src/sources/gloomberb-cloud/index.ts
+++ b/src/sources/gloomberb-cloud/index.ts
@@ -73,6 +73,8 @@ function mapCloudSecFiling(item: {
   form: string;
   filingDate: string;
   acceptedAt?: string;
+  /** Unmodified SEC acceptanceDateTime; a missing timezone is not inferred. */
+  acceptedAtRaw?: string;
   primaryDocument?: string;
   primaryDocDescription?: string;
   items?: string;
@@ -86,6 +88,7 @@ function mapCloudSecFiling(item: {
     form: item.form,
     filingDate: new Date(`${item.filingDate}T00:00:00Z`),
     acceptedAt: item.acceptedAt ? new Date(item.acceptedAt) : undefined,
+    acceptedAtRaw: item.acceptedAtRaw,
     primaryDocument: item.primaryDocument,
     primaryDocDescription: item.primaryDocDescription,
     items: item.items,

--- a/src/sources/sec-edgar.test.ts
+++ b/src/sources/sec-edgar.test.ts
@@ -845,14 +845,15 @@ describe("SecEdgarClient", () => {
 });
 
 
-test("SEC ISO acceptance timestamps preserve publication instants and do not infer a timezone", () => {
+test("SEC acceptance timestamps preserve source values without inferring missing timezones", () => {
   const values = ["2026-09-09T20:54:25.000Z", "2025-03-20T16:05:00-04:00", "2025-03-20T16:05:00", "20250320200500"];
   const rows = parseRecentFilings({ cik: "1048911", filings: { recent: {
     accessionNumber: values.map((_, i) => `0001048911-26-00000${i}`),
     form: values.map(() => "8-K"), filingDate: values.map(() => "2025-03-20"),
     acceptanceDateTime: values,
   } } }, 4);
+  expect(rows.map((row) => row.acceptedAtRaw)).toEqual(values);
   expect(rows.map((row) => row.acceptedAt?.toISOString())).toEqual([
-    "2026-09-09T20:54:25.000Z", "2025-03-20T20:05:00.000Z", undefined, "2025-03-20T20:05:00.000Z",
+    "2026-09-09T20:54:25.000Z", "2025-03-20T20:05:00.000Z", undefined, undefined,
   ]);
 });

--- a/src/sources/sec-edgar.test.ts
+++ b/src/sources/sec-edgar.test.ts
@@ -843,3 +843,16 @@ describe("SecEdgarClient", () => {
     expect(documents[1]?.description).toBe("Investor presentation");
   });
 });
+
+
+test("SEC ISO acceptance timestamps preserve publication instants and do not infer a timezone", () => {
+  const values = ["2026-09-09T20:54:25.000Z", "2025-03-20T16:05:00-04:00", "2025-03-20T16:05:00", "20250320200500"];
+  const rows = parseRecentFilings({ cik: "1048911", filings: { recent: {
+    accessionNumber: values.map((_, i) => `0001048911-26-00000${i}`),
+    form: values.map(() => "8-K"), filingDate: values.map(() => "2025-03-20"),
+    acceptanceDateTime: values,
+  } } }, 4);
+  expect(rows.map((row) => row.acceptedAt?.toISOString())).toEqual([
+    "2026-09-09T20:54:25.000Z", "2025-03-20T20:05:00.000Z", undefined, "2025-03-20T20:05:00.000Z",
+  ]);
+});

--- a/src/sources/sec-edgar.ts
+++ b/src/sources/sec-edgar.ts
@@ -136,14 +136,8 @@ function parseTimestamp(value: unknown): Date | undefined {
     const timestamp = new Date(digits);
     return Number.isFinite(timestamp.getTime()) ? timestamp : undefined;
   }
-  if (!/^\d{14}$/.test(digits)) return undefined;
-  const year = Number(digits.slice(0, 4));
-  const month = Number(digits.slice(4, 6));
-  const day = Number(digits.slice(6, 8));
-  const hour = Number(digits.slice(8, 10));
-  const minute = Number(digits.slice(10, 12));
-  const second = Number(digits.slice(12, 14));
-  return new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  // Compact SEC wall-clock values carry no timezone. Keep the source value separately.
+  return undefined;
 }
 
 function parseDate(value: unknown): Date | undefined {
@@ -308,6 +302,7 @@ function parseFilingColumns(
       form,
       filingDate,
       acceptedAt: parseTimestamp(acceptanceTimes[index]),
+      acceptedAtRaw: typeof acceptanceTimes[index] === "string" ? acceptanceTimes[index].trim() || undefined : undefined,
       primaryDocument,
       primaryDocDescription: String(primaryDescriptions[index] ?? "").trim() || undefined,
       items: String(items[index] ?? "").trim() || undefined,

--- a/src/sources/sec-edgar.ts
+++ b/src/sources/sec-edgar.ts
@@ -132,6 +132,10 @@ function zeroPadCik(value: unknown): string | null {
 
 function parseTimestamp(value: unknown): Date | undefined {
   const digits = String(value ?? "").trim();
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/.test(digits)) {
+    const timestamp = new Date(digits);
+    return Number.isFinite(timestamp.getTime()) ? timestamp : undefined;
+  }
   if (!/^\d{14}$/.test(digits)) return undefined;
   const year = Number(digits.slice(0, 4));
   const month = Number(digits.slice(4, 6));

--- a/src/types/data-provider.ts
+++ b/src/types/data-provider.ts
@@ -31,6 +31,8 @@ export interface SecFilingItem {
   form: string;
   filingDate: Date;
   acceptedAt?: Date;
+  /** Unmodified SEC acceptanceDateTime; a missing timezone is not inferred. */
+  acceptedAtRaw?: string;
   primaryDocument?: string;
   primaryDocDescription?: string;
   items?: string;

--- a/src/types/financials.ts
+++ b/src/types/financials.ts
@@ -205,11 +205,11 @@ export interface DividendAction {
 export interface SplitAction {
   date: string;
   description?: string;
-  /** New shares per old share, e.g. 10 for a ten-for-one forward split. */
+  /** Provider adjustment ratio; may represent a split or a spinoff price adjustment, not verified share terms. */
   ratio?: number;
-  /** Old shares surrendered. */
+  /** Denominator of the provider adjustment factor. */
   fromFactor?: number;
-  /** New shares received. */
+  /** Numerator of the provider adjustment factor. */
   toFactor?: number;
 }
 


### PR DESCRIPTION
The corporate-action feed labelled GE’s April 2024 spinoff price-adjustment factor, 1253:1000, as a stock split. SEC research hid the resolved issuer, omitted current ISO acceptance timestamps, and gave no upfront warning when document previews omitted merger terms. Reopening newly timestamped filings from the native cache also crashed because persisted dates were strings.

- Display split-feed records as provider factors, retaining the exact ratio and source description. Their coverage notice does not infer share quantities, legal effective dates, merger terms, or spinoff distributions.
- Show SEC issuer names and CIKs in the list, detail, and exports. Current PARA legitimately resolves to Banzai/Parabolic after ticker reuse; historical Paramount is not inferred.
- Preserve SEC acceptanceDateTime as acceptedAtRaw. Populate acceptedAt only for explicit-zone ISO values; compact and timezone-free source values stay unconverted. Display SEC-reported acceptance separately from filing date and explicitly distinguish it from verified public availability or announcement time. Cached strings and cloud responses follow the same rule.
- Flag truncated primary or inline exhibit previews before the document text, retaining the full SEC filing link. Add descriptions for successor-issuer and amended merger-registration forms.

Validation: 82 focused tests / 214 assertions pass, including extraction-limit propagation, cached JSON timestamps, cloud timestamp boundaries, and GE’s actual factor. OpenTUI and browser typechecks pass. Rebased onto the merged earnings-source improvements in #770 and retained both disclosures.

Actual native journeys confirm GE’s factor/detail, current PARA’s issuer, PSKY’s closing 8-K12B preview notice, and the two FDX guidance filings after restarting from cache. Actual app SEC document fetches retrieved FDX’s December 19, 2024 and March 20, 2025 guidance exhibits plus PSKY’s closing filing and two S-4/A amendments. For the two FDX filings, primary filing-index/SGML clocks are 16:10:08 and 16:10:11; submissions JSON reports 21:10:08Z and 20:10:11Z, consistent with seasonal Eastern offsets for these two observations. This does not verify all SEC timestamps or equate acceptance with dissemination.

Limits: authenticated transcript guidance was unavailable. Structured merger elections/proration, predecessor resolution, spinoff distribution terms, and portfolio adjustments remain unsupported. SEC document previews remain capped at 16,000 characters; the cap is now explicit. These scenarios remain partial research coverage. Cloud timestamp parity is in vincelwt/gloomberb-platform#227. No release/version changes.
