### PR TITLE
Watermark chart screenshots with the Gloomberb wordmark

### DIFF
--- a/src/cli/desktop-pane-shot.ts
+++ b/src/cli/desktop-pane-shot.ts
@@ -190,6 +190,8 @@ async function buildShotPage(outdir: string, payload: DesktopPaneShotPayload): P
         const style = document.createElement("style");
         style.textContent = ${JSON.stringify(SHOT_MODE_CSS)};
         document.head.appendChild(style);
+        // Same brand mark charts show for in-app pane captures and OS screenshots.
+        document.documentElement.setAttribute("data-gloom-screenshot", "true");
         const watermark = ${JSON.stringify(payload.watermark ?? null)};
         if (watermark) {
           const mark = document.createElement("div");

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -463,6 +463,24 @@ const ARMED_TOOL_BY_INTERACTION = {
 
 const COMPOSITE_PANEL_ROLE = "composite-chart-panel";
 
+// Wordmark cell grid at scale 1 (27 columns of 8px, 4 rows of 12px).
+const WATERMARK_BASE_WIDTH_PX = 216;
+const WATERMARK_BASE_HEIGHT_PX = 48;
+
+/**
+ * Size the screenshot wordmark to roughly half the plot width, capped so it
+ * stays a mark rather than a poster. Plots too small for a legible mark get
+ * none: a clipped wordmark reads as a glitch.
+ */
+export function chartWatermarkScale(plotWidthPx: number, plotHeightPx: number): number | null {
+  const scale = Math.min(
+    (plotWidthPx * 0.5) / WATERMARK_BASE_WIDTH_PX,
+    (plotHeightPx * 0.4) / WATERMARK_BASE_HEIGHT_PX,
+    3,
+  );
+  return scale >= 1 ? Math.round(scale * 4) / 4 : null;
+}
+
 let nextDrawingSequence = 1;
 
 function nextDrawingId(): string {
@@ -1668,7 +1686,7 @@ export function CompositeChart({
   isSeriesToggleable,
 }: CompositeChartProps) {
   const activeThemeColors = useThemeColors();
-  const { cellWidthPx = 8, pixelRatio = 1 } = useUiCapabilities();
+  const { cellWidthPx = 8, cellHeightPx = 18, pixelRatio = 1 } = useUiCapabilities();
   const isDesktopWeb = useUiHost().kind === "desktop-web";
   const showTextFallback = useShowChartTextFallback();
   const [internalCursorDate, setInternalCursorDate] = useState<Date | null>(null);
@@ -1932,6 +1950,9 @@ export function CompositeChart({
   const horizontalReserved = leftAxisWidth + rightAxisWidth
     + axisGap * ((leftAxisWidth ? 1 : 0) + (rightAxisWidth ? 1 : 0));
   const plotWidth = Math.max(1, totalWidth - horizontalReserved);
+  const watermarkScale = isDesktopWeb
+    ? chartWatermarkScale(plotWidth * cellWidthPx, plotHeight * cellHeightPx)
+    : null;
   const downsampleWidth = Math.max(
     1,
     Math.round(plotWidth * cellWidthPx * Math.max(1, pixelRatio)),
@@ -2294,7 +2315,7 @@ export function CompositeChart({
           showTextFallback={showTextFallback}
         />
       ))}
-      {isDesktopWeb ? (
+      {watermarkScale ? (
         // Hidden until a screenshot reveals it (see utils/screenshot-watermark).
         // Above the opaque bitmaps, below drawings, crosshair and readouts.
         <Box
@@ -2308,7 +2329,7 @@ export function CompositeChart({
           justifyContent="center"
           data-gloom-role={CHART_WATERMARK_ROLE}
         >
-          <AsciiText text="Gloomberb" font="wordmark" color={resolvedColors.textDim} />
+          <AsciiText text="Gloomberb" font="wordmark" scale={watermarkScale} color={resolvedColors.textDim} />
         </Box>
       ) : null}
       {xMarkers.length > 0 ? (

--- a/src/components/chart/composite/composite-chart.tsx
+++ b/src/components/chart/composite/composite-chart.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  AsciiText,
   Box,
   ChartSurface,
   ScrollBox,
@@ -17,6 +18,7 @@ import { colors as themeColors, hoverBg } from "../../../theme/colors";
 import { useThemeColors } from "../../../theme/theme-context";
 import { displayWidth, formatPercentRaw, truncateToDisplayWidth } from "../../../utils/format";
 import { isPlainKey } from "../../../utils/keyboard";
+import { CHART_WATERMARK_ROLE } from "../../../utils/screenshot-watermark";
 import type { ResolvedSeries } from "../../../time-series/types";
 import { downsampleCompositeChartScene } from "./downsample";
 import { reuseResolvedSeriesList } from "./panel-series";
@@ -2292,6 +2294,23 @@ export function CompositeChart({
           showTextFallback={showTextFallback}
         />
       ))}
+      {isDesktopWeb ? (
+        // Hidden until a screenshot reveals it (see utils/screenshot-watermark).
+        // Above the opaque bitmaps, below drawings, crosshair and readouts.
+        <Box
+          position="absolute"
+          left={leftPadding}
+          top={legendRows}
+          width={plotWidth}
+          height={plotHeight}
+          zIndex={5}
+          alignItems="center"
+          justifyContent="center"
+          data-gloom-role={CHART_WATERMARK_ROLE}
+        >
+          <AsciiText text="Gloomberb" font="wordmark" color={resolvedColors.textDim} />
+        </Box>
+      ) : null}
       {xMarkers.length > 0 ? (
         <Box
           position="absolute"

--- a/src/renderers/electrobun/view/dom-ui-host.tsx
+++ b/src/renderers/electrobun/view/dom-ui-host.tsx
@@ -68,8 +68,10 @@ export function createDomUiHost(
       publicSharing: options.publicSharing ?? false,
       precisePointer: true,
       fractionalViewport: true,
-      cellWidthPx: WEB_CELL_WIDTH,
-      cellHeightPx: WEB_CELL_HEIGHT,
+      // Live: the grid resizes with the configured font size (theme/font-scale),
+      // and pixel measurements derived from cells must follow it.
+      get cellWidthPx() { return WEB_CELL_WIDTH; },
+      get cellHeightPx() { return WEB_CELL_HEIGHT; },
       pixelRatio: Math.min(window.devicePixelRatio || 1, 2),
       canvasCharts: true,
       nativeContextMenu: options.nativeContextMenu ?? false,

--- a/src/renderers/electrobun/view/host/block-glyph-canvas.tsx
+++ b/src/renderers/electrobun/view/host/block-glyph-canvas.tsx
@@ -1,0 +1,98 @@
+/** @jsxImportSource react */
+import { memo, useEffect, useRef, type CSSProperties } from "react";
+
+/**
+ * Quadrant coverage for the 2x2 block glyphs the ascii fonts are built from,
+ * as [top-left, top-right, bottom-left, bottom-right]. Fonts on Windows and
+ * Linux either lack these glyphs or fall back to a face with other metrics,
+ * so drawing the cells directly is the only way the wordmark looks the same
+ * everywhere.
+ */
+const QUADRANTS: Record<string, readonly [boolean, boolean, boolean, boolean]> = {
+  " ": [false, false, false, false],
+  "▘": [true, false, false, false],
+  "▝": [false, true, false, false],
+  "▖": [false, false, true, false],
+  "▗": [false, false, false, true],
+  "▀": [true, true, false, false],
+  "▄": [false, false, true, true],
+  "▌": [true, false, true, false],
+  "▐": [false, true, false, true],
+  "▞": [false, true, true, false],
+  "▚": [true, false, false, true],
+  "▛": [true, true, true, false],
+  "▜": [true, true, false, true],
+  "▙": [true, false, true, true],
+  "▟": [false, true, true, true],
+  "█": [true, true, true, true],
+};
+
+export function blockGlyphPath(
+  lines: readonly string[],
+  cellWidth: number,
+  cellHeight: number,
+): Path2D {
+  const path = new Path2D();
+  const halfWidth = cellWidth / 2;
+  const halfHeight = cellHeight / 2;
+  lines.forEach((line, row) => {
+    let column = 0;
+    for (const character of line) {
+      const quadrants = QUADRANTS[character];
+      if (quadrants) {
+        const x = column * cellWidth;
+        const y = row * cellHeight;
+        if (quadrants[0]) path.rect(x, y, halfWidth, halfHeight);
+        if (quadrants[1]) path.rect(x + halfWidth, y, halfWidth, halfHeight);
+        if (quadrants[2]) path.rect(x, y + halfHeight, halfWidth, halfHeight);
+        if (quadrants[3]) path.rect(x + halfWidth, y + halfHeight, halfWidth, halfHeight);
+      }
+      column += 1;
+    }
+  });
+  return path;
+}
+
+export const BlockGlyphCanvas = memo(function BlockGlyphCanvas({
+  lines,
+  color,
+  cellWidth,
+  cellHeight,
+  style,
+}: {
+  lines: readonly string[];
+  color?: string;
+  cellWidth: number;
+  cellHeight: number;
+  style?: CSSProperties;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const columns = Math.max(0, ...lines.map((line) => [...line].length));
+  const width = columns * cellWidth;
+  const height = lines.length * cellHeight;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+    const scale = Math.max(1, Math.min(globalThis.devicePixelRatio || 1, 3));
+    canvas.width = Math.ceil(width * scale);
+    canvas.height = Math.ceil(height * scale);
+    context.setTransform(scale, 0, 0, scale, 0, 0);
+    context.clearRect(0, 0, width, height);
+    // The computed color resolves theme variables the canvas cannot parse.
+    context.fillStyle = getComputedStyle(canvas).color;
+    // One path for every cell: a union has no anti-aliased seams between
+    // neighbouring quadrants, separate fills would.
+    context.fill(blockGlyphPath(lines, cellWidth, cellHeight));
+  }, [cellHeight, cellWidth, color, height, lines, width]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      style={{ display: "block", width, height, color, ...style }}
+    />
+  );
+});

--- a/src/renderers/electrobun/view/host/block-glyph-canvas.tsx
+++ b/src/renderers/electrobun/view/host/block-glyph-canvas.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { memo, useEffect, useRef, type CSSProperties } from "react";
+import { memo, useEffect, useRef, useState, type CSSProperties } from "react";
 
 /**
  * Quadrant coverage for the 2x2 block glyphs the ascii fonts are built from,
@@ -53,6 +53,22 @@ export function blockGlyphPath(
   return path;
 }
 
+/**
+ * Page zoom and moving between displays change the ratio after mount; without
+ * following it the canvas keeps its old backing size and goes blurry.
+ */
+function useDevicePixelRatio(): number {
+  const [ratio, setRatio] = useState(() => globalThis.devicePixelRatio || 1);
+  useEffect(() => {
+    if (typeof matchMedia !== "function") return;
+    const query = matchMedia(`(resolution: ${ratio}dppx)`);
+    const update = () => setRatio(globalThis.devicePixelRatio || 1);
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, [ratio]);
+  return ratio;
+}
+
 export const BlockGlyphCanvas = memo(function BlockGlyphCanvas({
   lines,
   color,
@@ -67,6 +83,7 @@ export const BlockGlyphCanvas = memo(function BlockGlyphCanvas({
   style?: CSSProperties;
 }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const pixelRatio = useDevicePixelRatio();
   const columns = Math.max(0, ...lines.map((line) => [...line].length));
   const width = columns * cellWidth;
   const height = lines.length * cellHeight;
@@ -76,7 +93,7 @@ export const BlockGlyphCanvas = memo(function BlockGlyphCanvas({
     if (!canvas) return;
     const context = canvas.getContext("2d");
     if (!context) return;
-    const scale = Math.max(1, Math.min(globalThis.devicePixelRatio || 1, 3));
+    const scale = Math.max(1, Math.min(pixelRatio, 3));
     canvas.width = Math.ceil(width * scale);
     canvas.height = Math.ceil(height * scale);
     context.setTransform(scale, 0, 0, scale, 0, 0);
@@ -86,7 +103,7 @@ export const BlockGlyphCanvas = memo(function BlockGlyphCanvas({
     // One path for every cell: a union has no anti-aliased seams between
     // neighbouring quadrants, separate fills would.
     context.fill(blockGlyphPath(lines, cellWidth, cellHeight));
-  }, [cellHeight, cellWidth, color, height, lines, width]);
+  }, [cellHeight, cellWidth, color, height, lines, pixelRatio, width]);
 
   return (
     <canvas

--- a/src/renderers/electrobun/view/host/text.tsx
+++ b/src/renderers/electrobun/view/host/text.tsx
@@ -7,7 +7,9 @@ import {
   type TextProps,
 } from "../../../../ui/host";
 import { WEB_CELL_WIDTH } from "../input-host";
+import { renderAsciiText } from "../../../../ui/ascii-font";
 import { webAsciiTextLines, webAsciiTextWordmarkVariant } from "./ascii-text";
+import { BlockGlyphCanvas } from "./block-glyph-canvas";
 import { mouseHandlers } from "./mouse";
 import { cleanDomProps, commonStyle, textStyle } from "./style";
 
@@ -15,6 +17,10 @@ import { cleanDomProps, commonStyle, textStyle } from "./style";
 function wordmarkCharWidthPx(): number {
   return Math.max(10, WEB_CELL_WIDTH);
 }
+
+// Matches the legacy wordmark text rendering: one cell per glyph, 12px rows.
+const BLOCK_GLYPH_CELL_WIDTH = 8;
+const BLOCK_GLYPH_CELL_HEIGHT = 12;
 
 interface WebAsciiTextProps extends AsciiTextProps {
   desktopPlatform?: string;
@@ -98,8 +104,30 @@ export function WebAsciiText({
   backgroundColor,
   selectable = false,
   desktopPlatform,
+  scale,
   ...props
 }: WebAsciiTextProps) {
+  if (scale != null) {
+    return (
+      <div
+        {...cleanDomProps(props)}
+        data-gloom-role={(props["data-gloom-role"] as string | undefined) ?? "ascii-text"}
+        style={{
+          ...commonStyle({ ...props, bg: bg ?? backgroundColor }),
+          flexShrink: 0,
+          backgroundColor: bg ?? backgroundColor,
+          ...(props.style as CSSProperties | undefined),
+        }}
+      >
+        <BlockGlyphCanvas
+          lines={renderAsciiText(text, font)}
+          color={color ?? fg}
+          cellWidth={BLOCK_GLYPH_CELL_WIDTH * scale}
+          cellHeight={BLOCK_GLYPH_CELL_HEIGHT * scale}
+        />
+      </div>
+    );
+  }
   const wordmarkVariant = webAsciiTextWordmarkVariant(text, font, desktopPlatform);
   const isCompatWordmark = wordmarkVariant === "compat";
   const isLegacyWordmark = wordmarkVariant === "legacy";
@@ -114,7 +142,6 @@ export function WebAsciiText({
     <div
       {...cleanDomProps(props)}
       data-gloom-role={(props["data-gloom-role"] as string | undefined) ?? "ascii-text"}
-      data-gloom-wordmark={wordmarkVariant ?? undefined}
       style={{
         ...commonStyle({ ...props, fg: resolvedColor, bg: resolvedBackground }),
         display: isLegacyWordmark ? "flex" : "block",

--- a/src/renderers/electrobun/view/host/text.tsx
+++ b/src/renderers/electrobun/view/host/text.tsx
@@ -114,6 +114,7 @@ export function WebAsciiText({
     <div
       {...cleanDomProps(props)}
       data-gloom-role={(props["data-gloom-role"] as string | undefined) ?? "ascii-text"}
+      data-gloom-wordmark={wordmarkVariant ?? undefined}
       style={{
         ...commonStyle({ ...props, fg: resolvedColor, bg: resolvedBackground }),
         display: isLegacyWordmark ? "flex" : "block",

--- a/src/renderers/electrobun/view/main.tsx
+++ b/src/renderers/electrobun/view/main.tsx
@@ -21,6 +21,7 @@ import {
   installElectrobunHttpFetchTransport,
 } from "./http-fetch";
 import { installElectrobunUpdateHost } from "./update-host";
+import { installScreenshotWatermark } from "./screenshot-watermark";
 import { installElectrobunWindowFullscreenTracking } from "./window-fullscreen";
 import { DesktopFatalScreen, ElectrobunErrorBoundary } from "./fatal-screen";
 import { WebInputHostProvider } from "./input-host";
@@ -104,6 +105,7 @@ async function boot() {
   installElectrobunAiHost();
   installFocusScopeRelease();
   installElectrobunWindowFullscreenTracking();
+  installScreenshotWatermark();
   const desktopSnapshot = init.windowKind === "detached" && init.paneId && init.desktopSnapshot
     ? prepareDetachedSnapshot(init.desktopSnapshot, init.paneId)
     : init.desktopSnapshot;

--- a/src/renderers/electrobun/view/screenshot-watermark.test.ts
+++ b/src/renderers/electrobun/view/screenshot-watermark.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+import { screenshotKeySignal } from "./screenshot-watermark";
+
+test("the modifier prefix of an OS screenshot chord reveals the watermark", () => {
+  // Cmd+Shift+4: the page sees Meta, then Shift, and never the digit.
+  expect(screenshotKeySignal({ key: "Meta", metaKey: true, shiftKey: false })).toBe("keep");
+  expect(screenshotKeySignal({ key: "Shift", metaKey: true, shiftKey: true })).toBe("show");
+  // Win+Shift+S arrives in the other order.
+  expect(screenshotKeySignal({ key: "Meta", metaKey: true, shiftKey: true })).toBe("show");
+  expect(screenshotKeySignal({ key: "PrintScreen", metaKey: false, shiftKey: false })).toBe("show");
+});
+
+test("a complete chord that reaches the page is an app shortcut, not a screenshot", () => {
+  expect(screenshotKeySignal({ key: "c", metaKey: true, shiftKey: true })).toBe("hide");
+  expect(screenshotKeySignal({ key: "Escape", metaKey: false, shiftKey: false })).toBe("hide");
+  expect(screenshotKeySignal({ key: "Shift", metaKey: false, shiftKey: true })).toBe("keep");
+  expect(screenshotKeySignal({ key: "Control", metaKey: false, shiftKey: true })).toBe("keep");
+});

--- a/src/renderers/electrobun/view/screenshot-watermark.test.ts
+++ b/src/renderers/electrobun/view/screenshot-watermark.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "bun:test";
-import { screenshotKeySignal } from "./screenshot-watermark";
+import { createDomTestHarness } from "./test-utils";
+import { installScreenshotWatermark, screenshotKeySignal } from "./screenshot-watermark";
+import { SCREENSHOT_WATERMARK_ATTRIBUTE } from "../../../utils/screenshot-watermark";
+
+const { window: testWindow } = createDomTestHarness({ withUi: false });
 
 test("the modifier prefix of an OS screenshot chord reveals the watermark", () => {
   // Cmd+Shift+4: the page sees Meta, then Shift, and never the digit.
@@ -15,4 +19,30 @@ test("a complete chord that reaches the page is an app shortcut, not a screensho
   expect(screenshotKeySignal({ key: "Escape", metaKey: false, shiftKey: false })).toBe("hide");
   expect(screenshotKeySignal({ key: "Shift", metaKey: false, shiftKey: true })).toBe("keep");
   expect(screenshotKeySignal({ key: "Control", metaKey: false, shiftKey: true })).toBe("keep");
+});
+
+test("a capture app taking focus holds the watermark until focus returns", async () => {
+  const win = testWindow as unknown as Window;
+  const shown = () => win.document.documentElement.getAttribute(SCREENSHOT_WATERMARK_ATTRIBUTE) === "true";
+  const dispatch = (event: unknown) => win.dispatchEvent(event as Event);
+  const uninstall = installScreenshotWatermark(win);
+  try {
+    dispatch(new testWindow.KeyboardEvent("keydown", { key: "Meta", metaKey: true }));
+    expect(shown()).toBe(false);
+    dispatch(new testWindow.KeyboardEvent("keydown", { key: "Shift", metaKey: true, shiftKey: true }));
+    expect(shown()).toBe(true);
+
+    // Cmd+Shift+5: the Screenshot app owns focus for as long as it likes.
+    dispatch(new testWindow.Event("blur"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(shown()).toBe(true);
+    dispatch(new testWindow.Event("focus"));
+    expect(shown()).toBe(true);
+
+    // Back in the app, any real interaction clears it at once.
+    dispatch(new testWindow.MouseEvent("mousedown"));
+    expect(shown()).toBe(false);
+  } finally {
+    uninstall();
+  }
 });

--- a/src/renderers/electrobun/view/screenshot-watermark.ts
+++ b/src/renderers/electrobun/view/screenshot-watermark.ts
@@ -1,0 +1,77 @@
+/// <reference lib="dom" />
+
+import { setScreenshotWatermarkVisible } from "../../../utils/screenshot-watermark";
+
+/**
+ * How long the watermark stays after the last screenshot signal. Cmd+Shift+4
+ * still needs a region drag and Cmd+Shift+5 shows a toolbar first; both
+ * happen in a system overlay the page never hears about, so time is the only
+ * cue left. A mistaken chord costs a few seconds of faint wordmark, nothing
+ * more.
+ */
+export const SCREENSHOT_WATERMARK_LINGER_MS = 6_000;
+
+export type ScreenshotKeySignal = "show" | "hide" | "keep";
+
+type ScreenshotKeyEventLike = Pick<KeyboardEvent, "key" | "metaKey" | "shiftKey">;
+
+const MODIFIER_KEYS = new Set(["Alt", "AltGraph", "Control", "Fn", "Hyper", "Meta", "OS", "Shift", "Super"]);
+
+/**
+ * Classify a keydown. The OS swallows the final key of its screenshot chords
+ * (Cmd+Shift+3/4/5 on macOS, Win+Shift+S on Windows), so the modifier prefix
+ * is the only part the page ever sees; that prefix reveals the watermark. Any
+ * complete chord that does reach the page is an app shortcut, not a
+ * screenshot, and hides it again. Print Screen is delivered on Windows and on
+ * desktops that do not grab it globally, so it counts as a screenshot outright.
+ */
+export function screenshotKeySignal(event: ScreenshotKeyEventLike): ScreenshotKeySignal {
+  if (event.key === "PrintScreen" || event.key === "Snapshot") return "show";
+  if (MODIFIER_KEYS.has(event.key)) {
+    return event.metaKey && event.shiftKey ? "show" : "keep";
+  }
+  return "hide";
+}
+
+export function installScreenshotWatermark(target: Window = window): () => void {
+  let lingerTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const hide = () => {
+    if (lingerTimer !== null) {
+      clearTimeout(lingerTimer);
+      lingerTimer = null;
+    }
+    setScreenshotWatermarkVisible(false);
+  };
+
+  const show = () => {
+    if (lingerTimer !== null) clearTimeout(lingerTimer);
+    setScreenshotWatermarkVisible(true);
+    lingerTimer = setTimeout(hide, SCREENSHOT_WATERMARK_LINGER_MS);
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    const signal = screenshotKeySignal(event);
+    if (signal === "show") show();
+    else if (signal === "hide") hide();
+  };
+  const onKeyUp = (event: KeyboardEvent) => {
+    // Print Screen on Windows often only surfaces as keyup.
+    if (screenshotKeySignal(event) === "show" && !MODIFIER_KEYS.has(event.key)) show();
+  };
+  // Pointer input means the user is back in the app; system capture overlays
+  // keep their own mouse events.
+  const onPointer = () => hide();
+
+  target.addEventListener("keydown", onKeyDown, true);
+  target.addEventListener("keyup", onKeyUp, true);
+  target.addEventListener("mousedown", onPointer, true);
+  target.addEventListener("wheel", onPointer, { capture: true, passive: true });
+  return () => {
+    hide();
+    target.removeEventListener("keydown", onKeyDown, true);
+    target.removeEventListener("keyup", onKeyUp, true);
+    target.removeEventListener("mousedown", onPointer, true);
+    target.removeEventListener("wheel", onPointer, { capture: true } as EventListenerOptions);
+  };
+}

--- a/src/renderers/electrobun/view/screenshot-watermark.ts
+++ b/src/renderers/electrobun/view/screenshot-watermark.ts
@@ -4,12 +4,18 @@ import { setScreenshotWatermarkVisible } from "../../../utils/screenshot-waterma
 
 /**
  * How long the watermark stays after the last screenshot signal. Cmd+Shift+4
- * still needs a region drag and Cmd+Shift+5 shows a toolbar first; both
- * happen in a system overlay the page never hears about, so time is the only
- * cue left. A mistaken chord costs a few seconds of faint wordmark, nothing
- * more.
+ * still needs a region drag in a system overlay the page never hears about,
+ * so time is the only cue left. A mistaken chord costs a few seconds of faint
+ * wordmark, nothing more.
  */
-export const SCREENSHOT_WATERMARK_LINGER_MS = 6_000;
+export const SCREENSHOT_WATERMARK_LINGER_MS = 10_000;
+
+/**
+ * Grace after the window regains focus. Cmd+Shift+5 and Win+Shift+S hand
+ * focus to a capture app; the shot is taken while we are blurred, and focus
+ * comes back right after, so the mark only has to survive that hand-back.
+ */
+const REFOCUS_GRACE_MS = 1_500;
 
 export type ScreenshotKeySignal = "show" | "hide" | "keep";
 
@@ -34,20 +40,28 @@ export function screenshotKeySignal(event: ScreenshotKeyEventLike): ScreenshotKe
 }
 
 export function installScreenshotWatermark(target: Window = window): () => void {
-  let lingerTimer: ReturnType<typeof setTimeout> | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let visible = false;
+  let blurredWhileVisible = false;
 
+  const clearTimer = () => {
+    if (timer !== null) clearTimeout(timer);
+    timer = null;
+  };
   const hide = () => {
-    if (lingerTimer !== null) {
-      clearTimeout(lingerTimer);
-      lingerTimer = null;
-    }
+    clearTimer();
+    visible = false;
+    blurredWhileVisible = false;
     setScreenshotWatermarkVisible(false);
   };
-
+  const hideAfter = (ms: number) => {
+    clearTimer();
+    timer = setTimeout(hide, ms);
+  };
   const show = () => {
-    if (lingerTimer !== null) clearTimeout(lingerTimer);
+    visible = true;
     setScreenshotWatermarkVisible(true);
-    lingerTimer = setTimeout(hide, SCREENSHOT_WATERMARK_LINGER_MS);
+    hideAfter(SCREENSHOT_WATERMARK_LINGER_MS);
   };
 
   const onKeyDown = (event: KeyboardEvent) => {
@@ -62,16 +76,30 @@ export function installScreenshotWatermark(target: Window = window): () => void 
   // Pointer input means the user is back in the app; system capture overlays
   // keep their own mouse events.
   const onPointer = () => hide();
+  // A capture app stealing focus is the screenshot in progress: hold the mark
+  // for as long as it keeps focus, then let it fade once we are back.
+  const onBlur = () => {
+    if (!visible) return;
+    blurredWhileVisible = true;
+    clearTimer();
+  };
+  const onFocus = () => {
+    if (blurredWhileVisible) hideAfter(REFOCUS_GRACE_MS);
+  };
 
   target.addEventListener("keydown", onKeyDown, true);
   target.addEventListener("keyup", onKeyUp, true);
   target.addEventListener("mousedown", onPointer, true);
   target.addEventListener("wheel", onPointer, { capture: true, passive: true });
+  target.addEventListener("blur", onBlur);
+  target.addEventListener("focus", onFocus);
   return () => {
     hide();
     target.removeEventListener("keydown", onKeyDown, true);
     target.removeEventListener("keyup", onKeyUp, true);
     target.removeEventListener("mousedown", onPointer, true);
     target.removeEventListener("wheel", onPointer, { capture: true } as EventListenerOptions);
+    target.removeEventListener("blur", onBlur);
+    target.removeEventListener("focus", onFocus);
   };
 }

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -587,7 +587,7 @@ body.gloom-dragging [data-gloom-role="chart-surface"] {
 [data-gloom-role="chart-watermark"] {
   visibility: hidden;
   pointer-events: none;
-  opacity: 0.32;
+  opacity: 0.28;
 }
 html[data-gloom-screenshot="true"] [data-gloom-role="chart-watermark"] {
   visibility: visible;

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -582,3 +582,21 @@ body.gloom-dragging [data-gloom-role="chart-surface"] {
     0 14px 34px color-mix(in srgb, var(--gloom-bg) 42%, transparent),
     inset 0 1px 0 color-mix(in srgb, var(--gloom-text-bright) 5%, transparent);
 }
+/* Chart screenshot watermark: mounted by every chart, revealed together by
+   html[data-gloom-screenshot] (pane capture, OS screenshot chords, CLI shots). */
+[data-gloom-role="chart-watermark"] {
+  visibility: hidden;
+  pointer-events: none;
+  opacity: 0.28;
+  container-type: size;
+}
+html[data-gloom-screenshot="true"] [data-gloom-role="chart-watermark"] {
+  visibility: visible;
+}
+/* A clipped wordmark reads as a glitch; small plots stay clean instead. */
+@container (width < 280px) or (height < 96px) {
+  [data-gloom-role="chart-watermark"] > [data-gloom-role="ascii-text"] { display: none; }
+}
+@container (width < 600px) {
+  [data-gloom-role="chart-watermark"] > [data-gloom-role="ascii-text"][data-gloom-wordmark="compat"] { display: none; }
+}

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -587,7 +587,7 @@ body.gloom-dragging [data-gloom-role="chart-surface"] {
 [data-gloom-role="chart-watermark"] {
   visibility: hidden;
   pointer-events: none;
-  opacity: 0.28;
+  opacity: 0.2;
 }
 html[data-gloom-screenshot="true"] [data-gloom-role="chart-watermark"] {
   visibility: visible;

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -587,7 +587,7 @@ body.gloom-dragging [data-gloom-role="chart-surface"] {
 [data-gloom-role="chart-watermark"] {
   visibility: hidden;
   pointer-events: none;
-  opacity: 0.2;
+  opacity: 0.1;
 }
 html[data-gloom-screenshot="true"] [data-gloom-role="chart-watermark"] {
   visibility: visible;

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -587,16 +587,8 @@ body.gloom-dragging [data-gloom-role="chart-surface"] {
 [data-gloom-role="chart-watermark"] {
   visibility: hidden;
   pointer-events: none;
-  opacity: 0.28;
-  container-type: size;
+  opacity: 0.4;
 }
 html[data-gloom-screenshot="true"] [data-gloom-role="chart-watermark"] {
   visibility: visible;
-}
-/* A clipped wordmark reads as a glitch; small plots stay clean instead. */
-@container (width < 280px) or (height < 96px) {
-  [data-gloom-role="chart-watermark"] > [data-gloom-role="ascii-text"] { display: none; }
-}
-@container (width < 600px) {
-  [data-gloom-role="chart-watermark"] > [data-gloom-role="ascii-text"][data-gloom-wordmark="compat"] { display: none; }
 }

--- a/src/renderers/electrobun/view/styles.css
+++ b/src/renderers/electrobun/view/styles.css
@@ -587,7 +587,7 @@ body.gloom-dragging [data-gloom-role="chart-surface"] {
 [data-gloom-role="chart-watermark"] {
   visibility: hidden;
   pointer-events: none;
-  opacity: 0.4;
+  opacity: 0.32;
 }
 html[data-gloom-screenshot="true"] [data-gloom-role="chart-watermark"] {
   visibility: visible;

--- a/src/renderers/opentui/ui-host.tsx
+++ b/src/renderers/opentui/ui-host.tsx
@@ -123,7 +123,7 @@ export const openTuiUiHost: UiHost = {
   ImageSurface: OpenTuiImageSurface,
   MediaSurface: OpenTuiMediaSurface as UiHost["MediaSurface"],
   SpinnerMark: OpenTuiSpinnerMark as UiHost["SpinnerMark"],
-  AsciiText: ({ text, font = "tiny", color, fg, bg, backgroundColor, selectable = false, ...props }) => {
+  AsciiText: ({ text, font = "tiny", color, fg, bg, backgroundColor, selectable = false, scale: _scale, ...props }) => {
     const resolvedColor = color ?? fg;
     const resolvedBackground = backgroundColor ?? bg;
     if (font === "wordmark") {

--- a/src/ui/host.tsx
+++ b/src/ui/host.tsx
@@ -261,6 +261,12 @@ interface SpinnerMarkProps extends BoxProps {
 export interface AsciiTextProps extends BoxProps {
   text: string;
   font?: AsciiFontName;
+  /**
+   * Multiplier on the glyph cell. When set, DOM hosts paint the block glyphs
+   * themselves at that size instead of relying on a font that has them, so
+   * the art looks the same on every platform. Terminals ignore it.
+   */
+  scale?: number;
   color?: string;
   fg?: string;
   bg?: string;

--- a/src/utils/dom-screenshot.ts
+++ b/src/utils/dom-screenshot.ts
@@ -1,5 +1,7 @@
 /// <reference lib="dom" />
 
+import { isScreenshotWatermarkVisible, setScreenshotWatermarkVisible } from "./screenshot-watermark";
+
 export interface PngScreenshot {
   pngBase64: string;
   width: number;
@@ -355,7 +357,15 @@ async function captureElementPngBase64(element: HTMLElement): Promise<PngScreens
   if (!context) throw new Error("Could not create pane screenshot.");
   context.scale(scale, scale);
   context.clearRect(0, 0, width, height);
-  drawElement(context, element, { left: rect.left, top: rect.top });
+  // Reveal the chart watermark only for the synchronous paint below: the
+  // browser never gets a frame in between, so the live UI does not flicker.
+  const watermarkWasVisible = isScreenshotWatermarkVisible();
+  setScreenshotWatermarkVisible(true);
+  try {
+    drawElement(context, element, { left: rect.left, top: rect.top });
+  } finally {
+    if (!watermarkWasVisible) setScreenshotWatermarkVisible(false);
+  }
 
   return {
     pngBase64: await blobToBase64(await canvasToPngBlob(canvas)),

--- a/src/utils/screenshot-watermark.ts
+++ b/src/utils/screenshot-watermark.ts
@@ -1,0 +1,27 @@
+/// <reference lib="dom" />
+
+/**
+ * Screenshot branding for the DOM renderers.
+ *
+ * Chart bitmaps are opaque, so the wordmark cannot literally sit behind the
+ * plot. Instead every chart mounts a faint, always-hidden watermark layer and
+ * this attribute on `<html>` reveals all of them at once. Flipping an
+ * attribute is synchronous, which lets the pane capture paint the watermark
+ * without a React render, and lets the OS screenshot detector toggle it
+ * without touching component state.
+ */
+export const SCREENSHOT_WATERMARK_ATTRIBUTE = "data-gloom-screenshot";
+
+export const CHART_WATERMARK_ROLE = "chart-watermark";
+
+export function isScreenshotWatermarkVisible(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.documentElement.getAttribute(SCREENSHOT_WATERMARK_ATTRIBUTE) === "true";
+}
+
+export function setScreenshotWatermarkVisible(visible: boolean): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  if (visible) root.setAttribute(SCREENSHOT_WATERMARK_ATTRIBUTE, "true");
+  else root.removeAttribute(SCREENSHOT_WATERMARK_ATTRIBUTE);
+}


### PR DESCRIPTION
## What

When someone captures a chart pane on desktop or in the browser build, the plot now carries a faint Gloomberb ASCII wordmark (the same one shown on empty layouts). It never appears during normal use.

Three triggers reveal it, all through one `data-gloom-screenshot` attribute on `<html>`:

- **Pane > Copy Screenshot** (`CmdOrCtrl+Shift+C`): `dom-screenshot.ts` sets the attribute for the synchronous paint only, so the live UI never shows a frame with it.
- **OS screenshot chords** on desktop: the OS swallows the final key of `Cmd+Shift+3/4/5` and `Win+Shift+S`, so the view watches for the `Meta+Shift` modifier prefix (and `PrintScreen`) and reveals the mark for 10 s, or for as long as a capture app (`Cmd+Shift+5`, `Win+Shift+S`) holds focus. A complete chord reaching the app, a click, or a scroll hides it immediately.
- **`gloomberb shot`**: CLI screenshots set the attribute for the page.

## How

- `src/utils/screenshot-watermark.ts`: attribute helpers shared by all triggers.
- `composite-chart.tsx`: on `desktop-web`, mounts an absolutely positioned `chart-watermark` layer over the plot area (above the opaque bitmaps, below drawings, crosshair and readouts). Every chart surface (chart composer, static charts) goes through `CompositeChart`, so it covers all of them.
- `styles.css`: hidden by default, `visibility: visible` under the attribute, 10% opacity. The DOM host now reports live cell sizes so the mark keeps its proportion under font scaling, and the canvas redraws on devicePixelRatio changes (page zoom, display moves).
- `screenshot-watermark.ts` (electrobun view): chord classifier plus installer, wired in `main.tsx`.
- `AsciiText` gains a `scale` prop: the DOM host then paints the block glyphs itself on a canvas (`block-glyph-canvas.tsx`), so the wordmark is identical on every platform and is sized to about half the plot width. Plots too small for a legible mark get none.

## Verified

- CLI shot of the AAPL chart renders the centered wordmark.
- Headless Chrome harness around the real `dom-screenshot.ts`: live page clean, captured PNG watermarked, attribute restored after capture.
- Unit test for the chord classifier.

## Screenshot

AAPL chart captured with the watermark:

![Chart with Gloomberb watermark](https://raw.githubusercontent.com/gloom-sh/gloomberb/assets/pr-861/chart-screenshot-watermark-7c9fc57c.png)







