### PR TITLE
Reject contradictory price history in portfolio risk estimates

### DIFF
--- a/src/plugins/builtin/account-management/pane.tsx
+++ b/src/plugins/builtin/account-management/pane.tsx
@@ -475,7 +475,7 @@ export function AccountManagementPane({ focused, width, height }: PaneProps) {
     [portfolioReturnSeries],
   );
   const beta = useMemo(
-    () => (portfolioReturnSeries && spyReturnSeries ? computeDatedBeta(portfolioReturnSeries, spyReturnSeries) : null),
+    () => (portfolioReturnSeries ? computeDatedBeta(portfolioReturnSeries, spyReturnSeries.returns) : null),
     [portfolioReturnSeries, spyReturnSeries],
   );
   const localAnalyticsPreview = useMemo(

--- a/src/plugins/builtin/analytics/index.tsx
+++ b/src/plugins/builtin/analytics/index.tsx
@@ -191,7 +191,7 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
   );
 
   const beta = useMemo(
-    () => (portfolioReturnSeries && spyReturnSeries ? computeDatedBeta(portfolioReturnSeries, spyReturnSeries) : null),
+    () => (portfolioReturnSeries ? computeDatedBeta(portfolioReturnSeries, spyReturnSeries.returns) : null),
     [portfolioReturnSeries, spyReturnSeries],
   );
 
@@ -243,8 +243,10 @@ function PortfolioAnalyticsPane({ focused, width, height }: PaneProps) {
       missingCount: returnSeriesResult.missingCount,
       unvaluedCount: returnSeriesResult.unvaluedCount,
       unsupportedReason: returnSeriesResult.unsupportedReason,
+      historyIntegrity: returnSeriesResult.historyIntegrity,
+      benchmarkIntegrity: spyReturnSeries.integrity,
     }),
-    [beta, returnSeriesResult.coverage, returnSeriesResult.missingCount, returnSeriesResult.unvaluedCount, returnSeriesResult.unsupportedReason, sharpe],
+    [beta, returnSeriesResult, spyReturnSeries.integrity, sharpe],
   );
   const metricsHeight = summaryRows.length + riskRows.length + 5;
   const historyNote = performanceHistoryNote(brokerPerformance.performance);

--- a/src/plugins/builtin/analytics/metrics.test.ts
+++ b/src/plugins/builtin/analytics/metrics.test.ts
@@ -3,6 +3,7 @@ import {
   computeBeta,
   computeDatedBeta,
   computeDatedReturns,
+  resolveDatedReturns,
   computeSectorAllocation,
   computeSharpeRatio,
   computeWeightedPortfolioReturns,
@@ -89,6 +90,21 @@ describe("computeBeta", () => {
       { dateKey: "2024-01-02", value: 0.1 },
       { dateKey: "2024-01-03", value: -0.1 },
     ]);
+  });
+
+  test("quarantines contradictory samples and permits a corrected duplicate to recover", () => {
+    const start = { date: new Date("2026-09-08"), close: 100 };
+    const bad = { date: new Date("2026-09-09"), open: 105, high: 102, low: 99, close: 101 };
+    const end = { date: new Date("2026-09-10"), close: 110 };
+    const input = [start, bad, end];
+    const rejected = resolveDatedReturns(input);
+    expect(computeDatedReturns(input)).toEqual([]);
+    expect(rejected.integrity?.sourcePoints[0]).toMatchObject({ date: "2026-09-09T00:00:00.000Z", open: 105, high: 102 });
+    const recovered = resolveDatedReturns([...input, { ...bad, high: 106 }]);
+    expect(recovered.integrity).toBeNull();
+    expect(recovered.returns.map((entry) => entry.value)).toEqual([0.01, 9 / 101]);
+    expect(bad.high).toBe(102);
+    expect(rejected.integrity?.sourcePoints[0]?.high).toBe(102);
   });
 });
 

--- a/src/plugins/builtin/analytics/metrics.ts
+++ b/src/plugins/builtin/analytics/metrics.ts
@@ -2,6 +2,7 @@ import type { PricePoint } from "../../../types/financials";
 import type { TickerRecord } from "../../../types/ticker";
 import type { BrokerAccount } from "../../../types/trading";
 import { getPricePointTimestamp } from "../../../utils/price-history";
+import { mergePriceHistoryIntegrity, pricePointIntegrity, type PriceHistoryIntegrity } from "../../../utils/price-history-integrity";
 
 export interface DatedReturn {
   dateKey: string;
@@ -81,9 +82,24 @@ export function computeBeta(assetReturns: number[], marketReturns: number[]): nu
   return covariance / marketVariance;
 }
 
-export function computeDatedReturns(history: PricePoint[]): DatedReturn[] {
-  const points = history
-    .map((point) => ({ point, timestamp: getPricePointTimestamp(point) }))
+export interface ReturnHistoryResult {
+  returns: DatedReturn[];
+  integrity: PriceHistoryIntegrity | null;
+}
+
+export function resolveDatedReturns(history: PricePoint[]): ReturnHistoryResult {
+  const byTimestamp = new Map<number, PricePoint>();
+  for (const point of history) {
+    const timestamp = getPricePointTimestamp(point);
+    if (Number.isFinite(timestamp)) byTimestamp.set(timestamp, point);
+  }
+  const reported = [...byTimestamp].map(([timestamp, point]) => ({ timestamp, point }));
+  const issues = reported.map(({ point }) => pricePointIntegrity(point))
+    .filter((entry): entry is PriceHistoryIntegrity => !!entry);
+  // Dropping the rejected day would silently change the risk sample and bridge
+  // its neighbors. Quarantine the sample until corrected source data arrives.
+  if (issues.length > 0) return { returns: [], integrity: mergePriceHistoryIntegrity(...issues) };
+  const points = reported
     .filter(({ point, timestamp }) => (
       Number.isFinite(timestamp)
       && Number.isFinite(point.close)
@@ -102,7 +118,11 @@ export function computeDatedReturns(history: PricePoint[]): DatedReturn[] {
       value,
     });
   }
-  return returns;
+  return { returns, integrity: null };
+}
+
+export function computeDatedReturns(history: PricePoint[]): DatedReturn[] {
+  return resolveDatedReturns(history).returns;
 }
 
 export function computeWeightedPortfolioReturns(series: WeightedReturnSeries[]): DatedReturn[] {

--- a/src/plugins/builtin/analytics/pane-model.test.ts
+++ b/src/plugins/builtin/analytics/pane-model.test.ts
@@ -2,8 +2,56 @@ import { expect, test } from "bun:test";
 import type { ResolvedPortfolioAccountState } from "../portfolio-list/summary";
 import type { PortfolioSummaryTotals } from "../portfolio-list/metrics";
 import type { TickerRecord } from "../../../types/ticker";
+import type { PricePoint } from "../../../types/financials";
 import { buildChartKey } from "../../../market-data/selectors";
-import { buildAnalyticsRiskRows, buildAnalyticsSummaryRows, buildPortfolioChartTargets, buildPortfolioReturnSeries } from "./pane-model";
+import { buildAnalyticsRiskRows, buildAnalyticsSummaryRows, buildBenchmarkReturnSeries, buildPortfolioChartTargets, buildPortfolioReturnSeries } from "./pane-model";
+
+function riskTicker(symbol: string): TickerRecord {
+  return { metadata: { ticker: symbol, exchange: "NYSE", currency: "USD", name: symbol,
+    positions: [{ portfolio: "main", shares: 10, avgCost: 100, markPrice: 120, broker: "manual", currency: "USD" }],
+    portfolios: ["main"], watchlists: [], custom: {}, tags: [],
+  } };
+}
+
+function riskHistory(): PricePoint[] {
+  return Array.from({ length: 21 }, (_, index) => ({ date: new Date(Date.UTC(2026, 7, 21 + index)), close: 740 + index + index % 2 }));
+}
+
+// Original reported SPY contradiction captured during the research audit.
+const rejectedSpy = { date: new Date("2026-09-10"), open: 764.08, high: 758.555, low: 757.57, close: 758.15, volume: 3461376 };
+
+test("a rejected benchmark suppresses beta while the independent basket Sharpe remains available", () => {
+  const request = buildPortfolioChartTargets([riskTicker("SPY")])[0]!.request;
+  const history = [...riskHistory().slice(0, -1), rejectedSpy];
+  const entries = new Map([[buildChartKey(request), { data: history }]]);
+  const result = buildBenchmarkReturnSeries(request, entries);
+  expect(result.returns).toEqual([]);
+  expect(result.integrity?.sourcePoints[0]).toMatchObject({ open: 764.08, high: 758.555, close: 758.15 });
+  const rows = buildAnalyticsRiskRows({ sharpe: 1.75, beta: 1.2, benchmarkIntegrity: result.integrity });
+  expect(rows[0]?.value).toBe("1.75");
+  expect(rows[1]).toMatchObject({ value: "—", detail: "SPY benchmark: inconsistent OHLC history" });
+  entries.set(buildChartKey(request), { data: riskHistory() });
+  expect(buildBenchmarkReturnSeries(request, entries)).toMatchObject({ integrity: null });
+  expect(buildBenchmarkReturnSeries(request, entries).returns).toHaveLength(20);
+  expect(history.at(-1)?.high).toBe(758.555);
+});
+
+test("a corrupt holding cannot be silently dropped from estimated portfolio risk", () => {
+  const targets = buildPortfolioChartTargets([riskTicker("SPY"), riskTicker("MSFT")]);
+  const chartEntries = new Map(targets.map(({ request }, index) => [buildChartKey(request), {
+    data: index === 0 ? [...riskHistory().slice(0, -1), rejectedSpy] : riskHistory(),
+  }]));
+  const input = { chartTargets: targets, chartEntries, financials: new Map(),
+    columnContext: { activeTab: "main", baseCurrency: "USD", exchangeRates: new Map<string, number>(), now: 0 } };
+  const result = buildPortfolioReturnSeries(input);
+  expect(result).toMatchObject({ returns: null, coverage: 0.5, missingCount: 1 });
+  expect(result.historyIntegrity[0]).toMatchObject({ symbol: "SPY", integrity: { sourcePoints: [{ ...rejectedSpy, date: "2026-09-10T00:00:00.000Z" }] } });
+  const rows = buildAnalyticsRiskRows({ ...result, sharpe: 2, beta: 1 });
+  expect(rows.every((row) => row.value === "—" && row.detail === "Inconsistent OHLC history: SPY")).toBe(true);
+  chartEntries.set(buildChartKey(targets[0]!.request), { data: riskHistory() });
+  expect(buildPortfolioReturnSeries(input).returns).toHaveLength(20);
+  expect(buildPortfolioReturnSeries(input).historyIntegrity).toEqual([]);
+});
 
 test("converts every account balance while keeping leverage independent of display currency", () => {
   const accountState = {

--- a/src/plugins/builtin/analytics/pane-model.ts
+++ b/src/plugins/builtin/analytics/pane-model.ts
@@ -5,6 +5,7 @@ import type { BrokerAccount, BrokerPortfolioPerformance } from "../../../types/t
 import type { Portfolio, TickerRecord } from "../../../types/ticker";
 import { formatCompact, formatNumber, formatPercentRaw } from "../../../utils/format";
 import { formatRelativeAge } from "../../../utils/relative-time";
+import type { PriceHistoryIntegrity } from "../../../utils/price-history-integrity";
 import { instrumentFromTicker, type ChartRequest } from "../../../market-data/request-types";
 import { buildChartKey } from "../../../market-data/selectors";
 import { resolvePortfolioAccountMetrics, resolvePortfolioMarketValue } from "../portfolio-list/account-metrics";
@@ -16,12 +17,13 @@ import {
   formatSignedCompact,
 } from "./display";
 import {
-  computeDatedReturns,
+  resolveDatedReturns,
   computeWeightedPortfolioReturns,
   syntheticAccountUnsupportedReason,
   syntheticPositionUnsupportedReason,
   type DatedReturn,
   type WeightedReturnSeries,
+  type ReturnHistoryResult,
 } from "./metrics";
 import { getPortfolioPositionValue } from "./sector-model";
 import type { AnalyticsMetricRow } from "./view";
@@ -85,6 +87,7 @@ export interface PortfolioReturnSeriesResult {
   /** Holdings with no reliable base-currency value, so weights cannot be determined. */
   unvaluedCount: number;
   unsupportedReason: string | null;
+  historyIntegrity: Array<{ symbol: string; integrity: PriceHistoryIntegrity }>;
 }
 
 export function buildPortfolioReturnSeries({
@@ -106,6 +109,7 @@ export function buildPortfolioReturnSeries({
   let missingCount = 0;
   let unvaluedCount = 0;
   let unsupportedReason = syntheticAccountUnsupportedReason(account);
+  const historyIntegrity: PortfolioReturnSeriesResult["historyIntegrity"] = [];
   for (const { ticker, request } of chartTargets) {
     unsupportedReason ??= syntheticPositionUnsupportedReason(
       ticker,
@@ -120,7 +124,9 @@ export function buildPortfolioReturnSeries({
     const key = buildChartKey(request);
     const entry = chartEntries.get(key);
     const history = entry?.data ?? entry?.lastGoodData ?? null;
-    const returns = history && history.length >= 11 ? computeDatedReturns(history) : [];
+    const resolved = resolveDatedReturns(history ?? []);
+    if (resolved.integrity) historyIntegrity.push({ symbol: ticker.metadata.ticker, integrity: resolved.integrity });
+    const returns = resolved.returns;
     if (value == null || returns.length < 10) {
       missingCount += 1;
       continue;
@@ -132,23 +138,22 @@ export function buildPortfolioReturnSeries({
 
   const returns = computeWeightedPortfolioReturns(weightedSeries);
   return {
-    returns: !unsupportedReason && unvaluedCount === 0 && returns.length > 0 ? returns : null,
+    returns: !unsupportedReason && unvaluedCount === 0 && historyIntegrity.length === 0 && returns.length > 0 ? returns : null,
     coverage: totalValue > 0 ? coveredValue / totalValue : chartTargets.length === 0 ? 1 : 0,
     missingCount,
     unvaluedCount,
     unsupportedReason,
+    historyIntegrity,
   };
 }
 
 export function buildBenchmarkReturnSeries(
   request: ChartRequest,
   chartEntries: ChartEntryLookup,
-): DatedReturn[] | null {
+): ReturnHistoryResult {
   const entry = chartEntries.get(buildChartKey(request));
   const history = entry?.data ?? entry?.lastGoodData ?? null;
-  if (!history || history.length < 11) return null;
-  const returns = computeDatedReturns(history);
-  return returns.length > 0 ? returns : null;
+  return resolveDatedReturns(history ?? []);
 }
 
 export function buildAnalyticsSummaryRows({
@@ -319,6 +324,8 @@ export function buildAnalyticsRiskRows({
   missingCount = 0,
   unvaluedCount = 0,
   unsupportedReason = null,
+  historyIntegrity = [],
+  benchmarkIntegrity = null,
 }: {
   sharpe: number | null;
   beta: number | null;
@@ -326,21 +333,27 @@ export function buildAnalyticsRiskRows({
   missingCount?: number;
   unvaluedCount?: number;
   unsupportedReason?: string | null;
+  historyIntegrity?: PortfolioReturnSeriesResult["historyIntegrity"];
+  benchmarkIntegrity?: PriceHistoryIntegrity | null;
 }): AnalyticsMetricRow[] {
   const unavailable = unvaluedCount > 0
     ? `${unvaluedCount} holding${unvaluedCount === 1 ? "" : "s"} unvalued; check prices and FX`
+    : historyIntegrity.length > 0 ? `Inconsistent OHLC history: ${historyIntegrity.map((entry) => entry.symbol).join(", ")}`
     : unsupportedReason;
   const partial = formatRiskCoverage(coverage, missingCount);
   return [
     { id: "sharpe", label: "Est. Sharpe", value: sharpe, method: "Current weights; price returns; 5% Rf, 252 sessions" },
     { id: "beta", label: "Est. Beta (SPY)", value: beta, method: "Current weights; excludes cash, fees and trades" },
-  ].map((row) => ({
-    id: row.id,
-    label: row.label,
-    value: unavailable ? "—" : formatNumber(row.value ?? undefined, 2),
-    detail: unavailable ?? (row.value == null ? "Insufficient history for basket estimate" : `${row.method}${partial ? `; partial: ${partial}` : ""}`),
-    color: colors.textMuted,
-  }));
+  ].map((row) => {
+    const reason = unavailable ?? (row.id === "beta" && benchmarkIntegrity ? "SPY benchmark: inconsistent OHLC history" : null);
+    return {
+      id: row.id,
+      label: row.label,
+      value: reason ? "—" : formatNumber(row.value ?? undefined, 2),
+      detail: reason ?? (row.value == null ? "Insufficient history for basket estimate" : `${row.method}${partial ? `; partial: ${partial}` : ""}`),
+      color: colors.textMuted,
+    };
+  });
 }
 
 export function resolvePerformancePalette(

--- a/src/sync/core-contributors.test.ts
+++ b/src/sync/core-contributors.test.ts
@@ -527,6 +527,23 @@ describe("core sync contributors", () => {
     expect(supported.analyticsByPortfolio.main.spyBeta).toBeCloseTo(1.5, 5);
     expect(supported.analyticsByPortfolio.main.oneYearReturn).toBeNull();
 
+    const cleanBenchmark = state.financials.get("SPY")!.priceHistory!;
+    const benchmarkEnd = cleanBenchmark.at(-1)!;
+    state.financials.get("SPY")!.priceHistory = [...cleanBenchmark.slice(0, -1), { ...benchmarkEnd, high: benchmarkEnd.close - 1 }];
+    setSyncedProfileAnalytics("main", { oneYearReturn: 0.25, spyBeta: 1.4 });
+    const invalidBenchmark = await coreCollectionsSyncContributor.collect({ state }) as any;
+    expect(invalidBenchmark.analyticsByPortfolio.main).toEqual({ oneYearReturn: 0.25, spyBeta: null });
+    state.financials.get("SPY")!.priceHistory = cleanBenchmark;
+    const cleanHolding = state.financials.get("7203.T")!.priceHistory!;
+    const holdingEnd = cleanHolding.at(-1)!;
+    state.financials.get("7203.T")!.priceHistory = [...cleanHolding.slice(0, -1), { ...holdingEnd, low: holdingEnd.close + 1 }];
+    const invalidHolding = await coreCollectionsSyncContributor.collect({ state }) as any;
+    expect(invalidHolding.analyticsByPortfolio.main).toEqual({ oneYearReturn: null, spyBeta: null });
+    state.financials.get("7203.T")!.priceHistory = cleanHolding;
+    setSyncedProfileAnalytics("main", null);
+    const corrected = await coreCollectionsSyncContributor.collect({ state }) as any;
+    expect(corrected.analyticsByPortfolio.main.spyBeta).toBeCloseTo(1.5, 5);
+
     mainTicker.metadata.positions[0]!.side = "short";
     const short = await coreCollectionsSyncContributor.collect({ state }) as any;
     expect(short.analyticsByPortfolio.main.spyBeta).toBeNull();

--- a/src/sync/core-contributors.ts
+++ b/src/sync/core-contributors.ts
@@ -9,7 +9,7 @@ import type { SyncContributor } from "./types";
 import { convertCurrency } from "../utils/format";
 import {
   computeDatedBeta,
-  computeDatedReturns,
+  resolveDatedReturns,
   computeWeightedPortfolioReturns,
   syntheticAccountUnsupportedReason,
   syntheticPositionUnsupportedReason,
@@ -383,12 +383,14 @@ function collectAnalyticsByPortfolio(
   brokerAccounts: Record<string, BrokerAccount[]>,
 ) {
   const output: Record<string, Record<string, unknown>> = {};
-  const spyReturns = computeDatedReturns(recentPriceHistory(financials.get("SPY")?.priceHistory ?? [], 366));
+  const spySample = resolveDatedReturns(recentPriceHistory(financials.get("SPY")?.priceHistory ?? [], 366));
+  const spyReturns = spySample.returns;
   for (const portfolio of config.portfolios) {
     const account = portfolio.brokerInstanceId && portfolio.brokerAccountId
       ? brokerAccounts[portfolio.brokerInstanceId]?.find((entry) => entry.accountId === portfolio.brokerAccountId)
       : undefined;
     let unsupported = !!syntheticAccountUnsupportedReason(account);
+    let invalidHistory = false;
     const datedReturnSeries: WeightedReturnSeries[] = [];
     for (const ticker of tickers.values()) {
       const tickerFinancials = financials.get(ticker.metadata.ticker);
@@ -404,7 +406,9 @@ function collectAnalyticsByPortfolio(
           unsupported = true;
           continue;
         }
-        const returns = computeDatedReturns(recentPriceHistory(tickerFinancials?.priceHistory ?? [], 366));
+        const sample = resolveDatedReturns(recentPriceHistory(tickerFinancials?.priceHistory ?? [], 366));
+        invalidHistory ||= sample.integrity != null;
+        const returns = sample.returns;
         if (returns.length >= 10) datedReturnSeries.push({ weight: value, returns });
         else unsupported = true;
       }
@@ -414,8 +418,8 @@ function collectAnalyticsByPortfolio(
     output[portfolio.id] = {
       // A weighted history of today's holdings is not the investor's actual
       // one-year account return. Only preserve an explicitly supplied preview.
-      oneYearReturn: previewAnalytics?.oneYearReturn ?? null,
-      spyBeta: previewAnalytics?.spyBeta
+      oneYearReturn: invalidHistory ? null : previewAnalytics?.oneYearReturn ?? null,
+      spyBeta: invalidHistory || spySample.integrity ? null : previewAnalytics?.spyBeta
         ?? (
           portfolioReturns.length > 0 && spyReturns.length > 0
             ? computeDatedBeta(portfolioReturns, spyReturns)


### PR DESCRIPTION
Portfolio estimated beta and Sharpe could still consume contradictory OHLC records after the chart and correlation tools rejected them. For example, the captured SPY record reports an open of 764.08 above its high of 758.555. A cached shared-profile estimate could also override the rejected current input.

Risk samples now retain immutable diagnostics and withhold calculations until the source data is corrected. A rejected benchmark suppresses beta while preserving an independent clean portfolio Sharpe; a rejected holding prevents estimates from silently using only the remaining holdings. The portfolio pane explains the affected source. Account-profile previews and sync-derived estimates use the same validation, and a cached preview cannot restore an estimate contradicted by current history. Corrected duplicate observations replace older reports and restore valid calculations.

Validation: CI passed all 3,159 tests / 12,760 assertions across 526 files, runtime type checks and build/upgrade checks. Focused coverage: 48 tests / 221 assertions across portfolio math, pane models, account-profile models and sync collection; all six TypeScript targets; browser build; plugin manifest check. Controlled full-app browser checks at 1000/600 pixels and native tmux checks at 100/80 columns cover switching between clean holdings with a bad benchmark and holdings with rejected history. Both renderers show the corresponding reason and retain independent metrics. Console/runtime scans were clean. Fixtures use isolated manual portfolios; no user accounts or public profiles were changed.

Deployment run 34632839567 passed, including production verification. In an isolated browser context on term.gloom.sh with identical controlled inputs, the prior build displayed beta 0.81 from the contradictory SPY bar. After ordinary reload onto the deployed build, beta is unavailable with the source-integrity reason while the independent Sharpe remains available. Switching to the affected portfolio suppresses both estimates. No real account or public profile was changed.

No release or version bump.
