### PR TITLE
Fix research data integrity and Treasury curve rendering

### DIFF
--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -56,6 +56,12 @@ Sector and industry ETF returns are price returns in the listing currency, witho
 
 One unit of the row currency buys the amount in the column currency. Indicative cross rates are calculated through USD legs, whose observation times can differ. Missing, stale, or unknown observation times appear as current status.
 
+## Credit spreads
+
+CRD shows daily closing option-adjusted spreads for the ICE BofA US Corporate (US IG), US High Yield (US HY), and AAA, AA, A, and BBB US Corporate indices from FRED. Source percentages are converted to basis points; 1D is the change from the previous available observation. These are spreads, not bond yields.
+
+Each series keeps its own observation date. A shared date appears in the footer when all displayed observations agree; otherwise an AS OF column identifies each row's date. Refresh time does not change an observation date. Headless reports retain each FRED series identifier, title, units, frequency, and date.
+
 ## Options
 
 OVME uses a European-exercise Black–Scholes model. It does not model early exercise or discrete dividends. Theta is per day; vega is per volatility percentage point; rho is per rate percentage point. The UI keeps these units beside their values.

--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -26,6 +26,8 @@ SEC EPS uses corroborated split-adjusted share bases. Unverified bases are unava
 
 Market capitalization can come from a financial snapshot when a current quote does not supply it. Its retrieval time is not its valuation date. Source and freshness details remain attached to the affected value; market-cap comparisons require a valid currency conversion.
 
+Relative Valuation excludes explicitly stale quote prices, changes, and quote market caps from comparisons. Its exports retain the original quote, source timestamp and stale status, and identify incomplete output. Separately reported fundamentals and fallback market caps retain their own source and retrieval time; these are not dated by the rejected quote.
+
 Bank capital metrics and REIT FFO/AFFO depend on source coverage. Operating cash flow is not a substitute for FFO/AFFO. Missing measures are identified in the financial view.
 
 ## Treasury curve

--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -28,6 +28,12 @@ Market capitalization can come from a financial snapshot when a current quote do
 
 Bank capital metrics and REIT FFO/AFFO depend on source coverage. Operating cash flow is not a substitute for FFO/AFFO. Missing measures are identified in the financial view.
 
+## Treasury curve
+
+GC plots constant-maturity Treasury yields against elapsed maturity, with month/year axis and cursor labels. The table retains each tenor's published observation date. The 10Y−2Y spread is measured in basis points; a negative value indicates inversion. Missing tenors remain unavailable, and a curve requires matching dates.
+
+Use the existing Date footer action (`d`) to enter an as-of date, then Enter to submit. Latest (`l`) returns to the latest published curve. A holiday or weekend request uses the latest preceding published session within the lookup window; the requested date and observation date remain distinct. Refresh time is not the observation date.
+
 ## Portfolio analytics
 
 P&L for manual portfolios covers current holdings. Manual portfolios have no cash-flow performance history; reconcile corporate actions through **PF → Set position**. Distributions are not automatically credited.

--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -54,6 +54,10 @@ One unit of the row currency buys the amount in the column currency. Indicative 
 
 OVME uses a European-exercise Black–Scholes model. It does not model early exercise or discrete dividends. Theta is per day; vega is per volatility percentage point; rho is per rate percentage point. The UI keeps these units beside their values.
 
+OMON HV30 is the annualized sample standard deviation of 30 daily log returns from 31 distinct reported observations, using 252 trading days per year. A later correction replaces the same timestamp. Missing or nonpositive closes and contradictory OHLC inside that window make HV30 and IV/HV unavailable; they are not skipped to bridge a return. A quote explicitly marked stale cannot seed underlying-dependent Greeks, ATM selection, or the calculator. Contract quotes remain visible with their own timestamps.
+
+OVME values are per underlying unit, not a position or contract total. Rates and continuous dividend yield are entered in percent; time uses calendar days, retaining fractional days. A chain expiry date is seeded at 16:00 New York with historical daylight-saving offsets. Verify and edit the time for other settlement schedules or early closes, especially index options. The calculator does not resolve adjusted deliverables or contract multipliers, model multi-leg payoffs, or compute assignment outcomes.
+
 A calculator opened from a chain uses a saved contract observation. Its quote and last-trade timestamps are separate; neither makes a saved quote executable. The market reference identifies midpoint, last, or manual input. Crossed or one-sided quotes do not supply a valid midpoint.
 
 ## Earnings and corporate actions

--- a/src/cli/commands/market-fx.test.ts
+++ b/src/cli/commands/market-fx.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import { createDefaultConfig } from "../../types/config";
+import type { CliCommandContext } from "../../types/plugin";
+import { marketDataCliCommands } from "./market";
+
+const fx = marketDataCliCommands.find((command) => command.name === "fx")!;
+
+function harness(baseCurrency: string, rates: Record<string, number>) {
+  const config = createDefaultConfig("/tmp/gloom-fx-command-fixture");
+  config.baseCurrency = baseCurrency;
+  const rows: unknown[] = [];
+  const requests: string[] = [];
+  let closed = 0;
+  const context = {
+    initMarketData: async () => ({
+      config,
+      persistence: { close: () => { closed++; } },
+      dataProvider: { getExchangeRate: async (currency: string) => {
+        requests.push(currency);
+        const rate = rates[currency];
+        if (rate == null) throw new Error(`Missing ${currency}/USD`);
+        return rate;
+      } },
+    }),
+    printResult: (result: { data: unknown }) => { rows.push(result.data); },
+    fail: (message: string): never => { throw new Error(message); },
+  } as unknown as CliCommandContext;
+  return { context, rows, requests, closed: () => closed };
+}
+
+test("FX command converts both USD legs into the configured base currency", async () => {
+  const run = harness("EUR", { GBP: 1.5, EUR: 1.2 });
+  await fx.execute(["GBP"], run.context);
+  expect(run.rows).toEqual([[{ currency: "GBP", baseCurrency: "EUR", rate: 1.25 }]]);
+  expect(run.requests.sort()).toEqual(["EUR", "GBP"]);
+  expect(run.closed()).toBe(1);
+});
+
+test("FX command handles identity and USD inverses without requiring a USD quote", async () => {
+  const identity = harness("EUR", {});
+  await fx.execute(["EUR"], identity.context);
+  expect(identity.rows).toEqual([[{ currency: "EUR", baseCurrency: "EUR", rate: 1 }]]);
+  expect(identity.requests).toEqual([]);
+  const inverse = harness("EUR", { EUR: 1.25 });
+  await fx.execute(["USD"], inverse.context);
+  expect(inverse.rows).toEqual([[{ currency: "USD", baseCurrency: "EUR", rate: 0.8 }]]);
+  const usdBase = harness("USD", { JPY: 0.0065 });
+  await fx.execute(["JPY"], usdBase.context);
+  expect(usdBase.rows).toEqual([[{ currency: "JPY", baseCurrency: "USD", rate: 0.0065 }]]);
+});
+
+test("FX command does not publish a conversion when either rate leg is unavailable", async () => {
+  for (const rates of [{ GBP: 1.5 }, { EUR: 1.2 }, { GBP: 1.5, EUR: 0 }, { GBP: NaN, EUR: 1.2 }]) {
+    const run = harness("EUR", rates);
+    await expect(fx.execute(["GBP"], run.context)).rejects.toThrow("GBP/EUR");
+    expect(run.rows).toEqual([]);
+    expect(run.closed()).toBe(1);
+  }
+});

--- a/src/cli/commands/market.ts
+++ b/src/cli/commands/market.ts
@@ -13,6 +13,7 @@ import type {
 import { formatMarketPriceWithCurrency } from "../../market-data/market/format";
 import { formatCompact } from "../../utils/format";
 import { withCliServices, withMarketData } from "../context";
+import { createBaseConverter } from "../base-converter";
 import { isoDate, parsePositiveInt, requireArg, takeOption } from "./command-utils";
 
 const VALID_RANGES = new Set<TimeRange>(TIME_RANGES);
@@ -419,10 +420,12 @@ async function runOptions(rawArgs: string[], ctx: Parameters<CliCommandDef["exec
 }
 
 async function runFx(rawArgs: string[], ctx: Parameters<CliCommandDef["execute"]>[1]) {
-  const currency = requireArg(rawArgs[0]?.toUpperCase(), "Usage: gloomberb fx <currency>", ctx);
+  const currency = requireArg(rawArgs[0]?.trim().toUpperCase(), "Usage: gloomberb fx <currency>", ctx);
   await withMarketData(ctx, async (market) => {
-    const rate = await market.dataProvider.getExchangeRate(currency);
-    ctx.printResult({ data: [{ currency, baseCurrency: market.config.baseCurrency, rate }] }, {
+    const baseCurrency = market.config.baseCurrency.trim().toUpperCase();
+    const rate = await createBaseConverter(market.dataProvider, baseCurrency)(1, currency);
+    if (!Number.isFinite(rate) || rate <= 0) ctx.fail(`Exchange rate unavailable for ${currency}/${baseCurrency}`);
+    ctx.printResult({ data: [{ currency, baseCurrency, rate }] }, {
       columns: [
         { key: "currency", header: "Currency" },
         { key: "baseCurrency", header: "Base" },

--- a/src/components/chart/composite/axis-overlays.tsx
+++ b/src/components/chart/composite/axis-overlays.tsx
@@ -104,11 +104,13 @@ export function StaticXAxisLabels({
         ? visiblePositionedLabels.map((entry) => entry.label)
         : visibleLabels).join(" ")}
     >
-      {uiHost.kind === "desktop-web" && visiblePositionedLabels.length > 0 ? (
+      {visiblePositionedLabels.length > 0 && (uiHost.kind === "desktop-web" || visibleLabels.length === 0) ? (
         <Box position="absolute" left={0} top={0} width={width} height={1}>
           {visiblePositionedLabels.map((entry, index) => {
             const ratio = clampRatio(entry.ratio);
-            const edgeStyle = ratio <= 0
+            const edgeStyle = uiHost.kind !== "desktop-web"
+              ? { left: Math.max(0, Math.min(width - entry.label.length, markerColumn(ratio, width) - Math.floor(entry.label.length / 2))) }
+              : ratio <= 0
               ? { left: 0 }
               : ratio >= 1
                 ? { right: 0 }

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -2314,8 +2314,8 @@ export function CompositeChart({
         <Box flexDirection="row" width={totalWidth} height={1}>
           {leftPadding > 0 ? <Box width={leftPadding} /> : null}
           <StaticXAxisLabels
-            labels={xAxis?.labels ? [...xAxis.labels] : [timeAxisLayout.text]}
-            positionedLabels={xAxis?.labels ? undefined : timeAxisLayout.ticks}
+            labels={xAxis?.ticks ? [] : xAxis?.labels ? [...xAxis.labels] : [timeAxisLayout.text]}
+            positionedLabels={xAxis?.ticks ?? (xAxis?.labels ? undefined : timeAxisLayout.ticks)}
             width={plotWidth}
             color={resolvedColors.textDim}
             cursorColumn={timeAxisCursorColumn}

--- a/src/components/chart/composite/types.ts
+++ b/src/components/chart/composite/types.ts
@@ -151,6 +151,8 @@ export interface CompositeChartXMarker {
 export interface CompositeChartXAxis {
   /** Evenly spread labels drawn instead of date ticks. */
   labels?: readonly string[];
+  /** Labels positioned on a numeric domain rather than evenly spread. */
+  ticks?: readonly { label: string; ratio: number }[];
   /** Vertical guide lines through the plot, captioned below the axis. */
   markers?: readonly CompositeChartXMarker[];
   formatCursor?: (xRatio: number) => string;

--- a/src/components/chart/static/chart-surface.tsx
+++ b/src/components/chart/static/chart-surface.tsx
@@ -39,6 +39,8 @@ export interface StaticChartSurfaceProps {
   timeAxisColor?: string;
   /** Evenly spread labels for an x that is not time; implies an axis row. */
   xAxisLabels?: readonly string[];
+  /** Numeric-domain ticks at their actual plot ratios; implies an axis row. */
+  xAxisTicks?: CompositeChartXAxis["ticks"];
   xAxisColor?: string;
   formatXAxisCursorValue?: (xRatio: number) => string;
   xMarkers?: readonly StaticChartXMarker[];
@@ -98,6 +100,7 @@ export function StaticChartSurface({
   showTimeAxis = false,
   timeAxisColor,
   xAxisLabels,
+  xAxisTicks,
   xAxisColor,
   formatXAxisCursorValue,
   xMarkers,
@@ -125,10 +128,10 @@ export function StaticChartSurface({
     [formatYAxisValue],
   );
   const xAxis = useMemo<CompositeChartXAxis | undefined>(() => (
-    xAxisLabels || xMarkers || formatXAxisCursorValue
-      ? { labels: xAxisLabels, markers: xMarkers, formatCursor: formatXAxisCursorValue }
+    xAxisLabels || xAxisTicks || xMarkers || formatXAxisCursorValue
+      ? { labels: xAxisLabels, ticks: xAxisTicks, markers: xMarkers, formatCursor: formatXAxisCursorValue }
       : undefined
-  ), [formatXAxisCursorValue, xAxisLabels, xMarkers]);
+  ), [formatXAxisCursorValue, xAxisLabels, xAxisTicks, xMarkers]);
 
   return (
     <Box flexDirection="column" width={totalWidth} height={totalHeight}>
@@ -145,7 +148,7 @@ export function StaticChartSurface({
         colors={chartColors}
         navigable={false}
         showLegend={false}
-        showTimeAxis={showTimeAxis || (xAxisLabels?.length ?? 0) > 0}
+        showTimeAxis={showTimeAxis || (xAxisLabels?.length ?? 0) > 0 || (xAxisTicks?.length ?? 0) > 0}
         formatAxisValue={formatAxisValue}
         xAxis={xAxis}
         remoteKind="static-chart"

--- a/src/components/chart/static/series.ts
+++ b/src/components/chart/static/series.ts
@@ -3,9 +3,9 @@ import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Static charts read left to right by observation, not by wall clock: a yield
- * curve's tenors, a Kelly curve's fractions, and a sparse economic release are
- * all indices in disguise. Declaring a one-day market cadence gives every
+ * Static charts default to reading left to right by observation. Callers with
+ * unequal numeric or calendar gaps opt into calendarSpaced to preserve them.
+ * Declaring a one-day market cadence gives every
  * observation one slot on the composite time scale, matching the legacy
  * index-spaced renderer, while real dates still label the axis.
  */

--- a/src/plugins/builtin/credit-conditions/index.test.tsx
+++ b/src/plugins/builtin/credit-conditions/index.test.tsx
@@ -1,12 +1,13 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, spyOn, test } from "bun:test";
 import { act } from "react";
-import { PaneFooterProvider } from "../../../components/layout/pane/footer";
+import { apiClient } from "../../../api-client";
+import { PaneFooterBar, PaneFooterProvider } from "../../../components/layout/pane/footer";
 import {
   attachFredSeriesPersistence,
   resetFredSeriesPersistence,
   type FredSeriesCacheEntry,
 } from "../../../data/fred-series";
-import { testRender } from "../../../renderers/opentui/test-utils";
+import { createTestControls, testRender } from "../../../renderers/opentui/test-utils";
 import { MemoryPluginPersistence } from "../../../test-support/plugin-persistence";
 import {
   AppContext,
@@ -14,10 +15,13 @@ import {
   PaneInstanceProvider,
 } from "../../../state/app/context";
 import { createDefaultConfig } from "../../../types/config";
+import { Box } from "../../../ui";
 import { CREDIT_SERIES } from "./model";
 import { CreditConditionsPane } from "./index";
 
 let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+let persistence: MemoryPluginPersistence;
+let requestSpy: ReturnType<typeof spyOn> | undefined;
 
 function entry(seriesId: string, index: number): FredSeriesCacheEntry {
   return {
@@ -58,7 +62,7 @@ async function settle() {
 
 beforeEach(() => {
   resetFredSeriesPersistence();
-  const persistence = new MemoryPluginPersistence();
+  persistence = new MemoryPluginPersistence();
   for (const [index, { seriesId }] of CREDIT_SERIES.entries()) {
     persistence.seedResource(
       "fred-series",
@@ -76,42 +80,59 @@ afterEach(async () => {
     setup = undefined;
   }
   resetFredSeriesPersistence();
+  requestSpy?.mockRestore();
+  requestSpy = undefined;
 });
 
-describe("CreditConditionsPane", () => {
-  test("selects credit rows with keyboard and mouse", async () => {
-    const state = createInitialState(createDefaultConfig("/tmp/gloomberb-credit-test"));
-    setup = await testRender(
-      <AppContext value={{ state, dispatch: () => {} }}>
-        <PaneInstanceProvider paneId="credit:test">
-          <PaneFooterProvider>
-            {() => <CreditConditionsPane paneId="credit:test" paneType="credit-conditions" focused width={72} height={18} />}
-          </PaneFooterProvider>
-        </PaneInstanceProvider>
-      </AppContext>,
-      { width: 72, height: 18 },
-    );
-    await settle();
-
-    expect(setup.captureCharFrame()).toContain(`${CREDIT_SERIES[0].seriesId} Option-Adjusted Spread`);
-
-    await act(async () => {
-      setup!.mockInput.pressArrow("up");
-      setup!.mockInput.pressEnter();
-      await setup!.renderOnce();
-    });
-    await settle();
-    const keyboardTitle = `${CREDIT_SERIES[5].seriesId} Option-Adjusted Spread`;
-    expect(setup.captureCharFrame()).toContain(keyboardTitle);
-
-    let mouseSelected = false;
-    for (let row = 3; row < 9 && !mouseSelected; row += 1) {
-      await act(async () => {
-        await setup!.mockMouse.click(2, row);
-        await setup!.renderOnce();
-      });
-      mouseSelected = !setup.captureCharFrame().includes(keyboardTitle);
-    }
-    expect(mouseSelected).toBe(true);
+test.each([80, 120])("mixed cached observation dates stay attached to credit values at %i columns", async (width) => {
+  const old = entry("BAMLC0A4CBBB", 4).data;
+  old.observations = old.observations.slice(0, 1);
+  persistence.seedResource("fred-series", "BAMLC0A4CBBB:limit=45:sort=desc", old,
+    { sourceKey: "gloomberb-cloud", schemaVersion: 2 });
+  requestSpy = spyOn(apiClient, "getCloudFredSeries").mockImplementation(async (seriesId) => {
+    const index = CREDIT_SERIES.findIndex((definition) => definition.seriesId === seriesId);
+    if (index < 0) throw new Error("Unknown fixture series");
+    return entry(seriesId, index).data;
   });
+  const state = createInitialState(createDefaultConfig("/tmp/gloomberb-credit-test"));
+  setup = await testRender(
+    <AppContext value={{ state, dispatch: () => {} }}>
+      <PaneInstanceProvider paneId="credit:test">
+        <PaneFooterProvider>
+          {(footer) => <Box width={width} height={18} flexDirection="column">
+            <Box width={width} height={17}>
+              <CreditConditionsPane paneId="credit:test" paneType="credit-conditions" focused width={width} height={17} />
+            </Box>
+            <PaneFooterBar footer={footer} focused width={width} />
+          </Box>}
+        </PaneFooterProvider>
+      </PaneInstanceProvider>
+    </AppContext>,
+    { width, height: 18 },
+  );
+  await settle();
+
+  const mixed = setup.captureCharFrame();
+  expect(mixed).toContain("mixed dates");
+  expect(mixed).not.toContain("as of 2026-08-18");
+  expect(mixed).toContain("AS OF");
+  expect(mixed.split("\n").find((line) => line.includes("BBB"))).toContain("2026-08-17");
+  expect(mixed.split("\n").find((line) => line.includes("AAA"))).toContain("2026-08-18");
+  expect(requestSpy).not.toHaveBeenCalled();
+
+  const controls = createTestControls(() => setup!);
+  await controls.clickFrameText("AS OF");
+  await settle();
+  await controls.clickFrameText("AS OF");
+  await settle();
+  const sorted = setup.captureCharFrame();
+  expect(sorted.indexOf("BBB")).toBeLessThan(sorted.indexOf("AAA"));
+
+  await act(async () => { setup!.mockInput.pressKey("r"); });
+  await settle();
+  const common = setup.captureCharFrame();
+  expect(requestSpy).toHaveBeenCalledTimes(CREDIT_SERIES.length);
+  expect(common).toContain("as of 2026-08-18");
+  expect(common).not.toContain("mixed dates");
+  expect(common).not.toContain("AS OF");
 });

--- a/src/plugins/builtin/credit-conditions/index.tsx
+++ b/src/plugins/builtin/credit-conditions/index.tsx
@@ -10,7 +10,7 @@ import { useAsyncResource } from "../../../react/async-resource";
 import { useShortcut } from "../../../react/input";
 import { colors } from "../../../theme/colors";
 import type { PaneProps } from "../../../types/plugin";
-import { Box, Text, TextAttributes } from "../../../ui";
+import { Box, TextAttributes } from "../../../ui";
 import type { PluginModule } from "../plugin-module";
 import { useAutoRefresh } from "../shared/auto-refresh";
 import { getCachedCreditConditions, loadCreditConditions } from "./client";
@@ -25,7 +25,7 @@ export { creditConditionsHeadless } from "./headless";
 
 const EMPTY_ROWS: CreditConditionRow[] = [];
 
-type SortId = "label" | "oas" | "change";
+type SortId = "label" | "oas" | "change" | "date";
 interface Column extends DataTableColumn { id: SortId }
 
 const COLUMNS: readonly Column[] = [
@@ -44,6 +44,7 @@ function sortRows(rows: CreditConditionRow[], id: SortId, descending: boolean): 
   return [...rows].sort((left, right) => {
     let comparison = 0;
     if (id === "label") comparison = left.label.localeCompare(right.label);
+    else if (id === "date") comparison = left.date.localeCompare(right.date);
     else if (id === "oas") comparison = left.oasBp - right.oasBp;
     else comparison = (left.dailyChangeBp ?? -Infinity) - (right.dailyChangeBp ?? -Infinity);
     return descending ? -comparison : comparison;
@@ -59,6 +60,7 @@ function renderCell(
   const selected = state.selected ? colors.selectedText : undefined;
   if (column.id === "label") return { text: row.label, color: selected ?? colors.text, attributes: TextAttributes.BOLD };
   if (column.id === "oas") return { text: formatBp(row.oasBp), color: selected ?? colors.textBright };
+  if (column.id === "date") return { text: row.date, color: selected ?? colors.textDim };
   return {
     text: formatBp(row.dailyChangeBp, true),
     color: selected ?? (row.dailyChangeBp == null
@@ -78,6 +80,7 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
   const error = resource.error ?? resource.data?.errors[0] ?? null;
   const lastUpdated = stale ? null : resource.updatedAt;
   const rows = resource.data?.rows ?? EMPTY_ROWS;
+  const mixedDates = new Set(rows.map((row) => row.date)).size > 1;
   const [selectedId, setSelectedId] = useState<CreditSeriesId | null>(rows[0]?.seriesId ?? null);
   const [sort, setSort] = useState<{ id: SortId; descending: boolean }>({ id: "label", descending: false });
   useEffect(() => {
@@ -88,11 +91,13 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
   useAutoRefresh(lastUpdated, refresh);
 
   const sorted = useMemo(() => sortRows(rows, sort.id, sort.descending), [rows, sort]);
-  const selectedRow = rows.find((row) => row.seriesId === selectedId) ?? rows[0] ?? null;
   const columns = useMemo<Column[]>(() => {
-    const labelWidth = Math.max(12, width - 23);
-    return COLUMNS.map((column) => column.id === "label" ? { ...column, width: labelWidth } : { ...column });
-  }, [width]);
+    const labelWidth = Math.max(12, width - 23 - (mixedDates ? 11 : 0));
+    return [
+      ...COLUMNS.map((column) => column.id === "label" ? { ...column, width: labelWidth } : { ...column }),
+      ...(mixedDates ? [{ id: "date" as const, label: "AS OF", width: 10, align: "right" as const }] : []),
+    ];
+  }, [mixedDates, width]);
   const renderRowCell = useCallback((
     row: CreditConditionRow,
     column: Column,
@@ -109,15 +114,16 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
     event.stopPropagation?.();
   });
   const partial = rows.length > 0 && rows.length < CREDIT_SERIES.length;
-  const asOf = rows.reduce<string | null>((latest, row) => !latest || row.date > latest ? row.date : latest, null);
+  const asOf = mixedDates ? null : rows[0]?.date;
   const footerInfo = useMemo<PaneFooterSegment[]>(() => [
     ...(asOf ? [{ id: "as-of", parts: [{ text: `as of ${asOf}`, tone: "muted" as const }] }] : []),
+    ...(mixedDates ? [{ id: "mixed-dates", parts: [{ text: "mixed dates", tone: "warning" as const }] }] : []),
     ...(rows.length > 0 ? [{ id: "delayed", parts: [{ text: "delayed", tone: "muted" as const }] }] : []),
     ...(partial ? [{ id: "partial", parts: [{ text: `PARTIAL ${rows.length}/${CREDIT_SERIES.length}`, tone: "warning" as const, bold: true }] }] : []),
     ...(stale ? [{ id: "stale", parts: [{ text: "STALE", tone: "warning" as const }] }] : []),
     ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
     ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
-  ], [asOf, error, loading, partial, rows.length, stale]);
+  ], [asOf, mixedDates, error, loading, partial, rows.length, stale]);
   usePaneFooter(paneId, () => ({ info: footerInfo }), [footerInfo, paneId]);
 
   if (rows.length === 0 && loading) {
@@ -133,19 +139,11 @@ export function CreditConditionsPane({ paneId, focused, width, height }: PanePro
     );
   }
 
-  const metadata = (
-    <Box height={2} flexDirection="column" paddingX={1}>
-      <Text fg={colors.textMuted}>FRED · option-adjusted spread · daily close</Text>
-      <Text fg={colors.textDim}>{selectedRow?.title ?? ""}</Text>
-    </Box>
-  );
-
   return (
     <DataTableView<CreditConditionRow, Column>
       focused={focused}
       rootWidth={width}
       rootHeight={height}
-      rootBefore={metadata}
       selection={{
         kind: "id",
         selectedId,

--- a/src/plugins/builtin/options/analytics.test.ts
+++ b/src/plugins/builtin/options/analytics.test.ts
@@ -81,3 +81,45 @@ test("derives call and put Greeks from the chain IV", () => {
   expect(call?.gamma).toBeCloseTo(put!.gamma, 10);
   expect(call?.vegaPerPoint).toBeCloseTo(put!.vegaPerPoint, 10);
 });
+
+
+test("rejects bad observations inside the selected HV window instead of bridging them", () => {
+  const good = priceHistory();
+  const extended = [{ date: new Date(Date.UTC(2025, 11, 31)), close: 100 }, ...good];
+  for (const bad of [{ high: 90, low: 110 }, { high: 99 }, { close: 0 }, { close: Number.NaN }]) {
+    const points = extended.map((point, i) => i === 15 ? { ...point, ...bad } : point);
+    expect(historicalVolatility30d(points)).toBeNull();
+    const summary = calculateOptionsSummary({ underlyingSymbol: "AAPL", expirationDates: [], calls: [contract(100, .2, 100, 200)], puts: [] }, 100, points);
+    expect(summary.historicalVolatilityUnavailableReason).toBeTruthy();
+    expect(summary.impliedHistoricalRatio).toBeNull();
+    expect(summary.atmImpliedVolatility).toBe(.2);
+  }
+  // An excluded earlier bad bar cannot contaminate a complete later window.
+  expect(historicalVolatility30d([{ ...extended[0]!, high: 90, low: 110 }, ...good])).toBeCloseTo(historicalVolatility30d(good)!, 12);
+});
+
+test("deduplicates corrections before selecting 31 observations and retains immutable rejected source data", () => {
+  const good = priceHistory();
+  expect(historicalVolatility30d(good.slice(1).flatMap((point) => [point, point]))).toBeNull();
+  const broken = { ...good[15]!, high: 90, low: 110 };
+  const corrected = [...good.slice(0, 15), broken, ...good.slice(16), good[15]!];
+  expect(historicalVolatility30d(corrected)).toBeCloseTo(historicalVolatility30d(good)!, 12);
+  const chain = { underlyingSymbol: "AAPL", expirationDates: [], calls: [], puts: [] };
+  const summary = calculateOptionsSummary(chain, 100, [...good, broken]);
+  expect(summary.historicalVolatility30d).toBeNull();
+  const diagnostic = summary.historicalVolatilityIntegrity!;
+  expect(diagnostic.sourcePoints).toHaveLength(1);
+  expect(diagnostic.sourcePoints[0]!.date).toBe(good[15]!.date.toISOString());
+  broken.high = 120;
+  expect(diagnostic.sourcePoints[0]!.high).toBe(90);
+  expect(Object.isFrozen(diagnostic.sourcePoints)).toBe(true);
+  expect(Object.isFrozen(diagnostic.sourcePoints[0])).toBe(true);
+});
+
+test("validates chronology without requiring full OHLC and handles finite extreme prices", () => {
+  const good = priceHistory();
+  expect(historicalVolatility30d([...good].reverse())).toBeCloseTo(historicalVolatility30d(good)!, 12);
+  expect(historicalVolatility30d([...good, { date: new Date(Number.NaN), close: 100 }])).toBeNull();
+  expect(historicalVolatility30d(good.map((point, i) => ({ ...point, close: i % 2 ? 1e300 : 1e-300 })))).toBeFinite();
+  expect(historicalVolatility30d(good.map((point) => ({ ...point, close: 100 })))).toBe(0);
+});

--- a/src/plugins/builtin/options/analytics.ts
+++ b/src/plugins/builtin/options/analytics.ts
@@ -1,3 +1,4 @@
+import { mergePriceHistoryIntegrity, pricePointIntegrity, type PriceHistoryIntegrity } from "../../../utils/price-history-integrity";
 import type { OptionContract, OptionsChain, PricePoint } from "../../../types/financials";
 import {
   DEFAULT_OPTION_CALC_DRAFT,
@@ -13,6 +14,8 @@ const HISTORICAL_VOLATILITY_SESSIONS = 30;
 export interface OptionsSummary {
   atmImpliedVolatility: number | null;
   historicalVolatility30d: number | null;
+  historicalVolatilityUnavailableReason?: string;
+  historicalVolatilityIntegrity?: PriceHistoryIntegrity;
   impliedHistoricalRatio: number | null;
   expirationVolume: number;
   putCallVolumeRatio: number | null;
@@ -45,23 +48,53 @@ function atmImpliedVolatility(chain: OptionsChain, spot: number | undefined): nu
   return atTheMoney.reduce((total, value) => total + value, 0) / atTheMoney.length;
 }
 
-/** Annualized standard deviation of the latest 30 daily log returns. */
-export function historicalVolatility30d(points: readonly PricePoint[]): number | null {
-  const closes = points
-    .map((point) => ({
-      close: point.close,
-      time: point.date instanceof Date ? point.date.getTime() : Date.parse(String(point.date)),
-    }))
-    .filter((point) => positive(point.close) && Number.isFinite(point.time))
-    .sort((a, b) => a.time - b.time)
-    .slice(-(HISTORICAL_VOLATILITY_SESSIONS + 1))
-    .map((point) => point.close);
-  if (closes.length < HISTORICAL_VOLATILITY_SESSIONS + 1) return null;
+interface HistoricalVolatilityResult {
+  value: number | null;
+  unavailableReason?: string;
+  integrity?: PriceHistoryIntegrity;
+}
 
-  const returns = closes.slice(1).map((close, index) => Math.log(close / closes[index]!));
+/** Select observations before validating prices; a rejected close must never be bridged. */
+function historicalVolatilityResult(points: readonly PricePoint[]): HistoricalVolatilityResult {
+  const observations = new Map<number, PricePoint>();
+  for (const point of points) {
+    const time = new Date(point.date).getTime();
+    if (!Number.isFinite(time)) {
+      return { value: null, unavailableReason: "HV30 unavailable: invalid history date" };
+    }
+    // Persisted corrections replace the same observation, not an extra return.
+    observations.set(time, point);
+  }
+  const selected = [...observations.entries()]
+    .sort(([a], [b]) => a - b)
+    .slice(-(HISTORICAL_VOLATILITY_SESSIONS + 1))
+    .map(([, point]) => point);
+  const rejected = selected.flatMap((point) => {
+    const integrity = pricePointIntegrity(point);
+    return integrity ? [integrity] : [];
+  });
+  if (rejected.length > 0) {
+    return {
+      value: null,
+      unavailableReason: "HV30 unavailable: inconsistent OHLC history",
+      integrity: mergePriceHistoryIntegrity(...rejected),
+    };
+  }
+  if (selected.some((point) => !positive(point.close))) {
+    return { value: null, unavailableReason: "HV30 unavailable: missing or nonpositive close" };
+  }
+  if (selected.length < HISTORICAL_VOLATILITY_SESSIONS + 1) return { value: null };
+  // Subtract logs instead of taking a ratio that can overflow for finite prices.
+  const logs = selected.map((point) => Math.log(point.close));
+  const returns = logs.slice(1).map((log, index) => log - logs[index]!);
   const mean = returns.reduce((total, value) => total + value, 0) / returns.length;
   const variance = returns.reduce((total, value) => total + (value - mean) ** 2, 0) / (returns.length - 1);
-  return Math.sqrt(variance * TRADING_DAYS_PER_YEAR);
+  return { value: Math.sqrt(variance * TRADING_DAYS_PER_YEAR) };
+}
+
+/** Annualized sample standard deviation of the latest 30 daily log returns. */
+export function historicalVolatility30d(points: readonly PricePoint[]): number | null {
+  return historicalVolatilityResult(points).value;
 }
 
 export function calculateOptionsSummary(
@@ -70,7 +103,8 @@ export function calculateOptionsSummary(
   priceHistory: readonly PricePoint[],
 ): OptionsSummary {
   const atmIv = atmImpliedVolatility(chain, spot);
-  const historicalVolatility = historicalVolatility30d(priceHistory);
+  const historical = historicalVolatilityResult(priceHistory);
+  const historicalVolatility = historical.value;
   const callVolume = sum(chain.calls, "volume");
   const putVolume = sum(chain.puts, "volume");
   const callOpenInterest = sum(chain.calls, "openInterest");
@@ -79,6 +113,8 @@ export function calculateOptionsSummary(
   return {
     atmImpliedVolatility: atmIv,
     historicalVolatility30d: historicalVolatility,
+    ...(historical.unavailableReason ? { historicalVolatilityUnavailableReason: historical.unavailableReason } : {}),
+    ...(historical.integrity ? { historicalVolatilityIntegrity: historical.integrity } : {}),
     impliedHistoricalRatio: atmIv != null && historicalVolatility != null && historicalVolatility > 0
       ? atmIv / historicalVolatility
       : null,

--- a/src/plugins/builtin/options/view.test.tsx
+++ b/src/plugins/builtin/options/view.test.tsx
@@ -1,5 +1,7 @@
 import { afterEach, expect, test } from "bun:test";
 import { act, useState } from "react";
+import { Box } from "../../../ui";
+import { PaneFooterBar, PaneFooterProvider } from "../../../components/layout/pane/footer";
 import type { ScrollBoxRenderable } from "@opentui/core";
 import { takeSavedTextFile, testRender } from "../../../renderers/opentui/test-utils";
 import { exportPaneTable, hasPaneTableExporter } from "../../../state/pane-table-export-registry";
@@ -76,12 +78,18 @@ function makeFinancials(price: number): TickerFinancials {
 function OptionsHarness({
   ticker,
   quotePrice,
+  quoteStale,
+  history,
+  showFooter = false,
   width = 122,
   height = 14,
   onCapture = () => { },
 }: {
   ticker: TickerRecord;
   quotePrice?: number;
+  quoteStale?: boolean;
+  history?: TickerFinancials["priceHistory"];
+  showFooter?: boolean;
   width?: number;
   height?: number;
   onCapture?: (capturing: boolean) => void;
@@ -96,12 +104,18 @@ function OptionsHarness({
   state.focusedPaneId = TEST_PANE_ID;
   state.tickers = new Map([[ticker.metadata.ticker, ticker]]);
   if (quotePrice != null) {
-    state.financials = new Map([[ticker.metadata.ticker, makeFinancials(quotePrice)]]);
+    const financials = makeFinancials(quotePrice);
+    financials.quote.stale = quoteStale;
+    if (history) financials.priceHistory = history;
+    state.financials = new Map([[ticker.metadata.ticker, financials]]);
   }
 
   return (
     <TestPaneProvider state={state} paneId={TEST_PANE_ID} pluginId="ticker-research" runtime={createTestPluginRuntime()}>
-      <OptionsView width={width} height={height} focused onCapture={onCapture} />
+      {showFooter ? <PaneFooterProvider>{(footer) => <Box width={width} height={height} flexDirection="column">
+        <Box width={width} height={height - 1}><OptionsView width={width} height={height - 1} focused onCapture={onCapture} /></Box>
+        <PaneFooterBar footer={footer} focused width={width} />
+      </Box>}</PaneFooterProvider> : <OptionsView width={width} height={height} focused onCapture={onCapture} />}
     </TestPaneProvider>
   );
 }
@@ -568,4 +582,61 @@ test("keeps the selected chain visible when its refresh fails", async () => {
   expect(frame).toContain("C LAST");
   expect(frame).toContain("101");
   expect(frame).not.toContain("Options chain unavailable.");
+});
+
+
+test("stale underlying preserves contract observations but cannot seed current Greeks or calculator", async () => {
+  const provider = createTestDataProvider({ getOptionsChain: async () => makeChain([100, 101], 101) });
+  setSharedMarketDataCoordinator(new MarketDataCoordinator(provider));
+  let setStale!: (value: boolean) => void;
+  function FreshnessHarness() {
+    const [stale, updateStale] = useState(true);
+    setStale = updateStale;
+    return <OptionsHarness ticker={makeTicker("AAPL")} quotePrice={101} quoteStale={stale} showFooter height={20} width={160} />;
+  }
+  await act(async () => {
+    testSetup = await testRender(<FreshnessHarness />, { width: 160, height: 20 });
+  });
+  await renderSettled();
+  const frame = testSetup!.captureCharFrame();
+  if (process.env.OPTIONS_AUDIT_EVIDENCE) await Bun.write(`${process.env.OPTIONS_AUDIT_EVIDENCE}/stale-underlying.txt`, frame);
+  expect(frame).toContain("ATM IV —");
+  expect(frame).toContain("Underlying quote stale");
+  expect(frame).not.toContain("[c]alc");
+  await exportPaneTable(TEST_PANE_ID, "stale-options.csv");
+  const saved = takeSavedTextFile()!.text;
+  if (process.env.OPTIONS_AUDIT_EVIDENCE) await Bun.write(`${process.env.OPTIONS_AUDIT_EVIDENCE}/stale-underlying.csv`, saved);
+  const lines = saved.trim().split("\n").map((line) => line.split(","));
+  const deltaColumns = lines[0]!.flatMap((cell, i) => cell.includes("Δ") ? [i] : []);
+  expect(deltaColumns).toHaveLength(2);
+  for (const row of lines.slice(1)) for (const i of deltaColumns) expect(row[i]).toBe("—");
+  expect(saved).toContain("10.05,10.15,10.1");
+  await act(async () => { setStale(false); });
+  await renderSettled();
+  const recovered = testSetup!.captureCharFrame();
+  expect(recovered).toContain("ATM IV 20.0%");
+  expect(recovered).toContain("[c]alc");
+  expect(recovered).not.toContain("Underlying quote stale");
+  if (process.env.OPTIONS_AUDIT_EVIDENCE) await Bun.write(`${process.env.OPTIONS_AUDIT_EVIDENCE}/underlying-recovery.txt`, recovered);
+});
+
+
+test("rejected history disables HV and IV/HV without discarding healthy chain analytics", async () => {
+  const provider = createTestDataProvider({ getOptionsChain: async () => makeChain([100, 101], 101) });
+  setSharedMarketDataCoordinator(new MarketDataCoordinator(provider));
+  const history = Array.from({ length: 31 }, (_, i) => ({
+    date: new Date(Date.UTC(2026, 0, i + 1)), close: 100 + i % 2,
+    ...(i === 15 ? { high: 90, low: 110 } : {}),
+  }));
+  await act(async () => {
+    testSetup = await testRender(<OptionsHarness ticker={makeTicker("AAPL")} quotePrice={101} history={history} showFooter height={20} width={160} />, { width: 160, height: 20 });
+  });
+  await renderSettled();
+  const frame = testSetup!.captureCharFrame();
+  if (process.env.OPTIONS_AUDIT_EVIDENCE) await Bun.write(`${process.env.OPTIONS_AUDIT_EVIDENCE}/rejected-history.txt`, frame);
+  expect(frame).toContain("ATM IV 20.0%");
+  expect(frame).toContain("HV30 —");
+  expect(frame).toContain("IV/HV —");
+  expect(frame).toContain("HV30 unavailable: inconsistent OHLC history");
+  expect(frame).toContain("[c]alc");
 });

--- a/src/plugins/builtin/options/view.tsx
+++ b/src/plugins/builtin/options/view.tsx
@@ -124,7 +124,8 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
   }] : [], { liveStreaming });
   const underlyingFinancials = useTickerFinancials(isOpt ? effectiveTicker : null, null);
   const underlying = isOpt ? underlyingFinancials : financials;
-  const spot = underlying?.quote?.price;
+  const underlyingStale = underlying?.quote?.stale === true;
+  const spot = underlyingStale ? undefined : underlying?.quote?.price;
   const dividendYield = underlying?.fundamentals?.dividendYield;
   const instrument = target?.instrument ?? null;
   const baseRequest = target
@@ -356,7 +357,8 @@ export function OptionsView({ width, height, focused, onCapture = () => {} }: Op
 
   useOptionsAccessFooter({
     chain,
-    error,
+    error: [error, underlyingStale ? "Underlying quote stale: Greeks and calculator unavailable" : null,
+      summary?.historicalVolatilityUnavailableReason].filter(Boolean).join(" · ") || null,
     focused,
     hints: footerHints,
     loading,

--- a/src/plugins/builtin/research/relative-valuation-headless.test.ts
+++ b/src/plugins/builtin/research/relative-valuation-headless.test.ts
@@ -116,3 +116,52 @@ test("a foreign fundamental capitalization converts in its own currency, indepen
   expect(comparableMarketCap(row.marketCap, row.marketCapCurrency, "USD", new Map([["TWD", 0.03]]))).toBe(30);
   expect(comparableMarketCap(row.marketCap, row.marketCapCurrency, "USD", new Map())).toBeNull();
 });
+
+test("stale quotes cannot rank as current prices or seed quote-based cash-flow yields", async () => {
+  const observed = { annualStatements: [], quarterlyStatements: [], priceHistory: [],
+    // Condensed source boundary from the captured PLD financials response: the
+    // financials envelope succeeded while its embedded quote was explicitly stale.
+    quote: { symbol: "PLD", price: 135.75, change: 1.34, changePercent: .9969496317, currency: "USD",
+      lastUpdated: 1789167600002, stale: true, marketCap: 131961405440, providerId: "gloomberb-cloud", dataSource: "delayed" as const },
+    fundamentals: { trailingPE: 30.233854, freeCashFlow: 5406941184, financialCurrency: "USD", operatingMargin: .4,
+      source: "yahoo" as const, fetchedAt: "2026-09-11T23:52:16.139Z", stale: false } };
+  const raw = structuredClone(observed);
+  const values = relativeValuationValues(observed);
+  expect(values).toMatchObject({ price: null, changePercent: null, marketCap: null, fcfYield: null,
+    quoteStale: true, quoteAsOf: observed.quote.lastUpdated, trailingPE: 30.233854, operatingMargin: .4,
+    reportedQuote: { price: 135.75, stale: true, marketCap: observed.quote.marketCap, lastUpdated: observed.quote.lastUpdated },
+    fundamentalsProvenance: { source: "yahoo", retrievedAt: observed.fundamentals.fetchedAt, stale: false } });
+  expect(observed).toEqual(raw);
+  const ctx = { signal: new AbortController().signal, marketData: createTestDataProvider({
+    getTickerFinancials: async (symbol) => symbol === "MISSING" ? Promise.reject(new Error("source unavailable"))
+      : { ...observed, quote: { ...observed.quote, symbol, stale: symbol === "PLD" } },
+  }) } as HeadlessPaneContext;
+  const symbols = ["PLD", "FRESH", "MISSING"];
+  const result = await relativeValuationHeadless.load({ symbols, argument: symbols, rawArgument: symbols.join(","), options: {} }, ctx);
+  expect(result.complete).toBe(false);
+  expect(result.errors).toContain("PLD: Quote stale: quote-based values unavailable");
+  expect(result.errors).toContain("MISSING: source unavailable");
+  expect(result.unavailableSymbols).toEqual(["MISSING"]);
+  expect(result.metadata?.staleSymbols).toEqual(["PLD"]);
+  expect(result.rows[1]).toMatchObject({ price: 135.75, changePercent: observed.quote.changePercent,
+    marketCap: observed.quote.marketCap, quoteStale: false });
+  expect(Number(result.rows[1]!.fcfYield)).toBeCloseTo(observed.fundamentals.freeCashFlow / observed.quote.marketCap, 12);
+  const priceColumn = relativeValuationHeadless.columns!.find((column) => column.key === "price")!;
+  expect(priceColumn.format!(result.rows[0]!.price, result.rows[0]!)).toBe("-");
+  expect(relativeValuationHeadless.columns!.find((column) => column.key === "trailingPE")!.format!(values.trailingPE, values)).toBe("30.2");
+});
+
+test("a stale quote may use an independent fundamental cap with its own source and currency", async () => {
+  const financials = { annualStatements: [], quarterlyStatements: [], priceHistory: [],
+    quote: { symbol: "DUAL", price: 50, change: 1, changePercent: 2, currency: "USD", lastUpdated: 1789167600002, stale: true, marketCap: 500 },
+    fundamentals: { marketCap: 100, marketCapCurrency: "EUR", freeCashFlow: 5, financialCurrency: "EUR", source: "yahoo" as const,
+      fetchedAt: "2026-09-11T23:52:16.139Z", stale: false } };
+  const values = relativeValuationValues(financials);
+  expect(values).toMatchObject({ price: null, marketCap: 100, marketCapCurrency: "EUR", fcfYield: .05,
+    marketCapProvenance: { kind: "fundamentals", source: "yahoo", retrievedAt: financials.fundamentals.fetchedAt, stale: false } });
+  const recovered = relativeValuationValues({ ...financials, quote: { ...financials.quote, stale: false } });
+  expect(recovered).toMatchObject({ price: 50, marketCap: 500, marketCapCurrency: "USD", fcfYield: null, quoteStale: false });
+  const unknown = relativeValuationValues({ ...financials, quote: { ...financials.quote, stale: undefined } });
+  expect(unknown.quoteStale).toBeNull();
+  expect(unknown.reportedQuote?.stale).toBeNull();
+});

--- a/src/plugins/builtin/research/relative-valuation-headless.ts
+++ b/src/plugins/builtin/research/relative-valuation-headless.ts
@@ -2,7 +2,7 @@ import { formatPriceEarnings, PRICE_EARNINGS_NOTICE } from "../../../utils/price
 import type { HeadlessPaneDefinition } from "../../../types/headless";
 import { formatCurrency, formatNumber, formatPercent } from "../../../utils/format";
 import { loadHeadlessFinancials, loadHeadlessSymbols } from "../shared/headless-market-data";
-import { relativeValuationValues } from "./relative-valuation-model";
+import { RELATIVE_VALUATION_STALE_QUOTE_NOTICE, relativeValuationValues } from "./relative-valuation-model";
 import { paneSchemas } from "./headless-schema";
 
 export const relativeValuationHeadless: HeadlessPaneDefinition<"rows"> = {
@@ -31,7 +31,12 @@ export const relativeValuationHeadless: HeadlessPaneDefinition<"rows"> = {
     const unavailableSymbols = [...loaded.unavailableSymbols, ...rows.filter((row) => ![
       row.marketCap, row.trailingPE, row.forwardPE, row.evSales, row.fcfYield, row.revenueGrowth, row.operatingMargin,
     ].some((value) => value != null)).map(({ symbol }) => symbol)];
-    return { rows, unavailableSymbols, errors: loaded.errors, metadata: {
+    const staleSymbols = rows.filter((row) => row.quoteStale).map((row) => row.symbol);
+    const errors = [...loaded.errors, ...staleSymbols.map((symbol) => `${symbol}: ${RELATIVE_VALUATION_STALE_QUOTE_NOTICE}`)];
+    return { rows, unavailableSymbols, errors, complete: unavailableSymbols.length === 0 && errors.length === 0, metadata: {
+      staleSymbols,
+      quoteBasis: "Stale quote fields are excluded from comparison; reportedQuote retains the rejected observation and quoteAsOf retains its source timestamp.",
+      fundamentalsBasis: "Provider multiples and operating metrics retain independent fundamentalsProvenance. Retrieval time does not establish the valuation date.",
       notices: rows.some((row) => Object.values(row.reportedMultiples).some((value) => value != null && value <= 0)) ? [PRICE_EARNINGS_NOTICE] : [],
       multipleBasis: "Comparable P/E fields require a positive finite multiple; reportedMultiples preserves the finite provider values.",
       marketCapBasis: "Market caps retain their own currency and source. Fundamentals retrieval time is not a valuation date; quote timestamps do not date fallback caps.",

--- a/src/plugins/builtin/research/relative-valuation-model.ts
+++ b/src/plugins/builtin/research/relative-valuation-model.ts
@@ -3,10 +3,13 @@ import { selectMarketCapitalization } from "../../../utils/market-capitalization
 import type { TickerFinancials } from "../../../types/financials";
 export { convertMarketCapitalization as comparableMarketCap } from "../../../utils/market-capitalization";
 
+export const RELATIVE_VALUATION_STALE_QUOTE_NOTICE = "Quote stale: quote-based values unavailable";
+
 export function relativeValuationValues(financials: TickerFinancials | null) {
   const quote = financials?.quote;
   const fundamentals = financials?.fundamentals;
-  const capitalization = selectMarketCapitalization(quote, fundamentals);
+  const quoteStale = quote?.stale === true;
+  const capitalization = selectMarketCapitalization(quoteStale ? undefined : quote, fundamentals);
   const compatibleCurrency = !!fundamentals?.financialCurrency && !!quote?.currency
     && fundamentals.financialCurrency === quote.currency;
   const reportedMultiples = {
@@ -14,9 +17,21 @@ export function relativeValuationValues(financials: TickerFinancials | null) {
     forwardPE: fundamentals?.forwardPE != null && Number.isFinite(fundamentals.forwardPE) ? fundamentals.forwardPE : null,
   };
   return {
-    price: quote?.price ?? null,
+    price: quoteStale ? null : quote?.price ?? null,
+    quoteStale: quote?.stale ?? null,
+    quoteAsOf: quote && Number.isFinite(quote.lastUpdated) && quote.lastUpdated > 0 ? quote.lastUpdated : null,
+    // Retain the rejected observation separately from values used for comparison.
+    reportedQuote: quote ? {
+      price: quote.price, changePercent: quote.changePercent, marketCap: quote.marketCap ?? null,
+      currency: quote.currency, lastUpdated: quote.lastUpdated, stale: quote.stale ?? null,
+      providerId: quote.providerId ?? null, dataSource: quote.dataSource ?? null,
+    } : null,
+    fundamentalsProvenance: fundamentals ? {
+      source: fundamentals.source ?? null, retrievedAt: fundamentals.fetchedAt ?? null,
+      stale: fundamentals.stale ?? null,
+    } : null,
     currency: quote?.currency ?? null,
-    changePercent: quote?.changePercent ?? null,
+    changePercent: quoteStale ? null : quote?.changePercent ?? null,
     marketCap: capitalization?.value ?? null,
     marketCapCurrency: capitalization?.currency ?? null,
     marketCapProvenance: capitalization?.provenance ?? null,

--- a/src/plugins/builtin/research/relative-valuation-pane.test.tsx
+++ b/src/plugins/builtin/research/relative-valuation-pane.test.tsx
@@ -1,0 +1,68 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { Box } from "../../../ui";
+import { PaneFooterBar, PaneFooterProvider } from "../../../components/layout/pane/footer";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { createInitialState } from "../../../state/app/context";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
+import { TestPaneProvider, createTestPaneConfig } from "../../../test-support/pane";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../../market-data/coordinator";
+import { exportPaneTable } from "../../../state/pane-table-export-registry";
+import { takeSavedTextFile } from "../../../renderers/opentui/test-utils";
+import { RelativeValuationPane } from "./relative-valuation-pane";
+
+let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+const paneId = "relative-valuation:test";
+function Harness({ width }: { width: number }) {
+  const config = createTestPaneConfig("/tmp/gloom-relative-valuation-test", {
+    instanceId: paneId, paneId: "relative-valuation-pane", settings: { symbols: ["PLD", "FRESH", "MISSING"] },
+  });
+  const state = createInitialState(config);
+  return <TestPaneProvider state={state} paneId={paneId} pluginId="ticker-research" runtime={createTestPluginRuntime()}>
+    <PaneFooterProvider>{(footer) => <Box width={width} height={16} flexDirection="column">
+      <Box width={width} height={15}><RelativeValuationPane paneId={paneId} paneType="relative-valuation-pane" focused width={width} height={15} /></Box>
+      <PaneFooterBar footer={footer} focused width={width} />
+    </Box>}</PaneFooterProvider>
+  </TestPaneProvider>;
+}
+async function settle() {
+  for (let i = 0; i < 5; i++) await act(async () => { await new Promise((r) => setTimeout(r, 0)); await setup!.renderOnce(); });
+}
+afterEach(async () => {
+  if (setup) await act(async () => { setup!.renderer.destroy(); });
+  setup = undefined;
+  setSharedMarketDataCoordinator(null);
+});
+test("stale peer remains inspectable with contextual failure, excluded quote values and healthy peers intact", async () => {
+  let stale = true;
+  setSharedMarketDataCoordinator(new MarketDataCoordinator(createTestDataProvider({ getTickerFinancials: async (symbol) => {
+    if (symbol === "MISSING") throw new Error("source unavailable");
+    return { annualStatements: [], quarterlyStatements: [], priceHistory: [],
+      quote: { symbol, price: symbol === "PLD" ? 135.75 : 200, change: 1, changePercent: 1, currency: "USD", lastUpdated: 1789167600002,
+        stale: symbol === "PLD" && stale, marketCap: 1000 },
+      fundamentals: { trailingPE: 30.2, operatingMargin: .4, financialCurrency: "USD" },
+    };
+  } })));
+  await act(async () => { setup = await testRender(<Harness width={120} />, { width: 120, height: 16 }); });
+  await settle();
+  const frame = setup!.captureCharFrame();
+  if (process.env.RV_AUDIT_EVIDENCE) await Bun.write(`${process.env.RV_AUDIT_EVIDENCE}/stale-ui.txt`, frame);
+  expect(frame).toContain("Stale quotes: PLD");
+  expect(frame).toContain("MISSING: source unavailable");
+  expect(frame).toContain("PLD");
+  expect(frame).toContain("$200.00");
+  expect(frame).not.toContain("$135.75");
+  await exportPaneTable(paneId, "rv-stale.csv");
+  const csv = takeSavedTextFile()!.text;
+  if (process.env.RV_AUDIT_EVIDENCE) await Bun.write(`${process.env.RV_AUDIT_EVIDENCE}/stale-ui.csv`, csv);
+  expect(csv).toContain("PLD,'-,'-,—,30.2");
+  stale = false;
+  await act(async () => { setup!.mockInput.pressKey("r"); });
+  await settle();
+  const recovered = setup!.captureCharFrame();
+  expect(recovered).toContain("$135.75");
+  expect(recovered).not.toContain("Stale quotes:");
+  expect(recovered).toContain("MISSING: source unavailable");
+  if (process.env.RV_AUDIT_EVIDENCE) await Bun.write(`${process.env.RV_AUDIT_EVIDENCE}/recovered-ui.txt`, recovered);
+});

--- a/src/plugins/builtin/research/relative-valuation-pane.tsx
+++ b/src/plugins/builtin/research/relative-valuation-pane.tsx
@@ -22,7 +22,7 @@ import { useBoundTicker as useSymbolBinding } from "../shared/ticker-request";
 import { useFxRatesMap } from "../../../market-data/hooks";
 import { comparableMarketCap, relativeValuationValues } from "./relative-valuation-model";
 
-type RelativeColumnId = "symbol" | Exclude<keyof ReturnType<typeof relativeValuationValues>, "currency" | "reportedMultiples" | "marketCapCurrency" | "marketCapProvenance">;
+type RelativeColumnId = "symbol" | "price" | "changePercent" | "marketCap" | "trailingPE" | "forwardPE" | "evSales" | "fcfYield" | "revenueGrowth" | "operatingMargin";
 type RelativeColumn = DataTableColumn & { id: RelativeColumnId };
 type RelativeRow = ReturnType<typeof relativeValuationValues> & {
   symbol: string;
@@ -153,6 +153,10 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
   const missingFx = rows.some((row, index) => row.marketCap != null && comparableRows[index]?.marketCap == null);
   const sortedRows = useMemo(() => sortRelativeRows(comparableRows, sortPreference), [comparableRows, sortPreference]);
 
+  const staleSymbols = rows.filter((row) => row.quoteStale).map((row) => row.symbol);
+  const rowErrors = rows.filter((row) => row.error).map((row) => `${row.symbol}: ${row.error}`);
+  const status = [error, ...rowErrors, staleSymbols.length ? `Stale quotes: ${staleSymbols.join(", ")}` : null,
+    missingFx ? "Market-cap FX unavailable" : null].filter(Boolean).join(" · ") || null;
   const selectedRow = sortedRows[selectedIdx];
   const selectedCapNotice = selectedRow?.marketCapProvenance?.kind === "fundamentals"
     ? `${selectedRow.symbol} cap: ${describeFundamentalMarketCap(selectedRow.marketCapProvenance)}.` : undefined;
@@ -163,7 +167,7 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
     const selectedColor = rowState.selected ? colors.selectedText : undefined;
     switch (column.id) {
       case "symbol":
-        return { text: row.symbol, color: selectedColor ?? (row.error ? colors.warning : colors.textBright), attributes: TextAttributes.BOLD };
+        return { text: row.symbol, color: selectedColor ?? (row.error || row.quoteStale ? colors.warning : colors.textBright), attributes: TextAttributes.BOLD };
       case "price":
         return { text: row.price != null ? formatCurrency(row.price, row.currency ?? "USD") : "-", color: selectedColor ?? colors.text };
       case "changePercent":
@@ -198,8 +202,8 @@ export function RelativeValuationPane({ focused, width, height }: PaneProps) {
   }, []);
 
   usePaneFooter("relative-valuation", () => ({
-    info: loadingErrorFooterInfo(loading, error ?? (missingFx ? "Market-cap FX unavailable" : null)),
-  }), [error, loading, missingFx]);
+    info: loadingErrorFooterInfo(loading, status),
+  }), [status, loading]);
 
   return (
     <DataTableView<RelativeRow, RelativeColumn>

--- a/src/plugins/builtin/ticker-detail/financials/model.test.ts
+++ b/src/plugins/builtin/ticker-detail/financials/model.test.ts
@@ -166,3 +166,50 @@ test("annual balance sheets show the latest dated snapshot with comparable year-
   financials.quarterlyStatements = [{ date: "2025-12-31", currency: "USD", totalAssets: 200 }];
   expect(buildFinancialTableModel(financials, { period: "annual", statement: "balance" })?.statements.map(({ date }) => date)).toEqual(["2025-12-31"]);
 });
+
+test("an EPS-only quarter cannot replace the latest available balance sheet", () => {
+  // Reduced from the public BAC capture: June coverage has EPS but no balance sheet.
+  const financials: TickerFinancials = {
+    annualStatements: [{ date: "2025-12-31", currency: "USD", totalAssets: 3_411_738_000_000 }],
+    quarterlyStatements: [
+      { date: "2025-03-31", currency: "USD", totalAssets: 3_349_424_000_000 },
+      { date: "2026-03-31", currency: "USD", totalAssets: 3_496_186_000_000 },
+      { date: "2026-06-30", currency: "USD", eps: 1.21 },
+    ],
+    priceHistory: [],
+  };
+  const source = structuredClone(financials);
+  const balance = buildFinancialTableModel(financials, { period: "annual", statement: "balance" })!;
+  expect(balance.statements.map(({ date }) => date)).toEqual(["2026-03-31", "2025-12-31"]);
+  const assets = balance.rows.find(({ summaryKey }) => summaryKey === "totalAssets")!.cells[0]!;
+  expect(assets.value).toBe(3_496_186_000_000);
+  expect(assets.growth).toBeCloseTo(3_496_186_000_000 / 3_349_424_000_000 - 1);
+  const income = buildFinancialTableModel(financials, { period: "quarterly", statement: "income", expandAll: true })!;
+  expect(income.statements[0]!.date).toBe("2026-06-30");
+  expect(income.rows.find(({ key }) => key === "eps")!.cells[0]!.value).toBe(1.21);
+  expect(financials).toEqual(source);
+
+  // Missing/non-finite fields are not balance coverage, but a reported zero is.
+  financials.quarterlyStatements.at(-1)!.totalAssets = NaN;
+  expect(buildFinancialTableModel(financials, { period: "annual", statement: "balance" })!.statements[0]!.date).toBe("2026-03-31");
+  financials.quarterlyStatements.at(-1)!.totalDebt = 0;
+  const zero = buildFinancialTableModel(financials, { period: "annual", statement: "balance", expandAll: true })!;
+  expect(zero.statements[0]!.date).toBe("2026-06-30");
+  expect(zero.rows.find(({ key }) => key === "totalDebt")!.cells[0]!.value).toBe(0);
+});
+
+test("liabilities plus equity requires its own components and cannot copy total assets", () => {
+  const table = buildFinancialTableModel({
+    annualStatements: [
+      { date: "2022-12-31", totalAssets: 100, totalLiabilities: 60, totalEquityGrossMinorityInterest: 35 },
+      { date: "2023-12-31", totalAssets: 110, totalLiabilities: 70, totalEquity: 40 },
+      { date: "2024-12-31", totalAssets: 120, totalLiabilities: 80, totalEquityGrossMinorityInterest: 0 },
+      { date: "2025-12-31", totalAssets: 130 },
+    ],
+    quarterlyStatements: [],
+  }, { period: "annual", statement: "balance" })!;
+  const total = table.rows.find(({ id }) => id === "balance:liabilities-equity:0")!;
+  expect(total.cells.map(({ value }) => value)).toEqual([undefined, 80, undefined, 95]);
+  expect(total.cells[0]!.valueText.trim()).toBe("—");
+  expect(table.rows.find(({ summaryKey }) => summaryKey === "totalAssets")!.cells.map(({ value }) => value)).toEqual([130, 120, 110, 100]);
+});

--- a/src/plugins/builtin/ticker-detail/financials/model.ts
+++ b/src/plugins/builtin/ticker-detail/financials/model.ts
@@ -348,14 +348,20 @@ export function selectFinancialStatements(
 
   // A balance sheet is a dated snapshot. It needs neither a four-quarter sum
   // nor four reports before the latest position can be compared with year end.
-  const latest = quarterlyStatements.at(-1);
-  if (period === "annual" && statement === "balance" && latest && latest.date > (annualStatements.at(-1)?.date ?? "")) {
-    statements.unshift(latest);
-    const previous = [...quarterlyStatements].reverse().find((candidate) => {
-      const days = (Date.parse(latest.date) - Date.parse(candidate.date)) / 86_400_000;
-      return days >= 350 && days <= 380 && candidate.currency === latest.currency;
-    });
-    if (previous) previousStatementMap.set(latest.date, previous);
+  if (period === "annual" && statement === "balance") {
+    const balanceRows = FINANCIAL_SUB_TABS.find((tab) => tab.key === "balance")!.rows;
+    // Coverage arrives by metric: a newer EPS-only row is not a balance sheet.
+    const latest = quarterlyStatements.findLast((candidate) => (
+      balanceRows.some((row) => hasFinancialRowValue(row, [candidate]))
+    ));
+    if (latest && latest.date > (annualStatements.at(-1)?.date ?? "")) {
+      statements.unshift(latest);
+      const previous = [...quarterlyStatements].reverse().find((candidate) => {
+        const days = (Date.parse(latest.date) - Date.parse(candidate.date)) / 86_400_000;
+        return days >= 350 && days <= 380 && candidate.currency === latest.currency;
+      });
+      if (previous) previousStatementMap.set(latest.date, previous);
+    }
   }
   return { statements, previousStatementMap };
 }

--- a/src/plugins/builtin/ticker-detail/financials/schema.ts
+++ b/src/plugins/builtin/ticker-detail/financials/schema.ts
@@ -376,7 +376,6 @@ export const FINANCIAL_SUB_TABS: FinancialSubTab[] = [
         label: "Liab + Equity",
         id: "balance:liabilities-equity",
         compute: (statement) => {
-          if (statement.totalAssets != null) return statement.totalAssets;
           if (statement.totalLiabilities == null || statement.totalEquityGrossMinorityInterest == null) return undefined;
           return statement.totalLiabilities + statement.totalEquityGrossMinorityInterest;
         },

--- a/src/plugins/builtin/ticker-detail/headless.test.ts
+++ b/src/plugins/builtin/ticker-detail/headless.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/headless";
 import { createTestDataProvider } from "../../../test-support/data-provider";
+import { renderHeadlessPaneText } from "../../../cli/pane-functions/headless";
 import { financialStatementsHeadless, historicalPricesHeadless, quoteComparisonHeadless } from "./headless";
 
 function args(symbols: string[], options: HeadlessPaneLoadArgs["options"] = {}): HeadlessPaneLoadArgs {
@@ -74,6 +75,24 @@ test("quote comparison retains successful exchange-qualified inputs when a peer 
   expect(result.rows).toEqual([{ symbol: "ABC", name: "Company", price: 105, change: 5, changePercent: 5, currency: "USD", marketCap: null, updatedAt: 123 }]);
   expect(result.unavailableSymbols).toEqual(["MISSING"]);
   expect(result.errors).toEqual(["MISSING: No quote"]);
+});
+
+test("quote monitor exports retain FX precision and small changes without altering raw values", async () => {
+  // Retained public EUR/USD quote fields; provider retrieval is not replayed here.
+  const quote = { symbol: "EURUSD=X", name: "EUR/USD", instrumentType: "CURRENCY",
+    price: 1.1602274179458618, change: -0.0010778820541381684,
+    changePercent: -0.09281642425451501, currency: "USD", lastUpdated: 1789162140000 };
+  const ctx = { signal: new AbortController().signal, marketData: createTestDataProvider({ getQuote: async () => quote }) } as HeadlessPaneContext;
+  const input = args([quote.symbol]);
+  const result = await quoteComparisonHeadless.load(input, ctx);
+  expect(result.rows[0]).toMatchObject({ price: quote.price, change: quote.change, instrumentType: "CURRENCY" });
+  const text = renderHeadlessPaneText(quoteComparisonHeadless, result, input, "Quote Monitor");
+  expect(text).toContain("$1.160227");
+  expect(text).toContain("-$0.001078");
+  expect(text).not.toContain("-$0.00 ");
+  const priceColumn = quoteComparisonHeadless.columns!.find(({ key }) => key === "price")!;
+  expect(priceColumn.format!(0.00651236716657877, { instrumentType: "CURRENCY", currency: "USD" })).toBe("$0.006512");
+  expect(priceColumn.format!(null, { currency: "USD" })).toBe("—");
 });
 
 test("historical prices use remembered exchanges and clip and sort the full OHLCV history", async () => {

--- a/src/plugins/builtin/ticker-detail/headless.ts
+++ b/src/plugins/builtin/ticker-detail/headless.ts
@@ -1,8 +1,8 @@
 import { FINANCIAL_VINTAGE_NOTICE } from "../../../utils/financial-statements";
 import type { HeadlessPaneColumn, HeadlessPaneDefinition } from "../../../types/headless";
 import type { TimeRange } from "../../../time-series/range";
-import { formatCurrency, formatNumber, formatPercentRaw } from "../../../utils/format";
-import { formatMarketPrice } from "../../../market-data/market/format";
+import { formatNumber, formatPercentRaw } from "../../../utils/format";
+import { formatMarketPrice, formatMarketPriceWithCurrency } from "../../../market-data/market/format";
 import { pricePointValues, priceHistoryIntegrityNotice } from "../../../utils/price-history-integrity";
 import { buildFinancialTableModel, financialStatementCurrency, financialStatementDateNotice, financialStatementLimitations, formatFinancialHeader } from "./financials/model";
 import { paneSchemas } from "./headless-schema";
@@ -65,6 +65,15 @@ export const financialStatementsHeadless: HeadlessPaneDefinition<"rows"> = {
   },
 };
 
+function quoteAmount(value: unknown, row: Record<string, unknown>, signed = false): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "—";
+  const options = { assetCategory: typeof row.instrumentType === "string" ? row.instrumentType : undefined, minimumFractionDigits: 2 };
+  const amount = typeof row.currency === "string" && row.currency.trim()
+    ? formatMarketPriceWithCurrency(value, row.currency, options)
+    : formatMarketPrice(value, options);
+  return `${signed && value >= 0 ? "+" : ""}${amount}`;
+}
+
 export const quoteComparisonHeadless: HeadlessPaneDefinition<"rows"> = {
   ...paneSchemas["quote-monitor-pane"],
   shape: "rows",
@@ -72,8 +81,8 @@ export const quoteComparisonHeadless: HeadlessPaneDefinition<"rows"> = {
   columns: [
     { key: "symbol", header: "Ticker" },
     { key: "name", header: "Name" },
-    { key: "price", header: "Last", align: "right", format: (value, row) => formatCurrency(Number(value), String(row.currency)) },
-    { key: "change", header: "Change", align: "right", format: (value, row) => `${Number(value) >= 0 ? "+" : ""}${formatCurrency(Number(value), String(row.currency))}` },
+    { key: "price", header: "Last", align: "right", format: (value, row) => quoteAmount(value, row) },
+    { key: "change", header: "Change", align: "right", format: (value, row) => quoteAmount(value, row, true) },
     { key: "changePercent", header: "Change %", align: "right", format: (value) => formatPercentRaw(Number(value)) },
   ],
   async load({ symbols }, ctx) {
@@ -84,6 +93,7 @@ export const quoteComparisonHeadless: HeadlessPaneDefinition<"rows"> = {
     return {
       rows: loaded.entries.map(({ symbol, data: quote }) => ({
         symbol, name: quote.name ?? "", price: quote.price, currency: quote.currency,
+        ...(quote.instrumentType ? { instrumentType: quote.instrumentType } : {}),
         change: quote.change, changePercent: quote.changePercent,
         marketCap: quote.marketCap ?? null, updatedAt: quote.lastUpdated,
       })),

--- a/src/plugins/builtin/ticker-detail/quote-monitor/card.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor/card.tsx
@@ -87,17 +87,18 @@ export function QuoteMonitorCard({
   const priceAttributes = flashDirection ? TextAttributes.DIM : TextAttributes.BOLD;
   const changeAttributes = flashDirection ? TextAttributes.DIM : TextAttributes.NONE;
   const currency = quote?.currency ?? ticker?.metadata.currency ?? "USD";
+  const assetCategory = quote?.instrumentType ?? ticker?.metadata.assetCategory;
   const stacked = width < 31;
   const priceText = display
-    ? formatMarketPriceWithCurrency(display.price, currency, { assetCategory: ticker?.metadata.assetCategory })
+    ? formatMarketPriceWithCurrency(display.price, currency, { assetCategory })
     : "";
   const changePercentText = display ? formatPercentRaw(display.changePercent) : "";
-  const changeValueText = display ? formatSignedMarketPrice(display.change, { assetCategory: ticker?.metadata.assetCategory }) : "";
+  const changeValueText = display ? formatSignedMarketPrice(display.change, { assetCategory }) : "";
   const priceColumnWidth = Math.max(priceText.length, changePercentText.length + changeValueText.length + 1);
   const nameMaxWidth = Math.max(10, width - priceColumnWidth - (nativePaneChrome ? 5 : 3));
   const sparklineRange = resolvePriceSparklineRange(priceHistory, chartPeriod);
   const rangeLabel = sparklineRange
-    ? `${chartPeriod} ${formatMarketPriceWithCurrency(sparklineRange.min, currency, { assetCategory: ticker?.metadata.assetCategory })}-${formatMarketPriceWithCurrency(sparklineRange.max, currency, { assetCategory: ticker?.metadata.assetCategory })}`
+    ? `${chartPeriod} ${formatMarketPriceWithCurrency(sparklineRange.min, currency, { assetCategory })}-${formatMarketPriceWithCurrency(sparklineRange.max, currency, { assetCategory })}`
     : "";
   const sparklineWidth = Math.max(8, width - (nativePaneChrome ? rangeLabel.length + 5 : 2));
   const trend = quoteTrend(display?.change);

--- a/src/plugins/builtin/ticker-detail/quote-monitor/index.test.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor/index.test.tsx
@@ -98,6 +98,7 @@ function makeFinancials(
 }
 
 function createQuoteMonitorHarness(options: {
+  width?: number;
   symbols?: string[];
   financials?: Map<string, TickerFinancials>;
   pinCalls?: PinTickerCall[];
@@ -138,7 +139,7 @@ function createQuoteMonitorHarness(options: {
       pinCalls: options.pinCalls,
       settingsCalls: options.settingsCalls,
     })}>
-      <QuoteMonitorPane paneId="quote-monitor:test" paneType="quote-monitor" focused width={72} height={7} />
+      <QuoteMonitorPane paneId="quote-monitor:test" paneType="quote-monitor" focused width={options.width ?? 72} height={7} />
     </TestPaneProvider>
   );
 }
@@ -170,6 +171,17 @@ async function flushFrames(count: number) {
 }
 
 describe("QuoteMonitorPane", () => {
+  test.each([80, 120])("uses returned FX instrument type when no ticker metadata exists at %s columns", async (width) => {
+    const symbol = "EURUSD=X";
+    const financials = makeFinancials(symbol, 1.1602274179458618, -0.0010778820541381684, -0.09281642425451501, []);
+    financials.quote!.instrumentType = "CURRENCY";
+    await renderHarness(createQuoteMonitorHarness({ width, symbols: [symbol], financials: new Map([[symbol, financials]]) }), { width, height: 7 });
+    await renderOnce();
+    const frame = testSetup!.captureCharFrame();
+    expect(frame).toContain("$1.160227");
+    expect(frame).toContain("-0.001078");
+  });
+
   test("opens a Ticker Research pane on the second card click", async () => {
     const pinCalls: PinTickerCall[] = [];
     await renderHarness(createQuoteMonitorHarness({ pinCalls }), {

--- a/src/plugins/builtin/yield-curve/chart.test.ts
+++ b/src/plugins/builtin/yield-curve/chart.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { buildStaticChartSeries } from "../../../components/chart/static/chart-surface";
+import { buildCompositeChartScene } from "../../../components/chart/composite/scene";
+import { buildYieldCurveChart } from "./chart";
+import { TREASURY_MATURITIES } from "./treasury-data";
+
+test("curve projection preserves maturity distances, including missing tenors", () => {
+  const source = TREASURY_MATURITIES.map(({ maturity, years }, index) => ({
+    maturity, maturityYears: years, yield: 4 + index / 10,
+  }));
+  for (const data of [source, source.filter(({ maturity }) => maturity !== "6M")]) {
+    const chart = buildYieldCurveChart(data, 62);
+    const scene = buildCompositeChartScene(buildStaticChartSeries(chart.points, "line", "green", [], true),
+      [{ id: "main" }], { width: 70, height: 12, rightOffsetRatio: 0 })!;
+    expect(scene.timeScale.kind).toBe("calendar");
+    const projected = scene.panels[0]!.series[0]!.points;
+    for (let index = 0; index < data.length; index++) {
+      expect(projected[index]!.xRatio).toBeCloseTo((data[index]!.maturityYears - 1 / 12) / (30 - 1 / 12), 10);
+      expect(projected[index]!.value).toBe(data[index]!.yield);
+    }
+    expect(chart.formatCursor(0)).toBe("1.0M");
+    expect(chart.formatCursor(1)).toBe("30.0Y");
+  }
+});
+
+test("partial curve ticks stay in range and readable at narrow widths", () => {
+  const source = [{ maturity: "5Y", maturityYears: 5, yield: 4 }, { maturity: "10Y", maturityYears: 10, yield: 4.3 }];
+  const chart = buildYieldCurveChart(source, 20);
+  expect(chart.ticks).toEqual([{ label: "5Y", ratio: 0 }, { label: "10Y", ratio: 1 }]);
+  expect(chart.formatCursor(0.5)).toBe("7.5Y");
+  expect(buildYieldCurveChart([], 20).points).toEqual([]);
+});

--- a/src/plugins/builtin/yield-curve/chart.ts
+++ b/src/plugins/builtin/yield-curve/chart.ts
@@ -1,0 +1,37 @@
+import type { ProjectedChartPoint } from "../../../components/chart/core/data";
+import type { YieldPoint } from "./treasury-data";
+
+const YEAR_MS = 365 * 86_400_000;
+
+/** Encode maturity in the chart's continuous coordinate space, never as calendar labels. */
+export function buildYieldCurveChart(points: readonly YieldPoint[], width: number) {
+  const available = points.filter((point) => point.yield != null && Number.isFinite(point.yield)
+    && Number.isFinite(point.maturityYears) && point.maturityYears > 0)
+    .toSorted((a, b) => a.maturityYears - b.maturityYears);
+  const first = available[0];
+  const last = available.at(-1);
+  const min = first?.maturityYears ?? 0;
+  const span = (last?.maturityYears ?? min) - min;
+  const ratio = (years: number) => span > 0 ? (years - min) / span : 0;
+  const ticks = first && last && first !== last
+    ? [{ label: first.maturity, ratio: 0 }, { label: last.maturity, ratio: 1 }]
+    : [];
+  // Keep the short end dense in the data without piling up overlapping labels.
+  for (const years of [10, 20, 5, 2, 1]) {
+    const x = ratio(years);
+    if (x <= 0 || x >= 1 || ticks.some((tick) => Math.abs(tick.ratio - x) * Math.max(1, width - 1) < 6)) continue;
+    ticks.push({ label: `${years}Y`, ratio: x });
+  }
+  const chartPoints: ProjectedChartPoint[] = available.map((point) => ({
+    date: new Date(point.maturityYears * YEAR_MS),
+    open: point.yield!, high: point.yield!, low: point.yield!, close: point.yield!, volume: 0,
+  }));
+  return {
+    points: chartPoints,
+    ticks: ticks.toSorted((a, b) => a.ratio - b.ratio),
+    formatCursor: (x: number) => {
+      const years = min + Math.max(0, Math.min(1, x)) * span;
+      return years < 1 ? `${(years * 12).toFixed(1)}M` : `${years.toFixed(1)}Y`;
+    },
+  };
+}

--- a/src/plugins/builtin/yield-curve/index.tsx
+++ b/src/plugins/builtin/yield-curve/index.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Button, DataTableView, Notice, PaneStatusBody, StaticChartSurface, TextField, type PaneFooterSegment } from "../../../components";
-import type { ProjectedChartPoint } from "../../../components/chart/core/data";
+import { DataTableView, Notice, PaneStatusBody, StaticChartSurface, TextField, type PaneFooterSegment } from "../../../components";
 import { resolveChartPalette } from "../../../components/chart/core/palette";
 import { useAsyncResource } from "../../../react/async-resource";
 import { useShortcut } from "../../../react/input";
@@ -9,13 +8,13 @@ import { colors } from "../../../theme/colors";
 import type { PaneProps } from "../../../types/plugin";
 import { Box, ScrollBox, Text, type InputRenderable } from "../../../ui";
 import type { PluginModule } from "../plugin-module";
-import { useAutoRefresh, useUpdatedAgo } from "../shared/auto-refresh";
+import { useAutoRefresh } from "../shared/auto-refresh";
 import { usePaneStatusFooter } from "../shared/pane-footer";
 import { yieldCurveHeadless } from "./headless";
+import { buildYieldCurveChart } from "./chart";
 import { completeYieldCurve, loadHistoricalYieldCurve, yieldCurveDate } from "./history";
 import {
   curveAsOf,
-  isInverted,
   loadYieldCurve,
   parseYieldPoints,
   spreadBasisPoints,
@@ -46,6 +45,7 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
   const [dateError, setDateError] = useState<string | null>(null);
   const [editing, setEditing] = useState(false);
   const dateInput = useRef<InputRenderable>(null);
+  useEffect(() => { if (editing) dateInput.current?.focus?.(); }, [editing]);
   useEffect(() => { setDraftDate(requestedDate); }, [requestedDate]);
   const loadCurve = useCallback(async () => ({
     requestedDate,
@@ -58,7 +58,6 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
   const points = data?.requestedDate === requestedDate ? data.points : EMPTY_POINTS;
   const refreshLatest = useCallback(() => { if (!requestedDate) void load(); }, [requestedDate, load]);
   useAutoRefresh(lastUpdated, refreshLatest);
-  const updatedAgo = useUpdatedAgo(points.length ? lastUpdated : null);
   const selectDate = (value: string) => {
     try {
       const nextDate = yieldCurveDate(value);
@@ -80,7 +79,6 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
     if (ev.name === "d") {
       ev.preventDefault();
       setEditing(true);
-      dateInput.current?.focus?.();
     } else if (ev.name === "r") {
       void load();
     } else if (ev.name === "l") {
@@ -88,27 +86,28 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
     }
   });
 
-  const inverted = isInverted(points);
   const bp = spreadBasisPoints(points);
   // Treasury series are daily closes, so which session the curve represents is
   // status the user needs; "updated Xm ago" only says when we last fetched it.
   const asOf = curveAsOf(points);
 
   const yieldStatus = useMemo<PaneFooterSegment[]>(() => [
-      ...(inverted ? [{ id: "inverted", parts: [{ text: "INVERTED", tone: "warning" as const, bold: true }] }] : []),
-      ...(bp != null ? [{ id: "spread", parts: [{ text: `10Y − 2Y ${bp >= 0 ? "+" : ""}${bp}bp`, tone: bp < 0 ? "warning" as const : "muted" as const }] }] : []),
+      ...(bp != null ? [{ id: "spread", parts: [{ text: `10Y−2Y ${bp >= 0 ? "+" : ""}${bp}bp`, tone: bp < 0 ? "warning" as const : "muted" as const }] }] : []),
       ...(asOf ? [{ id: "as-of", parts: [{ text: `as of ${asOf}`, tone: "muted" as const }] }] : []),
-      ...(requestedDate && asOf && requestedDate !== asOf ? [{ id: "requested", parts: [{ text: `requested ${requestedDate} · prior published session`, tone: "muted" as const }] }] : []),
+      ...(requestedDate && requestedDate !== asOf ? [{ id: "requested", parts: [{ text: `requested ${requestedDate}`, tone: "muted" as const }] }] : []),
       ...(!asOf && points.length ? [{ id: "mixed-dates", parts: [{ text: "Mixed or unknown observation dates", tone: "warning" as const }] }] : []),
       ...(points.some((point) => point.yield == null) ? [{ id: "missing", parts: [{ text: "Some tenors unavailable", tone: "warning" as const }] }] : []),
       ...(points.some((point) => point.stale) ? [{ id: "stale", parts: [{ text: "Cached source · refresh failed", tone: "warning" as const }] }] : []),
-      ...(updatedAgo ? [{ id: "updated", parts: [{ text: `updated ${updatedAgo}`, tone: "muted" as const }] }] : []),
-  ], [asOf, bp, inverted, updatedAgo, points, requestedDate]);
+  ], [asOf, bp, points, requestedDate]);
   usePaneStatusFooter({
     registrationId: "yield-curve",
     loading,
     error,
     info: yieldStatus,
+    hints: [
+      { id: "date", key: "d", label: "ate", onPress: () => setEditing(true) },
+      ...(requestedDate ? [{ id: "latest", key: "l", label: "atest", onPress: () => selectDate("") }] : []),
+    ],
   });
 
   const validPoints = asOf ? parseYieldPoints(points) : [];
@@ -118,19 +117,11 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
 
   const palette = resolveChartPalette(colors, "positive");
 
-  // Map yield points to chart points: use epoch + maturityYears*365*86400000 to space them on the x-axis
-  const chartPoints: ProjectedChartPoint[] = validPoints.map((p) => ({
-    date: new Date(p.maturityYears * 365 * 86400000),
-    open: p.yield!,
-    high: p.yield!,
-    low: p.yield!,
-    close: p.yield!,
-    volume: 0,
-  }));
+  const chart = buildYieldCurveChart(validPoints, Math.max(1, chartWidth - 8));
 
   return (
     <Box flexDirection="column" width={width} height={height}>
-      <Box flexDirection="row" paddingX={1} gap={1} alignItems="flex-end" flexShrink={0}>
+      {editing ? <Box flexDirection="row" paddingX={1} flexShrink={0}>
         <TextField label="As-of date" type="date" value={draftDate} width={12}
           placeholder="YYYY-MM-DD" inputRef={dateInput} focused={focused && editing}
           onChange={setDraftDate} onSubmit={selectDate}
@@ -138,12 +129,7 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
           onKeyDown={(event) => {
             if (event.name === "escape") { setEditing(false); dateInput.current?.blur?.(); }
           }} />
-        <Button label="View" onPress={() => selectDate(draftDate)} compact />
-        <Button label="Latest" shortcut="l" onPress={() => selectDate("")} compact />
-        <Button label="Edit date" displayLabel="Date" shortcut="d" compact onPress={() => {
-          setEditing(true); dateInput.current?.focus?.();
-        }} />
-      </Box>
+      </Box> : null}
       {dateError ? <Notice tone="negative">{dateError}</Notice> : null}
       <PaneStatusBody loading={loading && points.length === 0} error={points.length === 0 ? error : null}
         loadingLabel="Loading yield curve..." subject="yield curve">
@@ -151,10 +137,13 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
       <ScrollBox flexGrow={1} scrollY focusable={false}>
         <Box flexDirection="column">
           {/* Chart */}
-          {chartPoints.length >= 2 ? (
+          {chart.points.length >= 2 ? (
             <Box flexDirection="column" paddingX={1} marginTop={1}>
               <StaticChartSurface
-                points={chartPoints}
+                points={chart.points}
+                calendarSpaced
+                xAxisTicks={chart.ticks}
+                formatXAxisCursorValue={chart.formatCursor}
                 width={chartWidth}
                 height={chartHeight}
                 mode="line"

--- a/src/plugins/builtin/yield-curve/pane.test.tsx
+++ b/src/plugins/builtin/yield-curve/pane.test.tsx
@@ -1,18 +1,28 @@
 import { afterEach, expect, spyOn, test } from "bun:test";
-import { act, useReducer } from "react";
+import { act, useEffect, useReducer } from "react";
+import { RemoteUiRegistryProvider, useRemoteUiRegistry, type RemoteUiRegistry } from "../../../remote/semantic-tree";
 import { apiClient } from "../../../api-client";
-import { emitKeypress, testRender } from "../../../renderers/opentui/test-utils";
+import { createTestControls, emitKeypress, testRender } from "../../../renderers/opentui/test-utils";
 import { AppContext, PaneInstanceProvider, appReducer, createInitialState } from "../../../state/app/context";
 import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
 import { cloneLayout, createDefaultConfig } from "../../../types/config";
 import { PluginRenderProvider } from "../../runtime";
 import { YieldCurvePane } from "./index";
 import { TREASURY_MATURITIES } from "./treasury-data";
+import { PaneFooterProvider, PaneFooterBar } from "../../../components/layout/pane/footer";
+import { Box } from "../../../ui";
 
 const id = "yield-curve:test";
 let setup: Awaited<ReturnType<typeof testRender>> | undefined;
 let latestSpy: ReturnType<typeof spyOn> | undefined;
 let historySpy: ReturnType<typeof spyOn> | undefined;
+let registry: RemoteUiRegistry | null = null;
+
+function RegistryProbe() {
+  const value = useRemoteUiRegistry();
+  useEffect(() => { registry = value; }, [value]);
+  return null;
+}
 
 function Harness() {
   const config = createDefaultConfig("/tmp/gloom-curve-test");
@@ -23,7 +33,10 @@ function Harness() {
   const [state, dispatch] = useReducer(appReducer, initial);
   return <AppContext value={{state, dispatch}}><PaneInstanceProvider paneId={id}>
     <PluginRenderProvider pluginId="macro" runtime={createTestPluginRuntime()}>
-      <YieldCurvePane paneId={id} paneType="yield-curve" focused width={70} height={30} />
+      <PaneFooterProvider>{(footer) => <Box width={70} height={30} flexDirection="column">
+        <YieldCurvePane paneId={id} paneType="yield-curve" focused width={70} height={29} />
+        <PaneFooterBar footer={footer} focused width={70} />
+      </Box>}</PaneFooterProvider>
     </PluginRenderProvider>
   </PaneInstanceProvider></AppContext>;
 }
@@ -35,7 +48,20 @@ async function frame() {
 afterEach(async () => {
   if (setup) await act(async () => { setup!.renderer.destroy(); });
   setup = undefined;
+  registry = null;
   latestSpy?.mockRestore(); historySpy?.mockRestore();
+});
+
+test("Treasury curve axis and cursor use maturity rather than synthetic calendar dates", async () => {
+  latestSpy = spyOn(apiClient, "getCloudYieldCurve").mockResolvedValue(TREASURY_MATURITIES.map(({ maturity, years }, index) => ({ maturity, maturityYears: years, yield: 4 + index / 10, asOf: "2026-09-10" })));
+  await act(async () => { setup = await testRender(<RemoteUiRegistryProvider><RegistryProbe /><Harness /></RemoteUiRegistryProvider>, { width: 70, height: 30 }); });
+  await frame(); await frame();
+  expect(setup!.captureCharFrame()).toMatch(/1M.*5Y.*10Y.*20Y.*30Y/);
+  const chart = registry!.snapshot().find((node) => node.metadata?.kind === "static-chart")!;
+  await act(async () => { await registry!.invoke(chart.id, "moveCursor", { x: 30, y: 4 }); });
+  await frame(); await frame();
+  expect(setup!.captureCharFrame()).toMatch(/\d+\.\dY/);
+  expect(setup!.captureCharFrame()).not.toMatch(/19[789]\d/);
 });
 
 test("date submission hides the previous curve while pending and keeps controls available after failure", async () => {
@@ -56,9 +82,12 @@ test("date submission hides the previous curve while pending and keeps controls 
   await act(async () => { rejectHistory(new Error("offline")); });
   await frame();
   expect(setup!.captureCharFrame()).toContain("No Treasury observations");
+  const controls = createTestControls(() => setup!);
+  await act(async () => { await controls.clickFrameText("[d]ate"); });
+  await frame();
   expect(setup!.captureCharFrame()).toContain("As-of date");
-  expect(setup!.captureCharFrame()).toContain("Latest");
-  await emitKeypress(setup!, { name: "l" });
+  await emitKeypress(setup!, { name: "escape" });
+  await act(async () => { await controls.clickFrameText("[l]atest"); });
   await frame();
   expect(setup!.captureCharFrame()).toContain("2026-09-08");
 });


### PR DESCRIPTION
Research workflows exposed incorrect FX conversions, incomplete financial snapshots, stale valuation inputs, and misleading Treasury chart geometry. This fixes those paths and reduces recurring UI text.

- **Financials:** use the newest quarter with actual balance-sheet coverage; do not manufacture liabilities plus equity by copying assets.
- **FX / Quote Monitor:** convert into the configured base currency through both USD legs and preserve FX price/change precision using the returned instrument type.
- **Options:** keep invalid bars and duplicate observations from producing misleading HV30; explicitly stale underlying quotes cannot supply Greeks, ATM selection, or calculator seeds.
- **Relative valuation:** exclude stale quote-derived comparison values, retain the rejected observation and independently sourced fundamentals with their provenance, and mark affected exports incomplete.
- **Treasury / Credit:** preserve elapsed maturity spacing and maturity cursor labels; show each credit row's date when sources differ. Date actions use the existing footer, and recurring methodology lives in docs.

Validation includes focused regressions and in-process component replays of captured public financial, FX, Treasury, and FRED credit responses. Treasury replays cover current data, a weekend resolving to the prior published session, and March 2020. Options payoff/model invariants are synthetic, not live chain or execution validation. Final local validation at `1e8c0341`: **3,183 tests / 13,035 assertions pass**, all six runtime TypeScript projects pass, and plugin-manifest/proxy-host generation checks pass. CI verifies the PR against the current base before merge.

Fresh browser interaction was unavailable because automatic approval review rejected opening a tab; native tmux access was denied. Those paths were not retried through alternate routes. In-process OpenTUI coverage and build checks do not establish production browser/native workflow coverage.

No GitHub release or version change. The broader investor-persona sweep remains active.
