### PR TITLE
Keep AI screens and earnings research tied to source inputs

### DIFF
--- a/src/plugins/builtin/ai/screener/contract.test.ts
+++ b/src/plugins/builtin/ai/screener/contract.test.ts
@@ -7,6 +7,10 @@ import {
 } from "./contract";
 
 describe("AI screener helpers", () => {
+  test("malformed candidates are not reported as a successful empty screen", () => {
+    expect(() => parseScreenerResponse('{"tickers":[{"reason":"missing symbol"}]}')).toThrow("malformed ticker candidates");
+    expect(parseScreenerResponse('{"tickers":[]}').tickers).toEqual([]);
+  });
   test("includes the model override in run identity", () => {
     expect(getScreenerPromptSignature("quality", "codex", "gpt-a"))
       .not.toBe(getScreenerPromptSignature("quality", "codex", "gpt-b"));

--- a/src/plugins/builtin/ai/screener/contract.ts
+++ b/src/plugins/builtin/ai/screener/contract.ts
@@ -93,6 +93,8 @@ export function buildScreenerPrompt({
     "- Return at most 25 unique ticker candidates.",
     "- Use uppercase symbols.",
     "- `reason` must be concise and specific.",
+    "- Include the exchange. For financial criteria, give the fiscal period, reporting currency, metric values and source in `reason`.",
+    "- Do not treat unavailable data as a match or invent sources. State any unverified coverage in the summary.",
     "- Omit any company you cannot validate with confidence.",
   );
 
@@ -109,6 +111,10 @@ export function parseScreenerResponse(raw: string): ParsedScreenerResponse {
   const tickersRaw = Array.isArray(payload.tickers) ? payload.tickers : null;
   if (!tickersRaw) {
     throw new Error("AI screener JSON did not include a `tickers` array.");
+  }
+  if (tickersRaw.some((entry) => !entry || typeof entry !== "object"
+    || !normalizeString((entry as Record<string, unknown>).symbol))) {
+    throw new Error("AI screener returned malformed ticker candidates. Previous results are retained; retry the screen.");
   }
 
   const tickers = tickersRaw

--- a/src/plugins/builtin/ai/screener/pane.tsx
+++ b/src/plugins/builtin/ai/screener/pane.tsx
@@ -330,7 +330,6 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
     return true;
   }, [activateTicker, cursorSymbol]);
 
-  const contentHeight = Math.max(height - 3, 4);
   const editorProvider = editorState ? getAiProvider(editorState.providerId, providers) : null;
   const refreshActiveTab = useCallback(() => {
     if (!activeTab || isRunningActiveTab) return;
@@ -415,7 +414,6 @@ export function AiScreenerPane({ focused, width, height }: PaneProps) {
           activeTab={activeTab}
           columnContext={columnContext}
           columns={columns}
-          contentHeight={contentHeight}
           cursorSymbol={cursorSymbol}
           financialsMap={financialsMap}
           focused={focused}

--- a/src/plugins/builtin/ai/screener/results-view.tsx
+++ b/src/plugins/builtin/ai/screener/results-view.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Box, Text } from "../../../../ui";
-import { EmptyState, Spinner, TickerListTableView, type DataTableKeyEvent } from "../../../../components";
+import { EmptyState, Prose, Spinner, TickerListTableView, type DataTableKeyEvent } from "../../../../components";
 import type { ColumnConfig } from "../../../../types/config";
 import type { TickerFinancials } from "../../../../types/financials";
 import type { TickerRecord } from "../../../../types/ticker";
@@ -16,7 +16,6 @@ export function AiScreenerResultsView({
   activeTab,
   columnContext,
   columns,
-  contentHeight,
   cursorSymbol,
   financialsMap,
   focused,
@@ -34,7 +33,6 @@ export function AiScreenerResultsView({
   activeTab: AiScreenerTab | null;
   columnContext: ColumnContext;
   columns: ColumnConfig[];
-  contentHeight: number;
   cursorSymbol: string | null;
   financialsMap: Map<string, TickerFinancials>;
   focused: boolean;
@@ -95,8 +93,13 @@ export function AiScreenerResultsView({
           ))}
         </Box>
       )}
+      {activeTab && activeTab.results.length > 0 && (
+        <Box paddingX={1} flexDirection="column">
+          <Prose width={detailTextWidth} color={colors.textDim} text={t("AI rationale; listing identity checked. Verify financial criteria in company research.")} />
+        </Box>
+      )}
 
-      <Box flexGrow={1} minHeight={contentHeight}>
+      <Box flexGrow={1} minHeight={0}>
         {!activeTab ? (
           <Box padding={1} flexGrow={1}>
             <EmptyState title={t("No AI screeners yet.")} hint={t("Click + to create one.")} />
@@ -132,10 +135,10 @@ export function AiScreenerResultsView({
             onRootKeyDown={onRootKeyDown}
             resetScrollKey={activeTab.id}
             onRowActivate={onRowActivate}
-            emptyTitle="No matches yet."
+            emptyTitle={activeTab.lastSuccessAt ? "No resolved matches in this run." : "No matches yet."}
             emptyHint={promptDirty && !isRunningActiveTab
               ? "Prompt changed. Refresh to rerun."
-              : "Run this screener. Use PS to customize columns."}
+              : activeTab.lastSuccessAt ? "Review the summary and lookup warnings, or refine the prompt." : "Run this screener. Use PS to customize columns."}
           />
         )}
       </Box>

--- a/src/plugins/builtin/ai/screener/results.test.ts
+++ b/src/plugins/builtin/ai/screener/results.test.ts
@@ -54,3 +54,27 @@ test("AI screener refuses a wrong-exchange ADR and distinguishes saved listings 
     new Map([["VOD:XLON", saved!]]), () => {}, createTestDataProvider({ search: async () => { throw new Error("Should use saved listing"); } }));
   expect(reused.results[0]?.symbol).toBe("VOD:XLON");
 });
+
+test("an unqualified dual listing cannot silently select the first search result", async () => {
+  const repository = setup();
+  const provider = createTestDataProvider({ search: async () => [result("ASML", "NASDAQ"), result("ASML", "AMS")] });
+  const ambiguous = await validateScreenerResults([{ symbol: "ASML", exchange: "", reason: "Technology" }], new Map(), () => {}, provider);
+  expect(ambiguous.results).toEqual([]);
+  expect(await repository.loadAllTickers()).toEqual([]);
+  const qualified = await validateScreenerResults([{ symbol: "ASML.AS", exchange: "AMS", reason: "EUR listing" }], new Map(), () => {}, provider);
+  expect(qualified.results[0]?.exchange).toBe("AMS");
+});
+
+test("a failed lookup retains other resolved candidates and identifies incomplete coverage", async () => {
+  setup();
+  const provider = createTestDataProvider({ search: async (symbol) => {
+    if (symbol === "FAIL") throw new Error("upstream unavailable");
+    return [result("MSFT", "NASDAQ")];
+  } });
+  const validated = await validateScreenerResults([
+    { symbol: "FAIL", exchange: "NYSE", reason: "Unverified" },
+    { symbol: "MSFT", exchange: "NASDAQ", reason: "Candidate" },
+  ], new Map(), () => {}, provider);
+  expect(validated.results.map((entry) => entry.symbol)).toEqual(["MSFT"]);
+  expect(validated.warning).toContain("Lookup failed for 1: FAIL");
+});

--- a/src/plugins/builtin/ai/screener/results.ts
+++ b/src/plugins/builtin/ai/screener/results.ts
@@ -13,7 +13,7 @@ import { getSortValue, type ColumnContext } from "../../portfolio-list/metrics";
 import type { ScreenerSortPreference } from "./model";
 import type { ValidatedScreenerResult } from "./contract";
 
-function summarizeWarning(unresolved: string[], duplicateCount: number): string | null {
+function summarizeWarning(unresolved: string[], failed: string[], duplicateCount: number): string | null {
   const parts: string[] = [];
   if (duplicateCount > 0) {
     parts.push(`Dropped ${duplicateCount} duplicate${duplicateCount === 1 ? "" : "s"}.`);
@@ -21,6 +21,7 @@ function summarizeWarning(unresolved: string[], duplicateCount: number): string 
   if (unresolved.length > 0) {
     parts.push(`Could not resolve ${unresolved.length}: ${unresolved.slice(0, 5).join(", ")}${unresolved.length > 5 ? "..." : ""}.`);
   }
+  if (failed.length > 0) parts.push(`Lookup failed for ${failed.length}: ${failed.slice(0, 5).join(", ")}. Retry to check these candidates.`);
   return parts.length > 0 ? parts.join(" ") : null;
 }
 
@@ -56,11 +57,14 @@ async function resolveCandidateTicker(
     throw new Error("AI screener could not access the ticker repository.");
   }
 
-  const localTicker = [...localTickers.values()].find((ticker) => matchesCandidate({
+  const localMatches = [...localTickers.values()].filter((ticker) => matchesCandidate({
     providerId: "saved", symbol: ticker.metadata.ticker, exchange: ticker.metadata.exchange,
     name: ticker.metadata.name, currency: ticker.metadata.currency, type: ticker.metadata.assetCategory || "",
     brokerContract: ticker.metadata.broker_contracts?.[0],
   }, candidate));
+  // A saved ticker is not evidence that an unqualified symbol has only one listing.
+  const qualified = !!(parsePublicTickerKey(candidate.symbol).exchange || candidate.exchange);
+  const localTicker = qualified && localMatches.length === 1 ? localMatches[0] : undefined;
   if (localTicker) {
     return {
       symbol: localTicker.metadata.ticker,
@@ -71,7 +75,12 @@ async function resolveCandidateTicker(
   }
 
   const searchResults = await dataProvider.search(candidate.symbol);
-  const selected = searchResults.find((result) => matchesCandidate(result, candidate)) ?? null;
+  const matches = searchResults.filter((result) => matchesCandidate(result, candidate));
+  const venues = new Set(matches.map((result) => canonicalExchange(
+    parsePublicTickerKey(result.brokerContract?.localSymbol || result.symbol).exchange
+      || result.primaryExchange || result.brokerContract?.primaryExchange || result.exchange,
+  )));
+  const selected = venues.size === 1 ? matches[0] : null;
   if (!selected) return null;
 
   const { ticker, created } = await upsertTickerFromSearchResult(registry.tickerRepository, selected);
@@ -99,11 +108,19 @@ export async function validateScreenerResults(
 ): Promise<{ results: ValidatedScreenerResult[]; warning: string | null }> {
   const resolved: ValidatedScreenerResult[] = [];
   const unresolved: string[] = [];
+  const failed: string[] = [];
   let duplicateCount = 0;
   const seen = new Set<string>();
+  if (!getSharedRegistry() || !dataProvider) throw new Error("AI screener could not access the ticker repository.");
 
   for (const candidate of candidates) {
-    const result = await resolveCandidateTicker(candidate, localTickers, stateDispatch, dataProvider);
+    let result: ValidatedScreenerResult | null;
+    try {
+      result = await resolveCandidateTicker(candidate, localTickers, stateDispatch, dataProvider);
+    } catch {
+      failed.push(candidate.symbol);
+      continue;
+    }
     if (!result) {
       unresolved.push(candidate.symbol);
       continue;
@@ -118,7 +135,7 @@ export async function validateScreenerResults(
 
   return {
     results: resolved,
-    warning: summarizeWarning(unresolved, duplicateCount),
+    warning: summarizeWarning(unresolved, failed, duplicateCount),
   };
 }
 

--- a/src/plugins/builtin/ai/screener/runner.test.tsx
+++ b/src/plugins/builtin/ai/screener/runner.test.tsx
@@ -1,0 +1,68 @@
+import { afterEach, expect, test } from "bun:test";
+import { act, useState } from "react";
+import { testRender } from "../../../../renderers/opentui/test-utils";
+import { JsonTickerRepository } from "../../../../data/json-ticker-repository";
+import { createTestDataProvider } from "../../../../test-support/data-provider";
+import { Box } from "../../../../ui";
+import { setSharedRegistryForTests, type PluginRegistry } from "../../../registry";
+import { setAiRunHost } from "../runner";
+import { createScreenerTab, type AiScreenerTab } from "./model";
+import { getScreenerPromptSignature } from "./contract";
+import { useAiScreenerRunner } from "./runner";
+
+let renderer: Awaited<ReturnType<typeof testRender>> | undefined;
+afterEach(() => { renderer?.renderer.destroy(); renderer = undefined; setAiRunHost(null); setSharedRegistryForTests(undefined); });
+function deferred<T>() { let resolve!: (value: T) => void; const promise = new Promise<T>((done) => { resolve = done; }); return { promise, resolve }; }
+const response = (symbol: string) => JSON.stringify({ tickers: [{ symbol, exchange: "NASDAQ", reason: "Controlled response" }] });
+
+async function harness(search = async (symbol: string) => [{ providerId: "test", symbol, exchange: "NASDAQ", name: symbol, currency: "USD", type: "EQUITY" }]) {
+  const values = new Map<string, string>();
+  setSharedRegistryForTests({ tickerRepository: new JsonTickerRepository({ getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); }, removeItem: (key) => { values.delete(key); } }), events: { emit() {} } } as unknown as PluginRegistry);
+  const provider = createTestDataProvider({ search });
+  let current!: { tab: AiScreenerTab; edit: (prompt: string) => void; run: () => Promise<void> };
+  function Harness() {
+    const [tab, setTab] = useState(() => createScreenerTab("Original criteria", "anthropic"));
+    const runner = useAiScreenerRunner({ dataProvider: provider, dispatch() {}, providers: [{ id: "anthropic", name: "Claude", available: true, status: "ready", outputModes: ["screener"] }],
+      tabs: [tab], tickers: new Map(), upsertTab: (_id, updater) => setTab(updater) });
+    current = { tab, edit: (prompt) => setTab((old) => ({ ...old, prompt })), run: () => runner.runTab(tab.id) };
+    return <Box />;
+  }
+  renderer = await testRender(<Harness />, { width: 80, height: 12 });
+  await act(async () => { await renderer!.renderOnce(); });
+  return () => current;
+}
+async function flush() { await act(async () => { await Bun.sleep(5); await renderer!.renderOnce(); }); }
+
+test("editing the prompt during a run preserves the identity of the submitted criteria", async () => {
+  const output = deferred<string>();
+  setAiRunHost({ checkStatus: async () => ({ available: true, authenticated: true, message: null }), run: () => ({ done: output.promise, cancel() {} }) });
+  const state = await harness();
+  let run!: Promise<void>;
+  await act(async () => { run = state().run(); await Bun.sleep(0); });
+  await act(async () => { state().edit("Different criteria"); });
+  output.resolve(response("AAPL"));
+  await act(async () => { await run; });
+  expect(state().tab.prompt).toBe("Different criteria");
+  expect(state().tab.lastRunPromptSignature).toBe(getScreenerPromptSignature("Original criteria", "anthropic"));
+});
+
+test("a superseded run cannot overwrite newer results after its ticker lookup completes", async () => {
+  const delayed = deferred<Array<{ providerId: string; symbol: string; exchange: string; name: string; currency: string; type: string }>>();
+  let lookupStarted = false;
+  let runs = 0;
+  setAiRunHost({ checkStatus: async () => ({ available: true, authenticated: true, message: null }), run: () => ({ done: Promise.resolve(response(++runs === 1 ? "OLD" : "NEW")), cancel() {} }) });
+  const state = await harness(async (symbol) => {
+    if (symbol === "OLD") { lookupStarted = true; return delayed.promise; }
+    return [{ providerId: "test", symbol, exchange: "NASDAQ", name: symbol, currency: "USD", type: "EQUITY" }];
+  });
+  let oldRun!: Promise<void>;
+  await act(async () => { oldRun = state().run(); await Bun.sleep(0); });
+  await flush();
+  expect(lookupStarted).toBe(true);
+  await act(async () => { await state().run(); });
+  expect(state().tab.results[0]?.symbol).toBe("NEW");
+  delayed.resolve([{ providerId: "test", symbol: "OLD", exchange: "NASDAQ", name: "OLD", currency: "USD", type: "EQUITY" }]);
+  await act(async () => { await oldRun; });
+  expect(state().tab.results[0]?.symbol).toBe("NEW");
+});

--- a/src/plugins/builtin/ai/screener/runner.ts
+++ b/src/plugins/builtin/ai/screener/runner.ts
@@ -40,8 +40,10 @@ export function useAiScreenerRunner({
 }: UseAiScreenerRunnerOptions) {
   const [runState, setRunState] = useState<RunState | null>(null);
   const runRef = useRef<AiRunController | null>(null);
+  const requestRef = useRef(0);
 
   const cancelRun = useCallback(() => {
+    requestRef.current += 1;
     runRef.current?.cancel();
     runRef.current = null;
     setRunState(null);
@@ -51,6 +53,11 @@ export function useAiScreenerRunner({
     const tab = tabs.find((entry) => entry.id === tabId);
     if (!tab) return;
     const selection = resolveSelection(tab);
+    const requestId = ++requestRef.current;
+    const isCurrent = () => requestRef.current === requestId;
+    runRef.current?.cancel();
+    runRef.current = null;
+    setRunState(null);
 
     const provider = getAiProvider(selection.providerId, providers);
     if (!provider) {
@@ -67,6 +74,7 @@ export function useAiScreenerRunner({
 
     try {
       const providerStatus = await checkAiProviderStatus(provider);
+      if (!isCurrent()) return;
       if (!providerStatus.available || (!providerStatus.authenticated && !providerStatus.inconclusive)) {
         upsertTab(tab.id, (current) => ({
           ...current,
@@ -75,6 +83,7 @@ export function useAiScreenerRunner({
         return;
       }
     } catch (error) {
+      if (!isCurrent()) return;
       upsertTab(tab.id, (current) => ({
         ...current,
         lastError: error instanceof Error ? error.message : `${provider.name} status check failed.`,
@@ -82,7 +91,6 @@ export function useAiScreenerRunner({
       return;
     }
 
-    runRef.current?.cancel();
     const startedAt = Date.now();
     const prompt = buildScreenerPrompt({
       currentDate: new Date(startedAt).toISOString().slice(0, 10),
@@ -106,6 +114,7 @@ export function useAiScreenerRunner({
         modelId: selection.modelId ?? undefined,
         outputMode: "screener",
         onChunk: (output) => {
+          if (!isCurrent()) return;
           setRunState((current) => (
             current?.tabId === tab.id
               ? { ...current, output }
@@ -115,9 +124,11 @@ export function useAiScreenerRunner({
       });
       runRef.current = run;
       rawOutput = await run.done;
+      if (!isCurrent()) return;
 
       const parsed = parseScreenerResponse(rawOutput);
       const validated = await validateScreenerResults(parsed.tickers, tickers, dispatch, dataProvider);
+      if (!isCurrent()) return;
 
       upsertTab(tab.id, (current) => ({
         ...current,
@@ -126,7 +137,7 @@ export function useAiScreenerRunner({
         results: validated.results,
         lastSuccessAt: startedAt,
         lastRunPromptSignature: getScreenerPromptSignature(
-          current.prompt,
+          tab.prompt,
           selection.providerId,
           selection.modelId,
         ),
@@ -135,7 +146,7 @@ export function useAiScreenerRunner({
         debugOutput: null,
       }));
     } catch (error: unknown) {
-      if (isAiRunCancelled(error)) return;
+      if (!isCurrent() || isAiRunCancelled(error)) return;
       upsertTab(tab.id, (current) => ({
         ...current,
         lastError: error instanceof Error ? error.message : "AI screener failed.",
@@ -153,6 +164,7 @@ export function useAiScreenerRunner({
   }, [dataProvider, dispatch, providers, resolveSelection, tabs, tickers, upsertTab]);
 
   useEffect(() => () => {
+    requestRef.current += 1;
     runRef.current?.cancel();
   }, []);
 

--- a/src/plugins/builtin/research/corporate-actions-pane.tsx
+++ b/src/plugins/builtin/research/corporate-actions-pane.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, ScrollBox, Text, TextAttributes, type ScrollBoxRenderable } from "../../../ui";
 import {
   DataTableStackView,
+  Prose,
   usePaneFooter,
   type DataTableCell,
   type DataTableColumn,
@@ -113,8 +114,11 @@ function scoreFilingForEarnings(filing: SecFilingItem, earningsDate: string): nu
   return score;
 }
 
-export function matchEarningsSecFiling(row: { status: string; date: string; dateType?: EventRow["dateType"] } | null | undefined, filings: readonly SecFilingItem[]): SecFilingItem | null {
-  if (!row || row.status !== "Earnings" || row.dateType === "fiscal-period-end") return null;
+export function matchEarningsSecFiling(row: { status: string; date: string; dateType?: EventRow["dateType"]; dateEvidence?: EventRow["dateEvidence"] } | null | undefined, filings: readonly SecFilingItem[]): SecFilingItem | null {
+  if (!row || row.status !== "Earnings") return null;
+  if (row.dateType === "fiscal-period-end") {
+    return row.dateEvidence ? filings.find((filing) => filing.accessionNumber === row.dateEvidence?.accessionNumber) ?? null : null;
+  }
   let best: { filing: SecFilingItem; score: number } | null = null;
   for (const filing of filings) {
     const score = scoreFilingForEarnings(filing, row.date);
@@ -164,7 +168,13 @@ function eventSummaryLine(row: EventRow): string {
   ].filter((line): line is string => !!line).join(" | ");
 }
 
-function buildEventDetailBody({
+function earningsInput(value: number | undefined, currency?: string): string {
+  if (value == null || !Number.isFinite(value)) return "-";
+  const amount = new Intl.NumberFormat("en-US", { maximumFractionDigits: 8 }).format(value);
+  return currency ? `${amount} ${currency}` : amount;
+}
+
+export function buildEventDetailBody({
   row,
   secFilingsLoading,
   filing,
@@ -188,10 +198,24 @@ function buildEventDetailBody({
     return lines.join("\n");
   }
 
+  lines.push("", "EPS comparison (provider values)");
+  lines.push(`Actual: ${earningsInput(row.epsActual, row.epsCurrency)} | Consensus: ${earningsInput(row.epsEstimate, row.epsCurrency)}`);
+  if (row.epsDifference != null) lines.push(`Difference: ${earningsInput(row.epsDifference, row.epsCurrency)}`);
+  if (row.surprisePercent != null) lines.push(`Surprise: ${earningsInput(row.surprisePercent)}%`);
+  lines.push("EPS and consensus may be adjusted; the provider does not specify the accounting basis. Statement EPS can differ.");
+  if (row.providerId || row.fetchedAt) lines.push([row.providerId, row.fetchedAt ? `Fetched ${row.fetchedAt}` : null].filter(Boolean).join(" | "));
+  if (row.fiscalPeriodEnd) lines.push(`Fiscal period: ${row.fiscalPeriodEnd} (${row.periodDateSource === "sec" ? "SEC corroborated" : "provider date"})`);
+  if (row.providerPeriodDate) lines.push(`Provider period date: ${row.providerPeriodDate}`);
+  if (row.dateEvidence) lines.push(`Period evidence: ${row.dateEvidence.accessionNumber}, filed ${row.dateEvidence.filed}. This is not an announcement date or verification of every metric.`);
+  if (row.qRevenue == null && row.earningsState === "reported") lines.push("Quarterly revenue unavailable: no matching statement period was identified.");
+
   lines.push("", "SEC Filing");
   if (row.dateType === "fiscal-period-end") {
-    lines.push("The source supplies a fiscal period end, not an announcement date. Open SEC filings to locate the earnings release.");
-    return lines.join("\n");
+    lines.push("The event source supplies a fiscal period date, not an announcement date.");
+    if (!row.dateEvidence) {
+      lines.push("Open SEC filings to locate the earnings release.");
+      return lines.join("\n");
+    }
   }
   if (secFilingsLoading && !filing) {
     lines.push("Loading recent SEC filings...");
@@ -501,13 +525,13 @@ export function CorporateActionsView({
       }}
       onActivate={(row) => setOpenRowId(row.id)}
       onDetailKeyDown={handleDetailKeyDown}
-      rootBefore={sourceNotice && rows.length > 0 ? (
-        <Box
-          height={1}
-          paddingX={1}
-          {...(sourceNotice.failed ? { "data-gloom-status": "error" } : {})}
-        >
-          <Text fg={sourceNotice.failed ? colors.negative : colors.textDim}>{sourceNotice.text}</Text>
+      rootBefore={rows.length > 0 ? (
+        <Box flexDirection="column" paddingX={1}>
+          {sourceNotice && <Box {...(sourceNotice.failed ? { "data-gloom-status": "error" } : {})}>
+            <Prose width={width - 2} color={sourceNotice.failed ? colors.negative : colors.textDim} text={sourceNotice.text} />
+          </Box>}
+          {rows.some((row) => row.status === "Earnings") && <Prose width={width - 2} color={colors.textDim}
+            text="Event EPS and consensus use an unspecified accounting basis; TTM uses statements. Period ends are not announcement dates. Open a row for source details." />}
         </Box>
       ) : undefined}
       rootWidth={width}

--- a/src/plugins/builtin/research/event-model.test.ts
+++ b/src/plugins/builtin/research/event-model.test.ts
@@ -3,7 +3,7 @@ import { buildEventRows, eventSourceNotice, formatEventMetric } from "./event-mo
 
 test("ADR reported EPS and company revenue keep their distinct currencies", () => {
   const rows = buildEventRows({ symbol: "TSM", currency: "USD", dividends: [], splits: [],
-    earnings: [{ date: "2026-01-15", epsActual: 2.5, currency: "USD" }],
+    earnings: [{ date: "2025-12-31", dateType: "fiscal-period-end", epsActual: 2.5, currency: "USD" }],
   }, null, { financialCurrency: "TWD", quarterlyStatements: [
     { date: "2025-12-31", currency: "TWD", totalRevenue: 1000000000000, eps: 15 },
   ] }, "USD");
@@ -52,4 +52,26 @@ test("partial and stale corporate data are not described as an empty event histo
     actions: { symbol: "RIVN", dividends: [], splits: [], earnings: [], coverage: { earnings: "unavailable", dividends: "available" }, stale: true },
   });
   expect(notice).toEqual({ text: "Unavailable: earnings   Corporate actions stale", failed: true });
+});
+
+test("period aliases retain exact filing provenance and raw surprise inputs", () => {
+  const evidence = { accessionNumber: "0000909832-26-000051", filed: "2026-06-03", startDate: "2026-02-16" };
+  const [row] = buildEventRows({ symbol: "COST", providerId: "yahoo", dividends: [], splits: [], earnings: [
+    { date: "2026-05-31", dateType: "fiscal-period-end", epsActual: 4.93, epsEstimate: 4.9231, difference: 0.0069, surprisePercent: 0.14 },
+  ] }, null, { quarterlyStatements: [{ date: "2026-05-10", providerDate: "2026-05-31", dateSource: "sec", dateEvidence: evidence, totalRevenue: 70_527_000_000, currency: "USD" }] }, "USD");
+  expect(row).toMatchObject({ date: "2026-05-10", providerPeriodDate: "2026-05-31", fiscalPeriodEnd: "2026-05-10", period: "Q26-05-10", dateEvidence: evidence,
+    qRevenue: 70_527_000_000, epsEstimate: 4.9231, epsActual: 4.93, epsDifference: 0.0069, surprisePercent: 0.14, epsBasis: "provider-unspecified" });
+});
+
+test("missing or ambiguous fiscal periods and announcements cannot borrow a previous quarter's revenue", () => {
+  const actions = { symbol: "TEST", dividends: [], splits: [], earnings: [
+    { date: "2026-06-30", dateType: "fiscal-period-end" as const, epsActual: 2 },
+    { date: "2026-08-01", dateType: "announcement" as const, epsActual: 2 },
+  ] };
+  for (const statements of [
+    [{ date: "2026-03-31", totalRevenue: 100 }],
+    [{ date: "2026-06-28", providerDate: "2026-06-30", totalRevenue: 100 }, { date: "2026-06-30", totalRevenue: 200 }],
+  ]) {
+    expect(buildEventRows(actions, null, { quarterlyStatements: statements }, "USD").every((row) => row.qRevenue == null)).toBe(true);
+  }
 });

--- a/src/plugins/builtin/research/event-model.ts
+++ b/src/plugins/builtin/research/event-model.ts
@@ -27,6 +27,18 @@ export interface EventRow {
   revenueCurrency?: string;
   qEps?: number;
   qRevenue?: number;
+  earningsState?: "pending" | "reported";
+  epsActual?: number;
+  epsEstimate?: number;
+  epsDifference?: number;
+  surprisePercent?: number;
+  epsBasis?: "provider-unspecified";
+  providerId?: string;
+  fetchedAt?: string;
+  fiscalPeriodEnd?: string;
+  periodDateSource?: FinancialStatement["dateSource"];
+  providerPeriodDate?: string;
+  dateEvidence?: FinancialStatement["dateEvidence"];
   annualEps?: number;
   annualRevenue?: number;
   value: string;
@@ -65,23 +77,15 @@ function quarterLabel(statement: FinancialStatement | undefined): string {
   return statement?.date ? `Q${statement.date.slice(2)}` : "-";
 }
 
-function daysBetween(leftDate: string, rightDate: string): number {
-  const left = new Date(`${leftDate}T00:00:00Z`).getTime();
-  const right = new Date(`${rightDate}T00:00:00Z`).getTime();
-  if (!Number.isFinite(left) || !Number.isFinite(right)) return Number.POSITIVE_INFINITY;
-  return Math.abs(left - right) / 86_400_000;
-}
-
 function statementForEarningsDate(
   quarterlyStatements: readonly FinancialStatement[],
-  earningsDate: string,
+  earning: CorporateActionsData["earnings"][number],
 ): FinancialStatement | undefined {
-  let best: FinancialStatement | undefined;
-  for (const statement of quarterlyStatements) {
-    if (statement.date > earningsDate) continue;
-    if (!best || statement.date > best.date) best = statement;
-  }
-  return best && daysBetween(best.date, earningsDate) <= 140 ? best : undefined;
+  // Announcement proximity cannot establish which quarter a result describes.
+  // Vendor period aliases are usable only when the statement retains that identity.
+  if (earning.dateType !== "fiscal-period-end") return undefined;
+  const matches = quarterlyStatements.filter((statement) => statement.date === earning.date || statement.providerDate === earning.date);
+  return matches.length === 1 ? matches[0] : undefined;
 }
 
 function estimateKey(estimate: AnalystEstimateRecord): string {
@@ -187,10 +191,10 @@ export function buildEventRows(
 
   for (const earning of data?.earnings ?? []) {
     // A pending announcement must never inherit the previous report's actuals.
-    const statement = earning.epsActual == null ? undefined : statementForEarningsDate(quarterlyStatements, earning.date);
+    const statement = earning.epsActual == null ? undefined : statementForEarningsDate(quarterlyStatements, earning);
     rows.push({
       id: `earn:${earning.date}`,
-      date: earning.date,
+      date: statement?.date ?? earning.date,
       dateType: earning.dateType,
       status: "Earnings",
       period: statement ? quarterLabel(statement) : earning.time?.trim() || "-",
@@ -199,8 +203,20 @@ export function buildEventRows(
       revenueCurrency: statement ? statement.currency ?? financials?.financialCurrency : undefined,
       qEps: earning.epsActual ?? earning.epsEstimate,
       qRevenue: statement?.totalRevenue,
-      value: earning.surprisePercent != null ? formatPercentRaw(earning.surprisePercent) : "-",
-      tone: earning.surprisePercent == null ? "muted" : earning.surprisePercent >= 0 ? "positive" : "negative",
+      earningsState: earning.epsActual == null ? "pending" : "reported",
+      epsActual: earning.epsActual,
+      epsEstimate: earning.epsEstimate,
+      epsDifference: earning.epsActual == null ? undefined : earning.difference,
+      surprisePercent: earning.epsActual == null ? undefined : earning.surprisePercent,
+      epsBasis: "provider-unspecified",
+      providerId: data?.providerId,
+      fetchedAt: data?.fetchedAt,
+      fiscalPeriodEnd: statement?.date,
+      periodDateSource: statement?.dateSource,
+      providerPeriodDate: earning.dateType === "fiscal-period-end" ? earning.date : undefined,
+      dateEvidence: statement?.dateEvidence,
+      value: earning.epsActual != null && earning.surprisePercent != null ? formatPercentRaw(earning.surprisePercent) : "-",
+      tone: earning.epsActual == null || earning.surprisePercent == null ? "muted" : earning.surprisePercent >= 0 ? "positive" : "negative",
     });
   }
 

--- a/src/plugins/builtin/research/headless.test.ts
+++ b/src/plugins/builtin/research/headless.test.ts
@@ -53,6 +53,24 @@ function args(options: Record<string, string | number | boolean>): HeadlessPaneL
 const context = {} as HeadlessPaneContext;
 
 describe("earnings estimates headless", () => {
+  test("all excludes cash actions and reported excludes pending announcements and statement TTM", async () => {
+    const definition = createEarningsEstimatesHeadless({ loadSources: async () => ({ ...sources, actions: { ...sources.actions!,
+      dividends: [{ exDate: "2026-07-01", amount: 1 }],
+      earnings: [...sources.actions!.earnings, { date: "2026-10-01", epsEstimate: 1 }],
+    } }) });
+    const all = await definition.load(args({ kind: "all" }), context);
+    expect(all.rows.some((row) => row.status === "Dividend")).toBe(false);
+    const reported = await definition.load(args({ kind: "reported" }), context);
+    expect(reported.rows).toHaveLength(1);
+    expect(reported.rows[0]).toMatchObject({ epsActual: 0.48, epsEstimate: 0.45, epsDifference: 0.03, surprisePercent: 6.67 });
+  });
+
+  test("stale source rows remain usable while reporting incomplete coverage", async () => {
+    const definition = createEarningsEstimatesHeadless({ loadSources: async () => ({ ...sources, actions: { ...sources.actions!, stale: true } }) });
+    const result = await definition.load(args({ kind: "all" }), context);
+    expect(result.rows.length).toBeGreaterThan(0);
+    expect(result.errors?.join(" ")).toContain("stale");
+  });
   test("maps the shared event model into estimate rows", async () => {
     const definition = createEarningsEstimatesHeadless({
       loadSources: async () => sources,

--- a/src/plugins/builtin/research/headless.ts
+++ b/src/plugins/builtin/research/headless.ts
@@ -9,7 +9,7 @@ import type {
   HeadlessPaneLoadArgs,
   HeadlessRowsResult,
 } from "../../../types/plugin";
-import { formatEventMetric, buildEventRows, type EventRow } from "./event-model";
+import { formatEventMetric, buildEventRows, eventSourceNotice, type EventRow } from "./event-model";
 
 const ESTIMATE_COLUMNS = [
   { key: "date", header: "Date" },
@@ -83,9 +83,9 @@ const defaultDependencies: EarningsEstimatesHeadlessDependencies = {
 };
 
 function matchesKind(row: EventRow, kind: string): boolean {
-  if (kind === "all") return true;
+  if (kind === "all") return ["Earnings", "Q Est", "FY Est", "TTM"].includes(row.status);
   if (kind === "estimates") return row.status === "Q Est" || row.status === "FY Est";
-  return row.status === "Earnings" || row.status === "TTM";
+  return row.status === "Earnings" && row.earningsState === "reported";
 }
 
 export function projectEarningsEstimatesHeadless(
@@ -101,17 +101,28 @@ export function projectEarningsEstimatesHeadless(
     sources.currency,
   ).filter((row) => matchesKind(row, kind));
   const rows = matching.slice(0, limit).map((row) => ({ ...row }));
+  const notice = eventSourceNotice({ variant: "earnings-estimates", symbol: args.symbols[0] ?? String(args.argument ?? ""),
+    actions: sources.actions, estimates: sources.estimates,
+    actionsError: sources.actions ? null : "Source unavailable", estimatesError: sources.estimates ? null : "Source unavailable",
+  });
+  const errors = [...(sources.errors ?? []), ...(notice?.failed ? [notice.text] : [])];
+  const unmatchedReportedPeriods = matching.filter((row) => row.earningsState === "reported" && !row.fiscalPeriodEnd).map((row) => row.date);
+  if (unmatchedReportedPeriods.length) errors.push(`No statement period identified for ${unmatchedReportedPeriods.length} reported earnings row(s); quarterly revenue is unavailable.`);
 
   return {
     columns: ESTIMATE_COLUMNS,
     rows,
-    errors: sources.errors?.length ? sources.errors : undefined,
+    errors: errors.length ? errors : undefined,
     metadata: {
       currency: sources.currency,
       kind,
       total: matching.length,
       returned: rows.length,
       truncated: rows.length < matching.length,
+      coverageNote: notice?.text,
+      epsBasis: "Provider EPS and consensus may be adjusted; accounting basis is unspecified. TTM EPS comes from statements.",
+      dateNote: "Fiscal period dates are not announcement dates. Revenue is attached only to an identified statement period.",
+      unmatchedReportedPeriods,
     },
   };
 }

--- a/src/plugins/builtin/research/index.test.ts
+++ b/src/plugins/builtin/research/index.test.ts
@@ -8,7 +8,7 @@ import {
   sortRatingRows,
   type RatingSortPreference,
 } from "./analyst-pane";
-import { buildEventRows, matchEarningsSecFiling } from "./corporate-actions-pane";
+import { buildEventDetailBody, buildEventRows, matchEarningsSecFiling } from "./corporate-actions-pane";
 import { eventSourceNotice } from "./event-model";
 
 const ratings: AnalystRatingRecord[] = [
@@ -260,7 +260,7 @@ describe("event rows", () => {
       dividends: [],
       splits: [],
       earnings: [
-        { date: "2026-05-01", epsActual: 1.24, surprisePercent: 4.2 },
+        { date: "2026-03-31", dateType: "fiscal-period-end" as const, epsActual: 1.24, surprisePercent: 4.2 },
       ],
     };
     const financials = {
@@ -273,7 +273,7 @@ describe("event rows", () => {
     };
     const rows = buildEventRows(actions, null, financials, "USD");
 
-    const earnings = rows.find((row) => row.id === "earn:2026-05-01");
+    const earnings = rows.find((row) => row.id === "earn:2026-03-31");
     const ttm = rows.find((row) => row.status === "TTM");
 
     expect(earnings).toMatchObject({
@@ -363,6 +363,15 @@ describe("event rows", () => {
 
     expect(matchEarningsSecFiling(row, filings)?.accessionNumber).toBe("0000320193-26-000009");
     expect(matchEarningsSecFiling({ ...row!, dateType: "fiscal-period-end" }, filings)).toBeNull();
+    const periodRow = { ...row!, dateType: "fiscal-period-end" as const,
+      dateEvidence: { accessionNumber: "0000320193-26-000010", filed: "2026-02-04", startDate: "2025-10-01" } };
+    expect(matchEarningsSecFiling(periodRow, filings)?.form).toBe("10-Q");
+    const detail = buildEventDetailBody({ row: periodRow, secFilingsLoading: false,
+      filing: filings[0]!, documents: [], documentsLoading: false, inlineContent: new Map(),
+      primaryContent: "Fiscal statement content", primaryContentLoading: false });
+    expect(detail).toContain("not an announcement date");
+    expect(detail).toContain("Fiscal statement content");
+    expect(detail).toContain("accounting basis");
   });
 });
 


### PR DESCRIPTION
AI screen results could silently pick the first listing for an ambiguous symbol, lose all resolved candidates after one lookup failure, or overwrite a newer run after delayed validation. The screener now rejects ambiguous venues, preserves partial results with coverage warnings, retains good results after malformed output, and ties asynchronous results to the submitted prompt. The results view distinguishes AI rationale from listing identity checks.

Earnings research previously mixed pending announcements into `EE --kind reported`, included dividends in `EE --kind all`, and borrowed nearby statements without establishing the reported quarter. Rows now use unique exact fiscal dates or retained provider-date aliases, preserve the original vendor date and SEC period evidence, and expose actual EPS, consensus, difference, surprise, source and accounting-basis limitations. Exact period evidence opens its SEC filing without treating its filing date as an announcement date.

Observed source checks:
- COST: the vendor May31 period now displays the corroborated May10 quarter, EPS4.93 and revenue70.527B USD. [Issuer release](https://investor.costco.com/news/news-details/2026/Costco-Wholesale-Corporation-Reports-Third-Quarter-and-Year-To-Date-Operating-Results-For-Fiscal-2026/default.aspx) was May28; the [10-Q](https://www.sec.gov/Archives/edgar/data/909832/000090983226000051/cost-20260510.htm) was filed June3. Native navigation reached that exact filing. September24 remains pending.
- NVDA: [issuer results](https://investor.nvidia.com/news/press-release-details/2026/NVIDIA-Announces-Financial-Results-for-Second-Quarter-Fiscal-2027/default.aspx) identify July26 period EPS2.22 as non-GAAP versus GAAP2.46. Provider EPS basis remains explicitly unspecified rather than inferred from the security. Exported actual/consensus arithmetic agrees with all eight COST/NVDA displayed surprises to two decimals.

Validation: 82 focused tests / 229 assertions, all six runtime typechecks, live native CLI reads, actual native COST table → detail → SEC filing, and desktop EE screenshot. AI request/race/provider failure checks use controlled OpenTUI responses; native discovery and the browser both show that no legitimate AI provider/account is connected. Live generated screening and its source completeness remain unverified. No backend changes or release.
