### PR TITLE
Preserve cross-market research and reject inconsistent price history

### DIFF
--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -801,7 +801,11 @@ function CompositePanelSurface({
         endValue,
         startTime,
         endTime,
-        bars: countMeasureBars(scene.dates, startTime, endTime),
+        // Cross-market cursor stops include every listing's observations;
+        // measured bars still follow the primary market's session scale.
+        bars: countMeasureBars(scene.timeScale.kind === "market"
+          ? scene.timeScale.anchors.map(({ timestamp }) => new Date(timestamp))
+          : scene.dates, startTime, endTime),
         domain: measureDomain,
       }),
       startValueLabel: measureDomain && startValue !== null

--- a/src/components/chart/composite/panel-series.ts
+++ b/src/components/chart/composite/panel-series.ts
@@ -38,6 +38,7 @@ function sameSeriesMeta(left: ResolvedSeries, right: ResolvedSeries): boolean {
     && left.interpolation === right.interpolation
     && left.warning === right.warning
     && left.hidden === right.hidden
+    && left.observationKind === right.observationKind
     && left.timeBasis?.kind === right.timeBasis?.kind
     && left.timeBasis?.timeZone === right.timeBasis?.timeZone
     && left.timeBasis?.cadenceMs === right.timeBasis?.cadenceMs;

--- a/src/components/chart/composite/price-series.ts
+++ b/src/components/chart/composite/price-series.ts
@@ -7,6 +7,7 @@ import type {
   TimeSeriesPoint,
 } from "../../../time-series/types";
 import type { PricePoint } from "../../../types/financials";
+import { pricePointValues, priceHistoryIntegrityNotice } from "../../../utils/price-history-integrity";
 
 export interface PricePointsToResolvedSeriesOptions {
   id: string;
@@ -24,23 +25,16 @@ export interface PricePointsToResolvedSeriesOptions {
   timeBasis?: ResolvedSeriesMarketTimeBasis;
 }
 
-function finiteOrNull(value: number | null | undefined): number | null {
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
 function normalizePricePoint(point: PricePoint, providerId?: string): TimeSeriesPoint | null {
   const date = point.date instanceof Date ? new Date(point.date) : new Date(point.date as unknown as string | number);
   if (!Number.isFinite(date.getTime())) return null;
+  const { integrity, ...values } = pricePointValues(point);
   return {
     date,
     observedAt: date,
-    value: finiteOrNull(point.close),
-    open: finiteOrNull(point.open),
-    high: finiteOrNull(point.high),
-    low: finiteOrNull(point.low),
-    close: finiteOrNull(point.close),
-    volume: finiteOrNull(point.volume),
-    provenance: providerId ? { providerId, quality: "reported" } : undefined,
+    value: values.close,
+    ...values,
+    provenance: providerId || integrity ? { providerId, quality: "reported", ...(integrity ? { priceHistoryIntegrity: integrity } : {}) } : undefined,
   };
 }
 
@@ -71,6 +65,6 @@ export function pricePointsToResolvedSeries(
     interpolation: "none",
     timeBasis: options.timeBasis,
     points: [...byTimestamp.values()].sort((left, right) => left.date.getTime() - right.date.getTime()),
-    warning: options.warning,
+    warning: [options.warning, priceHistoryIntegrityNotice([...byTimestamp.values()].filter((point) => point.provenance?.priceHistoryIntegrity).length)].filter(Boolean).join(" ") || undefined,
   };
 }

--- a/src/components/chart/composite/scene-market-cursor.test.ts
+++ b/src/components/chart/composite/scene-market-cursor.test.ts
@@ -4,6 +4,7 @@ import { createTestDataProvider } from "../../../test-support/data-provider";
 import { resolveChartSpecData } from "../../../time-series/resolve";
 import { applyCompositeChartCursor, buildCompositeChartScene, resolveAdjacentCompositeCursorDate, resolveCompositeCursorDate } from "./scene";
 import { countMeasureBars } from "./tools";
+import { pricePointIntegrity } from "../../../utils/price-history-integrity";
 import { reuseResolvedSeriesIdentity } from "./panel-series";
 
 function market(id: string, zone: string, dates: string[], values: number[]): ResolvedSeries {
@@ -127,4 +128,21 @@ test("resolved crypto weekend observations and their studies keep exact timestam
   const onlyCrypto = buildCompositeChartScene([crypto, average], spec.panels, { width: 101, height: 20 })!;
   expect(onlyCrypto.timeScale.kind).toBe("calendar");
   expect(onlyCrypto.dates.map(date => date.toISOString())).toEqual(history["BTC-USD"]!.map(point => point.date.toISOString()));
+});
+
+
+test("a quarantined crypto observation stays selectable beside an exchange session", () => {
+  const crypto = { ...asx(), id: "BTC", observationKind: "market" as const, timeBasis: undefined };
+  const invalidDate = new Date("2026-01-09T00:00:00Z");
+  const integrity = pricePointIntegrity({ date: invalidDate, open: 120, high: 110, low: 90, close: 100 })!;
+  crypto.points = [
+    { date: new Date("2026-01-08"), value: 100 },
+    { date: invalidDate, value: null, provenance: { priceHistoryIntegrity: integrity } },
+  ];
+  const scene = buildCompositeChartScene([us(), crypto], [{ id: "main" }], { width: 101, height: 20 })!;
+  expect(scene.dates.some(date => date.getTime() === invalidDate.getTime())).toBe(true);
+  const selected = applyCompositeChartCursor(scene, invalidDate);
+  expect(selected.cursorDate?.getTime()).toBe(invalidDate.getTime());
+  expect(selected.cursorValues.find(value => value.seriesId === "BTC")?.value).toBeNull();
+  expect(selected.cursorValues.find(value => value.seriesId === "BTC")?.point?.provenance?.priceHistoryIntegrity).toEqual(integrity);
 });

--- a/src/components/chart/composite/scene-market-cursor.test.ts
+++ b/src/components/chart/composite/scene-market-cursor.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "bun:test";
+import { CHART_SPEC_VERSION, type ChartSpec, type ResolvedSeries, type TimeSeriesPoint } from "../../../time-series/types";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { resolveChartSpecData } from "../../../time-series/resolve";
+import { applyCompositeChartCursor, buildCompositeChartScene, resolveAdjacentCompositeCursorDate, resolveCompositeCursorDate } from "./scene";
+import { countMeasureBars } from "./tools";
+import { reuseResolvedSeriesIdentity } from "./panel-series";
+
+function market(id: string, zone: string, dates: string[], values: number[]): ResolvedSeries {
+  return {
+    id, label: id, color: "#ffffff", unit: "%", unitGroup: "percent", nativeFrequency: "daily",
+    dataShape: "scalar", style: "line", transform: "percent", axis: "left", panelId: "main", interpolation: "none",
+    timeBasis: { kind: "market", timeZone: zone, cadenceMs: 86_400_000 },
+    points: dates.map((date, index) => ({ date: new Date(date), value: values[index]! })),
+  };
+}
+const asx = () => market("ASX", "Australia/Sydney", ["2026-01-07T23:00:00Z", "2026-01-08T23:00:00Z"], [0, 10]);
+const us = () => market("US", "America/New_York", ["2026-01-08T14:30:00Z", "2026-01-09T14:30:00Z"], [0, 20]);
+
+test("every cross-market endpoint remains inspectable by pointer and keyboard in either series order", () => {
+  for (const entries of [[asx(), us()], [us(), asx()]]) {
+    const scene = buildCompositeChartScene(entries, [{ id: "main" }], { width: 101, height: 20 })!;
+    expect(scene.timeScale.kind === "market" && scene.timeScale.anchorSeriesId).toBe(entries[0]!.id);
+    const sortedDates = entries.flatMap(entry => entry.points.map(point => point.date.toISOString())).sort();
+    expect(scene.dates.map(date => date.toISOString())).toEqual(sortedDates);
+    for (const entry of scene.panels[0]!.series) for (const projected of entry.points) {
+      const requested = new Date(projected.timestamp);
+      const pointerDate = resolveCompositeCursorDate(scene, projected.xRatio * (scene.width - 1));
+      expect(pointerDate?.getTime()).toBe(requested.getTime());
+      const inspected = applyCompositeChartCursor(scene, requested);
+      expect(inspected.cursorDate?.getTime()).toBe(requested.getTime());
+      expect(inspected.cursorValues.find(value => value.seriesId === entry.source.id)?.value).toBe(projected.value);
+    }
+    const last = resolveAdjacentCompositeCursorDate(scene, null, -1)!;
+    expect(last.toISOString()).toBe("2026-01-09T14:30:00.000Z");
+    expect(applyCompositeChartCursor(scene, last).cursorValues.find(value => value.seriesId === "US")?.value).toBe(20);
+    let cursor = resolveAdjacentCompositeCursorDate(scene, null, 1)!;
+    const traversed = [cursor.toISOString()];
+    for (let index = 1; index < scene.dates.length; index++) {
+      cursor = resolveAdjacentCompositeCursorDate(scene, cursor, 1)!;
+      traversed.push(cursor.toISOString());
+    }
+    expect(traversed).toEqual(sortedDates);
+    // Cursor observations are not a count of the primary market's bars.
+    if (scene.timeScale.kind === "market") {
+      expect(countMeasureBars(scene.timeScale.anchors.map(anchor => new Date(anchor.timestamp)), scene.startTime, scene.endTime)).toBe(2);
+    }
+  }
+});
+
+test("new market cursor slots neither expose unpublished filings nor add nonmarket source dates", () => {
+  const published: TimeSeriesPoint = { date: new Date("2025-12-31"), value: 500, availableAt: new Date("2026-01-08T20:00:00Z") };
+  const notYetPublished: TimeSeriesPoint = { date: new Date("2026-01-01"), value: 900, availableAt: new Date("2026-01-10T20:00:00Z") };
+  const filing: ResolvedSeries = { ...asx(), id: "filing", timeBasis: undefined, transform: "raw", style: "columns", points: [published, notYetPublished] };
+  const scene = buildCompositeChartScene([asx(), us(), filing], [{ id: "main" }], {
+    width: 101, height: 20, clipToViewport: true,
+    viewport: { start: new Date("2026-01-07T23:00:00Z"), end: new Date("2026-01-09T14:30:00Z") },
+  })!;
+  expect(scene.dates.map(date => date.toISOString())).toEqual([
+    "2026-01-07T23:00:00.000Z", "2026-01-08T14:30:00.000Z", "2026-01-08T23:00:00.000Z", "2026-01-09T14:30:00.000Z",
+  ]);
+  expect(applyCompositeChartCursor(scene, new Date("2026-01-08T14:30:00Z")).cursorValues.find(value => value.seriesId === "filing")?.value).toBeNull();
+  const publishedCursor = applyCompositeChartCursor(scene, new Date("2026-01-08T23:00:00Z"));
+  expect(publishedCursor.cursorValues.find(value => value.seriesId === "filing")?.value).toBe(500);
+  const projected = scene.panels[0]!.series.find(entry => entry.source.id === "filing")!.points;
+  expect(projected).toHaveLength(1);
+  expect(projected[0]!.point).toBe(published);
+  expect(projected[0]!.xRatio).toBe(scene.panels[0]!.series.find(entry => entry.source.id === "ASX")!.points.at(-1)!.xRatio);
+});
+
+test("only finite visible market observations add cursor stops while a hidden primary preserves geometry", () => {
+  const primary = asx();
+  const secondary = us();
+  secondary.points.push({ date: new Date("2026-01-09T14:15:00Z"), value: null });
+  secondary.points.push({ date: new Date("2026-01-10T14:30:00Z"), value: 30 });
+  const scene = buildCompositeChartScene([secondary], [{ id: "main" }], {
+    width: 101, height: 20, timelineSeries: [primary, secondary], clipToViewport: true,
+    viewport: { start: primary.points[0]!.date, end: new Date("2026-01-09T14:30:00Z") },
+  })!;
+  expect(scene.timeScale.kind === "market" && scene.timeScale.anchorSeriesId).toBe("ASX");
+  expect(scene.dates.map(date => date.toISOString())).toEqual([
+    "2026-01-07T23:00:00.000Z", "2026-01-08T14:30:00.000Z", "2026-01-08T23:00:00.000Z", "2026-01-09T14:30:00.000Z",
+  ]);
+});
+
+test("resolved crypto weekend observations and their studies keep exact timestamps beside an equity market", async () => {
+  const history: Record<string, Array<{ date: Date; close: number }>> = {
+    "BTC-USD": ["2026-01-09", "2026-01-10", "2026-01-11"].map((date, index) => ({ date: new Date(date), close: 100 + index * 10 })),
+    SPY: [{ date: new Date("2026-01-09T14:30:00Z"), close: 50 }],
+  };
+  const getHistory = async (symbol: string) => history[symbol] ?? [];
+  const spec: ChartSpec = {
+    version: CHART_SPEC_VERSION,
+    viewport: { range: "1M", resolution: "1d", dateWindow: { start: "2026-01-09", end: "2026-01-11" } },
+    panels: [{ id: "main" }],
+    series: [["BTC-USD", "CCC"], ["SPY", "NYSE"]].map(([symbol, exchange]) => ({
+      id: symbol!, source: { kind: "security", instrument: { symbol: symbol!, exchange }, fieldId: "market.close" },
+      style: "line", transform: "raw", axis: "left", panelId: "main", interpolation: "none",
+    })),
+    studies: [{ id: "sma", kind: "sma", inputSeriesIds: ["BTC-USD"], parameters: { period: 2 }, panelId: "main", axis: "left" }],
+  };
+  const result = await resolveChartSpecData(spec, {
+    now: new Date("2026-01-12"),
+    dataProvider: createTestDataProvider({
+      getQuote: async symbol => ({ symbol, currency: "USD", instrumentType: symbol === "BTC-USD" ? "CRYPTOCURRENCY" : "ETF", price: history[symbol]!.at(-1)!.close, change: 0, changePercent: 0 }),
+      getTickerFinancials: async symbol => ({ annualStatements: [], quarterlyStatements: [], priceHistory: history[symbol] ?? [] }),
+      getDetailedPriceHistory: getHistory, getPriceHistory: getHistory, getPriceHistoryForResolution: getHistory,
+    }),
+    loadFredSeries: async () => ({ data: { observations: [], info: null }, fetchedAt: 0, stale: false, source: "network" as const }),
+  });
+  const crypto = result.series.find(entry => entry.id === "BTC-USD")!;
+  const average = result.series.find(entry => entry.id === "sma")!;
+  expect(crypto.timeBasis).toBeUndefined();
+  // Retaining a previous render's identical points must not discard newly
+  // established observation semantics at the identity-reuse boundary.
+  const reusedCrypto = reuseResolvedSeriesIdentity({ ...crypto, observationKind: undefined }, crypto);
+  const scene = buildCompositeChartScene(result.series.map(entry => entry.id === crypto.id ? reusedCrypto : entry), spec.panels, { width: 101, height: 20 })!;
+  const projected = scene.panels[0]!.series.find(entry => entry.source.id === "BTC-USD")!.points;
+  expect(projected.map(point => new Date(point.timestamp).toISOString())).toEqual(history["BTC-USD"]!.map(point => point.date.toISOString()));
+  for (const point of projected) {
+    expect(resolveCompositeCursorDate(scene, point.xRatio * (scene.width - 1))?.getTime()).toBe(point.timestamp);
+    expect(applyCompositeChartCursor(scene, new Date(point.timestamp)).cursorValues.find(value => value.seriesId === "BTC-USD")?.value).toBe(point.value);
+  }
+  expect(crypto.observationKind).toBe("market");
+  expect(average.observationKind).toBe("market");
+  expect(scene.panels[0]!.series.find(entry => entry.source.id === "sma")!.points.map(point => point.value)).toEqual([105, 115]);
+  const onlyCrypto = buildCompositeChartScene([crypto, average], spec.panels, { width: 101, height: 20 })!;
+  expect(onlyCrypto.timeScale.kind).toBe("calendar");
+  expect(onlyCrypto.dates.map(date => date.toISOString())).toEqual(history["BTC-USD"]!.map(point => point.date.toISOString()));
+});

--- a/src/components/chart/composite/scene.ts
+++ b/src/components/chart/composite/scene.ts
@@ -437,6 +437,8 @@ function attachLastPriceMarker(
   const projected = panel?.series.find((entry) => entry.source.id === primary.id);
   const domain = panel?.axes[primary.axis];
   if (!panel || !projected || !domain) return;
+  // A rejected latest bar does not turn the preceding close into a current price.
+  if (normalizedSourcePoints(primary).at(-1)?.point.provenance?.priceHistoryIntegrity) return;
   const value = lastCloseOf(projected.points);
   if (value === null) return;
   const yRatio = projectCompositeValue(value, domain);
@@ -492,6 +494,11 @@ function buildCursorValues(
   const cursorTime = cursorDate?.getTime() ?? viewport.endTime;
   return panels.flatMap((panel) => panel.series.map((entry) => {
     let projected = cursorPointForSeries(entry, cursorTime);
+    const integrityGap = normalizedSourcePoints(entry.source).findLast(({ timestamp, point }) => (
+      timestamp <= cursorTime && timestamp > (projected?.timestamp ?? Number.NEGATIVE_INFINITY)
+      && point.provenance?.priceHistoryIntegrity
+    ));
+    if (integrityGap) projected = null;
     // The drawn navigation buffer can include observations after the chosen
     // end. An unarmed legend describes the active window, including when the
     // pointer leaves; explicitly inspected cursor dates keep their own behavior.
@@ -502,7 +509,7 @@ function buildCursorValues(
       color: entry.source.color,
       unit: entry.source.unit,
       value: projected?.value ?? null,
-      point: projected?.point ?? null,
+      point: projected?.point ?? integrityGap?.point ?? null,
     };
   }));
 }
@@ -540,7 +547,9 @@ export function buildCompositeChartScene(
   const dataSeries = series.filter((entry) => normalizedPoints(entry).length > 0);
   if (dataSeries.length === 0) return null;
 
-  const times = dataSeries.flatMap((entry) => normalizedPoints(entry).map((point) => point.timestamp));
+  const times = dataSeries.flatMap((entry) => normalizedSourcePoints(entry)
+    .filter(({ value, point }) => value !== null || point.provenance?.priceHistoryIntegrity)
+    .map((point) => point.timestamp));
   const uniqueTimes = [...new Set(times)].sort((left, right) => left - right);
   if (uniqueTimes.length === 0) return null;
   const firstTime = uniqueTimes[0]!;

--- a/src/components/chart/composite/scene.ts
+++ b/src/components/chart/composite/scene.ts
@@ -39,6 +39,10 @@ function pointTime(point: TimeSeriesPoint): number | null {
   return Number.isFinite(time) ? time : null;
 }
 
+function isMarketObservationSeries(series: ResolvedSeries): boolean {
+  return series.observationKind === "market" || series.timeBasis?.kind === "market";
+}
+
 function pointTimestampForScale(
   series: ResolvedSeries,
   point: TimeSeriesPoint,
@@ -46,7 +50,7 @@ function pointTimestampForScale(
 ): number | null {
   const timestamp = pointTime(point);
   if (timestamp === null) return null;
-  return timeScale?.kind === "market" && !series.timeBasis
+  return timeScale?.kind === "market" && !isMarketObservationSeries(series)
     ? effectiveTimeSeriesPointTime(point)
     : timestamp;
 }
@@ -96,7 +100,7 @@ function normalizedSourcePoints(
   series: ResolvedSeries,
   timeScale?: CompositeTimeScale,
 ): NormalizedSourcePoint[] {
-  const effectiveTimes = timeScale?.kind === "market" && !series.timeBasis;
+  const effectiveTimes = timeScale?.kind === "market" && !isMarketObservationSeries(series);
   const last = series.points[series.points.length - 1];
   const lastTimestamp = last ? pointTime(last) : null;
   const lastValue = last ? resolveTimeSeriesPointValue(last) : null;
@@ -157,7 +161,7 @@ function scopeSeriesToViewport(
   clipToViewport: boolean,
 ): ResolvedSeries | null {
   const points = normalizedSourcePoints(series, timeScale);
-  const placement = timeScale.kind === "market" && !series.timeBasis
+  const placement = timeScale.kind === "market" && !isMarketObservationSeries(series)
     ? "next-market-slot" as const
     : "timestamp" as const;
   const visible = points.filter(({ timestamp }) => {
@@ -342,7 +346,7 @@ function projectSeries(
 ): CompositeProjectedPoint[] {
   const projected: CompositeProjectedPoint[] = [];
   let breakBefore = true;
-  const placement = timeScale.kind === "market" && !series.timeBasis
+  const placement = timeScale.kind === "market" && !isMarketObservationSeries(series)
     ? "next-market-slot" as const
     : "timestamp" as const;
   const stepSeries = series.interpolation === "step-after" || series.style === "step";
@@ -572,9 +576,17 @@ export function buildCompositeChartScene(
     : scopedSeries;
   const visibleTimes = uniqueTimes.filter((time) => time >= startTime && time <= plotEndTime);
   const marketTimes = timeScale.kind === "market"
-    ? timeScale.anchors
-      .map(({ timestamp }) => timestamp)
+    // The first market controls session spacing, but every plotted market
+    // observation must remain inspectable. Other exchanges can trade before
+    // or after its anchors. Nonmarket source dates stay excluded: filings
+    // retain their availability-based placement on eligible market slots.
+    ? [...new Set([
+      ...timeScale.anchors.map(({ timestamp }) => timestamp),
+      ...scopedSeries.filter(isMarketObservationSeries)
+        .flatMap((entry) => normalizedPoints(entry).map(({ timestamp }) => timestamp)),
+    ])]
       .filter((time) => time >= startTime && time <= plotEndTime)
+      .sort((left, right) => left - right)
     : [];
   const cursorTimes = timeScale.kind === "market" ? marketTimes : visibleTimes;
   const dates = (cursorTimes.length > 0

--- a/src/components/chart/composite/scene.ts
+++ b/src/components/chart/composite/scene.ts
@@ -592,7 +592,9 @@ export function buildCompositeChartScene(
     ? [...new Set([
       ...timeScale.anchors.map(({ timestamp }) => timestamp),
       ...scopedSeries.filter(isMarketObservationSeries)
-        .flatMap((entry) => normalizedPoints(entry).map(({ timestamp }) => timestamp)),
+        .flatMap((entry) => normalizedSourcePoints(entry)
+          .filter(({ value, point }) => value !== null || point.provenance?.priceHistoryIntegrity)
+          .map(({ timestamp }) => timestamp)),
     ])]
       .filter((time) => time >= startTime && time <= plotEndTime)
       .sort((left, right) => left - right)

--- a/src/components/price-performance.tsx
+++ b/src/components/price-performance.tsx
@@ -15,7 +15,7 @@ function returnValueColor(value: number | null): string {
 }
 
 function hasAnyReturn(fields: readonly PriceReturnField[]): boolean {
-  return fields.some((field) => field.value != null);
+  return fields.some((field) => field.value != null || field.unavailableReason);
 }
 
 function chunkFields<T>(fields: readonly T[], size: number): T[][] {

--- a/src/market-data/performance.ts
+++ b/src/market-data/performance.ts
@@ -1,4 +1,5 @@
 import type { PricePoint, Quote } from "../types/financials";
+import { pricePointIntegrity } from "../utils/price-history-integrity";
 
 export interface PriceReturnHorizon {
   id: string;
@@ -11,6 +12,7 @@ export interface PriceReturnField {
   id: string;
   label: string;
   value: number | null;
+  unavailableReason?: "inconsistent-ohlc";
 }
 
 export const PRICE_RETURN_HORIZONS: PriceReturnHorizon[] = [
@@ -31,7 +33,7 @@ function normalizePriceReturnHistory(points: readonly PricePoint[]): PricePoint[
   const byTimestamp = new Map<number, PricePoint>();
   for (const point of points) {
     const date = coercePointDate(point.date as Date | string | number);
-    if (!date || !Number.isFinite(point.close)) continue;
+    if (!date || (!Number.isFinite(point.close) && !pricePointIntegrity(point))) continue;
     byTimestamp.set(date.getTime(), { ...point, date });
   }
   return [...byTimestamp.entries()]
@@ -77,8 +79,18 @@ export function computePriceReturnForHorizon(
   points: readonly PricePoint[],
   horizon: PriceReturnHorizon,
 ): number | null {
+  return priceReturnForHorizon(points, horizon).value;
+}
+
+function priceReturnForHorizon(
+  points: readonly PricePoint[],
+  horizon: PriceReturnHorizon,
+): Pick<PriceReturnField, "value" | "unavailableReason"> {
   const history = normalizePriceReturnHistory(points);
-  if (history.length < 2) return null;
+  if (history.length < 2) return {
+    value: null,
+    ...(history.some(pricePointIntegrity) ? { unavailableReason: "inconsistent-ohlc" as const } : {}),
+  };
 
   const latest = history.at(-1)!;
   const cutoff = subtractHorizon(latest.date, horizon);
@@ -92,9 +104,12 @@ export function computePriceReturnForHorizon(
     }
   }
 
-  if (!baseline || !Number.isFinite(baseline.close) || baseline.close === 0) return null;
-  if (!Number.isFinite(latest.close)) return null;
-  return (latest.close - baseline.close) / baseline.close;
+  if (history.some((point) => point.date >= (baseline?.date ?? cutoff) && pricePointIntegrity(point))) {
+    return { value: null, unavailableReason: "inconsistent-ohlc" };
+  }
+  if (!baseline || !Number.isFinite(baseline.close) || baseline.close === 0) return { value: null };
+  if (!Number.isFinite(latest.close)) return { value: null };
+  return { value: (latest.close - baseline.close) / baseline.close };
 }
 
 export function buildPriceReturnFields(
@@ -104,6 +119,6 @@ export function buildPriceReturnFields(
   return horizons.map((horizon) => ({
     id: horizon.id,
     label: horizon.label,
-    value: computePriceReturnForHorizon(points, horizon),
+    ...priceReturnForHorizon(points, horizon),
   }));
 }

--- a/src/plugins/builtin/chart-composer/headless.ts
+++ b/src/plugins/builtin/chart-composer/headless.ts
@@ -1,6 +1,7 @@
 import { financialPeriodCoverage } from "../../../time-series/financial-period-coverage";
 import { FINANCIAL_VINTAGE_NOTICE, SEC_EPS_BASIS_NOTICE } from "../../../utils/financial-statements";
 import { graphRowsForFinancials, summarizeResolvedSeries } from "../../../time-series/reporting";
+import { priceHistoryIntegrityNotices } from "../../../time-series/market";
 import type { HeadlessPaneContext, HeadlessPaneDefinition, HeadlessSeriesResult } from "../../../types/headless";
 import type { ChartResolutionResult, ChartSeriesSpec, ChartSpec } from "../../../time-series/types";
 import { mergePriceHistoryWindows, resolveChartSpecData } from "../../../time-series/resolve";
@@ -69,6 +70,7 @@ export async function loadChartPaneModel(
   spec = { ...spec, series: spec.series.map((series) => resolvedSeries.get(series.id) ?? series) };
   const ids = new Set(spec.series.map((series) => series.id));
   const periodCoverage = financialPeriodCoverage(spec, chart.series);
+  const integrityNotices = priceHistoryIntegrityNotices(chart.series);
   return {
     chart,
     spec,
@@ -76,6 +78,7 @@ export async function loadChartPaneModel(
       complete: periodCoverage.every((entry) => entry.complete),
       stats: periodCoverage.map((entry) => ({ label: `${entry.label} observations`, value: `${entry.returned}/${entry.requested} ${entry.period}${entry.complete ? "" : " (partial)"}` })),
     } : {}),
+    ...(integrityNotices.length ? { complete: false } : {}),
     snapshot: {
       financials: [...financials].map(([key, data]) => [key, { ...data, priceHistory: histories.get(key) ?? data.priceHistory }]),
       intradayHistories: [],
@@ -112,7 +115,7 @@ export async function loadChartPaneModel(
     metadata: {
       viewport: spec.viewport, panels: spec.panels, warnings: chart.warnings,
       ...(periodCoverage.length ? { periodCoverage } : {}),
-      notices: chart.warnings.filter((warning) => warning === FINANCIAL_VINTAGE_NOTICE || warning === SEC_EPS_BASIS_NOTICE || warning === chart.priceComparison?.notice),
+      notices: [...chart.warnings.filter((warning) => warning === FINANCIAL_VINTAGE_NOTICE || warning === SEC_EPS_BASIS_NOTICE || warning === chart.priceComparison?.notice), ...integrityNotices],
       priceComparison: chart.priceComparison ?? null,
       summaries: chart.series.map((series) => ({ id: series.id, ...summarizeResolvedSeries(series) })),
     },

--- a/src/plugins/builtin/chart-composer/headless.ts
+++ b/src/plugins/builtin/chart-composer/headless.ts
@@ -1,7 +1,7 @@
 import { financialPeriodCoverage } from "../../../time-series/financial-period-coverage";
 import { FINANCIAL_VINTAGE_NOTICE, SEC_EPS_BASIS_NOTICE } from "../../../utils/financial-statements";
 import { graphRowsForFinancials, summarizeResolvedSeries } from "../../../time-series/reporting";
-import { priceHistoryIntegrityNotices } from "../../../time-series/market";
+import { priceHistoryIntegrityNotices, chartPriceHistoryIntegrityNotices } from "../../../time-series/market";
 import type { HeadlessPaneContext, HeadlessPaneDefinition, HeadlessSeriesResult } from "../../../types/headless";
 import type { ChartResolutionResult, ChartSeriesSpec, ChartSpec } from "../../../time-series/types";
 import { mergePriceHistoryWindows, resolveChartSpecData } from "../../../time-series/resolve";
@@ -70,7 +70,8 @@ export async function loadChartPaneModel(
   spec = { ...spec, series: spec.series.map((series) => resolvedSeries.get(series.id) ?? series) };
   const ids = new Set(spec.series.map((series) => series.id));
   const periodCoverage = financialPeriodCoverage(spec, chart.series);
-  const integrityNotices = priceHistoryIntegrityNotices(chart.series);
+  const integrityNotices = chart.priceHistoryIntegrity
+    ? chartPriceHistoryIntegrityNotices(chart.priceHistoryIntegrity) : priceHistoryIntegrityNotices(chart.series);
   return {
     chart,
     spec,
@@ -114,6 +115,7 @@ export async function loadChartPaneModel(
     }),
     metadata: {
       viewport: spec.viewport, panels: spec.panels, warnings: chart.warnings,
+      ...(chart.priceHistoryIntegrity?.length ? { priceHistoryIntegrity: chart.priceHistoryIntegrity } : {}),
       ...(periodCoverage.length ? { periodCoverage } : {}),
       notices: [...chart.warnings.filter((warning) => warning === FINANCIAL_VINTAGE_NOTICE || warning === SEC_EPS_BASIS_NOTICE || warning === chart.priceComparison?.notice), ...integrityNotices],
       priceComparison: chart.priceComparison ?? null,

--- a/src/plugins/builtin/correlation/headless.test.ts
+++ b/src/plugins/builtin/correlation/headless.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/headless";
 import { createTestDataProvider } from "../../../test-support/data-provider";
 import { correlationHeadless, relationshipHeadless } from "./headless";
+import { buildCorrelationMatrix, buildCorrelationSeries, buildStatusSummary, pairKey } from "./matrix/model";
 
 function args(symbols: string[]): HeadlessPaneLoadArgs {
   return { symbols, argument: symbols, rawArgument: symbols.join(","), options: { range: "ALL", rangePreset: "1Y", correlationWindow: 5 } };
@@ -68,4 +69,45 @@ test("rolling correlation waits for the entire selected observation window", asy
   expect(result.series[1]!.points).toHaveLength(0);
   expect(result.metadata).toMatchObject({ latestCorrelation: null, returnCount: 6 });
   expect(result.stats?.find((stat) => stat.key === "beta")?.value).toBeCloseTo(1);
+});
+
+
+test("inconsistent OHLC quarantines risk windows, retains original diagnostics and leaves independent pairs usable", async () => {
+  const ctx = context();
+  const cleanHistory = await ctx.marketData.getPriceHistory("SPY", "", "1Y");
+  // Captured SPY contradiction: reported open exceeds reported high.
+  const corrupt = { ...cleanHistory[3]!, open: 764.0800, high: 758.555, low: 757.570, close: 758.150, volume: 3461376 };
+  const history = cleanHistory.map((point, index) => index === 3 ? corrupt : point);
+  ctx.marketData = createTestDataProvider({ getPriceHistory: async (symbol) => symbol === "SPY" ? history : cleanHistory });
+  const bySymbol = new Map([
+    ["ABC", buildCorrelationSeries("ABC", cleanHistory)],
+    ["SPY", buildCorrelationSeries("SPY", history)],
+    ["CONSTANT", buildCorrelationSeries("CONSTANT", cleanHistory.map(point => ({ ...point, close: 100 })))],
+  ]);
+  const matrix = buildCorrelationMatrix([...bySymbol.keys()], bySymbol);
+  expect(matrix.results.get(pairKey("ABC", "ABC"))?.correlation).toBeCloseTo(1);
+  expect(matrix.results.get(pairKey("SPY", "SPY"))?.correlation).toBeNull();
+  expect(matrix.results.get(pairKey("CONSTANT", "CONSTANT"))?.correlation).toBeNull();
+  expect(matrix.hasThinPair).toBe(false);
+  expect(buildStatusSummary([...bySymbol.keys()], bySymbol, matrix.sampleMin, matrix.sampleMax, matrix.hasThinPair)).toContain("Inconsistent OHLC: SPY");
+  const result = await correlationHeadless.load(args(["ABC", "DEF", "SPY"]), ctx);
+  expect(result.rows[0]!.correlation).toBeCloseTo(1);
+  expect(result.rows.slice(1).every((row) => row.correlation === null && row.sampleSize === 0)).toBe(true);
+  expect(result.unavailableSymbols).toEqual(["SPY"]);
+  expect(result.errors?.every((error) => error.includes("Inconsistent OHLC"))).toBe(true);
+  expect(result.metadata?.availability).toEqual(expect.arrayContaining([expect.objectContaining({
+    symbol: "SPY", status: "invalid", integrity: [expect.objectContaining({ sourcePoints: [expect.objectContaining({ open: 764.0800, high: 758.555, close: 758.150 })] })],
+  })]));
+  const relationship = await relationshipHeadless.load(args(["ABC", "SPY"]), ctx);
+  expect(relationship.series.every((series) => series.points.length === 0)).toBe(true);
+  expect(relationship.stats?.filter((stat) => stat.key !== "returnCount").every((stat) => stat.value === null)).toBe(true);
+  expect(relationship.unavailableSymbols).toEqual(["SPY"]);
+  expect(relationship.errors).toEqual([expect.stringContaining("Inconsistent OHLC")]);
+  expect(relationship.metadata?.integrity).toMatchObject({ right: [{ sourcePoints: [expect.objectContaining({ close: corrupt.close })] }] });
+  expect(history[3]).toBe(corrupt);
+  expect(history[3]!.open).toBe(764.0800);
+  ctx.marketData = createTestDataProvider({ getPriceHistory: async () => cleanHistory });
+  const recovered = await relationshipHeadless.load(args(["ABC", "SPY"]), ctx);
+  expect(recovered.stats?.find((stat) => stat.key === "rSquared")?.value).toBeCloseTo(1);
+  expect(recovered.errors).toEqual([]);
 });

--- a/src/plugins/builtin/correlation/headless.ts
+++ b/src/plugins/builtin/correlation/headless.ts
@@ -28,7 +28,9 @@ export const correlationHeadless: HeadlessPaneDefinition<"rows"> = {
     if (!unavailableSymbols.length && rows.every((row) => row.correlation == null)) unavailableSymbols.push(...symbols);
     const unavailablePairs = rows.filter((row) => row.correlation == null).map((row) => ({
       left: row.left, right: row.right, sampleSize: row.sampleSize,
-      reason: row.sampleSize < 5 ? "Insufficient shared return observations" : "Zero return variance",
+      reason: bySymbol.get(row.left as string)?.status === "invalid" || bySymbol.get(row.right as string)?.status === "invalid"
+        ? "Inconsistent OHLC history"
+        : row.sampleSize < 5 ? "Insufficient shared return observations" : "Zero return variance",
     }));
     return {
       rows, unavailableSymbols,
@@ -42,6 +44,7 @@ export const correlationHeadless: HeadlessPaneDefinition<"rows"> = {
         returnAlignment: "Local-price close-to-close returns between shared UTC dates; no FX conversion, and exchange closing times may differ.",
         availability: symbols.map((symbol) => ({
           symbol, status: bySymbol.get(symbol)?.status ?? "error", observationCount: bySymbol.get(symbol)?.observationCount ?? 0,
+          ...(bySymbol.get(symbol)?.integrity ? { integrity: bySymbol.get(symbol)!.integrity } : {}),
           firstDate: bySymbol.get(symbol)?.prices.at(0)?.dateKey ?? null,
           lastDate: bySymbol.get(symbol)?.prices.at(-1)?.dateKey ?? null,
         })),
@@ -64,6 +67,8 @@ export const relationshipHeadless: HeadlessPaneDefinition<"series"> = {
     const unavailableSymbols = symbols.filter((symbol) => (histories.get(symbol) ?? []).filter((point) => (
       Number.isFinite(point.close) && point.close > 0 && Number.isFinite(new Date(point.date).getTime())
     )).length < 2);
+    if (analysis.integrity?.left.length) unavailableSymbols.push(symbols[0]!);
+    if (analysis.integrity?.right.length) unavailableSymbols.push(symbols[1]!);
     if (!unavailableSymbols.length && !analysis.returns.length) unavailableSymbols.push(...symbols);
     return {
       symbols,
@@ -81,9 +86,10 @@ export const relationshipHeadless: HeadlessPaneDefinition<"series"> = {
         { key: "returnCount", label: "Shared returns", value: analysis.stats?.sampleSize ?? analysis.returns.length },
       ],
       unavailableSymbols: [...new Set(unavailableSymbols)],
-      errors: loaded.errors,
+      errors: [...loaded.errors, ...(analysis.unavailableReason ? [analysis.unavailableReason] : [])],
       metadata: {
         left: symbols[0], right: symbols[1], range, correlationWindow,
+        ...(analysis.integrity ? { integrity: analysis.integrity } : {}),
         latestRatio: analysis.latestRatio, latestCorrelation: analysis.latestCorrelation,
         regression: analysis.stats, alignedPriceCount: analysis.aligned.length, returnCount: analysis.returns.length,
       },

--- a/src/plugins/builtin/correlation/index.tsx
+++ b/src/plugins/builtin/correlation/index.tsx
@@ -230,15 +230,9 @@ function CorrelationMatrixPane({ focused, width, height }: PaneProps) {
               </Box>
               {/* Cells */}
               {symbols.map((colSym) => {
-                const isDiag = rowSym === colSym;
-                let r: number | null = null;
-                if (isDiag) {
-                  r = 1;
-                } else {
-                  r = matrix.results.get(pairKey(rowSym, colSym))?.correlation ?? null;
-                }
+                const r = matrix.results.get(pairKey(rowSym, colSym))?.correlation ?? null;
                 const cellColors = resolveCorrelationHeatmapCellColors(r);
-                const text = isDiag ? " 1.00" : formatCorrelation(r);
+                const text = formatCorrelation(r);
                 return (
                   <Box
                     key={colSym}

--- a/src/plugins/builtin/correlation/matrix/model.ts
+++ b/src/plugins/builtin/correlation/matrix/model.ts
@@ -153,7 +153,7 @@ export function buildStatusSummary(
 
   if (sampleMin != null && sampleMax != null) {
     parts.push(sampleMin === sampleMax ? `obs ${sampleMin}` : `obs ${sampleMin}-${sampleMax}`);
-  } else if (symbols.length >= 2) {
+  } else if (symbols.length >= 2 && invalid.length === 0) {
     parts.push("No paired dates yet");
   }
 

--- a/src/plugins/builtin/correlation/matrix/model.ts
+++ b/src/plugins/builtin/correlation/matrix/model.ts
@@ -1,3 +1,4 @@
+import { pricePointIntegrity, type PriceHistoryIntegrity } from "../../../../utils/price-history-integrity";
 import type { QueryEntry } from "../../../../market-data/result-types";
 import { colors } from "../../../../theme/colors";
 import type { PricePoint } from "../../../../types/financials";
@@ -9,13 +10,14 @@ export const MATRIX_CELL_WIDTH = 10;
 export const MIN_MATRIX_CELL_WIDTH = 7;
 const MIN_CORRELATION_OBSERVATIONS = 5;
 
-export type SeriesStatus = "loading" | "ready" | "insufficient" | "empty" | "error";
+export type SeriesStatus = "loading" | "ready" | "insufficient" | "empty" | "error" | "invalid";
 
 export interface CorrelationSeries {
   symbol: string;
   prices: DailyClose[];
   status: SeriesStatus;
   observationCount: number;
+  integrity?: PriceHistoryIntegrity[];
 }
 
 export function displaySymbol(symbol: string): string {
@@ -63,6 +65,8 @@ export function getSeriesForEntry(
 }
 
 export function buildCorrelationSeries(symbol: string, history: readonly PricePoint[]): CorrelationSeries {
+  const integrity = history.flatMap((point) => { const issue = pricePointIntegrity(point); return issue ? [issue] : []; });
+  if (integrity.length) return { symbol, prices: [], observationCount: 0, status: "invalid", integrity };
   const prices = dailyCloses(history);
   const observationCount = Math.max(0, prices.length - 1);
   return {
@@ -75,6 +79,7 @@ export function rowHeaderColor(status: SeriesStatus): string {
   switch (status) {
     case "loading":
       return colors.textDim;
+    case "invalid":
     case "error":
     case "empty":
       return colors.negative;
@@ -100,7 +105,6 @@ export function buildCorrelationMatrix(
 
   for (let rowIndex = 0; rowIndex < symbols.length; rowIndex++) {
     for (let colIndex = 0; colIndex < symbols.length; colIndex++) {
-      if (rowIndex === colIndex) continue;
       const rowSym = symbols[rowIndex]!;
       const colSym = symbols[colIndex]!;
       const rowSeries = seriesBySymbol.get(rowSym);
@@ -111,7 +115,8 @@ export function buildCorrelationMatrix(
       results.set(pairKey(rowSym, colSym), result);
       if (rowIndex < colIndex) {
         if (result.sampleSize > 0) sampleSizes.push(result.sampleSize);
-        if (result.correlation == null && result.sampleSize < MIN_CORRELATION_OBSERVATIONS) {
+        if (rowSeries?.status !== "invalid" && colSeries?.status !== "invalid"
+          && result.correlation == null && result.sampleSize < MIN_CORRELATION_OBSERVATIONS) {
           hasThinPair = true;
         }
       }
@@ -139,7 +144,9 @@ export function buildStatusSummary(
   const loading = byStatus("loading");
   const errors = [...byStatus("error"), ...byStatus("empty")];
   const insufficient = byStatus("insufficient");
+  const invalid = byStatus("invalid");
 
+  if (invalid.length > 0) parts.push(`Inconsistent OHLC: ${formatSeriesSymbolList(invalid, seriesBySymbol)}`);
   if (loading.length > 0) parts.push(`Loading: ${formatSeriesSymbolList(loading, seriesBySymbol)}`);
   if (errors.length > 0) parts.push(`No data: ${formatSeriesSymbolList(errors, seriesBySymbol)}`);
   if (insufficient.length > 0) parts.push(`Need history: ${formatSeriesSymbolList(insufficient, seriesBySymbol, true)}`);

--- a/src/plugins/builtin/correlation/relationship/model.ts
+++ b/src/plugins/builtin/correlation/relationship/model.ts
@@ -1,3 +1,4 @@
+import { pricePointIntegrity, type PriceHistoryIntegrity } from "../../../../utils/price-history-integrity";
 import type { ProjectedChartPoint } from "../../../../components/chart/core/data";
 import type { TimeRange } from "../../../../components/chart/core/types";
 import type { ScatterChartPoint } from "../../../../components/chart/static";
@@ -39,6 +40,8 @@ export interface RelationshipRegressionStats {
 }
 
 export interface RelationshipAnalysis {
+  unavailableReason?: string;
+  integrity?: { left: PriceHistoryIntegrity[]; right: PriceHistoryIntegrity[] };
   aligned: RelationshipAlignedPoint[];
   returns: RelationshipReturnPoint[];
   ratioPoints: ProjectedChartPoint[];
@@ -149,6 +152,15 @@ export function buildRelationshipAnalysis(
   rightPoints: PricePoint[],
   correlationWindow = DEFAULT_RELATIONSHIP_CORRELATION_WINDOW,
 ): RelationshipAnalysis {
+  const issues = (points: PricePoint[]) => points.flatMap((point) => {
+    const issue = pricePointIntegrity(point); return issue ? [issue] : [];
+  });
+  const integrity = { left: issues(leftPoints), right: issues(rightPoints) };
+  if (integrity.left.length || integrity.right.length) return {
+    aligned: [], returns: [], ratioPoints: [], correlationPoints: [], scatterPoints: [],
+    stats: null, latestRatio: null, latestCorrelation: null, integrity,
+    unavailableReason: "Inconsistent OHLC history; relationship calculations are unavailable for this window.",
+  };
   const aligned = alignRelationshipPrices(leftPoints, rightPoints);
   const returns = buildRelationshipReturns(aligned);
   const correlationPoints = buildRollingCorrelationPoints(returns, correlationWindow);

--- a/src/plugins/builtin/correlation/relationship/pane.tsx
+++ b/src/plugins/builtin/correlation/relationship/pane.tsx
@@ -222,7 +222,7 @@ export function RelationshipGraphPane({ focused, width, height }: PaneProps) {
       { id: "summary", parts: [{ text: footerSummary, tone: "muted" as const }] },
       ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
       ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
-      ...(!loading && analysis && analysis.returns.length < correlationWindow
+      ...(!loading && analysis && !analysis.unavailableReason && analysis.returns.length < correlationWindow
         ? [{ id: "correlation-history", parts: [{ text: `Correlation needs ${correlationWindow} shared returns; ${analysis.returns.length} available`, tone: "warning" as const }] }]
         : []),
     ],
@@ -252,7 +252,7 @@ export function RelationshipGraphPane({ focused, width, height }: PaneProps) {
 
   if (!analysis || analysis.aligned.length < 2) {
     return (
-      <PaneStatusBody loading={loading} error={loading ? null : error} subject="relationship history" empty emptyTitle="No overlapping price history." />
+      <PaneStatusBody loading={loading} error={loading ? null : analysis?.unavailableReason ?? error} subject="relationship history" empty emptyTitle="No overlapping price history." />
     );
   }
 

--- a/src/plugins/builtin/dividend-yield/client.test.ts
+++ b/src/plugins/builtin/dividend-yield/client.test.ts
@@ -88,7 +88,7 @@ describe("cash distribution calculations", () => {
       requested.push(sourceSymbol);
       if (sourceSymbol !== expected) return Response.json({ chart: { result: [] }, quoteSummary: { result: [] } });
       if (url.includes("/chart/")) return Response.json({ chart: { result: [{
-        meta: { symbol: expected, currency, regularMarketPrice: 100 }, timestamp: [timestamp],
+        meta: { symbol: expected, currency, regularMarketPrice: 100, dataGranularity: "1mo" }, timestamp: [timestamp],
         indicators: { quote: [{ close: [100] }] }, events: { dividends: { [timestamp]: { date: timestamp, amount } } },
       }] } });
       return Response.json({ quoteSummary: { result: [{ summaryDetail: { currency } }] } });
@@ -143,7 +143,7 @@ describe("cash distribution calculations", () => {
       if (url.includes("fc.yahoo.com")) return new Response("", { headers: { "set-cookie": "test=fixture" } });
       if (url.includes("getcrumb")) return new Response("fixture-crumb");
       if (url.includes("/chart/")) return Response.json({ chart: { result: [{
-        meta: { currency: "EUR", regularMarketPrice: 80 }, timestamp: [timestamp],
+        meta: { currency: "EUR", regularMarketPrice: 80, dataGranularity: "1mo" }, timestamp: [timestamp],
         indicators: { quote: [{ close: [80] }] }, events: { dividends: { [timestamp]: { date: timestamp, amount: 4 } } },
       }] } });
       if (url.includes("/quoteSummary/")) return Response.json({ quoteSummary: { result: [{ summaryDetail: { currency: "EUR" } }] } });

--- a/src/plugins/builtin/ticker-detail/data-panes/historical-prices.tsx
+++ b/src/plugins/builtin/ticker-detail/data-panes/historical-prices.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 import { TextAttributes } from "../../../../ui";
 import {
   DataTableView,
+  Notice,
   loadingText,
   unavailableText,
   usePaneFooter,
@@ -15,6 +16,7 @@ import type { PricePoint } from "../../../../types/financials";
 import { colors, priceColor } from "../../../../theme/colors";
 import { formatCompact, formatPercent } from "../../../../utils/format";
 import { formatMarketPrice } from "../../../../market-data/market/format";
+import { pricePointValues, priceHistoryIntegrityNotice } from "../../../../utils/price-history-integrity";
 import {
   useAssetData,
   useDebouncedPluginPaneState,
@@ -28,7 +30,7 @@ type HistoryColumn = DataTableColumn & { id: HistoryColumnId };
 
 export type HistoricalPriceRow = {
   key: string;
-  point: PricePoint;
+  point: ReturnType<typeof pricePointValues>;
   date: string;
   change: number | null;
   changePercent: number | null;
@@ -49,7 +51,7 @@ function formatMaybePercent(value: number | null): string {
   return value == null ? "-" : formatPercent(value);
 }
 
-function formatMaybeCompact(value: number | undefined): string {
+function formatMaybeCompact(value: number | null | undefined): string {
   return value == null ? "-" : formatCompact(value);
 }
 
@@ -57,19 +59,19 @@ export function buildHistoricalPriceRows(points: PricePoint[]): HistoricalPriceR
   const sorted = points
     .flatMap((point, sourceIndex) => {
       const date = pricePointDate(point);
-      return date ? [{ point, date, sourceIndex }] : [];
+      return date ? [{ point: pricePointValues(point), date, sourceIndex }] : [];
     })
     .sort((left, right) => left.date.getTime() - right.date.getTime());
   return sorted.map((entry, index) => {
     const previous = sorted[index - 1]?.point;
     const { point, date, sourceIndex } = entry;
-    const change = previous ? point.close - previous.close : null;
+    const change = previous?.close != null && point.close != null ? point.close - previous.close : null;
     return {
       key: `${date.toISOString()}:${sourceIndex}`,
       point,
       date: formatDateTime(date),
       change,
-      changePercent: previous?.close ? change! / previous.close : null,
+      changePercent: previous?.close && change !== null ? change / previous.close : null,
     };
   }).reverse();
 }
@@ -113,6 +115,7 @@ export function HistoricalPricesPane({ focused, width, height }: PaneProps) {
   }, [dataProvider, range]);
   const { data, loading, error, reload } = useTickerRequest<PricePoint[]>(loader, symbol, exchange);
   const rows = useMemo(() => buildHistoricalPriceRows(data ?? []), [data]);
+  const integrityNotice = priceHistoryIntegrityNotice(rows.filter((row) => row.point.integrity).length);
   const columns = useMemo(() => buildHistoryColumns(width), [width]);
   const boundedSelectedIdx = rows.length > 0 ? Math.min(selectedIdx, rows.length - 1) : -1;
   const cycleRange = useCallback(() => setRange((current) => nextHistoryRange(current)), [setRange]);
@@ -181,6 +184,7 @@ export function HistoricalPricesPane({ focused, width, height }: PaneProps) {
       onRootKeyDown={handleKeyDown}
       rootWidth={width}
       rootHeight={height}
+      rootBefore={integrityNotice ? <Notice>{integrityNotice}</Notice> : undefined}
       columns={columns}
       items={rows}
       sortColumnId={null}

--- a/src/plugins/builtin/ticker-detail/headless.ts
+++ b/src/plugins/builtin/ticker-detail/headless.ts
@@ -3,6 +3,7 @@ import type { HeadlessPaneColumn, HeadlessPaneDefinition } from "../../../types/
 import type { TimeRange } from "../../../time-series/range";
 import { formatCurrency, formatNumber, formatPercentRaw } from "../../../utils/format";
 import { formatMarketPrice } from "../../../market-data/market/format";
+import { pricePointValues, priceHistoryIntegrityNotice } from "../../../utils/price-history-integrity";
 import { buildFinancialTableModel, financialStatementCurrency, financialStatementDateNotice, financialStatementLimitations, formatFinancialHeader } from "./financials/model";
 import { paneSchemas } from "./headless-schema";
 import {
@@ -112,10 +113,10 @@ export const historicalPricesHeadless: HeadlessPaneDefinition<"rows"> = {
       const date = new Date(point.date);
       return {
         date: Number.isFinite(date.getTime()) ? date.toISOString() : String(point.date),
-        open: point.open ?? null, high: point.high ?? null, low: point.low ?? null,
-        close: point.close, volume: point.volume ?? null,
+        ...pricePointValues(point),
       };
     }).sort((left, right) => left.date.localeCompare(right.date));
-    return { rows, unavailableSymbols: rows.length ? [] : [symbol], metadata: { symbol, range } };
+    const notice = priceHistoryIntegrityNotice(rows.filter((row) => row.integrity).length);
+    return { rows, ...(notice ? { complete: false } : {}), unavailableSymbols: rows.some((row) => row.close !== null) ? [] : [symbol], metadata: { symbol, range, ...(notice ? { notices: [notice] } : {}) } };
   },
 };

--- a/src/plugins/builtin/ticker-detail/overview-tab.tsx
+++ b/src/plugins/builtin/ticker-detail/overview-tab.tsx
@@ -115,7 +115,7 @@ export function OverviewTab({
   const performanceFields = buildPriceReturnFields(
     appendQuoteToPriceReturnHistory(financials?.priceHistory ?? [], quote),
   ).map((field) => {
-    if (field.value != null) return field;
+    if (field.value != null || field.unavailableReason) return field;
     if (field.id === "1Y" && fundamentals?.return1Y != null) {
       return { ...field, value: fundamentals.return1Y };
     }
@@ -124,7 +124,7 @@ export function OverviewTab({
     }
     return field;
   });
-  const hasPerformance = performanceFields.some((field) => field.value != null);
+  const hasPerformance = performanceFields.some((field) => field.value != null || field.unavailableReason);
   const positionRows = buildPositionRows({
     ticker,
     quote,
@@ -239,6 +239,8 @@ export function OverviewTab({
             )}
           </Box>
         )}
+
+        {priceSeries.warning && <Notice>{priceSeries.warning}</Notice>}
 
         {hasHistory && (
           <CompositeChart

--- a/src/sources/history-coverage.test.ts
+++ b/src/sources/history-coverage.test.ts
@@ -7,7 +7,7 @@ const meta = { symbol: "SHEL.L", exchangeName: "LSE", currency: "GBp" };
 const point = (date: string, close: number) => ({ date: new Date(date), close });
 
 test("the shared Yahoo request boundary removes spanning OHLC and retains source provenance", async () => {
-  const raw = { chart: { result: [{ meta,
+  const raw = { chart: { result: [{ meta: { ...meta, dataGranularity: "1wk" },
     timestamp: [Date.parse("2005-07-18T07:00:00Z") / 1000, Date.parse("2005-07-25T07:00:00Z") / 1000],
     indicators: { quote: [{ open: [1829.5, 1764], high: [1845, 1776], low: [1720, 1701], close: [1748, 1747], volume: [42, 58] }] },
   }] } };

--- a/src/sources/provider-router/history-boundary-cache.test.ts
+++ b/src/sources/provider-router/history-boundary-cache.test.ts
@@ -14,9 +14,9 @@ test("saved JEPQ range, broader-window and detailed caches cannot retain pre-inc
     const store = new AppPersistence(createTempDbPath("jepq-boundary"));
     try {
       for (const [kind, variantKey] of [
-        ["price-history", "exchange=NASDAQ;range=ALL;version=4"],
-        ["price-history", "exchange=NASDAQ;range=ALL;resolution=1wk;version=4"],
-        ["price-history", "range=ALL;resolution=1wk;version=4"],
+        ["price-history", "exchange=NASDAQ;range=ALL;version=4;granularity=1"],
+        ["price-history", "exchange=NASDAQ;range=ALL;resolution=1wk;version=4;granularity=1"],
+        ["price-history", "range=ALL;resolution=1wk;version=4;granularity=1"],
         ["detailed-price-history", "exchange=NASDAQ;start=2000-01-01;end=2026-08-31;bar=1wk;version=4"],
       ]) store.resources.set({ namespace: "market", kind: kind!, entityKey: ticker, variantKey, sourceKey: "provider:gloomberb-cloud" }, bad, { cachePolicy: policy });
       let calls = 0;
@@ -37,10 +37,10 @@ test("saved JEPQ range, broader-window and detailed caches cannot retain pre-inc
   }
 });
 
-test("source failure cannot resurrect old JEPQ cache, while an unrelated weekly cache remains usable", async () => {
+test("source failure cannot resurrect old JEPQ cache, while an unrelated verified-cadence weekly cache remains usable", async () => {
   const store = new AppPersistence(createTempDbPath("jepq-boundary-miss"));
   try {
-    for (const ticker of ["JEPQ", "QQQ"]) store.resources.set({ namespace: "market", kind: "price-history", entityKey: ticker, variantKey: "exchange=NASDAQ;range=ALL;resolution=1wk;version=4", sourceKey: "provider:gloomberb-cloud" }, ticker === "JEPQ" ? bad : good, { cachePolicy: policy });
+    for (const ticker of ["JEPQ", "QQQ"]) store.resources.set({ namespace: "market", kind: "price-history", entityKey: ticker, variantKey: "exchange=NASDAQ;range=ALL;resolution=1wk;version=4;granularity=1", sourceKey: "provider:gloomberb-cloud" }, ticker === "JEPQ" ? bad : good, { cachePolicy: policy });
     const requested: string[] = [];
     const router = new AssetDataRouter({ ...fallbackProvider, id: "gloomberb-cloud", async getPriceHistoryForResolution(ticker) { requested.push(ticker); return []; } }, [], store.resources);
     expect(await router.getPriceHistoryForResolution("JEPQ", "NASDAQ", "ALL", "1wk")).toEqual([]);
@@ -52,7 +52,7 @@ test("source failure cannot resurrect old JEPQ cache, while an unrelated weekly 
 test("monthly cache is refreshed independently of unaffected daily and weekly variants", async () => {
   const store = new AppPersistence(createTempDbPath("monthly-calendar-cache"));
   try {
-    for (const resolution of ["1mo", "1wk", "1d"]) store.resources.set({ namespace: "market", kind: "price-history", entityKey: "QQQ", variantKey: `exchange=NASDAQ;range=ALL;resolution=${resolution};version=4`, sourceKey: "provider:gloomberb-cloud" }, good, { cachePolicy: policy });
+    for (const resolution of ["1mo", "1wk", "1d"]) store.resources.set({ namespace: "market", kind: "price-history", entityKey: "QQQ", variantKey: `exchange=NASDAQ;range=ALL;resolution=${resolution};version=4;granularity=1`, sourceKey: "provider:gloomberb-cloud" }, good, { cachePolicy: policy });
     const resolutions: string[] = [];
     const router = new AssetDataRouter({ ...fallbackProvider, id: "gloomberb-cloud", async getPriceHistoryForResolution(_ticker, _exchange, _range, resolution) { resolutions.push(resolution); return good; } }, [], store.resources);
     for (const resolution of ["1mo", "1wk", "1d"] as const) await router.getPriceHistoryForResolution("QQQ", "NASDAQ", "ALL", resolution);

--- a/src/sources/provider-router/history.test.ts
+++ b/src/sources/provider-router/history.test.ts
@@ -18,6 +18,45 @@ afterEach(() => {
 });
 
 describe("AssetDataRouter chart history", () => {
+  test("retires persisted ALL bars with unverified cadence without losing finite windows or corrected cache reuse", async () => {
+    const path = createTempDbPath("all-cadence-cache");
+    let persistence = new AppPersistence(path);
+    const policy = { staleMs: 60_000, expireMs: 60_000 };
+    const wrong = [{ date: new Date("2026-08-10"), close: 0.000004 }];
+    const corrected = [{ date: new Date("2026-08-01"), close: 0.000006 }];
+    const sourceKey = "provider:gloomberb-cloud";
+    for (const symbol of ["SHIB-USD", "OFFLINE-USD"]) {
+      persistence.resources.set({ namespace: "market", kind: "price-history", entityKey: symbol,
+        variantKey: "exchange=CCC;range=ALL;resolution=1mo;version=4;calendar=1", sourceKey }, wrong, { cachePolicy: policy });
+    }
+    persistence.resources.set({ namespace: "market", kind: "price-history", entityKey: "FINITE-USD",
+      variantKey: "exchange=CCC;range=5Y;resolution=1mo;version=4;calendar=1", sourceKey }, corrected, { cachePolicy: policy });
+    persistence.close();
+    persistence = new AppPersistence(path);
+    let calls = 0;
+    const provider: DataProvider = { ...fallbackProvider, id: "gloomberb-cloud", name: "Cloud",
+      async getPriceHistoryForResolution(symbol) {
+        calls++;
+        if (symbol !== "SHIB-USD") throw new Error("Provider temporarily unavailable");
+        return corrected;
+      } };
+    try {
+      let router = new AssetDataRouter(provider, [], persistence.resources);
+      expect((await router.getPriceHistoryForResolution("SHIB-USD", "CCC", "ALL", "1mo")).map((p) => p.close)).toEqual([0.000006]);
+      expect(calls).toBe(1);
+      // A new app instance must read the corrected record, including as a
+      // wider source buffer for a shorter window, without refetching.
+      persistence.close(); persistence = new AppPersistence(path);
+      router = new AssetDataRouter(provider, [], persistence.resources);
+      expect((await router.getPriceHistoryForResolution("SHIB-USD", "CCC", "ALL", "1mo")).map((p) => p.close)).toEqual([0.000006]);
+      expect((await router.getPriceHistoryForResolution("SHIB-USD", "CCC", "5Y", "1mo")).map((p) => p.close)).toEqual([0.000006]);
+      expect((await router.getPriceHistoryForResolution("FINITE-USD", "CCC", "5Y", "1mo")).map((p) => p.close)).toEqual([0.000006]);
+      expect(calls).toBe(1);
+      await expect(router.getPriceHistoryForResolution("OFFLINE-USD", "CCC", "ALL", "1mo")).rejects.toThrow("No resolution-aware history provider");
+      expect(calls).toBe(2);
+    } finally { persistence.close(); }
+  });
+
   test("uses requested bar cadence for fetched and cached charts and infers generic daily data", async () => {
     const originalNow = Date.now;
     Date.now = () => Date.parse("2026-09-10T19:39:09Z");
@@ -270,7 +309,7 @@ describe("AssetDataRouter chart history", () => {
       .all("market", "price-history", "FTC") as Array<{ variant_key: string }>;
     expect(cachedRows.map((row) => row.variant_key)).toEqual([
       "exchange=LSE;range=ALL;resolution=1wk",
-      "exchange=LSE;range=ALL;resolution=1wk;version=4;unit=GBP",
+      "exchange=LSE;range=ALL;resolution=1wk;version=4;granularity=1;unit=GBP",
     ]);
 
     persistence.close();

--- a/src/sources/provider-router/history.ts
+++ b/src/sources/provider-router/history.ts
@@ -75,6 +75,10 @@ function priceHistoryVariantParts(
     ["version", PRICE_HISTORY_CACHE_VERSION],
     ["inception", inceptionVersion],
     ["calendar", monthly ? 1 : undefined],
+    // Old Yahoo/cloud ALL responses could serve weekly/quarterly bars under
+    // a different requested interval. Exact and broader cache lookups must
+    // refetch these windows instead of relabeling the cached bars.
+    ["granularity", range === "ALL" ? 1 : undefined],
   ];
   return unit.divisor === 1
     ? versionedParts
@@ -101,7 +105,12 @@ function makeHistoryRequestIdentity(
   const cacheVariantKeys = [
     identity.variantKey,
     buildVariantKey(priceHistoryVariantParts(input.fallbackVariantParts, input.exchange, input.ticker)),
-  ];
+  ].flatMap((key) => {
+    // Broker and independent-provider records did not use the affected Yahoo
+    // request. Keep their old keys readable, then filter by source below.
+    const legacy = key.replace(/;granularity=1(?=;|$)/, "");
+    return legacy === key ? [key] : [key, legacy];
+  });
   return {
     target: { symbol: input.ticker, exchange: input.exchange },
     identity,
@@ -365,8 +374,14 @@ export class ProviderRouterHistoryRoutes {
       request.cacheVariantKeys,
       sourceKeys,
       false,
-    ).filter((record) => request.cachePolicyKey === "priceHistoryIntraday"
-      || !hasUnverifiedShellHistory(record.value, request.target, record.sourceKey, request.requestedStart));
+    ).filter((record) => {
+      const unverifiedAllInterval = ["provider:yahoo", "provider:gloomberb-cloud"].includes(record.sourceKey)
+        && /(?:^|;)range=ALL(?:;|$)/.test(record.variantKey)
+        && !/(?:^|;)granularity=1(?:;|$)/.test(record.variantKey);
+      if (unverifiedAllInterval) return false;
+      return request.cachePolicyKey === "priceHistoryIntraday"
+        || !hasUnverifiedShellHistory(record.value, request.target, record.sourceKey, request.requestedStart);
+    });
     const cached = cachedRecords.find((record) => record.value.length > 0) ?? cachedRecords[0] ?? null;
     const cachedValue = cached ? normalizeRequestHistory(cached.value, request) : [];
     const cachedHistoryStale = request.isCachedValueStale(cachedValue);

--- a/src/sources/provider-router/shell-history-cache.test.ts
+++ b/src/sources/provider-router/shell-history-cache.test.ts
@@ -24,9 +24,9 @@ test("saved Shell source caches recover across range, broader and detailed paths
     const corrected = good.map((point) => ({ ...point, historySource: { ...point.historySource!, provider: origin } }));
     try {
       for (const [kind, variantKey] of [
-        ["price-history", "exchange=LSE;range=ALL;version=4;calendar=1;unit=GBP"],
-        ["price-history", "exchange=LSE;range=ALL;resolution=1wk;version=4;unit=GBP"],
-        ["price-history", "range=ALL;resolution=1wk;version=4;unit=GBP"],
+        ["price-history", "exchange=LSE;range=ALL;version=4;calendar=1;granularity=1;unit=GBP"],
+        ["price-history", "exchange=LSE;range=ALL;resolution=1wk;version=4;granularity=1;unit=GBP"],
+        ["price-history", "range=ALL;resolution=1wk;version=4;granularity=1;unit=GBP"],
         ["detailed-price-history", "exchange=LSE;start=1996-01-01;end=2026-09-10;bar=1wk;version=4;unit=GBP"],
       ]) store.resources.set({ namespace: "market", kind: kind!, entityKey: ticker, variantKey, sourceKey: `provider:${id}` }, legacy, { cachePolicy: policy });
       let calls = 0;
@@ -109,14 +109,14 @@ test("legacy financial snapshots lose affected history while valid accounts and 
 });
 
 
-test("safe old filtered caches recover missing disclosure only for requested long windows", async () => {
+test("cadence-verified filtered caches recover missing disclosure only for requested long windows", async () => {
   for (const origin of ["yahoo", "twelvedata"] as const) {
     const store = new AppPersistence(createTempDbPath("shell-lineage-missing-provenance"));
     const legacy = good.map(({ historySource, ...point }) => point);
     const corrected = good.map((point) => ({ ...point, historySource: { ...point.historySource!, provider: origin } }));
     try {
       store.resources.set({ namespace: "market", kind: "price-history", entityKey: "SHEL",
-        variantKey: "exchange=LSE;range=ALL;resolution=1wk;version=4;unit=GBP", sourceKey: "provider:gloomberb-cloud" }, legacy, { cachePolicy: policy });
+        variantKey: "exchange=LSE;range=ALL;resolution=1wk;version=4;granularity=1;unit=GBP", sourceKey: "provider:gloomberb-cloud" }, legacy, { cachePolicy: policy });
       let calls = 0;
       const provider = { ...fallbackProvider, id: "gloomberb-cloud", async getPriceHistoryForResolution() { calls++; return corrected; } };
       const router = new AssetDataRouter(provider, [], store.resources);

--- a/src/sources/yahoo-finance/requests.test.ts
+++ b/src/sources/yahoo-finance/requests.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import { fetchYahooChart } from "./requests";
+import type { YahooHttpClient } from "./http";
+
+function chart(granularity: unknown) {
+  return { chart: { result: [{ meta: { symbol: "MSFT", currency: "USD", dataGranularity: granularity },
+    timestamp: [Date.parse("1965-01-01") / 1000, Date.parse("2026-08-01") / 1000],
+    indicators: { quote: [{ open: [2, 4], high: [4, 6], low: [1, 3], close: [3, 5], volume: [12, 34] }] },
+  }] } };
+}
+function http(raw: unknown, urls: URL[]) {
+  return { fetchJson: async (url: string) => { urls.push(new URL(url)); return structuredClone(raw); } } as unknown as YahooHttpClient;
+}
+
+test("native full history requests explicit bounds and retains exact prices and pre-1970 source dates", async () => {
+  const urls: URL[] = [];const raw = chart("1mo");
+  const result = await fetchYahooChart(http(raw, urls), "MSFT", "max", "1mo");
+  expect(urls[0]!.searchParams.has("range")).toBe(false);
+  expect(Number(urls[0]!.searchParams.get("period1"))).toBeLessThan(Date.parse("1965-01-01") / 1000);
+  expect(Number(urls[0]!.searchParams.get("period2"))).toBeGreaterThan(Date.now() / 1000 - 10);
+  expect(result.history.map((p) => p.date.toISOString().slice(0, 10))).toEqual(["1965-01-01", "2026-08-01"]);
+  expect(result.history.map((p) => [p.open, p.high, p.low, p.close, p.volume])).toEqual([[2, 4, 1, 3, 12], [4, 6, 3, 5, 34]]);
+  expect(raw.chart.result[0]!.indicators.quote[0]!.close).toEqual([3, 5]);
+});
+
+test("native history rejects weekly or quarterly data mislabeled as monthly, and missing cadence", async () => {
+  for (const served of ["1wk", "3mo", "1d", undefined]) {
+    await expect(fetchYahooChart(http(chart(served), []), "SHIB-USD", "max", "1mo")).rejects.toThrow("requested 1mo");
+  }
+});
+
+test("finite windows preserve range and equivalent hourly cadence is accepted", async () => {
+  const urls: URL[] = [];
+  await fetchYahooChart(http(chart("60m"), urls), "MSFT", "1mo", "1h");
+  expect(urls[0]!.searchParams.get("range")).toBe("1mo");
+  expect(urls[0]!.searchParams.has("period1")).toBe(false);
+});

--- a/src/sources/yahoo-finance/requests.ts
+++ b/src/sources/yahoo-finance/requests.ts
@@ -1,3 +1,4 @@
+import { matchesYahooChartInterval, yahooHistoryRangeParams } from "./yahoo-chart-interval";
 import type {
   CompanyProfile,
   PricePoint,
@@ -33,7 +34,7 @@ export async function fetchYahooChart(
 }> {
   const params = new URLSearchParams({
     interval,
-    range,
+    ...yahooHistoryRangeParams(range),
     includePrePost: String(includePrePost),
     events: "div,split",
   });
@@ -42,6 +43,9 @@ export async function fetchYahooChart(
   const result = data.chart?.result?.[0];
   if (!result?.timestamp?.length) {
     throw new Error(data.chart?.error?.description || `No chart data for ${symbol}`);
+  }
+  if (!matchesYahooChartInterval(interval, result.meta?.dataGranularity)) {
+    throw new Error(`Yahoo returned ${result.meta?.dataGranularity ?? "unknown"} bars for requested ${interval} history`);
   }
   const quote = result.indicators?.quote?.[0];
   if (!quote) throw new Error(`Missing indicators for ${symbol}`);

--- a/src/sources/yahoo-finance/types.ts
+++ b/src/sources/yahoo-finance/types.ts
@@ -2,6 +2,7 @@ type TradingPeriod = { start?: number; end?: number; gmtoffset?: number; timezon
 
 export type ChartResult = {
   meta?: {
+    dataGranularity?: string;
     instrumentType?: string;
     symbol?: string;
     currency?: string; longName?: string; shortName?: string;

--- a/src/sources/yahoo-finance/yahoo-chart-interval.ts
+++ b/src/sources/yahoo-finance/yahoo-chart-interval.ts
@@ -1,0 +1,18 @@
+/** Keep in sync with the backend Yahoo service's yahoo-chart-interval.ts. */
+const EARLIEST_HISTORY_SECOND = Date.parse("1900-01-01T00:00:00Z") / 1000;
+
+/** Yahoo's range=max overrides interval (for example monthly SHIB becomes
+ * weekly and monthly MSFT becomes quarterly). Explicit bounds retain the
+ * requested interval. The early bound preserves available pre-1970 history;
+ * it is a request boundary, not an assertion about an instrument's inception. */
+export function yahooHistoryRangeParams(range: string, now = Date.now()): Record<string, string> {
+  return range === "max"
+    ? { period1: String(EARLIEST_HISTORY_SECOND), period2: String(Math.floor(now / 1000)) }
+    : { range };
+}
+
+export function matchesYahooChartInterval(requested: string, served: unknown): boolean {
+  if (typeof served !== "string" || !served.trim()) return false;
+  const canonical = (value: string) => value === "1h" ? "60m" : value;
+  return canonical(requested) === canonical(served);
+}

--- a/src/time-series/chart-data.ts
+++ b/src/time-series/chart-data.ts
@@ -1,4 +1,5 @@
 import type { PricePoint, Quote } from "../types/financials";
+import { pricePointIntegrity } from "../utils/price-history-integrity";
 import { isQuoteStaleForCurrentSession } from "../market-data/quotes/freshness";
 import { hasLikelyQuoteUnitMismatch } from "../utils/currency-units";
 import { resolveExchangeTimeZone } from "../utils/exchanges";
@@ -76,6 +77,8 @@ function finiteOrFallback(value: number | undefined, fallback: number): number {
 }
 
 function mergeQuoteIntoLatestBar(latest: PricePoint, quotePrice: number): PricePoint {
+  // A later quote cannot establish which reported OHLC field was wrong.
+  if (pricePointIntegrity(latest)) return latest;
   const open = finiteOrFallback(latest.open, latest.close);
   const high = finiteOrFallback(latest.high, Math.max(open, latest.close));
   const low = finiteOrFallback(latest.low, Math.min(open, latest.close));

--- a/src/time-series/market.ts
+++ b/src/time-series/market.ts
@@ -2,7 +2,7 @@ import type { PricePoint, TickerFinancials } from "../types/financials";
 import { pricePointIntegrity, pricePointValues, priceHistoryIntegrityNotice, mergePriceHistoryIntegrity, type PriceHistoryIntegrity } from "../utils/price-history-integrity";
 import { canonicalTimeSeriesFieldId, isFundamentalFieldId, isMarketFieldId } from "./field-catalog";
 import { extractFundamentalSeries } from "./fundamentals";
-import type { ResolvedSeries, SecuritySeriesSource, SeriesPeriod, TimeSeriesPoint } from "./types";
+import type { ChartSeriesPriceHistoryIntegrity, ResolvedSeries, SecuritySeriesSource, SeriesPeriod, TimeSeriesPoint } from "./types";
 
 function finiteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
@@ -122,6 +122,35 @@ export function priceHistoryIntegrityNotices(series: readonly Pick<ResolvedSerie
     const notice = priceHistoryIntegrityNotice(dates.size);
     return notice ? [`${entry.label}: ${notice}`] : [];
   });
+}
+
+export function collectPriceHistoryIntegrity(
+  series: readonly Pick<ResolvedSeries, "id" | "label" | "points">[],
+  scope: ChartSeriesPriceHistoryIntegrity["scope"],
+  includeSource?: (seriesId: string, sourceTime: number) => boolean,
+): ChartSeriesPriceHistoryIntegrity[] {
+  return series.flatMap((entry) => {
+    const sources = new Map<string, PriceHistoryIntegrity["sourcePoints"][number]>();
+    for (const point of entry.points) {
+      for (const source of point.provenance?.priceHistoryIntegrity?.sourcePoints ?? []) {
+        if (!includeSource || includeSource(entry.id, Date.parse(source.date))) sources.set(JSON.stringify(source), source);
+      }
+    }
+    return sources.size ? [{
+      seriesId: entry.id, label: entry.label, scope,
+      integrity: mergePriceHistoryIntegrity({ reason: "inconsistent-ohlc", sourcePoints: [...sources.values()] }),
+    }] : [];
+  });
+}
+
+export function chartPriceHistoryIntegrityNotices(entries: readonly ChartSeriesPriceHistoryIntegrity[]): string[] {
+  const bySeries = new Map<string, { label: string; dates: Set<string> }>();
+  for (const entry of entries) {
+    const group = bySeries.get(entry.seriesId) ?? { label: entry.label, dates: new Set<string>() };
+    entry.integrity.sourcePoints.forEach((source) => group.dates.add(source.date));
+    bySeries.set(entry.seriesId, group);
+  }
+  return [...bySeries.values()].map(({ label, dates }) => `${label}: ${priceHistoryIntegrityNotice(dates.size)}`);
 }
 
 /** Pure security-source coordinator used by runtime hooks after data loading. */

--- a/src/time-series/market.ts
+++ b/src/time-series/market.ts
@@ -1,7 +1,8 @@
 import type { PricePoint, TickerFinancials } from "../types/financials";
+import { pricePointIntegrity, pricePointValues, priceHistoryIntegrityNotice, mergePriceHistoryIntegrity, type PriceHistoryIntegrity } from "../utils/price-history-integrity";
 import { canonicalTimeSeriesFieldId, isFundamentalFieldId, isMarketFieldId } from "./field-catalog";
 import { extractFundamentalSeries } from "./fundamentals";
-import type { SecuritySeriesSource, SeriesPeriod, TimeSeriesPoint } from "./types";
+import type { ResolvedSeries, SecuritySeriesSource, SeriesPeriod, TimeSeriesPoint } from "./types";
 
 function finiteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
@@ -38,17 +39,19 @@ interface AggregatedPricePoint {
   low: number;
   close: number;
   volume?: number;
+  integrity?: PriceHistoryIntegrity;
 }
 
 /** Aggregates OHLCV correctly: first open, max high, min low, last close, summed volume. */
 function aggregatePriceHistory(
   points: readonly PricePoint[],
   period: SeriesPeriod,
-): PricePoint[] {
+): Array<PricePoint & { integrity?: PriceHistoryIntegrity }> {
   const sorted = points
     .flatMap((point) => {
       const date = pricePointDate(point.date);
-      return date && finiteNumber(point.close) ? [{ ...point, date }] : [];
+      const integrity = pricePointIntegrity(point);
+      return date && (finiteNumber(point.close) || integrity) ? [{ ...point, date, integrity }] : [];
     })
     .sort((left, right) => left.date.getTime() - right.date.getTime());
   if (period === "auto") return sorted.map((point) => ({ ...point, date: new Date(point.date) }));
@@ -69,6 +72,7 @@ function aggregatePriceHistory(
         low,
         close: point.close,
         volume: finiteNumber(point.volume) ? point.volume : undefined,
+        integrity: point.integrity,
       });
       continue;
     }
@@ -76,6 +80,8 @@ function aggregatePriceHistory(
     current.high = Math.max(current.high, high);
     current.low = Math.min(current.low, low);
     current.close = point.close;
+    if (point.integrity) current.integrity = current.integrity
+      ? mergePriceHistoryIntegrity(current.integrity, point.integrity) : point.integrity;
     if (finiteNumber(point.volume)) current.volume = (current.volume ?? 0) + point.volume;
   }
   return [...buckets.values()];
@@ -89,27 +95,32 @@ export function extractPriceSeries(
   if (!isMarketFieldId(fieldId)) return [];
   const aggregated = aggregatePriceHistory(priceHistory, source.period ?? "auto");
   return aggregated.map((point) => {
+    const { integrity, ...values } = pricePointValues(point, point.integrity);
     const value = fieldId === "market.open"
-      ? point.open
+      ? values.open
       : fieldId === "market.high"
-        ? point.high
+        ? values.high
         : fieldId === "market.low"
-          ? point.low
+          ? values.low
           : fieldId === "market.volume"
-            ? point.volume
-            : point.close;
+            ? values.volume
+            : values.close;
     return {
       date: new Date(point.date),
       observedAt: new Date(point.date),
       availableAt: new Date(point.date),
-      value: finiteNumber(value) ? value : null,
-      open: finiteNumber(point.open) ? point.open : null,
-      high: finiteNumber(point.high) ? point.high : null,
-      low: finiteNumber(point.low) ? point.low : null,
-      close: finiteNumber(point.close) ? point.close : null,
-      volume: finiteNumber(point.volume) ? point.volume : null,
-      provenance: { quality: "reported" as const },
+      value,
+      ...values,
+      provenance: { quality: "reported" as const, ...(integrity ? { priceHistoryIntegrity: integrity } : {}) },
     };
+  });
+}
+
+export function priceHistoryIntegrityNotices(series: readonly Pick<ResolvedSeries, "label" | "points">[]): string[] {
+  return series.flatMap((entry) => {
+    const dates = new Set(entry.points.flatMap((point) => point.provenance?.priceHistoryIntegrity?.sourcePoints.map((source) => source.date) ?? []));
+    const notice = priceHistoryIntegrityNotice(dates.size);
+    return notice ? [`${entry.label}: ${notice}`] : [];
   });
 }
 

--- a/src/time-series/price-comparison.test.ts
+++ b/src/time-series/price-comparison.test.ts
@@ -104,6 +104,62 @@ describe("normalized market price comparison", () => {
     expect(result.priceComparison?.sourceBounds?.NEWER.start).toBe(Date.parse("2026-01-07T23:00:00Z"));
   });
 
+  test("Auto cached and network comparisons use the same effective calendar resolution", async () => {
+    const chart = spec();
+    chart.viewport = { range: "1Y", resolution: "auto" };
+    chart.series[0]!.source = { kind: "security", instrument: { symbol: "OLDER", exchange: "CCC" }, fieldId: "market.close" };
+    const data = {
+      OLDER: rows([["2026-09-08", 100], ["2026-09-09", 110]]),
+      NEWER: rows([["2026-09-08T13:30:00Z", 50], ["2026-09-09T13:30:00Z", 60]]),
+    };
+    const seeded = seedChartResolutionResult(chart, new Map(chart.series.map((entry) => [chartQuoteOverrideKeyForSource(entry.source), data[entry.id as keyof typeof data]])), sources(data).now);
+    const network = await resolveChartSpecData(chart, sources(data));
+    expect(seeded?.resolution).toBe("1d");
+    expect(seeded?.resolution).toBe(network.resolution);
+    expect(seeded?.priceComparison).toEqual(network.priceComparison);
+    expect(seeded?.series.map((entry) => entry.points.map((point) => point.value))).toEqual([[0, 10], [0, 20]]);
+  });
+
+  test("date-only windows include prior-UTC sessions but timestamp navigation remains exact", async () => {
+    const chart = spec();
+    chart.viewport.dateWindow = { start: "2026-01-08", end: "2026-01-09" };
+    chart.series[0]!.source = { kind: "security", instrument: { symbol: "OLDER", exchange: "ASX" }, fieldId: "market.close" };
+    const data = {
+      OLDER: rows([["2026-01-06T23:00:00Z", 90], ["2026-01-07T23:00:00Z", 100], ["2026-01-08T23:00:00Z", 110], ["2026-01-09T23:00:00Z", 150]]),
+      NEWER: rows([["2026-01-07T14:30:00Z", 30], ["2026-01-08T14:30:00Z", 50], ["2026-01-09T14:30:00Z", 60], ["2026-01-10T14:30:00Z", 90]]),
+    };
+    chart.studies = [{ id: "sma", kind: "sma", inputSeriesIds: ["OLDER"], parameters: { period: 2 }, panelId: "main", axis: "left" }];
+    const network = await resolveChartSpecData(chart, sources(data));
+    const seeded = seedChartResolutionResult(chart, new Map(chart.series.map((entry) => [chartQuoteOverrideKeyForSource(entry.source), data[entry.id as keyof typeof data]])));
+    for (const result of [network, seeded!]) {
+      expect(result.series.slice(0, 2).map((entry) => entry.points.map((point) => point.value))).toEqual([[0, 10], [0, 20]]);
+      expect(result.viewport?.start.toISOString()).toBe("2026-01-07T23:00:00.000Z");
+      expect(result.viewport?.end.toISOString()).toBe("2026-01-09T23:59:59.999Z");
+      expect(result.series.find((entry) => entry.id === "sma")?.points.map((point) => [point.rawValue, point.value])).toEqual([[95, -5], [105, 5]]);
+    }
+    expect(chart.viewport.dateWindow).toEqual({ start: "2026-01-08", end: "2026-01-09" });
+    const requestViewport = { start: date("2026-01-08"), end: date("2026-01-09T23:59:59.999Z") };
+    const panned = await resolveChartSpecData(chart, sources(data), new ChartResolveCache(), { requestViewport });
+    expect(panned.priceComparison?.start).toBeNull();
+    expect(panned.viewport).toEqual(requestViewport);
+    chart.viewport.dateWindow = { start: requestViewport.start.toISOString(), end: requestViewport.end.toISOString() };
+    const timestamped = await resolveChartSpecData(chart, sources(data));
+    expect(timestamped.priceComparison?.start).toBeNull();
+  });
+
+  test("price overlays normalize against their own compared input rather than the global timestamp envelope", async () => {
+    const chart = spec();
+    chart.viewport.dateWindow = { start: "2026-01-08", end: "2026-01-09" };
+    chart.series[0]!.source = { kind: "security", instrument: { symbol: "OLDER", exchange: "NZX" }, fieldId: "market.close" };
+    chart.studies = [{ id: "sma", kind: "sma", inputSeriesIds: ["NEWER"], parameters: { period: 2 }, panelId: "main", axis: "left" }];
+    const result = await resolveChartSpecData(chart, sources({
+      OLDER: rows([["2026-01-07T21:00:00Z", 100], ["2026-01-08T21:00:00Z", 110]]),
+      NEWER: rows([["2026-01-07T21:00:00Z", 30], ["2026-01-08T21:00:00Z", 50], ["2026-01-09T21:00:00Z", 60]]),
+    }));
+    expect(result.series.find((entry) => entry.id === "sma")?.points.map((point) => [point.rawValue, point.value])).toEqual([[40, -20], [55, 10]]);
+    expect(result.series[1]!.points.map((point) => point.value)).toEqual([0, 20]);
+  });
+
   test("one-leg streamed and snapshot quotes cannot rewrite a shared weekly source bar", async () => {
     const compared = spec("1wk");
     const inputs = sources();

--- a/src/time-series/price-comparison.test.ts
+++ b/src/time-series/price-comparison.test.ts
@@ -66,7 +66,42 @@ describe("normalized market price comparison", () => {
     expect(result.series.map((s) => s.points.at(-1)?.value)).toEqual([100, 200]);
     expect(result.series.map((s) => s.points.length)).toEqual([3, 2]);
     const shifted = result.series.map((s, index) => ({ ...s, points: s.points.map((p) => ({ ...p, date: new Date(p.date.getTime() + index * 1_000) })) }));
-    expect(resolvePriceComparison(spec(), shifted, { start: null, end: null })?.start).toBeNull();
+    expect(resolvePriceComparison(spec(), shifted, { start: null, end: null }, "1m")?.start).toBeNull();
+  });
+
+  test("daily comparisons align market dates while preserving exact source timestamps and endpoints", async () => {
+    const chart = spec();
+    chart.series[0]!.source = { kind: "security", instrument: { symbol: "OLDER", exchange: "CCC" }, fieldId: "market.close" };
+    const data = {
+      OLDER: rows([["2026-09-07", 80], ["2026-09-08", 100], ["2026-09-09", 110], ["2026-09-10", 200]]),
+      NEWER: rows([["2026-09-08T13:30:00Z", 50], ["2026-09-09T13:30:00Z", 60]]),
+    };
+    const result = await resolveChartSpecData(chart, sources(data));
+    expect(result.priceComparison).toMatchObject({ alignment: "session-date", sourceBounds: {
+      OLDER: { start: Date.parse("2026-09-08"), end: Date.parse("2026-09-09") },
+      NEWER: { start: Date.parse("2026-09-08T13:30:00Z"), end: Date.parse("2026-09-09T13:30:00Z") },
+    } });
+    for (const collection of [result.series, result.bufferedSeries!, result.legendSeries!]) {
+      expect(collection.map((entry) => entry.points.map((point) => point.value))).toEqual([[0, 10], [0, 20]]);
+      expect(collection[0]!.points.at(-1)!.date.toISOString()).toBe("2026-09-09T00:00:00.000Z");
+      expect(collection[1]!.points[0]!.date.toISOString()).toBe("2026-09-08T13:30:00.000Z");
+    }
+    expect(summarizeResolvedSeries(result.series[1]!)).toMatchObject({ startValue: 50, endValue: 60, return: 0.2 });
+    const seeded = seedChartResolutionResult(chart, new Map(chart.series.map((entry) => [chartQuoteOverrideKeyForSource(entry.source), data[entry.id as keyof typeof data]])));
+    expect(seeded?.series.map((entry) => entry.points.at(-1)?.value)).toEqual([10, 20]);
+    expect(data.OLDER.at(-1)?.close).toBe(200);
+  });
+
+  test("session dates handle venues opening on the preceding UTC day", async () => {
+    const chart = spec();
+    chart.series[1]!.source = { kind: "security", instrument: { symbol: "NEWER", exchange: "ASX" }, fieldId: "market.close" };
+    const result = await resolveChartSpecData(chart, sources({
+      OLDER: rows([["2026-01-08T14:30:00Z", 10], ["2026-01-09T14:30:00Z", 12]]),
+      NEWER: rows([["2026-01-07T23:00:00Z", 20], ["2026-01-08T23:00:00Z", 30]]),
+    }));
+    expect(result.series.map((entry) => entry.points.at(-1)?.value)).toEqual([20, 50]);
+    // In summer Sydney's opening bar starts on the previous UTC date.
+    expect(result.priceComparison?.sourceBounds?.NEWER.start).toBe(Date.parse("2026-01-07T23:00:00Z"));
   });
 
   test("one-leg streamed and snapshot quotes cannot rewrite a shared weekly source bar", async () => {

--- a/src/time-series/price-comparison.ts
+++ b/src/time-series/price-comparison.ts
@@ -1,15 +1,32 @@
 import { scalarPointValue } from "./alignment";
 import { getTimeSeriesField } from "./field-catalog";
 import type { ChartSpec, ResolvedSeries } from "./types";
+import type { ManualChartResolution } from "./resolution";
+import { zonedDateTimeParts } from "../utils/zoned-date-time";
 
 export const PRICE_COMPARISON_BASIS = "Price returns in each listing's currency; cash distributions and FX conversion excluded.";
 
 export interface PriceComparison {
   seriesIds: string[];
-  /** Exact source observation timestamps, never filled or rounded across markets. */
+  /** Display envelope; each leg retains its exact source endpoints below. */
   start: number | null;
   end: number | null;
   notice: string;
+  alignment?: "session-date" | "timestamp";
+  sourceBounds?: Record<string, { start: number; end: number }>;
+}
+
+function observationDate(time: number, series: ResolvedSeries): string {
+  const date = new Date(time);
+  // Date-only provider bars are represented as UTC midnight throughout the app.
+  // Timestamped bars use the exchange's local calendar; crypto uses UTC.
+  if (time % 86_400_000 === 0 || !series.timeBasis) return date.toISOString().slice(0, 10);
+  const { year, month, day } = zonedDateTimeParts(time, series.timeBasis.timeZone);
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+export function priceComparisonBoundsForSeries(series: ResolvedSeries, comparison: PriceComparison | null) {
+  return comparison?.sourceBounds?.[series.id] ?? comparison;
 }
 
 function displayDate(time: number): string {
@@ -37,37 +54,51 @@ export function resolvePriceComparison(
   spec: ChartSpec,
   series: readonly ResolvedSeries[],
   bounds: { start: number | null; end: number | null },
+  resolution: ManualChartResolution | "auto" = spec.viewport.resolution,
 ): PriceComparison | null {
   const seriesIds = priceComparisonSeriesIds(spec);
   if (!seriesIds) return null;
   const byId = new Map(series.map((entry) => [entry.id, entry]));
-  const timestamps = seriesIds.map((id) => new Set((byId.get(id)?.points ?? []).flatMap((point) => {
+  const calendarBars = resolution === "1d" || resolution === "1wk" || resolution === "1mo";
+  const observations = seriesIds.map((id) => new Map((byId.get(id)?.points ?? []).flatMap((point) => {
     const time = point.date.getTime();
     const value = scalarPointValue(point);
     return Number.isFinite(time) && value !== null
       && (bounds.start === null || time >= bounds.start)
-      && (bounds.end === null || time <= bounds.end) ? [time] : [];
+      && (bounds.end === null || time <= bounds.end)
+      ? [[calendarBars ? observationDate(time, byId.get(id)!) : String(time), point] as const] : [];
   })));
-  const shared = [...timestamps[0]!].filter((time) => timestamps.every((times) => times.has(time))).sort((a, b) => a - b);
-  const start = shared.find((time) => seriesIds.every((id) => {
-    const point = byId.get(id)?.points.find((point) => point.date.getTime() === time);
+  const shared = [...observations[0]!.keys()].filter((key) => observations.every((points) => points.has(key)))
+    .sort((a, b) => calendarBars ? a.localeCompare(b) : Number(a) - Number(b));
+  const start = shared.find((key) => observations.every((points) => {
+    const point = points.get(key);
     return point && scalarPointValue(point) !== 0;
   }));
   const end = shared.at(-1);
-  if (start === undefined || end === undefined || start >= end) return {
+  if (start === undefined || end === undefined || start === end) return {
     seriesIds, start: null, end: null,
     notice: `${PRICE_COMPARISON_BASIS} Comparison unavailable: need two shared dates and a nonzero baseline.`,
   };
+  const sourceBounds = Object.fromEntries(seriesIds.map((id, index) => [id, {
+    start: observations[index]!.get(start)!.date.getTime(),
+    end: observations[index]!.get(end)!.date.getTime(),
+  }]));
   return {
-    seriesIds, start, end,
-    notice: `${PRICE_COMPARISON_BASIS} Shared observations: ${displayDate(start)} to ${displayDate(end)}.`,
+    seriesIds,
+    start: Math.min(...Object.values(sourceBounds).map((range) => range.start)),
+    end: Math.max(...Object.values(sourceBounds).map((range) => range.end)),
+    alignment: calendarBars ? "session-date" : "timestamp",
+    sourceBounds,
+    notice: calendarBars
+      ? `${PRICE_COMPARISON_BASIS} Shared calendar dates: ${start} to ${end}; market session times may differ.`
+      : `${PRICE_COMPARISON_BASIS} Shared observations: ${displayDate(Number(start))} to ${displayDate(Number(end))}.`,
   };
 }
 
 /** Clip only compared legs; raw observations and study inputs stay available in the source cache. */
 export function clipPriceComparison(series: ResolvedSeries, comparison: PriceComparison | null): ResolvedSeries {
   if (!comparison?.seriesIds.includes(series.id)) return series;
-  const { start, end } = comparison;
+  const { start, end } = priceComparisonBoundsForSeries(series, comparison)!;
   return {
     ...series,
     // The legend must describe the compared endpoint, not a newer one-leg quote.

--- a/src/time-series/price-comparison.ts
+++ b/src/time-series/price-comparison.ts
@@ -1,6 +1,6 @@
 import { scalarPointValue } from "./alignment";
 import { getTimeSeriesField } from "./field-catalog";
-import type { ChartSpec, ResolvedSeries } from "./types";
+import type { ChartSpec, ResolvedSeries, TimeSeriesPoint } from "./types";
 import type { ManualChartResolution } from "./resolution";
 import { zonedDateTimeParts } from "../utils/zoned-date-time";
 
@@ -23,6 +23,26 @@ function observationDate(time: number, series: ResolvedSeries): string {
   if (time % 86_400_000 === 0 || !series.timeBasis) return date.toISOString().slice(0, 10);
   const { year, month, day } = zonedDateTimeParts(time, series.timeBasis.timeZone);
   return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+/** Date-only research windows select local sessions; runtime timestamps remain exact. */
+export function priceObservationWindowFilter(
+  series: ResolvedSeries,
+  bounds: { start: number | null; end: number | null },
+  resolution: ManualChartResolution | "auto",
+  dateWindow: ChartSpec["viewport"]["dateWindow"] | null,
+): (time: number) => boolean {
+  const calendarBars = resolution === "1d" || resolution === "1wk" || resolution === "1mo";
+  const calendarWindow = calendarBars && dateWindow
+    && /^\d{4}-\d{2}-\d{2}$/.test(dateWindow.start)
+    && /^\d{4}-\d{2}-\d{2}$/.test(dateWindow.end) ? dateWindow : null;
+  return (time) => {
+    if (!Number.isFinite(time)) return false;
+    const key = calendarWindow ? observationDate(time, series) : null;
+    return key !== null
+      ? key >= calendarWindow!.start && key <= calendarWindow!.end
+      : (bounds.start === null || time >= bounds.start) && (bounds.end === null || time <= bounds.end);
+  };
 }
 
 export function priceComparisonBoundsForSeries(series: ResolvedSeries, comparison: PriceComparison | null) {
@@ -61,20 +81,16 @@ export function resolvePriceComparison(
   if (!seriesIds) return null;
   const byId = new Map(series.map((entry) => [entry.id, entry]));
   const calendarBars = resolution === "1d" || resolution === "1wk" || resolution === "1mo";
-  const calendarWindow = calendarBars && dateWindow
-    && /^\d{4}-\d{2}-\d{2}$/.test(dateWindow.start)
-    && /^\d{4}-\d{2}-\d{2}$/.test(dateWindow.end) ? dateWindow : null;
-  const observations = seriesIds.map((id) => new Map((byId.get(id)?.points ?? []).flatMap((point) => {
-    const time = point.date.getTime();
-    const value = scalarPointValue(point);
-    if (!Number.isFinite(time) || value === null) return [];
-    const key = calendarBars ? observationDate(time, byId.get(id)!) : String(time);
-    const inWindow = calendarWindow
-      ? key >= calendarWindow.start && key <= calendarWindow.end
-      : (bounds.start === null || time >= bounds.start)
-        && (bounds.end === null || time <= bounds.end);
-    return inWindow ? [[key, point] as const] : [];
-  })));
+  const observations = seriesIds.map((id) => {
+    const entry = byId.get(id);
+    if (!entry) return new Map<string, TimeSeriesPoint>();
+    const inWindow = priceObservationWindowFilter(entry, bounds, resolution, dateWindow);
+    return new Map(entry.points.flatMap((point) => {
+      const time = point.date.getTime();
+      if (!inWindow(time) || scalarPointValue(point) === null) return [];
+      return [[calendarBars ? observationDate(time, entry) : String(time), point] as const];
+    }));
+  });
   const shared = [...observations[0]!.keys()].filter((key) => observations.every((points) => points.has(key)))
     .sort((a, b) => calendarBars ? a.localeCompare(b) : Number(a) - Number(b));
   const start = shared.find((key) => observations.every((points) => {

--- a/src/time-series/price-comparison.ts
+++ b/src/time-series/price-comparison.ts
@@ -55,18 +55,25 @@ export function resolvePriceComparison(
   series: readonly ResolvedSeries[],
   bounds: { start: number | null; end: number | null },
   resolution: ManualChartResolution | "auto" = spec.viewport.resolution,
+  dateWindow: ChartSpec["viewport"]["dateWindow"] | null = spec.viewport.dateWindow,
 ): PriceComparison | null {
   const seriesIds = priceComparisonSeriesIds(spec);
   if (!seriesIds) return null;
   const byId = new Map(series.map((entry) => [entry.id, entry]));
   const calendarBars = resolution === "1d" || resolution === "1wk" || resolution === "1mo";
+  const calendarWindow = calendarBars && dateWindow
+    && /^\d{4}-\d{2}-\d{2}$/.test(dateWindow.start)
+    && /^\d{4}-\d{2}-\d{2}$/.test(dateWindow.end) ? dateWindow : null;
   const observations = seriesIds.map((id) => new Map((byId.get(id)?.points ?? []).flatMap((point) => {
     const time = point.date.getTime();
     const value = scalarPointValue(point);
-    return Number.isFinite(time) && value !== null
-      && (bounds.start === null || time >= bounds.start)
-      && (bounds.end === null || time <= bounds.end)
-      ? [[calendarBars ? observationDate(time, byId.get(id)!) : String(time), point] as const] : [];
+    if (!Number.isFinite(time) || value === null) return [];
+    const key = calendarBars ? observationDate(time, byId.get(id)!) : String(time);
+    const inWindow = calendarWindow
+      ? key >= calendarWindow.start && key <= calendarWindow.end
+      : (bounds.start === null || time >= bounds.start)
+        && (bounds.end === null || time <= bounds.end);
+    return inWindow ? [[key, point] as const] : [];
   })));
   const shared = [...observations[0]!.keys()].filter((key) => observations.every((points) => points.has(key)))
     .sort((a, b) => calendarBars ? a.localeCompare(b) : Number(a) - Number(b));

--- a/src/time-series/price-history-integrity-window.test.ts
+++ b/src/time-series/price-history-integrity-window.test.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "bun:test";
+import type { PricePoint } from "../types/financials";
+import type { HeadlessPaneContext } from "../types/headless";
+import { createTestDataProvider } from "../test-support/data-provider";
+import { loadChartPaneModel } from "../plugins/builtin/chart-composer/headless";
+import { CHART_SPEC_VERSION, type ChartSpec } from "./types";
+import { chartQuoteOverrideKeyForSource } from "./live-quotes";
+import { ChartResolveCache, resolveChartSpecData, seedChartResolutionResult } from "./resolve";
+
+const row = (date: string, close = 10, bad = false): PricePoint => ({
+  date: new Date(date), close, ...(bad ? { open: 30, high: 20, low: 5 } : {}),
+});
+function chart(start = "2026-09-08", end = "2026-09-10"): ChartSpec {
+  return {
+    version: CHART_SPEC_VERSION,
+    viewport: { range: "1M", resolution: "1d", dateWindow: { start, end } },
+    panels: [{ id: "main" }], studies: [],
+    series: ["A", "B"].map((symbol) => ({
+      id: symbol, source: { kind: "security", instrument: { symbol, exchange: "NASDAQ" }, fieldId: "market.close" },
+      style: "line", transform: "percent", axis: "left", panelId: "main", interpolation: "none",
+    })),
+  };
+}
+function provider(histories: Record<string, PricePoint[]>) {
+  const getHistory = async (symbol: string) => histories[symbol] ?? [];
+  return createTestDataProvider({
+    getQuote: async (symbol) => ({ symbol, currency: "USD", instrumentType: "ETF", price: 12, change: 0, changePercent: 0, lastUpdated: 0 }),
+    getPriceHistory: getHistory, getPriceHistoryForResolution: getHistory, getDetailedPriceHistory: getHistory,
+  });
+}
+
+test("rejected requested comparison endpoints remain exported and incomplete while valid shared returns survive", async () => {
+  for (const edge of [0, 2]) {
+    const spec = chart();
+    const histories = {
+      A: [8, 9, 10].map((day, index) => row(`2026-09-${String(day).padStart(2, "0")}`, 10 + index, index === edge)),
+      B: [8, 9, 10].map((day, index) => row(`2026-09-${String(day).padStart(2, "0")}`, 10 + index)),
+    };
+    const model = await loadChartPaneModel(spec, { marketData: provider(histories) } as HeadlessPaneContext);
+    const seed = seedChartResolutionResult(spec, new Map(spec.series.map((entry) => [chartQuoteOverrideKeyForSource(entry.source), histories[entry.id as "A" | "B"]])))!;
+    expect(model.complete).toBe(false);
+    expect(model.chart.priceHistoryIntegrity).toEqual(seed.priceHistoryIntegrity);
+    expect(model.metadata!.priceHistoryIntegrity).toEqual(model.chart.priceHistoryIntegrity);
+    for (const result of [model.chart, seed]) {
+      expect(result.priceHistoryIntegrity).toHaveLength(1);
+      expect(result.priceHistoryIntegrity![0]).toMatchObject({ seriesId: "A", scope: "requested-observation" });
+      expect(result.priceHistoryIntegrity![0]!.integrity.sourcePoints).toEqual([{ ...histories.A[edge], date: histories.A[edge]!.date.toISOString() }]);
+      expect(result.series.every((entry) => entry.points.length === 2 && entry.points.every((point) => !point.provenance?.priceHistoryIntegrity))).toBe(true);
+      expect(result.series.every((entry) => entry.points[0]!.value === 0)).toBe(true);
+      expect(result.priceComparison?.start).toBe(Date.parse(edge === 0 ? "2026-09-09" : "2026-09-08"));
+      expect(result.priceComparison?.end).toBe(Date.parse(edge === 0 ? "2026-09-10" : "2026-09-09"));
+      expect(result.warnings.some((warning) => warning.includes("inconsistent OHLC"))).toBe(true);
+    }
+    expect((model.metadata!.summaries as Array<{ return: number | null }>).every((summary) => summary.return !== null)).toBe(true);
+    expect((model.metadata!.notices as string[]).some((notice) => notice.includes("inconsistent OHLC"))).toBe(true);
+  }
+});
+
+test("integrity metadata excludes unrelated corruption in the loaded navigation buffer", async () => {
+  const spec = chart();
+  const histories = {
+    A: [row("2026-09-07", 10, true), row("2026-09-08", 10), row("2026-09-09", 11), row("2026-09-10", 12), row("2026-09-11", 12, true)],
+    B: [row("2026-09-08", 10), row("2026-09-09", 11), row("2026-09-10", 12)],
+  };
+  const model = await loadChartPaneModel(spec, { marketData: provider(histories) } as HeadlessPaneContext);
+  expect(model.complete).not.toBe(false);
+  expect(model.chart.priceHistoryIntegrity).toBeUndefined();
+  expect(model.metadata!.priceHistoryIntegrity).toBeUndefined();
+  expect(model.chart.warnings.some((warning) => warning.includes("inconsistent OHLC"))).toBe(false);
+});
+
+test("date-only integrity selection uses local market sessions while explicit and panned timestamps stay exact", async () => {
+  const spec = chart("2026-01-08", "2026-01-10");
+  spec.series[0]!.source = { kind: "security", instrument: { symbol: "A", exchange: "ASX" }, fieldId: "market.close" };
+  const histories = {
+    A: [row("2026-01-06T23:00:00Z", 10, true), row("2026-01-07T23:00:00Z", 10, true), row("2026-01-08T23:00:00Z", 11), row("2026-01-09T23:00:00Z", 12), row("2026-01-11T23:00:00Z", 12, true)],
+    B: [row("2026-01-08T14:30:00Z", 10), row("2026-01-09T14:30:00Z", 11), row("2026-01-10T14:30:00Z", 12)],
+  };
+  const sources = { dataProvider: provider(histories) };
+  const selected = await resolveChartSpecData(spec, sources);
+  const seed = seedChartResolutionResult(spec, new Map(spec.series.map((entry) => [chartQuoteOverrideKeyForSource(entry.source), histories[entry.id as "A" | "B"]])))!;
+  for (const result of [selected, seed]) {
+    expect(result.priceHistoryIntegrity?.flatMap((entry) => entry.integrity.sourcePoints.map((point) => point.date))).toEqual(["2026-01-07T23:00:00.000Z"]);
+    expect(result.priceComparison?.sourceBounds?.A.start).toBe(Date.parse("2026-01-08T23:00:00Z"));
+  }
+  const exact = { start: new Date("2026-01-08T00:00:00Z"), end: new Date("2026-01-10T23:59:59.999Z") };
+  const panned = await resolveChartSpecData(spec, sources, new ChartResolveCache(), { requestViewport: exact });
+  expect(panned.priceHistoryIntegrity).toBeUndefined();
+  expect(panned.warnings.some((warning) => warning.includes("inconsistent OHLC"))).toBe(false);
+  spec.viewport.dateWindow = { start: exact.start.toISOString(), end: exact.end.toISOString() };
+  expect((await resolveChartSpecData(spec, sources)).priceHistoryIntegrity).toBeUndefined();
+});
+
+test("a comparison with no usable overlap still preserves rejected selected rows", async () => {
+  const spec = chart();
+  const histories = { A: [row("2026-09-08", 10, true), row("2026-09-09", 11)], B: [row("2026-09-08", 10), row("2026-09-09", 11)] };
+  const model = await loadChartPaneModel(spec, { marketData: provider(histories) } as HeadlessPaneContext);
+  expect(model.chart.priceComparison?.start).toBeNull();
+  expect(model.series.every((entry) => entry.points.length === 0)).toBe(true);
+  expect(model.chart.priceHistoryIntegrity![0]!.integrity.sourcePoints[0]!.open).toBe(30);
+  expect(model.complete).toBe(false);
+});
+
+test("observation-count windows exclude older corrupt rows while retaining a rejected selected row", async () => {
+  const spec = chart();
+  spec.viewport = { range: "ALL", resolution: "1d", maxPoints: 2 };
+  const histories = {
+    A: [row("2026-09-07", 10, true), row("2026-09-08", 10), row("2026-09-09", 11), row("2026-09-10", 12)],
+    B: [row("2026-09-08", 10), row("2026-09-09", 11), row("2026-09-10", 12)],
+  };
+  const model = await loadChartPaneModel(spec, { marketData: provider(histories) } as HeadlessPaneContext);
+  const seeded = seedChartResolutionResult(spec, new Map(spec.series.map((entry) => [chartQuoteOverrideKeyForSource(entry.source), histories[entry.id as "A" | "B"]])))!;
+  expect(model.complete).not.toBe(false);
+  for (const result of [model.chart, seeded]) {
+    expect(result.series.every((entry) => entry.points.length === 2)).toBe(true);
+    expect(result.priceHistoryIntegrity).toBeUndefined();
+    expect(result.warnings.some((warning) => warning.includes("inconsistent OHLC"))).toBe(false);
+  }
+  histories.A[3] = row("2026-09-10", 12, true);
+  const rejected = await loadChartPaneModel(spec, { marketData: provider(histories) } as HeadlessPaneContext);
+  expect(rejected.complete).toBe(false);
+  expect(rejected.chart.priceHistoryIntegrity?.every((entry) => entry.integrity.sourcePoints.every((point) => point.date === "2026-09-10T00:00:00.000Z"))).toBe(true);
+});
+
+test("a hidden source used only to retain the chart timeline does not report unrelated integrity warnings", async () => {
+  const spec = chart();
+  spec.series[0]!.visible = false;
+  const histories = {
+    A: [row("2026-09-08", 10, true), row("2026-09-09", 11), row("2026-09-10", 12)],
+    B: [row("2026-09-08", 10), row("2026-09-09", 11), row("2026-09-10", 12)],
+  };
+  const model = await loadChartPaneModel(spec, { marketData: provider(histories) } as HeadlessPaneContext);
+  expect(model.chart.timelineSeries?.[0]?.points.some((point) => point.provenance?.priceHistoryIntegrity)).toBe(true);
+  expect(model.chart.priceHistoryIntegrity).toBeUndefined();
+  expect(model.complete).not.toBe(false);
+  expect(model.chart.warnings.some((warning) => warning.includes("inconsistent OHLC"))).toBe(false);
+});

--- a/src/time-series/price-history-integrity.test.ts
+++ b/src/time-series/price-history-integrity.test.ts
@@ -1,0 +1,172 @@
+import { expect, test } from "bun:test";
+import type { PricePoint } from "../types/financials";
+import type { HeadlessPaneContext } from "../types/headless";
+import { createTestDataProvider } from "../test-support/data-provider";
+import { pricePointIntegrity, pricePointValues } from "../utils/price-history-integrity";
+import { historicalPricesHeadless } from "../plugins/builtin/ticker-detail/headless";
+import { loadChartPaneModel } from "../plugins/builtin/chart-composer/headless";
+import { extractPriceSeries } from "./market";
+import { appendLiveQuotePoint } from "./chart-data";
+import { seedChartResolutionResult } from "./resolve";
+import { chartQuoteOverrideKeyForSource } from "./live-quotes";
+import { resolveStudies } from "./studies";
+import { buildPriceReturnFields } from "../market-data/performance";
+import { pricePointsToResolvedSeries } from "../components/chart/composite/price-series";
+import { applyCompositeChartCursor, buildCompositeChartScene } from "../components/chart/composite/scene";
+import { CHART_SPEC_VERSION, type ChartSpec, type ResolvedSeries, type SeriesPeriod, type SeriesTransform } from "./types";
+
+// Actual SPY row retained from the September 10 Yahoo history cache. The open
+// exceeds the reported high; a later close does not tell us which field is wrong.
+const reported: PricePoint = {
+  date: new Date("2026-09-10T13:30:00.000Z"),
+  open: 764.0800170898438, high: 758.5549926757812, low: 757.5700073242188,
+  close: 758.1500244140625, volume: 3461376,
+};
+const history: PricePoint[] = [
+  { date: new Date("2026-09-09T13:30:00Z"), close: 757 }, reported,
+  { date: new Date("2026-09-11T13:30:00Z"), close: 760 },
+  { date: new Date("2026-09-14T13:30:00Z"), close: 761 },
+];
+const source = { kind: "security" as const, instrument: { symbol: "SPY", exchange: "ARCX" }, fieldId: "market.ohlcv" };
+function spec(transform: SeriesTransform = "raw"): ChartSpec {
+  return {
+    version: CHART_SPEC_VERSION,
+    viewport: { range: "1M", resolution: "1d", dateWindow: { start: "2026-09-08", end: "2026-09-15" } },
+    panels: [{ id: "main" }], studies: [],
+    series: [{ id: "price", source, style: "candles", transform, axis: "left", panelId: "main", interpolation: "none" }],
+  };
+}
+function resolved(points: PricePoint[] = history): ResolvedSeries {
+  return {
+    ...spec().series[0]!, id: "price", label: "SPY", color: "#ffffff", unit: "USD/share", unitGroup: "price:USD",
+    nativeFrequency: "daily", dataShape: "ohlcv", axis: "left", timeBasis: { kind: "market", timeZone: "America/New_York" }, points: extractPriceSeries(points, source),
+  };
+}
+
+test("the invariant detects contradictions without inventing missing OHLC or losing tiny and negative valid prices", () => {
+  for (const point of [reported, { ...reported, open: undefined, high: 1, low: 2 }, { ...reported, open: undefined, high: 800, low: 759 }]) {
+    const checked = pricePointValues(point);
+    expect(checked).toMatchObject({ open: null, high: null, low: null, close: null, volume: null });
+    expect(checked.integrity?.reason).toBe("inconsistent-ohlc");
+    expect(checked.integrity?.sourcePoints[0]).toEqual({ ...point, date: point.date.toISOString() });
+    expect(Object.isFrozen(checked.integrity?.sourcePoints[0])).toBe(true);
+  }
+  for (const point of [
+    { date: reported.date, close: 758 },
+    { date: reported.date, open: -2, high: 0, low: -3, close: -1 },
+    { date: reported.date, open: 0.00000002, high: 0.00000003, low: 0.00000001, close: 0.000000025 },
+    { date: reported.date, high: 0.3, close: 0.1 + 0.2 },
+  ]) expect(pricePointIntegrity(point)).toBeUndefined();
+  expect(pricePointIntegrity({ date: reported.date, high: 0.00000001, close: 0.00000002 })).toBeDefined();
+  const copy = { ...reported };
+  const diagnostic = pricePointIntegrity(copy)!;
+  copy.open = 1;
+  expect(diagnostic.sourcePoints[0]!.open).toBe(reported.open);
+  const withSource: PricePoint = { ...reported, historySource: { provider: "yahoo", symbol: "SHEL", exchange: "LSE", currency: "GBP" } };
+  const sourceDiagnostic = pricePointIntegrity(withSource)!;
+  withSource.historySource!.provider = "twelvedata";
+  expect(sourceDiagnostic.sourcePoints[0]!.historySource?.provider).toBe("yahoo");
+  expect(Object.isFrozen(sourceDiagnostic.sourcePoints[0]!.historySource)).toBe(true);
+});
+
+test("every price field and aggregated window retain an explicit gap and original source diagnostics", () => {
+  for (const period of ["auto", "daily", "weekly", "monthly", "quarterly", "annual"] as SeriesPeriod[]) {
+    for (const field of ["ohlcv", "open", "high", "low", "close", "volume"]) {
+      const points = extractPriceSeries(history, { ...source, fieldId: `market.${field}`, period });
+      const gap = points.find((point) => point.provenance?.priceHistoryIntegrity)!;
+      expect(gap).toMatchObject({ value: null, open: null, high: null, low: null, close: null, volume: null });
+      expect(gap.provenance!.priceHistoryIntegrity!.sourcePoints).toEqual([{ ...reported, date: reported.date.toISOString() }]);
+      expect(points.every((point) => point.value !== reported.close)).toBe(true);
+    }
+  }
+  const nonFiniteClose = extractPriceSeries([{ ...reported, close: NaN }], source);
+  expect(nonFiniteClose).toHaveLength(1);
+  expect(nonFiniteClose[0]!.value).toBeNull();
+  const merged = extractPriceSeries([reported, { ...reported, date: new Date("2026-09-11") }], { ...source, period: "weekly" })[0]!.provenance!.priceHistoryIntegrity!;
+  expect(merged.sourcePoints).toHaveLength(2);
+  expect(Object.isFrozen(merged)).toBe(true);
+  expect(Object.isFrozen(merged.sourcePoints)).toBe(true);
+});
+
+test("seed, resolved chart transforms and HP exports agree on quarantined values and visible notices", async () => {
+  const context = {
+    marketData: createTestDataProvider({ getPriceHistory: async () => history, getPriceHistoryForResolution: async () => history }),
+  } as HeadlessPaneContext;
+  const hp = await historicalPricesHeadless.load({ symbols: ["SPY:ARCX"], options: { range: "ALL" }, argument: ["SPY:ARCX"], rawArgument: "SPY:ARCX" }, context);
+  expect(hp.rows[1]).toMatchObject({ date: reported.date.toISOString(), close: null, open: null, integrity: pricePointIntegrity(reported) });
+  expect(hp.metadata!.notices).toHaveLength(1);
+  expect(hp.complete).toBe(false);
+  const seeded = seedChartResolutionResult(spec(), new Map([[chartQuoteOverrideKeyForSource(source), history]]))!;
+  expect(seeded.warnings.join(" ")).toContain("inconsistent OHLC");
+  for (const transform of ["raw", "percent", "index100", "log", "yoy", "qoq"] as SeriesTransform[]) {
+    const model = await loadChartPaneModel(spec(transform), context);
+    expect(model.chart.errors).toEqual([]);
+    expect(model.complete).toBe(false);
+    const json = JSON.parse(JSON.stringify(model));
+    const gap = json.series[0].points.find((point: { provenance?: { priceHistoryIntegrity?: unknown } }) => point.provenance?.priceHistoryIntegrity);
+    expect(gap).toMatchObject({ value: null, open: null, high: null, low: null, close: null });
+    expect(gap.provenance.priceHistoryIntegrity.sourcePoints[0].open).toBe(reported.open);
+    expect(json.metadata.notices.join(" ")).toContain("inconsistent OHLC");
+    expect(json.metadata.summaries[0]).toMatchObject({ return: null, startValue: null, endValue: null });
+  }
+});
+
+test("a fresh quote cannot silently repair an inconsistent reported bar", () => {
+  const now = Date.parse("2026-09-10T15:00:00Z");
+  const result = appendLiveQuotePoint([reported], {
+    symbol: "SPY", currency: "USD", price: 766, change: 8, changePercent: 1, lastUpdated: now, marketState: "REGULAR",
+  }, { now, mode: "ohlc", resolution: "1d", exchange: "ARCX" });
+  expect(result[0]).toEqual(reported);
+  expect(extractPriceSeries(result, source)[0]!.value).toBeNull();
+});
+
+test("overview chart and return windows preserve the integrity boundary without suppressing unaffected horizons", () => {
+  const chart = pricePointsToResolvedSeries(history, { id: "overview", label: "SPY", color: "#fff", unit: "USD" });
+  expect(chart.points[1]).toMatchObject({ value: null, open: null, close: null });
+  expect(chart.warning).toContain("inconsistent OHLC");
+  const fields = buildPriceReturnFields([
+    { date: new Date("2025-10-09"), close: 700 }, reported,
+    { date: new Date("2026-09-11"), close: 760 }, { date: new Date("2026-10-11"), close: 770 },
+  ]);
+  expect(fields.find((field) => field.id === "1M")!.value).toBeCloseTo(10 / 760);
+  expect(fields.find((field) => field.id === "1Y")).toMatchObject({ value: null, unavailableReason: "inconsistent-ohlc" });
+  expect(buildPriceReturnFields([reported]).every((field) => field.unavailableReason === "inconsistent-ohlc")).toBe(true);
+});
+
+test("chart cursor and latest-price marker cannot carry a prior close across a rejected bar", () => {
+  const latestBad = resolved(history.slice(0, 2));
+  const options = { width: 100, height: 20 };
+  const scene = buildCompositeChartScene([latestBad], [{ id: "main" }], options)!;
+  expect(scene.endTime).toBe(reported.date.getTime());
+  expect(scene.panels[0]!.lastPrice).toBeUndefined();
+  expect(scene.cursorValues[0]!.value).toBeNull();
+  const hovered = applyCompositeChartCursor(scene, reported.date);
+  expect(hovered.cursorValues[0]!.point?.provenance?.priceHistoryIntegrity).toBeDefined();
+  expect(hovered.cursorValues[0]!.value).toBeNull();
+  expect(applyCompositeChartCursor(scene, history[0]!.date).cursorValues[0]!.value).toBe(757);
+  const recovered = buildCompositeChartScene([resolved()], [{ id: "main" }], options)!;
+  expect(recovered.cursorValues[0]!.value).toBe(761);
+  expect(recovered.panels[0]!.lastPrice?.value).toBe(761);
+  expect(applyCompositeChartCursor(recovered, reported.date).cursorValues[0]!.value).toBeNull();
+});
+
+test("rolling and recursive studies restart after a corrupt row instead of calculating around it", () => {
+  const input = resolved();
+  for (const kind of ["sma", "ema", "bollinger", "rsi", "macd"] as const) {
+    const result = resolveStudies([input], [{ id: kind, kind, inputSeriesIds: [input.id], parameters: { period: 2, fast: 1, slow: 2, signal: 1 }, panelId: "main", axis: "left" }]);
+    for (const output of result.series) {
+      expect(output.points.find((point) => point.date.getTime() === reported.date.getTime())?.value).toBeNull();
+      expect(output.points.some((point) => point.date.getTime() === history[2]!.date.getTime() && point.value !== null)).toBe(false);
+    }
+    if (kind === "sma" || kind === "ema") expect(result.series[0]!.points.at(-1)?.value).toBe(760.5);
+  }
+});
+
+test("pair studies keep the corrupt observation as a gap and retain valid peer levels on recovery", () => {
+  const input = resolved();
+  const peer = { ...resolved([{ date: history[0]!.date, close: 10 }]), id: "peer", label: "Peer" };
+  for (const kind of ["ratio", "spread"] as const) {
+    const output = resolveStudies([input, peer], [{ id: kind, kind, inputSeriesIds: [input.id, peer.id], parameters: {}, panelId: "main", axis: "left" }]).series[0]!;
+    expect(output.points.map((point) => point.value)).toEqual(kind === "ratio" ? [75.7, null, 76, 76.1] : [747, null, 750, 751]);
+  }
+});

--- a/src/time-series/price-history-integrity.test.ts
+++ b/src/time-series/price-history-integrity.test.ts
@@ -157,9 +157,27 @@ test("rolling and recursive studies restart after a corrupt row instead of calcu
     for (const output of result.series) {
       expect(output.points.find((point) => point.date.getTime() === reported.date.getTime())?.value).toBeNull();
       expect(output.points.some((point) => point.date.getTime() === history[2]!.date.getTime() && point.value !== null)).toBe(false);
+      const warmup = output.points.find((point) => point.date.getTime() === history[2]!.date.getTime());
+      expect(warmup?.provenance?.priceHistoryIntegrity?.sourcePoints[0]?.date).toBe(reported.date.toISOString());
     }
     if (kind === "sma" || kind === "ema") expect(result.series[0]!.points.at(-1)?.value).toBe(760.5);
   }
+});
+
+test("a study retains integrity attribution while warming up after a gap outside the visible window", async () => {
+  const chart = spec();
+  chart.viewport.dateWindow = { start: "2026-09-11", end: "2026-09-15" };
+  chart.studies = [{ id: "sma", kind: "sma", inputSeriesIds: ["price"], parameters: { period: 2 }, panelId: "main", axis: "left" }];
+  const model = await loadChartPaneModel(chart, {
+    marketData: createTestDataProvider({ getPriceHistory: async () => history, getPriceHistoryForResolution: async () => history }),
+  } as HeadlessPaneContext);
+  const study = model.series.find((entry) => entry.id === "sma")!;
+  expect(study.points[0]).toMatchObject({ date: history[2]!.date, value: null });
+  expect(study.points[0]!.provenance?.priceHistoryIntegrity?.sourcePoints[0]?.date).toBe(reported.date.toISOString());
+  expect(study.points[1]).toMatchObject({ value: 760.5 });
+  expect(study.points[1]!.provenance?.priceHistoryIntegrity).toBeUndefined();
+  expect(model.complete).toBe(false);
+  expect(model.chart.warnings.some((warning) => warning.startsWith("SMA") && warning.includes("inconsistent OHLC"))).toBe(true);
 });
 
 test("pair studies keep the corrupt observation as a gap and retain valid peer levels on recovery", () => {
@@ -169,4 +187,8 @@ test("pair studies keep the corrupt observation as a gap and retain valid peer l
     const output = resolveStudies([input, peer], [{ id: kind, kind, inputSeriesIds: [input.id, peer.id], parameters: {}, panelId: "main", axis: "left" }]).series[0]!;
     expect(output.points.map((point) => point.value)).toEqual(kind === "ratio" ? [75.7, null, 76, 76.1] : [747, null, 750, 751]);
   }
+  const constantPeer = { ...peer, points: resolved(history.map((point) => ({ date: point.date, close: 10 }))).points };
+  const correlation = resolveStudies([input, constantPeer], [{ id: "corr", kind: "correlation", inputSeriesIds: [input.id, peer.id], parameters: { period: 2, returns: 0 }, panelId: "main", axis: "left" }]).series[0]!;
+  expect(correlation.points.at(-1)?.value).toBeNull(); // Zero variance after enough valid observations.
+  expect(correlation.points.at(-1)?.provenance?.priceHistoryIntegrity).toBeUndefined();
 });

--- a/src/time-series/price-history-integrity.test.ts
+++ b/src/time-series/price-history-integrity.test.ts
@@ -178,6 +178,7 @@ test("a study retains integrity attribution while warming up after a gap outside
   expect(study.points[1]!.provenance?.priceHistoryIntegrity).toBeUndefined();
   expect(model.complete).toBe(false);
   expect(model.chart.warnings.some((warning) => warning.startsWith("SMA") && warning.includes("inconsistent OHLC"))).toBe(true);
+  expect(model.chart.priceHistoryIntegrity?.map((entry) => [entry.seriesId, entry.scope])).toEqual([["sma", "visible-calculation"]]);
 });
 
 test("pair studies keep the corrupt observation as a gap and retain valid peer levels on recovery", () => {

--- a/src/time-series/reporting.ts
+++ b/src/time-series/reporting.ts
@@ -104,6 +104,16 @@ export function limitGraphRowsBySymbol(
 
 /** Export raw endpoints even when a chart displays percentages, indices, or logs. */
 export function summarizeResolvedSeries(series: ResolvedSeries) {
+  if (series.points.some((point) => point.provenance?.priceHistoryIntegrity)) {
+    return {
+      startDate: series.points[0]?.date.toISOString() ?? null,
+      endDate: series.points.at(-1)?.date.toISOString() ?? null,
+      startValue: null, endValue: null, return: null,
+      unit: series.rawUnit ?? series.unit,
+      pointCount: series.points.length,
+      unavailableReason: "Inconsistent OHLC history in the selected observations.",
+    };
+  }
   const observations = series.points.flatMap((point) => {
     const value = point.rawValue === undefined ? point.value ?? point.close : point.rawValue;
     return typeof value === "number" && Number.isFinite(value) ? [{ date: point.date, value }] : [];

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -38,7 +38,7 @@ import {
   fundamentalSeriesUsesAvailabilityFallback,
   valuationSeriesUsesLiveQuote,
 } from "./fundamentals";
-import { extractSecuritySeries, priceHistoryIntegrityNotices } from "./market";
+import { extractSecuritySeries, collectPriceHistoryIntegrity, chartPriceHistoryIntegrityNotices } from "./market";
 import {
   activeStudyInputSeriesIds,
   maxStudyWarmupPoints,
@@ -46,7 +46,7 @@ import {
 } from "./studies";
 import { applyResolvedSeriesTransform } from "./transforms";
 import { clipSeriesToWindow } from "./alignment";
-import { clipPriceComparison, priceComparisonBoundsForSeries, priceComparisonSeriesIds, resolvePriceComparison, type PriceComparison } from "./price-comparison";
+import { clipPriceComparison, priceComparisonBoundsForSeries, priceComparisonSeriesIds, priceObservationWindowFilter, resolvePriceComparison, type PriceComparison } from "./price-comparison";
 import { reportingCurrencySeries } from "./reporting-currency";
 import { chartQuoteOverrideKeyForSource } from "./live-quotes";
 import { chartSeriesSourceKey } from "../capabilities/chart-series";
@@ -354,6 +354,26 @@ function filterPoints(points: readonly TimeSeriesPoint[], bounds: DateBounds): T
   });
 }
 
+function resolvePriceHistoryIntegrity(
+  spec: ChartSpec,
+  requestedSeries: readonly ResolvedSeries[],
+  visibleSeries: readonly ResolvedSeries[],
+  bounds: DateBounds,
+  resolution: ManualChartResolution,
+  dateWindow: ChartSpec["viewport"]["dateWindow"] | null,
+) {
+  const filters = new Map(requestedSeries.map((entry) => [entry.id, priceObservationWindowFilter(entry, bounds, resolution, dateWindow)]));
+  const requestedIds = activeStudyInputSeriesIds(spec.studies);
+  spec.series.filter((entry) => entry.visible !== false).forEach((entry) => requestedIds.add(entry.id));
+  const selected = requestedSeries.filter((entry) => requestedIds.has(entry.id)).map((entry) => limitSeriesObservations(spec, {
+    ...entry, points: entry.points.filter((point) => filters.get(entry.id)!(point.date.getTime())),
+  }));
+  return [
+    ...collectPriceHistoryIntegrity(selected, "requested-observation", (id, time) => filters.get(id)!(time)),
+    ...collectPriceHistoryIntegrity(visibleSeries, "visible-calculation"),
+  ];
+}
+
 function comparisonDisplayBounds(bounds: DateBounds, comparison: PriceComparison | null): DateBounds {
   if (comparison?.alignment !== "session-date" || comparison.start === null || comparison.end === null) return bounds;
   // A date-only selection can include a local session that began on the prior
@@ -429,8 +449,10 @@ export function seedChartResolutionResult(
       : { ...entry, points: filterPoints(entry.points, entryBounds) };
     return clipPriceComparison(limitSeriesObservations(spec, clipped), priceComparison);
   });
+  const priceHistoryIntegrity = resolvePriceHistoryIntegrity(spec, series, visible, bounds, resolution, spec.viewport.dateWindow ?? null);
   return {
     series: visible,
+    ...(priceHistoryIntegrity.length ? { priceHistoryIntegrity } : {}),
     ...(priceComparison ? { priceComparison } : {}),
     legendSeries: visible,
     ...(spec.viewport.maxPoints === undefined ? { bufferedSeries } : {}),
@@ -439,7 +461,7 @@ export function seedChartResolutionResult(
       ? { viewport: { start: new Date(displayBounds.start), end: new Date(displayBounds.end) } } : {}),
     loading: true,
     errors: studies.errors,
-    warnings: [...studies.warnings, ...priceHistoryIntegrityNotices(visible), ...(priceComparison ? [priceComparison.notice] : [])],
+    warnings: [...studies.warnings, ...chartPriceHistoryIntegrityNotices(priceHistoryIntegrity), ...(priceComparison ? [priceComparison.notice] : [])],
     resolution,
   };
 }
@@ -1331,8 +1353,12 @@ export async function resolveChartSpecData(
   });
   resolved = resolved.map((entry) => limitSeriesObservations(spec, entry));
   resolved = resolved.map((entry) => clipPriceComparison(entry, priceComparison));
+  const priceHistoryIntegrity = resolvePriceHistoryIntegrity(
+    spec, rawSeries, resolved,
+    bounds, resolution, requestBounds ? null : spec.viewport.dateWindow ?? null,
+  );
   if (priceComparison) warnings.push(priceComparison.notice);
-  warnings.push(...priceHistoryIntegrityNotices(resolved));
+  warnings.push(...chartPriceHistoryIntegrityNotices(priceHistoryIntegrity));
   warnings.push(...financialPeriodCoverageWarnings(financialPeriodCoverage(spec, resolved)));
   const resolvedById = new Map(resolved.map((entry) => [entry.id, entry] as const));
   const hiddenBaseSeries = rawSeries
@@ -1368,6 +1394,7 @@ export async function resolveChartSpecData(
     : undefined;
   return {
     series: resolved,
+    ...(priceHistoryIntegrity.length ? { priceHistoryIntegrity } : {}),
     ...(priceComparison ? { priceComparison } : {}),
     ...(sharedSupport.length > 0 ? { resolutionSupport: sharedSupport } : {}),
     legendSeries,

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -46,7 +46,7 @@ import {
 } from "./studies";
 import { applyResolvedSeriesTransform } from "./transforms";
 import { clipSeriesToWindow } from "./alignment";
-import { clipPriceComparison, priceComparisonBoundsForSeries, priceComparisonSeriesIds, resolvePriceComparison } from "./price-comparison";
+import { clipPriceComparison, priceComparisonBoundsForSeries, priceComparisonSeriesIds, resolvePriceComparison, type PriceComparison } from "./price-comparison";
 import { reportingCurrencySeries } from "./reporting-currency";
 import { chartQuoteOverrideKeyForSource } from "./live-quotes";
 import { chartSeriesSourceKey } from "../capabilities/chart-series";
@@ -354,6 +354,16 @@ function filterPoints(points: readonly TimeSeriesPoint[], bounds: DateBounds): T
   });
 }
 
+function comparisonDisplayBounds(bounds: DateBounds, comparison: PriceComparison | null): DateBounds {
+  if (comparison?.alignment !== "session-date" || comparison.start === null || comparison.end === null) return bounds;
+  // A date-only selection can include a local session that began on the prior
+  // UTC day. Keep its original timestamp visible in the rendering viewport.
+  return {
+    start: bounds.start === null ? null : Math.min(bounds.start, comparison.start),
+    end: bounds.end === null ? null : Math.max(bounds.end, comparison.end),
+  };
+}
+
 function followLatestMarketObservation(
   bounds: DateBounds,
   series: readonly ResolvedSeries[],
@@ -399,7 +409,9 @@ export function seedChartResolutionResult(
     for (const point of entry.points) latest = Math.max(latest, point.date.getTime());
   }
   const bounds = requestedBounds(spec, referenceNow ?? new Date(latest));
-  const priceComparison = resolvePriceComparison(spec, series, bounds);
+  const resolution = requestResolution(spec, bounds, new Set(series.map((entry) => entry.id)), {}, []);
+  const priceComparison = resolvePriceComparison(spec, series, bounds, resolution);
+  const displayBounds = comparisonDisplayBounds(bounds, priceComparison);
   const comparisonBounds = priceComparison && priceComparison.start !== null
     ? priceComparison : bounds;
   const baseSeries = series.map((entry) => prepareBaseSeriesForStudies(entry, priceComparisonBoundsForSeries(entry, priceComparison) ?? comparisonBounds));
@@ -408,12 +420,13 @@ export function seedChartResolutionResult(
   const studies = resolveStudies(series, spec.studies);
   const bufferedSeries = [
     ...baseSeries,
-    ...applyStudyPresentationTransforms(studies.series, spec.studies, series, comparisonBounds),
+    ...applyStudyPresentationTransforms(studies.series, spec.studies, series, comparisonBounds, undefined, priceComparison),
   ].map((entry) => clipPriceComparison(entry, priceComparison));
   const visible = bufferedSeries.map((entry) => {
-    const clipped = bounds.start !== null && bounds.end !== null
-      ? clipSeriesToWindow(entry, new Date(bounds.start), new Date(bounds.end))
-      : { ...entry, points: filterPoints(entry.points, bounds) };
+    const entryBounds = presentationBounds(entry, spec.studies, priceComparison, bounds);
+    const clipped = entryBounds.start !== null && entryBounds.end !== null
+      ? clipSeriesToWindow(entry, new Date(entryBounds.start), new Date(entryBounds.end))
+      : { ...entry, points: filterPoints(entry.points, entryBounds) };
     return clipPriceComparison(limitSeriesObservations(spec, clipped), priceComparison);
   });
   return {
@@ -422,14 +435,12 @@ export function seedChartResolutionResult(
     legendSeries: visible,
     ...(spec.viewport.maxPoints === undefined ? { bufferedSeries } : {}),
     ...((explicitBounds(spec) !== null || spec.viewport.maxPoints === undefined)
-      && bounds.start !== null && bounds.end !== null
-      ? { viewport: { start: new Date(bounds.start), end: new Date(bounds.end) } } : {}),
+      && displayBounds.start !== null && displayBounds.end !== null
+      ? { viewport: { start: new Date(displayBounds.start), end: new Date(displayBounds.end) } } : {}),
     loading: true,
     errors: studies.errors,
     warnings: [...studies.warnings, ...(priceComparison ? [priceComparison.notice] : [])],
-    resolution: spec.viewport.resolution === "auto"
-      ? getPresetResolution(spec.viewport.range)
-      : spec.viewport.resolution,
+    resolution,
   };
 }
 
@@ -742,6 +753,7 @@ function baseSecuritySeries(
     axis: spec.axis === "right" ? "right" : "left",
     panelId: spec.panelId,
     interpolation: spec.interpolation,
+    observationKind: marketField ? "market" : undefined,
     timeBasis: marketTimeZone
       ? {
           kind: "market",
@@ -893,12 +905,25 @@ function studyForOutput(
     .sort((left, right) => right.id.length - left.id.length)[0];
 }
 
+function presentationBounds(
+  series: ResolvedSeries,
+  studies: readonly ChartSpec["studies"][number][],
+  comparison: PriceComparison | null,
+  fallback: DateBounds,
+): DateBounds {
+  const study = studyForOutput(series.id, studies);
+  const sourceId = study && (study.kind === "sma" || study.kind === "ema" || study.kind === "bollinger")
+    ? study.inputSeriesIds[0] : series.id;
+  return (sourceId && comparison?.sourceBounds?.[sourceId]) || fallback;
+}
+
 function applyStudyPresentationTransforms(
   outputs: ResolvedSeries[],
   studies: readonly ChartSpec["studies"][number][],
   rawSeries: readonly ResolvedSeries[],
   visibleBounds: DateBounds,
   fallbackBaselineBounds?: DateBounds,
+  priceComparison?: PriceComparison | null,
 ): ResolvedSeries[] {
   const rawById = new Map(rawSeries.map((series) => [series.id, series] as const));
   return outputs.map((output) => {
@@ -909,10 +934,12 @@ function applyStudyPresentationTransforms(
     const input = rawById.get(study.inputSeriesIds[0] ?? "");
     if (!input || input.transform === "raw") return output;
     const baseline = input.transform === "percent" || input.transform === "index100"
-      ? scalarBaseline(input, visibleBounds)
+      ? scalarBaseline(input, priceComparisonBoundsForSeries(input, priceComparison ?? null) ?? visibleBounds)
         ?? (fallbackBaselineBounds ? scalarBaseline(input, fallbackBaselineBounds) : null)
       : undefined;
-    return applyResolvedSeriesTransform(output, input.transform, { baseline });
+    const transformed = applyResolvedSeriesTransform(output, input.transform, { baseline });
+    const inputBounds = priceComparison?.sourceBounds?.[input.id];
+    return inputBounds ? { ...transformed, points: filterPoints(transformed.points, inputBounds) } : transformed;
   });
 }
 
@@ -1261,7 +1288,8 @@ export async function resolveChartSpecData(
   const bounds = hasExplicitWindow
     ? requestVisibleBounds
     : followLatestMarketObservation(initialVisibleBounds, rawSeries);
-  const priceComparison = resolvePriceComparison(spec, rawSeries, bounds, initialResolution);
+  const priceComparison = resolvePriceComparison(spec, rawSeries, bounds, initialResolution, requestBounds ? null : spec.viewport.dateWindow);
+  const displayBounds = comparisonDisplayBounds(bounds, priceComparison);
   const comparisonBounds = priceComparison && priceComparison.start !== null
     ? priceComparison : bounds;
   const resolution = initialResolution;
@@ -1286,6 +1314,7 @@ export async function resolveChartSpecData(
         rawSeries,
         comparisonBounds,
         priceComparison ? undefined : requestVisibleBounds,
+        priceComparison,
       ),
     ];
     warnings.push(...studyResult.warnings);
@@ -1294,11 +1323,12 @@ export async function resolveChartSpecData(
 
   const bufferedSeries = assignAxes(resolved, [...spec.series, ...spec.studies], warnings)
     .map((entry) => clipPriceComparison(entry, priceComparison));
-  resolved = bufferedSeries.map((entry) => (
-    bounds.start !== null && bounds.end !== null
-      ? clipSeriesToWindow(entry, new Date(bounds.start), new Date(bounds.end))
-      : { ...entry, points: filterPoints(entry.points, bounds) }
-  ));
+  resolved = bufferedSeries.map((entry) => {
+    const entryBounds = presentationBounds(entry, spec.studies, priceComparison, bounds);
+    return entryBounds.start !== null && entryBounds.end !== null
+      ? clipSeriesToWindow(entry, new Date(entryBounds.start), new Date(entryBounds.end))
+      : { ...entry, points: filterPoints(entry.points, entryBounds) };
+  });
   resolved = resolved.map((entry) => limitSeriesObservations(spec, entry));
   resolved = resolved.map((entry) => clipPriceComparison(entry, priceComparison));
   if (priceComparison) warnings.push(priceComparison.notice);
@@ -1332,8 +1362,8 @@ export async function resolveChartSpecData(
   }
 
   const exposeViewport = hasExplicitWindow || spec.viewport.maxPoints === undefined;
-  const viewport = exposeViewport && bounds.start !== null && bounds.end !== null
-    ? { start: new Date(bounds.start), end: new Date(bounds.end) }
+  const viewport = exposeViewport && displayBounds.start !== null && displayBounds.end !== null
+    ? { start: new Date(displayBounds.start), end: new Date(displayBounds.end) }
     : undefined;
   return {
     series: resolved,

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -46,7 +46,7 @@ import {
 } from "./studies";
 import { applyResolvedSeriesTransform } from "./transforms";
 import { clipSeriesToWindow } from "./alignment";
-import { clipPriceComparison, priceComparisonSeriesIds, resolvePriceComparison } from "./price-comparison";
+import { clipPriceComparison, priceComparisonBoundsForSeries, priceComparisonSeriesIds, resolvePriceComparison } from "./price-comparison";
 import { reportingCurrencySeries } from "./reporting-currency";
 import { chartQuoteOverrideKeyForSource } from "./live-quotes";
 import { chartSeriesSourceKey } from "../capabilities/chart-series";
@@ -402,7 +402,7 @@ export function seedChartResolutionResult(
   const priceComparison = resolvePriceComparison(spec, series, bounds);
   const comparisonBounds = priceComparison && priceComparison.start !== null
     ? priceComparison : bounds;
-  const baseSeries = series.map((entry) => prepareBaseSeriesForStudies(entry, comparisonBounds));
+  const baseSeries = series.map((entry) => prepareBaseSeriesForStudies(entry, priceComparisonBoundsForSeries(entry, priceComparison) ?? comparisonBounds));
   // Calculate studies from raw buffered inputs, then use the same presentation
   // and visible-window rules as the network result.
   const studies = resolveStudies(series, spec.studies);
@@ -1261,13 +1261,13 @@ export async function resolveChartSpecData(
   const bounds = hasExplicitWindow
     ? requestVisibleBounds
     : followLatestMarketObservation(initialVisibleBounds, rawSeries);
-  const priceComparison = resolvePriceComparison(spec, rawSeries, bounds);
+  const priceComparison = resolvePriceComparison(spec, rawSeries, bounds, initialResolution);
   const comparisonBounds = priceComparison && priceComparison.start !== null
     ? priceComparison : bounds;
   const resolution = initialResolution;
   const baseSeries = rawSeries
     .filter((entry) => visibleSeriesIds.has(entry.id))
-    .map((entry) => prepareBaseSeriesForStudies(entry, comparisonBounds, false, priceComparison ? undefined : requestVisibleBounds));
+    .map((entry) => prepareBaseSeriesForStudies(entry, priceComparisonBoundsForSeries(entry, priceComparison) ?? comparisonBounds, false, priceComparison ? undefined : requestVisibleBounds));
   // Studies run over the same loaded history their base series carries. Clipping
   // them to the requested window instead left a study with no observations
   // wherever the accumulated buffer had already been panned past, so a study's

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -38,7 +38,7 @@ import {
   fundamentalSeriesUsesAvailabilityFallback,
   valuationSeriesUsesLiveQuote,
 } from "./fundamentals";
-import { extractSecuritySeries } from "./market";
+import { extractSecuritySeries, priceHistoryIntegrityNotices } from "./market";
 import {
   activeStudyInputSeriesIds,
   maxStudyWarmupPoints,
@@ -439,7 +439,7 @@ export function seedChartResolutionResult(
       ? { viewport: { start: new Date(displayBounds.start), end: new Date(displayBounds.end) } } : {}),
     loading: true,
     errors: studies.errors,
-    warnings: [...studies.warnings, ...(priceComparison ? [priceComparison.notice] : [])],
+    warnings: [...studies.warnings, ...priceHistoryIntegrityNotices(visible), ...(priceComparison ? [priceComparison.notice] : [])],
     resolution,
   };
 }
@@ -1332,6 +1332,7 @@ export async function resolveChartSpecData(
   resolved = resolved.map((entry) => limitSeriesObservations(spec, entry));
   resolved = resolved.map((entry) => clipPriceComparison(entry, priceComparison));
   if (priceComparison) warnings.push(priceComparison.notice);
+  warnings.push(...priceHistoryIntegrityNotices(resolved));
   warnings.push(...financialPeriodCoverageWarnings(financialPeriodCoverage(spec, resolved)));
   const resolvedById = new Map(resolved.map((entry) => [entry.id, entry] as const));
   const hiddenBaseSeries = rawSeries

--- a/src/time-series/studies.ts
+++ b/src/time-series/studies.ts
@@ -89,6 +89,7 @@ function outputSeries(
     panelId: spec.panelId,
     interpolation: options.interpolation ?? "none",
     timeBasis: input.timeBasis,
+    observationKind: input.observationKind,
     points: options.points,
   };
 }

--- a/src/time-series/studies.ts
+++ b/src/time-series/studies.ts
@@ -1,4 +1,5 @@
-import { alignTimeSeries, scalarPointValue } from "./alignment";
+import { alignTimeSeries, effectiveTimeSeriesPointTime, scalarPointValue } from "./alignment";
+import { mergePriceHistoryIntegrity } from "../utils/price-history-integrity";
 import type {
   ChartStudyKind,
   ChartStudySpec,
@@ -499,6 +500,81 @@ function requiredInputs(kind: ChartStudyKind): number {
   return kind === "ratio" || kind === "spread" || kind === "correlation" ? 2 : 1;
 }
 
+/**
+ * A contradictory observation interrupts the input history. Running studies on
+ * each continuous segment keeps finite windows from skipping the missing bar
+ * and makes recursive indicators warm up again from valid observations.
+ */
+function resolveInterruptedStudy(
+  inputs: readonly ResolvedSeries[],
+  spec: ChartStudySpec,
+): StudyResolutionResult | null {
+  const gaps = new Map<number, TimeSeriesPoint>();
+  for (const input of inputs) {
+    for (const point of input.points) {
+      const integrity = point.provenance?.priceHistoryIntegrity;
+      if (!integrity) continue;
+      const timestamp = effectiveTimeSeriesPointTime(point);
+      const previous = gaps.get(timestamp)?.provenance?.priceHistoryIntegrity;
+      gaps.set(timestamp, {
+        date: new Date(timestamp), observedAt: new Date(timestamp), value: null,
+        provenance: {
+          quality: "derived",
+          priceHistoryIntegrity: previous ? mergePriceHistoryIntegrity(previous, integrity) : integrity,
+        },
+      });
+    }
+  }
+  if (!gaps.size) return null;
+  const times = [...gaps.keys()].sort((left, right) => left - right);
+  const outputs = new Map<string, ResolvedSeries>();
+  const warnings = new Set<string>();
+  const errors = new Set<string>();
+  const cursors = inputs.map((input) => ({
+    input,
+    points: [...input.points].sort((left, right) => effectiveTimeSeriesPointTime(left) - effectiveTimeSeriesPointTime(right)),
+    index: 0,
+    previous: undefined as TimeSeriesPoint | undefined,
+  }));
+  let start = Number.NEGATIVE_INFINITY;
+  for (const end of [...times, Number.POSITIVE_INFINITY]) {
+    const segmentInputs = cursors.map((cursor) => {
+      while (cursor.index < cursor.points.length && effectiveTimeSeriesPointTime(cursor.points[cursor.index]!) <= start) {
+        cursor.previous = cursor.points[cursor.index++];
+      }
+      const previous = cursor.previous;
+      const points: TimeSeriesPoint[] = [];
+      while (cursor.index < cursor.points.length && effectiveTimeSeriesPointTime(cursor.points[cursor.index]!) < end) {
+        const point = cursor.points[cursor.index++]!;
+        points.push(point);
+        cursor.previous = point;
+      }
+      // A valid unaffected peer remains usable for as-of ratio/spread levels.
+      // Correlations instead restart their shared observations and returns.
+      if (spec.kind === "ratio" || spec.kind === "spread") {
+        if (previous && !previous.provenance?.priceHistoryIntegrity) points.unshift(previous);
+      }
+      return { ...cursor.input, points };
+    });
+    const segment = resolveStudies(segmentInputs, [spec]);
+    for (const output of segment.series) {
+      const points = output.points.filter((point) => effectiveTimeSeriesPointTime(point) > start);
+      const previous = outputs.get(output.id);
+      outputs.set(output.id, { ...output, points: [...(previous?.points ?? []), ...points] });
+    }
+    for (const warning of segment.warnings) {
+      if (!warning.includes("not enough valid history")) warnings.add(warning);
+    }
+    for (const error of segment.errors) errors.add(error);
+    start = end;
+  }
+  for (const output of outputs.values()) {
+    output.points.push(...gaps.values());
+    output.points.sort((left, right) => left.date.getTime() - right.date.getTime());
+  }
+  return { series: [...outputs.values()], warnings: [...warnings], errors: [...errors] };
+}
+
 /** Base series that must be calculated for currently visible studies. */
 export function activeStudyInputSeriesIds(
   studySpecs: readonly ChartStudySpec[],
@@ -527,6 +603,13 @@ export function resolveStudies(
     }
     const input = inputs[0]!;
     const color = spec.color ?? STUDY_COLORS[index % STUDY_COLORS.length]!;
+    const interrupted = resolveInterruptedStudy(inputs as ResolvedSeries[], { ...spec, color });
+    if (interrupted) {
+      resolved.push(...interrupted.series);
+      warnings.push(...interrupted.warnings);
+      errors.push(...interrupted.errors);
+      return;
+    }
     let outputs: ResolvedSeries[] = [];
     if (spec.kind === "sma") outputs = resolveMovingAverage(spec, input, color, false);
     else if (spec.kind === "ema") outputs = resolveMovingAverage(spec, input, color, true);

--- a/src/time-series/studies.ts
+++ b/src/time-series/studies.ts
@@ -559,6 +559,18 @@ function resolveInterruptedStudy(
     const segment = resolveStudies(segmentInputs, [spec]);
     for (const output of segment.series) {
       const points = output.points.filter((point) => effectiveTimeSeriesPointTime(point) > start);
+      const gap = gaps.get(start);
+      if (gap && spec.kind !== "ratio" && spec.kind !== "spread" && spec.kind !== "volume") {
+        // A gap just outside the visible window still invalidates the next
+        // warmup observations. Keep those nulls and their original diagnostic
+        // explicit so clipping cannot hide why a study is unavailable.
+        const firstComputed = points[0] ? effectiveTimeSeriesPointTime(points[0]) : Number.POSITIVE_INFINITY;
+        points.unshift(...segmentInputs[0]!.points.filter((point) => effectiveTimeSeriesPointTime(point) < firstComputed).map((point) => ({
+          date: new Date(point.date), observedAt: new Date(point.observedAt),
+          availableAt: point.availableAt ? new Date(point.availableAt) : undefined,
+          value: null, provenance: gap.provenance,
+        })));
+      }
       const previous = outputs.get(output.id);
       outputs.set(output.id, { ...output, points: [...(previous?.points ?? []), ...points] });
     }

--- a/src/time-series/types.ts
+++ b/src/time-series/types.ts
@@ -109,6 +109,7 @@ export interface TimeSeriesPoint {
   volume?: number | null;
   periodLabel?: string;
   provenance?: {
+    priceHistoryIntegrity?: import("../utils/price-history-integrity").PriceHistoryIntegrity;
     secEpsBasis?: import("../utils/sec-eps-basis").SecEpsBasis;
     providerId?: string;
     quality?: "reported" | "derived" | "estimated";

--- a/src/time-series/types.ts
+++ b/src/time-series/types.ts
@@ -173,8 +173,18 @@ export interface TimeSeriesFieldDefinition {
   defaultInterpolation: SeriesInterpolation;
 }
 
+export interface ChartSeriesPriceHistoryIntegrity {
+  seriesId: string;
+  label: string;
+  /** A selected source row, or a visible calculation affected by an earlier row. */
+  scope: "requested-observation" | "visible-calculation";
+  integrity: import("../utils/price-history-integrity").PriceHistoryIntegrity;
+}
+
 export interface ChartResolutionResult {
   series: ResolvedSeries[];
+  /** Survives comparison clipping; contains selected rows and affected visible calculations, not unrelated loaded history. */
+  priceHistoryIntegrity?: ChartSeriesPriceHistoryIntegrity[];
   /** Method and exact shared source dates for normalized closing-price comparisons. */
   priceComparison?: import("./price-comparison").PriceComparison;
   /** Provider capabilities shared by every active market series. */

--- a/src/time-series/types.ts
+++ b/src/time-series/types.ts
@@ -146,6 +146,9 @@ export interface ResolvedSeries {
   interpolation: SeriesInterpolation;
   /** Present only for exchange-traded market observations. */
   timeBasis?: ResolvedSeriesMarketTimeBasis;
+  /** Price/volume observations and their derived studies, including 24/7
+   * markets. Independent of whether the chart compresses exchange sessions. */
+  observationKind?: "market";
   /** Regular-session move supplied with the latest market quote. */
   latestChangePercent?: number;
   points: TimeSeriesPoint[];

--- a/src/utils/price-history-integrity.ts
+++ b/src/utils/price-history-integrity.ts
@@ -1,0 +1,61 @@
+import type { PricePoint } from "../types/financials";
+
+type ReportedPricePoint = Readonly<Omit<PricePoint, "date" | "historySource"> & {
+  date: string;
+  historySource?: Readonly<NonNullable<PricePoint["historySource"]>>;
+}>;
+
+export interface PriceHistoryIntegrity {
+  readonly reason: "inconsistent-ohlc";
+  /** Original reported values, retained for inspection, never used as replacements. */
+  readonly sourcePoints: ReadonlyArray<ReportedPricePoint>;
+}
+
+function snapshotReportedPoint(point: ReportedPricePoint): ReportedPricePoint {
+  return Object.freeze({ ...point, ...(point.historySource ? { historySource: Object.freeze({ ...point.historySource }) } : {}) });
+}
+
+export function mergePriceHistoryIntegrity(...entries: readonly PriceHistoryIntegrity[]): PriceHistoryIntegrity {
+  return Object.freeze({
+    reason: "inconsistent-ohlc",
+    sourcePoints: Object.freeze(entries.flatMap((entry) => entry.sourcePoints.map(snapshotReportedPoint))),
+  });
+}
+
+function finite(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function above(left: number, right: number): boolean {
+  return left - right > 8 * Number.EPSILON * Math.max(Math.abs(left), Math.abs(right));
+}
+
+/** Missing OHLC fields are not contradictory: close-only histories remain usable. */
+export function pricePointIntegrity(point: PricePoint): PriceHistoryIntegrity | undefined {
+  const { open, high, low, close } = point;
+  const invalid = (finite(high) && finite(low) && above(low, high))
+    || [open, close].some((value) => finite(value)
+      && ((finite(high) && above(value, high)) || (finite(low) && above(low, value))));
+  if (!invalid) return undefined;
+  const date = new Date(point.date);
+  return Object.freeze({
+    reason: "inconsistent-ohlc",
+    sourcePoints: Object.freeze([snapshotReportedPoint({ ...point, date: Number.isFinite(date.getTime()) ? date.toISOString() : String(point.date) })]),
+  });
+}
+
+/** Calculation/display fields deliberately exclude the contradictory source row. */
+export function pricePointValues(point: PricePoint, integrity = pricePointIntegrity(point)) {
+  const value = (number: number | undefined) => !integrity && finite(number) ? number : null;
+  return {
+    open: value(point.open), high: value(point.high), low: value(point.low),
+    close: value(point.close), volume: value(point.volume),
+    ...(integrity ? { integrity } : {}),
+  };
+}
+
+export function priceHistoryIntegrityNotice(count: number): string | undefined {
+  return count > 0
+    ? `${count} inconsistent OHLC ${count === 1 ? "bar is" : "bars are"} unavailable. Affected calculations contain gaps; original values and reasons are retained in JSON exports.`
+    : undefined;
+}


### PR DESCRIPTION
Mixed-market research could show empty comparisons, drop crypto weekend observations, or display the wrong value when inspecting another exchange’s endpoint. Yahoo full-history responses could also carry the wrong interval, and contradictory OHLC records remained usable in charts and risk statistics.

This change preserves original market observations across the research workflow:

- Daily and slower comparisons share calendar dates while retaining each listing’s timestamps and baseline. Cached Auto results, date-only session windows, price overlays and cursor navigation use the same observations. Crypto prices and their studies stay at their own timestamps, including weekends; financial disclosures retain their availability rules.
- Yahoo full-history requests use explicit bounds and verify the returned interval. Cache migration retires affected Yahoo/cloud ALL histories while retaining valid broker and independent-source caches.
- Contradictory OHLC records become explicit gaps with immutable original diagnostics. Charts, historical tables, overview returns and studies cannot replace an invalid current value with a previous price or calculate across it silently. Risk matrices and relationship analysis leave affected windows unavailable, including matrix diagonals, while retaining usable independent pairs.
- Comparison clipping preserves selected-window integrity diagnostics and marks partial research exports, even when the valid shared interval is shorter than the requested interval.

Validation: all 3,147 tests / 12,700 assertions across 526 files pass on the published head. CI passed all six runtime TypeScript targets, desktop/browser builds, browser bundle audit, Cloudflare dry run, native build and upgrade smoke. Focused regression coverage includes 528 tests / 3,358 assertions across 60 files. Independent source reviews, original Yahoo/cache replay and combined recorded-input rendering passed. Recorded-input OpenTUI checks cover 80/110-column historical prices, charts, overview, correlation and relationship panes. The original SPY and BTC contradictions remain available in exported diagnostics; clean controls and subsequent valid-data recovery remain usable.

Live verification: the built browser app and isolated native tmux app show matching BTC/ETH/SPY/SHIB comparisons for 1M and 1Y; browser reload preserves the selected window. Browser console and native runtime scans were clean. The public production backend returns correctly dated monthly history for SHIB, MSFT, JEPQ and Shell, and distinct weekly SHIB history. Missing feeds in the local proxy are outside the verified comparison flow. No release or version bump.
