### PR TITLE
Invalidate unverified dividend yields cached during rolling deployment

### DIFF
--- a/src/sources/provider-router/cache.test.ts
+++ b/src/sources/provider-router/cache.test.ts
@@ -22,6 +22,12 @@ test("legacy cloud yields refresh without discarding quotes, accounts or native 
   expect(value.annualStatements).toEqual(old.annualStatements);
   expect(value.fundamentals?.revenue).toBe(88775000064);
   expect((read("provider:yahoo").value as ReturnType<typeof makeFinancials>).fundamentals?.dividendYield).toBe(0.16);
+  // A new client can cache an old backend response during a rolling deploy.
+  cacheRouterResource(persistence.resources, "financials", "NESN", key.variantKey, key.sourceKey, old, cachePolicy);
+  expect(read().schemaVersion).toBe(5);
+  expect(read().stale).toBe(true);
+  expect((read().value as ReturnType<typeof makeFinancials>).fundamentals?.dividendYield).toBeUndefined();
+  expect((read().value as ReturnType<typeof makeFinancials>).quote).toEqual(old.quote);
   const corrected = { ...old, fundamentals: { ...old.fundamentals, dividendYield: 0.0399, dividendYieldBasis: "forward" as const, dividendYieldSource: "yahoo" as const } };
   cacheRouterResource(persistence.resources, "financials", "NESN", key.variantKey, key.sourceKey, corrected, cachePolicy);
   expect(read().schemaVersion).toBe(5);

--- a/src/sources/provider-router/cache.ts
+++ b/src/sources/provider-router/cache.ts
@@ -159,9 +159,13 @@ export function listCachedResources<T>(
     // issuer data, but obtain the quote through its independent freshness route.
     let value = record.value as TickerFinancials;
     if (record.schemaVersion < 4) value = { ...value, quote: undefined, quoteContributions: undefined };
-    // Prior cloud yields could contain uncorroborated annualization. Remove
-    // that metric and refresh while retaining valid quotes and issuer data.
-    const legacyYield = record.schemaVersion < 5 && value.fundamentals?.dividendYield != null;
+    // A new client can cache an old backend response during a rolling deploy.
+    // Require the metric's own provenance as well as the cache schema before
+    // reusing a cloud yield; retain valid quotes and other issuer data.
+    const statistics = value.fundamentals;
+    const hasDividendProvenance = ["forward", "trailing"].includes(statistics?.dividendYieldBasis ?? "")
+      && ["twelvedata", "yahoo"].includes(statistics?.dividendYieldSource ?? "");
+    const legacyYield = statistics?.dividendYield != null && (record.schemaVersion < 5 || !hasDividendProvenance);
     if (legacyYield) value = { ...value, fundamentals: { ...value.fundamentals,
       dividendYield: undefined, dividendYieldBasis: undefined, dividendYieldSource: undefined } };
     return { ...record, stale: record.stale || legacyYield, value: value as T };


### PR DESCRIPTION
During a rolling deployment, the updated web client can cache an older backend response under the newest local schema. That creates a schema5 record containing Nestlé's old unlabeled 16% yield, which the schema-only migration in PR797 would keep after backend PR236 finishes deploying.

Require a recognized dividend basis and source on the metric itself before reusing any cloud yield. Missing provenance makes the cached record stale and removes only that yield; quotes, statements and other issuer data remain usable, native provider caches remain intact, and correctly tagged forward/trailing yields stay cached.

Validation: the new schema5/old-response regression fails before the change and passes afterward; 25 cache/financials tests and 85 assertions pass, all six TypeScript targets pass, and the browser build passes. The main 236/797 correction is already verified in a fresh production browser plus reload, showing 3.99% forward yield. The controlled rolling-response browser replay also passes: an old response first renders16%, then the same context reload obtains actual current production data and shows Fwd Div Yld3.99%, with a new network request and no runtime errors. No release or version change.
