### PR TITLE
Fix incomplete portfolio allocations and mixed-unit account history

### DIFF
--- a/src/plugins/builtin/analytics/broker-performance.test.ts
+++ b/src/plugins/builtin/analytics/broker-performance.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+import type { BrokerPortfolioPerformance } from "../../../types/trading";
+import { buildPerformanceChartPoints, performanceHistoryNote, resolvePerformanceMetric } from "./broker-performance";
+import { buildHistoryAxisLabel, formatHistoryAxisValue } from "./pane-model";
+
+test("missing NAV never substitutes a percentage and deposit growth remains a value series", () => {
+  const performance: BrokerPortfolioPerformance = { accountId: "test", source: "flex", period: "2026", currency: "USD", fetchedAt: 1, points: [
+    { date: "2026-03-01", value: 21000, cumulativeReturn: .1 },
+    { date: "2026-01-01", value: 10000, cumulativeReturn: 0 },
+    { date: "2026-02-01", cumulativeReturn: .1 },
+  ] };
+  expect(buildPerformanceChartPoints(performance).map((point) => point.close)).toEqual([10000, 21000]);
+  expect(buildHistoryAxisLabel({ performance, activePortfolio: null, baseCurrency: "EUR" })).toBe("Value (USD)");
+  expect(performanceHistoryNote(performance)).toContain("1 missing value observation omitted");
+  expect(performanceHistoryNote(performance)).toContain("deposits and withdrawals");
+});
+
+test("a lone or duplicated NAV cannot change a usable return series into a currency chart", () => {
+  const performance: BrokerPortfolioPerformance = { accountId: "test", source: "flex", period: "2026", currency: "USD", fetchedAt: 1, points: [
+    { date: "2026-01-01", cumulativeReturn: 0 },
+    { date: "2026-02-01", cumulativeReturn: .1 },
+    { date: "2026-03-01", value: 21000, cumulativeReturn: .1 },
+    { date: "2026-03-01", value: 21000, cumulativeReturn: .1 },
+  ] };
+  expect(resolvePerformanceMetric(performance)).toBe("cumulativeReturn");
+  expect(buildPerformanceChartPoints(performance).map((point) => point.close)).toEqual([0, .1, .1]);
+  expect(buildHistoryAxisLabel({ performance, activePortfolio: null, baseCurrency: "USD" })).toBe("Return");
+  expect(formatHistoryAxisValue(.1, performance)).toBe("10.0%");
+});

--- a/src/plugins/builtin/analytics/broker-performance.ts
+++ b/src/plugins/builtin/analytics/broker-performance.ts
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
+import { useAsyncResource } from "../../../react/async-resource";
 import type { ProjectedChartPoint } from "../../../components/chart/core/data";
 import type { AppConfig, BrokerInstanceConfig } from "../../../types/config";
 import type { BrokerPortfolioPerformance } from "../../../types/trading";
@@ -53,27 +54,44 @@ function resolveBrokerAccountId(portfolio: Portfolio | null): string | null {
   return parts[0] === "broker" && parts.length >= 3 ? parts.slice(2).join(":") : null;
 }
 
-export function performancePointValue(point: BrokerPortfolioPerformance["points"][number]): number | null {
-  if (point.value != null && Number.isFinite(point.value)) return point.value;
-  if (point.cumulativeReturn != null && Number.isFinite(point.cumulativeReturn)) return point.cumulativeReturn;
-  return null;
+export type PerformanceMetric = "value" | "cumulativeReturn";
+
+function finitePointValue(point: BrokerPortfolioPerformance["points"][number], metric: PerformanceMetric): number | null {
+  const value = point[metric];
+  return value != null && Number.isFinite(value) ? value : null;
+}
+
+/** Choose one unit for the entire series; a missing NAV is never a percentage. */
+export function resolvePerformanceMetric(performance: BrokerPortfolioPerformance | null): PerformanceMetric {
+  const points = performance?.points.filter((point) => Number.isFinite(new Date(point.date).getTime())) ?? [];
+  const count = (metric: PerformanceMetric) => new Set(points.filter((point) => finitePointValue(point, metric) != null)
+    .map((point) => new Date(point.date).getTime())).size;
+  const valueCount = count("value");
+  const returnCount = count("cumulativeReturn");
+  return valueCount >= 2 || (valueCount > 0 && returnCount < 2) ? "value" : "cumulativeReturn";
 }
 
 export function buildPerformanceChartPoints(performance: BrokerPortfolioPerformance | null): ProjectedChartPoint[] {
   if (!performance) return [];
-  return performance.points.flatMap((point) => {
-    const value = performancePointValue(point);
+  const metric = resolvePerformanceMetric(performance);
+  const byDate = new Map<number, ProjectedChartPoint>();
+  for (const point of performance.points) {
+    const value = finitePointValue(point, metric);
     const date = new Date(point.date);
-    if (value == null || !Number.isFinite(date.getTime())) return [];
-    return [{
-      date,
-      open: value,
-      high: value,
-      low: value,
-      close: value,
-      volume: 0,
-    }];
-  });
+    if (value == null || !Number.isFinite(date.getTime())) continue;
+    byDate.set(date.getTime(), { date, open: value, high: value, low: value, close: value, volume: 0 });
+  }
+  return [...byDate.values()].sort((left, right) => left.date.getTime() - right.date.getTime());
+}
+
+export function performanceHistoryNote(performance: BrokerPortfolioPerformance | null): string | null {
+  if (!performance) return null;
+  const metric = resolvePerformanceMetric(performance);
+  const missing = performance.points.filter((point) => finitePointValue(point, metric) == null).length;
+  const basis = metric === "value"
+    ? "Account value includes deposits and withdrawals. Investment returns require cash-flow adjustments."
+    : "Broker-reported return; calculation method not supplied.";
+  return `${basis}${missing ? ` ${missing} missing ${metric === "value" ? "value" : "return"} observation${missing === 1 ? "" : "s"} omitted.` : ""}`;
 }
 
 export function useBrokerPortfolioPerformance(
@@ -83,60 +101,24 @@ export function useBrokerPortfolioPerformance(
   const { getBrokerAdapter } = usePluginBrokerActions();
   const brokerInstances = useMemo(() => findBrokerPerformanceCandidates(config, portfolio), [config, portfolio]);
   const accountId = useMemo(() => resolveBrokerAccountId(portfolio), [portfolio]);
-  const [state, setState] = useState<BrokerPerformanceState>({
-    loading: false,
-    performance: null,
-    error: null,
-  });
-
-  useEffect(() => {
-    let cancelled = false;
-    if (brokerInstances.length === 0 || !accountId) {
-      setState({ loading: false, performance: null, error: null });
-      return;
+  const load = useCallback(async () => {
+    let lastError: string | null = null;
+    for (const brokerInstance of brokerInstances) {
+      const broker = getBrokerAdapter(brokerInstance.brokerType);
+      if (!broker?.getPortfolioPerformance || !accountId) continue;
+      try {
+        const performance = await broker.getPortfolioPerformance(brokerInstance, accountId);
+        if (performance && performance.accountId !== accountId) {
+          lastError = "Returned history belongs to a different account";
+          continue;
+        }
+        if (performance && performance.points.length > 0) return performance;
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
+      }
     }
-
-    setState((current) => ({ ...current, loading: true, error: null }));
-    void (async () => {
-      let lastError: string | null = null;
-      for (const brokerInstance of brokerInstances) {
-        const broker = getBrokerAdapter(brokerInstance.brokerType);
-        if (!broker?.getPortfolioPerformance) continue;
-        try {
-          const performance = await broker.getPortfolioPerformance(brokerInstance, accountId);
-          if (performance && performance.points.length > 0) {
-            if (!cancelled) {
-              setState({ loading: false, performance, error: null });
-            }
-            return;
-          }
-        } catch (error) {
-          lastError = error instanceof Error ? error.message : String(error);
-        }
-      }
-
-      if (!cancelled) {
-        setState({
-          loading: false,
-          performance: null,
-          error: lastError ?? "No IBKR portfolio history returned",
-        });
-      }
-    })()
-      .catch((error) => {
-        if (!cancelled) {
-          setState({
-            loading: false,
-            performance: null,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
+    throw new Error(lastError ?? "No account history returned");
   }, [accountId, brokerInstances, getBrokerAdapter]);
-
-  return state;
+  const resource = useAsyncResource(brokerInstances.length > 0 && accountId ? load : null);
+  return { loading: resource.loading, performance: resource.data, error: resource.error };
 }

--- a/src/plugins/builtin/analytics/display.ts
+++ b/src/plugins/builtin/analytics/display.ts
@@ -25,11 +25,13 @@ export function betaColor(beta: number): string {
   return colors.positive;
 }
 
-export function formatSignedCompact(value: number): string {
+export function formatSignedCompact(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return "—";
   return `${value >= 0 ? "+" : ""}${formatCompact(value)}`;
 }
 
-export function formatWeight(weight: number): string {
+export function formatWeight(weight: number | null): string {
+  if (weight == null || !Number.isFinite(weight)) return "—";
   return `${(weight * 100).toFixed(1)}%`;
 }
 
@@ -38,7 +40,8 @@ export function formatReturn(value: number): string {
   return `${pct >= 0 ? "+" : ""}${pct.toFixed(2)}%`;
 }
 
-export function renderBar(weight: number, maxWidth: number): string {
+export function renderBar(weight: number | null, maxWidth: number): string {
+  if (weight == null || !Number.isFinite(weight) || weight <= 0) return "";
   const filled = Math.round(weight * maxWidth);
   return "█".repeat(Math.min(filled, maxWidth));
 }

--- a/src/plugins/builtin/analytics/index.test.tsx
+++ b/src/plugins/builtin/analytics/index.test.tsx
@@ -8,6 +8,8 @@ import type { AppConfig } from "../../../types/config";
 import type { TickerFinancials } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 import type { BrokerAccount } from "../../../types/trading";
+import type { BrokerAdapter } from "../../../types/plugin";
+import type { BrokerPortfolioPerformance } from "../../../types/trading";
 import type { PluginRuntimeAccess } from "../../runtime";
 import { portfolioAnalyticsModule } from "./index";
 import { TestPaneProvider, createTestPaneConfig } from "../../../test-support/pane";
@@ -139,12 +141,16 @@ function AnalyticsHarness({
   financials,
   runtime = createTestPluginRuntime(),
   ticker = createSharedTicker(),
+  width = 100,
+  height = 24,
 }: {
   config: AppConfig;
   brokerAccounts?: Record<string, BrokerAccount[]>;
   financials?: TickerFinancials;
   runtime?: PluginRuntimeAccess;
   ticker?: TickerRecord;
+  width?: number;
+  height?: number;
 }) {
   const initialState = createInitialState(config);
   initialState.focusedPaneId = TEST_PANE_ID;
@@ -166,8 +172,8 @@ function AnalyticsHarness({
         paneId={TEST_PANE_ID}
         paneType="analytics"
         focused
-        width={100}
-        height={24}
+        width={width}
+        height={height}
       />
     </TestPaneProvider>
   );
@@ -177,16 +183,6 @@ async function flushFrame() {
   await act(async () => {
     await testSetup!.renderOnce();
   });
-}
-
-function expectBlankLineBetween(frame: string, beforeText: string, afterText: string) {
-  const lines = frame.split("\n");
-  const beforeRow = lines.findIndex((line) => line.includes(beforeText));
-  const afterRow = lines.findIndex((line) => line.includes(afterText));
-
-  expect(beforeRow).toBeGreaterThanOrEqual(0);
-  expect(afterRow).toBe(beforeRow + 2);
-  expect(lines[beforeRow + 1]?.trim()).toBe("");
 }
 
 beforeEach(() => {
@@ -205,6 +201,49 @@ afterEach(async () => {
 });
 
 describe("PortfolioAnalyticsPane", () => {
+  test("switching accounts hides prior performance while the next account is pending", async () => {
+    const firstId = BROKER_PORTFOLIO_ID;
+    const secondId = "broker:ibkr-flex:DU54321";
+    let completeSecond!: (value: BrokerPortfolioPerformance) => void;
+    const second = new Promise<BrokerPortfolioPerformance>((resolve) => { completeSecond = resolve; });
+    const adapter: BrokerAdapter = {
+      id: "ibkr", name: "Fixture", configSchema: [], validate: async () => true, importPositions: async () => [],
+      getPortfolioPerformance: async (_instance, accountId) => accountId === "DU54321" ? second : {
+        accountId, source: "flex", period: "First account", fetchedAt: 1,
+        points: [{ date: "2026-01-01", value: 10000, cumulativeReturn: 0 }, { date: "2026-02-01", value: 11000, cumulativeReturn: .1 }],
+      },
+    };
+    const runtime = createTestPluginRuntime({ getBrokerAdapter: () => adapter });
+    const config = createAnalyticsConfig(firstId);
+    config.portfolios = [
+      { id: firstId, name: "First", currency: "USD", brokerInstanceId: "ibkr-flex", brokerAccountId: "DU12345" },
+      { id: secondId, name: "Second", currency: "USD", brokerInstanceId: "ibkr-flex", brokerAccountId: "DU54321" },
+    ];
+    config.brokerInstances = [{ id: "ibkr-flex", brokerType: "ibkr", label: "Fixture", enabled: false, config: {} }];
+    const ticker = createSharedTicker();
+    ticker.metadata.portfolios = [firstId, secondId];
+    ticker.metadata.positions = [firstId, secondId].map((portfolio) => ({ ...ticker.metadata.positions[1]!, portfolio }));
+    await act(async () => {
+      testSetup = await testRender(<AnalyticsHarness config={config} runtime={runtime} ticker={ticker} />, { width: 100, height: 24 });
+      await testSetup.renderOnce();
+    });
+    await flushFrame();
+    expect(testSetup!.captureCharFrame()).toContain("+10.00%");
+    await act(async () => { testSetup!.mockInput.pressArrow("right"); await testSetup!.renderOnce(); });
+    await flushFrame();
+    expect(harnessState?.paneState[TEST_PANE_ID]?.portfolioId).toBe(secondId);
+    expect(testSetup!.captureCharFrame()).not.toContain("+10.00%");
+    expect(testSetup!.captureCharFrame()).not.toContain("Portfolio History");
+    await act(async () => {
+      completeSecond({ accountId: "DU54321", source: "flex", period: "Second account", fetchedAt: 1,
+        points: [{ date: "2026-01-01", cumulativeReturn: 0 }, { date: "2026-02-01", cumulativeReturn: .2 }] });
+      await second;
+    });
+    await flushFrame();
+    expect(testSetup!.captureCharFrame()).toContain("+20.00%");
+    expect(testSetup!.captureCharFrame()).not.toContain("+10.00%");
+  });
+
   test("renders portfolio tabs and filters broker-managed positions to the active portfolio", async () => {
     await act(async () => {
       testSetup = await testRender(
@@ -226,7 +265,6 @@ describe("PortfolioAnalyticsPane", () => {
     expect(frame).toContain("Est. Sharpe");
     expect(frame).toContain("Beta (SPY)");
     expect(frame).toContain("SECTOR");
-    expectBlankLineBetween(frame, "Beta (SPY)", "Sector Allocation");
     expect(frame).toContain("Technology");
     expect(frame).toContain("100.0%");
     expect(frame).not.toContain("2.5k");
@@ -384,11 +422,13 @@ describe("PortfolioAnalyticsPane", () => {
     await act(async () => {
       testSetup = await testRender(
         <AnalyticsHarness
+          width={80}
+          height={30}
           config={config}
           runtime={runtime}
           ticker={createBrokerTicker(GATEWAY_PORTFOLIO_ID, "ibkr-live")}
         />,
-        { width: 100, height: 24 },
+        { width: 80, height: 30 },
       );
       await Promise.resolve();
       await testSetup.renderOnce();
@@ -402,9 +442,11 @@ describe("PortfolioAnalyticsPane", () => {
       { instanceId: "ibkr-live", accountId: "DU12345" },
       { instanceId: "ibkr-flex", accountId: "DU12345" },
     ]);
-    expect(frame).toContain("Hist Ret");
+    expect(frame).toContain("Broker return");
     expect(frame).toContain("+10.00%");
     expect(frame).toContain("Portfolio History");
+    expect(frame).toContain("Technology");
+    expect(frame).toContain("100.0%");
     expect(frame).toContain("Flex FLEX");
   });
 

--- a/src/plugins/builtin/analytics/index.tsx
+++ b/src/plugins/builtin/analytics/index.tsx
@@ -1,11 +1,12 @@
 import { Box, Text } from "../../../ui";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TextAttributes } from "../../../ui";
-import { EmptyState, Tabs } from "../../../components";
+import { EmptyState, Notice, Tabs } from "../../../components";
 import type { PaneProps } from "../../../types/plugin";
 import type { PluginModule } from "../plugin-module";
 import { colors } from "../../../theme/colors";
 import { convertCurrency } from "../../../utils/format";
+import { wrapTextLines } from "../../../utils/text-wrap";
 import {
   getFocusedCollectionId,
   useAppSelector,
@@ -18,6 +19,7 @@ import { usePortfolioAccountState } from "../portfolio-list/header";
 import { calculatePortfolioSummaryTotals, type ColumnContext } from "../portfolio-list/metrics";
 import {
   buildPerformanceChartPoints,
+  performanceHistoryNote,
   useBrokerPortfolioPerformance,
 } from "./broker-performance";
 import {
@@ -43,7 +45,6 @@ import {
   nextSectorSortPreference,
   sortSectorRows,
   type SectorSortPreference,
-  type SectorTableRow,
 } from "./sector-model";
 import { describePortfolioTab, resolvePortfolioId, resolveTemplatePortfolioId } from "./portfolio-selection";
 import {
@@ -194,10 +195,20 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
     [portfolioReturnSeries, spyReturnSeries],
   );
 
-  const sectorRows = useMemo<SectorTableRow[]>(
+  const sectorAllocation = useMemo(
     () => buildSectorRowsFromPortfolioColumns(portfolioTickers, financials, columnContext),
     [columnContext, financials, portfolioTickers],
   );
+  const allocationNotices = [
+    { text: "Weights use gross position value; cash excluded.", tone: "muted" as const },
+    ...(sectorAllocation.unvaluedSymbols.length > 0 ? [{
+      text: `Weights unavailable: missing prices or FX for ${sectorAllocation.unvaluedSymbols.join(", ")}.`, tone: "warning" as const,
+    }] : []),
+    ...(sectorAllocation.fundSymbols.length > 0 ? [{
+      text: "Fund constituents and ETF overlap are unavailable; funds are grouped separately.", tone: "muted" as const,
+    }] : []),
+  ];
+  const sectorRows = sectorAllocation.rows;
   const sortedSectorRows = useMemo(
     () => sortSectorRows(sectorRows, sectorSort),
     [sectorRows, sectorSort],
@@ -236,7 +247,12 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
     [beta, returnSeriesResult.coverage, returnSeriesResult.missingCount, returnSeriesResult.unvaluedCount, returnSeriesResult.unsupportedReason, sharpe],
   );
   const metricsHeight = summaryRows.length + riskRows.length + 5;
-  const availableHistoryChartHeight = height - metricsHeight - 7;
+  const historyNote = performanceHistoryNote(brokerPerformance.performance);
+  const noticeWidth = Math.max(1, width - 2);
+  const noticeHeight = allocationNotices.reduce((total, notice) => total + wrapTextLines(notice.text, noticeWidth).length, 0)
+    + (historyNote ? wrapTextLines(historyNote, noticeWidth).length : 0);
+  // Keep table rows available after the history method and coverage notices wrap.
+  const availableHistoryChartHeight = height - metricsHeight - 7 - noticeHeight;
   const historyChartHeight = performanceChartPoints.length >= 2 && availableHistoryChartHeight >= 5
     ? Math.min(8, availableHistoryChartHeight)
     : 0;
@@ -313,13 +329,18 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
                 axisLabel={historyAxisLabel}
                 period={brokerPerformance.performance?.period}
                 stale={brokerPerformance.performance?.stale}
+                note={historyNote}
+                manual={!activePortfolio?.brokerInstanceId}
                 formatAxisValue={formatHistoryAxis}
               />
 
               <Box height={1} paddingX={1}>
                 <Text fg={colors.textDim} attributes={TextAttributes.BOLD}>
-                  Sector Allocation
+                  Holdings by sector
                 </Text>
+              </Box>
+              <Box paddingX={1} flexDirection="column">
+                {allocationNotices.map((notice) => <Notice key={notice.text} tone={notice.tone}>{notice.text}</Notice>)}
               </Box>
 
               <SectorAllocationTable

--- a/src/plugins/builtin/analytics/pane-model.ts
+++ b/src/plugins/builtin/analytics/pane-model.ts
@@ -10,7 +10,7 @@ import { buildChartKey } from "../../../market-data/selectors";
 import { resolvePortfolioAccountMetrics, resolvePortfolioMarketValue } from "../portfolio-list/account-metrics";
 import type { ColumnContext, PortfolioSummaryTotals } from "../portfolio-list/metrics";
 import type { ResolvedPortfolioAccountState } from "../portfolio-list/summary";
-import { performancePointValue } from "./broker-performance";
+import { buildPerformanceChartPoints, resolvePerformanceMetric } from "./broker-performance";
 import {
   formatReturn,
   formatSignedCompact,
@@ -238,11 +238,13 @@ export function buildAnalyticsSummaryRows({
     });
   }
 
-  const latestPerformancePoint = brokerPerformance?.points.at(-1);
-  if (latestPerformancePoint?.cumulativeReturn != null) {
+  const latestPerformancePoint = brokerPerformance?.points
+    .filter((point) => Number.isFinite(new Date(point.date).getTime()))
+    .sort((left, right) => new Date(left.date).getTime() - new Date(right.date).getTime()).at(-1);
+  if (latestPerformancePoint?.cumulativeReturn != null && Number.isFinite(latestPerformancePoint.cumulativeReturn)) {
     rows.push({
       id: "historical-return",
-      label: "Hist Ret",
+      label: "Broker return",
       value: formatReturn(latestPerformancePoint.cumulativeReturn),
       detail: brokerPerformance?.period,
       color: priceColor(latestPerformancePoint.cumulativeReturn),
@@ -344,11 +346,9 @@ export function buildAnalyticsRiskRows({
 export function resolvePerformancePalette(
   performance: BrokerPortfolioPerformance | null,
 ): ReturnType<typeof resolveChartPalette> {
-  const points = performance?.points ?? [];
-  const first = points.find((point) => performancePointValue(point) != null);
-  const last = [...points].reverse().find((point) => performancePointValue(point) != null);
-  const firstValue = first ? performancePointValue(first) : null;
-  const lastValue = last ? performancePointValue(last) : null;
+  const points = buildPerformanceChartPoints(performance);
+  const firstValue = points[0]?.close ?? null;
+  const lastValue = points.at(-1)?.close ?? null;
   return resolveChartPalette(colors, firstValue != null && lastValue != null && lastValue < firstValue ? "negative" : "positive");
 }
 
@@ -361,8 +361,8 @@ export function buildHistoryAxisLabel({
   activePortfolio: Portfolio | null;
   baseCurrency: string;
 }): string {
-  return performance?.points.some((point) => point.value != null)
-    ? `Value (${performance.currency ?? activePortfolio?.currency ?? baseCurrency})`
+  return resolvePerformanceMetric(performance) === "value"
+    ? `Value (${performance?.currency ?? activePortfolio?.currency ?? baseCurrency})`
     : "Return";
 }
 
@@ -370,7 +370,7 @@ export function formatHistoryAxisValue(
   value: number,
   performance: BrokerPortfolioPerformance | null,
 ): string {
-  return performance?.points.some((point) => point.value != null)
+  return resolvePerformanceMetric(performance) === "value"
     ? formatCompact(value)
     : `${(value * 100).toFixed(1)}%`;
 }

--- a/src/plugins/builtin/analytics/sector-model.test.ts
+++ b/src/plugins/builtin/analytics/sector-model.test.ts
@@ -39,3 +39,18 @@ test("gross long/short concentration keeps signed P&L and missing cost cannot be
     expect(sortSectorRows(rows, { columnId: "return", direction }).at(-1)?.returnPct).toBeNull();
   }
 });
+
+test("known zero broker values and marks retain zero weight and losses without becoming missing data", () => {
+  for (const zeroValue of [{ marketValue: 0 }, { markPrice: 0 }]) {
+    const worthless = holding("ZERO");
+    worthless.metadata.sector = "Energy";
+    worthless.metadata.positions = [{ portfolio: "main", shares: 10, avgCost: 100, currency: "USD", broker: "manual", ...zeroValue }];
+    const calculate = () => buildSectorRowsFromPortfolioColumns([holding("AAPL"), worthless], new Map(), context());
+    expect(calculate().unvaluedSymbols).toEqual([]);
+    expect(calculate().rows.find((row) => row.sector === "Energy")).toMatchObject({ value: 0, weight: 0, pnl: -1000, returnPct: -100 });
+    expect(calculate().rows.find((row) => row.sector === "Technology")?.weight).toBe(1);
+    worthless.metadata.positions = [{ portfolio: "main", shares: 10, avgCost: 100, currency: "USD", broker: "manual" }];
+    expect(calculate().unvaluedSymbols).toEqual(["ZERO"]);
+    expect(calculate().rows.every((row) => row.weight === null)).toBe(true);
+  }
+});

--- a/src/plugins/builtin/analytics/sector-model.test.ts
+++ b/src/plugins/builtin/analytics/sector-model.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import type { TickerRecord } from "../../../types/ticker";
+import { buildSectorRowsFromPortfolioColumns, sortSectorRows } from "./sector-model";
+
+const holding = (symbol: string, currency = "USD", assetCategory = "STK"): TickerRecord => ({ metadata: {
+  ticker: symbol, name: symbol, currency, assetCategory, exchange: "NASDAQ", sector: "Technology",
+  portfolios: ["main"], watchlists: [], custom: {}, tags: [],
+  positions: [{ portfolio: "main", shares: 10, avgCost: 100, markPrice: 120, currency, broker: "manual" }],
+} });
+const context = () => ({ activeTab: "main", baseCurrency: "USD", exchangeRates: new Map<string, number>(), now: 0 });
+
+test("missing FX does not disappear from concentration or renormalize the remaining portfolio", () => {
+  const tickers = [holding("AAPL"), holding("SAP", "EUR"), holding("QQQ", "USD", "ETF")];
+  const ctx = context();
+  const missing = buildSectorRowsFromPortfolioColumns(tickers, new Map(), ctx);
+  expect(missing.unvaluedSymbols).toEqual(["SAP"]);
+  expect(missing.fundSymbols).toEqual(["QQQ"]);
+  expect(missing.rows.find((row) => row.sector === "Technology")).toMatchObject({ value: null, pnl: null, costBasis: null, weight: null, returnPct: null });
+  expect(missing.rows.find((row) => row.sector === "Funds")).toMatchObject({ value: 1200, pnl: 200, weight: null });
+  ctx.exchangeRates.set("EUR", 1.2);
+  const restored = buildSectorRowsFromPortfolioColumns(tickers, new Map(), ctx);
+  expect(restored.unvaluedSymbols).toEqual([]);
+  expect(restored.rows.find((row) => row.sector === "Technology")?.weight).toBeCloseTo(2640 / 3840);
+  expect(restored.rows.find((row) => row.sector === "Funds")?.weight).toBeCloseTo(1200 / 3840);
+});
+
+test("gross long/short concentration keeps signed P&L and missing cost cannot become zero", () => {
+  const long = holding("AAPL");
+  const short = holding("MSFT");
+  short.metadata.positions[0]!.shares = -10;
+  short.metadata.positions[0]!.avgCost = 130;
+  const aggregate = () => buildSectorRowsFromPortfolioColumns([long, short], new Map(), context()).rows[0]!;
+  expect(aggregate()).toMatchObject({ value: 2400, costBasis: 2300, pnl: 300, weight: 1 });
+  expect(aggregate().returnPct).toBeCloseTo(300 / 2300 * 100);
+  short.metadata.positions[0]!.avgCost = Number.NaN;
+  expect(aggregate()).toMatchObject({ value: 2400, costBasis: null, pnl: null, weight: 1, returnPct: null });
+  const rows = [aggregate(), { ...aggregate(), id: "known", returnPct: -5 }];
+  for (const direction of ["asc", "desc"] as const) {
+    expect(sortSectorRows(rows, { columnId: "return", direction }).at(-1)?.returnPct).toBeNull();
+  }
+});

--- a/src/plugins/builtin/analytics/sector-model.ts
+++ b/src/plugins/builtin/analytics/sector-model.ts
@@ -14,11 +14,17 @@ export interface SectorTableColumn extends DataTableColumn {
 export interface SectorTableRow {
   id: string;
   sector: string;
-  weight: number;
-  value: number;
-  pnl: number;
+  weight: number | null;
+  value: number | null;
+  pnl: number | null;
   returnPct: number | null;
-  costBasis: number;
+  costBasis: number | null;
+}
+
+export interface PortfolioSectorAllocation {
+  rows: SectorTableRow[];
+  unvaluedSymbols: string[];
+  fundSymbols: string[];
 }
 
 export interface SectorSortPreference {
@@ -48,7 +54,7 @@ export function buildSectorColumns(width: number): SectorTableColumn[] {
     { id: "weight", label: "WEIGHT", width: weightWidth, align: "right" },
     { id: "value", label: "VALUE", width: valueWidth, align: "right" },
     { id: "pnl", label: "P&L", width: pnlWidth, align: "right" },
-    { id: "return", label: "RETURN", width: returnWidth, align: "right" },
+    { id: "return", label: "P&L %", width: returnWidth, align: "right" },
     { id: "bar", label: "ALLOCATION", width: barWidth, align: "left" },
   ];
 }
@@ -62,7 +68,7 @@ export function getPortfolioPositionValue(
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
 }
 
-function getSectorSortValue(row: SectorTableRow, columnId: SectorColumnId): string | number {
+function getSectorSortValue(row: SectorTableRow, columnId: SectorColumnId): string | number | null {
   switch (columnId) {
     case "sector":
       return row.sector;
@@ -71,7 +77,7 @@ function getSectorSortValue(row: SectorTableRow, columnId: SectorColumnId): stri
     case "pnl":
       return row.pnl;
     case "return":
-      return row.returnPct ?? Number.NEGATIVE_INFINITY;
+      return row.returnPct;
     case "bar":
     case "weight":
       return row.weight;
@@ -107,22 +113,30 @@ export function buildSectorRowsFromPortfolioColumns(
   tickers: TickerRecord[],
   financialsMap: Map<string, TickerFinancials>,
   columnContext: ColumnContext,
-): SectorTableRow[] {
+): PortfolioSectorAllocation {
   const sectorMap = new Map<string, {
     sector: string;
-    value: number;
-    pnl: number;
-    costBasis: number;
+    value: number | null;
+    pnl: number | null;
+    costBasis: number | null;
   }>();
+  const unvaluedSymbols: string[] = [];
+  const fundSymbols: string[] = [];
+  const addKnown = (total: number | null, value: unknown): number | null => (
+    total != null && typeof value === "number" && Number.isFinite(value) ? total + value : null
+  );
 
   for (const ticker of tickers) {
     const financials = financialsMap.get(ticker.metadata.ticker);
     const value = getPortfolioPositionValue(ticker, financials, columnContext);
-    if (value == null) continue;
+    if (value == null) unvaluedSymbols.push(ticker.metadata.ticker);
 
     const pnl = getSortValue(PORTFOLIO_PNL_COLUMN, ticker, financials, columnContext);
     const costBasis = getSortValue(PORTFOLIO_COST_COLUMN, ticker, financials, columnContext);
-    const sector = ticker.metadata.sector || financials?.profile?.sector || "Unknown";
+    const isFund = [ticker.metadata.assetCategory, financials?.quote?.instrumentType]
+      .some((type) => /^(ETF|ETN|FUND|MUTUALFUND|MUTUAL_FUND)$/i.test(type ?? ""));
+    if (isFund) fundSymbols.push(ticker.metadata.ticker);
+    const sector = isFund ? "Funds" : ticker.metadata.sector || financials?.profile?.sector || "Unknown";
     const current = sectorMap.get(sector) ?? {
       sector,
       value: 0,
@@ -130,23 +144,24 @@ export function buildSectorRowsFromPortfolioColumns(
       costBasis: 0,
     };
 
-    current.value += value;
-    current.pnl += typeof pnl === "number" && Number.isFinite(pnl) ? pnl : 0;
-    current.costBasis += typeof costBasis === "number" && Number.isFinite(costBasis) ? costBasis : 0;
+    current.value = addKnown(current.value, value);
+    current.pnl = addKnown(current.pnl, pnl);
+    current.costBasis = addKnown(current.costBasis, costBasis);
     sectorMap.set(sector, current);
   }
 
-  const totalValue = [...sectorMap.values()].reduce((sum, row) => sum + row.value, 0);
-  if (totalValue === 0) return [];
+  const totalValue = unvaluedSymbols.length === 0
+    ? [...sectorMap.values()].reduce((sum, row) => sum + (row.value ?? 0), 0) : null;
 
-  return [...sectorMap.values()]
+  const rows = [...sectorMap.values()]
     .map((row) => ({
       ...row,
       id: row.sector,
-      weight: row.value / totalValue,
-      returnPct: row.costBasis !== 0 ? (row.pnl / row.costBasis) * 100 : null,
+      weight: row.value != null && totalValue != null && totalValue > 0 ? row.value / totalValue : null,
+      returnPct: row.pnl != null && row.costBasis != null && row.costBasis !== 0 ? (row.pnl / row.costBasis) * 100 : null,
     }))
-    .sort((left, right) => right.weight - left.weight || left.sector.localeCompare(right.sector));
+    .sort((left, right) => compareSortValues(left.weight, right.weight, "desc") || left.sector.localeCompare(right.sector));
+  return { rows, unvaluedSymbols, fundSymbols };
 }
 
 export function sortSectorRows(rows: SectorTableRow[], sort: SectorSortPreference): SectorTableRow[] {

--- a/src/plugins/builtin/analytics/sector-model.ts
+++ b/src/plugins/builtin/analytics/sector-model.ts
@@ -65,7 +65,7 @@ export function getPortfolioPositionValue(
   columnContext: ColumnContext,
 ): number | null {
   const value = getSortValue(PORTFOLIO_VALUE_COLUMN, ticker, financials, columnContext);
-  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
 }
 
 function getSectorSortValue(row: SectorTableRow, columnId: SectorColumnId): string | number | null {

--- a/src/plugins/builtin/analytics/view.tsx
+++ b/src/plugins/builtin/analytics/view.tsx
@@ -60,6 +60,8 @@ export function PortfolioHistorySection({
   axisLabel,
   period,
   stale,
+  note,
+  manual,
   formatAxisValue,
 }: {
   show: boolean;
@@ -72,6 +74,8 @@ export function PortfolioHistorySection({
   axisLabel: string;
   period: string | undefined;
   stale: boolean | undefined;
+  note: string | null;
+  manual: boolean;
   formatAxisValue: (value: number) => string;
 }) {
   if (show) {
@@ -83,6 +87,7 @@ export function PortfolioHistorySection({
             {`  Flex ${period ?? ""}${stale ? " - cached" : ""}`}
           </Text>
         </Box>
+        {note ? <Box paddingX={1} flexDirection="column" flexShrink={0}><Notice tone="muted">{note}</Notice></Box> : null}
         <Box paddingX={1} height={height}>
           <StaticChartSurface
             points={points}
@@ -102,20 +107,32 @@ export function PortfolioHistorySection({
   if (loading) {
     return (
       <Box height={1} paddingX={1}>
-        <Spinner label={loadingText("IBKR history")} />
+        <Spinner label={loadingText("account history")} />
       </Box>
     );
   }
 
   if (error) {
     return (
-      <Box paddingX={1}>
-        <Notice>{`${unavailableText("IBKR history")} ${error}`}</Notice>
+      <Box paddingX={1} flexDirection="column" flexShrink={0}>
+        <Notice>{`${unavailableText("Account history")} ${error}`}</Notice>
       </Box>
     );
   }
 
-  return null;
+  if (points.length > 0) {
+    return (
+      <Box paddingX={1} flexDirection="column" flexShrink={0}>
+        <Notice tone="muted">{`${points.length >= 2 ? "Enlarge this pane to view account history." : "Account history needs at least two observations for a chart."}${note ? ` ${note}` : ""}`}</Notice>
+      </Box>
+    );
+  }
+
+  return manual ? (
+    <Box paddingX={1} flexDirection="column" flexShrink={0}>
+      <Notice tone="muted">Manual portfolios have no cash-flow performance history. P&L covers current holdings. Reconcile corporate actions with PF → Set position; distributions are not credited.</Notice>
+    </Box>
+  ) : null;
 }
 
 export function SectorAllocationTable({
@@ -162,11 +179,11 @@ export function SectorAllocationTable({
           case "weight":
             return { text: formatWeight(row.weight) };
           case "value":
-            return { text: formatCompact(row.value) };
+            return { text: row.value == null ? "—" : formatCompact(row.value) };
           case "pnl":
             return {
               text: formatSignedCompact(row.pnl),
-              color: priceColor(row.pnl),
+              color: row.pnl == null ? colors.textMuted : priceColor(row.pnl),
             };
           case "return":
             return {

--- a/src/plugins/builtin/portfolio-list/cli/render.test.ts
+++ b/src/plugins/builtin/portfolio-list/cli/render.test.ts
@@ -1,4 +1,6 @@
 import { expect, spyOn, test } from "bun:test";
+import { serializeCliResult, type CliResult } from "../../../../cli/result";
+import { DEFAULT_CLI_OPTIONS } from "../../../../cli/options";
 import { createDefaultConfig } from "../../../../types/config";
 import type { CliCommandContext } from "../../../../types/plugin";
 import type { TickerRecord } from "../../../../types/ticker";
@@ -35,4 +37,30 @@ test("ticker and collection CLI reconcile short P&L and withhold totals for a mi
   expect(result).toMatch(/Total P&L[^\n]*—/);
   expect(result).toContain("P&L unavailable for MISSING");
   expect(result).toContain("+$100");
+});
+
+test("portfolio JSON and CSV exports preserve signed positions, currencies and unknown totals", async () => {
+  const config = createDefaultConfig("/unused-test-data");
+  const missing: TickerRecord = { metadata: { ...ticker.metadata, ticker: "MISSING" } };
+  let result: CliResult | undefined;
+  const output: string[] = [];
+  const logger = spyOn(console, "log").mockImplementation((...args) => { output.push(args.join(" ")); });
+  try {
+    await showCollection("main", {
+      cliOptions: { ...DEFAULT_CLI_OPTIONS, format: "json" },
+      printResult: (value: CliResult) => { result = value; },
+      initMarketData: async () => ({ config, persistence: { close() {} }, store: { loadAllTickers: async () => [ticker, missing] },
+        dataProvider: createTestDataProvider({ getQuote: async symbol => { if (symbol === "MISSING") throw new Error("No quote"); return quote; } }),
+      }),
+      fail: (message: string) => { throw new Error(message); },
+    } as unknown as CliCommandContext);
+  } finally { logger.mockRestore(); }
+  expect(output).toEqual([]);
+  const json = JSON.parse(serializeCliResult(result!, { ...DEFAULT_CLI_OPTIONS, format: "json" }));
+  expect(json.data[0]).toMatchObject({ symbol: "AAPL", shares: -10, costBasis: -1000, marketValue: -900, unrealizedPnl: 100, positionCurrency: "USD", baseCurrency: "USD" });
+  expect(json.data[1]).toMatchObject({ symbol: "MISSING", marketValue: null, unrealizedPnl: null });
+  expect(json.metadata).toMatchObject({ totalUnrealizedPnl: null, complete: false, unavailableSymbols: ["MISSING"] });
+  const csv = serializeCliResult(result!, { ...DEFAULT_CLI_OPTIONS, format: "csv" });
+  expect(csv).toContain("unrealizedPnl,baseCurrency");
+  expect(csv).toContain("-1000,-900,100,USD");
 });

--- a/src/plugins/builtin/portfolio-list/cli/render.ts
+++ b/src/plugins/builtin/portfolio-list/cli/render.ts
@@ -96,11 +96,12 @@ async function showCollectionWithMarketData(
   const id = matchedPortfolio?.id ?? matchedWatchlist!.id;
   const displayName = matchedPortfolio?.name ?? matchedWatchlist!.name;
   const currency = matchedPortfolio?.currency ?? baseCurrency;
+  const structured = isPortfolio && ctx.cliOptions?.format != null && ctx.cliOptions.format !== "text";
   const filtered = tickers.filter((ticker) =>
     isPortfolio ? ticker.metadata.portfolios.includes(id) : ticker.metadata.watchlists.includes(id)
   );
 
-  if (filtered.length === 0) {
+  if (filtered.length === 0 && !structured) {
     console.log(cliStyles.bold(displayName));
     console.log(cliStyles.muted("No tickers in this collection."));
     return;
@@ -118,14 +119,18 @@ async function showCollectionWithMarketData(
     }),
   );
 
-  console.log(cliStyles.bold(displayName + (isPortfolio ? ` (${currency})` : "")));
-  console.log(cliStyles.muted(`${filtered.length} ticker${filtered.length === 1 ? "" : "s"}`));
-  console.log("");
+  if (!structured) {
+    console.log(cliStyles.bold(displayName + (isPortfolio ? ` (${currency})` : "")));
+    console.log(cliStyles.muted(`${filtered.length} ticker${filtered.length === 1 ? "" : "s"}`));
+    console.log("");
+  }
 
   if (isPortfolio) {
     let totalPnl = 0;
     const unavailablePnl = new Set<string>();
     const rows: string[][] = [];
+    const positionsExport: Record<string, unknown>[] = [];
+    const known = (value: number | null | undefined): number | null => value != null && Number.isFinite(value) ? value : null;
 
     for (const ticker of filtered) {
       const quote = quotes.get(ticker.metadata.ticker);
@@ -138,6 +143,9 @@ async function showCollectionWithMarketData(
 
       if (positions.length === 0) {
         rows.push([ticker.metadata.ticker, priceText, changeText, "—", "—", "—"]);
+        positionsExport.push({ symbol: ticker.metadata.ticker, exchange: ticker.metadata.exchange, shares: null, avgCost: null,
+          positionCurrency: null, quotePrice: known(activeQuote?.price), quoteCurrency: quote?.currency ?? null,
+          costBasis: null, marketValue: null, unrealizedPnl: null, baseCurrency });
         continue;
       }
 
@@ -156,6 +164,12 @@ async function showCollectionWithMarketData(
           : brokerPnl != null ? await toBase(brokerPnl, positionCurrency) : null;
         if (pnl != null && Number.isFinite(pnl)) totalPnl += pnl;
         else unavailablePnl.add(ticker.metadata.ticker);
+        const direction = metrics.totalPriceUnits < 0 ? -1 : 1;
+        positionsExport.push({ symbol: ticker.metadata.ticker, exchange: ticker.metadata.exchange,
+          shares: metrics.totalShares, avgCost: position.avgCost, positionCurrency,
+          quotePrice: known(activeQuote?.price), quoteCurrency, quoteAsOf: quote?.lastUpdated ?? null,
+          costBasis: known(direction * costBasisBase), marketValue: currentValueBase == null ? null : known(direction * currentValueBase),
+          unrealizedPnl: known(pnl), baseCurrency, dateAcquired: position.dateAcquired ?? null });
 
         rows.push([
           ticker.metadata.ticker,
@@ -166,6 +180,20 @@ async function showCollectionWithMarketData(
           pnl == null || !Number.isFinite(pnl) ? "—" : colorBySign(formatSignedCurrency(pnl, baseCurrency), pnl),
         ]);
       }
+    }
+
+    const accountingBasis = "Unrealized P&L on current positions; excludes realized trades, distributions and cash flows. This is not account investment return.";
+    const manualAccounting = !matchedPortfolio?.brokerId && !matchedPortfolio?.brokerInstanceId
+      ? "Manual holdings are snapshots. Reconcile shares and per-share cost after corporate actions using portfolio position set; cash distributions are not credited."
+      : null;
+    if (structured) {
+      ctx.printResult({ data: positionsExport, metadata: {
+        portfolioId: id, portfolioName: displayName, baseCurrency,
+        totalUnrealizedPnl: unavailablePnl.size > 0 ? null : totalPnl,
+        complete: unavailablePnl.size === 0, unavailableSymbols: [...unavailablePnl],
+        accountingBasis, ...(manualAccounting ? { manualAccounting } : {}),
+      } });
+      return;
     }
 
     console.log(renderTable(
@@ -181,6 +209,8 @@ async function showCollectionWithMarketData(
     ));
     console.log("");
     console.log(renderStat("Total P&L", unavailablePnl.size > 0 ? "—" : colorBySign(formatSignedCurrency(totalPnl, baseCurrency), totalPnl)));
+    console.log(cliStyles.muted(accountingBasis));
+    if (manualAccounting) console.log(cliStyles.muted(manualAccounting));
     if (unavailablePnl.size > 0) console.log(cliStyles.muted(`P&L unavailable for ${[...unavailablePnl].join(", ")}: a quote, broker value or currency conversion is missing.`));
   } else {
     const rows: string[][] = [];

--- a/src/plugins/builtin/portfolio-list/command-bar.ts
+++ b/src/plugins/builtin/portfolio-list/command-bar.ts
@@ -53,6 +53,7 @@ function buildManualPortfolioPositionWorkflow(
     {
       id: "shares",
       label: "Shares",
+      description: "Current quantity after any corporate actions; existing holdings are not adjusted automatically.",
       type: "number",
       placeholder: "10",
       required: !options.positionOptional,
@@ -60,6 +61,7 @@ function buildManualPortfolioPositionWorkflow(
     {
       id: "avgCost",
       label: "Avg Cost",
+      description: "Current per-share cost basis after adjustments. Cash distributions are not tracked.",
       type: "number",
       placeholder: "180",
       required: !options.positionOptional,

--- a/src/plugins/builtin/portfolio-list/command-bar.ts
+++ b/src/plugins/builtin/portfolio-list/command-bar.ts
@@ -53,7 +53,7 @@ function buildManualPortfolioPositionWorkflow(
     {
       id: "shares",
       label: "Shares",
-      description: "Current quantity after any corporate actions; existing holdings are not adjusted automatically.",
+      description: "No automatic adjustments. Enter current quantity.",
       type: "number",
       placeholder: "10",
       required: !options.positionOptional,
@@ -61,7 +61,7 @@ function buildManualPortfolioPositionWorkflow(
     {
       id: "avgCost",
       label: "Avg Cost",
-      description: "Current per-share cost basis after adjustments. Cash distributions are not tracked.",
+      description: "Distributions are not tracked. Enter adjusted cost per share.",
       type: "number",
       placeholder: "180",
       required: !options.positionOptional,

--- a/src/plugins/builtin/portfolio-list/mutations.test.ts
+++ b/src/plugins/builtin/portfolio-list/mutations.test.ts
@@ -176,6 +176,19 @@ describe("portfolio-list mutations", () => {
     }]);
   });
 
+  test("split reconciliation preserves a single acquisition date without retaining stale valuation", () => {
+    const position = { portfolio: "main", shares: 10, avgCost: 500, currency: "USD", broker: "manual", dateAcquired: "2024-01-02", marketValue: 10000, markPrice: 1000 };
+    const ticker = makeTicker({ portfolios: ["main"], positions: [position] });
+    const input = { shares: 100, avgCost: 50, currency: "USD" };
+    const reconciled = setManualPortfolioPosition(ticker, "main", input).ticker.metadata.positions[0]!;
+    expect(reconciled.dateAcquired).toBe("2024-01-02");
+    expect(reconciled.shares * reconciled.avgCost).toBe(position.shares * position.avgCost);
+    expect(reconciled.marketValue).toBeUndefined();
+    expect(reconciled.markPrice).toBeUndefined();
+    ticker.metadata.positions.push({ ...position, dateAcquired: "2024-03-01" });
+    expect(setManualPortfolioPosition(ticker, "main", input).ticker.metadata.positions[0]!.dateAcquired).toBeUndefined();
+  });
+
   test("resolves position currency from explicit, ticker, portfolio, or base currency defaults", () => {
     const portfolio = { id: "research", name: "Research", currency: "EUR" };
 

--- a/src/plugins/builtin/portfolio-list/mutations.ts
+++ b/src/plugins/builtin/portfolio-list/mutations.ts
@@ -180,7 +180,12 @@ export function setManualPortfolioPosition(
     throw new Error("Position currency is required.");
   }
 
-  const replacedPositionCount = ticker.metadata.positions.filter((position) => position.portfolio === portfolioId).length;
+  const replacedPositions = ticker.metadata.positions.filter((position) => position.portfolio === portfolioId);
+  const replacedPositionCount = replacedPositions.length;
+  // Editing a single snapshot (for example after a split) does not change its
+  // acquisition date. A consolidated replacement of several lots has no one date.
+  const dateAcquired = replacedPositions.length === 1 && replacedPositions[0]?.broker === "manual"
+    ? replacedPositions[0].dateAcquired : undefined;
   const nextPositions = ticker.metadata.positions.filter((position) => position.portfolio !== portfolioId);
   const addedMembership = !ticker.metadata.portfolios.includes(portfolioId);
 
@@ -190,6 +195,7 @@ export function setManualPortfolioPosition(
     avgCost: input.avgCost,
     currency: nextCurrency,
     broker: "manual",
+    ...(dateAcquired ? { dateAcquired } : {}),
   });
 
   return {


### PR DESCRIPTION
A missing foreign-exchange valuation could disappear from portfolio sector allocation and leave the remaining holdings labelled 100%. Broker history also substituted a return fraction for missing account value, plotting `[10000, 0.1, 21000]` on a USD axis, and briefly retained the prior account's history when switching accounts.

This change preserves incomplete sector groups and withholds allocation weights until every held value is available. Explicitly identified funds are grouped separately with an ETF look-through limitation. Account history uses one metric throughout, sorts and deduplicates observations, identifies omitted observations and cash-flow limitations, and belongs to the requested account. Wrapped notices leave room for holdings at narrow terminal sizes.

Manual position edits preserve an existing acquisition date when updating one position; consolidated lots do not acquire an invented aggregate date. The manual workflow explains that corporate actions and distributions are not automatically booked. `portfolio show --json`, `--csv` and `--ndjson` now return raw signed position values, currencies, quote timestamps and null unavailable values instead of printing a text table.

Validation:
- 99 analytics/portfolio tests, 351 assertions; all six runtime typechecks and plugin-manifest check pass.
- Actual isolated OpenTUI app at 140×44 and 80×30: missing EUR/USD, stock plus ETF, missing NAV, portfolio switching and manual NVDA split reconciliation.
- Actual isolated CLI JSON/CSV exports: missing-FX totals remain null; split shares10→100 and cost500→50 preserve basis5000 and acquisition date2024-01-02.
- Synthetic broker data exercises the app boundary; no authenticated broker/account writes. Automatic corporate-action accounting, ETF constituents/overlap and manual cash-flow-adjusted performance remain unsupported and explicitly disclosed.
