### PR TITLE
Bundle Prediction Markets into the web build

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "gloom-market-halts": "github:gloom-sh/gloom-market-halts",
         "gloom-market-heatmap": "github:gloom-sh/gloom-market-heatmap",
         "gloom-polls": "github:gloom-sh/gloom-polls",
+        "gloom-prediction-markets": "gloom-sh/gloom-prediction-markets",
         "happy-dom": "^20.11.1",
         "png-to-ico": "^2.1.8",
         "rcedit": "^4.0.1",
@@ -567,6 +568,8 @@
     "gloom-market-heatmap": ["gloom-market-heatmap@github:gloom-sh/gloom-market-heatmap#5bf76b2", { "peerDependencies": { "gloomberb": ">=0.15.0", "react": ">=19" }, "optionalPeers": ["gloomberb", "react"] }, "gloom-sh-gloom-market-heatmap-5bf76b2", "sha512-4Yu/NnSdYzeqlnEKYsygtEvR+npV/IMsCOPyixStX1kcc6AJOe/VssSOFV4dioFq6Rl00gBpIOMos6H8ErDwkw=="],
 
     "gloom-polls": ["gloom-polls@github:gloom-sh/gloom-polls#ce3a6fe", { "peerDependencies": { "gloomberb": ">=0.15.0", "react": ">=19" }, "optionalPeers": ["gloomberb", "react"] }, "gloom-sh-gloom-polls-ce3a6fe", "sha512-ITmADYrDpes2kanwExIUemhIG5EpVKfhqmBw516vwIQGr8escWlQxTMKtIsDGAIcXYSC8M/6c1o8lt/nZpOIqw=="],
+
+    "gloom-prediction-markets": ["gloom-prediction-markets@github:gloom-sh/gloom-prediction-markets#1618365", { "peerDependencies": { "gloomberb": ">=0.15.0", "react": ">=19" }, "optionalPeers": ["gloomberb", "react"] }, "gloom-sh-gloom-prediction-markets-1618365", "sha512-T10OgiqV24worSyvP2/gmN2NVeXC7C1iA8lUbcYYtUnDV4MvhcOsSb7Yw9a2CYMo+qFLNvggTN74WLdfLOU9dA=="],
 
     "google-auth-library": ["google-auth-library@10.9.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg=="],
 

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -14,7 +14,7 @@ Open [term.gloom.sh](https://term.gloom.sh) and sign in with a free Gloom Cloud 
 
 ## Plugins
 
-Every web-capable plugin is compiled into the build, so Fear & Greed, the IPO calendar, Market Halts, Market Heatmap, and Polls are there on first load with nothing to install. Disable any of them from the plugin directory as you would a built-in.
+Every web-capable plugin is compiled into the build, so Fear & Greed, the IPO calendar, Market Halts, Market Heatmap, Polls, and Prediction Markets are there on first load with nothing to install. Disable any of them from the plugin directory as you would a built-in.
 
 The browser app does not install plugins. Code you pick would run on the origin holding your session, and a plugin is a React component sharing the app's own modules, so there is nothing to sandbox it with. Installing belongs to the desktop app and the terminal, which run on your machine. The plugin directory still lists everything and says where each plugin runs.
 
@@ -22,6 +22,6 @@ The browser app does not install plugins. Code you pick would run on the origin 
 
 The browser build omits brokers and native integrations, filesystem notes, local AI, plugin installation, updater/debug tools, application menus, native window controls, pop-out native windows, and native context menus.
 
-Modules whose feeds the build has no path to are also unavailable: RSS/Substack, prediction markets, market movers, dividend/ownership/SEC panes, earnings, and TV.
+Modules whose feeds the build has no path to are also unavailable: RSS/Substack, market movers, dividend/ownership/SEC panes, earnings, and TV.
 
 For local development, validation, and deployment details, see [Contributing](../CONTRIBUTING.md#browser-development).

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "gloom-market-halts": "github:gloom-sh/gloom-market-halts",
     "gloom-market-heatmap": "github:gloom-sh/gloom-market-heatmap",
     "gloom-polls": "github:gloom-sh/gloom-polls",
+    "gloom-prediction-markets": "gloom-sh/gloom-prediction-markets",
     "happy-dom": "^20.11.1",
     "png-to-ico": "^2.1.8",
     "rcedit": "^4.0.1",

--- a/scripts/audit-web-bundle.ts
+++ b/scripts/audit-web-bundle.ts
@@ -1,6 +1,7 @@
 import { readdir, readFile, stat } from "fs/promises";
 import { join, relative } from "path";
 import { WEB_BUNDLED_PLUGIN_PACKAGES } from "../src/plugins/web-bundled";
+import { isProxiedHost } from "../src/utils/plugin-proxy-hosts";
 
 const root = join(process.cwd(), "dist", "web");
 
@@ -21,11 +22,21 @@ const NATIVE_OR_FORK = /kohor\.st|__GLOOM_CLOUD_HOSTED|\/_gloomberb\/rpc|receive
  *
  * A host that sends no CORS headers can still ship here: that is how every
  * bundled plugin reaches its data, by declaring the host and letting the worker
- * proxy it (`src/utils/plugin-proxy-hosts.json`). The hosts below belong to
- * panes deliberately left out of the browser catalog, so finding one means a
- * pane got in that cannot fetch anything once it renders.
+ * proxy it. So the list below is filtered by the committed allowlist rather
+ * than checked as written: a host a bundled plugin declares is reachable by
+ * definition, and leaving it here would fail the build the day that plugin
+ * ships. What remains belongs to panes deliberately left out of the browser
+ * catalog, where finding one means a pane got in that cannot fetch anything
+ * once it renders.
  */
-const UNSUPPORTED_PROVIDER = /api\.thebuildout\.ai|api\.elections\.kalshi\.com|forms13f\.com/;
+const UNSUPPORTED_PROVIDER_HOSTS = [
+  "api.thebuildout.ai",
+  "api.elections.kalshi.com",
+  "forms13f.com",
+].filter((host) => !isProxiedHost(host));
+const UNSUPPORTED_PROVIDER = UNSUPPORTED_PROVIDER_HOSTS.length > 0
+  ? new RegExp(UNSUPPORTED_PROVIDER_HOSTS.map((host) => host.replaceAll(".", "\\.")).join("|"))
+  : null;
 
 const failures: string[] = [];
 for (const path of outputFiles) {
@@ -35,7 +46,7 @@ for (const path of outputFiles) {
   const content = await readFile(path, "utf8");
   if (/sourceMappingURL=/.test(content)) failures.push(`${name}: source map reference`);
   if (NATIVE_OR_FORK.test(content)) failures.push(`${name}: forbidden native or fork code`);
-  if (UNSUPPORTED_PROVIDER.test(content)) failures.push(`${name}: unsupported provider code`);
+  if (UNSUPPORTED_PROVIDER?.test(content)) failures.push(`${name}: unsupported provider code`);
   if (name.endsWith(".html")) {
     if (/<script(?![^>]*\bsrc=)[^>]*>/i.test(content)) failures.push(`${name}: inline script`);
     if (/<style\b/i.test(content)) failures.push(`${name}: inline style block`);

--- a/src/plugins/web-bundled.ts
+++ b/src/plugins/web-bundled.ts
@@ -23,6 +23,7 @@ export const WEB_BUNDLED_PLUGIN_PACKAGES = [
   "gloom-market-halts",
   "gloom-market-heatmap",
   "gloom-polls",
+  "gloom-prediction-markets",
 ] as const;
 
 /**

--- a/src/utils/plugin-proxy-hosts.json
+++ b/src/utils/plugin-proxy-hosts.json
@@ -1,8 +1,12 @@
 {
   "hosts": [
+    "api.elections.kalshi.com",
     "api.nasdaq.com",
     "api.votehub.com",
+    "clob.polymarket.com",
+    "data-api.polymarket.com",
     "fc.yahoo.com",
+    "gamma-api.polymarket.com",
     "nasdaqtrader.com",
     "production.dataviz.cnn.io",
     "query1.finance.yahoo.com",


### PR DESCRIPTION
#842 compiled the five market plugins into the hosted app. Prediction Markets was extracted the same day (#841) and missed the list, so on term.gloom.sh it was a marketplace entry labelled "desktop and terminal" rather than a pane.

It already declares `"web"` in its targets and the four venue hosts it fetches, so bundling it is the devDependency, the package name, and a regenerated allowlist. The Polymarket and Kalshi hosts arrive from the plugin's own declaration:

```
api.elections.kalshi.com   <- prediction-markets
clob.polymarket.com        <- prediction-markets
data-api.polymarket.com    <- prediction-markets
gamma-api.polymarket.com   <- prediction-markets
```

## The audit guard

The bundle audit refused the build. `api.elections.kalshi.com` sat in its unsupported-provider list from when no pane on the web could reach it — a list whose own comment says a bundled plugin can ship a CORS-less host by declaring it and letting the worker proxy it. The two had to disagree eventually.

That list is now filtered by the committed allowlist rather than checked as written, so a host a bundled plugin declares is reachable by definition and what remains still catches a pane sneaking in with a feed nobody proxies. Leaving it literal meant the next plugin to ship one of those hosts would fail the build for doing exactly what the proxy exists to allow.

## Websocket

Polymarket's book and trade socket cannot go through an HTTP proxy, so it connects directly. It accepts a `term.gloom.sh` origin (checked against the live endpoint), so live updates work on the web with no further plumbing.

## Testing

- `bun run typecheck`, `bun test` (3319 pass), `bun run web:audit`, `bun run cloudflare:dry-run`, proxy-allowlist and manifest checks.
- Web build emits `assets/plugins/gloom-prediction-markets/index.js` and the app bundle references it ("Bundled 6 plugins").
- Compiled the plugin with the host bundler out of `node_modules` and loaded it: no `node:` specifiers, every `gloomberb/*` it touches resolves through the host registry, and its CLI launch writes a pane instance into a config built by the host's own copy of `types/config`.
- Both halves of the allowlist agree: the browser transport routes the four venue hosts to `/http-proxy` and sends unlisted hosts direct; the worker accepts those four and refuses `http://` and unlisted hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)