### PR TITLE
Recover missing research quotes without discarding company data

### DIFF
--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -1,4 +1,4 @@
-import { EmptyState, SectionHeading } from "../../../components";
+import { EmptyState, Notice, SectionHeading } from "../../../components";
 import { CompositeChart, pricePointsToResolvedSeries } from "../../../components/chart/composite";
 import { CompanyLogo } from "../../../components/company-logo";
 import { PriceReturnStrip } from "../../../components/price-performance";
@@ -202,6 +202,10 @@ export function OverviewTab({
             <QuoteBook quote={quote} assetCategory={ticker.metadata.assetCategory} width={quoteBookWidth} />
           )}
         </Box>
+
+        {!quote && financials && (
+          <Notice>{t("Current quote unavailable. Other research data is still available.")}</Notice>
+        )}
 
         {(hasDayRange || hasYearRange) && quote && (
           <Box flexDirection={rangeInline ? "row" : "column"} gap={rangeInline ? 2 : 0} width={contentWidth}>

--- a/src/sources/provider-router/batches.ts
+++ b/src/sources/provider-router/batches.ts
@@ -39,7 +39,7 @@ export class ProviderRouterBatchRoutes {
   constructor(private readonly deps: ProviderRouterBatchDeps) {}
 
   private needsSingleFinancialsRoute(value: TickerFinancials): boolean {
-    return !(hasDetailedStatementRows(value) && hasDeepStatementHistory(value));
+    return !value.quote || !(hasDetailedStatementRows(value) && hasDeepStatementHistory(value));
   }
 
   async getQuotesBatch(
@@ -127,7 +127,7 @@ export class ProviderRouterBatchRoutes {
     targets.forEach((target, index) => {
       const context = this.deps.contextFromCachedTarget(target);
       const cached = this.deps.readCachedMergedFinancialsSelection(target.symbol, target.exchange, context, true);
-      if (cached.value && !forceRefresh && target.statementHistory !== "extended") {
+      if (cached.value?.quote && !forceRefresh && target.statementHistory !== "extended") {
         results[index] = { target, financials: cached.value };
         return;
       }

--- a/src/sources/provider-router/cache.test.ts
+++ b/src/sources/provider-router/cache.test.ts
@@ -5,6 +5,25 @@ import { cleanupProviderRouterTestFiles, createTempDbPath, makeFinancials, makeQ
 
 afterEach(cleanupProviderRouterTestFiles);
 
+test("legacy cloud financial caches retain statements but refresh quotes whose freshness was lost", () => {
+  const persistence = new AppPersistence(createTempDbPath("nested-quote-freshness"));
+  const key = { namespace: "market", kind: "financials", entityKey: "7203", variantKey: "exchange=TYO", sourceKey: "provider:gloomberb-cloud" };
+  const cachePolicy = { staleMs: 60_000, expireMs: 120_000 };
+  const old = makeFinancials({ quote: makeQuote({ symbol: "7203", currency: "JPY", price: 2980.5, providerId: "gloomberb-cloud" }),
+    annualStatements: [{ date: "2026-03-31", totalRevenue: 100, fieldAvailability: { totalRevenue: "2026-05-08" } }],
+  });
+  persistence.resources.set(key, old, { cachePolicy, schemaVersion: 3 });
+  const quote = makeQuote({ symbol: "7203", currency: "JPY", price: 2994, providerId: "yahoo" });
+  persistence.resources.set({ ...key, kind: "quote", sourceKey: "provider:yahoo" }, quote, { cachePolicy });
+  const read = () => listCachedResources(persistence.resources, "financials", "7203", [key.variantKey], [key.sourceKey], true)[0]!.value as ReturnType<typeof makeFinancials>;
+  expect(read().quote).toBeUndefined();
+  expect(read().annualStatements).toEqual(old.annualStatements);
+  expect(listCachedResources(persistence.resources, "quote", "7203", [key.variantKey], ["provider:yahoo"], true)[0]!.value).toEqual(quote);
+  cacheRouterResource(persistence.resources, "financials", "7203", key.variantKey, key.sourceKey, { ...old, quote: { ...old.quote!, stale: true } }, cachePolicy);
+  expect(read().quote?.stale).toBe(true);
+  persistence.close();
+});
+
 test("refreshes legacy SEC annual caches without discarding unrelated data and accepts repaired writes", () => {
   const persistence = new AppPersistence(createTempDbPath("sec-annual-cache-version"));
   const key = { namespace: "market", kind: "financials", entityKey: "COST", variantKey: "exchange=NASDAQ", sourceKey: "provider:yahoo" };

--- a/src/sources/provider-router/cache.ts
+++ b/src/sources/provider-router/cache.ts
@@ -7,7 +7,7 @@ import { canonicalExchange } from "../../utils/exchanges";
 import { isPriceHistoryStaleForCurrentWindow } from "../../utils/price-history";
 
 const MARKET_NAMESPACE = "market";
-const FINANCIALS_SCHEMA_VERSION = 3;
+const FINANCIALS_SCHEMA_VERSION = 4;
 
 const DEFAULT_CACHE_POLICIES = {
   brokerQuote: { staleMs: 15_000, expireMs: 15 * 60_000 },
@@ -145,7 +145,7 @@ export function listCachedResources<T>(
     sourceKeys,
     allowExpired,
   }).filter((record) => {
-    if (kind !== "financials" || record.schemaVersion >= FINANCIALS_SCHEMA_VERSION) return true;
+    if (kind !== "financials" || record.schemaVersion >= 3) return true;
     // Earlier merges could date unknown fields from a partial availability map,
     // in addition to the older SEC annual/concept errors. Cached dates cannot
     // distinguish inferred metadata from source evidence; refresh dated rows.
@@ -153,6 +153,12 @@ export function listCachedResources<T>(
     const value = record.value as TickerFinancials;
     return ![...(value.annualStatements ?? []), ...(value.quarterlyStatements ?? [])]
       .some((row) => row.availableAt || Object.keys(row.fieldAvailability ?? {}).length > 0);
+  }).map((record) => {
+    if (kind !== "financials" || record.schemaVersion >= 4 || record.sourceKey !== "provider:gloomberb-cloud") return record;
+    // Legacy cloud aggregates lost the nested quote's stale flag. Retain valid
+    // issuer data, but obtain the quote through its independent freshness route.
+    const value = record.value as TickerFinancials;
+    return { ...record, value: { ...value, quote: undefined, quoteContributions: undefined } as T };
   });
   if (records.length === 0) return [];
 

--- a/src/sources/provider-router/cached-financials.test.ts
+++ b/src/sources/provider-router/cached-financials.test.ts
@@ -69,6 +69,7 @@ describe("AssetDataRouter cached financials", () => {
         },
       }),
       {
+        schemaVersion: 4,
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
         fetchedAt: now,
       },
@@ -97,6 +98,7 @@ describe("AssetDataRouter cached financials", () => {
         }),
       }),
       {
+        schemaVersion: 4,
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
         fetchedAt: now,
       },
@@ -160,6 +162,7 @@ describe("AssetDataRouter cached financials", () => {
         }),
       }),
       {
+        schemaVersion: 4,
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
         fetchedAt: now,
       },
@@ -190,6 +193,7 @@ describe("AssetDataRouter cached financials", () => {
         }),
       }),
       {
+        schemaVersion: 4,
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
         fetchedAt: now,
       },
@@ -254,6 +258,7 @@ describe("AssetDataRouter cached financials", () => {
         },
       }),
       {
+        schemaVersion: 4,
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
         fetchedAt: now,
       },
@@ -313,6 +318,7 @@ describe("AssetDataRouter cached financials", () => {
         },
       }),
       {
+        schemaVersion: 4,
         cachePolicy: { staleMs: 60_000, expireMs: 60_000 },
         fetchedAt: now,
       },
@@ -365,6 +371,7 @@ describe("AssetDataRouter cached financials", () => {
         }),
       }),
       {
+        schemaVersion: 4,
         cachePolicy: { staleMs: 60_000, expireMs: 7 * 24 * 60 * 60_000 },
         fetchedAt: old,
       },
@@ -392,6 +399,7 @@ describe("AssetDataRouter cached financials", () => {
         }),
       }),
       {
+        schemaVersion: 4,
         cachePolicy: { staleMs: 60_000, expireMs: 7 * 24 * 60 * 60_000 },
         fetchedAt: now,
       },
@@ -459,6 +467,7 @@ describe("AssetDataRouter cached financials", () => {
         },
       }),
       {
+        schemaVersion: 4,
         cachePolicy: { staleMs: 60_000, expireMs: 7 * 24 * 60 * 60_000 },
         fetchedAt: now,
       },
@@ -475,6 +484,7 @@ describe("AssetDataRouter cached financials", () => {
         annualStatements: [{ date: "2025-12-31", totalRevenue: 100 }],
       }),
       {
+        schemaVersion: 4,
         cachePolicy: { staleMs: 60_000, expireMs: 7 * 24 * 60 * 60_000 },
         fetchedAt: now + 1_000,
       },
@@ -504,6 +514,7 @@ describe("AssetDataRouter cached financials", () => {
         }),
       }),
       {
+        schemaVersion: 4,
         cachePolicy: { staleMs: 60_000, expireMs: 7 * 24 * 60 * 60_000 },
         fetchedAt: now - 1_000,
       },
@@ -579,6 +590,7 @@ describe("AssetDataRouter cached financials", () => {
         },
       }),
       {
+        schemaVersion: 4,
         cachePolicy: { staleMs: 60_000, expireMs: 7 * 24 * 60 * 60_000 },
         fetchedAt: old,
       },
@@ -604,6 +616,7 @@ describe("AssetDataRouter cached financials", () => {
         listingExchangeName: "JPX",
       }),
       {
+        schemaVersion: 4,
         cachePolicy: { staleMs: 60_000, expireMs: 7 * 24 * 60 * 60_000 },
         fetchedAt: now,
       },

--- a/src/sources/provider-router/financial-routes.ts
+++ b/src/sources/provider-router/financial-routes.ts
@@ -84,6 +84,24 @@ export class ProviderRouterFinancialRoutes {
     exchange?: string,
     context?: MarketDataRequestContext,
   ): Promise<TickerFinancials> {
+    const financials = await this.loadTickerFinancials(ticker, exchange, context);
+    if (financials.quote) return financials;
+    // Statement depth does not establish quote freshness. Use the same quote
+    // fallback route as QQ, including its cache and broker/listing context.
+    try {
+      const quote = await this.getQuote(ticker, exchange, context);
+      return resolveTickerFinancialsQuoteState(financials, quote) ?? financials;
+    } catch {
+      // Delisted or temporarily unquoted issuers can still have valid accounts.
+      return financials;
+    }
+  }
+
+  private async loadTickerFinancials(
+    ticker: string,
+    exchange?: string,
+    context?: MarketDataRequestContext,
+  ): Promise<TickerFinancials> {
     const isOptionTicker =
       parseOptionSymbol(ticker) != null ||
       parseOptionSymbol(context?.instrument?.localSymbol ?? "") != null ||

--- a/src/sources/provider-router/quote-completion.test.ts
+++ b/src/sources/provider-router/quote-completion.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, expect, test } from "bun:test";
+import { AppPersistence } from "../../data/app-persistence";
+import type { DataProvider } from "../../types/data-provider";
+import { AssetDataRouter } from "./index";
+import { cleanupProviderRouterTestFiles, createTempDbPath, fallbackProvider, makeFinancials, makeQuote } from "./test-support";
+
+afterEach(cleanupProviderRouterTestFiles);
+
+test.each(["single", "batch"] as const)("%s financials recover a stale embedded Tokyo quote through the quote route", async (route) => {
+  const persistence = new AppPersistence(createTempDbPath(`tokyo-quote-${route}`));
+  const originalNow = Date.now;
+  Date.now = () => Date.parse("2026-09-10T21:50:00Z");
+  const calls = { financials: 0, fallbackFinancials: 0, fallbackQuote: 0 };
+  const staleQuote = makeQuote({ symbol: "7203", price: 2980.5, currency: "JPY", change: 9.5,
+    changePercent: 0.31975765735442613, previousClose: 2971, stale: true,
+    lastUpdated: Date.parse("2026-09-10T06:24:00Z"), exchangeName: "TYO",
+    providerId: "gloomberb-cloud", dataSource: "delayed", marketState: "PRE" });
+  const snapshot = makeFinancials({ quote: staleQuote, profile: { description: "Toyota Motor Corporation" },
+    annualStatements: Array.from({ length: 5 }, (_, i) => ({ date: `${2022 + i}-03-31`, currency: "JPY", totalRevenue: 100 + i, inventory: 10 })),
+  });
+  const cloud: DataProvider = {
+    ...fallbackProvider, id: "gloomberb-cloud", priority: 100,
+    async getTickerFinancials() { calls.financials++; return snapshot; },
+    async getTickerFinancialsBatch(targets) { calls.financials++; return targets.map((target) => ({ target, financials: snapshot })); },
+    async getQuote() { return staleQuote; },
+  };
+  let quoteFails = false;
+  const yahoo: DataProvider = {
+    ...fallbackProvider, id: "yahoo", priority: 1000,
+    async getTickerFinancials() { calls.fallbackFinancials++; throw new Error("No supplemental statements"); },
+    async getQuote(symbol, exchange) {
+      calls.fallbackQuote++;
+      expect([symbol, exchange]).toEqual(["7203", "TYO"]);
+      if (quoteFails) throw new Error("Quote unavailable");
+      return makeQuote({ symbol, price: 2994, currency: "JPY", change: 23,
+        changePercent: 0.7741501178054527, lastUpdated: Date.parse("2026-09-10T06:30:00Z"),
+        exchangeName: "TYO", providerId: "yahoo", marketState: "PRE" });
+    },
+  };
+  const router = new AssetDataRouter(yahoo, [cloud], persistence.resources);
+  const load = async () => route === "single"
+    ? router.getTickerFinancials("7203", "TYO")
+    : (await router.getTickerFinancialsBatch([{ symbol: "7203", exchange: "TYO" }]))[0]!.financials!;
+  try {
+    const result = await load();
+    expect(result.quote).toMatchObject({ price: 2994, currency: "JPY", change: 23, providerId: "yahoo" });
+    expect(result.annualStatements).toEqual(snapshot.annualStatements);
+    expect(calls).toEqual({ financials: 1, fallbackFinancials: 0, fallbackQuote: 1 });
+    expect((await load()).quote?.price).toBe(2994);
+    expect(calls.fallbackQuote).toBe(1);
+
+    // Historical research remains usable when every current quote source fails.
+    quoteFails = true;
+    const withoutCache = new AssetDataRouter(yahoo, [cloud]);
+    const historical = await withoutCache.getTickerFinancials("7203", "TYO");
+    expect(historical.quote).toBeUndefined();
+    expect(historical.annualStatements).toEqual(snapshot.annualStatements);
+  } finally {
+    Date.now = originalNow;
+    persistence.close();
+  }
+});


### PR DESCRIPTION
A research bundle with detailed statements could bypass quote fallback, leaving DES on an older embedded Tokyo quote while QQ used Yahoo's official close. Financial research now completes missing or rejected quotes through the same quote route, including listing/broker context and its cache. This also covers cached and batch responses; usable statements remain available if every quote source fails.

Previously cached cloud financial bundles may have lost their embedded quote's stale flag. The financial-only cache migration refreshes those quotes while retaining statement availability evidence and other independently cached prices. Overview now explains when a current quote is unavailable instead of leaving a blank price block.

Validation: 116 focused provider-router/research tests, including single/batch stale-Tokyo fallback, warm-cache reuse, all-quotes-failed preservation, and legacy cache migration. All six renderer TypeScript checks pass. Actual isolated native DES shows Toyota ¥2,994 (+0.77%), matching QQ; TM's old active POST quote remains unavailable with its financial research visible at 140/80 columns. Backend companion preserves closing-auction observations and serializes quote freshness: https://github.com/vincelwt/gloomberb-platform/pull/232.

Browser validation: fresh 1280×900 Toyota overview shows ¥2,994 (+0.77%) and retains it after reload; fresh 900×700 TM financials → Overview shows the wrapped unavailable-quote message, including after reload. Screenshots visually inspected and app logs empty. Browser uses anonymous local source API with live Yahoo quote/history, production company data captures, and an isolated memory cache.
