### PR TITLE
Make FX matrix refresh request updated provider rates

### DIFF
--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -68,6 +68,8 @@ Sector and industry ETF returns are price returns in the listing currency, witho
 
 ## FX matrix
 
+`r` refreshes the selected currencies through the provider, and automatic refresh follows the configured interval. Ordinary renders reuse cached rates. A refresh can still return the provider's cached observation; its source date and any stale or failure status remain visible.
+
 One unit of the row currency buys the amount in the column currency. Indicative cross rates are calculated through USD legs, whose observation times can differ. Missing, stale, or unknown observation times appear as current status.
 
 ## Credit spreads

--- a/src/market-data/coordinator/auxiliary.ts
+++ b/src/market-data/coordinator/auxiliary.ts
@@ -185,6 +185,7 @@ export function loadArticleSummaryEntry(options: {
 export function loadFxRateEntry(options: {
   dataProvider: DataProvider;
   currency: string;
+  forceRefresh?: boolean;
   store: QueryStore<number>;
   runSingleFlight: RunSingleFlight;
 }): Promise<QueryEntry<number>> {
@@ -192,7 +193,7 @@ export function loadFxRateEntry(options: {
   const normalizedCurrency = options.currency.trim().toUpperCase();
   const key = buildFxKey(normalizedCurrency);
   const current = store.get(key);
-  if (hasFreshEntryData(current, FX_CACHE_TTL_MS) && !current.error
+  if (!options.forceRefresh && hasFreshEntryData(current, FX_CACHE_TTL_MS) && !current.error
     && (current.staleAt == null || current.staleAt > Date.now())) {
     return Promise.resolve(current);
   }

--- a/src/market-data/coordinator/fx-refresh.test.ts
+++ b/src/market-data/coordinator/fx-refresh.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+import { AssetDataRouter } from "../../sources/provider-router";
+import { createTestDataProvider } from "../../test-support/data-provider";
+import type { ExchangeRateSnapshot } from "../../types/exchange-rate";
+import { MarketDataCoordinator } from "./index";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(done => { resolve = done; });
+  return { promise, resolve };
+}
+
+for (const cachedRouter of [false, true]) {
+  test(`FX refresh bypasses fresh ${cachedRouter ? "router" : "direct"} cache, shares requests and preserves failed-source age`, async () => {
+    const firstTime = Date.now() - 60_000;
+    const snapshot = (rate: number, asOf: number): ExchangeRateSnapshot => ({
+      rate, fromCurrency: "EUR", toCurrency: "USD", source: "controlled-fx",
+      asOf: new Date(asOf).toISOString(), fetchedAt: new Date(asOf).toISOString(),
+      staleAt: new Date(asOf + 3_600_000).toISOString(), stale: false,
+    });
+    const pending = deferred<ExchangeRateSnapshot>();
+    let calls = 0;
+    let fail = false;
+    const provider = createTestDataProvider({
+      id: "controlled-fx",
+      getExchangeRateSnapshot: async currency => {
+        expect(currency).toBe("EUR");
+        calls++;
+        if (fail) throw new Error("source offline");
+        return calls === 1 ? snapshot(1.1, firstTime) : pending.promise;
+      },
+    });
+    const coordinator = new MarketDataCoordinator(cachedRouter ? new AssetDataRouter(provider) : provider);
+    try {
+      expect((await coordinator.loadFxRate("EUR")).data).toBe(1.1);
+      expect((await coordinator.loadFxRate("EUR")).data).toBe(1.1);
+      expect((await coordinator.loadFxRate("USD", { forceRefresh: true })).data).toBe(1);
+      expect(calls).toBe(1);
+
+      const firstRefresh = coordinator.loadFxRate("EUR", { forceRefresh: true });
+      const secondRefresh = coordinator.loadFxRate("EUR", { forceRefresh: true });
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(calls).toBe(2);
+      const secondTime = firstTime + 30_000;
+      pending.resolve(snapshot(1.2, secondTime));
+      expect((await firstRefresh).data).toBe(1.2);
+      expect((await secondRefresh).data).toBe(1.2);
+      expect(coordinator.getFxEntry("EUR").asOf).toBe(secondTime);
+
+      fail = true;
+      const failed = await coordinator.loadFxRate("EUR", { forceRefresh: true });
+      expect(failed.data ?? failed.lastGoodData).toBe(1.2);
+      expect(failed.asOf).toBe(secondTime);
+      expect(failed.fetchedAt).toBe(secondTime);
+      expect(failed.error).not.toBeNull();
+      expect(calls).toBe(3);
+    } finally {
+      coordinator.destroy();
+    }
+  });
+}

--- a/src/market-data/coordinator/index.ts
+++ b/src/market-data/coordinator/index.ts
@@ -350,10 +350,11 @@ export class MarketDataCoordinator {
     });
   }
 
-  async loadFxRate(currency: string): Promise<QueryEntry<number>> {
-    return this.loadCachedQuery("getExchangeRate", [currency], buildFxKey(currency), this.fxStore) ?? loadFxRateEntry({
+  async loadFxRate(currency: string, options: { forceRefresh?: boolean } = {}): Promise<QueryEntry<number>> {
+    return this.loadCachedQuery("getExchangeRate", [currency], buildFxKey(currency), this.fxStore, options.forceRefresh) ?? loadFxRateEntry({
       dataProvider: this.dataProvider,
       currency,
+      forceRefresh: options.forceRefresh,
       store: this.fxStore,
       runSingleFlight: (key, task) => this.runSingleFlight(key, task),
     });

--- a/src/plugins/builtin/fx-matrix/index.tsx
+++ b/src/plugins/builtin/fx-matrix/index.tsx
@@ -39,11 +39,9 @@ function FxMatrixPane({ focused, width, height }: PaneProps) {
   const refresh = useCallback(() => {
     const coordinator = getSharedMarketDataCoordinator();
     if (!coordinator) return;
-    // A rate that is still fresh is left alone by the coordinator; a failed one
-    // is retried, which is the case that matters here.
     for (const currency of currencies) {
       if (currency === "USD") continue;
-      void coordinator.loadFxRate(currency).catch(() => {});
+      void coordinator.loadFxRate(currency, { forceRefresh: true }).catch(() => {});
     }
   }, [currencies]);
 

--- a/src/plugins/builtin/fx-matrix/refresh.test.tsx
+++ b/src/plugins/builtin/fx-matrix/refresh.test.tsx
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import { act } from "react";
+import { MarketDataCoordinator, setSharedMarketDataCoordinator } from "../../../market-data/coordinator";
+import { testRender } from "../../../renderers/opentui/test-utils";
+import { AssetDataRouter } from "../../../sources/provider-router";
+import { createInitialState } from "../../../state/app/context";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { TestPaneProvider, createTestPaneConfig } from "../../../test-support/pane";
+import { fxMatrixModule } from "./index";
+
+test("the FX matrix refresh key updates cached cross rates without refetching on renders", async () => {
+  const requests: string[] = [];
+  let eurRate = 1.1;
+  const source = createTestDataProvider({
+    id: "controlled-fx",
+    getExchangeRateSnapshot: async currency => {
+      requests.push(currency);
+      return {
+        fromCurrency: currency, toCurrency: "USD", rate: currency === "EUR" ? eurRate : 1 / 150,
+        source: "controlled-fx", asOf: new Date().toISOString(), fetchedAt: new Date().toISOString(), stale: false,
+      };
+    },
+  });
+  const provider = new AssetDataRouter(source);
+  const coordinator = new MarketDataCoordinator(provider);
+  setSharedMarketDataCoordinator(coordinator);
+  const config = createTestPaneConfig("/tmp/fx-matrix-refresh-unused", {
+    paneId: "fx-matrix", instanceId: "fx-matrix", settings: { currencies: ["USD", "EUR", "JPY"] },
+  });
+  config.refreshIntervalMinutes = 0;
+  const state = createInitialState(config);
+  const runtime = { getMarketData: () => provider };
+  const Pane = fxMatrixModule.panes![0]!.component;
+  let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+  const settle = async () => {
+    for (let frame = 0; frame < 4; frame++) await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+      await setup!.renderOnce();
+    });
+  };
+  try {
+    await act(async () => {
+      setup = await testRender(
+        <TestPaneProvider state={state} paneId="fx-matrix" runtime={runtime} pluginId="market-overview">
+          <Pane paneId="fx-matrix" paneType="fx-matrix" focused width={80} height={14} />
+        </TestPaneProvider>,
+        { width: 80, height: 14 },
+      );
+    });
+    await settle();
+    expect(requests.sort()).toEqual(["EUR", "JPY"]);
+    expect(setup!.captureCharFrame()).toContain("1.1000");
+
+    eurRate = 1.2;
+    await act(async () => { setup!.mockInput.pressKey("r"); });
+    await settle();
+    const refreshed = setup!.captureCharFrame();
+    expect(requests.length).toBe(4);
+    expect(refreshed).toContain("1.2000");
+    expect(refreshed).toContain("180.00");
+    expect(refreshed).toContain("0.8333");
+    await settle();
+    expect(requests.length).toBe(4);
+  } finally {
+    if (setup) await act(async () => setup!.renderer.destroy());
+    coordinator.destroy();
+    setSharedMarketDataCoordinator(null);
+  }
+});


### PR DESCRIPTION
Refreshing the FX matrix could leave rates unchanged for up to an hour because both manual refresh and the configured automatic refresh reused a fresh local cache. Pass an explicit refresh request through the coordinator's shared-query and direct-provider paths so the existing refresh action reaches the provider.

Ordinary reads still reuse cached rates, concurrent refreshes share a request, and USD identity needs no provider call. A failed refresh preserves the previous rate and its original observation/retrieval times with an error. No new UI controls or explanatory text; refresh behavior is documented in the existing research data guide. Provider-side caches remain authoritative for the observation returned.

Validation: 3,291 tests / 14,133 assertions pass across 538 files on the integrated frontend; all six TypeScript targets and both generated-file checks pass. Independent review passed 44 tests / 207 assertions, including the actual pane → coordinator → router refresh path: after the controlled source changes EUR/USD from 1.1 to 1.2, pressing the existing `r` updates the matrix and inverse/cross values. Recorded public FX models and rendering checks are retained separately; their explicit stale flags were not relaxed.
