### PR TITLE
Expose live quotes and the pane loading helpers to plugins

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -899,6 +899,51 @@ Use `Box` and `ScrollBox` to arrange content. Custom chart surfaces, order-book 
 
 Use `usePaneSettingValue(key, fallback)` from `gloomberb/react` for persistent pane settings and `usePaneTitle(title)` for a content-derived pane title. They update the active saved layout without requiring direct app-config writes. Both accept an optional explicit pane ID.
 
+### Loading data into a pane
+
+A pane that fetches on a schedule uses the host's loading helpers rather than its own `useEffect` and timers, so it cancels, refreshes, and reports age the same way built-in panes do:
+
+```tsx
+import { useAsyncResource, useAutoRefresh, useUpdatedAgo } from "gloomberb/react";
+import { usePaneStatusFooter } from "gloomberb/components";
+import { createPluginCache } from "gloomberb/utils";
+
+const { data, loading, error, updatedAt, load } = useAsyncResource(loadThing, { initialData: getCachedThing });
+useAutoRefresh(updatedAt, load);
+const updatedAgo = useUpdatedAgo(updatedAt);
+usePaneStatusFooter({ registrationId: "my-pane", loading, error });
+```
+
+The loader receives `force` so a manual reload can bypass the plugin's own cache; `initialData` seeds the pane from that cache before the first fetch resolves.
+
+`createPluginCache` keeps the last good payload in plugin persistence with a TTL, so the pane has something to show before its first fetch after a restart. Table panes get `compareSortValues` and `cycleSortPreference` from `gloomberb/utils` so mixed columns sort like the host's.
+
+### Live quotes
+
+`gloomberb/quotes` is the streaming layer over `useMarketData()`. A pane showing many symbols subscribes to them and receives the same live or polled updates the host's screeners get, through one shared feed per symbol:
+
+```tsx
+import {
+  buildScreenerQuoteTargets,
+  overlayScreenerQuoteEntries,
+  resolveScreenerQuoteFeedStatus,
+  useLiveQuoteEntries,
+  useLiveStreamingSetting,
+  LIVE_STREAMING_QUICK_SETTING,
+} from "gloomberb/quotes";
+
+const liveStreaming = useLiveStreamingSetting();
+const targets = useMemo(() => buildScreenerQuoteTargets(rows, selectedSymbol), [rows, selectedSymbol]);
+const { entries, freshnessNow, subscriptionStartedAt } = useLiveQuoteEntries(targets, { liveStreaming });
+const liveRows = useMemo(() => overlayScreenerQuoteEntries(rows, entries), [rows, entries]);
+```
+
+Declare `LIVE_STREAMING_QUICK_SETTING` in the pane's `quickSettings` so the toggle sits in the header on the same persisted key as every other screener. The module is shared with the host and never bundled into a plugin: the subscriptions are host state.
+
+### Network access
+
+List every third-party host a plugin fetches from in its `hosts` field, as bare domains. The terminal and desktop reach anything, so there it is documentation and what the plugin directory shows. On the web, the browser cannot call a host without CORS headers, and the hosted app proxies exactly the hosts that bundled plugins declare. A host left out works on the desktop and fails on the web.
+
 Pane footers show changing status such as loading, errors, stale data, or live/delayed feeds. Preserve existing pane-specific action shortcuts instead of duplicating them in body toolbars. Do not repeat the pane title, fixed labels, row counts, or generic keyboard hints:
 
 ```typescript

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -866,7 +866,7 @@ Choose the existing control that owns the interaction you need:
 |------|------------|
 | Sortable/selectable rows | `DataTableView`, `TickerListTableView` |
 | Table with a detail stack | `DataTableStackView`, `FeedDataTableStackView` |
-| Charts | `StaticChartSurface`, `MetricTreemapSurface`, `SpeedometerGauge` |
+| Charts | `CompositeChart` (time series), `StaticChartSurface`, `MetricTreemapSurface`, `SpeedometerGauge` |
 | Navigation and choices | `Tabs`, `SegmentedControl`, `SelectButton`, `Checkbox` |
 | Actions and inputs | `Button`, `TextField`, `NumberField`, `InputSearchBar` |
 | Clickable/expandable summaries | `ActionRow` |

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "./types/trading": "./src/types/trading.ts",
     "./time-series": "./src/public/time-series.ts",
     "./market-data": "./src/public/market-data.ts",
+    "./quotes": "./src/public/quotes.ts",
     "./dialog": "./src/ui/dialog.tsx",
     "./broker": "./src/public/broker.ts"
   },

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,22 @@
 export { PriceSelectorDialog } from "./price-selector-dialog";
 export { StaticChartSurface } from "./chart/static";
 export type { StaticChartOverlay } from "./chart/static/chart-surface";
+// The time-series chart: one or more panels of resolved series with axes,
+// a cursor, and range selection. Ticker overview, polls, econ statistics,
+// and prediction markets all draw with it.
+export { CompositeChart, pricePointsToResolvedSeries } from "./chart/composite";
+export type {
+  CompositeAxisDomain,
+  CompositeAxisSide,
+  CompositeChartColors,
+  CompositeChartProps,
+  CompositeChartScene,
+  CompositeCursorValue,
+  CompositePanelScene,
+  CompositeProjectedPoint,
+  CompositeProjectedSeries,
+  PricePointsToResolvedSeriesOptions,
+} from "./chart/composite";
 // A static chart's callers project their own points and pick a palette; these
 // are the same helpers the host's gauges and sparklines use to do that.
 export type { ProjectedChartPoint } from "./chart/core/data";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,11 @@
 
 export { PriceSelectorDialog } from "./price-selector-dialog";
 export { StaticChartSurface } from "./chart/static";
+export type { StaticChartOverlay } from "./chart/static/chart-surface";
+// A static chart's callers project their own points and pick a palette; these
+// are the same helpers the host's gauges and sparklines use to do that.
+export type { ProjectedChartPoint } from "./chart/core/data";
+export { resolveChartPalette } from "./chart/core/palette";
 export {
   buildMetricTreemapNavigationTiles,
   findMetricTreemapNeighbor,
@@ -28,6 +33,10 @@ export type { FeedDataTableItem } from "./feed-data-table/stack-view";
 export { activeStackIndex, sortStackItems } from "./feed-stack-controller";
 export type { StackSortPreference } from "./feed-stack-controller";
 export { PaneFooterScope, usePaneFooter } from "./layout/pane/footer";
+// The common footer shapes on top of `usePaneFooter`: a status segment that
+// changes with loading/error state, and one that also carries a link.
+export { usePaneStatusFooter, usePaneStatusLinkFooter } from "../plugins/builtin/shared/pane-footer";
+export { loadingErrorFooterInfo } from "../plugins/builtin/shared/table-pane";
 export type { PaneFooterPressEvent, PaneFooterSegment, PaneHint } from "./layout/pane/footer";
 export {
   getPaneSidebarWidth,

--- a/src/plugins/builtin/plugin-module.ts
+++ b/src/plugins/builtin/plugin-module.ts
@@ -26,6 +26,7 @@ const HANDLED_MODULE_KEYS = [
   "broker",
   "capabilities",
   "slots",
+  "hosts",
 ] as const satisfies readonly (keyof PluginModule)[];
 
 type MissingModuleKey = Exclude<keyof PluginModule, typeof HANDLED_MODULE_KEYS[number]>;
@@ -76,6 +77,8 @@ export function composeBuiltinPlugin(options: CompositePluginOptions): GloomPlug
   const capabilities = modules.flatMap((module) => module.capabilities ?? []);
   const brokers = modules.flatMap((module) => module.broker ? [module.broker] : []);
   const slots = composeSlots(modules);
+  // The plugin reaches every host any of its modules reaches.
+  const hosts = [...new Set(modules.flatMap((module) => module.hosts ?? []))];
   let startedModules: PluginModule[] = [];
 
   return {
@@ -85,6 +88,7 @@ export function composeBuiltinPlugin(options: CompositePluginOptions): GloomPlug
     ...(paneTemplates.length > 0 ? { paneTemplates } : {}),
     ...(capabilities.length > 0 ? { capabilities } : {}),
     ...(slots ? { slots } : {}),
+    ...(hosts.length > 0 ? { hosts } : {}),
 
     async setup(ctx: GloomPluginContext) {
       startedModules = [];

--- a/src/plugins/builtin/shared/pane-footer.ts
+++ b/src/plugins/builtin/shared/pane-footer.ts
@@ -1,10 +1,8 @@
 import { useMemo } from "react";
-import {
-  useExternalLinkFooter,
-  usePaneFooter,
-  type PaneFooterSegment,
-  type PaneHint,
-} from "../../../components";
+// Deep imports on purpose: the components barrel re-exports this module for
+// plugins, and importing the barrel back would make a cycle.
+import { usePaneFooter, type PaneFooterSegment, type PaneHint } from "../../../components/layout/pane/footer";
+import { useExternalLinkFooter } from "../../../components/use-external-link-footer";
 
 const EMPTY_STATUS_INFO: PaneFooterSegment[] = [];
 

--- a/src/plugins/builtin/shared/table-pane.ts
+++ b/src/plugins/builtin/shared/table-pane.ts
@@ -1,5 +1,8 @@
 import { useEffect } from "react";
-import type { DataTableKeyEvent, PaneFooterSegment } from "../../../components";
+// Deep imports on purpose: the components barrel re-exports this module for
+// plugins, and importing the barrel back would make a cycle.
+import type { DataTableKeyEvent } from "../../../components/data-table/view";
+import type { PaneFooterSegment } from "../../../components/layout/pane/footer";
 
 export function loadingErrorFooterInfo(loading: boolean, error: string | null | undefined): PaneFooterSegment[] {
   return [

--- a/src/plugins/host-contract.ts
+++ b/src/plugins/host-contract.ts
@@ -41,6 +41,9 @@ export const SHARED_SPECIFIERS = [
   "gloomberb/dialog",
   "gloomberb/market-data",
   "gloomberb/time-series",
+  // Quote subscriptions live in host state; a bundled copy would open its own
+  // feed and never see the host's updates.
+  "gloomberb/quotes",
 ] as const;
 
 export type SharedSpecifier = (typeof SHARED_SPECIFIERS)[number];

--- a/src/plugins/host-modules.ts
+++ b/src/plugins/host-modules.ts
@@ -28,6 +28,7 @@ export async function installPluginHostModules(): Promise<void> {
     dialog,
     marketData,
     timeSeries,
+    quotes,
   ] = await Promise.all([
     import("react"),
     import("react/jsx-runtime"),
@@ -45,6 +46,7 @@ export async function installPluginHostModules(): Promise<void> {
     import("../ui/dialog"),
     import("../public/market-data"),
     import("../public/time-series"),
+    import("../public/quotes"),
   ]);
 
   const registry: Record<string, unknown> = {
@@ -63,6 +65,7 @@ export async function installPluginHostModules(): Promise<void> {
     "gloomberb/dialog": dialog,
     "gloomberb/market-data": marketData,
     "gloomberb/time-series": timeSeries,
+    "gloomberb/quotes": quotes,
   };
 
   for (const specifier of SHARED_SPECIFIERS) {

--- a/src/public/market-data.ts
+++ b/src/public/market-data.ts
@@ -7,3 +7,10 @@
  */
 export * from "../market-data/request-types";
 export * from "../market-data/market/format";
+
+// Yahoo Finance's JSON endpoints need a crumb and cookie pair, retries on the
+// 4xx/5xx it throws under load, and browser-like headers. A plugin scraping a
+// Yahoo screener or quote endpoint gets that dance here rather than
+// reimplementing it, and goes through `httpFetch` so the desktop and web
+// renderers can route it.
+export { YahooHttpClient } from "../sources/yahoo-finance/http";

--- a/src/public/quotes.ts
+++ b/src/public/quotes.ts
@@ -1,0 +1,48 @@
+/**
+ * Public live-quote surface for external plugins (`gloomberb/quotes`).
+ *
+ * `useMarketData()` from `gloomberb/react` hands a plugin the `DataProvider`
+ * for one-off reads. This module is the streaming layer on top of it: a pane
+ * that shows many symbols at once subscribes to them here and receives the
+ * same live or polled updates the host's own screeners get, through the same
+ * subscription registry, so two panes watching the same symbol share one feed.
+ *
+ * It is a shared host module, not something a plugin bundle can carry a copy
+ * of: the subscriptions live in host state, and a second instance would open a
+ * second feed and never see the first one's updates.
+ *
+ * Compatibility commitment: see the note in `./utils.ts`.
+ */
+
+// Subscribing a list of targets and reading the entries as they update.
+export { DEFAULT_QUOTE_POLL_INTERVAL_MS, useLiveQuoteEntries } from "../state/hooks/quote-streaming";
+export type { QuoteUpdateOptions } from "../state/hooks/quote-streaming";
+export type { QuoteSubscriptionTarget } from "../types/data-provider";
+export type { QueryEntry } from "../market-data/result-types";
+export type { Quote } from "../types/financials";
+
+// A screener-style pane holds rows it fetched itself and overlays the live
+// feed on top. These are the host's helpers for that pattern: build the
+// subscription targets from the rows, merge the entries back in, and summarise
+// whether the feed is live, mixed, or polling for the footer.
+export {
+  buildScreenerQuoteTargets,
+  overlayScreenerQuoteEntries,
+  resolveScreenerQuoteFeedStatus,
+} from "../plugins/builtin/shared/screener-live-quotes";
+export type {
+  ScreenerQuoteFeedStatus,
+  ScreenerQuoteFreshness,
+  ScreenerQuoteRow,
+} from "../plugins/builtin/shared/screener-live-quotes";
+
+// The persisted "Live streaming" pane setting and its quick toggle, so a
+// plugin pane offers the same control, on the same key, as the built-ins.
+export {
+  LIVE_STREAMING_QUICK_SETTING,
+  LIVE_STREAMING_SETTING_FIELD,
+  LIVE_STREAMING_SETTING_KEY,
+  resolveLiveStreamingSetting,
+  useLiveStreamingSetting,
+  withLiveStreamingSetting,
+} from "../plugins/builtin/shared/live-streaming";

--- a/src/public/react.ts
+++ b/src/public/react.ts
@@ -62,3 +62,16 @@ export {
 
 // Keyboard handling for plugin panes; the renderer decides how events arrive.
 export { useShortcut } from "../react/input";
+
+// Loading one thing asynchronously into a pane: data, loading, error, reload.
+// Every data pane needs this, and a plugin that hand-rolls it drifts from the
+// host's cancellation and stale-response handling.
+export { useAsyncResource } from "../react/async-resource";
+
+// Periodic refresh tied to app activity, and the "updated 2m ago" label that
+// goes with it, so plugin panes refresh on the same cadence as built-ins and
+// stop while the app is in the background.
+export { useAutoRefresh, useUpdatedAgo } from "../plugins/builtin/shared/auto-refresh";
+
+// The type behind `useConnectionHealth()`, for a plugin that passes it around.
+export type { ConnectionHealthRegistry } from "../core/connection-health";

--- a/src/public/react.ts
+++ b/src/public/react.ts
@@ -73,5 +73,6 @@ export { useAsyncResource } from "../react/async-resource";
 // stop while the app is in the background.
 export { useAutoRefresh, useUpdatedAgo } from "../plugins/builtin/shared/auto-refresh";
 
-// The type behind `useConnectionHealth()`, for a plugin that passes it around.
-export type { ConnectionHealthRegistry } from "../core/connection-health";
+// The class behind `useConnectionHealth()`. A value export so a plugin test
+// can construct one to exercise its own connection-status registration.
+export { ConnectionHealthRegistry } from "../core/connection-health";

--- a/src/public/utils.ts
+++ b/src/public/utils.ts
@@ -7,8 +7,8 @@
  * when a real plugin needs it, and prefer widening later over exporting
  * speculatively.
  *
- * `scripts/check-public-api.ts` pins the exported names so the surface cannot
- * grow by accident during an unrelated refactor.
+ * `src/public/public-api.test.ts` checks that every subpath resolves and that a
+ * bundled plugin shares the host's module instances.
  */
 
 export { createThrottledFetch } from "../utils/throttled-fetch";
@@ -75,3 +75,21 @@ export { splitLongTextSegmentByDisplayWidth, truncateWithEllipsis, wrapTextLines
 export { httpFetch, setHttpFetchTransport } from "../utils/http-transport";
 export type { HttpFetchTransport } from "../utils/http-transport";
 export { debugLog } from "../utils/debug-log";
+
+// A pane that fetches on its own schedule and wants to survive restarts: a
+// persisted cache keyed by the plugin, with a TTL and a stale-while-refresh
+// read. The Fear & Greed and IPO calendar plugins both keep their last good
+// payload this way so the pane has something to show before the first fetch.
+export { createPluginCache } from "../data/plugin-cache";
+export type { PluginCacheResult } from "../data/plugin-cache";
+
+// Table sorting, so a plugin table cycles its sort the same way built-in ones
+// do and orders mixed null/number/string columns identically.
+export { compareSortValues, cycleSortPreference } from "../utils/sort-values";
+export type { SortDirection, SortPreference } from "../utils/sort-values";
+
+// Exchange schedules are published as wall-clock times in a named zone.
+export { zonedDateTimeParts, zonedWallClockToUtcMs } from "../utils/zoned-date-time";
+
+// A list pane with a search field hands the arrow keys between the two.
+export { isPlainArrowUp, stopSearchFocusNavigation } from "../utils/search-focus-navigation";

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -687,6 +687,18 @@ export interface GloomPlugin {
   cliCommands?: CliCommandDef[];
   /** Defaults to every target when omitted. */
   targets?: readonly PluginTarget[];
+  /**
+   * Third-party hosts the plugin fetches from, as bare domains
+   * (`"api.example.com"`; a parent domain also covers its subdomains).
+   *
+   * Terminal and desktop reach anything, so this is informational there and
+   * is what the plugin directory shows under "Network access". On the web the
+   * browser cannot call a host that sends no CORS headers, so the hosted app
+   * proxies exactly the hosts the bundled plugins declare here and refuses
+   * the rest. A plugin that leaves a host out works on the desktop and fails
+   * on the web.
+   */
+  hosts?: readonly string[];
   /** Shown in the marketplace pane and on the website. */
   homepage?: string;
 


### PR DESCRIPTION
First of four host PRs to extract `polls`, `fear-greed`, `market-halts`, `market-heatmap`, and `ipo-calendar` into `gloom-*` repositories. This one only widens the public surface; nothing moves yet.

## `gloomberb/quotes` (new subpath)

The live quote layer. `useMarketData()` gives a plugin one-off reads; this gives it the streaming subscriptions the host's own screeners use, sharing one feed per symbol:

- `useLiveQuoteEntries`, `QuoteSubscriptionTarget`, `QueryEntry`, `Quote`
- screener helpers: `buildScreenerQuoteTargets`, `overlayScreenerQuoteEntries`, `resolveScreenerQuoteFeedStatus`
- the persisted "Live streaming" setting and its quick toggle, so plugin panes use the same key as built-ins

Registered in `SHARED_SPECIFIERS` and the host-modules registry. Must never be bundled into a plugin: the subscriptions are host state.

## Helpers made public

Every polling pane needs these, and a plugin that hand-rolls them drifts from the host's cancellation and refresh behaviour:

| Subpath | Added |
|---|---|
| `gloomberb/react` | `useAsyncResource`, `useAutoRefresh`, `useUpdatedAgo`, `ConnectionHealthRegistry` (type) |
| `gloomberb/components` | `usePaneStatusFooter`, `usePaneStatusLinkFooter`, `loadingErrorFooterInfo`, `resolveChartPalette`, `ProjectedChartPoint`, `StaticChartOverlay` |
| `gloomberb/utils` | `createPluginCache`, `compareSortValues`, `cycleSortPreference`, `zonedDateTimeParts`, `zonedWallClockToUtcMs`, `isPlainArrowUp`, `stopSearchFocusNavigation` |
| `gloomberb/market-data` | `YahooHttpClient` |

Two shared helpers switched to deep imports so the components barrel can re-export them without a cycle.

## `GloomPlugin.hosts`

Bare domains a plugin fetches from. Informational on terminal/desktop and what the directory shows; on the web it will drive the proxy allowlist for bundled plugins (next PR). `composeBuiltinPlugin` unions its modules' hosts.

## Verification

`bun test`: 3159 pass. `bun run typecheck` clean on every target. PLUGINS.md documents the new surface with examples checked against the real signatures.