### PR TITLE
Preserve dated capitalization in relative valuation

### DIFF
--- a/src/plugins/builtin/research/relative-valuation-headless.test.ts
+++ b/src/plugins/builtin/research/relative-valuation-headless.test.ts
@@ -85,3 +85,34 @@ test("loss-making peers retain reported multiples without ranking them as cheap 
   }
   expect(financials.fundamentals).toMatchObject({ trailingPE: -5.2, forwardPE: -9, freeCashFlow: -20 });
 });
+
+test("qualified peers retain dated fundamental caps after stale quote removal and preserve cash-flow currency boundaries", async () => {
+  const base = { annualStatements: [], quarterlyStatements: [], priceHistory: [],
+    fundamentals: { marketCap: 55_866_216_448, marketCapCurrency: "USD", financialCurrency: "USD",
+      freeCashFlow: -7_940_250_112, source: "yahoo" as const, fetchedAt: "2026-09-11T15:23:57.311Z", stale: false } };
+  const values = relativeValuationValues(base);
+  expect(values).toMatchObject({ price: null, currency: null, marketCap: base.fundamentals.marketCap, marketCapCurrency: "USD",
+    marketCapProvenance: { kind: "fundamentals", source: "yahoo", retrievedAt: base.fundamentals.fetchedAt, stale: false } });
+  expect(values.fcfYield).toBeCloseTo(-7_940_250_112 / 55_866_216_448, 12);
+  expect(relativeValuationValues({ ...base, fundamentals: { ...base.fundamentals, financialCurrency: undefined } }).fcfYield).toBeNull();
+  expect(relativeValuationValues({ ...base, fundamentals: { ...base.fundamentals, financialCurrency: "EUR" } }).fcfYield).toBeNull();
+
+  const requested: Array<[string, string | undefined]> = [];
+  const ctx = { signal: new AbortController().signal,
+    marketData: createTestDataProvider({ async getTickerFinancials(symbol, exchange) { requested.push([symbol, exchange]); return base; } }) } as HeadlessPaneContext;
+  const result = await relativeValuationHeadless.load({ symbols: ["F:XNYS"], argument: ["F:XNYS"], rawArgument: "F:XNYS", options: {} }, ctx);
+  expect(result.rows[0]).toMatchObject({ symbol: "F:XNYS", marketCapCurrency: "USD", marketCapProvenance: values.marketCapProvenance });
+  expect(result.unavailableSymbols).toEqual([]);
+  expect(requested).toEqual([["F", "NYSE"]]);
+  expect(result.metadata?.marketCapBasis).toContain("retrieval time is not a valuation date");
+});
+
+test("a foreign fundamental capitalization converts in its own currency, independently of the quote", () => {
+  const financials = { annualStatements: [], quarterlyStatements: [], priceHistory: [],
+    quote: { symbol: "TSM", price: 200, currency: "USD", change: 0, changePercent: 0, lastUpdated: 1 },
+    fundamentals: { marketCap: 1000, marketCapCurrency: "TWD", financialCurrency: "TWD", freeCashFlow: 100 } };
+  const row = relativeValuationValues(financials);
+  expect(row).toMatchObject({ price: 200, currency: "USD", marketCap: 1000, marketCapCurrency: "TWD", fcfYield: 0.1 });
+  expect(comparableMarketCap(row.marketCap, row.marketCapCurrency, "USD", new Map([["TWD", 0.03]]))).toBe(30);
+  expect(comparableMarketCap(row.marketCap, row.marketCapCurrency, "USD", new Map())).toBeNull();
+});

--- a/src/plugins/builtin/research/relative-valuation-headless.ts
+++ b/src/plugins/builtin/research/relative-valuation-headless.ts
@@ -34,6 +34,7 @@ export const relativeValuationHeadless: HeadlessPaneDefinition<"rows"> = {
     return { rows, unavailableSymbols, errors: loaded.errors, metadata: {
       notices: rows.some((row) => Object.values(row.reportedMultiples).some((value) => value != null && value <= 0)) ? [PRICE_EARNINGS_NOTICE] : [],
       multipleBasis: "Comparable P/E fields require a positive finite multiple; reportedMultiples preserves the finite provider values.",
+      marketCapBasis: "Market caps retain their own currency and source. Fundamentals retrieval time is not a valuation date; quote timestamps do not date fallback caps.",
     } };
 
   },

--- a/src/plugins/builtin/research/relative-valuation-model.ts
+++ b/src/plugins/builtin/research/relative-valuation-model.ts
@@ -1,9 +1,11 @@
 import { comparablePriceEarnings } from "../../../utils/price-earnings";
+import { selectMarketCapitalization } from "../../../utils/market-capitalization";
 import type { TickerFinancials } from "../../../types/financials";
 
 export function relativeValuationValues(financials: TickerFinancials | null) {
   const quote = financials?.quote;
   const fundamentals = financials?.fundamentals;
+  const capitalization = selectMarketCapitalization(quote, fundamentals);
   const compatibleCurrency = !!fundamentals?.financialCurrency && !!quote?.currency
     && fundamentals.financialCurrency === quote.currency;
   const reportedMultiples = {
@@ -14,7 +16,9 @@ export function relativeValuationValues(financials: TickerFinancials | null) {
     price: quote?.price ?? null,
     currency: quote?.currency ?? null,
     changePercent: quote?.changePercent ?? null,
-    marketCap: quote?.marketCap ?? null,
+    marketCap: capitalization?.value ?? null,
+    marketCapCurrency: capitalization?.currency ?? null,
+    marketCapProvenance: capitalization?.provenance ?? null,
     trailingPE: comparablePriceEarnings(reportedMultiples.trailingPE),
     forwardPE: comparablePriceEarnings(reportedMultiples.forwardPE),
     reportedMultiples,
@@ -24,8 +28,9 @@ export function relativeValuationValues(financials: TickerFinancials | null) {
         ? fundamentals.enterpriseToRevenue
         : fundamentals?.enterpriseValue != null && fundamentals.revenue != null && fundamentals.revenue > 0
           ? fundamentals.enterpriseValue / fundamentals.revenue : null,
-    fcfYield: compatibleCurrency && fundamentals?.freeCashFlow != null && quote?.marketCap != null && quote.marketCap > 0
-      ? fundamentals.freeCashFlow / quote.marketCap : null,
+    fcfYield: capitalization && fundamentals?.financialCurrency === capitalization.currency
+      && fundamentals.freeCashFlow != null && Number.isFinite(fundamentals.freeCashFlow) && capitalization.value > 0
+      ? fundamentals.freeCashFlow / capitalization.value : null,
     revenueGrowth: fundamentals?.revenueGrowth ?? fundamentals?.lastQuarterGrowth ?? null,
     operatingMargin: fundamentals?.operatingMargin ?? null,
   };

--- a/src/plugins/builtin/research/relative-valuation-pane.tsx
+++ b/src/plugins/builtin/research/relative-valuation-pane.tsx
@@ -1,4 +1,5 @@
 import { formatPriceEarnings, PRICE_EARNINGS_NOTICE } from "../../../utils/price-earnings";
+import { describeFundamentalMarketCap } from "../../../utils/market-capitalization";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, TextAttributes } from "../../../ui";
 import {
@@ -21,7 +22,7 @@ import { useBoundTicker as useSymbolBinding } from "../shared/ticker-request";
 import { useFxRatesMap } from "../../../market-data/hooks";
 import { comparableMarketCap, relativeValuationValues } from "./relative-valuation-model";
 
-type RelativeColumnId = "symbol" | Exclude<keyof ReturnType<typeof relativeValuationValues>, "currency" | "reportedMultiples">;
+type RelativeColumnId = "symbol" | Exclude<keyof ReturnType<typeof relativeValuationValues>, "currency" | "reportedMultiples" | "marketCapCurrency" | "marketCapProvenance">;
 type RelativeColumn = DataTableColumn & { id: RelativeColumnId };
 type RelativeRow = ReturnType<typeof relativeValuationValues> & {
   symbol: string;
@@ -97,7 +98,7 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
   const [selectedIdx, setSelectedIdx] = useState(0);
   const [sortPreference, setSortPreference] = useState<RelativeSortPreference>(DEFAULT_RELATIVE_SORT);
   const baseCurrency = useAppSelector((state) => state.config.baseCurrency);
-  const fxRates = useFxRatesMap([baseCurrency, ...rows.map((row) => row.currency)]);
+  const fxRates = useFxRatesMap([baseCurrency, ...rows.map((row) => row.marketCapCurrency)]);
   const columns = useMemo(() => buildRelativeColumns(width, baseCurrency), [width, baseCurrency]);
   const fetchGenRef = useRef(0);
 
@@ -147,12 +148,16 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
   }, [reload]);
 
   const comparableRows = useMemo(() => rows.map((row) => ({
-    ...row, marketCap: comparableMarketCap(row.marketCap, row.currency, baseCurrency, fxRates),
+    ...row, marketCap: comparableMarketCap(row.marketCap, row.marketCapCurrency, baseCurrency, fxRates),
   })), [rows, baseCurrency, fxRates]);
   const missingFx = rows.some((row, index) => row.marketCap != null && comparableRows[index]?.marketCap == null);
   const sortedRows = useMemo(() => sortRelativeRows(comparableRows, sortPreference), [comparableRows, sortPreference]);
 
   const hasNonComparablePE = rows.some((row) => Object.values(row.reportedMultiples).some((value) => value != null && value <= 0));
+  const hasFundamentalCap = rows.some((row) => row.marketCapProvenance?.kind === "fundamentals");
+  const selectedRow = sortedRows[selectedIdx];
+  const selectedCapNotice = selectedRow?.marketCapProvenance?.kind === "fundamentals"
+    ? `${selectedRow.symbol} cap: ${describeFundamentalMarketCap(selectedRow.marketCapProvenance)}.` : undefined;
 
   useClampSelectedIndex(rows.length, selectedIdx, setSelectedIdx);
 
@@ -210,8 +215,10 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
       onRootKeyDown={handleKeyDown}
       rootWidth={width}
       rootHeight={height}
-      rootBefore={hasNonComparablePE ? <Box paddingX={1} flexShrink={0}>
-        <Prose text={PRICE_EARNINGS_NOTICE} width={Math.max(8, width - 2)} color={colors.textDim} />
+      rootBefore={hasNonComparablePE || hasFundamentalCap ? <Box paddingX={1} flexShrink={0} flexDirection="column">
+        {hasNonComparablePE ? <Prose text={PRICE_EARNINGS_NOTICE} width={Math.max(8, width - 2)} color={colors.textDim} /> : null}
+        {hasFundamentalCap ? <Prose text="Some market caps use financial snapshots; quote time does not date these values. Select a row for its source." width={Math.max(8, width - 2)} color={colors.textDim} /> : null}
+        {selectedCapNotice ? <Prose text={selectedCapNotice} width={Math.max(8, width - 2)} color={colors.textDim} /> : null}
       </Box> : undefined}
       columns={columns}
       items={sortedRows}

--- a/src/utils/market-capitalization.test.ts
+++ b/src/utils/market-capitalization.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import { selectMarketCapitalization, describeFundamentalMarketCap } from "./market-capitalization";
+import type { Quote } from "../types/financials";
+
+const quote: Quote = { symbol: "F:XNYS", price: 14.01, currency: "USD", change: 0, changePercent: 0,
+  lastUpdated: Date.parse("2026-09-11T15:30:00Z"), providerId: "yahoo" };
+const fundamentals = { marketCap: 55_866_216_448, marketCapCurrency: "USD", source: "yahoo" as const,
+  fetchedAt: "2026-09-11T15:23:57.311Z", financialCurrency: "USD", freeCashFlow: -7_940_250_112, stale: false };
+
+test("a lightweight quote preserves the separately sourced capitalization and retrieval time", () => {
+  const selected = selectMarketCapitalization(quote, fundamentals)!;
+  expect(selected).toEqual({ value: fundamentals.marketCap, currency: "USD",
+    provenance: { kind: "fundamentals", source: "yahoo", retrievedAt: fundamentals.fetchedAt, stale: false } });
+  expect(describeFundamentalMarketCap(selected.provenance)).toContain("retrieved 2026-09-11 15:23:57 UTC");
+  expect(describeFundamentalMarketCap(selected.provenance)).toContain("valuation date unavailable");
+  expect(selectMarketCapitalization(undefined, fundamentals)).toEqual(selected);
+  expect(quote.marketCap).toBeUndefined();
+});
+
+test("a valid quote capitalization wins without borrowing the fallback currency or retrieval time", () => {
+  expect(selectMarketCapitalization({ ...quote, marketCap: 60e9 }, { ...fundamentals, marketCapCurrency: "EUR" }))
+    .toEqual({ value: 60e9, currency: "USD", provenance: { kind: "quote", source: "yahoo" } });
+  expect(selectMarketCapitalization({ ...quote, marketCap: 0 }, fundamentals)?.value).toBe(0);
+});
+
+test.each([undefined, "", "GBp"])("unknown or unnormalized capitalization currency %s is not inferred from a USD quote", (marketCapCurrency) => {
+  expect(selectMarketCapitalization(quote, { ...fundamentals, marketCapCurrency })).toBeNull();
+});
+
+test.each([NaN, Infinity, -1])("unusable capitalization %s is not ranked", (marketCap) => {
+  expect(selectMarketCapitalization({ ...quote, marketCap }, { ...fundamentals, marketCap })).toBeNull();
+});
+
+test("stale and undated fundamental provenance remains explicit", () => {
+  const selected = selectMarketCapitalization(quote, { ...fundamentals, fetchedAt: undefined, stale: true })!;
+  expect(describeFundamentalMarketCap(selected.provenance)).toContain("retrieval time unavailable, stale");
+  expect(selected.provenance.retrievedAt).toBeUndefined();
+});

--- a/src/utils/market-capitalization.ts
+++ b/src/utils/market-capitalization.ts
@@ -1,0 +1,44 @@
+import type { Fundamentals, Quote } from "../types/financials";
+
+export interface MarketCapitalization {
+  value: number;
+  currency: string;
+  provenance: {
+    kind: "quote" | "fundamentals";
+    source?: string;
+    retrievedAt?: string;
+    stale?: boolean;
+  };
+}
+
+function usableValue(value: number | undefined): value is number {
+  return value != null && Number.isFinite(value) && value >= 0;
+}
+
+function explicitCurrency(currency: string | undefined): currency is string {
+  return currency != null && /^[A-Z]{3}$/.test(currency);
+}
+
+/** A lightweight quote can omit capitalization without invalidating the snapshot. */
+export function selectMarketCapitalization(
+  quote: Quote | undefined,
+  fundamentals: Fundamentals | undefined,
+): MarketCapitalization | null {
+  if (usableValue(quote?.marketCap) && explicitCurrency(quote?.currency)) {
+    return { value: quote.marketCap, currency: quote.currency,
+      provenance: { kind: "quote", source: quote.providerId } };
+  }
+  if (!usableValue(fundamentals?.marketCap) || !explicitCurrency(fundamentals?.marketCapCurrency)) return null;
+  return { value: fundamentals.marketCap, currency: fundamentals.marketCapCurrency,
+    provenance: { kind: "fundamentals", source: fundamentals.source,
+      retrievedAt: fundamentals.fetchedAt, stale: fundamentals.stale } };
+}
+
+export function describeFundamentalMarketCap(provenance: MarketCapitalization["provenance"]): string {
+  const source = provenance.source ?? "source unavailable";
+  const parsed = provenance.retrievedAt ? Date.parse(provenance.retrievedAt) : NaN;
+  const retrieval = Number.isFinite(parsed)
+    ? `retrieved ${new Date(parsed).toISOString().replace("T", " ").replace(/\.\d{3}Z$/, " UTC")}`
+    : "retrieval time unavailable";
+  return `${source} fundamentals, ${retrieval}${provenance.stale ? ", stale" : ""}; valuation date unavailable`;
+}


### PR DESCRIPTION
Relative valuation lost available market capitalization when an old aggregate quote was removed and replaced by a lightweight quote. In the recorded qualified Ford, GM and Rivian snapshots, capitalization remained in fundamentals but the table read only the quote field.

A shared selector now keeps valid quote capitalization first and otherwise uses a fundamental capitalization with its own explicit currency. Relative valuation converts that currency before sorting, preserves source/retrieval metadata in JSON, and shows the selected row’s fundamental provenance. Retrieval time is explicitly distinguished from the unavailable valuation date. FCF yield requires matching known cash-flow and capitalization currencies; Rivian’s unknown cash-flow currency remains unavailable.

Validation: 24 tests / 82 assertions, all six TypeScript projects and web build pass. Restoring the actual native research cache shows GM77.85B, Ford55.87B and Rivian23.24B without changing their quotes. Native140/80-column display, source selection and saved80-column restart passed. No release or version change.
