### PR TITLE
Prevent partial numeric labels on narrow chart axes

### DIFF
--- a/src/components/chart/composite/format.test.ts
+++ b/src/components/chart/composite/format.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./format";
 import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
 import {
+  renderCompositeAxisText,
   renderCompositeTimeAxis,
   renderCompositeViewportTimeAxis,
 } from "./text-renderer";
@@ -198,4 +199,16 @@ describe("composite chart unit formatting", () => {
     expect(formatCompositeCursorValue(-12_345_600_000, { ...domain, unit: "EUR", unitGroup: "currency-total" })).toBe("€-12.35B");
     expect(formatCompositeCursorValue(123_456_000, { ...domain, unit: "CAD", unitGroup: "currency-total:CAD" })).toBe("123.46M CAD");
   });
+});
+
+// Regression: truncating before PriceAxisLabels bypassed its full-value guard.
+test("constrained axis ticks never become plausible numeric prefixes", () => {
+  const domain = { side: "right" as const, seriesIds: ["tiny"], min: 3.88e-6, max: 6.12e-6, scale: "linear" as const, unit: "USD", unitGroup: "price" };
+  for (const side of ["left", "right"] as const) {
+    const short = renderCompositeAxisText(domain, 5, 8, side).map((row) => row.trim()).filter(Boolean);
+    expect(short).toEqual(["…", "…", "…"]);
+    expect(renderCompositeAxisText(domain, 5, 12, side)[0]?.trim()).toBe("$0.00000612");
+    expect(renderCompositeAxisText(domain, 5, 5, side, () => "12345 CAD")[0]?.trim()).toBe("…");
+    expect(renderCompositeAxisText(domain, 5, 5, side, () => "−12.5%")[0]?.trim()).toBe("…");
+  }
 });

--- a/src/components/chart/composite/text-renderer.ts
+++ b/src/components/chart/composite/text-renderer.ts
@@ -1,3 +1,4 @@
+import { displayWidth, padTo } from "../../../utils/format";
 import { compositeAxisTicks, type CompositeAxisValueFormatter } from "./format";
 import type { CompositeViewportRange } from "./interactions";
 import { resolveCompositeObservationWidth } from "./rasterizer";
@@ -293,8 +294,10 @@ export function renderCompositeAxisText(
   if (!domain || width <= 0) return rows;
   for (const tick of compositeAxisTicks(domain, 3, format)) {
     const row = clamp(Math.round(tick.ratio * Math.max(height - 1, 0)), 0, Math.max(height - 1, 0));
-    const label = tick.label.length > width ? tick.label.slice(0, width) : tick.label;
-    rows[row] = side === "left" ? label.padStart(width) : label.padEnd(width);
+    // Never pass a clipped number to the axis renderer: its later overflow
+    // guard cannot distinguish that prefix from a complete formatted value.
+    const label = displayWidth(tick.label) > width ? "…" : tick.label;
+    rows[row] = padTo(label, width, side === "left" ? "right" : "left");
   }
   return rows;
 }


### PR DESCRIPTION
Narrow chart gutters could display a plausible numeric prefix: the shared axis text renderer shortened `$0.00000612` to `$0.000006` before the later overflow guard saw it. Preserve complete labels, including currency suffixes and signs; use an explicit ellipsis when the entire value cannot fit.

Validation: 152 composite-chart tests / 987 assertions, all six runtime typechecks, and actual 28-column native overview before/after with captured SHIB production data. Independent review approved the change. No quote values, chart geometry, release, or version changed.
