### PR TITLE
Lock a pane so the close shortcut leaves it open

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -664,6 +664,8 @@ Available field types:
 - `multi-select`
 - `ordered-multi-select`
 
+Every pane also gets a built-in **Lock Pane** toggle, so a pane with no `settings` of its own still opens a settings dialog. A locked pane stays in the layout when the close shortcut (`CmdOrCtrl+W`, `CmdOrCtrl+Alt+W`, or double `Esc`) is pressed; explicit closes still work. It is stored on the pane instance under the reserved `pane.locked` key, never in pane settings, so `applyValue` never sees it and a published layout never carries it. Do not register a field with a `pane.`-prefixed key.
+
 Imperative pane settings access is available on the plugin context:
 
 ```typescript

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -664,7 +664,7 @@ Available field types:
 - `multi-select`
 - `ordered-multi-select`
 
-Every pane also gets a built-in **Lock Pane** toggle, so a pane with no `settings` of its own still opens a settings dialog. A locked pane stays in the layout when the close shortcut (`CmdOrCtrl+W`, `CmdOrCtrl+Alt+W`, or double `Esc`) is pressed; explicit closes still work. It is stored on the pane instance under the reserved `pane.locked` key, never in pane settings, so `applyValue` never sees it and a published layout never carries it. Do not register a field with a `pane.`-prefixed key.
+Every pane also gets a built-in **Lock Pane** toggle, so a pane with no `settings` of its own still opens a settings dialog. A locked pane stays in the layout when the close shortcut (`CmdOrCtrl+W`, `CmdOrCtrl+Alt+W`, or double `Esc`) is pressed; explicit closes still work. It is also offered in the pane action menu next to Close Pane. It is stored on the pane instance under the reserved `pane.locked` key, never in pane settings, so `applyValue` never sees it and a published layout never carries it. Do not register a field with a `pane.`-prefixed key.
 
 Imperative pane settings access is available on the plugin context:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,7 +20,7 @@ The desktop app and TUI share the command language and plugin system. The [brows
 | `Ctrl+P` | Open command mode |
 | `` ` `` | Open ticker search |
 | `Ctrl+,` | Open focused pane settings |
-| `Ctrl+W` | Close focused pane |
+| `Ctrl+W` | Close focused pane (unless it is locked) |
 | `Ctrl+Shift+M` | Move focused window (`WIN resize` starts resize mode) |
 | `Ctrl+Shift+D` | Dock or float focused pane |
 | `Ctrl+Shift+E` | Export focused pane table as CSV |

--- a/src/components/command-bar/workflow/ops.test.ts
+++ b/src/components/command-bar/workflow/ops.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { cloneLayout, createDefaultConfig, findPaneInstance, type LayoutConfig } from "../../../types/config";
 import { createInitialState } from "../../../state/app/context";
+import { PANE_LOCK_SETTING_KEY } from "../../../pane-settings";
 import { createTestDataProvider } from "../../../test-support/data-provider";
 import { applyPaneSettingFieldValue, createPaneTemplateOrThrow, resolveTickerInput, resolveTickerInputOrThrow } from "./ops";
 import type { TickerRecord } from "../../../types/ticker";
@@ -407,6 +408,65 @@ describe("applyPaneSettingFieldValue", () => {
     expect(findPaneInstance(persisted[0]!, pane.instanceId)?.settings).toEqual({
       canonical: { mode: "area" },
     });
+  });
+
+  test("stores the pane lock on the instance instead of routing it through pane settings", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-workflow-ops-test");
+    const layout = cloneLayout(config.layout);
+    const pane = findPaneInstance(layout, "portfolio-list:main");
+    if (!pane) throw new Error("missing test pane");
+    pane.settings = { canonical: { mode: "line" } };
+    const state = createInitialState({ ...config, layout });
+    const persisted: LayoutConfig[] = [];
+    const applied: unknown[] = [];
+
+    await applyPaneSettingFieldValue(pane.instanceId, {
+      key: PANE_LOCK_SETTING_KEY,
+      label: "Lock Pane",
+      type: "toggle",
+    }, true, {
+      dataProvider: makeDataProvider() as any,
+      tickerRepository: makeTickerRepository() as any,
+      dispatch: () => {},
+      getState: () => state,
+      persistLayout: (nextLayout) => { persisted.push(nextLayout); },
+      pluginRegistry: {
+        resolvePaneSettings: () => ({
+          paneId: pane.instanceId,
+          pane,
+          paneDef: {
+            id: pane.paneId,
+            name: "Portfolio List",
+            component: () => null,
+            defaultPosition: "left",
+          },
+          rawSettings: pane.settings,
+          settingsDef: {
+            fields: [],
+            applyValue: (settings: Record<string, unknown>, field: unknown, value: unknown) => {
+              applied.push([settings, field, value]);
+              return { canonical: { mode: value } };
+            },
+          },
+          context: {
+            config: state.config,
+            layout: state.config.layout,
+            paneId: pane.instanceId,
+            paneType: pane.paneId,
+            pane,
+            settings: { ...pane.settings },
+            paneState: {},
+            activeTicker: null,
+            activeCollectionId: null,
+          },
+        }),
+      } as any,
+    });
+
+    expect(applied).toHaveLength(0);
+    const updated = findPaneInstance(persisted[0]!, pane.instanceId);
+    expect(updated?.locked).toBe(true);
+    expect(updated?.settings).toEqual({ canonical: { mode: "line" } });
   });
 
   test("atomically clears dependent plugin settings when a selector changes", async () => {

--- a/src/components/command-bar/workflow/ops.ts
+++ b/src/components/command-bar/workflow/ops.ts
@@ -3,7 +3,7 @@ import type { PaneSettingField, PaneTemplateContext, PaneTemplateCreateOptions, 
 import { getFocusedCollectionId, getFocusedTickerSymbol } from "../../../state/app/context";
 import type { PluginRegistry } from "../../../plugins/registry";
 import { formatTickerListInput } from "../../../tickers/list";
-import { updatePaneInstance, setPaneSettings } from "../../../pane-settings";
+import { PANE_LOCK_SETTING_KEY, setPaneLocked, updatePaneInstance, setPaneSettings } from "../../../pane-settings";
 import { TICKER_RESEARCH_PANE_ID } from "../../../types/config";
 import { cleanPortfolioPaneSettings, resolvePortfolioPaneCollectionId } from "../../../plugins/builtin/portfolio-list/settings";
 import {
@@ -264,6 +264,17 @@ export async function applyPaneSettingFieldValue(
 
   const state = deps.getState();
   const shouldPushHistory = options?.pushHistory !== false;
+
+  // The lock lives on the pane instance, not in pane settings, so it never
+  // reaches a plugin's `applyValue`.
+  if (field.key === PANE_LOCK_SETTING_KEY) {
+    deps.persistLayout(
+      setPaneLocked(state.config.layout, targetId, value === true),
+      { pushHistory: shouldPushHistory },
+    );
+    return;
+  }
+
   const clearOnChange = !Object.is(descriptor.context.settings[field.key], value)
     ? Object.fromEntries((field.clearOnChange ?? []).map((key) => [key, ""]))
     : {};

--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -5,6 +5,7 @@ import { useShortcut, useViewport } from "../../react/input";
 import { resolveTickerForPane, useAppDispatch, useAppSelector } from "../../state/app/context";
 import type { DesktopWindowBridge } from "../../types/desktop-window";
 import { findPaneInstance } from "../../types/config";
+import { isPaneLocked } from "../../pane-settings";
 import type { PluginRegistry } from "../../plugins/registry";
 import { floatingPaneBg, floatingPaneTitleBg, paneTitleText } from "../../theme/colors";
 import { useThemeColors } from "../../theme/theme-context";
@@ -66,6 +67,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
     ? getTitlebarLeadingInset({ windowFullscreen })
     : 0;
   const instance = useAppSelector((state) => findPaneInstance(state.config.layout, desktopWindowBridge.paneId) ?? null);
+  const locked = isPaneLocked(instance);
   const paneDef = instance ? pluginRegistry.panes.get(instance.paneId) ?? null : null;
   const hasPaneSettings = !!instance && pluginRegistry.hasPaneSettings(instance.instanceId);
   const titleState = useMemo(
@@ -121,7 +123,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
       if (recordDoubleEscapeClose(doubleEscapeState, desktopWindowBridge.paneId, Date.now())) {
         event.preventDefault();
         event.stopPropagation();
-        void desktopWindowBridge.closeDetachedPane?.(desktopWindowBridge.paneId);
+        if (!locked) void desktopWindowBridge.closeDetachedPane?.(desktopWindowBridge.paneId);
       }
       return;
     }
@@ -132,8 +134,14 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
   useShortcut((event) => {
     if (event.name !== "w" || (!event.ctrl && !event.meta && !event.super)) return;
     if (inputCaptured && event.ctrl && !event.meta && !event.super) return;
+    // Swallowed either way, so a locked pane never falls through to the
+    // window's own close accelerator.
     event.preventDefault();
     event.stopPropagation();
+    if (locked) {
+      pluginRegistry.notify({ body: "Pane is locked. Unlock it in pane settings.", type: "info" });
+      return;
+    }
     void desktopWindowBridge.closeDetachedPane?.(desktopWindowBridge.paneId);
   });
 
@@ -297,6 +305,26 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
                   </Box>
                 ))}
                 <Box flexGrow={1} minWidth={0} />
+                {locked && (
+                  <Box
+                    height={1}
+                    minWidth={20}
+                    paddingLeft={1}
+                    paddingRight={1}
+                    alignItems="center"
+                    justifyContent="center"
+                    data-gloom-role="pane-lock"
+                    aria-label="Locked: the close shortcut leaves this pane open"
+                    title="Locked: the close shortcut leaves this pane open"
+                  >
+                    <Span style={{ display: "inline-flex", width: 12, height: 12, color: colors.textDim }}>
+                      <svg viewBox="0 0 12 12" width="12" height="12" fill="none" aria-hidden="true">
+                        <rect x="2.5" y="5.5" width="7" height="5" rx="1.2" fill="currentColor" />
+                        <path d="M4.25 5.5V4a1.75 1.75 0 0 1 3.5 0v1.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                      </svg>
+                    </Span>
+                  </Box>
+                )}
                 {(hasPaneSettings || sharePayload) && (
                   <Text
                     fg={paneTitleText(focused, true, colors)}

--- a/src/components/layout/detached-pane-shell.tsx
+++ b/src/components/layout/detached-pane-shell.tsx
@@ -5,7 +5,7 @@ import { useShortcut, useViewport } from "../../react/input";
 import { resolveTickerForPane, useAppDispatch, useAppSelector } from "../../state/app/context";
 import type { DesktopWindowBridge } from "../../types/desktop-window";
 import { findPaneInstance } from "../../types/config";
-import { isPaneLocked } from "../../pane-settings";
+import { isPaneLocked, PANE_LOCK_SETTING_KEY } from "../../pane-settings";
 import type { PluginRegistry } from "../../plugins/registry";
 import { floatingPaneBg, floatingPaneTitleBg, paneTitleText } from "../../theme/colors";
 import { useThemeColors } from "../../theme/theme-context";
@@ -172,6 +172,19 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
     void sharePane();
   });
 
+  const togglePaneLock = useCallback(() => {
+    void pluginRegistry.applyPaneSettingValueFn(
+      desktopWindowBridge.paneId,
+      { key: PANE_LOCK_SETTING_KEY, label: "Lock Pane", type: "toggle" },
+      !locked,
+    ).catch((error) => {
+      pluginRegistry.notify({
+        body: error instanceof Error ? error.message : "Could not update pane setting.",
+        type: "error",
+      });
+    });
+  }, [desktopWindowBridge.paneId, locked, pluginRegistry]);
+
   const openActions = useCallback((event?: { stopPropagation?: () => void; preventDefault?: () => void }) => {
     stopMouse(event);
     focusPane();
@@ -189,6 +202,12 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
       accelerator: PANE_MANAGEMENT_ACCELERATORS.share,
       onSelect: sharePane,
     });
+    items.push({
+      id: "toggle-pane-lock",
+      // The label carries the state: the terminal menu has no checkmark column.
+      label: locked ? "Unlock Pane" : "Lock Pane",
+      onSelect: togglePaneLock,
+    });
     void showContextMenu({
       kind: "pane",
       paneId: desktopWindowBridge.paneId,
@@ -199,7 +218,7 @@ export function DetachedPaneShell({ pluginRegistry, desktopWindowBridge }: Detac
       if (!shown && hasPaneSettings) pluginRegistry.openPaneSettingsFn(desktopWindowBridge.paneId);
       else if (!shown && sharePayload) void sharePane();
     });
-  }, [desktopWindowBridge.paneId, focusPane, hasPaneSettings, instance?.paneId, pluginRegistry, sharePane, sharePayload, showContextMenu, title]);
+  }, [desktopWindowBridge.paneId, focusPane, hasPaneSettings, instance?.paneId, locked, pluginRegistry, sharePane, sharePayload, showContextMenu, title, togglePaneLock]);
   const toggleQuickSetting = useCallback((key: string, event?: { stopPropagation?: () => void; preventDefault?: () => void }) => {
     stopMouse(event);
     focusPane();

--- a/src/components/layout/floating-pane.tsx
+++ b/src/components/layout/floating-pane.tsx
@@ -16,6 +16,7 @@ interface FloatingPaneWrapperProps {
   zIndex: number;
   focused: boolean;
   windowModeSelected?: boolean;
+  locked?: boolean;
   showActions?: boolean;
   quickSettings?: PaneHeaderQuickSetting[];
   onMouseDown?: (event: any) => void;
@@ -63,6 +64,7 @@ export function FloatingPaneWrapper({
   zIndex,
   focused,
   windowModeSelected = false,
+  locked = false,
   showActions = false,
   quickSettings,
   onMouseDown,
@@ -116,6 +118,7 @@ export function FloatingPaneWrapper({
         focused={focused}
         windowModeSelected={windowModeSelected}
         floating
+        locked={locked}
         showActions={showActions}
         quickSettings={quickSettings}
         onHeaderMouseMove={onHeaderMouseMove}

--- a/src/components/layout/pane/header.tsx
+++ b/src/components/layout/pane/header.tsx
@@ -8,6 +8,7 @@ const PANE_HEADER_HEIGHT = 1;
 const PANE_HEADER_GRIP = ":: ";
 export const PANE_HEADER_ACTION = " ... ";
 export const PANE_HEADER_CLOSE = " x ";
+export const PANE_HEADER_LOCK = " 🔒 ";
 
 interface PaneHeaderProps {
   title: string;
@@ -15,6 +16,7 @@ interface PaneHeaderProps {
   focused: boolean;
   windowModeSelected?: boolean;
   floating?: boolean;
+  locked?: boolean;
   showActions?: boolean;
   quickSettings?: PaneHeaderQuickSetting[];
   onHeaderMouseMove?: (event: any) => void;
@@ -117,6 +119,7 @@ export function PaneHeader({
   focused,
   windowModeSelected = false,
   floating = false,
+  locked = false,
   showActions = false,
   quickSettings = [],
   onHeaderMouseMove,
@@ -134,7 +137,9 @@ export function PaneHeader({
   const backgroundColor = floating ? floatingPaneTitleBg(visuallyFocused) : paneTitleBg(visuallyFocused);
   const actionText = showActions ? PANE_HEADER_ACTION : "     ";
   const closeText = floating ? PANE_HEADER_CLOSE : "";
-  const terminalQuickSettingsWidth = quickSettings.reduce((total) => total + displayWidth(" ⚡ "), 0);
+  const lockText = locked ? PANE_HEADER_LOCK : "";
+  const terminalQuickSettingsWidth = quickSettings.reduce((total) => total + displayWidth(" ⚡ "), 0)
+    + displayWidth(lockText);
   const textColor = paneTitleText(visuallyFocused, floating);
   const handleTerminalHeaderMouseDown = useCallback((event: any) => {
     capturePointerDrag(nativeRenderer, terminalHeaderRef.current);
@@ -202,6 +207,25 @@ export function PaneHeader({
           </Box>
         ))}
         <Box flexGrow={1} minWidth={0} />
+        {locked && (
+          <Box data-gloom-role="pane-lock">
+            <DesktopPaneButton
+              color={colors.textMuted}
+              label="Locked: the close shortcut leaves this pane open"
+              icon={(
+                <svg viewBox="0 0 12 12" width="12" height="12" fill="none" aria-hidden="true">
+                  <rect x="2.5" y="5.5" width="7" height="5" rx="1.2" fill="currentColor" />
+                  <path
+                    d="M4.25 5.5V4a1.75 1.75 0 0 1 3.5 0v1.5"
+                    stroke="currentColor"
+                    strokeWidth="1.2"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              )}
+            />
+          </Box>
+        )}
         <Box data-gloom-role="pane-action">
           {showActions ? (
             <DesktopPaneButton
@@ -272,6 +296,9 @@ export function PaneHeader({
           />
         ))}
         <Text fg={borderColor} selectable={false}>{fill}</Text>
+        {locked && (
+          <TerminalPaneButton text={lockText} fg={colors.textMuted} role="pane-lock" />
+        )}
         <TerminalPaneButton
           text={actionText}
           fg={textColor}
@@ -319,6 +346,9 @@ export function PaneHeader({
           onMouseDown={setting.onMouseDown}
         />
       ))}
+      {locked && (
+        <TerminalPaneButton text={lockText} fg={colors.textMuted} role="pane-lock" />
+      )}
       <TerminalPaneButton
         text={actionText}
         fg={textColor}

--- a/src/components/layout/pane/index.tsx
+++ b/src/components/layout/pane/index.tsx
@@ -14,6 +14,7 @@ interface PaneWrapperProps {
   width?: number;
   height?: number | `${number}%` | "auto";
   flexGrow?: number;
+  locked?: boolean;
   showActions?: boolean;
   quickSettings?: PaneHeaderQuickSetting[];
   onMouseDown?: (event: any) => void;
@@ -36,6 +37,7 @@ export function PaneWrapper({
   width = 0,
   height,
   flexGrow,
+  locked = false,
   showActions = false,
   quickSettings,
   onMouseDown,
@@ -88,6 +90,7 @@ export function PaneWrapper({
           width={width}
           focused={focused}
           windowModeSelected={windowModeSelected}
+          locked={locked}
           showActions={showActions}
           quickSettings={quickSettings}
           onHeaderMouseMove={onHeaderMouseMove}

--- a/src/components/layout/shell/index.test.tsx
+++ b/src/components/layout/shell/index.test.tsx
@@ -61,6 +61,7 @@ function createShellPluginRegistry(options?: {
     getPluginPaneIds: () => [],
     getPluginPaneTemplateIds: () => [],
     hasPaneSettings: (paneId: string) => paneId === "portfolio-list:main",
+    notify: () => {},
     openPaneSettingsFn: () => {},
     openCommandBar: () => {},
     showPane: () => {},
@@ -1290,6 +1291,87 @@ describe("Shell", () => {
     expect(updateLayout?.layout.instances.map((instance: { instanceId: string }) => instance.instanceId)).toEqual(["portfolio-list:main"]);
     expect(updateLayout?.layout.floating).toEqual([]);
     expect(updateLayout?.layout.dockRoot).toEqual({ kind: "pane", instanceId: "portfolio-list:main" });
+  });
+
+  test("keeps a locked pane when Ctrl+W is pressed", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-test");
+    const mainPane = config.layout.instances.find((instance) => instance.instanceId === "portfolio-list:main");
+    if (!mainPane) throw new Error("missing default portfolio pane");
+
+    const lockedLayout = {
+      dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+      instances: [{ ...mainPane, locked: true }],
+      floating: [],
+      detached: [],
+    };
+    const state = createShellStateWithLayout(
+      { ...config, layout: cloneLayout(lockedLayout) },
+      cloneLayout(lockedLayout),
+      "portfolio-list:main",
+    );
+    const actions: Array<any> = [];
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: (action) => actions.push(action) }}>
+        <TestDialogProvider>
+          <Shell pluginRegistry={createShellPluginRegistry()} />
+        </TestDialogProvider>
+      </AppContext>,
+      { width: 40, height: 10 },
+    );
+
+    await testSetup.renderOnce();
+    await emitKeypress({ name: "w", ctrl: true });
+    expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
+
+    await emitKeypress({ name: "escape", sequence: "\u001b" });
+    await emitKeypress({ name: "escape", sequence: "\u001b" });
+    expect(actions.some((action) => action.type === "UPDATE_LAYOUT")).toBe(false);
+  });
+
+  test("closes only the unlocked floating panes with Ctrl+Alt+W", async () => {
+    const config = createDefaultConfig("/tmp/gloomberb-shell-test");
+    const mainPane = config.layout.instances.find((instance) => instance.instanceId === "portfolio-list:main");
+    const detailPane = config.layout.instances.find((instance) => instance.instanceId === "ticker-detail:main");
+    if (!mainPane || !detailPane) throw new Error("missing default panes");
+
+    const mixedLayout = {
+      dockRoot: { kind: "pane" as const, instanceId: "portfolio-list:main" },
+      instances: [
+        { ...mainPane },
+        { ...detailPane, locked: true },
+        { ...detailPane, instanceId: "ticker-detail:secondary" },
+      ],
+      floating: [
+        { instanceId: "ticker-detail:main", x: 4, y: 2, width: 30, height: 8 },
+        { instanceId: "ticker-detail:secondary", x: 8, y: 3, width: 30, height: 8 },
+      ],
+      detached: [],
+    };
+    const state = createShellStateWithLayout(
+      { ...config, layout: cloneLayout(mixedLayout) },
+      cloneLayout(mixedLayout),
+      "portfolio-list:main",
+    );
+    const actions: Array<any> = [];
+
+    testSetup = await testRender(
+      <AppContext value={{ state, dispatch: (action) => actions.push(action) }}>
+        <TestDialogProvider>
+          <Shell pluginRegistry={createShellPluginRegistry()} />
+        </TestDialogProvider>
+      </AppContext>,
+      { width: 40, height: 12 },
+    );
+
+    await testSetup.renderOnce();
+    await emitKeypress({ name: "w", ctrl: true, alt: true });
+
+    const updateLayout = actions.find((action) => action.type === "UPDATE_LAYOUT");
+    expect(updateLayout?.layout.instances.map((instance: { instanceId: string }) => instance.instanceId))
+      .toEqual(["portfolio-list:main", "ticker-detail:main"]);
+    expect(updateLayout?.layout.floating.map((entry: { instanceId: string }) => entry.instanceId))
+      .toEqual(["ticker-detail:main"]);
   });
 
 });

--- a/src/components/layout/shell/menu.test.ts
+++ b/src/components/layout/shell/menu.test.ts
@@ -37,6 +37,40 @@ describe("pane action menu", () => {
     expect(shared).toBe(true);
     expect(share?.accelerator).toBe("CmdOrCtrl+Shift+S");
   });
+
+  test("toggles the pane lock and names the item for the next state", async () => {
+    const layout = {
+      dockRoot: { kind: "pane", instanceId: "chart-1" },
+      instances: [{ instanceId: "chart-1", paneId: "chart-composer" }],
+      floating: [],
+      detached: [],
+    } as any;
+    const persisted: any[] = [];
+    const buildMenu = (locked: boolean) => menuForPane(
+      {
+        instance: { ...layout.instances[0], locked: locked || undefined },
+        def: { defaultPosition: "right" },
+        floating: false,
+      } as any,
+      { ...layout, instances: [{ ...layout.instances[0], locked: locked || undefined }] },
+      120,
+      40,
+      { hasPaneSettings: () => false, openWindowMode: () => {} } as any,
+      (nextLayout: any) => { persisted.push(nextLayout); },
+      () => {},
+      () => {},
+    );
+
+    const lock = buildMenu(false).find((item) => item.type !== "divider" && item.id === "toggle-pane-lock");
+    expect(lock?.label).toBe("Lock Pane");
+    await lock?.onSelect?.();
+    expect(persisted.at(-1)?.instances[0]?.locked).toBe(true);
+
+    const unlock = buildMenu(true).find((item) => item.type !== "divider" && item.id === "toggle-pane-lock");
+    expect(unlock?.label).toBe("Unlock Pane");
+    await unlock?.onSelect?.();
+    expect(persisted.at(-1)?.instances[0]?.locked).toBeUndefined();
+  });
 });
 
 describe("action menu sizing", () => {

--- a/src/components/layout/shell/menu.ts
+++ b/src/components/layout/shell/menu.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../plugins/pane-manager";
 import type { PluginRegistry } from "../../../plugins/registry";
 import type { LayoutConfig } from "../../../types/config";
+import { isPaneLocked, setPaneLocked } from "../../../pane-settings";
 import { contextMenuDivider, type ContextMenuItem } from "../../../types/context-menu";
 import {
   formatPlatformShortcutLabel,
@@ -102,6 +103,14 @@ export function menuForPane(
       },
     });
   }
+
+  const locked = isPaneLocked(pane.instance);
+  baseActions.push({
+    id: "toggle-pane-lock",
+    // The label carries the state: the terminal menu has no checkmark column.
+    label: locked ? "Unlock Pane" : "Lock Pane",
+    onSelect: () => persistLayout(setPaneLocked(layout, pane.instance.instanceId, !locked)),
+  });
 
   baseActions.push({
     id: "close-pane",

--- a/src/components/layout/shell/pane/actions.ts
+++ b/src/components/layout/shell/pane/actions.ts
@@ -11,12 +11,17 @@ import {
 } from "../../../../plugins/pane-manager";
 import type { PluginRegistry } from "../../../../plugins/registry";
 import type { LayoutConfig } from "../../../../types/config";
+import { isPaneLockedInLayout } from "../../../../pane-settings";
 import type { RendererHost } from "../../../../ui";
 import { capturePaneScreenshotPngBase64 } from "../../../../utils/dom-screenshot";
 import {
   exportPaneTableCsv,
   hasPaneTableExporter,
 } from "../../../../state/pane-table-export-registry";
+
+function notifyPaneLocked(pluginRegistry: PluginRegistry): void {
+  pluginRegistry.notify({ body: "Pane is locked. Unlock it in pane settings.", type: "info" });
+}
 
 function removedFocusRestoreOptions(
   layout: LayoutConfig,
@@ -103,17 +108,29 @@ export function useShellPaneActions({
 
   const closeFocusedPane = useCallback(() => {
     if (!focusedPaneId || !isPaneInLayout(visibleLayout, focusedPaneId)) return false;
+    if (isPaneLockedInLayout(visibleLayout, focusedPaneId)) {
+      notifyPaneLocked(pluginRegistry);
+      // Handled, so the keypress never reaches the host's own close shortcut.
+      return true;
+    }
     const nextLayout = removePane(visibleLayout, focusedPaneId);
     persistLayout(nextLayout, removedFocusRestoreOptions(nextLayout, focusedPaneId, previousFocusedPaneId));
     return true;
-  }, [focusedPaneId, persistLayout, previousFocusedPaneId, visibleLayout]);
+  }, [focusedPaneId, persistLayout, pluginRegistry, previousFocusedPaneId, visibleLayout]);
 
   const closeAllFloatingPanes = useCallback(() => {
     if (visibleLayout.floating.length === 0) return false;
-    const nextLayout = removeFloatingPanes(visibleLayout);
+    const lockedIds = new Set(visibleLayout.floating
+      .map((entry) => entry.instanceId)
+      .filter((instanceId) => isPaneLockedInLayout(visibleLayout, instanceId)));
+    if (lockedIds.size === visibleLayout.floating.length) {
+      notifyPaneLocked(pluginRegistry);
+      return true;
+    }
+    const nextLayout = removeFloatingPanes(visibleLayout, { keepInstanceIds: lockedIds });
     persistLayout(nextLayout, removedFocusRestoreOptions(nextLayout, focusedPaneId, previousFocusedPaneId));
     return true;
-  }, [focusedPaneId, persistLayout, previousFocusedPaneId, visibleLayout]);
+  }, [focusedPaneId, persistLayout, pluginRegistry, previousFocusedPaneId, visibleLayout]);
 
   const copyFocusedPaneScreenshot = useCallback(() => {
     if (!focusedPaneId || !nativePaneChrome || !rendererHost.copyPngImage) return false;

--- a/src/components/layout/shell/pane/layers.tsx
+++ b/src/components/layout/shell/pane/layers.tsx
@@ -131,6 +131,7 @@ export function ShellPaneLayers({
                     focused={focused}
                     width={rect.width}
                     height={rect.height}
+                    locked={pane.instance.locked === true}
                     showActions={showActions}
                     quickSettings={getPaneQuickSettings(leaf.instanceId)}
                     windowModeSelected={windowModeSelected}
@@ -193,6 +194,7 @@ export function ShellPaneLayers({
                   zIndex={pane.floating?.zIndex ?? 50}
                   focused={focused}
                   windowModeSelected={windowModeSelected}
+                  locked={pane.instance.locked === true}
                   showActions={showActions}
                   quickSettings={getPaneQuickSettings(pane.instance.instanceId)}
                   footer={footer}

--- a/src/data/config/layout.ts
+++ b/src/data/config/layout.ts
@@ -155,6 +155,7 @@ function sanitizePaneInstances(
           : undefined,
         settings: migrateChartPaneSettings(originalPaneId, binding, settings, chartMigration),
         placementMemory: sanitizePlacementMemory(entry.placementMemory),
+        locked: entry.locked === true ? true : undefined,
       };
     });
   return instances;

--- a/src/data/config/store/index.test.ts
+++ b/src/data/config/store/index.test.ts
@@ -86,6 +86,24 @@ describe("sanitizeLayout", () => {
     });
   });
 
+  test("keeps the pane lock across a save/load round trip", () => {
+    const layout = sanitizeLayout({
+      dockRoot: { kind: "pane", instanceId: "portfolio-list:locked" },
+      instances: [
+        {
+          instanceId: "portfolio-list:locked",
+          paneId: "portfolio-list",
+          binding: { kind: "none" },
+          locked: true,
+        },
+      ],
+      floating: [],
+      detached: [],
+    }, DEFAULT_LAYOUT);
+
+    expect(layout.instances[0]?.locked).toBe(true);
+  });
+
   test("prunes abandoned panes while retaining a hidden follow source", () => {
     const layout = sanitizeLayout({
       dockRoot: { kind: "pane", instanceId: "ticker-research:visible" },

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -177,6 +177,8 @@ export const es: Record<string, string> = {
 
   // ── Confirm / workflow ───────────────────────────────────────
   "Close Pane": "Cerrar panel",
+  "Lock Pane": "Bloquear panel",
+  "Unlock Pane": "Desbloquear panel",
   "Close All Floating Panes": "Cerrar todos los paneles flotantes",
   "Close Floating Panes": "Cerrar paneles flotantes",
   "Portfolio Name": "Nombre de la cartera",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -178,6 +178,8 @@ export const ja: Record<string, string> = {
 
   // ── Confirm / workflow ───────────────────────────────────────
   "Close Pane": "ペインを閉じる",
+  "Lock Pane": "ペインをロック",
+  "Unlock Pane": "ペインのロックを解除",
   "Close All Floating Panes": "すべてのフローティング ペインを閉じる",
   "Close Floating Panes": "フローティング ペインを閉じる",
   "Portfolio Name": "ポートフォリオ名",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -176,6 +176,8 @@ export const ko: Record<string, string> = {
 
   // ── Confirm / workflow ───────────────────────────────────────
   "Close Pane": "패널 닫기",
+  "Lock Pane": "패널 잠금",
+  "Unlock Pane": "패널 잠금 해제",
   "Close All Floating Panes": "모든 플로팅 패널 닫기",
   "Close Floating Panes": "플로팅 패널 닫기",
   "Portfolio Name": "포트폴리오 이름",

--- a/src/i18n/zh-cn.ts
+++ b/src/i18n/zh-cn.ts
@@ -178,6 +178,8 @@ export const zhCN: Record<string, string> = {
 
   // ── Confirm / workflow ───────────────────────────────────────
   "Close Pane": "关闭面板",
+  "Lock Pane": "锁定面板",
+  "Unlock Pane": "解锁面板",
   "Close All Floating Panes": "关闭所有浮动面板",
   "Close Floating Panes": "关闭浮动面板",
   "Portfolio Name": "组合名称",

--- a/src/i18n/zh-tw.ts
+++ b/src/i18n/zh-tw.ts
@@ -178,6 +178,8 @@ export const zhTW: Record<string, string> = {
 
   // ── Confirm / workflow ───────────────────────────────────────
   "Close Pane": "關閉面板",
+  "Lock Pane": "鎖定面板",
+  "Unlock Pane": "解鎖面板",
   "Close All Floating Panes": "關閉所有浮動面板",
   "Close Floating Panes": "關閉浮動面板",
   "Portfolio Name": "投資組合名稱",

--- a/src/pane-settings.ts
+++ b/src/pane-settings.ts
@@ -71,3 +71,27 @@ export function deletePaneSetting(
   delete nextSettings[key];
   return setPaneSettings(layout, paneId, Object.keys(nextSettings).length > 0 ? nextSettings : undefined);
 }
+
+/**
+ * Reserved settings key for the pane lock. The value lives on the instance
+ * rather than in pane settings so a plugin's `applyValue` never sees it and a
+ * published layout never carries someone else's lock.
+ */
+export const PANE_LOCK_SETTING_KEY = "pane.locked";
+
+export function isPaneLocked(instance: PaneInstanceConfig | null | undefined): boolean {
+  return instance?.locked === true;
+}
+
+export function isPaneLockedInLayout(layout: LayoutConfig, paneId: string): boolean {
+  return isPaneLocked(findPaneInstance(layout, paneId));
+}
+
+export function setPaneLocked(layout: LayoutConfig, paneId: string, locked: boolean): LayoutConfig {
+  const current = findPaneInstance(layout, paneId);
+  if (!current || isPaneLocked(current) === locked) return layout;
+  return updatePaneInstance(layout, paneId, (instance) => ({
+    ...instance,
+    locked: locked ? true : undefined,
+  }));
+}

--- a/src/plugins/builtin/help/index.tsx
+++ b/src/plugins/builtin/help/index.tsx
@@ -203,11 +203,11 @@ function HelpPane({ focused, width, height }: PaneProps) {
             <Section title="Pane Management">
               <ShortcutRow
                 badges={[platformShortcut("W")]}
-                description="Close the focused pane, docked or floating."
+                description="Close the focused pane, docked or floating. Locked panes stay open."
               />
               <ShortcutRow
                 badges={[platformShortcut(["Alt", "W"])]}
-                description="Close all floating panes."
+                description="Close all floating panes except locked ones."
               />
               <ShortcutRow
                 badges={[platformShortcut(",")]}

--- a/src/plugins/pane-manager/layout-state.ts
+++ b/src/plugins/pane-manager/layout-state.ts
@@ -159,14 +159,21 @@ export function removePane(layout: LayoutConfig, instanceId: string): LayoutConf
   ));
 }
 
-export function removeFloatingPanes(layout: LayoutConfig): LayoutConfig {
-  if (layout.floating.length === 0) return layout;
+export function removeFloatingPanes(
+  layout: LayoutConfig,
+  options: { keepInstanceIds?: ReadonlySet<string> } = {},
+): LayoutConfig {
+  const keep = options.keepInstanceIds;
+  const removedIds = layout.floating
+    .map((entry) => entry.instanceId)
+    .filter((instanceId) => !keep?.has(instanceId));
+  if (removedIds.length === 0) return layout;
   return finalizeLayout(removePaneInstances(
     {
       ...layout,
-      floating: [],
+      floating: layout.floating.filter((entry) => keep?.has(entry.instanceId)),
     },
-    layout.floating.map((entry) => entry.instanceId),
+    removedIds,
   ));
 }
 

--- a/src/plugins/registry/pane-settings.ts
+++ b/src/plugins/registry/pane-settings.ts
@@ -3,7 +3,7 @@ import {
   resolveCollectionForPane,
   resolveTickerForPane,
 } from "../../core/state/app/state";
-import { getPaneSettings } from "../../pane-settings";
+import { getPaneSettings, isPaneLocked, PANE_LOCK_SETTING_KEY } from "../../pane-settings";
 import type { AppConfig, LayoutConfig, PaneInstanceConfig } from "../../types/config";
 import type {
   PaneDef,
@@ -80,7 +80,7 @@ export function resolveRegistryPaneSettings({
   if (!pane) return null;
 
   const paneDef = paneDefs.get(pane.paneId);
-  if (!paneDef || (!paneDef.settings && !paneDef.tableExport)) return null;
+  if (!paneDef) return null;
 
   const pluginId = paneOwners.get(pane.paneId);
   const paneSettings = getPaneSettings(pane);
@@ -106,13 +106,12 @@ export function resolveRegistryPaneSettings({
   const baseSettingsDef = typeof paneDef.settings === "function"
     ? paneDef.settings(context)
     : paneDef.settings;
-  if (!baseSettingsDef && !paneDef.tableExport) return null;
-  const settingsDef: PaneSettingsDef = paneDef.tableExport
-    ? {
-      ...(baseSettingsDef ?? {}),
-      fields: [
-        ...(baseSettingsDef?.fields ?? []),
-        {
+  const settingsDef: PaneSettingsDef = {
+    ...(baseSettingsDef ?? {}),
+    fields: [
+      ...(baseSettingsDef?.fields ?? []),
+      ...(paneDef.tableExport
+        ? [{
           key: "tableExport.csv",
           label: "Export CSV",
           description: "Export the current table as an Excel-compatible CSV file.",
@@ -125,15 +124,22 @@ export function resolveRegistryPaneSettings({
             pane.title ?? paneDef.name,
             actionContext.notify,
           ),
-        },
-      ],
-    }
-    : baseSettingsDef!;
+        } satisfies PaneSettingField]
+        : []),
+      {
+        key: PANE_LOCK_SETTING_KEY,
+        label: "Lock Pane",
+        description: "Keep this pane in the layout when the close shortcut is pressed.",
+        type: "toggle",
+      },
+    ],
+  };
 
   const rawSettings = { ...paneSettings };
-  const resolvedSettings = {
+  const resolvedSettings: Record<string, unknown> = {
     ...paneSettings,
     ...(settingsDef.values ?? {}),
+    [PANE_LOCK_SETTING_KEY]: isPaneLocked(pane),
   };
   if (pluginId) {
     for (const field of settingsDef.fields) {

--- a/src/remote/controller.ts
+++ b/src/remote/controller.ts
@@ -9,7 +9,7 @@ import {
 } from "../plugins/pane-manager";
 import type { PluginRegistry } from "../plugins/registry";
 import type { AppAction, AppState } from "../state/app/context";
-import { setPaneSettings } from "../pane-settings";
+import { PANE_LOCK_SETTING_KEY, setPaneSettings } from "../pane-settings";
 import type { DesktopWindowBridge } from "../types/desktop-window";
 import { applyJsonPatch } from "./json-patch";
 import { revisionFor } from "./revision";
@@ -340,8 +340,10 @@ export function createAppRemoteController({
         } else {
           const instanceId = descriptor?.paneId ?? paneId;
           const current = pluginRegistry.resolvePaneSettings(instanceId)?.context.settings ?? {};
+          // The lock is resolved into the settings view but lives on the instance.
+          const { [PANE_LOCK_SETTING_KEY]: _locked, ...currentSettings } = current;
           pluginRegistry.updateLayoutFn(setPaneSettings(getState().config.layout, instanceId, {
-            ...current,
+            ...currentSettings,
             [key]: input.value,
           }));
         }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -66,6 +66,8 @@ export interface PaneInstanceConfig {
   params?: Record<string, string>;
   settings?: Record<string, unknown>;
   placementMemory?: PanePlacementMemory;
+  /** Pinned by the user: the keyboard close shortcuts leave this pane alone. */
+  locked?: boolean;
 }
 
 interface DockPaneNode {
@@ -558,6 +560,7 @@ export function createPaneInstance(
     params: options.params ? { ...options.params } : undefined,
     settings: clonePaneSettings(options.settings),
     placementMemory: clonePlacementMemory(options.placementMemory),
+    locked: options.locked === true ? true : undefined,
   };
 }
 


### PR DESCRIPTION
## What

Adds a per-pane **Lock Pane** toggle, in pane settings and in the pane action menu next to Close Pane, with a padlock in the pane header while it is on. A locked pane stays put when the close shortcut is pressed.

## Behavior

Blocked while locked:

- `CmdOrCtrl+W` on the focused pane
- `CmdOrCtrl+Alt+W`, which now closes only the *unlocked* floating panes
- double-`Esc`, the terminal equivalent of the same accidental close
- `CmdOrCtrl+W` in a popped-out desktop window

The keypress is still swallowed rather than passed on, so a locked pane can never fall through to the host window's own close accelerator, and a toast says why nothing happened. Explicit closes still work: the floating pane's `x`, the pane menu's Close Pane, and the layout manager.

No dedicated accelerator. Locking is a set-and-leave action that does not earn a slot, and a one-chord toggle for an anti-accident feature is itself an accident risk: a mistyped chord would silently unlock a pane and you would find out when `Cmd+W` ate it. The menu item is where Close Pane already lives, so it is discoverable without memorizing anything. The menu label carries the state (Lock Pane / Unlock Pane) because the terminal menu renderer has no checkmark column.

## Storage

The flag lives on the pane instance (`locked`) rather than in pane settings, so a plugin's `applyValue` never sees it and a published layout never carries someone else's lock. `applyPaneSettingFieldValue` intercepts the reserved `pane.locked` key and writes it to the layout.

Every pane now resolves a settings dialog, so panes that previously exposed no settings get the lock too; their dialog contains just that toggle.

## Verified

- `bun run typecheck` and `bun test` (3159 pass) clean, `bun run i18n:audit` reports no new gaps.
- End to end in tmux: the menu shows Lock Pane above Close Pane, picking it adds 🔒 to the header and flips the label to Unlock Pane, `Ctrl+W` leaves the pane open with the toast, unlocking lets `Ctrl+W` close it, and the lock survives a save/reload.

New tests cover the Ctrl+W and Ctrl+Alt+W lock paths, the menu toggle and its label, the instance-vs-settings storage split, and the persistence round trip. Each was confirmed to fail without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)