### PR TITLE
Preserve exact crypto symbols and research link venues

### DIFF
--- a/src/components/command-bar/list/model.ts
+++ b/src/components/command-bar/list/model.ts
@@ -23,6 +23,8 @@ export interface ResultItem {
   /** Short tag drawn left of the label: a shortcut, an asset class, a document type. */
   badge?: string;
   right?: string;
+  /** Provider type retained for symbol/alias identity checks. */
+  instrumentType?: string;
   shortcutQuery?: string;
   searchText?: string;
   /** Tints the trailing marker and the section heading with the AI accent. */

--- a/src/components/command-bar/routes/ticker-search/actions.ts
+++ b/src/components/command-bar/routes/ticker-search/actions.ts
@@ -60,6 +60,7 @@ export function useCommandBarTickerSearchActions({
       return {
         id: candidate.id,
         label: candidate.label,
+        instrumentType: candidate.instrumentType,
         detail,
         badge,
         right,
@@ -79,6 +80,7 @@ export function useCommandBarTickerSearchActions({
     return {
       id: candidate.id,
       label: candidate.label,
+      instrumentType: candidate.instrumentType,
       detail,
       badge,
       right,

--- a/src/components/command-bar/routes/ticker-search/results.test.ts
+++ b/src/components/command-bar/routes/ticker-search/results.test.ts
@@ -55,6 +55,16 @@ test("exact-match promotion never treats a futures or FX spelling as an equity",
   }
 });
 
+test("crypto punctuation aliases never outrank the verified exact symbol in command results", () => {
+  const rows = mergeTickerSearchResultItems("SHIB-USD", [
+    { ...resultItem("alias", "SHIB/USD", "COINBASE PRO", "search"), category: "Other Listings", instrumentType: "Digital Currency" },
+    { ...resultItem("exact", "SHIB-USD", "CCC", "search"), category: "Other Listings", instrumentType: "CRYPTOCURRENCY" },
+  ], []);
+  expect(rows[0]?.category).not.toBe("Exact Match");
+  expect(rows[1]?.category).toBe("Exact Match");
+  expect(mergePlainRootTickerResults("SHIB-USD", rows, [resultItem("pane", "Research", "", "action")])[0]?.id).toBe("exact");
+});
+
 test("folds a plain query's symbol hits into one capped Instruments section behind the local rows", () => {
   const pane: ResultItem = {
     id: "pane:news",

--- a/src/renderers/browser/research-entry.test.ts
+++ b/src/renderers/browser/research-entry.test.ts
@@ -18,3 +18,15 @@ test("venue-qualified browser entries preserve listing identity and explicit sym
     .toEqual({ symbol: "VOD:XLON", tab: "overview" });
   expect(researchEntryFromSearch("?ticker=VOD&exchange=LSE%3Bbad")).toBeNull();
 });
+
+test("crypto pair links survive the URL writer's slash and spaced venue round trip", () => {
+  for (const ticker of ["SHIB/USD", "SHIB/USD:COINBASE PRO"]) {
+    const params = new URLSearchParams({ ticker, exchange: "COINBASE PRO", tab: "chart" });
+    expect(researchEntryFromSearch(params.toString())).toEqual({ symbol: "SHIB/USD:COINBASE PRO", tab: "chart" });
+  }
+  expect(researchEntryFromSearch("?ticker=SHIB-USD&exchange=CCC"))
+    .toEqual({ symbol: "SHIB-USD:CCC", tab: "overview" });
+  for (const ticker of ["SHIB/USD/OTHER", "../USD", "SHIB/USD:COINBASE;BAD", "SHIB/USD:COINBASE\nPRO"]) {
+    expect(researchEntryFromSearch(new URLSearchParams({ ticker }).toString())).toBeNull();
+  }
+});

--- a/src/renderers/browser/research-entry.ts
+++ b/src/renderers/browser/research-entry.ts
@@ -4,12 +4,16 @@ import { parsePublicTickerKey, publicTickerKey } from "../../utils/exchanges";
 export function researchEntryFromSearch(search: string): { symbol: string; tab: string } | null {
   const params = new URLSearchParams(search);
   const symbol = params.get("ticker")?.trim().toUpperCase();
-  if (!symbol || !/^[A-Z0-9.^=:_-]{1,24}$/.test(symbol)) return null;
+  if (!symbol) return null;
+  const requested = parsePublicTickerKey(symbol);
+  const validSymbol = /^[A-Z0-9.^=_-]{1,24}$/.test(requested.symbol)
+    || /^[A-Z0-9][A-Z0-9._-]{0,14}\/[A-Z0-9][A-Z0-9._-]{0,14}$/.test(requested.symbol);
+  if (!validSymbol) return null;
   const exchange = params.get("exchange")?.trim().toUpperCase();
-  if (exchange && !/^[A-Z0-9._-]{1,32}$/.test(exchange)) return null;
+  if ([exchange, requested.exchange].some((venue) => venue && !/^[A-Z0-9][A-Z0-9 ._-]{0,31}$/.test(venue))) return null;
   // Carry a separate venue through the same listing-qualified resolver used by
   // search and deep links. An explicit symbol suffix/key remains authoritative.
-  const target = exchange && !parsePublicTickerKey(symbol).exchange && !tickerHasYahooSuffix(symbol)
+  const target = exchange && !requested.exchange && !tickerHasYahooSuffix(symbol)
     ? publicTickerKey(symbol, exchange)
     : symbol;
   const tab = params.get("tab") ?? "overview";

--- a/src/sources/yahoo-finance/snapshots.ts
+++ b/src/sources/yahoo-finance/snapshots.ts
@@ -145,6 +145,7 @@ export async function loadYahooTickerFinancials(
 
   const quote: Quote = {
     symbol,
+    instrumentType: meta.instrumentType,
     providerId: loaders.providerId,
     price: currentPrice,
     currency: normalizedCurrency,
@@ -230,6 +231,7 @@ export async function loadYahooQuote(
 
   return {
     symbol,
+    instrumentType: meta.instrumentType,
     providerId: loaders.providerId,
     price,
     currency: normalizedCurrency,

--- a/src/sources/yahoo-finance/types.ts
+++ b/src/sources/yahoo-finance/types.ts
@@ -2,6 +2,7 @@ type TradingPeriod = { start?: number; end?: number; gmtoffset?: number; timezon
 
 export type ChartResult = {
   meta?: {
+    instrumentType?: string;
     currency?: string; longName?: string; shortName?: string;
     regularMarketPrice?: number; chartPreviousClose?: number;
     fiftyTwoWeekHigh?: number; fiftyTwoWeekLow?: number;

--- a/src/tickers/search/index.test.ts
+++ b/src/tickers/search/index.test.ts
@@ -75,7 +75,7 @@ describe("ticker-search utilities", () => {
       .toMatchObject({ kind: "provider", result: { exchange: "CCC" } });
     expect(await resolveTickerSearch({ query: "SHIB-USD:COINBASE PRO", activeTicker: null, tickers, dataProvider })).toBeNull();
     // A hyphen alone cannot establish an instrument's type or its identity.
-    for (const invalid of [{ instrumentType: "EQUITY" }, { symbol: "OTHER-USD" }, { price: 0 }, { instrumentType: undefined }]) {
+    for (const invalid of [{ instrumentType: "EQUITY" }, { symbol: "OTHER-USD" }, { price: 0 }, { price: -1 }, { instrumentType: undefined }]) {
       expect(await resolveTickerSearch({ query: "SHIB-USD", activeTicker: null, tickers: new Map(),
         dataProvider: createTestDataProvider({ search: async () => [alias], getQuote: async () => ({ ...quote, ...invalid }) }) })).toBeNull();
     }

--- a/src/tickers/search/index.test.ts
+++ b/src/tickers/search/index.test.ts
@@ -3,6 +3,7 @@ import type { DataProvider } from "../../types/data-provider";
 import type { InstrumentSearchResult } from "../../types/instrument";
 import type { TickerRecord } from "../../types/ticker";
 import { createTestDataProvider } from "../../test-support/data-provider";
+import { loadYahooQuote } from "../../sources/yahoo-finance/snapshots";
 import {
   buildTickerSearchCandidates,
   createLocalTickerSearchCandidates,
@@ -58,6 +59,52 @@ function makeDataProvider(results: InstrumentSearchResult[]): DataProvider {
 }
 
 describe("ticker-search utilities", () => {
+  test("verifies omitted crypto symbols before selecting a punctuation alias on another venue", async () => {
+    const alias = makeSearchResult("SHIB/USD", "SHIBA INU US Dollar", { type: "Digital Currency", exchange: "COINBASE PRO" });
+    const quote = { symbol: "SHIB-USD", instrumentType: "CRYPTOCURRENCY", price: 0.00000509, currency: "USD", lastUpdated: 1789077420000,
+      change: 0, changePercent: 0, listingExchangeName: "CCC" };
+    const dataProvider = createTestDataProvider({ search: async () => [alias], getQuote: async () => quote });
+    const savedAlias = makeTicker("SHIB/USD", "SHIBA INU US Dollar", { exchange: "COINBASE PRO", assetCategory: "Digital Currency" });
+    const tickers = new Map([["SHIB/USD", savedAlias]]);
+    expect(await resolveTickerSearch({ query: "SHIB-USD", activeTicker: null, tickers, dataProvider }))
+      .toMatchObject({ kind: "provider", symbol: "SHIB-USD", result: { exchange: "CCC", currency: "USD", type: "CRYPTOCURRENCY" } });
+    const candidates = await searchTickerCandidates({ query: "SHIB-USD", tickers, dataProvider });
+    expect(candidates[0]?.symbol).toBe("SHIB-USD");
+    expect(findExactTickerSearchMatch(candidates, "SHIB-USD")?.symbol).toBe("SHIB-USD");
+    expect(await resolveTickerSearch({ query: "SHIB-USD:CCC", activeTicker: null, tickers, dataProvider }))
+      .toMatchObject({ kind: "provider", result: { exchange: "CCC" } });
+    expect(await resolveTickerSearch({ query: "SHIB-USD:COINBASE PRO", activeTicker: null, tickers, dataProvider })).toBeNull();
+    // A hyphen alone cannot establish an instrument's type or its identity.
+    for (const invalid of [{ instrumentType: "EQUITY" }, { symbol: "OTHER-USD" }, { price: 0 }, { instrumentType: undefined }]) {
+      expect(await resolveTickerSearch({ query: "SHIB-USD", activeTicker: null, tickers: new Map(),
+        dataProvider: createTestDataProvider({ search: async () => [alias], getQuote: async () => ({ ...quote, ...invalid }) }) })).toBeNull();
+    }
+  });
+
+  test("prefers literal provider symbols without losing equity share-class aliases", async () => {
+    const results = [makeSearchResult("SHIB/USD", "Shiba Inu", { type: "Digital Currency", exchange: "COINBASE PRO" }),
+      makeSearchResult("SHIB-USD", "Shiba Inu", { type: "CRYPTOCURRENCY", exchange: "CCC", currency: "USD" })];
+    expect(await resolveTickerSearch({ query: "SHIB-USD", activeTicker: null, tickers: new Map(), dataProvider: makeDataProvider(results) }))
+      .toMatchObject({ symbol: "SHIB-USD" });
+    expect(await resolveTickerSearch({ query: "BRK-B", activeTicker: null, tickers: new Map(),
+      dataProvider: makeDataProvider([makeSearchResult("BRK.B", "Berkshire", { exchange: "NYSE" })]) }))
+      .toMatchObject({ symbol: "BRK.B" });
+  });
+
+  test("native Yahoo chart instrument type verifies an omitted crypto catalogue entry", async () => {
+    const dataProvider = createTestDataProvider({
+      search: async () => [makeSearchResult("SHIB/USD", "Shiba Inu", { exchange: "COINBASE PRO", type: "Digital Currency" })],
+      getQuote: async (symbol) => loadYahooQuote(symbol, {
+        providerId: "yahoo-finance",
+        fetchChart: async () => ({ meta: { instrumentType: "CRYPTOCURRENCY", currency: "USD", exchangeName: "CCC",
+          regularMarketPrice: 0.00000509, regularMarketTime: 1789077420 }, history: [{ date: new Date("2026-09-10"), close: 0.00000509 }] }),
+        fetchQuoteSupplement: async () => ({}), fetchExtendedHoursData: async () => ({}),
+      }),
+    });
+    expect(await resolveTickerSearch({ query: "SHIB-USD", activeTicker: null, tickers: new Map(), dataProvider }))
+      .toMatchObject({ symbol: "SHIB-USD", result: { type: "CRYPTOCURRENCY", exchange: "CCC" } });
+  });
+
   test("preserves futures, FX and index identity across saved and provider search matches", async () => {
     for (const symbol of ["ES=F", "6J=F", "JPY=X", "EURUSD=X", "EUR/USD", "^GSPC"]) {
       const lookalike = symbol.replace(/[^A-Z0-9]/g, "");

--- a/src/tickers/search/index.ts
+++ b/src/tickers/search/index.ts
@@ -303,10 +303,10 @@ async function searchProviderResults(
         const quote = await dataProvider.getQuote(symbol, exchange);
         const type = isCryptoInstrumentType(quote.instrumentType) ? quote.instrumentType : marketType;
         if (Number.isFinite(quote.price) && quote.price !== 0
-          && (!isCryptoInstrumentType(type) || quote.price > 0)
           && Number.isFinite(quote.lastUpdated) && quote.lastUpdated > 0
           && quote.currency?.trim()
           && type
+          && (!isCryptoInstrumentType(type) || quote.price > 0)
           && (!exchange || canonicalExchange(quote.listingExchangeName || quote.exchangeName) === exchange)
           && (possibleCryptoPair ? normalizeTickerSymbol(quote.symbol) === symbol
             : findExactTickerSearchMatch([{ label: quote.symbol }], symbol))) {

--- a/src/tickers/search/index.ts
+++ b/src/tickers/search/index.ts
@@ -10,6 +10,7 @@ import {
   findExactTickerSearchMatch,
   getForexQuoteCurrency,
   isExplicitMarketSymbol,
+  isCryptoInstrumentType,
   normalizeSearchText,
   normalizeTickerSymbol,
   rankTickerSearchItems,
@@ -77,6 +78,7 @@ export function createLocalTickerSearchCandidates(
       kind: "ticker",
       saved: true,
       instrumentClass: classifyInstrumentKind(hint?.brokerContract?.secType || hint?.type || ticker.metadata.assetCategory),
+      instrumentType: hint?.brokerContract?.secType || hint?.type || ticker.metadata.assetCategory,
       searchAliases: buildSymbolAliases(symbol),
       ticker,
       result: hint,
@@ -108,6 +110,7 @@ function createProviderTickerSearchCandidates(
       kind: "search",
       saved,
       instrumentClass: classifyInstrumentKind(result.brokerContract?.secType || result.type),
+      instrumentType: result.brokerContract?.secType || result.type,
       searchAliases: buildSearchResultAliases(result),
       result,
     }];
@@ -283,21 +286,29 @@ async function searchProviderResults(
     }
   }));
 
-  // Some search catalogues omit futures and return similarly spelled equities.
-  // A quote for the exact market symbol can supply a verifiable research target.
-  if (isExplicitMarketSymbol(query)
-    && !findExactTickerSearchMatch([...byKey.values()].map((result) => ({ label: getSearchResultSymbol(result) })), query)) {
-    const { symbol, exchange } = parsePublicTickerKey(normalizeTickerSymbol(query));
-    const type = /=F$/.test(symbol) ? "FUTURE"
+  // Catalogues can omit exact market symbols or return a crypto pair from a
+  // different venue. Verify the requested quote before accepting an alias.
+  const requested = parsePublicTickerKey(normalizeTickerSymbol(query));
+  const possibleCryptoPair = /^[A-Z0-9]{1,15}-[A-Z]{3,5}$/.test(requested.symbol);
+  if ((isExplicitMarketSymbol(query) || possibleCryptoPair)
+    && !findExactTickerSearchMatch([...byKey.values()].map((result) => ({
+      label: getSearchResultSymbol(result), instrumentType: result.type, right: result.exchange,
+    })), query)) {
+    const { symbol, exchange } = requested;
+    const marketType = /=F$/.test(symbol) ? "FUTURE"
       : /^(?:[A-Z]{3}(?:\/[A-Z]{3}|(?:[A-Z]{3})?=X))$/.test(symbol) ? "CURRENCY"
       : /^\^[A-Z0-9.-]+$/.test(symbol) ? "INDEX" : null;
-    if (type) {
+    if (marketType || possibleCryptoPair) {
       try {
         const quote = await dataProvider.getQuote(symbol, exchange);
+        const type = isCryptoInstrumentType(quote.instrumentType) ? quote.instrumentType : marketType;
         if (Number.isFinite(quote.price) && quote.price !== 0
           && Number.isFinite(quote.lastUpdated) && quote.lastUpdated > 0
           && quote.currency?.trim()
-          && findExactTickerSearchMatch([{ label: quote.symbol }], symbol)) {
+          && type
+          && (!exchange || canonicalExchange(quote.listingExchangeName || quote.exchangeName) === exchange)
+          && (possibleCryptoPair ? normalizeTickerSymbol(quote.symbol) === symbol
+            : findExactTickerSearchMatch([{ label: quote.symbol }], symbol))) {
           add([{
             providerId: quote.providerId || dataProvider.id,
             symbol,

--- a/src/tickers/search/index.ts
+++ b/src/tickers/search/index.ts
@@ -303,6 +303,7 @@ async function searchProviderResults(
         const quote = await dataProvider.getQuote(symbol, exchange);
         const type = isCryptoInstrumentType(quote.instrumentType) ? quote.instrumentType : marketType;
         if (Number.isFinite(quote.price) && quote.price !== 0
+          && (!isCryptoInstrumentType(type) || quote.price > 0)
           && Number.isFinite(quote.lastUpdated) && quote.lastUpdated > 0
           && quote.currency?.trim()
           && type

--- a/src/tickers/search/ranking.ts
+++ b/src/tickers/search/ranking.ts
@@ -81,20 +81,25 @@ export function findExactTickerSearchMatch<T extends Pick<TickerSearchRankableIt
   items: T[],
   query: string,
 ): T | null {
+  const literal = items.find((item) => normalizeTickerSymbol(item.symbol || item.label) === normalizeTickerSymbol(query));
+  if (literal) return literal;
   if (isQualifiedTickerQuery(query)) {
-    return items.find((item) => normalizeTickerSymbol(item.symbol || item.label) === normalizeTickerSymbol(query))
-      ?? items.find((item) => matchesQualifiedTicker(item, query)) ?? null;
+    return items.find((item) => matchesQualifiedTicker(item, query)) ?? null;
   }
   const aliasForms = buildSymbolAliases(query);
   const normalizedAliases = new Set(aliasForms.map((value) => normalizeSearchText(value)));
   const compactAliases = new Set(aliasForms.map((value) => compactSearchText(value)));
 
-  return items.find((item) => !isExplicitMarketSymbol(item.symbol || item.label) &&
+  return items.find((item) => !isExplicitMarketSymbol(item.symbol || item.label) && !isCryptoInstrumentType(item.instrumentType) &&
     getItemSearchAliases(item).some((alias) =>
       normalizedAliases.has(normalizeSearchText(alias))
       || compactAliases.has(compactSearchText(alias))
     )
   ) ?? null;
+}
+
+export function isCryptoInstrumentType(type?: string): boolean {
+  return ["CRYPTO", "CRYPTOCURRENCY", "DIGITALCURRENCY"].includes((type ?? "").toUpperCase().replace(/[\s_-]/g, ""));
 }
 
 function isQualifiedTickerQuery(query: string): boolean {
@@ -207,14 +212,16 @@ export function rankTickerSearchItems<T extends Pick<TickerSearchRankableItem, "
   const matchedLocalSymbols = new Set(
     ranked
       .filter(({ item, textScore }) => textScore > 0 && item.kind === "ticker")
-      .map(({ item, normalizedSymbol }) => isQualifiedTickerQuery(query) ? getTickerSearchListingKey(item) : normalizedSymbol),
+      .map(({ item, normalizedSymbol }) => isQualifiedTickerQuery(query) || isCryptoInstrumentType(item.instrumentType)
+        ? getTickerSearchListingKey(item) : normalizedSymbol),
   );
 
   const filtered = ranked.filter(({ item, normalizedSymbol, textScore }) => {
     if (textScore <= 0) return false;
     if (isExplicitMarketSymbol(query) && !isExplicitMarketSymbol(item.symbol || item.label)) return false;
     if (item.kind !== "search") return true;
-    return !matchedLocalSymbols.has(isQualifiedTickerQuery(query) ? getTickerSearchListingKey(item) : normalizedSymbol);
+    return !matchedLocalSymbols.has(isQualifiedTickerQuery(query) || isCryptoInstrumentType(item.instrumentType)
+      ? getTickerSearchListingKey(item) : normalizedSymbol);
   });
 
   type RankedEntry = (typeof ranked)[number];
@@ -440,7 +447,9 @@ function scoreSymbolMatchRank(
   intent: SearchQueryIntent,
   item: Pick<TickerSearchRankableItem, "label"> & Partial<TickerSearchRankableItem>,
 ): number {
+  if (normalizeTickerSymbol(item.symbol || item.label) === normalizeTickerSymbol(intent.rawQuery)) return 4;
   if (isQualifiedTickerQuery(intent.rawQuery)) return matchesQualifiedTicker(item, intent.rawQuery) ? 4 : 0;
+  if (isCryptoInstrumentType(item.instrumentType)) return 0;
   if (isExplicitMarketSymbol(item.symbol || item.label)) return 0;
   if (!intent.normalizedQuery && !intent.compactQuery) return 0;
   const displaySymbol = normalizeSearchText(item.symbol || item.label);

--- a/src/tickers/search/types.ts
+++ b/src/tickers/search/types.ts
@@ -14,6 +14,7 @@ export interface TickerSearchRankableItem {
   symbol?: string;
   saved?: boolean;
   instrumentClass?: TickerSearchInstrumentClass;
+  instrumentType?: string;
   exchangeLabel?: string;
   primaryExchangeLabel?: string;
   providerRank?: number;


### PR DESCRIPTION
Opening `?ticker=SHIB-USD` selected the catalogue's `SHIB/USD` Coinbase Pro listing, leaving the original research panes unbound. The generated URL then failed on a fresh load because the parser rejected its slash and spaced exchange name.

Prefer the literal requested symbol and carry provider instrument type through search and command results. If a hyphenated pair is missing from the catalogue, an exact quote must verify a positive price, crypto type, symbol, currency, timestamp and any requested venue before it is added. Native Yahoo quotes now retain their reported instrument type. Existing equity share-class aliases remain supported. Browser entries accept a single pair slash and safe exchange spaces, including qualified keys emitted by the app.

Validation: 45 focused tests / 222 assertions and all six runtime typechecks passed. Actual isolated browser visits verified cold SHIB-USD, its emitted URL reload, and a fresh Coinbase slash-form link; actual native tmux at 140×44 verified the exact CCC result and opening it. Provider chart/quote metadata corroborates SHIB-USD/CCC/CRYPTOCURRENCY. Coinbase-specific quote coverage remains unavailable in the captured flow. Tiny-price display corrections are handled separately in #786.

Evidence ledger: `/home/vince/code/gloom/persona-audit/crypto-research-links.json`, with screenshots, native captures and provider payloads in `crypto-link-evidence`. No release or version change.
