### PR TITLE
Keep calculator units and model assumptions readable in narrow panes

### DIFF
--- a/src/plugins/builtin/options-calculator/pane.test.tsx
+++ b/src/plugins/builtin/options-calculator/pane.test.tsx
@@ -2,7 +2,8 @@ import { afterEach, expect, test } from "bun:test";
 import { useReducer } from "react";
 import { act } from "react";
 import { useShortcut } from "../../../react/input";
-import { testRender } from "../../../renderers/opentui/test-utils";
+import { emitKeypress, testRender } from "../../../renderers/opentui/test-utils";
+import { PaneKeyboardScrollController } from "../../../state/pane-scroll-registry";
 import {
   AppContext,
   PaneInstanceProvider,
@@ -28,7 +29,7 @@ function GlobalTabHandler() {
   return null;
 }
 
-function Harness({ params }: { params?: Record<string, string> }) {
+function Harness({ params, width = 90, height = 18 }: { params?: Record<string, string>; width?: number; height?: number }) {
   const config = createDefaultConfig("/tmp/gloomberb-options-calculator-test");
   config.layout = {
     dockRoot: { kind: "pane", instanceId: TEST_PANE_ID },
@@ -51,13 +52,14 @@ function Harness({ params }: { params?: Record<string, string> }) {
     <AppContext value={{ state, dispatch }}>
       <GlobalTabHandler />
       <PaneInstanceProvider paneId={TEST_PANE_ID}>
+        <PaneKeyboardScrollController paneId={TEST_PANE_ID} focused />
         <PluginRenderProvider pluginId="ticker-research" runtime={createTestPluginRuntime()}>
           <OptionsCalculatorPane
             paneId={TEST_PANE_ID}
             paneType={OPTIONS_CALCULATOR_PANE_ID}
             focused
-            width={90}
-            height={18}
+            width={width}
+            height={height}
           />
         </PluginRenderProvider>
       </PaneInstanceProvider>
@@ -65,9 +67,9 @@ function Harness({ params }: { params?: Record<string, string> }) {
   );
 }
 
-async function render(params?: Record<string, string>) {
+async function render(params?: Record<string, string>, width = 90, height = 18) {
   await act(async () => {
-    testSetup = await testRender(<Harness params={params} />, { width: 90, height: 18 });
+    testSetup = await testRender(<Harness params={params} width={width} height={height} />, { width, height });
     await Promise.resolve();
     await testSetup.renderOnce();
   });
@@ -84,6 +86,32 @@ afterEach(async () => {
     await act(async () => { testSetup!.renderer.destroy(); });
     testSetup = undefined;
   }
+});
+
+test("narrow results keep assumptions visible while scrolling Greeks and editing fixed inputs", async () => {
+  await render({
+    symbol: "COST:XNAS", side: "call", spot: "902.63", strike: "905", days: "14.1784",
+    volatility: "0.269", rate: "0.04", marketPrice: "18.075", marketPriceSource: "mid",
+    marketReference: JSON.stringify({ contractSymbol: "COST260925C00905000", expiration: 1790294400,
+      currency: "USD", bid: 17.2, ask: 18.95, lastPrice: 18.67, lastTradeDate: 1789139450 }),
+  }, 48, 16);
+  expect(testSetup!.captureCharFrame()).toContain("COST260925C00905000");
+  expect(testSetup!.captureCharFrame()).toContain("discrete dividends.");
+  await emitKeypress(testSetup!, { name: "end", sequence: "\u001B[F" });
+  const bottom = testSetup!.captureCharFrame();
+  expect(bottom).toMatch(/Theta\s+-[\d.]+\s+per day/);
+  expect(bottom).toMatch(/Vega\s+[\d.]+\s+per vol pt/);
+  expect(bottom).toMatch(/Rho\s+[+\d.]+\s+per rate pt/);
+  expect(bottom).toContain("discrete dividends.");
+
+  // Inputs stay reachable while the researcher reads the bottom of the results.
+  await emitKeypress(testSetup!, { name: "tab", sequence: "\t" });
+  await act(async () => { await testSetup!.mockInput.typeText("910"); testSetup!.mockInput.pressEnter(); });
+  await act(async () => { await testSetup!.renderOnce(); });
+  expect(testSetup!.captureCharFrame()).toMatch(/Spot\s+910/);
+  await emitKeypress(testSetup!, { name: "escape", sequence: "\u001B" });
+  await emitKeypress(testSetup!, { name: "home", sequence: "\u001B[H" });
+  expect(testSetup!.captureCharFrame()).toContain("COST260925C00905000");
 });
 
 test("prices the seeded contract and solves its implied volatility", async () => {

--- a/src/plugins/builtin/options-calculator/pane.tsx
+++ b/src/plugins/builtin/options-calculator/pane.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useMemo, useState } from "react";
-import { KeyValueRow, SegmentedControl, usePaneFooter } from "../../../components";
+import { KeyValueRow, Prose, SegmentedControl, usePaneFooter } from "../../../components";
 import { useShortcut } from "../../../react/input";
 import { usePaneInstance, usePaneStateValue } from "../../../state/app/context";
 import { colors } from "../../../theme/colors";
 import type { PaneProps } from "../../../types/plugin";
-import { Box, Text, TextAttributes, useUiHost } from "../../../ui";
+import { Box, ScrollBox, Text, TextAttributes, useUiHost } from "../../../ui";
 import { formatNumber } from "../../../utils/format";
 import { isPlainKey } from "../../../utils/keyboard";
 import type { InlineField } from "../kelly-sizer/fields";
@@ -126,11 +126,13 @@ export function OptionsCalculatorPane({ focused, width, height }: PaneProps) {
   const columns = width >= 78 ? 3 : width >= 42 ? 2 : 1;
   const fieldWidth = Math.max(12, Math.min(26, Math.floor((width - 2) / columns)));
   const rows = Math.max(1, Math.ceil(fields.length / columns));
-  const pairMetrics = width >= 50;
-  const metricWidth = pairMetrics ? Math.floor((width - 2) / 2) : Math.max(1, width - 2);
-  const trailingMetricWidth = pairMetrics ? Math.max(1, width - 2 - metricWidth) : metricWidth;
-  const referenceHeight = optionQuoteContextHeight(draft.marketReference, width - 2, Math.max(1, height - rows - 5), true);
-  const showGreeks = height >= 1 + rows + 1 + (pairMetrics ? 1 : 2) + (pairMetrics ? 3 : 5) + 1 + referenceHeight;
+  // Each paired metric needs room for its label, value and complete unit.
+  const pairMetrics = width >= 82;
+  // Leave a column for the native scrollbar beside the result body's padding.
+  const resultWidth = Math.max(1, width - 3);
+  const metricWidth = pairMetrics ? Math.floor(resultWidth / 2) : resultWidth;
+  const trailingMetricWidth = pairMetrics ? Math.max(1, resultWidth - metricWidth) : metricWidth;
+  const referenceHeight = optionQuoteContextHeight(draft.marketReference, resultWidth, Number.POSITIVE_INFINITY, true);
 
   return (
     <Box flexDirection="column" width={width} height={height}>
@@ -174,29 +176,29 @@ export function OptionsCalculatorPane({ focused, width, height }: PaneProps) {
 
       <Box height={1} />
 
-      {draft.marketReference && <Box paddingX={1} height={referenceHeight} flexShrink={0}>
-        <OptionQuoteContext reference={draft.marketReference} width={width - 2} height={referenceHeight} snapshot />
-      </Box>}
+      <ScrollBox id="options-calculator-results" flexGrow={1} flexBasis={0} minHeight={0} scrollY focusable={false}>
+        {draft.marketReference && <Box paddingX={1} height={referenceHeight} flexShrink={0}>
+          <OptionQuoteContext reference={draft.marketReference} width={resultWidth} height={referenceHeight} snapshot scrollable={false} />
+        </Box>}
 
-      <Box flexDirection={pairMetrics ? "row" : "column"} paddingX={1}>
-        <KeyValueRow
-          label="Model"
-          value={formatNumber(valuation.price, 4)}
-          detail="per unit"
-          color={colors.textBright}
-          width={metricWidth}
-        />
-        <KeyValueRow
-          label="Implied IV"
-          value={implied.volatility != null ? `${formatNumber(implied.volatility * 100, 2)}%` : "—"}
-          detail={implied.volatility != null ? draft.marketPriceSource === "mid" ? "from mid"
-            : draft.marketPriceSource === "last" ? "from last" : "from input" : undefined}
-          color={implied.volatility != null ? colors.positive : colors.textDim}
-          width={trailingMetricWidth}
-        />
-      </Box>
+        <Box flexDirection={pairMetrics ? "row" : "column"} paddingX={1}>
+          <KeyValueRow
+            label="Model"
+            value={formatNumber(valuation.price, 4)}
+            detail="per unit"
+            color={colors.textBright}
+            width={metricWidth}
+          />
+          <KeyValueRow
+            label="Implied IV"
+            value={implied.volatility != null ? `${formatNumber(implied.volatility * 100, 2)}%` : "—"}
+            detail={implied.volatility != null ? draft.marketPriceSource === "mid" ? "from mid"
+              : draft.marketPriceSource === "last" ? "from last" : "from input" : undefined}
+            color={implied.volatility != null ? colors.positive : colors.textDim}
+            width={trailingMetricWidth}
+          />
+        </Box>
 
-      {showGreeks ? (
         <Box flexDirection="column" paddingX={1}>
           <Box flexDirection={pairMetrics ? "row" : "column"}>
             <KeyValueRow label="Delta" value={formatSigned(valuation.delta, 4)} width={metricWidth} />
@@ -208,17 +210,10 @@ export function OptionsCalculatorPane({ focused, width, height }: PaneProps) {
           </Box>
           <KeyValueRow label="Rho" value={formatSigned(valuation.rhoPerPoint, 4)} detail="per rate pt" width={metricWidth} />
         </Box>
-      ) : null}
+      </ScrollBox>
 
-      <Box flexGrow={1} />
-
-      <Box height={1} paddingX={1} overflow="hidden">
-        <Text fg={colors.textMuted}>
-          {truncateText(
-            "European exercise only: no early exercise or discrete dividends.",
-            Math.max(1, width - 2),
-          )}
-        </Text>
+      <Box paddingX={1} flexShrink={0}>
+        <Prose text="European exercise only: no early exercise or discrete dividends." width={Math.max(8, width - 2)} color={colors.textMuted} />
       </Box>
     </Box>
   );

--- a/src/plugins/builtin/options/quote-context.tsx
+++ b/src/plugins/builtin/options/quote-context.tsx
@@ -10,17 +10,20 @@ export function optionQuoteContextHeight(reference: OptionMarketReference | unde
 }
 
 /** Shared source context for the selected chain contract and its calculator snapshot. */
-export function OptionQuoteContext({ reference, width, height, snapshot = false }: {
+export function OptionQuoteContext({ reference, width, height, snapshot = false, scrollable = true }: {
   reference: OptionMarketReference;
   width: number;
   height: number;
   snapshot?: boolean;
+  /** A parent scrolling the full result body can own overflow instead. */
+  scrollable?: boolean;
 }) {
-  return <ScrollBox key={JSON.stringify(reference)} height={height} flexShrink={0} scrollY focusable={false}>
-    <Box flexDirection="column">
-      {optionMarketReferenceLines(reference).map((line, index) => (
-        <Prose key={index} text={snapshot && index === 0 ? `Snapshot: ${line}` : line} width={Math.max(8, width)} color={colors.textDim} />
-      ))}
-    </Box>
-  </ScrollBox>;
+  const content = <Box flexDirection="column">
+    {optionMarketReferenceLines(reference).map((line, index) => (
+      <Prose key={index} text={snapshot && index === 0 ? `Snapshot: ${line}` : line} width={Math.max(8, width)} color={colors.textDim} />
+    ))}
+  </Box>;
+  return scrollable
+    ? <ScrollBox key={JSON.stringify(reference)} height={height} flexShrink={0} scrollY focusable={false}>{content}</ScrollBox>
+    : content;
 }


### PR DESCRIPTION
Narrow options calculators clipped Greek units and the European-exercise assumptions, and short panes hid the final Greeks. Stack the result rows at narrow widths, keep all results in the shared scroll area, and wrap the full model assumptions below it. Inputs remain visible and editable while results scroll; the recorded contract context scrolls with the results.

Validation: 57 tests / 268 assertions, all six TypeScript targets, web build and PR CI passed. Actual native 48/60/80-column captures and browser 480×720 / 480×360 checks confirm the full assumptions and every Greek remain reachable, editing still works while scrolled, and ordinary reload retains the saved inputs. Rendered checks use an isolated recorded COST contract fixture; pricing calculations are unchanged.
