### PR TITLE
Preserve saved research settings on immediate browser reload

### DIFF
--- a/src/renderers/browser/main.tsx
+++ b/src/renderers/browser/main.tsx
@@ -22,6 +22,7 @@ import { BROWSER_DATA_DIR, installBrowserConfigStore } from "./config-host";
 import { browserRendererHost, browserUiHost } from "./ui-host";
 import { createBrowserDeepLinkBridge } from "./deeplink-bridge";
 import { initializeBrowserResearchActivity, recordResearchActivity } from "../../api-client/research-activity";
+import { flushPendingPersistence } from "../../state/persist-scheduler";
 
 // Declared here rather than sniffed: the desktop view and the hosted browser
 // app are both browser contexts but differ in what plugins may do.
@@ -36,6 +37,12 @@ root.render(<div className="gloom-loading">Starting Gloomberb...</div>);
 
 async function boot(): Promise<void> {
   installBrowserConfigStore();
+  // A document reload does not unmount React. Flush both config and session
+  // timers while localStorage is still available, including background tabs.
+  window.addEventListener("pagehide", () => { void flushPendingPersistence(); });
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") void flushPendingPersistence();
+  });
   installBrowserFetchTransports();
   initializeBrowserResearchActivity();
   installFocusScopeRelease();

--- a/src/state/persist-scheduler.test.ts
+++ b/src/state/persist-scheduler.test.ts
@@ -1,11 +1,31 @@
 import { describe, expect, test } from "bun:test";
-import { createPersistScheduler } from "./persist-scheduler";
+import { createPersistScheduler, flushPendingPersistence } from "./persist-scheduler";
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 describe("createPersistScheduler", () => {
+  test("page exit drains the latest config and session once, excluding cancelled writes", async () => {
+    const saved: string[] = [];
+    const config = createPersistScheduler<string>({ delayMs: 60_000, save: (value) => { saved.push(value); } });
+    const session = createPersistScheduler<string>({ delayMs: 60_000, save: (value) => { saved.push(value); } });
+    const cancelled = createPersistScheduler<string>({ delayMs: 60_000, save: (value) => { saved.push(value); } });
+    config.schedule("old chart");
+    config.schedule("percent chart");
+    session.schedule("selected pane");
+    cancelled.schedule("discarded");
+    cancelled.cancel();
+    await flushPendingPersistence();
+    await flushPendingPersistence();
+    expect(saved).toEqual(["percent chart", "selected pane"]);
+
+    // Returning from a background tab must allow subsequent changes to save.
+    config.schedule("index chart");
+    await flushPendingPersistence();
+    expect(saved).toEqual(["percent chart", "selected pane", "index chart"]);
+  });
+
   test("coalesces scheduled saves and writes the latest value", async () => {
     const saved: number[] = [];
     const scheduler = createPersistScheduler<number>({

--- a/src/state/persist-scheduler.ts
+++ b/src/state/persist-scheduler.ts
@@ -2,6 +2,13 @@ export const CONFIG_SAVE_DEBOUNCE_MS = 500;
 export const SESSION_SAVE_DEBOUNCE_MS = 1000;
 export const PLUGIN_STATE_SAVE_DEBOUNCE_MS = 500;
 
+const pendingFlushes = new Set<() => Promise<void>>();
+
+/** Drain delayed writes before the browser suspends or discards this page. */
+export async function flushPendingPersistence(): Promise<void> {
+  await Promise.allSettled([...pendingFlushes].map((flush) => flush()));
+}
+
 export interface PersistSchedulerOptions<T> {
   delayMs: number;
   save: (value: T) => Promise<void> | void;
@@ -48,6 +55,7 @@ export function createPersistScheduler<T>({
 
   const drain = async () => {
     clearTimer();
+    pendingFlushes.delete(drain);
     if (!hasPendingValue) return inFlight;
     const value = pendingValue as T;
     pendingValue = undefined;
@@ -59,6 +67,7 @@ export function createPersistScheduler<T>({
     schedule(value: T): void {
       pendingValue = value;
       hasPendingValue = true;
+      pendingFlushes.add(drain);
       clearTimer();
       timer = setTimeout(() => {
         void drain();
@@ -69,11 +78,13 @@ export function createPersistScheduler<T>({
     },
     cancel(): void {
       clearTimer();
+      pendingFlushes.delete(drain);
       pendingValue = undefined;
       hasPendingValue = false;
     },
     saveImmediately(value: T): Promise<void> {
       clearTimer();
+      pendingFlushes.delete(drain);
       pendingValue = undefined;
       hasPendingValue = false;
       return enqueueSave(value, false);


### PR DESCRIPTION
Selecting a chart transform, pressing Save, and immediately reloading could restore the previous transform because config and session writes were still waiting on their debounce timers. Browser page-hide and background events now flush pending persistence, preserving saved research settings when leaving the page.

Validation: 11 focused persistence/browser-storage tests (29 assertions), all six TypeScript projects, and web build passed. Actual production reproduced PERCENT reverting to RAW; the local rendered app with live cloud data retains PERCENT after immediate reload and 3M after immediate close/reopen. Independently reviewed. No release or version change.
