### PR TITLE
Calculate rolling correlation from shared observations

### DIFF
--- a/src/time-series/spec-studies.test.ts
+++ b/src/time-series/spec-studies.test.ts
@@ -381,12 +381,48 @@ describe("study resolution", () => {
     });
     expect(result.series.find(({ id }) => id === "spread")?.points).toHaveLength(5);
     const correlation = result.series.find(({ id }) => id === "correlation")?.points ?? [];
-    expect(correlation).toHaveLength(3);
-    expect(correlation.every((entry) => Math.abs((entry.value ?? 0) - 0.5) < 1e-10)).toBe(true);
+    expect(correlation).toHaveLength(0);
+    expect(result.warnings).toContain("correlation: not enough valid history to calculate correlation.");
     expect(result.series.find(({ id }) => id === "correlation")).toMatchObject({
       style: "line",
       interpolation: "none",
     });
+  });
+
+  test("correlates returns over shared observations without inventing closed-market zero returns", () => {
+    const series = (id: string, rows: Array<[string, number | null]>): ResolvedSeries => ({
+      ...resolved(id),
+      points: rows.map(([day, value]) => ({ date: new Date(day), observedAt: new Date(day), value })),
+    });
+    // Stock closes Friday, then Tuesday after a holiday. Crypto also trades
+    // throughout the weekend. Both have identical returns on common dates.
+    const stock = series("stock", [["2026-09-04", 100], ["2026-09-08", 110], ["2026-09-09", 99], ["2026-09-10", 118.8]]);
+    const crypto = series("crypto", [["2026-09-04", 1000], ["2026-09-05", 2000], ["2026-09-06", 500], ["2026-09-07", 1500], ["2026-09-08", 1100], ["2026-09-09", 990], ["2026-09-10", 1188]]);
+    const result = resolveStudies([stock, crypto], [study("corr", "correlation", ["stock", "crypto"], { period: 3 })]);
+    const points = result.series[0]!.points;
+    expect(points).toHaveLength(1);
+    expect(points[0]!.date.toISOString().slice(0, 10)).toBe("2026-09-10");
+    expect(points[0]!.value).toBeCloseTo(1, 12);
+
+    // A missing stock observation cannot be replaced by its previous close.
+    stock.points.splice(1, 0, { date: new Date("2026-09-07"), observedAt: new Date("2026-09-07"), value: null });
+    expect(resolveStudies([stock, crypto], [study("corr", "correlation", ["stock", "crypto"], { period: 3 })]).series[0]!.points).toEqual(points);
+  });
+
+  test("correlation waits for matching publication times instead of pairing equal observation dates", () => {
+    const left = resolved("left");
+    left.points = left.points.slice(0, 3);
+    const right = { ...resolved("right", 2), points: left.points.map((point) => ({
+      ...point, value: point.value! * 2,
+      availableAt: new Date(point.date.getTime() + 12 * 60 * 60_000),
+    })) };
+    const calculation = study("corr", "correlation", ["left", "right"], { period: 2 });
+    expect(resolveStudies([left, right], [calculation]).series[0]!.points).toHaveLength(0);
+    left.points = left.points.map((point) => ({ ...point, availableAt: new Date(point.date.getTime() + 12 * 60 * 60_000) }));
+    const [point] = resolveStudies([left, right], [calculation]).series[0]!.points;
+    expect(point?.date).toEqual(new Date("2024-01-03T12:00:00Z"));
+    expect(point?.availableAt).toEqual(point?.date);
+    expect(point?.value).toBeCloseTo(1, 12);
   });
 
   test("returns actionable errors for missing inputs instead of throwing", () => {

--- a/src/time-series/studies.ts
+++ b/src/time-series/studies.ts
@@ -380,13 +380,14 @@ function ratioUnit(left: ResolvedSeries, right: ResolvedSeries): {
   };
 }
 
-function pairedSamples(left: ResolvedSeries, right: ResolvedSeries): PairedSample[] {
+function pairedSamples(left: ResolvedSeries, right: ResolvedSeries, carryForward: boolean): PairedSample[] {
   return alignTimeSeries([left, right], {
     mode: "intersection",
-    // Formula inputs are point-in-time values, regardless of how either
-    // source is drawn. Carry only the latest publicly available observation;
-    // alignTimeSeries still gates every value by availableAt.
-    carryForward: true,
+    // Ratios/spreads compare latest known levels; correlations need actual
+    // shared observations before calculating returns. Carrying a closed market
+    // invents zero returns and mismatches both sides of a weekend/holiday move.
+    // Both modes still respect the publication time of each observation.
+    carryForward,
   }).flatMap((row) => {
     const leftValue = row.values[left.id];
     const rightValue = row.values[right.id];
@@ -419,7 +420,7 @@ function resolvePairStudy(
   right: ResolvedSeries,
   color: string,
 ): ResolvedSeries[] {
-  const paired = pairedSamples(left, right);
+  const paired = pairedSamples(left, right, spec.kind !== "correlation");
   if (spec.kind === "ratio" || spec.kind === "spread") {
     const multiplier = finiteNumber(spec.parameters.multiplier) ? spec.parameters.multiplier : 1;
     const points = paired.map((sample) => derivedPoint(
@@ -479,7 +480,7 @@ function resolvePairStudy(
       rightVariance += rightDelta ** 2;
     }
     const denominator = Math.sqrt(leftVariance * rightVariance);
-    const value = denominator === 0 ? null : covariance / denominator;
+    const value = denominator === 0 ? null : Math.max(-1, Math.min(1, covariance / denominator));
     points.push(derivedPoint({ point: values[index]!.point, value: values[index]!.left }, value));
   }
   return [outputSeries(spec, left, {
@@ -550,7 +551,7 @@ export function resolveStudies(
         );
       }
       if (spec.kind === "correlation" && input.nativeFrequency !== pairedInput.nativeFrequency) {
-        warnings.push(`${spec.id}: correlation mixes ${input.nativeFrequency} and ${pairedInput.nativeFrequency} observations using as-of alignment.`);
+        warnings.push(`${spec.id}: correlation mixes ${input.nativeFrequency} and ${pairedInput.nativeFrequency} observations; only matching observation times contribute.`);
       }
       outputs = resolvePairStudy(spec, input, pairedInput, color);
     }


### PR DESCRIPTION
Rolling chart correlation carried a closed market's last price across another asset's trading days, creating artificial zero returns. A stock/crypto weekend-and-holiday example with identical shared-date returns reported 0.47675 instead of 1.00.

Correlations now align actual shared observation times before computing returns. Ratio and spread formulas retain their latest-known-value behavior, and publication-time gates remain enforced. Exact matching does not imply synchronized exchange closes or fiscal-period matching.

Validation: 85 focused tests / 570 assertions, all six runtime typechecks, independent review, and native 140×44 / 80×30 controlled before/after checks. The regression fails before the fix. Combined browser verification with a separate checkbox-state fix remains pending; no release or version change.
