### PR TITLE
Keep financial chart values readable in legends

### DIFF
--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -435,6 +435,23 @@ describe("CompositeChart", () => {
     expect(accessoryStart - lastLegendEnd).toBeGreaterThan(1);
   });
 
+  test("retains financial values and negative signs when long legend names need truncation", async () => {
+    testSetup = await testRender(
+      <CompositeChart width={100} height={12} panels={[{ id: "main" }]} series={[
+        { ...series("revenue", "main", "left", "USD", [90_007_000_000]), label: "MSFT:XNAS Revenue", unitGroup: "currency-total:USD" },
+        { ...series("margin", "main", "right", "%", [-49.612]), label: "Very long issuer Operating Margin", unitGroup: "percent" },
+        { ...series("hk-revenue", "main", "left", "USD", [90_007_000_000]), label: "腾讯控股腾讯控股 Revenue", unitGroup: "currency-total:USD" },
+      ]} />,
+      { width: 102, height: 14 },
+    );
+    await act(async () => { await testSetup!.renderOnce(); await testSetup!.renderOnce(); });
+    const legend = testSetup.captureCharFrame().split("\n")[0]!;
+    expect(legend).toContain("MSFT:XNAS Revenue $90.01B");
+    expect(legend).toContain("... -49.6%");
+    expect(legend).toContain("腾讯控股腾讯控股");
+    expect(legend.match(/\$90\.01B/g)).toHaveLength(2);
+  });
+
   test("keeps non-plotted legend series available for restoring", async () => {
     const price = series("price", "main", "left", "USD", [100, 103, 101]);
     const hiddenRevenue = series("revenue", "main", "right", "%", [4, 6, 8]);

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -15,9 +15,8 @@ import { useShortcut } from "../../../react/input";
 import { useOptionalPaneInstanceId, usePaneSettingValue } from "../../../state/app/context";
 import { colors as themeColors, hoverBg } from "../../../theme/colors";
 import { useThemeColors } from "../../../theme/theme-context";
-import { formatPercentRaw } from "../../../utils/format";
+import { displayWidth, formatPercentRaw, truncateToDisplayWidth } from "../../../utils/format";
 import { isPlainKey } from "../../../utils/keyboard";
-import { truncateWithEllipsis } from "../../../utils/text-wrap";
 import type { ResolvedSeries } from "../../../time-series/types";
 import { downsampleCompositeChartScene } from "./downsample";
 import { reuseResolvedSeriesList } from "./panel-series";
@@ -1360,19 +1359,27 @@ function CompositeLegend({
         && Number.isFinite(entry.latestChangePercent)
       ? ` ${formatPercentRaw(entry.latestChangePercent)}`
       : "";
-    const fullText = entry.points.length === 0
-      ? `${entry.label}${entry.hidden ? "" : " no data"}`
-      : `${entry.label} ${legendValue(
+    const valueText = entry.points.length === 0
+      ? entry.hidden ? "" : "no data"
+      : `${legendValue(
         entry,
         cursorValue?.value ?? null,
         formatValue,
       )}${changeText}`;
+    const fullText = [entry.label, valueText].filter(Boolean).join(" ");
     const details = formatCompositePointDetails(cursorValue?.point);
-    const tooltip = details ? `${fullText} · ${details}` : fullText;
-    const textWidth = Math.max(1, Math.min(30, [...fullText].length));
+    const exactTotal = entry.unitGroup.split(":")[0] === "currency-total"
+      && cursorValue?.value != null && Number.isFinite(cursorValue.value)
+      ? `Value ${cursorValue.value} ${entry.unit}` : "";
+    const tooltip = [fullText, exactTotal, details].filter(Boolean).join(" · ");
+    // Keep the value (including its sign/unit) intact. Long names may shorten;
+    // oversized values remain reachable through the scrollable legend.
+    const labelWidth = Math.max(0, 30 - (valueText ? displayWidth(valueText) + 1 : 0));
+    const text = [truncateToDisplayWidth(entry.label, labelWidth), valueText].filter(Boolean).join(" ");
+    const textWidth = Math.max(1, displayWidth(text));
     return {
       entry,
-      text: truncateWithEllipsis(fullText, textWidth),
+      text,
       width: textWidth + 2,
       toggleable,
       tooltip,

--- a/src/components/chart/composite/format.test.ts
+++ b/src/components/chart/composite/format.test.ts
@@ -180,5 +180,9 @@ describe("composite chart unit formatting", () => {
     expect(formatChartLegendValue(79_432.18, "USD", "price:USD")).toBe("$79,432.18");
     expect(formatCompositeCursorValue(79_432.18, domain)).toBe("$79,432.18");
     expect(formatCompositeAxisValue(79_432.18, domain)).toBe("$79K");
+    expect(formatChartLegendValue(1_234_567.89, "USD", "price:USD")).toBe("$1,234,567.89");
+    expect(formatChartLegendValue(90_007_000_000, "USD", "currency-total:USD")).toBe("$90.01B");
+    expect(formatChartLegendValue(-12_345_600_000, "EUR", "currency-total")).toBe("€-12.35B");
+    expect(formatChartLegendValue(123_456_000, "CAD", "currency-total:CAD")).toBe("123.46M CAD");
   });
 });

--- a/src/components/chart/composite/format.ts
+++ b/src/components/chart/composite/format.ts
@@ -54,6 +54,15 @@ export function formatChartLegendValue(value: number, unit: string, unitGroup = 
   }
   if (group.includes("ratio") || trimmed.toLowerCase() === "x") return `${compact}x`;
   if (group.startsWith("derived-unit:")) return `${compact} ${trimmed}`;
+  if (group.split(":")[0] === "currency-total") {
+    const scale = ([[1e12, "T"], [1e9, "B"], [1e6, "M"], [1e3, "K"]] as const)
+      .find(([divisor]) => Math.abs(value) >= divisor);
+    if (scale) {
+      const amount = `${Number((value / scale[0]).toFixed(2))}${scale[1]}`;
+      const prefix = currencyPrefix(trimmed);
+      return prefix ? `${prefix}${amount}` : `${amount} ${trimmed}`.trim();
+    }
+  }
   const fullPrice = formatFullCurrencyValue(value, trimmed);
   if (fullPrice) return fullPrice;
   return trimmed && trimmed.length <= 6 ? `${compact}${trimmed.startsWith("/") ? "" : " "}${trimmed}` : compact;


### PR DESCRIPTION
Financial chart legends cut off large totals (`MSFT:XNAS Revenue $90,007,0...`) and long metric names could hide the entire value. Legends now reserve space for the value, sign and unit before shortening the label. Terminal sizing uses display columns so Chinese/wide-character names do not wrap out of the single-row legend.

Aggregate currency totals use compact K/M/B/T notation with two decimal places, while quoted-price precision is preserved. Browser tooltips retain the exact numeric total, currency and period/source context. Underlying points and exported data are unchanged.

Validated with 142 chart tests (952 assertions), all six runtime typechecks, a browser build, actual live-cloud GF MSFT before/after browser captures at desktop and640px, and captured-SEC native replay at140x44 and80x30. Regression includes negative margins, large USD/EUR/CAD totals, million-dollar quoted prices and Chinese labels. Independent review found the wide-character issue and the renderer regression now covers it. No release or version bump.
