### PR TITLE
Use current trading sessions across quote and provider caches

### DIFF
--- a/src/market-data/market/freshness.ts
+++ b/src/market-data/market/freshness.ts
@@ -153,6 +153,13 @@ function usSessionState(timestampMs: number): UsSessionState {
   return "POSTPOST";
 }
 
+/** Provider session labels may outlive the active session they described. */
+export function activeUsExtendedHoursSession(now: number): "PRE" | "POST" | null {
+  if (!Number.isFinite(new Date(now).getTime())) return null;
+  const session = usSessionState(now);
+  return session === "PRE" || session === "POST" ? session : null;
+}
+
 export function isTimestampStaleForExchangeSession(
   timestampMs: number,
   exchange?: string,
@@ -186,7 +193,7 @@ function isTimestampStaleForExchangeSessionUnsafe(
 
   if (isUsExtendedHoursExchange(canonical)) {
     const session = usSessionState(now);
-    if (session === "PRE" || session === "REGULAR" || session === "POST") {
+    if (session === "PRE" || session === "REGULAR" || session === "POST" || session === "POSTPOST") {
       return true;
     }
   }

--- a/src/market-data/market/freshness.ts
+++ b/src/market-data/market/freshness.ts
@@ -154,9 +154,14 @@ function usSessionState(timestampMs: number): UsSessionState {
 }
 
 /** Provider session labels may outlive the active session they described. */
-export function activeUsExtendedHoursSession(now: number): "PRE" | "POST" | null {
+export function activeUsMarketSession(now: number): "PRE" | "REGULAR" | "POST" | null {
   if (!Number.isFinite(new Date(now).getTime())) return null;
   const session = usSessionState(now);
+  return session === "PRE" || session === "REGULAR" || session === "POST" ? session : null;
+}
+
+export function activeUsExtendedHoursSession(now: number): "PRE" | "POST" | null {
+  const session = activeUsMarketSession(now);
   return session === "PRE" || session === "POST" ? session : null;
 }
 

--- a/src/market-data/quotes/freshness.test.ts
+++ b/src/market-data/quotes/freshness.test.ts
@@ -19,6 +19,69 @@ function quote(overrides: Partial<Quote>): Quote {
 }
 
 describe("quote freshness", () => {
+  test.each([
+    ["PRE", "2026-09-11T07:59:59Z", false],
+    ["PRE", "2026-09-11T08:00:00Z", true],
+    ["PRE", "2026-09-11T13:29:59Z", true],
+    ["PRE", "2026-09-11T13:30:00Z", false],
+    ["POST", "2026-09-11T19:59:59Z", false],
+    ["POST", "2026-09-11T20:00:00Z", true],
+    ["POST", "2026-09-11T23:59:59Z", true],
+    ["POST", "2026-09-12T00:00:00Z", false],
+    ["PRE", "2026-09-12T12:00:00Z", false],
+    ["POST", "2026-09-13T21:00:00Z", false],
+    ["PREPRE", "2026-09-11T07:00:00Z", false],
+    ["POSTPOST", "2026-09-12T02:00:00Z", false],
+    ["PRE", "2026-01-06T08:59:59Z", false],
+    ["PRE", "2026-01-06T09:00:00Z", true],
+    ["POST", "2026-01-07T00:59:59Z", true],
+    ["POST", "2026-01-07T01:00:00Z", false],
+  ] as const)("requires a missing %s price only in its current active session at %s", (marketState, timestamp, expected) => {
+    const now = Date.parse(timestamp);
+    const input = quote({ currency: "USD", listingExchangeName: "NASDAQ", exchangeName: "NMS", marketState, lastUpdated: now - 1_000 });
+    expect(isQuoteStaleForCurrentSession(input, now)).toBe(expected);
+    expect(isQuoteStaleForCurrentSession({ ...input, preMarketPrice: 168, postMarketPrice: 168 }, now)).toBe(false);
+    expect(isQuoteStaleForCurrentSession({ ...input, stale: true }, now)).toBe(true);
+  });
+
+  test("recorded NasdaqGM alias preserves active-session and old-date guards", () => {
+    const active = Date.parse("2026-09-11T22:00:00Z");
+    for (const listingExchangeName of ["NGM", "NasdaqGM", "NASDAQGM"]) {
+      const input = quote({ listingExchangeName, exchangeName: "NGM", currency: "USD", marketState: "POST", lastUpdated: active - 1_000 });
+      expect(isQuoteStaleForCurrentSession(input, active)).toBe(true);
+      expect(isQuoteStaleForCurrentSession(input, Date.parse("2026-09-12T03:00:00Z"))).toBe(false);
+      expect(isQuoteStaleForCurrentSession(input, Date.parse("2026-09-14T14:00:00Z"))).toBe(true);
+    }
+  });
+
+  test("retained or unknown provider states cannot establish a price for the current extended session", () => {
+    const postNow = Date.parse("2026-09-14T22:00:00Z");
+    const retained = quote({ currency: "USD", listingExchangeName: "NASDAQ", marketState: "PRE", lastUpdated: Date.parse("2026-09-14T09:00:00Z") });
+    expect(isQuoteStaleForCurrentSession(retained, postNow)).toBe(true);
+    expect(isQuoteStaleForCurrentSession({ ...retained, preMarketPrice: 168 }, postNow)).toBe(true);
+    expect(isQuoteStaleForCurrentSession({ ...retained, marketState: "POST", preMarketPrice: 168 }, postNow)).toBe(true);
+    expect(isQuoteStaleForCurrentSession({ ...retained, marketState: "POST", postMarketPrice: 168, lastUpdated: postNow }, postNow)).toBe(false);
+    for (const marketState of ["REGULAR", "POSTPOST", "CLOSED", undefined] as const) {
+      expect(isQuoteStaleForCurrentSession({ ...retained, marketState, postMarketPrice: 168 }, postNow)).toBe(true);
+    }
+    const preNow = Date.parse("2026-09-14T09:00:00Z");
+    expect(isQuoteStaleForCurrentSession({ ...retained, marketState: "POST", postMarketPrice: 168 }, preNow)).toBe(true);
+    expect(isQuoteStaleForCurrentSession({ ...retained, postMarketPrice: 168 }, preNow)).toBe(true);
+    expect(isQuoteStaleForCurrentSession({ ...retained, preMarketPrice: 168 }, preNow)).toBe(false);
+    expect(isQuoteStaleForCurrentSession({ ...retained, marketState: undefined, preMarketPrice: 168 }, preNow)).toBe(true);
+    expect(isQuoteStaleForCurrentSession({ ...retained, marketState: undefined }, Date.parse("2026-09-15T03:00:00Z"))).toBe(false);
+  });
+
+  test("overnight labels cannot bypass explicit stale or the existing prior-session date check", () => {
+    const input = quote({ listingExchangeName: "ARCA", currency: "USD", marketState: "POSTPOST", lastUpdated: Date.parse("2026-09-11T23:59:52Z") });
+    expect(isQuoteStaleForCurrentSession(input, Date.parse("2026-09-12T03:00:00Z"))).toBe(false);
+    expect(isQuoteStaleForCurrentSession(input, Date.parse("2026-09-14T14:00:00Z"))).toBe(true);
+    expect(isQuoteStaleForCurrentSession(input, Date.parse("2026-09-15T02:00:00Z"))).toBe(true);
+    expect(isQuoteStaleForCurrentSession(input, Date.parse("2026-09-14T07:59:59Z"))).toBe(false);
+    expect(isQuoteStaleForCurrentSession({ ...input, stale: true }, Date.parse("2026-09-12T03:00:00Z"))).toBe(true);
+    expect(isQuoteStaleForCurrentSession({ ...input, marketState: "REGULAR", lastUpdated: Date.parse("2026-09-14T14:00:00Z") }, Date.parse("2026-09-14T14:01:00Z"))).toBe(false);
+  });
+
   test("treats multi-business-day-old non-US closed quotes as stale", () => {
     expect(
       isQuoteStaleForCurrentSession(

--- a/src/market-data/quotes/freshness.ts
+++ b/src/market-data/quotes/freshness.ts
@@ -1,6 +1,6 @@
 import type { Quote } from "../../types/financials";
 import { canonicalExchange } from "../../utils/exchanges";
-import { isTimestampStaleForExchangeSession } from "../market/freshness";
+import { activeUsExtendedHoursSession, isTimestampStaleForExchangeSession } from "../market/freshness";
 
 const EXTENDED_HOURS_EXCHANGES = new Set(["NASDAQ", "NYSE", "AMEX", "ARCA", "BATS"]);
 
@@ -8,21 +8,18 @@ export function isExtendedHoursExchange(quote: Quote): boolean {
   return EXTENDED_HOURS_EXCHANGES.has(canonicalExchange(quote.listingExchangeName || quote.exchangeName));
 }
 
-function isQuoteMissingActiveSessionPrice(quote: Quote): boolean {
+function isQuoteMissingActiveSessionPrice(quote: Quote, now: number): boolean {
   if (!isExtendedHoursExchange(quote)) return false;
-  if ((quote.marketState === "PRE" || quote.marketState === "PREPRE") && quote.preMarketPrice == null) {
-    return true;
-  }
-  if ((quote.marketState === "POST" || quote.marketState === "POSTPOST") && quote.postMarketPrice == null) {
-    return true;
-  }
-  return false;
+  const activeSession = activeUsExtendedHoursSession(now);
+  if (!activeSession) return false;
+  if (quote.marketState !== activeSession) return true;
+  return activeSession === "PRE" ? quote.preMarketPrice == null : quote.postMarketPrice == null;
 }
 
 export function isQuoteStaleForCurrentSession(quote: Quote | null | undefined, now = Date.now()): boolean {
   if (!quote) return false;
   if (quote.stale === true) return true;
-  if (isQuoteMissingActiveSessionPrice(quote)) return true;
+  if (isQuoteMissingActiveSessionPrice(quote, now)) return true;
 
   return isTimestampStaleForExchangeSession(
     quote.lastUpdated,

--- a/src/market-data/quotes/resolution.test.ts
+++ b/src/market-data/quotes/resolution.test.ts
@@ -81,6 +81,36 @@ describe("quote-resolution", () => {
     expect(quote?.routingExchangeName).toBe("SMART");
     expect(quote?.provenance?.price?.providerId).toBe("ibkr");
     expect(quote?.provenance?.session?.providerId).toBe("yahoo");
+
+    const streamed = upsertQuoteContributionMap({ yahoo: contributions.yahoo! }, contributions.ibkr!, { now });
+    expect(streamed.ibkr?.price).toBe(100);
+    expect(resolveCanonicalQuote(streamed, now).quote).toMatchObject({ price: 100, marketState: "PRE", preMarketPrice: 101 });
+  });
+
+  test("admits incomplete price contributions only from the current extended session", () => {
+    for (const [nowIso, marketState] of [["2026-09-14T11:00:00Z", "PRE"], ["2026-09-14T22:00:00Z", "POST"]] as const) {
+      const now = Date.parse(nowIso);
+      const yahoo = { symbol: "AMD", providerId: "yahoo", price: 99, currency: "USD", change: 0, changePercent: 0,
+        lastUpdated: now - 60_000, listingExchangeName: "NASDAQ", marketState,
+        ...(marketState === "PRE" ? { preMarketPrice: 101 } : { postMarketPrice: 102 }) };
+      const ibkr = { ...yahoo, providerId: "ibkr", dataSource: "live" as const, price: 100,
+        marketState: undefined, preMarketPrice: undefined, postMarketPrice: undefined };
+      const good = resolveCanonicalQuote({ yahoo, ibkr }, now).quote;
+      expect(good).toMatchObject({ price: 100, marketState });
+      for (const overrides of [
+        { stale: true }, { lastUpdated: now - 86_400_000 }, { lastUpdated: NaN }, { lastUpdated: Infinity },
+        { lastUpdated: 0 }, { lastUpdated: now + 60_000 },
+        { lastUpdated: Date.parse(marketState === "PRE" ? "2026-09-14T07:59:00Z" : "2026-09-14T11:00:00Z") },
+        { marketState: marketState === "PRE" ? "POST" as const : "PRE" as const, preMarketPrice: 101, postMarketPrice: 102 },
+      ]) {
+        const rejected = { ...ibkr, ...overrides };
+        expect(resolveCanonicalQuote({ yahoo, ibkr: rejected }, now).quote?.price).toBe(99);
+        expect(upsertQuoteContributionMap({ yahoo }, rejected, { now }).ibkr).toBeUndefined();
+      }
+      // Price-only contributions remain useful as retained data; they cannot
+      // establish a complete current-session quote without session metadata.
+      expect(resolveCanonicalQuote({ ibkr }, now).quote?.marketState).toBeUndefined();
+    }
   });
 
   test("uses provider previous close with the live broker price for daily change", () => {

--- a/src/market-data/quotes/resolution.ts
+++ b/src/market-data/quotes/resolution.ts
@@ -10,7 +10,8 @@ import type {
 } from "../../types/financials";
 import { hasLikelyQuoteUnitMismatch } from "../../utils/currency-units";
 import { debugLog } from "../../utils/debug-log";
-import { hasFreshQuoteForCurrentSession, isQuoteStaleForCurrentSession } from "./freshness";
+import { isExtendedHoursExchange, isQuoteStaleForCurrentSession } from "./freshness";
+import { activeUsExtendedHoursSession, isTimestampStaleForExchangeSession } from "../market/freshness";
 import {
   finalizeSessionFields,
   getQuoteContributionKey,
@@ -269,11 +270,22 @@ function buildAcceptedPriceCandidates(contributions: QuoteContribution[]): {
   return { accepted, rejectedProviders };
 }
 
+export function isQuoteContributionStaleForCurrentSession(contribution: Quote, now = Date.now()): boolean {
+  if (contribution.marketState != null) return isQuoteStaleForCurrentSession(contribution, now);
+  // A price-only source can be combined with independent session metadata.
+  // Its observation must still belong to the current active session.
+  const timestamp = contribution.lastUpdated;
+  if (contribution.stale === true || !Number.isFinite(timestamp) || timestamp <= 0 || timestamp > now) return true;
+  const activeSession = isExtendedHoursExchange(contribution) ? activeUsExtendedHoursSession(now) : null;
+  if (activeSession && activeUsExtendedHoursSession(timestamp) !== activeSession) return true;
+  return isTimestampStaleForExchangeSession(timestamp, contribution.listingExchangeName || contribution.exchangeName, now);
+}
+
 function filterFreshQuoteCandidates(
   contributions: QuoteContribution[],
   now: number,
 ): { accepted: QuoteContribution[]; rejectedProviders: string[] } {
-  if (!hasFreshQuoteForCurrentSession(contributions, now)) {
+  if (!contributions.some((contribution) => !isQuoteContributionStaleForCurrentSession(contribution, now))) {
     return { accepted: contributions, rejectedProviders: [] };
   }
 
@@ -281,7 +293,7 @@ function filterFreshQuoteCandidates(
   const rejectedProviders = new Set<string>();
 
   for (const contribution of contributions) {
-    if (isQuoteStaleForCurrentSession(contribution, now)) {
+    if (isQuoteContributionStaleForCurrentSession(contribution, now)) {
       rejectedProviders.add(contribution.providerId);
       quoteResolutionLog.warn("Rejected stale quote contribution for the current session", {
         providerId: contribution.providerId,
@@ -499,7 +511,7 @@ export function upsertQuoteContributionMap(
   const normalized = normalizeQuoteContribution(quote);
   if (!normalized) return current ?? {};
   const now = options.now ?? Date.now();
-  if (isQuoteStaleForCurrentSession(normalized, now) && hasFreshQuoteForCurrentSession(quoteContributionValues(current), now)) {
+  if (isQuoteContributionStaleForCurrentSession(normalized, now) && quoteContributionValues(current).some((contribution) => !isQuoteContributionStaleForCurrentSession(contribution, now))) {
     quoteResolutionLog.warn("Rejected incoming stale quote contribution for the current session", {
       incomingProviderId: normalized.providerId,
       incomingPrice: normalized.price,

--- a/src/sources/provider-router/broker-session.test.ts
+++ b/src/sources/provider-router/broker-session.test.ts
@@ -1,0 +1,52 @@
+import { expect, spyOn, test } from "bun:test";
+import { AppPersistence } from "../../data/app-persistence";
+import type { Quote } from "../../types/financials";
+import { isQuoteStaleForCurrentSession } from "../../market-data/quotes/freshness";
+import { AssetDataRouter } from "./index";
+import { attachTestRegistry, brokerInstance, fallbackProvider, makeFinancials, setBrokerInstances } from "./test-support";
+
+test("broker price and provider session survive scalar, batch and cached financials composition", async () => {
+  for (const [time, marketState] of [["2026-04-08T11:00:00Z", "PRE"], ["2026-04-08T22:00:00Z", "POST"]] as const) {
+    const now = Date.parse(time);
+    const clock = spyOn(Date, "now").mockReturnValue(now);
+    const store = new AppPersistence(":memory:");
+    try {
+      const brokerQuote: Quote = { symbol: "AMD", providerId: "ibkr", dataSource: "live", price: 100.25,
+        currency: "USD", change: 1, changePercent: 1, lastUpdated: now - 60_000,
+        listingExchangeName: "NASDAQ", routingExchangeName: "SMART", sessionConfidence: "unknown" };
+      const yahoo: Quote = { ...brokerQuote, providerId: "yahoo", dataSource: "delayed", price: 99.7,
+        lastUpdated: now - 180_000, routingExchangeName: undefined, marketState, sessionConfidence: "derived",
+        ...(marketState === "PRE" ? { preMarketPrice: 101 } : { postMarketPrice: 102 }) };
+      let brokerCalls = 0;
+      const router = new AssetDataRouter({ ...fallbackProvider, id: "yahoo",
+        getQuote: async () => yahoo, getTickerFinancials: async () => makeFinancials({ quote: yahoo }) }, [], store.resources);
+      attachTestRegistry(router, { brokers: [["ibkr", {
+        id: "ibkr", name: "Test broker", configSchema: [], validate: async () => true, importPositions: async () => [],
+        getQuote: async () => { brokerCalls += 1; return brokerQuote; },
+        getTickerFinancials: async () => makeFinancials({ quote: { ...brokerQuote, price: 100 } }),
+      }]] });
+      setBrokerInstances(router, [brokerInstance()]);
+      const context = { brokerId: "ibkr", brokerInstanceId: "ibkr-work" };
+      const target = { symbol: "AMD", exchange: "NASDAQ", ...context };
+      function expectComposed(quote: Quote | undefined | null, price: number) {
+        expect(quote).toMatchObject({ price, lastUpdated: brokerQuote.lastUpdated, marketState, routingExchangeName: "SMART" });
+        expect(quote?.provenance).toMatchObject({ price: { providerId: "ibkr" }, session: { providerId: "yahoo" } });
+        expect(isQuoteStaleForCurrentSession(quote, now)).toBe(false);
+      }
+      expectComposed((await router.getTickerFinancials("AMD", "NASDAQ", context)).quote, 100);
+      expectComposed(router.getCachedFinancialsForTargets([target]).get("AMD")?.quote, 100);
+      expectComposed(await router.getQuote("AMD", "NASDAQ", context), 100.25);
+      expectComposed(await router.getQuote("AMD", "NASDAQ", context), 100.25);
+      expectComposed((await router.getQuotesBatch([{ symbol: "AMD", exchange: "NASDAQ", context }]))[0]?.quote, 100.25);
+      expect(brokerCalls).toBe(1);
+      expectComposed(router.getCachedFinancialsForTargets([target]).get("AMD")?.quote, 100.25);
+      brokerQuote.stale = true;
+      store.resources.set({ namespace: "market", kind: "quote", entityKey: "AMD", variantKey: "exchange=NASDAQ", sourceKey: "broker:ibkr:ibkr-work" }, brokerQuote,
+        { schemaVersion: 1, cachePolicy: { staleMs: 60_000, expireMs: 60_000 }, fetchedAt: now });
+      expect((await router.getQuote("AMD", "NASDAQ", context)).price).toBe(99.7);
+    } finally {
+      store.close();
+      clock.mockRestore();
+    }
+  }
+});

--- a/src/sources/provider-router/cached-financials.test.ts
+++ b/src/sources/provider-router/cached-financials.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { AppPersistence } from "../../data/app-persistence";
 import type { DataProvider } from "../../types/data-provider";
 import { AssetDataRouter } from "./index";
@@ -11,7 +11,10 @@ import {
   makeQuote,
 } from "./test-support";
 
+let clock: ReturnType<typeof spyOn> | undefined;
 afterEach(() => {
+  clock?.mockRestore();
+  clock = undefined;
   cleanupProviderRouterTestFiles();
 });
 
@@ -165,6 +168,7 @@ describe("AssetDataRouter cached financials", () => {
   });
 
   test("drops cached premarket cloud quotes that lack an active-session price", () => {
+    clock = spyOn(Date, "now").mockReturnValue(Date.parse("2026-09-14T11:00:00Z"));
     const dbPath = createTempDbPath("stale-cloud-premarket-cache");
     const persistence = new AppPersistence(dbPath);
     const now = Date.now();

--- a/src/sources/provider-router/financial-routes.ts
+++ b/src/sources/provider-router/financial-routes.ts
@@ -10,7 +10,7 @@ import type {
 } from "../../types/financials";
 import { parseOptionSymbol } from "../../utils/options";
 import { isQuoteStaleForCurrentSession } from "../../market-data/quotes/freshness";
-import { resolveTickerFinancialsQuoteState } from "../../market-data/quotes/resolution";
+import { isQuoteContributionStaleForCurrentSession, resolveTickerFinancialsQuoteState } from "../../market-data/quotes/resolution";
 import {
   listCachedResources,
   normalizeTicker,
@@ -193,7 +193,10 @@ export class ProviderRouterFinancialRoutes {
       ...this.deps.getProviderSourceKeys(),
     ];
     const rawCached = selectCachedResource<Quote>(this.deps.resources, "quote", entityKey, variantKeys, sourceKeys, false);
-    const cached = rawCached && !isQuoteStaleForCurrentSession(quoteWithFreshnessExchange(rawCached.value, exchange))
+    const cachedIsStale = rawCached && (brokerSourceKeys.includes(rawCached.sourceKey)
+      ? isQuoteContributionStaleForCurrentSession(quoteWithFreshnessExchange(rawCached.value, exchange))
+      : isQuoteStaleForCurrentSession(quoteWithFreshnessExchange(rawCached.value, exchange)));
+    const cached = rawCached && !cachedIsStale
       ? rawCached
       : null;
     const forceRefresh = context?.cacheMode === "refresh";
@@ -206,7 +209,7 @@ export class ProviderRouterFinancialRoutes {
     }
 
     const brokerQuote = await withBrokerTimeout(this.deps.primaryRoutes.fetchBrokerQuote(ticker, exchange, context));
-    if (brokerQuote && !isQuoteStaleForCurrentSession(quoteWithFreshnessExchange(brokerQuote.value, exchange))) {
+    if (brokerQuote && !isQuoteContributionStaleForCurrentSession(quoteWithFreshnessExchange(brokerQuote.value, exchange))) {
       return this.mergeBrokerQuoteWithProviderReference(
         brokerQuote.value,
         await this.getProviderReferenceQuote(ticker, exchange, context),
@@ -284,7 +287,7 @@ export class ProviderRouterFinancialRoutes {
       ? selectCachedResource<TickerFinancials>(this.deps.resources, "financials", entityKey, quoteVariantKeys, brokerSourceKeys, allowExpired)
       : null;
     const sanitizedBrokerRecord = brokerRecord
-      ? { ...brokerRecord, value: sanitizeCachedFinancials(brokerRecord.value, options) }
+      ? { ...brokerRecord, value: sanitizeCachedFinancials(brokerRecord.value, { ...options, allowIncompleteSession: true }) }
       : null;
     const providerSourceKeys = this.deps.getProviderSourceKeys();
     const includeSymbolProviderFallback = options.includeSymbolProviderFallback !== false;
@@ -323,7 +326,7 @@ export class ProviderRouterFinancialRoutes {
       quoteVariantKeys,
       quoteSourceKeys,
     );
-    const quoteSelection = selectCachedQuoteRecord(quoteRecords, exchange, options);
+    const quoteSelection = selectCachedQuoteRecord(quoteRecords, exchange, options, brokerSourceKeys);
     const mergedValue = mergeFinancials(sanitizedBrokerRecord?.value ?? null, providerSelection.value);
     const value = quoteSelection.quote
       ? resolveTickerFinancialsQuoteState(mergedValue, quoteSelection.quote)

--- a/src/sources/provider-router/financials.test.ts
+++ b/src/sources/provider-router/financials.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import {
   dropUnusableProviderQuote,
   mergeFinancials,
@@ -8,7 +8,14 @@ import {
 import { makeFinancials, makeQuote } from "./test-support";
 
 describe("provider-router financial quote usability", () => {
+  let clock: ReturnType<typeof spyOn>;
+  beforeEach(() => {
+    clock = spyOn(Date, "now").mockReturnValue(Date.parse("2026-09-14T18:00:00Z"));
+  });
+  afterEach(() => clock.mockRestore());
+
   test("rejects active-session labels without active-session prices", () => {
+    clock.mockReturnValue(Date.parse("2026-09-14T11:00:00Z"));
     expect(isProviderQuoteUsableForCurrentSession(makeQuote({
       listingExchangeName: "NASDAQ",
       marketState: "PRE",
@@ -67,12 +74,36 @@ describe("provider-router financial quote usability", () => {
   });
 
   test("still ages out a US after-hours quote the provider stopped updating", () => {
+    clock.mockReturnValue(Date.parse("2026-09-14T22:00:00Z"));
     expect(isProviderQuoteUsableForCurrentSession(makeQuote({
       listingExchangeName: "NASDAQ",
       marketState: "POST",
       postMarketPrice: 101,
       lastUpdated: Date.now() - 15 * 60_000,
     }), "NASDAQ")).toBe(false);
+  });
+
+  test("retained US session labels stop the intraday age limit only outside active hours", () => {
+    for (const marketState of ["PRE", "REGULAR", "POST"] as const) {
+      const quote = makeQuote({ listingExchangeName: "NASDAQGM", marketState, preMarketPrice: 101, postMarketPrice: 102,
+        lastUpdated: Date.parse("2026-09-11T23:58:46Z"), dataSource: "delayed" });
+      for (const time of ["2026-09-12T03:01:00Z", "2026-09-12T16:00:00Z", "2026-09-14T07:59:59Z"]) {
+        clock.mockReturnValue(Date.parse(time));
+        // A retained REGULAR label still follows its existing overnight date
+        // policy; PRE/POST closing observations may survive the weekend.
+        expect(isProviderQuoteUsableForCurrentSession(quote)).toBe(!(marketState === "REGULAR" && time === "2026-09-12T16:00:00Z"));
+        expect(isProviderQuoteUsableForCurrentSession({ ...quote, stale: true })).toBe(false);
+      }
+      clock.mockReturnValue(Date.parse("2026-09-15T02:00:00Z"));
+      expect(isProviderQuoteUsableForCurrentSession(quote)).toBe(false);
+    }
+    for (const [time, marketState] of [["2026-09-14T11:00:00Z", "PRE"], ["2026-09-14T18:00:00Z", "REGULAR"], ["2026-09-14T22:00:00Z", "POST"]] as const) {
+      clock.mockReturnValue(Date.parse(time));
+      const quote = makeQuote({ listingExchangeName: "NASDAQGM", marketState, preMarketPrice: 101, postMarketPrice: 102,
+        lastUpdated: Date.now() - 31 * 60_000, dataSource: "delayed" });
+      expect(isProviderQuoteUsableForCurrentSession(quote)).toBe(false);
+      expect(isProviderQuoteUsableForCurrentSession({ ...quote, lastUpdated: Date.now() - 16 * 60_000 })).toBe(true);
+    }
   });
 
   test("rejects empty zero provider quotes", () => {

--- a/src/sources/provider-router/financials.ts
+++ b/src/sources/provider-router/financials.ts
@@ -5,8 +5,10 @@ import { coalesceFinancialPeriodAliases, mergeFinancialStatementRows } from "../
 import { normalizePriceHistory, normalizeTickerFinancialsPriceHistory } from "../../utils/price-history";
 import { redactUnavailableFundamentals, RETRACTABLE_VALUATION_FIELDS } from "../../utils/fundamentals";
 import { isExtendedHoursExchange, isQuoteStaleForCurrentSession } from "../../market-data/quotes/freshness";
+import { activeUsMarketSession } from "../../market-data/market/freshness";
 import {
   mergeQuoteContributionMaps,
+  isQuoteContributionStaleForCurrentSession,
   resolveCanonicalQuote,
   resolveTickerFinancialsQuoteState,
   seedQuoteContributions,
@@ -64,7 +66,7 @@ function excludeNonCompanyFinancials(financials: TickerFinancials): TickerFinanc
 
 export function sanitizeCachedFinancials(
   financials: TickerFinancials,
-  options: { includeStaleQuotes?: boolean } = {},
+  options: { includeStaleQuotes?: boolean; allowIncompleteSession?: boolean } = {},
 ): TickerFinancials {
   financials = excludeNonCompanyFinancials({
     ...financials,
@@ -72,7 +74,10 @@ export function sanitizeCachedFinancials(
     annualStatements: coalesceFinancialPeriodAliases(financials.annualStatements),
     quarterlyStatements: coalesceFinancialPeriodAliases(financials.quarterlyStatements),
   });
-  if (options.includeStaleQuotes || !isQuoteStaleForCurrentSession(financials.quote)) return financials;
+  const stale = financials.quote && (options.allowIncompleteSession
+    ? isQuoteContributionStaleForCurrentSession(financials.quote)
+    : isQuoteStaleForCurrentSession(financials.quote));
+  if (options.includeStaleQuotes || !stale) return financials;
   return {
     ...financials,
     quote: undefined,
@@ -104,15 +109,15 @@ const ACTIVE_DELAYED_PROVIDER_QUOTE_MAX_AGE_MS = 30 * 60_000;
  * regular hours. Yahoo reports POST for Tokyo or Sydney for hours after the
  * close, and that closing quote is exactly what a world board should show.
  */
-function isQuoteInActiveSession(quote: Quote): boolean {
+function isQuoteInActiveSession(quote: Quote, now: number): boolean {
+  if (isExtendedHoursExchange(quote)) return activeUsMarketSession(now) != null;
   const state = quote.marketState ?? "";
   if (state === "REGULAR") return true;
-  if (state === "PRE" || state === "POST") return isExtendedHoursExchange(quote);
   return false;
 }
 
 function isActiveProviderQuoteTooOld(quote: Quote, now = Date.now()): boolean {
-  if (!isQuoteInActiveSession(quote)) return false;
+  if (!isQuoteInActiveSession(quote, now)) return false;
   if (!Number.isFinite(quote.lastUpdated)) return false;
   const maxAge =
     quote.dataSource === "delayed"
@@ -151,10 +156,13 @@ export function dropUnusableProviderQuote(value: TickerFinancials, exchange?: st
 function sanitizeCachedQuote(
   quote: Quote,
   exchange: string | undefined,
-  options: { includeStaleQuotes?: boolean } = {},
+  options: { includeStaleQuotes?: boolean; allowIncompleteSession?: boolean } = {},
 ): Quote | null {
   const normalized = quoteWithFreshnessExchange(quote, exchange);
-  return options.includeStaleQuotes || !isQuoteStaleForCurrentSession(normalized)
+  const stale = options.allowIncompleteSession
+    ? isQuoteContributionStaleForCurrentSession(normalized)
+    : isQuoteStaleForCurrentSession(normalized);
+  return options.includeStaleQuotes || !stale
     ? normalized
     : null;
 }
@@ -361,12 +369,15 @@ export function selectCachedQuoteRecord(
   records: CachedResourceRecord<Quote>[],
   exchange: string | undefined,
   options: { includeStaleQuotes?: boolean } = {},
+  brokerSourceKeys: readonly string[] = [],
 ): CachedQuoteSelection {
   let stale = false;
 
   for (const record of records) {
     stale ||= record.stale === true;
-    const quote = sanitizeCachedQuote(record.value, exchange, options);
+    const quote = sanitizeCachedQuote(record.value, exchange, {
+      ...options, allowIncompleteSession: brokerSourceKeys.includes(record.sourceKey),
+    });
     if (quote) return { quote, stale };
   }
 

--- a/src/time-series/chart-data.test.ts
+++ b/src/time-series/chart-data.test.ts
@@ -9,7 +9,7 @@ function quoteFixture(overrides: Partial<Quote> = {}): Quote {
     currency: "USD",
     change: 0,
     changePercent: 0,
-    lastUpdated: Date.parse("2026-05-15T20:30:00Z"),
+    lastUpdated: Date.parse("2026-05-15T19:30:00Z"),
     listingExchangeName: "NASDAQ",
     marketState: "REGULAR",
     ...overrides,
@@ -58,12 +58,12 @@ describe("appendLiveQuotePoint", () => {
     const extended = appendLiveQuotePoint(
       history,
       quoteFixture(),
-      { now: Date.parse("2026-05-15T21:00:00Z") },
+      { now: Date.parse("2026-05-15T19:45:00Z") },
     );
 
     expect(extended).toHaveLength(3);
     expect(extended.at(-1)).toEqual({
-      date: new Date("2026-05-15T20:30:00Z"),
+      date: new Date("2026-05-15T19:30:00Z"),
       close: 129,
     });
   });
@@ -71,7 +71,7 @@ describe("appendLiveQuotePoint", () => {
   test("merges a quote into the active OHLC bucket", () => {
     const history: PricePoint[] = [
       {
-        date: new Date("2026-05-15T20:25:00Z"),
+        date: new Date("2026-05-15T19:25:00Z"),
         open: 124,
         high: 130,
         low: 122,
@@ -82,9 +82,9 @@ describe("appendLiveQuotePoint", () => {
 
     const extended = appendLiveQuotePoint(
       history,
-      quoteFixture({ lastUpdated: Date.parse("2026-05-15T20:29:00Z") }),
+      quoteFixture({ lastUpdated: Date.parse("2026-05-15T19:29:00Z") }),
       {
-        now: Date.parse("2026-05-15T20:30:00Z"),
+        now: Date.parse("2026-05-15T19:30:00Z"),
         mode: "ohlc",
         resolution: "5m",
       },
@@ -92,7 +92,7 @@ describe("appendLiveQuotePoint", () => {
 
     expect(extended).toHaveLength(1);
     expect(extended[0]).toEqual({
-      date: new Date("2026-05-15T20:25:00Z"),
+      date: new Date("2026-05-15T19:25:00Z"),
       open: 124,
       high: 130,
       low: 122,
@@ -104,7 +104,7 @@ describe("appendLiveQuotePoint", () => {
   test("seeds a new OHLC bucket from the live price instead of prior-bar extremes", () => {
     const history: PricePoint[] = [
       {
-        date: new Date("2026-05-15T20:25:00Z"),
+        date: new Date("2026-05-15T19:25:00Z"),
         open: 124,
         high: 180,
         low: 80,
@@ -115,9 +115,9 @@ describe("appendLiveQuotePoint", () => {
 
     const extended = appendLiveQuotePoint(
       history,
-      quoteFixture({ lastUpdated: Date.parse("2026-05-15T20:30:00Z") }),
+      quoteFixture({ lastUpdated: Date.parse("2026-05-15T19:30:00Z") }),
       {
-        now: Date.parse("2026-05-15T20:31:00Z"),
+        now: Date.parse("2026-05-15T19:31:00Z"),
         mode: "ohlc",
         resolution: "5m",
       },
@@ -125,7 +125,7 @@ describe("appendLiveQuotePoint", () => {
 
     expect(extended).toHaveLength(2);
     expect(extended[1]).toEqual({
-      date: new Date("2026-05-15T20:30:00Z"),
+      date: new Date("2026-05-15T19:30:00Z"),
       open: 129,
       high: 129,
       low: 129,

--- a/src/utils/exchanges.ts
+++ b/src/utils/exchanges.ts
@@ -4,6 +4,7 @@ export const CANONICAL_EXCHANGE_ALIASES: Record<string, string> = {
   XNAS: "NASDAQ",
   NMS: "NASDAQ",
   NGM: "NASDAQ",
+  NASDAQGM: "NASDAQ",
   NCM: "NASDAQ",
   NYQ: "NYSE",
   NYS: "NYSE",


### PR DESCRIPTION
Latest US ETF observations could show stale prices after extended trading ended because the UI and provider router trusted retained PRE/POST labels. Use the current New York session for extended-price and provider-age checks, recognize the exact NasdaqGM alias, and prevent Friday observations from becoming fresh again after Monday trading.

Preserve the quote resolver's separate price/session provider contract: current partial broker contributions remain eligible for composition, while explicit stale values, invalid observations and incompatible session observations are rejected at the relevant boundary. Existing chart/router fixtures now use clocks that match the sessions they test. No UI text, actions, layout or version changes.

Validation: 3,288 tests / 14,093 assertions pass across 536 files; all six TypeScript targets and both generated-file checks pass. Recorded six-ETF provider/router replays and broker PRE/POST scenarios cover fresh reads, cached reads, batches, updates, explicit stale values and Monday transitions. Thirty dividend-pane scenarios pass at 48/80/120 columns, including unchanged post-deployment JEPQ/VYM financials; an independent calculation also matches the rendered cash yields. Sixteen parent-pane frames remain unchanged. The initial full-suite failures are preserved in audit evidence and were resolved before publication.

The broader existing frontend timestamp helper can still accept malformed or future complete quotes; that is tracked separately. This change validates incomplete contributions and keeps the already shipped backend and dividend timestamp guards intact.
