### PR TITLE
Refresh stale wider history caches for shorter chart requests

### DIFF
--- a/src/sources/provider-router/history.test.ts
+++ b/src/sources/provider-router/history.test.ts
@@ -402,6 +402,48 @@ describe("AssetDataRouter chart history", () => {
     persistence.close();
   });
 
+  test("revalidates a stale wider cache once for concurrent shorter requests and persists the correction", async () => {
+    const persistence = new AppPersistence(createTempDbPath("stale-wider-chart-cache"));
+    const date = new Date(Date.now() - 24 * 60 * 60_000);
+    const stalePoint = { date, open: 764.08, high: 758.555, low: 757.57, close: 758.15 };
+    const correctedPoint = { date, open: 758.03, high: 760.11, low: 756.64, close: 757.83 };
+    let resolveFresh!: (points: typeof stalePoint[]) => void;
+    const fresh = new Promise<typeof stalePoint[]>((resolve) => { resolveFresh = resolve; });
+    let calls = 0;
+    const provider = {
+      ...fallbackProvider,
+      async getPriceHistoryForResolution(_symbol: string, _exchange: string, range: string) {
+        if (range === "5Y") return [stalePoint];
+        calls += 1;
+        return fresh;
+      },
+    };
+    try {
+      await new AssetDataRouter(provider, [], persistence.resources)
+        .getPriceHistoryForResolution("SPY", "NYSEARCA", "5Y", "1d");
+      persistence.database.connection.query("UPDATE resource_cache SET stale_at = ?").run(Date.now() - 1);
+      const router = new AssetDataRouter(provider, [], persistence.resources);
+      const initial = await Promise.all(Array.from({ length: 2 }, () =>
+        router.getPriceHistoryForResolution("SPY", "NYSEARCA", "1M", "1d")));
+      expect(initial.map((points) => points[0]?.close)).toEqual([758.15, 758.15]);
+      await Promise.resolve();
+      expect(calls).toBe(1);
+      resolveFresh([correctedPoint]);
+      await fresh;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      const reloaded = await new AssetDataRouter(provider, [], persistence.resources)
+        .getPriceHistoryForResolution("SPY", "NYSEARCA", "1M", "1d");
+      expect(reloaded.map(({ date: _date, ...point }) => point)).toEqual([
+        { open: 758.03, high: 760.11, low: 756.64, close: 757.83 },
+      ]);
+      expect(calls).toBe(1);
+    } finally {
+      resolveFresh?.([]);
+      await fresh;
+      persistence.close();
+    }
+  });
+
   test("falls back to later providers for fixed-resolution chart history", async () => {
     const cloudProvider: DataProvider = {
       ...fallbackProvider,

--- a/src/sources/provider-router/history.ts
+++ b/src/sources/provider-router/history.ts
@@ -374,7 +374,7 @@ export class ProviderRouterHistoryRoutes {
     const usableCached = cachedValue.length > 0 && cached && !cached.expired && !cachedHistoryStale;
     if (usableCached && !forceRefresh) {
       const exactHit = request.exactCacheVariantKeys.includes(cached.variantKey);
-      if (cached.stale && exactHit) {
+      if (cached.stale) {
         scheduleRouterRevalidation(this.historyRefreshInFlight, request.identity.revalidationKey, () => this.refreshHistory(request));
       }
       return exactHit || !request.requestedRange


### PR DESCRIPTION
A shorter chart request can reuse an unexpired wider history cache, but stale wider hits never triggered refresh. For example, SPY 1M daily repeatedly returned yesterday's partial 5Y tail even after the source had corrected it.

Schedule the existing deduplicated background refresh for stale wider hits as well as exact hits. Cached history remains immediately available, and the refreshed shorter range is persisted for subsequent requests. Price values and malformed-bar handling are unchanged.

Validation: 31 tests /87 assertions pass across provider-router history, historical boundary-cache and price-history suites. All six TypeScript targets passed. The regression covers concurrent shorter requests and correction reuse by a new router. An isolated replay of the actual SPY cache changes from zero source calls on both attempts to one source call followed by corrected captured source data. The first stale response remains available under the existing refresh policy; invalid OHLC presentation is tracked separately.
