### PR TITLE
Honor individual quote freshness in cloud batches

### DIFF
--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -1073,6 +1073,7 @@ export interface CloudMarketBatchItem<T> {
   status: CloudMarketStatus;
   data: T | null;
   reasonCode?: string;
+  stale?: boolean;
 }
 
 export interface CloudMarketBatchPayload<T> {

--- a/src/sources/gloomberb-cloud/index.test.ts
+++ b/src/sources/gloomberb-cloud/index.test.ts
@@ -120,6 +120,26 @@ afterEach(() => {
 });
 
 describe("GloomberbCloudProvider", () => {
+  test("stale items in a successful quote batch cannot bypass single-quote freshness checks", async () => {
+    const targets = [{ symbol: "VOD", exchange: "NASDAQ" }, { symbol: "VOD:XLON", exchange: "LSE" }];
+    const quote = { symbol: "VOD", price: 118, currency: "GBp", change: 1, changePercent: 0.85, lastUpdated: 1, stale: false };
+    for (const status of ["success", "partial"] as const) {
+      apiClient.getCloudQuotesBatch = async () => ({ status: "success", stale: false, data: { items: [
+        { symbol: "VOD", exchange: "LSE", status, stale: true, data: quote },
+        { symbol: "VOD", exchange: "NASDAQ", status: "success", stale: false, data: { ...quote, price: 15, currency: "USD" } },
+      ] } });
+      apiClient.getCloudQuote = async () => ({ status, stale: true, data: quote });
+      const provider = new GloomberbCloudProvider();
+      const results = await provider.getQuotesBatch(targets);
+      expect(results[0]?.target).toBe(targets[1]!);
+      expect(results[0]?.quote).toBeNull();
+      expect(results[0]?.error?.message).toContain("stale");
+      expect(results[1]?.target).toBe(targets[0]!);
+      expect(results[1]?.quote).toMatchObject({ symbol: "VOD", currency: "USD", price: 15 });
+      await expect(provider.getQuote("VOD:XLON", "LSE")).rejects.toThrow("stale");
+    }
+  });
+
   test("splits saved listing keys for cloud requests while preserving returned ticker identity", async () => {
     const calls: Array<[string, string, string | undefined]> = [];
     const quote = { symbol: "VOD", price: 118, currency: "GBp", change: 1, changePercent: 0.85, lastUpdated: 1 };

--- a/src/sources/gloomberb-cloud/index.ts
+++ b/src/sources/gloomberb-cloud/index.ts
@@ -298,6 +298,12 @@ export class GloomberbCloudProvider implements AssetDataProvider {
           symbol: item.symbol,
           exchange: item.exchange,
         };
+        // A successful batch can contain an expired cache fallback for only
+        // one listing. Match the single-quote freshness boundary and let the
+        // normal router retry that item without discarding its healthy peers.
+        if (item.stale === true) {
+          return { target, quote: null, error: createProviderMiss(`Cloud quotes are stale for ${target.symbol}`) };
+        }
         if ((item.status === "success" || item.status === "partial") && item.data) {
           return {
             target,


### PR DESCRIPTION
A successful cloud quote batch can contain individually stale cache fallbacks. The adapter ignored each item's stale flag, so sector research could display an expired price and calculate trailing returns from it while single-quote requests correctly rejected the same response.

Honor the per-item flag and return a provider miss for that listing, allowing the existing router to retry it. Healthy batch entries remain available and saved listing identities stay intact.

Validation: 143 tests / 487 assertions, six TypeScript targets, and web build pass. Captured production replay rejects XLE's stale $64.60, retries only XLE, preserves its independently available daily history, and leaves healthy XLI unchanged. A fresh local browser with live production data verified stale-item retries, successful recoveries, and explicit unavailable rows when fresh quotes could not be obtained; historical returns remain available. No version or release change.
