### PR TITLE
Preserve FX price precision in chart legends and cursors

### DIFF
--- a/src/components/chart/composite/format.ts
+++ b/src/components/chart/composite/format.ts
@@ -38,16 +38,16 @@ function currencyPrefix(unit: string): string {
   return currency ? CURRENCY_SYMBOLS[currency] ?? "" : "";
 }
 
-function formatFullCurrencyValue(value: number, unit: string): string | null {
+function formatFullCurrencyValue(value: number, unit: string, assetCategory?: string): string | null {
   const currency = unitCurrencyCode(unit);
-  return currency ? formatMarketPriceWithCurrency(value, currency) : null;
+  return currency ? formatMarketPriceWithCurrency(value, currency, { assetCategory }) : null;
 }
 
 export function formatCompositeSeriesValue(value: number, series: ResolvedSeries): string {
-  return formatChartLegendValue(value, series.unit, series.unitGroup);
+  return formatChartLegendValue(value, series.unit, series.unitGroup, series.priceAssetCategory);
 }
 
-export function formatChartLegendValue(value: number, unit: string, unitGroup = ""): string {
+export function formatChartLegendValue(value: number, unit: string, unitGroup = "", assetCategory?: string): string {
   const trimmed = unit.trim();
   const group = unitGroup.toLowerCase();
   const compact = compactNumber(value);
@@ -65,7 +65,7 @@ export function formatChartLegendValue(value: number, unit: string, unitGroup = 
       return prefix ? `${prefix}${amount}` : `${amount} ${trimmed}`.trim();
     }
   }
-  const fullPrice = formatFullCurrencyValue(value, trimmed);
+  const fullPrice = formatFullCurrencyValue(value, trimmed, assetCategory);
   if (fullPrice) return fullPrice;
   return trimmed && trimmed.length <= 6 ? `${compact}${trimmed.startsWith("/") ? "" : " "}${trimmed}` : compact;
 }
@@ -87,7 +87,13 @@ export function formatCompositeCursorValue(value: number, domain: CompositeAxisD
   if (group.split(":")[0] === "currency-total") {
     return formatChartLegendValue(value, domain.unit, domain.unitGroup);
   }
-  const fullPrice = formatFullCurrencyValue(value, domain.unit);
+  // An axis can serve several price series. Keep the most precise value the
+  // shared formatter produces, rather than inheriting the first asset's rounding.
+  const categories = domain.priceAssetCategories?.length ? domain.priceAssetCategories : [undefined];
+  const fullPrice = categories.reduce<string>((best, category) => {
+    const formatted = formatFullCurrencyValue(value, domain.unit, category) ?? "";
+    return formatted.length > best.length ? formatted : best;
+  }, "");
   if (fullPrice) return fullPrice;
   return formatCompositeAxisValue(value, domain);
 }

--- a/src/components/chart/composite/fx-precision.test.ts
+++ b/src/components/chart/composite/fx-precision.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test";
+import { createTestDataProvider } from "../../../test-support/data-provider";
+import { createDefaultConfig } from "../../../types/config";
+import { loadChartPaneModel } from "../../../plugins/builtin/chart-composer/headless";
+import { buildPriceChartPreset } from "../../../plugins/builtin/chart-composer/presets";
+import { formatMarketPriceWithCurrency } from "../../../market-data/market/format";
+import { applyResolvedSeriesTransform } from "../../../time-series/transforms";
+import type { HeadlessPaneContext } from "../../../types/headless";
+import { formatCompositeCursorValue, formatCompositeSeriesValue } from "./format";
+import { applyCompositeChartCursor, buildCompositeChartScene, resolveCompositeCursorDate } from "./scene";
+import { reuseResolvedSeriesIdentity } from "./panel-series";
+
+const cases = [
+  ["EURUSD=X", "USD", "CURRENCY", 1.1602274179458618, "$1.160227"],
+  ["USDEUR=X", "EUR", "CURRENCY", 0.8618999719619751, "€0.8619"],
+  ["JPY=X", "JPY", "CURRENCY", 153.5540008544922, "¥153.554001"],
+  ["JPYUSD=X", "USD", "CURRENCY", 0.00651236716657877, "$0.006512"],
+  ["AAPL", "USD", "EQUITY", 259.7499, "$259.75"],
+  ["BTC-USD", "USD", "CRYPTOCURRENCY", 79_432.18, "$79,432.18"],
+  ["SHIB-USD", "USD", "CRYPTOCURRENCY", 0.00000526, "$0.00000526"],
+] as const;
+
+async function priceModel(symbol: string, currency: string, instrumentType: string, value: number) {
+  const step = Math.min(0.0001, value / 10);
+  const points = [0, 1, 2].map((offset) => ({ date: new Date(Date.UTC(2026, 8, 9 + offset)), close: value + (offset - 2) * step }));
+  const spec = buildPriceChartPreset(symbol);
+  spec.viewport = { ...spec.viewport, range: "1M", resolution: "1d", dateWindow: { start: "2026-09-09", end: "2026-09-11" } };
+  spec.studies = [{ id: "sma", kind: "sma", inputSeriesIds: [spec.series[0]!.id], parameters: { period: 2 }, panelId: "main", axis: "left" }];
+  const provider = createTestDataProvider({
+    getQuote: async () => ({ symbol, currency, instrumentType, price: value, change: 0, changePercent: 0, lastUpdated: Date.parse("2026-09-11T21:00Z"), stale: true }),
+    getTickerFinancials: async () => ({ annualStatements: [], quarterlyStatements: [], priceHistory: points }),
+    getPriceHistory: async () => points,
+    getPriceHistoryForResolution: async () => points,
+    getDetailedPriceHistory: async () => points,
+  });
+  const model = await loadChartPaneModel(spec, {
+    marketData: provider, config: createDefaultConfig("/tmp/fx-precision-unused"),
+    apiClient: {} as HeadlessPaneContext["apiClient"], signal: new AbortController().signal,
+  });
+  return { model, points };
+}
+
+for (const [symbol, currency, category, value, expected] of cases) {
+  test(`${symbol} keeps its price basis through export, legend, pointer cursor and price study`, async () => {
+    const { model, points } = await priceModel(symbol, currency, category, value);
+    const series = model.chart.series.find((entry) => entry.id === model.spec.series[0]!.id)!;
+    expect(series.points.map((point) => point.value)).toEqual(points.map((point) => point.close));
+    const exported = JSON.parse(JSON.stringify(model)).series.find((entry: { id: string }) => entry.id === series.id);
+    expect(exported.points.at(-1).value).toBe(value);
+    expect(exported.unit).toBe(series.unit);
+    expect(formatCompositeSeriesValue(value, series)).toBe(expected);
+    expect(formatCompositeSeriesValue(value, exported)).toBe(expected);
+
+    const scene = buildCompositeChartScene(model.chart.series, model.spec.panels, { width: 101, height: 20 })!;
+    const panel = scene.panels.find((entry) => entry.series.some((item) => item.source.id === series.id))!;
+    const projected = panel.series.find((entry) => entry.source.id === series.id)!.points.at(-1)!;
+    const cursorDate = resolveCompositeCursorDate(scene, projected.xRatio * (scene.width - 1))!;
+    const cursor = applyCompositeChartCursor(scene, cursorDate).cursorValues.find((entry) => entry.seriesId === series.id)!;
+    expect(cursor.value).toBe(value);
+    expect(formatCompositeCursorValue(cursor.value!, panel.axes[series.axis]!)).toBe(expected);
+    const average = model.chart.series.find((entry) => entry.id === "sma")!;
+    const averageValue = average.points.at(-1)!.value!;
+    expect(formatCompositeSeriesValue(averageValue, average)).toBe(formatMarketPriceWithCurrency(averageValue, currency, { assetCategory: category }));
+  });
+}
+
+test("shared price axes retain FX cursor precision in either order and metadata recovery updates identical points", async () => {
+  const fx = (await priceModel("EURUSD=X", "USD", "CURRENCY", 1.1602274179458618)).model.chart.series[0]!;
+  const equity = (await priceModel("AAPL", "USD", "EQUITY", 259.7499)).model.chart.series[0]!;
+  for (const entries of [[equity, fx], [fx, equity]]) {
+    const scene = buildCompositeChartScene(entries, [{ id: "main" }], { width: 101, height: 20 })!;
+    expect(formatCompositeCursorValue(1.1602274179458618, scene.panels[0]!.axes.left!)).toBe("$1.160227");
+  }
+  const untyped = { ...fx, priceAssetCategory: undefined };
+  const recovered = reuseResolvedSeriesIdentity(untyped, fx);
+  expect(formatCompositeSeriesValue(1.1602274179458618, untyped)).toBe("$1.16");
+  expect(formatCompositeSeriesValue(1.1602274179458618, recovered)).toBe("$1.160227");
+  expect(recovered.points).toBe(untyped.points);
+});
+
+test("FX metadata does not turn normalized returns or ratios into currency prices", async () => {
+  const fx = (await priceModel("EURUSD=X", "USD", "CURRENCY", 1.1602274179458618)).model.chart.series[0]!;
+  const percent = applyResolvedSeriesTransform(fx, "percent");
+  const latest = percent.points.at(-1)!;
+  expect(latest.value).toBeCloseTo((fx.points.at(-1)!.value! / fx.points[0]!.value! - 1) * 100, 10);
+  expect(latest.rawValue).toBe(fx.points.at(-1)!.value);
+  expect(formatCompositeSeriesValue(latest.value!, percent)).toEndWith("%");
+  expect(formatCompositeSeriesValue(1.25, { ...fx, unit: "x", unitGroup: "ratio" })).toBe("1.25x");
+});

--- a/src/components/chart/composite/panel-series.ts
+++ b/src/components/chart/composite/panel-series.ts
@@ -28,6 +28,7 @@ function sameSeriesMeta(left: ResolvedSeries, right: ResolvedSeries): boolean {
     && left.color === right.color
     && left.unit === right.unit
     && left.unitGroup === right.unitGroup
+    && left.priceAssetCategory === right.priceAssetCategory
     && left.nativeFrequency === right.nativeFrequency
     && left.timestampMode === right.timestampMode
     && left.dataShape === right.dataShape

--- a/src/components/chart/composite/scene.ts
+++ b/src/components/chart/composite/scene.ts
@@ -299,6 +299,7 @@ function buildAxisDomain(
     scale,
     unit: first.unit,
     unitGroup: first.unitGroup,
+    priceAssetCategories: [...new Set(axisSeries.flatMap((entry) => entry.priceAssetCategory ? [entry.priceAssetCategory] : []))],
     seriesIds: axisSeries.map((entry) => entry.id),
   };
 }

--- a/src/components/chart/composite/types.ts
+++ b/src/components/chart/composite/types.ts
@@ -24,6 +24,8 @@ export interface CompositeAxisDomain {
   scale: PanelScale;
   unit: string;
   unitGroup: string;
+  /** Each source's price category, retained when different assets share an axis. */
+  priceAssetCategories?: string[];
   seriesIds: string[];
 }
 

--- a/src/time-series/resolve.ts
+++ b/src/time-series/resolve.ts
@@ -769,6 +769,8 @@ function baseSecuritySeries(
     color: spec.color ?? SERIES_COLORS[index % SERIES_COLORS.length]!,
     unit,
     unitGroup: currencyUnitGroup,
+    priceAssetCategory: marketField && field.unitGroup === "price"
+      ? financials.quote?.instrumentType || quoteMetadata?.instrumentType : undefined,
     volumeUnit,
     ...(priceIssues.length ? { valuationPriceIssues: priceIssues } : {}),
     warning: field.id === "market.volume" && !volumeUnit && points.length > 0

--- a/src/time-series/studies.ts
+++ b/src/time-series/studies.ts
@@ -82,6 +82,8 @@ function outputSeries(
     color: options.color,
     unit: options.unit ?? input.unit,
     unitGroup: options.unitGroup ?? input.unitGroup,
+    priceAssetCategory: (options.unit ?? input.unit) === input.unit
+      && (options.unitGroup ?? input.unitGroup) === input.unitGroup ? input.priceAssetCategory : undefined,
     nativeFrequency: options.nativeFrequency ?? input.nativeFrequency,
     dataShape: "scalar",
     style: options.style ?? "line",

--- a/src/time-series/types.ts
+++ b/src/time-series/types.ts
@@ -135,6 +135,8 @@ export interface ResolvedSeries {
   /** Unit of rawValue, retained when presentation transforms change unit. */
   rawUnit?: string;
   unitGroup: string;
+  /** Source instrument category used only for monetary market-price precision. */
+  priceAssetCategory?: string;
   /** Volume basis established by the source instrument; omitted when unspecified. */
   volumeUnit?: "shares" | "contracts";
   nativeFrequency: SeriesPeriod;


### PR DESCRIPTION
FX chart legends and cursor labels lost instrument-specific precision after price history was resolved. For example, recorded EUR/USD 1.1602274179458618 appeared as $1.16, and USD/JPY 153.5540008544922 as ¥153.55. Carry the source instrument category into the existing market formatter so full price labels display $1.160227 and ¥153.554001 consistently with other quote views.

Same-unit price studies retain the category. A shared price axis keeps the most precise result from the existing formatter regardless of series order, and late metadata recovery refreshes labels without replacing unchanged points. Compact ticks, raw/exported values, units, percentage returns, historical gaps and existing controls remain intact.

Validation: 3,319 tests / 14,876 assertions across 543 files, all six TypeScript targets and both generated-file checks pass on the integrated branch. Recorded source replay preserves eight chart models and two comparisons; twelve actual pane/keyboard-cursor cases at 48/80/120 columns pass 66 assertions. Independent review also covers equity/FX/crypto axis ordering, small prices, same-unit studies and metadata-only recovery. No new UI prose or buttons.
