### PR TITLE
Show percentage and series units in research text exports

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -172,6 +172,8 @@ Running `gloomberb` with no arguments launches the terminal UI. Normal commands 
 
 Human-readable output is the default. Automation can opt into structured output with `--json`, `--csv`, or `--ndjson`. JSON output favors the richest fetched model available and includes display-column metadata when a command has table columns; CSV and NDJSON use the command's tabular row view. Common global flags include `--limit`, `--refresh`, `--quiet`, `--no-color`, `--dry-run`, and `--yes`.
 
+Headless chart text includes a Unit column when a series supplies one; values keep that unit's scale (for example, `2.7 %` versus `270 bp`). DVD text labels cash growth, CAGR and earnings payout as percentages, while their structured `value` fields remain fractional ratios (`0.03` means 3%). `fn --csv` preserves the report fields and encodes nested sections or series as JSON cells, retaining raw numeric values alongside any separate display strings; it does not flatten or rescale those observations.
+
 | Command | Use |
 |---------|-----|
 | `gloomberb` | Launch the terminal UI |

--- a/src/cli/pane-functions/headless.test.ts
+++ b/src/cli/pane-functions/headless.test.ts
@@ -288,3 +288,27 @@ test("headless text preserves applicable coverage notices once before the export
   expect(text.indexOf("Historical versions unavailable.")).toBeLessThan(text.indexOf("VALUE"));
   expect(text).toContain("96571000000");
 });
+
+
+test("series text distinguishes explicit percent, basis-point and index units without scaling exports", () => {
+  const definition: HeadlessPaneDefinition<"series"> = { shape: "series", argument: { kind: "none" }, options: [], load: () => ({ series: [] }) };
+  const result: HeadlessSeriesResult = { series: [
+    { id: "percent", label: "Credit percent", unit: "%", points: [{ date: "2026-09-10", value: 2.7 }] },
+    { id: "bp", label: "Credit basis points", unit: "bp", points: [{ date: "2026-09-10", value: 270 }] },
+    { id: "index", label: "Indexed value", unit: "index", points: [{ date: "2026-09-10", value: 102.5 }] },
+    { id: "missing", label: "Unknown unit", points: [{ date: "2026-09-10", value: 0 }] },
+    { id: "empty", label: "Missing value", unit: "%", points: [] },
+  ] };
+  const text = renderHeadlessPaneText(definition, result, args, "Research");
+  expect(text).toContain("UNIT");
+  expect(text.split("\n").find(line => line.includes("Credit percent"))).toMatch(/2\.7\s+%/);
+  expect(text.split("\n").find(line => line.includes("Credit basis points"))).toMatch(/270\s+bp/);
+  expect(text.split("\n").find(line => line.includes("Indexed value"))).toMatch(/102\.5\s+index/);
+  expect(text.split("\n").find(line => line.includes("Unknown unit"))).toMatch(/0\s+-/);
+  expect(text.split("\n").find(line => line.includes("Missing value"))).toMatch(/-\s+%/);
+  expect(jsonData(definition, result)).toMatchObject({ data: { series: result.series } });
+  const csv = serializeCliResult({ data: serializeHeadlessPaneResult(definition, result) }, { ...DEFAULT_CLI_OPTIONS, format: "csv" });
+  expect(csv).toContain('""unit"":""%"",""points"":[{""date"":""2026-09-10"",""value"":2.7}]');
+  expect(csv).toContain('""unit"":""bp"",""points"":[{""date"":""2026-09-10"",""value"":270}]');
+  expect(renderHeadlessPaneText(definition, { series: [result.series[3]!] }, args, "Unknown")).not.toContain("UNIT");
+});

--- a/src/cli/pane-functions/headless.ts
+++ b/src/cli/pane-functions/headless.ts
@@ -325,6 +325,7 @@ function renderSeries(result: HeadlessSeriesResult): string[] {
       series: series.label,
       latest: latest ? displayValue(latest.date) : "-",
       value: latest?.value ?? latest?.close ?? null,
+      unit: series.unit?.trim() || null,
       points: series.points.length,
     };
   });
@@ -332,6 +333,7 @@ function renderSeries(result: HeadlessSeriesResult): string[] {
     { key: "series", header: "Series" },
     { key: "latest", header: "Latest" },
     { key: "value", header: "Value", align: "right" },
+    ...(rows.some((row) => row.unit) ? [{ key: "unit", header: "Unit" }] : []),
     { key: "points", header: "Points", align: "right" },
   ];
   const lines = [renderRows(rows, columns, undefined)];

--- a/src/plugins/builtin/dividend-yield/headless.test.ts
+++ b/src/plugins/builtin/dividend-yield/headless.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 import type { HeadlessPaneContext, HeadlessPaneLoadArgs } from "../../../types/plugin";
 import type { DividendData } from "./client";
 import { createDividendYieldHeadless } from "./headless";
+import { renderHeadlessPaneText, serializeHeadlessPaneResult } from "../../../cli/pane-functions/headless";
+import { serializeCliResult } from "../../../cli/result";
+import { DEFAULT_CLI_OPTIONS } from "../../../cli/options";
 
 const fixture: DividendData = {
   price: 200,
@@ -85,4 +88,35 @@ describe("dividend yield headless", () => {
     });
     expect(result.metadata).toMatchObject({ totalPayments: 1, returnedPayments: 1 });
   });
+});
+
+
+test("cash growth and payout text use percentages while JSON and CSV keep fractional values", async () => {
+  for (const [growth, formatted] of [[-0.152317880794702, "-15.23%"], [0.11248149975332988, "+11.25%"], [0, "0.00%"], [null, "—"]] as const) {
+    const data = { ...fixture, metrics: { ...fixture.metrics, payoutRatio: growth, growth1Y: growth, growth3Y: growth } };
+    const definition = createDividendYieldHeadless({ loadData: async () => data });
+    const request = args({ type: "all", limit: 40 });
+    const result = await definition.load(request, context);
+    const text = renderHeadlessPaneText(definition, result, request, "DVD");
+    const section = result.sections[0]!;
+    const entries = "entries" in section ? section.entries : [];
+    expect(entries.filter((entry) => entry.label === "1Y Cash Growth" || entry.label === "3Y Cash CAGR")).toEqual([
+      { label: "1Y Cash Growth", value: growth, formatted },
+      { label: "3Y Cash CAGR", value: growth, formatted },
+    ]);
+    expect(text).toContain("1Y Cash Growth");
+    expect(text).toContain("3Y Cash CAGR");
+    expect(text).toContain(formatted);
+    // Controlled provider ratio contract; these finite values are not asserted to be live ETF payouts.
+    expect(entries.find((entry) => entry.label === "Earnings Payout")).toEqual({ label: "Earnings Payout", value: growth, formatted: formatted.replace(/^\+/, "") });
+    const serialized = serializeHeadlessPaneResult(definition, result);
+    const json = JSON.parse(serializeCliResult({ data: serialized }, { ...DEFAULT_CLI_OPTIONS, format: "json" }));
+    const raw = json.data.sections[0].entries.filter((entry: { label: string }) => ["Earnings Payout", "1Y Cash Growth", "3Y Cash CAGR"].includes(entry.label));
+    expect(raw.map((entry: { value: unknown }) => entry.value)).toEqual([growth, growth, growth]);
+    // fn CSV retains nested sections as JSON cells; display strings cannot replace numeric values.
+    const csv = serializeCliResult({ data: serialized }, { ...DEFAULT_CLI_OPTIONS, format: "csv" });
+    expect(csv).toContain(`""label"":""1Y Cash Growth"",""value"":${JSON.stringify(growth)},""formatted"":""${formatted}""`);
+    expect(csv).toContain(`""label"":""Earnings Payout"",""value"":${JSON.stringify(growth)}`);
+    expect(data.metrics.growth1Y).toBe(growth);
+  }
 });

--- a/src/plugins/builtin/dividend-yield/headless.ts
+++ b/src/plugins/builtin/dividend-yield/headless.ts
@@ -7,7 +7,7 @@ import type {
 import { dividendReferencePrice, fetchDividendData, type DividendData } from "./client";
 import type { DividendPayment } from "./types";
 import { formatDividendYield, toDividendRows } from "./view";
-import { formatDistributionAmount } from "../../../utils/format";
+import { formatDistributionAmount, formatPercent } from "../../../utils/format";
 import type { Quote } from "../../../types/financials";
 import { dividendPriceStatus, dividendQuotePriceMetadata } from "./reference-price";
 
@@ -85,9 +85,9 @@ export function projectDividendYieldHeadless(
           { label: "Forward yield", value: metrics.forwardYield, formatted: formatDividendYield(metrics.forwardYield) },
           { label: "Trailing rate", value: metrics.trailingRate, formatted: formatDistributionAmount(metrics.trailingRate ?? undefined, currency) },
           { label: "Forward rate", value: metrics.forwardRate, formatted: formatDistributionAmount(metrics.forwardRate ?? undefined, currency) },
-          { label: "Payout ratio", value: metrics.payoutRatio },
-          { label: "1Y growth", value: metrics.growth1Y },
-          { label: "3Y growth", value: metrics.growth3Y },
+          { label: "Earnings Payout", value: metrics.payoutRatio, formatted: formatDividendYield(metrics.payoutRatio) },
+          { label: "1Y Cash Growth", value: metrics.growth1Y, formatted: formatPercent(metrics.growth1Y ?? undefined) },
+          { label: "3Y Cash CAGR", value: metrics.growth3Y, formatted: formatPercent(metrics.growth3Y ?? undefined) },
           { label: "Frequency", value: metrics.paymentFrequency },
           { label: "Ex-dividend", value: metrics.exDividendDate },
           { label: "Next pay", value: metrics.nextPayDate },

--- a/src/types/headless.ts
+++ b/src/types/headless.ts
@@ -138,6 +138,8 @@ export interface HeadlessSeriesPoint extends HeadlessPaneRow {
 export interface HeadlessSeries {
   id: string;
   label: string;
+  /** Explicit unit of the point values; report formatting does not rescale them. */
+  unit?: string;
   points: HeadlessSeriesPoint[];
 }
 


### PR DESCRIPTION
Dividend research text reports printed fractional growth values such as -0.152317880794702 without percentage formatting, and generic economic-series reports omitted known units. Use the existing percentage formatters for cash growth, three-year cash CAGR and earnings payout, and show an explicit unit in the series table when the source supplies one.

Raw numeric values in JSON/CSV, source prices and observation times remain unchanged; formatted strings stay separate. Unknown units remain unknown. The existing usage guide explains structured export fields. No pane controls, layout or standing explanations change.

Validation: 3,321 tests / 14,923 assertions across 543 files, all six TypeScript targets and both generated-file checks pass on the integrated branch. Fifteen recorded/controlled pane cases at 48/80/120 columns pass 66 assertions. Final replay matches all native dividend values and source times plus parsed JSON/CSV sections; only retrieval clocks differ between runs. Captured credit-series points and units are unchanged. Finite payout coverage uses the existing fractional provider contract as a controlled case; the captured ETFs have no payout value.
