### PR TITLE
Keep wrapped research notes in copied chart images

### DIFF
--- a/src/utils/dom-screenshot.test.ts
+++ b/src/utils/dom-screenshot.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { renderedTextFragments } from "./dom-screenshot";
+
+function measuredLines(lines: { text: string; left: number; top: number }[]) {
+  const value = lines.map((line) => line.text).join("");
+  const boundaries: { start: number; end: number; left: number; top: number }[] = [];
+  let offset = 0;
+  for (const line of lines) {
+    boundaries.push({ start: offset, end: offset + line.text.length, left: line.left, top: line.top });
+    offset += line.text.length;
+  }
+  return { value, measure: (start: number, end: number) => boundaries.flatMap((line) => {
+    const from = Math.max(start, line.start);
+    const to = Math.min(end, line.end);
+    return to > from ? [{ left: line.left + (from - line.start) * 8, top: line.top, width: (to - from) * 8, height: 16 }] : [];
+  }) };
+}
+
+test("screenshot text retains a soft-wrapped research caveat on its measured lines", () => {
+  const fixture = measuredLines([
+    { text: "Latest available statements. SEC EPS uses ", left: 8, top: 20 },
+    { text: "corroborated split-adjusted share bases. ", left: 8, top: 38 },
+    { text: "Unverified bases are unavailable.", left: 8, top: 56 },
+  ]);
+  const result = renderedTextFragments(fixture.value, fixture.measure);
+  expect(result.map((fragment) => fragment.value)).toEqual([
+    "Latest available statements. SEC EPS uses ",
+    "corroborated split-adjusted share bases. ", "Unverified bases are unavailable.",
+  ]);
+  expect(result.map((fragment) => fragment.rect.top)).toEqual([20, 38, 56]);
+  expect(result.map((fragment) => fragment.value).join("")).toBe(fixture.value);
+});
+
+test("line fragments preserve explicit breaks, blank-line spacing and inline indentation", () => {
+  const fixture = measuredLines([
+    { text: "first\n\n", left: 40, top: 10 },
+    { text: "second ", left: 8, top: 46 },
+    { text: "wrapped", left: 8, top: 64 },
+  ]);
+  expect(renderedTextFragments(fixture.value, fixture.measure).map(({ value, rect }) => [value, rect.left, rect.top]))
+    .toEqual([["first\n\n", 40, 10], ["second ", 8, 46], ["wrapped", 8, 64]]);
+});
+
+test("range probes keep surrogate pairs intact and invisible text terminates", () => {
+  const fixture = measuredLines([{ text: "USD 🧾 ", left: 0, top: 0 }, { text: "evidence", left: 0, top: 18 }]);
+  const result = renderedTextFragments(fixture.value, (start, end) => {
+    expect(start).not.toBe(5); expect(end).not.toBe(5);
+    return fixture.measure(start, end);
+  });
+  expect(result.map((fragment) => fragment.value)).toEqual(["USD 🧾 ", "evidence"]);
+  expect(renderedTextFragments("hidden", () => [])).toEqual([]);
+});

--- a/src/utils/dom-screenshot.ts
+++ b/src/utils/dom-screenshot.ts
@@ -136,10 +136,52 @@ function fontFor(style: CSSStyleDeclaration): string {
   ].join(" ");
 }
 
-function textBaselineOffset(style: CSSStyleDeclaration, rect: DOMRect): number {
+function textBaselineOffset(style: CSSStyleDeclaration, rect: Pick<DOMRect, "height">): number {
   const fontSize = px(style.fontSize) || rect.height;
   const lineHeight = px(style.lineHeight) || rect.height || fontSize;
   return Math.max(fontSize * 0.78, (lineHeight + fontSize * 0.58) / 2);
+}
+
+type TextRect = Pick<DOMRect, "left" | "top" | "width" | "height">;
+
+/** Recover the browser's actual line breaks, including font and inline layout. */
+export function renderedTextFragments(
+  value: string,
+  measure: (start: number, end: number) => readonly TextRect[],
+): { value: string; rect: TextRect }[] {
+  const offsets = [0];
+  for (const character of value) offsets.push(offsets.at(-1)! + character.length);
+  const fragments: { value: string; rect: TextRect }[] = [];
+  let start = 0;
+  const visible = (rects: readonly TextRect[]) => rects.filter((rect) => rect.width > 0 && rect.height > 0);
+  while (start < offsets.length - 1) {
+    const remaining = visible(measure(offsets[start]!, value.length));
+    const first = remaining[0];
+    if (!first) break;
+    // Binary search by code-point boundaries; measuring every glyph in long
+    // research notes would add unnecessary layout work to each screenshot.
+    let low = start + 1;
+    let high = offsets.length - 1;
+    let end = low;
+    while (low <= high) {
+      const middle = Math.floor((low + high) / 2);
+      const rects = visible(measure(offsets[start]!, offsets[middle]!));
+      if (rects.every((rect) => Math.abs(rect.top - first.top) < 0.5)) {
+        end = middle;
+        low = middle + 1;
+      } else high = middle - 1;
+    }
+    const rects = visible(measure(offsets[start]!, offsets[end]!));
+    if (rects.length) {
+      const left = Math.min(...rects.map((rect) => rect.left));
+      fragments.push({ value: value.slice(offsets[start], offsets[end]), rect: {
+        left, top: first.top, height: Math.max(...rects.map((rect) => rect.height)),
+        width: Math.max(...rects.map((rect) => rect.left + rect.width)) - left,
+      } });
+    }
+    start = end;
+  }
+  return fragments;
 }
 
 function drawTextNode(
@@ -157,8 +199,7 @@ function drawTextNode(
   const range = document.createRange();
   range.selectNodeContents(textNode);
   const rects = Array.from(range.getClientRects()).filter((rect) => rect.width > 0 && rect.height > 0);
-  range.detach();
-  if (rects.length === 0) return;
+  if (rects.length === 0) { range.detach(); return; }
 
   context.fillStyle = style.color;
   context.font = fontFor(style);
@@ -166,17 +207,21 @@ function drawTextNode(
   context.textBaseline = "alphabetic";
   context.direction = style.direction === "rtl" ? "rtl" : "ltr";
 
-  const explicitLines = value.split(/\r?\n/);
-  if (explicitLines.length === rects.length) {
-    rects.forEach((rect, index) => {
-      const line = explicitLines[index] ?? "";
-      if (line.length === 0) return;
-      context.fillText(line, rect.left - origin.left, rect.top - origin.top + textBaselineOffset(style, rect));
-    });
-    return;
-  }
-
-  context.fillText(value, rects[0]!.left - origin.left, rects[0]!.top - origin.top + textBaselineOffset(style, rects[0]!));
+  try {
+    const fragments = rects.length === 1 ? [{ value, rect: rects[0]! }]
+      : renderedTextFragments(value, (start, end) => {
+        range.setStart(textNode, start);
+        range.setEnd(textNode, end);
+        return Array.from(range.getClientRects());
+      });
+    for (const fragment of fragments) {
+      const text = style.whiteSpace === "normal" || style.whiteSpace === "nowrap"
+        ? fragment.value.replace(/\s+/g, " ") : fragment.value.replace(/\r?\n/g, "");
+      if (!text) continue;
+      const rect = fragment.rect;
+      context.fillText(text, rect.left - origin.left, rect.top - origin.top + textBaselineOffset(style, rect));
+    }
+  } finally { range.detach(); }
 }
 
 function drawCanvasElement(


### PR DESCRIPTION
Copy Screenshot dropped automatically wrapped text from research charts. A saved Apple EPS chart showed the full share-basis explanation on screen, while its copied PNG truncated the first line and omitted the rest.

Split painted text using the browser’s measured Range line positions, preserving complete paragraphs at their visible coordinates. Range probes use code-point boundaries and a binary search per line; single-line text keeps the direct path. Explicit breaks and blank-line spacing follow the measured geometry.

Validation: 21 screenshot/regression tests / 64 assertions, all six TypeScript targets and web build. Actual Copy Screenshot PNGs from the app before/after show the full SEC explanation restored; 800px and 480px pane exports were inspected. The actual deployed financial data and saved date window remain unchanged. No release or product version change.
