### PR TITLE
Preserve research values and years in chart labels

### DIFF
--- a/src/components/chart/composite/composite-chart.test.tsx
+++ b/src/components/chart/composite/composite-chart.test.tsx
@@ -435,6 +435,25 @@ describe("CompositeChart", () => {
     expect(accessoryStart - lastLegendEnd).toBeGreaterThan(1);
   });
 
+  test("shortens long comparison names before clipping yield precision or units at 80 columns", async () => {
+    testSetup = await testRender(
+      <CompositeChart width={78} height={12}
+        series={[
+          { ...series("ig", "main", "left", "%", [5.68]), label: "ICE BofA US Corporate Index Effective Yield" },
+          { ...series("hy", "main", "left", "%", [7.42]), label: "ICE BofA US High Yield Index Effective Yield" },
+        ]}
+        panels={[{ id: "main" }]}
+        legendAccessory={<Box width={14} height={1}><Text>+ add series</Text></Box>}
+        legendAccessoryWidth={14}
+      />, { width: 80, height: 14 },
+    );
+    await act(async () => { await testSetup!.renderOnce(); await testSetup!.renderOnce(); });
+    const legend = testSetup.captureCharFrame().split("\n").find((line) => line.includes("+ add series"))!;
+    expect(legend).toContain("5.68%");
+    expect(legend).toContain("7.42%");
+    expect(legend.indexOf("7.42%") + 5).toBeLessThan(legend.indexOf("+ add series"));
+  });
+
   test("leaving a historical chart restores its window's legend value instead of the navigation buffer", async () => {
     let setCursor: (date: Date | null) => void = () => {};
     const margin: ResolvedSeries = {

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -1396,11 +1396,13 @@ function CompositeLegend({
       entry,
       text,
       width: textWidth + 2,
+      labelWidth,
+      valueText,
       toggleable,
       tooltip,
     };
   });
-  const desiredSeriesWidth = entries.reduce(
+  let desiredSeriesWidth = entries.reduce(
     (total, entry, index) => total + entry.width + (index > 0 ? 1 : 0),
     0,
   );
@@ -1410,6 +1412,27 @@ function CompositeLegend({
   const reservedAccessoryGap = accessory && width > resolvedAccessoryWidth ? 1 : 0;
   // The cursor date lives on the time axis, where the crosshair points at it.
   const widthBeforeAccessory = Math.max(0, width - resolvedAccessoryWidth - reservedAccessoryGap);
+  // A slightly overflowing row should shorten names before hiding a value's
+  // final digits/unit under the accessory. Keep a readable name fragment; if
+  // the full row cannot fit even then, retain its existing scrollable layout.
+  const minimumSeriesWidth = entries.reduce((total, entry, index) => {
+    const text = [truncateToDisplayWidth(entry.entry.label, Math.min(8, entry.labelWidth)), entry.valueText]
+      .filter(Boolean).join(" ");
+    return total + Math.max(1, displayWidth(text)) + 2 + (index > 0 ? 1 : 0);
+  }, 0);
+  if (minimumSeriesWidth <= widthBeforeAccessory) {
+    while (desiredSeriesWidth > widthBeforeAccessory) {
+      const shrinkable = entries.filter((entry) => entry.labelWidth > 8)
+        .sort((left, right) => right.labelWidth - left.labelWidth)[0];
+      if (!shrinkable) break;
+      const previousWidth = shrinkable.width;
+      shrinkable.labelWidth -= 1;
+      shrinkable.text = [truncateToDisplayWidth(shrinkable.entry.label, shrinkable.labelWidth), shrinkable.valueText]
+        .filter(Boolean).join(" ");
+      shrinkable.width = Math.max(1, displayWidth(shrinkable.text)) + 2;
+      desiredSeriesWidth -= previousWidth - shrinkable.width;
+    }
+  }
   const seriesWidth = Math.min(desiredSeriesWidth, widthBeforeAccessory);
   const accessorySpacerWidth = accessory
     ? Math.max(reservedAccessoryGap, width - seriesWidth - resolvedAccessoryWidth)

--- a/src/components/chart/composite/time-axis.test.ts
+++ b/src/components/chart/composite/time-axis.test.ts
@@ -61,6 +61,15 @@ function marketScene(
 }
 
 describe("adaptive composite time axis", () => {
+  test("retains the research year on a same-year stress window even in a narrow export", () => {
+    for (const width of [18, 40, 80]) {
+      const layout = viewport("2025-03-01T00:00:00Z", "2025-05-31T23:59:59Z", width);
+      expect(layout.text).toContain("2025");
+      expect(layout.ticks[0]?.timestamp).toBe(Date.parse("2025-03-01T00:00:00Z"));
+      expect(layout.ticks.at(-1)?.timestamp).toBe(Date.parse("2025-05-31T23:59:59Z"));
+      expectValidLayout(layout, width);
+    }
+  });
   test("increases intraday density with width while keeping concise UTC clock labels", () => {
     const narrow = viewport(
       "2026-07-29T09:30:00.000Z",
@@ -169,8 +178,8 @@ describe("adaptive composite time axis", () => {
 
     expect(monday?.ratio).toBe(0.25);
     expect(monday?.start).toBeLessThan(30);
-    expect(layout.ticks.some((tick) => tick.label.includes("4"))).toBe(false);
-    expect(layout.ticks.some((tick) => tick.label.includes("5"))).toBe(false);
+    expect(layout.ticks.some((tick) => tick.timestamp === Date.parse("2025-01-04"))).toBe(false);
+    expect(layout.ticks.some((tick) => tick.timestamp === Date.parse("2025-01-05"))).toBe(false);
     expectValidLayout(layout, 80);
   });
 

--- a/src/components/chart/composite/time-axis.ts
+++ b/src/components/chart/composite/time-axis.ts
@@ -361,11 +361,7 @@ function formatBoundaryLabel(
     }
     case "day":
     case "week":
-      return calendarLabel(
-        timestamp,
-        includeBoundaryYear
-          && date.getUTCFullYear() !== new Date(counterpart).getUTCFullYear(),
-      );
+      return calendarLabel(timestamp, includeBoundaryYear);
     case "month":
       return calendarLabel(timestamp, includeBoundaryYear);
     case "year":
@@ -513,6 +509,13 @@ function layoutTimeAxis({
   if (startLabel.length + endLabel.length + 1 > axisWidth) {
     startLabel = formatBoundaryLabel(firstTimestamp, lastTimestamp, interval, false);
     endLabel = formatBoundaryLabel(lastTimestamp, firstTimestamp, interval, false);
+  }
+  if (startLabel.length + endLabel.length + 1 > axisWidth) {
+    // A standalone same-year chart still needs its year. Shorten the right
+    // endpoint first instead of dropping that context from both boundaries.
+    if (new Date(firstTimestamp).getUTCFullYear() === new Date(lastTimestamp).getUTCFullYear()) {
+      endLabel = formatBoundaryLabel(lastTimestamp, firstTimestamp, interval, false, false);
+    }
   }
   if (startLabel.length + endLabel.length + 1 > axisWidth) {
     startLabel = formatBoundaryLabel(firstTimestamp, lastTimestamp, interval, false, false);


### PR DESCRIPTION
At 80 terminal columns, two long credit-series names push the last yield's precision and percent sign under the add-series control. Shorten names to fit the row when complete values and readable name fragments fit; preserve the existing horizontal scroll and keyboard behavior for larger rows.

A same-year daily/weekly stress-chart export also omits its year. Include it on boundary labels and retain one year while compacting a narrow same-year axis. Source data, viewport and timestamps are unchanged.

Validation: 58 composite/time-axis tests (715 assertions), all six TypeScript targets and web build. Actual native 80-column yield view now shows both 5.68% and 7.42%; native 40-column stress view retains 2025. Actual browser Copy Screenshot output was inspected at 800px: the 2025 window and both endpoint yields are complete, and plot pixels match the earlier export. Existing oversized/crowded legend scroll and keyboard tests pass. No release/version change.
