### PR TITLE
Preserve option strike centering while a new expiry loads

### DIFF
--- a/src/renderers/electrobun/view/data-table/index.test.tsx
+++ b/src/renderers/electrobun/view/data-table/index.test.tsx
@@ -15,6 +15,7 @@ const items = Array.from({ length: 100 }, (_, index) => index);
 
 test("controlled centering keeps following late quotes until the user scrolls", async () => {
   let updateQuoteTarget: (index: number) => void = () => {};
+  let updateItems: (next: number[]) => void = () => {};
   let userScrolls = 0;
   let controlledScrolls = 0;
   let paginationChecks = 0;
@@ -26,6 +27,8 @@ test("controlled centering keeps following late quotes until the user scrolls", 
     const scrollRef = useRef<ScrollBoxRenderable | null>(null);
     const userScrolled = useRef(false);
     const [targetIndex, setTargetIndex] = useState(0);
+    const [currentItems, setCurrentItems] = useState(items);
+    updateItems = setCurrentItems;
     // Options waits for the underlying quote, then follows it until an actual
     // user scroll. The renderer must not turn its own centering into that lock.
     updateQuoteTarget = (index) => {
@@ -46,7 +49,7 @@ test("controlled centering keeps following late quotes until the user scrolls", 
     return (
       <AppContext value={{ state, dispatch: () => {} }}>
         <WebDataTable
-          items={items}
+          items={currentItems}
           columns={[{ id: "strike", label: "Strike", width: 10, align: "right" }]}
           sortColumnId={null}
           sortDirection="asc"
@@ -92,6 +95,21 @@ test("controlled centering keeps following late quotes until the user scrolls", 
   expect(userScrolls).toBe(0);
   expect(controlledScrolls).toBe(2);
 
+  // An uncached options expiry empties the table while loading. The browser
+  // clamps the old scroll offset to zero when its scrollable content vanishes.
+  // That native scroll event must not lock out the next expiry's ATM selection.
+  await act(async () => { updateItems([]); });
+  await act(async () => {
+    body.scrollTop = 0;
+    emitScroll();
+    await settle();
+  });
+  expect(userScrolls).toBe(0);
+  await act(async () => { updateItems(items); updateQuoteTarget(60); });
+  await act(async () => { emitScroll(); await settle(); });
+  expect(body.scrollTop).toBe(55 * WEB_CELL_HEIGHT);
+  expect(userScrolls).toBe(0);
+
   await act(async () => {
     body.dispatchEvent(new testWindow.WheelEvent("wheel", { bubbles: true, deltaY: -50 }) as unknown as Event);
     body.scrollTop = 0;
@@ -99,9 +117,9 @@ test("controlled centering keeps following late quotes until the user scrolls", 
     await settle();
   });
   expect(userScrolls).toBe(1);
-  expect(paginationChecks).toBe(3);
+  expect(paginationChecks).toBe(4);
   expect(ranges.at(-1)).toEqual({ start: 0, end: 10 });
 
-  await act(async () => { updateQuoteTarget(60); await settle(); });
+  await act(async () => { updateQuoteTarget(70); await settle(); });
   expect(body.scrollTop).toBe(0);
 });

--- a/src/renderers/electrobun/view/data-table/index.tsx
+++ b/src/renderers/electrobun/view/data-table/index.tsx
@@ -211,6 +211,15 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
   useEffect(() => {
     if (scrollToIndex == null || items.length === 0) {
       lastAppliedScrollRequestRef.current = null;
+      if (items.length === 0 && bodyElementRef.current) {
+        // Loading a different dataset removes the rows and the browser clamps
+        // the old vertical offset to zero. Treat that ensuing scroll like our
+        // own centering, so it cannot become a user's manual selection lock.
+        controlledScrollOffsetRef.current = {
+          top: 0,
+          left: bodyElementRef.current.scrollLeft,
+        };
+      }
       return;
     }
     const scrollRequestKey = `${scrollToIndex}:${scrollToIndexVersion}:${scrollToIndexAlign}`;


### PR DESCRIPTION
Changing from a centered options chain to an uncached expiry temporarily removes every row. The browser clamps the scroll offset to zero; the web table reported that scroll as user navigation, which stopped automatic selection and left the new expiry on its lowest strike.

Record the expected empty-table clamp as controlled scrolling. Real wheel and touch input still clear the controlled offset. The existing regression now covers populated → loading → populated data, late centering, and retained manual-scroll behavior.

Validation: 18 focused tests / 85 assertions; all six typecheck targets and web build passed. Actual local browser with live production AAPL options responses: September → October → November → October selects and centers strike 325 near the approximately $326 stock price, instead of strike 130/25. No page errors. New York timezone, 1600×1000; narrow-desktop reload check also completed. No real holdings, orders, release or version changes.
