### PR TITLE
Preserve tiny prices and report volume units accurately

### DIFF
--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -1471,6 +1471,20 @@ describe("CompositeChart", () => {
     expect(capturedSurfaceNode!.width).toBeGreaterThanOrEqual(30);
   });
 
+  test("static overview charts reserve the complete tiny-price marker without losing the plot", async () => {
+    testSetup = await testRender(
+      <CaptureChartSurfaceProvider>
+        <CompositeChart width={60} height={12} showLegend={false} interactive={false}
+          series={[{ ...series("price", "main", "right", "USD", [0.000005, 0.0000051, 0.00000526]), unitGroup: "price:USD", timeBasis: { kind: "market", timeZone: "UTC" } }]}
+          panels={[{ id: "main" }]} />
+      </CaptureChartSurfaceProvider>,
+      { width: 62, height: 14 },
+    );
+    await act(async () => testSetup!.renderOnce());
+    expect(testSetup.captureCharFrame()).toContain("$0.00000526");
+    expect(capturedSurfaceNode!.width).toBeGreaterThanOrEqual(30);
+  });
+
   test("preserves integer-domain cursor decimals without moving the plot and honors hidden axes", async () => {
     let setAxisWidth: ((value: number) => void) | null = null;
     function Harness() {

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -379,7 +379,8 @@ function compositeAxisLabelWidth(
       // below one currency unit. Probe those digits without changing the data.
       const scale = domain.unitGroup.toLowerCase().split(":")[0] === "currency-total"
         ? 10 ** Math.max(0, Math.min(12, Math.floor(Math.log10(Math.abs(value) || 1) / 3) * 3))
-        : 1;
+        : Math.abs(value) > 0 && Math.abs(value) < 0.01
+          ? 10 ** Math.floor(Math.log10(Math.abs(value))) : 1;
       const precisionValue = (value < 0 ? -1 : 1) * (Math.floor(Math.abs(value) / scale) + 0.1234) * scale;
       labels.push(cursorFormat(precisionValue, domain));
     }
@@ -1881,7 +1882,8 @@ export function CompositeChart({
   const availableAxisWidth = axisCount > 0
     ? Math.max(0, Math.floor((totalWidth - minimumPlotWidth) / axisCount) - 1)
     : 0;
-  const includeCursorLabels = interactive || cursorDate !== undefined;
+  // Static overview charts also pin the latest price with cursor precision.
+  const includeCursorLabels = interactive || cursorDate !== undefined || !!scenePanels?.some((panel) => panel.lastPrice);
   const resolvedAxisWidth = useMemo(() => maximumAxisWidth === 0 ? 0 : Math.min(
     availableAxisWidth,
     Math.max(

--- a/src/market-data/market/format.test.ts
+++ b/src/market-data/market/format.test.ts
@@ -16,7 +16,9 @@ describe("resolveAssetDisplayKind", () => {
   });
 
   test("maps common broker security types", () => {
-    expect(resolveAssetDisplayKind({ assetCategory: "CRYPTO" })).toBe("crypto");
+    for (const assetCategory of ["CRYPTO", "CRYPTOCURRENCY", "Digital Currency"]) {
+      expect(resolveAssetDisplayKind({ assetCategory })).toBe("crypto");
+    }
     expect(resolveAssetDisplayKind({ assetCategory: "STK" })).toBe("equity");
     expect(resolveAssetDisplayKind({ contractSecType: "OPT" })).toBe("contract");
     expect(resolveAssetDisplayKind({ assetCategory: "FOREX" })).toBe("cash");
@@ -53,6 +55,16 @@ describe("formatMarketPrice", () => {
     expect(formatMarketPrice(1.084567, { isCashBalance: true })).toBe("1.084567");
     expect(formatMarketPrice(1.17364, { assetCategory: "CURRENCY" })).toBe("1.17364");
     expect(formatMarketPrice(0.000123456789, { assetCategory: "CRYPTO" })).toBe("0.00012346");
+  });
+
+  test("keeps tiny nonzero quotes, ranges and signed changes meaningful without asset metadata", () => {
+    expect(formatMarketPriceWithCurrency(0.000005100000180391362, "USD")).toBe("$0.0000051");
+    expect(formatMarketPriceWithCurrency(0.000005259999852569308, "USD")).toBe("$0.00000526");
+    expect(formatSignedMarketPrice(-0.00000015256411960863806)).toBe("-0.0000001526");
+    expect(formatMarketPrice(0.0000051, { maxWidth: 7 })).toBe("5.1e-6");
+    expect(formatMarketPrice(1.234e-25)).toBe("1.234e-25");
+    expect(formatMarketPrice(0)).toBe("0");
+    expect(formatMarketPriceWithCurrency(0, "USD")).toBe("$0");
   });
 
   test("can adapt chart precision to the visible price range", () => {

--- a/src/market-data/market/format.ts
+++ b/src/market-data/market/format.ts
@@ -16,7 +16,7 @@ export interface MarketFormatOptions extends AssetDisplayContext {
 }
 
 const CASH_TYPES = new Set(["CASH", "FX", "FOREX", "CCY", "CURRENCY", "CURRENCYPAIR"]);
-const CRYPTO_TYPES = new Set(["CRYPTO", "CRYPTOCURRENCY", "COIN", "TOKEN"]);
+const CRYPTO_TYPES = new Set(["CRYPTO", "CRYPTOCURRENCY", "DIGITALCURRENCY", "COIN", "TOKEN"]);
 const EQUITY_TYPES = new Set(["STK", "STOCK", "EQUITY", "ETF", "ETN", "ETP", "FUND", "MUTUALFUND", "CEF", "ADR"]);
 const CONTRACT_TYPES = new Set(["OPT", "OPTION", "OPTIONS", "FUT", "FUTURE", "FUTURES", "FOP"]);
 
@@ -134,6 +134,29 @@ function getAdaptivePriceFractionDigits(priceRange: number | undefined, precisio
   return Math.max(0, Math.ceil(-Math.log10(visibleStep)) + precisionOffset);
 }
 
+/** Keep four significant digits for tiny prices even when instrument metadata
+ * is absent. Decimal formatting below this floor otherwise turns real prices
+ * and day-range endpoints into identical zeroes. */
+function tinyPriceFractionDigits(value: number): number {
+  const absolute = Math.abs(value);
+  return absolute > 0 && absolute < 0.01 && Number.isFinite(absolute)
+    ? Math.max(0, 3 - Math.floor(Math.log10(absolute))) : 0;
+}
+
+function formatPriceNumber(value: number, decimals: number, maxWidth: number | undefined, minimumDecimals = 0): string {
+  const tinyDecimals = tinyPriceFractionDigits(value);
+  const rendered = tinyDecimals > 20
+    ? "0"
+    : formatVariableNumber(value, Math.max(decimals, tinyDecimals), tinyDecimals > 0 ? undefined : maxWidth, minimumDecimals);
+  if (value === 0 || !Number.isFinite(value) || (Number(rendered.replaceAll(",", "")) !== 0 && fitsWidth(rendered, maxWidth))) return rendered;
+  // A constrained cell must not imply a worthless asset or unchanged price.
+  for (let precision = 4; precision >= 1; precision -= 1) {
+    const scientific = Number(value.toPrecision(precision)).toExponential();
+    if (fitsWidth(scientific, maxWidth)) return scientific;
+  }
+  return "…";
+}
+
 function getPriceMaxFractionDigits(
   kind: AssetDisplayKind,
   value: number,
@@ -190,8 +213,8 @@ export function resolveAssetDisplayKind({
   if (isCashBalance) return "cash";
 
   const normalizedType = normalizeType(contractSecType || assetCategory);
-  if (CASH_TYPES.has(normalizedType) || normalizedType.includes("FOREX") || normalizedType.includes("CURRENCY")) return "cash";
   if (CRYPTO_TYPES.has(normalizedType) || normalizedType.includes("CRYPTO")) return "crypto";
+  if (CASH_TYPES.has(normalizedType) || normalizedType.includes("FOREX") || normalizedType.includes("CURRENCY")) return "cash";
   if (EQUITY_TYPES.has(normalizedType)) return "equity";
   if (CONTRACT_TYPES.has(normalizedType)) return "contract";
   if ((multiplier ?? 1) > 1) return "contract";
@@ -224,7 +247,7 @@ export function formatMarketPrice(value: number | undefined, options: MarketForm
     getPriceMaxFractionDigits(kind, value, options.priceRange, options.precisionOffset ?? 0),
     minimumFractionDigits,
   );
-  return formatVariableNumber(value, maxFractionDigits, options.maxWidth, minimumFractionDigits);
+  return formatPriceNumber(value, maxFractionDigits, options.maxWidth, minimumFractionDigits);
 }
 
 export function formatMarketCost(value: number | undefined, options: MarketFormatOptions = {}): string {

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -16,7 +16,7 @@ import type { TickerRecord } from "../../../types/ticker";
 import { Box, ScrollBox, Text, TextAttributes, useUiCapabilities } from "../../../ui";
 import { selectEffectiveExchangeRates } from "../../../utils/exchange-rate-map";
 import { resolveExchangeTimeZone } from "../../../utils/exchanges";
-import { convertCurrency, formatPercentRaw, truncateToDisplayWidth } from "../../../utils/format";
+import { convertCurrency, displayWidth, formatPercentRaw, truncateToDisplayWidth } from "../../../utils/format";
 import { CompactRangeBar, PositionTable, QuoteBook, StatGrid } from "./overview/components";
 import { buildOverviewStats, buildPositionRows } from "./overview/model";
 
@@ -83,6 +83,12 @@ export function OverviewTab({
   const quoteBookInline = hasBidAsk && contentWidth >= 68;
   const quoteBookWidth = quoteBookInline ? Math.min(32, Math.max(24, Math.floor(contentWidth * 0.3))) : Math.min(contentWidth, 32);
   const quoteSummaryWidth = quoteBookInline ? Math.max(20, contentWidth - quoteBookWidth - 2) : contentWidth;
+  const quotePriceText = quote ? formatMarketPriceWithCurrency(quote.price, quote.currency, { assetCategory: ticker.metadata.assetCategory }) : "";
+  const quoteChangeText = quote ? formatSignedMarketPrice(quote.change, { assetCategory: ticker.metadata.assetCategory }) : "";
+  const quotePercentText = quote ? `(${formatPercentRaw(quote.changePercent)})` : "";
+  const quoteTextWidth = Math.max(1, quoteSummaryWidth - (nativePaneChrome ? 6 : 0));
+  const stackQuoteChange = displayWidth(quoteChangeText) + 1 + displayWidth(quotePercentText) > quoteTextWidth;
+  const stackQuoteSummary = displayWidth(quotePriceText) + 3 + displayWidth(quoteChangeText) + displayWidth(quotePercentText) > quoteTextWidth;
   const companyName = ticker.metadata.name || quote?.name || "";
   const marketStateText = quote?.marketState ? t(marketStateLabel(quote.marketState)) : "";
   const companyNameWidth = Math.max(0, quoteSummaryWidth - (nativePaneChrome ? 6 : 0)
@@ -154,13 +160,14 @@ export function OverviewTab({
             </Box>
 
             {quote && (
-              <Box flexDirection="row" gap={2}>
+              <Box flexDirection={stackQuoteSummary ? "column" : "row"} gap={stackQuoteSummary ? 0 : 2}>
                 <Text attributes={TextAttributes.BOLD} fg={colors.textBright}>
-                  {formatMarketPriceWithCurrency(quote.price, quote.currency, { assetCategory: ticker.metadata.assetCategory })}
+                  {quotePriceText}
                 </Text>
-                <Text fg={priceColor(quote.change)}>
-                  {formatSignedMarketPrice(quote.change, { assetCategory: ticker.metadata.assetCategory })} ({formatPercentRaw(quote.changePercent)})
-                </Text>
+                <Box flexDirection={stackQuoteChange ? "column" : "row"} gap={stackQuoteChange ? 0 : 1}>
+                  <Text fg={priceColor(quote.change)}>{quoteChangeText}</Text>
+                  <Text fg={priceColor(quote.change)}>{quotePercentText}</Text>
+                </Box>
               </Box>
             )}
             {quote && (quote.marketState === "PRE" || quote.marketState === "PREPRE") && quote.preMarketPrice != null && (

--- a/src/plugins/builtin/ticker-detail/overview/components.tsx
+++ b/src/plugins/builtin/ticker-detail/overview/components.tsx
@@ -96,12 +96,12 @@ export function CompactRangeBar({
   if (range <= 0) return null;
   const position = Math.max(0, Math.min(1, (current - low) / range));
   const pctLabel = `${Math.round(position * 100)}%`;
-  const lowText = formatMarketPriceWithCurrency(low, currency, { assetCategory });
-  const highText = formatMarketPriceWithCurrency(high, currency, { assetCategory });
   const endpointWidth = Math.min(
     RANGE_ENDPOINT_WIDTH,
     Math.max(7, Math.floor((width - 8) / 3)),
   );
+  const lowText = formatMarketPriceWithCurrency(low, currency, { assetCategory, maxWidth: endpointWidth });
+  const highText = formatMarketPriceWithCurrency(high, currency, { assetCategory, maxWidth: endpointWidth });
   const barWidth = Math.max(5, width - endpointWidth * 2 - 2);
   const markerIndex = Math.max(0, Math.min(barWidth - 1, Math.round(position * (barWidth - 1))));
   const labelWidth = Math.max(0, width - displayWidth(pctLabel));

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -78,6 +78,29 @@ describe("resolveChartSpecData", () => {
     expect(seeded?.bufferedSeries?.find((entry) => entry.panelId === "volume")?.points).toHaveLength(1);
   });
 
+  test("direct volume fields and volume studies retain established units without labeling crypto volume as shares", async () => {
+    for (const [instrumentType, expectedUnit] of [["EQUITY", "shares"], ["FUTURE", "contracts"], ["CRYPTOCURRENCY", ""], [undefined, ""]] as const) {
+      const history = [{ date: new Date("2026-01-15"), close: 1, volume: 1234 }];
+      const financials = { ...emptyFinancials(), quote: { symbol: "TEST", currency: "USD", price: 1, change: 0, changePercent: 0, lastUpdated: Date.parse("2026-01-15"), instrumentType }, priceHistory: history };
+      const provider = createTestDataProvider({
+        getQuote: async () => financials.quote,
+        getTickerFinancials: async () => financials,
+        getPriceHistory: async () => history,
+        getPriceHistoryForResolution: async () => history,
+      });
+      const result = await resolveChartSpecData(chartSpec({
+        viewport: { range: "1M", resolution: "1d" },
+        series: [chartSeries({ id: "direct", source: { kind: "security", instrument: { symbol: "TEST" }, fieldId: "market.volume" } }), chartSeries({ id: "price", source: { kind: "security", instrument: { symbol: "TEST" }, fieldId: "market.close" } })],
+        studies: [{ id: "volume", kind: "volume", inputSeriesIds: ["price"], parameters: {}, panelId: "main", axis: "left" }],
+      }), { dataProvider: provider, loadFredSeries: async () => fredLoad(), now: new Date("2026-01-16") });
+      for (const id of ["direct", "volume"]) {
+        expect(result.series.find((entry) => entry.id === id)?.unit).toBe(expectedUnit);
+        expect(result.series.find((entry) => entry.id === id)?.points.map((point) => point.value)).toEqual([1234]);
+      }
+      expect(result.warnings.some((warning) => warning.includes("does not specify"))).toBe(!expectedUnit);
+    }
+  });
+
   test("cached history honors the visible date range before the network resolves", () => {
     const source = { kind: "security" as const, instrument: { symbol: "TEST", exchange: "NASDAQ" }, fieldId: "market.close" };
     const history = ["2021-01-01", "2026-08-01", "2026-08-15", "2026-09-10"].map((day, i) => ({

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -97,7 +97,7 @@ describe("resolveChartSpecData", () => {
         expect(result.series.find((entry) => entry.id === id)?.unit).toBe(expectedUnit);
         expect(result.series.find((entry) => entry.id === id)?.points.map((point) => point.value)).toEqual([1234]);
       }
-      expect(result.warnings.some((warning) => warning.includes("does not specify"))).toBe(!expectedUnit);
+      expect(result.warnings.some((warning) => warning.includes("Volume unit unknown"))).toBe(!expectedUnit);
     }
   });
 

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -1,3 +1,4 @@
+import { resolveAssetDisplayKind } from "../market-data/market/format";
 import { financialPeriodCoverage, financialPeriodCoverageWarnings, limitSeriesObservations } from "./financial-period-coverage";
 import { FINANCIAL_VINTAGE_NOTICE } from "../utils/financial-statements";
 import { appendLiveQuotePoint } from "./chart-data";
@@ -670,9 +671,10 @@ function baseSecuritySeries(
   const points = extractSecuritySeries(financials, spec.source);
   const symbol = instrumentLabel(spec.source);
   const currency = financials.quote?.currency;
-  const unit = field.unit.startsWith("currency") && currency
-    ? field.unit.replace("currency", currency)
-    : field.unit;
+  const assetKind = resolveAssetDisplayKind({ assetCategory: financials.quote?.instrumentType });
+  const volumeUnit = assetKind === "equity" ? "shares" as const : assetKind === "contract" ? "contracts" as const : undefined;
+  const unit = field.id === "market.volume" ? volumeUnit ?? ""
+    : field.unit.startsWith("currency") && currency ? field.unit.replace("currency", currency) : field.unit;
   const currencyUnitGroup = field.unit.startsWith("currency") && currency
     ? `${field.unitGroup}:${currency}`
     : field.unitGroup;
@@ -693,6 +695,9 @@ function baseSecuritySeries(
     color: spec.color ?? SERIES_COLORS[index % SERIES_COLORS.length]!,
     unit,
     unitGroup: currencyUnitGroup,
+    volumeUnit,
+    warning: field.id === "market.volume" && !volumeUnit && points.length > 0
+      ? "The provider does not specify the volume unit." : undefined,
     nativeFrequency: spec.source.period && spec.source.period !== "auto"
       ? spec.source.period
       : field.nativeFrequency,

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -697,7 +697,7 @@ function baseSecuritySeries(
     unitGroup: currencyUnitGroup,
     volumeUnit,
     warning: field.id === "market.volume" && !volumeUnit && points.length > 0
-      ? "The provider does not specify the volume unit." : undefined,
+      ? "Volume unit unknown." : undefined,
     nativeFrequency: spec.source.period && spec.source.period !== "auto"
       ? spec.source.period
       : field.nativeFrequency,

--- a/src/time-series/spec-studies.test.ts
+++ b/src/time-series/spec-studies.test.ts
@@ -22,6 +22,7 @@ function resolved(id: string, multiplier = 1): ResolvedSeries {
     color: "#fff",
     unit: "USD/share",
     unitGroup: "price",
+    volumeUnit: "shares",
     nativeFrequency: "daily",
     dataShape: "ohlcv",
     style: "line",
@@ -423,6 +424,16 @@ describe("study resolution", () => {
     expect(point?.date).toEqual(new Date("2024-01-03T12:00:00Z"));
     expect(point?.availableAt).toEqual(point?.date);
     expect(point?.value).toBeCloseTo(1, 12);
+  });
+
+  test("volume studies preserve known instrument units and disclose unspecified provider volume", () => {
+    for (const volumeUnit of ["shares", "contracts", undefined] as const) {
+      const input = { ...resolved("volume-input"), volumeUnit };
+      const result = resolveStudies([input], [study("volume", "volume", [input.id])]);
+      expect(result.series[0]?.unit).toBe(volumeUnit ?? "");
+      expect(result.series[0]?.points.map((point) => point.value)).toEqual(input.points.map((point) => point.volume));
+      expect(result.warnings).toEqual(volumeUnit ? [] : ["Volume for VOLUME-INPUT: the provider does not specify the unit."]);
+    }
   });
 
   test("returns actionable errors for missing inputs instead of throwing", () => {

--- a/src/time-series/spec-studies.test.ts
+++ b/src/time-series/spec-studies.test.ts
@@ -432,7 +432,7 @@ describe("study resolution", () => {
       const result = resolveStudies([input], [study("volume", "volume", [input.id])]);
       expect(result.series[0]?.unit).toBe(volumeUnit ?? "");
       expect(result.series[0]?.points.map((point) => point.value)).toEqual(input.points.map((point) => point.volume));
-      expect(result.warnings).toEqual(volumeUnit ? [] : ["Volume for VOLUME-INPUT: the provider does not specify the unit."]);
+      expect(result.warnings).toEqual(volumeUnit ? [] : ["Volume unit unknown: VOLUME-INPUT."]);
     }
   });
 

--- a/src/time-series/studies.ts
+++ b/src/time-series/studies.ts
@@ -306,7 +306,7 @@ function resolveVolume(spec: ChartStudySpec, input: ResolvedSeries, color: strin
     label: `Volume ${input.label}`,
     points,
     color,
-    unit: "shares",
+    unit: input.volumeUnit ?? "",
     unitGroup: "volume",
     style: "columns",
     axis: "left",
@@ -532,7 +532,12 @@ export function resolveStudies(
     else if (spec.kind === "bollinger") outputs = resolveBollinger(spec, input, color);
     else if (spec.kind === "rsi") outputs = resolveRsi(spec, input, color);
     else if (spec.kind === "macd") outputs = resolveMacd(spec, input, color);
-    else if (spec.kind === "volume") outputs = resolveVolume(spec, input, color);
+    else if (spec.kind === "volume") {
+      outputs = resolveVolume(spec, input, color);
+      if (!input.volumeUnit && outputs.some((output) => output.points.length > 0)) {
+        warnings.push(`Volume for ${input.label}: the provider does not specify the unit.`);
+      }
+    }
     else {
       const pairedInput = inputs[1]!;
       const inputUnit = seriesUnit(input);

--- a/src/time-series/studies.ts
+++ b/src/time-series/studies.ts
@@ -535,7 +535,7 @@ export function resolveStudies(
     else if (spec.kind === "volume") {
       outputs = resolveVolume(spec, input, color);
       if (!input.volumeUnit && outputs.some((output) => output.points.length > 0)) {
-        warnings.push(`Volume for ${input.label}: the provider does not specify the unit.`);
+        warnings.push(`Volume unit unknown: ${input.label}.`);
       }
     }
     else {

--- a/src/time-series/types.ts
+++ b/src/time-series/types.ts
@@ -130,6 +130,8 @@ export interface ResolvedSeries {
   /** Unit of rawValue, retained when presentation transforms change unit. */
   rawUnit?: string;
   unitGroup: string;
+  /** Volume basis established by the source instrument; omitted when unspecified. */
+  volumeUnit?: "shares" | "contracts";
   nativeFrequency: SeriesPeriod;
   /** Authored time basis retained for layout and cursor semantics. */
   timestampMode?: SeriesTimestampMode;


### PR DESCRIPTION
Small nonzero crypto prices such as SHIB-USD at $0.0000051 rendered as $0, with a zero daily change and indistinguishable range endpoints. Preserve four significant digits for tiny prices, use scientific notation when space is constrained, and reserve enough chart axis space for the pinned latest price. Range endpoints use their actual cell width, and long quote/change text stacks in narrow panes.

Volume series now use shares or contracts only when supported by instrument metadata. Unspecified provider volume keeps its numerical value and exposes an unknown-unit status instead of claiming crypto volume is shares.

Validation: 342 market-format, time-series, composite-chart and ticker-detail tests (1,778 assertions); all six runtime typechecks; actual browser SHIB-USD:CCC overview/chart with production cloud data; controlled native before/after replay of the captured production quote/history at wide and narrow terminal sizes. Independent read-only review approved the source diff. No release or version change.
