### PR TITLE
Honor supported manual chart intervals over all history

### DIFF
--- a/src/plugins/builtin/chart-composer/pane.tsx
+++ b/src/plugins/builtin/chart-composer/pane.tsx
@@ -503,13 +503,22 @@ function ChartComposerSurface({
   const vintageNoticeHeight = showVintageNotice ? wrapTextLines(financialNotice, Math.max(8, width - 2)).length : 0;
   const comparisonNotice = resolution.priceComparison?.notice;
   const comparisonNoticeHeight = comparisonNotice ? wrapTextLines(comparisonNotice, Math.max(8, width - 2)).length : 0;
-  const statusWarning = resolution.warnings.find((warning) => warning !== FINANCIAL_VINTAGE_NOTICE && warning !== SEC_EPS_BASIS_NOTICE && warning !== comparisonNotice);
-
-  const statusNotice = resolution.errors[0] ?? statusWarning;
+  const statusError = resolution.errors[0];
+  // Failed series use their authored id in errors and their display label in warnings.
+  const errorSeries = spec.series.find((entry) => statusError?.startsWith(`${entry.label ?? entry.id}: `));
+  const errorMessage = errorSeries ? statusError?.slice(`${errorSeries.label ?? errorSeries.id}: `.length) : undefined;
+  const errorSeriesLabel = legendSeries?.find((entry) => entry.id === errorSeries?.id)?.label;
+  const duplicateErrorNotices = new Set([statusError, errorMessage,
+    errorSeriesLabel && errorMessage ? `${errorSeriesLabel}: ${errorMessage}` : undefined]);
+  const statusWarnings = resolution.warnings.filter((warning) => (
+    warning !== FINANCIAL_VINTAGE_NOTICE && warning !== SEC_EPS_BASIS_NOTICE && warning !== comparisonNotice
+    && !duplicateErrorNotices.has(warning)
+  ));
+  const statusNotices = [...new Set([...(statusError ? [statusError] : []), ...statusWarnings])];
   // Leave one cell for a scrollbar when a short pane cannot show the full notice.
   const statusNoticeWidth = Math.max(8, width - 3);
-  const statusNoticeHeight = statusNotice
-    ? Math.min(wrapTextLines(statusNotice, statusNoticeWidth).length,
+  const statusNoticeHeight = statusNotices.length > 0
+    ? Math.min(statusNotices.reduce((lines, notice) => lines + wrapTextLines(notice, statusNoticeWidth).length, 0),
       Math.max(1, height - 2 - vintageNoticeHeight - comparisonNoticeHeight - 4))
     : 0;
 
@@ -612,9 +621,11 @@ function ChartComposerSurface({
       {comparisonNotice && <Box paddingX={1} flexShrink={0}>
         <Prose text={comparisonNotice} width={Math.max(8, width - 2)} color={colors.textDim} />
       </Box>}
-      {statusNotice && <ScrollBox key={statusNotice} height={statusNoticeHeight} flexShrink={0} scrollY focusable={false}>
-        <Box paddingX={1} flexShrink={0}>
-          <Prose text={statusNotice} width={statusNoticeWidth} color={colors.warning} />
+      {statusNotices.length > 0 && <ScrollBox key={statusNotices.join("\n")} height={statusNoticeHeight} flexShrink={0} scrollY focusable={false}>
+        <Box flexDirection="column" paddingX={1} flexShrink={0}>
+          {statusNotices.map((notice) => (
+            <Prose key={notice} text={notice} width={statusNoticeWidth} color={colors.warning} />
+          ))}
         </Box>
       </ScrollBox>}
       <Box flexGrow={1} minHeight={4}>

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -524,6 +524,97 @@ describe("resolveChartSpecData", () => {
     ]);
   });
 
+  test.each([
+    { selected: "1wk", maxRange: "ALL", range: "ALL", expected: "1wk" },
+    { selected: "1mo", maxRange: "ALL", range: "ALL", expected: "1mo" },
+    { selected: "1wk", maxRange: "5Y", range: "ALL", expected: "1mo" },
+    { selected: "5m", maxRange: "1W", range: "ALL", expected: "1mo" },
+    { selected: "1wk", maxRange: "5Y", range: "1Y", expected: "1wk" },
+  ] as const)("honors $selected/$range only within the provider's $maxRange limit", async ({ selected, maxRange, range, expected }) => {
+    const requests: string[] = [];
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => emptyFinancials(),
+      getChartResolutionSupport: () => [
+        { resolution: selected, maxRange },
+        { resolution: "1mo", maxRange: "ALL" },
+      ],
+      getPriceHistoryForResolution: async (_symbol, _exchange, _range, resolution) => {
+        requests.push(resolution);
+        return [{ date: new Date("2026-08-03"), close: resolution === "1wk" ? 35 : 33 }];
+      },
+    });
+    const spec = chartSpec({
+      viewport: { range, resolution: selected },
+      series: [chartSeries({ source: {
+        kind: "security", instrument: { symbol: "TEST", exchange: "LSE" }, fieldId: "market.close",
+      } })],
+    });
+    const result = await resolveChartSpecData(spec, {
+      dataProvider: provider, now: new Date("2026-09-11"), loadFredSeries: async () => fredLoad(),
+    });
+
+    expect(requests).toEqual([expected]);
+    expect(result.resolution).toBe(expected);
+    expect(result.series[0]?.points.at(-1)?.value).toBe(expected === "1wk" ? 35 : 33);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.some((warning) => warning.includes("Auto resolution was used instead")))
+      .toBe(expected !== selected);
+  });
+
+  test.each(["ALL", "5Y"] as const)("checks explicit long date windows against the %s manual limit", async (maxRange) => {
+    const requests: string[] = [];
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => emptyFinancials(),
+      getChartResolutionSupport: () => [
+        { resolution: "1wk", maxRange },
+        { resolution: "1mo", maxRange: "ALL" },
+      ],
+      getDetailedPriceHistory: async (_symbol, _exchange, _start, _end, resolution) => {
+        requests.push(resolution);
+        return [{ date: new Date("1997-07-01"), close: 10 }];
+      },
+    });
+    const spec = chartSpec({
+      viewport: { range: "ALL", resolution: "1wk", dateWindow: { start: "1997-01-01", end: "2026-09-11" } },
+      series: [chartSeries({ source: {
+        kind: "security", instrument: { symbol: "TEST", exchange: "LSE" }, fieldId: "market.close",
+      } })],
+    });
+    const result = await resolveChartSpecData(spec, {
+      dataProvider: provider, now: new Date("2026-09-11"), loadFredSeries: async () => fredLoad(),
+    });
+    expect(requests).toEqual([maxRange === "ALL" ? "1wk" : "1mo"]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("requires every comparison source to support the manual ALL interval", async () => {
+    const requests: string[] = [];
+    const provider = createTestDataProvider({
+      getTickerFinancials: async () => emptyFinancials(),
+      getChartResolutionSupport: (symbol) => [
+        { resolution: "1wk", maxRange: symbol === "UNLIMITED" ? "ALL" : "5Y" },
+        { resolution: "1mo", maxRange: "ALL" },
+      ],
+      getPriceHistoryForResolution: async (symbol, _exchange, _range, resolution) => {
+        requests.push(`${symbol}:${resolution}`);
+        return [{ date: new Date("2026-08-03"), close: 33 }];
+      },
+    });
+    const spec = chartSpec({
+      viewport: { range: "ALL", resolution: "1wk" },
+      series: ["UNLIMITED", "LIMITED"].map((symbol) => chartSeries({ id: symbol, source: {
+        kind: "security", instrument: { symbol, exchange: "LSE" }, fieldId: "market.close",
+      } })),
+    });
+    const result = await resolveChartSpecData(spec, {
+      dataProvider: provider, now: new Date("2026-09-11"), loadFredSeries: async () => fredLoad(),
+    });
+    expect(requests.sort()).toEqual(["LIMITED:1mo", "UNLIMITED:1mo"]);
+    expect(result.resolution).toBe("1mo");
+    expect(result.resolutionSupport).toContainEqual({ resolution: "1wk", maxRange: "5Y" });
+    expect(result.warnings).toContain("1WK data is unavailable for this range. Auto resolution was used instead.");
+  });
+
   test("keeps the snapshot exchange when a newer quote omits it", async () => {
     const historyExchanges: string[] = [];
     const source = {

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -282,6 +282,7 @@ function requestResolution(
   if (spec.viewport.resolution !== "auto") {
     const maxRange = getSupportMaxRange(sharedSupport, spec.viewport.resolution);
     const supported = sharedSupport.length === 0
+      || maxRange === "ALL"
       || (
         maxRange !== null
         && bounds.start !== null


### PR DESCRIPTION
A saved chart selecting `1WK` over `ALL` requested monthly bars even when every source advertised weekly coverage over `ALL`. Accept that explicit capability with open date bounds, preserving finite range limits and the intersection of comparison-source capabilities.

Show all distinct chart warnings so a source coverage limitation cannot hide a genuine interval fallback. Keep the existing wrapped, scrollable notice area and avoid repeating an error as a warning.

Validation: 163 focused tests / 777 assertions, all six TypeScript projects, and web build pass. Actual native Shell weekly/ALL now stores 1,102 weekly bars and renders the August 31 close of £34.37, including restart and 80-column checks. Recorded-source replay confirms the prior request was monthly (August close £33.445); no source prices are altered. Finite and intraday limits, explicit windows, and mixed-source support have regression coverage.
