### PR TITLE
Capture pane screenshots on a transparent page

### DIFF
--- a/src/cli/desktop-pane-shot.ts
+++ b/src/cli/desktop-pane-shot.ts
@@ -131,7 +131,13 @@ const SHOT_MODE_CSS = [
   "[data-gloom-role='composite-chart-toolbar']",
   "[data-gloom-role='chart-series-quick-add']",
   "[data-gloom-role='pane-close']",
+  "[data-gloom-role='resize-handle']",
 ].join(", ") + " { display: none !important; }\n"
+  // The pane fills the viewport and has rounded corners. With the page painted
+  // in the theme background, the PNG carried square theme-coloured corners
+  // that showed on any other backdrop; a transparent page keeps only the pane.
+  + "html, body, #root { background: transparent !important; }\n"
+  + "[data-gloom-role='pane-window'][data-floating='true'] { box-shadow: none !important; }\n"
   // Sits where the hidden close button was: one cell high, right-aligned in the title bar.
   + "[data-gloom-role='shot-watermark'] { position: fixed; top: 1px; right: 10px; height: var(--cell-h);"
   + " line-height: var(--cell-h); font-size: 12px; letter-spacing: 0.02em; color: var(--gloom-text-dim, #888);"
@@ -438,6 +444,9 @@ async function capturePageScreenshot({
       height: heightPx,
       deviceScaleFactor,
       mobile: false,
+    });
+    await session.send("Emulation.setDefaultBackgroundColorOverride", {
+      color: { r: 0, g: 0, b: 0, a: 0 },
     });
     await waitForShotReady(session);
     const rendered = await readRenderedPaneState(session);


### PR DESCRIPTION
`gloomberb shot` PNGs had square theme-coloured corners behind the pane's 6px radius, visible as clipped corners when the image sits on a light or dark web page. The page behind the pane is now transparent (CSS plus `Emulation.setDefaultBackgroundColorOverride`), the floating box shadow is dropped since it painted onto that transparent area, and the resize handle glyph is hidden with the rest of the interactive chrome.

Verified: corner pixels are fully transparent, the pane border is intact, `bun test src/cli/pane-functions` passes.