### PR TITLE
Keep daily and after-hours quote returns distinct

### DIFF
--- a/src/cli/commands/ticker.ts
+++ b/src/cli/commands/ticker.ts
@@ -261,13 +261,13 @@ export async function buildTickerReport({
   appendMetricSection(lines, "Extended Hours", [
     ["Pre-Market", quote.preMarketPrice != null
       ? colorBySign(
-        `${formatMarketPriceWithCurrency(quote.preMarketPrice, quote.currency, { assetCategory: tickerFile?.metadata.assetCategory })} (${formatSignedPercentRaw(quote.preMarketChangePercent ?? 0)})`,
+        `${formatMarketPriceWithCurrency(quote.preMarketPrice, quote.currency, { assetCategory: tickerFile?.metadata.assetCategory })} (${quote.preMarketChangePercent != null ? formatSignedPercentRaw(quote.preMarketChangePercent) : "—"})`,
         quote.preMarketChange ?? 0,
       )
       : "—"],
     ["After Hours", quote.postMarketPrice != null
       ? colorBySign(
-        `${formatMarketPriceWithCurrency(quote.postMarketPrice, quote.currency, { assetCategory: tickerFile?.metadata.assetCategory })} (${formatSignedPercentRaw(quote.postMarketChangePercent ?? 0)})`,
+        `${formatMarketPriceWithCurrency(quote.postMarketPrice, quote.currency, { assetCategory: tickerFile?.metadata.assetCategory })} (${quote.postMarketChangePercent != null ? formatSignedPercentRaw(quote.postMarketChangePercent) : "—"})`,
         quote.postMarketChange ?? 0,
       )
       : "—"],

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -14,7 +14,7 @@ export function formatSignedCurrency(value: number, currency: string): string {
   return value > 0 ? `+${formatCurrency(value, currency)}` : formatCurrency(value, currency);
 }
 
-export function formatSignedPercentRaw(value: number): string {
+export function formatSignedPercentRaw(value: number | undefined): string {
   return formatPercentRaw(value);
 }
 

--- a/src/components/layout/market-summary.ts
+++ b/src/components/layout/market-summary.ts
@@ -87,7 +87,7 @@ export function useMarketSummary(): MarketSummary {
   }, [appActive]);
 
   const activeSpyQuote = getActiveQuoteDisplay(spyQuote);
-  const spyColor = activeSpyQuote ? priceColor(activeSpyQuote.change, colors) : colors.textDim;
+  const spyColor = activeSpyQuote?.change != null ? priceColor(activeSpyQuote.change, colors) : colors.textDim;
   const spyText = activeSpyQuote
     ? `SPY ${formatMarketPrice(activeSpyQuote.price, { assetCategory: "ETF" })} ${formatPercentRaw(activeSpyQuote.changePercent)}`
     : "SPY —";

--- a/src/market-data/market/status.test.ts
+++ b/src/market-data/market/status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { marketStateCountdown } from "./status";
+import { getActiveQuoteDisplay, marketStateCountdown } from "./status";
 
 describe("marketStateCountdown", () => {
   test("adds precision as the US session boundary approaches", () => {
@@ -9,4 +9,18 @@ describe("marketStateCountdown", () => {
     expect(marketStateCountdown("REGULAR", Date.parse("2026-08-18T19:00:00Z"))).toBe("1h");
     expect(marketStateCountdown("REGULAR", Date.parse("2026-08-18T19:50:42Z"))).toBe("9m 18s");
   });
+});
+
+
+test("active after-hours price keeps daily change against previous close, including a regular-only primary quote", () => {
+  const quote = { symbol: "NVDA", currency: "USD", price: 218.36, change: -5.31, changePercent: -2.374,
+    previousClose: 223.67, marketState: "POST" as const, postMarketPrice: 218.47,
+    postMarketChange: 0.11, postMarketChangePercent: 0.0503755266532, lastUpdated: 1789072245412 };
+  const active = getActiveQuoteDisplay(quote)!;
+  expect(active.price).toBe(218.47);
+  expect(active.change).toBeCloseTo(-5.2, 8);
+  expect(active.changePercent).toBeCloseTo(-2.324853578933245, 8);
+  for (const previousClose of [undefined, 0, Number.NaN]) {
+    expect(getActiveQuoteDisplay({ ...quote, previousClose })).toEqual({ price: 218.47, change: undefined, changePercent: undefined });
+  }
 });

--- a/src/market-data/market/status.ts
+++ b/src/market-data/market/status.ts
@@ -16,8 +16,8 @@ const CLOSING_COUNTDOWN_WINDOW_SECONDS = 60 * 60;
 
 export interface ActiveQuoteDisplay {
   price: number;
-  change: number;
-  changePercent: number;
+  change?: number;
+  changePercent?: number;
 }
 
 export function marketStateLabel(state: MarketState): string {
@@ -85,12 +85,13 @@ function isClosedMarketState(state?: MarketState): boolean {
 }
 
 /** Closed prices are final snapshots, so they should not look live or directional. */
-export function marketPriceColor(change: number, state?: MarketState): string {
-  return isClosedMarketState(state) ? colors.textDim : priceColor(change);
+export function marketPriceColor(change: number | undefined, state?: MarketState): string {
+  return change == null || isClosedMarketState(state) ? colors.textDim : priceColor(change);
 }
 
 /** Preserve a closed session's direction while visually distinguishing it from a live move. */
-export function marketChangeColor(change: number, state?: MarketState): string {
+export function marketChangeColor(change: number | undefined, state?: MarketState): string {
+  if (change == null) return colors.textDim;
   const directionalColor = priceColor(change);
   if (!isClosedMarketState(state) || change === 0) return directionalColor;
   return blendHex(directionalColor, colors.textDim, CLOSED_CHANGE_MUTING_RATIO);
@@ -126,22 +127,17 @@ export function exchangeShortName(exchangeName?: string, fullExchangeName?: stri
 export function getActiveQuoteDisplay(quote: Quote | null | undefined): ActiveQuoteDisplay | null {
   if (!quote) return null;
   if ((quote.marketState === "PRE" || quote.marketState === "PREPRE") && quote.preMarketPrice != null) {
-    return {
-      price: quote.preMarketPrice,
-      change: quote.preMarketChange ?? 0,
-      changePercent: quote.preMarketChangePercent ?? 0,
-    };
+    return { price: quote.preMarketPrice, change: quote.preMarketChange, changePercent: quote.preMarketChangePercent };
   }
-  if ((quote.marketState === "POST" || quote.marketState === "POSTPOST") && quote.postMarketPrice != null) {
-    return {
-      price: quote.postMarketPrice,
-      change: quote.postMarketChange ?? 0,
-      changePercent: quote.postMarketChangePercent ?? 0,
-    };
+  const extendedPrice = (quote.marketState === "POST" || quote.marketState === "POSTPOST") ? quote.postMarketPrice : undefined;
+  if (extendedPrice != null) {
+    // Generic quote/day-P&L views use the daily reference, while the separate
+    // extended-hours row uses the completed regular session as its reference.
+    const previousClose = quote.previousClose;
+    const change = previousClose != null && Number.isFinite(previousClose) && previousClose > 0
+      ? extendedPrice - previousClose : undefined;
+    return { price: extendedPrice, change,
+      changePercent: change != null ? (change / previousClose!) * 100 : undefined };
   }
-  return {
-    price: quote.price,
-    change: quote.change,
-    changePercent: quote.changePercent,
-  };
+  return { price: quote.price, change: quote.change, changePercent: quote.changePercent };
 }

--- a/src/market-data/quotes/contributions.ts
+++ b/src/market-data/quotes/contributions.ts
@@ -69,8 +69,9 @@ export function finalizeSessionFields(
       preMarketChange: undefined,
       preMarketChangePercent: undefined,
       postMarketPrice: quote.postMarketPrice ?? (canProjectSessionPrice ? quote.price : undefined),
-      postMarketChange: quote.postMarketChange ?? (canProjectSessionPrice ? quote.change : undefined),
-      postMarketChangePercent: quote.postMarketChangePercent ?? (canProjectSessionPrice ? quote.changePercent : undefined),
+      // A daily move uses the previous day's close, not the after-hours baseline.
+      postMarketChange: quote.postMarketChange,
+      postMarketChangePercent: quote.postMarketChangePercent,
     };
   }
 
@@ -128,6 +129,10 @@ export function mergeQuoteContribution(
   const merged: QuoteContribution = {
     ...current,
     ...reconcileQuoteDayRange(next, current),
+    // Close provenance belongs to this observation; never borrow an anchor
+    // from another session, listing or currency when a new quote omits it.
+    regularClose: next.regularClose,
+    regularCloseSessionDate: next.regularClose != null ? next.regularCloseSessionDate : undefined,
   };
 
   if (next.marketState == null && current.marketState != null) {
@@ -146,8 +151,9 @@ export function mergeQuoteContribution(
       merged.preMarketChangePercent = next.preMarketChangePercent ?? (canProjectNextSessionPrice ? next.changePercent : current.preMarketChangePercent);
     } else {
       merged.postMarketPrice = next.postMarketPrice ?? (canProjectNextSessionPrice ? next.price : current.postMarketPrice);
-      merged.postMarketChange = next.postMarketChange ?? (canProjectNextSessionPrice ? next.change : current.postMarketChange);
-      merged.postMarketChangePercent = next.postMarketChangePercent ?? (canProjectNextSessionPrice ? next.changePercent : current.postMarketChangePercent);
+      const changesPostPrice = next.postMarketPrice != null || canProjectNextSessionPrice;
+      merged.postMarketChange = next.postMarketChange ?? (changesPostPrice ? undefined : current.postMarketChange);
+      merged.postMarketChangePercent = next.postMarketChangePercent ?? (changesPostPrice ? undefined : current.postMarketChangePercent);
     }
   }
 

--- a/src/market-data/quotes/resolution.test.ts
+++ b/src/market-data/quotes/resolution.test.ts
@@ -5,7 +5,7 @@ import {
   resolveTickerFinancialsQuoteState,
   upsertQuoteContributionMap,
 } from "./resolution";
-import { normalizeQuoteContribution } from "./contributions";
+import { mergeQuoteContribution, normalizeQuoteContribution } from "./contributions";
 
 describe("quote-resolution", () => {
   test("keeps actual trade price and timestamp paired with the selected price provider", () => {
@@ -517,4 +517,44 @@ describe("quote-resolution", () => {
     expect(financials?.quote?.marketState).toBeUndefined();
     expect(financials?.quote?.provenance?.price?.providerId).toBe("ibkr");
   });
+});
+
+
+test("live after-hours prices never inherit the daily loss as their session return", () => {
+  const base = { symbol: "NVDA", providerId: "gloomberb-cloud", dataSource: "live" as const,
+    marketState: "POST" as const, price: 218.47, currency: "USD", previousClose: 223.67,
+    change: -5.2, changePercent: -2.324853578933245,
+    exchangeName: "NASDAQ", lastUpdated: Date.parse("2026-09-10T20:30:00Z") };
+  const noClose = normalizeQuoteContribution(base)!;
+  expect(noClose.postMarketPrice).toBe(218.47);
+  expect(noClose.postMarketChange).toBeUndefined();
+  expect(noClose.postMarketChangePercent).toBeUndefined();
+  const reported = normalizeQuoteContribution({ ...base, regularClose: 218.36, regularCloseSessionDate: "2026-09-10",
+    postMarketPrice: 218.47, postMarketChange: 0.11, postMarketChangePercent: 0.0503755266532 })!;
+  const canonical = resolveCanonicalQuote({ cloud: reported }, base.lastUpdated).quote!;
+  expect(canonical.change).toBeCloseTo(-5.2, 8);
+  expect(canonical.postMarketChange).toBe(0.11);
+  expect(canonical.regularClose).toBe(218.36);
+  for (const change of [{}, { currency: "EUR" }, { symbol: "ASML", exchangeName: "AMS" },
+    { lastUpdated: base.lastUpdated + 86400000 }]) {
+    const next = mergeQuoteContribution(reported, { ...base, ...change, marketState: undefined, price: 219 });
+    expect(next.postMarketPrice).toBe(219);
+    expect(next.postMarketChange).toBeUndefined();
+    expect(next.postMarketChangePercent).toBeUndefined();
+    expect(next.regularClose).toBeUndefined();
+    expect(next.regularCloseSessionDate).toBeUndefined();
+  }
+});
+
+test("a different price provider cannot inherit a closing-price anchor", () => {
+  const now = Date.parse("2026-09-10T20:30:00Z");
+  const result = resolveCanonicalQuote({
+    cloud: { symbol: "NVDA", providerId: "gloomberb-cloud", dataSource: "delayed", price: 218.47, currency: "USD",
+      change: -5.2, changePercent: -2.32, lastUpdated: now - 900000, regularClose: 218.36, regularCloseSessionDate: "2026-09-10" },
+    ibkr: { symbol: "NVDA", providerId: "ibkr", dataSource: "live", price: 219, currency: "USD",
+      change: -4.67, changePercent: -2.08, lastUpdated: now },
+  }, now).quote!;
+  expect(result.price).toBe(219);
+  expect(result.regularClose).toBeUndefined();
+  expect(result.regularCloseSessionDate).toBeUndefined();
 });

--- a/src/market-data/quotes/resolution.ts
+++ b/src/market-data/quotes/resolution.ts
@@ -442,6 +442,8 @@ export function resolveCanonicalQuote(
     change: Number(resolved.change ?? priceProvider?.change ?? 0),
     changePercent: Number(resolved.changePercent ?? priceProvider?.changePercent ?? 0),
     previousClose: resolved.previousClose as Quote["previousClose"],
+    regularClose: priceProvider?.regularClose,
+    regularCloseSessionDate: priceProvider?.regularClose != null ? priceProvider.regularCloseSessionDate : undefined,
     changeSessionDate: resolved.changeSessionDate as Quote["changeSessionDate"],
     high52w: resolved.high52w as Quote["high52w"],
     low52w: resolved.low52w as Quote["low52w"],

--- a/src/plugins/builtin/alerts/quotes.ts
+++ b/src/plugins/builtin/alerts/quotes.ts
@@ -28,8 +28,8 @@ export async function resolveAlertQuote(
   return {
     ...quote,
     price: display.price,
-    change: display.change,
-    changePercent: display.changePercent,
+    change: display.change ?? Number.NaN,
+    changePercent: display.changePercent ?? Number.NaN,
   };
 }
 

--- a/src/plugins/builtin/portfolio-list/column-values.ts
+++ b/src/plugins/builtin/portfolio-list/column-values.ts
@@ -296,11 +296,13 @@ export function getColumnValue(
       };
     case "ext_hours":
       if ((quote?.marketState === "PRE" || quote?.marketState === "PREPRE") && quote.preMarketPrice != null) {
-        const changePercent = activeQuote?.changePercent ?? quote.preMarketChangePercent ?? 0;
+        const changePercent = quote.preMarketChangePercent;
+        if (!finiteNumber(changePercent)) return { text: "—" };
         return { text: formatPercentRaw(changePercent), color: priceColor(changePercent) };
       }
       if ((quote?.marketState === "POST" || quote?.marketState === "POSTPOST") && quote.postMarketPrice != null) {
-        const changePercent = activeQuote?.changePercent ?? quote.postMarketChangePercent ?? 0;
+        const changePercent = quote.postMarketChangePercent;
+        if (!finiteNumber(changePercent)) return { text: "—" };
         return { text: formatPercentRaw(changePercent), color: priceColor(changePercent) };
       }
       return { text: "—" };
@@ -328,7 +330,7 @@ export function getColumnValue(
       return { text: formatPercentRaw((marketValue / ctx.portfolioTotalMarketValue) * 100) };
     }
     case "day_pnl":
-      if (activeQuote && positionMetrics.grossPriceUnits !== 0) {
+      if (activeQuote && finiteNumber(activeQuote.change) && positionMetrics.grossPriceUnits !== 0) {
         const dayPnl = toBaseQuote(totalPriceUnits * activeQuote.change);
         return { text: `${dayPnl >= 0 ? "+" : ""}${formatCompact(dayPnl)}`, color: priceColor(dayPnl) };
       }
@@ -476,7 +478,7 @@ export function getSortValue(
         ? (quote?.bidSize ?? 0) + (quote?.askSize ?? 0)
         : null;
     case "change":
-      return activeQuote ? activeQuote.change : null;
+      return activeQuote?.change ?? null;
     case "change_pct":
       return activeQuote?.changePercent ?? null;
     case "volume":
@@ -500,10 +502,10 @@ export function getSortValue(
       return fundamentals?.dividendYield ?? null;
     case "ext_hours":
       if ((quote?.marketState === "PRE" || quote?.marketState === "PREPRE") && quote.preMarketPrice != null) {
-        return activeQuote?.changePercent ?? quote.preMarketChangePercent ?? 0;
+        return quote.preMarketChangePercent ?? null;
       }
       if ((quote?.marketState === "POST" || quote?.marketState === "POSTPOST") && quote.postMarketPrice != null) {
-        return activeQuote?.changePercent ?? quote.postMarketChangePercent ?? 0;
+        return quote.postMarketChangePercent ?? null;
       }
       return null;
     case "side":
@@ -529,7 +531,7 @@ export function getSortValue(
         : null;
     }
     case "day_pnl":
-      if (activeQuote && positionMetrics.grossPriceUnits !== 0) {
+      if (activeQuote && finiteNumber(activeQuote.change) && positionMetrics.grossPriceUnits !== 0) {
         return toBaseQuote(totalPriceUnits * activeQuote.change);
       }
       return null;

--- a/src/plugins/builtin/portfolio-list/metrics.test.ts
+++ b/src/plugins/builtin/portfolio-list/metrics.test.ts
@@ -489,3 +489,23 @@ describe("position aggregation across sides, currencies and broker coverage", ()
     expect(getSortValue(column("pnl"), ticker, undefined, defaultColumnContext)).toBeNull();
   });
 });
+
+
+test("portfolio daily P&L and extended-hours returns use distinct reference closes", () => {
+  const ticker = createTicker({ positions: [{ portfolio: "main", shares: 10, avgCost: 200, broker: "manual" }] });
+  const financials = createFinancials({ quote: { price: 218.36, previousClose: 223.67,
+    change: -5.31, changePercent: -2.374, marketState: "POST", postMarketPrice: 218.47,
+    postMarketChange: 0.11, postMarketChangePercent: 0.0503755266532 } });
+  const column = (id: string): ColumnConfig => ({ id, label: id, width: 15, align: "right" });
+  expect(getSortValue(column("day_pnl"), ticker, financials, defaultColumnContext)).toBeCloseTo(-52, 8);
+  expect(getColumnValue(column("change_pct"), ticker, financials, defaultColumnContext).text).toBe("-2.32%");
+  expect(getColumnValue(column("ext_hours"), ticker, financials, defaultColumnContext).text).toBe("+0.05%");
+  expect(calculatePortfolioSummaryTotals([ticker], new Map([["AAPL", financials]]), "USD", new Map([["USD", 1]]), true, "main").dailyPnl).toBeCloseTo(-52, 8);
+  delete financials.quote!.previousClose;
+  expect(getColumnValue(column("day_pnl"), ticker, financials, defaultColumnContext).text).toBe("—");
+  expect(getSortValue(column("day_pnl"), ticker, financials, defaultColumnContext)).toBeNull();
+  expect(calculatePortfolioSummaryTotals([ticker], new Map([["AAPL", financials]]), "USD", new Map([["USD", 1]]), true, "main").dailyPnl).toBeNaN();
+  delete financials.quote!.postMarketChangePercent;
+  expect(getColumnValue(column("ext_hours"), ticker, financials, defaultColumnContext).text).toBe("—");
+  expect(getSortValue(column("ext_hours"), ticker, financials, defaultColumnContext)).toBeNull();
+});

--- a/src/plugins/builtin/portfolio-list/summary/totals.ts
+++ b/src/plugins/builtin/portfolio-list/summary/totals.ts
@@ -58,8 +58,8 @@ export function calculatePortfolioSummaryTotals(
     const quoteCurrency = quote?.currency || ticker.metadata.currency || "USD";
 
     if (!isPortfolio) {
-      if (quote?.changePercent != null) {
-        watchlistChangeSum += quote.changePercent;
+      if (activeQuote?.changePercent != null) {
+        watchlistChangeSum += activeQuote.changePercent;
         watchlistCount++;
       }
       continue;
@@ -77,7 +77,7 @@ export function calculatePortfolioSummaryTotals(
     const toBaseQuote = (value: number) => toBase(value, quoteCurrency);
 
     if (quote && activeQuote) {
-      const previousClose = quote.previousClose ?? (activeQuote.price - activeQuote.change);
+      const previousClose = activeQuote.change != null ? activeQuote.price - activeQuote.change : Number.NaN;
       totalMktValue += toBaseQuote(grossPriceUnits * activeQuote.price);
       netMktValue += toBaseQuote(totalPriceUnits * activeQuote.price);
       totalPrevValue += toBaseQuote(grossPriceUnits * previousClose);

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -170,7 +170,7 @@ export function OverviewTab({
                   {formatMarketPriceWithCurrency(quote.preMarketPrice, quote.currency, { assetCategory: ticker.metadata.assetCategory })}
                 </Text>
                 <Text fg={priceColor(quote.preMarketChange ?? 0)}>
-                  {formatSignedMarketPrice(quote.preMarketChange ?? 0, { assetCategory: ticker.metadata.assetCategory })} ({formatPercentRaw(quote.preMarketChangePercent ?? 0)})
+                  {formatSignedMarketPrice(quote.preMarketChange, { assetCategory: ticker.metadata.assetCategory })} ({formatPercentRaw(quote.preMarketChangePercent)})
                 </Text>
               </Box>
             )}
@@ -181,7 +181,7 @@ export function OverviewTab({
                   {formatMarketPriceWithCurrency(quote.postMarketPrice, quote.currency, { assetCategory: ticker.metadata.assetCategory })}
                 </Text>
                 <Text fg={priceColor(quote.postMarketChange ?? 0)}>
-                  {formatSignedMarketPrice(quote.postMarketChange ?? 0, { assetCategory: ticker.metadata.assetCategory })} ({formatPercentRaw(quote.postMarketChangePercent ?? 0)})
+                  {formatSignedMarketPrice(quote.postMarketChange, { assetCategory: ticker.metadata.assetCategory })} ({formatPercentRaw(quote.postMarketChangePercent)})
                 </Text>
               </Box>
             )}

--- a/src/sources/gloomberb-cloud/normalizers.test.ts
+++ b/src/sources/gloomberb-cloud/normalizers.test.ts
@@ -8,6 +8,8 @@ describe("mapCloudFinancials", () => {
         symbol: "VOD",
         price: 23.1,
         currency: "GBp",
+        regularClose: 23,
+        regularCloseSessionDate: "2026-05-12",
         change: 1,
         changePercent: 4.5,
         lastUpdated: Date.parse("2026-05-13T15:00:00Z"),
@@ -28,6 +30,8 @@ describe("mapCloudFinancials", () => {
 
     expect(financials.quote?.currency).toBe("GBP");
     expect(financials.quote?.price).toBeCloseTo(0.231);
+    expect(financials.quote?.regularClose).toBeCloseTo(0.23);
+    expect(financials.quote?.regularCloseSessionDate).toBe("2026-05-12");
     expect(financials.priceHistory[0]?.close).toBeCloseTo(0.231);
     expect(financials.priceHistory[0]?.date.toISOString()).toBe("2026-05-13T09:15:00.000Z");
   });

--- a/src/sources/gloomberb-cloud/normalizers.ts
+++ b/src/sources/gloomberb-cloud/normalizers.ts
@@ -45,6 +45,7 @@ export function mapQuote(
     price: normalizePriceValueByDivisor(quote.price, divisor) ?? quote.price,
     change: normalizePriceValueByDivisor(quote.change, divisor) ?? quote.change,
     previousClose: normalizePriceValueByDivisor(quote.previousClose, divisor),
+    regularClose: normalizePriceValueByDivisor(quote.regularClose, divisor),
     high52w: normalizePriceValueByDivisor(quote.high52w, divisor),
     low52w: normalizePriceValueByDivisor(quote.low52w, divisor),
     bid: normalizePriceValueByDivisor(quote.bid, divisor),

--- a/src/types/financials.ts
+++ b/src/types/financials.ts
@@ -29,6 +29,10 @@ export interface Quote {
   change: number;
   changePercent: number;
   previousClose?: number;
+  /** Official close of a completed regular session, in this quote's currency. */
+  regularClose?: number;
+  /** Exchange-local date of regularClose; separate from the daily previous-close reference. */
+  regularCloseSessionDate?: string;
   /** Provider's exchange-local session date for the daily quote reference. */
   changeSessionDate?: string;
   high52w?: number;


### PR DESCRIPTION
An after-hours price could inherit the quote's full-day move, making NVDA's small after-hours gain appear as a −2.32% loss. Remove that fallback and display unavailable session returns as em dashes. Preserve the additive regular-close reference and its date in the quote's currency without borrowing another provider's anchor.

Generic price/day-change views and portfolio day P&L now compare the active POST price with `previousClose`; the Ext Hours column alone uses the completed regular session's delta. An unavailable daily reference leaves daily returns and P&L unavailable. This also handles providers that keep the regular close in the primary price while supplying a separate POST price.

Validation: 98 focused tests / 464 assertions, all six TypeScript projects, web build. A browser and real tmux OpenTUI replay of a captured live Alpaca NVDA snapshot shows daily −$5.20 (−2.32%) alongside after-hours +$0.1102 (+0.05%); removing the close reference shows — rather than zero. The production API before capture and independent Yahoo/Alpaca source payloads are retained locally in `persona-audit/extended-delta-evidence/` and `persona-audit/reproducibility-evidence/`.

Paired with the backend regular-close calculation fix. Browser/native after proof is an explicitly controlled replay of real provider data; the production fix has not yet been deployed. Held for review, no release.
