### PR TITLE
Preserve listing identity in browser research links

### DIFF
--- a/src/app/pane-runtime/ticker-open-runtime.test.tsx
+++ b/src/app/pane-runtime/ticker-open-runtime.test.tsx
@@ -7,12 +7,23 @@ import { createInitialState, type AppAction } from "../../state/app/context";
 import { createDefaultConfig, createPaneInstance, TICKER_RESEARCH_PANE_ID } from "../../types/config";
 import type { TickerRecord } from "../../types/ticker";
 import { useAppTickerOpenRuntime } from "./ticker-open-runtime";
+import { researchEntryFromSearch } from "../../renderers/browser/research-entry";
 
 test("a slow linked ticker applies its tab to the reused or new pane after hydration", async () => {
-  for (const reusePane of [true, false]) {
+  for (const { savedListing, savedExchange, reusePane } of [
+    { savedListing: "VOD:XLON", savedExchange: "JSE", reusePane: true },
+    { savedListing: "VOD", savedExchange: "LSE", reusePane: true },
+    { savedListing: "VOD", savedExchange: "JSE", reusePane: false },
+  ]) {
     const config = createDefaultConfig(":memory:");
-    config.layout = createBrowserResearchLayout(reusePane ? "VOD:XLON" : "NVDA");
+    config.layout = createBrowserResearchLayout(savedListing);
     const stateRef = { current: createInitialState(config) };
+    // A saved same-spelling issuer on another venue must not satisfy the link.
+    stateRef.current.tickers.set("VOD", { metadata: {
+      ticker: "VOD", exchange: savedExchange,
+      currency: savedExchange === "LSE" ? "GBP" : "ZAR", name: savedExchange === "LSE" ? "Vodafone" : "Vodacom",
+      portfolios: [], watchlists: [], positions: [], custom: {}, tags: [],
+    } });
     const actions: AppAction[] = [];
     const focused: string[] = [];
     let layouts = 0;
@@ -45,10 +56,12 @@ test("a slow linked ticker applies its tab to the reused or new pane after hydra
     const rendered = await testRender(<Harness />, { width: 20, height: 2 });
     try {
       await act(async () => { await rendered.renderOnce(); });
-      const opening = runtime.openPinnedTicker("VOD:XLON", { tabId: "financials", floating: true });
+      const entry = researchEntryFromSearch("?ticker=VOD&exchange=LSE&tab=financials")!;
+      const opening = runtime.openPinnedTicker(entry.symbol, { tabId: entry.tab, floating: true });
       // Focus may change while the provider is still resolving the linked listing.
       stateRef.current.focusedPaneId = "world-indices:main";
-      expect(actions).toEqual([]);
+      // Explicit exact local matches may resolve without the deferred provider.
+      if (savedExchange !== "LSE") expect(actions).toEqual([]);
       releaseSearch();
       await act(async () => { await opening; });
       const paneId = reusePane ? BROWSER_RESEARCH_PANE_ID : "ticker-detail:linked";
@@ -58,7 +71,9 @@ test("a slow linked ticker applies its tab to the reused or new pane after hydra
       expect(stateRef.current.config.layout.instances.find((pane) => pane.instanceId === paneId)?.binding)
         .toEqual({ kind: "fixed", symbol: "VOD:XLON" });
       expect(focused).toEqual([paneId]);
-      expect(layouts).toBe(reusePane ? 0 : 1);
+      expect(layouts).toBe(savedListing === "VOD:XLON" ? 0 : 1);
+      expect(stateRef.current.config.layout.instances.filter((pane) => pane.paneId === TICKER_RESEARCH_PANE_ID))
+        .toHaveLength(reusePane ? 1 : 2);
     } finally {
       await act(async () => { rendered.renderer.destroy(); });
     }

--- a/src/app/pane-runtime/ticker-open-runtime.ts
+++ b/src/app/pane-runtime/ticker-open-runtime.ts
@@ -21,6 +21,9 @@ import {
   resolveTickerOpenTarget,
   type TickerOpenTarget,
 } from "../../tickers/open-target";
+import { findExactTickerSearchMatch } from "../../tickers/search";
+import { parsePublicTickerKey } from "../../utils/exchanges";
+import { tickerHasYahooSuffix } from "../../sources/yahoo-finance/symbols";
 
 interface UseAppTickerOpenRuntimeOptions {
   activatePane: (paneId: string, layout?: LayoutConfig) => void;
@@ -89,14 +92,38 @@ export function useAppTickerOpenRuntime({
     const symbol = target.symbol;
     const currentState = stateRef.current;
     const currentLayout = currentState.config.layout;
-    const existing = options?.forceNewPane
+    let existing = options?.forceNewPane
       ? null
       : findFixedTickerPaneForSymbol(currentLayout, paneType, symbol);
+    if (!options?.forceNewPane && !existing && (parsePublicTickerKey(symbol).exchange || tickerHasYahooSuffix(symbol))) {
+      existing = currentLayout.instances.find((instance) => {
+        if (instance.paneId !== paneType || instance.binding?.kind !== "fixed" || !isPaneInLayout(currentLayout, instance.instanceId)) return false;
+        const ticker = currentState.tickers.get(instance.binding.symbol);
+        return !!ticker?.metadata.exchange && !!findExactTickerSearchMatch([
+          { label: instance.binding.symbol, right: ticker.metadata.exchange },
+        ], symbol);
+      }) ?? null;
+    }
     if (existing) {
+      // A reload can qualify a previously bare saved symbol. Reuse only the
+      // verified same listing, retaining its pane identity and its followers.
+      const previousSymbol = existing.binding?.kind === "fixed" ? existing.binding.symbol : null;
+      let nextLayout = currentLayout;
+      if (previousSymbol && previousSymbol !== symbol) {
+        const existingId = existing.instanceId;
+        nextLayout = { ...currentLayout, instances: currentLayout.instances.map((instance) => (
+          instance.instanceId === existingId ? {
+            ...instance,
+            binding: { kind: "fixed" as const, symbol },
+            title: !instance.title || instance.title === previousSymbol ? symbol : instance.title,
+          } : instance
+        )) };
+        persistLayout(nextLayout);
+      }
       if (paneType === TICKER_RESEARCH_PANE_ID && options?.tabId) {
         dispatch({ type: "UPDATE_PANE_STATE", paneId: existing.instanceId, patch: { activeTabId: options.tabId } });
       }
-      focusVisiblePane(existing.instanceId, currentLayout);
+      focusVisiblePane(existing.instanceId, nextLayout);
       return;
     }
 

--- a/src/plugins/builtin/ticker-detail/pane.tsx
+++ b/src/plugins/builtin/ticker-detail/pane.tsx
@@ -28,6 +28,8 @@ import { TICKER_RESEARCH_BUILTIN_TABS } from "./research-tabs";
 import { useLiveStreamingSetting } from "../shared/live-streaming";
 import { useCloudAccessFooter } from "../shared/cloud-upgrade";
 import { CLOUD_QUOTE_DELAY_MINUTES } from "../shared/plan-access";
+import { parsePublicTickerKey } from "../../../utils/exchanges";
+import { tickerHasYahooSuffix } from "../../../sources/yahoo-finance/symbols";
 
 const TICKER_RESEARCH_TAB_COMMIT_DELAY_MS = 120;
 
@@ -104,9 +106,16 @@ export function TickerResearchPane({ focused, width, height }: PaneProps) {
     if (!focused || !ticker || getCurrentPluginTarget() !== "web") return;
     const url = new URL(window.location.href);
     url.searchParams.set("ticker", ticker.metadata.ticker);
+    // A bare ticker can name different issuers on different venues. Keep the
+    // selected listing on reload, and replace any previous pane's venue.
+    if (ticker.metadata.exchange && !parsePublicTickerKey(ticker.metadata.ticker).exchange && !tickerHasYahooSuffix(ticker.metadata.ticker)) {
+      url.searchParams.set("exchange", ticker.metadata.exchange);
+    } else {
+      url.searchParams.delete("exchange");
+    }
     url.searchParams.set("tab", activeTabId);
     window.history.replaceState(window.history.state, "", url.href);
-  }, [focused, ticker?.metadata.ticker, activeTabId]);
+  }, [focused, ticker?.metadata.ticker, ticker?.metadata.exchange, activeTabId]);
   const [pluginCaptured, setPluginCaptured] = useState(false);
   useEffect(() => {
     if (focused && Number.isFinite(financials?.quote?.price) && (financials?.quote?.price ?? 0) > 0) {

--- a/src/renderers/browser/deeplink-bridge.test.ts
+++ b/src/renderers/browser/deeplink-bridge.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
 
 describe("browser social share handoff", () => {
   test("preserves the incoming ticker while the previous workspace restores", () => {
-    const location = { search: "?ticker=NVDA&tab=earnings-calls" };
+    const location = { search: "?ticker=VOD&exchange=LSE&tab=earnings-calls" };
     Object.defineProperty(globalThis, "window", { configurable: true, value: {
       location, addEventListener() {}, removeEventListener() {},
     } });
@@ -18,7 +18,7 @@ describe("browser social share handoff", () => {
     location.search = "?ticker=AAPL&tab=overview";
     const seen: string[] = [];
     bridge.subscribe(({ url }) => seen.push(url));
-    expect(seen).toEqual(["gloomberb://ticker/NVDA?tab=earnings-calls"]);
+    expect(seen).toEqual(["gloomberb://ticker/VOD%3AXLON?tab=earnings-calls"]);
   });
   test("maps a valid pane share query to the common deep-link runtime", () => {
     const id = "0123456789abcdef0123456789abcdef";

--- a/src/renderers/browser/research-entry.test.ts
+++ b/src/renderers/browser/research-entry.test.ts
@@ -6,3 +6,15 @@ test("normalizes ticker links while rejecting commands and invalid tab paths", (
   expect(researchEntryFromSearch("?ticker=NVDA&tab=../../bad")).toEqual({ symbol: "NVDA", tab: "overview" });
   for (const search of ["", "?ticker=", "?ticker=NVDA%20%3B%20rm", "?ticker=%3Cscript%3E"]) expect(researchEntryFromSearch(search)).toBeNull();
 });
+
+test("venue-qualified browser entries preserve listing identity and explicit symbol precedence", () => {
+  expect(researchEntryFromSearch("?ticker=vod&exchange=lse&tab=financials"))
+    .toEqual({ symbol: "VOD:XLON", tab: "financials" });
+  expect(researchEntryFromSearch("?ticker=BRK.B&exchange=NYSE"))
+    .toEqual({ symbol: "BRK.B:XNYS", tab: "overview" });
+  expect(researchEntryFromSearch("?ticker=ASML.AS&exchange=NASDAQ"))
+    .toEqual({ symbol: "ASML.AS", tab: "overview" });
+  expect(researchEntryFromSearch("?ticker=VOD%3AXLON&exchange=JSE"))
+    .toEqual({ symbol: "VOD:XLON", tab: "overview" });
+  expect(researchEntryFromSearch("?ticker=VOD&exchange=LSE%3Bbad")).toBeNull();
+});

--- a/src/renderers/browser/research-entry.ts
+++ b/src/renderers/browser/research-entry.ts
@@ -1,7 +1,17 @@
+import { tickerHasYahooSuffix } from "../../sources/yahoo-finance/symbols";
+import { parsePublicTickerKey, publicTickerKey } from "../../utils/exchanges";
+
 export function researchEntryFromSearch(search: string): { symbol: string; tab: string } | null {
   const params = new URLSearchParams(search);
   const symbol = params.get("ticker")?.trim().toUpperCase();
   if (!symbol || !/^[A-Z0-9.^=:_-]{1,24}$/.test(symbol)) return null;
+  const exchange = params.get("exchange")?.trim().toUpperCase();
+  if (exchange && !/^[A-Z0-9._-]{1,32}$/.test(exchange)) return null;
+  // Carry a separate venue through the same listing-qualified resolver used by
+  // search and deep links. An explicit symbol suffix/key remains authoritative.
+  const target = exchange && !parsePublicTickerKey(symbol).exchange && !tickerHasYahooSuffix(symbol)
+    ? publicTickerKey(symbol, exchange)
+    : symbol;
   const tab = params.get("tab") ?? "overview";
-  return { symbol, tab: /^[a-z-]{1,40}$/.test(tab) ? tab : "overview" };
+  return { symbol: target, tab: /^[a-z-]{1,40}$/.test(tab) ? tab : "overview" };
 }


### PR DESCRIPTION
A browser link such as `?ticker=VOD&exchange=LSE` discarded the exchange and opened Vodacom in Johannesburg (ZAR) instead of Vodafone in London (GBP). Carry the venue through the existing listing-qualified resolver and preserve the selected venue when a research pane updates its URL. Explicit suffixes and colon-qualified keys take precedence over conflicting exchange metadata.

Reloading a formerly bare symbol can now produce a qualified key. Reuse the verified same-listing research pane while preserving its instance ID, followers, custom title, and requested tab; a same-spelling security on another venue remains separate.

Validation: 33 focused tests / 144 assertions, all six TypeScript projects, and browser production build pass. Actual anonymous Chrome against live production data confirmed the original JSE/ZAR error, corrected London/GBP behavior with a saved JSE workspace, AAPL reload retaining six panes and zero floating duplicates, and ASML.AS retaining EUR despite exchange=NASDAQ. No response interception or clock overrides were used.

The initial suspicion that a saved NVDA workspace hid an AAPL link was disproven by complete screenshots: AAPL opens in a focused floating pane. This change does not reset saved workspaces. Signed-in cloud-synced layouts were not exercised. Audit evidence is recorded locally in persona-audit/workspace-url.json.
