### PR TITLE
Preserve fund yield and description in research views

### DIFF
--- a/src/sources/provider-router/cached-financials.test.ts
+++ b/src/sources/provider-router/cached-financials.test.ts
@@ -32,6 +32,36 @@ test("confirmed fund classification prevents cached company accounts from return
   expect(mergeFinancials(contaminated, null)?.fundamentals?.trailingPE).toBe(0.238);
 });
 
+test("fund research keeps distribution yield and description through cache and merge boundaries", () => {
+  const now = Date.now();
+  const fund = makeFinancials({
+    quote: makeQuote({ symbol: "SGOV", providerId: "gloomberb-cloud", instrumentType: "ETF", lastUpdated: now }),
+    fundamentals: { dividendYield: 0.036658540225881886, source: "twelvedata", fetchedAt: "2026-09-10T22:30:00Z", stale: true,
+      enterpriseValue: 0, revenue: 0, netIncome: 0, freeCashFlow: 0 },
+    profile: { description: "Short Treasury bond fund", sector: "Contaminated issuer sector" },
+    annualStatements: [{ date: "2025-12-31", totalRevenue: 0 }],
+  });
+  for (const value of [sanitizeCachedFinancials(fund, { includeStaleQuotes: true }), mergeFinancials(fund, null)!]) {
+    expect(value.fundamentals).toEqual({ dividendYield: 0.036658540225881886, source: "twelvedata", fetchedAt: "2026-09-10T22:30:00Z", stale: true });
+    expect(value.profile).toEqual({ description: "Short Treasury bond fund" });
+    expect(value.annualStatements).toEqual([]);
+  }
+  const company = makeFinancials({
+    quote: makeQuote({ symbol: "SGOV", providerId: "yahoo", instrumentType: "EQUITY", lastUpdated: now - 1000 }),
+    fundamentals: { dividendYield: 0.99, revenue: 0 }, profile: { description: "Wrong company" },
+  });
+  const emptyFund = makeFinancials({ quote: fund.quote });
+  for (const value of [mergeFinancials(emptyFund, company)!, mergeFinancials(company, emptyFund)!]) {
+    expect(value.quote?.instrumentType).toBe("ETF");
+    expect(value.fundamentals).toBeUndefined();
+    expect(value.profile).toBeUndefined();
+  }
+  expect(mergeFinancials(fund, company)?.profile?.description).toBe("Short Treasury bond fund");
+  expect(mergeFinancials(company, null)?.fundamentals?.revenue).toBe(0);
+  expect(sanitizeCachedFinancials({ ...fund, fundamentals: { dividendYield: 0 } }, { includeStaleQuotes: true }).fundamentals?.dividendYield).toBe(0);
+  expect(sanitizeCachedFinancials({ ...fund, quote: { ...fund.quote!, instrumentType: "INDEX" } }, { includeStaleQuotes: true }).profile).toBeUndefined();
+});
+
 describe("AssetDataRouter cached financials", () => {
   test("drops stale cached cloud quotes while preserving cached cloud fundamentals", () => {
     const dbPath = createTempDbPath("stale-cloud-cached-financials");

--- a/src/sources/provider-router/financials.ts
+++ b/src/sources/provider-router/financials.ts
@@ -28,12 +28,34 @@ export interface CachedQuoteSelection {
   stale: boolean;
 }
 
+function researchInstrumentType(quote: Quote | undefined): string | undefined {
+  return quote?.instrumentType?.toLowerCase().replace(/[\s_-]/g, "");
+}
+
+function isFundQuote(quote: Quote | undefined): boolean {
+  return ["etf", "exchangetradedfund", "mutualfund", "fund"].includes(researchInstrumentType(quote) ?? "");
+}
+
 function excludeNonCompanyFinancials(financials: TickerFinancials): TickerFinancials {
-  const type = financials.quote?.instrumentType?.toLowerCase().replace(/[\s_-]/g, "");
+  const type = researchInstrumentType(financials.quote);
   if (!type || !["etf", "exchangetradedfund", "mutualfund", "fund", "index", "currency", "forex", "fx", "future", "futures", "cryptocurrency", "crypto", "digitalcurrency"].includes(type)) return financials;
   // An empty company response for a confirmed fund or other non-equity must
   // not inherit stale issuer accounts from a former symbol collision.
-  return { ...financials, financialCurrency: undefined, fundamentals: undefined, profile: undefined, annualStatements: [], quarterlyStatements: [] };
+  const fund = isFundQuote(financials.quote);
+  const statistics = financials.fundamentals;
+  return {
+    ...financials,
+    financialCurrency: undefined,
+    fundamentals: fund && statistics?.dividendYield != null ? {
+      dividendYield: statistics.dividendYield,
+      source: statistics.source,
+      fetchedAt: statistics.fetchedAt,
+      stale: statistics.stale,
+    } : undefined,
+    profile: fund && financials.profile?.description ? { description: financials.profile.description } : undefined,
+    annualStatements: [],
+    quarterlyStatements: [],
+  };
 }
 
 export function sanitizeCachedFinancials(
@@ -256,6 +278,11 @@ export function mergeFinancials(primary: TickerFinancials | null, fallback: Tick
     seedQuoteContributions(fallback),
   );
   const resolvedQuote = resolveCanonicalQuote(quoteContributions).quote;
+  // A fund's distribution yield or description must not be borrowed from an
+  // old company response for a colliding symbol. Only classified fund sources
+  // can contribute those fields when the resolved security is a fund.
+  const primaryResearch = isFundQuote(resolvedQuote) && !isFundQuote(primary.quote) ? undefined : primary;
+  const fallbackResearch = isFundQuote(resolvedQuote) && !isFundQuote(fallback.quote) ? undefined : fallback;
 
   return excludeNonCompanyFinancials({
     ...fallback,
@@ -264,8 +291,8 @@ export function mergeFinancials(primary: TickerFinancials | null, fallback: Tick
     financialCurrency: primary.financialCurrency ?? (hasStatementRows(primary) ? undefined : fallback.financialCurrency),
     quote: resolvedQuote,
     quoteContributions,
-    profile: mergeDefinedObject(primary.profile, fallback.profile),
-    fundamentals: mergeFundamentals(primary.fundamentals, fallback.fundamentals),
+    profile: mergeDefinedObject(primaryResearch?.profile, fallbackResearch?.profile),
+    fundamentals: mergeFundamentals(primaryResearch?.fundamentals, fallbackResearch?.fundamentals),
     priceHistory: normalizePriceHistory(dominant.priceHistory.length > 0 ? dominant.priceHistory : secondary.priceHistory),
     annualStatements: mergeFinancialStatementRows(primary.annualStatements, fallback.annualStatements),
     quarterlyStatements: mergeFinancialStatementRows(primary.quarterlyStatements, fallback.quarterlyStatements),


### PR DESCRIPTION
Known ETFs lost their distribution yield and description when the frontend removed company-only research fields. After the backend classified SGOV correctly, its valid 3.67% source yield and fund description disappeared from the overview.

Keep fund yield, its source/freshness metadata and the fund description through cache sanitization and financial merges. Continue excluding issuer metrics and statements. When the resolved security is a fund, a company or unclassified fallback cannot contribute research fields from a colliding symbol.

Validation: 104 provider-router tests (348 assertions), all six TypeScript projects, and a web build. A fresh local browser using the actual production SGOV API and a reload both retained the yield and description with no company zeros. An isolated native tmux run using the captured production payload also displayed both fields. No real portfolio changes or release/version changes.
