### PR TITLE
Recover annual growth around intervening provider periods

### DIFF
--- a/src/plugins/builtin/ticker-detail/financials/aggregation.ts
+++ b/src/plugins/builtin/ticker-detail/financials/aggregation.ts
@@ -205,7 +205,17 @@ export function buildPreviousStatementMap(
 
   for (let index = 1; index < sourceStatements.length; index += 1) {
     const current = sourceStatements[index]!;
-    const previous = sourceStatements[index - 1]!;
+    // Providers can include off-cycle 12-month observations (for example ADR
+    // EPS) between fiscal years. They must not hide a comparable prior year.
+    // More than one annual candidate is ambiguous; do not guess its identity.
+    const candidates = period === "annual"
+      ? sourceStatements.filter((candidate) => {
+        const days = (Date.parse(current.date) - Date.parse(candidate.date)) / 86_400_000;
+        return days >= 300 && days <= 430;
+      })
+      : [sourceStatements[index - 1]!];
+    if (candidates.length !== 1) continue;
+    const previous = candidates[0]!;
     const days = (Date.parse(current.date) - Date.parse(previous.date)) / 86_400_000;
     const [minimum, maximum] = period === "annual" ? [300, 430] : [60, 120];
     if (days < minimum! || days > maximum! || !Number.isFinite(days)) continue;

--- a/src/plugins/builtin/ticker-detail/financials/model.test.ts
+++ b/src/plugins/builtin/ticker-detail/financials/model.test.ts
@@ -125,6 +125,30 @@ test("growth is unavailable across missing years or a reporting currency change"
   expect(table?.rows.find((row) => row.summaryKey === "totalRevenue")?.cells.map((cell) => cell.growth)).toEqual([undefined, undefined, undefined]);
 });
 
+test("annual growth finds a unique prior year around interleaved ADR EPS observations", () => {
+  const annualStatements = [
+    { date: "2025-03-31", currency: "JPY", totalRevenue: 48_036_704_000_000, eps: 3595.6 },
+    { date: "2025-06-30", currency: "JPY", eps: 3251.3 },
+    { date: "2025-09-30", currency: "JPY", eps: 3534.8 },
+    { date: "2026-03-31", currency: "JPY", totalRevenue: 50_684_952_000_000, eps: 2952.5 },
+  ];
+  const model = () => buildFinancialTableModel({ annualStatements, quarterlyStatements: [] }, {
+    period: "annual", statement: "income", expandAll: true,
+  })!;
+  const revenue = (table: ReturnType<typeof model>) => table.rows.find((row) => row.summaryKey === "totalRevenue")!.cells[0]!;
+  const table = model();
+  expect(revenue(table)).toMatchObject({ value: 50_684_952_000_000 });
+  expect(revenue(table).growth).toBeCloseTo(0.0551296775);
+  expect(table.rows.find((row) => row.key === "eps")!.cells[0]!.growth).toBeCloseTo(-0.1788574925);
+  expect(table.statements.map((row) => row.date)).toEqual([...annualStatements].reverse().map((row) => row.date));
+
+  annualStatements[0]!.currency = "USD";
+  expect(revenue(model()).growth).toBeUndefined();
+  annualStatements[0]!.currency = "JPY";
+  annualStatements.splice(1, 0, { date: "2025-04-30", currency: "JPY", totalRevenue: 49_000_000_000_000, eps: 3500 });
+  expect(revenue(model()).growth).toBeUndefined();
+});
+
 test("annual balance sheets show the latest dated snapshot with comparable year-on-year growth", () => {
   const financials = {
     annualStatements: [{ date: "2025-12-31", currency: "USD", totalAssets: 200 }],


### PR DESCRIPTION
Toyota ADR annual research hid valid year-over-year growth because Yahoo includes June and September 12-month EPS observations between the March fiscal years. The table compared only adjacent records, then rejected the short date gap, leaving revenue and EPS growth blank even though the matching prior year was loaded.

Find the unique prior-year statement within the existing annual comparison bounds. TM now shows revenue growth of +5.5% and EPS growth of −18%, matching its Tokyo listing. Preserve all provider amounts and dates; ambiguous periods, missing years and currency changes still leave growth unavailable. Quarterly comparison behavior is unchanged.

Validation:
- Actual CLI and native annual/quarterly research for TM, 7203.T and GM; TM annual before/after exports retain identical values and dates while restoring growth.
- Toyota FY2026 issuer results confirm JPY50.684952T revenue and JPY295.25 EPS per ordinary share; its 2026 20-F confirms ten ordinary shares per ADS. TM reports JPY2952.50 per ADS, while its quote remains USD.
- Regression covers intervening partial records, valid prior-year revenue/EPS, currency mismatch and ambiguous candidates. Ticker-detail suites and all six runtime typechecks pass.

Primary sources: [Toyota FY2026 results](https://global.toyota/pages/global_toyota/ir/financial-results/2026_4q_summary_en.pdf), [Toyota 2026 20-F, item 9](https://global.toyota/pages/global_toyota/ir/library/sec/20-F_202603_final.pdf). Audit evidence is under `/home/vince/code/gloom/persona-audit/toyota-evidence/`.

The app still lacks an explicit depositary-ratio contract and some quarterly EPS observations. This change does not reconstruct those values or convert statement currencies. No release or version change.
