### PR TITLE
Retain international chart currency and price precision

### DIFF
--- a/src/components/chart/composite/format.test.ts
+++ b/src/components/chart/composite/format.test.ts
@@ -201,6 +201,17 @@ describe("composite chart unit formatting", () => {
   });
 });
 
+test("international price legends and cursors retain currency and price precision", () => {
+  for (const [currency, expected] of [["CAD", "CA$173.45"], ["CHF", "CHF173.45"], ["HKD", "HK$173.45"], ["SEK", "SEK173.45"]]) {
+    const unit = `${currency}/share`;
+    const domain = { side: "right" as const, seriesIds: ["price"], min: 170, max: 180, scale: "linear" as const, unit, unitGroup: `price:${currency}` };
+    expect(formatChartLegendValue(173.45, unit, domain.unitGroup)).toBe(expected);
+    expect(formatCompositeCursorValue(173.45, domain)).toBe(expected);
+  }
+  expect(formatChartLegendValue(173.45, "CAD/JPY", "derived-unit:cad/jpy")).toBe("173 CAD/JPY");
+  expect(formatChartLegendValue(173.45, "CPI", "index")).toBe("173 CPI");
+});
+
 // Regression: truncating before PriceAxisLabels bypassed its full-value guard.
 test("constrained axis ticks never become plausible numeric prefixes", () => {
   const domain = { side: "right" as const, seriesIds: ["tiny"], min: 3.88e-6, max: 6.12e-6, scale: "linear" as const, unit: "USD", unitGroup: "price" };

--- a/src/components/chart/composite/format.ts
+++ b/src/components/chart/composite/format.ts
@@ -10,6 +10,8 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
   CNY: "¥",
 };
 
+const CURRENCY_CODES = new Set(Intl.supportedValuesOf("currency"));
+
 const HOUR_MS = 60 * 60 * 1_000;
 const INTRADAY_SPAN_MAX_MS = 36 * HOUR_MS;
 
@@ -28,7 +30,7 @@ function compactNumber(value: number): string {
 
 function unitCurrencyCode(unit: string): string | null {
   const currency = unit.trim().toUpperCase().split(/[\s/]/)[0] ?? "";
-  return CURRENCY_SYMBOLS[currency] ? currency : null;
+  return CURRENCY_CODES.has(currency) ? currency : null;
 }
 
 function currencyPrefix(unit: string): string {

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -40,6 +40,37 @@ const fredLoad = (
 });
 
 describe("resolveChartSpecData", () => {
+  test("qualified price charts retain quote metadata without injecting the fetched snapshot into history", async () => {
+    let quoteCalls = 0;
+    let financialCalls = 0;
+    const history = [{ date: new Date("2026-01-15"), close: 77.53, volume: 1234 }];
+    const provider = createTestDataProvider({
+      getQuote: async () => { quoteCalls++; return { symbol: "NESN", currency: "CHF", instrumentType: "EQUITY", price: 999, change: 0, changePercent: 0, lastUpdated: Date.parse("2026-01-16") }; },
+      getTickerFinancials: async () => { financialCalls++; return emptyFinancials(); },
+      getPriceHistory: async () => history,
+      getPriceHistoryForResolution: async () => history,
+    });
+    const spec = chartSpec({ viewport: { range: "1M", resolution: "1d" }, series: [chartSeries({ source: { kind: "security", instrument: { symbol: "NESN", exchange: "SWX" }, fieldId: "market.close" } })] });
+    const cache = new ChartResolveCache();
+    const sources = { dataProvider: provider, loadFredSeries: async () => fredLoad(), now: new Date("2026-01-16") };
+    const result = await resolveChartSpecData(spec, sources, cache);
+    expect(result.series[0]).toMatchObject({ unit: "CHF/share", unitGroup: "price:CHF", volumeUnit: "shares" });
+    expect(result.series[0]?.points.map((point) => point.value)).toEqual([77.53]);
+    await resolveChartSpecData(spec, sources, cache);
+    expect(quoteCalls).toBe(1);
+    expect(financialCalls).toBe(0);
+
+    const unavailable = createTestDataProvider({
+      getQuote: async () => { throw new Error("Quote temporarily unavailable"); },
+      getPriceHistory: async () => history,
+      getPriceHistoryForResolution: async () => history,
+    });
+    const withoutMetadata = await resolveChartSpecData(spec, { ...sources, dataProvider: unavailable });
+    expect(withoutMetadata.errors).toEqual([]);
+    expect(withoutMetadata.series[0]?.points.map((point) => point.value)).toEqual([77.53]);
+    expect(withoutMetadata.series[0]?.unit).toBe("currency/share");
+  });
+
   test("seeds study series so their panels survive the wait for real data", async () => {
     const date = new Date("2026-01-05T00:00:00.000Z");
     const seeded = seedChartResolutionResult(

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -61,7 +61,8 @@ describe("resolveChartSpecData", () => {
     expect(financialCalls).toBe(0);
 
     const unavailable = createTestDataProvider({
-      getQuote: async () => { throw new Error("Quote temporarily unavailable"); },
+      // Optional metadata can also fail synchronously in a provider adapter.
+      getQuote: () => { throw new Error("Quote temporarily unavailable"); },
       getPriceHistory: async () => history,
       getPriceHistoryForResolution: async () => history,
     });

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -109,6 +109,7 @@ export interface ChartResolveOptions {
 /** Raw source data retained while live quotes recompute the chart tail. */
 export class ChartResolveCache {
   readonly financialsByInstrument = new Map<string, Promise<TickerFinancials | null>>();
+  readonly quoteMetadataByInstrument = new Map<string, Promise<Pick<Quote, "currency" | "instrumentType"> | null>>();
   readonly priceHistoryByRequest = new Map<string, Promise<TickerFinancials["priceHistory"]>>();
   readonly accumulatedPriceHistory = new Map<string, TickerFinancials["priceHistory"]>();
   readonly resolutionSupportByInstrument = new Map<string, Promise<ChartResolutionSupport[]>>();
@@ -664,14 +665,15 @@ function baseSecuritySeries(
   financials: TickerFinancials,
   index: number,
   marketResolution?: ManualChartResolution,
+  quoteMetadata?: Pick<Quote, "currency" | "instrumentType"> | null,
 ): ResolvedSeries | null {
   if (spec.source.kind !== "security") return null;
   const field = getTimeSeriesField(spec.source.fieldId);
   if (!field) return null;
   const points = extractSecuritySeries(financials, spec.source);
   const symbol = instrumentLabel(spec.source);
-  const currency = financials.quote?.currency;
-  const assetKind = resolveAssetDisplayKind({ assetCategory: financials.quote?.instrumentType });
+  const currency = financials.quote?.currency || quoteMetadata?.currency;
+  const assetKind = resolveAssetDisplayKind({ assetCategory: financials.quote?.instrumentType || quoteMetadata?.instrumentType });
   const volumeUnit = assetKind === "equity" ? "shares" as const : assetKind === "contract" ? "contracts" as const : undefined;
   const unit = field.id === "market.volume" ? volumeUnit ?? ""
     : field.unit.startsWith("currency") && currency ? field.unit.replace("currency", currency) : field.unit;
@@ -942,6 +944,18 @@ export async function resolveChartSpecData(
     }
     return pending;
   };
+  const loadQuoteMetadata = (source: Extract<ChartSeriesSpec["source"], { kind: "security" }>) => {
+    const key = instrumentKey(source);
+    let pending = cache.quoteMetadataByInstrument.get(key);
+    if (!pending) {
+      pending = sources.dataProvider!.getQuote(
+        source.instrument.symbol, source.instrument.exchange ?? "", requestContext(source),
+      ).then(({ currency, instrumentType }) => ({ currency, instrumentType }))
+        .catch(() => { cache.quoteMetadataByInstrument.delete(key); return null; });
+      cache.quoteMetadataByInstrument.set(key, pending);
+    }
+    return pending;
+  };
   const loadResolutionSupport = (
     source: Extract<ChartSeriesSpec["source"], { kind: "security" }>,
     immediate: boolean,
@@ -1137,6 +1151,11 @@ export async function resolveChartSpecData(
         ? sources.quoteOverrides?.get(chartQuoteOverrideKeyForSource(source))
         : undefined;
       const financialsPromise = needsFinancials ? loadFinancials(source) : Promise.resolve(null);
+      // Qualified price charts avoid loading company statements. They still
+      // need listing metadata when no streamed quote has supplied it. Retain
+      // only currency/type: a metadata fetch must not append an old price.
+      const quoteMetadataPromise = !needsFinancials && !quoteOverride?.currency
+        ? loadQuoteMetadata(source) : Promise.resolve(null);
       let resolvedSource = source;
       let financials: TickerFinancials | null;
       let history: TickerFinancials["priceHistory"] | null;
@@ -1167,6 +1186,7 @@ export async function resolveChartSpecData(
         merged,
         index,
         initialResolution,
+        await quoteMetadataPromise,
       );
       if (!result) throw new Error(`Unknown field ${source.fieldId}.`);
       if (isFundamentalFieldId(source.fieldId) && fundamentalSeriesUsesAvailabilityFallback(merged, source)) {

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -948,9 +948,9 @@ export async function resolveChartSpecData(
     const key = instrumentKey(source);
     let pending = cache.quoteMetadataByInstrument.get(key);
     if (!pending) {
-      pending = sources.dataProvider!.getQuote(
+      pending = Promise.resolve().then(() => sources.dataProvider!.getQuote(
         source.instrument.symbol, source.instrument.exchange ?? "", requestContext(source),
-      ).then(({ currency, instrumentType }) => ({ currency, instrumentType }))
+      )).then(({ currency, instrumentType }) => ({ currency, instrumentType }))
         .catch(() => { cache.quoteMetadataByInstrument.delete(key); return null; });
       cache.quoteMetadataByInstrument.set(key, pending);
     }


### PR DESCRIPTION
International chart legends and cursor labels lost currencies and rounded prices because only five currency codes were recognized: a CHF 77.53 observation could appear as 77.5. Qualified price charts could also skip both financials and quote metadata. The chart now recognizes supported currency codes and caches currency and instrument type when the stream has not supplied them. Metadata retrieval never appends its snapshot price to historical data. Both synchronous adapter errors and rejected metadata requests preserve valid history.

Validation: 2,955 tests and 11,186 assertions pass, including the CLI integration regression found by initial CI. All six TypeScript projects and the web build passed before the optional-lookup guard; replacement CI checks the final change. Actual production Swiss chart reproduced the display problem. Local browser with live cloud data retains CHF 78.31 at desktop and narrow widths; native captured-source replay retains CHF 77.53 at 140 and 80 columns. CAD/HKD/SEK and derived-unit regressions are included. No version or release change.
