### PR TITLE
Preserve complete chart cursor amounts and price precision

### DIFF
--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -1250,9 +1250,11 @@ describe("CompositeChart", () => {
     await act(async () => testSetup!.renderOnce());
 
     // Pressing the ruler icon has to arm the tool for an unmodified drag.
+    const toolbarRow = testSetup.captureCharFrame().split("\n").findIndex((line) => line.includes("↔"));
+    const rulerX = testSetup.captureCharFrame().split("\n")[toolbarRow]!.indexOf("↔");
     await act(async () => {
-      await testSetup!.mockMouse.moveTo(11, 1);
-      await testSetup!.mockMouse.click(11, 1);
+      await testSetup!.mockMouse.moveTo(rulerX, toolbarRow);
+      await testSetup!.mockMouse.click(rulerX, toolbarRow);
     });
     await act(async () => testSetup!.renderOnce());
     await act(async () => {
@@ -1264,7 +1266,7 @@ describe("CompositeChart", () => {
 
     await act(async () => {
       capturedSurfaceProps!.onMouseUp(pointerEvent(30, 2));
-      await testSetup!.mockMouse.click(11, 1);
+      await testSetup!.mockMouse.click(rulerX, toolbarRow);
     });
     await act(async () => testSetup!.renderOnce());
     await act(async () => {
@@ -1438,6 +1440,63 @@ describe("CompositeChart", () => {
     expect(frame).toContain("106%");
     expect(frame).toContain("2025-01-03");
     expect(frame).toContain("────────");
+  });
+
+  test.each([
+    ["USD", "currency-total:USD", 90_007_000_000, "$90.01B"],
+    ["EUR", "currency-total:EUR", -12_345_600_000, "€-12.35B"],
+    ["CAD", "currency-total:CAD", 123_456_000, "123.46M CAD"],
+    ["USD", "price:USD", 1_234_567.89, "$1,234,567.89"],
+    ["USD", "price:USD", 0.0123, "$0.0123"],
+    ["USD", "price:USD", 1e30, "…"],
+  ] as const)("renders a complete cursor marker for %s %s %s", async (unit, unitGroup, value, label) => {
+    testSetup = await testRender(
+      <CaptureChartSurfaceProvider>
+        <CompositeChart
+          width={60}
+          height={12}
+          showLegend={false}
+          series={[{
+            ...series("price", "main", "left", unit, [value * 0.8, value, value * 1.2]),
+            unitGroup,
+          }]}
+          panels={[{ id: "main" }]}
+          cursorDate={new Date("2025-01-02T00:00:00.000Z")}
+        />
+      </CaptureChartSurfaceProvider>,
+      { width: 62, height: 14 },
+    );
+    await act(async () => testSetup!.renderOnce());
+    expect(testSetup.captureCharFrame()).toContain(label);
+    expect(capturedSurfaceNode!.width).toBeGreaterThanOrEqual(30);
+  });
+
+  test("preserves integer-domain cursor decimals without moving the plot and honors hidden axes", async () => {
+    let setAxisWidth: ((value: number) => void) | null = null;
+    function Harness() {
+      const [axisWidth, setWidth] = useState(9);
+      setAxisWidth = setWidth;
+      return <CaptureChartSurfaceProvider>
+        <CompositeChart width={60} height={12} showLegend={false} axisWidth={axisWidth}
+          series={[series("price", "main", "left", "USD", [100, 200, 100])]}
+          panels={[{ id: "main" }]}
+        />
+      </CaptureChartSurfaceProvider>;
+    }
+    testSetup = await testRender(<Harness />, { width: 62, height: 14 });
+    await act(async () => testSetup!.renderOnce());
+    const plotWidth = capturedSurfaceNode!.width as number;
+    const plotHeight = capturedSurfaceNode!.height as number;
+    await act(async () => capturedSurfaceProps!.onMouseMove(pointerEvent(
+      (plotWidth - 1) / 2, (plotHeight - 1) * 0.4975,
+    )));
+    await act(async () => testSetup!.renderOnce());
+    expect(testSetup.captureCharFrame()).toContain("$150.28");
+    expect(capturedSurfaceNode!.width).toBe(plotWidth);
+    await act(async () => setAxisWidth?.(0));
+    await act(async () => testSetup!.renderOnce());
+    expect(capturedSurfaceNode!.width).toBe(60);
+    expect(testSetup.captureCharFrame()).not.toContain("$");
   });
 
   test("keeps the requested window while older cached observations partially overlap it", async () => {
@@ -1641,6 +1700,7 @@ describe("CompositeChart", () => {
 
   test("keeps the date axis and mouse recovery when refreshed data misses the zoomed window", async () => {
     let replacePoints: ((points: TimeSeriesPoint[]) => void) | null = null;
+    let lastWindow: { start: Date; end: Date } | null = null;
     function Harness() {
       const [points, setPoints] = useState(
         series("price", "main", "left", "USD", [100, 101, 102, 103, 104, 105, 106, 107, 108]).points,
@@ -1660,6 +1720,7 @@ describe("CompositeChart", () => {
             start: new Date("2025-01-01T00:00:00.000Z"),
             end: new Date("2025-01-09T00:00:00.000Z"),
           }}
+          onViewportChange={(next) => { lastWindow = next; }}
         />
       );
     }
@@ -1692,8 +1753,6 @@ describe("CompositeChart", () => {
 
     // An observation-free window keeps the chart frame and its axes; only the
     // plotted points go away.
-    // An observation-free window keeps the chart frame and its axes; only the
-    // plotted points go away.
     const emptyFrame = testSetup.captureCharFrame();
     expect(emptyFrame).not.toContain("No chart data");
     expect(emptyFrame).not.toContain("•");
@@ -1711,8 +1770,8 @@ describe("CompositeChart", () => {
 
     const recoveredFrame = testSetup.captureCharFrame();
     expect(recoveredFrame).toContain("•");
-    expect(recoveredFrame).toContain("2025-01-01");
-    expect(recoveredFrame).toContain("Jan 9");
+    expect(lastWindow!.start.getTime()).toBeLessThanOrEqual(Date.parse("2025-01-01"));
+    expect(lastWindow!.end.getTime()).toBeGreaterThanOrEqual(Date.parse("2025-01-09"));
   });
 
   test("restores persisted drawings from pane settings on mount", async () => {

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -360,16 +360,30 @@ function cursorAxisLabel(
 const MINIMUM_AXIS_LABEL_WIDTH = 3;
 
 /**
- * Cells the gutter needs for its own labels. Ticks cover the axis itself, and a
- * mid-domain sample covers the wider cursor readout that lands between them.
+ * Reserve cursor precision even when the tick values are round numbers. This
+ * keeps the plot stable while the pointer moves between integer tick values.
  */
 function compositeAxisLabelWidth(
   domain: CompositeAxisDomain | undefined,
-  format: CompositeAxisValueFormatter = formatCompositeAxisValue,
+  format: CompositeAxisValueFormatter | undefined,
+  includeCursor: boolean,
 ): number {
   if (!domain) return 0;
-  const labels = compositeAxisTicks(domain, 3, format).map((tick) => tick.label);
-  labels.push(format((domain.min + domain.max) / 2, domain));
+  const ticks = compositeAxisTicks(domain, 3, format);
+  const labels = ticks.map((tick) => tick.label);
+  if (includeCursor) {
+    const cursorFormat = format ?? formatCompositeCursorValue;
+    for (const { value } of ticks) {
+      labels.push(cursorFormat(value, domain));
+      // Totals use two decimals at their compact scale; prices can use four
+      // below one currency unit. Probe those digits without changing the data.
+      const scale = domain.unitGroup.toLowerCase().split(":")[0] === "currency-total"
+        ? 10 ** Math.max(0, Math.min(12, Math.floor(Math.log10(Math.abs(value) || 1) / 3) * 3))
+        : 1;
+      const precisionValue = (value < 0 ? -1 : 1) * (Math.floor(Math.abs(value) / scale) + 0.1234) * scale;
+      labels.push(cursorFormat(precisionValue, domain));
+    }
+  }
   return labels.reduce((widest, label) => Math.max(widest, [...label].length), 0);
 }
 
@@ -1861,16 +1875,23 @@ export function CompositeChart({
   const maximumAxisWidth = Math.max(0, Math.floor(axisWidth));
   // Gutters follow their labels. A fixed budget left dead space beside short
   // prices, which costs plot width on every chart that does not need it.
-  const resolvedAxisWidth = useMemo(() => Math.min(
-    maximumAxisWidth,
+  const axisCount = Number(hasLeftAxis) + Number(hasRightAxis);
+  // Keep at least half the chart (and 12 cells on small charts) for the plot.
+  const minimumPlotWidth = Math.min(totalWidth, Math.max(12, Math.floor(totalWidth / 2)));
+  const availableAxisWidth = axisCount > 0
+    ? Math.max(0, Math.floor((totalWidth - minimumPlotWidth) / axisCount) - 1)
+    : 0;
+  const includeCursorLabels = interactive || cursorDate !== undefined;
+  const resolvedAxisWidth = useMemo(() => maximumAxisWidth === 0 ? 0 : Math.min(
+    availableAxisWidth,
     Math.max(
-      MINIMUM_AXIS_LABEL_WIDTH,
+      Math.min(MINIMUM_AXIS_LABEL_WIDTH, maximumAxisWidth),
       ...(projectedScene?.panels ?? []).flatMap((panel) => [
-        compositeAxisLabelWidth(panel.axes.left, formatAxisValue),
-        compositeAxisLabelWidth(panel.axes.right, formatAxisValue),
-      ]),
+        compositeAxisLabelWidth(panel.axes.left, formatAxisValue, includeCursorLabels),
+        compositeAxisLabelWidth(panel.axes.right, formatAxisValue, includeCursorLabels),
+      ]).map((width) => includeCursorLabels ? width : Math.min(width, maximumAxisWidth)),
     ),
-  ), [formatAxisValue, maximumAxisWidth, projectedScene]);
+  ), [availableAxisWidth, formatAxisValue, includeCursorLabels, maximumAxisWidth, projectedScene]);
   const leftAxisWidth = hasLeftAxis ? resolvedAxisWidth : 0;
   const rightAxisWidth = hasRightAxis ? resolvedAxisWidth : 0;
   const axisGap = resolvedAxisWidth > 0 ? 1 : 0;

--- a/src/components/chart/composite/format.test.ts
+++ b/src/components/chart/composite/format.test.ts
@@ -194,5 +194,8 @@ describe("composite chart unit formatting", () => {
     expect(formatChartLegendValue(90_007_000_000, "USD", "currency-total:USD")).toBe("$90.01B");
     expect(formatChartLegendValue(-12_345_600_000, "EUR", "currency-total")).toBe("€-12.35B");
     expect(formatChartLegendValue(123_456_000, "CAD", "currency-total:CAD")).toBe("123.46M CAD");
+    expect(formatCompositeCursorValue(90_007_000_000, { ...domain, unitGroup: "currency-total:USD" })).toBe("$90.01B");
+    expect(formatCompositeCursorValue(-12_345_600_000, { ...domain, unit: "EUR", unitGroup: "currency-total" })).toBe("€-12.35B");
+    expect(formatCompositeCursorValue(123_456_000, { ...domain, unit: "CAD", unitGroup: "currency-total:CAD" })).toBe("123.46M CAD");
   });
 });

--- a/src/components/chart/composite/format.ts
+++ b/src/components/chart/composite/format.ts
@@ -82,6 +82,9 @@ export function formatCompositeAxisValue(value: number, domain: CompositeAxisDom
 export function formatCompositeCursorValue(value: number, domain: CompositeAxisDomain): string {
   const group = domain.unitGroup.toLowerCase();
   if (group.startsWith("derived-unit:")) return compactNumber(value);
+  if (group.split(":")[0] === "currency-total") {
+    return formatChartLegendValue(value, domain.unit, domain.unitGroup);
+  }
   const fullPrice = formatFullCurrencyValue(value, domain.unit);
   if (fullPrice) return fullPrice;
   return formatCompositeAxisValue(value, domain);

--- a/src/components/chart/composite/price-axis-labels.test.ts
+++ b/src/components/chart/composite/price-axis-labels.test.ts
@@ -17,5 +17,13 @@ describe("buildCursorPriceAxisOverlay", () => {
 
     expect(overlay.labelText).toBe("$214.03");
     expect(overlay.topPercent).toBeCloseTo((cursorPixelY / (height * cellHeightPx - 1)) * 100, 5);
+
+    // An extreme value or a narrow pane must not present a partial amount or
+    // lose its trailing currency. The full value remains in the chart legend.
+    for (const cursorLabel of ["$90.01B", "-123.46M CAD", "$1,234,567.89"]) {
+      expect(buildCursorPriceAxisOverlay({
+        axisWidth: 4, axisSectionWidth: 5, height, cursorPixelY, cursorLabel, cellHeightPx,
+      }).labelText).toBe("…");
+    }
   });
 });

--- a/src/components/chart/composite/price-axis-labels.tsx
+++ b/src/components/chart/composite/price-axis-labels.tsx
@@ -5,7 +5,9 @@ import { colors } from "../../../theme/colors";
 function formatAxisCell(label: string | null, width: number): string {
   if (width <= 0) return "";
   if (!label) return " ".repeat(width);
-  return label.length >= width ? label.slice(0, width) : label.padStart(width);
+  // A clipped numeric prefix can change both magnitude and currency. If a
+  // constrained chart cannot fit the complete label, show no partial value.
+  return ([...label].length > width ? "…" : label).padStart(width);
 }
 
 interface PriceAxisMarker {

--- a/src/components/chart/composite/types.ts
+++ b/src/components/chart/composite/types.ts
@@ -185,6 +185,7 @@ export interface CompositeChartProps {
    */
   viewportResetKey?: string;
   colors?: Partial<CompositeChartColors>;
+  /** Tick gutter budget. Cursor values can widen it; zero hides both axes. */
   axisWidth?: number;
   showLegend?: boolean;
   /** Show the regular-session percentage beside latest eligible legend values. */


### PR DESCRIPTION
Financial-chart cursor amounts were truncated by a gutter measured using compact tick labels: actual MSFT quarterly revenue appeared as `$90,` instead of `$90.01B`. Format currency totals consistently with the legend, reserve cursor decimal precision before hover, and preserve full quote-price formatting, negative signs and currency suffixes.

The gutter can expand for a complete cursor label while keeping at least half the chart for plotting; `axisWidth=0` still hides axes. If an extreme value cannot fit, display an ellipsis instead of a misleading partial amount.

Validation:
- Actual native GF MSFT before/after journeys at 140×44 and 80×30, using the normal provider and an isolated configuration. Both corrected markers show `$90.01B`; source value is unchanged at 90,007,000,000 USD.
- Composite-chart native render regressions cover USD totals, negative EUR totals, CAD suffixes, million-dollar quote prices, sub-dollar precision, stable hover geometry, hidden axes and constrained overflow.
- Complete composite-chart suite and all six runtime typechecks pass.

Evidence: `/home/vince/code/gloom/persona-audit/cursor-value-evidence/`. Browser/desktop marker overflow uses the same complete-label handling; actual terminal evidence is separate from controlled renderer fixtures. No release or version change.
