### PR TITLE
Keep terminal focus borders from hiding numeric values

### DIFF
--- a/src/components/layout/pane/sizing.test.ts
+++ b/src/components/layout/pane/sizing.test.ts
@@ -38,6 +38,7 @@ describe("pane sizing", () => {
       height: 28,
       flexGrow: 0,
       flexBasis: undefined,
+      paddingX: 1,
     });
   });
 });

--- a/src/components/layout/pane/sizing.ts
+++ b/src/components/layout/pane/sizing.ts
@@ -41,6 +41,9 @@ function getPaneBodyLayoutProps(nativePaneChrome: boolean | undefined, bodyHeigh
     height: bodyHeight,
     flexGrow: bodyHeight == null ? 1 : 0,
     flexBasis: bodyHeight == null ? 0 : undefined,
+    // Terminal focus borders occupy the outer columns. Keep every pane's
+    // content inside them, including while focus moves between panes.
+    paddingX: 1,
   };
 }
 
@@ -71,5 +74,5 @@ export function resolvePaneBodyFrame({
 
 function resolvePaneBodyWidth(width: number, nativePaneChrome: boolean | undefined): number {
   const finiteWidth = Number.isFinite(width) ? width : 1;
-  return nativePaneChrome ? Math.max(1, finiteWidth) : Math.max(1, Math.floor(finiteWidth));
+  return nativePaneChrome ? Math.max(1, finiteWidth) : Math.max(1, Math.floor(finiteWidth) - 2);
 }

--- a/src/components/layout/shell/index.test.tsx
+++ b/src/components/layout/shell/index.test.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../../state/app/context";
 import { TICKER_RESEARCH_PANE_ID, cloneLayout, createDefaultConfig, type LayoutConfig } from "../../../types/config";
 import type { PaneProps } from "../../../types/plugin";
-import { Textarea } from "../../../ui";
+import { Text, Textarea } from "../../../ui";
 import { TransientLayoutProvider, useTransientLayout, type TransientLayoutState } from "../transient-layout";
 import { resolvePaneFocusSourceLayout } from "./fullscreen";
 import {
@@ -162,6 +162,30 @@ function findUpdateLayout(actions: ShellTestAction[]) {
 }
 
 describe("Shell", () => {
+  test.each([false, true])("keeps both numeric edges visible under terminal focus borders (floating=%s)", async (floating) => {
+    const config = createDefaultConfig("/tmp/gloomberb-pane-border-test");
+    const main = requireLayoutInstance(config, "portfolio-list:main");
+    const detail = requireLayoutInstance(config, "ticker-detail:main");
+    const layout: LayoutConfig = {
+      dockRoot: { kind: "pane", instanceId: main.instanceId },
+      instances: floating ? [main, detail] : [main],
+      floating: floating ? [{ instanceId: detail.instanceId, x: 4, y: 2, width: 50, height: 12 }] : [],
+      detached: [],
+    };
+    let contentWidth = 0;
+    const EdgeValues = ({ width }: PaneProps) => {
+      contentWidth = width;
+      return <Text>{`49.6%${".".repeat(Math.max(0, width - 10))}-8.5%`}</Text>;
+    };
+    const registry = createShellPluginRegistry(floating
+      ? { tickerDetailComponent: EdgeValues }
+      : { portfolioListComponent: EdgeValues });
+    await renderShellForWindowModeTest(createShellStateWithLayout(config, layout, floating ? detail.instanceId : main.instanceId), { registry });
+    await testSetup!.renderOnce();
+    expect(contentWidth).toBe((floating ? 50 : 80) - 2);
+    expect(testSetup!.captureCharFrame()).toContain(`49.6%${".".repeat(contentWidth - 10)}-8.5%`);
+  });
+
   test("uses the desktop titlebar overlay height for shell chrome math", () => {
     expect(resolveAppHeaderHeightCells({ titleBarOverlay: true, cellHeightPx: 18 })).toBe(28 / 18);
     expect(resolveAppHeaderHeightCells({ titleBarOverlay: false, cellHeightPx: 18 })).toBe(1);


### PR DESCRIPTION
Focused terminal panes painted their side borders over the first and last content columns. This hid numeric signs/digits: an actual MSFT margin chart displayed 9.6% instead of 49.6%, and edge-aligned table values were vulnerable too.

Reserve one content column on each side in the shared terminal pane frame and pass the resulting inner width to pane content. This applies consistently to docked, floating and detached panes without resizing content when focus changes. Browser/desktop flex sizing is preserved.

Validated with 204 focused layout/chart tests (1,175 assertions), including full numeric rows at both edges of focused docked/floating panes. Actual terminal captures at 140×44 and 80×30 reproduce the lost digit before and show the full percentage after. No release or version bump.
