### PR TITLE
Keep sector rankings on a shared session and reject invalid return endpoints

### DIFF
--- a/src/plugins/builtin/sectors/client.test.ts
+++ b/src/plugins/builtin/sectors/client.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { DataProvider } from "../../../types/data-provider";
 import type { PricePoint, Quote } from "../../../types/financials";
 import { loadSectorRows } from "./client";
+import { projectSectorRows } from "./headless";
 
 const sectors = [
   { name: "Technology", etf: "XLK" },
@@ -90,4 +91,69 @@ test("one missing baseline bar cannot change a fund's comparison window", async 
   expect(outcomes[0]?.row?.return1M).toBeCloseTo(16.6666667);
   expect(outcomes[1]?.row?.return1M).toBeNull();
   expect(outcomes.map(({ row }) => row?.return1Y)).toEqual([31.25, 31.25]);
+});
+
+test("a prior-session quote cannot lead the current sector ranking", async () => {
+  const provider = {
+    getQuote: async (symbol: string) => symbol === "XLK" ? quote(symbol) : {
+      ...quote(symbol), price: 117, changePercent: 17, changeSessionDate: "2026-09-09",
+    },
+    getPriceHistory: async () => history,
+  } as unknown as DataProvider;
+  const rows = projectSectorRows(sectors, await loadSectorRows(sectors, provider));
+  expect(rows.map((row) => row.etf)).toEqual(["XLK", "XLF"]);
+  expect(rows[1]).toMatchObject({ price: null, changePercent: null, lastReportedPrice: 117,
+    quoteSessionDate: "2026-09-09", quoteUnavailable: true, returnAsOfDate: "2026-09-10" });
+  expect(rows[1]?.quoteIssue).toContain("shared session is 2026-09-10");
+  expect(rows[1]?.return1M).toBeCloseTo(11.111111);
+  expect(rows[1]?.return1Y).toBe(25);
+});
+
+test.each([
+  { stale: true },
+  { changeSessionDate: "2026-02-30" },
+  { changeSessionDate: undefined, lastUpdated: NaN },
+])("withholds unverifiable session prices even when all quotes share the defect: %j", async (override) => {
+  const provider = {
+    getQuote: async (symbol: string) => ({ ...quote(symbol), ...override }),
+    getPriceHistory: async () => history,
+  } as unknown as DataProvider;
+  const rows = await loadSectorRows(sectors, provider);
+  for (const { row } of rows) {
+    expect(row).toMatchObject({ price: null, changePercent: null, quoteUnavailable: true, return1Y: 25 });
+    expect(row?.quoteIssue).toBeTruthy();
+  }
+});
+
+test("missing session change stays unavailable while a reported zero is valid", async () => {
+  const provider = {
+    getQuote: async (symbol: string) => ({ ...quote(symbol), changePercent: symbol === "XLK" ? NaN : 0 }),
+    getPriceHistory: async () => history,
+  } as unknown as DataProvider;
+  const rows = projectSectorRows(sectors, await loadSectorRows(sectors, provider));
+  expect(rows.map((row) => row.etf)).toEqual(["XLF", "XLK"]);
+  expect(rows[0]).toMatchObject({ changePercent: 0, quoteIssue: null });
+  expect(rows[1]).toMatchObject({ price: 105, changePercent: null, quoteIssue: "1D change unavailable" });
+});
+
+test("a corrected boundary response replaces the cached contradiction without mutating it", async () => {
+  const bad = { ...history[0]!, open: 80, high: 79, low: 78 };
+  const original = { ...bad };
+  let corrected = false;
+  const provider = {
+    getQuote: async (symbol: string) => quote(symbol),
+    getPriceHistory: async () => [bad, ...history.slice(1)],
+    getDetailedPriceHistory: async () => [{ ...bad, ...(corrected ? { high: 81 } : {}) }],
+  } as unknown as DataProvider;
+  const [first] = await loadSectorRows(sectors.slice(0, 1), provider);
+  expect(first?.row?.return1Y).toBeNull();
+  expect(first?.row?.return1M).toBeCloseTo(16.6666667);
+  const diagnostic = first?.row?.returnIntegrity?.["1Y"];
+  expect(diagnostic?.sourcePoints[0]).toMatchObject({ close: 80, high: 79, low: 78 });
+  corrected = true;
+  const [next] = await loadSectorRows(sectors.slice(0, 1), provider);
+  expect(next?.row?.return1Y).toBe(31.25);
+  expect(next?.row?.returnIntegrity).toEqual({});
+  expect(bad).toEqual(original);
+  expect(diagnostic?.sourcePoints[0]?.high).toBe(79);
 });

--- a/src/plugins/builtin/sectors/client.ts
+++ b/src/plugins/builtin/sectors/client.ts
@@ -46,11 +46,19 @@ export async function loadSectorRows(
     let history: PricePoint[] = histories.get(sector.etf) ?? [];
     const quote = quotes.get(sector.etf) ?? null;
     if (!quote && history.length === 0) return { etf: sector.etf, row: null };
-    const price = quote && Number.isFinite(quote.price) && quote.price > 0 ? quote.price : null;
-    const currentPrice = quoteDates.get(sector.etf) === asOfDate ? price : null;
+    const lastReportedPrice = quote && Number.isFinite(quote.price) && quote.price > 0 ? quote.price : null;
+    const sessionDate = quoteDates.get(sector.etf) ?? null;
+    const priceIssue = !quote || lastReportedPrice == null ? "quote unavailable"
+      : !sessionDate ? "quote session unknown"
+      : quote.stale ? `stale quote from ${sessionDate}`
+      : sessionDate !== asOfDate ? `quote from ${sessionDate}; shared session is ${asOfDate}`
+      : null;
+    const price = priceIssue ? null : lastReportedPrice;
+    const changePercent = price != null && Number.isFinite(quote?.changePercent) ? quote!.changePercent : null;
+    const quoteIssue = priceIssue ?? (changePercent == null ? "1D change unavailable" : null);
     // A strict trailing request may begin after the prior year's weekend or
     // holiday. Ask for a small boundary buffer when the provider supports it.
-    if (asOfDate && !computeTrailingReturn(history, "1Y", currentPrice, asOfDate)
+    if (asOfDate && computeTrailingReturn(history, "1Y", price, asOfDate)?.value == null
       && provider.getDetailedPriceHistory) {
       const start = new Date(`${sectorReturnTargetDate(asOfDate, "1Y")}T00:00:00Z`);
       start.setUTCDate(start.getUTCDate() - 7);
@@ -59,19 +67,26 @@ export async function loadSectorRows(
       const extended = await provider.getDetailedPriceHistory(sector.etf, "", start, end, "1d").catch(() => []);
       if (extended.length > 0) history = [...history, ...extended];
     }
-    const month = computeTrailingReturn(history, "1M", currentPrice, asOfDate);
-    const year = computeTrailingReturn(history, "1Y", currentPrice, asOfDate);
+    const month = computeTrailingReturn(history, "1M", price, asOfDate);
+    const year = computeTrailingReturn(history, "1Y", price, asOfDate);
     return {
       etf: sector.etf,
       row: {
         price,
         quoteUnavailable: price == null,
-        changePercent: quote?.changePercent ?? null,
+        quoteSessionDate: sessionDate,
+        quoteIssue,
+        lastReportedPrice,
+        changePercent,
         return1M: month?.value ?? null,
         return1Y: year?.value ?? null,
         returnAsOfDate: asOfDate,
         return1MStartDate: month?.startDate ?? null,
         return1YStartDate: year?.startDate ?? null,
+        returnIntegrity: {
+          ...(month?.integrity ? { "1M": month.integrity } : {}),
+          ...(year?.integrity ? { "1Y": year.integrity } : {}),
+        },
         currency: quote?.currency ?? "USD",
       },
     };
@@ -92,6 +107,7 @@ function quoteSessionDate(quote: Quote): string | null {
   const declared = quote.changeSessionDate;
   if (typeof declared === "string" && /^\d{4}-\d{2}-\d{2}$/.test(declared)
     && Number.isFinite(Date.parse(declared)) && new Date(declared).toISOString().slice(0, 10) === declared) return declared;
+  if (declared != null) return null;
   if (!Number.isFinite(quote.lastUpdated) || quote.lastUpdated <= 0) return null;
   // Every instrument in these collections is a US-listed ETF. quote.price is
   // the regular-session price; prefer its declared session when supplied.

--- a/src/plugins/builtin/sectors/headless.test.ts
+++ b/src/plugins/builtin/sectors/headless.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
 import { createSectorsHeadless } from "./headless";
+import { pricePointIntegrity } from "../../../utils/price-history-integrity";
 
 function args(collection: string): HeadlessPaneLoadArgs {
   return { rawArgument: "", argument: null, symbols: [], options: { collection } };
@@ -51,4 +52,21 @@ test("an available quote does not make an unavailable annual window complete", a
   expect(result.unavailableSymbols).toContain("XLK");
   expect(result.errors?.some((error) => error.startsWith("XLK:"))).toBe(true);
   expect(result.rows.find((row) => row.etf === "XLK")).toMatchObject({ price: 100, return1M: 2, return1Y: null });
+});
+
+test("exports stale quote dates and rejected endpoints with the matching reason", async () => {
+  const integrity = pricePointIntegrity({ date: new Date("2025-09-10"), open: 80, high: 79, low: 78, close: 80 })!;
+  const headless = createSectorsHeadless({
+    load: async (_args, definitions) => definitions.map((definition) => ({ etf: definition.etf, row: {
+      price: null, lastReportedPrice: 117, quoteSessionDate: "2026-09-09", quoteIssue: "stale quote from 2026-09-09",
+      quoteUnavailable: true, changePercent: null, return1M: 2, return1Y: null, returnIntegrity: { "1Y": integrity },
+    } })),
+  });
+  const result = await headless.load(args("sectors"), {} as HeadlessPaneContext);
+  expect(result.unavailableSymbols).toContain("XLK");
+  expect(result.errors).toContain("XLK: stale quote from 2026-09-09.");
+  expect(result.errors).toContain("XLK: 1Y: inconsistent OHLC at return endpoint.");
+  expect(result.errors?.some((error) => error.includes("history does not cover"))).toBe(false);
+  expect(result.rows.find((row) => row.etf === "XLK")).toMatchObject({ lastReportedPrice: 117,
+    quoteSessionDate: "2026-09-09", returnIntegrity: { "1Y": integrity } });
 });

--- a/src/plugins/builtin/sectors/headless.ts
+++ b/src/plugins/builtin/sectors/headless.ts
@@ -6,7 +6,7 @@ import type {
 import { formatCurrency, formatPercentRaw } from "../../../utils/format";
 import { loadSectorRows, type SectorRowOutcome } from "./client";
 import { getSectorCollection, type SectorCollectionId, type SectorDef } from "./sector-data";
-import { DEFAULT_SORT_PREFERENCE, sortRows, type SectorRow } from "./sector-model";
+import { DEFAULT_SORT_PREFERENCE, sectorRowIssues, sortRows, type SectorRow } from "./sector-model";
 
 const COLUMNS = [
   { key: "name", header: "Sector" },
@@ -31,6 +31,10 @@ export function projectSectorRows(
     currency: byEtf.get(definition.etf)?.currency ?? "USD",
     loading: false,
     quoteUnavailable: !byEtf.get(definition.etf) || byEtf.get(definition.etf)?.quoteUnavailable === true,
+    quoteSessionDate: byEtf.get(definition.etf)?.quoteSessionDate ?? null,
+    quoteIssue: byEtf.get(definition.etf)?.quoteIssue ?? null,
+    lastReportedPrice: byEtf.get(definition.etf)?.lastReportedPrice ?? null,
+    returnIntegrity: byEtf.get(definition.etf)?.returnIntegrity ?? {},
     returnAsOfDate: byEtf.get(definition.etf)?.returnAsOfDate ?? null,
     return1MStartDate: byEtf.get(definition.etf)?.return1MStartDate ?? null,
     return1YStartDate: byEtf.get(definition.etf)?.return1YStartDate ?? null,
@@ -71,10 +75,11 @@ export function createSectorsHeadless(
       const rows = projectSectorRows(definitions, outcomes);
       const unavailableQuotes = rows.filter((row) => row.quoteUnavailable).map((row) => row.etf);
       const unavailableReturns = rows.filter((row) => row.return1M == null || row.return1Y == null).map((row) => row.etf);
-      const unavailableSymbols = [...new Set([...unavailableQuotes, ...unavailableReturns])];
+      const unavailableDailyChanges = rows.filter((row) => row.changePercent == null).map((row) => row.etf);
+      const unavailableSymbols = [...new Set([...unavailableQuotes, ...unavailableReturns, ...unavailableDailyChanges])];
       return {
         unavailableSymbols: unavailableSymbols.length > 0 ? unavailableSymbols : undefined,
-        errors: unavailableReturns.map((symbol) => `${symbol}: price history does not cover one or more requested calendar windows.`),
+        errors: rows.flatMap((row) => sectorRowIssues(row).map((issue) => `${row.etf}: ${issue}.`)),
         rows: rows.map((row) => ({ ...row })),
         metadata: {
           collection: collectionId,
@@ -82,6 +87,7 @@ export function createSectorsHeadless(
           requested: definitions.length,
           unavailableQuotes,
           unavailableReturns,
+          unavailableDailyChanges,
           returnDefinition: "ETF price returns in listing currency; cash distributions are not reinvested. Shared ending session and calendar-month/year boundaries; prior close used for holidays.",
           returnWindows: rows.map((row) => ({ symbol: row.etf, asOfDate: row.returnAsOfDate, monthStartDate: row.return1MStartDate, yearStartDate: row.return1YStartDate })),
         },

--- a/src/plugins/builtin/sectors/index.tsx
+++ b/src/plugins/builtin/sectors/index.tsx
@@ -6,6 +6,7 @@ import type { PluginModule } from "../plugin-module";
 import { usePaneSettingValue } from "../../../state/app/context";
 import { colors, priceColor } from "../../../theme/colors";
 import { formatCurrency, formatPercentRaw } from "../../../utils/format";
+import { wrapTextLines } from "../../../utils/text-wrap";
 import { useAssetData, useDebouncedPluginPaneState, usePluginPaneState, usePluginTickerActions } from "../../runtime";
 import { useAutoRefresh, useUpdatedAgo } from "../shared/auto-refresh";
 import { SectorMoveBar } from "./move-bar";
@@ -24,6 +25,7 @@ import {
   buildSectorColumns,
   nextSortPreference,
   normalizeRowsForCollection,
+  sectorRowIssues,
   sortRows,
   updateRowsForCollection,
   type SectorColumn,
@@ -58,11 +60,11 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
     [activeCollection.id, savedIndustryEtfs, savedSectorEtfs],
   );
   const [rowsByCollection, setRowsByCollection] = useDebouncedPluginPaneState<SectorRowsByCollection>(
-    "rowsByCollection:v2",
+    "rowsByCollection:v3",
     INITIAL_ROWS_BY_COLLECTION,
   );
   const [lastRefreshByCollection, setLastRefreshByCollection] = useDebouncedPluginPaneState<SectorRefreshByCollection>(
-    "lastRefreshByCollection:v1",
+    "lastRefreshByCollection:v2",
     INITIAL_REFRESH_BY_COLLECTION,
   );
   const [selectedEtf, setSelectedEtf] = usePluginPaneState<string | null>("selectedEtf", null);
@@ -108,17 +110,11 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
       if (fetchGenRef.current !== gen) return;
       const loadedByEtf = new Map(outcomes.map((outcome) => [outcome.etf, outcome.row]));
       setRowsByCollection((prev) => updateRowsForCollection(prev, collectionId, sectorDefs, (rows) => (
-        rows.map((row) => ({ ...row, ...(loadedByEtf.get(row.etf) ?? { price: null, changePercent: null, return1M: null, return1Y: null, returnAsOfDate: null, return1MStartDate: null, return1YStartDate: null, quoteUnavailable: true }), loading: false }))
+        rows.map((row) => ({ ...row, ...(loadedByEtf.get(row.etf) ?? { price: null, changePercent: null, return1M: null, return1Y: null, returnAsOfDate: null, return1MStartDate: null, return1YStartDate: null, quoteUnavailable: true, quoteSessionDate: null, quoteIssue: "quote unavailable", lastReportedPrice: null, returnIntegrity: {} }), loading: false }))
       )));
 
       const loadedCount = outcomes.filter((outcome) => outcome.row).length;
-      const missingQuotes = outcomes.filter((outcome) => !outcome.row || outcome.row.quoteUnavailable).length;
-      const missingReturns = outcomes.filter((outcome) => outcome.row && (outcome.row.return1M == null || outcome.row.return1Y == null)).length;
-      const warnings = [
-        ...(missingQuotes > 0 ? [`${missingQuotes} quotes unavailable`] : []),
-        ...(missingReturns > 0 ? [`${missingReturns} return windows incomplete`] : []),
-      ];
-      setLoadError(loadedCount === 0 ? "Sector data unavailable" : warnings.join(" · ") || null);
+      setLoadError(loadedCount === 0 ? "Sector data unavailable" : null);
       // A refresh that returned nothing must not claim the board is current.
       if (loadedCount === 0) return;
       setLastRefreshByCollection((prev) => ({ ...prev, [collectionId]: Date.now() }));
@@ -212,18 +208,27 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
 
   const updatedAgo = useUpdatedAgo(lastRefreshMs);
   const returnAsOfDate = rows.map((row) => row.returnAsOfDate).filter((date): date is string => !!date).sort().at(-1);
+  const incompleteRows = rows.filter((row) => !row.loading && sectorRowIssues(row).length > 0).length;
+  const selectedRow = rows.find((row) => row.etf === selectedEtf);
+  const selectedIssues = selectedRow && !selectedRow.loading ? sectorRowIssues(selectedRow) : [];
+  const selectedIssue = selectedIssues.length > 0 ? `${selectedEtf}: ${selectedIssues.join(" · ")}` : null;
+  const noticeWidth = Math.max(1, width - 2);
+  const definition = "ETF price returns; cash distributions excluded.";
+  const noticeHeight = 1 + wrapTextLines(definition, noticeWidth).length
+    + (selectedIssue ? wrapTextLines(selectedIssue, noticeWidth).length : 0);
 
   usePaneFooter("sectors", () => {
     const info: PaneFooterSegment[] = [];
     if (loading) info.push({ id: "loading", parts: [{ text: "loading", tone: "muted" }] });
     if (loadError) info.push({ id: "error", parts: [{ text: loadError, tone: "warning" }] });
+    if (incompleteRows) info.push({ id: "incomplete", parts: [{ text: `${incompleteRows} ETFs have unavailable values`, tone: "warning" }] });
     if (returnAsOfDate) info.push({ id: "return-as-of", parts: [{ text: `returns as of ${returnAsOfDate}`, tone: "muted" }] });
-    if (updatedAgo) info.push({ id: "updated", parts: [{ text: `updated ${updatedAgo}`, tone: "muted" }] });
+    if (updatedAgo) info.push({ id: "updated", parts: [{ text: `checked ${updatedAgo}`, tone: "muted" }] });
     return { info };
-  }, [loadError, loading, returnAsOfDate, updatedAgo]);
+  }, [loadError, loading, incompleteRows, returnAsOfDate, updatedAgo]);
 
   const rootBefore = (
-    <Box height={2} paddingX={1} flexDirection="column">
+    <Box height={noticeHeight} flexShrink={0} paddingX={1} flexDirection="column">
       <Tabs
         tabs={tabs}
         activeValue={activeCollection.id}
@@ -236,7 +241,8 @@ function SectorPerformancePane({ focused, width, height }: PaneProps) {
         variant="bare"
         focused={focused}
       />
-      <Notice tone="muted">ETF price returns; cash distributions excluded.</Notice>
+      <Notice tone="muted">{definition}</Notice>
+      {selectedIssue ? <Notice tone="warning">{selectedIssue}</Notice> : null}
     </Box>
   );
 

--- a/src/plugins/builtin/sectors/sector-model.test.ts
+++ b/src/plugins/builtin/sectors/sector-model.test.ts
@@ -36,4 +36,24 @@ describe("sector calendar price returns", () => {
     const rows = [{ etf: "missing", return1Y: null }, { etf: "loss", return1Y: -5 }, { etf: "gain", return1Y: 10 }] as SectorRow[];
     expect(sortRows(rows, { columnId: "return1Y", direction }).at(-1)?.etf).toBe("missing");
   });
+
+  test("rejects inconsistent endpoints without substituting an older bar or live quote", () => {
+    const baseline = { ...point("2026-08-10", 100), high: 99, low: 98 };
+    const end = point("2026-09-10", 110);
+    const badStart = computeTrailingReturn([point("2026-08-07", 90), baseline, end], "1M");
+    expect(badStart).toMatchObject({ value: null, startDate: "2026-08-10" });
+    expect(badStart?.integrity?.sourcePoints[0]?.close).toBe(100);
+    const badEnd = computeTrailingReturn([point("2026-08-10", 100), { ...end, high: 105, low: 99 }], "1M", 112);
+    expect(badEnd?.value).toBeNull();
+    expect(badEnd?.integrity?.sourcePoints[0]?.close).toBe(110);
+    // A point-to-point price return does not depend on intermediate closes.
+    const cleanEndpoints = computeTrailingReturn([point("2026-08-10", 100),
+      { ...point("2026-08-20", 120), high: 105, low: 99 }, end], "1M");
+    expect(cleanEndpoints?.value).toBeCloseTo(10);
+  });
+
+  test("an invalid newest close cannot reveal an older duplicate or baseline", () => {
+    const history = [point("2026-08-07", 90), point("2026-08-10", 100), point("2026-08-10", NaN), point("2026-09-10", 110)];
+    expect(computeTrailingReturn(history, "1M")).toBeNull();
+  });
 });

--- a/src/plugins/builtin/sectors/sector-model.ts
+++ b/src/plugins/builtin/sectors/sector-model.ts
@@ -2,6 +2,7 @@ import type { DataTableColumn } from "../../../components";
 import type { PricePoint } from "../../../types/financials";
 import { compareSortValues, type SortDirection } from "../../../utils/sort-values";
 import { getPricePointTimestamp } from "../../../utils/price-history";
+import { mergePriceHistoryIntegrity, pricePointIntegrity, type PriceHistoryIntegrity } from "../../../utils/price-history-integrity";
 import {
   getSectorCollection,
   type SectorCollectionId,
@@ -19,6 +20,10 @@ export interface SectorRow extends SectorDef {
   currency: string;
   loading: boolean;
   quoteUnavailable?: boolean;
+  quoteSessionDate?: string | null;
+  quoteIssue?: string | null;
+  lastReportedPrice?: number | null;
+  returnIntegrity?: Partial<Record<SectorReturnRange, PriceHistoryIntegrity>>;
   returnAsOfDate?: string | null;
   return1MStartDate?: string | null;
   return1YStartDate?: string | null;
@@ -86,6 +91,10 @@ export function normalizeRowsForCollection(
       currency: existing?.currency ?? "USD",
       loading: existing?.loading ?? true,
       quoteUnavailable: existing?.quoteUnavailable ?? false,
+      quoteSessionDate: existing?.quoteSessionDate ?? null,
+      quoteIssue: existing?.quoteIssue ?? null,
+      lastReportedPrice: existing?.lastReportedPrice ?? null,
+      returnIntegrity: existing?.returnIntegrity ?? {},
       returnAsOfDate: existing?.returnAsOfDate ?? null,
       return1MStartDate: existing?.return1MStartDate ?? null,
       return1YStartDate: existing?.return1YStartDate ?? null,
@@ -106,18 +115,20 @@ export function updateRowsForCollection(
 }
 
 function getSortedHistory(history: readonly PricePoint[]): Array<{ point: PricePoint; timestamp: number }> {
-  return history
-    .map((point) => ({ point, timestamp: getPricePointTimestamp(point) }))
-    .filter(({ point, timestamp }) => (
-      Number.isFinite(timestamp)
-      && Number.isFinite(point.close)
-      && point.close > 0
-    ))
+  // Later responses may correct a cached observation. Keep the last report at
+  // each timestamp, including invalid closes, so they cannot expose an older one.
+  const byTimestamp = new Map<number, PricePoint>();
+  for (const point of history) {
+    const timestamp = getPricePointTimestamp(point);
+    if (Number.isFinite(timestamp)) byTimestamp.set(timestamp, point);
+  }
+  return [...byTimestamp].map(([timestamp, point]) => ({ point, timestamp }))
     .sort((left, right) => left.timestamp - right.timestamp);
 }
 
 export function latestHistoryClose(history: readonly PricePoint[]): number | null {
-  return getSortedHistory(history).at(-1)?.point.close ?? null;
+  const point = getSortedHistory(history).at(-1)?.point;
+  return point && !pricePointIntegrity(point) && Number.isFinite(point.close) && point.close > 0 ? point.close : null;
 }
 
 export function latestHistoryDate(history: readonly PricePoint[]): string | null {
@@ -143,7 +154,7 @@ export function computeTrailingReturn(
   range: SectorReturnRange,
   latestPrice?: number | null,
   asOfDate = latestHistoryDate(history),
-): { value: number; startDate: string; endDate: string } | null {
+): { value: number | null; startDate: string; endDate: string; integrity?: PriceHistoryIntegrity } | null {
   if (!asOfDate) return null;
   const points = getSortedHistory(history);
   const target = sectorReturnTargetDate(asOfDate, range);
@@ -154,11 +165,29 @@ export function computeTrailingReturn(
   const startDate = new Date(baseline.timestamp).toISOString().slice(0, 10);
   if (Date.parse(target) - Date.parse(startDate) > 7 * DAY_MS) return null;
   const end = points.findLast(({ timestamp }) => new Date(timestamp).toISOString().slice(0, 10) === asOfDate);
+  const integrity = [pricePointIntegrity(baseline.point), end && pricePointIntegrity(end.point)]
+    .filter((entry): entry is PriceHistoryIntegrity => !!entry);
+  if (integrity.length > 0) return {
+    value: null, startDate, endDate: asOfDate, integrity: mergePriceHistoryIntegrity(...integrity),
+  };
   const endPrice = latestPrice != null && Number.isFinite(latestPrice) && latestPrice > 0
     ? latestPrice
     : end?.point.close;
-  if (endPrice == null || !Number.isFinite(endPrice) || endPrice <= 0) return null;
-  return { value: (endPrice / baseline.point.close - 1) * 100, startDate, endDate: asOfDate };
+  if (endPrice == null || !Number.isFinite(endPrice) || endPrice <= 0
+    || !Number.isFinite(baseline.point.close) || baseline.point.close <= 0) return null;
+  const value = (endPrice / baseline.point.close - 1) * 100;
+  return Number.isFinite(value) ? { value, startDate, endDate: asOfDate } : null;
+}
+
+export function sectorRowIssues(row: SectorRow): string[] {
+  const issues: string[] = [];
+  if (row.quoteIssue) issues.push(row.quoteIssue);
+  else if (row.quoteUnavailable) issues.push("quote unavailable");
+  for (const range of ["1M", "1Y"] as const) {
+    if (row.returnIntegrity?.[range]) issues.push(`${range}: inconsistent OHLC at return endpoint`);
+    else if (row[range === "1M" ? "return1M" : "return1Y"] == null) issues.push(`${range}: history does not cover the shared window`);
+  }
+  return issues;
 }
 
 export function buildSectorColumns(width: number): SectorColumn[] {


### PR DESCRIPTION
Sector rotation could rank yesterday's +17% quote above today's +1% move under the same 1D heading. It could also calculate a monthly or annual return from an endpoint whose reported OHLC values contradict one another.

The board now requires a usable quote from the shared session for Last and 1D, retains the reported price and session in JSON, and explains unavailable values for the selected ETF. Return endpoints use the shared OHLC validation; original rejected records remain in exports, unaffected horizons remain usable, and a newer corrected response can replace an older duplicate. Computed pane caches are refreshed so older unvalidated rankings cannot reappear after reload. The footer labels refresh time as “checked” and derives availability from the displayed rows.

Validation: 22 sector regression tests / 75 assertions, all six TypeScript targets, browser build and plugin manifest check pass. Controlled provider scenarios reproduced the prior-session ranking error and verify invalid-date, zero/missing-change, contradictory endpoint, duplicate correction and JSON diagnostics behavior. Browser checks at 1100 and 600 pixels and native tmux checks at 82 and 60 columns verify sorting, selection explanations and wrapping with no relevant console/runtime warnings. Browser network fixtures explicitly refresh the source timestamp while retaining its older declared session, exercising the distinction beyond the provider router's timestamp check. These scenarios use isolated fixtures, not real portfolio data.

No release or version bump.
