### PR TITLE
Open company details from floating research tables

### DIFF
--- a/src/app/pane-runtime/ticker-open-runtime.test.tsx
+++ b/src/app/pane-runtime/ticker-open-runtime.test.tsx
@@ -1,3 +1,4 @@
+import { getDockedPaneIds } from "../../plugins/pane-manager";
 import { expect, test } from "bun:test";
 import { act } from "react";
 import { testRender } from "../../renderers/opentui/test-utils";
@@ -105,6 +106,43 @@ test("ambiguous deep links open the listing picker without publishing an arbitra
     await act(async () => { await rendered.renderOnce(); await runtime.openPinnedTicker("GLD"); });
     expect(actions).toEqual([{ type: "SET_COMMAND_BAR", open: true, query: "GLD", launch: { kind: "ticker-search", query: "GLD" } }]);
     expect(notifications[0]).toContain("Multiple listings match GLD");
+  } finally {
+    await act(async () => { rendered.renderer.destroy(); });
+  }
+});
+
+test.each(["floating", "docked", "only-floating"])("ticker research opens visibly from a %s source", async (mode) => {
+  const source = createPaneInstance("relative-valuation", { instanceId: "relative-valuation:source", binding: { kind: "none" } });
+  const anchor = createPaneInstance("world-indices", { instanceId: "world-indices:anchor", binding: { kind: "none" } });
+  const config = createDefaultConfig(":memory:");
+  config.layout = { dockRoot: mode === "only-floating" ? null : { kind: "pane", instanceId: mode === "docked" ? source.instanceId : anchor.instanceId },
+    instances: mode === "only-floating" || mode === "docked" ? [source] : [source, anchor],
+    floating: mode === "docked" ? [] : [{ instanceId: source.instanceId, x: 2, y: 2, width: 80, height: 20, zIndex: 1 }], detached: [] };
+  const stateRef = { current: createInitialState(config) };
+  stateRef.current.focusedPaneId = source.instanceId;
+  const ticker: TickerRecord = { metadata: { ticker: "RIVN:XNAS", exchange: "NASDAQ", currency: "USD", name: "Rivian",
+    portfolios: [], watchlists: [], positions: [], custom: {}, tags: [] } };
+  let runtime!: ReturnType<typeof useAppTickerOpenRuntime>;
+  const activated: string[] = [];
+  function Harness() {
+    runtime = useAppTickerOpenRuntime({ stateRef, dataProvider: createTestDataProvider(), tickerRepository: {} as any, dispatch() {},
+      pluginRegistry: { panes: new Map([[TICKER_RESEARCH_PANE_ID, { id: TICKER_RESEARCH_PANE_ID }]]), events: { emit() {} },
+        getTermSizeFn: () => ({ width: 120, height: 40 }) } as any,
+      buildPaneInstance: (paneId, options) => createPaneInstance(paneId, { ...options, instanceId: "ticker-detail:opened" }),
+      persistLayout: (layout) => { stateRef.current.config.layout = layout; },
+      activatePane: (paneId) => { activated.push(paneId); }, focusVisiblePane() {},
+    });
+    return <text>Research</text>;
+  }
+  const rendered = await testRender(<Harness />, { width: 20, height: 2 });
+  try {
+    await act(async () => { await rendered.renderOnce(); runtime.placePinnedTickerTarget({ symbol: "RIVN:XNAS", ticker, created: false }, { floating: false }); });
+    const layout = stateRef.current.config.layout;
+    expect(getDockedPaneIds(layout)).toContain("ticker-detail:opened");
+    expect(layout.instances.find((pane) => pane.instanceId === "ticker-detail:opened")?.binding).toEqual({ kind: "fixed", symbol: "RIVN:XNAS" });
+    expect(activated).toEqual(["ticker-detail:opened"]);
+    if (mode !== "docked") expect(layout.floating.map((pane) => pane.instanceId)).toContain(source.instanceId);
+    else expect(getDockedPaneIds(layout)).toContain(source.instanceId);
   } finally {
     await act(async () => { rendered.renderer.destroy(); });
   }

--- a/src/app/pane-runtime/ticker-open-runtime.ts
+++ b/src/app/pane-runtime/ticker-open-runtime.ts
@@ -5,6 +5,7 @@ import {
   addPaneToLayout,
   getDockedPaneIds,
   isPaneInLayout,
+  isPaneDocked,
 } from "../../plugins/pane-manager";
 import type { PluginRegistry } from "../../plugins/registry";
 import { findFixedTickerPaneForSymbol } from "../../plugins/ticker-navigation";
@@ -145,7 +146,7 @@ export function useAppTickerOpenRuntime({
         currentLayout,
         instance,
         {
-          relativeTo: currentState.focusedPaneId && isPaneInLayout(currentLayout, currentState.focusedPaneId)
+          relativeTo: currentState.focusedPaneId && isPaneDocked(currentLayout, currentState.focusedPaneId)
             ? currentState.focusedPaneId
             : (getDockedPaneIds(currentLayout).at(-1) ?? instance.instanceId),
           position: "right",


### PR DESCRIPTION
Opening a company from a floating research table could silently leave the workspace unchanged: ticker navigation requested a docked detail pane relative to the focused floating pane, which is not a valid dock anchor.

Choose the focused pane only when it is docked, otherwise use the last docked pane or create the first docked pane in an entirely floating workspace. The source research table remains available.

Validation: regression reproduced before the fix; 13 focused tests / 56 assertions cover floating, docked and entirely floating layouts. All six type-check targets and web build pass. Independent review passed another 5 tests / 37 assertions. Actual browser and native journeys open visible company details from the floating peer table; saved browser details survive reload.

No release or version change.
