### PR TITLE
fix: keep explicit chart windows and legends within bounds

### DIFF
--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -435,6 +435,33 @@ describe("CompositeChart", () => {
     expect(accessoryStart - lastLegendEnd).toBeGreaterThan(1);
   });
 
+  test("leaving a historical chart restores its window's legend value instead of the navigation buffer", async () => {
+    let setCursor: (date: Date | null) => void = () => {};
+    const margin: ResolvedSeries = {
+      ...series("margin", "main", "left", "%", []), label: "MSFT Operating Margin",
+      style: "line", interpolation: "none",
+      points: [point("2024-06-30", 44.64), point("2025-06-30", 45.62), point("2026-06-30", 46.78)],
+    };
+    function HistoricalChart() {
+      const [cursor, updateCursor] = useState<Date | null>(null);
+      setCursor = updateCursor;
+      return <CompositeChart width={100} height={12} panels={[{ id: "main" }]} series={[margin]} clipToViewport
+        viewport={{ start: new Date("2016-01-01"), end: new Date("2025-12-31T23:59:59.999Z") }} cursorDate={cursor} />;
+    }
+    testSetup = await testRender(<HistoricalChart />, { width: 102, height: 14 });
+    await act(async () => { await testSetup!.renderOnce(); await testSetup!.renderOnce(); });
+    const legend = () => testSetup!.captureCharFrame().split("\n")[0]!;
+    expect(legend()).toContain("45.6%");
+    expect(legend()).not.toContain("46.8%");
+    await act(async () => { setCursor(new Date("2024-06-30")); });
+    await act(async () => { await testSetup!.renderOnce(); });
+    expect(legend()).toContain("44.6%");
+    await act(async () => { setCursor(null); });
+    await act(async () => { await testSetup!.renderOnce(); });
+    expect(legend()).toContain("45.6%");
+    expect(legend()).not.toContain("46.8%");
+  });
+
   test("retains financial values and negative signs when long legend names need truncation", async () => {
     testSetup = await testRender(
       <CompositeChart width={100} height={12} panels={[{ id: "main" }]} series={[

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -1615,6 +1615,7 @@ export function CompositeChart({
   focused = false,
   cursorDate,
   viewport,
+  clipToViewport = false,
   viewportResetKey,
   colors,
   interactive = true,
@@ -1851,10 +1852,12 @@ export function CompositeChart({
       width: 1,
       height: Math.max(panelCount, 1),
       viewport: effectiveViewport ?? undefined,
+      clipToViewport,
       timelineSeries: marketTimelineSeries,
       rightOffsetRatio,
     });
   }, [
+    clipToViewport,
     effectiveViewport,
     lastTickKey,
     marketTimelineSeries,

--- a/src/components/chart/composite/scene.test.ts
+++ b/src/components/chart/composite/scene.test.ts
@@ -41,6 +41,63 @@ function series(overrides: Partial<ResolvedSeries> & Pick<ResolvedSeries, "id" |
 }
 
 describe("composite chart scene", () => {
+  test("default legend stays inside the viewport when the right buffer contains a newer observation", () => {
+    const margin = series({ id: "margin", unit: "%", unitGroup: "percent", points: [
+      point("2024-06-30", 44.64), point("2025-06-30", 45.62), point("2026-06-30", 46.78),
+    ] });
+    const options = { width: 100, height: 20, viewport: {
+      start: new Date("2016-01-01"), end: new Date("2025-12-31T23:59:59.999Z"),
+    } };
+    const scene = buildCompositeChartScene([margin], [{ id: "main" }], options)!;
+    // The navigation buffer remains available to draw and inspect explicitly.
+    expect(scene.panels[0]?.series[0]?.points.at(-1)?.value).toBe(46.78);
+    expect(scene.cursorValues[0]?.value).toBe(45.62);
+    const hovered = applyCompositeChartCursor(scene, new Date("2024-06-30"));
+    expect(hovered.cursorValues[0]?.value).toBe(44.64);
+    const cleared = applyCompositeChartCursor(hovered, null);
+    expect(cleared.cursorValues[0]?.value).toBe(45.62);
+    expect(cleared.panels).toBe(scene.panels);
+    const navigated = buildCompositeChartScene([margin], [{ id: "main" }], {
+      ...options, viewport: { start: new Date("2025-01-01"), end: new Date("2026-12-31") },
+    })!;
+    expect(navigated.cursorValues[0]?.value).toBe(46.78);
+    expect(margin.points).toHaveLength(3);
+  });
+
+  test("an empty default window cannot borrow a value from either side of its bounds", () => {
+    const options = { width: 100, height: 20, viewport: {
+      start: new Date("2016-01-01"), end: new Date("2025-12-31T23:59:59.999Z"),
+    } };
+    for (const date of ["2015-12-31", "2026-06-30"]) {
+      const scene = buildCompositeChartScene([series({ id: "outside", points: [point(date, 99)] })], [{ id: "main" }], options)!;
+      expect(scene.cursorValues.every((entry) => entry.value === null)).toBe(true);
+      const hovered = applyCompositeChartCursor(scene, new Date("2020-01-01"));
+      expect(applyCompositeChartCursor(hovered, null).cursorValues.every((entry) => entry.value === null)).toBe(true);
+    }
+  });
+
+  test("explicit research windows bound marks and hover while keeping source data available for navigation", () => {
+    const margin = series({ id: "margin", style: "columns", points: [
+      point("2025-06-30", 45.62), point("2026-06-30", 46.78),
+    ] });
+    const options = { width: 100, height: 20, clipToViewport: true, viewport: {
+      start: new Date("2016-01-01"), end: new Date("2025-12-31T23:59:59.999Z"),
+    } };
+    const scene = buildCompositeChartScene([margin], [{ id: "main" }], options)!;
+    expect(scene.panels[0]?.series[0]?.points.map((entry) => entry.value)).toEqual([45.62]);
+    expect(scene.dates.every((date) => date <= options.viewport.end)).toBe(true);
+    expect(applyCompositeChartCursor(scene, new Date("2026-06-30")).cursorValues[0]?.value).toBe(45.62);
+    const navigated = buildCompositeChartScene([margin], [{ id: "main" }], {
+      ...options, viewport: { start: new Date("2025-01-01"), end: new Date("2026-12-31") },
+    })!;
+    expect(navigated.panels[0]?.series[0]?.points.map((entry) => entry.value)).toEqual([45.62, 46.78]);
+    expect(margin.points).toHaveLength(2);
+    // Ordinary market charts retain their right offset and newest observation.
+    const ordinary = buildCompositeChartScene([margin], [{ id: "main" }], { width: 100, height: 20 })!;
+    expect(ordinary.panels[0]?.series[0]?.points.at(-1)?.value).toBe(46.78);
+    expect(ordinary.panels[0]?.series[0]?.points.at(-1)?.xRatio).toBeCloseTo(NEWEST_X_RATIO);
+  });
+
   test("keeps a panel and its height while its series has no observations in view", () => {
     const price = series({
       id: "price",

--- a/src/components/chart/composite/scene.ts
+++ b/src/components/chart/composite/scene.ts
@@ -154,6 +154,7 @@ function scopeSeriesToViewport(
   startTime: number,
   endTime: number,
   timeScale: CompositeTimeScale,
+  clipToViewport: boolean,
 ): ResolvedSeries | null {
   const points = normalizedSourcePoints(series, timeScale);
   const placement = timeScale.kind === "market" && !series.timeBasis
@@ -161,6 +162,7 @@ function scopeSeriesToViewport(
     : "timestamp" as const;
   const visible = points.filter(({ timestamp }) => {
     if (timestamp >= startTime && timestamp <= endTime) return true;
+    if (clipToViewport) return false;
     const projected = projectCompositeTimestamp(timeScale, timestamp, placement);
     return !!projected && projected.ratio >= 0 && projected.ratio <= 1;
   });
@@ -463,11 +465,10 @@ function nearestDate(dates: Date[], requested: Date): Date | null {
 
 function cursorPointForSeries(
   series: CompositePanelScene["series"][number],
-  cursorTime: number | null,
+  cursorTime: number,
 ): CompositeProjectedPoint | null {
   const points = series.points;
   if (points.length === 0) return null;
-  if (cursorTime === null) return points.at(-1) ?? null;
 
   let low = 0;
   let high = points.length;
@@ -482,10 +483,15 @@ function cursorPointForSeries(
 function buildCursorValues(
   panels: CompositePanelScene[],
   cursorDate: Date | null,
+  viewport: Pick<CompositeChartScene, "startTime" | "endTime">,
 ): CompositeCursorValue[] {
-  const cursorTime = cursorDate?.getTime() ?? null;
+  const cursorTime = cursorDate?.getTime() ?? viewport.endTime;
   return panels.flatMap((panel) => panel.series.map((entry) => {
-    const projected = cursorPointForSeries(entry, cursorTime);
+    let projected = cursorPointForSeries(entry, cursorTime);
+    // The drawn navigation buffer can include observations after the chosen
+    // end. An unarmed legend describes the active window, including when the
+    // pointer leaves; explicitly inspected cursor dates keep their own behavior.
+    if (!cursorDate && projected && projected.timestamp < viewport.startTime) projected = null;
     return {
       seriesId: entry.source.id,
       label: entry.source.label,
@@ -518,7 +524,7 @@ export function applyCompositeChartCursor(
     ...scene,
     cursorDate,
     cursorXRatio,
-    cursorValues: buildCursorValues(scene.panels, cursorDate),
+    cursorValues: buildCursorValues(scene.panels, cursorDate, scene),
   };
 }
 
@@ -550,13 +556,13 @@ export function buildCompositeChartScene(
   // The plot reaches past the viewport by the reserved right offset. Panned
   // back into history that space holds real observations, so navigation and
   // the cursor follow the drawn edge rather than the viewport end.
-  const plotEndTime = Math.max(endTime, unprojectCompositeTimestamp(timeScale, 1));
+  const plotEndTime = options.clipToViewport ? endTime : Math.max(endTime, unprojectCompositeTimestamp(timeScale, 1));
   // A step holds its level to the newest observation and no further: the space
   // reserved after it stays empty. With data still ahead of the window, the
   // level runs to the drawn edge instead.
   const stepTrailingTime = Math.min(plotEndTime, Math.max(lastTime, endTime));
   const scopedSeries = viewport
-    ? dataSeries.flatMap((entry) => scopeSeriesToViewport(entry, startTime, endTime, timeScale) ?? [])
+    ? dataSeries.flatMap((entry) => scopeSeriesToViewport(entry, startTime, endTime, timeScale, options.clipToViewport === true) ?? [])
     : dataSeries;
   // A range without observations still has a chart: keep the panels, axes and
   // grid and simply draw no points, instead of blanking the whole surface.
@@ -632,7 +638,7 @@ export function buildCompositeChartScene(
     panels: panelScenes,
     cursorDate,
     cursorXRatio,
-    cursorValues: buildCursorValues(panelScenes, cursorDate),
+    cursorValues: buildCursorValues(panelScenes, cursorDate, { startTime, endTime }),
   };
 }
 

--- a/src/components/chart/composite/types.ts
+++ b/src/components/chart/composite/types.ts
@@ -127,6 +127,8 @@ export interface BuildCompositeChartSceneOptions {
     start: Date;
     end: Date;
   };
+  /** Keep displayed observations and cursor dates inside the active window. */
+  clipToViewport?: boolean;
   /** Authored series order retained even when the primary anchor is hidden. */
   timelineSeries?: ResolvedSeries[];
   /**
@@ -179,6 +181,8 @@ export interface CompositeChartProps {
     start: Date;
     end: Date;
   };
+  /** An explicit research window bounds marks and hover, including right padding. */
+  clipToViewport?: boolean;
   /**
    * Stable identity for the authored viewport. Changing it resets user navigation;
    * viewport updates under the same key are treated as adaptive data refreshes.

--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -691,6 +691,7 @@ function ChartComposerSurface({
           timelineSeries={resolution.timelineSeries}
           panels={spec.panels}
           viewport={viewport}
+          clipToViewport={!!spec.viewport.dateWindow}
           viewportResetKey={authoredViewportKey}
           width={Math.max(1, width)}
           height={Math.max(4, height - 1 - vintageNoticeHeight - comparisonNoticeHeight)}


### PR DESCRIPTION
A saved annual research chart ending in 2025 displayed Microsoft's 2026 operating margin in its default legend and could draw the 2026 bar in the reserved space on the right. Moving the pointer over 2025 showed 45.6%, then leaving the chart restored the out-of-window 46.8% value.

Default legends now select within the active window. Explicit authored date windows also bound displayed observations and hover dates, including the right padding. Source and navigation buffers remain available, so deliberate panning can reveal later data in a changed window; ordinary live charts keep their existing spacing and newest bar.

Validation: 91 focused tests / 367 assertions, all six TypeScript targets and web build passed. Regressions cover pointer/keyboard cursor clearing, both empty-window bounds, later-bar exclusion, navigation recovery and ordinary chart offsets. Reproduced the original defect in actual production, then verified the local build against unmodified production APIs, including right-edge hover, pointer leave and saved-workspace reload. Native 80/140-column recorded-production-response checks also passed. No release/version bump.
