### PR TITLE
Fix desktop checkbox state for chart formulas and other selections

### DIFF
--- a/src/plugins/builtin/chart-composer/settings.ts
+++ b/src/plugins/builtin/chart-composer/settings.ts
@@ -50,7 +50,7 @@ export const CHART_STUDY_OPTIONS: Array<PaneSettingOption & { value: BuiltinStud
 export const CHART_FORMULA_OPTIONS: Array<PaneSettingOption & { value: PairStudySelection }> = [
   { value: "ratio", label: "Ratio", description: "First series divided by the second series." },
   { value: "spread", label: "Spread", description: "First series minus the second series." },
-  { value: "correlation", label: "Correlation 20", description: "20-observation rolling return correlation." },
+  { value: "correlation", label: "Correlation 20", description: "20-observation rolling return correlation on shared observation times." },
 ];
 
 export const CHART_SETTING_KEYS = {

--- a/src/renderers/electrobun/view/desktop/controls.test.tsx
+++ b/src/renderers/electrobun/view/desktop/controls.test.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import { expect, test } from "bun:test";
 import { act, useState } from "react";
-import { WebSegmentedControl } from "./controls";
+import { WebCheckbox, WebSegmentedControl } from "./controls";
 import { WebListView } from "./list-view";
 import { Button } from "../../../../components/ui/button";
 import { TextField } from "../../../../components/ui/fields";
@@ -10,6 +10,49 @@ import { Box, Text } from "../../../../ui";
 import { createDomTestHarness } from "../test-utils";
 
 const { render: renderDom } = createDomTestHarness();
+
+test("desktop checkbox keeps browser state aligned with controlled selection on input and label clicks", async () => {
+  const changes: boolean[] = [];
+  const parentEvents: string[] = [];
+  function Selection() {
+    const [selected, setSelected] = useState(false);
+    return <div onClick={() => parentEvents.push("click")} onMouseDown={() => parentEvents.push("mousedown")}
+      onKeyDown={() => parentEvents.push("keydown")}>
+      <WebCheckbox label="Correlation 20" checked={selected} onChange={(value) => {
+        changes.push(value);
+        setSelected(value);
+      }} />
+      <output>{selected ? "Study enabled" : "Study disabled"}</output>
+      <WebCheckbox label="Unavailable" disabled checked={false} onChange={() => parentEvents.push("disabled")} />
+    </div>;
+  }
+  const container = await renderDom(<Selection />);
+  const [input, disabled] = [...container.querySelectorAll("input")];
+  const [label, disabledLabel] = [...container.querySelectorAll("label")];
+  const mouseDown = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+  const space = new KeyboardEvent("keydown", { key: " ", bubbles: true, cancelable: true });
+  await act(async () => {
+    input!.dispatchEvent(mouseDown);
+    input!.dispatchEvent(space);
+  });
+  // Browser focus and keyboard activation must remain enabled; happy-dom does
+  // not synthesize a native Space click, so the actual click is tested below.
+  expect(mouseDown.defaultPrevented).toBe(false);
+  expect(space.defaultPrevented).toBe(false);
+  await act(async () => { input!.click(); });
+  expect(container.querySelector("output")!.textContent).toBe("Study enabled");
+  expect(input!.checked).toBe(true);
+  await act(async () => { label!.click(); });
+  expect(container.querySelector("output")!.textContent).toBe("Study disabled");
+  expect(input!.checked).toBe(false);
+  await act(async () => { label!.click(); });
+  expect(input!.checked).toBe(true);
+  await act(async () => { input!.click(); });
+  expect(input!.checked).toBe(false);
+  await act(async () => { disabled!.click(); disabledLabel!.click(); });
+  expect(changes).toEqual([true, false, true, false]);
+  expect(parentEvents).toEqual([]);
+});
 
 test("desktop segmented controls expose radio semantics and keyboard selection", async () => {
   const selected: string[] = [];

--- a/src/renderers/electrobun/view/desktop/controls.tsx
+++ b/src/renderers/electrobun/view/desktop/controls.tsx
@@ -150,13 +150,10 @@ export function WebCheckbox({
     >
       <label
         onMouseDown={(event) => {
-          event.preventDefault();
           event.stopPropagation();
         }}
         onClick={(event) => {
-          event.preventDefault();
           event.stopPropagation();
-          if (!disabled) onChange?.(!checked);
         }}
         style={{
           display: "flex",
@@ -175,8 +172,15 @@ export function WebCheckbox({
         <input
           type="checkbox"
           checked={checked}
-          readOnly
           disabled={disabled}
+          onChange={(event) => {
+            if (!disabled) onChange?.(event.currentTarget.checked);
+          }}
+          onKeyDown={(event) => {
+            // Space activates the native input. Keep it out of pane shortcuts
+            // without cancelling the browser's checked-state transition.
+            if (event.key === " ") event.stopPropagation();
+          }}
           style={{
             appearance: "none",
             WebkitAppearance: "none",


### PR DESCRIPTION
Clicking a desktop checkbox could add a chart study while leaving the native input unchecked. The label cancelled the browser's checked transition after React had updated the selected study, so the custom checkmark and chart disagreed with accessibility and input state.

Use the native input's change event for mouse, label and Space activation while keeping pane shortcut events isolated. Clarify that rolling correlation uses shared observation times; the calculation fix is a separate PR.

Validation: the controlled-selection regression fails on the original code and passes after the fix; 112 desktop renderer/chart-composer tests (449 assertions) and all six runtime typechecks pass. Actual Chrome verification against production data passed input, label and focused Space toggles, removal, reopening, and desktop/narrow views. A combined preview with the separate shared-observation math patch rendered SPY/Bitcoin daily correlation0.299; independent calculation from the captured source bars gave0.2992736422. No release/version changes.
