### PR TITLE
Correct valuation units and make research details reachable

### DIFF
--- a/docs/economics-reference.md
+++ b/docs/economics-reference.md
@@ -1,0 +1,49 @@
+# Economic statistics reference
+
+[Research data conventions](research-data.md) · [User guide](usage.md)
+
+ECST shows FRED observations transformed into the measures below. The pane keeps the source series ID and link, observation dates, units, historical comparisons and current data failures beside the values. Its filter also searches the statistic descriptions.
+
+## Measurement conventions
+
+`y/y` compares with the corresponding period one year earlier. `m/m` is the percentage change from the preceding month; payrolls use the absolute change instead. `q/q annualized` compounds the quarterly ratio to the fourth power, then expresses the change as a percentage. Monthly and quarterly transforms require the matching calendar period; missing observations are not replaced with a different period.
+
+NSA means not seasonally adjusted. An annual-rate housing count is a flow stated at an annual rate. Effective fed funds is the monthly average effective overnight rate, while the FOMC sets a separate target range. The curve spread is 10Y minus 2Y; its zero reference marks inversion. The core-PCE 2% line is a reference: the Fed target applies to overall PCE inflation.
+
+The latest observation date identifies the source period, not necessarily its release date. The previous value is the preceding available print. The 1Y comparison uses the matching calendar period for monthly and quarterly data and a nearby prior business observation for daily data.
+
+## Series catalog
+
+| Statistic | FRED series | Transform | Description |
+| --- | --- | --- | --- |
+| CPI | [CPIAUCNS](https://fred.stlouisfed.org/series/CPIAUCNS) | yoy | Headline consumer prices against a year earlier, not seasonally adjusted, including food and energy. |
+| Core CPI | [CPILFENS](https://fred.stlouisfed.org/series/CPILFENS) | yoy | Consumer prices excluding food and energy against a year earlier, not seasonally adjusted. |
+| PCE Prices | [PCEPI](https://fred.stlouisfed.org/series/PCEPI) | yoy | The price index for personal consumption, broader in scope than CPI. |
+| Core PCE Prices | [PCEPILFE](https://fred.stlouisfed.org/series/PCEPILFE) | yoy | Excludes food and energy to track underlying PCE inflation. The Fed target applies to overall PCE inflation. |
+| Producer Prices | [PPIFID](https://fred.stlouisfed.org/series/PPIFID) | yoy | Final-demand producer prices against a year earlier, not seasonally adjusted. |
+| Unemployment Rate | [UNRATE](https://fred.stlouisfed.org/series/UNRATE) | level | Share of the labour force without work and looking for it. |
+| Nonfarm Payrolls | [PAYEMS](https://fred.stlouisfed.org/series/PAYEMS) | change | Jobs added or lost last month. |
+| Initial Jobless Claims | [ICSA](https://fred.stlouisfed.org/series/ICSA) | level | Weekly filings for unemployment benefits. |
+| Job Openings | [JTSJOL](https://fred.stlouisfed.org/series/JTSJOL) | level | Unfilled positions employers report, a measure of labour demand. |
+| Real GDP | [GDPC1](https://fred.stlouisfed.org/series/GDPC1) | qoq-annualized | Inflation-adjusted output, stated at the annual rate the quarter implies. |
+| Industrial Production | [INDPRO](https://fred.stlouisfed.org/series/INDPRO) | yoy | Output of factories, mines and utilities against a year earlier. |
+| Capacity Utilization | [TCU](https://fred.stlouisfed.org/series/TCU) | level | The share of industry's capacity in use, used as a gauge of slack. |
+| Durable Goods Orders | [DGORDER](https://fred.stlouisfed.org/series/DGORDER) | mom | New orders for goods meant to last, used as an indicator of investment. |
+| Factory Orders | [AMTMNO](https://fred.stlouisfed.org/series/AMTMNO) | mom | New orders across manufacturing, durable and not. |
+| Retail Sales | [RSAFS](https://fred.stlouisfed.org/series/RSAFS) | yoy | Household spending at retailers, not adjusted for prices. |
+| Core Retail Sales | [RSFSXMV](https://fred.stlouisfed.org/series/RSFSXMV) | yoy | Retail sales excluding motor vehicles. |
+| Consumer Sentiment | [UMCSENT](https://fred.stlouisfed.org/series/UMCSENT) | level | Michigan's survey of households' views of their finances. |
+| Personal Income | [PI](https://fred.stlouisfed.org/series/PI) | mom | What households received before tax, month on month. |
+| Personal Spending | [PCE](https://fred.stlouisfed.org/series/PCE) | mom | Household spending, a component of GDP. |
+| Housing Starts | [HOUST](https://fred.stlouisfed.org/series/HOUST) | level | Homes broken ground on, at an annual rate. |
+| Building Permits | [PERMIT](https://fred.stlouisfed.org/series/PERMIT) | level | Permits issued for new housing. |
+| New Home Sales | [HSN1F](https://fred.stlouisfed.org/series/HSN1F) | level | Newly built homes sold, at an annual rate. |
+| Effective Federal Funds Rate | [FEDFUNDS](https://fred.stlouisfed.org/series/FEDFUNDS) | level | Monthly average effective overnight rate; the FOMC sets a separate target range. |
+| 10-Year Treasury | [DGS10](https://fred.stlouisfed.org/series/DGS10) | level | The benchmark long rate that discounts almost everything else. |
+| 2-Year Treasury | [DGS2](https://fred.stlouisfed.org/series/DGS2) | level | The short end, which tracks where policy is expected to go. |
+| 10Y minus 2Y Spread | [T10Y2Y](https://fred.stlouisfed.org/series/T10Y2Y) | level | The 10-year yield minus the 2-year yield. Negative values indicate an inverted curve. |
+| 10-Year Real Yield | [DFII10](https://fred.stlouisfed.org/series/DFII10) | level | The inflation-protected long rate. |
+| M2 Money Stock | [M2SL](https://fred.stlouisfed.org/series/M2SL) | yoy | Growth in the M2 money stock. |
+| Trade Balance | [BOPGSTB](https://fred.stlouisfed.org/series/BOPGSTB) | level | Goods and services exported less imported. |
+| Nonfarm Productivity | [OPHNFB](https://fred.stlouisfed.org/series/OPHNFB) | qoq-annualized | Output per hour worked. |
+| Unit Labor Costs | [ULCNFB](https://fred.stlouisfed.org/series/ULCNFB) | qoq-annualized | Labour cost per unit of output; pay growth relative to productivity. |

--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -1,6 +1,6 @@
 # Research data conventions
 
-[User guide](usage.md) · [Price comparisons](price-comparisons.md)
+[User guide](usage.md) · [Price comparisons](price-comparisons.md) · [Economic statistics](economics-reference.md) · [Market valuation](valuation-reference.md)
 
 This reference describes how the terminal calculates and labels research data. Pane bodies show the data and current failures; recurring methodology belongs here. Headless reports and shared chart metadata retain source details and limitations.
 

--- a/docs/valuation-reference.md
+++ b/docs/valuation-reference.md
@@ -1,0 +1,37 @@
+# Market valuation reference
+
+`VAL` compares broad valuation and allocation measures with their loaded histories. Each detail retains its formula or input basis, available dollar levels, comparison dates, source link and current data status. The table's valuation zones are fixed application thresholds, not investment recommendations or forecasts.
+
+## Source coverage and units
+
+| Measure | Configured inputs and calculation | Interpretation and limits |
+| --- | --- | --- |
+| Buffett indicator | Intended dollar market capitalization / nominal GDP × 100. GDP is a quarterly, seasonally adjusted annual rate in USD billions. | Currently unavailable: the configured market history supplies index points, not monetary capitalization. [GDP metadata](https://fred.stlouisfed.org/series/GDP). |
+| Tobin's Q | `NCBEILQ027S` / `TNWMVBSNNCB`: nonfinancial corporate equity liabilities divided by net worth. Both quarterly, end-of-period Z.1 series are in USD millions and are scaled to billions before calculation. | This implementation is an equity-to-net-worth proxy. Its line at 1 means equal equity and net-worth levels; it does not separately measure replacement cost. These sector aggregates should not be described as a listed-stock portfolio. [Equity metadata](https://fred.stlouisfed.org/series/NCBEILQ027S), [net-worth metadata](https://fred.stlouisfed.org/series/TNWMVBSNNCB). |
+| Shiller CAPE | The source's monthly `cape` column, based on price and ten-year average real earnings. | Loaded directly; the app does not recompute earnings or substitute total-return CAPE. Changes in payout policy can affect historical comparability. [Shiller data](https://shillerdata.com/). |
+| Excess CAPE yield | The source's monthly `excessCapeYield` column, multiplied by 100 to display percentage points. | The definition is inverse CAPE minus the real ten-year yield. A larger spread has the cheaper direction in the table. The app does not reconstruct the real yield or equate it to a quoted TIPS yield. [Shiller data](https://shillerdata.com/), [authors' ECY definition, page 4](https://storage.googleapis.com/ni_library_storage/Research/CAPE_and_the_COVID_19_Pandemic_Effect.pdf). |
+| S&P 500 dividend yield | Shiller annual dividends / price × 100, using the monthly dataset's `dividend` and `price` columns. | Annual dividend totals are interpolated to monthly observations in the source; this is not a forward declared-dividend yield. No dollar market-cap levels are shown. [Shiller data conventions](https://shillerdata.com/). |
+| Household equity allocation | `BOGZ1FL153064486Q`, already expressed as a percentage. | Includes households and nonprofit organizations, and both direct and indirect corporate-equity holdings as a share of financial assets. It measures allocation, not a company's earnings multiple. [Source metadata](https://fred.stlouisfed.org/series/BOGZ1FL153064486Q). |
+| Margin debt / GDP | `BOGZ1FL663067003Q` / nominal GDP × 100. The numerator is scaled from USD millions to billions. | The numerator includes broker/dealer customer margin loans **and other receivables**; it is not a pure margin-loan total. GDP is an annual rate, while receivables are a quarterly balance. [Receivables metadata](https://fred.stlouisfed.org/series/BOGZ1FL663067003Q). |
+| Market cap / corporate profits | Intended dollar capitalization / `CPROFIT`, a quarterly series in USD billions at a seasonally adjusted annual rate. | Currently unavailable because monetary capitalization is missing. `CPROFIT` includes inventory valuation and capital consumption adjustments (IVA/CCAdj); the previous after-tax label did not match this series' metadata. [Profits metadata](https://fred.stlouisfed.org/series/CPROFIT). |
+| Market cap / M2 | Intended dollar capitalization / `M2SL` × 100. M2 is a monthly, seasonally adjusted money-stock level in USD billions. | Currently unavailable because monetary capitalization is missing. This denominator is a stock, unlike annualized GDP or profits. [M2 metadata](https://fred.stlouisfed.org/series/M2SL). |
+
+## Why three market-cap ratios are unavailable
+
+The configured `^W5000` history contains Wilshire index closing levels. A quote currency of USD does not make an index level a dollar market capitalization. Wilshire's rule book explains that divisor adjustments change the conversion between index points and capitalization over time; a fixed one-billion-dollar multiplier is invalid. [Wilshire Index Rule Book, sections 2.2.1 and 6.2](https://assets-global.website-files.com/60f8038183eb84c40e8c14e9/612f894c20ad970151859d9d_FT%20Wilshire%205000%20Index%20Series.pdf).
+
+VAL therefore leaves Buffett, cap/profits and cap/M2 unavailable, including when old cached index observations exist. Their charts, dollar levels, valuation zones and derived statistics are not produced. The six independent measures retain their own source coverage. Restoring these ratios requires a verified monetary-capitalization history with the intended universe, or a matching historical divisor series. An unrelated equity aggregate or a constant estimated conversion would change the measure.
+
+## Dates and historical comparisons
+
+Ratio histories align on numerator observation dates. The denominator is interpolated between observations and held flat after its latest observation; numerator dates before the first denominator observation are omitted. This is a historical alignment convention, not a reconstruction of what was publicly available on each past date. FRED data can be revised, and interpolated values can use later observations.
+
+For monetary ratios, the `as of …Q…` label beside the denominator identifies its latest observation quarter. It is not a publication date or an unrevised data vintage. The pane footer identifies the selected measure's latest observation and flags data that exceed that measure's age threshold. Refresh time alone does not establish that the underlying observation is current.
+
+`1Y ago` uses the last available observation on or before 365 days before the latest value. Mean, high, low, percentile and trend statistics use the entire loaded history. The selected range changes the displayed chart window; it does not redefine those statistics. “All-time” extrema refer to the available input history and retain their observation dates.
+
+## Zones, yields and trends
+
+The color bands use fixed thresholds for each measure. The `RICH` percentile and trend deviation orient values so a larger number means more expensive: lower yields and excess yields reverse the direction used by price ratios. This normalization supports comparison; the underlying measures retain different economic meanings.
+
+Trend fits are log-linear for positive level measures and linear for excess CAPE yield, which can be zero or negative. The deviation is measured against the fitted history, not against an independently estimated fair value. Economic regimes, interest rates, sector composition, revisions and source coverage can all affect historical comparisons. Allocation and receivables measures describe investor positioning and balance sheets rather than directly pricing future cash flows.

--- a/src/plugins/builtin/econ-statistics/defs.ts
+++ b/src/plugins/builtin/econ-statistics/defs.ts
@@ -49,7 +49,10 @@ export interface StatDef {
   reference: { value: number; label: string } | null;
   /** How old the newest print may get before the pane flags it stale. */
   staleAfterMs: number;
+  /** Searchable description; the long-form reference lives in docs/economics-reference.md. */
   note: string;
+  /** Concise measurement identity that must remain beside the values. */
+  measurementBasis?: string;
   limit: number;
 }
 

--- a/src/plugins/builtin/econ-statistics/detail.tsx
+++ b/src/plugins/builtin/econ-statistics/detail.tsx
@@ -128,26 +128,25 @@ export function StatDetail({
           <Text fg={colors.textDim}>{"  %ile "}</Text>
           <Text fg={colors.textBright}>{formatNumber(view.percentile, 0)}</Text>
         </Box>
-        <Box flexDirection="row" height={1} overflow="hidden">
-          <Text fg={colors.textDim}>High </Text>
-          <Text fg={colors.text}>{`${stat.formatValue(view.high.value)} ${view.high.date}`}</Text>
-          <Text fg={colors.textDim}>{"  Low "}</Text>
-          <Text fg={colors.text}>{`${stat.formatValue(view.low.value)} ${view.low.date}`}</Text>
+        <Box flexDirection="row" flexWrap="wrap" columnGap={2}>
+          <Box flexDirection="row" flexShrink={0} height={1}>
+            <Text fg={colors.textDim}>High </Text>
+            <Text fg={colors.text}>{`${stat.formatValue(view.high.value)} ${view.high.date}`}</Text>
+          </Box>
+          <Box flexDirection="row" flexShrink={0} height={1}>
+            <Text fg={colors.textDim}>Low </Text>
+            <Text fg={colors.text}>{`${stat.formatValue(view.low.value)} ${view.low.date}`}</Text>
+          </Box>
         </Box>
         <Box flexDirection="row" height={1} overflow="hidden">
-          <Text fg={colors.textDim}>{`${categoryLabel(stat.category)} · FRED ${stat.seriesId}`}</Text>
-        </Box>
-      </Box>
-
-      <Box flexDirection="column" gap={1} width={Math.max(1, width - 2)}>
-        <Text fg={colors.textDim} wrapMode="word" wrapText>{stat.note}</Text>
-        <Box flexDirection="row" height={1} overflow="hidden">
+          <Text fg={colors.textDim}>{`${categoryLabel(stat.category)} · `}</Text>
           <ExternalLinkText
             url={`https://fred.stlouisfed.org/series/${stat.seriesId}`}
-            label={`${stat.label}, FRED`}
+            label={`FRED ${stat.seriesId}`}
             color={colors.text}
           />
         </Box>
+        {stat.measurementBasis && <Text fg={colors.textDim} wrapMode="word" wrapText>{stat.measurementBasis}</Text>}
       </Box>
     </Box>
   );

--- a/src/plugins/builtin/econ-statistics/pane.test.tsx
+++ b/src/plugins/builtin/econ-statistics/pane.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { createInitialState } from "../../../state/app/context";
+import { createTestPaneConfig, TestPaneProvider } from "../../../test-support/pane";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
+import { Box } from "../../../ui";
+import { statsCache } from "./cache";
+import { EconStatisticsPane } from "./pane";
+import { STATS } from "./stats";
+
+let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+afterEach(async () => {
+  if (setup) await act(async () => { setup!.renderer.destroy(); });
+  setup = undefined;
+  statsCache.reset();
+});
+
+test.each([
+  { width: 48, partial: false },
+  { width: 120, partial: false },
+  { width: 48, partial: true },
+])("selected source and basis remain reachable at $width columns with partial=$partial", async ({ width, partial }) => {
+  // Hydrate the actual catalog loader without contacting a provider. Quarter and
+  // month series need enough calendar observations for their real transforms.
+  statsCache.hydrate(STATS.map((stat) => [stat.seriesId, partial && stat.seriesId === "CPIAUCNS" ? [] : Array.from({ length: 25 }, (_, index) => ({
+    date: new Date(Date.UTC(2019, index * (stat.transform === "qoq-annualized" ? 3 : 1), 1)).toISOString().slice(0, 10),
+    value: 100 + index,
+  }))] as const));
+  const state = createInitialState(createTestPaneConfig("/tmp/gloom-ecst-scroll", {
+    instanceId: "ecst:test", paneId: "econ-statistics", settings: { stat: "curve-spread" },
+  }));
+  await act(async () => {
+    setup = await testRender(
+      <TestPaneProvider state={state} paneId="ecst:test" pluginId="market-overview" runtime={createTestPluginRuntime()}>
+        <Box width={width} height={36}>
+          <EconStatisticsPane paneId="ecst:test" paneType="econ-statistics" width={width} height={36} focused />
+        </Box>
+      </TestPaneProvider>,
+      { width, height: 36 },
+    );
+  });
+  for (let frame = 0; frame < 4; frame++) await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await setup!.renderOnce();
+  });
+  expect(setup!.captureCharFrame()).toContain("2s10s");
+  await act(async () => {
+    for (let tick = 0; tick < 8; tick++) await setup!.mockMouse.scroll(width - 1, 34, "down");
+    await setup!.renderOnce();
+  });
+  const scrolled = setup!.captureCharFrame();
+  expect(scrolled).toContain("FRED T10Y2Y");
+  expect(scrolled).toContain("10Y minus 2Y");
+  expect(scrolled).toContain("High 124.00% 2021-01-01");
+  expect(scrolled).toContain("Low 100.00% 2019-01-01");
+  expect(scrolled).toContain("20Y");
+  expect(scrolled).toContain("All");
+  if (partial) expect(scrolled).toContain("CPIAUCNS");
+});

--- a/src/plugins/builtin/econ-statistics/pane.tsx
+++ b/src/plugins/builtin/econ-statistics/pane.tsx
@@ -227,6 +227,10 @@ export function EconStatisticsPane({ focused, width, height }: PaneProps) {
   const tableHeight = split
     ? Math.max(3, height - 2)
     : Math.min(rows.length + 2, Math.max(3, height - 12));
+  // The stacked list consumes real rows. Giving its detail scroller the whole
+  // pane height leaves its lower content clipped outside the scroll viewport.
+  const bodyHeight = Math.max(1, height - (error ? 1 : 0));
+  const detailHeight = split ? bodyHeight : Math.max(1, bodyHeight - tableHeight - 1);
 
   return (
     <Box flexDirection="column" width={width} height={height}>
@@ -276,7 +280,7 @@ export function EconStatisticsPane({ focused, width, height }: PaneProps) {
           </Box>
         </Box>
 
-        <Box flexDirection="column" flexGrow={1} width={detailWidth} overflow="hidden">
+        <Box flexDirection="column" flexGrow={1} width={detailWidth} height={detailHeight} overflow="hidden">
           <Box flexDirection="row" height={1} paddingX={1} overflow="hidden" justifyContent="flex-end">
             <SegmentedControl
               options={RANGE_OPTIONS}
@@ -284,7 +288,7 @@ export function EconStatisticsPane({ focused, width, height }: PaneProps) {
               onChange={(value) => setRange(value as StatRangeId)}
             />
           </Box>
-          <ScrollBox flexGrow={1} scrollY focusable={false}>
+          <ScrollBox height={Math.max(1, detailHeight - 1)} scrollY focusable={false}>
             <Box flexDirection="column" paddingBottom={1}>
               <StatDetail
                 view={selected}

--- a/src/plugins/builtin/econ-statistics/stats.ts
+++ b/src/plugins/builtin/econ-statistics/stats.ts
@@ -24,6 +24,7 @@ export const STATS: readonly StatDef[] = [
   // ---- Inflation -------------------------------------------------------
   stat({
     id: "cpi-yoy",
+    measurementBasis: "Not seasonally adjusted",
     label: "CPI",
     shortLabel: "CPI y/y",
     category: "inflation",
@@ -39,6 +40,7 @@ export const STATS: readonly StatDef[] = [
   }),
   stat({
     id: "core-cpi-yoy",
+    measurementBasis: "NSA · excludes food & energy",
     label: "Core CPI",
     shortLabel: "Core CPI y/y",
     category: "inflation",
@@ -69,6 +71,7 @@ export const STATS: readonly StatDef[] = [
   }),
   stat({
     id: "core-pce-yoy",
+    measurementBasis: "Excludes food & energy",
     label: "Core PCE Prices",
     shortLabel: "Core PCE y/y",
     category: "inflation",
@@ -84,6 +87,7 @@ export const STATS: readonly StatDef[] = [
   }),
   stat({
     id: "ppi-yoy",
+    measurementBasis: "Final demand · not seasonally adjusted",
     label: "Producer Prices",
     shortLabel: "PPI y/y",
     category: "inflation",
@@ -131,6 +135,7 @@ export const STATS: readonly StatDef[] = [
   }),
   stat({
     id: "initial-claims",
+    measurementBasis: "Weekly",
     label: "Initial Jobless Claims",
     shortLabel: "Claims",
     category: "labor",
@@ -163,6 +168,7 @@ export const STATS: readonly StatDef[] = [
   // ---- Growth ----------------------------------------------------------
   stat({
     id: "real-gdp",
+    measurementBasis: "q/q annualized",
     label: "Real GDP",
     shortLabel: "Real GDP q/q",
     category: "growth",
@@ -178,6 +184,7 @@ export const STATS: readonly StatDef[] = [
   }),
   stat({
     id: "industrial-production",
+    measurementBasis: "y/y",
     label: "Industrial Production",
     shortLabel: "Ind. prod.",
     category: "growth",
@@ -240,6 +247,7 @@ export const STATS: readonly StatDef[] = [
   // ---- Consumer --------------------------------------------------------
   stat({
     id: "retail-sales",
+    measurementBasis: "Not adjusted for prices",
     label: "Retail Sales",
     shortLabel: "Retail y/y",
     category: "consumer",
@@ -255,6 +263,7 @@ export const STATS: readonly StatDef[] = [
   }),
   stat({
     id: "core-retail-sales",
+    measurementBasis: "y/y · excludes motor vehicles",
     label: "Core Retail Sales",
     shortLabel: "Core retail",
     category: "consumer",
@@ -270,6 +279,7 @@ export const STATS: readonly StatDef[] = [
   }),
   stat({
     id: "consumer-sentiment",
+    measurementBasis: "Michigan survey",
     label: "Consumer Sentiment",
     shortLabel: "Sentiment",
     category: "consumer",
@@ -285,6 +295,7 @@ export const STATS: readonly StatDef[] = [
   }),
   stat({
     id: "personal-income",
+    measurementBasis: "Before tax",
     label: "Personal Income",
     shortLabel: "Income m/m",
     category: "consumer",
@@ -317,6 +328,7 @@ export const STATS: readonly StatDef[] = [
   // ---- Housing ---------------------------------------------------------
   stat({
     id: "housing-starts",
+    measurementBasis: "Annual rate",
     label: "Housing Starts",
     shortLabel: "Starts",
     category: "housing",
@@ -347,6 +359,7 @@ export const STATS: readonly StatDef[] = [
   }),
   stat({
     id: "new-home-sales",
+    measurementBasis: "Annual rate",
     label: "New Home Sales",
     shortLabel: "New homes",
     category: "housing",
@@ -363,6 +376,7 @@ export const STATS: readonly StatDef[] = [
   // ---- Rates & money ---------------------------------------------------
   stat({
     id: "fed-funds",
+    measurementBasis: "Monthly average · overnight",
     label: "Effective Federal Funds Rate",
     shortLabel: "Effective fed funds",
     category: "rates",
@@ -408,6 +422,7 @@ export const STATS: readonly StatDef[] = [
   }),
   stat({
     id: "curve-spread",
+    measurementBasis: "10Y minus 2Y",
     label: "10Y minus 2Y Spread",
     shortLabel: "2s10s",
     category: "rates",
@@ -423,6 +438,7 @@ export const STATS: readonly StatDef[] = [
   }),
   stat({
     id: "real-ten-year",
+    measurementBasis: "Inflation-protected",
     label: "10-Year Real Yield",
     shortLabel: "10Y real",
     category: "rates",
@@ -455,6 +471,7 @@ export const STATS: readonly StatDef[] = [
   // ---- Trade & costs ---------------------------------------------------
   stat({
     id: "trade-balance",
+    measurementBasis: "Goods & services · exports minus imports",
     label: "Trade Balance",
     shortLabel: "Trade balance",
     category: "trade",
@@ -471,6 +488,7 @@ export const STATS: readonly StatDef[] = [
   }),
   stat({
     id: "productivity",
+    measurementBasis: "q/q annualized · output per hour",
     label: "Nonfarm Productivity",
     shortLabel: "Productivity",
     category: "trade",
@@ -486,6 +504,7 @@ export const STATS: readonly StatDef[] = [
   }),
   stat({
     id: "unit-labor-costs",
+    measurementBasis: "q/q annualized",
     label: "Unit Labor Costs",
     shortLabel: "Labor costs",
     category: "trade",

--- a/src/plugins/builtin/market-valuation/align.ts
+++ b/src/plugins/builtin/market-valuation/align.ts
@@ -1,4 +1,4 @@
-import type { IndicatorDef, SeriesDef } from "./defs";
+import { indicatorUnavailableReason, type IndicatorDef, type SeriesDef } from "./defs";
 import type { DatedSeries } from "./series";
 
 export interface ScaledObs {
@@ -33,6 +33,7 @@ export function vintageLabel(prefix: string, vintageDate: string): string {
 }
 
 export function scaleObservations(def: SeriesDef, data: DatedSeries): ScaledObs[] {
+  if (def.unavailableReason) throw new Error(def.unavailableReason);
   const points: ScaledObs[] = [];
   for (const obs of data.observations) {
     if (obs.value == null || !Number.isFinite(obs.value)) continue;
@@ -94,6 +95,8 @@ export function buildValuationSeries(
   indicator: IndicatorDef,
   legs: ReadonlyMap<string, DatedSeries>,
 ): ValuationSeries {
+  const unavailable = indicatorUnavailableReason(indicator);
+  if (unavailable) throw new Error(unavailable);
   if (indicator.input.kind === "direct") {
     const def = indicator.input.series;
     const data = legs.get(def.key);

--- a/src/plugins/builtin/market-valuation/chart-series.ts
+++ b/src/plugins/builtin/market-valuation/chart-series.ts
@@ -4,7 +4,7 @@ import { colors } from "../../../theme/colors";
 import type { ResolvedSeries, TimeSeriesPoint } from "../../../time-series/types";
 import { buildValuationSeries } from "./align";
 import { defaultValuationSeriesLoader, type ValuationSeriesLoader } from "./client";
-import { indicatorSeries, type IndicatorDef } from "./defs";
+import { indicatorUnavailableReason, indicatorSeries, type IndicatorDef } from "./defs";
 import { findIndicator, INDICATORS } from "./indicators";
 import type { DatedSeries } from "./series";
 
@@ -59,6 +59,8 @@ export async function resolveValuationSeries(
     throw new Error(`Unknown valuation series ${seriesId}`);
   }
 
+  const unavailable = indicatorUnavailableReason(indicator);
+  if (unavailable) throw new Error(unavailable);
   const legs = new Map<string, DatedSeries>();
   await Promise.all(indicatorSeries(indicator).map(async (def) => {
     legs.set(def.key, await loader(def));
@@ -74,9 +76,9 @@ export async function resolveValuationSeries(
     id: `market-valuation:${indicator.id}`,
     label: indicator.label,
     color: colors.textBright,
-    // Percent-scaled ratios share an axis with each other, never with a price.
-    unit: indicator.ratioScale === 100 ? "%" : "x",
-    unitGroup: indicator.ratioScale === 100 ? "valuation-percent" : "valuation-ratio",
+    // Source percentages need the same units as ratios scaled into percentages.
+    unit: indicator.axisUnit === "%" ? "%" : "x",
+    unitGroup: indicator.axisUnit === "%" ? "valuation-percent" : "valuation-ratio",
     nativeFrequency: "daily",
     dataShape: "scalar",
     style: "line",

--- a/src/plugins/builtin/market-valuation/client.test.ts
+++ b/src/plugins/builtin/market-valuation/client.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { MemoryPluginPersistence } from "../../../test-support/plugin-persistence";
-import { attachValuationPersistence, resetValuationPersistence } from "./cache";
-import { loadValuationBundle, requiredSeries, type ValuationSeriesLoader } from "./client";
+import { attachValuationPersistence, loadCachedSeries, resetValuationPersistence } from "./cache";
+import { createValuationSeriesLoader, getCachedValuationBundle, loadValuationBundle, requiredSeries, type ValuationSeriesLoader } from "./client";
 import { BUFFETT_INDICATOR, INDICATORS, SHILLER_CAPE, TOBINS_Q } from "./indicators";
 import type { DatedObservation, DatedSeries } from "./series";
+import { buildValuationSeries } from "./align";
+import { resolveValuationSeries } from "./chart-series";
 import { createSourceLoader, shillerObservations } from "./sources";
 
 function obs(values: Array<[string, number]>): DatedObservation[] {
@@ -39,32 +41,44 @@ afterEach(resetValuationPersistence);
 
 describe("requiredSeries", () => {
   test("fetches a leg shared by two indicators only once", () => {
-    // Buffett and Cap/M2 share the Wilshire leg.
-    const keys = requiredSeries(INDICATORS).map((def) => def.key);
-    expect(keys.filter((key) => key === "W5000")).toHaveLength(1);
+    const keys = requiredSeries([TOBINS_Q, TOBINS_Q, BUFFETT_INDICATOR]).map((def) => def.key);
+    expect(keys.filter((key) => key === "NCBEILQ027S")).toHaveLength(1);
+    expect(keys).not.toContain("W5000");
     expect(new Set(keys).size).toBe(keys.length);
   });
 });
 
 describe("loadValuationBundle", () => {
-  test("builds every registered indicator", async () => {
-    const bundle = await loadValuationBundle({ loader: everyLeg });
-    expect(bundle.builds.map((build) => build.indicator.id))
-      .toEqual(INDICATORS.map((indicator) => indicator.id));
+  test("does not fetch or compute unsupported monetary inputs, leaving six independent measures", async () => {
+    const requested: string[] = [];
+    const bundle = await loadValuationBundle({ loader: async (def) => {
+      requested.push(def.key);
+      return everyLeg(def);
+    } });
+    expect(requested).not.toContain("W5000");
+    expect(requested).not.toContain("CPROFIT");
+    expect(requested).not.toContain("M2SL");
+    expect(bundle.builds.map((build) => build.indicator.id)).toEqual([
+      "shiller-cape", "excess-cape-yield", "tobins-q", "household-equity-allocation",
+      "sp500-dividend-yield", "margin-debt-gdp",
+    ]);
+    expect(bundle.builds.find((build) => build.indicator.id === "shiller-cape")!.series.points.at(-1)!.ratio).toBe(38.1);
+    expect(bundle.builds.find((build) => build.indicator.id === "tobins-q")!.series.points.at(-1)!.ratio).toBeCloseTo(64 / 41);
+    expect(bundle.errors).toHaveLength(3);
+    expect(bundle.errors.every((error) => error.includes("index points"))).toBe(true);
   });
 
   test("one broken leg only drops the indicators that need it", async () => {
     const bundle = await loadValuationBundle({
       loader: async (def) => {
-        if (def.key === "W5000") throw new Error("history unavailable");
+        if (def.key === "NCBEILQ027S") throw new Error("FRED unavailable");
         return everyLeg(def);
       },
     });
     const ids = bundle.builds.map((build) => build.indicator.id);
-    expect(ids).not.toContain("buffett");
-    expect(ids).not.toContain("market-cap-m2");
+    expect(ids).not.toContain("tobins-q");
     expect(ids).toContain("shiller-cape");
-    expect(bundle.errors.join(" ")).toContain("W5000");
+    expect(bundle.errors.join(" ")).toContain("FRED unavailable");
   });
 
   test("throws when nothing builds", async () => {
@@ -137,5 +151,38 @@ describe("shillerObservations", () => {
       sourceUrl: "x",
       fetchedAt: "y",
     }, "earnings")).toThrow("no earnings observations");
+  });
+});
+
+
+describe("market-capitalization source basis", () => {
+  test("legacy persisted index closes cannot revive any of the three monetary ratios", async () => {
+    await Promise.all(Object.entries(LEGS).map(([key, observations]) => loadCachedSeries(key, async () => observations)));
+    const cached = getCachedValuationBundle()!;
+    expect(cached.builds).toHaveLength(6);
+    expect(cached.errors).toHaveLength(3);
+    const legs = new Map(Object.entries(LEGS).map(([seriesId, observations]) => [seriesId, { seriesId, observations, provenance: "fred" as const }]));
+    for (const id of ["buffett", "market-cap-profits", "market-cap-m2"]) {
+      const indicator = INDICATORS.find((entry) => entry.id === id)!;
+      expect(() => buildValuationSeries(indicator, legs)).toThrow("index points");
+      await expect(loadValuationBundle({ loader: everyLeg, indicators: [indicator] })).rejects.toThrow("dollar market capitalization");
+      let calls = 0;
+      await expect(resolveValuationSeries(id, async (def) => { calls += 1; return everyLeg(def); })).rejects.toThrow("index points");
+      expect(calls).toBe(0);
+    }
+    const loader = createValuationSeriesLoader({
+      loadFred: async () => { throw new Error("unexpected transport"); },
+      loadMarketHistory: async () => { throw new Error("unexpected transport"); },
+      loadShiller: async () => { throw new Error("unexpected transport"); },
+    });
+    if (BUFFETT_INDICATOR.input.kind !== "ratio") throw new Error("ratio expected");
+    await expect(loader(BUFFETT_INDICATOR.input.numerator)).rejects.toThrow("index points");
+    const cape = await resolveValuationSeries("shiller-cape", everyLeg);
+    expect(cape.points.at(-1)!.value).toBe(38.1);
+    const allocation = await resolveValuationSeries("household-equity-allocation", everyLeg);
+    expect(allocation.points.at(-1)!.value).toBe(45.8);
+    expect(allocation.unit).toBe("%");
+    expect(allocation.unitGroup).toBe("valuation-percent");
+    expect(cape.unit).toBe("x");
   });
 });

--- a/src/plugins/builtin/market-valuation/client.ts
+++ b/src/plugins/builtin/market-valuation/client.ts
@@ -1,6 +1,6 @@
 import { buildValuationSeries } from "./align";
 import { getCachedSeries, loadCachedSeries } from "./cache";
-import { indicatorSeries, type IndicatorDef, type SeriesDef } from "./defs";
+import { indicatorUnavailableReason, indicatorSeries, type IndicatorDef, type SeriesDef } from "./defs";
 import { INDICATORS } from "./indicators";
 import type { DatedSeries } from "./series";
 import {
@@ -20,6 +20,7 @@ export function requiredSeries(
 ): SeriesDef[] {
   const seen = new Map<string, SeriesDef>();
   for (const indicator of indicators) {
+    if (indicatorUnavailableReason(indicator)) continue;
     for (const def of indicatorSeries(indicator)) {
       if (!seen.has(def.key)) seen.set(def.key, def);
     }
@@ -30,11 +31,14 @@ export function requiredSeries(
 /** Cache-first around the cloud sources; exported so Bun-side tooling can reuse it. */
 export function createValuationSeriesLoader(deps: ValuationSourceDeps): ValuationSeriesLoader {
   const cloudLoader = createSourceLoader(deps);
-  return async (def) => ({
-    seriesId: def.key,
-    observations: await loadCachedSeries(def.key, async () => (await cloudLoader(def)).observations),
-    provenance: provenanceFor(def),
-  });
+  return async (def) => {
+    if (def.unavailableReason) throw new Error(def.unavailableReason);
+    return {
+      seriesId: def.key,
+      observations: await loadCachedSeries(def.key, async () => (await cloudLoader(def)).observations),
+      provenance: provenanceFor(def),
+    };
+  };
 }
 
 export const defaultValuationSeriesLoader = createValuationSeriesLoader(cloudSourceDeps);
@@ -53,8 +57,9 @@ export function getCachedValuationBundle(
       provenance: provenanceFor(def),
     });
   }
-  const builds = buildIndicators(legs, [], indicators);
-  return builds.length > 0 ? { builds, errors: [], fetchedAt: Date.now() } : null;
+  const errors: string[] = [];
+  const builds = buildIndicators(legs, errors, indicators);
+  return builds.length > 0 || errors.length > 0 ? { builds, errors, fetchedAt: Date.now() } : null;
 }
 
 function buildIndicators(
@@ -64,6 +69,11 @@ function buildIndicators(
 ): IndicatorBuild[] {
   const builds: IndicatorBuild[] = [];
   for (const indicator of indicators) {
+    const unavailable = indicatorUnavailableReason(indicator);
+    if (unavailable) {
+      errors.push(`${indicator.label}: ${unavailable}`);
+      continue;
+    }
     if (indicatorSeries(indicator).some((def) => !legs.has(def.key))) continue;
     try {
       const series = buildValuationSeries(indicator, legs);
@@ -82,8 +92,8 @@ function buildIndicators(
 function summarizeErrors(errors: readonly string[]): string {
   if (errors.length === 0) return "Market valuation data unavailable";
   const reasons = new Set(errors.map((entry) => entry.replace(/^[^:]+:\s*/, "")));
-  const reason = reasons.size === 1 ? [...reasons][0]! : `${errors.length} series failed`;
-  return errors.length > 1 ? `${reason} (${errors.length} series)` : reason;
+  if (reasons.size === 1) return [...reasons][0]!;
+  return `${errors[0]} (${errors.length - 1} other failures)`;
 }
 
 export async function loadValuationBundle(options?: {

--- a/src/plugins/builtin/market-valuation/defs.ts
+++ b/src/plugins/builtin/market-valuation/defs.ts
@@ -27,6 +27,8 @@ export interface SeriesDef {
   /** Multiplier that brings a raw observation into billions of dollars. */
   scaleToBillions: number;
   source: SeriesSource;
+  /** A verified source-basis failure; also blocks persisted observations of this leg. */
+  unavailableReason?: string;
 }
 
 export type ValuationZoneId =
@@ -81,6 +83,7 @@ export interface IndicatorDef {
   label: string;
   /** Fits the summary table's INDICATOR column. */
   shortLabel: string;
+  /** Concise formula/input basis; interpretation lives in docs/valuation-reference.md. */
   description: string;
   input: IndicatorInput;
   /** Multiplies the raw value: 100 renders a quotient as a percent. */
@@ -107,7 +110,6 @@ export interface IndicatorDef {
   trendModel: "log" | "linear";
   /** How old the newest observation may get before the pane flags it stale. */
   staleAfterMs: number;
-  notes: string[];
   link: { url: string; label: string } | null;
 }
 
@@ -248,4 +250,9 @@ export function indicatorSeries(indicator: IndicatorDef): SeriesDef[] {
   return indicator.input.kind === "ratio"
     ? [indicator.input.numerator, indicator.input.denominator]
     : [indicator.input.series];
+}
+
+/** A known input failure must survive caching, injected loaders, and chart resolution. */
+export function indicatorUnavailableReason(indicator: IndicatorDef): string | null {
+  return indicatorSeries(indicator).find((def) => def.unavailableReason)?.unavailableReason ?? null;
 }

--- a/src/plugins/builtin/market-valuation/detail.tsx
+++ b/src/plugins/builtin/market-valuation/detail.tsx
@@ -107,53 +107,41 @@ export function IndicatorDetail({
         </Box>
       )}
 
-      <Box flexDirection="column" gap={0}>
+      <Text fg={colors.textDim} wrapMode="word" wrapText>{indicator.description}</Text>
+
+      <Box flexDirection="column" gap={0} width={Math.max(1, width - 2)}>
         {levels && view.current.numeratorBillions != null
           && view.current.denominatorBillions != null ? (
-          <Box flexDirection="row" height={1} overflow="hidden">
-            <Text fg={colors.textDim}>{`${levels.numeratorLabel} `}</Text>
-            <Text fg={colors.textBright}>{formatTrillions(view.current.numeratorBillions)}</Text>
-            <Text fg={colors.textDim}>{`  ${levels.denominatorLabel} `}</Text>
-            <Text fg={colors.textBright}>{formatTrillions(view.current.denominatorBillions)}</Text>
-            {view.vintageLabel ? (
-              <Text fg={colors.textDim}>{`  ${view.vintageLabel}`}</Text>
-            ) : null}
+          <Box flexDirection="row" flexWrap="wrap" columnGap={2} rowGap={0}>
+            <Box flexDirection="row" flexShrink={0}>
+              <Text fg={colors.textDim}>{`${levels.numeratorLabel} `}</Text>
+              <Text fg={colors.textBright}>{formatTrillions(view.current.numeratorBillions)}</Text>
+            </Box>
+            <Box flexDirection="row" flexShrink={0}>
+              <Text fg={colors.textDim}>{`${levels.denominatorLabel} `}</Text>
+              <Text fg={colors.textBright}>{formatTrillions(view.current.denominatorBillions)}</Text>
+            </Box>
+            {view.vintageLabel ? <Text fg={colors.textDim}>{view.vintageLabel}</Text> : null}
           </Box>
         ) : null}
-        <Box flexDirection="row" height={1} overflow="hidden">
-          <Text fg={colors.textDim}>1Y ago </Text>
-          <Text fg={colors.text}>
-            {view.ratioOneYearAgo == null ? "--" : indicator.formatValue(view.ratioOneYearAgo)}
-          </Text>
-          <Text fg={colors.textDim}>{"  mean "}</Text>
-          <Text fg={colors.text}>{indicator.formatValue(view.mean)}</Text>
-          <Text fg={colors.textDim}>{"  ATH "}</Text>
-          <Text fg={colors.text}>
-            {`${indicator.formatValue(view.allTimeHigh.ratio)} ${view.allTimeHigh.date}`}
-          </Text>
-          <Text fg={colors.textDim}>{"  ATL "}</Text>
-          <Text fg={colors.text}>
-            {`${indicator.formatValue(view.allTimeLow.ratio)} ${view.allTimeLow.date}`}
-          </Text>
+        <Box flexDirection="row" flexWrap="wrap" columnGap={2} rowGap={0}>
+          {[
+            ["1Y ago", view.ratioOneYearAgo == null ? "--" : indicator.formatValue(view.ratioOneYearAgo)],
+            ["mean", indicator.formatValue(view.mean)],
+            ["ATH", `${indicator.formatValue(view.allTimeHigh.ratio)} ${view.allTimeHigh.date}`],
+            ["ATL", `${indicator.formatValue(view.allTimeLow.ratio)} ${view.allTimeLow.date}`],
+          ].map(([label, value]) => (
+            <Box key={label} flexDirection="row" flexShrink={0}>
+              <Text fg={colors.textDim}>{`${label} `}</Text>
+              <Text fg={colors.text}>{value}</Text>
+            </Box>
+          ))}
         </Box>
       </Box>
 
-      <Box flexDirection="column" gap={1} width={Math.max(1, width - 2)}>
-        {indicator.notes.map((note) => (
-          <Text key={note.slice(0, 24)} fg={colors.textDim} wrapMode="word" wrapText>
-            {note}
-          </Text>
-        ))}
-        {indicator.link ? (
-          <Box flexDirection="row" height={1} overflow="hidden">
-            <ExternalLinkText
-              url={indicator.link.url}
-              label={indicator.link.label}
-              color={colors.text}
-            />
-          </Box>
-        ) : null}
-      </Box>
+      {indicator.link ? (
+        <ExternalLinkText url={indicator.link.url} label={indicator.link.label} color={colors.text} />
+      ) : null}
     </Box>
   );
 }

--- a/src/plugins/builtin/market-valuation/headless.test.ts
+++ b/src/plugins/builtin/market-valuation/headless.test.ts
@@ -51,8 +51,16 @@ describe("market valuation headless model", () => {
       "Shiller CAPE",
     ]);
     expect(result.sections[0]).toMatchObject({
-      rows: [{ id: "shiller-cape", value: 39, formattedValue: "39.0" }],
+      rows: [{ id: "shiller-cape", value: 39, formattedValue: "39.0", unit: "x" }],
     });
+    expect(result.sections[1]).toMatchObject({ entries: expect.arrayContaining([
+      { label: "Basis", value: expect.stringContaining("real earnings") },
+    ]) });
+    for (const indicator of ["buffett", "market-cap-profits", "market-cap-m2"]) {
+      await expect(marketValuationHeadless.load({ ...loadArgs(), argument: indicator }, context))
+        .rejects.toThrow("dollar market capitalization");
+    }
+    expect(shillerCalls).toBe(1);
     expect(result.metadata).toMatchObject({ range: "10Y", selected: "shiller-cape" });
   });
 });

--- a/src/plugins/builtin/market-valuation/headless.ts
+++ b/src/plugins/builtin/market-valuation/headless.ts
@@ -24,6 +24,8 @@ function detailEntries(view: IndicatorViewModel): HeadlessPaneEntry[] {
   const format = view.indicator.formatValue;
   return [
     { label: "Current", value: view.current.ratio, formatted: format(view.current.ratio) },
+    { label: "Basis", value: view.indicator.description },
+    { label: "Unit", value: view.indicator.axisUnit || "x" },
     {
       label: "1Y ago",
       value: view.ratioOneYearAgo,
@@ -66,6 +68,8 @@ export function projectValuationHeadlessBundle(
     indicator: view.indicator.label,
     value: view.current.ratio,
     formattedValue: view.indicator.formatValue(view.current.ratio),
+    basis: view.indicator.description,
+    unit: view.indicator.axisUnit || "x",
     zone: view.zone.label,
     richPercentile: view.richPercentile,
     richSigma: view.richSigma,

--- a/src/plugins/builtin/market-valuation/indicators.ts
+++ b/src/plugins/builtin/market-valuation/indicators.ts
@@ -23,11 +23,13 @@ function ratio(value: number): string {
 }
 
 /**
- * Total US market value. FRED discontinued the WILL5000* family, so this comes
- * from the cloud's own price history rather than the econ proxy.
+ * Retained source identity for saved indicators and old caches. Price-index points
+ * are not dollar market capitalization: a historical divisor would be required.
+ * Never scale these observations into a monetary ratio (see valuation-reference.md).
  */
 const WILSHIRE_5000: SeriesDef = {
   key: "W5000",
+  unavailableReason: "^W5000 provides index points; dollar market capitalization is unavailable.",
   scaleToBillions: 1,
   source: {
     kind: "market-history",
@@ -57,7 +59,7 @@ export const BUFFETT_INDICATOR: IndicatorDef = {
   id: "buffett",
   label: "Buffett Indicator",
   shortLabel: "Buffett",
-  description: "US total market cap over nominal GDP.",
+  description: "Market capitalization / nominal GDP (annual rate), %.",
   input: {
     kind: "ratio",
     numerator: WILSHIRE_5000,
@@ -79,10 +81,6 @@ export const BUFFETT_INDICATOR: IndicatorDef = {
   chartGridStep: 150,
   trendModel: "log",
   staleAfterMs: DAILY_STALE_MS,
-  notes: [
-    "Total US market value against one year of economic output. Warren Buffett called it probably the best single measure of where valuations stand at any given moment, in a December 2001 Fortune essay written with Carol Loomis.",
-    "Rates, buybacks, and a larger listed share of the economy have all raised what fair looks like since 2001, so read the trend deviation alongside the absolute zone.",
-  ],
   link: {
     url: "https://en.wikipedia.org/wiki/Buffett_indicator",
     label: "Buffett indicator, Wikipedia",
@@ -93,7 +91,7 @@ export const TOBINS_Q: IndicatorDef = {
   id: "tobins-q",
   label: "Tobin's Q",
   shortLabel: "Tobin Q",
-  description: "Corporate equity market value over replacement cost of net assets.",
+  description: "Nonfinancial corporate equities / net worth; quarterly Z.1.",
   input: {
     kind: "ratio",
     numerator: {
@@ -120,14 +118,10 @@ export const TOBINS_Q: IndicatorDef = {
     { max: null, id: "significantly-overvalued", label: "Significantly Overvalued" },
   ],
   zoneScale: { min: 0, max: 2, edges: [0, 0.55, 0.8, 1.1, 1.4, 2], ticks: [0, 0.55, 1, 1.4, 2] },
-  reference: { value: 1, label: "replacement cost" },
+  reference: { value: 1, label: "equities = net worth" },
   chartGridStep: 0.5,
   trendModel: "log",
   staleAfterMs: QUARTERLY_STALE_MS,
-  notes: [
-    "Equity market value against what it would cost to rebuild the assets behind it. Q above 1 means the market pays more than replacement cost.",
-    "Built from the Fed's quarterly Z.1 financial accounts for nonfinancial corporate business, so it moves in quarterly steps and revises with each release.",
-  ],
   link: { url: "https://en.wikipedia.org/wiki/Tobin%27s_q", label: "Tobin's q, Wikipedia" },
 };
 
@@ -135,7 +129,7 @@ export const SHILLER_CAPE: IndicatorDef = {
   id: "shiller-cape",
   label: "Shiller CAPE",
   shortLabel: "CAPE",
-  description: "S&P 500 price over ten years of inflation-adjusted earnings.",
+  description: "Price / ten-year mean real earnings; Shiller monthly CAPE.",
   input: { kind: "direct", series: shillerSeries("SHILLER_CAPE", "cape") },
   ratioScale: 1,
   formatValue: (value) => formatNumber(value, 1),
@@ -153,10 +147,6 @@ export const SHILLER_CAPE: IndicatorDef = {
   chartGridStep: 10,
   trendModel: "log",
   staleAfterMs: MONTHLY_STALE_MS,
-  notes: [
-    "Price divided by the average of ten years of real earnings, which smooths away the profit cycle that makes a one-year P/E swing hardest exactly when it matters most.",
-    "Robert Shiller's series runs back to 1881. It has spent decades above its own median without mean-reverting, so treat it as a long-horizon return signal rather than a timing tool.",
-  ],
   link: {
     url: "https://en.wikipedia.org/wiki/Cyclically_adjusted_price-to-earnings_ratio",
     label: "CAPE ratio, Wikipedia",
@@ -167,7 +157,7 @@ export const EXCESS_CAPE_YIELD: IndicatorDef = {
   id: "excess-cape-yield",
   label: "Excess CAPE Yield",
   shortLabel: "ERP (ECY)",
-  description: "CAPE earnings yield over the real 10-year Treasury yield.",
+  description: "1/CAPE − real 10Y Treasury yield; Shiller monthly (%).",
   input: { kind: "direct", series: shillerSeries("SHILLER_ECY", "excessCapeYield") },
   // Shiller publishes it as a decimal fraction; show it as a percent.
   ratioScale: 100,
@@ -188,10 +178,6 @@ export const EXCESS_CAPE_YIELD: IndicatorDef = {
   // The spread has been negative, so a log fit would silently drop those years.
   trendModel: "linear",
   staleAfterMs: MONTHLY_STALE_MS,
-  notes: [
-    "What stocks yield over inflation-protected bonds: the CAPE earnings yield minus the real ten-year Treasury yield. It is the equity risk premium in the form Shiller publishes.",
-    "Unlike a price ratio, higher is cheaper. It went negative before the 1929 and 2000 peaks, when bonds out-yielded stocks outright.",
-  ],
   link: {
     url: "https://en.wikipedia.org/wiki/Equity_premium_puzzle",
     label: "Equity risk premium, Wikipedia",
@@ -202,7 +188,7 @@ export const SP500_DIVIDEND_YIELD: IndicatorDef = {
   id: "sp500-dividend-yield",
   label: "S&P 500 Dividend Yield",
   shortLabel: "Div yield",
-  description: "Index dividend over index price.",
+  description: "Annual dividends / price; Shiller monthly series (%).",
   input: {
     kind: "ratio",
     numerator: shillerSeries("SHILLER_DIVIDEND", "dividend"),
@@ -224,10 +210,6 @@ export const SP500_DIVIDEND_YIELD: IndicatorDef = {
   chartGridStep: 4,
   trendModel: "log",
   staleAfterMs: MONTHLY_STALE_MS,
-  notes: [
-    "What the index pays out against what it costs. Buybacks have moved a large share of shareholder return off this line since the 1980s, so the modern level is structurally lower than the pre-1990 record.",
-    "Read it against its own recent decades rather than the full history for that reason.",
-  ],
   link: { url: "https://en.wikipedia.org/wiki/Dividend_yield", label: "Dividend yield, Wikipedia" },
 };
 
@@ -235,7 +217,7 @@ export const HOUSEHOLD_EQUITY_ALLOCATION: IndicatorDef = {
   id: "household-equity-allocation",
   label: "Investor Equity Allocation",
   shortLabel: "Equity alloc",
-  description: "Share of household financial assets held in equities.",
+  description: "Household and nonprofit direct/indirect equities / financial assets, %.",
   input: {
     kind: "direct",
     series: {
@@ -261,10 +243,6 @@ export const HOUSEHOLD_EQUITY_ALLOCATION: IndicatorDef = {
   chartGridStep: 10,
   trendModel: "log",
   staleAfterMs: QUARTERLY_STALE_MS,
-  notes: [
-    "How much of what households own sits in stocks. When investors are already all-in there is little cash left to bid prices higher, which is why this has tracked ten-year forward returns more closely than any price ratio.",
-    "From the Fed's quarterly Z.1 accounts, counting equities held directly and through funds.",
-  ],
   link: {
     url: "https://fred.stlouisfed.org/series/BOGZ1FL153064486Q",
     label: "Household equity share, FRED",
@@ -275,7 +253,7 @@ export const MARKET_CAP_TO_M2: IndicatorDef = {
   id: "market-cap-m2",
   label: "Market Cap to M2",
   shortLabel: "Cap / M2",
-  description: "US total market cap against the money supply.",
+  description: "Market capitalization / M2 money stock, %.",
   input: {
     kind: "ratio",
     numerator: WILSHIRE_5000,
@@ -298,10 +276,6 @@ export const MARKET_CAP_TO_M2: IndicatorDef = {
   chartGridStep: 100,
   trendModel: "log",
   staleAfterMs: DAILY_STALE_MS,
-  notes: [
-    "Market value measured against the money supply rather than output, which is the liquidity-adjusted read on the same question the Buffett indicator asks.",
-    "It falls when the Fed expands M2 faster than equities rise, so the 2020 surge shows up here as cheapening even while price ratios were climbing.",
-  ],
   link: { url: "https://fred.stlouisfed.org/series/M2SL", label: "M2 money stock, FRED" },
 };
 
@@ -309,7 +283,7 @@ export const MARGIN_DEBT_TO_GDP: IndicatorDef = {
   id: "margin-debt-gdp",
   label: "Margin Debt to GDP",
   shortLabel: "Margin debt",
-  description: "Borrowing against securities, against the size of the economy.",
+  description: "Margin loans and other customer receivables / nominal GDP (annual rate), %.",
   input: {
     kind: "ratio",
     numerator: {
@@ -336,10 +310,6 @@ export const MARGIN_DEBT_TO_GDP: IndicatorDef = {
   chartGridStep: 1,
   trendModel: "log",
   staleAfterMs: QUARTERLY_STALE_MS,
-  notes: [
-    "How much investors have borrowed against their holdings. Leverage is what turns a decline into forced selling, so it is froth rather than value, but it peaks where valuations do.",
-    "Its two highest readings are the first quarter of 2000 and the third of 2008. From the Fed's Z.1 accounts, which reach further back than FINRA's own margin table.",
-  ],
   link: {
     url: "https://fred.stlouisfed.org/series/BOGZ1FL663067003Q",
     label: "Margin account receivables, FRED",
@@ -350,7 +320,7 @@ export const MARKET_CAP_TO_PROFITS: IndicatorDef = {
   id: "market-cap-profits",
   label: "Market Cap to Corporate Profits",
   shortLabel: "Cap / profits",
-  description: "US total market cap over after-tax corporate profits.",
+  description: "Market capitalization / corporate profits (IVA/CCAdj, annual rate).",
   input: {
     kind: "ratio",
     numerator: WILSHIRE_5000,
@@ -377,13 +347,9 @@ export const MARKET_CAP_TO_PROFITS: IndicatorDef = {
   chartGridStep: 5,
   trendModel: "log",
   staleAfterMs: DAILY_STALE_MS,
-  notes: [
-    "A price-to-earnings ratio for the whole economy rather than the index, using what every US corporation actually earned after tax.",
-    "Profits are near a record share of GDP, so this asks whether the market is dear even against unusually good earnings. Its highest reading is March 2000.",
-  ],
   link: {
     url: "https://fred.stlouisfed.org/series/CPROFIT",
-    label: "Corporate profits after tax, FRED",
+    label: "Corporate profits (IVA/CCAdj), FRED",
   },
 };
 

--- a/src/plugins/builtin/market-valuation/pane.test.tsx
+++ b/src/plugins/builtin/market-valuation/pane.test.tsx
@@ -1,6 +1,7 @@
+import { Box } from "../../../ui";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { act } from "react";
-import { PaneFooterProvider } from "../../../components/layout/pane/footer";
+import { act, useReducer } from "react";
+import { PaneFooterProvider, PaneFooterBar } from "../../../components/layout/pane/footer";
 import {
   attachValuationPersistence,
   hydrateValuationSeries,
@@ -8,7 +9,7 @@ import {
 } from "./cache";
 import { testRender } from "../../../renderers/opentui/test-utils";
 import {
-  AppContext,
+  AppContext, appReducer,
   createInitialState,
   PaneInstanceProvider,
 } from "../../../state/app/context";
@@ -22,7 +23,7 @@ function obs(values: Array<[string, number]>) {
   return values.map(([date, value]) => ({ date, value }));
 }
 
-/** Wilshire 76.2T over GDP 32.5T is 235%; the Z.1 pair is 38.0T / 40.0T, or 0.95. */
+/** Synthetic cache includes the legacy index-points input; Z.1 is 38.0T / 40.0T. */
 const LEGS: Array<[string, Array<{ date: string; value: number }>]> = [
   ["W5000", obs([
     ["2024-01-02", 60_000],
@@ -99,7 +100,7 @@ async function settle() {
 
 const TEST_PANE_ID = "valuation:test";
 
-async function renderPane(settings: Record<string, unknown> = {}, width = 128) {
+async function renderPane(settings: Record<string, unknown> = {}, width = 128, height = 40) {
   const layout = {
     dockRoot: { kind: "pane" as const, instanceId: TEST_PANE_ID },
     instances: [{ instanceId: TEST_PANE_ID, paneId: "market-valuation", settings }],
@@ -111,24 +112,19 @@ async function renderPane(settings: Record<string, unknown> = {}, width = 128) {
     layout,
     layouts: [{ name: "Default", layout: cloneLayout(layout) }],
   });
-  setup = await testRender(
-    <AppContext value={{ state, dispatch: () => {} }}>
+  state.focusedPaneId = TEST_PANE_ID;
+  function Harness() {
+    const [current, dispatch] = useReducer(appReducer, state);
+    return <AppContext value={{ state: current, dispatch }}>
       <PaneInstanceProvider paneId={TEST_PANE_ID}>
-        <PaneFooterProvider>
-          {() => (
-            <MarketValuationPane
-              paneId={TEST_PANE_ID}
-              paneType="market-valuation"
-              focused
-              width={width}
-              height={40}
-            />
-          )}
-        </PaneFooterProvider>
+        <PaneFooterProvider>{footer => <Box width={width} height={height + 1} flexDirection="column">
+          <Box height={height}><MarketValuationPane paneId={TEST_PANE_ID} paneType="market-valuation" focused width={width} height={height}/></Box>
+          <PaneFooterBar footer={footer} focused width={width}/>
+        </Box>}</PaneFooterProvider>
       </PaneInstanceProvider>
-    </AppContext>,
-    { width, height: 40 },
-  );
+    </AppContext>;
+  }
+  setup = await testRender(<Harness/>, { width, height: height + 1 });
   await settle();
   return setup.captureCharFrame();
 }
@@ -147,45 +143,29 @@ afterEach(async () => {
   resetValuationPersistence();
 });
 
+
 describe("MarketValuationPane", () => {
-  test("summarizes every indicator in one table, each in its own units", async () => {
+  test("retired index-point ratios stay unavailable beside valid monetary and direct measures", async () => {
     const frame = await renderPane();
     // A percent, a bare multiple, and two yields all sit in one VALUE column.
     for (const label of ["Buffett", "CAPE", "Tobin Q", "Equity alloc", "Div yield", "Cap / M2"]) {
       expect(frame).toContain(label);
     }
-    expect(frame).toContain("234%");
+    expect(frame).not.toContain("234%");
+    expect(frame).toMatch(/Buffett\s+--\s+Unavailable/);
     expect(frame).toContain("41.2");
     expect(frame).toContain("0.95");
-    expect(frame).toContain("329%");
-  });
-
-  test("wide panes put the list beside the detail, narrow ones stack it", async () => {
-    const split = await renderPane({}, 128);
-    // In the split the chart shares a line with the list rows.
-    expect(split).toMatch(/Buffett.*\n/);
-    const stacked = await renderPane({}, 92);
-    expect(stacked).toContain("Buffett");
-    expect(stacked).toContain("Cap / M2");
-  });
-
-  test("the filter narrows the list without blanking the detail", async () => {
-    const frame = await renderPane();
-    expect(frame).toContain("filter indicators");
-  });
-
-  test("a yield reads cheap when it is high, unlike a price ratio", async () => {
-    const frame = await renderPane();
-    // Both Buffett at 234% and an excess CAPE yield of 1.0% mean expensive.
-    expect(frame).toMatch(/Buffett\s+234%\s+Sig\. over/);
-    expect(frame).toMatch(/ERP \(ECY\)\s+1\.0%\s+Sig\. over/);
+    expect(frame).not.toContain("329%");
+    expect(frame).toMatch(/Cap \/ profits\s+--\s+Unavailable/);
+    expect(frame).toMatch(/Cap \/ M2\s+--\s+Unavailable/);
+    expect(frame).toContain("index points; dollar market capitalization is unavailable");
   });
 
   test("detail follows the selected indicator without repeating the row", async () => {
     const frame = await renderPane({ indicator: "tobins-q" });
     expect(frame).toContain("Equities");
     expect(frame).toContain("Net worth");
-    expect(frame).toContain("replacement cost");
+    expect(frame).toContain("equities = net worth");
     expect(frame).not.toContain("Mkt cap");
     // The row above already names the indicator and its zone.
     expect(frame).not.toContain("Fair Valued");
@@ -193,14 +173,14 @@ describe("MarketValuationPane", () => {
 
   test("a direct indicator shows no dollar levels row", async () => {
     const frame = await renderPane({ indicator: "shiller-cape" });
-    expect(frame).toContain("ten years of real earnings");
+    expect(frame).toContain("ten-year mean real earnings");
     expect(frame).not.toContain("Mkt cap");
     expect(frame).not.toContain("Equities");
   });
 
   test("draws the mean apart from the reference line", async () => {
-    const frame = await renderPane();
-    expect(frame).toContain("parity");
+    const frame = await renderPane({ indicator: "tobins-q" });
+    expect(frame).toContain("equities = net worth");
     expect(frame).toContain("mean");
   });
 });
@@ -244,4 +224,37 @@ describe("shouldPersistSelection", () => {
       knownIds,
     })).toBe(false);
   });
+});
+
+
+test("unavailable rows remain selectable alongside usable indicators", async () => {
+  await renderPane({ indicator: "buffett" }, 80);
+  const lines = setup!.captureCharFrame().split("\n");
+  const y = lines.findIndex((line) => /CAPE\s+41.2/.test(line));
+  expect(y).toBeGreaterThan(0);
+  await act(async () => { await setup!.mockMouse.click(3, y); });
+  await settle();
+  expect(setup!.captureCharFrame()).not.toContain("Buffett Indicator unavailable");
+  expect(setup!.captureCharFrame()).toContain("ten-year mean real earnings");
+  await act(async () => {
+    await setup!.mockInput.pressArrow("up");
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  });
+  await settle();
+  expect(setup!.captureCharFrame()).toContain("Buffett Indicator unavailable");
+});
+
+test("a short stacked pane scrolls to monetary basis, extrema dates and source", async () => {
+  await renderPane({ indicator: "tobins-q" }, 48, 25);
+  for (let i = 0; i < 10; i += 1) {
+    await act(async () => { await setup!.mockMouse.scroll(47, 20, "down"); });
+  }
+  await settle();
+  const frame = setup!.captureCharFrame();
+  expect(frame).toContain("38.0T");
+  expect(frame).toContain("40.0T");
+  expect(frame).toContain("Net worth as of 2026Q1");
+  expect(frame).toContain("2024-01-01");
+  expect(frame).toContain("2026-01-01");
+  expect(frame).toContain("Tobin's q, Wikipedia");
 });

--- a/src/plugins/builtin/market-valuation/pane.tsx
+++ b/src/plugins/builtin/market-valuation/pane.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
   DataTableView,
-  EmptyState,
+  EmptyState, ExternalLinkText,
   InputSearchBar, Notice, PaneStatusBody, SegmentedControl, type DataTableCell,
   type DataTableColumn,
   type DataTableKeyEvent,
@@ -13,15 +13,16 @@ import { useShortcut } from "../../../react/input";
 import { usePaneSettingValue } from "../../../state/app/context";
 import { colors } from "../../../theme/colors";
 import type { PaneProps } from "../../../types/plugin";
-import { Box, ScrollBox, type InputRenderable } from "../../../ui";
+import { Box, ScrollBox, Text, type InputRenderable } from "../../../ui";
 import { formatNumber } from "../../../utils/format";
 import { isPlainKey } from "../../../utils/keyboard";
 import { stopSearchFocusNavigation } from "../../../utils/search-focus-navigation";
 import { useAutoRefresh } from "../shared/auto-refresh";
 import { usePaneStatusFooter } from "../shared/pane-footer";
 import { getCachedValuationBundle, loadValuationBundle } from "./client";
-import { shortZoneLabel, type ValuationRangeId } from "./defs";
+import { indicatorUnavailableReason, shortZoneLabel, type IndicatorDef, type ValuationRangeId } from "./defs";
 import { IndicatorDetail } from "./detail";
+import { INDICATORS } from "./indicators";
 import { RANGE_OPTIONS, VALUATION_DEFAULTS } from "./settings";
 import {
   formatSigma,
@@ -38,13 +39,19 @@ const LIST_WIDTH = 46;
 type ColumnId = "name" | "value" | "zone" | "percentile" | "sigma";
 interface Column extends DataTableColumn { id: ColumnId }
 
-function matchesQuery(view: IndicatorViewModel, query: string): boolean {
+interface IndicatorRow {
+  indicator: IndicatorDef;
+  view: IndicatorViewModel | null;
+  error: string | null;
+}
+
+function matchesQuery(row: IndicatorRow, query: string): boolean {
   if (!query) return true;
   const haystack = [
-    view.indicator.label,
-    view.indicator.shortLabel,
-    view.indicator.description,
-    view.zone.label,
+    row.indicator.label,
+    row.indicator.shortLabel,
+    row.indicator.description,
+    row.view?.zone.label,
   ].join(" ").toLowerCase();
   return query.split(/\s+/).every((token) => haystack.includes(token));
 }
@@ -66,7 +73,17 @@ function buildColumns(width: number, stacked: boolean): Column[] {
   ];
 }
 
-function cellsFor(view: IndicatorViewModel): Record<ColumnId, DataTableCell> {
+function cellsFor(row: IndicatorRow): Record<ColumnId, DataTableCell> {
+  const view = row.view;
+  if (!view) {
+    return {
+      name: { text: row.indicator.shortLabel, color: colors.textBright },
+      value: { text: "--", color: colors.textDim },
+      zone: { text: "Unavailable", color: colors.warning },
+      percentile: { text: "--", color: colors.textDim },
+      sigma: { text: "--", color: colors.textDim },
+    };
+  }
   return {
     name: { text: view.indicator.shortLabel, color: colors.textBright },
     value: { text: view.indicator.formatValue(view.current.ratio), color: view.zone.color },
@@ -144,14 +161,20 @@ export function MarketValuationPane({ focused, width, height }: PaneProps) {
     () => (bundle ? selectValuationViews(bundle, range) : []),
     [bundle, range],
   );
+  const rows = useMemo<IndicatorRow[]>(() => bundle ? INDICATORS.flatMap((indicator) => {
+    const view = views.find((entry) => entry.indicator.id === indicator.id) ?? null;
+    const error = indicatorUnavailableReason(indicator);
+    return view || error ? [{ indicator, view, error }] : [];
+  }) : [], [bundle, views]);
   const normalizedQuery = query.trim().toLowerCase();
   const visible = useMemo(
-    () => views.filter((view) => matchesQuery(view, normalizedQuery)),
-    [normalizedQuery, views],
+    () => rows.filter((row) => matchesQuery(row, normalizedQuery)),
+    [normalizedQuery, rows],
   );
   // Filtering narrows the list, but the detail keeps showing the chosen indicator
   // until the user picks another, so typing never blanks the chart.
-  const selected = views.find((view) => view.indicator.id === indicatorId) ?? views[0] ?? null;
+  const selected = rows.find((row) => row.indicator.id === indicatorId) ?? rows[0] ?? null;
+  const selectedView = selected?.view;
   const selectionOnScreen = visible.some((view) => view.indicator.id === selected?.indicator.id);
 
   const chooseIndicator = useCallback((
@@ -162,26 +185,34 @@ export function MarketValuationPane({ focused, width, height }: PaneProps) {
       id,
       reason,
       selectionOnScreen,
-      knownIds: views.map((view) => view.indicator.id),
+      knownIds: rows.map((row) => row.indicator.id),
     })) return;
     setIndicatorId(id);
-  }, [selectionOnScreen, setIndicatorId, views]);
+  }, [selectionOnScreen, setIndicatorId, rows]);
 
-  const error = resource.error ?? bundle?.errors[0] ?? null;
+  const basisErrors = new Set(INDICATORS.flatMap((indicator) => {
+    const reason = indicatorUnavailableReason(indicator);
+    return reason ? [`${indicator.label}: ${reason}`] : [];
+  }));
+  const sourceError = bundle?.errors.find((entry) => !basisErrors.has(entry));
+  const unavailableCount = bundle?.errors.filter((entry) => basisErrors.has(entry)).length ?? 0;
+  const bodyError = resource.error ?? sourceError ?? null;
+  const error = bodyError ?? selected?.error
+    ?? (unavailableCount ? `${unavailableCount} unavailable` : null);
   const footerInfo = useMemo<PaneFooterSegment[]>(() => {
-    if (!selected) return [];
+    if (!selectedView) return [];
     const info: PaneFooterSegment[] = [
-      { id: "as-of", parts: [{ text: `as of ${selected.asOf}`, tone: "muted" }] },
-      { id: "delayed", parts: [{ text: "delayed", tone: "muted" }] },
+      { id: "as-of", parts: [{ text: `as of ${selectedView.asOf}`, tone: "muted" }] },
+      ...(width >= 80 ? [{ id: "delayed", parts: [{ text: "delayed", tone: "muted" as const }] }] : []),
     ];
-    if (selected.observationStale) {
+    if (selectedView.observationStale) {
       info.push({ id: "stale", parts: [{ text: "STALE", tone: "warning", bold: true }] });
     }
     if (normalizedQuery) {
       info.push({ id: "filter", parts: [{ text: `filter: ${normalizedQuery}`, tone: "value" }] });
     }
     return info;
-  }, [normalizedQuery, selected]);
+  }, [normalizedQuery, selectedView, width]);
 
   usePaneStatusFooter({
     registrationId: "market-valuation",
@@ -212,6 +243,9 @@ export function MarketValuationPane({ focused, width, height }: PaneProps) {
   const tableHeight = split
     ? Math.max(3, height - 2)
     : Math.min(visible.length + 2, Math.max(3, height - 12));
+  // The stacked table consumes rows outside the detail scroll viewport.
+  const bodyHeight = Math.max(1, height - (bodyError ? 1 : 0));
+  const detailHeight = split ? bodyHeight : Math.max(1, bodyHeight - tableHeight - 1);
 
   const list = (
     <Box flexDirection="column" width={listWidth} flexShrink={0}>
@@ -229,7 +263,7 @@ export function MarketValuationPane({ focused, width, height }: PaneProps) {
         onQueryChange={setQuery}
       />
       <Box flexDirection="column" width={listWidth} height={tableHeight} flexShrink={0} overflow="hidden">
-        <DataTableView<IndicatorViewModel, Column>
+        <DataTableView<IndicatorRow, Column>
           focused={focused && !searchFocused}
           rootWidth={listWidth}
           rootHeight={tableHeight}
@@ -254,7 +288,7 @@ export function MarketValuationPane({ focused, width, height }: PaneProps) {
   );
 
   const detail = (
-    <Box flexDirection="column" flexGrow={1} width={detailWidth} overflow="hidden">
+    <Box flexDirection="column" flexGrow={1} width={detailWidth} height={detailHeight} overflow="hidden">
       <Box flexDirection="row" height={1} paddingX={1} overflow="hidden" justifyContent="flex-end">
         <SegmentedControl
           options={RANGE_OPTIONS}
@@ -262,14 +296,24 @@ export function MarketValuationPane({ focused, width, height }: PaneProps) {
           onChange={(value) => setRange(value as ValuationRangeId)}
         />
       </Box>
-      <ScrollBox flexGrow={1} scrollY focusable={false}>
+      <ScrollBox height={Math.max(1, detailHeight - 1)} scrollY focusable={false}>
         <Box flexDirection="column" paddingBottom={1}>
-          <IndicatorDetail
-            view={selected}
+          {selectedView ? <IndicatorDetail
+            view={selectedView}
             width={detailWidth}
             height={Math.max(12, height - (split ? 3 : tableHeight + 3))}
             focused={focused && !searchFocused}
-          />
+          /> : (
+            <Box flexDirection="column" padding={1} gap={1}>
+              <EmptyState status="error" title={`${selected.indicator.label} unavailable`} message={selected.error ?? undefined} />
+              <Text fg={colors.textDim} wrapMode="word" wrapText>{selected.indicator.description}</Text>
+              {selected.indicator.link ? <ExternalLinkText
+                url={selected.indicator.link.url}
+                label={selected.indicator.link.label}
+                color={colors.textDim}
+              /> : null}
+            </Box>
+          )}
         </Box>
       </ScrollBox>
     </Box>
@@ -281,9 +325,9 @@ export function MarketValuationPane({ focused, width, height }: PaneProps) {
         {list}
         {detail}
       </Box>
-      {error ? (
+      {bodyError ? (
         <Box height={1} paddingX={1} overflow="hidden">
-          <Notice>{error}</Notice>
+          <Notice>{bodyError}</Notice>
         </Box>
       ) : null}
     </Box>


### PR DESCRIPTION
VAL treated raw Wilshire index points as USD billions, producing unsupported Buffett, cap/profits and cap/M2 values and valuation zones. Block those calculations at the shared model boundary, including persisted observations, injected loaders and chart/CLI paths. Keep the unavailable measures selectable with a source-unit reason and preserve independent indicators. Household allocation charts now retain percentage units instead of labelling a 45.8% allocation as 45.8x; source-basis labels also match the configured FRED measures.

ECST and VAL detail scrollers used the full pane height below their tables, leaving source details and dates clipped beyond the actual viewport. Allocate the remaining height and retain narrow value/date groups so mouse scrolling reaches the metadata. Move recurring methodology to linked economics and valuation references, consolidate source labels, and preserve search, existing controls, dates, units and current failures.

Validation: recorded public-input replay reproduces the old monetary ratios and confirms guarded unavailability. Focused regressions exercise caches, chart/CLI boundaries, selection and narrow-pane mouse scrolling. Final source 154eea98 passed 3,162 tests / 13,018 assertions, all six runtime TypeScript projects, and generated plugin/proxy checks. Local browser/native validation remains unavailable under the existing tool restrictions; these captures are in-process OpenTUI replays. No release or version change.
