### PR TITLE
Respect valuation retractions across cached research data

### DIFF
--- a/src/plugins/builtin/ticker-detail/overview/model.ts
+++ b/src/plugins/builtin/ticker-detail/overview/model.ts
@@ -96,7 +96,9 @@ export function buildOverviewStats({
       valueColor: priceColor(fundamentals.revenueGrowth),
     });
   }
-  if (fundamentals?.enterpriseValue != null) {
+  if (fundamentals?.unavailableFields?.includes("enterpriseValue")) {
+    stats.push({ label: "EV", value: "—" });
+  } else if (fundamentals?.enterpriseValue != null) {
     stats.push({ label: "EV", value: formatCompactCurrency(fundamentals.enterpriseValue, quoteCurrency) });
   }
 

--- a/src/sources/gloomberb-cloud/normalizers.ts
+++ b/src/sources/gloomberb-cloud/normalizers.ts
@@ -16,6 +16,7 @@ import { normalizePriceValueByDivisor, resolveCurrencyUnit } from "../../utils/c
 import { resolveExchangeTimeZone } from "../../utils/exchanges";
 import { createProviderMiss } from "../provider-errors";
 import { reconcileQuoteDayRange } from "../../market-data/quotes/day-range";
+import { redactUnavailableFundamentals } from "../../utils/fundamentals";
 
 export const GLOOMBERB_CLOUD_PROVIDER_ID = "gloomberb-cloud" as const;
 
@@ -201,7 +202,7 @@ export function mapCloudFinancials(
     quote,
     quoteContributions: financials.quoteContributions,
     profile: financials.profile,
-    fundamentals: financials.fundamentals,
+    fundamentals: redactUnavailableFundamentals(financials.fundamentals),
     financialCurrency: financials.financialCurrency,
     statementHistory: financials.statementHistory,
     annualStatements: financials.annualStatements ?? [],

--- a/src/sources/provider-router/cache.test.ts
+++ b/src/sources/provider-router/cache.test.ts
@@ -24,13 +24,13 @@ test("legacy cloud yields refresh without discarding quotes, accounts or native 
   expect((read("provider:yahoo").value as ReturnType<typeof makeFinancials>).fundamentals?.dividendYield).toBe(0.16);
   // A new client can cache an old backend response during a rolling deploy.
   cacheRouterResource(persistence.resources, "financials", "NESN", key.variantKey, key.sourceKey, old, cachePolicy);
-  expect(read().schemaVersion).toBe(5);
+  expect(read().schemaVersion).toBe(6);
   expect(read().stale).toBe(true);
   expect((read().value as ReturnType<typeof makeFinancials>).fundamentals?.dividendYield).toBeUndefined();
   expect((read().value as ReturnType<typeof makeFinancials>).quote).toEqual(old.quote);
   const corrected = { ...old, fundamentals: { ...old.fundamentals, dividendYield: 0.0399, dividendYieldBasis: "forward" as const, dividendYieldSource: "yahoo" as const } };
   cacheRouterResource(persistence.resources, "financials", "NESN", key.variantKey, key.sourceKey, corrected, cachePolicy);
-  expect(read().schemaVersion).toBe(5);
+  expect(read().schemaVersion).toBe(6);
   expect(read().stale).toBe(false);
   expect(read().value).toEqual(corrected);
   persistence.close();

--- a/src/sources/provider-router/cache.ts
+++ b/src/sources/provider-router/cache.ts
@@ -3,11 +3,12 @@ import type { TimeRange } from "../../time-series/range";
 import type { BrokerContractRef } from "../../types/instrument";
 import type { PricePoint, TickerFinancials } from "../../types/financials";
 import type { CachePolicy, CachePolicyMap } from "../../types/persistence";
-import { canonicalExchange } from "../../utils/exchanges";
+import { canonicalExchange, parsePublicTickerKey, resolveExchangeTimeZone } from "../../utils/exchanges";
+import { redactUnavailableFundamentals, RETRACTABLE_VALUATION_FIELDS } from "../../utils/fundamentals";
 import { isPriceHistoryStaleForCurrentWindow } from "../../utils/price-history";
 
 const MARKET_NAMESPACE = "market";
-const FINANCIALS_SCHEMA_VERSION = 5;
+const FINANCIALS_SCHEMA_VERSION = 6;
 
 const DEFAULT_CACHE_POLICIES = {
   brokerQuote: { staleMs: 15_000, expireMs: 15 * 60_000 },
@@ -127,6 +128,24 @@ export function sortCachedRecords<T>(
   });
 }
 
+function hasUnverifiedLegacyAsmlValuation(record: CachedResourceRecord, value: TickerFinancials): boolean {
+  if (record.schemaVersion >= 6 || !RETRACTABLE_VALUATION_FIELDS.some((field) => value.fundamentals?.[field] != null)) return false;
+  const target = parsePublicTickerKey(record.entityKey);
+  const quote = parsePublicTickerKey(value.quote?.symbol ?? "");
+  if (![target.symbol, quote.symbol].some((symbol) => symbol === "ASML" || symbol === "ASML.AS")) return false;
+  const requested = target.exchange || (target.symbol === "ASML.AS" ? "AMS" : "")
+    || canonicalExchange(record.variantKey.match(/(?:^|;)exchange=([^;]+)/)?.[1]);
+  const rawListing = value.quote?.listingExchangeName || value.quote?.exchangeName || quote.exchange;
+  const listing = canonicalExchange(rawListing);
+  // Only corroborated non-US listings may retain their legacy valuation.
+  // A requested venue alone does not prove which listing supplied old data.
+  const verifiedForeign = ["ASML", "ASML.AS"].includes(quote.symbol) && resolveExchangeTimeZone(listing)
+    && rawListing?.trim().toUpperCase() !== "EURONEXT" && !["NASDAQ", "NYSE", "AMEX", "ARCA"].includes(listing)
+    && (!requested || requested === listing) && (!quote.exchange || quote.exchange === listing) && !!value.quote?.currency
+    && (listing !== "AMS" || value.quote.currency === "EUR");
+  return !verifiedForeign;
+}
+
 export function listCachedResources<T>(
   resources: ResourceStore | undefined,
   kind: string,
@@ -158,6 +177,7 @@ export function listCachedResources<T>(
     // Legacy cloud aggregates lost the nested quote's stale flag. Retain valid
     // issuer data, but obtain the quote through its independent freshness route.
     let value = record.value as TickerFinancials;
+    const legacyValuation = hasUnverifiedLegacyAsmlValuation(record, value);
     if (record.schemaVersion < 4) value = { ...value, quote: undefined, quoteContributions: undefined };
     // A new client can cache an old backend response during a rolling deploy.
     // Require the metric's own provenance as well as the cache schema before
@@ -168,7 +188,9 @@ export function listCachedResources<T>(
     const legacyYield = statistics?.dividendYield != null && (record.schemaVersion < 5 || !hasDividendProvenance);
     if (legacyYield) value = { ...value, fundamentals: { ...value.fundamentals,
       dividendYield: undefined, dividendYieldBasis: undefined, dividendYieldSource: undefined } };
-    return { ...record, stale: record.stale || legacyYield, value: value as T };
+    if (legacyValuation) value = { ...value, fundamentals: redactUnavailableFundamentals({ ...value.fundamentals,
+      unavailableFields: [...RETRACTABLE_VALUATION_FIELDS] }) };
+    return { ...record, stale: record.stale || legacyYield || legacyValuation, value: value as T };
   });
   if (records.length === 0) return [];
 

--- a/src/sources/provider-router/financial-routes.ts
+++ b/src/sources/provider-router/financial-routes.ts
@@ -22,6 +22,7 @@ import {
   hasShallowStatementHistory,
   mergeCachedFinancialRecords,
   mergeFinancials,
+  mergeRefreshedFinancials,
   quoteWithFreshnessExchange,
   sanitizeCachedFinancials,
   selectCachedQuoteRecord,
@@ -29,7 +30,7 @@ import {
   type CachedFinancialsSelection,
 } from "./financials";
 import type { ProviderRouterPrimaryRoutes } from "./primary";
-import type { ProviderRouterCoreDeps } from "./route-types";
+import type { ProviderRouterCoreDeps, SourceResult } from "./route-types";
 
 export interface ProviderRouterFinancialRouteDeps extends Pick<
   ProviderRouterCoreDeps,
@@ -58,6 +59,26 @@ function withoutSessionState(quote: Quote): Quote {
 
 export class ProviderRouterFinancialRoutes {
   constructor(private readonly deps: ProviderRouterFinancialRouteDeps) {}
+
+  private mergeProviderEnrichment(cached: CachedFinancialsSelection, fresh: SourceResult<TickerFinancials> | null): TickerFinancials {
+    const merged = mergeFinancials(cached.value, fresh?.value ?? null)!;
+    if (!fresh) return merged;
+    const sources = this.deps.getProviderSourceKeys();
+    const rank = (source: string) => sources.includes(source) ? sources.indexOf(source) : Number.MAX_SAFE_INTEGER;
+    const contributions = (cached.providerRecords ?? []).map((record) => ({ sourceKey: record.sourceKey,
+      value: record.sourceKey === fresh.sourceKey ? mergeRefreshedFinancials(record.value, fresh.value) : record.value,
+    }));
+    if (!contributions.some((entry) => entry.sourceKey === fresh.sourceKey)) contributions.push(fresh);
+    contributions.sort((a, b) => rank(a.sourceKey) - rank(b.sourceKey));
+    let providerValue: TickerFinancials | null = null;
+    for (const contribution of contributions) {
+      providerValue = mergeFinancials(providerValue, sanitizeCachedFinancials(contribution.value));
+    }
+    const authoritative = mergeFinancials(cached.brokerRecord?.value ?? null, providerValue);
+    // Keep the existing quote and statement merge, including standalone live
+    // quotes; valuation corrections follow their provider/broker contribution.
+    return { ...merged, fundamentals: authoritative?.fundamentals };
+  }
 
   getCachedFinancialsForTargets(
     targets: CachedFinancialsTarget[],
@@ -124,14 +145,14 @@ export class ProviderRouterFinancialRoutes {
       }
       if (context?.statementHistory !== "extended" && !cached.stale && hasMeaningfulProfile(cached.value) && hasShallowStatementHistory(cached.value)) {
         const providerResult = await this.deps.primaryRoutes.fetchProviderFinancials(ticker, exchange, context);
-        return mergeFinancials(cached.value, providerResult?.value ?? null) ?? cached.value;
+        return this.mergeProviderEnrichment(cached, providerResult);
       }
       if (!cached.stale && hasMeaningfulProfile(cached.value)) {
         return cached.value;
       }
       if (!hasMeaningfulProfile(cached.value) && !cached.stale) {
         const providerResult = await this.deps.primaryRoutes.fetchProviderFinancials(ticker, exchange, context);
-        return mergeFinancials(cached.value, providerResult?.value ?? null) ?? cached.value;
+        return this.mergeProviderEnrichment(cached, providerResult);
       }
     }
 
@@ -305,6 +326,7 @@ export class ProviderRouterFinancialRoutes {
       : mergedValue;
     return {
       brokerRecord: sanitizedBrokerRecord,
+      providerRecords,
       providerValue: providerSelection.value,
       value,
       stale: (sanitizedBrokerRecord?.stale ?? false) || providerSelection.stale || quoteSelection.stale,

--- a/src/sources/provider-router/financials.ts
+++ b/src/sources/provider-router/financials.ts
@@ -3,6 +3,7 @@ import type { AnalystResearchData, CorporateActionsData, FinancialStatement, Fun
 import { hasLikelyQuoteUnitMismatch } from "../../utils/currency-units";
 import { coalesceFinancialPeriodAliases, mergeFinancialStatementRows } from "../../utils/financial-statements";
 import { normalizePriceHistory, normalizeTickerFinancialsPriceHistory } from "../../utils/price-history";
+import { redactUnavailableFundamentals, RETRACTABLE_VALUATION_FIELDS } from "../../utils/fundamentals";
 import { isExtendedHoursExchange, isQuoteStaleForCurrentSession } from "../../market-data/quotes/freshness";
 import {
   mergeQuoteContributionMaps,
@@ -13,6 +14,7 @@ import {
 
 export interface CachedFinancialsSelection {
   brokerRecord: CachedResourceRecord<TickerFinancials> | null;
+  providerRecords?: CachedResourceRecord<TickerFinancials>[];
   providerValue: TickerFinancials | null;
   value: TickerFinancials | null;
   stale: boolean;
@@ -66,6 +68,7 @@ export function sanitizeCachedFinancials(
 ): TickerFinancials {
   financials = excludeNonCompanyFinancials({
     ...financials,
+    fundamentals: redactUnavailableFundamentals(financials.fundamentals),
     annualStatements: coalesceFinancialPeriodAliases(financials.annualStatements),
     quarterlyStatements: coalesceFinancialPeriodAliases(financials.quarterlyStatements),
   });
@@ -251,11 +254,22 @@ function mergeDefinedObject<T extends object>(preferred: T | null | undefined, f
 }
 
 function mergeFundamentals(primary: Fundamentals | undefined, fallback: Fundamentals | undefined): Fundamentals | undefined {
+  primary = redactUnavailableFundamentals(primary);
+  fallback = redactUnavailableFundamentals(fallback);
   if (primary?.financialCurrency && fallback?.financialCurrency && primary.financialCurrency !== fallback.financialCurrency) {
     // Revenue and cash flows must come from the same reporting currency.
     return primary;
   }
   const merged = mergeDefinedObject(primary, fallback);
+  if (merged) {
+    const unavailable = new Set(fallback?.unavailableFields ?? []);
+    for (const field of RETRACTABLE_VALUATION_FIELDS) {
+      if (primary?.unavailableFields?.includes(field)) unavailable.add(field);
+      else if (typeof primary?.[field] === "number" && Number.isFinite(primary[field])) unavailable.delete(field);
+    }
+    if (unavailable.size) merged.unavailableFields = [...unavailable];
+    else delete merged.unavailableFields;
+  }
   const dividend = primary?.dividendYield != null ? primary : fallback;
   if (merged && dividend) {
     // A yield's source and basis must come from the same observation as its
@@ -269,14 +283,16 @@ function mergeFundamentals(primary: Fundamentals | undefined, fallback: Fundamen
     // A fallback cannot retrospectively denominate an older cached snapshot.
     delete merged.financialCurrency;
   }
-  return merged;
+  return redactUnavailableFundamentals(merged);
 }
 
 export function mergeFinancials(primary: TickerFinancials | null, fallback: TickerFinancials | null): TickerFinancials | null {
   if (!primary || !fallback) {
     const single = primary ?? fallback;
     const resolved = single ? resolveTickerFinancialsQuoteState(normalizeTickerFinancialsPriceHistory(single)) : null;
-    return resolved ? excludeNonCompanyFinancials(resolved) : null;
+    return resolved ? excludeNonCompanyFinancials({ ...resolved,
+      fundamentals: redactUnavailableFundamentals(resolved.fundamentals),
+    }) : null;
   }
 
   const preferFallbackPriceData = hasLikelyQuoteUnitMismatch(primary.quote, fallback.quote);
@@ -306,6 +322,21 @@ export function mergeFinancials(primary: TickerFinancials | null, fallback: Tick
     annualStatements: mergeFinancialStatementRows(primary.annualStatements, fallback.annualStatements),
     quarterlyStatements: mergeFinancialStatementRows(primary.quarterlyStatements, fallback.quarterlyStatements),
   });
+}
+
+/** Enrichment keeps existing quote/field priorities, but new valuation decisions
+ * must supersede the older cache that caused this provider fetch. */
+export function mergeRefreshedFinancials(cached: TickerFinancials, fresh: TickerFinancials | null): TickerFinancials {
+  const merged = mergeFinancials(cached, fresh)!;
+  const statistics = redactUnavailableFundamentals(fresh?.fundamentals);
+  if (!statistics) return merged;
+  const update: Fundamentals = { unavailableFields: statistics.unavailableFields };
+  const currencyConflict = cached.fundamentals?.financialCurrency && statistics.financialCurrency
+    && cached.fundamentals.financialCurrency !== statistics.financialCurrency;
+  for (const field of RETRACTABLE_VALUATION_FIELDS) {
+    if (!currencyConflict && typeof statistics[field] === "number" && Number.isFinite(statistics[field])) update[field] = statistics[field];
+  }
+  return { ...merged, fundamentals: mergeFundamentals(update, merged.fundamentals) };
 }
 
 export function mergeCachedFinancialRecords(

--- a/src/sources/provider-router/valuation-retractions.test.ts
+++ b/src/sources/provider-router/valuation-retractions.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, expect, test } from "bun:test";
+import { AppPersistence } from "../../data/app-persistence";
+import type { Fundamentals } from "../../types/financials";
+import type { BrokerAdapter } from "../../types/broker";
+import { mapCloudFinancials } from "../gloomberb-cloud/normalizers";
+import { buildOverviewStats } from "../../plugins/builtin/ticker-detail/overview/model";
+import { cacheRouterResource, listCachedResources } from "./cache";
+import { mergeFinancials, mergeRefreshedFinancials, sanitizeCachedFinancials } from "./financials";
+import { AssetDataRouter } from "./index";
+import { attachTestRegistry, brokerInstance, cleanupProviderRouterTestFiles, createTempDbPath, fallbackProvider, makeFinancials, makeQuote, setBrokerInstances } from "./test-support";
+
+afterEach(cleanupProviderRouterTestFiles);
+
+const fields = ["enterpriseValue", "enterpriseToRevenue"] as const;
+const recorded = makeFinancials({
+  quote: makeQuote({ symbol: "ASML", listingExchangeName: "NASDAQ", currency: "USD", providerId: "gloomberb-cloud" }),
+  fundamentals: { financialCurrency: "EUR", enterpriseValue: 43_716_311_028_848, enterpriseToRevenue: 1065.865,
+    dividendYield: 0.0054, dividendYieldBasis: "forward", dividendYieldSource: "yahoo", revenue: 32_667_300_000 },
+  annualStatements: [{ date: "2025-12-31", currency: "EUR", totalRevenue: 32_667_300_000 }],
+});
+const roundTrip = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+test("explicit cloud retraction survives serialization, cached fallback, and further sparse merges", () => {
+  const corrected = mapCloudFinancials(roundTrip(makeFinancials({
+    quote: recorded.quote, fundamentals: { financialCurrency: "EUR", trailingPE: 58.7, unavailableFields: [...fields] },
+  })));
+  const merged = mergeFinancials(corrected, roundTrip(recorded))!;
+  expect(merged.fundamentals).toEqual({ financialCurrency: "EUR", trailingPE: 58.7, unavailableFields: [...fields],
+    dividendYield: 0.0054, dividendYieldBasis: "forward", dividendYieldSource: "yahoo", revenue: 32_667_300_000 });
+  expect(merged.annualStatements).toEqual(recorded.annualStatements);
+  const sparse = makeFinancials({ fundamentals: { financialCurrency: "EUR", forwardPE: 28.8 } });
+  expect(mergeFinancials(sparse, roundTrip(merged))?.fundamentals?.unavailableFields).toEqual(fields);
+  expect(mergeFinancials(merged, recorded)?.fundamentals?.enterpriseValue).toBeUndefined();
+  // Omission is still a partial response, not a retraction.
+  expect(mergeFinancials(sparse, recorded)?.fundamentals?.enterpriseValue).toBe(recorded.fundamentals!.enterpriseValue);
+});
+
+test("authoritative finite observations clear inherited markers without suppressing valid native values", () => {
+  const unavailable = makeFinancials({ fundamentals: { financialCurrency: "EUR", unavailableFields: [...fields] } });
+  for (const value of [662_293_158_034, 0, -100]) {
+    const native = makeFinancials({ quote: { ...recorded.quote!, providerId: "yahoo" },
+      fundamentals: { financialCurrency: "EUR", enterpriseValue: value } });
+    const merged = mergeFinancials(native, unavailable)!;
+    expect(merged.fundamentals?.enterpriseValue).toBe(value);
+    expect(merged.fundamentals?.unavailableFields).toEqual(["enterpriseToRevenue"]);
+  }
+  expect(mergeFinancials(makeFinancials({ fundamentals: { enterpriseValue: Number.NaN } }), unavailable)?.fundamentals?.enterpriseValue).toBeUndefined();
+  const repaired = makeFinancials({ fundamentals: { enterpriseValue: 662_293_158_034, enterpriseToRevenue: 16 } });
+  expect(mergeFinancials(repaired, unavailable)?.fundamentals?.unavailableFields).toBeUndefined();
+});
+
+test("standalone marked rows redact contradictory values and show the normal unavailable EV value", () => {
+  const marked = roundTrip({ ...recorded, fundamentals: { ...recorded.fundamentals, unavailableFields: [...fields] } });
+  for (const result of [mapCloudFinancials(marked), sanitizeCachedFinancials(marked, { includeStaleQuotes: true }), mergeFinancials(marked, null)!]) {
+    expect(result.fundamentals?.enterpriseValue).toBeUndefined();
+    expect(result.fundamentals?.enterpriseToRevenue).toBeUndefined();
+    const stats = buildOverviewStats({ quote: result.quote, fundamentals: result.fundamentals,
+      quoteCurrency: "USD", baseCurrency: "USD", toBase: (value) => value });
+    expect(stats.find((row) => row.label === "EV")?.value).toBe("—");
+  }
+});
+
+test("malformed optional retraction metadata cannot throw or erase unrelated fields", () => {
+  for (const unavailableFields of [42, ["revenue", "unknown"], null]) {
+    const malformed = { ...recorded, fundamentals: { ...recorded.fundamentals, unavailableFields } } as unknown as typeof recorded;
+    const value = mergeFinancials(mapCloudFinancials(malformed), recorded)!;
+    expect(value.fundamentals?.unavailableFields).toBeUndefined();
+    expect(value.fundamentals?.enterpriseValue).toBe(recorded.fundamentals!.enterpriseValue);
+    expect(value.fundamentals?.revenue).toBe(32_667_300_000);
+  }
+});
+
+test("enrichment preserves reporting currency for finite corrections but permits explicit retractions", () => {
+  const fresh = makeFinancials({ fundamentals: { financialCurrency: "USD", enterpriseValue: 662_293_158_034, enterpriseToRevenue: 16 } });
+  expect(mergeRefreshedFinancials(recorded, fresh).fundamentals).toEqual(recorded.fundamentals);
+  const unavailable = { ...fresh, fundamentals: { ...fresh.fundamentals, unavailableFields: [...fields] } };
+  expect(mergeRefreshedFinancials(recorded, unavailable).fundamentals?.enterpriseValue).toBeUndefined();
+  expect(mergeRefreshedFinancials(recorded, unavailable).fundamentals?.financialCurrency).toBe("EUR");
+});
+
+test("legacy cloud ASML valuation is retired and recovers with a marker-bearing write; other identities retain data", () => {
+  const persistence = new AppPersistence(createTempDbPath("asml-valuation-retractions"));
+  const cachePolicy = { staleMs: 60_000, expireMs: 120_000 };
+  const cases = [
+    { entityKey: "ASML", variantKey: "exchange=NASDAQ", sourceKey: "provider:gloomberb-cloud", quote: recorded.quote, retract: true },
+    { entityKey: "ASML:XNAS", variantKey: "", sourceKey: "provider:gloomberb-cloud", quote: undefined, retract: true },
+    { entityKey: "ASML", variantKey: "", sourceKey: "provider:gloomberb-cloud", quote: undefined, retract: true },
+    { entityKey: "ASML", variantKey: "exchange=AMS", sourceKey: "provider:gloomberb-cloud", quote: { ...recorded.quote!, listingExchangeName: "EURONEXT", currency: "EUR" }, retract: true },
+    { entityKey: "ASML", variantKey: "exchange=NASDAQ", sourceKey: "provider:gloomberb-cloud", quote: { ...recorded.quote!, listingExchangeName: "AMS", currency: "EUR" }, retract: true },
+    { entityKey: "ASML", variantKey: "exchange=AMS", sourceKey: "provider:gloomberb-cloud", quote: { ...recorded.quote!, symbol: "ASML:XNAS", listingExchangeName: "AMS", currency: "EUR" }, retract: true },
+    { entityKey: "ASML", variantKey: "exchange=AMS", sourceKey: "provider:gloomberb-cloud", quote: { ...recorded.quote!, listingExchangeName: "AMS", currency: "EUR" }, retract: false },
+    { entityKey: "ASML.AS", variantKey: "", sourceKey: "provider:gloomberb-cloud", quote: { ...recorded.quote!, symbol: "ASML.AS", listingExchangeName: "XAMS", currency: "EUR" }, retract: false },
+    { entityKey: "ASML", variantKey: "exchange=BMV", sourceKey: "provider:gloomberb-cloud", quote: { ...recorded.quote!, listingExchangeName: "BMV", currency: "MXN" }, retract: false },
+    { entityKey: "ASML", variantKey: "exchange=NASDAQ", sourceKey: "provider:yahoo", quote: { ...recorded.quote!, providerId: "yahoo" }, retract: false },
+    { entityKey: "TSM", variantKey: "exchange=NYSE", sourceKey: "provider:gloomberb-cloud", quote: { ...recorded.quote!, symbol: "TSM", listingExchangeName: "NYSE" }, retract: false },
+  ];
+  for (const entry of cases) {
+    const key = { namespace: "market", kind: "financials", entityKey: entry.entityKey, variantKey: entry.variantKey, sourceKey: entry.sourceKey };
+    const value = { ...recorded, quote: entry.quote };
+    persistence.resources.set(key, value, { cachePolicy, schemaVersion: 5 });
+    const read = () => listCachedResources(persistence.resources, "financials", key.entityKey, [key.variantKey], [key.sourceKey], true)[0]!;
+    const result = read(); const fundamentals = (result.value as typeof value).fundamentals as Fundamentals;
+    expect(result.stale).toBe(entry.retract);
+    expect(fundamentals.enterpriseValue).toBe(entry.retract ? undefined : recorded.fundamentals!.enterpriseValue);
+    expect(fundamentals.enterpriseToRevenue).toBe(entry.retract ? undefined : recorded.fundamentals!.enterpriseToRevenue);
+    expect((result.value as typeof value).annualStatements).toEqual(recorded.annualStatements);
+    expect(fundamentals.dividendYield).toBe(0.0054);
+    if (entry.retract) {
+      expect(fundamentals.unavailableFields).toEqual(fields);
+      const corrected = { ...value, fundamentals: { financialCurrency: "EUR", unavailableFields: [...fields] } };
+      cacheRouterResource(persistence.resources, "financials", key.entityKey, key.variantKey, key.sourceKey, corrected, cachePolicy);
+      expect(read().schemaVersion).toBe(6);
+      expect(read().stale).toBe(false);
+      expect(read().value).toEqual(corrected);
+    }
+  }
+  // Losing the old quote's freshness does not invalidate its stable listing identity.
+  const olderAmsterdam = { ...recorded, quote: { ...recorded.quote!, listingExchangeName: "AMS", currency: "EUR" } };
+  persistence.resources.set({ namespace: "market", kind: "financials", entityKey: "ASML", variantKey: "exchange=AMS", sourceKey: "provider:gloomberb-cloud" },
+    olderAmsterdam, { cachePolicy, schemaVersion: 3 });
+  const older = listCachedResources(persistence.resources, "financials", "ASML", ["exchange=AMS"], ["provider:gloomberb-cloud"], true)[0]!.value as typeof recorded;
+  expect(older.quote).toBeUndefined();
+  expect(older.fundamentals?.enterpriseValue).toBe(recorded.fundamentals!.enterpriseValue);
+  expect(older.fundamentals?.unavailableFields).toBeUndefined();
+  persistence.close();
+});
+
+test("a newly fetched retraction overrides an earlier finite cache during profile or history enrichment", async () => {
+  for (const profile of [undefined, { description: "ASML" }]) {
+    const persistence = new AppPersistence(createTempDbPath("fresh-retraction-over-cache"));
+    const cached = { ...recorded, profile };
+    cacheRouterResource(persistence.resources, "financials", "ASML", "exchange=NASDAQ", "provider:gloomberb-cloud", cached,
+      { staleMs: 60_000, expireMs: 120_000 });
+    let loads = 0;
+    const router = new AssetDataRouter({ ...fallbackProvider, id: "gloomberb-cloud",
+      async getTickerFinancials() {
+        loads++;
+        return makeFinancials({ quote: recorded.quote, fundamentals: { unavailableFields: [...fields] } });
+      },
+    }, [], persistence.resources);
+    const value = await router.getTickerFinancials("ASML", "NASDAQ");
+    expect(loads).toBe(1);
+    expect(value.fundamentals?.enterpriseValue).toBeUndefined();
+    expect(value.fundamentals?.enterpriseToRevenue).toBeUndefined();
+    expect(value.fundamentals?.dividendYield).toBe(0.0054);
+    expect(value.annualStatements).toEqual(recorded.annualStatements);
+    // The next authoritative finite correction must also replace the cached retraction.
+    const repaired = new AssetDataRouter({ ...fallbackProvider, id: "gloomberb-cloud",
+      async getTickerFinancials() {
+        return makeFinancials({ quote: recorded.quote, fundamentals: { enterpriseValue: 662_293_158_034, enterpriseToRevenue: 16 } });
+      },
+    }, [], persistence.resources);
+    const recovered = await repaired.getTickerFinancials("ASML", "NASDAQ");
+    expect(recovered.fundamentals?.enterpriseValue).toBe(662_293_158_034);
+    expect(recovered.fundamentals?.enterpriseToRevenue).toBe(16);
+    expect(recovered.fundamentals?.unavailableFields).toBeUndefined();
+    persistence.close();
+  }
+});
+
+test("provider enrichment preserves authoritative native and broker valuation contributions", async () => {
+  for (const sourceKey of ["provider:yahoo", "broker:ibkr:ibkr-work"]) {
+    const persistence = new AppPersistence(createTempDbPath("valuation-contribution-priority"));
+    const valid = { ...recorded, quote: { ...recorded.quote!, providerId: sourceKey.includes("broker") ? "ibkr" : "yahoo", dataSource: "live" as const, price: 1700 },
+      fundamentals: { financialCurrency: "EUR", enterpriseValue: 662_293_158_034 } };
+    cacheRouterResource(persistence.resources, "financials", "ASML", "exchange=NASDAQ", sourceKey, valid,
+      { staleMs: 60_000, expireMs: 120_000 });
+    let cloudLoads = 0;
+    const router = new AssetDataRouter(fallbackProvider, [{ ...fallbackProvider, id: "yahoo", priority: 1,
+      async getTickerFinancials() { throw new Error("Native provider temporarily unavailable"); },
+    }, { ...fallbackProvider, id: "gloomberb-cloud", priority: 100,
+      async getTickerFinancials() { cloudLoads++; return makeFinancials({ quote: recorded.quote, fundamentals: { unavailableFields: [...fields] } }); },
+    }], persistence.resources);
+    const broker: BrokerAdapter = { id: "ibkr", name: "IBKR", configSchema: [], async validate() { return true; }, async importPositions() { return []; } };
+    attachTestRegistry(router, { brokers: [["ibkr", broker]] });
+    setBrokerInstances(router, [brokerInstance()]);
+    const result = await router.getTickerFinancials("ASML", "NASDAQ", sourceKey.includes("broker")
+      ? { brokerId: "ibkr", brokerInstanceId: "ibkr-work" } : undefined);
+    expect(cloudLoads).toBe(1);
+    expect(result.fundamentals?.enterpriseValue).toBe(662_293_158_034);
+    expect(result.fundamentals?.unavailableFields).not.toContain("enterpriseValue");
+    if (sourceKey.includes("broker")) expect(result.quote?.price).toBe(1700);
+    persistence.close();
+  }
+});
+
+test("a quote-only primary cache cannot shield a fallback provider valuation from its own retraction", async () => {
+  const persistence = new AppPersistence(createTempDbPath("mixed-valuation-origin"));
+  const cachePolicy = { staleMs: 60_000, expireMs: 120_000 };
+  cacheRouterResource(persistence.resources, "financials", "ASML", "exchange=NASDAQ", "provider:yahoo",
+    makeFinancials({ quote: { ...recorded.quote!, providerId: "yahoo" } }), cachePolicy);
+  cacheRouterResource(persistence.resources, "financials", "ASML", "exchange=NASDAQ", "provider:gloomberb-cloud", recorded, cachePolicy);
+  const router = new AssetDataRouter(fallbackProvider, [{ ...fallbackProvider, id: "yahoo", priority: 1,
+    async getTickerFinancials() { throw new Error("Native snapshot unavailable"); },
+  }, { ...fallbackProvider, id: "gloomberb-cloud", priority: 100,
+    async getTickerFinancials() { return makeFinancials({ quote: recorded.quote, fundamentals: { unavailableFields: [...fields] } }); },
+  }], persistence.resources);
+  const result = await router.getTickerFinancials("ASML", "NASDAQ");
+  expect(result.fundamentals?.enterpriseValue).toBeUndefined();
+  expect(result.fundamentals?.enterpriseToRevenue).toBeUndefined();
+  expect(result.fundamentals?.unavailableFields).toEqual(fields);
+  expect(result.fundamentals?.revenue).toBe(32_667_300_000);
+  persistence.close();
+});

--- a/src/types/financials.ts
+++ b/src/types/financials.ts
@@ -95,6 +95,8 @@ export interface Fundamentals {
   pegRatio?: number;
   enterpriseValue?: number;
   enterpriseToRevenue?: number;
+  /** Explicit provider retractions; omitted fields alone remain eligible for fallback. */
+  unavailableFields?: Array<"enterpriseValue" | "enterpriseToRevenue">;
   operatingCashFlow?: number;
   freeCashFlow?: number;
   dividendYield?: number;

--- a/src/utils/fundamentals.ts
+++ b/src/utils/fundamentals.ts
@@ -1,0 +1,15 @@
+import type { Fundamentals } from "../types/financials";
+
+export const RETRACTABLE_VALUATION_FIELDS = ["enterpriseValue", "enterpriseToRevenue"] as const;
+
+/** A retraction survives serialization and overrides a contradictory cached number. */
+export function redactUnavailableFundamentals(value: Fundamentals | undefined): Fundamentals | undefined {
+  if (!value || value.unavailableFields === undefined) return value;
+  const unavailableFields = Array.isArray(value.unavailableFields)
+    ? RETRACTABLE_VALUATION_FIELDS.filter((field) => value.unavailableFields!.includes(field)) : [];
+  const result = { ...value };
+  if (unavailableFields.length) result.unavailableFields = unavailableFields;
+  else delete result.unavailableFields;
+  for (const field of unavailableFields) delete result[field];
+  return result;
+}


### PR DESCRIPTION
ASML's cloud providers reported an incorrect US enterprise value of $43.72T. After the backend withdrew EV and EV/revenue, cached financials could restore those numbers during fallback or profile/history enrichment. Honor the backend's explicit retraction markers and show the normal unavailable EV value.

The change retires affected legacy cloud ASML valuations, preserves corroborated foreign listings and native Yahoo values, and applies fresh valuation decisions to their original provider contribution before the existing broker/provider merge. Ordinary sparse responses retain fallback fields; later valid finite observations can clear a retraction. Currency guards and quote priorities remain in force. Backend PR239 is already deployed.

Validation: 103 focused tests / 479 assertions, browser build, controlled native 140/80 captures showing $43.72T before and unavailable EV after, plus local browser using actual deployed backend data. Final six-target typecheck and CI results are recorded with the PR checks.
