### PR TITLE
Keep quote board status scoped to the selected markets

### DIFF
--- a/src/plugins/builtin/shared/use-quote-board.test.tsx
+++ b/src/plugins/builtin/shared/use-quote-board.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { act, useMemo } from "react";
+import { act, useMemo, useState } from "react";
 import { testRender } from "../../../renderers/opentui/test-utils";
 import type { MarketDataRequestContext, QuoteBatchResult } from "../../../types/data-provider";
 import type { Quote } from "../../../types/financials";
@@ -53,22 +53,28 @@ function batchProvider(reply: () => QuoteBatchResult[] | Error) {
 
 let quotes: BoardQuoteMap = new Map();
 let refreshBoard: () => void = () => {};
+let setBoardSymbols: (symbols: string[]) => void = () => {};
+let setBoardProvider: (provider: object | null) => void = () => {};
 
-function Probe({ intervalMs }: { intervalMs: number }) {
-  const board = useQuoteBoard(SYMBOLS, intervalMs);
+function Probe({ intervalMs, symbols }: { intervalMs: number; symbols: string[] }) {
+  const board = useQuoteBoard(symbols, intervalMs);
   quotes = board.quotes;
   refreshBoard = board.refresh;
   return <Text>{`${board.quotes.size}`}</Text>;
 }
 
 function Harness({ provider, intervalMs }: { provider: object; intervalMs: number }) {
+  const [symbols, setSymbols] = useState(SYMBOLS);
+  const [activeProvider, setProvider] = useState<object | null>(provider);
+  setBoardSymbols = setSymbols;
+  setBoardProvider = setProvider;
   const runtime = useMemo(
-    () => ({ getMarketData: () => provider }) as unknown as PluginRuntimeAccess,
-    [provider],
+    () => ({ getMarketData: () => activeProvider }) as unknown as PluginRuntimeAccess,
+    [activeProvider],
   );
   return (
     <PluginRenderProvider runtime={runtime} pluginId="test">
-      <Probe intervalMs={intervalMs} />
+      <Probe intervalMs={intervalMs} symbols={symbols} />
     </PluginRenderProvider>
   );
 }
@@ -207,5 +213,66 @@ describe("useQuoteBoard failure handling", () => {
     const status = quoteBoardStatus(quotes);
     expect(status).toMatchObject({ stale: 0, unavailable: 1 });
     expect(quoteBoardFooterInfo(status).map((segment) => segment.id)).toEqual(["error", "fresh"]);
+  });
+});
+
+describe("useQuoteBoard target changes", () => {
+  test("drops removed quotes and errors while retaining overlapping quotes across pending requests", async () => {
+    const pending: Array<(rows: QuoteBatchResult[]) => void> = [];
+    const provider = { getQuotesBatch: () => new Promise<QuoteBatchResult[]>((resolve) => pending.push(resolve)) };
+    await mount(provider);
+    const recent = { ...quote("^GSPC", 100), lastUpdated: 1_700_001_000_000 };
+    const retained = quote("^FTSE", 200);
+    await act(async () => pending.shift()!([
+      { target: { symbol: "^GSPC" }, quote: recent },
+      { target: { symbol: "^FTSE" }, quote: retained },
+    ]));
+    await settle();
+    await act(async () => refreshBoard());
+    const previousRequest = pending.shift()!;
+    await act(async () => setBoardSymbols(["^FTSE", "DX-Y.NYB"]));
+    await settle();
+    const currentRequest = pending.shift()!;
+    expect([...quotes.keys()]).toEqual(["^FTSE", "DX-Y.NYB"]);
+    expect(quotes.get("^FTSE")?.quote).toBe(retained);
+    expect(quoteBoardStatus(quotes).latestTs).toBe(retained.lastUpdated);
+    await act(async () => previousRequest([
+      { target: { symbol: "^GSPC" }, quote: null, error: new Error("removed listing failed") },
+      { target: { symbol: "^FTSE" }, quote: quote("^FTSE", 999) },
+    ]));
+    await settle();
+    expect([...quotes.keys()]).toEqual(["^FTSE", "DX-Y.NYB"]);
+    expect(quotes.get("^FTSE")?.quote).toBe(retained);
+    expect(quotes.get("^FTSE")?.loading).toBe(true);
+    await act(async () => currentRequest([
+      { target: { symbol: "^FTSE" }, quote: null, error: new Error("temporary outage") },
+      { target: { symbol: "DX-Y.NYB" }, quote: null, error: new Error("unavailable") },
+    ]));
+    await settle();
+    expect(quoteBoardStatus(quotes)).toMatchObject({ stale: 1, unavailable: 1, loading: 0, latestTs: retained.lastUpdated });
+    expect(quotes.get("^FTSE")?.quote).toBe(retained);
+    await act(async () => setBoardSymbols(["^FTSE"]));
+    await settle();
+    expect([...quotes.keys()]).toEqual(["^FTSE"]);
+    expect(quoteBoardStatus(quotes).unavailable).toBe(0);
+    await act(async () => pending.shift()!([{ target: { symbol: "^FTSE" }, quote: retained }]));
+    await settle();
+  });
+
+  test("invalidates pending work and prunes selection when the provider disconnects", async () => {
+    let finish!: (rows: QuoteBatchResult[]) => void;
+    const provider = { getQuotesBatch: () => new Promise<QuoteBatchResult[]>((resolve) => { finish = resolve; }) };
+    await mount(provider);
+    await act(async () => { setBoardSymbols(["^FTSE"]); setBoardProvider(null); });
+    await settle();
+    expect([...quotes.keys()]).toEqual(["^FTSE"]);
+    expect(quotes.get("^FTSE")?.loading).toBe(false);
+    await act(async () => finish(SYMBOLS.map((symbol) => ({ target: { symbol }, quote: quote(symbol, 999) }))));
+    await settle();
+    expect([...quotes.keys()]).toEqual(["^FTSE"]);
+    expect(quotes.get("^FTSE")?.quote).toBeNull();
+    await act(async () => setBoardSymbols([]));
+    await settle();
+    expect(quoteBoardStatus(quotes)).toEqual({ loading: 0, stale: 0, unavailable: 0, latestTs: 0 });
   });
 });

--- a/src/plugins/builtin/shared/use-quote-board.ts
+++ b/src/plugins/builtin/shared/use-quote-board.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PaneFooterSegment } from "../../../components";
 import { colors } from "../../../theme/colors";
 import type { MarketState, Quote } from "../../../types/financials";
@@ -25,7 +25,7 @@ function errorMessage(value: unknown): string {
  * ago: keep the last good quote and mark it stale instead.
  */
 function mergeQuotes(previous: BoardQuoteMap, loaded: BoardQuoteMap): BoardQuoteMap {
-  const next = new Map(previous);
+  const next: BoardQuoteMap = new Map();
   for (const [symbol, state] of loaded) {
     const retained = state.quote ?? previous.get(symbol)?.quote ?? null;
     next.set(symbol, {
@@ -39,11 +39,11 @@ function mergeQuotes(previous: BoardQuoteMap, loaded: BoardQuoteMap): BoardQuote
 }
 
 /**
- * Polls a fixed symbol list for a quote board (world indices, futures).
+ * Polls the active symbol list for a quote board (world indices, futures).
  *
  * Boards differ only in which symbols they watch, so the batch/serial fallback
  * and the stale-response guard live here instead of in each pane. `symbols`
- * must be a stable reference; boards build theirs from module-level catalogs.
+ * must keep a stable reference until the catalog or saved selection changes.
  *
  * The first load may serve the provider cache, which is what makes a board
  * paint instantly on open. Every load after it is a refresh the user asked for
@@ -58,20 +58,25 @@ export function useQuoteBoard(symbols: string[], refreshIntervalMs: number): {
   // A manual refresh can land after an in-flight poll, so only the newest
   // request is allowed to write.
   const fetchGenRef = useRef(0);
+  // Settings changes must affect rows and footer status in the same render,
+  // including the frame before the next request effect starts.
+  const activeQuotes = useMemo(() => new Map(symbols.flatMap((symbol) => {
+    const state = quotes.get(symbol);
+    return state ? [[symbol, state] as const] : [];
+  })), [quotes, symbols]);
 
   const load = useCallback((forceRefresh: boolean) => {
-    if (!dataProvider) return;
-
     fetchGenRef.current += 1;
     const gen = fetchGenRef.current;
 
     setQuotes((prev) => {
-      const next = new Map(prev);
+      const next: BoardQuoteMap = new Map();
       for (const symbol of symbols) {
-        next.set(symbol, { ...(prev.get(symbol) ?? EMPTY_STATE), loading: true });
+        next.set(symbol, { ...(prev.get(symbol) ?? EMPTY_STATE), loading: !!dataProvider });
       }
       return next;
     });
+    if (!dataProvider || symbols.length === 0) return;
 
     const loadQuotes = async (): Promise<BoardQuoteMap> => {
       const next: BoardQuoteMap = new Map();
@@ -124,10 +129,13 @@ export function useQuoteBoard(symbols: string[], refreshIntervalMs: number): {
   useEffect(() => {
     load(false);
     const interval = setInterval(() => load(true), refreshIntervalMs);
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(interval);
+      fetchGenRef.current += 1;
+    };
   }, [load, refreshIntervalMs]);
 
-  return { quotes, refresh };
+  return { quotes: activeQuotes, refresh };
 }
 
 export interface QuoteBoardStatus {

--- a/src/plugins/builtin/world-indices/pane.test.tsx
+++ b/src/plugins/builtin/world-indices/pane.test.tsx
@@ -6,7 +6,9 @@ import { createDefaultConfig } from "../../../types/config";
 import type { QuoteBatchResult } from "../../../types/data-provider";
 import type { PluginRuntimeAccess } from "../../runtime";
 import { worldIndicesModule } from "./index";
-import { TestPaneProvider } from "../../../test-support/pane";
+import { Box } from "../../../ui";
+import { PaneFooterProvider, PaneFooterBar } from "../../../components/layout/pane/footer";
+import { TestPaneProvider, createTestPaneConfig } from "../../../test-support/pane";
 
 const WorldIndicesPane = worldIndicesModule.panes![0]!.component as (props: {
   paneId: string;
@@ -111,4 +113,44 @@ describe("WorldIndicesPane", () => {
     expect(frame).toContain("6,812.44");
     expect(frame).toContain("SPX");
   });
+});
+
+// Saved selections share one live pane, so removed regions must leave no status behind.
+test.each([80, 120])("saved index selection prunes unavailable counts and source times at %i cells", async (width) => {
+  const times = { "^GSPC": Date.parse("2026-09-11T20:46:00Z"), "^FTSE": Date.parse("2026-09-11T15:35:00Z") };
+  let selectSymbols!: (symbols: string[]) => void;
+  const provider = { getQuotesBatch: async (targets: Array<{ symbol: string }>) => targets.map((target) => ({
+    target, quote: target.symbol === "DX-Y.NYB" ? null : {
+      symbol: target.symbol, price: PRICES[target.symbol], change: 12.5, changePercent: 0.42,
+      currency: "USD", marketState: "CLOSED", lastUpdated: times[target.symbol as keyof typeof times],
+    },
+  })) };
+  const runtime = { getMarketData: () => provider } as unknown as PluginRuntimeAccess;
+  function SelectionHarness() {
+    const [symbols, setSymbols] = useState(["^GSPC", "^FTSE", "DX-Y.NYB"]);
+    selectSymbols = setSymbols;
+    const config = createTestPaneConfig("/tmp/gloomberb-wei-selection-test", {
+      paneId: "world-indices", instanceId: "world-indices", settings: { symbols },
+    });
+    const state = createInitialState(config);
+    return <TestPaneProvider state={state} paneId="world-indices" runtime={runtime} pluginId="market-overview">
+      <PaneFooterProvider>{(footer) => <Box width={width} height={24} flexDirection="column">
+        <Box width={width} height={23}><WorldIndicesPane paneId="world-indices" paneType="world-indices" focused width={width} height={23} /></Box>
+        <PaneFooterBar footer={footer} focused width={width} />
+      </Box>}</PaneFooterProvider>
+    </TestPaneProvider>;
+  }
+  await act(async () => { testSetup = await testRender(<SelectionHarness />, { width, height: 24 }); });
+  await settle();
+  const formatTime = (value: number) => new Date(value).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  expect(testSetup!.captureCharFrame()).toContain("1 unavailable");
+  expect(testSetup!.captureCharFrame()).toContain(formatTime(times["^GSPC"]));
+  await act(async () => selectSymbols(["^FTSE"]));
+  await settle();
+  const frame = testSetup!.captureCharFrame();
+  expect(frame).toContain("FTSE");
+  expect(frame).not.toContain("DXY");
+  expect(frame).not.toContain("unavailable");
+  expect(frame).toContain(formatTime(times["^FTSE"]));
+  expect(frame).not.toContain(formatTime(times["^GSPC"]));
 });


### PR DESCRIPTION
Changing a saved World Indices selection could leave removed symbols in the shared quote state. For example, narrowing the board to Asia still showed an unavailable DXY count and a US-market timestamp in the footer.

Keep quote state scoped to the current symbol list, preserve overlapping observations during refresh, and invalidate pending work when the selection or provider changes. The current render also filters state immediately, so rows and footer describe the same selection before the next request starts. Existing controls and footer layout are unchanged.

Regression coverage exercises selection changes during pending requests, late responses, provider disconnect, and the actual World Indices footer at 80 and 120 columns. Recorded production-response component replay verifies sorting, refresh and Asia selection with 18 of 19 global indices available. These are in-process component checks; fresh browser/tmux interaction was unavailable in this environment.

Validation: 3,158 tests / 12,845 assertions and all six runtime TypeScript projects pass. Independent review covered all three consumers and an additional provider-replacement race. No release or version change.
