### PR TITLE
Keep historical SEC EPS comparisons on a proven share basis

### DIFF
--- a/src/plugins/builtin/chart-composer/headless.ts
+++ b/src/plugins/builtin/chart-composer/headless.ts
@@ -1,5 +1,5 @@
 import { financialPeriodCoverage } from "../../../time-series/financial-period-coverage";
-import { FINANCIAL_VINTAGE_NOTICE } from "../../../utils/financial-statements";
+import { FINANCIAL_VINTAGE_NOTICE, SEC_EPS_BASIS_NOTICE } from "../../../utils/financial-statements";
 import { graphRowsForFinancials, summarizeResolvedSeries } from "../../../time-series/reporting";
 import type { HeadlessPaneContext, HeadlessPaneDefinition, HeadlessSeriesResult } from "../../../types/headless";
 import type { ChartResolutionResult, ChartSeriesSpec, ChartSpec } from "../../../time-series/types";
@@ -112,7 +112,7 @@ export async function loadChartPaneModel(
     metadata: {
       viewport: spec.viewport, panels: spec.panels, warnings: chart.warnings,
       ...(periodCoverage.length ? { periodCoverage } : {}),
-      notices: chart.warnings.filter((warning) => warning === FINANCIAL_VINTAGE_NOTICE || warning === chart.priceComparison?.notice),
+      notices: chart.warnings.filter((warning) => warning === FINANCIAL_VINTAGE_NOTICE || warning === SEC_EPS_BASIS_NOTICE || warning === chart.priceComparison?.notice),
       priceComparison: chart.priceComparison ?? null,
       summaries: chart.series.map((series) => ({ id: series.id, ...summarizeResolvedSeries(series) })),
     },

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -1,4 +1,4 @@
-import { FINANCIAL_VINTAGE_NOTICE } from "../../../utils/financial-statements";
+import { FINANCIAL_VINTAGE_NOTICE, SEC_EPS_BASIS_NOTICE } from "../../../utils/financial-statements";
 import { wrapTextLines } from "../../../utils/text-wrap";
 import { isFundamentalFieldId } from "../../../time-series/field-catalog";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -556,10 +556,11 @@ function ChartComposerSurface({
 
   const showVintageNotice = spec.series.some((entry) => entry.visible !== false
     && entry.source.kind === "security" && isFundamentalFieldId(entry.source.fieldId));
-  const vintageNoticeHeight = showVintageNotice ? wrapTextLines(FINANCIAL_VINTAGE_NOTICE, Math.max(8, width - 2)).length : 0;
+  const financialNotice = [FINANCIAL_VINTAGE_NOTICE, ...(resolution.warnings.includes(SEC_EPS_BASIS_NOTICE) ? [SEC_EPS_BASIS_NOTICE] : [])].join(" ");
+  const vintageNoticeHeight = showVintageNotice ? wrapTextLines(financialNotice, Math.max(8, width - 2)).length : 0;
   const comparisonNotice = resolution.priceComparison?.notice;
   const comparisonNoticeHeight = comparisonNotice ? wrapTextLines(comparisonNotice, Math.max(8, width - 2)).length : 0;
-  const statusWarning = resolution.warnings.find((warning) => warning !== FINANCIAL_VINTAGE_NOTICE && warning !== comparisonNotice);
+  const statusWarning = resolution.warnings.find((warning) => warning !== FINANCIAL_VINTAGE_NOTICE && warning !== SEC_EPS_BASIS_NOTICE && warning !== comparisonNotice);
 
   usePaneFooter(footerId, () => ({
     info: [
@@ -678,7 +679,7 @@ function ChartComposerSurface({
       />
 
       {showVintageNotice && <Box paddingX={1} flexShrink={0}>
-        <Prose text={FINANCIAL_VINTAGE_NOTICE} width={Math.max(8, width - 2)} color={colors.textDim} />
+        <Prose text={financialNotice} width={Math.max(8, width - 2)} color={colors.textDim} />
       </Box>}
       {comparisonNotice && <Box paddingX={1} flexShrink={0}>
         <Prose text={comparisonNotice} width={Math.max(8, width - 2)} color={colors.textDim} />

--- a/src/plugins/builtin/ticker-detail/headless.ts
+++ b/src/plugins/builtin/ticker-detail/headless.ts
@@ -21,10 +21,11 @@ export const financialStatementsHeadless: HeadlessPaneDefinition<"rows"> = {
       expandAll: true,
     });
     const statementCurrency = financialStatementCurrency(financials, table?.statements ?? []);
-    const dates = table?.statements.map(({ date, currency, dateSource, providerDate, dateEvidence, availableAt, fieldAvailability }) => ({
+    const dates = table?.statements.map(({ date, currency, dateSource, providerDate, dateEvidence, availableAt, fieldAvailability, epsBasis }) => ({
       date, currency: currency ?? statementCurrency ?? null,
       availableAt: availableAt ?? null,
       fieldAvailability: fieldAvailability ? { ...fieldAvailability } : null,
+      ...(epsBasis ? { epsBasis } : {}),
       dateSource: date === "TTM" ? "derived" : dateSource ?? "provider",
       providerDate: date === "TTM" ? null : providerDate ?? null,
       dateEvidence: date === "TTM" || dateSource !== "sec" ? null : dateEvidence ?? null,

--- a/src/sources/provider-router/cache.test.ts
+++ b/src/sources/provider-router/cache.test.ts
@@ -5,6 +5,24 @@ import { cleanupProviderRouterTestFiles, createTempDbPath, makeFinancials, makeQ
 
 afterEach(cleanupProviderRouterTestFiles);
 
+test("legacy SEC EPS caches refresh for cloud and native without discarding unrelated resources", () => {
+  const persistence = new AppPersistence(createTempDbPath("eps-share-basis"));
+  const cachePolicy = { staleMs: 60_000, expireMs: 120_000 };
+  for (const sourceKey of ["provider:gloomberb-cloud", "provider:yahoo"]) {
+    const key = { namespace: "market", kind: "financials", entityKey: "AAPL", variantKey: "exchange=NASDAQ", sourceKey };
+    const old = makeFinancials({ annualStatements: [{ date: "2017-09-30", dateSource: "sec", eps: 9.21 }] });
+    persistence.resources.set(key, old, { cachePolicy, schemaVersion: 6 });
+    expect(listCachedResources(persistence.resources, "financials", "AAPL", [key.variantKey], [sourceKey], true)).toEqual([]);
+    const current = makeFinancials({ annualStatements: [{ date: "2017-09-30", dateSource: "sec", eps: 2.3025,
+      epsBasis: { status: "split-adjusted", source: "sec", originalValue: 9.21, basisDate: "2020-08-28", factor: 4, evidence: [] } }] });
+    cacheRouterResource(persistence.resources, "financials", "AAPL", key.variantKey, sourceKey, current, cachePolicy);
+    expect(listCachedResources(persistence.resources, "financials", "AAPL", [key.variantKey], [sourceKey], true)[0]!.value).toEqual(current);
+    persistence.resources.set({ ...key, entityKey: "MSFT" }, makeFinancials({ annualStatements: [{ date: "2025-06-30", totalRevenue: 100 }] }), { cachePolicy, schemaVersion: 6 });
+    expect(listCachedResources(persistence.resources, "financials", "MSFT", [key.variantKey], [sourceKey], true)).toHaveLength(1);
+  }
+  persistence.close();
+});
+
 test("legacy cloud yields refresh without discarding quotes, accounts or native provider values", () => {
   const persistence = new AppPersistence(createTempDbPath("dividend-yield-provenance"));
   const key = { namespace: "market", kind: "financials", entityKey: "NESN", variantKey: "exchange=SWX", sourceKey: "provider:gloomberb-cloud" };
@@ -24,13 +42,13 @@ test("legacy cloud yields refresh without discarding quotes, accounts or native 
   expect((read("provider:yahoo").value as ReturnType<typeof makeFinancials>).fundamentals?.dividendYield).toBe(0.16);
   // A new client can cache an old backend response during a rolling deploy.
   cacheRouterResource(persistence.resources, "financials", "NESN", key.variantKey, key.sourceKey, old, cachePolicy);
-  expect(read().schemaVersion).toBe(6);
+  expect(read().schemaVersion).toBe(7);
   expect(read().stale).toBe(true);
   expect((read().value as ReturnType<typeof makeFinancials>).fundamentals?.dividendYield).toBeUndefined();
   expect((read().value as ReturnType<typeof makeFinancials>).quote).toEqual(old.quote);
   const corrected = { ...old, fundamentals: { ...old.fundamentals, dividendYield: 0.0399, dividendYieldBasis: "forward" as const, dividendYieldSource: "yahoo" as const } };
   cacheRouterResource(persistence.resources, "financials", "NESN", key.variantKey, key.sourceKey, corrected, cachePolicy);
-  expect(read().schemaVersion).toBe(6);
+  expect(read().schemaVersion).toBe(7);
   expect(read().stale).toBe(false);
   expect(read().value).toEqual(corrected);
   persistence.close();

--- a/src/sources/provider-router/cache.ts
+++ b/src/sources/provider-router/cache.ts
@@ -8,7 +8,7 @@ import { redactUnavailableFundamentals, RETRACTABLE_VALUATION_FIELDS } from "../
 import { isPriceHistoryStaleForCurrentWindow } from "../../utils/price-history";
 
 const MARKET_NAMESPACE = "market";
-const FINANCIALS_SCHEMA_VERSION = 6;
+const FINANCIALS_SCHEMA_VERSION = 7;
 
 const DEFAULT_CACHE_POLICIES = {
   brokerQuote: { staleMs: 15_000, expireMs: 15 * 60_000 },
@@ -164,6 +164,13 @@ export function listCachedResources<T>(
     sourceKeys,
     allowExpired,
   }).filter((record) => {
+    // Older SEC projections can mix pre/post-split EPS in one long history.
+    // Refresh the source evidence instead of relabeling old numbers locally.
+    if (kind === "financials" && record.schemaVersion < 7) {
+      const value = record.value as TickerFinancials;
+      if ([...(value.annualStatements ?? []), ...(value.quarterlyStatements ?? [])]
+        .some((row) => row.dateSource === "sec" && row.eps !== undefined)) return false;
+    }
     if (kind !== "financials" || record.schemaVersion >= 3) return true;
     // Earlier merges could date unknown fields from a partial availability map,
     // in addition to the older SEC annual/concept errors. Cached dates cannot

--- a/src/sources/provider-router/valuation-retractions.test.ts
+++ b/src/sources/provider-router/valuation-retractions.test.ts
@@ -109,7 +109,7 @@ test("legacy cloud ASML valuation is retired and recovers with a marker-bearing 
       expect(fundamentals.unavailableFields).toEqual(fields);
       const corrected = { ...value, fundamentals: { financialCurrency: "EUR", unavailableFields: [...fields] } };
       cacheRouterResource(persistence.resources, "financials", key.entityKey, key.variantKey, key.sourceKey, corrected, cachePolicy);
-      expect(read().schemaVersion).toBe(6);
+      expect(read().schemaVersion).toBe(7);
       expect(read().stale).toBe(false);
       expect(read().value).toEqual(corrected);
     }

--- a/src/sources/sec-edgar.ts
+++ b/src/sources/sec-edgar.ts
@@ -1,5 +1,6 @@
 import type { SecFilingDocument, SecFilingItem } from "../types/data-provider";
 import type { FinancialStatement } from "../types/financials";
+import { createSecEpsBasisResolver } from "../utils/sec-eps-basis";
 import { truncateWithEllipsis } from "../utils/text-wrap";
 import { decodeHtmlEntities } from "../utils/html-entities";
 import {
@@ -568,9 +569,19 @@ function fillCompanyFactsStatementRows(
   }
 }
 
-function finalizeCompanyFactsStatements(rows: Map<string, FinancialStatement>, selectedFacts: Map<string, CompanyFactsEntry>): FinancialStatement[] {
+function finalizeCompanyFactsStatements(rows: Map<string, FinancialStatement>, selectedFacts: Map<string, CompanyFactsEntry>, resolveEps: ReturnType<typeof createSecEpsBasisResolver>): FinancialStatement[] {
   const statements = Array.from(rows.values()).sort((left, right) => left.date.localeCompare(right.date));
   for (const statement of statements) {
+    const epsFact = selectedFacts.get(`${statement.date}:eps`);
+    if (epsFact) {
+      const normalized = resolveEps(epsFact);
+      if (normalized.basis) {
+        statement.epsBasis = normalized.basis;
+        statement.eps = normalized.value;
+        if (normalized.availableAt) statement.fieldAvailability!.eps = normalized.availableAt;
+        else if (statement.fieldAvailability) delete statement.fieldAvailability.eps;
+      }
+    }
     // A selected duration fact identifies the fiscal period. Its accession and
     // filing date are evidence for that identity, never row-wide availability.
     const anchor = [...selectedFacts.entries()]
@@ -626,9 +637,10 @@ export function parseCompanyFactsFinancialStatements(payload: unknown): SecCompa
     fillCompanyFactsStatementRows(quarterlyRows, quarterlySelectedFacts, entries, field, "quarterly", annualPeriodEnds);
   }
 
+  const resolveEps = createSecEpsBasisResolver(payload);
   return {
-    annualStatements: finalizeCompanyFactsStatements(annualRows, annualSelectedFacts),
-    quarterlyStatements: finalizeCompanyFactsStatements(quarterlyRows, quarterlySelectedFacts),
+    annualStatements: finalizeCompanyFactsStatements(annualRows, annualSelectedFacts, resolveEps),
+    quarterlyStatements: finalizeCompanyFactsStatements(quarterlyRows, quarterlySelectedFacts, resolveEps),
   };
 }
 

--- a/src/time-series/fundamentals.ts
+++ b/src/time-series/fundamentals.ts
@@ -117,6 +117,7 @@ function statementTime(statement: FinancialStatement): number {
 }
 
 function statementNumber(statement: FinancialStatement, field: NumericStatementField): number | null {
+  if (field === "eps" && statement.epsBasis?.status === "unresolved") return null;
   const value = statement[field];
   return finiteNumber(value) ? value : null;
 }
@@ -216,9 +217,16 @@ function mergeStatementPeriodGroup(statements: readonly InternalStatement[]): In
         derived: statement.__timeSeriesDerivedFields?.includes(field) === true,
       }];
     });
+    const verifiedEps = field === "eps" ? candidates.filter((candidate) => candidate.statement.epsBasis?.status === "split-adjusted") : [];
+    const unresolvedEps = field === "eps" ? compatibleStatements.find((statement) => statement.epsBasis?.status === "unresolved") : undefined;
+    if (unresolvedEps && verifiedEps.length === 0) {
+      merged.epsBasis = unresolvedEps.epsBasis;
+      continue;
+    }
     if (candidates.length === 0) continue;
-    const selected = selectFieldCandidate(candidates);
+    const selected = selectFieldCandidate(verifiedEps.length ? verifiedEps : candidates);
     record[field] = selected.value;
+    if (field === "eps" && selected.statement.epsBasis) merged.epsBasis = selected.statement.epsBasis;
     if (selected.availableAt) fieldAvailability[field] = selected.availableAt;
     if (selected.derived) derivedFields.push(field);
   }
@@ -303,9 +311,11 @@ export function deriveQuarterlyStatements(
   for (const annualStatement of mergeStatementsByPeriod(annualStatements)) {
     let target: InternalStatement = byDate.get(annualStatement.date) ?? { date: annualStatement.date, currency: annualStatement.currency };
     if (target.currency !== annualStatement.currency) continue;
+    if (annualStatement.epsBasis?.status === "unresolved" && target.eps === undefined) target.epsBasis = annualStatement.epsBasis;
     let changed = false;
 
     for (const field of [...QUARTERLY_FLOW_FIELDS, ...QUARTERLY_AVERAGE_FIELDS]) {
+      if (field === "eps" && target.epsBasis?.status === "unresolved") continue;
       if (statementNumber(target, field) !== null) continue;
       const annualValue = statementNumber(annualStatement, field);
       if (annualValue === null) continue;
@@ -361,6 +371,8 @@ function buildTtmStatements(statements: readonly FinancialStatement[]): Internal
       __timeSeriesTtm: true,
       __timeSeriesDerivedFields: [],
     };
+    const unresolvedEps = window.find((statement) => statement.epsBasis?.status === "unresolved");
+    if (unresolvedEps) ttm.epsBasis = unresolvedEps.epsBasis;
 
     for (const field of [...QUARTERLY_FLOW_FIELDS, ...QUARTERLY_AVERAGE_FIELDS]) {
       const values = window.map((statement) => statementNumber(statement, field));
@@ -469,6 +481,7 @@ function selectedCash(statement: FinancialStatement): SelectedStatementField | n
 function selectedEps(
   statement: FinancialStatement,
 ): { value: number; dependencies: NumericStatementField[] } | null {
+  if (statement.epsBasis?.status === "unresolved") return null;
   if (finiteNumber(statement.eps) && statement.eps !== 0) {
     return { value: statement.eps, dependencies: ["eps"] };
   }
@@ -585,7 +598,10 @@ function pointForStatement(
     // Providers do not supply a reliable issuer fiscal-year/quarter identity.
     // Calendar-month numbering would mislabel non-calendar fiscal years.
     periodLabel: `${period === "annual" ? "Year" : period === "ttm" ? "TTM" : "Quarter"} ended ${statement.date}`,
-    provenance: { quality: derived ? "derived" : "reported" },
+    provenance: {
+      quality: derived || (metric === "eps" && statement.epsBasis?.factor !== undefined && statement.epsBasis.factor !== 1) ? "derived" : "reported",
+      ...((metric === "eps" || metric === "trailingPE") && statement.epsBasis ? { secEpsBasis: statement.epsBasis } : {}),
+    },
   };
 }
 

--- a/src/time-series/reporting.ts
+++ b/src/time-series/reporting.ts
@@ -67,6 +67,11 @@ export function graphRowsForFinancials(
     const previous = points[index - 1]?.value;
     const current = point.value;
     const currentLabel = point.periodLabel === "Current";
+    const previousPoint = points[index - 1];
+    const elapsedDays = previousPoint ? (point.observedAt.getTime() - previousPoint.observedAt.getTime()) / 86_400_000 : 0;
+    // Withheld observations must not turn a multi-year gap into YoY growth.
+    const consecutivePeriod = period === "annual"
+      ? elapsedDays >= 335 && elapsedDays <= 395 : elapsedDays >= 60 && elapsedDays <= 120;
     const date = currentLabel ? "Current" : point.observedAt.toISOString().slice(0, 10);
     return {
       key: `${symbol}:${date}:${metric}`,
@@ -74,7 +79,7 @@ export function graphRowsForFinancials(
       date,
       category: point.periodLabel ?? date,
       value: current,
-      growth: typeof previous === "number" && previous !== 0
+      growth: consecutivePeriod && typeof previous === "number" && previous !== 0
         ? (current - previous) / Math.abs(previous)
         : null,
       barWidth: Math.max(1, Math.round((Math.abs(current) / maximum) * 24)),

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -1,6 +1,6 @@
 import { resolveAssetDisplayKind } from "../market-data/market/format";
 import { financialPeriodCoverage, financialPeriodCoverageWarnings, limitSeriesObservations } from "./financial-period-coverage";
-import { FINANCIAL_VINTAGE_NOTICE } from "../utils/financial-statements";
+import { FINANCIAL_VINTAGE_NOTICE, SEC_EPS_BASIS_NOTICE } from "../utils/financial-statements";
 import { appendLiveQuotePoint } from "./chart-data";
 import {
   getTimeRangeForDateWindow,
@@ -1189,6 +1189,10 @@ export async function resolveChartSpecData(
           ? { ...financials, quote: latestQuote(financials.quote, quoteOverride) }
           : financials;
       if (!merged) throw new Error(`No financial data is available for ${instrumentLabel(source)}.`);
+      if ((source.fieldId === "fundamental.eps" || source.fieldId === "valuation.trailingPE")
+        && [...merged.annualStatements, ...merged.quarterlyStatements].some((row) => row.epsBasis)) {
+        warnings.push(SEC_EPS_BASIS_NOTICE);
+      }
       const resolvedSpec = resolvedSource === source ? seriesSpec : { ...seriesSpec, source: resolvedSource };
       sources.onSecurityData?.(resolvedSpec, merged, history !== null);
       const result = baseSecuritySeries(

--- a/src/time-series/sec-eps-research.test.ts
+++ b/src/time-series/sec-eps-research.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { parseCompanyFactsFinancialStatements } from "../sources/sec-edgar";
+import { mergeFinancialStatementRows } from "../utils/financial-statements";
+import { extractFundamentalSeries } from "./fundamentals";
+import { graphRowsForFinancials } from "./reporting";
+
+const old = { form: "10-K", accn: "0000320193-19-000119", filed: "2019-10-31" };
+const next = { form: "10-K", accn: "0000320193-20-000096", filed: "2020-10-30" };
+const oldPeriod = { start: "2016-09-25", end: "2017-09-30" };
+const comparison = { start: "2017-10-01", end: "2018-09-29" };
+const payload = { facts: { "us-gaap": {
+  StockholdersEquityNoteStockSplitConversionRatio1: { units: { pure: [{ ...next, end: "2020-08-28", val: 4 }] } },
+  EarningsPerShareDiluted: { units: { "USD/shares": [
+    { ...old, ...oldPeriod, val: 9.21 }, { ...old, ...comparison, val: 11.91 }, { ...next, ...comparison, val: 2.98 },
+  ] } },
+  NetIncomeLoss: { units: { USD: [
+    { ...old, ...oldPeriod, val: 48_351_000_000 },
+    { ...old, ...comparison, val: 59_531_000_000 }, { ...next, ...comparison, val: 59_531_000_000 },
+  ] } },
+} } };
+
+test("SEC split correction survives cached statement merging, graph growth and JSON export", () => {
+  const projected = parseCompanyFactsFinancialStatements(payload);
+  const annualStatements = mergeFinancialStatementRows(projected.annualStatements, [
+    { date: "2017-09-30", currency: "USD", eps: 9.21, netIncome: 48_351_000_000 },
+  ]);
+  expect(annualStatements[0]).toMatchObject({ eps: 2.3025, netIncome: 48_351_000_000, fieldAvailability: { eps: "2020-10-30", netIncome: "2019-10-31" }, dateEvidence: { filed: "2019-10-31" } });
+  const refreshed = mergeFinancialStatementRows([{ date: "2017-09-30", currency: "USD", eps: 9.21 }], projected.annualStatements);
+  expect(refreshed[0]).toMatchObject({ eps: 2.3025, epsBasis: { factor: 4 }, fieldAvailability: { eps: "2020-10-30" } });
+  const unrelated = mergeFinancialStatementRows([{ date: "2017-09-30", currency: "USD", eps: 10 }], projected.annualStatements)[0]!;
+  expect(unrelated.eps).toBe(10);
+  expect(unrelated.epsBasis).toBeUndefined();
+  const financials = { annualStatements, quarterlyStatements: [], priceHistory: [] };
+  const series = extractFundamentalSeries(financials, { kind: "security", instrument: { symbol: "AAPL" }, fieldId: "fundamental.eps", period: "annual", timestampMode: "period-end" });
+  const exported = JSON.parse(JSON.stringify(series));
+  expect(exported[0]).toMatchObject({ value: 2.3025, observedAt: "2017-09-30T00:00:00.000Z", availableAt: "2020-10-30T00:00:00.000Z", provenance: { quality: "derived", secEpsBasis: { originalValue: 9.21, factor: 4 } } });
+  expect(graphRowsForFinancials(financials, "fundamental", "eps", "annual", "AAPL")[1]!.growth).toBeCloseTo(2.98 / 2.3025 - 1, 10);
+});
+
+test("unresolved EPS cannot return through cached fallback, inferred P/E or a multi-year growth gap", () => {
+  const row = { ...parseCompanyFactsFinancialStatements(payload).annualStatements[0]!, eps: undefined };
+  row.epsBasis = { ...row.epsBasis!, status: "unresolved", factor: undefined };
+  const merged = mergeFinancialStatementRows([row], [{ date: row.date, currency: "USD", eps: 9.21, dilutedShares: 5_251_692_000 }]);
+  expect(merged[0]!.eps).toBeUndefined();
+  const financials = { annualStatements: [
+    { date: "2016-09-24", currency: "USD", eps: 2 }, ...merged,
+    { date: "2018-09-29", currency: "USD", eps: 3 },
+  ], quarterlyStatements: [], priceHistory: [{ date: new Date("2019-10-31"), close: 50 }],
+  quote: { symbol: "AAPL", price: 50, currency: "USD", change: 0, changePercent: 0, lastUpdated: Date.parse("2019-10-31") } };
+  const eps = graphRowsForFinancials(financials, "fundamental", "eps", "annual", "AAPL");
+  expect(eps.map((point) => point.date)).toEqual(["2016-09-24", "2018-09-29"]);
+  expect(eps[1]!.growth).toBeNull();
+  const pe = extractFundamentalSeries({ ...financials, annualStatements: merged }, { kind: "security", instrument: { symbol: "AAPL" }, fieldId: "valuation.trailingPE", period: "annual", timestampMode: "period-end" });
+  expect(pe).toEqual([]);
+});

--- a/src/time-series/types.ts
+++ b/src/time-series/types.ts
@@ -109,6 +109,7 @@ export interface TimeSeriesPoint {
   volume?: number | null;
   periodLabel?: string;
   provenance?: {
+    secEpsBasis?: import("../utils/sec-eps-basis").SecEpsBasis;
     providerId?: string;
     quality?: "reported" | "derived" | "estimated";
   };

--- a/src/types/financials.ts
+++ b/src/types/financials.ts
@@ -255,6 +255,8 @@ export interface CompanyProfile {
 }
 
 export interface FinancialStatement {
+  /** SEC EPS share basis; raw source values remain available in the evidence. */
+  epsBasis?: import("../utils/sec-eps-basis").SecEpsBasis;
   date: string;
   /** Source of the fiscal period date; does not establish metric publication dates. */
   dateSource?: "sec" | "provider";

--- a/src/utils/financial-statements.ts
+++ b/src/utils/financial-statements.ts
@@ -1,8 +1,9 @@
 import type { FinancialStatement } from "../types/financials";
 
 export const FINANCIAL_VINTAGE_NOTICE = "Latest available statements may include restatements. Historical as-of values are not reconstructed.";
+export const SEC_EPS_BASIS_NOTICE = "SEC EPS uses corroborated split-adjusted share bases. Unverified bases are unavailable.";
 
-const STATEMENT_METADATA_KEYS = new Set(["date", "dateSource", "providerDate", "dateEvidence", "currency", "availableAt", "fieldAvailability"]);
+const STATEMENT_METADATA_KEYS = new Set(["date", "dateSource", "providerDate", "dateEvidence", "currency", "availableAt", "fieldAvailability", "epsBasis"]);
 const NEARBY_PERIOD_END_MS = 7 * 24 * 60 * 60 * 1_000;
 
 /** An explicit field map is authoritative: omitted fields have unknown availability. */
@@ -139,6 +140,8 @@ export function mergeFinancialStatementRows(
       // otherwise retain their primary provider's period identity.
       date: canonicalStatementDate(row, fallback),
     } as FinancialStatement;
+    const correctedFallbackEps = !row.epsBasis && !!fallback?.epsBasis && row.eps === fallback.epsBasis.originalValue;
+    if (row.eps !== undefined && !row.epsBasis && !correctedFallbackEps) delete merged.epsBasis;
     // Period provenance belongs to the selected date. It must not leak from a
     // different fallback period or become publication evidence for any value.
     const dateOwner = [row, fallback].find((candidate) => candidate?.date === merged.date && candidate.dateSource === "sec")
@@ -152,6 +155,19 @@ export function mergeFinancialStatementRows(
     const keys = metricKeys(row, fallback);
 
     for (const key of keys) {
+      // A refreshed SEC decision supersedes precisely the original EPS still
+      // held by a primary cache; unrelated provider values keep their priority.
+      if (key === "eps" && correctedFallbackEps) {
+        if (fallback!.epsBasis!.status === "unresolved") delete merged.eps;
+        else merged.eps = fallback!.eps;
+        const available = statementFieldAvailability(fallback, "eps");
+        if (available && merged.eps !== undefined) fieldAvailability.eps = available;
+        continue;
+      }
+      if (key === "eps" && row.epsBasis?.status === "unresolved") {
+        delete merged.eps;
+        continue;
+      }
       const primaryHasValue = hasMetricValue(row, key);
       const fallbackHasValue = hasMetricValue(fallback, key);
       if (!primaryHasValue && fallbackHasValue) {

--- a/src/utils/sec-eps-basis.test.ts
+++ b/src/utils/sec-eps-basis.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { createSecEpsBasisResolver } from "./sec-eps-basis";
+
+const oldAccn = "0000320193-19-000119";
+const newAccn = "0000320193-20-000096";
+const period = { start: "2017-10-01", end: "2018-09-29", form: "10-K" };
+const before = { ...period, accn: oldAccn, filed: "2019-10-31", val: 11.91 };
+const after = { ...period, accn: newAccn, filed: "2020-10-30", val: 2.98 };
+const split = { end: "2020-08-28", val: 4, accn: newAccn, filed: "2020-10-30", form: "10-K" };
+const payload = (eps = [before, after], splitRows = [split], incomes = eps.map((row) => ({ ...row, val: 59_531_000_000 }))) => ({
+  facts: { "us-gaap": {
+    EarningsPerShareDiluted: { units: { "USD/shares": eps } },
+    StockholdersEquityNoteStockSplitConversionRatio1: { units: { pure: splitRows } },
+    NetIncomeLoss: { units: { USD: incomes } },
+    WeightedAverageNumberOfDilutedSharesOutstanding: { units: { shares: eps.map((row) => ({ ...row, val: row.val === 2.98 ? 20_000_435_000 : 5_000_109_000 })) } },
+  } },
+});
+
+describe("SEC EPS share-basis evidence", () => {
+  test("uses an exact split and rounded comparative EPS with unchanged income", () => {
+    const resolve = createSecEpsBasisResolver(payload());
+    const older = { ...before, start: "2016-09-25", end: "2017-09-30", val: 9.21 };
+    expect(resolve(older)).toMatchObject({ value: 2.3025, availableAt: "2020-10-30", basis: {
+      status: "split-adjusted", originalValue: 9.21, originalFiled: "2019-10-31", factor: 4,
+      evidence: [{ date: "2020-08-28", ratio: 4, accessionNumber: newAccn, beforeEps: 11.91, afterEps: 2.98 }],
+    } });
+    expect(resolve(after)).toMatchObject({ value: 2.98, basis: { factor: 1, originalValue: 2.98 } });
+  });
+
+  test("links an earlier accession only with matching comparative EPS and shares", () => {
+    const earlier = { ...before, accn: "0000320193-18-000145", filed: "2018-11-05" };
+    expect(createSecEpsBasisResolver(payload([earlier, before, after]))(earlier)).toMatchObject({ value: 2.9775, basis: { factor: 4 } });
+    // This accession still has a direct same-period split witness, so use a
+    // different old period to test the repeat-only link rather than that edge.
+    const repeated = { ...before, start: "2016-09-25", end: "2017-09-30", val: 9.21 };
+    const oldRepeat = { ...repeated, accn: earlier.accn, filed: earlier.filed };
+    const fixture = payload([oldRepeat, repeated, before, after]);
+    expect(createSecEpsBasisResolver(fixture)(oldRepeat).basis?.factor).toBe(4);
+    fixture.facts["us-gaap"].WeightedAverageNumberOfDilutedSharesOutstanding.units.shares[0]!.val += 1;
+    expect(createSecEpsBasisResolver(fixture)(oldRepeat)).toMatchObject({ basis: { status: "unresolved" } });
+    expect(createSecEpsBasisResolver(fixture)(oldRepeat).value).toBeUndefined();
+  });
+
+  test("does not double-adjust an already restated pre-effective filing", () => {
+    const earlyAdjusted = { ...after, accn: "0000320193-20-000062", filed: "2020-07-31" };
+    const resolve = createSecEpsBasisResolver(payload([before, earlyAdjusted, after]));
+    expect(resolve(earlyAdjusted)).toMatchObject({ value: 2.98, availableAt: "2020-10-30", basis: { factor: 1 } });
+  });
+
+  test("composes two disclosed, independently corroborated split factors", () => {
+    const a = { ...before, start: "2010-09-26", end: "2011-09-24", accn: "0000320193-12-000001", filed: "2012-10-31", val: 28 };
+    const b = { ...a, accn: "0000320193-14-000001", filed: "2014-10-31", val: 4 };
+    const c = { ...a, accn: newAccn, filed: "2020-10-30", val: 1 };
+    const one = { ...split, end: "2014-06-06", val: 7, accn: b.accn, filed: b.filed };
+    const resolve = createSecEpsBasisResolver(payload([a, b, c], [one, split]));
+    expect(resolve({ ...a, end: "2010-09-25", val: 14 })).toMatchObject({ value: .5, basis: { factor: 28 } });
+    expect(resolve(b)).toMatchObject({ value: 1, basis: { factor: 4 } });
+  });
+
+  test("supports a reverse split without confusing it with earnings growth", () => {
+    const pre = { ...before, val: 2 };
+    const post = { ...after, val: 10 };
+    expect(createSecEpsBasisResolver(payload([pre, post], [{ ...split, val: .2 }]))(pre)).toMatchObject({ value: 10, basis: { factor: .2 } });
+  });
+
+  test("never infers a split from EPS changes, price changes, or filing chronology", () => {
+    expect(createSecEpsBasisResolver(payload([before, after], []))(before)).toEqual({ value: 11.91, availableAt: before.filed });
+    const unknown = { ...before, accn: "0000320193-17-000001", filed: "2017-10-31" };
+    expect(createSecEpsBasisResolver(payload())(unknown).value).toBeUndefined();
+    const restatement = payload();
+    restatement.facts["us-gaap"].NetIncomeLoss.units.USD[1]!.val += 1;
+    expect(createSecEpsBasisResolver(restatement)(before).value).toBeUndefined();
+    expect(createSecEpsBasisResolver(payload([before, { ...after, val: 3.5 }]))(before).value).toBeUndefined();
+  });
+
+  test("rejects conflicting, missing, zero and invalid-date evidence", () => {
+    expect(createSecEpsBasisResolver(payload([before, after], [split, { ...split, val: 5 }]))(before).value).toBeUndefined();
+    expect(createSecEpsBasisResolver(payload([{ ...before, val: 0 }, { ...after, val: 0 }]))(before).value).toBeUndefined();
+    expect(() => createSecEpsBasisResolver(payload([before, after], [{ ...split, end: "2020-99-99" }]))).not.toThrow();
+    expect(createSecEpsBasisResolver(payload())({ ...before, filed: undefined }).value).toBeUndefined();
+  });
+});

--- a/src/utils/sec-eps-basis.ts
+++ b/src/utils/sec-eps-basis.ts
@@ -1,0 +1,152 @@
+/** Keep this pure SEC projection rule synchronized with the cloud backend. */
+export interface SecEpsSplitEvidence {
+  date: string;
+  ratio: number;
+  accessionNumber: string;
+  filed: string;
+  comparativePeriodEnd?: string;
+  beforeAccessionNumber?: string;
+  beforeEps?: number;
+  afterEps?: number;
+}
+
+export interface SecEpsBasis {
+  status: "split-adjusted" | "unresolved";
+  source: "sec";
+  originalValue: number;
+  originalFiled?: string;
+  basisDate: string;
+  factor?: number;
+  evidence: SecEpsSplitEvidence[];
+}
+
+type Fact = { start?: string; end?: string; val?: number; accn?: string; filed?: string; form?: string };
+type Row = Fact & { start: string; end: string; val: number; accn: string; filed: string };
+type Edge = { node: string; factor: number; evidence?: SecEpsSplitEvidence };
+const date = (value: unknown): value is string => typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)
+  && Number.isFinite(Date.parse(`${value}T00:00:00Z`)) && new Date(`${value}T00:00:00Z`).toISOString().slice(0, 10) === value;
+const record = (value: unknown): Record<string, unknown> => value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+
+function entries(payload: unknown, tag: string, unit: string): Fact[] {
+  const values = record(record(record(record(record(payload).facts)["us-gaap"])[tag]).units)[unit];
+  return Array.isArray(values) ? values.map(record).filter((row) => typeof row.val === "number" && Number.isFinite(row.val)
+    && date(row.end) && date(row.filed) && /^(10-K|10-Q)(\/A)?$/.test(String(row.form))
+    && /^\d{10}-\d{2}-\d{6}$/.test(String(row.accn))) as Fact[] : [];
+}
+
+function uniqueObservations(rows: Fact[]): Map<string, Row> {
+  const result = new Map<string, Row>();
+  const ambiguous = new Set<string>();
+  for (const row of rows) {
+    if (!date(row.start) || !row.end || row.start > row.end || row.filed! < row.end) continue;
+    const key = `${row.accn}:${row.start}:${row.end}`;
+    if (result.has(key) && result.get(key)!.val !== row.val) ambiguous.add(key);
+    result.set(key, row as Row);
+  }
+  for (const key of ambiguous) result.delete(key);
+  return result;
+}
+
+/**
+ * Share bases belong to source accessions, not filing dates. A split edge needs
+ * an explicit SEC split fact and unchanged same-period income with inverse EPS
+ * restatement. Repeated EPS AND diluted shares connect otherwise equal bases.
+ * No price jump, ticker exception, or chronological assumption establishes one.
+ */
+export function createSecEpsBasisResolver(payload: unknown): (fact: Fact) => { value?: number; basis?: SecEpsBasis; availableAt?: string } {
+  const splits = entries(payload, "StockholdersEquityNoteStockSplitConversionRatio1", "pure")
+    .filter((row) => row.val! > 0 && row.val !== 1)
+    .sort((a, b) => a.filed!.localeCompare(b.filed!));
+  if (splits.length === 0) return (fact) => ({ value: fact.val, availableAt: fact.filed });
+  const eventRows = new Map<string, Fact>();
+  const conflicts = new Set<string>();
+  for (const split of splits) {
+    if (eventRows.has(split.end!) && eventRows.get(split.end!)!.val !== split.val) conflicts.add(split.end!);
+    if (!eventRows.has(split.end!)) eventRows.set(split.end!, split);
+  }
+  const latest = [...eventRows.values()].sort((a, b) => a.end!.localeCompare(b.end!)).at(-1)!;
+  const eps = uniqueObservations(entries(payload, "EarningsPerShareDiluted", "USD/shares"));
+  const shares = uniqueObservations(entries(payload, "WeightedAverageNumberOfDilutedSharesOutstanding", "shares"));
+  const income = uniqueObservations(entries(payload, "NetIncomeLoss", "USD"));
+  const graph = new Map<string, Edge[]>();
+  const connect = (before: string, after: string, ratio: number, evidence?: SecEpsSplitEvidence) => {
+    graph.set(after, [...graph.get(after) ?? [], { node: before, factor: ratio, evidence }]);
+    graph.set(before, [...graph.get(before) ?? [], { node: after, factor: 1 / ratio, evidence }]);
+  };
+  const identical = new Map<string, Row>();
+  const periods = new Map<string, Row[]>();
+  for (const [key, row] of eps) {
+    const period = `${row.start}:${row.end}`;
+    periods.set(period, [...periods.get(period) ?? [], row]);
+    const denominator = shares.get(key)?.val;
+    if (!row.val || !denominator || denominator <= 0) continue;
+    const identity = `${period}:${row.val}:${denominator}`;
+    const prior = identical.get(identity);
+    if (prior && prior.accn !== row.accn) connect(prior.accn, row.accn, 1);
+    else identical.set(identity, row);
+  }
+  const proved = new Map<string, SecEpsSplitEvidence>();
+  for (const split of eventRows.values()) {
+    if (conflicts.has(split.end!)) continue;
+    for (const after of eps.values()) {
+      if (after.accn !== split.accn || after.filed !== split.filed || after.end >= split.end! || after.val === 0) continue;
+      for (const before of periods.get(`${after.start}:${after.end}`) ?? []) {
+        if (before.accn === after.accn || before.filed >= after.filed || before.val === after.val || before.val * after.val <= 0) continue;
+        const beforeIncome = income.get(`${before.accn}:${before.start}:${before.end}`)?.val;
+        const afterIncome = income.get(`${after.accn}:${after.start}:${after.end}`)?.val;
+        if (beforeIncome === undefined || beforeIncome === 0 || beforeIncome !== afterIncome) continue;
+        // EPS reports rounded to cents have overlapping rounding intervals.
+        // This accommodates 11.91 / 4 -> 2.98 without inventing precision.
+        const tolerance = .005 + .005 / split.val!;
+        if (Math.abs(before.val / split.val! - after.val) > tolerance + 1e-12
+          || Math.abs(before.val - after.val) <= tolerance * 2) continue;
+        const evidence: SecEpsSplitEvidence = {
+          date: split.end!, ratio: split.val!, accessionNumber: split.accn!, filed: split.filed!,
+          comparativePeriodEnd: before.end, beforeAccessionNumber: before.accn, beforeEps: before.val, afterEps: after.val,
+        };
+        connect(before.accn, after.accn, split.val!, evidence);
+        proved.set(split.end!, evidence);
+      }
+    }
+  }
+  const paths = new Map<string, { factor: number; evidence: SecEpsSplitEvidence[] }>();
+  const queue = [latest.accn!];
+  paths.set(latest.accn!, { factor: 1, evidence: [] });
+  let inconsistent = false;
+  for (let i = 0; i < queue.length; i++) {
+    const node = queue[i]!;
+    const path = paths.get(node)!;
+    for (const edge of graph.get(node) ?? []) {
+      const factor = path.factor * edge.factor;
+      if (!Number.isFinite(factor) || factor <= 0) { inconsistent = true; continue; }
+      const previous = paths.get(edge.node);
+      if (previous) {
+        if (Math.abs(previous.factor - factor) > Math.max(previous.factor, factor) * 1e-10) inconsistent = true;
+        continue;
+      }
+      paths.set(edge.node, { factor, evidence: [...path.evidence, ...edge.evidence ? [edge.evidence] : []] });
+      queue.push(edge.node);
+    }
+  }
+  return (fact) => {
+    if (!fact.end || fact.end >= latest.end!) return { value: fact.val, availableAt: fact.filed };
+    const path = fact.accn ? paths.get(fact.accn) : undefined;
+    const target = proved.get(latest.end!);
+    const evidence = [...new Map([...(path?.evidence ?? []), target ?? {
+      date: latest.end!, ratio: latest.val!, accessionNumber: latest.accn!, filed: latest.filed!,
+    }].map((item) => [item.date, item])).values()].sort((a, b) => a.date.localeCompare(b.date));
+    const basis: SecEpsBasis = {
+      status: "unresolved", source: "sec", originalValue: fact.val!, originalFiled: fact.filed,
+      basisDate: latest.end!, evidence,
+    };
+    // Any unproved intervening disclosure can represent an additional share basis.
+    const unproved = [...eventRows.values()].some((event) => event.end! > fact.end! && !proved.has(event.end!));
+    if (!path || !target || inconsistent || unproved || !date(fact.filed)) return { basis };
+    const value = fact.val! / path.factor;
+    if (!Number.isFinite(value)) return { basis };
+    return {
+      value, basis: { ...basis, status: "split-adjusted", factor: path.factor },
+      availableAt: [fact.filed, ...evidence.map((item) => item.filed)].sort().at(-1),
+    };
+  };
+}


### PR DESCRIPTION
Apple’s annual EPS comparison mixed pre-split 2017 EPS of $9.21 with split-adjusted 2018 EPS of $2.98, producing a false −67.64% decline. Use exact SEC split disclosures and corroborated same-period filing observations to put proven EPS values on a consistent share basis. The 2017 value becomes $2.3025; its original value, factor, filing evidence and later availability date remain in research exports. Unproved bases are unavailable.

The native SEC parser matches deployed backend PR240. Statement merges preserve explicit withdrawals and precise source corrections, old SEC resource caches refresh, and EPS/P/E derivations cannot restore withheld values. Per-period growth requires adjacent annual or quarterly observations. Charts explain the share basis alongside the existing latest-facts notice; common price-comparison notices remain intact.

Validation: 204 tests / 880 assertions, all six TypeScript targets, web build, independent source reviews, actual production API initial/repeat controls, and local browser against deployed backend240. Saved annual EPS and MSFT/COST/AAPL comparisons reopen correctly. Recorded-source native checks cover 140/80 columns; 30 margin and 30 FCF observations independently match fresh SEC facts. This is latest-facts research, not a reconstructed historical as-of database.

The independently confirmed shared Copy Screenshot wrapped-text clipping is recorded for a separate bounded fix; JSON exports retain full basis evidence. Backend240 is deployed before this frontend change. No release or product version change.
