### PR TITLE
Find plugins installed under either product name

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -114,7 +114,7 @@ The toolbar controls preset or exact date ranges, intervals from one minute thro
 | `ERN` | Earnings calendar |
 | `IPO` | Upcoming and recent IPOs |
 | `HALT` | US trading halts with reason and resumption times |
-| `TV` | Live Bloomberg, CNBC, and Yahoo Finance television ([TV plugin](https://github.com/gloom-sh/gloomberb-tv)) |
+| `TV` | Live Bloomberg, CNBC, and Yahoo Finance television ([TV plugin](https://github.com/gloom-sh/gloom-tv)) |
 | `BI` / `SP` | S&P 500 sector performance |
 | `FXC` | Major FX cross rates |
 | `FNG` | Fear and greed market gauge |

--- a/src/plugins/host-link.test.ts
+++ b/src/plugins/host-link.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, readlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { linkHostPackages } from "./host-link";
+import { pluginDirectoryNames } from "./plugin-names";
+
+/**
+ * A plugin is installed into a directory named after its repository, but
+ * declares a sibling plugin by package name. Plugin repos are renaming from
+ * `gloomberb-` to `gloom-` one at a time, so those two names disagree for as
+ * long as the migration runs. When the link is missed the sibling's import
+ * throws and the plugin fails to load, which is why this is worth pinning.
+ */
+describe("pluginDirectoryNames", () => {
+  test("looks under both product names, declared name first", () => {
+    expect(pluginDirectoryNames("gloomberb-ibkr")).toEqual(["gloomberb-ibkr", "gloom-ibkr"]);
+    expect(pluginDirectoryNames("gloom-ibkr")).toEqual(["gloom-ibkr", "gloomberb-ibkr"]);
+  });
+
+  test("leaves a name that is neither alone", () => {
+    expect(pluginDirectoryNames("react")).toEqual(["react"]);
+  });
+});
+
+describe("linkPeerPlugins", () => {
+  /** A plugins dir holding `peerDir`, plus a plugin that depends on `peerDep`. */
+  function setup(peerDep: string, peerDir: string) {
+    const root = mkdtempSync(join(tmpdir(), "gloom-host-link-"));
+    const hostRoot = join(root, "host");
+    const pluginsDir = join(root, "plugins");
+    const pluginDir = join(pluginsDir, "gateway");
+    mkdirSync(hostRoot, { recursive: true });
+    mkdirSync(join(pluginsDir, peerDir), { recursive: true });
+    mkdirSync(pluginDir, { recursive: true });
+    writeFileSync(
+      join(pluginDir, "package.json"),
+      JSON.stringify({ name: "gateway", peerDependencies: { [peerDep]: ">=1.0.0" } }),
+    );
+    return { hostRoot, pluginsDir, pluginDir };
+  }
+
+  test("links a peer whose install directory uses the other product name", () => {
+    const { hostRoot, pluginsDir, pluginDir } = setup("gloomberb-ibkr", "gloom-ibkr");
+
+    const result = linkHostPackages(pluginDir, hostRoot, pluginsDir);
+
+    // Named for the import specifier, pointing at the directory that exists.
+    expect(result.linked).toContain("gloomberb-ibkr");
+    expect(readlinkSync(join(pluginDir, "node_modules", "gloomberb-ibkr"))).toBe(
+      join(pluginsDir, "gloom-ibkr"),
+    );
+  });
+
+  test("links a gloom- peer, which the old prefix filter dropped", () => {
+    const { hostRoot, pluginsDir, pluginDir } = setup("gloom-ibkr", "gloom-ibkr");
+
+    const result = linkHostPackages(pluginDir, hostRoot, pluginsDir);
+
+    expect(result.linked).toContain("gloom-ibkr");
+  });
+
+  test("skips a peer that is not installed under either name", () => {
+    const { hostRoot, pluginsDir, pluginDir } = setup("gloomberb-ibkr", "unrelated");
+
+    const result = linkHostPackages(pluginDir, hostRoot, pluginsDir);
+
+    expect(result.linked).not.toContain("gloomberb-ibkr");
+  });
+});

--- a/src/plugins/host-link.ts
+++ b/src/plugins/host-link.ts
@@ -1,6 +1,8 @@
 import { existsSync, lstatSync, mkdirSync, readlinkSync, rmSync, symlinkSync } from "fs";
 import { dirname, join, resolve } from "path";
 
+import { isPluginPackageName, pluginDirectoryNames } from "./plugin-names";
+
 /**
  * External plugins live in `~/.gloomberb/plugins/<name>/`, outside any
  * `node_modules` chain that could reach the running Gloomberb install. Left
@@ -76,16 +78,18 @@ function linkPeerPlugins(pluginDir: string, pluginsDir: string): string[] {
   let peers: string[] = [];
   try {
     const pkg = JSON.parse(require("fs").readFileSync(join(pluginDir, "package.json"), "utf-8"));
-    peers = Object.keys(pkg.peerDependencies ?? {}).filter((name) => name.startsWith("gloomberb-"));
+    peers = Object.keys(pkg.peerDependencies ?? {}).filter(isPluginPackageName);
   } catch {
     return linked;
   }
 
   for (const peer of peers) {
-    // Installed directories are named after the repository, which is the package
-    // name for every plugin in the registry.
-    const target = join(pluginsDir, peer);
-    if (!existsSync(target)) continue;
+    // Declared by package name, installed under a directory named for the repo:
+    // the two disagree while the plugin is mid-rename.
+    const target = pluginDirectoryNames(peer)
+      .map((name) => join(pluginsDir, name))
+      .find((candidate) => existsSync(candidate));
+    if (!target) continue;
     const linkPath = join(pluginDir, "node_modules", peer);
     if (alreadyLinked(linkPath, target)) {
       linked.push(peer);

--- a/src/plugins/plugin-names.ts
+++ b/src/plugins/plugin-names.ts
@@ -1,0 +1,32 @@
+/**
+ * Plugin repositories are renaming from `gloomberb-` to `gloom-`, one at a
+ * time, as the product name moves.
+ *
+ * A plugin is installed into a directory named after the repository it was
+ * cloned from, so the same plugin can sit under either name depending on when
+ * it was installed. Anything that looks a plugin up by name has to accept both,
+ * or it will miss an install that is already there: the peer linker would fail
+ * to resolve a sibling's imports, and the seeder would install a second copy
+ * whose duplicate id the loader then refuses.
+ */
+export const PLUGIN_NAME_PREFIXES = ["gloom-", "gloomberb-"] as const;
+
+/** True for a name that belongs to a plugin package under either product name. */
+export function isPluginPackageName(name: string): boolean {
+  return PLUGIN_NAME_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
+
+/**
+ * The directory names a plugin could be installed under, the given name first.
+ *
+ * A name with neither prefix is returned alone, so this is safe to call on any
+ * dependency name.
+ */
+export function pluginDirectoryNames(name: string): string[] {
+  for (const prefix of PLUGIN_NAME_PREFIXES) {
+    if (!name.startsWith(prefix)) continue;
+    const other = PLUGIN_NAME_PREFIXES.find((candidate) => candidate !== prefix);
+    return [name, `${other}${name.slice(prefix.length)}`];
+  }
+  return [name];
+}

--- a/src/plugins/seed.test.ts
+++ b/src/plugins/seed.test.ts
@@ -56,7 +56,7 @@ describe("seedExtractedPlugins", () => {
       dir,
     ));
 
-    expect(installs).not.toContain("gloom-sh/gloomberb-substack");
+    expect(installs).not.toContain("gloom-sh/gloom-substack");
     // Recorded, so we stop asking rather than retrying every launch.
     expect(result.seeded).toContain("substack");
   });
@@ -64,11 +64,28 @@ describe("seedExtractedPlugins", () => {
   test("records a plugin that is already installed without reinstalling it", async () => {
     const installs: string[] = [];
     const result = await withPluginsDir((pluginsDir) => {
+      mkdirSync(join(pluginsDir, "gloom-substack"), { recursive: true });
+      return seedExtractedPlugins(config(), async (ref) => { installs.push(ref); }, pluginsDir);
+    });
+
+    expect(installs).not.toContain("gloom-sh/gloom-substack");
+    expect(result.seeded).toContain("substack");
+  });
+
+  /**
+   * The plugin repositories are renaming to `gloom-`, so anyone who installed
+   * one before the rename has it in a directory under the old name. Seeding by
+   * the new name alone would clone a second copy, and the loader then refuses
+   * both for sharing an id.
+   */
+  test("finds an install made before the repository was renamed", async () => {
+    const installs: string[] = [];
+    const result = await withPluginsDir((pluginsDir) => {
       mkdirSync(join(pluginsDir, "gloomberb-substack"), { recursive: true });
       return seedExtractedPlugins(config(), async (ref) => { installs.push(ref); }, pluginsDir);
     });
 
-    expect(installs).not.toContain("gloom-sh/gloomberb-substack");
+    expect(installs).not.toContain("gloom-sh/gloom-substack");
     expect(result.seeded).toContain("substack");
   });
 
@@ -78,7 +95,7 @@ describe("seedExtractedPlugins", () => {
       const result = await withPluginsDir((dir) => seedExtractedPlugins(
         config({ disabledPlugins: [owner] }), async (ref) => { installs.push(ref); }, dir,
       ));
-      expect(installs).not.toContain("gloom-sh/gloomberb-tv");
+      expect(installs).not.toContain("gloom-sh/gloom-tv");
       expect(result.seeded).toContain("tv");
     }
   });

--- a/src/plugins/seed.ts
+++ b/src/plugins/seed.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import type { AppConfig } from "../types/config";
 import { debugLog } from "../utils/debug-log";
 import { getPluginsDir } from "./loader";
+import { pluginDirectoryNames } from "./plugin-names";
 
 const log = debugLog.createLogger("plugin-seed");
 
@@ -16,13 +17,13 @@ const log = debugLog.createLogger("plugin-seed");
  * so it is never reinstalled — including when the user removes it deliberately.
  */
 export const EXTRACTED_PLUGINS = [
-  { id: "tv", repo: "gloom-sh/gloomberb-tv", directory: "gloomberb-tv", previousOwnerIds: ["macro", "macro-tv"] },
-  { id: "substack", repo: "gloom-sh/gloomberb-substack", directory: "gloomberb-substack" },
+  { id: "tv", repo: "gloom-sh/gloom-tv", directory: "gloom-tv", previousOwnerIds: ["macro", "macro-tv"] },
+  { id: "substack", repo: "gloom-sh/gloom-substack", directory: "gloom-substack" },
   { id: "ibkr", repo: "gloom-sh/gloomberb-ibkr", directory: "gloomberb-ibkr" },
   { id: "ibkr-gateway", repo: "gloom-sh/gloomberb-ibkr-gateway", directory: "gloomberb-ibkr-gateway" },
-  { id: "public", repo: "gloom-sh/gloomberb-public", directory: "gloomberb-public" },
-  { id: "robinhood", repo: "gloom-sh/gloomberb-robinhood", directory: "gloomberb-robinhood" },
-  { id: "simplefin", repo: "gloom-sh/gloomberb-simplefin", directory: "gloomberb-simplefin" },
+  { id: "public", repo: "gloom-sh/gloom-public", directory: "gloom-public" },
+  { id: "robinhood", repo: "gloom-sh/gloom-robinhood", directory: "gloom-robinhood" },
+  { id: "simplefin", repo: "gloom-sh/gloom-simplefin", directory: "gloom-simplefin" },
 ] as const;
 
 export interface SeedResult {
@@ -32,8 +33,13 @@ export interface SeedResult {
   seeded: string[];
 }
 
+/**
+ * Checks both product names, because a plugin installed before its repository
+ * was renamed sits in a directory under the old one. Missing that install would
+ * clone a second copy, and the loader refuses the duplicate id.
+ */
 function isInstalled(directory: string, pluginsDir: string): boolean {
-  return existsSync(join(pluginsDir, directory));
+  return pluginDirectoryNames(directory).some((name) => existsSync(join(pluginsDir, name)));
 }
 
 /**


### PR DESCRIPTION
Prep for renaming the plugin repositories from `gloomberb-*` to `gloom-*`.

A plugin is installed into a directory named after **the repository** (`git clone` target in `installPlugin`), but a sibling plugin is declared by **package name**. Those two agree only while both use the same product name, so a rename breaks two lookups:

- `linkPeerPlugins` filtered peers with `startsWith("gloomberb-")` and resolved them to exactly that directory. IBKR Gateway imports `gloomberb-ibkr/config` at module load, so a missed link means the plugin throws on load.
- `seedExtractedPlugins` checked a single directory. Pointed at a renamed repo, it would clone a second copy next to an existing install, and the loader refuses two plugins with one id.

Both now use `pluginDirectoryNames()`, which tries the declared name first and then the counterpart prefix. That covers an old install under a new declaration and the reverse.

`EXTRACTED_PLUGINS` moves to the five repos already renamed (tv, substack, public, robinhood, simplefin). **IBKR and IBKR Gateway deliberately stay on `gloomberb-`**: they are a peer pair, and renaming them before this ships would break the gateway for anyone installing on a current release.

Tests cover the peer link across names and a seed against a pre-rename directory. Full `src/plugins` suite and `bun run typecheck` pass.