### PR TITLE
Preserve unknown financial field publication dates

### DIFF
--- a/src/sources/provider-router/cache.test.ts
+++ b/src/sources/provider-router/cache.test.ts
@@ -22,3 +22,22 @@ test("refreshes legacy SEC annual caches without discarding unrelated data and a
   expect(read("financials").find((row) => row.sourceKey === "provider:yahoo")?.value).toEqual(repaired);
   persistence.close();
 });
+
+test("refreshes schema-two quarterly availability while retaining undated statements and unrelated cached data", () => {
+  const persistence = new AppPersistence(createTempDbPath("field-availability-cache-version"));
+  const key = { namespace: "market", kind: "financials", entityKey: "MSFT", variantKey: "exchange=NASDAQ", sourceKey: "provider:yahoo" };
+  const cachePolicy = { staleMs: 60_000, expireMs: 120_000 };
+  const unsafe = makeFinancials({ annualStatements: [], quarterlyStatements: [{ date: "2025-12-31", totalRevenue: 100, grossProfit: 40,
+    availableAt: "2026-04-01", fieldAvailability: { totalRevenue: "2026-04-01", grossProfit: "2026-02-01" } }] });
+  persistence.resources.set(key, unsafe, { cachePolicy, schemaVersion: 2 });
+  persistence.resources.set({ ...key, sourceKey: "provider:gloomberb-cloud" }, makeFinancials({ annualStatements: [], quarterlyStatements: [{ date: "2025-12-31", totalRevenue: 100 }] }), { cachePolicy, schemaVersion: 2 });
+  persistence.resources.set({ ...key, kind: "quote" }, makeQuote({ symbol: "MSFT" }), { cachePolicy, schemaVersion: 2 });
+  const read = (kind: string) => listCachedResources(persistence.resources, kind, "MSFT", [key.variantKey], [key.sourceKey, "provider:gloomberb-cloud"], true);
+  expect(read("financials").map((row) => row.sourceKey)).toEqual(["provider:gloomberb-cloud"]);
+  expect(read("quote")).toHaveLength(1);
+  const repaired = makeFinancials({ annualStatements: [], quarterlyStatements: [{ date: "2025-12-31", totalRevenue: 100, grossProfit: 40,
+    fieldAvailability: { grossProfit: "2026-02-01" } }] });
+  cacheRouterResource(persistence.resources, "financials", "MSFT", key.variantKey, key.sourceKey, repaired, cachePolicy);
+  expect(read("financials").find((record) => record.sourceKey === key.sourceKey)?.value).toEqual(repaired);
+  persistence.close();
+});

--- a/src/sources/provider-router/cache.ts
+++ b/src/sources/provider-router/cache.ts
@@ -7,7 +7,7 @@ import { canonicalExchange } from "../../utils/exchanges";
 import { isPriceHistoryStaleForCurrentWindow } from "../../utils/price-history";
 
 const MARKET_NAMESPACE = "market";
-const FINANCIALS_SCHEMA_VERSION = 2;
+const FINANCIALS_SCHEMA_VERSION = 3;
 
 const DEFAULT_CACHE_POLICIES = {
   brokerQuote: { staleMs: 15_000, expireMs: 15 * 60_000 },
@@ -146,11 +146,13 @@ export function listCachedResources<T>(
     allowExpired,
   }).filter((record) => {
     if (kind !== "financials" || record.schemaVersion >= FINANCIALS_SCHEMA_VERSION) return true;
-    // Legacy SEC-supplemented annuals mixed quarter facts and fallback
-    // concepts. Their period durations cannot be reconstructed from cache.
-    // Refresh those records; unrelated quote/history/company caches remain usable.
+    // Earlier merges could date unknown fields from a partial availability map,
+    // in addition to the older SEC annual/concept errors. Cached dates cannot
+    // distinguish inferred metadata from source evidence; refresh dated rows.
+    // Unrelated quote/history/company and undated financial caches remain usable.
     const value = record.value as TickerFinancials;
-    return !value.annualStatements?.some((row) => row.availableAt || Object.keys(row.fieldAvailability ?? {}).length > 0);
+    return ![...(value.annualStatements ?? []), ...(value.quarterlyStatements ?? [])]
+      .some((row) => row.availableAt || Object.keys(row.fieldAvailability ?? {}).length > 0);
   });
   if (records.length === 0) return [];
 

--- a/src/time-series/fundamentals.test.ts
+++ b/src/time-series/fundamentals.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { FinancialStatement, TickerFinancials } from "../types/financials";
 import { alignTimeSeries } from "./alignment";
 import { extractFredSeries } from "./economic";
-import { deriveQuarterlyStatements, extractFundamentalSeries } from "./fundamentals";
+import { deriveQuarterlyStatements, extractFundamentalSeries, fundamentalSeriesUsesAvailabilityFallback } from "./fundamentals";
 import type { ResolvedSeries, SecuritySeriesSource } from "./types";
 
 const DAY = 24 * 60 * 60 * 1_000;
@@ -327,20 +327,25 @@ describe("fundamental series extraction", () => {
     expect(points[0]?.availableAt?.toISOString().slice(0, 10)).toBe("2025-02-01");
   });
 
-  test("falls back to row availability only for a dependency without field provenance", () => {
-    const points = extractFundamentalSeries(
-      financials([], [{
-        date: "2024-12-31",
-        availableAt: "2025-04-01",
-        fieldAvailability: { grossProfit: "2025-02-01" },
-        grossProfit: 40,
-        totalRevenue: 100,
-      }]),
-      source("fundamental.grossMargin", "annual"),
-    );
-
-    expect(points[0]?.value).toBe(40);
-    expect(points[0]?.date.toISOString().slice(0, 10)).toBe("2025-04-01");
+  test("partial field maps cannot date unknown metrics or their derived dependencies", () => {
+    const statement = { date: "2024-12-31", availableAt: "2025-04-01", grossProfit: 40, totalRevenue: 100 };
+    for (const fieldAvailability of [{ grossProfit: "2025-02-01" }, {}, { grossProfit: "2025-02-01", totalRevenue: "invalid" }]) {
+      for (const availableAt of [undefined, statement.availableAt]) {
+        const snapshot = financials([], [{ ...statement, availableAt, fieldAvailability }]);
+        for (const [field, value] of [["totalRevenue", 100], ["grossMargin", 40]] as const) {
+          const definition = source(`fundamental.${field}`, "annual");
+          const [point] = extractFundamentalSeries(snapshot, definition);
+          expect(point?.value).toBe(value);
+          expect(point?.availableAt).toBeUndefined();
+          expect(point?.date.toISOString().slice(0, 10)).toBe(statement.date);
+          expect(fundamentalSeriesUsesAvailabilityFallback(snapshot, definition)).toBe(true);
+        }
+      }
+    }
+    // Legacy rows with no per-field map still declare a date for the complete row.
+    const [legacy] = extractFundamentalSeries(financials([], [statement]), source("fundamental.grossMargin", "annual"));
+    expect(legacy?.value).toBe(40);
+    expect(legacy?.availableAt?.toISOString().slice(0, 10)).toBe(statement.availableAt);
   });
 
   test("tracks only the EPS branch actually used by historical PE", () => {
@@ -549,4 +554,29 @@ test("quarterly share averages derive from the annual average instead of copying
     { date: "2025-09-30", basicShares: 80 },
   ], [{ date: "2025-12-31", basicShares: 85 }]);
   expect(rows.at(-1)?.basicShares).toBe(70);
+});
+
+test("derived Q4 and TTM dates require every flow input while retaining dated balance snapshots", () => {
+  const quarters: FinancialStatement[] = [
+    { date: "2024-03-31", totalRevenue: 20, availableAt: "2024-05-01" },
+    { date: "2024-06-30", totalRevenue: 20 },
+    { date: "2024-09-30", totalRevenue: 20, availableAt: "2024-11-01" },
+  ];
+  const annual: FinancialStatement = {
+    date: "2024-12-31", totalRevenue: 100, totalAssets: 200, availableAt: "2025-02-01",
+  };
+  const q4 = deriveQuarterlyStatements(quarters, [annual]).at(-1)!;
+  expect(q4).toMatchObject({ totalRevenue: 40, totalAssets: 200, fieldAvailability: { totalAssets: "2025-02-01" } });
+  expect(q4.availableAt).toBeUndefined();
+  expect(q4.fieldAvailability?.totalRevenue).toBeUndefined();
+  const snapshot = financials(quarters, [annual]);
+  for (const [metric, value, availableAt] of [["totalRevenue", 100, undefined], ["totalAssets", 200, "2025-02-01"]] as const) {
+    const [point] = extractFundamentalSeries(snapshot, source(`fundamental.${metric}`, "ttm"));
+    expect(point?.value).toBe(value);
+    expect(point?.availableAt?.toISOString().slice(0, 10)).toBe(availableAt);
+  }
+  const known = financials(quarters.map((row, index) => index === 1 ? { ...row, availableAt: "2025-04-01" } : row), [annual]);
+  const [complete] = extractFundamentalSeries(known, source("fundamental.totalRevenue", "ttm"));
+  expect(complete?.value).toBe(100);
+  expect(complete?.availableAt?.toISOString().slice(0, 10)).toBe("2025-04-01");
 });

--- a/src/time-series/fundamentals.ts
+++ b/src/time-series/fundamentals.ts
@@ -3,7 +3,7 @@ import type {
   PricePoint,
   TickerFinancials,
 } from "../types/financials";
-import { areNearbyFinancialPeriodEnds } from "../utils/financial-statements";
+import { areNearbyFinancialPeriodEnds, completeAvailability, statementFieldAvailability } from "../utils/financial-statements";
 import { canonicalTimeSeriesFieldId } from "./field-catalog";
 import type { SecuritySeriesSource, SeriesPeriod, TimeSeriesPoint } from "./types";
 
@@ -112,17 +112,6 @@ function validDate(value: unknown): Date | null {
   return Number.isFinite(parsed.getTime()) ? parsed : null;
 }
 
-function latestDateString(values: Array<string | null | undefined>): string | undefined {
-  let latest: { value: string; time: number } | undefined;
-  for (const value of values) {
-    if (!value) continue;
-    const time = Date.parse(value);
-    if (!Number.isFinite(time)) continue;
-    if (!latest || time > latest.time) latest = { value, time };
-  }
-  return latest?.value;
-}
-
 function statementTime(statement: FinancialStatement): number {
   return Date.parse(statement.date);
 }
@@ -142,9 +131,15 @@ function setStatementNumber(
   statement.__timeSeriesDerivedFields = [
     ...new Set([...(statement.__timeSeriesDerivedFields ?? []), field]),
   ];
-  if (availableAt) {
-    statement.fieldAvailability = { ...statement.fieldAvailability, [field]: availableAt };
-  }
+  statement.fieldAvailability = { ...statement.fieldAvailability };
+  if (availableAt) statement.fieldAvailability[field] = availableAt;
+  else delete statement.fieldAvailability[field];
+}
+
+function completeStatementAvailability(statement: InternalStatement): string | undefined {
+  return completeAvailability(NUMERIC_STATEMENT_FIELDS
+    .filter((field) => statementNumber(statement, field) !== null)
+    .map((field) => statementFieldAvailability(statement, field)));
 }
 
 function periodCategory(date: string, period: "annual" | "quarterly"): string {
@@ -217,7 +212,7 @@ function mergeStatementPeriodGroup(statements: readonly InternalStatement[]): In
       return [{
         statement,
         value,
-        availableAt: statement.fieldAvailability?.[field] ?? statement.availableAt,
+        availableAt: statementFieldAvailability(statement, field),
         derived: statement.__timeSeriesDerivedFields?.includes(field) === true,
       }];
     });
@@ -228,10 +223,8 @@ function mergeStatementPeriodGroup(statements: readonly InternalStatement[]): In
     if (selected.derived) derivedFields.push(field);
   }
 
-  if (Object.keys(fieldAvailability).length > 0) {
-    merged.fieldAvailability = fieldAvailability;
-    merged.availableAt = latestDateString(Object.values(fieldAvailability));
-  }
+  merged.fieldAvailability = fieldAvailability;
+  merged.availableAt = completeStatementAvailability(merged);
   if (derivedFields.length > 0) merged.__timeSeriesDerivedFields = derivedFields;
   return merged;
 }
@@ -283,7 +276,7 @@ function precedingQuarterInputs(
         date: statement.date,
         time,
         value,
-        availableAt: statement.fieldAvailability?.[field] ?? statement.availableAt,
+        availableAt: statementFieldAvailability(statement, field),
       });
     }
   }
@@ -323,8 +316,8 @@ export function deriveQuarterlyStatements(
       const annualTotal = annualValue * (QUARTERLY_AVERAGE_FIELDS.includes(field) ? 4 : 1);
       const derived = annualTotal - previousInputs.reduce((sum, input) => sum + input.value, 0);
       if (!Number.isFinite(derived)) continue;
-      const availableAt = latestDateString([
-        annualStatement.fieldAvailability?.[field] ?? annualStatement.availableAt,
+      const availableAt = completeAvailability([
+        statementFieldAvailability(annualStatement, field),
         ...previousInputs.map((input) => input.availableAt),
       ]);
       setStatementNumber(target, field, derived, availableAt);
@@ -335,17 +328,13 @@ export function deriveQuarterlyStatements(
       if (statementNumber(target, field) !== null) continue;
       const annualValue = statementNumber(annualStatement, field);
       if (annualValue === null) continue;
-      const availableAt = annualStatement.fieldAvailability?.[field] ?? annualStatement.availableAt;
+      const availableAt = statementFieldAvailability(annualStatement, field);
       setStatementNumber(target, field, annualValue, availableAt);
       changed = true;
     }
 
     if (changed) {
-      target.availableAt = latestDateString([
-        target.availableAt,
-        annualStatement.availableAt,
-        ...Object.values(target.fieldAvailability ?? {}),
-      ]);
+      target.availableAt = completeStatementAvailability(target);
       byDate.set(target.date, target);
     }
   }
@@ -368,7 +357,6 @@ function buildTtmStatements(statements: readonly FinancialStatement[]): Internal
     const ttm: InternalStatement = {
       date: latest.date,
       currency: latest.currency,
-      availableAt: latestDateString(window.map((statement) => statement.availableAt)),
       fieldAvailability: {},
       __timeSeriesTtm: true,
       __timeSeriesDerivedFields: [],
@@ -380,8 +368,8 @@ function buildTtmStatements(statements: readonly FinancialStatement[]): Internal
       (ttm as unknown as Record<string, unknown>)[field] = values.reduce((sum, value) => sum + value, 0)
         / (QUARTERLY_AVERAGE_FIELDS.includes(field) ? 4 : 1);
       ttm.__timeSeriesDerivedFields!.push(field);
-      const availableAt = latestDateString(window.map((statement) => (
-        statement.fieldAvailability?.[field] ?? statement.availableAt
+      const availableAt = completeAvailability(window.map((statement) => (
+        statementFieldAvailability(statement, field)
       )));
       if (availableAt) ttm.fieldAvailability![field] = availableAt;
     }
@@ -390,13 +378,10 @@ function buildTtmStatements(statements: readonly FinancialStatement[]): Internal
       const value = statementNumber(latest, field);
       if (value === null) continue;
       (ttm as unknown as Record<string, unknown>)[field] = value;
-      const availableAt = latest.fieldAvailability?.[field] ?? latest.availableAt;
+      const availableAt = statementFieldAvailability(latest, field);
       if (availableAt) ttm.fieldAvailability![field] = availableAt;
     }
-    ttm.availableAt = latestDateString([
-      ttm.availableAt,
-      ...Object.values(ttm.fieldAvailability ?? {}),
-    ]);
+    ttm.availableAt = completeStatementAvailability(ttm);
     result.push(ttm);
   }
   return result;
@@ -548,10 +533,7 @@ function metricDependencies(metric: string, statement: FinancialStatement): Nume
 
 function metricAvailability(statement: FinancialStatement, metric: string): string | undefined {
   const dependencies = metricDependencies(metric, statement);
-  if (dependencies.length === 0) return statement.availableAt;
-  return latestDateString(dependencies.map((field) => (
-    latestDateString([statement.fieldAvailability?.[field]]) ?? statement.availableAt
-  )));
+  return completeAvailability(dependencies.map((field) => statementFieldAvailability(statement, field)));
 }
 
 function fundamentalValue(

--- a/src/utils/financial-statements.test.ts
+++ b/src/utils/financial-statements.test.ts
@@ -22,6 +22,27 @@ test("period evidence follows the selected fiscal date without inventing field a
 });
 
 describe("mergeFinancialStatementRows", () => {
+  test("merging and JSON roundtrips preserve unknown fields in an authoritative availability map", () => {
+    const primary: FinancialStatement = {
+      date: "2025-12-31", availableAt: "2026-04-01", totalRevenue: 100, grossProfit: 40,
+      fieldAvailability: { grossProfit: "2026-02-01" },
+    };
+    const fallback: FinancialStatement = { date: primary.date, netIncome: 10, availableAt: "2026-03-01" };
+    const merged = JSON.parse(JSON.stringify(mergeFinancialStatementRows([primary], [fallback])[0])) as FinancialStatement;
+    expect(merged).toMatchObject({ totalRevenue: 100, grossProfit: 40, netIncome: 10,
+      fieldAvailability: { grossProfit: "2026-02-01", netIncome: "2026-03-01" } });
+    expect(merged.availableAt).toBeUndefined();
+    expect(merged.fieldAvailability?.totalRevenue).toBeUndefined();
+    expect(mergeFinancialStatementRows([merged], [fallback])[0]).toEqual(merged);
+    // Independent evidence may date a matching retained value, but not a different one.
+    const [corroborated] = mergeFinancialStatementRows([merged], [{ date: primary.date, totalRevenue: 100, availableAt: "2026-02-15" }]);
+    expect(corroborated?.fieldAvailability?.totalRevenue).toBe("2026-02-15");
+    expect(corroborated?.availableAt).toBe("2026-03-01");
+    const [emptyMap] = mergeFinancialStatementRows([{ ...primary, fieldAvailability: {} }], [{ date: primary.date }]);
+    expect(emptyMap?.fieldAvailability).toEqual({});
+    expect(emptyMap?.availableAt).toBeUndefined();
+  });
+
   test("preserves per-field availability across providers", () => {
     const [merged] = mergeFinancialStatementRows(
       [{

--- a/src/utils/financial-statements.ts
+++ b/src/utils/financial-statements.ts
@@ -5,6 +5,20 @@ export const FINANCIAL_VINTAGE_NOTICE = "Latest available statements may include
 const STATEMENT_METADATA_KEYS = new Set(["date", "dateSource", "providerDate", "dateEvidence", "currency", "availableAt", "fieldAvailability"]);
 const NEARBY_PERIOD_END_MS = 7 * 24 * 60 * 60 * 1_000;
 
+/** An explicit field map is authoritative: omitted fields have unknown availability. */
+export function statementFieldAvailability(row: FinancialStatement | undefined, field: string): string | undefined {
+  const value = row?.fieldAvailability !== undefined ? row.fieldAvailability?.[field] : row?.availableAt;
+  return value && Number.isFinite(Date.parse(value)) ? value : undefined;
+}
+
+/** A derived value is dated only when every input's availability is known. */
+export function completeAvailability(values: readonly (string | null | undefined)[]): string | undefined {
+  if (values.length === 0 || values.some((value) => !value || !Number.isFinite(Date.parse(value)))) return undefined;
+  return values.reduce<string | undefined>((latest, value) => (
+    !latest || Date.parse(value!) > Date.parse(latest) ? value! : latest
+  ), undefined);
+}
+
 function metricKeys(...rows: Array<FinancialStatement | undefined>): string[] {
   return [...new Set(rows.flatMap((row) => Object.keys(row ?? {})))]
     .filter((key) => !STATEMENT_METADATA_KEYS.has(key));
@@ -145,29 +159,24 @@ export function mergeFinancialStatementRows(
       }
 
       if (primaryHasValue) {
-        const primaryAvailability = row.fieldAvailability?.[key] ?? row.availableAt;
+        const primaryAvailability = statementFieldAvailability(row, key);
         const valuesMatch = fallbackHasValue && Object.is(metricValue(row, key), metricValue(fallback, key));
         const availability = primaryAvailability
-          ?? (valuesMatch ? fallback?.fieldAvailability?.[key] ?? fallback?.availableAt : undefined);
+          ?? (valuesMatch ? statementFieldAvailability(fallback, key) : undefined);
         if (availability) fieldAvailability[key] = availability;
       } else if (fallbackHasValue) {
-        const availability = fallback?.fieldAvailability?.[key] ?? fallback?.availableAt;
+        const availability = statementFieldAvailability(fallback, key);
         if (availability) fieldAvailability[key] = availability;
       }
     }
 
     // A fallback row-level date cannot safely date a different primary value.
     // Retained fallback fields still carry their own per-field provenance.
-    const primaryHasMetrics = keys.some((key) => hasMetricValue(row, key));
     const retainedMetricKeys = keys.filter((key) => hasMetricValue(merged, key));
-    const completeFieldAvailability = retainedMetricKeys.length > 0
-      && retainedMetricKeys.every((key) => !!fieldAvailability[key]);
-    const availableAt = completeFieldAvailability
-      ? Object.values(fieldAvailability).sort().at(-1)
-      : row.availableAt ?? (!primaryHasMetrics ? fallback?.availableAt : undefined);
+    const availableAt = completeAvailability(retainedMetricKeys.map((key) => fieldAvailability[key]));
     if (availableAt) merged.availableAt = availableAt;
     else delete merged.availableAt;
-    if (Object.keys(fieldAvailability).length > 0) merged.fieldAvailability = fieldAvailability;
+    if (Object.keys(fieldAvailability).length > 0 || row.fieldAvailability !== undefined || fallback?.fieldAvailability !== undefined) merged.fieldAvailability = fieldAvailability;
     else delete merged.fieldAvailability;
     return merged;
   });


### PR DESCRIPTION
A partial statement availability map was treated as permission to date every other field from the row or another known metric. A captured live MSFT native-provider snapshot demonstrates the error: FY2025 debt of $60.588B has no publication metadata, yet the chart assigned July 30, 2025 from other SEC fields and suppressed its missing-publication warning.

Treat explicit field maps, including empty maps, as authoritative; missing or invalid entries remain unknown. Legacy statements without a field map retain valid whole-row dates. Q4, trailing-year totals, margins and valuation dependencies receive an availability date only when every required input is dated. Balance-sheet snapshots retain their own dates, and merged rows are dated only when all retained numeric fields have known availability. Matching values can still receive independent source evidence during a provider merge.

The financial cache schema advances from 2 to 3 because earlier merges may already have materialized unsupported dates. Only older dated financial records are refreshed; undated financials and unrelated quote/history caches remain usable.

Validation: 93 focused tests / 380 assertions and all six runtime typechecks pass. Regressions cover partial/empty/invalid maps, unchanged scalar and derived amounts, legacy row dates, unknown Q4/TTM inputs, independently dated balance snapshots, matching-value evidence, JSON roundtrips, and persistent cache refresh. Replaying the captured MSFT snapshot removes debt's unsupported date and activates the existing warning; its properly dated 45.621956% operating margin stays unchanged.

This does not reconstruct original historical vintages or exact public-distribution times. Unknown dates continue to use the existing visibly disclosed fiscal-period fallback; they are not suitable as verified historical availability. The evidence is a replay of an actual captured provider response plus controlled regressions, not a new live-provider fetch or a new native-rendering claim. No release or version change. Hold merge for root review.
