### PR TITLE
Reject invalid source times across quote research consumers

### DIFF
--- a/docs/research-data.md
+++ b/docs/research-data.md
@@ -4,6 +4,8 @@
 
 This reference describes how the terminal calculates and labels research data. Pane bodies show the data and current failures; recurring methodology belongs here. Headless reports and shared chart metadata retain source details and limitations.
 
+A quote needs a finite, positive observation timestamp that is no later than the current clock. Missing, invalid or future source times cannot establish a current price, chart update or quote-derived valuation. Receipt time does not replace source time. Retained observations keep their values and existing stale/error status until valid data arrives; historical statement-price observations remain separate.
+
 ## Charts, comparisons, and correlations
 
 Normalized price charts show closing-price returns in each listing's currency. They exclude cash distributions, reinvestment, and FX conversion. They are not total-return or investor-currency performance charts.

--- a/src/market-data/quotes/freshness.ts
+++ b/src/market-data/quotes/freshness.ts
@@ -4,6 +4,14 @@ import { activeUsExtendedHoursSession, isTimestampStaleForExchangeSession } from
 
 const EXTENDED_HOURS_EXCHANGES = new Set(["NASDAQ", "NYSE", "AMEX", "ARCA", "BATS"]);
 
+/** Receipt time cannot establish when the source observed a quoted price. */
+export function hasValidQuoteObservationTime(quote: Pick<Quote, "lastUpdated">, now = Date.now()): boolean {
+  const timestamp = quote.lastUpdated;
+  return typeof timestamp === "number" && Number.isFinite(timestamp) && timestamp > 0
+    && Number.isFinite(now) && timestamp <= now
+    && Number.isFinite(new Date(timestamp).getTime()) && Number.isFinite(new Date(now).getTime());
+}
+
 export function isExtendedHoursExchange(quote: Quote): boolean {
   return EXTENDED_HOURS_EXCHANGES.has(canonicalExchange(quote.listingExchangeName || quote.exchangeName));
 }
@@ -19,6 +27,7 @@ function isQuoteMissingActiveSessionPrice(quote: Quote, now: number): boolean {
 export function isQuoteStaleForCurrentSession(quote: Quote | null | undefined, now = Date.now()): boolean {
   if (!quote) return false;
   if (quote.stale === true) return true;
+  if (!hasValidQuoteObservationTime(quote, now)) return true;
   if (isQuoteMissingActiveSessionPrice(quote, now)) return true;
 
   return isTimestampStaleForExchangeSession(

--- a/src/market-data/quotes/observation-time.test.ts
+++ b/src/market-data/quotes/observation-time.test.ts
@@ -1,0 +1,74 @@
+import { expect, spyOn, test } from "bun:test";
+import type { Quote } from "../../types/financials";
+import { isProviderQuoteUsableForCurrentSession } from "../../sources/provider-router/financials";
+import { hasFreshQuoteForCurrentSession, isQuoteStaleForCurrentSession } from "./freshness";
+import { isQuoteContributionStaleForCurrentSession } from "./resolution";
+
+const quote = (lastUpdated: unknown, overrides: Partial<Quote> = {}): Quote => ({
+  symbol: "TEST", currency: "USD", price: 100, change: 1, changePercent: 1,
+  lastUpdated: lastUpdated as number, dataSource: "delayed", ...overrides,
+});
+
+test("invalid source observation times remain unavailable across sessions and serialized inputs", () => {
+  const scenarios = [
+    { now: "2026-09-14T11:00:00Z", venue: "NASDAQ", marketState: "PRE" },
+    { now: "2026-09-14T18:00:00Z", venue: "NASDAQ", marketState: "REGULAR" },
+    { now: "2026-09-14T22:00:00Z", venue: "NASDAQ", marketState: "POST" },
+    { now: "2026-09-12T03:01:00Z", venue: "NASDAQGM", marketState: "POST" },
+    { now: "2026-09-14T05:00:00Z", venue: "JPX", marketState: "REGULAR" },
+    { now: "2026-09-14T18:00:00Z", venue: "OSAKA", marketState: "POST", instrumentType: "INDEX" },
+    { now: "2026-09-12T03:01:00Z", venue: "CCY", marketState: "CLOSED", instrumentType: "CURRENCY" },
+    { now: "2026-09-12T03:01:00Z", venue: "CCC", marketState: "REGULAR" },
+    { now: "2026-09-12T03:01:00Z", venue: undefined, marketState: undefined },
+  ] as const;
+  const clock = spyOn(Date, "now");
+  try {
+    for (const scenario of scenarios) {
+      const now = Date.parse(scenario.now);
+      clock.mockReturnValue(now);
+      for (const invalid of [NaN, Infinity, -Infinity, -1e20, 1e20, 0, -1, undefined, null, "2026-09-11", now + 1]) {
+        const input = Object.freeze(quote(invalid, {
+          listingExchangeName: scenario.venue, marketState: scenario.marketState,
+          instrumentType: "instrumentType" in scenario ? scenario.instrumentType : "EQUITY",
+          preMarketPrice: 100, postMarketPrice: 100, receivedAt: now,
+        }));
+        expect(isQuoteStaleForCurrentSession(input, now)).toBe(true);
+        expect(isProviderQuoteUsableForCurrentSession(input, scenario.venue)).toBe(false);
+        expect(isQuoteStaleForCurrentSession(JSON.parse(JSON.stringify(input)), now)).toBe(true);
+        expect(isQuoteContributionStaleForCurrentSession({ ...input, marketState: undefined }, now)).toBe(true);
+      }
+    }
+  } finally { clock.mockRestore(); }
+});
+
+test("valid delayed, live, last-session and unknown/index observations retain their existing session rules", () => {
+  const clock = spyOn(Date, "now");
+  try {
+    for (const [date, marketState] of [["2026-09-14T11:00:00Z", "PRE"], ["2026-09-14T18:00:00Z", "REGULAR"], ["2026-09-14T22:00:00Z", "POST"]] as const) {
+      const now = Date.parse(date); clock.mockReturnValue(now);
+      for (const dataSource of ["delayed", "realtime"] as const) {
+        const sourceTime = now - (dataSource === "delayed" ? 16 * 60_000 : 1_000);
+        const input = quote(sourceTime, { listingExchangeName: "NASDAQ", marketState, dataSource, preMarketPrice: 100, postMarketPrice: 100 });
+        expect(isQuoteStaleForCurrentSession(input)).toBe(false);
+        expect(isProviderQuoteUsableForCurrentSession(input)).toBe(true);
+        expect(isQuoteStaleForCurrentSession({ ...input, stale: true })).toBe(true);
+      }
+    }
+    const weekend = Date.parse("2026-09-12T03:01:00Z"); clock.mockReturnValue(weekend);
+    const retained = quote(Date.parse("2026-09-11T23:59:00Z"), { listingExchangeName: "NASDAQGM", marketState: "POST" });
+    expect(isProviderQuoteUsableForCurrentSession(retained)).toBe(true);
+    clock.mockReturnValue(Date.parse("2026-09-15T02:00:00Z"));
+    expect(isProviderQuoteUsableForCurrentSession(retained)).toBe(false);
+    clock.mockReturnValue(weekend);
+    for (const venue of [undefined, "UNKNOWN", "OSAKA"]) {
+      expect(isProviderQuoteUsableForCurrentSession(quote(weekend - 6 * 3_600_000, { listingExchangeName: venue, marketState: "CLOSED", instrumentType: "INDEX" }))).toBe(true);
+    }
+    expect(isQuoteStaleForCurrentSession(null)).toBe(false);
+    expect(isQuoteStaleForCurrentSession(undefined)).toBe(false);
+    expect(hasFreshQuoteForCurrentSession([null, undefined])).toBe(false);
+    expect(hasFreshQuoteForCurrentSession([quote(NaN), quote(weekend + 1)])).toBe(false);
+    expect(hasFreshQuoteForCurrentSession([quote(NaN), retained])).toBe(true);
+    expect(isQuoteStaleForCurrentSession(quote(weekend), NaN)).toBe(true);
+    expect(isQuoteStaleForCurrentSession(quote(weekend), 1e20)).toBe(true);
+  } finally { clock.mockRestore(); }
+});

--- a/src/market-data/quotes/resolution.ts
+++ b/src/market-data/quotes/resolution.ts
@@ -10,7 +10,7 @@ import type {
 } from "../../types/financials";
 import { hasLikelyQuoteUnitMismatch } from "../../utils/currency-units";
 import { debugLog } from "../../utils/debug-log";
-import { isExtendedHoursExchange, isQuoteStaleForCurrentSession } from "./freshness";
+import { hasValidQuoteObservationTime, isExtendedHoursExchange, isQuoteStaleForCurrentSession } from "./freshness";
 import { activeUsExtendedHoursSession, isTimestampStaleForExchangeSession } from "../market/freshness";
 import {
   finalizeSessionFields,
@@ -275,7 +275,7 @@ export function isQuoteContributionStaleForCurrentSession(contribution: Quote, n
   // A price-only source can be combined with independent session metadata.
   // Its observation must still belong to the current active session.
   const timestamp = contribution.lastUpdated;
-  if (contribution.stale === true || !Number.isFinite(timestamp) || timestamp <= 0 || timestamp > now) return true;
+  if (contribution.stale === true || !hasValidQuoteObservationTime(contribution, now)) return true;
   const activeSession = isExtendedHoursExchange(contribution) ? activeUsExtendedHoursSession(now) : null;
   if (activeSession && activeUsExtendedHoursSession(timestamp) !== activeSession) return true;
   return isTimestampStaleForExchangeSession(timestamp, contribution.listingExchangeName || contribution.exchangeName, now);

--- a/src/plugins/builtin/portfolio-list/pane/index.test.tsx
+++ b/src/plugins/builtin/portfolio-list/pane/index.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -34,6 +34,7 @@ let testSetup: Awaited<ReturnType<typeof testRender>> | undefined;
 let harnessDispatch: React.Dispatch<AppAction> | null = null;
 let sharedCoordinator: MarketDataCoordinator | null = null;
 let harnessState: ReturnType<typeof createInitialState> | null = null;
+let quoteClock: ReturnType<typeof spyOn> | undefined;
 const tempPaths: string[] = [];
 const tempPersistences: AppPersistence[] = [];
 
@@ -465,6 +466,8 @@ afterEach(async () => {
   for (const path of tempPaths.splice(0)) {
     if (existsSync(path)) rmSync(path, { force: true });
   }
+  quoteClock?.mockRestore();
+  quoteClock = undefined;
 });
 
 describe("PortfolioListPane cash and margin UI", () => {
@@ -1372,6 +1375,8 @@ describe("PortfolioListPane cash and margin UI", () => {
   });
 
   test("updates a non-selected broker-linked row from streamed quotes", async () => {
+    let observationNow = Date.parse("2026-09-14T11:00:00Z");
+    quoteClock = spyOn(Date, "now").mockImplementation(() => observationNow);
     const config = createPortfolioConfigWithColumns(
       "broker:ibkr-live:DU12345",
       ["ticker", "price", "change_pct", "latency"],
@@ -1409,6 +1414,8 @@ describe("PortfolioListPane cash and margin UI", () => {
             change: 2,
             changePercent: 0.64,
             previousClose: 313,
+            marketState: "PRE",
+            preMarketPrice: 315,
             name: "Microsoft",
           }),
         };
@@ -1431,6 +1438,8 @@ describe("PortfolioListPane cash and margin UI", () => {
             change: 2,
             changePercent: 0.64,
             previousClose: 313,
+            marketState: "PRE",
+            preMarketPrice: 315,
             name: "Microsoft",
           });
       },
@@ -1504,6 +1513,7 @@ describe("PortfolioListPane cash and margin UI", () => {
     });
     await flushFrame();
 
+    observationNow += 1_000;
     await act(async () => {
       streamed?.(
         {
@@ -1532,7 +1542,7 @@ describe("PortfolioListPane cash and margin UI", () => {
           preMarketPrice: 126.5,
           preMarketChange: 6.5,
           preMarketChangePercent: 5.41,
-          lastUpdated: Date.now() + 1_000,
+          lastUpdated: Date.now(),
         }),
       );
       await Promise.resolve();

--- a/src/plugins/builtin/ticker-detail/headless.ts
+++ b/src/plugins/builtin/ticker-detail/headless.ts
@@ -1,4 +1,5 @@
 import { FINANCIAL_VINTAGE_NOTICE } from "../../../utils/financial-statements";
+import { hasValidQuoteObservationTime } from "../../../market-data/quotes/freshness";
 import type { HeadlessPaneColumn, HeadlessPaneDefinition } from "../../../types/headless";
 import type { TimeRange } from "../../../time-series/range";
 import { formatNumber, formatPercentRaw } from "../../../utils/format";
@@ -88,7 +89,10 @@ export const quoteComparisonHeadless: HeadlessPaneDefinition<"rows"> = {
   async load({ symbols }, ctx) {
     const loaded = await loadHeadlessSymbols(symbols, ctx, async (key) => {
       const { symbol, exchange } = await resolveHeadlessInstrument(ctx, key);
-      return ctx.marketData.getQuote(symbol, exchange);
+      const quote = await ctx.marketData.getQuote(symbol, exchange);
+      if (!quote) throw new Error(`Quote is unavailable for ${key}`);
+      if (!hasValidQuoteObservationTime(quote)) throw new Error(`Quote observation time is unavailable for ${key}`);
+      return quote;
     });
     return {
       rows: loaded.entries.map(({ symbol, data: quote }) => ({

--- a/src/plugins/builtin/ticker-detail/quote-monitor/retained-status.test.tsx
+++ b/src/plugins/builtin/ticker-detail/quote-monitor/retained-status.test.tsx
@@ -99,6 +99,21 @@ test("explicit stale cached quote is identified while its provider refresh is pe
   expect(recovered).not.toContain("Stale quote");
 });
 
+test.each(["NaN", "Infinity", "future"] as const)("retained quote with %s source time stays visibly stale until a valid observation arrives", async kind => {
+  let complete!: (value: Quote) => void;
+  const pending = new Promise<Quote>(resolve => { complete = resolve; });
+  const invalidTime = kind === "NaN" ? NaN : kind === "Infinity" ? Infinity : Date.now() + 86_400_000;
+  const cached = { ...quote(), lastUpdated: invalidTime, receivedAt: Date.now() };
+  const retained = await render(80, () => pending, cached);
+  expect(retained).toContain("$1.160227");
+  expect(retained).toContain("Stale quote");
+  expect(Object.is(cached.lastUpdated, invalidTime)).toBe(true);
+  await act(async () => { complete(quote(1.170227)); });
+  const recovered = await frame();
+  expect(recovered).toContain("$1.170227");
+  expect(recovered).not.toContain("Stale quote");
+});
+
 // Dense boards can allocate only three rows to a narrow card. The failure must
 // remain visible there without pushing the retained quote off the card.
 test.each(["error", "stale"] as const)("compact retained card identifies %s without wrapping a long symbol", async (kind) => {

--- a/src/plugins/builtin/ticker-detail/quote-time-integrity.test.ts
+++ b/src/plugins/builtin/ticker-detail/quote-time-integrity.test.ts
@@ -1,0 +1,42 @@
+import { expect, spyOn, test } from "bun:test";
+import { AssetDataRouter } from "../../../sources/provider-router";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { createDefaultConfig } from "../../../types/config";
+import type { Quote } from "../../../types/financials";
+import { appendLiveQuotePoint } from "../../../time-series/chart-data";
+import { quoteComparisonHeadless } from "./headless";
+
+for (const routed of [false, true]) test(`QM ${routed ? "routed" : "direct"} exports reject invalid quote times without losing healthy peers and recover the actual observation`, async () => {
+  const now = Date.parse("2026-09-12T03:01:00Z");
+  const clock = spyOn(Date, "now").mockReturnValue(now);
+  const sourceTime = Date.parse("2026-09-11T23:59:00Z");
+  const sourceQuote: Quote = Object.freeze({ symbol: "BAD", price: 59.786, currency: "USD", change: 0.486, changePercent: 0.81956,
+    lastUpdated: sourceTime, listingExchangeName: "NASDAQGM", marketState: "POST", dataSource: "delayed" });
+  let lastUpdated: number | null = NaN;
+  const provider = createTestDataProvider({
+    getQuote: async symbol => ({ ...sourceQuote, symbol, lastUpdated: symbol === "GOOD" ? sourceTime : lastUpdated as number }),
+  });
+  const context = { marketData: routed ? new AssetDataRouter(provider) : provider, config: createDefaultConfig("/tmp/quote-time-export-unused"), signal: new AbortController().signal } as any;
+  const args = { symbols: ["BAD", "GOOD"], argument: ["BAD", "GOOD"], rawArgument: "BAD,GOOD", options: {} };
+  try {
+    for (const invalid of [NaN, Infinity, JSON.parse(JSON.stringify(NaN)), now + 60_000]) {
+      lastUpdated = invalid;
+      const model = await quoteComparisonHeadless.load(args, context);
+      const serialized = JSON.parse(JSON.stringify(model));
+      expect(serialized.rows.map((row: any) => row.symbol)).toEqual(["GOOD"]);
+      expect(serialized.unavailableSymbols).toEqual(["BAD"]);
+      expect(serialized.errors.length).toBe(1);
+      const history = [{ date: new Date(sourceTime - 600_000), close: 59 }];
+      expect(appendLiveQuotePoint(history, { ...sourceQuote, lastUpdated: invalid })).toBe(history);
+    }
+    lastUpdated = sourceTime;
+    const recovered = await quoteComparisonHeadless.load(args, context);
+    expect(recovered.rows.map(row => row.symbol)).toEqual(["BAD", "GOOD"]);
+    expect(recovered.unavailableSymbols).toEqual([]);
+    expect(recovered.rows[0]).toMatchObject({ price: 59.786, updatedAt: sourceTime, change: 0.486, currency: "USD" });
+    const history = [{ date: new Date(sourceTime - 600_000), close: 59 }];
+    const appended = appendLiveQuotePoint(history, sourceQuote);
+    expect(appended.at(-1)).toMatchObject({ date: new Date(sourceTime), close: sourceQuote.price });
+    expect(sourceQuote.lastUpdated).toBe(sourceTime);
+  } finally { clock.mockRestore(); }
+});

--- a/src/time-series/live-quotes.ts
+++ b/src/time-series/live-quotes.ts
@@ -5,6 +5,7 @@ import type { BrokerContractRef } from "../types/instrument";
 import type { ChartSeriesSpec, ChartSpec, SecuritySeriesSource } from "./types";
 import { activeStudyInputSeriesIds } from "./studies";
 import { valuationSeriesUsesLiveQuote } from "./fundamentals";
+import { hasValidQuoteObservationTime } from "../market-data/quotes/freshness";
 
 export const LIVE_CHART_REFRESH_INTERVAL_MS = 1_000;
 
@@ -97,8 +98,8 @@ export function liveChartQuoteTargetSignature(spec: ChartSpec): string {
 
 /** A malformed timestamp cannot outrank a usable source observation forever. */
 export function compareChartQuoteRecency(next: Quote, current: Quote): number {
-  const sourceTime = (quote: Quote) => Number.isFinite(quote.lastUpdated) && quote.lastUpdated > 0
-    && Number.isFinite(new Date(quote.lastUpdated).getTime()) ? quote.lastUpdated : -Infinity;
+  const now = Date.now();
+  const sourceTime = (quote: Quote) => hasValidQuoteObservationTime(quote, now) ? quote.lastUpdated : -Infinity;
   const nextTime = sourceTime(next);
   const currentTime = sourceTime(current);
   if (nextTime !== currentTime) return nextTime > currentTime ? 1 : -1;

--- a/src/time-series/resolve.test.ts
+++ b/src/time-series/resolve.test.ts
@@ -1,5 +1,5 @@
 import { FINANCIAL_VINTAGE_NOTICE } from "../utils/financial-statements";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { chartSeriesSourceKey } from "../capabilities";
 import type { FredSeriesData, FredSeriesLoadResult } from "../data/fred-series";
 import { buildCustomChartPreset } from "../plugins/builtin/chart-composer/presets";
@@ -1628,9 +1628,10 @@ describe("resolveChartSpecData", () => {
     expect(sma.points.at(-1)?.value).toBeCloseTo(15.5);
   });
 
-  test("keeps a quote received after resolution starts inside the latest viewport", async () => {
-    const now = Date.parse("2026-08-05T14:00:00Z");
+  test.each([0, 60_000])("validates a quote received after resolution starts against %i ms elapsed", async (elapsed) => {
+    const now = Date.parse("2026-08-05T22:00:00Z");
     const quoteTime = now + 60_000;
+    const clock = spyOn(Date, "now").mockReturnValue(now);
     const provider = createTestDataProvider({
       getTickerFinancials: async () => ({
         ...emptyFinancials(),
@@ -1648,10 +1649,13 @@ describe("resolveChartSpecData", () => {
           postMarketChangePercent: -0.77,
         },
       }),
-      getPriceHistoryForResolution: async () => [
-        { date: new Date(now - 2 * 86_400_000), open: 99, high: 102, low: 98, close: 100 },
-        { date: new Date(now - 86_400_000), open: 100, high: 101, low: 99, close: 100 },
-      ],
+      getPriceHistoryForResolution: async () => {
+        clock.mockReturnValue(now + elapsed);
+        return [
+          { date: new Date(now - 2 * 86_400_000), open: 99, high: 102, low: 98, close: 100 },
+          { date: new Date(now - 86_400_000), open: 100, high: 101, low: 99, close: 100 },
+        ];
+      },
     });
     const spec: ChartSpec = chartSpec({
       viewport: { range: "6M", resolution: "1d" },
@@ -1673,40 +1677,42 @@ describe("resolveChartSpecData", () => {
       }],
     });
 
-    const result = await resolveChartSpecData(spec, {
-      dataProvider: provider,
-      now: new Date(now),
-      quoteOverrides: new Map([[
-        chartQuoteOverrideKeyForSource({
-          kind: "security",
-          instrument: { symbol: "FRESH", exchange: "XNAS" },
-          fieldId: "market.ohlcv",
-        }),
-        {
-          symbol: "FRESH",
-          price: 130,
-          currency: "USD",
-          change: 30,
-          changePercent: 30,
-          lastUpdated: quoteTime,
-          listingExchangeName: "XNAS",
-          marketState: "POST",
-          postMarketPrice: 129,
-          postMarketChange: -1,
-          postMarketChangePercent: -0.77,
-        },
-      ]]),
-      loadFredSeries: async () => fredLoad(),
-    });
+    try {
+      const result = await resolveChartSpecData(spec, {
+        dataProvider: provider,
+        now: new Date(now),
+        quoteOverrides: new Map([[
+          chartQuoteOverrideKeyForSource({
+            kind: "security",
+            instrument: { symbol: "FRESH", exchange: "XNAS" },
+            fieldId: "market.ohlcv",
+          }),
+          {
+            symbol: "FRESH",
+            price: 130,
+            currency: "USD",
+            change: 30,
+            changePercent: 30,
+            lastUpdated: quoteTime,
+            listingExchangeName: "XNAS",
+            marketState: "POST",
+            postMarketPrice: 129,
+            postMarketChange: -1,
+            postMarketChangePercent: -0.77,
+          },
+        ]]),
+        loadFredSeries: async () => fredLoad(),
+      });
 
-    expect(result.errors).toEqual([]);
-    expect(result.viewport?.end.getTime()).toBe(quoteTime);
-    const price = result.series.find((entry) => entry.id === "price");
-    const sma = result.series.find((entry) => entry.id === "sma");
-    expect(price?.points.at(-1)?.date.getTime()).toBe(quoteTime);
-    expect(price?.points.at(-1)?.close).toBe(129);
-    expect(price?.latestChangePercent).toBe(30);
-    expect(sma?.points.at(-1)?.date.getTime()).toBe(quoteTime);
+      expect(result.errors).toEqual([]);
+      expect(result.viewport?.end.getTime()).toBe(elapsed ? quoteTime : now);
+      const price = result.series.find((entry) => entry.id === "price");
+      const sma = result.series.find((entry) => entry.id === "sma");
+      expect(price?.points.at(-1)?.date.getTime()).toBe(elapsed ? quoteTime : now - 86_400_000);
+      expect(price?.points.at(-1)?.close).toBe(elapsed ? 129 : 100);
+      expect(price?.latestChangePercent).toBe(elapsed ? 30 : undefined);
+      expect(sma?.points.at(-1)?.date.getTime()).toBe(elapsed ? quoteTime : now - 86_400_000);
+    } finally { clock.mockRestore(); }
   });
 
   test.each(["line", "candles"] as const)("keeps one daily bar when a live quote updates a %s chart", async (style) => {

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -1,4 +1,5 @@
 import { resolveAssetDisplayKind } from "../market-data/market/format";
+import { hasValidQuoteObservationTime } from "../market-data/quotes/freshness";
 import { SnapshotHistoryUnavailableError } from "../market-data/snapshot-provider";
 import { financialPeriodCoverage, financialPeriodCoverageWarnings, limitSeriesObservations } from "./financial-period-coverage";
 import { HistoryCoverageError, historyCoverageNotice, isShellLondonTarget } from "../sources/history-coverage";
@@ -757,7 +758,8 @@ function baseSecuritySeries(
     ? resolveExchangeTimeZone(marketExchange)
     : null;
   const latestChangePercent = marketField && field.unit.startsWith("currency")
-    ? financials.quote?.changePercent
+    && financials.quote && hasValidQuoteObservationTime(financials.quote)
+    ? financials.quote.changePercent
     : undefined;
   const priceIssues = valuationPriceIssues(financials, spec.source);
   return {
@@ -999,7 +1001,8 @@ export async function resolveChartSpecData(
     return { series: [], loading: false, errors: ["Market data is unavailable."], warnings };
   }
 
-  const referenceNow = sources.now ?? new Date();
+  const resolutionStartedAt = Date.now();
+  const referenceNow = sources.now ?? new Date(resolutionStartedAt);
   const comparedSeriesIds = new Set(priceComparisonSeriesIds(spec) ?? []);
   const initialVisibleBounds = requestedBounds(spec, referenceNow);
 
@@ -1265,11 +1268,16 @@ export async function resolveChartSpecData(
       // Display style does not change the sampling interval: line and candle
       // charts must merge a live quote into the same active price bar.
       const liveBarResolution = initialResolution;
+      // The viewport's initial reference stays fixed while a source request
+      // runs. Validate a newly arrived quote against the elapsed clock.
+      const observationNow = referenceNow.getTime() + Math.max(0, Date.now() - resolutionStartedAt);
       const merged = history
         // A streamed quote may update only one leg, even inside the same weekly
         // bar. Comparison endpoints therefore use source history observations;
         // quotes still provide currency/type without rewriting their prices.
-        ? mergeHistory(financials, history, quoteOverride, referenceNow.getTime(), liveBarResolution, resolvedSource.instrument.exchange, !comparedSeriesIds.has(seriesSpec.id))
+        ? mergeHistory(financials, history, quoteOverride,
+          observationNow,
+          liveBarResolution, resolvedSource.instrument.exchange, !comparedSeriesIds.has(seriesSpec.id))
         : quoteOverride && financials
           ? { ...financials, quote: latestQuote(financials.quote, quoteOverride) }
           : financials;

--- a/src/time-series/valuation-price.test.ts
+++ b/src/time-series/valuation-price.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import type { TickerFinancials } from "../types/financials";
 import { createTestDataProvider } from "../test-support/data-provider";
 import { createDefaultConfig } from "../types/config";
@@ -126,6 +126,37 @@ test("actual resolver/export retain stale-source diagnostics and historical valu
   expect(recovered.complete).not.toBe(false);
 });
 
+test("future Current quote times retain invalid-time provenance without changing historical multiples", async () => {
+  const now = Date.parse("2026-09-12T04:00:00Z");
+  const clock = spyOn(Date, "now").mockReturnValue(now);
+  const data = fixture();
+  const future = now + 86_400_000;
+  data.quote!.lastUpdated = future;
+  const original = JSON.stringify(data);
+  try {
+    for (const field of fields) {
+      expect(extractFundamentalSeries(data, source(field)).some(point => point.periodLabel === "Current")).toBe(false);
+      expect(valuationPriceIssues(data, source(field))).toEqual([expect.objectContaining({ reason: "invalid-timestamp", quote: expect.objectContaining({ lastUpdated: future, price: 60 }) })]);
+    }
+    const model = await load(data);
+    expect(model.series[0]?.points.map(point => point.value)).toEqual([5.5]);
+    expect(model.complete).toBe(false);
+    expect(model.metadata?.warnings).toEqual(expect.arrayContaining([expect.stringContaining("source quote timestamp is unavailable")]));
+    expect(model.metadata?.valuationPriceIssues).toEqual([expect.objectContaining({ issues: [expect.objectContaining({ reason: "invalid-timestamp", quote: expect.objectContaining({ lastUpdated: future }) })] })]);
+    expect(JSON.stringify(data)).toBe(original);
+    for (const viewport of [{ dateWindow: { start: "2026-09-10T13:00:00Z", end: "2026-09-10T20:00:00Z" } }, { maxPoints: 1 }]) {
+      const historical = await load(data, viewport);
+      expect(historical.complete).not.toBe(false);
+      expect(historical.metadata?.valuationPriceIssues).toBeUndefined();
+    }
+    data.quote!.lastUpdated = now - 60_000;
+    const recovered = await load(data);
+    expect(recovered.series[0]?.points.at(-1)).toMatchObject({ periodLabel: "Current", value: 6 });
+    expect(recovered.metadata?.valuationPriceIssues).toBeUndefined();
+    expect(recovered.complete).not.toBe(false);
+  } finally { clock.mockRestore(); }
+});
+
 test("actual resolver/export count a null corrupt valuation as unavailable and retain the original candle", async () => {
   const data = fixture(); data.quote!.stale = true; data.priceHistory[1]!.open = 70;
   const model = await load(data);
@@ -189,7 +220,7 @@ test("invalid non-OHLC prices interrupt studies and retain the reason during lat
   expect(warmup.chart.warnings.some((warning) => warning.includes("inconsistent OHLC"))).toBe(false);
 });
 
-test("actual live quote status changes and timestamp recovery recompute Current valuations", async () => {
+test.each(["NaN", "future"] as const)("actual live quote status and %s timestamp recovery recompute Current valuations", async invalidKind => {
   const data = fixture();
   const spec: ChartSpec = { version: CHART_SPEC_VERSION, viewport: { range: "5Y", resolution: "1d" }, panels: [{ id: "main" }],
     studies: [], series: [{ id: "pe", source: source(), style: "line", transform: "raw", axis: "left", panelId: "main", interpolation: "none" }] };
@@ -208,7 +239,7 @@ test("actual live quote status changes and timestamp recovery recompute Current 
   }
   const valid = { ...data.quote!, stale: false };
   try {
-    emit(target, { ...valid, lastUpdated: NaN, receivedAt: 1 });
+    emit(target, { ...valid, lastUpdated: invalidKind === "NaN" ? NaN : Date.now() + 86_400_000, receivedAt: 1 });
     await waitForCount(1);
     // A valid timestamp must dislodge the malformed prior stream observation.
     emit(target, { ...valid, receivedAt: 2 });
@@ -223,7 +254,7 @@ test("actual live quote status changes and timestamp recovery recompute Current 
     expect(results.at(-1)?.series[0]?.points.at(-1)?.value).toBe(6);
     expect(results.at(-1)?.warnings.some((warning) => warning.includes("source quote is stale"))).toBe(false);
   } finally { stop(); }
-  for (const invalid of [NaN, Infinity, 0, -1, 9e20]) {
+  for (const invalid of [NaN, Infinity, 0, -1, 9e20, Date.now() + 86_400_000]) {
     data.quote!.lastUpdated = invalid;
     const recovered = await resolveChartSpecData(spec, { dataProvider: provider, now: new Date("2026-09-12"),
       quoteOverrides: new Map([[chartQuoteOverrideKeyForSource(source()), valid]]) });

--- a/src/time-series/valuation-price.ts
+++ b/src/time-series/valuation-price.ts
@@ -1,4 +1,5 @@
 import type { PricePoint, Quote } from "../types/financials";
+import { hasValidQuoteObservationTime } from "../market-data/quotes/freshness";
 import { mergePriceHistoryIntegrity, pricePointIntegrity } from "../utils/price-history-integrity";
 
 export type ValuationPriceIssue = ({
@@ -13,14 +14,14 @@ export type ValuationPriceIssue = ({
 
 export function valuationQuoteIssue(quote: Quote | undefined): ValuationPriceIssue | undefined {
   if (!quote) return undefined;
+  const validObservationTime = hasValidQuoteObservationTime(quote);
   const reason = quote.stale === true ? "stale"
     : !Number.isFinite(quote.price) || quote.price <= 0 ? "invalid-price"
-      : !Number.isFinite(quote.lastUpdated) || quote.lastUpdated <= 0
-        || !Number.isFinite(new Date(quote.lastUpdated).getTime()) ? "invalid-timestamp" : null;
+      : !validObservationTime ? "invalid-timestamp" : null;
   if (!reason) return undefined;
   const { symbol, currency, price, lastUpdated, stale, providerId } = quote;
   return { kind: "quote", reason, quote: { symbol, currency, price, lastUpdated, stale, providerId },
-    ...(Number.isFinite(lastUpdated) && lastUpdated > 0 && Number.isFinite(new Date(lastUpdated).getTime())
+    ...(validObservationTime
       ? { affectedAt: new Date(lastUpdated).toISOString() } : {}) };
 }
 


### PR DESCRIPTION
Missing, invalid or future quote timestamps could supply a current quote or valuation, and a future-dated chart observation could prevent a later valid quote from replacing it. Apply the shared observation-time check at quote, headless research and chart boundaries; preserve rejected source details, independent historical observations and recovery when valid data arrives.

Chart requests validate arriving observations against actual elapsed request time while keeping the requested viewport fixed. The portfolio stream test now advances a controlled clock before publishing a later quote instead of inventing a future timestamp. Existing status/error handling is reused, with no new UI text or controls; methodology is in the research data guide.

Validation: 3,301 tests / 14,668 assertions across 540 files pass on the integrated branch, along with all six TypeScript targets and both generated-file checks. Independent review covers direct QM and Current valuation consumers, subscription/snapshot recovery, and eight retained-data pane cases at 80/120 columns. The initial full-suite fixture failure and corrected rerun are preserved in the audit evidence. GUI verification remains limited to in-process pane renders and normal CI.
