### PR TITLE
fix: retain sourced capitalization in overview and watchlists

### DIFF
--- a/src/plugins/builtin/portfolio-list/column-values.ts
+++ b/src/plugins/builtin/portfolio-list/column-values.ts
@@ -1,4 +1,5 @@
 import { comparablePriceEarnings, formatPriceEarnings } from "../../../utils/price-earnings";
+import { convertMarketCapitalization, selectMarketCapitalization } from "../../../utils/market-capitalization";
 import type { ColumnConfig } from "../../../types/config";
 import type { AnalystResearchData, CorporateActionsData, MarketState, TickerFinancials } from "../../../types/financials";
 import type { EarningsEvent } from "../../../types/data-provider";
@@ -284,9 +285,11 @@ export function getColumnValue(
       const position = ((activeQuote.price - quote.low52w) / range) * 100;
       return { text: formatPercentRaw(Math.max(0, Math.min(100, position))) };
     }
-    case "market_cap":
-      if (!quote?.marketCap) return { text: "—" };
-      return { text: formatCompact(toBaseQuote(quote.marketCap)) };
+    case "market_cap": {
+      const cap = selectMarketCapitalization(quote, fundamentals);
+      const value = cap ? convertMarketCapitalization(cap.value, cap.currency, ctx.baseCurrency, ctx.exchangeRates) : null;
+      return { text: value == null ? "—" : formatCompact(value) };
+    }
     case "pe":
       return { text: formatPriceEarnings(fundamentals?.trailingPE) };
     case "forward_pe":
@@ -493,8 +496,10 @@ export function getSortValue(
       const range = quote.high52w - quote.low52w;
       return range > 0 ? ((activeQuote.price - quote.low52w) / range) * 100 : null;
     }
-    case "market_cap":
-      return quote?.marketCap ? toBaseQuote(quote.marketCap) : null;
+    case "market_cap": {
+      const cap = selectMarketCapitalization(quote, fundamentals);
+      return cap ? convertMarketCapitalization(cap.value, cap.currency, ctx.baseCurrency, ctx.exchangeRates) : null;
+    }
     case "pe":
       return comparablePriceEarnings(fundamentals?.trailingPE);
     case "forward_pe":

--- a/src/plugins/builtin/portfolio-list/pane/data.ts
+++ b/src/plugins/builtin/portfolio-list/pane/data.ts
@@ -3,6 +3,7 @@ import { PRICE_SPARKLINE_COLUMN_ID } from "../../../../components/price-sparklin
 import type { AppConfig, ColumnConfig } from "../../../../types/config";
 import type { TickerFinancials } from "../../../../types/financials";
 import type { TickerRecord } from "../../../../types/ticker";
+import { selectMarketCapitalization } from "../../../../utils/market-capitalization";
 import type { CollectionSortPreference } from "../../../../state/app/context";
 import { isQuoteStaleForCurrentSession } from "../../../../market-data/quotes/freshness";
 import { resolveQuoteAgeTimestamp } from "../../../../market-data/quotes/time";
@@ -149,6 +150,8 @@ export function buildTrackedCurrencies(
     if (financials?.quote?.currency) {
       currencies.add(financials.quote.currency);
     }
+    const cap = selectMarketCapitalization(financials?.quote, financials?.fundamentals);
+    if (cap) currencies.add(cap.currency);
   }
 
   for (const balance of accountState?.visibleCashBalances ?? []) {

--- a/src/plugins/builtin/portfolio-list/pane/index.tsx
+++ b/src/plugins/builtin/portfolio-list/pane/index.tsx
@@ -1,7 +1,11 @@
 import { Box } from "../../../../ui";
+import { colors } from "../../../../theme/colors";
+import { describeFundamentalMarketCap, selectMarketCapitalization } from "../../../../utils/market-capitalization";
+import { wrapTextLines } from "../../../../utils/text-wrap";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Tabs,
+  Prose,
   usePaneFooter,
   type DataTableKeyEvent,
   type TickerListVisibleRange,
@@ -404,7 +408,12 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
   }, [activeCollectionId, config, currentPortfolio]);
   const showQuickAdd = !!(activeCollectionId && activeCollectionEntry && quickAddCollectionKind);
   const quickAddHeight = showQuickAdd ? 1 : 0;
-  const contentHeight = Math.max(1, height - headerHeight - drawerHeight - quickAddHeight);
+  const selectedFinancials = cursorSymbol ? financialsMap.get(cursorSymbol) : undefined;
+  const selectedCap = selectMarketCapitalization(selectedFinancials?.quote, selectedFinancials?.fundamentals);
+  const capNotice = viewMode === "table" && columns.some((column) => column.id === "market_cap") && selectedCap?.provenance.kind === "fundamentals"
+    ? `${cursorSymbol} market cap: ${describeFundamentalMarketCap(selectedCap.provenance)}.` : undefined;
+  const capNoticeHeight = capNotice ? wrapTextLines(capNotice, Math.max(8, width - 2)).length : 0;
+  const contentHeight = Math.max(1, height - headerHeight - drawerHeight - quickAddHeight - capNoticeHeight);
   const quickAddRow = activeCollectionId && activeCollectionEntry && quickAddCollectionKind ? (
     <QuickAddTickerInput
       collectionId={activeCollectionId}
@@ -435,6 +444,7 @@ export function PortfolioListPane({ focused, width, height }: PaneProps) {
         </Box>
       )}
 
+      {capNotice ? <Box paddingX={1} flexShrink={0}><Prose text={capNotice} width={Math.max(8, width - 2)} color={colors.textDim} /></Box> : null}
       {viewMode === "table" ? (
         <PortfolioTickerTable
           columns={columns}

--- a/src/plugins/builtin/research/relative-valuation-model.ts
+++ b/src/plugins/builtin/research/relative-valuation-model.ts
@@ -1,6 +1,7 @@
 import { comparablePriceEarnings } from "../../../utils/price-earnings";
 import { selectMarketCapitalization } from "../../../utils/market-capitalization";
 import type { TickerFinancials } from "../../../types/financials";
+export { convertMarketCapitalization as comparableMarketCap } from "../../../utils/market-capitalization";
 
 export function relativeValuationValues(financials: TickerFinancials | null) {
   const quote = financials?.quote;
@@ -34,18 +35,4 @@ export function relativeValuationValues(financials: TickerFinancials | null) {
     revenueGrowth: fundamentals?.revenueGrowth ?? fundamentals?.lastQuarterGrowth ?? null,
     operatingMargin: fundamentals?.operatingMargin ?? null,
   };
-}
-
-export function comparableMarketCap(
-  value: number | null,
-  currency: string | null,
-  baseCurrency: string,
-  rates: ReadonlyMap<string, number>,
-): number | null {
-  if (value == null || !Number.isFinite(value) || !currency) return null;
-  if (currency === baseCurrency) return value;
-  const fromRate = currency === "USD" ? 1 : rates.get(currency);
-  const toRate = baseCurrency === "USD" ? 1 : rates.get(baseCurrency);
-  if (fromRate == null || toRate == null || !Number.isFinite(fromRate) || !Number.isFinite(toRate) || fromRate <= 0 || toRate <= 0) return null;
-  return value * fromRate / toRate;
 }

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -1,4 +1,4 @@
-import { EmptyState, Notice, SectionHeading } from "../../../components";
+import { EmptyState, Notice, Prose, SectionHeading } from "../../../components";
 import { CompositeChart, pricePointsToResolvedSeries } from "../../../components/chart/composite";
 import { CompanyLogo } from "../../../components/company-logo";
 import { PriceReturnStrip } from "../../../components/price-performance";
@@ -19,6 +19,7 @@ import { resolveExchangeTimeZone } from "../../../utils/exchanges";
 import { convertCurrency, displayWidth, formatPercentRaw, truncateToDisplayWidth } from "../../../utils/format";
 import { CompactRangeBar, PositionTable, QuoteBook, StatGrid } from "./overview/components";
 import { buildOverviewStats, buildPositionRows } from "./overview/model";
+import { describeFundamentalMarketCap, selectMarketCapitalization } from "../../../utils/market-capitalization";
 
 export function OverviewTab({
   width,
@@ -38,11 +39,13 @@ export function OverviewTab({
 
   const quote = financials?.quote;
   const fundamentals = financials?.fundamentals;
+  const capitalization = selectMarketCapitalization(quote, fundamentals);
   const profile = financials?.profile;
   const exchangeRates = useFxRatesMap([
     baseCurrency,
     ticker.metadata.currency,
     quote?.currency,
+    capitalization?.currency,
     ...ticker.metadata.positions.map((position) => position.currency),
   ]);
   const effectiveExchangeRates = selectEffectiveExchangeRates(exchangeRates, exchangeRatesState);
@@ -107,6 +110,7 @@ export function OverviewTab({
     quoteCurrency,
     baseCurrency,
     toBase,
+    marketCapExchangeRates: effectiveExchangeRates,
   });
   const performanceFields = buildPriceReturnFields(
     appendQuoteToPriceReturnHistory(financials?.priceHistory ?? [], quote),
@@ -260,6 +264,7 @@ export function OverviewTab({
           <Box flexDirection="column">
             <SectionHeading title={t("Fundamentals")} />
             <StatGrid fields={stats} width={contentWidth} />
+            {capitalization?.provenance.kind === "fundamentals" ? <Prose text={`Market cap: ${describeFundamentalMarketCap(capitalization.provenance)}.`} width={contentWidth} color={colors.textDim} /> : null}
           </Box>
         )}
 

--- a/src/plugins/builtin/ticker-detail/overview/model.ts
+++ b/src/plugins/builtin/ticker-detail/overview/model.ts
@@ -1,4 +1,5 @@
 import { formatPriceEarnings } from "../../../../utils/price-earnings";
+import { convertMarketCapitalization, selectMarketCapitalization } from "../../../../utils/market-capitalization";
 import { priceColor } from "../../../../theme/colors";
 import type { Quote, TickerFinancials } from "../../../../types/financials";
 import type { TickerPosition, TickerRecord } from "../../../../types/ticker";
@@ -36,13 +37,14 @@ export function buildOverviewStats({
   fundamentals,
   quoteCurrency,
   baseCurrency,
-  toBase,
+  marketCapExchangeRates = new Map(),
 }: {
   quote: Quote | undefined;
   fundamentals: TickerFinancials["fundamentals"] | undefined;
   quoteCurrency: string;
   baseCurrency: string;
   toBase: CurrencyConverter;
+  marketCapExchangeRates?: ReadonlyMap<string, number>;
 }): StatField[] {
   const stats: StatField[] = [];
   const financialCurrency = fundamentals?.financialCurrency;
@@ -53,8 +55,10 @@ export function buildOverviewStats({
   if (quote?.volume != null) {
     stats.push({ label: "Volume", value: formatCompact(quote.volume) });
   }
-  if (quote?.marketCap) {
-    stats.push({ label: "Market Cap", value: formatCompactCurrency(toBase(quote.marketCap, quoteCurrency), baseCurrency) });
+  const capitalization = selectMarketCapitalization(quote, fundamentals);
+  if (capitalization) {
+    const converted = convertMarketCapitalization(capitalization.value, capitalization.currency, baseCurrency, marketCapExchangeRates);
+    stats.push({ label: "Market Cap", value: formatCompactCurrency(converted ?? capitalization.value, converted == null ? capitalization.currency : baseCurrency) });
   }
   if (fundamentals?.sharesOutstanding) {
     stats.push({ label: "Shares Out", value: formatCompact(fundamentals.sharesOutstanding) });

--- a/src/utils/market-capitalization-consumers.test.ts
+++ b/src/utils/market-capitalization-consumers.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import type { TickerRecord } from "../types/ticker";
+import type { TickerFinancials } from "../types/financials";
+import { getColumnValue, getSortValue } from "../plugins/builtin/portfolio-list/column-values";
+import { buildTrackedCurrencies } from "../plugins/builtin/portfolio-list/pane/data";
+import { buildOverviewStats } from "../plugins/builtin/ticker-detail/overview/model";
+
+const ticker: TickerRecord = { metadata: { ticker: "F:XNYS", name: "Ford", exchange: "NYSE", currency: "USD",
+  portfolios: [], watchlists: [], positions: [], custom: {}, tags: [] } };
+const column = { id: "market_cap", label: "MCAP", width: 12, align: "right" as const };
+const fundamentals = { marketCap: 100, marketCapCurrency: "EUR", financialCurrency: "USD", freeCashFlow: -20,
+  source: "yahoo" as const, fetchedAt: "2026-09-11T15:23:57Z" };
+const makeFinancials = (extra: Partial<TickerFinancials> = {}): TickerFinancials => ({
+  annualStatements: [], quarterlyStatements: [], priceHistory: [], fundamentals, ...extra,
+});
+const context = { baseCurrency: "GBP", exchangeRates: new Map([["EUR", 1.2], ["GBP", 2]]), now: 1 };
+const overview = (data: TickerFinancials, rates = context.exchangeRates) => buildOverviewStats({
+  quote: data.quote, fundamentals: data.fundamentals, quoteCurrency: "USD", baseCurrency: "GBP",
+  toBase: () => { throw new Error("Market cap must not use a quote-currency conversion"); }, marketCapExchangeRates: rates,
+});
+
+test("overview and portfolio use the cap's explicit currency when a quote has no capitalization", () => {
+  const data = makeFinancials({ quote: { symbol: "F:XNYS", currency: "USD", price: 14, change: 0, changePercent: 0, lastUpdated: 1 } });
+  expect(getColumnValue(column, ticker, data, context).text).toBe("60");
+  expect(getSortValue(column, ticker, data, context)).toBe(60);
+  expect(overview(data).find(({ label }) => label === "Market Cap")?.value).toBe("60 GBP");
+  expect(data.quote?.marketCap).toBeUndefined();
+  expect(data.fundamentals).toEqual(fundamentals);
+});
+
+test("fundamental caps remain available without reviving any price quote", () => {
+  const data = makeFinancials();
+  expect(getColumnValue(column, ticker, data, context).text).toBe("60");
+  expect(getSortValue(column, ticker, data, context)).toBe(60);
+  expect(overview(data).find(({ label }) => label === "Market Cap")?.value).toBe("60 GBP");
+  expect(data.quote).toBeUndefined();
+});
+
+test("missing FX never creates a comparable 1:1 market cap; overview retains explicit original units", () => {
+  const data = makeFinancials(); const exchangeRates = new Map<string, number>();
+  expect(getColumnValue(column, ticker, data, { ...context, exchangeRates }).text).toBe("—");
+  expect(getSortValue(column, ticker, data, { ...context, exchangeRates })).toBeNull();
+  expect(overview(data, exchangeRates).find(({ label }) => label === "Market Cap")?.value).toBe("100 EUR");
+  expect(buildTrackedCurrencies([ticker], new Map([[ticker.metadata.ticker, data]]), null, "GBP")).toContain("EUR");
+});
+
+test("a valid quote cap keeps precedence and its own currency", () => {
+  const data = makeFinancials({ quote: { symbol: "F:XNYS", currency: "USD", marketCap: 200, price: 14, change: 0, changePercent: 0, lastUpdated: 1 } });
+  expect(getColumnValue(column, ticker, data, context).text).toBe("100");
+  expect(getSortValue(column, ticker, data, context)).toBe(100);
+  expect(overview(data).find(({ label }) => label === "Market Cap")?.value).toBe("100 GBP");
+});
+
+test("ticker and statement currencies cannot fill a missing capitalization currency", () => {
+  const data = makeFinancials({ fundamentals: { ...fundamentals, marketCapCurrency: undefined } });
+  expect(getColumnValue(column, ticker, data, context).text).toBe("—");
+  expect(getSortValue(column, ticker, data, context)).toBeNull();
+  expect(overview(data).some(({ label }) => label === "Market Cap")).toBe(false);
+});

--- a/src/utils/market-capitalization.ts
+++ b/src/utils/market-capitalization.ts
@@ -42,3 +42,17 @@ export function describeFundamentalMarketCap(provenance: MarketCapitalization["p
     : "retrieval time unavailable";
   return `${source} fundamentals, ${retrieval}${provenance.stale ? ", stale" : ""}; valuation date unavailable`;
 }
+
+export function convertMarketCapitalization(
+  value: number | null,
+  currency: string | null,
+  baseCurrency: string,
+  rates: ReadonlyMap<string, number>,
+): number | null {
+  if (value == null || !Number.isFinite(value) || !currency) return null;
+  if (currency === baseCurrency) return value;
+  const fromRate = currency === "USD" ? 1 : rates.get(currency);
+  const toRate = baseCurrency === "USD" ? 1 : rates.get(baseCurrency);
+  if (fromRate == null || toRate == null || !Number.isFinite(fromRate) || !Number.isFinite(toRate) || fromRate <= 0 || toRate <= 0) return null;
+  return value * fromRate / toRate;
+}


### PR DESCRIPTION
Overview and watchlist market caps disappeared when a fresh lightweight quote omitted capitalization even though qualified fundamentals retained it. Both now use the same source-aware selector as relative valuation: a valid quote cap takes precedence, otherwise a fundamentals cap requires its own explicit currency and displays its source and retrieval time, with valuation date marked unavailable.

Cap conversion and sorting require valid FX rates. If FX is missing, overview retains explicitly labeled original units and the comparable watchlist column stays unavailable. The selected-row provenance notice appears only when the table actually shows market cap. Prices, holdings and other accounting metrics retain their existing behavior.

Validation: 55 focused tests / 205 assertions, all six TypeScript projects, and web build passed. Native live-data watchlist/overview controls and a separately labeled financial-refresh outage replay using the original recorded cache passed at 140 and 80 columns, including saved restart; quote requests remained live. The final browser build passed the qualified watchlist → Ford overview → ordinary reload journey against anonymous production APIs. Independent source review passed. No release or version change.
