### PR TITLE
Preserve selected listings across research commands

### DIFF
--- a/src/components/command-bar/commands/collection.ts
+++ b/src/components/command-bar/commands/collection.ts
@@ -31,6 +31,7 @@ export async function executeCollectionCommandAction(options: {
   commandId: CollectionCommandId;
   rawInput?: string;
   explicitTargetId?: string | null;
+  selectedTicker?: TickerRecord;
   activeTickerSymbol: string | null;
   activeCollectionId: string | null;
   getState: () => AppState;
@@ -45,12 +46,14 @@ export async function executeCollectionCommandAction(options: {
   const kind = getCollectionCommandKind(options.commandId);
   const action = getCollectionCommandAction(options.commandId);
   const deps = options.buildWorkflowDeps();
-  const resolvedTicker = await resolveTickerInput(
-    options.rawInput,
-    options.activeTickerSymbol,
-    options.activeCollectionId,
-    deps,
-  );
+  const resolvedTicker = options.selectedTicker
+    ? { symbol: options.selectedTicker.metadata.ticker, ticker: options.selectedTicker }
+    : await resolveTickerInput(
+      options.rawInput,
+      options.activeTickerSymbol,
+      options.activeCollectionId,
+      deps,
+    );
 
   if (!resolvedTicker) {
     options.openModeRoute("ticker-search", options.rawInput?.trim() || "", {

--- a/src/components/command-bar/list/model.ts
+++ b/src/components/command-bar/list/model.ts
@@ -1,4 +1,5 @@
 import type { CommandBarResultLine } from "../../../types/plugin";
+import type { TickerRecord } from "../../../types/ticker";
 import {
   buildSections,
   type CommandBarCategoryPriorities,
@@ -25,6 +26,8 @@ export interface ResultItem {
   right?: string;
   /** Provider type retained for symbol/alias identity checks. */
   instrumentType?: string;
+  /** Materialize this exact listing when another command consumes the row. */
+  resolveTicker?: () => Promise<TickerRecord>;
   shortcutQuery?: string;
   searchText?: string;
   /** Tints the trailing marker and the section heading with the AI accent. */

--- a/src/components/command-bar/pane-templates/workflow.ts
+++ b/src/components/command-bar/pane-templates/workflow.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import type { AppState } from "../../../state/app/context";
+import type { TickerRecord } from "../../../types/ticker";
 import type {
   PaneTemplateCreateOptions,
   PaneTemplateDef,
@@ -43,6 +44,7 @@ type ExecuteCollectionCommandFn = (
   commandId: CollectionCommandId,
   rawInput?: string,
   explicitTargetId?: string | null,
+  selectedTicker?: TickerRecord,
 ) => void | Promise<void>;
 
 interface UseCommandBarPaneTemplateActionsOptions {
@@ -184,13 +186,24 @@ export function useCommandBarPaneTemplateActions({
     routePayload: Record<string, unknown> | undefined,
   ): ResultItem => {
     const routeAction = String(routePayload?.action ?? "");
+    if (!item.resolveTicker) return item;
     if (routeAction === "pane-template") {
       const templateId = String(routePayload?.templateId ?? "");
       const template = pluginRegistry.paneTemplates.get(templateId);
       if (!template) return item;
       return {
         ...item,
-        action: () => { void runPaneTemplateShortcut(template, item.label); },
+        secondaryAction: undefined,
+        action: async () => {
+          try {
+            const ticker = await item.resolveTicker!();
+            await openPaneTemplateDirect(template, {
+              arg: ticker.metadata.ticker, symbol: ticker.metadata.ticker, ticker,
+            });
+          } catch (error) {
+            notify(error instanceof Error ? error.message : "Could not open the selected listing.", { type: "error" });
+          }
+        },
       };
     }
     if (routeAction === "collection-command") {
@@ -198,11 +211,19 @@ export function useCommandBarPaneTemplateActions({
       if (!isCollectionCommand(commandId)) return item;
       return {
         ...item,
-        action: () => { void executeCollectionCommand(commandId, item.label); },
+        secondaryAction: undefined,
+        action: async () => {
+          try {
+            const ticker = await item.resolveTicker!();
+            await executeCollectionCommand(commandId, ticker.metadata.ticker, undefined, ticker);
+          } catch (error) {
+            notify(error instanceof Error ? error.message : "Could not open the selected listing.", { type: "error" });
+          }
+        },
       };
     }
     return item;
-  }, [executeCollectionCommand, pluginRegistry.paneTemplates, runPaneTemplateShortcut]);
+  }, [executeCollectionCommand, notify, openPaneTemplateDirect, pluginRegistry.paneTemplates]);
 
   const getAvailablePaneTemplates = useCallback((
     options?: PaneTemplateCreateOptions,

--- a/src/components/command-bar/routes/ticker-search/actions.ts
+++ b/src/components/command-bar/routes/ticker-search/actions.ts
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useRef } from "react";
 import type { AppState } from "../../../../state/app/context";
 import type { AppTickerRepositoryPort } from "../../../../core/app-service-ports";
 import type { PluginRegistry } from "../../../../plugins/registry";
+import type { InstrumentSearchResult } from "../../../../types/instrument";
+import { publicTickerKey } from "../../../../utils/exchanges";
 import {
   rankTickerSearchItems,
   upsertTickerFromSearchResult,
@@ -34,17 +36,22 @@ export function useCommandBarTickerSearchActions({
 }: UseCommandBarTickerSearchActionsOptions) {
   const tickerSearchCacheRef = useRef<Map<string, TickerSearchCandidate[]>>(new Map());
 
-  const openTickerResearch = useCallback((result: any, options?: { forceNewPane?: boolean }) => {
+  const resolveSearchTicker = useCallback(async (result: InstrumentSearchResult, tickerSymbol?: string) => {
+    const { ticker, created } = await upsertTickerFromSearchResult(tickerRepository, result, { tickerSymbol });
+    dispatch({ type: "UPDATE_TICKER", ticker });
+    if (created) {
+      pluginRegistry.events.emit("ticker:added", { symbol: ticker.metadata.ticker, ticker });
+    }
+    return ticker;
+  }, [dispatch, pluginRegistry.events, tickerRepository]);
+
+  const openTickerResearch = useCallback((result: InstrumentSearchResult, options?: { forceNewPane?: boolean }) => {
     (async () => {
-      const { ticker, created } = await upsertTickerFromSearchResult(tickerRepository, result);
-      dispatch({ type: "UPDATE_TICKER", ticker });
-      if (created) {
-        pluginRegistry.events.emit("ticker:added", { symbol: ticker.metadata.ticker, ticker });
-      }
+      const ticker = await resolveSearchTicker(result);
       focusTicker(ticker.metadata.ticker, options);
       closeAll({ revertThemePreview: false });
     })();
-  }, [closeAll, dispatch, focusTicker, pluginRegistry.events, tickerRepository]);
+  }, [closeAll, focusTicker, resolveSearchTicker]);
 
   const mapTickerSearchCandidateToResultItem = useCallback((candidate: TickerSearchCandidate): ResultItem => {
     const detail = formatTickerSearchDetail(candidate);
@@ -66,6 +73,7 @@ export function useCommandBarTickerSearchActions({
         right,
         category: candidate.category,
         kind: "ticker",
+        resolveTicker: async () => candidate.ticker!,
         secondaryAction: () => {
           focusTicker(candidate.ticker!.metadata.ticker, { forceNewPane: true });
           closeAll({ revertThemePreview: false });
@@ -86,10 +94,15 @@ export function useCommandBarTickerSearchActions({
       right,
       category: candidate.category,
       kind: "search",
+      resolveTicker: () => resolveSearchTicker(candidate.result!, publicTickerKey(
+        candidate.symbol,
+        candidate.result!.exchange === "SMART" ? candidate.result!.primaryExchange
+          : candidate.result!.exchange || candidate.result!.primaryExchange,
+      )),
       secondaryAction: () => openTickerResearch(candidate.result!, { forceNewPane: true }),
       action: () => openTickerResearch(candidate.result!),
     };
-  }, [closeAll, focusTicker, openTickerResearch]);
+  }, [closeAll, focusTicker, openTickerResearch, resolveSearchTicker]);
 
   const buildTickerSearchResultItems = useCallback((candidates: TickerSearchCandidate[], query: string): ResultItem[] => (
     candidates.length > 0

--- a/src/components/command-bar/routing/actions.ts
+++ b/src/components/command-bar/routing/actions.ts
@@ -137,6 +137,7 @@ export function useCommandBarRouteActions({
     commandId: CollectionCommandId,
     rawInput?: string,
     explicitTargetId?: string | null,
+    selectedTicker?: TickerRecord,
   ) => executeCollectionCommandAction({
     activeCollectionId,
     activeTickerSymbol,
@@ -150,6 +151,7 @@ export function useCommandBarRouteActions({
     openModeRoute,
     pushRoute,
     rawInput,
+    selectedTicker,
   }), [
     activeCollectionId,
     activeTickerSymbol,
@@ -232,4 +234,3 @@ export function useCommandBarRouteActions({
     tickerActionItems,
   };
 }
-

--- a/src/components/command-bar/surface/listing-selection.test.tsx
+++ b/src/components/command-bar/surface/listing-selection.test.tsx
@@ -1,0 +1,84 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import type { PaneTemplateCreateOptions, PaneTemplateDef } from "../../../types/plugin";
+import type { TickerRecord } from "../../../types/ticker";
+import { CommandBarHarness, createCommandBarTestControls, emitKeypress, makeTicker } from "./test-harness";
+
+let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+afterEach(async () => { await act(async () => { setup?.renderer.destroy(); }); setup = undefined; });
+const { waitForFrameToContain } = createCommandBarTestControls(() => setup!);
+
+for (const savedDefault of [false, true]) {
+  test(`EE listing choice preserves TSX identity with ${savedDefault ? "a saved Nasdaq default" : "an unavailable default quote"}`, async () => {
+    const created: Array<{ templateId: string; options?: PaneTemplateCreateOptions }> = [];
+    const searchQueries: string[] = [];
+    setup = await testRender(<CommandBarHarness
+      query="EE SHOP"
+      live
+      extraTickers={savedDefault ? [makeTicker("SHOP", "Shopify Inc.")] : []}
+      dataProvider={createTestDataProvider({
+        search: async (query) => {
+          searchQueries.push(query);
+          return [
+            { providerId: "test", symbol: "SHOP", name: "Shopify Inc.", exchange: "NASDAQ", currency: "USD", type: "EQUITY" },
+            { providerId: "test", symbol: "SHOP", name: "Shopify Inc.", exchange: "TSX", currency: "CAD", type: "EQUITY" },
+          ];
+        },
+        getQuote: async () => { throw new Error("Default quote unavailable"); },
+      })}
+      configurePluginRegistry={(registry) => {
+        (registry.paneTemplates as Map<string, PaneTemplateDef>).set("earnings-estimates", {
+          id: "earnings-estimates", paneId: "quote-monitor", label: "Earnings Estimates",
+          description: "Research earnings estimates", shortcut: { prefix: "EE", argKind: "ticker" },
+        });
+        registry.createPaneFromTemplateAsyncFn = async (templateId, options) => { created.push({ templateId, options }); };
+      }}
+    />, { width: 100, height: 24 });
+    await setup.renderOnce();
+    // Enter must resolve an ambiguity; Tab deliberately selects another listing
+    // even when a saved default could be opened without prompting.
+    await emitKeypress(setup, savedDefault ? { name: "tab" } : { name: "return", sequence: "\r" });
+    await waitForFrameToContain("TSX");
+    await emitKeypress(setup, { name: "down" });
+    const queriesBeforeChoice = searchQueries.length;
+    await emitKeypress(setup, { name: "return", sequence: "\r", shift: savedDefault });
+    await act(async () => { await Bun.sleep(20); });
+    await setup.renderOnce();
+    expect(created).toHaveLength(1);
+    expect(created[0]?.templateId).toBe("earnings-estimates");
+    expect(created[0]?.options?.symbol).toBe("SHOP:XTSE");
+    expect(created[0]?.options?.ticker?.metadata).toMatchObject({ ticker: "SHOP:XTSE", exchange: "TSX", currency: "CAD" });
+    expect(searchQueries).toHaveLength(queriesBeforeChoice);
+    expect(setup.captureCharFrame()).toContain("Search or run a command");
+  });
+}
+
+test("watchlist listing selection consumes the chosen record without re-searching its bare symbol", async () => {
+  const saved: TickerRecord[] = [];
+  let rejectFurtherSearch = false;
+  setup = await testRender(<CommandBarHarness
+    query="AW SHOP" live onSaveTicker={(ticker) => saved.push(ticker)}
+    configureState={(state) => ({ ...state, paneState: { "portfolio-list:main": { collectionId: "watchlist" } } })}
+    dataProvider={createTestDataProvider({
+      search: async () => {
+        if (rejectFurtherSearch) throw new Error("Search is no longer available");
+        return [
+          { providerId: "test", symbol: "SHOP", name: "Shopify Inc.", exchange: "NASDAQ", currency: "USD", type: "EQUITY" },
+          { providerId: "test", symbol: "SHOP", name: "Shopify Inc.", exchange: "TSX", currency: "CAD", type: "EQUITY" },
+        ];
+      },
+    })}
+  />, { width: 100, height: 24 });
+  await setup.renderOnce();
+  await emitKeypress(setup, { name: "return", sequence: "\r" });
+  await waitForFrameToContain("TSX");
+  await emitKeypress(setup, { name: "down" });
+  rejectFurtherSearch = true;
+  await emitKeypress(setup, { name: "return", sequence: "\r" });
+  await act(async () => { await Bun.sleep(20); });
+  await setup.renderOnce();
+  expect(saved.at(-1)?.metadata).toMatchObject({ ticker: "SHOP:XTSE", exchange: "TSX", currency: "CAD", watchlists: ["watchlist"] });
+  expect(setup.captureCharFrame()).toContain("Search or run a command");
+});

--- a/src/tickers/search/index.test.ts
+++ b/src/tickers/search/index.test.ts
@@ -385,9 +385,30 @@ describe("ticker-search utilities", () => {
       ],
     });
 
-    expect(results[0]?.symbol).toBe("AAPLC.BA");
-    expect(results.find((item) => item.symbol === "AAPL")?.primaryExchangeLabel).toBeUndefined();
+    expect(results.find((item) => item.id === "goto:AAPL")?.primaryExchangeLabel).toBeUndefined();
+    expect(results.find((item) => item.kind === "search" && item.symbol === "AAPL")?.primaryExchangeLabel).toBe("BUE");
   });
+
+  for (const savedSymbol of ["SHOP", "SHOP:XNAS"]) {
+    test(`saved ${savedSymbol} deduplicates venue aliases while retaining the unsaved TSX listing`, () => {
+      const results = buildTickerSearchCandidates({
+        query: "Shopify",
+        tickers: new Map([[savedSymbol, makeTicker(savedSymbol, "Shopify Inc.", { exchange: "NASDAQ" })]]),
+        providerResults: [
+          makeSearchResult("SHOP", "Shopify Inc.", { exchange: "XNAS", currency: "USD" }),
+          makeSearchResult("SHOP", "Shopify Inc.", { exchange: "NASDAQ", currency: "USD" }),
+          makeSearchResult("SHOP", "Shopify Inc.", { exchange: "TSX", currency: "CAD" }),
+          makeSearchResult("SHOP", "Shopify Inc.", { exchange: "SMART", primaryExchange: "XTSE", currency: "CAD" }),
+        ],
+      });
+      expect(results).toHaveLength(2);
+      expect(results.find((item) => item.kind === "ticker")?.id).toBe(`goto:${savedSymbol}`);
+      const foreign = results.find((item) => item.kind === "search")!;
+      expect(foreign.saved).toBe(false);
+      expect(foreign.category).not.toBe("Saved");
+      expect(foreign.result?.currency).toBe("CAD");
+    });
+  }
 
   test("uses provider ordering to prefer the canonical saved listing for company-name queries", () => {
     const tickers = new Map<string, TickerRecord>([

--- a/src/tickers/search/index.ts
+++ b/src/tickers/search/index.ts
@@ -104,7 +104,10 @@ function createProviderTickerSearchCandidates(
     const symbol = getSearchResultSymbol(result);
     const currency = result.currency || getForexQuoteCurrency(symbol);
     if (currency && !result.currency) result = { ...result, currency };
-    const saved = localTickers.has(symbol);
+    const listingKey = publicTickerKey(symbol, listingExchange(result));
+    const savedTicker = localTickers.get(listingKey) ?? localTickers.get(symbol);
+    const saved = !!savedTicker
+      && publicTickerKey(savedTicker.metadata.ticker, savedTicker.metadata.exchange) === listingKey;
     return [{
       id: buildProviderCandidateId(result, symbol),
       label: symbol,

--- a/src/tickers/search/ranking.ts
+++ b/src/tickers/search/ranking.ts
@@ -146,8 +146,11 @@ function matchesQualifiedTicker(
   return exchanges.some((exchange) => getYahooSymbol(candidate.symbol, exchange).toUpperCase() === normalized);
 }
 
-function getTickerSearchListingKey(item: TickerSearchRankableItem): string {
-  return `${normalizeTickerSymbol(item.symbol || item.label)}|${canonicalExchange(item.exchangeLabel || item.primaryExchangeLabel || item.right)}`;
+function getTickerSearchListingKey(item: Pick<TickerSearchRankableItem, "label"> & Partial<TickerSearchRankableItem>): string {
+  const parsed = parsePublicTickerKey(normalizeTickerSymbol(item.symbol || item.label));
+  const exchange = parsed.exchange || (item.exchangeLabel === "SMART" ? item.primaryExchangeLabel
+    : item.exchangeLabel || item.primaryExchangeLabel || item.right);
+  return `${parsed.symbol}|${canonicalExchange(exchange)}`;
 }
 
 export function rankTickerSearchItems<T extends Pick<TickerSearchRankableItem, "id" | "label" | "detail" | "kind" | "category" | "right"> & Partial<TickerSearchRankableItem>>(
@@ -209,19 +212,18 @@ export function rankTickerSearchItems<T extends Pick<TickerSearchRankableItem, "
       };
     });
 
-  const matchedLocalSymbols = new Set(
+  // A saved symbol replaces its own source listing, not every exchange using it.
+  const matchedLocalListings = new Set(
     ranked
       .filter(({ item, textScore }) => textScore > 0 && item.kind === "ticker")
-      .map(({ item, normalizedSymbol }) => isQualifiedTickerQuery(query) || isCryptoInstrumentType(item.instrumentType)
-        ? getTickerSearchListingKey(item) : normalizedSymbol),
+      .map(({ item }) => getTickerSearchListingKey(item)),
   );
 
-  const filtered = ranked.filter(({ item, normalizedSymbol, textScore }) => {
+  const filtered = ranked.filter(({ item, textScore }) => {
     if (textScore <= 0) return false;
     if (isExplicitMarketSymbol(query) && !isExplicitMarketSymbol(item.symbol || item.label)) return false;
     if (item.kind !== "search") return true;
-    return !matchedLocalSymbols.has(isQualifiedTickerQuery(query) || isCryptoInstrumentType(item.instrumentType)
-      ? getTickerSearchListingKey(item) : normalizedSymbol);
+    return !matchedLocalListings.has(getTickerSearchListingKey(item));
   });
 
   type RankedEntry = (typeof ranked)[number];
@@ -596,6 +598,5 @@ function scoreSearchField(query: string, value: string, weights: { exact: number
 
 function getTickerSearchDedupKey(item: Pick<TickerSearchRankableItem, "id" | "kind" | "label" | "detail" | "right"> & Partial<TickerSearchRankableItem>): string {
   if (item.kind !== "ticker" && item.kind !== "search") return item.id;
-  const qualifier = normalizeSearchText(item.right || item.detail.split("|").at(-1) || "");
-  return `${normalizeSearchText(item.symbol || item.label)}|${qualifier}`;
+  return getTickerSearchListingKey(item);
 }


### PR DESCRIPTION
Selecting a listing from a research shortcut could resolve the bare symbol again and open a different exchange. In the native app, `EE Shopify` → Stuttgart (`307 / XSTU`) opened Frankfurt instead. Saving a bare symbol also hid other exchanges in subsequent searches.

Preserve canonical listing identity when combining saved and provider search results. Research and collection commands consume the exact selected record, retaining its exchange, currency and broker metadata without another symbol search. Enter and Shift+Enter retain the requested capability.

Validation: 237 tests / 838 assertions across command-bar and ticker suites, all six TypeScript targets, and web build. Regression coverage includes unavailable default quotes, saved Nasdaq versus Toronto, equivalent venue aliases, SMART primary exchanges, and the collection handoff when a subsequent search is unavailable. Actual native keyboard replay opens `307:XSTU` with source-confirmed EUR metadata and restores the Toronto choice beside saved Nasdaq; Back returns to the original command. The XSTU estimates endpoint currently returns not found, which remains visible instead of substituting Frankfurt data.
