### PR TITLE
Fix dividend cash history and corporate-action research states

### DIFF
--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -60,4 +60,6 @@ A calculator opened from a chain uses a saved contract observation. Its quote an
 
 Event EPS and consensus can use an unspecified accounting basis, while TTM values come from statements. Fiscal period ends are not announcement dates. Open an event row for its source inputs and dates.
 
+Consensus estimates are forecasts for the stated fiscal period. The provider's prior-year input can itself be an estimate; it does not establish a reported result. Fetched timestamps identify retrieval, not when consensus was revised. Filing evidence corroborates a fiscal period without verifying every reported metric.
+
 Split-feed factors may include spinoff price adjustments. Merger terms, spinoff distributions, and security conversions are not covered. Source failures and unavailable event data remain visible rather than appearing as an empty event calendar.

--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -42,6 +42,8 @@ Broker account-value history includes deposits and withdrawals. Investment retur
 
 Dividend cash yield excludes taxes and reinvestment. SEC yield, tax components, and future payments are not modeled. Forward yield is an estimate rather than a guaranteed distribution. Dividend amounts and reference prices must use compatible listing currencies and units.
 
+TTM cash/share sums reported cash with ex-dates within the trailing calendar year. The chart changes on ex-dates and when earlier payments leave that window, holding each level between changes. Cash growth compares complete trailing-year windows; a positive baseline followed by no cash gives −100%, while a zero or incomplete baseline has no defined growth rate. Special distributions remain part of reported cash.
+
 Sector and industry ETF returns are price returns in the listing currency, without reinvested distributions. Rankings use a shared ending session and calendar-month/year boundaries, using a prior close for holidays. Missing or inconsistent endpoints remain unavailable. A successful refresh does not make an old quote current.
 
 ## FX matrix

--- a/src/components/chart/static/chart-surface.test.tsx
+++ b/src/components/chart/static/chart-surface.test.tsx
@@ -6,6 +6,7 @@ import { RemoteUiRegistryProvider, useRemoteUiRegistry, type RemoteUiRegistry } 
 import { resolveChartPalette } from "../core/palette";
 import { StaticChartSurface, buildStaticChartSeries } from "./chart-surface";
 import type { ProjectedChartPoint } from "../core/data";
+import { buildCompositeChartScene } from "../composite/scene";
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let remoteRegistry: RemoteUiRegistry | null = null;
@@ -35,6 +36,18 @@ function RemoteRegistryProbe() {
 }
 
 describe("StaticChartSurface", () => {
+  test("calendar step charts preserve unequal time gaps and hold values until the next change", () => {
+    const irregular = points.map((point, index) => ({ ...point, date: new Date(`2026-01-${["01", "02", "11"][index]}`) }));
+    const series = buildStaticChartSeries(irregular, "step", "#00ff00", [], true);
+    const scene = buildCompositeChartScene(series, [{ id: "main" }], { width: 80, height: 10 });
+    expect(scene?.timeScale.kind).toBe("calendar");
+    const primary = scene!.panels[0]!.series[0]!;
+    expect(primary.source.style).toBe("step");
+    const [first, second, last] = primary.points;
+    expect((second!.xRatio - first!.xRatio) / (last!.xRatio - first!.xRatio)).toBeCloseTo(0.1, 10);
+    expect(primary.points.map((point) => point.value)).toEqual([3.5, 4.1, 4.9]);
+  });
+
   test("aligns an index-keyed overlay to the primary observations", () => {
     const [primary, overlay] = buildStaticChartSeries(points, "line", "#00ff00", [
       { id: "secondary", color: "#ffaa00", points: [{ index: 0, value: 1 }, { index: 2, value: 3 }, { index: 9, value: 4 }] },

--- a/src/components/chart/static/chart-surface.tsx
+++ b/src/components/chart/static/chart-surface.tsx
@@ -30,7 +30,9 @@ export interface StaticChartSurfaceProps {
   points: ProjectedChartPoint[];
   width: number;
   height: number;
-  mode?: ChartRenderMode;
+  mode?: ChartRenderMode | "step";
+  /** Preserve elapsed calendar time between irregular observations. */
+  calendarSpaced?: boolean;
   colors: StaticChartPalette;
   overlays?: readonly StaticChartOverlay[];
   showTimeAxis?: boolean;
@@ -45,9 +47,10 @@ export interface StaticChartSurfaceProps {
   formatYAxisValue?: (value: number) => string;
 }
 
-const STYLE_BY_MODE: Record<ChartRenderMode, ResolvedSeries["style"]> = {
+const STYLE_BY_MODE: Record<ChartRenderMode | "step", ResolvedSeries["style"]> = {
   area: "area",
   line: "line",
+  step: "step",
   candles: "candles",
   ohlc: "ohlc",
   hlc: "hlc",
@@ -57,9 +60,10 @@ const PANELS = [{ id: "main" }];
 
 export function buildStaticChartSeries(
   points: readonly ProjectedChartPoint[],
-  mode: ChartRenderMode,
+  mode: ChartRenderMode | "step",
   color: string,
   overlays: readonly StaticChartOverlay[] = [],
+  calendarSpaced = false,
 ): ResolvedSeries[] {
   const ohlc = mode === "candles" || mode === "ohlc" || mode === "hlc";
   const primary = staticSeries(
@@ -71,14 +75,14 @@ export function buildStaticChartSeries(
         ? { open: point.open, high: point.high, low: point.low, close: point.close, volume: point.volume }
         : {}),
     })),
-    { id: "primary", color, style: STYLE_BY_MODE[mode], dataShape: ohlc ? "ohlcv" : "scalar" },
+    { id: "primary", color, style: STYLE_BY_MODE[mode], dataShape: ohlc ? "ohlcv" : "scalar", calendarSpaced },
   );
   const overlaySeries = overlays.map((overlay) => staticSeries(
     overlay.points.flatMap(({ index, value }) => {
       const anchor = points[index];
       return anchor && Number.isFinite(value) ? [scalarPoint(anchor.date, value)] : [];
     }),
-    { id: overlay.id, color: overlay.color },
+    { id: overlay.id, color: overlay.color, calendarSpaced },
   ));
   return [primary, ...overlaySeries];
 }
@@ -88,6 +92,7 @@ export function StaticChartSurface({
   width,
   height,
   mode = "line",
+  calendarSpaced = false,
   colors,
   overlays,
   showTimeAxis = false,
@@ -104,8 +109,8 @@ export function StaticChartSurface({
   const totalHeight = Math.max(1, Math.floor(height));
   const labelRows = yAxisLabel ? 1 : 0;
   const series = useMemo(
-    () => buildStaticChartSeries(points, mode, colors.lineColor, overlays),
-    [colors.lineColor, mode, overlays, points],
+    () => buildStaticChartSeries(points, mode, colors.lineColor, overlays, calendarSpaced),
+    [colors.lineColor, mode, overlays, points, calendarSpaced],
   );
   const chartColors = useMemo(() => ({
     background: colors.bgColor,

--- a/src/plugins/builtin/dividend-yield/client.test.ts
+++ b/src/plugins/builtin/dividend-yield/client.test.ts
@@ -69,6 +69,37 @@ describe("extractDividendFields", () => {
 });
 
 describe("cash distribution calculations", () => {
+  test("native income keeps the listing's ex-date when its session starts on the previous UTC date", async () => {
+    const timestamp = Date.parse("2026-01-01T23:00:00Z") / 1000;
+    setHttpFetchTransport(async (url) => {
+      if (url.includes("fc.yahoo.com")) return new Response("", { headers: { "set-cookie": "test=fixture" } });
+      if (url.includes("getcrumb")) return new Response("fixture-crumb");
+      if (url.includes("/chart/")) return Response.json({ chart: { result: [{
+        meta: { currency: "AUD", exchangeTimezoneName: "Australia/Sydney", regularMarketPrice: 100, dataGranularity: "1mo" },
+        timestamp: [timestamp], indicators: { quote: [{ close: [100] }] },
+        events: { dividends: { one: { date: timestamp, amount: 0.25 } } },
+      }] } });
+      return Response.json({ quoteSummary: { result: [{ summaryDetail: { currency: "AUD" } }] } });
+    });
+    const data = await fetchDividendData("FIXTURE.AX", null);
+    expect(data.payments[0]).toMatchObject({ exDate: new Date("2026-01-02"), amount: 0.25, currency: "AUD" });
+  });
+
+  test("a complete cash suspension is a full decline from a positive baseline", () => {
+    const history = [payment("2020-08-01", 1), payment("2021-08-01", 1), payment("2022-08-01", 1), payment("2023-08-01", 1)];
+    const afterSuspension = new Date("2024-09-10T12:00:00Z");
+    expect(buildDividendMetrics(history, null, 100, { now: afterSuspension })).toMatchObject({
+      trailingRate: 0, growth1Y: -1, growth3Y: -1,
+    });
+    // With no cash in either annual window, percentage growth is undefined.
+    expect(buildDividendMetrics(history, null, 100, { now }).growth1Y).toBeNull();
+    expect(buildDividendMetrics(history, null, 100, { now: afterSuspension, historyAvailable: false })).toMatchObject({
+      trailingRate: null, growth1Y: null, growth3Y: null,
+    });
+    // An incomplete initial year must not turn missing observations into a cut.
+    expect(buildDividendMetrics([payment("2023-08-01")], null, 100, { now: afterSuspension }).growth1Y).toBeNull();
+  });
+
   test.each([
     ["SHY:XNAS", "", "SHY", "USD", 0.244],
     ["LQD:ARCX", "NASDAQ", "LQD", "USD", 0.444],

--- a/src/plugins/builtin/dividend-yield/client.ts
+++ b/src/plugins/builtin/dividend-yield/client.ts
@@ -84,7 +84,7 @@ export function toDividendPayment(
   if (!Number.isFinite(amount) || amount <= 0) return null;
   const unit = resolveCurrencyUnit(currency);
   const parsed = new Date(`${exDate}T00:00:00.000Z`);
-  if (Number.isNaN(parsed.getTime())) return null;
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== exDate) return null;
   return {
     exDate: parsed,
     recordDate: null,
@@ -161,7 +161,7 @@ async function fetchDividendDataForSymbol(
 
   const payments: DividendPayment[] = [];
   if (chartResult.status === "fulfilled") {
-    for (const dividend of mapYahooDividends(chartResult.value.events)) {
+    for (const dividend of mapYahooDividends(chartResult.value.events, chartResult.value.meta)) {
       const payment = toDividendPayment(dividend.exDate, dividend.amount, rawCurrency);
       if (payment) payments.push(payment);
     }
@@ -211,8 +211,8 @@ export function buildDividendMetrics(
     ? eligible.filter((payment) => payment.exDate > cutoff).reduce((sum, payment) => sum + payment.amount, 0)
     : options.summaryRatesComparable !== false ? quoteFields?.trailingAnnualDividendRate ?? null : null;
   const forwardRate = options.summaryRatesComparable !== false ? quoteFields?.forwardAnnualDividendRate ?? null : null;
-  const growth1Y = computeGrowth(eligible, 1, now);
-  const growth3Y = computeGrowth(eligible, 3, now);
+  const growth1Y = options.historyAvailable !== false ? computeGrowth(eligible, 1, now) : null;
+  const growth3Y = options.historyAvailable !== false ? computeGrowth(eligible, 3, now) : null;
 
   const exDividendDate = quoteFields?.exDividendDate != null
     ? new Date(quoteFields.exDividendDate * 1000)
@@ -257,7 +257,7 @@ function computeGrowth(payments: DividendPayment[], years: number, now: Date): n
   if (!payments.some((payment) => payment.exDate <= priorStart)) return null;
   const recent = payments.filter((p) => p.exDate > recentStart && p.exDate <= now).reduce((sum, p) => sum + p.amount, 0);
   const prior = payments.filter((p) => p.exDate > priorStart && p.exDate <= priorEnd).reduce((sum, p) => sum + p.amount, 0);
-  return prior > 0 && recent > 0 ? Math.pow(recent / prior, 1 / years) - 1 : null;
+  return prior > 0 ? Math.pow(recent / prior, 1 / years) - 1 : null;
 }
 
 function inferFrequency(payments: DividendPayment[], now: Date): DividendMetrics["paymentFrequency"] {

--- a/src/plugins/builtin/dividend-yield/pane.tsx
+++ b/src/plugins/builtin/dividend-yield/pane.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   DataTableView,
+  KeyValueRow,
   Notice,
   StaticChartSurface,
   usePaneFooter,
@@ -79,22 +80,13 @@ function buildMetricRows(metrics: DividendMetrics, currency: string): MetricRow[
 }
 
 function renderMetricCell(row: MetricRow, width: number) {
-  const valueWidth = Math.min(row.value.length, Math.max(6, width - 8));
-  const labelWidth = Math.max(8, width - valueWidth - 1);
+  const rowWidth = Math.max(1, width - 1);
+  const valueWidth = Math.min(rowWidth, Math.max(6, row.value.length));
   return (
-    <Box height={1} flexDirection="row">
-      <Text fg={colors.textDim}>{row.label.slice(0, labelWidth).padEnd(labelWidth)}</Text>
-      <Text
-        fg={row.color ?? colors.text}
-        attributes={row.bold ? TextAttributes.BOLD : undefined}
-      >
-        {row.value}
-      </Text>
-    </Box>
+    <KeyValueRow label={row.label} value={row.value.padStart(valueWidth)}
+      width={rowWidth} labelWidth={rowWidth - valueWidth} color={row.color} emphasis={row.bold ?? false} />
   );
 }
-
-const MIN_METRIC_COLUMN_WIDTH = 18;
 
 function DividendSummary({
   metrics,
@@ -112,9 +104,9 @@ function DividendSummary({
   warnings: string[];
 }) {
   const metricRows = buildMetricRows(metrics, currency);
-  // Two 18-cell blocks overflow anything narrower than 38 cells, so collapse.
-  const columnCount = width - 2 >= MIN_METRIC_COLUMN_WIDTH * 2 ? 2 : 1;
-  const colWidth = Math.max(MIN_METRIC_COLUMN_WIDTH, Math.floor((width - 2) / columnCount));
+  const minColumnWidth = Math.max(...metricRows.map((row) => row.label.length + 2 + Math.max(6, row.value.length)));
+  const columnCount = width - 2 >= minColumnWidth * 2 ? 2 : 1;
+  const colWidth = Math.max(1, Math.floor((width - 2) / columnCount));
   const rowCount = Math.ceil(metricRows.length / columnCount);
   const chartHeight = chartPoints.length >= 2 ? 6 : 0;
   const palette = resolveChartPalette(colors, "positive");
@@ -143,7 +135,9 @@ function DividendSummary({
             points={chartPoints}
             width={Math.max(10, width - 2)}
             height={chartHeight}
-            mode="line"
+            mode="step"
+            calendarSpaced
+            showTimeAxis
             colors={palette}
             yAxisLabel="TTM cash/share"
             yAxisColor={colors.textDim}

--- a/src/plugins/builtin/dividend-yield/provider-client.test.ts
+++ b/src/plugins/builtin/dividend-yield/provider-client.test.ts
@@ -39,9 +39,11 @@ test("browser income distinguishes confirmed no cash from unknown coverage, fail
   }
   const noQuote = await fetchProviderDividendData(createTestDataProvider({ getCorporateActions: async () => actions() }), "FUND", null, "AMS");
   expect(noQuote.metrics).toMatchObject({ trailingRate: 4, trailingYield: null });
-  await expect(fetchProviderDividendData(createTestDataProvider({
-    getCorporateActions: async () => actions({ dividends: [{ exDate: "broken", amount: 4 }] }),
-  }), "FUND", 100, "AMS", "EUR")).rejects.toThrow("records are invalid");
+  for (const exDate of ["broken", "2026-02-30", "2025-02-29", "2026-04-31"]) {
+    await expect(fetchProviderDividendData(createTestDataProvider({
+      getCorporateActions: async () => actions({ dividends: [{ exDate, amount: 4 }] }),
+    }), "FUND", 100, "AMS", "EUR")).rejects.toThrow("records are invalid");
+  }
 });
 
 test("cached dividend and quote provenance survive projection without hiding usable history", async () => {

--- a/src/plugins/builtin/dividend-yield/view.test.ts
+++ b/src/plugins/builtin/dividend-yield/view.test.ts
@@ -19,7 +19,33 @@ test("cash chart reaches the current zero cash rate after payments stop", () => 
     toDividendPayment("2023-08-04", 0.125, "USD")!,
     toDividendPayment("2024-08-07", 0.125, "USD")!,
   ], new Date("2026-09-10"));
-  expect(points.at(-1)).toMatchObject({ date: new Date("2026-09-10"), close: 0 });
+  expect(points.map((point) => [point.date.toISOString().slice(0, 10), point.close])).toEqual([
+    ["2024-08-04", 0], ["2024-08-07", 0.125], ["2025-08-07", 0], ["2026-09-10", 0],
+  ]);
+});
+
+test("cash chart drops on each expiry and combines same-day cash and expiries once", () => {
+  const points = buildTrailingCashChartPoints([
+    toDividendPayment("2022-01-01", 1, "USD")!,
+    toDividendPayment("2023-01-01", 1, "USD")!,
+    toDividendPayment("2023-04-01", 2, "USD")!,
+    toDividendPayment("2024-01-01", 4, "USD")!,
+    toDividendPayment("2024-01-01", 5, "USD")!,
+  ], new Date("2024-05-01"));
+  expect(points.map((point) => [point.date.toISOString().slice(0, 10), point.close])).toEqual([
+    ["2023-01-01", 1], ["2023-04-01", 3], ["2024-01-01", 11], ["2024-04-01", 9], ["2024-05-01", 9],
+  ]);
+});
+
+test("February 29 cash leaves the clamped annual window on March 1 of the following year", () => {
+  const points = buildTrailingCashChartPoints([
+    toDividendPayment("2022-01-01", 1, "USD")!,
+    toDividendPayment("2024-02-28", 2, "USD")!,
+    toDividendPayment("2024-02-29", 3, "USD")!,
+  ], new Date("2025-03-02"));
+  expect(points.slice(-3).map((point) => [point.date.toISOString().slice(0, 10), point.close])).toEqual([
+    ["2025-02-28", 3], ["2025-03-01", 0], ["2025-03-02", 0],
+  ]);
 });
 
 test("leap-day cash chart retains payments after the clamped February 28 cutoff", () => {

--- a/src/plugins/builtin/dividend-yield/view.ts
+++ b/src/plugins/builtin/dividend-yield/view.ts
@@ -12,21 +12,25 @@ export function buildTrailingCashChartPoints(payments: DividendPayment[], now = 
     .sort((a, b) => a.exDate.getTime() - b.exDate.getTime());
   const firstDate = sorted[0]?.exDate;
   if (!firstDate) return [];
-  const points: ProjectedChartPoint[] = [];
+  // Rolling cash changes both on ex-dates and when payments leave the window.
+  // Date rollover deliberately expires February 29 on March 1 in a non-leap
+  // year, when the clamped trailing-year cutoff first reaches that payment.
+  const dates = new Set<number>([now.getTime()]);
   for (const payment of sorted) {
-    const cutoff = calendarYearsBefore(payment.exDate, 1);
+    dates.add(payment.exDate.getTime());
+    const expiry = new Date(payment.exDate);
+    expiry.setUTCFullYear(expiry.getUTCFullYear() + 1);
+    if (expiry <= now) dates.add(expiry.getTime());
+  }
+  const points: ProjectedChartPoint[] = [];
+  for (const timestamp of [...dates].sort((a, b) => a - b)) {
+    const date = new Date(timestamp);
+    const cutoff = calendarYearsBefore(date, 1);
     // Avoid drawing the first partial year of a fund's history as a full-year cash rate.
     if (cutoff < firstDate) continue;
-    const cash = sorted.filter((p) => p.exDate > cutoff && p.exDate <= payment.exDate)
+    const cash = sorted.filter((p) => p.exDate > cutoff && p.exDate <= date)
       .reduce((sum, p) => sum + p.amount, 0);
-    points.push({ date: payment.exDate, open: cash, high: cash, low: cash, close: cash, volume: 0 });
-  }
-  // A suspended payer still needs a current point: otherwise its chart stops
-  // at the final payout and suggests that historical cash rate remains current.
-  const currentCutoff = calendarYearsBefore(now, 1);
-  if (now > sorted.at(-1)!.exDate && currentCutoff >= firstDate) {
-    const cash = sorted.filter((payment) => payment.exDate > currentCutoff).reduce((sum, payment) => sum + payment.amount, 0);
-    points.push({ date: now, open: cash, high: cash, low: cash, close: cash, volume: 0 });
+    points.push({ date, open: cash, high: cash, low: cash, close: cash, volume: 0 });
   }
   return points;
 }

--- a/src/plugins/builtin/research/corporate-actions-pane.test.tsx
+++ b/src/plugins/builtin/research/corporate-actions-pane.test.tsx
@@ -1,0 +1,68 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender, emitKeypress } from "../../../renderers/opentui/test-utils";
+import { createInitialState } from "../../../state/app/context";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { TestPaneProvider, createTestTicker, createTestPaneConfig } from "../../../test-support/pane";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
+import type { CorporateActionsData } from "../../../types/financials";
+import { Box } from "../../../ui";
+import { CorporateActionsView } from "./corporate-actions-pane";
+
+let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+
+async function frame() {
+  await act(async () => { await Bun.sleep(1); });
+  await act(async () => { await setup!.renderOnce(); });
+}
+
+async function render(actions: CorporateActionsData, variant: "corporate-actions" | "earnings-estimates", width = 80) {
+  const paneId = `${variant}:TEST`;
+  const config = createTestPaneConfig("/tmp/gloom-corporate-actions-pane-test", {
+    instanceId: paneId, paneId: variant, binding: { kind: "fixed", symbol: "TEST" },
+  });
+  const state = createInitialState(config);
+  state.focusedPaneId = paneId;
+  state.tickers = new Map([["TEST", createTestTicker("TEST", "Test", { exchange: "ASX", currency: "AUD" })]]);
+  const provider = createTestDataProvider({
+    getCorporateActions: async () => actions,
+    getAnalystResearch: async () => ({ symbol: "TEST", recommendations: [], ratings: [], earningsEstimates: [], revenueEstimates: [] }),
+  });
+  await act(async () => {
+    setup = await testRender(
+      <TestPaneProvider state={state} paneId={paneId} pluginId="ticker-research" runtime={createTestPluginRuntime({ getMarketData: () => provider })}>
+        <Box width={width} height={24} flexDirection="column">
+          <CorporateActionsView focused width={width} height={24} variant={variant} footerPaneId={variant} />
+        </Box>
+      </TestPaneProvider>,
+      { width, height: 24 },
+    );
+  });
+  for (let index = 0; index < 4; index++) await frame();
+}
+
+afterEach(async () => {
+  if (setup) await act(async () => { setup!.renderer.destroy(); });
+  setup = undefined;
+});
+
+test("opening a fiscal-period row cannot select a same-day pending announcement", async () => {
+  await render({ symbol: "TEST", dividends: [], splits: [], earnings: [
+    { date: "2026-09-30", dateType: "announcement", epsEstimate: 2.2 },
+    { date: "2026-09-30", dateType: "fiscal-period-end", epsActual: 2, epsEstimate: 1.8, currency: "USD" },
+  ] }, "earnings-estimates", 120);
+  await emitKeypress(setup!, { name: "down" });
+  await frame();
+  await emitKeypress(setup!, { name: "return" });
+  await frame();
+  expect(setup!.captureCharFrame()).toContain("Actual: 2 USD | Consensus: 1.8 USD");
+  expect(setup!.captureCharFrame()).not.toContain("Actual: - | Consensus: 2.2");
+});
+
+test.each(["corporate-actions", "earnings-estimates"] as const)("%s preserves unavailable source status with no visible rows", async (variant) => {
+  await render({ symbol: "TEST", earnings: [], splits: [],
+    dividends: variant === "earnings-estimates" ? [{ exDate: "2026-09-30", amount: 0.1 }] : [],
+    coverage: { dividends: "available", splits: "unavailable", earnings: "unavailable" },
+  }, variant);
+  expect(setup!.captureCharFrame()).toContain(variant === "earnings-estimates" ? "Unavailable: earnings" : "Unavailable: splits, earnings");
+});

--- a/src/plugins/builtin/research/corporate-actions-pane.tsx
+++ b/src/plugins/builtin/research/corporate-actions-pane.tsx
@@ -195,7 +195,7 @@ export function buildEventDetailBody({
   primaryContentLoading: boolean;
 }): string {
   if (row.status === "Q Est" || row.status === "FY Est") {
-    const lines = ["Forecast for the stated fiscal period end; this is not an earnings announcement date."];
+    const lines = [`Fiscal period end: ${row.date}`];
     for (const [key, label] of [["eps", "EPS"], ["revenue", "Revenue"]] as const) {
       const estimate = row.estimateInputs?.[key];
       if (!estimate) continue;
@@ -203,21 +203,20 @@ export function buildEventDetailBody({
       lines.push("", `${label} consensus${estimate.currency ? "" : " (currency unavailable)"}`,
         `Average: ${amount(estimate.average)}`,
         `Low: ${amount(estimate.low)} | High: ${amount(estimate.high)}`,
-        `Prior-year comparison: ${amount(estimate.yearAgo)} (provider input; may be a forecast)`,
+        `Prior-year input: ${amount(estimate.yearAgo)}`,
         `Provider growth: ${estimate.growth == null ? "-" : formatPercent(estimate.growth)}`,
         `Contributing analysts: ${estimate.analysts ?? "-"}`);
     }
     if (!row.estimateInputs) lines.push("", eventSummaryLine(row), "Detailed estimate inputs are unavailable.");
-    if (row.estimateGrowthMetric) lines.push("", `The table growth value refers to ${row.estimateGrowthMetric === "eps" ? "EPS" : "revenue"}.`);
-    lines.push("", "Consensus is a forecast. EPS accounting and adjustment basis are unspecified; statement EPS may differ.",
+    if (row.estimateGrowthMetric) lines.push("", `Table growth: ${row.estimateGrowthMetric === "eps" ? "EPS" : "Revenue"}`);
+    lines.push("",
       `Source: ${row.providerId ?? "unavailable"}`,
-      row.fetchedAt ? `Fetched: ${row.fetchedAt} (retrieval time, not an estimate revision date).` : "Retrieval time unavailable.");
+      row.fetchedAt ? `Fetched: ${row.fetchedAt}` : "Retrieval time unavailable.");
     return lines.join("\n");
   }
   const lines: string[] = ["Summary", eventSummaryLine(row)];
   if (row.status === "Factor") {
     lines.push("", "Provider split/adjustment factor",
-      "This factor can encode a stock split or a spinoff price adjustment. It does not establish shares received, distribution terms, or the legal effective date. Verify those terms in issuer filings.",
       ...(row.providerDescription ? [`Provider description: ${row.providerDescription}`] : []));
   }
   if (row.status !== "Earnings") {
@@ -228,18 +227,16 @@ export function buildEventDetailBody({
   lines.push(`Actual: ${earningsInput(row.epsActual, row.epsCurrency)} | Consensus: ${earningsInput(row.epsEstimate, row.epsCurrency)}`);
   if (row.epsDifference != null) lines.push(`Difference: ${earningsInput(row.epsDifference, row.epsCurrency)}`);
   if (row.surprisePercent != null) lines.push(`Surprise: ${earningsInput(row.surprisePercent)}%`);
-  lines.push("EPS and consensus may be adjusted; the provider does not specify the accounting basis. Statement EPS can differ.");
   if (row.providerId || row.fetchedAt) lines.push([row.providerId, row.fetchedAt ? `Fetched ${row.fetchedAt}` : null].filter(Boolean).join(" | "));
   if (row.fiscalPeriodEnd) lines.push(`Fiscal period: ${row.fiscalPeriodEnd} (${row.periodDateSource === "sec" ? "SEC corroborated" : "provider date"})`);
   if (row.providerPeriodDate) lines.push(`Provider period date: ${row.providerPeriodDate}`);
-  if (row.dateEvidence) lines.push(`Period evidence: ${row.dateEvidence.accessionNumber}, filed ${row.dateEvidence.filed}. This is not an announcement date or verification of every metric.`);
+  if (row.dateEvidence) lines.push(`Period evidence: ${row.dateEvidence.accessionNumber}, filed ${row.dateEvidence.filed}`);
   if (row.qRevenue == null && row.earningsState === "reported") lines.push("Quarterly revenue unavailable: no matching statement period was identified.");
 
   lines.push("", "SEC Filing");
   if (row.dateType === "fiscal-period-end") {
-    lines.push("The event source supplies a fiscal period date, not an announcement date.");
     if (!row.dateEvidence) {
-      lines.push("Open SEC filings to locate the earnings release.");
+      lines.push("Related SEC filing unavailable.");
       return lines.join("\n");
     }
   }

--- a/src/plugins/builtin/research/corporate-actions-pane.tsx
+++ b/src/plugins/builtin/research/corporate-actions-pane.tsx
@@ -577,7 +577,7 @@ export function CorporateActionsView({
       )}
       emptyStateTitle={loading
         ? (variant === "earnings-estimates" ? "Loading earnings estimates..." : "Loading events...")
-        : error ?? (variant === "earnings-estimates" ? "No earnings estimates" : "No events")}
+        : error ?? sourceNotice?.text ?? (variant === "earnings-estimates" ? "No earnings estimates" : "No events")}
     />
   );
 }

--- a/src/plugins/builtin/research/event-model.test.ts
+++ b/src/plugins/builtin/research/event-model.test.ts
@@ -21,6 +21,23 @@ test("pending RIVN earnings show consensus without borrowing prior-quarter actua
   expect(row?.revenueCurrency).toBeUndefined();
 });
 
+test("same-day announcements and fiscal periods retain independent detail identities", () => {
+  const actions = { symbol: "TEST", dividends: [], splits: [], earnings: [
+    { date: "2026-09-30", dateType: "announcement" as const, epsEstimate: 2.2 },
+    { date: "2026-09-30", dateType: "fiscal-period-end" as const, epsActual: 2, epsEstimate: 1.8 },
+  ] };
+  const rows = buildEventRows(actions, null, null, "USD");
+  const reported = rows.find((row) => row.earningsState === "reported")!;
+  const pending = rows.find((row) => row.earningsState === "pending")!;
+  expect(new Set(rows.map((row) => row.id)).size).toBe(2);
+  // Detail lookup uses the selected row's id; it must not resolve to the announcement.
+  expect(rows.find((row) => row.id === reported.id)).toMatchObject({ epsActual: 2, epsEstimate: 1.8 });
+  expect(rows.find((row) => row.id === pending.id)).toMatchObject({ earningsState: "pending", epsEstimate: 2.2 });
+  const reordered = buildEventRows({ ...actions, earnings: [...actions.earnings].reverse() }, null, null, "USD");
+  expect(reordered.find((row) => row.earningsState === "reported")?.id).toBe(reported.id);
+  expect(reordered.find((row) => row.earningsState === "pending")?.id).toBe(pending.id);
+});
+
 test("ADRs keep independent consensus EPS and revenue currencies and never infer missing ones", () => {
   const rows = buildEventRows(null, { symbol: "TSM", currency: "USD", recommendations: [], ratings: [],
     earningsEstimates: [{ date: "2026-09-30", period: "current_quarter", average: 4.46, currency: "USD" }],
@@ -52,6 +69,23 @@ test("partial and stale corporate data are not described as an empty event histo
     actions: { symbol: "RIVN", dividends: [], splits: [], earnings: [], coverage: { earnings: "unavailable", dividends: "available" }, stale: true },
   });
   expect(notice).toEqual({ text: "Unavailable: earnings   Corporate actions stale", failed: true });
+});
+
+test("EE ignores dividends, adjustments and pending announcements when assessing reported earnings coverage", () => {
+  const state = { variant: "earnings-estimates" as const, symbol: "TEST", actionsError: null, estimatesError: null, estimates: null,
+    actions: { symbol: "TEST", dividends: [{ exDate: "2026-09-30", amount: 0.1 }],
+      splits: [{ date: "2026-09-30", fromFactor: 10, toFactor: 1 }],
+      earnings: [{ date: "2026-09-30", dateType: "announcement" as const, epsEstimate: 2.2 }],
+    },
+  };
+  expect(eventSourceNotice(state)).toEqual({ text: "No reported earnings for TEST", failed: false });
+  expect(eventSourceNotice({ ...state, variant: "corporate-actions" })).toBeNull();
+  expect(eventSourceNotice({ ...state, actions: { ...state.actions,
+    earnings: [{ ...state.actions.earnings[0]!, epsActual: 0 }],
+  } })).toBeNull();
+  expect(eventSourceNotice({ ...state, actions: { ...state.actions,
+    coverage: { earnings: "unavailable" },
+  } })).toEqual({ text: "Unavailable: earnings", failed: true });
 });
 
 test("period aliases retain exact filing provenance and raw surprise inputs", () => {

--- a/src/plugins/builtin/research/event-model.test.ts
+++ b/src/plugins/builtin/research/event-model.test.ts
@@ -38,6 +38,22 @@ test("same-day announcements and fiscal periods retain independent detail identi
   expect(reordered.find((row) => row.earningsState === "pending")?.id).toBe(pending.id);
 });
 
+test("multiple reported records and exact duplicates retain unique same-provenance identities", () => {
+  const first = { date: "2026-09-30", dateType: "announcement" as const, epsActual: 2, epsEstimate: 1.8 };
+  const second = { ...first, epsActual: 3, epsEstimate: 2.7 };
+  for (const dateType of ["announcement", "fiscal-period-end", undefined] as const) {
+    const actions = { symbol: "TEST", dividends: [], splits: [], earnings: [first, second, first].map((earning) => ({ ...earning, dateType })) };
+    const rows = buildEventRows(actions, null, null, "USD");
+    expect(new Set(rows.map((row) => row.id)).size).toBe(3);
+    const selected = rows.find((row) => row.epsActual === 3)!;
+    expect(rows.find((row) => row.id === selected.id)?.epsEstimate).toBe(2.7);
+    const reordered = buildEventRows({ ...actions, earnings: [actions.earnings[1]!, actions.earnings[2]!, actions.earnings[0]!] }, null, null, "USD");
+    expect(reordered.find((row) => row.id === selected.id)?.epsActual).toBe(3);
+    expect(new Set(reordered.map((row) => row.id))).toEqual(new Set(rows.map((row) => row.id)));
+    expect(rows.every((row) => row.fiscalPeriodEnd === undefined)).toBe(true);
+  }
+});
+
 test("ADRs keep independent consensus EPS and revenue currencies and never infer missing ones", () => {
   const rows = buildEventRows(null, { symbol: "TSM", currency: "USD", recommendations: [], ratings: [],
     earningsEstimates: [{ date: "2026-09-30", period: "current_quarter", average: 4.46, currency: "USD" }],

--- a/src/plugins/builtin/research/event-model.ts
+++ b/src/plugins/builtin/research/event-model.ts
@@ -201,7 +201,7 @@ export function buildEventRows(
     // A pending announcement must never inherit the previous report's actuals.
     const statement = earning.epsActual == null ? undefined : statementForEarningsDate(quarterlyStatements, earning);
     rows.push({
-      id: `earn:${earning.date}`,
+      id: `earn:${earning.date}${earning.dateType ? `:${earning.dateType}` : ""}`,
       date: statement?.date ?? earning.date,
       dateType: earning.dateType,
       status: "Earnings",
@@ -323,7 +323,9 @@ export function eventSourceNotice(state: EventSourceState): EventSourceNotice | 
     notices.push(`${actionsLabel} unavailable: ${state.actionsError}`);
   } else if (unavailableSections.length > 0) {
     notices.push(`Unavailable: ${unavailableSections.join(", ")}`);
-  } else if (state.actions && !hasCorporateActionRows(state.actions)) {
+  } else if (state.actions && !(state.variant === "earnings-estimates"
+    ? state.actions.earnings.some((earning) => earning.epsActual != null)
+    : hasCorporateActionRows(state.actions))) {
     notices.push(state.variant === "earnings-estimates"
       ? `No reported earnings for ${state.symbol}`
       : `No dividends, splits, or reported earnings for ${state.symbol}`);

--- a/src/plugins/builtin/research/event-model.ts
+++ b/src/plugins/builtin/research/event-model.ts
@@ -175,6 +175,26 @@ function earningsDetail(earning: CorporateActionsData["earnings"][number]): stri
   return earning.dateType === "fiscal-period-end" ? `Period end; ${detail}` : detail;
 }
 
+function earningsRowIds(earnings: CorporateActionsData["earnings"]): string[] {
+  const baseIds = earnings.map((earning) => `earn:${earning.date}${earning.dateType ? `:${earning.dateType}` : ""}`);
+  const counts = new Map<string, number>();
+  for (const id of baseIds) counts.set(id, (counts.get(id) ?? 0) + 1);
+  const occurrences = new Map<string, number>();
+  return earnings.map((earning, index) => {
+    let id = baseIds[index]!;
+    // The source has no event ID or fiscal-period identity for announcements.
+    // Retain colliding records without assigning inferred periods; their supplied
+    // inputs keep distinct details stable when the provider reorders the feed.
+    if (counts.get(id)! > 1) id += `:${JSON.stringify([
+      earning.time ?? null, earning.currency ?? null, earning.epsActual ?? null,
+      earning.epsEstimate ?? null, earning.difference ?? null, earning.surprisePercent ?? null,
+    ])}`;
+    const occurrence = (occurrences.get(id) ?? 0) + 1;
+    occurrences.set(id, occurrence);
+    return occurrence === 1 ? id : `${id}:${occurrence}`;
+  });
+}
+
 function eventSortRank(status: EventStatus): number {
   switch (status) {
     case "Q Est": return 0;
@@ -197,11 +217,13 @@ export function buildEventRows(
   const ttm = ttmRow(quarterlyStatements, financials?.financialCurrency);
   if (ttm) rows.push(ttm);
 
-  for (const earning of data?.earnings ?? []) {
+  const earnings = data?.earnings ?? [];
+  const earningsIds = earningsRowIds(earnings);
+  for (const [index, earning] of earnings.entries()) {
     // A pending announcement must never inherit the previous report's actuals.
     const statement = earning.epsActual == null ? undefined : statementForEarningsDate(quarterlyStatements, earning);
     rows.push({
-      id: `earn:${earning.date}${earning.dateType ? `:${earning.dateType}` : ""}`,
+      id: earningsIds[index]!,
       date: statement?.date ?? earning.date,
       dateType: earning.dateType,
       status: "Earnings",

--- a/src/plugins/builtin/research/index.test.ts
+++ b/src/plugins/builtin/research/index.test.ts
@@ -289,7 +289,7 @@ describe("event rows", () => {
     };
     const rows = buildEventRows(actions, null, financials, "USD");
 
-    const earnings = rows.find((row) => row.id === "earn:2026-03-31");
+    const earnings = rows.find((row) => row.status === "Earnings" && row.date === "2026-03-31");
     const ttm = rows.find((row) => row.status === "TTM");
 
     expect(earnings).toMatchObject({

--- a/src/plugins/builtin/research/index.test.ts
+++ b/src/plugins/builtin/research/index.test.ts
@@ -192,7 +192,7 @@ describe("event rows", () => {
       inlineContent: new Map(), primaryContent: null, primaryContentLoading: false });
     expect(detail).toContain("Low: 4 USD | High: 5 USD");
     expect(detail).toContain("Low: 1,400,000,000,000 TWD | High: 1,500,000,000,000 TWD");
-    expect(detail).toContain("Prior-year comparison: 0 USD");
+    expect(detail).toContain("Prior-year input: 0 USD");
     expect(detail).toContain("Provider growth: 0.00%");
     expect(detail).toContain("Provider growth: +45.00%");
   });
@@ -385,9 +385,7 @@ describe("event rows", () => {
     const detail = buildEventDetailBody({ row: periodRow, secFilingsLoading: false,
       filing: filings[0]!, documents: [], documentsLoading: false, inlineContent: new Map(),
       primaryContent: "Fiscal statement content", primaryContentLoading: false });
-    expect(detail).toContain("not an announcement date");
     expect(detail).toContain("Fiscal statement content");
-    expect(detail).toContain("accounting basis");
   });
 });
 

--- a/src/renderers/electrobun/view/data-table/index.tsx
+++ b/src/renderers/electrobun/view/data-table/index.tsx
@@ -362,7 +362,11 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
             emptyContent ?? (
               <div
                 style={{
-                  width: "100%",
+                  width: viewportWidth > 0 ? viewportWidth * WEB_CELL_WIDTH : "100%",
+                  maxWidth: "100%",
+                  boxSizing: "border-box",
+                  position: "sticky",
+                  left: 0,
                   padding: `${WEB_CELL_HEIGHT}px ${WEB_CELL_WIDTH}px`,
                   color: CSS_TEXT_DIM,
                   lineHeight: "var(--cell-h)",
@@ -370,11 +374,11 @@ export function WebDataTable<T, C extends DataTableColumn = DataTableColumn>({
               >
                 {/* cellTextStyle is inline-block for real cells, so the title and
                     hint would share one line and read as a single run-on string. */}
-                <div style={{ ...cellTextStyle(CSS_TEXT_BRIGHT, TextAttributes.BOLD), display: "block" }}>
+                <div style={{ ...cellTextStyle(CSS_TEXT_BRIGHT, TextAttributes.BOLD), display: "block", whiteSpace: "normal", overflowWrap: "anywhere" }}>
                   {emptyStateTitle}
                 </div>
                 {emptyStateHint ? (
-                  <div style={{ ...cellTextStyle(CSS_TEXT_DIM, TextAttributes.NONE), display: "block" }}>
+                  <div style={{ ...cellTextStyle(CSS_TEXT_DIM, TextAttributes.NONE), display: "block", whiteSpace: "normal", overflowWrap: "anywhere" }}>
                     {emptyStateHint}
                   </div>
                 ) : null}

--- a/src/sources/yahoo-finance/mappers.test.ts
+++ b/src/sources/yahoo-finance/mappers.test.ts
@@ -1,9 +1,58 @@
 import { describe, expect, test } from "bun:test";
-import { extractExtendedHoursPrices, mapYahooAnalystResearchResponse, mapYahooCalendarEarnings, mapYahooEarningsHistory } from "./mappers";
+import { extractExtendedHoursPrices, mapYahooAnalystResearchResponse, mapYahooCalendarEarnings, mapYahooDividends, mapYahooEarningsHistory, mapYahooSplits, yahooRawDate } from "./mappers";
 import { loadYahooCorporateActions } from "./quote-summary";
 import type { ChartResult } from "./types";
 
 describe("Yahoo mappers", () => {
+  test("uses historical exchange-local dates for dividend and split timestamps", () => {
+    // Synthetic source-boundary fixtures; these do not assert an issuer's actual actions.
+    const cases = [
+      ["Australia/Sydney", "2026-01-01T23:00:00Z", "2026-01-02"],
+      ["Australia/Sydney", "2026-07-01T00:00:00Z", "2026-07-01"],
+      ["Pacific/Auckland", "2026-01-01T21:00:00Z", "2026-01-02"],
+      ["Europe/London", "2026-07-01T07:00:00Z", "2026-07-01"],
+      ["America/New_York", "2026-01-02T14:30:00Z", "2026-01-02"],
+      ["America/New_York", "2026-07-01T13:30:00Z", "2026-07-01"],
+      // The DST change means the same UTC clock time falls on different local dates.
+      ["Australia/Sydney", "2026-04-04T13:30:00Z", "2026-04-05"],
+      ["Australia/Sydney", "2026-04-05T13:30:00Z", "2026-04-05"],
+    ];
+    for (const [exchangeTimezoneName, instant, expected] of cases) {
+      const date = Date.parse(instant!) / 1000;
+      const events = {
+        dividends: { one: { date, amount: 0.25 } },
+        splits: { one: { date, numerator: 1, denominator: 10, splitRatio: "1:10" } },
+      };
+      const meta = { exchangeTimezoneName };
+      expect(mapYahooDividends(events, meta)).toEqual([{ exDate: expected, amount: 0.25 }]);
+      expect(mapYahooSplits(events, meta)).toEqual([{ date: expected, description: "1:10 split", ratio: 0.1, fromFactor: 10, toFactor: 1 }]);
+    }
+  });
+
+  test("preserves UTC fallback and independent date-only fields without inferring a timezone", () => {
+    const date = Date.parse("2026-01-01T23:00:00Z") / 1000;
+    const events = { dividends: { valid: { date, amount: 1 }, invalid: { date: Infinity, amount: 1 } }, splits: { valid: { date }, invalid: { date: 1e20 } } };
+    for (const meta of [undefined, {}, { exchangeTimezoneName: "Unknown/Exchange" }]) {
+      expect(mapYahooDividends(events, meta)).toEqual([{ exDate: "2026-01-01", amount: 1 }]);
+      expect(mapYahooSplits(events, meta).map((row) => row.date)).toEqual(["2026-01-01"]);
+    }
+    expect(yahooRawDate("2026-01-02")).toBe("2026-01-02");
+    expect(yahooRawDate({ fmt: "2026-01-02", raw: date })).toBe("2026-01-02");
+  });
+
+  test("carries chart timezone through corporate-action loading", async () => {
+    const date = Date.parse("2026-01-01T23:00:00Z") / 1000;
+    const data = await loadYahooCorporateActions({ ticker: "FIXTURE.AX", providerId: "yahoo",
+      fetchChart: async () => ({ meta: { currency: "AUD", exchangeTimezoneName: "Australia/Sydney" }, events: {
+        dividends: { one: { date, amount: 0.25 } }, splits: { one: { date, numerator: 1, denominator: 10 } },
+      } }),
+      fetchJsonWithCrumb: async () => { throw new Error("Independent earnings unavailable"); },
+    });
+    expect(data.dividends).toEqual([{ exDate: "2026-01-02", amount: 0.25 }]);
+    expect(data.splits[0]).toMatchObject({ date: "2026-01-02", ratio: 0.1, fromFactor: 10, toFactor: 1 });
+    expect(data.currency).toBe("AUD");
+  });
+
   test("normalizes London price targets without converting USD earnings estimates", () => {
     const data = mapYahooAnalystResearchResponse({ price: { currency: "GBp" },
       financialData: { targetMeanPrice: 3812.312, currentPrice: 3533.5 },

--- a/src/sources/yahoo-finance/mappers.ts
+++ b/src/sources/yahoo-finance/mappers.ts
@@ -9,6 +9,7 @@ import type {
   SplitAction,
 } from "../../types/financials";
 import { resolveCurrencyUnit } from "../../utils/currency-units";
+import { zonedDateTimeParts } from "../../utils/zoned-date-time";
 import type { ChartResult, YahooEarningsTrend, YahooQuoteSummaryResult } from "./types";
 
 export type ExtendedHoursData = {
@@ -175,20 +176,20 @@ export function mapYahooAnalystResearchResponse(
   };
 }
 
-export function mapYahooDividends(events: ChartResult["events"]): DividendAction[] {
+export function mapYahooDividends(events: ChartResult["events"], meta?: ChartResult["meta"]): DividendAction[] {
   return Object.values(events?.dividends ?? {})
     .map((dividend): DividendAction | null => {
-      const date = yahooTimestampDate(dividend.date);
+      const date = yahooTimestampDate(dividend.date, meta?.exchangeTimezoneName);
       if (!date || dividend.amount == null || !Number.isFinite(dividend.amount)) return null;
       return { exDate: date, amount: dividend.amount };
     })
     .filter((dividend): dividend is DividendAction => dividend !== null);
 }
 
-export function mapYahooSplits(events: ChartResult["events"]): SplitAction[] {
+export function mapYahooSplits(events: ChartResult["events"], meta?: ChartResult["meta"]): SplitAction[] {
   return Object.values(events?.splits ?? {})
     .map((split): SplitAction | null => {
-      const date = yahooTimestampDate(split.date);
+      const date = yahooTimestampDate(split.date, meta?.exchangeTimezoneName);
       if (!date) return null;
       const numerator = split.numerator;
       const denominator = split.denominator;
@@ -413,10 +414,21 @@ function mapYahooEstimate(
   };
 }
 
-function yahooTimestampDate(value: number | undefined): string | undefined {
+function yahooTimestampDate(value: number | undefined, exchangeTimeZone?: string): string | undefined {
   if (value == null || !Number.isFinite(value)) return undefined;
   const date = new Date(value * 1000);
-  return Number.isNaN(date.getTime()) ? undefined : date.toISOString().slice(0, 10);
+  if (Number.isNaN(date.getTime())) return undefined;
+  // Chart action timestamps are instants. Use the historical exchange-local date,
+  // not today's GMT offset, which can differ because of daylight saving time.
+  if (exchangeTimeZone) {
+    try {
+      const { year, month, day } = zonedDateTimeParts(date.getTime(), exchangeTimeZone);
+      return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+    } catch {
+      // Preserve the existing UTC fallback when the provider supplies no usable timezone.
+    }
+  }
+  return date.toISOString().slice(0, 10);
 }
 
 function computeExtendedHoursChange(

--- a/src/sources/yahoo-finance/quote-summary.ts
+++ b/src/sources/yahoo-finance/quote-summary.ts
@@ -172,8 +172,8 @@ export async function loadYahooCorporateActions({
         name: result?.price?.shortName ?? result?.price?.longName,
         currency: dividendUnit.currency || undefined,
         exchange: result?.price?.exchangeName ?? result?.quoteType?.exchange,
-        dividends: mapYahooDividends(chart?.events).map((dividend) => ({ ...dividend, amount: dividend.amount / dividendUnit.divisor })),
-        splits: mapYahooSplits(chart?.events),
+        dividends: mapYahooDividends(chart?.events, chart?.meta).map((dividend) => ({ ...dividend, amount: dividend.amount / dividendUnit.divisor })),
+        splits: mapYahooSplits(chart?.events, chart?.meta),
         earnings: [
           ...mapYahooCalendarEarnings(result ?? {}),
           ...mapYahooEarningsHistory(result ?? {}),

--- a/src/sources/yahoo-finance/types.ts
+++ b/src/sources/yahoo-finance/types.ts
@@ -9,6 +9,7 @@ export type ChartResult = {
     regularMarketPrice?: number; chartPreviousClose?: number;
     fiftyTwoWeekHigh?: number; fiftyTwoWeekLow?: number;
     exchangeName?: string; fullExchangeName?: string;
+    exchangeTimezoneName?: string;
     regularMarketTime?: number;
     currentTradingPeriod?: { pre?: TradingPeriod; regular?: TradingPeriod; post?: TradingPeriod };
     preMarketPrice?: number; postMarketPrice?: number;


### PR DESCRIPTION
Income research could show a blank growth rate after a complete dividend suspension, and its cash chart skipped the dates when payments aged out of the trailing year. Event research could show the wrong earnings detail for same-day records or describe unavailable data as an empty calendar.

This change:
- Calculates a full cash decline from a positive, complete baseline as −100%, while keeping unknown and zero baselines undefined.
- Plots trailing cash on payment and expiry dates with calendar spacing and steps; retains date labels and collapses narrow income summaries before labels collide.
- Uses Yahoo's historical exchange timezone for dividend and split instants, including sessions starting on the previous UTC date.
- Keeps same-day earnings records independently selectable and preserves missing/unavailable earnings states in EE and EVT.
- Rejects impossible dividend calendar dates and wraps empty-table source failures within the visible browser pane.
- Moves recurring event-detail methodology to docs while retaining source inputs, dates, and active failures; no duplicate actions or informational toolbars.

Validation: 3,173 local tests passed (12,825 assertions), all six runtime typechecks passed, and the browser bundle audit passed before rebasing onto the latest main. Targeted source fixtures cover leap days, suspensions, duplicate events, exchange dates, and unavailable coverage. Actual terminal checks used live INTC/SGOV income data at 120/80 columns; browser checks used captured public dividend data at 1440/720px with sorting and reload. Combined browser/terminal fixture checks separately validated selection of same-date earnings records, unavailable EVT/EE coverage, and ASX action-date projection; the 74-test research suite and browser-table interaction test passed after the detail/wrapping edits. Fresh public probes also covered SCHD, JEPQ, VOD London, and COST. Authenticated hosted provider parity remains a separate sweep item. No version bump or GitHub release.
