### PR TITLE
Honor financial period counts and expose incomplete history

### DIFF
--- a/src/cli/pane-functions/headless.test.ts
+++ b/src/cli/pane-functions/headless.test.ts
@@ -268,3 +268,14 @@ describe("headless pane arguments and options", () => {
     });
   });
 });
+
+test("partial usable reports retain rows without marking their symbol wholly unavailable", async () => {
+  const definition: HeadlessPaneDefinition<"rows"> = {
+    shape: "rows", argument: { kind: "none" }, options: [],
+    load: () => ({ symbols: ["MSFT"], rows: [{ date: "2025-06-30", margin: .46 }], complete: false }),
+  };
+  const report = await buildHeadlessFunctionReport({
+    headless: definition, token: "partial", label: "Partial", options: {}, instance: {}, capability: { id: "partial" },
+  } as ResolvedPaneFunction, { config: createDefaultConfig("/tmp/gloomberb-headless-partial") } as MarketContext, "");
+  expect(report.data).toMatchObject({ rowCount: 1, empty: false, complete: false, unavailableSymbols: [], rows: [{ date: "2025-06-30", margin: .46 }] });
+});

--- a/src/cli/pane-functions/headless.ts
+++ b/src/cli/pane-functions/headless.ts
@@ -420,7 +420,7 @@ export async function buildHeadlessFunctionReport(
       options: resolved.options,
       rowCount,
       empty: rowCount === 0,
-      complete: unavailableSymbols.length === 0 && !loaded.result.errors?.length,
+      complete: loaded.result.complete !== false && unavailableSymbols.length === 0 && !loaded.result.errors?.length,
       unavailableSymbols,
       ...serialized,
     },

--- a/src/plugins/builtin/chart-composer/cli-options.ts
+++ b/src/plugins/builtin/chart-composer/cli-options.ts
@@ -95,6 +95,9 @@ export function applyChartComposerCapabilityOptions(
       ...next,
       viewport: {
         ...next.viewport,
+        // A period count is not a five-year date window. Preserve authored
+        // constraints, otherwise select from all available observations.
+        ...(!selectedRange && !next.viewport.dateWindow ? { range: "ALL" as const } : {}),
         maxPoints: Math.max(1, Math.min(40, Math.floor(options.periods))),
       },
     };

--- a/src/plugins/builtin/chart-composer/financial-periods.fixture.json
+++ b/src/plugins/builtin/chart-composer/financial-periods.fixture.json
@@ -1,0 +1,225 @@
+{
+  "source": "SEC CompanyFacts, MSFT CIK0000789019; cloud MSFT financials; captured2026-09-10",
+  "secAnnual": [
+    {
+      "date": "2008-06-30",
+      "operatingIncome": 22271000000,
+      "totalRevenue": 60420000000,
+      "availableAt": "2010-07-30",
+      "fieldAvailability": {
+        "totalRevenue": "2010-07-30",
+        "operatingIncome": "2010-07-30"
+      }
+    },
+    {
+      "date": "2009-06-30",
+      "operatingIncome": 20363000000,
+      "totalRevenue": 58437000000,
+      "availableAt": "2010-07-30",
+      "fieldAvailability": {
+        "totalRevenue": "2010-07-30",
+        "operatingIncome": "2010-07-30"
+      }
+    },
+    {
+      "date": "2010-06-30",
+      "operatingIncome": 24098000000,
+      "totalRevenue": 62484000000,
+      "availableAt": "2010-07-30",
+      "fieldAvailability": {
+        "totalRevenue": "2010-07-30",
+        "operatingIncome": "2010-07-30"
+      }
+    },
+    {
+      "date": "2011-06-30",
+      "operatingIncome": 27161000000,
+      "totalRevenue": 69943000000,
+      "availableAt": "2011-07-28",
+      "fieldAvailability": {
+        "totalRevenue": "2011-07-28",
+        "operatingIncome": "2011-07-28"
+      }
+    },
+    {
+      "date": "2012-06-30",
+      "operatingIncome": 21763000000,
+      "totalRevenue": 73723000000,
+      "availableAt": "2012-07-26",
+      "fieldAvailability": {
+        "totalRevenue": "2012-07-26",
+        "operatingIncome": "2012-07-26"
+      }
+    },
+    {
+      "date": "2013-06-30",
+      "operatingIncome": 26764000000,
+      "totalRevenue": 77849000000,
+      "availableAt": "2015-07-31",
+      "fieldAvailability": {
+        "totalRevenue": "2013-07-30",
+        "operatingIncome": "2013-07-30"
+      }
+    },
+    {
+      "date": "2014-06-30",
+      "operatingIncome": 27759000000,
+      "totalRevenue": 86833000000,
+      "availableAt": "2016-07-28",
+      "fieldAvailability": {
+        "totalRevenue": "2014-07-31",
+        "operatingIncome": "2014-07-31"
+      }
+    },
+    {
+      "date": "2015-06-30",
+      "operatingIncome": 18161000000,
+      "totalRevenue": 93580000000,
+      "availableAt": "2016-07-28",
+      "fieldAvailability": {
+        "totalRevenue": "2015-07-31",
+        "operatingIncome": "2015-07-31"
+      }
+    },
+    {
+      "date": "2016-06-30",
+      "operatingIncome": 26078000000,
+      "totalRevenue": 91154000000,
+      "availableAt": "2018-08-03",
+      "fieldAvailability": {
+        "totalRevenue": "2018-08-03",
+        "operatingIncome": "2018-08-03"
+      }
+    },
+    {
+      "date": "2017-06-30",
+      "operatingIncome": 29025000000,
+      "totalRevenue": 96571000000,
+      "availableAt": "2018-08-03",
+      "fieldAvailability": {
+        "totalRevenue": "2018-08-03",
+        "operatingIncome": "2018-08-03"
+      }
+    },
+    {
+      "date": "2018-06-30",
+      "operatingIncome": 35058000000,
+      "totalRevenue": 110360000000,
+      "availableAt": "2018-08-03",
+      "fieldAvailability": {
+        "totalRevenue": "2018-08-03",
+        "operatingIncome": "2018-08-03"
+      }
+    },
+    {
+      "date": "2019-06-30",
+      "operatingIncome": 42959000000,
+      "totalRevenue": 125843000000,
+      "availableAt": "2019-08-01",
+      "fieldAvailability": {
+        "totalRevenue": "2019-08-01",
+        "operatingIncome": "2019-08-01"
+      }
+    },
+    {
+      "date": "2020-06-30",
+      "operatingIncome": 52959000000,
+      "totalRevenue": 143015000000,
+      "availableAt": "2020-07-30",
+      "fieldAvailability": {
+        "totalRevenue": "2020-07-30",
+        "operatingIncome": "2020-07-30"
+      }
+    },
+    {
+      "date": "2021-06-30",
+      "operatingIncome": 69916000000,
+      "totalRevenue": 168088000000,
+      "availableAt": "2021-07-29",
+      "fieldAvailability": {
+        "totalRevenue": "2021-07-29",
+        "operatingIncome": "2021-07-29"
+      }
+    },
+    {
+      "date": "2022-06-30",
+      "operatingIncome": 83383000000,
+      "totalRevenue": 198270000000,
+      "availableAt": "2022-07-28",
+      "fieldAvailability": {
+        "totalRevenue": "2022-07-28",
+        "operatingIncome": "2022-07-28"
+      }
+    },
+    {
+      "date": "2023-06-30",
+      "operatingIncome": 88523000000,
+      "totalRevenue": 211915000000,
+      "availableAt": "2023-07-27",
+      "fieldAvailability": {
+        "totalRevenue": "2023-07-27",
+        "operatingIncome": "2023-07-27"
+      }
+    },
+    {
+      "date": "2024-06-30",
+      "operatingIncome": 109433000000,
+      "totalRevenue": 245122000000,
+      "availableAt": "2024-07-30",
+      "fieldAvailability": {
+        "totalRevenue": "2024-07-30",
+        "operatingIncome": "2024-07-30"
+      }
+    },
+    {
+      "date": "2025-06-30",
+      "operatingIncome": 128528000000,
+      "totalRevenue": 281724000000,
+      "availableAt": "2025-07-30",
+      "fieldAvailability": {
+        "totalRevenue": "2025-07-30",
+        "operatingIncome": "2025-07-30"
+      }
+    },
+    {
+      "date": "2026-06-30",
+      "operatingIncome": 155237000000,
+      "totalRevenue": 331839000000,
+      "availableAt": "2026-07-29",
+      "fieldAvailability": {
+        "totalRevenue": "2026-07-29",
+        "operatingIncome": "2026-07-29"
+      }
+    }
+  ],
+  "cloudAnnual": [
+    {
+      "date": "2022-06-30",
+      "currency": "USD"
+    },
+    {
+      "date": "2023-06-30",
+      "currency": "USD",
+      "operatingIncome": 88523000000,
+      "totalRevenue": 211915000000
+    },
+    {
+      "date": "2024-06-30",
+      "currency": "USD",
+      "operatingIncome": 109433000000,
+      "totalRevenue": 245122000000
+    },
+    {
+      "date": "2025-06-30",
+      "currency": "USD",
+      "operatingIncome": 128528000000,
+      "totalRevenue": 281724000000
+    },
+    {
+      "date": "2026-06-30",
+      "currency": "USD",
+      "operatingIncome": 155237000000,
+      "totalRevenue": 331839000000
+    }
+  ]
+}

--- a/src/plugins/builtin/chart-composer/headless.test.ts
+++ b/src/plugins/builtin/chart-composer/headless.test.ts
@@ -97,3 +97,36 @@ test("chart reports retain raw comparison endpoints and growth preceding a finan
   expect(financial.series[0]!.points).toHaveLength(1);
   expect(financial.series[0]!.points[0]).toMatchObject({ value: 150, growth: 0.5 });
 });
+
+test("explicit financial periods replay available SEC history and expose actual cloud depth deficits", async () => {
+  const actual = await import("./financial-periods.fixture.json");
+  const { buildFundamentalChartPreset } = await import("./presets");
+  const { applyChartComposerCapabilityOptions } = await import("./cli-options");
+  const options = { metric: "operatingMargin", period: "annual", periods: 10 };
+  const spec = applyChartComposerCapabilityOptions(buildFundamentalChartPreset(["MSFT"]), "fundamental-series", options);
+  const context = { ...fixture().context, settings: { chartSpec: spec }, marketData: createTestDataProvider({
+    getTickerFinancials: async () => ({ annualStatements: actual.secAnnual, quarterlyStatements: [], priceHistory: [] }),
+  }) };
+  const args = { argument: ["MSFT"], rawArgument: "MSFT", symbols: ["MSFT"], options };
+  const full = await chartHeadless("fundamental-graph-pane").load(args, context);
+  expect(spec.viewport.range).toBe("ALL");
+  expect(full.series[0]!.points).toHaveLength(10);
+  expect(full.series[0]!.points[0]!.observedAt.toISOString()).toBe("2017-06-30T00:00:00.000Z");
+  expect(full.complete).toBe(true);
+  expect(full.metadata?.periodCoverage).toEqual([expect.objectContaining({ requested: 10, returned: 10, complete: true })]);
+  const partial = await chartHeadless("fundamental-graph-pane").load(args, { ...context, marketData: createTestDataProvider({
+    getTickerFinancials: async () => ({ annualStatements: actual.cloudAnnual, quarterlyStatements: [], priceHistory: [] }),
+  }) });
+  expect(partial.series[0]!.points).toHaveLength(4);
+  expect(partial.complete).toBe(false);
+  expect(partial.unavailableSymbols).toEqual([]);
+  expect(partial.metadata?.periodCoverage).toEqual([expect.objectContaining({ requested: 10, returned: 4, complete: false })]);
+  expect((partial as ChartPaneModel).chart.warnings.join(" ")).toContain("4 of 10 requested annual observations");
+  const constrained = applyChartComposerCapabilityOptions({ ...spec, viewport: { ...spec.viewport,
+    dateWindow: { start: "2024-01-01", end: "2025-12-31" } } }, "fundamental-series", options);
+  const windowed = await chartHeadless("fundamental-graph-pane").load(args, { ...context, settings: { chartSpec: constrained } });
+  expect(windowed.series[0]!.points).toHaveLength(2);
+  expect(windowed.complete).toBe(false);
+  const explicitRange = applyChartComposerCapabilityOptions(spec, "fundamental-series", { ...options, rangePreset: "1Y" });
+  expect(explicitRange.viewport.range).toBe("1Y");
+});

--- a/src/plugins/builtin/chart-composer/headless.ts
+++ b/src/plugins/builtin/chart-composer/headless.ts
@@ -1,3 +1,4 @@
+import { financialPeriodCoverage } from "../../../time-series/financial-period-coverage";
 import { graphRowsForFinancials, summarizeResolvedSeries } from "../../../time-series/reporting";
 import type { HeadlessPaneContext, HeadlessPaneDefinition, HeadlessSeriesResult } from "../../../types/headless";
 import type { ChartResolutionResult, ChartSeriesSpec, ChartSpec } from "../../../time-series/types";
@@ -66,9 +67,14 @@ export async function loadChartPaneModel(
   });
   spec = { ...spec, series: spec.series.map((series) => resolvedSeries.get(series.id) ?? series) };
   const ids = new Set(spec.series.map((series) => series.id));
+  const periodCoverage = financialPeriodCoverage(spec, chart.series);
   return {
     chart,
     spec,
+    ...(periodCoverage.length ? {
+      complete: periodCoverage.every((entry) => entry.complete),
+      stats: periodCoverage.map((entry) => ({ label: `${entry.label} observations`, value: `${entry.returned}/${entry.requested} ${entry.period}${entry.complete ? "" : " (partial)"}` })),
+    } : {}),
     snapshot: {
       financials: [...financials].map(([key, data]) => [key, { ...data, priceHistory: histories.get(key) ?? data.priceHistory }]),
       intradayHistories: [],
@@ -104,6 +110,7 @@ export async function loadChartPaneModel(
     }),
     metadata: {
       viewport: spec.viewport, panels: spec.panels, warnings: chart.warnings,
+      ...(periodCoverage.length ? { periodCoverage } : {}),
       summaries: chart.series.map((series) => ({ id: series.id, ...summarizeResolvedSeries(series) })),
     },
   };

--- a/src/time-series/financial-period-coverage.test.ts
+++ b/src/time-series/financial-period-coverage.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import { buildValuationChartPreset, buildFundamentalChartPreset } from "../plugins/builtin/chart-composer/presets";
+import { applyChartComposerCapabilityOptions } from "../plugins/builtin/chart-composer/cli-options";
+import { financialPeriodCoverage, limitSeriesObservations } from "./financial-period-coverage";
+import type { ResolvedSeries, TimeSeriesPoint } from "./types";
+
+const point = (date: string, value: number | null, periodLabel: string): TimeSeriesPoint => ({ date: new Date(date), observedAt: new Date(date), value, periodLabel });
+
+test("latest quarterly valuation counts usable periods while preserving gaps and excluding the current snapshot", () => {
+  const spec = applyChartComposerCapabilityOptions(buildValuationChartPreset(["MSFT"]), "valuation-series", { metric: "trailingPE", period: "quarterly", periods: 3 });
+  const series = { id: spec.series[0]!.id, label: "MSFT P/E", nativeFrequency: "quarterly", points: [
+    point("2025-03-31", 20, "Q1 2025"), point("2025-06-30", 21, "Q2 2025"),
+    point("2025-09-30", null, "Q3 2025"), point("2025-12-31", 22, "Q4 2025"),
+    point("2026-03-31", Number.NaN, "Q1 2026"), point("2026-09-10", 25, "Current"),
+  ] } as ResolvedSeries;
+  const result = limitSeriesObservations(spec, series);
+  expect(result.points.map((entry) => entry.value)).toEqual([20, 21, null, 22, Number.NaN]);
+  expect(financialPeriodCoverage(spec, [result])).toEqual([expect.objectContaining({ requested: 3, returned: 3, period: "quarterly", complete: true })]);
+  const currentOnly = limitSeriesObservations(spec, { ...series, points: [series.points.at(-1)!] });
+  expect(currentOnly.points).toEqual([]);
+  expect(financialPeriodCoverage(spec, [currentOnly])[0]).toMatchObject({ returned: 0, complete: false });
+  spec.viewport.maxPoints = 2;
+  const lastTwo = limitSeriesObservations(spec, series);
+  expect(lastTwo.points.map((entry) => entry.value)).toEqual([21, null, 22, Number.NaN]);
+  expect(financialPeriodCoverage(spec, [lastTwo])[0]).toMatchObject({ returned: 2, complete: true });
+});
+
+test("zero-valued financial observations are usable and hidden series do not create coverage deficits", () => {
+  const spec = applyChartComposerCapabilityOptions(buildFundamentalChartPreset(["MSFT", "V"]), "fundamental-series", { metric: "operatingMargin", period: "annual", periods: 2 });
+  spec.series[1]!.visible = false;
+  const result = limitSeriesObservations(spec, { id: spec.series[0]!.id, label: "MSFT Margin", nativeFrequency: "annual", points: [
+    point("2024-06-30", 0, "2024"), point("2025-06-30", .4, "2025"),
+  ] } as ResolvedSeries);
+  expect(result.points.map((entry) => entry.value)).toEqual([0, .4]);
+  expect(financialPeriodCoverage(spec, [result])).toHaveLength(1);
+  expect(financialPeriodCoverage(spec, [result])[0]?.complete).toBe(true);
+});

--- a/src/time-series/financial-period-coverage.ts
+++ b/src/time-series/financial-period-coverage.ts
@@ -1,0 +1,57 @@
+import type { ChartSeriesSpec, ChartSpec, ResolvedSeries, TimeSeriesPoint } from "./types";
+
+function isFinancialSeries(series: ChartSeriesSpec | undefined): boolean {
+  return series?.source.kind === "security" && /^(fundamental|valuation)\./.test(series.source.fieldId);
+}
+
+/** Current multiples are snapshots, not annual/quarterly financial observations. */
+function isUsableFinancialObservation(point: TimeSeriesPoint): boolean {
+  return point.periodLabel !== "Current" && point.value != null && Number.isFinite(point.value);
+}
+
+export function limitSeriesObservations(spec: ChartSpec, series: ResolvedSeries): ResolvedSeries {
+  if (spec.viewport.maxPoints === undefined) return series;
+  const definition = spec.series.find((entry) => entry.id === series.id);
+  if (!isFinancialSeries(definition)) {
+    return { ...series, points: series.points.slice(-spec.viewport.maxPoints) };
+  }
+  const points = series.points.filter((point) => point.periodLabel !== "Current");
+  let remaining = spec.viewport.maxPoints;
+  let start = points.length;
+  for (let index = points.length - 1; index >= 0; index--) {
+    if (!isUsableFinancialObservation(points[index]!)) continue;
+    start = index;
+    if (--remaining <= 0) break;
+  }
+  // Count usable observations, but retain missing periods within the selected
+  // history and at its end so charts cannot draw through absent financial data.
+  return { ...series, points: points.slice(start) };
+}
+
+export interface FinancialPeriodCoverage {
+  seriesId: string;
+  label: string;
+  period: string;
+  requested: number;
+  returned: number;
+  complete: boolean;
+}
+
+export function financialPeriodCoverage(spec: ChartSpec, series: readonly ResolvedSeries[]): FinancialPeriodCoverage[] {
+  const requested = spec.viewport.maxPoints;
+  if (requested === undefined) return [];
+  return spec.series.filter((entry) => entry.visible !== false && isFinancialSeries(entry)).map((definition) => {
+    const resolved = series.find((entry) => entry.id === definition.id);
+    const returned = resolved?.points.filter(isUsableFinancialObservation).length ?? 0;
+    const period = definition.source.kind === "security" && definition.source.period && definition.source.period !== "auto"
+      ? definition.source.period : resolved?.nativeFrequency ?? "financial";
+    return { seriesId: definition.id, label: resolved?.label ?? definition.label ?? definition.id,
+      period, requested, returned, complete: returned >= requested };
+  });
+}
+
+export function financialPeriodCoverageWarnings(coverage: readonly FinancialPeriodCoverage[]): string[] {
+  return coverage.filter((entry) => !entry.complete).map((entry) => (
+    `${entry.label}: ${entry.returned} of ${entry.requested} requested ${entry.period} observations available in this window.`
+  ));
+}

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -1,3 +1,4 @@
+import { financialPeriodCoverage, financialPeriodCoverageWarnings, limitSeriesObservations } from "./financial-period-coverage";
 import { appendLiveQuotePoint } from "./chart-data";
 import {
   getTimeRangeForDateWindow,
@@ -403,8 +404,7 @@ export function seedChartResolutionResult(
     const clipped = bounds.start !== null && bounds.end !== null
       ? clipSeriesToWindow(entry, new Date(bounds.start), new Date(bounds.end))
       : { ...entry, points: filterPoints(entry.points, bounds) };
-    return spec.viewport.maxPoints === undefined ? clipped
-      : { ...clipped, points: clipped.points.slice(-spec.viewport.maxPoints) };
+    return limitSeriesObservations(spec, clipped);
   });
   return {
     series: visible,
@@ -1204,12 +1204,8 @@ export async function resolveChartSpecData(
       ? clipSeriesToWindow(entry, new Date(bounds.start), new Date(bounds.end))
       : { ...entry, points: filterPoints(entry.points, bounds) }
   ));
-  if (spec.viewport.maxPoints !== undefined) {
-    resolved = resolved.map((entry) => ({
-      ...entry,
-      points: entry.points.slice(-spec.viewport.maxPoints!),
-    }));
-  }
+  resolved = resolved.map((entry) => limitSeriesObservations(spec, entry));
+  warnings.push(...financialPeriodCoverageWarnings(financialPeriodCoverage(spec, resolved)));
   const resolvedById = new Map(resolved.map((entry) => [entry.id, entry] as const));
   const hiddenBaseSeries = rawSeries
     .filter((entry) => !visibleSeriesIds.has(entry.id))

--- a/src/types/headless.ts
+++ b/src/types/headless.ts
@@ -92,6 +92,8 @@ export interface HeadlessPaneEntry {
 }
 
 interface HeadlessPaneResultBase {
+  /** False when usable output does not fully cover the requested inputs/depth. */
+  complete?: boolean;
   /** Resolved inputs, including implicit peers or symbols parsed from an expression. */
   symbols?: string[];
   /** Missing inputs must remain visible even when other inputs returned rows. */


### PR DESCRIPTION
Requesting ten annual financial observations previously kept the default five-year window, silently returned fewer rows, and could still report the research complete. Explicit GF/GE period counts now select from all available history unless an explicit date window/range constrains the request. Financial counts exclude current snapshots and missing values while preserving gaps between observations.

Chart warnings, CLI statistics, and structured period coverage expose requested versus available observations; partial histories retain usable rows with `complete: false`. This does not guarantee provider depth: actual cloud MSFT/V responses still expose only four usable operating-margin observations, while captured SEC history supplies ten. Provider retrieval is a separate follow-up.

Validated with 140 focused tests (561 assertions), six runtime typechecks, manifest check, and actual terminal replay of captured SEC/cloud responses. Tests cover observation limits, date constraints, zero values, missing periods, current multiples, partial result propagation, and growth lookback. No release or version bump.
