### PR TITLE
Resolve ambiguous listings inside research pane forms

### DIFF
--- a/src/components/command-bar/workflow/ops.test.ts
+++ b/src/components/command-bar/workflow/ops.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { cloneLayout, createDefaultConfig, findPaneInstance, type LayoutConfig } from "../../../types/config";
 import { createInitialState } from "../../../state/app/context";
 import { createTestDataProvider } from "../../../test-support/data-provider";
-import { applyPaneSettingFieldValue, createPaneTemplateOrThrow, resolveTickerInput } from "./ops";
+import { applyPaneSettingFieldValue, createPaneTemplateOrThrow, resolveTickerInput, resolveTickerInputOrThrow } from "./ops";
 import type { TickerRecord } from "../../../types/ticker";
 
 function makeDataProvider() {
@@ -591,5 +591,23 @@ test("interactive ambiguous ticker input returns to the picker without mutating 
     dataProvider: createTestDataProvider({ search: async () => ["BYMA", "NYSE"].map((exchange) => ({ providerId: "cloud", symbol: "GLD", exchange, name: "SPDR", type: "ETF" })) }),
   });
   expect(resolved).toBeNull();
+  expect(writes).toBe(0);
+});
+
+test("form ticker resolution preserves competing listing identities instead of claiming no match", async () => {
+  const state = createInitialState(createDefaultConfig(":memory:"));
+  let writes = 0;
+  const deps = {
+    getState: () => state, dispatch: () => { writes++; }, pluginRegistry: {} as any,
+    tickerRepository: { createTicker: async () => { writes++; throw new Error("Must not create ticker"); } } as any,
+    dataProvider: createTestDataProvider({ search: async () => [
+      { providerId: "cloud", symbol: "COST", exchange: "NASDAQ", name: "Costco Wholesale", type: "Common Stock" },
+      { providerId: "cloud", symbol: "COST", exchange: "LSE", name: "Costain Group", type: "Common Stock" },
+    ] }),
+  };
+  const error = await resolveTickerInputOrThrow("COST", null, null, deps).catch((error) => error);
+  expect(error.name).toBe("AmbiguousTickerError");
+  expect(error.listings).toEqual(["COST:XNAS", "COST:XLON"]);
+  expect(error.listingNames).toEqual({ "COST:XNAS": "Costco Wholesale", "COST:XLON": "Costain Group" });
   expect(writes).toBe(0);
 });

--- a/src/components/command-bar/workflow/runtime.ts
+++ b/src/components/command-bar/workflow/runtime.ts
@@ -10,6 +10,7 @@ import type { AppAction } from "../../../state/app/context";
 import type { PluginRegistry } from "../../../plugins/registry";
 import type { NativeSelectElement } from "../../ui/native-select";
 import { extractBrokerWorkflowValues } from "./broker";
+import { buildTickerListingPicker } from "./ticker-listing-picker";
 import type {
   CommandBarCollectionWorkflowActions,
   CommandBarNotifyFn,
@@ -161,6 +162,18 @@ export function useCommandBarWorkflowRuntime({
       }
       closeAll({ revertThemePreview: false });
     } catch (error) {
+      const listingPicker = buildTickerListingPicker(route, error, (fieldId) => {
+        const field = visibleFields.find((field) => field.id === fieldId);
+        return field ? getWorkflowFieldStringValue(field, route.values[fieldId]) : "";
+      });
+      if (listingPicker) {
+        setRouteStack((current) => {
+          const top = current.at(-1);
+          if (top?.kind !== "workflow" || top.payload !== route.payload || !top.pending) return current;
+          return [...current.slice(0, -1), { ...top, pending: false, error: null }, listingPicker];
+        });
+        return;
+      }
       updateTopRoute((current) => current.kind === "workflow"
         ? {
           ...current,

--- a/src/components/command-bar/workflow/ticker-listing-picker.test.ts
+++ b/src/components/command-bar/workflow/ticker-listing-picker.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import { AmbiguousTickerError } from "../../../tickers/search";
+import { buildTickerListingPicker } from "./ticker-listing-picker";
+import { updateRouteStack } from "./route-actions";
+import type { CommandBarRoute, CommandBarWorkflowRoute } from "./types";
+
+const workflow: CommandBarWorkflowRoute = {
+  kind: "workflow", workflowId: "fundamental-graph-pane", title: "Fundamental Graph",
+  fields: [{ id: "tickers", label: "Tickers", type: "text" }],
+  values: { tickers: "MSFT, COST, AAPL", metric: "eps", range: "10Y" },
+  activeFieldId: "tickers", submitLabel: "Create Pane", pending: false, error: null,
+  payload: { kind: "pane-template", actionId: "fundamental-graph-pane" },
+  payloadMeta: { argPlaceholder: "tickers" },
+};
+const ambiguity = new AmbiguousTickerError("COST", ["COST:XNAS", "COST:XLON"], {
+  "COST:XNAS": "Costco Wholesale", "COST:XLON": "Costain Group",
+});
+
+test("listing choice retains the complete research form and changes only the ambiguous symbol", () => {
+  const picker = buildTickerListingPicker(workflow, ambiguity, () => "msft, cost, aapl")!;
+  expect(picker.options.map((option) => [option.id, option.detail])).toEqual([
+    ["MSFT, COST:XNAS, AAPL", "Costco Wholesale"], ["MSFT, COST:XLON, AAPL", "Costain Group"],
+  ]);
+  let routes: CommandBarRoute[] = [workflow, picker];
+  updateRouteStack((updater) => { routes = typeof updater === "function" ? updater(routes) : updater; },
+    String(picker.payload!.fieldId), picker.options[0]!.id);
+  const updated = routes[0] as CommandBarWorkflowRoute;
+  expect(updated.values).toEqual({ ...workflow.values, tickers: "MSFT, COST:XNAS, AAPL" });
+  expect(workflow.values.tickers).toBe("MSFT, COST, AAPL");
+  // The next unresolved ticker gets its own choice without undoing the first.
+  const second = buildTickerListingPicker(updated, new AmbiguousTickerError("AAPL", ["AAPL:XNAS", "AAPL:XMEX"]), () => String(updated.values.tickers))!;
+  expect(second.options[1]!.id).toBe("MSFT, COST:XNAS, AAPL:XMEX");
+});
+
+test("single-ticker forms can disambiguate, while missing matches and unrelated errors retain normal handling", () => {
+  const single = { ...workflow, fields: [{ id: "ticker", label: "Ticker", type: "text" as const }], payloadMeta: { argPlaceholder: "ticker" } };
+  expect(buildTickerListingPicker(single, ambiguity, () => "cost")?.options[0]?.id).toBe("COST:XNAS");
+  expect(buildTickerListingPicker(workflow, new Error("No ticker match"), () => "COST")).toBeNull();
+  expect(buildTickerListingPicker(workflow, ambiguity, () => "MSFT, AAPL")).toBeNull();
+  expect(buildTickerListingPicker({ ...workflow, payload: { kind: "plugin-command", actionId: "other" } }, ambiguity, () => "COST")).toBeNull();
+});

--- a/src/components/command-bar/workflow/ticker-listing-picker.ts
+++ b/src/components/command-bar/workflow/ticker-listing-picker.ts
@@ -1,0 +1,35 @@
+import { AmbiguousTickerError } from "../../../tickers/search";
+import { formatTickerListInput, parseTickerListInput } from "../../../tickers/list";
+import type { CommandBarPickerRoute, CommandBarWorkflowRoute } from "./types";
+
+/** Keep the form intact while the user resolves one ambiguous listing at a time. */
+export function buildTickerListingPicker(
+  route: CommandBarWorkflowRoute,
+  error: unknown,
+  readValue: (fieldId: string) => string,
+): CommandBarPickerRoute | null {
+  if (!(error instanceof AmbiguousTickerError) || route.payload.kind !== "pane-template") return null;
+  const fieldId = String(route.payloadMeta?.argPlaceholder ?? "");
+  if ((fieldId !== "ticker" && fieldId !== "tickers") || !route.fields.some((field) => field.id === fieldId)) return null;
+  let tokens: string[];
+  try {
+    tokens = fieldId === "tickers" ? parseTickerListInput(readValue(fieldId)) : [readValue(fieldId).trim().toUpperCase()];
+  } catch {
+    return null;
+  }
+  if (!tokens.includes(error.query) || error.listings.length < 2) return null;
+  return {
+    kind: "picker",
+    pickerId: "field-select",
+    title: `Choose listing for ${error.query}`,
+    query: "",
+    selectedIdx: 0,
+    hoveredIdx: null,
+    options: error.listings.map((listing) => ({
+      id: formatTickerListInput(tokens.map((token) => token === error.query ? listing : token)),
+      label: error.listingNames[listing] ? `${listing} · ${error.listingNames[listing]}` : listing,
+      detail: error.listingNames[listing],
+    })),
+    payload: { parentKind: "workflow", fieldId, fieldType: "text" },
+  };
+}

--- a/src/components/command-bar/workflow/tickers.ts
+++ b/src/components/command-bar/workflow/tickers.ts
@@ -138,6 +138,7 @@ export async function resolveTickerInput(
   activeTicker: string | null,
   collectionId: string | null,
   deps: SharedWorkflowDeps,
+  options: { preserveAmbiguity?: boolean } = {},
 ): Promise<ResolvedTickerInput | null> {
   const state = deps.getState();
   let resolvedTicker;
@@ -151,7 +152,7 @@ export async function resolveTickerInput(
     });
   } catch (error) {
     // Interactive callers already open a listing picker for unresolved input.
-    if (error instanceof AmbiguousTickerError) return null;
+    if (error instanceof AmbiguousTickerError && !options.preserveAmbiguity) return null;
     throw error;
   }
   if (!resolvedTicker) return null;
@@ -164,7 +165,7 @@ export async function resolveTickerInputOrThrow(
   collectionId: string | null,
   deps: SharedWorkflowDeps,
 ): Promise<ResolvedTickerInput> {
-  const resolved = await resolveTickerInput(rawInput, activeTicker, collectionId, deps);
+  const resolved = await resolveTickerInput(rawInput, activeTicker, collectionId, deps, { preserveAmbiguity: true });
   if (!resolved) {
     throw new Error(`No ticker match found for "${rawInput ?? activeTicker ?? ""}".`);
   }

--- a/src/tickers/search/index.ts
+++ b/src/tickers/search/index.ts
@@ -37,7 +37,7 @@ export {
 export { upsertTickerFromSearchResult } from "./upsert";
 
 export class AmbiguousTickerError extends Error {
-  constructor(readonly query: string, readonly listings: readonly string[]) {
+  constructor(readonly query: string, readonly listings: readonly string[], readonly listingNames: Readonly<Record<string, string>> = {}) {
     super(`Multiple listings match ${query}. Choose an exchange in search or use ${listings.slice(0, 3).join(", ")}.`);
     this.name = "AmbiguousTickerError";
   }
@@ -253,7 +253,9 @@ export async function resolveTickerSearch({
       // An unavailable quote cannot establish the default listing.
     }
     if (new Set(verified.map((item) => publicTickerKey(item.symbol, listingExchange(item.result!)))).size !== 1) {
-      throw new AmbiguousTickerError(symbol, [...listings]);
+      throw new AmbiguousTickerError(symbol, [...listings], Object.fromEntries(matches.map((item) => [
+        publicTickerKey(item.symbol, listingExchange(item.result!)), item.result!.name,
+      ])));
     }
     exactMatch = verified[0]!;
   }


### PR DESCRIPTION
Creating a fundamental comparison with `GF MSFT,COST,AAPL` reported “No ticker match found for COST” because the form discarded the distinction between an unknown symbol and competing listings. COST identifies both Costco on NASDAQ and Costain in London.

Pane forms now open a listing picker with the qualified symbol and issuer name. Choosing a listing changes that symbol in the form while retaining the other inputs; Back preserves the original form. Further ambiguous symbols can be resolved in turn. Late search failures cannot open the picker after the form has been closed or replaced.

Validation: 53 focused tests / 199 assertions, all six TypeScript targets, browser build, and an independent code review with active/canceled/reopened asynchronous form probes passed. Actual local Chromium with production market responses completed the comparison, canceled and retried the picker, and retained the chart after reload. The 900px view shows issuer/exchange choices; an isolated native tmux session completed the same flow at 140 and 80 columns. No broker positions or authentication state were modified.

No version bump or GitHub release.
