### PR TITLE
Expose consensus ranges and source inputs in estimate details

### DIFF
--- a/src/plugins/builtin/research/corporate-actions-pane.tsx
+++ b/src/plugins/builtin/research/corporate-actions-pane.tsx
@@ -447,7 +447,8 @@ export function CorporateActionsView({
         primaryContentLoading,
       })
     : "";
-  const detailTextWidth = Math.max(width - 2, 12);
+  // Leave room for both horizontal padding cells and the vertical scrollbar.
+  const detailTextWidth = Math.max(width - 3, 12);
   const detailLines = openRow?.status === "Q Est" || openRow?.status === "FY Est"
     ? detailBody.split(/\r?\n/).flatMap((line) => line ? wrapTextLines(line, detailTextWidth) : [""])
     : wrapTextLines(detailBody, detailTextWidth);

--- a/src/plugins/builtin/research/corporate-actions-pane.tsx
+++ b/src/plugins/builtin/research/corporate-actions-pane.tsx
@@ -16,6 +16,7 @@ import type {
 import { blendHex, colors } from "../../../theme/colors";
 import { isPlainKey } from "../../../utils/keyboard";
 import { wrapTextLines } from "../../../utils/text-wrap";
+import { formatPercent } from "../../../utils/format";
 import { useResolvedEntryValue, useSecFilingDocuments, useSecFilingsQuery } from "../../../market-data/hooks";
 import { instrumentFromTicker } from "../../../market-data/request-types";
 import { usePaneTicker } from "../../../state/app/context";
@@ -194,6 +195,26 @@ export function buildEventDetailBody({
   primaryContent: string | null | undefined;
   primaryContentLoading: boolean;
 }): string {
+  if (row.status === "Q Est" || row.status === "FY Est") {
+    const lines = ["Forecast for the stated fiscal period end; this is not an earnings announcement date."];
+    for (const [key, label] of [["eps", "EPS"], ["revenue", "Revenue"]] as const) {
+      const estimate = row.estimateInputs?.[key];
+      if (!estimate) continue;
+      const amount = (value: number | undefined) => earningsInput(value, estimate.currency);
+      lines.push("", `${label} consensus${estimate.currency ? "" : " (currency unavailable)"}`,
+        `Average: ${amount(estimate.average)}`,
+        `Low: ${amount(estimate.low)} | High: ${amount(estimate.high)}`,
+        `Prior-year comparison: ${amount(estimate.yearAgo)} (provider input; may be a forecast)`,
+        `Provider growth: ${estimate.growth == null ? "-" : formatPercent(estimate.growth)}`,
+        `Contributing analysts: ${estimate.analysts ?? "-"}`);
+    }
+    if (!row.estimateInputs) lines.push("", eventSummaryLine(row), "Detailed estimate inputs are unavailable.");
+    if (row.estimateGrowthMetric) lines.push("", `The table growth value refers to ${row.estimateGrowthMetric === "eps" ? "EPS" : "revenue"}.`);
+    lines.push("", "Consensus is a forecast. EPS accounting and adjustment basis are unspecified; statement EPS may differ.",
+      `Source: ${row.providerId ?? "unavailable"}`,
+      row.fetchedAt ? `Fetched: ${row.fetchedAt} (retrieval time, not an estimate revision date).` : "Retrieval time unavailable.");
+    return lines.join("\n");
+  }
   const lines: string[] = ["Summary", eventSummaryLine(row)];
   if (row.status === "Factor") {
     lines.push("", "Provider split/adjustment factor",
@@ -427,6 +448,9 @@ export function CorporateActionsView({
       })
     : "";
   const detailTextWidth = Math.max(width - 2, 12);
+  const detailLines = openRow?.status === "Q Est" || openRow?.status === "FY Est"
+    ? detailBody.split(/\r?\n/).flatMap((line) => line ? wrapTextLines(line, detailTextWidth) : [""])
+    : wrapTextLines(detailBody, detailTextWidth);
   const scrollDetailBy = useCallback((delta: number) => {
     const scrollBox = detailScrollRef.current;
     if (!scrollBox?.viewport) return;
@@ -468,7 +492,7 @@ export function CorporateActionsView({
         focusable={false}
       >
         <Box flexDirection="column">
-          {wrapTextLines(detailBody, detailTextWidth).map((line, index) => (
+          {detailLines.map((line, index) => (
             <Box key={`event-detail-${index}`} height={1}>
               <Text fg={colors.text}>{line}</Text>
             </Box>

--- a/src/plugins/builtin/research/event-model.ts
+++ b/src/plugins/builtin/research/event-model.ts
@@ -40,6 +40,9 @@ export interface EventRow {
   epsBasis?: "provider-unspecified";
   providerId?: string;
   fetchedAt?: string;
+  /** Keep the supplied ranges and comparison inputs available in detail/export. */
+  estimateInputs?: { eps?: AnalystEstimateRecord; revenue?: AnalystEstimateRecord };
+  estimateGrowthMetric?: "eps" | "revenue";
   fiscalPeriodEnd?: string;
   periodDateSource?: FinancialStatement["dateSource"];
   providerPeriodDate?: string;
@@ -233,6 +236,13 @@ export function buildEventRows(
       status: isFiscal ? "FY Est" : "Q Est",
       period: formatPeriod(pair.period),
       detail: formatEstimateDetail(pair),
+      providerId: estimates?.providerId,
+      fetchedAt: estimates?.fetchedAt,
+      estimateInputs: {
+        ...(pair.eps ? { eps: { ...pair.eps } } : {}),
+        ...(pair.revenue ? { revenue: { ...pair.revenue } } : {}),
+      },
+      estimateGrowthMetric: pair.eps?.growth != null ? "eps" : pair.revenue?.growth != null ? "revenue" : undefined,
       epsCurrency: pair.eps?.currency,
       revenueCurrency: pair.revenue?.currency,
       qEps: isFiscal ? undefined : pair.eps?.average,

--- a/src/plugins/builtin/research/index.test.ts
+++ b/src/plugins/builtin/research/index.test.ts
@@ -181,6 +181,22 @@ describe("analyst summary", () => {
 });
 
 describe("event rows", () => {
+  test("estimate drilldown and JSON retain distinct EPS/revenue inputs, currencies and attribution", () => {
+    const eps = { date: "2026-09-30", period: "current quarter", currency: "USD", average: 4.4, low: 4, high: 5, yearAgo: 0, growth: 0, analysts: 12 };
+    const revenue = { date: eps.date, period: eps.period, currency: "TWD", average: 1.45e12, low: 1.4e12, high: 1.5e12, yearAgo: 1e12, growth: .45, analysts: 20 };
+    const rows = buildEventRows(null, { symbol: "TSM", providerId: "yahoo", fetchedAt: "2026-09-11T12:00:00Z",
+      recommendations: [], ratings: [], earningsEstimates: [eps], revenueEstimates: [revenue] }, null, "USD");
+    const row = JSON.parse(JSON.stringify(rows[0]));
+    expect(row).toMatchObject({ estimateInputs: { eps, revenue }, estimateGrowthMetric: "eps", providerId: "yahoo", fetchedAt: "2026-09-11T12:00:00Z" });
+    const detail = buildEventDetailBody({ row, secFilingsLoading: false, filing: null, documents: [], documentsLoading: false,
+      inlineContent: new Map(), primaryContent: null, primaryContentLoading: false });
+    expect(detail).toContain("Low: 4 USD | High: 5 USD");
+    expect(detail).toContain("Low: 1,400,000,000,000 TWD | High: 1,500,000,000,000 TWD");
+    expect(detail).toContain("Prior-year comparison: 0 USD");
+    expect(detail).toContain("Provider growth: 0.00%");
+    expect(detail).toContain("Provider growth: +45.00%");
+  });
+
   test("combines EPS and revenue estimates into one estimate row", () => {
     const rows = buildEventRows(null, {
       symbol: "AAPL",


### PR DESCRIPTION
Opening an earnings estimate repeated only the table summary, although the provider supplied consensus ranges, prior-year comparison inputs and separate EPS and revenue analyst counts. The shared event row and JSON export now retain those inputs, and the detail shows each metric’s currency, growth definition and source retrieval time.

The detail identifies forecasts and explains that the prior-year comparator may itself be a forecast. Compact wrapping preserves the full detail in an 80-column terminal, including the scrollbar allowance.

Validation: 22 focused tests / 55 assertions, all six TypeScript targets and the web build passed. Independent review passed 18 tests / 46 assertions and approved the final width correction. Actual Yahoo Shopify data, CLI JSON and native 140/80-column drilldowns agree on the next-year EPS range of 1.97–2.93 USD, revenue range of 17.7951B–21.25B USD and 39/50 contributors. The next-quarter detail and keyboard Back/scroll also passed at 80 columns. Anonymous hosted access requires signup/email verification; no authenticated browser pass is claimed. No release or version bump.
