### PR TITLE
Capture Windows main launch failure diagnostics

### DIFF
--- a/scripts/verify-windows-desktop.ps1
+++ b/scripts/verify-windows-desktop.ps1
@@ -206,12 +206,14 @@ function Wait-ForNewWindows {
     [hashtable]$KnownHandles,
     [int]$MinimumCount,
     [string]$Label,
-    [int]$TimeoutSeconds = 35
+    [int]$TimeoutSeconds = 35,
+    [scriptblock]$OnDiscovered
   )
 
   $Deadline = (Get-Date).AddSeconds($TimeoutSeconds)
   do {
     $Windows = @(Get-VisibleWindows | Where-Object { -not $KnownHandles.ContainsKey([string]$_.Handle) })
+    if ($OnDiscovered) { $null = & $OnDiscovered $Windows }
     if ($Windows.Count -ge $MinimumCount) {
       return $Windows
     }
@@ -1243,10 +1245,51 @@ function Restore-EnvironmentVariable {
   }
 }
 
-function Save-OnboardingFailureDiagnostics {
+function Add-TrackedWindowProcesses {
+  param(
+    [System.Collections.Generic.List[object]]$TrackedProcesses,
+    [object[]]$Windows
+  )
+
+  # Retain a handle on first sight, even if another required window never opens.
+  foreach ($Window in $Windows) {
+    if (-not $Window.Id -or $TrackedProcesses.Id -contains $Window.Id) { continue }
+    $Tracked = [pscustomobject]@{
+      Id = $Window.Id
+      ProcessName = $Window.ProcessName
+      Process = $null
+      StateError = $null
+    }
+    $TrackedProcesses.Add($Tracked)
+    try {
+      $Tracked.Process = Get-Process -Id $Window.Id -ErrorAction Stop
+      $Tracked.Process.EnableRaisingEvents = $true
+    } catch {
+      $Tracked.StateError = $_.Exception.Message
+    }
+  }
+}
+
+function Close-TrackedProcessHandles {
+  param([object[]]$TrackedProcesses)
+
+  foreach ($Tracked in $TrackedProcesses) {
+    if ($Tracked.Process) {
+      try {
+        $Tracked.Process.Dispose()
+      } catch {
+        Write-Host "Could not dispose process handle $($Tracked.Id): $($_.Exception.Message)"
+      }
+    }
+  }
+}
+
+function Save-LaunchFailureDiagnostics {
   param(
     [object[]]$TrackedProcesses,
-    [string]$FailureMessage
+    [string]$FailureMessage,
+    [string]$Stage,
+    [string]$OutputPath
   )
 
   # Read retained process handles before cleanup. Looking up only a PID after exit
@@ -1283,13 +1326,13 @@ function Save-OnboardingFailureDiagnostics {
   }
   [pscustomobject]@{
     CapturedAt = [DateTime]::UtcNow.ToString("o")
-    Stage = "onboarding-failure-before-cleanup"
+    Stage = $Stage
     Failure = $FailureMessage
     Processes = $ProcessStates
     Windows = $Windows
     WindowInventoryError = $WindowInventoryError
   } | ConvertTo-Json -Depth 8 | Set-Content `
-    -Path (Join-Path $GuiArtifactDir "windows-onboarding-failure.json") -Encoding UTF8
+    -Path $OutputPath -Encoding UTF8
 }
 
 function Capture-OnboardingScreenshot {
@@ -1332,29 +1375,18 @@ function Capture-OnboardingScreenshot {
       Process = $OnboardingProcess
       StateError = $null
     })
+    try {
+      $OnboardingProcess.EnableRaisingEvents = $true
+    } catch {
+      $TrackedProcesses[0].StateError = $_.Exception.Message
+    }
     $OnboardingWindows = @(Wait-ForNewWindows `
       -KnownHandles $InitialWindowHandles `
       -MinimumCount 1 `
-      -Label "Gloomberb onboarding window")
+      -Label "Gloomberb onboarding window" `
+      -OnDiscovered { param($Windows) Add-TrackedWindowProcesses $TrackedProcesses $Windows })
     $OnboardingWindowProcessIds += $OnboardingProcess.Id
     $OnboardingWindowProcessIds += @($OnboardingWindows | Select-Object -ExpandProperty Id | Where-Object { $_ })
-    foreach ($WindowProcessId in @($OnboardingWindowProcessIds | Select-Object -Unique)) {
-      if ($WindowProcessId -eq $OnboardingProcess.Id) { continue }
-      $Tracked = [pscustomobject]@{
-        Id = $WindowProcessId
-        ProcessName = ($OnboardingWindows | Where-Object Id -eq $WindowProcessId | Select-Object -First 1).ProcessName
-        Process = $null
-        StateError = $null
-      }
-      $TrackedProcesses.Add($Tracked)
-      try {
-        $Tracked.Process = Get-Process -Id $WindowProcessId -ErrorAction Stop
-        # Force a process handle to be opened while the window is still alive.
-        $Tracked.Process.EnableRaisingEvents = $true
-      } catch {
-        $Tracked.StateError = $_.Exception.Message
-      }
-    }
 
     Save-WindowInventory (Join-Path $GuiArtifactDir "windows-onboarding-after-launch.txt")
     $null = Capture-WindowScreenshotByTitle `
@@ -1365,9 +1397,11 @@ function Capture-OnboardingScreenshot {
   } catch {
     $OnboardingFailure = $_
     try {
-      Save-OnboardingFailureDiagnostics `
+      Save-LaunchFailureDiagnostics `
         -TrackedProcesses $TrackedProcesses.ToArray() `
-        -FailureMessage $OnboardingFailure.Exception.Message
+        -FailureMessage $OnboardingFailure.Exception.Message `
+        -Stage "onboarding-failure-before-cleanup" `
+        -OutputPath (Join-Path $GuiArtifactDir "windows-onboarding-failure.json")
     } catch {
       Write-Host "Could not save onboarding failure diagnostics: $($_.Exception.Message)"
     }
@@ -1383,15 +1417,7 @@ function Capture-OnboardingScreenshot {
     if ($OnboardingProcess -and -not $OnboardingProcess.HasExited) {
       Stop-Process -Id $OnboardingProcess.Id -Force -ErrorAction SilentlyContinue
     }
-    foreach ($Tracked in $TrackedProcesses) {
-      if ($Tracked.Process) {
-        try {
-          $Tracked.Process.Dispose()
-        } catch {
-          Write-Host "Could not dispose onboarding process handle $($Tracked.Id): $($_.Exception.Message)"
-        }
-      }
-    }
+    Close-TrackedProcessHandles $TrackedProcesses.ToArray()
 
     Restore-EnvironmentVariable "HOME" $PreviousHome
     Restore-EnvironmentVariable "USERPROFILE" $PreviousUserProfile
@@ -1462,6 +1488,7 @@ $InstallLog = Join-Path $env:TEMP "gloomberb-install-$PID.log"
 $UninstallLog = Join-Path $env:TEMP "gloomberb-uninstall-$PID.log"
 $GuiProcess = $null
 $LaunchedWindowProcessIds = @()
+$TrackedGuiProcesses = New-Object System.Collections.Generic.List[object]
 $SeededDesktopConfig = $null
 
 try {
@@ -1512,11 +1539,25 @@ try {
   $GuiProcess = Start-Process `
     -FilePath (Join-Path $InstallDir "bin\launcher.exe") `
     -WorkingDirectory (Join-Path $InstallDir "bin") `
+    -RedirectStandardOutput (Join-Path $GuiArtifactDir "windows-main-stdout.log") `
+    -RedirectStandardError (Join-Path $GuiArtifactDir "windows-main-stderr.log") `
     -PassThru
+  $TrackedGuiProcesses.Add([pscustomobject]@{
+    Id = $GuiProcess.Id
+    ProcessName = "launcher"
+    Process = $GuiProcess
+    StateError = $null
+  })
+  try {
+    $GuiProcess.EnableRaisingEvents = $true
+  } catch {
+    $TrackedGuiProcesses[0].StateError = $_.Exception.Message
+  }
   $LaunchedWindows = @(Wait-ForNewWindows `
     -KnownHandles $InitialWindowHandles `
     -MinimumCount 2 `
-    -Label "Gloomberb main and detached windows")
+    -Label "Gloomberb main and detached windows" `
+    -OnDiscovered { param($Windows) Add-TrackedWindowProcesses $TrackedGuiProcesses $Windows })
   $LaunchedWindowProcessIds += $GuiProcess.Id
   $LaunchedWindowProcessIds += @($LaunchedWindows | Select-Object -ExpandProperty Id)
 
@@ -1616,6 +1657,18 @@ try {
     throw "Windows GUI exited during smoke test with code $($GuiProcess.ExitCode)"
   }
 } catch {
+  $GuiFailure = $_
+  if ($GuiProcess) {
+    try {
+      Save-LaunchFailureDiagnostics `
+        -TrackedProcesses $TrackedGuiProcesses.ToArray() `
+        -FailureMessage $GuiFailure.Exception.Message `
+        -Stage "main-and-detached-failure-before-cleanup" `
+        -OutputPath (Join-Path $GuiArtifactDir "windows-main-failure.json")
+    } catch {
+      Write-Host "Could not save Windows GUI failure diagnostics: $($_.Exception.Message)"
+    }
+  }
   try {
     Capture-DesktopScreenshot (Join-Path $GuiArtifactDir "windows-gui-failure.png")
   } catch {
@@ -1626,13 +1679,14 @@ try {
   } catch {
     Write-Host "Could not capture Windows GUI failure window inventory: $($_.Exception.Message)"
   }
-  throw
+  throw $GuiFailure
 } finally {
   Stop-ProcessIds $LaunchedWindowProcessIds
 
   if ($GuiProcess -and -not $GuiProcess.HasExited) {
     Stop-Process -Id $GuiProcess.Id -Force -ErrorAction SilentlyContinue
   }
+  Close-TrackedProcessHandles $TrackedGuiProcesses.ToArray()
 
   if ($SeededDesktopConfig) {
     Remove-Item -Path $SeededDesktopConfig.GlobalConfigPath -Force -ErrorAction SilentlyContinue

--- a/scripts/verify-windows-diagnostics.test.ps1
+++ b/scripts/verify-windows-diagnostics.test.ps1
@@ -6,7 +6,7 @@ $ParseErrors = $null
 $ScriptPath = Join-Path $PSScriptRoot "verify-windows-desktop.ps1"
 $Ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$Tokens, [ref]$ParseErrors)
 if ($ParseErrors.Count) { throw ($ParseErrors | Out-String) }
-foreach ($Name in @("Capture-OnboardingScreenshot", "Restore-EnvironmentVariable", "Save-OnboardingFailureDiagnostics", "New-WindowHandleSet")) {
+foreach ($Name in @("Capture-OnboardingScreenshot", "Restore-EnvironmentVariable", "Save-LaunchFailureDiagnostics", "New-WindowHandleSet", "Add-TrackedWindowProcesses", "Close-TrackedProcessHandles")) {
   $Definition = $Ast.Find({
     param($Node)
     $Node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $Node.Name -eq $Name
@@ -78,8 +78,10 @@ function Start-Process {
 }
 
 function Wait-ForNewWindows {
-  param($KnownHandles, $MinimumCount, $Label)
-  return [pscustomobject]@{ Id = 102; ProcessName = "bun"; Handle = 196988; MainWindowTitle = "Gloomberb" }
+  param($KnownHandles, $MinimumCount, $Label, $OnDiscovered)
+  $Window = [pscustomobject]@{ Id = 102; ProcessName = "bun"; Handle = 196988; MainWindowTitle = "Gloomberb" }
+  & $OnDiscovered @($Window)
+  return $Window
 }
 
 function Get-Process { [CmdletBinding()] param($Id) return $script:Child }
@@ -157,6 +159,154 @@ function Test-WindowDiagnosticsInventory {
 }
 Test-WindowDiagnosticsInventory
 
+# Execute the unchanged production poll loop against a clock/window stand-in.
+# A first window disappearing cannot erase its process before a second appears.
+function Test-PartialWindowDiscovery {
+  $Definition = $Ast.Find({
+    param($Node)
+    $Node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $Node.Name -eq "Wait-ForNewWindows"
+  }, $false)
+  Invoke-Expression $Definition.Extent.Text
+  function Get-Date { return [DateTime]::new(2026, 9, 12).AddMilliseconds($script:PollTime) }
+  function Start-Sleep { param($Milliseconds) $script:PollTime += $Milliseconds }
+  function Get-VisibleWindows {
+    if ($script:PollTime -eq 0 -or $script:DiscoveryRecovers) {
+      [pscustomobject]@{ Id = 102; ProcessName = "bun"; Handle = 10; MainWindowTitle = "Gloomberb" }
+    } else {
+      $script:Child.HasExited = $true
+      $script:Child.ExitCode = 23
+    }
+    if ($script:DiscoveryRecovers -and $script:PollTime -gt 0) {
+      [pscustomobject]@{ Id = 102; ProcessName = "bun"; Handle = 11; MainWindowTitle = "Detached Watchlist" }
+    }
+    [pscustomobject]@{ Id = 999; ProcessName = "existing"; Handle = 9; MainWindowTitle = "Existing window" }
+  }
+  foreach ($Recovers in @($false, $true)) {
+    $script:DiscoveryRecovers = $Recovers
+    $script:PollTime = 0
+    $script:Child = New-TestProcess 102 "bun"
+    $Tracked = New-Object System.Collections.Generic.List[object]
+    $Failure = $null
+    $Windows = @()
+    try {
+      $Windows = @(Wait-ForNewWindows -KnownHandles @{ "9" = $true } -MinimumCount 2 -Label "main and detached" `
+        -OnDiscovered { param($Rows) Add-TrackedWindowProcesses $Tracked $Rows })
+    } catch { $Failure = $_.Exception.Message }
+    Assert-Condition ($Tracked.Count -eq 1 -and $Tracked[0].Process.EnableRaisingEvents) "First window's process was not retained exactly once"
+    if ($Recovers) {
+      Assert-Condition ($null -eq $Failure -and $Windows.Count -eq 2 -and $script:PollTime -eq 500) "Discovery changed the two-window success condition"
+    } else {
+      Assert-Condition ($Failure -eq "Timed out waiting for main and detached. Expected at least 2 new visible window(s)." -and $script:PollTime -eq 35000) "Discovery changed the window requirement or timeout"
+      Assert-Condition ($Tracked[0].Process.HasExited -and $Tracked[0].Process.ExitCode -eq 23) "Disappeared window lost its retained exit evidence"
+    }
+  }
+  Write-Host "PASS partial window discovery: retained exit and two-window recovery"
+}
+
+# Run the actual installer/GUI try/catch/finally with external operations mocked.
+# Failure is injected before any native window or after both were discovered.
+function Test-MainLaunchDiagnostics {
+  param([string]$RootTestDir)
+  $MainVerification = @($Ast.EndBlock.Statements | Where-Object { $_ -is [System.Management.Automation.Language.TryStatementAst] })
+  Assert-Condition ($MainVerification.Count -eq 1) "Could not isolate the main verification lifecycle"
+  function Assert-TuiStarts { param($CliPath) }
+  function Disable-InstalledDesktopUpdates { param($InstallDir) }
+  function Capture-OnboardingScreenshot { param($InstallDir, $OutputPath) }
+  function Seed-DesktopConfig { return $null }
+  function Start-Process {
+    param($FilePath, $WorkingDirectory, $ArgumentList, $RedirectStandardOutput, $RedirectStandardError, [switch]$Wait, [switch]$PassThru)
+    if ($Wait) {
+      New-Item -ItemType Directory -Force (Join-Path $InstallDir "bin") | Out-Null
+      "test CLI" | Set-Content (Join-Path $InstallDir "bin\gloomberb.cmd")
+      return [pscustomobject]@{ ExitCode = 0 }
+    }
+    Assert-Condition ($RedirectStandardOutput -eq (Join-Path $script:GuiArtifactDir "windows-main-stdout.log")) "Main launch stdout was not retained"
+    Assert-Condition ($RedirectStandardError -eq (Join-Path $script:GuiArtifactDir "windows-main-stderr.log")) "Main launch stderr was not retained separately"
+    "main launcher output" | Set-Content $RedirectStandardOutput
+    "main launcher error" | Set-Content $RedirectStandardError
+    return $script:Launcher
+  }
+  function Wait-ForNewWindows {
+    param($KnownHandles, $MinimumCount, $Label, $OnDiscovered)
+    Assert-Condition ($MinimumCount -eq 2 -and $Label -eq "Gloomberb main and detached windows") "Main verification weakened its window requirement"
+    Assert-Condition $script:Launcher.EnableRaisingEvents "Launcher handle was not retained before waiting"
+    if ($script:Mode -eq "main-launcher-exit") {
+      $script:Launcher.HasExited = $true
+      $script:Launcher.ExitCode = 32
+      throw "Original main window timeout"
+    }
+    $Rows = @(
+      [pscustomobject]@{ Id = 102; ProcessName = "bun"; Handle = 10; MainWindowTitle = "Gloomberb" },
+      [pscustomobject]@{ Id = 102; ProcessName = "bun"; Handle = 11; MainWindowTitle = "Detached Watchlist" }
+    )
+    & $OnDiscovered $Rows
+    Assert-Condition $script:Child.EnableRaisingEvents "App process handle was not retained during discovery"
+    if ($script:Mode -eq "main-partial-exit") {
+      $script:Child.HasExited = $true
+      $script:Child.ExitCode = 23
+      throw "Original main window timeout"
+    }
+    return $Rows
+  }
+  function Export-WindowIcon { param($Window, $OutputPath, $Label) throw "Original main verification failure" }
+  function Stop-ProcessIds {
+    param($Ids)
+    if ($script:Mode -in @("main-launcher-exit", "main-partial-exit")) {
+      Assert-Condition ($Ids.Count -eq 0) "Diagnostics broadened cleanup to processes seen during a failed wait"
+    } else {
+      Assert-Condition ($Ids -contains 101 -and $Ids -contains 102) "Main cleanup lost successfully discovered processes"
+    }
+    $script:Stopped = $true
+    $script:Events.Add("cleanup")
+  }
+  function Get-ChildItem { [CmdletBinding()] param($Path, $Filter, [switch]$File) return @() }
+  foreach ($Mode in @("main-launcher-exit", "main-partial-exit", "main-later-failure", "diagnostics-fail", "write-fail")) {
+    $script:Mode = $Mode
+    $script:Events = New-Object System.Collections.Generic.List[string]
+    $script:Stopped = $false
+    $script:Launcher = New-TestProcess 101 "launcher"
+    $script:Child = New-TestProcess 102 "bun"
+    $script:GuiArtifactDir = Join-Path $RootTestDir $Mode
+    New-Item -ItemType Directory -Force $script:GuiArtifactDir | Out-Null
+    if ($Mode -eq "write-fail") {
+      New-Item -ItemType Directory (Join-Path $script:GuiArtifactDir "windows-main-failure.json") | Out-Null
+    }
+    $InstallDir = Join-Path $script:GuiArtifactDir "install"
+    $InstallerPath = Join-Path $RootTestDir "unused-installer.exe"
+    $InstallLog = Join-Path $RootTestDir "unused-install.log"
+    $GuiProcess = $null
+    $LaunchedWindowProcessIds = @()
+    $SeededDesktopConfig = $null
+    $TrackedGuiProcesses = New-Object System.Collections.Generic.List[object]
+    $ObservedFailure = $null
+    try { Invoke-Expression $MainVerification[0].Extent.Text } catch { $ObservedFailure = $_.Exception.Message }
+    $ExpectedFailure = if ($Mode -in @("main-launcher-exit", "main-partial-exit")) { "Original main window timeout" } else { "Original main verification failure" }
+    Assert-Condition ($ObservedFailure -eq $ExpectedFailure) "Main diagnostics changed the failure: $ObservedFailure"
+    Assert-Condition ($script:Stopped -and $script:Events.Contains("dispose-101")) "Main failure did not clean up and dispose launcher"
+    Assert-Condition ($script:Events.IndexOf("refresh-101") -ge 0 -and $script:Events.IndexOf("refresh-101") -lt $script:Events.IndexOf("cleanup")) "Main process evidence was collected after cleanup"
+    if ($Mode -ne "main-launcher-exit") {
+      Assert-Condition $script:Events.Contains("dispose-102") "Main failure did not dispose app process handle"
+    }
+    if ($Mode -ne "write-fail") {
+      $Evidence = Get-Content (Join-Path $script:GuiArtifactDir "windows-main-failure.json") -Raw | ConvertFrom-Json
+      Assert-Condition ($Evidence.Stage -eq "main-and-detached-failure-before-cleanup" -and $Evidence.Failure -eq $ExpectedFailure) "Main evidence lost stage or original failure"
+      $ExpectedProcesses = if ($Mode -eq "main-launcher-exit") { 1 } else { 2 }
+      Assert-Condition ($Evidence.Processes.Count -eq $ExpectedProcesses) "Main evidence lost or duplicated a tracked process"
+      if ($Mode -eq "main-launcher-exit") {
+        Assert-Condition ($Evidence.Processes[0].HasExited -and $Evidence.Processes[0].ExitCode -eq 32) "Launcher exit was lost"
+      } elseif ($Mode -eq "main-partial-exit") {
+        $Child = $Evidence.Processes | Where-Object Id -eq 102
+        Assert-Condition ($Child.HasExited -and $Child.ExitCode -eq 23) "Partial discovery exit was lost"
+      } elseif ($Mode -eq "diagnostics-fail") {
+        Assert-Condition ($Evidence.WindowInventoryError -eq "Window inventory failed") "Window read failure discarded independent process evidence"
+      } else {
+        Assert-Condition (-not $Evidence.Processes[0].HasExited -and $null -eq $Evidence.Processes[0].ExitCode) "Alive launcher got an invented exit code"
+      }
+    }
+    Write-Host "PASS main diagnostics: $Mode"
+  }
+}
+
 $TestDir = Join-Path ([System.IO.Path]::GetTempPath()) "gloom-windows-diagnostics-$([Guid]::NewGuid())"
 $InitialHome = $env:HOME
 $InitialUserProfile = $env:USERPROFILE
@@ -200,6 +350,9 @@ try {
     }
     Write-Host "PASS onboarding diagnostics: $Mode"
   }
+  Test-PartialWindowDiscovery
+  Test-MainLaunchDiagnostics $TestDir
 } finally {
+  Restore-EnvironmentVariable "ELECTROBUN_CONSOLE" $InitialConsole
   Remove-Item -Path $TestDir -Recurse -Force -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
The installed Windows verifier could time out waiting for the main and detached windows without retaining the second launch’s stdout, stderr, or process status. Reuse the existing pre-cleanup diagnostics for that stage and retain process handles as windows first appear, so a first window’s exit remains inspectable while waiting for the second.

The launch/window requirements, 35-second discovery timeout, screenshot assertions, environment restoration, and cleanup PID selection stay unchanged. The recorded failure’s cause remains unresolved; the onboarding CEF warning is not established as causal.

Validation: source review and `git diff --check` pass. Added controlled PowerShell lifecycle/poll regressions; execution requires the existing Windows CI job because PowerShell is unavailable locally. No release or version change.
