### PR TITLE
fix: refresh repaired fund history and monthly calendars

### DIFF
--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -1042,6 +1042,15 @@ export interface CloudMarketResponse<T> {
   staleAt?: string;
   stale?: boolean;
   currency?: string;
+  coverage?: {
+    inceptionDate: string;
+    firstAllowedBarDate: string;
+    source: "issuer";
+    sourceUrl: string;
+    firstBarDate: string | null;
+    lastBarDate: string | null;
+    barCount: number;
+  };
   providerMeta?: {
     provider?: string;
     upstream?: string;

--- a/src/sources/gloomberb-cloud/index.test.ts
+++ b/src/sources/gloomberb-cloud/index.test.ts
@@ -480,6 +480,22 @@ describe("GloomberbCloudProvider", () => {
     });
   });
 
+  test("monthly requests use calendar dates even near a US timezone boundary", async () => {
+    const requests: Array<Record<string, string | number | undefined>> = [];
+    apiClient.getCloudHistory = async (_symbol, _exchange, params = {}) => {
+      requests.push(params);
+      return { status: "success", data: [{ date: "2026-08-01", close: 710 }] };
+    };
+    const provider = new GloomberbCloudProvider();
+    const rows = await provider.getDetailedPriceHistory("QQQ", "NASDAQ", new Date("2026-01-01T00:00:00Z"), new Date("2026-09-01T00:00:00Z"), "1mo");
+    expect(requests[0]).toEqual({ interval: "1month", startDate: "2026-01-01", endDate: "2026-09-01" });
+    expect(rows[0]?.close).toBe(710);
+    await provider.getPriceHistoryForResolution("QQQ", "NASDAQ", "ALL", "1mo");
+    expect(requests[1]?.interval).toBe("1month");
+    expect(requests[1]?.startDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(requests[1]?.endDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
   test("fetches fixed-resolution chart history with the requested interval", async () => {
     apiClient.ensureVerifiedSession = async () => verifiedUser;
 

--- a/src/sources/gloomberb-cloud/index.ts
+++ b/src/sources/gloomberb-cloud/index.ts
@@ -148,7 +148,7 @@ function mapCloudPriceHistory(
     ?? ""
   ).trim().toLowerCase();
   if (
-    /(min|h)$/i.test(interval)
+    /^\d+(min|h)$/i.test(interval)
     && upstream !== "yahoo"
     && hasMalformedIntradayHistory(points)
   ) {
@@ -433,7 +433,7 @@ export class GloomberbCloudProvider implements AssetDataProvider {
     const interval = toCloudInterval(resolution);
     const endDate = new Date();
     const startDate = getRangeStartDate(bufferRange, endDate);
-    const includeTime = /(min|h)$/i.test(interval);
+    const includeTime = /^\d+(min|h)$/i.test(interval);
     const response = await withCloudFallback(
       () => apiClient.getCloudHistory(target.symbol, exchange, {
         interval,
@@ -456,7 +456,7 @@ export class GloomberbCloudProvider implements AssetDataProvider {
     const target = cloudInstrumentTarget(ticker, exchange);
     exchange = target.exchange ?? "";
     const interval = toCloudInterval(barSize);
-    const includeTime = /(min|h)$/i.test(interval);
+    const includeTime = /^\d+(min|h)$/i.test(interval);
     const response = await withCloudFallback(
       () => apiClient.getCloudHistory(target.symbol, exchange, {
         interval,

--- a/src/sources/provider-router/history-boundary-cache.test.ts
+++ b/src/sources/provider-router/history-boundary-cache.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, expect, test } from "bun:test";
+import { AppPersistence } from "../../data/app-persistence";
+import { AssetDataRouter } from "./index";
+import { cleanupProviderRouterTestFiles, createTempDbPath, fallbackProvider } from "./test-support";
+
+afterEach(cleanupProviderRouterTestFiles);
+const bad = [{ date: new Date("2013-03-25"), close: .55227 }];
+const good = [{ date: new Date("2022-05-02"), close: 49.21 }, { date: new Date("2026-08-24"), close: 59.87 }];
+const equalHistory = (value: unknown) => expect(JSON.stringify(value)).toBe(JSON.stringify(good));
+const policy = { staleMs: 60_000, expireMs: 600_000 };
+
+test("saved JEPQ range, broader-window and detailed caches cannot retain pre-inception rows", async () => {
+  for (const ticker of ["JEPQ", "JEPQ:XNAS"]) {
+    const store = new AppPersistence(createTempDbPath("jepq-boundary"));
+    try {
+      for (const [kind, variantKey] of [
+        ["price-history", "exchange=NASDAQ;range=ALL;version=4"],
+        ["price-history", "exchange=NASDAQ;range=ALL;resolution=1wk;version=4"],
+        ["price-history", "range=ALL;resolution=1wk;version=4"],
+        ["detailed-price-history", "exchange=NASDAQ;start=2000-01-01;end=2026-08-31;bar=1wk;version=4"],
+      ]) store.resources.set({ namespace: "market", kind: kind!, entityKey: ticker, variantKey, sourceKey: "provider:gloomberb-cloud" }, bad, { cachePolicy: policy });
+      let calls = 0;
+      const load = async () => { calls++; return good; };
+      const provider = { ...fallbackProvider, id: "gloomberb-cloud", getPriceHistory: load, getPriceHistoryForResolution: load, getDetailedPriceHistory: load };
+      const read = async (router: AssetDataRouter) => {
+        equalHistory(await router.getPriceHistory(ticker, "NASDAQ", "ALL"));
+        equalHistory(await router.getPriceHistoryForResolution(ticker, "NASDAQ", "5Y", "1wk"));
+        equalHistory(await router.getDetailedPriceHistory(ticker, "NASDAQ", new Date("2000-01-01"), new Date("2026-08-31"), "1wk"));
+      };
+      await read(new AssetDataRouter(provider, [], store.resources));
+      expect(calls).toBe(3);
+      // A new router models restart: the corrected records, including serialized
+      // dates, are reusable; old broader variants still cannot win selection.
+      await read(new AssetDataRouter(provider, [], store.resources));
+      expect(calls).toBe(3);
+    } finally { store.close(); }
+  }
+});
+
+test("source failure cannot resurrect old JEPQ cache, while an unrelated weekly cache remains usable", async () => {
+  const store = new AppPersistence(createTempDbPath("jepq-boundary-miss"));
+  try {
+    for (const ticker of ["JEPQ", "QQQ"]) store.resources.set({ namespace: "market", kind: "price-history", entityKey: ticker, variantKey: "exchange=NASDAQ;range=ALL;resolution=1wk;version=4", sourceKey: "provider:gloomberb-cloud" }, ticker === "JEPQ" ? bad : good, { cachePolicy: policy });
+    const requested: string[] = [];
+    const router = new AssetDataRouter({ ...fallbackProvider, id: "gloomberb-cloud", async getPriceHistoryForResolution(ticker) { requested.push(ticker); return []; } }, [], store.resources);
+    expect(await router.getPriceHistoryForResolution("JEPQ", "NASDAQ", "ALL", "1wk")).toEqual([]);
+    equalHistory(await router.getPriceHistoryForResolution("QQQ", "NASDAQ", "ALL", "1wk"));
+    expect(requested).toEqual(["JEPQ"]);
+  } finally { store.close(); }
+});
+
+test("monthly cache is refreshed independently of unaffected daily and weekly variants", async () => {
+  const store = new AppPersistence(createTempDbPath("monthly-calendar-cache"));
+  try {
+    for (const resolution of ["1mo", "1wk", "1d"]) store.resources.set({ namespace: "market", kind: "price-history", entityKey: "QQQ", variantKey: `exchange=NASDAQ;range=ALL;resolution=${resolution};version=4`, sourceKey: "provider:gloomberb-cloud" }, good, { cachePolicy: policy });
+    const resolutions: string[] = [];
+    const router = new AssetDataRouter({ ...fallbackProvider, id: "gloomberb-cloud", async getPriceHistoryForResolution(_ticker, _exchange, _range, resolution) { resolutions.push(resolution); return good; } }, [], store.resources);
+    for (const resolution of ["1mo", "1wk", "1d"] as const) await router.getPriceHistoryForResolution("QQQ", "NASDAQ", "ALL", resolution);
+    expect(resolutions).toEqual(["1mo"]);
+  } finally { store.close(); }
+});
+
+test("the inception repair leaves historical JEPQ intraday caches reusable", async () => {
+  const store = new AppPersistence(createTempDbPath("jepq-intraday-control"));
+  try {
+    store.resources.set({ namespace: "market", kind: "detailed-price-history", entityKey: "JEPQ", variantKey: "exchange=NASDAQ;start=2026-08-01;end=2026-08-31;bar=1h;version=4", sourceKey: "provider:gloomberb-cloud" }, good, { cachePolicy: policy });
+    let calls = 0;
+    const router = new AssetDataRouter({ ...fallbackProvider, id: "gloomberb-cloud", async getDetailedPriceHistory() { calls++; return []; } }, [], store.resources);
+    equalHistory(await router.getDetailedPriceHistory("JEPQ", "NASDAQ", new Date("2026-08-01"), new Date("2026-08-31"), "1h"));
+    expect(calls).toBe(0);
+  } finally { store.close(); }
+});

--- a/src/sources/provider-router/history.ts
+++ b/src/sources/provider-router/history.ts
@@ -12,7 +12,7 @@ import {
 } from "../../time-series/resolution";
 import { clipPriceHistoryToRange } from "../../time-series/history-window";
 import { repairIsolatedIntradayOhlcOutliers } from "../../time-series/history-quality";
-import { canonicalExchange } from "../../utils/exchanges";
+import { canonicalExchange, parsePublicTickerKey } from "../../utils/exchanges";
 import { resolvePriceHistoryCurrencyUnit } from "../../utils/currency-units";
 import { isPriceHistoryStaleForCurrentWindow, normalizePriceHistory, priceHistoryIntervalMs } from "../../utils/price-history";
 import { shouldLogProviderError } from "../provider-errors";
@@ -51,11 +51,26 @@ interface HistoryRequestDescriptor {
 function priceHistoryVariantParts(
   parts: Array<[string, string | number | undefined | null]>,
   exchange: string,
+  ticker: string,
 ): Array<[string, string | number | undefined | null]> {
   const unit = resolvePriceHistoryCurrencyUnit(null, exchange);
+  const target = parsePublicTickerKey(ticker);
+  const venue = target.exchange || canonicalExchange(exchange);
+  // Old cloud weekly/monthly JEPQ responses contained prices from 2013, before
+  // this fund existed. Refetch this exact US/bare identity after backend repair;
+  // neither broader cached windows nor saved detailed requests may reuse them.
+  const bar = parts.find(([key]) => key === "resolution" || key === "bar")?.[1];
+  const range = parts.find(([key]) => key === "range")?.[1];
+  const intraday = typeof bar === "string" ? /^\d+(m|min|h)$/.test(bar)
+    : typeof range === "string" && isIntradayRange(range as TimeRange);
+  const inceptionVersion = !intraday && target.symbol === "JEPQ" && (!venue || venue === "NASDAQ") ? 1 : undefined;
+  const monthly = bar === "1mo" || bar === "1month"
+    || (bar == null && parts.some(([key, value]) => key === "range" && value === "ALL"));
   const versionedParts: Array<[string, string | number | undefined | null]> = [
     ...parts,
     ["version", PRICE_HISTORY_CACHE_VERSION],
+    ["inception", inceptionVersion],
+    ["calendar", monthly ? 1 : undefined],
   ];
   return unit.divisor === 1
     ? versionedParts
@@ -77,11 +92,11 @@ function makeHistoryRequestIdentity(
     kind: input.kind,
     ticker: input.ticker,
     context: input.context,
-    variantParts: priceHistoryVariantParts(input.variantParts, input.exchange),
+    variantParts: priceHistoryVariantParts(input.variantParts, input.exchange, input.ticker),
   });
   const cacheVariantKeys = [
     identity.variantKey,
-    buildVariantKey(priceHistoryVariantParts(input.fallbackVariantParts, input.exchange)),
+    buildVariantKey(priceHistoryVariantParts(input.fallbackVariantParts, input.exchange, input.ticker)),
   ];
   return {
     identity,


### PR DESCRIPTION
Monthly chart requests were treated as intraday because `1month` ends in `h`, producing timestamp request boundaries instead of calendar dates. The cloud provider now recognizes only numeric minute/hour intervals.

Refresh affected saved JEPQ calendar-history and monthly-history variants after the paired backend correction. Old broader-window and detailed caches cannot restore pre-launch rows or empty monthly responses. Unrelated daily/weekly and JEPQ intraday variants remain reusable; provider and broker priority is unchanged. Type the backend's returned issuer/coverage metadata.

Validation: 48 focused tests / 172 assertions cover persisted-cache restart, source failure, broader-window fallback, intraday and unrelated ETF controls, and timezone-edge monthly requests. Recorded-source browser Save/reload and native 80/140-column checks show a JEPQ/QQQ monthly comparison using May 2022–August 2026 shared observations, with price-return limitations visible. The paired backend removes only confirmed pre-launch JEPQ buckets and restores monthly history. No release/version bump.
