### PR TITLE
Resolve duplicate ticker listings from explicit identity

### DIFF
--- a/src/app/pane-runtime/ticker-open-runtime.test.tsx
+++ b/src/app/pane-runtime/ticker-open-runtime.test.tsx
@@ -79,3 +79,33 @@ test("a slow linked ticker applies its tab to the reused or new pane after hydra
     }
   }
 });
+
+
+test("ambiguous deep links open the listing picker without publishing an arbitrary ticker", async () => {
+  const actions: AppAction[] = [];
+  const notifications: string[] = [];
+  const stateRef = { current: createInitialState(createDefaultConfig(":memory:")) };
+  let runtime!: ReturnType<typeof useAppTickerOpenRuntime>;
+  function Harness() {
+    runtime = useAppTickerOpenRuntime({
+      stateRef,
+      dataProvider: createTestDataProvider({
+        search: async () => ["BYMA", "NYSE"].map((exchange) => ({ providerId: "cloud", symbol: "GLD", name: "SPDR", exchange, type: "ETF" })),
+        getQuote: async () => ({ symbol: "GLD", price: 400, currency: "USD", lastUpdated: 1, change: 0, changePercent: 0 }),
+      }),
+      tickerRepository: { createTicker: async () => { throw new Error("Must not create an ambiguous ticker"); } } as any,
+      dispatch: (action) => { actions.push(action); },
+      pluginRegistry: { notify: ({ body }: { body: string }) => { notifications.push(body); } } as any,
+      buildPaneInstance: () => null, persistLayout() {}, activatePane() {}, focusVisiblePane() {},
+    });
+    return <text>Research</text>;
+  }
+  const rendered = await testRender(<Harness />, { width: 20, height: 2 });
+  try {
+    await act(async () => { await rendered.renderOnce(); await runtime.openPinnedTicker("GLD"); });
+    expect(actions).toEqual([{ type: "SET_COMMAND_BAR", open: true, query: "GLD", launch: { kind: "ticker-search", query: "GLD" } }]);
+    expect(notifications[0]).toContain("Multiple listings match GLD");
+  } finally {
+    await act(async () => { rendered.renderer.destroy(); });
+  }
+});

--- a/src/app/pane-runtime/ticker-open-runtime.ts
+++ b/src/app/pane-runtime/ticker-open-runtime.ts
@@ -21,7 +21,7 @@ import {
   resolveTickerOpenTarget,
   type TickerOpenTarget,
 } from "../../tickers/open-target";
-import { findExactTickerSearchMatch } from "../../tickers/search";
+import { AmbiguousTickerError, findExactTickerSearchMatch } from "../../tickers/search";
 import { parsePublicTickerKey } from "../../utils/exchanges";
 import { tickerHasYahooSuffix } from "../../sources/yahoo-finance/symbols";
 
@@ -67,11 +67,15 @@ export function useAppTickerOpenRuntime({
       }
       return target;
     } catch (err) {
+      if (err instanceof AmbiguousTickerError) {
+        dispatch({ type: "SET_COMMAND_BAR", open: true, query: rawSymbol,
+          launch: { kind: "ticker-search", query: rawSymbol } });
+      }
       const message = err instanceof Error ? err.message : String(err);
       pluginRegistry.notify({ body: `Failed to open ${rawSymbol}: ${message}`, type: "error" });
       return null;
     }
-  }, [dataProvider, pluginRegistry, stateRef, tickerRepository]);
+  }, [dataProvider, dispatch, pluginRegistry, stateRef, tickerRepository]);
 
   const publishTickerOpenTarget = useCallback((target: TickerOpenTarget) => {
     const currentTicker = stateRef.current.tickers.get(target.symbol);

--- a/src/components/command-bar/routes/ticker-search/results.test.ts
+++ b/src/components/command-bar/routes/ticker-search/results.test.ts
@@ -75,7 +75,7 @@ test("folds a plain query's symbol hits into one capped Instruments section behi
     action: () => {},
   };
   const providerItems = [
-    resultItem("search:NVDA", "NVDA", "Equity NASDAQ", "search"),
+    resultItem("search:NVDA", "NVDA", "NASDAQ", "search"),
     // The saved row for the same symbol carries a different badge; one row per symbol.
     resultItem("goto:NVDA", "NVDA", "NASDAQ"),
     resultItem("search:NVDA.MX", "NVDA.MX", "Equity BMV", "search"),
@@ -116,4 +116,13 @@ test("names the instrument class for the badge column", () => {
   })).toBe("ETF");
   expect(formatInstrumentBadge({ instrumentClass: "derivative" })).toBe("DERIV");
   expect(formatInstrumentBadge({ instrumentClass: "other", result: search("INDEX") })).toBeUndefined();
+});
+
+
+test("plain exact-symbol search retains venue choices while deduplicating the same listing", () => {
+  const items = [resultItem("gld:tsv", "GLD", "TSXV", "search"),
+    resultItem("gld:nyse", "GLD", "NYSE", "search"), resultItem("gld:byma", "GLD", "BYMA", "search"),
+    resultItem("gld:duplicate", "GLD", "XNYS", "search")];
+  expect(mergePlainRootTickerResults("GLD", items, []).map((item) => item.id))
+    .toEqual(["gld:tsv", "gld:nyse", "gld:byma"]);
 });

--- a/src/components/command-bar/routes/ticker-search/results.ts
+++ b/src/components/command-bar/routes/ticker-search/results.ts
@@ -5,6 +5,7 @@ import {
   type TickerSearchCandidate,
 } from "../../../../tickers/search";
 import type { ResultItem } from "../../list/model";
+import { canonicalExchange } from "../../../../utils/exchanges";
 import { isExplicitMarketSymbol } from "../../../../tickers/search/ranking";
 
 export const QUICK_LOOK_TICKER_SEARCH_OPTIONS = { includeOptionContracts: false } as const;
@@ -92,9 +93,9 @@ function isInstrumentItem(item: ResultItem): boolean {
 
 /**
  * Fold symbol-search rows into a plain root query's list. An exact symbol hit
- * is promoted ahead of everything; the rest collapse into one Instruments
- * section with one row per symbol, since the listing split of the DES route
- * is noise next to panes and commands. Info rows ("no matches", "search
+ * is promoted ahead of everything, with distinct venues retained so a bare
+ * symbol cannot hide another security. Non-exact matches collapse into one
+ * Instruments section with one row per symbol. Info rows ("no matches", "search
  * failed") are dropped: the instruments are an extra here, never the answer.
  */
 export function mergePlainRootTickerResults(
@@ -104,17 +105,18 @@ export function mergePlainRootTickerResults(
 ): ResultItem[] {
   const seenSymbols = new Set<string>();
   const instruments: ResultItem[] = [];
+  const isExact = (item: ResultItem) => item.category === "Exact Match" || isExactTickerResultMatch(item, query);
   for (const item of providerItems) {
     if (!isInstrumentItem(item)) continue;
     const symbol = item.label.trim().toUpperCase();
-    if (seenSymbols.has(symbol)) continue;
-    seenSymbols.add(symbol);
+    const key = isExact(item) ? `${symbol}:${canonicalExchange(item.right)}` : symbol;
+    if (seenSymbols.has(key)) continue;
+    seenSymbols.add(key);
     instruments.push(item);
     if (instruments.length >= ROOT_INSTRUMENTS_LIMIT) break;
   }
   if (instruments.length === 0) return rootItems;
 
-  const isExact = (item: ResultItem) => item.category === "Exact Match" || isExactTickerResultMatch(item, query);
   return [
     ...instruments.filter(isExact).map((item) => ({ ...item, category: "Exact Match" })),
     ...rootItems,

--- a/src/components/command-bar/workflow/ops.test.ts
+++ b/src/components/command-bar/workflow/ops.test.ts
@@ -580,3 +580,16 @@ describe("applyPaneSettingFieldValue", () => {
     });
   });
 });
+
+
+test("interactive ambiguous ticker input returns to the picker without mutating research or holdings", async () => {
+  const state = createInitialState(createDefaultConfig(":memory:"));
+  let writes = 0;
+  const resolved = await resolveTickerInput("GLD", null, null, {
+    getState: () => state, dispatch: () => { writes++; }, pluginRegistry: {} as any,
+    tickerRepository: { createTicker: async () => { writes++; throw new Error("Must not create ticker"); } } as any,
+    dataProvider: createTestDataProvider({ search: async () => ["BYMA", "NYSE"].map((exchange) => ({ providerId: "cloud", symbol: "GLD", exchange, name: "SPDR", type: "ETF" })) }),
+  });
+  expect(resolved).toBeNull();
+  expect(writes).toBe(0);
+});

--- a/src/components/command-bar/workflow/tickers.ts
+++ b/src/components/command-bar/workflow/tickers.ts
@@ -5,7 +5,7 @@ import type { PluginRegistry } from "../../../plugins/registry";
 import { isManualPortfolio } from "../../../plugins/builtin/portfolio-list/mutations";
 import type { DataProvider } from "../../../types/data-provider";
 import type { Portfolio, TickerRecord, Watchlist } from "../../../types/ticker";
-import { resolveTickerSearch, upsertTickerFromSearchResult } from "../../../tickers/search";
+import { AmbiguousTickerError, resolveTickerSearch, upsertTickerFromSearchResult } from "../../../tickers/search";
 import { parseTickerListInput } from "../../../tickers/list";
 
 export interface SharedWorkflowDeps {
@@ -140,13 +140,20 @@ export async function resolveTickerInput(
   deps: SharedWorkflowDeps,
 ): Promise<ResolvedTickerInput | null> {
   const state = deps.getState();
-  const resolvedTicker = await resolveTickerSearch({
-    query: rawInput,
-    activeTicker,
-    tickers: state.tickers,
-    dataProvider: deps.dataProvider,
-    searchContext: getTickerSearchContext(state, collectionId),
-  });
+  let resolvedTicker;
+  try {
+    resolvedTicker = await resolveTickerSearch({
+      query: rawInput,
+      activeTicker,
+      tickers: state.tickers,
+      dataProvider: deps.dataProvider,
+      searchContext: getTickerSearchContext(state, collectionId),
+    });
+  } catch (error) {
+    // Interactive callers already open a listing picker for unresolved input.
+    if (error instanceof AmbiguousTickerError) return null;
+    throw error;
+  }
   if (!resolvedTicker) return null;
   return materializeResolvedTicker(resolvedTicker, deps);
 }

--- a/src/tickers/open-target.test.ts
+++ b/src/tickers/open-target.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import { JsonTickerRepository } from "../data/json-ticker-repository";
 import { createTestDataProvider } from "../test-support/data-provider";
+import { AmbiguousTickerError } from "./search";
 import { resolveTickerOpenTarget } from "./open-target";
 
 function repository() {
@@ -68,4 +69,18 @@ test("quote-only hydration verifies the returned symbol and listing before prese
       }
     }
   }
+});
+
+
+test("ambiguous search cannot fall through to an unqualified quote and create a ticker", async () => {
+  const tickerRepository = repository();
+  let quoteCalls = 0;
+  await expect(resolveTickerOpenTarget({ query: "GLD", tickerRepository, tickers: new Map(),
+    dataProvider: createTestDataProvider({
+      search: async () => ["BYMA", "NYSE"].map((exchange) => ({ providerId: "cloud", symbol: "GLD", name: "SPDR", exchange, type: "ETF" })),
+      getQuote: async () => { quoteCalls++; return { symbol: "GLD", currency: "USD", price: 400, lastUpdated: 1, change: 0, changePercent: 0 }; },
+    }),
+  })).rejects.toBeInstanceOf(AmbiguousTickerError);
+  expect(quoteCalls).toBe(1);
+  expect(await tickerRepository.loadAllTickers()).toEqual([]);
 });

--- a/src/tickers/open-target.ts
+++ b/src/tickers/open-target.ts
@@ -2,6 +2,7 @@ import type { AppTickerRepositoryPort } from "../core/app-service-ports";
 import type { SearchRequestContext, DataProvider } from "../types/data-provider";
 import type { TickerRecord } from "../types/ticker";
 import {
+  AmbiguousTickerError,
   normalizeTickerInput,
   findExactTickerSearchMatch,
   resolveTickerSearch,
@@ -41,7 +42,8 @@ export async function resolveTickerOpenTarget({
       dataProvider,
       searchContext,
     });
-  } catch {
+  } catch (error) {
+    if (error instanceof AmbiguousTickerError) throw error;
     resolved = null;
   }
 

--- a/src/tickers/search/index.test.ts
+++ b/src/tickers/search/index.test.ts
@@ -5,6 +5,7 @@ import type { TickerRecord } from "../../types/ticker";
 import { createTestDataProvider } from "../../test-support/data-provider";
 import { loadYahooQuote } from "../../sources/yahoo-finance/snapshots";
 import {
+  AmbiguousTickerError,
   buildTickerSearchCandidates,
   createLocalTickerSearchCandidates,
   findExactTickerSearchMatch,
@@ -59,6 +60,68 @@ function makeDataProvider(results: InstrumentSearchResult[]): DataProvider {
 }
 
 describe("ticker-search utilities", () => {
+  test("duplicate bare symbols follow verified quote identity independent of catalogue order", async () => {
+    for (const [symbol, venue, currency, providerCurrency] of [
+      ["GLD", "NYSE", "USD", "USD"],
+      ["VOD", "LSE", "GBP", "GBp"],
+      ["7203", "TYO", "JPY", "JPY"],
+    ]) {
+      const wanted = makeSearchResult(symbol!, "Exact listing", { exchange: venue, currency: providerCurrency });
+      const other = makeSearchResult(symbol!, "Other listing", { exchange: "BYMA", currency: "ARS" });
+      for (const results of [[other, wanted], [wanted, other]]) {
+        const resolved = await resolveTickerSearch({ query: symbol, activeTicker: null, tickers: new Map(),
+          dataProvider: createTestDataProvider({ search: async () => results, getQuote: async () => ({
+            symbol: symbol!, listingExchangeName: venue, currency: currency!, price: 100, lastUpdated: 1, change: 0, changePercent: 0,
+          }) }),
+        });
+        expect(resolved).toMatchObject({ kind: "provider", result: { exchange: venue, currency } });
+      }
+    }
+  });
+
+  test("ambiguous symbols require venue, currency and exact quote evidence", async () => {
+    const results = [makeSearchResult("GLD", "SPDR", { exchange: "BYMA", currency: "ARS" }),
+      makeSearchResult("GLD", "SPDR", { exchange: "NYSE", currency: "USD" })];
+    const quote = { symbol: "GLD", listingExchangeName: "NYSE", currency: "USD", price: 400, lastUpdated: 1, change: 0, changePercent: 0 };
+    for (const invalid of [null, { ...quote, listingExchangeName: undefined }, { ...quote, currency: "ARS" },
+      { ...quote, symbol: "GLDM" }, { ...quote, price: Number.NaN }, { ...quote, lastUpdated: 0 }]) {
+      await expect(resolveTickerSearch({ query: "GLD", activeTicker: null, tickers: new Map(),
+        dataProvider: createTestDataProvider({ search: async () => results, getQuote: async () => {
+          if (!invalid) throw new Error("Quote unavailable");
+          return invalid;
+        } }),
+      })).rejects.toBeInstanceOf(AmbiguousTickerError);
+    }
+  });
+
+  test("explicit venues and saved identities bypass default quote disambiguation", async () => {
+    const results = [makeSearchResult("VOD", "Vodacom", { exchange: "JSE", currency: "ZAR" }),
+      makeSearchResult("VOD", "Vodafone", { exchange: "LSE", currency: "GBP" }),
+      makeSearchResult("VOD", "Vodafone ADR", { exchange: "NASDAQ", currency: "USD" })];
+    let quoteCalls = 0;
+    const dataProvider = createTestDataProvider({ search: async () => results, getQuote: async () => {
+      quoteCalls++; throw new Error("Quote unavailable");
+    } });
+    for (const [query, exchange] of [["VOD:XLON", "LSE"], ["VOD:LSE", "LSE"], ["VOD:JSE", "JSE"], ["VOD:NASDAQ", "NASDAQ"]]) {
+      expect(await resolveTickerSearch({ query, activeTicker: null, tickers: new Map(), dataProvider }))
+        .toMatchObject({ kind: "provider", result: { exchange } });
+    }
+    const saved = makeTicker("VOD", "Saved Vodafone", { exchange: "LSE", currency: "GBP" });
+    expect(await resolveTickerSearch({ query: "VOD", activeTicker: null, tickers: new Map([["VOD", saved]]), dataProvider }))
+      .toMatchObject({ kind: "local", ticker: saved });
+    expect(quoteCalls).toBe(0);
+  });
+
+  test("share-class aliases keep the requested security when duplicate venues need a quote", async () => {
+    expect(await resolveTickerSearch({ query: "BRK-B", activeTicker: null, tickers: new Map(),
+      dataProvider: createTestDataProvider({
+        search: async () => [makeSearchResult("BRK.B", "Berkshire", { exchange: "BYMA", currency: "ARS" }),
+          makeSearchResult("BRK.B", "Berkshire", { exchange: "NYSE", currency: "USD" })],
+        getQuote: async () => ({ symbol: "BRK-B", listingExchangeName: "NYSE", currency: "USD", price: 400, lastUpdated: 1, change: 0, changePercent: 0 }),
+      }),
+    })).toMatchObject({ kind: "provider", symbol: "BRK.B", result: { exchange: "NYSE" } });
+  });
+
   test("verifies omitted crypto symbols before selecting a punctuation alias on another venue", async () => {
     const alias = makeSearchResult("SHIB/USD", "SHIBA INU US Dollar", { type: "Digital Currency", exchange: "COINBASE PRO" });
     const quote = { symbol: "SHIB-USD", instrumentType: "CRYPTOCURRENCY", price: 0.00000509, currency: "USD", lastUpdated: 1789077420000,

--- a/src/tickers/search/index.test.ts
+++ b/src/tickers/search/index.test.ts
@@ -69,12 +69,16 @@ describe("ticker-search utilities", () => {
       const wanted = makeSearchResult(symbol!, "Exact listing", { exchange: venue, currency: providerCurrency });
       const other = makeSearchResult(symbol!, "Other listing", { exchange: "BYMA", currency: "ARS" });
       for (const results of [[other, wanted], [wanted, other]]) {
+        const quoteCalls: Parameters<DataProvider["getQuote"]>[] = [];
         const resolved = await resolveTickerSearch({ query: symbol, activeTicker: null, tickers: new Map(),
-          dataProvider: createTestDataProvider({ search: async () => results, getQuote: async () => ({
-            symbol: symbol!, listingExchangeName: venue, currency: currency!, price: 100, lastUpdated: 1, change: 0, changePercent: 0,
-          }) }),
+          searchContext: { brokerId: "ibkr", brokerInstanceId: "research-account", preferBroker: true, interactive: true, onPartial: () => {} },
+          dataProvider: createTestDataProvider({ search: async () => results, getQuote: async (...args) => {
+            quoteCalls.push(args);
+            return { symbol: symbol!, listingExchangeName: venue, currency: currency!, price: 100, lastUpdated: 1, change: 0, changePercent: 0 };
+          } }),
         });
         expect(resolved).toMatchObject({ kind: "provider", result: { exchange: venue, currency } });
+        expect(quoteCalls).toEqual([[symbol, "", { brokerId: "ibkr", brokerInstanceId: "research-account" }]]);
       }
     }
   });

--- a/src/tickers/search/index.ts
+++ b/src/tickers/search/index.ts
@@ -1,9 +1,10 @@
 import type { SearchRequestContext, DataProvider } from "../../types/data-provider";
 import type { InstrumentSearchResult } from "../../types/instrument";
 import type { TickerRecord } from "../../types/ticker";
-import { canonicalExchange, parsePublicTickerKey } from "../../utils/exchanges";
+import { canonicalExchange, parsePublicTickerKey, publicTickerKey } from "../../utils/exchanges";
 import { tickerHasYahooSuffix } from "../../sources/yahoo-finance/symbols";
 import { parseOptionSymbol } from "../../utils/options";
+import { resolveCurrencyUnit } from "../../utils/currency-units";
 import {
   buildSymbolAliases,
   classifyInstrumentKind,
@@ -34,6 +35,13 @@ export {
   rankTickerSearchItems,
 } from "./ranking";
 export { upsertTickerFromSearchResult } from "./upsert";
+
+export class AmbiguousTickerError extends Error {
+  constructor(readonly query: string, readonly listings: readonly string[]) {
+    super(`Multiple listings match ${query}. Choose an exchange in search or use ${listings.slice(0, 3).join(", ")}.`);
+    this.name = "AmbiguousTickerError";
+  }
+}
 
 const OPTION_TYPES = new Set(["OPT", "OPTION", "OPTIONS"]);
 
@@ -212,14 +220,51 @@ export async function resolveTickerSearch({
     await searchProviderResults(dataProvider, symbol, searchContext),
     tickers,
   );
-  const exactMatch = findExactTickerSearchMatch(providerItems, symbol);
+  const literalMatches = providerItems.filter((item) => normalizeTickerSymbol(item.symbol) === symbol);
+  const matches = literalMatches.length ? literalMatches
+    : providerItems.filter((item) => findExactTickerSearchMatch([item], symbol));
+  let exactMatch = matches[0];
   if (!exactMatch?.result) return null;
+
+  const listings = new Set(matches.map((item) => publicTickerKey(item.symbol, listingExchange(item.result!))));
+  if (listings.size > 1 && !parsePublicTickerKey(symbol).exchange && !tickerHasYahooSuffix(symbol)) {
+    // Search order is relevance, not a canonical listing identifier. Align bare
+    // symbols with the quote source only when it supplies the exact identity.
+    let verified: TickerSearchCandidate[] = [];
+    try {
+      const quote = await dataProvider.getQuote(symbol, "");
+      const exchange = canonicalExchange(quote.listingExchangeName || quote.exchangeName);
+      const currency = resolveCurrencyUnit(quote.currency).currency;
+      if (exchange && currency && Number.isFinite(quote.price) && quote.price !== 0
+        && Number.isFinite(quote.lastUpdated) && quote.lastUpdated > 0) {
+        verified = matches.filter((item) => {
+          const result = item.result!;
+          const candidateCurrency = resolveCurrencyUnit(result.currency).currency;
+          return canonicalExchange(listingExchange(result)) === exchange
+            && (!candidateCurrency || candidateCurrency === currency)
+            && findExactTickerSearchMatch([{ label: quote.symbol, right: exchange, instrumentType: quote.instrumentType }], item.symbol)
+            && (!isCryptoInstrumentType(result.type) || quote.price > 0);
+        }).map((item) => ({ ...item, result: { ...item.result!, currency } }));
+      }
+    } catch {
+      // An unavailable quote cannot establish the default listing.
+    }
+    if (new Set(verified.map((item) => publicTickerKey(item.symbol, listingExchange(item.result!)))).size !== 1) {
+      throw new AmbiguousTickerError(symbol, [...listings]);
+    }
+    exactMatch = verified[0]!;
+  }
 
   return {
     kind: "provider",
     symbol: exactMatch.symbol,
-    result: exactMatch.result,
+    result: exactMatch.result!,
   };
+}
+
+function listingExchange(result: InstrumentSearchResult): string {
+  return result.exchange === "SMART" ? result.primaryExchange || result.exchange
+    : result.exchange || result.primaryExchange || "";
 }
 
 function buildProviderHints(

--- a/src/tickers/search/index.ts
+++ b/src/tickers/search/index.ts
@@ -232,7 +232,10 @@ export async function resolveTickerSearch({
     // symbols with the quote source only when it supplies the exact identity.
     let verified: TickerSearchCandidate[] = [];
     try {
-      const quote = await dataProvider.getQuote(symbol, "");
+      const quote = await dataProvider.getQuote(symbol, "", {
+        brokerId: searchContext?.brokerId,
+        brokerInstanceId: searchContext?.brokerInstanceId,
+      });
       const exchange = canonicalExchange(quote.listingExchangeName || quote.exchangeName);
       const currency = resolveCurrencyUnit(quote.currency).currency;
       if (exchange && currency && Number.isFinite(quote.price) && quote.price !== 0


### PR DESCRIPTION
A bare ticker can identify different securities on different exchanges. GLD research previously accepted the first provider search result, which could open the Argentine BYMA listing and its 13K chart while an unqualified comparison showed the quote provider’s ~$398 default. Plain command search also hid alternate exact-symbol venues behind one row.

Duplicate exact listings now resolve automatically only when a quote verifies the symbol, venue and currency. Otherwise, research opens the existing listing picker; the quote fallback cannot silently bypass that ambiguity. Exact-symbol command results retain separate venues, while explicit venue queries and saved identities remain authoritative. No US venue is inferred from ticker spelling or price. Quote verification uses the same selected broker and account context as search.

Validation: 62 focused tests / 286 assertions, all six TypeScript targets, browser checks at 1440×1000 and 640×850, and real native tmux at 140 and 80 columns. Replaying the actual GLD catalogue in BYMA-first order reproduces the old failure; the local fix asks for a listing, then preserves NYSE or BYMA selection through reload. Missing BYMA quotes remain explicitly unavailable. No real portfolio data changed.

An already-open unqualified comparison chart can still display its provider data behind the picker; this change prevents arbitrary research identity selection and does not redefine raw chart symbol semantics. No release or version bump.
