### PR TITLE
Retrieve extended financial history for research chart windows

### DIFF
--- a/src/api-client/data.ts
+++ b/src/api-client/data.ts
@@ -196,8 +196,10 @@ export class CloudDataApi {
   async getCloudFinancials(
     symbol: string,
     exchange?: string,
+    statementHistory?: "extended",
   ): Promise<CloudMarketResponse<TickerFinancials>> {
-    return this.requestMarketSymbol("/market/financials", symbol, exchange);
+    const path = cloudMarketSymbolPath("/market/financials", symbol, exchange);
+    return this.request(statementHistory === "extended" ? `${path}&statementHistory=extended` : path);
   }
 
   async getCloudFinancialsBatch(

--- a/src/market-data/snapshot-provider.test.ts
+++ b/src/market-data/snapshot-provider.test.ts
@@ -79,3 +79,15 @@ test("captured intraday data rejects other intervals and clips explicit windows 
   await expect(unavailable.getPriceHistory("AAPL", "NASDAQ", "1D")).rejects.toThrow("Session unavailable");
   await expect(unavailable.getDetailedPriceHistory!("AAPL", "NASDAQ", points[0]!.date, points[2]!.date, "1m")).rejects.toThrow("Session unavailable");
 });
+
+test("an ordinary captured snapshot cannot satisfy an explicit extended history request", async () => {
+ const captured = financials("MSFT", 100), extended = { ...captured, annualStatements: [{ date: "2010-06-30", totalRevenue: 100 }] };
+ let requests = 0;
+ const provider = createSnapshotDataProvider({ financials: [["MSFT:NASDAQ", captured]] }, createTestDataProvider({
+  async getTickerFinancials(_symbol, _exchange, context) { requests++; expect(context?.statementHistory).toBe("extended"); return extended; },
+ }));
+ expect(await provider.getTickerFinancials("MSFT", "NASDAQ")).toBe(captured);
+ expect(await provider.getTickerFinancials("MSFT", "NASDAQ", { statementHistory: "extended" })).toBe(extended);
+ expect((await provider.getTickerFinancialsBatch!([{ symbol: "MSFT", exchange: "NASDAQ", statementHistory: "extended" }]))[0]?.financials).toBe(extended);
+ expect(requests).toBe(2);
+});

--- a/src/market-data/snapshot-provider.ts
+++ b/src/market-data/snapshot-provider.ts
@@ -52,13 +52,13 @@ export function createSnapshotDataProvider(snapshot: SnapshotMarketData, fallbac
   };
   const overrides: Partial<DataProvider> = {
     async getTickerFinancials(symbol, exchange, context) {
-      return financials(symbol, exchange) ?? fallback.getTickerFinancials(symbol, exchange, context);
+      return (context?.statementHistory === "extended" ? undefined : financials(symbol, exchange)) ?? fallback.getTickerFinancials(symbol, exchange, context);
     },
     getCachedFinancialsForTargets(targets, settings) {
       const captured = new Map<string, TickerFinancials>();
       const missing: CachedFinancialsTarget[] = [];
       for (const target of targets) {
-        const value = financials(target.symbol, target.exchange);
+        const value = target.statementHistory === "extended" ? undefined : financials(target.symbol, target.exchange);
         if (value) captured.set(target.symbol.trim().toUpperCase(), value);
         else missing.push(target);
       }
@@ -68,7 +68,7 @@ export function createSnapshotDataProvider(snapshot: SnapshotMarketData, fallbac
     },
     getTickerFinancialsBatch(targets, settings) {
       return seededBatch(targets, (target): TickerFinancialsBatchResult | undefined => {
-        const value = financials(target.symbol, target.exchange);
+        const value = target.statementHistory === "extended" ? undefined : financials(target.symbol, target.exchange);
         return value ? { target, financials: value } : undefined;
       }, (missing) => fallback.getTickerFinancialsBatch?.(missing, settings) ?? Promise.all(missing.map(async (target) => ({
         target, financials: await fallback.getTickerFinancials(target.symbol, target.exchange, target),

--- a/src/sources/gloomberb-cloud/index.ts
+++ b/src/sources/gloomberb-cloud/index.ts
@@ -208,10 +208,10 @@ export class GloomberbCloudProvider implements AssetDataProvider {
     return true;
   }
 
-  async getTickerFinancials(ticker: string, exchange = "", _context?: MarketDataRequestContext): Promise<TickerFinancials> {
+  async getTickerFinancials(ticker: string, exchange = "", context?: MarketDataRequestContext): Promise<TickerFinancials> {
     const target = cloudInstrumentTarget(ticker, exchange);
     return withCloudFallback(async () => {
-      const response = await apiClient.getCloudFinancials(target.symbol, target.exchange);
+      const response = await apiClient.getCloudFinancials(target.symbol, target.exchange, context?.statementHistory);
       if (isStaleCloudResponse(response)) {
         throw createProviderMiss(`Cloud financials are stale for ${ticker}`);
       }
@@ -226,6 +226,12 @@ export class GloomberbCloudProvider implements AssetDataProvider {
     targets: CachedFinancialsTarget[],
     options: { forceRefresh?: boolean } = {},
   ): Promise<TickerFinancialsBatchResult[]> {
+    if (targets.some((target) => target.statementHistory === "extended")) {
+      return Promise.all(targets.map(async (target) => {
+        try { return { target, financials: await this.getTickerFinancials(target.symbol, target.exchange, target) }; }
+        catch (error) { return { target, financials: null, error }; }
+      }));
+    }
     return withCloudFallback(async () => {
       const response = await apiClient.getCloudFinancialsBatch(
         targets.map((target) => cloudInstrumentTarget(target.symbol, target.exchange)),

--- a/src/sources/gloomberb-cloud/normalizers.ts
+++ b/src/sources/gloomberb-cloud/normalizers.ts
@@ -203,6 +203,7 @@ export function mapCloudFinancials(
     profile: financials.profile,
     fundamentals: financials.fundamentals,
     financialCurrency: financials.financialCurrency,
+    statementHistory: financials.statementHistory,
     annualStatements: financials.annualStatements ?? [],
     quarterlyStatements: financials.quarterlyStatements ?? [],
     priceHistory: (financials.priceHistory ?? []).map((point) =>

--- a/src/sources/provider-router/batches.ts
+++ b/src/sources/provider-router/batches.ts
@@ -127,7 +127,7 @@ export class ProviderRouterBatchRoutes {
     targets.forEach((target, index) => {
       const context = this.deps.contextFromCachedTarget(target);
       const cached = this.deps.readCachedMergedFinancialsSelection(target.symbol, target.exchange, context, true);
-      if (cached.value && !forceRefresh) {
+      if (cached.value && !forceRefresh && target.statementHistory !== "extended") {
         results[index] = { target, financials: cached.value };
         return;
       }
@@ -135,7 +135,7 @@ export class ProviderRouterBatchRoutes {
     });
 
     const batchProvider = this.deps.providersInPriorityOrder().find((provider) => provider.getTickerFinancialsBatch);
-    const providerMisses = misses.filter(({ target }) => !this.deps.hasCachedTargetBrokerContext(target));
+    const providerMisses = misses.filter(({ target }) => target.statementHistory !== "extended" && !this.deps.hasCachedTargetBrokerContext(target));
     const providerIndexes = new Map<string, Array<{ index: number; target: CachedFinancialsTarget }>>();
     if (batchProvider && providerMisses.length > 0) {
       for (const entry of providerMisses) {

--- a/src/sources/provider-router/brokers.ts
+++ b/src/sources/provider-router/brokers.ts
@@ -107,6 +107,7 @@ export function hasCachedTargetBrokerContext(target: CachedFinancialsTarget): bo
 
 export function contextFromCachedTarget(target: CachedFinancialsTarget): MarketDataRequestContext {
   return {
+    statementHistory: target.statementHistory,
     brokerId: target.brokerId,
     brokerInstanceId: target.brokerInstanceId,
     instrument: target.instrument ?? null,

--- a/src/sources/provider-router/financial-routes.ts
+++ b/src/sources/provider-router/financial-routes.ts
@@ -1,3 +1,4 @@
+import { financialHistoryVariants, hasReusableExtendedHistory } from "./statement-history";
 import type {
   CachedFinancialsTarget,
   MarketDataRequestContext,
@@ -65,6 +66,7 @@ export class ProviderRouterFinancialRoutes {
     const results = new Map<string, TickerFinancials>();
     for (const target of targets) {
       const cached = this.readCachedMergedFinancials(target.symbol, target.exchange, {
+        statementHistory: target.statementHistory,
         brokerId: target.brokerId,
         brokerInstanceId: target.brokerInstanceId,
         instrument: target.instrument ?? undefined,
@@ -93,15 +95,16 @@ export class ProviderRouterFinancialRoutes {
       quarterlyStatements: base?.quarterlyStatements ?? [],
       priceHistory: base?.priceHistory ?? [],
     });
-    const cached = this.readCachedMergedFinancialsSelection(ticker, exchange, context, false, {
+    const cached = this.readCachedMergedFinancialsSelection(ticker, exchange, context, context?.statementHistory === "extended", {
       includeSymbolProviderFallback: true,
     });
     const forceRefresh = context?.cacheMode === "refresh";
-    if (cached.value && !forceRefresh) {
+    if (cached.value && !forceRefresh && (context?.statementHistory !== "extended" || hasReusableExtendedHistory(cached.value))) {
+      if (context?.statementHistory === "extended" && !cached.stale) return cached.value;
       if (isOptionTicker && !cached.value.quote) {
         return quoteOnlyFinancials(cached.value);
       }
-      if (!cached.stale && hasMeaningfulProfile(cached.value) && hasShallowStatementHistory(cached.value)) {
+      if (context?.statementHistory !== "extended" && !cached.stale && hasMeaningfulProfile(cached.value) && hasShallowStatementHistory(cached.value)) {
         const providerResult = await this.deps.primaryRoutes.fetchProviderFinancials(ticker, exchange, context);
         return mergeFinancials(cached.value, providerResult?.value ?? null) ?? cached.value;
       }
@@ -119,7 +122,9 @@ export class ProviderRouterFinancialRoutes {
       const providerResult = await this.deps.primaryRoutes.fetchProviderFinancials(ticker, exchange, context);
       const merged = mergeFinancials(
         brokerResult?.value ?? cached.brokerRecord?.value ?? null,
-        providerResult?.value ?? cached.providerValue ?? null,
+        context?.statementHistory === "extended"
+          ? mergeFinancials(providerResult?.value ?? null, cached.providerValue)
+          : providerResult?.value ?? cached.providerValue ?? null,
       );
       if (isOptionTicker && !merged?.quote) {
         return quoteOnlyFinancials(merged ?? cached.value);
@@ -232,10 +237,11 @@ export class ProviderRouterFinancialRoutes {
     options: CachedFinancialsReadOptions = {},
   ): CachedFinancialsSelection {
     const entityKey = this.deps.getEntityKey(ticker, context?.instrument);
-    const variantKeys = this.deps.getTickerVariantCandidates(exchange);
+    const quoteVariantKeys = this.deps.getTickerVariantCandidates(exchange);
+    const variantKeys = financialHistoryVariants(quoteVariantKeys, context);
     const brokerSourceKeys = this.deps.getBrokerCandidatesForContext(context, false).map((candidate) => this.deps.brokerSourceKey(candidate));
     const brokerRecord = brokerSourceKeys.length > 0
-      ? selectCachedResource<TickerFinancials>(this.deps.resources, "financials", entityKey, variantKeys, brokerSourceKeys, allowExpired)
+      ? selectCachedResource<TickerFinancials>(this.deps.resources, "financials", entityKey, quoteVariantKeys, brokerSourceKeys, allowExpired)
       : null;
     const sanitizedBrokerRecord = brokerRecord
       ? { ...brokerRecord, value: sanitizeCachedFinancials(brokerRecord.value, options) }
@@ -267,11 +273,11 @@ export class ProviderRouterFinancialRoutes {
         this.deps.resources,
         "quote",
         quoteEntityKey,
-        variantKeys,
+        quoteVariantKeys,
         quoteSourceKeys,
         allowExpired,
       )),
-      variantKeys,
+      quoteVariantKeys,
       quoteSourceKeys,
     );
     const quoteSelection = selectCachedQuoteRecord(quoteRecords, exchange, options);

--- a/src/sources/provider-router/financials.ts
+++ b/src/sources/provider-router/financials.ts
@@ -179,6 +179,7 @@ export function hasShallowStatementHistory(data: TickerFinancials | null | undef
 export function mergeMissingStatementArrays(primary: TickerFinancials, fallback: TickerFinancials): TickerFinancials {
   return excludeNonCompanyFinancials({
     ...primary,
+    statementHistory: fallback.statementHistory?.status === "available" ? fallback.statementHistory : primary.statementHistory ?? fallback.statementHistory,
     financialCurrency: primary.financialCurrency ?? (hasStatementRows(primary) ? undefined : fallback.financialCurrency),
     annualStatements: mergeFinancialStatementRows(primary.annualStatements, fallback.annualStatements),
     quarterlyStatements: mergeFinancialStatementRows(primary.quarterlyStatements, fallback.quarterlyStatements),
@@ -259,6 +260,7 @@ export function mergeFinancials(primary: TickerFinancials | null, fallback: Tick
   return excludeNonCompanyFinancials({
     ...fallback,
     ...primary,
+    statementHistory: primary.statementHistory ?? fallback.statementHistory,
     financialCurrency: primary.financialCurrency ?? (hasStatementRows(primary) ? undefined : fallback.financialCurrency),
     quote: resolvedQuote,
     quoteContributions,

--- a/src/sources/provider-router/primary.ts
+++ b/src/sources/provider-router/primary.ts
@@ -1,3 +1,5 @@
+import { selectCachedResource } from "./cache";
+import { financialHistoryVariants, hasReusableExtendedHistory } from "./statement-history";
 import type { MarketDataRequestContext } from "../../types/data-provider";
 import type { Quote, TickerFinancials } from "../../types/financials";
 import { normalizeTickerFinancialsPriceHistory } from "../../utils/price-history";
@@ -57,19 +59,25 @@ export class ProviderRouterPrimaryRoutes {
     context?: MarketDataRequestContext,
   ): Promise<SourceResult<TickerFinancials> | null> {
     const entityKey = this.options.getEntityKey(ticker, context?.instrument);
-    const variantKey = this.options.getTickerVariantCandidates(exchange)[0] ?? "";
+    const variantKey = financialHistoryVariants(this.options.getTickerVariantCandidates(exchange), context)[0] ?? "";
     let primaryResult: SourceResult<TickerFinancials> | null = null;
 
     for (const provider of this.options.providersInPriorityOrder()) {
       try {
         const rawValue = await provider.getTickerFinancials(ticker, exchange, context);
         const resolvedValue = resolveTickerFinancialsQuoteState(normalizeTickerFinancialsPriceHistory(rawValue));
-        const value = resolvedValue ? dropUnusableProviderQuote(resolvedValue, exchange) : null;
+        let value = resolvedValue ? dropUnusableProviderQuote(resolvedValue, exchange) : null;
         if (!value) continue;
         const sourceKey = this.options.providerSourceKey(provider);
+        if (context?.statementHistory === "extended" && !hasReusableExtendedHistory(value)) {
+          const previous = selectCachedResource<TickerFinancials>(this.options.resources, "financials", entityKey, [variantKey], [sourceKey], true);
+          const attempt = value.statementHistory;
+          value = { ...mergeFinancials(value, previous?.value ?? null)!, statementHistory: attempt };
+        }
         const cacheValue = primaryResult
           ? {
             financialCurrency: value.financialCurrency,
+            statementHistory: value.statementHistory,
             annualStatements: value.annualStatements,
             quarterlyStatements: value.quarterlyStatements,
             priceHistory: [],
@@ -81,11 +89,13 @@ export class ProviderRouterPrimaryRoutes {
           variantKey,
           sourceKey,
           cacheValue,
-          this.options.resolveProviderPolicy("financials", provider),
+          context?.statementHistory === "extended" && !hasReusableExtendedHistory(value)
+            ? { staleMs: 60_000, expireMs: 60_000 }
+            : this.options.resolveProviderPolicy("financials", provider),
         );
         if (!primaryResult) {
           primaryResult = { sourceKey, value };
-          if (hasDetailedStatementRows(value) && hasDeepStatementHistory(value)) return primaryResult;
+          if (context?.statementHistory === "extended" ? value.statementHistory?.status === "available" : hasDetailedStatementRows(value) && hasDeepStatementHistory(value)) return primaryResult;
           continue;
         }
         if (!primaryResult.value.quote && value.quote) {
@@ -104,7 +114,7 @@ export class ProviderRouterPrimaryRoutes {
             sourceKey: primaryResult.sourceKey,
             value: mergeMissingStatementArrays(primaryResult.value, value),
           };
-          if (hasDetailedStatementRows(primaryResult.value) && hasDeepStatementHistory(primaryResult.value)) return primaryResult;
+          if (context?.statementHistory === "extended" ? primaryResult.value.statementHistory?.status === "available" : hasDetailedStatementRows(primaryResult.value) && hasDeepStatementHistory(primaryResult.value)) return primaryResult;
         }
       } catch (error) {
         if (shouldLogProviderError(error)) {

--- a/src/sources/provider-router/statement-history.test.ts
+++ b/src/sources/provider-router/statement-history.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, expect, test } from "bun:test";
+import { AppPersistence } from "../../data/app-persistence";
+import type { MarketDataRequestContext } from "../../types/data-provider";
+import { AssetDataRouter } from "./index";
+import { cleanupProviderRouterTestFiles, createTempDbPath, fallbackProvider, makeFinancials, makeQuote } from "./test-support";
+
+const rows = Array.from({ length: 19 }, (_, index) => ({ date: `${2007 + index}-12-31`, currency: "USD", totalRevenue: 100 + index, operatingIncome: 40, inventory: 5 }));
+const financials = (extended: boolean, status: "available" | "retryable-failure" = "available") => makeFinancials({
+ quote: makeQuote(), profile: { description: "Microsoft Corporation" }, annualStatements: extended ? rows : rows.slice(-5),
+ ...(extended ? { statementHistory: { mode: "extended" as const, source: "sec" as const, status, fetchedAt: new Date().toISOString() } } : {}),
+});
+afterEach(cleanupProviderRouterTestFiles);
+
+test("extended requests bypass a default deep cache and reuse the whole extended source for later counts", async () => {
+ const persistence = new AppPersistence(createTempDbPath("extended"));
+ const calls: Array<MarketDataRequestContext | undefined> = [];
+ const provider = { ...fallbackProvider, async getTickerFinancials(_symbol: string, _exchange?: string, context?: MarketDataRequestContext) { calls.push(context); return financials(context?.statementHistory === "extended"); } };
+ const router = new AssetDataRouter(provider, [], persistence.resources);
+ try {
+  expect((await router.getTickerFinancials("MSFT", "NASDAQ")).annualStatements).toHaveLength(5);
+  expect((await router.getTickerFinancials("MSFT", "NASDAQ", { statementHistory: "extended" })).annualStatements).toHaveLength(19);
+  const second = new AssetDataRouter(provider, [], persistence.resources);
+  expect((await second.getTickerFinancials("MSFT", "NASDAQ", { statementHistory: "extended" })).annualStatements).toHaveLength(19);
+  expect((await second.getTickerFinancials("MSFT", "NASDAQ")).annualStatements).toHaveLength(5);
+  expect(calls.map(c => c?.statementHistory)).toEqual([undefined, "extended"]);
+ } finally { persistence.close(); }
+});
+
+test("failed extension keeps usable rows and retries instead of caching a shallow answer for statement TTL", async () => {
+ const persistence = new AppPersistence(createTempDbPath("extended-retry"));
+ let calls = 0;
+ const provider = { ...fallbackProvider, async getTickerFinancials() { calls++; return financials(true, calls === 1 ? "retryable-failure" : "available"); } };
+ const router = new AssetDataRouter(provider, [], persistence.resources);
+ try {
+  expect((await router.getTickerFinancials("MSFT", "NASDAQ", { statementHistory: "extended" })).annualStatements).toHaveLength(19);
+  expect((await router.getTickerFinancials("MSFT", "NASDAQ", { statementHistory: "extended" })).statementHistory?.status).toBe("available");
+  expect(calls).toBe(2);
+ } finally { persistence.close(); }
+});
+
+test("mixed batches retain extended intent through the single route instead of default batch cache", async () => {
+ let batches = 0;
+ const contexts: Array<MarketDataRequestContext | undefined> = [];
+ const router = new AssetDataRouter({ ...fallbackProvider,
+  async getTickerFinancialsBatch(targets) { batches++; return targets.map(target => ({ target, financials: financials(false) })); },
+  async getTickerFinancials(_symbol, _exchange, context) { contexts.push(context); return financials(context?.statementHistory === "extended"); },
+ });
+ const result = await router.getTickerFinancialsBatch([{ symbol: "MSFT", exchange: "NASDAQ", statementHistory: "extended" }, { symbol: "V", exchange: "NYSE" }]);
+ expect(result.map(item => item.financials?.annualStatements.length)).toEqual([19, 5]);
+ expect(contexts[0]?.statementHistory).toBe("extended");
+ expect(batches).toBe(1);
+});
+
+test("a failed refresh preserves the previous extended rows across repeated retries", async () => {
+ const persistence = new AppPersistence(createTempDbPath("extended-last-good"));
+ let failed = false;
+ const provider = { ...fallbackProvider, async getTickerFinancials() {
+  const value = financials(true, failed ? "retryable-failure" : "available");
+  return failed ? { ...value, annualStatements: value.annualStatements.slice(-4) } : value;
+ } };
+ const router = new AssetDataRouter(provider, [], persistence.resources);
+ try {
+  await router.getTickerFinancials("MSFT", "NASDAQ", { statementHistory: "extended" });
+  failed = true;
+  for (let attempt = 0; attempt < 2; attempt++) {
+   const value = await router.getTickerFinancials("MSFT", "NASDAQ", { statementHistory: "extended", cacheMode: "refresh" });
+   expect(value.annualStatements).toHaveLength(19);
+   expect(value.statementHistory?.status).toBe("retryable-failure");
+  }
+ } finally { persistence.close(); }
+});

--- a/src/sources/provider-router/statement-history.ts
+++ b/src/sources/provider-router/statement-history.ts
@@ -1,0 +1,15 @@
+import type { MarketDataRequestContext } from "../../types/data-provider";
+import type { TickerFinancials } from "../../types/financials";
+
+export function financialHistoryVariants(variants: string[], context?: MarketDataRequestContext): string[] {
+  return context?.statementHistory === "extended"
+    ? variants.map((variant) => `${variant};history=extended:v1`)
+    : variants;
+}
+
+/** A nominal row count never certifies that the extended source was attempted. */
+export function hasReusableExtendedHistory(value: TickerFinancials | null | undefined): boolean {
+  const attempt = value?.statementHistory;
+  return !!attempt && attempt.status !== "retryable-failure"
+    && Date.now() - Date.parse(attempt.fetchedAt) < 6 * 60 * 60_000;
+}

--- a/src/sources/sec-edgar.test.ts
+++ b/src/sources/sec-edgar.test.ts
@@ -140,6 +140,7 @@ describe("parseCompanyFactsFinancialStatements", () => {
       NetIncomeLoss: { units: { USD: [{ ...earlier, accn: "0000909832-24-000050", filed: "2024-10-20", val: 10 }] } },
     } } });
     expect(statements.annualStatements[0]).toMatchObject({ date: "2024-09-01", dateSource: "sec",
+      currency: "USD",
       dateEvidence: { accessionNumber: earlier.accn, filed: earlier.filed, startDate: earlier.start },
       availableAt: "2024-10-20", fieldAvailability: { totalRevenue: "2024-10-09", netIncome: "2024-10-20" } });
   });
@@ -251,6 +252,7 @@ describe("parseCompanyFactsFinancialStatements", () => {
     expect(statements.annualStatements).toEqual([{
       date: "2020-12-31",
       dateSource: "sec",
+      currency: "USD",
       availableAt: "2020-12-31",
       fieldAvailability: {
         totalRevenue: "2020-12-31",
@@ -271,6 +273,7 @@ describe("parseCompanyFactsFinancialStatements", () => {
       {
         date: "2021-03-31",
         dateSource: "sec",
+      currency: "USD",
         availableAt: "2021-03-31",
         fieldAvailability: {
           totalRevenue: "2021-03-31",
@@ -290,6 +293,7 @@ describe("parseCompanyFactsFinancialStatements", () => {
       {
         date: "2021-06-30",
         dateSource: "sec",
+      currency: "USD",
         availableAt: "2021-06-30",
         fieldAvailability: { totalRevenue: "2021-06-30" },
         totalRevenue: 40,
@@ -339,6 +343,7 @@ describe("parseCompanyFactsFinancialStatements", () => {
     expect(parseCompanyFactsFinancialStatements(payload).quarterlyStatements).toEqual([{
       date: "2025-03-29",
       dateSource: "sec",
+      currency: "USD",
       availableAt: "2025-05-02",
       fieldAvailability: { totalRevenue: "2025-05-02" },
       totalRevenue: 95_359,
@@ -467,6 +472,7 @@ describe("parseCompanyFactsFinancialStatements", () => {
       {
         date: "2025-03-31",
         dateSource: "sec",
+      currency: "USD",
         availableAt: "2025-03-31",
         fieldAvailability: { totalRevenue: "2025-03-31", grossProfit: "2025-03-31" },
         totalRevenue: 100,
@@ -475,6 +481,7 @@ describe("parseCompanyFactsFinancialStatements", () => {
       {
         date: "2026-03-31",
         dateSource: "sec",
+      currency: "USD",
         availableAt: "2026-03-31",
         fieldAvailability: { totalRevenue: "2026-03-31", grossProfit: "2026-03-31" },
         totalRevenue: 200,
@@ -856,4 +863,22 @@ test("SEC acceptance timestamps preserve source values without inferring missing
   expect(rows.map((row) => row.acceptedAt?.toISOString())).toEqual([
     "2026-09-09T20:54:25.000Z", "2025-03-20T20:05:00.000Z", undefined, undefined,
   ]);
+});
+
+test("statement retrieval verifies the issuer and preserves class identity without borrowing issuer EPS", async () => {
+  const client = new SecEdgarClient() as any;
+  client.loadLookup = async () => new Map([["BRK-B", { cik: "0001067983" }]]);
+  const raw = {
+    cik: 1067983,
+    facts: { "us-gaap": {
+      Revenues: { units: { USD: [{ start: "2025-01-01", end: "2025-12-31", val: 100, form: "10-K", filed: "2026-02-15" }] } },
+      EarningsPerShareDiluted: { units: { "USD/shares": [{ start: "2025-01-01", end: "2025-12-31", val: 200, form: "10-K", filed: "2026-02-15" }] } },
+    } },
+  };
+  client.fetchJson = async () => raw;
+  const value = await client.getFinancialStatements("BRK.B");
+  expect(value.annualStatements[0]).toMatchObject({ currency: "USD", totalRevenue: 100 });
+  expect(value.annualStatements[0].eps).toBeUndefined();
+  client.fetchJson = async () => ({ ...raw, cik: 789019 });
+  await expect(client.getFinancialStatements("BRK.B")).rejects.toThrow("issuer mismatch");
 });

--- a/src/sources/sec-edgar.ts
+++ b/src/sources/sec-edgar.ts
@@ -492,6 +492,7 @@ function isAnnualDurationFact(entry: CompanyFactsEntry): boolean {
 }
 
 function isQuarterlyCompanyFact(entry: CompanyFactsEntry, periodType: "duration" | "instant"): boolean {
+  if (!/^(10-K|10-Q)(\/A)?$/.test(normalize(entry.form))) return false;
   if (periodType === "instant") {
     return /^CY\d{4}Q[1-4]I$/.test(entry.frame ?? "")
       || (
@@ -523,7 +524,7 @@ function setCompanyFactValue(
 ): void {
   const selectionKey = `${date}:${String(field)}`;
   if (!shouldReplaceCompanyFact(entry, selectedFacts.get(selectionKey))) return;
-  const row = rows.get(date) ?? { date, dateSource: "sec" };
+  const row = rows.get(date) ?? { date, dateSource: "sec", currency: "USD" };
   (row as unknown as Record<string, unknown>)[field] = value;
   if (entry.filed) {
     row.fieldAvailability = {
@@ -586,10 +587,8 @@ function finalizeCompanyFactsStatements(rows: Map<string, FinancialStatement>, s
       statement.freeCashFlow = statement.operatingCashFlow + statement.capitalExpenditure;
       const operatingCashFlowAvailableAt = statement.fieldAvailability?.operatingCashFlow;
       const capitalExpenditureAvailableAt = statement.fieldAvailability?.capitalExpenditure;
-      const derivedAvailableAt = [operatingCashFlowAvailableAt, capitalExpenditureAvailableAt]
-        .filter((value): value is string => !!value)
-        .sort()
-        .at(-1);
+      const derivedAvailableAt = operatingCashFlowAvailableAt && capitalExpenditureAvailableAt
+        ? [operatingCashFlowAvailableAt, capitalExpenditureAvailableAt].sort().at(-1) : undefined;
       if (derivedAvailableAt) {
         statement.fieldAvailability = {
           ...(statement.fieldAvailability ?? {}),
@@ -597,6 +596,10 @@ function finalizeCompanyFactsStatements(rows: Map<string, FinancialStatement>, s
         };
       }
     }
+    const numericFields = Object.keys(statement).filter((field) => typeof (statement as unknown as Record<string, unknown>)[field] === "number");
+    statement.fieldAvailability ??= {};
+    statement.availableAt = numericFields.every((field) => statement.fieldAvailability?.[field])
+      ? Object.values(statement.fieldAvailability).sort().at(-1) : undefined;
   }
   return statements;
 }
@@ -752,11 +755,19 @@ export class SecEdgarClient {
     if (!normalizedTicker) return null;
 
     const lookup = await this.loadLookup();
-    const entry = lookup.get(normalizedTicker);
+    const entry = lookup.get(normalizedTicker) ?? lookup.get(normalizedTicker.replace(/\./g, "-"));
     if (!entry) return null;
 
     const payload = await this.fetchJson<unknown>(`${COMPANY_FACTS_URL}/CIK${entry.cik}.json`);
-    return parseCompanyFactsFinancialStatements(payload);
+    if (zeroPadCik(asRecord(payload)?.cik) !== entry.cik) throw new Error("SEC companyfacts issuer mismatch");
+    const statements = parseCompanyFactsFinancialStatements(payload);
+    if (/[.-]/.test(normalizedTicker)) {
+      for (const row of [...statements.annualStatements, ...statements.quarterlyStatements]) {
+        delete row.eps;
+        if (row.fieldAvailability) delete row.fieldAvailability.eps;
+      }
+    }
+    return statements;
   }
 
   async getFilingDocuments(filing: SecFilingItem): Promise<SecFilingDocument[]> {

--- a/src/sources/yahoo-finance.ts
+++ b/src/sources/yahoo-finance.ts
@@ -69,33 +69,43 @@ export class YahooFinanceClient implements DataProvider {
 
   private shouldSupplementSecStatements(ticker: string, exchange: string, financials: TickerFinancials): boolean {
     if (!/^[A-Z0-9.-]+$/i.test(ticker.trim())) return false;
-    if (ticker.includes(".")) return false;
+    if (ticker.includes(".") && !/^[A-Z]+\.[AB]$/i.test(ticker)) return false;
     const normalizedExchange = exchange.trim().toUpperCase();
     return SEC_STATEMENT_SUPPLEMENT_EXCHANGES.has(normalizedExchange)
-      && (financials.quote?.currency ?? "USD").toUpperCase() === "USD";
+      && (financials.quote?.currency ?? "USD").toUpperCase() === "USD"
+      && ![financials.financialCurrency, ...financials.annualStatements.map((row) => row.currency), ...financials.quarterlyStatements.map((row) => row.currency)].some((currency) => currency != null && currency.toUpperCase() !== "USD");
   }
 
   private async supplementSecStatements(
     ticker: string,
     exchange: string,
     financials: TickerFinancials,
+    extended = false,
   ): Promise<TickerFinancials> {
-    if (!this.shouldSupplementSecStatements(ticker, exchange, financials)) return financials;
+    const stamp = (status: "available" | "unsupported" | "retryable-failure") => extended
+      ? { mode: "extended" as const, source: "sec" as const, status, fetchedAt: new Date().toISOString() } : undefined;
+    if (!this.shouldSupplementSecStatements(ticker, exchange, financials)) return { ...financials, statementHistory: stamp("unsupported") };
     try {
       const secStatements = await this.secClient.getFinancialStatements(ticker);
       if (
         !secStatements
         || (secStatements.annualStatements.length === 0 && secStatements.quarterlyStatements.length === 0)
       ) {
-        return financials;
+        return { ...financials, statementHistory: stamp("unsupported") };
       }
       return {
         ...financials,
-        annualStatements: mergeFinancialStatementRows(financials.annualStatements, secStatements.annualStatements),
-        quarterlyStatements: mergeFinancialStatementRows(financials.quarterlyStatements, secStatements.quarterlyStatements),
+        financialCurrency: financials.financialCurrency ?? "USD",
+        statementHistory: stamp("available"),
+        annualStatements: extended
+          ? mergeFinancialStatementRows(secStatements.annualStatements, financials.annualStatements)
+          : mergeFinancialStatementRows(financials.annualStatements, secStatements.annualStatements),
+        quarterlyStatements: extended
+          ? mergeFinancialStatementRows(secStatements.quarterlyStatements, financials.quarterlyStatements)
+          : mergeFinancialStatementRows(financials.quarterlyStatements, secStatements.quarterlyStatements),
       };
     } catch {
-      return financials;
+      return { ...financials, statementHistory: stamp("retryable-failure") };
     }
   }
 
@@ -128,7 +138,7 @@ export class YahooFinanceClient implements DataProvider {
   }
 
   /** Fetch full financials for a ticker */
-  async getTickerFinancials(ticker: string, exchange = "", _context?: MarketDataRequestContext): Promise<TickerFinancials> {
+  async getTickerFinancials(ticker: string, exchange = "", context?: MarketDataRequestContext): Promise<TickerFinancials> {
     const symbolsToTry = getYahooSymbolsToTry(ticker, exchange);
     let lastError: any;
 
@@ -145,7 +155,7 @@ export class YahooFinanceClient implements DataProvider {
           fetchTimeseries: (targetSymbol, types, period1) => this.fetchTimeseries(targetSymbol, types, period1),
           providerId: this.id,
         });
-        return await this.supplementSecStatements(ticker, exchange, result);
+        return await this.supplementSecStatements(ticker, exchange, result, context?.statementHistory === "extended");
       } catch (err) {
         lastError = err;
       }

--- a/src/time-series/financial-history-request.test.ts
+++ b/src/time-series/financial-history-request.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test";
+import { createTestDataProvider } from "../test-support/data-provider";
+import { ChartResolveCache, resolveChartSpecData } from "./resolve";
+import { CHART_SPEC_VERSION, type ChartSpec } from "./types";
+
+test("calendar windows and counts share extended history while current multiples use a separate default flight", async () => {
+ const calls: Array<string | undefined> = [];
+ const provider = createTestDataProvider({ async getTickerFinancials(_symbol, _exchange, context) {
+  calls.push(context?.statementHistory);
+  await new Promise(resolve => setTimeout(resolve, 1));
+  return { annualStatements: [{ date: "2025-12-31", totalRevenue: 100 }], quarterlyStatements: [], priceHistory: [] };
+ } });
+ const spec = (maxPoints?: number): ChartSpec => ({ version: CHART_SPEC_VERSION, viewport: { range: "ALL", resolution: "auto", maxPoints }, panels: [{ id: "main" }], studies: [], series: [{ id: "revenue", style: "line", axis: "left", panelId: "main", transform: "raw", interpolation: "none", source: { kind: "security", instrument: { symbol: "MSFT", exchange: "NASDAQ" }, fieldId: "fundamental.totalRevenue", period: "annual" } }] });
+ const cache = new ChartResolveCache();
+ const snapshot = spec();
+ snapshot.series[0]!.source = { kind: "security", instrument: { symbol: "MSFT", exchange: "NASDAQ" }, fieldId: "valuation.forwardPE" };
+ const fiveYear = spec(); fiveYear.viewport.range = "5Y";
+ await Promise.all([snapshot, fiveYear, spec(10), spec(20)].map(value => resolveChartSpecData(value, { dataProvider: provider }, cache)));
+ expect(calls.sort()).toEqual(["extended", undefined]);
+});

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -910,16 +910,29 @@ export async function resolveChartSpecData(
   const initialVisibleBounds = requestedBounds(spec, referenceNow);
 
   const loadFinancials = (source: Extract<ChartSeriesSpec["source"], { kind: "security" }>) => {
-    const key = instrumentKey(source);
+    const fieldId = getTimeSeriesField(source.fieldId)?.id ?? source.fieldId;
+    // Calendar-window research needs the same full source bundle as a period
+    // count. Current forward multiples have no historical statement series.
+    const statementHistory = /^(fundamental|valuation)\./.test(fieldId)
+      && fieldId !== "valuation.forwardPE" && fieldId !== "valuation.pegRatio"
+      ? "extended" as const : undefined;
+    const key = `${instrumentKey(source)}|history:${statementHistory ?? "default"}`;
     let pending = cache.financialsByInstrument.get(key);
     if (!pending) {
       pending = sources.dataProvider!
         .getTickerFinancials(
           source.instrument.symbol,
           source.instrument.exchange ?? "",
-          requestContext(source),
+          { ...requestContext(source), statementHistory },
         )
-        .catch(() => null);
+        .then((value) => {
+          if (value.statementHistory?.status === "retryable-failure") {
+            warnings.push(`${source.instrument.symbol}: extended SEC history is temporarily unavailable; retained observations may be from an earlier retrieval.`);
+          }
+          if (statementHistory && (!value.statementHistory || value.statementHistory.status === "retryable-failure")) cache.financialsByInstrument.delete(key);
+          return value;
+        })
+        .catch(() => { cache.financialsByInstrument.delete(key); return null; });
       cache.financialsByInstrument.set(key, pending);
     }
     return pending;

--- a/src/types/data-provider.ts
+++ b/src/types/data-provider.ts
@@ -87,9 +87,11 @@ export interface MarketDataRequestContext {
   brokerInstanceId?: string;
   instrument?: BrokerContractRef | null;
   cacheMode?: "default" | "refresh";
+  statementHistory?: "extended";
 }
 
 export interface CachedFinancialsTarget {
+  statementHistory?: "extended";
   symbol: string;
   exchange?: string;
   brokerId?: string;

--- a/src/types/financials.ts
+++ b/src/types/financials.ts
@@ -418,7 +418,18 @@ export interface PricePoint {
   volume?: number;
 }
 
+export interface StatementHistoryAttempt {
+  mode: "extended";
+  source: "sec";
+  status: "available" | "unsupported" | "retryable-failure";
+  fetchedAt: string;
+  attemptedAt?: string;
+  cik?: string;
+  reason?: string;
+}
+
 export interface TickerFinancials {
+  statementHistory?: StatementHistoryAttempt;
   financialCurrency?: string;
   quote?: Quote;
   quoteContributions?: QuoteContributionMap;


### PR DESCRIPTION
Historical financial charts can show only four annual values or five quarters despite requesting a much longer window. Request the backend's extended statement bundle for historical fundamental and valuation fields, for both calendar windows and explicit period counts. Current-only forward P/E and PEG snapshots keep the default request.

Default and extended cache/in-flight keys stay separate. Captured snapshots and batch shortcuts cannot satisfy an extended request with shallow data; failed enrichment preserves prior observations, retries, and reports a warning. Native SEC supplementation verifies the issuer, labels USD fact units, rejects unsupported filing forms and avoids borrowing issuer EPS for a qualified share class. Existing requested-versus-usable coverage and latest-vintage disclosures are retained.

Validation: all 2,910 tests pass (10,936 assertions) and all six runtime TypeScript checks pass. Cloud-only CLI through the paired local backend returns 10 annual operating-margin observations each for MSFT/V/COST; all 30 match independent arithmetic from raw SEC facts exactly. The ordinary five-year MSFT quarterly revenue chart returns 20 quarters. Annual 20 stays partial at 19/19/18; the same SEC bundle is reused. An isolated native terminal run rendered all three histories with complete axes and the vintage notice. Actual browser command and chart-editor validation also passed: annual ALL rendered all three histories (19/19/18 annual rows), with extended HTTP requests captured.

Requires backend https://github.com/vincelwt/gloomberb-platform/pull/230 for browser SEC retrieval. The HTTP integration uses fresh ordinary-provider production captures and live SEC requests with isolated storage; production deployment validation remains outstanding. Latest facts are not historical as-of reconstruction. Hold merge for review; no release.
