### PR TITLE
Restore pane header actions below desktop dividers

### DIFF
--- a/src/components/layout/shell/index.tsx
+++ b/src/components/layout/shell/index.tsx
@@ -164,8 +164,13 @@ export function Shell({
     pluginRegistry,
   });
   const dockGeometryOptions = useMemo<DockGeometryOptions>(() => (
-    nativePaneChrome ? { precise: true } : { reserveDividerGutters: true }
-  ), [nativePaneChrome]);
+    nativePaneChrome ? {
+      precise: true,
+      // A whole text row overlaps the next pane's header buttons. Keep the
+      // visible divider centered and share its smaller hit rect with the host.
+      dividerSize: { horizontal: 1, vertical: Math.min(1, 8 / (cellHeightPx ?? 18)) },
+    } : { reserveDividerGutters: true }
+  ), [nativePaneChrome, cellHeightPx]);
   const bounds = useMemo<LayoutBounds>(() => ({ x: 0, y: 0, width, height: contentHeight }), [contentHeight, width]);
 
   const persistLayout = useCallback((nextLayout: LayoutConfig, options?: { pushHistory?: boolean; focusedPaneId?: string | null }) => {

--- a/src/plugins/pane-manager.test.ts
+++ b/src/plugins/pane-manager.test.ts
@@ -93,6 +93,28 @@ describe("pane-manager split-tree drops", () => {
     expect(right!.rect.x).toBe(divider!.rect.x + divider!.rect.width);
   });
 
+  test("desktop resize targets stay centered without covering lower pane header actions", () => {
+    const config = createDefaultConfig("/tmp/gloomberb-test");
+    const layout: LayoutConfig = { ...config.layout, dockRoot: {
+      kind: "split", axis: "horizontal", ratio: 0.5,
+      first: { kind: "split", axis: "vertical", ratio: 0.5,
+        first: { kind: "pane", instanceId: "top" }, second: { kind: "pane", instanceId: "bottom" } },
+      second: { kind: "pane", instanceId: "right" },
+    } };
+    const original = getDockLeafLayouts(layout, BOUNDS, { precise: true });
+    const bottom = original.find((leaf) => leaf.instanceId === "bottom")!;
+    for (const cellHeight of [14, 18, 24]) {
+      const options = { precise: true, dividerSize: { horizontal: 1, vertical: 8 / cellHeight } };
+      expect(getDockLeafLayouts(layout, BOUNDS, options)).toEqual(original);
+      const dividers = getDockDividerLayouts(layout, BOUNDS, options);
+      const vertical = dividers.find((divider) => divider.axis === "vertical")!.rect;
+      expect(vertical.height * cellHeight).toBeCloseTo(8);
+      expect(vertical.y + vertical.height / 2).toBe(bottom.rect.y);
+      expect(vertical.y + vertical.height).toBeLessThan(bottom.rect.y + 0.45);
+      expect(dividers.find((divider) => divider.axis === "horizontal")!.rect.width).toBe(1);
+    }
+  });
+
   test("splits the hovered pane on leaf drops and matches the preview", () => {
     const config = createDefaultConfig("/tmp/gloomberb-test");
     const notesPane = createPaneInstance("chat");

--- a/src/plugins/pane-manager/dock-tree.ts
+++ b/src/plugins/pane-manager/dock-tree.ts
@@ -42,7 +42,7 @@ export interface DockResizeTarget extends DockDividerLayout {
 
 export interface DockGeometryOptions {
   precise?: boolean;
-  dividerSize?: number;
+  dividerSize?: number | { horizontal: number; vertical: number };
   reserveDividerGutters?: boolean;
 }
 
@@ -169,7 +169,9 @@ function collectDockGeometry(
   }
 
   const precise = options.precise === true;
-  const dividerSize = options.dividerSize ?? 1;
+  const dividerSize = typeof options.dividerSize === "object"
+    ? options.dividerSize[node.axis]
+    : options.dividerSize ?? 1;
   const reserveDividerGutters = options.reserveDividerGutters === true && !precise;
 
   if (node.axis === "horizontal") {


### PR DESCRIPTION
Desktop resize targets occupied a full text row and overlapped the next pane's header. In the default research workspace, the divider intercepted Sector Performance's menu button and prevented CSV export.

Use an 8-pixel vertical resize target centered on the same split. The shared geometry supplies both DOM and host hit regions; pane dimensions, split ratios, horizontal targets and terminal gutters retain their behavior.

Validation: 49 focused layout tests / 184 assertions, all six TypeScript targets, and web build pass. Independent review passed. Actual browser at 1440×1000 and 900×700 opens the lower-pane menu without forced clicks. A 60-pixel divider drag moved the split exactly 60 pixels, and the menu remained usable. CSV download succeeded and all 11 exported rows matched rendered values. No version or release change.
