### PR TITLE
Keep option quote attribution tied to the selected contract

### DIFF
--- a/src/components/data-table/view.test.tsx
+++ b/src/components/data-table/view.test.tsx
@@ -312,6 +312,18 @@ test("fulfills a center request after rows are laid out and then leaves manual s
   await renderSettled();
   expect(body.scrollTop).toBe(50);
   expect(scrollSources.at(-1)).toBe("user");
+
+  await act(async () => { setDeferredRows!([]); });
+  await renderSettled();
+  expect(body.scrollTop).toBe(0);
+  expect(scrollSources.at(-1)).toBe("programmatic");
+  expect(testSetup.captureCharFrame()).toContain("Loading rows");
+  await act(async () => { setDeferredRows!(largeRows); });
+  await renderSettled();
+  expect(body.scrollTop).toBe(500 - Math.floor(body.viewport.height / 2));
+  await act(async () => { body.scrollTo(50); });
+  await renderSettled();
+  expect(scrollSources.at(-1)).toBe("user");
 });
 
 

--- a/src/components/ui/data-table/opentui/index.tsx
+++ b/src/components/ui/data-table/opentui/index.tsx
@@ -419,6 +419,17 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
   }, [columns.length, headerScrollRef, horizontalScrollbarVisible, items.length, measuredViewportHeight, scrollRef]);
 
   useEffect(() => {
+    if (items.length === 0) {
+      lastAppliedScrollRequestRef.current = null;
+      const body = scrollRef.current;
+      if (body && body.scrollTop !== 0) {
+        // Removing a scrolled dataset is a layout reset, not user navigation.
+        // Reveal its loading state and let the next dataset center normally.
+        body.scrollTo(0);
+        controlledScrollTopRef.current = body.scrollTop;
+      }
+      return;
+    }
     if (scrollToIndex == null) {
       lastAppliedScrollRequestRef.current = null;
       return;
@@ -440,7 +451,9 @@ export function OpenTuiDataTable<T, C extends DataTableColumn = DataTableColumn>
     // completed requests remain consumed while users scroll or rows append.
   }, [
     applyScrollToIndex,
+    items.length,
     measuredViewportHeight,
+    scrollRef,
     scrollToIndex,
     scrollToIndexAlign,
     scrollToIndexVersion,

--- a/src/plugins/builtin/options-calculator/index.tsx
+++ b/src/plugins/builtin/options-calculator/index.tsx
@@ -14,7 +14,7 @@ export const optionsCalculatorModule: PluginModule = {
       component: OptionsCalculatorPane,
       defaultPosition: "right",
       defaultMode: "floating",
-      defaultFloatingSize: { width: 76, height: 16 },
+      defaultFloatingSize: { width: 76, height: 20 },
     },
   ],
 

--- a/src/plugins/builtin/options-calculator/model.test.ts
+++ b/src/plugins/builtin/options-calculator/model.test.ts
@@ -7,6 +7,8 @@ import {
   draftFromParams,
   solveImpliedVolatility,
   valueOption,
+  updateOptionCalcDraft,
+  reconcileOptionCalcDraft,
   type OptionCalcDraft,
 } from "./model";
 
@@ -20,6 +22,37 @@ const CANONICAL: OptionCalcDraft = {
   volatility: 0.2,
   dividendYield: 0,
 };
+
+test("contract edits retain numeric what-if inputs without borrowing market attribution", () => {
+  const original: OptionCalcDraft = { ...CANONICAL, marketPrice: 20.425, marketPriceSource: "mid",
+    marketReference: { contractSymbol: "COST260925C00900000", currency: "USD", expiration: 1790294400,
+      bid: 19.75, ask: 21.1, lastPrice: 21.34, lastTradeDate: 1789136721 } };
+  for (const patch of [{ side: "put" as const }, { strike: 105 }, { daysToExpiry: 14 }, { symbol: "COST" }]) {
+    const changed = updateOptionCalcDraft(original, patch);
+    expect(changed.marketPrice).toBe(20.425);
+    expect(changed.marketPriceSource).toBeUndefined();
+    expect(changed.marketReference).toBeUndefined();
+    const restored = updateOptionCalcDraft(changed, { side: original.side, strike: original.strike,
+      daysToExpiry: original.daysToExpiry, symbol: original.symbol });
+    expect(restored.marketPriceSource).toBeUndefined();
+  }
+  expect(updateOptionCalcDraft(original, { side: original.side })).toEqual(original);
+  expect(updateOptionCalcDraft(original, { volatility: 0.4, spot: 120 }).marketReference).toEqual(original.marketReference);
+  expect(updateOptionCalcDraft(original, { marketPrice: 20.425 }).marketPriceSource).toBeUndefined();
+  expect(updateOptionCalcDraft({ ...CANONICAL, marketPrice: 5 }, { side: "put" }).marketPrice).toBe(5);
+});
+
+test("restored legacy changed-contract drafts lose stale source attribution before interaction", () => {
+  const seed = { ...CANONICAL, marketPrice: 20.425, marketPriceSource: "mid" as const };
+  const legacyPut = { ...seed, side: "put" as const };
+  expect(reconcileOptionCalcDraft(legacyPut, seed)).toMatchObject({
+    side: "put", marketPrice: 20.425, marketPriceSource: undefined, marketReference: undefined,
+  });
+  expect(reconcileOptionCalcDraft(seed, seed).marketPriceSource).toBe("mid");
+  expect(reconcileOptionCalcDraft({ ...seed, marketPrice: 5 }, seed).marketPriceSource).toBeUndefined();
+  const manual = updateOptionCalcDraft(legacyPut, { side: "call" });
+  expect(reconcileOptionCalcDraft(manual, seed).marketPriceSource).toBeUndefined();
+});
 
 describe("valueOption", () => {
   test("matches the textbook Black-Scholes call and put", () => {

--- a/src/plugins/builtin/options-calculator/model.ts
+++ b/src/plugins/builtin/options-calculator/model.ts
@@ -1,4 +1,5 @@
 import { zonedWallClockToUtcMs } from "../../../utils/zoned-date-time";
+import { optionMarketReference, parseOptionMarketReference, type OptionMarketReference } from "../options/market-reference";
 
 export const OPTIONS_CALCULATOR_PANE_ID = "options-calculator";
 export const OPTIONS_CALCULATOR_TEMPLATE_ID = "options-calculator-pane";
@@ -23,6 +24,26 @@ export interface OptionCalcDraft {
   /** 0 means "not supplied", which is also the only price no option can trade at. */
   marketPrice: number;
   marketPriceSource?: "mid" | "last";
+  marketReference?: OptionMarketReference;
+}
+
+/** Edited contracts retain numeric what-if inputs, but lose the old contract's market attribution. */
+export function updateOptionCalcDraft(current: OptionCalcDraft, patch: Partial<OptionCalcDraft>): OptionCalcDraft {
+  const changedContract = (["symbol", "side", "strike", "daysToExpiry"] as const)
+    .some((key) => patch[key] !== undefined && patch[key] !== current[key]);
+  const changedPrice = Object.hasOwn(patch, "marketPrice");
+  return { ...current, ...patch, ...(changedContract || changedPrice
+    ? { marketPriceSource: undefined, marketReference: undefined } : {}) };
+}
+
+/** Repair already-saved edited drafts from clients that retained the seed's attribution. */
+export function reconcileOptionCalcDraft(current: OptionCalcDraft, seed: OptionCalcDraft): OptionCalcDraft {
+  const sameContract = (["symbol", "side", "strike", "daysToExpiry"] as const)
+    .every((key) => current[key] === seed[key]);
+  if (!sameContract || current.marketPrice !== seed.marketPrice || current.marketPriceSource !== seed.marketPriceSource) {
+    return { ...current, marketPriceSource: undefined, marketReference: undefined };
+  }
+  return { ...current, marketReference: optionMarketReference(current.marketReference) };
 }
 
 export const DEFAULT_OPTION_CALC_DRAFT: OptionCalcDraft = {
@@ -268,6 +289,7 @@ function numberParam(params: Record<string, string>, key: string, fallback: numb
 
 export function draftFromParams(params: Record<string, string> | undefined): OptionCalcDraft {
   if (!params) return DEFAULT_OPTION_CALC_DRAFT;
+  const marketReference = parseOptionMarketReference(params.marketReference);
   return {
     symbol: params.symbol ?? DEFAULT_OPTION_CALC_DRAFT.symbol,
     side: params.side === "put" ? "put" : "call",
@@ -280,5 +302,6 @@ export function draftFromParams(params: Record<string, string> | undefined): Opt
     marketPrice: numberParam(params, "marketPrice", DEFAULT_OPTION_CALC_DRAFT.marketPrice),
     ...(params.marketPriceSource === "mid" || params.marketPriceSource === "last"
       ? { marketPriceSource: params.marketPriceSource } : {}),
+    ...(marketReference ? { marketReference } : {}),
   };
 }

--- a/src/plugins/builtin/options-calculator/pane.tsx
+++ b/src/plugins/builtin/options-calculator/pane.tsx
@@ -9,7 +9,8 @@ import { formatNumber } from "../../../utils/format";
 import { isPlainKey } from "../../../utils/keyboard";
 import type { InlineField } from "../kelly-sizer/fields";
 import { InlineFieldView, truncateText } from "../kelly-sizer/view";
-import { OPTIONS_CALCULATOR_PANE_ID, describeDraftProblem, draftFromParams, solveImpliedVolatility, valueOption, type OptionCalcDraft, type OptionSide } from "./model";
+import { OPTIONS_CALCULATOR_PANE_ID, describeDraftProblem, draftFromParams, reconcileOptionCalcDraft, solveImpliedVolatility, updateOptionCalcDraft, valueOption, type OptionCalcDraft, type OptionSide } from "./model";
+import { OptionQuoteContext, optionQuoteContextHeight } from "../options/quote-context";
 
 const SIDE_OPTIONS = [
   { label: "Call", value: "call" },
@@ -23,13 +24,15 @@ function formatSigned(value: number, decimals: number): string {
 export function OptionsCalculatorPane({ focused, width, height }: PaneProps) {
   const ui = useUiHost();
   const paneInstance = usePaneInstance();
-  const [draft, setDraft] = usePaneStateValue<OptionCalcDraft>("draft", draftFromParams(paneInstance?.params));
+  const seed = useMemo(() => draftFromParams(paneInstance?.params), [paneInstance?.params]);
+  const [storedDraft, setDraft] = usePaneStateValue<OptionCalcDraft>("draft", seed);
+  const draft = useMemo(() => reconcileOptionCalcDraft(storedDraft, seed), [storedDraft, seed]);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [activeFieldId, setActiveFieldId] = useState<string | null>(null);
 
   const updateDraft = useCallback((patch: Partial<OptionCalcDraft>) => {
-    setDraft((current) => ({ ...current, ...patch }));
-  }, [setDraft]);
+    setDraft((current) => updateOptionCalcDraft(reconcileOptionCalcDraft(current, seed), patch));
+  }, [seed, setDraft]);
 
   const fields = useMemo<InlineField[]>(() => [
     { id: "spot", label: "Spot", value: draft.spot, valueText: String(draft.spot), onValue: (value) => updateDraft({ spot: value }) },
@@ -53,7 +56,7 @@ export function OptionsCalculatorPane({ focused, width, height }: PaneProps) {
     { id: "dividendYield", label: "Div yld", value: draft.dividendYield, percent: true, onValue: (value) => updateDraft({ dividendYield: value }) },
     {
       id: "marketPrice",
-      label: draft.marketPriceSource === "mid" ? "Mid" : draft.marketPriceSource === "last" ? "Last" : "Market",
+      label: draft.marketPriceSource === "mid" ? "Mid" : draft.marketPriceSource === "last" ? "Last" : draft.marketPrice > 0 ? "Input" : "Market",
       value: draft.marketPrice,
       valueText: String(Number(draft.marketPrice.toPrecision(12))),
       // Clearing the field is how a standalone user says "no market price".
@@ -126,7 +129,8 @@ export function OptionsCalculatorPane({ focused, width, height }: PaneProps) {
   const pairMetrics = width >= 50;
   const metricWidth = pairMetrics ? Math.floor((width - 2) / 2) : Math.max(1, width - 2);
   const trailingMetricWidth = pairMetrics ? Math.max(1, width - 2 - metricWidth) : metricWidth;
-  const showGreeks = height >= 1 + rows + 1 + (pairMetrics ? 1 : 2) + (pairMetrics ? 3 : 5) + 1;
+  const referenceHeight = optionQuoteContextHeight(draft.marketReference, width - 2, Math.max(1, height - rows - 5));
+  const showGreeks = height >= 1 + rows + 1 + (pairMetrics ? 1 : 2) + (pairMetrics ? 3 : 5) + 1 + referenceHeight;
 
   return (
     <Box flexDirection="column" width={width} height={height}>
@@ -170,6 +174,10 @@ export function OptionsCalculatorPane({ focused, width, height }: PaneProps) {
 
       <Box height={1} />
 
+      {draft.marketReference && <Box paddingX={1} height={referenceHeight} flexShrink={0}>
+        <OptionQuoteContext reference={draft.marketReference} width={width - 2} height={referenceHeight} snapshot />
+      </Box>}
+
       <Box flexDirection={pairMetrics ? "row" : "column"} paddingX={1}>
         <KeyValueRow
           label="Model"
@@ -181,7 +189,8 @@ export function OptionsCalculatorPane({ focused, width, height }: PaneProps) {
         <KeyValueRow
           label="Implied IV"
           value={implied.volatility != null ? `${formatNumber(implied.volatility * 100, 2)}%` : "—"}
-          detail={implied.volatility != null ? "from market" : undefined}
+          detail={implied.volatility != null ? draft.marketPriceSource === "mid" ? "from mid"
+            : draft.marketPriceSource === "last" ? "from last" : "from input" : undefined}
           color={implied.volatility != null ? colors.positive : colors.textDim}
           width={trailingMetricWidth}
         />

--- a/src/plugins/builtin/options-calculator/pane.tsx
+++ b/src/plugins/builtin/options-calculator/pane.tsx
@@ -129,7 +129,7 @@ export function OptionsCalculatorPane({ focused, width, height }: PaneProps) {
   const pairMetrics = width >= 50;
   const metricWidth = pairMetrics ? Math.floor((width - 2) / 2) : Math.max(1, width - 2);
   const trailingMetricWidth = pairMetrics ? Math.max(1, width - 2 - metricWidth) : metricWidth;
-  const referenceHeight = optionQuoteContextHeight(draft.marketReference, width - 2, Math.max(1, height - rows - 5));
+  const referenceHeight = optionQuoteContextHeight(draft.marketReference, width - 2, Math.max(1, height - rows - 5), true);
   const showGreeks = height >= 1 + rows + 1 + (pairMetrics ? 1 : 2) + (pairMetrics ? 3 : 5) + 1 + referenceHeight;
 
   return (

--- a/src/plugins/builtin/options/calc-seed.test.ts
+++ b/src/plugins/builtin/options/calc-seed.test.ts
@@ -87,6 +87,10 @@ describe("buildChainCalcParams", () => {
     });
 
     expect(draftFromParams(params!)).toMatchObject({marketPrice: 7.5, marketPriceSource: "mid"});
+    expect(draftFromParams(params!).marketReference).toMatchObject({
+      contractSymbol: "AAPL260919C00230000", expiration: EXPIRATION, bid: 7, ask: 8,
+      lastPrice: 12, lastTradeDate: 0,
+    });
   });
 
   test("returns nothing without a contract or a trustworthy underlying spot", () => {

--- a/src/plugins/builtin/options/calc-seed.ts
+++ b/src/plugins/builtin/options/calc-seed.ts
@@ -1,6 +1,7 @@
 import type { OptionContract } from "../../../types/financials";
 import { buildOptionCalcParams, type OptionSide } from "../options-calculator/model";
 import type { OptionTableRow } from "./types";
+import { optionMarketReference } from "./market-reference";
 
 /**
  * Which contract the calculator should open on. An explicit pick (clicking a
@@ -57,5 +58,7 @@ export function buildChainCalcParams(options: {
     dividendYield: options.dividendYield,
   }, options.now);
   if (market.source) params.marketPriceSource = market.source;
+  const reference = optionMarketReference(contract);
+  if (reference) params.marketReference = JSON.stringify(reference);
   return params;
 }

--- a/src/plugins/builtin/options/market-reference.test.ts
+++ b/src/plugins/builtin/options/market-reference.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { optionMarketReference, optionMarketReferenceLines, parseOptionMarketReference } from "./market-reference";
+
+const recorded = {
+  contractSymbol: "COST260925P01020000", expiration: 1790294400, currency: "USD",
+  bid: 114.8, ask: 120.55, lastPrice: 72.55, lastTradeDate: 1786630795,
+};
+
+test("keeps historical trades distinct and never substitutes retrieval time for a quote clock", () => {
+  const reference = optionMarketReference({ ...recorded, asOf: "2026-09-11T14:51:16Z" })!;
+  const lines = optionMarketReferenceLines(reference).join("\n");
+  expect(lines).toContain("spread 5.75 (4.89% of mid)");
+  expect(lines).toContain("Quote time unavailable");
+  expect(lines).toContain("Last 72.55 · trade 2026-08-13 14:19:55 UTC");
+  expect(lines).not.toContain("14:51:16");
+  const updated = optionMarketReferenceLines({ ...reference, lastUpdated: 1789140000123 }).join("\n");
+  expect(updated).toContain("Quote 2026-09-11 15:20:00 UTC");
+  expect(updated).toContain("trade 2026-08-13 14:19:55 UTC");
+});
+
+test("does not fabricate a midpoint for one-sided, crossed, missing or malformed quotes", () => {
+  for (const [bid, ask, result] of [[0, 0.19, "one-sided"], [2, 1, "crossed"], [NaN, Infinity, "bid/ask unavailable"]] as const) {
+    const lines = optionMarketReferenceLines(optionMarketReference({ ...recorded, bid, ask, lastPrice: 0, lastTradeDate: 0 })!).join("\n");
+    expect(lines).toContain(result);
+    expect(lines).not.toContain("% of mid");
+    expect(lines).toContain("Last — · trade time unavailable");
+  }
+  expect(optionMarketReferenceLines({ ...recorded, bid: 1, ask: 1 }).join("\n")).toContain("spread 0 (0.00% of mid)");
+});
+
+test("round-trips only valid optional reference metadata across saved pane params", () => {
+  expect(parseOptionMarketReference(JSON.stringify(recorded))).toEqual(recorded);
+  for (const malformed of ["not JSON", "null", "42", "[]", JSON.stringify({ ...recorded, expiration: 1e100 })]) {
+    expect(parseOptionMarketReference(malformed)).toBeUndefined();
+  }
+});

--- a/src/plugins/builtin/options/market-reference.ts
+++ b/src/plugins/builtin/options/market-reference.ts
@@ -1,0 +1,53 @@
+import type { OptionContract } from "../../../types/financials";
+import { formatExpDate } from "../../../utils/options";
+
+/** A saved contract observation, never a claim that its prices are executable. */
+export type OptionMarketReference = Pick<OptionContract,
+  "contractSymbol" | "expiration" | "currency" | "bid" | "ask" | "lastPrice" | "lastTradeDate" | "lastUpdated">;
+
+export function optionMarketReference(value: unknown): OptionMarketReference | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.contractSymbol !== "string" || !raw.contractSymbol.trim()
+    || typeof raw.expiration !== "number" || !Number.isFinite(raw.expiration)
+    || raw.expiration <= 0 || !Number.isFinite(new Date(raw.expiration * 1000).getTime())) return undefined;
+  const number = (key: string): number => typeof raw[key] === "number" && Number.isFinite(raw[key]) && raw[key] >= 0
+    ? raw[key] : 0;
+  return {
+    contractSymbol: raw.contractSymbol,
+    expiration: raw.expiration,
+    currency: typeof raw.currency === "string" ? raw.currency : "",
+    bid: number("bid"), ask: number("ask"), lastPrice: number("lastPrice"), lastTradeDate: number("lastTradeDate"),
+    ...(number("lastUpdated") > 0 ? { lastUpdated: number("lastUpdated") } : {}),
+  };
+}
+
+export function parseOptionMarketReference(value: string | undefined): OptionMarketReference | undefined {
+  if (!value) return undefined;
+  try { return optionMarketReference(JSON.parse(value)); } catch { return undefined; }
+}
+
+function timestamp(milliseconds: number | undefined): string | null {
+  if (!milliseconds || !Number.isFinite(milliseconds)) return null;
+  const date = new Date(milliseconds);
+  return Number.isFinite(date.getTime()) ? date.toISOString().replace("T", " ").replace(/\.\d{3}Z$/, " UTC") : null;
+}
+
+const price = (value: number) => Number.isFinite(value) && value > 0 ? String(Number(value.toPrecision(12))) : "—";
+
+export function optionMarketReferenceLines(reference: OptionMarketReference): string[] {
+  const { bid, ask } = reference;
+  const twoSided = bid > 0 && ask >= bid;
+  const spread = twoSided ? ask - bid : null;
+  const market = twoSided
+    ? `spread ${Number(spread!.toPrecision(12))} (${(spread! / ((bid + ask) / 2) * 100).toFixed(2)}% of mid)`
+    : bid > ask && ask > 0 ? "crossed quote; no midpoint"
+      : bid > 0 || ask > 0 ? "one-sided quote; no midpoint" : "bid/ask unavailable";
+  const quoteTime = timestamp(reference.lastUpdated);
+  const tradeTime = timestamp(reference.lastTradeDate * 1000);
+  return [
+    `${reference.contractSymbol} · ${reference.currency || "currency unknown"} · expires ${formatExpDate(reference.expiration)}`,
+    `Bid ${price(bid)} · Ask ${price(ask)} · ${market}`,
+    `Quote ${quoteTime ?? "time unavailable"} · Last ${price(reference.lastPrice)} · trade ${tradeTime ?? "time unavailable"}`,
+  ];
+}

--- a/src/plugins/builtin/options/quote-context.tsx
+++ b/src/plugins/builtin/options/quote-context.tsx
@@ -4,9 +4,9 @@ import { colors } from "../../../theme/colors";
 import { wrapTextLines } from "../../../utils/text-wrap";
 import { optionMarketReferenceLines, type OptionMarketReference } from "./market-reference";
 
-export function optionQuoteContextHeight(reference: OptionMarketReference | undefined, width: number, maximum: number): number {
+export function optionQuoteContextHeight(reference: OptionMarketReference | undefined, width: number, maximum: number, snapshot = false): number {
   return reference ? Math.min(Math.max(1, maximum), optionMarketReferenceLines(reference)
-    .reduce((height, line) => height + wrapTextLines(line, Math.max(8, width)).length, 0)) : 0;
+    .reduce((height, line, index) => height + wrapTextLines(snapshot && index === 0 ? `Snapshot: ${line}` : line, Math.max(8, width)).length, 0)) : 0;
 }
 
 /** Shared source context for the selected chain contract and its calculator snapshot. */

--- a/src/plugins/builtin/options/quote-context.tsx
+++ b/src/plugins/builtin/options/quote-context.tsx
@@ -1,0 +1,26 @@
+import { Prose } from "../../../components";
+import { Box, ScrollBox } from "../../../ui";
+import { colors } from "../../../theme/colors";
+import { wrapTextLines } from "../../../utils/text-wrap";
+import { optionMarketReferenceLines, type OptionMarketReference } from "./market-reference";
+
+export function optionQuoteContextHeight(reference: OptionMarketReference | undefined, width: number, maximum: number): number {
+  return reference ? Math.min(Math.max(1, maximum), optionMarketReferenceLines(reference)
+    .reduce((height, line) => height + wrapTextLines(line, Math.max(8, width)).length, 0)) : 0;
+}
+
+/** Shared source context for the selected chain contract and its calculator snapshot. */
+export function OptionQuoteContext({ reference, width, height, snapshot = false }: {
+  reference: OptionMarketReference;
+  width: number;
+  height: number;
+  snapshot?: boolean;
+}) {
+  return <ScrollBox key={JSON.stringify(reference)} height={height} flexShrink={0} scrollY focusable={false}>
+    <Box flexDirection="column">
+      {optionMarketReferenceLines(reference).map((line, index) => (
+        <Prose key={index} text={snapshot && index === 0 ? `Snapshot: ${line}` : line} width={Math.max(8, width)} color={colors.textDim} />
+      ))}
+    </Box>
+  </ScrollBox>;
+}

--- a/src/plugins/builtin/options/view.test.tsx
+++ b/src/plugins/builtin/options/view.test.tsx
@@ -77,11 +77,13 @@ function OptionsHarness({
   ticker,
   quotePrice,
   width = 122,
+  height = 14,
   onCapture = () => { },
 }: {
   ticker: TickerRecord;
   quotePrice?: number;
   width?: number;
+  height?: number;
   onCapture?: (capturing: boolean) => void;
 }) {
   const config = createTestPaneConfig("/tmp/gloomberb-options-test", {
@@ -99,7 +101,7 @@ function OptionsHarness({
 
   return (
     <TestPaneProvider state={state} paneId={TEST_PANE_ID} pluginId="ticker-research" runtime={createTestPluginRuntime()}>
-      <OptionsView width={width} height={14} focused onCapture={onCapture} />
+      <OptionsView width={width} height={height} focused onCapture={onCapture} />
     </TestPaneProvider>
   );
 }
@@ -107,7 +109,7 @@ function OptionsHarness({
 function RealtimeOptionsHarness({ ticker }: { ticker: TickerRecord }) {
   const [quotePrice, setQuotePrice] = useState(120.2);
   setOptionsQuotePrice = setQuotePrice;
-  return <OptionsHarness ticker={ticker} quotePrice={quotePrice} />;
+  return <OptionsHarness ticker={ticker} quotePrice={quotePrice} height={20} />;
 }
 
 async function renderSettled() {
@@ -227,7 +229,7 @@ test("streams live quotes without resetting manual scroll", async () => {
       <RealtimeOptionsHarness ticker={makeTicker("AAPL")} />,
       {
         width: 124,
-        height: 16,
+        height: 22,
       },
     );
   });

--- a/src/plugins/builtin/options/view.test.tsx
+++ b/src/plugins/builtin/options/view.test.tsx
@@ -186,7 +186,7 @@ test("defaults the table around the nearest strike to the current quote", async 
 test("keeps table geometry steady while a cold expiry has no contract context", async () => {
   const firstExpiry = 1_782_345_600;
   const nextExpiry = firstExpiry + 7 * 86400;
-  const initial = makeChain([100, 101], 101, [firstExpiry, nextExpiry]);
+  const initial = makeChain(Array.from({ length: 100 }, (_, index) => 50 + index), 120, [firstExpiry, nextExpiry]);
   let finishNext!: (chain: OptionsChain) => void;
   const next = new Promise<OptionsChain>((resolve) => { finishNext = resolve; });
   const provider = createTestDataProvider({
@@ -194,7 +194,7 @@ test("keeps table geometry steady while a cold expiry has no contract context", 
   });
   setSharedMarketDataCoordinator(new MarketDataCoordinator(provider));
   await act(async () => {
-    testSetup = await testRender(<OptionsHarness ticker={makeTicker("AAPL")} quotePrice={101} />, { width: 124, height: 16 });
+    testSetup = await testRender(<OptionsHarness ticker={makeTicker("AAPL")} quotePrice={120} />, { width: 124, height: 16 });
   });
   await renderSettled();
   const tableHeight = () => (testSetup!.renderer.root.findDescendantById("options-table-body-scroll") as ScrollBoxRenderable).height;
@@ -212,7 +212,8 @@ test("keeps table geometry steady while a cold expiry has no contract context", 
   }); });
   await renderSettled();
   expect(tableHeight()).toBe(before);
-  expect(testSetup!.captureCharFrame()).toContain("AAPL260626C00101000");
+  expect(testSetup!.captureCharFrame()).toContain("AAPL260626C00120000");
+  expect((testSetup!.renderer.root.findDescendantById("options-table-body-scroll") as ScrollBoxRenderable).scrollTop).toBeGreaterThan(0);
 });
 
 test("shows volatility statistics and mirrored default Greeks", async () => {

--- a/src/plugins/builtin/options/view.test.tsx
+++ b/src/plugins/builtin/options/view.test.tsx
@@ -183,6 +183,38 @@ test("defaults the table around the nearest strike to the current quote", async 
   expect(frame).not.toContain(" 50 ");
 });
 
+test("keeps table geometry steady while a cold expiry has no contract context", async () => {
+  const firstExpiry = 1_782_345_600;
+  const nextExpiry = firstExpiry + 7 * 86400;
+  const initial = makeChain([100, 101], 101, [firstExpiry, nextExpiry]);
+  let finishNext!: (chain: OptionsChain) => void;
+  const next = new Promise<OptionsChain>((resolve) => { finishNext = resolve; });
+  const provider = createTestDataProvider({
+    getOptionsChain: async (_symbol, _exchange, expiration) => expiration === nextExpiry ? next : initial,
+  });
+  setSharedMarketDataCoordinator(new MarketDataCoordinator(provider));
+  await act(async () => {
+    testSetup = await testRender(<OptionsHarness ticker={makeTicker("AAPL")} quotePrice={101} />, { width: 124, height: 16 });
+  });
+  await renderSettled();
+  const tableHeight = () => (testSetup!.renderer.root.findDescendantById("options-table-body-scroll") as ScrollBoxRenderable).height;
+  const before = tableHeight();
+  await act(async () => { testSetup!.mockInput.pressEnter(); });
+  await renderSettled();
+  await act(async () => { testSetup!.mockInput.pressKey("l"); });
+  await renderSettled();
+  expect(testSetup!.captureCharFrame()).toContain("Loading strikes");
+  expect(testSetup!.captureCharFrame()).not.toContain("AAPL260619C");
+  expect(tableHeight()).toBe(before);
+  await act(async () => { finishNext({ ...initial,
+    calls: initial.calls.map((c) => ({ ...c, expiration: nextExpiry, contractSymbol: c.contractSymbol.replace("260619", "260626") })),
+    puts: initial.puts.map((c) => ({ ...c, expiration: nextExpiry, contractSymbol: c.contractSymbol.replace("260619", "260626") })),
+  }); });
+  await renderSettled();
+  expect(tableHeight()).toBe(before);
+  expect(testSetup!.captureCharFrame()).toContain("AAPL260626C00101000");
+});
+
 test("shows volatility statistics and mirrored default Greeks", async () => {
   const provider = createTestDataProvider({
     getOptionsChain: async () => makeChain([100, 101], 101),

--- a/src/plugins/builtin/options/view.tsx
+++ b/src/plugins/builtin/options/view.tsx
@@ -106,6 +106,7 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
   const [interactive, setInteractive] = useState(false);
   const userSelectedStrikeRef = useRef(false);
   const initializedExpiryTargetRef = useRef<string | null>(null);
+  const quoteContextRowsRef = useRef(3);
   const onCaptureRef = useRef(onCapture);
   const target = resolveOptionsTarget(ticker);
   const isOpt = target?.isOptionTicker ?? false;
@@ -474,7 +475,12 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     : 0;
   const expirationTabsWidth = Math.max(width - 9 - (loading ? 2 : 0), 8);
   const summaryRowCount = height >= 10 ? 2 : height >= 7 ? 1 : 0;
-  const quoteContextHeight = optionQuoteContextHeight(selectedReference, width - 2, Math.max(1, Math.floor(height / 3)));
+  // Keep the table's geometry stable through an empty cold-expiry response.
+  // Growing it during loading can turn a clamped scroll into apparent user navigation.
+  const maxContextHeight = Math.max(1, Math.floor(height / 3));
+  quoteContextRowsRef.current = Math.max(quoteContextRowsRef.current,
+    optionQuoteContextHeight(selectedReference, width - 2, maxContextHeight));
+  const quoteContextHeight = Math.min(maxContextHeight, quoteContextRowsRef.current);
   const tableHeight = Math.max(1, height - 1 - summaryRowCount - (isOpt && parsed ? 1 : 0) - quoteContextHeight);
   // The strip scrolls; without a marker a clipped last date reads as the last expiry.
   const expirationStripOverflows = chain.expirationDates
@@ -515,7 +521,9 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
         </Box>
       )}
 
-      {selectedReference && <OptionQuoteContext reference={selectedReference} width={width - 2} height={quoteContextHeight} />}
+      <Box height={quoteContextHeight} flexShrink={0}>
+        {selectedReference && <OptionQuoteContext reference={selectedReference} width={width - 2} height={quoteContextHeight} />}
+      </Box>
 
       <DataTableView<OptionTableRow, OptionColumn>
         focused={focused}

--- a/src/plugins/builtin/options/view.tsx
+++ b/src/plugins/builtin/options/view.tsx
@@ -45,6 +45,8 @@ import {
 import { useOptionsAccessFooter } from "./footer";
 import { useLiveStreamingSetting } from "../shared/live-streaming";
 import { signedPositionDirection } from "../portfolio-list/position-metrics";
+import { optionMarketReference } from "./market-reference";
+import { OptionQuoteContext, optionQuoteContextHeight } from "./quote-context";
 
 type SummaryMetric = { label: string; value: string };
 
@@ -306,15 +308,17 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
   })), [optionFieldIds]);
 
   const selectedRow = rows[strikeIdx] ?? null;
+  const selectedSide = resolveCalcSide(calcSide, parsed?.side, selectedRow);
+  const selectedReference = optionMarketReference(selectedSide === "put" ? selectedRow?.put : selectedRow?.call);
   const calcParams = useMemo(() => buildChainCalcParams({
     symbol: effectiveTicker,
     row: selectedRow,
-    side: resolveCalcSide(calcSide, parsed?.side, selectedRow),
+    side: selectedSide,
     // On an option ticker the pane quote is the contract's own price, so load
     // the underlying snapshot rather than silently using the option mark as spot.
     spot,
     dividendYield,
-  }), [calcSide, dividendYield, effectiveTicker, parsed?.side, selectedRow, spot]);
+  }), [dividendYield, effectiveTicker, selectedSide, selectedRow, spot]);
 
   const openCalculator = useCallback(() => {
     if (!calcParams) return;
@@ -470,7 +474,8 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
     : 0;
   const expirationTabsWidth = Math.max(width - 9 - (loading ? 2 : 0), 8);
   const summaryRowCount = height >= 10 ? 2 : height >= 7 ? 1 : 0;
-  const tableHeight = Math.max(1, height - 1 - summaryRowCount - (isOpt && parsed ? 1 : 0));
+  const quoteContextHeight = optionQuoteContextHeight(selectedReference, width - 2, Math.max(1, Math.floor(height / 3)));
+  const tableHeight = Math.max(1, height - 1 - summaryRowCount - (isOpt && parsed ? 1 : 0) - quoteContextHeight);
   // The strip scrolls; without a marker a clipped last date reads as the last expiry.
   const expirationStripOverflows = chain.expirationDates
     .reduce((total, ts) => total + formatExpDate(ts).length + 2, 0) > expirationTabsWidth;
@@ -509,6 +514,8 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
           </Text>
         </Box>
       )}
+
+      {selectedReference && <OptionQuoteContext reference={selectedReference} width={width - 2} height={quoteContextHeight} />}
 
       <DataTableView<OptionTableRow, OptionColumn>
         focused={focused}


### PR DESCRIPTION
Changing a chain-seeded call to a put kept the call midpoint labelled as market data and solved a misleading "from market" IV. The chain and calculator now show the exact contract, bid/ask spread, quote clock availability, and last trade clock separately. Contract or input-price edits retain the numeric what-if input while removing the old contract's quote attribution, including recovery of already-saved edited drafts.

Native cold-expiry loading also now treats the emptied table's scroll reset as programmatic, allowing the new chain to center near the underlying price while preserving subsequent manual scrolling. Quote context stays readable and scrollable in narrow panes.

Validation: 63 focused tests / 285 assertions, all six TypeScript targets, web build, actual anonymous production option chains through a local preview, and isolated native research layout at 80/60/48 columns. The live before case used COST September 25 900C changed to 900P; old last trades and one-sided books were also exercised. No orders, holdings changes, release, or version bump. PR and main CI passed. Deployed production restored-draft recovery, fresh contract selection, side-change attribution, and ordinary reloads passed with zero page errors.
