### PR TITLE
Align price comparisons to shared observation dates

### DIFF
--- a/docs/price-comparisons.md
+++ b/docs/price-comparisons.md
@@ -1,0 +1,11 @@
+# Price comparisons
+
+Normalized closing-price comparisons use the earliest and latest exact source timestamps shared by every visible leg in the selected window. A valid start requires a finite, nonzero price for every leg; a finite zero endpoint remains valid. There must be two shared dates. Missing observations are not carried, interpolated or rounded between exchanges.
+
+This applies to two or more visible closing-price/OHLCV series on one panel, with the same percent/index-100 transform and requested period. Raw values, economic/capability series, mixed transformations/periods and observation-count-limited charts retain their existing meaning. Studies continue to calculate from raw buffered data; price studies use the comparison baseline for presentation.
+
+Compared curves and legends stop at the shared endpoint. Streamed or financial-snapshot quotes supply metadata but cannot append to or rewrite a comparison's historical bars. This also prevents a one-leg quote from changing a weekly bar while the other leg remains historical. The source history cache is unchanged.
+
+The chart body, headless report and share warnings disclose the source dates and price-return basis. Each leg stays in its own listing currency; cash distributions and investor-currency conversion are not added. Source bar dates are not a claim that different exchanges close simultaneously, nor proof of complete corporate-action coverage. Weekly/monthly dates identify the provider's bars, which can represent a partial period.
+
+Example: recorded JEPQ/QQQ daily history through September 10, 2026 starts in May 2022 versus September 2021. Their first shared observation is May 4, 2022. Using that date gives closing-price changes of 16.06% and 115.02%; independently starting QQQ in 2021 gives 88.32% over a different period. JEPQ's issuer reports separately calculated reinvested total returns in its [factsheet](https://am.jpmorgan.com/content/dam/jpm-am-aem/americas/us/en/literature/fact-sheet/etfs/FS-JEPQ.PDF).

--- a/src/plugins/builtin/chart-composer/headless-schema.ts
+++ b/src/plugins/builtin/chart-composer/headless-schema.ts
@@ -134,7 +134,7 @@ export const paneSchemas = {
     discovery: {
       id: "price-comparison",
       aliases: ["stock comparison", "price performance comparison", "returns comparison", "compare stock prices"],
-      limitations: ["Compares market prices or percentage returns, never company financial statements."],
+      limitations: ["Compares closing-price changes in each listing's currency over shared observation dates. Cash distributions and FX conversion are excluded; these are not reinvested total returns."],
       screenshotReadiness: "ready",
     },
   },

--- a/src/plugins/builtin/chart-composer/headless.ts
+++ b/src/plugins/builtin/chart-composer/headless.ts
@@ -112,7 +112,8 @@ export async function loadChartPaneModel(
     metadata: {
       viewport: spec.viewport, panels: spec.panels, warnings: chart.warnings,
       ...(periodCoverage.length ? { periodCoverage } : {}),
-      notices: chart.warnings.filter((warning) => warning === FINANCIAL_VINTAGE_NOTICE),
+      notices: chart.warnings.filter((warning) => warning === FINANCIAL_VINTAGE_NOTICE || warning === chart.priceComparison?.notice),
+      priceComparison: chart.priceComparison ?? null,
       summaries: chart.series.map((series) => ({ id: series.id, ...summarizeResolvedSeries(series) })),
     },
   };

--- a/src/plugins/builtin/chart-composer/index.tsx
+++ b/src/plugins/builtin/chart-composer/index.tsx
@@ -291,7 +291,7 @@ const chartComposerTemplates: PaneTemplateDef[] = [
     id: "comparison-chart-pane",
     prefix: "CMP",
     label: "Comparison Chart",
-    description: "Compare percentage performance for two or more tickers.",
+    description: "Compare price returns over shared observation dates for two or more tickers.",
     argKind: "ticker-list",
     minimumSymbols: 2,
     build: buildComparisonChartPreset,

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -557,7 +557,9 @@ function ChartComposerSurface({
   const showVintageNotice = spec.series.some((entry) => entry.visible !== false
     && entry.source.kind === "security" && isFundamentalFieldId(entry.source.fieldId));
   const vintageNoticeHeight = showVintageNotice ? wrapTextLines(FINANCIAL_VINTAGE_NOTICE, Math.max(8, width - 2)).length : 0;
-  const statusWarning = resolution.warnings.find((warning) => warning !== FINANCIAL_VINTAGE_NOTICE);
+  const comparisonNotice = resolution.priceComparison?.notice;
+  const comparisonNoticeHeight = comparisonNotice ? wrapTextLines(comparisonNotice, Math.max(8, width - 2)).length : 0;
+  const statusWarning = resolution.warnings.find((warning) => warning !== FINANCIAL_VINTAGE_NOTICE && warning !== comparisonNotice);
 
   usePaneFooter(footerId, () => ({
     info: [
@@ -678,6 +680,9 @@ function ChartComposerSurface({
       {showVintageNotice && <Box paddingX={1} flexShrink={0}>
         <Prose text={FINANCIAL_VINTAGE_NOTICE} width={Math.max(8, width - 2)} color={colors.textDim} />
       </Box>}
+      {comparisonNotice && <Box paddingX={1} flexShrink={0}>
+        <Prose text={comparisonNotice} width={Math.max(8, width - 2)} color={colors.textDim} />
+      </Box>}
       <Box flexGrow={1} minHeight={4}>
         <CompositeChart
           series={plottedSeries}
@@ -687,7 +692,7 @@ function ChartComposerSurface({
           viewport={viewport}
           viewportResetKey={authoredViewportKey}
           width={Math.max(1, width)}
-          height={Math.max(4, height - 1 - vintageNoticeHeight)}
+          height={Math.max(4, height - 1 - vintageNoticeHeight - comparisonNoticeHeight)}
           focused={focused}
           interactive={surfacePointerInteractive}
           allowHistoricalBackfill

--- a/src/plugins/builtin/chart-composer/semantic.ts
+++ b/src/plugins/builtin/chart-composer/semantic.ts
@@ -84,6 +84,7 @@ export function chartComposerSemanticMetadata(
     loading: resolution.loading,
     errors: resolution.errors,
     warnings: resolution.warnings,
+    priceComparison: resolution.priceComparison ?? null,
     resolutionSupport: resolution.resolutionSupport ?? null,
     viewport: viewportEvidence(runtimeViewport ?? resolution.viewport),
     authoredViewport: viewportEvidence(resolution.viewport),

--- a/src/time-series/price-comparison.test.ts
+++ b/src/time-series/price-comparison.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { createTestDataProvider } from "../test-support/data-provider";
+import type { PricePoint, Quote } from "../types/financials";
+import { chartQuoteOverrideKeyForSource } from "./live-quotes";
+import { resolvePriceComparison } from "./price-comparison";
+import { ChartResolveCache, resolveChartSpecData, seedChartResolutionResult } from "./resolve";
+import { summarizeResolvedSeries } from "./reporting";
+import { CHART_SPEC_VERSION, type ChartSpec } from "./types";
+
+const date = (day: string) => new Date(day);
+const rows = (values: [string, number][]): PricePoint[] => values.map(([day, close]) => ({ date: date(day), close }));
+const spec = (resolution: "1d" | "1wk" = "1d"): ChartSpec => ({
+  version: CHART_SPEC_VERSION,
+  viewport: { range: "5Y", resolution, dateWindow: { start: "2021-01-01", end: "2026-09-10" } },
+  panels: [{ id: "main" }], studies: [],
+  series: ["OLDER", "NEWER"].map((symbol) => ({
+    id: symbol, source: { kind: "security", instrument: { symbol, exchange: "NASDAQ" }, fieldId: "market.close" },
+    style: "line", transform: "percent", axis: "left", panelId: "main", interpolation: "none",
+  })),
+});
+const histories = {
+  OLDER: rows([["2021-01-04", 100], ["2022-05-02", 80], ["2022-05-09", 90], ["2026-09-07", 180], ["2026-09-10", 200]]),
+  NEWER: rows([["2022-05-02", 50], ["2022-05-09", 55], ["2026-09-07", 60]]),
+};
+function sources(history: Record<string, PricePoint[]> = histories) {
+  const getHistory = async (symbol: string) => history[symbol] ?? [];
+  return {
+    now: date("2026-09-10T18:00:00Z"),
+    dataProvider: createTestDataProvider({
+      getQuote: async (symbol) => ({ symbol, currency: "USD", instrumentType: "ETF", price: 999, change: 0, changePercent: 50, lastUpdated: Date.parse("2026-09-10T18:00:00Z") }),
+      getTickerFinancials: async (symbol) => ({ annualStatements: [], quarterlyStatements: [], priceHistory: history[symbol] ?? [] }),
+      getDetailedPriceHistory: getHistory,
+      getPriceHistory: getHistory,
+      getPriceHistoryForResolution: getHistory,
+    }),
+    loadFredSeries: async () => ({ data: { observations: [], info: null }, fetchedAt: 0, stale: false, source: "network" as const }),
+  };
+}
+
+describe("normalized market price comparison", () => {
+  for (const resolution of ["1d", "1wk"] as const) {
+    test(`${resolution} uses shared inception and endpoint in chart, buffered rendering and raw report`, async () => {
+      const result = await resolveChartSpecData(spec(resolution), sources());
+      expect(result.priceComparison).toMatchObject({ start: Date.parse("2022-05-02"), end: Date.parse("2026-09-07") });
+      for (const collection of [result.series, result.bufferedSeries!, result.legendSeries!]) {
+        expect(collection.map((s) => s.points[0]?.value)).toEqual([0, 0]);
+        expect(collection.map((s) => s.points.at(-1)?.value)).toEqual([125, 20]);
+        expect(collection.map((s) => s.latestChangePercent)).toEqual([undefined, undefined]);
+      }
+      expect(summarizeResolvedSeries(result.series[0]!)).toMatchObject({
+        startDate: "2022-05-02T00:00:00.000Z", endDate: "2026-09-07T00:00:00.000Z", startValue: 80, endValue: 180, return: 1.25,
+      });
+      expect(histories.OLDER[0]?.close).toBe(100);
+      const seeded = seedChartResolutionResult(spec(resolution), new Map(spec().series.map((s) => [chartQuoteOverrideKeyForSource(s.source), histories[s.id as keyof typeof histories]])));
+      expect(seeded?.series.map((s) => s.points.at(-1)?.value)).toEqual([125, 20]);
+      expect(seeded?.priceComparison?.start).toBe(result.priceComparison?.start);
+    });
+  }
+
+  test("missing holiday dates use an exact overlap without carrying or rounding observations", async () => {
+    const result = await resolveChartSpecData(spec(), sources({
+      OLDER: rows([["2026-09-04", 10], ["2026-09-07", 15], ["2026-09-08", 20], ["2026-09-09", 30], ["2026-09-10", 40]]),
+      NEWER: rows([["2026-09-08", 100], ["2026-09-10", 300]]),
+    }));
+    expect(result.priceComparison).toMatchObject({ start: Date.parse("2026-09-08"), end: Date.parse("2026-09-10") });
+    expect(result.series.map((s) => s.points.at(-1)?.value)).toEqual([100, 200]);
+    expect(result.series.map((s) => s.points.length)).toEqual([3, 2]);
+    const shifted = result.series.map((s, index) => ({ ...s, points: s.points.map((p) => ({ ...p, date: new Date(p.date.getTime() + index * 1_000) })) }));
+    expect(resolvePriceComparison(spec(), shifted, { start: null, end: null })?.start).toBeNull();
+  });
+
+  test("one-leg streamed and snapshot quotes cannot rewrite a shared weekly source bar", async () => {
+    const compared = spec("1wk");
+    const inputs = sources();
+    const quote: Quote = { symbol: "NEWER", currency: "USD", price: 900, change: 0, changePercent: 99, lastUpdated: inputs.now.getTime(), marketState: "REGULAR" };
+    inputs.dataProvider.getTickerFinancials = async (symbol) => ({ annualStatements: [], quarterlyStatements: [], priceHistory: histories[symbol as keyof typeof histories], quote });
+    // Bare listings also load financials with a snapshot quote.
+    for (const s of compared.series) if (s.source.kind === "security") delete s.source.instrument.exchange;
+    const result = await resolveChartSpecData(compared, { ...inputs, quoteOverrides: new Map([[chartQuoteOverrideKeyForSource(compared.series[1]!.source), quote]]) });
+    expect(result.series.map((s) => s.points.at(-1)?.value)).toEqual([125, 20]);
+    expect(result.series.map((s) => s.points.at(-1)?.rawValue)).toEqual([180, 60]);
+  });
+
+  test("missing, disjoint and single-overlap history leave comparison unavailable, then recover from the source", async () => {
+    for (const newer of [[], rows([["2026-09-10", 60]]), rows([["2025-01-02", 60], ["2025-01-03", 65]])]) {
+      const result = await resolveChartSpecData(spec(), sources({ ...histories, NEWER: newer }));
+      expect(result.priceComparison).toMatchObject({ start: null, end: null });
+      expect(result.series.every((s) => s.points.length === 0)).toBe(true);
+      expect(result.bufferedSeries?.every((s) => s.points.length === 0)).toBe(true);
+    }
+    const partialSeed = seedChartResolutionResult(spec(), new Map([[chartQuoteOverrideKeyForSource(spec().series[0]!.source), histories.OLDER]]));
+    expect(partialSeed?.series[0]?.points).toEqual([]);
+    const recovered = await resolveChartSpecData(spec(), sources());
+    expect(recovered.series[0]?.points.at(-1)?.value).toBe(125);
+  });
+
+  test("a legitimate zero endpoint is -100%; a zero baseline is never divided", async () => {
+    const result = await resolveChartSpecData(spec(), sources({
+      OLDER: rows([["2026-09-07", 0], ["2026-09-08", 10], ["2026-09-10", 0]]),
+      NEWER: rows([["2026-09-07", 50], ["2026-09-08", 100], ["2026-09-10", 200]]),
+    }));
+    expect(result.priceComparison?.start).toBe(Date.parse("2026-09-08"));
+    expect(result.series.map((s) => s.points.at(-1)?.value)).toEqual([-100, 100]);
+  });
+
+  test("index100 shares dates while price studies still calculate from raw buffered observations", async () => {
+    const indexed = spec();
+    indexed.series.forEach((s) => { s.transform = "index100"; });
+    indexed.studies = [
+      { id: "sma", kind: "sma", inputSeriesIds: ["OLDER"], parameters: { period: 2 }, panelId: "main", axis: "left" },
+      { id: "ratio", kind: "ratio", inputSeriesIds: ["OLDER", "NEWER"], parameters: {}, panelId: "ratio", axis: "left" },
+    ];
+    const result = await resolveChartSpecData(indexed, sources());
+    expect(result.series.slice(0, 2).map((s) => s.points.at(-1)?.value)).toEqual([225, 120]);
+    const sma = result.series.find((s) => s.id === "sma")!;
+    const firstCommon = sma.points.find((p) => p.date.getTime() === Date.parse("2022-05-02"))!;
+    expect(firstCommon.rawValue).toBe(90);
+    expect(firstCommon.value).toBe(112.5);
+    expect(result.series.find((s) => s.id === "ratio")?.points.at(-1)?.value).toBe(200 / 60);
+  });
+
+  test("explicit/panned windows recompute shared baselines while raw, mixed and period-limited charts retain their meaning", async () => {
+    const selected = spec();
+    selected.viewport.dateWindow!.start = "2022-05-09";
+    const cache = new ChartResolveCache();
+    const result = await resolveChartSpecData(selected, sources(), cache);
+    expect(result.series.map((s) => s.points.at(-1)?.value)).toEqual([100, 100 / 11]);
+    const panned = await resolveChartSpecData(selected, sources(), cache, { requestViewport: { start: date("2026-09-07"), end: date("2026-09-10") } });
+    expect(panned.priceComparison?.start).toBeNull();
+    const raw = spec();
+    raw.series.forEach((s) => { s.transform = "raw"; });
+    const rawResult = await resolveChartSpecData(raw, sources());
+    expect(rawResult.priceComparison).toBeUndefined();
+    expect(rawResult.series.map((s) => s.points[0]?.value)).toEqual([100, 50]);
+    expect(rawResult.series.map((s) => s.points.at(-1)?.value)).toEqual([200, 60]);
+    const mixed = spec();
+    mixed.series[1]!.source = { kind: "economic", provider: "fred", seriesId: "GDP" };
+    expect(resolvePriceComparison(mixed, rawResult.series, { start: null, end: null })).toBeNull();
+    const limited = spec(); limited.viewport.maxPoints = 2;
+    expect(resolvePriceComparison(limited, rawResult.series, { start: null, end: null })).toBeNull();
+  });
+});

--- a/src/time-series/price-comparison.ts
+++ b/src/time-series/price-comparison.ts
@@ -1,0 +1,79 @@
+import { scalarPointValue } from "./alignment";
+import { getTimeSeriesField } from "./field-catalog";
+import type { ChartSpec, ResolvedSeries } from "./types";
+
+export const PRICE_COMPARISON_BASIS = "Price returns in each listing's currency; cash distributions and FX conversion excluded.";
+
+export interface PriceComparison {
+  seriesIds: string[];
+  /** Exact source observation timestamps, never filled or rounded across markets. */
+  start: number | null;
+  end: number | null;
+  notice: string;
+}
+
+function displayDate(time: number): string {
+  const iso = new Date(time).toISOString();
+  return iso.endsWith("T00:00:00.000Z") ? iso.slice(0, 10) : iso.replace("T", " ").replace(".000Z", " UTC");
+}
+
+/** Comparable normalized closing-price legs share observed endpoints. Other chart meanings are unchanged. */
+export function priceComparisonSeriesIds(spec: ChartSpec): string[] | null {
+  if (spec.viewport.maxPoints !== undefined) return null;
+  const visible = spec.series.filter((entry) => entry.visible !== false);
+  if (visible.length < 2 || !visible.every((entry) => {
+    const field = entry.source.kind === "security" ? getTimeSeriesField(entry.source.fieldId)?.id : null;
+    return (field === "market.close" || field === "market.ohlcv")
+      && (entry.transform === "percent" || entry.transform === "index100")
+      && entry.transform === visible[0]!.transform
+      && entry.panelId === visible[0]!.panelId
+      && entry.source.kind === "security" && visible[0]!.source.kind === "security"
+      && (entry.source.period ?? "auto") === (visible[0]!.source.period ?? "auto");
+  })) return null;
+  return visible.map((entry) => entry.id);
+}
+
+export function resolvePriceComparison(
+  spec: ChartSpec,
+  series: readonly ResolvedSeries[],
+  bounds: { start: number | null; end: number | null },
+): PriceComparison | null {
+  const seriesIds = priceComparisonSeriesIds(spec);
+  if (!seriesIds) return null;
+  const byId = new Map(series.map((entry) => [entry.id, entry]));
+  const timestamps = seriesIds.map((id) => new Set((byId.get(id)?.points ?? []).flatMap((point) => {
+    const time = point.date.getTime();
+    const value = scalarPointValue(point);
+    return Number.isFinite(time) && value !== null
+      && (bounds.start === null || time >= bounds.start)
+      && (bounds.end === null || time <= bounds.end) ? [time] : [];
+  })));
+  const shared = [...timestamps[0]!].filter((time) => timestamps.every((times) => times.has(time))).sort((a, b) => a - b);
+  const start = shared.find((time) => seriesIds.every((id) => {
+    const point = byId.get(id)?.points.find((point) => point.date.getTime() === time);
+    return point && scalarPointValue(point) !== 0;
+  }));
+  const end = shared.at(-1);
+  if (start === undefined || end === undefined || start >= end) return {
+    seriesIds, start: null, end: null,
+    notice: `${PRICE_COMPARISON_BASIS} Comparison unavailable: need two shared dates and a nonzero baseline.`,
+  };
+  return {
+    seriesIds, start, end,
+    notice: `${PRICE_COMPARISON_BASIS} Shared observations: ${displayDate(start)} to ${displayDate(end)}.`,
+  };
+}
+
+/** Clip only compared legs; raw observations and study inputs stay available in the source cache. */
+export function clipPriceComparison(series: ResolvedSeries, comparison: PriceComparison | null): ResolvedSeries {
+  if (!comparison?.seriesIds.includes(series.id)) return series;
+  const { start, end } = comparison;
+  return {
+    ...series,
+    // The legend must describe the compared endpoint, not a newer one-leg quote.
+    latestChangePercent: undefined,
+    points: start === null || end === null ? [] : series.points.filter((point) => (
+      point.date.getTime() >= start && point.date.getTime() <= end
+    )),
+  };
+}

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -45,6 +45,7 @@ import {
 } from "./studies";
 import { applyResolvedSeriesTransform } from "./transforms";
 import { clipSeriesToWindow } from "./alignment";
+import { clipPriceComparison, priceComparisonSeriesIds, resolvePriceComparison } from "./price-comparison";
 import { chartQuoteOverrideKeyForSource } from "./live-quotes";
 import { chartSeriesSourceKey } from "../capabilities/chart-series";
 import { resolutionForExplicitMarketPeriods } from "./market-resolution";
@@ -395,22 +396,26 @@ export function seedChartResolutionResult(
     for (const point of entry.points) latest = Math.max(latest, point.date.getTime());
   }
   const bounds = requestedBounds(spec, referenceNow ?? new Date(latest));
-  const baseSeries = series.map((entry) => prepareBaseSeriesForStudies(entry, bounds));
+  const priceComparison = resolvePriceComparison(spec, series, bounds);
+  const comparisonBounds = priceComparison && priceComparison.start !== null
+    ? priceComparison : bounds;
+  const baseSeries = series.map((entry) => prepareBaseSeriesForStudies(entry, comparisonBounds));
   // Calculate studies from raw buffered inputs, then use the same presentation
   // and visible-window rules as the network result.
   const studies = resolveStudies(series, spec.studies);
   const bufferedSeries = [
     ...baseSeries,
-    ...applyStudyPresentationTransforms(studies.series, spec.studies, series, bounds),
-  ];
+    ...applyStudyPresentationTransforms(studies.series, spec.studies, series, comparisonBounds),
+  ].map((entry) => clipPriceComparison(entry, priceComparison));
   const visible = bufferedSeries.map((entry) => {
     const clipped = bounds.start !== null && bounds.end !== null
       ? clipSeriesToWindow(entry, new Date(bounds.start), new Date(bounds.end))
       : { ...entry, points: filterPoints(entry.points, bounds) };
-    return limitSeriesObservations(spec, clipped);
+    return clipPriceComparison(limitSeriesObservations(spec, clipped), priceComparison);
   });
   return {
     series: visible,
+    ...(priceComparison ? { priceComparison } : {}),
     legendSeries: visible,
     ...(spec.viewport.maxPoints === undefined ? { bufferedSeries } : {}),
     ...((explicitBounds(spec) !== null || spec.viewport.maxPoints === undefined)
@@ -418,7 +423,7 @@ export function seedChartResolutionResult(
       ? { viewport: { start: new Date(bounds.start), end: new Date(bounds.end) } } : {}),
     loading: true,
     errors: studies.errors,
-    warnings: studies.warnings,
+    warnings: [...studies.warnings, ...(priceComparison ? [priceComparison.notice] : [])],
     resolution: spec.viewport.resolution === "auto"
       ? getPresetResolution(spec.viewport.range)
       : spec.viewport.resolution,
@@ -577,12 +582,13 @@ function mergeHistory(
   now: number,
   liveBarResolution?: ManualChartResolution,
   exchange?: string,
+  appendQuote = true,
 ): TickerFinancials {
   const base = financials ?? emptyFinancials();
   const quote = latestQuote(base.quote, quoteOverride);
-  const priceHistory = appendLiveQuotePoint(history, quote, liveBarResolution
+  const priceHistory = appendQuote ? appendLiveQuotePoint(history, quote, liveBarResolution
     ? { now, mode: "ohlc", resolution: liveBarResolution, exchange }
-    : { now });
+    : { now }) : history;
   return { ...base, quote, priceHistory };
 }
 
@@ -914,6 +920,7 @@ export async function resolveChartSpecData(
   }
 
   const referenceNow = sources.now ?? new Date();
+  const comparedSeriesIds = new Set(priceComparisonSeriesIds(spec) ?? []);
   const initialVisibleBounds = requestedBounds(spec, referenceNow);
 
   const loadFinancials = (source: Extract<ChartSeriesSpec["source"], { kind: "security" }>) => {
@@ -1174,7 +1181,10 @@ export async function resolveChartSpecData(
       // charts must merge a live quote into the same active price bar.
       const liveBarResolution = initialResolution;
       const merged = history
-        ? mergeHistory(financials, history, quoteOverride, referenceNow.getTime(), liveBarResolution, resolvedSource.instrument.exchange)
+        // A streamed quote may update only one leg, even inside the same weekly
+        // bar. Comparison endpoints therefore use source history observations;
+        // quotes still provide currency/type without rewriting their prices.
+        ? mergeHistory(financials, history, quoteOverride, referenceNow.getTime(), liveBarResolution, resolvedSource.instrument.exchange, !comparedSeriesIds.has(seriesSpec.id))
         : quoteOverride && financials
           ? { ...financials, quote: latestQuote(financials.quote, quoteOverride) }
           : financials;
@@ -1211,10 +1221,13 @@ export async function resolveChartSpecData(
   const bounds = hasExplicitWindow
     ? requestVisibleBounds
     : followLatestMarketObservation(initialVisibleBounds, rawSeries);
+  const priceComparison = resolvePriceComparison(spec, rawSeries, bounds);
+  const comparisonBounds = priceComparison && priceComparison.start !== null
+    ? priceComparison : bounds;
   const resolution = initialResolution;
   const baseSeries = rawSeries
     .filter((entry) => visibleSeriesIds.has(entry.id))
-    .map((entry) => prepareBaseSeriesForStudies(entry, bounds, false, requestVisibleBounds));
+    .map((entry) => prepareBaseSeriesForStudies(entry, comparisonBounds, false, priceComparison ? undefined : requestVisibleBounds));
   // Studies run over the same loaded history their base series carries. Clipping
   // them to the requested window instead left a study with no observations
   // wherever the accumulated buffer had already been panned past, so a study's
@@ -1231,21 +1244,24 @@ export async function resolveChartSpecData(
         studyResult.series,
         spec.studies,
         rawSeries,
-        bounds,
-        requestVisibleBounds,
+        comparisonBounds,
+        priceComparison ? undefined : requestVisibleBounds,
       ),
     ];
     warnings.push(...studyResult.warnings);
     errors.push(...studyResult.errors);
   }
 
-  const bufferedSeries = assignAxes(resolved, [...spec.series, ...spec.studies], warnings);
+  const bufferedSeries = assignAxes(resolved, [...spec.series, ...spec.studies], warnings)
+    .map((entry) => clipPriceComparison(entry, priceComparison));
   resolved = bufferedSeries.map((entry) => (
     bounds.start !== null && bounds.end !== null
       ? clipSeriesToWindow(entry, new Date(bounds.start), new Date(bounds.end))
       : { ...entry, points: filterPoints(entry.points, bounds) }
   ));
   resolved = resolved.map((entry) => limitSeriesObservations(spec, entry));
+  resolved = resolved.map((entry) => clipPriceComparison(entry, priceComparison));
+  if (priceComparison) warnings.push(priceComparison.notice);
   warnings.push(...financialPeriodCoverageWarnings(financialPeriodCoverage(spec, resolved)));
   const resolvedById = new Map(resolved.map((entry) => [entry.id, entry] as const));
   const hiddenBaseSeries = rawSeries
@@ -1281,6 +1297,7 @@ export async function resolveChartSpecData(
     : undefined;
   return {
     series: resolved,
+    ...(priceComparison ? { priceComparison } : {}),
     ...(sharedSupport.length > 0 ? { resolutionSupport: sharedSupport } : {}),
     legendSeries,
     ...(spec.viewport.maxPoints === undefined ? { bufferedSeries } : {}),

--- a/src/time-series/types.ts
+++ b/src/time-series/types.ts
@@ -168,6 +168,8 @@ export interface TimeSeriesFieldDefinition {
 
 export interface ChartResolutionResult {
   series: ResolvedSeries[];
+  /** Method and exact shared source dates for normalized closing-price comparisons. */
+  priceComparison?: import("./price-comparison").PriceComparison;
   /** Provider capabilities shared by every active market series. */
   resolutionSupport?: ChartResolutionSupport[];
   /** Series available to the legend, including hidden base series that can be restored. */


### PR DESCRIPTION
A five-year JEPQ/QQQ comparison used JEPQ's first available 2022 close against QQQ's 2021 baseline, presenting percentages over different periods. Normalized comparable closing-price series now use exact source dates shared by every leg and stop at the shared endpoint. A newer quote cannot append to or rewrite only one leg, including within a weekly bar.

The chart, headless report and share warnings disclose the actual dates and price-return basis: listing currencies, cash distributions excluded, no FX conversion. Missing overlap remains unavailable. Raw/mixed/economic/period-limited charts retain their behavior; studies still calculate from raw inputs.

Validation: 81 tests / 516 assertions; all six TypeScript targets; web build. Actual local browser with unmodified production responses verified daily/weekly JEPQ–QQQ, VWRP–VWRL, Save and ordinary reload. Recorded-source native charts passed at 140 and 80 columns. Daily recorded common-date returns independently match 16.06% / 115.02%.

A separate confirmed provider issue returns pre-inception 2013 JEPQ weekly/monthly prices. This PR aligns available observations; it does not certify source history or construct reinvested total returns. The provider issue is being handled separately. No release or version bump.
