### PR TITLE
Keep non-meaningful P/E out of valuation rankings

### DIFF
--- a/src/cli/commands/ticker.ts
+++ b/src/cli/commands/ticker.ts
@@ -1,3 +1,4 @@
+import { formatPriceEarnings } from "../../utils/price-earnings";
 import {
   formatCompact,
   formatCurrency,
@@ -276,8 +277,8 @@ export async function buildTickerReport({
   appendMetricSection(lines, "Fundamentals", [
     ["Market Cap", marketCapText],
     ["Enterprise Value", formatNullableCompact(fundamentals?.enterpriseValue)],
-    ["P/E (TTM)", fundamentals?.trailingPE != null ? formatNumber(fundamentals.trailingPE, 2) : "—"],
-    ["Forward P/E", fundamentals?.forwardPE != null ? formatNumber(fundamentals.forwardPE, 2) : "—"],
+    ["P/E (TTM)", formatPriceEarnings(fundamentals?.trailingPE, 2)],
+    ["Forward P/E", formatPriceEarnings(fundamentals?.forwardPE, 2)],
     ["PEG", fundamentals?.pegRatio != null ? formatNumber(fundamentals.pegRatio, 2) : "—"],
     ["EPS", fundamentals?.eps != null ? formatCurrency(fundamentals.eps, quote.currency) : "—"],
     [`Dividend Yield${fundamentals?.dividendYieldBasis ? ` (${fundamentals.dividendYieldBasis})` : ""}`, fundamentals?.dividendYield != null ? formatPercent(fundamentals.dividendYield) : "—"],

--- a/src/plugins/builtin/ai/ticker-context.ts
+++ b/src/plugins/builtin/ai/ticker-context.ts
@@ -1,3 +1,4 @@
+import { formatPriceEarnings } from "../../../utils/price-earnings";
 import { convertCurrency, formatCompact, formatCompactCurrency, formatCurrency, formatPercent } from "../../../utils/format";
 import { formatMarketPriceWithCurrency } from "../../../market-data/market/format";
 import type { TickerFinancials } from "../../../types/financials";
@@ -35,8 +36,8 @@ export function buildTickerAiContext(
   }
 
   if (fundamentals) {
-    if (fundamentals.trailingPE) lines.push(`P/E (TTM): ${fundamentals.trailingPE.toFixed(1)}`);
-    if (fundamentals.forwardPE) lines.push(`Forward P/E: ${fundamentals.forwardPE.toFixed(1)}`);
+    if (fundamentals.trailingPE != null) lines.push(`P/E (TTM): ${formatPriceEarnings(fundamentals.trailingPE)}${fundamentals.trailingPE <= 0 ? " (not meaningful; non-positive reported multiple)" : ""}`);
+    if (fundamentals.forwardPE != null) lines.push(`Forward P/E: ${formatPriceEarnings(fundamentals.forwardPE)}${fundamentals.forwardPE <= 0 ? " (not meaningful; non-positive reported multiple)" : ""}`);
     if (fundamentals.pegRatio) lines.push(`PEG: ${fundamentals.pegRatio.toFixed(2)}`);
     if (fundamentals.revenue) lines.push(`Revenue: ${formatCompact(fundamentals.revenue)}`);
     if (fundamentals.netIncome) lines.push(`Net Income: ${formatCompact(fundamentals.netIncome)}`);

--- a/src/plugins/builtin/portfolio-list/column-values.ts
+++ b/src/plugins/builtin/portfolio-list/column-values.ts
@@ -1,3 +1,4 @@
+import { comparablePriceEarnings, formatPriceEarnings } from "../../../utils/price-earnings";
 import type { ColumnConfig } from "../../../types/config";
 import type { AnalystResearchData, CorporateActionsData, MarketState, TickerFinancials } from "../../../types/financials";
 import type { EarningsEvent } from "../../../types/data-provider";
@@ -287,9 +288,9 @@ export function getColumnValue(
       if (!quote?.marketCap) return { text: "—" };
       return { text: formatCompact(toBaseQuote(quote.marketCap)) };
     case "pe":
-      return { text: fundamentals?.trailingPE ? formatNumber(fundamentals.trailingPE, 1) : "—" };
+      return { text: formatPriceEarnings(fundamentals?.trailingPE) };
     case "forward_pe":
-      return { text: fundamentals?.forwardPE ? formatNumber(fundamentals.forwardPE, 1) : "—" };
+      return { text: formatPriceEarnings(fundamentals?.forwardPE) };
     case "dividend_yield":
       return {
         text: fundamentals?.dividendYield != null ? `${(fundamentals.dividendYield * 100).toFixed(2)}%` : "—",
@@ -495,9 +496,9 @@ export function getSortValue(
     case "market_cap":
       return quote?.marketCap ? toBaseQuote(quote.marketCap) : null;
     case "pe":
-      return fundamentals?.trailingPE ?? null;
+      return comparablePriceEarnings(fundamentals?.trailingPE);
     case "forward_pe":
-      return fundamentals?.forwardPE ?? null;
+      return comparablePriceEarnings(fundamentals?.forwardPE);
     case "dividend_yield":
       return fundamentals?.dividendYield ?? null;
     case "ext_hours":

--- a/src/plugins/builtin/research/relative-valuation-headless.test.ts
+++ b/src/plugins/builtin/research/relative-valuation-headless.test.ts
@@ -69,3 +69,19 @@ test("provider EV/S requires verified compatible reporting units even when a rat
   financials.fundamentals.enterpriseToRevenue = NaN;
   expect(relativeValuationValues(financials).evSales).toBe(4);
 });
+
+test("loss-making peers retain reported multiples without ranking them as cheap earnings", async () => {
+  const financials = { annualStatements: [], quarterlyStatements: [], priceHistory: [],
+    quote: { symbol: "LOSS", price: 16, currency: "USD", change: 0, changePercent: 0, lastUpdated: 1, marketCap: 100 },
+    fundamentals: { trailingPE: -5.2, forwardPE: -9, financialCurrency: "USD", freeCashFlow: -20 } };
+  const ctx = { signal: new AbortController().signal,
+    marketData: createTestDataProvider({ getTickerFinancials: async () => financials }) } as HeadlessPaneContext;
+  const result = await relativeValuationHeadless.load({ symbols: ["LOSS"], argument: ["LOSS"], rawArgument: "LOSS", options: {} }, ctx);
+  expect(result.rows[0]).toMatchObject({ trailingPE: null, forwardPE: null, fcfYield: -0.2,
+    reportedMultiples: { trailingPE: -5.2, forwardPE: -9 } });
+  for (const key of ["trailingPE", "forwardPE"]) {
+    const column = relativeValuationHeadless.columns!.find((column) => column.key === key)!;
+    expect(column.format!(result.rows[0]![key], result.rows[0]!)).toBe("N/M");
+  }
+  expect(financials.fundamentals).toMatchObject({ trailingPE: -5.2, forwardPE: -9, freeCashFlow: -20 });
+});

--- a/src/plugins/builtin/research/relative-valuation-headless.ts
+++ b/src/plugins/builtin/research/relative-valuation-headless.ts
@@ -1,3 +1,4 @@
+import { formatPriceEarnings, PRICE_EARNINGS_NOTICE } from "../../../utils/price-earnings";
 import type { HeadlessPaneDefinition } from "../../../types/headless";
 import { formatCurrency, formatNumber, formatPercent } from "../../../utils/format";
 import { loadHeadlessFinancials, loadHeadlessSymbols } from "../shared/headless-market-data";
@@ -11,7 +12,11 @@ export const relativeValuationHeadless: HeadlessPaneDefinition<"rows"> = {
   columns: [
     { key: "symbol", header: "Ticker" },
     { key: "price", header: "Last", align: "right", format: (value, row) => value == null || !row.currency ? "-" : formatCurrency(Number(value), String(row.currency)) },
-    ...[["trailingPE", "P/E"], ["forwardPE", "Fwd P/E"], ["evSales", "EV/S"]].map(([key, header]) => ({
+    ...([ ["trailingPE", "P/E"], ["forwardPE", "Fwd P/E"] ] as const).map(([key, header]) => ({
+      key, header, align: "right" as const,
+      format: (_value: unknown, row: Record<string, unknown>) => formatPriceEarnings((row.reportedMultiples as ReturnType<typeof relativeValuationValues>["reportedMultiples"] | undefined)?.[key]),
+    })),
+    ...[["evSales", "EV/S"]].map(([key, header]) => ({
       key: key!, header: header!, align: "right" as const,
       format: (value: unknown) => value == null ? "-" : formatNumber(Number(value), 1),
     })),
@@ -26,6 +31,10 @@ export const relativeValuationHeadless: HeadlessPaneDefinition<"rows"> = {
     const unavailableSymbols = [...loaded.unavailableSymbols, ...rows.filter((row) => ![
       row.marketCap, row.trailingPE, row.forwardPE, row.evSales, row.fcfYield, row.revenueGrowth, row.operatingMargin,
     ].some((value) => value != null)).map(({ symbol }) => symbol)];
-    return { rows, unavailableSymbols, errors: loaded.errors };
+    return { rows, unavailableSymbols, errors: loaded.errors, metadata: {
+      notices: rows.some((row) => Object.values(row.reportedMultiples).some((value) => value != null && value <= 0)) ? [PRICE_EARNINGS_NOTICE] : [],
+      multipleBasis: "Comparable P/E fields require a positive finite multiple; reportedMultiples preserves the finite provider values.",
+    } };
+
   },
 };

--- a/src/plugins/builtin/research/relative-valuation-model.ts
+++ b/src/plugins/builtin/research/relative-valuation-model.ts
@@ -1,3 +1,4 @@
+import { comparablePriceEarnings } from "../../../utils/price-earnings";
 import type { TickerFinancials } from "../../../types/financials";
 
 export function relativeValuationValues(financials: TickerFinancials | null) {
@@ -5,13 +6,18 @@ export function relativeValuationValues(financials: TickerFinancials | null) {
   const fundamentals = financials?.fundamentals;
   const compatibleCurrency = !!fundamentals?.financialCurrency && !!quote?.currency
     && fundamentals.financialCurrency === quote.currency;
+  const reportedMultiples = {
+    trailingPE: fundamentals?.trailingPE != null && Number.isFinite(fundamentals.trailingPE) ? fundamentals.trailingPE : null,
+    forwardPE: fundamentals?.forwardPE != null && Number.isFinite(fundamentals.forwardPE) ? fundamentals.forwardPE : null,
+  };
   return {
     price: quote?.price ?? null,
     currency: quote?.currency ?? null,
     changePercent: quote?.changePercent ?? null,
     marketCap: quote?.marketCap ?? null,
-    trailingPE: fundamentals?.trailingPE ?? null,
-    forwardPE: fundamentals?.forwardPE ?? null,
+    trailingPE: comparablePriceEarnings(reportedMultiples.trailingPE),
+    forwardPE: comparablePriceEarnings(reportedMultiples.forwardPE),
+    reportedMultiples,
     // Vendor ADR ratios can mix unverified valuation and reporting units too.
     evSales: !compatibleCurrency ? null
       : fundamentals?.enterpriseToRevenue != null && Number.isFinite(fundamentals.enterpriseToRevenue)

--- a/src/plugins/builtin/research/relative-valuation-pane.tsx
+++ b/src/plugins/builtin/research/relative-valuation-pane.tsx
@@ -1,7 +1,9 @@
+import { formatPriceEarnings, PRICE_EARNINGS_NOTICE } from "../../../utils/price-earnings";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { TextAttributes } from "../../../ui";
+import { Box, TextAttributes } from "../../../ui";
 import {
   DataTableView,
+  Prose,
   usePaneFooter,
   type DataTableCell,
   type DataTableColumn,
@@ -19,7 +21,7 @@ import { useBoundTicker as useSymbolBinding } from "../shared/ticker-request";
 import { useFxRatesMap } from "../../../market-data/hooks";
 import { comparableMarketCap, relativeValuationValues } from "./relative-valuation-model";
 
-type RelativeColumnId = "symbol" | Exclude<keyof ReturnType<typeof relativeValuationValues>, "currency">;
+type RelativeColumnId = "symbol" | Exclude<keyof ReturnType<typeof relativeValuationValues>, "currency" | "reportedMultiples">;
 type RelativeColumn = DataTableColumn & { id: RelativeColumnId };
 type RelativeRow = ReturnType<typeof relativeValuationValues> & {
   symbol: string;
@@ -150,6 +152,8 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
   const missingFx = rows.some((row, index) => row.marketCap != null && comparableRows[index]?.marketCap == null);
   const sortedRows = useMemo(() => sortRelativeRows(comparableRows, sortPreference), [comparableRows, sortPreference]);
 
+  const hasNonComparablePE = rows.some((row) => Object.values(row.reportedMultiples).some((value) => value != null && value <= 0));
+
   useClampSelectedIndex(rows.length, selectedIdx, setSelectedIdx);
 
   const renderCell = useCallback((row: RelativeRow, column: RelativeColumn, _index: number, rowState: { selected: boolean }): DataTableCell => {
@@ -164,9 +168,9 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
       case "marketCap":
         return { text: formatCompact(row.marketCap ?? undefined), color: selectedColor ?? colors.textDim };
       case "trailingPE":
-        return { text: formatNumber(row.trailingPE ?? undefined, 1), color: selectedColor ?? colors.text };
+        return { text: formatPriceEarnings(row.reportedMultiples.trailingPE), color: selectedColor ?? colors.text };
       case "forwardPE":
-        return { text: formatNumber(row.forwardPE ?? undefined, 1), color: selectedColor ?? colors.text };
+        return { text: formatPriceEarnings(row.reportedMultiples.forwardPE), color: selectedColor ?? colors.text };
       case "evSales":
         return { text: formatNumber(row.evSales ?? undefined, 1), color: selectedColor ?? colors.text };
       case "fcfYield":
@@ -206,6 +210,9 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
       onRootKeyDown={handleKeyDown}
       rootWidth={width}
       rootHeight={height}
+      rootBefore={hasNonComparablePE ? <Box paddingX={1} flexShrink={0}>
+        <Prose text={PRICE_EARNINGS_NOTICE} width={Math.max(8, width - 2)} color={colors.textDim} />
+      </Box> : undefined}
       columns={columns}
       items={sortedRows}
       sortColumnId={sortPreference.columnId}

--- a/src/plugins/builtin/ticker-detail/overview/model.ts
+++ b/src/plugins/builtin/ticker-detail/overview/model.ts
@@ -1,3 +1,4 @@
+import { formatPriceEarnings } from "../../../../utils/price-earnings";
 import { priceColor } from "../../../../theme/colors";
 import type { Quote, TickerFinancials } from "../../../../types/financials";
 import type { TickerPosition, TickerRecord } from "../../../../types/ticker";
@@ -59,10 +60,10 @@ export function buildOverviewStats({
     stats.push({ label: "Shares Out", value: formatCompact(fundamentals.sharesOutstanding) });
   }
   if (fundamentals?.trailingPE != null) {
-    stats.push({ label: "P/E (TTM)", value: formatNumber(fundamentals.trailingPE, 1) });
+    stats.push({ label: "P/E (TTM)", value: formatPriceEarnings(fundamentals.trailingPE) });
   }
   if (fundamentals?.forwardPE != null) {
-    stats.push({ label: "Fwd P/E", value: formatNumber(fundamentals.forwardPE, 1) });
+    stats.push({ label: "Fwd P/E", value: formatPriceEarnings(fundamentals.forwardPE) });
   }
   if (fundamentals?.eps != null) {
     stats.push({ label: "EPS", value: financialCurrency ? formatCurrency(fundamentals.eps, financialCurrency) : formatNumber(fundamentals.eps, 2) });

--- a/src/time-series/fundamentals.ts
+++ b/src/time-series/fundamentals.ts
@@ -674,7 +674,7 @@ function providerCurrentValuationPoint(
     : metric === "pegRatio"
       ? financials.fundamentals?.pegRatio
       : undefined;
-  if (!finiteNumber(value)) return null;
+  if (!finiteNumber(value) || (metric === "forwardPE" && value <= 0)) return null;
   const quoteTime = financials.quote?.lastUpdated;
   const date = validDate(finiteNumber(quoteTime) && quoteTime > 0 ? quoteTime : null);
   if (!date) return null;

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -2184,3 +2184,23 @@ test("financial charts disclose snapshot vintages once without changing period o
     expect(result.series[0]?.points[0]).toMatchObject({ value: 96_571_000_000, observedAt: new Date("2017-06-30T00:00:00Z"), availableAt: new Date("2018-08-03T00:00:00Z"), date: new Date(timestampMode === "period-end" ? "2017-06-30T00:00:00Z" : "2018-08-03T00:00:00Z") });
   }
 });
+
+test.each([-9, 0, 12])("forward P/E chart handles reported multiple %s without inventing comparable points", async (forwardPE) => {
+  const now = new Date("2026-06-01T16:00:00Z");
+  const financials = { ...emptyFinancials(), fundamentals: { forwardPE },
+    quote: { symbol: "TEST", price: 20, currency: "USD", change: 0, changePercent: 0, lastUpdated: now.getTime() } };
+  const provider = createTestDataProvider({ getTickerFinancials: async () => financials });
+  const spec = chartSpec({ viewport: { range: "1Y", resolution: "auto" }, series: [chartSeries({
+    source: { kind: "security", instrument: { symbol: "TEST" }, fieldId: "valuation.forwardPE" },
+  })] });
+  const result = await resolveChartSpecData(spec, { dataProvider: provider, now, loadFredSeries: async () => fredLoad() });
+  expect(result.errors).toEqual([]);
+  if (forwardPE > 0) {
+    expect(result.series[0]?.points.map((point) => point.value)).toEqual([12]);
+    expect(result.series[0]?.warning).toBeUndefined();
+  } else {
+    expect(result.series[0]?.points).toEqual([]);
+    expect(result.series[0]?.warning).toContain("not meaningful");
+  }
+  expect(financials.fundamentals.forwardPE).toBe(forwardPE);
+});

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -1226,6 +1226,11 @@ export async function resolveChartSpecData(
         await quoteMetadataPromise,
       );
       if (!result) throw new Error(`Unknown field ${source.fieldId}.`);
+      const reportedForwardPE = merged.fundamentals?.forwardPE;
+      if (source.fieldId === "valuation.forwardPE" && reportedForwardPE != null
+        && Number.isFinite(reportedForwardPE) && reportedForwardPE <= 0) {
+        result.warning = [result.warning, "Reported forward P/E is non-positive and is not meaningful for valuation."].filter(Boolean).join(" ");
+      }
       if (isFundamentalFieldId(source.fieldId) && fundamentalSeriesUsesAvailabilityFallback(merged, source)) {
         result.warning = [result.warning, "Publication dates are unavailable for some observations; period-end dates are used as a fallback."].filter(Boolean).join(" ");
       }

--- a/src/utils/price-earnings.test.ts
+++ b/src/utils/price-earnings.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import type { TickerFinancials } from "../types/financials";
+import type { TickerRecord } from "../types/ticker";
+import { getColumnValue, getSortValue } from "../plugins/builtin/portfolio-list/column-values";
+import { buildOverviewStats } from "../plugins/builtin/ticker-detail/overview/model";
+import { relativeValuationValues } from "../plugins/builtin/research/relative-valuation-model";
+
+const ticker: TickerRecord = { metadata: {
+  ticker: "TEST", name: "Test", exchange: "NASDAQ", currency: "USD",
+  portfolios: [], watchlists: [], positions: [], custom: {}, tags: [],
+} };
+const context = { baseCurrency: "USD", exchangeRates: new Map<string, number>(), now: 1 };
+
+test.each([
+  { value: -5.2, text: "N/M", comparable: null },
+  { value: 0, text: "N/M", comparable: null },
+  { value: undefined, text: "—", comparable: null },
+  { value: Number.NaN, text: "—", comparable: null },
+  { value: Number.POSITIVE_INFINITY, text: "—", comparable: null },
+  { value: 12.3, text: "12.3", comparable: 12.3 },
+])("portfolio and peer P/E comparisons handle $value consistently", ({ value, text, comparable }) => {
+  const data: TickerFinancials = { annualStatements: [], quarterlyStatements: [], priceHistory: [],
+    fundamentals: { trailingPE: value, forwardPE: value, eps: -3.1 } };
+  for (const id of ["pe", "forward_pe"]) {
+    const column = { id, label: id, width: 8, align: "right" as const };
+    expect(getColumnValue(column, ticker, data, context).text).toBe(text);
+    expect(getSortValue(column, ticker, data, context)).toBe(comparable);
+  }
+  expect(relativeValuationValues(data)).toMatchObject({ trailingPE: comparable, forwardPE: comparable });
+});
+
+test("overview keeps reported losses and a positive forecast while marking the trailing multiple non-comparable", () => {
+  const fundamentals = { trailingPE: -5.2, forwardPE: 12.3, eps: -3.1, financialCurrency: "USD" };
+  const stats = buildOverviewStats({ quote: undefined, fundamentals, quoteCurrency: "USD", baseCurrency: "USD", toBase: (value) => value });
+  expect(stats.find(({ label }) => label === "P/E (TTM)")?.value).toBe("N/M");
+  expect(stats.find(({ label }) => label === "Fwd P/E")?.value).toBe("12.3");
+  expect(stats.find(({ label }) => label === "EPS")?.value).toBe("-$3.10");
+  expect(fundamentals).toMatchObject({ trailingPE: -5.2, forwardPE: 12.3, eps: -3.1 });
+});

--- a/src/utils/price-earnings.ts
+++ b/src/utils/price-earnings.ts
@@ -1,0 +1,13 @@
+import { formatNumber } from "./format";
+
+export const PRICE_EARNINGS_NOTICE = "N/M = not meaningful. Non-positive P/E values are excluded from ranking.";
+
+/** Negative earnings do not make a security cheaper than a profitable peer. */
+export function comparablePriceEarnings(value: number | null | undefined): number | null {
+  return value != null && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+export function formatPriceEarnings(value: number | null | undefined, precision = 1): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return value <= 0 ? "N/M" : formatNumber(value, precision);
+}


### PR DESCRIPTION
Sorting the peer comparison by lowest P/E put loss-making Rivian ahead of profitable Ford and GM. Non-positive finite P/E now displays as N/M and sorts after comparable positive multiples in either direction. The table explains the exclusion; headless results retain the original provider multiples alongside the comparable values.

The same P/E treatment covers portfolio columns, overview/CLI output, AI context and current forward-P/E charts. Missing values remain unavailable, and reported losses, negative cash-flow yields and positive forward estimates remain intact.

Validation: 97 focused tests / 447 assertions, all six type-check targets, web build, and green PR CI. Independent immutable-source review plus 64 tests / 296 assertions. Recovered-source runtime checks use anonymous live market data: browser ascending/descending P/E ordering and saved-layout reload; native 80/140-column rendering and both sort directions. Current forward-P/E headless output reports unavailable with its reason instead of a negative comparable observation.

No release or version change.
