### PR TITLE
Use statement reporting currency in financial charts

### DIFF
--- a/src/time-series/fundamentals.ts
+++ b/src/time-series/fundamentals.ts
@@ -4,7 +4,8 @@ import type {
   TickerFinancials,
 } from "../types/financials";
 import { areNearbyFinancialPeriodEnds, completeAvailability, statementFieldAvailability } from "../utils/financial-statements";
-import { canonicalTimeSeriesFieldId } from "./field-catalog";
+import { canonicalTimeSeriesFieldId, getTimeSeriesField } from "./field-catalog";
+import { reportingCurrencySeries } from "./reporting-currency";
 import type { SecuritySeriesSource, SeriesPeriod, TimeSeriesPoint } from "./types";
 
 type NumericStatementField =
@@ -601,6 +602,7 @@ function pointForStatement(
     provenance: {
       quality: derived || (metric === "eps" && statement.epsBasis?.factor !== undefined && statement.epsBasis.factor !== 1) ? "derived" : "reported",
       ...((metric === "eps" || metric === "trailingPE") && statement.epsBasis ? { secEpsBasis: statement.epsBasis } : {}),
+      currency: statement.currency,
     },
   };
 }
@@ -821,7 +823,9 @@ export function extractFundamentalSeries(
       );
       return point ? [point] : [];
     });
-    return dedupeFundamentalPeriods(points);
+    const deduped = dedupeFundamentalPeriods(points);
+    return getTimeSeriesField(canonicalId)?.unit.startsWith("currency")
+      ? reportingCurrencySeries(deduped, financials.financialCurrency).points : deduped;
   }
 
   if (namespace !== "valuation" || !VALUATION_IDS.has(metric)) return [];

--- a/src/time-series/reporting-currency.test.ts
+++ b/src/time-series/reporting-currency.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test";
+import { createTestDataProvider } from "../test-support/data-provider";
+import type { TickerFinancials } from "../types/financials";
+import { extractFundamentalSeries } from "./fundamentals";
+import { resolveChartSpecData } from "./resolve";
+import { graphRowsForFinancials, summarizeResolvedSeries } from "./reporting";
+import { CHART_SPEC_VERSION, type ChartSpec, type SecuritySeriesSource } from "./types";
+
+const source = (fieldId = "fundamental.totalRevenue"): SecuritySeriesSource => ({
+  kind: "security", instrument: { symbol: "SHEL", exchange: "LSE" }, fieldId,
+  period: "annual", timestampMode: "period-end",
+});
+const financials = (): TickerFinancials => ({
+  financialCurrency: "USD",
+  quote: { symbol: "SHEL", currency: "GBP", price: 35.37, change: 0, changePercent: 0, lastUpdated: Date.parse("2026-01-02") },
+  priceHistory: [{ date: new Date("2025-12-31"), close: 35 }],
+  quarterlyStatements: [],
+  annualStatements: [2024, 2025].map((year, i) => ({
+    date: `${year}-12-31`, currency: "USD", totalRevenue: 100 + i * 20, operatingIncome: 10 + i * 2, eps: 2 + i,
+  })),
+});
+async function resolve(value: TickerFinancials, fieldId = "fundamental.totalRevenue") {
+  const spec: ChartSpec = {
+    version: CHART_SPEC_VERSION, viewport: { range: "5Y", resolution: "1d" },
+    panels: [{ id: "main" }], studies: [],
+    series: [{ id: "series", source: source(fieldId), style: "columns", transform: "raw", axis: "left", panelId: "main", interpolation: "none" }],
+  };
+  return resolveChartSpecData(spec, {
+    now: new Date("2026-01-02"),
+    dataProvider: createTestDataProvider({
+      getTickerFinancials: async () => value,
+      getQuote: async () => { if (!value.quote) throw new Error("Quote unavailable"); return value.quote; },
+      getPriceHistoryForResolution: async () => value.priceHistory,
+    }),
+  });
+}
+
+test("statement money and EPS use reporting currency while the London price stays GBP", async () => {
+  const value = financials();
+  const revenue = (await resolve(value)).series[0]!;
+  expect(revenue.unit).toBe("USD");
+  expect(revenue.points.map((point) => point.value)).toEqual([100, 120]);
+  expect(summarizeResolvedSeries(revenue)).toMatchObject({ unit: "USD", startValue: 100, endValue: 120 });
+  expect((await resolve(value, "fundamental.eps")).series[0]?.unit).toBe("USD/share");
+  expect((await resolve(value, "market.close")).series[0]?.unit).toBe("GBP/share");
+  expect(value.annualStatements[1]?.totalRevenue).toBe(120);
+});
+
+test("statement currency survives missing quotes and outranks inconsistent aggregate metadata", async () => {
+  const value = financials();
+  value.quote = undefined;
+  value.financialCurrency = "EUR";
+  const result = await resolve(value);
+  expect(result.series[0]).toMatchObject({ unit: "USD", unitGroup: "currency-total:USD" });
+  expect(result.errors).toEqual([]);
+  expect(result.series[0]?.points.at(-1)?.value).toBe(120);
+  value.financialCurrency = "USD";
+  value.annualStatements.forEach((row) => { delete row.currency; });
+  expect((await resolve(value)).series[0]?.unit).toBe("USD");
+});
+
+test("an unavailable reporting currency is not replaced by the share quotation currency", async () => {
+  const value = financials();
+  value.financialCurrency = undefined;
+  value.annualStatements.forEach((row) => { delete row.currency; });
+  const result = await resolve(value);
+  expect(result.series[0]?.unit).toBe("currency");
+  expect(result.warnings.some((warning) => warning.includes("Reporting currency is unavailable"))).toBe(true);
+});
+
+test("currency changes preserve source dates as gaps and do not suppress dimensionless margins", async () => {
+  const value = financials();
+  value.annualStatements[0]!.currency = "EUR";
+  const points = extractFundamentalSeries(value, source());
+  expect(points.map((point) => point.value)).toEqual([null, 120]);
+  expect(points[0]).toMatchObject({ observedAt: new Date("2024-12-31"), provenance: { currency: "EUR" } });
+  expect(value.annualStatements[0]!.totalRevenue).toBe(100);
+  const result = await resolve(value);
+  expect(result.series[0]?.unit).toBe("USD");
+  expect(result.warnings.some((warning) => warning.includes("Only USD reporting-currency"))).toBe(true);
+  expect(extractFundamentalSeries(value, source("fundamental.operatingMargin")).map((point) => point.value)).toEqual([10, 10]);
+
+  // Aggregate USD does not establish the currency of a missing historical row
+  // once the supplied statements show that the reporting currency changed.
+  value.annualStatements.splice(1, 0, { date: "2025-06-30", totalRevenue: 115 });
+  expect(extractFundamentalSeries(value, source()).map((point) => point.value)).toEqual([null, null, 120]);
+
+  // The headless table filters unavailable values, but a missing intervening
+  // reporting-currency period must not become ordinary annual growth.
+  value.annualStatements = [
+    { date: "2023-12-31", currency: "USD", totalRevenue: 100 },
+    { date: "2024-12-31", currency: "EUR", totalRevenue: 110 },
+    { date: "2025-12-31", currency: "USD", totalRevenue: 120 },
+    { date: "2026-12-31", currency: "USD", totalRevenue: 132 },
+  ];
+  const rows = graphRowsForFinancials(value, "fundamental", "totalRevenue", "annual", "SHEL");
+  expect(rows.map((row) => row.value)).toEqual([100, 120, 132]);
+  expect(rows.map((row) => row.growth)).toEqual([null, null, .1]);
+});

--- a/src/time-series/reporting-currency.ts
+++ b/src/time-series/reporting-currency.ts
@@ -1,0 +1,33 @@
+import type { TimeSeriesPoint } from "./types";
+
+/** Statement currency is independent of the currency in which a share trades. */
+export function reportingCurrencySeries(points: readonly TimeSeriesPoint[], fallbackCurrency?: string) {
+  const declared = fallbackCurrency?.trim() || undefined;
+  const explicit = new Set(points.flatMap((point) => point.provenance?.currency?.trim() ? [point.provenance.currency.trim()] : []));
+  // A current aggregate cannot fill historical currency gaps when the rows
+  // themselves establish a currency change or contradict that aggregate.
+  const fallback = explicit.size === 0 || (explicit.size === 1 && declared && explicit.has(declared)) ? declared : undefined;
+  const withCurrency = points.map((point) => ({
+    ...point,
+    provenance: { ...point.provenance, currency: point.provenance?.currency?.trim() || fallback },
+  }));
+  const latest = [...withCurrency].sort((a, b) => b.observedAt.getTime() - a.observedAt.getTime())
+    .find((point) => point.provenance.currency);
+  const currency = latest?.provenance.currency;
+  if (!currency) return {
+    points: withCurrency,
+    currency: undefined,
+    warning: points.length ? "Reporting currency is unavailable for these monetary observations." : undefined,
+  };
+  const excluded = withCurrency.some((point) => point.provenance.currency !== currency);
+  return {
+    currency,
+    // A gap preserves the fiscal date and source currency without calculating a
+    // return or study across monetary values in different units.
+    points: withCurrency.map((point) => point.provenance.currency === currency
+      ? point : { ...point, value: null, rawValue: null }),
+    warning: excluded
+      ? `Only ${currency} reporting-currency observations are shown; other or unspecified currencies are unavailable. No FX conversion is applied.`
+      : undefined,
+  };
+}

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -46,6 +46,7 @@ import {
 import { applyResolvedSeriesTransform } from "./transforms";
 import { clipSeriesToWindow } from "./alignment";
 import { clipPriceComparison, priceComparisonSeriesIds, resolvePriceComparison } from "./price-comparison";
+import { reportingCurrencySeries } from "./reporting-currency";
 import { chartQuoteOverrideKeyForSource } from "./live-quotes";
 import { chartSeriesSourceKey } from "../capabilities/chart-series";
 import { resolutionForExplicitMarketPeriods } from "./market-resolution";
@@ -678,7 +679,9 @@ function baseSecuritySeries(
   if (!field) return null;
   const points = extractSecuritySeries(financials, spec.source);
   const symbol = instrumentLabel(spec.source);
-  const currency = financials.quote?.currency || quoteMetadata?.currency;
+  const statementCurrency = field.id.startsWith("fundamental.") && field.unit.startsWith("currency")
+    ? reportingCurrencySeries(points, financials.financialCurrency) : null;
+  const currency = statementCurrency ? statementCurrency.currency : financials.quote?.currency || quoteMetadata?.currency;
   const assetKind = resolveAssetDisplayKind({ assetCategory: financials.quote?.instrumentType || quoteMetadata?.instrumentType });
   const volumeUnit = assetKind === "equity" ? "shares" as const : assetKind === "contract" ? "contracts" as const : undefined;
   const unit = field.id === "market.volume" ? volumeUnit ?? ""
@@ -705,7 +708,7 @@ function baseSecuritySeries(
     unitGroup: currencyUnitGroup,
     volumeUnit,
     warning: field.id === "market.volume" && !volumeUnit && points.length > 0
-      ? "Volume unit unknown." : undefined,
+      ? "Volume unit unknown." : statementCurrency?.warning,
     nativeFrequency: spec.source.period && spec.source.period !== "auto"
       ? spec.source.period
       : field.nativeFrequency,
@@ -1204,7 +1207,7 @@ export async function resolveChartSpecData(
       );
       if (!result) throw new Error(`Unknown field ${source.fieldId}.`);
       if (isFundamentalFieldId(source.fieldId) && fundamentalSeriesUsesAvailabilityFallback(merged, source)) {
-        result.warning = "Publication dates are unavailable for some observations; period-end dates are used as a fallback.";
+        result.warning = [result.warning, "Publication dates are unavailable for some observations; period-end dates are used as a fallback."].filter(Boolean).join(" ");
       }
       return result;
     } catch (error) {

--- a/src/time-series/types.ts
+++ b/src/time-series/types.ts
@@ -112,6 +112,8 @@ export interface TimeSeriesPoint {
     secEpsBasis?: import("../utils/sec-eps-basis").SecEpsBasis;
     providerId?: string;
     quality?: "reported" | "derived" | "estimated";
+    /** Reporting currency of this monetary statement observation. */
+    currency?: string;
   };
 }
 


### PR DESCRIPTION
Financial charts used the share quotation currency to label company statements. GF SHEL:XLON therefore displayed USD94.66B of revenue as £94.66B; a missing quote could also remove COST’s known USD unit and trigger a misleading mixed-unit warning.

Use each statement’s reporting currency, with compatible aggregate financial metadata as fallback. Preserve unknown or different-currency periods as gaps and disclose the coverage; do not convert values. Prices retain their trading currency, dimensionless margins retain their observations, and EPS source evidence remains intact. The existing consecutive-period guard prevents headless growth from bridging a withheld year.

Validation: 82 focused tests / 422 assertions, all six TypeScript targets, and web build passed. Independent review passed 208 tests / 901 assertions. Actual local web with production data and ordinary reload shows Shell $94.66B; the three-company comparison retains USD units. Native 140/80-column checks passed with live provider data. No release or version bump.
