### PR TITLE
Fix option expiry research and short contract counts

### DIFF
--- a/src/plugins/builtin/options/view.test.tsx
+++ b/src/plugins/builtin/options/view.test.tsx
@@ -449,6 +449,7 @@ test("starts at a held contract's expiry and preserves a researcher-selected rol
   const provider = createTestDataProvider({
     getTickerFinancials: async () => makeFinancials(326.72),
     getOptionsChain: async (_ticker, _exchange, expirationDate) => {
+      if (_ticker === "MSFT") return new Promise<OptionsChain>(() => {});
       requestedExpirations.push(expirationDate);
       const expiry = expirationDate ?? expirationDates[0]!;
       const chain = makeChain([330 + expirationDates.indexOf(expiry) * 10], 340, expirationDates);
@@ -465,8 +466,14 @@ test("starts at a held contract's expiry and preserves a researcher-selected rol
     { portfolio: "fixture", shares: -1, avgCost: 5.52, broker: "manual", multiplier: 100 },
     { portfolio: "fixture", shares: 1, side: "long", avgCost: 5.52, broker: "manual", multiplier: 100 },
   ];
+  let selectTicker: (ticker: TickerRecord) => void = () => {};
+  function SwitchingHarness() {
+    const [selected, setSelected] = useState(ticker);
+    selectTicker = setSelected;
+    return <OptionsHarness ticker={selected} />;
+  }
   await act(async () => {
-    testSetup = await testRender(<OptionsHarness ticker={ticker} />, { width: 124, height: 16 });
+    testSetup = await testRender(<SwitchingHarness />, { width: 124, height: 16 });
   });
   await renderSettled();
   expect(requestedExpirations.at(-1)).toBe(expirationDates[1]);
@@ -488,6 +495,15 @@ test("starts at a held contract's expiry and preserves a researcher-selected rol
   await act(async () => { testSetup!.mockInput.pressArrow("left"); });
   await renderSettled();
   expect(testSetup!.captureCharFrame()).toContain("340");
+
+  // Returning before another instrument's catalogue loads must initialize the
+  // holding again, rather than retain that intermediate target's index zero.
+  await act(async () => { selectTicker(makeTicker("MSFT")); });
+  await renderSettled();
+  expect(testSetup!.captureCharFrame()).toContain("Loading options chain");
+  await act(async () => { selectTicker(ticker); });
+  await renderSettled();
+  expect(testSetup!.captureCharFrame()).toMatch(/34\.05\s+34\s+.*340/);
 });
 
 test("keeps the selected chain visible when its refresh fails", async () => {

--- a/src/plugins/builtin/options/view.test.tsx
+++ b/src/plugins/builtin/options/view.test.tsx
@@ -442,6 +442,54 @@ test("clicking the option table focuses expiration tabs for arrow navigation", a
   expect(requestedExpirations).toContain(expirationDates[1]);
 });
 
+test("starts at a held contract's expiry and preserves a researcher-selected roll expiry", async () => {
+  const expirationDates = [Date.UTC(2026, 8, 18), Date.UTC(2026, 9, 16), Date.UTC(2026, 10, 20)]
+    .map((ms) => ms / 1000);
+  const requestedExpirations: Array<number | undefined> = [];
+  const provider = createTestDataProvider({
+    getTickerFinancials: async () => makeFinancials(326.72),
+    getOptionsChain: async (_ticker, _exchange, expirationDate) => {
+      requestedExpirations.push(expirationDate);
+      const expiry = expirationDate ?? expirationDates[0]!;
+      const chain = makeChain([330 + expirationDates.indexOf(expiry) * 10], 340, expirationDates);
+      for (const contract of [...chain.calls, ...chain.puts]) contract.expiration = expiry;
+      return chain;
+    },
+  });
+  const coordinator = new MarketDataCoordinator(provider);
+  setSharedMarketDataCoordinator(coordinator);
+  const ticker = makeTicker("AAPL 261016C00340000");
+  ticker.metadata.assetCategory = "OPT";
+  ticker.metadata.positions = [
+    { portfolio: "fixture", shares: 2, side: "short", avgCost: 5.52, broker: "manual", multiplier: 100 },
+    { portfolio: "fixture", shares: -1, avgCost: 5.52, broker: "manual", multiplier: 100 },
+    { portfolio: "fixture", shares: 1, side: "long", avgCost: 5.52, broker: "manual", multiplier: 100 },
+  ];
+  await act(async () => {
+    testSetup = await testRender(<OptionsHarness ticker={ticker} />, { width: 124, height: 16 });
+  });
+  await renderSettled();
+  expect(requestedExpirations.at(-1)).toBe(expirationDates[1]);
+  expect(testSetup!.captureCharFrame()).toContain("Position: -2 call contracts (SHORT)");
+
+  await act(async () => { testSetup!.mockInput.pressEnter(); });
+  await renderSettled();
+  await act(async () => { testSetup!.mockInput.pressArrow("right"); });
+  await renderSettled();
+  expect(requestedExpirations.at(-1)).toBe(expirationDates[2]);
+  expect(testSetup!.captureCharFrame()).toContain("350");
+
+  // A refreshed expiry catalogue must not undo the user's chosen roll date.
+  await act(async () => {
+    await coordinator.loadOptions({ instrument: { symbol: "AAPL", exchange: "" } }, { forceRefresh: true });
+  });
+  await renderSettled();
+  expect(testSetup!.captureCharFrame()).toContain("350");
+  await act(async () => { testSetup!.mockInput.pressArrow("left"); });
+  await renderSettled();
+  expect(testSetup!.captureCharFrame()).toContain("340");
+});
+
 test("keeps the selected chain visible when its refresh fails", async () => {
   let failRefresh = false;
   const provider = createTestDataProvider({

--- a/src/plugins/builtin/options/view.tsx
+++ b/src/plugins/builtin/options/view.tsx
@@ -197,6 +197,7 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
   }, [expirationCount]);
 
   useEffect(() => {
+    initializedExpiryTargetRef.current = null;
     userSelectedStrikeRef.current = false;
     setScrollToIndexAlign("nearest");
     setInteractive(false);

--- a/src/plugins/builtin/options/view.tsx
+++ b/src/plugins/builtin/options/view.tsx
@@ -44,6 +44,7 @@ import {
 } from "./live-quotes";
 import { useOptionsAccessFooter } from "./footer";
 import { useLiveStreamingSetting } from "../shared/live-streaming";
+import { signedPositionDirection } from "../portfolio-list/position-metrics";
 
 type SummaryMetric = { label: string; value: string };
 
@@ -102,12 +103,14 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
   } | null>(null);
   const [interactive, setInteractive] = useState(false);
   const userSelectedStrikeRef = useRef(false);
+  const initializedExpiryTargetRef = useRef<string | null>(null);
   const onCaptureRef = useRef(onCapture);
   const target = resolveOptionsTarget(ticker);
   const isOpt = target?.isOptionTicker ?? false;
   const parsed = target?.parsedOption ?? null;
   const effectiveTicker = target?.effectiveTicker ?? "";
   const effectiveExchange = target?.effectiveExchange ?? "";
+  const selectionTargetKey = `${ticker?.metadata.ticker ?? ""}|${target?.cacheKey ?? ""}`;
   const underlyingQuoteTarget = isOpt
     ? effectiveTicker ? { symbol: effectiveTicker, exchange: effectiveExchange, route: "provider" as const } : null
     : quoteSubscriptionTargetFromTicker(ticker, effectiveTicker, "provider");
@@ -155,6 +158,13 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     ?? (selectedExpiration == null || initialChainExpiration === selectedExpiration ? initialChain : null);
   const strikesLoading = strikeChain === null;
   const expirationCount = chain?.expirationDates.length ?? 0;
+  // Keep the date strip stable while a mouse press focuses this pane. A new
+  // tab list asks the web host to reveal the active tab and can move the date
+  // being clicked before mouse-up, cancelling selection of an offscreen expiry.
+  const expirationTabs = useMemo(() => (chain?.expirationDates ?? []).map((ts, i) => ({
+    label: formatExpDate(ts),
+    value: String(i),
+  })), [chain?.expirationDates]);
   const loading = (initialChainEntry?.phase === "loading" || initialChainEntry?.phase === "refreshing") && !chain
     || (expirationChainEntry?.phase === "loading" || expirationChainEntry?.phase === "refreshing");
   // Refresh failures keep a ready entry with last-good data and an error.
@@ -194,16 +204,19 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     setExpIdx(0);
     setStrikeIdx(0);
     setCalcSide(null);
-  }, [effectiveTicker]);
+  }, [selectionTargetKey]);
 
   useEffect(() => {
-    if (!parsed || !initialChain || initialChain.expirationDates.length === 0) return;
+    if (initializedExpiryTargetRef.current === selectionTargetKey) return;
+    if (!initialChain || initialChain.expirationDates.length === 0) return;
+    initializedExpiryTargetRef.current = selectionTargetKey;
+    if (!parsed) return;
+    // The holding chooses the initial expiry only. Reapplying it after every
+    // selection or catalogue refresh prevents researching another expiry.
     const bestExpIdx = initialChain.expirationDates.reduce((best, ts, i) =>
       Math.abs(ts - parsed.expTs) < Math.abs(initialChain.expirationDates[best]! - parsed.expTs) ? i : best, 0);
-    if (bestExpIdx !== expIdx) {
-      setExpIdx(bestExpIdx);
-    }
-  }, [expIdx, initialChain, parsed]);
+    setExpIdx(bestExpIdx);
+  }, [initialChain, parsed, selectionTargetKey]);
 
   useEffect(() => {
     userSelectedStrikeRef.current = false;
@@ -451,8 +464,8 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     return <EmptyState title={`No options available for ${effectiveTicker}.`} />;
   }
 
-  const posShares = isOpt && parsed
-    ? ticker.metadata.positions.reduce((sum, p) => sum + p.shares, 0)
+  const positionContracts = isOpt && parsed
+    ? ticker.metadata.positions.reduce((sum, p) => sum + Math.abs(p.shares) * signedPositionDirection(p), 0)
     : 0;
   const expirationTabsWidth = Math.max(width - 9 - (loading ? 2 : 0), 8);
   const summaryRowCount = height >= 10 ? 2 : height >= 7 ? 1 : 0;
@@ -471,10 +484,7 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
         <Text fg={colors.textDim}>Exp:</Text>
         <Box width={expirationTabsWidth} height={1} overflow="hidden">
           <Tabs
-            tabs={chain.expirationDates.map((ts, i) => ({
-              label: formatExpDate(ts),
-              value: String(i),
-            }))}
+            tabs={expirationTabs}
             activeValue={String(expIdx)}
             onSelect={(value) => {
               enterInteractive();
@@ -494,7 +504,7 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
       {isOpt && parsed && (
         <Box height={1}>
           <Text fg={colors.textBright}>
-            {`Position: ${posShares} ${parsed.side === "C" ? "call" : "put"} contract${posShares !== 1 ? "s" : ""} @ $${parsed.strike}`}
+            {`Position: ${positionContracts} ${parsed.side === "C" ? "call" : "put"} contract${Math.abs(positionContracts) !== 1 ? "s" : ""}${positionContracts < 0 ? " (SHORT)" : ""} @ $${parsed.strike}`}
           </Text>
         </Box>
       )}

--- a/src/utils/options.test.ts
+++ b/src/utils/options.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test";
+
+test("expiry labels preserve the contract date across investor time zones", () => {
+  const modulePath = new URL("./options.ts", import.meta.url).pathname;
+  // Separate processes exercise the host Date implementation without changing
+  // the timezone used by other suites. Include DST and a year boundary.
+  for (const timezone of ["America/New_York", "America/Los_Angeles", "Asia/Tokyo"]) {
+    const result = Bun.spawnSync([process.execPath, "-e", `
+      import { formatExpDate } from ${JSON.stringify(modulePath)};
+      console.log(JSON.stringify([
+        Date.UTC(2026, 8, 11), Date.UTC(2026, 9, 16),
+        Date.UTC(2026, 10, 20), Date.UTC(2027, 0, 1),
+      ].map(ms => formatExpDate(ms / 1000))));
+    `], { env: { ...process.env, TZ: timezone }, stdout: "pipe", stderr: "pipe" });
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.toString())).toEqual([
+      "Sep 11 '26", "Oct 16 '26", "Nov 20 '26", "Jan 1 '27",
+    ]);
+  }
+});

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -3,12 +3,12 @@ import type { TickerRecord } from "../types/ticker";
 
 const MONTH_ABBREV = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-/** Format a unix timestamp (seconds) as "Mon DD 'YY" */
+/** Chain timestamps encode an expiry calendar date in UTC, not a local instant. */
 export function formatExpDate(ts: number): string {
   const d = new Date(ts * 1000);
-  const month = MONTH_ABBREV[d.getMonth()] || String(d.getMonth() + 1);
-  const yy = String(d.getFullYear()).slice(2);
-  return `${month} ${d.getDate()} '${yy}`;
+  const month = MONTH_ABBREV[d.getUTCMonth()] || String(d.getUTCMonth() + 1);
+  const yy = String(d.getUTCFullYear()).slice(2);
+  return `${month} ${d.getUTCDate()} '${yy}`;
 }
 
 /**


### PR DESCRIPTION
Option expiry labels appeared a day early for users in American time zones, and opening a held option kept forcing the chain back to that contract's expiry when researching a roll. Offscreen expiry clicks could also be cancelled when focusing the pane moved the date strip. Preserve UTC calendar dates, initialize the held expiry once per instrument, and keep the date strip stable through focus changes.

The options position row now uses the shared position-direction rules, so positive broker quantities marked short and signed quantities produce the correct net contract count and an explicit SHORT label.

Validation: 39 focused tests / 167 assertions, including time-zone/year-boundary labels, expiry navigation and catalogue refresh, and mixed long/short quantities. Actual native app before/after checks used isolated research holdings with live options API responses; browser checks compared actual production with the local build. Protective-put, covered-call, and collar expiry arithmetic was independently reconciled to calculator interactions. Historical last trades were labelled as such; no real holdings or orders were written.
