### PR TITLE
Show source dates and stale FX conversion warnings

### DIFF
--- a/src/api-client/data.ts
+++ b/src/api-client/data.ts
@@ -1,3 +1,4 @@
+import type { ExchangeRateSnapshot } from "../types/exchange-rate";
 import type { TickerFinancials } from "../types/financials";
 import type { InstrumentSearchResult } from "../types/instrument";
 import {
@@ -273,8 +274,8 @@ export class CloudDataApi {
 
   async getCloudExchangeRate(
     fromCurrency: string,
-  ): Promise<CloudMarketResponse<{ rate: number }>> {
-    return this.request<CloudMarketResponse<{ rate: number }>>(
+  ): Promise<CloudMarketResponse<Partial<ExchangeRateSnapshot> & { rate: number }>> {
+    return this.request<CloudMarketResponse<Partial<ExchangeRateSnapshot> & { rate: number }>>(
       cloudExchangeRatePath(fromCurrency),
     );
   }

--- a/src/data/cached-query.ts
+++ b/src/data/cached-query.ts
@@ -33,11 +33,20 @@ export class CachedQuery<T> implements CachedQueryHandle<T> {
     read: (allowExpired: boolean) => CachedValue<T> | null;
     fetch?: (force: boolean) => Promise<CachedValue<T>>;
     acceptCached?: (value: T) => boolean;
+    /** Optional source-age/identity limit that also applies to stale fallback. */
+    acceptResult?: (result: CachedValue<T>) => boolean;
   }) {
     this.state = { result: options.read(false), loading: false, error: null };
   }
 
-  getSnapshot = (): CachedQueryState<T> => this.state;
+  getSnapshot = (): CachedQueryState<T> => {
+    if (this.state.result && !this.usable(this.state.result)) this.state = { ...this.state, result: null };
+    return this.state;
+  };
+
+  private usable(result: CachedValue<T> | null): CachedValue<T> | null {
+    return result && (this.options.acceptResult?.(result) ?? true) ? result : null;
+  }
 
   subscribe = (listener: () => void): (() => void) => {
     this.listeners.add(listener);
@@ -61,7 +70,7 @@ export class CachedQuery<T> implements CachedQueryHandle<T> {
     replace?: boolean;
     fetch?: (force: boolean) => Promise<CachedValue<T>>;
   } = {}): Promise<CachedValue<T>> {
-    const cached = this.state.result ?? this.options.read(false);
+    const cached = this.usable(this.state.result) ?? this.usable(this.options.read(false));
     const acceptable = cached && (this.options.acceptCached?.(cached.value) ?? true);
     if (!force && acceptable && cached.staleAt > Date.now()) return Promise.resolve(cached);
     if (!this.active || replace) {
@@ -72,7 +81,7 @@ export class CachedQuery<T> implements CachedQueryHandle<T> {
         if (generation === this.generation) this.publish({ result, loading: false, error: null });
         return result;
       }, (error: unknown) => {
-        const fallback = cached ?? this.options.read(true);
+        const fallback = this.usable(cached) ?? this.usable(this.options.read(true));
         if (generation === this.generation) this.publish({ result: fallback, loading: false, error });
         if (fallback) return { ...fallback, refreshError: error };
         throw error;

--- a/src/data/cached-query.ts
+++ b/src/data/cached-query.ts
@@ -5,6 +5,8 @@ export interface CachedValue<T> {
   staleAt: number;
   expiresAt: number;
   source: string;
+  /** Source observation time, when supplied; fetchedAt remains retrieval time. */
+  asOf?: number;
   refreshError?: unknown;
 }
 

--- a/src/market-data/coordinator/auxiliary.ts
+++ b/src/market-data/coordinator/auxiliary.ts
@@ -191,7 +191,8 @@ export function loadFxRateEntry(options: {
   const normalizedCurrency = options.currency.trim().toUpperCase();
   const key = buildFxKey(normalizedCurrency);
   const current = store.get(key);
-  if (hasFreshEntryData(current, FX_CACHE_TTL_MS)) {
+  if (hasFreshEntryData(current, FX_CACHE_TTL_MS) && !current.error
+    && (current.staleAt == null || current.staleAt > Date.now())) {
     return Promise.resolve(current);
   }
   if (normalizedCurrency === "USD") {
@@ -203,9 +204,19 @@ export function loadFxRateEntry(options: {
     store.update(key, loadingEntry);
     const startedAt = Date.now();
     try {
-      const rate = await dataProvider.getExchangeRate(normalizedCurrency);
-      const attempts = [createAttempt(dataProvider.id, startedAt, "success")];
-      return store.update(key, (current) => readyEntry(current, rate, dataProvider.id, attempts, { keepLastGoodOnEmpty: true }));
+      const snapshot = await dataProvider.getExchangeRateSnapshot?.(normalizedCurrency);
+      const rate = snapshot?.rate ?? await dataProvider.getExchangeRate(normalizedCurrency);
+      if (!Number.isFinite(rate) || rate <= 0 || (snapshot && (snapshot.fromCurrency !== normalizedCurrency || snapshot.toCurrency !== "USD"))) {
+        throw new Error(`Invalid exchange rate for ${normalizedCurrency}/USD`);
+      }
+      const source = snapshot?.source ?? dataProvider.id;
+      const attempts = [createAttempt(source, startedAt, "success")];
+      return store.update(key, (current) => {
+        const entry = readyEntry(current, rate, source, attempts, { keepLastGoodOnEmpty: true });
+        const time = (value?: string) => value && Number.isFinite(Date.parse(value)) ? Date.parse(value) : undefined;
+        return { ...entry, fetchedAt: time(snapshot?.fetchedAt) ?? entry.fetchedAt, asOf: time(snapshot?.asOf),
+          staleAt: snapshot?.stale ? Math.min(time(snapshot.staleAt) ?? Date.now(), Date.now()) : time(snapshot?.staleAt) ?? entry.staleAt };
+      });
     } catch (error) {
       const classified = classifyError(error);
       const attempt = createAttempt(dataProvider.id, startedAt, "fatal_error", classified.reasonCode, classified.message);

--- a/src/market-data/coordinator/auxiliary.ts
+++ b/src/market-data/coordinator/auxiliary.ts
@@ -1,3 +1,4 @@
+import { exchangeRateMetadata, isUsableCachedExchangeRate } from "../../utils/exchange-rate-snapshot";
 import type { DataProvider, SecFilingDocument, SecFilingItem } from "../../types/data-provider";
 import type { OptionsChain } from "../../types/financials";
 import type { OptionsRequest, SecFilingsRequest } from "../request-types";
@@ -206,21 +207,20 @@ export function loadFxRateEntry(options: {
     try {
       const snapshot = await dataProvider.getExchangeRateSnapshot?.(normalizedCurrency);
       const rate = snapshot?.rate ?? await dataProvider.getExchangeRate(normalizedCurrency);
-      if (!Number.isFinite(rate) || rate <= 0 || (snapshot && (snapshot.fromCurrency !== normalizedCurrency || snapshot.toCurrency !== "USD"))) {
-        throw new Error(`Invalid exchange rate for ${normalizedCurrency}/USD`);
-      }
+      const metadata = exchangeRateMetadata(snapshot ?? rate, normalizedCurrency, Date.now(), Date.now());
       const source = snapshot?.source ?? dataProvider.id;
       const attempts = [createAttempt(source, startedAt, "success")];
       return store.update(key, (current) => {
         const entry = readyEntry(current, rate, source, attempts, { keepLastGoodOnEmpty: true });
-        const time = (value?: string) => value && Number.isFinite(Date.parse(value)) ? Date.parse(value) : undefined;
-        return { ...entry, fetchedAt: time(snapshot?.fetchedAt) ?? entry.fetchedAt, asOf: time(snapshot?.asOf),
-          staleAt: snapshot?.stale ? Math.min(time(snapshot.staleAt) ?? Date.now(), Date.now()) : time(snapshot?.staleAt) ?? entry.staleAt };
+        return { ...entry, ...metadata };
       });
     } catch (error) {
       const classified = classifyError(error);
       const attempt = createAttempt(dataProvider.id, startedAt, "fatal_error", classified.reasonCode, classified.message);
-      return store.update(key, (current) => errorEntry(current, attempt));
+      return store.update(key, (current) => errorEntry(
+        isUsableCachedExchangeRate(current.data ?? current.lastGoodData, normalizedCurrency, current)
+          ? current : { ...current, data: null, lastGoodData: null }, attempt,
+      ));
     }
   });
 }

--- a/src/market-data/coordinator/index.test.ts
+++ b/src/market-data/coordinator/index.test.ts
@@ -154,6 +154,28 @@ describe("MarketDataCoordinator", () => {
     expect(calls).toBe(0);
   });
 
+  it("retries a recently retrieved stale FX rate without changing its source time on failure", async () => {
+    const now = Date.now();
+    let calls = 0;
+    const provider = createProvider({
+      getExchangeRateSnapshot: async () => {
+        if (++calls > 1) throw new Error("rate provider offline");
+        return { fromCurrency: "EUR", toCurrency: "USD", rate: 1.16, source: "yahoo",
+          asOf: new Date(now - 7_200_000).toISOString(), fetchedAt: new Date(now).toISOString(),
+          staleAt: new Date(now - 3_600_000).toISOString(), stale: true };
+      },
+    });
+    const coordinator = new MarketDataCoordinator(provider);
+    const first = await coordinator.loadFxRate("EUR");
+    const retry = await coordinator.loadFxRate("EUR");
+    expect(calls).toBe(2);
+    expect(first.asOf).toBe(now - 7_200_000);
+    expect(retry.lastGoodData).toBe(1.16);
+    expect(retry.asOf).toBe(first.asOf);
+    expect(retry.fetchedAt).toBe(first.fetchedAt);
+    expect(retry.error?.message).toContain("offline");
+  });
+
   it("reuses fresh empty tab query results instead of refetching on reopen", async () => {
     let optionsCalls = 0;
     const provider = createProvider({

--- a/src/market-data/coordinator/index.ts
+++ b/src/market-data/coordinator/index.ts
@@ -382,6 +382,7 @@ export class MarketDataCoordinator {
         lastGoodData: value ?? current.lastGoodData,
         source: result?.source ?? null,
         fetchedAt: result?.fetchedAt ?? null,
+        asOf: result?.asOf,
         staleAt: result?.staleAt ?? null,
         error: classified ?? (!loading && result && value == null ? { reasonCode: "NO_DATA", message: "No data available" } : null),
         attempts: result ? [createAttempt(result.source, result.fetchedAt, error ? "fatal_error" : value == null ? "empty" : "success", classified?.reasonCode, classified?.message)] : [],

--- a/src/market-data/coordinator/index.ts
+++ b/src/market-data/coordinator/index.ts
@@ -379,7 +379,9 @@ export class MarketDataCoordinator {
       store.set(key, {
         phase: loading ? (result ? "refreshing" : "loading") : result ? "ready" : "error",
         data: value,
-        lastGoodData: value ?? current.lastGoodData,
+        // FX query ownership includes the maximum source age. A null result
+        // means there is no valid conversion fallback left to project.
+        lastGoodData: value ?? (method === "getExchangeRate" ? null : current.lastGoodData),
         source: result?.source ?? null,
         fetchedAt: result?.fetchedAt ?? null,
         asOf: result?.asOf,

--- a/src/market-data/result-types.ts
+++ b/src/market-data/result-types.ts
@@ -27,6 +27,7 @@ export interface QueryEntry<T> {
   lastGoodData: T | null;
   source: string | null;
   fetchedAt: number | null;
+  asOf?: number;
   staleAt: number | null;
   error: { reasonCode: string; message: string } | null;
   attempts: ProviderAttempt[];

--- a/src/plugins/builtin/fx-matrix/index.tsx
+++ b/src/plugins/builtin/fx-matrix/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import {
   DataTableView,
+  Prose,
   usePaneFooter,
   type DataTableCell,
   type DataTableColumn,
@@ -15,6 +16,7 @@ import type { PaneProps } from "../../../types/plugin";
 import { TextAttributes } from "../../../ui";
 import { isPlainKey } from "../../../utils/keyboard";
 import { useAssetData } from "../../runtime";
+import { summarizeFxRates, fxStatusLabel } from "../../../utils/fx-status";
 import type { PluginModule } from "../plugin-module";
 import { useAutoRefresh, useUpdatedAgo } from "../shared/auto-refresh";
 import { MAJOR_CURRENCIES, formatRate, resolveCurrencies, type MajorCurrency } from "./pairs";
@@ -25,32 +27,6 @@ const NO_SAVED_CURRENCIES: string[] = [];
 const BASE_COLUMN_WIDTH = 5;
 const RATE_COLUMN_WIDTH = 10;
 
-interface FxStatus {
-  loading: number;
-  unavailable: number;
-  latestTs: number;
-}
-
-/**
- * Per-currency load state for the footer and the cell placeholders. The rates
- * map above already subscribes this pane to the same coordinator keys, so
- * reading the entries here re-renders with it.
- */
-function readFxStatus(currencies: readonly MajorCurrency[], rates: Map<string, number>): FxStatus {
-  const coordinator = getSharedMarketDataCoordinator();
-  let loading = 0;
-  let unavailable = 0;
-  let latestTs = 0;
-  for (const currency of currencies) {
-    if (currency === "USD") continue;
-    const entry = coordinator?.getFxEntry(currency) ?? null;
-    if (entry?.phase === "loading") loading += 1;
-    else if (!rates.has(currency)) unavailable += 1;
-    latestTs = Math.max(latestTs, entry?.fetchedAt ?? 0);
-  }
-  return { loading, unavailable, latestTs };
-}
-
 function FxMatrixPane({ focused, width, height }: PaneProps) {
   const dataProvider = useAssetData();
   const [savedCurrencies] = usePaneSettingValue<string[]>("currencies", NO_SAVED_CURRENCIES);
@@ -58,7 +34,8 @@ function FxMatrixPane({ focused, width, height }: PaneProps) {
   const [selectedCurrency, setSelectedCurrency] = useState<string | null>(null);
 
   const rates = useFxRatesMap(currencies);
-  const status = useMemo(() => readFxStatus(currencies, rates), [currencies, rates]);
+  const status = summarizeFxRates(currencies, rates, (currency) => getSharedMarketDataCoordinator()?.getFxEntry(currency));
+  const statusText = fxStatusLabel(status);
 
   const refresh = useCallback(() => {
     const coordinator = getSharedMarketDataCoordinator();
@@ -71,7 +48,7 @@ function FxMatrixPane({ focused, width, height }: PaneProps) {
     }
   }, [currencies]);
 
-  useAutoRefresh(status.latestTs || null, refresh);
+  useAutoRefresh(status.latestFetchedAt || null, refresh);
 
   const columns = useMemo<DataTableColumn[]>(() => [
     { id: "base", label: "", width: BASE_COLUMN_WIDTH, align: "left" },
@@ -120,20 +97,16 @@ function FxMatrixPane({ focused, width, height }: PaneProps) {
     return true;
   }, [refresh]);
 
-  const updatedAgo = useUpdatedAgo(status.latestTs || null);
+  const updatedAgo = useUpdatedAgo(status.latestFetchedAt || null);
 
   usePaneFooter(FX_MATRIX_PANE_ID, () => {
     const info: PaneFooterSegment[] = [];
     if (status.loading > 0) info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
-    if (status.unavailable > 0) {
-      info.push({
-        id: "unavailable",
-        parts: [{ text: `${status.unavailable} unavailable`, tone: "warning" }],
-      });
-    }
-    if (updatedAgo) info.push({ id: "updated", parts: [{ text: `updated ${updatedAgo}`, tone: "muted" }] });
+    if (statusText) info.push({ id: "rates", parts: [{ text: statusText, tone: status.stale || status.unknownTime || status.unavailable ? "warning" : "muted" }] });
+    if (status.sources.length) info.push({ id: "sources", parts: [{ text: status.sources.join("/"), tone: "muted" }] });
+    if (updatedAgo) info.push({ id: "updated", parts: [{ text: `fetched ${updatedAgo}`, tone: "muted" }] });
     return { info };
-  }, [status.loading, status.unavailable, updatedAgo]);
+  }, [status.loading, statusText, status.sources.join("/"), updatedAgo]);
 
   return (
     <DataTableView<MajorCurrency>
@@ -144,6 +117,7 @@ function FxMatrixPane({ focused, width, height }: PaneProps) {
         getId: (row) => row,
         onChange: (id) => setSelectedCurrency(id),
       }}
+      rootBefore={<Prose width={Math.max(1, width - 2)} text="One unit of the row currency buys the column amount. Indicative cross rates use USD legs; observation times may differ." color={colors.textDim} />}
       rootWidth={width}
       rootHeight={height}
       columns={columns}

--- a/src/plugins/builtin/portfolio-list/pane/index.tsx
+++ b/src/plugins/builtin/portfolio-list/pane/index.tsx
@@ -18,6 +18,8 @@ import {
   type CollectionSortPreference,
 } from "../../../../state/app/context";
 import { selectEffectiveExchangeRates } from "../../../../utils/exchange-rate-map";
+import { summarizeFxRates, fxStatusLabel } from "../../../../utils/fx-status";
+import { getSharedMarketDataCoordinator } from "../../../../market-data/coordinator";
 import type { TickerRecord } from "../../../../types/ticker";
 import type { PaneProps } from "../../../../types/plugin";
 import { calculatePortfolioSummaryTotals, resolveCollectionSortPreference, type ColumnContext } from "../metrics";
@@ -141,6 +143,9 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
   );
   const fetchedExchangeRates = useFxRatesMap(trackedCurrencies);
   const effectiveExchangeRates = selectEffectiveExchangeRates(fetchedExchangeRates, cachedExchangeRates);
+  const conversionCurrencies = trackedCurrencies.some((currency) => currency !== config.baseCurrency) ? trackedCurrencies : [];
+  const fxStatus = summarizeFxRates(conversionCurrencies, effectiveExchangeRates, (currency) => getSharedMarketDataCoordinator()?.getFxEntry(currency));
+  const fxStatusText = fxStatusLabel(fxStatus);
   const portfolioSummaryTotals = useMemo(() => calculatePortfolioSummaryTotals(
     tickers,
     financialsMap,
@@ -377,7 +382,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
   ]);
 
   usePaneFooter("portfolio-list", () => ({
-    info: summaryFooterInfo,
+    info: fxStatusText ? [...summaryFooterInfo, { id: "fx", parts: [{ text: `FX ${fxStatusText}`, tone: fxStatus.stale || fxStatus.unknownTime || fxStatus.unavailable ? "warning" as const : "muted" as const }] }] : summaryFooterInfo,
     hints: showCashDrawer
       ? [{
           id: "cash",
@@ -386,7 +391,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
           onPress: () => setCashDrawerExpanded(!cashDrawerExpanded),
         }]
       : [],
-  }), [cashDrawerExpanded, setCashDrawerExpanded, showCashDrawer, summaryFooterInfo]);
+  }), [cashDrawerExpanded, setCashDrawerExpanded, showCashDrawer, summaryFooterInfo, fxStatusText]);
 
   const quickAddCollectionKind = useMemo<QuickAddCollectionKind | null>(() => {
     if (!activeCollectionId) return null;

--- a/src/sources/gloomberb-cloud/index.ts
+++ b/src/sources/gloomberb-cloud/index.ts
@@ -1,3 +1,4 @@
+import type { ExchangeRateSnapshot } from "../../types/exchange-rate";
 import type { TimeRange } from "../../time-series/range";
 import {
   normalizeChartResolutionSupport,
@@ -312,8 +313,20 @@ export class GloomberbCloudProvider implements AssetDataProvider {
   }
 
   async getExchangeRate(fromCurrency: string): Promise<number> {
-    const response = await apiClient.getCloudExchangeRate(fromCurrency);
-    return unwrapRequiredCloudResponse(response, `Cloud exchange rate is unavailable for ${fromCurrency}`).rate;
+    return (await this.getExchangeRateSnapshot(fromCurrency)).rate;
+  }
+
+  async getExchangeRateSnapshot(fromCurrency: string): Promise<ExchangeRateSnapshot> {
+    const currency = fromCurrency.trim().toUpperCase();
+    const response = await apiClient.getCloudExchangeRate(currency);
+    const data = unwrapRequiredCloudResponse(response, `Cloud exchange rate is unavailable for ${currency}`);
+    if (!Number.isFinite(data.rate) || data.rate <= 0 || (data.fromCurrency && data.fromCurrency !== currency)
+      || (data.toCurrency && data.toCurrency !== "USD")) throw new Error(`Invalid exchange rate for ${currency}/USD`);
+    // Older servers have no observation metadata. Keep asOf unknown rather than
+    // presenting the request completion time as the rate's time.
+    return { ...data, rate: data.rate, fromCurrency: currency, toCurrency: "USD", source: data.source ?? this.id,
+      asOf: data.asOf ?? response.asOf, fetchedAt: data.fetchedAt ?? new Date().toISOString(),
+      stale: data.stale === true || response.stale === true };
   }
 
   async search(query: string, _context?: SearchRequestContext): Promise<InstrumentSearchResult[]> {

--- a/src/sources/gloomberb-cloud/index.ts
+++ b/src/sources/gloomberb-cloud/index.ts
@@ -1,3 +1,4 @@
+import { exchangeRateMetadata } from "../../utils/exchange-rate-snapshot";
 import type { ExchangeRateSnapshot } from "../../types/exchange-rate";
 import type { TimeRange } from "../../time-series/range";
 import {
@@ -320,8 +321,7 @@ export class GloomberbCloudProvider implements AssetDataProvider {
     const currency = fromCurrency.trim().toUpperCase();
     const response = await apiClient.getCloudExchangeRate(currency);
     const data = unwrapRequiredCloudResponse(response, `Cloud exchange rate is unavailable for ${currency}`);
-    if (!Number.isFinite(data.rate) || data.rate <= 0 || (data.fromCurrency && data.fromCurrency !== currency)
-      || (data.toCurrency && data.toCurrency !== "USD")) throw new Error(`Invalid exchange rate for ${currency}/USD`);
+    exchangeRateMetadata({ ...data, asOf: data.asOf ?? response.asOf }, currency);
     // Older servers have no observation metadata. Keep asOf unknown rather than
     // presenting the request completion time as the rate's time.
     return { ...data, rate: data.rate, fromCurrency: currency, toCurrency: "USD", source: data.source ?? this.id,

--- a/src/sources/provider-router/cached-routes.test.ts
+++ b/src/sources/provider-router/cached-routes.test.ts
@@ -175,4 +175,29 @@ describe("shared cached market queries", () => {
     } finally { persistence.close(); }
   });
 
+  test("FX memory, persistence and renderer fallbacks expire by source time during a failed refresh", async () => {
+    const actualNow = Date.now;
+    let now = actualNow();
+    const sourceTime = now - 7 * 86_400_000 + 1000;
+    Date.now = () => now;
+    const persistence = new AppPersistence(":memory:");
+    let calls = 0;
+    const provider = createTestDataProvider({ id: "fx", getExchangeRateSnapshot: async () => {
+      if (++calls > 1) throw new Error("offline");
+      return { rate: 1.16, fromCurrency: "EUR", toCurrency: "USD", source: "yahoo", asOf: new Date(sourceTime).toISOString(), fetchedAt: new Date(now).toISOString(), stale: true };
+    } });
+    const router = new AssetDataRouter(provider, [], persistence.resources);
+    const coordinator = new MarketDataCoordinator(router);
+    try {
+      expect((await coordinator.loadFxRate("EUR")).data).toBe(1.16);
+      now += 2000;
+      expect(router.getCachedExchangeRates(["EUR"], { allowExpired: true }).has("EUR")).toBe(false);
+      const entry = await coordinator.loadFxRate("EUR");
+      expect(entry.data).toBeNull();
+      expect(entry.lastGoodData).toBeNull();
+      expect(entry.error).not.toBeNull();
+      await expect(router.getExchangeRate("EUR")).rejects.toThrow();
+    } finally { Date.now = actualNow; coordinator.destroy(); persistence.close(); }
+  });
+
 });

--- a/src/sources/provider-router/cached-routes.test.ts
+++ b/src/sources/provider-router/cached-routes.test.ts
@@ -15,6 +15,15 @@ function deferred<T>() {
 }
 
 describe("shared cached market queries", () => {
+  test("USD identity works offline without fetching or expiring from its undated static cache", async () => {
+    let calls = 0;
+    const provider = createTestDataProvider({ id: "offline", getExchangeRate: async () => { calls++; throw new Error("offline"); } });
+    const router = new AssetDataRouter(provider);
+    expect(await router.getExchangeRate("USD")).toBe(1);
+    expect(router.getCachedExchangeRates(["USD"]).get("USD")).toBe(1);
+    expect(router.getCachedExchangeRates(["USD"], { allowExpired: false }).get("USD")).toBe(1);
+    expect(calls).toBe(0);
+  });
   test("retries partial corporate actions and invalidates cached estimates without reporting currency", async () => {
     const persistence = new AppPersistence(":memory:");
     let actionCalls = 0;

--- a/src/sources/provider-router/cached-routes.test.ts
+++ b/src/sources/provider-router/cached-routes.test.ts
@@ -137,4 +137,42 @@ describe("shared cached market queries", () => {
     } finally { persistence.close(); }
   });
 
+  test("FX source observation and retrieval times survive cache reload and failed refresh", async () => {
+    const now = Date.now();
+    const fetchedAt = now - 30 * 60_000;
+    const asOf = now - 45 * 60_000;
+    let calls = 0;
+    const persistence = new AppPersistence(":memory:");
+    const provider = createTestDataProvider({ id: "cloud", getExchangeRateSnapshot: async () => {
+      if (++calls > 1) throw new Error("offline");
+      return { fromCurrency: "EUR", toCurrency: "USD", rate: 1.16, source: "yahoo", asOf: new Date(asOf).toISOString(),
+        fetchedAt: new Date(fetchedAt).toISOString(), staleAt: new Date(now + 30 * 60_000).toISOString(), stale: false };
+    } });
+    const router = new AssetDataRouter(provider, [], persistence.resources);
+    const coordinator = new MarketDataCoordinator(router);
+    const reloaded = new AssetDataRouter(provider, [], persistence.resources);
+    try {
+      expect(await coordinator.loadFxRate("EUR")).toMatchObject({ data: 1.16, source: "yahoo", fetchedAt, asOf });
+      expect(await reloaded.getExchangeRate("EUR")).toBe(1.16);
+      expect(reloaded.getCachedQuery("getExchangeRate", ["EUR"]).getSnapshot().result).toMatchObject({ source: "yahoo", fetchedAt, asOf });
+      expect(calls).toBe(1);
+      await router.getCachedQuery("getExchangeRate", ["EUR"]).load({ force: true });
+      expect(coordinator.getFxEntry("EUR")).toMatchObject({ data: 1.16, source: "yahoo", fetchedAt, asOf });
+      expect(coordinator.getFxEntry("EUR").error).not.toBeNull();
+      expect(calls).toBe(2);
+    } finally { coordinator.destroy(); persistence.close(); }
+  });
+
+  test("expired numeric FX fallback also rejects a mismatched pair", () => {
+    const persistence = new AppPersistence(":memory:");
+    const provider = createTestDataProvider({ id: "fx" });
+    persistence.resources.set({ namespace: "market", kind: "exchange-rate", entityKey: "EUR/USD", sourceKey: "provider:fx" },
+      { fromCurrency: "JPY", toCurrency: "USD", rate: 0.0065 },
+      { fetchedAt: Date.now() - 10_000, cachePolicy: { staleMs: 1, expireMs: 2 } });
+    const router = new AssetDataRouter(provider, [], persistence.resources);
+    try {
+      expect(router.getCachedExchangeRates(["EUR"], { allowExpired: true }).has("EUR")).toBe(false);
+    } finally { persistence.close(); }
+  });
+
 });

--- a/src/sources/provider-router/cached-routes.ts
+++ b/src/sources/provider-router/cached-routes.ts
@@ -18,6 +18,7 @@ interface Route {
   rank?: (value: any) => number;
   acceptCached?: (value: any) => boolean;
   decode?: (value: any) => unknown;
+  metadata?: (value: any) => Partial<CachedValue<unknown>>;
   encode?: (value: any) => unknown;
   empty?: () => unknown;
   throwLastError?: boolean;
@@ -53,20 +54,22 @@ export class ProviderRouterCachedRoutes {
     const read = (allowExpired: boolean): CachedValue<unknown> | null => {
       if (staticUsd) return { value: 1, fetchedAt: 0, staleAt: Infinity, expiresAt: Infinity, source: "static" };
       const records = listCachedResources<unknown>(this.deps.resources, route.kind, route.entityKey, route.variants, sourceKeys, allowExpired)
-        .map((record) => ({ ...record, value: route.decode ? route.decode(record.value) : record.value }))
-        .filter((record) => (route.rank?.(record.value) ?? 0) >= 0);
+        .filter((record) => (route.rank?.(record.value) ?? 0) >= 0)
+        .map((record) => ({ ...record, value: route.decode ? route.decode(record.value) : record.value, metadata: route.metadata?.(record.value) }));
       const record = (route.acceptCached ? records.find((entry) => route.acceptCached!(entry.value)) : null) ?? records[0];
       if (!record) return null;
       return {
         value: record.value,
         fetchedAt: record.fetchedAt, staleAt: record.staleAt, expiresAt: record.expiresAt,
         source: record.sourceKey.replace(/^provider:/, ""),
+        ...record.metadata,
       };
     };
     const store = (value: unknown, sourceKey: string, policy: ReturnType<ProviderRouterCoreDeps["resolveProviderPolicy"]>): CachedValue<unknown> => {
       this.deps.cacheResource(route.kind, route.entityKey, route.variants[0] ?? "", sourceKey, route.encode ? route.encode(value) : value, policy);
       const fetchedAt = Date.now();
-      return { value, fetchedAt, staleAt: fetchedAt + policy.staleMs, expiresAt: fetchedAt + policy.expireMs, source: sourceKey.replace(/^provider:/, "") };
+      return { value: route.decode ? route.decode(value) : value, fetchedAt, staleAt: fetchedAt + policy.staleMs,
+        expiresAt: fetchedAt + policy.expireMs, source: sourceKey.replace(/^provider:/, ""), ...route.metadata?.(value) };
     };
     const query = new CachedQuery({
       read,
@@ -124,8 +127,10 @@ export class ProviderRouterCachedRoutes {
       const value = this.get("getExchangeRate", [currency]).getSnapshot().result;
       if (value && (options.allowExpired !== false || value.expiresAt > Date.now())) results.set(currency, value.value);
       else if (options.allowExpired !== false) {
-        const record = listCachedResources<{ rate: number }>(this.deps.resources, "exchange-rate", `${currency.trim().toUpperCase()}/USD`, [""], this.deps.getProviderSourceKeys(), true)[0];
-        if (record && Number.isFinite(record.value.rate) && record.value.rate > 0) results.set(currency, record.value.rate);
+        const route = this.describe("getExchangeRate", [currency]);
+        const record = listCachedResources<{ rate: number }>(this.deps.resources, "exchange-rate", route.entityKey, [""], this.deps.getProviderSourceKeys(), true)
+          .find((candidate) => (route.rank?.(candidate.value) ?? -1) >= 0);
+        if (record) results.set(currency, record.value.rate);
       }
     }
     return results;
@@ -143,9 +148,26 @@ export class ProviderRouterCachedRoutes {
         const currency = ticker.trim().toUpperCase();
         return {
           kind: "exchange-rate", policy: "exchangeRate", entityKey: `${currency}/USD`, variants: [""],
-          request: (provider) => provider.getExchangeRate(currency),
-          rank: (rate: number) => Number.isFinite(rate) && rate > 0 ? 2 : -1,
-          decode: (data: { rate: number }) => data.rate, encode: (rate) => ({ rate }),
+          request: (provider) => provider.getExchangeRateSnapshot?.(currency) ?? provider.getExchangeRate(currency),
+          rank: (value: any) => {
+            const rate = typeof value === "number" ? value : value?.rate;
+            return Number.isFinite(rate) && rate > 0 && (!value?.fromCurrency || value.fromCurrency === currency)
+              && (!value?.toCurrency || value.toCurrency === "USD") ? 2 : -1;
+          },
+          decode: (data: any) => typeof data === "number" ? data : data.rate,
+          encode: (data: any) => typeof data === "number" ? { rate: data } : data,
+          metadata: (data: any) => {
+            if (typeof data !== "object" || !data) return {};
+            const finiteTime = (value: unknown) => typeof value === "string" && Number.isFinite(Date.parse(value)) ? Date.parse(value) : undefined;
+            const fetchedAt = finiteTime(data.fetchedAt);
+            const staleAt = finiteTime(data.staleAt);
+            return {
+              ...(fetchedAt !== undefined ? { fetchedAt, expiresAt: fetchedAt + 7 * 24 * 60 * 60_000 } : {}),
+              ...(staleAt !== undefined || data.stale === true ? { staleAt: data.stale === true ? Math.min(staleAt ?? Date.now(), Date.now()) : staleAt! } : {}),
+              asOf: finiteTime(data.asOf),
+              ...(typeof data.source === "string" ? { source: data.source } : {}),
+            };
+          },
           error: `No exchange rate provider available for ${currency}`,
         };
       }

--- a/src/sources/provider-router/cached-routes.ts
+++ b/src/sources/provider-router/cached-routes.ts
@@ -1,3 +1,4 @@
+import { exchangeRateMetadata, isUsableCachedExchangeRate } from "../../utils/exchange-rate-snapshot";
 import { CachedQuery, type CachedValue } from "../../data/cached-query";
 import type { CachedAssetArgs, CachedAssetMethod, CachedAssetValue, DataProvider, MarketDataRequestContext, SecFilingItem } from "../../types/data-provider";
 import type { AnalystResearchData, CorporateActionsData, HolderData } from "../../types/financials";
@@ -15,10 +16,10 @@ interface Route {
   variants: string[];
   request: (provider: DataProvider, force: boolean) => Promise<unknown> | undefined;
   error: string;
-  rank?: (value: any) => number;
+  rank?: (value: any, fetchedAt?: number) => number;
   acceptCached?: (value: any) => boolean;
   decode?: (value: any) => unknown;
-  metadata?: (value: any) => Partial<CachedValue<unknown>>;
+  metadata?: (value: any, fetchedAt?: number) => Partial<CachedValue<unknown>>;
   encode?: (value: any) => unknown;
   empty?: () => unknown;
   throwLastError?: boolean;
@@ -54,8 +55,8 @@ export class ProviderRouterCachedRoutes {
     const read = (allowExpired: boolean): CachedValue<unknown> | null => {
       if (staticUsd) return { value: 1, fetchedAt: 0, staleAt: Infinity, expiresAt: Infinity, source: "static" };
       const records = listCachedResources<unknown>(this.deps.resources, route.kind, route.entityKey, route.variants, sourceKeys, allowExpired)
-        .filter((record) => (route.rank?.(record.value) ?? 0) >= 0)
-        .map((record) => ({ ...record, value: route.decode ? route.decode(record.value) : record.value, metadata: route.metadata?.(record.value) }));
+        .filter((record) => (route.rank?.(record.value, record.fetchedAt) ?? 0) >= 0)
+        .map((record) => ({ ...record, value: route.decode ? route.decode(record.value) : record.value, metadata: route.metadata?.(record.value, record.fetchedAt) }));
       const record = (route.acceptCached ? records.find((entry) => route.acceptCached!(entry.value)) : null) ?? records[0];
       if (!record) return null;
       return {
@@ -69,10 +70,13 @@ export class ProviderRouterCachedRoutes {
       this.deps.cacheResource(route.kind, route.entityKey, route.variants[0] ?? "", sourceKey, route.encode ? route.encode(value) : value, policy);
       const fetchedAt = Date.now();
       return { value: route.decode ? route.decode(value) : value, fetchedAt, staleAt: fetchedAt + policy.staleMs,
-        expiresAt: fetchedAt + policy.expireMs, source: sourceKey.replace(/^provider:/, ""), ...route.metadata?.(value) };
+        expiresAt: fetchedAt + policy.expireMs, source: sourceKey.replace(/^provider:/, ""), ...route.metadata?.(value, fetchedAt) };
     };
     const query = new CachedQuery({
       read,
+      acceptResult: method === "getExchangeRate" ? (result) => isUsableCachedExchangeRate(
+        result.value as number, String(args[0]).trim().toUpperCase(), result,
+      ) : undefined,
       acceptCached: route.acceptCached,
       fetch: async (force) => {
         if (route.brokerRequest) {
@@ -129,7 +133,7 @@ export class ProviderRouterCachedRoutes {
       else if (options.allowExpired !== false) {
         const route = this.describe("getExchangeRate", [currency]);
         const record = listCachedResources<{ rate: number }>(this.deps.resources, "exchange-rate", route.entityKey, [""], this.deps.getProviderSourceKeys(), true)
-          .find((candidate) => (route.rank?.(candidate.value) ?? -1) >= 0);
+          .find((candidate) => (route.rank?.(candidate.value, candidate.fetchedAt) ?? -1) >= 0);
         if (record) results.set(currency, record.value.rate);
       }
     }
@@ -149,25 +153,13 @@ export class ProviderRouterCachedRoutes {
         return {
           kind: "exchange-rate", policy: "exchangeRate", entityKey: `${currency}/USD`, variants: [""],
           request: (provider) => provider.getExchangeRateSnapshot?.(currency) ?? provider.getExchangeRate(currency),
-          rank: (value: any) => {
-            const rate = typeof value === "number" ? value : value?.rate;
-            return Number.isFinite(rate) && rate > 0 && (!value?.fromCurrency || value.fromCurrency === currency)
-              && (!value?.toCurrency || value.toCurrency === "USD") ? 2 : -1;
+          rank: (value: any, fetchedAt) => {
+            try { exchangeRateMetadata(value, currency, Date.now(), fetchedAt); return 2; }
+            catch { return -1; }
           },
           decode: (data: any) => typeof data === "number" ? data : data.rate,
           encode: (data: any) => typeof data === "number" ? { rate: data } : data,
-          metadata: (data: any) => {
-            if (typeof data !== "object" || !data) return {};
-            const finiteTime = (value: unknown) => typeof value === "string" && Number.isFinite(Date.parse(value)) ? Date.parse(value) : undefined;
-            const fetchedAt = finiteTime(data.fetchedAt);
-            const staleAt = finiteTime(data.staleAt);
-            return {
-              ...(fetchedAt !== undefined ? { fetchedAt, expiresAt: fetchedAt + 7 * 24 * 60 * 60_000 } : {}),
-              ...(staleAt !== undefined || data.stale === true ? { staleAt: data.stale === true ? Math.min(staleAt ?? Date.now(), Date.now()) : staleAt! } : {}),
-              asOf: finiteTime(data.asOf),
-              ...(typeof data.source === "string" ? { source: data.source } : {}),
-            };
-          },
+          metadata: (data, fetchedAt) => exchangeRateMetadata(data, currency, Date.now(), fetchedAt),
           error: `No exchange rate provider available for ${currency}`,
         };
       }

--- a/src/sources/yahoo-finance.test.ts
+++ b/src/sources/yahoo-finance.test.ts
@@ -3,6 +3,26 @@ import { YahooFinanceClient } from "./yahoo-finance";
 import { getYahooSymbolsToTry } from "./yahoo-finance/symbols";
 
 describe("YahooFinanceClient exchange aliases", () => {
+  test("FX rates keep the matching price observation time and reject another pair", async () => {
+    const provider = new YahooFinanceClient() as any;
+    const previous = Date.now() - 7_200_000;
+    provider.fetchChart = async () => ({ meta: { symbol: "JPYUSD=X", currency: "USD", regularMarketPrice: 1 / 154, regularMarketTime: previous / 1000 }, history: [] });
+    const snapshot = await provider.getExchangeRateSnapshot("JPY");
+    expect(snapshot.rate).toBeCloseTo(1 / 154, 12);
+    expect(snapshot.asOf).toBe(new Date(previous).toISOString());
+    expect(Date.parse(snapshot.fetchedAt)).toBeGreaterThan(previous);
+    expect(snapshot.stale).toBe(true);
+    provider.fetchChart = async () => ({ meta: { symbol: "JPYUSD=X", currency: "USD", regularMarketPrice: 0.0065, regularMarketTime: previous / 1000 }, history: [{ date: new Date(previous), close: 0.006475719157606363 }] });
+    expect((await provider.getExchangeRateSnapshot("JPY")).rate).toBe(0.006475719157606363);
+    provider.fetchChart = async () => ({ meta: { symbol: "JPYUSD=X", currency: "USD" }, history: [{ date: new Date(previous), close: 1 / 155 }] });
+    expect(await provider.getExchangeRateSnapshot("JPY")).toMatchObject({ rate: 1 / 155, asOf: new Date(previous).toISOString() });
+    provider.fetchChart = async () => ({ meta: { symbol: "USDJPY=X", currency: "JPY", regularMarketPrice: 154 }, history: [] });
+    await expect(provider.getExchangeRateSnapshot("JPY")).rejects.toThrow("pair mismatch");
+    provider.fetchChart = async () => ({ meta: { regularMarketPrice: 1 / 154 }, history: [{ date: new Date(previous), close: 1 / 155 }] });
+    // An unrelated old bar cannot supply the timestamp for an undated current price.
+    expect((await provider.getExchangeRateSnapshot("JPY")).asOf).toBeUndefined();
+  });
+
   test("maps detailed statement sub-lines from fundamentals timeseries", async () => {
     const provider = new YahooFinanceClient() as any;
     const point = (type: string, value: number) => ({

--- a/src/sources/yahoo-finance.ts
+++ b/src/sources/yahoo-finance.ts
@@ -1,3 +1,4 @@
+import { exchangeRateMetadata } from "../utils/exchange-rate-snapshot";
 import type { ExchangeRateSnapshot } from "../types/exchange-rate";
 import type { Quote, PricePoint, TickerFinancials, OptionsChain, CompanyProfile, HolderData, AnalystResearchData, CorporateActionsData } from "../types/financials";
 import type { DataProvider, EarningsEvent, MarketDataRequestContext, NewsItem, SecFilingItem } from "../types/data-provider";
@@ -229,10 +230,11 @@ export class YahooFinanceClient implements DataProvider {
     const time = useBar ? last.date.getTime() : currentTime;
     const asOf = typeof time === "number" && Number.isFinite(time) && time > 0 ? new Date(time).toISOString() : undefined;
     const retrieved = Date.now();
-    if (asOf && Date.parse(asOf) > retrieved + 60_000) throw new Error(`Future exchange rate observation for ${normalized}/USD`);
     const staleAt = Math.min(retrieved + 60 * 60_000, asOf ? Date.parse(asOf) + 60 * 60_000 : Infinity);
-    return { fromCurrency: normalized, toCurrency: "USD", rate, source: this.id, asOf, fetchedAt: new Date(retrieved).toISOString(),
+    const snapshot: ExchangeRateSnapshot = { fromCurrency: normalized, toCurrency: "USD", rate, source: this.id, asOf, fetchedAt: new Date(retrieved).toISOString(),
       staleAt: new Date(staleAt).toISOString(), stale: staleAt <= retrieved, delayMinutes: 0 };
+    exchangeRateMetadata(snapshot, normalized, retrieved);
+    return snapshot;
   }
 
   /** Search for a ticker by name/symbol - uses direct fetch (no retry) for speed */

--- a/src/sources/yahoo-finance.ts
+++ b/src/sources/yahoo-finance.ts
@@ -1,3 +1,4 @@
+import type { ExchangeRateSnapshot } from "../types/exchange-rate";
 import type { Quote, PricePoint, TickerFinancials, OptionsChain, CompanyProfile, HolderData, AnalystResearchData, CorporateActionsData } from "../types/financials";
 import type { DataProvider, EarningsEvent, MarketDataRequestContext, NewsItem, SecFilingItem } from "../types/data-provider";
 import type { TimeRange } from "../time-series/range";
@@ -202,19 +203,36 @@ export class YahooFinanceClient implements DataProvider {
     throw lastError || new Error(`No quote for ${ticker}`);
   }
 
-  /** Fetch exchange rate to USD */
+  /** Fetch exchange rate to USD. */
   async getExchangeRate(fromCurrency: string): Promise<number> {
-    // Normalize sub-unit currencies to their main unit
-    const { currency: normalized } = normalizeSubUnitCurrency(fromCurrency);
-    fromCurrency = normalized;
-    if (fromCurrency === "USD") return 1;
+    return (await this.getExchangeRateSnapshot(fromCurrency)).rate;
+  }
 
-    const { meta, history } = await this.fetchChart(`${fromCurrency}USD=X`, "1mo");
-    const rate = meta.regularMarketPrice ?? history[history.length - 1]?.close;
-    if (typeof rate !== "number" || !Number.isFinite(rate) || rate <= 0) {
-      throw new Error(`No exchange rate data for ${fromCurrency}/USD`);
+  async getExchangeRateSnapshot(fromCurrency: string): Promise<ExchangeRateSnapshot> {
+    const { currency } = normalizeSubUnitCurrency(fromCurrency);
+    const normalized = currency.trim().toUpperCase();
+    if (!/^[A-Z]{3}$/.test(normalized)) throw new Error("Exchange rates require a three-letter currency code");
+    const fetchedAt = new Date().toISOString();
+    if (normalized === "USD") return { fromCurrency: normalized, toCurrency: "USD", rate: 1, source: "identity", fetchedAt, stale: false };
+    const { meta, history } = await this.fetchChart(`${normalized}USD=X`, "1mo");
+    if ((meta.symbol && meta.symbol !== `${normalized}USD=X`) || (meta.currency && meta.currency !== "USD")) {
+      throw new Error(`Exchange rate pair mismatch for ${normalized}/USD`);
     }
-    return rate;
+    const last = history.at(-1);
+    const hasCurrent = typeof meta.regularMarketPrice === "number" && Number.isFinite(meta.regularMarketPrice) && meta.regularMarketPrice > 0;
+    const currentTime = Number(meta.regularMarketTime) * 1000;
+    // Yahoo rounds regularMarketPrice (JPY/USD can become 0.0065). Prefer
+    // the full-precision chart close when it describes the same observation.
+    const useBar = last && (!hasCurrent || last.date.getTime() >= currentTime);
+    const rate = useBar ? last.close : hasCurrent ? meta.regularMarketPrice! : undefined;
+    if (typeof rate !== "number" || !Number.isFinite(rate) || rate <= 0) throw new Error(`No exchange rate data for ${normalized}/USD`);
+    const time = useBar ? last.date.getTime() : currentTime;
+    const asOf = typeof time === "number" && Number.isFinite(time) && time > 0 ? new Date(time).toISOString() : undefined;
+    const retrieved = Date.now();
+    if (asOf && Date.parse(asOf) > retrieved + 60_000) throw new Error(`Future exchange rate observation for ${normalized}/USD`);
+    const staleAt = Math.min(retrieved + 60 * 60_000, asOf ? Date.parse(asOf) + 60 * 60_000 : Infinity);
+    return { fromCurrency: normalized, toCurrency: "USD", rate, source: this.id, asOf, fetchedAt: new Date(retrieved).toISOString(),
+      staleAt: new Date(staleAt).toISOString(), stale: staleAt <= retrieved, delayMinutes: 0 };
   }
 
   /** Search for a ticker by name/symbol - uses direct fetch (no retry) for speed */

--- a/src/sources/yahoo-finance/types.ts
+++ b/src/sources/yahoo-finance/types.ts
@@ -3,6 +3,7 @@ type TradingPeriod = { start?: number; end?: number; gmtoffset?: number; timezon
 export type ChartResult = {
   meta?: {
     instrumentType?: string;
+    symbol?: string;
     currency?: string; longName?: string; shortName?: string;
     regularMarketPrice?: number; chartPreviousClose?: number;
     fiftyTwoWeekHigh?: number; fiftyTwoWeekLow?: number;

--- a/src/types/data-provider.ts
+++ b/src/types/data-provider.ts
@@ -1,3 +1,4 @@
+import type { ExchangeRateSnapshot } from "./exchange-rate";
 import type {
   AnalystResearchData,
   CorporateActionsData,
@@ -155,6 +156,7 @@ export interface AssetDataProvider {
   getTickerFinancials(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<TickerFinancials>;
   getQuote(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<Quote>;
   getExchangeRate(fromCurrency: string): Promise<number>;
+  getExchangeRateSnapshot?(fromCurrency: string): Promise<ExchangeRateSnapshot>;
   search(query: string, context?: SearchRequestContext): Promise<InstrumentSearchResult[]>;
   getSecFilings?(ticker: string, count?: number, exchange?: string, context?: MarketDataRequestContext): Promise<SecFilingItem[]>;
   getHolders?(ticker: string, exchange?: string, context?: MarketDataRequestContext): Promise<HolderData>;

--- a/src/types/exchange-rate.ts
+++ b/src/types/exchange-rate.ts
@@ -1,0 +1,13 @@
+/** Quote currency units per one base-currency unit; conversion rates use USD. */
+export interface ExchangeRateSnapshot {
+  fromCurrency: string;
+  toCurrency: "USD";
+  rate: number;
+  source: string;
+  /** Provider observation time, independent of retrieval/cache age. */
+  asOf?: string;
+  fetchedAt: string;
+  staleAt?: string;
+  stale: boolean;
+  delayMinutes?: number;
+}

--- a/src/utils/exchange-rate-snapshot.test.ts
+++ b/src/utils/exchange-rate-snapshot.test.ts
@@ -17,4 +17,6 @@ test("FX retention is bounded by observation age, independent of a recent fetch"
   ]) expect(() => exchangeRateMetadata(data, "EUR", now)).toThrow();
   expect(() => exchangeRateMetadata({ rate: 1.16 }, "EUR", now, now - MAX_FX_OBSERVATION_AGE_MS)).toThrow();
   expect(exchangeRateMetadata({ ...recent, stale: true, asOf: new Date(now).toISOString() }, "EUR", now).staleAt).toBe(now);
+  expect(exchangeRateMetadata(1, "USD", now, 0)).toEqual({ staleAt: Infinity, expiresAt: Infinity, source: "identity" });
+  expect(() => exchangeRateMetadata(1.01, "USD", now, 0)).toThrow();
 });

--- a/src/utils/exchange-rate-snapshot.test.ts
+++ b/src/utils/exchange-rate-snapshot.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test";
+import { exchangeRateMetadata, MAX_FX_OBSERVATION_AGE_MS } from "./exchange-rate-snapshot";
+
+test("FX retention is bounded by observation age, independent of a recent fetch", () => {
+  const now = Date.parse("2026-09-10T22:00:00Z");
+  const sourceTime = now - 6 * 86_400_000;
+  const recent = { rate: 1.16, fromCurrency: "EUR", toCurrency: "USD", fetchedAt: new Date(now).toISOString() };
+  expect(exchangeRateMetadata({ ...recent, asOf: new Date(sourceTime).toISOString() }, "EUR", now))
+    .toMatchObject({ fetchedAt: now, asOf: sourceTime, expiresAt: sourceTime + MAX_FX_OBSERVATION_AGE_MS, staleAt: sourceTime + 3_600_000 });
+  for (const data of [
+    { ...recent, asOf: new Date(now - MAX_FX_OBSERVATION_AGE_MS).toISOString() },
+    { ...recent, asOf: new Date(now + 120_000).toISOString() },
+    { ...recent, asOf: "invalid" },
+    { ...recent, fetchedAt: "invalid" },
+    { ...recent, staleAt: "invalid" },
+    { ...recent, fromCurrency: "JPY" },
+  ]) expect(() => exchangeRateMetadata(data, "EUR", now)).toThrow();
+  expect(() => exchangeRateMetadata({ rate: 1.16 }, "EUR", now, now - MAX_FX_OBSERVATION_AGE_MS)).toThrow();
+  expect(exchangeRateMetadata({ ...recent, stale: true, asOf: new Date(now).toISOString() }, "EUR", now).staleAt).toBe(now);
+});

--- a/src/utils/exchange-rate-snapshot.ts
+++ b/src/utils/exchange-rate-snapshot.ts
@@ -1,0 +1,49 @@
+import type { ExchangeRateSnapshot } from "../types/exchange-rate";
+
+export const MAX_FX_OBSERVATION_AGE_MS = 7 * 24 * 60 * 60_000;
+const FX_FRESH_MS = 60 * 60_000;
+
+export function isUsableCachedExchangeRate(rate: number | null, currency: string,
+  timing: { asOf?: number; fetchedAt?: number | null }, now = Date.now()): boolean {
+  try {
+    exchangeRateMetadata({ rate, asOf: timing.asOf === undefined ? undefined : new Date(timing.asOf).toISOString() },
+      currency, now, timing.fetchedAt ?? undefined);
+    return true;
+  } catch { return false; }
+}
+
+/** Validate before numeric decoding, including persisted and legacy snapshots. */
+export function exchangeRateMetadata(value: unknown, currency: string, now = Date.now(), fallbackFetchedAt?: number) {
+  const data = typeof value === "number" ? { rate: value } : value as Partial<ExchangeRateSnapshot> | null;
+  const fail = () => { throw new Error(`Invalid or expired exchange rate for ${currency}/USD`); };
+  if (!data || typeof data !== "object" || !Number.isFinite(data.rate) || data.rate! <= 0
+    || (data.fromCurrency !== undefined && data.fromCurrency !== currency)
+    || (data.toCurrency !== undefined && data.toCurrency !== "USD")) return fail();
+  const timestamp = (input: unknown): number | undefined => {
+    if (input === undefined) return undefined;
+    if (typeof input !== "string" || !Number.isFinite(Date.parse(input))) return fail();
+    return Date.parse(input);
+  };
+  const asOf = timestamp(data.asOf);
+  const fetchedAt = timestamp(data.fetchedAt) ?? fallbackFetchedAt;
+  const declaredStaleAt = timestamp(data.staleAt);
+  const observation = asOf ?? fetchedAt;
+  if ([asOf, fetchedAt].some((time) => time !== undefined && (!Number.isFinite(time) || time > now + 60_000))
+    || (observation !== undefined && now - observation >= MAX_FX_OBSERVATION_AGE_MS)) return fail();
+  const expiresAt = Math.min(fetchedAt === undefined ? Infinity : fetchedAt + MAX_FX_OBSERVATION_AGE_MS,
+    asOf === undefined ? Infinity : asOf + MAX_FX_OBSERVATION_AGE_MS);
+  if (expiresAt <= now) return fail();
+  const delay = typeof data.delayMinutes === "number" && Number.isFinite(data.delayMinutes) && data.delayMinutes >= 0
+    ? Math.min(data.delayMinutes, 15) * 60_000 : 0;
+  const staleAt = Math.min(declaredStaleAt ?? Infinity,
+    fetchedAt === undefined ? Infinity : fetchedAt + FX_FRESH_MS,
+    asOf === undefined ? Infinity : asOf + FX_FRESH_MS + delay,
+    data.stale === true ? now : Infinity);
+  return {
+    ...(fetchedAt !== undefined ? { fetchedAt } : {}),
+    asOf,
+    ...(Number.isFinite(expiresAt) ? { expiresAt } : {}),
+    ...(Number.isFinite(staleAt) ? { staleAt } : {}),
+    ...(typeof data.source === "string" ? { source: data.source } : {}),
+  };
+}

--- a/src/utils/exchange-rate-snapshot.ts
+++ b/src/utils/exchange-rate-snapshot.ts
@@ -3,6 +3,14 @@ import type { ExchangeRateSnapshot } from "../types/exchange-rate";
 export const MAX_FX_OBSERVATION_AGE_MS = 7 * 24 * 60 * 60_000;
 const FX_FRESH_MS = 60 * 60_000;
 
+interface FxRateMetadata {
+  fetchedAt?: number;
+  asOf?: number;
+  staleAt?: number;
+  expiresAt?: number;
+  source?: string;
+}
+
 export function isUsableCachedExchangeRate(rate: number | null, currency: string,
   timing: { asOf?: number; fetchedAt?: number | null }, now = Date.now()): boolean {
   try {
@@ -13,12 +21,17 @@ export function isUsableCachedExchangeRate(rate: number | null, currency: string
 }
 
 /** Validate before numeric decoding, including persisted and legacy snapshots. */
-export function exchangeRateMetadata(value: unknown, currency: string, now = Date.now(), fallbackFetchedAt?: number) {
+export function exchangeRateMetadata(value: unknown, currency: string, now = Date.now(), fallbackFetchedAt?: number): FxRateMetadata {
   const data = typeof value === "number" ? { rate: value } : value as Partial<ExchangeRateSnapshot> | null;
   const fail = () => { throw new Error(`Invalid or expired exchange rate for ${currency}/USD`); };
   if (!data || typeof data !== "object" || !Number.isFinite(data.rate) || data.rate! <= 0
     || (data.fromCurrency !== undefined && data.fromCurrency !== currency)
     || (data.toCurrency !== undefined && data.toCurrency !== "USD")) return fail();
+  // The numeraire identity needs no market observation or upstream request.
+  if (currency === "USD") {
+    if (data.rate !== 1) return fail();
+    return { staleAt: Infinity, expiresAt: Infinity, source: "identity" };
+  }
   const timestamp = (input: unknown): number | undefined => {
     if (input === undefined) return undefined;
     if (typeof input !== "string" || !Number.isFinite(Date.parse(input))) return fail();

--- a/src/utils/fx-status.test.ts
+++ b/src/utils/fx-status.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+import { summarizeFxRates, fxStatusLabel } from "./fx-status";
+import { createIdleEntry } from "../market-data/result-types";
+
+test("cross-currency status exposes oldest source time, stale fallback, missing and undated rates separately", () => {
+  const now = Date.parse("2026-09-10T21:00:00Z");
+  const eur = { ...createIdleEntry<number>(), phase: "ready" as const, data: 1.16, source: "yahoo", asOf: now - 45 * 60_000, fetchedAt: now - 30 * 60_000, staleAt: now + 30 * 60_000 };
+  const jpy = { ...eur, data: 1 / 154, asOf: now - 2 * 60 * 60_000, fetchedAt: now - 2 * 60 * 60_000, staleAt: now - 60 * 60_000, error: { reasonCode: "offline", message: "offline" } };
+  const read = (currency: string) => currency === "EUR" ? eur : currency === "JPY" ? jpy : null;
+  const rates = new Map([["USD", 1], ["EUR", 1.16], ["JPY", 1 / 154], ["GBP", 1.33]]);
+  const status = summarizeFxRates(["USD", "EUR", "JPY", "GBP", "CHF", "EUR"], rates, read, now);
+  expect(status).toMatchObject({ unavailable: 1, stale: 1, unknownTime: 1, oldestAsOf: jpy.asOf, latestFetchedAt: eur.fetchedAt, sources: ["yahoo"] });
+  expect(fxStatusLabel(status)).toContain("oldest rate 2026-09-10 19:00 UTC");
+  expect(fxStatusLabel(status)).toContain("1 rate time unknown");
+  expect(summarizeFxRates(["USD"], rates, read, now).oldestAsOf).toBeNull();
+});

--- a/src/utils/fx-status.ts
+++ b/src/utils/fx-status.ts
@@ -1,0 +1,46 @@
+import type { QueryEntry } from "../market-data/result-types";
+
+export interface FxRateStatus {
+  loading: number;
+  unavailable: number;
+  stale: number;
+  unknownTime: number;
+  oldestAsOf: number | null;
+  latestFetchedAt: number | null;
+  sources: string[];
+}
+
+/** A fetched timestamp never stands in for a source observation timestamp. */
+export function summarizeFxRates(
+  currencies: readonly string[],
+  rates: ReadonlyMap<string, number>,
+  read: (currency: string) => QueryEntry<number> | null | undefined,
+  now = Date.now(),
+): FxRateStatus {
+  const status: FxRateStatus = { loading: 0, unavailable: 0, stale: 0, unknownTime: 0, oldestAsOf: null, latestFetchedAt: null, sources: [] };
+  const sources = new Set<string>();
+  for (const currency of new Set(currencies.map((value) => value.trim().toUpperCase()))) {
+    if (currency === "USD") continue;
+    const entry = read(currency);
+    if (entry?.phase === "loading" || entry?.phase === "refreshing") status.loading++;
+    const rate = rates.get(currency);
+    if (rate == null || !Number.isFinite(rate) || rate <= 0) { status.unavailable++; continue; }
+    // A legacy persisted numeric rate may be present without a dated query.
+    if (!entry || entry.asOf == null || !Number.isFinite(entry.asOf)) status.unknownTime++;
+    else status.oldestAsOf = Math.min(status.oldestAsOf ?? Infinity, entry.asOf);
+    if (entry?.error || (entry?.staleAt != null && entry.staleAt <= now)) status.stale++;
+    if (entry?.fetchedAt != null) status.latestFetchedAt = Math.max(status.latestFetchedAt ?? 0, entry.fetchedAt);
+    if (entry?.source && entry.source !== "static" && entry.source !== "identity") sources.add(entry.source);
+  }
+  status.sources = [...sources].sort();
+  return status;
+}
+
+export function fxStatusLabel(status: FxRateStatus): string {
+  const parts: string[] = [];
+  if (status.unavailable) parts.push(`${status.unavailable} unavailable`);
+  if (status.stale) parts.push(`${status.stale} stale`);
+  if (status.unknownTime) parts.push(`${status.unknownTime} rate ${status.unknownTime === 1 ? "time" : "times"} unknown`);
+  if (status.oldestAsOf != null) parts.push(`oldest rate ${new Date(status.oldestAsOf).toISOString().slice(0, 16).replace("T", " ")} UTC`);
+  return parts.join(" · ");
+}


### PR DESCRIPTION
The FX matrix labelled retrieval time as “updated” while conversion rates had no visible observation date or stale-fallback warning. Portfolio totals could likewise use an old FX leg without showing its age.

Preserve optional FX snapshots through provider routing, persistence and coordinator metadata while keeping existing numeric conversion callers compatible. The matrix explains row/column direction and USD-leg cross construction, separates oldest source observation from fetch age, and distinguishes unavailable, stale and undated rates. Portfolio status shows the same relevant FX warning. Legacy servers remain usable with an explicit unknown observation-time label.

Keep Yahoo's full-precision chart close when it matches the summary's observation time: the live JPY/USD payload had a rounded `0.0065` summary versus `0.006475719157606363` in the same-time chart. Validate pair identity before decoding, including expired cache fallback. Failed refreshes retain the original source/retrieval times.

Validation: 121 focused tests / 472 assertions; all six TypeScript projects and browser build passed. Actual local browser against unchanged production API showed populated rates with unknown observation times. Browser and tmux replays of seven captured Yahoo observations showed dated rates; controlled missing JPY/stale EUR/undated CHF responses showed distinct warnings. An in-memory mixed EUR/JPY portfolio rendered the stale-FX warning; no real portfolio/account was modified. Authenticated broker portfolio and live Pro FX coverage remain unverified.

Backend companion: https://github.com/vincelwt/gloomberb-platform/pull/231. Both payload versions are supported, so either deployment order is compatible. Audit evidence: local `persona-audit/fx.json` and `fx-evidence/`. Held for review; no release.

Review follow-up: enforce the seven-day limit from source observation time across native/cloud reads, persistent and in-memory fallback, and renderer projection; a recent retrieval cannot renew an expired observation. Browser controlled eight-day-old HTTP200 rate is unavailable.

Final validation: offline USD/USD remains exactly1 without provider calls. Full local suite:2929tests/11033assertions passed. Actual80-column terminal portfolio captures retain stale/unavailable FX warnings.
