### PR TITLE
Preserve earnings estimate horizons and calendar dates

### DIFF
--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -87,3 +87,7 @@ Event EPS and consensus can use an unspecified accounting basis, while TTM value
 Consensus estimates are forecasts for the stated fiscal period. The provider's prior-year input can itself be an estimate; it does not establish a reported result. Fetched timestamps identify retrieval, not when consensus was revised. Filing evidence corroborates a fiscal period without verifying every reported metric.
 
 Split-feed factors may include spinoff price adjustments. Merger terms, spinoff distributions, and security conversions are not covered. Source failures and unavailable event data remain visible rather than appearing as an empty event calendar.
+
+## Earnings estimate comparisons
+
+ERN groups and displays announcement dates on the same UTC calendar day. Exact call times, when supplied without a market-session label, use your local time. EPS 30D is the current estimate minus the estimate from thirty days earlier; a seven-day observation cannot fill a missing thirty-day value. REV 30D shows upward/downward revision counts over that same thirty-day window. An unknown count remains unavailable rather than becoming zero, and a directional color requires both counts. The CLI retains separately named seven-day and thirty-day source fields.

--- a/src/plugins/builtin/earnings/table.test.ts
+++ b/src/plugins/builtin/earnings/table.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { colors } from "../../../theme/colors";
+import type { EarningsEvent } from "../../../types/data-provider";
+import { buildEarningsColumns, renderEarningsCell, type EarningsColumn } from "./table";
+
+function event(values: Partial<EarningsEvent> = {}): EarningsEvent {
+  return {
+    symbol: "TEST", name: "Controlled estimate", earningsDate: new Date("2026-09-12T00:00:00Z"),
+    epsEstimate: 4, epsActual: null, revenueEstimate: null, revenueActual: null,
+    surprise: null, timing: "", ...values,
+  };
+}
+
+function cell(id: EarningsColumn["id"], values: Partial<EarningsEvent>) {
+  return renderEarningsCell({ kind: "event", key: "test", eventIdx: 0, event: event(values) },
+    buildEarningsColumns(180).find((column) => column.id === id)!, false);
+}
+
+describe("earnings estimate comparison basis", () => {
+  test("30-day changes do not substitute 7-day observations", () => {
+    expect(cell("epsTrend", { epsTrend7dAgo: 3, epsTrend30dAgo: null }).text).toBe("—");
+    expect(cell("epsTrend", { epsTrend7dAgo: 3, epsTrend30dAgo: 2 }).text).toBe("2.00");
+    expect(cell("epsTrend", { epsEstimate: 0, epsTrend30dAgo: 2 }).text).toBe("-2.00");
+    expect(cell("epsTrend", { epsEstimate: null, epsTrend30dAgo: 2 }).text).toBe("—");
+  });
+
+  test("revision counts preserve one horizon and distinguish unknown from zero", () => {
+    const partial = cell("epsRevisions", {
+      epsRevisionUp30d: 3, epsRevisionDown30d: null, epsRevisionDown7d: 2,
+    });
+    expect(partial.text).toBe("3/—");
+    expect(partial.color).toBe(colors.textDim);
+    expect(cell("epsRevisions", { epsRevisionUp7d: 3, epsRevisionDown7d: 2 }).text).toBe("—");
+    expect(cell("epsRevisions", { epsRevisionUp30d: null, epsRevisionDown30d: 0 }).text).toBe("—/0");
+    expect(cell("epsRevisions", { epsRevisionUp30d: 0, epsRevisionDown30d: 0 }).text).toBe("0/0");
+    expect(cell("epsRevisions", { epsRevisionUp30d: 3, epsRevisionDown30d: 0 }).color).toBe(colors.positive);
+    expect(cell("epsRevisions", { epsRevisionUp30d: 0, epsRevisionDown30d: 3 }).color).toBe(colors.negative);
+  });
+
+  test("calendar dates agree with UTC grouping across time zones and year boundaries", () => {
+    const modulePath = new URL("./table.ts", import.meta.url).pathname;
+    const script = `import { buildEarningsColumns, renderEarningsCell } from ${JSON.stringify(modulePath)};
+      const column = buildEarningsColumns(180).find(c => c.id === 'date');
+      const dates = ['2026-09-12T00:00:00Z', '2026-12-31T23:00:00Z'];
+      console.log(JSON.stringify(dates.map(date => renderEarningsCell({kind:'event', event:{earningsDate:new Date(date)}},column,false).text)));`;
+    for (const timezone of ["UTC", "America/Los_Angeles", "Pacific/Kiritimati"]) {
+      const result = Bun.spawnSync([process.execPath, "-e", script], { env: { ...process.env, TZ: timezone } });
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout.toString())).toEqual(["Sep 12", "Dec 31"]);
+    }
+  });
+});

--- a/src/plugins/builtin/earnings/table.ts
+++ b/src/plugins/builtin/earnings/table.ts
@@ -26,7 +26,7 @@ export type EarningsColumn = DataTableColumn & { id: EarningsColumnId };
 const MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] as const;
 
 function formatDate(date: Date): string {
-  return `${MONTH_NAMES[date.getMonth()]} ${date.getDate()}`;
+  return `${MONTH_NAMES[date.getUTCMonth()]} ${date.getUTCDate()}`;
 }
 
 function formatTime(date: Date | null | undefined): string {
@@ -48,10 +48,10 @@ function formatRange(
 }
 
 function formatRevisionSummary(event: EarningsEvent): string {
-  const up = event.epsRevisionUp30d ?? event.epsRevisionUp7d;
-  const down = event.epsRevisionDown30d ?? event.epsRevisionDown7d;
+  const up = event.epsRevisionUp30d;
+  const down = event.epsRevisionDown30d;
   if (up == null && down == null) return "—";
-  return `${up ?? 0}/${down ?? 0}`;
+  return `${up ?? "—"}/${down ?? "—"}`;
 }
 
 function formatAnalystSummary(event: EarningsEvent): string {
@@ -98,7 +98,7 @@ export function buildEarningsColumns(width: number): EarningsColumn[] {
     { id: "epsRange", label: "EPS RNG", width: epsRangeWidth, align: "right" },
     { id: "epsGrowth", label: "EPS YOY", width: growthWidth, align: "right" },
     { id: "epsTrend", label: "EPS 30D", width: trendWidth, align: "right" },
-    { id: "epsRevisions", label: "REV", width: revisionsWidth, align: "right" },
+    { id: "epsRevisions", label: "REV 30D", width: revisionsWidth, align: "right" },
     { id: "revenueEstimate", label: "SALES", width: revenueWidth, align: "right" },
     { id: "revenueRange", label: "SALES RNG", width: revenueRangeWidth, align: "right" },
     { id: "revenueGrowth", label: "SALES YOY", width: growthWidth, align: "right" },
@@ -167,7 +167,7 @@ export function renderEarningsCell(
       };
     case "epsTrend": {
       const current = row.event.epsEstimate;
-      const prior = row.event.epsTrend30dAgo ?? row.event.epsTrend7dAgo;
+      const prior = row.event.epsTrend30dAgo;
       const change = current != null && prior != null ? current - prior : null;
       return {
         text: change != null ? formatNumber(change, 2) : "—",
@@ -175,11 +175,12 @@ export function renderEarningsCell(
       };
     }
     case "epsRevisions": {
-      const net = (row.event.epsRevisionUp30d ?? row.event.epsRevisionUp7d ?? 0)
-        - (row.event.epsRevisionDown30d ?? row.event.epsRevisionDown7d ?? 0);
+      const up = row.event.epsRevisionUp30d;
+      const down = row.event.epsRevisionDown30d;
+      const net = up != null && down != null ? up - down : null;
       return {
         text: formatRevisionSummary(row.event),
-        color: selectedColor ?? (net > 0 ? colors.positive : net < 0 ? colors.negative : colors.textDim),
+        color: selectedColor ?? (net != null && net > 0 ? colors.positive : net != null && net < 0 ? colors.negative : colors.textDim),
       };
     }
     case "revenueEstimate":


### PR DESCRIPTION
ERN could label a seven-day EPS estimate change as “EPS 30D” and combine upward/downward revision counts from different windows. Missing counts also became zero, producing a misleading directional color. Use only thirty-day observations in those columns, preserve unknown counts, and make the existing revision header explicit.

Displayed announcement dates now use the same UTC calendar day as the table grouping and CLI, avoiding a previous-day date for users west of UTC. Methodology stays in docs; no new controls or recurring text.

Validation: three regressions fail before the change and pass afterward, including three time zones and year boundaries. Controlled actual-pane replays at 80/120/180 columns verify dates, revision rendering and ticker activation. Full suite: 3,197 tests / 13,459 assertions; six TypeScript projects and generated checks pass. These are in-process OpenTUI replays, not fresh native/browser sessions. No release or version change.
