### PR TITLE
Fix reporting periods, currency bases and futures chart data

### DIFF
--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -24,6 +24,8 @@ Statements are the latest available source snapshots and may include restatement
 
 Financial table headers retain reporting currencies and date-source markers: **P** means a provider period date, which may be approximate; **S** means a SEC-corroborated fiscal date. Filing evidence identifies the period without establishing a publication date for every metric. Mixed or missing reporting currencies are not silently converted.
 
+Chart-derived P/E, price/sales, EV/sales, EV/EBITDA and price/free-cash-flow require compatible price and statement currencies. A statement's own currency takes precedence; aggregate reporting currency fills missing row metadata only when the other statements do not contradict it. Explicit minor units such as GBp/GBX convert to GBP without an FX assumption. Foreign or unknown currency pairs remain unavailable with a chart and export warning. Separately converted summary fundamentals do not establish historical statement units, and this conversion does not change provider share or depositary-receipt bases.
+
 SEC EPS uses corroborated split-adjusted share bases. Unverified bases are unavailable. Nonpositive P/E values display as **N/M** and are excluded from meaningful P/E rankings.
 
 Market capitalization can come from a financial snapshot when a current quote does not supply it. Its retrieval time is not its valuation date. Source and freshness details remain attached to the affected value; market-cap comparisons require a valid currency conversion.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -83,6 +83,8 @@ Open **Series** to add, remove, reorder, or hide series and choose each series' 
 
 The toolbar controls preset or exact date ranges, intervals from one minute through monthly, the primary chart mode, technical indicators, and pair formulas. Indicators include volume, SMA, EMA, Bollinger Bands, RSI, and MACD; formulas include ratio, spread, and rolling correlation. Mixed-frequency values use as-of alignment: fundamentals use filing dates when available, sparse series carry forward only after becoming available, and missing publication dates are called out in the chart status.
 
+`GIP` session loading retains finite zero and negative prices when provider metadata identifies a futures instrument. If another or unknown instrument type reports a nonpositive close in the selected window or its calculation buffer, the result is unavailable; JSON metadata retains the rejected values and dates in `intradayPriceDomainFailures`. Inconsistent OHLC bars still become gaps. Logarithmic scales and transforms retain their positive-value requirement.
+
 ### Markets, News, and Macro
 
 | Shortcut | Function |

--- a/src/api-client/types.ts
+++ b/src/api-client/types.ts
@@ -659,6 +659,8 @@ export interface CloudFilingEventPayload {
     shortName: string;
   };
   filedAt: string;
+  /** Verified SEC filing calendar date; filedAt may instead be an acceptance instant. */
+  filingDate?: string | null;
   docUrl: string;
   items: string[];
   labels: string[];

--- a/src/market-data/snapshot-provider.ts
+++ b/src/market-data/snapshot-provider.ts
@@ -1,5 +1,5 @@
 import type { DataProvider, CachedFinancialsTarget, TickerFinancialsBatchResult, QuoteBatchResult } from "../types/data-provider";
-import type { OptionsChain, PricePoint, TickerFinancials } from "../types/financials";
+import type { OptionsChain, PricePoint, Quote, TickerFinancials } from "../types/financials";
 import { canonicalTickerKey, parsePublicTickerKey } from "../utils/exchanges";
 import { clipPriceHistoryToRange } from "../time-series/history-window";
 import { getPresetResolution, normalizeChartResolutionSupport, TIME_RANGE_ORDER, type ManualChartResolution } from "../time-series/resolution";
@@ -12,6 +12,8 @@ export interface SnapshotMarketData {
     resolution: ManualChartResolution;
     points: PricePoint[];
     unavailableReason: string | null;
+    /** Metadata already fetched to validate the captured history's price domain. */
+    quote?: Quote;
   }>;
   optionsChains?: ReadonlyArray<readonly [string, OptionsChain]>;
 }
@@ -75,11 +77,11 @@ export function createSnapshotDataProvider(snapshot: SnapshotMarketData, fallbac
       }))));
     },
     async getQuote(symbol, exchange, context) {
-      return financials(symbol, exchange)?.quote ?? fallback.getQuote(symbol, exchange, context);
+      return intraday(symbol, exchange)?.quote ?? financials(symbol, exchange)?.quote ?? fallback.getQuote(symbol, exchange, context);
     },
     getQuotesBatch(targets, settings) {
       return seededBatch(targets, (target): QuoteBatchResult | undefined => {
-        const quote = financials(target.symbol, target.exchange)?.quote;
+        const quote = intraday(target.symbol, target.exchange)?.quote ?? financials(target.symbol, target.exchange)?.quote;
         return quote ? { target, quote } : undefined;
       }, (missing) => fallback.getQuotesBatch?.(missing, settings) ?? Promise.all(missing.map(async (target) => ({
         target, quote: await fallback.getQuote(target.symbol, target.exchange, target.context),

--- a/src/market-data/snapshot-provider.ts
+++ b/src/market-data/snapshot-provider.ts
@@ -18,6 +18,14 @@ export interface SnapshotMarketData {
   optionsChains?: ReadonlyArray<readonly [string, OptionsChain]>;
 }
 
+/** A captured result is authoritative; trying another interval cannot repair it. */
+export class SnapshotHistoryUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SnapshotHistoryUnavailableError";
+  }
+}
+
 const SNAPSHOT_RESOLUTIONS = normalizeChartResolutionSupport(
   TIME_RANGE_ORDER.map((maxRange) => ({ resolution: getPresetResolution(maxRange), maxRange })),
 );
@@ -48,7 +56,7 @@ export function createSnapshotDataProvider(snapshot: SnapshotMarketData, fallbac
   const intraday = lookup((snapshot.intradayHistories ?? []).map((history) => [canonicalTickerKey(history.symbol, history.exchange), history]));
   const history = (symbol: string, exchange?: string, resolution?: string) => {
     const captured = intraday(symbol, exchange);
-    if (captured?.unavailableReason) throw new Error(captured.unavailableReason);
+    if (captured?.unavailableReason) throw new SnapshotHistoryUnavailableError(captured.unavailableReason);
     if (captured && resolution && captured.resolution !== resolution) return [];
     return captured?.points ?? financials(symbol, exchange)?.priceHistory;
   };

--- a/src/plugins/builtin/chart-composer/headless.ts
+++ b/src/plugins/builtin/chart-composer/headless.ts
@@ -195,7 +195,9 @@ export function chartHeadless(template: keyof typeof paneSchemas): HeadlessPaneD
         if (!model.snapshot.financials.some(([candidate]) => candidate === key)) {
           model.snapshot.financials.push([key, { annualStatements: [], quarterlyStatements: [], priceHistory: points }]);
         }
-        if (unavailableReason && !model.chart.errors.includes(unavailableReason)) model.chart.errors.push(unavailableReason);
+        if (unavailableReason && !model.chart.errors.some((error) => error === unavailableReason || error.endsWith(`: ${unavailableReason}`))) {
+          model.chart.errors.push(unavailableReason);
+        }
       }
       return model;
     },

--- a/src/plugins/builtin/chart-composer/headless.ts
+++ b/src/plugins/builtin/chart-composer/headless.ts
@@ -5,7 +5,7 @@ import { priceHistoryIntegrityNotices, chartPriceHistoryIntegrityNotices } from 
 import type { HeadlessPaneContext, HeadlessPaneDefinition, HeadlessSeriesResult } from "../../../types/headless";
 import type { ChartResolutionResult, ChartSeriesSpec, ChartSpec } from "../../../time-series/types";
 import { mergePriceHistoryWindows, resolveChartSpecData } from "../../../time-series/resolve";
-import { intradaySessionDates, loadIntradayWindow, resolveIntradayRequest, type IntradayRequest, type IntradayWindow } from "../../../time-series/session-history";
+import { intradaySessionDates, loadIntradayWindow, resolveIntradayRequest, type IntradayRequest, type IntradayWindow, type LoadedIntradayWindow } from "../../../time-series/session-history";
 import { createSnapshotDataProvider } from "../../../market-data/snapshot-provider";
 import type { TickerFinancials, PricePoint } from "../../../types/financials";
 import { createChartSeriesResolver } from "../../../capabilities";
@@ -19,7 +19,7 @@ export interface ChartPaneModel extends HeadlessSeriesResult {
   spec: ChartSpec;
   snapshot: {
     financials: Array<[string, TickerFinancials]>;
-    intradayHistories: Array<IntradayWindow & {
+    intradayHistories: Array<IntradayWindow & Pick<LoadedIntradayWindow, "quote" | "priceDomainFailure"> & {
       symbol: string;
       exchange: string;
       rangePreset: IntradayRequest["rangePreset"];
@@ -184,6 +184,12 @@ export function chartHeadless(template: keyof typeof paneSchemas): HeadlessPaneD
         }
       }
       model.snapshot.intradayHistories = intradayHistories;
+      const priceDomainFailures = intradayHistories.flatMap(({ symbol, exchange, priceDomainFailure }) =>
+        priceDomainFailure ? [{ symbol, exchange, ...priceDomainFailure }] : []);
+      if (priceDomainFailures.length) {
+        model.complete = false;
+        model.metadata = { ...model.metadata, intradayPriceDomainFailures: priceDomainFailures };
+      }
       for (const { symbol, exchange, points, unavailableReason } of intradayHistories) {
         const key = publicTickerKey(symbol, exchange);
         if (!model.snapshot.financials.some(([candidate]) => candidate === key)) {

--- a/src/plugins/builtin/filing-events/feed.test.ts
+++ b/src/plugins/builtin/filing-events/feed.test.ts
@@ -22,6 +22,50 @@ function filingEvent(overrides: Partial<CloudFilingEventPayload> = {}): CloudFil
 }
 
 describe("buildFilingEventsFeed", () => {
+  test("keeps explicit filing and personnel calendar dates across time zones while legacy instants stay local", () => {
+    const event = filingEvent({
+      filedAt: "2026-09-01T01:30:00Z",
+      read: true,
+      headline: "Officer appointment",
+      people: [{ name: "Officer", role: "CEO", action: "joined", effective: "2026-09-01" }],
+    });
+    const events = [
+      { ...event, filingDate: "2026-09-01" },
+      event,
+      { ...event, filingDate: "2026-02-29" },
+    ];
+    for (const [timezone, filed] of [
+      ["America/Los_Angeles", "Aug 31, 26"],
+      ["Europe/Berlin", "Sep 01, 26"],
+      ["Pacific/Auckland", "Sep 01, 26"],
+    ]) {
+      const result = Bun.spawnSync([process.execPath, "--eval", `
+        import { buildFilingEventsFeed } from ${JSON.stringify(new URL("./feed.ts", import.meta.url).href)};
+        console.log(JSON.stringify(buildFilingEventsFeed(${JSON.stringify(events)}, 80)));
+      `], { env: { ...process.env, TZ: timezone! } });
+      expect(result.exitCode).toBe(0);
+      const feed = JSON.parse(result.stdout.toString());
+      expect(feed.entries.map((entry: { filedLabel: string }) => entry.filedLabel)).toEqual(["Sep 01, 26", filed, filed]);
+      expect(feed.entries[0].people[0].detail).toBe("CEO, joined, effective Sep 01, 26");
+      expect(feed.summaryLine).toContain(`since ${filed}`);
+    }
+  });
+
+  test("validates source calendar dates without normalizing an invalid day into another month", () => {
+    const feed = buildFilingEventsFeed([filingEvent({
+      read: true, headline: "Appointment", filingDate: "2024-02-29",
+      people: [
+        { name: "Valid", role: "CEO", action: "joined", effective: "2024-02-29" },
+        { name: "Invalid", role: "CFO", action: "joined", effective: "2026-02-29" },
+      ],
+    })], 80);
+    expect(feed.entries[0]?.filedLabel).toBe("Feb 29, 24");
+    expect(feed.summaryLine).toContain("since Feb 29, 24");
+    expect(feed.entries[0]?.people.map((person) => person.detail)).toEqual([
+      "CEO, joined, effective Feb 29, 24", "CFO, joined, effective —",
+    ]);
+  });
+
   test("puts what a model read first and leaves the rest below", () => {
     const feed = buildFilingEventsFeed([
       filingEvent({ id: "routine", filedAt: "2026-07-22T00:00:00.000Z" }),

--- a/src/plugins/builtin/filing-events/feed.ts
+++ b/src/plugins/builtin/filing-events/feed.ts
@@ -40,7 +40,7 @@ export interface FilingEventsFeed {
   entries: FilingEventEntry[];
 }
 
-function formatFiled(value: string): string {
+function formatInstant(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "—";
   return date.toLocaleDateString("en-US", {
@@ -48,6 +48,19 @@ function formatFiled(value: string): string {
     day: "2-digit",
     year: "2-digit",
   });
+}
+
+function formatCalendarDate(value: string | null | undefined): string | null {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const date = new Date(`${value}T00:00:00Z`);
+  if (!Number.isFinite(date.getTime()) || date.toISOString().slice(0, 10) !== value) return null;
+  return date.toLocaleDateString("en-US", {
+    month: "short", day: "2-digit", year: "2-digit", timeZone: "UTC",
+  });
+}
+
+function formatFiled(event: CloudFilingEventPayload): string {
+  return formatCalendarDate(event.filingDate) ?? formatInstant(event.filedAt);
 }
 
 function itemsLabel(event: CloudFilingEventPayload): string {
@@ -60,7 +73,7 @@ function personDetail(person: CloudFilingEventPayload["people"][number]): string
   return [
     person.role,
     person.action,
-    person.effective ? `effective ${formatFiled(person.effective)}` : null,
+    person.effective ? `effective ${formatCalendarDate(person.effective) ?? "—"}` : null,
   ].filter(Boolean).join(", ");
 }
 
@@ -92,7 +105,7 @@ function buildEntry(
   for (const person of people) lines += proseLines(person.detail, proseWidth, `${person.name}  `);
   return {
     id: event.id,
-    filedLabel: formatFiled(event.filedAt),
+    filedLabel: formatFiled(event),
     itemsLabel: itemsLabel(event),
     docUrl: event.docUrl,
     material: event.material,
@@ -105,7 +118,7 @@ function buildEntry(
 
 function summaryLine(events: CloudFilingEventPayload[], newsCount: number): string {
   const oldest = events[events.length - 1];
-  const since = oldest ? ` since ${formatFiled(oldest.filedAt)}` : "";
+  const since = oldest ? ` since ${formatFiled(oldest)}` : "";
   const news = newsCount === 0
     ? "none carry news"
     : newsCount === 1

--- a/src/plugins/builtin/thirteenf/api.test.ts
+++ b/src/plugins/builtin/thirteenf/api.test.ts
@@ -4,9 +4,11 @@ import { setHttpFetchTransport } from "../../../utils/http-transport";
 import {
   attachThirteenFApiPersistence,
   lookupThirteenFTickers,
+  mapForm,
   resetThirteenFApiPersistence,
   searchThirteenFFunds,
 } from "./api";
+import { buildPeriodReports } from "./model";
 
 afterEach(() => {
   setHttpFetchTransport(null);
@@ -14,6 +16,23 @@ afterEach(() => {
 });
 
 describe("13F API", () => {
+  test("preserves amendment semantics when the source provides only the supported form_type alias", () => {
+    const base = {
+      cik: "1067983", period_of_report: "2026-06-30", accession_number: "original",
+      filed_as_of_date: "2026-08-14", form_type: "13F-HR", table_value_total: 100, table_entry_total: 1,
+    };
+    const original = mapForm(base)!;
+    const addition = mapForm({
+      ...base, accession_number: "addition", filed_as_of_date: "2026-08-20", form_type: "13F-HR/A",
+      amendment_type: "NEW HOLDINGS", table_value_total: 50,
+    })!;
+    expect(original.isAmendment).toBe(false);
+    expect(addition).toMatchObject({ submissionType: "13F-HR/A", isAmendment: true });
+    expect(buildPeriodReports([original, addition])[0]).toMatchObject({ complete: true, tableValueTotal: 150, tableEntryTotal: 2 });
+    const unknown = mapForm({ ...base, accession_number: "unknown", form_type: "13F-HR/A" })!;
+    expect(buildPeriodReports([unknown])[0]).toMatchObject({ complete: false, tableValueTotal: null });
+  });
+
   test("uses the shared HTTP transport", async () => {
     const urls: string[] = [];
     setHttpFetchTransport(async (url) => {

--- a/src/plugins/builtin/thirteenf/api.ts
+++ b/src/plugins/builtin/thirteenf/api.ts
@@ -159,17 +159,18 @@ export function mapForm(raw: any): ThirteenFFormSummary | null {
   const accessionNumber = normalizeAccessionNumber(raw.accession_number, raw.url);
   const periodOfReport = stringOrEmpty(raw.period_of_report);
   if (!cik || !accessionNumber || !periodOfReport) return null;
+  const submissionType = stringOrEmpty(raw.submission_type || raw.form_type);
   return {
     url: stringOrEmpty(raw.url),
     accessionNumber,
-    submissionType: stringOrEmpty(raw.submission_type || raw.form_type),
+    submissionType,
     periodOfReport,
     filedAsOfDate: stringOrEmpty(raw.filed_as_of_date),
     cik,
     companyName: stringOrEmpty(raw.company_name),
     tableValueTotal: numberOrNull(raw.table_value_total),
     tableEntryTotal: numberOrNull(raw.table_entry_total),
-    isAmendment: boolOrFalse(raw.is_amendment) || stringOrEmpty(raw.submission_type).includes("/A"),
+    isAmendment: boolOrFalse(raw.is_amendment) || submissionType.includes("/A"),
     amendmentType: stringOrEmpty(raw.amendment_type) || undefined,
   };
 }

--- a/src/plugins/builtin/thirteenf/data.test.ts
+++ b/src/plugins/builtin/thirteenf/data.test.ts
@@ -14,6 +14,36 @@ afterEach(() => {
 });
 
 describe("13F data cache", () => {
+  test("keeps performance returns and latest filing metadata in their own reporting periods", async () => {
+    let reportedPeriod = "2026-09-30";
+    setHttpFetchTransport(async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path.endsWith("/funds")) return json([{ cik: "1067983", name: "Fund" }]);
+      if (path.endsWith("/topfunds")) return json([{
+        cik: "1067983", name: "Fund", period_of_report: "2026-06-30", pnl: 12,
+      }]);
+      if (path.endsWith("/forms")) return json([{
+        accession_number: "filing", cik: "1067983", company_name: "Fund", submission_type: "13F-HR",
+        period_of_report: reportedPeriod, filed_as_of_date: "2026-10-15", table_value_total: 100, table_entry_total: 2,
+      }]);
+      return json([]);
+    });
+    const performance = await loadBrowserRows("performance", "");
+    expect(performance.rows[0]).toMatchObject({ periodOfReport: "2026-06-30", estQuarterReturn: 12 });
+    expect(performance.rows[0]?.tableValueTotal).toBeUndefined();
+    expect(performance.rows[0]?.filedAsOfDate).toBeUndefined();
+    expect(performance.rows[0]?.tableEntryTotal).toBeUndefined();
+
+    const funds = await loadBrowserRows("funds", "Fund");
+    expect(funds.rows[0]).toMatchObject({ periodOfReport: "2026-09-30", tableValueTotal: 100, estQuarterReturn: null });
+
+    reportedPeriod = "2026-06-30";
+    for (const tab of ["performance", "funds"] as const) {
+      const matching = await loadBrowserRows(tab, "Fund");
+      expect(matching.rows[0]).toMatchObject({ periodOfReport: "2026-06-30", tableValueTotal: 100, estQuarterReturn: 12 });
+    }
+  });
+
   test("loads all additive filings, uses their combined denominator, and detects truncated holdings", async () => {
     const fetched: string[] = [];
     const forms = [

--- a/src/plugins/builtin/thirteenf/model.ts
+++ b/src/plugins/builtin/thirteenf/model.ts
@@ -126,16 +126,22 @@ export function buildBrowserRows(options: {
   const funds = options.funds ?? options.topFunds ?? [];
   return funds.map((fund) => {
     const topFund = topByCik.get(fund.cik);
-    const form = options.forms?.get(fund.cik);
+    const latestForm = options.forms?.get(fund.cik);
+    // Performance belongs to its supplied quarter; a later (or stale) filing
+    // cannot supply that quarter's portfolio value or filing date.
+    const periodOfReport = options.source === "performance"
+      ? topFund?.periodOfReport ?? latestForm?.periodOfReport
+      : latestForm?.periodOfReport ?? topFund?.periodOfReport;
+    const form = latestForm?.periodOfReport === periodOfReport ? latestForm : undefined;
     return {
       id: `${options.source}:${fund.cik}`,
       cik: fund.cik,
       name: fund.name,
-      periodOfReport: form?.periodOfReport ?? topFund?.periodOfReport,
+      periodOfReport,
       filedAsOfDate: form?.filedAsOfDate,
       tableValueTotal: form?.tableValueTotal,
       tableEntryTotal: form?.tableEntryTotal,
-      estQuarterReturn: topFund?.pnl ?? null,
+      estQuarterReturn: topFund && topFund.periodOfReport === periodOfReport ? topFund.pnl : null,
       source: options.source,
     };
   });

--- a/src/time-series/fundamentals.test.ts
+++ b/src/time-series/fundamentals.test.ts
@@ -12,7 +12,11 @@ function financials(
   annualStatements: FinancialStatement[],
   priceHistory: TickerFinancials["priceHistory"] = [],
 ): TickerFinancials {
-  return { quarterlyStatements, annualStatements, priceHistory };
+  return {
+    quarterlyStatements, annualStatements, priceHistory, financialCurrency: "USD",
+    // Price metadata establishes historical USD units without adding a current observation.
+    quote: { symbol: "TEST", currency: "USD", price: 0, change: 0, changePercent: 0, lastUpdated: 0 },
+  };
 }
 
 function source(

--- a/src/time-series/fundamentals.ts
+++ b/src/time-series/fundamentals.ts
@@ -6,6 +6,7 @@ import type {
 import { areNearbyFinancialPeriodEnds, completeAvailability, statementFieldAvailability } from "../utils/financial-statements";
 import { canonicalTimeSeriesFieldId, getTimeSeriesField } from "./field-catalog";
 import { reportingCurrencySeries } from "./reporting-currency";
+import { createValuationCurrencyContext, type ValuationCurrencyContext } from "./valuation-currency";
 import type { SecuritySeriesSource, SeriesPeriod, TimeSeriesPoint } from "./types";
 
 type NumericStatementField =
@@ -633,11 +634,12 @@ function historicalValuation(
   financials: TickerFinancials,
   statement: FinancialStatement,
   metric: string,
+  currencies: ValuationCurrencyContext,
 ): number | null {
-  if (statement.currency && financials.quote?.currency && statement.currency !== financials.quote.currency) return null;
   const priceDate = metricAvailability(statement, metric) ?? statement.date;
   const price = priceAtOrBefore(financials.priceHistory, priceDate);
-  return price === null ? null : valuationAtPrice(statement, metric, price);
+  const comparablePrice = price === null ? null : currencies.priceInStatementUnits(statement, price);
+  return comparablePrice === null ? null : valuationAtPrice(statement, metric, comparablePrice);
 }
 
 function valuationAtPrice(
@@ -695,6 +697,7 @@ function currentDerivedValuationPoint(
   financials: TickerFinancials,
   statements: readonly FinancialStatement[],
   metric: string,
+  currencies: ValuationCurrencyContext,
 ): TimeSeriesPoint | null {
   const quote = financials.quote;
   const quoteDate = validDate(quote?.lastUpdated);
@@ -702,11 +705,12 @@ function currentDerivedValuationPoint(
   const quoteTime = quoteDate.getTime();
   const statement = statements
     .flatMap((candidate) => {
-      if (candidate.currency && quote.currency && candidate.currency !== quote.currency) return [];
+      const comparablePrice = currencies.priceInStatementUnits(candidate, quote.price);
+      if (comparablePrice === null) return [];
       const availableAt = validDate(metricAvailability(candidate, metric) ?? candidate.date);
       const observedAt = validDate(candidate.date);
       if (!availableAt || !observedAt || availableAt.getTime() > quoteTime) return [];
-      if (valuationAtPrice(candidate, metric, quote.price) === null) return [];
+      if (valuationAtPrice(candidate, metric, comparablePrice) === null) return [];
       return [{ candidate, observedAt: observedAt.getTime(), availableAt: availableAt.getTime() }];
     })
     .sort((left, right) => (
@@ -714,7 +718,9 @@ function currentDerivedValuationPoint(
     ))
     .at(-1)?.candidate;
   if (!statement) return null;
-  const value = valuationAtPrice(statement, metric, quote.price);
+  const comparablePrice = currencies.priceInStatementUnits(statement, quote.price);
+  if (comparablePrice === null) return null;
+  const value = valuationAtPrice(statement, metric, comparablePrice);
   if (value === null) return null;
   return {
     date: quoteDate,
@@ -835,8 +841,9 @@ export function extractFundamentalSeries(
   }
 
   const selected = sourceStatements(financials, source.period, metric);
+  const currencies = createValuationCurrencyContext(financials);
   const historical = selected.statements.flatMap((statement) => {
-    const value = historicalValuation(financials, statement, metric);
+    const value = historicalValuation(financials, statement, metric, currencies);
     if (value === null) return [];
     const point = pointForStatement(
       statement,
@@ -848,7 +855,7 @@ export function extractFundamentalSeries(
     );
     return point ? [point] : [];
   });
-  const current = currentDerivedValuationPoint(financials, selected.statements, metric);
+  const current = currentDerivedValuationPoint(financials, selected.statements, metric, currencies);
   const dedupedHistorical = dedupeFundamentalPeriods(historical);
   return dedupeAndSortPoints(current ? [...dedupedHistorical, current] : dedupedHistorical);
 }
@@ -860,4 +867,14 @@ export function fundamentalSeriesUsesAvailabilityFallback(
   if (!financials || source.timestampMode === "period-end") return false;
   const points = extractFundamentalSeries(financials, source);
   return points.some((point) => point.availableAt === undefined);
+}
+
+/** Explains withheld currency-dependent values through chart and export metadata. */
+export function valuationCurrencyWarning(financials: TickerFinancials, source: SecuritySeriesSource): string | undefined {
+  const [namespace, metric = ""] = canonicalTimeSeriesFieldId(source.fieldId).split(".");
+  if (namespace !== "valuation" || !QUOTE_DERIVED_VALUATION_IDS.has(metric)) return undefined;
+  const selected = sourceStatements(financials, source.period, metric);
+  return createValuationCurrencyContext(financials).warning(selected.statements.filter((row) => (
+    valuationAtPrice(row, metric, 1) !== null
+  )));
 }

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -1892,6 +1892,7 @@ describe("resolveChartSpecData", () => {
       getTickerFinancials: async () => ({
         ...emptyFinancials(),
         quarterlyStatements: statements,
+        financialCurrency: "USD",
         quote: {
           symbol: "LIVE",
           price: 50,

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -1,4 +1,5 @@
 import { resolveAssetDisplayKind } from "../market-data/market/format";
+import { SnapshotHistoryUnavailableError } from "../market-data/snapshot-provider";
 import { financialPeriodCoverage, financialPeriodCoverageWarnings, limitSeriesObservations } from "./financial-period-coverage";
 import { HistoryCoverageError, historyCoverageNotice, isShellLondonTarget } from "../sources/history-coverage";
 import { FINANCIAL_VINTAGE_NOTICE, SEC_EPS_BASIS_NOTICE } from "../utils/financial-statements";
@@ -656,6 +657,7 @@ async function loadPriceHistory(
       observeCoverage(detailed);
       if (historyIntersectsBounds(detailed, request.visibleBounds)) return detailed;
     } catch (error) {
+      if (error instanceof SnapshotHistoryUnavailableError) throw error;
       if (error instanceof HistoryCoverageError) coverageNotice ??= error.message;
       // Fall through to trailing history when a provider cannot serve the exact window.
     }
@@ -686,6 +688,7 @@ async function loadPriceHistory(
         return resolved;
       }
     } catch (error) {
+      if (error instanceof SnapshotHistoryUnavailableError) throw error;
       if (error instanceof HistoryCoverageError) coverageNotice ??= error.message;
       // Some providers expose the resolution API but only support a subset.
     }

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -36,6 +36,7 @@ import {
 } from "./field-catalog";
 import {
   fundamentalSeriesUsesAvailabilityFallback,
+  valuationCurrencyWarning,
   valuationSeriesUsesLiveQuote,
 } from "./fundamentals";
 import { extractSecuritySeries, collectPriceHistoryIntegrity, chartPriceHistoryIntegrityNotices } from "./market";
@@ -764,7 +765,7 @@ function baseSecuritySeries(
     unitGroup: currencyUnitGroup,
     volumeUnit,
     warning: field.id === "market.volume" && !volumeUnit && points.length > 0
-      ? "Volume unit unknown." : statementCurrency?.warning,
+      ? "Volume unit unknown." : statementCurrency?.warning ?? valuationCurrencyWarning(financials, spec.source),
     nativeFrequency: spec.source.period && spec.source.period !== "auto"
       ? spec.source.period
       : field.nativeFrequency,

--- a/src/time-series/session-history-domain.test.ts
+++ b/src/time-series/session-history-domain.test.ts
@@ -3,7 +3,7 @@ import type { PricePoint, Quote } from "../types/financials";
 import { createDefaultConfig } from "../types/config";
 import { createTestDataProvider } from "../test-support/data-provider";
 import { createSnapshotDataProvider } from "../market-data/snapshot-provider";
-import { chartHeadless, type ChartPaneModel } from "../plugins/builtin/chart-composer/headless";
+import { chartHeadless, loadChartPaneModel, type ChartPaneModel } from "../plugins/builtin/chart-composer/headless";
 import { buildIntradayPriceChartPreset } from "../plugins/builtin/chart-composer/presets";
 import { loadIntradayWindow, resolveIntradaySessionWindow } from "./session-history";
 
@@ -130,5 +130,31 @@ describe("intraday price domains", () => {
     expect((await provider.getQuotesBatch!([{ symbol: "CL=F", exchange: "NYMEX" }]))[0]?.quote).toBe(captured);
     await expect(provider.getTickerFinancials("CL=F", "NYMEX")).rejects.toThrow("unused");
     await expect(provider.getQuote("CL=F", "OTHER")).rejects.toThrow("unused");
+  });
+
+  test("captured GIP domain failures survive the chart reload used by rendered screenshots", async () => {
+    const { model } = await modelFor(bars([17.73, 0, -37.63, 1.5]), quote("EQUITY"));
+    const reason = model.snapshot.intradayHistories[0]!.unavailableReason!;
+    expect(model.errors).toHaveLength(1);
+    for (const exactWindow of [true, false]) {
+      let calls = 0;
+      const snapshot = createSnapshotDataProvider(model.snapshot, createTestDataProvider({
+        getPriceHistoryForResolution: async () => { calls++; return bars([10, 11]); },
+        getDetailedPriceHistory: async () => { calls++; return bars([10, 11]); },
+      }));
+      const spec = { ...model.spec, viewport: { ...model.spec.viewport } };
+      if (!exactWindow) delete spec.viewport.dateWindow;
+      const reloaded = await loadChartPaneModel(spec, {
+        marketData: snapshot, apiClient: {} as never,
+        config: createDefaultConfig("/tmp/gloom-session-domain-reload"),
+        signal: new AbortController().signal,
+      });
+      expect(reloaded.errors).toHaveLength(1);
+      expect(reloaded.errors?.[0]).toContain(reason);
+      expect(reloaded.chart.warnings.some((warning) => warning.includes(reason))).toBe(true);
+      expect(reloaded.chart.warnings.join(" ")).not.toContain("Choose Auto");
+      expect(reloaded.series.every(({ points }) => points.length === 0)).toBe(true);
+      expect(calls).toBe(0);
+    }
   });
 });

--- a/src/time-series/session-history-domain.test.ts
+++ b/src/time-series/session-history-domain.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import type { PricePoint, Quote } from "../types/financials";
+import { createDefaultConfig } from "../types/config";
+import { createTestDataProvider } from "../test-support/data-provider";
+import { createSnapshotDataProvider } from "../market-data/snapshot-provider";
+import { chartHeadless, type ChartPaneModel } from "../plugins/builtin/chart-composer/headless";
+import { buildIntradayPriceChartPreset } from "../plugins/builtin/chart-composer/presets";
+import { loadIntradayWindow, resolveIntradaySessionWindow } from "./session-history";
+
+// Synthetic domain boundary, not a replay of a published exchange tape. CME
+// permits negative CL prices: cmegroup.com/notices/clearing/2020/04/Chadv20-160.html
+function bars(values: number[], date = "2020-04-20"): PricePoint[] {
+  return values.map((close, minute) => ({
+    date: new Date(`${date}T18:${String(minute).padStart(2, "0")}:00Z`),
+    open: close, high: close + 0.1, low: close - 0.1, close, volume: 100 + minute,
+  }));
+}
+
+function quote(instrumentType?: string, symbol = "CL=F"): Quote {
+  return { symbol, instrumentType, price: 999, currency: "USD", change: 0, changePercent: 0, lastUpdated: Date.now() };
+}
+
+const request = { rangePreset: "1D", resolution: "1m", session: "2020-04-20" } as const;
+
+async function modelFor(points: PricePoint[], reportedQuote: Quote | Error, log = false) {
+  let quoteCalls = 0;
+  const provider = createTestDataProvider({
+    async getQuote() { quoteCalls++; if (reportedQuote instanceof Error) throw reportedQuote; return reportedQuote; },
+    getPriceHistoryForResolution: async () => points,
+    getDetailedPriceHistory: async () => points,
+  });
+  const spec = buildIntradayPriceChartPreset("CL=F:NYMEX");
+  if (log) spec.panels[0]!.scale = "log";
+  const model = await chartHeadless("graph-intraday-price-pane").load({
+    rawArgument: "CL=F:NYMEX", argument: "CL=F:NYMEX", symbols: ["CL=F:NYMEX"], options: { session: request.session },
+  }, {
+    marketData: provider, apiClient: {} as never,
+    config: createDefaultConfig("/tmp/gloom-session-domain-test"),
+    signal: new AbortController().signal, settings: { chartSpec: spec },
+  }) as ChartPaneModel;
+  return { model, quoteCalls };
+}
+
+describe("intraday price domains", () => {
+  test("GIP preserves futures price, OHLC and volume through zero/negative prices without appending the metadata quote", async () => {
+    const points = bars([17.73, 0, -37.63, 1.5]);
+    const { model, quoteCalls } = await modelFor(points, quote("FUTURE"));
+    const price = model.chart.series[0]!;
+    expect(price.points.map(({ value }) => value)).toEqual([17.73, 0, -37.63, 1.5]);
+    expect(price.points.map(({ open, high, low, close, volume }) => ({ open, high, low, close, volume })))
+      .toEqual(points.map(({ open, high, low, close, volume }) => ({ open, high, low, close, volume })));
+    expect(model.chart.series[1]?.points.map(({ value }) => value)).toEqual([100, 101, 102, 103]);
+    expect(model.chart.series[1]?.unit).toBe("contracts");
+    expect(model.errors).toEqual([]);
+    expect(model.unavailableSymbols).toEqual([]);
+    expect(quoteCalls).toBe(1);
+  });
+
+  test("a nonpositive-only latest futures session is retained instead of falling back to an older positive session", async () => {
+    const points = [...bars([10, 11], "2020-04-19"), ...bars([0, -37.63])];
+    const provider = createTestDataProvider({ getQuote: async () => quote("FUT"), getPriceHistoryForResolution: async () => points });
+    const loaded = await loadIntradayWindow({ provider, symbol: "CL=F", exchange: "NYMEX", request: { ...request, session: null } });
+    expect(loaded.points.map(({ close }) => close)).toEqual([0, -37.63]);
+    expect(loaded.sessionDates).toEqual(["2020-04-20"]);
+    expect(loaded.unavailableReason).toBeNull();
+  });
+
+  test("unverified, equity and option domains fail visibly and retain rejected observations in generic JSON metadata", async () => {
+    for (const reported of [quote(), quote("EQUITY"), quote("ETF"), quote("OPTION"), quote("FUTURE", "OTHER"), new Error("metadata unavailable")]) {
+      const points = bars([17.73, 0, -37.63, 1.5]);
+      const { model } = await modelFor(points, reported);
+      expect(model.chart.series.every(({ points }) => points.length === 0)).toBe(true);
+      expect(model.complete).toBe(false);
+      expect(model.unavailableSymbols).toEqual(["CL=F:NYMEX"]);
+      expect(model.errors?.join(" ")).toContain("nonpositive");
+      const failure = model.snapshot.intradayHistories[0]!.priceDomainFailure!;
+      expect(failure.sourcePoints.map(({ close }) => close)).toEqual([0, -37.63]);
+      expect(failure.sourcePoints.map(({ date }) => date)).toEqual(points.slice(1, 3).map(({ date }) => date.toISOString()));
+      expect(model.metadata?.intradayPriceDomainFailures).toEqual([{ symbol: "CL=F", exchange: "NYMEX", ...failure }]);
+      expect(Object.isFrozen(failure.sourcePoints)).toBe(true);
+      expect(Object.isFrozen(failure.sourcePoints[0])).toBe(true);
+      points[1]!.close = 123;
+      expect(failure.sourcePoints[0]!.close).toBe(0);
+    }
+  });
+
+  test("required earlier study inputs cannot bridge bad equity bars, but observations after the selected window do not reject it", async () => {
+    const selected = bars([10, 11]);
+    const before = await modelFor([...bars([-1, 2], "2020-04-19"), ...selected], quote("EQUITY"));
+    expect(before.model.complete).toBe(false);
+    expect(before.model.snapshot.intradayHistories[0]?.priceDomainFailure?.sourcePoints[0]?.date).toBe("2020-04-19T18:00:00.000Z");
+    const after = await modelFor([...selected, ...bars([-1, 2], "2020-04-21")], quote("EQUITY"));
+    expect(after.model.chart.series[0]?.points.map(({ value }) => value)).toEqual([10, 11]);
+    expect(after.model.errors).toEqual([]);
+  });
+
+  test("timestamp corrections supersede an earlier rejected close and positive histories incur no domain metadata request", async () => {
+    const points = bars([0, 11]);
+    points.push({ ...points[0]!, close: 10, open: 10, high: 11, low: 9 });
+    let calls = 0;
+    const loaded = await loadIntradayWindow({
+      provider: createTestDataProvider({ getDetailedPriceHistory: async () => points, getQuote: async () => { calls++; return quote("EQUITY"); } }),
+      symbol: "CL=F", exchange: "NYMEX", request,
+    });
+    expect(loaded.points.map(({ close }) => close)).toEqual([10, 11]);
+    expect(loaded.unavailableReason).toBeNull();
+    expect(calls).toBe(0);
+    expect((await modelFor(bars([10, 11]), quote("EQUITY"))).quoteCalls).toBe(1);
+    expect(resolveIntradaySessionWindow(bars([0, -1]), { rangePreset: "1D" }).points).toHaveLength(2);
+  });
+
+  test("futures permission preserves independent OHLC quarantine and logarithmic-scale guards", async () => {
+    const points = bars([10, -2, 3]);
+    points[1]!.high = -3;
+    const { model } = await modelFor(points, quote("FUTURE"));
+    expect(model.chart.series[0]?.points.map(({ value }) => value)).toEqual([10, null, 3]);
+    expect(model.complete).toBe(false);
+    expect(model.chart.priceHistoryIntegrity?.[0]?.integrity.sourcePoints[0]?.close).toBe(-2);
+    const log = await modelFor(bars([10, 0, -2, 3]), quote("FUTURE"), true);
+    expect(log.model.chart.warnings.join(" ")).toContain("2 non-positive observations");
+    expect(log.model.chart.series[0]?.points.map(({ value }) => value)).toEqual([10, 0, -2, 3]);
+  });
+
+  test("a captured domain quote serves scalar and batch metadata without inventing company financials", async () => {
+    const captured = quote("FUTURE");
+    const provider = createSnapshotDataProvider({ financials: [], intradayHistories: [{
+      symbol: "CL=F", exchange: "NYMEX", resolution: "1m", points: bars([-1, -2]), unavailableReason: null, quote: captured,
+    }] }, createTestDataProvider());
+    expect(await provider.getQuote("CL=F", "NYMEX")).toBe(captured);
+    expect((await provider.getQuotesBatch!([{ symbol: "CL=F", exchange: "NYMEX" }]))[0]?.quote).toBe(captured);
+    await expect(provider.getTickerFinancials("CL=F", "NYMEX")).rejects.toThrow("unused");
+    await expect(provider.getQuote("CL=F", "OTHER")).rejects.toThrow("unused");
+  });
+});

--- a/src/time-series/session-history.ts
+++ b/src/time-series/session-history.ts
@@ -1,5 +1,5 @@
 import type { DataProvider } from "../types/data-provider";
-import type { PricePoint } from "../types/financials";
+import type { PricePoint, Quote } from "../types/financials";
 import type { TimeRange } from "./range";
 import {
   getPresetResolution,
@@ -8,6 +8,7 @@ import {
 } from "./resolution";
 import { resolveExchangeTimeZone } from "../utils/exchanges";
 import { getPricePointTimestamp } from "../utils/price-history";
+import { pricePointIntegrity } from "../utils/price-history-integrity";
 import { zonedWallClockToUtcMs } from "../utils/zoned-date-time";
 
 export type IntradayRangePreset = "1D" | "1W";
@@ -23,6 +24,20 @@ export interface IntradayWindow {
   sessionDates: string[];
   start: Date | null;
   end: Date | null;
+}
+
+export interface IntradayPriceDomainFailure {
+  readonly reason: "nonpositive-price";
+  readonly instrumentType: string | null;
+  /** Rejected observations from the selected window or its calculation buffer. */
+  readonly sourcePoints: ReadonlyArray<Readonly<Omit<PricePoint, "date"> & { date: string }>>;
+}
+
+export interface LoadedIntradayWindow extends IntradayWindow {
+  bufferedPoints: PricePoint[];
+  unavailableReason: string | null;
+  quote?: Quote;
+  priceDomainFailure?: IntradayPriceDomainFailure;
 }
 
 const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
@@ -101,7 +116,9 @@ function normalizedPoints(points: readonly PricePoint[]): PricePoint[] {
   const byTimestamp = new Map<number, PricePoint>();
   for (const point of points) {
     const timestamp = getPricePointTimestamp(point);
-    if (!Number.isFinite(timestamp) || !Number.isFinite(point.close) || point.close <= 0) continue;
+    // Session selection is independent of the asset's price domain. In
+    // particular, a zero/negative futures close is still an observation.
+    if (!Number.isFinite(timestamp) || (!Number.isFinite(point.close) && !pricePointIntegrity(point))) continue;
     byTimestamp.set(timestamp, {
       ...point,
       date: point.date instanceof Date ? point.date : new Date(timestamp),
@@ -261,7 +278,7 @@ export async function loadIntradayWindow(options: {
   exchange: string;
   request: IntradayRequest;
   now?: Date;
-}): Promise<IntradayWindow & { bufferedPoints: PricePoint[]; unavailableReason: string | null }> {
+}): Promise<LoadedIntradayWindow> {
   const timeZone = resolveExchangeTimeZone(options.exchange) ?? "UTC";
   let raw = options.request.session
     ? await loadHistoricalFallback(
@@ -336,5 +353,33 @@ export async function loadIntradayWindow(options: {
       unavailableReason: unavailableReason(options.symbol, options.request, "not-intraday"),
     };
   }
-  return { ...window, bufferedPoints: normalizedPoints(raw), unavailableReason: null };
+  const bufferedPoints = normalizedPoints(raw);
+  // Earlier rows feed study warmup; later rows cannot affect this window.
+  const nonpositive = bufferedPoints.filter((point) => point.close <= 0
+    && getPricePointTimestamp(point) <= window.end!.getTime());
+  if (nonpositive.length) {
+    // Metadata is needed only at this boundary. Do not infer a futures domain
+    // from a ticker suffix, a contract multiplier, or an option security type.
+    const reportedQuote = await options.provider.getQuote(options.symbol, options.exchange).catch(() => undefined);
+    const quote = reportedQuote?.symbol.trim().toUpperCase() === options.symbol.trim().toUpperCase()
+      ? reportedQuote : undefined;
+    const instrumentType = quote?.instrumentType?.trim().toUpperCase() || null;
+    if (instrumentType === "FUTURE" || instrumentType === "FUTURES" || instrumentType === "FUT") {
+      return { ...window, bufferedPoints, unavailableReason: null, quote };
+    }
+    const priceDomainFailure: IntradayPriceDomainFailure = Object.freeze({
+      reason: "nonpositive-price",
+      instrumentType,
+      sourcePoints: Object.freeze(nonpositive.map((point) => Object.freeze({
+        ...point,
+        date: new Date(point.date).toISOString(),
+        ...(point.historySource ? { historySource: Object.freeze({ ...point.historySource }) } : {}),
+      }))),
+    });
+    return {
+      ...window, points: [], bufferedPoints: [], quote, priceDomainFailure,
+      unavailableReason: `Intraday history for ${options.symbol} is unavailable: ${nonpositive.length} nonpositive close${nonpositive.length === 1 ? "" : "s"} in the selected window or its calculation buffer require verified futures metadata (type: ${instrumentType ?? "unknown"}).`,
+    };
+  }
+  return { ...window, bufferedPoints, unavailableReason: null };
 }

--- a/src/time-series/valuation-currency.test.ts
+++ b/src/time-series/valuation-currency.test.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "bun:test";
+import { createTestDataProvider } from "../test-support/data-provider";
+import { createDefaultConfig } from "../types/config";
+import type { TickerFinancials } from "../types/financials";
+import { loadChartPaneModel } from "../plugins/builtin/chart-composer/headless";
+import { extractFundamentalSeries, valuationCurrencyWarning } from "./fundamentals";
+import { CHART_SPEC_VERSION, type ChartSpec, type SecuritySeriesSource } from "./types";
+
+const fields = ["trailingPE", "priceSales", "evSales", "evEbitda", "priceFcf"] as const;
+const source = (metric: string): SecuritySeriesSource => ({
+  kind: "security", instrument: { symbol: "SHEL", exchange: "LSE" },
+  fieldId: `valuation.${metric}`, period: "annual", timestampMode: "available-at",
+});
+const fixture = (): TickerFinancials => ({
+  financialCurrency: "GBP",
+  quote: { symbol: "SHEL", currency: "GBP", price: 35, change: 0, changePercent: 0,
+    lastUpdated: Date.parse("2026-09-11T16:00:00Z") },
+  annualStatements: [{ date: "2025-12-31", availableAt: "2026-03-12", eps: 3,
+    totalRevenue: 300, dilutedShares: 10, totalDebt: 20, cashAndCashEquivalents: 5,
+    ebitda: 60, freeCashFlow: 25 }],
+  quarterlyStatements: [],
+  priceHistory: [{ date: new Date("2026-03-12"), close: 30 }],
+});
+
+test("missing statement currency cannot turn a known foreign or unknown basis into valuation ratios", () => {
+  for (const reporting of ["USD", undefined]) {
+    const data = fixture(); data.financialCurrency = reporting;
+    // Summary fundamentals may have been converted separately and cannot fill this gap.
+    data.fundamentals = { financialCurrency: "GBP" };
+    const original = JSON.stringify(data);
+    for (const metric of fields) {
+      expect(extractFundamentalSeries(data, source(metric))).toEqual([]);
+      expect(valuationCurrencyWarning(data, source(metric))).toContain(reporting ?? "unknown");
+    }
+    expect(extractFundamentalSeries(data, { ...source(""), fieldId: "fundamental.totalRevenue" })[0]?.value).toBe(300);
+    expect(JSON.stringify(data)).toBe(original);
+  }
+});
+
+test("same-currency monetary ratios retain historical and current values", () => {
+  const data = fixture();
+  const expected = [[10, 35 / 3], [1, 350 / 300], [315 / 300, 365 / 300], [315 / 60, 365 / 60], [12, 14]];
+  for (const [index, metric] of fields.entries()) {
+    expect(extractFundamentalSeries(data, source(metric)).map((point) => point.value)).toEqual(expected[index]!);
+    expect(valuationCurrencyWarning(data, source(metric))).toBeUndefined();
+  }
+  // Row metadata wins over a contradictory current aggregate.
+  data.annualStatements[0]!.currency = "GBP";
+  data.financialCurrency = "EUR";
+  expect(extractFundamentalSeries(data, source("trailingPE")).at(-1)?.value).toBe(35 / 3);
+});
+
+test("missing or unknown price units cannot borrow the statement currency or an exchange default", () => {
+  for (const currency of [undefined, "", "   ", "XXX", "unknown"]) {
+    const data = fixture(); data.quote!.currency = currency;
+    for (const metric of fields) {
+      expect(extractFundamentalSeries(data, source(metric))).toEqual([]);
+      expect(valuationCurrencyWarning(data, source(metric))).toContain("unknown price");
+    }
+    // The provider's own forward multiple does not multiply these statement legs.
+    data.fundamentals = { forwardPE: 12 };
+    expect(extractFundamentalSeries(data, source("forwardPE"))[0]?.value).toBe(12);
+    expect(valuationCurrencyWarning(data, source("forwardPE"))).toBeUndefined();
+  }
+});
+
+test("historical currency changes prevent filling missing row units from the current aggregate", () => {
+  const data = fixture();
+  data.quote!.lastUpdated = 0; // Historical observations only.
+  data.annualStatements = [
+    { ...data.annualStatements[0]!, date: "2023-12-31", currency: "GBP" },
+    { ...data.annualStatements[0]!, date: "2024-12-31", currency: "EUR" },
+    { ...data.annualStatements[0]!, date: "2025-12-31" },
+  ];
+  const points = extractFundamentalSeries(data, source("trailingPE"));
+  expect(points.map((point) => point.observedAt.toISOString().slice(0, 10))).toEqual(["2023-12-31"]);
+  expect(valuationCurrencyWarning(data, source("trailingPE"))).toContain("EUR/unknown");
+});
+
+test("GBP and explicitly declared pence denominations produce the same ratios without FX or double scaling", () => {
+  const baseline = fixture();
+  for (const currency of ["GBp", "GBX"]) {
+    const raw = fixture(); raw.quote!.currency = currency; raw.quote!.price *= 100;
+    raw.priceHistory = raw.priceHistory.map((row) => ({ ...row, close: row.close * 100 }));
+    for (const metric of fields) {
+      expect(extractFundamentalSeries(raw, source(metric)).map((point) => point.value))
+        .toEqual(extractFundamentalSeries(baseline, source(metric)).map((point) => point.value));
+      expect(valuationCurrencyWarning(raw, source(metric))).toBeUndefined();
+    }
+  }
+  const minorStatement = fixture();
+  minorStatement.annualStatements[0]!.currency = "GBp";
+  for (const key of ["eps", "totalRevenue", "totalDebt", "cashAndCashEquivalents", "ebitda", "freeCashFlow"] as const) {
+    minorStatement.annualStatements[0]![key]! *= 100;
+  }
+  for (const metric of fields) {
+    expect(extractFundamentalSeries(minorStatement, source(metric)).map((point) => point.value))
+      .toEqual(extractFundamentalSeries(baseline, source(metric)).map((point) => point.value));
+  }
+  // A denomination change cannot supply the units of a missing historical row.
+  minorStatement.annualStatements.push({ ...baseline.annualStatements[0]!, date: "2026-03-31" });
+  expect(valuationCurrencyWarning(minorStatement, source("trailingPE"))).toContain("unknown");
+});
+
+test("chart and headless export explain withheld currency ratios and recover when compatible units arrive", async () => {
+  const data = fixture(); data.financialCurrency = "USD";
+  const spec: ChartSpec = { version: CHART_SPEC_VERSION, viewport: { range: "5Y", resolution: "1d" },
+    panels: [{ id: "main" }], studies: [], series: [{ id: "pe", source: source("trailingPE"),
+      style: "line", transform: "raw", axis: "left", panelId: "main", interpolation: "none" }] };
+  const context = {
+    marketData: createTestDataProvider({ getTickerFinancials: async () => data,
+      getQuote: async () => data.quote!, getPriceHistoryForResolution: async () => data.priceHistory }),
+    config: createDefaultConfig("/tmp/valuation-currency-test"), signal: new AbortController().signal,
+    apiClient: {} as Parameters<typeof loadChartPaneModel>[1]["apiClient"],
+  };
+  const blocked = await loadChartPaneModel(spec, context);
+  expect(blocked.series[0]?.points).toEqual([]);
+  expect(blocked.unavailableSymbols).toHaveLength(1);
+  expect(blocked.metadata?.warnings).toEqual(expect.arrayContaining([expect.stringContaining("USD reporting, GBP price")]));
+  expect(blocked.metadata?.summaries).toEqual(expect.arrayContaining([expect.objectContaining({ endValue: null, unit: "x" })]));
+  data.annualStatements[0]!.currency = "GBP";
+  const recovered = await loadChartPaneModel(spec, context);
+  expect(recovered.series[0]?.points.at(-1)?.value).toBe(35 / 3);
+  expect(recovered.unavailableSymbols).toEqual([]);
+  expect((recovered.metadata?.warnings as string[]).some((warning) => warning.includes("Valuation currency"))).toBe(false);
+});

--- a/src/time-series/valuation-currency.ts
+++ b/src/time-series/valuation-currency.ts
@@ -1,0 +1,46 @@
+import type { FinancialStatement, TickerFinancials } from "../types/financials";
+import { resolveCurrencyUnit, type CurrencyUnitInfo } from "../utils/currency-units";
+
+function knownUnit(currency?: string): CurrencyUnitInfo | null {
+  const unit = resolveCurrencyUnit(currency);
+  return /^[A-Z]{3}$/.test(unit.currency) && unit.currency !== "XXX" ? unit : null;
+}
+
+function sameUnit(left: CurrencyUnitInfo, right: CurrencyUnitInfo): boolean {
+  return left.currency === right.currency && left.divisor === right.divisor;
+}
+
+/** Price and statement amounts must share a verified monetary basis before division. */
+export function createValuationCurrencyContext(financials: TickerFinancials) {
+  const quoteUnit = knownUnit(financials.quote?.currency);
+  const declared = knownUnit(financials.financialCurrency);
+  const explicit = [...financials.annualStatements, ...financials.quarterlyStatements]
+    .flatMap((row) => row.currency?.trim() ? [knownUnit(row.currency)] : []);
+  // Current aggregate metadata cannot fill historical holes across a currency or
+  // denomination change. A row's own declaration always takes precedence.
+  const fallback = declared && explicit.every((unit) => unit && sameUnit(unit, declared))
+    ? declared : null;
+  const statementUnit = (row: FinancialStatement) => row.currency?.trim()
+    ? knownUnit(row.currency) : fallback;
+
+  return {
+    priceInStatementUnits(row: FinancialStatement, price: number): number | null {
+      const unit = statementUnit(row);
+      if (!quoteUnit || !unit || unit.currency !== quoteUnit.currency) return null;
+      // GBp/GBX prices can be compared with GBP statements without an FX rate.
+      // Already normalized GBP prices retain divisor 1 and are not scaled twice.
+      return price / quoteUnit.divisor * unit.divisor;
+    },
+    warning(rows: readonly FinancialStatement[]): string | undefined {
+      const incompatible = rows.filter((row) => {
+        const unit = statementUnit(row);
+        return !quoteUnit || !unit || unit.currency !== quoteUnit.currency;
+      });
+      if (!incompatible.length) return undefined;
+      const currencies = [...new Set(incompatible.map((row) => statementUnit(row)?.currency ?? "unknown"))];
+      return `Valuation currency mismatch or unknown basis: ${currencies.join("/")} reporting, ${quoteUnit?.currency ?? "unknown"} price. Affected ratios are unavailable.`;
+    },
+  };
+}
+
+export type ValuationCurrencyContext = ReturnType<typeof createValuationCurrencyContext>;


### PR DESCRIPTION
Research workflows could combine data from different reporting periods or currencies, shift filing dates across time zones, and silently omit valid zero/negative futures prices.

- Keep 13F estimated returns attached to their reporting quarter; withhold holdings metadata from another quarter and honor amendment status through the supported form-type alias.
- Preserve explicit SEC filing and personnel calendar dates across time zones. Legacy acceptance timestamps retain their existing behavior; the new nullable API field is backward-compatible with backend PR256.
- Require compatible price/statement currencies for chart-derived valuation ratios. Use consistent aggregate metadata only when row currency is missing, preserve explicit row precedence, and convert minor units exactly once. Do not rescale depositary shares.
- Preserve verified futures prices and volumes through zero/negative sessions. Unverified or incompatible instrument types produce explicit unavailability with rejected source observations retained in exports. Existing OHLC and logarithmic guards remain active. Captured source errors survive pane rendering, so rejected data does not suggest changing to an unsupported interval.

Methodology stays in docs. Existing pane controls remain in place; added messages describe active data failures.

Validation: 3,180 tests / 13,274 assertions; all six runtime TypeScript projects; plugin manifest and proxy allowlist checks. Independent reviews, recorded public payloads, and actual in-process component replays at 48/80/120 columns cover the affected boundaries. Synthetic variations are identified in the audit evidence. Fresh local native/browser research validation remains unavailable in this session. No release or version change.
