### PR TITLE
Retain dividend yield basis and provenance in research views

### DIFF
--- a/src/cli/commands/ticker.ts
+++ b/src/cli/commands/ticker.ts
@@ -280,7 +280,7 @@ export async function buildTickerReport({
     ["Forward P/E", fundamentals?.forwardPE != null ? formatNumber(fundamentals.forwardPE, 2) : "—"],
     ["PEG", fundamentals?.pegRatio != null ? formatNumber(fundamentals.pegRatio, 2) : "—"],
     ["EPS", fundamentals?.eps != null ? formatCurrency(fundamentals.eps, quote.currency) : "—"],
-    ["Dividend Yield", fundamentals?.dividendYield != null ? formatPercent(fundamentals.dividendYield) : "—"],
+    [`Dividend Yield${fundamentals?.dividendYieldBasis ? ` (${fundamentals.dividendYieldBasis})` : ""}`, fundamentals?.dividendYield != null ? formatPercent(fundamentals.dividendYield) : "—"],
     ["Revenue", formatNullableCompact(fundamentals?.revenue)],
     ["Net Income", formatNullableCompact(fundamentals?.netIncome)],
     ["Operating Cash Flow", formatNullableCompact(fundamentals?.operatingCashFlow)],

--- a/src/plugins/builtin/ai/ticker-context.ts
+++ b/src/plugins/builtin/ai/ticker-context.ts
@@ -44,7 +44,7 @@ export function buildTickerAiContext(
     if (fundamentals.operatingMargin != null) lines.push(`Operating Margin: ${formatPercent(fundamentals.operatingMargin)}`);
     if (fundamentals.profitMargin != null) lines.push(`Profit Margin: ${formatPercent(fundamentals.profitMargin)}`);
     if (fundamentals.freeCashFlow) lines.push(`Free Cash Flow: ${formatCompact(fundamentals.freeCashFlow)}`);
-    if (fundamentals.dividendYield != null) lines.push(`Dividend Yield: ${formatPercent(fundamentals.dividendYield)}`);
+    if (fundamentals.dividendYield != null) lines.push(`Dividend Yield${fundamentals.dividendYieldBasis ? ` (${fundamentals.dividendYieldBasis})` : ""}: ${formatPercent(fundamentals.dividendYield)}${fundamentals.dividendYieldSource ? ` [${fundamentals.dividendYieldSource}]` : ""}`);
     if (fundamentals.return1Y != null) lines.push(`1Y Return: ${formatPercent(fundamentals.return1Y)}`);
   }
 

--- a/src/plugins/builtin/ticker-detail/overview/model.ts
+++ b/src/plugins/builtin/ticker-detail/overview/model.ts
@@ -71,7 +71,8 @@ export function buildOverviewStats({
     stats.push({ label: "PEG", value: formatNumber(fundamentals.pegRatio, 2) });
   }
   if (fundamentals?.dividendYield != null) {
-    stats.push({ label: "Div Yield", value: formatPercent(fundamentals.dividendYield) });
+    const label = fundamentals.dividendYieldBasis === "forward" ? "Fwd Div Yld" : fundamentals.dividendYieldBasis === "trailing" ? "TTM Div Yld" : "Div Yield";
+    stats.push({ label, value: formatPercent(fundamentals.dividendYield) });
   }
   if (fundamentals?.revenue != null) {
     stats.push({ label: "Revenue", value: money(fundamentals.revenue) });

--- a/src/sources/provider-router/cache.test.ts
+++ b/src/sources/provider-router/cache.test.ts
@@ -5,6 +5,31 @@ import { cleanupProviderRouterTestFiles, createTempDbPath, makeFinancials, makeQ
 
 afterEach(cleanupProviderRouterTestFiles);
 
+test("legacy cloud yields refresh without discarding quotes, accounts or native provider values", () => {
+  const persistence = new AppPersistence(createTempDbPath("dividend-yield-provenance"));
+  const key = { namespace: "market", kind: "financials", entityKey: "NESN", variantKey: "exchange=SWX", sourceKey: "provider:gloomberb-cloud" };
+  const cachePolicy = { staleMs: 60_000, expireMs: 120_000 };
+  const old = makeFinancials({ quote: makeQuote({ symbol: "NESN", currency: "CHF" }),
+    fundamentals: { dividendYield: 0.16, revenue: 88775000064 }, profile: { description: "Nestle" },
+    annualStatements: [{ date: "2025-12-31", totalRevenue: 100 }] });
+  persistence.resources.set(key, old, { cachePolicy, schemaVersion: 4 });
+  persistence.resources.set({ ...key, sourceKey: "provider:yahoo" }, old, { cachePolicy, schemaVersion: 4 });
+  const read = (sourceKey = key.sourceKey) => listCachedResources(persistence.resources, "financials", "NESN", [key.variantKey], [sourceKey], true)[0]!;
+  const record = read(); const value = record.value as ReturnType<typeof makeFinancials>;
+  expect(record.stale).toBe(true);
+  expect(value.fundamentals?.dividendYield).toBeUndefined();
+  expect(value.quote).toEqual(old.quote);
+  expect(value.annualStatements).toEqual(old.annualStatements);
+  expect(value.fundamentals?.revenue).toBe(88775000064);
+  expect((read("provider:yahoo").value as ReturnType<typeof makeFinancials>).fundamentals?.dividendYield).toBe(0.16);
+  const corrected = { ...old, fundamentals: { ...old.fundamentals, dividendYield: 0.0399, dividendYieldBasis: "forward" as const, dividendYieldSource: "yahoo" as const } };
+  cacheRouterResource(persistence.resources, "financials", "NESN", key.variantKey, key.sourceKey, corrected, cachePolicy);
+  expect(read().schemaVersion).toBe(5);
+  expect(read().stale).toBe(false);
+  expect(read().value).toEqual(corrected);
+  persistence.close();
+});
+
 test("legacy cloud financial caches retain statements but refresh quotes whose freshness was lost", () => {
   const persistence = new AppPersistence(createTempDbPath("nested-quote-freshness"));
   const key = { namespace: "market", kind: "financials", entityKey: "7203", variantKey: "exchange=TYO", sourceKey: "provider:gloomberb-cloud" };

--- a/src/sources/provider-router/cache.ts
+++ b/src/sources/provider-router/cache.ts
@@ -7,7 +7,7 @@ import { canonicalExchange } from "../../utils/exchanges";
 import { isPriceHistoryStaleForCurrentWindow } from "../../utils/price-history";
 
 const MARKET_NAMESPACE = "market";
-const FINANCIALS_SCHEMA_VERSION = 4;
+const FINANCIALS_SCHEMA_VERSION = 5;
 
 const DEFAULT_CACHE_POLICIES = {
   brokerQuote: { staleMs: 15_000, expireMs: 15 * 60_000 },
@@ -154,11 +154,17 @@ export function listCachedResources<T>(
     return ![...(value.annualStatements ?? []), ...(value.quarterlyStatements ?? [])]
       .some((row) => row.availableAt || Object.keys(row.fieldAvailability ?? {}).length > 0);
   }).map((record) => {
-    if (kind !== "financials" || record.schemaVersion >= 4 || record.sourceKey !== "provider:gloomberb-cloud") return record;
+    if (kind !== "financials" || record.sourceKey !== "provider:gloomberb-cloud") return record;
     // Legacy cloud aggregates lost the nested quote's stale flag. Retain valid
     // issuer data, but obtain the quote through its independent freshness route.
-    const value = record.value as TickerFinancials;
-    return { ...record, value: { ...value, quote: undefined, quoteContributions: undefined } as T };
+    let value = record.value as TickerFinancials;
+    if (record.schemaVersion < 4) value = { ...value, quote: undefined, quoteContributions: undefined };
+    // Prior cloud yields could contain uncorroborated annualization. Remove
+    // that metric and refresh while retaining valid quotes and issuer data.
+    const legacyYield = record.schemaVersion < 5 && value.fundamentals?.dividendYield != null;
+    if (legacyYield) value = { ...value, fundamentals: { ...value.fundamentals,
+      dividendYield: undefined, dividendYieldBasis: undefined, dividendYieldSource: undefined } };
+    return { ...record, stale: record.stale || legacyYield, value: value as T };
   });
   if (records.length === 0) return [];
 

--- a/src/sources/provider-router/cached-financials.test.ts
+++ b/src/sources/provider-router/cached-financials.test.ts
@@ -36,13 +36,13 @@ test("fund research keeps distribution yield and description through cache and m
   const now = Date.now();
   const fund = makeFinancials({
     quote: makeQuote({ symbol: "SGOV", providerId: "gloomberb-cloud", instrumentType: "ETF", lastUpdated: now }),
-    fundamentals: { dividendYield: 0.036658540225881886, source: "twelvedata", fetchedAt: "2026-09-10T22:30:00Z", stale: true,
+    fundamentals: { dividendYield: 0.036658540225881886, dividendYieldBasis: "forward", dividendYieldSource: "twelvedata", source: "twelvedata", fetchedAt: "2026-09-10T22:30:00Z", stale: true,
       enterpriseValue: 0, revenue: 0, netIncome: 0, freeCashFlow: 0 },
     profile: { description: "Short Treasury bond fund", sector: "Contaminated issuer sector" },
     annualStatements: [{ date: "2025-12-31", totalRevenue: 0 }],
   });
   for (const value of [sanitizeCachedFinancials(fund, { includeStaleQuotes: true }), mergeFinancials(fund, null)!]) {
-    expect(value.fundamentals).toEqual({ dividendYield: 0.036658540225881886, source: "twelvedata", fetchedAt: "2026-09-10T22:30:00Z", stale: true });
+    expect(value.fundamentals).toEqual({ dividendYield: 0.036658540225881886, dividendYieldBasis: "forward", dividendYieldSource: "twelvedata", source: "twelvedata", fetchedAt: "2026-09-10T22:30:00Z", stale: true });
     expect(value.profile).toEqual({ description: "Short Treasury bond fund" });
     expect(value.annualStatements).toEqual([]);
   }

--- a/src/sources/provider-router/financials.test.ts
+++ b/src/sources/provider-router/financials.test.ts
@@ -116,3 +116,13 @@ test("fallback reporting currency does not label unknown primary statement units
   expect(mergeMissingStatementArrays(primary, fallback).financialCurrency).toBeUndefined();
   expect(mergeFinancials(primary, fallback)?.financialCurrency).toBeUndefined();
 });
+
+test("yield basis and source stay attached to the selected yield observation", () => {
+  const forward = makeFinancials({ fundamentals: { dividendYield: 0.0399, dividendYieldBasis: "forward", dividendYieldSource: "yahoo" } });
+  const trailing = makeFinancials({ fundamentals: { dividendYield: 0.03, dividendYieldBasis: "trailing", dividendYieldSource: "twelvedata", revenue: 100 } });
+  expect(mergeFinancials(forward, trailing)?.fundamentals).toMatchObject({ dividendYield: 0.0399, dividendYieldBasis: "forward", dividendYieldSource: "yahoo", revenue: 100 });
+  const unknown = makeFinancials({ fundamentals: { dividendYield: 0.16 } });
+  expect(mergeFinancials(unknown, forward)?.fundamentals?.dividendYieldBasis).toBeUndefined();
+  expect(mergeFinancials(unknown, forward)?.fundamentals?.dividendYieldSource).toBeUndefined();
+  expect(mergeFinancials(makeFinancials({ fundamentals: { revenue: 200 } }), forward)?.fundamentals).toMatchObject({ dividendYield: 0.0399, dividendYieldBasis: "forward", dividendYieldSource: "yahoo" });
+});

--- a/src/sources/provider-router/financials.ts
+++ b/src/sources/provider-router/financials.ts
@@ -48,6 +48,8 @@ function excludeNonCompanyFinancials(financials: TickerFinancials): TickerFinanc
     financialCurrency: undefined,
     fundamentals: fund && statistics?.dividendYield != null ? {
       dividendYield: statistics.dividendYield,
+      dividendYieldBasis: statistics.dividendYieldBasis,
+      dividendYieldSource: statistics.dividendYieldSource,
       source: statistics.source,
       fetchedAt: statistics.fetchedAt,
       stale: statistics.stale,
@@ -254,6 +256,13 @@ function mergeFundamentals(primary: Fundamentals | undefined, fallback: Fundamen
     return primary;
   }
   const merged = mergeDefinedObject(primary, fallback);
+  const dividend = primary?.dividendYield != null ? primary : fallback;
+  if (merged && dividend) {
+    // A yield's source and basis must come from the same observation as its
+    // value, never from an unrelated fallback that supplied other metrics.
+    merged.dividendYieldBasis = dividend.dividendYieldBasis;
+    merged.dividendYieldSource = dividend.dividendYieldSource;
+  }
   if (merged && primary && !primary.financialCurrency && [
     primary.revenue, primary.netIncome, primary.operatingCashFlow, primary.freeCashFlow, primary.eps,
   ].some((value) => value != null)) {

--- a/src/types/financials.ts
+++ b/src/types/financials.ts
@@ -98,6 +98,8 @@ export interface Fundamentals {
   operatingCashFlow?: number;
   freeCashFlow?: number;
   dividendYield?: number;
+  dividendYieldBasis?: "forward" | "trailing";
+  dividendYieldSource?: "twelvedata" | "yahoo";
   revenue?: number;
   netIncome?: number;
   eps?: number;


### PR DESCRIPTION
Research views need to distinguish indicated forward dividend yields from trailing distributions. [Backend PR236](https://github.com/vincelwt/gloomberb-platform/pull/236) addresses Nestlé's upstream 16% annualization error using an independently verified 3.99% forward yield.

Preserve a dividend yield's basis and source together through merged financials and fund filtering, show the basis in overview/CLI/AI output, and discard unsafe yields from older cloud cache snapshots while retaining other usable data. Native provider caches remain intact. The overview label fits the terminal's existing label width; option-model numerical inputs retain their forward interpretation.

Validation: 130 provider-router and option-consumer tests / 462 assertions, all six TypeScript targets, and web build. The local browser and native app render `Fwd Div Yld +3.99%` from captured provider data passed through the patched backend; browser reload retains it. Browser console only reports an unrelated optional ticker-logo 404. Actual production verification remains pending the paired deployments. No release or version change.
