### PR TITLE
Fix research sign-in recovery and equity chart volume units

### DIFF
--- a/src/market-data/market/format.ts
+++ b/src/market-data/market/format.ts
@@ -17,7 +17,7 @@ export interface MarketFormatOptions extends AssetDisplayContext {
 
 const CASH_TYPES = new Set(["CASH", "FX", "FOREX", "CCY", "CURRENCY", "CURRENCYPAIR"]);
 const CRYPTO_TYPES = new Set(["CRYPTO", "CRYPTOCURRENCY", "DIGITALCURRENCY", "COIN", "TOKEN"]);
-const EQUITY_TYPES = new Set(["STK", "STOCK", "EQUITY", "ETF", "ETN", "ETP", "FUND", "MUTUALFUND", "CEF", "ADR"]);
+const EQUITY_TYPES = new Set(["STK", "STOCK", "COMMONSTOCK", "EQUITY", "ETF", "ETN", "ETP", "FUND", "MUTUALFUND", "CEF", "ADR"]);
 const CONTRACT_TYPES = new Set(["OPT", "OPTION", "OPTIONS", "FUT", "FUTURE", "FUTURES", "FOP"]);
 
 const currencySymbols = new Map<string, string>();

--- a/src/plugins/builtin/dividend-yield/pane.tsx
+++ b/src/plugins/builtin/dividend-yield/pane.tsx
@@ -17,6 +17,8 @@ import { Box, Text, TextAttributes } from "../../../ui";
 import { formatDistributionAmount, formatPercentRaw } from "../../../utils/format";
 import { resolveCurrencyUnit } from "../../../utils/currency-units";
 import { handleRefreshKey, loadingErrorFooterInfo } from "../shared/table-pane";
+import { SignInWall } from "../cloud/auth-actions";
+import { isCloudSessionRequired, useResearchCloudSession } from "../shared/research-cloud-session";
 import { dividendReferencePrice, fetchDividendData, repriceDividendMetrics } from "./client";
 import { buildTrailingCashChartPoints, formatDividendYield } from "./view";
 import {
@@ -174,6 +176,7 @@ export function DividendYieldPane({ focused, width, height, loadData = fetchDivi
   focused: boolean; width: number; height: number; loadData?: typeof fetchDividendData;
 }) {
   const { symbol, ticker, financials } = usePaneTicker();
+  const cloudSession = useResearchCloudSession();
   const quoteCurrency = financials?.quote?.currency;
   const exchange = ticker?.metadata.exchange ?? "";
   const quotePrice = financials?.quote?.price ?? null;
@@ -185,18 +188,19 @@ export function DividendYieldPane({ focused, width, height, loadData = fetchDivi
   const quoteRef = useRef({ price: quotePrice, currency: quoteCurrency });
   quoteRef.current = { price: quotePrice, currency: quoteCurrency };
 
-  const request = useCallback(() => loadData(symbol!, quoteRef.current.price, exchange, quoteRef.current.currency), [exchange, loadData, symbol]);
+  const request = useCallback(() => loadData(symbol!, quoteRef.current.price, exchange, quoteRef.current.currency), [exchange, loadData, symbol, cloudSession.requestKey]);
   const { data, loading, error, updatedAt, reload: refresh } = useAsyncResource(symbol ? request : null);
+  const authWall = !data && isCloudSessionRequired(error);
   useEffect(() => { if (updatedAt !== null) setSelectedIdx(0); }, [updatedAt]);
 
   usePaneFooter("dividend-yield", () => ({
     info: [
-      ...loadingErrorFooterInfo(loading, error),
+      ...loadingErrorFooterInfo(loading, authWall ? null : error),
       ...(data?.fetchedAt ? [{ id: "history-as-of", parts: [{
         text: `History fetched ${data.fetchedAt}`, tone: "muted" as const,
       }] }] : []),
     ],
-  }), [data?.fetchedAt, error, loading]);
+  }), [authWall, data?.fetchedAt, error, loading]);
 
   const payments = data?.payments ?? [];
   const currency = data?.currency ?? payments[0]?.currency ?? resolveCurrencyUnit(ticker?.metadata.currency).currency;
@@ -229,6 +233,8 @@ export function DividendYieldPane({ focused, width, height, loadData = fetchDivi
     : loading
       ? "Loading dividends..."
       : error ?? (data?.historyAvailable ? "No cash distributions reported." : "Dividend history unavailable.");
+
+  if (authWall) return <SignInWall action="view dividend history" needsVerification={cloudSession.needsVerification} />;
 
   return (
     <DataTableView<DividendRow, DividendColumn>

--- a/src/plugins/builtin/research/analyst-pane.tsx
+++ b/src/plugins/builtin/research/analyst-pane.tsx
@@ -11,6 +11,8 @@ import { blendHex, colors, priceColor } from "../../../theme/colors";
 import { formatCurrency, formatPercent } from "../../../utils/format";
 import { useAssetData } from "../../runtime";
 import { handleRefreshKey, loadingErrorFooterInfo } from "../shared/table-pane";
+import { SignInWall } from "../cloud/auth-actions";
+import { isCloudSessionRequired, useResearchCloudSession } from "../shared/research-cloud-session";
 import { useBoundTicker as useSymbolBinding, useTickerRequest } from "../shared/ticker-request";
 import { loadAnalystResearch } from "./client";
 import {
@@ -83,6 +85,7 @@ function AnalystSummary({ data }: { data: AnalystResearchData | null }) {
 
 export function AnalystResearchView({ focused, width, height }: { focused: boolean; width: number; height: number }) {
   const dataProvider = useAssetData();
+  const cloudSession = useResearchCloudSession();
   const { symbol, exchange } = useSymbolBinding();
   const [sortPreference, setSortPreference] = useState<RatingSortPreference>(DEFAULT_RATING_SORT);
   const loader = useCallback((nextSymbol: string, nextExchange: string, forceRefresh: boolean) => {
@@ -93,8 +96,9 @@ export function AnalystResearchView({ focused, width, height }: { focused: boole
       nextExchange,
       forceRefresh ? { cacheMode: "refresh" } : undefined,
     );
-  }, [dataProvider]);
+  }, [dataProvider, cloudSession.requestKey]);
   const { data, loading, error, reload } = useTickerRequest<AnalystResearchData>(loader, symbol, exchange);
+  const authWall = !data && isCloudSessionRequired(error);
   const rows = useMemo(() => sortRatingRows(data?.ratings ?? [], sortPreference), [data?.ratings, sortPreference]);
   const ratingCurrency = data?.priceTarget?.currency ?? data?.currency ?? "USD";
   const columns = useMemo(
@@ -141,8 +145,10 @@ export function AnalystResearchView({ focused, width, height }: { focused: boole
   }, []);
 
   usePaneFooter("analyst-research", () => ({
-    info: loadingErrorFooterInfo(loading, error),
-  }), [error, loading]);
+    info: loadingErrorFooterInfo(loading, authWall ? null : error),
+  }), [authWall, error, loading]);
+
+  if (authWall) return <SignInWall action="view analyst research" needsVerification={cloudSession.needsVerification} />;
 
   return (
     <DataTableView<AnalystResearchData["ratings"][number], RatingColumn>

--- a/src/plugins/builtin/research/corporate-actions-pane.tsx
+++ b/src/plugins/builtin/research/corporate-actions-pane.tsx
@@ -23,6 +23,8 @@ import { usePaneTicker } from "../../../state/app/context";
 import { isUsEquityTicker } from "../../../utils/sec";
 import { useAssetData } from "../../runtime";
 import { handleRefreshKey, loadingErrorFooterInfo } from "../shared/table-pane";
+import { SignInWall } from "../cloud/auth-actions";
+import { isCloudSessionRequired, useResearchCloudSession } from "../shared/research-cloud-session";
 import { useBoundTicker as useSymbolBinding, useTickerRequest } from "../shared/ticker-request";
 import {
   documentContentKey,
@@ -307,17 +309,18 @@ export function CorporateActionsView({
   variant?: "corporate-actions" | "earnings-estimates";
 }) {
   const dataProvider = useAssetData();
+  const cloudSession = useResearchCloudSession();
   const { symbol, ticker, exchange, currency } = useSymbolBinding();
   // The shared ticker snapshot already subscribes to financials for this pane.
   const { financials: financialsData } = usePaneTicker();
   const actionsLoader = useCallback((nextSymbol: string, nextExchange: string, forceRefresh: boolean) => {
     if (!dataProvider?.getCorporateActions) throw new Error("Corporate actions source unavailable");
     return dataProvider.getCorporateActions(nextSymbol, nextExchange, forceRefresh ? { cacheMode: "refresh" } : undefined);
-  }, [dataProvider]);
+  }, [dataProvider, cloudSession.requestKey]);
   const analystLoader = useCallback(async (nextSymbol: string, nextExchange: string, forceRefresh: boolean) => {
     if (!dataProvider?.getAnalystResearch) return null;
     return dataProvider.getAnalystResearch(nextSymbol, nextExchange, forceRefresh ? { cacheMode: "refresh" } : undefined);
-  }, [dataProvider]);
+  }, [dataProvider, cloudSession.requestKey]);
   const {
     data: actionsData,
     loading: actionsLoading,
@@ -358,9 +361,10 @@ export function CorporateActionsView({
   const todayKey = todayDateKey();
   const futureRowBackground = blendHex(colors.bg, colors.positive, 0.16);
   const loading = actionsLoading || analystLoading;
+  const authWall = !loading && !actionsData && !analystData && (isCloudSessionRequired(actionsError) || isCloudSessionRequired(analystError));
   // Parallel requests fail with the same message ("No ticker selected"), so the
   // footer must report each distinct reason once.
-  const error = [...new Set([actionsError, analystError].filter((value): value is string => !!value))]
+  const error = [...new Set([actionsError, analystError].filter((value): value is string => !!value && !isCloudSessionRequired(value)))]
     .join(" | ") || null;
   const reload = useCallback(() => {
     reloadActions();
@@ -537,6 +541,11 @@ export function CorporateActionsView({
   usePaneFooter(footerPaneId, () => ({
     info: loadingErrorFooterInfo(loading, error),
   }), [error, footerPaneId, loading]);
+
+  if (authWall) return <SignInWall
+    action={variant === "earnings-estimates" ? "view earnings estimates" : "view corporate actions"}
+    needsVerification={cloudSession.needsVerification}
+  />;
 
   return (
     <DataTableStackView<EventRow, EventColumn>

--- a/src/plugins/builtin/shared/research-cloud-session.test.tsx
+++ b/src/plugins/builtin/shared/research-cloud-session.test.tsx
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, expect, spyOn, test } from "bun:test";
+import { act } from "react";
+import { apiClient, type AuthUser } from "../../../api-client";
+import { PaneFooterBar, PaneFooterProvider } from "../../../components/layout/pane/footer";
+import { createTestControls, emitKeypress, testRender } from "../../../renderers/opentui/test-utils";
+import { createInitialState } from "../../../state/app/context";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { TestPaneProvider, createTestPaneConfig, createTestTicker } from "../../../test-support/pane";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
+import { Box } from "../../../ui";
+import { DividendYieldPane } from "../dividend-yield/pane";
+import { fetchProviderDividendData } from "../dividend-yield/provider-client";
+import { AnalystResearchView } from "../research/analyst-pane";
+import { CorporateActionsView } from "../research/corporate-actions-pane";
+import { isCloudSessionRequired } from "./research-cloud-session";
+
+const denial = "Gloom Cloud requires signup and email verification";
+const panes = ["dividend-yield", "analyst-research", "corporate-actions", "earnings-estimates"] as const;
+let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+let user: AuthUser | null = null;
+const listeners = new Set<() => void>();
+let getUserSpy: ReturnType<typeof spyOn>;
+let subscribeSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  user = null;
+  getUserSpy = spyOn(apiClient, "getCurrentUser").mockImplementation(() => user);
+  subscribeSpy = spyOn(apiClient, "subscribeCurrentUser").mockImplementation((listener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  });
+});
+
+afterEach(async () => {
+  if (setup) await act(async () => { setup!.renderer.destroy(); });
+  setup = undefined;
+  getUserSpy.mockRestore();
+  subscribeSpy.mockRestore();
+  listeners.clear();
+});
+
+async function frame() {
+  await act(async () => { await Bun.sleep(1); });
+  await act(async () => { await setup!.renderOnce(); });
+}
+
+async function setSession(emailVerified: boolean | null) {
+  await act(async () => {
+    user = emailVerified === null ? null : { id: "research-test", email: "research@example.test", emailVerified, plan: "free" } as AuthUser;
+    for (const listener of listeners) listener();
+  });
+  for (let i = 0; i < 5; i++) await frame();
+}
+
+async function render(pane: typeof panes[number], state: { cloudRequired: boolean; failure?: string; analystDenied?: boolean }) {
+  const commands: string[] = [];
+  const checkAccess = () => {
+    if (state.failure) throw new Error(state.failure);
+    if (state.cloudRequired && !user?.emailVerified) throw new Error(denial);
+  };
+  const provider = createTestDataProvider({
+    getCorporateActions: async () => {
+      checkAccess();
+      return { symbol: "TEST", currency: "USD", coverage: { dividends: "available", earnings: "available", splits: "available" },
+        dividends: [{ exDate: "2026-08-01", amount: 0.25 }], splits: [],
+        earnings: [{ date: "2026-06-30", dateType: "fiscal-period-end", epsActual: 2, currency: "USD" }],
+      };
+    },
+    getAnalystResearch: async () => {
+      checkAccess();
+      if (state.analystDenied) throw new Error(denial);
+      return { symbol: "TEST", currency: "USD", recommendations: [], ratings: [{ date: "2026-08-01", firm: "Fixture Research", currentPriceTarget: 120 }],
+        earningsEstimates: [{ date: "2026-09-30", period: "current_quarter", average: 3 }], revenueEstimates: [],
+      };
+    },
+  });
+  const id = `${pane}:TEST`;
+  const config = createTestPaneConfig("/tmp/gloom-research-auth-test", { instanceId: id, paneId: pane, binding: { kind: "fixed", symbol: "TEST" } });
+  const appState = createInitialState(config);
+  appState.focusedPaneId = id;
+  appState.tickers = new Map([["TEST", createTestTicker("TEST", "Test", { exchange: "ASX" })]]);
+  const runtime = createTestPluginRuntime({ getMarketData: () => provider, openCommandBar: (query) => commands.push(query ?? "") });
+  const loadData = (symbol: string, price: number | null, exchange?: string, currency?: string) => fetchProviderDividendData(provider, symbol, price, exchange, currency);
+  const content = pane === "dividend-yield"
+    ? <DividendYieldPane focused width={80} height={23} loadData={loadData} />
+    : pane === "analyst-research"
+      ? <AnalystResearchView focused width={80} height={23} />
+      : <CorporateActionsView focused width={80} height={23} variant={pane} footerPaneId={pane} />;
+  await act(async () => {
+    setup = await testRender(<TestPaneProvider state={appState} paneId={id} pluginId="ticker-research" runtime={runtime}>
+      <PaneFooterProvider>{(footer) => <Box width={80} height={24} flexDirection="column">
+        <Box width={80} height={23}>{content}</Box>
+        <PaneFooterBar footer={footer} focused width={80} />
+      </Box>}</PaneFooterProvider>
+    </TestPaneProvider>, { width: 80, height: 24 });
+  });
+  for (let i = 0; i < 5; i++) await frame();
+  return commands;
+}
+
+test.each(panes)("%s recovers from sign-in and verification while preserving provider failures", async (pane) => {
+  const state = { cloudRequired: true, failure: undefined as string | undefined };
+  const commands = await render(pane, state);
+  const controls = createTestControls(() => setup!);
+  expect(setup!.captureCharFrame()).toContain("Sign in to");
+  expect(setup!.captureCharFrame()).not.toContain(denial);
+  await controls.clickFrameText("Log in");
+  expect(commands.at(-1)).toBe("Log In");
+  await setSession(false);
+  expect(setup!.captureCharFrame()).toContain("Verify your email to");
+  await controls.clickFrameText("Resend Verification Email");
+  expect(commands.at(-1)).toBe("Resend Verification Email");
+  state.failure = "Research provider timed out";
+  await setSession(true);
+  expect(setup!.captureCharFrame()).toContain(state.failure);
+  expect(setup!.captureCharFrame()).not.toContain("Sign in to");
+  state.failure = undefined;
+  await emitKeypress(setup!, { name: "r" });
+  for (let i = 0; i < 5; i++) await frame();
+  expect(setup!.captureCharFrame()).toContain(pane === "dividend-yield" ? "TTM Cash/Share" : pane === "analyst-research" ? "Fixture Research" : "Earnings");
+  expect(setup!.captureCharFrame()).not.toContain("Research provider timed out");
+  // A usable non-Cloud source remains available without any signed-in account.
+  state.cloudRequired = false;
+  await setSession(null);
+  expect(setup!.captureCharFrame()).not.toContain("Sign in to");
+  expect(setup!.captureCharFrame()).toContain(pane === "dividend-yield" ? "TTM Cash/Share" : pane === "analyst-research" ? "Fixture Research" : "Earnings");
+});
+
+test("partial event data keeps usable rows and reports an auth-denied source once", async () => {
+  await render("corporate-actions", { cloudRequired: false, analystDenied: true });
+  const output = setup!.captureCharFrame();
+  expect(output).toContain("Dividend");
+  expect(output).toContain("Earnings");
+  expect(output.match(/Gloom Cloud requires signup/g)).toHaveLength(1);
+  expect(output).not.toContain("Sign in to");
+});
+
+test("Cloud account detection does not turn unrelated provider failures into sign-in prompts", () => {
+  expect(isCloudSessionRequired(denial)).toBe(true);
+  for (const error of [null, "Unauthorized: Yahoo", "Verification service unavailable", "Cloud request failed", "Gloom Cloud Pro required"]) {
+    expect(isCloudSessionRequired(error)).toBe(false);
+  }
+});

--- a/src/plugins/builtin/shared/research-cloud-session.ts
+++ b/src/plugins/builtin/shared/research-cloud-session.ts
@@ -1,0 +1,16 @@
+import { apiClient } from "../../../api-client";
+import { usePlanAccess } from "./plan-access";
+
+/** Match the Cloud provider's explicit account gate, not another provider's auth failure. */
+export function isCloudSessionRequired(error: string | null | undefined): boolean {
+  return error === "Gloom Cloud requires signup and email verification";
+}
+
+/** A session change must retry an already-open research pane's denied request. */
+export function useResearchCloudSession() {
+  const access = usePlanAccess();
+  return {
+    requestKey: JSON.stringify([apiClient.getCurrentUser()?.id ?? null, access.emailVerified]),
+    needsVerification: access.signedIn && !access.emailVerified,
+  };
+}

--- a/src/time-series/live-quotes.test.ts
+++ b/src/time-series/live-quotes.test.ts
@@ -151,7 +151,7 @@ describe("live chart quotes", () => {
     expect(snapshots).toHaveLength(2);
   });
 
-  test("does not refresh resolved charts for receivedAt-only quote updates", async () => {
+  test("ignores receipt-only updates but refreshes changed price or security type", async () => {
     const spec = specWithSeries([securitySeries("price", "AAPL", "market.close")]);
     let handler: Parameters<NonNullable<ReturnType<typeof createTestDataProvider>["subscribeQuotes"]>>[1]
       | undefined;
@@ -182,6 +182,8 @@ describe("live chart quotes", () => {
 
     handler!(target!, { ...quote("AAPL", 101, 100), receivedAt: 102 });
     await waitFor(() => refreshCalls === 2);
+    handler!(target!, { ...quote("AAPL", 101, 100), receivedAt: 103, instrumentType: "Common Stock" });
+    await waitFor(() => refreshCalls === 3);
     dispose();
   });
 

--- a/src/time-series/live-quotes.ts
+++ b/src/time-series/live-quotes.ts
@@ -106,6 +106,7 @@ function hasResolutionRelevantChange(next: Quote, current: Quote | undefined): b
   return next.lastUpdated !== current.lastUpdated
     || next.price !== current.price
     || next.currency !== current.currency
+    || next.instrumentType !== current.instrumentType
     || next.providerId !== current.providerId
     || next.marketState !== current.marketState
     || next.preMarketPrice !== current.preMarketPrice

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -145,8 +145,34 @@ describe("resolveChartSpecData", () => {
     expect(seeded?.bufferedSeries?.find((entry) => entry.panelId === "volume")?.points).toHaveLength(1);
   });
 
+  test("a currency-only live quote still loads security type without replacing its price", async () => {
+    let quoteCalls = 0;
+    let financialCalls = 0;
+    const source = { kind: "security" as const, instrument: { symbol: "NVDA", exchange: "XNAS" }, fieldId: "market.close" };
+    const history = [{ date: new Date("2026-01-15T14:30:00Z"), close: 77.53, volume: 1234 }];
+    const provider = createTestDataProvider({
+      getQuote: async () => { quoteCalls++; return { symbol: "NVDA", currency: "USD", instrumentType: "Common Stock", price: 999, change: 0, changePercent: 0, lastUpdated: Date.parse("2026-01-16T16:00:00Z") }; },
+      getTickerFinancials: async () => { financialCalls++; return emptyFinancials(); },
+      getPriceHistory: async () => history,
+      getPriceHistoryForResolution: async () => history,
+    });
+    const spec = chartSpec({ viewport: { range: "1M", resolution: "1d" }, series: [chartSeries({ source })],
+      studies: [{ id: "volume", kind: "volume", inputSeriesIds: ["price"], parameters: {}, panelId: "main", axis: "left" }] });
+    const sources = { dataProvider: provider, loadFredSeries: async () => fredLoad(), now: new Date("2026-01-16T16:00:00Z"),
+      quoteOverrides: new Map([[chartQuoteOverrideKeyForSource(source), { symbol: "NVDA", currency: "USD", price: 78, change: 0, changePercent: 0, lastUpdated: Date.parse("2026-01-16T16:00:00Z") }]]) };
+    const cache = new ChartResolveCache();
+    const result = await resolveChartSpecData(spec, sources, cache);
+    expect(result.series[0]).toMatchObject({ unit: "USD/share", volumeUnit: "shares" });
+    expect(result.series.find((series) => series.id === "volume")?.unit).toBe("shares");
+    expect(result.series[0]?.points.map((point) => point.value)).toEqual([77.53, 78]);
+    expect(result.warnings.some((warning) => warning.includes("Volume unit unknown"))).toBe(false);
+    await resolveChartSpecData(spec, sources, cache);
+    expect(quoteCalls).toBe(1);
+    expect(financialCalls).toBe(0);
+  });
+
   test("direct volume fields and volume studies retain established units without labeling crypto volume as shares", async () => {
-    for (const [instrumentType, expectedUnit] of [["EQUITY", "shares"], ["FUTURE", "contracts"], ["CRYPTOCURRENCY", ""], [undefined, ""]] as const) {
+    for (const [instrumentType, expectedUnit] of [["EQUITY", "shares"], ["Common Stock", "shares"], ["FUTURE", "contracts"], ["CRYPTOCURRENCY", ""], [undefined, ""]] as const) {
       const history = [{ date: new Date("2026-01-15"), close: 1, volume: 1234 }];
       const financials = { ...emptyFinancials(), quote: { symbol: "TEST", currency: "USD", price: 1, change: 0, changePercent: 0, lastUpdated: Date.parse("2026-01-15"), instrumentType }, priceHistory: history };
       const provider = createTestDataProvider({

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -1241,7 +1241,7 @@ export async function resolveChartSpecData(
       // Qualified price charts avoid loading company statements. They still
       // need listing metadata when no streamed quote has supplied it. Retain
       // only currency/type: a metadata fetch must not append an old price.
-      const quoteMetadataPromise = !needsFinancials && !quoteOverride?.currency
+      const quoteMetadataPromise = !needsFinancials && (!quoteOverride?.currency || !quoteOverride?.instrumentType)
         ? loadQuoteMetadata(source) : Promise.resolve(null);
       let resolvedSource = source;
       let financials: TickerFinancials | null;


### PR DESCRIPTION
Research panes now use the existing sign-in and verification actions when Cloud access is required, and automatically retry after the account changes. DVD, ANR, EVT, and EE preserve successful provider data and ordinary failures while removing duplicate authentication errors from the body/footer.

Price charts recognize the provider's `Common Stock` classification as shares, fetch missing security metadata even when a live quote already supplies currency, and refresh when the type arrives. Metadata completion preserves the streamed price; unclassified crypto volume remains unknown.

Validation: 3,154 local tests / 12,815 assertions and all six TypeScript projects pass. Focused rendered checks cover sign-in, verification, provider failure, retry, partial data, and volume units. Independent integrated review passed. Fresh tmux interaction verification was blocked by socket access denial; no terminal session started. Fresh browser validation is unavailable in this session because automatic approval review rejected creating a browser tab. GitHub Verify passed both build/test and typecheck jobs. No release or version change.
