### PR TITLE
Show quote failures and remove repeated research UI

### DIFF
--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -12,6 +12,8 @@ Daily, weekly, and monthly comparisons use shared calendar dates, with each mark
 
 Correlation and relationship views calculate close-to-close returns between shared observations. Missing dates are not filled to manufacture a sample. Returns use local prices without currency conversion; different exchanges can close at different times. Correlation requires enough shared returns and nonzero variance.
 
+Relationship graph controls stay in the footer: `t` cycles the time range, `p` cycles the rolling observation window, `c` toggles correlation, and `f` toggles the fit line. Each action is clickable and shows its current state. In narrow panes, `+` means enabled and `−` means disabled.
+
 Contradictory OHLC bars are unavailable rather than silently repaired. Charts leave gaps and dependent risk calculations can be unavailable. These are current data problems and remain visible in the terminal.
 
 Chart controls: select ranges and intervals above the plot; click a legend entry to hide or restore a series; use **+ add series** to add one. The existing footer offers **Series**, **Indicators**, **Formulas**, and **Share**, also available with `s`, `i`, `f`, and `y`. `t` opens the interval picker. Sharing publishes a chart snapshot; pane sharing is available from the pane menu.

--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -34,7 +34,7 @@ Bank capital metrics and REIT FFO/AFFO depend on source coverage. Operating cash
 
 GC plots constant-maturity Treasury yields against elapsed maturity, with month/year axis and cursor labels. The table retains each tenor's published observation date. The 10Y−2Y spread is measured in basis points; a negative value indicates inversion. Missing tenors remain unavailable, and a curve requires matching dates.
 
-Use the existing Date footer action (`d`) to enter an as-of date, then Enter to submit. Latest (`l`) returns to the latest published curve. A holiday or weekend request uses the latest preceding published session within the lookup window; the requested date and observation date remain distinct. Refresh time is not the observation date.
+Use the existing Date footer action (`d`) to enter an as-of date, then Enter or View to submit. Latest (`l`) returns to the latest published curve. A holiday or weekend request uses the latest preceding published session within the lookup window; the requested date and observation date remain distinct. Refresh time is not the observation date.
 
 ## Portfolio analytics
 

--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -42,7 +42,7 @@ P&L for manual portfolios covers current holdings. Manual portfolios have no cas
 
 Sector weights use gross position values and exclude cash. Fund constituents and ETF overlap are not available; funds are grouped separately. Missing position prices or FX prevent complete weights.
 
-Sharpe and beta are estimates for a basket of current holdings and weights, rather than a reconstruction of historical account performance. They require usable price histories; a contradictory holding history suppresses the basket estimates. An invalid benchmark history suppresses beta independently of Sharpe.
+Sharpe and beta are estimates for a basket of current holdings and weights, rather than a reconstruction of historical account performance. They use price returns and exclude cash, fees, distributions and historical trades. Sharpe assumes a fixed 5% annual risk-free rate and 252 trading sessions per year; beta uses SPY as the benchmark. They require usable price histories; a contradictory holding history suppresses the basket estimates. An invalid benchmark history suppresses beta independently of Sharpe.
 
 Broker account-value history includes deposits and withdrawals. Investment returns require cash-flow adjustments. Broker-reported return series may not specify their calculation method. Currency values and percentage returns retain distinct axis labels; missing observations and cached data remain identified in the UI.
 

--- a/src/plugins/builtin/analytics/pane-model.test.ts
+++ b/src/plugins/builtin/analytics/pane-model.test.ts
@@ -138,6 +138,18 @@ test("does not publish portfolio risk from just the valued portion when FX is mi
   expect(leveraged.unsupportedReason).toContain("Leveraged account");
 
   const supported = buildAnalyticsRiskRows({ ...buildPortfolioReturnSeries(input), sharpe: 2, beta: 1 });
-  expect(supported.every((row) => row.label.startsWith("Est.") && row.detail?.includes("Current weights"))).toBe(true);
-  expect(supported[0]!.detail).toContain("5% Rf, 252 sessions");
+  expect(supported.map((row) => row.value)).toEqual(["2.00", "1.00"]);
+});
+
+
+test("risk row detail reflects partial or unavailable inputs while retaining valid zero estimates", () => {
+  const healthy = buildAnalyticsRiskRows({ sharpe: 0, beta: 0 });
+  expect(healthy.map((row) => [row.label, row.value, row.detail])).toEqual([
+    ["Est. Sharpe", "0.00", undefined], ["Est. Beta (SPY)", "0.00", undefined],
+  ]);
+  const partial = buildAnalyticsRiskRows({ sharpe: 0, beta: null, coverage: .7, missingCount: 2 });
+  expect(partial[0]).toMatchObject({ value: "0.00", detail: "Partial: +70.00% of value, 2 holdings pending" });
+  expect(partial[1]).toMatchObject({ value: "—", detail: "Insufficient history for basket estimate" });
+  const unavailable = buildAnalyticsRiskRows({ sharpe: 0, beta: 0, coverage: .7, missingCount: 2, unvaluedCount: 1 });
+  expect(unavailable.every((row) => row.value === "—" && row.detail?.includes("check prices and FX"))).toBe(true);
 });

--- a/src/plugins/builtin/analytics/pane-model.ts
+++ b/src/plugins/builtin/analytics/pane-model.ts
@@ -342,15 +342,15 @@ export function buildAnalyticsRiskRows({
     : unsupportedReason;
   const partial = formatRiskCoverage(coverage, missingCount);
   return [
-    { id: "sharpe", label: "Est. Sharpe", value: sharpe, method: "Current weights; price returns; 5% Rf, 252 sessions" },
-    { id: "beta", label: "Est. Beta (SPY)", value: beta, method: "Current weights; excludes cash, fees and trades" },
+    { id: "sharpe", label: "Est. Sharpe", value: sharpe },
+    { id: "beta", label: "Est. Beta (SPY)", value: beta },
   ].map((row) => {
     const reason = unavailable ?? (row.id === "beta" && benchmarkIntegrity ? "SPY benchmark: inconsistent OHLC history" : null);
     return {
       id: row.id,
       label: row.label,
       value: reason ? "—" : formatNumber(row.value ?? undefined, 2),
-      detail: reason ?? (row.value == null ? "Insufficient history for basket estimate" : `${row.method}${partial ? `; partial: ${partial}` : ""}`),
+      detail: reason ?? (row.value == null ? "Insufficient history for basket estimate" : partial ? `Partial: ${partial}` : undefined),
       color: colors.textMuted,
     };
   });

--- a/src/plugins/builtin/correlation/relationship/controls.tsx
+++ b/src/plugins/builtin/correlation/relationship/controls.tsx
@@ -1,6 +1,5 @@
 import { Box, Text } from "../../../../ui";
 import { colors } from "../../../../theme/colors";
-import { Checkbox } from "../../../../components/ui/checkbox";
 
 export function RelationshipMetricsTable({
   rows,
@@ -26,19 +25,5 @@ export function RelationshipMetricsTable({
         </Box>
       ))}
     </Box>
-  );
-}
-
-export function RelationshipToggle({
-  checked,
-  label,
-  onPress,
-}: {
-  checked: boolean;
-  label: string;
-  onPress: () => void;
-}) {
-  return (
-    <Checkbox label={label} checked={checked} width={label.length + 6} onChange={onPress} />
   );
 }

--- a/src/plugins/builtin/correlation/relationship/pane.tsx
+++ b/src/plugins/builtin/correlation/relationship/pane.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Button, PaneStatusBody, usePaneFooter } from "../../../../components";
+import { PaneStatusBody, usePaneFooter } from "../../../../components";
 import { resolveChartPalette } from "../../../../components/chart/core/palette";
 import { StaticMultiLineChartSurface, StaticScatterChartSurface } from "../../../../components/chart/static";
 import { useShortcut, type KeyEventLike } from "../../../../react/input";
@@ -11,7 +11,7 @@ import { Box, Text } from "../../../../ui";
 import { formatNumber } from "../../../../utils/format";
 import { usePluginPaneState } from "../../../runtime";
 import { formatDateTime, useBoundTicker } from "../../shared/ticker-request";
-import { RelationshipMetricsTable, RelationshipToggle } from "./controls";
+import { RelationshipMetricsTable } from "./controls";
 import { useRelationshipHistories } from "./history";
 import {
   DEFAULT_RELATIONSHIP_CORRELATION_WINDOW,
@@ -97,7 +97,7 @@ export function RelationshipGraphPane({ focused, width, height }: PaneProps) {
   const chartWidth = Math.max(20, width - 2);
   // Panels are allocated in priority order out of the rows that actually exist, so
   // a short pane drops the lowest-priority chart instead of clipping every axis.
-  const headerRows = 2;
+  const headerRows = 1;
   const availableChartRows = Math.max(0, height - headerRows);
   const railWidth = chartWidth >= 68 ? Math.min(34, Math.floor(chartWidth * 0.3)) : 0;
   const statsBelowRows = railWidth === 0 ? 1 : 0;
@@ -218,19 +218,18 @@ export function RelationshipGraphPane({ focused, width, height }: PaneProps) {
   });
 
   usePaneFooter("relationship-graph", () => ({
-    info: [
-      { id: "summary", parts: [{ text: footerSummary, tone: "muted" as const }] },
-      ...(loading ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }] : []),
-      ...(error ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }] : []),
-      ...(!loading && analysis && !analysis.unavailableReason && analysis.returns.length < correlationWindow
-        ? [{ id: "correlation-history", parts: [{ text: `Correlation needs ${correlationWindow} shared returns; ${analysis.returns.length} available`, tone: "warning" as const }] }]
-        : []),
-    ],
+    info: error
+      ? [{ id: "error", parts: [{ text: error, tone: "warning" as const }] }]
+      : loading
+        ? [{ id: "loading", parts: [{ text: "loading", tone: "muted" as const }] }]
+        : analysis && !analysis.unavailableReason && analysis.returns.length < correlationWindow
+          ? [{ id: "correlation-history", parts: [{ text: `Correlation needs ${correlationWindow} shared returns; ${analysis.returns.length} available`, tone: "warning" as const }] }]
+          : [{ id: "summary", parts: [{ text: footerSummary, tone: "muted" as const }] }],
     hints: [
-      { id: "range", key: "t", label: "ime range", onPress: cycleRange },
-      { id: "window", key: "p", label: "eriod", onPress: cycleWindow },
-      { id: "correlation", key: "c", label: "orr", onPress: toggleCorrelation },
-      { id: "regression", key: "f", label: "it line", onPress: toggleRegression },
+      { id: "range", key: "t", label: width < 80 ? range : `ime ${range}`, onPress: cycleRange },
+      { id: "window", key: "p", label: width < 80 ? `${correlationWindow}obs` : `eriod ${correlationWindow} obs`, onPress: cycleWindow },
+      { id: "correlation", key: "c", label: width < 60 ? `orr${showCorrelation ? "+" : "−"}` : `orr ${showCorrelation ? "on" : "off"}`, onPress: toggleCorrelation },
+      { id: "regression", key: "f", label: width < 60 ? `it${showRegression ? "+" : "−"}` : `it ${showRegression ? "on" : "off"}`, onPress: toggleRegression },
     ],
   }), [
     cycleRange,
@@ -240,6 +239,10 @@ export function RelationshipGraphPane({ focused, width, height }: PaneProps) {
     error,
     footerSummary,
     loading,
+    range,
+    showCorrelation,
+    showRegression,
+    width,
     toggleCorrelation,
     toggleRegression,
   ]);
@@ -264,12 +267,6 @@ export function RelationshipGraphPane({ focused, width, height }: PaneProps) {
       overflow="hidden"
       paddingX={1}
     >
-      <Box height={1} flexDirection="row" gap={2}>
-        <RelationshipToggle checked={showCorrelation} label="Correlation" onPress={toggleCorrelation} />
-        <RelationshipToggle checked={showRegression} label="Fit line" onPress={toggleRegression} />
-        <Button label={`Range ${range}`} variant="ghost" onPress={cycleRange} />
-        <Button label={`Window ${correlationWindow} obs`} variant="ghost" onPress={cycleWindow} />
-      </Box>
       <Box height={1} flexDirection="row" gap={2}>
         {priceSeries.map((series) => (
           <Box key={series.id} flexDirection="row" gap={1}>

--- a/src/plugins/builtin/portfolio-list/cli/render.test.ts
+++ b/src/plugins/builtin/portfolio-list/cli/render.test.ts
@@ -59,7 +59,8 @@ test("portfolio JSON and CSV exports preserve signed positions, currencies and u
   const json = JSON.parse(serializeCliResult(result!, { ...DEFAULT_CLI_OPTIONS, format: "json" }));
   expect(json.data[0]).toMatchObject({ symbol: "AAPL", shares: -10, costBasis: -1000, marketValue: -900, unrealizedPnl: 100, positionCurrency: "USD", baseCurrency: "USD" });
   expect(json.data[1]).toMatchObject({ symbol: "MISSING", marketValue: null, unrealizedPnl: null });
-  expect(json.metadata).toMatchObject({ totalUnrealizedPnl: null, complete: false, unavailableSymbols: ["MISSING"] });
+  expect(json.metadata).toMatchObject({ totalUnrealizedPnl: null, complete: false, unavailableSymbols: ["MISSING"],
+    accountingBasis: expect.any(String), manualAccounting: expect.any(String) });
   const csv = serializeCliResult(result!, { ...DEFAULT_CLI_OPTIONS, format: "csv" });
   expect(csv).toContain("unrealizedPnl,baseCurrency");
   expect(csv).toContain("-1000,-900,100,USD");

--- a/src/plugins/builtin/portfolio-list/cli/render.ts
+++ b/src/plugins/builtin/portfolio-list/cli/render.ts
@@ -209,8 +209,6 @@ async function showCollectionWithMarketData(
     ));
     console.log("");
     console.log(renderStat("Total P&L", unavailablePnl.size > 0 ? "—" : colorBySign(formatSignedCurrency(totalPnl, baseCurrency), totalPnl)));
-    console.log(cliStyles.muted(accountingBasis));
-    if (manualAccounting) console.log(cliStyles.muted(manualAccounting));
     if (unavailablePnl.size > 0) console.log(cliStyles.muted(`P&L unavailable for ${[...unavailablePnl].join(", ")}: a quote, broker value or currency conversion is missing.`));
   } else {
     const rows: string[][] = [];

--- a/src/plugins/builtin/ticker-detail/financials/model.ts
+++ b/src/plugins/builtin/ticker-detail/financials/model.ts
@@ -156,7 +156,7 @@ export function financialStatementLimitations(financials: TickerFinancials | nul
     return typeof value === "number" && Number.isFinite(value);
   }));
   if (/\breit\b/i.test(industry) && !hasMetric(["fundsFromOperations", "adjustedFundsFromOperations", "ffo", "affo"])) {
-    return ["FFO/AFFO are unavailable. Operating cash flow is not a substitute for these REIT measures."];
+    return ["FFO/AFFO are unavailable."];
   }
   if (/\bbanks?\b/i.test(industry) && !hasMetric(["commonEquityTier1Ratio", "cet1Ratio", "riskWeightedAssets"])) {
     return ["Bank capital measures, including CET1 and risk-weighted assets, are unavailable."];

--- a/src/plugins/builtin/ticker-detail/quote-monitor/card.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor/card.tsx
@@ -9,6 +9,7 @@ import { colors, priceColor } from "../../../../theme/colors";
 import { formatPercentRaw } from "../../../../utils/format";
 import { formatMarketPriceWithCurrency, formatSignedMarketPrice } from "../../../../market-data/market/format";
 import { getActiveQuoteDisplay } from "../../../../market-data/market/status";
+import { isQuoteStaleForCurrentSession } from "../../../../market-data/quotes/freshness";
 import { useQuoteFlashDirection } from "../../../../components/quote-flash";
 import {
   PriceAreaSparklineBackground,
@@ -29,15 +30,17 @@ const UNKNOWN_SYMBOL_REASONS = new Set(["NOT_FOUND", "BAD_MAPPING"]);
 interface QuoteStatus {
   failed: boolean;
   text: string;
+  stale?: boolean;
 }
 
-function resolveQuoteStatus(entry: QueryEntry<Quote> | null, symbol: string): QuoteStatus {
+function resolveQuoteStatus(entry: QueryEntry<Quote> | null, symbol: string, quote: Quote | null | undefined): QuoteStatus {
   const error = entry?.error;
   if (error) {
     return UNKNOWN_SYMBOL_REASONS.has(error.reasonCode)
       ? { failed: true, text: `${symbol} not recognized` }
       : { failed: true, text: error.message || "Quote unavailable" };
   }
+  if (isQuoteStaleForCurrentSession(quote)) return { failed: true, text: "Stale quote", stale: true };
   if (entry?.phase === "ready") return { failed: false, text: "No quote data" };
   return { failed: false, text: "Loading quote..." };
 }
@@ -81,7 +84,7 @@ export function QuoteMonitorCard({
   );
   const flashDirection = useQuoteFlashDirection(flashFinancials, valueFlashingEnabled);
   const display = getActiveQuoteDisplay(quote);
-  const quoteStatus = resolveQuoteStatus(quoteEntry, symbol);
+  const quoteStatus = resolveQuoteStatus(quoteEntry, symbol, quote);
   const quoteFailed = quoteStatus.failed && !!display;
   const changeColor = quoteFailed ? colors.textDim : priceColor(display?.change ?? 0);
   const priceAttributes = flashDirection ? TextAttributes.DIM : TextAttributes.BOLD;
@@ -89,6 +92,7 @@ export function QuoteMonitorCard({
   const currency = quote?.currency ?? ticker?.metadata.currency ?? "USD";
   const assetCategory = quote?.instrumentType ?? ticker?.metadata.assetCategory;
   const stacked = width < 31;
+  const compactQuoteFailure = quoteFailed && stacked && height <= 3;
   const priceText = display
     ? formatMarketPriceWithCurrency(display.price, currency, { assetCategory })
     : "";
@@ -103,6 +107,7 @@ export function QuoteMonitorCard({
   const sparklineWidth = Math.max(8, width - (nativePaneChrome ? rangeLabel.length + 5 : 2));
   const trend = quoteTrend(display?.change);
   const terminalSparklineHeight = !nativePaneChrome && !stacked && height >= 4 ? 2 : 1;
+  const showTerminalSparkline = !quoteFailed || height >= (stacked ? 3 : 2) + 1 + terminalSparklineHeight;
   const desktopPriceStyle = nativePaneChrome
     ? {
         fontSize: "22px",
@@ -272,7 +277,7 @@ export function QuoteMonitorCard({
               </Text>
               <Box flexDirection="column">
                 <Text attributes={priceAttributes} fg={changeColor} style={desktopPriceStyle}>
-                  {priceText}
+                  {compactQuoteFailure ? `${priceText} · ${quoteStatus.stale ? "STALE" : "ERROR"}` : priceText}
                 </Text>
                 <Box flexDirection="row" gap={1}>
                   <Text fg={changeColor} attributes={changeAttributes} style={desktopChangeStyle}>{changePercentText}</Text>
@@ -323,7 +328,10 @@ export function QuoteMonitorCard({
             </Box>
           )}
 
-          <Box height={terminalSparklineHeight} flexDirection="row" alignItems="center" gap={1}>
+          {quoteFailed && !compactQuoteFailure && (
+            <Box height={1} overflow="hidden"><Text fg={colors.negative}>{quoteStatus.text}</Text></Box>
+          )}
+          {showTerminalSparkline && <Box height={terminalSparklineHeight} flexDirection="row" alignItems="center" gap={1}>
             <PriceSparkline
               priceHistory={priceHistory}
               width={sparklineWidth}
@@ -337,7 +345,7 @@ export function QuoteMonitorCard({
                 {rangeLabel}
               </Text>
             )}
-          </Box>
+          </Box>}
         </Box>
       )}
     </Box>

--- a/src/plugins/builtin/ticker-detail/quote-monitor/retained-status.test.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor/retained-status.test.tsx
@@ -1,0 +1,119 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../../../../renderers/opentui/test-utils";
+import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../../../market-data/coordinator";
+import { createTestDataProvider } from "../../../../test-support/data-provider";
+import { createTestPluginRuntime } from "../../../../test-support/plugin-runtime";
+import { TestPaneProvider, createTestPaneConfig } from "../../../../test-support/pane";
+import { createInitialState } from "../../../../state/app/context";
+import type { Quote, TickerFinancials } from "../../../../types/financials";
+import { QuoteMonitorPane } from "./index";
+
+let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+let coordinator: MarketDataCoordinator | undefined;
+const symbol = "EURUSD=X";
+const instrument = { symbol, exchange: "" };
+
+async function frame() {
+  for (let i = 0; i < 3; i++) await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await setup!.renderOnce();
+  });
+  return setup!.captureCharFrame();
+}
+
+afterEach(async () => {
+  if (setup) await act(async () => { setup!.renderer.destroy(); });
+  setup = undefined;
+  coordinator?.destroy();
+  coordinator = undefined;
+  setSharedMarketDataCoordinator(null);
+});
+
+async function render(width: number, getQuote: () => Promise<Quote>, cached?: Quote, height = 7, targetSymbol = symbol) {
+  const provider = createTestDataProvider({ getQuote });
+  coordinator = new MarketDataCoordinator(provider);
+  setSharedMarketDataCoordinator(coordinator);
+  const config = createTestPaneConfig("/tmp/gloom-qm-retained-status", {
+    instanceId: "qm:test", paneId: "quote-monitor", binding: { kind: "none" },
+    settings: { symbols: [targetSymbol], liveStreaming: false },
+  });
+  const state = createInitialState(config);
+  if (cached) state.financials.set(targetSymbol, {
+    quote: cached, annualStatements: [], quarterlyStatements: [], priceHistory: [],
+  } satisfies TickerFinancials);
+  await act(async () => {
+    setup = await testRender(<TestPaneProvider state={state} paneId="qm:test" pluginId="ticker-research"
+      runtime={createTestPluginRuntime({ getMarketData: () => provider })}>
+      <QuoteMonitorPane paneId="qm:test" paneType="quote-monitor" focused width={width} height={height} />
+    </TestPaneProvider>, { width, height });
+  });
+  return frame();
+}
+
+function quote(price = 1.160227): Quote {
+  return { symbol, price, currency: "USD", instrumentType: "CURRENCY", change: -0.001078,
+    changePercent: -0.09, lastUpdated: Date.now() };
+}
+
+test.each([80, 120])("retained provider quote exposes refresh failure and clears it on recovery at %i columns", async (width) => {
+  let fail = false;
+  let price = 1.160227;
+  let calls = 0;
+  const initial = await render(width, async () => {
+    calls++;
+    if (fail) throw new Error("FX feed disconnected");
+    return quote(price);
+  });
+  expect(calls).toBeGreaterThan(0);
+  expect(initial).toContain("$1.160227");
+  expect(initial).not.toContain("disconnected");
+
+  fail = true;
+  await act(async () => { await coordinator!.loadQuotesBatch([instrument], { forceRefresh: true }); });
+  const entry = coordinator!.getQuoteEntry(instrument);
+  expect(entry.error?.message).toBe("FX feed disconnected");
+  expect(entry.lastGoodData?.price).toBe(1.160227);
+  const failed = await frame();
+  expect(failed).toContain("$1.160227");
+  expect(failed).toContain("FX feed disconnected");
+
+  fail = false;
+  price = 1.170227;
+  await act(async () => { await coordinator!.loadQuotesBatch([instrument], { forceRefresh: true }); });
+  const recovered = await frame();
+  expect(recovered).toContain("$1.170227");
+  expect(recovered).not.toContain("disconnected");
+  expect(coordinator!.getQuoteEntry(instrument).error).toBeNull();
+});
+
+test("explicit stale cached quote is identified while its provider refresh is pending", async () => {
+  let complete!: (value: Quote) => void;
+  const pending = new Promise<Quote>((resolve) => { complete = resolve; });
+  const retained = await render(80, () => pending, { ...quote(), stale: true });
+  expect(retained).toContain("$1.160227");
+  expect(retained).toContain("Stale quote");
+  await act(async () => { complete(quote(1.170227)); });
+  const recovered = await frame();
+  expect(recovered).toContain("$1.170227");
+  expect(recovered).not.toContain("Stale quote");
+});
+
+// Dense boards can allocate only three rows to a narrow card. The failure must
+// remain visible there without pushing the retained quote off the card.
+test.each(["error", "stale"] as const)("compact retained card identifies %s without wrapping a long symbol", async (kind) => {
+  const longSymbol = "LRCX260918C01200000";
+  const optionQuote: Quote = { ...quote(14.23), symbol: longSymbol, instrumentType: "OPTION", change: -0.07 };
+  let finish!: (value: Quote) => void;
+  const pending = new Promise<Quote>((resolve) => { finish = resolve; });
+  const result = await render(30, () => kind === "error" ? Promise.reject(new Error("FX feed disconnected")) : pending,
+    { ...optionQuote, stale: kind === "stale" }, 3, longSymbol);
+  expect(result).toContain(longSymbol);
+  expect(result).toContain("-0.07");
+  expect(result).toContain("$14.23");
+  expect(result).toContain(kind === "stale" ? "STALE" : "ERROR");
+  if (kind === "stale") {
+    await act(async () => { finish({ ...optionQuote, price: 14.5, lastUpdated: Date.now() }); });
+    expect(await frame()).not.toContain("STALE");
+  }
+});

--- a/src/plugins/builtin/yield-curve/index.tsx
+++ b/src/plugins/builtin/yield-curve/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { DataTableView, Notice, PaneStatusBody, StaticChartSurface, TextField, type PaneFooterSegment } from "../../../components";
+import { Button, DataTableView, Notice, PaneStatusBody, StaticChartSurface, TextField, type PaneFooterSegment } from "../../../components";
 import { resolveChartPalette } from "../../../components/chart/core/palette";
 import { useAsyncResource } from "../../../react/async-resource";
 import { useShortcut } from "../../../react/input";
@@ -121,14 +121,15 @@ export function YieldCurvePane({ focused, width, height }: PaneProps) {
 
   return (
     <Box flexDirection="column" width={width} height={height}>
-      {editing ? <Box flexDirection="row" paddingX={1} flexShrink={0}>
+      {editing ? <Box flexDirection="row" paddingX={1} gap={1} alignItems="flex-end" flexShrink={0}>
         <TextField label="As-of date" type="date" value={draftDate} width={12}
           placeholder="YYYY-MM-DD" inputRef={dateInput} focused={focused && editing}
           onChange={setDraftDate} onSubmit={selectDate}
-          onMouseDown={() => setEditing(true)} onBlur={() => setEditing(false)}
+          onMouseDown={() => setEditing(true)}
           onKeyDown={(event) => {
             if (event.name === "escape") { setEditing(false); dateInput.current?.blur?.(); }
           }} />
+        <Button label="View" onPress={() => selectDate(draftDate)} compact />
       </Box> : null}
       {dateError ? <Notice tone="negative">{dateError}</Notice> : null}
       <PaneStatusBody loading={loading && points.length === 0} error={points.length === 0 ? error : null}

--- a/src/plugins/builtin/yield-curve/pane.test.tsx
+++ b/src/plugins/builtin/yield-curve/pane.test.tsx
@@ -91,3 +91,24 @@ test("date submission hides the previous curve while pending and keeps controls 
   await frame();
   expect(setup!.captureCharFrame()).toContain("2026-09-08");
 });
+
+test("the transient date editor can be submitted with the mouse", async () => {
+  latestSpy = spyOn(apiClient, "getCloudYieldCurve").mockResolvedValue(TREASURY_MATURITIES.map(({ maturity, years }) => ({ maturity, maturityYears: years, yield: 4.5, asOf: "2026-09-08" })));
+  historySpy = spyOn(apiClient, "getCloudFredSeries").mockResolvedValue({
+    observations: [{ date: "2024-03-01", value: 4.2 }],
+    info: { id: "DGS10", title: "Treasury yield", units: "Percent", frequency: "Daily", seasonalAdjustment: "", source: "FRED", notes: "" },
+  });
+  await act(async () => { setup = await testRender(<Harness />, { width: 70, height: 30 }); });
+  await frame(); await frame();
+  const controls = createTestControls(() => setup!);
+  await act(async () => { await controls.clickFrameText("[d]ate"); });
+  await frame();
+  await act(async () => { await setup!.mockInput.typeText("2024-03-02"); });
+  await frame();
+  await act(async () => { await controls.clickFrameText("View"); });
+  await frame(); await frame();
+  expect(historySpy).toHaveBeenCalledTimes(10);
+  expect(setup!.captureCharFrame()).toContain("2024-03-01");
+  expect(setup!.captureCharFrame()).toContain("requested 2024-03-02");
+  expect(setup!.captureCharFrame()).not.toContain("As-of date");
+});


### PR DESCRIPTION
Quote Monitor could retain a price after a failed refresh without displaying its failure in terminal cards. Research panes also repeated methodology and controls on every use. This makes current quote failures visible and reduces recurring UI clutter.

- Show retained quote errors/stale status, including compact option cards; clear the status on recovery. Valid same-session cache fallback stays usable.
- Move healthy portfolio risk-method details and repeated CLI accounting prose into docs, retaining partial coverage/errors and structured metadata. The shorter rows expose previously clipped pending-holding counts.
- Remove GR's duplicate body toolbar; its existing footer controls retain selected states, keyboard shortcuts and mouse actions at 48–120 columns. Keep the REIT missing-FFO notice while removing repeated explanatory prose.
- Restore mouse submission in GC's temporary date editor after PR843's cleanup. View appears only while editing; Date and Latest remain footer actions.

Validation at `e77fe93c`: **3,159 tests / 12,956 assertions pass**, all six runtime typechecks pass, and generated manifest/proxy-host checks pass. Independent reviews and in-process rendering cover failure/recovery, mouse/keyboard actions, and narrow layouts. No calculation formulas or source dates changed.

The Windows desktop onboarding smoke check failed on base `2a648f84` after packaging, installer, and CLI checks passed. Its artifacts are being investigated separately; this PR does not claim that desktop verification passed. Fresh browser/native interaction remains unavailable under the existing tool restrictions.

No GitHub release or version change. The broader investor sweep remains active.
