### PR TITLE
Correct short position valuation in ticker research

### DIFF
--- a/src/plugins/builtin/ticker-detail/overview/model.test.ts
+++ b/src/plugins/builtin/ticker-detail/overview/model.test.ts
@@ -44,6 +44,13 @@ describe("research position valuation", () => {
       .toMatchObject({ cost: "$5,000.00", value: "$4,000.00", pnlValue: 1000, ret: "+20.00%" });
   });
 
+  test("negative entry prices keep the P&L direction in the return denominator", () => {
+    expect(row({ shares: 1, avgCost: -10, multiplier: 100 }, { quotePrice: -20 }))
+      .toMatchObject({ cost: "-$1,000.00", value: "-$2,000.00", pnlValue: -1000, ret: "-100.00%" });
+    expect(row({ shares: 1, side: "short", avgCost: -10, multiplier: 100 }, { quotePrice: -20 }))
+      .toMatchObject({ pnlValue: 1000, ret: "+100.00%" });
+  });
+
   test("position cost and quote marks use their own currencies before signed P&L", () => {
     const toBase = (value: number, currency: string) => currency === "EUR" ? value * 1.2 : value;
     expect(row({ side: "short", currency: "EUR" }, { quotePrice: 130, toBase }))

--- a/src/plugins/builtin/ticker-detail/overview/model.test.ts
+++ b/src/plugins/builtin/ticker-detail/overview/model.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import type { Quote } from "../../../../types/financials";
+import type { TickerPosition, TickerRecord } from "../../../../types/ticker";
+import { buildPositionRows } from "./model";
+
+function row(position: Partial<TickerPosition>, options: {
+  quotePrice?: number | null;
+  quoteCurrency?: string;
+  toBase?: (value: number, currency: string) => number;
+} = {}) {
+  const ticker: TickerRecord = { metadata: {
+    ticker: "TEST", exchange: "NASDAQ", currency: "USD", name: "Controlled position",
+    portfolios: ["test"], watchlists: [], custom: {}, tags: [], assetCategory: "STK",
+    positions: [{ portfolio: "test", broker: "manual", shares: 10, avgCost: 100, ...position }],
+  } };
+  const quotePrice = options.quotePrice === undefined ? 120 : options.quotePrice;
+  return buildPositionRows({ ticker, quote: quotePrice == null ? undefined : { price: quotePrice } as Quote,
+    quoteCurrency: options.quoteCurrency ?? "USD", baseCurrency: "USD",
+    toBase: options.toBase ?? ((value) => value),
+  })[0]!;
+}
+
+describe("research position valuation", () => {
+  test("equivalent short conventions retain gross exposure but reverse price P&L", () => {
+    const positive = row({ side: "short" });
+    const negative = row({ shares: -10 });
+    expect(positive).toEqual(negative);
+    expect(positive).toMatchObject({ account: "test SHORT", qty: "-10 sh", cost: "$1,000.00", value: "$1,200.00", pnl: "-$200.00", ret: "-20.00%", pnlValue: -200 });
+    expect(row({ side: "short" }, { quotePrice: 80 })).toMatchObject({ pnlValue: 200, ret: "+20.00%" });
+    expect(row({})).toMatchObject({ qty: "10 sh", pnlValue: 200 });
+  });
+
+  test("broker signed and magnitude market values agree, and reported P&L wins", () => {
+    expect(row({ shares: -10, marketValue: -1200 })).toEqual(row({ shares: -10, marketValue: 1200 }));
+    expect(row({ shares: -10, marketValue: -1200 })).toMatchObject({ value: "$1,200.00", pnlValue: -200 });
+    expect(row({ shares: -10, marketValue: -1200, unrealizedPnl: -175 })).toMatchObject({ pnlValue: -175, ret: "-17.50%" });
+    expect(row({ shares: -10, markPrice: 80 })).toMatchObject({ mark: "$80", value: "$800.00", pnlValue: 200 });
+  });
+
+  test("derivative marks use contract multipliers while broker costs may already be scaled", () => {
+    expect(row({ shares: 2, side: "short", avgCost: 5, multiplier: 100 }, { quotePrice: 6 }))
+      .toMatchObject({ qty: "-2 ct", cost: "$1,000.00", value: "$1,200.00", pnlValue: -200, ret: "-20.00%" });
+    expect(row({ shares: -10, avgCost: 500, multiplier: 100, marketValue: -4000, unrealizedPnl: 1000 }))
+      .toMatchObject({ cost: "$5,000.00", value: "$4,000.00", pnlValue: 1000, ret: "+20.00%" });
+  });
+
+  test("position cost and quote marks use their own currencies before signed P&L", () => {
+    const toBase = (value: number, currency: string) => currency === "EUR" ? value * 1.2 : value;
+    expect(row({ side: "short", currency: "EUR" }, { quotePrice: 130, toBase }))
+      .toMatchObject({ cost: "$1,200.00", value: "$1,300.00", pnlValue: -100, ret: "-8.33%" });
+    expect(row({ side: "short", currency: "EUR", markPrice: 110 }, { quotePrice: 130, toBase }))
+      .toMatchObject({ cost: "$1,200.00", value: "$1,320.00", pnlValue: -120, ret: "-10.00%" });
+  });
+
+  test("missing FX or marks never produce a valid-looking P&L", () => {
+    const toBase = (value: number, currency: string) => currency === "USD" ? value : Number.NaN;
+    expect(row({ side: "short", currency: "EUR" }, { toBase }))
+      .toMatchObject({ cost: "—", value: "$1,200.00", pnl: "—", ret: "—", pnlValue: null });
+    expect(row({ side: "short", currency: "EUR", markPrice: 110 }, { toBase }))
+      .toMatchObject({ cost: "—", value: "—", pnl: "—", ret: "—", pnlValue: null });
+    expect(row({ side: "short" }, { quotePrice: null }))
+      .toMatchObject({ cost: "$1,000.00", mark: "—", value: "—", pnlValue: null });
+  });
+});

--- a/src/plugins/builtin/ticker-detail/overview/model.ts
+++ b/src/plugins/builtin/ticker-detail/overview/model.ts
@@ -139,7 +139,7 @@ export function buildPositionRows({
         ? signedPositionDirection(position) * marketValueBase - metrics.signedCost
         : null);
     const returnPercent = pnlValue != null && costBasisBase != null && costBasisBase !== 0
-      ? formatPercentRaw((pnlValue / costBasisBase) * 100)
+      ? formatPercentRaw((pnlValue / Math.abs(costBasisBase)) * 100)
       : "—";
     const unit = metrics.multiplierHint > 1 ? " ct" : " sh";
 

--- a/src/plugins/builtin/ticker-detail/overview/model.ts
+++ b/src/plugins/builtin/ticker-detail/overview/model.ts
@@ -15,6 +15,7 @@ import {
   formatMarketQuantity,
 } from "../../../../market-data/market/format";
 import type { PositionTableRow, StatField } from "./types";
+import { getPortfolioPositionMetrics, signedPositionDirection } from "../../portfolio-list/position-metrics";
 
 type CurrencyConverter = (value: number, fromCurrency: string) => number;
 
@@ -25,7 +26,7 @@ function compactPositionAccount(position: TickerPosition): string {
     ? rawAccount.split(":").filter(Boolean).at(-1) || rawAccount
     : rawAccount;
   const prefix = !isBrokerPortfolio && position.broker && position.broker !== "manual" ? `${position.broker} ` : "";
-  const suffix = position.side === "short" ? " SHORT" : "";
+  const suffix = signedPositionDirection(position) < 0 ? " SHORT" : "";
   return `${prefix}${account}${suffix}`;
 }
 
@@ -116,39 +117,46 @@ export function buildPositionRows({
 }): PositionTableRow[] {
   return ticker.metadata.positions.map((position) => {
     const positionCurrency = position.currency || quoteCurrency;
-    const costBasis = position.shares * position.avgCost * (position.multiplier || 1);
-    const costBasisBase = toBase(costBasis, positionCurrency);
-    const fallbackMarkPrice = position.markPrice ?? quote?.price;
-    const fallbackMarkCurrency = position.markPrice != null ? positionCurrency : quoteCurrency;
-    const marketValueBase = position.marketValue != null
-      ? toBase(position.marketValue, positionCurrency)
-      : fallbackMarkPrice != null
-        ? toBase(Math.abs(position.shares) * fallbackMarkPrice * (position.multiplier || 1), fallbackMarkCurrency)
-        : null;
-    const pnlValue = position.unrealizedPnl != null
-      ? toBase(position.unrealizedPnl, positionCurrency)
+    const metrics = getPortfolioPositionMetrics(
+      { ...ticker, metadata: { ...ticker.metadata, positions: [position] } },
+      undefined,
+      quoteCurrency,
+      { currency: baseCurrency, convert: toBase },
+    );
+    const finiteValue = (value: number | null): number | null => value != null && Number.isFinite(value) ? value : null;
+    const costBasisBase = finiteValue(metrics.totalCost);
+    const hasBrokerMark = Number.isFinite(position.markPrice);
+    const fallbackMarkPrice = hasBrokerMark ? position.markPrice : quote?.price;
+    const fallbackMarkCurrency = hasBrokerMark ? positionCurrency : quoteCurrency;
+    const marketValueBase = finiteValue(metrics.hasBrokerMktValue
+      ? metrics.brokerMktValue
+      : Number.isFinite(quote?.price)
+        ? toBase(metrics.grossPriceUnits * quote!.price, quoteCurrency)
+        : null);
+    const pnlValue = finiteValue(metrics.hasBrokerPnl
+      ? metrics.brokerPnl
       : marketValueBase != null
-        ? marketValueBase - costBasisBase
-        : null;
-    const returnPercent = pnlValue != null && costBasisBase !== 0
-      ? formatPercentRaw((pnlValue / Math.abs(costBasisBase)) * 100)
+        ? signedPositionDirection(position) * marketValueBase - metrics.signedCost
+        : null);
+    const returnPercent = pnlValue != null && costBasisBase != null && costBasisBase !== 0
+      ? formatPercentRaw((pnlValue / costBasisBase) * 100)
       : "—";
-    const unit = position.multiplier && position.multiplier > 1 ? " ct" : " sh";
+    const unit = metrics.multiplierHint > 1 ? " ct" : " sh";
 
     return {
       account: compactPositionAccount(position),
-      qty: `${formatMarketQuantity(position.shares, { assetCategory: ticker.metadata.assetCategory, multiplier: position.multiplier })}${unit}`,
+      qty: `${formatMarketQuantity(metrics.totalShares, { assetCategory: ticker.metadata.assetCategory, multiplier: position.multiplier })}${unit}`,
       avg: formatMarketCostWithCurrency(position.avgCost, positionCurrency, {
         assetCategory: ticker.metadata.assetCategory,
         multiplier: position.multiplier,
       }),
-      mark: fallbackMarkPrice != null
+      mark: fallbackMarkPrice != null && Number.isFinite(fallbackMarkPrice)
         ? formatMarketPriceWithCurrency(fallbackMarkPrice, fallbackMarkCurrency, {
             assetCategory: ticker.metadata.assetCategory,
             multiplier: position.multiplier,
           })
         : "—",
-      cost: formatCurrency(costBasisBase, baseCurrency),
+      cost: costBasisBase != null ? formatCurrency(costBasisBase, baseCurrency) : "—",
       value: marketValueBase != null ? formatCurrency(marketValueBase, baseCurrency) : "—",
       pnl: pnlValue != null ? `${pnlValue >= 0 ? "+" : ""}${formatCurrency(pnlValue, baseCurrency)}` : "—",
       ret: returnPercent,


### PR DESCRIPTION
Ticker Research showed a gain for a losing short: 10 shares short at a $100 cost and $120 mark displayed +$200, while a broker using -10 shares displayed +$2,200. Research now uses the portfolio position valuation rules, showing -$200 for both conventions, signed quantities and a SHORT label, while retaining gross cost and exposure values.

The same calculation respects broker-reported P&L, signed broker market values, contract multipliers and already-scaled broker costs. Missing FX or a missing mark leaves dependent valuation fields unavailable. Returns retain an absolute cost denominator, including negative entry prices.

Validation: 30 focused portfolio and research tests (114 assertions), all six TypeScript targets, and the real native app in tmux at 140×44 and 80×44. Controlled positions were stored only in a temporary test data directory; no real portfolio records were modified. Browser and production position rendering remain unverified. No release or version change.
