### PR TITLE
Resolve dividend research for qualified listings

### DIFF
--- a/src/plugins/builtin/dividend-yield/client.test.ts
+++ b/src/plugins/builtin/dividend-yield/client.test.ts
@@ -69,6 +69,58 @@ describe("extractDividendFields", () => {
 });
 
 describe("cash distribution calculations", () => {
+  test.each([
+    ["SHY:XNAS", "", "SHY", "USD", 0.244],
+    ["LQD:ARCX", "NASDAQ", "LQD", "USD", 0.444],
+    ["VOD:XLON", "NASDAQ", "VOD.L", "GBp", 2.03],
+    ["SHOP:XTSE", "NASDAQ", "SHOP.TO", "CAD", 0.1],
+    ["SAP:XFRA", "", "SAP.F", "EUR", 2.35],
+    ["BRK.B:XNYS", "", "BRK-B", "USD", 0.1],
+    ["SHY", "", "SHY", "USD", 0.244],
+    ["VOD.L", "", "VOD.L", "GBp", 2.03],
+  ] as const)("loads the selected dividend listing %s with separate exchange %s", async (symbol, exchange, expected, currency, amount) => {
+    const requested: string[] = [];
+    const timestamp = Math.floor((Date.now() - 86_400_000) / 1000);
+    setHttpFetchTransport(async (url) => {
+      if (url.includes("fc.yahoo.com")) return new Response("", { headers: { "set-cookie": "test=fixture" } });
+      if (url.includes("getcrumb")) return new Response("fixture-crumb");
+      const sourceSymbol = decodeURIComponent(new URL(url).pathname.split("/").at(-1)!);
+      requested.push(sourceSymbol);
+      if (sourceSymbol !== expected) return Response.json({ chart: { result: [] }, quoteSummary: { result: [] } });
+      if (url.includes("/chart/")) return Response.json({ chart: { result: [{
+        meta: { symbol: expected, currency, regularMarketPrice: 100 }, timestamp: [timestamp],
+        indicators: { quote: [{ close: [100] }] }, events: { dividends: { [timestamp]: { date: timestamp, amount } } },
+      }] } });
+      return Response.json({ quoteSummary: { result: [{ summaryDetail: { currency } }] } });
+    });
+
+    const data = await fetchDividendData(symbol, null, exchange);
+    expect(requested).toEqual([expected, expected]);
+    expect(data.historyAvailable).toBe(true);
+    expect(data.payments).toHaveLength(1);
+    expect(data.payments[0]?.amount).toBeCloseTo(amount / (currency === "GBp" ? 100 : 1), 12);
+    expect(data.currency).toBe(currency === "GBp" ? "GBP" : currency);
+  });
+
+  test("an unavailable explicitly selected foreign listing does not fall back to another venue", async () => {
+    const requested: string[] = [];
+    setHttpFetchTransport(async (url) => {
+      if (url.includes("fc.yahoo.com")) return new Response("", { headers: { "set-cookie": "test=fixture" } });
+      if (url.includes("getcrumb")) return new Response("fixture-crumb");
+      requested.push(decodeURIComponent(new URL(url).pathname.split("/").at(-1)!));
+      return Response.json({ chart: { result: [] }, quoteSummary: { result: [] } });
+    });
+    await expect(fetchDividendData("SAP:XFRA", null)).rejects.toThrow("No dividend data found");
+    expect(requested).toEqual(["SAP.F", "SAP.F"]);
+  });
+
+  test.each(["SHY:UNKNOWN", "VOD.L:XNAS"])("rejects unmapped or contradictory listing %s without a US fallback", async (symbol) => {
+    const requested: string[] = [];
+    setHttpFetchTransport(async (url) => { requested.push(url); throw new Error("Unexpected source request"); });
+    await expect(fetchDividendData(symbol, null)).rejects.toThrow("selected listing");
+    expect(requested).toEqual([]);
+  });
+
   test("uses recent payment cadence and does not imply suspended dividends still pay quarterly", () => {
     const quarterly = Array.from({ length: 8 }, (_, quarter) => payment(
       new Date(Date.UTC(2024, 8 + quarter * 3, 25)).toISOString().slice(0, 10),

--- a/src/plugins/builtin/dividend-yield/client.ts
+++ b/src/plugins/builtin/dividend-yield/client.ts
@@ -7,6 +7,7 @@ import type { QuoteSummaryResponse } from "../../../sources/yahoo-finance/types"
 import type { DividendMetrics, DividendPayment } from "./types";
 import { resolveCurrencyUnit } from "../../../utils/currency-units";
 import { calendarYearsBefore } from "./calendar";
+import { parsePublicTickerKey } from "../../../utils/exchanges";
 
 export const YAHOO_DIVIDENDS_CONNECTION_ID = "yahoo-dividends";
 const yahoo = new YahooHttpClient();
@@ -116,7 +117,11 @@ export async function fetchDividendData(
   exchange = "",
   currentPriceCurrency?: string,
 ): Promise<DividendData> {
-  const symbols = exchange ? getYahooSymbolsToTry(symbol, exchange) : [symbol];
+  const qualified = parsePublicTickerKey(symbol);
+  const symbols = qualified.exchange
+    ? getYahooSymbolsToTry(symbol, exchange, { exactExchange: true })
+    : exchange ? getYahooSymbolsToTry(symbol, exchange) : [symbol];
+  if (symbols.length === 0) throw new Error(`Dividend source does not support the selected listing ${symbol}`);
   let lastError: unknown;
   for (const yahooSymbol of symbols) {
     try {

--- a/src/sources/yahoo-finance/symbols.ts
+++ b/src/sources/yahoo-finance/symbols.ts
@@ -56,13 +56,26 @@ export function getYahooSymbol(ticker: string, exchange: string): string {
   return `${normalizeYahooTicker(ticker, canonical)}${suffix}`;
 }
 
-export function getYahooSymbolsToTry(ticker: string, exchange: string): string[] {
+export function getYahooSymbolsToTry(
+  ticker: string,
+  exchange: string,
+  options: { exactExchange?: boolean } = {},
+): string[] {
   const qualified = parsePublicTickerKey(ticker);
   ticker = qualified.symbol;
   exchange = qualified.exchange || exchange;
-  if (tickerHasYahooSuffix(ticker)) return [ticker];
-
   const canonical = canonicalExchange(exchange) || exchange;
+  // Explicit listings may use symbol spelling alternatives, but must not
+  // resolve an unknown exchange to the default US suffix or try another venue.
+  const exactSuffix = options.exactExchange
+    ? Object.entries(EXCHANGE_SUFFIX_MAP).find(([key]) => canonicalExchange(key) === canonical)?.[1]
+    : undefined;
+  if (options.exactExchange && exactSuffix === undefined) return [];
+  if (tickerHasYahooSuffix(ticker)) {
+    if (options.exactExchange && (!exactSuffix || !ticker.endsWith(exactSuffix))) return [];
+    return [ticker];
+  }
+
   const normalized = normalizeYahooTicker(ticker, canonical);
   const dotVariant = normalized.includes(".") ? normalized.replace(/\./g, "-") : null;
 
@@ -79,16 +92,18 @@ export function getYahooSymbolsToTry(ticker: string, exchange: string): string[]
     return Array.from(symbols);
   }
 
-  const fallbacks = EXCHANGE_FALLBACKS[canonical] ?? EXCHANGE_FALLBACKS[exchange];
+  const fallbacks = options.exactExchange
+    ? undefined
+    : EXCHANGE_FALLBACKS[canonical] ?? EXCHANGE_FALLBACKS[exchange];
   if (fallbacks) {
     const results = fallbacks.map((suffix) => `${normalized}${suffix}`);
     if (dotVariant) results.unshift(...fallbacks.map((suffix) => `${dotVariant}${suffix}`));
     return results;
   }
 
-  const primary = getYahooSymbol(ticker, canonical);
+  const primary = options.exactExchange ? `${normalized}${exactSuffix}` : getYahooSymbol(ticker, canonical);
   if (dotVariant) {
-    const suffix = EXCHANGE_SUFFIX_MAP[canonical] ?? EXCHANGE_SUFFIX_MAP[exchange] ?? "";
+    const suffix = exactSuffix ?? EXCHANGE_SUFFIX_MAP[canonical] ?? EXCHANGE_SUFFIX_MAP[exchange] ?? "";
     return [`${dotVariant}${suffix}`, primary];
   }
   return [primary];


### PR DESCRIPTION
Opening native dividend research for a qualified ticker such as `SHY:XNAS` failed when its separate exchange metadata was empty. The client now resolves that qualified listing through the existing Yahoo exchange mapper, so saved layouts and command-bar transitions load the selected instrument’s cash distributions.

Qualified identity takes precedence over stale separate exchange metadata. Strict mapping rejects unknown or conflicting listings before HTTP and does not try a different venue after a foreign listing fails. Existing bare-symbol behavior, cash-flow calculations and currency conversion stay intact.

Validation: 104 tests / 453 assertions, all six TypeScript projects, and the web build pass. Actual native SHY, LQD and London VOD transitions work; the saved layout survives an 80-column restart. Regression tests cover outbound symbols, pence conversion, class symbols, unknown venues and failed foreign listings. Public five-fund price comparisons were exercised separately; the hosted dividend tab remains authentication-gated. No release or version change.
