### PR TITLE
Disclose historical financial snapshot limitations and preserve availability metadata

### DIFF
--- a/src/cli/pane-functions/headless.test.ts
+++ b/src/cli/pane-functions/headless.test.ts
@@ -279,3 +279,12 @@ test("partial usable reports retain rows without marking their symbol wholly una
   } as ResolvedPaneFunction, { config: createDefaultConfig("/tmp/gloomberb-headless-partial") } as MarketContext, "");
   expect(report.data).toMatchObject({ rowCount: 1, empty: false, complete: false, unavailableSymbols: [], rows: [{ date: "2025-06-30", margin: .46 }] });
 });
+
+test("headless text preserves applicable coverage notices once before the exported rows", () => {
+  const text = renderHeadlessPaneText({ shape: "rows", columns: [{ key: "value", header: "Value" }] } as any,
+    { rows: [{ value: 96_571_000_000 }], metadata: { notices: ["Historical versions unavailable.", "Historical versions unavailable.", null, ""] } },
+    { symbols: ["MSFT"], options: {}, argument: "MSFT", rawArgument: "MSFT" }, "Financial Statements");
+  expect(text.match(/Historical versions unavailable\./g)).toHaveLength(1);
+  expect(text.indexOf("Historical versions unavailable.")).toBeLessThan(text.indexOf("VALUE"));
+  expect(text).toContain("96571000000");
+});

--- a/src/cli/pane-functions/headless.ts
+++ b/src/cli/pane-functions/headless.ts
@@ -356,6 +356,11 @@ export function renderHeadlessPaneText(
   fallbackTitle: string,
 ): string {
   const lines = [reportTitle(definition, args, fallbackTitle), ""];
+  const notices = result.metadata?.notices;
+  if (Array.isArray(notices)) {
+    const textNotices = [...new Set(notices.filter((notice): notice is string => typeof notice === "string" && notice.trim().length > 0))];
+    if (textNotices.length) lines.push(...textNotices, "");
+  }
   switch (definition.shape) {
     case "rows": {
       const rowsResult = result as HeadlessPaneResult & { rows: HeadlessPaneRow[]; columns?: HeadlessPaneColumn[] };

--- a/src/plugins/builtin/chart-composer/headless.ts
+++ b/src/plugins/builtin/chart-composer/headless.ts
@@ -1,4 +1,5 @@
 import { financialPeriodCoverage } from "../../../time-series/financial-period-coverage";
+import { FINANCIAL_VINTAGE_NOTICE } from "../../../utils/financial-statements";
 import { graphRowsForFinancials, summarizeResolvedSeries } from "../../../time-series/reporting";
 import type { HeadlessPaneContext, HeadlessPaneDefinition, HeadlessSeriesResult } from "../../../types/headless";
 import type { ChartResolutionResult, ChartSeriesSpec, ChartSpec } from "../../../time-series/types";
@@ -111,6 +112,7 @@ export async function loadChartPaneModel(
     metadata: {
       viewport: spec.viewport, panels: spec.panels, warnings: chart.warnings,
       ...(periodCoverage.length ? { periodCoverage } : {}),
+      notices: chart.warnings.filter((warning) => warning === FINANCIAL_VINTAGE_NOTICE),
       summaries: chart.series.map((series) => ({ id: series.id, ...summarizeResolvedSeries(series) })),
     },
   };

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -1,7 +1,11 @@
+import { FINANCIAL_VINTAGE_NOTICE } from "../../../utils/financial-statements";
+import { wrapTextLines } from "../../../utils/text-wrap";
+import { isFundamentalFieldId } from "../../../time-series/field-catalog";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useUiCapabilities, useUiHost } from "../../../ui";
 import {
   ChoiceDialog,
+  Prose,
   Tabs,
   usePaneFooter,
   type PaneFooterPressEvent,
@@ -549,12 +553,17 @@ function ChartComposerSurface({
     }
   }, { enabled: focused && !dialogOpen });
 
+  const showVintageNotice = spec.series.some((entry) => entry.visible !== false
+    && entry.source.kind === "security" && isFundamentalFieldId(entry.source.fieldId));
+  const vintageNoticeHeight = showVintageNotice ? wrapTextLines(FINANCIAL_VINTAGE_NOTICE, Math.max(8, width - 2)).length : 0;
+  const statusWarning = resolution.warnings.find((warning) => warning !== FINANCIAL_VINTAGE_NOTICE);
+
   usePaneFooter(footerId, () => ({
     info: [
       ...(resolution.loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(resolution.errors[0] ? [{ id: "error", parts: [{ text: resolution.errors[0], tone: "warning" as const }] }] : []),
-      ...(!resolution.errors[0] && resolution.warnings[0]
-        ? [{ id: "warning", parts: [{ text: resolution.warnings[0], tone: "warning" as const }] }]
+      ...(!resolution.errors[0] && statusWarning
+        ? [{ id: "warning", parts: [{ text: statusWarning, tone: "warning" as const }] }]
         : []),
     ],
     hints: [
@@ -581,7 +590,7 @@ function ChartComposerSurface({
     shareData,
     resolution.errors,
     resolution.loading,
-    resolution.warnings,
+    statusWarning,
   ]);
 
   const emptyMessage = spec.series.length === 0
@@ -665,6 +674,9 @@ function ChartComposerSurface({
         renderTrigger={() => null}
       />
 
+      {showVintageNotice && <Box paddingX={1} flexShrink={0}>
+        <Prose text={FINANCIAL_VINTAGE_NOTICE} width={Math.max(8, width - 2)} color={colors.textDim} />
+      </Box>}
       <Box flexGrow={1} minHeight={4}>
         <CompositeChart
           series={plottedSeries}
@@ -674,7 +686,7 @@ function ChartComposerSurface({
           viewport={viewport}
           viewportResetKey={authoredViewportKey}
           width={Math.max(1, width)}
-          height={Math.max(4, height - 1)}
+          height={Math.max(4, height - 1 - vintageNoticeHeight)}
           focused={focused}
           interactive={surfacePointerInteractive}
           allowHistoricalBackfill

--- a/src/plugins/builtin/ticker-detail/financials/tab.tsx
+++ b/src/plugins/builtin/ticker-detail/financials/tab.tsx
@@ -1,3 +1,4 @@
+import { FINANCIAL_VINTAGE_NOTICE } from "../../../../utils/financial-statements";
 import { Box, Text, useUiCapabilities } from "../../../../ui";
 import { TextAttributes, type ScrollBoxRenderable } from "../../../../ui";
 import { useShortcut } from "../../../../react/input";
@@ -400,6 +401,7 @@ export function ResolvedFinancialsTab({
         resetScrollKey={`${resolvedPeriod}:${subTab.key}:${displayStatements.length}`}
         rootBefore={(
           <>
+            <Notice tone="muted">{FINANCIAL_VINTAGE_NOTICE}</Notice>
             {financialStatementLimitations(financials).map((limitation) => <Notice key={limitation} tone="muted">{limitation}</Notice>)}
             {financialStatementDateNotice(displayStatements) && <Notice tone="muted">{financialStatementDateNotice(displayStatements)}</Notice>}
             <Box flexDirection="row" height={1}>

--- a/src/plugins/builtin/ticker-detail/headless.test.ts
+++ b/src/plugins/builtin/ticker-detail/headless.test.ts
@@ -54,7 +54,7 @@ test("financial exports distinguish provider dates from SEC period evidence and 
   expect(columns.find(({ date }) => date === "2024-09-01")).toMatchObject({ dateSource: "sec", providerDate: "2024-08-31", dateEvidence, label: "2024-09-01 USD (SEC date)" });
   expect(columns.find(({ date }) => date === "2023-08-31")).toMatchObject({ dateSource: "provider", dateEvidence: null, label: "2023-08-31 USD (provider date)" });
   expect(columns.find(({ date }) => date === "TTM")).toMatchObject({ dateSource: "derived", dateEvidence: null, providerDate: null });
-  expect(columns.every((column) => !("availableAt" in column))).toBe(true);
+  expect(columns.every((column) => column.availableAt === null && column.fieldAvailability === null)).toBe(true);
   expect(result.columns?.find(({ key }) => key === "2023-08-31")?.header).toContain("provider date");
 });
 
@@ -95,4 +95,17 @@ test("historical prices use remembered exchanges and clip and sort the full OHLC
   expect(requests).toEqual([["ABC", "LSE", "1M"]]);
   expect(result.rows.map((row) => row.close)).toEqual([18, 22]);
   expect(result.rows[1]).toEqual({ date: "2026-03-09T00:00:00.000Z", open: 20, high: 23, low: 19, close: 22, volume: 100 });
+});
+
+test("financial JSON exports preserve selected metric availability separately from fiscal-period evidence", async () => {
+  const fieldAvailability = { totalRevenue: "2018-08-03", netIncome: "2018-08-03", capitalExpenditure: "2017-08-02" };
+  const dateEvidence = { accessionNumber: "0001564590-17-014900", filed: "2017-08-02", startDate: "2016-07-01" };
+  const ctx = { marketData: createTestDataProvider({ getTickerFinancials: async () => ({
+    annualStatements: [{ date: "2017-06-30", currency: "USD", dateSource: "sec", dateEvidence, availableAt: "2018-08-03", fieldAvailability, totalRevenue: 96_571_000_000, netIncome: 25_489_000_000 }],
+    quarterlyStatements: [], priceHistory: [],
+  }) }) } as HeadlessPaneContext;
+  const result = await financialStatementsHeadless.load(args(["MSFT"], { period: "annual", statement: "income" }), ctx);
+  const restored = JSON.parse(JSON.stringify(result));
+  expect(restored.metadata.columns[0]).toMatchObject({ date: "2017-06-30", dateEvidence, availableAt: "2018-08-03", fieldAvailability });
+  expect(restored.rows.find((row: { metric: string }) => row.metric.includes("Revenue"))["2017-06-30"]).toBe(96_571_000_000);
 });

--- a/src/plugins/builtin/ticker-detail/headless.ts
+++ b/src/plugins/builtin/ticker-detail/headless.ts
@@ -1,3 +1,4 @@
+import { FINANCIAL_VINTAGE_NOTICE } from "../../../utils/financial-statements";
 import type { HeadlessPaneColumn, HeadlessPaneDefinition } from "../../../types/headless";
 import type { TimeRange } from "../../../time-series/range";
 import { formatCurrency, formatNumber, formatPercentRaw } from "../../../utils/format";
@@ -20,8 +21,10 @@ export const financialStatementsHeadless: HeadlessPaneDefinition<"rows"> = {
       expandAll: true,
     });
     const statementCurrency = financialStatementCurrency(financials, table?.statements ?? []);
-    const dates = table?.statements.map(({ date, currency, dateSource, providerDate, dateEvidence }) => ({
+    const dates = table?.statements.map(({ date, currency, dateSource, providerDate, dateEvidence, availableAt, fieldAvailability }) => ({
       date, currency: currency ?? statementCurrency ?? null,
+      availableAt: availableAt ?? null,
+      fieldAvailability: fieldAvailability ? { ...fieldAvailability } : null,
       dateSource: date === "TTM" ? "derived" : dateSource ?? "provider",
       providerDate: date === "TTM" ? null : providerDate ?? null,
       dateEvidence: date === "TTM" || dateSource !== "sec" ? null : dateEvidence ?? null,
@@ -51,6 +54,7 @@ export const financialStatementsHeadless: HeadlessPaneDefinition<"rows"> = {
         symbol, name: financials.quote?.name ?? symbol, currency: statementCurrency ?? null, quoteCurrency: financials.quote?.currency ?? null,
         statement: table?.subTab.key ?? options.statement, statementLabel: table?.subTab.name ?? null,
         period: table?.period ?? options.period, growthBasis: table?.period === "quarterly" ? "QoQ" : "YoY", columns: dates,
+        notices: rows.length ? [FINANCIAL_VINTAGE_NOTICE] : [],
         limitations: financialStatementLimitations(financials),
         dateProvenance: financialStatementDateNotice(table?.statements ?? []),
       },

--- a/src/time-series/fundamentals.ts
+++ b/src/time-series/fundamentals.ts
@@ -802,7 +802,7 @@ function dedupeFundamentalPeriods(points: readonly TimeSeriesPoint[]): TimeSerie
     ));
 }
 
-/** Extracts a point-in-time-safe fundamental or valuation series from a snapshot. */
+/** Extracts the selected statement snapshot, retaining known availability dates without reconstructing prior vintages. */
 export function extractFundamentalSeries(
   financials: TickerFinancials | null,
   source: SecuritySeriesSource,

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -1,3 +1,4 @@
+import { FINANCIAL_VINTAGE_NOTICE } from "../utils/financial-statements";
 import { describe, expect, test } from "bun:test";
 import { chartSeriesSourceKey } from "../capabilities";
 import type { FredSeriesData, FredSeriesLoadResult } from "../data/fred-series";
@@ -2020,4 +2021,20 @@ describe("mergePriceHistoryWindows", () => {
       }
     }
   });
+});
+
+test("financial charts disclose snapshot vintages once without changing period or availability timestamps", async () => {
+  const dataProvider = createTestDataProvider({ getTickerFinancials: async () => ({
+    annualStatements: [{ date: "2017-06-30", totalRevenue: 96_571_000_000, netIncome: 25_489_000_000, fieldAvailability: { totalRevenue: "2018-08-03", netIncome: "2018-08-03" } }],
+    quarterlyStatements: [], priceHistory: [],
+  }) });
+  for (const timestampMode of ["period-end", "available-at"] as const) {
+    const result = await resolveChartSpecData(chartSpec({ viewport: { range: "ALL", resolution: "auto" },
+      series: ["totalRevenue", "netIncome"].map((field) => chartSeries({ id: field, style: "columns",
+        source: { kind: "security", instrument: { symbol: "MSFT", exchange: "NASDAQ" }, fieldId: `fundamental.${field}`, period: "annual", timestampMode },
+      })),
+    }), { dataProvider });
+    expect(result.warnings.filter((warning) => warning === FINANCIAL_VINTAGE_NOTICE)).toHaveLength(1);
+    expect(result.series[0]?.points[0]).toMatchObject({ value: 96_571_000_000, observedAt: new Date("2017-06-30T00:00:00Z"), availableAt: new Date("2018-08-03T00:00:00Z"), date: new Date(timestampMode === "period-end" ? "2017-06-30T00:00:00Z" : "2018-08-03T00:00:00Z") });
+  }
 });

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -1,4 +1,5 @@
 import { financialPeriodCoverage, financialPeriodCoverageWarnings, limitSeriesObservations } from "./financial-period-coverage";
+import { FINANCIAL_VINTAGE_NOTICE } from "../utils/financial-statements";
 import { appendLiveQuotePoint } from "./chart-data";
 import {
   getTimeRangeForDateWindow,
@@ -883,7 +884,9 @@ export async function resolveChartSpecData(
   options: ChartResolveOptions = {},
 ): Promise<ChartResolutionResult> {
   const errors: string[] = [];
-  const warnings: string[] = [];
+  const warnings: string[] = spec.series.some((entry) => entry.visible !== false
+    && entry.source.kind === "security" && isFundamentalFieldId(entry.source.fieldId))
+    ? [FINANCIAL_VINTAGE_NOTICE] : [];
   const priorityWarnings: string[] = [];
   const baseSeriesIds = new Set(spec.series.map((entry) => entry.id));
   const visibleSeriesIds = new Set(spec.series

--- a/src/utils/financial-statements.ts
+++ b/src/utils/financial-statements.ts
@@ -1,5 +1,7 @@
 import type { FinancialStatement } from "../types/financials";
 
+export const FINANCIAL_VINTAGE_NOTICE = "Latest available statements may include restatements. Historical as-of values are not reconstructed.";
+
 const STATEMENT_METADATA_KEYS = new Set(["date", "dateSource", "providerDate", "dateEvidence", "currency", "availableAt", "fieldAvailability"]);
 const NEARBY_PERIOD_END_MS = 7 * 24 * 60 * 60 * 1_000;
 


### PR DESCRIPTION
Historical financial views use the latest available statement snapshot, which can contain restated comparative values. Microsoft’s FY2017 source facts illustrate the risk: revenue changed from $89.950B in the original annual report to $96.571B in the later comparative statements. The mapper retains the selected field’s later filing date, but FA exports omitted that metadata and the chart’s date selector did not explain that original vintages were not reconstructed.

Add one shared disclosure to FA, GF, and valuation views and their CLI reports. FA JSON now retains nullable statement `availableAt` and `fieldAvailability` separately from fiscal-period evidence; unknown availability remains unknown. Chart warnings include the same notice once, while the visible body notice leaves changing errors and coverage warnings in the footer. The shared text report renderer prints explicit metadata notices once above its tables. Values, dates, selection and calculations are unchanged.

Validation after rebasing onto the observation-count and pane-padding fixes: 85 focused tests / 338 assertions and all six runtime typechecks pass. Regressions cover JSON availability preservation independently of fiscal-date evidence, unchanged selected values and timestamps in both date modes, and deduplicated CLI notices. Actual native before/after captures against base959cbcac verify FA and GF; native GE confirms the vintage notice and the existing missing-publication warning coexist. Actual CLI FA/GF/GE text displays the notice and JSON retains availability fields. A fresh combined native check preserves the full GE axis values (27.8x, 24.6x, 21.4x), GF axis labels, and the wrapped notice.

Primary evidence: [Microsoft 2017 annual report](https://www.microsoft.com/investor/reports/ar17/), [2018 annual report](https://www.microsoft.com/investor/reports/ar18/), and actual SEC CompanyFacts fetched through the app. A production chart-model replay of the live native-provider snapshot preserves FY2017 at96.571B with observedAt2017-06-30 and availableAt2018-08-03; only the selected timestamp mode changes the plotted date.

Limits: this discloses snapshot coverage; it does not add original-vintage/as-of reconstruction, estimate history, survivorship handling or verified intraday publication times. The rebased change preserves the separate observation-count coverage metadata and explicit incomplete-report status. Provider depth remains a separate limitation. No release or version changes. Hold merge for root review.
