### PR TITLE
Preserve tiny prices in historical tables and exports

### DIFF
--- a/src/plugins/builtin/ticker-detail/data-panes/historical-prices.test.tsx
+++ b/src/plugins/builtin/ticker-detail/data-panes/historical-prices.test.tsx
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../../../../renderers/opentui/test-utils";
+import { createInitialState } from "../../../../state/app/context";
+import { createTestDataProvider } from "../../../../test-support/data-provider";
+import { createTestPaneConfig, createTestTicker, TestPaneProvider } from "../../../../test-support/pane";
+import { createTestPluginRuntime } from "../../../../test-support/plugin-runtime";
+import { HistoricalPricesPane } from "./historical-prices";
+
+test("historical table preserves tiny prices and signed changes inside its numeric columns", async () => {
+  const paneId = "history:test";
+  const symbol = "SHIB-USD:CCC";
+  const config = createTestPaneConfig("/tmp/gloom-history-precision-test", {
+    instanceId: paneId, paneId: "historical-prices", binding: { kind: "fixed", symbol },
+  });
+  const state = createInitialState(config);
+  state.tickers.set(symbol, createTestTicker(symbol));
+  const provider = createTestDataProvider({
+    getPriceHistory: async () => [
+      { date: new Date("2026-09-09"), close: 0.00000531 },
+      { date: new Date("2026-09-10"), open: 0.00000531, high: 0.00000542, low: 0.00000501, close: 0.00000532 },
+      { date: new Date("2026-09-11"), close: 0.0000053 },
+    ],
+  });
+  const runtime = createTestPluginRuntime({ getMarketData: () => provider });
+  let setup!: Awaited<ReturnType<typeof testRender>>;
+  await act(async () => { setup = await testRender(
+    <TestPaneProvider state={state} dispatch={() => {}} paneId={paneId} pluginId="ticker-research" runtime={runtime}>
+      <HistoricalPricesPane paneId={paneId} paneType="historical-prices" focused width={110} height={10} />
+    </TestPaneProvider>, { width: 110, height: 10 },
+  ); });
+  try {
+    await act(async () => { await Promise.resolve(); await setup.renderOnce(); });
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("0.00000532");
+    expect(frame).toContain("0.00000542");
+    expect(frame).toContain("0.00000501");
+    expect(frame).toContain("-2e-8");
+    expect(frame).toContain("0.00000001");
+  } finally { await act(async () => { setup.renderer.destroy(); }); }
+});

--- a/src/plugins/builtin/ticker-detail/data-panes/historical-prices.tsx
+++ b/src/plugins/builtin/ticker-detail/data-panes/historical-prices.tsx
@@ -13,7 +13,8 @@ import { TIME_RANGES, type TimeRange } from "../../../../time-series/range";
 import type { PaneProps } from "../../../../types/plugin";
 import type { PricePoint } from "../../../../types/financials";
 import { colors, priceColor } from "../../../../theme/colors";
-import { formatCompact, formatNumber, formatPercent } from "../../../../utils/format";
+import { formatCompact, formatPercent } from "../../../../utils/format";
+import { formatMarketPrice } from "../../../../market-data/market/format";
 import {
   useAssetData,
   useDebouncedPluginPaneState,
@@ -39,8 +40,9 @@ function pricePointDate(point: PricePoint): Date | null {
   return Number.isFinite(date.getTime()) ? date : null;
 }
 
-function formatMaybePrice(value: number | undefined): string {
-  return value == null ? "-" : formatNumber(value, 2);
+function formatMaybePrice(value: number | null | undefined, width: number): string {
+  return value == null || !Number.isFinite(value) ? "-"
+    : formatMarketPrice(value, { minimumFractionDigits: 2, maxWidth: width });
 }
 
 function formatMaybePercent(value: number | null): string {
@@ -142,15 +144,15 @@ export function HistoricalPricesPane({ focused, width, height }: PaneProps) {
       case "date":
         return { text: row.date, color: selectedColor ?? colors.textDim };
       case "open":
-        return { text: formatMaybePrice(row.point.open), color: selectedColor ?? colors.text };
+        return { text: formatMaybePrice(row.point.open, column.width), color: selectedColor ?? colors.text };
       case "high":
-        return { text: formatMaybePrice(row.point.high), color: selectedColor ?? colors.text };
+        return { text: formatMaybePrice(row.point.high, column.width), color: selectedColor ?? colors.text };
       case "low":
-        return { text: formatMaybePrice(row.point.low), color: selectedColor ?? colors.text };
+        return { text: formatMaybePrice(row.point.low, column.width), color: selectedColor ?? colors.text };
       case "close":
-        return { text: formatNumber(row.point.close, 2), color: selectedColor ?? colors.textBright, attributes: TextAttributes.BOLD };
+        return { text: formatMaybePrice(row.point.close, column.width), color: selectedColor ?? colors.textBright, attributes: TextAttributes.BOLD };
       case "change":
-        return { text: row.change == null ? "-" : formatNumber(row.change, 2), color: selectedColor ?? priceColor(row.change ?? 0) };
+        return { text: formatMaybePrice(row.change, column.width), color: selectedColor ?? priceColor(row.change ?? 0) };
       case "changePercent":
         return { text: formatMaybePercent(row.changePercent), color: selectedColor ?? priceColor(row.changePercent ?? 0) };
       case "volume":

--- a/src/plugins/builtin/ticker-detail/headless.test.ts
+++ b/src/plugins/builtin/ticker-detail/headless.test.ts
@@ -97,6 +97,21 @@ test("historical prices use remembered exchanges and clip and sort the full OHLC
   expect(result.rows[1]).toEqual({ date: "2026-03-09T00:00:00.000Z", open: 20, high: 23, low: 19, close: 22, volume: 100 });
 });
 
+test("historical price exports preserve tiny OHLC values without changing raw data", async () => {
+  const point = { date: new Date("2026-09-10"), open: 0.00000531, high: 0.00000542, low: 0.00000501, close: 0.00000532, volume: 123456 };
+  const ctx = { marketData: createTestDataProvider({ getPriceHistory: async () => [point] }) } as HeadlessPaneContext;
+  const result = await historicalPricesHeadless.load(args(["SHIB-USD:CCC"]), ctx);
+  const row = result.rows[0]!;
+  for (const key of ["open", "high", "low", "close"] as const) {
+    const column = historicalPricesHeadless.columns!.find((column) => column.key === key)!;
+    expect(row[key]).toBe(point[key]);
+    expect(Number(column.format!(row[key], row))).toBe(point[key]);
+    expect(column.format!(0, row)).toBe("0.00");
+    expect(column.format!(null, row)).toBe("-");
+    expect(column.format!(123.45, row)).toBe("123.45");
+  }
+});
+
 test("financial JSON exports preserve selected metric availability separately from fiscal-period evidence", async () => {
   const fieldAvailability = { totalRevenue: "2018-08-03", netIncome: "2018-08-03", capitalExpenditure: "2017-08-02" };
   const dateEvidence = { accessionNumber: "0001564590-17-014900", filed: "2017-08-02", startDate: "2016-07-01" };

--- a/src/plugins/builtin/ticker-detail/headless.ts
+++ b/src/plugins/builtin/ticker-detail/headless.ts
@@ -2,6 +2,7 @@ import { FINANCIAL_VINTAGE_NOTICE } from "../../../utils/financial-statements";
 import type { HeadlessPaneColumn, HeadlessPaneDefinition } from "../../../types/headless";
 import type { TimeRange } from "../../../time-series/range";
 import { formatCurrency, formatNumber, formatPercentRaw } from "../../../utils/format";
+import { formatMarketPrice } from "../../../market-data/market/format";
 import { buildFinancialTableModel, financialStatementCurrency, financialStatementDateNotice, financialStatementLimitations, formatFinancialHeader } from "./financials/model";
 import { paneSchemas } from "./headless-schema";
 import {
@@ -98,7 +99,9 @@ export const historicalPricesHeadless: HeadlessPaneDefinition<"rows"> = {
     { key: "date", header: "Date", format: (value) => String(value).slice(0, 10) },
     ...["open", "high", "low", "close", "volume"].map((key) => ({
       key, header: key, align: "right" as const,
-      format: (value: unknown) => value == null ? "-" : formatNumber(Number(value), key === "volume" ? 0 : 2),
+      format: (value: unknown) => value == null || !Number.isFinite(Number(value)) ? "-"
+        : key === "volume" ? formatNumber(Number(value), 0)
+        : formatMarketPrice(Number(value), { minimumFractionDigits: 2 }),
     })),
   ],
   async load({ symbols, options }, ctx) {


### PR DESCRIPTION
Historical OHLCV tables and formatted CLI exports rendered nonzero SHIB prices and daily changes as `0.00`, making tiny-price research unusable. Use the shared market-price formatter for OHLC and change cells, with width-aware scientific notation when needed; retain raw export numbers and distinguish missing values from zero.

Validated production before and local live-API browser after/reload, actual native 140/80-column rendering, and CLI before/after output. The 24 focused tests (98 assertions), all six TypeScript targets and web build pass. Tests cover tiny OHLC export roundtrips, unchanged ordinary prices/zero/missing values, and rendered prices plus signed sub-cent changes.

A separately observed provider/history freshness issue is under investigation; this patch changes formatting only. No version bump or release.
