### PR TITLE
Fix external-plugin host module resolution in Bun compiled executables

### DIFF
--- a/src/plugins/bundle.ts
+++ b/src/plugins/bundle.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import { findHostPackageRoot } from "./host-link";
 import { resolvePluginBrowserEntry } from "./loader";
 import { PLUGIN_HOST_GLOBAL, SHARED_SPECIFIERS } from "./host-contract";
+import { importPluginHostModule } from "./host-module-imports";
 
 /**
  * Compiles an external plugin for a renderer that cannot read the filesystem.
@@ -124,8 +125,8 @@ export function createSharedModuleResolver(
   };
 }
 
-async function hostExportNames(specifier: string): Promise<readonly string[]> {
-  const mod = await import(specifier);
+export async function hostExportNames(specifier: string): Promise<readonly string[]> {
+  const mod = await importPluginHostModule(specifier);
   return Object.keys(mod).sort();
 }
 

--- a/src/plugins/host-module-imports.test.ts
+++ b/src/plugins/host-module-imports.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { bundleExternalPlugin, hostExportNames } from "./bundle";
+import { PLUGIN_HOST_GLOBAL, SHARED_SPECIFIERS } from "./host-contract";
+import { importAllPluginHostModules, importPluginHostModule } from "./host-module-imports";
+
+describe("plugin host module imports", () => {
+  test("has a host module for every shared specifier", async () => {
+    const registry = await importAllPluginHostModules();
+
+    expect(Object.keys(registry).sort()).toEqual([...SHARED_SPECIFIERS].sort());
+    for (const specifier of SHARED_SPECIFIERS) {
+      expect(await importPluginHostModule(specifier)).toBeTruthy();
+    }
+  });
+
+  test("discovers export names through host-local imports", async () => {
+    const names = await hostExportNames("gloomberb/ui");
+
+    expect(names).toContain("Box");
+    expect(names).toContain("Text");
+  });
+
+  test("discovers and bundles shared modules from a Bun compiled executable", () => {
+    const entry = join(import.meta.dir, `.compiled-host-module-entry-${process.pid}.ts`);
+    const outfile = join(import.meta.dir, `.compiled-host-module-entry-${process.pid}.exe`);
+    writeFileSync(entry, `
+      import { mkdtempSync, rmSync, writeFileSync } from "fs";
+      import { tmpdir } from "os";
+      import { join } from "path";
+      import { bundleExternalPlugin, hostExportNames } from "./bundle";
+      import { importAllPluginHostModules } from "./host-module-imports";
+
+      const pluginDir = mkdtempSync(join(tmpdir(), "gloom-compiled-plugin-"));
+      try {
+        writeFileSync(join(pluginDir, "package.json"), JSON.stringify({ name: "compiled-plugin", main: "index.tsx" }));
+        writeFileSync(join(pluginDir, "index.tsx"), [
+          "import { Box } from \\\"gloomberb/ui\\\";",
+          "export default { id: \\\"compiled-plugin\\\", name: \\\"Compiled plugin\\\", version: \\\"1.0.0\\\", Box };",
+          "",
+        ].join("\\n"));
+        const hostModules = await importAllPluginHostModules();
+        const names = await hostExportNames("gloomberb/ui");
+        const result = await bundleExternalPlugin(pluginDir, join(pluginDir, "out"));
+        const code = await Bun.file(result.outputPath).text();
+        console.log(JSON.stringify({
+          importMetaDir: import.meta.dir,
+          hostModuleCount: Object.keys(hostModules).length,
+          names,
+          shared: result.shared,
+          hasHostRegistry: code.includes(${JSON.stringify(PLUGIN_HOST_GLOBAL)}),
+        }));
+      } finally {
+        rmSync(pluginDir, { recursive: true, force: true });
+      }
+    `);
+
+    try {
+      const build = Bun.spawnSync(
+        [process.execPath, "build", "--compile", entry, "--outfile", outfile],
+        { cwd: join(import.meta.dir, "../.."), stdout: "pipe", stderr: "pipe" },
+      );
+      if (build.exitCode !== 0) {
+        throw new Error(`compiled test fixture failed to build:\n${build.stdout.toString()}\n${build.stderr.toString()}`);
+      }
+
+      const run = Bun.spawnSync([outfile], { stdout: "pipe", stderr: "pipe" });
+      if (run.exitCode !== 0) {
+        throw new Error(`compiled test fixture failed to run:\n${run.stdout.toString()}\n${run.stderr.toString()}`);
+      }
+      const result = JSON.parse(run.stdout.toString()) as {
+        importMetaDir: string;
+        hostModuleCount: number;
+        names: string[];
+        shared: string[];
+        hasHostRegistry: boolean;
+      };
+
+      expect(result.importMetaDir.replaceAll("\\", "/")).toMatch(/\/~BUN\/root$/i);
+      expect(result.hostModuleCount).toBe(SHARED_SPECIFIERS.length);
+      expect(result.names).toContain("Box");
+      expect(result.shared).toEqual(["gloomberb/ui"]);
+      expect(result.hasHostRegistry).toBe(true);
+    } finally {
+      rmSync(entry, { force: true });
+      rmSync(outfile, { force: true });
+    }
+  });
+});

--- a/src/plugins/host-module-imports.ts
+++ b/src/plugins/host-module-imports.ts
@@ -1,0 +1,45 @@
+import { SHARED_SPECIFIERS, type SharedSpecifier } from "./host-contract";
+
+type HostModuleImporter = () => Promise<object>;
+
+/**
+ * The host's canonical implementation for every public shared-module
+ * specifier. Resolve Gloomberb's own modules relative to this file: a
+ * Bun-compiled host has no filesystem package root from which
+ * `import("gloomberb/ui")` can be resolved.
+ */
+const HOST_MODULE_IMPORTERS = {
+  "react": () => import("react"),
+  "react/jsx-runtime": () => import("react/jsx-runtime"),
+  "react/jsx-dev-runtime": () => import("react/jsx-dev-runtime"),
+  "gloomberb/types/plugin": () => import("../types/plugin"),
+  "gloomberb/types/persistence": () => import("../types/persistence"),
+  "gloomberb/ui": () => import("../ui"),
+  "gloomberb/components": () => import("../components"),
+  "gloomberb/theme": () => import("../theme/colors"),
+  "gloomberb/capabilities": () => import("../capabilities"),
+  "gloomberb/utils": () => import("../public/utils"),
+  "gloomberb/react": () => import("../public/react"),
+  "gloomberb/broker": () => import("../public/broker"),
+  "gloomberb/dialog": () => import("../ui/dialog"),
+  "gloomberb/market-data": () => import("../public/market-data"),
+  "gloomberb/time-series": () => import("../public/time-series"),
+  "gloomberb/layout": () => import("../public/layout"),
+  "gloomberb/quotes": () => import("../public/quotes"),
+} satisfies Record<SharedSpecifier, HostModuleImporter>;
+
+/** Import one host module without depending on bare Gloomberb package resolution. */
+export async function importPluginHostModule(specifier: string): Promise<object> {
+  if (!(SHARED_SPECIFIERS as readonly string[]).includes(specifier)) {
+    throw new Error(`Unknown plugin host module: ${specifier}`);
+  }
+  return HOST_MODULE_IMPORTERS[specifier as SharedSpecifier]();
+}
+
+/** Import the complete registry from the same map used by the bundler. */
+export async function importAllPluginHostModules(): Promise<Readonly<Record<SharedSpecifier, object>>> {
+  const entries = await Promise.all(
+    SHARED_SPECIFIERS.map(async (specifier) => [specifier, await importPluginHostModule(specifier)] as const),
+  );
+  return Object.fromEntries(entries) as Record<SharedSpecifier, object>;
+}

--- a/src/plugins/host-modules.ts
+++ b/src/plugins/host-modules.ts
@@ -1,4 +1,5 @@
 import { PLUGIN_HOST_GLOBAL, SHARED_SPECIFIERS } from "./host-contract";
+import { importAllPluginHostModules } from "./host-module-imports";
 
 /**
  * Publishes the host's shared modules for compiled plugin bundles to read.
@@ -13,63 +14,7 @@ export async function installPluginHostModules(): Promise<void> {
   const globals = globalThis as Record<string, unknown>;
   if (globals[PLUGIN_HOST_GLOBAL]) return;
 
-  const [
-    react,
-    jsxRuntime,
-    typesPlugin,
-    typesPersistence,
-    ui,
-    components,
-    theme,
-    capabilities,
-    utils,
-    pluginReact,
-    broker,
-    dialog,
-    marketData,
-    timeSeries,
-    layout,
-    quotes,
-  ] = await Promise.all([
-    import("react"),
-    import("react/jsx-runtime"),
-    // Type-only modules still need an entry: a plugin may import a runtime
-    // value from them, and a missing key throws a clearer error than undefined.
-    import("../types/plugin"),
-    import("../types/persistence"),
-    import("../ui"),
-    import("../components"),
-    import("../theme/colors"),
-    import("../capabilities"),
-    import("../public/utils"),
-    import("../public/react"),
-    import("../public/broker"),
-    import("../ui/dialog"),
-    import("../public/market-data"),
-    import("../public/time-series"),
-    import("../public/layout"),
-    import("../public/quotes"),
-  ]);
-
-  const registry: Record<string, unknown> = {
-    "react": react,
-    "react/jsx-runtime": jsxRuntime,
-    "react/jsx-dev-runtime": jsxRuntime,
-    "gloomberb/types/plugin": typesPlugin,
-    "gloomberb/types/persistence": typesPersistence,
-    "gloomberb/ui": ui,
-    "gloomberb/components": components,
-    "gloomberb/theme": theme,
-    "gloomberb/capabilities": capabilities,
-    "gloomberb/utils": utils,
-    "gloomberb/react": pluginReact,
-    "gloomberb/broker": broker,
-    "gloomberb/dialog": dialog,
-    "gloomberb/market-data": marketData,
-    "gloomberb/time-series": timeSeries,
-    "gloomberb/layout": layout,
-    "gloomberb/quotes": quotes,
-  };
+  const registry = await importAllPluginHostModules();
 
   for (const specifier of SHARED_SPECIFIERS) {
     if (!registry[specifier]) throw new Error(`Plugin host registry is missing "${specifier}"`);


### PR DESCRIPTION
External plugins can fail to bundle when Gloomberb runs from a Bun compiled executable.

`bundleExternalPlugin()` discovers the exports of shared host modules through bare `gloomberb/*` imports. This works when Gloomberb runs through Bun normally, but in a compiled executable `import.meta.dir` points into Bun's embedded filesystem on Windows, where those package imports cannot be resolved.

This change introduces one canonical mapping from public shared specifiers to their host-local module imports. Both export-name discovery and the renderer host registry consume that mapping, so external-plugin bundling no longer depends on resolving the Gloomberb package by name from the compiled process.

Reproduction before the change:

* normal Bun: shared host imports PASS, external plugin bundle PASS
* Bun compiled executable: bare `gloomberb/*` imports FAIL, external plugin bundle FAIL

After the change:

* normal Bun: PASS
* Bun compiled executable: host-local shared-module discovery PASS
* synthetic external plugin bundle: PASS
* all 17 shared specifiers covered by the canonical mapping

Validation:

* focused tests: 15/15 PASS
* `src/plugins` suite: 1297 PASS, with one unrelated pre-existing Windows/Bun `-e` resolution failure in `earnings/table.test.ts`
* Electrobun Bun typecheck: PASS
* Electrobun View typecheck: PASS
* browser typecheck: PASS
* `git diff --check`: PASS

The production JSX/runtime fix already present on `main` is intentionally not included in this change.
