### PR TITLE
Preserve chart windows, dates and missing observations when sharing

### DIFF
--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -1423,6 +1423,27 @@ describe("CompositeChart", () => {
     expect(frame).toContain("────────");
   });
 
+  test("keeps the requested window while older cached observations partially overlap it", async () => {
+    testSetup = await testRender(
+      <CompositeChart
+        width={90}
+        height={14}
+        series={[{
+          ...series("price", "main", "left", "USD", []),
+          points: [point("2026-07-31", 100), point("2026-08-15", 110), point("2026-08-31", 105)],
+        }]}
+        panels={[{ id: "main" }]}
+        viewport={{ start: new Date("2026-08-10"), end: new Date("2026-09-10") }}
+      />,
+      { width: 92, height: 16 },
+    );
+    await act(async () => testSetup!.renderOnce());
+    const frame = testSetup.captureCharFrame();
+    expect(frame).toContain("Aug 10");
+    expect(frame).toContain("Sep 10");
+    expect(frame).not.toContain("Jul 31");
+  });
+
   test("zooms around the mouse pointer with control-wheel", async () => {
     testSetup = await testRender(
       <CaptureChartSurfaceProvider>

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -54,7 +54,6 @@ import {
   COMPOSITE_KEYBOARD_PAN_RATIO,
   COMPOSITE_ZOOM_STEP_FACTOR,
   buildCompositeNavigationFrame,
-  clampCompositeViewport,
   compositeNavigationDataViewport,
   compositeViewportPositions,
   fitCompositeViewport,
@@ -1709,10 +1708,12 @@ export function CompositeChart({
     [allowHistoricalBackfill, marketTimelineSeries, visibleSeries],
   );
   const authoredViewport = useMemo(() => {
-    if (!navigationFrame) return viewport ?? null;
-    return viewport
-      ? clampCompositeViewport(navigationFrame, viewport)
-      : compositeNavigationDataViewport(navigationFrame);
+    // The requested dates own the axis, including gaps in a cached or partial
+    // response. Fitting them to available observations silently changes the
+    // research period. User pan/zoom gestures retain their navigation limits.
+    if (viewport && Number.isFinite(viewport.start.getTime())
+      && Number.isFinite(viewport.end.getTime()) && viewport.start <= viewport.end) return viewport;
+    return navigationFrame ? compositeNavigationDataViewport(navigationFrame) : null;
   }, [navigationFrame, viewport]);
   const activeUserViewport = authoredViewportChanged ? null : userViewport;
   const effectiveViewport = activeUserViewport ?? authoredViewport;

--- a/src/components/chart/composite/scene.test.ts
+++ b/src/components/chart/composite/scene.test.ts
@@ -624,3 +624,31 @@ describe("composite chart scene", () => {
     expect(applyCompositeChartCursor(withCursor, new Date("2025-01-01T00:00:00.000Z"))).toBe(withCursor);
   });
 });
+
+test("a missing step observation before the viewport prevents carrying an older known level into it", () => {
+  const step = series({ id: "step", style: "step", interpolation: "step-after", points: [
+    point("2026-07-26", 4), { ...point("2026-08-01", 0), value: null }, point("2026-08-20", 5),
+  ] });
+  const scene = buildCompositeChartScene([step], [{ id: "main" }], {
+    width: 100, height: 20, viewport: { start: new Date("2026-08-10"), end: new Date("2026-09-10") },
+  });
+  const values = scene?.panels[0]?.series[0]?.points ?? [];
+  expect(values.length).toBeGreaterThan(0);
+  expect(values.every((point) => point.value === 5)).toBe(true);
+  expect(values[0]!.timestamp).toBe(new Date("2026-08-20").getTime());
+});
+
+test("opening step observations replace the older anchor before scaling and carrying levels", () => {
+  for (const value of [4, null]) {
+    const step = series({ id: "step", style: "step", interpolation: "step-after", points: [
+      point("2026-07-26", 999), { ...point("2026-08-10", 0), value }, point("2026-08-20", 5),
+    ] });
+    const scene = buildCompositeChartScene([step], [{ id: "main" }], {
+      width: 100, height: 20, viewport: { start: new Date("2026-08-10"), end: new Date("2026-09-10") },
+    });
+    const points = scene?.panels[0]?.series[0]?.points ?? [];
+    expect(points.length).toBeGreaterThan(0);
+    expect(points.every((point) => point.value !== 999)).toBe(true);
+    expect(points[0]!.timestamp).toBe(new Date(value === null ? "2026-08-20" : "2026-08-10").getTime());
+  }
+});

--- a/src/components/chart/composite/scene.ts
+++ b/src/components/chart/composite/scene.ts
@@ -165,7 +165,8 @@ function scopeSeriesToViewport(
     return !!projected && projected.ratio >= 0 && projected.ratio <= 1;
   });
   if (series.interpolation === "step-after" || series.style === "step") {
-    const anchor = [...points].reverse().find(({ timestamp, value }) => timestamp < startTime && value !== null);
+    const anchor = points.some(({ timestamp }) => timestamp === startTime) ? undefined
+      : [...points].reverse().find(({ timestamp }) => timestamp < startTime);
     if (anchor && !visible.includes(anchor)) visible.unshift(anchor);
   }
   return visible.some(({ value }) => value !== null)

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -182,6 +182,7 @@ function ChartComposerSurface({
   const runtimeViewportTimerRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
   const adaptiveViewportRef = useRef<RuntimeChartViewport | null>(null);
   const requestViewportRef = useRef<RuntimeChartViewport | null>(null);
+  const requestViewportOwnerRef = useRef(authoredViewportKey);
   const activeRuntimeViewport = runtimeViewportState?.key === authoredViewportKey
     ? runtimeViewportState
     : null;
@@ -272,11 +273,18 @@ function ChartComposerSurface({
     ),
     [resolution.bufferedSeries, resolution.legendSeries, resolution.series, spec],
   );
-  const shareData = useMemo(() => buildChartShareData(plottedSeries), [plottedSeries]);
+  const shareWarnings = useMemo(() => [...resolution.errors, ...resolution.warnings], [resolution.errors, resolution.warnings]);
+  const shareData = useMemo(() => buildChartShareData(plottedSeries, activeRuntimeViewport?.requestViewport ?? viewport, shareWarnings),
+    [plottedSeries, activeRuntimeViewport?.requestViewport, viewport, shareWarnings]);
   const createPublicShare = usePublicShare();
   const shareChart = useCallback(() => {
-    if (shareData) void createPublicShare({ kind: "chart", data: shareData });
-  }, [createPublicShare, shareData]);
+    // Read the latest gesture immediately, even before its history request's
+    // debounce commits. Sharing should match the window visible at the click.
+    const visibleWindow = requestViewportOwnerRef.current === authoredViewportKey
+      ? requestViewportRef.current ?? viewport : viewport;
+    const data = buildChartShareData(plottedSeries, visibleWindow, shareWarnings);
+    if (data) void createPublicShare({ kind: "chart", data });
+  }, [createPublicShare, plottedSeries, viewport, shareWarnings, authoredViewportKey]);
   const [interactionCaptured, setInteractionCapturedState] = useState(false);
   // Typing in quick-add must not freeze the plot: it only takes the keyboard.
   const [modalCaptured, setModalCaptured] = useState(false);
@@ -324,6 +332,7 @@ function ChartComposerSurface({
     );
     adaptiveViewportRef.current = restored?.adaptiveViewport ?? null;
     requestViewportRef.current = restored?.requestViewport ?? null;
+    requestViewportOwnerRef.current = authoredViewportKey;
     setRuntimeViewportState((current) => current?.key === authoredViewportKey ? current : restored);
     if (persistedInteractionViewport && !restored) setStoredInteractionViewport(null);
     return () => {
@@ -353,6 +362,7 @@ function ChartComposerSurface({
     if (!Number.isFinite(start) || !Number.isFinite(end) || start > end) return;
     const viewport = { start: new Date(start), end: new Date(end) };
     requestViewportRef.current = viewport;
+    requestViewportOwnerRef.current = authoredViewportKey;
     // A pan can leave the window a provider serves at the current resolution
     // just as a zoom can, so both re-pick.
     if (spec.viewport.resolution === "auto") adaptiveViewportRef.current = viewport;

--- a/src/renderers/share/chart.test.ts
+++ b/src/renderers/share/chart.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { sharedChartGeometry } from "./chart";
+
+describe("shared chart coordinates", () => {
+  test("aligns unequal and irregular histories by their timestamps, including singleton series", () => {
+    const result = sharedChartGeometry({ title: "Common dates", series: [
+      { name: "Long", unit: "%", points: [{ x: "2026-01-01", y: 0 }, { x: "2026-01-10", y: 10 }, { x: "2026-01-11", y: 11 }] },
+      { name: "Short", unit: "%", points: [{ x: "2026-01-10", y: 5 }, { x: "2026-01-11", y: 6 }] },
+      { name: "Single", unit: "%", points: [{ x: "2026-01-10", y: 8 }] },
+    ] });
+    const [long, short, single] = result.panels[0]!.series;
+    expect(long!.segments[0]!.map((point) => point.x)).toEqual([20, 884, 980]);
+    expect(short!.segments[0]![0]!.x).toBe(884);
+    expect(single!.segments[0]![0]!.x).toBe(884);
+    expect(result.startLabel).toBe("2026-01-01");
+    expect(result.endLabel).toBe("2026-01-11");
+  });
+
+  test("keeps gaps, incompatible units and a requested date window", () => {
+    const result = sharedChartGeometry({ title: "Units", viewport: { start: "2026-01-01", end: "2026-01-11" }, series: [
+      { name: "Price", unit: "USD", points: [{ x: "2026-01-02", y: 100 }, { x: "2026-01-03", y: null }, { x: "2026-01-04", y: 110 }] },
+      { name: "Return", unit: "%", points: [{ x: "2026-01-04", y: 1 }] },
+    ] });
+    expect(result.panels.map((panel) => panel.unit)).toEqual(["USD", "%"]);
+    expect(result.panels[0]!.series[0]!.segments).toHaveLength(2);
+    expect(result.panels[0]!.min).toBe(100);
+    expect(result.panels[0]!.max).toBe(110);
+    expect(result.panels[1]!.series[0]!.segments[0]![0]!.x).toBe(308);
+  });
+
+  test("uses common numeric and categorical axes for existing share formats", () => {
+    for (const inputs of [[1, 10, 11], ["one", "ten", "eleven"]] as const) {
+      const result = sharedChartGeometry({ title: "Legacy", series: [
+        { name: "A", points: inputs.map((x, y) => ({ x, y })) },
+        { name: "B", points: [{ x: inputs[1], y: 1 }] },
+      ] });
+      expect(result.panels[0]!.series[1]!.segments[0]![0]!.x).toBe(result.panels[0]!.series[0]!.segments[0]![1]!.x);
+      expect(result.panels[0]!.unit).toBe("Unit unavailable");
+    }
+  });
+});
+
+test("shared steps retain level changes and empty panels have no numerical evidence", async () => {
+  const { sharedChartLinePoints } = await import("./chart");
+  const result = sharedChartGeometry({ title: "Known and unknown", series: [
+    { name: "Rate", unit: "%", style: "step", points: [{ x: 1, y: 2 }, { x: 2, y: 3 }] },
+    { name: "Unavailable price", unit: "USD", points: [{ x: 1, y: null }] },
+  ] });
+  expect(result.panels[0]!.hasValues).toBe(true);
+  expect(sharedChartLinePoints(result.panels[0]!.series[0]!.segments[0]!, "step")).toBe("20,300 980,300 980,20");
+  expect(result.panels[1]!.hasValues).toBe(false);
+});

--- a/src/renderers/share/chart.ts
+++ b/src/renderers/share/chart.ts
@@ -1,0 +1,74 @@
+import type { ChartShareData } from "../../shares/payload";
+
+export interface SharedChartMark { x: number; y: number; label: string }
+export interface SharedChartPanel {
+  unit: string;
+  hasValues: boolean;
+  min: number;
+  max: number;
+  series: Array<{ name: string; index: number; style: "line" | "step" | "points"; segments: SharedChartMark[][] }>;
+}
+
+/** Shared coordinates are data coordinates, never independent row indices. */
+export function sharedChartGeometry(data: ChartShareData) {
+  const labels = data.series.flatMap((entry) => entry.points.map((point) => point.x));
+  const dates = labels.every((value) => typeof value === "string" && /^\d{4}-\d{2}-\d{2}(?:T.*)?$/.test(value)
+    && Number.isFinite(Date.parse(value)));
+  const numeric = labels.every((value) => typeof value === "number");
+  const categories = [...new Set(labels.map((value) => `${typeof value}:${value}`))];
+  const position = (value: string | number) => dates ? Date.parse(String(value)) : numeric ? Number(value)
+    : categories.indexOf(`${typeof value}:${value}`);
+  const positions = labels.map(position);
+  let start = Math.min(...positions);
+  let end = Math.max(...positions);
+  if (dates && data.viewport) { start = Date.parse(data.viewport.start); end = Date.parse(data.viewport.end); }
+  const x = (value: string | number) => start === end ? 500 : 20 + (position(value) - start) / (end - start) * 960;
+  const groups = new Map<string, Array<{ entry: ChartShareData["series"][number]; index: number }>>();
+  data.series.forEach((entry, index) => {
+    const unit = entry.unit || "Unit unavailable";
+    groups.set(unit, [...(groups.get(unit) ?? []), { entry, index }]);
+  });
+  const scopedPoints = (entry: ChartShareData["series"][number]) => {
+    const ordered = [...entry.points].sort((a, b) => position(a.x) - position(b.x));
+    const anchor = entry.style === "step" && !ordered.some((point) => position(point.x) === start)
+      ? ordered.findLast((point) => position(point.x) < start) : undefined;
+    return ordered.filter((point) => point === anchor || (position(point.x) >= start && position(point.x) <= end));
+  };
+  const panels: SharedChartPanel[] = [...groups].map(([unit, entries]) => {
+    const values = entries.flatMap(({ entry }) => scopedPoints(entry)
+      .flatMap((point) => point.y === null ? [] : [point.y]));
+    let min = values.length ? Math.min(...values) : 0;
+    let max = values.length ? Math.max(...values) : 1;
+    if (min === max) { const pad = Math.abs(min) * 0.05 || 1; min -= pad; max += pad; }
+    return { unit, hasValues: values.length > 0, min, max, series: entries.map(({ entry, index }) => {
+      const segments: SharedChartMark[][] = [];
+      let current: SharedChartMark[] = [];
+      for (const point of scopedPoints(entry)) {
+        if (point.y === null) {
+          if (current.length) segments.push(current);
+          current = [];
+          continue;
+        }
+        current.push({ x: Math.max(20, x(point.x)), y: 300 - (point.y - min) / (max - min) * 280,
+          label: `${point.x}: ${point.y} ${entry.unit ?? "(unit unavailable)"}` });
+      }
+      if (entry.style === "step" && current.length && current.at(-1)!.x < 980 && end > start) {
+        const last = current.at(-1)!;
+        current.push({ ...last, x: 980, label: `Held level from ${last.label}` });
+      }
+      if (current.length) segments.push(current);
+      return { name: entry.name, index, style: entry.style ?? "line", segments };
+    }) };
+  });
+  const dateLabel = (time: number) => new Date(time).toISOString().replace("T", " ").slice(0, end - start <= 2 * 86400000 ? 16 : 10);
+  return { panels, startLabel: dates ? dateLabel(start) : String(numeric ? start : labels.find((value) => position(value) === start)),
+    endLabel: dates ? dateLabel(end) : String(numeric ? end : labels.find((value) => position(value) === end)),
+    axisLabel: dates ? "Time (UTC)" : numeric ? "X value" : "Category" };
+}
+
+/** Expand step-after observations without inventing intermediate values. */
+export function sharedChartLinePoints(segment: SharedChartMark[], style: "line" | "step" | "points"): string {
+  return segment.flatMap((point, index) => style === "step" && index > 0
+    ? [`${point.x},${segment[index - 1]!.y}`, `${point.x},${point.y}`]
+    : [`${point.x},${point.y}`]).join(" ");
+}

--- a/src/renderers/share/styles.css
+++ b/src/renderers/share/styles.css
@@ -52,3 +52,32 @@ main.pane h1 { margin-bottom: 14px; overflow-wrap: anywhere; }
   .layout-pane { padding: 7px; font-size: 12px; }
   .layout-extra-panes { right: 10px; bottom: 10px; width: 52%; }
 }
+.snapshot-date, .chart-notes { color: #b8bbc5; font-size: 12px; }
+.chart-panel { margin: 28px 0; }
+.chart-dates { display: flex; justify-content: space-between; gap: 12px; font-size: 12px; }
+.chart-unit { display: block; margin-bottom: 8px; font-size: 12px; }
+.chart-plot { display: flex; height: 300px; }
+.chart-plot .chart { flex: 1; min-width: 0; height: 100%; }
+.chart-y-axis { display: flex; flex-direction: column; justify-content: space-between; padding: 18px 8px 18px 0; width: 76px; flex-shrink: 0; text-align: right; font-size: 12px; line-height: 1; }
+.chart-dates { margin-top: 8px; margin-left: 84px; }
+.chart-grid { stroke: #4a4e5c; stroke-width: 0.5; vector-effect: non-scaling-stroke; }
+.series-point { fill: #f1b94a; stroke-width: 4; vector-effect: non-scaling-stroke; }
+.series-point.series-0 { stroke: #f1b94a; }
+.series-point.series-1 { fill: #62b8f6; } .series-point.series-2 { fill: #7fd18a; } .series-point.series-3 { fill: #ef7f7f; } .series-point.series-4 { fill: #b697ef; } .series-point.series-5 { fill: #e29b63; }
+.series-key { display: inline-block; width: 14px; margin-right: 6px; border-top: 2px solid #f1b94a; vertical-align: middle; }
+.series-key.series-1 { border-color: #62b8f6; } .series-key.series-2 { border-color: #7fd18a; } .series-key.series-3 { border-color: #ef7f7f; } .series-key.series-4 { border-color: #b697ef; } .series-key.series-5 { border-color: #e29b63; }
+.shared-data summary { cursor: pointer; padding: 10px 0; }
+.shared-data caption { text-align: left; padding: 10px; }
+.shared-data .table-wrap { max-height: 360px; margin-top: 12px; }
+@media (max-width: 640px) {
+  .chart-dates { flex-wrap: wrap; }
+  .chart-dates span:nth-child(2) { order: 3; flex-basis: 100%; text-align: center; }
+  .chart-plot { height: 200px; }
+  .chart-y-axis { width: 64px; padding-top: 12px; padding-bottom: 12px; }
+  .chart-dates { margin-left: 72px; }
+  .legend { font-size: 12px; }
+}
+
+main.wide h1, .legend li, .chart-notes li, .shared-data caption { overflow-wrap: anywhere; }
+.chart-unavailable { color: #b8bbc5; border: 1px solid #4a4e5c; padding: 20px; }
+.chart-y-axis { font-variant-numeric: tabular-nums; }

--- a/src/renderers/share/view.test.tsx
+++ b/src/renderers/share/view.test.tsx
@@ -98,3 +98,23 @@ test("pane share renders the handoff copy, tracked CTA and printable facts only"
   expect(html).not.toContain("<script>");
   expect(html).toContain("Delete share");
 });
+
+test("chart snapshot retains exact values, gaps and units without a fabricated empty-panel scale", () => {
+  const html = renderToStaticMarkup(<ShareView share={{
+    kind: "chart",
+    data: { title: "Research snapshot", series: [
+      { name: "Price", unit: "USD", points: [{ x: "2026-01-01", y: 123.456789 }, { x: "2026-01-02", y: null }, { x: "2026-01-03", y: 124 }] },
+      { name: "Missing yield", unit: "%", points: [{ x: "2026-01-01", y: null }] },
+    ], warnings: ["Partial history"] },
+    createdAt: "2026-09-10T12:00:00Z", expiresAt: "2026-10-10T12:00:00Z", ownedByViewer: false,
+  }} />);
+  expect(html).toContain("123.456789");
+  expect(html).toContain("Unavailable");
+  expect(html).toContain("Partial history");
+  expect(html).toContain("Snapshot shared 2026-09-10 12:00 UTC");
+  expect(html.match(/<circle/g)).toHaveLength(2);
+  expect(html).not.toContain("<polyline");
+  const emptyPanel = html.slice(html.indexOf('aria-label="% chart"'), html.indexOf('class="chart-notes"'));
+  expect(emptyPanel).toContain("No observations available");
+  expect(emptyPanel).not.toContain("chart-y-axis");
+});

--- a/src/renderers/share/view.tsx
+++ b/src/renderers/share/view.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource react */
 import type { ShareRecord } from "../../shares/api";
+import { sharedChartGeometry, sharedChartLinePoints } from "./chart";
 
 const FACT_LIMIT = 8;
 const FACT_MAX_LENGTH = 120;
@@ -125,24 +126,32 @@ export function ShareView({
       </main>
     );
   }
-  const values = share.data.series.flatMap((series) => series.points.map((point) => point.y));
-  const min = Math.min(...values);
-  const max = Math.max(...values);
-  const span = max - min || 1;
+  const chart = sharedChartGeometry(share.data);
+  const format = (value: number) => value.toLocaleString("en-US", { maximumSignificantDigits: 6 });
   return (
     <main className="wide">
       <h1>{share.data.title}</h1>
-      <svg className="chart" viewBox="0 0 1000 420" role="img" aria-label={share.data.title}>
-        {share.data.series.map((series, seriesIndex) => {
-          const points = series.points.map((point, index) => {
-            const x = series.points.length <= 1 ? 500 : 20 + (index / (series.points.length - 1)) * 960;
-            const y = 400 - ((point.y - min) / span) * 380;
-            return `${x},${y}`;
-          }).join(" ");
-          return <polyline key={series.name} points={points} className={`series series-${seriesIndex % 6}`} />;
-        })}
-      </svg>
-      <ul className="legend">{share.data.series.map((series) => <li key={series.name}>{series.name}</li>)}</ul>
+      <p className="snapshot-date">Snapshot shared {new Date(share.createdAt).toISOString().replace("T", " ").slice(0, 16)} UTC. Observation dates appear below.</p>
+      {chart.panels.map((panel) => <section className="chart-panel" key={panel.unit} aria-label={`${panel.unit} chart`}>
+        <strong className="chart-unit">{panel.unit}</strong>
+        {panel.hasValues ? <><div className="chart-plot"><div className="chart-y-axis"><span>{format(panel.max)}</span><span>{format((panel.max + panel.min) / 2)}</span><span>{format(panel.min)}</span></div>
+        <svg className="chart" viewBox="0 0 1000 320" preserveAspectRatio="none" role="img" aria-label={`${share.data.title} — ${panel.unit}`}>
+          <line x1="20" x2="980" y1="160" y2="160" className="chart-grid" />
+          {panel.series.flatMap((series) => series.segments.map((segment, segmentIndex) => segment.length === 1 || series.style === "points"
+            ? segment.map((point, pointIndex) => <circle key={`${series.index}:${segmentIndex}:${pointIndex}`} cx={point.x} cy={point.y} r="1" className={`series-point series-${series.index % 6}`}><title>{`${series.name}: ${point.label}`}</title></circle>)
+            : <polyline key={`${series.index}:${segmentIndex}`} points={sharedChartLinePoints(segment, series.style)} className={`series series-${series.index % 6}`}><title>{series.name}</title></polyline>))}
+        </svg></div>
+        <div className="chart-dates"><span>{chart.startLabel}</span><span>{chart.axisLabel}</span><span>{chart.endLabel}</span></div></> : <p className="chart-unavailable">No observations available in this window.</p>}
+        <ul className="legend">{panel.series.map((series) => <li key={series.index}><span className={`series-key series-${series.index % 6}`} />{series.name}</li>)}</ul>
+      </section>)}
+      {share.data.warnings?.length ? <ul className="chart-notes">{share.data.warnings.map((warning, index) => <li key={index}>{warning}</li>)}</ul> : null}
+      <details className="shared-data"><summary>View snapshot data</summary>
+        {share.data.series.map((series, index) => <div className="table-wrap" key={index}><table>
+          <caption>{series.name} · {series.unit ?? "Unit unavailable"}</caption>
+          <thead><tr><th>{chart.axisLabel}</th><th>Value</th></tr></thead>
+          <tbody>{series.points.map((point, pointIndex) => <tr key={pointIndex}><td>{point.x}</td><td>{point.y === null ? "Unavailable" : String(point.y)}</td></tr>)}</tbody>
+        </table></div>)}
+      </details>
       <SourceLink url={share.data.sourceUrl} />
       {ownerActions}
     </main>

--- a/src/shares/api.test.ts
+++ b/src/shares/api.test.ts
@@ -24,6 +24,21 @@ const portablePane = {
 const shareId = "0123456789abcdef0123456789abcdef";
 
 describe("share API client", () => {
+  test("chart viewport dates require real calendar dates and explicit timestamp zones", () => {
+    const payload = (start: string, end = start) => ({ kind: "chart", data: {
+      title: "Window", viewport: { start, end }, series: [{ name: "A", points: [{ x: start, y: 1 }] }],
+    } });
+    for (const date of ["2024-02-29", "2000-02-29", "2026-09-10T12:30Z", "2026-09-10T12:30:45.123+02:00"]) {
+      expect(parseSharePayload(payload(date))).not.toBeNull();
+    }
+    for (const date of ["2026-02-30", "2026-02-29", "1900-02-29", "2026-04-31", "2026-00-01", "2026-01-00",
+      "09/10/2026", "2026-9-1", "2026-09-10T12:30:00", "2026-02-30T12:00:00Z", "2026-09-10T24:00:00Z",
+      "2026-09-10T12:60:00Z", "2026-09-10T12:30:60Z", "2026-09-10T12:30:00+24:00", "2026-09-10T12:30:00+02:60"]) {
+      expect(parseSharePayload(payload(date))).toBeNull();
+    }
+    expect(parseSharePayload(payload("2026-09-10T03:00:00+02:00", "2026-09-10T00:30:00Z"))).toBeNull();
+  });
+
   test("validates strict payloads and http(s)-only source URLs", () => {
     expect(parseSharePayload(article)).toEqual(article);
     expect(parseSharePayload({ ...article, data: { ...article.data, sourceUrl: "javascript:alert(1)" } })).toBeNull();

--- a/src/shares/chart-snapshot.test.ts
+++ b/src/shares/chart-snapshot.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { ResolvedSeries } from "../time-series/types";
 import { buildChartShareData } from "./chart-snapshot";
+import { parseSharePayload } from "./payload";
 
 function series(pointCount: number): ResolvedSeries {
   return {
@@ -31,4 +32,105 @@ describe("chart share snapshots", () => {
     expect(shared?.series[0]?.points[0]?.y).toBe(0);
     expect(shared?.series[0]?.points.at(-1)?.y).toBe(999);
   });
+  test("exports the visible window with its units, gaps and source warnings", () => {
+    const input = series(5);
+    input.points[2]!.value = null;
+    input.warning = "Delayed observations";
+    const shared = buildChartShareData([input], { start: input.points[1]!.date, end: input.points[3]!.date });
+    expect(shared?.series[0]?.points.map((point) => point.y)).toEqual([1, null, 3]);
+    expect(shared?.series[0]?.unit).toBe("USD");
+    expect(shared?.viewport).toEqual({ start: "2025-01-02T00:00:00.000Z", end: "2025-01-04T00:00:00.000Z" });
+    expect(shared?.warnings).toContain("AAPL: Delayed observations");
+    expect(parseSharePayload({ kind: "chart", data: shared })).not.toBeNull();
+  });
+  test("preserves finite-bucket extremes and missing intervals while bounding a large comparison", () => {
+    const input = series(2_000);
+    input.points[501]!.value = 50_000;
+    input.points[700]!.value = null;
+    const sampled = buildChartShareData([input]);
+    expect(sampled?.series[0]?.points.some((point) => point.y === 50_000)).toBe(true);
+    expect(sampled?.series[0]?.points.some((point) => point.y === null)).toBe(true);
+    const large = buildChartShareData(Array.from({ length: 20 }, (_, index) => ({ ...input, label: `${index} ${"長".repeat(110)}` })));
+    expect(large?.series.flatMap((entry) => entry.points).length).toBeLessThanOrEqual(1_000);
+    expect(new TextEncoder().encode(JSON.stringify(large)).length).toBeLessThan(128 * 1024);
+    expect(parseSharePayload({ kind: "chart", data: large })).not.toBeNull();
+  });
 })
+
+test("dense missing observations keep bounded finite evidence without bridging any original gap", () => {
+  const input = series(5_000);
+  input.points.forEach((point, index) => { if (index % 10 === 0 || index === 4_999) point.value = null; });
+  input.points[501]!.value = 50_000;
+  const shared = buildChartShareData([input]);
+  expect(shared).not.toBeNull();
+  const points = shared!.series[0]!.points;
+  expect(points.length).toBeLessThanOrEqual(500);
+  expect(points[0]!.y).toBeNull();
+  expect(points.at(-1)!.y).toBeNull();
+  expect(points.some((point) => point.y === 50_000)).toBe(true);
+  expect(points.some((point) => point.y === 1)).toBe(true);
+  expect(points.some((point) => point.y === 4_998)).toBe(true);
+  const sourceIndex = new Map(input.points.map((point, index) => [point.date.toISOString(), index]));
+  for (let index = 1; index < points.length; index++) {
+    if (points[index - 1]!.y === null || points[index]!.y === null) continue;
+    const start = sourceIndex.get(String(points[index - 1]!.x))!;
+    const end = sourceIndex.get(String(points[index]!.x))!;
+    expect(input.points.slice(start + 1, end).every((point) => point.value !== null)).toBe(true);
+  }
+  const large = buildChartShareData(Array.from({ length: 20 }, (_, index) => ({ ...input, label: `Series ${index}` })));
+  expect(large!.series.every((entry) => entry.points.some((point) => point.y !== null))).toBe(true);
+  expect(large!.series.flatMap((entry) => entry.points).length).toBeLessThanOrEqual(1_000);
+  expect(parseSharePayload({ kind: "chart", data: large })).not.toBeNull();
+});
+
+test("a step window retains the original preceding observation, and respects an intervening missing value", async () => {
+  const { sharedChartGeometry } = await import("../renderers/share/chart");
+  const input = series(0);
+  input.style = "step";
+  input.points = [{ date: new Date("2026-07-26"), value: 4 }, { date: new Date("2026-10-25"), value: 5 }];
+  const window = { start: new Date("2026-08-10"), end: new Date("2026-09-10") };
+  const shared = buildChartShareData([input], window)!;
+  expect(shared.series[0]!.points).toEqual([{ x: "2026-07-26T00:00:00.000Z", y: 4 }]);
+  const geometry = sharedChartGeometry(shared);
+  expect(geometry.startLabel).toBe("2026-08-10");
+  expect(geometry.panels[0]!.series[0]!.segments[0]!.map((point) => point.x)).toEqual([20, 980]);
+  expect(geometry.panels[0]!.series[0]!.segments[0]![0]!.label).toContain("2026-07-26");
+  input.points.splice(1, 0, { date: new Date("2026-08-01"), value: null });
+  expect(buildChartShareData([input], window)).toBeNull();
+});
+
+test("a step observation exactly at the opening supersedes the older anchor, including a null", async () => {
+  const { sharedChartGeometry } = await import("../renderers/share/chart");
+  const window = { start: new Date("2026-08-10"), end: new Date("2026-09-10") };
+  for (const value of [4, null]) {
+    const input = series(0);
+    input.style = "step";
+    input.points = [{ date: new Date("2026-07-26"), value: 999 }, { date: window.start, value }];
+    const shared = buildChartShareData([input], window);
+    if (value === null) expect(shared).toBeNull();
+    else expect(shared!.series[0]!.points.map((point) => point.y)).toEqual([4]);
+    // Existing/manual payloads can still contain the pre-window context.
+    const geometry = sharedChartGeometry({ title: "Boundary", viewport: { start: window.start.toISOString(), end: window.end.toISOString() }, series: [
+      { name: "Step", style: "step", points: input.points.map((point) => ({ x: point.date.toISOString(), y: point.value })) },
+    ] });
+    expect(geometry.panels[0]!.hasValues).toBe(value !== null);
+    expect(geometry.panels[0]!.max).toBeLessThan(999);
+  }
+});
+
+test("market comparisons cannot share fiscal values before their known availability", () => {
+  const price = series(0);
+  price.timeBasis = { kind: "market", timeZone: "America/New_York" };
+  price.points = [{ date: new Date("2026-01-02"), value: 100 }, { date: new Date("2026-01-30"), value: 110 }];
+  const fundamental = series(0);
+  fundamental.label = "Revenue";
+  fundamental.style = "step";
+  fundamental.points = [{ date: new Date("2025-12-31"), availableAt: new Date("2026-02-15"), value: 500 }];
+  const january = buildChartShareData([price, fundamental], { start: new Date("2026-01-01"), end: new Date("2026-01-31") })!;
+  expect(january.series.find((entry) => entry.name === "Revenue")!.points.every((point) => point.y === null)).toBe(true);
+  const february = buildChartShareData([price, fundamental], { start: new Date("2026-02-01"), end: new Date("2026-02-28") })!;
+  expect(february.series.find((entry) => entry.name === "Revenue")!.points).toEqual([{ x: "2026-02-15T00:00:00.000Z", y: 500 }]);
+  expect(february.warnings!.some((note) => note.includes("known availability"))).toBe(true);
+  // Pure fiscal-period charts retain their expressly chosen period axis.
+  expect(buildChartShareData([fundamental])!.series[0]!.points[0]!.x).toBe("2025-12-31T00:00:00.000Z");
+});

--- a/src/shares/chart-snapshot.ts
+++ b/src/shares/chart-snapshot.ts
@@ -1,28 +1,103 @@
 import type { ResolvedSeries } from "../time-series/types";
 import type { ChartShareData } from "./payload";
+import { effectiveTimeSeriesPointTime } from "../time-series/alignment";
 
+type SharedPoint = ChartShareData["series"][number]["points"][number];
 const MAX_POINTS = 500;
+const MAX_TOTAL_POINTS = 1_000;
 
-function sample<T>(values: T[], limit: number): T[] {
+// Sample finite extrema first, reserving enough space to restore original gaps.
+// Every omitted interval containing a null stays broken, even with dense gaps.
+function sample(values: SharedPoint[], limit: number): SharedPoint[] {
   if (values.length <= limit) return values;
-  return Array.from({ length: limit }, (_, index) => (
-    values[Math.round(index * (values.length - 1) / (limit - 1))]!
-  ));
+  const finiteIndices = values.flatMap((point, index) => point.y === null ? [] : [index]);
+  if (finiteIndices.length !== values.length) {
+    if (!finiteIndices.length) return [values[0]!, values.at(-1)!];
+    // At most N finite points, N-1 intervening gaps and two boundary gaps.
+    const finiteLimit = Math.floor((limit - 1) / 2);
+    const selected = sample(finiteIndices.map((index) => ({ x: index, y: values[index]!.y })), finiteLimit);
+    const result: SharedPoint[] = [];
+    let previous = -1;
+    for (const selectedPoint of selected) {
+      const index = Number(selectedPoint.x);
+      for (let cursor = previous + 1; cursor < index; cursor++) {
+        if (values[cursor]!.y === null) { result.push(values[cursor]!); break; }
+      }
+      result.push(values[index]!);
+      previous = index;
+    }
+    if (values.at(-1)!.y === null) result.push(values.at(-1)!);
+    return result;
+  }
+  const buckets = Math.floor((limit - 2) / 2);
+  const result = [values[0]!];
+  for (let bucket = 0; bucket < buckets; bucket++) {
+    const start = 1 + Math.floor(bucket * (values.length - 2) / buckets);
+    const end = 1 + Math.floor((bucket + 1) * (values.length - 2) / buckets);
+    const entries = values.slice(start, end);
+    let low = 0;
+    let high = 0;
+    entries.forEach((point, index) => {
+      if (point.y! < entries[low]!.y!) low = index;
+      if (point.y! > entries[high]!.y!) high = index;
+    });
+    for (const index of [...new Set([low, high])].sort((a, b) => a - b)) result.push(entries[index]!);
+  }
+  result.push(values.at(-1)!);
+  return result;
 }
 
-export function buildChartShareData(series: ResolvedSeries[]): ChartShareData | null {
-  const sharedSeries = series.flatMap((entry) => {
-    const points = entry.points.flatMap((point) => {
-      const y = point.value ?? point.close;
-      return typeof y === "number" && Number.isFinite(y)
-        ? [{ x: point.date.toISOString(), y }]
-        : [];
+export function buildChartShareData(
+  series: ResolvedSeries[],
+  viewport?: { start: Date; end: Date } | null,
+  warnings: readonly string[] = [],
+): ChartShareData | null {
+  const visible = series.filter((entry) => !entry.hidden).slice(0, 20);
+  const hasMarketTimeline = series.some((entry) => entry.timeBasis?.kind === "market");
+  const limit = Math.min(MAX_POINTS, Math.floor(MAX_TOTAL_POINTS / Math.max(1, visible.length)));
+  const notes = [...warnings];
+  if (series.filter((entry) => !entry.hidden).length > 20) notes.push("Only the first 20 visible series are included.");
+  const window = viewport && Number.isFinite(viewport.start.getTime()) && Number.isFinite(viewport.end.getTime())
+    && viewport.start <= viewport.end ? viewport : null;
+  const sharedSeries = visible.flatMap((entry) => {
+    if (entry.warning) notes.push(`${entry.label}: ${entry.warning}`);
+    const step = entry.style === "step" || entry.interpolation === "step-after";
+    const useAvailability = hasMarketTimeline && !entry.timeBasis;
+    if (useAvailability && entry.points.some((point) => effectiveTimeSeriesPointTime(point) !== point.date.getTime())) {
+      notes.push(`${entry.label}: dates use known availability on the market chart; underlying fiscal period dates are not included in this snapshot.`);
+    }
+    const observations = entry.points.map((point) => useAvailability
+      ? { ...point, date: new Date(effectiveTimeSeriesPointTime(point)) } : point)
+      .filter((point) => Number.isFinite(point.date.getTime()))
+      .sort((a, b) => a.date.getTime() - b.date.getTime());
+    const anchor = step && window && !observations.some((point) => point.date.getTime() === window.start.getTime())
+      ? observations.findLast((point) => point.date < window.start) : undefined;
+    const points = observations.flatMap((point): SharedPoint[] => {
+      const time = point.date.getTime();
+      if (point !== anchor && window && (time < window.start.getTime() || time > window.end.getTime())) return [];
+      return [{ x: point.date.toISOString(), y: Number.isFinite(point.value) ? point.value : null }];
     });
-    return points.length > 0 ? [{ name: entry.label, points: sample(points, MAX_POINTS) }] : [];
+    if (points.length === 0) {
+      notes.push(`${entry.label}: no observations in the shared window.`);
+      if (!window) return [];
+      points.push({ x: window.start.toISOString(), y: null });
+    }
+    if (points.length > limit) notes.push(`${entry.label}: sampled for sharing; some observations are omitted and missing intervals may appear wider.`);
+    if (entry.dataShape === "ohlcv") notes.push(`${entry.label}: closing values; OHLC bars are not included in this snapshot.`);
+    if (step) notes.push(`${entry.label}: step levels are held between observations; the preceding observation is retained when needed to explain the window's opening level.`);
+    const style: "line" | "step" | "points" = entry.style === "columns" || entry.style === "points" ? "points"
+      : entry.style === "step" || entry.interpolation === "step-after" ? "step" : "line";
+    if (entry.style === "columns") notes.push(`${entry.label}: column observations shown as points.`);
+    return [{ style, name: entry.label.slice(0, 120), ...(entry.unit ? { unit: entry.unit.slice(0, 80) } : {}), points: sample(points, limit) }];
   });
-  if (sharedSeries.length === 0) return null;
+  if (!sharedSeries.some((entry) => entry.points.some((point) => point.y !== null))) return null;
+  const title = sharedSeries.map((entry) => entry.name).join(" / ");
+  const uniqueNotes = [...new Set(notes.filter(Boolean))];
   return {
-    title: sharedSeries.map((entry) => entry.name).join(" / "),
+    title: title.length <= 200 ? title : `Chart comparison (${sharedSeries.length} series)`,
     series: sharedSeries,
+    ...(window ? { viewport: { start: window.start.toISOString(), end: window.end.toISOString() } } : {}),
+    ...(uniqueNotes.length ? { warnings: uniqueNotes.slice(0, uniqueNotes.length > 20 ? 19 : 20).map((note) => note.slice(0, 500))
+      .concat(uniqueNotes.length > 20 ? [`${uniqueNotes.length - 19} additional data warnings; inspect the source chart.`] : []) } : {}),
   };
 }

--- a/src/shares/payload.ts
+++ b/src/shares/payload.ts
@@ -32,8 +32,12 @@ export interface ChartShareData {
   title: string;
   series: Array<{
     name: string;
-    points: Array<{ x: string | number; y: number }>;
+    unit?: string;
+    style?: "line" | "step" | "points";
+    points: Array<{ x: string | number; y: number | null }>;
   }>;
+  viewport?: { start: string; end: string };
+  warnings?: string[];
   sourceUrl?: string;
 }
 
@@ -78,6 +82,24 @@ function safeOptionalUrl(value: unknown): value is string | undefined {
   return value === undefined || (typeof value === "string" && safeExternalUrl(value) !== null);
 }
 
+function viewportDate(value: unknown): value is string {
+  if (typeof value !== "string" || value.length > 40) return false;
+  const match = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d{1,9})?)?(Z|[+-]\d{2}:\d{2}))?$/.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const days = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (month < 1 || month > 12 || day < 1 || day > days[month - 1]!) return false;
+  if (match[4] !== undefined) {
+    if (Number(match[4]) > 23 || Number(match[5]) > 59 || Number(match[6] ?? 0) > 59) return false;
+    const zone = match[7]!;
+    if (zone !== "Z" && (Number(zone.slice(1, 3)) > 23 || Number(zone.slice(4, 6)) > 59)) return false;
+  }
+  return Number.isFinite(Date.parse(value));
+}
+
 function isCell(value: unknown): value is CellValue {
   return value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean";
 }
@@ -99,18 +121,28 @@ function isTableData(value: unknown): value is TableShareData {
 
 function isChartData(value: unknown): value is ChartShareData {
   if (!record(value) || !shortString(value.title) || !safeOptionalUrl(value.sourceUrl)) return false;
+  if (Object.keys(value).some((key) => !["title", "series", "sourceUrl", "viewport", "warnings"].includes(key))) return false;
+  if (value.warnings !== undefined && (!Array.isArray(value.warnings) || value.warnings.length > 20
+    || !value.warnings.every((warning) => shortString(warning, 500)))) return false;
+  if (value.viewport !== undefined && (!record(value.viewport)
+    || Object.keys(value.viewport).some((key) => !["start", "end"].includes(key))
+    || !viewportDate(value.viewport.start) || !viewportDate(value.viewport.end)
+    || Date.parse(value.viewport.start) > Date.parse(value.viewport.end))) return false;
   return Array.isArray(value.series)
     && value.series.length > 0
     && value.series.length <= MAX_CHART_SERIES
     && value.series.every((series) => record(series)
+      && Object.keys(series).every((key) => ["name", "points", "unit", "style"].includes(key))
       && shortString(series.name, 120)
+      && (series.unit === undefined || shortString(series.unit, 80))
+      && (series.style === undefined || ["line", "step", "points"].includes(series.style as string))
       && Array.isArray(series.points)
       && series.points.length > 0
       && series.points.length <= MAX_CHART_POINTS
       && series.points.every((point) => record(point)
+        && Object.keys(point).every((key) => ["x", "y"].includes(key))
         && ((typeof point.x === "string" && point.x.length <= 100) || (typeof point.x === "number" && Number.isFinite(point.x)))
-        && typeof point.y === "number"
-        && Number.isFinite(point.y)));
+        && (point.y === null || (typeof point.y === "number" && Number.isFinite(point.y)))));
 }
 
 function isArticleData(value: unknown): value is ArticleShareData {


### PR DESCRIPTION
A shared chart positioned each series by row index, falsely aligning histories with different dates. It also exported buffered observations outside the selected window, dropped missing values and units, and could reveal financial values before their known availability. Native charts could shift a requested window to older cached dates or carry an obsolete step level through an opening gap.

Shared snapshots now use common date coordinates, retain the requested window, split incompatible units into separate panels, preserve gaps and step levels, and offer exact values in a keyboard-accessible table. Bounded sampling keeps finite evidence and missing intervals, with visible coverage and sampling notes. Availability rules match the native market comparison; the snapshot explicitly identifies when plotted availability dates replace fiscal dates. Source step observations retain their original timestamp when used as opening context.

Native viewport ownership and step-opening precedence are corrected. Sharing reads the latest gesture before the history-request debounce, so a click captures the visible window.

Validation: actual native partial-cache before/after and live QQQ/TQQQ/SQQQ 1M workflows; actual native step-gap check; browser before/after controlled share fixtures at 390, 768 and 1200px plus 200% zoom; keyboard table and exact numeric-value checks. Independent reviews and regressions cover irregular histories, singleton series, dense gaps, sampling budget, mixed units, strict dates, step boundaries and availability look-ahead. Full local suite and six runtime typechecks passed before integration; final integrated CI runs on this PR. Actual public creation requires a signed-in Cloud account and remains unverified; native attempt returned the expected sign-in error.

Companion backend schema: https://github.com/vincelwt/gloomberb-platform/pull/228 (merge before this frontend; production deployment must finish). No version bump or GitHub release.
