### PR TITLE
Disclose FRED credit history coverage in saved research charts

### DIFF
--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -343,6 +343,8 @@ export interface CloudFredSeriesInfoPayload {
   source: string;
   notes: string;
   lastUpdated?: string;
+  observationStart?: string;
+  observationEnd?: string;
 }
 
 export interface CloudFredSeriesPayload {

--- a/src/data/fred-series.ts
+++ b/src/data/fred-series.ts
@@ -6,7 +6,8 @@ import type {
 
 const CACHE_KIND = "fred-series";
 const CACHE_SOURCE = "gloomberb-cloud";
-const CACHE_SCHEMA_VERSION = 1;
+// Refresh persisted metadata that predates FRED's source coverage dates.
+const CACHE_SCHEMA_VERSION = 2;
 const CACHE_POLICY = {
   staleMs: 24 * 60 * 60 * 1000,
   expireMs: 30 * 24 * 60 * 60 * 1000,

--- a/src/plugins/builtin/credit-conditions/client.test.ts
+++ b/src/plugins/builtin/credit-conditions/client.test.ts
@@ -60,7 +60,7 @@ describe("loadCreditConditions", () => {
       expect(persistence.getResource<{ observations: unknown[] }>(
         "fred-series",
         `${CREDIT_SERIES[0].seriesId}:limit=45:sort=desc`,
-        { sourceKey: "gloomberb-cloud", schemaVersion: 1 },
+        { sourceKey: "gloomberb-cloud", schemaVersion: 2 },
       )?.value.observations).toHaveLength(45);
 
       resetFredSeriesPersistence();

--- a/src/plugins/builtin/credit-conditions/index.test.tsx
+++ b/src/plugins/builtin/credit-conditions/index.test.tsx
@@ -64,7 +64,7 @@ beforeEach(() => {
       "fred-series",
       `${seriesId}:limit=45:sort=desc`,
       entry(seriesId, index).data,
-      { sourceKey: "gloomberb-cloud", schemaVersion: 1 },
+      { sourceKey: "gloomberb-cloud", schemaVersion: 2 },
     );
   }
   attachFredSeriesPersistence(persistence);

--- a/src/plugins/builtin/econ/fred-cache.test.ts
+++ b/src/plugins/builtin/econ/fred-cache.test.ts
@@ -44,6 +44,31 @@ afterEach(() => {
 });
 
 describe("FRED series cache", () => {
+  test("refreshes legacy metadata and preserves coverage and source freshness through reopening", async () => {
+    const persistence = new MemoryPluginPersistence();
+    const request: FredSeriesRequest = { seriesId: "BAMLC0A0CM", startDate: "2007-01-01", sortOrder: "asc" };
+    const old = { ...makeSeries(0.8), info: { ...makeSeries(0.8).info!, id: request.seriesId } };
+    persistence.seedResource("fred-series", "BAMLC0A0CM:start=2007-01-01:sort=asc", old,
+      { sourceKey: "gloomberb-cloud", schemaVersion: 1 });
+    attachFredSeriesPersistence(persistence);
+    let calls = 0;
+    const fetchedAt = new Date(Date.now() - 60_000).toISOString();
+    const updated = { ...old, fetchedAt, info: { ...old.info, observationStart: "2023-09-12", observationEnd: "2026-09-10" } };
+    const loaded = await loadCachedFredSeries(request, async () => { calls++; return updated; });
+    expect(calls).toBe(1);
+    expect(loaded.data.info?.observationStart).toBe("2023-09-12");
+    resetFredSeriesPersistence();
+    attachFredSeriesPersistence(persistence);
+    const reopened = await loadCachedFredSeries(request, async () => { throw Error("Must reuse upgraded cache"); });
+    expect(reopened.data).toEqual(updated);
+    expect(reopened.fetchedAt).toBe(Date.parse(fetchedAt));
+    expect(reopened.stale).toBe(false);
+    const offline = await loadCachedFredSeries(request, async () => { throw Error("offline"); }, { force: true });
+    expect(offline.stale).toBe(true);
+    expect(offline.data.info?.observationEnd).toBe("2026-09-10");
+    expect(offline.fetchedAt).toBe(Date.parse(fetchedAt));
+  });
+
   test("uses server-hydrated series without calling the network loader", async () => {
     hydrateFredSeries([["cpiaucsl", {
       data: makeSeries(321),
@@ -93,7 +118,7 @@ describe("FRED series cache", () => {
       makeSeries(319),
       {
         sourceKey: "gloomberb-cloud",
-        schemaVersion: 1,
+        schemaVersion: 2,
         stale: true,
       },
     );

--- a/src/time-series/economic.test.ts
+++ b/src/time-series/economic.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import type { CloudFredSeriesInfoPayload } from "../api-client";
+import { fredCreditCoverageNotice } from "./economic";
+
+const info: CloudFredSeriesInfoPayload = {
+  id: "BAMLC0A0CM", title: "ICE BofA US Corporate Index Option-Adjusted Spread",
+  units: "Percent", frequency: "Daily, Close", seasonalAdjustment: "Not Seasonally Adjusted", source: "",
+  observationStart: "2023-09-12", observationEnd: "2026-09-10",
+  notes: "Starting in April 2026, this series will only include 3 years of observations. For more data, go to the source.",
+};
+
+test("credit coverage uses declared source dates and only warns before the visible boundary", () => {
+  for (const start of [null, Date.parse("2020-01-01"), Date.parse("2023-09-11")]) {
+    expect(fredCreditCoverageNotice("bamlc0a0cm", info, start)).toContain("2023-09-12 to 2026-09-10");
+    expect(fredCreditCoverageNotice("BAMLC0A0CM", info, start)).toContain("3 years");
+  }
+  expect(fredCreditCoverageNotice(info.id, info, Date.parse("2023-09-12"))).toBeNull();
+  expect(fredCreditCoverageNotice(info.id, info, Date.parse("2025-01-01"))).toBeNull();
+  expect(fredCreditCoverageNotice(info.id, { ...info, notes: "" }, null)).not.toContain("3 years");
+  // A future source extension must move the boundary instead of enforcing a rolling date guess.
+  expect(fredCreditCoverageNotice(info.id, { ...info, observationStart: "1996-12-31", notes: "" }, Date.parse("2020-01-01"))).toBeNull();
+});
+
+test("missing or mismatched coverage cannot claim a retention boundary", () => {
+  for (const metadata of [null, { ...info, id: "BAMLH0A0HYM2" }, { ...info, observationStart: undefined },
+    { ...info, observationStart: "2023-02-30" }, { ...info, observationStart: "2027-01-01" }]) {
+    expect(fredCreditCoverageNotice(info.id, metadata, null)).toBeNull();
+  }
+  expect(fredCreditCoverageNotice("CPIAUCSL", { ...info, id: "CPIAUCSL" }, null)).toBeNull();
+});

--- a/src/time-series/economic.ts
+++ b/src/time-series/economic.ts
@@ -1,4 +1,34 @@
 import type { TimeSeriesPoint } from "./types";
+import type { CloudFredSeriesInfoPayload } from "../api-client";
+
+const ICE_CREDIT_SERIES = new Set([
+  "BAMLC0A0CM", "BAMLC0A1CAAA", "BAMLC0A2CAA", "BAMLC0A3CA", "BAMLC0A4CBBB",
+  "BAMLH0A0HYM2", "BAMLC0A0CMEY", "BAMLH0A0HYM2EY",
+]);
+
+function sourceDate(value: string | undefined): number | null {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const time = Date.parse(value);
+  return Number.isFinite(time) && new Date(time).toISOString().slice(0, 10) === value ? time : null;
+}
+
+/** Source coverage is separate from query limits and calculation buffers. */
+export function fredCreditCoverageNotice(
+  seriesId: string,
+  info: CloudFredSeriesInfoPayload | null,
+  visibleStart: number | null,
+): string | null {
+  const id = seriesId.trim().toUpperCase();
+  if (!ICE_CREDIT_SERIES.has(id) || info?.id.trim().toUpperCase() !== id) return null;
+  const start = sourceDate(info.observationStart);
+  const end = sourceDate(info.observationEnd);
+  if (start === null || end === null || start > end) return null;
+  if (visibleStart !== null && visibleStart >= start) return null;
+  const retention = /Starting in April 2026, this series will only include 3 years of observations\./.test(info.notes)
+    ? " FRED limits this ICE series to 3 years."
+    : "";
+  return `FRED coverage: ${info.observationStart} to ${info.observationEnd}. Earlier dates are unavailable from this source.${retention}`;
+}
 
 export interface FredObservationLike {
   date: string;

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -40,6 +40,41 @@ const fredLoad = (
 });
 
 describe("resolveChartSpecData", () => {
+  test("credit stress windows disclose source coverage without clipping buffers or scaling effective yields", async () => {
+    const spec = buildCustomChartPreset("FRED:BAMLC0A0CM,FRED:BAMLC0A0CMEY");
+    const requests: string[] = [];
+    const sources = {
+      now: new Date("2026-09-11"),
+      loadFredSeries: async (request: { seriesId: string; startDate?: string }) => {
+        requests.push(request.startDate!);
+        const yieldSeries = request.seriesId.endsWith("EY");
+        return fredLoad({
+          observations: [
+            { date: "2023-09-12", value: yieldSeries ? 5.82 : 1.23 },
+            { date: "2025-04-09", value: yieldSeries ? 5.5 : 1.21 },
+            { date: "2026-09-10", value: yieldSeries ? 5.68 : 0.8 },
+          ],
+          info: { id: request.seriesId, title: yieldSeries ? "IG effective yield" : "IG OAS", units: "Percent",
+            frequency: "Daily, Close", seasonalAdjustment: "Not Seasonally Adjusted", source: "FRED", notes: "",
+            observationStart: "2023-09-12", observationEnd: "2026-09-10" },
+        });
+      },
+    };
+    const fiveYear = await resolveChartSpecData(spec, sources);
+    expect(fiveYear.warnings.filter((warning) => warning.includes("FRED coverage"))).toHaveLength(2);
+    expect(fiveYear.warnings.some((warning) => warning.includes("vintage dates"))).toBe(true);
+    expect(fiveYear.series.map((series) => series.points.at(-1)?.value)).toEqual([0.8, 5.68]);
+    expect(fiveYear.series.map((series) => series.unit)).toEqual(["%", "%"]);
+    const recent = await resolveChartSpecData({ ...spec, viewport: { ...spec.viewport, range: "1Y" } }, sources);
+    expect(requests.at(-1)! < "2023-09-12").toBe(true); // Calculation buffer predates the visible window.
+    expect(recent.warnings.some((warning) => warning.includes("FRED coverage"))).toBe(false);
+    const old = await resolveChartSpecData({ ...spec, viewport: { ...spec.viewport,
+      dateWindow: { start: "2020-01-01", end: "2020-06-30" } } }, sources);
+    expect(old.series.every((series) => series.points.length === 0)).toBe(true);
+    expect(old.warnings.filter((warning) => warning.includes("Earlier dates are unavailable"))).toHaveLength(2);
+    expect(old.viewport.start?.toISOString().slice(0, 10)).toBe("2020-01-01");
+  });
+
   test("qualified price charts retain quote metadata without injecting the fetched snapshot into history", async () => {
     let quoteCalls = 0;
     let financialCalls = 0;

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -27,7 +27,7 @@ import type { TimeRange } from "./range";
 import type { DataProvider, MarketDataRequestContext } from "../types/data-provider";
 import type { Quote, TickerFinancials } from "../types/financials";
 import type { FredSeriesLoadResult, FredSeriesRequest } from "../data/fred-series";
-import { extractFredSeries } from "./economic";
+import { extractFredSeries, fredCreditCoverageNotice } from "./economic";
 import {
   getTimeSeriesField,
   isFundamentalFieldId,
@@ -1166,6 +1166,8 @@ export async function resolveChartSpecData(
         };
         const fred = await loadEconomicSeries(request);
         const result = baseEconomicSeries(seriesSpec, fred, index);
+        const coverageNotice = fredCreditCoverageNotice(seriesSpec.source.seriesId, fred.data.info, requestVisibleBounds.start);
+        if (result && coverageNotice) priorityWarnings.push(`${result.label}: ${coverageNotice}`);
         const freshnessWarning = staleFredWarning(fred);
         if (result && freshnessWarning) priorityWarnings.push(`${result.label}: ${freshnessWarning}`);
         return result;


### PR DESCRIPTION
A credit chart requesting five years or a 2020 stress window currently leaves unavailable ICE history unexplained. Use FRED's declared observation start/end to disclose that boundary, including its current three-year retention note when the exact source metadata states it. Visible dates control the notice; calculation buffers do not trigger it. Yield and spread observations retain their original percent units.

Refresh the persisted FRED metadata schema so saved charts receive source coverage after backend244. Existing stale-source and unavailable-vintage notices remain visible. The source boundary follows metadata if upstream coverage changes; no older history is manufactured.

Validation: 63 focused tests (292 assertions), all six TypeScript targets and web build. The persistence regression verifies old metadata refresh, reopen and offline freshness. Actual FRED data through the locally patched backend renders IG/HY 5.68%/7.42%, complete older-window notices at native 80 columns, and a saved 2025 stress chart that survives ordinary reload. Actual Copy Screenshot output was inspected; headless model preserves period dates and selected endpoint values. Backend service uses isolated SQL for local proof; production deployment verification follows review.

Dependencies: backend244 must deploy first. Separate chart QA followups will address existing 80-column legend clipping and short-window screenshot year context. No release/version change.
