### PR TITLE
Label financial observations by reported period end

### DIFF
--- a/src/components/chart/composite/column-layout.ts
+++ b/src/components/chart/composite/column-layout.ts
@@ -53,7 +53,7 @@ function observedTimestamp(point: CompositeProjectedPoint): number | null {
 function annualBucket(point: CompositeProjectedPoint): FinancialPeriodBucket | null {
   const periodLabel = point.point.periodLabel?.trim();
   const timestamp = observedTimestamp(point);
-  if (!periodLabel || !/^FY\d{4}$/.test(periodLabel) || timestamp === null) return null;
+  if (!periodLabel || !/^(?:FY\d{4}|Year ended \d{4}-\d{2}-\d{2})$/.test(periodLabel) || timestamp === null) return null;
   const observedAt = new Date(timestamp);
   const observedYear = observedAt.getUTCFullYear();
   const cohortYear = observedAt.getUTCMonth() <= 1 ? observedYear - 1 : observedYear;
@@ -63,7 +63,7 @@ function annualBucket(point: CompositeProjectedPoint): FinancialPeriodBucket | n
 function quarterlyBucket(point: CompositeProjectedPoint): FinancialPeriodBucket | null {
   const periodLabel = point.point.periodLabel?.trim();
   const timestamp = observedTimestamp(point);
-  if (!periodLabel || !/^\d{4} Q[1-4]$/.test(periodLabel) || timestamp === null) return null;
+  if (!periodLabel || !/^(?:\d{4} Q[1-4]|Quarter ended \d{4}-\d{2}-\d{2})$/.test(periodLabel) || timestamp === null) return null;
 
   const observedYear = new Date(timestamp).getUTCFullYear();
   let nearest: { year: number; quarter: number; distance: number } | null = null;

--- a/src/components/chart/composite/format.test.ts
+++ b/src/components/chart/composite/format.test.ts
@@ -83,6 +83,16 @@ describe("composite chart timestamp formatting", () => {
 });
 
 describe("composite chart point details", () => {
+  test("shows explicit financial period ends once and keeps their later availability", () => {
+    for (const period of ["Quarter", "Year", "TTM"]) {
+      expect(formatCompositePointDetails({
+        date: new Date("2025-07-30"), observedAt: new Date("2025-06-30"),
+        availableAt: new Date("2025-07-30"), value: 76_441_000_000,
+        periodLabel: `${period} ended 2025-06-30`, provenance: { quality: "reported" },
+      })).toBe(`${period} ended 2025-06-30 · Available 2025-07-30 · Reported`);
+    }
+  });
+
   test("disambiguates fiscal period, availability, and provenance", () => {
     const point: TimeSeriesPoint = {
       date: new Date("2025-03-14T00:00:00.000Z"),

--- a/src/components/chart/composite/format.ts
+++ b/src/components/chart/composite/format.ts
@@ -148,7 +148,8 @@ export function formatCompositePointDetails(point: TimeSeriesPoint | null | unde
   const availableAt = validUtcTimestamp(point.availableAt);
 
   if (periodLabel) details.push(periodLabel);
-  if (observedAt) {
+  const labelIncludesObservedDate = ["Quarter", "Year", "TTM"].some((period) => periodLabel === `${period} ended ${observedAt}`);
+  if (observedAt && !labelIncludesObservedDate) {
     const isFiscalPeriod = periodLabel && periodLabel.toLowerCase() !== "current";
     details.push(`${isFiscalPeriod ? "Period ended" : "Observed"} ${observedAt}`);
   }

--- a/src/components/chart/composite/renderers.test.ts
+++ b/src/components/chart/composite/renderers.test.ts
@@ -115,13 +115,13 @@ describe("composite chart renderers", () => {
     expect(Math.max(...greenXs)).toBeLessThan(Math.min(...orangeXs));
   });
 
-  test("groups offset annual and quarterly fiscal closes into stable cohort lanes", () => {
+  test("groups explicit period-end labels and legacy fiscal labels into the same stable cohort lanes", () => {
     const cases = [
       {
         frequency: "annual" as const,
         first: [
-          { date: "2024-01-28", periodLabel: "FY2024" },
-          { date: "2025-01-26", periodLabel: "FY2025" },
+          { date: "2024-01-28", periodLabel: "Year ended 2024-01-28" },
+          { date: "2025-01-26", periodLabel: "Year ended 2025-01-26" },
         ],
         second: [
           { date: "2023-12-31", periodLabel: "FY2023" },
@@ -131,8 +131,8 @@ describe("composite chart renderers", () => {
       {
         frequency: "quarterly" as const,
         first: [
-          { date: "2024-01-28", periodLabel: "2024 Q1" },
-          { date: "2024-04-28", periodLabel: "2024 Q2" },
+          { date: "2024-01-28", periodLabel: "Quarter ended 2024-01-28" },
+          { date: "2024-04-28", periodLabel: "Quarter ended 2024-04-28" },
         ],
         second: [
           { date: "2023-12-31", periodLabel: "2023 Q4" },

--- a/src/time-series/fundamentals.test.ts
+++ b/src/time-series/fundamentals.test.ts
@@ -29,6 +29,21 @@ function source(
 }
 
 describe("fundamental series extraction", () => {
+  test("labels issuer periods by their reported end instead of inferring fiscal quarters or years", () => {
+    // MSFT June 2025 is fiscal Q4; Target's year ended February 2025 is fiscal 2024.
+    const cases = [
+      { period: "quarterly" as const, date: "2025-06-30", filed: "2025-07-30", value: 76_441_000_000, label: "Quarter ended 2025-06-30" },
+      { period: "annual" as const, date: "2025-02-01", filed: "2025-03-12", value: 106_566_000_000, label: "Year ended 2025-02-01" },
+    ];
+    for (const entry of cases) {
+      const row = { date: entry.date, availableAt: entry.filed, totalRevenue: entry.value };
+      const snapshot = financials(entry.period === "quarterly" ? [row] : [], entry.period === "annual" ? [row] : []);
+      const [point] = extractFundamentalSeries(snapshot, source("fundamental.totalRevenue", entry.period));
+      expect(point).toMatchObject({ value: entry.value, periodLabel: entry.label, observedAt: new Date(entry.date), availableAt: new Date(entry.filed) });
+      expect(point?.date).toEqual(new Date(entry.filed));
+    }
+  });
+
   const quarters: FinancialStatement[] = [
     { date: "2024-03-31", availableAt: "2024-05-01", totalRevenue: 10 },
     { date: "2024-06-30", availableAt: "2024-08-01", totalRevenue: 20 },
@@ -69,7 +84,7 @@ describe("fundamental series extraction", () => {
 
   test("timestamps reported values when they became available, not at period end", () => {
     const points = extractFundamentalSeries(financials(quarters, annual), source("fundamental.totalRevenue"));
-    const q4 = points.find((point) => point.periodLabel === "2024 Q4");
+    const q4 = points.find((point) => point.periodLabel === "Quarter ended 2024-12-31");
     expect(q4?.value).toBe(40);
     expect(q4?.observedAt.toISOString().slice(0, 10)).toBe("2024-12-31");
     expect(q4?.date.toISOString().slice(0, 10)).toBe("2025-02-15");
@@ -104,13 +119,13 @@ describe("fundamental series extraction", () => {
       value: point.value,
     }))).toEqual([
       {
-        period: "2025 Q2",
+        period: "Quarter ended 2025-06-28",
         observedAt: "2025-06-28",
         availableAt: "2025-08-01",
         value: 94_036,
       },
       {
-        period: "2025 Q3",
+        period: "Quarter ended 2025-09-27",
         observedAt: "2025-09-27",
         availableAt: "2025-10-31",
         value: 102_466,
@@ -137,7 +152,7 @@ describe("fundamental series extraction", () => {
       source("fundamental.totalRevenue"),
     );
 
-    expect(points.map((point) => point.periodLabel)).toEqual(["2025 Q1", "2025 Q2"]);
+    expect(points.map((point) => point.periodLabel)).toEqual(["Quarter ended 2025-03-29", "Quarter ended 2025-06-28"]);
   });
 
   test("preserves distinct irregular periods within one calendar quarter", () => {
@@ -176,7 +191,7 @@ describe("fundamental series extraction", () => {
     expect(points.map((point) => ({
       period: point.periodLabel,
       value: point.value,
-    }))).toEqual([{ period: "TTM 2025 Q4", value: 100 }]);
+    }))).toEqual([{ period: "TTM ended 2025-12-27", value: 100 }]);
   });
 
   test("retains a later disclosed value when a period is actually restated", () => {
@@ -278,7 +293,7 @@ describe("fundamental series extraction", () => {
     );
     expect(points).toHaveLength(1);
     expect(points[0]?.value).toBe(100);
-    expect(points[0]?.periodLabel).toBe("TTM 2024 Q4");
+    expect(points[0]?.periodLabel).toBe("TTM ended 2024-12-31");
     expect(points[0]?.date.toISOString().slice(0, 10)).toBe("2025-02-15");
   });
 
@@ -303,7 +318,7 @@ describe("fundamental series extraction", () => {
       timeline: [new Date("2025-01-15T00:00:00Z"), new Date("2025-02-15T00:00:00Z")],
     });
     expect(rows[0]?.values.revenue?.value).toBe(30);
-    expect(rows[0]?.values.revenue?.point.periodLabel).toBe("2024 Q3");
+    expect(rows[0]?.values.revenue?.point.periodLabel).toBe("Quarter ended 2024-09-30");
     expect(rows[1]?.values.revenue?.value).toBe(40);
     expect(rows[1]?.values.revenue?.carried).toBe(false);
   });
@@ -382,7 +397,7 @@ describe("fundamental series extraction", () => {
     );
 
     expect(points).toHaveLength(1);
-    expect(points[0]?.periodLabel).toBe("FY2024");
+    expect(points[0]?.periodLabel).toBe("Year ended 2024-12-28");
     expect(points[0]?.value).toBe(20.2);
   });
 

--- a/src/time-series/fundamentals.ts
+++ b/src/time-series/fundamentals.ts
@@ -142,10 +142,10 @@ function completeStatementAvailability(statement: InternalStatement): string | u
     .map((field) => statementFieldAvailability(statement, field)));
 }
 
-function periodCategory(date: string, period: "annual" | "quarterly"): string {
+/** Internal calendar bucket for selecting adjacent inputs, not an issuer fiscal label. */
+function calendarQuarterBucket(date: string): string {
   const parsedYear = Number(date.slice(0, 4));
   let year = Number.isFinite(parsedYear) ? parsedYear : 0;
-  if (period === "annual") return year > 0 ? `FY${year}` : date;
 
   let month = Number(date.slice(5, 7));
   const day = Number(date.slice(8, 10));
@@ -260,13 +260,13 @@ function precedingQuarterInputs(
   const annualTime = statementTime(annualStatement);
   if (!Number.isFinite(annualTime)) return [];
 
-  const annualCategory = periodCategory(annualStatement.date, "quarterly");
+  const annualCategory = calendarQuarterBucket(annualStatement.date);
   const byCategory = new Map<string, PrecedingQuarterInput>();
   for (const statement of quarterlyStatements) {
     if (statement.currency !== annualStatement.currency) continue;
     const time = statementTime(statement);
     if (!Number.isFinite(time) || time >= annualTime || annualTime - time > 370 * DAY_MS) continue;
-    const category = periodCategory(statement.date, "quarterly");
+    const category = calendarQuarterBucket(statement.date);
     if (category === annualCategory) continue;
     const value = statementNumber(statement, field);
     if (value === null) continue;
@@ -582,11 +582,9 @@ function pointForStatement(
     observedAt,
     availableAt: availableAt ?? undefined,
     value,
-    periodLabel: period === "annual"
-      ? periodCategory(statement.date, "annual")
-      : period === "ttm"
-        ? `TTM ${periodCategory(statement.date, "quarterly")}`
-        : periodCategory(statement.date, "quarterly"),
+    // Providers do not supply a reliable issuer fiscal-year/quarter identity.
+    // Calendar-month numbering would mislabel non-calendar fiscal years.
+    periodLabel: `${period === "annual" ? "Year" : period === "ttm" ? "TTM" : "Quarter"} ended ${statement.date}`,
     provenance: { quality: derived ? "derived" : "reported" },
   };
 }


### PR DESCRIPTION
Financial charts inferred fiscal labels from calendar months and years. Microsoft's June quarter appeared as Q2 despite being its fiscal Q4, and an annual period ending in early 2025 was labelled FY2025 even when the issuer calls it fiscal 2024. The statement contract has no authoritative issuer fiscal-quarter or fiscal-year identity.

Label these observations by their reported period ends: `Quarter ended DATE`, `Year ended DATE`, or `TTM ended DATE`. Keep the existing internal calendar buckets for arithmetic, remove duplicate period dates from point tooltips, and let column grouping recognize both the new labels and legacy fiscal labels. Values, observation/publication dates, Q4/TTM calculations, and Current-snapshot exclusions are unchanged.

Validation: 102 focused tests / 458 assertions and all six runtime typechecks pass, including mixed new/legacy column grouping, offset fiscal closes, tooltip metadata, unchanged values/dates, TTM derivation and period counts. Actual CLI GF MSFT quarterly returns `Quarter ended 2026-06-30`; GF TGT annual returns `Year ended 2025-02-01` with revenue $106.566B. An actual native GF chart retains full axes, the compact revenue legend, and keyboard cursor navigation after rebasing onto the legend fix. Native legend metadata is not displayed as a hover tooltip, so that check establishes chart stability; browser tooltip verification is tracked separately.

Primary evidence: [Microsoft's FY25 Q4 release](https://www.microsoft.com/en-us/Investor/earnings/FY-2025-Q4/press-release-webcast) identifies the June 30 quarter as Q4. [Target's 2024 annual report](https://corporate.target.com/investors/annual/2024-annual-report/10-k-report/10-k-part-ii/item-8-financial-statements-and-supplementary-data) identifies fiscal 2024 as ending February 1, 2025.

No fiscal-period metadata is invented. This preserves the reported period end and does not resolve upstream approximate dates or reconstruct historical vintages. No release/version changes. Hold merge for root review.
