### PR TITLE
Preserve dividend yield reference price timestamps

### DIFF
--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -60,6 +60,8 @@ Broker account-value history includes deposits and withdrawals. Investment retur
 
 Dividend cash yield excludes taxes and reinvestment. SEC yield, tax components, and future payments are not modeled. Forward yield is an estimate rather than a guaranteed distribution. Dividend amounts and reference prices must use compatible listing currencies and units.
 
+Dividend reference prices retain their own source timestamp, including Yahoo's regular-session price when a separate quote is unavailable. The footer prioritizes that timestamp and shows the separate history retrieval time when space permits; exports retain both. Stale prices and missing price timestamps remain explicit. Fetching cash history does not refresh the time of its reference price.
+
 TTM cash/share sums reported cash with ex-dates within the trailing calendar year. The chart changes on ex-dates and when earlier payments leave that window, holding each level between changes. Cash growth compares complete trailing-year windows; a positive baseline followed by no cash gives −100%, while a zero or incomplete baseline has no defined growth rate. Special distributions remain part of reported cash.
 
 Sector and industry ETF returns are price returns in the listing currency, without reinvested distributions. Rankings use a shared ending session and calendar-month/year boundaries, using a prior close for holidays. Missing or inconsistent endpoints remain unavailable. A successful refresh does not make an old quote current.

--- a/src/plugins/builtin/dividend-yield/client.ts
+++ b/src/plugins/builtin/dividend-yield/client.ts
@@ -1,6 +1,7 @@
 import type { ConnectionHealthRegistry } from "../../../core/connection-health";
 import { YahooHttpClient } from "../../../sources/yahoo-finance/http";
-import { financeRawNumber, mapYahooDividends } from "../../../sources/yahoo-finance/mappers";
+import { deriveMarketState, financeRawNumber, mapYahooDividends } from "../../../sources/yahoo-finance/mappers";
+import { isTimestampStaleForExchangeSession } from "../../../market-data/market/freshness";
 import { fetchYahooChart } from "../../../sources/yahoo-finance/requests";
 import { getYahooSymbolsToTry } from "../../../sources/yahoo-finance/symbols";
 import type { QuoteSummaryResponse } from "../../../sources/yahoo-finance/types";
@@ -8,6 +9,7 @@ import type { DividendMetrics, DividendPayment } from "./types";
 import { resolveCurrencyUnit } from "../../../utils/currency-units";
 import { calendarYearsBefore } from "./calendar";
 import { parsePublicTickerKey } from "../../../utils/exchanges";
+import { dividendPriceAsOf } from "./reference-price";
 
 export const YAHOO_DIVIDENDS_CONNECTION_ID = "yahoo-dividends";
 const yahoo = new YahooHttpClient();
@@ -169,8 +171,15 @@ async function fetchDividendDataForSymbol(
   }
 
   const chartPrice = chartResult.status === "fulfilled" ? chartResult.value.meta.regularMarketPrice : null;
-  const resolvedPrice = dividendReferencePrice(currentPrice, currentPriceCurrency, currency)
+  const suppliedPrice = dividendReferencePrice(currentPrice, currentPriceCurrency, currency);
+  const resolvedPrice = suppliedPrice
     ?? (chartPrice != null && Number.isFinite(chartPrice) && chartPrice > 0 ? chartPrice / divisor : null);
+  const selectedChart = suppliedPrice == null && resolvedPrice != null && chartResult.status === "fulfilled"
+    ? chartResult.value.meta : null;
+  const priceAsOf = selectedChart ? dividendPriceAsOf((selectedChart.regularMarketTime ?? NaN) * 1000) : undefined;
+  const priceStale = selectedChart && priceAsOf
+    ? isTimestampStaleForExchangeSession(Date.parse(priceAsOf), selectedChart.exchangeName, Date.now(), deriveMarketState(selectedChart))
+    : undefined;
 
   const historyAvailable = chartResult.status === "fulfilled";
   // Yahoo annual-rate fields can use a different denomination from its pence
@@ -184,7 +193,7 @@ async function fetchDividendDataForSymbol(
     throw new Error(`No dividend data found for ${symbol}`);
   }
 
-  return { payments, metrics, price: resolvedPrice, currency, historyAvailable,
+  return { payments, metrics, price: resolvedPrice, priceAsOf, priceStale, currency, historyAvailable,
     providerId: "yahoo", ...(historyAvailable ? { fetchedAt: new Date().toISOString() } : {}),
     notes: ["Cash yield excludes taxes and reinvestment. SEC yield, tax components and future payments are not modeled."],
   };

--- a/src/plugins/builtin/dividend-yield/headless.ts
+++ b/src/plugins/builtin/dividend-yield/headless.ts
@@ -8,6 +8,8 @@ import { dividendReferencePrice, fetchDividendData, type DividendData } from "./
 import type { DividendPayment } from "./types";
 import { formatDividendYield, toDividendRows } from "./view";
 import { formatDistributionAmount } from "../../../utils/format";
+import type { Quote } from "../../../types/financials";
+import { dividendPriceStatus, dividendQuotePriceMetadata } from "./reference-price";
 
 const PAYMENT_COLUMNS = [
   { key: "exDate", header: "Ex-date" },
@@ -24,23 +26,20 @@ const defaultDependencies: DividendYieldHeadlessDependencies = {
   async loadData(symbol, context) {
     let currentPrice: number | null = null;
     let currentPriceCurrency: string | undefined;
-    let quoteAsOf: string | undefined;
-    let quoteStale: boolean | undefined;
+    let referenceQuote: Quote | undefined;
     const instrument = await context.resolveInstrument?.(symbol);
     const exchange = instrument?.exchange ?? "";
     try {
       const quote = await context.marketData.getQuote(symbol, exchange);
       currentPrice = quote.price ?? null;
       currentPriceCurrency = quote.currency;
-      quoteAsOf = Number.isFinite(quote.lastUpdated) ? new Date(quote.lastUpdated).toISOString() : undefined;
-      quoteStale = quote.stale;
+      referenceQuote = quote;
     } catch {
       currentPrice = null;
     }
     const data = await fetchDividendData(symbol, currentPrice, exchange, currentPriceCurrency);
-    if (dividendReferencePrice(currentPrice, currentPriceCurrency, data.currency ?? "USD") != null) {
-      data.priceAsOf = quoteAsOf;
-      data.priceStale = quoteStale;
+    if (referenceQuote && dividendReferencePrice(currentPrice, currentPriceCurrency, data.currency ?? "USD") != null) {
+      Object.assign(data, dividendQuotePriceMetadata(referenceQuote));
     }
     return data;
   },
@@ -70,6 +69,7 @@ export function projectDividendYieldHeadless(
   });
   const metrics = data.metrics;
   const currency = data.currency ?? data.payments[0]?.currency ?? "USD";
+  const priceStatus = dividendPriceStatus(data.price, data.priceAsOf, data.priceStale);
 
   return {
     sections: [
@@ -78,7 +78,9 @@ export function projectDividendYieldHeadless(
         entries: [
           { label: "Price", value: data.price },
           ...(data.stale ? [{ label: "History status", value: "Stale cash history; recent distributions may be missing." }] : []),
-          ...(data.priceStale ? [{ label: "Price status", value: "Stale reference price; cash yield may be out of date." }] : []),
+          ...(priceStatus ? [{ label: "Price status", value: priceStatus === "stale"
+            ? "Stale reference price; cash yield may be out of date."
+            : "Reference price time unavailable; cash yield may be out of date." }] : []),
           { label: "Trailing yield", value: metrics.trailingYield, formatted: formatDividendYield(metrics.trailingYield) },
           { label: "Forward yield", value: metrics.forwardYield, formatted: formatDividendYield(metrics.forwardYield) },
           { label: "Trailing rate", value: metrics.trailingRate, formatted: formatDistributionAmount(metrics.trailingRate ?? undefined, currency) },

--- a/src/plugins/builtin/dividend-yield/pane.test.tsx
+++ b/src/plugins/builtin/dividend-yield/pane.test.tsx
@@ -1,0 +1,86 @@
+import { afterEach, expect, test } from "bun:test";
+import { act } from "react";
+import { createInitialState } from "../../../state/app/context";
+import { TestPaneProvider, createTestPaneConfig, createTestTicker } from "../../../test-support/pane";
+import { createTestPluginRuntime } from "../../../test-support/plugin-runtime";
+import { PaneFooterProvider, PaneFooterBar } from "../../../components/layout/pane/footer";
+import { Box } from "../../../ui";
+import { emitKeypress, testRender } from "../../../renderers/opentui/test-utils";
+import { setHttpFetchTransport } from "../../../utils/http-transport";
+import { DividendYieldPane } from "./pane";
+
+let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+afterEach(async () => {
+  if (setup) await act(async () => { setup!.renderer.destroy(); });
+  setup = undefined;
+  setHttpFetchTransport(null);
+});
+
+async function frame() {
+  for (let i = 0; i < 3; i++) await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await setup!.renderOnce();
+  });
+  return setup!.captureCharFrame();
+}
+
+test.each([48, 80, 120])("native dividend refresh keeps the selected price's time and status reachable at %d columns", async (width) => {
+  const sourceTime = Math.floor(Date.now() / 1000);
+  const oldTime = sourceTime - 10 * 86_400;
+  let priceTime: number | undefined = oldTime;
+  let fail = false;
+  setHttpFetchTransport(async (url) => {
+    if (url.includes("fc.yahoo.com")) return new Response("", { headers: { "set-cookie": "test=fixture" } });
+    if (url.includes("getcrumb")) return new Response("fixture");
+    if (url.includes("/chart/")) {
+      if (fail) throw new Error("Controlled cash source unavailable");
+      return Response.json({ chart: { result: [{
+        meta: { currency: "USD", exchangeName: "NMS", regularMarketPrice: 100, regularMarketTime: priceTime, dataGranularity: "1mo" },
+        timestamp: [sourceTime], indicators: { quote: [{ close: [100] }] },
+        events: { dividends: { cash: { date: sourceTime - 86_400, amount: 4 } } },
+      }] } });
+    }
+    return Response.json({ quoteSummary: { result: [] } });
+  });
+  const id = "income-price-test";
+  const state = createInitialState(createTestPaneConfig("/tmp/gloom-dividend-price-test", {
+    instanceId: id, paneId: "dividend-yield", binding: { kind: "fixed", symbol: "FUND" },
+  }));
+  state.tickers.set("FUND", createTestTicker("FUND"));
+  await act(async () => {
+    setup = await testRender(<TestPaneProvider state={state} paneId={id} pluginId="dividend-yield" runtime={createTestPluginRuntime()}>
+      <PaneFooterProvider>{(footer) => <Box width={width} height={24} flexDirection="column">
+        <Box height={23} flexShrink={0}><DividendYieldPane focused width={width} height={23} /></Box>
+        <PaneFooterBar footer={footer} focused width={width} />
+      </Box>}</PaneFooterProvider>
+    </TestPaneProvider>, { width, height: 24 });
+  });
+  const before = await frame();
+  expect(before).toContain("4.00%");
+  expect(before).toContain(new Date(oldTime * 1000).toISOString());
+  expect(before.match(/Stale price/g)).toHaveLength(1);
+  expect(before).not.toContain("cash yield may be out of date");
+
+  priceTime = undefined;
+  await emitKeypress(setup!, { name: "r", sequence: "r" });
+  const missing = await frame();
+  expect(missing).toContain("4.00%");
+  expect(missing).toContain("Reference price time unavailable");
+  expect(missing).not.toContain(new Date(oldTime * 1000).toISOString());
+
+  priceTime = sourceTime;
+  await emitKeypress(setup!, { name: "r", sequence: "r" });
+  const fresh = await frame();
+  expect(fresh).toContain("4.00%");
+  expect(fresh).toContain(new Date(sourceTime * 1000).toISOString());
+  expect(fresh).not.toContain("Stale price");
+  expect(fresh).not.toContain("time unavailable");
+  if (width >= 80) expect(fresh).toContain("History fetched");
+
+  fail = true;
+  await emitKeypress(setup!, { name: "r", sequence: "r" });
+  const failed = await frame();
+  expect(failed).toContain("No dividend data found");
+  expect(failed).toContain("4.00%"); // Retained cash stays usable while its current failure is explicit.
+  expect(failed).not.toContain("Price 20");
+});

--- a/src/plugins/builtin/dividend-yield/pane.tsx
+++ b/src/plugins/builtin/dividend-yield/pane.tsx
@@ -32,6 +32,7 @@ import {
   type DividendSortPreference,
 } from "./model";
 import type { DividendMetrics } from "./types";
+import { dividendPriceAsOf, dividendPriceStatus, dividendQuotePriceMetadata } from "./reference-price";
 
 function formatRate(value: number | null, currency: string): string {
   if (value == null) return "—";
@@ -193,23 +194,31 @@ export function DividendYieldPane({ focused, width, height, loadData = fetchDivi
   const authWall = !data && isCloudSessionRequired(error);
   useEffect(() => { if (updatedAt !== null) setSelectedIdx(0); }, [updatedAt]);
 
-  usePaneFooter("dividend-yield", () => ({
-    info: [
-      ...loadingErrorFooterInfo(loading, authWall ? null : error),
-      ...(data?.fetchedAt ? [{ id: "history-as-of", parts: [{
-        text: `History fetched ${data.fetchedAt}`, tone: "muted" as const,
-      }] }] : []),
-    ],
-  }), [authWall, data?.fetchedAt, error, loading]);
-
   const payments = data?.payments ?? [];
   const currency = data?.currency ?? payments[0]?.currency ?? resolveCurrencyUnit(ticker?.metadata.currency).currency;
   const paneReferencePrice = dividendReferencePrice(quotePrice, quoteCurrency, currency);
   const currentPrice = paneReferencePrice ?? data?.price ?? null;
-  const referencePriceStale = paneReferencePrice != null ? financials?.quote?.stale : data?.priceStale;
+  const priceMetadata = paneReferencePrice != null && financials?.quote
+    ? dividendQuotePriceMetadata(financials.quote) : data;
+  const priceAsOf = dividendPriceAsOf(Date.parse(priceMetadata?.priceAsOf ?? ""));
+  const priceStatus = dividendPriceStatus(currentPrice, priceAsOf, priceMetadata?.priceStale);
+
+  usePaneFooter("dividend-yield", () => {
+    const active = loadingErrorFooterInfo(loading, authWall ? null : error);
+    if (active.length > 0) return { info: active };
+    const priceText = priceStatus === "unknown-time" ? "Reference price time unavailable"
+      : priceStatus === "stale" ? `Stale price${priceAsOf ? ` ${priceAsOf}` : ""}`
+      : currentPrice != null && priceAsOf ? `Price ${priceAsOf}` : "";
+    const historyText = data?.fetchedAt ? `History fetched ${data.fetchedAt}` : "";
+    const showHistory = historyText && (!priceText || priceText.length + historyText.length + 3 <= width - 4);
+    return { info: priceText || showHistory ? [{ id: "source-time", parts: [
+      ...(priceText ? [{ text: priceText, tone: priceStatus ? "warning" as const : "muted" as const }] : []),
+      ...(showHistory ? [{ text: `${priceText ? " · " : ""}${historyText}`, tone: "muted" as const }] : []),
+    ] }] : [] };
+  }, [authWall, currentPrice, data?.fetchedAt, error, loading, priceAsOf, priceStatus, width]);
+
   const sourceWarnings = [
     ...(data?.stale ? ["Stale cash history; recent distributions may be missing."] : []),
-    ...(referencePriceStale ? ["Stale reference price; cash yield may be out of date."] : []),
   ];
   const metrics = data?.metrics ? repriceDividendMetrics(data.metrics, currentPrice) : undefined;
   const rows = useMemo(() => toDividendRows(payments), [payments]);

--- a/src/plugins/builtin/dividend-yield/provider-client.ts
+++ b/src/plugins/builtin/dividend-yield/provider-client.ts
@@ -1,6 +1,7 @@
 import type { DataProvider } from "../../../types/data-provider";
 import { resolveCurrencyUnit } from "../../../utils/currency-units";
 import { buildDividendMetrics, dividendReferencePrice, toDividendPayment, type DividendData } from "./client";
+import { dividendQuotePriceMetadata } from "./reference-price";
 
 /** Hosted browsers use their configured provider instead of cross-origin Yahoo requests. */
 export async function fetchProviderDividendData(
@@ -32,11 +33,7 @@ export async function fetchProviderDividendData(
     providerId: actions.providerId,
     fetchedAt: actions.fetchedAt,
     stale: actions.stale,
-    ...(suppliedPrice == null && price != null ? {
-      priceAsOf: quote?.lastUpdated != null && Number.isFinite(quote.lastUpdated)
-        ? new Date(quote.lastUpdated).toISOString() : undefined,
-      priceStale: quote?.stale,
-    } : {}),
+    ...(suppliedPrice == null && price != null && quote ? dividendQuotePriceMetadata(quote) : {}),
     metrics: buildDividendMetrics(payments, null, price),
     notes: ["Cash yield excludes taxes and reinvestment. SEC yield, tax components and future payments are not modeled.",
       "This source supplies ex-dates; indicated annual rates and payment dates are unavailable."],

--- a/src/plugins/builtin/dividend-yield/reference-price.test.ts
+++ b/src/plugins/builtin/dividend-yield/reference-price.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, expect, test } from "bun:test";
+import { setHttpFetchTransport } from "../../../utils/http-transport";
+import type { HeadlessPaneContext } from "../../../types/plugin";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { fetchDividendData } from "./client";
+import { createDividendYieldHeadless, projectDividendYieldHeadless } from "./headless";
+import { fetchProviderDividendData } from "./provider-client";
+
+afterEach(() => setHttpFetchTransport(null));
+
+function chartFixture() {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const meta = { currency: "USD", exchangeName: "NMS", regularMarketPrice: 100,
+    regularMarketTime: timestamp, dataGranularity: "1mo" };
+  setHttpFetchTransport(async (url) => {
+    if (url.includes("fc.yahoo.com")) return new Response("", { headers: { "set-cookie": "test=fixture" } });
+    if (url.includes("getcrumb")) return new Response("fixture");
+    if (url.includes("/chart/")) return Response.json({ chart: { result: [{ meta, timestamp: [timestamp],
+      indicators: { quote: [{ close: [100] }] },
+      events: { dividends: { cash: { date: timestamp - 86_400, amount: 4 } } },
+    }] } });
+    return Response.json({ quoteSummary: { result: [] } });
+  });
+  return meta;
+}
+
+test("dividend price/time selection stays paired through native and headless fallback", async () => {
+  const meta = chartFixture();
+  const chartAsOf = new Date(meta.regularMarketTime * 1000).toISOString();
+  const fallback = await fetchDividendData("FUND", 250, "NASDAQ", "EUR");
+  expect(fallback).toMatchObject({ price: 100, priceAsOf: chartAsOf, priceStale: false });
+  expect(fallback.metrics.trailingYield).toBe(0.04);
+
+  const supplied = await fetchDividendData("FUND", 250, "NASDAQ", "USD");
+  expect(supplied.price).toBe(250);
+  expect(supplied.priceAsOf).toBeUndefined(); // Its caller owns the separate quote timestamp.
+  const quoteTime = meta.regularMarketTime * 1000 - 1_000;
+  for (const currency of ["USD", "EUR"]) {
+    const result = await createDividendYieldHeadless().load({ argument: "FUND", symbols: ["FUND"], options: {} }, {
+      resolveInstrument: async () => ({ symbol: "FUND", exchange: "NASDAQ" }),
+      marketData: { getQuote: async () => ({ symbol: "FUND", price: 250, currency,
+        lastUpdated: quoteTime, stale: true, change: 0, changePercent: 0 }) },
+    } as unknown as HeadlessPaneContext);
+    expect(result.metadata?.priceAsOf).toBe(currency === "USD" ? new Date(quoteTime).toISOString() : chartAsOf);
+    expect(result.metadata?.priceStale).toBe(currency === "USD");
+    expect(result.sections[0]?.entries?.find((row) => row.label === "Trailing yield")?.value).toBe(currency === "USD" ? 0.016 : 0.04);
+  }
+});
+
+test("old, missing and recovered Yahoo times do not alter the cash numerator or borrow fetch time", async () => {
+  const meta = chartFixture();
+  const fresh = meta.regularMarketTime;
+  for (const timestamp of [fresh - 10 * 86_400, undefined, 0, NaN, Infinity, 1e20, fresh + 86_400, fresh]) {
+    meta.regularMarketTime = timestamp as number;
+    const data = await fetchDividendData("FUND", null);
+    const result = projectDividendYieldHeadless(data, { argument: "FUND", symbols: ["FUND"], options: {} });
+    expect(data.metrics.trailingRate).toBe(4);
+    expect(data.metrics.trailingYield).toBe(0.04);
+    const status = result.sections[0]?.entries?.find((row) => row.label === "Price status")?.value;
+    if (timestamp === fresh) {
+      expect(data.priceAsOf).toBe(new Date(fresh * 1000).toISOString());
+      expect(data.priceStale).toBe(false);
+      expect(status).toBeUndefined();
+    } else if (timestamp === fresh - 10 * 86_400) {
+      expect(data.priceStale).toBe(true);
+      expect(status).toContain("Stale reference price");
+    } else {
+      expect(data.priceAsOf).toBeUndefined();
+      expect(data.priceStale).toBeUndefined();
+      expect(result.metadata?.priceAsOf).toBeNull();
+      expect(status).toContain("time unavailable");
+    }
+  }
+});
+
+test("provider quote metadata handles missing dates without losing valid cash or borrowing an unused quote time", async () => {
+  let quoteTime = NaN;
+  const provider = createTestDataProvider({
+    getCorporateActions: async () => ({ symbol: "FUND", currency: "USD", coverage: { dividends: "available" },
+      dividends: [{ exDate: new Date(Date.now() - 86_400_000).toISOString().slice(0, 10), amount: 4 }], splits: [], earnings: [] }),
+    getQuote: async () => ({ symbol: "FUND", currency: "USD", price: 80, lastUpdated: quoteTime, change: 0, changePercent: 0 }),
+  });
+  for (const timestamp of [NaN, 1e20, Date.now() + 86_400_000, Date.now()]) {
+    quoteTime = timestamp;
+    const data = await fetchProviderDividendData(provider, "FUND", null);
+    expect(data.metrics.trailingYield).toBe(0.05);
+    expect(data.priceAsOf).toBe(Number.isFinite(new Date(timestamp).getTime()) && timestamp <= Date.now() ? new Date(timestamp).toISOString() : undefined);
+  }
+  const supplied = await fetchProviderDividendData(provider, "FUND", 200, "", "USD");
+  expect(supplied.price).toBe(200);
+  expect(supplied.priceAsOf).toBeUndefined();
+});
+
+test("a future external quote time cannot make a dividend yield look fresh or borrow chart time", async () => {
+  const meta = chartFixture();
+  let quoteTime = Date.now() + 86_400_000;
+  const load = () => createDividendYieldHeadless().load({ argument: "FUND", symbols: ["FUND"], options: {} }, {
+    resolveInstrument: async () => ({ symbol: "FUND", exchange: "NASDAQ" }),
+    marketData: { getQuote: async () => ({ symbol: "FUND", price: 200, currency: "USD",
+      lastUpdated: quoteTime, exchangeName: "NASDAQ", marketState: "CLOSED", stale: false, change: 0, changePercent: 0 }) },
+  } as unknown as HeadlessPaneContext);
+  const future = await load();
+  expect(future.metadata?.priceAsOf).toBeNull();
+  expect(future.metadata?.priceStale).toBeNull();
+  expect(future.sections[0]?.entries?.find((row) => row.label === "Trailing yield")?.value).toBe(0.02);
+  expect(future.sections[0]?.entries?.find((row) => row.label === "Price status")?.value).toContain("time unavailable");
+  quoteTime = meta.regularMarketTime * 1000 - 1_000;
+  const recovered = await load();
+  expect(recovered.metadata?.priceAsOf).toBe(new Date(quoteTime).toISOString());
+  expect(recovered.metadata?.priceStale).toBe(false);
+  expect(recovered.sections[0]?.entries?.find((row) => row.label === "Price status")).toBeUndefined();
+});

--- a/src/plugins/builtin/dividend-yield/reference-price.ts
+++ b/src/plugins/builtin/dividend-yield/reference-price.ts
@@ -1,0 +1,27 @@
+import { isQuoteStaleForCurrentSession } from "../../../market-data/quotes/freshness";
+import type { Quote } from "../../../types/financials";
+
+/** A missing source timestamp must never become the time we fetched its data. */
+export function dividendPriceAsOf(timestampMs: number | undefined): string | undefined {
+  if (timestampMs == null || !Number.isFinite(timestampMs) || timestampMs <= 0 || timestampMs > Date.now()) return undefined;
+  const date = new Date(timestampMs);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : undefined;
+}
+
+export function dividendQuotePriceMetadata(quote: Quote) {
+  const priceAsOf = dividendPriceAsOf(quote.lastUpdated);
+  return {
+    priceAsOf,
+    priceStale: quote.stale === true || (priceAsOf ? isQuoteStaleForCurrentSession(quote) : undefined),
+  };
+}
+
+export function dividendPriceStatus(
+  price: number | null,
+  priceAsOf: string | undefined,
+  priceStale: boolean | undefined,
+): "stale" | "unknown-time" | null {
+  if (price == null || !Number.isFinite(price) || price <= 0) return null;
+  if (priceStale) return "stale";
+  return dividendPriceAsOf(Date.parse(priceAsOf ?? "")) ? null : "unknown-time";
+}


### PR DESCRIPTION
Dividend yield research discarded the timestamp of Yahoo's fallback price. A captured VYM replay could therefore calculate yield using a ten-day-old price while showing a fresh history-fetch time. Preserve the selected price/time pair through native loading, provider fallback and CLI output; incompatible or unused quotes cannot supply its date.

The existing footer shows the price date and one stale or unavailable-time status. Missing, invalid and future timestamps cannot borrow retrieval time. The prior body warning is removed, and history retrieval time remains separate when space permits. JEPQ, VYM and SGOV cash totals and distribution cadence are unchanged.

Validation: 3,266 tests / 13,913 assertions; all six TypeScript projects and generated checks pass. Independent review includes captured and controlled pane replays at 48/80/120 columns, source selection, stale/future/missing-time transitions and recovery. These are in-process rendering checks with recorded public data, not a fresh browser/native research session. No release or version bump.
