### PR TITLE
Follow the selected listing in saved research charts

### DIFF
--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -33,6 +33,7 @@ import {
   usePaneTicker,
 } from "../../../state/app/context";
 import { colors } from "../../../theme/colors";
+import { publicTickerKey } from "../../../utils/exchanges";
 import { CHART_COMPOSER_PANE_ID } from "../../../types/config";
 import { useRemoteUiNode } from "../../../remote/semantic-tree";
 import { SeriesEditorDialog } from "./editor";
@@ -55,7 +56,7 @@ import {
   getSelectedPairStudies,
   setBuiltinStudies,
   setPairStudies,
-  rebindChartSecuritySymbol,
+  rebindResearchChartSpec,
   type BuiltinStudySelection,
   type PairStudySelection,
 } from "./presets";
@@ -737,22 +738,9 @@ export function ChartComposerPane({ paneId, focused, width, height }: PaneProps)
   );
 }
 
-function firstChartSecuritySymbol(spec: ChartSpec): string | null {
-  for (const entry of spec.series) {
-    if (entry.source.kind === "security") return entry.source.instrument.symbol;
-  }
-  return null;
-}
-
-function specHasSecuritySymbol(spec: ChartSpec, symbol: string | null | undefined): boolean {
-  if (!symbol) return false;
-  return spec.series.some((entry) => (
-    entry.source.kind === "security" && entry.source.instrument.symbol === symbol
-  ));
-}
-
 export function ChartComposerResearchTab({ focused, width, height, onCapture }: TickerResearchTabProps) {
-  const { symbol } = usePaneTicker();
+  const { symbol: paneSymbol, ticker } = usePaneTicker();
+  const symbol = paneSymbol ? publicTickerKey(paneSymbol, ticker?.metadata.exchange) : null;
   const fallback = useMemo(() => symbol ? buildPriceChartPreset(symbol) : buildEmptyChartPreset(), [symbol]);
   const [storedSpec, setStoredSpec] = usePaneSettingValue<unknown>(CHART_SPEC_SETTING_KEY, fallback);
   const spec = useMemo(() => parseChartSpecOr(storedSpec, fallback), [fallback, storedSpec]);
@@ -760,15 +748,7 @@ export function ChartComposerResearchTab({ focused, width, height, onCapture }: 
 
   useEffect(() => {
     if (!symbol) return;
-    const previousSymbol = previousSymbolRef.current;
-    const fromSymbol = specHasSecuritySymbol(spec, previousSymbol)
-      ? previousSymbol
-      : firstChartSecuritySymbol(spec) ?? previousSymbol;
-    if (!fromSymbol || fromSymbol === symbol) {
-      previousSymbolRef.current = symbol;
-      return;
-    }
-    const rebound = rebindChartSecuritySymbol(spec, fromSymbol, symbol);
+    const rebound = rebindResearchChartSpec(spec, previousSymbolRef.current, symbol);
     if (rebound !== spec) setStoredSpec(rebound);
     previousSymbolRef.current = symbol;
   }, [setStoredSpec, spec, symbol]);

--- a/src/plugins/builtin/chart-composer/presets.test.ts
+++ b/src/plugins/builtin/chart-composer/presets.test.ts
@@ -22,6 +22,7 @@ import {
   parseChartExpression,
   parseSeriesExpression,
   rebindChartSecuritySymbol,
+  rebindResearchChartSpec,
   resolveChartFieldAlias,
   setBuiltinStudies,
   setPairStudies,
@@ -415,6 +416,40 @@ describe("chart composer presets and formulas", () => {
       source: { instrument: { symbol: "NVDA" } },
     });
     expect(rebound.series[1]).toEqual(customized.series[1]);
+  });
+
+  test("research follows the exact listing while preserving other venues and authored chart state", () => {
+    for (const [previous, next, exchange] of [["ASML:XAMS", "ASML:NASDAQ", "NASDAQ"], ["ASML:XNAS", "ASML:AMS", "AMS"]]) {
+      const comparison = buildComparisonChartPreset([previous!, next!, "SPY:ARCX"]);
+      const customized = setBuiltinStudies({ ...comparison,
+        viewport: { range: "3M", resolution: "1h" },
+        series: comparison.series.map((entry, index) => ({ ...entry, label: index === 0 ? "My primary listing" : entry.label })),
+      }, ["sma20"]);
+      const rebound = rebindResearchChartSpec(customized, previous!, next!);
+      expect(rebound.series[0]).toMatchObject({ id: customized.series[0]!.id, label: "My primary listing", transform: "percent",
+        source: { instrument: { symbol: "ASML", exchange } } });
+      expect(rebound.series.slice(1)).toEqual(customized.series.slice(1));
+      expect(rebound.viewport).toEqual(customized.viewport);
+      expect(rebound.panels).toEqual(customized.panels);
+      expect(rebound.studies).toEqual(customized.studies);
+    }
+  });
+
+  test("research repairs a persisted qualified primary once and keeps equivalent aliases unchanged", () => {
+    const stored = buildPriceChartPreset("ASML:XAMS");
+    const restored = rebindResearchChartSpec(stored, "ASML:XNAS", "ASML:XNAS");
+    expect(restored.series[0]?.source).toMatchObject({ instrument: { symbol: "ASML", exchange: "NASDAQ" } });
+    expect(rebindResearchChartSpec(restored, "ASML:XNAS", "ASML:NASDAQ")).toBe(restored);
+    expect(rebindResearchChartSpec(stored, "ASML:XAMS", "ASML:AMS")).toBe(stored);
+    const labelled = { ...stored, series: stored.series.map((entry) => ({ ...entry, label: "ASML:XAMS" })) };
+    expect(rebindResearchChartSpec(labelled, "ASML:AMS", "ASML:XNAS").series[0]?.label).toBe("ASML:XNAS");
+  });
+
+  test("a restored target or economic-only chart does not replace unrelated comparisons", () => {
+    const comparison = buildComparisonChartPreset(["SPY:ARCX", "ASML:XNAS"]);
+    expect(rebindResearchChartSpec(comparison, "ASML:XAMS", "ASML:NASDAQ")).toBe(comparison);
+    const economic = buildCustomChartPreset("FRED:CPIAUCSL");
+    expect(rebindResearchChartSpec(economic, "ASML:XAMS", "ASML:XNAS")).toBe(economic);
   });
 
   test("binds pair formulas to the first two visible series after reordering", () => {

--- a/src/plugins/builtin/chart-composer/presets.ts
+++ b/src/plugins/builtin/chart-composer/presets.ts
@@ -664,6 +664,26 @@ export function rebindChartSecuritySymbol(spec: ChartSpec, previous: string, nex
   return changed ? { ...spec, series } : spec;
 }
 
+/** Follow the research listing, including its venue, while keeping comparisons. */
+export function rebindResearchChartSpec(spec: ChartSpec, previous: string | null, next: string | null): ChartSpec {
+  const nextInstrument = next ? normalizeInstrument(next, true) : null;
+  if (!nextInstrument) return spec;
+  const previousInstrument = previous ? normalizeInstrument(previous, true) : null;
+  const previousKey = previousInstrument && publicTickerKey(previousInstrument.symbol, previousInstrument.exchange);
+  const nextKey = publicTickerKey(nextInstrument.symbol, nextInstrument.exchange);
+  const securityKeys = spec.series.flatMap((entry) => entry.source.kind === "security"
+    ? [publicTickerKey(entry.source.instrument.symbol, entry.source.instrument.exchange)]
+    : []);
+  if (previousKey && securityKeys.includes(previousKey)) {
+    return rebindChartSecuritySymbol(spec, previousKey, nextKey);
+  }
+  // A restored chart can already contain the target after its old context was
+  // lost. Do not replace an unrelated first comparison in that case.
+  if (securityKeys.includes(nextKey)) return spec;
+  const primary = securityKeys[0];
+  return primary ? rebindChartSecuritySymbol(spec, primary, nextKey) : spec;
+}
+
 export function buildIntradayPriceChartPreset(symbol: string): ChartSpec {
   const normalized = normalizeInstrument(symbol, true);
   if (!normalized) return buildEmptyChartPreset();


### PR DESCRIPTION
A saved research chart could keep plotting ASML Amsterdam after the user switched the research pane to ASML NASDAQ. The pane title and neighboring chart changed to the US listing, but the embedded chart retained Amsterdam even after reload because its rebinding caller discarded the exchange.

Research charts now match and rebind the complete listing identity. Known exchange metadata also qualifies bare research symbols before saving a chart. The change preserves transforms, ranges, studies, series IDs and unrelated comparison series; explicit listing keys retain precedence over remembered metadata. If a restored chart already contains the target listing, an unrelated first benchmark is left intact.

Validation: 37 focused tests / 226 assertions, all six TypeScript targets, browser build, real native fixtures at 140 and 80 columns, and local browser checks with live market data. Native before/after changes the incorrectly retained XAMS series to XNAS without losing its percent transform. Local XAMS→XNAS and reverse switches retain 1Y/percent and the exact listing source after Save followed immediately by reload. No real portfolio data changed; no release/version bump.
