### PR TITLE
Preserve Windows startup failure evidence before cleanup

### DIFF
--- a/.github/workflows/verify-windows.yml
+++ b/.github/workflows/verify-windows.yml
@@ -41,6 +41,10 @@ jobs:
 
       - uses: ./.github/actions/setup-bun
 
+      - name: Test Windows verification diagnostics
+        shell: pwsh
+        run: ./scripts/verify-windows-diagnostics.test.ps1
+
       - name: Build Windows desktop package
         shell: pwsh
         run: ./scripts/build-windows-desktop-package.ps1

--- a/scripts/verify-windows-desktop.ps1
+++ b/scripts/verify-windows-desktop.ps1
@@ -1233,7 +1233,7 @@ function Restore-EnvironmentVariable {
   param(
     [string]$Name,
     [AllowNull()]
-    [string]$Value
+    [object]$Value
   )
 
   if ($null -eq $Value) {

--- a/scripts/verify-windows-desktop.ps1
+++ b/scripts/verify-windows-desktop.ps1
@@ -127,35 +127,54 @@ public struct GloomberbPoint {
 "@
 
 function Get-VisibleWindows {
+  param([switch]$IncludeHiddenAndBounds)
+
   $Windows = New-Object System.Collections.Generic.List[object]
   $Callback = [GloomberbWin32+EnumWindowsProc]{
     param([IntPtr]$Handle, [IntPtr]$Param)
 
-    if (-not [GloomberbWin32]::IsWindowVisible($Handle)) {
+    $IsVisible = [GloomberbWin32]::IsWindowVisible($Handle)
+    if (-not $IncludeHiddenAndBounds -and -not $IsVisible) {
       return $true
     }
 
     $TextLength = [GloomberbWin32]::GetWindowTextLength($Handle)
-    if ($TextLength -le 0) {
+    if (-not $IncludeHiddenAndBounds -and $TextLength -le 0) {
       return $true
     }
 
     $TitleBuilder = New-Object System.Text.StringBuilder ($TextLength + 1)
     [void][GloomberbWin32]::GetWindowText($Handle, $TitleBuilder, $TitleBuilder.Capacity)
     $Title = $TitleBuilder.ToString()
-    if ([string]::IsNullOrWhiteSpace($Title)) {
+    if (-not $IncludeHiddenAndBounds -and [string]::IsNullOrWhiteSpace($Title)) {
       return $true
     }
 
     $ProcessIdValue = [uint32]0
     [void][GloomberbWin32]::GetWindowThreadProcessId($Handle, [ref]$ProcessIdValue)
     $Process = Get-Process -Id ([int]$ProcessIdValue) -ErrorAction SilentlyContinue
-    $Windows.Add([pscustomobject]@{
+    $Window = [pscustomobject]@{
       Id = [int]$ProcessIdValue
       ProcessName = if ($Process) { $Process.ProcessName } else { "" }
       MainWindowTitle = $Title
       Handle = $Handle.ToInt64()
-    })
+    }
+    if ($IncludeHiddenAndBounds) {
+      $Bounds = $null
+      $BoundsError = $null
+      try {
+        $Bounds = Get-WindowBounds $Window
+      } catch {
+        $BoundsError = $_.Exception.Message
+      }
+      $Window | Add-Member -NotePropertyMembers @{
+        IsVisible = $IsVisible
+        IsMinimized = [GloomberbWin32]::IsIconic($Handle)
+        Bounds = $Bounds
+        BoundsError = $BoundsError
+      }
+    }
+    $Windows.Add($Window)
     return $true
   }
 
@@ -1224,6 +1243,55 @@ function Restore-EnvironmentVariable {
   }
 }
 
+function Save-OnboardingFailureDiagnostics {
+  param(
+    [object[]]$TrackedProcesses,
+    [string]$FailureMessage
+  )
+
+  # Read retained process handles before cleanup. Looking up only a PID after exit
+  # loses the exit code and can accidentally inspect a reused PID.
+  $ProcessStates = @(
+    foreach ($Tracked in $TrackedProcesses) {
+      $State = [ordered]@{
+        Id = $Tracked.Id
+        ProcessName = $Tracked.ProcessName
+        HasExited = $null
+        ExitCode = $null
+        StateError = $Tracked.StateError
+      }
+      if ($Tracked.Process) {
+        try {
+          $Tracked.Process.Refresh()
+          $State.HasExited = $Tracked.Process.HasExited
+          if ($State.HasExited) {
+            $State.ExitCode = $Tracked.Process.ExitCode
+          }
+        } catch {
+          $State.StateError = $_.Exception.Message
+        }
+      }
+      [pscustomobject]$State
+    }
+  )
+  $Windows = @()
+  $WindowInventoryError = $null
+  try {
+    $Windows = @(Get-VisibleWindows -IncludeHiddenAndBounds)
+  } catch {
+    $WindowInventoryError = $_.Exception.Message
+  }
+  [pscustomobject]@{
+    CapturedAt = [DateTime]::UtcNow.ToString("o")
+    Stage = "onboarding-failure-before-cleanup"
+    Failure = $FailureMessage
+    Processes = $ProcessStates
+    Windows = $Windows
+    WindowInventoryError = $WindowInventoryError
+  } | ConvertTo-Json -Depth 8 | Set-Content `
+    -Path (Join-Path $GuiArtifactDir "windows-onboarding-failure.json") -Encoding UTF8
+}
+
 function Capture-OnboardingScreenshot {
   param(
     [string]$InstallDir,
@@ -1233,6 +1301,7 @@ function Capture-OnboardingScreenshot {
   $OnboardingHome = Join-Path $env:TEMP "GloomberbOnboardingHome-$PID"
   $OnboardingProcess = $null
   $OnboardingWindowProcessIds = @()
+  $TrackedProcesses = New-Object System.Collections.Generic.List[object]
   $PreviousHome = $env:HOME
   $PreviousUserProfile = $env:USERPROFILE
   $PreviousElectrobunConsole = $env:ELECTROBUN_CONSOLE
@@ -1254,13 +1323,38 @@ function Capture-OnboardingScreenshot {
     $OnboardingProcess = Start-Process `
       -FilePath (Join-Path $InstallDir "bin\launcher.exe") `
       -WorkingDirectory (Join-Path $InstallDir "bin") `
+      -RedirectStandardOutput (Join-Path $GuiArtifactDir "windows-onboarding-stdout.log") `
+      -RedirectStandardError (Join-Path $GuiArtifactDir "windows-onboarding-stderr.log") `
       -PassThru
+    $TrackedProcesses.Add([pscustomobject]@{
+      Id = $OnboardingProcess.Id
+      ProcessName = "launcher"
+      Process = $OnboardingProcess
+      StateError = $null
+    })
     $OnboardingWindows = @(Wait-ForNewWindows `
       -KnownHandles $InitialWindowHandles `
       -MinimumCount 1 `
       -Label "Gloomberb onboarding window")
     $OnboardingWindowProcessIds += $OnboardingProcess.Id
     $OnboardingWindowProcessIds += @($OnboardingWindows | Select-Object -ExpandProperty Id | Where-Object { $_ })
+    foreach ($WindowProcessId in @($OnboardingWindowProcessIds | Select-Object -Unique)) {
+      if ($WindowProcessId -eq $OnboardingProcess.Id) { continue }
+      $Tracked = [pscustomobject]@{
+        Id = $WindowProcessId
+        ProcessName = ($OnboardingWindows | Where-Object Id -eq $WindowProcessId | Select-Object -First 1).ProcessName
+        Process = $null
+        StateError = $null
+      }
+      $TrackedProcesses.Add($Tracked)
+      try {
+        $Tracked.Process = Get-Process -Id $WindowProcessId -ErrorAction Stop
+        # Force a process handle to be opened while the window is still alive.
+        $Tracked.Process.EnableRaisingEvents = $true
+      } catch {
+        $Tracked.StateError = $_.Exception.Message
+      }
+    }
 
     Save-WindowInventory (Join-Path $GuiArtifactDir "windows-onboarding-after-launch.txt")
     $null = Capture-WindowScreenshotByTitle `
@@ -1268,11 +1362,35 @@ function Capture-OnboardingScreenshot {
       -Path $OutputPath `
       -Label "Onboarding window" `
       -InitialDelaySeconds 8
+  } catch {
+    $OnboardingFailure = $_
+    try {
+      Save-OnboardingFailureDiagnostics `
+        -TrackedProcesses $TrackedProcesses.ToArray() `
+        -FailureMessage $OnboardingFailure.Exception.Message
+    } catch {
+      Write-Host "Could not save onboarding failure diagnostics: $($_.Exception.Message)"
+    }
+    try {
+      Capture-DesktopScreenshot (Join-Path $GuiArtifactDir "windows-onboarding-failure.png")
+    } catch {
+      Write-Host "Could not capture onboarding failure screenshot: $($_.Exception.Message)"
+    }
+    throw $OnboardingFailure
   } finally {
     Stop-ProcessIds $OnboardingWindowProcessIds
 
     if ($OnboardingProcess -and -not $OnboardingProcess.HasExited) {
       Stop-Process -Id $OnboardingProcess.Id -Force -ErrorAction SilentlyContinue
+    }
+    foreach ($Tracked in $TrackedProcesses) {
+      if ($Tracked.Process) {
+        try {
+          $Tracked.Process.Dispose()
+        } catch {
+          Write-Host "Could not dispose onboarding process handle $($Tracked.Id): $($_.Exception.Message)"
+        }
+      }
     }
 
     Restore-EnvironmentVariable "HOME" $PreviousHome

--- a/scripts/verify-windows-diagnostics.test.ps1
+++ b/scripts/verify-windows-diagnostics.test.ps1
@@ -1,0 +1,187 @@
+$ErrorActionPreference = "Stop"
+
+# Load only the production functions under test; do not run the installer or GUI.
+$Tokens = $null
+$ParseErrors = $null
+$ScriptPath = Join-Path $PSScriptRoot "verify-windows-desktop.ps1"
+$Ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$Tokens, [ref]$ParseErrors)
+if ($ParseErrors.Count) { throw ($ParseErrors | Out-String) }
+foreach ($Name in @("Capture-OnboardingScreenshot", "Restore-EnvironmentVariable", "Save-OnboardingFailureDiagnostics", "New-WindowHandleSet")) {
+  $Definition = $Ast.Find({
+    param($Node)
+    $Node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $Node.Name -eq $Name
+  }, $false)
+  if (-not $Definition) { throw "Missing production function: $Name" }
+  Invoke-Expression $Definition.Extent.Text
+}
+
+function Assert-Condition {
+  param([bool]$Condition, [string]$Message)
+  if (-not $Condition) { throw $Message }
+}
+
+function New-TestProcess {
+  param([int]$ProcessId, [string]$Name)
+  $Process = [pscustomobject]@{
+    Id = $ProcessId
+    ProcessName = $Name
+    HasExited = $false
+    ExitCode = $null
+    EnableRaisingEvents = $false
+  }
+  $Process | Add-Member ScriptMethod Refresh { $script:Events.Add("refresh-$($this.Id)") }
+  $Process | Add-Member ScriptMethod Dispose { $script:Events.Add("dispose-$($this.Id)") }
+  return $Process
+}
+
+function Get-VisibleWindows {
+  param([switch]$IncludeHiddenAndBounds)
+  if ($IncludeHiddenAndBounds) {
+    Assert-Condition (-not $script:Stopped) "Window evidence was collected after cleanup"
+    if ($script:Mode -eq "diagnostics-fail") { throw "Window inventory failed" }
+    return [pscustomobject]@{
+      Id = 102; Handle = 196988; MainWindowTitle = "Gloomberb"
+      IsVisible = $false; Bounds = $null; BoundsError = "Window bounds are invalid"
+    }
+  }
+  return @()
+}
+
+function Save-WindowInventory { param([string]$Path) }
+
+function Start-Process {
+  param($FilePath, $WorkingDirectory, $RedirectStandardOutput, $RedirectStandardError, [switch]$PassThru)
+  Assert-Condition ($RedirectStandardOutput -ne $RedirectStandardError) "Launch streams must use separate files"
+  Assert-Condition ((Split-Path $RedirectStandardOutput) -eq $script:GuiArtifactDir) "stdout must be retained in the artifact directory"
+  Assert-Condition ((Split-Path $RedirectStandardError) -eq $script:GuiArtifactDir) "stderr must be retained in the artifact directory"
+  "launcher output" | Set-Content $RedirectStandardOutput
+  "launcher error" | Set-Content $RedirectStandardError
+  return $script:Launcher
+}
+
+function Wait-ForNewWindows {
+  param($KnownHandles, $MinimumCount, $Label)
+  return [pscustomobject]@{ Id = 102; ProcessName = "bun"; Handle = 196988; MainWindowTitle = "Gloomberb" }
+}
+
+function Get-Process { [CmdletBinding()] param($Id) return $script:Child }
+
+function Capture-WindowScreenshotByTitle {
+  param($Title, $Path, $Label, $InitialDelaySeconds)
+  Assert-Condition $script:Child.EnableRaisingEvents "Child process handle must be retained before waiting"
+  if ($script:Mode -eq "success") { return [pscustomobject]@{ Id = 102 } }
+  if ($script:Mode -eq "exited") {
+    $script:Child.HasExited = $true
+    $script:Child.ExitCode = 23
+  }
+  throw "Original onboarding window failure"
+}
+
+function Capture-DesktopScreenshot {
+  param($Path)
+  Assert-Condition (-not $script:Stopped) "Failure screenshot was collected after cleanup"
+  if ($script:Mode -eq "diagnostics-fail") { throw "Screenshot failed" }
+  "pre-cleanup screenshot" | Set-Content $Path
+}
+
+function Stop-ProcessIds {
+  param($Ids)
+  Assert-Condition ($Ids -contains 101 -and $Ids -contains 102) "Cleanup lost a launched process"
+  $script:Stopped = $true
+  $script:Events.Add("cleanup")
+}
+
+function Stop-Process { [CmdletBinding()] param($Id, [switch]$Force) $script:Launcher.HasExited = $true }
+
+# Exercise the real enumeration callback with a pure Win32 stand-in. No native
+# windows are created; ordinary discovery must still omit hidden/untitled rows.
+Add-Type @"
+using System;
+using System.Text;
+public static class GloomberbWin32 {
+  public delegate bool EnumWindowsProc(IntPtr handle, IntPtr param);
+  public static bool EnumWindows(EnumWindowsProc callback, IntPtr param) {
+    for (int i = 1; i <= 3; i++) callback(new IntPtr(i), param);
+    return true;
+  }
+  public static bool IsWindowVisible(IntPtr handle) { return handle.ToInt32() != 2; }
+  public static bool IsIconic(IntPtr handle) { return handle.ToInt32() == 2; }
+  public static int GetWindowTextLength(IntPtr handle) { return handle.ToInt32() == 2 ? 0 : 9; }
+  public static int GetWindowText(IntPtr handle, StringBuilder text, int capacity) {
+    if (handle.ToInt32() != 2) text.Append("Gloomberb");
+    return text.Length;
+  }
+  public static uint GetWindowThreadProcessId(IntPtr handle, out uint processId) { processId = 102; return 1; }
+}
+"@
+
+function Test-WindowDiagnosticsInventory {
+  $Definition = $Ast.Find({
+    param($Node)
+    $Node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $Node.Name -eq "Get-VisibleWindows"
+  }, $false)
+  Invoke-Expression $Definition.Extent.Text
+  function Get-WindowBounds {
+    param($Window)
+    if ($Window.Handle -eq 3) { throw "Invalid window dimensions" }
+    return [pscustomobject]@{ Left = 0; Top = 0; Width = 800; Height = 600 }
+  }
+  $script:Child = New-TestProcess 102 "bun"
+  $Normal = @(Get-VisibleWindows)
+  $Diagnostics = @(Get-VisibleWindows -IncludeHiddenAndBounds)
+  Assert-Condition ($Normal.Count -eq 2 -and $Normal.Handle -notcontains 2) "Normal discovery admitted a hidden/titleless window"
+  Assert-Condition ($Diagnostics.Count -eq 3) "Diagnostic inventory lost a native window"
+  $Hidden = $Diagnostics | Where-Object Handle -eq 2
+  Assert-Condition ($Hidden.MainWindowTitle -eq "" -and -not $Hidden.IsVisible -and $Hidden.Bounds.Width -eq 800) "Hidden/titleless window evidence was lost"
+  $Invalid = $Diagnostics | Where-Object Handle -eq 3
+  Assert-Condition ($Invalid.BoundsError -eq "Invalid window dimensions" -and $null -eq $Invalid.Bounds) "Invalid bounds evidence was lost"
+  Write-Host "PASS window diagnostics: normal, hidden/titleless, invalid bounds"
+}
+Test-WindowDiagnosticsInventory
+
+$TestDir = Join-Path ([System.IO.Path]::GetTempPath()) "gloom-windows-diagnostics-$([Guid]::NewGuid())"
+$InitialHome = $env:HOME
+$InitialUserProfile = $env:USERPROFILE
+$InitialConsole = $env:ELECTROBUN_CONSOLE
+try {
+  foreach ($Mode in @("success", "exited", "alive", "diagnostics-fail", "write-fail")) {
+    $script:Mode = $Mode
+    $script:Events = New-Object System.Collections.Generic.List[string]
+    $script:Stopped = $false
+    $script:Launcher = New-TestProcess 101 "launcher"
+    $script:Child = New-TestProcess 102 "bun"
+    $script:GuiArtifactDir = Join-Path $TestDir $Mode
+    New-Item -ItemType Directory -Force $script:GuiArtifactDir | Out-Null
+    if ($Mode -eq "write-fail") {
+      New-Item -ItemType Directory (Join-Path $script:GuiArtifactDir "windows-onboarding-failure.json") | Out-Null
+    }
+    $ObservedFailure = $null
+    try {
+      Capture-OnboardingScreenshot -InstallDir $TestDir -OutputPath (Join-Path $TestDir "unused.png")
+    } catch {
+      $ObservedFailure = $_.Exception.Message
+    }
+    Assert-Condition ($ObservedFailure -eq $(if ($Mode -eq "success") { $null } else { "Original onboarding window failure" })) "Diagnostics changed the verification outcome: $ObservedFailure"
+    Assert-Condition $script:Stopped "Failure did not clean up processes"
+    Assert-Condition ($script:Events.Contains("dispose-101") -and $script:Events.Contains("dispose-102")) "Retained process handles were not disposed"
+    Assert-Condition ($env:HOME -ceq $InitialHome -and $env:USERPROFILE -ceq $InitialUserProfile -and $env:ELECTROBUN_CONSOLE -ceq $InitialConsole) "Failure did not restore the environment"
+    if ($Mode -eq "diagnostics-fail") {
+      $Evidence = Get-Content (Join-Path $script:GuiArtifactDir "windows-onboarding-failure.json") -Raw | ConvertFrom-Json
+      Assert-Condition ($Evidence.WindowInventoryError -eq "Window inventory failed") "Window read failure was lost"
+      Assert-Condition ($Evidence.Processes.Count -eq 2) "Window read failure discarded independent process evidence"
+    } elseif ($Mode -eq "success") {
+      Assert-Condition (-not (Test-Path (Join-Path $script:GuiArtifactDir "windows-onboarding-failure.json"))) "Healthy launch generated failure diagnostics"
+    } elseif ($Mode -ne "write-fail") {
+      $Evidence = Get-Content (Join-Path $script:GuiArtifactDir "windows-onboarding-failure.json") -Raw | ConvertFrom-Json
+      $ChildState = $Evidence.Processes | Where-Object Id -eq 102
+      Assert-Condition ($Evidence.Stage -eq "onboarding-failure-before-cleanup") "Incorrect evidence stage"
+      Assert-Condition ($ChildState.HasExited -eq ($Mode -eq "exited")) "Incorrect child liveness"
+      Assert-Condition ($ChildState.ExitCode -eq $(if ($Mode -eq "exited") { 23 } else { $null })) "Missing or invented child exit code"
+      Assert-Condition ($Evidence.Windows[0].BoundsError -eq "Window bounds are invalid") "Bounds failure evidence was lost"
+      Assert-Condition (Test-Path (Join-Path $script:GuiArtifactDir "windows-onboarding-failure.png")) "Missing pre-cleanup screenshot"
+    }
+    Write-Host "PASS onboarding diagnostics: $Mode"
+  }
+} finally {
+  Remove-Item -Path $TestDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/verify-windows-diagnostics.test.ps1
+++ b/scripts/verify-windows-diagnostics.test.ps1
@@ -20,6 +20,24 @@ function Assert-Condition {
   if (-not $Condition) { throw $Message }
 }
 
+# PowerShell 7.5 distinguishes an absent variable from a present empty value.
+# A string-typed restoration argument would coerce the former to the latter.
+$RestoreTestName = "GLOOM_DIAGNOSTICS_RESTORE_$([Guid]::NewGuid().ToString('N'))"
+try {
+  foreach ($ExpectedValue in @($null, "", "original")) {
+    Set-Item -Path "Env:$RestoreTestName" -Value "temporary"
+    Restore-EnvironmentVariable $RestoreTestName $ExpectedValue
+    $Restored = Get-Item -Path "Env:$RestoreTestName" -ErrorAction SilentlyContinue
+    if ($null -eq $ExpectedValue) {
+      Assert-Condition ($null -eq $Restored) "Restoration created an originally absent variable"
+    } else {
+      Assert-Condition ($null -ne $Restored -and $Restored.Value -ceq $ExpectedValue) "Restoration changed an existing variable"
+    }
+  }
+} finally {
+  Remove-Item -Path "Env:$RestoreTestName" -ErrorAction SilentlyContinue
+}
+
 function New-TestProcess {
   param([int]$ProcessId, [string]$Name)
   $Process = [pscustomobject]@{


### PR DESCRIPTION
The Windows onboarding check can fail after finding a Gloomberb window, but its current failure screenshot is taken after cleanup closes the app. Preserve launcher stdout/stderr, retained process exit status, window visibility/bounds and a screenshot before cleanup so the failure can be diagnosed.

Keep existing window discovery, timeouts and screenshot assertions. Diagnostic failures preserve the original verification failure. PowerShell tests exercise hidden/titleless enumeration and success/failure cleanup. Their first CI run exposed the existing environment-restoration helper coercing an absent value into an empty string; preserve null so cleanup restores the original state.

Validation: independent source reviews and diff checks passed. The updated exact-head Windows run34662853817 passed all diagnostic regression cases, CLI verification and the unchanged desktop checks. The initial run exposed the environment-restoration bug, now covered by absent/empty/non-empty regression cases. PowerShell is unavailable locally. This does not claim a fix for the original startup failure from34661025639; the later main buildf8b07e6a passed Windows CLI and desktop verification. No release or version change.
